### PR TITLE
Complete RR operator observability assets

### DIFF
--- a/.github/workflows/alert-rules.yml
+++ b/.github/workflows/alert-rules.yml
@@ -1,18 +1,22 @@
-name: Alert rules
+name: Observability assets
 
-# Validates the shipped Prometheus alert-rule pack with promtool:
-# `check rules` for syntax/shape, `test rules` for the per-rule unit
-# tests (every rule has a firing and a non-firing case). Path-scoped
-# to the pack so it costs nothing on unrelated changes.
+# Validates the shipped Grafana dashboard structurally, then checks the
+# Prometheus alert-rule pack with promtool (`check rules` for syntax/shape,
+# `test rules` for per-rule behavior). Path-scoped to those assets so it
+# costs nothing on unrelated changes.
 
 on:
   push:
     paths:
       - "examples/prometheus/**"
+      - "docs/grafana/rustbgpd-overview.json"
+      - "scripts/check-grafana-dashboard.py"
       - ".github/workflows/alert-rules.yml"
   pull_request:
     paths:
       - "examples/prometheus/**"
+      - "docs/grafana/rustbgpd-overview.json"
+      - "scripts/check-grafana-dashboard.py"
       - ".github/workflows/alert-rules.yml"
 
 jobs:
@@ -21,6 +25,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
+      - name: Check Grafana dashboard
+        run: python3 scripts/check-grafana-dashboard.py
       - name: Install promtool (pinned)
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Operator dashboard and alerting cover slow peers and RIB actor latency.**
+  The shipped Grafana overview now separates transport endpoints from bare
+  neighbor addresses, exposes coalesced outbound queues, slow-peer state,
+  discrete update-group membership, export-policy transition state/duration,
+  actor-poll latency, and accepted-policy age. Prometheus rules warn on a peer
+  that remains slow for five minutes and on actor polls above the exact 200ms
+  histogram boundary; structural dashboard and promtool gates protect both.
+
 - **RFC 8326 graceful-shutdown advertise intent is visible per neighbor.**
   `rbgp neighbor <peer>` reports the local desired state as enabled, disabled,
   or unknown when connected to an older daemon; JSON and `NeighborState` field

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -3,13 +3,11 @@
 A ready-to-import overview dashboard lives at
 [`grafana/rustbgpd-overview.json`](grafana/rustbgpd-overview.json)
 (uid `rustbgpd-overview`). It covers session health (including graceful
-restart), RIB scale (including the per-peer attribute-intern gauge),
-churn/distribution (including the ADR-0098 update-group gauges and index
-internals), policy decisions and engine errors, BMP/event-outbox health,
-RPKI/ASPA state, and an operations row (config transactions, event-stream
-subscribers, jemalloc memory). Every panel references metrics the daemon
-actually exports from `crates/telemetry/src/metrics.rs` — no speculative
-series.
+restart and slow-peer queues), RIB scale, update-group membership,
+policy-transition actor occupancy, accepted-policy age, policy decisions and
+engine errors, BMP/event-outbox health, RPKI/ASPA state, and core operations.
+Every panel references metrics the daemon actually exports from
+`crates/telemetry/src/metrics.rs` — no speculative series.
 
 ## Enable the metrics endpoint
 
@@ -46,16 +44,26 @@ Template variables:
 
 - **Instance** — Prometheus `instance` label, populated from
   `bgp_rib_outbound_registered_peers` (always exported, even at zero).
