### PR TITLE
feat: expose max-prefix capacity metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Max-prefix capacity is alertable before teardown.** Prometheus and the
+  shipped Grafana overview expose actor-owned usage, finite limits, and
+  headroom for aggregate, IPv4-unicast, and IPv6-unicast scopes. Unlimited and
+  disconnected scopes remain absent instead of reporting fake zeroes, and the
+  example alert pack warns on sustained 80% utilization.
+
 - **Per-neighbor max-prefix headroom is operator-visible.** Neighbor detail now
   exposes the authoritative O(1) aggregate max-prefix-counted NLRI identity
   count plus unique IPv4- and IPv6-unicast prefix counts, with effective finite

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -1037,7 +1037,7 @@ async fn run_listener(
             .await
         }
         ListenerEndpoint::Uds { path, mode } => {
-            run_uds_listener(
+            Box::pin(run_uds_listener(
                 path,
                 mode,
                 access_mode,
@@ -1093,7 +1093,7 @@ async fn run_listener(
                 shutdown_rx,
                 rpc_shutdown_tx,
                 config_tx,
-            )
+            ))
             .await
         }
     }

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -136,6 +136,9 @@ pub struct BgpMetrics {
     config_transaction_lifecycle: IntCounterVec,
 
     // ── Policy ──────────────────────────────────────────────────
+    max_prefix_usage: IntGaugeVec,
+    max_prefix_limit: IntGaugeVec,
+    max_prefix_headroom: IntGaugeVec,
     max_prefix_exceeded: IntCounterVec,
 
     // ── RIB drops ───────────────────────────────────────────────
@@ -573,6 +576,33 @@ impl BgpMetrics {
                 "Number of times a peer exceeded its max-prefix limit",
             ),
             &["peer"],
+        )
+        .expect("valid metric definition");
+
+        let max_prefix_usage = IntGaugeVec::new(
+            Opts::new(
+                "bgp_max_prefix_usage",
+                "Accepted NLRI identities currently counted toward max-prefix enforcement.",
+            ),
+            &["peer", "scope"],
+        )
+        .expect("valid metric definition");
+
+        let max_prefix_limit = IntGaugeVec::new(
+            Opts::new(
+                "bgp_max_prefix_limit",
+                "Finite configured maximum for max-prefix enforcement; absent when unlimited.",
+            ),
+            &["peer", "scope"],
+        )
+        .expect("valid metric definition");
+
+        let max_prefix_headroom = IntGaugeVec::new(
+            Opts::new(
+                "bgp_max_prefix_headroom",
+                "Remaining accepted NLRI identities before the finite max-prefix limit; absent when unlimited.",
+            ),
+            &["peer", "scope"],
         )
         .expect("valid metric definition");
 
