### PR TITLE
test: tier-harden loader edge fixtures

### DIFF
--- a/src/config/diagnostic.rs
+++ b/src/config/diagnostic.rs
@@ -799,8 +799,7 @@ md5password = \"hunter2-typo-secret\"
     fn full_load_with_diagnostics_invalid_hold_time() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
-        std::fs::write(
-            &path,
+        let source = crate::test_support::tier_authorized_uds_test_config(
             "\
 [global]
 asn = 65000
@@ -815,8 +814,8 @@ address = \"10.0.0.1\"
 remote_asn = 65001
 hold_time = 2
 ",
-        )
-        .unwrap();
+        );
+        std::fs::write(&path, source).unwrap();
         let err = super::super::Config::load_with_diagnostics(path.to_str().unwrap()).unwrap_err();
         assert!(err.contains("hold_time = 2"), "got: {err}");
         assert!(err.contains("must be 0 or >= 3"), "got: {err}");

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -5847,7 +5847,9 @@ local_vtep_ip = "10.0.0.1"
         );
 
         let request = proto::ApplyEvpnRuntimeRequest {
-            candidate_toml: l2vni_runtime_candidate_toml().to_string(),
+            candidate_toml: crate::test_support::tier_authorized_uds_test_config(
+                l2vni_runtime_candidate_toml(),
+            ),
             validate_only: false,
         };
         let mut caller = Box::pin(reload_apply.apply_request(&request));


### PR DESCRIPTION
## Summary

- explicitly Tier-prepare the invalid-hold-time full-loader diagnostic fixture
- explicitly Tier-prepare the dropped-mid-converge runtime request fixture
- preserve the original diagnostic caret and real convergence-gate semantics

This 11-line D0 prerequisite was discovered when the final injector-removal branch ran all binary tests. Both fixtures passed on the parent only because the test-only Legacy loader injector masked their raw no-security inputs.

## Load-bearing proof

With the production injector temporarily removed and restored after each run:

- removing diagnostic Tier preparation fails before the hold-time text/message/caret assertions
- removing EVPN request Tier preparation fails before the dropped caller reaches the real convergence gate

Both mutations exited 101 and were restored. No production code changed.

## Verification

- diagnostic module: 16/16
- EVPN runtime module: 112/112
- exact injector-disabled tests: 1/1 each
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `git diff --check`

Independent review reran both exact tests and returned GO.

Linear: LAN-549 tranche D0
