### PR TITLE
feat(adapter): serve the noexport views from the export-explain surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Birdwatcher adapter serves the Alice-LG noexport views.**
+  `GET /routes/noexport/{id}` completes the adapter's looking-glass
+  contract: Loc-RIB best routes not advertised to the peer
+  (`RibService.ListBestRoutes` minus `ListAdvertisedRoutes`), each
+  explained by a live-ladder dry run (`ExplainAdvertisedRoute`) and
+  tagged with a synthesized `64496:65521:<gate id>` noexport-reason
+  large community plus human-readable `noexport_reason` /
+  `noexport_reason_detail` keys. The view covers every export-ladder
+  suppression (split horizon, RFC 4456 reflection, family, RFC 9494
+  LLGR, RFC 5291 ORF, RFC 4684 RT membership, export policy), is
+  prefix-granular, and serves an empty view for peers with no live
+  session. All backing RPCs are `sensitive_read`-tier — no
+  authorization change for existing adapter deployments.
+
 ### Fixed
 
 - **Release tarballs ship `rs-config-render`.** The route-server

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ fanout numbers — is the [feature tour](docs/feature-tour.md).
 - **Hosting provider prefix management** — API-driven customer prefix announcements
 - **SDN / network automation controllers** — programmable BGP control plane
 - **Route collectors and looking glasses** — structured data via gRPC, MRT, BMP,
-  plus a Birdwatcher-shaped status/peer/accepted-route subset via the external
-  `examples/birdwatcher-adapter` (not yet a complete Alice-LG backend)
+  plus a Birdwatcher-shaped status/peer/accepted/filtered/noexport subset via
+  the external `examples/birdwatcher-adapter`
 - **Lab and test environments** — clean API, structured logs, containerlab interop
 
 See [docs/USE_CASES.md](docs/USE_CASES.md) for detailed deployment scenarios with

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -136,7 +136,8 @@ the data-driven filtering/tooling wrapper, not the daemon.
   `PolicyService.ListRejectedRoutes` and `rbgp rib received <peer> --rejected`,
   and the birdwatcher adapter now serves its filtered-route views from it
   (reject reasons mapped to large communities under `64496:65520:*`; the
-  noexport view remains) (LAN-472).
+  noexport view has since shipped too, from the export-explain surface)
+  (LAN-472).
 - ~~Ship ADR-0107 NEXT_HOP self-consistency~~ **Shipped (#964):**
   `next_hop_ownership = "strict_peer"` fail-closed ingress gate; ADR-0107
   Accepted; same-AS mode stays deferred behind the fleet inventory (LAN-473).
@@ -479,12 +480,11 @@ Details in the "Recently shipped" section below and ADR-0097.
   and a curated `examples/route-server` profile. The canonical semantic diff
   engine, `rbgp diff`, BIRD/FRR/GoBGP/MRT adapters, and BMP Adj-RIB-Out import
   are also shipped, as is the ARouteServer target (`tools/rs-config-render`).
-  Remaining demand-shaped work: a real shadow/canary receipt,
-  completion of the Alice-LG contract beyond the current Birdwatcher-shaped
-  status/peer/accepted-route/filtered-route subset (structured reject reasons
-  ship via `PolicyService.ListRejectedRoutes` and back the adapter's
-  filtered-route views; the noexport view remains), and a 1000+-peer
-  route-server scale receipt.
+  The birdwatcher adapter's Alice-LG contract is complete
+  (status/peer/accepted/filtered/noexport views; reject reasons via
+  `PolicyService.ListRejectedRoutes`, noexport via the export-explain
+  surface). Remaining demand-shaped work: a real shadow/canary receipt
+  and a 1000+-peer route-server scale receipt.
 - **RFC 9857 SR-Policy-state-in-BGP-LS** (receive/reflect/API) — published
   RFC, no open-source implementation found, drops onto the existing
   BGP-LS substrate; deepens the controller feed (TE controllers reading
@@ -495,13 +495,13 @@ Details in the "Recently shipped" section below and ADR-0097.
 **The route-server (IXP) track** — the core is shipped; remaining work is
 adoption tooling. ADR-0101/M83 covers RFC 7947 transparency, Add-Path and
 `per_client_best` path-hiding mitigation, RFC 9234 OTC, ASPA/ROV hygiene, and
-multi-stack BIRD/GoBGP/FRR/StayRTR proof. Next useful slices are an Alice-LG
-contract completion for the adapter's noexport view (the structured
-reject reasons ship via `PolicyService.ListRejectedRoutes` and
-`rbgp rib received <peer> --rejected`, and the adapter serves filtered-route
-views from them, mapped to large communities under `64496:65520:*`), a
-1000+-peer route-server scale receipt, and shadow/canary RIB-diff
-tooling (`rbgp diff` against an incumbent's MRT/BMP feed). The ARouteServer
+multi-stack BIRD/GoBGP/FRR/StayRTR proof. The adapter's Alice-LG contract
+is complete: filtered-route views from `PolicyService.ListRejectedRoutes`
+(reject reasons mapped to large communities under `64496:65520:*`) and
+noexport views from the export-explain surface (`64496:65521:*`). Next
+useful slices are a 1000+-peer route-server scale receipt and
+shadow/canary RIB-diff tooling (`rbgp diff` against an incumbent's
+MRT/BMP feed). The ARouteServer
 target ships as `tools/rs-config-render`. The current external adapter already
 serves the Birdwatcher-shaped status, peer, accepted-route, and filtered-route
 subset.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -390,8 +390,9 @@ accepted-route endpoints (`/status`, `/protocols/bgp`,
 `/routes/protocol/{id}`, `/routes/peer/{peer}`) now live in the maintained
 external `examples/birdwatcher-adapter`, which also serves a filtered-route
 view (`/routes/filtered/{id}`, from `PolicyService.ListRejectedRoutes` with
-structured reject reasons). This is not yet a complete Alice-LG backend:
-noexport views are absent. A
+structured reject reasons) and a noexport view (`/routes/noexport/{id}`,
+best-routes-minus-advertised with each suppression explained by
+`RibService.ExplainAdvertisedRoute`). A
 config that still sets `[global.telemetry.looking_glass]` fails to load with a
 migration error. See the adapter README for the endpoint→gRPC mapping.
 

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -423,11 +423,13 @@ that is the signal to fall back to the durable cursor.
 **Reference consumers in-tree:** `examples/event-bridge/` (gRPC →
 JSON-lines event bridge, the minimal Shape-A skeleton) and
 `examples/birdwatcher-adapter/` (a Birdwatcher-shaped status, peer,
-accepted-route, and filtered-route REST subset sourced entirely from the
-public gRPC API, including per-route `age` from `received_at_epoch_seconds`
-and `GET /routes/filtered/{id}` served from
-`PolicyService.ListRejectedRoutes` with structured reject reasons). It is
-not a complete Alice-LG backend: noexport views are not wired. The adapter
+accepted-route, filtered-route, and noexport REST subset sourced entirely
+from the public gRPC API, including per-route `age` from
+`received_at_epoch_seconds`, `GET /routes/filtered/{id}` served from
+`PolicyService.ListRejectedRoutes` with structured reject reasons, and
+`GET /routes/noexport/{id}` served from the `ListBestRoutes` −
+`ListAdvertisedRoutes` diff with each suppression explained by
+`RibService.ExplainAdvertisedRoute`). The adapter
 is the honest template: if
 the public API is missing a field an external tool needs, the fix is an
 additive proto field, not a daemon-internal shortcut — that is how

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1870,17 +1870,20 @@ loser would survive the equal-cost multipath cut.
 
 ### Looking glass (Birdwatcher-shaped REST subset)
 
