### PR TITLE
Close doc-precision and lint-policy sweep residue

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,14 +115,19 @@ Each component is the single source of truth for its domain. No overlapping auth
 
 | Component | Owns | Authoritative for |
 |-----------|------|-------------------|
-| **PeerManager** | Neighbor lifecycle, config intent | Which peers should exist and their parameters |
-| **FSM** | Protocol state transitions | What state each peer session is actually in |
-| **RIB** | Routing state | What routes exist, which is best, what to advertise |
-| **Transport** | Socket I/O, wire framing | TCP connections, message encode/decode, session runtime |
-| **FIB runtime** | Kernel forwarding state (`src/fib_runtime.rs`) | Which unicast routes are installed in Linux and their owned-state across restart; the sole owner of netlink route programming |
+| **PeerManager** | Neighbor lifecycle, config intent (`src/peer_manager`) | Which peers should exist and their parameters |
+| **FSM** | Protocol state transitions (`crates/fsm`) | What state each peer session is actually in |
+| **RibManager** | Routing state (`crates/rib`) | What routes exist, which is best, what to advertise |
+| **Transport** | Socket I/O, wire framing (`crates/transport`) | TCP connections, message encode/decode, session runtime |
+| **FIB runtime** | Kernel forwarding state (`src/fib_runtime.rs`) | Which unicast routes are installed into the configured `[[fib_tables]]` and their owned-state across restart. Owns netlink route programming for that table set only — the BLACKHOLE reconciler and the EVPN Linux dataplane own their own, disjoint kernel domains |
+| **BLACKHOLE reconciler** | RFC 7999 kernel discard routes (`src/blackhole.rs`) | Which `RTN_BLACKHOLE` rows in the main table are daemon-owned (installed this lifetime or adopted by marker at startup per ADR-0079). Deliberately separate from the FIB runtime: RTBH is a unicast/RIB feature, not part of the `[[fib_tables]]` projection |
 | **BFD actor** | BFD session liveness (`src/bfd_runtime.rs`) | Whether each BFD-tracked peer's forwarding path is up; the sole owner of BFD sockets, timers, and discriminators (drives RFC 5882 coupling) |
-| **Config transaction controller** | Transaction execution, confirmed-commit state, rollback orchestration | Which candidate TOML changes can commit atomically and when runtime config mutations are fenced |
-| **API** | Request/response adaptation | Nothing — it translates gRPC into commands and queries |
+| **EVPN runtime converger** | Live EVPN runtime model (`src/evpn_runtime_converger.rs`) | Which validated candidate EVPN runtime mutations converge, in what order, and how far the rollback ladder unwinds a failed apply (ADR-0063) |
+| **EVPN dataplane supervisor** | EVPN kernel intent (`src/evpn_dataplane.rs` → `crates/evpn-linux`) | The `DataplaneIntent` projected from EVPN best paths, and the FDB / neighbor / nexthop-group / IP-VRF state the reconcile actor owns in the kernel. The supervisor is daemon-owned glue precisely because ADR-0054 forbids `evpn-linux` from depending on `rib` or `transport` |
+| **Config transaction controller** | Transaction execution, confirmed-commit state, rollback orchestration (`src/config_transaction_control.rs`, `src/confirm_journal.rs`) | Which candidate TOML changes can commit atomically and when runtime config mutations are fenced |
+| **BMP manager** | Collector connections and monitoring feed (`crates/bmp`) | What each collector has been told: per-peer up/down, pre- and post-policy PDUs, and Loc-RIB instance state (RFC 7854 / 8671 / 9069). Unidirectional — never a routing input |
+| **Event history manager** | Durable event outbox (`crates/event-history`) | `event_id` assignment and cursor durability; producer payload bytes pass through unchanged (ADR-0072) |
+| **API** | Request/response adaptation (`crates/api`) | Nothing — it translates gRPC into commands and queries |
 | **EVPN originator** | MAC / IP-VRF route generation counters (`src/evpn_originator`, `src/evpn_l3_originator.rs`) | EVPN origination generation/sequence numbers; uses `Arc<RwLock>` by design — lower-frequency kernel-observation glue, outside the RIB hot-path "no shared mutable routing state / no locks" invariant |
 
 The API layer is explicitly *not* a source of truth. It is an adapter between gRPC callers and the authoritative components.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1962,35 +1962,32 @@ branch is between features.
   neither has a test-module discount available. Keep splitting only where it
   reduces real conflict or review cost.
 - [ ] **Doc-precision + lint-policy consistency sweep (v0.41.0 review).** A
