### PR TITLE
fix(renderer): translate timed max-prefix restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   generation-fenced restart attempt after the hold-down, invalidates stale
   countdowns on config or dynamic-range replacement, and exposes the action,
   configured duration, and remaining milliseconds through gRPC, CLI, and JSON.
+  `rs-config-render` maps ARouteServer's OpenBGPD-style `restart_after` minutes
+  to checked seconds and records the emitted timer in its render receipt.
 
 - **Operator dashboard and alerting cover slow peers and RIB actor latency.**
   The shipped Grafana overview now separates transport endpoints from bare

--- a/docs/adr/0110-irr-peeringdb-filtering-pipeline.md
+++ b/docs/adr/0110-irr-peeringdb-filtering-pipeline.md
@@ -176,7 +176,7 @@ lands (ADR-0107 and the community-based announcement-control track).
 | IRR origin-AS enforcement | `route.origin-as` accessor (`==`/`!=`/asn-set `in`, three-valued on absent origin) + indexed `asn-set` | Shipped (#757; the gap claimed in earlier drafts was stale — verified end-to-end with docs and tests) |
 | RPKI ROA validation via RTR (RFC 6811/8097) | `[rpki.cache_servers]`, `route.rpki == valid\|invalid\|not-found`, `OV_*` ext-community tagging | Shipped |
 | RPKI ROAs merged as route objects | generator-side (arouteserver does the merge) | N/A to daemon |
-| Max-prefix, per client per family | `max_prefixes_ipv4`/`_ipv6` (+aggregate), Cease/1 with RFC 4486 data | Shipped (ADR-0108). **Partial:** shutdown only; the renderer refuses arouteserver's timed `restart` action until the daemon has a timed hold-down, because operator-latched shutdown is not equivalent |
+| Max-prefix, per client per family | `max_prefixes_ipv4`/`_ipv6` (+aggregate), Cease/1 with RFC 4486 data | Shipped (ADR-0108), including ARouteServer's OpenBGPD-style timed `restart` action with checked minute-to-second conversion |
 | NEXT_HOP enforcement, `strict` | pre-policy ownership gate | In flight (ADR-0107 strict pilot) |
 | NEXT_HOP enforcement, `same-as` | fleet inventory mode | **Gap:** explicitly deferred by ADR-0107 until the inventory exists; renderer must reject `next_hop.policy: same-as` until then |
 | Max AS_PATH length | `match_as_path_length_le` / `route.as-path.len` | Shipped |
@@ -200,11 +200,9 @@ lands (ADR-0107 and the community-based announcement-control track).
 | Operator local-customization hooks (`.local` files) | rpol `import` + `rpol_roots` for policy; **TOML has no include** — the renderer owns the whole TOML and must provide merge-in points itself | Design point for the renderer, not a daemon gap |
 
 Summary: after the two in-flight tracks land, every load-bearing axis is
-covered by shipped primitives except four bounded items — origin-AS
-accessor (small language addition), max-prefix restart action (ADR-0108
-deferral), NEXT_HOP same-AS (ADR-0107 deferral, renderer-rejected until
-then), and looking-glass reject-reason retention (separate adoption-track
-item). None blocks a first pilot at OpenBGPD-equivalence level.
+covered by shipped primitives except two bounded items — NEXT_HOP same-AS
+(ADR-0107 deferral, renderer-rejected until then), and looking-glass reject-reason
+retention (separate adoption-track item). Neither blocks a pilot; active ceilings remain accepted-route-only.
 
 ### Delivery plan
 
@@ -241,7 +239,7 @@ item). None blocks a first pilot at OpenBGPD-equivalence level.
    freshness").
 
 **Phase 2 — parity and upstream (after a pilot transcript exists):**
-max-prefix restart-timer action; reject-reason retention wiring for the
+reject-reason retention wiring for the
 looking-glass surface; offer the template package + builder upstream.
 
 **Phase 3 — demand-gated:** bgpq4-JSON→rpol native converter; PeeringDB
@@ -295,5 +293,4 @@ exists.
   arouteserver-target deferral and RTT-community reject
 - [ADR-0107](0107-route-server-next-hop-ownership.md) — NEXT_HOP
   ownership (strict pilot in flight; same-AS deferred)