-For status, peer, accepted-route, and filtered-route views in external
-looking glass frontends, run the external `examples/birdwatcher-adapter`
-binary. It serves the Birdwatcher-shaped endpoints (`/status`,
-`/protocols/bgp` with real per-neighbor filtered counts,
-`/routes/protocol/{id}`, `/routes/peer/{peer}`, `/routes/filtered/{id}`)
-from the daemon's gRPC API. The filtered view surfaces the
-`PolicyService.ListRejectedRoutes` reject-retention store with a
-synthesized reject-reason large community per route (mapping table and
-Alice-LG rejection config in the adapter's README). Alice-LG's noexport
-view is not exposed (no NO_EXPORT-excluded route set is retained). The
-in-daemon `[global.telemetry.looking_glass]` server has been removed.
+For status, peer, accepted-route, filtered-route, and noexport views in
+external looking glass frontends, run the external
+`examples/birdwatcher-adapter` binary. It serves the Birdwatcher-shaped
+endpoints (`/status`, `/protocols/bgp` with real per-neighbor filtered
+counts, `/routes/protocol/{id}`, `/routes/peer/{peer}`,
+`/routes/filtered/{id}`, `/routes/noexport/{id}`) from the daemon's gRPC
+API. The filtered view surfaces the `PolicyService.ListRejectedRoutes`
+reject-retention store with a synthesized reject-reason large community
+per route; the noexport view diffs Loc-RIB best against the peer's
+Adj-RIB-Out and names each suppression's export gate via
+`RibService.ExplainAdvertisedRoute`, with its own synthesized
+noexport-reason community (mapping tables and Alice-LG config in the
+adapter's README). The in-daemon `[global.telemetry.looking_glass]`
+server has been removed.
 
 ### EVPN Route Reflector + Bidirectional VTEP
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -165,9 +165,8 @@ to gRPC.
 
 The in-daemon looking glass HTTP server has been removed. The external
 `examples/birdwatcher-adapter` binary serves a Birdwatcher-shaped read-only
-status, peer, accepted-route, and filtered-route subset over the daemon's
-gRPC API. It is not a complete Alice-LG backend (noexport views are not
-wired).
+status, peer, accepted-route, filtered-route, and noexport subset over the
+daemon's gRPC API.
 
 **Disclosure surface.** Beyond neighbor state, received routes, and peer
 addresses, the adapter's `GET /routes/filtered/{id}` endpoint serves
@@ -176,11 +175,17 @@ retained rejection's prefix, next hop, AS path, communities, RPKI/ASPA
 validation state, and the policy rejection reason (canonical reason token,
 human-readable detail string, and a synthesized reject-reason large
 community). `GET /protocols/bgp` carries real per-neighbor filtered counts.
-The adapter's HTTP listener is unauthenticated and has no TLS; it binds
-`127.0.0.1:8080` by default and listens elsewhere only if you pass
-`--listen` / `BIRDWATCHER_ADAPTER_LISTEN`. Anyone who can reach it can
-enumerate what your import policy rejects and why — treat that as
-looking-glass data you are choosing to publish.
+`GET /routes/noexport/{id}` additionally serves every Loc-RIB best route
+withheld from that peer with the export gate that stopped it (split
+horizon, reflection rules, family, LLGR, ORF, RT membership, or export
+policy — including the deciding policy term's detail line), sourced from
+`RibService.ListBestRoutes`, `ListAdvertisedRoutes`, and
+`ExplainAdvertisedRoute`. The adapter's HTTP listener is unauthenticated
+and has no TLS; it binds `127.0.0.1:8080` by default and listens elsewhere
+only if you pass `--listen` / `BIRDWATCHER_ADAPTER_LISTEN`. Anyone who can
+reach it can enumerate what your import policy rejects, what your export
+policy withholds from each peer, and why — treat that as looking-glass
+data you are choosing to publish.
 
 Mitigations, in preference order:
 
@@ -188,9 +193,12 @@ Mitigations, in preference order:
   and put an authenticating reverse proxy in front of it before any wider
   exposure — the same network-level discipline as Prometheus.
 - Point the adapter at a dedicated gRPC listener and cap it:
-  `ListRejectedRoutes` is a `sensitive_read`-tier method, so `max_tier =
-  "read"` on that listener denies the filtered view while keeping liveness
-  reads working.
+  `ListRejectedRoutes` and the noexport view's backing RPCs
+  (`ListBestRoutes`, `ListAdvertisedRoutes`, `ExplainAdvertisedRoute`) are
+  all `sensitive_read`-tier methods — the noexport view raises no tier
+  requirement beyond what the adapter already needed — so `max_tier =
+  "read"` on that listener denies both the filtered and noexport views
+  while keeping liveness reads working.
 - Disable retention daemon-side with `[policy.reject_retention]
   enabled = false`: the reject store is never populated and the filtered
   view is served empty as a configuration fact.

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -409,9 +409,10 @@ IX peer C  ──┘
 - **Birdwatcher-shaped REST subset** — the external
   [`examples/birdwatcher-adapter`](../examples/birdwatcher-adapter/) serves
   accepted-route, filtered-route (with reject-reason communities synthesized
-  from `PolicyService.ListRejectedRoutes` structured reasons), peer (with
-  real filtered counts), and status views from the gRPC API; only the
-  noexport view remains before it is a complete Alice-LG backend
+  from `PolicyService.ListRejectedRoutes` structured reasons), noexport
+  (best-routes-minus-advertised, each suppression explained by the live
+  export ladder), peer (with real filtered counts), and status views from
+  the gRPC API
 - **Best-path explain** — `rbgp rib --prefix X --explain` shows why a
   route was selected over alternatives
 

--- a/docs/cookbook/ixp-filter-pipeline.md
+++ b/docs/cookbook/ixp-filter-pipeline.md
@@ -194,8 +194,10 @@ workflow; the full explain surface catalog is in
 The external
 [`examples/birdwatcher-adapter`](../../examples/birdwatcher-adapter/README.md)
 serves a Birdwatcher-shaped REST subset from the daemon's gRPC API —
-status, peers, a member's accepted routes, and the filtered-route view
-above. For the filtered view it synthesizes one reject-reason large
+status, peers, a member's accepted routes, the filtered-route view
+above, and a noexport view (routes withheld from a member, each named
+by the export gate that stopped it, tagged `64496:65521:<id>`). For the
+filtered view it synthesizes one reject-reason large
 community (`64496:65520:<id>`, one stable id per reason token) on each
 route, matchable by Alice-LG's `[rejection_reasons]` config exactly
 like arouteserver's reject-reason tagging on BIRD; the adapter README
@@ -208,9 +210,11 @@ cargo run --release -p birdwatcher-adapter -- \
 ```
 
 The adapter needs a (read-only) gRPC TCP listener on the daemon, and
-`[policy.reject_retention]` enabled for the filtered view. Honest
-boundary: this is a maintained subset, not yet a complete Alice-LG
-backend — there is no noexport view, and a few Birdwatcher fields are
-served as sentinels (the adapter README lists every gap).
+`[policy.reject_retention]` enabled for the filtered view. The noexport
+view is served from the export-explain surface (best-routes-minus-
+advertised, one export-ladder dry run per suppressed prefix). Honest
+boundary: this is a maintained single-table unicast subset — a few
+Birdwatcher fields are served as sentinels (the adapter README lists
+every gap).
 
 [arouteserver]: https://github.com/pierky/arouteserver

--- a/docs/cookbook/monitoring-feed.md
+++ b/docs/cookbook/monitoring-feed.md
@@ -141,13 +141,16 @@ $ ls /var/lib/rustbgpd/mrt/
 feed.20260703.120001.123456789.mrt.gz
 ```
 
-**Looking glass (optional):** for status, peer, accepted-route, and
-filtered-route views in an Alice-LG-style frontend, run the
+**Looking glass (optional):** for status, peer, accepted-route,
+filtered-route, and noexport views in an Alice-LG-style frontend, run the
 [`examples/birdwatcher-adapter/`](../../examples/birdwatcher-adapter/)
 against a gRPC TCP listener. (The in-daemon
 `[global.telemetry.looking_glass]` server has been removed.) The filtered
 view is served from `PolicyService.ListRejectedRoutes` with structured
-reject reasons; noexport views are not yet supplied.
+reject reasons; the noexport view diffs the Loc-RIB best set against the
+peer's Adj-RIB-Out and names each suppression's export gate via
+`RibService.ExplainAdvertisedRoute` — see the adapter README for exactly
+what each view contains.
 
 ## Watch
 

--- a/docs/feature-tour.md
+++ b/docs/feature-tour.md
@@ -61,8 +61,8 @@ Prometheus metrics, gNMI / OpenConfig BGP telemetry (`Capabilities` /
 `Get` / `Subscribe`, RFC 7951 JSON over mTLS) plus a transaction-backed
 `Set` subset for static numbered-neighbor config, BMP export to
 collectors (all three RIB views), MRT TABLE_DUMP_V2 snapshots, a
-Birdwatcher-shaped status/peer/accepted-route REST subset via the
-external `examples/birdwatcher-adapter`, structured JSON logging, and
+Birdwatcher-shaped status/peer/accepted/filtered/noexport REST subset
+via the external `examples/birdwatcher-adapter`, structured JSON logging, and
 per-peer counters. The explain surfaces have their own catalog:
 [explain.md](explain.md). gNMI operator guide: [GNMI.md](GNMI.md);
 Grafana dashboard: [GRAFANA.md](GRAFANA.md).

--- a/examples/birdwatcher-adapter/Cargo.toml
+++ b/examples/birdwatcher-adapter/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 publish = false
-description = "Birdwatcher-shaped status, peer, and accepted-route REST adapter for rustbgpd, backed by the daemon gRPC API."
+description = "Birdwatcher-shaped status, peer, accepted-route, filtered-route, and noexport REST adapter for rustbgpd, backed by the daemon gRPC API."
 
 [[bin]]
 name = "birdwatcher-adapter"

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -2,12 +2,14 @@
 
 Standalone HTTP server that exposes a **Birdwatcher-shaped read-only subset**
 for [Alice-LG](https://github.com/alice-lg/alice-lg) and similar looking glass
-frontends. It serves status, peer, accepted-route, and filtered-route views
-from a running rustbgpd over gRPC. The status/peer/accepted endpoint paths and
-response shapes match the removed in-daemon
+frontends. It serves status, peer, accepted-route, filtered-route, and
+noexport views from a running rustbgpd over gRPC. The status/peer/accepted
+endpoint paths and response shapes match the removed in-daemon
 `[global.telemetry.looking_glass]` server this adapter replaces; the filtered
-view is served from the daemon's reject-retention store. This is not a
-complete Alice-LG backend (no noexport view).
+view is served from the daemon's reject-retention store and the noexport view
+from a live-ladder dry run of the export decision. Coverage is honest, not
+complete: IPv4/IPv6 unicast single-table only (no VPN/EVPN views, no
+`/routes/dump`).
 
 Rationale: the daemon's durable API identity is **gRPC + `rbgp`**.
 Partial compatibility with someone else's REST API inside daemon core
@@ -45,12 +47,11 @@ every RPC the adapter calls is a read.
 | `GET /routes/protocol/{id}`  | `RibService.ListReceivedRoutes` (paged, all unicast families)  |
 | `GET /routes/peer/{peer}`    | `RibService.ListReceivedRoutes` (paged, all unicast families)  |
 | `GET /routes/filtered/{id}`  | `PolicyService.ListRejectedRoutes` (unpaged — the store is bounded at the `[policy.reject_retention]` capacity, default 1024/peer) |
+| `GET /routes/noexport/{id}`  | `RibService.ListBestRoutes` − `RibService.ListAdvertisedRoutes` (both paged), each missing prefix explained by `RibService.ExplainAdvertisedRoute` |
 
 There are no placeholder 501 responses. Route `age` is served from the
 `Route.received_at_epoch_seconds` proto field (RIB receive time) on the
 accepted view and from the rejection wall-clock time on the filtered view.
-Alice-LG's noexport view is not implemented (the daemon does not retain a
-NO_EXPORT-excluded route set).
 
 ## Filtered routes and reject reasons
 
@@ -109,6 +110,74 @@ reject_id = 65520
 6 = Malformed attributes (treat-as-withdraw, RFC 7606)
 ```
 
+## Noexport routes and reasons
+
+`/routes/noexport/{id}` (accepts `bgp_<addr>` protocol ids and bare peer IPs)
+serves every Loc-RIB best route that is **not** in the peer's Adj-RIB-Out,
+each explained by `RibService.ExplainAdvertisedRoute` — a dry run of the same
+export staging body the live path executes, so the reason cannot drift from
+the real decision. Precisely what the view contains:
+
+- **All export-ladder suppressions**, not only NO_EXPORT-community routes:
+  split horizon, iBGP/RFC 4456 reflection rules, family negotiation,
+  RFC 9494 LLGR-stale handling, RFC 5291 ORF, RFC 4684 RT membership, and
+  export-policy denial. Each route names its stopping gate.
+- **Prefix-granular**: a prefix with any advertised path is "exported" —
+  an Add-Path peer's partially-suppressed extra paths are not reported.
+- **IPv4/IPv6 unicast, single-best candidates only** (Loc-RIB best routes
+  are the export candidate set), matching the rest of the adapter.
+- **No live session ⇒ empty view** with a log line — nothing is being
+  exported *or* withheld, same posture as the filtered view.
+- If the snapshot diff races an in-flight advertisement (the explain says
+  the route *would* be advertised), the route is dropped from the view —
+  it never fabricates a "not exported" claim.
+
+**Cost:** one `ExplainAdvertisedRoute` call per suppressed prefix on every
+request. Alice-LG's `[noexport] load_on_demand` (its default) fits this —
+the view is only computed when an operator opens it. For very large
+Loc-RIBs, consider fronting the adapter with a caching proxy.
+
+### Noexport-reason → large-community mapping
+
+Same edge-synthesis convention as the reject reasons: one appended triplet
+`64496:65521:<id>` per route — function `65521` (adjacent to the
+reject-reason function `65520`, distinct so the `[rejection]` and
+`[noexport]` matchers never overlap), and a stable id per stopping gate:
+
+| Stopping gate    | Large community  | Meaning                                          |
+|------------------|------------------|--------------------------------------------------|
+| `split_horizon`  | `64496:65521:1`  | Route originated from the target peer            |
+| `rr_reflection`  | `64496:65521:2`  | iBGP split-horizon / RFC 4456 reflection rules   |
+| `family`         | `64496:65521:3`  | Peer did not negotiate the route's AFI/SAFI      |
+| `llgr`           | `64496:65521:4`  | RFC 9494 LLGR-stale suppression                  |
+| `orf`            | `64496:65521:5`  | RFC 5291 outbound route filter                   |
+| `rt_membership`  | `64496:65521:6`  | RFC 4684 RT-Constrain membership gate            |
+| `export_policy`  | `64496:65521:7`  | Denied by export policy (detail = deciding term) |
+| *(unrecognized)* | `64496:65521:0`  | Future gate this adapter build predates          |
+
+The ids are append-only. Each noexport route also carries human-readable
+`noexport_reason` (the gate name) / `noexport_reason_detail` extra JSON
+keys, ignored by parsers that don't know them.
+
+Alice-LG config to render the reasons:
+
+```ini
+[noexport]
+asn = 64496
+noexport_id = 65521
+load_on_demand = true
+
+[noexport_reasons]
+0 = Route was not exported
+1 = Route originated from this peer (split horizon)
+2 = Route reflection rules (RFC 4456)
+3 = Address family not negotiated
+4 = Long-lived stale route (RFC 9494)
+5 = Outbound route filter (RFC 5291)
+6 = RT membership (RFC 4684)
+7 = Denied by export policy
+```
+
 ### Field-level gaps
 
 | Field | Adapter value | Limitation |
@@ -128,7 +197,10 @@ the adapter returns `502 Bad Gateway` (the in-daemon server returned
 ## Testing
 
 - Unit tests: `cargo test -p birdwatcher-adapter`
-- End-to-end smoke test of the status/peer/accepted/filtered-route subset:
-  `cargo test --test birdwatcher_adapter_smoke` (root package; spawns a real
-  daemon plus this adapter, announces a clean route and a loop-poisoned one,
-  and asserts both the accepted and filtered views).
+- End-to-end smoke test of the status/peer/accepted/filtered/noexport
+  subset: `cargo test --test birdwatcher_adapter_smoke` (root package;
+  spawns a real daemon plus this adapter, announces a clean route and a
+  loop-poisoned one from one live peer plus an announce-nothing receiver
+  peer, and asserts the accepted, filtered, and both sides of the noexport
+  views — suppressed route present for the announcer, exported route absent
+  for the receiver).

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -1,11 +1,11 @@
 //! Birdwatcher-shaped REST looking glass adapter for rustbgpd.
 //!
-//! Standalone HTTP server that serves the status, peer, accepted-route, and
-//! filtered-route subset consumed by Alice-LG and similar looking glass
-//! frontends, sourcing all data from a running rustbgpd over gRPC. This
-//! replaces the removed in-daemon `[global.telemetry.looking_glass]` server's
-//! four endpoints and adds the filtered view on top. It is not a complete
-//! Alice-LG backend: noexport views are not wired up.
+//! Standalone HTTP server that serves the status, peer, accepted-route,
+//! filtered-route, and noexport subset consumed by Alice-LG and similar
+//! looking glass frontends, sourcing all data from a running rustbgpd over
+//! gRPC. This replaces the removed in-daemon
+//! `[global.telemetry.looking_glass]` server's four endpoints and adds the
+//! filtered and noexport views on top.
 //!
 //! **Supported endpoints** (single-table mode):
 //! - `GET /status` — daemon status
@@ -15,11 +15,22 @@
 //! - `GET /routes/filtered/{id}` — rejected routes retained by the peer's
 //!   session (`PolicyService.ListRejectedRoutes`), tagged with a synthesized
 //!   reject-reason large community (see the README mapping table)
+//! - `GET /routes/noexport/{id}` — Loc-RIB best routes NOT advertised to the
+//!   peer (`ListBestRoutes` minus `ListAdvertisedRoutes`), each explained by
+//!   the live export gate ladder (`RibService.ExplainAdvertisedRoute`) and
+//!   tagged with a synthesized noexport-reason large community
+//!
+//! Coverage is honest, not complete: routes are IPv4/IPv6 unicast only
+//! (no VPN/EVPN views), the noexport view is prefix-granular and covers
+//! every export-ladder suppression (split horizon, RR reflection, family,
+//! LLGR, ORF, RT membership, export policy) — not only NO_EXPORT-community
+//! routes — and multi-table endpoints beyond `/routes/peer` are absent.
 //!
 //! Response shapes use Birdwatcher field names so Alice-LG can parse this
 //! subset without adapter code. Fields that have no rustbgpd equivalent are
 //! present but empty/zero.
 
+use std::collections::HashSet;
 use std::net::{IpAddr, SocketAddr};
 
 use axum::extract::{Path, State};
@@ -34,7 +45,7 @@ use tracing::{error, info};
 #[derive(Parser, Debug)]
 #[command(
     name = "birdwatcher-adapter",
-    about = "Birdwatcher-shaped status, peer, accepted-route, and filtered-route REST subset, served from rustbgpd's gRPC API"
+    about = "Birdwatcher-shaped status, peer, accepted-route, filtered-route, and noexport REST subset, served from rustbgpd's gRPC API"
 )]
 struct Args {
     /// rustbgpd gRPC endpoint, e.g. `http://127.0.0.1:50051`.
@@ -81,6 +92,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/routes/protocol/{id}", get(routes_protocol))
         .route("/routes/peer/{peer}", get(routes_peer))
         .route("/routes/filtered/{id}", get(routes_filtered))
+        .route("/routes/noexport/{id}", get(routes_noexport))
         .with_state(state);
 
     info!(addr = %args.listen, "starting Birdwatcher-shaped looking glass subset");
@@ -421,6 +433,189 @@ fn rejected_route_to_birdwatcher(route: &proto::RejectedRoute, peer: IpAddr) -> 
 }
 
 // ---------------------------------------------------------------------------
+// GET /routes/noexport/{id}  — Alice-LG not-exported view
+//   →  RibService.ListBestRoutes − RibService.ListAdvertisedRoutes,
+//      each missing prefix explained by RibService.ExplainAdvertisedRoute
+// ---------------------------------------------------------------------------
+
+async fn routes_noexport(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<Value>, StatusCode> {
+    // Accepts both the "bgp_<addr>" protocol id and a bare peer IP.
+    let addr_str = id.strip_prefix("bgp_").unwrap_or(&id).replace('_', ":");
+    let peer_addr: IpAddr = addr_str.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let mut rib = proto::rib_service_client::RibServiceClient::new(state.channel.clone());
+
+    // Adj-RIB-Out prefix set. Prefix-granular on purpose: any advertised
+    // path for a prefix means the prefix is exported (an Add-Path peer's
+    // partially-suppressed extra paths are not reported as noexport).
+    let mut advertised: HashSet<(String, u32)> = HashSet::new();
+    let mut page_token = String::new();
+    loop {
+        let resp = rib
+            .list_advertised_routes(proto::ListRoutesRequest {
+                neighbor_address: peer_addr.to_string(),
+                afi_safi: proto::AddressFamily::Unspecified as i32,
+                page_size: 1000,
+                page_token,
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| bad_gateway("ListAdvertisedRoutes", &e))?
+            .into_inner();
+        advertised.extend(
+            resp.routes
+                .iter()
+                .map(|r| (r.prefix.clone(), r.prefix_length)),
+        );
+        if resp.next_page_token.is_empty() {
+            break;
+        }
+        page_token = resp.next_page_token;
+    }
+
+    // Loc-RIB best — the export candidate set (single-best send mode;
+    // only best routes are export candidates).
+    let mut best: Vec<proto::Route> = Vec::new();
+    let mut page_token = String::new();
+    loop {
+        let resp = rib
+            .list_best_routes(proto::ListRoutesRequest {
+                afi_safi: proto::AddressFamily::Unspecified as i32,
+                page_size: 1000,
+                page_token,
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| bad_gateway("ListBestRoutes", &e))?
+            .into_inner();
+        best.extend(resp.routes);
+        if resp.next_page_token.is_empty() {
+            break;
+        }
+        page_token = resp.next_page_token;
+    }
+
+    // One explain per suppressed prefix — a dry run of the same staging
+    // body the live export path executes, so the reason cannot drift
+    // from the real decision. O(suppressed prefixes) RPCs; pair with
+    // Alice-LG's `[noexport] load_on_demand` (its own default) so this
+    // is only computed when an operator opens the view.
+    let mut routes: Vec<Value> = Vec::new();
+    for route in noexport_candidates(&best, &advertised) {
+        let explain = match rib
+            .explain_advertised_route(proto::ExplainAdvertisedRouteRequest {
+                peer_address: peer_addr.to_string(),
+                prefix: route.prefix.clone(),
+                prefix_length: route.prefix_length,
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(r) => r.into_inner(),
+            // Peer not registered for outbound updates (no live
+            // session): nothing is being exported *or* withheld — an
+            // empty noexport view, same posture as the filtered view.
+            Err(s) if s.code() == tonic::Code::NotFound => {
+                info!(
+                    peer = %peer_addr,
+                    "peer has no outbound export state; serving empty noexport view"
+                );
+                return Ok(Json(serde_json::json!({
+                    "api": api_block(),
+                    "routes": [],
+                })));
+            }
+            Err(e) => return Err(bad_gateway("ExplainAdvertisedRoute", &e)),
+        };
+        if let Some(v) = noexport_route_to_birdwatcher(route, &explain) {
+            routes.push(v);
+        }
+    }
+
+    Ok(Json(serde_json::json!({
+        "api": api_block(),
+        "routes": routes,
+    })))
+}
+
+/// Loc-RIB best routes whose prefix is absent from the peer's advertised
+/// set — the not-exported candidates, deduped per prefix (multipath /
+/// Add-Path can put several best paths on one prefix).
+fn noexport_candidates<'a>(
+    best: &'a [proto::Route],
+    advertised: &HashSet<(String, u32)>,
+) -> Vec<&'a proto::Route> {
+    let mut seen: HashSet<(&str, u32)> = HashSet::new();
+    best.iter()
+        .filter(|r| !advertised.contains(&(r.prefix.clone(), r.prefix_length)))
+        .filter(|r| seen.insert((r.prefix.as_str(), r.prefix_length)))
+        .collect()
+}
+
+/// Synthesized noexport-reason large community, `64496:65521:<gate id>`.
+///
+/// Same edge-synthesis convention as `reject_reason_community`: global
+/// administrator `64496` (RFC 5398 documentation ASN, collision-free with
+/// wire communities), function `65521` (adjacent to the reject-reason
+/// function `65520`, distinct so Alice-LG's `[rejection]` and `[noexport]`
+/// matchers never overlap), and a stable id per export gate that stopped
+/// the route (`0` = gate not recognized by this adapter build). Gate names
+/// are the daemon's stable export-ladder vocabulary; ids are append-only.
+fn noexport_reason_community(gate: &str) -> [u64; 3] {
+    let id = match gate {
+        "split_horizon" => 1,
+        "rr_reflection" => 2,
+        "family" => 3,
+        "llgr" => 4,
+        "orf" => 5,
+        "rt_membership" => 6,
+        "export_policy" => 7,
+        _ => 0,
+    };
+    [64496, 65521, id]
+}
+
+/// Convert a suppressed best route plus its export explain to the
+/// birdwatcher route JSON shape.
+///
+/// Same shape as `route_to_birdwatcher` (the route carries its full
+/// Loc-RIB attributes), with the suppression surfaced twice: as the
+/// synthesized noexport-reason large community (what Alice-LG matches)
+/// and as human-readable `noexport_reason` / `noexport_reason_detail`
+/// extra keys (the stopping gate name and its detail line, ignored by
+/// parsers that don't know them).
+///
+/// Returns `None` when the explain does not actually deny the route —
+/// an advertisement the snapshot diff raced (the daemon decided
+/// ADVERTISE between the two listings). Serving that as "not exported"
+/// would be a fabrication; it disappears from the view instead.
+fn noexport_route_to_birdwatcher(
+    route: &proto::Route,
+    explain: &proto::ExplainAdvertisedRouteResponse,
+) -> Option<Value> {
+    if explain.decision != proto::ExplainDecision::Deny as i32 {
+        return None;
+    }
+    let stop = explain
+        .gates
+        .iter()
+        .find(|g| g.verdict == proto::ExportGateVerdict::Stop as i32);
+    let (gate, detail) = stop.map_or(("", ""), |g| (g.gate.as_str(), g.detail.as_str()));
+
+    let mut json = route_to_birdwatcher(route);
+    json["noexport_reason"] = Value::from(gate);
+    json["noexport_reason_detail"] = Value::from(detail);
+    json["bgp"]["large_communities"]
+        .as_array_mut()
+        .expect("route_to_birdwatcher always renders bgp.large_communities")
+        .push(serde_json::json!(noexport_reason_community(gate)));
+    Some(json)
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -715,6 +910,142 @@ mod tests {
             let body = filtered_routes_body(&resp, peer);
             assert!(body["api"].is_object(), "{body}");
             assert_eq!(body["routes"], serde_json::json!([]), "{body}");
+        }
+    }
+
+    /// The set diff behind the noexport view: a route suppressed for the
+    /// peer appears, an exported route does not, duplicate best paths
+    /// for one prefix render once, and an empty Loc-RIB yields an empty
+    /// view. This is the mutation-proof core — flipping the membership
+    /// test either way fails it.
+    #[test]
+    fn noexport_candidates_keep_suppressed_and_exclude_exported() {
+        let mk = |prefix: &str, len: u32, path_id: u32| proto::Route {
+            prefix: prefix.to_string(),
+            prefix_length: len,
+            path_id,
+            ..Default::default()
+        };
+        let best = vec![
+            mk("10.1.0.0", 24, 0), // suppressed
+            mk("10.2.0.0", 24, 0), // exported
+            mk("10.1.0.0", 24, 1), // second best path, same prefix
+        ];
+        let advertised: HashSet<(String, u32)> = [("10.2.0.0".to_string(), 24)].into();
+
+        let candidates = noexport_candidates(&best, &advertised);
+        let networks: Vec<(&str, u32)> = candidates
+            .iter()
+            .map(|r| (r.prefix.as_str(), r.prefix_length))
+            .collect();
+        assert_eq!(
+            networks,
+            vec![("10.1.0.0", 24)],
+            "suppressed once, exported absent"
+        );
+
+        assert!(
+            noexport_candidates(&[], &advertised).is_empty(),
+            "empty Loc-RIB yields an empty noexport view"
+        );
+    }
+
+    /// Every export-ladder gate maps to its pinned triplet, and an
+    /// unknown (future) gate degrades to the generic id 0. Like the
+    /// reject-reason ids, these are part of the documented Alice-LG
+    /// contract — append-only.
+    #[test]
+    fn noexport_reason_community_mapping_is_stable() {
+        for (gate, id) in [
+            ("split_horizon", 1),
+            ("rr_reflection", 2),
+            ("family", 3),
+            ("llgr", 4),
+            ("orf", 5),
+            ("rt_membership", 6),
+            ("export_policy", 7),
+            ("some_future_gate", 0),
+        ] {
+            assert_eq!(
+                noexport_reason_community(gate),
+                [64496, 65521, id],
+                "gate {gate:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn noexport_route_conversion_matches_birdwatcher_shape() {
+        let route = proto::Route {
+            prefix: "10.1.0.0".to_string(),
+            prefix_length: 24,
+            next_hop: "192.0.2.9".to_string(),
+            peer_address: "192.0.2.9".to_string(),
+            as_path: vec![65010],
+            local_pref: 100,
+            large_communities: vec!["65001:1:2".to_string()],
+            ..Default::default()
+        };
+        let explain = proto::ExplainAdvertisedRouteResponse {
+            decision: proto::ExplainDecision::Deny as i32,
+            gates: vec![
+                proto::ExportGateStep {
+                    gate: "best_route".to_string(),
+                    code: "learned".to_string(),
+                    verdict: proto::ExportGateVerdict::Pass as i32,
+                    detail: "Loc-RIB best".to_string(),
+                },
+                proto::ExportGateStep {
+                    gate: "export_policy".to_string(),
+                    code: "policy_denied".to_string(),
+                    verdict: proto::ExportGateVerdict::Stop as i32,
+                    detail: "denied by term no-transit".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let json =
+            noexport_route_to_birdwatcher(&route, &explain).expect("denied route must render");
+        // Base birdwatcher route shape is preserved…
+        assert_eq!(json["network"], "10.1.0.0/24");
+        assert_eq!(json["gateway"], "192.0.2.9");
+        assert_eq!(json["learnt_from"], "192.0.2.9");
+        assert_eq!(json["bgp"]["as_path"], serde_json::json!([65010]));
+        assert_eq!(json["bgp"]["local_pref"], 100);
+        // …the stopping gate is surfaced as the reason…
+        assert_eq!(json["noexport_reason"], "export_policy");
+        assert_eq!(json["noexport_reason_detail"], "denied by term no-transit");
+        // …and the synthesized triplet rides last after wire communities.
+        assert_eq!(
+            json["bgp"]["large_communities"],
+            serde_json::json!([[65001, 1, 2], [64496, 65521, 7]])
+        );
+    }
+
+    /// An explain that does not deny (the snapshot diff raced an
+    /// in-flight advertisement) renders nothing — the view never
+    /// fabricates a "not exported" claim.
+    #[test]
+    fn noexport_route_conversion_skips_non_denied() {
+        let route = proto::Route {
+            prefix: "10.1.0.0".to_string(),
+            prefix_length: 24,
+            ..Default::default()
+        };
+        for decision in [
+            proto::ExplainDecision::Advertise,
+            proto::ExplainDecision::Unspecified,
+            proto::ExplainDecision::NoBestRoute,
+        ] {
+            let explain = proto::ExplainAdvertisedRouteResponse {
+                decision: decision as i32,
+                ..Default::default()
+            };
+            assert!(
+                noexport_route_to_birdwatcher(&route, &explain).is_none(),
+                "decision {decision:?} must not render as noexport"
+            );
         }
     }
 

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -17,6 +17,13 @@
 //! `/routes/filtered/{id}` view (reason token + synthesized reason
 //! community) and the real `routes.filtered` neighbor-summary count
 //! end-to-end.
+//!
+//! A third neighbor (127.0.0.2, announce-nothing receiver) exercises the
+//! `/routes/noexport/{id}` view from both sides: the accepted route is
+//! exported to the receiver (so its noexport view is empty) while split
+//! horizon suppresses it toward its announcer (so it appears in the
+//! announcer's noexport view with the gate name and the synthesized
+//! noexport-reason community).
 
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
@@ -161,6 +168,11 @@ description = "smoke peer"
 address = "127.0.0.1"
 remote_asn = 65020
 description = "live peer"
+
+[[neighbors]]
+address = "127.0.0.2"
+remote_asn = 65030
+description = "receiver peer"
 "#,
         runtime_dir = runtime_dir.display()
     );
@@ -224,6 +236,49 @@ fn establish_bgp_and_announce(bgp_port: u16) -> TcpStream {
     stream
 }
 
+/// Second minimal speaker: complete the handshake as AS 65030 from
+/// source address 127.0.0.2 (the daemon maps sessions to configured
+/// neighbors by source IP) and announce nothing — a pure receiver, so
+/// the daemon's export path advertises the accepted route to it. The
+/// std TcpStream API cannot bind a source address; borrow tokio's
+/// TcpSocket for the connect and hand back a blocking std stream.
+fn establish_bgp_receiver(bgp_port: u16) -> TcpStream {
+    use rustbgpd_wire::message::{Message, encode_message};
+    use rustbgpd_wire::open::OpenMessage;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .expect("build tokio runtime");
+    let stream = rt
+        .block_on(async {
+            let socket = tokio::net::TcpSocket::new_v4()?;
+            socket.bind("127.0.0.2:0".parse().unwrap())?;
+            socket
+                .connect(format!("127.0.0.1:{bgp_port}").parse().unwrap())
+                .await?
+                .into_std()
+        })
+        .expect("connect to BGP port from 127.0.0.2");
+    stream
+        .set_nonblocking(false)
+        .expect("blocking receiver stream");
+
+    let open = Message::Open(OpenMessage {
+        version: 4,
+        my_as: 65030,
+        hold_time: 90,
+        bgp_identifier: "10.0.0.3".parse().unwrap(),
+        capabilities: Vec::new(),
+    });
+    let mut stream = stream;
+    for msg in [&open, &Message::Keepalive] {
+        let encoded = encode_message(msg).expect("encode BGP message");
+        stream.write_all(&encoded).expect("write BGP message");
+    }
+    stream
+}
+
 /// Inverse of the servers' `format_epoch_secs` (`"YYYY-MM-DD HH:MM:SS"`
 /// → Unix epoch seconds) so two `age` renderings can be compared with
 /// clock-recovery jitter tolerance. Howard Hinnant's `days_from_civil`.
@@ -246,7 +301,7 @@ fn epoch_from_timestamp(s: &str) -> u64 {
 }
 
 #[test]
-fn adapter_serves_birdwatcher_shaped_status_peer_accepted_and_filtered_route_subset() {
+fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_subset() {
     let temp = tempfile::tempdir().expect("create temp dir");
     let grpc_port = free_port();
     let adapter_port = free_port();
@@ -399,4 +454,61 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_and_filtered_route_sub
     // the filtered view is empty, not an error.
     let down = get_json(adapter_port, "/routes/filtered/bgp_192.0.2.10", "adapter");
     assert_eq!(down["routes"], serde_json::json!([]), "{down}");
+
+    // /routes/noexport/{id} — the accepted route is Loc-RIB best, but
+    // split horizon suppresses it toward its own announcer: the
+    // announcer's noexport view must serve it with the stopping gate
+    // name and the synthesized noexport-reason community.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let noexport = loop {
+        let noexport = get_json(adapter_port, "/routes/noexport/bgp_127.0.0.1", "adapter");
+        if noexport["routes"].as_array().is_some_and(|r| r.len() == 1) {
+            break noexport;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "suppressed route did not appear on the noexport view\nadapter: {noexport}\ndaemon stderr:\n{}",
+            daemon.stderr()
+        );
+        thread::sleep(Duration::from_millis(200));
+    };
+    let suppressed = &noexport["routes"][0];
+    assert_eq!(suppressed["network"], "10.99.0.0/24", "{noexport}");
+    assert_eq!(suppressed["noexport_reason"], "split_horizon", "{noexport}");
+    assert!(
+        suppressed["bgp"]["large_communities"]
+            .as_array()
+            .is_some_and(|lcs| lcs.contains(&serde_json::json!([64496, 65521, 1]))),
+        "noexport route must carry the synthesized split_horizon community: {noexport}"
+    );
+
+    // Bring up the announce-nothing receiver peer: the daemon exports
+    // the accepted route to it. Once the export shows on the neighbor
+    // summary, the exported route must NOT appear in the receiver's
+    // noexport view (mutation proof: exported ≠ noexport).
+    let _receiver_session = establish_bgp_receiver(bgp_port);
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        let protocols = get_json(adapter_port, "/protocols/bgp", "adapter");
+        let exported = &protocols["protocols"]["bgp_127.0.0.2"]["routes"]["exported"];
+        let receiver_noexport = get_json(adapter_port, "/routes/noexport/bgp_127.0.0.2", "adapter");
+        if exported == 1 && receiver_noexport["routes"] == serde_json::json!([]) {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "exported route must leave the receiver's noexport view\nprotocols: {protocols}\nnoexport: {receiver_noexport}\ndaemon stderr:\n{}",
+            daemon.stderr()
+        );
+        thread::sleep(Duration::from_millis(200));
+    }
+
+    // A configured peer with no live session has no outbound export
+    // state — the noexport view is empty, not an error.
+    let down_noexport = get_json(adapter_port, "/routes/noexport/bgp_192.0.2.10", "adapter");
+    assert_eq!(
+        down_noexport["routes"],
+        serde_json::json!([]),
+        "{down_noexport}"
+    );
 }


### PR DESCRIPTION
## Summary

Completes the birdwatcher adapter's Alice-LG contract: `GET /routes/noexport/{id}` now serves the routes accepted into the Loc-RIB but not exported to a peer, with the real reason for each suppression.

## Implementation

- **Data source:** `RibService.ListBestRoutes` minus `RibService.ListAdvertisedRoutes` (both paged) yields the suppressed prefix set; each one is explained by `RibService.ExplainAdvertisedRoute` — a dry run of the same export staging body the live path executes, so the reason cannot drift from the real decision.
- **Coverage (honest, documented):** every export-ladder suppression (split horizon, RFC 4456 reflection, family negotiation, RFC 9494 LLGR, RFC 5291 ORF, RFC 4684 RT membership, export policy) — not only NO_EXPORT-community routes. Prefix-granular, IPv4/IPv6 unicast single-best candidates, empty view for peers with no live session, and a route whose explain does not deny (a raced in-flight advertisement) is dropped rather than fabricated.
- **Alice-LG integration:** one synthesized `64496:65521:<gate id>` large community per route (function adjacent to the reject-reason `65520`, ids append-only and pinned by test) plus human-readable `noexport_reason` / `noexport_reason_detail` extra keys; README documents the mapping table and the matching `[noexport]` / `[noexport_reasons]` config, including `load_on_demand` for the per-request explain cost.
- **Authorization:** all three backing RPCs are `sensitive_read`-tier, the same tier the adapter already required for `ListRejectedRoutes` — no change for existing deployments; `max_tier = "read"` still denies both the filtered and noexport views (docs/SECURITY.md updated, disclosure surface extended).

## Tests

- Unit: set-diff mutation proof (suppressed route present, exported route absent, per-prefix dedupe, empty Loc-RIB), gate→community mapping pinned, noexport route shape, non-deny skip.
- E2E smoke: extended with an announce-nothing receiver peer — the accepted route appears in its announcer's noexport view (split horizon, with the synthesized community) and leaves the receiver's noexport view once exported; a session-less peer serves an empty view.

## Docs

README/ROADMAP, adapter README (new noexport section), docs/{SECURITY,EMBEDDING,CONFIGURATION,OPERATIONS,USE_CASES,feature-tour}.md, cookbook (monitoring-feed, ixp-filter-pipeline), CHANGELOG — every "noexport views are not wired" claim flipped.