### PR TITLE
Normalize the peer metric label to the bare neighbor address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,62 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   not ask for, the import report states that it was added, why, what it does to
   the sessions below, and that it is startup-only; the emitted config carries
   the same explanation as a comment, and deleting the line restores permit-all.
+- **BREAKING (metrics): the `peer` label is now the bare neighbor address on
+  every metric family.** Metric labels are a public API, and this one had two
+  incompatible formats — sometimes within a single family. Session-owned
+  series labelled `peer` with the transport endpoint (`192.0.2.1:179`,
+  `[2001:db8::1]:179`) while RIB-, policy-, BFD-, and BMP-owned series used the
+  bare configured address (`192.0.2.1`, `2001:db8::1`). `bgp_policy_routes_total`
+  carried both: its `direction="import"` series came from the session and its
+  `direction="export"` series from the RIB. The consequence was silent, because
+  Prometheus reports no error for a query that matches nothing:
+  `sum by (peer) (bgp_policy_routes_total)` returned two series per peer, and
+  any `by (peer)` join across the two groups returned empty — so an alert built
+  that way never fired.
+
+  Every emission site now uses the bare address, produced by one helper
+  (`rustbgpd_telemetry::peer_label`). The port carried nothing joinable: it was
+  the *configured* endpoint, not the observed source port, and neighbor
+  identity is already unique by address (configuration validation rejects the
+  same IPv6 link-local address on two interfaces), so no peer needed it to be
+  told apart. The structured-log `peer` field on session events follows the
+  same change, and now matches the rest of the daemon's logs.
+
+  **Series that changed format** — all previously `addr:port`, now bare
+  address: `bgp_session_state_transitions_total`, `bgp_session_flaps_total`,
+  `bgp_session_established_total`, `bgp_fsm_stale_timer_events_total`,
+  `bgp_messages_sent_total`, `bgp_messages_received_total`,
+  `bgp_notifications_sent_total`, `bgp_notifications_received_total`,
+  `bgp_peer_outbound_queue_depth`, `bgp_peer_slow`,
+  `bgp_rejected_routes_retained`, `bgp_max_prefix_usage`,
+  `bgp_max_prefix_limit`, `bgp_max_prefix_headroom`,
+  `bgp_max_prefix_exceeded_total`, `bgp_update_malformed_total`,
+  `bgp_otc_routes_blocked_total`, `bgp_role_mismatch_total`,
+  `bgp_as_path_loop_detected_total`, `bgp_bgpls_nlri_discarded_total`,
+  `bgp_rr_loop_detected_total`,
+  `bgp_inbound_rib_backpressure_total`,
+  `bgp_hold_timer_rearmed_pending_input_total`,
+  `bgp_send_hold_expirations_total`, `bmp_source_drops_total`, and the
+  `direction="import"` half of `bgp_policy_routes_total`. Every other
+  `peer`-labelled family already used the bare address and is unchanged.
+
+  **What operator PromQL needs:** drop any port-stripping `label_replace` from
+  cross-family joins, and rewrite selectors that pinned an endpoint —
+  `bgp_peer_slow{peer="192.0.2.1:179"}` becomes
+  `bgp_peer_slow{peer="192.0.2.1"}`, and `peer=~"192\\.0\\.2\\.1:.*"` becomes an
+  exact match. Recording rules and dashboards keyed on the old values see the
+  old series go stale and new ones appear; counters restart from zero, which
+  `rate()` and `increase()` handle as an ordinary reset. The shipped dashboard
+  and alert pack are updated: the dashboard's two peer selectors
+  (`$peer` endpoint / `$neighbor` address) collapse into one `$peer`, which
+  also fixes the RIB, GR, and BFD panels that returned no data whenever a
+  specific peer was selected, and `BgpPeerAdjRibInEmpty` joins directly instead
+  of rewriting the label. `rbgp doctor`'s slow-peer remediation now prints a
+  selector that resolves. No transitional dual-emit is provided: emitting both
+  formats would double the per-peer series count of 26 families for the whole
+  transition window, and it would preserve the exact failure being fixed —
+  `sum by (peer)` would still return two series per peer, so a dashboard that
+  looked correct during the overlap would break at removal instead of now.
 
 - **Unknown FlowSpec component types keep their hard rejection, now with a
   conformance-citing diagnostic.** *No decode-acceptance change: input that

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -624,7 +624,7 @@ fn peer_checks(
             name: format!("peer.{address}.slow_peer"),
             status: CheckStatus::Warn,
             detail: format!(
-                "peer {address} is flagged slow: outbound queue persistently backlogged; inspect bgp_peer_outbound_queue_depth for this peer's socket and enable slow_peer_isolation for chronic single-peer lag"
+                "peer {address} is flagged slow: outbound queue persistently backlogged; inspect bgp_peer_outbound_queue_depth{{peer=\"{address}\"}} and enable slow_peer_isolation for chronic single-peer lag"
             ),
         });
     }
@@ -2036,13 +2036,12 @@ tcp_ao = { key = "<redacted>", send_id = 1, recv_id = 2, algorithm = "hmac(sha25
         assert!(checks[0].status == CheckStatus::Ok);
         assert_eq!(checks[1].name, "peer.10.0.0.2.slow_peer");
         assert!(checks[1].status == CheckStatus::Warn);
-        assert!(checks[1].detail.contains("bgp_peer_outbound_queue_depth"));
-        assert!(checks[1].detail.contains("for this peer's socket"));
         assert!(checks[1].detail.contains("slow_peer_isolation"));
-        // The metric's `peer` label is a SocketAddr, so a bare-IP selector is
-        // misleading and may match nothing. Reintroducing it makes this red.
+        // The `peer` label is the bare neighbor address across every
+        // family, so the remediation can hand over a selector that
+        // actually resolves. Dropping the label makes this red.
         assert!(
-            !checks[1]
+            checks[1]
                 .detail
                 .contains(r#"bgp_peer_outbound_queue_depth{peer="10.0.0.2"}"#)
         );
@@ -2476,9 +2475,7 @@ paths = ["x"]
             let detail = check["detail"].as_str().unwrap();
             check["name"] == "peer.10.0.0.2.slow_peer"
                 && check["status"] == "warn"
-                && detail.contains("bgp_peer_outbound_queue_depth")
-                && detail.contains("for this peer's socket")
-                && !detail.contains(r#"{peer="10.0.0.2"}"#)
+                && detail.contains(r#"bgp_peer_outbound_queue_depth{peer="10.0.0.2"}"#)
         }));
     }
 

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -7,7 +7,10 @@
 //! Most label values are plain strings — callers pass `state.as_str()`,
 //! `"keepalive"`, etc. Reason labels covered by the
 //! [`reason_labels`] contract are typed instead, so the canonical
-//! vocabulary is enforced at compile time.
+//! vocabulary is enforced at compile time. The `peer` label has one
+//! canonical form — the bare neighbor address, built by
+//! [`peer_label`] — so `by (peer)` aggregations and cross-family joins
+//! behave.
 
 #![deny(unsafe_code)]
 #![deny(clippy::all)]
@@ -18,5 +21,5 @@ pub mod metrics;
 pub mod reason_labels;
 
 pub use logging::{LoggingError, init_logging, reload_per_peer_directives};
-pub use metrics::BgpMetrics;
+pub use metrics::{BgpMetrics, non_canonical_peer_labels, peer_label};
 pub use reason_labels::{NextHopOwnershipBlockReason, OtcBlockReason, RrLoopReason};

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -1,12 +1,59 @@
 //! Prometheus metrics for session, RIB, policy, EVPN, GR, and RPKI counters/gauges.
 
 use std::cell::RefCell;
+use std::net::IpAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use prometheus::{
     HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry,
 };
+
+/// Canonical `peer` label value: the neighbor's bare IP address.
+///
+/// **Every** `peer`-labeled series exported by this crate uses this one
+/// form — `"192.0.2.1"`, `"2001:db8::1"` — so that `by (peer)`
+/// aggregations return one series per peer and joins across metric
+/// families (session ⇄ RIB ⇄ policy) match. Producing the label any
+/// other way, in particular stringifying a `SocketAddr` and picking up
+/// the `:179` endpoint port, splits every such query silently:
+/// Prometheus reports no error for a join that matches nothing.
+///
+/// Route this through here rather than calling `to_string()` at the
+/// emission site, so there is one place to grep and one place to
+/// change. [`non_canonical_peer_labels`] enforces the invariant over a
+/// live registry.
+#[must_use]
+pub fn peer_label(addr: IpAddr) -> String {
+    addr.to_string()
+}
+
+/// Every `peer` label value in `registry` that is not the canonical
+/// [`peer_label`] form, as `(family_name, peer_value)` pairs.
+///
+/// An empty result means the invariant holds. Exposed (not test-only)
+/// so crates that drive real sessions can assert it against the
+/// registry those sessions actually wrote to.
+#[must_use]
+pub fn non_canonical_peer_labels(registry: &Registry) -> Vec<(String, String)> {
+    let mut offenders = Vec::new();
+    for family in registry.gather() {
+        for metric in family.get_metric() {
+            for label in metric.get_label() {
+                if label.name() != "peer" {
+                    continue;
+                }
+                let value = label.value();
+                if value.parse::<IpAddr>().is_err() {
+                    offenders.push((family.name().to_owned(), value.to_owned()));
+                }
+            }
+        }
+    }
+    offenders.sort_unstable();
+    offenders.dedup();
+    offenders
+}
 
 /// Monotonic id distinguishing `BgpMetrics` instances (tests create
 /// several on one thread). Clones share the id — they share the
