### PR TITLE
docs: repair route-server CLI examples

### DIFF
--- a/docs/adr/0096-policy-language.md
+++ b/docs/adr/0096-policy-language.md
@@ -180,7 +180,8 @@ verdicts only; XR profiles attached policies; Batfish is offline). We
 ship, in one verb:
 
 ```
-rbgp policy test my-policy.rpol --rib live --direction import --peer 10.0.0.1
+rbgp policy test my-policy.rpol --policy 'customer-in(200)' \
+  --direction import --neighbor 10.0.0.1
   → accepted / rejected / modified counts
   → per-term hit counters
   → sample before/after attribute diffs (--show-changes N)

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -203,7 +203,8 @@ on for `route_server_client` sessions** (the standard IXP posture),
 off otherwise, inheritable from a peer group. On sessions explicitly
 set off, control communities reach that member verbatim (full
 pass-through). Suppression shows up in
-`rbgp neighbor <ip> explain <prefix>` as the `rs_control` gate rung.
+`rbgp rib --prefix <prefix> advertised <addr> --explain` as the
+`rs_control` gate rung.
 
 Cost note: the filter is route-granular at emit (ADR-0101 Decision 3).
 Enabled sessions stay in shared update-groups; a distribution pass

--- a/examples/route-server/README.md
+++ b/examples/route-server/README.md
@@ -44,7 +44,7 @@ its generic deny, and test both the exception and an unauthorized control.
   path, the route server advertises the best *permitted* candidate instead
   of hiding the prefix — the BIRD-`secondary` equivalent. Trade-off: such
   peers are excluded from update-group sharing (visible as the
-  `per_client_best` reason in `rbgp neighbor show`).
+  `per_client_best` reason in `rbgp neighbor <addr>`).
 
 ## RFC 1997 `NO_EXPORT` and route-server transparency
 
@@ -65,7 +65,7 @@ rbgp policy check hygiene.rpol
 
 # Run, then inspect a member:
 rbgp neighbor 198.51.100.3                 # Distribution Mode: per-client-best
-rbgp rib advertised 198.51.100.3 --explain --prefix 203.0.113.0/24
+rbgp rib --prefix 203.0.113.0/24 advertised 198.51.100.3 --explain
 ```
 
 The explain output for a per-client-best member shows the ranked candidate


### PR DESCRIPTION
## Summary

- replace stale route-server neighbor/explain command forms with the shipped `rbgp rib --prefix ... advertised ... --explain` contract
- use the real neighbor-detail form instead of the nonexistent `neighbor show` pseudo-subcommand
- update the policy dry-run example to require `--policy`, the shipped direction, and neighbor selector

## Load-bearing proof

Docs-only mutation proof is N/A. Branch-built parser receipts prove each corrected command passes Clap and reaches the deliberately absent daemon socket; the stale option-order and planned `--rib live` spellings fail at Clap, while `neighbor show` is incorrectly interpreted as peer address `show`.

## Verification

- exact parser accept/reject receipts with branch-built `target/debug/rbgp`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- `git diff --check`

Independent exact-diff review returned GO. Final scope is three documentation files and 10 changed lines.

Linear: LAN-551