### PR TITLE
docs: true up TCP-AO and roadmap status

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1290,8 +1290,8 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
   (`RouteAttrBundle` / `materialize_attrs`), cutting per-UPDATE attribute-clone
   churn. Cold-start BGP reconnect also retries the first TCP-level dial misses
   quickly before returning to the slower exponential guard, reducing boot-order
-  establishment delay when rustbgpd starts before passive peers. Remaining
-  backlog, in rough priority order. Remaining FIB projection table-name
+  establishment delay when rustbgpd starts before passive peers. The remaining
+  backlog follows in rough priority order. FIB projection table-name
   ownership and lower-volume API/CLI serializer cleanup are measurement-gated.
   - FIB projection: shipped the configured-table policy precompile so
     `allowed_neighbors` is parsed once per projection pass and peer /

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -207,11 +207,12 @@ reachability, run-context detection, state-dir disk probes (LAN-482).
 unknown config keys~~ **Shipped (#993):** unknown-key config errors now carry
 a did-you-mean line inside the existing diagnostic frame, ranked by the same
 Levenshtein machinery as the `.rpol` suggestions (LAN-481);
-config version history + `rollback N`, completing the
-check/compare/confirm/rollback workflow no open-source daemon offers whole
-(LAN-483); a bounded BIRD/FRR/GoBGP config importer — structure only, with a
-fail-stop report of everything left for hand-translation, verified through
-the existing shadow-trial runbook (LAN-484).
+~~config version history + `rollback N`~~ **Shipped (#1016):** retained applied
+versions and rollback share the same transaction/validation path, completing
+the check/compare/confirm/rollback workflow (LAN-483); ~~a bounded
+BIRD/FRR/GoBGP config importer~~ **Shipped (#1015):** structure-only conversion
+with a fail-stop unsupported-directive report and shadow-trial workflow
+(LAN-484).
 
 Deliberately *not* here: a web UI, Terraform/Ansible providers (maintenance
 surface without demonstrated demand — revisit on operator pull), and
@@ -525,9 +526,9 @@ Details in the "Recently shipped" section below and ADR-0097.
   RFC, no open-source implementation found, drops onto the existing
   BGP-LS substrate; deepens the controller feed (TE controllers reading
   SR policy state over gRPC).
-- **ASPA/RTRv2 conformance refresh** against the latest drafts — cheap
-  insurance for a day-one-RFC-compliant claim while BIRD's ASPA sits in a
-  side branch and FRR has none.
+- ~~**ASPA/RTRv2 conformance refresh**~~ **Shipped (M84/#759, LAN-243):**
+  multi-cache RTR v1/v2 epoch, reconnect, replacement, withdrawal, and serial-
+  regression behavior is retained in the interop receipt.
 **The route-server (IXP) track** — the core is shipped; remaining work is
 adoption tooling. ADR-0101/M83 covers RFC 7947 transparency, Add-Path and
 `per_client_best` path-hiding mitigation, RFC 9234 OTC, ASPA/ROV hygiene, and
@@ -1290,9 +1291,8 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
   churn. Cold-start BGP reconnect also retries the first TCP-level dial misses
   quickly before returning to the slower exponential guard, reducing boot-order
   establishment delay when rustbgpd starts before passive peers. Remaining
-  backlog, in rough priority order. Near-term performance/polish targets are
-  the remaining FIB projection table-name ownership and high-volume CLI / JSON
-  serializer allocation cleanups.
+  backlog, in rough priority order. Remaining FIB projection table-name
+  ownership and lower-volume API/CLI serializer cleanup are measurement-gated.
   - FIB projection: shipped the configured-table policy precompile so
     `allowed_neighbors` is parsed once per projection pass and peer /
     peer-group membership checks reuse prebuilt sets. The new root
@@ -1300,14 +1300,13 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
     behind the `bench-internals` feature. Remaining possible cleanup:
     table-name ownership in projected status/drop rows, if a future profile
     shows those allocations matter enough to justify changing the data shape.
-  - API route listing: shipped the API-service cleanup that fuses family
+  - API/CLI route listing: shipped the API-service cleanup that fuses family
     filtering, route filters, pagination, and `route_to_proto` response
     construction into one pass over the RIB snapshot; canonical large-community
     filters now compare typed values instead of allocating a per-route
-    `Vec<String>`. Remaining: CLI route JSON still maps proto routes into a
-    second owned `JsonRoute` tree before serialization; replace that with
-    borrowed/streaming serializers if route-list JSON output shows up in
-    profiles.
+    `Vec<String>`. CLI route JSON uses borrowed serializers over the proto
+    routes (#518), preserving the public shape without building a second owned
+    `JsonRoute` tree. Further route-list work is measurement-gated.
   - RPKI validation: shipped the bucketed VRP lookup index and RFC 6811
     `maxLength` correctness fix, replacing the linear VRP scan with an
     ancestor-bucket lookup while preserving overlapping-VRP semantics. Cache
@@ -1405,10 +1404,10 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
     runtime serializers now return `CliError::Json` instead of panicking on
     `serde_json` failures. The high-volume CLI BGP event stream now uses
     borrowed `Serialize` wrappers for event envelopes and EVPN route payloads
-    instead of cloning proto fields into a second `serde_json::Value` tree.
-    Remaining allocation/data-shape cleanup: CLI route JSON still maps proto
-    routes into a second owned `JsonRoute` tree, and lower-volume API/CLI
-    snapshot/reporting paths should only be changed when a profile shows value.
+    instead of cloning proto fields into a second `serde_json::Value` tree, and
+    route-list JSON serializes borrowed proto routes directly (#518).
+    Lower-volume API/CLI snapshot/reporting paths should only be changed when a
+    profile shows value.
   - Benchmark infrastructure: automatic per-PR CI bench triggering on the pinned
     `[self-hosted, rustbgpd-bench]` runner (the manual `Criterion Bench Compare`
     workflow exists); a continuous churn bench (short criterion variant of the

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -141,7 +141,7 @@ IPv4/IPv6 `Prefix` routes.
 | Feature | rustbgpd | FRR | BIRD | GoBGP | OpenBGPd |
 |---|:---:|:---:|:---:|:---:|:---:|
 | TCP MD5 (RFC 2385) | Yes | Yes | Yes | Yes | Yes |
-| TCP-AO (RFC 5925) | Static + dynamic-prefix keyrings; add-only successor reload | No | Yes | No | No |
+| TCP-AO (RFC 5925) | Static + dynamic-prefix keyrings; observation-gated live rotation; deletion restart-required | No | Yes | No | No |
 | GTSM / TTL Security | Yes | Yes | Yes | Yes | Yes |
 | RPKI origin validation | Yes | Yes | Yes | Yes | Yes |
 | ASPA path verification | Yes[^aspa] | No | Yes | No | Yes |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -268,7 +268,7 @@ exceeding the fail-closed inspection path. SIGHUP can append a globally
 preflighted non-preferred successor generation without changing Current/RNext;
 a later immutable generation can select that installed successor and deprecate
 its predecessor after authenticated peer use is observed across the affected
-session cohort. Deletion, edits or reordering of existing MKTs, protected-owner
+session cohort. Deletion, edits, or reordering of existing MKTs, protected-owner
 CRUD, and Prometheus exposure of per-socket inspection remain deferred.
 
 ## Shutdown warm-checkpoint confidentiality
@@ -431,7 +431,7 @@ the roadmap:
 - TCP-AO supports ordered static-neighbor and direct dynamic-prefix keyrings,
   add-only non-preferred successor installation on SIGHUP, and a later
   observation-gated SIGHUP generation that selects the installed successor and
-  deprecates its predecessor. Deletion, edits/reordering of existing MKTs, and
+  deprecates its predecessor. Deletion, edits, or reordering of existing MKTs, and
   protected-owner CRUD require a restart.
   Protected static-neighbor interop is covered by M43 against BIRD 3.3.1 on
   Linux with `CONFIG_TCP_AO=y`.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -266,8 +266,10 @@ transport binding enforce the same 4,096-MKT inspection ceiling independently
 for each listener address family, preventing a valid configuration from
 exceeding the fail-closed inspection path. SIGHUP can append a globally
 preflighted non-preferred successor generation without changing Current/RNext;
-selection, deprecation, deletion, protected-owner CRUD, and metrics exposure of
-per-socket inspection remain deferred.
+a later immutable generation can select that installed successor and deprecate
+its predecessor after authenticated peer use is observed across the affected
+session cohort. Deletion, edits or reordering of existing MKTs, protected-owner
+CRUD, and Prometheus exposure of per-socket inspection remain deferred.
 
 ## Shutdown warm-checkpoint confidentiality
 
@@ -427,9 +429,10 @@ the roadmap:
   controls, client deadlines, and the documented `grpc_authz` / stream metrics
   to detect or constrain accepted-client abuse in v1.
 - TCP-AO supports ordered static-neighbor and direct dynamic-prefix keyrings,
-  plus add-only non-preferred successor installation on SIGHUP. Selection,
-  deprecation, deletion, edits/reordering, and protected-owner CRUD require a
-  restart.
+  add-only non-preferred successor installation on SIGHUP, and a later
+  observation-gated SIGHUP generation that selects the installed successor and
+  deprecates its predecessor. Deletion, edits/reordering of existing MKTs, and
+  protected-owner CRUD require a restart.
   Protected static-neighbor interop is covered by M43 against BIRD 3.3.1 on
   Linux with `CONFIG_TCP_AO=y`.
 - gRPC token and mTLS material behind unchanged paths rotate on SIGHUP as one


### PR DESCRIPTION
## Summary

- document observation-gated live TCP-AO successor selection and deprecation while keeping restart-required mutations explicit
- mark the shipped config history/importer and ASPA/RTRv2 work accurately in the roadmap
- replace stale owned route-JSON allocation notes with the shipped borrowed-serializer state

## Evidence

Validated against the current reload planner/apply path, TCP-AO rotation cohort logic, ADR-0062, deletion restart gating, and the merged receipts for #1015, #1016, #759, and #518.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `git diff --check`

Docs-only load-bearing mutation proof: N/A. An independent evidence review found and removed one remaining contradictory high-volume serializer roadmap clause before publication.

Linear: LAN-550
