### PR TITLE
fix(rib): interpret RFC 10005 link bandwidth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **RFC 10005 Link Bandwidth receiver subset.** The typed wire accessor recognizes
+  exact transitive/non-transitive communities; weighting selects the lowest finite
+  nonnegative value without altering raw reflection. Zero stays valid;
+  construction stays type `0x40`.
+
 ### Added
 
 - **Opt-in timed restart after max-prefix teardown.** Neighbors and peer groups

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -1966,22 +1966,71 @@ mod tests {
     }
 
     #[test]
+    /// Load-bearing proof: restoring first-match, selecting the maximum,
+    /// rejecting either exact type, a different ASN, or finite zero (including
+    /// `-0`), or accepting negative/non-finite values breaks an assertion below.
     fn route_link_bandwidth_accessor() {
         let v4 = Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24);
-        let mut route = make_route(1, v4, 100);
-
-        // No extended communities → no link bandwidth.
-        assert!(route.link_bandwidth().is_none());
-
-        // A Link Bandwidth community surfaces its bandwidth (bytes/second);
-        // an unrelated Route Target sitting alongside it is ignored.
+        let read = |communities| {
+            let mut route = make_route(1, v4, 100);
+            Arc::make_mut(&mut route.attributes)
+                .push(PathAttribute::ExtendedCommunities(communities));
+            route.link_bandwidth()
+        };
+        let lb = |type_byte: u8, asn: u16, bw: f32| {
+            let asn = asn.to_be_bytes();
+            let bw = bw.to_be_bytes();
+            ExtendedCommunity::new(u64::from_be_bytes([
+                type_byte, 0x04, asn[0], asn[1], bw[0], bw[1], bw[2], bw[3],
+            ]))
+        };
         let rt = ExtendedCommunity::new(u64::from_be_bytes([0x00, 0x02, 0xFD, 0xE9, 0, 0, 0, 100]));
-        let lb = ExtendedCommunity::link_bandwidth(65001, 1.25e9_f32);
-        Arc::make_mut(&mut route.attributes).push(PathAttribute::ExtendedCommunities(vec![rt, lb]));
 
-        let bw = route.link_bandwidth().expect("link bandwidth present");
-        // Exact round-trip through IEEE-754 bytes — assert bitwise equality.
-        assert_eq!(bw.to_bits(), 1.25e9_f32.to_bits());
+        assert!(read(vec![]).is_none());
+        let mut mixed = vec![
+            rt,
+            lb(0x00, 64512, 90.0),
+            lb(0x40, 65001, 40.0),
+            lb(0x40, 65001, 40.0),
+            lb(0x00, 65534, 30.0),
+        ];
+        assert_eq!(read(mixed.clone()), Some(30.0));
+        mixed.reverse();
+        assert_eq!(read(mixed), Some(30.0));
+
+        assert_eq!(read(vec![lb(0x40, 1, -5.0), lb(0x00, 2, 5.0)]), Some(5.0));
+        assert!(read(vec![lb(0x40, 1, -5.0)]).is_none());
+
+        assert_eq!(
+            read(vec![lb(0x00, 1, 0.0)]).unwrap().to_bits(),
+            0.0_f32.to_bits()
+        );
+        for zeros in [[0.0, -0.0], [-0.0, 0.0]] {
+            assert_eq!(
+                read(zeros.map(|bw| lb(0x40, 1, bw)).to_vec())
+                    .unwrap()
+                    .to_bits(),
+                (-0.0_f32).to_bits()
+            );
+        }
+
+        assert_eq!(
+            read(vec![
+                lb(0x00, 1, f32::NAN),
+                lb(0x40, 2, f32::INFINITY),
+                lb(0x00, 3, f32::NEG_INFINITY),
+                lb(0x40, 4, 7.0),
+            ]),
+            Some(7.0)
+        );
+        assert!(
+            read(vec![
+                lb(0x00, 1, f32::NAN),
+                lb(0x40, 2, f32::INFINITY),
+                lb(0x00, 3, f32::NEG_INFINITY),
+            ])
+            .is_none()
+        );
     }
 
     #[test]

