### PR TITLE
fix: retire denied FlowSpec and EVPN replacements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Import-policy-denied FlowSpec and EVPN replacements now withdraw the exact accepted identity.
 - **Release tarballs ship `rs-config-render`.** The route-server
   config renderer was built by the release workflow but never staged
   into `rustbgpd-<arch>.tar.gz` — v0.60.0 tarballs contain only

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -1944,8 +1944,10 @@ impl PeerSession {
         // happens once in `RouteAttrBundle::new`.
         let mut flowspec_announced: Vec<FlowSpecRoute> = Vec::new();
         let mut flowspec_withdrawn: Vec<FlowSpecKey> = Vec::new();
+        let mut denied_flowspec: Vec<FlowSpecKey> = Vec::new();
         let mut evpn_announced: Vec<EvpnRibRoute> = Vec::new();
         let mut evpn_withdrawn: Vec<EvpnRouteKey> = Vec::new();
+        let mut policy_denied_evpn: Vec<EvpnRouteKey> = Vec::new();
         let mut bgpls_announced: Vec<BgpLsRibRoute> = Vec::new();
         let mut bgpls_withdrawn: Vec<BgpLsRouteKey> = Vec::new();
         let mut denied_bgpls: Vec<BgpLsRouteKey> = Vec::new();
@@ -2060,6 +2062,11 @@ impl PeerSession {
                                     is_llgr_stale: false,
                                     path_id: 0,
                                 });
+                            } else {
+                                denied_flowspec.push(FlowSpecKey {
+                                    afi: mp.afi,
+                                    rule: rule.clone(),
+                                });
                             }
                         }
                         continue;
@@ -2128,6 +2135,8 @@ impl PeerSession {
                                     is_stale: false,
                                     is_llgr_stale: false,
                                 });
+                            } else {
+                                policy_denied_evpn.push(route.key());
                             }
                         }
                         continue;
@@ -2737,11 +2746,21 @@ impl PeerSession {
         for key in &flowspec_withdrawn {
             self.known_flowspec.remove(key);
         }
+        for key in denied_flowspec {
+            if self.known_flowspec.remove(&key) {
+                flowspec_withdrawn.push(key);
+            }
+        }
         for route in &flowspec_announced {
             self.known_flowspec.insert(route.selection_key());
         }
         for key in &evpn_withdrawn {
             self.known_evpn.remove(key);
+        }
+        for key in policy_denied_evpn {
+            if self.known_evpn.remove(&key) {
+                evpn_withdrawn.push(key);
+            }
         }
         for route in &evpn_announced {
             self.known_evpn.insert(route.key());

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -10407,6 +10407,261 @@ async fn denied_mp_add_path_replacements_preserve_sibling_and_deduplicate_overla
     }
 }
 
