### PR TITLE
Stage peer-group policy context before PeerUp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The initial table dump now evaluates export policy with the peer's
+  peer-group.** The session staged its peer-group policy context *after* the
+  `PeerUp` registration, but `PeerUp` builds the initial Adj-RIB-Out
+  synchronously — so the first full-table dump to a newly established peer was
+  evaluated with no peer-group, and any export rule matching on peer-group
+  began applying only from the next update. On a route server with
+  group-scoped export filtering this advertised routes the operator's policy
+  intends to deny, at every session establishment and every re-establishment.
+  The context is now staged before `PeerUp`, alongside the RFC 9234 role, RFC
+  7947 control-community, exact-encoder, and RFC 4724 contexts. **This is a
+  wire-visible change to the initial dump:** an upgraded daemon's first dump to
+  a group-scoped peer may now be correctly filtered, or otherwise transformed
+  by group-matched policy actions, where it previously was not. Peers whose
+  export policy does not match on peer-group are unaffected.
+
 - **Daemon exits non-zero when shutdown is caused by unexpected gRPC server
   termination.** The coordinated teardown (NOTIFICATIONs, GR marker,
   checkpoints) still runs, but the process now exits 1 so supervisors with

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -538,6 +538,22 @@ impl PeerSession {
                         })
                         .await;
 
+                    // Stage the peer-group policy context before `PeerUp` for
+                    // the same reason as the contexts above: `PeerUp` builds
+                    // the initial Adj-RIB-Out synchronously, and every export
+                    // evaluation in that dump must already see the group a
+                    // group-scoped export rule matches on. Sent after `PeerUp`
+                    // this dump escaped the filter that every later update
+                    // honored.
+                    let _ = self
+                        .rib_tx
+                        .send(RibUpdate::SetPeerPolicyContext {
+                            peer: self.peer_ip,
+                            session_id: self.session_identity.id,
+                            peer_group: self.config.peer_group.clone(),
+                        })
+                        .await;
+
                     // Register with RIB manager for outbound updates
                     let _ = self
                         .rib_tx
@@ -583,14 +599,6 @@ impl PeerSession {
                             peer: self.peer_ip,
                             session_id: self.session_identity.id,
                             limits: add_path_send_limits,
-                        })
-                        .await;
-                    let _ = self
-                        .rib_tx
-                        .send(RibUpdate::SetPeerPolicyContext {
-                            peer: self.peer_ip,
-                            session_id: self.session_identity.id,
-                            peer_group: self.config.peer_group.clone(),
                         })
                         .await;
                 }

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -4,8 +4,8 @@ use crate::PeerCommandError;
 use bytes::Bytes;
 use rustbgpd_fsm::PeerConfig;
 use rustbgpd_policy::{
-    AsPathRegex, CommunityMatch, Policy, PolicyAction, PolicyChain, PolicyStatement,
-    RouteModifications,
+    AsPathRegex, CommunityMatch, NeighborSetMatch, Policy, PolicyAction, PolicyChain,
+    PolicyStatement, RouteModifications,
 };
 use rustbgpd_wire::{
     AddressPrefixOrf, AsPath, AsPathSegment, FlowSpecComponent, FlowSpecPrefix, FlowSpecRule,
@@ -1824,7 +1824,148 @@ async fn recv_peer_up_after_export_context(rib_rx: &mut mpsc::Receiver<RibUpdate
         rib_rx.recv().await.unwrap(),
         RibUpdate::SetPeerGracefulRestartContext { .. }
     ));
+    // Staged before `PeerUp` alongside the other export contexts: the
+    // initial Adj-RIB-Out is built synchronously by `PeerUp`, so a
+    // group-scoped export rule must already have the peer's group.
+    assert!(matches!(
+        rib_rx.recv().await.unwrap(),
+        RibUpdate::SetPeerPolicyContext { .. }
+    ));
     rib_rx.recv().await.unwrap()
