### PR TITLE
fix: keep critical CLI examples parse-valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **GShut receiver verification is executable from `rbgp`.** The runbook uses
+  the parse-valid received-RIB command, whose JSON now exposes optional
+  `local_pref_attr` so operators can distinguish an explicit demotion to zero.
+
 - **RFC-correct RT/RO policy action encoding.** TOML
   `set_community_add` / `set_community_remove` and `.rpol` `add` / `remove`
   actions now share the same typed encoder: numeric ASNs through 65535 use RFC

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ test as-set-is-rejected {
 
 Then ask the daemon *what would happen* — before you commit anything:
 
+<!-- rbgp-cli-conformance -->
 ```bash
 rbgp policy check hygiene.rpol      # offline: compile + run the in-language tests
 rbgp policy test hygiene.rpol --policy ixp-hygiene --direction import

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -709,12 +709,18 @@ impl Serialize for JsonRouteRef<'_> {
         if route.llgr_stale {
             len += 1;
         }
+        if route.local_pref_attr.is_some() {
+            len += 1;
+        }
 
         let mut map = serializer.serialize_map(Some(len))?;
         map.serialize_entry("prefix", &JsonRoutePrefix(route))?;
         map.serialize_entry("next_hop", &route.next_hop)?;
         map.serialize_entry("as_path", &route.as_path)?;
         map.serialize_entry("local_pref", &route.local_pref)?;
+        if let Some(local_pref) = route.local_pref_attr {
+            map.serialize_entry("local_pref_attr", &local_pref)?;
+        }
         match route.med_attr {
             Some(med) => map.serialize_entry("med", &med)?,
             None if self.med_attr_supported => map.serialize_entry("med", &None::<u32>)?,
@@ -2707,6 +2713,20 @@ mod tests {
             serde_json::to_value(JsonRoutes(&[with_med, zero_med])).unwrap();
         assert_eq!(value[0]["med"], 50);
         assert_eq!(value[1]["med"], 0);
+    }
+
+    #[test]
+    fn route_list_json_exposes_explicit_local_pref_presence() {
+        let mut explicit_zero = route_for_json(0, "");
+        explicit_zero.local_pref = 0;
+        explicit_zero.local_pref_attr = Some(0);
+        let mut absent = route_for_json(0, "");
+        absent.local_pref = 0;
+        let value: serde_json::Value =
+            serde_json::to_value(JsonRoutes(&[explicit_zero, absent])).unwrap();
+
+        assert_eq!(value[0]["local_pref_attr"], 0);
+        assert!(value[1].get("local_pref_attr").is_none());
     }
 
     /// GR stale flags serialize only when set, matching the VPN /

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3012,6 +3012,107 @@ mod tests {
     use clap::Parser;
 
     #[test]
+    fn curated_documentation_commands_parse_with_the_real_cli() {
+        const MARKER: &str = "<!-- rbgp-cli-conformance -->";
+        const DOCUMENTS: &[(&str, usize)] = &[
+            ("README.md", 4),
+            ("docs/QUICKSTART.md", 5),
+            ("docs/cookbook/route-server.md", 3),
+            ("docs/explain.md", 5),
+            ("docs/OPERATIONS.md", 2),
+        ];
+
+        let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        for (relative_path, expected_commands) in DOCUMENTS {
+            let contents = std::fs::read_to_string(repository.join(relative_path))
+                .unwrap_or_else(|error| panic!("failed to read {relative_path}: {error}"));
+            let lines: Vec<_> = contents.lines().collect();
+            let markers: Vec<_> = lines
+                .iter()
+                .enumerate()
+                .filter(|(_, line)| line.trim() == MARKER)
+                .map(|(index, _)| index)
+                .collect();
+            assert_eq!(
+                markers.len(),
+                1,
+                "{relative_path} must contain exactly one curated CLI block"
+            );
+            assert!(
+                lines
+                    .get(markers[0] + 1)
+                    .is_some_and(|line| line.trim().starts_with("```")),
+                "{relative_path} conformance marker must immediately precede its code fence"
+            );
+
+            let mut in_fence = false;
+            let mut parsed = 0;
+            for (offset, line) in lines[(markers[0] + 1)..].iter().enumerate() {
+                let trimmed = line.trim();
+                if trimmed.starts_with("```") {
+                    if in_fence {
+                        break;
+                    }
+                    in_fence = true;
+                    continue;
+                }
+                if !in_fence {
+                    continue;
+                }
+
+                let command = trimmed.strip_prefix("$ ").unwrap_or(trimmed);
+                if !command.starts_with("rbgp ") {
+                    continue;
+                }
+                assert!(
+                    !command.ends_with('\\'),
+                    "{relative_path}:{} curated rbgp command must stay on one line",
+                    markers[0] + offset + 2
+                );
+                let command = command
+                    .split_once(" #")
+                    .map_or(command, |(command, _)| command);
+                let piped_to_jq = command.contains(" | jq ");
+                // Shell comments and pipelines remain documentation; this gate
+                // parses only the rbgp argv and never executes either suffix.
+                let command = command
+                    .split_once(" |")
+                    .map_or(command, |(command, _)| command);
+                if piped_to_jq {
+                    assert!(
+                        command
+                            .split_whitespace()
+                            .any(|arg| arg == "--json" || arg == "-j"),
+                        "{relative_path}:{} pipes rbgp output to jq without selecting JSON",
+                        markers[0] + offset + 2
+                    );
+                }
+                let arguments: Vec<_> = command
+                    .split_whitespace()
+                    .map(|argument| match argument {
+                        "<draining-peer>" | "<receiving-peer>" => "192.0.2.1",
+                        _ if argument.starts_with('<') && argument.ends_with('>') => {
+                            panic!("{relative_path}: add an explicit normalization for {argument}")
+                        }
+                        _ => argument,
+                    })
+                    .collect();
+                Cli::try_parse_from(arguments).unwrap_or_else(|error| {
+                    panic!(
+                        "{relative_path}:{} does not parse as documented:\n{command}\n{error}",
+                        markers[0] + offset + 2
+                    )
+                });
+                parsed += 1;
+            }
+            assert_eq!(
+                parsed, *expected_commands,
+                "{relative_path} curated command set changed; review the block and update its count"
+            );
+        }
+    }
+
+    #[test]
     fn v1_stable_cli_command_inventory_matches_clap_tree() {
         let inventory_path = concat!(
             env!("CARGO_MANIFEST_DIR"),

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1970,14 +1970,14 @@ The community is attached on the wire by the per-peer transport layer
 initiator side — the RIB doesn't know about the toggle. The
 authoritative checks are:
 
+<!-- rbgp-cli-conformance -->
 ```bash
 # Receiver-side: routes from a draining peer that honor the community
 # show explicit local_pref_attr = 0 in the RIB (proves the implicit
 # chain-tail rule fired). EBGP-received routes have no LOCAL_PREF on
 # the wire, so look at local_pref_attr (explicit) rather than
 # local_pref (proto3 default).
-rbgp rib --neighbor <draining-peer> \
-    | jq '.routes[] | {prefix, localPrefAttr, communities}'
+rbgp --json rib received <draining-peer> | jq '.[] | {prefix, local_pref_attr, communities}'
 
 # Initiator-side: confirm the local desired advertisement state.
 rbgp neighbor <receiving-peer> | grep 'GShut Advertise Intent: enabled'

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -81,6 +81,7 @@ rustbgpd config.toml
 The minimal example uses `/tmp/rustbgpd` as its runtime state directory, so point
 the CLI at that socket:
 
+<!-- rbgp-cli-conformance -->
 ```bash
 export RUSTBGPD_ADDR=unix:///tmp/rustbgpd/grpc.sock
 

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -236,6 +236,7 @@ $ rbgp neighbor 198.51.100.3             # Distribution Mode: per-client-best
 
 Transparency and per-member views:
 
+<!-- rbgp-cli-conformance -->
 ```console
 $ rbgp rib recv 198.51.100.2             # what a member sent us
 $ rbgp rib sent 198.51.100.3             # what that member sees back

--- a/docs/explain.md
+++ b/docs/explain.md
@@ -141,6 +141,7 @@ member-support workflow around this view is in the
 
 "Member AS64500 says their prefix isn't visible." In order:
 
+<!-- rbgp-cli-conformance -->
 ```bash
 # 1. Is the session even up, and are we retaining anything from them?
 rbgp summary


### PR DESCRIPTION
## Summary

Fixes the GShut receiver verification command end to end and adds a small real-Clap fence around 19 critical copy/paste CLI examples. The corrected recipe now selects JSON, uses the actual top-level array/snake-case shape, and can distinguish explicit LOCAL_PREF 0 from attribute absence.

## Changes

- replace the invalid `rbgp rib --neighbor` recipe with `rbgp --json rib received` and a truthful jq query
- expose optional `local_pref_attr` in route-list JSON only when the proto field is present
- mark five curated documentation blocks and parse their 19 rbgp commands through `Cli::try_parse_from`
- fail closed on marker/count drift, multiline commands, unknown placeholders, invalid flags/subcommands, and jq pipelines without JSON
- add an Unreleased changelog note

## Testing

- [x] cargo test --workspace passes (including 422 rbgp binary tests)
- [x] cargo clippy --workspace --all-targets -- -D warnings clean
- [x] cargo fmt --all -- --check clean
- [x] RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps clean
- [x] Relevant interop test intentionally not applicable: CLI serialization/docs only
- [x] Performance receipt intentionally not applicable

Load-bearing mutation proof:

- restoring `rib --neighbor` makes the curated gate RED on unexpected `--neighbor`
- changing a separate tagged `rbgp bfd` command to `rbgp bfdd` makes it RED on an unknown subcommand
- removing `--json` from the jq pipeline makes it RED before parsing
- splitting a tagged command with a backslash makes it RED on the single-line grammar
- removing `local_pref_attr` serialization makes the focused presence test RED (`0` becomes null)

Every mutation was restored and both focused tests plus the full quartet re-ran green.

## Docs / release notes

- [x] CHANGELOG.md updated
- [x] ROADMAP.md intentionally not needed
- [x] Operator docs updated
- [x] Hot tracking docs not touched

## Related issues

LAN-554