### PR TITLE
Zero Adj-RIB-Out gauges on the graceful-restart down path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`bgp_rib_adj_out_prefixes` no longer reads stale-nonzero through a
+  graceful-restart hold window.** Entering GR tears down the peer's outbound
+  registration and its Adj-RIB-Out along with it, but only the `PeerDown`
+  teardown zeroed the seven per-family gauge series; the GR down path left
+  them advertising the departed session's counts for the whole restart timer.
+  The reset moved into the shared outbound-teardown helper, so both paths —
+  plus collision failback and replacement-`PeerUp`, which empty the same table
+  — now zero it where the table is actually removed. RFC 4724 retention is an
+  Adj-RIB-In property: `bgp_rib_prefixes`, `bgp_gr_active_peers`, and
+  `bgp_gr_stale_routes` remain the series that stay nonzero for a peer
+  expected back, and `bgp_rib_outbound_registered_peers` already decremented at
+  GR entry. **Operator-visible for dashboards and alerts:** an advertised-count
+  panel or rule that read the old nonzero plateau during a restart now sees
+  zero until the peer returns and its table is rebuilt.
+
 - **The initial table dump now evaluates export policy with the peer's
   peer-group.** The session staged its peer-group policy context *after* the
   `PeerUp` registration, but `PeerUp` builds the initial Adj-RIB-Out

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -321,11 +321,6 @@ impl RibManager {
 
         self.clear_peer_adj_rib_in(peer);
 
-        let peer_label = peer.to_string();
-        for family in ["all", "flowspec", "evpn", "bgpls", "vpn", "labeled", "rtc"] {
-            self.metrics
-                .set_adj_rib_out_prefixes(&peer_label, family, 0);
-        }
         self.clear_outbound_peer_state(peer);
         self.peer_asn.remove(&peer);
         self.peer_group.remove(&peer);
@@ -458,6 +453,20 @@ impl RibManager {
             i64::try_from(self.outbound_peers.len()).unwrap_or(i64::MAX),
         );
         self.adj_ribs_out.remove(&peer);
+        // The gauge reports the size of the table removed on the line
+        // above, so it is zeroed here rather than at the `PeerDown` call
+        // site: the graceful-restart down path empties the same table and
+        // must not leave the series advertising prefixes for an
+        // Adj-RIB-Out that no longer exists. RFC 4724 retention is an
+        // Adj-RIB-*In* property — `bgp_rib_prefixes`, `bgp_gr_active_peers`
+        // and `bgp_gr_stale_routes` carry the "expected back" signal for
+        // the hold window; this series carries what we would actually
+        // re-advertise, which is nothing until the peer returns.
+        let peer_label = peer.to_string();
+        for family in ["all", "flowspec", "evpn", "bgpls", "vpn", "labeled", "rtc"] {
+            self.metrics
+                .set_adj_rib_out_prefixes(&peer_label, family, 0);
+        }
         // Outbound prefix admission is per-registration (ADR-0113): the
         // admitted set and its blocking latch describe what the departing
         // session was advertising. A reconnect starts empty and admits its

--- a/crates/rib/src/manager/tests/events_metrics.rs
+++ b/crates/rib/src/manager/tests/events_metrics.rs
@@ -1167,6 +1167,81 @@ fn peer_down_zeroes_all_adj_rib_out_family_gauges() {
     }
 }
 
+/// Graceful-restart entry empties the peer's Adj-RIB-Out exactly as a
+/// `PeerDown` does (`clear_outbound_peer_state` removes the table on both
+/// paths), so the gauge must read zero for the whole hold window. RFC 4724
+/// retention is an Adj-RIB-*In* property: `bgp_rib_prefixes`,
+/// `bgp_gr_active_peers` and `bgp_gr_stale_routes` are the series that stay
+/// nonzero for a peer expected back. Pinning the zero here keeps this path
+/// from drifting away from the `PeerDown` reset again.
+#[test]
+fn graceful_restart_zeroes_all_adj_rib_out_family_gauges() {
+    let metrics = BgpMetrics::new();
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let peer_label = peer.to_string();
+    let families = ADJ_RIB_OUT_FAMILIES;
+
+    for (index, family) in families.iter().enumerate() {
+        metrics.set_adj_rib_out_prefixes(
+            &peer_label,
+            family,
+            i64::try_from(index + 1).expect("fixture count fits i64"),
+        );
+    }
+
+    manager.handle_update(RibUpdate::PeerGracefulRestart {
+        peer,
+        session_id: 0,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_llgr_capable: false,
+        peer_llgr_families: Vec::new(),
+        llgr_stale_time: 0,
+    });
+
+    // The assertions below only describe the hold window if the peer is
+    // actually in it — a GR entry that fell through to a full teardown
+    // would zero the gauges for the wrong reason.
+    assert!(
+        manager.gr_peers.contains_key(&peer),
+        "fixture must leave the peer inside the GR hold window"
+    );
+
+    // Load-bearing proof: dropping the zero-all loop from
+    // `clear_outbound_peer_state` (or moving it back to the `PeerDown` call
+    // site) leaves every seeded sentinel behind and fails here.
+    let gathered = metrics.registry().gather();
+    let gauge = gathered
+        .iter()
+        .find(|family| family.name() == "bgp_rib_adj_out_prefixes")
+        .expect("Adj-RIB-Out gauge family remains registered");
+    for family in families {
+        let observed = gauge
+            .metric
+            .iter()
+            .find(|metric| {
+                metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "peer" && label.value() == peer_label)
+                    && metric
+                        .get_label()
+                        .iter()
+                        .any(|label| label.name() == "afi_safi" && label.value() == family)
+            })
+            .unwrap_or_else(|| panic!("graceful restart removed the {family} Adj-RIB-Out series"))
+            .get_gauge()
+            .value();
+        assert!(
+            observed.abs() < f64::EPSILON,
+            "graceful restart left the {family} Adj-RIB-Out gauge at {observed}"
+        );
+    }
+}
+
 #[tokio::test]
 #[expect(
     clippy::cast_possible_truncation,

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1054,6 +1054,17 @@ counters, using a 15-minute increase window:
 | `bgp_selection_deferral_timeouts_total{afi_safi}` | Family gates released by the selection-deferral timer |
 | `bgp_selection_deferral_ledger_overflows_total{afi_safi}` | Gated families whose next identity would exceed the process-wide one-million-identity or 64 MiB logical retained-key-data ledger and therefore use a complete release sweep |
 
