### PR TITLE
test: migrate early interop labs to tier auth

### DIFF
--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -647,6 +647,13 @@ M3 FRR (3-node):
 FRR-A advertises: 192.168.1.0/24, 192.168.2.0/24, 10.10.0.0/16 via `network` statements.
 FRR-B receives only (no route advertisements).
 
+The topology uses the repository's public test-only operator token. Load it
+before running any of the manual gRPC commands below:
+
+```sh
+TOKEN=$(cat tests/fixtures/grpc-test-only-operator.token)
+```
+
 ### Test 1: Route Redistribution
 
 After sessions reach Established, FRR-A's routes should propagate through
@@ -675,6 +682,7 @@ Inject a route via gRPC and verify both peers receive it.
 
 ```sh
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -H "authorization: Bearer $TOKEN" \
   -d '{"prefix": "10.99.0.0", "prefix_length": 24, "next_hop": "10.0.0.1"}' \
   <rustbgpd-mgmt-ip>:50051 rustbgpd.v1.InjectionService/AddPath
 
@@ -701,6 +709,7 @@ Withdraw the injected route via gRPC.
 
 ```sh
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -H "authorization: Bearer $TOKEN" \
   -d '{"prefix": "10.99.0.0", "prefix_length": 24}' \
   <rustbgpd-mgmt-ip>:50051 rustbgpd.v1.InjectionService/DeletePath
 ```
@@ -754,6 +763,13 @@ FRR-09 and FRR-10 are present in the topology but added dynamically via gRPC.
 Each FRR peer advertises 2 prefixes (172.16.x0.0/24, 172.16.x1.0/24).
 FRR-01 has a per-peer export policy: deny 10.0.0.0/8 le 32.
 
+The topology uses the repository's public test-only operator token. Load it
+before running any of the manual gRPC commands below:
+
+```sh
+TOKEN=$(cat tests/fixtures/grpc-test-only-operator.token)
+```
+
 ### Test 1: All 8 Static Sessions Establish
 
 Wait for all 8 FRR peers to report `Established` via `show bgp neighbors`.
@@ -764,6 +780,7 @@ Wait for all 8 FRR peers to report `Established` via `show bgp neighbors`.
 
 ```sh
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -H "authorization: Bearer $TOKEN" \
   <rustbgpd-mgmt-ip>:50051 rustbgpd.v1.NeighborService/ListNeighbors
 ```
 
@@ -773,6 +790,7 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 
 ```sh
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -H "authorization: Bearer $TOKEN" \
   <rustbgpd-mgmt-ip>:50051 rustbgpd.v1.RibService/ListReceivedRoutes
 ```
 
@@ -786,6 +804,7 @@ export policy) should NOT see it. FRR-02 (no per-peer policy) should see it.
 
 ```sh
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -H "authorization: Bearer $TOKEN" \
   -d '{"prefix": "10.99.0.0", "prefix_length": 24, "next_hop": "10.0.10.1"}' \
   <rustbgpd-mgmt-ip>:50051 rustbgpd.v1.InjectionService/AddPath
 
@@ -802,6 +821,7 @@ returns 9.
 
 ```sh
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -H "authorization: Bearer $TOKEN" \
   -d '{"config": {"address": "10.0.18.2", "remote_asn": 65018, "description": "frr-09-dynamic"}}' \
   <rustbgpd-mgmt-ip>:50051 rustbgpd.v1.NeighborService/AddNeighbor
 ```
@@ -814,6 +834,7 @@ Delete FRR-09 via gRPC. Verify ListNeighbors returns 8 again.
 
 ```sh
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -H "authorization: Bearer $TOKEN" \
   -d '{"address": "10.0.18.2"}' \
   <rustbgpd-mgmt-ip>:50051 rustbgpd.v1.NeighborService/DeleteNeighbor
 ```
@@ -827,12 +848,14 @@ Disable FRR-01 via `DisableNeighbor`, verify session drops. Re-enable via
 
 ```sh
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -H "authorization: Bearer $TOKEN" \
   -d '{"address": "10.0.10.2", "reason": "test"}' \
   <rustbgpd-mgmt-ip>:50051 rustbgpd.v1.NeighborService/DisableNeighbor
 
 # Wait 5s, verify FRR-01 is not Established
 
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -H "authorization: Bearer $TOKEN" \
   -d '{"address": "10.0.10.2"}' \
   <rustbgpd-mgmt-ip>:50051 rustbgpd.v1.NeighborService/EnableNeighbor
 ```

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -266,6 +266,220 @@ fn shared_test_only_operator_auth_is_tier_valid_and_wired() {
     );
 }
 
