### PR TITLE
Add restart-required [global] ebgp_requires_policy config boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`[global] ebgp_requires_policy` configuration boundary (ADR-0112,
+  RFC 8212).** The opt-in enforcement mode now parses, defaults to `false`,
+  classifies as restart-required, and is pinned to the startup value across
+  SIGHUP: a reload logs an `ERROR`, keeps the running import/export treatment
+  of every eBGP session unchanged, and carries the operator's edit forward on
+  disk. `rustbgpd --diff` and the v1 runtime configuration transaction name
+  `[global].ebgp_requires_policy` explicitly instead of only the `[global]`
+  section, and the transaction rejects such a candidate rather than persisting
+  or partly adopting it. Enforcement itself — the reserved internal deny,
+  directional policy-presence status, and `rbgp doctor` integration — is not
+  implemented yet; setting the field `true` logs a startup warning and changes
+  no routing behavior.
+
 ### Changed
 
 - **Live edits of `max_prefix_restart_seconds` reschedule the pending

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -138,6 +138,7 @@ Required. Defines the local BGP speaker identity.
 | `honor_blackhole`   | bool   | no       | `false`              | Enable RFC 7999 receiver scoping on EBGP imports — see below |
 | `install_blackhole_discard` | bool | no | `false`              | Install kernel blackhole routes for accepted RFC 7999 host routes — see below |
 | `allow_blackhole_broad_prefixes` | bool | no | `false`           | Permit non-host BLACKHOLE discard installs when the FIB slice is enabled |
+| `ebgp_requires_policy` | bool | no       | `false`              | RFC 8212: require explicit operator import/export policy on eBGP sessions. **Restart-required** and **not yet enforced** — see below |
 | `multipath_relax`   | bool   | no       | `false`              | ADR-0066 multipath-relax: group unicast ECMP candidates by `AS_PATH` *length* instead of an exact `AS_PATH` match (FRR's `bgp bestpath as-path multipath-relax`). Best-path-wide; inert unless a `[[fib_tables]]` sets `maximum_paths`, `maximum_paths_ebgp`, or `maximum_paths_ibgp` above `1` |
 | `link_bandwidth_weighted` | bool | no   | `false`              | ADR-0068 weighted multipath: weight unicast ECMP next-hops by the lowest finite nonnegative RFC 10005 Link Bandwidth value when the whole equal-cost group carries a positive one; zero, missing, or unusable values fall back to equal cost. Best-path-wide; inert unless a `[[fib_tables]]` sets `maximum_paths`, `maximum_paths_ebgp`, or `maximum_paths_ibgp` above `1` |
 
@@ -370,6 +371,34 @@ configured, `honor_blackhole` remains hot-applied through the peer manager.
 The `"BLACKHOLE"` alias is accepted everywhere `match_community`,
 `set_community_add`, and `set_community_remove` parse community values, so
 policies can refer to it by name without repeating `65535:666`.
+
+### `ebgp_requires_policy` — RFC 8212 explicit policy on eBGP
+
+RFC 8212 makes an eBGP route without an explicit import policy ineligible for
+the decision process, and keeps a route without an explicit export policy out
+of that peer's Adj-RIB-Out. rustbgpd's historical behavior is permit-all when a
+session resolves no policy chain, so the RFC 8212 boundary is an opt-in knob:
+
+```toml
+[global]
+ebgp_requires_policy = true
+```
+
+**Enforcement is not implemented yet.** ADR-0112 sequences the work, and this
+release only lands the configuration boundary: the field parses, classifies as
+restart-required, and is pinned across SIGHUP. Setting it `true` logs a startup
+warning and changes no import or export behavior. Do not rely on it for
+route-leak protection until the enforcement path ships.
+
+The knob is deliberately restart-required rather than hot-applied. Enabling it
+flips both directions on every eBGP session at once, and recovering a peer's
+Adj-RIB-In afterwards depends on negotiated Route Refresh, so a fleet-wide
+transition must not hide inside a SIGHUP. A reload that changes the field logs
+an `ERROR`, keeps the running value at the startup value, and reports the
+candidate as restart-required; `rustbgpd --diff` and the v1 runtime
+configuration transaction both name `[global].ebgp_requires_policy` rather than
+only the `[global]` section. The v1 transaction rejects such a candidate outright
+instead of persisting or partly adopting it.
 
 ---
 

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -224,6 +224,7 @@ that are stood up once at startup. Two flags are hot-pluggable.
 | `cluster_id` | restart-required | RFC 4456 cluster identity; affects every iBGP advertisement. |
 | `honor_graceful_shutdown` | live | Hot-applied by `reload.rs`. Re-evaluates the GShut LOCAL_PREF de-preference against existing Adj-RIB-In on toggle. |
 | `honor_blackhole` | live (with FIB-discard caveat) | Hot-applied when `[global] install_blackhole_discard` is false. When the FIB-discard reconciler is configured (`install_blackhole_discard = true` and the FIB table is set up), `honor_blackhole` is **restart-required** — toggling it would change the discard-spawn-gate decision made at startup. Logged as `ERROR` during reload in that case. |
+| `ebgp_requires_policy` | restart-required | ADR-0112 RFC 8212 enforcement mode. Pinned to the startup value by `reload.rs`: a SIGHUP reports the changed candidate as restart-required (`[global].ebgp_requires_policy` is named in `--diff` and in the v1 transaction rejection) and logs an `ERROR`, but the running import/export treatment of every eBGP session stays at the startup value. Enforcement itself is not implemented yet. |
 | `install_blackhole_discard` | restart-required | The RFC 7999 kernel-discard reconciler spawns once at startup. |
 | `allow_blackhole_broad_prefixes` | restart-required | Same — feeds the discard-spawn gate. |
 | `multipath_relax` | restart-required | RIB best-path tie-break behavior; reconciling mid-flight would require an Adj-RIB-Out rebuild. |

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -989,6 +989,11 @@
           "default": null,
           "minimum": 0
         },
