### PR TITLE
test: tier-harden EVPN runtime fixtures

### DIFF
--- a/src/evpn_plan_decomposer.rs
+++ b/src/evpn_plan_decomposer.rs
@@ -402,9 +402,13 @@ pub(crate) fn decompose_evpn_runtime_candidate(
 mod tests {
     use super::*;
     use crate::config::Config;
+    use crate::test_support::{
+        assert_tier_authorized_test_config, tier_authorized_uds_test_config,
+    };
 
     fn candidate_from_toml(toml: &str) -> EvpnRuntimeCandidate {
         let config = Config::load_toml_with_diagnostics(toml, "decomposer test config").unwrap();
+        assert_tier_authorized_test_config(&config);
         EvpnRuntimeCandidate::new(
             config.resolve_evpn_instances().unwrap(),
             config.resolve_evpn_ip_vrfs().unwrap(),
@@ -439,13 +443,10 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 "#;
 
     fn with_header(body: &str) -> String {
-        format!("{HEADER}{body}")
+        tier_authorized_uds_test_config(&format!("{HEADER}{body}"))
     }
 
     fn vni(raw: u32) -> EvpnInstanceId {

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -3448,9 +3448,11 @@ fn evpn_runtime_candidate_from_toml(
             "candidate_toml must contain a full rustbgpd config".to_string(),
         ));
     }
+    let candidate_toml = crate::test_support::tier_authorized_uds_test_config(candidate_toml);
     let candidate =
-        Config::load_toml_with_diagnostics(candidate_toml, "candidate EVPN runtime config")
+        Config::load_toml_with_diagnostics(&candidate_toml, "candidate EVPN runtime config")
             .map_err(GrpcEvpnRuntimeApplyError::InvalidArgument)?;
+    crate::test_support::assert_tier_authorized_test_config(&candidate);
     evpn_runtime_candidate_from_config(&candidate)
 }
 
@@ -3899,8 +3901,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
 "#
     }
 
@@ -3913,9 +3913,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -3934,9 +3931,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -3963,9 +3957,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -3997,9 +3988,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -4037,9 +4025,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[evpn_instances]]
 vni = 100
 rd = "65000:100"
@@ -4071,9 +4056,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -4114,9 +4096,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[evpn_instances]]
 vni = 100
 rd = "65000:100"
@@ -4151,9 +4130,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -4190,9 +4166,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -4254,9 +4227,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[evpn_instances]]
 vni = 100
 rd = "65000:100"
@@ -4310,9 +4280,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[evpn_instances]]
 vni = 100
 rd = "65000:100"
@@ -4342,9 +4309,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -4383,9 +4347,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[evpn_instances]]
 vni = 100
 rd = "65000:100"
@@ -4422,9 +4383,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -4463,9 +4421,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[evpn_instances]]
 vni = 100
 rd = "65000:111"
@@ -4502,9 +4457,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[evpn_instances]]
 vni = 200
 rd = "65000:222"
@@ -4528,9 +4480,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -4561,9 +4510,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[evpn_instances]]
 vni = 100
 rd = "65000:100"
@@ -4588,9 +4534,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[evpn_instances]]
 vni = 100
 rd = "65000:100"
@@ -4614,9 +4557,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 200
@@ -4644,9 +4584,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -4676,9 +4613,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[evpn_instances]]
 vni = 100
 rd = "65000:111"
@@ -4705,9 +4639,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -4736,9 +4667,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[evpn_instances]]
 vni = 100
 rd = "65000:111"
@@ -4764,9 +4692,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -4804,9 +4729,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[evpn_instances]]
 vni = 100
 rd = "65000:111"
@@ -4835,9 +4757,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -4874,9 +4793,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[evpn_ip_vrfs]]
 name = "tenant-blue"
 vni = 5000
@@ -4903,9 +4819,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -4947,9 +4860,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -4994,9 +4904,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[evpn_ip_vrfs]]
 name = "tenant-blue"
 vni = 5000
@@ -5031,9 +4938,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[evpn_ip_vrfs]]
 name = "tenant-blue"
 vni = 5000
@@ -5057,9 +4961,6 @@ listen_port = 179
 [global.telemetry]
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[evpn_ip_vrfs]]
 name = "tenant-blue"
 vni = 5001