+}
+
+/// Export chain that denies every route advertised to a member of
+/// `group`, and permits everything else.
+fn deny_export_to_peer_group(group: &str) -> PolicyChain {
+    PolicyChain::new(vec![Policy {
+        entries: vec![PolicyStatement {
+            prefix: None,
+            ge: None,
+            le: None,
+            action: PolicyAction::Deny,
+            match_community: vec![],
+            match_as_path: None,
+            match_neighbor_set: Some(NeighborSetMatch {
+                addresses: vec![],
+                remote_asns: vec![],
+                peer_groups: vec![group.to_string()],
+            }),
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: None,
+            modifications: RouteModifications::default(),
+        }],
+        default_action: PolicyAction::Permit,
+    }])
+}
+
+/// Bring one peer to Established against a REAL `RibManager` that already
+/// holds one route, and return the prefixes its initial full-table dump
+/// announced. The peer's export chain denies everything advertised to
+/// peer-group `rs-members`.
+async fn initial_dump_announcements(peer_group: Option<&str>) -> Vec<Prefix> {
+    let (rib_tx, rib_rx) = mpsc::channel(64);
+    let (_query_tx, query_rx) = mpsc::channel(8);
+    let manager = tokio::spawn(
+        rustbgpd_rib::RibManager::new(rib_rx, query_rx, None, None, BgpMetrics::new()).run(),
+    );
+
+    // One route from an unrelated peer, so the dump has something to carry.
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9));
+    let mut route = make_route(100);
+    route.prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24));
+    route.peer = source;
+    route.next_hop = source;
+    route.attributes = Arc::new(vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 9)),
+    ]);
+    rib_tx
+        .send(RibUpdate::RoutesReceived {
+            peer: source,
+            session_id: 0,
+            announced: vec![route],
+            withdrawn: vec![],
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![],
+            evpn_withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+
+    let mut peer_config = PeerConfig::new(65001, 65010, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    let mut config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    config.peer_group = peer_group.map(str::to_string);
+    let (_cmd_tx, cmd_rx) = mpsc::channel(8);
+    let mut session = PeerSession::new(
+        config,
+        BgpMetrics::new(),
+        cmd_rx,
+        rib_tx,
+        None,
+        Some(deny_export_to_peer_group("rs-members")),
+        None,
+        None,
+        None,
+        false,
+    );
+    let (client, _peer_end) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65010).await;
+
+    // Collect the dump through its End-of-RIB — the marker the RIB always
+    // emits for a negotiated family, so an empty result is observed, not
+    // assumed from a timeout.
+    let mut announced = Vec::new();
+    loop {
+        let update = tokio::time::timeout(Duration::from_secs(10), session.outbound_rx.recv())
+            .await
+            .expect("initial table dump must reach the peer's outbound channel")
+            .expect("outbound channel must stay open");
+        announced.extend(update.announce.iter().map(|route| route.prefix));
+        if !update.end_of_rib.is_empty() {
+            break;
+        }
+    }
+    manager.abort();
+    announced
+}
+
+/// `PeerUp` builds the initial Adj-RIB-Out synchronously, so the RIB must
+/// already know the peer's group when it evaluates export policy for that
+/// first full-table dump. With the context sent afterwards the dump
+/// escaped a group-scoped deny that every later update honored — on a
+/// route server with group-scoped export filtering, a leak at session
+/// establishment.
+#[tokio::test]
+async fn initial_table_dump_applies_peer_group_export_policy() {
+    assert!(
+        initial_dump_announcements(Some("rs-members"))
+            .await
+            .is_empty(),
+        "initial dump to an rs-members peer must be filtered by the \
+         group-scoped export deny, not just later updates"
+    );
+    // Control: the dump is not empty for some unrelated reason.
+    assert_eq!(
+        initial_dump_announcements(Some("transit")).await.len(),
+        1,
+        "a peer outside the denied group must still receive the initial dump"
+    );
 }
 /// All-empty `OutboundRouteUpdate` for the rib-out BMP tap tests.
 fn empty_outbound_update() -> OutboundRouteUpdate {


### PR DESCRIPTION
## Problem

The session emitted `RibUpdate::SetPeerPolicyContext` **after** the `PeerUp`
registration (`crates/transport/src/session/fsm.rs`). `RibManager::handle_peer_up`
builds the initial Adj-RIB-Out synchronously, and `send_initial_table` reads
`self.peer_group` — a map populated only by `handle_set_peer_policy_context` — to
feed export-policy evaluation.

The initial full-table dump to a newly established peer therefore evaluated export
policy with `peer_group = None`. Any export rule matching on peer-group did not
apply to that dump; it began applying only from the next update. On a route server
with group-scoped export filtering, that advertised routes the operator's policy
intends to deny — a leak at session establishment. It was not a one-time startup
condition: a plain `PeerDown` removes the stored group, so every flap and
re-establishment reproduced it.

## Fix

Send the context in the pre-`PeerUp` staging block, next to the RFC 9234 role, RFC
7947 control-community, exact-encoder, and RFC 4724 contexts already staged there
for exactly this reason. The staged contexts do not depend on each other's order,
and the message is still sent exactly once per Established transition, from the
single site in the tree that emits it.

Re-establishment paths were checked. A plain reconnect, a GR/LLGR reconnect, and a
registration failback all clear the outbound registration before the returning
session reaches Established, so the staged message is accepted on its own session
identity. The one behavior narrowing is the RFC 4271 §6.8 collision window, where
two sessions for one address are briefly live: the incoming session's context now
arrives while the predecessor is still registered, so the session-identity gate
discards it and the peer keeps the group its predecessor installed. That value is
peer-keyed and comes from the same neighbor configuration — the group only ever
reaches the RIB at Established, so both concurrent sessions carry the same string —
and whichever session survives the collision keeps it. The alternative (dropping
the gate for this message, or a fifth session-keyed pending map) buys nothing
observable here.

## Operator impact

**This is a wire-visible change to the initial dump.** After upgrading, the first
full-table dump to a peer in a peer-group may be filtered — or otherwise
transformed by group-matched policy actions such as next-hop, community, or
`AS_PATH` modifications — where it previously was not. That is the intended policy
result, but it is a change in what a peer receives at establishment. Peers whose
export policy does not match on peer-group are unaffected.

## Test

`initial_table_dump_applies_peer_group_export_policy` runs a real `RibManager`
holding one route and feeds it the session's own establishment message stream, then
reads the initial dump off the peer's outbound channel through its End-of-RIB. A
member of the denied group must receive nothing; a peer in another group must still
receive the route, so an empty dump cannot pass the test for an unrelated reason.

Proven red against the unfixed ordering, with the fix reverted and the test kept:

```
thread 'session::tests::initial_table_dump_applies_peer_group_export_policy' panicked at
crates/transport/src/session/tests.rs:1956:5:
initial dump to an rs-members peer must be filtered by the group-scoped export deny,
not just later updates
```

One existing helper encoded the old ordering: `recv_peer_up_after_export_context`
asserted the four staged contexts and then expected `PeerUp` as the next message.
It now asserts `SetPeerPolicyContext` in the staged set, which is where the message
belongs; its two callers fail against the unfixed ordering for the same reason.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo test --workspace --no-fail-fast`, `cargo doc --workspace --no-deps` — all exit 0.
