### PR TITLE
telemetry: surface route-safety failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Route-safety dashboard and actionable alerts.** The shipped Grafana
+  overview adds exact-export rejection and malformed-UPDATE disposition rates, raw
+  step-rendered selection-deferral state, and timeout/ledger-overflow rates
+  while preserving each metric's native labels. Four warning rules alert only on
+  increases in those failure counters; exhaustive Prometheus fixtures and the
+  structural dashboard checker pin the queries, discrete rendering, and the
+  exclusion of normal deferral activity. The daemon materializes the bounded
+  counter label sets when sessions and selection-deferral families are created
+  so ordinary scrape history can establish a zero baseline before producers
+  emit failures.
+
 - **Minimum accepted BGP hold time.** Per-neighbor and peer-group
   `min_hold_time` controls cause the daemon to reject peer OPEN proposals
   below the configured floor (including zero) with OPEN Error 2/6. Unset

--- a/crates/rib/src/manager/selection_deferral.rs
+++ b/crates/rib/src/manager/selection_deferral.rs
@@ -401,6 +401,7 @@ impl SelectionDeferral {
         }
         for (&(afi, safi), gate) in &active {
             let label = afi_safi_label(afi, safi);
+            metrics.initialize_selection_deferral_failure_series(label);
             metrics.set_selection_deferral_active(label, true);
             metrics.set_selection_deferral_waiters(label, gauge_val(Self::blocking_waiters(gate)));
         }

--- a/crates/rib/src/manager/tests/selection_deferral.rs
+++ b/crates/rib/src/manager/tests/selection_deferral.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
 
@@ -40,6 +40,32 @@ fn assert_counter_value(metrics: &BgpMetrics, name: &str, expected: f64) {
         (actual - expected).abs() < f64::EPSILON,
         "expected {name}={expected}, got {actual}"
     );
+}
+
+fn counter_values_by_label(
+    metrics: &BgpMetrics,
+    name: &str,
+    label_name: &str,
+) -> HashMap<String, f64> {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == name)
+        .map_or_else(HashMap::new, |family| {
+            family
+                .get_metric()
+                .iter()
+                .map(|metric| {
+                    let label = metric
+                        .get_label()
+                        .iter()
+                        .find(|label| label.name() == label_name)
+                        .unwrap_or_else(|| panic!("{name} sample lacks {label_name}"));
+                    (label.value().to_string(), metric.get_counter().value())
+                })
+                .collect()
+        })
 }
 
 fn peer(octet: u8) -> IpAddr {
@@ -160,6 +186,46 @@ fn config(timeout: Duration, peers: &[IpAddr]) -> SelectionDeferralConfig {
             })
             .collect(),
     }
+}
+
+/// Load-bearing proof: deleting the failure-series initialization from
+/// `SelectionDeferral::new` leaves both maps empty in this fresh registry.
+#[test]
+fn selection_deferral_construction_materializes_failure_counter_children() {
+    let metrics = BgpMetrics::new();
+    let (_tx, rx) = mpsc::channel(8);
+    let selection_config = SelectionDeferralConfig {
+        timeout: Duration::from_mins(1),
+        waiters: vec![SelectionDeferralWaiterConfig {
+            peer: peer(1),
+            families: vec![FAMILY, READY_FAMILY],
+        }],
+    };
+
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone())
+        .with_selection_deferral(selection_config);
+    assert!(manager.selection_deferral.is_some());
+
+    let expected = HashMap::from([
+        ("ipv4_unicast".to_string(), 0.0),
+        ("ipv6_unicast".to_string(), 0.0),
+    ]);
+    assert_eq!(
+        counter_values_by_label(
+            &metrics,
+            "bgp_selection_deferral_timeouts_total",
+            "afi_safi"
+        ),
+        expected
+    );
+    assert_eq!(
+        counter_values_by_label(
+            &metrics,
+            "bgp_selection_deferral_ledger_overflows_total",
+            "afi_safi"
+        ),
+        expected
+    );
 }
 
 fn commit_control_markers(

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -2810,7 +2810,15 @@ impl BgpMetrics {
         family: &str,
         reason: crate::reason_labels::ExactExportReason,
     ) {
-        let family = match family {
+        let family = Self::exact_export_family_label(family);
+        let reason = reason.as_str();
+        self.exact_export_rejections
+            .with_label_values(&[peer, family, reason])
+            .inc();
+    }
+
+    fn exact_export_family_label(family: &str) -> &str {
+        match family {
             "ipv4_unicast"
             | "ipv6_unicast"
             | "ipv4_flowspec"
@@ -2824,11 +2832,28 @@ impl BgpMetrics {
             | "ipv6_labeled_unicast"
             | "rtc" => family,
             _ => "unknown",
-        };
-        let reason = reason.as_str();
-        self.exact_export_rejections
-            .with_label_values(&[peer, family, reason])
-            .inc();
+        }
+    }
+
+    /// Materialize zero-valued exact-export rejection children for one peer's
+    /// configured, supported families.
+    ///
+    /// Prometheus range functions need a pre-event sample to observe the first
+    /// increment. Families and reasons remain bounded by the same canonical
+    /// vocabularies used by [`Self::record_exact_export_rejection`].
+    pub fn initialize_exact_export_rejection_series<'a>(
+        &self,
+        peer: &str,
+        families: impl IntoIterator<Item = &'a str>,
+    ) {
+        for family in families {
+            let family = Self::exact_export_family_label(family);
+            for reason in crate::reason_labels::ExactExportReason::ALL {
+                self.exact_export_rejections
+                    .with_label_values(&[peer, family, reason.as_str()])
+                    .inc_by(0);
+            }
+        }
     }
 
     /// Record a `PeerUp` that replaced a still-registered outbound sender
@@ -3039,6 +3064,16 @@ impl BgpMetrics {
             .inc();
     }
 
+    /// Materialize zero-valued malformed-UPDATE children for every canonical
+    /// RFC 7606 disposition at one transport endpoint.
+    pub fn initialize_update_malformed_series(&self, peer: &str) {
+        for disposition in crate::reason_labels::MalformedUpdateDisposition::ALL {
+            self.update_malformed
+                .with_label_values(&[peer, disposition.as_str()])
+                .inc_by(0);
+        }
+    }
+
     /// Record RFC 9234 OTC route-leak blocking. The `reason` label
     /// value is the canonical
     /// [`crate::reason_labels::OtcBlockReason`] string — typed here
@@ -3184,6 +3219,17 @@ impl BgpMetrics {
         self.selection_deferral_ledger_overflows
             .with_label_values(&[afi_safi])
             .inc();
+    }
+
+    /// Materialize zero-valued timeout and ledger-overflow children for one
+    /// active selection-deferral family.
+    pub fn initialize_selection_deferral_failure_series(&self, afi_safi: &str) {
+        self.selection_deferral_timeouts
+            .with_label_values(&[afi_safi])
+            .inc_by(0);
+        self.selection_deferral_ledger_overflows
+            .with_label_values(&[afi_safi])
+            .inc_by(0);
     }
 
     /// Set RPKI VRP count by address family.

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -521,6 +521,43 @@ fn send_hold_duration(config: &TransportConfig) -> Option<Duration> {
         .then(|| Duration::from_secs(u64::from(config.peer.send_hold_time)))
 }
 
+/// Bounded family vocabulary shared with exact-export rejection telemetry.
+/// Multicast and invalid AFI/SAFI pairs have no exact-export candidate type.
+fn configured_exact_export_family_label((afi, safi): (Afi, Safi)) -> Option<&'static str> {
+    match (afi, safi) {
+        (Afi::Ipv4, Safi::Unicast) => Some("ipv4_unicast"),
+        (Afi::Ipv6, Safi::Unicast) => Some("ipv6_unicast"),
+        (Afi::Ipv4, Safi::FlowSpec) => Some("ipv4_flowspec"),
+        (Afi::Ipv6, Safi::FlowSpec) => Some("ipv6_flowspec"),
+        (Afi::L2Vpn, Safi::Evpn) => Some("l2vpn_evpn"),
+        (Afi::BgpLs, Safi::BgpLs) => Some("bgpls"),
+        (Afi::BgpLs, Safi::BgpLsVpn) => Some("bgpls_vpn"),
+        (Afi::Ipv4, Safi::MplsVpn) => Some("l3vpn_ipv4_unicast"),
+        (Afi::Ipv6, Safi::MplsVpn) => Some("l3vpn_ipv6_unicast"),
+        (Afi::Ipv4, Safi::LabeledUnicast) => Some("ipv4_labeled_unicast"),
+        (Afi::Ipv6, Safi::LabeledUnicast) => Some("ipv6_labeled_unicast"),
+        (Afi::Ipv4, Safi::RtConstrain) => Some("rtc"),
+        _ => None,
+    }
+}
+
+fn initialize_route_safety_metric_series(
+    config: &TransportConfig,
+    metrics: &BgpMetrics,
+    neighbor_label: &str,
+    endpoint_label: &str,
+) {
+    let families = config.peer.effective_families();
+    metrics.initialize_exact_export_rejection_series(
+        neighbor_label,
+        families
+            .iter()
+            .copied()
+            .filter_map(configured_exact_export_family_label),
+    );
+    metrics.initialize_update_malformed_series(endpoint_label);
+}
+
 /// Resolve next-hop for import policy modifications.
 ///
 /// `NextHopAction::Self_` uses the local TCP address (or router-id as fallback).
