### PR TITLE
ci: verify hosted grpcurl downloads

### DIFF
--- a/.github/actions/setup-dataplane-host/action.yml
+++ b/.github/actions/setup-dataplane-host/action.yml
@@ -10,9 +10,6 @@ inputs:
   containerlab-version:
     required: false
     default: "0.74.3"
-  grpcurl-version:
-    required: false
-    default: "1.9.1"
   build-image:
     description: "Build rustbgpd:dev (set 'false' for jobs that build their own)."
     required: false
@@ -37,8 +34,6 @@ runs:
 
     - name: Install grpcurl + jq
       shell: bash
-      env:
-        GRPCURL_VERSION: ${{ inputs.grpcurl-version }}
       run: |
         set -euo pipefail
         # jq is normally preinstalled on hosted runners; only touch apt when it
@@ -50,10 +45,7 @@ runs:
             echo "::warning::apt-get update reported repo errors; installing jq from cache"
           sudo apt-get install -y jq
         fi
-        curl -fsSL --retry 3 --retry-delay 3 \
-          "https://github.com/fullstorydev/grpcurl/releases/download/v${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz" \
-          | sudo tar -xz -C /usr/local/bin grpcurl
-        grpcurl -version
+        bash .github/scripts/install-grpcurl.sh
 
     - name: Load kernel dataplane modules (vrf / vxlan / bridge / bonding)
       id: dataplane-modules