-  whole-codebase review found no correctness or security defects; the actionable
-  residue is documentation/policy drift, all low-risk:
-  - Status (2026-07-17): the ARCHITECTURE.md channel-enumeration,
-    ownership-table EVPN exception, and SECURITY.md unsafe-code-wording
-    sub-items below landed across the v0.41–v0.51 doc passes, and
-    `#![deny(unsafe_code)]` is on the event-history and cli crates. The one
-    live residue is the thiserror 1.x/2.x duplicate — upstream-blocked
-    (thiserror 1.x is pulled only by `protobuf` via `prometheus`, not by any
-    first-party crate), so it is periodic hygiene, not actionable until
-    upstream moves off it.
-  - ARCHITECTURE.md design-invariant #3 understates the intentional
-    unbounded-channel set — it names only the collision-notification channel, but
-    `bfd_runtime` (state-change fan-out), `peer_manager` (internal + session-notify),
-    `main` / `reload.rs` (config + internal-command coordinator), and
-    `transport::session::writer` (priority) all carry justified unbounded channels.
-    Re-enumerate the intentional set so the invariant stays a usable review gate.
-  - ARCHITECTURE.md ownership table: note that the EVPN originator subsystem
-    (`evpn_originator`, `evpn_l3_originator`) uses `Arc<RwLock>` generation counters
-    by design — the "no shared mutable routing state" invariant is narrowly about
-    the RIB hot path, not lower-frequency kernel-observation daemon glue.
-  - `#![deny(unsafe_code)]` is missing on `crates/event-history` (lib) and
-    `crates/cli` (bin) although CONTRIBUTING.md says "every crate"; both are
-    unsafe-free today — add for consistency + future-proofing.
-  - SECURITY.md "No unsafe code. Every crate enforces `#![deny(unsafe_code)]`"
-    overstates: `crates/transport` carries a scoped `#[allow(unsafe_code)]` on
-    `socket_opts` (TCP_MD5SIG / IP_MINTTL / TCP-AO FFI — the only unsafe in the
-    tree). Reword to acknowledge the documented exception.
-  - Optional periodic hygiene: trim the `thiserror` 1.x duplicate (1.0.69 + 2.0.18
-    both resolved) at the next dependency refresh.
+  whole-codebase review found no correctness or security defects; the residue was
+  documentation/policy drift, all low-risk. The documentation and lint-policy
+  sub-items are now closed:
+  - ARCHITECTURE.md design-invariant #3 re-enumerates the intentional
+    unbounded-channel set (collision notifications, `peer_manager` internals,
+    the `reload.rs` coordinator, the transport writer's priority channel, BFD
+    state-change fan-out), so the invariant reads as a usable review gate.
+  - The ARCHITECTURE.md ownership table is trued up against the actors at HEAD:
+    the BLACKHOLE reconciler, EVPN runtime converger, EVPN dataplane supervisor,
+    BMP manager, and event-history manager have rows; the FIB runtime's scope is
+    stated as the configured `[[fib_tables]]` rather than all netlink route
+    programming; and the EVPN originator's by-design `Arc<RwLock>` generation
+    counters are noted as outside the RIB hot-path "no locks" invariant.
+  - `#![deny(unsafe_code)]` is on every workspace crate root — the last four
+    (`examples/event-bridge`, `examples/birdwatcher-adapter`, and both
+    `tools/rs-config-render` roots) landed with this item, so CONTRIBUTING.md's
+    "every crate" is now literally true.
+  - SECURITY.md states the actual posture: the `crates/transport` `socket_opts`
+    FFI allow, the daemon binary's `cfg_attr` gate under the `jemalloc` /
+    `dhat-heap` allocator features, and the test/bench targets that carry
+    justified `unsafe` outside any shipped path.
+
+  The one live residue is the `thiserror` 1.x/2.x duplicate (1.0.69 + 2.0.18 both
+  resolved) — upstream-blocked, since 1.x is pulled only by `protobuf` via
+  `prometheus` and by no first-party crate. Periodic hygiene at a dependency
+  refresh, not actionable until upstream moves off it.
 - [x] **Retire `rustbgpctl` in favor of `rbgp` (single CLI name).** The CLI
   crate now ships only the `rbgp` binary. The old `include!` alias/shim and
   long-form binary are removed; supported docs, package artifacts, generated

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,11 +47,25 @@ input from the network. It runs under continuous fuzzing in CI.
 - **No unbounded allocations.** All channels are bounded. Per-peer
   prefix limits enforced at insertion. UPDATE attribute sizes enforced
   at decode time.
