### PR TITLE
Record why each legacy-auth config stays unmigrated

### DIFF
--- a/tests/interop/configs/rustbgpd-frr-badopen.toml
+++ b/tests/interop/configs/rustbgpd-frr-badopen.toml
@@ -15,5 +15,6 @@ remote_asn = 65099
 description = "frr-badopen"
 hold_time = 90
 
+# Legacy: no gRPC listener is configured here, so tier roles would govern nothing.
 [security.grpc]
 enforcement = "legacy"

--- a/tests/interop/configs/rustbgpd-m33-scale.toml
+++ b/tests/interop/configs/rustbgpd-m33-scale.toml
@@ -38,5 +38,6 @@ hold_time = 180
 families = ["l2vpn_evpn"]
 route_reflector_client = true
 
+# Legacy: the M33 driver and soak read the RIB over plaintext grpcurl, presenting no credential.
 [security.grpc]
 enforcement = "legacy"

--- a/tests/interop/configs/rustbgpd-m37-originator.toml
+++ b/tests/interop/configs/rustbgpd-m37-originator.toml
@@ -30,5 +30,6 @@ description = "consumer-frr"
 hold_time = 30
 families = ["l2vpn_evpn"]
 
+# Legacy: M37 asserts via FRR's RIB, kernel bridge fdb, and Prometheus — never this gRPC listener.
 [security.grpc]
 enforcement = "legacy"

--- a/tests/interop/configs/rustbgpd-m39-pe1.toml
+++ b/tests/interop/configs/rustbgpd-m39-pe1.toml
@@ -53,5 +53,6 @@ vrf_device = "vrf1"
 l3vxlan_device = "l3vxlan100"
 table_id = 100
 
+# Legacy: the M39 driver reads the RIB over plaintext grpcurl; the Gate 9 soak reuses this config.
 [security.grpc]
 enforcement = "legacy"

--- a/tests/interop/configs/rustbgpd-m67-vtep.toml
+++ b/tests/interop/configs/rustbgpd-m67-vtep.toml
@@ -45,5 +45,6 @@ hold_time = 30
 families = ["l2vpn_evpn"]
 route_reflector_client = true
 
+# Legacy: M67 mounts its operator token on pe1/pe2 only; driver and soak read this vtep via plain rbgp.
 [security.grpc]
 enforcement = "legacy"

--- a/tests/interop/configs/rustbgpd-soak-gr-restart.toml
+++ b/tests/interop/configs/rustbgpd-soak-gr-restart.toml
@@ -24,5 +24,6 @@ gr_restart_time = 15
 gr_stale_routes_time = 20
 llgr_stale_time = 60
 
+# Legacy: the GR-restart soak observes via Prometheus and FRR only, with no gRPC client or token.
 [security.grpc]
 enforcement = "legacy"

--- a/tests/interop/configs/rustbgpd-soak-hot-reload.toml
+++ b/tests/interop/configs/rustbgpd-soak-hot-reload.toml
@@ -21,5 +21,6 @@ remote_asn = 65002
 description = "frr-soak-hot-reload-cycle-0"
 hold_time = 90
 
+# Legacy: the soak's generated candidates pin this same block, and its rbgp calls carry no token.
 [security.grpc]
 enforcement = "legacy"

--- a/tests/interop/configs/rustbgpd-soak-inject-churn.toml
+++ b/tests/interop/configs/rustbgpd-soak-inject-churn.toml
@@ -19,5 +19,6 @@ remote_asn = 65002
 description = "frr-soak-inject"
 hold_time = 90
 
+# Legacy: the churn soak drives rbgp rib add/delete over the plaintext listener with no token.
 [security.grpc]
 enforcement = "legacy"

--- a/tests/interop_tier_auth_dataplane.rs
+++ b/tests/interop_tier_auth_dataplane.rs
@@ -10,10 +10,31 @@ const TOKEN: &str = "/run/rustbgpd/grpc-test-only-operator.token";
 const PRINCIPAL: &str = "rustbgpd://operator/test-only";
 const TOKEN_BIND: &str =
     "../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro";
