### PR TITLE
Fix first-hour adoption defects in doctor, docs, and the LG adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,40 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`rbgp doctor` no longer fails in the container image.** The image runs as
+  a nonroot user with a working directory it cannot write, and doctor
+  defaulted its bundle to `./rustbgpd-doctor-<ts>.tar.gz` — so the tool the
+  README names for bug reports exited 1 with a bare `Permission denied` at the
+  moment someone was trying to file one. Without `--output` the bundle now
+  goes to the first writable of: the working directory (unchanged where it
+  works), the daemon's `runtime_state_dir`, the temp directory. Independently,
+  a bundle that still cannot be written now names the target path and points
+  at `--output`, and a missing or unreadable `--token-file` names the path
+  instead of surfacing a bare errno.
+- **The `already_advertised` export-explain gate no longer claims the peer
+  holds the route.** `identical route already advertised — peer is in sync`
+  overstated what BGP can tell a sender: there is no acceptance signal, so a
+  peer that treats every UPDATE as withdrawn (RFC 7606) stays Established with
+  zero routes while that line reads "in sync". The unicast, VPN, and
+  labeled-unicast rungs, the `rbgp rib advertised --explain` summary line, and
+  the `already_advertised` field documentation now scope the claim to local
+  Adj-RIB-Out state and say that remote acceptance is not observable.
+- **Route-server cookbooks give the FRR first-AS relaxation in the form that
+  works.** Both `docs/cookbook/route-server.md` and
+  `docs/cookbook/route-server-migration.md` told operators to disable
+  `enforce-first-as` on the member without saying the fix must be
+  per-neighbor; the global `no bgp enforce-first-as` alone is insufficient in
+  FRR 10.3.1, as `docs/INTEROP.md` already recorded. Both pages now give
+  `no neighbor <route-server> enforce-first-as` and describe the failure mode,
+  which is silent: the member treats the updates as withdrawn (RFC 7606),
+  stays Established, holds zero routes, and neither side logs an error.
+- **Alice-LG adapter no longer serves a fabricated preferred-route count.**
+  `examples/birdwatcher-adapter` emitted a hardcoded `"preferred": 0` on
+  `/protocols/bgp`, so a looking glass showed every member with zero preferred
+  routes regardless of the Loc-RIB. The gRPC surface exposes no per-peer best
+  count and deriving one means paging the whole Loc-RIB on every poll, so the
+  field is omitted rather than served wrong; the README records the omission.
+  `imported`, `filtered`, and `exported` are unchanged.
 - **`bgp_rib_adj_out_prefixes` no longer reads stale-nonzero through a
   graceful-restart hold window.** Entering GR tears down the peer's outbound
   registration and its Adj-RIB-Out along with it, but only the `PeerDown`

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -81,7 +81,8 @@ const STATE_DIR_DISK_WARN_BYTES: u64 = 1024 * 1024 * 1024;
 const STATE_DIR_DISK_FAIL_BYTES: u64 = 100 * 1024 * 1024;
 
 pub(crate) struct DoctorOptions<'a> {
-    /// Bundle output path. Defaults to `rustbgpd-doctor-<unix-seconds>.tar.gz`.
+    /// Bundle output path. Defaults to `rustbgpd-doctor-<unix-seconds>.tar.gz`
+    /// under [`default_bundle_dir`].
     pub output: Option<&'a Path>,
     /// Daemon log file to tail into the bundle (the daemon itself logs to
     /// stdout/journald; only an operator-named file is ever read).
