### PR TITLE
Apply RFC 9774 to prohibited AS path sets

### DIFF
--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -15137,6 +15137,90 @@ async fn rfc7606_treat_as_withdraw_removes_routes_and_keeps_session() {
     assert_single_malformed_disposition(&session, "treat_as_withdraw");
 }
 
+/// Load-bearing RFC 9774 proof: deleting the raw `AS_SET` inspection admits
+/// both announcements, so the exact mixed-withdrawal and prefix-state
+/// assertions fail. The explicit/replacement overlap also proves one output.
+#[tokio::test]
+async fn rfc9774_as_set_replacement_withdraws_exactly_once_and_keeps_session() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    let overlap = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let replacement = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let first_seen = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    session
+        .process_update(rfc7606_update(
+            rfc7606_attr_bytes(&[]),
+            &[overlap, replacement],
+        ))
+        .await;
+    let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
+        panic!("expected initial accepted routes");
+    };
+    assert_eq!(announced.len(), 2);
+
+    let mut withdrawn = Vec::new();
+    rustbgpd_wire::nlri::encode_nlri(&[overlap], &mut withdrawn);
+    let malformed = UpdateMessage {
+        withdrawn_routes: Bytes::from(withdrawn),
+        path_attributes: Bytes::from(
+            [
+                &[0x40, 1, 1, 0][..],
+                &[0x40, 2, 6, 1, 1, 0, 0, 0xFD, 0xEA],
+                &[0x40, 3, 4, 10, 0, 0, 2],
+            ]
+            .concat(),
+        ),
+        nlri: rfc7606_update(Vec::new(), &[overlap, replacement, first_seen]).nlri,
+    };
+    session.process_update(malformed).await;
+    let RibUpdate::RoutesReceived {
+        announced,
+        withdrawn,
+        ..
+    } = rib_rx
+        .try_recv()
+        .expect("RFC 9774 withdrawal must reach RIB")
+    else {
+        panic!("expected treat-as-withdraw RoutesReceived");
+    };
+    assert!(announced.is_empty());
+    assert_eq!(
+        withdrawn,
+        vec![(Prefix::V4(overlap), 0), (Prefix::V4(replacement), 0)],
+        "explicit/replacement overlap is emitted once; first-seen stays silent"
+    );
+    assert!(rib_rx.try_recv().is_err());
+    assert_eq!(session.known_prefix_count(), 0);
+    assert_eq!(session.fsm.state(), SessionState::Established);
+    assert_single_malformed_disposition(&session, "treat_as_withdraw");
+}
+
+/// Load-bearing RFC 7606 §5.2 composition proof: deleting the new RFC 9774
+/// detector (or bypassing existing disposition composition) leaves this
+/// no-NLRI `AS_SET` UPDATE Established instead of reset.
+#[tokio::test]
+async fn rfc9774_as_set_without_reachable_nlri_resets_session() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    session
+        .process_update(rfc7606_update(
+            vec![0x40, 1, 1, 0, 0x40, 2, 6, 1, 1, 0, 0, 0xFD, 0xEA],
+            &[],
+        ))
+        .await;
+    assert_ne!(session.fsm.state(), SessionState::Established);
+    while let Ok(update) = rib_rx.try_recv() {
+        assert!(!matches!(update, RibUpdate::RoutesReceived { .. }));
+    }
+    assert_single_malformed_disposition(&session, "session_reset");
+}
+
 /// RFC 7606 §7.7: a malformed AGGREGATOR is attribute-discard — the UPDATE
 /// (and its announcements) proceed without the attribute, and the session
 /// stays Established.

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -912,6 +912,10 @@ pub struct RevisedAttributeDecode {
 /// Returns `Err` only for session-reset-class problems: a malformed or
 /// duplicated `MP_REACH_NLRI`/`MP_UNREACH_NLRI` (§7.11 — the NLRI cannot be
 /// reliably located).
+#[expect(
+    clippy::too_many_lines,
+    reason = "framing inspection, duplicate ordering, and disposition accumulation must stay ordered"
+)]
 pub fn decode_path_attributes_revised(
     mut buf: &[u8],
     four_octet_as: bool,
@@ -938,6 +942,28 @@ pub fn decode_path_attributes_revised(
                 break;
             }
         };
