### PR TITLE
Hot-apply all-live peer-group edits without a session reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,24 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   GR entry. **Operator-visible for dashboards and alerts:** an advertised-count
   panel or rule that read the old nonzero plateau during a restart now sees
   zero until the peer returns and its table is rebuilt.
+- **Hot-applicable peer-group edits no longer tear down every inheriting
+  session.** `apply_peer_group_change` reshaped (delete + re-add) the group's
+  static members for *any* change, so raising a group-level maximum bounced
+  every client that inherits from it — while the identical neighbor-level edit
+  hot-applied in place. A peer-group change's changed fields are now
+  partitioned by reload-matrix impact class the way neighbor changes already
+  were: a change set whose every field is `live` is applied to each member in
+  place, with no session reset, and a set that mixes in any session-reset,
+  restart-required, or unclassified field keeps the ADR-0081 reshape path. The
+  in-place path carries the same atomicity contract — every member's next
+  config is resolved and its live prior captured before any peer is touched, a
+  mid-cohort failure restores the earlier members in reverse order and reports
+  a compound error naming any it could not, and the stored group definition
+  advances only after the whole cohort succeeded. Dynamic inheritors are part
+  of that cohort and pick the new values up without waiting for a reconnect.
+  For a route server, where clients inherit from a group, a group-level limit
+  raise is now flap-free during exactly the incident the limit exists to
+  contain.
 
 - **The initial table dump now evaluates export policy with the peer's
   peer-group.** The session staged its peer-group policy context *after* the

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -67,9 +67,12 @@ rebuilt; the transaction executor captures prior static peer configs and
 restores them if apply or persistence fails, and after a successful persist it
 gracefully resets the live dynamic sessions accepted by an affected range so
 they re-accept under the committed config (ADR-0086). SIGHUP and targeted
-peer-group RPCs hot-apply policy-only peer-group edits to live dynamic
-sessions, but no-preview session-shaping peer-group edits on those paths leave
-dynamic sessions on their running config until reconnect. Dynamic-range
+peer-group RPCs partition a group edit's changed fields by impact class: an
+all-`live` change set is applied in place to every inheriting member, static
+and dynamic, with no session reset, while a set mixing in any session-reset,
+restart-required, or unclassified field reshapes as before. Session-shaping
+peer-group edits on those paths still leave dynamic sessions on their running
+config until reconnect. Dynamic-range
 peer-group reassignments and mixed policy/session effective-impact candidates
 remain rejected even though SIGHUP can hot-reconcile some of those shapes
 best-effort.
@@ -152,7 +155,7 @@ configure their keyring directly.
 | `slow_peer_duration` | live (effective next session) | Same as neighbor. |
 | `slow_peer_isolation` | live (effective next session) | Same as neighbor. |
 | `max_prefixes` | live | Same as neighbor. |
-| `max_prefix_restart_seconds` | live (static session reset; transaction dynamic bounce) | Inherited by group members. Direct group edits reshape static members and manager-sync all dynamic members without bouncing them. Committed config transactions also bounce enabled dynamic sessions; disabled dynamic peers retain admin state and adopt the new duration. An armed countdown reschedules to now + the new duration; removing the duration cancels it. |
+| `max_prefix_restart_seconds` | live | Inherited by group members. An all-`live` group edit applies in place to static and dynamic members without bouncing them; a mixed change set reshapes static members and manager-syncs dynamic ones. Committed config transactions also bounce enabled dynamic sessions; disabled dynamic peers retain admin state and adopt the new duration. An armed countdown reschedules to now + the new duration; removing the duration cancels it. |
 | `md5_password` | live (effective next session) | Same as neighbor — pinned by group, applied to the inheriting peer's next socket. |
 | `bfd` | restart-required | Pinned. |
 | `ttl_security` | live (effective next session) | |