+#[test]
+#[allow(clippy::too_many_lines)] // one frozen inventory keeps config/topology/driver wiring atomic
+fn early_interop_auth_inventory_is_tier_wired() {
+    // Load-bearing: reverting a config to legacy, dropping a token bind,
+    // downgrading the operator role, bypassing the helper, removing a driver
+    // opt-in, or removing an M0 UDS identity makes an assertion below red.
+    const TCP_SLICES: &[(&str, &str)] = &[
+        ("m3-frr.clab.yml", "test-m3-frr.sh"),
+        ("m4-frr.clab.yml", "test-m4-frr.sh"),
+        ("m10-frr-ipv6.clab.yml", "test-m10-frr-ipv6.sh"),
+        ("m11-gr-frr.clab.yml", "test-m11-gr-frr.sh"),
+        ("m12-ec-frr.clab.yml", "test-m12-ec-frr.sh"),
+        ("m13-policy-frr.clab.yml", "test-m13-policy-frr.sh"),
+        ("m14-rr-frr.clab.yml", "test-m14-rr-frr.sh"),
+        ("m15-rr-frr.clab.yml", "test-m15-rr-frr.sh"),
+        ("m16-llgr-frr.clab.yml", "test-m16-llgr-frr.sh"),
+        ("m17-addpath-frr.clab.yml", "test-m17-addpath-frr.sh"),
+        ("m18-extnexthop-frr.clab.yml", "test-m18-extnexthop-frr.sh"),
+        (
+            "m19-routeserver-frr.clab.yml",
+            "test-m19-routeserver-frr.sh",
+        ),
+        ("m20-privateas-frr.clab.yml", "test-m20-privateas-frr.sh"),
+        ("m21-rpki-frr.clab.yml", "test-m21-rpki-frr.sh"),
+        ("m22-flowspec-frr.clab.yml", "test-m22-flowspec-frr.sh"),
+        ("m23-gobgp.clab.yml", "test-m23-gobgp.sh"),
+        ("m24-bmp-frr.clab.yml", "test-m24-bmp-frr.sh"),
+        ("m25-md5-gtsm-frr.clab.yml", "test-m25-md5-gtsm-frr.sh"),
+        ("m26-cease-frr.clab.yml", "test-m26-cease-frr.sh"),
+        ("m27-aspa-rtr2.clab.yml", "test-m27-aspa-rtr2.sh"),
+        ("m28-dynamic-frr.clab.yml", "test-m28-dynamic-frr.sh"),
+        ("m29-evpn-rr-frr.clab.yml", "test-m29-evpn-rr-frr.sh"),
+        ("m30-evpn-type2-frr.clab.yml", "test-m30-evpn-type2-frr.sh"),
+        (
+            "m30b-evpn-type5-frr.clab.yml",
+            "test-m30b-evpn-type5-frr.sh",
+        ),
+        (
+            "m31-evpn-mac-mobility-frr.clab.yml",
+            "test-m31-evpn-mac-mobility-frr.sh",
+        ),
+        (
+            "m32-evpn-multihome-frr.clab.yml",
+            "test-m32-evpn-multihome-frr.sh",
+        ),
+        (
+            "m32b-evpn-ead-synthetic.clab.yml",
+            "test-m32b-evpn-ead-synthetic.sh",
+        ),
+        (
+            "m34-policy-soft-reset-frr.clab.yml",
+            "test-m34-policy-soft-reset-frr.sh",
+        ),
+        (
+            "m35-graceful-shutdown-frr.clab.yml",
+            "test-m35-graceful-shutdown-frr.sh",
+        ),
+        (
+            "m35b-graceful-shutdown-flowspec-frr.clab.yml",
+            "test-m35b-graceful-shutdown-flowspec-frr.sh",
+        ),
+        (
+            "m35c-graceful-shutdown-evpn-frr.clab.yml",
+            "test-m35c-graceful-shutdown-evpn-frr.sh",
+        ),
+    ];
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let interop = root.join("tests/interop");
+    let expected_bind = format!(
+        "../fixtures/grpc-test-only-operator.token:{TEST_ONLY_GRPC_TOKEN_CONTAINER_PATH}:ro"
+    );
+    let expected_token_path = root.join(TEST_ONLY_GRPC_TOKEN_REPO_PATH);
+    let mut config_count = 0;
+
+    for (topology_name, driver_name) in TCP_SLICES {
+        let topology_source = fs::read_to_string(interop.join(topology_name))
+            .unwrap_or_else(|err| panic!("failed to read {topology_name}: {err}"));
+        let topology: serde_yaml::Value = serde_yaml::from_str(&topology_source)
+            .unwrap_or_else(|err| panic!("failed to parse {topology_name}: {err}"));
+        let binds = topology["topology"]["nodes"]["rustbgpd"]["binds"]
+            .as_sequence()
+            .unwrap_or_else(|| panic!("{topology_name} rustbgpd binds must be a sequence"));
+        assert!(
+            binds
+                .iter()
+                .any(|bind| bind.as_str() == Some(expected_bind.as_str())),
+            "{topology_name} must mount the shared test-only token"
+        );
+
+        for bind in binds.iter().filter_map(serde_yaml::Value::as_str) {
+            let Some((host_path, _)) = bind.split_once(':') else {
+                continue;
+            };
+            if !host_path.starts_with("./configs/rustbgpd-")
+                || !Path::new(host_path)
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("toml"))
+            {
+                continue;
+            }
+            config_count += 1;
+            let config_source =
+                fs::read_to_string(interop.join(host_path.trim_start_matches("./")))
+                    .unwrap_or_else(|err| panic!("failed to read {host_path}: {err}"));
+            assert!(
+                config_source.contains(TEST_ONLY_GRPC_TOKEN_CONTAINER_PATH),
+                "{host_path} must use the shared test-only token path"
+            );
+            let materialized = materialize_shared_test_only_grpc_token(&config_source)
+                .replace("BMP_RECEIVER_ADDR", "127.0.0.1")
+                .replace("STAYRTR_ADDR", "127.0.0.1");
+            let config = parse_strict(&materialized).unwrap_or_else(|err| {
+                panic!("{host_path} must validate under tier enforcement: {err}")
+            });
+            assert_eq!(
+                config.security.grpc.enforcement,
+                GrpcEnforcementConfig::Tier,
+                "{host_path} must use tier enforcement"
+            );
+            let tcp = config
+                .global
+                .telemetry
+                .grpc_tcp
+                .as_ref()
+                .unwrap_or_else(|| panic!("{host_path} must configure gRPC TCP"));
+            assert_eq!(
+                tcp.token_file.as_deref(),
+                expected_token_path.to_str(),
+                "{host_path} must load the mounted test-only token"
+            );
+            assert_eq!(
+                tcp.principal.as_deref(),
+                Some(TEST_ONLY_GRPC_OPERATOR_PRINCIPAL),
+                "{host_path} must use the shared test-only principal"
+            );
+            assert_eq!(
+                config
+                    .security
+                    .grpc
+                    .roles
+                    .get(TEST_ONLY_GRPC_OPERATOR_PRINCIPAL),
+                Some(&GrpcRoleConfig::Operator),
+                "{host_path} test-only principal must be an operator"
+            );
+        }
+
+        let driver_source = fs::read_to_string(interop.join("scripts").join(driver_name))
+            .unwrap_or_else(|err| panic!("failed to read {driver_name}: {err}"));
+        assert_eq!(
+            driver_source
+                .lines()
+                .filter(|line| *line == "INTEROP_TEST_OPERATOR_AUTH=1")
+                .count(),
+            1,
+            "{driver_name} must opt into shared test-only grpcurl authentication"
+        );
+        assert!(
+            !driver_source.contains("grpcurl -plaintext"),
+            "{driver_name} must route direct grpcurl calls through grpcurl_call"
+        );
+    }
+    assert_eq!(
+        config_count, 32,
+        "the frozen M3-M32 and M34-M35c slice must cover 32 active configs"
+    );
+
+    for (label, config_name, topology_name) in [
+        ("M0 FRR", "rustbgpd-frr.toml", "m0-frr.clab.yml"),
+        ("M0 BIRD", "rustbgpd-bird.toml", "m0-bird.clab.yml"),
+    ] {
+        let source = fs::read_to_string(interop.join("configs").join(config_name))
+            .unwrap_or_else(|err| panic!("failed to read {config_name}: {err}"));
+        let config = parse_strict(&source)
+            .unwrap_or_else(|err| panic!("{label} must validate under tier enforcement: {err}"));
+        assert_eq!(
+            config.security.grpc.enforcement,
+            GrpcEnforcementConfig::Tier,
+            "{label} must use tier enforcement"
+        );
+        let uds = config
+            .global
+            .telemetry
+            .grpc_uds
+            .as_ref()
+            .unwrap_or_else(|| panic!("{label} must configure an explicit gRPC UDS"));
+        assert_eq!(
+            uds.principal.as_deref(),
+            Some(TEST_ONLY_GRPC_OPERATOR_PRINCIPAL),
+            "{label} must use the stable test-only principal"
+        );
+        assert_eq!(
+            config
+                .security
+                .grpc
+                .roles
+                .get(TEST_ONLY_GRPC_OPERATOR_PRINCIPAL),
+            Some(&GrpcRoleConfig::Operator),
+            "{label} test-only principal must be an operator"
+        );
+        assert!(
+            uds.token_file.is_none(),
+            "{label} UDS needs no bearer token"
+        );
+
+        let topology_source = fs::read_to_string(interop.join(topology_name))
+            .unwrap_or_else(|err| panic!("failed to read {topology_name}: {err}"));
+        assert!(
+            !topology_source.contains("grpc-test-only-operator.token"),
+            "{topology_name} must not mount a token for its UDS-only listener"
+        );
+    }
+}
+
 fn route_server_example_config() -> Config {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/route-server/config.toml");
     Config::load_with_diagnostics(path.to_str().expect("route-server example path is UTF-8"))

--- a/tests/interop/configs/rustbgpd-bird.toml
+++ b/tests/interop/configs/rustbgpd-bird.toml
@@ -7,11 +7,19 @@ listen_port = 179
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
 
+[global.telemetry.grpc_uds]
+path = "/tmp/rustbgpd.sock"
+mode = 0o600
+principal = "rustbgpd://operator/test-only"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"
+
 [[neighbors]]
 address = "10.0.1.2"
 remote_asn = 65003
 description = "bird-m0"
 hold_time = 90
-
-[security.grpc]
-enforcement = "legacy"

--- a/tests/interop/configs/rustbgpd-frr.toml
+++ b/tests/interop/configs/rustbgpd-frr.toml
@@ -7,11 +7,19 @@ listen_port = 179
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
 
+[global.telemetry.grpc_uds]
+path = "/tmp/rustbgpd.sock"
+mode = 0o600
+principal = "rustbgpd://operator/test-only"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"
+
 [[neighbors]]
 address = "10.0.0.2"
 remote_asn = 65002
 description = "frr-m0"
 hold_time = 90
-
-[security.grpc]
-enforcement = "legacy"

--- a/tests/interop/configs/rustbgpd-m10-frr-ipv6.toml
+++ b/tests/interop/configs/rustbgpd-m10-frr-ipv6.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -18,4 +20,7 @@ hold_time = 90
 families = ["ipv4_unicast", "ipv6_unicast"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m11-gr.toml
+++ b/tests/interop/configs/rustbgpd-m11-gr.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -20,4 +22,7 @@ gr_restart_time = 30
 gr_stale_routes_time = 30
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m12-ec.toml
+++ b/tests/interop/configs/rustbgpd-m12-ec.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -17,4 +19,7 @@ description = "frr-m12-ec"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m13-policy.toml
+++ b/tests/interop/configs/rustbgpd-m13-policy.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # --- Named policy definitions ---
 
@@ -70,4 +72,7 @@ description = "frr-b-downstream"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m14-rr.toml
+++ b/tests/interop/configs/rustbgpd-m14-rr.toml
@@ -10,6 +10,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -26,4 +28,7 @@ hold_time = 90
 route_reflector_client = true
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m15-rr.toml
+++ b/tests/interop/configs/rustbgpd-m15-rr.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # Import policy: set LOCAL_PREF 150 on all routes
 [policy]
@@ -28,4 +30,7 @@ description = "frr-m15"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m16-llgr.toml
+++ b/tests/interop/configs/rustbgpd-m16-llgr.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -21,4 +23,7 @@ gr_stale_routes_time = 20
 llgr_stale_time = 60
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m17-addpath.toml
+++ b/tests/interop/configs/rustbgpd-m17-addpath.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # FRR-A: source peer, no add-path
 [[neighbors]]
@@ -37,4 +39,7 @@ send = true
 send_max = 4
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m18-extnexthop.toml
+++ b/tests/interop/configs/rustbgpd-m18-extnexthop.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -19,4 +21,7 @@ families = ["ipv4_unicast", "ipv6_unicast"]
 local_ipv6_nexthop = "fd00::1"
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m19-routeserver.toml
+++ b/tests/interop/configs/rustbgpd-m19-routeserver.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # FRR-A: route server client
 [[neighbors]]
@@ -27,4 +29,7 @@ hold_time = 90
 route_server_client = true
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m20-privateas.toml
+++ b/tests/interop/configs/rustbgpd-m20-privateas.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # FRR-Source: private ASN peer (no removal on inbound)
 [[neighbors]]
@@ -42,4 +44,7 @@ hold_time = 90
 remove_private_as = "replace"
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m21-rpki.toml
+++ b/tests/interop/configs/rustbgpd-m21-rpki.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # RPKI cache — StayRTR on the containerlab management network.
 # The address is resolved at test time and patched into this config.
@@ -26,4 +28,7 @@ description = "frr-m21-rpki"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m22-flowspec.toml
+++ b/tests/interop/configs/rustbgpd-m22-flowspec.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -18,4 +20,7 @@ hold_time = 90
 families = ["ipv4_unicast", "ipv4_flowspec"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m23-gobgp.toml
+++ b/tests/interop/configs/rustbgpd-m23-gobgp.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -17,4 +19,7 @@ description = "gobgp-m23"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m24-bmp.toml
+++ b/tests/interop/configs/rustbgpd-m24-bmp.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # BMP collector — Python receiver on the containerlab management network.
 # The address is resolved at test time and patched into this config.
@@ -26,4 +28,7 @@ description = "frr-m24-bmp"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m25-md5-gtsm.toml
+++ b/tests/interop/configs/rustbgpd-m25-md5-gtsm.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # Peer A: TCP MD5 authentication
 [[neighbors]]
@@ -27,4 +29,7 @@ hold_time = 90
 ttl_security = true
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m26-cease.toml
+++ b/tests/interop/configs/rustbgpd-m26-cease.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -19,4 +21,7 @@ hold_time = 90
 max_prefixes = 2
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m27-aspa.toml
+++ b/tests/interop/configs/rustbgpd-m27-aspa.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [rpki]
 
@@ -31,4 +33,7 @@ description = "frr-b-m27"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m28-dynamic.toml
+++ b/tests/interop/configs/rustbgpd-m28-dynamic.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [peer_groups.ix-members]
 hold_time = 90
@@ -20,4 +22,7 @@ remote_asn = 0
 description = "dynamic from 10.0.0.0/24"
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m29-evpn.toml
+++ b/tests/interop/configs/rustbgpd-m29-evpn.toml
@@ -11,6 +11,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -21,4 +23,7 @@ families = ["l2vpn_evpn"]
 route_reflector_client = true
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m3-frr.toml
+++ b/tests/interop/configs/rustbgpd-m3-frr.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -23,4 +25,7 @@ description = "frr-b"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m30-rr.toml
+++ b/tests/interop/configs/rustbgpd-m30-rr.toml
@@ -11,6 +11,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -29,4 +31,7 @@ families = ["l2vpn_evpn"]
 route_reflector_client = true
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m30b-rr.toml
+++ b/tests/interop/configs/rustbgpd-m30b-rr.toml
@@ -15,6 +15,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -25,4 +27,7 @@ families = ["l2vpn_evpn"]
 route_reflector_client = true
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m31-rr.toml
+++ b/tests/interop/configs/rustbgpd-m31-rr.toml
@@ -11,6 +11,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -37,4 +39,7 @@ families = ["l2vpn_evpn"]
 route_reflector_client = true
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m32-rr.toml
+++ b/tests/interop/configs/rustbgpd-m32-rr.toml
@@ -11,6 +11,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -37,4 +39,7 @@ families = ["l2vpn_evpn"]
 route_reflector_client = true
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m32b-rr.toml
+++ b/tests/interop/configs/rustbgpd-m32b-rr.toml
@@ -14,6 +14,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.1.1.2"
@@ -32,4 +34,7 @@ families = ["l2vpn_evpn"]
 route_reflector_client = true
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m34-policy-soft-reset-deny.toml
+++ b/tests/interop/configs/rustbgpd-m34-policy-soft-reset-deny.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # Reloaded state: same chain reference (`filter`), but the
 # definition itself gains a deny rule for 192.168.1.0/24. The
@@ -32,4 +34,7 @@ description = "frr-m34"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m34-policy-soft-reset.toml
+++ b/tests/interop/configs/rustbgpd-m34-policy-soft-reset.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # Initial state: a single named policy with no statements and a
 # `permit` default — every received route lands in the RIB. The
@@ -28,4 +30,7 @@ description = "frr-m34"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m35-graceful-shutdown.toml
+++ b/tests/interop/configs/rustbgpd-m35-graceful-shutdown.toml
@@ -13,6 +13,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # No inline policy chains — default behavior is permit-all on both
 # sides. The receiver leg works because the global knob prepends the
@@ -27,4 +29,7 @@ description = "frr-m35"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m35b-graceful-shutdown-flowspec.toml
+++ b/tests/interop/configs/rustbgpd-m35b-graceful-shutdown-flowspec.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -18,4 +20,7 @@ hold_time = 90
 families = ["ipv4_unicast", "ipv4_flowspec"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m35c-graceful-shutdown-evpn.toml
+++ b/tests/interop/configs/rustbgpd-m35c-graceful-shutdown-evpn.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -18,4 +20,7 @@ hold_time = 90
 families = ["l2vpn_evpn"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m4-frr.toml
+++ b/tests/interop/configs/rustbgpd-m4-frr.toml
@@ -12,6 +12,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # FRR-01 (AS 65010) — has per-peer export policy
 [[neighbors]]
@@ -78,4 +80,7 @@ hold_time = 90
 # FRR-10 (AS 65019) — NOT configured, added dynamically
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/m10-frr-ipv6.clab.yml
+++ b/tests/interop/m10-frr-ipv6.clab.yml
@@ -23,6 +23,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m10-frr-ipv6.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip -6 addr add fd00::1/64 dev eth1

--- a/tests/interop/m11-gr-frr.clab.yml
+++ b/tests/interop/m11-gr-frr.clab.yml
@@ -22,6 +22,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m11-gr.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m12-ec-frr.clab.yml
+++ b/tests/interop/m12-ec-frr.clab.yml
@@ -20,6 +20,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m12-ec.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m13-policy-frr.clab.yml
+++ b/tests/interop/m13-policy-frr.clab.yml
@@ -22,6 +22,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m13-policy.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m14-rr-frr.clab.yml
+++ b/tests/interop/m14-rr-frr.clab.yml
@@ -22,6 +22,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m14-rr.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m15-rr-frr.clab.yml
+++ b/tests/interop/m15-rr-frr.clab.yml
@@ -18,6 +18,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m15-rr.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m16-llgr-frr.clab.yml
+++ b/tests/interop/m16-llgr-frr.clab.yml
@@ -18,6 +18,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m16-llgr.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m17-addpath-frr.clab.yml
+++ b/tests/interop/m17-addpath-frr.clab.yml
@@ -21,6 +21,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m17-addpath.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m18-extnexthop-frr.clab.yml
+++ b/tests/interop/m18-extnexthop-frr.clab.yml
@@ -22,6 +22,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m18-extnexthop.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip -6 addr add fd00::1/64 dev eth1

--- a/tests/interop/m19-routeserver-frr.clab.yml
+++ b/tests/interop/m19-routeserver-frr.clab.yml
@@ -44,6 +44,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m19-routeserver.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m20-privateas-frr.clab.yml
+++ b/tests/interop/m20-privateas-frr.clab.yml
@@ -27,6 +27,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m20-privateas.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m21-rpki-frr.clab.yml
+++ b/tests/interop/m21-rpki-frr.clab.yml
@@ -27,6 +27,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m21-rpki.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m22-flowspec-frr.clab.yml
+++ b/tests/interop/m22-flowspec-frr.clab.yml
@@ -20,6 +20,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m22-flowspec.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m23-gobgp.clab.yml
+++ b/tests/interop/m23-gobgp.clab.yml
@@ -24,6 +24,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m23-gobgp.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m24-bmp-frr.clab.yml
+++ b/tests/interop/m24-bmp-frr.clab.yml
@@ -21,6 +21,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m24-bmp.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m25-md5-gtsm-frr.clab.yml
+++ b/tests/interop/m25-md5-gtsm-frr.clab.yml
@@ -22,6 +22,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m25-md5-gtsm.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m26-cease-frr.clab.yml
+++ b/tests/interop/m26-cease-frr.clab.yml
@@ -21,6 +21,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m26-cease.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m27-aspa-rtr2.clab.yml
+++ b/tests/interop/m27-aspa-rtr2.clab.yml
@@ -27,6 +27,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m27-aspa.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m28-dynamic-frr.clab.yml
+++ b/tests/interop/m28-dynamic-frr.clab.yml
@@ -29,6 +29,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m28-dynamic.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m29-evpn-rr-frr.clab.yml
+++ b/tests/interop/m29-evpn-rr-frr.clab.yml
@@ -29,6 +29,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m29-evpn.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m3-frr.clab.yml
+++ b/tests/interop/m3-frr.clab.yml
@@ -21,6 +21,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m3-frr.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m30-evpn-type2-frr.clab.yml
+++ b/tests/interop/m30-evpn-type2-frr.clab.yml
@@ -33,6 +33,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m30-rr.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m30b-evpn-type5-frr.clab.yml
+++ b/tests/interop/m30b-evpn-type5-frr.clab.yml
@@ -37,6 +37,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m30b-rr.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m31-evpn-mac-mobility-frr.clab.yml
+++ b/tests/interop/m31-evpn-mac-mobility-frr.clab.yml
@@ -37,6 +37,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m31-rr.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m32-evpn-multihome-frr.clab.yml
+++ b/tests/interop/m32-evpn-multihome-frr.clab.yml
@@ -35,6 +35,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m32-rr.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m32b-evpn-ead-synthetic.clab.yml
+++ b/tests/interop/m32b-evpn-ead-synthetic.clab.yml
@@ -42,6 +42,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m32b-rr.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.1.1.1/30 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m34-policy-soft-reset-frr.clab.yml
+++ b/tests/interop/m34-policy-soft-reset-frr.clab.yml
@@ -35,6 +35,7 @@ topology:
         - ./configs/rustbgpd-m34-policy-soft-reset.toml:/etc/rustbgpd/config.initial.toml:ro
         - ./configs/rustbgpd-m34-policy-soft-reset-deny.toml:/etc/rustbgpd/config.deny.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m35-graceful-shutdown-frr.clab.yml
+++ b/tests/interop/m35-graceful-shutdown-frr.clab.yml
@@ -34,6 +34,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m35-graceful-shutdown.toml:/etc/rustbgpd/config.initial.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m35b-graceful-shutdown-flowspec-frr.clab.yml
+++ b/tests/interop/m35b-graceful-shutdown-flowspec-frr.clab.yml
@@ -22,6 +22,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m35b-graceful-shutdown-flowspec.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m35c-graceful-shutdown-evpn-frr.clab.yml
+++ b/tests/interop/m35c-graceful-shutdown-evpn-frr.clab.yml
@@ -22,6 +22,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m35c-graceful-shutdown-evpn.toml:/etc/rustbgpd/config.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up

--- a/tests/interop/m4-frr.clab.yml
+++ b/tests/interop/m4-frr.clab.yml
@@ -27,6 +27,7 @@ topology:
       binds:
         - ./configs/rustbgpd-m4-frr.toml:/etc/rustbgpd/config.template.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         # Copy the read-only template to a writable container-local path so the
         # atomic config persist (temp + rename) that AddNeighbor performs works;

--- a/tests/interop/scripts/test-m10-frr-ipv6.sh
+++ b/tests/interop/scripts/test-m10-frr-ipv6.sh
@@ -11,6 +11,8 @@
 
 TOPO="m10-frr-ipv6"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
@@ -18,18 +20,18 @@ FRR="clab-${TOPO}-frr"
 # Resolve rustbgpd container management IP for gRPC access
 
 grpc_list_routes() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_routes_for_peer() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"neighbor_address\": \"$1\"}" \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_best_routes() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListBestRoutes 2>/dev/null
 }
 
@@ -197,7 +199,7 @@ test_ipv6_injection() {
     log "Test 6: IPv6 route injection via gRPC"
 
     local result
-    result=$(grpcurl -plaintext -import-path . -proto "$PROTO" \
+    result=$(grpcurl_call \
         -d '{
             "prefix": "2001:db8:ff::",
             "prefix_length": 48,
@@ -220,7 +222,7 @@ test_ipv6_injection() {
     fi
 
     # Clean up: withdraw injected route
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{
             "prefix": "2001:db8:ff::",
             "prefix_length": 48

--- a/tests/interop/scripts/test-m11-gr-frr.sh
+++ b/tests/interop/scripts/test-m11-gr-frr.sh
@@ -15,6 +15,8 @@
 
 TOPO="m11-gr-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
@@ -22,23 +24,23 @@ FRR="clab-${TOPO}-frr"
 # Resolve rustbgpd container management IP for gRPC access
 
 grpc_list_routes() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_routes_for_peer() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"neighbor_address\": \"$1\"}" \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_neighbors() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/ListNeighbors 2>/dev/null
 }
 
 grpc_get_metrics() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.ControlService/GetMetrics 2>/dev/null
 }
 

--- a/tests/interop/scripts/test-m12-ec-frr.sh
+++ b/tests/interop/scripts/test-m12-ec-frr.sh
@@ -15,6 +15,8 @@
 
 TOPO="m12-ec-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
@@ -22,29 +24,29 @@ FRR="clab-${TOPO}-frr"
 # Resolve rustbgpd container management IP for gRPC access
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_received_for_peer() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"neighbor_address\": \"$1\"}" \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_best() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListBestRoutes 2>/dev/null
 }
 
 grpc_add_path() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "$1" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/AddPath 2>/dev/null
 }
 
 grpc_delete_path() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "$1" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/DeletePath 2>/dev/null
 }

--- a/tests/interop/scripts/test-m13-policy-frr.sh
+++ b/tests/interop/scripts/test-m13-policy-frr.sh
@@ -1,4 +1,4 @@
-#\!/usr/bin/env bash
+#!/usr/bin/env bash
 # M13 interop test — Policy Engine
 #
 # Validates: import/export policy actions end-to-end with FRR.
@@ -17,24 +17,26 @@
 
 TOPO="m13-policy-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR_A="clab-${TOPO}-frr-a"
 FRR_B="clab-${TOPO}-frr-b"
 
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_received_for_peer() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"neighbor_address\": \"$1\"}" \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_best() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListBestRoutes 2>/dev/null
 }
 

--- a/tests/interop/scripts/test-m14-rr-frr.sh
+++ b/tests/interop/scripts/test-m14-rr-frr.sh
@@ -18,18 +18,20 @@
 
 TOPO="m14-rr-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR_C1="clab-${TOPO}-frr-client1"
 FRR_C2="clab-${TOPO}-frr-client2"
 
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_best() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListBestRoutes 2>/dev/null
 }
 

--- a/tests/interop/scripts/test-m15-rr-frr.sh
+++ b/tests/interop/scripts/test-m15-rr-frr.sh
@@ -17,22 +17,24 @@
 
 TOPO="m15-rr-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_best() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListBestRoutes 2>/dev/null
 }
 
 grpc_soft_reset_in() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"address\": \"$1\"}" \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/SoftResetIn 2>/dev/null
 }