-- [ADR-0108](0108-per-family-max-prefix-limits.md) — per-family
-  max-prefix (restart action deferred)
+- [ADR-0108](0108-per-family-max-prefix-limits.md) — per-family max-prefix and timed restart

--- a/docs/cookbook/ixp-filter-pipeline.md
+++ b/docs/cookbook/ixp-filter-pipeline.md
@@ -47,24 +47,27 @@ Install and configure arouteserver itself per its
 [documentation][arouteserver] (`arouteserver setup`, then your
 `general.yml` / `clients.yml`).
 
-rustbgpd currently implements ARouteServer's shutdown action with
-post-import-policy prefix accounting. Configure that model explicitly;
-the renderer refuses `restart`, `block`, `warning`, or rejected-route
-counting instead of silently changing their behavior:
+rustbgpd implements ARouteServer's shutdown and OpenBGPD-style timed-restart
+actions with post-import-policy prefix accounting. ARouteServer's BIRD target
+restarts immediately and ignores `restart_after`; this is not BIRD timed parity.
+Configure the model explicitly; the renderer refuses `block`, `warning`, or
+rejected-route counting instead of silently changing their behavior:
 
 ```yaml
 cfg:
   filtering:
     max_prefix:
-      action: shutdown
+      action: restart
+      restart_after: 15 # ARouteServer minutes; rendered as 900 seconds
       count_rejected_routes: false
 ```
 
 An absent effective action disables max-prefix enforcement even when
 ARouteServer leaves resolved limit values in the context; a zero family
-limit is likewise treated as unset. ARouteServer 1.23.2 defaults
-`count_rejected_routes` to `true`, so an active positive shutdown limit must
-set it explicitly to `false` for rustbgpd's accepted-route accounting model.
+limit is likewise treated as unset, and a restart timer is emitted only with a
+positive family limit. ARouteServer 1.23.2 defaults `count_rejected_routes` to
+`true`, so an active positive shutdown or restart limit must set it explicitly
+to `false` for rustbgpd's accepted-route accounting model.
 
 The command's output format is arouteserver's, not ours: 1.23.2 emits
 a *sectioned report* (per-key heading plus a YAML fragment). The

--- a/tests/rs_config_render_emitted_check.rs
+++ b/tests/rs_config_render_emitted_check.rs
@@ -26,6 +26,9 @@ fn untouched_fixture_aborts_on_the_empty_irr_bundle() {
 }
 
 #[test]
