### PR TITLE
fix(bench): preserve sampler failure diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,10 @@ jobs:
           cargo test --test reloadstall_scenario_emitted_check
           bash -n bench/compare-criterion.sh
           bash -n bench/scale/route-server-1000/run-receipt.sh
-          shellcheck bench/scale/route-server-1000/run-receipt.sh
+          bash -n bench/tests/test-route-server-1000-receipt.sh
+          shellcheck bench/scale/route-server-1000/run-receipt.sh \
+            bench/tests/test-route-server-1000-receipt.sh
+          bash bench/tests/test-route-server-1000-receipt.sh
           bash -n bench/scale/compare-rrharness.sh
           bash bench/tests/test-rrharness-driver.sh
           python3 bench/scale/rebaseline/test_classifiers.py

--- a/bench/scale/route-server-1000/run-receipt.sh
+++ b/bench/scale/route-server-1000/run-receipt.sh
@@ -2,6 +2,53 @@
 # Fixed-shape retained receipt: 1,000 eBGP RS clients x 400 routes.
 set -euo pipefail
 
+pid_running() {
+    local state
+    [[ -n $1 ]] || return 1
+    state=$(awk '{print $3}' "/proc/$1/stat" 2>/dev/null) || return 1
+    [[ -n $state && $state != Z ]]
+}
+
+check_run_outcome() {
+    local hrc=$1 samplers_ok=$2 failures_ok=1 failure
+    for failure in readyz metrics rss; do
+        if [[ -e "$OUT/${failure}-failure" ]]; then
+            cat "$OUT/${failure}-failure" >&2
+            failures_ok=0
+        fi
+    done
+    [[ $hrc -eq 0 ]] || { echo "harness failed: $hrc" >&2; return 1; }
+    ((samplers_ok == 1)) || { echo "sampler completion/coverage failed" >&2; return 1; }
+    ((failures_ok == 1))
+}
+
+terminate_pid() {
+    local -n slot=$1
+    local pid=${slot:-}
+    [[ -n $pid ]] || return 0
+    if pid_running "$pid"; then
+        kill -TERM "$pid" 2>/dev/null || true
+        for _ in {1..20}; do pid_running "$pid" || break; sleep 0.1; done
+        if pid_running "$pid"; then kill -KILL "$pid" 2>/dev/null || true; fi
+    fi
+    wait "$pid" 2>/dev/null || true
+    slot=''
+}
+
+cleanup() {
+    local rc=$?
+    trap - EXIT
+    for slot in GUARD_PID READY_PID METRICS_PID RSS_PID H_PID DAEMON_PID; do terminate_pid "$slot"; done
+    if ((SUCCESS == 0)) && [[ -d $OUT ]]; then
+        printf 'status=failed\nexit_status=%s\n' "$rc" >"$OUT/exit-status.env"
+    fi
+    [[ -z $RUN ]] || rm -rf "$RUN"
+    exit "$rc"
+}
+
+# The focused mechanics test sources these exact production helpers.
+[[ ${BASH_SOURCE[0]} == "$0" ]] || return 0
+
 [[ $# -eq 0 ]] || { echo "usage: $0" >&2; exit 2; }
 for command in awk cargo curl find flock git grep mktemp nproc paste ps python3 rustc \
     sha256sum sort ss timeout tr uname xargs; do
@@ -31,31 +78,6 @@ readonly COMMIT TREE OUT
 mkdir -p "$OUT/build" "$OUT/scenario"
 chmod 700 "$OUT"
 SUCCESS=0 RUN='' DAEMON_PID='' H_PID='' READY_PID='' METRICS_PID='' RSS_PID='' GUARD_PID=''
-pid_running() {
-    [[ -n $1 && -r /proc/$1/stat ]] && [[ $(awk '{print $3}' "/proc/$1/stat") != Z ]]
-}
-terminate_pid() {
-    local -n slot=$1
-    local pid=${slot:-}
-    [[ -n $pid ]] || return 0
-    if pid_running "$pid"; then
-        kill -TERM "$pid" 2>/dev/null || true
-        for _ in {1..20}; do pid_running "$pid" || break; sleep 0.1; done
-        if pid_running "$pid"; then kill -KILL "$pid" 2>/dev/null || true; fi
-    fi
-    wait "$pid" 2>/dev/null || true
-    slot=''
-}
-cleanup() {
-    local rc=$?
-    trap - EXIT
-    for slot in GUARD_PID READY_PID METRICS_PID RSS_PID H_PID DAEMON_PID; do terminate_pid "$slot"; done
-    if ((SUCCESS == 0)) && [[ -d $OUT ]]; then
-        printf 'status=failed\nexit_status=%s\n' "$rc" >"$OUT/exit-status.env"
-    fi
-    [[ -z $RUN ]] || rm -rf "$RUN"
-    exit "$rc"
-}
 trap cleanup EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
@@ -290,9 +312,7 @@ samplers_ok=1
 wait_sampler readyz READY_PID 10 || samplers_ok=0
 wait_sampler metrics METRICS_PID 4 || samplers_ok=0
 wait_sampler rss RSS_PID 2 || samplers_ok=0
-[[ $hrc -eq 0 ]] || { echo "harness failed: $hrc" >&2; exit 1; }
-((samplers_ok == 1)) || { echo "sampler completion/coverage failed" >&2; exit 1; }
-for failure in readyz metrics rss; do [[ ! -e "$OUT/${failure}-failure" ]] || { cat "$OUT/${failure}-failure" >&2; exit 1; }; done
+check_run_outcome "$hrc" "$samplers_ok" || exit 1
 [[ -s "$OUT/metrics-after.prom" && -s "$OUT/advertised-explain.json" ]] || { echo "final evidence missing" >&2; exit 1; }
 
 awk -F, '$1=="reloadstall_csv" {n++; if ($3!=1000||$4!=1000||$5!=0||$6!=400000||$21!=0||$22!=1000||$23!=0) bad=1} END{exit bad || n!=4}' \

--- a/bench/tests/test-route-server-1000-receipt.sh
+++ b/bench/tests/test-route-server-1000-receipt.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo=$(git rev-parse --show-toplevel)
+driver="$repo/bench/scale/route-server-1000/run-receipt.sh"
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/route-server-1000-mechanics.XXXXXX")
+cleanup_tmp() { rm -rf "$tmp"; }
+trap cleanup_tmp EXIT INT TERM
+
+# shellcheck disable=SC1090 # The repository root is resolved dynamically.
+source "$driver"
+
+# Keep the production post-sampler path wired through the ordering helper. A
+# direct helper test alone would stay green if that call site were reverted.
+# shellcheck disable=SC2016 # Match the literal production shell variables.
+grep -Fxq 'check_run_outcome "$hrc" "$samplers_ok" || exit 1' "$driver" || {
+    echo 'production outcome path bypassed retained sampler diagnostics' >&2
+    exit 1
+}
+
+# Make awk lose the /proc state read for a live PID. The helper must classify
+# the process as gone without leaking the expected race to stderr.
+mkdir "$tmp/bin"
+cat >"$tmp/bin/awk" <<'EOF'
+#!/usr/bin/env bash
+if [[ ${FAKE_AWK_EMPTY:-0} == 1 ]]; then
+    exit 0
+fi
+echo 'simulated /proc stat race' >&2
+exit 2
+EOF
+chmod +x "$tmp/bin/awk"
+if PATH="$tmp/bin:$PATH" pid_running "$$" 2>"$tmp/pid.stderr"; then
+    echo 'pid_running accepted an unreadable process state' >&2
+    exit 1
+fi
+[[ ! -s "$tmp/pid.stderr" ]] || {
+    echo 'pid_running leaked a benign /proc disappearance to stderr' >&2
+    exit 1
+}
+if FAKE_AWK_EMPTY=1 PATH="$tmp/bin:$PATH" pid_running "$$"; then
+    echo 'pid_running accepted an empty process state' >&2
+    exit 1
+fi
+
+# A sampler intentionally terminates the harness after retaining its detailed
+# failure. Keep that root cause ahead of the consequential exit 143.
+OUT="$tmp/out"
+mkdir "$OUT"
+printf 'readyz exceeded 200/250ms contract: 503\t0.251\n' >"$OUT/readyz-failure"
+set +e
+(
+    set -e
+    # shellcheck disable=SC2034 # Consumed by the sourced cleanup helper.
+    SUCCESS=0 RUN=''
+    # shellcheck disable=SC2034 # Consumed by the sourced cleanup helper.
+    DAEMON_PID='' H_PID='' READY_PID='' METRICS_PID='' RSS_PID='' GUARD_PID=''
+    trap cleanup EXIT
+    check_run_outcome 143 0
+) >"$tmp/outcome.stdout" 2>"$tmp/outcome.stderr"
+outcome_rc=$?
+set -e
+if ((outcome_rc == 0)); then
+    echo 'failed harness and sampler outcome was accepted' >&2
+    exit 1
+fi
+root_line=$(grep -n -F 'readyz exceeded 200/250ms contract' "$tmp/outcome.stderr" | cut -d: -f1 || true)
+harness_line=$(grep -n -F 'harness failed: 143' "$tmp/outcome.stderr" | cut -d: -f1 || true)
+[[ -n $root_line && -n $harness_line && $root_line -lt $harness_line ]] || {
+    echo 'retained sampler root cause was not reported before harness termination' >&2
+    exit 1
+}
+[[ $(<"$OUT/exit-status.env") == $'status=failed\nexit_status=1' ]] || {
+    echo 'failed sampler outcome did not retain its nonzero exit status' >&2
+    exit 1
+}
+
+printf 'route-server-1000 receipt mechanics passed\n'


### PR DESCRIPTION
## Summary

- classify a failed or empty /proc process-state read as gone without leaking the expected race to stderr
- report retained readyz, metrics, and RSS sampler causes before the consequential harness termination
- preserve the nonzero EXIT status in the failed receipt during real cleanup
- run a focused shell regression in per-commit CI

## Scope

This changes only the retained route-server receipt harness and its CI mechanics test. It does not change the daemon, benchmark fleet shape, or performance thresholds, and it does not run or claim a new campaign.

## Load-bearing regression proof

The focused test was mutation-proven red for each guarded behavior:

- restoring the previous readable-file plus awk PID check fails with: `pid_running accepted an unreadable process state`
- removing the nonempty state guard fails with: `pid_running accepted an empty process state`
- restoring generic harness-error reporting ahead of retained sampler markers fails with: `retained sampler root cause was not reported before harness termination`
- recording a successful cleanup status for a failed sampler outcome fails with: `failed sampler outcome did not retain its nonzero exit status`
- bypassing the ordering helper at the real production post-sampler call site fails with: `production outcome path bypassed retained sampler diagnostics`

## Verification

- `bash -n bench/scale/route-server-1000/run-receipt.sh`
- `bash -n bench/tests/test-route-server-1000-receipt.sh`
- `shellcheck bench/scale/route-server-1000/run-receipt.sh bench/tests/test-route-server-1000-receipt.sh`
- `bash bench/tests/test-route-server-1000-receipt.sh`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `git diff --check origin/main...HEAD`

Linear: LAN-522