### PR TITLE
feat: support RFC 9072 extended OPEN parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **RFC 9072 extended BGP OPEN Optional Parameters lengths.** OPEN messages
+  keep the RFC 4271 encoding through 255 optional-parameter octets and use the
+  extended aggregate and per-parameter lengths only above that boundary.
+  Receivers accept extended encodings at any length, including zero, while
+  OPEN remains bounded to 4096 bytes. Unsupported Optional Parameter types
+  now produce OPEN Message Error / Unsupported Optional Parameter (2/4);
+  unknown capabilities inside the Capabilities parameter remain accepted.
+
 - **Fail-closed live TCP-AO MKT deletion on SIGHUP.** After a successor has
   been selected and its predecessor deprecated, a later immutable generation
   can remove only deprecated MKTs that are neither Current nor RNext while

--- a/crates/fsm/src/config.rs
+++ b/crates/fsm/src/config.rs
@@ -826,4 +826,61 @@ mod tests {
         assert_eq!(caps[0].safi, Safi::Unicast);
         assert_eq!(caps[0].send_receive, AddPathMode::Receive);
     }
+
+    #[test]
+    fn maximum_production_capability_set_uses_extended_open() {
+        use rustbgpd_wire::{
+            MAX_MESSAGE_LEN, Message, OpenMessage, decode_message, encode_message,
+        };
+
+        let mut cfg = test_config();
+        cfg.families = vec![
+            (Afi::Ipv4, Safi::Unicast),
+            (Afi::Ipv6, Safi::Unicast),
+            (Afi::Ipv4, Safi::FlowSpec),
+            (Afi::Ipv6, Safi::FlowSpec),
+            (Afi::L2Vpn, Safi::Evpn),
+            (Afi::BgpLs, Safi::BgpLs),
+            (Afi::BgpLs, Safi::BgpLsVpn),
+            (Afi::Ipv4, Safi::MplsVpn),
+            (Afi::Ipv6, Safi::MplsVpn),
+            (Afi::Ipv4, Safi::LabeledUnicast),
+            (Afi::Ipv6, Safi::LabeledUnicast),
+            (Afi::Ipv4, Safi::RtConstrain),
+        ];
+        cfg.graceful_restart = true;
+        cfg.llgr_stale_time = 3600;
+        cfg.add_path_receive = true;
+        cfg.add_path_send = true;
+        cfg.paths_limit_receive_max = 8;
+        cfg.prefix_orf_receive = true;
+        cfg.local_role = Some(BgpRole::RouteServer);
+
+        let capabilities = cfg.local_capabilities();
+        let capability_octets: usize = capabilities.iter().map(Capability::encoded_len).sum();
+        assert_eq!(capability_octets, 307);
+
+        let open = OpenMessage {
+            version: 4,
+            my_as: cfg.open_my_as(),
+            hold_time: cfg.hold_time,
+            bgp_identifier: cfg.local_router_id,
+            capabilities,
+        };
+        let encoded = encode_message(&Message::Open(open.clone())).unwrap();
+
+        // Mutation-red: reverting RFC 9072 framing makes the 307 capability
+        // octets fail the old u8 ceiling. Omitting any production capability
+        // changes the pinned 307/342-byte fleet fixture.
+        assert_eq!(encoded.len(), 342);
+        assert_eq!(open.encoded_len(), 342);
+        assert_eq!(encoded[28], 255); // Non-Ext OP Len
+        assert_eq!(encoded[29], 255); // Non-Ext OP Type marker
+        assert_eq!(&encoded[30..32], &310_u16.to_be_bytes());
+        assert_eq!(encoded[32], 2); // Capabilities Optional Parameter
+        assert_eq!(&encoded[33..35], &307_u16.to_be_bytes());
+
+        let decoded = decode_message(&mut encoded.freeze(), MAX_MESSAGE_LEN).unwrap();
+        assert_eq!(decoded, Message::Open(open));
+    }
 }

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -56,6 +56,7 @@ analyzers, test harnesses, MRT readers, etc.
 | 8950 | Extended next hop (IPv4 NLRI over IPv6 NH); optional acceptance of a link-local-primary `MP_REACH_NLRI` next-hop for unnumbered peers via `UpdateValidationOptions` |
 | 8955/8956 | FlowSpec: 13 component types, numeric/bitmask operators; §6.1-compliant `NEXT_HOP` validation (the irrelevant-next-hop case is accepted, not rejected); `FlowSpecRule::validate_encoded_len` rejects rules above the 12-bit `MAX_FLOWSPEC_NLRI_RULE_LEN` (4095 bytes) before they reach the wire |
 | 9012 | BGP Encapsulation extended community (§4.1) — VXLAN sub-type used by EVPN encap |
