### PR TITLE
fix(rib): zero all outbound family gauges on peer down

### DIFF
--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -321,10 +321,11 @@ impl RibManager {
 
         self.clear_peer_adj_rib_in(peer);
 
-        self.metrics
-            .set_adj_rib_out_prefixes(&peer.to_string(), "all", 0);
-        self.metrics
-            .set_adj_rib_out_prefixes(&peer.to_string(), "evpn", 0);
+        let peer_label = peer.to_string();
+        for family in ["all", "flowspec", "evpn", "bgpls", "vpn", "labeled", "rtc"] {
+            self.metrics
+                .set_adj_rib_out_prefixes(&peer_label, family, 0);
+        }
         self.clear_outbound_peer_state(peer);
         self.peer_asn.remove(&peer);
         self.peer_group.remove(&peer);

--- a/crates/rib/src/manager/tests/events_metrics.rs
+++ b/crates/rib/src/manager/tests/events_metrics.rs
@@ -941,6 +941,59 @@ async fn route_event_carries_best_path_id() {
 
 // --- Prometheus gauge tests ---
 
+#[test]
+fn peer_down_zeroes_all_adj_rib_out_family_gauges() {
+    let metrics = BgpMetrics::new();
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let peer_label = peer.to_string();
+    let families = ["all", "flowspec", "evpn", "bgpls", "vpn", "labeled", "rtc"];
+
+    for (index, family) in families.iter().enumerate() {
+        metrics.set_adj_rib_out_prefixes(
+            &peer_label,
+            family,
+            i64::try_from(index + 1).expect("fixture count fits i64"),
+        );
+    }
+
+    manager.handle_update(RibUpdate::PeerDown {
+        peer,
+        session_id: 0,
+    });
+
+    // Load-bearing proof: removing any family from the production teardown
+    // reset leaves that family's seeded nonzero series behind and fails here.
+    let gathered = metrics.registry().gather();
+    let gauge = gathered
+        .iter()
+        .find(|family| family.name() == "bgp_rib_adj_out_prefixes")
+        .expect("Adj-RIB-Out gauge family remains registered");
+    for family in families {
+        let observed = gauge
+            .metric
+            .iter()
+            .find(|metric| {
+                metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "peer" && label.value() == peer_label)
+                    && metric
+                        .get_label()
+                        .iter()
+                        .any(|label| label.name() == "afi_safi" && label.value() == family)
+            })
+            .unwrap_or_else(|| panic!("PeerDown removed the {family} Adj-RIB-Out series"))
+            .get_gauge()
+            .value();
+        assert!(
+            observed.abs() < f64::EPSILON,
+            "PeerDown left the {family} Adj-RIB-Out gauge at {observed}"
+        );
+    }
+}
+
 #[tokio::test]
 #[expect(
     clippy::cast_possible_truncation,


### PR DESCRIPTION
## Summary

- zero every Adj-RIB-Out family gauge when a peer leaves
- reuse one peer-label allocation across all seven resets
- add a focused production-lifecycle regression that requires every metric series to remain present and read zero after PeerDown

## Scope

This is the correctness prerequisite for LAN-518. It changes only peer-down metric cleanup and its focused test; it does not include selective metric refresh, a benchmark, grouping behavior, or other peer lifecycle semantics.

## Load-bearing regression proof

The test seeds all seven exact `(peer, afi_safi)` series nonzero, drives `RibUpdate::PeerDown` through the production dispatcher, requires every series to remain present, and then asserts zero.

Removing only the `rtc` reset made the test fail with:

`PeerDown left the rtc Adj-RIB-Out gauge at 7`

Restoring the production reset returned the test to green. The same exact-label oracle makes removing or misspelling any other family reset red.

## Verification

- focused `peer_down_zeroes_all_adj_rib_out_family_gauges` regression
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `git diff --check origin/main...HEAD`

Independent review: GO on exact family inventory, teardown ordering, production dispatch, and non-vacuous metric lookup.

Linear: LAN-524
Blocks: LAN-518