### PR TITLE
feat: add bearer auth to birdwatcher adapter

### DIFF
--- a/crates/api/src/authz_runtime/tests.rs
+++ b/crates/api/src/authz_runtime/tests.rs
@@ -95,6 +95,18 @@ fn roles(entries: &[(&str, PrincipalRole)]) -> Arc<BTreeMap<String, PrincipalRol
     )
 }
 
+fn tier_test_context(
+    listener: &str,
+    access_mode: &'static str,
+    max_tier: AuthTier,
+    authn: GrpcAuthnKind,
+    principal: &str,
+    role: PrincipalRole,
+) -> GrpcAuthAuditContext {
+    GrpcAuthAuditContext::new(listener, access_mode, max_tier, authn, principal)
+        .with_role_enforcement(AuthEnforcement::Tier, roles(&[(principal, role)]))
+}
+
 fn private_key(key: &KeyPair) -> PrivateKeyDer<'static> {
     PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key.serialize_der()))
 }
@@ -252,12 +264,13 @@ fn audit_decision_treats_unknown_as_operator_only() {
 #[tokio::test]
 async fn audit_layer_records_metric_and_forwards_request() {
     let metrics = BgpMetrics::new();
-    let context = GrpcAuthAuditContext::new(
+    let context = tier_test_context(
         "tcp://127.0.0.1:50051",
         "read_write",
         AuthTier::OperatorOnly,
         GrpcAuthnKind::BearerToken,
         "bearer-token",
+        PrincipalRole::Operator,
     );
     let layer = GrpcAuthzLayer::new(context, metrics.clone());
     let mut service = layer.layer(EchoService);
@@ -280,12 +293,13 @@ async fn audit_layer_records_metric_and_forwards_request() {
 #[tokio::test]
 async fn audit_layer_records_handler_error_status() {
     let metrics = BgpMetrics::new();
-    let context = GrpcAuthAuditContext::new(
+    let context = tier_test_context(
         "tcp://127.0.0.1:50051",
         "read_write",
         AuthTier::OperatorOnly,
         GrpcAuthnKind::BearerToken,
         "bearer-token",
+        PrincipalRole::Operator,
     );
     let layer = GrpcAuthzLayer::new(context, metrics.clone());
     let mut service = layer.layer(InvalidArgumentService);
@@ -306,12 +320,13 @@ async fn audit_layer_records_handler_error_status() {
 #[tokio::test]
 async fn audit_layer_attaches_request_summary_handle() {
     let metrics = BgpMetrics::new();
-    let context = GrpcAuthAuditContext::new(
+    let context = tier_test_context(
         "tcp://127.0.0.1:50051",
         "read_write",
         AuthTier::OperatorOnly,
         GrpcAuthnKind::BearerToken,
         "bearer-token",
+        PrincipalRole::Operator,
     );
     let layer = GrpcAuthzLayer::new(context, metrics.clone());
     let mut service = layer.layer(SummaryService);
@@ -330,12 +345,13 @@ async fn audit_layer_attaches_request_summary_handle() {
 #[tokio::test]
 async fn audit_layer_denies_method_above_listener_cap() {
     let metrics = BgpMetrics::new();
-    let context = GrpcAuthAuditContext::new(
+    let context = tier_test_context(
         "tcp://127.0.0.1:50051",
         "read_write",
         AuthTier::SensitiveRead,
         GrpcAuthnKind::BearerToken,
         "bearer-token",
+        PrincipalRole::Operator,
     );
     let layer = GrpcAuthzLayer::new(context, metrics.clone());
     let mut service = layer.layer(EchoService);
@@ -356,12 +372,13 @@ async fn audit_layer_denies_method_above_listener_cap() {
 #[tokio::test]
 async fn audit_layer_denies_unknown_path_below_operator_cap() {
     let metrics = BgpMetrics::new();
-    let context = GrpcAuthAuditContext::new(
+    let context = tier_test_context(
         "tcp://127.0.0.1:50051",
         "read_write",
         AuthTier::Mutating,
         GrpcAuthnKind::BearerToken,
         "bearer-token",
+        PrincipalRole::Operator,
     );
     let layer = GrpcAuthzLayer::new(context, metrics);
     let mut service = layer.layer(EchoService);
@@ -378,12 +395,13 @@ async fn audit_layer_denies_unknown_path_below_operator_cap() {
 #[tokio::test]
 async fn audit_layer_authenticates_bearer_token_before_listener_cap() {
     let metrics = BgpMetrics::new();
-    let context = GrpcAuthAuditContext::new(
+    let context = tier_test_context(
         "tcp://127.0.0.1:50051",
         "read_write",
         AuthTier::SensitiveRead,
         GrpcAuthnKind::BearerToken,
         "bearer-token",
+        PrincipalRole::Operator,
     )
     .with_bearer_token(Some("secret"));
     let layer = GrpcAuthzLayer::new(context, metrics.clone());
@@ -405,12 +423,13 @@ async fn audit_layer_authenticates_bearer_token_before_listener_cap() {
 #[tokio::test]
 async fn audit_layer_denies_over_cap_request_after_valid_bearer_token() {
     let metrics = BgpMetrics::new();
-    let context = GrpcAuthAuditContext::new(
+    let context = tier_test_context(
         "tcp://127.0.0.1:50051",
         "read_write",
         AuthTier::SensitiveRead,
         GrpcAuthnKind::BearerToken,
         "bearer-token",
+        PrincipalRole::Operator,
     )
     .with_bearer_token(Some("secret"));
     let layer = GrpcAuthzLayer::new(context, metrics.clone());
@@ -460,19 +479,18 @@ async fn tier_enforcement_allows_observer_sensitive_read() {
     assert!(text.contains("result=\"handler_ok\""));
 }
 
+/// Mutation proof: removing Tier enforcement from `tier_test_context` lets
+/// the observer mutate and makes the `PermissionDenied` assertion red.
 #[tokio::test]
 async fn tier_enforcement_denies_mutating_for_observer() {
     let metrics = BgpMetrics::new();
-    let context = GrpcAuthAuditContext::new(
+    let context = tier_test_context(
         "tcp://127.0.0.1:50051",
         "read_write",
         AuthTier::OperatorOnly,
         GrpcAuthnKind::BearerToken,
         "observer.example",
-    )
-    .with_role_enforcement(
-        AuthEnforcement::Tier,
-        roles(&[("observer.example", PrincipalRole::Observer)]),
+        PrincipalRole::Observer,
     )
     .with_bearer_token(Some("secret"));
     let layer = GrpcAuthzLayer::new(context, metrics.clone());

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -1652,15 +1652,26 @@ mod tests {
     use crate::proto::{EventCategory, WatchEventsRequest};
     use crate::test_support::{session_event, spawn_fake_peer_manager, spawn_fake_rib};
 
-    fn empty_roles() -> Arc<BTreeMap<String, PrincipalRole>> {
-        Arc::new(BTreeMap::new())
+    fn tier_authz(principal: &str) -> RuntimeAuthzConfig {
+        RuntimeAuthzConfig {
+            enforcement: AuthEnforcement::Tier,
+            roles: Arc::new(BTreeMap::from([(
+                principal.to_string(),
+                PrincipalRole::Operator,
+            )])),
+        }
     }
 
-    fn legacy_authz() -> RuntimeAuthzConfig {
-        RuntimeAuthzConfig {
-            enforcement: AuthEnforcement::Legacy,
-            roles: empty_roles(),
-        }
+    /// Mutation proof: restoring the old Legacy test builder or dropping its
+    /// principal mapping makes one of these exact assertions red.
+    #[test]
+    fn test_authz_builder_uses_tier_operator_role() {
+        let config = tier_authz("rustbgpd://operator/api-test");
+        assert_eq!(config.enforcement, AuthEnforcement::Tier);
+        assert_eq!(
+            config.roles.get("rustbgpd://operator/api-test"),
+            Some(&PrincipalRole::Operator)
+        );
     }
 
     #[test]
@@ -1796,7 +1807,7 @@ mod tests {
             addr,
             AccessMode::ReadOnly,
             AuthTier::SensitiveRead,
-            legacy_authz(),
+            tier_authz("test"),
             true,
             false,
             Some("test"),
@@ -1883,7 +1894,7 @@ mod tests {
             "127.0.0.1:50051".parse().unwrap(),
             AccessMode::ReadWrite,
             AuthTier::OperatorOnly,
-            legacy_authz(),
+            tier_authz("automation.example"),
             true,
             false,
             Some("automation.example"),
@@ -1905,7 +1916,7 @@ mod tests {
             "127.0.0.1:50051".parse().unwrap(),
             AccessMode::ReadWrite,
             AuthTier::OperatorOnly,
-            legacy_authz(),
+            tier_authz("rustbgpd://operator/ci"),
             true,
             false,
             Some("rustbgpd://operator/ci"),
@@ -1920,7 +1931,7 @@ mod tests {
             "127.0.0.1:50051".parse().unwrap(),
             AccessMode::ReadWrite,
             AuthTier::Mutating,
-            legacy_authz(),
+            tier_authz("mtls-unresolved"),
             true,
             true,
             Some("automation.example"),
@@ -1936,7 +1947,7 @@ mod tests {
             Path::new("/run/rustbgpd/grpc.sock"),
             AccessMode::ReadWrite,
             AuthTier::SensitiveRead,
-            legacy_authz(),
+            tier_authz("local-admin"),
             None,
             Some("local-admin"),
         );

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -24,19 +24,29 @@ container images; it builds with `--workspace` or an explicit
 ```sh
 cargo run --release -p birdwatcher-adapter -- \
     --grpc-addr http://127.0.0.1:50051 \
+    --grpc-token-file /run/secrets/rustbgpd-token \
     --listen 0.0.0.0:8080
 ```
 
 Flags (also settable via env):
 
-| Flag          | Env                             | Default          | Meaning                          |
-|---------------|---------------------------------|------------------|----------------------------------|
-| `--grpc-addr` | `BIRDWATCHER_ADAPTER_GRPC_ADDR` | (required)       | rustbgpd gRPC endpoint (TCP)     |
-| `--listen`    | `BIRDWATCHER_ADAPTER_LISTEN`    | `127.0.0.1:8080` | REST listen address              |
+| Flag                | Env                                   | Default          | Meaning                                      |
+|---------------------|---------------------------------------|------------------|----------------------------------------------|
+| `--grpc-addr`       | `BIRDWATCHER_ADAPTER_GRPC_ADDR`       | (required)       | rustbgpd gRPC endpoint (TCP)                 |
+| `--grpc-token-file` | `BIRDWATCHER_ADAPTER_GRPC_TOKEN_FILE` | (unset)          | Optional rustbgpd bearer-token file          |
+| `--listen`          | `BIRDWATCHER_ADAPTER_LISTEN`          | `127.0.0.1:8080` | REST listen address                          |
+
+The command-line token path takes precedence over the environment variable.
+The adapter reads it once at startup, trims trailing whitespace, and rejects
+empty token files or values that are not valid ASCII gRPC metadata without
+logging the token. Omitting it preserves unauthenticated compatibility for a
+daemon listener that permits it.
 
 The daemon needs a gRPC TCP listener the adapter can reach
 (`[global.telemetry.grpc_tcp]`); read-only access is sufficient —
-every RPC the adapter calls is a read.
+every RPC the adapter calls is a read. For a bearer-protected Tier listener,
+set its stable `principal` to an `observer` (or stronger) role and pass the
+matching token file to the adapter.
 
 ## Endpoint → gRPC mapping
 

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -32,6 +32,7 @@
 
 use std::collections::HashSet;
 use std::net::{IpAddr, SocketAddr};
+use std::path::{Path as FsPath, PathBuf};
 
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
@@ -39,7 +40,10 @@ use axum::{Json, Router, routing::get};
 use clap::Parser;
 use rustbgpd_api::proto;
 use serde_json::Value;
+use tonic::metadata::AsciiMetadataValue;
+use tonic::service::{Interceptor, interceptor::InterceptedService};
 use tonic::transport::Channel;
+use tonic::{Request, Status};
 use tracing::{error, info};
 
 #[derive(Parser, Debug)]
@@ -52,6 +56,10 @@ struct Args {
     #[arg(long, env = "BIRDWATCHER_ADAPTER_GRPC_ADDR")]
     grpc_addr: String,
 
+    /// Optional bearer-token file for rustbgpd gRPC authentication.
+    #[arg(long, env = "BIRDWATCHER_ADAPTER_GRPC_TOKEN_FILE")]
+    grpc_token_file: Option<PathBuf>,
+
     /// HTTP listen address for the birdwatcher REST surface.
     #[arg(
         long,
@@ -61,11 +69,66 @@ struct Args {
     listen: SocketAddr,
 }
 
-/// Shared state: one multiplexed gRPC channel; per-request clients are
-/// cheap clones of it.
+#[derive(Clone, Debug, Default)]
+struct BearerInterceptor {
+    authorization: Option<AsciiMetadataValue>,
+}
+
+impl Interceptor for BearerInterceptor {
+    fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
+        if let Some(authorization) = self.authorization.clone() {
+            request
+                .metadata_mut()
+                .insert("authorization", authorization);
+        }
+        Ok(request)
+    }
+}
+
+fn load_bearer_authorization(
+    token_file: Option<&FsPath>,
+) -> Result<Option<AsciiMetadataValue>, std::io::Error> {
+    let Some(token_file) = token_file else {
+        return Ok(None);
+    };
+    let raw = std::fs::read_to_string(token_file)?;
+    let token = raw.trim_end();
+    if token.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("token file is empty: {}", token_file.display()),
+        ));
+    }
+    if !token.is_ascii() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "invalid token file {}: authorization value must be valid ASCII gRPC metadata",
+                token_file.display()
+            ),
+        ));
+    }
+    let mut authorization =
+        AsciiMetadataValue::try_from(format!("Bearer {token}")).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "invalid token file {}: authorization value must be valid ASCII gRPC metadata",
+                    token_file.display()
+                ),
+            )
+        })?;
+    authorization.set_sensitive(true);
+    Ok(Some(authorization))
+}
+
+type Upstream = InterceptedService<Channel, BearerInterceptor>;
+
+/// Shared state: one multiplexed, optionally authenticated gRPC service;
+/// per-request clients are cheap clones of it.
 #[derive(Clone)]
 struct AppState {
-    channel: Channel,
+    upstream: Upstream,
 }
 
 #[tokio::main]
@@ -84,7 +147,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // `connect_lazy` so the adapter can start before/independently of
     // the daemon; requests fail with 502 until the daemon is reachable.
     let channel = Channel::from_shared(args.grpc_addr.clone())?.connect_lazy();
-    let state = AppState { channel };
+    let authorization = load_bearer_authorization(args.grpc_token_file.as_deref())?;
+    let upstream = InterceptedService::new(channel, BearerInterceptor { authorization });
+    let state = AppState { upstream };
 
     let app = Router::new()
         .route("/status", get(status))
@@ -126,7 +191,7 @@ fn api_block() -> Value {
 // ---------------------------------------------------------------------------
 
 async fn status(State(state): State<AppState>) -> Result<Json<Value>, StatusCode> {
-    let mut global = proto::global_service_client::GlobalServiceClient::new(state.channel.clone());
+    let mut global = proto::global_service_client::GlobalServiceClient::new(state.upstream.clone());
     let g = global
         .get_global(proto::GetGlobalRequest {})
         .await
@@ -134,7 +199,7 @@ async fn status(State(state): State<AppState>) -> Result<Json<Value>, StatusCode
         .into_inner();
 
     let mut control =
-        proto::control_service_client::ControlServiceClient::new(state.channel.clone());
+        proto::control_service_client::ControlServiceClient::new(state.upstream.clone());
     let h = control
         .get_health(proto::HealthRequest {})
         .await
@@ -162,7 +227,7 @@ async fn status(State(state): State<AppState>) -> Result<Json<Value>, StatusCode
 
 async fn protocols_bgp(State(state): State<AppState>) -> Result<Json<Value>, StatusCode> {
     let mut client =
-        proto::neighbor_service_client::NeighborServiceClient::new(state.channel.clone());
+        proto::neighbor_service_client::NeighborServiceClient::new(state.upstream.clone());
     let resp = client
         .list_neighbors(proto::ListNeighborsRequest {})
         .await
@@ -172,7 +237,7 @@ async fn protocols_bgp(State(state): State<AppState>) -> Result<Json<Value>, Sta
     // Birdwatcher returns protocols as a map keyed by protocol name.
     // Alice-LG iterates this map and reads fields like `neighbor_address`,
     // `neighbor_as`, `state`, `description`, `routes`, `state_changed`.
-    let mut policy = proto::policy_service_client::PolicyServiceClient::new(state.channel.clone());
+    let mut policy = proto::policy_service_client::PolicyServiceClient::new(state.upstream.clone());
     let mut protocols = serde_json::Map::new();
     for n in &resp.neighbors {
         let cfg = n.config.clone().unwrap_or_default();
@@ -244,7 +309,7 @@ async fn routes_peer(
 }
 
 async fn serve_routes_for_peer(state: &AppState, peer: IpAddr) -> Result<Json<Value>, StatusCode> {
-    let mut client = proto::rib_service_client::RibServiceClient::new(state.channel.clone());
+    let mut client = proto::rib_service_client::RibServiceClient::new(state.upstream.clone());
     let mut routes: Vec<Value> = Vec::new();
     let mut page_token = String::new();
     loop {
@@ -287,7 +352,7 @@ async fn routes_filtered(
     let addr_str = id.strip_prefix("bgp_").unwrap_or(&id).replace('_', ":");
     let peer_addr: IpAddr = addr_str.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
 
-    let mut client = proto::policy_service_client::PolicyServiceClient::new(state.channel.clone());
+    let mut client = proto::policy_service_client::PolicyServiceClient::new(state.upstream.clone());
     let resp = match client
         .list_rejected_routes(proto::ListRejectedRoutesRequest {
             peer_address: peer_addr.to_string(),
@@ -446,7 +511,7 @@ async fn routes_noexport(
     let addr_str = id.strip_prefix("bgp_").unwrap_or(&id).replace('_', ":");
     let peer_addr: IpAddr = addr_str.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
 
-    let mut rib = proto::rib_service_client::RibServiceClient::new(state.channel.clone());
+    let mut rib = proto::rib_service_client::RibServiceClient::new(state.upstream.clone());
 
     // Adj-RIB-Out prefix set. Prefix-granular on purpose: any advertised
     // path for a prefix means the prefix is exported (an Add-Path peer's
@@ -743,6 +808,102 @@ fn days_to_ymd(days: u64) -> (u64, u64, u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
+
+    fn token_file(name: &str, contents: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "rustbgpd-birdwatcher-{name}-{}",
+            std::process::id()
+        ));
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    /// Mutation proof: removing token loading, trailing-whitespace trimming,
+    /// sensitivity marking, or interceptor insertion makes an assertion red.
+    #[test]
+    fn bearer_token_file_is_loaded_once_as_sensitive_authorization() {
+        let path = token_file("valid-token", "secret-token\n");
+        let authorization = load_bearer_authorization(Some(&path)).unwrap().unwrap();
+        let _ = std::fs::remove_file(path);
+        assert_eq!(authorization, "Bearer secret-token");
+        assert!(authorization.is_sensitive());
+
+        let mut interceptor = BearerInterceptor {
+            authorization: Some(authorization),
+        };
+        let request = interceptor.call(Request::new(())).unwrap();
+        let inserted = request.metadata().get("authorization").unwrap();
+        assert_eq!(inserted, "Bearer secret-token");
+        assert!(inserted.is_sensitive());
+    }
+
+    /// Mutation proof: making authentication mandatory when the flag is
+    /// absent inserts metadata and makes this compatibility assertion red.
+    #[test]
+    fn absent_token_file_preserves_unauthenticated_compatibility() {
+        assert!(load_bearer_authorization(None).unwrap().is_none());
+        let mut interceptor = BearerInterceptor::default();
+        let request = interceptor.call(Request::new(())).unwrap();
+        assert!(request.metadata().get("authorization").is_none());
+    }
+
+    /// Mutation proof: accepting empty, non-ASCII, or control-bearing token
+    /// contents makes the corresponding case succeed and this test red.
+    #[test]
+    fn bearer_token_file_rejects_invalid_values_without_disclosure() {
+        for (name, contents, expected) in [
+            ("empty-token", "\n", "token file is empty"),
+            (
+                "non-ascii-token",
+                "secret-\u{e9}",
+                "authorization value must be valid ASCII gRPC metadata",
+            ),
+            (
+                "control-token",
+                "secret\nother",
+                "authorization value must be valid ASCII gRPC metadata",
+            ),
+        ] {
+            let path = token_file(name, contents);
+            let error = load_bearer_authorization(Some(&path)).unwrap_err();
+            let _ = std::fs::remove_file(path);
+            let rendered = error.to_string();
+            assert!(rendered.contains(expected), "{rendered}");
+            let secret = contents.trim_end();
+            if !secret.is_empty() {
+                assert!(!rendered.contains(secret), "{rendered}");
+            }
+        }
+    }
+
+    /// Mutation proof: removing the CLI flag, changing its destination, or
+    /// changing its exact environment binding makes an assertion red.
+    #[test]
+    fn grpc_token_file_flag_parses() {
+        let args = Args::try_parse_from([
+            "birdwatcher-adapter",
+            "--grpc-addr",
+            "http://127.0.0.1:50051",
+            "--grpc-token-file",
+            "/run/secrets/rustbgpd-token",
+        ])
+        .unwrap();
+        assert_eq!(
+            args.grpc_token_file.as_deref(),
+            Some(FsPath::new("/run/secrets/rustbgpd-token"))
+        );
+
+        let command = Args::command();
+        let token_arg = command
+            .get_arguments()
+            .find(|arg| arg.get_id() == "grpc_token_file")
+            .expect("grpc_token_file argument must exist");
+        assert_eq!(
+            token_arg.get_env(),
+            Some(std::ffi::OsStr::new("BIRDWATCHER_ADAPTER_GRPC_TOKEN_FILE"))
+        );
+    }
 
     #[test]
     fn route_conversion_matches_birdwatcher_shape() {

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -138,14 +138,63 @@ fn wait_for_tcp(port: u16, proc_: &mut Proc) {
     );
 }
 
-fn write_config(dir: &Path, grpc_port: u16, bgp_port: u16) -> PathBuf {
+/// Mutation proof: dropping Tier enforcement, the bearer credential, or the
+/// direct unauthenticated call makes this stop observing `Unauthenticated`.
+fn wait_for_unauthenticated_get_global(port: u16, proc_: &mut Proc) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build gRPC probe runtime");
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        let result = runtime.block_on(async {
+            let endpoint = format!("http://127.0.0.1:{port}");
+            let mut client =
+                rustbgpd_api::proto::global_service_client::GlobalServiceClient::connect(endpoint)
+                    .await
+                    .ok()?;
+            Some(
+                client
+                    .get_global(rustbgpd_api::proto::GetGlobalRequest {})
+                    .await,
+            )
+        });
+        if matches!(
+            result,
+            // Canonical gRPC status 16 = UNAUTHENTICATED. The root package
+            // intentionally has no direct tonic dependency.
+            Some(Err(ref status)) if status.code() as i32 == 16
+        ) {
+            return;
+        }
+        if let Ok(Some(status)) = proc_.child.try_wait() {
+            panic!(
+                "{} exited before the unauthenticated gRPC probe: {status}\nstderr:\n{}",
+                proc_.name,
+                proc_.stderr()
+            );
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!(
+        "unauthenticated GetGlobal was not rejected\ndaemon stderr:\n{}",
+        proc_.stderr()
+    );
+}
+
+fn write_config(dir: &Path, grpc_port: u16, bgp_port: u16) -> (PathBuf, PathBuf) {
     let runtime_dir = dir.join("runtime");
     std::fs::create_dir_all(&runtime_dir).expect("create runtime dir");
+    let token_path = dir.join("grpc-token");
+    std::fs::write(&token_path, "birdwatcher-smoke-token\n").expect("write test token");
     let config_path = dir.join("rustbgpd.toml");
     let config = format!(
         r#"
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://observer/birdwatcher-test" = "observer"
 
 [global]
 asn = 65001
@@ -158,6 +207,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "127.0.0.1:{grpc_port}"
+token_file = "{token_path}"
+principal = "rustbgpd://observer/birdwatcher-test"
 
 [[neighbors]]
 address = "192.0.2.10"
@@ -174,10 +225,26 @@ address = "127.0.0.2"
 remote_asn = 65030
 description = "receiver peer"
 "#,
-        runtime_dir = runtime_dir.display()
+        runtime_dir = runtime_dir.display(),
+        token_path = token_path.display()
+    );
+    let parsed: toml::Value = toml::from_str(&config).expect("test config must parse");
+    let principal = "rustbgpd://observer/birdwatcher-test";
+    assert_eq!(
+        parsed["security"]["grpc"]["enforcement"].as_str(),
+        Some("tier")
+    );
+    assert_eq!(
+        parsed["global"]["telemetry"]["grpc_tcp"]["principal"].as_str(),
+        Some(principal)
+    );
+    assert_eq!(
+        parsed["security"]["grpc"]["roles"][principal].as_str(),
+        Some("observer"),
+        "mutation proof: adapter smoke must pin the least-privilege observer role"
     );
     std::fs::write(&config_path, config).expect("write test config");
-    config_path
+    (config_path, token_path)
 }
 
 /// Minimal BGP speaker: connect to the daemon's listen port, complete
@@ -306,7 +373,7 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
     let grpc_port = free_port();
     let adapter_port = free_port();
     let bgp_port = free_port();
-    let config_path = write_config(temp.path(), grpc_port, bgp_port);
+    let (config_path, token_path) = write_config(temp.path(), grpc_port, bgp_port);
 
     // Spawn the daemon (serves gRPC). Structured logs go to stdout,
     // the banner to stderr.
@@ -327,6 +394,7 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
         stderr_path: daemon_stderr,
     };
     wait_for_tcp(grpc_port, &mut daemon);
+    wait_for_unauthenticated_get_global(grpc_port, &mut daemon);
 
     // Spawn the adapter against the daemon's gRPC endpoint. Built via
     // `cargo run` (same fallback pattern the rbgp test helper uses) —
@@ -338,6 +406,8 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
             .args(["run", "--quiet", "-p", "birdwatcher-adapter", "--"])
             .arg("--grpc-addr")
             .arg(format!("http://127.0.0.1:{grpc_port}"))
+            .arg("--grpc-token-file")
+            .arg(&token_path)
             .arg("--listen")
             .arg(format!("127.0.0.1:{adapter_port}"))
             .stdout(Stdio::null())

--- a/tests/commit_confirm_binary.rs
+++ b/tests/commit_confirm_binary.rs
@@ -134,7 +134,10 @@ fn base_toml(runtime_dir: &Path, extra: &str) -> String {
     format!(
         r#"
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/commit-confirm-test" = "operator"
 
 [global]
 asn = 65001
@@ -144,6 +147,10 @@ runtime_state_dir = "{runtime_dir}"
 
 [global.telemetry]
 log_format = "json"
+
+[global.telemetry.grpc_uds]
+path = "{runtime_dir}/grpc.sock"
+principal = "rustbgpd://operator/commit-confirm-test"
 
 [peer_groups.ix-members]
 {extra}
@@ -164,7 +171,23 @@ fn lab(dir: &Path) -> Lab {
     let runtime_dir = dir.join("runtime");
     std::fs::create_dir_all(&runtime_dir).expect("failed to create runtime dir");
     let config_path = dir.join("rustbgpd.toml");
-    std::fs::write(&config_path, base_toml(&runtime_dir, "")).expect("failed to write config");
+    let base = base_toml(&runtime_dir, "");
+    let parsed: toml::Value = toml::from_str(&base).expect("base config must parse");
+    let principal = "rustbgpd://operator/commit-confirm-test";
+    assert_eq!(
+        parsed["security"]["grpc"]["enforcement"].as_str(),
+        Some("tier"),
+        "mutation proof: binary fixture must exercise Tier authorization"
+    );
+    assert_eq!(
+        parsed["global"]["telemetry"]["grpc_uds"]["principal"].as_str(),
+        Some(principal)
+    );
+    assert_eq!(
+        parsed["security"]["grpc"]["roles"][principal].as_str(),
+        Some("operator")
+    );
+    std::fs::write(&config_path, base).expect("failed to write config");
     let candidate_path = dir.join("candidate.toml");
     std::fs::write(
         &candidate_path,

--- a/tests/evpn_dataplane_rr_only.rs
+++ b/tests/evpn_dataplane_rr_only.rs
@@ -158,7 +158,10 @@ fn write_config(dir: &Path) -> PathBuf {
     let config = format!(
         r#"
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/evpn-rr-test" = "operator"
 
 [global]
 asn = 65001
@@ -168,8 +171,27 @@ runtime_state_dir = "{runtime_dir}"
 
 [global.telemetry]
 log_format = "json"
+
+[global.telemetry.grpc_uds]
+path = "{runtime_dir}/grpc.sock"
+principal = "rustbgpd://operator/evpn-rr-test"
 "#,
         runtime_dir = runtime_dir.display()
+    );
+    let parsed: toml::Value = toml::from_str(&config).expect("test config must parse");
+    let principal = "rustbgpd://operator/evpn-rr-test";
+    assert_eq!(
+        parsed["security"]["grpc"]["enforcement"].as_str(),
+        Some("tier"),
+        "mutation proof: binary fixture must exercise Tier authorization"
+    );
+    assert_eq!(
+        parsed["global"]["telemetry"]["grpc_uds"]["principal"].as_str(),
+        Some(principal)
+    );
+    assert_eq!(
+        parsed["security"]["grpc"]["roles"][principal].as_str(),
+        Some("operator")
     );
     std::fs::write(&config_path, config).expect("failed to write test config");
     config_path

--- a/tests/evpn_instances_binary.rs
+++ b/tests/evpn_instances_binary.rs
@@ -131,7 +131,10 @@ fn write_config(dir: &Path) -> PathBuf {
     let config = format!(
         r#"
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/evpn-instances-test" = "operator"
 
 [global]
 asn = 65001
@@ -141,6 +144,10 @@ runtime_state_dir = "{runtime_dir}"
 
 [global.telemetry]
 log_format = "json"
+
+[global.telemetry.grpc_uds]
+path = "{runtime_dir}/grpc.sock"
+principal = "rustbgpd://operator/evpn-instances-test"
 
 [[evpn_instances]]
 vni = 200
@@ -158,6 +165,21 @@ route_targets = ["65000:100"]
 local_vtep_ip = "10.0.0.10"
 "#,
         runtime_dir = runtime_dir.display()
+    );
+    let parsed: toml::Value = toml::from_str(&config).expect("test config must parse");
+    let principal = "rustbgpd://operator/evpn-instances-test";
+    assert_eq!(
+        parsed["security"]["grpc"]["enforcement"].as_str(),
+        Some("tier"),
+        "mutation proof: binary fixture must exercise Tier authorization"
+    );
+    assert_eq!(
+        parsed["global"]["telemetry"]["grpc_uds"]["principal"].as_str(),
+        Some(principal)
+    );
+    assert_eq!(
+        parsed["security"]["grpc"]["roles"][principal].as_str(),
+        Some("operator")
     );
     std::fs::write(&config_path, config).expect("failed to write test config");
     config_path


### PR DESCRIPTION
## Summary

- add optional read-once bearer-token authentication to the birdwatcher adapter through one shared tonic interceptor
- document the CLI and environment control while preserving unauthenticated compatibility when no token file is configured
- migrate API test contexts and three live binary fixtures from Legacy bypasses to exact Tier principals and roles
- make the live birdwatcher smoke prove unauthenticated rejection before exercising all eight authenticated upstream RPC methods with an observer role

This is the independent API and live-binary fixture tranche for LAN-549. Production daemon authorization behavior is unchanged.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- birdwatcher adapter tests: 15/15
- API authorization runtime tests: 20/20
- API server tests: 13/13
- commit-confirm binary: 5/5
- EVPN instances binary: 2/2
- RR-only binary: 1/1
- authenticated birdwatcher smoke: 1/1

## Load-bearing regression proof

Eleven independent mutations were observed red and restored:

- Tier enforcement was removed from each API test builder
- bearer metadata sensitivity was disabled
- explicit ASCII validation was removed
- the exact Clap environment binding was changed
- the optional token path was made mandatory
- each of the three binary fixtures was downgraded to Legacy
- the smoke role was elevated from observer to operator
- interceptor metadata insertion was removed

The real smoke also rejects a direct unauthenticated `GetGlobal` before starting the authenticated adapter and reaches GetGlobal, GetHealth, ListNeighbors, ListRejectedRoutes, ListReceivedRoutes, ListAdvertisedRoutes, ListBestRoutes, and ExplainAdvertisedRoute.