+| 9072 | Extended Optional Parameters Length for BGP OPEN: classic encoding through 255 optional-parameter octets, extended aggregate and per-parameter lengths above that boundary, and permissive extended-format receive at smaller lengths |
 | 9135 | EVPN integrated routing for IRB |
 | 9136 | EVPN Type 5: IP Prefix advertisement |
 | 9234 | BGP Roles (OPEN capability code 9, `BgpRole`) + Only-to-Customer path attribute (type 35, `PathAttribute::OnlyToCustomer`). Codec only; malformed-length OTC is preserved as `Unknown` (not a fatal decode) so transport can apply RFC 7606 treat-as-withdraw. Negotiation + ingress/egress rules live in the daemon (ADR-0071) |

--- a/crates/wire/src/capability.rs
+++ b/crates/wire/src/capability.rs
@@ -842,29 +842,52 @@ impl Capability {
 /// # Errors
 ///
 /// Returns [`DecodeError::MalformedOptionalParameter`] if any parameter TLV
-/// is truncated or contains an invalid capability.
+/// is truncated or contains an invalid capability, or
+/// [`DecodeError::UnsupportedOptionalParameter`] for an unrecognized
+/// Optional Parameter type.
 pub fn decode_optional_parameters(
     buf: &mut impl Buf,
     opt_params_len: u8,
 ) -> Result<Vec<Capability>, DecodeError> {
+    decode_optional_parameters_inner(buf, usize::from(opt_params_len), false)
+}
+
+/// Decode RFC 9072 extended-width OPEN Optional Parameters.
+pub(crate) fn decode_extended_optional_parameters(
+    buf: &mut impl Buf,
+    opt_params_len: u16,
+) -> Result<Vec<Capability>, DecodeError> {
+    decode_optional_parameters_inner(buf, usize::from(opt_params_len), true)
+}
+
+fn decode_optional_parameters_inner(
+    buf: &mut impl Buf,
+    opt_params_len: usize,
+    extended: bool,
+) -> Result<Vec<Capability>, DecodeError> {
     let mut capabilities = Vec::new();
-    let mut remaining = usize::from(opt_params_len);
+    let mut remaining = opt_params_len;
+    let parameter_header_len = if extended { 3 } else { 2 };
 
     while remaining > 0 {
-        if buf.remaining() < 2 {
+        if remaining < parameter_header_len || buf.remaining() < parameter_header_len {
             return Err(DecodeError::MalformedOptionalParameter {
-                offset: usize::from(opt_params_len) - remaining,
+                offset: opt_params_len - remaining,
                 detail: "optional parameter TLV too short".into(),
             });
         }
 
         let param_type = buf.get_u8();
-        let param_len = buf.get_u8();
-        remaining = remaining.saturating_sub(2);
+        let param_len = if extended {
+            usize::from(buf.get_u16())
+        } else {
+            usize::from(buf.get_u8())
+        };
+        remaining -= parameter_header_len;
 
-        if usize::from(param_len) > remaining || buf.remaining() < usize::from(param_len) {
+        if param_len > remaining || buf.remaining() < param_len {
             return Err(DecodeError::MalformedOptionalParameter {
-                offset: usize::from(opt_params_len) - remaining,
+                offset: opt_params_len - remaining,
                 detail: format!(
                     "parameter type {param_type} claims length {param_len}, \
                      but only {remaining} bytes remain"
@@ -876,18 +899,17 @@ pub fn decode_optional_parameters(
             // Parse capabilities from a bounded sub-buffer so a malformed
             // capability length cannot consume into the next parameter or
             // beyond the OPEN body.
-            let param_bytes = buf.copy_to_bytes(usize::from(param_len));
+            let param_bytes = buf.copy_to_bytes(param_len);
             let mut cap_buf = param_bytes;
             while cap_buf.has_remaining() {
                 let cap = Capability::decode(&mut cap_buf)?;
                 capabilities.push(cap);
             }
         } else {
-            // Skip unknown parameter types
-            buf.advance(usize::from(param_len));
+            return Err(DecodeError::UnsupportedOptionalParameter { param_type });
         }
 
-        remaining = remaining.saturating_sub(usize::from(param_len));
+        remaining -= param_len;
     }
 
     Ok(capabilities)
@@ -931,6 +953,29 @@ pub fn encode_optional_parameters(
     )]
     buf.put_u8(cap_total as u8);
 
+    for cap in capabilities {
+        cap.encode(buf)?;
+    }
+    Ok(())
+}
+
+/// Encode capabilities in an RFC 9072 extended-width Optional Parameter.
+pub(crate) fn encode_extended_optional_parameters(
+    capabilities: &[Capability],
+    buf: &mut impl BufMut,
+) -> Result<(), EncodeError> {
+    if capabilities.is_empty() {
+        return Ok(());
+    }
+
+    let cap_total: usize = capabilities.iter().map(Capability::encoded_len).sum();
+    let cap_total = u16::try_from(cap_total).map_err(|_| EncodeError::ValueOutOfRange {
+        field: "capabilities_parameter_length",
+        value: cap_total.to_string(),
+    })?;
+
+    buf.put_u8(param_type::CAPABILITIES);
+    buf.put_u16(cap_total);
     for cap in capabilities {
         cap.encode(buf)?;
     }

--- a/crates/wire/src/constants.rs
+++ b/crates/wire/src/constants.rs
@@ -55,6 +55,8 @@ pub mod message_type {
 pub mod param_type {
     /// Capabilities Optional Parameter (RFC 5492).
     pub const CAPABILITIES: u8 = 2;
+    /// RFC 9072 extended Optional Parameters Length marker.
+    pub const EXTENDED_LENGTH: u8 = 255;
 }
 
 /// Capability codes (IANA BGP Capability Codes registry).

--- a/crates/wire/src/error.rs
+++ b/crates/wire/src/error.rs
@@ -66,6 +66,13 @@ pub enum DecodeError {
         detail: String,
     },
 
+    /// An OPEN carried an Optional Parameter type we do not support.
+    #[error("unsupported optional parameter type {param_type}")]
+    UnsupportedOptionalParameter {
+        /// The unrecognized Optional Parameter type code.
+        param_type: u8,
+    },
+
     /// UPDATE withdrawn/attribute/NLRI length fields are inconsistent.
     #[error("UPDATE length mismatch: {detail}")]
     UpdateLengthMismatch {
@@ -157,6 +164,11 @@ impl DecodeError {
             Self::MalformedField { message_type, .. } if *message_type == "UPDATE" => (
                 NotificationCode::UpdateMessage,
                 1, // Malformed Attribute List
+                Bytes::new(),
+            ),
+            Self::UnsupportedOptionalParameter { .. } => (
+                NotificationCode::OpenMessage,
+                4, // Unsupported Optional Parameter
                 Bytes::new(),
             ),
             Self::MalformedField { .. } | Self::MalformedOptionalParameter { .. } => {
@@ -275,5 +287,16 @@ mod tests {
         let (code, subcode, _) = err.to_notification();
         assert_eq!(code, NotificationCode::OpenMessage);
         assert_eq!(subcode, 0);
+    }
+
+    #[test]
+    fn unsupported_optional_parameter_maps_to_open_error_subcode_four() {
+        // Mutation-red: mapping this error through the generic OPEN branch
+        // changes the subcode from RFC 4271 Unsupported Optional Parameter (4).
+        let err = DecodeError::UnsupportedOptionalParameter { param_type: 99 };
+        let (code, subcode, data) = err.to_notification();
+        assert_eq!(code, NotificationCode::OpenMessage);
+        assert_eq!(subcode, 4);
+        assert!(data.is_empty());
     }
 }

--- a/crates/wire/src/header.rs
+++ b/crates/wire/src/header.rs
@@ -1,6 +1,6 @@
 use bytes::{Buf, BufMut};
 
-use crate::constants::{self, HEADER_LEN, MARKER, MARKER_LEN, MIN_MESSAGE_LEN};
+use crate::constants::{self, HEADER_LEN, MARKER, MARKER_LEN, MAX_MESSAGE_LEN, MIN_MESSAGE_LEN};
 use crate::error::DecodeError;
 
 /// BGP message type codes.
@@ -68,7 +68,8 @@ impl BgpHeader {
     ///
     /// `max_message_len` is the negotiated maximum message length: 4096
     /// normally, or 65535 when Extended Messages (RFC 8654) has been
-    /// negotiated.
+    /// negotiated. OPEN and KEEPALIVE are excluded by RFC 8654 and remain
+    /// capped at 4096 regardless of the supplied session limit.
     ///
     /// # Errors
     ///
@@ -97,6 +98,11 @@ impl BgpHeader {
         let type_byte = buf.get_u8();
         let message_type =
             MessageType::from_u8(type_byte).ok_or(DecodeError::UnknownMessageType(type_byte))?;
+        if matches!(message_type, MessageType::Open | MessageType::Keepalive)
+            && length > MAX_MESSAGE_LEN
+        {
+            return Err(DecodeError::InvalidLength { length });
+        }
 
         Ok(Self {
             length,
@@ -120,6 +126,8 @@ impl BgpHeader {
 ///
 /// `max_message_len` is the negotiated maximum message length: 4096
 /// normally, or 65535 when Extended Messages (RFC 8654) has been negotiated.
+/// OPEN and KEEPALIVE remain capped at 4096 and are rejected here before a
+/// framing caller buffers the declared body.
 ///
 /// Does NOT advance the buffer.
 ///
@@ -143,8 +151,12 @@ pub fn peek_message_length(buf: &[u8], max_message_len: u16) -> Result<Option<u1
     }
 
     let type_byte = buf[18];
-    if MessageType::from_u8(type_byte).is_none() {
-        return Err(DecodeError::UnknownMessageType(type_byte));
+    let message_type =
+        MessageType::from_u8(type_byte).ok_or(DecodeError::UnknownMessageType(type_byte))?;
+    if matches!(message_type, MessageType::Open | MessageType::Keepalive)
+        && length > MAX_MESSAGE_LEN
+    {
+        return Err(DecodeError::InvalidLength { length });
     }
 
     Ok(Some(length))
@@ -276,6 +288,20 @@ mod tests {
     }
 
     #[test]
+    fn extended_limit_excludes_open_and_keepalive_during_header_decode() {
+        for msg_type in [MessageType::Open, MessageType::Keepalive] {
+            let mut buf = make_header(4097, msg_type.as_u8()).freeze();
+
+            // Mutation-red: removing either per-type branch lets its 4097-byte
+            // header through under the negotiated extended limit.
+            assert_eq!(
+                BgpHeader::decode(&mut buf, EXTENDED_MAX_MESSAGE_LEN),
+                Err(DecodeError::InvalidLength { length: 4097 })
+            );
+        }
+    }
+
+    #[test]
     fn standard_rejects_4097() {
         let mut buf = make_header(4097, 2).freeze();
         assert!(matches!(
@@ -291,6 +317,20 @@ mod tests {
             peek_message_length(&buf, EXTENDED_MAX_MESSAGE_LEN).unwrap(),
             Some(5000)
         );
+    }
+
+    #[test]
+    fn peek_extended_limit_excludes_open_and_keepalive_before_buffering() {
+        for msg_type in [MessageType::Open, MessageType::Keepalive] {
+            let buf = make_header(4097, msg_type.as_u8());
+
+            // Mutation-red: removing the peek guard returns Some(4097), which
+            // makes transport wait for and buffer an invalid excluded PDU.
+            assert_eq!(
+                peek_message_length(&buf, EXTENDED_MAX_MESSAGE_LEN),
+                Err(DecodeError::InvalidLength { length: 4097 })
+            );
+        }
     }
 
     #[test]

--- a/crates/wire/src/message.rs
+++ b/crates/wire/src/message.rs
@@ -59,7 +59,8 @@ impl std::fmt::Display for Message {
 /// to determine when a complete message is available.
 ///
 /// `max_message_len` is the negotiated maximum: 4096 normally, or 65535
-/// when Extended Messages (RFC 8654) has been negotiated.
+/// when Extended Messages (RFC 8654) has been negotiated. OPEN and KEEPALIVE
+/// are excluded from the extension and remain capped at 4096.
 ///
 /// Advances the buffer past the consumed bytes on success.
 ///
@@ -299,6 +300,27 @@ mod tests {
             }],
         });
         assert!(encode_message_with_limit(&msg, EXTENDED_MAX_MESSAGE_LEN).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_4097_byte_open_under_extended_limit_as_header_error() {
+        let mut encoded = BytesMut::with_capacity(4097);
+        BgpHeader {
+            length: 4097,
+            message_type: MessageType::Open,
+        }
+        .encode(&mut encoded);
+        encoded.resize(4097, 0);
+
+        let err = decode_message(&mut encoded.freeze(), EXTENDED_MAX_MESSAGE_LEN).unwrap_err();
+
+        // Mutation-red: removing the header's per-type receive cap changes
+        // this from Bad Message Length to a later OPEN-body decode result.
+        assert_eq!(err, DecodeError::InvalidLength { length: 4097 });
+        let (code, subcode, data) = err.to_notification();
+        assert_eq!(code, NotificationCode::MessageHeader);
+        assert_eq!(subcode, 2);
+        assert_eq!(data.as_ref(), &4097_u16.to_be_bytes());
     }
 
     #[test]

--- a/crates/wire/src/open.rs
+++ b/crates/wire/src/open.rs
@@ -2,8 +2,11 @@ use std::net::Ipv4Addr;
 
 use bytes::{Buf, BufMut, BytesMut};
 
-use crate::capability::{Capability, decode_optional_parameters, encode_optional_parameters};
-use crate::constants::{BGP_VERSION, HEADER_LEN, MAX_MESSAGE_LEN};
+use crate::capability::{
+    Capability, decode_extended_optional_parameters, decode_optional_parameters,
+    encode_extended_optional_parameters, encode_optional_parameters,
+};
+use crate::constants::{BGP_VERSION, HEADER_LEN, MAX_MESSAGE_LEN, param_type};
 use crate::error::{DecodeError, EncodeError};
 use crate::header::{BgpHeader, MessageType};
 
@@ -57,21 +60,43 @@ impl OpenMessage {
         let my_as = buf.get_u16();
         let hold_time = buf.get_u16();
         let bgp_identifier = Ipv4Addr::from(buf.get_u32());
-        let opt_params_len = buf.get_u8();
+        let non_extended_len = buf.get_u8();
+        let mut optional_parameters = buf.copy_to_bytes(body_len - 10);
 
-        // Validate opt_params_len fits within the remaining body
-        let expected_body = 10 + usize::from(opt_params_len);
-        if expected_body != body_len {
-            return Err(DecodeError::MalformedField {
-                message_type: "OPEN",
-                detail: format!(
-                    "optional parameters length {opt_params_len} inconsistent \
-                     with body length {body_len} (expected {expected_body})"
-                ),
-            });
-        }
-
-        let capabilities = decode_optional_parameters(buf, opt_params_len)?;
+        let capabilities = if non_extended_len != 0
+            && optional_parameters.first() == Some(&param_type::EXTENDED_LENGTH)
+        {
+            if optional_parameters.remaining() < 3 {
+                return Err(DecodeError::MalformedOptionalParameter {
+                    offset: 0,
+                    detail: "extended optional parameters header too short".into(),
+                });
+            }
+            optional_parameters.advance(1); // Non-Ext OP Type marker.
+            let extended_len = optional_parameters.get_u16();
+            if optional_parameters.remaining() != usize::from(extended_len) {
+                return Err(DecodeError::MalformedField {
+                    message_type: "OPEN",
+                    detail: format!(
+                        "extended optional parameters length {extended_len} inconsistent \
+                         with body length {body_len}"
+                    ),
+                });
+            }
+            decode_extended_optional_parameters(&mut optional_parameters, extended_len)?
+        } else {
+            if optional_parameters.remaining() != usize::from(non_extended_len) {
+                let expected_body = 10 + usize::from(non_extended_len);
+                return Err(DecodeError::MalformedField {
+                    message_type: "OPEN",
+                    detail: format!(
+                        "optional parameters length {non_extended_len} inconsistent \
+                         with body length {body_len} (expected {expected_body})"
+                    ),
+                });
+            }
+            decode_optional_parameters(&mut optional_parameters, non_extended_len)?
+        };
 
         Ok(Self {
             version,
@@ -86,22 +111,21 @@ impl OpenMessage {
     ///
     /// # Errors
     ///
-    /// Returns an [`EncodeError`] if the optional parameters exceed 255 bytes
-    /// or the total message exceeds the maximum BGP message size.
+    /// Returns an [`EncodeError`] if an individual capability cannot be
+    /// encoded or the total OPEN exceeds the 4096-byte BGP message limit.
     pub fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
-        // Calculate optional parameters size
+        let capabilities_len: usize = self.capabilities.iter().map(Capability::encoded_len).sum();
+        let use_extended = !self.capabilities.is_empty() && capabilities_len + 2 > 255;
         let mut opt_params = BytesMut::new();
-        encode_optional_parameters(&self.capabilities, &mut opt_params)?;
+        if use_extended {
+            encode_extended_optional_parameters(&self.capabilities, &mut opt_params)?;
+        } else {
+            encode_optional_parameters(&self.capabilities, &mut opt_params)?;
+        }
         let opt_params_len = opt_params.len();
 
-        if opt_params_len > 255 {
-            return Err(EncodeError::ValueOutOfRange {
-                field: "optional_parameters_length",
-                value: opt_params_len.to_string(),
-            });
-        }
-
-        let total_len = HEADER_LEN + 10 + opt_params_len;
+        let body_prefix_len = if use_extended { 13 } else { 10 };
+        let total_len = HEADER_LEN + body_prefix_len + opt_params_len;
         if total_len > usize::from(MAX_MESSAGE_LEN) {
             return Err(EncodeError::MessageTooLong { size: total_len });
         }
@@ -122,11 +146,22 @@ impl OpenMessage {
         buf.put_u16(self.my_as);
         buf.put_u16(self.hold_time);
         buf.put_u32(u32::from(self.bgp_identifier));
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "codec bounds or masks the value before narrowing to the protocol field width"
-        )]
-        buf.put_u8(opt_params_len as u8);
+        if use_extended {
+            buf.put_u8(param_type::EXTENDED_LENGTH);
+            buf.put_u8(param_type::EXTENDED_LENGTH);
+            let opt_params_len =
+                u16::try_from(opt_params_len).map_err(|_| EncodeError::ValueOutOfRange {
+                    field: "optional_parameters_length",
+                    value: opt_params_len.to_string(),
+                })?;
+            buf.put_u16(opt_params_len);
+        } else {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "classic framing is selected only through 255 optional-parameter octets"
+            )]
+            buf.put_u8(opt_params_len as u8);
+        }
         buf.put_slice(&opt_params);
 
         Ok(())
@@ -136,9 +171,15 @@ impl OpenMessage {
     #[must_use]
     pub fn encoded_len(&self) -> usize {
         let cap_size: usize = self.capabilities.iter().map(Capability::encoded_len).sum();
-        // opt params wrapper: type(1) + len(1) per parameter block
-        let opt_params_overhead = if self.capabilities.is_empty() { 0 } else { 2 };
-        HEADER_LEN + 10 + opt_params_overhead + cap_size
+        if self.capabilities.is_empty() {
+            HEADER_LEN + 10
+        } else if cap_size + 2 <= 255 {
+            HEADER_LEN + 10 + 2 + cap_size
+        } else {
+            // Extended OPEN prefix adds marker type(1) + u16 aggregate
+            // length(2); the capability parameter uses a u16 length (3).
+            HEADER_LEN + 13 + 3 + cap_size
+        }
     }
 
     /// Extract the 4-byte ASN from capabilities, if advertised.
@@ -211,6 +252,209 @@ mod tests {
         let body_len = usize::from(header.length) - HEADER_LEN;
         let decoded = OpenMessage::decode(&mut bytes, body_len).unwrap();
         assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn classic_encoding_carries_255_optional_parameter_octets() {
+        // Capability TLV 253 + classic parameter header 2 = 255.
+        let mut original = minimal_open();
+        original.capabilities = vec![Capability::Unknown {
+            code: 200,
+            data: bytes::Bytes::from(vec![0xA5; 251]),
+        }];
+
+        let mut encoded = BytesMut::new();
+        original.encode(&mut encoded).unwrap();
+
+        // Mutation-red: selecting extended framing at >=255 changes both
+        // these boundary octets and the encoded length.
+        assert_eq!(encoded.len(), 284);
+        assert_eq!(encoded[28], 255); // classic aggregate length
+        assert_eq!(encoded[29], param_type::CAPABILITIES);
+        assert_eq!(encoded[30], 253); // classic parameter length
+
+        let mut bytes = encoded.freeze();
+        let header = BgpHeader::decode(&mut bytes, MAX_MESSAGE_LEN).unwrap();
+        let decoded =
+            OpenMessage::decode(&mut bytes, usize::from(header.length) - HEADER_LEN).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn extended_encoding_starts_above_255_optional_parameter_octets() {
+        // Capability TLV 254 cannot fit behind the classic 2-byte parameter
+        // header, so RFC 9072 widens both enclosing length fields.
+        let mut original = minimal_open();
+        original.capabilities = vec![Capability::Unknown {
+            code: 200,
+            data: bytes::Bytes::from(vec![0x5A; 252]),
+        }];
+
+        let mut encoded = BytesMut::new();
+        original.encode(&mut encoded).unwrap();
+
+        // Mutation-red: restoring the old 255-byte ceiling makes encode fail;
+        // keeping the classic parameter length changes these exact bytes.
+        assert_eq!(encoded.len(), 289);
+        assert_eq!(encoded[28], param_type::EXTENDED_LENGTH);
+        assert_eq!(encoded[29], param_type::EXTENDED_LENGTH);
+        assert_eq!(&encoded[30..32], &257_u16.to_be_bytes());
+        assert_eq!(encoded[32], param_type::CAPABILITIES);
+        assert_eq!(&encoded[33..35], &254_u16.to_be_bytes());
+        assert_eq!(original.encoded_len(), encoded.len());
+
+        let mut bytes = encoded.freeze();
+        let header = BgpHeader::decode(&mut bytes, MAX_MESSAGE_LEN).unwrap();
+        let decoded =
+            OpenMessage::decode(&mut bytes, usize::from(header.length) - HEADER_LEN).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    fn extended_open_body(non_extended_len: u8, parameters: &[u8]) -> BytesMut {
+        let mut body = BytesMut::new();
+        body.put_u8(BGP_VERSION);
+        body.put_u16(65001);
+        body.put_u16(90);
+        body.put_u32(u32::from(Ipv4Addr::new(10, 0, 0, 1)));
+        body.put_u8(non_extended_len);
+        body.put_u8(param_type::EXTENDED_LENGTH);
+        body.put_u16(u16::try_from(parameters.len()).unwrap());
+        body.put_slice(parameters);
+        body
+    }
+
+    #[test]
+    fn decode_accepts_forced_small_extended_encoding() {
+        let parameters = [
+            param_type::CAPABILITIES,
+            0,
+            4, // extended parameter length
+            200,
+            2,
+            0xAA,
+            0xBB, // unknown capability preserved inside type 2
+        ];
+        // RFC 9072 says the non-extended length is ignored once marker 255 is
+        // seen; use 1 to prove receivers do not require the recommended 255.
+        let mut body = extended_open_body(1, &parameters).freeze();
+        let body_len = body.len();
+        let decoded = OpenMessage::decode(&mut body, body_len).unwrap();
+
+        // Mutation-red: requiring the marker length to be 255 or decoding
+        // parameter lengths as u8 rejects/misparses this OPEN.
+        assert_eq!(
+            decoded.capabilities,
+            vec![Capability::Unknown {
+                code: 200,
+                data: bytes::Bytes::from_static(&[0xAA, 0xBB]),
+            }]
+        );
+    }
+
+    #[test]
+    fn decode_accepts_zero_length_extended_encoding() {
+        let mut body = extended_open_body(255, &[]).freeze();
+        let body_len = body.len();
+        let decoded = OpenMessage::decode(&mut body, body_len).unwrap();
+
+        // Mutation-red: treating an extended length of zero as truncated or
+        // falling back to classic framing makes this fail.
+        assert!(decoded.capabilities.is_empty());
+    }
+
+    #[test]
+    fn decode_rejects_inconsistent_extended_aggregate_length() {
+        let mut body = extended_open_body(255, &[]);
+        body[11] = 0;
+        body[12] = 1; // claim one parameter octet, provide none
+        let body_len = body.len();
+        let result = OpenMessage::decode(&mut body.freeze(), body_len);
+
+        // Mutation-red: dropping the aggregate/body consistency check accepts
+        // this structurally truncated extended OPEN.
+        assert!(matches!(result, Err(DecodeError::MalformedField { .. })));
+    }
+
+    #[test]
+    fn decode_rejects_unknown_optional_parameter_type() {
+        let body: &[u8] = &[
+            4, 0xFD, 0xE9, 0, 90, 10, 0, 0, 1, 3, // fixed OPEN + opt len
+            99, 1, 0xAA, // unsupported Optional Parameter
+        ];
+        let mut body = bytes::Bytes::copy_from_slice(body);
+        let result = OpenMessage::decode(&mut body, 13);
+
+        // Mutation-red: restoring the previous skip-unknown behavior returns
+        // a successful OPEN instead of the RFC 4271 2/4 error source.
+        assert_eq!(
+            result,
+            Err(DecodeError::UnsupportedOptionalParameter { param_type: 99 })
+        );
+    }
+
+    #[test]
+    fn extended_length_marker_is_unsupported_inside_parameter_list() {
+        let parameters = [param_type::EXTENDED_LENGTH, 0, 0];
+        let mut body = extended_open_body(255, &parameters).freeze();
+        let body_len = body.len();
+        let result = OpenMessage::decode(&mut body, body_len);
+
+        // Mutation-red: treating type 255 as a normal/skippable parameter
+        // outside its marker position accepts a forbidden encoding.
+        assert_eq!(
+            result,
+            Err(DecodeError::UnsupportedOptionalParameter {
+                param_type: param_type::EXTENDED_LENGTH,
+            })
+        );
+    }
+
+    fn unknown_capabilities_with_encoded_len(mut encoded_len: usize) -> Vec<Capability> {
+        let mut capabilities = Vec::new();
+        let mut code = 128_u8;
+        while encoded_len > 257 {
+            capabilities.push(Capability::Unknown {
+                code,
+                data: bytes::Bytes::from(vec![0; 255]),
+            });
+            code = code.wrapping_add(1);
+            encoded_len -= 257;
+        }
+        assert!(encoded_len >= 2);
+        capabilities.push(Capability::Unknown {
+            code,
+            data: bytes::Bytes::from(vec![0; encoded_len - 2]),
+        });
+        capabilities
+    }
+
+    #[test]
+    fn extended_open_accepts_4096_and_rejects_4097_atomically() {
+        let mut at_limit = minimal_open();
+        // Extended framing is 35 bytes: header 19 + body prefix 13 +
+        // capability-parameter header 3. 4061 capability bytes land at 4096.
+        at_limit.capabilities = unknown_capabilities_with_encoded_len(4061);
+        let mut encoded = BytesMut::new();
+        at_limit.encode(&mut encoded).unwrap();
+
+        // Mutation-red: changing the limit check from > to >= rejects this
+        // exact legal boundary.
+        assert_eq!(encoded.len(), 4096);
+        let mut bytes = encoded.freeze();
+        let header = BgpHeader::decode(&mut bytes, MAX_MESSAGE_LEN).unwrap();
+        let decoded =
+            OpenMessage::decode(&mut bytes, usize::from(header.length) - HEADER_LEN).unwrap();
+        assert_eq!(decoded, at_limit);
+
+        let mut over_limit = minimal_open();
+        over_limit.capabilities = unknown_capabilities_with_encoded_len(4062);
+        let mut encoded = BytesMut::new();
+        let result = over_limit.encode(&mut encoded);
+
+        // Mutation-red: removing the OPEN cap makes this exact 4097-byte
+        // message encode successfully.
+        assert_eq!(result, Err(EncodeError::MessageTooLong { size: 4097 }));
+        assert!(encoded.is_empty());
     }
 
     #[test]

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -804,6 +804,24 @@ does not change that boundary.
 
 ---
 
+## RFC 9072 — Extended OPEN Optional Parameters Length
+
+- Outbound OPEN messages retain the RFC 4271 format while the complete
+  Optional Parameters field is at most 255 octets. Larger fields use Optional
+  Parameter type 255 as the extended-length marker, a 16-bit aggregate length,
+  and 16-bit lengths for each enclosed Optional Parameter.
+- Extended-format OPEN messages are accepted even when their aggregate length
+  is 255 or less, including zero. The non-extended length octet is ignored
+  after the type-255 marker is recognized, as required by RFC 9072 §2.
+- The Capabilities Optional Parameter remains type 2, and individual capability
+  TLVs retain their 8-bit value lengths. Unknown capabilities are preserved;
+  an unknown Optional Parameter type is rejected with OPEN Message Error /
+  Unsupported Optional Parameter (2/4) and empty Notification Data.
+- RFC 8654 does not extend OPEN: both classic and RFC 9072 encodings remain
+  subject to the 4096-byte message maximum.
+
+---
+
 ## RFC 7911 — Add-Path
 
 ### Experimental Paths-Limit


### PR DESCRIPTION
## Summary

- retain classic BGP OPEN Optional Parameters framing through exactly 255 octets and emit RFC 9072 extended framing only above that boundary
- accept forced-small and zero-length extended OPENs while validating the aggregate and per-parameter lengths exactly
- reject unsupported Optional Parameter types with OPEN 2/4 while continuing to accept unknown capabilities inside parameter type 2
- keep OPEN and KEEPALIVE capped at 4096 bytes during header decode and pre-buffer peeking even after RFC 8654 Extended Messages negotiation
- document the wire behavior and cover the real maximum production capability set

## Operator impact

The largest currently valid configuration advertises 307 capability bytes. Before this change, rustbgpd could not encode its own OPEN and retried the session indefinitely. It now emits a 342-byte RFC 9072 OPEN and round-trips it through the production codec.

Peers without RFC 9072 support may reject a genuinely extended OPEN. rustbgpd does not silently strip configured capabilities or retry with a weaker capability set.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- `cargo test -p rustbgpd-wire` — 598 unit tests plus 14 property tests
- `cargo test -p rustbgpd-fsm` — production capability fixture and crate suite
- independent exact-diff standards review: GO

No live external-peer interop was run for this wire-codec change. Exact wire fixtures, round trips, production capability construction, property tests, and boundary mutations cover the protocol behavior.

## Load-bearing proof

Each mutation was applied independently, made its named proof red, and was restored before the final quartet:

- disable extended selection: first-over-255 and 307-byte production fixture fail
- change the threshold to extend at 255: exact classic-255 proof fails
- require the legacy marker length to equal 255: forced-small extended receive fails
- reject zero aggregate length: zero-length extended receive fails
- ignore aggregate inconsistency: truncated aggregate proof fails
- restore unknown-parameter skipping or generic error mapping: OPEN 2/4 proofs fail
- decode extended parameter length as u8: u16 fixture fails
- weaken outbound OPEN cap or make it inclusive: exact 4096/4097 proofs fail
- remove header or peek excluded-type caps: exact 4097 receive and pre-buffering proofs fail

## Standards

- [RFC 9072 section 2](https://www.rfc-editor.org/rfc/rfc9072.html#section-2)
- [RFC 4271 section 6.2](https://www.rfc-editor.org/rfc/rfc4271.html#section-6.2)
- [RFC 5492 section 3](https://www.rfc-editor.org/rfc/rfc5492.html#section-3)
- [RFC 8654 sections 4-6](https://www.rfc-editor.org/rfc/rfc8654.html#section-4)

Linear: LAN-562