### PR TITLE
perf: build rejected-route prototypes lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Rejected-route retention now builds its bounded attribute prototype lazily
+  on the first actual rejection in an UPDATE, avoiding reject-only summary and
+  timestamp construction on clean permitted UPDATEs while preserving one
+  shared prototype per rejected batch.
 - FlowSpec exports now enforce source and policy-added `NO_ADVERTISE`, apply
   generic export-policy path-attribute modifications, ignore inapplicable
   next-hop rewrites, and withdraw only the exact prior `(AFI, rule)` identity.

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -661,6 +661,36 @@ impl PeerSession {
         entry
     }
 
+    /// Build the bounded prototype shared by one UPDATE's retained rejects.
+    #[allow(clippy::unused_self, reason = "test-only build counter uses self")]
+    fn build_rejected_route_prototype(
+        &self,
+        (as_path, communities, large_communities): (
+            Option<&AsPath>,
+            &[u32],
+            &[rustbgpd_wire::LargeCommunity],
+        ),
+    ) -> RejectedRouteEntry {
+        #[cfg(test)]
+        self.rejected_route_prototype_builds
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let mut prototype = RejectedRouteEntry {
+            reason: ImportRejectReason::PolicyReject,
+            detail: None,
+            next_hop: None,
+            as_path: as_path.map(AsPath::to_aspath_string).unwrap_or_default(),
+            communities: communities.to_vec(),
+            communities_dropped: 0,
+            large_communities: large_communities.to_vec(),
+            large_communities_dropped: 0,
+            rpki: rustbgpd_wire::RpkiValidation::NotFound,
+            aspa: rustbgpd_wire::AspaValidation::Unknown,
+            rejected_at: SystemTime::now(),
+        };
+        prototype.enforce_bounds();
+        prototype
+    }
+
     /// Deliver a `RoutesReceived` batch to the RIB manager — block, never
     /// drop (ADR-0078). The fast path is a `try_send`; when the channel
     /// is full the saturation counter increments and the session task