@@ -160,7 +163,7 @@ configure their keyring directly.
 | `required_families` | live (static session reset; dynamic next reconnect) | Non-empty neighbor value overrides; empty/absent inherits. A committed config transaction classifies the effective change as `SessionReshape` and bounces affected enabled dynamic ranges after persistence. |
 | `graceful_restart` | live (effective next session) | |
 | `gr_restart_time` | live (effective next session) | |
-| `gr_peer_restart_time_max` | live (static session reset; dynamic next reconnect) | Inherited local helper cap. Peer-group edits rebuild static members; already accepted dynamic members keep their running cap until reconnect. A committed config transaction follows the transaction-overlay behavior above and bounces enabled dynamic members. |
+| `gr_peer_restart_time_max` | live | Inherited local helper cap. An all-`live` group edit swaps the cap in place on static and dynamic members alike; a change set that also moves a session-reset field rebuilds static members and leaves accepted dynamic members on their running cap until reconnect. A committed config transaction follows the transaction-overlay behavior above and bounces enabled dynamic members. |
 | `gr_stale_routes_time` | live | |
 | `llgr_stale_time` | live (effective next session) | |
 | `local_ipv6_nexthop` | live | |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5773,6 +5773,25 @@ pub fn describe_peer_group_changes(
     changes
 }
 
+/// True when every field that differs between two versions of one peer
+/// group is reload-matrix `live` (hot-applied), so the group edit can be
+/// applied in place to every inheriting member instead of reshaping
+/// (delete + re-add) their sessions.
+///
+/// The peer-group sibling of [`neighbor_change_hot_applicable`], and
+/// conservative on exactly the same edges: an empty change list (a
+/// runtime-relevant field `describe_peer_group_changes` doesn't cover,
+/// e.g. the `slow_peer_*` trio) and any field whose impact class is
+/// unknown or non-`HotApplied` both return `false`, keeping the reshape
+/// path as the fallback.
+pub fn peer_group_change_hot_applicable(old: &PeerGroupConfig, new: &PeerGroupConfig) -> bool {
+    let changes = describe_peer_group_changes(old, new);
+    !changes.is_empty()
+        && changes
+            .iter()
+            .all(|change| change.impact == Some(ConfigFieldImpact::HotApplied))
+}
+
 /// Compare two policy configurations.
 pub fn diff_policy(old: &PolicyConfig, new: &PolicyConfig) -> PolicyDiff {
     let definitions_added: Vec<String> = new

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -14102,8 +14102,9 @@ fn reload_matrix_pins_load_bearing_field_classes() {
         cap_rows[0]
     );
     assert!(
-        cap_rows[1].contains("| live (static session reset; dynamic next reconnect) |"),
-        "peer-group cap edits do not selectively hot-fanout: {}",
+        cap_rows[1].contains("| live |"),
+        "an all-hot peer-group cap edit hot-applies to static and dynamic \
+         members in place: {}",
         cap_rows[1]
     );
 }

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -356,7 +356,10 @@ impl PeerManager {
         }
     }
 
