### PR TITLE
docs: true up architecture and roadmap status

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,7 +47,7 @@ unicast Linux FIB, the BFD socket actor, and the EVPN dataplane glue).
 | `rustbgpd-evpn-linux` | Linux kernel dataplane for EVPN VTEP mode (`cfg(target_os = "linux")`). Reconciles remote-MAC FDB programming via rtnetlink, surfaces local-MAC observations from `RTNLGRP_NEIGH` upward (plus `RTNLGRP_IPV4_ROUTE` / `RTNLGRP_IPV6_ROUTE` for slice 6a sub-second IP-VRF route observation), supplies Linux rtnetlink dumps for VRF / L3VXLAN inventory (Gate 9), implements the `Dataplane::probe_ip_vrfs` IRB readiness call, and programs FDB nexthop groups via `NDA_NH_ID` / `NHA_FDB` for aliasing-ECMP receive paths (ADR-0059). `linux::nexthop_raw` is the raw-netlink primitive (rtnetlink 0.21 has no nexthop API); `linux::fdb_nhg` is the apply primitive with the CVE-2025-39851 guard; `group_state` + `nh_id_alloc` carry the refcount + NHID-tagging state the reconcile coordinator uses. Consumes domain types from `rustbgpd-evpn`; never imports `rib` or `transport`. See ADR-0054, ADR-0055, ADR-0058, ADR-0059. |
 | `rustbgpd-api` | gRPC server (tonic). Twelve services (eleven native, plus the vendored OpenConfig `gnmi.gNMI` service — Capabilities/Get/Set/Subscribe), proto codegen at build time. |
 | `rustbgpd-telemetry` | Prometheus metrics + structured tracing. |
-| `rbgp` | CLI tool. Client-only generated gRPC stubs; depends on `wire` for shared route/address-family parsing and formatting. Dev tests use `api` and `evpn` mock surfaces. |
+| `rustbgpctl` | CLI Cargo package/library; ships the `rbgp` binary. Client-only generated gRPC stubs; depends on `wire` for shared route/address-family parsing and formatting and on `policy` for policy tooling. Dev tests use `api` and `evpn` mock surfaces. |
 
 ### Hard rules
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -390,10 +390,12 @@ new AFI/SAFI and EVPN dataplane expansion.
   compared under channel saturation/virtual retry, dirty policy swaps and
   repeated regrouping, stale session generations, and RTC membership churn,
   with fixed PR schedules plus a hard-capped weekly 24-fixture parameter sweep.
-  Seeds vary identities, not operation ordering or scenario length. Remaining:
-  automated failure minimization, a broader fault matrix, restart/persistence,
-  growth measurement, and long-running folded-state comparison (LAN-18) rather
-  than relying only on bounded convergence receipts.
+  Seeds vary identities, not operation ordering or scenario length. Automated
+  failure minimization is also shipped
+  ([#1049](https://github.com/lance0/rustbgpd/pull/1049)). Remaining: a broader
+  fault matrix, restart/persistence, growth measurement, and long-running
+  folded-state comparison (LAN-18) rather than relying only on bounded
+  convergence receipts.
 - **Turn shipped shadow tooling into external evidence.** The canonical semantic
   diff engine, `rbgp diff`, incumbent snapshot adapters, and BMP Adj-RIB-Out
   importer are shipped. The remaining adoption gate is a real BIRD/FRR/GoBGP
@@ -491,8 +493,10 @@ Details in the "Recently shipped" section below and ADR-0097.
   onboarding and per-RFC receipts/conformance page current, and keep the
   published Grafana dashboard aligned with the shipped metrics. The secure
   route-server profile and RFC 9687 Send Hold Timer pieces are now shipped.
-  OSS-Fuzz submission #15874 is open and build-checked; upstream review,
-  merge, and the first hosted green build remain before onboarding is done.
+  OSS-Fuzz submission
+  [#15874](https://github.com/google/oss-fuzz/pull/15874) was closed because the
+  project does not yet meet the upstream adoption threshold; local
+  ClusterFuzzLite adoption is deferred and tracked as LAN-525.
 - **Route-server adoption polish** — the ADR-0101/M83 profile shipped the
   secure preset: RFC 7947 transparency, Add-Path and `per_client_best`
   path-hiding mitigation, RFC 9234 OTC toward members (including dynamic /


### PR DESCRIPTION
## Summary

- identify the CLI Cargo package/library as rustbgpctl while retaining rbgp as the shipped binary name
- document the CLI direct policy dependency alongside wire
- mark deterministic update-group failure minimization as shipped in #1049
- record that OSS-Fuzz onboarding was declined on current eligibility and that local ClusterFuzzLite work remains deferred

## Verification

- git diff --check
- cargo metadata --no-deps --format-version 1
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings

## Load-bearing proof

N/A: documentation-only change. Each corrected claim was checked against Cargo manifests, merged repository state, and the upstream OSS-Fuzz PR.