### PR TITLE
ci: enforce Clippy reasons on crate attributes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ripgrep
       - run: cargo fmt --check
-      - run: python3 scripts/check-clippy-reasons.py
+      - name: Check clippy suppression reasons
+        run: |
+          python3 -m unittest -v scripts/test_check_clippy_reasons.py
+          python3 scripts/check-clippy-reasons.py
       - run: python3 scripts/check-v1-stable-surface.py
       - run: python3 scripts/reflow-release-notes.py --selftest
       - run: cargo clippy --workspace --all-targets -- -D warnings

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -764,7 +764,10 @@ fn dir_writable(path: &Path) -> bool {
 }
 
 fn human_bytes(bytes: u64) -> String {
-    #[allow(clippy::cast_precision_loss)]
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "human-readable GiB display does not need integer precision"
+    )]
     let gib = bytes as f64 / (1024.0 * 1024.0 * 1024.0);
     if gib >= 1.0 {
         format!("{gib:.1} GiB")

--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -132,7 +132,10 @@ pub async fn list(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "CLI arguments map directly to one EVPN route request"
+)]
 pub async fn add_mac_ip(
     connection: Connection,
     rd: String,
@@ -169,7 +172,10 @@ pub async fn add_mac_ip(
     output::print_result(json, "add_evpn", "", "EVPN Type 2 route added")
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "CLI arguments map directly to one EVPN route request"
+)]
 pub async fn add_imet(
     connection: Connection,
     rd: String,
@@ -203,7 +209,10 @@ pub async fn add_imet(
     output::print_result(json, "add_evpn", "", "EVPN Type 3 route added")
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "CLI arguments map directly to one EVPN route request"
+)]
 pub async fn add_ip_prefix(
     connection: Connection,
     rd: String,

--- a/crates/cli/src/commands/fib_table.rs
+++ b/crates/cli/src/commands/fib_table.rs
@@ -104,7 +104,10 @@ pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
     render(&resp, json)
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "CLI arguments map directly to one FIB-table request"
+)]
 pub async fn set(
     connection: Connection,
     name: &str,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -9,7 +9,10 @@ mod test_support;
 mod tui;
 
 pub mod proto {
-    #![allow(clippy::large_enum_variant)]
+    #![allow(
+        clippy::large_enum_variant,
+        reason = "generated protobuf types preserve the wire schema"
+    )]
 
     tonic::include_proto!("rustbgpd.v1");
 }

--- a/crates/event-history/src/lib.rs
+++ b/crates/event-history/src/lib.rs
@@ -45,7 +45,10 @@
 
 #![deny(unsafe_code)]
 #![warn(clippy::all)]
-#![allow(clippy::module_name_repetitions)]
+#![allow(
+    clippy::module_name_repetitions,
+    reason = "public cross-crate types keep the event-history domain explicit"
+)]
 
 mod cursor;
 mod error;
@@ -364,9 +367,11 @@ impl EventHistorySender {
     /// event, increments its drop counter, and flips the degraded
     /// flag. Never blocks the producer.
     // mpsc::error::TrySendError carries the envelope on the Full /
-    // Closed variants — useful for telemetry but ~200B per Err.
-    // Boxing keeps the Result small on the success path.
-    #[allow(clippy::result_large_err)]
+    // Closed variants — useful for delivery accounting despite the ~200B Err.
+    #[allow(
+        clippy::result_large_err,
+        reason = "TrySendError returns the original event when delivery fails"
+    )]
     pub fn try_send(
         &self,
         env: EventEnvelope,

--- a/scripts/check-clippy-reasons.py
+++ b/scripts/check-clippy-reasons.py
@@ -10,6 +10,8 @@ import sys
 
 
 DEFAULT_PATHS = (
+    "crates/cli/src",
+    "crates/event-history/src",
     "crates/api/src",
     "crates/rib/src",
     "crates/fsm/src",
@@ -20,7 +22,7 @@ DEFAULT_PATHS = (
     "crates/wire/src",
     "crates/bmp/src",
 )
-ATTRIBUTE_HEAD = re.compile(r"#\[\s*(?:allow|expect)\s*\(")
+ATTRIBUTE_HEAD = re.compile(r"#!?\[\s*(?:allow|expect)\s*\(")
 REASON = re.compile(r"\breason\s*=")
 
 
@@ -40,7 +42,8 @@ def find_attribute_end(text: str, start: int) -> int | None:
     in_string = False
     escaped = False
     depth = 0
-    for idx in range(start + 2, len(text)):
+    body_start = start + (3 if text.startswith("#![", start) else 2)
+    for idx in range(body_start, len(text)):
         ch = text[idx]
         if in_string:
             if escaped:

--- a/scripts/test_check_clippy_reasons.py
+++ b/scripts/test_check_clippy_reasons.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Mutation proofs for the clippy-suppression reason ratchet."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("check-clippy-reasons.py")
+SPEC = importlib.util.spec_from_file_location("check_clippy_reasons", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+checker = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(checker)
+
+
+class ClippyReasonTests(unittest.TestCase):
+    def test_crate_level_suppression_without_reason_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "lib.rs"
+            source.write_text(
+                "#![allow(clippy::module_name_repetitions)]\n", encoding="utf-8"
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), str(source)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("missing reason", result.stdout)
+        self.assertIn("#![allow(clippy::module_name_repetitions)]", result.stdout)
+        self.assertNotIn("unterminated", result.stdout)
+
+    def test_cli_and_event_history_are_ratcheted_by_default(self) -> None:
+        self.assertIn("crates/cli/src", checker.DEFAULT_PATHS)
+        self.assertIn("crates/event-history/src", checker.DEFAULT_PATHS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- recognize both item-level and crate/module-level Clippy allow/expect attributes
- ratchet CLI and event-history suppressions into the default merge gate and backfill specific reasons
- run permanent checker self-tests before the production checker in ordinary CI

## Root cause

The checker matched only the outer attribute prefix. Inner attributes were silently invisible, and CLI plus event-history were absent from the default path list, allowing new unreasoned suppressions to merge there.

## Validation

- python3 -m unittest -v scripts/test_check_clippy_reasons.py
- python3 scripts/check-clippy-reasons.py
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
- independent review: SHIP after correcting one stale adjacent comment

## Load-bearing proof

- reverting inner-attribute recognition makes the crate-level suppression self-test fail instead of silently returning success
- removing CLI or event-history from the default scope makes the exact scope self-test fail
- the production no-argument checker covers all current suppressions in both added paths

Tracks LAN-537.