@@ -156,7 +157,13 @@ impl Bundle {
     }
 
     fn write_tar_gz(&self, path: &Path, root: &str) -> Result<(), CliError> {
-        let file = fs::File::create(path)?;
+        let file = fs::File::create(path).map_err(|error| {
+            CliError::Argument(format!(
+                "cannot write support bundle to {}: {error}\n  \
+                 hint: pass --output <FILE> to write it somewhere writable",
+                path.display()
+            ))
+        })?;
         let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
         let mut tar = tar::Builder::new(encoder);
         let mtime = now_unix_seconds();
@@ -921,6 +928,22 @@ fn dir_writable(path: &Path) -> bool {
     nix::unistd::access(path, nix::unistd::AccessFlags::W_OK).is_ok()
 }
 
+/// Directory a defaulted (no `--output`) bundle lands in: the working
+/// directory when it is writable — the historical behavior — else the
+/// daemon's runtime state dir, else the temp dir. The container image
+/// runs as a nonroot user with `/` as its working directory, so an
+/// unqualified `rbgp doctor` must not fail on an unwritable cwd right
+/// when someone is trying to file a report.
+fn default_bundle_dir(cwd: &Path, state_dir: Option<&str>) -> PathBuf {
+    [
+        cwd.to_path_buf(),
+        PathBuf::from(state_dir.unwrap_or(DEFAULT_STATE_DIR)),
+    ]
+    .into_iter()
+    .find(|dir| dir_writable(dir))
+    .unwrap_or_else(std::env::temp_dir)
+}
+
 fn human_bytes(bytes: u64) -> String {
     #[allow(
         clippy::cast_precision_loss,
@@ -1114,19 +1137,6 @@ pub(crate) async fn run(
     opts: &DoctorOptions<'_>,
 ) -> Result<i32, CliError> {
     let now = now_unix_seconds();
-    let bundle_path = opts
-        .output
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(format!("rustbgpd-doctor-{now}.tar.gz")));
-    // Root directory inside the tar: the bundle file name without
-    // extensions, so `tar xzf` yields exactly one directory.
-    let root = bundle_path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .map(|n| n.trim_end_matches(".tar.gz").trim_end_matches(".tgz"))
-        .filter(|n| !n.is_empty())
-        .map_or_else(|| format!("rustbgpd-doctor-{now}"), str::to_string);
-
     let mut reporter = Reporter {
         json: opts.json,
         checks: Vec::new(),
@@ -1657,6 +1667,22 @@ pub(crate) async fn run(
                    attach its report if appropriate.",
         },
     )?;
+    // Defaulted after the state dir is known, so the fallback can use it.
+    let bundle_path = opts.output.map_or_else(
+        || {
+            default_bundle_dir(Path::new("."), state_dir.as_deref())
+                .join(format!("rustbgpd-doctor-{now}.tar.gz"))
+        },
+        PathBuf::from,
+    );
+    // Root directory inside the tar: the bundle file name without
+    // extensions, so `tar xzf` yields exactly one directory.
+    let root = bundle_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n.trim_end_matches(".tar.gz").trim_end_matches(".tgz"))
+        .filter(|n| !n.is_empty())
+        .map_or_else(|| format!("rustbgpd-doctor-{now}"), str::to_string);
     bundle.write_tar_gz(&bundle_path, &root)?;
 
     let failed = reporter.any_fail();
@@ -2207,6 +2233,32 @@ paths = ["x"]
             assert_eq!(unwritable[0].status, CheckStatus::Fail);
             assert!(unwritable[0].detail.contains("not writable"));
             fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
+
+    #[test]
+    fn default_bundle_dir_falls_back_past_an_unwritable_working_directory() {
+        let cwd = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        assert_eq!(
+            default_bundle_dir(cwd.path(), Some(&state.path().display().to_string())),
+            cwd.path()
+        );
+
+        // access(W_OK) always succeeds for root, so the fallback rungs
+        // are only observable as an unprivileged user.
+        if !nix::unistd::geteuid().is_root() {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(cwd.path(), fs::Permissions::from_mode(0o555)).unwrap();
+            assert_eq!(
+                default_bundle_dir(cwd.path(), Some(&state.path().display().to_string())),
+                state.path()
+            );
+            assert_eq!(
+                default_bundle_dir(cwd.path(), Some("/nonexistent-state-dir")),
+                std::env::temp_dir()
+            );
+            fs::set_permissions(cwd.path(), fs::Permissions::from_mode(0o755)).unwrap();
         }
     }
 

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -1214,7 +1214,10 @@ fn print_explain_advertised(
         }
     }
     if explain.already_advertised {
-        println!("In sync: identical route already advertised - nothing would be re-sent");
+        println!(
+            "Adj-RIB-Out in sync: identical route already advertised - nothing would be \
+             re-sent; remote acceptance is not observable"
+        );
     }
     if !explain.reasons.is_empty() {
         println!("Reasons:");

--- a/crates/cli/src/connection.rs
+++ b/crates/cli/src/connection.rs
@@ -141,7 +141,8 @@ fn load_bearer_token(token_file: Option<&str>) -> Result<Option<AsciiMetadataVal
         return Ok(None);
     };
 
