### PR TITLE
fix(wire): enforce RFC 9552 BGP-LS attribute framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **RFC 9552 BGP-LS Attribute fault isolation.** Attribute 29 now enforces its
+  optional non-transitive flags and contained TLV framing. Malformed contained
+  framing discards only the complete attribute while preserving the BGP-LS
+  NLRI and session; valid unknown TLVs remain byte-stable for reflection.
+
 - **GShut receiver verification is executable from `rbgp`.** The runbook uses
   the parse-valid received-RIB command, whose JSON now exposes optional
   `local_pref_attr` so operators can distinguish an explicit demotion to zero.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -525,11 +525,11 @@ Details in the "Recently shipped" section below and ADR-0097.
 - **RFC 9857 SR Policy state in BGP-LS** (receive/reflect/API) — ADR-0116
   records a bounded fit for the controller-feed / RR niche, but feature code is
   a no-go until a named controller demand supplies a real producer, consumer,
-  and UPDATE capture. The type-5 NLRI and Attribute 29 bytes already pass opaquely;
-  generic RFC 9552 Attribute 29 framing/discard correctness and a consumer-
-  shaped API are prerequisites for typed SAFI-71 support. Origination, PCEP /
-  SRPM, TE computation, dataplane programming, Add-Path changes, and typed
-  SAFI-72 claims remain out of scope.
+  and UPDATE capture. The type-5 NLRI and Attribute 29 bytes pass opaquely, and
+  generic RFC 9552 Attribute 29 framing/discard correctness is shipped. A
+  consumer-shaped API remains a prerequisite for typed SAFI-71 support.
+  Origination, PCEP / SRPM, TE computation, dataplane programming, Add-Path
+  changes, and typed SAFI-72 claims remain out of scope.
 - ~~**ASPA/RTRv2 conformance refresh**~~ **Shipped (M84/#759, LAN-243):**
   multi-cache RTR v1/v2 epoch, reconnect, replacement, withdrawal, and serial-
   regression behavior is retained in the interop receipt.

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -11,7 +11,7 @@ use rustbgpd_wire::{
     AddressPrefixOrf, AsPath, AsPathSegment, FlowSpecComponent, FlowSpecPrefix, FlowSpecRule,
     Ipv4NlriEntry, Ipv4Prefix, Ipv6Prefix, Ipv6PrefixOffset, LlgrFamily, Message, MplsLabelEntry,
     NumericMatch, OrfAction, OrfEntries, OrfEntryGroup, OrfMatch, OrfPayload, OrfType, Origin,
-    PathAttribute, RouteDistinguisher, VpnNlri, VpnPrefix, WhenToRefresh,
+    PathAttribute, RawAttribute, RouteDistinguisher, VpnNlri, VpnPrefix, WhenToRefresh,
     bgpls::{BgpLsNlri, BgpLsNlriType, decode_bgpls_nlri, decode_bgpls_vpn_nlri},
 };
 use std::collections::HashMap;
@@ -16457,6 +16457,92 @@ async fn rfc7606_attribute_discard_keeps_announcement_and_session() {
     };
     assert_eq!(announced.len(), 1);
     assert_eq!(announced[0].prefix, Prefix::V4(prefix));
+    assert_eq!(session.fsm.state(), SessionState::Established);
+    assert_single_malformed_disposition(&session, "attribute_discard");
+}
+
+/// RFC 9552 §8.2.2: malformed TLV framing discards the complete BGP-LS
+/// Attribute while preserving its BGP-LS NLRI and the session.
+///
+/// Load-bearing live proof: bypassing the Attribute 29 parser leaves type 29
+/// on the delivered route and fails the absence assertion; changing its
+/// disposition to treat-as-withdraw removes the announcement and fails the
+/// `BgpLsRoutesReceived` assertion.
+#[tokio::test]
+async fn bgpls_attribute_discard_keeps_nlri_and_session() {
+    use rustbgpd_wire::MpReachNlri;
+
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::BgpLs, Safi::BgpLs)];
+    install_test_negotiated_session(&mut session, negotiated);
+
+    let nlri = BgpLsNlri::try_new(
+        BgpLsNlriType::Unknown(65_000),
+        None,
+        Bytes::from_static(&[0xaa, 0xbb, 0xcc]),
+    )
+    .unwrap();
+    let attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+        PathAttribute::MpReachNlri(MpReachNlri {
+            afi: Afi::BgpLs,
+            safi: Safi::BgpLs,
+            next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)),
+            link_local_next_hop: None,
+            announced: vec![],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![nlri.clone()],
+            labeled_announced: vec![],
+            vpn_announced: vec![],
+            rtc_announced: vec![],
+        }),
+        PathAttribute::Unknown(RawAttribute {
+            flags: rustbgpd_wire::constants::attr_flags::OPTIONAL,
+            type_code: rustbgpd_wire::constants::attr_type::BGP_LS,
+            // IGP Metric TLV 1095 declares four bytes but only three remain.
+            data: Bytes::from_static(&[0x04, 0x47, 0, 4, 0, 0, 7]),
+        }),
+    ];
+
+    session
+        .process_update(UpdateMessage::build(
+            &[],
+            &[],
+            &attrs,
+            true,
+            false,
+            Ipv4UnicastMode::Body,
+        ))
+        .await;
+
+    let RibUpdate::BgpLsRoutesReceived {
+        announced,
+        withdrawn,
+        ..
+    } = rib_rx.try_recv().expect("BGP-LS NLRI must survive")
+    else {
+        panic!("expected BgpLsRoutesReceived");
+    };
+    assert_eq!(announced.len(), 1);
+    assert_eq!(announced[0].nlri, nlri);
+    assert!(withdrawn.is_empty());
+    assert!(
+        !announced[0]
+            .attributes
+            .iter()
+            .any(|attr| attr.type_code() == rustbgpd_wire::constants::attr_type::BGP_LS),
+        "the malformed Attribute 29 must not enter Adj-RIB-In"
+    );
     assert_eq!(session.fsm.state(), SessionState::Established);
     assert_single_malformed_disposition(&session, "attribute_discard");
 }

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -61,7 +61,7 @@ analyzers, test harnesses, MRT readers, etc.
 | 9136 | EVPN Type 5: IP Prefix advertisement |
 | 9234 | BGP Roles (OPEN capability code 9, `BgpRole`) + Only-to-Customer path attribute (type 35, `PathAttribute::OnlyToCustomer`). Codec only; malformed-length OTC is preserved as `Unknown` (not a fatal decode) so transport can apply RFC 7606 treat-as-withdraw. Negotiation + ingress/egress rules live in the daemon (ADR-0071) |
 | 9494 | Long-lived graceful restart capability |
