### PR TITLE
Pin FlowSpec unknown-component rejection as RFC 8955 conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Unknown FlowSpec component types keep their hard rejection, now with a
+  conformance-citing diagnostic.** *No decode-acceptance change: input that
+  errored before still errors, and input that parsed before still parses.*
+  `rustbgpd-wire` embedders tracking the 0.16.0 acceptance changes can ignore
+  this entry — only the `DecodeError::MalformedField` detail string and the
+  documentation changed. Component types outside 1–13 remain a malformed
+  NLRI per RFC 8955 §4.2, dispositioned per RFC 7606 §7.11. Skip-unknown was
+  re-examined and is not implementable for this encoding: only the rule is
+  length-prefixed, each component's value grammar is selected by its type
+  code, so an unrecognized component cannot be measured or stepped over
+  without misparsing the remainder of the rule — and silently dropping one
+  would widen the rule's match set past what the sender specified.
+  `KNOWN_ISSUES.md` previously described the rejection as a forward-
+  compatibility defect to be fixed; it now records it as required behavior.
+
 - **Live edits of `max_prefix_restart_seconds` reschedule the pending
   automatic restart instead of cancelling it.** While a max-prefix hold-down
   countdown is armed, changing the duration re-arms the single pending attempt

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -353,10 +353,22 @@ resolved.
   was not negotiated, the wire format is ambiguous — the 4-byte path ID
   can be misparsed as normal NLRI prefix encoding. Compliant peers will
   never do this. Fixing it would require a deeper parser redesign.
-- **Unknown FlowSpec component types are rejected.** Component types >13
-  (or any future RFC extension) cause a hard decode error rather than
-  being preserved or skipped. This breaks forward compatibility if a
-  future RFC defines type 14+. Should switch to skip-unknown behavior.
+- **Unknown FlowSpec component types are rejected — and must be.**
+  A component type outside 1–13 makes the whole NLRI a decode error.
+  This is RFC 8955 §4.2 conformance, not a gap: "an NLRI that contains
+  an unknown component type[] is considered malformed". Skip-unknown is
+  not implementable for this encoding — only the *rule* is
+  length-prefixed, and each component's value grammar is selected by its
+  type code (types 1–2 are `<length, prefix>`, with an extra offset
+  octet under RFC 8956; types 3–13 are numeric- or bitmask-operator
+  lists whose width comes from the operator octet). A decoder cannot
+  measure a component it does not recognize, so it cannot resynchronize
+  on the next one, and dropping a component would widen the rule's match
+  set beyond what the sender asked for. Consequently a future type 14+
+  requires a rustbgpd upgrade to interoperate — as it does for every
+  RFC 8955 implementation. Disposition follows RFC 7606 §7.11
+  (session reset for malformed `MP_REACH_NLRI`), since the remaining
+  NLRI cannot be located.
 - **FlowSpec NLRI rule-length cap is enforced at encode time.** Rules
   exceeding the on-wire 12-bit limit (`MAX_FLOWSPEC_NLRI_RULE_LEN = 4095`)
   return `EncodeError::ValueOutOfRange` from

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -4994,6 +4994,34 @@ mod tests {
             other => panic!("expected MalformedField, got {other:?}"),
         }
     }
+    /// RFC 8955 §4.2 makes a `FlowSpec` NLRI carrying an unknown component
+    /// type malformed, and §10 defers to RFC 7606. Because the offending
+    /// component has no length, the remaining NLRI cannot be located — the
+    /// exact condition RFC 7606 §7.11 reserves session-reset for. Pin that
+    /// the error surfaces as `Err` from the revised decoder rather than as a
+    /// recoverable `malformed` entry.
+    #[test]
+    fn mp_reach_flowspec_unknown_component_is_session_reset() {
+        let value: &[u8] = &[
+            0x00, 0x01, // AFI = IPv4
+            0x85, // SAFI = 133 (FlowSpec)
+            0x00, // NH-Len = 0 (required for FlowSpec)
+            0x00, // Reserved
+            // FlowSpec NLRI: rule length 3, component type 14 (unallocated)
+            0x03, 14, 0x81, 0x06,
+        ];
+        let mut attr = vec![0x80, 14, u8::try_from(value.len()).unwrap()];
+        attr.extend_from_slice(value);
+        let err = decode_path_attributes_revised(&attr, true, false, &[]).unwrap_err();
+        match err {
+            DecodeError::MalformedField { detail, .. } => assert!(
+                detail.contains("unknown FlowSpec component type 14"),
+                "expected unknown-component rejection, got: {detail}"
+            ),
+            other => panic!("expected MalformedField, got {other:?}"),
+        }
+    }
+
     #[test]
     fn originator_id_roundtrip() {
         let attr = PathAttribute::OriginatorId(Ipv4Addr::new(10, 0, 0, 1));

--- a/crates/wire/src/flowspec.rs
+++ b/crates/wire/src/flowspec.rs
@@ -6,6 +6,26 @@
 //!
 //! The wire format uses a length-prefixed TLV structure with operator bytes
 //! that encode comparison semantics and value sizes.
+//!
+//! # Unknown component types are not skippable
+//!
+//! Only the *rule* carries an explicit length; a component does not. Each
+//! component's value grammar is chosen by its type code (RFC 8955 §4.2.2):
+//! types 1 and 2 are `<length, prefix>` (RFC 8956 §3.1 inserts a further
+//! offset octet for IPv6), and types 3-13 are operator lists delimited by the
+//! `end_of_list` bit, with per-term value widths taken from the operator
+//! octet's `len` field — and the operator octet itself is read as either a
+//! numeric or a bitmask operator depending, again, on the type code.
+//!
+//! A decoder therefore cannot compute the length of a component whose type it
+//! does not know, so it cannot resynchronize on the next component. RFC 8956
+//! is the precedent: it both allocated a new type (13) and changed the value
+//! grammar of existing types 1 and 2. Skipping an unknown type would
+//! misparse the remainder of the rule rather than preserve it.
+//!
+//! RFC 8955 §4.2 states the matching requirement directly: an NLRI containing
+//! an unknown component type "is considered malformed", handled per §10
+//! (RFC 7606). `decode_component` implements exactly that.
 
 use std::fmt;
 use std::net::Ipv4Addr;
@@ -609,9 +629,19 @@ fn decode_component(buf: &[u8], afi: Afi) -> Result<(FlowSpecComponent, usize), 
             let (ops, consumed) = decode_numeric_ops(rest)?;
             Ok((FlowSpecComponent::FlowLabel(ops), 1 + consumed))
         }