--- a/.github/scripts/install-grpcurl.sh
+++ b/.github/scripts/install-grpcurl.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly GRPCURL_VERSION="1.9.1"
+readonly GRPCURL_SHA256="588c9c429476d9ed66cd3b2ae32283a6da36e0cfbb7e446f5d6a1b68dc770214"
+readonly GRPCURL_ASSET="grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz"
+readonly GRPCURL_URL="https://github.com/fullstorydev/grpcurl/releases/download/v${GRPCURL_VERSION}/${GRPCURL_ASSET}"
+
+install_grpcurl() (
+    local version=${1:?version}
+    local sha256=${2:?sha256}
+    local url=${3:?url}
+    local install_dir=${4:?install directory}
+    local work_dir archive reported_version
+
+    work_dir=$(mktemp -d)
+    trap 'rm -rf -- "$work_dir"' EXIT
+    archive="$work_dir/grpcurl.tar.gz"
+
+    # Download to a file rather than streaming into tar: curl can discard a
+    # partial response before retrying, and extraction cannot see unverified
+    # bytes. --retry alone does not cover truncated transfers.
+    curl -fsSL \
+        --retry 3 \
+        --retry-all-errors \
+        --retry-delay 3 \
+        --connect-timeout 10 \
+        --max-time 120 \
+        --output "$archive" \
+        "$url"
+
+    if ! printf '%s  %s\n' "$sha256" "$archive" | sha256sum --check --status; then
+        echo "grpcurl ${version} archive checksum mismatch" >&2
+        return 1
+    fi
+
+    if [[ -w "$install_dir" ]]; then
+        tar -xzf "$archive" -C "$install_dir" grpcurl
+    else
+        sudo tar -xzf "$archive" -C "$install_dir" grpcurl
+    fi
+
+    reported_version=$("$install_dir/grpcurl" -version)
+    if [[ "$reported_version" != "grpcurl v${version}" ]]; then
+        echo "unexpected grpcurl version: ${reported_version}" >&2
+        return 1
+    fi
+    printf '%s\n' "$reported_version"
+)
+
+fail_self_test() {
+    echo "grpcurl installer self-test failed: $*" >&2
+    return 1
+}
+
+self_test() (
+    local repo_root fixture_dir source_dir base_archive archive checksum truncated_size
+    local wrong_version_archive wrong_version_checksum
+    local named_steps workflow_calls setup_calls
+
+    repo_root=$(git rev-parse --show-toplevel)
+    fixture_dir=$(mktemp -d)
+    trap 'rm -rf -- "$fixture_dir"' EXIT
+    [[ "$GRPCURL_SHA256" == "588c9c429476d9ed66cd3b2ae32283a6da36e0cfbb7e446f5d6a1b68dc770214" ]] \
+        || fail_self_test "pinned grpcurl v1.9.1 checksum drifted"
+    source_dir="$fixture_dir/source"
+    mkdir -p "$source_dir"
+    cat >"$source_dir/grpcurl" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' 'grpcurl v1.9.1'
+EOF
+    chmod +x "$source_dir/grpcurl"
+    # A second empty gzip member makes the full fixture distinct while the
+    # prefix remains a valid, extractable archive. Removing that final member
+    # therefore models a truncated transfer that tar alone would accept; only
+    # the checksum can make the negative case fail before extraction.
+    base_archive="$fixture_dir/grpcurl-base.tar.gz"
+    archive="$fixture_dir/grpcurl-valid.tar.gz"
+    tar -czf "$base_archive" -C "$source_dir" grpcurl
+    cp "$base_archive" "$archive"
+    printf '' | gzip >>"$archive"
+    checksum=$(sha256sum "$archive" | awk '{print $1}')
+
+    mkdir "$fixture_dir/valid-install"
+    install_grpcurl \
+        "$GRPCURL_VERSION" \
+        "$checksum" \
+        "file://$archive" \
+        "$fixture_dir/valid-install"
+    [[ -x "$fixture_dir/valid-install/grpcurl" ]] \
+        || fail_self_test "verified archive was not installed"
+
+    truncated_size=$(wc -c <"$base_archive")
+    head -c "$truncated_size" "$archive" >"$fixture_dir/grpcurl-truncated.tar.gz"
+    mkdir "$fixture_dir/truncated-install"
+    if install_grpcurl \
+        "$GRPCURL_VERSION" \
+        "$checksum" \
+        "file://$fixture_dir/grpcurl-truncated.tar.gz" \
+        "$fixture_dir/truncated-install" 2>/dev/null; then
+        fail_self_test "truncated archive was accepted"
+    fi
+    [[ ! -e "$fixture_dir/truncated-install/grpcurl" ]] \
+        || fail_self_test "truncated archive was extracted"
+
+    mkdir "$fixture_dir/wrong-checksum-install"
+    if install_grpcurl \
+        "$GRPCURL_VERSION" \
+        "0000000000000000000000000000000000000000000000000000000000000000" \
+        "file://$archive" \
+        "$fixture_dir/wrong-checksum-install" 2>/dev/null; then
+        fail_self_test "wrong checksum was accepted"
+    fi
+    [[ ! -e "$fixture_dir/wrong-checksum-install/grpcurl" ]] \
+        || fail_self_test "wrong-checksum archive was extracted"
+
+    mkdir "$fixture_dir/wrong-version-source" "$fixture_dir/wrong-version-install"
+    cat >"$fixture_dir/wrong-version-source/grpcurl" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' 'grpcurl v1.9.0'
+EOF
+    chmod +x "$fixture_dir/wrong-version-source/grpcurl"
+    wrong_version_archive="$fixture_dir/grpcurl-wrong-version.tar.gz"
+    tar -czf "$wrong_version_archive" \
+        -C "$fixture_dir/wrong-version-source" grpcurl
+    wrong_version_checksum=$(sha256sum "$wrong_version_archive" | awk '{print $1}')
+    if install_grpcurl \
+        "$GRPCURL_VERSION" \
+        "$wrong_version_checksum" \
+        "file://$wrong_version_archive" \
+        "$fixture_dir/wrong-version-install" 2>/dev/null; then
+        fail_self_test "wrong grpcurl version was accepted"
+    fi
+
+    named_steps=$(grep -cE '^[[:space:]]+- name: Install grpcurl' \
+        "$repo_root/.github/workflows/interop.yml")
+    workflow_calls=$(grep -cF 'bash .github/scripts/install-grpcurl.sh' \
+        "$repo_root/.github/workflows/interop.yml")
+    [[ "$workflow_calls" -eq "$named_steps" && "$workflow_calls" -gt 0 ]] \
+        || fail_self_test \
+            "every Interop grpcurl install step must call the shared helper (steps=${named_steps}, calls=${workflow_calls})"
+
+    setup_calls=$(grep -cF 'bash .github/scripts/install-grpcurl.sh' \
+        "$repo_root/.github/actions/setup-dataplane-host/action.yml")
+    [[ "$setup_calls" -eq 1 ]] \
+        || fail_self_test "setup-dataplane-host must call the shared helper exactly once"
+
+    if grep -R -E -n \
+        'fullstorydev/grpcurl/releases|grpcurl_.*linux_x86_64\.tar\.gz' \
+        "$repo_root/.github/workflows" \
+        "$repo_root/.github/actions"; then
+        fail_self_test "legacy grpcurl download call site remains outside the helper"
+    fi
+
+    printf '%s\n' 'grpcurl installer self-test passed'
+)
+
+case ${1:-} in
+    "")
+        install_grpcurl \
+            "$GRPCURL_VERSION" \
+            "$GRPCURL_SHA256" \
+            "$GRPCURL_URL" \
+            /usr/local/bin
+        ;;
+    --self-test)
+        self_test
+        ;;
+    *)
+        echo "usage: $0 [--self-test]" >&2
+        exit 2
+        ;;
+esac