+/// A denied `FlowSpec` replacement retires only an accepted `(AFI, rule)`
+/// identity. Explicit overlap is emitted once, first-seen/repeated denials stay
+/// silent, and the same destinationless rule in the other AFI remains live.
+///
+/// Break-to-red: deleting denied-key collection, or hard-coding either AFI,
+/// leaves the opposite-family deny-only identity accepted; removing the
+/// known-set gate emits first-seen/repeated withdrawals and duplicates overlap.
+#[tokio::test]
+#[expect(clippy::too_many_lines, reason = "one ordered dual-AFI scenario")]
+async fn denied_flowspec_replacements_retire_exact_afi_rule_identity() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::FlowSpec), (Afi::Ipv6, Safi::FlowSpec)];
+    install_test_negotiated_session(&mut session, negotiated);
+    let rule = |protocol: u8| FlowSpecRule {
+        components: vec![FlowSpecComponent::IpProtocol(vec![NumericMatch {
+            end_of_list: true,
+            and_bit: false,
+            lt: false,
+            gt: false,
+            eq: true,
+            value: u64::from(protocol),
+        }])],
+    };
+    let shared = rule(6);
+    let explicit = rule(17);
+    let overlap = rule(41);
+    let sibling = rule(47);
+    let first_seen = rule(132);
+    let update = |afi, announced: Vec<FlowSpecRule>, withdrawn: Vec<FlowSpecRule>| {
+        let mut reach =
+            empty_nonunicast_reach(afi, Safi::FlowSpec, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+        reach.flowspec_announced = announced;
+        let mut unreach = empty_nonunicast_unreach(afi, Safi::FlowSpec);
+        unreach.flowspec_withdrawn = withdrawn;
+        nonunicast_update(
+            nonunicast_accepted_attrs(),
+            reach,
+            (!unreach.flowspec_withdrawn.is_empty()).then_some(unreach),
+            false,
+        )
+    };
+    let key = |afi, rule: &FlowSpecRule| FlowSpecKey {
+        afi,
+        rule: rule.clone(),
+    };
+
+    session
+        .process_update(update(
+            Afi::Ipv4,
+            vec![shared.clone(), explicit.clone(), overlap.clone()],
+            vec![],
+        ))
+        .await;
+    session
+        .process_update(update(
+            Afi::Ipv6,
+            vec![shared.clone(), sibling.clone()],
+            vec![],
+        ))
+        .await;
+    for expected in [3, 2] {
+        let RibUpdate::RoutesReceived {
+            flowspec_announced,
+            flowspec_withdrawn,
+            ..
+        } = rib_rx.try_recv().expect("accepted FlowSpec reaches RIB")
+        else {
+            panic!("expected RoutesReceived");
+        };
+        assert_eq!(flowspec_announced.len(), expected);
+        assert!(flowspec_withdrawn.is_empty());
+    }
+    assert_eq!(session.known_prefix_count(), 5);
+    session.install_import_policy(Some(PolicyChain::new(vec![Policy {
+        entries: vec![],
+        default_action: PolicyAction::Deny,
+    }])));
+
+    session
+        .process_update(update(Afi::Ipv6, vec![shared.clone()], vec![]))
+        .await;
+    let RibUpdate::RoutesReceived {
+        flowspec_withdrawn, ..
+    } = rib_rx.try_recv().expect("denied replacement reaches RIB")
+    else {
+        panic!("expected RoutesReceived");
+    };
+    assert_eq!(flowspec_withdrawn, vec![key(Afi::Ipv6, &shared)]);
+    assert!(session.known_flowspec.contains(&key(Afi::Ipv4, &shared)));
+
+    session
+        .process_update(update(Afi::Ipv4, vec![shared.clone()], vec![]))
+        .await;
+    let RibUpdate::RoutesReceived {
+        flowspec_withdrawn, ..
+    } = rib_rx.try_recv().expect("opposite-AFI denial reaches RIB")
+    else {
+        panic!("expected RoutesReceived");
+    };
+    assert_eq!(flowspec_withdrawn, vec![key(Afi::Ipv4, &shared)]);
+
+    session
+        .process_update(update(Afi::Ipv4, vec![], vec![explicit.clone()]))
+        .await;
+    let RibUpdate::RoutesReceived {
+        flowspec_withdrawn, ..
+    } = rib_rx.try_recv().expect("explicit withdrawal reaches RIB")
+    else {
+        panic!("expected RoutesReceived");
+    };
+    assert_eq!(flowspec_withdrawn, vec![key(Afi::Ipv4, &explicit)]);
+
+    session
+        .process_update(update(
+            Afi::Ipv4,
+            vec![overlap.clone()],
+            vec![overlap.clone()],
+        ))
+        .await;
+    let RibUpdate::RoutesReceived {
+        flowspec_withdrawn, ..
+    } = rib_rx.try_recv().expect("overlap reaches RIB once")
+    else {
+        panic!("expected RoutesReceived");
+    };
+    assert_eq!(flowspec_withdrawn, vec![key(Afi::Ipv4, &overlap)]);
+
+    for _ in 0..2 {
+        session
+            .process_update(update(Afi::Ipv4, vec![first_seen.clone()], vec![]))
+            .await;
+        assert!(rib_rx.try_recv().is_err(), "unknown denial stays silent");
+    }
+    assert!(session.known_flowspec.contains(&key(Afi::Ipv6, &sibling)));
+    assert_eq!(session.known_prefix_count(), 1);
+}
+
+/// A denied EVPN Type-2 replacement retires its exact accepted key. Explicit
+/// overlap is emitted once, first-seen/repeated denials stay silent, and an
+/// untouched sibling remains accepted.
+///
+/// Break-to-red: deleting denied-key collection leaves the deny-only key live;
+/// removing the known-set membership gate emits unknown/repeated withdrawals
+/// and duplicates the explicit overlap.
+#[tokio::test]
+async fn denied_evpn_replacements_retire_exact_known_type2_key() {
+    use rustbgpd_wire::{
+        EthernetSegmentIdentifier, EthernetTagId, EvpnMacIp, EvpnRoute, MacAddress, MplsLabel,
+    };
+
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::L2Vpn, Safi::Evpn)];
+    install_test_negotiated_session(&mut session, negotiated);
+    let route = |suffix: u8| {
+        EvpnRoute::MacIp(EvpnMacIp {
+            rd: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 100]),
+            esi: EthernetSegmentIdentifier::ZERO,
+            ethernet_tag: EthernetTagId(100),
+            mac: MacAddress([0x02, 0, 0, 0, 0, suffix]),
+            ip: None,
+            label1: MplsLabel::new(10_000),
+            label2: None,
+        })
+    };
+    let deny_only = route(11);
+    let explicit = route(22);
+    let overlap = route(33);
+    let sibling = route(44);
+    let first_seen = route(55);
+    let update = |announced: Vec<EvpnRoute>, withdrawn: Vec<EvpnRoute>| {
+        let mut reach = empty_nonunicast_reach(
+            Afi::L2Vpn,
+            Safi::Evpn,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        );
+        reach.evpn_announced = announced;
+        let mut unreach = empty_nonunicast_unreach(Afi::L2Vpn, Safi::Evpn);
+        unreach.evpn_withdrawn = withdrawn;
+        nonunicast_update(
+            nonunicast_accepted_attrs(),
+            reach,
+            (!unreach.evpn_withdrawn.is_empty()).then_some(unreach),
+            false,
+        )
+    };
+
+    session
+        .process_update(update(
+            vec![
+                deny_only.clone(),
+                explicit.clone(),
+                overlap.clone(),
+                sibling.clone(),
+            ],
+            vec![],
+        ))
+        .await;
+    let RibUpdate::RoutesReceived {
+        evpn_announced,
+        evpn_withdrawn,
+        ..
+    } = rib_rx.try_recv().expect("accepted EVPN reaches RIB")
+    else {
+        panic!("expected RoutesReceived");
+    };
+    assert_eq!(evpn_announced.len(), 4);
+    assert!(evpn_withdrawn.is_empty());
+    assert_eq!(session.known_prefix_count(), 4);
+    session.install_import_policy(Some(PolicyChain::new(vec![Policy {
+        entries: vec![],
+        default_action: PolicyAction::Deny,
+    }])));
+
+    session
+        .process_update(update(vec![deny_only.clone()], vec![]))
+        .await;
+    let RibUpdate::RoutesReceived { evpn_withdrawn, .. } =
+        rib_rx.try_recv().expect("denied replacement reaches RIB")
+    else {
+        panic!("expected RoutesReceived");
+    };
+    assert_eq!(evpn_withdrawn, vec![deny_only.key()]);
+
+    session
+        .process_update(update(vec![], vec![explicit.clone()]))
+        .await;
+    let RibUpdate::RoutesReceived { evpn_withdrawn, .. } =
+        rib_rx.try_recv().expect("explicit withdrawal reaches RIB")
+    else {
+        panic!("expected RoutesReceived");
+    };
+    assert_eq!(evpn_withdrawn, vec![explicit.key()]);
+
+    session
+        .process_update(update(vec![overlap.clone()], vec![overlap.clone()]))
+        .await;
+    let RibUpdate::RoutesReceived { evpn_withdrawn, .. } =
+        rib_rx.try_recv().expect("overlap reaches RIB once")
+    else {
+        panic!("expected RoutesReceived");
+    };
+    assert_eq!(evpn_withdrawn, vec![overlap.key()]);
+
+    for _ in 0..2 {
+        session
+            .process_update(update(vec![first_seen.clone()], vec![]))
+            .await;
+        assert!(rib_rx.try_recv().is_err(), "unknown denial stays silent");
+    }
+    assert!(session.known_evpn.contains(&sibling.key()));
+    assert_eq!(session.known_prefix_count(), 1);
+}
+
 /// End-to-end ERR/GR + import-policy interaction: a denied replacement must
 /// remove the accepted route immediately, before `EoRR`, so neither refresh nor
 /// subsequent graceful-restart retention can keep it alive.

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -122,11 +122,11 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 ## Inbound filtered-replacement semantics
 
 - Import-policy denial of a replacement retires the exact previously accepted
