### PR TITLE
fix: normalize duplicate Large Communities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **RFC 8092 Large Community duplicate normalization.** Received attributes
+  silently retain only the first occurrence of each value, and the encoder
+  applies the same stable deduplication so locally constructed API or policy
+  attributes cannot transmit duplicates. Distinct-value order, flags,
+  length-encoding rules, and malformed-length behavior remain unchanged; the
+  emitted length is recomputed from the retained values.
+
 - **TCP-AO RNext updates preserve socket policy and fresh counters.** Runtime
   RNext selection now read-modify-writes Linux `TCP_AO_INFO` without forcing
   Current or resetting counters, and composite inspection returns the trailing

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -7,6 +7,12 @@ resolved.
 
 ## Resolved
 
+- **Large community duplicates normalized (resolved).** Per RFC 8092,
+  received duplicate values are silently removed and locally constructed
+  duplicates are removed again at encode. Both boundaries retain first-seen
+  order with expected linear work; flags, distinct-value order, and malformed
+  length handling are unchanged.
+
 - **Implicit IPv4 prevents IPv6-only peers (resolved).** Per RFC 4760
   §8, IPv4 unicast was implicitly added whenever it was not explicitly
   negotiated via the MultiProtocol capability, so a peer could not be
@@ -318,10 +324,6 @@ resolved.
   route/FIB ownership across restart or verify that forwarding state survived.
   ADR-0061 FIB programming is opt-in and scoped; crash-left rows are preserved
   as foreign rather than adopted.
-- **Large community duplicates preserved.** Duplicate large communities
-  in received UPDATEs are stored and re-advertised unchanged. Strict
-  RFC 8092 normalization (dedup on receipt and before encode) is deferred
-  as a hardening item.
 - **RT/RO extended communities are 2-octet AS-Specific only.** The
   `set_community_add`/`set_community_remove` policy actions encode RT/RO
   as 2-octet AS-Specific sub-type (type 0x00). ASNs > 65535 are rejected

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -688,7 +688,8 @@ pub enum PathAttribute {
     Communities(Vec<u32>),
     /// RFC 4360 EXTENDED COMMUNITIES.
     ExtendedCommunities(Vec<ExtendedCommunity>),
-    /// RFC 8092 LARGE COMMUNITIES.
+    /// RFC 8092 LARGE COMMUNITIES. Duplicate values are normalized at
+    /// decode and encode boundaries while retaining first-seen order.
     LargeCommunities(Vec<LargeCommunity>),
     /// RFC 4456 `ORIGINATOR_ID` — original router-id of the route.
     OriginatorId(Ipv4Addr),
@@ -1242,14 +1243,16 @@ fn decode_attribute_value(
                     ),
                 });
             }
+            let mut seen = std::collections::HashSet::with_capacity(value.len() / 12);
             let communities = value
                 .chunks_exact(12)
