### PR TITLE
test: tier-harden root config fixtures

### DIFF
--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -2772,6 +2772,9 @@ mod tests {
     use super::*;
     use crate::config::FibTableConfig;
     use crate::fib_runtime::FibRuntimeCommand;
+    use crate::test_support::{
+        assert_tier_authorized_test_config, tier_authorized_uds_test_config,
+    };
     use rustbgpd_api::peer_types::{
         FibTableSnapshot, RuntimeConfigDiff, RuntimeConfigTransactionPlan,
         RuntimeConfigTransactionPlanError,
@@ -2781,8 +2784,49 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
     use tokio::sync::Mutex;
 
+    fn tier_transaction_test_config(source: &str) -> String {
+        let prepared = tier_authorized_uds_test_config(source);
+        let config = Config::load_toml_with_diagnostics(&prepared, "transaction test config")
+            .expect("transaction test config must parse");
+        assert_tier_authorized_test_config(&config);
+        prepared
+    }
+
+    #[test]
+    fn root_fixture_test_surfaces_require_explicit_tier_preparation() {
+        let legacy_toml = concat!("enforcement = \"", "legacy\"");
+        let legacy_variant = concat!("GrpcEnforcementConfig::", "Legacy");
+        let helper = concat!("tier_authorized_uds", "_test_config");
+        let module_marker = "#[cfg(test)]\nmod tests {";
+        let module_sources = [
+            ("confirm_journal.rs", include_str!("confirm_journal.rs"), 2),
+            ("gnmi_set_bridge.rs", include_str!("gnmi_set_bridge.rs"), 2),
+            ("main.rs", include_str!("main.rs"), 2),
+            ("policy_admin.rs", include_str!("policy_admin.rs"), 2),
+        ];
+
+        for (path, source, helper_count) in module_sources {
+            let test_surface = source.rsplit_once(module_marker).unwrap().1;
+            assert!(!test_surface.contains(legacy_toml), "{path}");
+            assert!(!test_surface.contains(legacy_variant), "{path}");
+            assert_eq!(test_surface.matches(helper).count(), helper_count, "{path}");
+        }
+
+        let this_source = include_str!("config_transaction_control.rs");
+        let this_surface = this_source.rsplit_once(module_marker).unwrap().1;
+        let transaction_helper = concat!("tier_transaction", "_test_config");
+        assert!(!this_surface.contains(legacy_toml));
+        assert!(!this_surface.contains(legacy_variant));
+        assert_eq!(this_surface.matches(transaction_helper).count(), 12);
+
+        let peer_manager_tests = include_str!("peer_manager/tests.rs");
+        assert!(!peer_manager_tests.contains(legacy_toml));
+        assert!(!peer_manager_tests.contains(legacy_variant));
+        assert_eq!(peer_manager_tests.matches(helper).count(), 4);
+    }
+
     fn base_toml(extra: &str) -> String {
-        format!(
+        tier_transaction_test_config(&format!(
             r#"
 [global]
 asn = 65001
@@ -2793,16 +2837,13 @@ listen_port = 179
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[neighbors]]
 address = "10.0.0.2"
 remote_asn = 65002
 
 {extra}
 "#
-        )
+        ))
     }
 
     fn config_transaction_lifecycle_metric(
@@ -3566,7 +3607,7 @@ peer_group = "edge"
     /// produces a pure static-neighbor policy-chain impact.
     /// Dynamic-range transaction tests use `dynamic_live_policy_toml`.
     fn live_policy_toml(action: &str) -> String {
-        format!(
+        tier_transaction_test_config(&format!(
             r#"
 [global]
 asn = 65001
@@ -3576,9 +3617,6 @@ listen_port = 179
 [global.telemetry]
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [policy.definitions.f]
 default_action = "{action}"
@@ -3588,11 +3626,11 @@ address = "10.0.0.2"
 remote_asn = 65002
 import_policy_chain = ["f"]
 "#
-        )
+        ))
     }
 
     fn dynamic_live_policy_toml(action: &str) -> String {
-        format!(
+        tier_transaction_test_config(&format!(
             r#"
 [global]
 asn = 65001
@@ -3602,9 +3640,6 @@ listen_port = 179
 [global.telemetry]
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [peer_groups.ix]
 import_policy_chain = ["f"]
@@ -3617,11 +3652,11 @@ prefix = "10.30.0.9/16"
 peer_group = "ix"
 remote_asn = 65030
 "#
-        )
+        ))
     }
 
     fn peer_group_reshape_toml(hold_time: u32) -> String {
-        format!(
+        tier_transaction_test_config(&format!(
             r#"
 [global]
 asn = 65001
@@ -3631,9 +3666,6 @@ listen_port = 179
 [global.telemetry]
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [peer_groups.edge]
 hold_time = {hold_time}
@@ -3643,14 +3675,14 @@ address = "10.0.0.2"
 remote_asn = 65002
 peer_group = "edge"
 "#
-        )
+        ))
     }
 
     /// Peer group referenced only by a `[[dynamic_neighbors]]` range: a
     /// hold-time edit is a dynamic-range session reshape with no static
     /// members.
     fn dynamic_peer_group_reshape_toml(hold_time: u32) -> String {
-        format!(
+        tier_transaction_test_config(&format!(
             r#"
 [global]
 asn = 65001
@@ -3661,9 +3693,6 @@ listen_port = 179
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [peer_groups.ix]
 hold_time = {hold_time}
 
@@ -3672,7 +3701,7 @@ prefix = "10.30.0.0/16"
 peer_group = "ix"
 remote_asn = 65030
 "#
-        )
+        ))
     }
 
     fn dynamic_required_families_toml(required: bool) -> String {
@@ -3681,7 +3710,7 @@ remote_asn = 65030
         } else {
             "required_families = []"
         };
-        format!(
+        tier_transaction_test_config(&format!(
             r#"
 [global]
 asn = 65001
@@ -3690,8 +3719,6 @@ listen_port = 179
 [global.telemetry]
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
-[security.grpc]
-enforcement = "legacy"
 [peer_groups.ix]
 families = ["ipv4_unicast", "ipv6_unicast"]
 {required}
@@ -3700,14 +3727,14 @@ prefix = "10.30.0.0/16"
 peer_group = "ix"
 remote_asn = 65030
 "#
-        )
+        ))
     }
 
     /// Peer group with one static member and one `[[dynamic_neighbors]]`
     /// range: a hold-time edit reshapes the static member and resets the
     /// range's live dynamic sessions.
     fn mixed_peer_group_reshape_toml(hold_time: u32) -> String {
-        format!(
+        tier_transaction_test_config(&format!(
             r#"
 [global]
 asn = 65001
@@ -3717,9 +3744,6 @@ listen_port = 179
 [global.telemetry]
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [peer_groups.edge]
 hold_time = {hold_time}
@@ -3734,11 +3758,11 @@ prefix = "10.30.0.0/16"
 peer_group = "edge"
 remote_asn = 65030
 "#
-        )
+        ))
     }
 
     fn peer_group_reassignment_toml(group: &str) -> String {
-        format!(
+        tier_transaction_test_config(&format!(
             r#"
 [global]
 asn = 65001
@@ -3748,9 +3772,6 @@ listen_port = 179
 [global.telemetry]
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [peer_groups.edge]
 hold_time = 90
@@ -3763,7 +3784,7 @@ address = "10.0.0.2"
 remote_asn = 65002
 peer_group = "{group}"
 "#
-        )
+        ))
     }
 
     fn resolved_static_peer_configs(toml: &str) -> Vec<PeerManagerNeighborConfig> {
@@ -7363,7 +7384,7 @@ export_policy_chain = ["d-private"]
 export_policy_chain = ["stable"]
 "#
         };
-        format!(
+        tier_transaction_test_config(&format!(
             r#"
 [global]
 asn = 65001
@@ -7373,9 +7394,6 @@ listen_port = 179
 [global.telemetry]
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [policy.neighbor_sets.peer-context]
 addresses = ["10.0.0.12"]
@@ -7442,7 +7460,7 @@ remote_asn = 65001
 families = ["ipv4_unicast", "ipv6_unicast"]
 peer_group = "ge"
 "#
-        )
+        ))
     }
 
     async fn query_real_update_group_snapshot(
@@ -7839,7 +7857,6 @@ peer_group = "ge"
     }
 
     const HETEROGENEOUS_UPDATE_GROUP_TOML: &str = r#"
