### PR TITLE
Add RIB-owned outbound unicast prefix accounting

### DIFF
--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -166,6 +166,13 @@ impl AdjRibOut {
             })
     }
 
+    /// Return the number of DISTINCT unicast prefixes advertised in one
+    /// address family, independent of how many Add-Path identities carry
+    /// each prefix. [`Self::len`] counts route identities instead.
+    pub(crate) fn unicast_prefix_count(&self, afi: Afi) -> usize {
+        self.prefix_path_ids.family_len(afi)
+    }
+
     /// Return all path IDs currently advertised for a given prefix.
     #[must_use]
     pub fn path_ids_for_prefix(&self, prefix: &Prefix) -> SmallVec<[u32; 1]> {

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -2467,6 +2467,19 @@ impl RibManager {
         let grouped_unicast_count = self.grouped_advertised_count(peer);
         let grouped_vpn_count = self.grouped_vpn_advertised_count(peer);
 
+        // Local outbound capacity policy (ADR-0113) is the LAST gate before
+        // the commit: every earlier reason this peer must not receive a route
+        // has already run, so a route another gate rejected consumes no
+        // capacity, and a prefix blocked here never reaches Adj-RIB-Out, the
+        // grouped admitted set, or the wire. Withdrawals are untouched.
+        self.enforce_outbound_prefix_limits(
+            peer,
+            grouped_unicast_count.is_some(),
+            &mut announce,
+            &mut next_hop_override,
+            &withdraw,
+        );
+
         // Derive metric work from the final post-OTC, post-exact-export
         // vectors: a rejected announce can disappear or synthesize a
         // withdrawal, and the resulting committed family is the only safe

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -5,6 +5,7 @@ pub use bench_support::{AdjRibOutFanoutBenchReceipt, PolicyTransitionBenchReceip
 mod distribution;
 mod graceful_restart;
 mod helpers;
+mod outbound_prefix_limits;
 mod peer_lifecycle;
 mod route_refresh;
 mod selection_deferral;
@@ -189,6 +190,11 @@ pub struct RibManager {
     unicast_prefix_peers: UnicastPrefixPeers,
     loc_rib: LocRib,
     adj_ribs_out: HashMap<IpAddr, AdjRibOut>,
+    /// Per-peer outbound unicast prefix admission state (ADR-0113). An entry
+    /// exists only for a peer with at least one configured family limit, so
+    /// today — with no operator-facing knob — this map stays empty and the
+    /// export path keeps its unlimited state shape and per-route cost.
+    outbound_prefix_limits: HashMap<IpAddr, outbound_prefix_limits::OutboundPrefixLimits>,
     outbound_peers: HashMap<IpAddr, mpsc::Sender<OutboundRouteUpdate>>,
     /// Transport session identity recorded at `PeerUp` registration,
     /// keyed like `outbound_peers`. `handle_peer_down` /
@@ -1193,6 +1199,7 @@ impl RibManager {
             unicast_prefix_peers: UnicastPrefixPeers::default(),
             loc_rib: LocRib::new(),
             adj_ribs_out: HashMap::new(),
+            outbound_prefix_limits: HashMap::new(),
             outbound_peers: HashMap::new(),
             flush_poll_budget: FLUSH_POLL_BUDGET,
             outbound_session_ids: HashMap::new(),

--- a/crates/rib/src/manager/outbound_prefix_limits.rs
+++ b/crates/rib/src/manager/outbound_prefix_limits.rs
@@ -1,0 +1,311 @@
+//! Per-peer outbound unicast prefix accounting (ADR-0113).
+//!
+//! The RIB manager owns export policy, RFC 9234 OTC filtering, exact-export
+//! precommit, and Adj-RIB-Out truth, so it is also the owner of a local
+//! capacity policy over what it advertises. This module holds that
+//! accounting: a pure per-family batch admission helper plus the per-peer
+//! state it reads and advances.
+//!
+//! Every family is unlimited today. Nothing populates
+//! `RibManager::outbound_prefix_limits`, so the export path keeps exactly the
+//! state shape and per-route cost it has always had, and an update-group
+//! member gains no per-route state. The operator-facing limit — resolved
+//! neighbor/peer-group configuration, its transaction and reload semantics,
+//! and its API/CLI/metric surface — lands as one later change; ADR-0113
+//! sequences it that way so the accounting is reviewable while it is inert.
+
+use std::collections::{HashMap, HashSet};
+use std::net::IpAddr;
+use std::num::NonZeroU32;
+use std::sync::Arc;
+
+use rustbgpd_wire::{Afi, Prefix};
+
+use super::RibManager;
+use super::helpers::prefix_family;
+
+/// The unicast families this accounting covers. VPN, labeled unicast,
+/// `FlowSpec`, EVPN, BGP-LS, and RT-Constrain are deliberately out of scope.
+pub(in crate::manager) const LIMITED_FAMILIES: [Afi; 2] = [Afi::Ipv4, Afi::Ipv6];
+
+/// One unicast family's admission state for a peer.
+#[derive(Debug, Default)]
+pub(in crate::manager) struct FamilyAdmission {
+    /// Cap on distinct advertised prefixes; `None` is unlimited.
+    pub(in crate::manager) limit: Option<NonZeroU32>,
+    /// Admitted prefixes for an update-group member, whose unicast
+    /// advertised state is group-owned and therefore has no private
+    /// Adj-RIB-Out to count (ADR-0098). Bounded by `limit`, per member, and
+    /// never part of `GroupKey` — the shared table still stages once.
+    ///
+    /// An ungrouped peer leaves this empty: its private Adj-RIB-Out prefix
+    /// index is the authoritative admitted set and already refcounts
+    /// Add-Path identities per prefix.
+    pub(in crate::manager) grouped_admitted: HashSet<Prefix>,
+    /// Whether a blocking episode is open for this family. Set when a batch
+    /// blocks a net-new prefix, cleared when a later batch blocks nothing
+    /// and leaves headroom under the cap.
+    pub(in crate::manager) blocking: bool,
+}
+
+/// A peer's per-family outbound unicast admission state.
+///
+/// An entry exists only for a peer with at least one configured limit; an
+/// absent entry is the unlimited path, which allocates nothing and runs no
+/// per-route check.
+#[derive(Debug, Default)]
+pub(in crate::manager) struct OutboundPrefixLimits {
+    ipv4: FamilyAdmission,
+    ipv6: FamilyAdmission,
+}
+
+impl OutboundPrefixLimits {
+    /// Borrow one unicast family's state, or `None` for a family outside
+    /// [`LIMITED_FAMILIES`].
+    pub(in crate::manager) fn family(&self, afi: Afi) -> Option<&FamilyAdmission> {
+        match afi {
+            Afi::Ipv4 => Some(&self.ipv4),
+            Afi::Ipv6 => Some(&self.ipv6),
+            _ => None,
+        }
+    }
+
+    /// Mutable sibling of [`Self::family`].
+    pub(in crate::manager) fn family_mut(&mut self, afi: Afi) -> Option<&mut FamilyAdmission> {
+        match afi {
+            Afi::Ipv4 => Some(&mut self.ipv4),
+            Afi::Ipv6 => Some(&mut self.ipv6),
+            _ => None,
+        }
+    }
+}
+
+/// One family's verdict for a single outgoing batch.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(in crate::manager) struct BatchAdmission {
+    /// Net-new prefixes dropped because the family is at its cap. Every path
+    /// for such a prefix is dropped together: a prefix consumes one slot no
+    /// matter how many RFC 7911 path identities carry it.
+    pub(in crate::manager) blocked: HashSet<Prefix>,
+    /// Net-new prefixes that took a free slot in this batch.
+    pub(in crate::manager) admitted: HashSet<Prefix>,
+}
+
+/// Decide which of one family's announcements fit under `limit`.
+///
+/// `usage` is the family's distinct admitted-prefix count before the batch,
+/// `freed` the prefixes whose last advertised path this batch withdraws, and
+/// `is_admitted` answers whether a prefix is advertised today.
+///
+/// Withdrawals are never gated, and the post-withdraw projection is computed
+/// first, so a batch that drops one prefix and adds another fits at a full
+/// cap. An announcement for a prefix still admitted after the withdrawals
+/// always passes — an attribute change or an additional path identity for an
+/// admitted prefix is an update, not a new prefix.
+pub(in crate::manager) fn admit_batch<'a>(
+    limit: NonZeroU32,
+    usage: usize,
+    freed: &HashSet<Prefix>,
+    announced: impl IntoIterator<Item = &'a Prefix>,
+    is_admitted: impl Fn(&Prefix) -> bool,
+) -> BatchAdmission {
+    let limit = usize::try_from(limit.get()).unwrap_or(usize::MAX);
+    let mut usage = usage.saturating_sub(freed.len());
+    let mut verdict = BatchAdmission::default();
+    for prefix in announced {
+        if verdict.admitted.contains(prefix) || verdict.blocked.contains(prefix) {
+            continue;
+        }
+        if is_admitted(prefix) && !freed.contains(prefix) {
+            continue;
+        }
+        if usage < limit {
+            usage += 1;
+            verdict.admitted.insert(*prefix);
+        } else {
+            verdict.blocked.insert(*prefix);
+        }
+    }
+    verdict
+}
+
+/// One family's resolved batch inputs, carried from the read pass that needs
+/// the peer's advertised state to the write pass that advances it.
+struct FamilyVerdict {
+    afi: Afi,
+    /// Prefixes whose last advertised path this batch withdraws.
+    freed: HashSet<Prefix>,
+    /// Distinct admitted prefixes once this batch commits.
+    post_usage: usize,
+    limit: usize,
+    verdict: BatchAdmission,
+}
+
+impl RibManager {
+    /// Resolve one batch against every limited family of `peer`, reading the
+    /// advertised state that decides admission but mutating nothing.
+    ///
+    /// A grouped member's admitted set is prefix-only: update groups
+    /// disqualify Add-Path (ADR-0099), so its advertised identities are one
+    /// path per prefix. An ungrouped peer reads its private Adj-RIB-Out,
+    /// which does refcount path identities — there a prefix frees its slot
+    /// only when its LAST advertised path leaves.
+    fn outbound_limit_verdicts(
+        &self,
+        peer: IpAddr,
+        grouped: bool,
+        announce: &[crate::route::Route],
+        withdraw: &[(Prefix, u32)],
+    ) -> Vec<FamilyVerdict> {
+        let Some(limits) = self.outbound_prefix_limits.get(&peer) else {
+            return Vec::new();
+        };
+        let rib_out = self.adj_ribs_out.get(&peer);
+        let mut verdicts = Vec::new();
+        for afi in LIMITED_FAMILIES {
+            let Some(limit) = limits.family(afi).and_then(|family| family.limit) else {
+                continue;
+            };
+            let admitted = limits.family(afi).map(|family| &family.grouped_admitted);
+            let advertised_paths = |prefix: &Prefix| {
+                rib_out
+                    .map(|rib| rib.path_ids_for_prefix(prefix))
+                    .unwrap_or_default()
+            };
+            let is_admitted = |prefix: &Prefix| {
+                if grouped {
+                    admitted.is_some_and(|admitted| admitted.contains(prefix))
+                } else {
+                    !advertised_paths(prefix).is_empty()
+                }
+            };
+            let mut withdrawn: HashMap<Prefix, HashSet<u32>> = HashMap::new();
+            for (prefix, path_id) in withdraw {
+                if prefix_family(prefix).0 == afi {
+                    withdrawn.entry(*prefix).or_default().insert(*path_id);
+                }
+            }
+            let freed: HashSet<Prefix> = withdrawn
+                .into_iter()
+                .filter(|(prefix, path_ids)| {
+                    if grouped {
+                        is_admitted(prefix)
+                    } else {
+                        let advertised = advertised_paths(prefix);
+                        !advertised.is_empty() && advertised.iter().all(|id| path_ids.contains(id))
+                    }
+                })
+                .map(|(prefix, _)| prefix)
+                .collect();
+            let usage = if grouped {
+                admitted.map_or(0, HashSet::len)
+            } else {
+                rib_out.map_or(0, |rib| rib.unicast_prefix_count(afi))
+            };
+            let verdict = admit_batch(
+                limit,
+                usage,
+                &freed,
+                announce
+                    .iter()
+                    .map(|route| &route.prefix)
+                    .filter(|prefix| prefix_family(prefix).0 == afi),
+                is_admitted,
+            );
+            if freed.is_empty() && verdict.admitted.is_empty() && verdict.blocked.is_empty() {
+                continue;
+            }
+            verdicts.push(FamilyVerdict {
+                afi,
+                post_usage: usage.saturating_sub(freed.len()) + verdict.admitted.len(),
+                limit: usize::try_from(limit.get()).unwrap_or(usize::MAX),
+                verdict,
+                freed,
+            });
+        }
+        verdicts
+    }
+
+    /// Apply this peer's outbound unicast prefix limits to one final batch.
+    ///
+    /// Runs at the per-peer commit seam: after export policy, split horizon,
+    /// RFC 9234 OTC, and exact-export precommit have each removed everything
+    /// this peer must not receive, and before any Adj-RIB-Out or grouped
+    /// admitted-set mutation and before the envelope is enqueued. Routes an
+    /// earlier gate rejected therefore consume no capacity, and a blocked
+    /// prefix never reaches Adj-RIB-Out or the wire.
+    ///
+    /// The session stays Established: excess announcements are dropped from
+    /// the outgoing vector, nothing already advertised is withdrawn, and no
+    /// NOTIFICATION is sent.
+    ///
+    /// Returns immediately for a peer with no configured limit, which is
+    /// every peer until the operator-facing knob exists.
+    pub(super) fn enforce_outbound_prefix_limits(
+        &mut self,
+        peer: IpAddr,
+        grouped: bool,
+        announce: &mut Arc<[crate::route::Route]>,
+        next_hop_override: &mut Arc<[Option<rustbgpd_policy::NextHopAction>]>,
+        withdraw: &[(Prefix, u32)],
+    ) {
+        let verdicts = self.outbound_limit_verdicts(peer, grouped, announce, withdraw);
+        if verdicts.is_empty() {
+            return;
+        }
+
+        let blocked: HashSet<Prefix> = verdicts
+            .iter()
+            .flat_map(|family| family.verdict.blocked.iter().copied())
+            .collect();
+        if !blocked.is_empty() {
+            debug_assert_eq!(announce.len(), next_hop_override.len());
+            let (kept_routes, kept_next_hops): (Vec<_>, Vec<_>) = announce
+                .iter()
+                .zip(next_hop_override.iter())
+                .filter(|(route, _)| !blocked.contains(&route.prefix))
+                .map(|(route, next_hop)| (route.clone(), next_hop.clone()))
+                .unzip();
+            *announce = kept_routes.into();
+            *next_hop_override = kept_next_hops.into();
+        }
+
+        let mut recovered = false;
+        let Some(limits) = self.outbound_prefix_limits.get_mut(&peer) else {
+            return;
+        };
+        for family_verdict in verdicts {
+            let Some(family) = limits.family_mut(family_verdict.afi) else {
+                continue;
+            };
+            if grouped {
+                for prefix in &family_verdict.freed {
+                    family.grouped_admitted.remove(prefix);
+                }
+                family
+                    .grouped_admitted
+                    .extend(family_verdict.verdict.admitted);
+            }
+            if family_verdict.verdict.blocked.is_empty() {
+                if family.blocking && family_verdict.post_usage < family_verdict.limit {
+                    family.blocking = false;
+                    recovered = true;
+                }
+            } else {
+                family.blocking = true;
+            }
+        }
+        if recovered {
+            // Capacity opened while an episode was open, and blocked intent
+            // is deliberately not inventoried (a rejected-prefix overlay
+            // grows toward O(table) in exactly the failure this contains),
+            // so re-derive it from current intent through the existing
+            // export and exact-export path. This resync is peer-wide;
+            // ADR-0113 narrows it to the affected family alongside the
+            // coalescing and episode telemetry the operator knob needs.
+            // It cannot recur while the table stays over the cap: only a
+            // batch that leaves headroom clears the latch.
+            self.mark_outbound_dirty(peer);
+        }
+    }
+}

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -458,6 +458,12 @@ impl RibManager {
             i64::try_from(self.outbound_peers.len()).unwrap_or(i64::MAX),
         );
         self.adj_ribs_out.remove(&peer);
+        // Outbound prefix admission is per-registration (ADR-0113): the
+        // admitted set and its blocking latch describe what the departing
+        // session was advertising. A reconnect starts empty and admits its
+        // initial feed up to the cap, so stale accounting can neither
+        // consume a new generation's capacity nor clear its episode.
+        self.outbound_prefix_limits.remove(&peer);
         self.peer_export_policies.remove(&peer);
         self.peer_sendable_families.remove(&peer);
         self.peer_advertised_llgr_families.remove(&peer);

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -1049,6 +1049,7 @@ mod multipath_fib;
 mod no_export;
 mod orf;
 mod orr;
+mod outbound_prefix_limits;
 mod paged_query;
 mod per_client_best;
 mod policy;

--- a/crates/rib/src/manager/tests/outbound_prefix_limits.rs
+++ b/crates/rib/src/manager/tests/outbound_prefix_limits.rs
@@ -1,0 +1,404 @@
+//! Outbound unicast prefix accounting (ADR-0113).
+//!
+//! Two layers: the pure per-family batch helper, and the export seam that
+//! feeds it. Nothing outside these tests configures a limit, so the seam
+//! tests also pin the unlimited path that every peer takes today.
+
+use std::collections::HashSet;
+use std::num::NonZeroU32;
+
+use super::*;
+use crate::manager::outbound_prefix_limits::{BatchAdmission, admit_batch};
+
+fn v4(octet: u8) -> Prefix {
+    Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, octet), 32))
+}
+
+fn limit(n: u32) -> NonZeroU32 {
+    NonZeroU32::new(n).expect("test limits are non-zero")
+}
+
+// --- pure batch admission ---
+
+/// Load-bearing break: admitting unconditionally lets the third prefix
+/// through; counting the whole batch against the cap blocks the first two.
+#[test]
+fn net_new_prefixes_past_the_cap_are_blocked_and_the_rest_pass() {
+    let announced = [v4(1), v4(2), v4(3)];
+    let verdict = admit_batch(limit(2), 0, &HashSet::new(), &announced, |_| false);
+    assert_eq!(
+        verdict,
+        BatchAdmission {
+            admitted: HashSet::from([v4(1), v4(2)]),
+            blocked: HashSet::from([v4(3)]),
+        }
+    );
+}
+
+/// Load-bearing break: gating announcements for already-admitted prefixes
+/// (an attribute change or an extra path identity) blocks them at the cap.
+#[test]
+fn announcements_for_admitted_prefixes_pass_at_the_cap() {
+    let admitted = HashSet::from([v4(1), v4(2)]);
+    let announced = [v4(1), v4(2)];
+    let verdict = admit_batch(limit(2), 2, &HashSet::new(), &announced, |prefix| {
+        admitted.contains(prefix)
+    });
+    assert_eq!(verdict, BatchAdmission::default());
+}
+
+/// Load-bearing break: evaluating announcements before withdrawals blocks
+/// the new prefix even though the batch is net-neutral at the cap.
+#[test]
+fn a_withdrawal_frees_its_slot_before_announcements_are_considered() {
+    let admitted = HashSet::from([v4(1), v4(2)]);
+    let freed = HashSet::from([v4(1)]);
+    let announced = [v4(3)];
+    let verdict = admit_batch(limit(2), 2, &freed, &announced, |prefix| {
+        admitted.contains(prefix)
+    });
+    assert_eq!(
+        verdict,
+        BatchAdmission {
+            admitted: HashSet::from([v4(3)]),
+            blocked: HashSet::new(),
+        }
+    );
+}
+
+/// Load-bearing break: counting route identities instead of prefixes spends
+/// one slot per path and blocks the second and third identities.
+#[test]
+fn every_path_identity_for_one_prefix_shares_a_single_slot() {
+    // Three RFC 7911 identities for one NLRI, none advertised yet.
+    let announced = [v4(1), v4(1), v4(1)];
+    let verdict = admit_batch(limit(1), 0, &HashSet::new(), &announced, |_| false);
+    assert_eq!(
+        verdict,
+        BatchAdmission {
+            admitted: HashSet::from([v4(1)]),
+            blocked: HashSet::new(),
+        }
+    );
+}
+
+/// A prefix whose last path leaves and which the same batch re-announces is
+/// net-new again: it takes the slot its own withdrawal freed.
+#[test]
+fn a_freed_prefix_reannounced_in_the_same_batch_retakes_its_slot() {
+    let admitted = HashSet::from([v4(1)]);
+    let freed = HashSet::from([v4(1)]);
+    let announced = [v4(1)];
+    let verdict = admit_batch(limit(1), 1, &freed, &announced, |prefix| {
+        admitted.contains(prefix)
+    });
+    assert_eq!(
+        verdict,
+        BatchAdmission {
+            admitted: HashSet::from([v4(1)]),
+            blocked: HashSet::new(),
+        }
+    );
+}
+
+// --- export seam ---
+
+fn register_peer(manager: &mut RibManager, peer: IpAddr) -> mpsc::Receiver<OutboundRouteUpdate> {
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(64);
+    manager.handle_update(RibUpdate::PeerUp {
+        peer,
+        session_id: 0,
+        peer_asn: 65_000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: false,
+        route_reflector_client: false,
+        orr_vantage: None,
+        per_client_best: false,
+        interpret_rfc1997: true,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    });
+    let eor = outbound_rx.try_recv().expect("registration end-of-rib");
+    assert_eq!(eor.end_of_rib, ipv4_sendable());
+    outbound_rx
+}
+
+fn set_ipv4_limit(manager: &mut RibManager, peer: IpAddr, cap: u32) {
+    manager
+        .outbound_prefix_limits
+        .entry(peer)
+        .or_default()
+        .family_mut(Afi::Ipv4)
+        .expect("IPv4 unicast is a limited family")
+        .limit = Some(limit(cap));
+}
+
+fn announce(manager: &mut RibManager, source: IpAddr, announced: Vec<Route>) {
+    manager.handle_update(RibUpdate::RoutesReceived {
+        peer: source,
+        session_id: 0,
+        announced,
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    });
+    while manager.process_next_route_chunk() {}
+}
+
+fn withdraw(manager: &mut RibManager, source: IpAddr, withdrawn: Vec<(Prefix, u32)>) {
+    manager.handle_update(RibUpdate::RoutesReceived {
+        peer: source,
+        session_id: 0,
+        announced: vec![],
+        withdrawn,
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    });
+    while manager.process_next_route_chunk() {}
+}
+
+/// Prefixes the peer's envelopes leave advertised, i.e. announced and not
+/// later withdrawn.
+fn wire_prefixes(outbound_rx: &mut mpsc::Receiver<OutboundRouteUpdate>) -> HashSet<Prefix> {
+    let mut advertised = HashSet::new();
+    while let Ok(update) = outbound_rx.try_recv() {
+        for route in update.announce.iter() {
+            advertised.insert(route.prefix);
+        }
+        for (prefix, _) in &update.withdraw {
+            advertised.remove(prefix);
+        }
+    }
+    advertised
+}
+
+fn source_routes(source: Ipv4Addr, octets: &[u8]) -> Vec<Route> {
+    octets
+        .iter()
+        .map(|octet| {
+            crate::test_support::make_route(
+                Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, *octet), 32),
+                source,
+            )
+        })
+        .collect()
+}
+
+/// Inertness: with no limit configured — the state of every peer today —
+/// the export path advertises exactly what it advertised before this
+/// accounting existed, and allocates no admission state.
+#[test]
+fn an_unlimited_peer_admits_every_prefix_and_allocates_no_admission_state() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    manager.test_force_ungrouped = true;
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 113, 0, 1));
+    let mut outbound_rx = register_peer(&mut manager, peer);
+
+    let source = Ipv4Addr::new(192, 0, 2, 113);
+    announce(
+        &mut manager,
+        IpAddr::V4(source),
+        source_routes(source, &[1, 2, 3]),
+    );
+
+    assert_eq!(
+        wire_prefixes(&mut outbound_rx),
+        HashSet::from([v4(1), v4(2), v4(3)])
+    );
+    assert_eq!(
+        manager.adj_ribs_out.get(&peer).map_or(0, AdjRibOut::len),
+        3,
+        "the unlimited path must commit every advertised route"
+    );
+    assert!(
+        manager.outbound_prefix_limits.is_empty(),
+        "an unlimited peer must not allocate per-peer admission state"
+    );
+}
+
+/// Load-bearing break: dropping the enforcement call from the commit seam
+/// puts all three prefixes on the wire and in Adj-RIB-Out.
+#[test]
+fn an_ungrouped_peer_at_its_cap_blocks_the_excess_prefix() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    manager.test_force_ungrouped = true;
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 113, 0, 1));
+    let mut outbound_rx = register_peer(&mut manager, peer);
+    set_ipv4_limit(&mut manager, peer, 2);
+
+    let source = Ipv4Addr::new(192, 0, 2, 113);
+    announce(
+        &mut manager,
+        IpAddr::V4(source),
+        source_routes(source, &[1, 2, 3]),
+    );
+
+    let advertised = wire_prefixes(&mut outbound_rx);
+    assert_eq!(advertised.len(), 2, "only the cap may reach the wire");
+    let committed: HashSet<Prefix> = manager
+        .adj_ribs_out
+        .get(&peer)
+        .expect("a limited ungrouped peer keeps its private Adj-RIB-Out")
+        .iter()
+        .map(|route| route.prefix)
+        .collect();
+    assert_eq!(
+        committed, advertised,
+        "a blocked prefix must never enter Adj-RIB-Out"
+    );
+    assert!(
+        manager
+            .outbound_prefix_limits
+            .get(&peer)
+            .and_then(|limits| limits.family(Afi::Ipv4))
+            .is_some_and(|family| family.blocking),
+        "blocking a net-new prefix opens the family's episode"
+    );
+}
+
+/// A withdrawal at the cap frees its slot, and the freed capacity is
+/// re-offered to intent the limiter previously blocked — without an
+/// inventory of blocked prefixes.
+#[test]
+fn freed_capacity_readmits_previously_blocked_intent() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    manager.test_force_ungrouped = true;
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 113, 0, 1));
+    let mut outbound_rx = register_peer(&mut manager, peer);
+    set_ipv4_limit(&mut manager, peer, 2);
+
+    let source = Ipv4Addr::new(192, 0, 2, 113);
+    announce(
+        &mut manager,
+        IpAddr::V4(source),
+        source_routes(source, &[1, 2, 3]),
+    );
+    let advertised = wire_prefixes(&mut outbound_rx);
+    assert_eq!(advertised.len(), 2);
+    let blocked = *[v4(1), v4(2), v4(3)]
+        .iter()
+        .find(|prefix| !advertised.contains(prefix))
+        .expect("one prefix is over the cap");
+    let admitted = *advertised.iter().next().expect("the cap admitted two");
+
+    // Withdrawing an admitted prefix frees exactly one slot and schedules the
+    // peer's export resync, which re-derives the blocked prefix from current
+    // Loc-RIB intent.
+    withdraw(&mut manager, IpAddr::V4(source), vec![(admitted, 0)]);
+    assert!(
+        manager.dirty_peers.contains(&peer),
+        "freed capacity during an episode must schedule a recovery resync"
+    );
+    while manager.resync_dirty_peers_bounded() {}
+
+    let recovered = wire_prefixes(&mut outbound_rx);
+    assert!(
+        recovered.contains(&blocked),
+        "the freed slot must go to previously blocked intent"
+    );
+    assert_eq!(
+        manager
+            .adj_ribs_out
+            .get(&peer)
+            .map_or(0, |rib| rib.unicast_prefix_count(Afi::Ipv4)),
+        2,
+        "recovery must not exceed the cap"
+    );
+}
+
+/// One limited member must not fragment its update group: the sibling keeps
+/// the shared payload and both stay in the same group.
+///
+/// Load-bearing break: putting the limit in `GroupKey`, or filtering the
+/// shared payload instead of the member's final vector, changes the
+/// sibling's advertised set or splits the group.
+#[test]
+fn a_limited_group_member_blocks_alone() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let limited = IpAddr::V4(Ipv4Addr::new(10, 113, 0, 1));
+    let sibling = IpAddr::V4(Ipv4Addr::new(10, 113, 0, 2));
+    let mut limited_rx = register_peer(&mut manager, limited);
+    let mut sibling_rx = register_peer(&mut manager, sibling);
+    set_ipv4_limit(&mut manager, limited, 2);
+
+    let source = Ipv4Addr::new(192, 0, 2, 113);
+    announce(
+        &mut manager,
+        IpAddr::V4(source),
+        source_routes(source, &[1, 2, 3]),
+    );
+
+    let group = manager.grouped_member_of(limited);
+    assert!(
+        group.is_some(),
+        "the fixture must exercise the grouped path"
+    );
+    assert_eq!(
+        group,
+        manager.grouped_member_of(sibling),
+        "a limit must not split the update group"
+    );
+    assert_eq!(
+        wire_prefixes(&mut sibling_rx),
+        HashSet::from([v4(1), v4(2), v4(3)]),
+        "an unlimited sibling keeps the full shared payload"
+    );
+    let advertised = wire_prefixes(&mut limited_rx);
+    assert_eq!(
+        advertised.len(),
+        2,
+        "only the cap reaches the limited member"
+    );
+    assert_eq!(
+        manager
+            .outbound_prefix_limits
+            .get(&limited)
+            .and_then(|limits| limits.family(Afi::Ipv4))
+            .map(|family| family.grouped_admitted.clone()),
+        Some(advertised),
+        "the member's bounded admitted set is its advertised projection"
+    );
+}
+
+/// Admission is per session generation: teardown reaps it on the same seam
+/// as the rest of the peer's outbound state.
+#[test]
+fn peer_teardown_clears_admission_state() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    manager.test_force_ungrouped = true;
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 113, 0, 1));
+    let mut outbound_rx = register_peer(&mut manager, peer);
+    set_ipv4_limit(&mut manager, peer, 2);
+
+    let source = Ipv4Addr::new(192, 0, 2, 113);
+    announce(
+        &mut manager,
+        IpAddr::V4(source),
+        source_routes(source, &[1, 2, 3]),
+    );
+    drop(wire_prefixes(&mut outbound_rx));
+    assert!(manager.outbound_prefix_limits.contains_key(&peer));
+
+    manager.handle_update(RibUpdate::PeerDown {
+        peer,
+        session_id: 0,
+    });
+    assert!(
+        !manager.outbound_prefix_limits.contains_key(&peer),
+        "a reconnecting generation must start with empty admission state"
+    );
+}