@@ -1771,32 +1801,11 @@ impl PeerSession {
         // happens only on an actual deny, so the clean permit path pays
         // nothing.
         let retention_enabled = self.reject_retention_enabled;
-        // One bounded attribute summary per UPDATE: the AS-path render
-        // and community copies happen exactly once, truncated to the
-        // retention byte caps up front, and every rejected identity
-        // below clones this ≤ 512 B prototype (overriding the per-route
-        // fields) instead of re-deriving unbounded wire data per
-        // identity. Built only when retention is on and only from
-        // already-parsed attributes, so the clean path pays nothing.
-        let reject_proto = retention_enabled.then(|| {
-            let mut proto = RejectedRouteEntry {
-                reason: ImportRejectReason::PolicyReject,
-                detail: None,
-                next_hop: None,
-                as_path: parsed_as_path
-                    .map(AsPath::to_aspath_string)
-                    .unwrap_or_default(),
-                communities: update_communities.to_vec(),
-                communities_dropped: 0,
-                large_communities: update_large_communities.to_vec(),
-                large_communities_dropped: 0,
-                rpki: rustbgpd_wire::RpkiValidation::NotFound,
-                aspa: rustbgpd_wire::AspaValidation::Unknown,
-                rejected_at: SystemTime::now(),
-            };
-            proto.enforce_bounds();
-            proto
-        });
+        // One bounded attribute summary per UPDATE. It is initialized on the
+        // first actual policy, OTC, or ownership rejection; clean permitted
+        // UPDATEs avoid the AS-path render, community copies, and timestamp.
+        let reject_proto_attrs = (parsed_as_path, update_communities, update_large_communities);
+        let mut reject_proto: Option<RejectedRouteEntry> = None;
         let mut rejected_retained: Vec<(Prefix, u32, RejectedRouteEntry)> = Vec::new();
         // A denied announcement replaces any prior accepted path under the
         // same wire identity; retire it after explicit withdrawals below.
@@ -1879,7 +1888,10 @@ impl PeerSession {
                         ));
                     }
                     if result.action != rustbgpd_policy::PolicyAction::Permit {
-                        if let Some(proto) = reject_proto.as_ref() {
+                        if retention_enabled {
+                            let proto = reject_proto.get_or_insert_with(|| {
+                                self.build_rejected_route_prototype(reject_proto_attrs)
+                            });
                             let mut reject_entry = proto.clone();
                             reject_entry.detail.clone_from(&evaluation.matched_policy);
                             reject_entry.next_hop = Some(body_next_hop);
@@ -2522,7 +2534,10 @@ impl PeerSession {
                                 aspa_context,
                             });
                         } else {
-                            if let Some(proto) = reject_proto.as_ref() {
+                            if retention_enabled {
+                                let proto = reject_proto.get_or_insert_with(|| {
+                                    self.build_rejected_route_prototype(reject_proto_attrs)
+                                });
                                 let mut reject_entry = proto.clone();
                                 reject_entry.detail.clone_from(&evaluation.matched_policy);
                                 reject_entry.next_hop = Some(mp.next_hop);
@@ -2642,10 +2657,12 @@ impl PeerSession {
         // bounded per-UPDATE prototype — the attribute summary is
         // identical across the rejected identities, so each identity
         // clones the ≤ 512 B prototype instead of re-deriving it.
-        if let Some(proto) = reject_proto.as_ref() {
+        if retention_enabled {
             if let OtcIngressAction::DropUnicastAnnouncements(otc_reason) = otc_action
                 && !otc_rejected_unicast.is_empty()
             {
+                let proto = reject_proto
+                    .get_or_insert_with(|| self.build_rejected_route_prototype(reject_proto_attrs));
                 let mut entry = proto.clone();
                 entry.reason = ImportRejectReason::OtcRouteLeak;
                 entry.detail = Some(otc_reason.as_str().to_owned());
@@ -2656,6 +2673,8 @@ impl PeerSession {
             if let Some((ownership_reason, violating_next_hop, _)) = next_hop_ownership_rejection
                 && !ownership_rejected_unicast.is_empty()
             {
+                let proto = reject_proto
+                    .get_or_insert_with(|| self.build_rejected_route_prototype(reject_proto_attrs));
                 let mut entry = proto.clone();
                 entry.reason = ImportRejectReason::NextHopOwnership;
                 entry.detail = Some(ownership_reason.as_str().to_owned());

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -355,6 +355,8 @@ pub(crate) struct PeerSession {
     /// `[policy.reject_retention].enabled`). Read on the inbound UPDATE
     /// path to skip retention entirely when disabled.
     reject_retention_enabled: bool,
+    #[cfg(test)]
+    rejected_route_prototype_builds: std::sync::atomic::AtomicUsize,
     /// Bounded per-session store of rejected inbound routes with their
     /// reject reason (LAN-472) — the looking-glass filtered-route
     /// surface behind `PolicyService.ListRejectedRoutes`. Cleared on
@@ -970,6 +972,8 @@ impl PeerSession {
                 explain_cache_size,
             ),
             reject_retention_enabled,
+            #[cfg(test)]
+            rejected_route_prototype_builds: std::sync::atomic::AtomicUsize::new(0),
             rejected_routes: rejected_routes::RejectedRouteStore::with_capacity(
                 reject_retention_capacity,
             ),
@@ -1114,6 +1118,8 @@ impl PeerSession {
                 explain_cache_size,
             ),
             reject_retention_enabled,
+            #[cfg(test)]
+            rejected_route_prototype_builds: std::sync::atomic::AtomicUsize::new(0),
             rejected_routes: rejected_routes::RejectedRouteStore::with_capacity(
                 reject_retention_capacity,
             ),

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -14959,9 +14959,12 @@ async fn shared_group_wire_equivalence_proof_ignores_only_byte_inert_fields() {
 /// still flow, a previously accepted identity is retired treat-as-withdraw
 /// style, and a first-seen rejection stays silent. The spoofed UPDATE
 /// carries RFC 7999 BLACKHOLE, pinning ADR-0107 §5: a community is never
-/// an ownership bypass.
+/// an ownership bypass. Break-to-red: eager prototype construction fails the
+/// conforming zero count; per-identity ownership construction fails count one.
 #[tokio::test]
 async fn strict_peer_next_hop_rejects_foreign_ipv4_body_and_withdraws_replacement() {
+    use rustbgpd_telemetry::reason_labels::ImportRejectReason;
+
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     session.config.next_hop_ownership_strict_peer = true;
     session.negotiated = Some(negotiated_session(65002, false));
@@ -15004,6 +15007,7 @@ async fn strict_peer_next_hop_rejects_foreign_ipv4_body_and_withdraws_replacemen
         1,
         "conforming next-hop must be accepted under strict_peer"
     );
+    assert_eq!(rejected_route_prototype_builds(&session), 0);
     // Foreign next-hop (another member's address) + BLACKHOLE: rejected
     // pre-policy; the accepted identity is withdrawn, the first-seen one
     // stays silent, and the explicit withdrawal is preserved.
@@ -15052,6 +15056,18 @@ async fn strict_peer_next_hop_rejects_foreign_ipv4_body_and_withdraws_replacemen
         "first-seen rejections must stay silent"
     );
     assert_eq!(session.known_prefix_count(), 0);
+    let retained = session.rejected_routes.snapshot();
+    assert_eq!(retained.len(), 2);
+    assert_eq!(retained[0].1.rejected_at, retained[1].1.rejected_at);
+    assert_eq!(rejected_route_prototype_builds(&session), 1);
+    for (key, entry) in retained {
+        assert!(
+            key == retention_key(accepted) || key == retention_key(first_seen),
+            "ownership retention must keep each rejected identity"
+        );
+        assert_eq!(entry.reason, ImportRejectReason::NextHopOwnership);
+        assert_eq!(entry.next_hop, Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9))));
+    }
 }
 
 /// ADR-0107 strict-peer over MP IPv6 unicast: a conforming global
@@ -15987,6 +16003,133 @@ fn retention_key(prefix: Ipv4Prefix) -> RetentionKey {
     }
 }
 
+fn rejected_route_prototype_builds(session: &PeerSession) -> usize {
+    session
+        .rejected_route_prototype_builds
+        .load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Clean permitted UPDATEs must not construct reject-only diagnostic state.
+/// Break-to-red: eagerly initializing the prototype makes the build-count
+/// assertion fail, while dropping accepted paths fails the state assertions.
+#[tokio::test]
+async fn reject_retention_permitted_update_builds_no_prototype() {
+    let first = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let second = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let (mut session, _metrics) = retention_session_with_chain(None, |_| {});
+
+    session
+        .process_update(retention_update(&[first, second], &[]))
+        .await;
+
+    assert_eq!(rejected_route_prototype_builds(&session), 0);
+    assert!(session.rejected_routes.is_empty());
+    assert_eq!(session.known_prefix_count(), 2);
+    assert_eq!(session.import_policy_routes_permitted, 2);
+}
+
+/// Body and MP policy denies in one UPDATE share one bounded prototype and
+/// timestamp; the next UPDATE constructs fresh state from its own attributes.
+/// Break-to-red: per-identity construction changes the first count/timestamps;
+/// cross-UPDATE reuse makes the third entry retain the first UPDATE's summary.
+#[tokio::test]
+async fn reject_retention_shares_prototype_across_body_and_mp_policy_denies() {
+    use rustbgpd_wire::{MpReachNlri, NlriEntry};
+
+    let chain = PolicyChain::new(vec![Policy {
+        entries: vec![],
+        default_action: PolicyAction::Deny,
+    }]);
+    let (mut session, _metrics) = retention_session_with_chain(Some(chain), |_| {});
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)];
+    install_test_negotiated_session(&mut session, negotiated);
+    let body = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let mp = Prefix::V6(Ipv6Prefix::new("2001:db8:505::".parse().unwrap(), 64));
+    let later = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+
+    let first_attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+        PathAttribute::Communities(vec![100]),
+        PathAttribute::MpReachNlri(MpReachNlri {
+            afi: Afi::Ipv6,
+            safi: Safi::Unicast,
+            next_hop: "2001:db8::2".parse().unwrap(),
+            link_local_next_hop: None,
+            announced: vec![NlriEntry {
+                path_id: 0,
+                prefix: mp,
+            }],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            labeled_announced: vec![],
+            vpn_announced: vec![],
+            rtc_announced: vec![],
+        }),
+    ];
+    session
+        .process_update(UpdateMessage::build(
+            &[Ipv4NlriEntry {
+                path_id: 0,
+                prefix: body,
+            }],
+            &[],
+            &first_attrs,
+            true,
+            false,
+            Ipv4UnicastMode::Body,
+        ))
+        .await;
+    let entries = session.rejected_routes.snapshot();
+    assert_eq!(entries.len(), 2);
+    assert!(entries.iter().any(|(key, _)| *key == retention_key(body)));
+    assert!(entries.iter().any(|(key, _)| {
+        *key == RetentionKey {
+            afi: Afi::Ipv6,
+            safi: Safi::Unicast,
+            prefix: mp,
+            path_id: 0,
+        }
+    }));
+    assert_eq!(entries[0].1.rejected_at, entries[1].1.rejected_at);
+    assert_eq!(rejected_route_prototype_builds(&session), 1);
+
+    let second_attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002, 65003])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+        PathAttribute::Communities(vec![200]),
+    ];
+    session
+        .process_update(UpdateMessage::build(
+            &[Ipv4NlriEntry {
+                path_id: 0,
+                prefix: later,
+            }],
+            &[],
+            &second_attrs,
+            true,
+            false,
+            Ipv4UnicastMode::Body,
+        ))
+        .await;
+    let entries = session.rejected_routes.snapshot();
+    let later_entry = entries
+        .iter()
+        .find(|(key, _)| *key == retention_key(later))
+        .expect("second UPDATE rejection retained");
+    assert_eq!(rejected_route_prototype_builds(&session), 2);
+    assert_eq!(later_entry.1.as_path, "65002 65003");
+    assert_eq!(later_entry.1.communities, vec![200]);
+}
+
 /// LAN-472 pin: a policy deny retains the route with reason
 /// `policy_reject` and the attribute summary the member-support surface
 /// renders; a permitted sibling in the same UPDATE is not retained. The
@@ -16201,7 +16344,8 @@ async fn reject_retention_cap_evicts_oldest_reject() {
 
 /// LAN-472 pin: `[policy.reject_retention] enabled = false` records
 /// nothing, and the command surface reports the disabled state as a
-/// configuration fact rather than an empty answer.
+/// configuration fact rather than an empty answer. Break-to-red: constructing
+/// despite the off switch makes the prototype-count assertion fail.
 #[tokio::test]
 async fn reject_retention_disabled_records_nothing_and_reports_disabled() {
     let denied = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
@@ -16215,6 +16359,8 @@ async fn reject_retention_disabled_records_nothing_and_reports_disabled() {
     session
         .process_update(retention_update(&[denied], &[]))
         .await;
+    assert_eq!(session.import_policy_routes_denied, 1);
+    assert_eq!(rejected_route_prototype_builds(&session), 0);
     assert!(session.rejected_routes.is_empty());
     assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 0);
 
@@ -16266,18 +16412,26 @@ async fn reject_retention_records_as_path_loop_reason() {
 
 /// LAN-472 pin: an RFC 9234 OTC ingress drop (a pre-policy hygiene
 /// gate) retains the announced identity with the OTC reason token and
-/// the canonical sub-reason detail.
+/// the canonical sub-reason detail. Break-to-red: constructing per rejected
+/// identity makes the shared timestamp or exact build count fail.
 #[tokio::test]
 async fn reject_retention_records_otc_ingress_drop_with_detail() {
     use rustbgpd_telemetry::reason_labels::ImportRejectReason;
-    let dropped = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let first = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let second = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
     let (mut session, metrics) = retention_session_with_chain(None, |_| {});
     session.config.peer.local_role = Some(BgpRole::RouteServer);
     let update = UpdateMessage::build(
-        &[Ipv4NlriEntry {
-            path_id: 0,
-            prefix: dropped,
-        }],
+        &[
+            Ipv4NlriEntry {
+                path_id: 0,
+                prefix: first,
+            },
+            Ipv4NlriEntry {
+                path_id: 0,
+                prefix: second,
+            },
+        ],
         &[],
         &[
             PathAttribute::Origin(Origin::Igp),
@@ -16293,15 +16447,20 @@ async fn reject_retention_records_otc_ingress_drop_with_detail() {
     );
     session.process_update(update).await;
     let entries = session.rejected_routes.snapshot();
-    assert_eq!(entries.len(), 1);
-    assert_eq!(entries[0].0, retention_key(dropped));
-    assert_eq!(entries[0].1.reason, ImportRejectReason::OtcRouteLeak);
-    assert_eq!(
-        entries[0].1.detail.as_deref(),
-        Some("ingress_from_customer_rsclient"),
-        "the canonical OTC sub-reason token rides in the detail field"
-    );
-    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 1);
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].1.rejected_at, entries[1].1.rejected_at);
+    assert_eq!(rejected_route_prototype_builds(&session), 1);
+    for (key, entry) in entries {
+        assert!(key == retention_key(first) || key == retention_key(second));
+        assert_eq!(entry.reason, ImportRejectReason::OtcRouteLeak);
+        assert_eq!(entry.next_hop, None, "OTC does not invent a next-hop");
+        assert_eq!(
+            entry.detail.as_deref(),
+            Some("ingress_from_customer_rsclient"),
+            "the canonical OTC sub-reason token rides in the detail field"
+        );
+    }
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 2);
 }
 
 /// LAN-472 pin: the retention store is per-session diagnostic state —

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1963,6 +1963,10 @@ capacity = 1024
 | `enabled`  | bool    | no       | `true`  | Gates retention entirely. When `false`, the reject paths skip entry construction (one boolean check per gate) and the query surface reports the disabled state as a configuration fact rather than an empty answer. |
 | `capacity` | integer | no       | `1024`  | Per-peer retention cap, LRU on rejection recency — a reject storm converges on the most recent `capacity` rejections. Each entry is one rejected `(AFI, SAFI, prefix, path_id)` with its reason and a compact attribute summary, ≤ ~512 bytes realistic worst case ⇒ ~0.5 MiB bound per peer at the default. Raise it toward the expected member announcement count for full coverage on route-server fleets. |
 
+With retention enabled, a clean permitted UPDATE does not construct a
+rejection summary. The first policy, OTC, or next-hop-ownership rejection in
+an UPDATE builds one bounded prototype shared by that UPDATE's identities.
+
 Like `[policy.explain]`, this is **diagnostic state only** — it never
 affects which routes are accepted. Scope is IPv4 / IPv6 unicast
 (max-prefix violations tear the session down, so there is no per-route


### PR DESCRIPTION
## Summary

- defer the bounded rejected-route attribute prototype until an UPDATE actually rejects a route
- share one prototype across body policy, MP policy, OTC, and next-hop ownership rejects in the same UPDATE
- preserve per-identity rejection details while keeping clean permitted UPDATEs free of reject-only summary work
- document the retention construction model

## Root cause

Rejected-route retention initialized its AS-path string, bounded community copies, and timestamp for every retention-enabled UPDATE even when every route was permitted. The implementation comment promised a zero-cost clean path, but the prototype was created before any rejection was known.

## Operator impact

Clean accepted UPDATEs no longer construct diagnostic state that will be discarded. Rejected routes retain the same bounded summaries, reasons, per-route validation state, and one shared timestamp per UPDATE.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- `git diff --check`
- independent focused transport audit and full transport test suite

## Load-bearing regression proof

Each mutation was applied, observed red, then restored: eager construction; per-identity body, MP, OTC, and ownership construction; cross-UPDATE prototype reuse; omitted MP retention; and construction while retention is disabled. Existing maximal attribute-bound coverage remains green.

Linear: LAN-505