### PR TITLE
fix: enforce NO_ADVERTISE on EVPN exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- EVPN exports now enforce stored-route `NO_ADVERTISE` before policy and
+  policy-added `NO_ADVERTISE` before Adj-RIB-Out commit, withdrawing only the
+  exact prior advertisement and remaining silent for first-seen suppression.
 - Outbound RFC 9234 OTC diagnostics now emit once per transition into a blocked disposition, rather than repeating on unchanged refresh/resync retries; permit, withdrawal, or session reset re-arms the edge.
 - Import-policy-denied FlowSpec and EVPN replacements now withdraw the exact accepted identity.
 - **Release tarballs ship `rs-config-render`.** The route-server

--- a/crates/rib/src/manager/distribution/evpn.rs
+++ b/crates/rib/src/manager/distribution/evpn.rs
@@ -199,6 +199,15 @@ impl RibManager {
                 continue;
             };
 
+            // RFC 1997: NO_ADVERTISE is a pre-policy export restriction.
+            // A permit policy cannot remove it to make the route eligible.
+            if super::no_advertise_export_suppressed(best.communities()) {
+                if rib_out.get_evpn(key).is_some() {
+                    evpn_withdraw.push(*key);
+                }
+                continue;
+            }
+
             // RFC 9494 §4.4: LLGR-stale toward a non-LLGR eBGP peer is
             // suppressed. See `llgr_stale_export_suppressed`.
             //
@@ -334,6 +343,16 @@ impl RibManager {
                     modified.next_hop = addr;
                 }
             }
+
+            // Export policy may scope an otherwise eligible route by adding
+            // NO_ADVERTISE. Stop it before the Adj-RIB-Out commit.
+            if super::no_advertise_export_suppressed(modified.communities()) {
+                if rib_out.get_evpn(key).is_some() {
+                    evpn_withdraw.push(*key);
+                }
+                continue;
+            }
+
             // Skip the announce if rib_out already holds the same route —
             // the dirty-resync path in particular re-evaluates every
             // advertised key and would otherwise re-emit no-op announces

--- a/crates/rib/src/manager/tests/evpn.rs
+++ b/crates/rib/src/manager/tests/evpn.rs
@@ -1,5 +1,53 @@
 use super::*;
 
+fn with_evpn_community(mut route: EvpnRibRoute, community: u32) -> EvpnRibRoute {
+    Arc::make_mut(&mut route.attributes).push(PathAttribute::Communities(vec![community]));
+    route
+}
+
+fn evpn_no_advertise_policy(
+    matched_community: u32,
+    add: bool,
+    remove: bool,
+) -> rustbgpd_policy::PolicyChain {
+    rustbgpd_policy::PolicyChain::new(vec![rustbgpd_policy::Policy {
+        entries: vec![rustbgpd_policy::PolicyStatement {
+            prefix: None,
+            ge: None,
+            le: None,
+            action: rustbgpd_policy::PolicyAction::Permit,
+            match_community: vec![rustbgpd_policy::CommunityMatch::Standard {
+                value: matched_community,
+            }],
+            match_as_path: None,
+            match_neighbor_set: None,
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: None,
+            modifications: rustbgpd_policy::RouteModifications {
+                communities_add: add
+                    .then_some(rustbgpd_wire::COMMUNITY_NO_ADVERTISE)
+                    .into_iter()
+                    .collect(),
+                communities_remove: remove
+                    .then_some(rustbgpd_wire::COMMUNITY_NO_ADVERTISE)
+                    .into_iter()
+                    .collect(),
+                ..rustbgpd_policy::RouteModifications::default()
+            },
+        }],
+        default_action: rustbgpd_policy::PolicyAction::Permit,
+    }])
+}
+
 /// Regression: EVPN routes learned from a peer that goes down must be
 /// withdrawn from remaining peers. Before this fix, `handle_peer_down` removed
 /// the dead peer's Adj-RIB-In but never called `recompute_and_distribute_evpn`,