-    let raw = fs::read_to_string(token_file)?;
+    let raw = fs::read_to_string(token_file)
+        .map_err(|e| CliError::Argument(format!("failed to read token file {token_file}: {e}")))?;
     let token = raw.trim_end();
     if token.is_empty() {
         return Err(CliError::Argument(format!(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -286,7 +286,9 @@ enum Command {
         1  error (could not produce a bundle)\n  \
         2  bundle written but one or more checks are red")]
     Doctor {
-        /// Output tarball path. Defaults to `rustbgpd-doctor-<unix-seconds>.tar.gz`.
+        /// Output tarball path. Defaults to `rustbgpd-doctor-<unix-seconds>.tar.gz`
+        /// in the first writable of: the working directory, the daemon's
+        /// runtime state dir, the temp dir.
         #[arg(long, value_name = "FILE")]
         output: Option<PathBuf>,
 

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -506,7 +506,8 @@ pub struct JsonExplainAdvertisedRoute {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub update_group_id: Option<u64>,
     /// True on an advertise decision when the identical route already
-    /// sits in the advertised state (peer in sync, nothing re-sent).
+    /// sits in the advertised state (Adj-RIB-Out in sync, nothing
+    /// re-sent). Local state only — remote acceptance is not observable.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub already_advertised: bool,
     /// Route Distinguisher for a VPN explain; absent for unicast.

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -1299,8 +1299,8 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
                         gate: "adj_rib_out".to_string(),
                         code: "already_advertised".to_string(),
                         verdict: server_proto::ExportGateVerdict::Pass as i32,
-                        detail: "identical route already advertised - peer is in sync, no \
-                                 re-announcement"
+                        detail: "identical route already advertised — Adj-RIB-Out in sync, no \
+                                 re-announcement; remote acceptance is not observable"
                             .to_string(),
                     },
                 ],

--- a/crates/rib/src/manager/distribution/labeled.rs
+++ b/crates/rib/src/manager/distribution/labeled.rs
@@ -648,7 +648,8 @@ impl RibManager {
                     "adj_rib_out",
                     "already_advertised",
                     crate::update::ExportGateVerdict::Pass,
-                    "identical route already advertised — peer is in sync, no re-announcement"
+                    "identical route already advertised — Adj-RIB-Out in sync, no \
+                     re-announcement; remote acceptance is not observable"
                         .to_string(),
                 );
             }

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -1123,7 +1123,8 @@ impl RibManager {
                     "adj_rib_out",
                     "already_advertised",
                     Pass,
-                    "identical source path already occupies this outbound rank — peer is in sync"
+                    "identical source path already occupies this outbound rank — Adj-RIB-Out in \
+                     sync; remote acceptance is not observable"
                         .to_string(),
                 );
             } else if existing.is_some() {
@@ -1172,7 +1173,8 @@ impl RibManager {
                     "adj_rib_out",
                     "already_advertised",
                     Pass,
-                    "identical route already advertised — peer is in sync, no re-announcement"
+                    "identical route already advertised — Adj-RIB-Out in sync, no \
+                     re-announcement; remote acceptance is not observable"
                         .to_string(),
                 );
             } else if existing.is_some() {
@@ -2065,7 +2067,8 @@ impl RibManager {
                     "adj_rib_out",
                     "already_advertised",
                     crate::update::ExportGateVerdict::Pass,
-                    "identical route already advertised — peer is in sync, no re-announcement"
+                    "identical route already advertised — Adj-RIB-Out in sync, no \
+                     re-announcement; remote acceptance is not observable"
                         .to_string(),
                 );
             }

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -707,7 +707,8 @@ impl RibManager {
                     "adj_rib_out",
                     "already_advertised",
                     crate::update::ExportGateVerdict::Pass,
-                    "identical route already advertised — peer is in sync, no re-announcement"
+                    "identical route already advertised — Adj-RIB-Out in sync, no \
+                     re-announcement; remote acceptance is not observable"
                         .to_string(),
                 );
             }

--- a/crates/rib/src/manager/tests/export_explain.rs
+++ b/crates/rib/src/manager/tests/export_explain.rs
@@ -246,9 +246,19 @@ async fn add_path_source_explain_separates_inbound_identity_from_outbound_rank_a
     assert_eq!(explain.route_peer, Some(IpAddr::V4(source_b)));
     assert_eq!(explain.path_id, 2, "outbound rank is not the inbound ID");
     assert!(explain.already_advertised);
+    let terminal = explain.gates.last().expect("terminal adj_rib_out gate");
     assert_eq!(
-        explain.gates.last().map(|step| (step.gate, step.code)),
-        Some(("adj_rib_out", "already_advertised"))
+        (terminal.gate, terminal.code),
+        ("adj_rib_out", "already_advertised")
+    );
+    // The pass describes send-side state only: it must not claim the
+    // remote holds the route (BGP carries no acceptance signal).
+    assert!(
+        terminal
+            .detail
+            .contains("remote acceptance is not observable"),
+        "already_advertised detail overclaims remote state: {}",
+        terminal.detail
     );
 
     let legacy = query_explain_advertised_route(&tx, target, Prefix::V4(prefix)).await;

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -971,6 +971,7 @@ pub struct ExplainAdvertisedRoute {
     /// already sits in the advertised state (Adj-RIB-Out / group
     /// table), so the live path suppresses re-announcement. `false` on
     /// `Advertise` means the staged route differs and would be sent.
+    /// Local send-side state only — remote acceptance is not observable.
     pub already_advertised: bool,
     /// Route Distinguisher for a VPN explain; `None` for unicast.
     pub rd: Option<rustbgpd_wire::RouteDistinguisher>,

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1301,6 +1301,12 @@ more checks are red. A doctor run against a down daemon still produces a
 bundle (system facts + crash reports) and the manifest records which
 sections are missing.
 
+Without `--output` the bundle is written to the first writable of: the
+working directory, `runtime_state_dir`, the temp directory — so the
+container image, whose working directory is not writable by its nonroot
+user, still produces one. The final path is printed on the last line
+(`bundle` in `--json`). `--output <FILE>` overrides the choice.
+
 For live inspection, `rbgp neighbor <address>` reports the effective protected
 transport and an explicit TCP-AO health state. Direct dynamic-prefix sessions
 derive TCP-AO identity from their validated accepted socket rather than a
@@ -1913,7 +1919,11 @@ client/cluster rules) -> `family` (peer negotiated the AFI/SAFI) ->
 RFC 5291 filter) -> `export_policy` (per-chain verdict, labeled
 `policy:term` for `.rpol` members) -> `adj_rib_out` (diff against the
 advertised state: `staged_announce` = would send, `already_advertised`
-= identical route already advertised, peer in sync). The VPN ladder
+= identical route already advertised, Adj-RIB-Out in sync). Every
+`adj_rib_out` verdict describes local send-side state only: BGP has no
+acceptance signal, so an `already_advertised` pass never means the peer
+holds the route — a peer that treats the updates as withdrawn (RFC 7606)
+stays Established with none of them. The VPN ladder
 follows the live VPN staging order and adds `rt_membership`
 (RFC 4684); the labeled-unicast ladder follows the live labeled staging
 order (`family` first, no `rt_membership`/`orf`). A family still held by

