### PR TITLE
fix(peer): bound synchronized max-prefix restarts

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -495,6 +495,10 @@ retained as stale. By default the peer is not automatically re-enabled — use
 Setting the inheritable, non-zero `max_prefix_restart_seconds` opts that peer
 into exactly one restart attempt after the hold-down. A second breach creates a
 new hold-down; a failed attempt remains latched off until explicit enable.
+Peers whose hold-downs expire together share one 500 ms command-delivery window,
+so a stalled session cannot multiply the restart delay across the due set.
+Delivery failure replaces `last_error` with the cause and the exact
+`rbgp neighbor <addr> enable` recovery action.
 A restart-duration change, session-generation replacement, explicit disable,
 neighbor removal, or dynamic-range replacement invalidates an existing
 countdown rather than carrying it into new policy.

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -5,6 +5,7 @@ use rustbgpd_api::peer_types::{
     PeerManagerNeighborConfig, SessionLifecycleEventType, SetGshutError,
 };
 use rustbgpd_rib::RibUpdate;
+use rustbgpd_transport::{PeerCommand, PeerCommandError};
 use rustbgpd_transport::{PeerHandle, SessionIdentity, TcpAoKeyring, TransportConfig};
 use rustbgpd_wire::{Afi, Safi};
 use tokio::sync::oneshot;
@@ -16,6 +17,22 @@ use super::{
     ManagedPeer, PEER_LIFECYCLE_COMMAND_TIMEOUT, PEER_POLICY_UPDATE_TIMEOUT, PeerManager,
     PeerShutdownOutcome,
 };