@@ -1199,6 +1247,309 @@ async fn enhanced_route_refresh_evpn_replacement_preserves_route() {
     let best = query_evpn_routes(&tx).await;
     assert_eq!(best.len(), 1, "refreshed EVPN route must survive EoRR");
     assert_eq!(best[0].key(), imet_key);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Source `NO_ADVERTISE` is enforced before export policy, withdraws only the
+/// exact prior EVPN key, and recovers without disturbing a sibling route.
+///
+/// Break-to-red: deleting the pre-policy guard lets the targeted removal policy
+/// export the first-seen scoped route; removing the existing-state membership
+/// check emits a withdrawal for that unknown route; omitting or broadening the
+/// withdrawal fails the exact-key and sibling assertions; sticky suppression
+/// prevents the recovery announcement.
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one ordered actor scenario proves source precedence, silence, exact withdrawal, and recovery"
+)]
+async fn evpn_source_no_advertise_cannot_be_removed_by_export_policy() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let source = Ipv4Addr::new(198, 51, 100, 11);
+    let source_ip = IpAddr::V4(source);
+    let target = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 31));
+    let (out_tx, mut out_rx) = mpsc::channel(16);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        interpret_rfc1997: true,
+        session_id: 0,
+        peer: target,
+        peer_asn: 65100,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: Some(evpn_no_advertise_policy(
+            rustbgpd_wire::COMMUNITY_NO_ADVERTISE,
+            false,
+            true,
+        )),
+        sendable_families: evpn_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let first_seen = with_evpn_community(
+        make_evpn_imet(source, 99),
+        rustbgpd_wire::COMMUNITY_NO_ADVERTISE,
+    );
+    for attempt in 0..2 {
+        let mut scoped = first_seen.clone();
+        if attempt > 0 {
+            Arc::make_mut(&mut scoped.attributes).push(PathAttribute::Med(attempt));
+        }
+        tx.send(RibUpdate::RoutesReceived {
+            session_id: 0,
+            peer: source_ip,
+            announced: vec![],
+            withdrawn: vec![],
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![scoped],
+            evpn_withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+        let _ = query_evpn_routes(&tx).await;
+        assert!(
+            out_rx.try_recv().is_err(),
+            "first-seen and repeated source-scoped EVPN routes stay silent"
+        );
+    }
+
+    let primary = make_evpn_imet(source, 100);
+    let sibling = make_evpn_imet(source, 200);
+    let primary_key = primary.key();
+    let sibling_key = sibling.key();
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source_ip,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![primary.clone(), sibling],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_evpn_routes(&tx).await;
+    let initial = out_rx.try_recv().expect("plain EVPN routes must advertise");
+    assert_eq!(initial.evpn_announce.len(), 2);
+    assert!(
+        initial
+            .evpn_announce
+            .iter()
+            .any(|route| route.key() == primary_key)
+    );
+    assert!(
+        initial
+            .evpn_announce
+            .iter()
+            .any(|route| route.key() == sibling_key)
+    );
+
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source_ip,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![with_evpn_community(
+            primary.clone(),
+            rustbgpd_wire::COMMUNITY_NO_ADVERTISE,
+        )],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_evpn_routes(&tx).await;
+    let scoped = out_rx
+        .try_recv()
+        .expect("source NO_ADVERTISE must withdraw the prior EVPN route");
+    assert!(scoped.evpn_announce.is_empty());
+    assert_eq!(scoped.evpn_withdraw, vec![primary_key]);
+
+    let recovered_primary = with_evpn_community(primary, (65000u32 << 16) | 0x01BD);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source_ip,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![recovered_primary],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_evpn_routes(&tx).await;
+    let recovered = out_rx
+        .try_recv()
+        .expect("removing source NO_ADVERTISE must re-announce EVPN");
+    assert_eq!(recovered.evpn_announce.len(), 1);
+    assert_eq!(recovered.evpn_announce[0].key(), primary_key);
+    assert!(recovered.evpn_withdraw.is_empty());
+    assert!(
+        out_rx.try_recv().is_err(),
+        "sibling EVPN route must not churn"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Policy-added `NO_ADVERTISE` suppresses first-seen EVPN routes, withdraws
+/// only an exact prior advertisement, and recovers when policy scope is removed.
+///
+/// Break-to-red: deleting the post-policy guard announces the scoped route;
+/// removing the existing-state membership check emits a first-seen withdrawal;
+/// omitting or broadening the withdrawal fails the exact-key and sibling
+/// assertions; sticky suppression prevents either recovery announcement.
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one ordered actor scenario proves policy-added suppression, silence, exact withdrawal, and recovery"
+)]
+async fn evpn_policy_added_no_advertise_withdraws_exact_prior() {
+    let marker = (65000u32 << 16) | 0x01BC;
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let source = Ipv4Addr::new(198, 51, 100, 12);
+    let source_ip = IpAddr::V4(source);
+    let target = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 32));
+    let (out_tx, mut out_rx) = mpsc::channel(16);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        interpret_rfc1997: true,
+        session_id: 0,
+        peer: target,
+        peer_asn: 65100,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: Some(evpn_no_advertise_policy(marker, true, false)),
+        sendable_families: evpn_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let primary = with_evpn_community(make_evpn_imet(source, 300), marker);
+    let sibling = make_evpn_imet(source, 400);
+    let primary_key = primary.key();
+    let sibling_key = sibling.key();
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source_ip,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![primary.clone(), sibling],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_evpn_routes(&tx).await;
+    let first_seen = out_rx
+        .try_recv()
+        .expect("unscoped EVPN sibling must advertise");
+    assert_eq!(first_seen.evpn_announce.len(), 1);
+    assert_eq!(first_seen.evpn_announce[0].key(), sibling_key);
+    assert!(first_seen.evpn_withdraw.is_empty());
+
+    let mut repeated = primary.clone();
+    Arc::make_mut(&mut repeated.attributes).push(PathAttribute::Med(50));
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source_ip,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![repeated],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_evpn_routes(&tx).await;
+    assert!(
+        out_rx.try_recv().is_err(),
+        "repeated policy-scoped EVPN route stays silent"
+    );
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer: target,
+        export_policy: Some(evpn_no_advertise_policy(marker, false, false)),
+        reply,
+    })
+    .await
+    .unwrap();
+    response.await.unwrap().unwrap();
+    let _ = query_evpn_routes(&tx).await;
+    let recovered = out_rx
+        .try_recv()
+        .expect("removing policy-added NO_ADVERTISE must announce EVPN");
+    assert_eq!(recovered.evpn_announce.len(), 1);
+    assert_eq!(recovered.evpn_announce[0].key(), primary_key);
+    assert!(recovered.evpn_withdraw.is_empty());
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer: target,
+        export_policy: Some(evpn_no_advertise_policy(marker, true, false)),
+        reply,
+    })
+    .await
+    .unwrap();
+    response.await.unwrap().unwrap();
+    let _ = query_evpn_routes(&tx).await;
+    let scoped = out_rx
+        .try_recv()
+        .expect("policy-added NO_ADVERTISE must withdraw prior EVPN");
+    assert!(scoped.evpn_announce.is_empty());
+    assert_eq!(scoped.evpn_withdraw, vec![primary_key]);
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer: target,
+        export_policy: Some(evpn_no_advertise_policy(marker, false, false)),
+        reply,
+    })
+    .await
+    .unwrap();
+    response.await.unwrap().unwrap();
+    let _ = query_evpn_routes(&tx).await;
+    let recovered_again = out_rx
+        .try_recv()
+        .expect("EVPN must recover after repeated policy scope");
+    assert_eq!(recovered_again.evpn_announce.len(), 1);
+    assert_eq!(recovered_again.evpn_announce[0].key(), primary_key);
+    assert!(recovered_again.evpn_withdraw.is_empty());
+    assert!(
+        out_rx.try_recv().is_err(),
+        "sibling EVPN route must not churn"
+    );
 
     drop(tx);
     handle.await.unwrap();

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -18,7 +18,7 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 | Core BGP | RFC 4271, RFC 6793 (4-byte ASN), RFC 7606 (revised error handling) | FSM + UPDATE validation with treat-as-withdraw / attribute-discard, dual-stack IPv4/IPv6 unicast (SAFI 1) |
 | MP-BGP + extensions | RFC 4760, RFC 7911 (Add-Path), RFC 8654 (Extended Messages), RFC 8950 (Extended Next Hop) | Multiprotocol negotiation and modern capability set |
 | Route refresh / filtering | RFC 2918, RFC 7313 (Enhanced RR), RFC 5291/5292 (ORF) | Receive-side Address-Prefix ORF |