--- a/.github/scripts/install-grpcurl.sh
+++ b/.github/scripts/install-grpcurl.sh
@@ -41,7 +41,7 @@ install_grpcurl() (
         sudo tar -xzf "$archive" -C "$install_dir" grpcurl
     fi
 
-    reported_version=$("$install_dir/grpcurl" -version)
+    reported_version=$("$install_dir/grpcurl" -version 2>&1)
     if [[ "$reported_version" != "grpcurl v${version}" ]]; then
         echo "unexpected grpcurl version: ${reported_version}" >&2
         return 1
@@ -68,7 +68,7 @@ self_test() (
     mkdir -p "$source_dir"
     cat >"$source_dir/grpcurl" <<'EOF'
 #!/usr/bin/env sh
-printf '%s\n' 'grpcurl v1.9.1'
+printf '%s\n' 'grpcurl v1.9.1' >&2
 EOF
     chmod +x "$source_dir/grpcurl"
     # A second empty gzip member makes the full fixture distinct while the
@@ -118,7 +118,7 @@ EOF
     mkdir "$fixture_dir/wrong-version-source" "$fixture_dir/wrong-version-install"
     cat >"$fixture_dir/wrong-version-source/grpcurl" <<'EOF'
 #!/usr/bin/env sh
-printf '%s\n' 'grpcurl v1.9.0'
+printf '%s\n' 'grpcurl v1.9.0' >&2
 EOF
     chmod +x "$fixture_dir/wrong-version-source/grpcurl"
     wrong_version_archive="$fixture_dir/grpcurl-wrong-version.tar.gz"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
             echo "CI triggers must keep main-only pushes, all PRs, and Markdown ignores" >&2
             exit 1
           fi
+      - name: Check pinned grpcurl installer contract
+        shell: bash
+        run: |
+          bash -n .github/scripts/install-grpcurl.sh
+          shellcheck .github/scripts/install-grpcurl.sh
+          bash .github/scripts/install-grpcurl.sh --self-test
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -153,8 +153,7 @@ jobs:
 
       - name: Install grpcurl
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -188,8 +187,7 @@ jobs:
 
       - name: Install grpcurl
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -225,8 +223,7 @@ jobs:
         # jq drives the parity tuple comparisons (rustbgpd gRPC JSON
         # vs FRR vtysh JSON) and the policy test/stats assertions.
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -261,8 +258,7 @@ jobs:
 
       - name: Install grpcurl
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -296,8 +292,7 @@ jobs:
 
       - name: Install grpcurl
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -331,8 +326,7 @@ jobs:
 
       - name: Install grpcurl
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -366,8 +360,7 @@ jobs:
 
       - name: Install grpcurl + jq
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -409,8 +402,7 @@ jobs:
 
       - name: Install grpcurl + jq
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -458,8 +450,7 @@ jobs:
 
       - name: Install grpcurl + jq
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -497,8 +488,7 @@ jobs:
 
       - name: Install grpcurl + jq
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -536,8 +526,7 @@ jobs:
 
       - name: Install grpcurl + jq
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -575,8 +564,7 @@ jobs:
 
       - name: Install grpcurl + jq
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -614,8 +602,7 @@ jobs:
 
       - name: Install grpcurl + jq
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -653,8 +640,7 @@ jobs:
 
       - name: Install grpcurl + jq
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -695,8 +681,7 @@ jobs:
         # the direct convergence checks and `show bgp summary json`
         # for the per-step flap-detection assertion.
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -731,8 +716,7 @@ jobs:
 
       - name: Install grpcurl
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -767,8 +751,7 @@ jobs:
       - name: Install grpcurl + jq
         # jq drives the pmacct-msglog and gobmp-JSON oracle assertions.
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -817,8 +800,7 @@ jobs:
 
       - name: Install grpcurl + jq
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -861,8 +843,7 @@ jobs:
       - name: Install grpcurl + jq
         # jq drives the FRR vtysh / GoBGP JSON client-view assertions.
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -906,8 +887,7 @@ jobs:
       - name: Install grpcurl + jq
         # jq drives the rbgp JSON client-view assertions.
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -953,8 +933,7 @@ jobs:
       - name: Install grpcurl + jq
         # jq drives the bgpctl -j and rbgp JSON client-view assertions.
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -996,8 +975,7 @@ jobs:
 
       - name: Install grpcurl
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1037,8 +1015,7 @@ jobs:
 
       - name: Install grpcurl
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
 
       # Buildx cache cuts the docker build step from ~6 min to ~30 s on
       # cache hits. The cargo registry / target dir gets reused via the
@@ -1080,8 +1057,7 @@ jobs:
         # (scoped to the entry containing the test MAC); a substring
         # grep would let a malformed match slip past.
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -1118,8 +1094,7 @@ jobs:
         # jq is required for the strict per-prefix counting + session
         # uptime epoch comparison in test-m34.
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -1156,8 +1131,7 @@ jobs:
         # jq parses NeighborState.localPref + FRR's `show ip bgp` JSON
         # for the community-presence assertion.
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -1194,8 +1168,7 @@ jobs:
         # jq parses FRR's `show bgp ipv4 flowspec json` output for
         # the community-presence assertion.
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -1231,8 +1204,7 @@ jobs:
       - name: Install grpcurl + jq
         # jq pretty-prints EVPN diagnostics and parses grpcurl JSON.
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -1270,8 +1242,7 @@ jobs:
         # community assertions (BLACKHOLE + implicit NO_ADVERTISE
         # on tagged /32, neither on untagged /32).
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -1306,8 +1277,7 @@ jobs:
 
       - name: Install grpcurl
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1348,8 +1318,7 @@ jobs:
 
       - name: Install grpcurl and gnmic
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           curl -sL https://github.com/openconfig/gnmic/releases/download/v0.46.0/gnmic_0.46.0_Linux_x86_64.tar.gz \
             | sudo tar -xz -C /usr/local/bin gnmic
           sudo apt-get update -y && sudo apt-get install -y jq
@@ -1391,8 +1360,7 @@ jobs:
 
       - name: Install grpcurl and jq
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -1427,8 +1395,7 @@ jobs:
 
       - name: Install grpcurl, gnmic, and jq
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           curl -sL https://github.com/openconfig/gnmic/releases/download/v0.46.0/gnmic_0.46.0_Linux_x86_64.tar.gz \
             | sudo tar -xz -C /usr/local/bin gnmic
           sudo apt-get update -y && sudo apt-get install -y jq
@@ -1469,8 +1436,7 @@ jobs:
 
       - name: Install grpcurl
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1506,8 +1472,7 @@ jobs:
         # grpcurl injects routes via InjectionService.AddPath; jq parses FRR's
         # `show bgp ipv4 unicast json` for the received-prefix-set assertions.
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -1545,8 +1510,7 @@ jobs:
         # survival-window and never-drop assertions; the Prometheus
         # counters come over plain HTTP.
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
@@ -1584,8 +1548,7 @@ jobs:
         # the no-IPv4-MP assertion; grpcurl injects the bidirectional
         # route-exchange prefixes and reads rustbgpd's RIB.
         run: |
-          curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin grpcurl
+          bash .github/scripts/install-grpcurl.sh
           sudo apt-get update -y && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Summary

- replace 37 duplicated Interop installers and the dataplane-host installer with one pinned helper
- download grpcurl to a temporary file with bounded retries, verify the official SHA-256 before extraction, and assert the exact version
- run an offline self-test in the existing CI check job and reject legacy streaming installers

## Why

Interop run 29927970650 received a truncated grpcurl archive in M64 and failed before build/test with `gzip: stdin: unexpected end of file`. The retry passed, and this was the first such signature in the latest 100 Interop runs, but every duplicated `curl -sL | tar` call shared the same unverified-stream failure mode.

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
- bash -n and ShellCheck on the installer
- offline installer self-test
- actionlint v1.7.7 and YAML parsing
- isolated Ubuntu production-helper smoke against the pinned v1.9.1 asset
- independent exact-patch review: GO

## Load-bearing proof

- changing one pinned checksum digit fails the checksum contract
- removing checksum verification accepts the extractable truncated fixture and makes the self-test red
- restoring one legacy Interop pipeline makes the single-installer contract red
- removing the exact version assertion accepts a fake v1.9.0 binary and makes the self-test red

Linear: LAN-561