--- a/crates/rib/src/prefix_map.rs
+++ b/crates/rib/src/prefix_map.rs
@@ -15,7 +15,7 @@
 
 use ipnet::{Ipv4Net, Ipv6Net};
 use prefix_trie::PrefixMap;
-use rustbgpd_wire::{Ipv4Prefix, Ipv6Prefix, Prefix};
+use rustbgpd_wire::{Afi, Ipv4Prefix, Ipv6Prefix, Prefix};
 
 /// A `Prefix`-keyed map backed by per-family prefix tries.
 #[derive(Debug)]
@@ -68,6 +68,16 @@ impl<V> FamilyPrefixMap<V> {
     #[cfg(feature = "bench-internals")]
     pub(crate) fn mem_size(&self) -> usize {
         self.v4.mem_size() + self.v6.mem_size()
+    }
+
+    /// Number of stored prefixes in one address family. Zero for an AFI this
+    /// map never keys.
+    pub(crate) fn family_len(&self, afi: Afi) -> usize {
+        match afi {
+            Afi::Ipv4 => self.v4.len(),
+            Afi::Ipv6 => self.v6.len(),
+            _ => 0,
+        }
     }
 
     pub(crate) fn get(&self, prefix: &Prefix) -> Option<&V> {


### PR DESCRIPTION
First of the two implementation PRs for [ADR-0113](docs/adr/0113-outbound-prefix-limits.md). It adds the accounting and its export-path wiring behind an internal always-unlimited input; the operator-facing knob and its observability land together in the second.

## What

- A pure, per-family batch admission helper: it computes the post-withdraw projection first, so withdrawals always pass and a freed slot is available to announcements in the same batch. Announcements for a prefix still admitted after the withdrawals pass unconditionally (attribute change, extra path identity); a net-new prefix takes a free slot or is dropped from the outgoing vector. Slots count distinct prefixes, so every RFC 7911 path identity for one NLRI shares one slot.
- Enforcement at the per-peer commit seam in `try_send_and_commit_outbound_update_with_group_prior_and_otc_scope`, after export policy, split horizon, RFC 9234 OTC, and exact-export precommit, and before Adj-RIB-Out mutation and enqueue.
- Per-peer state that follows the update-group boundary: an ungrouped peer counts its private Adj-RIB-Out prefix index (which already refcounts path identities); a grouped member keeps a bounded prefix-only admitted set, per member and never in `GroupKey`.
- Lifecycle cleanup on the existing `clear_outbound_peer_state` choke point, so admission is per session generation and a reconnect starts empty.
- `AdjRibOut::unicast_prefix_count` (and its `FamilyPrefixMap` backing) for the distinct-prefix count the ungrouped path needs; `AdjRibOut::len` counts route identities.

## Why

An IX route server or route reflector can take a syntactically valid policy change that makes a much larger outbound table eligible for one client. The import-side `max_prefixes*` controls bound what rustbgpd accepts, not what it exports. ADR-0113 sequences the containment so the accounting lands reviewable and inert before a knob turns it on; this PR is deliberately the half with no public surface.

## Behavior at this commit

None. Nothing configures a limit, so `outbound_prefix_limits` stays empty, the enforcement call returns on its first map lookup, and every peer — grouped or private — keeps the state shape and per-route cost it has today. No config fields, no API/CLI/metric surface, no `GroupKey` change, no transport dependency. No CHANGELOG entry: there is nothing user-visible to describe yet.

## Design notes

- A limited member does not fragment its update group. The shared table still stages once; only the member's final vector is materialized when its cap changes a batch, so siblings keep the shared payload and group membership is unchanged.
- Blocked prefixes are deliberately not inventoried — a rejected-prefix overlay grows toward O(table) in exactly the failure this feature contains. When a withdrawal opens capacity during a blocking episode, the peer's existing export resync re-derives eligible intent from current Loc-RIB/group intent. That resync is peer-wide here; ADR-0113 narrows it to the affected family alongside the coalescing and episode telemetry the operator knob needs. It cannot recur while the table stays over the cap: only a batch that leaves headroom clears the latch.

## How verified

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast`, `cargo doc --workspace --no-deps`, `python3 scripts/check-v1-stable-surface.py`, and `cargo check -p rustbgpd-rib --features bench-internals --benches` all pass.

Ten new tests in `crates/rib/src/manager/tests/outbound_prefix_limits.rs`, five on the pure helper and five driving the real commit seam:

- the unlimited path admits every prefix and allocates no admission state (inertness);
- an ungrouped peer at its cap blocks only the excess prefix, and the blocked prefix is absent from both the wire and Adj-RIB-Out;
- freed capacity readmits previously blocked intent through the export resync, without exceeding the cap;
- a limited group member blocks alone: the unlimited sibling keeps the full shared payload and both stay in the same group;
- teardown clears admission state.

Red-proof: removing the `enforce_outbound_prefix_limits` call from the commit seam puts N+1 prefixes on the wire and fails all three seam tests that assert a cap. The helper tests name their own production break in each doc comment.