--- a/tests/interop/scripts/test-m16-llgr-frr.sh
+++ b/tests/interop/scripts/test-m16-llgr-frr.sh
@@ -21,17 +21,19 @@
 
 TOPO="m16-llgr-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_best() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListBestRoutes 2>/dev/null
 }
 

--- a/tests/interop/scripts/test-m17-addpath-frr.sh
+++ b/tests/interop/scripts/test-m17-addpath-frr.sh
@@ -22,6 +22,8 @@
 
 TOPO="m17-addpath-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR_A="clab-${TOPO}-frr-a"
 FRR_B="clab-${TOPO}-frr-b"
@@ -29,18 +31,18 @@ FRR_CLIENT="clab-${TOPO}-frr-client"
 
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_received_for_peer() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"neighbor_address\": \"$1\"}" \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_advertised() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"neighbor_address\": \"$1\"}" \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListAdvertisedRoutes 2>/dev/null
 }

--- a/tests/interop/scripts/test-m18-extnexthop-frr.sh
+++ b/tests/interop/scripts/test-m18-extnexthop-frr.sh
@@ -22,22 +22,24 @@
 
 TOPO="m18-extnexthop-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_best() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListBestRoutes 2>/dev/null
 }
 
 grpc_inject_route() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"prefix\": \"$1\", \"prefix_length\": $2, \"next_hop\": \"$3\", \"origin\": 0}" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/AddPath 2>/dev/null
 }