@@ -966,6 +1003,7 @@ impl PeerSession {
     ) -> Self {
         let peer_label = config.remote_addr.to_string();
         let peer_ip = config.remote_addr.ip();
+        initialize_route_safety_metric_series(&config, &metrics, &peer_ip.to_string(), &peer_label);
         let link_local_next_hop_scope = Self::link_local_next_hop_scope_from_config(&config);
         let fsm = Session::new(config.peer.clone());
         let explain_enabled = config.explain_enabled;
@@ -1111,6 +1149,7 @@ impl PeerSession {
     ) -> Self {
         let peer_label = config.remote_addr.to_string();
         let peer_ip = config.remote_addr.ip();
+        initialize_route_safety_metric_series(&config, &metrics, &peer_ip.to_string(), &peer_label);
         let link_local_next_hop_scope = Self::link_local_next_hop_scope_from_config(&config);
         let fsm = Session::new(config.peer.clone());
         let explain_enabled = config.explain_enabled;

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -21,6 +21,203 @@ use std::time::{Duration, Instant};
 use tokio::io::AsyncReadExt;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
+
+fn counter_samples(metrics: &BgpMetrics, name: &str) -> Vec<(HashMap<String, String>, f64)> {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == name)
+        .map_or_else(Vec::new, |family| {
+            family
+                .get_metric()
+                .iter()
+                .map(|metric| {
+                    let labels = metric
+                        .get_label()
+                        .iter()
+                        .map(|label| (label.name().to_string(), label.value().to_string()))
+                        .collect();
+                    (labels, metric.get_counter().value())
+                })
+                .collect()
+        })
+}
+
+fn assert_zero_counter_sample(
+    samples: &[(HashMap<String, String>, f64)],
+    expected_labels: &[(&str, &str)],
+) {
+    let matching: Vec<_> = samples
+        .iter()
+        .filter(|(labels, _)| {
+            expected_labels
+                .iter()
+                .all(|(name, value)| labels.get(*name).is_some_and(|actual| actual == value))
+        })
+        .collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected one counter sample with labels {expected_labels:?}, got {matching:?}"
+    );
+    assert!(
+        matching[0].1.abs() < f64::EPSILON,
+        "new counter child must start at zero"
+    );
+}
+
+fn exact_export_families() -> [((Afi, Safi), &'static str); 12] {
+    [
+        ((Afi::Ipv4, Safi::Unicast), "ipv4_unicast"),
+        ((Afi::Ipv6, Safi::Unicast), "ipv6_unicast"),
+        ((Afi::Ipv4, Safi::FlowSpec), "ipv4_flowspec"),
+        ((Afi::Ipv6, Safi::FlowSpec), "ipv6_flowspec"),
+        ((Afi::L2Vpn, Safi::Evpn), "l2vpn_evpn"),
+        ((Afi::BgpLs, Safi::BgpLs), "bgpls"),
+        ((Afi::BgpLs, Safi::BgpLsVpn), "bgpls_vpn"),
+        ((Afi::Ipv4, Safi::MplsVpn), "l3vpn_ipv4_unicast"),
+        ((Afi::Ipv6, Safi::MplsVpn), "l3vpn_ipv6_unicast"),
+        ((Afi::Ipv4, Safi::LabeledUnicast), "ipv4_labeled_unicast"),
+        ((Afi::Ipv6, Safi::LabeledUnicast), "ipv6_labeled_unicast"),
+        ((Afi::Ipv4, Safi::RtConstrain), "rtc"),
+    ]
+}
+
+/// Load-bearing proof: mapping any of these unsupported AFI/SAFI pairs to a
+/// metric family makes its exact `None` assertion fail.
+#[test]
+fn exact_export_metric_family_mapping_rejects_unsupported_pairs() {
+    for family in [
+        (Afi::Ipv4, Safi::Multicast),
+        (Afi::Ipv6, Safi::Multicast),
+        (Afi::Ipv6, Safi::RtConstrain),
+    ] {
+        assert_eq!(configured_exact_export_family_label(family), None);
+    }
+}
+
+/// Load-bearing proof: deleting the outbound-constructor initialization call,
+/// or any supported-family mapping arm, removes at least one asserted zero
+/// child from this fresh registry and makes the test fail.
+#[test]
+fn outbound_constructor_materializes_route_safety_counter_children() {
+    let mut peer_config = PeerConfig::new(65_001, 65_002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.families = exact_export_families()
+        .into_iter()
+        .map(|(family, _)| family)
+        .collect();
+    let config = TransportConfig::new(peer_config, "192.0.2.10:1179".parse().unwrap());
+    let metrics = BgpMetrics::new();
+    let (_cmd_tx, cmd_rx) = mpsc::channel(8);
+    let (rib_tx, _rib_rx) = mpsc::channel(8);
+
+    let _session = PeerSession::new(
+        config,
+        metrics.clone(),
+        cmd_rx,
+        rib_tx,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+    );
+
+    let exact = counter_samples(&metrics, "bgp_exact_export_rejections_total");
+    assert_eq!(exact.len(), exact_export_families().len() * 4);
+    for (_, family) in exact_export_families() {
+        for reason in [
+            "encoding",
+            "missing_ipv6_next_hop",
+            "ipv4_requires_extended_next_hop",
+            "message_too_long",
+        ] {
+            assert_zero_counter_sample(
+                &exact,
+                &[
+                    ("peer", "192.0.2.10"),
+                    ("family", family),
+                    ("reason", reason),
+                ],
+            );
+        }
+    }
+    let malformed = counter_samples(&metrics, "bgp_update_malformed_total");
+    assert_eq!(malformed.len(), 3);
+    for disposition in ["attribute_discard", "treat_as_withdraw", "session_reset"] {
+        assert_zero_counter_sample(
+            &malformed,
+            &[("peer", "192.0.2.10:1179"), ("disposition", disposition)],
+        );
+    }
+}
+
+/// Load-bearing proof: deleting the accepted-session constructor's
+/// initialization call leaves this independent fresh registry empty.
+#[tokio::test]
+async fn inbound_constructor_materializes_route_safety_counter_children() {
+    let mut peer_config = PeerConfig::new(65_001, 65_002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.families = vec![(Afi::Ipv6, Safi::Unicast)];
+    let config = TransportConfig::new(peer_config, "192.0.2.20:2179".parse().unwrap());
+    let metrics = BgpMetrics::new();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let connect = TcpStream::connect(listener.local_addr().unwrap());
+    let accept = listener.accept();
+    let (client, accepted) = tokio::join!(connect, accept);
+    let (_server, _) = accepted.unwrap();
+    let (_cmd_tx, cmd_rx) = mpsc::channel(8);
+    let (rib_tx, _rib_rx) = mpsc::channel(8);
+
+    let _session = PeerSession::new_inbound_with_identity_and_lifecycle(
+        config,
+        metrics.clone(),
+        cmd_rx,
+        rib_tx,
+        None,
+        None,
+        client.unwrap(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+        SessionIdentity::default(),
+        None,
+        None,
+        crate::TcpAoRotationGeneration::STARTUP,
+    );
+
+    let exact = counter_samples(&metrics, "bgp_exact_export_rejections_total");
+    assert_eq!(exact.len(), 4);
+    for reason in [
+        "encoding",
+        "missing_ipv6_next_hop",
+        "ipv4_requires_extended_next_hop",
+        "message_too_long",
+    ] {
+        assert_zero_counter_sample(
+            &exact,
+            &[
+                ("peer", "192.0.2.20"),
+                ("family", "ipv6_unicast"),
+                ("reason", reason),
+            ],
+        );
+    }
+
+    let malformed = counter_samples(&metrics, "bgp_update_malformed_total");
+    assert_eq!(malformed.len(), 3);
+    for disposition in ["attribute_discard", "treat_as_withdraw", "session_reset"] {
+        assert_zero_counter_sample(
+            &malformed,
+            &[("peer", "192.0.2.20:2179"), ("disposition", disposition)],
+        );
+    }
+}
+
 fn make_test_session(local_asn: u32, remote_asn: u32) -> PeerSession {
     let mut peer_config = PeerConfig::new(local_asn, remote_asn, Ipv4Addr::new(10, 0, 0, 1));
     peer_config.connect_retry_secs = 30;

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -5,8 +5,9 @@ A ready-to-import overview dashboard lives at
 (uid `rustbgpd-overview`). It covers session health (including graceful
 restart and slow-peer queues), RIB scale, update-group membership,
 policy-transition actor occupancy, accepted-policy age, policy decisions and
-engine errors, BMP/event-outbox health, RPKI/ASPA state, and core operations.
-Every panel references metrics the daemon actually exports from
+engine errors, route-safety rejections and selection-deferral state,
+BMP/event-outbox health, RPKI/ASPA state, and core operations. Every panel
+references metrics the daemon actually exports from
 `crates/telemetry/src/metrics.rs` — no speculative series.
 
 ## Enable the metrics endpoint
@@ -63,7 +64,9 @@ the next scrape.
 A ready-to-load Prometheus alert-rule pack (session down/flapping,
 empty Adj-RIB-In, max-prefix near-limit and breach, empty RPKI VRP table, event-outbox
 degradation, update-group residue growth, stalled policy transition, a slow
-peer endpoint, actor polls above 200ms, and daemon down) ships at
+peer endpoint, actor polls above 200ms, exact-export rejection, malformed
+UPDATE disposition, selection-deferral timeout and ledger overflow, and daemon
+down) ships at
 [`examples/prometheus/rustbgpd-alerts.yml`](../examples/prometheus/rustbgpd-alerts.yml),
 with per-rule unit tests in
 [`rustbgpd-alerts_test.yml`](../examples/prometheus/rustbgpd-alerts_test.yml)
@@ -74,6 +77,20 @@ with per-rule unit tests in
 
 - Counters are plotted with `rate(...[$__rate_interval])`; gauges are
   plotted raw. Single-stats use last-not-null.
+- Exact-export rejection and malformed-UPDATE disposition rates preserve the
+  metrics' two native peer identities:
+  `bgp_exact_export_rejections_total` uses the bare configured neighbor and
+  therefore `$neighbor`, while `bgp_update_malformed_total` uses the transport
+  endpoint and therefore `$peer`. The selection-deferral state panel renders
+  the raw `active` and `waiters` gauges as steps because their discrete changes
+  are normal convergence activity. Only timeout and bounded-ledger-overflow
+  counter increases alert; ordinary release reasons do not. Event-rate panels
+  filter out zero-valued seeded series so the legend remains actionable on
+  large peer fleets.
+- rustbgpd materializes the bounded route-safety counter label sets when a
+  session or selection-deferral family is created, before its producer actor
+  runs. Prometheus still has to scrape that zero value to establish a sampled
+  baseline, as with any pull-based counter.
 - Max-prefix capacity panels use the session endpoint label and the bounded
   `aggregate`, `ipv4_unicast`, and `ipv6_unicast` scopes. Limit/headroom series
   are intentionally absent for unlimited scopes, and every capacity series is
@@ -123,14 +140,32 @@ promtool check rules examples/prometheus/rustbgpd-alerts.yml
 
 The dashboard checker parses JSON, rejects duplicate panel IDs, validates the
 multi/All selector definitions, compares the required PromQL targets after
-whitespace normalization, and checks both workflow path filters plus the real
-checker step. Its mutation proof makes each of these changes red: malformed
-JSON, a non-integer or duplicate ID, deletion of any required target, removal
-of the `instance` selector, swapping endpoint/bare-address selectors, removing
-`$neighbor`, or replacing the executable workflow step with only a comment.
+whitespace normalization, pins the expanded full-width Route safety row, its
+three 8-by-8 panels, and discrete selection-state rendering, and checks both
+workflow path filters plus the real checker step. Its mutation proof makes
+each of these changes red: malformed JSON, a non-integer or duplicate ID,
+renaming, collapsing, resizing, or moving the required row; changing its type;
+moving or changing the type of a required panel; renaming any of the six
+route-safety metrics; swapping endpoint/bare-address selectors; changing
+either raw selection gauge to a rate; removing step rendering or `$neighbor`;
+dropping `instance` from a route-safety aggregation; weakening any of the six
+label-rich legends; dropping any seeded-series `> 0` filter; or replacing the
+executable workflow step with only a comment.
 
 The slow-peer fixture is red if its `== 1` predicate or five-minute hold is
 changed. The actor fixture is red if `ignoring(le)` is removed, `le="0.2"` is
 moved to `0.5`, `> 0` becomes `>= 0`, raw counters replace `increase`, or
 `job`/`poll_kind` are aggregated away. Its firing observation is in
 `(0.2, 0.5]`; exact-boundary and historical-flat controls remain healthy.
+Each route-safety counter fixture is red if its alert is deleted, its window is
+shortened from 15 to 5 minutes, `increase` becomes a raw counter, or `> 0`
+becomes `> 1`. Malformed UPDATE fixtures cover all three bounded RFC 7606
+dispositions and go red when the rule is restricted to one; exact-export keeps
+its bare-neighbor label, fires all four canonical rejection reasons, and spans
+unicast plus EVPN, so the demonstrated `reason="message_too_long"` and
+`family="ipv4_unicast"` restrictions fail. Timeout and overflow fixtures each
+fire across multiple supported AFI/SAFI values, so their demonstrated
+single-family restrictions and timeout/overflow swaps fail independently.
+Selection-deferral fixtures also inject normal active/waiter transitions and
+an `all_eor` release so substituting any of those normal signals false-alerts
+and fails.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1012,6 +1012,24 @@ instance owned. If the persisted file has an unsupported version or stale table
 signature, rustbgpd renames it to `fib-owned.json.stale` and starts with empty
 owned-state.
 
+### Route-safety alerts
+
+The shipped Prometheus rule pack alerts only on actionable route-safety event
+counters, using a 15-minute increase window:
+
+- `BgpExactExportRejected` means a post-policy announcement was withheld before
+  Adj-RIB-Out commit. Its `peer` label is the bare configured neighbor address;
+  correlate `family` and `reason` with the daemon warning and
+  `rbgp rib --prefix <prefix> advertised <peer> --explain`.
+- `BgpMalformedUpdate` reports one or more malformed UPDATEs by their strongest
+  RFC 7606 `disposition`. Its `peer` label is the transport endpoint
+  (`addr:port` or `[IPv6]:port`).
+- `BgpSelectionDeferralTimedOut` means a family gate used its configured timer
+  fallback before every planned-restart convergence signal arrived.
+- `BgpSelectionDeferralLedgerOverflow` means the bounded identity ledger fell
+  back to a complete release sweep. Safety is preserved, but table scale and
+  retained-key pressure merit investigation.
+
 ### Graceful Restart
 
 | Metric | What it tells you |
@@ -1046,6 +1064,11 @@ responses stay held until a post-failback BoRR is followed by the matching peer
 EoRR. Ordinary EoR, stray EoRR, and the local refresh timeout do not satisfy the
 waiter. Full or closed survivor outbound channels can lose the request, so the
 original selection-deferral deadline remains the bounded fallback.
+
+The `active` and `waiters` gauges, plus ordinary `all_eor`,
+`collision_refresh`, and `all_excluded` releases, are dashboard context rather
+than alert conditions. This avoids paging on normal planned-restart progress;
+use `rbgp neighbor <address>` to correlate the live per-family waiter state.
 
 ### BFD
 

--- a/docs/grafana/rustbgpd-overview.json
+++ b/docs/grafana/rustbgpd-overview.json
@@ -2557,6 +2557,86 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "id": 57,
+      "type": "row",
+      "title": "Route safety",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 152 },
+      "panels": []
+    },
+    {
+      "id": 58,
+      "type": "timeseries",
+      "title": "Export rejections / malformed UPDATEs",
+      "description": "Exact-export rejections use the bare configured neighbor address; malformed UPDATEs use the transport endpoint. Both are exceptional route-safety events, partitioned by their bounded reason labels.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 153 },
+      "fieldConfig": { "defaults": { "unit": "ops", "min": 0 }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (instance, peer, family, reason) (rate(bgp_exact_export_rejections_total{instance=~\"$instance\",peer=~\"$neighbor\"}[$__rate_interval])) > 0",
+          "legendFormat": "exact {{instance}} {{peer}} {{family}} {{reason}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (instance, peer, disposition) (rate(bgp_update_malformed_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval])) > 0",
+          "legendFormat": "malformed {{instance}} {{peer}} {{disposition}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 59,
+      "type": "timeseries",
+      "title": "Selection-deferral state",
+      "description": "Raw per-family gate state and frozen-roster waiter count. These are normal convergence state, not alert conditions; step rendering preserves discrete transitions.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 153 },
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "min": 0, "custom": { "lineInterpolation": "stepAfter" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_selection_deferral_active{instance=~\"$instance\"}",
+          "legendFormat": "{{instance}} {{afi_safi}} active",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_selection_deferral_waiters{instance=~\"$instance\"}",
+          "legendFormat": "{{instance}} {{afi_safi}} waiters",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 60,
+      "type": "timeseries",
+      "title": "Selection-deferral exceptional events",
+      "description": "Per-family rates for timer fallback and bounded-ledger overflow. Ordinary all-EoR, collision-refresh, and all-excluded releases are intentionally omitted.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 153 },
+      "fieldConfig": { "defaults": { "unit": "ops", "min": 0 }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (instance, afi_safi) (rate(bgp_selection_deferral_timeouts_total{instance=~\"$instance\"}[$__rate_interval])) > 0",
+          "legendFormat": "{{instance}} {{afi_safi}} timeout",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (instance, afi_safi) (rate(bgp_selection_deferral_ledger_overflows_total{instance=~\"$instance\"}[$__rate_interval])) > 0",
+          "legendFormat": "{{instance}} {{afi_safi}} ledger overflow",
+          "refId": "B"
+        }
+      ]
     }
   ]
 }

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -250,3 +250,76 @@ groups:
             increased by {{ $value | printf "%.0f" }} in the last 15
             minutes. Routes hitting the failing statement are being
             denied.
+
+      - alert: BgpExactExportRejected
+        # The counter is labeled with the bare configured neighbor address,
+        # not the transport endpoint used by session metrics. Every increment
+        # means an announcement was withheld before Adj-RIB-Out commit.
+        expr: increase(bgp_exact_export_rejections_total[15m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            Exact export rejected for {{ $labels.peer }} ({{ $labels.family }})
+          description: >-
+            bgp_exact_export_rejections_total for neighbor {{ $labels.peer }}
+            on {{ $labels.instance }} increased by
+            {{ $value | printf "%.0f" }} in the last 15 minutes
+            (family={{ $labels.family }}, reason={{ $labels.reason }}).
+            The rejected announcement was not committed to Adj-RIB-Out;
+            inspect the corresponding daemon warning and advertised-route
+            explain output.
+
+      - alert: BgpMalformedUpdate
+        # The counter keeps the transport/session peer label (addr:port or
+        # [IPv6]:port). Every increment is one malformed UPDATE after its
+        # strongest RFC 7606 disposition has been selected.
+        expr: increase(bgp_update_malformed_total[15m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            Malformed UPDATE from {{ $labels.peer }}
+            ({{ $labels.disposition }})
+          description: >-
+            bgp_update_malformed_total for session endpoint
+            {{ $labels.peer }} on {{ $labels.instance }} increased by
+            {{ $value | printf "%.0f" }} in the last 15 minutes. The
+            strongest RFC 7606 disposition was {{ $labels.disposition }};
+            inspect the peer and the daemon's malformed-UPDATE diagnostics.
+
+      - alert: BgpSelectionDeferralTimedOut
+        # Normal active/waiter/release state is intentionally not alertable.
+        # A timer release is an exceptional convergence fallback.
+        expr: increase(bgp_selection_deferral_timeouts_total[15m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            Selection deferral timed out for {{ $labels.afi_safi }}
+          description: >-
+            bgp_selection_deferral_timeouts_total for
+            {{ $labels.afi_safi }} on {{ $labels.instance }} increased by
+            {{ $value | printf "%.0f" }} in the last 15 minutes. The family
+            gate used its bounded timer fallback before all planned-restart
+            convergence signals arrived.
+      - alert: BgpSelectionDeferralLedgerOverflow
+        # Overflow remains safe because release falls back to a complete
+        # family sweep, but it signals that the bounded identity ledger was
+        # exhausted and merits operator investigation.
+        expr: increase(bgp_selection_deferral_ledger_overflows_total[15m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            Selection-deferral ledger overflow for {{ $labels.afi_safi }}
+          description: >-
+            bgp_selection_deferral_ledger_overflows_total for
+            {{ $labels.afi_safi }} on {{ $labels.instance }} increased by
+            {{ $value | printf "%.0f" }} in the last 15 minutes. The family
+            exceeded the bounded identity ledger and used a complete release
+            sweep; inspect table scale and retained-key pressure.

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -421,3 +421,271 @@ tests:
                 kind="arithmetic"} on edge1:9179 increased by 2 in the
                 last 15 minutes. Routes hitting the failing statement
                 are being denied.
+
+  # ── BgpExactExportRejected ───────────────────────────────
+  # Load-bearing: the event is inside 15m but outside 5m at evaluation time;
+  # the non-zero historical counter is flat. Deleting this rule, shortening
+  # 15m to 5m, changing > 0 to > 1, or replacing increase with the raw counter
+  # makes an exact case red. All four canonical reasons fire across unicast
+  # and non-unicast families, so the demonstrated single-reason and
+  # single-family restrictions make the exact expected set red. Peers are
+  # bare configured neighbor addresses, not transport endpoints.
+  - interval: 1m
+    input_series:
+      - series: 'bgp_exact_export_rejections_total{peer="192.0.2.10", family="ipv4_unicast", reason="message_too_long", instance="edge1:9179"}'
+        values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_exact_export_rejections_total{peer="2001:db8::10", family="ipv6_unicast", reason="missing_ipv6_next_hop", instance="edge1:9179"}'
+        values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_exact_export_rejections_total{peer="192.0.2.12", family="ipv4_unicast", reason="ipv4_requires_extended_next_hop", instance="edge2:9179"}'
+        values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_exact_export_rejections_total{peer="192.0.2.13", family="l2vpn_evpn", reason="encoding", instance="edge2:9179"}'
+        values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      # Historical non-zero control: a raw-counter query would false-alert.
+      - series: 'bgp_exact_export_rejections_total{peer="192.0.2.11", family="ipv6_unicast", reason="encoding", instance="edge2:9179"}'
+        values: "7x17"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: BgpExactExportRejected
+        exp_alerts: []
+      - eval_time: 16m
+        alertname: BgpExactExportRejected
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              peer: 192.0.2.10
+              family: ipv4_unicast
+              reason: message_too_long
+              instance: edge1:9179
+            exp_annotations:
+              summary: >-
+                Exact export rejected for 192.0.2.10 (ipv4_unicast)
+              description: >-
+                bgp_exact_export_rejections_total for neighbor 192.0.2.10 on
+                edge1:9179 increased by 1 in the last 15 minutes
+                (family=ipv4_unicast, reason=message_too_long). The rejected
+                announcement was not committed to Adj-RIB-Out; inspect the
+                corresponding daemon warning and advertised-route explain
+                output.
+          - exp_labels:
+              severity: warning
+              peer: "2001:db8::10"
+              family: ipv6_unicast
+              reason: missing_ipv6_next_hop
+              instance: edge1:9179
+            exp_annotations:
+              summary: >-
+                Exact export rejected for 2001:db8::10 (ipv6_unicast)
+              description: >-
+                bgp_exact_export_rejections_total for neighbor 2001:db8::10 on
+                edge1:9179 increased by 1 in the last 15 minutes
+                (family=ipv6_unicast, reason=missing_ipv6_next_hop). The
+                rejected announcement was not committed to Adj-RIB-Out;
+                inspect the corresponding daemon warning and advertised-route
+                explain output.
+          - exp_labels:
+              severity: warning
+              peer: 192.0.2.12
+              family: ipv4_unicast
+              reason: ipv4_requires_extended_next_hop
+              instance: edge2:9179
+            exp_annotations:
+              summary: >-
+                Exact export rejected for 192.0.2.12 (ipv4_unicast)
+              description: >-
+                bgp_exact_export_rejections_total for neighbor 192.0.2.12 on
+                edge2:9179 increased by 1 in the last 15 minutes
+                (family=ipv4_unicast,
+                reason=ipv4_requires_extended_next_hop). The rejected
+                announcement was not committed to Adj-RIB-Out; inspect the
+                corresponding daemon warning and advertised-route explain
+                output.
+          - exp_labels:
+              severity: warning
+              peer: 192.0.2.13
+              family: l2vpn_evpn
+              reason: encoding
+              instance: edge2:9179
+            exp_annotations:
+              summary: >-
+                Exact export rejected for 192.0.2.13 (l2vpn_evpn)
+              description: >-
+                bgp_exact_export_rejections_total for neighbor 192.0.2.13 on
+                edge2:9179 increased by 1 in the last 15 minutes
+                (family=l2vpn_evpn, reason=encoding). The rejected announcement
+                was not committed to Adj-RIB-Out; inspect the corresponding
+                daemon warning and advertised-route explain output.
+
+  # ── BgpMalformedUpdate ───────────────────────────────────
+  # Load-bearing: the same old-event and flat-counter controls pin increase,
+  # shortening 15m to 5m, and the single-event > 0 boundary. Deleting the rule
+  # or restricting it to one disposition also fails. All three bounded RFC
+  # 7606 dispositions fire independently with transport-endpoint labels.
+  - interval: 1m
+    input_series:
+      - series: 'bgp_update_malformed_total{peer="192.0.2.20:179", disposition="treat_as_withdraw", instance="edge1:9179"}'
+        values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_update_malformed_total{peer="[2001:db8::20]:179", disposition="attribute_discard", instance="edge1:9179"}'
+        values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_update_malformed_total{peer="192.0.2.21:179", disposition="session_reset", instance="edge1:9179"}'
+        values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_update_malformed_total{peer="[2001:db8::22]:179", disposition="session_reset", instance="edge2:9179"}'
+        values: "9x17"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: BgpMalformedUpdate
+        exp_alerts: []
+      - eval_time: 16m
+        alertname: BgpMalformedUpdate
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              peer: 192.0.2.20:179
+              disposition: treat_as_withdraw
+              instance: edge1:9179
+            exp_annotations:
+              summary: >-
+                Malformed UPDATE from 192.0.2.20:179 (treat_as_withdraw)
+              description: >-
+                bgp_update_malformed_total for session endpoint
+                192.0.2.20:179 on edge1:9179 increased by 1 in the last 15
+                minutes. The strongest RFC 7606 disposition was
+                treat_as_withdraw; inspect the peer and the daemon's
+                malformed-UPDATE diagnostics.
+          - exp_labels:
+              severity: warning
+              peer: "[2001:db8::20]:179"
+              disposition: attribute_discard
+              instance: edge1:9179
+            exp_annotations:
+              summary: >-
+                Malformed UPDATE from [2001:db8::20]:179 (attribute_discard)
+              description: >-
+                bgp_update_malformed_total for session endpoint
+                [2001:db8::20]:179 on edge1:9179 increased by 1 in the last
+                15 minutes. The strongest RFC 7606 disposition was
+                attribute_discard; inspect the peer and the daemon's
+                malformed-UPDATE diagnostics.
+          - exp_labels:
+              severity: warning
+              peer: 192.0.2.21:179
+              disposition: session_reset
+              instance: edge1:9179
+            exp_annotations:
+              summary: >-
+                Malformed UPDATE from 192.0.2.21:179 (session_reset)
+              description: >-
+                bgp_update_malformed_total for session endpoint
+                192.0.2.21:179 on edge1:9179 increased by 1 in the last 15
+                minutes. The strongest RFC 7606 disposition was
+                session_reset; inspect the peer and the daemon's
+                malformed-UPDATE diagnostics.
+
+  # ── BgpSelectionDeferralTimedOut ────────────────────────
+  # Load-bearing: the firing event is older than 5m but newer than 15m, while
+  # a non-zero flat family counter must remain healthy. Deleting the alert,
+  # shortening 15m to 5m, changing > 0 to > 1, using the raw or overflow
+  # counter, restricting the query to one AFI/SAFI, or substituting
+  # active/waiter/all-EoR state makes this test red.
+  - interval: 1m
+    input_series:
+      - series: 'bgp_selection_deferral_timeouts_total{afi_safi="ipv4_unicast", instance="edge1:9179"}'
+        values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_selection_deferral_timeouts_total{afi_safi="ipv6_flowspec", instance="edge2:9179"}'
+        values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_selection_deferral_timeouts_total{afi_safi="ipv6_unicast", instance="edge2:9179"}'
+        values: "4x17"
+      # Normal state transitions and an ordinary all-EoR release are controls,
+      # not alert inputs. They make metric-substitution mutations fail red.
+      - series: 'bgp_selection_deferral_active{afi_safi="ipv4_unicast", instance="edge3:9179"}'
+        values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_selection_deferral_waiters{afi_safi="ipv4_unicast", instance="edge3:9179"}'
+        values: "0 0 0 0 0 2 2 2 2 2 2 2 2 2 2 2 2"
+      - series: 'bgp_selection_deferral_releases_total{afi_safi="ipv4_unicast", reason="all_eor", instance="edge3:9179"}'
+        values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: BgpSelectionDeferralTimedOut
+        exp_alerts: []
+      - eval_time: 16m
+        alertname: BgpSelectionDeferralTimedOut
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              afi_safi: ipv4_unicast
+              instance: edge1:9179
+            exp_annotations:
+              summary: >-
+                Selection deferral timed out for ipv4_unicast
+              description: >-
+                bgp_selection_deferral_timeouts_total for ipv4_unicast on
+                edge1:9179 increased by 1 in the last 15 minutes. The family
+                gate used its bounded timer fallback before all
+                planned-restart convergence signals arrived.
+          - exp_labels:
+              severity: warning
+              afi_safi: ipv6_flowspec
+              instance: edge2:9179
+            exp_annotations:
+              summary: >-
+                Selection deferral timed out for ipv6_flowspec
+              description: >-
+                bgp_selection_deferral_timeouts_total for ipv6_flowspec on
+                edge2:9179 increased by 1 in the last 15 minutes. The family
+                gate used its bounded timer fallback before all
+                planned-restart convergence signals arrived.
+
+  # ── BgpSelectionDeferralLedgerOverflow ────────────────────
+  # Load-bearing: the fixture independently pins the overflow metric,
+  # increase, 15m-versus-5m range, and single-event > 0 boundary. Deleting the
+  # alert, restricting the query to one AFI/SAFI, or substituting timeout,
+  # active, waiter, or all-EoR state makes it red; the flat historical counter
+  # catches the raw-counter query.
+  - interval: 1m
+    input_series:
+      - series: 'bgp_selection_deferral_ledger_overflows_total{afi_safi="ipv6_unicast", instance="edge1:9179"}'
+        values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_selection_deferral_ledger_overflows_total{afi_safi="l2vpn_evpn", instance="edge2:9179"}'
+        values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_selection_deferral_ledger_overflows_total{afi_safi="ipv4_unicast", instance="edge2:9179"}'
+        values: "3x17"
+      # Normal state transitions and an ordinary all-EoR release are controls,
+      # not alert inputs. They make metric-substitution mutations fail red.
+      - series: 'bgp_selection_deferral_active{afi_safi="ipv6_unicast", instance="edge3:9179"}'
+        values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_selection_deferral_waiters{afi_safi="ipv6_unicast", instance="edge3:9179"}'
+        values: "0 0 0 0 0 3 3 3 3 3 3 3 3 3 3 3 3"
+      - series: 'bgp_selection_deferral_releases_total{afi_safi="ipv6_unicast", reason="all_eor", instance="edge3:9179"}'
+        values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: BgpSelectionDeferralLedgerOverflow
+        exp_alerts: []
+      - eval_time: 16m
+        alertname: BgpSelectionDeferralLedgerOverflow
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              afi_safi: ipv6_unicast
+              instance: edge1:9179
+            exp_annotations:
+              summary: >-
+                Selection-deferral ledger overflow for ipv6_unicast
+              description: >-
+                bgp_selection_deferral_ledger_overflows_total for
+                ipv6_unicast on edge1:9179 increased by 1 in the last 15
+                minutes. The family exceeded the bounded identity ledger and
+                used a complete release sweep; inspect table scale and
+                retained-key pressure.
+          - exp_labels:
+              severity: warning
+              afi_safi: l2vpn_evpn
+              instance: edge2:9179
+            exp_annotations:
+              summary: >-
+                Selection-deferral ledger overflow for l2vpn_evpn
+              description: >-
+                bgp_selection_deferral_ledger_overflows_total for
+                l2vpn_evpn on edge2:9179 increased by 1 in the last 15
+                minutes. The family exceeded the bounded identity ledger and
+                used a complete release sweep; inspect table scale and
+                retained-key pressure.

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -59,6 +59,51 @@ TARGETS = {
     ("Max-prefix remaining headroom", "A"): (
         'bgp_max_prefix_headroom{instance=~"$instance",peer=~"$peer"}'
     ),
+    ("Export rejections / malformed UPDATEs", "A"): (
+        "sum by (instance, peer, family, reason) "
+        "(rate(bgp_exact_export_rejections_total"
+        '{instance=~"$instance",peer=~"$neighbor"}[$__rate_interval])) > 0'
+    ),
+    ("Export rejections / malformed UPDATEs", "B"): (
+        "sum by (instance, peer, disposition) (rate(bgp_update_malformed_total"
+        '{instance=~"$instance",peer=~"$peer"}[$__rate_interval])) > 0'
+    ),
+    ("Selection-deferral state", "A"): (
+        'bgp_selection_deferral_active{instance=~"$instance"}'
+    ),
+    ("Selection-deferral state", "B"): (
+        'bgp_selection_deferral_waiters{instance=~"$instance"}'
+    ),
+    ("Selection-deferral exceptional events", "A"): (
+        "sum by (instance, afi_safi) (rate(bgp_selection_deferral_timeouts_total"
+        '{instance=~"$instance"}[$__rate_interval])) > 0'
+    ),
+    ("Selection-deferral exceptional events", "B"): (
+        "sum by (instance, afi_safi) "
+        "(rate(bgp_selection_deferral_ledger_overflows_total"
+        '{instance=~"$instance"}[$__rate_interval])) > 0'
+    ),
+}
+
+ROUTE_SAFETY_LEGENDS = {
+    ("Export rejections / malformed UPDATEs", "A"): (
+        "exact {{instance}} {{peer}} {{family}} {{reason}}"
+    ),
+    ("Export rejections / malformed UPDATEs", "B"): (
+        "malformed {{instance}} {{peer}} {{disposition}}"
+    ),
+    ("Selection-deferral state", "A"): "{{instance}} {{afi_safi}} active",
+    ("Selection-deferral state", "B"): "{{instance}} {{afi_safi}} waiters",
+    ("Selection-deferral exceptional events", "A"): "{{instance}} {{afi_safi}} timeout",
+    ("Selection-deferral exceptional events", "B"): (
+        "{{instance}} {{afi_safi}} ledger overflow"
+    ),
+}
+
+ROUTE_SAFETY_PANELS = {
+    "Export rejections / malformed UPDATEs": 0,
+    "Selection-deferral state": 8,
+    "Selection-deferral exceptional events": 16,
 }
 
 WORKFLOW_PATHS = {
@@ -145,17 +190,24 @@ def main() -> None:
             fail(f"${name} All value must be the regex .* ")
 
     targets: dict[tuple[str, str], list[str]] = {}
+    legends: dict[tuple[str, str], list[str | None]] = {}
     for panel in panels:
         title = panel.get("title")
         for target in panel.get("targets", []):
             key = (title, target.get("refId"))
             targets.setdefault(key, []).append(normalized(target.get("expr", "")))
+            legends.setdefault(key, []).append(target.get("legendFormat"))
 
     for key, expression in TARGETS.items():
         actual = targets.get(key, [])
         expected = [normalized(expression)]
         if actual != expected:
             fail(f"target {key[0]!r}/{key[1]} must equal {expected[0]!r}; got {actual!r}")
+
+    for key, expected in ROUTE_SAFETY_LEGENDS.items():
+        actual = legends.get(key, [])
+        if actual != [expected]:
+            fail(f"target {key[0]!r}/{key[1]} must use legend {expected!r}; got {actual!r}")
 
     update_group_panel = next(
         panel for panel in panels if panel.get("title") == "Update group by neighbor address"
@@ -174,6 +226,35 @@ def main() -> None:
         fail("slow-peer state must be pinned to the discrete 0..1 range")
     if slow_defaults.get("custom", {}).get("lineInterpolation") != "stepAfter":
         fail("slow-peer state must use step interpolation")
+
+    route_safety_row = next(
+        (panel for panel in panels if panel.get("title") == "Route safety"), None
+    )
+    if route_safety_row is None or route_safety_row.get("type") != "row":
+        fail("Route safety must exist as a dashboard row")
+    if route_safety_row.get("collapsed") is not False:
+        fail("Route safety row must be expanded by default")
+    row_position = route_safety_row.get("gridPos", {})
+    expected_row_position = {"h": 1, "w": 24, "x": 0, "y": 152}
+    if row_position != expected_row_position:
+        fail(f"Route safety row must use grid position {expected_row_position}")
+    for title, expected_x in ROUTE_SAFETY_PANELS.items():
+        panel = next((item for item in panels if item.get("title") == title), None)
+        if panel is None or panel.get("type") != "timeseries":
+            fail(f"{title} must exist as a timeseries panel")
+        position = panel.get("gridPos", {})
+        expected_position = {"h": 8, "w": 8, "x": expected_x, "y": 153}
+        if position != expected_position:
+            fail(f"{title} must use route-safety grid position {expected_position}")
+
+    selection_panel = next(
+        panel for panel in panels if panel.get("title") == "Selection-deferral state"
+    )
+    selection_defaults = selection_panel.get("fieldConfig", {}).get("defaults", {})
+    if selection_defaults.get("decimals") != 0 or selection_defaults.get("min") != 0:
+        fail("selection-deferral state must render as nonnegative whole values")
+    if selection_defaults.get("custom", {}).get("lineInterpolation") != "stepAfter":
+        fail("selection-deferral state must use step interpolation")
 
     try:
         workflow_text = WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add four warning alerts for exact-export rejection, malformed UPDATE handling, selection-deferral timeout, and deferral-ledger overflow
- add a route-safety Grafana row with multi-instance-safe aggregation, useful legends, and zero-series suppression
- materialize bounded children of the existing lazy counters before producers can run so the first post-baseline fault is observable
- document selector identities, CLI drill-down, bounded series cost, and the Prometheus baseline-scrape requirement

No protocol, route-selection, or export-policy behavior changes.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- dashboard structure and query validation
- Prometheus 3.4.1 rule validation and rule tests
- `git diff --check`

The commit and push hooks also repeated the Rust gate quartet successfully.

## Load-bearing proof

72 isolated mutations made the relevant checks fail. Coverage includes rule deletion, thresholds, windows, selector narrowing, forbidden normal-state alerting, dashboard query and structure changes, instance-label preservation, lifecycle seeding removal, supported and unsupported address-family mapping, and selection-deferral counter initialization removal.

Independent semantic, scope/UX, and false-green reviews returned SHIP after their findings were resolved.

## Operational bounds

An ordinary dual-stack peer materializes 11 existing counter series. The supported-family maximum is 51 peer-scoped series. As with any pull-based counter, Prometheus still needs a successful zero-baseline scrape before an immediately following first event can be evaluated by `increase()`.

Linear: https://linear.app/lance0/issue/LAN-573/rustbgpd-surface-route-safety-failures-in-dashboards-and-alerts