@@ -75,6 +122,11 @@ thread_local! {
 /// Label values are plain strings — this crate has no dependency on
 /// `rustbgpd-fsm` or `rustbgpd-wire`.  Callers pass `state.as_str()`,
 /// `"keepalive"`, etc.
+///
+/// The `peer` label is the one exception: it has a single canonical
+/// form, produced by [`peer_label`] and enforced by
+/// [`non_canonical_peer_labels`]. Never stringify a `SocketAddr` into
+/// it.
 ///
 /// **Adding a `peer`-labeled Vec metric?** Add it to the reap list in
 /// [`Self::reap_peer_series`] too, so the series are removed when the
@@ -2319,9 +2371,9 @@ impl BgpMetrics {
     /// re-added, its counters restart from zero, which `rate()` /
     /// `increase()` handle as an ordinary counter reset.
     ///
-    /// Matching is exact on the label string. Callers that emit the
-    /// peer under more than one formatting (e.g. bare address vs
-    /// address:port) must call this once per form.
+    /// Matching is exact on the label string, so `peer` must be the
+    /// canonical [`peer_label`] form — the same one every emission site
+    /// uses. One call reaps the peer everywhere.
     ///
     /// Reaping a peer with no live series is a no-op.
     ///
@@ -3272,7 +3324,7 @@ impl BgpMetrics {
     }
 
     /// Materialize zero-valued malformed-UPDATE children for every canonical
-    /// RFC 7606 disposition at one transport endpoint.
+    /// RFC 7606 disposition for one peer.
     pub fn initialize_update_malformed_series(&self, peer: &str) {
         for disposition in crate::reason_labels::MalformedUpdateDisposition::ALL {
             self.update_malformed
@@ -4191,6 +4243,8 @@ mod jemalloc_stats {
 
 #[cfg(test)]
 mod tests {
+    use std::net::Ipv4Addr;
+
     use prometheus::Encoder;
 
     use super::*;
@@ -5633,38 +5687,24 @@ mod tests {
     #[test]
     fn max_prefix_capacity_keeps_unlimited_distinct_from_zero() {
         let m = BgpMetrics::new();
-        let peer = "10.0.0.1:179";
+        let peer = "10.0.0.1";
 
         m.set_max_prefix_capacity(peer, "aggregate", 80, Some(100));
         m.set_max_prefix_capacity(peer, "ipv4_unicast", 12, None);
 
         let text = gather_text(&m);
-        assert!(text.contains(r#"bgp_max_prefix_usage{peer="10.0.0.1:179",scope="aggregate"} 80"#));
-        assert!(
-            text.contains(r#"bgp_max_prefix_limit{peer="10.0.0.1:179",scope="aggregate"} 100"#)
-        );
-        assert!(
-            text.contains(r#"bgp_max_prefix_headroom{peer="10.0.0.1:179",scope="aggregate"} 20"#)
-        );
-        assert!(
-            text.contains(r#"bgp_max_prefix_usage{peer="10.0.0.1:179",scope="ipv4_unicast"} 12"#)
-        );
-        assert!(
-            !text.contains(r#"bgp_max_prefix_limit{peer="10.0.0.1:179",scope="ipv4_unicast"}"#)
-        );
-        assert!(
-            !text.contains(r#"bgp_max_prefix_headroom{peer="10.0.0.1:179",scope="ipv4_unicast"}"#)
-        );
+        assert!(text.contains(r#"bgp_max_prefix_usage{peer="10.0.0.1",scope="aggregate"} 80"#));
+        assert!(text.contains(r#"bgp_max_prefix_limit{peer="10.0.0.1",scope="aggregate"} 100"#));
+        assert!(text.contains(r#"bgp_max_prefix_headroom{peer="10.0.0.1",scope="aggregate"} 20"#));
+        assert!(text.contains(r#"bgp_max_prefix_usage{peer="10.0.0.1",scope="ipv4_unicast"} 12"#));
+        assert!(!text.contains(r#"bgp_max_prefix_limit{peer="10.0.0.1",scope="ipv4_unicast"}"#));
+        assert!(!text.contains(r#"bgp_max_prefix_headroom{peer="10.0.0.1",scope="ipv4_unicast"}"#));
 
         m.set_max_prefix_capacity(peer, "aggregate", 101, None);
         let text = gather_text(&m);
-        assert!(
-            text.contains(r#"bgp_max_prefix_usage{peer="10.0.0.1:179",scope="aggregate"} 101"#)
-        );
-        assert!(!text.contains(r#"bgp_max_prefix_limit{peer="10.0.0.1:179",scope="aggregate"}"#));
-        assert!(
-            !text.contains(r#"bgp_max_prefix_headroom{peer="10.0.0.1:179",scope="aggregate"}"#)
-        );
+        assert!(text.contains(r#"bgp_max_prefix_usage{peer="10.0.0.1",scope="aggregate"} 101"#));
+        assert!(!text.contains(r#"bgp_max_prefix_limit{peer="10.0.0.1",scope="aggregate"}"#));
+        assert!(!text.contains(r#"bgp_max_prefix_headroom{peer="10.0.0.1",scope="aggregate"}"#));
     }
 
     /// Load-bearing session-reap proof: replacing the narrow reap with a zero
@@ -5673,7 +5713,7 @@ mod tests {
     #[test]
     fn max_prefix_capacity_reap_spares_peer_history() {
         let m = BgpMetrics::new();
-        let peer = "10.0.0.1:179";
+        let peer = "10.0.0.1";
         m.set_max_prefix_capacity(peer, "aggregate", 80, Some(100));
         m.record_max_prefix_exceeded(peer);
 
@@ -5683,7 +5723,7 @@ mod tests {
         assert!(!text.contains("bgp_max_prefix_usage"));
         assert!(!text.contains("bgp_max_prefix_limit"));
         assert!(!text.contains("bgp_max_prefix_headroom"));
-        assert!(text.contains(r#"bgp_max_prefix_exceeded_total{peer="10.0.0.1:179"} 1"#));
+        assert!(text.contains(r#"bgp_max_prefix_exceeded_total{peer="10.0.0.1"} 1"#));
     }
 
     /// ADR-0113: a family that becomes unlimited must DROP its numeric
@@ -5840,5 +5880,152 @@ mod tests {
         ] {
             assert!(text.contains(name), "{name} missing from scrape:\n{text}");
         }
+    }
+
+    // ── `peer` label-format invariant ──────────────────────────────
+    //
+    // Metric labels are a public API. A `peer` label emitted in two
+    // formats splits `sum by (peer)` into two series per peer and makes
+    // every `by (peer)` join across the two groups return empty —
+    // silently, because Prometheus raises no error for a join that
+    // matches nothing. These tests pin the one canonical format across
+    // the whole peer-labeled surface rather than spot-checking it.
+
+    /// Names of every gathered family carrying at least one `peer`
+    /// label, sorted and deduplicated.
+    fn peer_labeled_families(m: &BgpMetrics) -> Vec<String> {
+        let mut names: Vec<String> = m
+            .registry()
+            .gather()
+            .into_iter()
+            .filter(|family| {
+                family
+                    .get_metric()
+                    .iter()
+                    .any(|metric| metric.get_label().iter().any(|l| l.name() == "peer"))
+            })
+            .map(|family| family.name().to_owned())
+            .collect();
+        names.sort();
+        names.dedup();
+        names
+    }
+
+    /// The complete `peer`-labeled surface, as emitted by
+    /// `populate_all_peer_families`.
+    ///
+    /// Adding a `peer`-labeled family means adding it here, to
+    /// `populate_all_peer_families`, and to
+    /// [`BgpMetrics::reap_peer_series`] — the three are cross-checked
+    /// by the tests below.
+    // ponytail: a family declared but never recorded is invisible to
+    // `gather()`, so no runtime check can catch one that is added and
+    // left unpopulated; this list plus the struct doc comment is the
+    // practical ceiling.
+    const PEER_LABELED_FAMILIES: [&str; 49] = [
+        "bfd_session_flaps_total",
+        "bfd_session_up",
+        "bgp_as_path_loop_detected_total",
+        "bgp_bgpls_nlri_discarded_total",
+        "bgp_exact_export_rejections_total",
+        "bgp_fsm_stale_timer_events_total",
+        "bgp_gr_active_peers",
+        "bgp_gr_stale_routes",
+        "bgp_gr_timer_expired_total",
+        "bgp_hold_timer_rearmed_pending_input_total",
+        "bgp_inbound_rib_backpressure_total",
+        "bgp_max_prefix_exceeded_total",
+        "bgp_max_prefix_headroom",
+        "bgp_max_prefix_limit",
+        "bgp_max_prefix_usage",
+        "bgp_messages_received_total",
+        "bgp_messages_sent_total",
+        "bgp_notifications_received_total",
+        "bgp_notifications_sent_total",
+        "bgp_otc_routes_blocked_total",
+        "bgp_outbound_prefix_blocked_total",
+        "bgp_outbound_prefix_blocking",
+        "bgp_outbound_prefix_headroom",
+        "bgp_outbound_prefix_limit",
+        "bgp_outbound_prefix_usage",
+        "bgp_outbound_route_drops_total",
+        "bgp_peer_outbound_queue_depth",
+        "bgp_peer_slow",
+        "bgp_peer_update_group",
+        "bgp_policy_routes_total",
+        "bgp_rejected_routes_retained",
+        "bgp_rfc8212_missing_export_policy",
+        "bgp_rfc8212_missing_import_policy",
+        "bgp_rib_adj_out_prefixes",
+        "bgp_rib_outbound_registration_failover_total",
+        "bgp_rib_outbound_registration_replaced_total",
+        "bgp_rib_prefixes",
+        "bgp_rib_stale_peer_down_ignored_total",
+        "bgp_rib_stale_session_message_ignored_total",
+        "bgp_role_mismatch_total",
+        "bgp_route_refresh_in_progress",
+        "bgp_route_refresh_stale_entries",
+        "bgp_rr_loop_detected_total",
+        "bgp_send_hold_expirations_total",
+        "bgp_session_established_total",
+        "bgp_session_flaps_total",
+        "bgp_session_state_transitions_total",
+        "bgp_update_malformed_total",
+        "bmp_source_drops_total",
+    ];
+
+    #[test]
+    fn peer_labeled_family_surface_matches_the_pinned_list() {
+        let m = BgpMetrics::with_registry(Registry::new());
+        populate_all_peer_families(&m, &peer_label(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))));
+
+        // Names, not just a count: the format assertion below is only
+        // as good as the set of families it walks, so pin that set.
+        assert_eq!(
+            peer_labeled_families(&m),
+            PEER_LABELED_FAMILIES,
+            "peer-labeled family surface drifted from the pinned list"
+        );
+    }
+
+    #[test]
+    fn every_peer_labeled_series_uses_the_canonical_bare_address() {
+        let m = BgpMetrics::with_registry(Registry::new());
+        for addr in [
+            IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            IpAddr::V6("2001:db8::1".parse().unwrap()),
+        ] {
+            populate_all_peer_families(&m, &peer_label(addr));
+        }
+
+        assert_eq!(
+            non_canonical_peer_labels(m.registry()),
+            Vec::<(String, String)>::new(),
+            "every peer label must be the bare address form built by peer_label()"
+        );
+    }
+
+    #[test]
+    fn non_canonical_peer_labels_rejects_the_transport_endpoint_form() {
+        // Negative control: the checker is worth nothing unless it
+        // fails on the `addr:port` format this normalization retired.
+        let m = BgpMetrics::with_registry(Registry::new());
+        m.record_message_sent("192.0.2.1:179", "update");
+        m.set_rib_prefixes("[2001:db8::1]:179", "all", 1);
+        m.set_rib_prefixes("192.0.2.1", "all", 1);
+
+        assert_eq!(
+            non_canonical_peer_labels(m.registry()),
+            vec![
+                (
+                    "bgp_messages_sent_total".to_owned(),
+                    "192.0.2.1:179".to_owned()
+                ),
+                (
+                    "bgp_rib_prefixes".to_owned(),
+                    "[2001:db8::1]:179".to_owned()
+                ),
+            ]
+        );
     }
 }

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -159,6 +159,11 @@ pub(crate) struct PeerSession {
     metrics: BgpMetrics,
     commands: mpsc::Receiver<PeerCommand>,
     rib_tx: mpsc::Sender<RibUpdate>,
+    /// Canonical `peer` metric/log label — the bare neighbor address
+    /// from [`rustbgpd_telemetry::peer_label`], never the transport
+    /// endpoint's `addr:port`. It must equal what the RIB manager and
+    /// the BFD runtime emit for the same peer, or `by (peer)` queries
+    /// split. Diagnostics only; nothing dials or compares against it.
     peer_label: String,
     peer_ip: IpAddr,
     /// Cached scope for IPv6 link-local next-hop recursion on static
@@ -544,18 +549,17 @@ fn configured_exact_export_family_label((afi, safi): (Afi, Safi)) -> Option<&'st
 fn initialize_route_safety_metric_series(
     config: &TransportConfig,
     metrics: &BgpMetrics,
-    neighbor_label: &str,
-    endpoint_label: &str,
+    peer_label: &str,
 ) {
     let families = config.peer.effective_families();
     metrics.initialize_exact_export_rejection_series(
-        neighbor_label,
+        peer_label,
         families
             .iter()
             .copied()
             .filter_map(configured_exact_export_family_label),
     );
-    metrics.initialize_update_malformed_series(endpoint_label);
+    metrics.initialize_update_malformed_series(peer_label);
 }
 
 /// Resolve next-hop for import policy modifications.
@@ -1001,9 +1005,9 @@ impl PeerSession {
         session_identity: SessionIdentity,
         tcp_ao_generation: crate::TcpAoRotationGeneration,
     ) -> Self {
-        let peer_label = config.remote_addr.to_string();
         let peer_ip = config.remote_addr.ip();
-        initialize_route_safety_metric_series(&config, &metrics, &peer_ip.to_string(), &peer_label);
+        let peer_label = rustbgpd_telemetry::peer_label(peer_ip);
+        initialize_route_safety_metric_series(&config, &metrics, &peer_label);
         let link_local_next_hop_scope = Self::link_local_next_hop_scope_from_config(&config);
         let fsm = Session::new(config.peer.clone());
         let explain_enabled = config.explain_enabled;
@@ -1147,9 +1151,9 @@ impl PeerSession {
         tcp_ao_selected_owner: Option<crate::listener::TcpAoSelectedOwner>,
         tcp_ao_generation: crate::TcpAoRotationGeneration,
     ) -> Self {
-        let peer_label = config.remote_addr.to_string();
         let peer_ip = config.remote_addr.ip();
-        initialize_route_safety_metric_series(&config, &metrics, &peer_ip.to_string(), &peer_label);
+        let peer_label = rustbgpd_telemetry::peer_label(peer_ip);
+        initialize_route_safety_metric_series(&config, &metrics, &peer_label);
         let link_local_next_hop_scope = Self::link_local_next_hop_scope_from_config(&config);
         let fsm = Session::new(config.peer.clone());
         let explain_enabled = config.explain_enabled;

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -149,7 +149,7 @@ fn outbound_constructor_materializes_route_safety_counter_children() {
     for disposition in ["attribute_discard", "treat_as_withdraw", "session_reset"] {
         assert_zero_counter_sample(
             &malformed,
-            &[("peer", "192.0.2.10:1179"), ("disposition", disposition)],
+            &[("peer", "192.0.2.10"), ("disposition", disposition)],
         );
     }
 }
@@ -213,7 +213,7 @@ async fn inbound_constructor_materializes_route_safety_counter_children() {
     for disposition in ["attribute_discard", "treat_as_withdraw", "session_reset"] {
         assert_zero_counter_sample(
             &malformed,
-            &[("peer", "192.0.2.20:2179"), ("disposition", disposition)],
+            &[("peer", "192.0.2.20"), ("disposition", disposition)],
         );
     }
 }
@@ -234,6 +234,46 @@ fn make_test_session_with_peer_config(peer_config: PeerConfig) -> PeerSession {
     PeerSession::new(
         config, metrics, cmd_rx, rib_tx, None, None, None, None, None, false,
     )
+}
+
+/// The `peer` metric/log label is the bare neighbor address, never the
+/// transport endpoint's `addr:port`.
+///
+/// Sessions are the only emitter that holds a `SocketAddr`, so this is
+/// where the split used to be introduced: session-owned families said
+/// `10.0.0.2:179` while RIB-owned families said `10.0.0.2`, and every
+/// `by (peer)` join across the two returned empty. A non-179 port here
+/// proves the port is dropped rather than merely absent.
+#[test]
+fn session_peer_label_is_the_bare_neighbor_address() {
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    let config = TransportConfig::new(peer_config, "10.0.0.2:29179".parse().unwrap());
+    let metrics = BgpMetrics::new();
+    let (_cmd_tx, cmd_rx) = mpsc::channel(8);
+    let (rib_tx, _rib_rx) = mpsc::channel(8);
+    let session = PeerSession::new(
+        config,
+        metrics.clone(),
+        cmd_rx,
+        rib_tx,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+    );
+
+    assert_eq!(session.peer_label, "10.0.0.2");
+
+    // Construction alone seeds the route-safety series; drive a
+    // session-owned counter too, then check the whole registry.
+    metrics.record_message_sent(&session.peer_label, "update");
+    assert_eq!(
+        rustbgpd_telemetry::non_canonical_peer_labels(metrics.registry()),
+        Vec::<(String, String)>::new()
+    );
 }
 
 fn tcp_ao_deletion_test_fixture() -> (PeerSession, crate::TcpAoSessionDeletion) {
@@ -17700,7 +17740,7 @@ async fn reject_retention_records_policy_deny_and_clears_on_withdraw() {
     assert_eq!(entry.reason, ImportRejectReason::PolicyReject);
     assert_eq!(entry.next_hop, Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))));
     assert_eq!(entry.as_path, "65002");
-    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 1);
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2"), 1);
 
     // Explicit withdrawal clears the retained reject — the question
     // "why isn't my route accepted?" is moot once the peer stops
@@ -17712,7 +17752,7 @@ async fn reject_retention_records_policy_deny_and_clears_on_withdraw() {
         session.rejected_routes.is_empty(),
         "withdrawal clears the retained reject"
     );
-    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 0);
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2"), 0);
 }
 
 /// LAN-472 pin: when a previously rejected identity is later accepted
@@ -17764,7 +17804,7 @@ async fn reject_retention_clears_when_route_is_later_accepted() {
         session.rejected_routes.is_empty(),
         "acceptance clears the stale reject entry"
     );
-    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 0);
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2"), 0);
 }
 
 /// A hostile UPDATE with maximal attributes — a long `AS_PATH` and
@@ -17880,7 +17920,7 @@ async fn reject_retention_cap_evicts_oldest_reject() {
         !keys.contains(&retention_key(first)),
         "oldest reject evicted under the cap"
     );
-    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 2);
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2"), 2);
 }
 
 /// LAN-472 pin: `[policy.reject_retention] enabled = false` records
@@ -17903,7 +17943,7 @@ async fn reject_retention_disabled_records_nothing_and_reports_disabled() {
     assert_eq!(session.import_policy_routes_denied, 1);
     assert_eq!(rejected_route_prototype_builds(&session), 0);
     assert!(session.rejected_routes.is_empty());
-    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 0);
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2"), 0);
 
     let (reply_tx, reply_rx) = oneshot::channel();
     let flow = session
@@ -17948,7 +17988,7 @@ async fn reject_retention_records_as_path_loop_reason() {
     assert_eq!(entries[0].0, retention_key(looped));
     assert_eq!(entries[0].1.reason, ImportRejectReason::AsPathLoop);
     assert_eq!(entries[0].1.as_path, "65002 65001");
-    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 1);
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2"), 1);
 }
 
 /// LAN-472 pin: an RFC 9234 OTC ingress drop (a pre-policy hygiene
@@ -18001,7 +18041,7 @@ async fn reject_retention_records_otc_ingress_drop_with_detail() {
             "the canonical OTC sub-reason token rides in the detail field"
         );
     }
-    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 2);
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2"), 2);
 }
 
 /// LAN-472 pin: the retention store is per-session diagnostic state —
@@ -18019,7 +18059,7 @@ async fn session_down_flushes_reject_retention_and_gauge() {
         .process_update(retention_update(&[denied], &[]))
         .await;
     assert_eq!(session.rejected_routes.len(), 1);
-    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 1);
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2"), 1);
 
     session.execute_actions(vec![Action::SessionDown]).await;
     assert!(
@@ -18027,7 +18067,7 @@ async fn session_down_flushes_reject_retention_and_gauge() {
         "reject retention must be flushed on SessionDown"
     );
     assert_eq!(
-        metrics.rejected_routes_retained("10.0.0.2:179"),
+        metrics.rejected_routes_retained("10.0.0.2"),
         0,
         "the gauge follows the flush"
     );

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -45,17 +45,13 @@ Template variables:
 
 - **Instance** — Prometheus `instance` label, populated from
   `bgp_rib_outbound_registered_peers` (always exported, even at zero).
-- **Peer endpoint** (`$peer`) — transport/session metrics identify a peer as
-  `addr:port`: `192.0.2.1:179` for IPv4 and `[2001:db8::1]:179` for IPv6.
-  This selector supports multiple values and All.
-- **Neighbor address** (`$neighbor`) — RIB update-group metrics identify the
-  same peer by its bare configured address: `192.0.2.1` or `2001:db8::1`.
-  It is independently populated from the always-seeded and reaped
-  `bgp_peer_update_group` gauge and also supports multiple values and All.
+- **Peer** (`$peer`) — the `peer` label, populated from
+  `bgp_session_state_transitions_total`. Every exported metric family
+  identifies a peer the same way, by its bare neighbor address
+  (`192.0.2.1`, `2001:db8::1`), so one selector drives every per-peer panel
+  and `by (peer)` joins across families match. Supports multiple values
+  and All.
 
-The dashboard intentionally preserves these native, distinct metric identities
-instead of hiding a label rewrite inside its selectors. To correlate a row
-manually, strip the IPv4 port or the IPv6 brackets and port as shown above.
 Per-peer series are reaped when a peer is deleted, so stale values age out after
 the next scrape.
 
@@ -64,7 +60,7 @@ the next scrape.
 A ready-to-load Prometheus alert-rule pack (session down/flapping,
 empty Adj-RIB-In, max-prefix near-limit and breach, empty RPKI VRP table, event-outbox
 degradation, update-group residue growth, stalled policy transition, a slow
-peer endpoint, actor polls above 200ms, exact-export rejection, malformed
+peer, actor polls above 200ms, exact-export rejection, malformed
 UPDATE disposition, selection-deferral timeout and ledger overflow, and daemon
 down) ships at
 [`examples/prometheus/rustbgpd-alerts.yml`](../examples/prometheus/rustbgpd-alerts.yml),
@@ -77,11 +73,9 @@ with per-rule unit tests in
 
 - Counters are plotted with `rate(...[$__rate_interval])`; gauges are
   plotted raw. Single-stats use last-not-null.
-- Exact-export rejection and malformed-UPDATE disposition rates preserve the
-  metrics' two native peer identities:
-  `bgp_exact_export_rejections_total` uses the bare configured neighbor and
-  therefore `$neighbor`, while `bgp_update_malformed_total` uses the transport
-  endpoint and therefore `$peer`. The selection-deferral state panel renders
+- Exact-export rejection and malformed-UPDATE disposition rates share the
+  `$peer` selector, like every other per-peer panel.
+  The selection-deferral state panel renders
   the raw `active` and `waiters` gauges as steps because their discrete changes
   are normal convergence activity. Only timeout and bounded-ledger-overflow
   counter increases alert; ordinary release reasons do not. Event-rate panels
@@ -91,8 +85,8 @@ with per-rule unit tests in
   session or selection-deferral family is created, before its producer actor
   runs. Prometheus still has to scrape that zero value to establish a sampled
   baseline, as with any pull-based counter.
-- Max-prefix capacity panels use the session endpoint label and the bounded
-  `aggregate`, `ipv4_unicast`, and `ipv6_unicast` scopes. Limit/headroom series
+- Max-prefix capacity panels use the bounded `aggregate`, `ipv4_unicast`,
+  and `ipv6_unicast` scopes. Limit/headroom series
   are intentionally absent for unlimited scopes, and every capacity series is
   absent while the session is down; no-data is therefore distinct from zero
   headroom.
@@ -100,7 +94,7 @@ with per-rule unit tests in
   at enqueue-batch and writer-drain boundaries. A short convergence spike is
   not itself a slow peer; `bgp_peer_slow` is the daemon's persistent 0/1 state.
 - The update-group table is discrete. Group IDs 0 and above are stable group
-  identities; `-1` legitimately means the neighbor is on the per-peer fallback
+  identities; `-1` legitimately means the peer is on the per-peer fallback
   path.
 - Policy-transition **in progress** is current state. **Last completed policy
   transition** is a retained terminal duration and does not count upward while
@@ -146,9 +140,9 @@ workflow path filters plus the real checker step. Its mutation proof makes
 each of these changes red: malformed JSON, a non-integer or duplicate ID,
 renaming, collapsing, resizing, or moving the required row; changing its type;
 moving or changing the type of a required panel; renaming any of the six
-route-safety metrics; swapping endpoint/bare-address selectors; changing
-either raw selection gauge to a rate; removing step rendering or `$neighbor`;
-dropping `instance` from a route-safety aggregation; weakening any of the six
+route-safety metrics; declaring a second template variable over the `peer`
+label; changing either raw selection gauge to a rate; removing step
+rendering; dropping `instance` from a route-safety aggregation; weakening any of the six
 label-rich legends; dropping any seeded-series `> 0` filter; or replacing the
 executable workflow step with only a comment.
 
@@ -160,8 +154,8 @@ moved to `0.5`, `> 0` becomes `>= 0`, raw counters replace `increase`, or
 Each route-safety counter fixture is red if its alert is deleted, its window is
 shortened from 15 to 5 minutes, `increase` becomes a raw counter, or `> 0`
 becomes `> 1`. Malformed UPDATE fixtures cover all three bounded RFC 7606
-dispositions and go red when the rule is restricted to one; exact-export keeps
-its bare-neighbor label, fires all four canonical rejection reasons, and spans
+dispositions and go red when the rule is restricted to one; exact-export fires
+all four canonical rejection reasons, and spans
 unicast plus EVPN, so the demonstrated `reason="message_too_long"` and
 `family="ipv4_unicast"` restrictions fail. Timeout and overflow fixtures each
 fire across multiple supported AFI/SAFI values, so their demonstrated

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -577,6 +577,16 @@ configured peers, zero Established peers, or zero routes can still be ready.
 Event-history, EVPN, FIB, and peer-count health are surfaced through their own
 metrics and status commands rather than as v1 readiness gates.
 
+### The `peer` label
+
+Every `peer`-labeled series — session, RIB, policy, max-prefix, BFD, BMP —
+identifies the peer the same way: by its bare neighbor address, `192.0.2.1`
+or `2001:db8::1`, never the transport endpoint's `addr:port`. `sum by (peer)`
+therefore returns one series per peer, and a `by (peer)` join across any two
+families matches. Neighbor identity is unique by address (config validation
+rejects the same IPv6 link-local address on two interfaces), so no peer needs
+the port to be told apart.
+
 ### Per-peer series lifecycle
 
 All `peer`-labeled series are removed when the peer is **deleted** — a static
@@ -1065,12 +1075,10 @@ The shipped Prometheus rule pack alerts only on actionable route-safety event
 counters, using a 15-minute increase window:
 
 - `BgpExactExportRejected` means a post-policy announcement was withheld before
-  Adj-RIB-Out commit. Its `peer` label is the bare configured neighbor address;
-  correlate `family` and `reason` with the daemon warning and
-  `rbgp rib --prefix <prefix> advertised <peer> --explain`.
+  Adj-RIB-Out commit; correlate `family` and `reason` with the daemon warning
+  and `rbgp rib --prefix <prefix> advertised <peer> --explain`.
 - `BgpMalformedUpdate` reports one or more malformed UPDATEs by their strongest
-  RFC 7606 `disposition`. Its `peer` label is the transport endpoint
-  (`addr:port` or `[IPv6]:port`).
+  RFC 7606 `disposition`.
 - `BgpSelectionDeferralTimedOut` means a family gate used its configured timer
   fallback before every planned-restart convergence signal arrived.
 - `BgpSelectionDeferralLedgerOverflow` means the bounded identity ledger fell

--- a/docs/grafana/rustbgpd-overview.json
+++ b/docs/grafana/rustbgpd-overview.json
@@ -45,29 +45,13 @@
       },
       {
         "name": "peer",
-        "label": "Peer endpoint",
+        "label": "Peer",
         "type": "query",
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
         },
         "query": "label_values(bgp_session_state_transitions_total{instance=~\"$instance\"}, peer)",
-        "current": {},
-        "includeAll": true,
-        "multi": true,
-        "allValue": ".*",
-        "refresh": 2,
-        "sort": 1
-      },
-      {
-        "name": "neighbor",
-        "label": "Neighbor address",
-        "type": "query",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "query": "label_values(bgp_peer_update_group{instance=~\"$instance\"}, peer)",
         "current": {},
         "includeAll": true,
         "multi": true,
@@ -2377,8 +2361,8 @@
     {
       "id": 47,
       "type": "timeseries",
-      "title": "Outbound queue by peer endpoint",
-      "description": "Absolute coalesced UPDATE frames buffered for each transport endpoint. A sustained backlog is stronger evidence than a short convergence burst.",
+      "title": "Outbound queue by peer",
+      "description": "Absolute coalesced UPDATE frames buffered for each peer. A sustained backlog is stronger evidence than a short convergence burst.",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "gridPos": { "h": 8, "w": 8, "x": 0, "y": 124 },
       "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 }, "overrides": [] },
@@ -2395,8 +2379,8 @@
     {
       "id": 48,
       "type": "timeseries",
-      "title": "Slow peer endpoints",
-      "description": "1 while an Established transport endpoint has persistently failed to drain its outbound queue; 0 after recovery or teardown.",
+      "title": "Slow peers",
+      "description": "1 while an Established peer has persistently failed to drain its outbound queue; 0 after recovery or teardown.",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "gridPos": { "h": 8, "w": 8, "x": 8, "y": 124 },
       "fieldConfig": { "defaults": { "unit": "short", "min": 0, "max": 1, "custom": { "lineInterpolation": "stepAfter" } }, "overrides": [] },
@@ -2413,8 +2397,8 @@
     {
       "id": 49,
       "type": "table",
-      "title": "Update group by neighbor address",
-      "description": "Current stable update-group ID for each bare configured neighbor address. -1 is a legitimate value: that neighbor uses the per-peer fallback path.",
+      "title": "Update group by peer",
+      "description": "Current stable update-group ID for each peer. -1 is a legitimate value: that peer uses the per-peer fallback path.",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "gridPos": { "h": 8, "w": 8, "x": 16, "y": 124 },
       "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 }, "overrides": [] },
@@ -2422,7 +2406,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "bgp_peer_update_group{instance=~\"$instance\",peer=~\"$neighbor\"}",
+          "expr": "bgp_peer_update_group{instance=~\"$instance\",peer=~\"$peer\"}",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -2544,7 +2528,7 @@
       "id": 56,
       "type": "timeseries",
       "title": "Max-prefix remaining headroom",
-      "description": "Saturating finite-limit headroom by live session endpoint and scope. No data means unlimited or disconnected, not zero headroom.",
+      "description": "Saturating finite-limit headroom by live peer and scope. No data means unlimited or disconnected, not zero headroom.",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 144 },
       "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "min": 0 }, "overrides": [] },
@@ -2570,7 +2554,7 @@
       "id": 58,
       "type": "timeseries",
       "title": "Export rejections / malformed UPDATEs",
-      "description": "Exact-export rejections use the bare configured neighbor address; malformed UPDATEs use the transport endpoint. Both are exceptional route-safety events, partitioned by their bounded reason labels.",
+      "description": "Exact-export rejections and malformed UPDATEs are both exceptional route-safety events, partitioned by their bounded reason labels.",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "gridPos": { "h": 8, "w": 8, "x": 0, "y": 153 },
       "fieldConfig": { "defaults": { "unit": "ops", "min": 0 }, "overrides": [] },
@@ -2578,7 +2562,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum by (instance, peer, family, reason) (rate(bgp_exact_export_rejections_total{instance=~\"$instance\",peer=~\"$neighbor\"}[$__rate_interval])) > 0",
+          "expr": "sum by (instance, peer, family, reason) (rate(bgp_exact_export_rejections_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval])) > 0",
           "legendFormat": "exact {{instance}} {{peer}} {{family}} {{reason}}",
           "refId": "A"
         },

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -15,8 +15,9 @@
 # `bgp_session_established_total` / `bgp_session_flaps_total`
 # (entering Established increments the former, leaving it increments
 # the latter, so an Established peer always reads established = flaps + 1).
-# Session-level metrics label peers as "<addr>:<port>" (the transport
-# remote address); RIB metrics use the bare configured neighbor address.
+# Every `peer` label is the bare neighbor address ("192.0.2.1",
+# "2001:db8::1") in every metric family, so `by (peer)` aggregations and
+# joins across families work without rewriting the label.
 #
 # Unit tests: rustbgpd-alerts_test.yml (`promtool test rules`).
 
@@ -65,17 +66,14 @@ groups:
             {{ $value | printf "%.0f" }} times in the last 15 minutes.
 
       - alert: BgpPeerSlow
-        # Session metrics label `peer` as the transport endpoint
-        # (IPv4 addr:port or bracketed-IPv6 addr:port), not the bare
-        # configured neighbor address used by RIB metrics.
         expr: bgp_peer_slow == 1
         for: 5m
         labels:
           severity: warning
         annotations:
-          summary: "BGP peer endpoint {{ $labels.peer }} is slow"
+          summary: "BGP peer {{ $labels.peer }} is slow"
           description: >-
-            The Established session endpoint {{ $labels.peer }} on
+            The Established session to {{ $labels.peer }} on
             {{ $labels.instance }} has remained slow for 5 minutes because
             its outbound coalesced-frame queue is not draining. Updates are
             still buffered; inspect bgp_peer_outbound_queue_depth and the
@@ -84,18 +82,13 @@ groups:
       - alert: BgpPeerAdjRibInEmpty
         # Established (established > flaps) but zero prefixes in
         # Adj-RIB-In across all families (afi_safi="all" is the
-        # aggregate series). Session metrics label peers as
-        # "<addr>:<port>" while RIB metrics use the bare neighbor
-        # address, so label_replace strips the transport port before
-        # the join. Expected for send-only peers — silence or drop
-        # this rule for those.
+        # aggregate series). Session and RIB metrics share one `peer`
+        # label format, so the join needs no label rewrite. Expected
+        # for send-only peers — silence or drop this rule for those.
         expr: >-
           bgp_rib_prefixes{afi_safi="all"} == 0
           and on (instance, peer)
-          label_replace(
-            bgp_session_established_total > bgp_session_flaps_total,
-            "peer", "$1", "peer", `\[?([^\]]+?)\]?:[0-9]+$`
-          )
+          (bgp_session_established_total > bgp_session_flaps_total)
         for: 10m
         labels:
           severity: warning
@@ -252,9 +245,8 @@ groups:
             denied.
 
       - alert: BgpExactExportRejected
-        # The counter is labeled with the bare configured neighbor address,
-        # not the transport endpoint used by session metrics. Every increment
-        # means an announcement was withheld before Adj-RIB-Out commit.
+        # Every increment means an announcement was withheld before
+        # Adj-RIB-Out commit.
         expr: increase(bgp_exact_export_rejections_total[15m]) > 0
         for: 0m
         labels:
@@ -272,9 +264,8 @@ groups:
             explain output.
 
       - alert: BgpMalformedUpdate
-        # The counter keeps the transport/session peer label (addr:port or
-        # [IPv6]:port). Every increment is one malformed UPDATE after its
-        # strongest RFC 7606 disposition has been selected.
+        # Every increment is one malformed UPDATE after its strongest
+        # RFC 7606 disposition has been selected.
         expr: increase(bgp_update_malformed_total[15m]) > 0
         for: 0m
         labels:
@@ -284,8 +275,8 @@ groups:
             Malformed UPDATE from {{ $labels.peer }}
             ({{ $labels.disposition }})
           description: >-
-            bgp_update_malformed_total for session endpoint
-            {{ $labels.peer }} on {{ $labels.instance }} increased by
+            bgp_update_malformed_total for peer {{ $labels.peer }}
+            on {{ $labels.instance }} increased by
             {{ $value | printf "%.0f" }} in the last 15 minutes. The
             strongest RFC 7606 disposition was {{ $labels.disposition }};
             inspect the peer and the daemon's malformed-UPDATE diagnostics.

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -42,38 +42,37 @@ tests:
                 unreachable, or `prometheus_addr` is no longer configured.
 
   # ── Session rules ─────────────────────────────────────────────
-  # Session-level series carry the transport label "<addr>:<port>";
-  # bgp_rib_prefixes carries the bare neighbor address (matching the
-  # daemon's real export — the rules' label_replace bridges the two).
+  # Every series carries the bare neighbor address in `peer`, matching
+  # the daemon's real export, so the session/RIB join needs no rewrite.
   # 192.0.2.1 — flapped down and stayed down (established == flaps)
   # 192.0.2.2 — Established, empty Adj-RIB-In
   # 192.0.2.3 — flapping continuously
   # 192.0.2.4 — Established with prefixes (healthy)
   - interval: 1m
     input_series:
-      - series: 'bgp_session_flaps_total{peer="192.0.2.1:179", instance="edge1:9179"}'
+      - series: 'bgp_session_flaps_total{peer="192.0.2.1", instance="edge1:9179"}'
         values: "1x30"
-      - series: 'bgp_session_established_total{peer="192.0.2.1:179", instance="edge1:9179"}'
+      - series: 'bgp_session_established_total{peer="192.0.2.1", instance="edge1:9179"}'
         values: "1x30"
-      - series: 'bgp_session_flaps_total{peer="192.0.2.2:179", instance="edge1:9179"}'
+      - series: 'bgp_session_flaps_total{peer="192.0.2.2", instance="edge1:9179"}'
         values: "0x30"
-      - series: 'bgp_session_established_total{peer="192.0.2.2:179", instance="edge1:9179"}'
+      - series: 'bgp_session_established_total{peer="192.0.2.2", instance="edge1:9179"}'
         values: "1x30"
       - series: 'bgp_rib_prefixes{peer="192.0.2.2", afi_safi="all", instance="edge1:9179"}'
         values: "0x30"
-      # IPv6 peer bracketed on the session side, bare on the RIB side —
-      # pins the label_replace port-strip for both address families.
-      - series: 'bgp_session_flaps_total{peer="[2001:db8::2]:179", instance="edge1:9179"}'
+      # An IPv6 peer alongside the IPv4 ones — pins that the join
+      # matches for both address families.
+      - series: 'bgp_session_flaps_total{peer="2001:db8::2", instance="edge1:9179"}'
         values: "0x30"
-      - series: 'bgp_session_established_total{peer="[2001:db8::2]:179", instance="edge1:9179"}'
+      - series: 'bgp_session_established_total{peer="2001:db8::2", instance="edge1:9179"}'
         values: "1x30"
       - series: 'bgp_rib_prefixes{peer="2001:db8::2", afi_safi="all", instance="edge1:9179"}'
         values: "0x30"
-      - series: 'bgp_session_flaps_total{peer="192.0.2.3:179", instance="edge1:9179"}'
+      - series: 'bgp_session_flaps_total{peer="192.0.2.3", instance="edge1:9179"}'
         values: "0+1x30"
-      - series: 'bgp_session_flaps_total{peer="192.0.2.4:179", instance="edge1:9179"}'
+      - series: 'bgp_session_flaps_total{peer="192.0.2.4", instance="edge1:9179"}'
         values: "0x30"
-      - series: 'bgp_session_established_total{peer="192.0.2.4:179", instance="edge1:9179"}'
+      - series: 'bgp_session_established_total{peer="192.0.2.4", instance="edge1:9179"}'
         values: "1x30"
       - series: 'bgp_rib_prefixes{peer="192.0.2.4", afi_safi="all", instance="edge1:9179"}'
         values: "100x30"
@@ -87,12 +86,12 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: critical
-              peer: 192.0.2.1:179
+              peer: 192.0.2.1
               instance: edge1:9179
             exp_annotations:
-              summary: "BGP session to 192.0.2.1:179 not Established"
+              summary: "BGP session to 192.0.2.1 not Established"
               description: >-
-                The BGP session to peer 192.0.2.1:179 on edge1:9179 left
+                The BGP session to peer 192.0.2.1 on edge1:9179 left
                 Established more than 2 minutes ago and has not
                 re-established.
       # Only the churning peer trips the 15-minute flap threshold.
@@ -101,12 +100,12 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: warning
-              peer: 192.0.2.3:179
+              peer: 192.0.2.3
               instance: edge1:9179
             exp_annotations:
-              summary: "BGP session to 192.0.2.3:179 is flapping"
+              summary: "BGP session to 192.0.2.3 is flapping"
               description: >-
-                The BGP session to peer 192.0.2.3:179 on edge1:9179 left
+                The BGP session to peer 192.0.2.3 on edge1:9179 left
                 Established 15 times in the last 15 minutes.
       # Not yet firing (for: 10m).
       - eval_time: 5m
@@ -143,9 +142,9 @@ tests:
   # ── BgpMaxPrefixLimitExceeded ─────────────────────────────────
   - interval: 1m
     input_series:
-      - series: 'bgp_max_prefix_exceeded_total{peer="192.0.2.5:179", instance="edge1:9179"}'
+      - series: 'bgp_max_prefix_exceeded_total{peer="192.0.2.5", instance="edge1:9179"}'
         values: "0 0 0 1 1 1 1 1 1 1"
-      - series: 'bgp_max_prefix_exceeded_total{peer="192.0.2.6:179", instance="edge1:9179"}'
+      - series: 'bgp_max_prefix_exceeded_total{peer="192.0.2.6", instance="edge1:9179"}'
         values: "0x9"
     alert_rule_test:
       - eval_time: 5m
@@ -153,12 +152,12 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: critical
-              peer: 192.0.2.5:179
+              peer: 192.0.2.5
               instance: edge1:9179
             exp_annotations:
-              summary: "Peer 192.0.2.5:179 exceeded its max-prefix limit"
+              summary: "Peer 192.0.2.5 exceeded its max-prefix limit"
               description: >-
-                Peer 192.0.2.5:179 on edge1:9179 breached a configured
+                Peer 192.0.2.5 on edge1:9179 breached a configured
                 max-prefix ceiling in the last 10 minutes; the
                 session was torn down with a Cease / Maximum Number of
                 Prefixes Reached NOTIFICATION.
@@ -169,15 +168,15 @@ tests:
   # The no-limit peer pins unlimited-as-absence: usage alone must not alert.
   - interval: 1m
     input_series:
-      - series: 'bgp_max_prefix_usage{peer="192.0.2.7:179", scope="aggregate", instance="edge1:9179"}'
+      - series: 'bgp_max_prefix_usage{peer="192.0.2.7", scope="aggregate", instance="edge1:9179"}'
         values: "80x15"
-      - series: 'bgp_max_prefix_limit{peer="192.0.2.7:179", scope="aggregate", instance="edge1:9179"}'
+      - series: 'bgp_max_prefix_limit{peer="192.0.2.7", scope="aggregate", instance="edge1:9179"}'
         values: "100x15"
-      - series: 'bgp_max_prefix_usage{peer="192.0.2.8:179", scope="ipv4_unicast", instance="edge1:9179"}'
+      - series: 'bgp_max_prefix_usage{peer="192.0.2.8", scope="ipv4_unicast", instance="edge1:9179"}'
         values: "79x15"
-      - series: 'bgp_max_prefix_limit{peer="192.0.2.8:179", scope="ipv4_unicast", instance="edge1:9179"}'
+      - series: 'bgp_max_prefix_limit{peer="192.0.2.8", scope="ipv4_unicast", instance="edge1:9179"}'
         values: "100x15"
-      - series: 'bgp_max_prefix_usage{peer="192.0.2.9:179", scope="ipv6_unicast", instance="edge1:9179"}'
+      - series: 'bgp_max_prefix_usage{peer="192.0.2.9", scope="ipv6_unicast", instance="edge1:9179"}'
         values: "100x15"
     alert_rule_test:
       - eval_time: 9m
@@ -188,14 +187,14 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: warning
-              peer: 192.0.2.7:179
+              peer: 192.0.2.7
               scope: aggregate
               instance: edge1:9179
             exp_annotations:
               summary: >-
-                Peer 192.0.2.7:179 max-prefix aggregate usage is high
+                Peer 192.0.2.7 max-prefix aggregate usage is high
               description: >-
-                Peer 192.0.2.7:179 on edge1:9179 has remained at or above 80%
+                Peer 192.0.2.7 on edge1:9179 has remained at or above 80%
                 of its finite aggregate max-prefix limit for 10 minutes.
                 Continued accepted-route growth can exhaust
                 bgp_max_prefix_headroom and eventually trigger Cease / Maximum
@@ -207,9 +206,9 @@ tests:
   # expectations red.
   - interval: 30s
     input_series:
-      - series: 'bgp_peer_slow{peer="192.0.2.10:179", instance="edge1:9179", job="rustbgpd"}'
+      - series: 'bgp_peer_slow{peer="192.0.2.10", instance="edge1:9179", job="rustbgpd"}'
         values: "1x14"
-      - series: 'bgp_peer_slow{peer="[2001:db8::10]:179", instance="edge1:9179", job="rustbgpd"}'
+      - series: 'bgp_peer_slow{peer="2001:db8::10", instance="edge1:9179", job="rustbgpd"}'
         values: "0x14"
     alert_rule_test:
       - eval_time: 4m30s
@@ -220,13 +219,13 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: warning
-              peer: 192.0.2.10:179
+              peer: 192.0.2.10
               instance: edge1:9179
               job: rustbgpd
             exp_annotations:
-              summary: "BGP peer endpoint 192.0.2.10:179 is slow"
+              summary: "BGP peer 192.0.2.10 is slow"
               description: >-
-                The Established session endpoint 192.0.2.10:179 on
+                The Established session to 192.0.2.10 on
                 edge1:9179 has remained slow for 5 minutes because its
                 outbound coalesced-frame queue is not draining. Updates
                 are still buffered; inspect bgp_peer_outbound_queue_depth
@@ -428,8 +427,7 @@ tests:
   # 15m to 5m, changing > 0 to > 1, or replacing increase with the raw counter
   # makes an exact case red. All four canonical reasons fire across unicast
   # and non-unicast families, so the demonstrated single-reason and
-  # single-family restrictions make the exact expected set red. Peers are
-  # bare configured neighbor addresses, not transport endpoints.
+  # single-family restrictions make the exact expected set red.
   - interval: 1m
     input_series:
       - series: 'bgp_exact_export_rejections_total{peer="192.0.2.10", family="ipv4_unicast", reason="message_too_long", instance="edge1:9179"}'
@@ -522,13 +520,13 @@ tests:
   # 7606 dispositions fire independently with transport-endpoint labels.
   - interval: 1m
     input_series:
-      - series: 'bgp_update_malformed_total{peer="192.0.2.20:179", disposition="treat_as_withdraw", instance="edge1:9179"}'
+      - series: 'bgp_update_malformed_total{peer="192.0.2.20", disposition="treat_as_withdraw", instance="edge1:9179"}'
         values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
-      - series: 'bgp_update_malformed_total{peer="[2001:db8::20]:179", disposition="attribute_discard", instance="edge1:9179"}'
+      - series: 'bgp_update_malformed_total{peer="2001:db8::20", disposition="attribute_discard", instance="edge1:9179"}'
         values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
-      - series: 'bgp_update_malformed_total{peer="192.0.2.21:179", disposition="session_reset", instance="edge1:9179"}'
+      - series: 'bgp_update_malformed_total{peer="192.0.2.21", disposition="session_reset", instance="edge1:9179"}'
         values: "0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
-      - series: 'bgp_update_malformed_total{peer="[2001:db8::22]:179", disposition="session_reset", instance="edge2:9179"}'
+      - series: 'bgp_update_malformed_total{peer="2001:db8::22", disposition="session_reset", instance="edge2:9179"}'
         values: "9x17"
     alert_rule_test:
       - eval_time: 2m
@@ -539,43 +537,43 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: warning
-              peer: 192.0.2.20:179
+              peer: 192.0.2.20
               disposition: treat_as_withdraw
               instance: edge1:9179
             exp_annotations:
               summary: >-
-                Malformed UPDATE from 192.0.2.20:179 (treat_as_withdraw)
+                Malformed UPDATE from 192.0.2.20 (treat_as_withdraw)
               description: >-
-                bgp_update_malformed_total for session endpoint
-                192.0.2.20:179 on edge1:9179 increased by 1 in the last 15
+                bgp_update_malformed_total for peer
+                192.0.2.20 on edge1:9179 increased by 1 in the last 15
                 minutes. The strongest RFC 7606 disposition was
                 treat_as_withdraw; inspect the peer and the daemon's
                 malformed-UPDATE diagnostics.
           - exp_labels:
               severity: warning
-              peer: "[2001:db8::20]:179"
+              peer: "2001:db8::20"
               disposition: attribute_discard
               instance: edge1:9179
             exp_annotations:
               summary: >-
-                Malformed UPDATE from [2001:db8::20]:179 (attribute_discard)
+                Malformed UPDATE from 2001:db8::20 (attribute_discard)
               description: >-
-                bgp_update_malformed_total for session endpoint
-                [2001:db8::20]:179 on edge1:9179 increased by 1 in the last
+                bgp_update_malformed_total for peer
+                2001:db8::20 on edge1:9179 increased by 1 in the last
                 15 minutes. The strongest RFC 7606 disposition was
                 attribute_discard; inspect the peer and the daemon's
                 malformed-UPDATE diagnostics.
           - exp_labels:
               severity: warning
-              peer: 192.0.2.21:179
+              peer: 192.0.2.21
               disposition: session_reset
               instance: edge1:9179
             exp_annotations:
               summary: >-
-                Malformed UPDATE from 192.0.2.21:179 (session_reset)
+                Malformed UPDATE from 192.0.2.21 (session_reset)
               description: >-
-                bgp_update_malformed_total for session endpoint
-                192.0.2.21:179 on edge1:9179 increased by 1 in the last 15
+                bgp_update_malformed_total for peer
+                192.0.2.21 on edge1:9179 increased by 1 in the last 15
                 minutes. The strongest RFC 7606 disposition was
                 session_reset; inspect the peer and the daemon's
                 malformed-UPDATE diagnostics.

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -16,18 +16,17 @@ WORKFLOW = ROOT / ".github/workflows/alert-rules.yml"
 
 VARIABLES = {
     "peer": 'label_values(bgp_session_state_transitions_total{instance=~"$instance"}, peer)',
-    "neighbor": 'label_values(bgp_peer_update_group{instance=~"$instance"}, peer)',
 }
 
 TARGETS = {
-    ("Outbound queue by peer endpoint", "A"): (
+    ("Outbound queue by peer", "A"): (
         'bgp_peer_outbound_queue_depth{instance=~"$instance",peer=~"$peer"}'
     ),
-    ("Slow peer endpoints", "A"): (
+    ("Slow peers", "A"): (
         'bgp_peer_slow{instance=~"$instance",peer=~"$peer"}'
     ),
-    ("Update group by neighbor address", "A"): (
-        'bgp_peer_update_group{instance=~"$instance",peer=~"$neighbor"}'
+    ("Update group by peer", "A"): (
+        'bgp_peer_update_group{instance=~"$instance",peer=~"$peer"}'
     ),
     ("Policy transition in progress", "A"): (
         'bgp_rib_policy_transition_in_progress{instance=~"$instance"}'
@@ -62,7 +61,7 @@ TARGETS = {
     ("Export rejections / malformed UPDATEs", "A"): (
         "sum by (instance, peer, family, reason) "
         "(rate(bgp_exact_export_rejections_total"
-        '{instance=~"$instance",peer=~"$neighbor"}[$__rate_interval])) > 0'
+        '{instance=~"$instance",peer=~"$peer"}[$__rate_interval])) > 0'
     ),
     ("Export rejections / malformed UPDATEs", "B"): (
         "sum by (instance, peer, disposition) (rate(bgp_update_malformed_total"
@@ -189,6 +188,19 @@ def main() -> None:
         if variable.get("allValue") != ".*":
             fail(f"${name} All value must be the regex .* ")
 
+    # The `peer` label has one canonical format (the bare neighbor
+    # address), so the dashboard must expose exactly one selector for
+    # it. A second one reintroduces the split identity that made
+    # `by (peer)` joins across metric families silently return empty.
+    peer_selectors = sorted(
+        name
+        for name, variable in variables.items()
+        if variable.get("type") == "query"
+        and str(variable.get("query", "")).rstrip().endswith(", peer)")
+    )
+    if peer_selectors != ["peer"]:
+        fail(f"exactly one peer selector expected, found {peer_selectors}")
+
     targets: dict[tuple[str, str], list[str]] = {}
     legends: dict[tuple[str, str], list[str | None]] = {}
     for panel in panels:
@@ -210,7 +222,7 @@ def main() -> None:
             fail(f"target {key[0]!r}/{key[1]} must use legend {expected!r}; got {actual!r}")
 
     update_group_panel = next(
-        panel for panel in panels if panel.get("title") == "Update group by neighbor address"
+        panel for panel in panels if panel.get("title") == "Update group by peer"
     )
     update_group_target = update_group_panel["targets"][0]
     if update_group_panel.get("type") != "table":
@@ -220,7 +232,7 @@ def main() -> None:
     if update_group_target.get("format") != "table" or update_group_target.get("instant") is not True:
         fail("update-group target must be an instant table query")
 
-    slow_panel = next(panel for panel in panels if panel.get("title") == "Slow peer endpoints")
+    slow_panel = next(panel for panel in panels if panel.get("title") == "Slow peers")
     slow_defaults = slow_panel.get("fieldConfig", {}).get("defaults", {})
     if slow_defaults.get("min") != 0 or slow_defaults.get("max") != 1:
         fail("slow-peer state must be pinned to the discrete 0..1 range")

--- a/src/peer_manager/dynamic.rs
+++ b/src/peer_manager/dynamic.rs
@@ -443,8 +443,7 @@ impl PeerManager {
                 )
                 .await;
             if shutdown.joined() {
-                self.reap_deleted_peer_metric_series(peer_key.address, &managed.transport_config)
-                    .await;
+                self.reap_deleted_peer_metric_series(peer_key.address).await;
             } else {
                 warn!(
                     peer = %peer_key,

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -6,7 +6,7 @@ use rustbgpd_api::peer_types::{
 };
 use rustbgpd_rib::RibUpdate;
 use rustbgpd_transport::{PeerCommand, PeerCommandError};
-use rustbgpd_transport::{PeerHandle, SessionIdentity, TcpAoKeyring, TransportConfig};
+use rustbgpd_transport::{PeerHandle, SessionIdentity, TcpAoKeyring};
 use rustbgpd_wire::{Afi, Safi};
 use tokio::sync::oneshot;
 use tracing::{debug, error, info, warn};
@@ -1242,8 +1242,7 @@ impl PeerManager {
         // task records its final transitions before the shutdown join
         // above, so this runs after the last transport-side emission).
         if reap_metric_series && shutdown.joined() {
-            self.reap_deleted_peer_metric_series(address, &managed.transport_config)
-                .await;
+            self.reap_deleted_peer_metric_series(address).await;
         } else if reap_metric_series {
             warn!(
                 %address,
@@ -1255,25 +1254,17 @@ impl PeerManager {
 
     /// Remove a deleted peer's per-peer metric series.
     ///
-    /// Transport sessions label `peer` with the remote `SocketAddr`
-    /// (`"10.0.0.2:179"`, `"[fe80::2%3]:179"`), while the RIB manager
-    /// and BFD runtime label it with the bare address — reap both
-    /// exact forms. Call only after the peer has been removed from
-    /// `self.peers` and its session task joined.
-    pub(super) async fn reap_deleted_peer_metric_series(
-        &self,
-        address: std::net::IpAddr,
-        transport_config: &TransportConfig,
-    ) {
-        // The SocketAddr form is unique to this peer (same-address
-        // link-local peers differ in scope id), so it is always safe.
-        self.metrics
-            .reap_peer_series(&transport_config.remote_addr.to_string());
-        // The bare-address form can be shared with a surviving peer
-        // (the same link-local address on another interface) — leave
-        // it alone unless this peer was the last user of the address.
+    /// Every emission site — transport session, RIB manager, BFD
+    /// runtime — labels `peer` with the canonical bare address, so one
+    /// reap covers them all. Call only after the peer has been removed
+    /// from `self.peers` and its session task joined.
+    pub(super) async fn reap_deleted_peer_metric_series(&self, address: std::net::IpAddr) {
+        // The label can be shared with a surviving peer (the same
+        // link-local address on another interface) — leave it alone
+        // unless this peer was the last user of the address.
         if self.peer_keys_for_address(address).is_empty() {
-            self.metrics.reap_peer_series(&address.to_string());
+            self.metrics
+                .reap_peer_series(&rustbgpd_telemetry::peer_label(address));
             // The RIB manager emits bare-address series from its own
             // task; this marker is queued behind the session's final
             // `PeerDown`, so the RIB manager reaps again *after* its

--- a/src/peer_manager/notifications.rs
+++ b/src/peer_manager/notifications.rs
@@ -249,11 +249,7 @@ impl PeerManager {
                             // breach was discovered during the join barrier.
                             self.dynamic_peer_count = self.dynamic_peer_count.saturating_sub(1);
                             if shutdown.joined() {
-                                self.reap_deleted_peer_metric_series(
-                                    peer_addr,
-                                    &managed.transport_config,
-                                )
-                                .await;
+                                self.reap_deleted_peer_metric_series(peer_addr).await;
                             } else {
                                 info!(
                                     %peer_addr,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -6227,19 +6227,18 @@ fn peer_metric_series_count(metrics: &BgpMetrics, peer: &str) -> usize {
         .count()
 }
 
-/// Seed per-peer series under both label forms used at runtime: the
-/// transport sessions label `peer` with the remote `SocketAddr`, the
-/// RIB manager and BFD runtime with the bare address.
-fn seed_peer_metric_series(metrics: &BgpMetrics, transport_label: &str, bare_label: &str) {
-    metrics.record_state_transition(transport_label, "open_confirm", "established");
-    metrics.record_message_sent(transport_label, "keepalive");
-    metrics.set_rib_prefixes(bare_label, "ipv4_unicast", 42);
-    metrics.record_bfd_state(bare_label, true, false);
+/// Seed per-peer series across the emitters that own them — session,
+/// RIB, BFD — all under the one canonical bare-address `peer` label.
+fn seed_peer_metric_series(metrics: &BgpMetrics, peer_label: &str) {
+    metrics.record_state_transition(peer_label, "open_confirm", "established");
+    metrics.record_message_sent(peer_label, "keepalive");
+    metrics.set_rib_prefixes(peer_label, "ipv4_unicast", 42);
+    metrics.record_bfd_state(peer_label, true, false);
     // ADR-0112: peer creation materializes both directional gauges so a
     // healthy peer has a 0 series to alert on rather than an absent one. The
     // direct-insert test helpers bypass that path, so seed them here to keep
     // the reap accounting comparable to production.
-    metrics.set_rfc8212_missing_policy(bare_label, false, false);
+    metrics.set_rfc8212_missing_policy(peer_label, false, false);
 }
 
 #[tokio::test]
@@ -6267,22 +6266,13 @@ async fn delete_peer_reaps_metric_series() {
         fake_peer_handle(peer_addr, SessionState::Established, None, counters.clone()),
         false,
     );
-    let transport_label = mgr
-        .peers
-        .get(&key(peer_addr))
-        .unwrap()
-        .transport_config
-        .remote_addr
-        .to_string();
-    seed_peer_metric_series(&metrics_view, &transport_label, "10.0.0.2");
+    seed_peer_metric_series(&metrics_view, "10.0.0.2");
     metrics_view.record_fib_route_installed(); // process-global counter
-    assert!(peer_metric_series_count(&metrics_view, &transport_label) > 0);
     assert!(peer_metric_series_count(&metrics_view, "10.0.0.2") > 0);
 
     mgr.delete_peer(key(peer_addr), false).await.unwrap();
 
-    // Both label forms are gone; process-global counters are untouched.
-    assert_eq!(peer_metric_series_count(&metrics_view, &transport_label), 0);
+    // One reap clears every emitter; process-global counters are untouched.
     assert_eq!(peer_metric_series_count(&metrics_view, "10.0.0.2"), 0);
     let fib_installed = metrics_view
         .registry()
@@ -6321,17 +6311,9 @@ async fn session_flap_does_not_reap_metric_series() {
         fake_peer_handle(peer_addr, SessionState::Idle, None, counters.clone()),
         false,
     );
-    let transport_label = mgr
-        .peers
-        .get(&key(peer_addr))
-        .unwrap()
-        .transport_config
-        .remote_addr
-        .to_string();
-    seed_peer_metric_series(&metrics_view, &transport_label, "10.0.0.2");
-    metrics_view.record_state_transition(&transport_label, "established", "idle");
-    let before_transport = peer_metric_series_count(&metrics_view, &transport_label);
-    let before_bare = peer_metric_series_count(&metrics_view, "10.0.0.2");
+    seed_peer_metric_series(&metrics_view, "10.0.0.2");
+    metrics_view.record_state_transition("10.0.0.2", "established", "idle");
+    let before = peer_metric_series_count(&metrics_view, "10.0.0.2");
 
     // A static peer's session flap (BackToIdle) must keep its history.
     mgr.handle_session_notification(SessionNotification::BackToIdle {
@@ -6342,14 +6324,7 @@ async fn session_flap_does_not_reap_metric_series() {
     .await;
 
     assert!(mgr.peers.contains_key(&key(peer_addr)));
-    assert_eq!(
-        peer_metric_series_count(&metrics_view, &transport_label),
-        before_transport
-    );
-    assert_eq!(
-        peer_metric_series_count(&metrics_view, "10.0.0.2"),
-        before_bare
-    );
+    assert_eq!(peer_metric_series_count(&metrics_view, "10.0.0.2"), before);
     assert!(rib_rx.try_recv().is_err(), "no PeerDeleted on a flap");
 }
 
@@ -6378,16 +6353,8 @@ async fn reconfigure_peer_does_not_reap_metric_series() {
         fake_peer_handle(peer_addr, SessionState::Established, None, counters.clone()),
         false,
     );
-    let transport_label = mgr
-        .peers
-        .get(&key(peer_addr))
-        .unwrap()
-        .transport_config
-        .remote_addr
-        .to_string();
-    seed_peer_metric_series(&metrics_view, &transport_label, "10.0.0.2");
-    let before_transport = peer_metric_series_count(&metrics_view, &transport_label);
-    let before_bare = peer_metric_series_count(&metrics_view, "10.0.0.2");
+    seed_peer_metric_series(&metrics_view, "10.0.0.2");
+    let before = peer_metric_series_count(&metrics_view, "10.0.0.2");
 
     // Reconfigure routes through the same delete primitive, but the
     // peer continues to exist — its series and history must survive.
@@ -6396,14 +6363,7 @@ async fn reconfigure_peer_does_not_reap_metric_series() {
     mgr.reconfigure_peer(new_config).await.unwrap();
 
     assert!(mgr.peers.contains_key(&key(peer_addr)));
-    assert_eq!(
-        peer_metric_series_count(&metrics_view, &transport_label),
-        before_transport
-    );
-    assert_eq!(
-        peer_metric_series_count(&metrics_view, "10.0.0.2"),
-        before_bare
-    );
+    assert_eq!(peer_metric_series_count(&metrics_view, "10.0.0.2"), before);
     assert!(
         rib_rx.try_recv().is_err(),
         "no PeerDeleted on a reconfigure"
@@ -6437,14 +6397,7 @@ async fn dynamic_peer_auto_removal_reaps_metric_series() {
     );
     mgr.peers.get_mut(&key(peer_addr)).unwrap().is_dynamic = true;
     mgr.dynamic_peer_count = 1;
-    let transport_label = mgr
-        .peers
-        .get(&key(peer_addr))
-        .unwrap()
-        .transport_config
-        .remote_addr
-        .to_string();
-    seed_peer_metric_series(&metrics_view, &transport_label, "10.0.0.2");
+    seed_peer_metric_series(&metrics_view, "10.0.0.2");
 
     // Auto-removal on idle is a full deletion for a dynamic peer.
     mgr.handle_session_notification(SessionNotification::BackToIdle {
@@ -6455,7 +6408,6 @@ async fn dynamic_peer_auto_removal_reaps_metric_series() {
     .await;
 
     assert!(mgr.peers.is_empty());
-    assert_eq!(peer_metric_series_count(&metrics_view, &transport_label), 0);
     assert_eq!(peer_metric_series_count(&metrics_view, "10.0.0.2"), 0);
     let update = rib_rx.try_recv().expect("PeerDeleted queued for the RIB");
     assert!(matches!(update, RibUpdate::PeerDeleted { peer } if peer == peer_addr));


### PR DESCRIPTION
## Problem

The `peer` metric label had two incompatible formats — including within a single metric family:

```
bgp_policy_routes_total{action="permit",direction="export",peer="10.99.0.20",...}      2
bgp_policy_routes_total{action="permit",direction="import",peer="10.99.0.20:179",...}  4
```

Transport sessions stringified the remote `SocketAddr`; the RIB manager, BFD runtime, and BMP paths used the bare configured address. `bgp_policy_routes_total` carried both because its import half is recorded by the session and its export half by the RIB.

`sum by (peer) (bgp_policy_routes_total)` therefore returned two series per peer, and any `by (peer)` join across the two groups returned empty. Prometheus raises no error for a join that matches nothing, so an alert built that way silently never fires.

## Decision

The bare neighbor address wins, on every family.

The port carried nothing joinable. It is the *configured* endpoint, not the observed source port — a dynamic member connecting from an ephemeral port still labelled `:179`. Nor did it disambiguate anything: neighbor identity is already unique by address, because `Config::validate` rejects the same IPv6 link-local address bound to two interfaces, and the RIB keys peers by bare `IpAddr` regardless. A collision window's primary and candidate sessions are two sessions to the *same* peer and are meant to aggregate. So no consumer needs a port, and no separate disambiguating label is warranted.

Metric labels are a public API. The CHANGELOG entry is explicit that this is a breaking change, names all 26 families whose format moved, and states what operator PromQL needs.

## Change

Sessions were the only emitter holding a `SocketAddr`. Both `PeerSession` constructors now build the label through one sanctioned producer, `rustbgpd_telemetry::peer_label(IpAddr)`, and `initialize_route_safety_metric_series` collapses from two label parameters to one. Peer deletion reaps one label form instead of two. Every other emission site already held an `IpAddr` and is unchanged.

The structured-log `peer` field on session events follows, and now agrees with the rest of the daemon's logs.

**No transitional dual-emit.** Emitting both formats would double the per-peer series count of 26 families for the whole transition window, and it would preserve the exact failure being fixed: `sum by (peer)` would still return two series per peer, so a dashboard that looked correct during the overlap would break at removal instead of now.

## Shipped artifacts

- **Dashboard** — the two peer selectors (`$peer` endpoint / `$neighbor` address) collapse into one `$peer`. This also repairs a live defect: `$peer` was populated from a session metric but applied to `bgp_rib_prefixes`, `bgp_gr_*`, `bfd_session_*`, `bgp_route_refresh_*` and others, so those panels returned no data whenever a specific peer was selected rather than All.
- **Alert pack** — `BgpPeerAdjRibInEmpty` joins session and RIB directly; the `label_replace` port-strip is gone. Unit-test fixtures use one label format.
- **`scripts/check-grafana-dashboard.py`** — new invariant: exactly one template variable may be populated from the `peer` label.
- **`rbgp doctor`** — the slow-peer remediation prints `bgp_peer_outbound_queue_depth{peer="<addr>"}`, a selector that now resolves; previously it deliberately withheld one because the label was a `SocketAddr`.
- **`docs/GRAFANA.md`**, **`docs/OPERATIONS.md`** — the two-identity wording is replaced by the single contract; OPERATIONS gains a "The `peer` label" subsection.

Nothing ships referencing the retired form.

## Invariant

Enumerating, not spot-checking:

- `rustbgpd_telemetry::non_canonical_peer_labels(&Registry)` walks every gathered series and returns each `peer` value that does not parse as a bare `IpAddr`. Public, so any crate driving real sessions can assert it against the registry those sessions wrote to.
- `every_peer_labeled_series_uses_the_canonical_bare_address` drives all 49 peer-labeled families (through the existing `populate_all_peer_families` helper) for one IPv4 and one IPv6 peer, then asserts the checker finds nothing.
- `peer_labeled_family_surface_matches_the_pinned_list` compares the emitted family-name set against an explicit list, so the format assertion cannot silently stop covering a family.
- `non_canonical_peer_labels_rejects_the_transport_endpoint_form` is the negative control: the checker must fail on `192.0.2.1:179` and `[2001:db8::1]:179` while passing `192.0.2.1`.
- `session_peer_label_is_the_bare_neighbor_address` builds a session on a **non-179** remote port, proving the port is dropped rather than merely absent.

## Gates

```
cargo fmt --all -- --check                            0
cargo clippy --workspace --all-targets -- -D warnings 0
timeout 2400 cargo test --workspace --no-fail-fast    0
cargo doc --workspace --no-deps                       0
JSON parse of docs/grafana/rustbgpd-overview.json     0
python3 scripts/check-grafana-dashboard.py            0
promtool check rules  (3.4.1, the pinned CI version)  0
promtool test rules                                   0
```
