### PR TITLE
fix(cli): report BIRD include boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **BIRD config imports report standalone `include` statements.** The bounded
+  single-file importer preserves their source lines in every parser context,
+  gives explicit flattening guidance, and exits 2 with the translated skeleton
+  for operator review.
+
 - **ARouteServer renders fail stale on unsupported session semantics.**
   `rs-config-render` now exits 2 before writing output for effective multihop,
   IPv6-session RFC 8950, and active blackhole policy/propagation settings

--- a/crates/cli/src/importer/bird.rs
+++ b/crates/cli/src/importer/bird.rs
@@ -9,6 +9,9 @@
 
 use super::{GENERIC_GUIDANCE, Group, Model, Neighbor, RPOL_GUIDANCE, Skip};
 
+const INCLUDE_GUIDANCE: &str = "BIRD imports are deliberately single-file; flatten all referenced \
+                                 files into one source before importing";
+
 #[derive(Debug)]
 enum Event {
     /// `...;` statement (semicolon stripped).
@@ -188,17 +191,23 @@ pub fn parse(input: &str) -> Model {
                 };
                 stack.push(frame);
             }
-            Event::Stmt { line, text } => match ctx(&stack) {
-                Ctx::Top => top_stmt(&mut model, line, &text),
-                Ctx::Bgp => {
-                    let Some(Frame::Bgp(acc)) = stack.last_mut() else {
-                        unreachable!("ctx said Bgp");
-                    };
-                    bgp_stmt(&mut model, acc, line, &text);
+            Event::Stmt { line, text } => {
+                if text.split_whitespace().next() == Some("include") {
+                    skip(&mut model, line, text, INCLUDE_GUIDANCE);
+                    continue;
                 }
-                Ctx::Channel(ipv6) => channel_stmt(&mut model, &mut stack, ipv6, line, &text),
-                Ctx::Ignore => {}
-            },
+                match ctx(&stack) {
+                    Ctx::Top => top_stmt(&mut model, line, &text),
+                    Ctx::Bgp => {
+                        let Some(Frame::Bgp(acc)) = stack.last_mut() else {
+                            unreachable!("ctx said Bgp");
+                        };
+                        bgp_stmt(&mut model, acc, line, &text);
+                    }
+                    Ctx::Channel(ipv6) => channel_stmt(&mut model, &mut stack, ipv6, line, &text),
+                    Ctx::Ignore => {}
+                }
+            }
             Event::Close => {
                 if let Some(Frame::Bgp(acc)) = stack.pop() {
                     finalize_bgp(&mut model, acc);

--- a/crates/cli/tests/config_import.rs
+++ b/crates/cli/tests/config_import.rs
@@ -7,6 +7,7 @@
 use rustbgpctl::importer::{ImportError, SourceFormat, detect_format, import_source, run_import};
 
 const BIRD: &str = include_str!("fixtures/import/bird.conf");
+const BIRD_INCLUDES: &str = include_str!("fixtures/import/bird-includes.conf");
 const FRR: &str = include_str!("fixtures/import/frr.conf");
 const GOBGP: &str = include_str!("fixtures/import/gobgp.toml");
 
@@ -104,6 +105,48 @@ fn bird_report_lists_skipped_stanzas_with_lines() {
     let imported = import_source(SourceFormat::Bird, "bird.conf", BIRD).expect("translates");
     assert!(!imported.config_toml.contains("example-md5-secret"));
     assert_eq!(report.exit_code, 2);
+}
+
+/// Load-bearing include-boundary proof: removing the pre-context include
+/// intercept changes or loses these diagnostics, including the one inside an
+/// otherwise ignored block. Weakening its operator guidance also changes the
+/// exact tuples.
+#[test]
+fn bird_includes_are_reported_from_every_parser_context() {
+    const GUIDANCE: &str = "BIRD imports are deliberately single-file; flatten all referenced \
+                            files into one source before importing";
+
+    let imported = import_source(SourceFormat::Bird, "bird-includes.conf", BIRD_INCLUDES)
+        .expect("translates the available skeleton");
+    assert_eq!(imported.report.source_path, "bird-includes.conf");
+    let skips = imported
+        .report
+        .skipped
+        .iter()
+        .map(|skip| (skip.line, skip.stanza.as_str(), skip.guidance.as_str()))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        skips,
+        vec![
+            (Some(1), r#"include "conf.d/*.conf""#, GUIDANCE),
+            (Some(6), r#"include "peer.conf""#, GUIDANCE),
+            (Some(9), r#"include "policy.conf""#, GUIDANCE),
+            (Some(15), r#"include "device.conf""#, GUIDANCE),
+        ]
+    );
+    assert_eq!(imported.report.exit_code, 2);
+    assert!(imported.report.warnings.is_empty());
+    assert_eq!(imported.report.local_asn, 64500);
+    assert_eq!(imported.report.router_id, "192.0.2.10");
+    assert_eq!(imported.report.neighbor_count, 1);
+    assert!(imported.config_toml.contains("address = \"192.0.2.1\""));
+    assert!(imported.config_toml.contains("remote_asn = 64496"));
+    assert!(
+        imported
+            .config_toml
+            .contains("families = [\"ipv4_unicast\"]")
+    );
 }
 
 #[test]

--- a/crates/cli/tests/fixtures/import/bird-includes.conf
+++ b/crates/cli/tests/fixtures/import/bird-includes.conf
@@ -1,0 +1,16 @@
+include "conf.d/*.conf";
+router id 192.0.2.10;
+
+protocol bgp member {
+  local as 64500;
+  include "peer.conf";
+  neighbor 192.0.2.1 as 64496;
+  ipv4 {
+    include "policy.conf";
+    import all;
+  };
+}
+
+protocol device {
+  include "device.conf";
+}

--- a/docs/cookbook/route-server-migration.md
+++ b/docs/cookbook/route-server-migration.md
@@ -34,6 +34,12 @@ deliberately not translated — a wrong mechanical policy translation would
 be worse than the honest list; the sections below are the hand-translation
 map for exactly those stanzas.
 
+The importer deliberately reads one BIRD source file and does not resolve files
+named by standalone `include` statements. Flatten every referenced file into
+one source before importing. Standalone `include` statements that remain are
+reported with their source line and make the translated skeleton exit 2 for
+operator review.
+
 ## Baseline rustbgpd shape
 
 Start from:


### PR DESCRIPTION
## Summary

- recognize standalone BIRD `include` statements before importer context dispatch
- preserve their exact source line and semicolon-free stanza while explaining that imports are deliberately single-file
- keep the translated configuration skeleton, but exit 2 so unresolved includes cannot look complete
- document the flatten-first migration boundary

## Why

The importer already failed stop on unknown top-level includes, but the generic diagnostic did not explain that referenced files were absent. Includes inside an ignored block disappeared from the report entirely, while BGP and channel contexts produced differently scoped generic skips. Operators now get one stable, actionable diagnostic in every parser context without adding filesystem, wildcard, or recursive include resolution.

This deliberately covers standalone `include` statements only. BIRD token-splice includes inside an unfinished statement remain outside the bounded scanner contract.

## Load-bearing regression proof

`bird_includes_are_reported_from_every_parser_context` pins four ordered `(line, stanza, guidance)` tuples across top-level, BGP, channel, and already-ignored contexts, along with the translated neighbor skeleton.

- deleting the pre-context production intercept leaves exit 2 intact, but changes the top/BGP/channel tuples to generic or scope-prefixed diagnostics and drops the ignored-context include; the test fails
- weakening the single-file/flatten guidance changes all four exact tuples; the test fails

Both mutations were run, observed red, restored, and rerun green.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `git diff --check origin/main...HEAD`
- focused `config_import` suite: 21/21 passed
- independent exact-diff review: GO

Five files, 99 changed lines: 29 production, 59 test/fixture, and 11 docs/changelog.

Closes LAN-510.