@@ -1657,6 +1687,15 @@ impl BgpMetrics {
             .register(Box::new(config_transaction_lifecycle.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(max_prefix_usage.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(max_prefix_limit.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(max_prefix_headroom.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(max_prefix_exceeded.clone()))
             .expect("metric not already registered");
         registry
@@ -2032,6 +2071,9 @@ impl BgpMetrics {
             grpc_authz_decisions,
             grpc_credential_reloads,
             config_transaction_lifecycle,
+            max_prefix_usage,
+            max_prefix_limit,
+            max_prefix_headroom,
             max_prefix_exceeded,
             outbound_route_drops,
             inbound_rib_backpressure,
@@ -2189,6 +2231,9 @@ impl BgpMetrics {
         Self::reap_peer_series_from_vec(&self.peer_update_group, peer);
         Self::reap_peer_series_from_vec(&self.rib_prefixes, peer);
         Self::reap_peer_series_from_vec(&self.rib_adj_out_prefixes, peer);
+        Self::reap_peer_series_from_vec(&self.max_prefix_usage, peer);
+        Self::reap_peer_series_from_vec(&self.max_prefix_limit, peer);
+        Self::reap_peer_series_from_vec(&self.max_prefix_headroom, peer);
         Self::reap_peer_series_from_vec(&self.max_prefix_exceeded, peer);
         Self::reap_peer_series_from_vec(&self.outbound_route_drops, peer);
         Self::reap_peer_series_from_vec(&self.rib_outbound_registration_replaced, peer);
@@ -2606,6 +2651,51 @@ impl BgpMetrics {
     /// Record a max-prefix-exceeded event for a peer.
     pub fn record_max_prefix_exceeded(&self, peer: &str) {
         self.max_prefix_exceeded.with_label_values(&[peer]).inc();
+    }
+
+    /// Publish one authoritative max-prefix accounting scope.
+    ///
+    /// `scope` is deliberately bounded to the aggregate and the two unicast
+    /// families whose independent limits are enforced by the session actor.
+    /// An unlimited scope keeps its usage series but removes limit and
+    /// headroom instead of manufacturing a misleading zero.
+    pub fn set_max_prefix_capacity(
+        &self,
+        peer: &str,
+        scope: &str,
+        usage: usize,
+        limit: Option<u32>,
+    ) {
+        debug_assert!(matches!(
+            scope,
+            "aggregate" | "ipv4_unicast" | "ipv6_unicast"
+        ));
+        let labels = [peer, scope];
+        let usage = i64::try_from(usage).unwrap_or(i64::MAX);
+        self.max_prefix_usage.with_label_values(&labels).set(usage);
+        if let Some(limit) = limit {
+            self.max_prefix_limit
+                .with_label_values(&labels)
+                .set(i64::from(limit));
+            self.max_prefix_headroom
+                .with_label_values(&labels)
+                .set(i64::from(
+                    limit.saturating_sub(u32::try_from(usage).unwrap_or(u32::MAX)),
+                ));
+        } else {
+            let _ = self.max_prefix_limit.remove_label_values(&labels);
+            let _ = self.max_prefix_headroom.remove_label_values(&labels);
+        }
+    }
+
+    /// Remove every max-prefix capacity series owned by one live session.
+    ///
+    /// This is narrower than [`Self::reap_peer_series`]: session teardown
+    /// must not erase durable peer counters such as max-prefix exceed events.
+    pub fn reap_max_prefix_capacity(&self, peer: &str) {
+        Self::reap_peer_series_from_vec(&self.max_prefix_usage, peer);
+        Self::reap_peer_series_from_vec(&self.max_prefix_limit, peer);
+        Self::reap_peer_series_from_vec(&self.max_prefix_headroom, peer);
     }
 
     /// Record an outbound route update drop for a peer.
@@ -5202,6 +5292,7 @@ mod tests {
         m.set_peer_slow(peer, true);
         m.set_rejected_routes_retained(peer, 4);
         m.set_peer_update_group(peer, 1);
+        m.set_max_prefix_capacity(peer, "aggregate", 80, Some(100));
         m.record_max_prefix_exceeded(peer);
         m.record_outbound_route_drop(peer);
         m.record_inbound_rib_backpressure(peer);
@@ -5266,8 +5357,8 @@ mod tests {
         let m = BgpMetrics::new();
         populate_all_peer_families(&m, "10.0.0.1");
         populate_all_peer_families(&m, "10.0.0.2");
-        // 40 peer-labeled families; state transitions hold two series.
-        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 40);
+        // 43 peer-labeled families; state transitions hold two series.
+        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 43);
 
         m.reap_peer_series("10.0.0.1");
 
@@ -5277,7 +5368,66 @@ mod tests {
             "peer-labeled families not reaped: {leftovers:?}"
         );
         // The other peer's series are untouched.
-        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 40);
+        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 43);
+    }
+
+    /// Load-bearing finite/unlimited proof: removing either finite gauge
+    /// update, the saturating headroom calculation, or the unlimited removal
+    /// leaves an exact value or absence assertion red.
+    #[test]
+    fn max_prefix_capacity_keeps_unlimited_distinct_from_zero() {
+        let m = BgpMetrics::new();
+        let peer = "10.0.0.1:179";
+
+        m.set_max_prefix_capacity(peer, "aggregate", 80, Some(100));
+        m.set_max_prefix_capacity(peer, "ipv4_unicast", 12, None);
+
+        let text = gather_text(&m);
+        assert!(text.contains(r#"bgp_max_prefix_usage{peer="10.0.0.1:179",scope="aggregate"} 80"#));
+        assert!(
+            text.contains(r#"bgp_max_prefix_limit{peer="10.0.0.1:179",scope="aggregate"} 100"#)
+        );
+        assert!(
+            text.contains(r#"bgp_max_prefix_headroom{peer="10.0.0.1:179",scope="aggregate"} 20"#)
+        );
+        assert!(
+            text.contains(r#"bgp_max_prefix_usage{peer="10.0.0.1:179",scope="ipv4_unicast"} 12"#)
+        );
+        assert!(
+            !text.contains(r#"bgp_max_prefix_limit{peer="10.0.0.1:179",scope="ipv4_unicast"}"#)
+        );
+        assert!(
+            !text.contains(r#"bgp_max_prefix_headroom{peer="10.0.0.1:179",scope="ipv4_unicast"}"#)
+        );
+
+        m.set_max_prefix_capacity(peer, "aggregate", 101, None);
+        let text = gather_text(&m);
+        assert!(
+            text.contains(r#"bgp_max_prefix_usage{peer="10.0.0.1:179",scope="aggregate"} 101"#)
+        );
+        assert!(!text.contains(r#"bgp_max_prefix_limit{peer="10.0.0.1:179",scope="aggregate"}"#));
+        assert!(
+            !text.contains(r#"bgp_max_prefix_headroom{peer="10.0.0.1:179",scope="aggregate"}"#)
+        );
+    }
+
+    /// Load-bearing session-reap proof: replacing the narrow reap with a zero
+    /// write leaves live capacity series, while using the broad peer reap also
+    /// deletes the durable exceed counter; either mutation makes this red.
+    #[test]
+    fn max_prefix_capacity_reap_spares_peer_history() {
+        let m = BgpMetrics::new();
+        let peer = "10.0.0.1:179";
+        m.set_max_prefix_capacity(peer, "aggregate", 80, Some(100));
+        m.record_max_prefix_exceeded(peer);
+
+        m.reap_max_prefix_capacity(peer);
+
+        let text = gather_text(&m);
+        assert!(!text.contains("bgp_max_prefix_usage"));
+        assert!(!text.contains("bgp_max_prefix_limit"));
+        assert!(!text.contains("bgp_max_prefix_headroom"));
+        assert!(text.contains(r#"bgp_max_prefix_exceeded_total{peer="10.0.0.1:179"} 1"#));
     }
 
     #[test]

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -385,6 +385,13 @@ pub enum PeerCommand {
         /// Reply channel for success/failure.
         reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
+    /// Transfer ownership of shared max-prefix capacity gauges to a promoted
+    /// inbound collision candidate after the old primary has quiesced.
+    ActivateMaxPrefixMetrics {
+        /// Acknowledges that actor ownership is active and any Established
+        /// snapshot has been published.
+        reply: oneshot::Sender<()>,
+    },
     /// Collision resolution: send Cease/7 NOTIFICATION and tear down.
     CollisionDump,
     /// ADR-0073: query this session's import-decision cache. Read-only
@@ -1199,6 +1206,40 @@ impl PeerHandle {
     pub async fn collision_dump_timeout(&self, deadline: Duration) -> Result<(), PeerCommandError> {
         self.send_simple_command_timeout(PeerCommand::CollisionDump, "collision_dump", deadline)
             .await
+    }
+
+    /// Activate shared max-prefix capacity metrics after collision promotion.
+    ///
+    /// The command is acknowledged only after an already-Established actor has
+    /// published its exact current snapshot. The manager sends it after the
+    /// retiring primary has terminated, so that primary's final reap cannot erase
+    /// the promoted owner.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the session is unreachable or does not acknowledge
+    /// within `deadline`.
+    pub async fn activate_max_prefix_metrics_timeout(
+        &self,
+        deadline: Duration,
+    ) -> Result<(), PeerCommandError> {
+        let commands = self.commands.clone();
+        match tokio::time::timeout(deadline, async move {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            commands
+                .send(PeerCommand::ActivateMaxPrefixMetrics { reply: reply_tx })
+                .await
+                .map_err(|_| PeerCommandError::SessionExited)?;
+            reply_rx.await.map_err(|_| PeerCommandError::ReplyDropped)
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(_elapsed) => Err(PeerCommandError::TimedOut {
+                operation: "activate_max_prefix_metrics",
+                deadline,
+            }),
+        }
     }
 
     /// Send a ROUTE-REFRESH message for the given address family.

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -762,6 +762,12 @@ impl PeerSession {
                 let _ = reply.send(Ok(()));
                 ControlFlow::Continue(())
             }
+            PeerCommand::ActivateMaxPrefixMetrics { reply } => {
+                self.max_prefix_metric_lease.active = true;
+                self.sync_max_prefix_capacity_metrics();
+                let _ = reply.send(());
+                ControlFlow::Continue(())
+            }
             PeerCommand::CollisionDump => {
                 info!(peer = %self.peer_label, "collision dump: sending Cease/7");
                 self.stop_requested = true;

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -438,6 +438,10 @@ impl PeerSession {
                     self.negotiated = Some(*neg);
                     self.publish_export_profile();
                     self.established_at = Some(Instant::now());
+                    // Publish the empty/current capacity snapshot only after
+                    // this actor owns a live Established session. Collision
+                    // candidates remain suppressed until manager promotion.
+                    self.sync_max_prefix_capacity_metrics();
 
                     // Emit BMP Peer Up event — reliable (awaited): losing
                     // it would leave collectors permanently blind to
@@ -664,6 +668,10 @@ impl PeerSession {
                     self.negotiated_families.clear();
                     self.add_path_receive_families.clear();
                     self.clear_known_routes();
+                    // A disconnected session has no live capacity usage.
+                    // Remove, rather than zero, so reconnect and GR-retained
+                    // RIB rows cannot masquerade as current actor state.
+                    self.reap_max_prefix_capacity_metrics();
                     self.local_open_pdu = None;
                     self.remote_open_pdu = None;
                     self.last_down_reason = None;

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -1053,6 +1053,12 @@ impl PeerSession {
                 loop_rtc_withdrawn.push(key);
             }
         }
+        // This RFC 7606/loop-rejection path only removes accepted routes and
+        // therefore does not call max-prefix enforcement. Publish after its
+        // complete accounting transaction and before the first awaited RIB
+        // delivery so actor state and gauges cannot diverge on backpressure or
+        // channel failure.
+        self.sync_max_prefix_capacity_metrics();
         if !loop_withdrawn.is_empty()
             || !loop_fs_withdrawn.is_empty()
             || !loop_evpn_withdrawn.is_empty()

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -47,7 +47,7 @@ use crate::event_sink::{NoopTransportEventSink, TransportEventSink};
 use crate::framing::ReadBuffer;
 use crate::handle::{
     PeerCommand, PeerSessionState, SessionIdentity, SessionLifecycleNotification,
-    SessionNotification, SessionNotificationDirection, SessionNotificationEvent,
+    SessionNotification, SessionNotificationDirection, SessionNotificationEvent, SessionRole,
 };
 use crate::timer::{Timers, poll_timer};
 
@@ -58,6 +58,39 @@ use self::export::remove_private_asns;
 use self::export::{SessionExportEncoder, SessionExportProfile};
 #[cfg(test)]
 use self::fsm::{hard_reset_notification_in_actions, notification_teardown_event};
+
+/// Final cleanup for shared session-owned max-prefix gauge series.
+///
+/// Keeping this as a field guard, rather than implementing `Drop` on the
+/// complete session, preserves callers' ability to move owned diagnostic
+/// fields out of a stopped `PeerSession` while still covering task abort.
+struct MaxPrefixMetricLease {
+    metrics: BgpMetrics,
+    peer: String,
+    active: bool,
+}
+
+impl MaxPrefixMetricLease {
+    fn new(metrics: BgpMetrics, peer: String, active: bool) -> Self {
+        Self {
+            metrics,
+            peer,
+            active,
+        }
+    }
+
+    fn reap(&self) {
+        if self.active {
+            self.metrics.reap_max_prefix_capacity(&self.peer);
+        }
+    }
+}
+
+impl Drop for MaxPrefixMetricLease {
+    fn drop(&mut self) {
+        self.reap();
+    }
+}
 
 /// Runtime for a single BGP peer session.
 ///
@@ -203,6 +236,11 @@ pub(crate) struct PeerSession {
     /// behavior remain authoritative.
     session_event_tx: Option<mpsc::Sender<SessionNotificationEvent>>,
     session_identity: SessionIdentity,
+    /// Whether this actor owns the shared per-peer max-prefix gauge series.
+    /// Live collision candidates stay inactive until `PeerManager` has fully
+    /// quiesced the old primary, preventing either loser from erasing the
+    /// surviving actor's values.
+    max_prefix_metric_lease: MaxPrefixMetricLease,
     /// Optional BMP event sender (None when BMP not configured).
     bmp_tx: Option<mpsc::Sender<BmpEvent>>,
     /// A `RouteMonitoring` event for this session was dropped on a full
@@ -523,6 +561,37 @@ impl PeerSession {
             + self.known_rtc.len()
     }
 
+    /// Publish all three bounded max-prefix scopes from the session actor's
+    /// O(1) enforcement accounting. Never derive these values from the RIB:
+    /// its rows have different Add-Path and lifecycle semantics.
+    fn sync_max_prefix_capacity_metrics(&self) {
+        if !self.max_prefix_metric_lease.active || self.fsm.state() != SessionState::Established {
+            return;
+        }
+        self.metrics.set_max_prefix_capacity(
+            &self.peer_label,
+            "aggregate",
+            self.known_prefix_count(),
+            self.config.max_prefixes,
+        );
+        self.metrics.set_max_prefix_capacity(
+            &self.peer_label,
+            "ipv4_unicast",
+            self.known_unicast_v4,
+            self.config.max_prefixes_ipv4,
+        );
+        self.metrics.set_max_prefix_capacity(
+            &self.peer_label,
+            "ipv6_unicast",
+            self.known_unicast_v6,
+            self.config.max_prefixes_ipv6,
+        );
+    }
+
+    fn reap_max_prefix_capacity_metrics(&self) {
+        self.max_prefix_metric_lease.reap();
+    }
+
     /// First exceeded max-prefix bound, checked in a fixed order: the
     /// legacy aggregate `max_prefixes` (all counted families), then
     /// `max_prefixes_ipv4`, then `max_prefixes_ipv6` (unique unicast
@@ -567,6 +636,7 @@ impl PeerSession {
     /// (4 octets); the aggregate keeps its historical empty data. Returns
     /// `true` when a teardown was driven.
     async fn enforce_max_prefix_limits(&mut self, include_aggregate: bool) -> bool {
+        self.sync_max_prefix_capacity_metrics();
         let Some(violation) = self.max_prefix_violation(include_aggregate) else {
             return false;
         };
@@ -884,6 +954,11 @@ impl PeerSession {
         let import_needs_as_path_string =
             Self::import_chain_needs_as_path_string(import_policy.as_ref(), explain_enabled);
         let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_BUFFER);
+        let max_prefix_metric_lease = MaxPrefixMetricLease::new(
+            metrics.clone(),
+            peer_label.clone(),
+            session_identity.role == SessionRole::Primary,
+        );
         let export_encoder = Arc::new(SessionExportEncoder::new(SessionExportProfile::initial(
             &config,
             None,
@@ -924,6 +999,7 @@ impl PeerSession {
             session_lifecycle_tx,
             session_event_tx,
             session_identity,
+            max_prefix_metric_lease,
             bmp_tx,
             bmp_stream_diverged: false,
             bmp_repair_timer: None,
@@ -1018,6 +1094,11 @@ impl PeerSession {
         let import_needs_as_path_string =
             Self::import_chain_needs_as_path_string(import_policy.as_ref(), explain_enabled);
         let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_BUFFER);
+        let max_prefix_metric_lease = MaxPrefixMetricLease::new(
+            metrics.clone(),
+            peer_label.clone(),
+            session_identity.role == SessionRole::Primary,
+        );
         let export_encoder = Arc::new(SessionExportEncoder::new(SessionExportProfile::initial(
             &config,
             stream.local_addr().ok().map(|addr| addr.ip()),
@@ -1070,6 +1151,7 @@ impl PeerSession {
             session_lifecycle_tx,
             session_event_tx,
             session_identity,
+            max_prefix_metric_lease,
             bmp_tx,
             bmp_stream_diverged: false,
             bmp_repair_timer: None,

--- a/crates/transport/src/session/refresh_accounting.rs
+++ b/crates/transport/src/session/refresh_accounting.rs
@@ -125,6 +125,7 @@ impl PeerSession {
         };
         self.arm_refresh_accounting_timer();
         self.sweep_refresh_accounting(window.stale);
+        self.sync_max_prefix_capacity_metrics();
     }
 
     /// Reconcile every due family. Called before each buffered PDU decode and

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -173,6 +173,38 @@ fn make_test_session_with_rib(
     (session, rib_rx)
 }
 
+fn make_test_session_with_metrics_and_identity(
+    metrics: BgpMetrics,
+    session_identity: SessionIdentity,
+) -> (PeerSession, mpsc::Receiver<RibUpdate>) {
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    let mut config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    config.max_prefixes = Some(10);
+    config.max_prefixes_ipv4 = Some(5);
+    let (_cmd_tx, cmd_rx) = mpsc::channel(8);
+    let (rib_tx, rib_rx) = mpsc::channel(64);
+    (
+        PeerSession::new_with_identity_and_lifecycle(
+            config,
+            metrics,
+            cmd_rx,
+            rib_tx,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            session_identity,
+        ),
+        rib_rx,
+    )
+}
+
 fn make_test_session_with_channels(
     local_asn: u32,
     remote_asn: u32,
@@ -263,6 +295,36 @@ fn install_test_negotiated_session(session: &mut PeerSession, negotiated: Negoti
         })
         .collect();
     session.negotiated = Some(negotiated);
+}
+
+fn max_prefix_gauge(metrics: &BgpMetrics, name: &str, peer: &str, scope: &str) -> Option<f64> {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == name)
+        .and_then(|family| {
+            family.get_metric().iter().find_map(|metric| {
+                let has_peer = metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "peer" && label.value() == peer);
+                let has_scope = metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "scope" && label.value() == scope);
+                (has_peer && has_scope).then(|| metric.get_gauge().value())
+            })
+        })
+}
+
+fn assert_max_prefix_gauge(session: &PeerSession, name: &str, scope: &str, expected: Option<f64>) {
+    assert_eq!(
+        max_prefix_gauge(&session.metrics, name, &session.peer_label, scope),
+        expected,
+        "unexpected {name} for {} scope {scope}",
+        session.peer_label
+    );
 }
 
 fn install_enhanced_refresh_session(
@@ -11161,6 +11223,248 @@ async fn add_path_multiplicity_counts_one_prefix_for_max_prefix() {
     );
 }
 
+/// Load-bearing metric proof: removing the ordinary UPDATE sync leaves the
+/// announce/withdraw assertions stale; counting Add-Path IDs instead of unique
+/// prefixes changes `1` to `2`; removing finite-to-unlimited child removal
+/// leaves limit/headroom present after the runtime update.
+#[tokio::test]
+async fn max_prefix_capacity_metrics_follow_updates_and_runtime_limits() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    session.config.max_prefixes = Some(10);
+    session.config.max_prefixes_ipv4 = Some(5);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    while rib_rx.try_recv().is_ok() {}
+    install_dual_stack_session(&mut session, true);
+
+    for scope in ["aggregate", "ipv4_unicast", "ipv6_unicast"] {
+        assert_max_prefix_gauge(&session, "bgp_max_prefix_usage", scope, Some(0.0));
+    }
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_limit", "aggregate", Some(10.0));
+    assert_max_prefix_gauge(
+        &session,
+        "bgp_max_prefix_headroom",
+        "ipv4_unicast",
+        Some(5.0),
+    );
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_limit", "ipv6_unicast", None);
+
+    let prefix = v4_prefix(1);
+    session.process_update(ipv4_announce(prefix, 1, true)).await;
+    session.process_update(ipv4_announce(prefix, 2, true)).await;
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_usage", "aggregate", Some(1.0));
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_usage", "ipv4_unicast", Some(1.0));
+    assert_max_prefix_gauge(
+        &session,
+        "bgp_max_prefix_headroom",
+        "ipv4_unicast",
+        Some(4.0),
+    );
+
+    session.process_update(ipv4_withdraw(prefix, 1, true)).await;
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_usage", "ipv4_unicast", Some(1.0));
+    session.process_update(ipv4_withdraw(prefix, 2, true)).await;
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_usage", "aggregate", Some(0.0));
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_usage", "ipv4_unicast", Some(0.0));
+
+    let (reply, done) = oneshot::channel();
+    assert_eq!(
+        session
+            .handle_command(PeerCommand::UpdateRuntimeConfig {
+                max_prefixes: None,
+                max_prefixes_ipv4: None,
+                max_prefixes_ipv6: None,
+                gr_stale_routes_time: session.config.gr_stale_routes_time,
+                gr_peer_restart_time_max: session.config.gr_peer_restart_time_max,
+                local_ipv6_nexthop: session.config.local_ipv6_nexthop,
+                remove_private_as: session.config.remove_private_as,
+                reply,
+            })
+            .await,
+        ControlFlow::Continue(())
+    );
+    done.await.unwrap().unwrap();
+    for scope in ["aggregate", "ipv4_unicast", "ipv6_unicast"] {
+        assert_max_prefix_gauge(&session, "bgp_max_prefix_usage", scope, Some(0.0));
+        assert_max_prefix_gauge(&session, "bgp_max_prefix_limit", scope, None);
+        assert_max_prefix_gauge(&session, "bgp_max_prefix_headroom", scope, None);
+    }
+}
+
+/// Load-bearing lifecycle proof: replacing the `SessionDown` reap with zeroes
+/// leaves a live series while disconnected, and removing the Established sync
+/// leaves the reconnect snapshot absent rather than freshly zeroed.
+#[tokio::test]
+async fn max_prefix_capacity_metrics_reap_on_down_and_republish_on_reconnect() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    session.config.max_prefixes = Some(10);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    while rib_rx.try_recv().is_ok() {}
+    session
+        .process_update(ipv4_announce(v4_prefix(1), 0, false))
+        .await;
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_usage", "aggregate", Some(1.0));
+
+    session.drive_fsm(Event::ManualStop { reason: None }).await;
+    assert_eq!(session.fsm.state(), SessionState::Idle);
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_usage", "aggregate", None);
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_limit", "aggregate", None);
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_headroom", "aggregate", None);
+
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_usage", "aggregate", Some(0.0));
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_limit", "aggregate", Some(10.0));
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_headroom", "aggregate", Some(10.0));
+}
+
+/// Load-bearing collision-loser proof: allowing an inbound candidate to own
+/// or reap the shared label changes the primary's exact `2` usage or removes
+/// it when the losing candidate drops.
+#[tokio::test]
+async fn collision_candidate_cannot_overwrite_or_reap_primary_capacity_metrics() {
+    let metrics = BgpMetrics::new();
+    let (mut primary, mut primary_rib_rx) =
+        make_test_session_with_metrics_and_identity(metrics.clone(), SessionIdentity::primary(1));
+    let (mut candidate, mut candidate_rib_rx) =
+        make_test_session_with_metrics_and_identity(metrics, SessionIdentity::inbound_candidate(2));
+    let (primary_client, _primary_server) = connected_stream_pair().await;
+    primary.test_install_stream(primary_client);
+    establish_test_session(&mut primary, 65002).await;
+    while primary_rib_rx.try_recv().is_ok() {}
+    primary
+        .process_update(ipv4_announce(v4_prefix(1), 0, false))
+        .await;
+    primary
+        .process_update(ipv4_announce(v4_prefix(2), 0, false))
+        .await;
+
+    let (candidate_client, _candidate_server) = connected_stream_pair().await;
+    candidate.test_install_stream(candidate_client);
+    establish_test_session(&mut candidate, 65002).await;
+    while candidate_rib_rx.try_recv().is_ok() {}
+    candidate
+        .process_update(ipv4_announce(v4_prefix(3), 0, false))
+        .await;
+    assert_max_prefix_gauge(&primary, "bgp_max_prefix_usage", "aggregate", Some(2.0));
+
+    drop(candidate);
+    assert_max_prefix_gauge(&primary, "bgp_max_prefix_usage", "aggregate", Some(2.0));
+}
+
+/// Load-bearing promoted-actor proof: removing either the activation command's
+/// ownership flip or its synchronous snapshot leaves the exact `1` usage and
+/// `9` headroom absent. `PeerManager` ordering is covered by its production-path
+/// collision test.
+#[tokio::test]
+async fn promoted_collision_candidate_publishes_after_old_primary_quiesces() {
+    let metrics = BgpMetrics::new();
+    let (mut primary, mut primary_rib_rx) =
+        make_test_session_with_metrics_and_identity(metrics.clone(), SessionIdentity::primary(1));
+    let (mut candidate, mut candidate_rib_rx) =
+        make_test_session_with_metrics_and_identity(metrics, SessionIdentity::inbound_candidate(2));
+    let (primary_client, _primary_server) = connected_stream_pair().await;
+    primary.test_install_stream(primary_client);
+    establish_test_session(&mut primary, 65002).await;
+    while primary_rib_rx.try_recv().is_ok() {}
+    primary
+        .process_update(ipv4_announce(v4_prefix(1), 0, false))
+        .await;
+    primary
+        .process_update(ipv4_announce(v4_prefix(2), 0, false))
+        .await;
+
+    let (candidate_client, _candidate_server) = connected_stream_pair().await;
+    candidate.test_install_stream(candidate_client);
+    establish_test_session(&mut candidate, 65002).await;
+    while candidate_rib_rx.try_recv().is_ok() {}
+    candidate
+        .process_update(ipv4_announce(v4_prefix(3), 0, false))
+        .await;
+
+    drop(primary);
+    assert_max_prefix_gauge(&candidate, "bgp_max_prefix_usage", "aggregate", None);
+    let (reply, done) = oneshot::channel();
+    assert_eq!(
+        candidate
+            .handle_command(PeerCommand::ActivateMaxPrefixMetrics { reply })
+            .await,
+        ControlFlow::Continue(())
+    );
+    done.await.unwrap();
+    assert_max_prefix_gauge(&candidate, "bgp_max_prefix_usage", "aggregate", Some(1.0));
+    assert_max_prefix_gauge(
+        &candidate,
+        "bgp_max_prefix_headroom",
+        "aggregate",
+        Some(9.0),
+    );
+}
+
+/// Load-bearing refresh proof: removing the post-sweep metric sync leaves
+/// usage at `2` after `EoRR` and at `2` after timeout instead of the exact `1`
+/// then `0` snapshots below.
+#[tokio::test(start_paused = true)]
+async fn max_prefix_capacity_metrics_follow_eorr_and_timeout_reconciliation() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    session.config.max_prefixes = Some(10);
+    session.config.max_prefixes_ipv4 = Some(5);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    while rib_rx.try_recv().is_ok() {}
+    install_enhanced_refresh_session(&mut session, vec![(Afi::Ipv4, Safi::Unicast)], false);
+
+    let replayed = v4_prefix(1);
+    let omitted = v4_prefix(2);
+    session
+        .process_update(ipv4_announce(replayed, 0, false))
+        .await;
+    session
+        .process_update(ipv4_announce(omitted, 0, false))
+        .await;
+    while rib_rx.try_recv().is_ok() {}
+    session.begin_refresh_accounting(Afi::Ipv4, Safi::Unicast);
+    session
+        .process_update(ipv4_announce(replayed, 0, false))
+        .await;
+    session.end_refresh_accounting(Afi::Ipv4, Safi::Unicast);
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_usage", "aggregate", Some(1.0));
+    assert_max_prefix_gauge(
+        &session,
+        "bgp_max_prefix_headroom",
+        "ipv4_unicast",
+        Some(4.0),
+    );
+
+    session
+        .process_update(ipv4_announce(omitted, 0, false))
+        .await;
+    while rib_rx.try_recv().is_ok() {}
+    session.begin_refresh_accounting(Afi::Ipv4, Safi::Unicast);
+    tokio::time::advance(rustbgpd_rib::ERR_REFRESH_TIMEOUT).await;
+    session.expire_refresh_accounting_windows().await.unwrap();
+    assert!(matches!(
+        rib_rx.try_recv(),
+        Ok(RibUpdate::RouteRefreshTimeout {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            ..
+        })
+    ));
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_usage", "aggregate", Some(0.0));
+    assert_max_prefix_gauge(
+        &session,
+        "bgp_max_prefix_headroom",
+        "ipv4_unicast",
+        Some(5.0),
+    );
+}
+
 /// Negotiate IPv4+IPv6 unicast on an established fixture session.
 fn install_dual_stack_session(session: &mut PeerSession, add_path: bool) {
     let mut negotiated = negotiated_session(65002, false);
@@ -15575,7 +15879,9 @@ fn assert_single_malformed_disposition(session: &PeerSession, disposition: &str)
 
 /// RFC 7606 §7.4 + §2: a malformed MED treats the UPDATE as though its
 /// routes had been withdrawn — previously accepted routes for the same
-/// NLRI are removed — and the session stays Established.
+/// NLRI are removed — and the session stays Established. Load-bearing metric
+/// proof: removing the dedicated treat-as-withdraw sync leaves usage at `2`
+/// after the production accounting removed both routes.
 #[tokio::test]
 async fn rfc7606_treat_as_withdraw_removes_routes_and_keeps_session() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -15596,6 +15902,7 @@ async fn rfc7606_treat_as_withdraw_removes_routes_and_keeps_session() {
         panic!("expected initial accepted routes");
     };
     assert_eq!(announced.len(), 2);
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_usage", "aggregate", Some(2.0));
     // Re-announce with a malformed MED appended (length 3, must be 4).
     session
         .process_update(rfc7606_update(
@@ -15619,6 +15926,7 @@ async fn rfc7606_treat_as_withdraw_removes_routes_and_keeps_session() {
     assert!(withdrawn.contains(&(Prefix::V4(prefix_a), 0)));
     assert!(withdrawn.contains(&(Prefix::V4(prefix_b), 0)));
     assert_eq!(session.known_prefix_count(), 0);
+    assert_max_prefix_gauge(&session, "bgp_max_prefix_usage", "aggregate", Some(0.0));
     assert_eq!(
         session.fsm.state(),
         SessionState::Established,

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -61,7 +61,7 @@ the next scrape.
 ## Alert rules
 
 A ready-to-load Prometheus alert-rule pack (session down/flapping,
-empty Adj-RIB-In, max-prefix breach, empty RPKI VRP table, event-outbox
+empty Adj-RIB-In, max-prefix near-limit and breach, empty RPKI VRP table, event-outbox
 degradation, update-group residue growth, stalled policy transition, a slow
 peer endpoint, actor polls above 200ms, and daemon down) ships at
 [`examples/prometheus/rustbgpd-alerts.yml`](../examples/prometheus/rustbgpd-alerts.yml),
@@ -74,6 +74,11 @@ with per-rule unit tests in
 
 - Counters are plotted with `rate(...[$__rate_interval])`; gauges are
   plotted raw. Single-stats use last-not-null.
+- Max-prefix capacity panels use the session endpoint label and the bounded
+  `aggregate`, `ipv4_unicast`, and `ipv6_unicast` scopes. Limit/headroom series
+  are intentionally absent for unlimited scopes, and every capacity series is
+  absent while the session is down; no-data is therefore distinct from zero
+  headroom.
 - Outbound queue depth is an absolute gauge of coalesced UPDATE frames, sampled
   at enqueue-batch and writer-drain boundaries. A short convergence spike is
   not itself a slow peer; `bgp_peer_slow` is the daemon's persistent 0/1 state.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -514,6 +514,17 @@ family counts cover unicast only. If the session query times out, the snapshot
 is marked stale: configured limits remain visible, but headroom is withheld
 rather than derived from placeholder zero counts.
 
+Prometheus exposes the same live actor authority as
+`bgp_max_prefix_usage`, `bgp_max_prefix_limit`, and
+`bgp_max_prefix_headroom`, keyed by `peer` and bounded `scope`
+(`aggregate`, `ipv4_unicast`, or `ipv6_unicast`). Usage is the session
+actor's enforcement count, not an alias for `bgp_rib_prefixes`: in particular,
+unicast Add-Path IDs collapse to one unique prefix while the aggregate also
+includes max-prefix-counted non-unicast identities. Limit and headroom series
+exist only for finite configured bounds. All three capacity families are
+removed when the session goes down and republished from fresh actor state on
+reconnect; GR-retained RIB rows therefore never appear as live session usage.
+
 ---
 
 ## Key metrics to watch
@@ -552,9 +563,12 @@ All `peer`-labeled series are removed when the peer is **deleted** — a static
 neighbor delete (CLI/gRPC/config reload) or a dynamic peer's auto-removal
 when its session ends. Prometheus marks the removed series stale at the next
 scrape, so deleted peers stop appearing in instant queries instead of
-freezing at their last value. A session flap or admin disable does *not*
-remove anything: a flapping peer keeps its counters and history. If a deleted
-peer is later re-added, its per-peer counters restart from zero — PromQL
+freezing at their last value. A session flap or admin disable does not remove
+durable counters or history. The live `bgp_max_prefix_usage`,
+`bgp_max_prefix_limit`, and `bgp_max_prefix_headroom` gauges are the deliberate
+exception: they are removed while the session is down and republished on
+Established. If a deleted peer is later re-added, its per-peer counters restart
+from zero — PromQL
 `rate()` / `increase()` treat that as an ordinary counter reset, so
 dashboards see no negative-rate artifacts. Process-global counters and
 families keyed by other identities (AFI/SAFI, VRF, VNI, BMP collector) are
@@ -581,6 +595,9 @@ authenticated sensitive-read surface.
 | `bgp_rib_loc_prefixes{afi_safi}` | Loc-RIB size (best paths) per AFI/SAFI |
 | `bgp_rib_prefixes{peer,afi_safi}` | Adj-RIB-In size per peer + AFI/SAFI (received) |
 | `bgp_rib_adj_out_prefixes{peer,afi_safi}` | Adj-RIB-Out size per peer + AFI/SAFI (advertised) |
+| `bgp_max_prefix_usage{peer,scope}` | Live session-actor max-prefix enforcement count for `aggregate`, `ipv4_unicast`, or `ipv6_unicast`; series are absent while the session is down |
+| `bgp_max_prefix_limit{peer,scope}` | Effective finite bound for the same scope; absent means unlimited, never zero |
+| `bgp_max_prefix_headroom{peer,scope}` | Saturating `limit - usage` for a finite scope; absent when unlimited or disconnected |
 | `bgp_rib_attr_intern_global_size` | Unique attribute sets in the daemon-wide cross-peer intern table (attribute-memory dedup across ALL peers). Tracks reclaim sweeps and growth under churn; a monotonic slope under steady-state churn indicates an intern leak. Replaces the per-peer `bgp_rib_attr_intern_size{peer}` gauge |
 | `bgp_messages_received_total` | Inbound BGP messages by type |
 | `bgp_messages_sent_total` | Outbound BGP messages by type |
@@ -676,6 +693,13 @@ without a `reason` label encode the mechanism in the metric name.
 | `bgp_update_malformed_total{peer,disposition}` | Malformed UPDATE messages by the RFC 7606 disposition applied: `attribute_discard` (offending attribute dropped, UPDATE proceeds), `treat_as_withdraw` (every route in the UPDATE handled as withdrawn, session stays Established), or `session_reset` (NOTIFICATION + teardown, retained where the NLRI cannot be trusted — including the §5.2 escalation when a treat-as-withdraw-class error arrives with no reachable NLRI). One increment per malformed UPDATE, labeled with the strongest-action disposition that governed it (§3 (h)). Each increment is accompanied by a warn log line per malformed attribute and, at DEBUG, the §6 full-message hex capture |
 | `bgp_exact_export_rejections_total{peer,family,reason}` | Post-policy announcements rejected before Adj-RIB-Out commit because the session's exact one-route encoder could not produce a legal wire message. `family` is a bounded OpenConfig AFI/SAFI label; `reason` is `encoding`, `missing_ipv6_next_hop`, `ipv4_requires_extended_next_hop`, or `message_too_long`. Alert on a sustained increase, then correlate the peer/family with the warning log's bounded route identity and detail. Series are reaped only when the configured peer is deleted. |
 | `bgp_max_prefix_exceeded_total{peer}` | `max_prefixes` ceiling breaches; each increment is followed by max-prefix teardown: bare Cease/1 without Notification GR, or RFC 8538 Hard Reset encapsulating Cease/1 when the N-bit was negotiated (see "Peer max-prefix exceeded" above) |
+
+The shipped `BgpMaxPrefixNearLimit` example alert warns after a finite scope
+has remained at or above 80% usage for ten minutes. This threshold lives in the
+editable Prometheus rule, not daemon configuration. Unlimited and disconnected
+scopes cannot fire because their limit series is absent; the existing
+`BgpMaxPrefixLimitExceeded` counter alert remains the durable post-teardown
+signal.
 
 ### Event Streams
 

--- a/docs/grafana/rustbgpd-overview.json
+++ b/docs/grafana/rustbgpd-overview.json
@@ -2515,6 +2515,48 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "id": 55,
+      "type": "timeseries",
+      "title": "Max-prefix usage and finite limit",
+      "description": "Authoritative live session-actor usage and finite configured limit by bounded scope. Limit series are absent for unlimited scopes; every series is absent while disconnected.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 144 },
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "min": 0 }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_max_prefix_usage{instance=~\"$instance\",peer=~\"$peer\"}",
+          "legendFormat": "{{peer}} {{scope}} usage",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_max_prefix_limit{instance=~\"$instance\",peer=~\"$peer\"}",
+          "legendFormat": "{{peer}} {{scope}} limit",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 56,
+      "type": "timeseries",
+      "title": "Max-prefix remaining headroom",
+      "description": "Saturating finite-limit headroom by live session endpoint and scope. No data means unlimited or disconnected, not zero headroom.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 144 },
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "min": 0 }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "asc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_max_prefix_headroom{instance=~\"$instance\",peer=~\"$peer\"}",
+          "legendFormat": "{{peer}} {{scope}}",
+          "refId": "A"
+        }
+      ]
     }
   ]
 }

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -18,11 +18,6 @@
 # Session-level metrics label peers as "<addr>:<port>" (the transport
 # remote address); RIB metrics use the bare configured neighbor address.
 #
-# Not expressible with the current metric surface (noted, not faked):
-#   - prefix-limit "approaching" (>=80%): the daemon exports only the
-#     breach counter `bgp_max_prefix_exceeded_total`, no
-#     current/configured-limit gauge pair.
-#
 # Unit tests: rustbgpd-alerts_test.yml (`promtool test rules`).
 
 groups:
@@ -123,9 +118,27 @@ groups:
           summary: "Peer {{ $labels.peer }} exceeded its max-prefix limit"
           description: >-
             Peer {{ $labels.peer }} on {{ $labels.instance }} breached
-            its configured `max_prefixes` ceiling in the last 10 minutes;
+            a configured max-prefix ceiling in the last 10 minutes;
             the session was torn down with a Cease / Maximum Number of
             Prefixes Reached NOTIFICATION.
+
+      - alert: BgpMaxPrefixNearLimit
+        # Limit series exist only for finite configured bounds. Unlimited
+        # scopes are absent rather than represented by a fake zero, and
+        # disconnected sessions reap all three capacity series.
+        expr: bgp_max_prefix_usage / bgp_max_prefix_limit >= 0.8
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            Peer {{ $labels.peer }} max-prefix {{ $labels.scope }} usage is high
+          description: >-
+            Peer {{ $labels.peer }} on {{ $labels.instance }} has remained at
+            or above 80% of its finite {{ $labels.scope }} max-prefix limit for
+            10 minutes. Continued accepted-route growth can exhaust
+            bgp_max_prefix_headroom and eventually trigger Cease / Maximum
+            Number of Prefixes Reached.
 
       - alert: RpkiVrpTableEmpty
         # Series only exist once an RTR cache has delivered data, so

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -158,10 +158,48 @@ tests:
             exp_annotations:
               summary: "Peer 192.0.2.5:179 exceeded its max-prefix limit"
               description: >-
-                Peer 192.0.2.5:179 on edge1:9179 breached its configured
-                `max_prefixes` ceiling in the last 10 minutes; the
+                Peer 192.0.2.5:179 on edge1:9179 breached a configured
+                max-prefix ceiling in the last 10 minutes; the
                 session was torn down with a Cease / Maximum Number of
                 Prefixes Reached NOTIFICATION.
+
+  # ── BgpMaxPrefixNearLimit ─────────────────────────────────────
+  # Load-bearing: deleting the usage/limit ratio, changing the 80% boundary,
+  # or dropping the 10-minute hold changes an exact firing/non-firing case.
+  # The no-limit peer pins unlimited-as-absence: usage alone must not alert.
+  - interval: 1m
+    input_series:
+      - series: 'bgp_max_prefix_usage{peer="192.0.2.7:179", scope="aggregate", instance="edge1:9179"}'
+        values: "80x15"
+      - series: 'bgp_max_prefix_limit{peer="192.0.2.7:179", scope="aggregate", instance="edge1:9179"}'
+        values: "100x15"
+      - series: 'bgp_max_prefix_usage{peer="192.0.2.8:179", scope="ipv4_unicast", instance="edge1:9179"}'
+        values: "79x15"
+      - series: 'bgp_max_prefix_limit{peer="192.0.2.8:179", scope="ipv4_unicast", instance="edge1:9179"}'
+        values: "100x15"
+      - series: 'bgp_max_prefix_usage{peer="192.0.2.9:179", scope="ipv6_unicast", instance="edge1:9179"}'
+        values: "100x15"
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: BgpMaxPrefixNearLimit
+        exp_alerts: []
+      - eval_time: 11m
+        alertname: BgpMaxPrefixNearLimit
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              peer: 192.0.2.7:179
+              scope: aggregate
+              instance: edge1:9179
+            exp_annotations:
+              summary: >-
+                Peer 192.0.2.7:179 max-prefix aggregate usage is high
+              description: >-
+                Peer 192.0.2.7:179 on edge1:9179 has remained at or above 80%
+                of its finite aggregate max-prefix limit for 10 minutes.
+                Continued accepted-route growth can exhaust
+                bgp_max_prefix_headroom and eventually trigger Cease / Maximum
+                Number of Prefixes Reached.
 
   # ── BgpPeerSlow ───────────────────────────────────────────────
   # Load-bearing: reverting `== 1`, shortening/lengthening `for: 5m`,

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -50,6 +50,15 @@ TARGETS = {
         "clamp_min(time() - bgp_policy_generation_loaded_timestamp_seconds"
         '{instance=~"$instance"}, 0)'
     ),
+    ("Max-prefix usage and finite limit", "A"): (
+        'bgp_max_prefix_usage{instance=~"$instance",peer=~"$peer"}'
+    ),
+    ("Max-prefix usage and finite limit", "B"): (
+        'bgp_max_prefix_limit{instance=~"$instance",peer=~"$peer"}'
+    ),
+    ("Max-prefix remaining headroom", "A"): (
+        'bgp_max_prefix_headroom{instance=~"$instance",peer=~"$peer"}'
+    ),
 }
 
 WORKFLOW_PATHS = {

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -546,10 +546,11 @@ impl PeerManager {
                 };
                 if let Some((old_handle, old_session_id, new_session_id)) = promoted {
                     self.register_session(new_session_id, &peer_key);
-                    self.quiesce_retiring_session(
+                    self.finish_inbound_promotion(
                         &peer_key,
                         old_session_id,
                         old_handle,
+                        new_session_id,
                         "remote-wins collision loser",
                         true,
                     )
@@ -584,7 +585,7 @@ impl PeerManager {
     pub(super) fn promote_pending_inbound_handle(
         &mut self,
         peer_key: &PeerKey,
-    ) -> Option<(PeerHandle, u64)> {
+    ) -> Option<(PeerHandle, u64, u64)> {
         let (old_handle, old_session_id, new_session_id) = {
             let managed = self.peers.get_mut(peer_key)?;
             let pending = managed.pending_inbound.take()?;
@@ -594,24 +595,80 @@ impl PeerManager {
             (old_handle, old_session_id, pending.session_id)
         };
         self.register_session(new_session_id, peer_key);
-        Some((old_handle, old_session_id))
+        Some((old_handle, old_session_id, new_session_id))
     }
 
     pub(super) async fn promote_pending_inbound(&mut self, peer_key: &PeerKey) -> bool {
-        let Some((old_handle, old_session_id)) = self.promote_pending_inbound_handle(peer_key)
+        let Some((old_handle, old_session_id, new_session_id)) =
+            self.promote_pending_inbound_handle(peer_key)
         else {
             return false;
         };
+        self.finish_inbound_promotion(
+            peer_key,
+            old_session_id,
+            old_handle,
+            new_session_id,
+            "promote pending inbound old primary",
+            false,
+        )
+        .await;
+        true
+    }
+
+    async fn finish_inbound_promotion(
+        &mut self,
+        peer_key: &PeerKey,
+        old_session_id: u64,
+        old_handle: PeerHandle,
+        new_session_id: u64,
+        context: &'static str,
+        collision_dump: bool,
+    ) {
         let _ = self
             .quiesce_retiring_session(
                 peer_key,
                 old_session_id,
                 old_handle,
-                "promote pending inbound old primary",
-                false,
+                context,
+                collision_dump,
             )
             .await;
-        true
+        self.activate_promoted_max_prefix_metrics(peer_key, new_session_id)
+            .await;
+    }
+
+    async fn activate_promoted_max_prefix_metrics(
+        &self,
+        peer_key: &PeerKey,
+        expected_session_id: u64,
+    ) {
+        let Some(managed) = self.peers.get(peer_key) else {
+            return;
+        };
+        if managed.session_id != expected_session_id {
+            warn!(
+                peer = %peer_key.address,
+                expected_session_id,
+                current_session_id = managed.session_id,
+                "skipping stale max-prefix metric ownership transfer"
+            );
+            return;
+        }
+        if let Err(error) = managed
+            .handle
+            .activate_max_prefix_metrics_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT)
+            .await
+        {
+            // Missing gauges are safer than allowing a collision loser to
+            // publish or reap the winner's shared peer label.
+            warn!(
+                peer = %peer_key.address,
+                session_id = expected_session_id,
+                %error,
+                "failed to activate promoted session max-prefix metrics"
+            );
+        }
     }
 
     pub(super) async fn replace_with_inbound(

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1520,6 +1520,7 @@ struct FakePeerCounters {
     collision_dump: AtomicU32,
     query_state: AtomicU32,
     route_refresh: AtomicU32,
+    activate_max_prefix_metrics: AtomicU32,
     shutdown: AtomicU32,
     stop: AtomicU32,
 }
@@ -1776,6 +1777,12 @@ fn fake_peer_handle_with_route_refresh_reply(
                     } else {
                         pending_route_refresh_replies.push(reply);
                     }
+                }
+                PeerCommand::ActivateMaxPrefixMetrics { reply } => {
+                    counters
+                        .activate_max_prefix_metrics
+                        .fetch_add(1, Ordering::SeqCst);
+                    let _ = reply.send(());
                 }
                 PeerCommand::CollisionDump => {
                     counters.collision_dump.fetch_add(1, Ordering::SeqCst);
@@ -15136,11 +15143,151 @@ async fn primary_back_to_idle_promotes_pending_inbound_candidate() {
 
     assert_eq!(primary.shutdown.load(Ordering::SeqCst), 1);
     assert_eq!(pending.shutdown.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        pending.activate_max_prefix_metrics.load(Ordering::SeqCst),
+        1,
+        "BackToIdle promotion must transfer capacity-metric ownership"
+    );
     assert!(
         mgr.peers
             .get(&key(peer_addr))
             .is_some_and(|m| m.pending_inbound.is_none() && m.session_id == 2),
         "pending inbound candidate should be promoted when the primary idles"
+    );
+}
+
+fn max_prefix_capacity_gauge(
+    metrics: &BgpMetrics,
+    family: &str,
+    peer: &str,
+    scope: &str,
+) -> Option<f64> {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|metric_family| metric_family.name() == family)
+        .and_then(|metric_family| {
+            metric_family.get_metric().iter().find_map(|metric| {
+                let has_peer = metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "peer" && label.value() == peer);
+                let has_scope = metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "scope" && label.value() == scope);
+                (has_peer && has_scope).then(|| metric.get_gauge().value())
+            })
+        })
+}
+
+/// Load-bearing production ordering proof: deleting `PeerManager`'s activation
+/// leaves the gauge absent after primary termination; moving activation before
+/// `quiesce_retiring_session` makes the primary's final reap erase the exact
+/// candidate value and sets `activated_before_termination`.
+#[tokio::test]
+async fn production_collision_promotion_transfers_capacity_after_primary_termination() {
+    use rustbgpd_transport::PeerCommand;
+
+    let mut mgr = test_peer_manager();
+    let peer_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let peer_label = sock(peer_addr).to_string();
+    let terminated = Arc::new(AtomicBool::new(false));
+    let activated_before_termination = Arc::new(AtomicBool::new(false));
+    let activation_count = Arc::new(AtomicU32::new(0));
+
+    mgr.metrics
+        .set_max_prefix_capacity(&peer_label, "aggregate", 2, Some(10));
+    let (primary_tx, mut primary_rx) = mpsc::channel::<PeerCommand>(8);
+    let primary_metrics = mgr.metrics.clone();
+    let primary_peer_label = peer_label.clone();
+    let primary_terminated = terminated.clone();
+    let primary_task = tokio::spawn(async move {
+        while let Some(command) = primary_rx.recv().await {
+            if matches!(command, PeerCommand::Shutdown) {
+                primary_metrics.reap_max_prefix_capacity(&primary_peer_label);
+                primary_terminated.store(true, Ordering::SeqCst);
+                break;
+            }
+        }
+        Ok(())
+    });
+    insert_test_managed_peer(
+        &mut mgr,
+        peer_addr,
+        PeerHandle::from_parts(primary_tx, primary_task),
+        false,
+    );
+
+    let (candidate_tx, mut candidate_rx) = mpsc::channel::<PeerCommand>(8);
+    let candidate_metrics = mgr.metrics.clone();
+    let candidate_peer_label = peer_label.clone();
+    let candidate_terminated = terminated.clone();
+    let candidate_early = activated_before_termination.clone();
+    let candidate_activations = activation_count.clone();
+    let candidate_task = tokio::spawn(async move {
+        while let Some(command) = candidate_rx.recv().await {
+            match command {
+                PeerCommand::ActivateMaxPrefixMetrics { reply } => {
+                    if !candidate_terminated.load(Ordering::SeqCst) {
+                        candidate_early.store(true, Ordering::SeqCst);
+                    }
+                    candidate_metrics.set_max_prefix_capacity(
+                        &candidate_peer_label,
+                        "aggregate",
+                        1,
+                        Some(10),
+                    );
+                    candidate_activations.fetch_add(1, Ordering::SeqCst);
+                    let _ = reply.send(());
+                }
+                PeerCommand::Shutdown => {
+                    candidate_metrics.reap_max_prefix_capacity(&candidate_peer_label);
+                    break;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    attach_test_pending_inbound(
+        &mut mgr,
+        peer_addr,
+        PeerHandle::from_parts(candidate_tx, candidate_task),
+        2,
+    );
+
+    assert_eq!(
+        max_prefix_capacity_gauge(
+            &mgr.metrics,
+            "bgp_max_prefix_usage",
+            &peer_label,
+            "aggregate"
+        ),
+        Some(2.0),
+        "inactive candidate must not overwrite the primary"
+    );
+
+    mgr.resolve_collision(key(peer_addr), Ipv4Addr::new(10, 0, 0, 2))
+        .await;
+
+    assert!(terminated.load(Ordering::SeqCst));
+    assert!(!activated_before_termination.load(Ordering::SeqCst));
+    assert_eq!(activation_count.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        max_prefix_capacity_gauge(
+            &mgr.metrics,
+            "bgp_max_prefix_usage",
+            &peer_label,
+            "aggregate"
+        ),
+        Some(1.0)
+    );
+    assert!(
+        mgr.peers
+            .get(&key(peer_addr))
+            .is_some_and(|managed| managed.session_id == 2 && managed.pending_inbound.is_none())
     );
 }
 


### PR DESCRIPTION
## Summary

- expose actor-owned max-prefix usage, finite limits, and remaining headroom for aggregate, IPv4-unicast, and IPv6-unicast scopes
- keep unlimited scopes and disconnected sessions absent, with collision-safe quiesce-then-activate ownership transfer
- ship Grafana panels, a sustained 80 percent Prometheus alert, rule tests, and operator documentation
- box the one UDS listener future whose size crosses the Clippy threshold after adding the metric handles

Linear: [LAN-534](https://linear.app/lance0/issue/LAN-534/rustbgpd-add-max-prefix-usage-and-headroom-capacity-metrics)

## Correctness

The gauges use the session actor O(1) accounting that already enforces max-prefix limits; they do not scan or derive from the RIB. Inactive inbound collision candidates cannot publish or reap the shared peer label. Promotion first terminates the old owner and then activates the survivor, with a session-id fence and fail-safe missing gauges if activation cannot be acknowledged.

Enhanced-refresh EoRR and timeout sweeps, RFC 7606 treat-as-withdraw, ordinary updates, session down, reconnect, unlimited transitions, and peer deletion all reconcile the same authoritative series.

## Load-bearing regression proofs

Each added or extended guard was deliberately broken and observed red before restoration:

- removing ordinary UPDATE synchronization reports usage 0 instead of 1
- removing SessionDown reaping leaves the live series present
- removing Established publication leaves the reconnect snapshot absent instead of 0
- activating a collision candidate early overwrites primary usage 2 with 1
- removing either manager promotion activation leaves the activation count at 0 instead of 1
- removing promoted-actor synchronization leaves usage absent instead of 1
- removing enhanced-refresh reconciliation leaves stale usage 2 instead of 1
- removing RFC 7606 reconciliation leaves usage 2 instead of 0
- removing unlimited-transition cleanup leaves stale limit and headroom series
- removing narrow or broad reap coverage leaves stale capacity series
- weakening the alert boundary to 79 percent produces an unexpected alert
- changing the dashboard headroom expression fails the exact-target checker
- removing the UDS future boxing fails workspace Clippy with large_futures

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
- python3 scripts/check-grafana-dashboard.py
- Prometheus 3.4.1 promtool check rules
- Prometheus 3.4.1 promtool test rules
- git diff --check origin/main..HEAD

Independent review: SHIP, no remaining findings.