-| 9552 | BGP-LS and BGP-LS-VPN NLRI/TLV codec with opaque preservation of unknown NLRI types and TLVs. The daemon consumes it for the ADR-0077 receive/API tranche. Typed topology read accessors now live in the crate (the `bgpls_topo` module); outbound reflection and topology production remain outside the wire crate |
+| 9552 | BGP-LS and BGP-LS-VPN NLRI/TLV codec with opaque preservation of unknown NLRI types and TLVs. Attribute 29 enforces optional non-transitive flags and structural TLV framing; malformed contained framing uses RFC 9552 whole-attribute discard while retaining the NLRI. The daemon consumes the codec for the ADR-0077 receive/API tranche. Typed topology read accessors live in `bgpls_topo`; local topology production remains outside the wire crate |
 | 9687 | Send Hold Timer: NOTIFICATION code 8 (`NotificationCode::SendHoldTimerExpired`, subcode always 0 per §6). Codec only — the timer itself lives in the daemon |
 | 9785 §3 | DF Election preference algorithms + Don't-Preempt bit, extending the RFC 8584 DF Election Extended Community |
 | draft-abraitis-idr-addpath-paths-limit-04 | Experimental Paths-Limit capability (`PathsLimitFamily`, IANA-assigned capability code 76). The draft is expired and archived; interoperability and behavior remain experimental |

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -905,6 +905,9 @@ pub struct RevisedAttributeDecode {
 /// - §7.6/§7.7: `ATOMIC_AGGREGATE` with a non-zero length and `AGGREGATOR`
 ///   with a length other than 6/8 (by the 4-octet-AS negotiation) are
 ///   attribute-discard. The legacy decoder passes both through opaquely.
+/// - RFC 9552 §8.2.2: malformed TLV framing inside Attribute 29 is
+///   attribute-discard; the attribute is omitted while the NLRI remains
+///   available to the caller.
 ///
 /// `is_ibgp` selects the internal-neighbor branch of
 /// [`malformed_attr_disposition`] for `LOCAL_PREF` / `ORIGINATOR_ID` /
@@ -1090,8 +1093,18 @@ fn decode_attribute_value(
     add_path_families: &[(Afi, Safi)],
     bgpls_discarded: &mut u32,
 ) -> Result<PathAttribute, DecodeError> {
-    // Validate Optional + Transitive flags for known attribute types (RFC 4271 §6.3).
-    let flags_mask = attr_flags::OPTIONAL | attr_flags::TRANSITIVE;
+    // Validate the required flags for known attribute types (RFC 4271 §6.3).
+    // RFC 4271 §4.3 requires Partial=0 for optional non-transitive
+    // attributes. Existing typed attributes predate strict Partial checking;
+    // include it for newly recognized Attribute 29 without broadening their
+    // error surface in this change.
+    let flags_mask = attr_flags::OPTIONAL
+        | attr_flags::TRANSITIVE
+        | if type_code == attr_type::BGP_LS {
+            attr_flags::PARTIAL
+        } else {
+            0
+        };
     if let Some(expected) = expected_flags(type_code)
         && (flags & flags_mask) != expected
     {
@@ -1264,6 +1277,24 @@ fn decode_attribute_value(
         attr_type::PMSI_TUNNEL => {
             let pmsi = crate::pmsi::PmsiTunnel::decode(value)?;
             Ok(PathAttribute::PmsiTunnel(pmsi))
+        }
+        attr_type::BGP_LS => {
+            // RFC 9552 §8.2.2: an intact path-attribute boundary containing
+            // malformed TLV framing discards the whole BGP-LS Attribute. Do
+            // not validate fixed/variable value lengths or semantics here;
+            // a BGP-LS propagator is explicitly forbidden from doing so.
+            crate::bgpls::validate_bgpls_tlv_framing(value).map_err(|error| {
+                DecodeError::UpdateAttributeError {
+                    subcode: update_subcode::ATTRIBUTE_LENGTH_ERROR,
+                    data: attr_error_data(flags, type_code, value),
+                    detail: error.to_string(),
+                }
+            })?;
+            Ok(PathAttribute::Unknown(RawAttribute {
+                flags,
+                type_code,
+                data: Bytes::copy_from_slice(value),
+            }))
         }
         attr_type::ONLY_TO_CUSTOMER => {
             // Preserve as Unknown(RawAttribute) in two cases — both keep
@@ -1984,7 +2015,8 @@ fn expected_flags(type_code: u8) -> Option<u8> {
         | attr_type::ORIGINATOR_ID
         | attr_type::CLUSTER_LIST
         | attr_type::MP_REACH_NLRI
-        | attr_type::MP_UNREACH_NLRI => Some(attr_flags::OPTIONAL),
+        | attr_type::MP_UNREACH_NLRI
+        | attr_type::BGP_LS => Some(attr_flags::OPTIONAL),
         // Optional transitive
         attr_type::AGGREGATOR
         | attr_type::COMMUNITIES
@@ -2289,8 +2321,11 @@ pub fn encode_path_attributes(
                 value.extend_from_slice(&raw.data);
             }
         }
-        // Use extended length if value > 255 bytes
-        if value.len() > 255 {
+        // Preserve an explicitly received Extended Length encoding on opaque
+        // attributes even when the value would fit in one octet. Otherwise
+        // Unknown reflection would retain the flag but emit a one-octet
+        // length, corrupting the attribute boundary.
+        if value.len() > 255 || (flags & attr_flags::EXTENDED_LENGTH) != 0 {
             buf.push(flags | attr_flags::EXTENDED_LENGTH);
             buf.push(type_code);
             #[expect(
@@ -5326,6 +5361,108 @@ mod tests {
         buf.extend(valid_next_hop_bytes());
         buf.extend_from_slice(extra);
         buf
+    }
+    /// Load-bearing flag proof: removing Attribute 29 from `expected_flags`,
+    /// or omitting its Partial-bit check, accepts one of these fixtures.
+    #[test]
+    fn revised_bgpls_attribute_enforces_exact_flags() {
+        let value = [0x04, 0x47, 0, 1, 7]; // IGP Metric TLV, 1-byte value
+        for bad_flags in [
+            attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
+            attr_flags::OPTIONAL | attr_flags::PARTIAL,
+        ] {
+            let decoded = decode_path_attributes_revised(
+                &attr_bytes(bad_flags, attr_type::BGP_LS, &value),
+                true,
+                false,
+                &[],
+            )
+            .unwrap();
+            assert!(decoded.attributes.is_empty());
+            assert_eq!(decoded.malformed.len(), 1);
+            assert_eq!(decoded.malformed[0].type_code, attr_type::BGP_LS);
+            assert_eq!(
+                decoded.malformed[0].disposition,
+                ErrorDisposition::TreatAsWithdraw
+            );
+            assert!(matches!(
+                decoded.malformed[0].error,
+                DecodeError::UpdateAttributeError {
+                    subcode: update_subcode::ATTRIBUTE_FLAGS_ERROR,
+                    ..
+                }
+            ));
+        }
+    }
+    /// Load-bearing framing and disposition proof: bypassing the Attribute 29
+    /// TLV parser accepts this value, while changing its RFC 9552 disposition
+    /// to treat-as-withdraw fails the exact verdict below.
+    #[test]
+    fn revised_bgpls_attribute_truncated_tlv_is_attribute_discard() {
+        // Recognized IGP Metric TLV 1095 declares four value octets but only
+        // three remain inside the intact Attribute 29 boundary.
+        let value = [0x04, 0x47, 0, 4, 0, 0, 7];
+        let decoded = decode_path_attributes_revised(
+            &attr_bytes(attr_flags::OPTIONAL, attr_type::BGP_LS, &value),
+            true,
+            false,
+            &[],
+        )
+        .unwrap();
+        assert!(decoded.attributes.is_empty());
+        assert_eq!(decoded.malformed.len(), 1);
+        assert_eq!(decoded.malformed[0].type_code, attr_type::BGP_LS);
+        assert_eq!(
+            decoded.malformed[0].disposition,
+            ErrorDisposition::AttributeDiscard
+        );
+    }
+    /// Load-bearing forward-compatibility proof: rejecting a structurally
+    /// complete recognized TLV for a semantically impermissible value length,
+    /// rejecting an unknown TLV, or failing to retain the raw Attribute 29
+    /// payload makes the byte equality fail. Removing Attribute 29 flag
+    /// recognition accepts the mutated-flags copy and fails the final verdict.
+    #[test]
+    fn bgpls_attribute_unknown_tlv_roundtrips_byte_for_byte() {
+        let mut value = Vec::with_capacity(12);
+        // Node Flag Bits TLV 1024 has a specified one-octet value. A complete
+        // two-octet value is semantically impermissible, but RFC 9552 §8.2.2
+        // forbids a propagator from treating that as malformed.
+        value.extend_from_slice(&1024_u16.to_be_bytes());
+        value.extend_from_slice(&2_u16.to_be_bytes());
+        value.extend_from_slice(&[0xff, 0xff]);
+        // Unknown TLVs remain opaque and propagatable under RFC 9552 §5.1.
+        value.extend_from_slice(&65_000_u16.to_be_bytes());
+        value.extend_from_slice(&2_u16.to_be_bytes());
+        value.extend_from_slice(&[0xde, 0xad]);
+
+        let mut encoded = vec![
+            attr_flags::OPTIONAL | attr_flags::EXTENDED_LENGTH,
+            attr_type::BGP_LS,
+        ];
+        encoded.extend_from_slice(&u16::try_from(value.len()).unwrap().to_be_bytes());
+        encoded.extend_from_slice(&value);
+
+        let decoded = decode_path_attributes(&encoded, true, &[]).unwrap();
+        let [PathAttribute::Unknown(raw)] = decoded.as_slice() else {
+            panic!("valid BGP-LS Attribute must remain opaque");
+        };
+        assert_eq!(raw.type_code, attr_type::BGP_LS);
+        assert_eq!(raw.data.as_ref(), value);
+
+        let mut reencoded = Vec::new();
+        encode_path_attributes(&decoded, &mut reencoded, true, false).unwrap();
+        assert_eq!(reencoded, encoded);
+
+        let mut bad_flags = encoded;
+        bad_flags[0] |= attr_flags::TRANSITIVE;
+        let rejected = decode_path_attributes_revised(&bad_flags, true, false, &[]).unwrap();
+        assert!(rejected.attributes.is_empty());
+        assert_eq!(rejected.malformed.len(), 1);
+        assert_eq!(
+            rejected.malformed[0].disposition,
+            ErrorDisposition::TreatAsWithdraw
+        );
     }
     #[test]
     fn revised_malformed_med_is_treat_as_withdraw() {

--- a/crates/wire/src/bgpls.rs
+++ b/crates/wire/src/bgpls.rs
@@ -284,6 +284,25 @@ pub fn encode_bgpls_nlri(routes: &[BgpLsNlri], out: &mut Vec<u8>) -> Result<(), 
 /// Returns `DecodeError` if a TLV header or value is structurally truncated.
 pub fn decode_bgpls_tlvs(input: &[u8]) -> Result<Vec<BgpLsTlv>, DecodeError> {
     let mut tlvs = Vec::new();
+    visit_bgpls_tlvs(input, |type_code, value| {
+        tlvs.push(BgpLsTlv {
+            type_code,
+            value: Bytes::copy_from_slice(value),
+        });
+    })?;
+    Ok(tlvs)
+}
+
+/// Validate a sequence of BGP-LS TLV boundaries without retaining values.
+///
+/// # Errors
+///
+/// Returns `DecodeError` if a TLV header or value is structurally truncated.
+pub(crate) fn validate_bgpls_tlv_framing(input: &[u8]) -> Result<(), DecodeError> {
+    visit_bgpls_tlvs(input, |_, _| {})
+}
+
+fn visit_bgpls_tlvs(input: &[u8], mut visit: impl FnMut(u16, &[u8])) -> Result<(), DecodeError> {
     let mut offset = 0;
     while offset < input.len() {
         let remaining = input.len() - offset;
@@ -304,13 +323,10 @@ pub fn decode_bgpls_tlvs(input: &[u8]) -> Result<Vec<BgpLsTlv>, DecodeError> {
             )));
         }
 
-        tlvs.push(BgpLsTlv {
-            type_code,
-            value: Bytes::copy_from_slice(&input[offset..offset + value_len]),
-        });
+        visit(type_code, &input[offset..offset + value_len]);
         offset += value_len;
     }
-    Ok(tlvs)
+    Ok(())
 }
 
 /// Encode BGP-LS TLVs into `out`.

--- a/crates/wire/src/constants.rs
+++ b/crates/wire/src/constants.rs
@@ -155,6 +155,8 @@ pub mod attr_type {
     /// RFC 6514 §5: PMSI Tunnel attribute (used by EVPN Type 3 IMET
     /// for ingress-replication BUM).
     pub const PMSI_TUNNEL: u8 = 22;
+    /// RFC 9552 §5.3: BGP-LS Attribute.
+    pub const BGP_LS: u8 = 29;
     /// RFC 9234 §5: Only-to-Customer (OTC).
     pub const ONLY_TO_CUSTOMER: u8 = 35;
 }

--- a/crates/wire/src/validate.rs
+++ b/crates/wire/src/validate.rs
@@ -39,14 +39,19 @@ impl ErrorDisposition {
 /// malformation is treat-as-withdraw.
 ///
 /// `MP_REACH_NLRI` / `MP_UNREACH_NLRI` stay session-reset (§7.11: the NLRI
-/// cannot be reliably located). `ATOMIC_AGGREGATE` and `AGGREGATOR` are
-/// attribute-discard (§7.6, §7.7). Everything else — including `AS_PATH`
-/// (§7.2) — is treat-as-withdraw.
+/// cannot be reliably located). `ATOMIC_AGGREGATE` and `AGGREGATOR` use
+/// attribute-discard for their RFC 7606 §7.6/§7.7 length errors; the BGP-LS
+/// Attribute uses attribute-discard for contained TLV-framing errors
+/// (RFC 9552 §8.2.2). Attribute-flag conflicts are upgraded separately to
+/// treat-as-withdraw per RFC 7606 §3(c). Everything else — including
+/// `AS_PATH` (§7.2) — is treat-as-withdraw.
 #[must_use]
 pub fn malformed_attr_disposition(type_code: u8, is_ibgp: bool) -> ErrorDisposition {
     match type_code {
         attr_type::MP_REACH_NLRI | attr_type::MP_UNREACH_NLRI => ErrorDisposition::SessionReset,
-        attr_type::ATOMIC_AGGREGATE | attr_type::AGGREGATOR => ErrorDisposition::AttributeDiscard,
+        attr_type::ATOMIC_AGGREGATE | attr_type::AGGREGATOR | attr_type::BGP_LS => {
+            ErrorDisposition::AttributeDiscard
+        }
         attr_type::LOCAL_PREF | attr_type::ORIGINATOR_ID | attr_type::CLUSTER_LIST if !is_ibgp => {
             ErrorDisposition::AttributeDiscard
         }

--- a/docs/adr/0116-rfc-9857-sr-policy-state.md
+++ b/docs/adr/0116-rfc-9857-sr-policy-state.md
@@ -105,19 +105,19 @@ must use the corrected term.
 RFC 9857 inherits RFC 9552 fault handling, which refines the RFC 7606 recovery
 model for BGP-LS:
 
-- Outer UPDATE, MP_REACH/MP_UNREACH, NLRI, TLV, and sub-TLV containment,
-  length sums, and the permitted lengths of recognized TLVs and sub-TLVs are
-  syntax.  Recoverably malformed NLRIs are discarded individually.  A framing
-  failure that prevents locating the next NLRI uses AFI/SAFI disable where
-  available, otherwise session reset.
+- Outer UPDATE, MP_REACH/MP_UNREACH, NLRI, TLV, and recognized sub-TLV
+  containment and length sums are syntax.  Recoverably malformed NLRIs are
+  discarded individually.  A framing failure that prevents locating the next
+  NLRI uses AFI/SAFI disable where available, otherwise session reset.
 - A syntactically malformed TLV inside Attribute 29 discards the complete
   BGP-LS Attribute, not just that TLV.  The NLRI remains propagatable without
   Attribute 29 so consumers can distinguish lost attributes from a withdrawn
   object.
-- Missing mandatory TLVs, unexpected TLVs, field values, flag combinations,
-  and whether a TLV is meaningful for a particular NLRI are semantic checks.
-  A propagator must not reject an object for those reasons.  That judgment
-  belongs to the consuming application.
+- Missing mandatory TLVs, unexpected TLVs, fixed or variable value-length
+  constraints, field values, TLV-internal flag combinations, and whether a TLV
+  is meaningful for a particular NLRI are semantic checks.  A propagator must
+  not reject an object for those reasons.  That judgment belongs to the
+  consuming application.
 - Unknown NLRI/TLV/segment extensions remain opaque and round-trip.  RFC 4271
   path-attribute framing and flag rules still apply outside the more specific
   BGP-LS recovery behavior.


### PR DESCRIPTION
## Summary\n\nRecognize RFC 9552 BGP-LS Attribute 29 at the wire boundary so malformed contained TLV framing is isolated to the attribute instead of affecting its NLRI or session.\n\n## Changes\n\n- Enforce Attribute 29 optional, non-transitive flags, including Partial=0.\n- Validate generic Attribute 29 TLV boundaries and route structural failures through RFC 9552 Attribute Discard.\n- Preserve valid unknown TLVs, structurally complete semantic oddities, and received Extended Length encoding byte-for-byte.\n- Keep protocol-specific opaque TLVs 1025, 1097, and 1157 opaque; typed nested validation remains deferred with RFC 9857 state.\n- Update the RFC matrix, roadmap, ADR-0116, and changelog to match the shipped boundary.\n\n## Testing\n\n- [x] cargo test --workspace passes\n- [x] cargo clippy --workspace --all-targets -- -D warnings clean\n- [x] cargo fmt --all -- --check clean\n- [x] RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps passes\n- [x] Focused live session regression proves the BGP-LS NLRI survives, Attribute 29 is absent, and the session remains Established\n- [x] External interop harness intentionally not expanded; the existing raw-speaker machinery cannot inject this attribute without new framework work\n- [x] Performance receipt intentionally not applicable; this is bounded wire validation\n\n## Load-bearing regression proofs\n\n- Bypassing the Attribute 29 TLV parser makes both the wire and live-session tests fail.\n- Changing Attribute Discard to Treat As Withdraw removes the NLRI and makes both tests fail.\n- Removing Attribute 29 flag recognition or its Partial-bit check makes the bad-flags fixtures fail.\n- Reverting received Extended Length preservation makes exact byte equality fail.\n- The byte-stability fixture carries both a structurally complete, semantically impermissible recognized TLV and an unknown TLV, preventing semantic overvalidation.\n\n## Docs / release notes\n\n- [x] CHANGELOG.md updated\n- [x] ROADMAP.md updated\n- [x] Wire RFC matrix and ADR-0116 updated\n- [x] Hot tracking docs follow the low-conflict convention\n\n## Related issues\n\nLAN-564