+/// Load-bearing proof: dropping the active family ceiling or 37-minute to
+/// 2,220-second conversion breaks the exact assertions; emitting a daemon-
+/// invalid timer breaks the real `rustbgpd --check` invocation.
 fn emitted_config_passes_rustbgpd_check() {
     // Drop the abort-proving client, then render the healthy context.
     let mut value: serde_yaml::Value = serde_yaml::from_str(FIXTURE).expect("fixture parses");
@@ -37,8 +40,24 @@ fn emitted_config_passes_rustbgpd_check() {
         .as_mapping_mut()
         .expect("irrdb_info mapping")
         .remove(serde_yaml::Value::String("AS51325_bundle".to_owned()));
+    value["cfg"]["filtering"]["max_prefix"]["action"] = "restart".into();
+    value["cfg"]["filtering"]["max_prefix"]["restart_after"] = 37.into();
+    value["cfg"]["filtering"]["max_prefix"]["count_rejected_routes"] = false.into();
     let yaml = serde_yaml::to_string(&value).expect("context serializes");
     let rendered = render(&yaml, &rtr_options()).expect("healthy context renders");
+    assert!(
+        rendered.files["config.toml"]
+            .contains("max_prefixes_ipv6 = 1000\nmax_prefix_restart_seconds = 2220"),
+        "{}",
+        rendered.files["config.toml"]
+    );
+    let client = rendered.receipt["clients"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|client| client["id"] == "AS197000_1")
+        .unwrap();
+    assert_eq!(client["max_prefix_restart_seconds"], 2220);
 
     let out_dir = tempfile::tempdir().expect("tempdir");
     for (rel_path, contents) in &rendered.files {

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -56,10 +56,10 @@ and against a live run of the pinned arouteserver image by
 
 | File | Contents |
 |---|---|
-| `config.toml` | RS globals, RPKI cache servers, one `[[neighbors]]` per client: transparent `route_server_client` session, `role = "route_server"`, strict next-hop ownership, per-family max-prefix ceilings, per-client import policy chain, `per_client_best` (or Add-Path when the context enables it) |
+| `config.toml` | RS globals, RPKI cache servers, one `[[neighbors]]` per client: transparent `route_server_client` session, `role = "route_server"`, strict next-hop ownership, per-family max-prefix ceilings and OpenBGPD-style timed restart, per-client import policy chain, `per_client_best` (or Add-Path when the context enables it) |
 | `policy/rs-hygiene.rpol` | Shared import hygiene: reject AS_SET segments (always the first term), invalid/private/reserved ASNs in the path, transit-free and never-via-route-servers ASNs, AS_PATH length cap, bogon and black-list prefixes, prefix-length windows, RPKI origin validation with RFC 8097 tagging |
 | `policy/client-<id>.rpol` | The client's IRR-derived `prefix-set` and origin `asn-set`, one accept term (`route.origin-as in … && route.prefix in …`), and an unconditional reject tail |
-| `render-receipt.json` | Render timestamp, context fingerprint, per-client set cardinalities and max-prefix ceilings, warnings |
+| `render-receipt.json` | Render timestamp, context fingerprint, per-client set cardinalities, max-prefix ceilings and restart seconds, warnings |
 
 Every generated `.rpol` file carries in-language `test` blocks derived
 from the site's own data; `rbgp policy check` runs them.
@@ -110,16 +110,17 @@ has no RTT source; permanent), `next_hop.policy` other than `strict`
 `tag`/`tag_and_reject` (reject-reason community wiring is a tracked
 follow-up; the daemon retains rejected routes with reasons natively —
 see the route-server cookbook's filtered-route view), `prepend_rs_as`,
-`perform_graceful_shutdown`, `max_prefix.action` `restart`/`block`/`warning`,
+`perform_graceful_shutdown`, `max_prefix.action` `block`/`warning`,
 and an effective `max_prefix.count_rejected_routes: true` while a positive
-shutdown limit is active (ARouteServer 1.23.2 defaults this option to true,
+shutdown or restart limit is active (ARouteServer 1.23.2 defaults this option to true,
 while rustbgpd counts accepted routes only),
 per-client `black_list_pref` and IRR `white_list_*` entries (dropping
 a black list would fail open; dropping a white list would reject
 routes the site intends to accept), and disabling both IRR
-enforcement knobs. Only `max_prefix.action: shutdown` is rendered;
-an absent effective action emits no max-prefix ceilings, and zero is
-treated as an unset per-family limit.
+enforcement knobs. `shutdown` emits the positive family ceilings;
+`restart` additionally requires a positive `restart_after` in minutes, checked
+while converting to `u32` seconds. An absent action or zero family limits emit
+neither ceilings nor a restart timer.
 
 An empty per-client prefix or origin set aborts the whole render: an
 empty set under the default-reject tail is fail-closed for that client,

--- a/tools/rs-config-render/src/lib.rs
+++ b/tools/rs-config-render/src/lib.rs
@@ -835,6 +835,7 @@ struct ResolvedClient<'a> {
     allow_longer_prefixes: bool,
     limit_ipv4: Option<u32>,
     limit_ipv6: Option<u32>,
+    max_prefix_restart_seconds: Option<u32>,
 }
 
 pub fn render(context_input: &str, opts: &Options) -> Result<Rendered, RenderError> {
@@ -1110,21 +1111,26 @@ fn check_max_prefix_action(
 ) {
     match action {
         None | Some("shutdown") => {}
-        Some("restart") => {
-            let timer = restart_after
-                .map(|minutes| format!(" with restart_after={minutes} minutes"))
-                .unwrap_or_default();
-            refusals.push(format!(
-                "{scope}: max_prefix.action `restart`{timer} is not supported; rustbgpd \
-                 only implements shutdown and has no timed max-prefix restart"
-            ));
-        }
+        Some("restart") => match restart_after {
+            None => refusals.push(format!(
+                "{scope}: max_prefix.action `restart` requires restart_after > 0 minutes"
+            )),
+            Some(0) => refusals.push(format!(
+                "{scope}: max_prefix.action `restart` requires restart_after > 0 minutes"
+            )),
+            Some(minutes) if minutes.checked_mul(60).is_none() => refusals.push(format!(
+                "{scope}: max_prefix.restart_after={minutes} minutes exceeds rustbgpd's \
+                 u32-second maximum"
+            )),
+            Some(_) => {}
+        },
         Some(other @ ("block" | "warning")) => refusals.push(format!(
             "{scope}: max_prefix.action `{other}` is not supported; rustbgpd only \
-             implements shutdown"
+             implements `shutdown` and timed `restart`"
         )),
         Some(other) => refusals.push(format!(
-            "{scope}: unknown max_prefix.action `{other}` (only `shutdown` is supported)"
+            "{scope}: unknown max_prefix.action `{other}` (only `shutdown` and timed \
+             `restart` are supported)"
         )),
     }
 }
@@ -1134,7 +1140,7 @@ fn check_max_prefix_counting(
     scope: &str,
     refusals: &mut Vec<String>,
 ) {
-    if max_prefix.action == Some("shutdown")
+    if matches!(max_prefix.action, Some("shutdown" | "restart"))
         && (max_prefix.limit_ipv4.is_some() || max_prefix.limit_ipv6.is_some())
         && max_prefix.count_rejected_routes
     {
@@ -1229,11 +1235,20 @@ fn resolve_clients<'a>(
             ctx.cfg.filtering.max_prefix.as_ref(),
             filtering.max_prefix.as_ref(),
         );
-        let (limit_ipv4, limit_ipv6) = if max_prefix.action == Some("shutdown") {
+        let (limit_ipv4, limit_ipv6) = if matches!(max_prefix.action, Some("shutdown" | "restart"))
+        {
             (max_prefix.limit_ipv4, max_prefix.limit_ipv6)
         } else {
             (None, None)
         };
+        let max_prefix_restart_seconds = (max_prefix.action == Some("restart")
+            && (limit_ipv4.is_some() || limit_ipv6.is_some()))
+        .then(|| {
+            max_prefix
+                .restart_after
+                .and_then(|minutes| minutes.checked_mul(60))
+        })
+        .flatten();
 
         let description = client
             .description
@@ -1256,6 +1271,7 @@ fn resolve_clients<'a>(
             allow_longer_prefixes: ctx.cfg.filtering.irrdb.allow_longer_prefixes,
             limit_ipv4,
             limit_ipv6,
+            max_prefix_restart_seconds,
         });
     }
 
@@ -1391,6 +1407,9 @@ fn render_toml(
         }
         if let Some(limit) = rc.limit_ipv6 {
             let _ = writeln!(out, "max_prefixes_ipv6 = {limit}");
+        }
+        if let Some(seconds) = rc.max_prefix_restart_seconds {
+            let _ = writeln!(out, "max_prefix_restart_seconds = {seconds}");
         }
         let _ = writeln!(
             out,
@@ -1762,6 +1781,7 @@ fn build_receipt(
             "origin_set_size": rc.origins.len(),
             "max_prefixes_ipv4": rc.limit_ipv4,
             "max_prefixes_ipv6": rc.limit_ipv6,
+            "max_prefix_restart_seconds": rc.max_prefix_restart_seconds,
         })).collect::<Vec<_>>(),
         "warnings": warnings,
     })