-    fn removed_peer_config(peer: &PeerKey, managed: &ManagedPeer) -> PeerManagerNeighborConfig {
+    pub(super) fn removed_peer_config(
+        peer: &PeerKey,
+        managed: &ManagedPeer,
+    ) -> PeerManagerNeighborConfig {
         let tc = &managed.transport_config;
         PeerManagerNeighborConfig {
             address: peer.address,
@@ -717,25 +720,55 @@ impl PeerManager {
     /// socket-scoped fields are copied from `config` into the stored
     /// transport config by the next rebuild path, which resolves from the
     /// config snapshot anyway).
-    #[expect(
-        clippy::too_many_lines,
-        reason = "one linear pass: change detection, policy seam, knob apply, export refresh, bookkeeping"
-    )]
     pub(super) async fn hot_update_peer(
         &mut self,
         config: PeerManagerNeighborConfig,
     ) -> Result<(), PeerLifecycleError> {
         let peer = PeerKey::new(config.address, config.interface.clone());
+        if self
+            .peers
+            .get(&peer)
+            .ok_or_else(|| PeerLifecycleError::NotFound(peer.clone()))?
+            .is_dynamic
+        {
+            return Err(PeerLifecycleError::Invalid(format!(
+                "hot update target {peer} is a dynamic peer; reload reconciles static neighbors only"
+            )));
+        }
+        self.hot_update_peer_in_place(config).await
+    }
+
+    /// The applier half of [`Self::hot_update_peer`], without the
+    /// static-only guard.
+    ///
+    /// Everything it touches is per-session runtime state that an accepted
+    /// dynamic peer holds exactly like a static one, so the peer-group hot
+    /// path reaches dynamic inheritors through here. The guard above stays
+    /// on the reload entry point, where a dynamic target means the static
+    /// neighbor reconcile and the managed-peer set disagree.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one linear pass: change detection, policy seam, knob apply, export refresh, bookkeeping"
+    )]
+    pub(super) async fn hot_update_peer_in_place(
+        &mut self,
+        config: PeerManagerNeighborConfig,
+    ) -> Result<(), PeerLifecycleError> {
+        let peer = PeerKey::new(config.address, config.interface.clone());
+        #[cfg(test)]
+        if let Some(remaining) = self.inject_hot_update_failures.get_mut(&peer) {
+            if *remaining == 0 {
+                return Err(PeerLifecycleError::Internal(format!(
+                    "injected hot update failure for {peer}"
+                )));
+            }
+            *remaining -= 1;
+        }
         let (knobs_changed, export_knobs_changed, policies_changed, restart_policy_changed) = {
             let managed = self
                 .peers
                 .get(&peer)
                 .ok_or_else(|| PeerLifecycleError::NotFound(peer.clone()))?;
-            if managed.is_dynamic {
-                return Err(PeerLifecycleError::Invalid(format!(
-                    "hot update target {peer} is a dynamic peer; reload reconciles static neighbors only"
-                )));
-            }
             let tc = &managed.transport_config;
             // The export-affecting subset: `local_ipv6_nexthop` decides the
             // exact-export preflight's `MissingIpv6NextHop` suppression and

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -364,6 +364,11 @@ pub struct PeerManager {
     /// before any peer is touched.
     #[cfg(test)]
     inject_reconfigure_failures: std::collections::BTreeMap<PeerKey, u32>,
+    /// The same deterministic fault injection for the in-place applier
+    /// (`hot_update_peer_in_place`), so the peer-group hot path's
+    /// mid-cohort failure and rollback contract can be exercised.
+    #[cfg(test)]
+    inject_hot_update_failures: std::collections::BTreeMap<PeerKey, u32>,
 }
 
 impl PeerManager {
@@ -599,6 +604,8 @@ impl PeerManager {
             snapshot_key: crate::config::RuntimeSnapshotKey::random(),
             #[cfg(test)]
             inject_reconfigure_failures: std::collections::BTreeMap::new(),
+            #[cfg(test)]
+            inject_hot_update_failures: std::collections::BTreeMap::new(),
         }
     }
 

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -2547,6 +2547,24 @@ impl PeerManager {
             return Ok(());
         }
 
+        // Partition the group edit's changed fields by `ConfigFieldImpact`
+        // the way `diff_neighbors` already does for neighbor edits: when
+        // every changed field is reload-matrix `live`, the members'
+        // effective values are applied in place instead of bouncing every
+        // inheriting session. A mixed set (any field that is session-reset,
+        // restart-required, unclassified, or not described at all) keeps
+        // the reshape path below.
+        if let ConfigEvent::SetPeerGroup { name, .. } = &event
+            && let Some(old_group) = self.current_config.peer_groups.get(name)
+            && let Some(new_group) = next_config.peer_groups.get(name)
+            && crate::config::peer_group_change_hot_applicable(old_group, new_group)
+        {
+            let name = name.clone();
+            return self
+                .apply_peer_group_hot_change(event, next_config, &name, affected_peers)
+                .await;
+        }
+
         // ADR-0081: resolve every affected member's next config BEFORE
         // touching any peer, then commit the whole set through the
         // captured-prior reshape primitive. A resolution failure rejects with
@@ -2607,6 +2625,175 @@ impl PeerManager {
         self.reconcile_stale_dynamic_max_prefix_restarts();
         self.publish_policy_config_event(&event, priors.len());
         Ok(())
+    }
+
+    /// The all-hot half of [`Self::apply_peer_group_change`]: apply the
+    /// group's new effective values to every inheriting member in place,
+    /// under the same ADR-0081 contract the reshape path honors.
+    ///
+    /// Phase 1 resolves each member's next config and captures its live
+    /// prior before any peer is touched, so a resolution failure rejects
+    /// with zero peers touched. Phase 2 applies the cohort one member at a
+    /// time; a mid-cohort failure replays the captured priors in reverse
+    /// order (best-effort, so one stuck member cannot strand the rest) and
+    /// surfaces a compound error naming the members left advanced.
+    /// `current_config` — and with it the stored group definition —
+    /// advances only after the whole cohort succeeded.
+    ///
+    /// Unlike a reshape, dynamic inheritors are part of the cohort:
+    /// ADR-0081 decision 4 defers *reshaping* an accepted dynamic peer
+    /// because delete/re-add is wrong for an ephemeral session, but a hot
+    /// knob swap is as correct for it as for a static member, so it picks
+    /// the new effective values up without waiting for a reconnect.
+    async fn apply_peer_group_hot_change(
+        &mut self,
+        event: ConfigEvent,
+        next_config: Config,
+        group: &str,
+        affected_peers: Vec<IpAddr>,
+    ) -> Result<(), CatalogMutationError> {
+        let cohort = self.peer_group_hot_cohort(&next_config, group, &affected_peers)?;
+        let members = cohort.len();
+        let mut applied: Vec<PeerManagerNeighborConfig> = Vec::new();
+        for (next, prior) in cohort {
+            let peer = PeerKey::new(next.address, next.interface.clone());
+            let Err(error) = self.hot_update_peer_in_place(next).await else {
+                applied.push(prior);
+                continue;
+            };
+            let total = applied.len();
+            let mut failures = Vec::new();
+            for prior in applied.into_iter().rev() {
+                let restored = PeerKey::new(prior.address, prior.interface.clone());
+                if let Err(restore_error) = self.hot_update_peer_in_place(prior).await {
+                    failures.push(format!("{restored}: {restore_error}"));
+                }
+            }
+            return Err(CatalogMutationError::internal(if failures.is_empty() {
+                format!(
+                    "failed to hot-apply the peer-group change to {peer}: {error}; \
+                     prior peers restored"
+                )
+            } else {
+                format!(
+                    "failed to hot-apply the peer-group change to {peer}: {error}; \
+                     peer-group hot-apply rollback failed for {} of {total} prior peers \
+                     (unnamed priors were restored; each named member's state is described \
+                     by its error): {}",
+                    failures.len(),
+                    failures.join("; ")
+                )
+            }));
+        }
+
+        self.current_config = next_config;
+        self.sync_dynamic_max_prefix_restart_for_group(group);
+        self.reconcile_stale_dynamic_max_prefix_restarts();
+        self.publish_policy_config_event(&event, members);
+        info!(
+            group,
+            members, "hot-applied peer-group change in place (no session reshape)"
+        );
+        Ok(())
+    }
+
+    /// Phase 1 of [`Self::apply_peer_group_hot_change`]: every inheriting
+    /// member's next config paired with its captured live prior, in apply
+    /// order. Takes `&self` so it cannot touch a peer — a resolution
+    /// failure rejects the whole edit with zero peers mutated.
+    fn peer_group_hot_cohort(
+        &self,
+        next_config: &Config,
+        group: &str,
+        affected_peers: &[IpAddr],
+    ) -> Result<Vec<(PeerManagerNeighborConfig, PeerManagerNeighborConfig)>, CatalogMutationError>
+    {
+        // (next config, captured live prior) per member, in apply order.
+        let mut cohort: Vec<(PeerManagerNeighborConfig, PeerManagerNeighborConfig)> = Vec::new();
+        let mut seen = BTreeSet::new();
+
+        for peer_key in affected_peers
+            .iter()
+            .flat_map(|address| self.peer_keys_for_address(*address))
+        {
+            if seen.contains(&peer_key) {
+                continue;
+            }
+            let Some(managed) = self.peers.get(&peer_key) else {
+                continue;
+            };
+            // Dynamic peers at an affected address are swept below off their
+            // accepted range instead — the caller derived this address list
+            // from the static `[[neighbors]]` records.
+            if managed.is_dynamic {
+                continue;
+            }
+            seen.insert(peer_key.clone());
+            let prior = Self::removed_peer_config(&peer_key, managed);
+            let address = peer_key.address;
+            let Some(neighbor) = next_config.neighbors.iter().find(|neighbor| {
+                neighbor.address == address.to_string() && neighbor.interface == peer_key.interface
+            }) else {
+                return Err(CatalogMutationError::internal(format!(
+                    "static peer {peer_key} affected by the peer-group change has no neighbor \
+                     record in the updated config; refusing to hot-apply against an inconsistent \
+                     snapshot"
+                )));
+            };
+            let resolved = next_config
+                .resolve_neighbor(neighbor)
+                .map_err(catalog_config_error)?;
+            cohort.push((
+                Self::peer_manager_config_from_resolved(resolved, false),
+                prior,
+            ));
+        }
+
+        let Some(group_config) = next_config.peer_groups.get(group) else {
+            return Err(CatalogMutationError::internal(format!(
+                "peer group {group} vanished from the updated config while hot-applying it"
+            )));
+        };
+        let mut dynamic_members: Vec<PeerKey> = self
+            .peers
+            .iter()
+            .filter(|(peer_key, managed)| {
+                managed.is_dynamic
+                    && managed
+                        .accepted_dynamic_range
+                        .as_ref()
+                        .is_some_and(|accepted| accepted.peer_group == group)
+                    && !seen.contains(*peer_key)
+            })
+            .map(|(peer_key, _)| peer_key.clone())
+            .collect();
+        dynamic_members.sort();
+        for peer_key in dynamic_members {
+            let Some(managed) = self.peers.get(&peer_key) else {
+                continue;
+            };
+            let prior = Self::removed_peer_config(&peer_key, managed);
+            let resolved = next_config
+                .resolve_dynamic_neighbor(
+                    peer_key.address,
+                    managed.remote_asn,
+                    &managed.description,
+                    group_config,
+                    group,
+                    // ADR-0112: `remote_asn` is the ASN learned from OPEN,
+                    // which may have replaced an accept-any range's sentinel,
+                    // so re-resolution takes the pinned classification.
+                    managed.rfc8212_external,
+                )
+                .map_err(catalog_config_error)?;
+            let mut next = Self::peer_manager_config_from_resolved(resolved, false);
+            // The synthetic dynamic neighbor carries no interface; key the
+            // apply on the live peer.
+            next.interface.clone_from(&peer_key.interface);
+            cohort.push((next, prior));
+        }
+
+        Ok(cohort)
     }
 }
 

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -4626,6 +4626,227 @@ async fn peer_group_reshape_skips_dynamic_peers_without_bouncing() {
     );
 }
 