+        // RFC 8955 §4.2: an NLRI containing an unknown component type is
+        // malformed. This is not a forward-compatibility gap that
+        // skip-unknown would close — a component carries no length of its
+        // own, so an unrecognized type cannot be measured or stepped over
+        // (see the module docs). Rejecting the whole NLRI is both what the
+        // RFC requires and the only disposition that cannot silently widen
+        // a rule's match set by dropping a constraint the sender asked for.
         _ => Err(DecodeError::MalformedField {
             message_type: "UPDATE",
-            detail: format!("unknown FlowSpec component type {type_code}"),
+            detail: format!(
+                "unknown FlowSpec component type {type_code}: not skippable \
+                 (components carry no length), malformed NLRI per RFC 8955 §4.2"
+            ),
         }),
     }
 }
@@ -1228,6 +1258,85 @@ mod tests {
     fn empty_rule_rejected() {
         let rule = FlowSpecRule { components: vec![] };
         assert!(rule.validate().is_err());
+    }
+
+    /// The value bytes an unknown component type could carry are genuinely
+    /// ambiguous, which is why skip-unknown cannot be implemented: nothing
+    /// on the wire says which grammar to measure them with. Read as a
+    /// prefix, `10 C0 A8 81 06` is 192.168.0.0/16 and the component ends
+    /// after 3 octets. Read as a numeric-operator list, it is a two-term
+    /// list (`len=1` 2-octet term, then an `end_of_list` 1-octet term) and
+    /// the component ends after 5. Both readings are self-consistent and
+    /// disagree about where the next component starts — so a decoder that
+    /// guessed would resynchronize on garbage.
+    #[test]
+    fn unknown_component_value_length_is_ambiguous() {
+        let value: &[u8] = &[0x10, 0xC0, 0xA8, 0x81, 0x06];
+        let (_, as_prefix) = decode_prefix_component(value, Afi::Ipv4).unwrap();
+        let (_, as_ops) = decode_numeric_ops(value).unwrap();
+        assert_eq!(as_prefix, 3);
+        assert_eq!(as_ops, 5);
+    }
+
+    /// RFC 8955 §4.2: an NLRI containing an unknown component type is
+    /// malformed. Rejecting the whole NLRI is the only disposition that
+    /// neither misparses the remainder (see
+    /// `unknown_component_value_length_is_ambiguous`) nor widens the rule's
+    /// match set by dropping a constraint the sender specified.
+    #[test]
+    fn unknown_component_type_rejects_whole_nlri() {
+        // Rule = <len=6> <type 14> <the ambiguous value above>.
+        let buf: &[u8] = &[0x06, 14, 0x10, 0xC0, 0xA8, 0x81, 0x06];
+        let err = decode_flowspec_nlri(buf, Afi::Ipv4).unwrap_err();
+        let DecodeError::MalformedField { detail, .. } = &err else {
+            panic!("expected MalformedField, got {err:?}");
+        };
+        assert!(
+            detail.contains("unknown FlowSpec component type 14"),
+            "diagnostic must name the offending type, got: {detail}"
+        );
+        assert!(
+            detail.contains("RFC 8955"),
+            "diagnostic must cite the conformance requirement, got: {detail}"
+        );
+    }
+
+    /// The rejection covers the whole NLRI, not just the trailing rule: a
+    /// well-formed rule preceding one with an unknown component must not be
+    /// returned as if the update were partially usable.
+    #[test]
+    fn unknown_component_type_rejects_preceding_valid_rule_too() {
+        let good = FlowSpecRule {
+            components: vec![FlowSpecComponent::IpProtocol(vec![NumericMatch {
+                end_of_list: true,
+                and_bit: false,
+                lt: false,
+                gt: false,
+                eq: true,
+                value: 6,
+            }])],
+        };
+        let mut buf = Vec::new();
+        try_encode_flowspec_nlri(std::slice::from_ref(&good), &mut buf, Afi::Ipv4).unwrap();
+        // Sanity: on its own the first rule decodes.
+        assert_eq!(decode_flowspec_nlri(&buf, Afi::Ipv4).unwrap(), vec![good]);
+        // Append <len=2> <type 200> <0x81>.
+        buf.extend_from_slice(&[0x02, 200, 0x81]);
+        assert!(decode_flowspec_nlri(&buf, Afi::Ipv4).is_err());
+    }
+
+    /// Unknown-type rejection must not disturb the disposition for input
+    /// that is malformed in the ordinary way: a truncated prefix component
+    /// still fails, and still fails as `MalformedField`.
+    #[test]
+    fn truncated_prefix_component_still_malformed() {
+        // <len=3> <type 1> <prefix-len 24> <only one of three prefix octets>
+        let buf: &[u8] = &[0x03, 1, 24, 192];
+        let err = decode_flowspec_nlri(buf, Afi::Ipv4).unwrap_err();
+        assert!(
+            matches!(err, DecodeError::MalformedField { .. }),
+            "expected MalformedField, got {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`KNOWN_ISSUES.md` recorded the hard rejection of FlowSpec NLRI component
types outside 1–13 as a forward-compatibility defect, to be replaced with
skip-unknown behavior. That entry was wrong on both counts: skip-unknown is
prohibited by RFC 8955, and it is not implementable for this encoding even
setting the prohibition aside. This change keeps the rejection, documents
why, pins it with tests, and corrects the entry.

## Why skip-unknown is not implementable

Only the *rule* carries an explicit length (RFC 8955 §4.1). A component does
not — its value grammar is selected by its type code (§4.2.2):

- types 1 and 2 are `<length, prefix>`, and RFC 8956 §3.1 inserts a further
  offset octet for IPv6;
- types 3–13 are operator lists delimited by the `end_of_list` bit, with
  per-term value widths taken from the operator octet's `len` field — and the
  operator octet is itself read as either a numeric or a bitmask operator
  depending, again, on the type code.

So a decoder cannot compute the length of a component whose type it does not
know, and cannot resynchronize on the next component. The ambiguity is not
theoretical: `unknown_component_value_length_is_ambiguous` feeds the same five
octets to both of this crate's existing decoders and shows they consume
different amounts — 3 octets read as a prefix (192.168.0.0/16), 5 read as a
two-term numeric-operator list. Both readings are self-consistent and disagree
about where the next component starts. RFC 8956 is the precedent that this
matters in practice: it both allocated a new type (13) and changed the value
grammar of existing types 1 and 2.

RFC 8955 §4.2 states the conclusion normatively: an NLRI that "contains an
unknown component type[] is considered malformed", handled per §10 (RFC 7606).

## Why not skip the component and keep the rule

Even where a width were derivable, dropping a component is the wrong
disposition. FlowSpec matches the intersection (AND) of all components
present, so ignoring one produces a rule that matches strictly *more* traffic
than the sender specified — a filter silently broadened past its author's
intent. Accept-but-do-not-install was considered and rejected as well: it
cannot be reached here, because the parse desynchronizes before there is a
rule to withhold.

## What changed

Decode acceptance is unchanged — input that errored before still errors, and
input that parsed before still parses. Only the `DecodeError::MalformedField`
detail string and documentation changed, so embedders tracking the 0.16.0
acceptance changes are unaffected by this PR. The diagnostic now names the
conformance requirement rather than reading as an unimplemented feature.

Disposition is unchanged and follows RFC 7606 §7.11: a malformed
`MP_REACH_NLRI` is session-reset because the remaining NLRI cannot be
located — precisely the condition an unmeasurable component creates.

## Tests

- `unknown_component_value_length_is_ambiguous` — the two-readings proof above.
- `unknown_component_type_rejects_whole_nlri` — type 14 rejects, diagnostic
  names the type and cites the RFC.
- `unknown_component_type_rejects_preceding_valid_rule_too` — a well-formed
  rule ahead of an unknown-component rule is not returned as partially usable.
- `mp_reach_flowspec_unknown_component_is_session_reset` — the RFC 7606 §7.11
  disposition surfaces as `Err` from the revised decoder, not a recoverable
  `malformed` entry.
- `truncated_prefix_component_still_malformed` — ordinary malformed input
  keeps its existing `MalformedField` treatment.

`ROADMAP.md` already recorded this verdict from an earlier investigation;
`KNOWN_ISSUES.md` had not been updated to match, and now is.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -D warnings`,
`cargo test --workspace --no-fail-fast`, `cargo doc --workspace --no-deps`, and
`cargo +nightly fuzz build` (wire, which includes `decode_flowspec`) all exit 0.