-  VPN `(RD + prefix, path_id)`, labeled-unicast `(prefix, path_id)`, RTC
-  `(NLRI, path_id)`, or BGP-LS `(family, NLRI, path_id)` identity. First-seen
-  denials remain filter-only, explicit overlapping withdrawals are deduplicated,
-  and Add-Path siblings remain intact. EVPN and FlowSpec retain their existing
-  policy behavior.
+  FlowSpec `(AFI, rule)`, EVPN route key, VPN `(RD + prefix, path_id)`,
+  labeled-unicast `(prefix, path_id)`, RTC `(NLRI, path_id)`, or BGP-LS
+  `(family, NLRI, path_id)` identity. First-seen denials remain filter-only,
+  explicit overlapping withdrawals are deduplicated, and other AFI or Add-Path
+  siblings remain intact.
 - `AS_PATH`-loop and route-reflector-loop rejection likewise retires an exact
   previously accepted VPN, labeled-unicast, RTC, or BGP-LS replacement.
   First-seen and repeated rejected announcements remain silent, distinct valid


### PR DESCRIPTION
## Summary

Retire a previously accepted FlowSpec or EVPN route when a replacement announcement is denied by import policy. Without this presence-gated synthetic withdrawal, the stale prior route remains in the session accepted set and can stay reflected indefinitely.

