### PR TITLE
test: migrate dataplane interop labs to tier auth

### DIFF
--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -26,6 +26,10 @@ fn materialize_shared_test_only_grpc_token(source: &str) -> String {
     source.replace(TEST_ONLY_GRPC_TOKEN_CONTAINER_PATH, host_path)
 }
 
+fn parse_with_shared_test_grpc_token(source: &str) -> Result<Config, ConfigError> {
+    parse(&materialize_shared_test_only_grpc_token(source))
+}
+
 fn valid_toml() -> &'static str {
     // Shared test fixture used by hundreds of config tests below.
     // Opts into `enforcement = "legacy"` explicitly so the fixture
@@ -12645,7 +12649,7 @@ fn m49_interop_configs_describe_preference_df_with_dont_preempt() {
     // Pin the M49 interop fixtures: PE1 (pref 100, revertive) and PE2 (pref
     // 200, non-revertive) both run highest-preference. Guards the smoke against
     // drift in the configs or the DF config surface.
-    let pe1 = parse(include_str!(
+    let pe1 = parse_with_shared_test_grpc_token(include_str!(
         "../../tests/interop/configs/rustbgpd-m49-pe1.toml"
     ))
     .unwrap();
@@ -12654,7 +12658,7 @@ fn m49_interop_configs_describe_preference_df_with_dont_preempt() {
     assert_eq!(s1[0].df_preference, 100);
     assert!(!s1[0].df_dont_preempt);
 
-    let pe2 = parse(include_str!(
+    let pe2 = parse_with_shared_test_grpc_token(include_str!(
         "../../tests/interop/configs/rustbgpd-m49-pe2.toml"
     ))
     .unwrap();
@@ -12670,7 +12674,7 @@ fn m51_interop_config_describes_non_strict_bfd_with_fast_profile() {
     // a "fast" 300/300/3 profile (detection ≈ 900 ms) and a 90 s BGP hold timer.
     // Guards the smoke against drift in the config or the BFD config surface —
     // the whole point of M51 is that a BFD-down failover beats the hold timer.
-    let config = parse(include_str!(
+    let config = parse_with_shared_test_grpc_token(include_str!(
         "../../tests/interop/configs/rustbgpd-m51-bfd.toml"
     ))
     .unwrap();
@@ -12698,7 +12702,7 @@ fn m52_interop_config_enables_multipath_relax_with_mixed_asns() {
     // neighbors in *different* ASes (65002 / 65003) — the whole point of the
     // smoke is that only multipath-relax co-installs the equal-length,
     // different-AS paths.
-    let config = parse(include_str!(
+    let config = parse_with_shared_test_grpc_token(include_str!(
         "../../tests/interop/configs/rustbgpd-m52-fib-ecmp-relax.toml"
     ))
     .unwrap();
@@ -12713,7 +12717,7 @@ fn m55_interop_config_pins_role_matrix_and_strict_neighbor() {
     // Pin the M55 interop fixture: it needs three compatible role pairs, one
     // incompatible Provider/Provider pair, one strict-role/no-remote-role peer,
     // and one raw Customer fixture for deliberate OTC leak injection.
-    let config = parse(include_str!(
+    let config = parse_with_shared_test_grpc_token(include_str!(
         "../../tests/interop/configs/rustbgpd-m55-bgp-roles-otc.toml"
     ))
     .unwrap();

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -5232,6 +5232,14 @@ table_id = 6000
         )
     }
 
+    fn materialize_shared_test_only_grpc_token(toml: &str) -> String {
+        let token = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/grpc-test-only-operator.token"
+        );
+        toml.replace("/run/rustbgpd/grpc-test-only-operator.token", token)
+    }
+
     fn runtime_candidate_from_toml(toml: &str) -> rustbgpd_evpn::EvpnRuntimeCandidate {
         evpn_runtime_candidate_from_toml(toml).unwrap()
     }
@@ -9014,11 +9022,11 @@ local_vtep_ip = "10.0.0.1"
         // diff to an atomic tenant teardown (L2VNI 100 + its Ethernet
         // Segment). Guards the smoke against drift in either the configs or
         // the teardown classifier.
-        let current = runtime_model_from_candidate_toml(include_str!(
-            "../tests/interop/configs/rustbgpd-m47-pe1.toml"
+        let current = runtime_model_from_candidate_toml(&materialize_shared_test_only_grpc_token(
+            include_str!("../tests/interop/configs/rustbgpd-m47-pe1.toml"),
         ));
-        let candidate = runtime_candidate_from_toml(include_str!(
-            "../tests/interop/configs/rustbgpd-m47-teardown.toml"
+        let candidate = runtime_candidate_from_toml(&materialize_shared_test_only_grpc_token(
+            include_str!("../tests/interop/configs/rustbgpd-m47-teardown.toml"),
         ));
         let plan = current.plan_candidate(&candidate);
 
@@ -9042,11 +9050,11 @@ local_vtep_ip = "10.0.0.1"
         // referenced by L2VNI 10, so dropping both routes through the teardown
         // path rather than a standalone IP-VRF delete). Guards the smoke
         // against drift in either the configs or the teardown classifier.
-        let current = runtime_model_from_candidate_toml(include_str!(
-            "../tests/interop/configs/rustbgpd-m48-pe1.toml"
+        let current = runtime_model_from_candidate_toml(&materialize_shared_test_only_grpc_token(
+            include_str!("../tests/interop/configs/rustbgpd-m48-pe1.toml"),
         ));
-        let candidate = runtime_candidate_from_toml(include_str!(
-            "../tests/interop/configs/rustbgpd-m48-teardown.toml"
+        let candidate = runtime_candidate_from_toml(&materialize_shared_test_only_grpc_token(
+            include_str!("../tests/interop/configs/rustbgpd-m48-teardown.toml"),
         ));
         let plan = current.plan_candidate(&candidate);
 

--- a/tests/interop/configs/rustbgpd-m36-vtep.toml
+++ b/tests/interop/configs/rustbgpd-m36-vtep.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # Single EVPN instance bound to br100 / vxlan100 — the start script
 # pre-creates the topology in this container's netns. Probe must
@@ -29,4 +31,7 @@ hold_time = 30
 families = ["l2vpn_evpn"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m38-pe1.toml
+++ b/tests/interop/configs/rustbgpd-m38-pe1.toml
@@ -13,6 +13,8 @@ prometheus_addr = "0.0.0.0:9179"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[evpn_instances]]
 vni = 100
@@ -37,4 +39,7 @@ hold_time = 30
 families = ["l2vpn_evpn"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m38-pe2.toml
+++ b/tests/interop/configs/rustbgpd-m38-pe2.toml
@@ -13,6 +13,8 @@ prometheus_addr = "0.0.0.0:9179"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[evpn_instances]]
 vni = 100
@@ -37,4 +39,7 @@ hold_time = 30
 families = ["l2vpn_evpn"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m39b-pe1.toml
+++ b/tests/interop/configs/rustbgpd-m39b-pe1.toml
@@ -22,6 +22,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -44,4 +46,7 @@ l3vxlan_device = "l3vxlan100"
 table_id = 100
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m40-vtep.toml
+++ b/tests/interop/configs/rustbgpd-m40-vtep.toml
@@ -15,6 +15,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # Single L2 EVPN instance bound to br100 / vxlan100. The startup
 # script `start-rustbgpd-vtep.sh` pre-creates the bridge + VXLAN
@@ -44,4 +46,7 @@ hold_time = 180
 families = ["l2vpn_evpn"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m41-blackhole.toml
+++ b/tests/interop/configs/rustbgpd-m41-blackhole.toml
@@ -16,6 +16,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -24,4 +26,7 @@ description = "frr-m41"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m42-fib.toml
+++ b/tests/interop/configs/rustbgpd-m42-fib.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[fib_tables]]
 name = "edge"
@@ -23,4 +25,7 @@ description = "frr-m42"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m43-tcp-ao-selection.toml
+++ b/tests/interop/configs/rustbgpd-m43-tcp-ao-selection.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.43.2"
@@ -22,4 +24,7 @@ tcp_ao = [
 ]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m43-tcp-ao-successor.toml
+++ b/tests/interop/configs/rustbgpd-m43-tcp-ao-successor.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.43.2"
@@ -22,4 +24,7 @@ tcp_ao = [
 ]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m43-tcp-ao.toml
+++ b/tests/interop/configs/rustbgpd-m43-tcp-ao.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.43.2"
@@ -21,4 +23,7 @@ tcp_ao = [
 ]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m45-injector.toml
+++ b/tests/interop/configs/rustbgpd-m45-injector.toml
@@ -13,6 +13,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -21,9 +23,10 @@ description = "frr-receiver"
 hold_time = 180
 families = ["l2vpn_evpn"]
 
-# AddEvpnRoute / DeleteEvpnRoute are operator_only under the ADR-0064
-# default tier enforcement; the interop driver calls them over a
-# plaintext gRPC channel with no mTLS principal, so opt this listener
-# back to legacy (audit-only) enforcement for the smoke.
+# AddEvpnRoute / DeleteEvpnRoute are operator-only. This fixture uses the
+# repository-wide public test credential so the smoke exercises tier enforcement.
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m46-pe1.toml
+++ b/tests/interop/configs/rustbgpd-m46-pe1.toml
@@ -15,6 +15,8 @@ prometheus_addr = "0.0.0.0:9179"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[evpn_instances]]
 vni = 10
@@ -39,4 +41,7 @@ hold_time = 30
 families = ["l2vpn_evpn"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m46-pe2.toml
+++ b/tests/interop/configs/rustbgpd-m46-pe2.toml
@@ -14,6 +14,8 @@ prometheus_addr = "0.0.0.0:9179"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[evpn_instances]]
 vni = 10
@@ -38,4 +40,7 @@ hold_time = 30
 families = ["l2vpn_evpn"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m47-pe1.toml
+++ b/tests/interop/configs/rustbgpd-m47-pe1.toml
@@ -23,6 +23,8 @@ prometheus_addr = "0.0.0.0:9179"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[evpn_instances]]
 vni = 100
@@ -43,4 +45,7 @@ hold_time = 90
 families = ["l2vpn_evpn"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m47-teardown.toml
+++ b/tests/interop/configs/rustbgpd-m47-teardown.toml
@@ -20,6 +20,8 @@ prometheus_addr = "0.0.0.0:9179"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -29,4 +31,7 @@ hold_time = 90
 families = ["l2vpn_evpn"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m48-pe1.toml
+++ b/tests/interop/configs/rustbgpd-m48-pe1.toml
@@ -24,6 +24,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -51,4 +53,7 @@ l3vxlan_device = "l3vxlan100"
 table_id = 100
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m48-teardown.toml
+++ b/tests/interop/configs/rustbgpd-m48-teardown.toml
@@ -21,6 +21,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -30,4 +32,7 @@ hold_time = 180
 families = ["l2vpn_evpn"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m49-pe1.toml
+++ b/tests/interop/configs/rustbgpd-m49-pe1.toml
@@ -15,6 +15,8 @@ prometheus_addr = "0.0.0.0:9179"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[evpn_instances]]
 vni = 200
@@ -39,4 +41,7 @@ hold_time = 30
 families = ["l2vpn_evpn"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m49-pe2.toml
+++ b/tests/interop/configs/rustbgpd-m49-pe2.toml
@@ -17,6 +17,8 @@ prometheus_addr = "0.0.0.0:9179"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[evpn_instances]]
 vni = 200
@@ -42,4 +44,7 @@ hold_time = 30
 families = ["l2vpn_evpn"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m50-fib-ecmp.toml
+++ b/tests/interop/configs/rustbgpd-m50-fib-ecmp.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # ADR-0066 unicast multipath/ECMP: two equal-cost eBGP paths to the same
 # prefix install as a kernel RTA_MULTIPATH route.
@@ -35,4 +37,7 @@ description = "frr2-m50"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m51-bfd.toml
+++ b/tests/interop/configs/rustbgpd-m51-bfd.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # ADR-0067 single-hop BFD: a fast profile so the detection window (300 ms × 3 ≈
 # 900 ms) is comfortably under the BGP hold timer (90 s) — the whole point of
@@ -29,4 +31,7 @@ hold_time = 90
 bfd = { profile = "fast" }
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m52-fib-ecmp-relax.toml
+++ b/tests/interop/configs/rustbgpd-m52-fib-ecmp-relax.toml
@@ -14,6 +14,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[fib_tables]]
 name = "edge"
@@ -38,4 +40,7 @@ description = "frr2-m52"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m53-bgp-unnumbered.toml
+++ b/tests/interop/configs/rustbgpd-m53-bgp-unnumbered.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # ADR-0069 BGP unnumbered: two equal-cost IPv4 paths arrive over IPv6
 # link-local-only BGP sessions and install into Linux with per-next-hop dev
@@ -37,4 +39,7 @@ hold_time = 90
 families = ["ipv4_unicast", "ipv6_unicast"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m55-bgp-roles-otc.toml
+++ b/tests/interop/configs/rustbgpd-m55-bgp-roles-otc.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.55.1.2"
@@ -57,4 +59,7 @@ hold_time = 90
 role = "provider"
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m57-orf.toml
+++ b/tests/interop/configs/rustbgpd-m57-orf.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # Receive-side Address-Prefix ORF (RFC 5291/5292). The FRR client negotiates
 # ORF-Send and pushes its inbound prefix-list as an ORF; rustbgpd advertises
@@ -24,4 +26,7 @@ hold_time = 90
 prefix_orf_receive = true
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m58-fib-crud.toml
+++ b/tests/interop/configs/rustbgpd-m58-fib-crud.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # Start with one table so the ADR-0061 reconciler is running — runtime CRUD
 # (SetFibTable / DeleteFibTable) requires it. The test adds, mutates, and
@@ -29,4 +31,7 @@ description = "frr-m58"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m59-aspa-roles.toml
+++ b/tests/interop/configs/rustbgpd-m59-aspa-roles.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [rpki]
 
@@ -30,4 +32,7 @@ hold_time = 90
 role = "customer"
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m60-vtep.toml
+++ b/tests/interop/configs/rustbgpd-m60-vtep.toml
@@ -14,6 +14,8 @@ prometheus_addr = "0.0.0.0:9179"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # Single EVPN instance bound to br100 / vxlan100 — the start script
 # pre-creates the topology in this container's netns. Probe must
@@ -34,4 +36,7 @@ hold_time = 30
 families = ["l2vpn_evpn"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m62-blackhole.toml
+++ b/tests/interop/configs/rustbgpd-m62-blackhole.toml
@@ -17,6 +17,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -25,4 +27,7 @@ description = "frr-m62"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m63-stalled-rib.toml
+++ b/tests/interop/configs/rustbgpd-m63-stalled-rib.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.63.0.2"
@@ -21,4 +23,7 @@ description = "frr-m63"
 hold_time = 9
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m64-ipv6-only.toml
+++ b/tests/interop/configs/rustbgpd-m64-ipv6-only.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # The IPv6-only session: never negotiate IPv4 unicast. Without
 # disable_ipv4_unicast the RFC 4760 §8 fallback would implicitly add
@@ -32,4 +34,7 @@ description = "frr-m64-v4-regression"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m65-vtep.toml
+++ b/tests/interop/configs/rustbgpd-m65-vtep.toml
@@ -17,6 +17,8 @@ prometheus_addr = "0.0.0.0:9179"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # Single EVPN instance bound to br100 / vxlan100 — the start script
 # pre-creates the topology in this container's netns. The single-active
@@ -44,4 +46,7 @@ hold_time = 30
 families = ["l2vpn_evpn"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m66-vtep.toml
+++ b/tests/interop/configs/rustbgpd-m66-vtep.toml
@@ -16,6 +16,8 @@ prometheus_addr = "0.0.0.0:9179"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # Single EVPN instance bound to br100 / vxlan100 — the start script
 # pre-creates the topology in this container's netns. The single-active
@@ -45,4 +47,7 @@ families = ["l2vpn_evpn"]
 route_reflector_client = true
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m68-pe1.toml
+++ b/tests/interop/configs/rustbgpd-m68-pe1.toml
@@ -23,6 +23,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -53,4 +55,7 @@ table_id = 100
 overlay_index_mode = "gateway_ip"
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m69-pe1.toml
+++ b/tests/interop/configs/rustbgpd-m69-pe1.toml
@@ -13,6 +13,8 @@ prometheus_addr = "0.0.0.0:9179"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[evpn_instances]]
 vni = 200
@@ -37,4 +39,7 @@ hold_time = 30
 families = ["l2vpn_evpn"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/m36-evpn-vtep-smoke.clab.yml
+++ b/tests/interop/m36-evpn-vtep-smoke.clab.yml
@@ -45,6 +45,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m36-vtep.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-vtep.sh:/usr/local/bin/start-rustbgpd-vtep.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1

--- a/tests/interop/m38-evpn-df-election.clab.yml
+++ b/tests/interop/m38-evpn-df-election.clab.yml
@@ -41,6 +41,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m38-pe1.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-segment.sh:/usr/local/bin/start-rustbgpd-segment.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
@@ -55,6 +56,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m38-pe2.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-segment.sh:/usr/local/bin/start-rustbgpd-segment.sh:ro
       exec:
         - ip addr add 10.0.0.2/24 dev eth1

--- a/tests/interop/m39b-evpn-auto-rt-frr.clab.yml
+++ b/tests/interop/m39b-evpn-auto-rt-frr.clab.yml
@@ -43,6 +43,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m39b-pe1.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-m39-pe1.sh:/usr/local/bin/start-rustbgpd-m39-pe1.sh:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:

--- a/tests/interop/m40-evpn-aliasing-ecmp-frr.clab.yml
+++ b/tests/interop/m40-evpn-aliasing-ecmp-frr.clab.yml
@@ -50,6 +50,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m40-vtep.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-vtep.sh:/usr/local/bin/start-rustbgpd-vtep.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1

--- a/tests/interop/m41-blackhole-frr.clab.yml
+++ b/tests/interop/m41-blackhole-frr.clab.yml
@@ -27,6 +27,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m41-blackhole.toml:/etc/rustbgpd/config.initial.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1

--- a/tests/interop/m42-fib-runtime-frr.clab.yml
+++ b/tests/interop/m42-fib-runtime-frr.clab.yml
@@ -29,6 +29,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m42-fib.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1

--- a/tests/interop/m43-tcp-ao-bird.clab.yml
+++ b/tests/interop/m43-tcp-ao-bird.clab.yml
@@ -20,6 +20,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m43-tcp-ao.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./configs/rustbgpd-m43-tcp-ao-successor.toml:/etc/rustbgpd/config-successor.toml:ro
         - ./configs/rustbgpd-m43-tcp-ao-selection.toml:/etc/rustbgpd/config-selection.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro

--- a/tests/interop/m45-evpn-type5-injection.clab.yml
+++ b/tests/interop/m45-evpn-type5-injection.clab.yml
@@ -39,6 +39,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m45-injector.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1

--- a/tests/interop/m46-evpn-df-hrw.clab.yml
+++ b/tests/interop/m46-evpn-df-hrw.clab.yml
@@ -41,6 +41,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m46-pe1.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-segment.sh:/usr/local/bin/start-rustbgpd-segment.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
@@ -55,6 +56,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m46-pe2.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-segment.sh:/usr/local/bin/start-rustbgpd-segment.sh:ro
       exec:
         - ip addr add 10.0.0.2/24 dev eth1

--- a/tests/interop/m47-evpn-tenant-teardown.clab.yml
+++ b/tests/interop/m47-evpn-tenant-teardown.clab.yml
@@ -41,6 +41,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m47-pe1.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1

--- a/tests/interop/m48-evpn-tenant-teardown-datapath.clab.yml
+++ b/tests/interop/m48-evpn-tenant-teardown-datapath.clab.yml
@@ -41,6 +41,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m48-pe1.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-m39-pe1.sh:/usr/local/bin/start-rustbgpd-m39-pe1.sh:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
         - ./configs/rustbgpd-m48-teardown.toml:/etc/rustbgpd/teardown.toml:ro

--- a/tests/interop/m49-evpn-preference-df.clab.yml
+++ b/tests/interop/m49-evpn-preference-df.clab.yml
@@ -47,6 +47,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m49-pe1.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-segment.sh:/usr/local/bin/start-rustbgpd-segment.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
@@ -61,6 +62,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m49-pe2.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-segment.sh:/usr/local/bin/start-rustbgpd-segment.sh:ro
       exec:
         - ip addr add 10.0.0.2/24 dev eth1

--- a/tests/interop/m50-fib-ecmp-frr.clab.yml
+++ b/tests/interop/m50-fib-ecmp-frr.clab.yml
@@ -28,6 +28,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m50-fib-ecmp.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1

--- a/tests/interop/m51-bfd-frr.clab.yml
+++ b/tests/interop/m51-bfd-frr.clab.yml
@@ -29,6 +29,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m51-bfd.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1

--- a/tests/interop/m52-fib-ecmp-relax-frr.clab.yml
+++ b/tests/interop/m52-fib-ecmp-relax-frr.clab.yml
@@ -30,6 +30,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m52-fib-ecmp-relax.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1

--- a/tests/interop/m53-bgp-unnumbered-frr.clab.yml
+++ b/tests/interop/m53-bgp-unnumbered-frr.clab.yml
@@ -26,6 +26,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m53-bgp-unnumbered.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip -4 addr flush dev eth1

--- a/tests/interop/m55-bgp-roles-otc-frr.clab.yml
+++ b/tests/interop/m55-bgp-roles-otc-frr.clab.yml
@@ -28,6 +28,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m55-bgp-roles-otc.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.55.1.1/24 dev eth1

--- a/tests/interop/m57-orf-frr.clab.yml
+++ b/tests/interop/m57-orf-frr.clab.yml
@@ -32,6 +32,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m57-orf.toml:/etc/rustbgpd/config.initial.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1

--- a/tests/interop/m58-fib-table-crud-frr.clab.yml
+++ b/tests/interop/m58-fib-table-crud-frr.clab.yml
@@ -40,6 +40,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m58-fib-crud.toml:/etc/rustbgpd/config.template.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1

--- a/tests/interop/m59-aspa-roles-rtr2.clab.yml
+++ b/tests/interop/m59-aspa-roles-rtr2.clab.yml
@@ -31,6 +31,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m59-aspa-roles.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1

--- a/tests/interop/m60-evpn-adoption-sweep.clab.yml
+++ b/tests/interop/m60-evpn-adoption-sweep.clab.yml
@@ -47,6 +47,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m60-vtep.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-vtep.sh:/usr/local/bin/start-rustbgpd-vtep.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1

--- a/tests/interop/m61-evpn-l3-adoption-sweep.clab.yml
+++ b/tests/interop/m61-evpn-l3-adoption-sweep.clab.yml
@@ -60,6 +60,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m48-pe1.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-m39-pe1.sh:/usr/local/bin/start-rustbgpd-m39-pe1.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1

--- a/tests/interop/m62-blackhole-adoption-sweep.clab.yml
+++ b/tests/interop/m62-blackhole-adoption-sweep.clab.yml
@@ -50,6 +50,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m62-blackhole.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1

--- a/tests/interop/m63-stalled-rib-hold-timer.clab.yml
+++ b/tests/interop/m63-stalled-rib-hold-timer.clab.yml
@@ -35,6 +35,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m63-stalled-rib.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.63.0.1/24 dev eth1

--- a/tests/interop/m64-ipv6-only.clab.yml
+++ b/tests/interop/m64-ipv6-only.clab.yml
@@ -32,6 +32,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m64-ipv6-only.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.64.0.1/24 dev eth1

--- a/tests/interop/m65-evpn-single-active-failover.clab.yml
+++ b/tests/interop/m65-evpn-single-active-failover.clab.yml
@@ -63,6 +63,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m65-vtep.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-vtep.sh:/usr/local/bin/start-rustbgpd-vtep.sh:ro
       exec:
         - ip addr add 10.0.1.1/24 dev eth1

--- a/tests/interop/m66-evpn-es-drain-handover.clab.yml
+++ b/tests/interop/m66-evpn-es-drain-handover.clab.yml
@@ -94,8 +94,8 @@
 # principals — an operator (bearer-token TCP listener) and an
 # observer (UDS listener) — so the driver can assert the drain RPC's
 # ADR-0064 operator_only ceiling (observer → PermissionDenied) with
-# rbgp, the M54 denial pattern. The VTEP keeps the M65 legacy
-# fixture shape.
+# rbgp, the M54 denial pattern. The VTEP uses the shared public
+# test-only operator identity used by ordinary interop fixtures.
 #
 # Usage:
 #   docker build --target dev -t rustbgpd:dev .
@@ -113,6 +113,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m66-vtep.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-vtep.sh:/usr/local/bin/start-rustbgpd-vtep.sh:ro
       exec:
         - sh -c "echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6"
@@ -141,6 +142,7 @@ topology:
         - bridge fdb append 00:00:00:00:00:00 dev vxlan100 dst 10.0.2.2 self permanent
       env:
         RUST_LOG: info,rustbgpd_evpn_linux=debug,rustbgpd::evpn_dataplane=debug
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     pe1:
       kind: linux

--- a/tests/interop/m68-evpn-type5-gwip-overlay-index-frr.clab.yml
+++ b/tests/interop/m68-evpn-type5-gwip-overlay-index-frr.clab.yml
@@ -33,6 +33,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m68-pe1.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-m68-pe1.sh:/usr/local/bin/start-rustbgpd-m68-pe1.sh:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:

--- a/tests/interop/m69-evpn-preference-df-frr.clab.yml
+++ b/tests/interop/m69-evpn-preference-df-frr.clab.yml
@@ -29,6 +29,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m69-pe1.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-segment.sh:/usr/local/bin/start-rustbgpd-segment.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1

--- a/tests/interop/scripts/test-lib.sh
+++ b/tests/interop/scripts/test-lib.sh
@@ -236,7 +236,7 @@ pe_ctl_observer() {
     docker exec "$pe" rbgp -s "$observer_sock" "$@"
 }
 
-# rbgp against the VTEP/RR (legacy enforcement, plaintext TCP).
+# rbgp against the VTEP/RR using any CLI credential configured in its environment.
 vtep_ctl() {
     docker exec "$VTEP" rbgp -s http://127.0.0.1:50051 "$@"
 }

--- a/tests/interop/scripts/test-m36-evpn-vtep-smoke.sh
+++ b/tests/interop/scripts/test-m36-evpn-vtep-smoke.sh
@@ -27,6 +27,8 @@ set -eu
 
 TOPO="m36-evpn-vtep-smoke"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 

--- a/tests/interop/scripts/test-m38-evpn-df-election.sh
+++ b/tests/interop/scripts/test-m38-evpn-df-election.sh
@@ -26,6 +26,9 @@ PE2="clab-${TOPO}-pe2"
 ESI="00:00:00:00:00:00:00:00:00:01"
 VNI="100"
 PROTO="proto/rustbgpd.proto"
+TEST_OPERATOR_TOKEN_FILE="tests/fixtures/grpc-test-only-operator.token"
+IFS= read -r TEST_OPERATOR_TOKEN < "$TEST_OPERATOR_TOKEN_FILE"
+GRPC_AUTH=(-H "authorization: Bearer $TEST_OPERATOR_TOKEN")
 
 # Type 0x06 / Subtype 0x02 = ES-Import RT (RFC 7432 §7.6).
 # Type 0x06 / Subtype 0x01 = ESI Label (RFC 7432 §7.5).
@@ -100,6 +103,7 @@ grpc_list_evpn() {
     ip=$(resolve_ip "$container")
     [ -z "$ip" ] && return 1
     grpcurl -plaintext -import-path . -proto "$PROTO" \
+        "${GRPC_AUTH[@]}" \
         -d "{\"route_type_filter\": $route_type}" \
         "${ip}:50051" rustbgpd.v1.RibService/ListEvpnRoutes 2>/dev/null
 }

--- a/tests/interop/scripts/test-m39b-evpn-auto-rt-frr.sh
+++ b/tests/interop/scripts/test-m39b-evpn-auto-rt-frr.sh
@@ -36,6 +36,8 @@ PE2="clab-${TOPO}-pe2"
 RUSTBGPD="$PE1"
 export RUSTBGPD
 
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 
@@ -62,7 +64,7 @@ EXPECTED_AUTO_RT="65000:100"
 # ---------------------------------------------------------------------------
 
 grpc_list_evpn() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListEvpnRoutes 2>/dev/null || true
 }

--- a/tests/interop/scripts/test-m40-evpn-aliasing-ecmp-frr.sh
+++ b/tests/interop/scripts/test-m40-evpn-aliasing-ecmp-frr.sh
@@ -48,6 +48,8 @@ PE_C="clab-${TOPO}-pe-c"
 RUSTBGPD="$PE_RB"
 export RUSTBGPD
 
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 

--- a/tests/interop/scripts/test-m41-blackhole-frr.sh
+++ b/tests/interop/scripts/test-m41-blackhole-frr.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 
 TOPO="m41-blackhole-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
@@ -31,7 +33,7 @@ BLACKHOLE_VALUE=$(( (65535 << 16) | 666 ))     # 4294902426 = 0xFFFF_029A
 NO_ADVERTISE_VALUE=$(( (65535 << 16) | 65282 )) # 4294967042 = 0xFFFF_FF02
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
@@ -51,7 +53,7 @@ route_communities() {
 }
 
 grpc_blackholes() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListBlackholeDiscards 2>/dev/null
 }
 
@@ -99,7 +101,7 @@ dump_state_on_failure() {
     echo "===== rustbgpd container routes =====" >&2
     docker exec "$RUSTBGPD" ip route show >&2 || true
     echo "===== rustbgpd NeighborState 10.0.0.2 =====" >&2
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"address":"10.0.0.2"}' \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>&1 \
         | head -60 >&2 || true

--- a/tests/interop/scripts/test-m42-fib-runtime-frr.sh
+++ b/tests/interop/scripts/test-m42-fib-runtime-frr.sh
@@ -10,6 +10,8 @@ set -euo pipefail
 
 TOPO="m42-fib-runtime-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 TABLE_ID=1000
@@ -24,7 +26,7 @@ start_rustbgpd
 wait_frr_established "$FRR" "10.0.0.1" "rustbgpd ↔ FRR"
 
 grpc_fib_routes() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListFibRoutes
 }
 
@@ -79,7 +81,7 @@ dump_state_on_failure() {
     echo "===== rustbgpd main table =====" >&2
     docker exec "$RUSTBGPD" ip route show >&2 || true
     echo "===== rustbgpd NeighborState 10.0.0.2 =====" >&2
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"address":"10.0.0.2"}' \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>&1 \
         | head -80 >&2 || true

--- a/tests/interop/scripts/test-m43-tcp-ao-bird.sh
+++ b/tests/interop/scripts/test-m43-tcp-ao-bird.sh
@@ -24,6 +24,8 @@
 
 TOPO="m43-tcp-ao-bird"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=tests/interop/scripts/test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 BIRD="clab-${TOPO}-bird"
@@ -32,13 +34,13 @@ BAD_CONF="/etc/bird/bird-bad.conf"
 TEST_PREFIX="203.0.113.43"
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"neighbor_address": "10.0.43.2"}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 grpc_neighbor_state() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"address": "10.0.43.2"}' \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>/dev/null
 }
@@ -59,7 +61,7 @@ dump_diagnostics() {
     echo "--- BIRD protocol state ---" >&2
     docker exec "$BIRD" birdc show protocols all rustbgpd >&2 || true
     echo "--- rustbgpd TCP-AO support ---" >&2
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.GlobalService/GetGlobal >&2 || true
 }
 

--- a/tests/interop/scripts/test-m45-evpn-type5-injection.sh
+++ b/tests/interop/scripts/test-m45-evpn-type5-injection.sh
@@ -30,6 +30,8 @@
 
 TOPO="m45-evpn-type5-injection"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=tests/interop/scripts/test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 
@@ -52,31 +54,31 @@ ROUTER_MAC="02:00:00:00:50:00"
 # `|| true` so a non-zero grpcurl exit (RPC error) doesn't trip the
 # `set -e` from test-lib.sh — the assertions inspect the captured text.
 grpc_add_type5() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"routeType\":5,\"rd\":\"$RD\",\"ethernetTag\":0,\"label\":$VNI,\"nextHop\":\"$RUSTBGPD_IP\",\"routeTargets\":[\"$RT\"],\"disableVxlanEncap\":false,\"prefix\":\"$PREFIX\",\"prefixLength\":$PREFIX_LEN,\"routerMac\":\"$ROUTER_MAC\"}" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/AddEvpnRoute 2>&1 || true
 }
 
 grpc_add_type5_overlay_gateway() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"routeType\":5,\"rd\":\"$RD\",\"ethernetTag\":0,\"label\":$VNI,\"nextHop\":\"$RUSTBGPD_IP\",\"routeTargets\":[\"$RT\"],\"disableVxlanEncap\":false,\"prefix\":\"$OVERLAY_PREFIX\",\"prefixLength\":$OVERLAY_PREFIX_LEN,\"routerMac\":\"$ROUTER_MAC\",\"gateway\":\"$OVERLAY_GATEWAY\"}" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/AddEvpnRoute 2>&1 || true
 }
 
 grpc_delete_type5() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"routeType\":5,\"rd\":\"$RD\",\"ethernetTag\":0,\"prefix\":\"$PREFIX\",\"prefixLength\":$PREFIX_LEN}" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/DeleteEvpnRoute 2>&1 || true
 }
 
 grpc_delete_type5_overlay_gateway() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"routeType\":5,\"rd\":\"$RD\",\"ethernetTag\":0,\"prefix\":\"$OVERLAY_PREFIX\",\"prefixLength\":$OVERLAY_PREFIX_LEN}" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/DeleteEvpnRoute 2>&1 || true
 }
 
 grpc_list_evpn() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListEvpnRoutes 2>/dev/null || true
 }

--- a/tests/interop/scripts/test-m46-evpn-df-hrw.sh
+++ b/tests/interop/scripts/test-m46-evpn-df-hrw.sh
@@ -31,6 +31,9 @@ PE2="clab-${TOPO}-pe2"
 ESI="00:00:00:00:00:00:00:00:00:01"
 VNI="10"
 PROTO="proto/rustbgpd.proto"
+TEST_OPERATOR_TOKEN_FILE="tests/fixtures/grpc-test-only-operator.token"
+IFS= read -r TEST_OPERATOR_TOKEN < "$TEST_OPERATOR_TOKEN_FILE"
+GRPC_AUTH=(-H "authorization: Bearer $TEST_OPERATOR_TOKEN")
 
 resolve_ip() {
     docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$1" 2>/dev/null
@@ -84,6 +87,7 @@ grpc_list_evpn() {
     ip=$(resolve_ip "$container")
     [ -z "$ip" ] && return 1
     grpcurl -plaintext -import-path . -proto "$PROTO" \
+        "${GRPC_AUTH[@]}" \
         -d "{\"route_type_filter\": $route_type}" \
         "${ip}:50051" rustbgpd.v1.RibService/ListEvpnRoutes 2>/dev/null
 }

--- a/tests/interop/scripts/test-m47-evpn-tenant-teardown.sh
+++ b/tests/interop/scripts/test-m47-evpn-tenant-teardown.sh
@@ -29,6 +29,8 @@
 
 TOPO="m47-evpn-tenant-teardown"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=tests/interop/scripts/test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 
@@ -47,7 +49,7 @@ fi
 # ---------------------------------------------------------------------------
 
 grpc_list_evpn() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListEvpnRoutes 2>/dev/null || true
 }
@@ -65,7 +67,7 @@ evpn_has_route_type() {
 # handles the multi-line escaping.
 grpc_apply_teardown() {
     jq -Rs '{candidateToml: ., validateOnly: false}' <"$TEARDOWN_TOML" \
-        | grpcurl -plaintext -import-path . -proto "$PROTO" -d @ \
+        | grpcurl_call -d @ \
             "$GRPC_ADDR" rustbgpd.v1.EvpnService/ApplyEvpnRuntime 2>&1 || true
 }
 

--- a/tests/interop/scripts/test-m48-evpn-tenant-teardown-datapath.sh
+++ b/tests/interop/scripts/test-m48-evpn-tenant-teardown-datapath.sh
@@ -35,6 +35,8 @@ PE2="clab-${TOPO}-pe2"
 RUSTBGPD="$PE1"
 export RUSTBGPD
 
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 
@@ -60,13 +62,13 @@ fi
 # ---------------------------------------------------------------------------
 
 grpc_list_evpn() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{}' "$GRPC_ADDR" rustbgpd.v1.RibService/ListEvpnRoutes 2>/dev/null
 }
 
 grpc_apply_teardown() {
     jq -Rs '{candidateToml: ., validateOnly: false}' <"$TEARDOWN_TOML" \
-        | grpcurl -plaintext -import-path . -proto "$PROTO" -d @ \
+        | grpcurl_call -d @ \
             "$GRPC_ADDR" rustbgpd.v1.EvpnService/ApplyEvpnRuntime 2>&1 || true
 }
 

--- a/tests/interop/scripts/test-m49-evpn-preference-df.sh
+++ b/tests/interop/scripts/test-m49-evpn-preference-df.sh
@@ -38,6 +38,9 @@ PE2="clab-${TOPO}-pe2"
 ESI="00:00:00:00:00:00:00:00:00:01"
 VNI="200"
 PROTO="proto/rustbgpd.proto"
+TEST_OPERATOR_TOKEN_FILE="tests/fixtures/grpc-test-only-operator.token"
+IFS= read -r TEST_OPERATOR_TOKEN < "$TEST_OPERATOR_TOKEN_FILE"
+GRPC_AUTH=(-H "authorization: Bearer $TEST_OPERATOR_TOKEN")
 
 resolve_ip() {
     docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$1" 2>/dev/null
@@ -91,6 +94,7 @@ grpc_list_evpn() {
     ip=$(resolve_ip "$container")
     [ -z "$ip" ] && return 1
     grpcurl -plaintext -import-path . -proto "$PROTO" \
+        "${GRPC_AUTH[@]}" \
         -d "{\"route_type_filter\": $route_type}" \
         "${ip}:50051" rustbgpd.v1.RibService/ListEvpnRoutes 2>/dev/null
 }

--- a/tests/interop/scripts/test-m50-fib-ecmp-frr.sh
+++ b/tests/interop/scripts/test-m50-fib-ecmp-frr.sh
@@ -15,6 +15,8 @@ set -euo pipefail
 
 TOPO="m50-fib-ecmp-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR1="clab-${TOPO}-frr1"
 FRR2="clab-${TOPO}-frr2"
@@ -31,7 +33,7 @@ wait_frr_established "$FRR1" "10.0.0.1" "rustbgpd ↔ frr1"
 wait_frr_established "$FRR2" "10.0.1.1" "rustbgpd ↔ frr2"
 
 grpc_fib_routes() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListFibRoutes
 }
 

--- a/tests/interop/scripts/test-m51-bfd-frr.sh
+++ b/tests/interop/scripts/test-m51-bfd-frr.sh
@@ -20,6 +20,8 @@ set -euo pipefail
 
 TOPO="m51-bfd-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR1="clab-${TOPO}-frr1"
 PEER="10.0.0.2"
@@ -34,7 +36,7 @@ wait_frr_established "$FRR1" "10.0.0.1" "rustbgpd ↔ frr1"
 grpc_bfd_state() {
     # State of the BFD session to $PEER as reported by rustbgpd, e.g.
     # "BFD_SESSION_STATE_UP". Empty if the session is absent.
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"peer_address\": \"$PEER\"}" \
         "$GRPC_ADDR" rustbgpd.v1.BfdService/GetBfdSessions 2>/dev/null \
         | jq -r '.sessions[0].state // ""'
@@ -42,7 +44,7 @@ grpc_bfd_state() {
 
 grpc_bgp_state() {
     # rustbgpd's own view of the BGP session FSM state to $PEER.
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"address\": \"$PEER\"}" \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>/dev/null \
         | jq -r '.state // ""'
@@ -55,11 +57,11 @@ frr_bfd_status() {
 
 dump_state_on_failure() {
     echo "===== rustbgpd GetBfdSessions (raw) =====" >&2
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"peer_address\": \"$PEER\"}" \
         "$GRPC_ADDR" rustbgpd.v1.BfdService/GetBfdSessions >&2 2>&1 || true
     echo "===== rustbgpd GetNeighborState (raw) =====" >&2
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"address\": \"$PEER\"}" \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState >&2 2>&1 || true
     echo "===== frr1 vtysh: show bfd peers =====" >&2

--- a/tests/interop/scripts/test-m52-fib-ecmp-relax-frr.sh
+++ b/tests/interop/scripts/test-m52-fib-ecmp-relax-frr.sh
@@ -17,6 +17,8 @@ set -euo pipefail
 
 TOPO="m52-fib-ecmp-relax-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR1="clab-${TOPO}-frr1"
 FRR2="clab-${TOPO}-frr2"
@@ -33,7 +35,7 @@ wait_frr_established "$FRR1" "10.0.0.1" "rustbgpd ↔ frr1 (AS 65002)"
 wait_frr_established "$FRR2" "10.0.1.1" "rustbgpd ↔ frr2 (AS 65003)"
 
 grpc_fib_routes() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListFibRoutes
 }
 

--- a/tests/interop/scripts/test-m53-bgp-unnumbered-frr.sh
+++ b/tests/interop/scripts/test-m53-bgp-unnumbered-frr.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 
 TOPO="m53-bgp-unnumbered-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 
 FRR1="clab-${TOPO}-frr1"
@@ -25,24 +27,24 @@ resolve_grpc_addr
 start_rustbgpd
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes
 }
 
 grpc_list_fib() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListFibRoutes
 }
 
 grpc_list_neighbors() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/ListNeighbors
 }
 
 grpc_inject_route() {
     local addr=${INJECTED_PREFIX%/*}
     local plen=${INJECTED_PREFIX#*/}
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"prefix\": \"$addr\", \"prefix_length\": $plen, \"next_hop\": \"$LOCAL_LL\", \"origin\": 0}" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/AddPath >/dev/null
 }

--- a/tests/interop/scripts/test-m55-bgp-roles-otc-frr.sh
+++ b/tests/interop/scripts/test-m55-bgp-roles-otc-frr.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 TOPO="m55-bgp-roles-otc-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 
 FRR_CUSTOMER="clab-${TOPO}-frr-customer"
@@ -24,12 +26,12 @@ RUST_IP=$(resolve_ip "$RUSTBGPD")
 start_rustbgpd
 
 grpc_list_neighbors() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/ListNeighbors
 }
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes
 }
 
@@ -37,7 +39,7 @@ grpc_inject_route() {
     local prefix=$1
     local addr=${prefix%/*}
     local plen=${prefix#*/}
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"prefix\": \"$addr\", \"prefix_length\": $plen, \"next_hop\": \"10.55.1.1\", \"origin\": 0}" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/AddPath >/dev/null
 }

--- a/tests/interop/scripts/test-m57-orf-frr.sh
+++ b/tests/interop/scripts/test-m57-orf-frr.sh
@@ -20,6 +20,8 @@ set -euo pipefail
 
 TOPO="m57-orf-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
@@ -37,7 +39,7 @@ wait_frr_established "$FRR" "10.0.0.1" "rustbgpd ↔ FRR"
 # inbound ORF does not matter: the RFC 5291 §6 gate holds advertisement until
 # FRR's ORF arrives, then the filtered set is flooded.
 inject() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"prefix\":\"${1%/*}\",\"prefixLength\":${1#*/},\"nextHop\":\"10.0.0.1\",\"origin\":2,\"asPath\":[]}" \
         "$GRPC_ADDR" rustbgpd.v1.InjectionService/AddPath > /dev/null
 }

--- a/tests/interop/scripts/test-m58-fib-table-crud-frr.sh
+++ b/tests/interop/scripts/test-m58-fib-table-crud-frr.sh
@@ -15,6 +15,8 @@ set -euo pipefail
 
 TOPO="m58-fib-table-crud-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 
@@ -36,7 +38,7 @@ wait_frr_established "$FRR" "10.0.0.1" "rustbgpd ↔ FRR"
 # ---- gRPC helpers -----------------------------------------------------------
 
 grpc() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" "$@"
+    grpcurl_call "$@"
 }
 
 list_fib_tables() {

--- a/tests/interop/scripts/test-m59-aspa-roles.sh
+++ b/tests/interop/scripts/test-m59-aspa-roles.sh
@@ -17,6 +17,8 @@ set -euo pipefail
 
 TOPO="m59-aspa-roles-rtr2"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
 RTR_SERVER="clab-${TOPO}-rtr-server"
@@ -50,7 +52,7 @@ start_rtr_server() {
 }
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"neighbor_address": "10.0.0.2"}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }

--- a/tests/interop/scripts/test-m60-evpn-adoption-sweep.sh
+++ b/tests/interop/scripts/test-m60-evpn-adoption-sweep.sh
@@ -38,6 +38,8 @@ set -eu
 
 TOPO="m60-evpn-adoption-sweep"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 

--- a/tests/interop/scripts/test-m61-evpn-l3-adoption-sweep.sh
+++ b/tests/interop/scripts/test-m61-evpn-l3-adoption-sweep.sh
@@ -81,6 +81,8 @@ PE2="clab-${TOPO}-pe2"
 RUSTBGPD="$PE1"
 export RUSTBGPD
 
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 

--- a/tests/interop/scripts/test-m62-blackhole-adoption-sweep.sh
+++ b/tests/interop/scripts/test-m62-blackhole-adoption-sweep.sh
@@ -45,6 +45,8 @@ set -eu
 
 TOPO="m62-blackhole-adoption-sweep"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 
@@ -94,7 +96,7 @@ kernel_blackhole_foreign_present() {
 }
 
 grpc_blackholes() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListBlackholeDiscards 2>/dev/null
 }
 

--- a/tests/interop/scripts/test-m63-stalled-rib-hold-timer.sh
+++ b/tests/interop/scripts/test-m63-stalled-rib-hold-timer.sh
@@ -56,6 +56,8 @@ set -eu
 
 TOPO="m63-stalled-rib-hold-timer"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 
@@ -106,7 +108,7 @@ prom_labeled_sum() {
 }
 
 grpc_neighbor_state() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"address\":\"${FRR_IP}\"}" \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>/dev/null
 }
@@ -117,7 +119,7 @@ grpc_neighbor_state() {
 # call can block ~one stall interval and wreck the 1 s poll grain. A
 # timeout is an unknown reading (and itself evidence of the stall).
 grpc_neighbor_state_quick() {
-    grpcurl -plaintext -max-time 2 -import-path . -proto "$PROTO" \
+    grpcurl_call -max-time 2 \
         -d "{\"address\":\"${FRR_IP}\"}" \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>/dev/null
 }
@@ -126,7 +128,7 @@ grpc_neighbor_state_quick() {
 # from the RIB, not the transport's own bookkeeping). total_count is
 # pagination-proof.
 rib_received_count() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"neighbor_address\":\"${FRR_IP}\"}" \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null \
         | jq -r '.totalCount // 0'

--- a/tests/interop/scripts/test-m64-ipv6-only.sh
+++ b/tests/interop/scripts/test-m64-ipv6-only.sh
@@ -40,6 +40,8 @@ set -eu
 
 TOPO="m64-ipv6-only"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 
@@ -58,14 +60,14 @@ frr_neighbor_json() {
 }
 
 grpc_routes_from_peer() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"neighbor_address\": \"$1\"}" \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 inject_route() {
     local prefix=$1 len=$2 next_hop=$3
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{
             \"prefix\": \"${prefix}\",
             \"prefix_length\": ${len},

--- a/tests/interop/scripts/test-m65-evpn-single-active-failover.sh
+++ b/tests/interop/scripts/test-m65-evpn-single-active-failover.sh
@@ -73,6 +73,8 @@ TOPO="m65-evpn-single-active-failover"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RUSTBGPD="clab-${TOPO}-vtep"
 export RUSTBGPD
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 

--- a/tests/interop/scripts/test-m66-evpn-es-drain-handover.sh
+++ b/tests/interop/scripts/test-m66-evpn-es-drain-handover.sh
@@ -70,6 +70,8 @@ TOPO="m66-evpn-es-drain-handover"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RUSTBGPD="clab-${TOPO}-vtep"
 export RUSTBGPD
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=tests/interop/scripts/test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 

--- a/tests/interop/scripts/test-m68-evpn-type5-gwip-overlay-index-frr.sh
+++ b/tests/interop/scripts/test-m68-evpn-type5-gwip-overlay-index-frr.sh
@@ -10,6 +10,8 @@ PE2="clab-${TOPO}-pe2"
 RUSTBGPD="$PE1"
 export RUSTBGPD
 
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 

--- a/tests/interop/scripts/test-m69-evpn-preference-df-frr.sh
+++ b/tests/interop/scripts/test-m69-evpn-preference-df-frr.sh
@@ -22,6 +22,8 @@ VNI="200"
 FRR_DF_EXTCOMM="434036613111087304"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 
@@ -39,7 +41,7 @@ wait_grpc_ready() {
 }
 
 grpc_list_type4() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"route_type_filter": 4}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListEvpnRoutes 2>/dev/null
 }

--- a/tests/interop_tier_auth_dataplane.rs
+++ b/tests/interop_tier_auth_dataplane.rs
@@ -1,0 +1,173 @@
+//! Structural and production-loader gate for the active M36-M69 auth migration.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+const TOKEN: &str = "/run/rustbgpd/grpc-test-only-operator.token";
+const PRINCIPAL: &str = "rustbgpd://operator/test-only";
+const TOKEN_BIND: &str =
+    "../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro";
+const EXCLUDED: &[&str] = &[
+    "rustbgpd-m37-originator.toml",
+    "rustbgpd-m39-pe1.toml",
+    "rustbgpd-m67-vtep.toml",
+    "rustbgpd-m44-tier-authz.toml",
+    "rustbgpd-m54-gnmi.toml",
+    "rustbgpd-m56-gnmi-onchange.toml",
+    "rustbgpd-m66-pe1.toml",
+    "rustbgpd-m66-pe2.toml",
+    "rustbgpd-m67-pe1.toml",
+    "rustbgpd-m67-pe2.toml",
+];
+
+fn in_scope(name: &str) -> bool {
+    let Some(suffix) = name.strip_prefix("rustbgpd-m") else {
+        return false;
+    };
+    let digits: String = suffix.chars().take_while(char::is_ascii_digit).collect();
+    name.ends_with(".toml")
+        && digits.parse::<u8>().is_ok_and(|n| (36..=69).contains(&n))
+        && !EXCLUDED.contains(&name)
+}
+
+/// Reverting tier, removing a mount/opt-in/M66 token, bypassing the helper, or
+/// omitting a standalone header makes this red; semantic breaks fail `--check`.
+#[test]
+fn active_dataplane_interop_is_tier_authenticated_end_to_end() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let interop = root.join("tests/interop");
+    let config_dir = interop.join("configs");
+    let token_host = root.join("tests/fixtures/grpc-test-only-operator.token");
+    let mut configs = BTreeSet::new();
+
+    for entry in fs::read_dir(&config_dir).unwrap() {
+        let file = entry.unwrap().path();
+        let name = file.file_name().unwrap().to_str().unwrap();
+        if !in_scope(name) {
+            continue;
+        }
+        let source = fs::read_to_string(&file).expect("interop config must be readable");
+        let value: toml::Value =
+            toml::from_str(&source).unwrap_or_else(|error| panic!("{name}: {error}"));
+        let grpc = &value["global"]["telemetry"]["grpc_tcp"];
+        let security = &value["security"]["grpc"];
+        assert_eq!(grpc["token_file"].as_str(), Some(TOKEN), "{name}");
+        assert_eq!(grpc["principal"].as_str(), Some(PRINCIPAL), "{name}");
+        assert_eq!(security["enforcement"].as_str(), Some("tier"), "{name}");
+        let role = security["roles"][PRINCIPAL].as_str();
+        assert_eq!(role, Some("operator"), "{name}");
+
+        let materialized = source
+            .replace(TOKEN, &token_host.display().to_string())
+            .replace("STAYRTR_ADDR", "127.0.0.1")
+            .replace("BMP_RECEIVER_ADDR", "127.0.0.1");
+        let mut staged = tempfile::Builder::new()
+            .suffix(".config-check")
+            .tempfile_in(&config_dir)
+            .expect("create materialized config beside relative resources");
+        staged.write_all(materialized.as_bytes()).unwrap();
+        let output = Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
+            .arg("--check")
+            .arg(staged.path())
+            .current_dir(root)
+            .output()
+            .expect("run production config loader");
+        assert!(
+            output.status.success(),
+            "{name} failed production --check\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        configs.insert(name.to_owned());
+    }
+    assert_eq!(configs.len(), 35, "classify the changed config inventory");
+
+    let mut topologies = BTreeSet::new();
+    let mut mounted = BTreeSet::new();
+    for entry in fs::read_dir(&interop).unwrap() {
+        let file = entry.unwrap().path();
+        let name = file.file_name().unwrap().to_str().unwrap();
+        if !name.ends_with(".clab.yml") {
+            continue;
+        }
+        let source = fs::read_to_string(&file).expect("topology must be readable");
+        if !configs.iter().any(|config| source.contains(config)) {
+            continue;
+        }
+        let yaml: serde_yaml::Value = serde_yaml::from_str(&source)
+            .unwrap_or_else(|error| panic!("{name} invalid YAML: {error}"));
+        let nodes = yaml["topology"]["nodes"].as_mapping().expect("nodes map");
+        for (node_name, node) in nodes {
+            let Some(binds) = node["binds"].as_sequence() else {
+                continue;
+            };
+            let bound: Vec<_> = binds
+                .iter()
+                .filter_map(serde_yaml::Value::as_str)
+                .filter_map(|bind| Path::new(bind.split(':').next()?).file_name()?.to_str())
+                .filter(|config| configs.contains(*config))
+                .collect();
+            if bound.is_empty() {
+                continue;
+            }
+            topologies.insert(name.trim_end_matches(".clab.yml").to_owned());
+            mounted.extend(bound.iter().map(|config| (*config).to_owned()));
+            assert!(
+                binds.iter().any(|bind| bind.as_str() == Some(TOKEN_BIND)),
+                "{name} node {node_name:?} lacks shared token beside {bound:?}"
+            );
+        }
+    }
+    let unmounted: BTreeSet<_> = configs.difference(&mounted).cloned().collect();
+    assert_eq!(
+        unmounted,
+        BTreeSet::from(["rustbgpd-m47-teardown.toml".into()])
+    );
+    assert_eq!(topologies.len(), 29, "topology inventory changed");
+
+    let standalone = [
+        "m38-evpn-df-election",
+        "m46-evpn-df-hrw",
+        "m49-evpn-preference-df",
+    ];
+    for topology in &topologies {
+        let driver = match topology.as_str() {
+            "m59-aspa-roles-rtr2" => "test-m59-aspa-roles.sh".to_owned(),
+            _ => format!("test-{topology}.sh"),
+        };
+        let source = fs::read_to_string(interop.join("scripts").join(&driver))
+            .unwrap_or_else(|error| panic!("{driver}: {error}"));
+        if source.contains("source \"$SCRIPT_DIR/test-lib.sh\"") {
+            assert!(source.contains("INTEROP_TEST_OPERATOR_AUTH=1"), "{driver}");
+            assert!(
+                !source.contains("grpcurl -plaintext"),
+                "{driver} bypasses helper"
+            );
+        } else {
+            assert!(
+                standalone.contains(&topology.as_str()),
+                "unexpected {driver}"
+            );
+            assert!(source.contains(
+                "TEST_OPERATOR_TOKEN_FILE=\"tests/fixtures/grpc-test-only-operator.token\""
+            ));
+            assert!(
+                source.contains("\"${GRPC_AUTH[@]}\""),
+                "{driver} lacks bearer header"
+            );
+        }
+    }
+
+    let m66: serde_yaml::Value = serde_yaml::from_str(
+        &fs::read_to_string(interop.join("m66-evpn-es-drain-handover.clab.yml")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        m66["topology"]["nodes"]["vtep"]["env"]["RUSTBGPD_TOKEN_FILE"].as_str(),
+        Some(TOKEN),
+        "M66 vtep_ctl must inherit the shared token"
+    );
+}


### PR DESCRIPTION
## Summary

- migrate the safe active M36-M69 dataplane/EVPN fixture set to the shared test-only tier-auth convention
- wire 35 configs, 29 topologies, and 29 drivers, including all M43 candidate generations and M47/M48 teardown candidates
- authenticate the three standalone multi-node drivers with bounded bearer arrays and expose the shared CLI token to the M66 VTEP
- add an auto-discovered structural gate that runs all 35 configs through the real `rustbgpd --check` production loader
- materialize the shared test token only in six existing fixture-driven tests that now consume migrated container paths

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- focused M47/M48/M49/M51/M52/M55 semantic tests
- Bash syntax and ShellCheck error-severity checks for all changed drivers
- real M41 containerlab harness: 14/14
- no temporary config or container residue

## Load-bearing proof

Eight mutations were proven red and restored: config enforcement, role, topology mount, helper opt-in/bypass, standalone bearer header, M66 VTEP CLI environment, and a raw-valid `hold_time = 1` change rejected only by the real production loader. The gate also pins the exact unmounted exception to the host-fed M47 teardown candidate rather than relying on a count.

## Scope

This is LAN-546 Phase 2 slice 2. It intentionally excludes held/shared-soak fixtures, all soak files, dedicated M44/M54/M56 and M66/M67 PE identities, runtime legacy-mode removal, and production credential generation.

Docs: no user/operator documentation or changelog change is needed because daemon behavior and defaults do not change. The only prose adjustment corrects the shared test helper’s now-stale legacy-auth comment.