-global = { asn = 65001, router_id = "10.0.0.1", listen_port = 179, telemetry = { prometheus_addr = "0.0.0.0:9179", log_format = "json" } }
 policy = { definitions = { old-shared = { default_action = "permit" }, new-shared = { default_action = "permit", statements = [{ prefix = "198.51.100.0/24", action = "deny" }] } } }
 peer_groups = { changed = { export_policy_chain = ["CHANGED_POLICY"] } }
 neighbors = [
@@ -7849,6 +7866,13 @@ neighbors = [
   { address = "10.0.0.14", remote_asn = 65001, route_reflector_client = true, orr_vantage = "192.0.2.14" },
   { address = "10.0.0.15", remote_asn = 65003, add_path = { send = true, send_max = 4 } },
 ]
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
 "#;
 
     #[tokio::test]
@@ -7857,9 +7881,12 @@ neighbors = [
         use rustbgpd_rib::{PlannedGroupability, UpdateGroupImpactRollup};
         use rustbgpd_wire::{Afi, Safi};
 
-        let current_toml = HETEROGENEOUS_UPDATE_GROUP_TOML.replace("CHANGED_POLICY", "old-shared");
-        let candidate_toml =
-            HETEROGENEOUS_UPDATE_GROUP_TOML.replace("CHANGED_POLICY", "new-shared");
+        let current_toml = tier_transaction_test_config(
+            &HETEROGENEOUS_UPDATE_GROUP_TOML.replace("CHANGED_POLICY", "old-shared"),
+        );
+        let candidate_toml = tier_transaction_test_config(
+            &HETEROGENEOUS_UPDATE_GROUP_TOML.replace("CHANGED_POLICY", "new-shared"),
+        );
         let current = Config::load_toml_with_diagnostics(&current_toml, "heterogeneous current")
             .expect("heterogeneous current config must parse");
         let resolved = current

--- a/src/confirm_journal.rs
+++ b/src/confirm_journal.rs
@@ -453,6 +453,9 @@ fn fsync_dir(dir: &Path) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::{
+        assert_tier_authorized_test_config, tier_authorized_uds_test_config,
+    };
 
     const PREVIOUS_TOML: &str = r#"
 [global]
@@ -465,11 +468,19 @@ prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
 "#;
 
+    fn previous_toml() -> String {
+        let prepared = tier_authorized_uds_test_config(PREVIOUS_TOML);
+        let config = Config::load_toml_with_diagnostics(&prepared, "confirm journal test config")
+            .expect("confirm journal test config must parse");
+        assert_tier_authorized_test_config(&config);
+        prepared
+    }
+
     fn journal() -> ConfirmJournal {
         ConfirmJournal {
             confirm_id: "deploy-1".to_string(),
             deadline_unix_seconds: 1234,
-            rollback_toml: PREVIOUS_TOML.to_string(),
+            rollback_toml: previous_toml(),
             rollback_failed: false,
         }
     }
@@ -524,7 +535,7 @@ log_format = "json"
         assert_eq!(revert.notice.confirm_id, "deploy-1");
         assert_eq!(revert.config.global.asn, 65001);
         // Config file restored to the journaled previous config.
-        assert_eq!(fs::read_to_string(&config_path).unwrap(), PREVIOUS_TOML);
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), previous_toml());
         // Unconfirmed candidate saved aside verbatim.
         assert_eq!(
             fs::read_to_string(&revert.notice.backup_path).unwrap(),
@@ -609,7 +620,7 @@ log_format = "json"
         write(&path, &journal()).unwrap();
 
         let revert = boot_revert_check(&path, &config_path).unwrap().unwrap();
-        assert_eq!(fs::read_to_string(&config_path).unwrap(), PREVIOUS_TOML);
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), previous_toml());
         // No candidate existed, so nothing was saved aside.
         assert!(!revert.notice.backup_path.exists());
     }