--- a/tests/interop/scripts/test-m19-routeserver-frr.sh
+++ b/tests/interop/scripts/test-m19-routeserver-frr.sh
@@ -27,13 +27,15 @@
 
 TOPO="m19-routeserver-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR_A="clab-${TOPO}-frr-a"
 FRR_B="clab-${TOPO}-frr-b"
 
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 

--- a/tests/interop/scripts/test-m20-privateas-frr.sh
+++ b/tests/interop/scripts/test-m20-privateas-frr.sh
@@ -34,6 +34,8 @@
 
 TOPO="m20-privateas-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR_SOURCE="clab-${TOPO}-frr-source"
 FRR_REMOVE="clab-${TOPO}-frr-remove"
@@ -42,7 +44,7 @@ FRR_REPLACE="clab-${TOPO}-frr-replace"
 
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 

--- a/tests/interop/scripts/test-m21-rpki-frr.sh
+++ b/tests/interop/scripts/test-m21-rpki-frr.sh
@@ -18,6 +18,8 @@
 
 TOPO="m21-rpki-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 STAYRTR="clab-${TOPO}-stayrtr"
@@ -40,19 +42,19 @@ patch_rpki_config() {
 }
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"neighbor_address": "10.0.0.2"}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_best() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListBestRoutes 2>/dev/null
 }
 
 
 grpc_metrics() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.ControlService/GetMetrics 2>/dev/null
 }
 