+        // RFC 9774 §3 prohibits AS_SET and AS_CONFED_SET in both AS_PATH
+        // and AS4_PATH. Inspect the raw segment framing before duplicate
+        // handling: a prohibited segment in a later duplicate must retain
+        // treat-as-withdraw rather than being reduced to attribute-discard.
+        let prohibited_segment = match type_code {
+            attr_type::AS_PATH => prohibited_as_set(value, if four_octet_as { 4 } else { 2 }),
+            17 => prohibited_as_set(value, 4), // AS4_PATH (RFC 6793)
+            _ => None,
+        };
+        if let Some(segment_type) = prohibited_segment {
+            malformed.push(MalformedAttribute {
+                type_code,
+                disposition: ErrorDisposition::TreatAsWithdraw,
+                error: DecodeError::UpdateAttributeError {
+                    subcode: update_subcode::MALFORMED_AS_PATH,
+                    data: attr_error_data(flags, type_code, value),
+                    detail: format!(
+                        "RFC 9774 prohibits AS path segment type {segment_type} in attribute type {type_code}"
+                    ),
+                },
+            });
+        }
         if !seen.insert(type_code) {
             // RFC 7606 §3 (g): duplicate MP_REACH/MP_UNREACH is fatal; any
             // other duplicate keeps the first occurrence and discards the
@@ -1029,6 +1055,24 @@ pub fn decode_path_attributes_revised(
         bgpls_nlri_discarded: bgpls_discarded,
         malformed,
     })
+}
+
+/// Return the first RFC 9774-prohibited set segment in a raw AS path.
+fn prohibited_as_set(mut value: &[u8], asn_width: usize) -> Option<u8> {
+    while value.len() >= 2 {
+        let segment_type = value[0];
+        let count = usize::from(value[1]);
+        if count == 0 || !matches!(segment_type, 1..=4) {
+            return None;
+        }
+        let segment_len = count.checked_mul(asn_width)?;
+        let next = value.get(2_usize.checked_add(segment_len)?..)?;
+        if matches!(segment_type, 1 | 4) {
+            return Some(segment_type);
+        }
+        value = next;
+    }
+    None
 }
 /// Decode a single attribute value given its flags, type code, and raw bytes.
 #[expect(