-- **No `unsafe` code, with one scoped exception.** Every crate enforces
-  `#![deny(unsafe_code)]`. The sole exception is `crates/transport`'s
-  `socket_opts` module, which carries a documented `#[allow(unsafe_code)]` for
-  socket-option FFI (`TCP_MD5SIG`, `IP_MINTTL`, TCP-AO) that has no safe Rust
-  API; those are the only `unsafe` blocks in the tree.
+- **No `unsafe` code in shipped paths, with two scoped exceptions.** Every
+  workspace crate root carries `#![deny(unsafe_code)]`, so `unsafe` cannot enter
+  a crate without a visible, reviewed opt-out. There are two:
+  - `crates/transport`'s `socket_opts` module carries a documented
+    `#[allow(unsafe_code)]` for socket-option FFI (`TCP_MD5SIG`, `IP_MINTTL`,
+    TCP-AO) that has no safe Rust API. This is the only `unsafe` in any library
+    crate.
+  - The daemon binary's deny is `cfg_attr`-gated off when the `jemalloc` (the
+    default) or `dhat-heap` feature is on, because registering a
+    `#[global_allocator]` is itself an `unsafe` construct. Building with
+    `--no-default-features` re-arms the deny; the daemon writes no `unsafe`
+    blocks of its own under either configuration.
+
+  Test and benchmark targets are separate compilation units and are not covered
+  by a crate root's deny. Several carry justified `unsafe`: allocation-tracking
+  `GlobalAlloc` wrappers used by the memory-profile receipts (`crates/mrt`
+  benches, `crates/rib` tests, the standalone `bench/scale` harnesses) and
+  `libc` socket/netns helpers in the privileged `crates/evpn-linux` tests. None
+  of that code ships in the daemon or in any published library crate.
 - **Structured errors, not strings.** Every failure produces a
   machine-parseable event for forensic analysis.
 

--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -4,8 +4,9 @@
 //! require raw socket options that are only available on Linux. TCP-AO
 //! (RFC 5925) uses the same boundary for `setsockopt` and `getsockopt`.
 //!
-//! These are the only `unsafe` blocks in the project — they exist because
-//! there is no safe Rust API for `TCP_MD5SIG`, `IP_MINTTL`, or TCP-AO.
+//! These are the only `unsafe` blocks in any library crate — they exist
+//! because there is no safe Rust API for `TCP_MD5SIG`, `IP_MINTTL`, or
+//! TCP-AO. See SECURITY.md for the full unsafe-code posture.
 
 use std::io;
 #[cfg(target_os = "linux")]

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -30,6 +30,8 @@
 //! subset without adapter code. Fields that have no rustbgpd equivalent are
 //! present but empty/zero.
 
+#![deny(unsafe_code)]
+
 use std::collections::HashSet;
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path as FsPath, PathBuf};

--- a/examples/event-bridge/src/main.rs
+++ b/examples/event-bridge/src/main.rs
@@ -24,6 +24,8 @@
 //! categories should use `timestamp` from each event, not
 //! `event_id`. See ADR-0072.
 
+#![deny(unsafe_code)]
+
 use std::io::Write;
 
 use clap::Parser;

--- a/tools/rs-config-render/src/lib.rs
+++ b/tools/rs-config-render/src/lib.rs
@@ -35,6 +35,8 @@
 //! enforcement must never be reachable by a path that still carries an
 //! AS_SET — the hygiene ordering guarantees it is not.
 
