### PR TITLE
fix: validate BGP OPEN identities

### DIFF
--- a/crates/fsm/src/negotiation.rs
+++ b/crates/fsm/src/negotiation.rs
@@ -62,9 +62,18 @@ pub fn validate_open(
             Bytes::new(),
         ));
     }
-
-    // Determine peer's true ASN: prefer 4-octet capability, fall back to my_as
+    // Determine peer's true ASN: prefer 4-octet capability, fall back to my_as.
     let peer_asn = open.four_byte_as();
+
+    // RFC 7607 section 2: AS 0 is never a valid peer identity. Check both
+    // OPEN representations before the dynamic-neighbor wildcard below.
+    if open.my_as == 0 || peer_asn == 0 {
+        return Err(NotificationMessage::new(
+            NotificationCode::OpenMessage,
+            open_subcode::BAD_PEER_AS,
+            Bytes::new(),
+        ));
+    }
 
     // Verify peer ASN matches our configuration.
     // remote_asn == 0 is the dynamic-neighbor sentinel: accept any ASN from OPEN.
@@ -72,6 +81,15 @@ pub fn validate_open(
         return Err(NotificationMessage::new(
             NotificationCode::OpenMessage,
             open_subcode::BAD_PEER_AS,
+            Bytes::new(),
+        ));
+    }
+
+    // RFC 6286 section 2.2: equal identifiers are invalid only for iBGP.
+    if peer_asn == config.local_asn && open.bgp_identifier == config.local_router_id {
+        return Err(NotificationMessage::new(
+            NotificationCode::OpenMessage,
+            open_subcode::BAD_BGP_IDENTIFIER,
             Bytes::new(),
         ));
     }
@@ -650,6 +668,30 @@ mod tests {
     }
 
     #[test]
