### PR TITLE
fix(policy): select the largest reload cohort

### DIFF
--- a/docs/adr/0105-grouped-export-policy-transition.md
+++ b/docs/adr/0105-grouped-export-policy-transition.md
@@ -48,18 +48,18 @@ RIB work, so the fast path stays deliberately narrow.
 
 ### 2. Policy cohort, wire cohorts, and remainder
 
-PeerManager chooses at most one policy cohort. In caller order, it anchors on
-the first viable pair of installed and target export chains, then selects
-Established peers with that same pair, unchanged import policy, and no pending
-refresh or export apply. Fewer than two selected peers disables the cohort.
-Everything not selected remains the authoritative remainder; the algorithm
-does not recursively find a second cohort. The local repeated-pair preflight is
-O(targets squared) in the worst case; after it finds a possible pair, the
-Established-state selection pass is linear in targets and issues at most one
-session query per locally eligible candidate. Those queries run sequentially
-and each is bounded by the 100 ms peer-query timeout, so a fleet of wedged
-sessions costs up to one timeout per candidate while the PeerManager actor
-services only its readiness lane.
+PeerManager chooses at most one policy cohort. A local O(targets squared) pass
+selects the largest structurally equal pair of installed and target export
+chains; equal-size pairs tie-break by their lowest canonical `PeerKey`. Only
+locally eligible targets for that winning pair are queried, in caller order,
+and only Established peers enter the cohort. Import changes are tolerated:
+cohort setup hot-applies them per member and defers Route Refresh until after
+the batched RIB commit. Fewer than two Established winners disables the cohort
+without trying a runner-up. Everything not selected remains in its original
+order in the authoritative remainder; the algorithm does not recursively find
+a second cohort. State queries run sequentially and each is bounded by the
+100 ms peer-query timeout, so wedged winning sessions cost up to one timeout
+each while the PeerManager actor services only its readiness lane.
 
 The policy cohort is not a wire-equivalence cohort. RibManager independently
 revalidates update-group source and destination, clean state, live session and

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -345,54 +345,66 @@ impl PeerManager {
         }
     }
 
-    /// Select the first viable export-only cohort in target order. A local-only
-    /// preflight avoids session queries when no installed/target pair occurs
-    /// twice. Once the first Established local candidate fixes that pair, later
-    /// candidates either join it or remain in the authoritative remainder. The
+    /// Select the largest locally eligible export-only cohort, with a stable
+    /// lowest-`PeerKey` tie-break, while preserving caller order inside both
+    /// partitions. Only the winning pair is queried for Established state. The
     /// RIB independently revalidates runtime group identity, ownership,
