### PR TITLE
Exit non-zero when shutdown is caused by gRPC server failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Daemon exits non-zero when shutdown is caused by unexpected gRPC server
+  termination.** The coordinated teardown (NOTIFICATIONs, GR marker,
+  checkpoints) still runs, but the process now exits 1 so supervisors with
+  `Restart=on-failure` restart the daemon instead of treating the component
+  failure as a clean stop. Operator-initiated shutdowns (SIGINT/SIGTERM,
+  Shutdown RPC) still exit 0.
+
 - **RFC 6793 legacy-AS migration is lossless end to end.** Sessions without
   capability 65 now normalize received type 2/17 paths and type 7/18
   aggregators before loop detection, policy, and RIB processing, then derive

--- a/src/main.rs
+++ b/src/main.rs
@@ -2376,7 +2376,13 @@ fn main() {
         .enable_all()
         .build()
         .unwrap_or_else(|e| fatal_startup_error("failed to create tokio runtime", e));
-    rt.block_on(run(config, boot_revert_notice, profiler));
+    let grpc_server_failed = rt.block_on(run(config, boot_revert_notice, profiler));
+    if grpc_server_failed {
+        // The coordinated teardown already ran (NOTIFICATIONs, GR marker,
+        // checkpoints); the non-zero code tells supervisors (e.g. systemd
+        // Restart=on-failure) this was a component failure, not a clean stop.
+        process::exit(1);
+    }
 }
 
 /// Number of panic reports retained in `<runtime_state_dir>/crash/`;
@@ -2574,11 +2580,14 @@ fn resolve_rib_channel_capacity_from(env: Option<&str>) -> usize {
 }
 
 #[expect(clippy::too_many_lines)]