-const EXCLUDED: &[&str] = &[
+const CI_PRINCIPAL: &str = "rustbgpd://operator/ci";
+
+// In-range configs pinned to `enforcement = "legacy"`. Each records its reason
+// at its own `[security.grpc]` block, and the equality allowlist in
+// interop_tier_auth_rr.rs owns the legacy inventory. Excluded here because the
+// identity assertions below describe a listener that enforces tier ceilings,
+// which these deliberately do not:
+//   m37-originator — asserted via FRR's RIB, kernel bridge fdb, and Prometheus
+//   m39-pe1 — plaintext grpcurl driver; the Gate 9 soak reuses the config
+//   m67-vtep — M67 mounts its operator token on pe1/pe2 only
+const LEGACY_EXCEPTIONS: &[&str] = &[
     "rustbgpd-m37-originator.toml",
     "rustbgpd-m39-pe1.toml",
     "rustbgpd-m67-vtep.toml",
+];
+
+// In-range configs that DO enforce tier, but authenticate with a lab-owned
+// credential rather than the shared test-only operator identity, so the
+// `token_file`/`principal` assertions below cannot apply to them. Both shapes
+// are intrinsic to what the lab proves:
+//   m44/m54/m56 — native mTLS listeners; principals arrive as client-cert URI
+//     SANs, so there is no bearer token to mount
+//   m66/m67 pe1+pe2 — a bearer-token operator listener plus a UDS observer
+//     listener, so the driver can compose an operator drain with a link reason
+const LAB_CREDENTIAL_EXCEPTIONS: &[&str] = &[
     "rustbgpd-m44-tier-authz.toml",
     "rustbgpd-m54-gnmi.toml",
     "rustbgpd-m56-gnmi-onchange.toml",
@@ -30,7 +51,8 @@ fn in_scope(name: &str) -> bool {
     let digits: String = suffix.chars().take_while(char::is_ascii_digit).collect();
     name.ends_with(".toml")
         && digits.parse::<u8>().is_ok_and(|n| (36..=69).contains(&n))
-        && !EXCLUDED.contains(&name)
+        && !LEGACY_EXCEPTIONS.contains(&name)
+        && !LAB_CREDENTIAL_EXCEPTIONS.contains(&name)
 }
 
 /// Reverting tier, removing a mount/opt-in/M66 token, bypassing the helper, or
@@ -170,6 +192,55 @@ fn active_dataplane_interop_is_tier_authenticated_end_to_end() {
         Some(TOKEN),
         "M66 vtep_ctl must inherit the shared token"
     );
+}
+
+/// Both exception lists are proven, not merely trusted: a stale entry naming a
+/// renamed or deleted config, a legacy pin that silently moved to tier, or a
+/// lab config that adopted the shared identity and should rejoin the scoped
+/// assertions each make this red.
+#[test]
+fn auth_exceptions_still_match_their_declared_category() {
+    let config_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/interop/configs");
+    let read = |name: &str| {
+        fs::read_to_string(config_dir.join(name))
+            .unwrap_or_else(|error| panic!("{name} is listed but unreadable: {error}"))
+    };
+    let enforcement = |name: &str, source: &str| {
+        let value: toml::Value =
+            toml::from_str(source).unwrap_or_else(|error| panic!("{name}: {error}"));
+        value["security"]["grpc"]
+            .get("enforcement")
+            .and_then(toml::Value::as_str)
+            .map(str::to_owned)
+    };
+
+    for name in LEGACY_EXCEPTIONS {
+        let source = read(name);
+        assert_eq!(
+            enforcement(name, &source).as_deref(),
+            Some("legacy"),
+            "{name} is listed as a legacy exception but no longer pins legacy"
+        );
+    }
+
+    for name in LAB_CREDENTIAL_EXCEPTIONS {
+        let source = read(name);
+        assert_ne!(
+            enforcement(name, &source).as_deref(),
+            Some("legacy"),
+            "{name} is listed as a tier-enforcing exception but pins legacy"
+        );
+        let value: toml::Value = toml::from_str(&source).unwrap();
+        assert_eq!(
+            value["security"]["grpc"]["roles"][CI_PRINCIPAL].as_str(),
+            Some("operator"),
+            "{name} must map the lab-owned CI operator principal"
+        );
+        assert!(
+            !source.contains(PRINCIPAL),
+            "{name} uses the shared identity and belongs in the scoped assertions"
+        );
+    }
 }
 
 /// Load-bearing proof: restoring either daemon-log grep oracle, removing the

--- a/tests/interop_tier_auth_rr.rs
+++ b/tests/interop_tier_auth_rr.rs
@@ -62,16 +62,29 @@ const TOPOLOGIES: &[&str] = &[
     "m92-gobgp-v47-rs-differential",
     "m93-required-families-bird",
 ];
+// Configs deliberately held on `enforcement = "legacy"`. Each states its own
+// reason at its `[security.grpc]` block; the tags below are the short form.
+// Adding an entry means recording the reason in the config too.
 const LEGACY_ALLOWLIST: &[&str] = &[
+    // no gRPC listener to govern
     "tests/interop/configs/rustbgpd-frr-badopen.toml",
+    // driver and soak call grpcurl directly, uncredentialed
     "tests/interop/configs/rustbgpd-m33-scale.toml",
+    // asserted through FRR, bridge fdb, and Prometheus
     "tests/interop/configs/rustbgpd-m37-originator.toml",
+    // plaintext grpcurl driver; shared with the Gate 9 soak
     "tests/interop/configs/rustbgpd-m39-pe1.toml",
+    // operator token on pe1/pe2 only; vtep read over plain rbgp
     "tests/interop/configs/rustbgpd-m67-vtep.toml",
+    // soak observes via Prometheus and FRR, no gRPC client
     "tests/interop/configs/rustbgpd-soak-gr-restart.toml",
+    // soak's generated candidates pin the same legacy block
     "tests/interop/configs/rustbgpd-soak-hot-reload.toml",
+    // soak drives rbgp rib add/delete without a token
     "tests/interop/configs/rustbgpd-soak-inject-churn.toml",
+    // Gate 8b soaks observe via Prometheus only
     "tests/soak/configs/rustbgpd-soak-gate8b-pe1.toml",
+    // Gate 8b soaks observe via Prometheus only
     "tests/soak/configs/rustbgpd-soak-gate8b-pe2.toml",
 ];
 

--- a/tests/soak/configs/rustbgpd-soak-gate8b-pe1.toml
+++ b/tests/soak/configs/rustbgpd-soak-gate8b-pe1.toml
@@ -46,5 +46,6 @@ description = "pe2"
 hold_time = 30
 families = ["l2vpn_evpn"]
 
+# Legacy: the Gate 8b soaks observe via Prometheus only; no gRPC client or operator token is wired.
 [security.grpc]
 enforcement = "legacy"

--- a/tests/soak/configs/rustbgpd-soak-gate8b-pe2.toml
+++ b/tests/soak/configs/rustbgpd-soak-gate8b-pe2.toml
@@ -42,5 +42,6 @@ description = "pe1"
 hold_time = 30
 families = ["l2vpn_evpn"]
 
+# Legacy: the Gate 8b soaks observe via Prometheus only; no gRPC client or operator token is wired.
 [security.grpc]
 enforcement = "legacy"


### PR DESCRIPTION
The tier-auth migration moved every interop lab and config fixture onto
`enforcement = "tier"`. Ten configs deliberately remain on `legacy`, held
honest by the equality allowlist in `tests/interop_tier_auth_rr.rs` — but the
reason each one stays was recorded nowhere, so a reader had no way to tell a
deliberate exception from a missed migration.

Each config now carries a one-line rationale at its `[security.grpc]` block,
derived from the driver, soak harness, and topology that consume it:

| Config | Reason |
|---|---|
| `rustbgpd-frr-badopen.toml` | Declares no gRPC listener at all |
| `rustbgpd-m33-scale.toml` | Driver and soak read the RIB over plaintext grpcurl |
| `rustbgpd-m37-originator.toml` | Asserted via FRR, kernel bridge fdb, and Prometheus |
| `rustbgpd-m39-pe1.toml` | Plaintext grpcurl driver; shared with the Gate 9 soak |
| `rustbgpd-m67-vtep.toml` | M67 mounts its operator token on pe1/pe2 only |
| `rustbgpd-soak-gr-restart.toml` | Soak observes via Prometheus and FRR, no gRPC client |
| `rustbgpd-soak-hot-reload.toml` | Soak's generated candidates pin the same legacy block |
| `rustbgpd-soak-inject-churn.toml` | Soak drives `rbgp rib add`/`delete` without a token |
| `rustbgpd-soak-gate8b-pe1.toml` | Gate 8b soaks observe via Prometheus only |
| `rustbgpd-soak-gate8b-pe2.toml` | Gate 8b soaks observe via Prometheus only |

The allowlist entries carry the short form of the same reasons so the fence and
the configs agree, plus a note that adding an entry means recording the reason
in the config too.

The config edits are comment-only; no enforcement value changes and the legacy
set is unchanged. That fence classifies semantically
(`legacy_inventory_classification_is_semantic`), so the added comments cannot
perturb it.

## Dataplane fence: split the exception list by category

`tests/interop_tier_auth_dataplane.rs` excluded ten configs through one
undifferentiated list, conflating the same two ideas this PR separates
elsewhere. It is now two named lists, each with a doc comment stating what the
category means and why exclusion is correct:

- `LEGACY_EXCEPTIONS` (3) — `m37-originator`, `m39-pe1`, `m67-vtep`, all
  pinning `enforcement = "legacy"`. Reasons match the config comments above so
  the two cannot drift.
- `LAB_CREDENTIAL_EXCEPTIONS` (7) — `m44-tier-authz`, `m54-gnmi`,
  `m56-gnmi-onchange`, `m66-pe1/pe2`, `m67-pe1/pe2`. These enforce tier but
  authenticate with a lab-owned credential rather than the shared test-only
  operator identity: `m44`/`m54`/`m56` use native mTLS listeners whose
  principals arrive as client-cert URI SANs (no bearer token to mount), and the
  `m66`/`m67` PE nodes pair a bearer-token operator listener with a UDS observer
  listener so the driver can compose an operator drain with a link reason.

Membership is now proven rather than trusted. A new test asserts legacy entries
still pin legacy, lab-credential entries do not pin legacy, map the lab CI
operator principal, and have not adopted the shared identity; a stale entry
naming a renamed or deleted config fails as well. Verified to bite by
temporarily miscategorising a config.

Gates: `cargo test --workspace --no-fail-fast` and `cargo fmt --all -- --check`
both exit 0.