-    /// generation, and session state. If a selected session changes after this
-    /// observation, its hot-apply failure is restored by the owned cohort
-    /// transaction; a later RIB divergence hands the entire cohort to the
-    /// authoritative per-peer seam.
+    /// generation, and session state. If fewer than two winning members remain
+    /// Established, the caller takes the wholly authoritative path rather than
+    /// trying a runner-up cohort.
     pub(super) async fn export_only_policy_cohort_mask(
         &mut self,
         targets: &[ResolvedPeerPolicy],
     ) -> Vec<bool> {
         let mut selected = vec![false; targets.len()];
-        let has_repeated_pair = targets.iter().enumerate().any(|(index, target)| {
+        let mut groups: Vec<(usize, usize, PeerKey)> = Vec::new();
+        for (index, target) in targets.iter().enumerate() {
             let Some((installed, target_chain)) = self.local_export_only_policy_pair(target) else {
-                return false;
+                continue;
             };
-            targets[index + 1..].iter().any(|candidate| {
-                self.local_export_only_policy_pair(candidate).is_some_and(
-                    |(candidate_installed, candidate_target)| {
-                        candidate_installed == installed && candidate_target == target_chain
-                    },
-                )
-            })
-        });
-        if !has_repeated_pair {
-            return selected;
+            let peer_key = PeerKey::new(target.address, target.interface.clone());
+            let group = groups.iter().position(|(representative, _, _)| {
+                self.local_export_only_policy_pair(&targets[*representative])
+                    .is_some_and(|(group_installed, group_target)| {
+                        group_installed == installed && group_target == target_chain
+                    })
+            });
+            if let Some(group) = group {
+                groups[group].1 = groups[group].1.saturating_add(1);
+                if peer_key < groups[group].2 {
+                    groups[group].2 = peer_key;
+                }
+            } else {
+                groups.push((index, 1, peer_key));
+            }
         }
-
-        let mut anchor: Option<(Option<PolicyChain>, Option<PolicyChain>)> = None;
+        let mut winner: Option<(usize, usize, PeerKey)> = None;
+        for (representative, count, min_peer_key) in groups {
+            if count >= 2
+                && winner.as_ref().is_none_or(|(_, best_count, best_key)| {
+                    count > *best_count || (count == *best_count && min_peer_key < *best_key)
+                })
+            {
+                winner = Some((representative, count, min_peer_key));
+            }
+        }
+        let Some((representative, _, _)) = winner else {
+            return selected;
+        };
+        let (winning_installed, winning_target) = self
+            .local_export_only_policy_pair(&targets[representative])
+            .expect("winning cohort representative remains locally eligible");
+        let winning_installed = winning_installed.clone();
+        let winning_target = winning_target.clone();
 
         for (index, target) in targets.iter().enumerate() {
             let peer_key = PeerKey::new(target.address, target.interface.clone());
             let Some((installed, target_chain)) = self.local_export_only_policy_pair(target) else {
                 continue;
             };
-            if anchor
-                .as_ref()
-                .is_some_and(|(anchor_installed, anchor_target)| {
-                    anchor_installed != installed || anchor_target != target_chain
-                })
-            {
+            if installed != &winning_installed || target_chain != &winning_target {
                 continue;
             }
-            let prospective_anchor = anchor
-                .is_none()
-                .then(|| (installed.clone(), target_chain.clone()));
             let commands = self
                 .peers
                 .get(&peer_key)
@@ -410,10 +422,6 @@ impl PeerManager {
             self.drain_readiness_queries().await;
             if !established {
                 continue;
-            }
-
-            if let Some(prospective_anchor) = prospective_anchor {
-                anchor = Some(prospective_anchor);
             }
             selected[index] = true;
         }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1206,9 +1206,19 @@ fn established_export_policy_test_session(
     attempts: Arc<AtomicUsize>,
     fail_on_attempt: Option<usize>,
 ) -> PeerHandle {
+    established_export_policy_test_session_with_queries(addr, attempts, fail_on_attempt).0
+}
+
+fn established_export_policy_test_session_with_queries(
+    addr: IpAddr,
+    attempts: Arc<AtomicUsize>,
+    fail_on_attempt: Option<usize>,
+) -> (PeerHandle, Arc<AtomicUsize>) {
     use rustbgpd_transport::PeerCommand;
 
     let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(16);
+    let queries = Arc::new(AtomicUsize::new(0));
+    let task_queries = Arc::clone(&queries);
     let task = tokio::spawn(async move {
         while let Some(command) = session_rx.recv().await {
             match command {
@@ -1224,6 +1234,7 @@ fn established_export_policy_test_session(
                     let _ = reply.send(result);
                 }
                 PeerCommand::QueryState { reply } => {
+                    task_queries.fetch_add(1, Ordering::SeqCst);
                     let _ = reply.send(PeerSessionState {
                         fsm_state: SessionState::Established,
                         peer_ip: addr,
@@ -1260,7 +1271,7 @@ fn established_export_policy_test_session(
         }
         Ok(())
     });
-    PeerHandle::from_parts(session_tx, task)
+    (PeerHandle::from_parts(session_tx, task), queries)
 }
 
 fn rollback_ordering_policy_session(
@@ -9509,6 +9520,218 @@ async fn export_only_snapshot_skips_probe_without_repeated_policy_pair() {
     );
 
     drop(manager);
+}
+
+/// Load-bearing LAN-521 regression: restoring first-viable anchoring selects
+/// the leading two-peer pair, making the six-peer batch, single order, and
+/// cohort-first prior order below go red.
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "the actor regression keeps fleet partitioning, RIB dialogue, and prior order in one fixture"
+)]
+async fn export_only_snapshot_selects_largest_local_policy_pair() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let peers = (1..=10)
+        .map(|last| IpAddr::V4(Ipv4Addr::new(10, 36, 1, last)))
+        .collect::<Vec<_>>();
+    let small = &peers[0..2];
+    let large = &peers[2..8];
+    let ninth = peers[8];
+    let tenth = peers[9];
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(32);
+    let rib_task = tokio::spawn(async move {
+        let mut batches = Vec::new();
+        let mut singles = Vec::new();
+        while let Some(update) = rib_rx.recv().await {
+            match update {
+                RibUpdate::ReplacePeerExportPolicies {
+                    replacements,
+                    reply,
+                } => {
+                    batches.push(
+                        replacements
+                            .into_iter()
+                            .map(|replacement| replacement.peer)
+                            .collect::<Vec<_>>(),
+                    );
+                    let _ = reply.send(Ok(rustbgpd_rib::ExportPolicyCohortOutcome::Committed));
+                }
+                RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } => {
+                    singles.push(peer);
+                    let _ = reply.send(Ok(()));
+                }
+                _ => {}
+            }
+        }
+        (batches, singles)
+    });
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    let installs = Arc::new(AtomicUsize::new(0));
+    for &peer in &peers {
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            established_export_policy_test_session(peer, Arc::clone(&installs), None),
+            false,
+        );
+    }
+
+    let pair_two_chain = distinct_deny_policy_chain(0);
+    let pair_six_chain = distinct_deny_policy_chain(1);
+    let ninth_chain = distinct_deny_policy_chain(2);
+    let tenth_chain = distinct_deny_policy_chain(3);
+    let targets = peers
+        .iter()
+        .copied()
+        .map(|address| ResolvedPeerPolicy {
+            address,
+            interface: None,
+            import_policy: None,
+            export_policy: Some(if small.contains(&address) {
+                pair_two_chain.clone()
+            } else if large.contains(&address) {
+                pair_six_chain.clone()
+            } else if address == ninth {
+                ninth_chain.clone()
+            } else {
+                tenth_chain.clone()
+            }),
+        })
+        .collect::<Vec<_>>();
+    let priors = manager
+        .apply_resolved_policy_snapshot(targets)
+        .await
+        .expect("largest-pair snapshot must commit");
+    assert_eq!(
+        priors.iter().map(|prior| prior.address).collect::<Vec<_>>(),
+        large
+            .iter()
+            .chain(small)
+            .copied()
+            .chain([ninth, tenth])
+            .collect::<Vec<_>>(),
+        "apply order remains winning cohort then caller-ordered remainder"
+    );
+    assert_eq!(installs.load(Ordering::SeqCst), peers.len());
+
+    for &peer in &peers {
+        manager.delete_peer(key(peer), false).await.unwrap();
+    }
+    drop(manager);
+    let (batches, singles) = rib_task.await.unwrap();
+    assert_eq!(batches, vec![large.to_vec()]);
+    assert_eq!(
+        singles,
+        small
+            .iter()
+            .copied()
+            .chain([ninth, tenth])
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Load-bearing LAN-521 regression: replacing the canonical tie-break with
+/// first-seen selection makes the two permutations disagree; querying beyond
+/// the winning pair makes one of the losing-pair zero counters go red.
+#[tokio::test]
+async fn export_only_cohort_tie_break_is_stable_and_queries_only_winner() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let a1 = IpAddr::V4(Ipv4Addr::new(10, 36, 2, 1));
+    let b1 = IpAddr::V4(Ipv4Addr::new(10, 36, 2, 2));
+    let b2 = IpAddr::V4(Ipv4Addr::new(10, 36, 2, 3));
+    let a2 = IpAddr::V4(Ipv4Addr::new(10, 36, 2, 4));
+    let all = [a1, b1, b2, a2];
+    let permutations = [[a1, b1, b2, a2], [b2, a2, a1, b1]];
+    let winner_policy = distinct_deny_policy_chain(4);
+    let loser_policy = distinct_deny_policy_chain(5);
+
+    for order in permutations {
+        let (rib_tx, _rib_rx) = mpsc::channel(1);
+        let (_command_tx, command_rx) = mpsc::channel(1);
+        let mut manager = PeerManager::new(
+            command_rx,
+            65001,
+            Ipv4Addr::new(10, 0, 0, 1),
+            None,
+            None,
+            BgpMetrics::new(),
+            rib_tx,
+            None,
+        );
+        let installs = Arc::new(AtomicUsize::new(0));
+        let mut queries = Vec::new();
+        for &peer in &all {
+            let (handle, peer_queries) = established_export_policy_test_session_with_queries(
+                peer,
+                Arc::clone(&installs),
+                None,
+            );
+            insert_test_managed_peer(&mut manager, peer, handle, false);
+            queries.push((peer, peer_queries));
+        }
+        let targets = order
+            .iter()
+            .copied()
+            .map(|address| ResolvedPeerPolicy {
+                address,
+                interface: None,
+                import_policy: None,
+                export_policy: Some(if [a1, a2].contains(&address) {
+                    winner_policy.clone()
+                } else {
+                    loser_policy.clone()
+                }),
+            })
+            .collect::<Vec<_>>();
+        let mask = manager.export_only_policy_cohort_mask(&targets).await;
+        let selected = order
+            .iter()
+            .zip(&mask)
+            .filter_map(|(&peer, &selected)| selected.then_some(peer))
+            .collect::<Vec<_>>();
+        let remainder = order
+            .iter()
+            .zip(mask)
+            .filter_map(|(&peer, selected)| (!selected).then_some(peer))
+            .collect::<Vec<_>>();
+        for (peer, count) in &queries {
+            assert_eq!(
+                count.load(Ordering::SeqCst),
+                usize::from([a1, a2].contains(peer)),
+                "only the canonical winning pair may receive state queries"
+            );
+        }
+        assert_eq!(
+            selected,
+            order
+                .iter()
+                .copied()
+                .filter(|peer| [a1, a2].contains(peer))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            remainder,
+            order
+                .iter()
+                .copied()
+                .filter(|peer| [b1, b2].contains(peer))
+                .collect::<Vec<_>>()
+        );
+        drop(manager);
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- rank locally eligible installed/target export-policy pairs by cohort size
- use the lowest canonical PeerKey as the deterministic equal-size tie-break
- query only the winning pair while preserving caller order, authoritative fallback, and one-cohort semantics
- update ADR-0105 to describe the as-built selection model

## Why

The first-viable selector can anchor on a smaller policy pair solely because of target enumeration order. In the measured heterogeneous fleet it selected 200 peers instead of the fixed 600-peer cohort, leaving 800 authoritative per-peer replacements.

## Load-bearing proof

- The 6/2/1/1 actor regression fails when first-viable selection is restored: the exact RIB batch, authoritative singles, and prior-token order change.
- The opposite-permutation regression fails when the canonical tie-break is removed.
- The query-isolation assertion fails when losing policy pairs are queried.
- All mutations were restored before the final gate run.

No performance claim is made here; the next immutable LAN-333 campaign remains the measurement gate.

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
- git diff --check

Linear: https://linear.app/lance0/issue/LAN-521/select-the-largest-viable-export-policy-cohort-deterministically