-                .map(|c| {
-                    LargeCommunity::new(
+                .filter_map(|c| {
+                    let community = LargeCommunity::new(
                         u32::from_be_bytes([c[0], c[1], c[2], c[3]]),
                         u32::from_be_bytes([c[4], c[5], c[6], c[7]]),
                         u32::from_be_bytes([c[8], c[9], c[10], c[11]]),
-                    )
+                    );
+                    seen.insert(community).then_some(community)
                 })
                 .collect();
             Ok(PathAttribute::LargeCommunities(communities))
@@ -2223,7 +2226,11 @@ pub fn encode_path_attributes(
             PathAttribute::LargeCommunities(communities) => {
                 flags = attr_flags::OPTIONAL | attr_flags::TRANSITIVE;
                 type_code = attr_type::LARGE_COMMUNITIES;
+                let mut seen = std::collections::HashSet::with_capacity(communities.len());
                 for &c in communities {
+                    if !seen.insert(c) {
+                        continue;
+                    }
                     value.extend_from_slice(&c.global_admin.to_be_bytes());
                     value.extend_from_slice(&c.local_data1.to_be_bytes());
                     value.extend_from_slice(&c.local_data2.to_be_bytes());
@@ -4676,6 +4683,23 @@ mod tests {
         );
     }
     #[test]
+    fn decode_large_community_duplicates_preserves_first_seen_order() {
+        // RFC 8092 §3: a receiver silently removes redundant values.
+        // Load-bearing: removing receive-side dedup returns [b, a, a];
+        // reversing/sorting the retained values returns [a, b].
+        let a = LargeCommunity::new(65001, 100, 200);
+        let b = LargeCommunity::new(65002, 300, 400);
+        let mut buf = vec![0xC0, 32, 36];
+        for community in [b, a, a] {
+            buf.extend_from_slice(&community.global_admin.to_be_bytes());
+            buf.extend_from_slice(&community.local_data1.to_be_bytes());
+            buf.extend_from_slice(&community.local_data2.to_be_bytes());
+        }
+
+        let attrs = decode_path_attributes(&buf, true, &[]).unwrap();
+        assert_eq!(attrs, vec![PathAttribute::LargeCommunities(vec![b, a])]);
+    }
+    #[test]
     fn decode_large_community_bad_length() {
         // 10 bytes — not a multiple of 12
         let buf = [0xC0, 32, 10, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0];
@@ -4713,6 +4737,28 @@ mod tests {
         let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
         assert_eq!(decoded.len(), 1);
         assert_eq!(decoded[0], PathAttribute::LargeCommunities(lcs));
+    }
+    #[test]
+    fn encode_large_community_duplicates_preserves_first_seen_order() {
+        // RFC 8092 §3: duplicate values must not be transmitted.
+        // Load-bearing: removing encode-side dedup changes the raw length to
+        // 36 and emits a third value; reversing/sorting emits [a, b].
+        let a = LargeCommunity::new(65001, 100, 200);
+        let b = LargeCommunity::new(65002, 300, 400);
+        let attr = PathAttribute::LargeCommunities(vec![b, a, a]);
+        let mut buf = Vec::new();
+        encode_path_attributes(&[attr], &mut buf, true, false).unwrap();
+
+        let mut expected = vec![0xC0, 32, 24];
+        for community in [b, a] {
+            expected.extend_from_slice(&community.global_admin.to_be_bytes());
+            expected.extend_from_slice(&community.local_data1.to_be_bytes());
+            expected.extend_from_slice(&community.local_data2.to_be_bytes());
+        }
+        assert_eq!(buf, expected);
+
+        let decoded = decode_path_attributes(&buf, true, &[]).unwrap();
+        assert_eq!(decoded, vec![PathAttribute::LargeCommunities(vec![b, a])]);
     }
     #[test]
     fn large_community_expected_flags_validated() {

--- a/docs/adr/0031-large-communities.md
+++ b/docs/adr/0031-large-communities.md
@@ -21,8 +21,14 @@ communities (8 bytes). This is table stakes for any operator using
 
 `PathAttribute::LargeCommunities(Vec<LargeCommunity>)` variant with
 type code 32, flags `OPTIONAL | TRANSITIVE`. Decode validates length
-is a multiple of 12 and parses `chunks_exact(12)` into three `u32`s.
-Encode outputs three `u32::to_be_bytes()` per community.
+is a non-zero multiple of 12 and parses `chunks_exact(12)` into three
+`u32`s. Per RFC 8092 Section 3, decode silently removes duplicate values,
+retaining deterministic first-seen order. Encode repeats the same stable
+deduplication at the wire boundary so directly constructed API or policy
+attributes cannot transmit duplicates. Both boundaries use expected O(n)
+set membership; distinct-value ordering, flags, and length encoding are
+otherwise unchanged. Encode outputs three `u32::to_be_bytes()` per retained
+community.
 
 ### RIB
 
@@ -53,4 +59,6 @@ use the same `"LC:65001:100:200"` format. Applied by
 
 - 4-byte ASN operators can use community-based policy with rustbgpd
 - Wire codec adds one new attribute type (well-tested pattern)
+- Received and locally constructed duplicate values normalize before storage
+  or transmission, respectively
 - Consistent with existing community handling at all layers


### PR DESCRIPTION
## Summary

- remove duplicate RFC 8092 Large Community values at the receive boundary before storage
- independently deduplicate locally constructed values at encode so duplicates cannot be transmitted
- retain first-seen order with expected O(n) membership and preserve existing flags and malformed-length handling
- update the existing ADR, known-issue disposition, and changelog

Closes LAN-540.

## Load-bearing proof

- removing receive-side dedup returns three values and makes the decode regression fail
- removing encode-side dedup emits a 36-byte value with a third community and makes the raw-wire regression fail
- reversing either retained boundary order changes the deliberately noncanonical `B, A` result to `A, B` and makes its exact regression fail

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`

Behavior follows RFC 8092 sections 3 and 6: duplicate values are normalized, while malformed non-zero/multiple-of-12 length handling remains separate.