## Changes

- collect exact denied FlowSpec (AFI, rule) and EVPN route-key identities
- after explicit withdrawals and before permitted inserts, emit a synthetic withdrawal only when that identity was previously accepted
- preserve silent first-seen/repeated denials, deduplicate explicit overlap, and keep other-AFI or untouched siblings live
- document the completed filtered-replacement semantics

## Testing

- [x] cargo test --workspace passes
- [x] cargo clippy --workspace --all-targets -- -D warnings clean
- [x] cargo fmt --all -- --check clean
- [x] RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps clean
- [x] Relevant interop test intentionally not applicable: this repairs local import-policy replacement bookkeeping without changing BGP wire encoding
- [x] Performance receipt intentionally not applicable: no performance claim or hot-path redesign

Load-bearing proof: both new stateful tests failed on unmodified main because a deny-only replacement emitted no RIB update. Removing either family fix fails its exact test; hard-coding either FlowSpec AFI fails the dual-AFI identity assertions; removing either known-set membership gate fails explicit-overlap dedup. Every mutant was restored by exact blob hash before the full green run.

## Docs / release notes

- [x] CHANGELOG.md updated
- [x] ROADMAP.md intentionally not needed; this closes an already documented correctness gap
- [x] RFC_NOTES.md updated
- [x] No hot tracking doc touched

## Related issues

LAN-454: https://linear.app/lance0/issue/LAN-454/rustbgpd-evpnflowspec-inbound-replacement-denial-retirement-gap-stale