+#![deny(unsafe_code)]
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -1,6 +1,8 @@
 //! CLI wrapper around the renderer library. See `README.md` for the
 //! refresh loop (`render → rustbgpd --check → swap → SIGHUP`).
 
+#![deny(unsafe_code)]
+
 use std::path::PathBuf;
 use std::process::ExitCode;
 


### PR DESCRIPTION
Closes the documentation and lint-policy residue of the doc-precision sweep
tracked in the ROADMAP tech-debt block. Every claim below was re-verified
against HEAD before editing — two of the ROADMAP's sub-items had already
landed in earlier doc passes and are now recorded as closed rather than
re-fixed.

## `#![deny(unsafe_code)]` on every workspace crate root

The ROADMAP named `crates/event-history` and `crates/cli` as missing the
attribute; both have carried it since the v0.41–v0.51 doc passes. A sweep of
all workspace members found four roots that genuinely lacked it:

- `examples/event-bridge/src/main.rs`
- `examples/birdwatcher-adapter/src/main.rs`
- `tools/rs-config-render/src/lib.rs`
- `tools/rs-config-render/src/main.rs`

All four are unsafe-free today, so this fences future drift rather than fixing
a present problem. CONTRIBUTING.md's "`#![deny(unsafe_code)]` on every crate"
is now literally true of the workspace.

Deliberately left alone: the `bench/scale` harnesses (`rrharness`,
`reloadstall`) declare their own `[workspace]`, are not members of the main
workspace, and carry justified `libc` unsafe (`kill`, `sysconf`, `gettid`).
Forcing the deny there would break them for no benefit.

## ARCHITECTURE.md chapter-3 ownership table

Corrected against the actors at HEAD; the chapter itself is unchanged.

The load-bearing fix: the FIB runtime row claimed it was "the sole owner of
netlink route programming". It is not. `src/blackhole.rs` connects its own
`LinuxBlackholeFib` and programs `RTN_BLACKHOLE` discard routes into the main
table — a deliberately separate owner, since RTBH is a unicast/RIB feature and
not part of the `[[fib_tables]]` projection. The FIB runtime's authority is now
scoped to the configured `[[fib_tables]]`, and the disjoint kernel domains are
named.

Rows added for real owners the table omitted: the BLACKHOLE reconciler, the
EVPN runtime converger (`src/evpn_runtime_converger.rs`, ADR-0063), the EVPN
dataplane supervisor (`src/evpn_dataplane.rs` → `crates/evpn-linux`, ADR-0054),
the BMP manager, and the event-history manager (ADR-0072). Existing rows gained
their source paths, and the RIB row is named `RibManager` to match the type.

## SECURITY.md unsafe-boundary wording

The old text asserted that every crate enforces the deny and that the transport
socket-option FFI holds "the only `unsafe` blocks in the tree". Two
imprecisions:

- The daemon binary's deny is `cfg_attr`-gated off whenever the `jemalloc`
  (the default) or `dhat-heap` feature is on, because registering a
  `#[global_allocator]` is itself an unsafe construct. `--no-default-features`
  re-arms it.
- Test and bench targets are separate compilation units that a crate root's
  deny does not cover, and several carry justified unsafe: allocation-tracking
  `GlobalAlloc` wrappers behind the memory-profile receipts and `libc`
  socket/netns helpers in the privileged `evpn-linux` tests.

Both are now stated, together with the fact that none of that code ships in the
daemon or in any published library crate. The identical overstatement in the
`socket_opts` module doc comment is corrected to match.

## Out of scope

The `thiserror` 1.x/2.x duplicate remains open in the ROADMAP item. It is
pulled only by `protobuf` via `prometheus` and by no first-party crate, so it
stays upstream-blocked periodic hygiene. The ROADMAP item is trimmed to that
single surviving residue rather than removed.

No CHANGELOG entry: nothing user-visible changed. The lint attributes alter no
behavior, API, or output, and docs-only changes in this repo do not carry
CHANGELOG entries.

## Gates

All local, all exit 0: `cargo fmt --all -- --check`,
`cargo clippy --workspace --all-targets -- -D warnings`,
`cargo test --workspace --no-fail-fast`, `cargo doc --workspace --no-deps`.
Clippy at `-D warnings` across all targets is the one that matters here — it
confirms the four new denies introduce no breaks.