@@ -1896,7 +1940,7 @@ fn decode_as_path(mut buf: &[u8], four_octet_as: bool) -> Result<Vec<AsPathSegme
 /// NOTIFICATION data in UPDATE error subcodes per RFC 4271 §6.3.
 pub(crate) fn attr_error_data(flags: u8, type_code: u8, value: &[u8]) -> Vec<u8> {
     let mut buf = Vec::with_capacity(3 + value.len());
-    if value.len() > 255 {
+    if flags & attr_flags::EXTENDED_LENGTH != 0 || value.len() > 255 {
         buf.push(flags | attr_flags::EXTENDED_LENGTH);
         buf.push(type_code);
         #[expect(
@@ -5281,6 +5325,123 @@ mod tests {
             ErrorDisposition::TreatAsWithdraw
         );
     }
+    /// Load-bearing RFC 9774 matrix: deleting the raw segment inspection
+    /// makes every prohibited case clean/attribute-discard, while hard-coding
+    /// either AS width makes a later set disappear from one matrix row.
+    #[test]
+    fn revised_rfc9774_prohibits_set_segments_in_as_path_and_as4_path() {
+        const AS4_PATH: u8 = 17;
+        let cases = [
+            (
+                "four-octet AS_PATH AS_SET",
+                attr_type::AS_PATH,
+                1,
+                1,
+                true,
+                &[0, 0, 0xFD, 0xE9][..],
+            ),
+            (
+                "two-octet AS_PATH AS_SET",
+                attr_type::AS_PATH,
+                1,
+                1,
+                false,
+                &[0xFD, 0xE9],
+            ),
+            (
+                "AS4_PATH AS_SET",
+                AS4_PATH,
+                1,
+                1,
+                false,
+                &[0, 0, 0xFD, 0xE9],
+            ),
+            (
+                "AS4_PATH AS_CONFED_SET",
+                AS4_PATH,
+                4,
+                2,
+                false,
+                &[0, 0, 0xFD, 0xE9],
+            ),
+        ];
+        for (name, type_code, segment_type, preceding_sequences, four_octet_as, asn) in cases {
+            let mut value = Vec::new();
+            for _ in 0..preceding_sequences {
+                value.extend([2, 1]);
+                value.extend(asn);
+            }
+            value.extend([segment_type, 1]);
+            value.extend(asn);
+            let flags = if type_code == attr_type::AS_PATH {
+                attr_flags::TRANSITIVE
+            } else {
+                attr_flags::OPTIONAL | attr_flags::TRANSITIVE
+            };
+            let decoded = decode_path_attributes_revised(
+                &attr_bytes(flags, type_code, &value),
+                four_octet_as,
+                false,
+                &[],
+            )
+            .unwrap();
+            assert!(
+                decoded.malformed.iter().any(|malformed| {
+                    malformed.type_code == type_code
+                        && malformed.disposition == ErrorDisposition::TreatAsWithdraw
+                }),
+                "{name} must be treat-as-withdraw"
+            );
+        }
+
+        let has_rfc9774_taw = |decoded: &RevisedAttributeDecode| {
+            decoded.malformed.iter().any(|malformed| {
+                malformed.type_code == AS4_PATH
+                    && malformed.disposition == ErrorDisposition::TreatAsWithdraw
+            })
+        };
+        for (name, value) in [
+            ("AS_SEQUENCE", &[2, 1, 0, 0, 0xFD, 0xE9][..]),
+            ("truncated AS_SET", &[1, 2, 0, 0, 0xFD, 0xE9][..]),
+            ("zero-length AS_SET", &[1, 0][..]),
+        ] {
+            let bytes = attr_bytes(
+                attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
+                AS4_PATH,
+                value,
+            );
+            let decoded = decode_path_attributes_revised(&bytes, false, false, &[]).unwrap();
+            assert!(
+                !has_rfc9774_taw(&decoded),
+                "{name} must not acquire an RFC 9774 verdict"
+            );
+        }
+    }
+    /// Load-bearing duplicate proof: moving the RFC 9774 inspection below
+    /// duplicate discard leaves only `AttributeDiscard` and fails this test.
+    #[test]
+    fn revised_rfc9774_prohibited_later_duplicate_keeps_treat_as_withdraw() {
+        let mut attrs = valid_as_path_bytes();
+        attrs.extend(attr_bytes(
+            attr_flags::TRANSITIVE,
+            attr_type::AS_PATH,
+            &[1, 1, 0, 0, 0xFD, 0xEA],
+        ));
+        let decoded = decode_path_attributes_revised(&attrs, true, false, &[]).unwrap();
+        assert_eq!(decoded.malformed.len(), 2);
+        assert!(
+            decoded
+                .malformed
+                .iter()
+                .any(|malformed| { malformed.disposition == ErrorDisposition::TreatAsWithdraw })
+        );
+        assert!(
+            decoded
+                .malformed
+                .iter()
+                .any(|malformed| { malformed.disposition == ErrorDisposition::AttributeDiscard })
+        );
+    }
     #[test]
     fn revised_malformed_aggregator_is_attribute_discard() {
         // RFC 7606 §7.7: AGGREGATOR length must be 8 under 4-octet-AS
@@ -5325,6 +5486,28 @@ mod tests {
             decoded.malformed[0].disposition,
             ErrorDisposition::AttributeDiscard
         );
+    }
+    /// Load-bearing error-context proof: reverting `attr_error_data` to choose
+    /// width from value length emits `0x50, 2, 6, ...` and fails this equality.
+    #[test]
+    fn revised_rfc9774_extended_length_preserves_complete_attribute_header() {
+        let bytes = vec![
+            attr_flags::TRANSITIVE | attr_flags::EXTENDED_LENGTH,
+            attr_type::AS_PATH,
+            0,
+            6,
+            1,
+            1,
+            0,
+            0,
+            0xFD,
+            0xE9,
+        ];
+        let decoded = decode_path_attributes_revised(&bytes, true, false, &[]).unwrap();
+        let DecodeError::UpdateAttributeError { data, .. } = &decoded.malformed[0].error else {
+            panic!("expected RFC 9774 attribute error");
+        };
+        assert_eq!(data, &bytes);
     }
     #[test]
     fn revised_flag_conflict_on_aggregator_is_treat_as_withdraw() {

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -7,6 +7,10 @@ use crate::validate::{ErrorDisposition, malformed_attr_disposition};
 use bytes::Bytes;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+/// `AS4_PATH` path-attribute type code (RFC 6793).
+const AS4_PATH_TYPE_CODE: u8 = 17;
+
 /// Origin attribute values per RFC 4271 §5.1.1.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
@@ -948,7 +952,7 @@ pub fn decode_path_attributes_revised(
         // treat-as-withdraw rather than being reduced to attribute-discard.
         let prohibited_segment = match type_code {
             attr_type::AS_PATH => prohibited_as_set(value, if four_octet_as { 4 } else { 2 }),
-            17 => prohibited_as_set(value, 4), // AS4_PATH (RFC 6793)
+            AS4_PATH_TYPE_CODE => prohibited_as_set(value, 4),
             _ => None,
         };
         if let Some(segment_type) = prohibited_segment {
@@ -1939,8 +1943,10 @@ fn decode_as_path(mut buf: &[u8], four_octet_as: bool) -> Result<Vec<AsPathSegme
 /// Build the attribute-triplet (flags + type + length + value) used as
 /// NOTIFICATION data in UPDATE error subcodes per RFC 4271 §6.3.
 pub(crate) fn attr_error_data(flags: u8, type_code: u8, value: &[u8]) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(3 + value.len());
-    if flags & attr_flags::EXTENDED_LENGTH != 0 || value.len() > 255 {
+    let extended_length = flags & attr_flags::EXTENDED_LENGTH != 0 || value.len() > 255;
+    let header_len = if extended_length { 4 } else { 3 };
+    let mut buf = Vec::with_capacity(header_len + value.len());
+    if extended_length {
         buf.push(flags | attr_flags::EXTENDED_LENGTH);
         buf.push(type_code);
         #[expect(
@@ -5330,7 +5336,6 @@ mod tests {
     /// either AS width makes a later set disappear from one matrix row.
     #[test]
     fn revised_rfc9774_prohibits_set_segments_in_as_path_and_as4_path() {
-        const AS4_PATH: u8 = 17;
         let cases = [
             (
                 "four-octet AS_PATH AS_SET",
@@ -5350,7 +5355,7 @@ mod tests {
             ),
             (
                 "AS4_PATH AS_SET",
-                AS4_PATH,
+                AS4_PATH_TYPE_CODE,
                 1,
                 1,
                 false,
@@ -5358,7 +5363,7 @@ mod tests {
             ),
             (
                 "AS4_PATH AS_CONFED_SET",
-                AS4_PATH,
+                AS4_PATH_TYPE_CODE,
                 4,
                 2,
                 false,
@@ -5396,7 +5401,7 @@ mod tests {
 
         let has_rfc9774_taw = |decoded: &RevisedAttributeDecode| {
             decoded.malformed.iter().any(|malformed| {
-                malformed.type_code == AS4_PATH
+                malformed.type_code == AS4_PATH_TYPE_CODE
                     && malformed.disposition == ErrorDisposition::TreatAsWithdraw
             })
         };
@@ -5407,7 +5412,7 @@ mod tests {
         ] {
             let bytes = attr_bytes(
                 attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
-                AS4_PATH,
+                AS4_PATH_TYPE_CODE,
                 value,
             );
             let decoded = decode_path_attributes_revised(&bytes, false, false, &[]).unwrap();

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -320,7 +320,9 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 
 - The revised inbound attribute decoder inspects raw AS_PATH and opaque
   AS4_PATH segment framing for AS_SET and AS_CONFED_SET before duplicate
-  discard, and applies RFC 7606 treat-as-withdraw on every session and family.
+  discard, and assigns RFC 7606 treat-as-withdraw on every session and family.
+  When the UPDATE carries no reachable NLRI, the existing RFC 7606 §5.2
+  composition escalates that disposition to a session reset.
 - This targeted inspection does not add general AS4_PATH parsing or RFC 6793
   path reconstruction.
 

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -312,9 +312,17 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 ### AS_TRANS Handling
 
 - When encoding for a 2-byte-only peer: replace any ASN > 65535 with
-  AS_TRANS in AS_PATH, and include AS4_PATH for the full path.
-- When decoding from a 2-byte-only peer: if AS4_PATH is present,
-  reconstruct the true path per RFC 6793 §4.2.3.
+  AS_TRANS in AS_PATH. Emitting a compensating AS4_PATH is not implemented.
+- AS4_PATH and AS4_AGGREGATOR remain opaque attributes; inbound AS4_PATH is
+  not reconstructed into AS_PATH per RFC 6793 §4.2.3.
+
+## RFC 9774 — AS_SET / AS_CONFED_SET Deprecation
+
+- The revised inbound attribute decoder inspects raw AS_PATH and opaque
+  AS4_PATH segment framing for AS_SET and AS_CONFED_SET before duplicate
+  discard, and applies RFC 7606 treat-as-withdraw on every session and family.
+- This targeted inspection does not add general AS4_PATH parsing or RFC 6793
+  path reconstruction.
 
 ---
 
@@ -422,7 +430,8 @@ Interpretation decisions:
   so a hostile peer cannot spam operators at info/warn; nothing is rendered
   when DEBUG is disabled. Per-disposition counters are a follow-up.
 - AS4_PATH / AS4_AGGREGATOR are not decoded as typed attributes (they pass
-  through opaquely), so no malformation can be detected for them today.
+  through opaquely). The RFC 9774 set-segment inspection above is the narrow
+  exception; other AS4_PATH malformations are not detected.
 
 ## Milestone 1 — RFC 4271 Sections
 


### PR DESCRIPTION
## Summary

- apply RFC 9774 treat-as-withdraw to safely framed AS_SET and AS_CONFED_SET segments in AS_PATH and AS4_PATH
- inspect before duplicate-attribute discard, then reuse the existing RFC 7606 strongest-disposition and section 5.2 escalation paths
- preserve exact extended-length attribute bytes in validation error context
- correct the RFC notes to distinguish targeted AS4_PATH inspection from unsupported general reconstruction

## Correctness boundaries

- applies to every session and address family
- AS_PATH uses the negotiated two- or four-byte ASN width; AS4_PATH always uses four-byte ASNs in the OLD-peer context
- arbitrary malformed AS4_PATH remains outside this bounded change and is not upgraded to RFC 9774 treat-as-withdraw
- no compatibility knob, policy change, AS4_PATH reconstruction, or outbound redesign

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
- git diff --check origin/main...HEAD

All pass on c8ce469aa8962d7663e27f9eaf3153a812ec9f54.

## Load-bearing proofs

- removing the detector makes the wire matrix and both transport regressions fail because prohibited announcements are accepted and the no-NLRI session stays Established
- moving detection after duplicate discard loses the later prohibited segment and fails the exact malformed-disposition count
- weakening segment framing gives a truncated AS4_PATH an RFC 9774 verdict and fails the negative control
- deriving AS4_PATH width from negotiated AS_PATH width misses the OLD-peer AS4_PATH cases
- reverting extended-length reconstruction produces an internally inconsistent validation payload and fails byte equality

Each mutation was restored byte-for-byte before the final full gate run.

Linear: https://linear.app/lance0/issue/LAN-501/rfc-9774-treat-as-set-and-as-confed-set-as-withdraw-by-default