### PR TITLE
Harden config history and config import fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   policy-definitions are listed — with source line numbers — in an
   import report for hand-translation to `.rpol`. Secrets are never
   imported (MD5/auth presence is flagged instead). Distinct exit codes:
-  0 clean full translation, 1 error, 2 translated-with-skips, 3 nothing
-  translatable; the emitted config for every checked-in fixture is
+  0 clean full translation, 1 error, 2 translated-with-warnings-or-skips,
+  3 nothing translatable; the emitted config for every checked-in fixture is
   gate-tested against `rustbgpd --check`. The route-server migration
   cookbook now opens with the mechanical importer → `--check` → shadow
   trial → `rbgp diff advertised` flow.
@@ -60,8 +60,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   presence and non-emptiness.
 - Applied-config history and `rollback N`, completing the Junos-style
   transactional quartet (check / compare / commit confirmed / rollback).
-  Every durable config write — transaction applies, gRPC config CRUD, and
-  the boot-time config — is recorded in a bounded on-disk history under
+  Every applied config — transaction applies, gRPC config CRUD,
+  successful SIGHUP reloads, and the boot-time config — is recorded in a
+  bounded on-disk history under
   `<runtime_state_dir>/config-history/` (last 20 distinct configs,
   content-hash-deduplicated, timestamped, restart-safe). `rbgp config
   history` lists index / timestamp / SHA-256 / one-line summary; `rbgp
@@ -69,7 +70,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   executor — same plan classification, reload-impact and update-group
   annotations, receipts, and optional `--confirm-id`/`--confirm-timeout`
   confirmed-commit window (timeout auto-revert and boot revert included).
-  Rolling back past the retained history fails cleanly. New
+  Entry reads verify the content digest embedded in the file name and
+  reject non-regular or corrupt snapshots. Rolling back past the retained
+  history fails cleanly. New
   `ConfigService.ListConfigHistory` (`sensitive_read`) and
   `ConfigService.RollbackConfigTransaction` (`operator_only`, same tier as
   apply) RPCs; history responses carry metadata only, never config

--- a/crates/cli/src/importer/frr.rs
+++ b/crates/cli/src/importer/frr.rs
@@ -121,6 +121,18 @@ pub fn parse(input: &str) -> Model {
         }
 
         if let Some(rest) = text.strip_prefix("router bgp ") {
+            let mut instance = rest.split_whitespace();
+            let asn = instance.next().and_then(|word| word.parse().ok());
+            if instance.next().is_some() {
+                skip(
+                    &mut model,
+                    line,
+                    text.to_owned(),
+                    "BGP VRF/view instance: rustbgpd runs one global instance per daemon",
+                );
+                swallow_top = true;
+                continue;
+            }
             if model.local_asn.is_some() {
                 skip(
                     &mut model,
@@ -131,7 +143,7 @@ pub fn parse(input: &str) -> Model {
                 swallow_top = true;
                 continue;
             }
-            match rest.split_whitespace().next().and_then(|w| w.parse().ok()) {
+            match asn {
                 Some(asn) => {
                     model.local_asn = Some(asn);
                     in_bgp = true;
@@ -174,10 +186,17 @@ pub fn parse(input: &str) -> Model {
         skip(&mut model, line, text.to_owned(), GENERIC_GUIDANCE);
     }
 
-    // Post-pass: default IPv4-unicast activation for neighbors with no
-    // explicit activation anywhere (and no group families to inherit),
-    // and the `timers bgp` instance-default hold time for neighbors
+    // Post-pass: FRR's default IPv4-unicast activation is additive to
+    // explicit AF activation and applies to peer groups as well as peers.
+    // Also apply the `timers bgp` instance-default hold time to neighbors
     // without their own timers (group timers inherit at daemon level).
+    if default_ipv4 {
+        for group in &mut model.groups {
+            if !group.families.iter().any(|family| family == "ipv4_unicast") {
+                group.families.push("ipv4_unicast".to_owned());
+            }
+        }
+    }
     let groups = &model.groups;
     for neighbor in &mut model.neighbors {
         let group = neighbor
@@ -185,7 +204,13 @@ pub fn parse(input: &str) -> Model {
             .as_ref()
             .and_then(|name| groups.iter().find(|group| &group.name == name));
         let inherits_families = group.is_some_and(|g| !g.families.is_empty());
-        if neighbor.families.is_empty() && !inherits_families && default_ipv4 {
+        if default_ipv4
+            && !neighbor
+                .families
+                .iter()
+                .any(|family| family == "ipv4_unicast")
+            && (!neighbor.families.is_empty() || !inherits_families)
+        {
             neighbor.families.push("ipv4_unicast".to_owned());
         }
         if neighbor.hold_time.is_none() && group.and_then(|g| g.hold_time).is_none() {

--- a/crates/cli/src/importer/gobgp.rs
+++ b/crates/cli/src/importer/gobgp.rs
@@ -65,7 +65,11 @@ fn as_u32(value: &toml::Value) -> Option<u32> {
     match value {
         toml::Value::Integer(n) => u32::try_from(*n).ok(),
         // gobgp's config dumper writes some integers as floats.
-        toml::Value::Float(f) if f.fract() == 0.0 && *f >= 0.0 => Some(*f as u32),
+        toml::Value::Float(f)
+            if f.is_finite() && f.fract() == 0.0 && *f >= 0.0 && *f <= f64::from(u32::MAX) =>
+        {
+            Some(*f as u32)
+        }
         _ => None,
     }
 }

--- a/crates/cli/src/importer/mod.rs
+++ b/crates/cli/src/importer/mod.rs
@@ -17,13 +17,14 @@
 //!
 //! | code | meaning                                                    |
 //! |------|------------------------------------------------------------|
-//! | 0    | clean full structural translation (nothing skipped)        |
+//! | 0    | clean full structural translation (no warnings or skips)   |
 //! | 1    | error: unreadable source, unrecognized format, parse error |
-//! | 2    | translated with skips (config written; report lists them)  |
+//! | 2    | translated with warnings/skips (config written; review it) |
 //! | 3    | refused: no translatable BGP structure in the source       |
 //!
-//! Anything skipped is non-zero by construction: a silent partial
-//! translation would be worse than no translation.
+//! Anything requiring operator attention is non-zero by construction: a
+//! silent partial or placeholder-bearing translation would be worse than an
+//! explicit review result.
 
 pub mod bird;
 pub mod frr;
@@ -169,7 +170,11 @@ pub struct Report {
 
 impl Report {
     pub fn exit_code(&self) -> i32 {
-        if self.skipped.is_empty() { 0 } else { 2 }
+        if self.skipped.is_empty() && self.warnings.is_empty() {
+            0
+        } else {
+            2
+        }
     }
 
     pub fn render_text(&self) -> String {
@@ -220,7 +225,7 @@ impl Report {
             "\nresult: {} (exit {})",
             match self.exit_code() {
                 0 => "clean full structural translation",
-                _ => "translated with skips",
+                _ => "translated with warnings/skips; review required",
             },
             self.exit_code()
         );

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -60,7 +60,7 @@ const EXIT_CODES_HELP: &str = "Exit codes:\n  \
     diff advertised      0 no differences / 1 differences / 2 non-comparable input or error\n  \
     diff snapshot ...    0 snapshot emitted / 2 refused or malformed input\n  \
     config diff, plan    0 no changes / 1 error / 2 changes present\n  \
-    config import        0 clean translation / 1 error / 2 translated with skips / 3 nothing translatable\n  \
+    config import        0 clean / 1 error / 2 warnings or skips / 3 nothing translatable\n  \
     doctor               0 all checks green / 1 error / 2 red checks found\n  \
     policy check         0 clean / 1 diagnostics / 2 test failures / 3 coverage below --coverage-min\n  \
     policy test          0 ran / 1 compile diagnostics\n  \
@@ -543,9 +543,9 @@ enum ConfigAction {
     /// follow docs/cookbook/route-server-migration.md (shadow trial,
     /// `rbgp diff advertised`) before carrying traffic.
     #[command(after_help = "Exit codes:\n  \
-        0  clean full structural translation (nothing skipped)\n  \
+        0  clean full structural translation (no warnings or skips)\n  \
         1  error (unreadable source, unrecognized format, parse failure)\n  \
-        2  translated with skips (config written; the report lists every skipped stanza)\n  \
+        2  translated with warnings or skips (config written; review the report)\n  \
         3  refused (no translatable BGP structure in the source)")]
     Import {
         /// Source config: BIRD 2 (.conf), FRR running-config (.conf), or GoBGP (.toml)

--- a/crates/cli/tests/config_import.rs
+++ b/crates/cli/tests/config_import.rs
@@ -271,6 +271,18 @@ fn exit_2_translated_with_skips() {
     }
 }
 
+/// Load-bearing exit-contract proof: a placeholder-bearing translation must
+/// require review even when no stanza was skipped. Reverting `Report::exit_code`
+/// to inspect only `skipped` makes this return zero.
+#[test]
+fn exit_2_translated_with_warning_only() {
+    let source = "router bgp 64500\n neighbor 192.0.2.1 remote-as 64496\n!\n";
+    let imported = import_source(SourceFormat::Frr, "warning.conf", source).expect("translates");
+    assert!(imported.report.skipped.is_empty());
+    assert!(!imported.report.warnings.is_empty());
+    assert_eq!(imported.report.exit_code, 2);
+}
+
 #[test]
 fn exit_3_refused_when_nothing_translatable() {
     // Valid FRR shape, but no BGP instance at all.
@@ -330,6 +342,77 @@ fn group_remote_as_resolves_onto_members() {
             .config_toml
             .contains("address = \"192.0.2.200\"\nremote_asn = 64499")
     );
+}
+
+/// Load-bearing FRR-default proof: removing the additive default-IPv4
+/// post-pass leaves this explicitly IPv6-activated peer with IPv6 only,
+/// contrary to FRR's default AF semantics.
+#[test]
+fn frr_default_ipv4_is_additive_to_explicit_ipv6() {
+    let source = "\
+router bgp 64500
+ bgp router-id 192.0.2.10
+ neighbor 192.0.2.1 remote-as 64496
+ address-family ipv6 unicast
+  neighbor 192.0.2.1 activate
+ exit-address-family
+!
+";
+    let imported = import_source(SourceFormat::Frr, "dual.conf", source).expect("translates");
+    assert!(
+        imported
+            .config_toml
+            .contains("families = [\"ipv6_unicast\", \"ipv4_unicast\"]"),
+        "{}",
+        imported.config_toml
+    );
+}
+
+/// Load-bearing instance-boundary proof: accepting suffix tokens on the first
+/// `router bgp` line imports a VRF as rustbgpd's global instance and causes the
+/// real global instance below it to be discarded.
+#[test]
+fn frr_vrf_instance_is_not_imported_as_global() {
+    let source = "\
+router bgp 65100 vrf BLUE
+ bgp router-id 198.51.100.1
+ neighbor 198.51.100.2 remote-as 65101
+!
+router bgp 64500
+ bgp router-id 192.0.2.10
+ neighbor 192.0.2.1 remote-as 64496
+!
+";
+    let imported = import_source(SourceFormat::Frr, "vrf.conf", source).expect("translates");
+    assert_eq!(imported.report.local_asn, 64500);
+    assert_eq!(imported.report.neighbor_count, 1);
+    assert!(imported.config_toml.contains("address = \"192.0.2.1\""));
+    assert!(!imported.config_toml.contains("198.51.100.2"));
+    assert!(
+        imported
+            .report
+            .skipped
+            .iter()
+            .any(|skip| skip.stanza == "router bgp 65100 vrf BLUE")
+    );
+}
+
+/// Load-bearing numeric-boundary proof: Rust's float-to-integer cast saturates,
+/// so removing the explicit upper bound silently turns this invalid GoBGP AS
+/// into 4294967295 instead of refusing the source.
+#[test]
+fn gobgp_rejects_out_of_range_float_asn() {
+    let source = "\
+[global.config]
+as = 1e100
+router-id = \"192.0.2.10\"
+[[neighbors]]
+[neighbors.config]
+neighbor-address = \"192.0.2.1\"
+peer-as = 64496
+";
+    let error = import_source(SourceFormat::Gobgp, "overflow.toml", source).unwrap_err();
+    assert!(matches!(error, ImportError::Empty(_)), "{error:?}");
 }
 
 #[test]

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -187,10 +187,10 @@ For operators coming from Junos, the four verbs map directly:
 
 The daemon retains a bounded on-disk history of applied configs (the last 20
 distinct documents, content-hash-deduplicated, timestamped) under
-`<runtime_state_dir>/config-history/`. Every durable config write records an
-entry — transaction applies, gRPC neighbor/FIB/policy CRUD, and the config
-running at daemon startup — so the history survives restarts and "put back
-what was running yesterday" is one command:
+`<runtime_state_dir>/config-history/`. Transaction applies, gRPC
+neighbor/FIB/policy CRUD, successful SIGHUP reloads, and the config running at
+daemon startup all record an entry, so the history survives restarts and "put
+back what was running yesterday" is one command:
 
 ```bash
 # What has been applied? Newest first; index 0 is the running config.