@@ -5082,9 +4983,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100
@@ -5114,9 +5012,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_ip_vrfs]]
 name = "tenant-blue"
@@ -5151,9 +5046,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_ip_vrfs]]
 name = "tenant-blue"
@@ -5244,9 +5136,37 @@ table_id = 6000
         evpn_runtime_candidate_from_toml(toml).unwrap()
     }
 
+    fn load_runtime_test_config(toml: &str, source: &str) -> Config {
+        let config = Config::load_toml_with_diagnostics(
+            &crate::test_support::tier_authorized_uds_test_config(toml),
+            source,
+        )
+        .unwrap();
+        crate::test_support::assert_tier_authorized_test_config(&config);
+        config
+    }
+
     fn runtime_model_from_toml(toml: &str) -> rustbgpd_evpn::EvpnRuntimeModel {
         let candidate = runtime_candidate_from_toml(toml);
         rustbgpd_evpn::EvpnRuntimeModel::startup(
+            candidate.instances().clone(),
+            candidate.ip_vrfs().clone(),
+            candidate.ethernet_segments().to_vec(),
+        )
+    }
+
+    fn pre_authorized_runtime_candidate_from_toml(
+        toml: &str,
+    ) -> rustbgpd_evpn::EvpnRuntimeCandidate {
+        let config =
+            Config::load_toml_with_diagnostics(toml, "pre-authorized test config").unwrap();
+        crate::test_support::assert_tier_authorized_test_config(&config);
+        evpn_runtime_candidate_from_config(&config).unwrap()
+    }
+
+    fn pre_authorized_runtime_model_from_toml(toml: &str) -> rustbgpd_evpn::EvpnRuntimeModel {
+        let candidate = pre_authorized_runtime_candidate_from_toml(toml);
+        rustbgpd_evpn::EvpnRuntimeModel::coordinator_startup(
             candidate.instances().clone(),
             candidate.ip_vrfs().clone(),
             candidate.ethernet_segments().to_vec(),
@@ -5911,9 +5831,7 @@ local_vtep_ip = "10.0.0.1"
     /// the commit and advances the reload baseline on its own.
     #[tokio::test]
     async fn apply_request_dropped_mid_converge_still_commits_and_advances_baseline() {
-        let baseline =
-            Config::load_toml_with_diagnostics(minimal_runtime_candidate_toml(), "test baseline")
-                .unwrap();
+        let baseline = load_runtime_test_config(minimal_runtime_candidate_toml(), "test baseline");
         let coordinator = empty_evpn_runtime_coordinator();
         let entered = Arc::new(tokio::sync::Notify::new());
         let release = Arc::new(tokio::sync::Semaphore::new(0));
@@ -5960,12 +5878,8 @@ local_vtep_ip = "10.0.0.1"
     /// the abort must not cancel an EVPN converge already past planning.
     #[tokio::test]
     async fn reload_apply_dropped_mid_converge_still_commits_and_advances_baseline() {
-        let baseline =
-            Config::load_toml_with_diagnostics(minimal_runtime_candidate_toml(), "test baseline")
-                .unwrap();
-        let candidate =
-            Config::load_toml_with_diagnostics(l2vni_runtime_candidate_toml(), "test candidate")
-                .unwrap();
+        let baseline = load_runtime_test_config(minimal_runtime_candidate_toml(), "test baseline");
+        let candidate = load_runtime_test_config(l2vni_runtime_candidate_toml(), "test candidate");
         let coordinator = empty_evpn_runtime_coordinator();
         let entered = Arc::new(tokio::sync::Notify::new());
         let release = Arc::new(tokio::sync::Semaphore::new(0));
@@ -6013,16 +5927,13 @@ local_vtep_ip = "10.0.0.1"
     /// coordinator's watch — both directions: bind and unbind.
     #[tokio::test]
     async fn committed_config_advance_republishes_es_link_bindings() {
-        let baseline = Config::load_toml_with_diagnostics(
-            l2vni_one_es_runtime_candidate_toml(),
-            "test baseline",
-        )
-        .unwrap();
+        let baseline =
+            load_runtime_test_config(l2vni_one_es_runtime_candidate_toml(), "test baseline");
         let bound_toml = format!(
             "{}interface = \"bond0\"\nrecovery_delay_secs = 5\n",
             l2vni_one_es_runtime_candidate_toml()
         );
-        let bound = Config::load_toml_with_diagnostics(&bound_toml, "test candidate").unwrap();
+        let bound = load_runtime_test_config(&bound_toml, "test candidate");
 
         // Coordinator already holds the baseline model, so the
         // binding-only candidate is a planner no-op.
@@ -6062,11 +5973,8 @@ local_vtep_ip = "10.0.0.1"
         assert_eq!(binding.recovery_delay, Duration::from_secs(5));
 
         // Unbind: removing the keys republishes the empty map.
-        let unbound = Config::load_toml_with_diagnostics(
-            l2vni_one_es_runtime_candidate_toml(),
-            "test candidate",
-        )
-        .unwrap();
+        let unbound =
+            load_runtime_test_config(l2vni_one_es_runtime_candidate_toml(), "test candidate");
         let attempt = reload_apply
             .apply_config_if_changed(&unbound, evpn_runtime_changed_for_test)
             .await;
@@ -9022,12 +8930,14 @@ local_vtep_ip = "10.0.0.1"
         // diff to an atomic tenant teardown (L2VNI 100 + its Ethernet
         // Segment). Guards the smoke against drift in either the configs or
         // the teardown classifier.
-        let current = runtime_model_from_candidate_toml(&materialize_shared_test_only_grpc_token(
-            include_str!("../tests/interop/configs/rustbgpd-m47-pe1.toml"),
-        ));
-        let candidate = runtime_candidate_from_toml(&materialize_shared_test_only_grpc_token(
-            include_str!("../tests/interop/configs/rustbgpd-m47-teardown.toml"),
-        ));
+        let current =
+            pre_authorized_runtime_model_from_toml(&materialize_shared_test_only_grpc_token(
+                include_str!("../tests/interop/configs/rustbgpd-m47-pe1.toml"),
+            ));
+        let candidate =
+            pre_authorized_runtime_candidate_from_toml(&materialize_shared_test_only_grpc_token(
+                include_str!("../tests/interop/configs/rustbgpd-m47-teardown.toml"),
+            ));
         let plan = current.plan_candidate(&candidate);
 
         assert_eq!(plan.evpn_instances.deleted, vec![100]);
@@ -9050,12 +8960,14 @@ local_vtep_ip = "10.0.0.1"
         // referenced by L2VNI 10, so dropping both routes through the teardown
         // path rather than a standalone IP-VRF delete). Guards the smoke
         // against drift in either the configs or the teardown classifier.
-        let current = runtime_model_from_candidate_toml(&materialize_shared_test_only_grpc_token(
-            include_str!("../tests/interop/configs/rustbgpd-m48-pe1.toml"),
-        ));
-        let candidate = runtime_candidate_from_toml(&materialize_shared_test_only_grpc_token(
-            include_str!("../tests/interop/configs/rustbgpd-m48-teardown.toml"),
-        ));
+        let current =
+            pre_authorized_runtime_model_from_toml(&materialize_shared_test_only_grpc_token(
+                include_str!("../tests/interop/configs/rustbgpd-m48-pe1.toml"),
+            ));
+        let candidate =
+            pre_authorized_runtime_candidate_from_toml(&materialize_shared_test_only_grpc_token(
+                include_str!("../tests/interop/configs/rustbgpd-m48-teardown.toml"),
+            ));
         let plan = current.plan_candidate(&candidate);
 
         assert_eq!(plan.evpn_instances.deleted, vec![10]);
@@ -11501,9 +11413,6 @@ listen_port = 179
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[evpn_instances]]
 vni = 100

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -23,21 +23,19 @@ use crate::fib::FibRouteKey;
 
 const TEST_GRPC_OPERATOR_PRINCIPAL: &str = "rustbgpd://operator/test-only";
 
-/// Add the smallest production-valid Tier authorization surface to a
-/// unit-test config that does not exercise gRPC configuration itself.
+/// Add production-valid Tier authorization to a test config that does not exercise gRPC itself.
 ///
-/// Callers opt in explicitly so production config loaders always see
-/// exactly the text they were given. UDS filesystem permissions provide
-/// the authentication boundary; the stable principal supplies the Tier
-/// authorization identity.
+/// Callers opt in so production config loaders always see exactly the text they were given.
+/// UDS permissions authenticate; the stable principal supplies the Tier authorization identity.
 pub(crate) fn tier_authorized_uds_test_config(source: &str) -> String {
     assert!(
         !source.contains("[security.grpc"),
         "tier-authorized UDS test helper requires a config without security.grpc"
     );
     assert!(
-        !source.contains("[global.telemetry.grpc_uds]"),
-        "tier-authorized UDS test helper requires a config without grpc_uds"
+        !source.contains("[global.telemetry.grpc_uds]")
+            && !source.contains("[global.telemetry.grpc_tcp]"),
+        "tier-authorized UDS test helper requires a config without a gRPC listener"
     );
 
     format!(
@@ -45,13 +43,13 @@ pub(crate) fn tier_authorized_uds_test_config(source: &str) -> String {
 
 [global.telemetry.grpc_uds]
 path = "/tmp/rustbgpd-test.sock"
-principal = "rustbgpd://operator/test-only"
+principal = "{TEST_GRPC_OPERATOR_PRINCIPAL}"
 
 [security.grpc]
 enforcement = "tier"
 
 [security.grpc.roles]
-"rustbgpd://operator/test-only" = "operator"
+"{TEST_GRPC_OPERATOR_PRINCIPAL}" = "operator"
 "#
     )
 }
@@ -65,11 +63,15 @@ pub(crate) fn assert_tier_authorized_test_config(config: &Config) {
         config.security.grpc.roles.get(TEST_GRPC_OPERATOR_PRINCIPAL),
         Some(&GrpcRoleConfig::Operator)
     );
-    let principal = if let Some(uds) = config.global.telemetry.grpc_uds.as_ref() {
+    let telemetry = &config.global.telemetry;
+    let principal = if let Some(uds) = telemetry.grpc_uds.as_ref() {
         assert_eq!(uds.path.as_deref(), Some("/tmp/rustbgpd-test.sock"));
         uds.principal.as_deref()
     } else {
-        let tcp = config.global.telemetry.grpc_tcp.as_ref().unwrap();
+        let tcp = telemetry
+            .grpc_tcp
+            .as_ref()
+            .expect("missing test gRPC listener");
         assert!(tcp.token_file.is_some());
         tcp.principal.as_deref()
     };
@@ -95,15 +97,14 @@ mod tier_auth_tests {
     }
 
     #[test]
-    #[should_panic(expected = "requires a config without security.grpc")]
-    fn tier_auth_helper_rejects_preexisting_legacy_security() {
-        tier_authorized_uds_test_config("[security.grpc]\nenforcement = \"legacy\"\n");
-    }
-
-    #[test]
-    #[should_panic(expected = "requires a config without grpc_uds")]
-    fn tier_auth_helper_rejects_preexisting_uds_listener() {
-        tier_authorized_uds_test_config("[global.telemetry.grpc_uds]\npath = \"/tmp/x\"\n");
+    fn tier_auth_helper_rejects_preexisting_auth_or_listener() {
+        for source in [
+            "[security.grpc]\nenforcement = \"legacy\"\n",
+            "[global.telemetry.grpc_uds]\npath = \"/tmp/x\"\n",
+            "[global.telemetry.grpc_tcp]\naddress = \"127.0.0.1:50051\"\n",
+        ] {
+            assert!(std::panic::catch_unwind(|| tier_authorized_uds_test_config(source)).is_err());
+        }
     }
 }
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -18,8 +18,94 @@ use rustbgpd_wire::{
     AsPath, MacAddress, Origin, PathAttribute, Prefix, RouteDistinguisher, RpkiValidation,
 };
 
-use crate::config::FibTableConfig;
+use crate::config::{Config, FibTableConfig, GrpcEnforcementConfig, GrpcRoleConfig};
 use crate::fib::FibRouteKey;
+
+const TEST_GRPC_OPERATOR_PRINCIPAL: &str = "rustbgpd://operator/test-only";
+
+/// Add the smallest production-valid Tier authorization surface to a
+/// unit-test config that does not exercise gRPC configuration itself.
+///
+/// Callers opt in explicitly so production config loaders always see
+/// exactly the text they were given. UDS filesystem permissions provide
+/// the authentication boundary; the stable principal supplies the Tier
+/// authorization identity.
+pub(crate) fn tier_authorized_uds_test_config(source: &str) -> String {
+    assert!(
+        !source.contains("[security.grpc"),
+        "tier-authorized UDS test helper requires a config without security.grpc"
+    );
+    assert!(
+        !source.contains("[global.telemetry.grpc_uds]"),
+        "tier-authorized UDS test helper requires a config without grpc_uds"
+    );
+
+    format!(
+        r#"{source}
+
+[global.telemetry.grpc_uds]
+path = "/tmp/rustbgpd-test.sock"
+principal = "rustbgpd://operator/test-only"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"
+"#
+    )
+}
+
+pub(crate) fn assert_tier_authorized_test_config(config: &Config) {
+    assert_eq!(
+        config.security.grpc.enforcement,
+        GrpcEnforcementConfig::Tier
+    );
+    assert_eq!(
+        config.security.grpc.roles.get(TEST_GRPC_OPERATOR_PRINCIPAL),
+        Some(&GrpcRoleConfig::Operator)
+    );
+    let principal = if let Some(uds) = config.global.telemetry.grpc_uds.as_ref() {
+        assert_eq!(uds.path.as_deref(), Some("/tmp/rustbgpd-test.sock"));
+        uds.principal.as_deref()
+    } else {
+        let tcp = config.global.telemetry.grpc_tcp.as_ref().unwrap();
+        assert!(tcp.token_file.is_some());
+        tcp.principal.as_deref()
+    };
+    assert_eq!(principal, Some(TEST_GRPC_OPERATOR_PRINCIPAL));
+}
+
+#[cfg(test)]
+mod tier_auth_tests {
+    use super::*;
+
+    #[test]
+    fn tier_auth_helper_preserves_array_table_and_validates() {
+        let source = concat!(
+            "[global]\nasn = 65000\nrouter_id = \"10.0.0.1\"\nlisten_port = 179\n\n[global.telemetry]\nlog_format = \"json\"\n\n",
+            "[[neighbors]]\naddress = \"192.0.2.1\"\nremote_asn = 65001\n",
+        );
+        let augmented = tier_authorized_uds_test_config(source);
+        let config = Config::load_toml_with_diagnostics(&augmented, "tier auth helper").unwrap();
+
+        assert_eq!(config.neighbors[0].address, "192.0.2.1");
+        assert_eq!(config.neighbors[0].remote_asn, 65001);
+        assert_tier_authorized_test_config(&config);
+    }
+
+    #[test]
+    #[should_panic(expected = "requires a config without security.grpc")]
+    fn tier_auth_helper_rejects_preexisting_legacy_security() {
+        tier_authorized_uds_test_config("[security.grpc]\nenforcement = \"legacy\"\n");
+    }
+
+    #[test]
+    #[should_panic(expected = "requires a config without grpc_uds")]
+    fn tier_auth_helper_rejects_preexisting_uds_listener() {
+        tier_authorized_uds_test_config("[global.telemetry.grpc_uds]\npath = \"/tmp/x\"\n");
+    }
+}
 
 pub(crate) fn ip(s: &str) -> IpAddr {
     s.parse().unwrap()


### PR DESCRIPTION
## Summary

- add one explicitly invoked, test-only Tier-authorized UDS fixture helper with exact identity assertions
- migrate 39 repeated EVPN Legacy authorization blocks through the central helper
- keep the already Tier-authenticated M47/M48 interop fixtures on the raw production loader while preserving coordinator startup semantics
- fail closed if a caller already supplies security, UDS, or TCP gRPC configuration

This is the first bounded fixture-preparation tranche for LAN-549. Production loaders and Legacy compatibility behavior are unchanged.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- helper tests: 2/2, including all three pre-existing auth/listener collisions
- EVPN decomposer tests: 13/13
- EVPN runtime-converger tests: 112/112

## Load-bearing regression proof

Each mutation was applied independently, observed to fail with exit 101, and restored:

- removing the helper UDS identity fails the exact helper contract
- removing the security, UDS-listener, or TCP-listener collision guard fails its table case
- bypassing the runtime helper exposes the test loader Legacy fallback and fails the Tier invariant
- reverting the decomposer header wrapper exposes the same fallback and fails its Tier invariant
- changing the M47 interop fixture from Tier to Legacy fails the raw-loader Tier assertion before plan checks