--- a/docs/cookbook/route-server-migration.md
+++ b/docs/cookbook/route-server-migration.md
@@ -105,9 +105,22 @@ max_prefixes = 50000
 
 Notes:
 
-- FRR peers receiving transparent route-server paths usually need
-  `no enforce-first-as` on the member side because the member AS is not first in
-  reflected AS_PATHs.
+- FRR peers receiving transparent route-server paths need first-AS
+  enforcement relaxed on the member side, because the route server's AS is not
+  first in the AS_PATHs it forwards. The working form is **per-neighbor**:
+
+  ```frr
+  ! in the member's own FRR config, once per route-server neighbor
+  no neighbor 198.51.100.1 enforce-first-as
+  ```
+
+  The global `no bgp enforce-first-as` alone is **insufficient** in FRR 10.3.1.
+  Getting this wrong fails silently: FRR treats the offending updates as
+  withdrawn (RFC 7606) instead of resetting, so the session stays Established,
+  the member holds zero routes, and neither side logs an error. `rbgp rib
+  advertised` on the route server still shows the routes sent — it reports
+  local send-side state, not what the member accepted. Check `PfxRcd` on the
+  member.
 - FRR route-maps map naturally to TOML policy definitions for simple match/set
   chains, or to `.rpol` for reusable hygiene logic. The M80 receipt proves
   route-for-route parity between `.rpol` and FRR route-maps for the core

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -387,8 +387,22 @@ Transparency broke. Confirm `route_server_client = true` on the member —
 without it, the route server prepends its own ASN and rewrites NEXT_HOP
 like an ordinary eBGP speaker. Some stacks also reject the transparent
 first-AS (the neighbor AS isn't first in the path); disable first-AS
-enforcement on the *member* side (FRR `no enforce-first-as`, BIRD
-`enforce first as off`).
+enforcement on the *member* side. On FRR this must be **per-neighbor**,
+once per route-server neighbor in the member's own config —
+`no neighbor 198.51.100.1 enforce-first-as`. The global
+`no bgp enforce-first-as` alone is **insufficient** in FRR 10.3.1. BIRD
+uses `enforce first as off`.
+
+**A member is Established but receives nothing, and the route server
+says it sent the routes.** This is the silent form of the first-AS
+rejection above: FRR treats each offending update as withdrawn
+(RFC 7606) rather than resetting the session, so the session stays up,
+the member's `PfxRcd` stays 0, and neither side logs an error. `rbgp rib
+advertised` and the `already_advertised` explain gate report local
+send-side state — BGP carries no acceptance signal, so neither can see
+the member discarding them. Confirm the per-neighbor
+`no neighbor <route-server> enforce-first-as` is present on the member
+and re-check its received count.
 
 **A member leaks transit routes back into the fabric.** The RFC 9234
 role guards this: with `role = "route_server"` the route server attaches

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -197,7 +197,7 @@ load_on_demand = true
 | Field | Adapter value | Limitation |
 |---|---|---|
 | status `last_reconfig` | `""` | Reconfiguration time is not tracked. |
-| protocol `routes.preferred` | `0` | Sentinel only; preferred-route count is not exposed. |
+| protocol `routes.preferred` | omitted | No per-peer Loc-RIB best count exists on the gRPC surface; deriving one would page the whole Loc-RIB on every poll. The field is left out rather than served as a wrong `0` — a client that defaults absent fields still reads zero, but nothing here asserts it. |
 | route `interface` | `""` | Interface identity is not exposed for these routes. |
 | route `metric` | `0` | Sentinel only; this is not an IGP metric. |
 | route `primary` | `false` | Sentinel only; primary-route status is not exposed. |

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -271,10 +271,17 @@ async fn protocols_bgp(State(state): State<AppState>) -> Result<Json<Value>, Sta
                 "routes": {
                     // Same sources the in-daemon server used: current
                     // Adj-RIB-In count and current advertised count.
+                    //
+                    // `preferred` is deliberately absent, not zero: the
+                    // gRPC surface has no per-peer Loc-RIB best count, and
+                    // deriving one means paging the whole Loc-RIB
+                    // (`ListBestRoutes`, tallying `Route.peer_address`) on
+                    // every poll of this endpoint — a full-table walk per
+                    // refresh at IXP scale. Serve it here once the daemon
+                    // exposes the count on `NeighborState`.
                     "imported": n.prefixes_received,
                     "filtered": filtered,
-                    "exported": n.prefixes_sent,
-                    "preferred": 0
+                    "exported": n.prefixes_sent
                 }
             }),
         );

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -1913,7 +1913,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (doctor)
 _arguments "${_arguments_options[@]}" : \
-'--output=[Output tarball path. Defaults to \`rustbgpd-doctor-<unix-seconds>.tar.gz\`]:FILE:_files' \
+'--output=[Output tarball path. Defaults to \`rustbgpd-doctor-<unix-seconds>.tar.gz\` in the first writable of\: the working directory, the daemon'\''s runtime state dir, the temp dir]:FILE:_files' \
 '--log-file=[Daemon log file to tail (last 1000 lines) into the bundle. Without it the manifest records that the daemon logs to stdout/journald]:FILE:_files' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -760,7 +760,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand health" -l token-file -d 'Bear
 complete -c rbgp -n "__fish_rbgp_using_subcommand health" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand health" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand health" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l output -d 'Output tarball path. Defaults to `rustbgpd-doctor-<unix-seconds>.tar.gz`' -r -F
+complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l output -d 'Output tarball path. Defaults to `rustbgpd-doctor-<unix-seconds>.tar.gz` in the first writable of: the working directory, the daemon\'s runtime state dir, the temp dir' -r -F
 complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l log-file -d 'Daemon log file to tail (last 1000 lines) into the bundle. Without it the manifest records that the daemon logs to stdout/journald' -r -F
 complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -1906,7 +1906,10 @@ message ExplainAdvertisedRouteResponse {
   optional uint64 update_group_id = 14;
   // True when the decision is ADVERTISE but an identical route already
   // sits in the advertised state (Adj-RIB-Out / group table), so the
-  // live path suppresses re-announcement (peer is in sync).
+  // live path suppresses re-announcement. This is local send-side state
+  // only: BGP carries no acceptance signal, so it never means the peer
+  // holds the route (a peer treating updates as withdrawn per RFC 7606
+  // stays Established with none of them).
   bool already_advertised = 15;
   // Route Distinguisher echoed back for a VPN explain; empty for
   // unicast.


### PR DESCRIPTION
Four independent defects an operator hits in the first hour, found by
running the software. Each one failed quietly: nothing errored, and every
rustbgpd surface reported healthy.

## `rbgp doctor` could not write its bundle in the container image

The lean image's working directory is `/`, which its nonroot user cannot
write, and doctor defaulted the bundle to
`./rustbgpd-doctor-<ts>.tar.gz` — so the tool the README and QUICKSTART
name for bug reports exited 1 with a bare `Permission denied (os error
13)`, naming neither the file, the path, nor the flag that fixes it.

Without `--output` the bundle now goes to the first writable of: the
working directory (unchanged wherever it already worked), the daemon's
`runtime_state_dir`, the temp directory. The state dir is preferred over
the temp dir because the operator already has it mounted and it survives
a container restart; the image itself is left alone. Independently, a
bundle that still cannot be written now names the target path and points
at `--output`, and the same bare-errno shape on `--token-file` now names
the file it could not read.

## `already_advertised` explain claimed the peer was in sync

The gate read `identical route already advertised — peer is in sync`.
rustbgpd knows what it advertised; BGP carries no acceptance signal, so
it cannot know what the remote accepted. A peer that treats every UPDATE
as withdrawn per RFC 7606 stays Established holding zero routes while
that line reads "in sync" — which is exactly the FRR case below. The
unicast, VPN, and labeled-unicast rungs, the `rbgp rib advertised
--explain` summary line, the proto field comment, and the Rust field
docs now scope the claim to local Adj-RIB-Out state and say that remote
acceptance is not observable. The rib explain test pins the anti-
overclaim alongside its existing code/flag assertions.

## Cookbooks gave an FRR fix that does not work

FRR 10.x enables `enforce-first-as` by default and rejects RFC
7947-transparent route-server updates. Both `docs/cookbook/route-server.md`
and `docs/cookbook/route-server-migration.md` gave the relaxation without
saying it must be per-neighbor; the global `no bgp enforce-first-as` alone
is insufficient in FRR 10.3.1, which `docs/INTEROP.md` and the M19/M83
interop configs already recorded. Both pages now give
`no neighbor <route-server> enforce-first-as` and state the failure mode:
FRR treat-as-withdraws rather than resetting, so the session stays
Established, the member holds zero routes, and neither side logs an
error. Those two cookbook sites were the only operator-facing occurrences
of the global form.

## Alice-LG adapter served a fabricated preferred-route count

`examples/birdwatcher-adapter` emitted an unconditional `"preferred": 0`
on `/protocols/bgp`, so a looking glass showed every member with zero
preferred routes regardless of the Loc-RIB. The gRPC surface has no
per-peer Loc-RIB best count: `ListBestRoutes` is global (it ignores
`neighbor_address`) and `NeighborState` does not carry one, so deriving
the number means paging the entire Loc-RIB and tallying
`Route.peer_address` on every poll of an endpoint Alice-LG hits per
refresh — a full-table walk per poll at IXP scale. The field is omitted
rather than served wrong, and the README records the omission and the
condition that would let it be served. `imported`, `filtered`, and
`exported` are unchanged.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --
-D warnings`, `cargo test --workspace --no-fail-fast`, and `cargo doc
--workspace --no-deps` all exit 0. Checked-in shell completions were
regenerated for the changed `--output` help text.
