### PR TITLE
Treat role-aware ASPA first-AS mismatches as withdraw

### DIFF
--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -745,6 +745,43 @@ impl PeerSession {
             first_as_check_exempt: matches!(local_role, Some(BgpRole::RouteServerClient)),
         }
     }
+    /// Return the received and negotiated ASNs when an IPv4/IPv6-unicast
+    /// UPDATE between role-aware, four-octet-AS-capable eBGP speakers fails
+    /// the ASPA first-AS precondition. Roleless sessions keep their
+    /// compatibility behavior, and an RS-client remains exempt for a
+    /// transparent route server / IX.
+    pub(super) fn aspa_first_as_mismatch(
+        &self,
+        four_octet_as: bool,
+        is_ebgp: bool,
+        has_unicast_announcements: bool,
+        attrs: &[PathAttribute],
+    ) -> Option<(Option<u32>, u32)> {
+        if !four_octet_as || !is_ebgp || !has_unicast_announcements {
+            return None;
+        }
+        let context = self.aspa_validation_context();
+        if context.first_as_check_exempt {
+            return None;
+        }
+        let neighbor_asn = context.neighbor_asn?;
+        let path = attrs.iter().find_map(|attr| match attr {
+            PathAttribute::AsPath(path) => Some(path),
+            _ => None,
+        })?;
+        if path
+            .segments
+            .iter()
+            .any(|segment| matches!(segment, rustbgpd_wire::AsPathSegment::AsSet(_)))
+        {
+            return None;
+        }
+        let received_first_as = path.segments.iter().find_map(|segment| match segment {
+            rustbgpd_wire::AsPathSegment::AsSequence(asns) => asns.first().copied(),
+            rustbgpd_wire::AsPathSegment::AsSet(_) => None,
+        });
+        (received_first_as != Some(neighbor_asn)).then_some((received_first_as, neighbor_asn))
+    }
     /// RFC 7606 treat-as-withdraw primitive: drop every announcement carried
     /// in the UPDATE, withdraw any previously accepted route those
     /// announcements replace, process the explicit withdrawals normally