--- a/tests/interop/scripts/test-m22-flowspec-frr.sh
+++ b/tests/interop/scripts/test-m22-flowspec-frr.sh
@@ -30,6 +30,8 @@
 
 TOPO="m22-flowspec-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
@@ -39,19 +41,19 @@ FRR="clab-${TOPO}-frr"
 # ---------------------------------------------------------------------------
 
 grpc_add_flowspec() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "$1" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/AddFlowSpec 2>/dev/null
 }
 
 grpc_delete_flowspec() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "$1" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/DeleteFlowSpec 2>/dev/null
 }
 
 grpc_list_flowspec() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"afiSafi": "ADDRESS_FAMILY_IPV4_FLOWSPEC"}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListFlowSpecRoutes 2>/dev/null
 }

--- a/tests/interop/scripts/test-m23-gobgp.sh
+++ b/tests/interop/scripts/test-m23-gobgp.sh
@@ -19,6 +19,8 @@
 
 TOPO="m23-gobgp"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 GOBGP="clab-${TOPO}-gobgp"
 
@@ -28,19 +30,19 @@ GOBGP="clab-${TOPO}-gobgp"
 # ---------------------------------------------------------------------------
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"neighbor_address": "10.0.0.2"}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_add_route() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "$1" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/AddPath 2>/dev/null
 }
 
 grpc_delete_route() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "$1" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/DeletePath 2>/dev/null
 }