+        "ebgp_requires_policy": {
+          "description": "Require explicit operator import/export policy on EBGP sessions\n(RFC 8212). Off by default, which preserves the historical treatment of\nan EBGP session with no resolved policy chain as permit-all.\n\n**Restart-required.** The enforcement mode is read once at startup and\npinned across SIGHUP: a reload reports a changed value as\nrestart-required and keeps the running daemon on its startup value, so a\nfleet-wide, two-direction import/export transition cannot hide inside a\nhot reload.\n\nADR-0112 sequences enforcement behind this knob. This release accepts,\nclassifies, and pins the setting but does not yet install the reserved\ninternal deny, so `true` logs a startup warning and changes no routing\nbehavior until the enforcement path lands.",
+          "type": "boolean",
+          "default": false
+        },
         "honor_blackhole": {
           "description": "Honor RFC 7999 `BLACKHOLE` community on inbound EBGP routes by\nappending an implicit chain-tail rule that preserves the `BLACKHOLE`\nmarker and adds `NO_ADVERTISE` to keep the request local. Off by\ndefault; RFC 7999 §4 says receivers should not discard traffic without\nan explicit operator directive. This knob scopes the control-plane\nroute; kernel discard/null-route installation requires the separate\n`install_blackhole_discard` opt-in.\n\nSIGHUP hot-applies through the peer manager, matching\n`honor_graceful_shutdown`.",
           "type": "boolean",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -722,6 +722,24 @@ impl Config {
             .unwrap_or(DEFAULT_DYNAMIC_NEIGHBOR_LIMIT)
     }
 
+    /// Emit the startup warning for `[global] ebgp_requires_policy = true`
+    /// while ADR-0112 enforcement is still landing. The knob is accepted,
+    /// classified restart-required, and pinned across SIGHUP, but no reserved
+    /// internal deny is installed yet, so an operator who enables it must not
+    /// believe EBGP sessions are already fail-closed. Removed when the
+    /// enforcement path ships.
+    pub fn warn_if_ebgp_requires_policy_unenforced(&self) {
+        if self.global.ebgp_requires_policy {
+            tracing::warn!(
+                "[global] ebgp_requires_policy = true is recorded but NOT yet enforced: \
+                 EBGP sessions without explicit import/export policy still use the \
+                 permit-all default. Do not rely on this setting for RFC 8212 route-leak \
+                 protection until enforcement ships; see \
+                 docs/adr/0112-rfc-8212-ebgp-requires-policy.md."
+            );
+        }
+    }
+
     /// Emit the startup warning for the pre-ADR-0064 legacy gRPC
     /// authorization mode, if active. Tier enforcement becomes
     /// mandatory in a future release.
@@ -2475,6 +2493,12 @@ pub struct ConfigDiff {
     /// gate.
     pub honor_blackhole_changed: bool,
     pub global_changed: bool,
+    /// `[global] ebgp_requires_policy` changed. Already covered by the coarse
+    /// `global_changed` restart bucket; tracked separately so receipts can name
+    /// the field instead of only the section. ADR-0112 requires the RFC 8212
+    /// enforcement mode to be named explicitly, because the running mode stays
+    /// at its startup value while the on-disk candidate reads differently.
+    pub ebgp_requires_policy_changed: bool,
     pub rpki_changed: bool,
     pub bmp_changed: bool,
     /// `[gnmi_dialout]` changed. Reload-applied: the dial-out manager
@@ -3339,6 +3363,14 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
     if diff.global_changed {
         class.restart_required_sections.push("[global]".to_string());
     }
+    if diff.ebgp_requires_policy_changed {
+        // ADR-0112: name the RFC 8212 enforcement mode, not just `[global]`.
+        // The candidate is rejected outright rather than partly adopted, so the
+        // running enforcement mode stays at its startup value.
+        class
+            .restart_required_sections
+            .push("[global].ebgp_requires_policy".to_string());
+    }
     if diff.rpki_changed {
         class.restart_required_sections.push("[rpki]".to_string());
     }
@@ -3540,6 +3572,7 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
         },
         "restart_required": {
             "global_changed": diff.global_changed,
+            "ebgp_requires_policy_changed": diff.ebgp_requires_policy_changed,
             "rpki_changed": diff.rpki_changed,
             "bmp_changed": diff.bmp_changed,
             "mrt_changed": diff.mrt_changed,
@@ -3775,6 +3808,10 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
     if diff.global_changed {
         restart_sections.push("[global]");
     }
+    if diff.ebgp_requires_policy_changed {
+        restart_sections
+            .push("[global].ebgp_requires_policy (RFC 8212 enforcement mode; running value stays at the startup value)");
+    }
     if diff.rpki_changed {
         restart_sections.push("[rpki]");
     }
@@ -3935,6 +3972,8 @@ pub fn diff_config(old: &Config, new: &Config) -> ConfigDiff {
         honor_blackhole_changed: old.global.honor_blackhole != new.global.honor_blackhole
             && !blackhole_fib_discard_changed,
         global_changed: global_restart_required_changed(old, new),
+        ebgp_requires_policy_changed: old.global.ebgp_requires_policy
+            != new.global.ebgp_requires_policy,
         rpki_changed: old.rpki != new.rpki,
         bmp_changed: old.bmp != new.bmp,
         gnmi_dialout_changed: old.gnmi_dialout != new.gnmi_dialout,
@@ -4674,6 +4713,24 @@ pub(crate) fn pin_bfd_startup_only_runtime(new_config: &mut Config, current: &Co
             neighbor.bfd = pinned_bfd;
         }
     }
+    true
+}
+
+/// Pin `[global] ebgp_requires_policy` to the live snapshot. ADR-0112 makes the
+/// RFC 8212 enforcement mode restart-required: policy resolution consults it
+/// every time a peer's effective import/export chains are recomputed, so an
+/// unpinned SIGHUP would flip both directions on every EBGP session at once. A
+/// reload still *reports* the on-disk candidate through `ConfigDiff`; the
+/// running snapshot keeps the startup value until the daemon restarts. Returns
+/// whether anything was pinned.
+pub(crate) fn pin_ebgp_requires_policy_startup_only(
+    new_config: &mut Config,
+    current: &Config,
+) -> bool {
+    if new_config.global.ebgp_requires_policy == current.global.ebgp_requires_policy {
+        return false;
+    }
+    new_config.global.ebgp_requires_policy = current.global.ebgp_requires_policy;
     true
 }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -578,6 +578,22 @@ pub struct Global {
     /// `install_blackhole_discard = true`.
     #[serde(default)]
     pub allow_blackhole_broad_prefixes: bool,
+    /// Require explicit operator import/export policy on EBGP sessions
+    /// (RFC 8212). Off by default, which preserves the historical treatment of
+    /// an EBGP session with no resolved policy chain as permit-all.
+    ///
+    /// **Restart-required.** The enforcement mode is read once at startup and
+    /// pinned across SIGHUP: a reload reports a changed value as
+    /// restart-required and keeps the running daemon on its startup value, so a
+    /// fleet-wide, two-direction import/export transition cannot hide inside a
+    /// hot reload.
+    ///
+    /// ADR-0112 sequences enforcement behind this knob. This release accepts,
+    /// classifies, and pins the setting but does not yet install the reserved
+    /// internal deny, so `true` logs a startup warning and changes no routing
+    /// behavior until the enforcement path lands.
+    #[serde(default)]
+    pub ebgp_requires_policy: bool,
     /// Publish one durable, daemon-private MRT warm-cache checkpoint during
     /// coordinated shutdown. Off by default. This tranche only publishes the
     /// checkpoint and a generation-bound restart marker; boot never loads or

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -6548,6 +6548,94 @@ fn diff_config_flags_event_history_as_restart_required() {
     );
 }
 
+/// ADR-0112: the RFC 8212 enforcement mode is opt-in and off by default, so an
+/// existing deployment keeps permit-all EBGP behavior without editing anything.
+#[test]
+fn ebgp_requires_policy_defaults_off_and_parses() {
+    let default = parse(valid_toml()).unwrap();
+    assert!(
+        !default.global.ebgp_requires_policy,
+        "RFC 8212 enforcement must be opt-in"
+    );
+
+    let enabled = parse(&ebgp_requires_policy_toml()).unwrap();
+    assert!(enabled.global.ebgp_requires_policy);
+}
+
+/// `valid_toml()` with `ebgp_requires_policy = true` inside `[global]`.
+fn ebgp_requires_policy_toml() -> String {
+    valid_toml().replace(
+        "listen_port = 179",
+        "listen_port = 179\nebgp_requires_policy = true",
+    )
+}
+
+/// ADR-0112 restart pinning. Changing only `[global] ebgp_requires_policy` must
+/// classify as restart-required, name the *field* (not just `[global]`) in the
+/// human diff and in the v1 transaction rejection, and leave the running
+/// snapshot on its startup value after a SIGHUP-time pin. Hot-applying it would
+/// flip import and export on every EBGP session inside a reload.
+#[test]
+fn ebgp_requires_policy_diff_is_restart_required_named_and_pinned() {
+    let old = parse(valid_toml()).unwrap();
+    let new = parse(&ebgp_requires_policy_toml()).unwrap();
+
+    let diff = super::diff_config(&old, &new);
+    assert!(diff.ebgp_requires_policy_changed);
+    assert!(diff.global_changed);
+    assert!(diff.has_restart_required_changes());
+    assert!(
+        !diff.has_reload_applied_changes(),
+        "an enforcement-mode-only edit must not hot-apply"
+    );
+
+    let json = super::config_diff_json_value(&diff);
+    assert_eq!(
+        json["restart_required"]["ebgp_requires_policy_changed"],
+        true
+    );
+
+    let text = super::format_config_diff_with_style(&diff, &super::ConfigDiffTextStyle::default());
+    assert!(text.contains("[global].ebgp_requires_policy"), "{text}");
+
+    let class = super::classify_config_transaction_v1(&diff);
+    assert!(!class.is_committable());
+    assert!(
+        class
+            .restart_required_sections
+            .contains(&"[global].ebgp_requires_policy".to_string()),
+        "the v1 transaction receipt must name the enforcement mode: {class:?}"
+    );
+
+    // SIGHUP pins the running value back to the live snapshot.
+    let mut runtime = new.clone();
+    assert!(super::pin_ebgp_requires_policy_startup_only(
+        &mut runtime,
+        &old
+    ));
+    assert!(
+        !runtime.global.ebgp_requires_policy,
+        "the running enforcement mode stays at the startup value until restart"
+    );
+    let repinned = super::diff_config(&old, &runtime);
+    assert!(!repinned.ebgp_requires_policy_changed);
+    assert!(!repinned.global_changed);
+
+    // Idempotent: nothing to pin once the candidate already matches.
+    assert!(!super::pin_ebgp_requires_policy_startup_only(
+        &mut runtime,
+        &old
+    ));
+
+    // Disabling an enabled mode is pinned the same way.
+    let mut downgrade = old.clone();
+    assert!(super::pin_ebgp_requires_policy_startup_only(
+        &mut downgrade,
+        &new
+    ));
+    assert!(downgrade.global.ebgp_requires_policy);
+}
+
 #[test]
 fn diff_config_pins_entire_neighbor_when_tcp_ao_changes() {
     let mut old = parse(valid_toml()).unwrap();
@@ -13971,7 +14059,9 @@ fn reload_matrix_rows_for<'a>(matrix: &'a str, field: &str) -> Vec<&'a str> {
 /// deprecated unselected keys are live, while key edits and selected or
 /// nondeprecated-key deletion remain restart-required. `bfd` pins the
 /// unconditional restart-required side so a blanket "mark everything live"
-/// edit also fails.
+/// edit also fails. `ebgp_requires_policy` pins the ADR-0112 RFC 8212
+/// enforcement mode: re-marking it live would tell operators a SIGHUP can flip
+/// import and export on every EBGP session, which the reload path refuses.
 #[test]
 fn reload_matrix_pins_load_bearing_field_classes() {
     let matrix = load_reload_matrix();
@@ -13982,6 +14072,7 @@ fn reload_matrix_pins_load_bearing_field_classes() {
             "| live (ordered rotation generations) / otherwise restart-required |",
         ),
         ("bfd", "| restart-required |"),
+        ("ebgp_requires_policy", "| restart-required |"),
     ] {
         let rows = reload_matrix_rows_for(&matrix, field);
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -2774,6 +2774,7 @@ async fn run<T>(
         "starting rustbgpd"
     );
     config.warn_if_legacy_grpc_enforcement();
+    config.warn_if_ebgp_requires_policy_unenforced();
 
     let metrics = BgpMetrics::new();
     let grpc_listeners = resolve_grpc_listeners(&config).unwrap_or_else(|e| {
@@ -6369,6 +6370,7 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
                 link_bandwidth_weighted: false,
                 install_blackhole_discard: false,
                 allow_blackhole_broad_prefixes: false,
+                ebgp_requires_policy: false,
                 warm_cache_checkpoint_on_shutdown: false,
             },
             security: crate::config::SecurityConfig::default(),

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -402,6 +402,7 @@ impl PeerManager {
                     link_bandwidth_weighted: false,
                     install_blackhole_discard: false,
                     allow_blackhole_broad_prefixes: false,
+                    ebgp_requires_policy: false,
                     warm_cache_checkpoint_on_shutdown: false,
                 },
                 // PeerManager::new constructs an in-memory baseline

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -416,6 +416,7 @@ fn make_dynamic_manager_config() -> Config {
             link_bandwidth_weighted: false,
             install_blackhole_discard: false,
             allow_blackhole_broad_prefixes: false,
+            ebgp_requires_policy: false,
             warm_cache_checkpoint_on_shutdown: false,
         },
         security: crate::config::SecurityConfig {

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -1333,6 +1333,14 @@ pub(crate) async fn reload_config_with_tcp_ao(
         new_config.global.honor_blackhole = current.global.honor_blackhole;
         honor_blackhole_changed = false;
     }
+    if config::pin_ebgp_requires_policy_startup_only(&mut new_config, current) {
+        error!(
+            "[global].ebgp_requires_policy differs from the live config: the ADR-0112 \
+             RFC 8212 enforcement mode is read once at startup. Restart rustbgpd to \
+             change it. The running import/export treatment of every EBGP session is \
+             kept at its startup value for this reload."
+        );
+    }
     if config::pin_bfd_startup_only_runtime(&mut new_config, current) {
         error!(
             "BFD config differs from the live session set: the ADR-0067 BFD actor \
@@ -7433,6 +7441,29 @@ remote_asn = 65002
         assert!(!runtime.global.install_blackhole_discard);
         assert!(disk.global.honor_blackhole);
         assert!(disk.global.install_blackhole_discard);
+    }
+
+    /// ADR-0112: the RFC 8212 enforcement mode is restart-required. A SIGHUP
+    /// must keep the running snapshot on the startup value while the desired /
+    /// on-disk snapshot carries the operator's edit forward for persistence.
+    /// Hot-applying it would flip import and export on every EBGP session at
+    /// once, inside a reload.
+    #[tokio::test]
+    async fn reload_pin_ebgp_requires_policy_preserves_desired_toml_for_later_persistence() {
+        let new_toml = baseline_toml().replace(
+            "listen_port = 179",
+            "listen_port = 179\nebgp_requires_policy = true",
+        );
+        let (runtime, disk) = reload_then_persist_policy_after_desired_refresh(&new_toml).await;
+
+        assert!(
+            !runtime.global.ebgp_requires_policy,
+            "runtime must stay pinned to the live startup value"
+        );
+        assert!(
+            disk.global.ebgp_requires_policy,
+            "desired/disk snapshot must reflect the operator's opt-in"
+        );
     }
 
     // SoftResetIn-on-import-policy-change coverage is now PM-side:


### PR DESCRIPTION
First reviewable step of ADR-0112 (opt-in RFC 8212 explicit-policy
enforcement for eBGP). Lands the configuration boundary only — the reserved
internal deny, directional policy-presence status, and doctor integration
are not in this change.

## What lands

- `[global] ebgp_requires_policy` (bool, default `false`) in the config
  schema and the committed JSON Schema.
- Restart-required classification. The field already falls into the coarse
  `[global]` restart bucket; the diff now tracks it individually so receipts
  can name the enforcement mode rather than only the section. `rustbgpd
  --diff` text, the diff JSON (`restart_required.ebgp_requires_policy_changed`),
  and the v1 runtime configuration transaction all name
  `[global].ebgp_requires_policy`. The transaction rejects such a candidate
  outright instead of persisting or partly adopting it.
- SIGHUP pinning. `pin_ebgp_requires_policy_startup_only` keeps the running
  snapshot on the startup value and the reload path logs an `ERROR` pointing
  at restart. The desired / on-disk snapshot still carries the operator's
  edit forward for later persistence.
- A startup warning when the field is `true`, naming the missing enforcement
  so the setting is not mistaken for fail-closed behavior.
- `docs/CONFIGURATION.md` and `docs/reload-matrix.md` coverage; CHANGELOG
  entry.

## Why restart-required

Enabling the mode flips both directions on every eBGP session at once, and
recovering a peer's Adj-RIB-In afterwards depends on negotiated Route
Refresh. ADR-0112 therefore makes the toggle a deliberate deployment
boundary rather than something a hot reload performs fleet-wide.

## Tests

- `ebgp_requires_policy_defaults_off_and_parses` — opt-in default and TOML
  acceptance under `deny_unknown_fields`.
- `ebgp_requires_policy_diff_is_restart_required_named_and_pinned` — diff
  class, diff JSON, human `--diff` text, v1 transaction rejection, pin in
  both directions, and pin idempotence.
- `reload_pin_ebgp_requires_policy_preserves_desired_toml_for_later_persistence`
  — the reload seam: runtime pinned, disk snapshot advanced.
- `reload_matrix_pins_load_bearing_field_classes` extended, so re-marking the
  matrix row `live` fails.

Red-proofed: neutering the pin body fails both pin assertions.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D
warnings`, `cargo test --workspace --no-fail-fast`, `cargo doc --workspace
--no-deps`, and `scripts/check-v1-stable-surface.py` all exit 0.

## Remaining in ADR-0112

Provenance metadata and the reserved deny in policy resolution, threading
through PeerManager / sessions / RIB registration, the live policy-transaction
path with Route Refresh qualification, and the directional
gRPC / CLI / metrics / doctor surface.