@@ -1310,6 +1347,47 @@ impl PeerSession {
         if let Some(applied) = disposition {
             self.metrics
                 .record_update_malformed(&self.peer_label, malformed_disposition_label(applied));
+        }
+        // draft-ietf-sidrops-aspa-verification-26 §5: between role-aware,
+        // four-octet-AS-capable eBGP speakers, an AS_PATH whose most recently
+        // added AS is not the negotiated neighbor AS is semantically invalid
+        // and SHALL use RFC 7606 treat-as-withdraw. Section 6.2 scopes ASPA
+        // verification to IPv4/IPv6 unicast. Apply this before policy/ASPA
+        // state so the disposition cannot depend on an operator policy or
+        // cache snapshot.
+        let has_unicast_announcements = !parsed.announced.is_empty()
+            || parsed.attributes.iter().any(|attr| {
+                matches!(
+                    attr,
+                    PathAttribute::MpReachNlri(mp)
+                        if matches!(mp.afi, Afi::Ipv4 | Afi::Ipv6)
+                            && mp.safi == Safi::Unicast
+                            && !mp.announced.is_empty()
+                )
+            });
+        if let Some((received_first_as, neighbor_asn)) = self.aspa_first_as_mismatch(
+            four_octet_as,
+            is_ebgp,
+            has_unicast_announcements,
+            &parsed.attributes,
+        ) {
+            warn!(
+                peer = %self.peer_label,
+                received_first_as = ?received_first_as,
+                neighbor_asn,
+                "ASPA first-AS precondition failed; treating UPDATE as withdraw"
+            );
+            self.metrics.record_update_malformed(
+                &self.peer_label,
+                MalformedUpdateDisposition::TreatAsWithdraw,
+            );
+            self.treat_update_as_withdraw(
+                &parsed,
+                ImportRejectReason::TreatAsWithdraw,
+                Some("aspa_first_as_mismatch"),
+            )
+            .await;
+            return;
         }
         // 3. End-of-RIB detection (RFC 4724 §2). An UPDATE that only became
         // empty because malformed attributes were discarded is junk, not an

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -527,6 +527,166 @@ fn aspa_validation_context_preserves_roleless_legacy_behavior() {
     assert_eq!(context.local_role, None);
     assert!(!context.first_as_check_exempt);
 }
+fn aspa_first_as_update(prefix: Ipv4Prefix, first_asn: u32) -> UpdateMessage {
+    UpdateMessage::build(
+        &[Ipv4NlriEntry { path_id: 0, prefix }],
+        &[],
+        &[
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![first_asn, 65010])],
+            }),
+            PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+        ],
+        true,
+        false,
+        Ipv4UnicastMode::Body,
+    )
+}
+/// Load-bearing proof: deleting the role-aware first-AS branch in
+/// `process_update` leaves the second announcement installed, so the exact
+/// withdrawal and known-prefix assertions fail.
+#[tokio::test]
+async fn aspa_first_as_mismatch_withdraws_replacement_and_keeps_session_established() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    session.config.peer.local_role = Some(BgpRole::Peer);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    while rib_rx.try_recv().is_ok() {}
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    session
+        .process_update(aspa_first_as_update(prefix, 65002))
+        .await;
+    let RibUpdate::RoutesReceived { announced, .. } = rib_rx
+        .try_recv()
+        .expect("matching first-AS route must reach the RIB")
+    else {
+        panic!("expected matching first-AS RoutesReceived");
+    };
+    assert_eq!(announced.len(), 1, "matching first AS remains accepted");
+    assert_eq!(session.known_prefix_count(), 1);
+
+    session
+        .process_update(aspa_first_as_update(prefix, 65003))
+        .await;
+    let RibUpdate::RoutesReceived {
+        announced,
+        withdrawn,
+        ..
+    } = rib_rx
+        .try_recv()
+        .expect("mismatched replacement must reach the RIB as a withdrawal")
+    else {
+        panic!("expected treat-as-withdraw RoutesReceived");
+    };
+    assert!(announced.is_empty());
+    assert_eq!(withdrawn, vec![(Prefix::V4(prefix), 0)]);
+    assert_eq!(session.known_prefix_count(), 0);
+    assert_eq!(
+        session.fsm.state(),
+        SessionState::Established,
+        "first-AS treat-as-withdraw must not reset the session"
+    );
+    assert_single_malformed_disposition(&session, "treat_as_withdraw");
+}
+/// Load-bearing transparent-IX control: removing the RS-client exemption (or
+/// applying the first-AS check to every eBGP session) makes this mismatched
+/// route disappear instead of being announced.
+#[tokio::test]
+async fn aspa_first_as_mismatch_exempts_route_server_client() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    session.config.peer.local_role = Some(BgpRole::RouteServerClient);
+    install_test_negotiated_session(&mut session, negotiated_session(65002, false));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+
+    session
+        .process_update(aspa_first_as_update(prefix, 65003))
+        .await;
+    let RibUpdate::RoutesReceived {
+        announced,
+        withdrawn,
+        ..
+    } = rib_rx
+        .try_recv()
+        .expect("transparent-IX route must reach the RIB")
+    else {
+        panic!("expected route-server-client RoutesReceived");
+    };
+    assert_eq!(announced.len(), 1);
+    assert!(withdrawn.is_empty());
+    assert_eq!(session.known_prefix_count(), 1);
+}
+/// Load-bearing compatibility controls: removing either the eBGP or
+/// configured-role guard makes its corresponding mismatched path return a
+/// violation.
+#[test]
+fn aspa_first_as_mismatch_preserves_roleless_and_ibgp_compatibility() {
+    let attrs = [PathAttribute::AsPath(AsPath {
+        segments: vec![AsPathSegment::AsSequence(vec![65003])],
+    })];
+
+    let mut roleless_ebgp = make_test_session(65001, 65002);
+    install_test_negotiated_session(&mut roleless_ebgp, negotiated_session(65002, false));
+    assert_eq!(
+        roleless_ebgp.aspa_first_as_mismatch(true, true, true, &attrs),
+        None,
+        "roleless eBGP keeps legacy first-AS behavior"
+    );
+
+    let mut internal_role_session = make_test_session(65001, 65001);
+    internal_role_session.config.peer.local_role = Some(BgpRole::Peer);
+    install_test_negotiated_session(&mut internal_role_session, negotiated_session(65001, false));
+    assert_eq!(
+        internal_role_session.aspa_first_as_mismatch(true, false, true, &attrs),
+        None,
+        "the ASPA first-AS precondition is not applied to iBGP"
+    );
+
+    let mut external_role_session = make_test_session(65001, 65002);
+    external_role_session.config.peer.local_role = Some(BgpRole::Peer);
+    install_test_negotiated_session(&mut external_role_session, negotiated_session(65002, false));
+    assert_eq!(
+        external_role_session.aspa_first_as_mismatch(false, true, true, &attrs),
+        None,
+        "the draft check requires four-octet-AS capability"
+    );
+    assert_eq!(
+        external_role_session.aspa_first_as_mismatch(true, true, false, &attrs),
+        None,
+        "the draft check is scoped to IPv4/IPv6 unicast announcements"
+    );
+
+    let empty_path = [PathAttribute::AsPath(AsPath { segments: vec![] })];
+    assert_eq!(
+        external_role_session.aspa_first_as_mismatch(true, true, true, &empty_path),
+        Some((None, 65002)),
+        "an AS_PATH with no ordered first AS fails the neighbor-AS check"
+    );
+    let split_sequence = [PathAttribute::AsPath(AsPath {
+        segments: vec![
+            AsPathSegment::AsSequence(vec![]),
+            AsPathSegment::AsSequence(vec![65003]),
+        ],
+    })];
+    assert_eq!(
+        external_role_session.aspa_first_as_mismatch(true, true, true, &split_sequence),
+        Some((Some(65003), 65002)),
+        "the first ordered ASN may be in a later AS_SEQUENCE"
+    );
+    let with_as_set = [PathAttribute::AsPath(AsPath {
+        segments: vec![
+            AsPathSegment::AsSequence(vec![65003]),
+            AsPathSegment::AsSet(vec![65010]),
+        ],
+    })];
+    assert_eq!(
+        external_role_session.aspa_first_as_mismatch(true, true, true, &with_as_set),
+        None,
+        "AS_SET disposition remains outside the neighbor-AS gate"
+    );
+}
 fn configure_scoped_link_local_peer(session: &mut PeerSession) {
     session.peer_ip = IpAddr::V6("fe80::2".parse().unwrap());
     session.config.peer_interface = Some("eth1".to_string());


### PR DESCRIPTION
## What changed

- enforce the ASPA draft first-AS precondition for role-aware, four-octet-AS-capable eBGP IPv4/IPv6 unicast updates
- apply RFC 7606 treat-as-withdraw before policy and ASPA cache evaluation
- preserve transparent route-server-client, roleless, iBGP, non-unicast, and AS_SET compatibility boundaries

## Why

A mismatched first AS is semantically invalid in the current ASPA verification draft. Previously it could continue into policy and be installed, which made the result depend on later policy/cache state instead of the protocol disposition.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
- focused transport ASPA tests

## Load-bearing proofs

- removing the enforcement call leaves a mismatched replacement announced instead of withdrawing the prior route
- removing the route-server-client exemption drops a valid transparent-IX route
- removing the eBGP, role, capability, or family scope guards breaks the corresponding compatibility control