+// ── peer-group edits partitioned by `ConfigFieldImpact` ───────────────
+
+fn edge_group_max_prefixes_event(
+    hold_time: u16,
+    max_prefixes: u32,
+) -> rustbgpd_api::peer_types::ConfigEvent {
+    let mut definition = edge_group_definition(Some(hold_time));
+    definition.max_prefixes = Some(max_prefixes);
+    rustbgpd_api::peer_types::ConfigEvent::SetPeerGroup {
+        name: "edge".to_string(),
+        definition,
+        ack: None,
+    }
+}
+
+async fn edge_group_manager_with_members() -> PeerManager {
+    let config = load_test_config(EDGE_GROUP_TOML);
+    let mut mgr = peer_group_reshape_manager(config.clone());
+    for resolved in config.resolved_neighbors().unwrap() {
+        mgr.add_peer(
+            PeerManager::peer_manager_config_from_resolved(resolved, false),
+            false,
+        )
+        .await
+        .unwrap();
+    }
+    mgr
+}
+
+/// Load-bearing: a peer-group edit whose every changed field is
+/// reload-matrix `live` must apply to the inheriting members in place.
+/// Both halves fail without the impact partition — before it,
+/// `apply_peer_group_change` reshaped for *any* group change, so every
+/// member's session id changed (a `peer deleted` + re-add on the wire)
+/// even though the identical neighbor-level edit hot-applies.
+#[tokio::test]
+async fn peer_group_hot_field_edit_applies_in_place_without_session_reset() {
+    let mut mgr = edge_group_manager_with_members().await;
+    let addresses = [
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4)),
+    ];
+    let before: Vec<_> = addresses
+        .iter()
+        .map(|addr| {
+            let managed = mgr.peers.get(&key(*addr)).expect("managed peer");
+            assert_eq!(managed.transport_config.max_prefixes, None);
+            (*addr, managed.session_id)
+        })
+        .collect();
+
+    mgr.apply_peer_group_change(edge_group_max_prefixes_event(90, 5_000), addresses.to_vec())
+        .await
+        .unwrap();
+
+    for (addr, session_id) in before {
+        let managed = mgr.peers.get(&key(addr)).expect("hot-applied member");
+        assert_eq!(
+            managed.session_id, session_id,
+            "a pure-hot peer-group edit must not tear down {addr}'s session"
+        );
+        // Skipping the reshape is only correct if the member's *effective*
+        // state actually moved; a path that updated the stored group
+        // definition alone would leave both of these stale.
+        assert_eq!(
+            managed.max_prefixes,
+            Some(5_000),
+            "{addr} must inherit the new group maximum"
+        );
+        assert_eq!(managed.transport_config.max_prefixes, Some(5_000));
+    }
+    assert_eq!(
+        mgr.current_config
+            .peer_groups
+            .get("edge")
+            .expect("group definition")
+            .max_prefixes,
+        Some(5_000)
+    );
+}
+
+/// The other half of the partition: a change set that mixes a hot field
+/// with a session-reset one keeps the ADR-0081 reshape path, because the
+/// session-reset field can only take effect on a renegotiated session.
+#[tokio::test]
+async fn peer_group_mixed_impact_edit_still_reshapes_members() {
+    let mut mgr = edge_group_manager_with_members().await;
+    let addresses = [
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)),
+    ];
+    let before: Vec<_> = addresses
+        .iter()
+        .map(|addr| (*addr, mgr.peers.get(&key(*addr)).expect("peer").session_id))
+        .collect();
+
+    // `hold_time` is OPEN-negotiated (session reset) and `max_prefixes` is
+    // hot; a mixed set must not take the in-place path.
+    mgr.apply_peer_group_change(edge_group_max_prefixes_event(45, 5_000), addresses.to_vec())
+        .await
+        .unwrap();
+
+    for (addr, session_id) in before {
+        let managed = mgr.peers.get(&key(addr)).expect("reshaped member");
+        assert_ne!(
+            managed.session_id, session_id,
+            "a mixed-impact peer-group edit must still reshape {addr}"
+        );
+        assert_eq!(managed.hold_time, Some(45));
+        assert_eq!(managed.max_prefixes, Some(5_000));
+    }
+}
+
+/// ADR-0081 for the in-place path: a mid-cohort failure restores the
+/// members applied before it from their captured live priors, and
+/// `current_config` — so also the stored group definition — never
+/// advances.
+#[tokio::test]
+async fn peer_group_hot_apply_mid_cohort_failure_restores_prior_members() {
+    let mut mgr = edge_group_manager_with_members().await;
+    let a1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let a2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)); // its hot apply fails
+    let a3 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+    mgr.inject_hot_update_failures.insert(key(a2), 0);
+    let sessions: Vec<_> = [a1, a2, a3]
+        .into_iter()
+        .map(|addr| (addr, mgr.peers.get(&key(addr)).expect("peer").session_id))
+        .collect();
+
+    let Err(error) = mgr
+        .apply_peer_group_change(edge_group_max_prefixes_event(90, 5_000), vec![a1, a2, a3])
+        .await
+    else {
+        panic!("mid-cohort hot-apply failure must surface as Err");
+    };
+    assert!(
+        matches!(error, CatalogMutationError::Internal(_)),
+        "{error:?}"
+    );
+    let message = error.to_string();
+    assert!(message.contains("prior peers restored"), "{message}");
+    assert!(message.contains("10.0.0.3"), "{message}");
+
+    for (addr, session_id) in sessions {
+        let managed = mgr.peers.get(&key(addr)).expect("member");
+        assert_eq!(
+            managed.max_prefixes, None,
+            "{addr} must be back on (or never moved off) its prior value"
+        );
+        assert_eq!(managed.transport_config.max_prefixes, None);
+        assert_eq!(
+            managed.session_id, session_id,
+            "rollback of an in-place apply must not bounce {addr} either"
+        );
+    }
+    assert!(
+        mgr.current_config
+            .peer_groups
+            .get("edge")
+            .expect("group definition")
+            .max_prefixes
+            .is_none(),
+        "a failed hot apply must leave the group definition unchanged"
+    );
+}
+
+/// Dynamic inheritors are part of the hot cohort: ADR-0081 decision 4
+/// defers *reshaping* an accepted dynamic peer, but a hot knob swap needs
+/// no reconnect, so the new inherited value reaches the live session
+/// without a bounce.
+#[tokio::test]
+async fn peer_group_hot_field_edit_reaches_live_dynamic_members() {
+    let mut mgr = dynamic_test_manager();
+    let addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 91));
+    let (handle, mut applied_caps) = recording_runtime_config_handle();
+    insert_test_dynamic_managed_peer(
+        &mut mgr,
+        addr,
+        91,
+        handle,
+        true,
+        IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0)),
+        8,
+        "ix-members",
+    );
+    let session_id = mgr.peers[&key(addr)].session_id;
+    let cap_before = mgr.peers[&key(addr)]
+        .transport_config
+        .gr_peer_restart_time_max;
+    assert_ne!(cap_before, 1_800);
+
+    let mut definition = crate::policy_admin::config_peer_group_to_api(
+        &mgr.current_config.peer_groups["ix-members"],
+    );
+    definition.gr_peer_restart_time_max = Some(1_800);
+    mgr.apply_peer_group_change(
+        rustbgpd_api::peer_types::ConfigEvent::SetPeerGroup {
+            name: "ix-members".to_string(),
+            definition,
+            ack: None,
+        },
+        Vec::new(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        applied_caps.try_recv(),
+        Ok(1_800),
+        "the live dynamic session must receive the new inherited cap"
+    );
+    let managed = &mgr.peers[&key(addr)];
+    assert_eq!(managed.transport_config.gr_peer_restart_time_max, 1_800);
+    assert_eq!(
+        managed.session_id, session_id,
+        "a hot peer-group edit must not bounce the dynamic member"
+    );
+    assert!(managed.is_dynamic);
+}
+
 #[tokio::test]
 async fn required_family_group_reconcile_waits_for_dynamic_reconnect() {
     // Load-bearing: this shared SIGHUP/targeted-group reconcile primitive must


### PR DESCRIPTION
Editing a **peer-group** hot field tore down every inheriting session
(`peer deleted` + re-add), while the identical **neighbor-level** edit
hot-applied in place. `apply_peer_group_change` reshaped the group's static
members for *any* change, even for fields already classified
`ConfigFieldImpact::HotApplied`. For a route server — where clients inherit
from a group — a group-level limit raise flapped the whole client base during
exactly the incident the limit exists to contain.

## Change

A peer-group change's changed fields are now partitioned by
`ConfigFieldImpact`, the way `diff_neighbors` already does for neighbors
(`peer_group_change_hot_applicable`, the sibling of
`neighbor_change_hot_applicable`):

- **all-`live` change set** → new in-place apply path, no session reset;
- **anything else** — a session-reset, restart-required, unclassified, or
  undescribed field, or an empty change list — → the existing ADR-0081
  reshape path. Conservative on both edges, so the safe existing behaviour is
  the default.

Only `SetPeerGroup` on an existing group can take the new path;
`SetNeighborPeerGroup` / `ClearNeighborPeerGroup` (reassignments, classed
session-reset) and `DeletePeerGroup` are unchanged. SIGHUP reaches
`apply_peer_group_change` through the same `SetPeerGroup` command, so both
front doors are fixed at one place.

## ADR-0081 atomicity and rollback

The in-place path honours the same contract as the reshape primitive:

- **phase 1** resolves each member's next config and captures its live prior
  (`removed_peer_config`) under `&self`, so a resolution failure rejects with
  zero peers touched;
- **phase 2** applies the cohort one member at a time; a mid-cohort failure
  replays the captured priors in reverse order, best-effort so one stuck
  member cannot strand the rest, and returns a compound `Internal` error
  naming exactly the members it could not restore;
- `current_config` — and with it the stored group definition — advances only
  after the whole cohort succeeded.

Skipping the reshape does **not** mean updating the stored definition alone:
each member goes through the same in-place applier the neighbor path uses, so
the live effective values (session runtime knobs, policy chains, max-prefix
restart re-arm) actually move.

Dynamic inheritors are part of the cohort. ADR-0081 decision 4 defers
*reshaping* an accepted dynamic peer because delete/re-add is wrong for an
ephemeral session, but a hot knob swap needs no reconnect — so
`hot_update_peer`'s static-only guard moves to the reload entry point and the
applier half (`hot_update_peer_in_place`) is shared.

## Load-bearing proofs

Four tests, each red-proven against the pre-fix dispatch:

| Test | Pre-fix failure |
|---|---|
| `peer_group_hot_field_edit_applies_in_place_without_session_reset` | member session id `1` → `4` (teardown + re-add) |
| `peer_group_mixed_impact_edit_still_reshapes_members` | green pre-fix; goes red when the impact partition is dropped and every edit takes the hot path |
| `peer_group_hot_apply_mid_cohort_failure_restores_prior_members` | mid-cohort failure never surfaced as `Err` |
| `peer_group_hot_field_edit_reaches_live_dynamic_members` | live dynamic session received nothing (`Err(Empty)` vs `Ok(1800)`) |

## Docs

`docs/reload-matrix.md`: the `[peer_groups.<name>]` rows for
`max_prefix_restart_seconds` and `gr_peer_restart_time_max` claimed
`live (static session reset; …)`; both now hot-apply in place for an all-`live`
change set and are reclassed `live`, with the mixed-set behaviour spelled out
in the notes. The overview paragraph describes the partition. The class pin in
`reload_matrix_pins_load_bearing_field_classes` moves with it.

## Gates

`cargo fmt --all -- --check` · `cargo clippy --workspace --all-targets -D warnings` ·
`cargo test --workspace --no-fail-fast` · `cargo doc --workspace --no-deps` ·
`scripts/check-v1-stable-surface.py` ·
`cargo check -p rustbgpd-rib --features bench-internals --benches` — all exit 0.