-- **Peer** — the daemon's `peer` label (neighbor address), multi-select
-  with an All option. Per-peer series are reaped when a peer is deleted,
-  so stale neighbors age out of the picker on the next scrape.
+- **Peer endpoint** (`$peer`) — transport/session metrics identify a peer as
+  `addr:port`: `192.0.2.1:179` for IPv4 and `[2001:db8::1]:179` for IPv6.
+  This selector supports multiple values and All.
+- **Neighbor address** (`$neighbor`) — RIB update-group metrics identify the
+  same peer by its bare configured address: `192.0.2.1` or `2001:db8::1`.
+  It is independently populated from the always-seeded and reaped
+  `bgp_peer_update_group` gauge and also supports multiple values and All.
+
+The dashboard intentionally preserves these native, distinct metric identities
+instead of hiding a label rewrite inside its selectors. To correlate a row
+manually, strip the IPv4 port or the IPv6 brackets and port as shown above.
+Per-peer series are reaped when a peer is deleted, so stale values age out after
+the next scrape.
 
 ## Alert rules
 
 A ready-to-load Prometheus alert-rule pack (session down/flapping,
 empty Adj-RIB-In, max-prefix breach, empty RPKI VRP table, event-outbox
-degradation, update-group residue growth, stalled policy transition, daemon
-down) ships at
+degradation, update-group residue growth, stalled policy transition, a slow
+peer endpoint, actor polls above 200ms, and daemon down) ships at
 [`examples/prometheus/rustbgpd-alerts.yml`](../examples/prometheus/rustbgpd-alerts.yml),
 with per-rule unit tests in
 [`rustbgpd-alerts_test.yml`](../examples/prometheus/rustbgpd-alerts_test.yml)
@@ -66,6 +74,22 @@ with per-rule unit tests in
 
 - Counters are plotted with `rate(...[$__rate_interval])`; gauges are
   plotted raw. Single-stats use last-not-null.
+- Outbound queue depth is an absolute gauge of coalesced UPDATE frames, sampled
+  at enqueue-batch and writer-drain boundaries. A short convergence spike is
+  not itself a slow peer; `bgp_peer_slow` is the daemon's persistent 0/1 state.
+- The update-group table is discrete. Group IDs 0 and above are stable group
+  identities; `-1` legitimately means the neighbor is on the per-peer fallback
+  path.
+- Policy-transition **in progress** is current state. **Last completed policy
+  transition** is a retained terminal duration and does not count upward while
+  another transition runs. Actor p99 uses a fixed 15-minute window and stays
+  partitioned by `instance`, `job`, and `poll_kind`. Because polls exist only
+  during transitions, p99 is sparse and legitimately shows no data/NaN outside
+  those windows. The >200ms view is an `increase` estimate above the exact
+  `le="0.2"` histogram boundary.
+- Accepted-policy age is informational and clamped at zero to tolerate clock
+  correction. A static-policy deployment legitimately lets this age grow from
+  boot; rejected reloads also leave the last accepted timestamp unchanged.
 - "Peers registered for distribution" is
   `bgp_rib_outbound_registered_peers` — the closest exported gauge to
   "currently Established peers". The daemon does not export a per-peer
@@ -81,3 +105,27 @@ with per-rule unit tests in
 - EVPN metrics (the `evpn_*` families) are intentionally not on this
   overview dashboard; they are VTEP-alpha surface with per-VNI/MAC/ESI
   cardinality better served by a dedicated dashboard.
+
+## Validation and load-bearing proofs
+
+Run the same checks as CI with:
+
+```bash
+python3 scripts/check-grafana-dashboard.py
+promtool check rules examples/prometheus/rustbgpd-alerts.yml
+(cd examples/prometheus && promtool test rules rustbgpd-alerts_test.yml)
+```
+
+The dashboard checker parses JSON, rejects duplicate panel IDs, validates the
+multi/All selector definitions, compares the required PromQL targets after
+whitespace normalization, and checks both workflow path filters plus the real
+checker step. Its mutation proof makes each of these changes red: malformed
+JSON, a non-integer or duplicate ID, deletion of any required target, removal
+of the `instance` selector, swapping endpoint/bare-address selectors, removing
+`$neighbor`, or replacing the executable workflow step with only a comment.
+
+The slow-peer fixture is red if its `== 1` predicate or five-minute hold is
+changed. The actor fixture is red if `ignoring(le)` is removed, `le="0.2"` is
+moved to `0.5`, `> 0` becomes `>= 0`, raw counters replace `increase`, or
+`job`/`poll_kind` are aggregated away. Its firing observation is in
+`(0.2, 0.5]`; exact-boundary and historical-flat controls remain healthy.