+    fn reject_zero_peer_asn_before_dynamic_neighbor_wildcard() {
+        // Mutation-red: removing the AS 0 guard lets every case negotiate.
+        let mut cfg = test_config();
+        cfg.remote_asn = 0;
+
+        let mut legacy = peer_open();
+        legacy.my_as = 0;
+        legacy.capabilities.clear();
+
+        let mut four_octet = peer_open();
+        four_octet.my_as = rustbgpd_wire::constants::AS_TRANS;
+        four_octet.capabilities = vec![Capability::FourOctetAs { asn: 0 }];
+
+        let mut inconsistent = peer_open();
+        inconsistent.my_as = 0;
+
+        for open in [legacy, four_octet, inconsistent] {
+            let err = validate_open(&open, &cfg).unwrap_err();
+            assert_eq!(err.code, NotificationCode::OpenMessage);
+            assert_eq!(err.subcode, open_subcode::BAD_PEER_AS);
+        }
+    }
+
+    #[test]
     fn remote_asn_zero_accepts_any_peer_asn() {
         let mut cfg = test_config();
         cfg.remote_asn = 0; // dynamic-neighbor sentinel
@@ -658,6 +700,49 @@ mod tests {
         open.capabilities = vec![Capability::FourOctetAs { asn: 65099 }];
         let neg = validate_open(&open, &cfg).unwrap();
         assert_eq!(neg.peer_asn, 65099);
+    }
+
+    #[test]
+    fn reject_ibgp_peer_with_local_bgp_identifier() {
+        // Mutation-red: removing the iBGP duplicate-ID guard negotiates this OPEN.
+        let mut cfg = test_config();
+        cfg.remote_asn = cfg.local_asn;
+        let mut open = peer_open();
+        open.my_as = u16::try_from(cfg.local_asn).unwrap();
+        open.capabilities = vec![Capability::FourOctetAs { asn: cfg.local_asn }];
+        open.bgp_identifier = cfg.local_router_id;
+
+        let err = validate_open(&open, &cfg).unwrap_err();
+        assert_eq!(err.code, NotificationCode::OpenMessage);
+        assert_eq!(err.subcode, open_subcode::BAD_BGP_IDENTIFIER);
+    }
+
+    #[test]
+    fn ebgp_peer_may_share_local_bgp_identifier() {
+        // Mutation-red: making the duplicate-ID guard unconditional rejects this OPEN.
+        let cfg = test_config();
+        let mut open = peer_open();
+        open.bgp_identifier = cfg.local_router_id;
+
+        let negotiated = validate_open(&open, &cfg).unwrap();
+        assert_eq!(negotiated.peer_router_id, cfg.local_router_id);
+    }
+
+    #[test]
+    fn unusual_nonzero_bgp_identifiers_are_accepted() {
+        // Mutation-red: imposing IPv4 address-shape rules rejects at least one value.
+        let cfg = test_config();
+        for identifier in [
+            Ipv4Addr::new(0, 0, 0, 1),
+            Ipv4Addr::LOCALHOST,
+            Ipv4Addr::new(224, 0, 0, 1),
+            Ipv4Addr::BROADCAST,
+        ] {
+            let mut open = peer_open();
+            open.bgp_identifier = identifier;
+            let negotiated = validate_open(&open, &cfg).unwrap();
+            assert_eq!(negotiated.peer_router_id, identifier);
+        }
     }
 
     #[test]

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -228,6 +228,8 @@ pub enum SessionNotification {
         peer_addr: IpAddr,
         /// Router ID from the peer's OPEN message.
         remote_router_id: Ipv4Addr,
+        /// Peer ASN from OPEN negotiation, including a four-octet capability.
+        peer_asn: u32,
     },
     /// Session fell back to Idle.
     BackToIdle {

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -313,6 +313,7 @@ impl PeerSession {
                                 role: self.session_identity.role,
                                 peer_addr: self.peer_ip,
                                 remote_router_id: neg.peer_router_id,
+                                peer_asn: neg.peer_asn,
                             })
                         {
                             warn!(

--- a/crates/transport/tests/session_lifecycle.rs
+++ b/crates/transport/tests/session_lifecycle.rs
@@ -745,10 +745,14 @@ async fn lifecycle_only_channel_receives_collision_adjacent_state_changes() {
 
 #[tokio::test]
 async fn open_confirm_sends_session_notification() {
+    // Mutation-red: narrowing the negotiated peer ASN to the OPEN's AS_TRANS
+    // value makes the identity assertion below observe 23456 instead.
     // Verify that reaching OpenConfirm sends SessionNotification::OpenReceived
-    // with the correct remote_router_id. This exercises the fix for the bug
-    // where self.negotiated (set at Established) was read instead of
-    // self.fsm.negotiated() (set at OpenConfirm).
+    // with the lossless four-octet peer identity. This exercises the fix for
+    // the bug where self.negotiated (set at Established) was read instead of
+    // self.fsm.negotiated() (set at OpenConfirm), and keeps collision handling
+    // from falling back to a configured dynamic-neighbor wildcard.
+    const FOUR_OCTET_REMOTE_ASN: u32 = 4_200_000_001;
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let metrics = BgpMetrics::new();
@@ -756,8 +760,10 @@ async fn open_confirm_sends_session_notification() {
     let (notify_tx, mut notify_rx) = mpsc::unbounded_channel::<SessionNotification>();
 
     let (rib_tx, _rib_rx) = mpsc::channel::<RibUpdate>(64);
+    let mut config = transport_config(addr);
+    config.peer.remote_asn = FOUR_OCTET_REMOTE_ASN;
     let handle = PeerHandle::spawn(
-        transport_config(addr),
+        config,
         metrics.clone(),
         rib_tx,
         None,
@@ -779,7 +785,12 @@ async fn open_confirm_sends_session_notification() {
 
     // Send our OPEN — this should cause rustbgpd to transition to OpenConfirm
     // and send a SessionNotification::OpenReceived
-    send_bgp_message(&mut peer_stream, &Message::Open(mock_open())).await;
+    let mut open = mock_open();
+    open.my_as = rustbgpd_wire::constants::AS_TRANS;
+    open.capabilities = vec![Capability::FourOctetAs {
+        asn: FOUR_OCTET_REMOTE_ASN,
+    }];
+    send_bgp_message(&mut peer_stream, &Message::Open(open)).await;
 
     // The OpenReceived notification should arrive before Established (no
     // KEEPALIVE sent yet). Ordinary StateChanged events use the bounded
@@ -797,12 +808,18 @@ async fn open_confirm_sends_session_notification() {
 
     match notification {
         SessionNotification::OpenReceived {
-            remote_router_id, ..
+            remote_router_id,
+            peer_asn,
+            ..
         } => {
             assert_eq!(
                 remote_router_id,
                 Ipv4Addr::new(10, 0, 0, 2),
                 "should have remote router-id from OPEN"
+            );
+            assert_eq!(
+                peer_asn, FOUR_OCTET_REMOTE_ASN,
+                "collision notification must carry the lossless negotiated ASN"
             );
         }
         other => panic!("expected OpenReceived, got {other:?}"),

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -126,8 +126,8 @@ Required. Defines the local BGP speaker identity.
 
 | Field               | Type   | Required | Default              | Description                        |
 |---------------------|--------|----------|----------------------|------------------------------------|
-| `asn`               | u32    | yes      | --                   | Local autonomous system number     |
-| `router_id`         | string | yes      | --                   | BGP router ID (must be valid IPv4) |
+| `asn`               | u32    | yes      | --                   | Local autonomous system number; AS 0 is rejected at startup |
+| `router_id`         | string | yes      | --                   | Non-zero BGP Identifier in IPv4 dotted-quad form; `0.0.0.0` is rejected at startup |
 | `listen_port`       | u16    | yes      | --                   | TCP port to listen on (typically 179) |
 | `dynamic_neighbor_limit` | u32 | no     | `100`                | Maximum number of auto-accepted dynamic peers (1--5000) |
 | `worker_threads`    | usize  | no       | `min(cores, 8)`      | Tokio runtime worker threads. Unset caps to `min(CPU parallelism, 8)` to avoid over-provisioning the async runtime (one worker + stack reservation per core) on a high-core host for this I/O-bound daemon — reduces virtual-address reservation and scheduler footprint (RSS-neutral in benchmarks). `0` means unset. `RUSTBGPD_WORKER_THREADS` overrides. **Restart-required** (runtime built once at startup). |
@@ -140,6 +140,9 @@ Required. Defines the local BGP speaker identity.
 | `allow_blackhole_broad_prefixes` | bool | no | `false`           | Permit non-host BLACKHOLE discard installs when the FIB slice is enabled |
 | `multipath_relax`   | bool   | no       | `false`              | ADR-0066 multipath-relax: group unicast ECMP candidates by `AS_PATH` *length* instead of an exact `AS_PATH` match (FRR's `bgp bestpath as-path multipath-relax`). Best-path-wide; inert unless a `[[fib_tables]]` sets `maximum_paths`, `maximum_paths_ebgp`, or `maximum_paths_ibgp` above `1` |
 | `link_bandwidth_weighted` | bool | no   | `false`              | ADR-0068 weighted multipath: weight unicast ECMP next-hops by the lowest finite nonnegative RFC 10005 Link Bandwidth value when the whole equal-cost group carries a positive one; zero, missing, or unusable values fall back to equal cost. Best-path-wide; inert unless a `[[fib_tables]]` sets `maximum_paths`, `maximum_paths_ebgp`, or `maximum_paths_ibgp` above `1` |
+
+Startup validation rejects local AS 0 (RFC 7607 §2) and BGP Identifier zero
+(RFC 6286 §2.1) before any listener or peer session starts.
 
 ```toml
 [global]
@@ -3614,7 +3617,8 @@ starting:
 
 | Rule | Error |
 |------|-------|
-| `router_id` must be a valid IPv4 address | `invalid router_id` |
+| Local `asn` must not be AS 0 | `invalid local ASN` |
+| `router_id` must be a valid IPv4 dotted quad and must not be `0.0.0.0` | `invalid router_id` |
 | Each `address` in `[[neighbors]]` must be a valid IP address (IPv4 or IPv6) | `invalid neighbor address` |
 | IPv6 link-local `[[neighbors]]` must set `interface`; numbered neighbors must not | `invalid neighbor config` |
 | `[[neighbors]]` identity must be unique by address for numbered peers and by `(address, interface)` for IPv6 link-local peers | `duplicate neighbor address/interface` |

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -184,8 +184,12 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
   hold times. If the negotiated value is non-zero and less than 3 seconds,
   send NOTIFICATION (2, 6) — Unacceptable Hold Time. Zero means no
   keepalives (supported but discouraged in config docs).
-- **BGP Identifier:** Validated as a valid IPv4 address (non-zero,
-  non-multicast). Collision detection per §6.8.
+- **BGP Identifier:** RFC 6286 defines this as any non-zero unsigned 32-bit
+  integer rendered in dotted-quad form; multicast, loopback, and other
+  non-unicast-shaped values are valid. Zero and an iBGP peer using the local
+  identifier get Bad BGP Identifier. Equal identifiers are allowed for eBGP;
+  during a connection collision, the connection initiated by the speaker with
+  the larger AS number is preserved, including for four-octet ASNs (§2.3).
 - **Version:** Only BGP-4 (version 4). Any other version gets
   NOTIFICATION (2, 1) — Unsupported Version Number, with data field
   containing the supported version (4).
@@ -251,7 +255,10 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 - If an OPEN is received from a peer with the same BGP Identifier as
   an existing session, the collision resolution procedure applies:
   compare local and remote BGP Identifiers as unsigned 32-bit integers.
-  The connection initiated by the higher ID is kept.
+  The connection initiated by the higher ID is kept. If the identifiers
+  are equal for an eBGP collision, RFC 6286 §2.3 keeps the connection
+  initiated by the speaker with the larger AS number, including a
+  four-octet AS number.
 
 ### §8 — Finite State Machine
 

--- a/docs/adr/0021-tcp-collision-detection.md
+++ b/docs/adr/0021-tcp-collision-detection.md
@@ -9,7 +9,9 @@ RFC 4271 §6.8 requires that when both sides of a BGP session initiate TCP
 connections simultaneously, the collision must be resolved by comparing BGP
 Identifiers (router-ids). The side with the higher identifier keeps its
 initiated connection; the other side closes its connection with a Cease/7
-(Connection Collision Resolution) NOTIFICATION.
+(Connection Collision Resolution) NOTIFICATION. RFC 6286 §2.3 adds the eBGP
+tie-break for equal identifiers: preserve the connection initiated by the
+speaker with the larger AS number.
 
 The existing code dropped all inbound connections when the outbound was
 active, without comparing router-ids and without sending Cease/7. This
@@ -47,21 +49,23 @@ Cease subcode 7 (`CONNECTION_COLLISION_RESOLUTION`) added to
 ### Transport
 
 `SessionNotification` enum sent from peer sessions to PeerManager:
-- `OpenReceived { peer_addr, session_id, role, remote_router_id }` —
-  session entered OpenConfirm, remote router-id now available.
+- `OpenReceived { peer_addr, session_id, role, remote_router_id, peer_asn }` —
+  session entered OpenConfirm with the lossless negotiated router-id and peer
+  ASN available, including a four-octet ASN learned from the capability.
 - `BackToIdle { peer_addr, session_id, role }` — session fell back to
   Idle (connection failed or was torn down).
 
 `CollisionDump` command added to `PeerCommand` — sends Cease/7
 NOTIFICATION, cleans up RIB if Established, closes TCP.
 
-`remote_router_id: Option<Ipv4Addr>` added to `PeerSessionState` for
-queries during OpenConfirm state.
+`remote_router_id: Option<Ipv4Addr>` and `peer_asn: Option<u32>` in
+`PeerSessionState` carry the negotiated identity for queries during
+OpenConfirm state.
 
 Both `PeerHandle::spawn()` and `PeerHandle::spawn_inbound()` accept an
-optional `mpsc::Sender<SessionNotification>` parameter plus a
+optional `mpsc::UnboundedSender<SessionNotification>` parameter plus a
 monotonically allocated session id and role (`Primary` or
-`PendingInbound`).
+`InboundCandidate`).
 
 ### PeerManager
 
@@ -71,7 +75,11 @@ This supersedes the original parked-`TcpStream` sketch: holding an
 unstarted stream can deadlock simultaneous active-open because the
 candidate never progresses far enough to reveal the remote BGP Identifier.
 
-`session_notify_tx/rx` channel (capacity 64) created in `PeerManager::new()`.
+`session_notify_tx/rx` is created with `mpsc::unbounded_channel()` in
+`PeerManager::new()`. This collision-coordination lane is intentionally
+unbounded so its lossless notifications neither drop under backpressure nor
+block a session task and deadlock with `QueryState`; its event rate is bounded
+by session state transitions, not route volume.
 
 `run()` uses `tokio::select!` on both the command channel and the
 notification channel.
@@ -82,9 +90,9 @@ Inbound connection handling by existing session state:
 - **Connect/Active/OpenSent** → spawn a live `pending_inbound`
   candidate session, wait for an `OpenReceived` notification from either
   the current primary or the candidate.
-- **OpenConfirm** → resolve immediately (router-id available from
-  the current primary's state, or once the candidate reports its
-  OpenConfirm).
+- **OpenConfirm** → resolve immediately (negotiated router-id and peer ASN
+  available from the current primary's state, or once the candidate reports
+  its OpenConfirm).
 
 `resolve_collision()` compares `u32::from(local_router_id)` vs
 `u32::from(remote_router_id)`:
@@ -92,7 +100,11 @@ Inbound connection handling by existing session state:
   the current primary).
 - Local < remote → send `CollisionDump` to the current primary, promote
   the inbound candidate atomically.
-- Equal → drop inbound (degenerate case).
+- Equal identifiers on eBGP → compare the local and negotiated peer ASNs;
+  preserve the connection initiated by the larger-AS speaker per RFC 6286
+  §2.3.
+- Equal identifiers and ASNs → drop inbound defensively. Equal identifiers
+  on iBGP are rejected during OPEN negotiation before collision resolution.
 
 `BackToIdle` notification from the current primary with a pending inbound
 candidate → promote the pending candidate. `BackToIdle` or `OpenReceived`
@@ -108,7 +120,8 @@ No changes. Collision detection is a transport/PeerManager concern.
 ## Consequences
 
 **Positive:**
-- RFC 4271 §6.8 compliance — simultaneous-open scenarios resolve correctly.
+- RFC 4271 §6.8 and RFC 6286 §2.3 compliance — simultaneous-open scenarios,
+  including equal-identifier eBGP peers, resolve correctly.
 - Cease/7 NOTIFICATION sent per spec — remote peer knows why connection
   was closed.
 - FSM stays pure — no collision-aware logic added.
@@ -122,5 +135,5 @@ No changes. Collision detection is a transport/PeerManager concern.
 - PeerManager `run()` now has two select branches — slightly more complex.
 - `pending_inbound` live session held until resolution — bounded by the
   number of configured peers and drained on peer disable / shutdown.
-- Notification channel adds a small per-session overhead (one try_send per
-  state change to OpenConfirm or Idle).
+- The unbounded notification lane adds a small per-session overhead and relies
+  on the session-transition-bounded event rate described above.

--- a/src/config/diagnostic.rs
+++ b/src/config/diagnostic.rs
@@ -33,8 +33,11 @@ fn error_span_and_label(source: &str, error: &ConfigError) -> Option<(Range<usiz
                 .unwrap_or_else(|| e.message().to_string());
             Some((span, label))
         }
-        ConfigError::InvalidRouterId { .. } => {
-            lookup_value_span(source, &["global", "router_id"], "not a valid IPv4 address")
+        ConfigError::InvalidLocalAsn { .. } => {
+            lookup_value_span(source, &["global", "asn"], "AS 0 is reserved")
+        }
+        ConfigError::InvalidRouterId { reason, .. } => {
+            lookup_value_span(source, &["global", "router_id"], reason)
         }
         ConfigError::InvalidNeighborAddress { value, reason } => {
             find_neighbor_field_span(source, value, "address", reason)
@@ -483,6 +486,50 @@ log_format = \"text\"
         };
         let rendered = render_diagnostic(source, "config.toml", &error).unwrap();
         assert!(rendered.contains("not-an-ip"), "got: {rendered}");
+        assert!(rendered.contains('^'), "got: {rendered}");
+    }
+
+    #[test]
+    fn render_local_as_zero_points_to_global_asn() {
+        // Mutation-red: removing the InvalidLocalAsn span mapping returns None.
+        let source = "\
+[global]
+asn = 0
+router_id = \"1.2.3.4\"
+listen_port = 179
+";
+        let error = ConfigError::InvalidLocalAsn { value: 0 };
+        let rendered = render_diagnostic(source, "config.toml", &error).unwrap();
+        assert!(rendered.contains("asn = 0"), "got: {rendered}");
+        assert!(rendered.contains("AS 0 is reserved"), "got: {rendered}");
+        assert!(rendered.contains('^'), "got: {rendered}");
+    }
+
+    #[test]
+    fn render_local_router_id_zero_explains_nonzero_requirement() {
+        // Mutation-red: restoring the generic IPv4 label hides the actual constraint.
+        let source = "\
+[global]
+asn = 65000
+router_id = \"0.0.0.0\"
+listen_port = 179
+";
+        let error = ConfigError::InvalidRouterId {
+            value: "0.0.0.0".to_string(),
+            reason: "must be non-zero (RFC 6286 section 2.1)".to_string(),
+        };
+        let rendered = render_diagnostic(source, "config.toml", &error).unwrap();
+        assert!(
+            rendered.contains("router_id = \"0.0.0.0\""),
+            "got: {rendered}"
+        );
+        assert!(
+            rendered
+                .lines()
+                .last()
+                .is_some_and(|line| line.ends_with("must be non-zero (RFC 6286 section 2.1)")),
+            "the source underline must carry the actual constraint: {rendered}"
+        );
         assert!(rendered.contains('^'), "got: {rendered}");
     }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -2256,6 +2256,8 @@ pub enum ConfigError {
     Io(#[from] std::io::Error),
     #[error("failed to parse TOML: {0}")]
     Parse(#[from] toml::de::Error),
+    #[error("invalid local ASN {value}: AS 0 is reserved (RFC 7607 section 2)")]
+    InvalidLocalAsn { value: u32 },
     #[error("invalid router_id {value:?}: {reason}")]
     InvalidRouterId { value: String, reason: String },
     #[error("invalid neighbor address {value:?}: {reason}")]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1147,6 +1147,23 @@ fn invalid_router_id_rejected() {
 }
 
 #[test]
+fn local_as_zero_is_rejected() {
+    // Mutation-red: removing the global ASN predicate makes this fixture parse.
+    let toml_str = valid_toml().replace("asn = 65001", "asn = 0");
+    let err = parse(&toml_str).unwrap_err();
+    assert!(matches!(err, ConfigError::InvalidLocalAsn { value: 0 }));
+}
+
+#[test]
+fn local_router_id_zero_is_rejected() {
+    // Mutation-red: removing the non-zero router-ID predicate makes this fixture parse.
+    let toml_str = valid_toml().replace("router_id = \"10.0.0.1\"", "router_id = \"0.0.0.0\"");
+    let err = parse(&toml_str).unwrap_err();
+    assert!(matches!(err, ConfigError::InvalidRouterId { .. }));
+    assert!(err.to_string().contains("must be non-zero"));
+}
+
+#[test]
 fn invalid_neighbor_address_rejected() {
     let toml_str = valid_toml().replace("10.0.0.2", "bad-addr");
     let err = parse(&toml_str).unwrap_err();

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -67,14 +67,25 @@ pub(crate) fn effective_prefix_str(prefix: &str) -> Option<(IpAddr, u8)> {
 impl Config {
     #[expect(clippy::too_many_lines)]
     pub(crate) fn validate(&self) -> Result<(), ConfigError> {
-        // Validate router_id is a valid IPv4
-        self.global
-            .router_id
-            .parse::<Ipv4Addr>()
-            .map_err(|e| ConfigError::InvalidRouterId {
+        if self.global.asn == 0 {
+            return Err(ConfigError::InvalidLocalAsn {
+                value: self.global.asn,
+            });
+        }
+
+        // RFC 6286 section 2.1: the router ID is any non-zero u32.
+        let router_id = self.global.router_id.parse::<Ipv4Addr>().map_err(|e| {
+            ConfigError::InvalidRouterId {
                 value: self.global.router_id.clone(),
                 reason: e.to_string(),
-            })?;
+            }
+        })?;
+        if router_id.is_unspecified() {
+            return Err(ConfigError::InvalidRouterId {
+                value: self.global.router_id.clone(),
+                reason: "must be non-zero (RFC 6286 section 2.1)".to_string(),
+            });
+        }
 
         // Validate cluster_id if present
         if let Some(ref cid) = self.global.cluster_id {

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -678,9 +678,11 @@ impl PeerManager {
                 .await;
             }
             SessionState::OpenConfirm => {
-                // We already have router-id from negotiation; start a live
-                // inbound candidate and resolve immediately.
-                let remote_router_id = current_state.and_then(|s| s.remote_router_id);
+                // We already have the negotiated identity; start a live inbound
+                // candidate and resolve immediately without consulting config's
+                // dynamic-neighbor ASN wildcard.
+                let remote_identity =
+                    current_state.and_then(|state| state.remote_router_id.zip(state.peer_asn));
                 let started = self
                     .spawn_pending_inbound(
                         peer_key.clone(),
@@ -689,14 +691,14 @@ impl PeerManager {
                         accepted_generation,
                     )
                     .await;
-                if let Some(rid) = remote_router_id {
+                if let Some((router_id, peer_asn)) = remote_identity {
                     if started {
-                        self.resolve_collision(peer_key, rid).await;
+                        self.resolve_collision(peer_key, router_id, peer_asn).await;
                     }
                 } else {
                     // Shouldn't happen; the live candidate can still notify
                     // us once it receives the peer OPEN.
-                    warn!(%peer_addr, "OpenConfirm but no remote_router_id, waiting for inbound candidate notification");
+                    warn!(%peer_addr, "OpenConfirm but no negotiated peer identity, waiting for inbound candidate notification");
                 }
             }
         }
@@ -706,18 +708,29 @@ impl PeerManager {
         &mut self,
         peer_key: PeerKey,
         remote_router_id: Ipv4Addr,
+        peer_asn: u32,
     ) {
         let peer_addr = peer_key.address;
         let local_id = u32::from(self.router_id);
         let remote_id = u32::from(remote_router_id);
+        let equal_router_ids = local_id == remote_id;
+        let collision_order = match local_id.cmp(&remote_id) {
+            // RFC 6286 section 2.3: with equal eBGP identifiers, preserve the
+            // connection initiated by the speaker with the larger AS number.
+            std::cmp::Ordering::Equal => self.local_asn.cmp(&peer_asn),
+            ordering => ordering,
+        };
 
-        match local_id.cmp(&remote_id) {
+        match collision_order {
             std::cmp::Ordering::Greater => {
                 // We win — keep existing session, drop inbound
                 info!(
                     %peer_addr,
                     local_id = %self.router_id,
                     remote_id = %remote_router_id,
+                    self.local_asn,
+                    peer_asn,
+                    equal_router_ids,
                     "collision: local wins, dropping inbound"
                 );
                 if let Some(pending) = self
@@ -741,6 +754,9 @@ impl PeerManager {
                     %peer_addr,
                     local_id = %self.router_id,
                     remote_id = %remote_router_id,
+                    self.local_asn,
+                    peer_asn,
+                    equal_router_ids,
                     "collision: remote wins, replacing with inbound"
                 );
                 let promoted = {
@@ -767,11 +783,14 @@ impl PeerManager {
                 }
             }
             std::cmp::Ordering::Equal => {
-                // Equal router-ids — should not happen; drop inbound
+                // Equal iBGP identifiers are rejected during OPEN negotiation.
+                // If inconsistent metadata reaches here, do not promote it.
                 warn!(
                     %peer_addr,
                     router_id = %self.router_id,
-                    "collision: equal router-ids, dropping inbound"
+                    self.local_asn,
+                    peer_asn,
+                    "collision: equal router-id and AS, dropping inbound"
                 );
                 if let Some(pending) = self
                     .peers
@@ -782,7 +801,7 @@ impl PeerManager {
                         &peer_key,
                         pending.session_id,
                         pending.handle,
-                        "equal-router-id collision loser",
+                        "equal-identity collision loser",
                         true,
                     )
                     .await;

--- a/src/peer_manager/notifications.rs
+++ b/src/peer_manager/notifications.rs
@@ -110,6 +110,7 @@ impl PeerManager {
                 role,
                 peer_addr,
                 remote_router_id,
+                peer_asn,
             } => {
                 let Some(peer_key) = self.peer_key_for_session(session_id) else {
                     debug!(%peer_addr, session_id, ?role, "ignoring notification for unknown peer session");
@@ -130,7 +131,8 @@ impl PeerManager {
                     .get(&peer_key)
                     .is_some_and(|m| m.pending_inbound.is_some())
                 {
-                    self.resolve_collision(peer_key, remote_router_id).await;
+                    self.resolve_collision(peer_key, remote_router_id, peer_asn)
+                        .await;
                 }
             }
             SessionNotification::BackToIdle {

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -5090,6 +5090,7 @@ async fn local_wins_collision_preserves_candidate_terminal_breach() {
             role: rustbgpd_transport::SessionRole::InboundCandidate,
             peer_addr: addr,
             remote_router_id: Ipv4Addr::new(10, 0, 0, 2),
+            peer_asn: 65002,
         })
         .unwrap();
 
@@ -5147,6 +5148,7 @@ async fn remote_wins_collision_preserves_old_primary_terminal_breach() {
             role: rustbgpd_transport::SessionRole::InboundCandidate,
             peer_addr: addr,
             remote_router_id: Ipv4Addr::new(10, 0, 0, 2),
+            peer_asn: 65002,
         })
         .unwrap();
 
@@ -14815,10 +14817,12 @@ async fn simultaneous_active_open_runs_inbound_candidate_before_primary_idle() {
         SessionNotification::OpenReceived {
             role,
             remote_router_id,
+            peer_asn,
             ..
         } => {
             assert_eq!(*role, rustbgpd_transport::SessionRole::InboundCandidate);
             assert_eq!(*remote_router_id, Ipv4Addr::new(10, 0, 0, 2));
+            assert_eq!(*peer_asn, 65002);
         }
         other @ (SessionNotification::BackToIdle { .. }
         | SessionNotification::StateChanged { .. }
@@ -15227,6 +15231,7 @@ async fn collision_local_wins_drops_inbound_candidate() {
         role: rustbgpd_transport::SessionRole::InboundCandidate,
         peer_addr,
         remote_router_id: Ipv4Addr::new(10, 0, 0, 2),
+        peer_asn: 65002,
     })
     .await;
 
@@ -15242,7 +15247,9 @@ async fn collision_local_wins_drops_inbound_candidate() {
 }
 
 #[tokio::test]
-async fn collision_equal_router_ids_drops_inbound_candidate() {
+async fn collision_equal_router_ids_larger_remote_as_promotes_dynamic_inbound() {
+    // Mutation-red: deleting the AS tie-break, reversing it, or consulting the
+    // configured wildcard ASN 0 leaves the primary session in place.
     let (_cmd_tx, cmd_rx) = mpsc::channel(16);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
     let metrics = BgpMetrics::new();
@@ -15262,7 +15269,7 @@ async fn collision_equal_router_ids_drops_inbound_candidate() {
     insert_test_managed_peer_with_asn(
         &mut mgr,
         peer_addr,
-        65002,
+        0,
         fake_peer_handle(
             peer_addr,
             SessionState::OpenConfirm,
@@ -15288,6 +15295,72 @@ async fn collision_equal_router_ids_drops_inbound_candidate() {
         role: rustbgpd_transport::SessionRole::InboundCandidate,
         peer_addr,
         remote_router_id: Ipv4Addr::new(10, 0, 0, 2),
+        peer_asn: 4_200_000_001,
+    })
+    .await;
+
+    wait_counter(&primary.collision_dump, 1).await;
+    assert_eq!(primary.collision_dump.load(Ordering::SeqCst), 1);
+    assert_eq!(pending.collision_dump.load(Ordering::SeqCst), 0);
+    assert!(
+        mgr.peers
+            .get(&key(peer_addr))
+            .is_some_and(|m| m.pending_inbound.is_none() && m.session_id == 2),
+        "the larger remote four-octet AS must preserve its inbound connection; \
+         using ManagedPeer.remote_asn would read the dynamic wildcard 0 and fail"
+    );
+}
+
+#[tokio::test]
+async fn collision_equal_router_ids_larger_local_four_octet_as_drops_inbound() {
+    // Mutation-red: reversing the AS comparison promotes the pending inbound
+    // connection even though the larger local AS initiated the primary.
+    let (_cmd_tx, cmd_rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        cmd_rx,
+        4_200_000_001,
+        Ipv4Addr::new(10, 0, 0, 2),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+    let peer_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let primary = Arc::new(FakePeerCounters::default());
+    let pending = Arc::new(FakePeerCounters::default());
+    insert_test_managed_peer_with_asn(
+        &mut mgr,
+        peer_addr,
+        0,
+        fake_peer_handle(
+            peer_addr,
+            SessionState::OpenConfirm,
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            primary.clone(),
+        ),
+        false,
+    );
+    attach_test_pending_inbound(
+        &mut mgr,
+        peer_addr,
+        fake_peer_handle(
+            peer_addr,
+            SessionState::OpenConfirm,
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            pending.clone(),
+        ),
+        2,
+    );
+
+    mgr.handle_session_notification(SessionNotification::OpenReceived {
+        session_id: 2,
+        role: rustbgpd_transport::SessionRole::InboundCandidate,
+        peer_addr,
+        remote_router_id: Ipv4Addr::new(10, 0, 0, 2),
+        peer_asn: 65002,
     })
     .await;
 
@@ -15298,7 +15371,71 @@ async fn collision_equal_router_ids_drops_inbound_candidate() {
         mgr.peers
             .get(&key(peer_addr))
             .is_some_and(|m| m.pending_inbound.is_none() && m.session_id == 1),
-        "equal router-id collision must keep the primary session"
+        "the larger local four-octet AS must preserve its outbound connection"
+    );
+}
+
+#[tokio::test]
+async fn collision_equal_router_id_and_as_drops_inbound_defensively() {
+    // Mutation-red: treating an impossible equal identity as remote-wins
+    // replaces the primary session instead of failing closed.
+    let (_cmd_tx, cmd_rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        cmd_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 2),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+    let peer_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let primary = Arc::new(FakePeerCounters::default());
+    let pending = Arc::new(FakePeerCounters::default());
+    insert_test_managed_peer_with_asn(
+        &mut mgr,
+        peer_addr,
+        0,
+        fake_peer_handle(
+            peer_addr,
+            SessionState::OpenConfirm,
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            primary.clone(),
+        ),
+        false,
+    );
+    attach_test_pending_inbound(
+        &mut mgr,
+        peer_addr,
+        fake_peer_handle(
+            peer_addr,
+            SessionState::OpenConfirm,
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            pending.clone(),
+        ),
+        2,
+    );
+
+    mgr.handle_session_notification(SessionNotification::OpenReceived {
+        session_id: 2,
+        role: rustbgpd_transport::SessionRole::InboundCandidate,
+        peer_addr,
+        remote_router_id: Ipv4Addr::new(10, 0, 0, 2),
+        peer_asn: 65001,
+    })
+    .await;
+
+    wait_counter(&pending.collision_dump, 1).await;
+    assert_eq!(primary.collision_dump.load(Ordering::SeqCst), 0);
+    assert_eq!(pending.collision_dump.load(Ordering::SeqCst), 1);
+    assert!(
+        mgr.peers
+            .get(&key(peer_addr))
+            .is_some_and(|m| m.pending_inbound.is_none() && m.session_id == 1),
+        "equal AS and router ID is invalid iBGP identity and must not promote inbound"
     );
 }
 
@@ -15474,7 +15611,7 @@ async fn production_collision_promotion_transfers_capacity_after_primary_termina
         "inactive candidate must not overwrite the primary"
     );
 
-    mgr.resolve_collision(key(peer_addr), Ipv4Addr::new(10, 0, 0, 2))
+    mgr.resolve_collision(key(peer_addr), Ipv4Addr::new(10, 0, 0, 2), 65002)
         .await;
 
     assert!(terminated.load(Ordering::SeqCst));
@@ -15543,6 +15680,7 @@ async fn stale_collision_notifications_do_not_mutate_current_peer() {
         role: rustbgpd_transport::SessionRole::InboundCandidate,
         peer_addr,
         remote_router_id: Ipv4Addr::new(10, 0, 0, 2),
+        peer_asn: 65002,
     })
     .await;
     mgr.handle_session_notification(SessionNotification::BackToIdle {


### PR DESCRIPTION
## Summary

- reject local AS 0 and router ID 0 during configuration validation with source-located diagnostics
- reject peer AS 0 before the dynamic-neighbor wildcard and reject duplicate identifiers only for iBGP
- preserve equal-identifier eBGP collisions using the initiator from the larger negotiated ASN, including four-octet ASNs
- update current configuration, RFC, and collision-design documentation

## Why

AS 0 cannot identify a BGP speaker, while RFC 6286 permits any nonzero 32-bit BGP identifier and permits equal identifiers in eBGP. Equal-identifier eBGP collisions must use the AS-number tie-break; dropping every inbound candidate could discard the connection the RFC requires us to preserve.

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
- mutation-red config proofs for local AS 0 and router ID 0
- mutation-red OPEN proofs for AS 0, duplicate iBGP identifiers, and legal unusual nonzero identifiers
- mutation-red collision proofs for both ASN orderings, four-octet ASNs, dynamic-neighbor wildcard timing, and defensive equal identity
- transport lifecycle proof that negotiated four-octet ASN reaches collision handling losslessly
- independent exact-diff review: GO

Linear: LAN-557