+Retention during the hold window is an Adj-RIB-**In** property, and the
+routing metrics say so. `bgp_rib_prefixes` keeps counting the peer's retained
+(stale) received routes, alongside `bgp_gr_active_peers` and
+`bgp_gr_stale_routes`. `bgp_rib_adj_out_prefixes` drops to zero for that peer
+instead: entering GR tears down the session's outbound registration and its
+Adj-RIB-Out with it (`bgp_rib_outbound_registered_peers` decrements for the
+same reason), so there is nothing left to advertise until the peer returns and
+the table is rebuilt. A zero advertised-count for a peer whose received-count
+is still high is the expected shape of a restart in progress, not a lost
+table.
+
 For active gates, `rbgp neighbor <address>` and
 `NeighborService.GetNeighborState` also show the peer's waiter state, stamped
 session, blocking-waiter count, and remaining time. A released row retains its


### PR DESCRIPTION
## Problem

`bgp_rib_adj_out_prefixes` read stale-nonzero for the duration of a peer's
graceful-restart hold window.

Entering GR calls `clear_outbound_peer_state`, which removes the peer's
`adj_ribs_out` entry — the table the gauge reports. Only `peer_down_teardown`
zeroed the seven per-family series (`all`, `flowspec`, `evpn`, `bgpls`, `vpn`,
`labeled`, `rtc`), and it did so at its own call site rather than in the shared
helper. The GR down path therefore kept publishing the departed session's
counts against an Adj-RIB-Out that no longer existed.

It self-healed, which is why it went unnoticed: `PeerUp` eager-zeros all seven
families on GR re-establish before re-advertising, and GR abandonment expiry
routes through `peer_down_teardown`. The stale plateau lasted exactly as long
as the restart timer.

## Which reading is correct

Two readings were considered: the gauge should report the empty table (zero),
or the nonzero value is deliberate so an operator does not see a cliff for a
peer expected back. The codebase's own semantics settle it in favour of zero.

- Both the metric help (`Number of prefixes in Adj-RIB-Out per peer and
  AFI/SAFI`) and `docs/OPERATIONS.md` (`Adj-RIB-Out size per peer + AFI/SAFI
  (advertised)`) define the series as the table's size, not a notional
  retention.
- RFC 4724 retention in this implementation is an Adj-RIB-**In** property.
  `clear_outbound_peer_state` drops the Adj-RIB-Out on both paths; its comment
  is explicit that only peer-identity maps survive because the peer is
  expected back.
- The sibling series already report the peer's outbound side as gone during
  the same window. `bgp_rib_outbound_registered_peers` decrements from this
  very function, and the peer leaves its update group, moving
  `bgp_update_group_members`. A nonzero advertised-count contradicted both.
- The "expected back" signal already has dedicated series that do stay
  nonzero: `bgp_rib_prefixes` (retained stale received routes),
  `bgp_gr_active_peers`, and `bgp_gr_stale_routes`. Overloading the
  advertised-count gauge would duplicate them and lose the one question it
  answers.
- Decisively: `PeerUp` eager-zeros all seven families on GR re-establish
  before re-advertising. Under the no-cliff reading that is the worst possible
  place to zero, yet it is what the code does — so the nonzero hold-window
  value produced the cliff anyway, just later and at a more confusing moment.

## Change

Move the zero-all reset into `clear_outbound_peer_state`, adjacent to the
`adj_ribs_out.remove` it describes. That helper exists precisely to stop the
two teardown sites from drifting (it was introduced after the GR path missed
the ORF filter/gate cleanup), and this is the same drift recurring on the
metrics side. Fixing it there also covers collision failback and
replacement-`PeerUp`, which empty the same table; both immediately
re-register and re-seed the series, so neither changes shape.

Nothing asserted either behaviour before, which is how this drifted.
`graceful_restart_zeroes_all_adj_rib_out_family_gauges` now pins it next to
the existing `PeerDown` test, asserting the peer is genuinely inside the hold
window so the zero cannot be satisfied by an accidental full teardown.
Reverting the production change fails it with `graceful restart left the all
Adj-RIB-Out gauge at 1` while the `PeerDown` sibling still passes.

`docs/OPERATIONS.md` states the hold-window shape in the graceful-restart
metrics section: a zero advertised-count beside a still-high received-count is
a restart in progress, not a lost table.

## Operator impact

Dashboards and alert rules that read the old nonzero plateau during a restart
now see zero until the peer returns and its Adj-RIB-Out is rebuilt.
CHANGELOG entry added under Fixed.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D
warnings`, `cargo test --workspace --no-fail-fast`, `cargo doc --workspace
--no-deps`, and `cargo check -p rustbgpd-rib --features bench-internals
--benches` all exit 0.