-| Communities | RFC 1997 (well-known), RFC 4360 (Extended), RFC 8092 (Large) | Match plus policy set/remove; `NO_ADVERTISE` and `NO_EXPORT`/`NO_EXPORT_SUBCONFED` egress enforcement for unicast, VPNv4/VPNv6, labeled-unicast, RTC, and BGP-LS |
+| Communities | RFC 1997 (well-known), RFC 4360 (Extended), RFC 8092 (Large) | Match plus policy set/remove; `NO_ADVERTISE` egress enforcement for unicast, VPNv4/VPNv6, labeled-unicast, RTC, BGP-LS, and EVPN; `NO_EXPORT`/`NO_EXPORT_SUBCONFED` enforcement for the same set except EVPN |
 | Route reflection | RFC 4456, RFC 9107 (ORR, ADR-0095) | Per-client best paths via BGP-LS-sourced SPF |
 | Route server (IXP) | RFC 7947 (ADR-0039/0101), RFC 8195 | Transparent redistribution, §2.3.2 per-client best-path, member-set control communities (per-target announce/prepend steering, scrubbed on egress) |
 | Graceful restart | RFC 4724 (GR helper), RFC 9494 (LLGR) | Stale retention across all RR families; no forwarding-state preservation |
@@ -35,14 +35,16 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 
 ## RFC 1997 — well-known community export coverage
 