--- a/tools/rs-config-render/tests/golden.rs
+++ b/tools/rs-config-render/tests/golden.rs
@@ -455,8 +455,8 @@ fn client_black_and_white_lists_are_refused() {
 
 #[test]
 /// Load-bearing proof: removing the effective-action gate, client-to-general
-/// fallback, or zero-limit filter emits or suppresses an asserted config or
-/// receipt field.
+/// fallback, minute conversion, client timer override, receipt field, or
+/// zero-limit filter breaks an exact config or receipt assertion below.
 fn effective_max_prefix_action_controls_limit_emission() {
     let mut value = healthy_value();
     // ARouteServer can leave resolved limits populated while disabling
@@ -480,9 +480,11 @@ fn effective_max_prefix_action_controls_limit_emission() {
         "{}",
         disabled.files["config.toml"]
     );
+    assert!(!disabled.files["config.toml"].contains("max_prefix_restart_seconds"));
     for client in disabled.receipt["clients"].as_array().unwrap() {
         assert!(client["max_prefixes_ipv4"].is_null(), "{client}");
         assert!(client["max_prefixes_ipv6"].is_null(), "{client}");
+        assert!(client["max_prefix_restart_seconds"].is_null(), "{client}");
     }
 
     // The same clients inherit an enabled general shutdown action. Positive
@@ -498,6 +500,34 @@ fn effective_max_prefix_action_controls_limit_emission() {
     assert!(toml.contains("max_prefixes_ipv6 = 1000"), "{toml}");
     assert!(!toml.contains("max_prefixes_ipv4 = 0"), "{toml}");
     assert!(!toml.contains("max_prefixes_ipv6 = 0"), "{toml}");
+    assert!(!toml.contains("max_prefix_restart_seconds"), "{toml}");
+    assert!(
+        enabled.receipt["clients"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|client| client["max_prefix_restart_seconds"].is_null())
+    );
+
+    // General and client restart timers inherit leaf-wise and convert from
+    // ARouteServer minutes to rustbgpd seconds.
+    value["cfg"]["filtering"]["max_prefix"]["action"] = "restart".into();
+    value["cfg"]["filtering"]["max_prefix"]["restart_after"] = 37.into();
+    value["clients"][0]["cfg"]["filtering"]["max_prefix"]["action"] = "restart".into();
+    value["clients"][0]["cfg"]["filtering"]["max_prefix"]["restart_after"] = 2.into();
+    let restarted = render(&to_yaml(&value), &rtr_options()).expect("timed restart render");
+    let toml = &restarted.files["config.toml"];
+    assert!(
+        toml.contains("max_prefixes_ipv4 = 5000\nmax_prefix_restart_seconds = 120"),
+        "{toml}"
+    );
+    assert!(
+        toml.contains("max_prefixes_ipv6 = 1000\nmax_prefix_restart_seconds = 2220"),
+        "{toml}"
+    );
+    let clients = restarted.receipt["clients"].as_array().unwrap();
+    assert_eq!(clients[0]["max_prefix_restart_seconds"], 120);
+    assert_eq!(clients[1]["max_prefix_restart_seconds"], 2220);
 }
 
 #[test]
@@ -528,10 +558,11 @@ fn client_shutdown_overrides_unsupported_general_max_prefix_action() {
 }
 
 #[test]
-/// Load-bearing proof: accepting any listed action, dropping `restart_after`
-/// parsing, or dropping general-action inheritance misses an asserted refusal.
-fn unsupported_effective_max_prefix_actions_are_refused() {
-    for action in ["restart", "block", "warning"] {
+/// Load-bearing proof: accepting an unsupported action or deleting the
+/// required/nonzero/checked restart timer validation breaks a refusal; changing
+/// the largest representable minute conversion breaks the boundary assertion.
+fn restart_action_validates_timer_and_unsupported_actions_are_refused() {
+    for action in ["block", "warning", "mystery"] {
         let mut value = healthy_value();
         let mut clients = value["clients"].clone();
         set_path(
@@ -539,13 +570,6 @@ fn unsupported_effective_max_prefix_actions_are_refused() {
             &["cfg", "filtering", "max_prefix", "action"],
             serde_yaml::Value::String(action.into()),
         );
-        if action == "restart" {
-            set_path(
-                &mut clients[0],
-                &["cfg", "filtering", "max_prefix", "restart_after"],
-                serde_yaml::Value::Number(37.into()),
-            );
-        }
         set_path(&mut value, &["clients"], clients);
         let items = refusals(render(&to_yaml(&value), &rtr_options()));
         assert!(
@@ -553,37 +577,46 @@ fn unsupported_effective_max_prefix_actions_are_refused() {
                 && item.contains(&format!("action `{action}`"))),
             "{action}: {items:?}"
         );
-        if action == "restart" {
-            assert!(
-                items
-                    .iter()
-                    .any(|item| item.contains("restart_after=37 minutes")),
-                "{items:?}"
-            );
-        }
     }
 
-    // An absent client action inherits the general action.
-    let mut value = healthy_value();
-    set_path(
-        &mut value,
-        &["cfg", "filtering", "max_prefix", "action"],
-        serde_yaml::Value::String("restart".into()),
-    );
-    let items = refusals(render(&to_yaml(&value), &rtr_options()));
+    for (restart_after, marker) in [
+        (None, "requires restart_after > 0"),
+        (Some(0), "requires restart_after > 0"),
+        (Some(71_582_789), "u32-second maximum"),
+    ] {
+        let mut value = healthy_value();
+        value["cfg"]["filtering"]["max_prefix"]["restart_after"] =
+            restart_after.map_or(serde_yaml::Value::Null, |_| 37.into());
+        value["clients"][0]["cfg"]["filtering"]["max_prefix"]["action"] = "restart".into();
+        value["clients"][0]["cfg"]["filtering"]["max_prefix"]["limit_ipv4"] = 0.into();
+        if let Some(minutes) = restart_after {
+            value["clients"][0]["cfg"]["filtering"]["max_prefix"]["restart_after"] = minutes.into();
+        }
+        let items = refusals(render(&to_yaml(&value), &rtr_options()));
+        assert!(
+            items
+                .iter()
+                .any(|item| item.contains("client AS4242_1") && item.contains(marker)),
+            "{restart_after:?}: {items:?}"
+        );
+    }
+
+    let mut boundary = healthy_value();
+    boundary["clients"][0]["cfg"]["filtering"]["max_prefix"]["action"] = "restart".into();
+    boundary["clients"][0]["cfg"]["filtering"]["max_prefix"]["restart_after"] = 71_582_788.into();
+    let rendered = render(&to_yaml(&boundary), &rtr_options()).expect("boundary restart");
     assert!(
-        items
-            .iter()
-            .any(|item| item.contains("client AS197000_1") && item.contains("action `restart`")),
-        "{items:?}"
+        rendered.files["config.toml"].contains("max_prefix_restart_seconds = 4294967280"),
+        "{}",
+        rendered.files["config.toml"]
     );
 }
 
 #[test]
 /// Load-bearing proof: defaulting an omitted value to false, checking the
-/// value without an active shutdown/positive limit, deleting the true-value
-/// refusal, or reversing client-over-general precedence breaks an asserted
-/// success or refusal below.
+/// value without an active shutdown/restart positive limit, deleting the
+/// true-value refusal, or reversing client-over-general precedence breaks an
+/// asserted success or refusal below.
 fn rejected_route_counting_is_checked_only_for_an_active_limit() {
     // ARouteServer 1.23.2 defaults an omitted value to true. Silently treating
     // this context as accepted-only would change when shutdown happens.
@@ -602,6 +635,7 @@ fn rejected_route_counting_is_checked_only_for_an_active_limit() {
     );
 
     let mut inherited = healthy_value();
+    inherited["cfg"]["filtering"]["max_prefix"]["action"] = "restart".into();
     set_path(
         &mut inherited,
         &["cfg", "filtering", "max_prefix", "count_rejected_routes"],
@@ -634,6 +668,16 @@ fn rejected_route_counting_is_checked_only_for_an_active_limit() {
     // A client can explicitly select rustbgpd's accepted-route model over an
     // inherited general true value.
     let mut allowed_override = healthy_value();
+    set_path(
+        &mut allowed_override,
+        &["cfg", "filtering", "max_prefix", "action"],
+        serde_yaml::Value::String("restart".into()),
+    );
+    set_path(
+        &mut allowed_override,
+        &["cfg", "filtering", "max_prefix", "restart_after"],
+        serde_yaml::Value::Number(1.into()),
+    );
     set_path(
         &mut allowed_override,
         &["cfg", "filtering", "max_prefix", "count_rejected_routes"],
@@ -672,8 +716,13 @@ fn rejected_route_counting_is_checked_only_for_an_active_limit() {
     set_path(&mut disabled, &["clients"], clients);
     render(&to_yaml(&disabled), &rtr_options()).expect("disabled max-prefix counting");
 
-    // A shutdown action with only zero/unset family limits is also inactive.
+    // A timed restart with only zero/unset family limits is also inactive.
     let mut zero_limits = healthy_value();
+    set_path(
+        &mut zero_limits,
+        &["cfg", "filtering", "max_prefix", "action"],
+        serde_yaml::Value::String("restart".into()),
+    );
     set_path(
         &mut zero_limits,
         &["cfg", "filtering", "max_prefix", "count_rejected_routes"],
@@ -681,6 +730,11 @@ fn rejected_route_counting_is_checked_only_for_an_active_limit() {
     );
     let mut clients = zero_limits["clients"].clone();
     for client in clients.as_sequence_mut().expect("clients list") {
+        set_path(
+            client,
+            &["cfg", "filtering", "max_prefix", "action"],
+            serde_yaml::Value::String("restart".into()),
+        );
         set_path(
             client,
             &["cfg", "filtering", "max_prefix", "limit_ipv4"],
@@ -693,5 +747,15 @@ fn rejected_route_counting_is_checked_only_for_an_active_limit() {
         );
     }
     set_path(&mut zero_limits, &["clients"], clients);
-    render(&to_yaml(&zero_limits), &rtr_options()).expect("zero limits disable enforcement");
+    let rendered =
+        render(&to_yaml(&zero_limits), &rtr_options()).expect("zero limits disable enforcement");
+    assert!(!rendered.files["config.toml"].contains("max_prefixes_"));
+    assert!(!rendered.files["config.toml"].contains("max_prefix_restart_seconds"));
+    assert!(
+        rendered.receipt["clients"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|client| client["max_prefix_restart_seconds"].is_null())
+    );
 }


### PR DESCRIPTION
## Summary

- translate ARouteServer v1.23.2 OpenBGPD-style `restart_after` minutes into checked rustbgpd seconds
- preserve client-over-general timer/action/counting inheritance and existing positive per-family ceilings
- fail closed on missing, zero, or overflowing timers and on rejected-route counting for active ceilings
- emit the timed restart in both generated TOML and the render receipt
- document accepted-route accounting and the fact that ARouteServer BIRD restart remains immediate and ignores `restart_after`

## Root cause

`rs-config-render` still rejected `max_prefix.action: restart` after rustbgpd gained timed max-prefix restart. Accepting the action alone would have been unsafe: the renderer also retained ceilings only for `shutdown`, omitted the timer from generated TOML and receipts, and scoped counting validation only to shutdown.

## Upstream contract

This pins ARouteServer v1.23.2 semantics. `restart_after` is an OpenBGPD-style minute value inherited leaf-by-leaf. The renderer converts it with checked `u32` arithmetic, accepts at most 71,582,788 minutes, and emits a timer only alongside at least one positive family ceiling. This does not claim BIRD timed-restart parity.

## Operator impact

A valid timed-restart route-server context now renders a complete, daemon-checkable configuration instead of being refused. Ambiguous or unrepresentable inputs remain fail-closed with scoped diagnostics.

## Validation

- `cargo test -p rs-config-render --test golden` (20/20)
- `cargo test --test rs_config_render_emitted_check` (2/2, including real `rustbgpd --check`)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- `git diff --check`
- independent contract and exact-diff audit: GO

## Load-bearing regression proof

Each mutation was applied, observed red, and restored: wrong minute conversion; omitted receipt/timer emission; shutdown or absent-action leakage; broken client/general precedence including explicit client zero over general 37; deleted missing/zero/overflow validation; admitted block/warning/unknown actions; restart counting narrowed back to shutdown; omitted counting default changed to false; zero-limit filtering removed; timer emitted without a positive limit; and a daemon-invalid duplicate timer injected after the string assertions.

Linear: LAN-511