+/// Returns `true` when shutdown was caused by the gRPC server exiting
+/// unexpectedly (a component failure — the process must exit non-zero),
+/// `false` for operator-initiated shutdowns (signals, Shutdown RPC).
 async fn run<T>(
     mut config: Config,
     boot_revert_notice: Option<confirm_journal::BootRevertNotice>,
     profiler: Option<T>,
-) {
+) -> bool {
     // Snapshot the gRPC listener config as it was at process start.
     // The live TCP/UDS listeners bind once and are not rebuilt on
     // SIGHUP; this snapshot is what they're actually serving. Reload
@@ -4420,6 +4429,7 @@ async fn run<T>(
     let mut reload_in_flight: Option<
         tokio::task::JoinHandle<Option<Result<Config, &'static str>>>,
     > = None;
+    let mut grpc_server_failed = false;
     loop {
         tokio::select! {
             result = tokio::signal::ctrl_c() => {
@@ -4443,6 +4453,7 @@ async fn run<T>(
             result = &mut grpc_handle => {
                 error!(?result, "gRPC server exited unexpectedly");
                 info!("initiating shutdown due to gRPC server failure");
+                grpc_server_failed = true;
                 break;
             }
             _ = sighup.recv() => {
@@ -4937,6 +4948,7 @@ async fn run<T>(
     }
 
     info!("rustbgpd exiting");
+    grpc_server_failed
 }
 
 #[cfg(test)]

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -116,18 +116,17 @@ fn wait_for_http(port: u16, path: &str, proc_: &mut Proc) {
 }
 
 /// Wait until `port` accepts a TCP connection (daemon gRPC readiness).
-fn wait_for_tcp(port: u16, proc_: &mut Proc) {
+/// `Err` carries the exit status when the process died before listening
+/// (the caller may retry — see `spawn_daemon_listening`); a still-running
+/// process that never listens within the timeout panics.
+fn wait_for_tcp(port: u16, proc_: &mut Proc) -> Result<(), std::process::ExitStatus> {
     let deadline = Instant::now() + Duration::from_secs(120);
     while Instant::now() < deadline {
         if TcpStream::connect(("127.0.0.1", port)).is_ok() {
-            return;
+            return Ok(());
         }
         if let Ok(Some(status)) = proc_.child.try_wait() {
-            panic!(
-                "{} exited before listening on {port}: {status}\nstderr:\n{}",
-                proc_.name,
-                proc_.stderr()
-            );
+            return Err(status);
         }
         thread::sleep(Duration::from_millis(100));
     }
@@ -136,6 +135,50 @@ fn wait_for_tcp(port: u16, proc_: &mut Proc) {
         proc_.name,
         proc_.stderr()
     );
+}
+
+/// Spawn the daemon and wait for its gRPC TCP listener. `free_port()` is
+/// bind-then-release, so a parallel workspace test can steal the port
+/// before the daemon binds it; the daemon treats the lost gRPC bind as a
+/// component failure and exits non-zero. Retry the whole spawn with
+/// fresh ports (bounded) instead of failing the test on that race.
+/// Returns the daemon plus the ports and token path the rest of the test
+/// needs.
+fn spawn_daemon_listening(dir: &Path) -> (Proc, u16, u16, PathBuf) {
+    const ATTEMPTS: u32 = 3;
+    for attempt in 1..=ATTEMPTS {
+        let grpc_port = free_port();
+        let bgp_port = free_port();
+        let (config_path, token_path) = write_config(dir, grpc_port, bgp_port);
+        let daemon_stdout = dir.join("rustbgpd.stdout.log");
+        let daemon_stderr = dir.join("rustbgpd.stderr.log");
+        let mut daemon = Proc {
+            child: Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
+                .arg(&config_path)
+                .stdout(Stdio::from(
+                    std::fs::File::create(&daemon_stdout).expect("daemon stdout log"),
+                ))
+                .stderr(Stdio::from(
+                    std::fs::File::create(&daemon_stderr).expect("daemon stderr log"),
+                ))
+                .spawn()
+                .expect("spawn rustbgpd"),
+            name: "rustbgpd",
+            stderr_path: daemon_stderr,
+        };
+        match wait_for_tcp(grpc_port, &mut daemon) {
+            Ok(()) => return (daemon, grpc_port, bgp_port, token_path),
+            Err(status) if attempt < ATTEMPTS => eprintln!(
+                "rustbgpd exited before listening on {grpc_port} (attempt {attempt}): \
+                 {status}; retrying with fresh ports"
+            ),
+            Err(status) => panic!(
+                "rustbgpd exited before listening on {grpc_port}: {status}\nstderr:\n{}",
+                daemon.stderr()
+            ),
+        }
+    }
+    unreachable!("spawn retry loop returns or panics");
 }
 
 /// Mutation proof: dropping Tier enforcement, the bearer credential, or the
@@ -370,30 +413,11 @@ fn epoch_from_timestamp(s: &str) -> u64 {
 #[test]
 fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_subset() {
     let temp = tempfile::tempdir().expect("create temp dir");
-    let grpc_port = free_port();
     let adapter_port = free_port();
-    let bgp_port = free_port();
-    let (config_path, token_path) = write_config(temp.path(), grpc_port, bgp_port);
 
     // Spawn the daemon (serves gRPC). Structured logs go to stdout,
     // the banner to stderr.
-    let daemon_stdout = temp.path().join("rustbgpd.stdout.log");
-    let daemon_stderr = temp.path().join("rustbgpd.stderr.log");
-    let mut daemon = Proc {
-        child: Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
-            .arg(&config_path)
-            .stdout(Stdio::from(
-                std::fs::File::create(&daemon_stdout).expect("daemon stdout log"),
-            ))
-            .stderr(Stdio::from(
-                std::fs::File::create(&daemon_stderr).expect("daemon stderr log"),
-            ))
-            .spawn()
-            .expect("spawn rustbgpd"),
-        name: "rustbgpd",
-        stderr_path: daemon_stderr,
-    };
-    wait_for_tcp(grpc_port, &mut daemon);
+    let (mut daemon, grpc_port, bgp_port, token_path) = spawn_daemon_listening(temp.path());
     wait_for_unauthenticated_get_global(grpc_port, &mut daemon);
 
     // Spawn the adapter against the daemon's gRPC endpoint. Built via

--- a/tests/grpc_failure_exit_code.rs
+++ b/tests/grpc_failure_exit_code.rs
@@ -1,0 +1,198 @@
+//! Exit-code contract for daemon shutdown causes.
+//!
+//! Operator-initiated shutdown (SIGTERM) exits 0; shutdown caused by the
+//! gRPC server exiting unexpectedly (here: the TCP listener losing its
+//! bind because the port is already taken) runs the same coordinated
+//! teardown but exits non-zero, so supervisors like systemd with
+//! `Restart=on-failure` restart the daemon instead of treating the
+//! component failure as a clean stop.
+
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+struct Daemon {
+    child: Child,
+    stdout_path: PathBuf,
+    stderr_path: PathBuf,
+}
+
+impl Daemon {
+    fn logs(&self) -> String {
+        let read = |path: &Path| {
+            std::fs::read_to_string(path)
+                .unwrap_or_else(|e| format!("<failed to read {}: {e}>", path.display()))
+        };
+        format!(
+            "stdout:\n{}\nstderr:\n{}",
+            read(&self.stdout_path),
+            read(&self.stderr_path)
+        )
+    }
+
+    /// Wait for the daemon to exit within `timeout`.
+    fn wait_within(&mut self, timeout: Duration) -> ExitStatus {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            match self.child.try_wait() {
+                Ok(Some(status)) => return status,
+                Ok(None) => thread::sleep(Duration::from_millis(100)),
+                Err(e) => panic!("failed to poll rustbgpd: {e}"),
+            }
+        }
+        panic!("rustbgpd did not exit within timeout\n{}", self.logs());
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+fn write_config(dir: &Path, grpc_port: u16, bgp_port: u16) -> PathBuf {
+    let runtime_dir = dir.join("runtime");
+    std::fs::create_dir_all(&runtime_dir).expect("create runtime dir");
+    let token_path = dir.join("grpc-token");
+    std::fs::write(&token_path, "exit-code-test-token\n").expect("write test token");
+    let config_path = dir.join("rustbgpd.toml");
+    let config = format!(
+        r#"
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://observer/exit-code-test" = "observer"
+
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = {bgp_port}
+runtime_state_dir = "{runtime_dir}"
+
+[global.telemetry]
+log_format = "json"
+
+[global.telemetry.grpc_tcp]
+address = "127.0.0.1:{grpc_port}"
+token_file = "{token_path}"
+principal = "rustbgpd://observer/exit-code-test"
+"#,
+        runtime_dir = runtime_dir.display(),
+        token_path = token_path.display()
+    );
+    std::fs::write(&config_path, config).expect("write test config");
+    config_path
+}
+
+fn spawn_daemon(dir: &Path, config_path: &Path) -> Daemon {
+    let stdout_path = dir.join("rustbgpd.stdout.log");
+    let stderr_path = dir.join("rustbgpd.stderr.log");
+    Daemon {
+        child: Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
+            .arg(config_path)
+            .stdout(Stdio::from(
+                std::fs::File::create(&stdout_path).expect("daemon stdout log"),
+            ))
+            .stderr(Stdio::from(
+                std::fs::File::create(&stderr_path).expect("daemon stderr log"),
+            ))
+            .spawn()
+            .expect("spawn rustbgpd"),
+        stdout_path,
+        stderr_path,
+    }
+}
+
+/// Grab a free localhost port. Racy in principle, fine for a test.
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("bind 127.0.0.1:0")
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+#[test]
+fn grpc_bind_failure_exits_nonzero() {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    // Hold the gRPC port so the daemon's listener bind fails with
+    // AddrInUse — the gRPC server task exits, which must shut the
+    // daemon down with a non-zero exit code.
+    let occupied = TcpListener::bind("127.0.0.1:0").expect("bind occupied port");
+    let grpc_port = occupied.local_addr().unwrap().port();
+    let config_path = write_config(temp.path(), grpc_port, free_port());
+
+    let mut daemon = spawn_daemon(temp.path(), &config_path);
+    let status = daemon.wait_within(Duration::from_secs(120));
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "gRPC server failure must exit 1, got {status}\n{}",
+        daemon.logs()
+    );
+}
+
+#[test]
+fn sigterm_exits_zero() {
+    let temp = tempfile::tempdir().expect("create temp dir");
+
+    // `free_port()` is bind-then-release, so a parallel workspace test can
+    // steal the port before the daemon binds it; the daemon then exits
+    // non-zero (the very contract under test). Retry with fresh ports.
+    let mut daemon = 'spawned: {
+        for attempt in 1..=3 {
+            let grpc_port = free_port();
+            let config_path = write_config(temp.path(), grpc_port, free_port());
+            let mut daemon = spawn_daemon(temp.path(), &config_path);
+
+            // Wait until the gRPC listener is up so SIGTERM lands on a
+            // fully started daemon.
+            let deadline = Instant::now() + Duration::from_secs(120);
+            loop {
+                if TcpStream::connect(("127.0.0.1", grpc_port)).is_ok() {
+                    break 'spawned daemon;
+                }
+                if let Ok(Some(status)) = daemon.child.try_wait() {
+                    if attempt < 3 {
+                        eprintln!(
+                            "rustbgpd exited before listening on {grpc_port} \
+                             (attempt {attempt}): {status}; retrying with fresh ports"
+                        );
+                        break;
+                    }
+                    panic!(
+                        "rustbgpd exited before listening on {grpc_port}: {status}\n{}",
+                        daemon.logs()
+                    );
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "rustbgpd did not listen on {grpc_port} within timeout\n{}",
+                    daemon.logs()
+                );
+                thread::sleep(Duration::from_millis(100));
+            }
+        }
+        unreachable!("spawn retry loop either breaks 'spawned or panics");
+    };
+
+    let sigterm = Command::new("kill")
+        .args(["-TERM", &daemon.child.id().to_string()])
+        .status()
+        .expect("send SIGTERM");
+    assert!(sigterm.success(), "kill -TERM failed: {sigterm}");
+
+    let status = daemon.wait_within(Duration::from_secs(120));
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "SIGTERM must exit 0, got {status}\n{}",
+        daemon.logs()
+    );
+}


### PR DESCRIPTION
## What

- The daemon now exits **1** when shutdown is caused by the gRPC server exiting unexpectedly (e.g. a lost listener bind). Operator-initiated shutdowns (SIGINT, SIGTERM, Shutdown RPC) still exit **0**.
- Deflakes `tests/birdwatcher_adapter_smoke.rs`: the daemon spawn now retries with fresh ports (bounded at 3 attempts) when the daemon exits before its gRPC listener comes up.

## Why

The main select loop breaks on operator-initiated causes and on the unexpected gRPC server exit, but every path converged on the same teardown and the process always exited 0. Supervisors with `Restart=on-failure` (the shipped `examples/systemd/rustbgpd.service` default) treated a dead-control-plane daemon as a clean stop and never restarted it.

Exit code 1 follows the established convention: 1 is the general runtime-failure code (config load failure, listener failure with TCP-AO peers configured), 2 is reserved for config/usage errors, and 70 for internal profile bugs.

The smoke-test flake is the same contract seen from the other side: its bind-then-release `free_port()` can lose the port to a parallel workspace test, and the daemon losing the gRPC bind race now exits non-zero before listening. The retry detects the exited-before-listening shape and respawns with fresh ports; the pattern stays local to this file (the `free_port` helper is per-file, not shared).

## How

- `run()` returns whether shutdown was caused by the gRPC server failure; `main()` maps that to `process::exit(1)`. The coordinated teardown (NOTIFICATIONs, GR marker, warm checkpoints) is unchanged and completes before the exit in all cases.
- `tests/grpc_failure_exit_code.rs` proves both sides of the contract: pre-binding the gRPC port from the test makes the daemon exit 1; SIGTERM on a fully started daemon exits 0.

## Verified

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test --workspace --no-fail-fast` — exit 0 (includes the new exit-code tests and the deflaked adapter smoke test)
- `cargo doc --workspace --no-deps` — exit 0
