### PR TITLE
docs: document live update-group comparison

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -150,7 +150,11 @@ the data-driven filtering/tooling wrapper, not the daemon.
   attributes now treat-as-withdraw / attribute-discard per §7 across all
   families with the session staying Established; session reset only where the
   NLRI is untrustworthy. Adversarially reviewed pre-merge (LAN-465).
-  Follow-ups: per-disposition counters, interop-lab malformed-attr proof.
+  **Per-disposition counters + malformed-UPDATE interop proof shipped
+  ([#1014](https://github.com/lance0/rustbgpd/pull/1014)):**
+  `bgp_update_malformed_total{peer,disposition}` records
+  `attribute_discard`, `treat_as_withdraw`, and `session_reset`, and M91 drives
+  all three through a raw-speaker lab.
 - Fanout-observability trio: ~~per-update-group / queue-depth metrics~~
   **Shipped (#962)** (`bgp_peer_outbound_queue_depth`, `bgp_peer_update_group`)
   → ~~slow-peer detection~~ **Shipped (#967)** (threshold+duration detector,
@@ -370,13 +374,17 @@ new AFI/SAFI and EVPN dataplane expansion.
   proposes, but does not authorize, an actor-owned continuation; implementation
   remains blocked on resumable container ownership and exact-export
   continuation, not RIB sharding.
-- **Expose groupability before apply.** Config transaction planning now projects
+- **Expose groupability before apply and explain it live.** Config transaction planning now projects
   established-peer update-group membership with exact fallback reasons,
   affected peers/families, shared/private totals, resync scope, and bounded
-  receipt-envelope capacity classes. Remaining: surface the same classifier in
-  policy linting and add a post-renegotiation projection; until then session
-  reshape stays explicitly indeterminate. Do not present byte-precise memory or
-  time estimates until a calibrated model exists.
+  receipt-envelope capacity classes. The shipped live comparison
+  ([#1041](https://github.com/lance0/rustbgpd/pull/1041), LAN-456) reports whether
+  two configured peers share, occupy separate groups, or use a private fallback,
+  with ID-free membership and difference reasons.
+  Predictive policy-lint and post-renegotiation projections were rejected as
+  misleading: session reshapes stay explicitly indeterminate until negotiation
+  completes. Do not present byte-precise memory or time estimates until a
+  calibrated model exists.
 - **Keep update-group correctness as a permanent fault program.** The bounded
   deterministic foundation is shipped: grouped and forced-per-peer output are
   compared under channel saturation/virtual retry, dirty policy swaps and
@@ -400,11 +408,14 @@ new AFI/SAFI and EVPN dataplane expansion.
   rotate atomically on SIGHUP; listener, path, auth-mode, principal, role, and
   access changes remain restart-required. Privilege separation remains a
   larger architectural choice, not a release-checkbox claim.
-- **Pilot route-server next-hop ownership after its identity prerequisite.**
-  ADR-0107 documents the current transparent-but-unchecked pipeline and a
-  proposed opt-in strict-peer pilot. Bind its identity to the live session
-  generation; same-AS alternate next hops and explicit authorization remain
-  later modes behind a generation-consistent fleet inventory.
+- **Route-server next-hop ownership strict-peer pilot shipped
+  ([#964](https://github.com/lance0/rustbgpd/pull/964)).**
+  [ADR-0107](docs/adr/0107-route-server-next-hop-ownership.md) is Accepted:
+  opt-in `next_hop_ownership = "strict_peer"` checks the
+  immutable wire next-hop identity before import policy and fails closed for
+  third-party or unverifiable next hops. Same-AS alternate next hops and
+  explicit authorization remain deferred behind a generation-consistent fleet
+  inventory.
 - **Single-owner RIB actor ceiling: measured at 1M; sharding stays unjustified.**
   The named-workload number that gates ADR-0100 parallel-RibManager exists
   ([the 1M actor-ceiling receipt](docs/perf/actor-ceiling-1m-2026-07.md),

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1600,6 +1600,7 @@ A peer falls back to the plain per-peer path (with identical semantics
 | `per_client_best` | RFC 7947 §2.3.2 per-client best-path is enabled (the filtered best is per-member) |
 | `orr_vantage` | The peer is bound to an ORR vantage (per-vantage bests, ADR-0095) |
 | `orf_installed` | The peer negotiated ORF-receive (peer-pushed outbound filters) |
+| `slow_peer` | Slow-peer isolation moved the peer onto its own path; it can rejoin a group after the backlog clears |
 
 RT-Constrain negotiation is deliberately **not** in this table: since
 v2 it is part of the group key, not a fallback reason. Add-Path send
@@ -1614,6 +1615,42 @@ fallback reason on its `Update Group` line. Metrics:
 (registry growth — append-only for the process lifetime), and
 `bgp_update_group_residue_entries` (withdrawal residue held while a
 member is dirty; returns to zero when its resync completes).
+
+To compare two configured peers without depending on process-local `group:N`
+identifiers, query their live memberships directly:
+
+```console
+rbgp neighbor 192.0.2.10 --compare 192.0.2.11
+rbgp --json neighbor 2001:db8::10 --compare 2001:db8::11
+```
+
+The comparison reports one of four verdicts:
+
+| Verdict | Meaning |
+|---------|---------|
+| `shared` | Both peers are grouped in the same live shared-staging group |
+| `separate` | Both peers are grouped, but their staging inputs place them in different groups |
+| `private` | Both peers have live outbound membership and at least one uses a per-peer fallback path |
+| `unknown` | At least one configured peer has no live outbound registration, or the group metadata is unavailable |
+
+The output names each side's ID-free membership as `grouped`, `unknown`, or one
+of the fallback reasons in the table above. For `separate`, `differences` uses
+stable semantic categories rather than internal IDs: `export_policy`,
+`session_kind`, `route_reflector_client`, `local_role`, `rfc1997_mode`,
+`negotiated_families`, and `llgr_families`. `shared`, `private`, and `unknown`
+carry no difference list; for private peers, the side-specific membership
+reasons explain why shared staging is unavailable.
+
+Ordinary IPv6 literals work as shown above. The normal scoped link-local
+neighbor spelling is `fe80::1%eth0`, but live update-group comparison currently
+rejects any IPv6 link-local peer (scoped or bare) with `INVALID_ARGUMENT` because
+the actor-owned membership registry is keyed by address only. Inspect each
+scoped peer's `Update Group` line separately instead.
+
+See [ADR-0098](adr/0098-update-groups.md),
+[ADR-0099](adr/0099-update-groups-v2.md), and LAN-456 /
+[#1041](https://github.com/lance0/rustbgpd/pull/1041) for the live, ID-free
+comparison design.
 
 ---
 

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -403,6 +403,31 @@ gRPC consumer gains from the recent proto additions
   screen-scraping. The response's `update_group_id` and
   `NeighborState.update_group` expose ADR-0098 group membership for
   fleet-level diagnostics.
+- **Live update-group comparison** — set
+  `GetNeighborStateRequest.compare_address` (plus the matching
+  `compare_interface` identity field when present) to compare two configured
+  peers.
+  The response's optional `NeighborState.update_group_comparison` carries an
+  ID-free `shared`, `separate`, `private`, or `unknown` verdict, each side's
+  membership (`grouped`, `unknown`, or a private-path reason), and the stable
+  semantic differences between two separate groups: export policy, session
+  kind, RR-client role, local BGP role, RFC 1997 mode, negotiated families, and
+  LLGR families. `private` means at least one side uses a per-peer fallback;
+  inspect the two membership fields for the reason. `unknown` means at least
+  one configured peer has no live outbound registration or its group metadata
+  is unavailable. Process-local values such as `NeighborState.update_group =
+  "group:N"` remain diagnostic only and must not be persisted as identifiers.
+
+  The primary peer still uses `GetNeighborStateRequest.address` plus
+  `interface`. Both peers must exist. IPv6 global addresses are supported, but
+  the daemon currently rejects a comparison involving an IPv6 link-local peer,
+  even when the usual `fe80::1` + `interface = "eth0"` scoped form is supplied.
+  The compare request/response fields were added to the existing proto, so an
+  older daemon ignores the unknown request fields and returns no
+  `update_group_comparison`; treat absence after a compare request as "feature
+  unsupported", not as `shared` and not as permission to compare `group:N`
+  strings. The in-tree `rbgp` client reports this case as
+  `update-group comparison is not supported by this daemon`.
 - **`send_hold_time` (RFC 9687)** — settable in `AddNeighbor`'s
   `NeighborConfig` and in `PeerGroupDefinition`, with the same
   validation as the config path; `ListNeighbors` reports the


### PR DESCRIPTION
## Summary

- document `rbgp neighbor <peer> --compare <peer>` and its stable JSON/operator contract
- add the recoverable `slow_peer` update-group fallback reason
- document the additive gRPC comparison request/response for embedders, including older-daemon and IPv6 link-local boundaries
- retire roadmap claims already closed by #1014, #1041, and #964

## Scope

Documentation only. No runtime, protobuf, schema, generated inventory, or release-note change.

Load-bearing mutation proof: N/A — no test or gate is added or modified.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `git diff --check`

Linear: LAN-523