-- IPv4/IPv6 unicast, VPNv4/VPNv6, labeled-unicast, RTC, and BGP-LS SAFI 71/72
-  routes carrying `NO_ADVERTISE` are ineligible before export policy, and the
-  post-policy route is checked again before Adj-RIB-Out commit. A permit policy
-  cannot remove the community to bypass the restriction; a policy that adds it
-  suppresses the modified route.
+- IPv4/IPv6 unicast, VPNv4/VPNv6, labeled-unicast, RTC, BGP-LS SAFI 71/72,
+  and EVPN routes carrying `NO_ADVERTISE` in their stored route attributes are
+  ineligible toward every target before export policy, and the post-policy
+  route is checked again before Adj-RIB-Out commit. A permit policy cannot
+  remove the community to bypass the restriction; rustbgpd also conservatively
+  suppresses a modified route when export policy adds it.
 - `NO_EXPORT` (0xFFFFFF01) and `NO_EXPORT_SUBCONFED` (0xFFFFFF03) are enforced
-  at eBGP egress across the same family set: a route received with either
-  community is suppressed at staging toward every eBGP peer whose
+  at eBGP egress for IPv4/IPv6 unicast, VPNv4/VPNv6, labeled-unicast, RTC, and
+  BGP-LS: a route received with either community is suppressed at staging
+  toward every eBGP peer whose
   `interpret_rfc1997` knob is on (the default for plain eBGP and iBGP peers;
   route-server clients default to transparent pass-through, matching common
   IXP route-server practice — set `interpret_rfc1997 = true` on an RS client
@@ -67,9 +69,9 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 - The same predicate covers single-best plus Add-Path for unicast, VPN, and
   labeled routes; grouped/private and RFC 7947 per-client-best shapes apply to
   unicast, grouped/private applies to VPN, and RFC 9107 ORR applies to unicast
-  and labeled-unicast. RTC and both BGP-LS SAFIs use their single-best export
-  paths. Existing advertisements are withdrawn and logical Adj-RIB-Out state is
-  cleared.
+  and labeled-unicast. RTC, both BGP-LS SAFIs, and EVPN use their single-best
+  export paths. Existing advertisements are withdrawn and logical Adj-RIB-Out
+  state is cleared.
 - Add-Path and per-client-best remove scoped candidates before ranking, so
   surviving siblings compact normally. They also skip policy-modified
   candidates whose result carries `NO_ADVERTISE`. ORR single-best first
@@ -88,8 +90,8 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
   mechanics are correct and fail-closed — the amplification is inherent to
   SAFI 132, where one NLRI stands for the whole class of VPN routes carrying
   that RT.
-- `NO_ADVERTISE` and `NO_EXPORT` enforcement for EVPN and FlowSpec remains
-  deferred.
+- `NO_EXPORT` enforcement for EVPN, and `NO_ADVERTISE` / `NO_EXPORT`
+  enforcement for FlowSpec, remain deferred.
 
 ---
 


### PR DESCRIPTION
## Summary

Enforce RFC 1997 `NO_ADVERTISE` in EVPN outbound staging. A stored EVPN route carrying the community is now stopped before export policy can remove it, and an export policy that adds the community is stopped before Adj-RIB-Out commit.

Suppression remains transactional: only an exact prior EVPN key is queued for withdrawal, first-seen and repeated suppression stay silent, recovery reannounces, and sibling EVPN identities do not churn.

## Changes

- add source-route and post-modification EVPN `NO_ADVERTISE` gates
- add two actor-level state machines covering policy precedence, silence, exact withdrawal, recovery, and sibling isolation
- update RFC coverage notes and the changelog without claiming EVPN `NO_EXPORT` or immutable raw-wire history

## Load-bearing regression proof

- deleting the pre-policy guard exported the source-scoped route
- deleting the post-policy guard announced the policy-scoped route alongside its sibling
- removing exact prior-membership emitted an unknown withdrawal
- omitting the owed withdrawal left no withdrawal to consume
- broadening withdrawal to all advertised EVPN keys withdrew the sibling too
- overbroad source suppression blocked recovery reannouncement

Every mutation made its corresponding actor test red and was restored before the green gates.

## Testing

- [x] `cargo test -p rustbgpd-rib evpn_source_no_advertise_cannot_be_removed_by_export_policy -- --nocapture`
- [x] `cargo test -p rustbgpd-rib evpn_policy_added_no_advertise_withdraws_exact_prior -- --nocapture`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- [x] `git diff --check`
- [x] Interop intentionally not required: the change is family-local RIB staging and the actor regressions assert the emitted EVPN announce/withdraw transactions.
- [x] Performance receipt intentionally not applicable.

## Docs / release notes

- [x] `CHANGELOG.md` updated
- [x] `docs/RFC_NOTES.md` updated
- [x] `ROADMAP.md` intentionally unchanged; it has no LAN-444-specific completion line

## Related issues

Linear: LAN-444
