### PR TITLE
test: establish tier-auth interop harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,15 @@ jobs:
         run: |
           python3 -m unittest -v scripts/test_check_clippy_reasons.py
           python3 scripts/check-clippy-reasons.py
+      - name: Check shared test-only interop authentication helper
+        run: |
+          bash -n tests/interop/scripts/test-lib.sh \
+            tests/interop/scripts/test-test-operator-auth-helper.sh \
+            tests/interop/scripts/test-m1-frr.sh
+          shellcheck -x tests/interop/scripts/test-lib.sh \
+            tests/interop/scripts/test-test-operator-auth-helper.sh \
+            tests/interop/scripts/test-m1-frr.sh
+          bash tests/interop/scripts/test-test-operator-auth-helper.sh
       - run: python3 scripts/check-v1-stable-surface.py
       - run: python3 scripts/reflow-release-notes.py --selftest
       - run: cargo clippy --workspace --all-targets -- -D warnings

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ docker compose up -d
 
 Once both containers are running (a few seconds):
 
+The Compose service supplies its committed, public **test-only** bearer token
+to in-container `rbgp` commands. It is for this runnable demo, not deployment.
+
 ```bash
 # See the FRR peer come up
 docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 summary

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -485,10 +485,14 @@ FRR advertises: 192.168.1.0/24, 192.168.2.0/24, 10.10.0.0/16 via `network` state
 ### Test 1: Routes Appear in RIB
 
 After session reaches Established, wait for UPDATEs to propagate (typically <5s).
-Query via gRPC:
+The topology uses the repository's public test-only operator token. The
+automated M1 driver adds this header through the shared helper; for a manual
+query, load the same fixture:
 
 ```sh
+TOKEN=$(cat tests/fixtures/grpc-test-only-operator.token)
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -H "authorization: Bearer $TOKEN" \
   -d '{"neighbor_address": "10.0.0.2"}' \
   <rustbgpd-mgmt-ip>:50051 rustbgpd.v1.RibService/ListReceivedRoutes
 ```
@@ -568,7 +572,9 @@ match the Adj-RIB-In received routes, with `best: true` set.
 ### Test 1: ListBestRoutes Returns Correct Routes
 
 ```sh
+TOKEN=$(cat tests/fixtures/grpc-test-only-operator.token)
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -H "authorization: Bearer $TOKEN" \
   <rustbgpd-mgmt-ip>:50051 rustbgpd.v1.RibService/ListBestRoutes
 ```
 
@@ -580,11 +586,13 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 ```sh
 # Page 1 (size 2)
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -H "authorization: Bearer $TOKEN" \
   -d '{"page_size": 2}' \
   <rustbgpd-mgmt-ip>:50051 rustbgpd.v1.RibService/ListBestRoutes
 
 # Page 2
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -H "authorization: Bearer $TOKEN" \
   -d '{"page_size": 2, "page_token": "2"}' \
   <rustbgpd-mgmt-ip>:50051 rustbgpd.v1.RibService/ListBestRoutes
 ```

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -10,6 +10,9 @@ docker compose up -d
 ```
 
 First run builds the rustbgpd image (~60s). Sessions establish within seconds.
+The committed bearer token is intentionally public and test-only: it keeps the
+quick-start runnable while demonstrating tier authorization. Replace this
+entire credential arrangement in any real deployment.
 
 ## Try it
 
@@ -20,6 +23,7 @@ docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 rib
 docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 top
 
 # From the host (gRPC is forwarded to localhost:50051)