@@ -697,7 +708,7 @@ log_format = "json"
             &serde_json::to_string(&serde_json::json!({
                 "confirm_id": "deploy-1",
                 "deadline_unix_seconds": 1234,
-                "rollback_toml": PREVIOUS_TOML,
+                "rollback_toml": previous_toml(),
             }))
             .unwrap(),
         )
@@ -724,7 +735,7 @@ log_format = "json"
         assert!(revert.notice.rollback_failed);
         // The revert itself still applies — the journaled snapshot is the
         // proven pre-transaction config.
-        assert_eq!(fs::read_to_string(&config_path).unwrap(), PREVIOUS_TOML);
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), previous_toml());
     }
 
     #[test]
@@ -751,8 +762,8 @@ log_format = "json"
                 .is_symlink(),
             "the config symlink must survive the revert"
         );
-        assert_eq!(fs::read_to_string(&real).unwrap(), PREVIOUS_TOML);
-        assert_eq!(fs::read_to_string(&link).unwrap(), PREVIOUS_TOML);
+        assert_eq!(fs::read_to_string(&real).unwrap(), previous_toml());
+        assert_eq!(fs::read_to_string(&link).unwrap(), previous_toml());
         // Candidate saved aside next to the REAL file.
         assert_eq!(
             revert.notice.backup_path,
@@ -848,7 +859,7 @@ log_format = "json"
         assert!(message.contains("refusing to boot"), "{message}");
         assert!(message.contains("WAS applied"), "{message}");
         // The revert WAS written despite the refusal.
-        assert_eq!(fs::read_to_string(&config_path).unwrap(), PREVIOUS_TOML);
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), previous_toml());
         // The real candidate is preserved in the backup slot.
         let backup = unconfirmed_backup_path(&config_path);
         assert_eq!(
@@ -888,7 +899,7 @@ log_format = "json"
 
         let revert = boot_revert_check(&path, &config_path).unwrap().unwrap();
         // Revert still applied.
-        assert_eq!(fs::read_to_string(&config_path).unwrap(), PREVIOUS_TOML);
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), previous_toml());
         // The pre-existing candidate is untouched — NOT overwritten with the
         // current on-disk config.
         assert_eq!(
@@ -939,7 +950,7 @@ log_format = "json"
         write(&path, &journal()).unwrap();
 
         let revert = boot_revert_check(&path, &config_path).unwrap().unwrap();
-        assert_eq!(fs::read_to_string(&config_path).unwrap(), PREVIOUS_TOML);
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), previous_toml());
         assert_eq!(
             fs::read_to_string(&revert.notice.backup_path).unwrap(),
             "candidate from the crashed run",

--- a/src/gnmi_set_bridge.rs
+++ b/src/gnmi_set_bridge.rs
@@ -1022,8 +1022,12 @@ mod tests {
 
     use rustbgpd_api::gnmi::typed_value::Value as TypedValue;
 
+    use crate::test_support::{
+        assert_tier_authorized_test_config, tier_authorized_uds_test_config,
+    };
+
     fn base_config() -> Config {
-        toml::from_str(
+        let config = toml::from_str(&tier_authorized_uds_test_config(
             r#"
 [global]
 asn = 65001
@@ -1038,8 +1042,10 @@ address = "192.0.2.1"
 remote_asn = 65002
 description = "old"
 "#,
-        )
-        .unwrap()
+        ))
+        .unwrap();
+        assert_tier_authorized_test_config(&config);
+        config
     }
 
     fn bgp_prefix_elem() -> Vec<gnmi::PathElem> {
@@ -1332,7 +1338,7 @@ description = "old"
         // disabled). The ADR-0076 candidate validation then rejects the
         // transaction with the config-level unknown-mode diagnostic,
         // which the commit path surfaces as InvalidArgument.
-        let mut candidate = apply_transaction_to_config(
+        let candidate = apply_transaction_to_config(
             base_config(),
             &transaction(vec![peer_group_update(
                 "rs-clients",
@@ -1341,11 +1347,6 @@ description = "old"
             )]),
         )
         .unwrap();
-        // Keep the round-trip focused on the leaf under test: the bare
-        // test config has no gRPC roles, which tier enforcement (the
-        // serialized default) would reject before reaching the
-        // remove-private-as validation.
-        candidate.security.grpc.enforcement = crate::config::GrpcEnforcementConfig::Legacy;
         let group = candidate.peer_groups.get("rs-clients").unwrap();
         assert_eq!(
             group.remove_private_as.as_deref(),
@@ -1797,7 +1798,7 @@ description = "old"
         // parse accepts any u16; the native candidate validation owns the
         // 12-bit GR restart-time bound and the commit path surfaces its
         // diagnostic.
-        let mut candidate = apply_transaction_to_config(
+        let candidate = apply_transaction_to_config(
             base_config(),
             &transaction(vec![update_at(
                 "192.0.2.1",
@@ -1806,9 +1807,6 @@ description = "old"
             )]),
         )
         .unwrap();
-        // Same tier-enforcement carve-out as the remove-private-as
-        // round-trip test: keep validation focused on the leaf under test.
-        candidate.security.grpc.enforcement = crate::config::GrpcEnforcementConfig::Legacy;
         assert_eq!(candidate.neighbors[0].gr_restart_time, Some(4096));
 
         let candidate_toml = toml::to_string_pretty(&candidate).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -4905,6 +4905,9 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
+    use crate::test_support::{
+        assert_tier_authorized_test_config, tier_authorized_uds_test_config,
+    };
 
     fn unique_temp_path(name: &str) -> PathBuf {
         let suffix = SystemTime::now()
@@ -5055,6 +5058,7 @@ mod tests {
         let path = unique_temp_path(name);
         std::fs::write(&path, toml).unwrap();
         let config = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        assert_tier_authorized_test_config(&config);
         std::fs::remove_file(&path).ok();
         config
     }
@@ -5159,7 +5163,7 @@ mod tests {
     }
 
     fn tcp_ao_neighbor_toml(address: &str) -> String {
-        format!(
+        tier_authorized_uds_test_config(&format!(
             r#"
 [global]
 asn = 65001
@@ -5174,7 +5178,7 @@ address = "{address}"
 remote_asn = 65002
 tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)" }}
 "#
-        )
+        ))
     }
 
     #[test]

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -22,6 +22,8 @@ use tokio::net::TcpListener;
 use tokio::net::TcpStream;
 use tokio::sync::{Notify, broadcast, mpsc, oneshot};
 
+use crate::test_support::{assert_tier_authorized_test_config, tier_authorized_uds_test_config};
+
 fn key(addr: IpAddr) -> PeerKey {
     PeerKey::new(addr, None)
 }
@@ -384,7 +386,7 @@ fn make_dynamic_manager_config() -> Config {
         },
     );
 
-    Config {
+    let config = Config {
         global: crate::config::Global {
             asn: 65001,
             router_id: "10.0.0.1".to_string(),
@@ -395,7 +397,15 @@ fn make_dynamic_manager_config() -> Config {
                 prometheus_addr: Some("127.0.0.1:9179".to_string()),
                 log_format: "json".to_string(),
                 grpc_tcp: None,
-                grpc_uds: None,
+                grpc_uds: Some(crate::config::GrpcUdsListenerConfig {
+                    enabled: true,
+                    path: Some("/tmp/rustbgpd-test.sock".to_string()),
+                    mode: 0o600,
+                    access_mode: None,
+                    max_tier: None,
+                    token_file: None,
+                    principal: Some("rustbgpd://operator/test-only".to_string()),
+                }),
             },
             dynamic_neighbor_limit: Some(100),
             worker_threads: None,
@@ -409,8 +419,11 @@ fn make_dynamic_manager_config() -> Config {
         },
         security: crate::config::SecurityConfig {
             grpc: crate::config::GrpcSecurityConfig {
-                enforcement: crate::config::GrpcEnforcementConfig::Legacy,
-                ..Default::default()
+                enforcement: crate::config::GrpcEnforcementConfig::Tier,
+                roles: HashMap::from([(
+                    "rustbgpd://operator/test-only".to_string(),
+                    crate::config::GrpcRoleConfig::Operator,
+                )]),
             },
         },
         neighbors: Vec::new(),
@@ -436,11 +449,14 @@ fn make_dynamic_manager_config() -> Config {
         bfd_profiles: Vec::new(),
         apply_bum_enforcement: false,
         event_history: crate::config::EventHistoryConfig::default(),
-    }
+    };
+    assert_tier_authorized_test_config(&config);
+    config
 }
 
 fn load_test_config(toml: &str) -> Config {
-    Config::load_toml_with_diagnostics(toml, "test config").unwrap()
+    Config::load_toml_with_diagnostics(&tier_authorized_uds_test_config(toml), "test config")
+        .unwrap()
 }
 
 fn dynamic_test_manager() -> PeerManager {
@@ -1038,9 +1054,8 @@ md5_password = "old-secret"
         current,
     );
 
-    let diff = mgr
-        .diff_runtime_config(
-            r#"
+    let candidate = tier_authorized_uds_test_config(
+        r#"
 [global]
 asn = 65001
 router_id = "10.0.0.1"
@@ -1054,8 +1069,8 @@ address = "10.0.0.2"
 remote_asn = 65002
 md5_password = "new-secret"
 "#,
-        )
-        .unwrap();
+    );
+    let diff = mgr.diff_runtime_config(&candidate).unwrap();
 
     assert!(diff.has_reload_applied_changes);
     assert!(diff.has_actionable_changes);
@@ -9237,7 +9252,7 @@ async fn apply_resolved_policy_snapshot_skips_non_live_targets() {
 #[tokio::test]
 async fn apply_policy_impact_snapshot_expands_dynamic_range_targets() {
     let mut mgr = live_policy_test_manager();
-    let candidate = crate::config::Config::load_toml_with_diagnostics(
+    let candidate_toml = tier_authorized_uds_test_config(
         r#"
 [global]
 asn = 65001
@@ -9247,9 +9262,6 @@ listen_port = 179
 [global.telemetry]
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [peer_groups.ix]
 import_policy_chain = ["deny-import"]
@@ -9262,6 +9274,9 @@ prefix = "10.30.0.0/16"
 peer_group = "ix"
 remote_asn = 65030
 "#,
+    );
+    let candidate = crate::config::Config::load_toml_with_diagnostics(
+        &candidate_toml,
         "dynamic policy candidate",
     )
     .expect("test config must parse");

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -793,12 +793,11 @@ pub fn neighbor_policy_chains_from_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::{
+        assert_tier_authorized_test_config, tier_authorized_uds_test_config,
+    };
 
     fn minimal_config() -> Config {
-        // Bypasses `Config::load_*_with_diagnostics` so the
-        // test-only legacy-grpc auto-inject doesn't fire; declare
-        // the legacy posture explicitly so post-mutation
-        // validation in `apply_config_event` accepts the config.
         let toml = r#"
 [global]
 asn = 65001
@@ -809,14 +808,13 @@ listen_port = 179
 prometheus_addr = "127.0.0.1:9179"
 log_format = "json"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[neighbors]]
 address = "10.0.0.2"
 remote_asn = 65002
 "#;
-        toml::from_str(toml).unwrap()
+        let config = toml::from_str(&tier_authorized_uds_test_config(toml)).unwrap();
+        assert_tier_authorized_test_config(&config);
+        config
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- migrate six non-reload root test surfaces from implicit Legacy authorization to explicit Tier UDS fixtures
- prepare both heterogeneous update-group transaction inputs and assert the exact principal/role identity
- add a six-file inventory that rejects missing preparation seams and restored explicit Legacy bypasses

Production loader behavior and the production Legacy compatibility conversion are unchanged. The larger reload migration was split into a one-file follow-up after independent review proved the combined patch exceeded its hard cap.

## Load-bearing proof

Each mutation was applied independently, observed red with exit 101, and restored:

- remove heterogeneous candidate preparation: inventory expected 12 seams and found 11
- bypass the central Tier helper: transaction test observes Legacy instead of exact Tier
- remove the dynamic-manager UDS principal: exact peer identity assertion observes no principal
- restore an explicit Legacy block in the journal fixture: six-file inventory rejects it

With the production `cfg(test)` Legacy injector temporarily removed, all focused suites remained green: transaction 69, journal 22, gNMI 34, peer-manager 235, policy-admin 4, and TCP-AO listener 3.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `git diff --check`

Independent review also reran the inventory, real-RIB heterogeneous tests, gNMI validations, and TCP-AO loader tests before returning GO.

Linear: LAN-549 tranche B1