+
+async fn send_max_prefix_start_before(
+    commands: tokio::sync::mpsc::Sender<PeerCommand>,
+    deadline: tokio::time::Instant,
+) -> Result<(), PeerCommandError> {
+    tokio::select! {
+        biased;
+        () = tokio::time::sleep_until(deadline) => Err(PeerCommandError::TimedOut {
+            operation: "start",
+            deadline: PEER_LIFECYCLE_COMMAND_TIMEOUT,
+        }),
+        result = commands.send(PeerCommand::Start) => {
+            result.map_err(|_| PeerCommandError::SessionExited)
+        }
+    }
+}
 
 impl PeerManager {
     fn allocate_max_prefix_latch_generation(&mut self) -> u64 {
@@ -68,18 +85,21 @@ impl PeerManager {
     }
 
     pub(super) fn invalidate_max_prefix_restart(&mut self, peer: &PeerKey) {
+        if self.invalidate_max_prefix_restart_without_recompute(peer) {
+            self.recompute_next_max_prefix_restart_deadline();
+        }
+    }
+
+    fn invalidate_max_prefix_restart_without_recompute(&mut self, peer: &PeerKey) -> bool {
         let generation = self.allocate_max_prefix_latch_generation();
-        let changed = self.max_prefix_latches.get_mut(peer).is_some_and(|latch| {
+        self.max_prefix_latches.get_mut(peer).is_some_and(|latch| {
             if latch.deadline.take().is_some() {
                 latch.generation = generation;
                 true
             } else {
                 false
             }
-        });
-        if changed {
-            self.recompute_next_max_prefix_restart_deadline();
-        }
+        })
     }
 
     pub(super) fn remove_max_prefix_latch(&mut self, peer: &PeerKey) {
@@ -145,6 +165,8 @@ impl PeerManager {
             .collect();
         due.sort_by(|left, right| left.0.cmp(&right.0));
 
+        let attempt_deadline = now + PEER_LIFECYCLE_COMMAND_TIMEOUT;
+        let mut starts = Vec::with_capacity(due.len());
         for (peer, generation) in due {
             let latch_matches = self.max_prefix_latches.get(&peer).is_some_and(|latch| {
                 latch.generation == generation
@@ -159,20 +181,20 @@ impl PeerManager {
                     && self.dynamic_restart_policy_still_current(managed)
             });
             if !latch_matches || !peer_matches {
-                self.invalidate_max_prefix_restart(&peer);
+                let _ = self.invalidate_max_prefix_restart_without_recompute(&peer);
                 continue;
             }
 
             // Consume the single automatic attempt before awaiting the bounded
             // command. Failure therefore remains an indefinite fail-closed
             // latch and can never become a retry loop.
-            self.invalidate_max_prefix_restart(&peer);
+            let _ = self.invalidate_max_prefix_restart_without_recompute(&peer);
             let address = peer.address;
             if self.bfd_should_withhold(&address) {
                 if let Some(managed) = self.peers.get_mut(&peer) {
                     managed.enabled = true;
                 }
-                self.remove_max_prefix_latch(&peer);
+                let _ = self.max_prefix_latches.remove(&peer);
                 self.set_bfd_peer_disabled(address, false);
                 self.mark_bfd_withheld(address);
                 self.publish_peer_lifecycle_event(
@@ -183,19 +205,31 @@ impl PeerManager {
                 info!(%address, "max-prefix hold-down expired; strict BFD still withholds BGP until BFD Up");
                 continue;
             }
-            let result = self
+            let commands = self
                 .peers
                 .get(&peer)
                 .expect("validated above")
                 .handle
-                .start_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT)
-                .await;
+                .commands_sender();
+            starts.push((peer, commands));
+        }
+        self.recompute_next_max_prefix_restart_deadline();
+
+        let attempts = starts
+            .iter()
+            .map(|(_, commands)| send_max_prefix_start_before(commands.clone(), attempt_deadline));
+        let results = self
+            .await_with_readiness(futures::future::join_all(attempts))
+            .await;
+
+        for ((peer, _commands), result) in starts.into_iter().zip(results) {
+            let address = peer.address;
             match result {
                 Ok(()) => {
                     if let Some(managed) = self.peers.get_mut(&peer) {
                         managed.enabled = true;
                     }
-                    self.remove_max_prefix_latch(&peer);
+                    let _ = self.max_prefix_latches.remove(&peer);
                     self.set_bfd_peer_disabled(address, false);
                     self.publish_peer_lifecycle_event(
                         &peer,
@@ -207,6 +241,12 @@ impl PeerManager {
                     info!(%address, "peer automatically restarted after max-prefix hold-down");
                 }
                 Err(error) => {
+                    if let Some(latch) = self.max_prefix_latches.get_mut(&peer) {
+                        latch.error = format!(
+                            "automatic max-prefix restart failed: {error}; peer remains disabled; run 'rbgp neighbor {} enable' to retry",
+                            peer.label()
+                        );
+                    }
                     warn!(%address, %error, "automatic max-prefix restart attempt failed; peer remains latched disabled");
                 }
             }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -2245,7 +2245,8 @@ async fn dynamic_range_removal_invalidates_max_prefix_restart() {
 
 /// Load-bearing single-attempt proof: retaining the deadline after a failed
 /// Start turns the feature into an unbounded retry loop; clearing the latch
-/// entirely weakens fail-closed recovery. Both mutations make this red.
+/// entirely weakens fail-closed recovery. Omitting failure replacement leaves
+/// the stale breach text instead of the exact recovery action.
 #[tokio::test(start_paused = true)]
 async fn failed_max_prefix_restart_becomes_indefinite_shutdown() {
     let mut mgr = test_peer_manager();
@@ -2270,12 +2271,226 @@ async fn failed_max_prefix_restart_becomes_indefinite_shutdown() {
     assert!(!managed.enabled);
     let latch = mgr.max_prefix_latches.get(&key(addr)).unwrap();
     assert!(latch.deadline.is_none());
+    assert_eq!(
+        latch.error,
+        "automatic max-prefix restart failed: session task exited; peer remains disabled; run 'rbgp neighbor 10.0.0.73 enable' to retry"
+    );
     let info = mgr.get_peer_info(&key(addr)).await.unwrap();
     assert_eq!(info.max_prefix_action, "shutdown");
     assert_eq!(info.max_prefix_restart_remaining_millis, None);
     tokio::time::advance(Duration::from_secs(10)).await;
     mgr.handle_due_max_prefix_restarts().await;
     assert!(mgr.max_prefix_latches[&key(addr)].deadline.is_none());
+}
+
+fn full_max_prefix_restart_channel(release_after: Option<Duration>) -> PeerHandle {
+    use rustbgpd_transport::PeerCommand;
+
+    let (commands, mut receiver) = mpsc::channel(1);
+    commands
+        .try_send(PeerCommand::Start)
+        .expect("pre-fill the automatic-restart command channel");
+    let task = tokio::spawn(async move {
+        if let Some(delay) = release_after {
+            tokio::time::sleep(delay).await;
+            let _ = receiver.recv().await;
+        }
+        std::future::pending::<Result<(), rustbgpd_transport::TransportError>>().await
+    });
+    PeerHandle::from_parts(commands, task)
+}
+
+/// Load-bearing aggregate-restart proof:
+/// - sequential per-peer waits make the handler exceed the exact 500 ms bound;
+/// - bypassing `await_with_readiness` leaves the queued snapshot unanswered at 100 ms;
+/// - applying futures in completion order publishes the high peer before the low peer;
+/// - retaining the breach text instead of the delivery failure breaks the exact recovery error.
+#[tokio::test(start_paused = true)]
+async fn due_max_prefix_restarts_share_one_readiness_serving_deadline() {
+    use rustbgpd_api::peer_types::PeerManagerReadinessQuery;
+
+    let low = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 80));
+    let middle = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 81));
+    let high = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 82));
+    let (_commands_tx, commands_rx) = mpsc::channel(4);
+    let (rib_tx, _rib_rx) = mpsc::channel(4);
+    let (readiness_tx, readiness_rx) = mpsc::channel(1);
+    let mut mgr = PeerManager::new(
+        commands_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    )
+    .with_readiness_queries(readiness_rx);
+    for (address, release_after) in [
+        (low, Some(Duration::from_millis(300))),
+        (middle, None),
+        (high, Some(Duration::from_millis(100))),
+    ] {
+        insert_test_managed_peer(
+            &mut mgr,
+            address,
+            full_max_prefix_restart_channel(release_after),
+            false,
+        );
+        let managed = mgr.peers.get_mut(&key(address)).unwrap();
+        managed.enabled = false;
+        managed.max_prefix_restart_seconds = Some(1);
+        assert!(mgr.install_max_prefix_latch(
+            key(address),
+            1,
+            format!("stale max-prefix breach for {address}"),
+            Some(0),
+        ));
+    }
+
+    let mut events = mgr.session_events_tx.subscribe();
+    let (readiness_reply, readiness_response) = oneshot::channel();
+    readiness_tx
+        .send(PeerManagerReadinessQuery::ListPeers {
+            reply: readiness_reply,
+        })
+        .await
+        .unwrap();
+    let started = tokio::time::Instant::now();
+    let readiness = tokio::spawn(async move {
+        let peers = readiness_response.await.unwrap();
+        (tokio::time::Instant::now(), peers)
+    });
+    let handler = tokio::spawn(async move {
+        mgr.handle_due_max_prefix_restarts().await;
+        mgr
+    });
+    tokio::task::yield_now().await;
+
+    // Check between the snapshot's 100 ms per-session bound and the 200 ms
+    // readiness contract, avoiding an assertion on the timeout timer's edge.
+    tokio::time::advance(Duration::from_millis(150)).await;
+    for _ in 0..5 {
+        tokio::task::yield_now().await;
+    }
+    assert!(readiness.is_finished());
+    let (readiness_at, peers) = readiness.await.unwrap();
+    assert_eq!(peers.len(), 3);
+    assert!(readiness_at - started < Duration::from_millis(200));
+
+    tokio::time::advance(Duration::from_millis(150)).await;
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(199)).await;
+    tokio::task::yield_now().await;
+    assert!(!handler.is_finished());
+    tokio::time::advance(Duration::from_millis(1)).await;
+    for _ in 0..5 {
+        tokio::task::yield_now().await;
+    }
+    assert!(handler.is_finished());
+    let mgr = handler.await.unwrap();
+    assert_eq!(
+        tokio::time::Instant::now() - started,
+        Duration::from_millis(500)
+    );
+
+    let enabled: Vec<IpAddr> = std::iter::from_fn(|| events.try_recv().ok())
+        .filter_map(|event| match event {
+            SessionEvent::Lifecycle(event)
+                if event.event_type == SessionLifecycleEventType::PeerEnabled =>
+            {
+                Some(event.peer)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(enabled, vec![low, high]);
+    assert!(mgr.peers[&key(low)].enabled);
+    assert!(!mgr.peers[&key(middle)].enabled);
+    assert!(mgr.peers[&key(high)].enabled);
+    assert_eq!(mgr.max_prefix_latches[&key(middle)].deadline, None);
+    assert_eq!(
+        mgr.max_prefix_latches[&key(middle)].error,
+        "automatic max-prefix restart failed: start timed out after 500ms; peer remains disabled; run 'rbgp neighbor 10.0.0.81 enable' to retry"
+    );
+}
+
+fn straddling_restart_channel(starts: Arc<AtomicU32>) -> PeerHandle {
+    use rustbgpd_transport::PeerCommand;
+
+    let (commands, mut receiver) = mpsc::channel(1);
+    commands
+        .try_send(PeerCommand::CollisionDump)
+        .expect("pre-fill the straddling command channel");
+    let task = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(550)).await;
+        let _ = receiver.recv().await;
+        while let Some(command) = receiver.recv().await {
+            if matches!(command, PeerCommand::Start) {
+                starts.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        Ok(())
+    });
+    PeerHandle::from_parts(commands, task)
+}
+
+/// Load-bearing expired-deadline proof: replacing the biased deadline-first
+/// select with `timeout_at` lets the newly writable send win when the second
+/// readiness snapshot returns after the deadline, enabling the peer and
+/// incrementing `starts` at 550 ms.
+#[tokio::test(start_paused = true)]
+async fn readiness_straddle_cannot_accept_a_late_max_prefix_start() {
+    use rustbgpd_api::peer_types::PeerManagerReadinessQuery;
+
+    let address = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 83));
+    let starts = Arc::new(AtomicU32::new(0));
+    let (readiness_tx, readiness_rx) = mpsc::channel(2);
+    let mut mgr = test_peer_manager().with_readiness_queries(readiness_rx);
+    insert_test_managed_peer(
+        &mut mgr,
+        address,
+        straddling_restart_channel(starts.clone()),
+        false,
+    );
+    let managed = mgr.peers.get_mut(&key(address)).unwrap();
+    managed.enabled = false;
+    managed.max_prefix_restart_seconds = Some(1);
+    mgr.install_max_prefix_latch(key(address), 1, "stale breach".to_string(), Some(0));
+
+    let started = tokio::time::Instant::now();
+    let handler = tokio::spawn(async move {
+        mgr.handle_due_max_prefix_restarts().await;
+        mgr
+    });
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(450)).await;
+    let (second_reply, second_response) = oneshot::channel();
+    readiness_tx
+        .send(PeerManagerReadinessQuery::ListPeers {
+            reply: second_reply,
+        })
+        .await
+        .unwrap();
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(100)).await;
+    for _ in 0..5 {
+        tokio::task::yield_now().await;
+    }
+    second_response.await.unwrap();
+    let mgr = handler.await.unwrap();
+
+    assert_eq!(
+        tokio::time::Instant::now() - started,
+        Duration::from_millis(550)
+    );
+    assert_eq!(starts.load(Ordering::SeqCst), 0);
+    assert!(!mgr.peers[&key(address)].enabled);
+    assert!(
+        mgr.max_prefix_latches[&key(address)]
+            .error
+            .contains("start timed out after 500ms")
+    );
 }
 
 fn config_neighbor(addr: IpAddr, remote_asn: u32) -> crate::config::Neighbor {


### PR DESCRIPTION
## Summary

Bound a synchronized set of automatic max-prefix restart attempts to one shared 500 ms command-delivery deadline while continuing to serve the dedicated readiness lane. Failed delivery remains fail-closed and now leaves an actionable `last_error` instead of the stale breach reason.

## Changes

- collect validated due peers in stable order and send their `Start` commands concurrently against one absolute deadline
- select the deadline branch first so readiness work cannot admit a late command after expiry
- preserve single-attempt, BFD-withhold, dynamic-peer, and latch-generation fences
- replace retained failure text with the delivery cause and exact `rbgp neighbor <addr> enable` recovery action
- document the aggregate delivery window and recovery behavior

## Load-bearing regression proof

- sequential per-peer deadlines make the aggregate test red because the handler is not finished at 500 ms
- bypassing the readiness wrapper makes the queued snapshot assertion red at 150 ms
- applying actual completion order makes lifecycle events `[high, low]` instead of canonical `[low, high]`
- removing failure replacement leaves the stale max-prefix breach text instead of the exact recovery string
- replacing the biased deadline-first select with `timeout_at` admits one late `Start` after a readiness straddle, making the zero-start assertion red

All five mutations were applied one at a time, observed red, restored, and followed by the green focused suite.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- [x] `git diff --check`
- [x] Relevant interop test intentionally not applicable: no protocol or transport wire behavior changes
- [x] Performance receipt intentionally not applicable: this bounds actor latency rather than claiming throughput improvement

## Docs / release notes

- [x] CHANGELOG.md intentionally not needed: no stable API or configuration contract changes
- [x] ROADMAP.md intentionally not needed: work is tracked in Linear
- [x] Operator documentation updated
- [x] Hot tracking doc convention not applicable

## Related issues

- [LAN-516](https://linear.app/lance0/issue/LAN-516/bound-synchronized-automatic-max-prefix-restarts-to-one-peermanager)
