### PR TITLE
ci: deduplicate pull request workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 name: CI
 
+# Feature branches without a PR must use a draft PR or the local quartet;
+# hosted push CI is intentionally main-only to avoid duplicating PR runs.
 on:
   push:
+    branches: [main]
     paths-ignore:
       - "**/*.md"
   pull_request:
@@ -21,6 +24,23 @@ jobs:
           # Need history so the wire-readme freshness gate can diff
           # against the previous commit / PR base.
           fetch-depth: 0
+      - name: Check CI trigger contract
+        shell: bash
+        run: |
+          actual="$(sed -n '/^on:/,/^jobs:/p' .github/workflows/ci.yml | sed '$d')"
+          expected='on:
+            push:
+              branches: [main]
+              paths-ignore:
+                - "**/*.md"
+            pull_request:
+              paths-ignore:
+                - "**/*.md"'
+          if [[ "$actual" != "$expected" ]]; then
+            diff -u <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") || true
+            echo "CI triggers must keep main-only pushes, all PRs, and Markdown ignores" >&2
+            exit 1
+          fi
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy


### PR DESCRIPTION
## Summary

- restrict CI push events to `main` while preserving CI for every pull request
- keep the existing Markdown-only path ignores on both event paths
- add a focused trigger-contract check so removing the main-only filter makes CI fail
- document that feature branches without a PR use a draft PR or the local quartet

Tracks LAN-556.

## Evidence

PR #1091 created duplicate push and pull-request CI runs for the same branch and SHA. Recent successful PR CI runs have roughly 12-minute median wall time, so the duplicate consumes another full run of compute and cache pressure. Interop and Kernel Dataplane already use main-only push triggers.

ClusterFuzzLite is already manual-only and is not on the ordinary PR merge path.

## Verification

- scoped actionlint 1.7.7
- YAML event-matrix assertion
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `git diff --check`

## Load-bearing proof

Removing only `branches: [main]` makes the trigger-contract check exit 1 and show the missing line. The restored workflow passes the same check.