### PR TITLE
test: drain M83 distribution-mode probe

### DIFF
--- a/tests/interop/scripts/test-m83-routeserver-multistack.sh
+++ b/tests/interop/scripts/test-m83-routeserver-multistack.sh
@@ -486,7 +486,7 @@ flip_frr_per_client_best() {
 
 assert_per_client_best() {
     log "Assertions 29-33: per-client best-path (RFC 7947 §2.3.2, ADR-0101)"
-    if rs_ctl neighbor "$FRR_ADDR" | grep -q "per-client-best"; then
+    if rs_ctl neighbor "$FRR_ADDR" | grep "per-client-best" >/dev/null; then
         ok "rbgp neighbor shows Distribution Mode per-client-best"
     else
         fail "Distribution Mode per-client-best not reported"


### PR DESCRIPTION
## Summary

- drain the complete `rbgp neighbor` output before deciding whether per-client-best is present
- prevent `grep -q` from SIGPIPEing the producer under `set -o pipefail`

## Evidence

- M83 on #1102 failed both built-in attempts even though its diagnostic output contained `Distribution Mode:     per-client-best`
- the old quit-early pipeline returns 141 with a matching long producer; the draining pipeline returns 0

## Testing

- `bash -n tests/interop/scripts/test-m83-routeserver-multistack.sh`
- `git diff --check`
- commit hook: fmt and strict Clippy passed
- pre-push hook: strict docs passed; Rust-only gates correctly skipped for the shell-only diff
- hosted M83 remains the real end-to-end gate

## Load-bearing proof

Reverting the probe to `grep -q` reproduces exit 141 under pipefail and makes M83 report a false failure despite the matching line being present.