--- a/crates/rib/src/route.rs
+++ b/crates/rib/src/route.rs
@@ -180,15 +180,17 @@ impl Route {
         self.origin_type == RouteOrigin::Ebgp
     }
 
-    /// Link Bandwidth in **bytes per second** (draft-ietf-idr-link-bandwidth),
-    /// if the route carries a Link Bandwidth Extended Community. Used to weight
-    /// next hops for unequal-cost multipath. Returns the first match's bandwidth;
-    /// the advertising AS is discarded since weighting only needs the magnitude.
+    /// Lowest usable Link Bandwidth in **bytes per second** (RFC 10005 §§3.2, 4).
+    /// Both transitivity types and zero are accepted; negative and non-finite
+    /// values are ignored by local receiver policy. The raw communities remain
+    /// untouched for reflection.
     #[must_use]
     pub fn link_bandwidth(&self) -> Option<f32> {
         self.extended_communities()
             .iter()
-            .find_map(|c| c.as_link_bandwidth().map(|(_asn, bw)| bw))
+            .filter_map(|c| c.as_link_bandwidth().map(|(_asn, bw)| bw))
+            .filter(|bw| bw.is_finite() && *bw >= 0.0)
+            .min_by(f32::total_cmp)
     }
 
     /// Extract the ORIGIN attribute value, defaulting to Incomplete.

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -64,7 +64,7 @@ analyzers, test harnesses, MRT readers, etc.
 | 9687 | Send Hold Timer: NOTIFICATION code 8 (`NotificationCode::SendHoldTimerExpired`, subcode always 0 per §6). Codec only — the timer itself lives in the daemon |
 | 9785 §3 | DF Election preference algorithms + Don't-Preempt bit, extending the RFC 8584 DF Election Extended Community |
 | draft-abraitis-idr-addpath-paths-limit-04 | Experimental Paths-Limit capability (`PathsLimitFamily`, IANA-assigned capability code 76). The draft is expired and archived; interoperability and behavior remain experimental |
-| draft-ietf-idr-link-bandwidth | Link Bandwidth Extended Community (non-transitive two-octet-AS-specific, type 0x40 subtype 0x04): decode + construct of the advertising AS and the IEEE-754 bytes/second bandwidth used to weight unequal-cost multipath |
+| 10005 | Link Bandwidth Extended Community receiver subset: decode exact transitive/non-transitive types 0x00/0x40, subtype 0x04, as raw AS + IEEE-754 bytes/second; the constructor remains non-transitive type 0x40 |
 
 ### 0.15.0 compatibility note
 
