### PR TITLE
fix: retain BGP reset causes in diagnostics

### DIFF
--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -414,6 +414,7 @@ fn nofile_check(pid: u32, soft: u64, hard: u64, run_context: &str) -> Check {
 
 /// Pure per-peer session checks: state (with time-in-state derived from
 /// the most recent session event) and flap count.
+#[expect(clippy::too_many_arguments, reason = "snapshot fields")]
 fn peer_checks(
     address: &str,
     state: &str,
@@ -422,6 +423,7 @@ fn peer_checks(
     flap_count: u64,
     last_transition_unix: Option<u64>,
     now: u64,
+    last_error: &str,
 ) -> Vec<Check> {
     let mut checks = Vec::new();
     if stale {
@@ -457,10 +459,15 @@ fn peer_checks(
                 "with no recent state transition".to_string(),
             ),
         };
+        let cause = if last_error.is_empty() {
+            String::new()
+        } else {
+            format!("; last error: {last_error}")
+        };
         checks.push(Check {
             name: format!("peer.{address}.session"),
             status,
-            detail: format!("peer {address} in {state} {since}"),
+            detail: format!("peer {address} in {state} {since}{cause}"),
         });
     }
     if flap_count >= FLAP_FAIL_THRESHOLD {
@@ -1174,6 +1181,7 @@ pub(crate) async fn run(
                                 messages_received: n.messages_received,
                                 messages_sent: n.messages_sent,
                                 flap_count: n.flap_count,
+                                last_error: redact_text(&n.last_error),
                                 route_reflector_client: n.route_reflector_client,
                                 description: redact_text(
                                     &cfg.map(|c| c.description.clone()).unwrap_or_default(),
@@ -1197,6 +1205,7 @@ pub(crate) async fn run(
                             snapshot.flap_count,
                             transitions.get(&snapshot.address).copied(),
                             now,
+                            &snapshot.last_error,
                         ) {
                             reporter.record(check.name, check.status, check.detail);
                         }
@@ -1594,7 +1603,16 @@ tcp_ao = { key = "<redacted>", send_id = 1, recv_id = 2, algorithm = "hmac(sha25
 
     #[test]
     fn established_peer_is_green() {
-        let checks = peer_checks("10.0.0.2", "Established", false, 3600, 0, None, 1_000_000);
+        let checks = peer_checks(
+            "10.0.0.2",
+            "Established",
+            false,
+            3600,
+            0,
+            None,
+            1_000_000,
+            "",
+        );
         assert_eq!(checks.len(), 1);
         assert!(checks[0].status == CheckStatus::Ok);
         assert!(checks[0].detail.contains("Established"));
@@ -1604,7 +1622,16 @@ tcp_ao = { key = "<redacted>", send_id = 1, recv_id = 2, algorithm = "hmac(sha25
     fn peer_stuck_in_connect_past_threshold_is_red_with_duration() {
         let now = 1_000_000;
         let transitioned = now - (4 * 3600 + 12 * 60); // 4h12m ago
-        let checks = peer_checks("10.0.0.2", "Connect", false, 0, 0, Some(transitioned), now);
+        let checks = peer_checks(
+            "10.0.0.2",
+            "Connect",
+            false,
+            0,
+            0,
+            Some(transitioned),
+            now,
+            "",
+        );
         assert_eq!(checks.len(), 1);
         assert!(checks[0].status == CheckStatus::Fail);
         assert!(
@@ -1625,13 +1652,14 @@ tcp_ao = { key = "<redacted>", send_id = 1, recv_id = 2, algorithm = "hmac(sha25
             0,
             Some(now - STUCK_PEER_SECS + 1),
             now,
+            "",
         );
         assert!(checks[0].status == CheckStatus::Warn);
     }
 
     #[test]
     fn peer_in_connect_with_no_transition_event_is_red() {
-        let checks = peer_checks("10.0.0.2", "Connect", false, 0, 0, None, 1_000_000);
+        let checks = peer_checks("10.0.0.2", "Connect", false, 0, 0, None, 1_000_000, "");
         assert!(checks[0].status == CheckStatus::Fail);
         assert!(checks[0].detail.contains("no recent state transition"));
     }
@@ -1646,6 +1674,7 @@ tcp_ao = { key = "<redacted>", send_id = 1, recv_id = 2, algorithm = "hmac(sha25
             FLAP_FAIL_THRESHOLD,
             None,
             1_000_000,
+            "",
         );
         assert_eq!(checks.len(), 2);
         assert!(checks[1].status == CheckStatus::Fail);
@@ -1654,7 +1683,7 @@ tcp_ao = { key = "<redacted>", send_id = 1, recv_id = 2, algorithm = "hmac(sha25
 
     #[test]
     fn stale_peer_is_warn() {
-        let checks = peer_checks("10.0.0.2", "Stale", true, 0, 0, None, 1_000_000);
+        let checks = peer_checks("10.0.0.2", "Stale", true, 0, 0, None, 1_000_000, "");
         assert!(checks[0].status == CheckStatus::Warn);
         assert!(checks[0].detail.contains("stale"));
     }
@@ -2143,8 +2172,10 @@ paths = ["x"]
         ));
         // State 2 = Connect, no session events => stuck with no recent
         // transition => red.
-        *server.state.list_neighbors_response.lock().await =
-            vec![neighbor("10.0.0.9", 2, 0, "stuck peer")];
+        let mut stuck = neighbor("10.0.0.9", 2, 0, "stuck peer");
+        stuck.last_error =
+            "sent NOTIFICATION 2/7 (Unsupported Capability)\ntoken=must-not-escape".to_string();
+        *server.state.list_neighbors_response.lock().await = vec![stuck];
         let connection = connect(&server.addr, None).await;
         let dir = tempfile::tempdir().unwrap();
         let bundle_path = dir.path().join("bundle.tar.gz");
@@ -2170,7 +2201,19 @@ paths = ["x"]
             c["name"] == "peer.10.0.0.9.session"
                 && c["status"] == "fail"
                 && c["detail"].as_str().unwrap().contains("in Connect")
+                && c["detail"]
+                    .as_str()
+                    .unwrap()
+                    .contains("Unsupported Capability")
+                && c["detail"].as_str().unwrap().contains("[REDACTED]")
         }));
+        let peers: serde_json::Value =
+            serde_json::from_str(find(&files, "peers/neighbors.json")).unwrap();
+        assert_eq!(
+            peers[0]["last_error"],
+            "sent NOTIFICATION 2/7 (Unsupported Capability)\n[REDACTED]"
+        );
+        assert!(!find(&files, "manifest.json").contains("must-not-escape"));
     }
 
     /// LAN-324 scope item 5: a seeded `md5_password` value and a bearer

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -46,6 +46,7 @@ pub async fn list(connection: Connection, json: bool, wide: bool) -> Result<(), 
                     messages_received: n.messages_received,
                     messages_sent: n.messages_sent,
                     flap_count: n.flap_count,
+                    last_error: n.last_error.clone(),
                     route_reflector_client: n.route_reflector_client,
                     description: cfg.map(|c| c.description.clone()).unwrap_or_default(),
                 }

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -213,6 +213,7 @@ pub struct JsonNeighbor {
     pub messages_received: u64,
     pub messages_sent: u64,
     pub flap_count: u64,
+    pub last_error: String,
     pub route_reflector_client: bool,
     pub description: String,
 }

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -6,6 +6,34 @@ use super::{
 };
 
 impl PeerSession {
+    /// Retain a bounded, secret-free reset cause for snapshots, without
+    /// replacing an actionable error during intentional local maintenance.
+    pub(super) fn record_notification_cause(
+        &mut self,
+        direction: SessionNotificationDirection,
+        notification: &rustbgpd_wire::NotificationMessage,
+    ) {
+        if direction == SessionNotificationDirection::Sent
+            && notification.code == NotificationCode::Cease
+            && matches!(
+                notification.subcode,
+                cease_subcode::ADMINISTRATIVE_SHUTDOWN | cease_subcode::ADMINISTRATIVE_RESET
+            )
+        {
+            return;
+        }
+        let direction = match direction {
+            SessionNotificationDirection::Sent => "sent",
+            SessionNotificationDirection::Received => "received",
+        };
+        self.last_error = format!(
+            "{direction} NOTIFICATION {}/{} ({})",
+            notification.code.as_u8(),
+            notification.subcode,
+            rustbgpd_wire::notification::description(notification.code, notification.subcode)
+        );
+    }
+
     /// Handle a hold-timer expiry observed by the select loop.
     ///
     /// ADR-0078 rule 3: pending unprocessed input counts as peer
@@ -171,6 +199,7 @@ impl PeerSession {
                 Action::SendNotification(notif) => {
                     let code = notif.code;
                     let subcode = notif.subcode;
+                    self.record_notification_cause(SessionNotificationDirection::Sent, &notif);
                     // RFC 8538: track outbound Hard Reset to bypass GR
                     if code == NotificationCode::Cease && subcode == cease_subcode::HARD_RESET {
                         self.sent_hard_reset = true;

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -408,7 +408,7 @@ impl PeerSession {
         self.trigger_outbound_out_of_resources_teardown();
     }
 
-    /// Emit Cease/8 and hard-close the writer without assigning a cause.
+    /// Emit Cease/8, record its bounded cause, and hard-close the writer.
     /// Callers must log their own truthful cause before entering this common
     /// primitive (writer saturation, exact-snapshot invariant breach, etc.).
     pub(super) fn trigger_outbound_out_of_resources_teardown(&mut self) {
@@ -424,6 +424,7 @@ impl PeerSession {
             cease_subcode::OUT_OF_RESOURCES,
             bytes::Bytes::new(),
         );
+        self.record_notification_cause(SessionNotificationDirection::Sent, &notif);
         // Classify the upcoming BMP Peer Down truthfully: reason 1
         // (local system sent NOTIFICATION) carrying the Cease/8 PDU,
         // instead of the reason-4 "remote closed" default.
@@ -579,7 +580,10 @@ impl PeerSession {
                                     Some(PeerDownReason::RemoteNotification(raw_pdu.clone()));
                             }
                             self.notifications_received += 1;
-                            self.last_error = format!("{}/{}", notif.code.as_u8(), notif.subcode);
+                            self.record_notification_cause(
+                                SessionNotificationDirection::Received,
+                                &notif,
+                            );
                             self.metrics.record_notification_received(
                                 &self.peer_label,
                                 &notif.code.as_u8().to_string(),

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -2274,6 +2274,81 @@ fn connect_failure_is_retained_for_neighbor_diagnostics() {
     session.record_connect_failure(&error);
     assert_eq!(session.last_error, error.to_string());
 }
+
+/// Mutant: removing the sent-cause assignment leaves this snapshot empty.
+#[tokio::test]
+async fn required_family_rejection_reports_descriptive_sent_notification() {
+    let mut config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    config.families = vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)];
+    config.required_families = vec![(Afi::Ipv6, Safi::Unicast)];
+    let mut session = make_test_session_with_peer_config(config);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    session.drive_fsm(Event::ManualStart).await;
+    session
+        .drive_fsm(Event::OpenReceived(rustbgpd_wire::OpenMessage {
+            version: 4,
+            my_as: 65002,
+            hold_time: 90,
+            bgp_identifier: Ipv4Addr::new(10, 0, 0, 2),
+            capabilities: vec![Capability::MultiProtocol {
+                afi: Afi::BgpLs,
+                safi: Safi::BgpLs,
+            }],
+        }))
+        .await;
+
+    let (reply, state) = oneshot::channel();
+    let _ = session
+        .handle_command(PeerCommand::QueryState { reply })
+        .await;
+    assert_eq!(
+        state.await.unwrap().last_error,
+        "sent NOTIFICATION 2/7 (Unsupported Capability)"
+    );
+}
+/// Mutant: restoring numeric-only receive state loses direction and description.
+#[tokio::test]
+async fn received_notification_reports_direction_and_description() {
+    let mut session = make_test_session(65001, 65002);
+    let notification = NotificationMessage::new(
+        NotificationCode::Cease,
+        cease_subcode::OUT_OF_RESOURCES,
+        Bytes::new(),
+    );
+    session.read_buf.buf.extend_from_slice(
+        &rustbgpd_wire::encode_message(&Message::Notification(notification)).unwrap(),
+    );
+    session.process_read_buffer().await;
+    assert_eq!(
+        session.last_error,
+        "received NOTIFICATION 6/8 (Out of Resources)"
+    );
+}
+/// Mutant: removing the sent-admin guard mislabels intentional local maintenance.
+#[test]
+fn administrative_notifications_keep_directional_maintenance_semantics() {
+    let mut session = make_test_session(65001, 65002);
+    session.last_error = "previous actionable failure".to_string();
+    for subcode in [
+        cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+        cease_subcode::ADMINISTRATIVE_RESET,
+    ] {
+        let notification = NotificationMessage::new(NotificationCode::Cease, subcode, Bytes::new());
+        session.record_notification_cause(SessionNotificationDirection::Sent, &notification);
+        assert_eq!(session.last_error, "previous actionable failure");
+    }
+    let reset = NotificationMessage::new(
+        NotificationCode::Cease,
+        cease_subcode::ADMINISTRATIVE_RESET,
+        Bytes::new(),
+    );
+    session.record_notification_cause(SessionNotificationDirection::Received, &reset);
+    assert_eq!(
+        session.last_error,
+        "received NOTIFICATION 6/4 (Administrative Reset)"
+    );
+}
 /// LAN-201: a partial repair attempt — `PeerDown` enqueued, `PeerUp` hits
 /// a full channel — leaves the latch set and retries. The collector-visible
 /// sequence carries a duplicate `PeerDown`, which is acceptable: RFC 7854
@@ -14006,8 +14081,8 @@ async fn rr_originator_loop_withdraws_mp_add_paths_before_gr_and_preserves_sibli
 /// invariants without trying to force kernel TCP buffer saturation
 /// from a unit test. Load-bearing idempotency proof: removing the live-writer
 /// guard makes the second trigger increment both notification counters and
-/// emit a second `SessionNotificationEvent`, even though its notification
-/// cannot reach the already-closed writer.
+/// emit a second `SessionNotificationEvent`, while removing the cause recorder
+/// loses the exact `last_error`; its notification cannot reach the closed writer.
 #[tokio::test]
 async fn outbound_saturation_teardown_emits_cease_out_of_resources() {
     use rustbgpd_wire::notification::{NotificationCode, cease_subcode};
@@ -14026,6 +14101,10 @@ async fn outbound_saturation_teardown_emits_cease_out_of_resources() {
     assert_eq!(
         session.notifications_sent, 1,
         "a duplicate saturation trigger must not invent another sent notification"
+    );
+    assert_eq!(
+        session.last_error,
+        "sent NOTIFICATION 6/8 (Out of Resources)"
     );
     let prometheus_count = counter_value(
         &session.metrics,


### PR DESCRIPTION
## Summary

- retain bounded directional descriptions for locally sent and received BGP NOTIFICATION reset causes
- preserve prior actionable errors across intentional local Administrative Shutdown/Reset while keeping peer-originated maintenance visible
- expose the redacted cause in neighbor-list JSON, doctor peer verdicts, and support-bundle neighbor snapshots
- cover the direct Cease/Out-of-Resources teardown while leaving healthy collision arbitration outside error state

## Load-bearing proof

Each production mutation was applied independently, observed red with exit 101, and restored:

- removing the local Action::SendNotification recorder empties the required-family 2/7 snapshot cause
- restoring numeric-only receive state loses direction and the Unsupported/Out-of-Resources description
- removing the local administrative guard overwrites a prior actionable error with planned maintenance
- removing the direct Cease/8 recorder empties the saturation-teardown cause
- removing doctor cause threading drops Unsupported Capability from the peer verdict
- bypassing doctor redaction exposes the seeded token line in peers/neighbors.json

## Verification

- focused required-family, received-notification, administrative-maintenance, Cease/8, and doctor-bundle tests
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps
- git diff --check

Independent exact-diff review returned GO. Final scope is six files and 179 changed lines.

Linear: LAN-552
