### PR TITLE
fix(renderer): refuse unsupported session semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **ARouteServer renders fail stale on unsupported session semantics.**
+  `rs-config-render` now exits 2 before writing output for effective multihop,
+  IPv6-session RFC 8950, and active blackhole policy/propagation settings
+  instead of warning and silently omitting them.
+
 - **Cold-ingest fanout services readiness between outbound peers.** Ordinary
   route ingest now services the dedicated read-only readiness lane at peer
   boundaries, including mixed update-group and private-policy fleets, without

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -122,6 +122,12 @@ enforcement knobs. `shutdown` emits the positive family ceilings;
 while converting to `u32` seconds. An absent action or zero family limits emit
 neither ceilings nor a restart timer.
 
+The renderer also refuses effective nonzero multihop, RFC 8950 on an
+IPv6 session, and any active IPv4/IPv6 blackhole policy (including a
+matching per-client `announce_to_client` override). Those session and
+propagation semantics are not emitted; warning and continuing would
+silently change the route server's behavior.
+
 An empty per-client prefix or origin set aborts the whole render: an
 empty set under the default-reject tail is fail-closed for that client,
 and an empty upstream IRR answer almost always means broken data, not a

--- a/tools/rs-config-render/src/lib.rs
+++ b/tools/rs-config-render/src/lib.rs
@@ -257,7 +257,7 @@ struct Cfg {
     #[serde(default)]
     graceful_shutdown: Toggle,
     #[serde(default)]
-    blackhole_filtering: Option<serde_yaml::Value>,
+    blackhole_filtering: BlackholeFiltering,
     #[serde(default)]
     rtt_thresholds: Option<serde_yaml::Value>,
     #[serde(default)]
@@ -276,6 +276,13 @@ enum RouterId {
 struct Toggle {
     #[serde(default)]
     enabled: bool,
+}
+
+#[derive(Deserialize, Default)]
+struct BlackholeFiltering {
+    policy_ipv4: Option<String>,
+    policy_ipv6: Option<String>,
+    announce_to_client: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -405,6 +412,9 @@ struct ClientCfg {
     gtsm: Option<bool>,
     #[serde(default)]
     multihop: Option<u32>,
+    rfc8950: Option<bool>,
+    #[serde(default)]
+    blackhole_filtering: BlackholeFiltering,
     #[serde(default)]
     filtering: ClientFiltering,
 }
@@ -851,7 +861,7 @@ pub fn render(context_input: &str, opts: &Options) -> Result<Rendered, RenderErr
 
     check_refusals(&ctx, opts)?;
 
-    let resolved = resolve_clients(&ctx, opts, &mut warnings)?;
+    let resolved = resolve_clients(&ctx, opts)?;
     collect_warnings(&ctx, &mut warnings);
 
     let router_id = match &ctx.cfg.router_id {
@@ -937,6 +947,18 @@ fn check_refusals(ctx: &Context, opts: &Options) -> Result<(), RenderError> {
         );
     }
 
+    let blackhole = &cfg.blackhole_filtering;
+    for (name, policy) in [
+        ("policy_ipv4", &blackhole.policy_ipv4),
+        ("policy_ipv6", &blackhole.policy_ipv6),
+    ] {
+        if let Some(policy) = policy {
+            refusals.push(format!(
+                "general: blackhole_filtering.{name} `{policy}` is not rendered"
+            ));
+        }
+    }
+
     check_next_hop_policy(&filtering.next_hop.policy, "general", &mut refusals);
     check_reject_policy(&filtering.reject_policy.policy, "general", &mut refusals);
     if !filtering.irrdb.enforce_origin_in_as_set && !filtering.irrdb.enforce_prefix_in_as_set {
@@ -964,6 +986,32 @@ fn check_refusals(ctx: &Context, opts: &Options) -> Result<(), RenderError> {
     }
 
     for client in &ctx.clients {
+        let scope = format!("client {}", client.id);
+        let ipv6 = client.ip.contains(':');
+        let multihop = client.cfg.multihop.or(cfg.multihop).unwrap_or(0);
+        if multihop > 0 {
+            refusals.push(format!(
+                "{scope}: effective multihop={multihop} is not rendered; set this client to 0 or disable general multihop"
+            ));
+        }
+        let rfc8950 = client.cfg.rfc8950.unwrap_or(cfg.rfc8950);
+        if ipv6 && rfc8950 {
+            refusals.push(format!(
+                "{scope}: effective rfc8950=true is not rendered on IPv6 sessions"
+            ));
+        }
+        let client_has_blackhole_policy = if ipv6 {
+            blackhole.policy_ipv6.is_some() || (rfc8950 && blackhole.policy_ipv4.is_some())
+        } else {
+            blackhole.policy_ipv4.is_some()
+        };
+        let client_announce = client.cfg.blackhole_filtering.announce_to_client;
+        let general_announce = cfg.blackhole_filtering.announce_to_client.unwrap_or(true);
+        if client_has_blackhole_policy && client_announce.is_some_and(|v| v != general_announce) {
+            refusals.push(format!(
+                "{scope}: blackhole announce_to_client override is not rendered"
+            ));
+        }
         if let Some(next_hop) = &client.cfg.filtering.next_hop {
             check_next_hop_policy(
                 &next_hop.policy,
@@ -982,7 +1030,6 @@ fn check_refusals(ctx: &Context, opts: &Options) -> Result<(), RenderError> {
             filtering.max_prefix.as_ref(),
             client.cfg.filtering.max_prefix.as_ref(),
         );
-        let scope = format!("client {}", client.id);
         check_max_prefix_action(
             effective_max_prefix.action,
             effective_max_prefix.restart_after,
@@ -1155,7 +1202,6 @@ fn check_max_prefix_counting(
 fn resolve_clients<'a>(
     ctx: &'a Context,
     opts: &Options,
-    warnings: &mut Vec<String>,
 ) -> Result<Vec<ResolvedClient<'a>>, RenderError> {
     let mut resolved = Vec::new();
     let mut implausible = Vec::new();
@@ -1225,12 +1271,6 @@ fn resolve_clients<'a>(
         let add_path = client.cfg.add_path.unwrap_or(ctx.cfg.add_path);
         let per_client_best = ctx.cfg.path_hiding && !add_path;
         let gtsm = client.cfg.gtsm.unwrap_or(ctx.cfg.gtsm);
-        if client.cfg.multihop.or(ctx.cfg.multihop).is_some() {
-            warnings.push(format!(
-                "client {}: multihop is ignored (route-server clients are on-link)",
-                client.id
-            ));
-        }
         let max_prefix = effective_max_prefix(
             ctx.cfg.filtering.max_prefix.as_ref(),
             filtering.max_prefix.as_ref(),
@@ -1285,33 +1325,6 @@ fn collect_warnings(ctx: &Context, warnings: &mut Vec<String>) {
     if ctx.cfg.passive == Some(false) {
         warnings.push("passive=false is ignored: the daemon both listens and connects".to_owned());
     }
-    if ctx
-        .cfg
-        .blackhole_filtering
-        .as_ref()
-        .is_some_and(blackhole_configured)
-    {
-        warnings.push(
-            "blackhole_filtering is configured but not rendered (deferred); BLACKHOLE-tagged \
-             more-specifics are rejected by the prefix-length window terms — fail-closed, \
-             not fail-open"
-                .to_owned(),
-        );
-    }
-    if ctx.cfg.rfc8950 {
-        warnings.push(
-            "rfc8950 (IPv6 next hop for IPv4 NLRI) is not rendered yet; sessions are \
-             emitted per-family"
-                .to_owned(),
-        );
-    }
-}
-
-fn blackhole_configured(value: &serde_yaml::Value) -> bool {
-    value.as_mapping().is_some_and(|m| {
-        m.iter()
-            .any(|(k, v)| matches!(k.as_str(), Some("policy_ipv4" | "policy_ipv6")) && !v.is_null())
-    })
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/rs-config-render/tests/fixtures/context-small.yml
+++ b/tools/rs-config-render/tests/fixtures/context-small.yml
@@ -40,6 +40,7 @@ cfg:
   blackhole_filtering:
     policy_ipv4: null
     policy_ipv6: null
+    announce_to_client: true
   rtt_thresholds: null
   communities:
     blackholing: {std: null, lrg: null, ext: null}
@@ -84,6 +85,8 @@ clients:
     ip: "192.0.2.11"
     description: "member-one"
     cfg:
+      rfc8950: false
+      blackhole_filtering: {announce_to_client: true}
       filtering:
         irrdb:
           as_set_bundle_ids: ["AS4242_bundle"]
@@ -93,6 +96,8 @@ clients:
     ip: "2001:db8:0:1::22"
     description: "member-two-v6"
     cfg:
+      rfc8950: false
+      blackhole_filtering: {announce_to_client: true}
       gtsm: true
       filtering:
         irrdb:
@@ -105,6 +110,8 @@ clients:
     ip: "192.0.2.13"
     description: "member-empty-irr"
     cfg:
+      rfc8950: false
+      blackhole_filtering: {announce_to_client: true}
       filtering:
         irrdb:
           as_set_bundle_ids: ["AS51325_bundle"]

--- a/tools/rs-config-render/tests/golden.rs
+++ b/tools/rs-config-render/tests/golden.rs
@@ -39,6 +39,28 @@ fn set_path(root: &mut serde_yaml::Value, path: &[&str], new: serde_yaml::Value)
         );
 }
 
+fn set_client(root: &mut serde_yaml::Value, n: usize, path: &[&str], new: serde_yaml::Value) {
+    set_path(&mut root["clients"][n], path, new);
+}
+
+fn set_client_multihop(root: &mut serde_yaml::Value, n: usize, ttl: u64) {
+    set_client(root, n, &["cfg", "multihop"], ttl.into());
+}
+
+fn set_client_announce(root: &mut serde_yaml::Value, n: usize, value: bool) {
+    set_client(
+        root,
+        n,
+        &["cfg", "blackhole_filtering", "announce_to_client"],
+        value.into(),
+    );
+}
+
+fn set_blackhole_policy(root: &mut serde_yaml::Value, family: &str, policy: Option<&str>) {
+    let value = policy.map_or(serde_yaml::Value::Null, |p| p.into());
+    set_path(root, &["cfg", "blackhole_filtering", family], value);
+}
+
 fn to_yaml(value: &serde_yaml::Value) -> String {
     serde_yaml::to_string(value).expect("value serializes")
 }
@@ -264,6 +286,134 @@ fn refusal_matrix() {
             "no refusal containing {marker:?} for {path:?}: {items:?}"
         );
     }
+}
+
+#[test]
+/// Load-bearing: removing either field/refusal makes a nonzero case render;
+/// ignoring precedence wrongly refuses AS4242_1's explicit zero override.
+fn effective_nonzero_multihop_is_refused() {
+    use serde_yaml::Value;
+    for (general, client, id, ttl) in [(2, Some(0), "AS197000_1", 2), (0, Some(3), "AS4242_1", 3)] {
+        let mut value = healthy_value();
+        set_path(
+            &mut value,
+            &["cfg", "multihop"],
+            Value::Number(general.into()),
+        );
+        if let Some(client) = client {
+            set_client_multihop(&mut value, 0, client);
+        }
+        assert_eq!(
+            refusals(render(&to_yaml(&value), &rtr_options())),
+            [format!(
+                "client {id}: effective multihop={ttl} is not rendered; set this client to 0 or disable general multihop"
+            )]
+        );
+    }
+}
+
+#[test]
+/// Load-bearing: dropping parsing, fallback, IPv6 applicability, or explicit
+/// false precedence breaks one of these exact refusal/success verdicts.
+fn effective_rfc8950_is_refused_only_for_ipv6_sessions() {
+    use serde_yaml::Value;
+    let mut inherited = healthy_value();
+    set_path(&mut inherited, &["cfg", "rfc8950"], Value::Bool(true));
+    inherited["clients"][1]["cfg"]
+        .as_mapping_mut()
+        .unwrap()
+        .remove(Value::String("rfc8950".into()));
+    assert_eq!(
+        refusals(render(&to_yaml(&inherited), &rtr_options())),
+        ["client AS197000_1: effective rfc8950=true is not rendered on IPv6 sessions"]
+    );
+
+    let mut client = healthy_value();
+    set_client(&mut client, 1, &["cfg", "rfc8950"], Value::Bool(true));
+    assert_eq!(
+        refusals(render(&to_yaml(&client), &rtr_options())),
+        ["client AS197000_1: effective rfc8950=true is not rendered on IPv6 sessions"]
+    );
+
+    let mut inert = healthy_value();
+    set_path(&mut inert, &["cfg", "rfc8950"], Value::Bool(true));
+    render(&to_yaml(&inert), &rtr_options()).expect("client false overrides general true");
+    set_client(&mut inert, 0, &["cfg", "rfc8950"], Value::Bool(true));
+    render(&to_yaml(&inert), &rtr_options()).expect("RFC8950 is inert on an IPv4 session");
+}
+
+#[test]
+/// Load-bearing: removing policy/announce parsing misses a refusal; dropping
+/// family/value guards rejects an asserted inert case.
+fn blackhole_policy_and_matching_client_override_are_refused() {
+    use serde_yaml::Value;
+    let mut ipv6 = healthy_value();
+    set_blackhole_policy(&mut ipv6, "policy_ipv6", Some("rewrite-next-hop"));
+    set_client_announce(&mut ipv6, 0, false);
+    assert_eq!(
+        refusals(render(&to_yaml(&ipv6), &rtr_options())),
+        ["general: blackhole_filtering.policy_ipv6 `rewrite-next-hop` is not rendered"]
+    );
+
+    let mut overridden = healthy_value();
+    set_blackhole_policy(&mut overridden, "policy_ipv4", Some("propagate-unchanged"));
+    set_client_announce(&mut overridden, 0, false);
+    assert_eq!(
+        refusals(render(&to_yaml(&overridden), &rtr_options())),
+        [
+            "general: blackhole_filtering.policy_ipv4 `propagate-unchanged` is not rendered",
+            "client AS4242_1: blackhole announce_to_client override is not rendered",
+        ]
+    );
+
+    set_blackhole_policy(&mut overridden, "policy_ipv4", None);
+    render(&to_yaml(&overridden), &rtr_options()).expect("override is inert without a policy");
+
+    let mut rfc8950 = healthy_value();
+    set_blackhole_policy(&mut rfc8950, "policy_ipv4", Some("propagate-unchanged"));
+    set_client(&mut rfc8950, 1, &["cfg", "rfc8950"], Value::Bool(true));
+    set_client_announce(&mut rfc8950, 1, false);
+    assert_eq!(
+        refusals(render(&to_yaml(&rfc8950), &rtr_options())),
+        [
+            "general: blackhole_filtering.policy_ipv4 `propagate-unchanged` is not rendered",
+            "client AS197000_1: effective rfc8950=true is not rendered on IPv6 sessions",
+            "client AS197000_1: blackhole announce_to_client override is not rendered",
+        ]
+    );
+}
+
+#[test]
+/// Load-bearing: deleting the refusal exits zero and overwrites the sentinel bytes.
+fn cli_refusal_is_exit_two_and_writes_nothing() {
+    use serde_yaml::Value;
+    use std::{fs, process::Command};
+    let mut value = healthy_value();
+    set_client(&mut value, 1, &["cfg", "rfc8950"], Value::Bool(true));
+    let tmp = tempfile::tempdir().unwrap();
+    let context = tmp.path().join("context.yml");
+    let out = tmp.path().join("out");
+    let config = out.join("config.toml");
+    fs::write(&context, to_yaml(&value)).unwrap();
+    fs::create_dir(&out).unwrap();
+    fs::write(&config, b"last-good\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rs-config-render"))
+        .arg("--context")
+        .arg(context)
+        .arg("--out-dir")
+        .arg(out)
+        .arg("--rtr-cache")
+        .arg("127.0.0.1:3323")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("client AS197000_1: effective rfc8950=true is not rendered on IPv6 sessions"),
+        "{output:?}"
+    );
+    assert_eq!(fs::read(config).unwrap(), b"last-good\n");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Make `rs-config-render` honor its fail-stale contract when ARouteServer requests session or blackhole behavior rustbgpd cannot preserve. Effective nonzero multihop, RFC 8950 on IPv6 sessions, and active blackhole policy/propagation settings now refuse with exit 2 before any output is written.

## Changes

- model resolved client RFC 8950 and blackhole propagation fields without implementing those features
- resolve client-over-general multihop/RFC 8950 inheritance, including explicit false/zero overrides
- account for RFC 8950 IPv6 sessions carrying the IPv4 blackhole family
- distinguish active family-matching propagation overrides from inert resolved defaults
- replace warning-and-continue behavior with exact refusal diagnostics
- document the fail-stale behavior and record it in the changelog

## Load-bearing regression proof

Eleven one-at-a-time production mutations were observed red and restored:

- deleting multihop refusal or reversing explicit-zero precedence
- dropping client RFC 8950 parsing/precedence, general fallback, or IPv6 applicability
- deleting general blackhole refusal or client override refusal
- dropping blackhole family matching, value-difference guarding, or the RFC 8950 IPv4 cross-family clause
- deleting the CLI-triggered RFC 8950 refusal, which exits 0 and overwrites the pre-existing sentinel config

The corrected multihop remediation is independently exact: reverting production text to `use 0/unset` makes the inherited-value assertion red.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- [x] `git diff --check`
- [x] Pinned real ARouteServer 1.23.2 sectioned dump remains green
- [x] Relevant interop test intentionally not applicable: renderer refusal only; no daemon or wire behavior changes
- [x] Performance receipt intentionally not applicable

## Docs / release notes

- [x] CHANGELOG.md updated
- [x] ROADMAP.md intentionally not needed: this closes a renderer correctness gap, not a roadmap capability
- [x] Renderer README updated
- [x] Hot tracking doc convention not applicable

## Related issues

- [LAN-517](https://linear.app/lance0/issue/LAN-517/fail-stale-when-rs-config-render-cannot-preserve-arouteserver-session)