@@ -162,7 +162,7 @@ let bytes = encode_message(&Message::Open(open)).expect("encode OPEN");
 - **`PmsiTunnel`** / **`PmsiTunnelType`** / **`PmsiTunnelIdentifier`** — PMSI Tunnel attribute (RFC 6514 §5) carried on EVPN Type 3 IMET routes for ingress-replication BUM. Constructor `PmsiTunnel::for_evpn_ingress_replication(vni, ip)` emits the RFC 8365 §5.1.3 wire shape (raw 24-bit VNI in the label field, originator IP as the tunnel identifier).
 - **`RouteDistinguisher`** — RFC 4364 §4.2 8-byte RD, used by EVPN and VPNv4/v6. Implements `Display` + `FromStr` for the standard `asn:val` / `ipv4:val` textual encodings
 - **`DfElectionExtendedCommunity`** (`attribute`) — RFC 8584 §2.2 / RFC 9785 §3 DF Election Extended Community: `ExtendedCommunity::as_df_election()` decodes one, `ExtendedCommunity::df_election(algorithm, capabilities, preference: Option<u16>)` constructs it (EVPN DF election algorithm, capabilities, and the RFC 9785 preference / Don't-Preempt fields)
-- **Link Bandwidth** (draft-ietf-idr-link-bandwidth) — `ExtendedCommunity::as_link_bandwidth()` decodes the advertising AS and the IEEE-754 bytes/second bandwidth from a non-transitive two-octet-AS-specific community (type 0x40 subtype 0x04); `ExtendedCommunity::link_bandwidth(asn, bytes_per_sec)` constructs one, for weighting unequal-cost multipath next hops
+- **Link Bandwidth** (RFC 10005 §§2, 3.2) — `ExtendedCommunity::as_link_bandwidth()` decodes exact type 0x00/0x40, subtype 0x04, without interpreting the raw AS/float payload; `ExtendedCommunity::link_bandwidth(asn, bytes_per_sec)` continues to construct non-transitive type 0x40
 - **Origin Validation State** (RFC 8097) — `ExtendedCommunity::ORIGIN_VALIDATION_VALID` /
   `_NOT_FOUND` / `_INVALID` constants (type 0x43) for the RPKI prefix-origin
   validation-state extended community, rendered `OV_VALID` / `OV_NOT_FOUND` /

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -525,14 +525,13 @@ impl ExtendedCommunity {
         let raw = u64::from_be_bytes([0x06, 0x06, alg, cap[0], cap[1], 0, pref[0], pref[1]]);
         Self(raw)
     }
-    /// Decode as Link Bandwidth Extended Community
-    /// (draft-ietf-idr-link-bandwidth): non-transitive two-octet-AS-specific,
-    /// type `0x40`, subtype `0x04`. The value carries the 2-octet AS plus the
-    /// bandwidth as an IEEE-754 single-precision float in **bytes per second**.
-    /// Returns `(asn, bytes_per_sec)`.
+    /// Decode as Link Bandwidth Extended Community (RFC 10005 §2): transitive
+    /// or non-transitive two-octet-AS-specific, exact type `0x00` or `0x40`,
+    /// subtype `0x04`. Returns the raw `(asn, bytes_per_sec)` payload; receiver
+    /// policy is applied by the consumer.
     #[must_use]
     pub fn as_link_bandwidth(self) -> Option<(u16, f32)> {
-        if self.type_byte() != 0x40 || self.subtype() != 0x04 {
+        if !matches!(self.type_byte(), 0x00 | 0x40) || self.subtype() != 0x04 {
             return None;
         }
         let v = self.value_bytes();
@@ -540,10 +539,9 @@ impl ExtendedCommunity {
         let bytes_per_sec = f32::from_be_bytes([v[2], v[3], v[4], v[5]]);
         Some((asn, bytes_per_sec))
     }
-    /// Construct a Link Bandwidth Extended Community
-    /// (draft-ietf-idr-link-bandwidth): non-transitive two-octet-AS-specific,
-    /// type `0x40`, subtype `0x04`. `bytes_per_sec` is encoded as an IEEE-754
-    /// single-precision float.
+    /// Construct a non-transitive Link Bandwidth Extended Community
+    /// (RFC 10005 §2), type `0x40`, subtype `0x04`. `bytes_per_sec` is encoded
+    /// as an IEEE-754 single-precision float.
     #[must_use]
     pub fn link_bandwidth(asn: u16, bytes_per_sec: f32) -> Self {
         let a = asn.to_be_bytes();
@@ -3383,21 +3381,29 @@ mod tests {
         assert_eq!(decoded.to_bits(), bw.to_bits());
     }
     #[test]
+    /// Load-bearing proof: dropping exact type `0x00` or `0x40` receiver
+    /// support breaks that type's raw ASN/bandwidth assertions.
     fn ext_comm_link_bandwidth_decodes_known_wire_bytes() {
-        // type=0x40 subtype=0x04 AS=0xFDE9(65001) bw=IEEE-754(1.0)
         let one = 1.0_f32.to_be_bytes();
-        let raw = u64::from_be_bytes([0x40, 0x04, 0xFD, 0xE9, one[0], one[1], one[2], one[3]]);
-        let (asn, bw) = ExtendedCommunity::new(raw)
-            .as_link_bandwidth()
-            .expect("decodes as link bandwidth");
-        assert_eq!(asn, 65001);
-        assert_eq!(bw.to_bits(), 1.0_f32.to_bits());
+        for type_byte in [0x00, 0x40] {
+            let raw =
+                u64::from_be_bytes([type_byte, 0x04, 0xFD, 0xE9, one[0], one[1], one[2], one[3]]);
+            let (asn, bw) = ExtendedCommunity::new(raw)
+                .as_link_bandwidth()
+                .expect("decodes as link bandwidth");
+            assert_eq!(asn, 65001);
+            assert_eq!(bw.to_bits(), 1.0_f32.to_bits());
+        }
     }
     #[test]
+    /// Load-bearing proof: masking the type byte admits `0x80`/`0xc0`, while
+    /// dropping the subtype check admits the wrong-subtype assertion.
     fn ext_comm_link_bandwidth_rejects_wrong_type_or_subtype() {
-        // Right subtype (0x04) but transitive type (0x00) — not Link Bandwidth.
-        let transitive = ExtendedCommunity::new(u64::from_be_bytes([0x00, 0x04, 0, 0, 0, 0, 0, 0]));
-        assert!(transitive.as_link_bandwidth().is_none());
+        for type_byte in [0x80, 0xc0] {
+            let wrong_type =
+                ExtendedCommunity::new(u64::from_be_bytes([type_byte, 0x04, 0, 0, 0, 0, 0, 0]));
+            assert!(wrong_type.as_link_bandwidth().is_none());
+        }
         // Right type (0x40) but a different subtype.
         let wrong_sub = ExtendedCommunity::new(u64::from_be_bytes([0x40, 0x02, 0, 0, 0, 0, 0, 0]));
         assert!(wrong_sub.as_link_bandwidth().is_none());

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -267,8 +267,9 @@ IPv4/IPv6 `Prefix` routes.
     Per-class caps (`maximum_paths_ebgp` / `maximum_paths_ibgp`, FRR parity) let
     eBGP and iBGP groups carry different widths. The global
     `[global].link_bandwidth_weighted` knob (ADR-0068) weights ECMP next-hops by
-    their Link Bandwidth Extended Community (draft-ietf-idr-link-bandwidth, FRR's
-    `bgp bestpath bandwidth`) for unequal-cost load balancing. Add-Path
+    their lowest usable RFC 10005 Link Bandwidth Extended Community (receiver
+    subset; exact type 0x00/0x40). Zero or unusable values use equal-cost
+    fallback; FRR calls the weighting mode `bgp bestpath bandwidth`. Add-Path
     multi-path *send* (RFC 7911, route-server mode) and EVPN aliasing ECMP
     (ADR-0059 FDB nexthop groups, default-on) also ship.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -139,7 +139,7 @@ Required. Defines the local BGP speaker identity.
 | `install_blackhole_discard` | bool | no | `false`              | Install kernel blackhole routes for accepted RFC 7999 host routes — see below |
 | `allow_blackhole_broad_prefixes` | bool | no | `false`           | Permit non-host BLACKHOLE discard installs when the FIB slice is enabled |
 | `multipath_relax`   | bool   | no       | `false`              | ADR-0066 multipath-relax: group unicast ECMP candidates by `AS_PATH` *length* instead of an exact `AS_PATH` match (FRR's `bgp bestpath as-path multipath-relax`). Best-path-wide; inert unless a `[[fib_tables]]` sets `maximum_paths`, `maximum_paths_ebgp`, or `maximum_paths_ibgp` above `1` |
-| `link_bandwidth_weighted` | bool | no   | `false`              | ADR-0068 weighted multipath: weight unicast ECMP next-hops by their Link Bandwidth Extended Community (draft-ietf-idr-link-bandwidth, FRR's `bgp bestpath bandwidth`) when the whole equal-cost group carries one; otherwise equal-cost. Best-path-wide; inert unless a `[[fib_tables]]` sets `maximum_paths`, `maximum_paths_ebgp`, or `maximum_paths_ibgp` above `1` |
+| `link_bandwidth_weighted` | bool | no   | `false`              | ADR-0068 weighted multipath: weight unicast ECMP next-hops by the lowest finite nonnegative RFC 10005 Link Bandwidth value when the whole equal-cost group carries a positive one; zero, missing, or unusable values fall back to equal cost. Best-path-wide; inert unless a `[[fib_tables]]` sets `maximum_paths`, `maximum_paths_ebgp`, or `maximum_paths_ibgp` above `1` |
 
 ```toml
 [global]

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -1385,6 +1385,25 @@ while retaining the legacy raw unlimited sentinel for rolling compatibility.
 
 ---
 
+## RFC 10005 — Link Bandwidth receiver subset
+
+- **§2 / §3.2:** `ExtendedCommunity::as_link_bandwidth()` accepts the exact
+  transitive (`0x00`) and non-transitive (`0x40`) two-octet-AS-specific types
+  with subtype `0x04`. It returns the raw AS and IEEE-754 bytes/second value;
+  `ExtendedCommunity::link_bandwidth()` continues to construct non-transitive
+  type `0x40`.
+- **§4:** `Route::link_bandwidth()` chooses the lowest finite nonnegative value,
+  independent of transitivity or AS. Positive and negative zero are valid;
+  negative values are ignored. NaN and infinities are also ignored as a local
+  finite-value policy. With no usable value, existing equal-cost fallback wins.
+- **§3.3.2:** receive-side inspection does not mutate, reorder, or deduplicate
+  the raw Extended Communities vector, so unchanged-next-hop reflection remains
+  byte-preserving.
+
+This is a receiver subset, not full RFC 10005 sender or re-advertisement policy.
+
+---
+
 ## EVPN Extended Communities — typed accessors (RFC 7432 §7.5-§7.8)
 
 Subtypes with typed accessors on `ExtendedCommunity` (others pass

--- a/docs/adr/0068-weighted-multipath.md
+++ b/docs/adr/0068-weighted-multipath.md
@@ -13,13 +13,14 @@ bluntly:
 > weight). Unequal-cost / weighted multipath … is not supported; it is future
 > work.
 
-draft-ietf-idr-link-bandwidth defines a **Link Bandwidth Extended Community**
-(non-transitive two-octet-AS-specific, type `0x40` subtype `0x04`) carrying a
-path's link bandwidth as an IEEE-754 bytes/second value. FRR's
-`bgp bestpath bandwidth` weights ECMP next-hops in proportion to it, so a
-40G link draws ~4× the traffic of a 10G link in the same bundle. The wire
-parse landed already (`ExtendedCommunity::as_link_bandwidth` /
-`Route::link_bandwidth`); this ADR wires it into the FIB.
+RFC 10005 defines transitive and non-transitive **Link Bandwidth Extended
+Communities** (exact type `0x00`/`0x40`, subtype `0x04`) carrying an IEEE-754
+bytes/second value. This implementation is a receiver subset: it accepts both
+types, uses the lowest finite nonnegative value per §§3.2/4, and leaves the raw
+communities unchanged for §3.3.2 reflection. NaN/infinities are ignored by
+local finite-value policy. The constructor remains type `0x40`; sender
+transitivity/regeneration policy is not implemented. FRR's `bgp bestpath
+bandwidth` supplies the FIB-weighting model below.
 
 ## Decision
 
@@ -57,8 +58,9 @@ For each equal-cost group, after it is deduped and capped:
 The **all-or-nothing** rule (one path missing the community ⇒ the whole group
 reverts to equal weight) is deterministic and avoids inventing a default
 bandwidth for a path that never advertised one — a conservative reading of the
-draft, akin to FRR's `skip-missing`. It is documented as a limitation, not a
-silent guess.
+RFC, akin to FRR's `skip-missing`. RFC 10005 permits zero; locally, zero in any
+weighted group takes the existing equal-cost fallback because FIB weights must
+be positive. It is documented as a limitation, not a silent guess.
 
 ### Why global, not per-table
 

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -1005,7 +1005,7 @@
           "default": false
         },
         "link_bandwidth_weighted": {
-          "description": "ADR-0068 weighted multipath (FRR's `bgp bestpath bandwidth`). When `true`,\nunicast ECMP next-hops are weighted by their Link Bandwidth Extended\nCommunity (draft-ietf-idr-link-bandwidth) when the whole equal-cost group\ncarries one; otherwise they stay equal-cost. Off by default. Like\n`multipath_relax` it is a best-path-wide knob and is inert unless a table\nsets `maximum_paths`, `maximum_paths_ebgp`, or `maximum_paths_ibgp` above\n1.",
+          "description": "ADR-0068 weighted multipath (FRR's `bgp bestpath bandwidth`). When `true`,\nunicast ECMP next-hops are weighted using the lowest finite nonnegative\nRFC 10005 Link Bandwidth value on each route. Weighting applies only when\nevery path in the equal-cost group has a positive value; zero, missing,\nor unusable values keep the whole group equal-cost. Off by default. Like\n`multipath_relax` it is a best-path-wide knob and is inert unless a table\nsets `maximum_paths`, `maximum_paths_ebgp`, or `maximum_paths_ibgp` above\n1.",
           "type": "boolean",
           "default": false
         },

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -554,9 +554,10 @@ pub struct Global {
     #[serde(default)]
     pub multipath_relax: bool,
     /// ADR-0068 weighted multipath (FRR's `bgp bestpath bandwidth`). When `true`,
-    /// unicast ECMP next-hops are weighted by their Link Bandwidth Extended
-    /// Community (draft-ietf-idr-link-bandwidth) when the whole equal-cost group
-    /// carries one; otherwise they stay equal-cost. Off by default. Like
+    /// unicast ECMP next-hops are weighted using the lowest finite nonnegative
+    /// RFC 10005 Link Bandwidth value on each route. Weighting applies only when
+    /// every path in the equal-cost group has a positive value; zero, missing,
+    /// or unusable values keep the whole group equal-cost. Off by default. Like
     /// `multipath_relax` it is a best-path-wide knob and is inert unless a table
     /// sets `maximum_paths`, `maximum_paths_ebgp`, or `maximum_paths_ibgp` above
     /// 1.


### PR DESCRIPTION
## Summary

- accept exact transitive and non-transitive RFC 10005 Link Bandwidth communities on receive
- choose the lowest finite nonnegative duplicate independent of wire order, transitivity, or Global Administrator
- preserve positive and negative zero as valid while ignoring negative and non-finite values under documented local weighting policy
- leave raw Extended Communities byte/order-identical for reflection and keep the constructor non-transitive type `0x40`
- update standards, configuration, comparison, wire, ADR, and changelog documentation without claiming full sender compliance
- refresh the authoritative config-field documentation and shipped JSON Schema with the same receiver/fallback contract

## Root cause

The typed wire accessor recognized only type `0x40`, and `Route::link_bandwidth()` returned the first matching community. That blessed one historical draft encoding and made duplicate handling order-dependent despite rustbgpd already using the value for opt-in weighted multipath.

## Standards boundary

[RFC 10005](https://www.rfc-editor.org/rfc/rfc10005.html) requires receivers to process exact type `0x00` and `0x40` subtype `0x04`, ignore negative values, keep zero valid, and use the lowest duplicate for weighted load balancing. The RFC is silent on NaN/infinity; the derived route view ignores non-finite values to align rustbgpd’s existing finite-positive weight normalizer, while the raw wire accessor and reflected community vector remain unchanged.

This is a receiver interpretation subset. Sender transitivity configuration, regeneration, export filtering, best-path input, and FIB redesign are deliberately out of scope.

## Operator impact

Weighted-multipath deployments now interpret transitive and duplicate Link Bandwidth advertisements deterministically. Zero, missing, negative-only, or otherwise unusable values retain the existing equal-cost fallback.

## Validation

- focused wire Link Bandwidth tests (3/3)
- focused Route accessor test
- `cargo test --bin rustbgpd config_json_schema_committed_copy_is_fresh --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- `git diff --check`
- independent standards and exact-diff audit: GO

## Load-bearing regression proof

Each mutation was applied, observed red, and restored: remove type `0x00`; use a permissive transitivity mask; remove subtype validation; restore first-match; select maximum; accept negative or non-finite values; reject zero with `> 0`; and reject negative zero by sign bit. Tests also make the different-AS transitive community the unique minimum so an ASN filter cannot pass accidentally.

Linear: LAN-507