--- a/tests/interop/scripts/test-m24-bmp-frr.sh
+++ b/tests/interop/scripts/test-m24-bmp-frr.sh
@@ -17,6 +17,8 @@
 
 TOPO="m24-bmp-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 BMP_RECEIVER="clab-${TOPO}-bmp-receiver"

--- a/tests/interop/scripts/test-m25-md5-gtsm-frr.sh
+++ b/tests/interop/scripts/test-m25-md5-gtsm-frr.sh
@@ -17,13 +17,15 @@
 
 TOPO="m25-md5-gtsm-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR_A="clab-${TOPO}-frr-a"
 FRR_B="clab-${TOPO}-frr-b"
 
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"neighbor_address\": \"$1\"}" \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }

--- a/tests/interop/scripts/test-m26-cease-frr.sh
+++ b/tests/interop/scripts/test-m26-cease-frr.sh
@@ -22,23 +22,25 @@
 
 TOPO="m26-cease-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
 
 grpc_metrics() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.ControlService/GetMetrics 2>/dev/null
 }
 
 grpc_neighbor_state() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"address": "10.0.0.2"}' \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>/dev/null
 }
 
 grpc_enable_neighbor() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"address": "10.0.0.2"}' \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/EnableNeighbor >/dev/null
 }

--- a/tests/interop/scripts/test-m27-aspa-rtr2.sh
+++ b/tests/interop/scripts/test-m27-aspa-rtr2.sh
@@ -19,6 +19,8 @@
 
 TOPO="m27-aspa-rtr2"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR_A="clab-${TOPO}-frr-a"
 FRR_B="clab-${TOPO}-frr-b"
