### PR TITLE
docs: refresh peer session contributor map

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -214,7 +214,7 @@ gRPC request
 | FlowSpec NLRI | `crates/wire/src/flowspec.rs` |
 | FSM state transitions | `crates/fsm/src/lib.rs` |
 | Capability negotiation | `crates/fsm/src/negotiation.rs` |
-| Peer session runtime | `crates/transport/src/session/` (split into `mod.rs`, `fsm.rs`, `inbound.rs`, `outbound.rs`, `io.rs`, `commands.rs`, `writer.rs`, `import_decision_cache.rs`, `export.rs`, `refresh_accounting.rs`, `tests.rs`) |
+| Peer session runtime | `crates/transport/src/session/` (split into `mod.rs`, `fsm.rs`, `inbound.rs`, `outbound.rs`, `io.rs`, `commands.rs`, `writer.rs`, `import_decision_cache.rs`, `rejected_routes.rs`, `export.rs`, `refresh_accounting.rs`, `shared_group.rs`, `tests.rs`) |
 | Outbound UPDATE construction | `crates/transport/src/session/outbound.rs` — `prepare_outbound_attributes()` |
 | Policy evaluation | `crates/policy/src/engine.rs` |
 | Best-path selection | `crates/rib/src/best_path.rs` — `best_path_cmp` / `best_path_cmp_with_reason` |


### PR DESCRIPTION
## Summary

- add `rejected_routes.rs` and `shared_group.rs` to the peer-session contributor map
- make the documented module inventory match all 13 session source files

## Why

The `ARCHITECTURE.md` "Where to Change X" table omitted the rejected-route retention and update-group sharing modules. Contributors following that map could miss the owning files for those behaviors.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- exact `crates/transport/src/session/*.rs` inventory compared with the documented list
- `git diff --check`

## Load-bearing documentation proof

No production test or committed gate is added or touched. Before this change, the contributor row omitted two source files that exist in the session directory; after it, all 13 source files are named.

Linear: [LAN-579](https://linear.app/lance0/issue/LAN-579/doc-drift-architecturemd-transport-session-file-list-is-stale-missing)