@@ -207,7 +207,8 @@ rbgp config confirm undo-1
 
 `config history` lists index, timestamp, content hash, and a one-line summary
 per entry — never config document contents. `config rollback N` resolves
-entry N server-side and routes it through the **same transaction path as
+entry N server-side, verifies that its bytes match the SHA-256 in its file
+name, and routes it through the **same transaction path as
 `config apply`**: the same plan classification, the same reload-impact and
 update-group annotations, the same receipts, and the same
 `--confirm-id`/`--confirm-timeout` confirmed-commit window (journal, timeout

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -304,6 +304,17 @@ Use a separate `runtime_state_dir` for every concurrently running daemon.
 The directory is single-writer state for the marker, checkpoint, FIB receipt,
 and Unix socket; owner-only permissions do not make cross-process sharing safe.
 
+## Applied-config history confidentiality
+
+`<runtime_state_dir>/config-history/*.toml` and a pending
+`commit-confirm-journal.json` contain complete configuration snapshots. That
+can include TCP-MD5 passwords, TCP-AO keys, API credentials, and other secrets;
+the redacted `rbgp config history` summary does not make the files themselves
+safe to publish. Snapshot files are created owner-only (`0600`), and history
+reads verify their filename SHA-256 before they are eligible for rollback.
+Keep `runtime_state_dir` on owner-controlled local storage and protect backups
+as secret-bearing configuration, not as ordinary operational telemetry.
+
 ## Linux EVPN VTEP — `CAP_NET_ADMIN` requirement
 
 Running rustbgpd in **EVPN VTEP mode** on Linux (a non-empty

--- a/docs/cookbook/route-server-migration.md
+++ b/docs/cookbook/route-server-migration.md
@@ -11,9 +11,9 @@ before carrying production traffic.
 ## The mechanical first step
 
 ```bash
-# 1. Translate the structure; the report lists every stanza that was NOT
-#    translated, with source line numbers (exit 0 only when nothing was
-#    skipped; 2 = translated with skips; 3 = nothing translatable).
+# 1. Translate the structure; the report lists every warning and stanza that
+#    needs review, with source line numbers where available (exit 0 only
+#    when neither exists; 2 = translated but needs review; 3 = nothing).
 rbgp config import bird.conf --out config.toml
 
 # 2. Hand-translate the reported policy stanzas to .rpol

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -619,6 +619,8 @@ processes is unsupported even when their configuration files differ.
 |---|---|---|
 | `gr-restart.toml` | Graceful Restart coordination marker. Written on clean shutdown, read on startup to set the R-bit in OPEN. | Yes |
 | `warm-bundle-v1/` | Optional owner-private shutdown checkpoint (`manifest.json` plus a content-addressed MRT artifact). Published only when `warm_cache_checkpoint_on_shutdown = true`; not restored on startup. | Yes |
+| `commit-confirm-journal.json` | Owner-private pre-transaction config snapshot for crash-safe confirmed commits; consumed by confirm/abort/timeout or boot revert. | Until the transaction is terminal |
+| `config-history/*.toml` | Last 20 distinct applied configs for `rbgp config history` / `rollback N`; owner-private and secret-bearing. | Yes |
 | `fib-owned.json` | FIB ownership receipt — which kernel routes the daemon installed (ADR-0061). Used to drain orphan installs on next start. | Yes |
 | `grpc.sock` | gRPC UDS endpoint (if `[global.telemetry.grpc_uds]` configured). | Recreated on start |
 

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -132,10 +132,14 @@ the real decision. Precisely what the view contains:
   the route *would* be advertised), the route is dropped from the view —
   it never fabricates a "not exported" claim.
 
-**Cost:** one `ExplainAdvertisedRoute` call per suppressed prefix on every
-request. Alice-LG's `[noexport] load_on_demand` (its default) fits this —
-the view is only computed when an operator opens it. For very large
-Loc-RIBs, consider fronting the adapter with a caching proxy.
+**Cost:** each request pages the complete Loc-RIB and peer Adj-RIB-Out, then
+makes one `ExplainAdvertisedRoute` call per suppressed prefix. Both paged
+snapshots are version-fenced: concurrent table churn can fail the request
+rather than return a mixed-generation answer, so clients should retry a 502.
+Alice-LG's `[noexport] load_on_demand` (its default) fits this — the view is
+only computed when an operator opens it. Do not poll it as a metrics endpoint;
+for very large or fast-changing Loc-RIBs, use a caching proxy and expect the
+current per-request implementation to be expensive until a bulk RPC exists.
 
 ### Noexport-reason → large-community mapping
 

--- a/src/config_history.rs
+++ b/src/config_history.rs
@@ -1,9 +1,9 @@
 //! Bounded on-disk history of applied configs (Junos-style `rollback N`).
 //!
-//! Every durable config write funnels through [`crate::config_persister`]'s
-//! atomic persist step, which records the written document here — one entry
-//! per distinct config, content-hash-deduplicated against the newest entry
-//! and bounded to [`HISTORY_LIMIT`] snapshots under
+//! [`crate::config_persister`] records each validated applied config here —
+//! durable mutations, the boot snapshot, and successful SIGHUP refreshes —
+//! one entry per distinct config, content-hash-deduplicated against the newest
+//! entry and bounded to [`HISTORY_LIMIT`] snapshots under
 //! `<runtime_state_dir>/config-history/`. Rollback resolves an entry by
 //! index and routes it through the ordinary config transaction path (see
 //! `config_transaction_control`); this module only stores and lists.
@@ -11,8 +11,8 @@
 //! Entries are individual files named `<seq>-<unix_ts>-<sha256>.toml`,
 //! written with the commit-confirm journal's fsync'd atomic-write primitive.
 //! The monotonic sequence number orders entries (newest = highest); the
-//! content hash lives in the file name so recording and dedup never need to
-//! re-read old entries.
+//! content hash lives in the file name and is verified against the retained
+//! bytes before deduplication or rollback.
 
 #![deny(unsafe_code)]
 
@@ -45,7 +45,7 @@ pub struct HistoryEntry {
     pub sequence: u64,
     /// Unix seconds at record time.
     pub timestamp_unix_seconds: u64,
-    /// Hex-encoded SHA-256 of the persisted TOML document.
+    /// Hex-encoded SHA-256 of the applied TOML document.
     pub sha256: String,
     /// Entry file path.
     pub path: PathBuf,
@@ -82,10 +82,20 @@ pub fn record(dir: &Path, toml_str: &str) -> io::Result<bool> {
     fs::create_dir_all(dir)?;
     let hash = sha256_hex(toml_str);
     let entries = list(dir)?;
-    if entries.first().is_some_and(|newest| newest.sha256 == hash) {
+    if let Some(newest) = entries.first()
+        && newest.sha256 == hash
+        && read(newest).is_ok_and(|contents| contents == toml_str)
+    {
         return Ok(false);
     }
-    let sequence = entries.first().map_or(1, |newest| newest.sequence + 1);
+    let sequence = entries.first().map_or(Ok(1), |newest| {
+        newest.sequence.checked_add(1).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "config history sequence is exhausted",
+            )
+        })
+    })?;
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |duration| duration.as_secs());
@@ -155,6 +165,42 @@ pub fn read_entry(dir: &Path, index: usize) -> io::Result<(HistoryEntry, String)
             ),
         ));
     };
+    let toml_str = read(&entry)?;
+    Ok((entry, toml_str))
+}
+
+/// Load and integrity-check one exact history entry returned by [`list`].
+///
+/// Reading by entry rather than re-resolving its index keeps a concurrent
+/// append from pairing one snapshot's metadata with another snapshot's
+/// contents. The file name is only metadata until the retained bytes hash to
+/// the embedded digest; a corrupt or replaced entry is never eligible for a
+/// rollback.
+///
+/// # Errors
+///
+/// Returns `InvalidData` for a non-regular, oversized, non-UTF-8, or
+/// digest-mismatched entry, plus ordinary filesystem errors.
+pub fn read(entry: &HistoryEntry) -> io::Result<String> {
+    let metadata = fs::symlink_metadata(&entry.path)?;
+    if !metadata.file_type().is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "config history entry {} is not a regular file",
+                entry.path.display()
+            ),
+        ));
+    }
+    if metadata.len() > MAX_ENTRY_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "config history entry {} exceeds the {MAX_ENTRY_BYTES}-byte sanity limit",
+                entry.path.display()
+            ),
+        ));
+    }
     let mut reader = fs::File::open(&entry.path)?.take(MAX_ENTRY_BYTES + 1);
     let mut toml_str = String::new();
     reader.read_to_string(&mut toml_str)?;
@@ -167,7 +213,18 @@ pub fn read_entry(dir: &Path, index: usize) -> io::Result<(HistoryEntry, String)
             ),
         ));
     }
-    Ok((entry, toml_str))
+    let actual_hash = sha256_hex(&toml_str);
+    if actual_hash != entry.sha256 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "config history entry {} failed its SHA-256 integrity check (expected {}, got {actual_hash})",
+                entry.path.display(),
+                entry.sha256
+            ),
+        ));
+    }
+    Ok(toml_str)
 }
 
 /// One-line redacted summary of a retained config document: identity and
@@ -214,7 +271,7 @@ fn parse_entry_name(name: &str) -> Option<(u64, u64, String)> {
     if hash.len() != 64 || !hash.bytes().all(|b| b.is_ascii_hexdigit()) {
         return None;
     }
-    Some((sequence, timestamp, hash.to_string()))
+    Some((sequence, timestamp, hash.to_ascii_lowercase()))
 }
 
 #[cfg(test)]
@@ -330,6 +387,82 @@ mod tests {
         let empty = dir.path().join("empty");
         let error = read_entry(&empty, 1).unwrap_err();
         assert!(error.to_string().contains("0 retained entries"));
+    }
+
+    /// Load-bearing integrity proof: changing retained bytes without changing
+    /// the digest-bearing file name must make the entry unreadable. Removing
+    /// the digest comparison in `read` makes this test green-light a tampered
+    /// rollback candidate.
+    #[test]
+    fn read_entry_refuses_digest_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(record(dir.path(), &config_toml(65001)).unwrap());
+        let entry = list(dir.path()).unwrap().remove(0);
+        fs::write(&entry.path, config_toml(65002)).unwrap();
+
+        let error = read_entry(dir.path(), 0).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("integrity check"), "{error}");
+    }
+
+    /// Load-bearing dedup proof: a corrupt newest file that merely retains the
+    /// expected hash in its name must not suppress a fresh good snapshot.
+    /// Restoring the old filename-only dedup makes `record` return false.
+    #[test]
+    fn record_repairs_filename_only_dedup_after_corruption() {
+        let dir = tempfile::tempdir().unwrap();
+        let original = config_toml(65001);
+        assert!(record(dir.path(), &original).unwrap());
+        let entry = list(dir.path()).unwrap().remove(0);
+        fs::write(&entry.path, config_toml(65002)).unwrap();
+
+        assert!(record(dir.path(), &original).unwrap());
+        let entries = list(dir.path()).unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(read(&entries[0]).unwrap(), original);
+        assert!(read(&entries[1]).is_err(), "corrupt prior stays ineligible");
+    }
+
+    /// Load-bearing sequence-boundary proof: a corrupt maximum sequence must
+    /// fail closed instead of panicking in debug builds or wrapping to zero in
+    /// release builds. Restoring unchecked `newest.sequence + 1` breaks this.
+    #[test]
+    fn record_refuses_sequence_exhaustion() {
+        let dir = tempfile::tempdir().unwrap();
+        let prior = config_toml(65001);
+        let path = dir
+            .path()
+            .join(format!("{}-1-{}.toml", u64::MAX, sha256_hex(&prior)));
+        fs::write(path, prior).unwrap();
+
+        let error = record(dir.path(), &config_toml(65002)).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            error.to_string().contains("sequence is exhausted"),
+            "{error}"
+        );
+    }
+
+    /// Load-bearing file-type proof: a digest-shaped symlink must not turn the
+    /// rollback store into an arbitrary file reader. Replacing
+    /// `symlink_metadata` with an unchecked `File::open` makes this pass as a
+    /// valid snapshot.
+    #[cfg(unix)]
+    #[test]
+    fn read_refuses_symlink_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let contents = config_toml(65001);
+        let target = dir.path().join("target.toml");
+        fs::write(&target, &contents).unwrap();
+        let path = dir
+            .path()
+            .join(format!("0000000001-1-{}.toml", sha256_hex(&contents)));
+        std::os::unix::fs::symlink(&target, &path).unwrap();
+
+        let entry = list(dir.path()).unwrap().remove(0);
+        let error = read(&entry).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("not a regular file"), "{error}");
     }
 
     #[test]

--- a/src/config_persister.rs
+++ b/src/config_persister.rs
@@ -63,9 +63,10 @@ impl ConfigPersister {
         // Record the boot-time config as the newest history entry so the
         // first-ever rollback can restore what was running before the first
         // apply. Content-hash dedup keeps restarts from growing history.
-        if let Ok(toml_str) = toml::to_string_pretty(&self.current) {
-            self.record_history(&toml_str);
-        }
+        // Serialize the already-validated runtime snapshot. Re-reading the
+        // source here would create a validation-to-read race if an operator
+        // edits the file between startup validation and this task starting.
+        self.record_current_history();
         while let Some(mutation) = self.rx.recv().await {
             if let ConfigMutation::ReplaceConfigAck(new_config, ack) = mutation {
                 let previous = self.current.clone();
@@ -136,6 +137,11 @@ impl ConfigPersister {
             ConfigMutation::RefreshSnapshotNoPersist(new_config) => {
                 info!("refreshing persister config snapshot without writing to disk");
                 self.current = *new_config;
+                // The operator already persisted and successfully reloaded
+                // this desired config. Record the validated snapshot without
+                // writing it back: otherwise history index 0 still names the
+                // pre-SIGHUP config and `rollback 1` cannot restore it.
+                self.record_current_history();
                 false
             }
         }
@@ -167,6 +173,16 @@ impl ConfigPersister {
                 error = %error,
                 "failed to record applied config in the config history"
             );
+        }
+    }
+
+    fn record_current_history(&self) {
+        match toml::to_string_pretty(&self.current) {
+            Ok(toml_str) => self.record_history(&toml_str),
+            Err(error) => warn!(
+                error = %error,
+                "failed to serialize the applied config for config history"
+            ),
         }
     }
 }
@@ -380,6 +396,36 @@ log_format = "json"
         drop(tx);
         handle.await.unwrap();
         assert_eq!(crate::config_history::list(&history).unwrap().len(), 2);
+    }
+
+    /// Load-bearing SIGHUP-history proof: refreshing the validated desired
+    /// snapshot without a daemon write must still make that snapshot the
+    /// newest rollback entry. Removing the history record from
+    /// `RefreshSnapshotNoPersist` leaves this list at one entry.
+    #[test]
+    fn refresh_snapshot_no_persist_records_validated_config_history() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let history = dir.path().join("config-history");
+        let config = minimal_config();
+        std::fs::write(&path, toml::to_string_pretty(&config).unwrap()).unwrap();
+
+        let (_tx, rx) = mpsc::channel(1);
+        let mut persister = ConfigPersister::new(rx, path, config, Some(history.clone()));
+        persister.record_current_history();
+
+        let mut refreshed = minimal_config();
+        refreshed.neighbors.push(test_neighbor("10.0.0.2", 65002));
+        assert!(
+            !persister.apply(ConfigMutation::RefreshSnapshotNoPersist(Box::new(
+                refreshed.clone()
+            ),))
+        );
+
+        let entries = crate::config_history::list(&history).unwrap();
+        assert_eq!(entries.len(), 2);
+        let newest = crate::config_history::read(&entries[0]).unwrap();
+        assert_eq!(newest, toml::to_string_pretty(&refreshed).unwrap());
     }
 
     #[tokio::test]

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -706,9 +706,9 @@ impl ConfigTransactionController {
         for entry in &entries {
             // Summaries come from the entry contents; a per-entry read
             // failure degrades that one summary instead of failing the list.
-            let summary = crate::config_history::read_entry(dir, entry.index).map_or_else(
+            let summary = crate::config_history::read(entry).map_or_else(
                 |error| format!("(unreadable entry: {error})"),
-                |(_, toml_str)| crate::config_history::summarize(&toml_str),
+                |toml_str| crate::config_history::summarize(&toml_str),
             );
             proto_entries.push(proto::ConfigHistoryEntry {
                 index: u32::try_from(entry.index).unwrap_or(u32::MAX),


### PR DESCRIPTION
## Summary

- integrity-check applied-config history before listing or rollback, reject non-regular entries, repair corrupt filename-only dedup, and fail closed on sequence exhaustion
- record successful SIGHUP configurations so rollback history follows the actual desired configuration
- preserve FRR address-family and instance semantics, reject out-of-range GoBGP float ASNs, and make warning-bearing imports return the documented review-required exit code
- document secret-bearing runtime state and the Birdwatcher noexport endpoint's pagination, churn, and cost boundaries

## Why

The recently added config-history path trusted digest-shaped filenames without verifying the retained bytes, re-resolved indexes while rendering history, and did not record successful SIGHUP reloads. That could make metadata describe a different entry, leave a corrupt snapshot eligible for rollback, or leave rollback history behind the running desired configuration.

The config importer also treated FRR's implicit IPv4-unicast activation as mutually exclusive with explicit IPv6 activation, accepted a VRF/view instance as rustbgpd's global BGP instance, saturated oversized GoBGP float ASNs to `u32::MAX`, and reported warning-only translations as clean.

## Operator impact

Rollback candidates are now bound to their advertised SHA-256 and exact history entry. Successful SIGHUP reloads appear in history without rewriting the source file. Importer exit code 0 now means no warnings and no skipped stanzas; exit 2 means the emitted configuration requires review.

## Load-bearing regression proof

Each new regression was run against the reverted production behavior and observed red:

- removing the digest comparison admits modified snapshot bytes
- restoring filename-only dedup suppresses repair of a corrupt newest entry
- following a digest-shaped symlink admits a non-regular history entry
- restoring unchecked sequence increment panics or wraps at `u64::MAX`
- omitting the SIGHUP history record leaves only the boot snapshot
- inspecting skips alone returns exit 0 for a placeholder-bearing import
- restoring the old FRR post-pass drops implicit IPv4 from an explicitly IPv6 peer
- accepting tokens after `router bgp <asn>` imports a VRF instead of the later global instance
- restoring the unbounded float cast imports `1e100` as AS 4294967295

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