@@ -74,25 +76,25 @@ start_with_custom_config() {
 
 grpc_list_received_peer() {
     local peer=$1
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"neighbor_address\": \"$peer\"}" \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_received_all() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_best() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListBestRoutes 2>/dev/null
 }
 
 grpc_explain() {
     local prefix=$1
     local prefix_len=$2
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"prefix\": \"$prefix\", \"prefix_length\": $prefix_len}" \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ExplainBestPath 2>/dev/null
 }

--- a/tests/interop/scripts/test-m28-dynamic-frr.sh
+++ b/tests/interop/scripts/test-m28-dynamic-frr.sh
@@ -18,6 +18,8 @@
 
 TOPO="m28-dynamic-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
@@ -26,17 +28,17 @@ FRR="clab-${TOPO}-frr"
 # ---------------------------------------------------------------------------
 
 grpc_list_neighbors() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/ListNeighbors 2>/dev/null
 }
 
 grpc_list_dynamic_neighbors() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/ListDynamicNeighbors 2>/dev/null
 }
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"neighbor_address": "10.0.0.2"}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }

--- a/tests/interop/scripts/test-m29-evpn-rr-frr.sh
+++ b/tests/interop/scripts/test-m29-evpn-rr-frr.sh
@@ -20,6 +20,8 @@
 
 TOPO="m29-evpn-rr-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
@@ -28,7 +30,7 @@ FRR="clab-${TOPO}-frr"
 # ---------------------------------------------------------------------------
 
 grpc_list_neighbors() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/ListNeighbors 2>/dev/null
 }
 
@@ -36,7 +38,7 @@ grpc_list_evpn() {
     # Capture stderr so a grpcurl failure can be distinguished from an
     # empty proto3 response in the test below. Stdout is the JSON body
     # (possibly empty); stderr is the diagnostic.
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListEvpnRoutes
 }

--- a/tests/interop/scripts/test-m3-frr.sh
+++ b/tests/interop/scripts/test-m3-frr.sh
@@ -11,6 +11,8 @@
 
 TOPO="m3-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR_A="clab-${TOPO}-frr-a"
 FRR_B="clab-${TOPO}-frr-b"
@@ -19,17 +21,17 @@ FRR_B="clab-${TOPO}-frr-b"
 # Resolve rustbgpd container management IP for gRPC access
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_list_best() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListBestRoutes 2>/dev/null
 }
 
 grpc_list_advertised() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"neighbor_address\": \"$1\"}" \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListAdvertisedRoutes 2>/dev/null
 }
@@ -38,14 +40,14 @@ grpc_add_path() {
     local prefix=$1 prefix_len=$2 next_hop=$3
     shift 3
     local origin=${1:-0}
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"prefix\": \"$prefix\", \"prefix_length\": $prefix_len, \"next_hop\": \"$next_hop\", \"origin\": $origin}" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/AddPath 2>/dev/null
 }
 
 grpc_delete_path() {
     local prefix=$1 prefix_len=$2
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"prefix\": \"$prefix\", \"prefix_length\": $prefix_len}" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/DeletePath 2>/dev/null
 }

--- a/tests/interop/scripts/test-m30-evpn-type2-frr.sh
+++ b/tests/interop/scripts/test-m30-evpn-type2-frr.sh
@@ -25,6 +25,8 @@
 
 TOPO="m30-evpn-type2-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 
@@ -41,12 +43,12 @@ TEST_MAC="aa:bb:cc:00:00:01"
 # ---------------------------------------------------------------------------
 
 grpc_list_neighbors() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/ListNeighbors 2>/dev/null
 }
 
 grpc_list_evpn() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListEvpnRoutes 2>/dev/null
 }

--- a/tests/interop/scripts/test-m30b-evpn-type5-frr.sh
+++ b/tests/interop/scripts/test-m30b-evpn-type5-frr.sh
@@ -23,6 +23,8 @@
 
 TOPO="m30b-evpn-type5-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 
@@ -44,7 +46,7 @@ EXPECTED_RT_U64="842122827661412"
 # ---------------------------------------------------------------------------
 
 grpc_list_evpn() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListEvpnRoutes 2>/dev/null
 }

--- a/tests/interop/scripts/test-m31-evpn-mac-mobility-frr.sh
+++ b/tests/interop/scripts/test-m31-evpn-mac-mobility-frr.sh
@@ -29,6 +29,8 @@
 
 TOPO="m31-evpn-mac-mobility-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 

--- a/tests/interop/scripts/test-m32-evpn-multihome-frr.sh
+++ b/tests/interop/scripts/test-m32-evpn-multihome-frr.sh
@@ -23,6 +23,8 @@
 
 TOPO="m32-evpn-multihome-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 
@@ -36,7 +38,7 @@ RR_CLUSTER_ID="10.0.0.100"
 ES_SYS_MAC="aa:bb:cc:dd:ee:ff"
 
 grpc_list_evpn() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListEvpnRoutes 2>/dev/null
 }

--- a/tests/interop/scripts/test-m32b-evpn-ead-synthetic.sh
+++ b/tests/interop/scripts/test-m32b-evpn-ead-synthetic.sh
@@ -24,6 +24,8 @@
 
 TOPO="m32b-evpn-ead-synthetic"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 
@@ -36,7 +38,7 @@ CONVERGE_TIMEOUT=60
 TESTER_LINGER=120
 
 grpc_list_evpn() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -max-msg-sz 16777216 \
         -d '{}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListEvpnRoutes 2>/dev/null || true
@@ -132,7 +134,7 @@ else
 fi
 
 log "[check] tester peer stayed Established"
-neighbors_json=$(grpcurl -plaintext -import-path . -proto "$PROTO" \
+neighbors_json=$(grpcurl_call \
     "$GRPC_ADDR" rustbgpd.v1.NeighborService/ListNeighbors 2>/dev/null)
 if ! command -v jq >/dev/null 2>&1; then
     fail "jq is required for neighbor-state parsing (install with apt-get install jq)"

--- a/tests/interop/scripts/test-m34-policy-soft-reset-frr.sh
+++ b/tests/interop/scripts/test-m34-policy-soft-reset-frr.sh
@@ -31,6 +31,8 @@ set -euo pipefail
 
 TOPO="m34-policy-soft-reset-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
@@ -45,7 +47,7 @@ start_rustbgpd
 wait_frr_established "$FRR" "10.0.0.1" "rustbgpd ↔ FRR"
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
@@ -105,7 +107,7 @@ wait_route "10.10.0.0/16"
 # ---------------------------------------------------------------------------
 
 session_state_json() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"address": "10.0.0.2"}' \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>/dev/null
 }

--- a/tests/interop/scripts/test-m35-graceful-shutdown-frr.sh
+++ b/tests/interop/scripts/test-m35-graceful-shutdown-frr.sh
@@ -24,6 +24,8 @@ set -euo pipefail
 
 TOPO="m35-graceful-shutdown-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
