### PR TITLE
fix(rib): enforce FlowSpec export policy parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- FlowSpec exports now enforce source and policy-added `NO_ADVERTISE`, apply
+  generic export-policy path-attribute modifications, ignore inapplicable
+  next-hop rewrites, and withdraw only the exact prior `(AFI, rule)` identity.
 - EVPN exports now enforce stored-route `NO_ADVERTISE` before policy and
   policy-added `NO_ADVERTISE` before Adj-RIB-Out commit, withdrawing only the
   exact prior advertisement and remaining silent for first-seen suppression.

--- a/crates/rib/src/manager/distribution/flowspec.rs
+++ b/crates/rib/src/manager/distribution/flowspec.rs
@@ -175,7 +175,8 @@ impl RibManager {
     /// for initial table dump and ROUTE-REFRESH responses.
     #[expect(
         clippy::too_many_arguments,
-        reason = "FlowSpec staging mirrors unicast distribution context"
+        clippy::too_many_lines,
+        reason = "FlowSpec staging keeps the family-local export ladder together"
     )]
     pub(in crate::manager) fn stage_flowspec_rules(
         loc_rib: &LocRib,
@@ -202,6 +203,15 @@ impl RibManager {
             if let Some(best) = loc_rib.get_flowspec(key) {
                 let fs_family = (best.afi, Safi::FlowSpec);
                 if !sendable.is_some_and(|f| f.contains(&fs_family)) {
+                    if rib_out.get_flowspec(key).is_some() {
+                        fs_withdraw.push(key.clone());
+                    }
+                    continue;
+                }
+
+                // RFC 1997: NO_ADVERTISE is a pre-policy export restriction.
+                // A permit policy cannot remove it to make the rule eligible.
+                if super::no_advertise_export_suppressed(best.communities()) {
                     if rib_out.get_flowspec(key).is_some() {
                         fs_withdraw.push(key.clone());
                     }
@@ -294,7 +304,28 @@ impl RibManager {
                     rustbgpd_policy::evaluate_chain_with_attribution(export_pol, &ctx);
                 record_export_policy_eval(metrics, policy_stats, target_peer_label, &evaluation);
                 if result.action == rustbgpd_policy::PolicyAction::Permit {
-                    fs_announce.push(best.clone());
+                    let mut modified = best.clone();
+                    if !result.modifications.is_empty() {
+                        let mut modifications = result.modifications.clone();
+                        // RFC 8955/8956 FlowSpec MP_REACH carries NH-Len 0.
+                        // The shared helper's IPv4 next-hop support would
+                        // otherwise insert a legacy NEXT_HOP path attribute.
+                        modifications.set_next_hop = None;
+                        if !modifications.is_empty() {
+                            let next_hop = rustbgpd_policy::apply_modifications(
+                                &mut modified.attributes,
+                                &modifications,
+                            );
+                            debug_assert!(next_hop.is_none());
+                        }
+                    }
+                    if super::no_advertise_export_suppressed(modified.communities()) {
+                        if rib_out.get_flowspec(key).is_some() {
+                            fs_withdraw.push(key.clone());
+                        }
+                        continue;
+                    }
+                    fs_announce.push(modified);
                 } else if rib_out.get_flowspec(key).is_some() {
                     fs_withdraw.push(key.clone());
                 }

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -692,8 +692,8 @@ fn llgr_stale_export_suppressed(
 /// source route is ineligible before export policy can remove the community,
 /// and a modified route is ineligible when policy adds it. This predicate is
 /// deliberately target-independent: every supported unicast, VPN,
-/// labeled-unicast, RT-Constrain, and BGP-LS selection shape applies both
-/// checks.
+/// labeled-unicast, `FlowSpec`, EVPN, RT-Constrain, and BGP-LS selection shape
+/// applies both checks.
 pub(super) fn no_advertise_export_suppressed(communities: &[u32]) -> bool {
     communities.contains(&rustbgpd_wire::COMMUNITY_NO_ADVERTISE)
 }

--- a/crates/rib/src/manager/tests/flowspec.rs
+++ b/crates/rib/src/manager/tests/flowspec.rs
@@ -793,3 +793,320 @@ async fn flowspec_llgr_eor_sweeps_non_readvertised() {
     drop(tx);
     handle.await.unwrap();
 }
+
+fn with_flowspec_communities(mut route: FlowSpecRoute, communities: Vec<u32>) -> FlowSpecRoute {
+    route
+        .attributes
+        .retain(|attr| !matches!(attr, PathAttribute::Communities(_)));
+    route
+        .attributes
+        .push(PathAttribute::Communities(communities));
+    route
+}
+
+fn flowspec_policy_statement(
+    marker: u32,
+    modifications: rustbgpd_policy::RouteModifications,
+) -> rustbgpd_policy::PolicyStatement {
+    rustbgpd_policy::PolicyStatement {
+        prefix: None,
+        ge: None,
+        le: None,
+        action: rustbgpd_policy::PolicyAction::Permit,
+        match_community: vec![rustbgpd_policy::CommunityMatch::Standard { value: marker }],
+        match_as_path: None,
+        match_neighbor_set: None,
+        match_route_type: None,
+        match_evpn_route_type: None,
+        match_rpki_validation: None,
+        match_aspa_validation: None,
+        match_as_path_length_ge: None,
+        match_as_path_length_le: None,
+        match_local_pref_ge: None,
+        match_local_pref_le: None,
+        match_med_ge: None,
+        match_med_le: None,
+        match_next_hop: None,
+        modifications,
+    }
+}
+
+async fn replace_flowspec_routes(
+    tx: &mpsc::Sender<RibUpdate>,
+    source: IpAddr,
+    routes: Vec<FlowSpecRoute>,
+) {
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: routes,
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_flowspec_routes(tx).await;
+}
+
+/// Source `NO_ADVERTISE` outranks a policy that removes it. Suppression stays
+/// silent until an exact prior `(AFI, rule)` advertisement must be withdrawn.
+///
+/// Break-to-red: deleting the source guard announces the first route; removing
+/// the Adj-RIB-Out membership check emits a first-seen withdrawal; using only
+/// rule identity withdraws the same-looking IPv6 route; wrong-rule or broadened
+/// withdrawal churns the sibling; sticky suppression blocks recovery.
+#[tokio::test]
+async fn flowspec_source_no_advertise_precedes_removal_policy() {
+    let mut removal = rustbgpd_policy::RouteModifications::default();
+    removal
+        .communities_remove
+        .push(rustbgpd_wire::COMMUNITY_NO_ADVERTISE);
+    let policy = rustbgpd_policy::PolicyChain::new(vec![rustbgpd_policy::Policy {
+        entries: vec![flowspec_policy_statement(
+            rustbgpd_wire::COMMUNITY_NO_ADVERTISE,
+            removal,
+        )],
+        default_action: rustbgpd_policy::PolicyAction::Permit,
+    }]);
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let source_addr = Ipv4Addr::new(198, 51, 100, 41);
+    let source = IpAddr::V4(source_addr);
+    let target = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 41));
+    let (out_tx, mut out_rx) = mpsc::channel(16);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        interpret_rfc1997: true,
+        session_id: 0,
+        peer: target,
+        peer_asn: 65100,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: Some(policy),
+        sendable_families: vec![(Afi::Ipv4, Safi::FlowSpec), (Afi::Ipv6, Safi::FlowSpec)],
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let victim = make_destless_flowspec_route(Afi::Ipv4, source_addr, 6);
+    let victim_key = victim.selection_key();
+    let first_scoped =
+        with_flowspec_communities(victim.clone(), vec![rustbgpd_wire::COMMUNITY_NO_ADVERTISE]);
+    replace_flowspec_routes(&tx, source, vec![first_scoped.clone()]).await;
+    assert!(
+        out_rx.try_recv().is_err(),
+        "first-seen scoped rule is silent"
+    );
+
+    let mut changed_scoped = first_scoped;
+    changed_scoped.attributes.push(PathAttribute::Med(41));
+    replace_flowspec_routes(&tx, source, vec![changed_scoped]).await;
+    assert!(
+        out_rx.try_recv().is_err(),
+        "changed-attribute scoped rule remains silent"
+    );
+
+    let sibling = make_destless_flowspec_route(Afi::Ipv4, source_addr, 17);
+    let sibling_key = sibling.selection_key();
+    let mut other_afi = victim.clone();
+    other_afi.afi = Afi::Ipv6;
+    let other_afi_key = other_afi.selection_key();
+    replace_flowspec_routes(&tx, source, vec![victim.clone(), sibling, other_afi]).await;
+    let plain = out_rx.try_recv().expect("plain rules advertise");
+    assert_eq!(plain.flowspec_announce.len(), 3);
+    assert!(plain.flowspec_withdraw.is_empty());
+    for key in [&victim_key, &sibling_key, &other_afi_key] {
+        assert!(
+            plain
+                .flowspec_announce
+                .iter()
+                .any(|route| route.selection_key() == *key)
+        );
+    }
+
+    let scoped_replacement =
+        with_flowspec_communities(victim.clone(), vec![rustbgpd_wire::COMMUNITY_NO_ADVERTISE]);
+    replace_flowspec_routes(&tx, source, vec![scoped_replacement]).await;
+    let withdrawn = out_rx
+        .try_recv()
+        .expect("source restriction withdraws exact prior rule");
+    assert!(withdrawn.flowspec_announce.is_empty());
+    assert_eq!(withdrawn.flowspec_withdraw, vec![victim_key.clone()]);
+
+    let recovered = with_flowspec_communities(victim, vec![(65000u32 << 16) | 0x01BD]);
+    replace_flowspec_routes(&tx, source, vec![recovered]).await;
+    let recovery = out_rx.try_recv().expect("plain rule recovers");
+    assert_eq!(recovery.flowspec_announce.len(), 1);
+    assert_eq!(recovery.flowspec_announce[0].selection_key(), victim_key);
+    assert!(recovery.flowspec_withdraw.is_empty());
+    assert!(
+        out_rx.try_recv().is_err(),
+        "sibling and IPv6 rule do not churn"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Export modifications apply to `FlowSpec` except `set_next_hop`, and a
+/// policy-added `NO_ADVERTISE` suppresses or withdraws only the exact prior.
+///
+/// Break-to-red: deleting modification application loses every rewritten
+/// attribute; deleting the post-policy guard announces scoped rules; removing
+/// the membership check emits a first-seen withdrawal; passing `set_next_hop`
+/// to the shared helper inserts legacy `NEXT_HOP`; wrong/broad withdrawal churns
+/// the sibling; sticky suppression blocks both recovery announcements.
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one actor sequence proves modification, suppression, withdrawal, and recovery semantics"
+)]
+async fn flowspec_policy_modifications_suppress_and_recover_without_next_hop() {
+    let suppress_marker = (65000u32 << 16) | 0x01BD;
+    let permit_marker = (65000u32 << 16) | 0x01BE;
+    let added_standard = (65000u32 << 16) | 0x01BF;
+    let added_large = rustbgpd_wire::LargeCommunity::new(65000, 4, 45);
+    let modifications = rustbgpd_policy::RouteModifications {
+        set_local_pref: Some(275),
+        set_med: Some(44),
+        set_next_hop: Some(rustbgpd_policy::NextHopAction::Specific(IpAddr::V4(
+            Ipv4Addr::new(203, 0, 113, 44),
+        ))),
+        communities_add: vec![added_standard],
+        large_communities_add: vec![added_large],
+        as_path_prepend: Some((64512, 2)),
+        ..rustbgpd_policy::RouteModifications::default()
+    };
+    let mut suppress_modifications = modifications.clone();
+    suppress_modifications
+        .communities_add
+        .push(rustbgpd_wire::COMMUNITY_NO_ADVERTISE);
+    let policy = rustbgpd_policy::PolicyChain::new(vec![rustbgpd_policy::Policy {
+        entries: vec![
+            flowspec_policy_statement(suppress_marker, suppress_modifications),
+            flowspec_policy_statement(permit_marker, modifications),
+        ],
+        default_action: rustbgpd_policy::PolicyAction::Permit,
+    }]);
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let source_addr = Ipv4Addr::new(198, 51, 100, 42);
+    let source = IpAddr::V4(source_addr);
+    let target = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 42));
+    let (out_tx, mut out_rx) = mpsc::channel(16);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        interpret_rfc1997: true,
+        session_id: 0,
+        peer: target,
+        peer_asn: 65100,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: Some(policy),
+        sendable_families: ipv4_flowspec_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let mut victim = make_flowspec_route(source_addr);
+    victim.attributes.push(PathAttribute::AsPath(AsPath {
+        segments: vec![AsPathSegment::AsSequence(vec![65001])],
+    }));
+    let victim_key = victim.selection_key();
+    let sibling = make_flowspec_route_alt(source_addr);
+    let sibling_key = sibling.selection_key();
+    let scoped = with_flowspec_communities(victim.clone(), vec![suppress_marker]);
+    replace_flowspec_routes(&tx, source, vec![scoped.clone(), sibling]).await;
+    let first = out_rx.try_recv().expect("unscoped sibling advertises");
+    assert_eq!(first.flowspec_announce.len(), 1);
+    assert_eq!(first.flowspec_announce[0].selection_key(), sibling_key);
+    assert!(first.flowspec_withdraw.is_empty());
+
+    let mut changed_scoped = scoped;
+    changed_scoped
+        .attributes
+        .push(PathAttribute::LocalPref(999));
+    replace_flowspec_routes(&tx, source, vec![changed_scoped]).await;
+    assert!(
+        out_rx.try_recv().is_err(),
+        "changed-attribute policy-scoped rule remains silent"
+    );
+
+    let assert_modified = |route: &FlowSpecRoute| {
+        assert_eq!(route.local_pref_attr(), Some(275));
+        assert_eq!(route.med_attr(), Some(44));
+        assert!(route.communities().contains(&added_standard));
+        assert!(route.large_communities().contains(&added_large));
+        assert_eq!(
+            route.as_path().unwrap().segments,
+            vec![AsPathSegment::AsSequence(vec![64512, 64512, 65001])]
+        );
+        assert!(
+            route
+                .attributes
+                .iter()
+                .all(|attr| !matches!(attr, PathAttribute::NextHop(_))),
+            "FlowSpec must not acquire legacy NEXT_HOP"
+        );
+    };
+
+    let permitted = with_flowspec_communities(victim.clone(), vec![permit_marker]);
+    replace_flowspec_routes(&tx, source, vec![permitted]).await;
+    let recovery = out_rx.try_recv().expect("permitted rule recovers");
+    assert_eq!(recovery.flowspec_announce.len(), 1);
+    assert_eq!(recovery.flowspec_announce[0].selection_key(), victim_key);
+    assert_modified(&recovery.flowspec_announce[0]);
+
+    let rescoped = with_flowspec_communities(victim.clone(), vec![suppress_marker]);
+    replace_flowspec_routes(&tx, source, vec![rescoped.clone()]).await;
+    let withdrawn = out_rx
+        .try_recv()
+        .expect("post-policy restriction withdraws exact prior rule");
+    assert!(withdrawn.flowspec_announce.is_empty());
+    assert_eq!(withdrawn.flowspec_withdraw, vec![victim_key.clone()]);
+
+    let mut changed_again = rescoped;
+    changed_again.attributes.push(PathAttribute::Med(999));
+    replace_flowspec_routes(&tx, source, vec![changed_again]).await;
+    assert!(
+        out_rx.try_recv().is_err(),
+        "repeated suppression stays silent"
+    );
+
+    let recovered_again = with_flowspec_communities(victim, vec![permit_marker]);
+    replace_flowspec_routes(&tx, source, vec![recovered_again]).await;
+    let final_recovery = out_rx.try_recv().expect("rule recovers again");
+    assert_eq!(final_recovery.flowspec_announce.len(), 1);
+    assert_eq!(
+        final_recovery.flowspec_announce[0].selection_key(),
+        victim_key
+    );
+    assert_modified(&final_recovery.flowspec_announce[0]);
+    assert!(final_recovery.flowspec_withdraw.is_empty());
+    assert!(out_rx.try_recv().is_err(), "sibling rule does not churn");
+
+    drop(tx);
+    handle.await.unwrap();
+}

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -18,7 +18,7 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 | Core BGP | RFC 4271, RFC 6793 (4-byte ASN), RFC 7606 (revised error handling) | FSM + UPDATE validation with treat-as-withdraw / attribute-discard, dual-stack IPv4/IPv6 unicast (SAFI 1) |
 | MP-BGP + extensions | RFC 4760, RFC 7911 (Add-Path), RFC 8654 (Extended Messages), RFC 8950 (Extended Next Hop) | Multiprotocol negotiation and modern capability set |
 | Route refresh / filtering | RFC 2918, RFC 7313 (Enhanced RR), RFC 5291/5292 (ORF) | Receive-side Address-Prefix ORF |
-| Communities | RFC 1997 (well-known), RFC 4360 (Extended), RFC 8092 (Large) | Match plus policy set/remove; `NO_ADVERTISE` egress enforcement for unicast, VPNv4/VPNv6, labeled-unicast, RTC, BGP-LS, and EVPN; `NO_EXPORT`/`NO_EXPORT_SUBCONFED` enforcement for the same set except EVPN |
+| Communities | RFC 1997 (well-known), RFC 4360 (Extended), RFC 8092 (Large) | Match plus policy set/remove; `NO_ADVERTISE` egress enforcement for unicast, VPNv4/VPNv6, labeled-unicast, RTC, BGP-LS, EVPN, and FlowSpec; `NO_EXPORT`/`NO_EXPORT_SUBCONFED` enforcement for the same set except EVPN and FlowSpec |
 | Route reflection | RFC 4456, RFC 9107 (ORR, ADR-0095) | Per-client best paths via BGP-LS-sourced SPF |
 | Route server (IXP) | RFC 7947 (ADR-0039/0101), RFC 8195 | Transparent redistribution, §2.3.2 per-client best-path, member-set control communities (per-target announce/prepend steering, scrubbed on egress) |
 | Graceful restart | RFC 4724 (GR helper), RFC 9494 (LLGR) | Stale retention across all RR families; no forwarding-state preservation |
@@ -36,11 +36,11 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 ## RFC 1997 — well-known community export coverage
 
 - IPv4/IPv6 unicast, VPNv4/VPNv6, labeled-unicast, RTC, BGP-LS SAFI 71/72,
-  and EVPN routes carrying `NO_ADVERTISE` in their stored route attributes are
-  ineligible toward every target before export policy, and the post-policy
-  route is checked again before Adj-RIB-Out commit. A permit policy cannot
-  remove the community to bypass the restriction; rustbgpd also conservatively
-  suppresses a modified route when export policy adds it.
+  EVPN, and FlowSpec routes carrying `NO_ADVERTISE` in their stored route
+  attributes are ineligible toward every target before export policy, and the
+  post-policy route is checked again before Adj-RIB-Out commit. A permit policy
+  cannot remove the community to bypass the restriction; rustbgpd also
+  conservatively suppresses a modified route when export policy adds it.
 - `NO_EXPORT` (0xFFFFFF01) and `NO_EXPORT_SUBCONFED` (0xFFFFFF03) are enforced
   at eBGP egress for IPv4/IPv6 unicast, VPNv4/VPNv6, labeled-unicast, RTC, and
   BGP-LS: a route received with either community is suppressed at staging
@@ -69,9 +69,9 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 - The same predicate covers single-best plus Add-Path for unicast, VPN, and
   labeled routes; grouped/private and RFC 7947 per-client-best shapes apply to
   unicast, grouped/private applies to VPN, and RFC 9107 ORR applies to unicast
-  and labeled-unicast. RTC, both BGP-LS SAFIs, and EVPN use their single-best
-  export paths. Existing advertisements are withdrawn and logical Adj-RIB-Out
-  state is cleared.
+  and labeled-unicast. FlowSpec, RTC, both BGP-LS SAFIs, and EVPN use their
+  single-best export paths. Existing advertisements are withdrawn and logical
+  Adj-RIB-Out state is cleared.
 - Add-Path and per-client-best remove scoped candidates before ranking, so
   surviving siblings compact normally. They also skip policy-modified
   candidates whose result carries `NO_ADVERTISE`. ORR single-best first
@@ -90,8 +90,7 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
   mechanics are correct and fail-closed — the amplification is inherent to
   SAFI 132, where one NLRI stands for the whole class of VPN routes carrying
   that RT.
-- `NO_EXPORT` enforcement for EVPN, and `NO_ADVERTISE` / `NO_EXPORT`
-  enforcement for FlowSpec, remain deferred.
+- `NO_EXPORT` enforcement for EVPN and FlowSpec remains deferred.
 
 ---
 

--- a/docs/adr/0035-flowspec.md
+++ b/docs/adr/0035-flowspec.md
@@ -100,6 +100,16 @@ structured `FlowSpecAction` messages and converts them to the
 appropriate extended community encoding. Existing extended community
 wire codec and RIB storage handle these transparently.
 
+FlowSpec routes also retain ordinary BGP path attributes used by selection and
+policy, including `AS_PATH`, `LOCAL_PREF`, `MED`, and standard, extended, and
+large communities. Export policy applies those generic modifications while
+existing extended-community edits remain opaque path-attribute edits and can
+alter or remove the already-supported FlowSpec action communities. This adds
+no new action syntax, interpretation, or dataplane behavior. A configured
+`set_next_hop` is intentionally ignored for FlowSpec: RFC 8955/8956 MP_REACH
+uses NH-Len 0, so neither a route next-hop nor a legacy IPv4 `NEXT_HOP` path
+attribute is synthesized.
+
 ### Reuse of existing infrastructure
 
 FlowSpec routes flow through the same infrastructure as unicast:


### PR DESCRIPTION
## Summary

- enforce source and policy-added `NO_ADVERTISE` for FlowSpec exports
- apply existing export-policy path-attribute modifications while ignoring inapplicable next-hop rewrites
- withdraw only the exact prior `(AFI, rule)` identity and document the remaining FlowSpec export boundary

## Load-bearing regression proof

Two actor state machines cover source-policy precedence and post-policy modification/suppression. The following guarded breaks were each injected and made the corresponding test red before being restored:

- source guard deletion
- modification application deletion
- post-policy guard deletion
- Adj-RIB-Out membership removal
- wrong AFI identity
- wrong rule identity
- broadened withdrawal
- sticky recovery
- passing `set_next_hop` through to the shared helper

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- focused FlowSpec actor regressions
- `git diff --check`