+export RUSTBGPD_TOKEN_FILE="$PWD/../../tests/fixtures/grpc-test-only-operator.token"
 cargo run -p rustbgpctl --bin rbgp -- -s http://127.0.0.1:50051 neighbor
 cargo run -p rustbgpctl --bin rbgp -- -s http://127.0.0.1:50051 top
 ```

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -5,10 +5,12 @@
 #
 # Usage:
 #   docker compose up -d
+# The rustbgpd service sets RUSTBGPD_TOKEN_FILE for in-container rbgp calls.
 #   docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 neighbor
 #   docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 top
 #
 # From the host (gRPC exposed on localhost:50051):
+#   export RUSTBGPD_TOKEN_FILE="$PWD/../../tests/fixtures/grpc-test-only-operator.token"
 #   cargo run -p rustbgpctl --bin rbgp -- -s http://127.0.0.1:50051 neighbor
 #   cargo run -p rustbgpctl --bin rbgp -- -s http://127.0.0.1:50051 top
 
@@ -17,6 +19,11 @@ services:
     build: ../..
     volumes:
       - ./rustbgpd.toml:/etc/rustbgpd/config.toml:ro
+      # Public test-only credential shared with the interop harness. It is a
+      # runnable example, never a production secret.
+      - ../../tests/fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
+    environment:
+      RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
     networks:
       bgp:
         ipv4_address: 10.99.0.10

--- a/examples/docker-compose/rustbgpd.toml
+++ b/examples/docker-compose/rustbgpd.toml
@@ -11,18 +11,20 @@ listen_port = 179
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
 
-# Quick-start lab access: gRPC over TCP so `rbgp` can reach the daemon
-# from the host via the published port. Like `rustbgpd --init-config lab`, this
-# throwaway lab uses legacy gRPC authorization for zero-setup access.
-# Production deployments should use tier enforcement + [security.grpc.roles]
-# (see examples/route-server, examples/rr-evpn-fabric) and an mTLS proxy or
-# bearer token for any non-loopback listener.
+# Quick-start lab access: gRPC over TCP so `rbgp` can reach the daemon from the
+# host via the published port. The mounted bearer token is deliberately public
+# and test-only; it demonstrates tier authorization, not production security.
 [global.telemetry.grpc_tcp]
 enabled = true
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"
 
 [[neighbors]]
 address = "10.99.0.20"

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -9,6 +9,23 @@ use rustbgpd_policy::RouteType;
 use rustbgpd_wire::{Afi, BgpRole, Safi};
 use tempfile::NamedTempFile;
 
+const TEST_ONLY_GRPC_OPERATOR_PRINCIPAL: &str = "rustbgpd://operator/test-only";
+const TEST_ONLY_GRPC_TOKEN_CONTAINER_PATH: &str = "/run/rustbgpd/grpc-test-only-operator.token";
+const TEST_ONLY_GRPC_TOKEN_REPO_PATH: &str = "tests/fixtures/grpc-test-only-operator.token";
+
+fn materialize_shared_test_only_grpc_token(source: &str) -> String {
+    let host_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(TEST_ONLY_GRPC_TOKEN_REPO_PATH);
+    assert!(
+        host_path.is_file(),
+        "shared test-only gRPC token fixture must exist at {}",
+        host_path.display()
+    );
+    let host_path = host_path
+        .to_str()
+        .expect("repository test-token path must be UTF-8");
+    source.replace(TEST_ONLY_GRPC_TOKEN_CONTAINER_PATH, host_path)
+}
+
 fn valid_toml() -> &'static str {
     // Shared test fixture used by hundreds of config tests below.
     // Opts into `enforcement = "legacy"` explicitly so the fixture
@@ -115,6 +132,11 @@ fn config_examples_parse() {
         let source = fs::read_to_string(&path).unwrap_or_else(|err| {
             panic!("failed to read example config {label}: {err}");
         });
+        // The Docker Compose quick-start mounts the repository's public,
+        // test-only bearer fixture at a container-absolute path. Substitute
+        // the same fixture's host path so this production-path validation
+        // proves the shipped config without weakening token-file checks.
+        let source = materialize_shared_test_only_grpc_token(&source);
         // Strict parse (not the legacy-injecting `parse`) so every shipped
         // example is validated under the production v0.24.0
         // `enforcement = "tier"` default. Injection would mask examples that
@@ -135,6 +157,113 @@ fn config_examples_parse() {
             panic!("example config {label} failed validation under the tier default: {err}");
         });
     }
+}
+
+#[test]
+fn shared_test_only_operator_auth_is_tier_valid_and_wired() {
+    // Load-bearing foundation for incrementally moving ordinary interop
+    // configs off legacy authorization. Both migrated configs must use the
+    // same public test-only credential path and stable operator principal;
+    // their harnesses must mount that exact credential and opt into the
+    // shared grpcurl helper.
+    for (label, source) in [
+        (
+            "M1 ordinary interop",
+            include_str!("../../tests/interop/configs/rustbgpd-m1-frr.toml"),
+        ),
+        (
+            "Docker Compose quick-start",
+            include_str!("../../examples/docker-compose/rustbgpd.toml"),
+        ),
+    ] {
+        assert!(
+            source.contains(TEST_ONLY_GRPC_TOKEN_CONTAINER_PATH),
+            "{label} must use the shared test-only token path"
+        );
+        let materialized = materialize_shared_test_only_grpc_token(source);
+        let config = parse_strict(&materialized)
+            .unwrap_or_else(|err| panic!("{label} must validate under tier enforcement: {err}"));
+
+        assert_eq!(
+            config.security.grpc.enforcement,
+            GrpcEnforcementConfig::Tier,
+            "{label} must not fall back to legacy authorization"
+        );
+        let tcp = config
+            .global
+            .telemetry
+            .grpc_tcp
+            .as_ref()
+            .unwrap_or_else(|| panic!("{label} must configure gRPC TCP"));
+        assert!(tcp.enabled, "{label} gRPC TCP listener must be enabled");
+        assert_eq!(
+            tcp.principal.as_deref(),
+            Some(TEST_ONLY_GRPC_OPERATOR_PRINCIPAL),
+            "{label} must preserve the stable test-only operator principal"
+        );
+        assert_eq!(
+            config
+                .security
+                .grpc
+                .roles
+                .get(TEST_ONLY_GRPC_OPERATOR_PRINCIPAL),
+            Some(&GrpcRoleConfig::Operator),
+            "{label} principal must map to the operator role"
+        );
+    }
+
+    let m1_topology: serde_yaml::Value =
+        serde_yaml::from_str(include_str!("../../tests/interop/m1-frr.clab.yml"))
+            .expect("M1 topology must be YAML");
+    let m1_binds = m1_topology["topology"]["nodes"]["rustbgpd"]["binds"]
+        .as_sequence()
+        .expect("M1 rustbgpd binds must be a sequence");
+    assert!(
+        m1_binds.iter().any(|bind| {
+            bind.as_str()
+                == Some(
+                    "../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro",
+                )
+        }),
+        "M1 must mount the shared test-only token at its configured path"
+    );
+
+    let compose: serde_yaml::Value = serde_yaml::from_str(include_str!(
+        "../../examples/docker-compose/docker-compose.yml"
+    ))
+    .expect("Docker Compose quick-start must be YAML");
+    let compose_service = &compose["services"]["rustbgpd"];
+    let compose_volumes = compose_service["volumes"]
+        .as_sequence()
+        .expect("Compose rustbgpd volumes must be a sequence");
+    assert!(
+        compose_volumes.iter().any(|volume| {
+            volume.as_str()
+                == Some(
+                    "../../tests/fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro",
+                )
+        }),
+        "Compose must mount the shared test-only token at its configured path"
+    );
+    assert_eq!(
+        compose_service["environment"]["RUSTBGPD_TOKEN_FILE"].as_str(),
+        Some(TEST_ONLY_GRPC_TOKEN_CONTAINER_PATH),
+        "Compose must inject the shared token path into in-container rbgp"
+    );
+
+    let m1_driver = include_str!("../../tests/interop/scripts/test-m1-frr.sh");
+    assert!(
+        m1_driver.contains("INTEROP_TEST_OPERATOR_AUTH=1"),
+        "M1 must opt into shared test-only grpcurl authentication"
+    );
+    assert!(
+        m1_driver.matches("grpcurl_call").count() >= 2,
+        "M1 route queries must use the shared grpcurl helper"
+    );
+    assert!(
+        !m1_driver.contains("grpcurl -plaintext"),
+        "M1 must not copy bearer-token plumbing around the shared helper"
+    );
 }
 
 fn route_server_example_config() -> Config {

--- a/tests/fixtures/grpc-test-only-operator.token
+++ b/tests/fixtures/grpc-test-only-operator.token
@@ -1,0 +1,1 @@
+rustbgpd-public-test-only-operator-token

--- a/tests/interop/configs/rustbgpd-m1-frr.toml
+++ b/tests/interop/configs/rustbgpd-m1-frr.toml
@@ -9,12 +9,17 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"
 
 [[neighbors]]
 address = "10.0.0.2"
 remote_asn = 65002
 description = "frr-m1"
 hold_time = 90
-
-[security.grpc]
-enforcement = "legacy"

--- a/tests/interop/m1-frr.clab.yml
+++ b/tests/interop/m1-frr.clab.yml
@@ -20,6 +20,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m1-frr.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/scripts/test-lib.sh
+++ b/tests/interop/scripts/test-lib.sh
@@ -9,7 +9,7 @@
 # Provides:
 #   - Pre-flight checks (docker, grpcurl, containerlab topology running)
 #   - Timestamped log/ok/fail helpers
-#   - resolve_grpc_addr, resolve_ip
+#   - resolve_grpc_addr, resolve_ip, grpcurl_call
 #   - start_rustbgpd with gRPC health wait
 #   - wait_established (FRR vtysh polling)
 #   - Trap-based cleanup: auto-destroy containerlab on EXIT if CLEANUP=1
@@ -27,6 +27,13 @@ GRPC_ADDR=""
 # `pe1` / `pe2` rather than the single-rustbgpd `rustbgpd` shape)
 # can set RUSTBGPD before sourcing this lib.
 RUSTBGPD="${RUSTBGPD:-clab-${TOPO}-rustbgpd}"
+
+# Ordinary interop slices can opt into the shared, deliberately public
+# test-only operator credential by setting this to 1 before sourcing the
+# library. Dedicated authentication tests keep their own identities and
+# credential paths; they do not set this flag and are unaffected.
+INTEROP_TEST_OPERATOR_AUTH="${INTEROP_TEST_OPERATOR_AUTH:-0}"
+readonly INTEROP_TEST_OPERATOR_TOKEN_FILE="tests/fixtures/grpc-test-only-operator.token"
 
 pass=0
 fail=0
@@ -66,6 +73,12 @@ preflight() {
         errors=$((errors + 1))
     fi
 
+    if [ "$INTEROP_TEST_OPERATOR_AUTH" = "1" ] \
+        && [ ! -s "$INTEROP_TEST_OPERATOR_TOKEN_FILE" ]; then
+        echo "ERROR: shared test-only gRPC token missing or empty at $INTEROP_TEST_OPERATOR_TOKEN_FILE" >&2
+        errors=$((errors + 1))
+    fi
+
     if ! docker inspect "$RUSTBGPD" &>/dev/null; then
         echo "ERROR: container $RUSTBGPD not running — deploy topology first:" >&2
         echo "  containerlab deploy -t tests/interop/${TOPO}.clab.yml" >&2
@@ -101,8 +114,28 @@ resolve_grpc_addr() {
     log "gRPC endpoint: $GRPC_ADDR"
 }
 
-grpc_health() {
+# Run grpcurl with the repository's common import flags and, for ordinary
+# slices that opt in, the shared test-only bearer credential. Keeping the
+# header here lets future fixture migrations avoid copied token plumbing in
+# every call site. Arguments are passed through unchanged to grpcurl.
+grpcurl_call() {
+    local -a auth_args=()
+    if [ "$INTEROP_TEST_OPERATOR_AUTH" = "1" ]; then
+        local token=""
+        IFS= read -r token < "$INTEROP_TEST_OPERATOR_TOKEN_FILE"
+        if [ -z "$token" ]; then
+            echo "ERROR: shared test-only gRPC token is empty" >&2
+            return 1
+        fi
+        auth_args=(-H "authorization: Bearer $token")
+    fi
+
     grpcurl -plaintext -import-path . -proto "$PROTO" \
+        "${auth_args[@]}" "$@"
+}
+
+grpc_health() {
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.ControlService/GetHealth 2>/dev/null
 }
 

--- a/tests/interop/scripts/test-m1-frr.sh
+++ b/tests/interop/scripts/test-m1-frr.sh
@@ -11,6 +11,9 @@
 
 TOPO="m1-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
+# shellcheck source=tests/interop/scripts/test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
@@ -18,12 +21,12 @@ FRR="clab-${TOPO}-frr"
 # Resolve rustbgpd container management IP for gRPC access
 
 grpc_list_routes() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_routes_for_peer() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"neighbor_address\": \"$1\"}" \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
@@ -207,6 +210,8 @@ main() {
     log "Topology: $TOPO"
 
     resolve_grpc_addr
+    # Intentional: the shared helper defaults its optional extra arguments.
+    # shellcheck disable=SC2119
     start_rustbgpd
 
     test_routes_received

--- a/tests/interop/scripts/test-test-operator-auth-helper.sh
+++ b/tests/interop/scripts/test-test-operator-auth-helper.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Fast unit proof for the shared, public test-only interop bearer helper.
+# No daemon or network is used: grpcurl is replaced with an argv recorder.
+
+set -euo pipefail
+
+TOPO="test-operator-auth-helper"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export TOPO INTEROP_TEST_OPERATOR_AUTH
+
+# test-lib runs preflight while sourced. Satisfy its external-command probes
+# without Docker or network access; grpcurl remains an argv recorder below.
+docker() {
+    [ "${1:-}" = "inspect" ]
+}
+grpcurl() {
+    printf '<%s>\n' "$@"
+}
+jq() {
+    return 0
+}
+
+# shellcheck source=tests/interop/scripts/test-lib.sh
+source "$SCRIPT_DIR/test-lib.sh"
+
+expected_token=$(<"$INTEROP_TEST_OPERATOR_TOKEN_FILE")
+output=$(grpcurl_call -d '{}' 127.0.0.1:50051 rustbgpd.v1.ControlService/GetHealth)
+
+if ! grep -Fqx "<authorization: Bearer $expected_token>" <<<"$output"; then
+    echo "shared grpcurl helper did not inject the test-only bearer token" >&2
+    exit 1
+fi
+if [ "$(grep -Fxc '<-H>' <<<"$output")" -ne 1 ]; then
+    echo "shared grpcurl helper must inject exactly one authorization header" >&2
+    exit 1
+fi
+for argument in '<-plaintext>' '<-import-path>' '<.>' '<-proto>' \
+    '<proto/rustbgpd.proto>' '<-d>' '<{}>' '<127.0.0.1:50051>' \
+    '<rustbgpd.v1.ControlService/GetHealth>'; do
+    if ! grep -Fqx "$argument" <<<"$output"; then
+        echo "shared grpcurl helper dropped argument $argument" >&2
+        exit 1
+    fi
+done
+
+INTEROP_TEST_OPERATOR_AUTH=0
+export INTEROP_TEST_OPERATOR_AUTH
+output=$(grpcurl_call 127.0.0.1:50051 rustbgpd.v1.ControlService/GetHealth)
+if grep -Fq '<authorization:' <<<"$output"; then
+    echo "legacy/dedicated callers must not inherit the shared bearer header" >&2
+    exit 1
+fi
+
+echo "shared test-only interop authentication helper: PASS"


### PR DESCRIPTION
## Summary

- add one opt-in grpcurl helper for the public test-only operator bearer credential
- migrate the ordinary M1 FRR slice and Docker Compose quick-start from legacy authorization to tier enforcement
- keep dedicated authentication scenarios and the remaining ordinary interop fleet unchanged for the next bounded phase
- add fast CI and strict config/wiring guards, plus accurate manual command guidance

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- plain `bash -n` and `shellcheck -x` with only a local documented SC2119 suppression
- standalone helper argv receipt and exact Rust config/wiring tests
- `docker compose config --quiet`
- real Compose build/up: Established with seven routes, authenticated health succeeds, unauthenticated health fails closed
- real M1 FRR containerlab: 16/16 checks passed
- both real stacks were torn down with no residual containers

## Load-bearing proofs

- removing either migrated token path makes strict config validation red
- deleting either principal or operator role makes the semantic guard red
- removing the M1 or Compose token mount makes the wiring guard red
- removing helper header injection makes the shell receipt red
- removing Compose host-path materialization makes example validation red

The public fixture is intentionally conspicuous and test-only. Compose publishes gRPC only on host loopback; this credential arrangement is explicitly not deployment guidance.