@@ -40,7 +42,7 @@ wait_frr_established "$FRR" "10.0.0.1" "rustbgpd ↔ FRR"
 GSHUT_VALUE=$(( (65535 << 16) | 0 ))    # 4294901760 = 0xFFFF_0000
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
@@ -78,7 +80,7 @@ dump_state_on_failure() {
     echo "===== rustbgpd ListReceivedRoutes (raw) =====" >&2
     grpc_list_received | jq . >&2 || true
     echo "===== rustbgpd NeighborState 10.0.0.2 =====" >&2
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"address":"10.0.0.2"}' \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>&1 \
         | head -60 >&2 || true
@@ -223,7 +225,7 @@ frr_has_route() {
 }
 
 log "Injecting 172.16.0.0/24 via InjectionService.AddPath (steady state)..."
-grpcurl -plaintext -import-path . -proto "$PROTO" \
+grpcurl_call \
     -d '{"prefix":"172.16.0.0","prefixLength":24,"nextHop":"10.0.0.1","origin":2,"asPath":[]}' \
     "$GRPC_ADDR" rustbgpd.v1.InjectionService/AddPath > /dev/null
 
@@ -245,7 +247,7 @@ done
 
 log "Toggling GRACEFUL_SHUTDOWN advertise ON for 10.0.0.2 via gRPC..."
 log "(no delete + re-add — this exercises RibUpdate::RefreshPeerOutbound force-emit)"
-grpcurl -plaintext -import-path . -proto "$PROTO" \
+grpcurl_call \
     -d '{"address":"10.0.0.2","enabled":true}' \
     "$GRPC_ADDR" rustbgpd.v1.NeighborService/SetGracefulShutdown > /dev/null
 
@@ -275,7 +277,7 @@ done
 # ---------------------------------------------------------------------------
 
 log "Toggling GRACEFUL_SHUTDOWN advertise OFF for 10.0.0.2 via gRPC..."
-grpcurl -plaintext -import-path . -proto "$PROTO" \
+grpcurl_call \
     -d '{"address":"10.0.0.2","enabled":false}' \
     "$GRPC_ADDR" rustbgpd.v1.NeighborService/SetGracefulShutdown > /dev/null
 

--- a/tests/interop/scripts/test-m35b-graceful-shutdown-flowspec-frr.sh
+++ b/tests/interop/scripts/test-m35b-graceful-shutdown-flowspec-frr.sh
@@ -13,6 +13,8 @@ set -euo pipefail
 
 TOPO="m35b-graceful-shutdown-flowspec-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
@@ -30,14 +32,14 @@ RULE_ADD='{
 }'
 
 grpc_add_flowspec() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "$RULE_ADD" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/AddFlowSpec >/dev/null
 }
 
 grpc_set_gshut() {
     local enabled=${1:?}
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"address\":\"10.0.0.2\",\"enabled\":${enabled}}" \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/SetGracefulShutdown >/dev/null
 }
@@ -249,7 +251,7 @@ dump_state_on_failure() {
     echo "===== FRR FlowSpec text =====" >&2
     docker exec "$FRR" vtysh -c "show bgp ipv4 flowspec" >&2 || true
     echo "===== rustbgpd NeighborState 10.0.0.2 =====" >&2
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"address":"10.0.0.2"}' \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>&1 \
         | head -80 >&2 || true

--- a/tests/interop/scripts/test-m35c-graceful-shutdown-evpn-frr.sh
+++ b/tests/interop/scripts/test-m35c-graceful-shutdown-evpn-frr.sh
@@ -13,6 +13,8 @@ set -euo pipefail
 
 TOPO="m35c-graceful-shutdown-evpn-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
@@ -29,14 +31,14 @@ EVPN_ADD='{
 }'
 
 grpc_add_evpn() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "$EVPN_ADD" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/AddEvpnRoute >/dev/null
 }
 
 grpc_set_gshut() {
     local enabled=${1:?}
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"address\":\"10.0.0.2\",\"enabled\":${enabled}}" \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/SetGracefulShutdown >/dev/null
 }
@@ -243,11 +245,11 @@ dump_state_on_failure() {
     echo "===== FRR EVPN Type 2 JSON =====" >&2
     frr_evpn_macip_json | jq . >&2 || true
     echo "===== rustbgpd ListEvpnRoutes =====" >&2
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{}' "$GRPC_ADDR" rustbgpd.v1.RibService/ListEvpnRoutes 2>&1 \
         | head -80 >&2 || true
     echo "===== rustbgpd NeighborState 10.0.0.2 =====" >&2
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"address":"10.0.0.2"}' \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>&1 \
         | head -80 >&2 || true

--- a/tests/interop/scripts/test-m4-frr.sh
+++ b/tests/interop/scripts/test-m4-frr.sh
@@ -11,6 +11,8 @@
 
 TOPO="m4-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 
 
@@ -20,7 +22,7 @@ grpc() {
     local args=("$@")
     local method="${args[-1]}"
     unset 'args[-1]'
-    grpcurl -plaintext -import-path . -proto "$PROTO" "${args[@]}" "$GRPC_ADDR" "$method" 2>/dev/null
+    grpcurl_call "${args[@]}" "$GRPC_ADDR" "$method" 2>/dev/null
 }
 
 grpc_list_neighbors() {


### PR DESCRIPTION
## Summary

- migrate the active M0, M3-M32, and M34-M35c interop fixtures from legacy gRPC authorization to the shared test-only tier-auth convention
- mount the shared operator token and route ordinary grpcurl calls through the authenticated helper
- preserve M0 as an owner-only UDS exception and keep both M34 reload candidates auth-complete
- document authenticated manual commands for M3 and M4
- add a frozen semantic inventory gate across configs, topologies, drivers, and the M0 exception

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- Bash syntax and ShellCheck error-severity checks for all 31 migrated drivers
- real M0 tier-UDS/BGP smoke
- real M3 interop harness: 18/18

## Load-bearing proof

The focused gate was proven red independently for five production-fixture reversions: M3 tier to legacy, M4 token mount removal, M10 operator-role downgrade, M11 helper opt-in removal, and M12 direct grpcurl restoration. Each mutation failed the new inventory test and was restored before the full gate run.

## Scope

This is LAN-546 Phase 2 slice 1. It intentionally excludes M33, M36+, soak/shared-soak fixtures, dedicated auth scenarios, runtime legacy-mode removal, and credential generation.

Docs: `docs/INTEROP.md` now includes the shared test-only bearer header for the M3 and M4 manual commands. No changelog or roadmap update is needed because this changes first-party test infrastructure rather than daemon behavior or user-facing defaults.