### PR TITLE
Retry the grpcurl download and verification in CI

### DIFF
--- a/.github/scripts/install-grpcurl.sh
+++ b/.github/scripts/install-grpcurl.sh
@@ -6,6 +6,7 @@ readonly GRPCURL_VERSION="1.9.1"
 readonly GRPCURL_SHA256="588c9c429476d9ed66cd3b2ae32283a6da36e0cfbb7e446f5d6a1b68dc770214"
 readonly GRPCURL_ASSET="grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz"
 readonly GRPCURL_URL="https://github.com/fullstorydev/grpcurl/releases/download/v${GRPCURL_VERSION}/${GRPCURL_ASSET}"
+readonly GRPCURL_ATTEMPTS=3
 
 install_grpcurl() (
     local version=${1:?version}
@@ -18,13 +19,13 @@ install_grpcurl() (
     trap 'rm -rf -- "$work_dir"' EXIT
     archive="$work_dir/grpcurl.tar.gz"
 
-    # Download to a file rather than streaming into tar: curl can discard a
-    # partial response before retrying, and extraction cannot see unverified
-    # bytes. --retry alone does not cover truncated transfers.
+    # Download to a file rather than streaming into tar, so extraction cannot
+    # see unverified bytes. Single retry mechanism: the caller's loop owns
+    # retry and backoff, because only the checksum below catches a truncated
+    # or corrupted 200-OK body that `curl --retry` treats as success. Nesting
+    # `curl --retry` inside that loop would multiply the worst case past the
+    # interop job timeout.
     curl -fsSL \
-        --retry 3 \
-        --retry-all-errors \
-        --retry-delay 3 \
         --connect-timeout 10 \
         --max-time 120 \
         --output "$archive" \
@@ -49,6 +50,30 @@ install_grpcurl() (
     printf '%s\n' "$reported_version"
 )
 
+# The hosted release download is the only external fetch every Interop job
+# shares, so one CDN hiccup reds a ~38-job run. Retry download *and*
+# verification as a unit: a truncated or corrupted archive is re-fetched
+# rather than accepted, because each attempt re-runs the checksum and version
+# checks and a rejected archive is never installed. Persistent failure still
+# fails closed after the bounded attempts, naming the URL.
+install_grpcurl_with_retry() {
+    local url=${3:?url}
+    local attempt
+
+    for ((attempt = 1; attempt <= GRPCURL_ATTEMPTS; attempt++)); do
+        if install_grpcurl "$@"; then
+            return 0
+        fi
+        if ((attempt < GRPCURL_ATTEMPTS)); then
+            echo "::warning::grpcurl download/verify attempt ${attempt}/${GRPCURL_ATTEMPTS} failed; retrying" >&2
+            sleep $((attempt * 5))
+        fi
+    done
+
+    echo "::error::grpcurl download/verification failed after ${GRPCURL_ATTEMPTS} attempts: ${url}" >&2
+    return 1
+}
+
 fail_self_test() {
     echo "grpcurl installer self-test failed: $*" >&2
     return 1
@@ -56,7 +81,7 @@ fail_self_test() {
 
 self_test() (
     local repo_root fixture_dir source_dir base_archive archive checksum truncated_size
-    local wrong_version_archive wrong_version_checksum
+    local wrong_version_archive wrong_version_checksum retry_counter
     local named_steps workflow_calls setup_calls
 
     repo_root=$(git rev-parse --show-toplevel)
@@ -133,6 +158,39 @@ EOF
         fail_self_test "wrong grpcurl version was accepted"
     fi
 
+    # Retry cases stub the installer and `sleep` so the loop is exercised
+    # without network access or real backoff waits.
+    retry_counter="$fixture_dir/retry-attempts"
+    printf '0' >"$retry_counter"
+    (
+        sleep() { :; }
+        install_grpcurl() {
+            local count
+            count=$(($(cat "$retry_counter") + 1))
+            printf '%s' "$count" >"$retry_counter"
+            [[ "$count" -ge 2 ]]
+        }
+        install_grpcurl_with_retry \
+            "$GRPCURL_VERSION" "$GRPCURL_SHA256" "$GRPCURL_URL" /usr/local/bin
+    ) 2>/dev/null || fail_self_test "retry did not recover from a transient failure"
+    [[ "$(cat "$retry_counter")" -eq 2 ]] \
+        || fail_self_test "retry did not stop on the first success"
+
+    printf '0' >"$retry_counter"
+    if (
+        sleep() { :; }
+        install_grpcurl() {
+            printf '%s' "$(($(cat "$retry_counter") + 1))" >"$retry_counter"
+            return 1
+        }
+        install_grpcurl_with_retry \
+            "$GRPCURL_VERSION" "$GRPCURL_SHA256" "$GRPCURL_URL" /usr/local/bin
+    ) 2>/dev/null; then
+        fail_self_test "persistent download failure was not surfaced"
+    fi
+    [[ "$(cat "$retry_counter")" -eq "$GRPCURL_ATTEMPTS" ]] \
+        || fail_self_test "retry did not stop after ${GRPCURL_ATTEMPTS} attempts"
+
     named_steps=$(grep -cE '^[[:space:]]+- name: Install grpcurl' \
         "$repo_root/.github/workflows/interop.yml")
     workflow_calls=$(grep -cF 'bash .github/scripts/install-grpcurl.sh' \
@@ -158,7 +216,7 @@ EOF
 
 case ${1:-} in
     "")
-        install_grpcurl \
+        install_grpcurl_with_retry \
             "$GRPCURL_VERSION" \
             "$GRPCURL_SHA256" \
             "$GRPCURL_URL" \

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -224,7 +224,7 @@ jobs:
         # vs FRR vtysh JSON) and the policy test/stats assertions.
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -361,7 +361,7 @@ jobs:
       - name: Install grpcurl + jq
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -403,7 +403,7 @@ jobs:
       - name: Install grpcurl + jq
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -451,7 +451,7 @@ jobs:
       - name: Install grpcurl + jq
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -489,7 +489,7 @@ jobs:
       - name: Install grpcurl + jq
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -527,7 +527,7 @@ jobs:
       - name: Install grpcurl + jq
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -565,7 +565,7 @@ jobs:
       - name: Install grpcurl + jq
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -603,7 +603,7 @@ jobs:
       - name: Install grpcurl + jq
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -641,7 +641,7 @@ jobs:
       - name: Install grpcurl + jq
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -682,7 +682,7 @@ jobs:
         # for the per-step flap-detection assertion.
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -752,7 +752,7 @@ jobs:
         # jq drives the pmacct-msglog and gobmp-JSON oracle assertions.
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -801,7 +801,7 @@ jobs:
       - name: Install grpcurl + jq
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -844,7 +844,7 @@ jobs:
         # jq drives the FRR vtysh / GoBGP JSON client-view assertions.
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -888,7 +888,7 @@ jobs:
         # jq drives the rbgp JSON client-view assertions.
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -934,7 +934,7 @@ jobs:
         # jq drives the exact reconstructed-RIB and wire-receipt assertions.
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -975,7 +975,7 @@ jobs:
         # jq drives the bgpctl -j and rbgp JSON client-view assertions.
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1099,7 +1099,7 @@ jobs:
         # grep would let a malformed match slip past.
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1136,7 +1136,7 @@ jobs:
         # uptime epoch comparison in test-m34.
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1173,7 +1173,7 @@ jobs:
         # for the community-presence assertion.
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1210,7 +1210,7 @@ jobs:
         # the community-presence assertion.
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1246,7 +1246,7 @@ jobs:
         # jq pretty-prints EVPN diagnostics and parses grpcurl JSON.
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1284,7 +1284,7 @@ jobs:
         # on tagged /32, neither on untagged /32).
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1362,7 +1362,7 @@ jobs:
           bash .github/scripts/install-grpcurl.sh
           curl -sL https://github.com/openconfig/gnmic/releases/download/v0.46.0/gnmic_0.46.0_Linux_x86_64.tar.gz \
             | sudo tar -xz -C /usr/local/bin gnmic
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1402,7 +1402,7 @@ jobs:
       - name: Install grpcurl and jq
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1439,7 +1439,7 @@ jobs:
           bash .github/scripts/install-grpcurl.sh
           curl -sL https://github.com/openconfig/gnmic/releases/download/v0.46.0/gnmic_0.46.0_Linux_x86_64.tar.gz \
             | sudo tar -xz -C /usr/local/bin gnmic
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1514,7 +1514,7 @@ jobs:
         # `show bgp ipv4 unicast json` for the received-prefix-set assertions.
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1552,7 +1552,7 @@ jobs:
         # counters come over plain HTTP.
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1590,7 +1590,7 @@ jobs:
         # route-exchange prefixes and reads rustbgpd's RIB.
         run: |
           bash .github/scripts/install-grpcurl.sh
-          sudo apt-get update -y && sudo apt-get install -y jq
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## Problem

The hosted grpcurl release download is the only external fetch every Interop job shares, so a single CDN or network hiccup reds a ~38-job run. On 2026-07-24 the "M85/M93 — RR core + required-family enforcement against BIRD 2" job failed twice in a row after ~35 seconds at the "Install grpcurl + jq" step, then passed on the third attempt — a transient download failure, not a product failure.

## Fix

Wrap the shared installer's download in a bounded retry loop: 3 attempts with 5s then 10s backoff. This matches the shape the hardened containerlab installer already uses for the same class of failure.

Retry covers download **and** verification as a unit. Every attempt re-runs the checksum and version checks, so a truncated or corrupted archive is re-fetched rather than accepted, and a rejected archive is never installed. The verification added in #1097 is preserved exactly and still gates each attempt. After the final attempt the step fails, naming the URL and the attempt count.

curl's own `--retry` flags are dropped now that the outer loop owns retry. Only the checksum catches a truncated 200-OK body — which is the failure mode that matters here — and nesting the two retry mechanisms would multiply the worst case past the job timeout. That is the same reasoning the containerlab installer records.

All 20 grpcurl install steps across `interop.yml` and the dataplane host setup action already route through the shared script, so this is a single-file change for the download itself.

## jq

The same step's other network dependency is `apt-get update && apt-get install -y jq`. jq is preinstalled on hosted runners, and a transient error from a preinstalled third-party repo during `apt-get update` can fail the job on its own. The 28 interop sites now skip apt entirely when jq is already present — the guard the dataplane host setup action already applies.

## Verification

- `bash -n` and `shellcheck` clean on the installer.
- `install-grpcurl.sh --self-test` passes, extended with two new cases: a transient failure must install and stop on the first success, and a persistent failure must still fail after the bounded attempts.
- Both new cases were confirmed load-bearing by mutating the attempt bound to 1, which makes the self-test fail.
- Real-network smoke of the pinned URL and checksum with the retry flags removed.
- `interop.yml` parses; `cargo fmt --all -- --check` clean.