### PR TITLE
test: migrate RR interop labs to tier auth

### DIFF
--- a/tests/interop/configs/rustbgpd-m70-vtep.toml
+++ b/tests/interop/configs/rustbgpd-m70-vtep.toml
@@ -11,6 +11,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # ADR-0089 v1 shape: one VLAN-aware bridge, one traditional VXLAN
 # device per VNI, and a local bridge_vlan binding. Ethernet Tag ID
@@ -41,4 +43,7 @@ hold_time = 30
 families = ["l2vpn_evpn"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m71-vtep.toml
+++ b/tests/interop/configs/rustbgpd-m71-vtep.toml
@@ -29,6 +29,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -64,4 +66,7 @@ l3vxlan_device = "l3vxlan100"
 table_id = 100
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m72-vtep.toml
+++ b/tests/interop/configs/rustbgpd-m72-vtep.toml
@@ -17,6 +17,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.1.2"
@@ -56,4 +58,7 @@ l3vxlan_device = "l3vxlan100"
 table_id = 100
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m73-bgpls-rr.toml
+++ b/tests/interop/configs/rustbgpd-m73-bgpls-rr.toml
@@ -10,6 +10,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -28,4 +30,7 @@ route_reflector_client = true
 families = ["linkstate"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m74-vpnv4-rr.toml
+++ b/tests/interop/configs/rustbgpd-m74-vpnv4-rr.toml
@@ -10,6 +10,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -28,4 +30,7 @@ route_reflector_client = true
 families = ["l3vpn_ipv4_unicast"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m75-rtc-rr.toml
+++ b/tests/interop/configs/rustbgpd-m75-rtc-rr.toml
@@ -10,6 +10,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -38,4 +40,7 @@ route_reflector_client = true
 families = ["l3vpn_ipv4_unicast"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m76-orr-rr.toml
+++ b/tests/interop/configs/rustbgpd-m76-orr-rr.toml
@@ -17,6 +17,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -61,4 +63,7 @@ families = ["ipv4_unicast"]
 orr_vantage = "10.0.8.2"
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m77-gr-rr.toml
+++ b/tests/interop/configs/rustbgpd-m77-gr-rr.toml
@@ -23,6 +23,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.1.2"
@@ -55,4 +57,7 @@ graceful_restart = true
 gr_stale_routes_time = 60
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m78-rr1.toml
+++ b/tests/interop/configs/rustbgpd-m78-rr1.toml
@@ -18,6 +18,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -59,4 +61,7 @@ send = true
 send_max = 4
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m78-rr2.toml
+++ b/tests/interop/configs/rustbgpd-m78-rr2.toml
@@ -15,6 +15,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.5.2"
@@ -56,4 +58,7 @@ send = true
 send_max = 4
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m79-labeled-rr.toml
+++ b/tests/interop/configs/rustbgpd-m79-labeled-rr.toml
@@ -18,6 +18,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.1.2"
@@ -38,4 +40,7 @@ route_reflector_client = true
 families = ["ipv4_labeled_unicast", "ipv6_labeled_unicast"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m80-policy.toml
+++ b/tests/interop/configs/rustbgpd-m80-policy.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # All policy comes from the .rpol file (ADR-0096). The topology
 # stages it at /etc/rustbgpd/policies/core.rpol; the path here is
@@ -41,4 +43,7 @@ import_policy_chain = ["customer-in(300)"]
 export_policy_chain = ["edge-out"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m81-bmp-rr.toml
+++ b/tests/interop/configs/rustbgpd-m81-bmp-rr.toml
@@ -15,6 +15,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [bmp]
 sys_name = "rustbgpd-m81"
@@ -69,4 +71,7 @@ route_reflector_client = true
 families = ["ipv4_unicast", "ipv6_unicast", "l3vpn_ipv4_unicast"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m82-rr.toml
+++ b/tests/interop/configs/rustbgpd-m82-rr.toml
@@ -14,6 +14,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -32,4 +34,7 @@ families = ["l2vpn_evpn"]
 route_reflector_client = true
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m83-rs.toml
+++ b/tests/interop/configs/rustbgpd-m83-rs.toml
@@ -22,9 +22,14 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"
 
 # RPKI cache — StayRTR on the containerlab management network.
 [rpki]

--- a/tests/interop/configs/rustbgpd-m84-multicache.toml
+++ b/tests/interop/configs/rustbgpd-m84-multicache.toml
@@ -13,6 +13,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [rpki]
 
@@ -44,4 +46,7 @@ description = "frr-m84"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m85-client.toml
+++ b/tests/interop/configs/rustbgpd-m85-client.toml
@@ -13,6 +13,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.85.3.1"
@@ -22,4 +24,7 @@ hold_time = 90
 families = ["ipv4_unicast", "ipv6_unicast"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m85-rr.toml
+++ b/tests/interop/configs/rustbgpd-m85-rr.toml
@@ -23,6 +23,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.85.1.2"
@@ -53,4 +55,7 @@ route_reflector_client = true
 families = ["ipv4_unicast", "ipv6_unicast"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m86-client.toml
+++ b/tests/interop/configs/rustbgpd-m86-client.toml
@@ -13,6 +13,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.86.3.1"
@@ -22,4 +24,7 @@ hold_time = 90
 families = ["ipv4_unicast", "ipv6_unicast"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m86-rr.toml
+++ b/tests/interop/configs/rustbgpd-m86-rr.toml
@@ -19,6 +19,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.86.1.2"
@@ -49,4 +51,7 @@ route_reflector_client = true
 families = ["ipv4_unicast", "ipv6_unicast"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m87-rs.toml
+++ b/tests/interop/configs/rustbgpd-m87-rs.toml
@@ -16,9 +16,14 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"
 
 [policy.definitions.m87-add-sink-marker]
 default_action = "permit"

--- a/tests/interop/configs/rustbgpd-m89-paths-limit.toml
+++ b/tests/interop/configs/rustbgpd-m89-paths-limit.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.89.1.2"
@@ -49,4 +51,7 @@ send_max = 4
 receive_max = 7
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m91-rfc7606.toml
+++ b/tests/interop/configs/rustbgpd-m91-rfc7606.toml
@@ -9,6 +9,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # Raw fixture injects one malformed UPDATE per RFC 7606 disposition class.
 [[neighbors]]
@@ -18,4 +20,7 @@ description = "m91-raw-malformed"
 hold_time = 90
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m92-rs.toml
+++ b/tests/interop/configs/rustbgpd-m92-rs.toml
@@ -12,9 +12,14 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"
 
 [policy.definitions.deny-m92-v6-control]
 default_action = "permit"

--- a/tests/interop/configs/rustbgpd-m93-required.toml
+++ b/tests/interop/configs/rustbgpd-m93-required.toml
@@ -10,6 +10,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.93.0.2"
@@ -18,4 +20,7 @@ families = ["ipv4_unicast", "ipv6_unicast"]
 required_families = ["ipv6_unicast"]
 
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/m70-evpn-vlan-aware-bridge-frr.clab.yml
+++ b/tests/interop/m70-evpn-vlan-aware-bridge-frr.clab.yml
@@ -23,6 +23,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m70-vtep.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-m70-vtep.sh:/usr/local/bin/start-rustbgpd-m70-vtep.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
@@ -30,6 +31,7 @@ topology:
         - /usr/local/bin/start-rustbgpd-m70-vtep.sh 10.0.0.1
       env:
         RUST_LOG: info,rustbgpd_evpn_linux=debug,rustbgpd::evpn_originator=debug
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     frr:
       kind: linux

--- a/tests/interop/m71-evpn-esi-overlay-type5-receive-gobgp.clab.yml
+++ b/tests/interop/m71-evpn-esi-overlay-type5-receive-gobgp.clab.yml
@@ -46,6 +46,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m71-vtep.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-m71-vtep.sh:/usr/local/bin/start-rustbgpd-m71-vtep.sh:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
@@ -53,6 +54,7 @@ topology:
         - ip link set eth1 up
       env:
         RUST_LOG: info,rustbgpd_evpn_linux=debug,rustbgpd::evpn_dataplane=debug,rustbgpd::evpn_l3_originator=debug
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     pe:
       kind: linux

--- a/tests/interop/m72-evpn-esi-overlay-type5-all-active-gobgp.clab.yml
+++ b/tests/interop/m72-evpn-esi-overlay-type5-all-active-gobgp.clab.yml
@@ -43,6 +43,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m72-vtep.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-m72-vtep.sh:/usr/local/bin/start-rustbgpd-m72-vtep.sh:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
@@ -52,6 +53,7 @@ topology:
         - ip link set eth2 up
       env:
         RUST_LOG: info,rustbgpd_evpn_linux=debug,rustbgpd::evpn_dataplane=debug,rustbgpd::evpn_l3_originator=debug
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     pe1:
       kind: linux

--- a/tests/interop/m73-bgpls-reflection-gobgp.clab.yml
+++ b/tests/interop/m73-bgpls-reflection-gobgp.clab.yml
@@ -22,6 +22,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m73-bgpls-rr.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
@@ -30,6 +31,7 @@ topology:
         - ip link set eth2 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     gobgp-src:
       kind: linux

--- a/tests/interop/m74-vpnv4-reflection-gobgp.clab.yml
+++ b/tests/interop/m74-vpnv4-reflection-gobgp.clab.yml
@@ -24,6 +24,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m74-vpnv4-rr.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
@@ -32,6 +33,7 @@ topology:
         - ip link set eth2 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     gobgp-src:
       kind: linux

--- a/tests/interop/m75-rtc-vpnv4-filter-gobgp.clab.yml
+++ b/tests/interop/m75-rtc-vpnv4-filter-gobgp.clab.yml
@@ -28,6 +28,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m75-rtc-rr.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
@@ -38,6 +39,7 @@ topology:
         - ip link set eth3 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     gobgp-src:
       kind: linux

--- a/tests/interop/m76-orr-divergent-best-gobgp.clab.yml
+++ b/tests/interop/m76-orr-divergent-best-gobgp.clab.yml
@@ -25,6 +25,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m76-orr-rr.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
@@ -39,6 +40,7 @@ topology:
         - ip link set eth5 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     gobgp-src:
       kind: linux

--- a/tests/interop/m77-gr-llgr-rr-gobgp.clab.yml
+++ b/tests/interop/m77-gr-llgr-rr-gobgp.clab.yml
@@ -48,6 +48,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m77-gr-rr.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
@@ -58,6 +59,7 @@ topology:
         - ip link set eth3 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     gobgp-pe:
       kind: linux

--- a/tests/interop/m78-multicluster-orr-gobgp.clab.yml
+++ b/tests/interop/m78-multicluster-orr-gobgp.clab.yml
@@ -33,6 +33,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m78-rr1.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
@@ -45,6 +46,7 @@ topology:
         - ip link set eth4 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     rr2:
       kind: linux
@@ -52,6 +54,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m78-rr2.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.5.1/24 dev eth1
@@ -64,6 +67,7 @@ topology:
         - ip link set eth4 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     gobgp-src:
       kind: linux

--- a/tests/interop/m79-labeled-reflection-gobgp.clab.yml
+++ b/tests/interop/m79-labeled-reflection-gobgp.clab.yml
@@ -32,6 +32,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m79-labeled-rr.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
@@ -40,6 +41,7 @@ topology:
         - ip link set eth2 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     gobgp-pe:
       kind: linux

--- a/tests/interop/m80-rpol-policy-parity-frr.clab.yml
+++ b/tests/interop/m80-rpol-policy-parity-frr.clab.yml
@@ -26,6 +26,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m80-policy.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         # Both .rpol variants land at fixed read-only paths; the exec
         # below copies the initial one onto the working path the
         # config references, and the test script copies the lp150
@@ -44,6 +45,7 @@ topology:
         - cp /etc/rustbgpd/core.initial.rpol /etc/rustbgpd/policies/core.rpol
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     src:
       kind: linux

--- a/tests/interop/m81-bmp-trio-gobgp.clab.yml
+++ b/tests/interop/m81-bmp-trio-gobgp.clab.yml
@@ -36,6 +36,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m81-bmp-rr.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
@@ -44,6 +45,7 @@ topology:
         - ip link set eth2 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     gobgp-pe1:
       kind: linux

--- a/tests/interop/m82-evpn-bundle-srlinux.clab.yml
+++ b/tests/interop/m82-evpn-bundle-srlinux.clab.yml
@@ -35,6 +35,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m82-rr.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
@@ -43,6 +44,7 @@ topology:
         - ip link set eth2 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     gobgp-sink:
       kind: linux

--- a/tests/interop/m82-evpn-bundle-synthetic-gobgp.clab.yml
+++ b/tests/interop/m82-evpn-bundle-synthetic-gobgp.clab.yml
@@ -31,6 +31,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m82-rr.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
@@ -39,6 +40,7 @@ topology:
         - ip link set eth2 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     gobgp-src:
       kind: linux

--- a/tests/interop/m83-routeserver-multistack.clab.yml
+++ b/tests/interop/m83-routeserver-multistack.clab.yml
@@ -53,6 +53,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m83-rs.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./configs/m83-hygiene.rpol:/etc/rustbgpd/m83-hygiene.rpol:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
@@ -65,6 +66,7 @@ topology:
         - sysctl -w net.ipv4.ip_forward=1
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     bird:
       kind: linux

--- a/tests/interop/m84-rtr-multicache.clab.yml
+++ b/tests/interop/m84-rtr-multicache.clab.yml
@@ -51,12 +51,14 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m84-multicache.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.84.0.1/24 dev eth1
         - ip link set eth1 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     frr:
       kind: linux

--- a/tests/interop/m85-rr-bird.clab.yml
+++ b/tests/interop/m85-rr-bird.clab.yml
@@ -45,6 +45,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m85-rr.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.85.1.1/24 dev eth1
@@ -58,6 +59,7 @@ topology:
         - ip link set eth3 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     bird1:
       kind: linux
@@ -89,6 +91,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m85-client.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.85.3.2/24 dev eth1
@@ -96,6 +99,7 @@ topology:
         - ip link set eth1 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
   links:
     - endpoints: ["rustbgpd:eth1", "bird1:eth1"]

--- a/tests/interop/m86-rr-openbgpd.clab.yml
+++ b/tests/interop/m86-rr-openbgpd.clab.yml
@@ -42,6 +42,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m86-rr.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.86.1.1/24 dev eth1
@@ -55,6 +56,7 @@ topology:
         - ip link set eth3 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     obgp1:
       kind: linux
@@ -97,6 +99,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m86-client.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.86.3.2/24 dev eth1
@@ -104,6 +107,7 @@ topology:
         - ip link set eth1 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
   links:
     - endpoints: ["rustbgpd:eth1", "obgp1:eth1"]

--- a/tests/interop/m87-exact-export-rejection.clab.yml
+++ b/tests/interop/m87-exact-export-rejection.clab.yml
@@ -27,6 +27,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m87-rs.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.87.1.1/24 dev eth1
@@ -35,6 +36,7 @@ topology:
         - ip link set eth2 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     gobgp-source:
       kind: linux

--- a/tests/interop/m89-paths-limit-frr.clab.yml
+++ b/tests/interop/m89-paths-limit-frr.clab.yml
@@ -11,6 +11,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m89-paths-limit.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.89.1.1/24 dev eth1
@@ -27,6 +28,7 @@ topology:
         - ip link set eth4 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     source-a:
       kind: linux

--- a/tests/interop/m91-rfc7606-malformed.clab.yml
+++ b/tests/interop/m91-rfc7606-malformed.clab.yml
@@ -27,10 +27,13 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m91-rfc7606.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.91.1.1/24 dev eth1
         - ip link set eth1 up
+      env:
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     raw-peer:
       kind: linux

--- a/tests/interop/m92-gobgp-v47-rs-differential.clab.yml
+++ b/tests/interop/m92-gobgp-v47-rs-differential.clab.yml
@@ -26,10 +26,13 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m92-rs.toml:/config/rustbgpd.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 192.0.2.9/24 dev eth1
         - ip addr add 2001:db8:92::9/64 dev eth1
         - ip link set eth1 up
+      env:
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     gobgp-rs:
       kind: linux

--- a/tests/interop/m93-required-families-bird.clab.yml
+++ b/tests/interop/m93-required-families-bird.clab.yml
@@ -10,12 +10,14 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m93-required.toml:/fixtures/required.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
       exec:
         - ip addr add 10.93.0.1/24 dev eth1
         - ip -6 addr add 2001:db8:93::1/64 dev eth1 nodad
         - ip link set eth1 up
       env:
         RUST_LOG: info
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     bird:
       kind: linux

--- a/tests/interop/scripts/test-m70-evpn-vlan-aware-bridge-frr.sh
+++ b/tests/interop/scripts/test-m70-evpn-vlan-aware-bridge-frr.sh
@@ -11,6 +11,8 @@ set -euo pipefail
 
 TOPO="m70-evpn-vlan-aware-bridge-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=tests/interop/scripts/test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 

--- a/tests/interop/scripts/test-m71-evpn-esi-overlay-type5-receive-gobgp.sh
+++ b/tests/interop/scripts/test-m71-evpn-esi-overlay-type5-receive-gobgp.sh
@@ -38,6 +38,8 @@ set -euo pipefail
 
 TOPO="m71-evpn-esi-overlay-type5-receive-gobgp"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 
 VTEP="clab-${TOPO}-vtep"
 PE="clab-${TOPO}-pe"
@@ -156,7 +158,7 @@ vrf_route_absent() {
 # gRPC installed_routes_count for vrf1, used as a second assertion after
 # the kernel route is present.
 vrf_installed_count() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"name":"'"$TENANT_VRF"'"}' \
         "$GRPC_ADDR" rustbgpd.v1.EvpnService/GetIpVrf 2>/dev/null \
         | jq -r '.installedRoutesCount // 0' 2>/dev/null || echo 0

--- a/tests/interop/scripts/test-m72-evpn-esi-overlay-type5-all-active-gobgp.sh
+++ b/tests/interop/scripts/test-m72-evpn-esi-overlay-type5-all-active-gobgp.sh
@@ -24,6 +24,8 @@ set -euo pipefail
 
 TOPO="m72-evpn-esi-overlay-type5-all-active-gobgp"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 
 VTEP="clab-${TOPO}-vtep"
 PE1="clab-${TOPO}-pe1"
@@ -124,7 +126,7 @@ vrf_route_installed_ecmp() {
 }
 
 vrf_installed_count() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"name":"'"$TENANT_VRF"'"}' \
         "$GRPC_ADDR" rustbgpd.v1.EvpnService/GetIpVrf 2>/dev/null \
         | jq -r '.installedRoutesCount // 0' 2>/dev/null || echo 0

--- a/tests/interop/scripts/test-m73-bgpls-reflection-gobgp.sh
+++ b/tests/interop/scripts/test-m73-bgpls-reflection-gobgp.sh
@@ -16,6 +16,8 @@
 
 TOPO="m73-bgpls-reflection-gobgp"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 
 GOBGP_SRC="clab-${TOPO}-gobgp-src"

--- a/tests/interop/scripts/test-m74-vpnv4-reflection-gobgp.sh
+++ b/tests/interop/scripts/test-m74-vpnv4-reflection-gobgp.sh
@@ -23,6 +23,8 @@
 
 TOPO="m74-vpnv4-reflection-gobgp"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 
 GOBGP_SRC="clab-${TOPO}-gobgp-src"

--- a/tests/interop/scripts/test-m75-rtc-vpnv4-filter-gobgp.sh
+++ b/tests/interop/scripts/test-m75-rtc-vpnv4-filter-gobgp.sh
@@ -39,6 +39,8 @@
 
 TOPO="m75-rtc-vpnv4-filter-gobgp"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 
 GOBGP_SRC="clab-${TOPO}-gobgp-src"

--- a/tests/interop/scripts/test-m76-orr-divergent-best-gobgp.sh
+++ b/tests/interop/scripts/test-m76-orr-divergent-best-gobgp.sh
@@ -39,6 +39,8 @@
 
 TOPO="m76-orr-divergent-best-gobgp"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 
 GOBGP_SRC="clab-${TOPO}-gobgp-src"

--- a/tests/interop/scripts/test-m77-gr-llgr-rr-gobgp.sh
+++ b/tests/interop/scripts/test-m77-gr-llgr-rr-gobgp.sh
@@ -57,6 +57,8 @@
 
 TOPO="m77-gr-llgr-rr-gobgp"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 
 GOBGP_PE="clab-${TOPO}-gobgp-pe"

--- a/tests/interop/scripts/test-m78-multicluster-orr-gobgp.sh
+++ b/tests/interop/scripts/test-m78-multicluster-orr-gobgp.sh
@@ -48,6 +48,8 @@
 TOPO="m78-multicluster-orr-gobgp"
 RUSTBGPD="clab-${TOPO}-rr1"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 
 RR1="clab-${TOPO}-rr1"

--- a/tests/interop/scripts/test-m79-labeled-reflection-gobgp.sh
+++ b/tests/interop/scripts/test-m79-labeled-reflection-gobgp.sh
@@ -57,6 +57,8 @@
 
 TOPO="m79-labeled-reflection-gobgp"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 
 GOBGP_PE="clab-${TOPO}-gobgp-pe"

--- a/tests/interop/scripts/test-m80-rpol-policy-parity-frr.sh
+++ b/tests/interop/scripts/test-m80-rpol-policy-parity-frr.sh
@@ -48,6 +48,8 @@ set -euo pipefail
 
 TOPO="m80-rpol-policy-parity-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 SRC="clab-${TOPO}-src"
 PARITY="clab-${TOPO}-parity"
@@ -65,18 +67,18 @@ rbgp() {
 }
 
 grpc_list_best() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListBestRoutes 2>/dev/null
 }
 
 grpc_list_received_for_peer() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"neighbor_address\": \"$1\"}" \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
 neighbor_state() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"address\": \"$1\"}" \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>/dev/null
 }

--- a/tests/interop/scripts/test-m81-bmp-trio-gobgp.sh
+++ b/tests/interop/scripts/test-m81-bmp-trio-gobgp.sh
@@ -137,6 +137,8 @@
 
 TOPO="m81-bmp-trio-gobgp"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 
 PE1="clab-${TOPO}-gobgp-pe1"

--- a/tests/interop/scripts/test-m82-evpn-bundle-srlinux.sh
+++ b/tests/interop/scripts/test-m82-evpn-bundle-srlinux.sh
@@ -32,6 +32,8 @@
 
 TOPO="m82-evpn-bundle-srlinux"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 
 SRL="clab-${TOPO}-srl"

--- a/tests/interop/scripts/test-m82-evpn-bundle-synthetic-gobgp.sh
+++ b/tests/interop/scripts/test-m82-evpn-bundle-synthetic-gobgp.sh
@@ -30,6 +30,8 @@
 
 TOPO="m82-evpn-bundle-synthetic-gobgp"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 
 GOBGP_SRC="clab-${TOPO}-gobgp-src"

--- a/tests/interop/scripts/test-m83-routeserver-multistack.sh
+++ b/tests/interop/scripts/test-m83-routeserver-multistack.sh
@@ -89,6 +89,8 @@
 
 TOPO="m83-routeserver-multistack"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 
 BIRD="clab-${TOPO}-bird"

--- a/tests/interop/scripts/test-m84-rtr-multicache.sh
+++ b/tests/interop/scripts/test-m84-rtr-multicache.sh
@@ -46,6 +46,8 @@ set -euo pipefail
 
 TOPO="m84-rtr-multicache"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=tests/interop/scripts/test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
@@ -132,7 +134,7 @@ wait_log_count() {
 }
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"neighbor_address": "10.84.0.2"}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }

--- a/tests/interop/scripts/test-m85-rr-bird.sh
+++ b/tests/interop/scripts/test-m85-rr-bird.sh
@@ -34,6 +34,8 @@
 
 TOPO="m85-rr-bird"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 BIRD1="clab-${TOPO}-bird1"
@@ -51,7 +53,7 @@ B2_V6="2001:db8:852::/48"
 # Helpers
 # ---------------------------------------------------------------------------
 
-# rbgp against the RR / the rustbgpd client (legacy enforcement, plaintext).
+# rbgp against the RR / the rustbgpd client with the shared test-only token.
 rr_ctl()     { docker exec "$RUSTBGPD" rbgp -s http://127.0.0.1:50051 "$@"; }
 client_ctl() { docker exec "$CLIENT" rbgp -s http://127.0.0.1:50051 "$@"; }
 
@@ -92,7 +94,7 @@ birdc_route_all() {
 }
 
 grpc_get_metrics() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.ControlService/GetMetrics 2>/dev/null
 }
 

--- a/tests/interop/scripts/test-m86-rr-openbgpd.sh
+++ b/tests/interop/scripts/test-m86-rr-openbgpd.sh
@@ -32,6 +32,8 @@
 
 TOPO="m86-rr-openbgpd"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 OBGP1="clab-${TOPO}-obgp1"
@@ -51,7 +53,7 @@ O2_V6="2001:db8:862::/48"
 # Helpers
 # ---------------------------------------------------------------------------
 
-# rbgp against the RR / the rustbgpd client (legacy enforcement, plaintext).
+# rbgp against the RR / the rustbgpd client with the shared test-only token.
 rr_ctl()     { docker exec "$RUSTBGPD" rbgp -s http://127.0.0.1:50051 "$@"; }
 client_ctl() { docker exec "$CLIENT" rbgp -s http://127.0.0.1:50051 "$@"; }
 
@@ -81,7 +83,7 @@ wait_obgp_established() {
 }
 
 grpc_get_metrics() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.ControlService/GetMetrics 2>/dev/null
 }
 

--- a/tests/interop/scripts/test-m87-exact-export-rejection.sh
+++ b/tests/interop/scripts/test-m87-exact-export-rejection.sh
@@ -26,6 +26,8 @@
 
 TOPO="m87-exact-export-rejection"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/test-lib.sh"
 
@@ -82,7 +84,7 @@ wait_bird_established() {
 }
 
 neighbor_state() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d "{\"address\": \"${1:?}\"}" \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>/dev/null
 }
@@ -188,7 +190,7 @@ explain_advertises() {
 }
 
 metrics_text() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.ControlService/GetMetrics 2>/dev/null \
         | jq -r '.prometheusText // ""'
 }

--- a/tests/interop/scripts/test-m89-paths-limit-frr.sh
+++ b/tests/interop/scripts/test-m89-paths-limit-frr.sh
@@ -5,6 +5,8 @@
 
 TOPO="m89-paths-limit-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 
 FRR_IMAGE="quay.io/frrouting/frr@sha256:f90d26a9fd5c14fc5795a73b4254ac88bc3186c45bbeb220a225fb6182de812c"

--- a/tests/interop/scripts/test-m91-rfc7606-malformed.sh
+++ b/tests/interop/scripts/test-m91-rfc7606-malformed.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 
 TOPO="m91-rfc7606-malformed"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 source "$SCRIPT_DIR/test-lib.sh"
 
 RAW_PEER="clab-${TOPO}-raw-peer"
@@ -25,12 +27,12 @@ RUST_IP=$(resolve_ip "$RUSTBGPD")
 start_rustbgpd "RUST_LOG=info,rustbgpd_transport=debug /usr/local/bin/start-rustbgpd.sh >${RUST_LOG_FILE} 2>&1"
 
 grpc_list_neighbors() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/ListNeighbors
 }
 
 grpc_list_received() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes
 }
 

--- a/tests/interop/scripts/test-m92-gobgp-v47-rs-differential.sh
+++ b/tests/interop/scripts/test-m92-gobgp-v47-rs-differential.sh
@@ -10,6 +10,8 @@
 
 TOPO="m92-gobgp-v47-rs-differential"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 

--- a/tests/interop/scripts/test-m93-required-families-bird.sh
+++ b/tests/interop/scripts/test-m93-required-families-bird.sh
@@ -4,6 +4,8 @@
 
 TOPO="m93-required-families-bird"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
+export INTEROP_TEST_OPERATOR_AUTH
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 

--- a/tests/interop_tier_auth_rr.rs
+++ b/tests/interop_tier_auth_rr.rs
@@ -1,0 +1,275 @@
+//! Structural and production-loader gate for the active M70-M93 auth migration.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+const TOKEN: &str = "/run/rustbgpd/grpc-test-only-operator.token";
+const PRINCIPAL: &str = "rustbgpd://operator/test-only";
+const TOKEN_BIND: &str =
+    "../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro";
+const CONFIGS: &[&str] = &[
+    "rustbgpd-m70-vtep.toml",
+    "rustbgpd-m71-vtep.toml",
+    "rustbgpd-m72-vtep.toml",
+    "rustbgpd-m73-bgpls-rr.toml",
+    "rustbgpd-m74-vpnv4-rr.toml",
+    "rustbgpd-m75-rtc-rr.toml",
+    "rustbgpd-m76-orr-rr.toml",
+    "rustbgpd-m77-gr-rr.toml",
+    "rustbgpd-m78-rr1.toml",
+    "rustbgpd-m78-rr2.toml",
+    "rustbgpd-m79-labeled-rr.toml",
+    "rustbgpd-m80-policy.toml",
+    "rustbgpd-m81-bmp-rr.toml",
+    "rustbgpd-m82-rr.toml",
+    "rustbgpd-m83-rs.toml",
+    "rustbgpd-m84-multicache.toml",
+    "rustbgpd-m85-client.toml",
+    "rustbgpd-m85-rr.toml",
+    "rustbgpd-m86-client.toml",
+    "rustbgpd-m86-rr.toml",
+    "rustbgpd-m87-rs.toml",
+    "rustbgpd-m89-paths-limit.toml",
+    "rustbgpd-m91-rfc7606.toml",
+    "rustbgpd-m92-rs.toml",
+    "rustbgpd-m93-required.toml",
+];
+const TOPOLOGIES: &[&str] = &[
+    "m70-evpn-vlan-aware-bridge-frr",
+    "m71-evpn-esi-overlay-type5-receive-gobgp",
+    "m72-evpn-esi-overlay-type5-all-active-gobgp",
+    "m73-bgpls-reflection-gobgp",
+    "m74-vpnv4-reflection-gobgp",
+    "m75-rtc-vpnv4-filter-gobgp",
+    "m76-orr-divergent-best-gobgp",
+    "m77-gr-llgr-rr-gobgp",
+    "m78-multicluster-orr-gobgp",
+    "m79-labeled-reflection-gobgp",
+    "m80-rpol-policy-parity-frr",
+    "m81-bmp-trio-gobgp",
+    "m82-evpn-bundle-srlinux",
+    "m82-evpn-bundle-synthetic-gobgp",
+    "m83-routeserver-multistack",
+    "m84-rtr-multicache",
+    "m85-rr-bird",
+    "m86-rr-openbgpd",
+    "m87-exact-export-rejection",
+    "m89-paths-limit-frr",
+    "m91-rfc7606-malformed",
+    "m92-gobgp-v47-rs-differential",
+    "m93-required-families-bird",
+];
+const LEGACY_ALLOWLIST: &[&str] = &[
+    "tests/interop/configs/rustbgpd-frr-badopen.toml",
+    "tests/interop/configs/rustbgpd-m33-scale.toml",
+    "tests/interop/configs/rustbgpd-m37-originator.toml",
+    "tests/interop/configs/rustbgpd-m39-pe1.toml",
+    "tests/interop/configs/rustbgpd-m67-vtep.toml",
+    "tests/interop/configs/rustbgpd-soak-gr-restart.toml",
+    "tests/interop/configs/rustbgpd-soak-hot-reload.toml",
+    "tests/interop/configs/rustbgpd-soak-inject-churn.toml",
+    "tests/soak/configs/rustbgpd-soak-gate8b-pe1.toml",
+    "tests/soak/configs/rustbgpd-soak-gate8b-pe2.toml",
+];
+
+fn is_rr_slice(name: &str) -> bool {
+    let Some(suffix) = name.strip_prefix("rustbgpd-m") else {
+        return false;
+    };
+    let digits: String = suffix.chars().take_while(char::is_ascii_digit).collect();
+    name.ends_with(".toml")
+        && digits
+            .parse::<u8>()
+            .is_ok_and(|n| (70..=93).contains(&n) && n != 90)
+}
+
+fn has_legacy_enforcement(source: &str) -> bool {
+    let value: toml::Value = toml::from_str(source).expect("config must be valid TOML");
+    value
+        .get("security")
+        .and_then(|security| security.get("grpc"))
+        .and_then(|grpc| grpc.get("enforcement"))
+        .and_then(toml::Value::as_str)
+        == Some("legacy")
+}
+
+/// Reverting tier auth, a node bind/env, or driver helper wiring makes this
+/// red; semantic config breakage fails the production `--check` subprocess.
+#[test]
+fn rr_and_route_server_interop_is_tier_authenticated_end_to_end() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let interop = root.join("tests/interop");
+    let config_dir = interop.join("configs");
+    let token_host = root.join("tests/fixtures/grpc-test-only-operator.token");
+    let expected_configs: BTreeSet<_> = CONFIGS.iter().map(|name| (*name).to_owned()).collect();
+    let mut configs = BTreeSet::new();
+
+    for entry in fs::read_dir(&config_dir).unwrap() {
+        let file = entry.unwrap().path();
+        let name = file.file_name().unwrap().to_str().unwrap();
+        if !is_rr_slice(name) {
+            continue;
+        }
+        let source = fs::read_to_string(&file).expect("interop config must be readable");
+        let value: toml::Value =
+            toml::from_str(&source).unwrap_or_else(|error| panic!("{name}: {error}"));
+        let grpc = &value["global"]["telemetry"]["grpc_tcp"];
+        let security = &value["security"]["grpc"];
+        assert_eq!(grpc["token_file"].as_str(), Some(TOKEN), "{name}");
+        assert_eq!(grpc["principal"].as_str(), Some(PRINCIPAL), "{name}");
+        assert_eq!(security["enforcement"].as_str(), Some("tier"), "{name}");
+        assert_eq!(
+            security["roles"][PRINCIPAL].as_str(),
+            Some("operator"),
+            "{name}"
+        );
+
+        let materialized = source
+            .replace(TOKEN, &token_host.display().to_string())
+            .replace("policies/core.rpol", "rustbgpd-m80-policy.rpol")
+            .replace("PMACCT_ADDR", "127.0.0.1")
+            .replace("GOBMP_ADDR", "127.0.0.1")
+            .replace("SINK_ADDR", "127.0.0.1")
+            .replace("ROUTINATOR_ADDR", "127.0.0.1")
+            .replace("STAYRTR_ADDR", "127.0.0.1")
+            .replace("RTRV2_ADDR", "127.0.0.1");
+        let mut staged = tempfile::Builder::new()
+            .suffix(".config-check")
+            .tempfile_in(&config_dir)
+            .expect("create materialized config beside relative resources");
+        staged.write_all(materialized.as_bytes()).unwrap();
+        let output = Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
+            .arg("--check")
+            .arg(staged.path())
+            .current_dir(root)
+            .output()
+            .expect("run production config loader");
+        assert!(
+            output.status.success(),
+            "{name} failed production --check\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        configs.insert(name.to_owned());
+    }
+    assert_eq!(configs, expected_configs, "RR config inventory changed");
+
+    let expected_topologies: BTreeSet<_> =
+        TOPOLOGIES.iter().map(|name| (*name).to_owned()).collect();
+    let mut topologies = BTreeSet::new();
+    let mut mounted = BTreeSet::new();
+    let mut nodes = 0;
+    for entry in fs::read_dir(&interop).unwrap() {
+        let file = entry.unwrap().path();
+        let name = file.file_name().unwrap().to_str().unwrap();
+        if !name.ends_with(".clab.yml") {
+            continue;
+        }
+        let source = fs::read_to_string(&file).expect("topology must be readable");
+        if !configs.iter().any(|config| source.contains(config)) {
+            continue;
+        }
+        let yaml: serde_yaml::Value = serde_yaml::from_str(&source)
+            .unwrap_or_else(|error| panic!("{name} invalid YAML: {error}"));
+        for (node_name, node) in yaml["topology"]["nodes"].as_mapping().expect("nodes map") {
+            let Some(binds) = node["binds"].as_sequence() else {
+                continue;
+            };
+            let bound: Vec<_> = binds
+                .iter()
+                .filter_map(serde_yaml::Value::as_str)
+                .filter_map(|bind| Path::new(bind.split(':').next()?).file_name()?.to_str())
+                .filter(|config| configs.contains(*config))
+                .collect();
+            if bound.is_empty() {
+                continue;
+            }
+            nodes += 1;
+            mounted.extend(bound.iter().map(|config| (*config).to_owned()));
+            assert!(
+                binds.iter().any(|bind| bind.as_str() == Some(TOKEN_BIND)),
+                "{name} node {node_name:?} lacks shared token beside {bound:?}"
+            );
+            assert_eq!(
+                node["env"]["RUSTBGPD_TOKEN_FILE"].as_str(),
+                Some(TOKEN),
+                "{name} node {node_name:?} lacks token environment"
+            );
+        }
+        topologies.insert(name.trim_end_matches(".clab.yml").to_owned());
+    }
+    assert_eq!(
+        topologies, expected_topologies,
+        "topology inventory changed"
+    );
+    assert_eq!(nodes, 26, "rustbgpd node inventory changed");
+    assert_eq!(mounted, expected_configs, "config mount inventory changed");
+
+    let mut drivers = BTreeSet::new();
+    for topology in &topologies {
+        let driver = format!("test-{topology}.sh");
+        let source = fs::read_to_string(interop.join("scripts").join(&driver))
+            .unwrap_or_else(|error| panic!("{driver}: {error}"));
+        let opt_in = source
+            .find("INTEROP_TEST_OPERATOR_AUTH=1")
+            .expect("auth opt-in");
+        let helper = source
+            .find("source \"$SCRIPT_DIR/test-lib.sh\"")
+            .expect("test-lib");
+        assert!(opt_in < helper, "{driver} opts in after sourcing helper");
+        assert!(
+            !source.contains("grpcurl -plaintext"),
+            "{driver} bypasses helper"
+        );
+        drivers.insert(driver);
+    }
+    assert_eq!(drivers.len(), 23, "driver inventory changed");
+}
+
+/// Adding an unowned legacy config or removing a stale allowlist entry makes
+/// this red: equality deliberately fences both sides of the inventory.
+#[test]
+fn legacy_auth_inventory_is_exactly_the_owned_exceptions() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut live = BTreeSet::new();
+    for relative_dir in ["tests/interop/configs", "tests/soak/configs"] {
+        for entry in fs::read_dir(root.join(relative_dir)).unwrap() {
+            let file = entry.unwrap().path();
+            if file.extension().and_then(|ext| ext.to_str()) != Some("toml") {
+                continue;
+            }
+            if has_legacy_enforcement(&fs::read_to_string(&file).expect("config readable")) {
+                live.insert(
+                    file.strip_prefix(root)
+                        .unwrap()
+                        .to_str()
+                        .unwrap()
+                        .to_owned(),
+                );
+            }
+        }
+    }
+    assert_eq!(
+        live,
+        LEGACY_ALLOWLIST
+            .iter()
+            .map(|path| (*path).to_owned())
+            .collect()
+    );
+}
+
+/// Replacing semantic TOML inspection with a text search makes this red: the
+/// legacy value uses equivalent single-quote syntax and the tier value names
+/// legacy only in a comment.
+#[test]
+fn legacy_inventory_classification_is_semantic() {
+    assert!(has_legacy_enforcement(
+        "[security.grpc]\nenforcement = 'legacy'\n"
+    ));
+    assert!(!has_legacy_enforcement(
+        "[security.grpc]\nenforcement = 'tier' # enforcement = \"legacy\"\n"
+    ));
+}


### PR DESCRIPTION
## Summary

- migrate the exact active M70-M93 RR and route-server fixture set to the shared test-only operator tier-auth convention
- wire 25 configs, 26 rustbgpd nodes across 23 topologies, and 23 drivers consistently, including authenticated in-container `rbgp` and helper-backed `grpcurl`
- add an auto-discovered production-loader gate plus a semantic ten-path inventory for the remaining held or historical legacy fixtures

This completes the safe active-lab portion of LAN-546 without changing daemon defaults, production authorization behavior, held soaks, dedicated auth scenarios, or historical receipts.

## Scope

- 72 files, 539 insertions, 39 deletions
- 25 configs, 23 topologies, 23 drivers, one integration gate
- M80 policy reload, M92 candidate mutation, and M93 required-family mutation preserve the migrated authentication state

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --test interop_tier_auth_rr` (3/3)
- Bash syntax and ShellCheck error-severity checks for all 23 changed drivers
- real M85 RR/BIRD interop harness: 33 passed, 0 failed; teardown left no containers or lab directory
- repeated the focused gate, full quartet, shell checks, and M85 after rebasing onto merged PR #1076

## Load-bearing proof

Each mutation failed the focused gate and was restored:

- tier enforcement reverted to legacy
- shared token bind removed
- `RUSTBGPD_TOKEN_FILE` removed
- driver auth opt-in removed
- `grpcurl_call` replaced with a raw unauthenticated call
- TOML-valid invalid ASN reached the production `rustbgpd --check` loader
- unexpected live legacy config added
- stale allowlist entry retained after its config stopped using legacy
- semantic TOML classification replaced by a text search; alternate quoting and a comment-only match exposed the false green

## Documentation

No operator documentation changes are needed: this changes first-party test harness authentication only. The two stale M85/M86 harness comments now describe the shared test credential accurately.