--- a/docs/grafana/rustbgpd-overview.json
+++ b/docs/grafana/rustbgpd-overview.json
@@ -45,13 +45,29 @@
       },
       {
         "name": "peer",
-        "label": "Peer",
+        "label": "Peer endpoint",
         "type": "query",
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
         },
         "query": "label_values(bgp_session_state_transitions_total{instance=~\"$instance\"}, peer)",
+        "current": {},
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "neighbor",
+        "label": "Neighbor address",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": "label_values(bgp_peer_update_group{instance=~\"$instance\"}, peer)",
         "current": {},
         "includeAll": true,
         "multi": true,
@@ -2347,6 +2363,156 @@
           "expr": "jemalloc_resident_bytes{instance=~\"$instance\"}",
           "legendFormat": "resident",
           "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 46,
+      "type": "row",
+      "title": "Operator signals",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 123 },
+      "panels": []
+    },
+    {
+      "id": 47,
+      "type": "timeseries",
+      "title": "Outbound queue by peer endpoint",
+      "description": "Absolute coalesced UPDATE frames buffered for each transport endpoint. A sustained backlog is stronger evidence than a short convergence burst.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 124 },
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_peer_outbound_queue_depth{instance=~\"$instance\",peer=~\"$peer\"}",
+          "legendFormat": "{{peer}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 48,
+      "type": "timeseries",
+      "title": "Slow peer endpoints",
+      "description": "1 while an Established transport endpoint has persistently failed to drain its outbound queue; 0 after recovery or teardown.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 124 },
+      "fieldConfig": { "defaults": { "unit": "short", "min": 0, "max": 1, "custom": { "lineInterpolation": "stepAfter" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_peer_slow{instance=~\"$instance\",peer=~\"$peer\"}",
+          "legendFormat": "{{peer}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 49,
+      "type": "table",
+      "title": "Update group by neighbor address",
+      "description": "Current stable update-group ID for each bare configured neighbor address. -1 is a legitimate value: that neighbor uses the per-peer fallback path.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 124 },
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 }, "overrides": [] },
+      "options": { "showHeader": true },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_peer_update_group{instance=~\"$instance\",peer=~\"$neighbor\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 50,
+      "type": "stat",
+      "title": "Policy transition in progress",
+      "description": "Current ownership state only: 1 while the RIB actor owns an export-policy transition, otherwise 0.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 132 },
+      "fieldConfig": { "defaults": { "unit": "short", "min": 0, "max": 1 }, "overrides": [] },
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_rib_policy_transition_in_progress{instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 51,
+      "type": "stat",
+      "title": "Last completed policy transition",
+      "description": "Terminal duration of the most recently completed transition. This retained sample is not the live elapsed time of an in-progress transition.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 132 },
+      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_rib_policy_transition_last_duration_milliseconds{instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 52,
+      "type": "timeseries",
+      "title": "Policy-transition actor poll p99",
+      "description": "Fifteen-minute p99 by instance, scrape job, and bounded poll kind. This is actor occupancy per poll, not total transition duration.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 132 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.99, sum by (instance, job, poll_kind, le) (rate(bgp_rib_policy_transition_actor_poll_duration_seconds_bucket{instance=~\"$instance\"}[15m])))",
+          "legendFormat": "{{instance}} {{job}} {{poll_kind}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 54,
+      "type": "timeseries",
+      "title": "Policy-transition actor polls over 200ms",
+      "description": "Fifteen-minute increase estimate for actor polls above the exact 200ms bucket boundary, preserving instance, scrape job, and poll kind.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 132 },
+      "fieldConfig": { "defaults": { "unit": "short", "min": 0 }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "increase(bgp_rib_policy_transition_actor_poll_duration_seconds_count{instance=~\"$instance\"}[15m]) - ignoring(le) increase(bgp_rib_policy_transition_actor_poll_duration_seconds_bucket{instance=~\"$instance\",le=\"0.2\"}[15m])",
+          "legendFormat": "{{instance}} {{job}} {{poll_kind}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 53,
+      "type": "stat",
+      "title": "Accepted policy generation age",
+      "description": "Informational age of the last successfully accepted full policy generation. It is not an alert threshold; rejected reloads intentionally leave the timestamp unchanged.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 138 },
+      "fieldConfig": { "defaults": { "unit": "s", "min": 0 }, "overrides": [] },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "clamp_min(time() - bgp_policy_generation_loaded_timestamp_seconds{instance=~\"$instance\"}, 0)",
+          "refId": "A"
         }
       ]
     }

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -69,6 +69,23 @@ groups:
             {{ $labels.instance }} left Established
             {{ $value | printf "%.0f" }} times in the last 15 minutes.
 
+      - alert: BgpPeerSlow
+        # Session metrics label `peer` as the transport endpoint
+        # (IPv4 addr:port or bracketed-IPv6 addr:port), not the bare
+        # configured neighbor address used by RIB metrics.
+        expr: bgp_peer_slow == 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "BGP peer endpoint {{ $labels.peer }} is slow"
+          description: >-
+            The Established session endpoint {{ $labels.peer }} on
+            {{ $labels.instance }} has remained slow for 5 minutes because
+            its outbound coalesced-frame queue is not draining. Updates are
+            still buffered; inspect bgp_peer_outbound_queue_depth and the
+            remote receiver before the backlog reaches its bound.
+
       - alert: BgpPeerAdjRibInEmpty
         # Established (established > flaps) but zero prefixes in
         # Adj-RIB-In across all families (afi_safi="all" is the
@@ -176,6 +193,29 @@ groups:
             Check the poll_kind histogram and the daemon's policy-transition
             warning; bgp_rib_policy_transition_last_duration_milliseconds is
             the previous terminal sample until this transition completes.
+
+      - alert: BgpPolicyTransitionActorPollExceededReadinessBudget
+        # Histogram subtraction classifies observations above the exact
+        # 200ms bucket boundary. `ignoring(le)` is required to match the
+        # histogram count and bucket series while retaining bounded
+        # instance/job/poll_kind identity.
+        expr: >-
+          increase(bgp_rib_policy_transition_actor_poll_duration_seconds_count[15m])
+          - ignoring(le)
+          increase(bgp_rib_policy_transition_actor_poll_duration_seconds_bucket{le="0.2"}[15m])
+          > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            RIB actor poll exceeded readiness budget ({{ $labels.poll_kind }})
+          description: >-
+            The {{ $labels.poll_kind }} export-policy transition path on
+            {{ $labels.instance }} exceeded the 200ms actor-poll budget in
+            the last 15 minutes. A long single-threaded poll could delay a
+            concurrent readiness probe and other RIB work; inspect the
+            dashboard p99 and transition state before retrying a reload.
 
       - alert: BgpPolicyEvalErrors
         # An evaluation error makes the policy engine treat the

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -163,6 +163,38 @@ tests:
                 session was torn down with a Cease / Maximum Number of
                 Prefixes Reached NOTIFICATION.
 
+  # ── BgpPeerSlow ───────────────────────────────────────────────
+  # Load-bearing: reverting `== 1`, shortening/lengthening `for: 5m`,
+  # or aggregating away the endpoint makes one of these exact boundary
+  # expectations red.
+  - interval: 30s
+    input_series:
+      - series: 'bgp_peer_slow{peer="192.0.2.10:179", instance="edge1:9179", job="rustbgpd"}'
+        values: "1x14"
+      - series: 'bgp_peer_slow{peer="[2001:db8::10]:179", instance="edge1:9179", job="rustbgpd"}'
+        values: "0x14"
+    alert_rule_test:
+      - eval_time: 4m30s
+        alertname: BgpPeerSlow
+        exp_alerts: []
+      - eval_time: 5m30s
+        alertname: BgpPeerSlow
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              peer: 192.0.2.10:179
+              instance: edge1:9179
+              job: rustbgpd
+            exp_annotations:
+              summary: "BGP peer endpoint 192.0.2.10:179 is slow"
+              description: >-
+                The Established session endpoint 192.0.2.10:179 on
+                edge1:9179 has remained slow for 5 minutes because its
+                outbound coalesced-frame queue is not draining. Updates
+                are still buffered; inspect bgp_peer_outbound_queue_depth
+                and the remote receiver before the backlog reaches its
+                bound.
+
   # ── RpkiVrpTableEmpty ─────────────────────────────────────────
   - interval: 1m
     input_series:
@@ -275,6 +307,53 @@ tests:
                 policy-transition warning;
                 bgp_rib_policy_transition_last_duration_milliseconds is the
                 previous terminal sample until this transition completes.
+
+  # ── BgpPolicyTransitionActorPollExceededReadinessBudget ─────
+  # Load-bearing: the firing series has observations in (0.2, 0.5],
+  # the boundary series lands exactly at 0.2, and the historical series
+  # has a non-zero raw count-minus-bucket gap but no recent increase.
+  # Removing `ignoring(le)`, moving 0.2 to 0.5, changing > to >=, using
+  # raw counters, or aggregating away job/poll_kind makes this test red.
+  - interval: 1m
+    input_series:
+      - series: 'bgp_rib_policy_transition_actor_poll_duration_seconds_count{instance="edge1:9179", job="rustbgpd", poll_kind="prefix_snapshot"}'
+        values: "0+1x20"
+      - series: 'bgp_rib_policy_transition_actor_poll_duration_seconds_bucket{instance="edge1:9179", job="rustbgpd", poll_kind="prefix_snapshot", le="0.2"}'
+        values: "0x20"
+      - series: 'bgp_rib_policy_transition_actor_poll_duration_seconds_bucket{instance="edge1:9179", job="rustbgpd", poll_kind="prefix_snapshot", le="0.5"}'
+        values: "0+1x20"
+      # Exact-boundary observations are healthy: count == le="0.2".
+      - series: 'bgp_rib_policy_transition_actor_poll_duration_seconds_count{instance="edge2:9179", job="rustbgpd", poll_kind="bounded"}'
+        values: "0+1x20"
+      - series: 'bgp_rib_policy_transition_actor_poll_duration_seconds_bucket{instance="edge2:9179", job="rustbgpd", poll_kind="bounded", le="0.2"}'
+        values: "0+1x20"
+      - series: 'bgp_rib_policy_transition_actor_poll_duration_seconds_bucket{instance="edge2:9179", job="rustbgpd", poll_kind="bounded", le="0.5"}'
+        values: "0+1x20"
+      # Historical raw gap is flat throughout the evaluation window.
+      - series: 'bgp_rib_policy_transition_actor_poll_duration_seconds_count{instance="edge3:9179", job="route-server", poll_kind="finalize"}'
+        values: "10x20"
+      - series: 'bgp_rib_policy_transition_actor_poll_duration_seconds_bucket{instance="edge3:9179", job="route-server", poll_kind="finalize", le="0.2"}'
+        values: "7x20"
+      - series: 'bgp_rib_policy_transition_actor_poll_duration_seconds_bucket{instance="edge3:9179", job="route-server", poll_kind="finalize", le="0.5"}'
+        values: "10x20"
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: BgpPolicyTransitionActorPollExceededReadinessBudget
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: edge1:9179
+              job: rustbgpd
+              poll_kind: prefix_snapshot
+            exp_annotations:
+              summary: >-
+                RIB actor poll exceeded readiness budget (prefix_snapshot)
+              description: >-
+                The prefix_snapshot export-policy transition path on
+                edge1:9179 exceeded the 200ms actor-poll budget in the last
+                15 minutes. A long single-threaded poll could delay a
+                concurrent readiness probe and other RIB work; inspect the
+                dashboard p99 and transition state before retrying a reload.
 
   # ── BgpPolicyEvalErrors ───────────────────────────────────────
   - interval: 1m

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Validate the shipped Grafana dashboard's load-bearing operator views."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DASHBOARD = ROOT / "docs/grafana/rustbgpd-overview.json"
+WORKFLOW = ROOT / ".github/workflows/alert-rules.yml"
+
+VARIABLES = {
+    "peer": 'label_values(bgp_session_state_transitions_total{instance=~"$instance"}, peer)',
+    "neighbor": 'label_values(bgp_peer_update_group{instance=~"$instance"}, peer)',
+}
+
+TARGETS = {
+    ("Outbound queue by peer endpoint", "A"): (
+        'bgp_peer_outbound_queue_depth{instance=~"$instance",peer=~"$peer"}'
+    ),
+    ("Slow peer endpoints", "A"): (
+        'bgp_peer_slow{instance=~"$instance",peer=~"$peer"}'
+    ),
+    ("Update group by neighbor address", "A"): (
+        'bgp_peer_update_group{instance=~"$instance",peer=~"$neighbor"}'
+    ),
+    ("Policy transition in progress", "A"): (
+        'bgp_rib_policy_transition_in_progress{instance=~"$instance"}'
+    ),
+    ("Last completed policy transition", "A"): (
+        'bgp_rib_policy_transition_last_duration_milliseconds{instance=~"$instance"}'
+    ),
+    ("Policy-transition actor poll p99", "A"): (
+        "histogram_quantile(0.99, sum by (instance, job, poll_kind, le) "
+        "(rate(bgp_rib_policy_transition_actor_poll_duration_seconds_bucket"
+        '{instance=~"$instance"}[15m])))'
+    ),
+    ("Policy-transition actor polls over 200ms", "A"): (
+        "increase(bgp_rib_policy_transition_actor_poll_duration_seconds_count"
+        '{instance=~"$instance"}[15m]) - ignoring(le) '
+        "increase(bgp_rib_policy_transition_actor_poll_duration_seconds_bucket"
+        '{instance=~"$instance",le="0.2"}[15m])'
+    ),
+    ("Accepted policy generation age", "A"): (
+        "clamp_min(time() - bgp_policy_generation_loaded_timestamp_seconds"
+        '{instance=~"$instance"}, 0)'
+    ),
+}
+
+WORKFLOW_PATHS = {
+    "examples/prometheus/**",
+    "docs/grafana/rustbgpd-overview.json",
+    "scripts/check-grafana-dashboard.py",
+    ".github/workflows/alert-rules.yml",
+}
+
+
+def fail(message: str) -> None:
+    print(f"dashboard check: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def normalized(expression: str) -> str:
+    return " ".join(expression.split())
+
+
+def all_panels(panels: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    flattened: list[dict[str, Any]] = []
+    for panel in panels:
+        flattened.append(panel)
+        children = panel.get("panels", [])
+        if not isinstance(children, list):
+            fail(f"panel {panel.get('id')} has a non-list panels field")
+        flattened.extend(all_panels(children))
+    return flattened
+
+
+def workflow_trigger_paths(text: str) -> dict[str, set[str]]:
+    triggers: dict[str, set[str]] = {"push": set(), "pull_request": set()}
+    event: str | None = None
+    in_paths = False
+    for line in text.splitlines():
+        event_match = re.fullmatch(r"  (push|pull_request):", line)
+        if event_match:
+            event = event_match.group(1)
+            in_paths = False
+            continue
+        if event is not None and re.fullmatch(r"    paths:", line):
+            in_paths = True
+            continue
+        if in_paths:
+            path_match = re.fullmatch(r'      - ["\']([^"\']+)["\']', line)
+            if path_match:
+                triggers[event].add(path_match.group(1))
+                continue
+            if line.strip() and not line.startswith("      "):
+                in_paths = False
+        if event is not None and line and not line.startswith("  "):
+            event = None
+            in_paths = False
+    return triggers
+
+
+def main() -> None:
+    try:
+        dashboard = json.loads(DASHBOARD.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        fail(f"cannot parse {DASHBOARD.relative_to(ROOT)}: {error}")
+
+    panels = all_panels(dashboard.get("panels", []))
+    ids = [panel.get("id") for panel in panels]
+    if any(type(panel_id) is not int for panel_id in ids):
+        fail("every panel must have an integer id")
+    duplicates = sorted({panel_id for panel_id in ids if ids.count(panel_id) > 1})
+    if duplicates:
+        fail(f"duplicate panel ids: {duplicates}")
+
+    variables = {
+        variable.get("name"): variable
+        for variable in dashboard.get("templating", {}).get("list", [])
+    }
+    for name, query in VARIABLES.items():
+        variable = variables.get(name)
+        if variable is None:
+            fail(f"missing ${name} template variable")
+        if variable.get("type") != "query" or variable.get("query") != query:
+            fail(f"${name} does not use its exact label_values query")
+        if variable.get("multi") is not True or variable.get("includeAll") is not True:
+            fail(f"${name} must support multi-select and All")
+        if variable.get("allValue") != ".*":
+            fail(f"${name} All value must be the regex .* ")
+
+    targets: dict[tuple[str, str], list[str]] = {}
+    for panel in panels:
+        title = panel.get("title")
+        for target in panel.get("targets", []):
+            key = (title, target.get("refId"))
+            targets.setdefault(key, []).append(normalized(target.get("expr", "")))
+
+    for key, expression in TARGETS.items():
+        actual = targets.get(key, [])
+        expected = [normalized(expression)]
+        if actual != expected:
+            fail(f"target {key[0]!r}/{key[1]} must equal {expected[0]!r}; got {actual!r}")
+
+    update_group_panel = next(
+        panel for panel in panels if panel.get("title") == "Update group by neighbor address"
+    )
+    update_group_target = update_group_panel["targets"][0]
+    if update_group_panel.get("type") != "table":
+        fail("update-group IDs must use a discrete table panel")
+    if update_group_panel.get("fieldConfig", {}).get("defaults", {}).get("decimals") != 0:
+        fail("update-group IDs must render with zero decimal places")
+    if update_group_target.get("format") != "table" or update_group_target.get("instant") is not True:
+        fail("update-group target must be an instant table query")
+
+    slow_panel = next(panel for panel in panels if panel.get("title") == "Slow peer endpoints")
+    slow_defaults = slow_panel.get("fieldConfig", {}).get("defaults", {})
+    if slow_defaults.get("min") != 0 or slow_defaults.get("max") != 1:
+        fail("slow-peer state must be pinned to the discrete 0..1 range")
+    if slow_defaults.get("custom", {}).get("lineInterpolation") != "stepAfter":
+        fail("slow-peer state must use step interpolation")
+
+    try:
+        workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    except OSError as error:
+        fail(f"cannot read {WORKFLOW.relative_to(ROOT)}: {error}")
+    for event, paths in workflow_trigger_paths(workflow_text).items():
+        missing = sorted(WORKFLOW_PATHS - paths)
+        if missing:
+            fail(f"{event} paths are missing {missing}")
+    checker_steps = sum(
+        line.strip() == "run: python3 scripts/check-grafana-dashboard.py"
+        for line in workflow_text.splitlines()
+    )
+    if checker_steps != 1:
+        fail("workflow must contain exactly one executable dashboard-checker step")
+
+    print(
+        f"dashboard check: {len(panels)} unique panels, "
+        f"{len(TARGETS)} operator targets, and workflow triggers are valid"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- split transport-endpoint and bare-neighbor selectors in the shipped Grafana dashboard, then add the RR/IX fanout and policy-transition panels
- add slow-peer and actor-poll-budget alerts with exact boundary, duration, historical-flat, IPv6 endpoint, and label-preservation fixtures
- add a stdlib structural dashboard checker and run it in the path-scoped observability workflow
- document panel semantics, legitimate sentinel/retained states, sparse transition samples, and selector correlation

## Load-bearing proofs

The new fixtures were each made red by reverting their guarded behavior: the slow predicate and both shorter/longer hold durations; histogram label matching, threshold bucket, comparison, recent-increase logic, and label preservation. The dashboard gate was made red by malformed JSON, a duplicate panel ID, deletion of each required target, removal or swapping of endpoint/neighbor selectors, removal of the instance selector, and replacing the executable workflow step with a comment. Every mutation was restored before the final gates.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `python3 scripts/check-grafana-dashboard.py`
- Prometheus v3.4.1 `promtool check rules`
- Prometheus v3.4.1 `promtool test rules`
- `git diff --check`

Linear: LAN-503
