### PR TITLE
Reserve the config write before mutating runtime state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,49 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   through the statement path is also pointed at `.rpol` rather than labelled an
   unknown structural stanza, and report entries folded out of a multi-line
   source no longer carry that source's indentation runs.
+- **A rejected runtime mutation no longer tears down the session it was
+  refusing to change.** When config persistence failed — an unwritable config
+  directory, a read-only mount, a full filesystem — every persisted mutating
+  RPC had already applied its runtime change and then tried to undo it by
+  applying the inverse. `rbgp neighbor <addr> delete` returned
+  `FAILED_PRECONDITION`, which reads as "nothing happened", while the BGP
+  session had in fact been torn down and a *different* session re-established
+  in its place: new identity, uptime back to zero, cumulative counters back to
+  zero, metric series reaped and restarted, and `Flaps` still reading 0 so the
+  event was invisible in the operator's own flap accounting. Any `rate()` or
+  `increase()` spanning the window was silently wrong. The same
+  apply-then-compensate ordering affected `neighbor add`, both dynamic-neighbor
+  RPCs, all twelve policy and neighbor-set / policy-chain mutators, and the
+  peer-group and membership mutators, where it put a Route Refresh and an
+  Adj-RIB-Out rewrite on the wire twice — once forward, once as "rollback" —
+  or bounced every inheriting member's session twice, for a request that was
+  rejected.
+
+  Persistence is now a two-phase reservation shared by all of them: the
+  candidate config is serialized and durably staged next to the config file
+  *before* any runtime state is touched, the runtime change is applied only
+  once that succeeded, and the staged write is then published with a rename.
+  A staging failure is reported while the sessions, their counters, and their
+  metric series are still untouched, and an apply failure discards the staged
+  write instead of leaving it on disk. `FAILED_PRECONDITION` from a mutating
+  RPC now means what it says: no externally visible mutation. Rejections that
+  are simply bad requests keep their own status codes rather than being
+  reported as persistence faults. The ADR-0076 config-transaction executor and
+  FIB-table CRUD keep single-phase persistence — each owns a rollback that
+  restores exact prior state and already reports an ambiguous outcome when it
+  cannot.
+
+- **The shipped Docker quick-start now supports the workflow it documents.**
+  `examples/docker-compose` mounted the config read-only, so every mutating
+  command failed and the README's "no restarts to add peers, change policy, or
+  inject routes" was false out of the box. The config is now shipped as a
+  template and copied into the daemon's writable state volume on first start,
+  following the pattern the interop labs already use; runtime edits survive
+  `docker compose restart` and `down -v` reseeds from the template. The
+  standalone `docker run`, containerlab, and deployment examples carry the same
+  correction, and `docs/CONFIGURATION.md` states the requirement directly: the
+  config file's *directory* must be writable by the daemon for runtime
+  mutation, because persistence writes `<config>.tmp` alongside it and renames.
 
 - **`rbgp doctor` no longer fails in the container image.** The image runs as
   a nonroot user with a working directory it cannot write, and doctor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2882,6 +2882,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "toml_edit",
+ "tonic",
  "tower",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,6 +197,9 @@ serde_yaml.workspace = true
 tempfile.workspace = true
 tower.workspace = true
 criterion.workspace = true
+# Drives the gRPC services directly (Request/Status/Code) in the tests that
+# prove a rejected mutation leaves no observable trace.
+tonic.workspace = true
 # Enables Tokio's paused-clock test harness (`start_paused`) for deterministic,
 # wall-clock-free timer tests (e.g. the confirm-timeout auto-revert).
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -39,6 +39,7 @@ mod test_support;
 
 pub use config_service::update_group_impact_to_proto;
 pub use evpn_service::EvpnService;
+pub use neighbor_service::NeighborService;
 
 /// Public-facing alias for the proto-encoding helpers used by the
 /// binary's peer-manager + BFD bridge to construct

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -15,7 +15,7 @@ use crate::peer_types::{
 };
 use crate::proto;
 use crate::server::{
-    AccessMode, ConfigMutationGateFn, check_config_mutation_gate, persist_runtime_config_event,
+    AccessMode, ConfigMutationGateFn, check_config_mutation_gate, persist_then_apply,
     read_only_rejection,
 };
 use rustbgpd_rib::{
@@ -90,6 +90,7 @@ pub struct NeighborService {
 impl NeighborService {
     /// Create a new neighbor service with the given channels.
     #[cfg(test)]
+    #[must_use]
     pub fn new(
         local_asn: u32,
         access_mode: AccessMode,
@@ -372,25 +373,6 @@ async fn delete_static_peer(
         .await
         .map_err(|_| Status::internal("peer manager dropped reply"))?
         .map_err(peer_lifecycle_error_status)
-}
-
-async fn apply_peer_manager_config_event(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    event: ConfigEvent,
-) -> Result<(), Status> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(PeerManagerCommand::ApplyConfigEvent {
-            event,
-            reply: reply_tx,
-        })
-        .await
-        .map_err(|_| Status::internal("peer manager unavailable"))?;
-
-    reply_rx
-        .await
-        .map_err(|_| Status::internal("peer manager dropped reply"))?
-        .map_err(Status::internal)
 }
 
 async fn delete_dynamic_range(
@@ -1036,7 +1018,6 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         // Reserve config persistence capacity before mutating runtime state.
         // This makes AddNeighbor fail-fast when persistence is unavailable.
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_key = PeerKey::new(peer_config.address, peer_config.interface.clone());
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         let runtime_config_lock = self.runtime_config_lock.clone();
         let config_mutation_gate = self.config_mutation_gate.clone();
@@ -1044,28 +1025,21 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             let _guard = runtime_config_lock.lock().await;
             check_config_mutation_gate(&config_mutation_gate, "NeighborService.AddNeighbor")
                 .await?;
-            add_static_peer(&peer_mgr_tx, peer_config.clone()).await?;
 
-            // Keep the shared runtime-config lock held until the TOML write is
-            // acknowledged; otherwise a concurrent SIGHUP could reload stale
-            // disk and drop the accepted runtime neighbor from the snapshot.
-            if let Some(permit) = persist_permit
-                && let Err(error) =
-                    persist_runtime_config_event(permit, |ack| ConfigEvent::NeighborAdded {
-                        config: peer_config.clone(),
-                        ack: Some(ack),
-                    })
-                    .await
-            {
-                let rollback = delete_static_peer(&peer_mgr_tx, peer_key, true).await;
-                if let Err(rollback_error) = rollback {
-                    return Err(Status::internal(format!(
-                        "{error}; rollback of neighbor add failed: {rollback_error}"
-                    )));
-                }
-                return Err(error);
-            }
-            Ok::<(), Status>(())
+            // Stage the write first: a session that has already dialed out and
+            // sent an OPEN cannot be un-dialed, so a persistence failure must
+            // be known before the peer exists. Keep the shared runtime-config
+            // lock held across the whole window; otherwise a concurrent SIGHUP
+            // could reload stale disk between the runtime add and the commit.
+            persist_then_apply(
+                persist_permit,
+                |ack| ConfigEvent::NeighborAdded {
+                    config: peer_config.clone(),
+                    ack: Some(ack),
+                },
+                || add_static_peer(&peer_mgr_tx, peer_config.clone()),
+            )
+            .await
         });
         join.await
             .map_err(|_| Status::internal("neighbor add task did not complete"))??;
@@ -1094,47 +1068,27 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             let _guard = runtime_config_lock.lock().await;
             check_config_mutation_gate(&config_mutation_gate, "NeighborService.DeleteNeighbor")
                 .await?;
-            let removed = delete_static_peer(&peer_mgr_tx, peer.clone(), false).await?;
-
-            // Hold the shared runtime-config lock until persistence completes
-            // so SIGHUP cannot rebuild from stale TOML in the middle.
-            if let Some(permit) = persist_permit
-                && let Err(error) =
-                    persist_runtime_config_event(permit, |ack| ConfigEvent::NeighborDeleted {
-                        peer: peer.clone(),
-                        ack: Some(ack),
-                    })
-                    .await
-            {
-                let rollback = add_static_peer(&peer_mgr_tx, removed).await;
-                if let Err(rollback_error) = rollback {
-                    return Err(Status::internal(format!(
-                        "{error}; rollback of neighbor delete failed: {rollback_error}"
-                    )));
-                }
-                return Err(error);
-            }
-            // Delete differs from add on purpose: the live peer is removed
-            // before persistence, but the peer-manager config snapshot is only
-            // updated after the TOML write succeeds. That keeps the original
-            // config row available for rollback instead of reconstructing it
-            // from a lossy runtime snapshot.
-            if let Err(error) = apply_peer_manager_config_event(
-                &peer_mgr_tx,
-                ConfigEvent::NeighborDeleted {
+            // The session teardown below is irreversible: re-adding the peer
+            // builds a *new* session with a new identity, a zeroed uptime,
+            // zeroed counters, and a fresh metric series, and the teardown
+            // never reaches the operator's flap count. So the write is staged
+            // and acknowledged first — a persistence failure is reported while
+            // the session is still up and untouched. The shared runtime-config
+            // lock is held across the whole window so SIGHUP cannot rebuild
+            // from stale TOML in the middle.
+            persist_then_apply(
+                persist_permit,
+                |ack| ConfigEvent::NeighborDeleted {
                     peer: peer.clone(),
-                    ack: None,
+                    ack: Some(ack),
+                },
+                || async {
+                    delete_static_peer(&peer_mgr_tx, peer.clone(), true)
+                        .await
+                        .map(|_| ())
                 },
             )
             .await
-            {
-                tracing::warn!(
-                    %peer,
-                    error = %error,
-                    "neighbor delete persisted but peer-manager snapshot update failed"
-                );
-            }
-            Ok::<(), Status>(())
         });
         join.await
             .map_err(|_| Status::internal("neighbor delete task did not complete"))??;
@@ -1413,41 +1367,32 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             let _guard = runtime_config_lock.lock().await;
             check_config_mutation_gate(&config_mutation_gate, "NeighborService.AddDynamicNeighbor")
                 .await?;
-            add_dynamic_range(
-                &peer_mgr_tx,
-                range.prefix.clone(),
-                range.peer_group.clone(),
-                range.remote_asn,
-                description.clone(),
+            // Stage the write before the matcher changes, so a persistence
+            // failure cannot leave a range that briefly accepted a session.
+            // This runs inside the spawned task so a canceled gRPC request
+            // cannot split the runtime add from the queued config event, and
+            // the shared runtime-config lock is held across the whole window
+            // so a concurrent SIGHUP cannot reload stale disk in the middle.
+            persist_then_apply(
+                persist_permit,
+                |ack| ConfigEvent::DynamicNeighborAdded {
+                    prefix: range.prefix.clone(),
+                    peer_group: range.peer_group.clone(),
+                    remote_asn: range.remote_asn,
+                    description: description.clone(),
+                    ack: Some(ack),
+                },
+                || {
+                    add_dynamic_range(
+                        &peer_mgr_tx,
+                        range.prefix.clone(),
+                        range.peer_group.clone(),
+                        range.remote_asn,
+                        description.clone(),
+                    )
+                },
             )
-            .await?;
-
-            // Persist only after successful runtime mutation. This runs inside
-            // the spawned task so a canceled gRPC request cannot split runtime
-            // add from the queued config event. When persistence is configured,
-            // keep the shared runtime-config lock held until the TOML write is
-            // acknowledged; otherwise a concurrent SIGHUP could reload stale
-            // disk and drop the accepted runtime add from the rebuilt matcher.
-            if let Some(permit) = persist_permit
-                && let Err(error) =
-                    persist_runtime_config_event(permit, |ack| ConfigEvent::DynamicNeighborAdded {
-                        prefix: range.prefix.clone(),
-                        peer_group: range.peer_group.clone(),
-                        remote_asn: range.remote_asn,
-                        description: description.clone(),
-                        ack: Some(ack),
-                    })
-                    .await
-            {
-                let rollback = delete_dynamic_range(&peer_mgr_tx, range.prefix.clone()).await;
-                if let Err(rollback_error) = rollback {
-                    return Err(Status::internal(format!(
-                        "{error}; rollback of dynamic-neighbor add failed: {rollback_error}"
-                    )));
-                }
-                return Err(error);
-            }
-            Ok::<(), Status>(())
+            .await
         });
         join.await
             .map_err(|_| Status::internal("dynamic-neighbor add task did not complete"))??;
@@ -1479,37 +1424,25 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
                 "NeighborService.DeleteDynamicNeighbor",
             )
             .await?;
-            let removed = delete_dynamic_range(&peer_mgr_tx, prefix.clone()).await?;
-
-            // Queue persistence inside the spawned task so cancellation after
-            // runtime delete cannot leave disk with the removed range. Hold the
-            // shared runtime-config lock until the write is acknowledged so
-            // SIGHUP cannot rebuild from stale TOML in the middle.
-            if let Some(permit) = persist_permit
-                && let Err(error) = persist_runtime_config_event(permit, |ack| {
-                    ConfigEvent::DynamicNeighborDeleted {
-                        prefix: prefix.clone(),
-                        ack: Some(ack),
-                    }
-                })
-                .await
-            {
-                let rollback = add_dynamic_range(
-                    &peer_mgr_tx,
-                    removed.prefix,
-                    removed.peer_group,
-                    removed.remote_asn,
-                    removed.description,
-                )
-                .await;
-                if let Err(rollback_error) = rollback {
-                    return Err(Status::internal(format!(
-                        "{error}; rollback of dynamic-neighbor delete failed: {rollback_error}"
-                    )));
-                }
-                return Err(error);
-            }
-            Ok::<(), Status>(())
+            // Stage the write first so a persistence failure leaves the range
+            // in place rather than removing and re-adding it. This runs inside
+            // the spawned task so cancellation cannot split runtime delete
+            // from the queued config event, and the shared runtime-config lock
+            // is held across the window so SIGHUP cannot rebuild from stale
+            // TOML in the middle.
+            persist_then_apply(
+                persist_permit,
+                |ack| ConfigEvent::DynamicNeighborDeleted {
+                    prefix: prefix.clone(),
+                    ack: Some(ack),
+                },
+                || async {
+                    delete_dynamic_range(&peer_mgr_tx, prefix.clone())
+                        .await
+                        .map(|_| ())
+                },
+            )
+            .await
         });
         join.await
             .map_err(|_| Status::internal("dynamic-neighbor delete task did not complete"))??;
@@ -2055,6 +1988,28 @@ mod tests {
             .unwrap();
         });
 
+        let staged = match config_rx.recv().await.unwrap() {
+            ConfigEvent::DynamicNeighborAdded {
+                prefix,
+                peer_group,
+                remote_asn,
+                description,
+                ack,
+            } => {
+                assert_eq!(prefix, "192.0.2.0/24");
+                assert_eq!(peer_group, "fabric");
+                assert_eq!(remote_asn, 65002);
+                assert_eq!(description.as_deref(), Some("lab range"));
+                assert!(
+                    matches!(peer_mgr_rx.try_recv(), Err(TryRecvError::Empty)),
+                    "the matcher must not change before the write is staged"
+                );
+                ack.unwrap()
+            }
+            _ => panic!("expected DynamicNeighborAdded"),
+        };
+        let staged = tokio::spawn(staged.accept());
+
         match peer_mgr_rx.recv().await.unwrap() {
             PeerManagerCommand::AddDynamicRange {
                 prefix,
@@ -2067,39 +2022,22 @@ mod tests {
                 assert_eq!(peer_group, "fabric");
                 assert_eq!(remote_asn, 65002);
                 assert_eq!(description.as_deref(), Some("lab range"));
-                reply.send(Ok(())).unwrap();
-            }
-            _ => panic!("expected AddDynamicRange"),
-        }
-
-        match config_rx.recv().await.unwrap() {
-            ConfigEvent::DynamicNeighborAdded {
-                prefix,
-                peer_group,
-                remote_asn,
-                description,
-                ack,
-            } => {
-                assert_eq!(prefix, "192.0.2.0/24");
-                assert_eq!(peer_group, "fabric");
-                assert_eq!(remote_asn, 65002);
-                assert_eq!(description.as_deref(), Some("lab range"));
-                let ack = ack.unwrap();
                 assert!(
                     tokio::time::timeout(Duration::from_millis(20), &mut call)
                         .await
                         .is_err(),
-                    "call must wait for config persistence acknowledgement"
+                    "call must wait for the staged write to be committed"
                 );
-                ack.send(Ok(())).unwrap();
+                reply.send(Ok(())).unwrap();
             }
-            _ => panic!("expected DynamicNeighborAdded"),
+            _ => panic!("expected AddDynamicRange"),
         }
+        assert!(staged.await.unwrap(), "the staged write must be committed");
         call.await.unwrap();
     }
 
     #[tokio::test]
-    async fn add_dynamic_neighbor_rolls_back_when_persist_fails() {
+    async fn add_dynamic_neighbor_persist_failure_adds_no_range() {
         let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(16);
         let (rib_tx, _rib_rx) = mpsc::channel(16);
         let (config_tx, mut config_rx) = mpsc::channel(16);
@@ -2123,38 +2061,23 @@ mod tests {
             .await
         });
 
-        match peer_mgr_rx.recv().await.unwrap() {
-            PeerManagerCommand::AddDynamicRange { reply, .. } => {
-                reply.send(Ok(())).unwrap();
-            }
-            _ => panic!("expected AddDynamicRange"),
-        }
         match config_rx.recv().await.unwrap() {
             ConfigEvent::DynamicNeighborAdded { ack, .. } => {
-                ack.unwrap()
-                    .send(Err("disk full".to_string()))
-                    .expect("send persist failure");
+                ack.unwrap().fail_write("disk full");
             }
             _ => panic!("expected DynamicNeighborAdded"),
-        }
-        match peer_mgr_rx.recv().await.unwrap() {
-            PeerManagerCommand::DeleteDynamicRange { prefix, reply } => {
-                assert_eq!(prefix, "192.0.2.0/24");
-                reply
-                    .send(Ok(RemovedDynamicRange {
-                        prefix,
-                        peer_group: "fabric".to_string(),
-                        remote_asn: 65002,
-                        description: Some("lab range".to_string()),
-                    }))
-                    .unwrap();
-            }
-            _ => panic!("expected DeleteDynamicRange rollback"),
         }
 
         let err = call.await.unwrap().unwrap_err();
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
         assert!(err.message().contains("config persistence failed"));
+        assert!(
+            matches!(
+                peer_mgr_rx.try_recv(),
+                Err(TryRecvError::Empty | TryRecvError::Disconnected)
+            ),
+            "a rejected dynamic-range add must not touch the matcher"
+        );
     }
 
     #[tokio::test]
@@ -2211,9 +2134,28 @@ mod tests {
             .unwrap();
         });
 
+        let staged = match config_rx.recv().await.unwrap() {
+            ConfigEvent::DynamicNeighborDeleted { prefix, ack } => {
+                assert_eq!(prefix, "192.0.2.0/24");
+                assert!(
+                    matches!(peer_mgr_rx.try_recv(), Err(TryRecvError::Empty)),
+                    "the matcher must not change before the write is staged"
+                );
+                ack.unwrap()
+            }
+            _ => panic!("expected DynamicNeighborDeleted"),
+        };
+        let staged = tokio::spawn(staged.accept());
+
         match peer_mgr_rx.recv().await.unwrap() {
             PeerManagerCommand::DeleteDynamicRange { prefix, reply } => {
                 assert_eq!(prefix, "192.0.2.0/24");
+                assert!(
+                    tokio::time::timeout(Duration::from_millis(20), &mut call)
+                        .await
+                        .is_err(),
+                    "call must wait for the staged write to be committed"
+                );
                 reply
                     .send(Ok(RemovedDynamicRange {
                         prefix,
@@ -2225,26 +2167,12 @@ mod tests {
             }
             _ => panic!("expected DeleteDynamicRange"),
         }
-
-        match config_rx.recv().await.unwrap() {
-            ConfigEvent::DynamicNeighborDeleted { prefix, ack } => {
-                assert_eq!(prefix, "192.0.2.0/24");
-                let ack = ack.unwrap();
-                assert!(
-                    tokio::time::timeout(Duration::from_millis(20), &mut call)
-                        .await
-                        .is_err(),
-                    "call must wait for config persistence acknowledgement"
-                );
-                ack.send(Ok(())).unwrap();
-            }
-            _ => panic!("expected DynamicNeighborDeleted"),
-        }
+        assert!(staged.await.unwrap(), "the staged write must be committed");
         call.await.unwrap();
     }
 
     #[tokio::test]
-    async fn delete_dynamic_neighbor_rolls_back_when_persist_fails() {
+    async fn delete_dynamic_neighbor_persist_failure_keeps_the_range() {
         let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(16);
         let (rib_tx, _rib_rx) = mpsc::channel(16);
         let (config_tx, mut config_rx) = mpsc::channel(16);
@@ -2263,47 +2191,23 @@ mod tests {
             .await
         });
 
-        let removed = RemovedDynamicRange {
-            prefix: "192.0.2.0/24".to_string(),
-            peer_group: "fabric".to_string(),
-            remote_asn: 65002,
-            description: Some("lab range".to_string()),
-        };
-        match peer_mgr_rx.recv().await.unwrap() {
-            PeerManagerCommand::DeleteDynamicRange { prefix, reply } => {
-                assert_eq!(prefix, "192.0.2.0/24");
-                reply.send(Ok(removed.clone())).unwrap();
-            }
-            _ => panic!("expected DeleteDynamicRange"),
-        }
         match config_rx.recv().await.unwrap() {
             ConfigEvent::DynamicNeighborDeleted { ack, .. } => {
-                ack.unwrap()
-                    .send(Err("disk full".to_string()))
-                    .expect("send persist failure");
+                ack.unwrap().fail_write("disk full");
             }
             _ => panic!("expected DynamicNeighborDeleted"),
-        }
-        match peer_mgr_rx.recv().await.unwrap() {
-            PeerManagerCommand::AddDynamicRange {
-                prefix,
-                peer_group,
-                remote_asn,
-                description,
-                reply,
-            } => {
-                assert_eq!(prefix, removed.prefix);
-                assert_eq!(peer_group, removed.peer_group);
-                assert_eq!(remote_asn, removed.remote_asn);
-                assert_eq!(description, removed.description);
-                reply.send(Ok(())).unwrap();
-            }
-            _ => panic!("expected AddDynamicRange rollback"),
         }
 
         let err = call.await.unwrap().unwrap_err();
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
         assert!(err.message().contains("config persistence failed"));
+        assert!(
+            matches!(
+                peer_mgr_rx.try_recv(),
+                Err(TryRecvError::Empty | TryRecvError::Disconnected)
+            ),
+            "a rejected dynamic-range delete must not touch the matcher"
+        );
     }
 
     #[tokio::test]
@@ -2994,6 +2898,21 @@ mod tests {
             .await
         });
 
+        // The config write is staged BEFORE the peer exists.
+        let staged = match config_rx.recv().await.unwrap() {
+            ConfigEvent::NeighborAdded { config, ack } => {
+                assert_eq!(config.address.to_string(), "10.0.0.2");
+                assert_eq!(config.required_families, vec![(Afi::Ipv4, Safi::Unicast)]);
+                assert!(
+                    matches!(peer_mgr_rx.try_recv(), Err(TryRecvError::Empty)),
+                    "no runtime mutation may be issued before the write is staged"
+                );
+                ack.unwrap()
+            }
+            _ => panic!("expected NeighborAdded"),
+        };
+        let staged = tokio::spawn(staged.accept());
+
         match peer_mgr_rx.recv().await.unwrap() {
             PeerManagerCommand::AddPeer {
                 config,
@@ -3001,33 +2920,25 @@ mod tests {
                 reply,
             } => {
                 assert_eq!(config.address.to_string(), "10.0.0.2");
+                assert_eq!(config.remote_asn, 65002);
                 assert_eq!(config.required_families, vec![(Afi::Ipv4, Safi::Unicast)]);
                 assert!(sync_config_snapshot);
-                reply.send(Ok(())).unwrap();
-            }
-            _ => panic!("expected AddPeer"),
-        }
-
-        match config_rx.recv().await.unwrap() {
-            ConfigEvent::NeighborAdded { config, ack } => {
-                assert_eq!(config.address.to_string(), "10.0.0.2");
-                assert_eq!(config.required_families, vec![(Afi::Ipv4, Safi::Unicast)]);
-                let ack = ack.unwrap();
                 assert!(
                     tokio::time::timeout(Duration::from_millis(20), &mut call)
                         .await
                         .is_err(),
-                    "call must wait for config persistence acknowledgement"
+                    "call must wait for the staged write to be committed"
                 );
-                ack.send(Ok(())).unwrap();
+                reply.send(Ok(())).unwrap();
             }
-            _ => panic!("expected NeighborAdded"),
+            _ => panic!("expected AddPeer"),
         }
+        assert!(staged.await.unwrap(), "the staged write must be committed");
         call.await.unwrap().unwrap();
     }
 
     #[tokio::test]
-    async fn add_neighbor_rolls_back_when_persist_fails() {
+    async fn add_neighbor_persist_failure_creates_no_peer() {
         let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(16);
         let (rib_tx, _rib_rx) = mpsc::channel(16);
         let (config_tx, mut config_rx) = mpsc::channel(16);
@@ -3057,36 +2968,25 @@ mod tests {
             .await
         });
 
-        match peer_mgr_rx.recv().await.unwrap() {
-            PeerManagerCommand::AddPeer { reply, .. } => {
-                reply.send(Ok(())).unwrap();
-            }
-            _ => panic!("expected AddPeer"),
-        }
         match config_rx.recv().await.unwrap() {
             ConfigEvent::NeighborAdded { ack, .. } => {
-                ack.unwrap()
-                    .send(Err("disk full".to_string()))
-                    .expect("send persist failure");
+                ack.unwrap().fail_write("disk full");
             }
             _ => panic!("expected NeighborAdded"),
-        }
-        match peer_mgr_rx.recv().await.unwrap() {
-            PeerManagerCommand::DeletePeer {
-                peer,
-                sync_config_snapshot,
-                reply,
-            } => {
-                assert_eq!(peer.address.to_string(), "10.0.0.2");
-                assert!(sync_config_snapshot);
-                assert!(reply.send(Ok(test_static_peer_config())).is_ok());
-            }
-            _ => panic!("expected DeletePeer rollback"),
         }
 
         let err = call.await.unwrap().unwrap_err();
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
         assert!(err.message().contains("config persistence failed"));
+        // No session was ever created, so there is nothing to compensate for:
+        // the peer manager saw no command at all.
+        assert!(
+            matches!(
+                peer_mgr_rx.try_recv(),
+                Err(TryRecvError::Empty | TryRecvError::Disconnected)
+            ),
+            "a rejected add must not touch the peer manager"
+        );
     }
 
     #[tokio::test]
@@ -3110,6 +3010,20 @@ mod tests {
             .await
         });
 
+        // The write is staged while the session is still up.
+        let staged = match config_rx.recv().await.unwrap() {
+            ConfigEvent::NeighborDeleted { peer, ack } => {
+                assert_eq!(peer.address.to_string(), "10.0.0.2");
+                assert!(
+                    matches!(peer_mgr_rx.try_recv(), Err(TryRecvError::Empty)),
+                    "the session must not be torn down before the write is staged"
+                );
+                ack.unwrap()
+            }
+            _ => panic!("expected NeighborDeleted"),
+        };
+        let staged = tokio::spawn(staged.accept());
+
         match peer_mgr_rx.recv().await.unwrap() {
             PeerManagerCommand::DeletePeer {
                 peer,
@@ -3117,90 +3031,25 @@ mod tests {
                 reply,
             } => {
                 assert_eq!(peer.address.to_string(), "10.0.0.2");
-                assert!(!sync_config_snapshot);
-                assert!(reply.send(Ok(test_static_peer_config())).is_ok());
-            }
-            _ => panic!("expected DeletePeer"),
-        }
-
-        match config_rx.recv().await.unwrap() {
-            ConfigEvent::NeighborDeleted { peer, ack } => {
-                assert_eq!(peer.address.to_string(), "10.0.0.2");
-                let ack = ack.unwrap();
+                // One command now does both: there is no separate snapshot
+                // fix-up, because the config row is no longer rollback state.
+                assert!(sync_config_snapshot);
                 assert!(
                     tokio::time::timeout(Duration::from_millis(20), &mut call)
                         .await
                         .is_err(),
-                    "call must wait for config persistence acknowledgement"
+                    "call must wait for the staged write to be committed"
                 );
-                ack.send(Ok(())).unwrap();
-            }
-            _ => panic!("expected NeighborDeleted"),
-        }
-        match peer_mgr_rx.recv().await.unwrap() {
-            PeerManagerCommand::ApplyConfigEvent { event, reply } => {
-                assert!(matches!(event, ConfigEvent::NeighborDeleted { .. }));
-                reply.send(Ok(())).unwrap();
-            }
-            _ => panic!("expected ApplyConfigEvent"),
-        }
-        call.await.unwrap().unwrap();
-    }
-
-    #[tokio::test]
-    async fn delete_neighbor_succeeds_when_snapshot_update_fails_after_persist() {
-        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(16);
-        let (rib_tx, _rib_rx) = mpsc::channel(16);
-        let (config_tx, mut config_rx) = mpsc::channel(16);
-        let svc = NeighborService::new(
-            65001,
-            AccessMode::ReadWrite,
-            peer_mgr_tx,
-            rib_tx,
-            Some(config_tx),
-        );
-
-        let call = tokio::spawn(async move {
-            svc.delete_neighbor(Request::new(proto::DeleteNeighborRequest {
-                address: "10.0.0.2".into(),
-                interface: String::new(),
-            }))
-            .await
-        });
-
-        match peer_mgr_rx.recv().await.unwrap() {
-            PeerManagerCommand::DeletePeer {
-                sync_config_snapshot,
-                reply,
-                ..
-            } => {
-                assert!(!sync_config_snapshot);
                 assert!(reply.send(Ok(test_static_peer_config())).is_ok());
             }
             _ => panic!("expected DeletePeer"),
         }
-        match config_rx.recv().await.unwrap() {
-            ConfigEvent::NeighborDeleted { ack, .. } => {
-                ack.unwrap()
-                    .send(Ok(()))
-                    .expect("send persist acknowledgement");
-            }
-            _ => panic!("expected NeighborDeleted"),
-        }
-        match peer_mgr_rx.recv().await.unwrap() {
-            PeerManagerCommand::ApplyConfigEvent { reply, .. } => {
-                reply
-                    .send(Err("peer manager shutting down".to_string()))
-                    .unwrap();
-            }
-            _ => panic!("expected ApplyConfigEvent"),
-        }
-
+        assert!(staged.await.unwrap(), "the staged write must be committed");
         call.await.unwrap().unwrap();
     }
 
     #[tokio::test]
-    async fn delete_neighbor_rolls_back_when_persist_fails() {
+    async fn delete_neighbor_persist_failure_leaves_the_session_alone() {
         let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(16);
         let (rib_tx, _rib_rx) = mpsc::channel(16);
         let (config_tx, mut config_rx) = mpsc::channel(16);
@@ -3212,7 +3061,6 @@ mod tests {
             Some(config_tx),
         );
 
-        let removed = test_static_peer_config();
         let call = tokio::spawn(async move {
             svc.delete_neighbor(Request::new(proto::DeleteNeighborRequest {
                 address: "10.0.0.2".into(),
@@ -3221,42 +3069,26 @@ mod tests {
             .await
         });
 
-        match peer_mgr_rx.recv().await.unwrap() {
-            PeerManagerCommand::DeletePeer {
-                sync_config_snapshot,
-                reply,
-                ..
-            } => {
-                assert!(!sync_config_snapshot);
-                assert!(reply.send(Ok(removed.clone())).is_ok());
-            }
-            _ => panic!("expected DeletePeer"),
-        }
         match config_rx.recv().await.unwrap() {
             ConfigEvent::NeighborDeleted { ack, .. } => {
-                ack.unwrap()
-                    .send(Err("disk full".to_string()))
-                    .expect("send persist failure");
+                ack.unwrap().fail_write("disk full");
             }
             _ => panic!("expected NeighborDeleted"),
-        }
-        match peer_mgr_rx.recv().await.unwrap() {
-            PeerManagerCommand::AddPeer {
-                config,
-                sync_config_snapshot,
-                reply,
-            } => {
-                assert_eq!(config.address, removed.address);
-                assert_eq!(config.remote_asn, removed.remote_asn);
-                assert!(sync_config_snapshot);
-                reply.send(Ok(())).unwrap();
-            }
-            _ => panic!("expected AddPeer rollback"),
         }
 
         let err = call.await.unwrap().unwrap_err();
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
         assert!(err.message().contains("config persistence failed"));
+        // The old ordering tore the session down and then re-added the peer,
+        // which the operator sees as a brand-new session with zeroed counters
+        // and no flap recorded. Nothing reaches the peer manager now.
+        assert!(
+            matches!(
+                peer_mgr_rx.try_recv(),
+                Err(TryRecvError::Empty | TryRecvError::Disconnected)
+            ),
+            "a rejected delete must not touch the live session"
+        );
     }
 
     #[tokio::test]

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -17,9 +17,8 @@ use crate::peer_types::{
 use crate::policy_helpers::proto_statement_to_input;
 use crate::proto;
 use crate::server::{
-    AccessMode, ConfigMutationGateFn, apply_catalog_mutation, catalog_mutation_error_to_status,
-    peer_manager_request, persist_rollback_error, persist_runtime_config_event,
-    read_only_rejection, run_shielded_catalog_mutation,
+    AccessMode, ConfigMutationGateFn, apply_catalog_mutation, peer_manager_request,
+    persist_then_apply, read_only_rejection, run_shielded_catalog_mutation,
 };
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -422,71 +421,44 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         let name = req.name;
         self.run_mutation("PeerGroupService.SetPeerGroup", move || async move {
-            // Prior state is the unredacted stored definition (including
-            // md5_password) so a rollback restores the secret intact.
-            let prior =
-                peer_manager_request(&peer_mgr_tx, |reply| PeerManagerCommand::GetPeerGroup {
-                    name: name.clone(),
-                    reply,
-                })
-                .await?;
-
-            let persisted = if preserve_md5_password {
-                peer_manager_request(&peer_mgr_tx, |reply| {
-                    PeerManagerCommand::SetPeerGroupPreserveMd5 {
+            // A request that omits md5_password keeps the stored secret. Read
+            // it here rather than merging inside the peer manager: the prior
+            // definition is unredacted, and this runs under the
+            // runtime-config lock every catalog writer takes, so carrying the
+            // secret forward is race-free and leaves one definition to both
+            // stage and apply.
+            let mut persisted = definition;
+            if preserve_md5_password {
+                let prior =
+                    peer_manager_request(&peer_mgr_tx, |reply| PeerManagerCommand::GetPeerGroup {
                         name: name.clone(),
-                        definition,
                         reply,
-                    }
-                })
-                .await?
-                .map_err(|error| catalog_mutation_error_to_status(&error))?
-            } else {
-                let persisted = definition.clone();
-                apply_catalog_mutation(&peer_mgr_tx, |reply| PeerManagerCommand::SetPeerGroup {
-                    name: name.clone(),
-                    definition,
-                    reply,
-                })
-                .await?;
-                persisted
-            };
-
-            if let Some(permit) = persist_permit
-                && let Err(error) =
-                    persist_runtime_config_event(permit, |ack| ConfigEvent::SetPeerGroup {
-                        name: name.clone(),
-                        definition: persisted,
-                        ack: Some(ack),
                     })
-                    .await
-            {
-                // Plain SetPeerGroup (not preserve-md5): the prior is the
-                // full stored definition, secret included.
-                let rollback = match prior {
-                    Some(prior) => {
-                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                            PeerManagerCommand::SetPeerGroup {
-                                name: name.clone(),
-                                definition: prior,
-                                reply,
-                            }
-                        })
-                        .await
-                    }
-                    None => {
-                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                            PeerManagerCommand::DeletePeerGroup {
-                                name: name.clone(),
-                                reply,
-                            }
-                        })
-                        .await
-                    }
-                };
-                return Err(persist_rollback_error("peer-group set", error, rollback));
+                    .await?
+                    .ok_or_else(|| Status::not_found(format!("peer group {name} not found")))?;
+                persisted.md5_password = prior.md5_password;
             }
-            Ok(())
+
+            // A group edit that is not policy-only rebuilds every inheriting
+            // member's session. Stage the write first so a persistence
+            // failure cannot bounce them once on the way out and again on the
+            // way back.
+            persist_then_apply(
+                persist_permit,
+                |ack| ConfigEvent::SetPeerGroup {
+                    name: name.clone(),
+                    definition: persisted.clone(),
+                    ack: Some(ack),
+                },
+                || {
+                    apply_catalog_mutation(&peer_mgr_tx, |reply| PeerManagerCommand::SetPeerGroup {
+                        name: name.clone(),
+                        definition: persisted.clone(),
+                        reply,
+                    })
+                },
+            )
+            .await
         })
         .await?;
 
@@ -509,44 +481,22 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         let name = req.name;
         self.run_mutation("PeerGroupService.DeletePeerGroup", move || async move {
-            let prior =
-                peer_manager_request(&peer_mgr_tx, |reply| PeerManagerCommand::GetPeerGroup {
+            persist_then_apply(
+                persist_permit,
+                |ack| ConfigEvent::DeletePeerGroup {
                     name: name.clone(),
-                    reply,
-                })
-                .await?;
-            apply_catalog_mutation(&peer_mgr_tx, |reply| PeerManagerCommand::DeletePeerGroup {
-                name: name.clone(),
-                reply,
-            })
-            .await?;
-
-            if let Some(permit) = persist_permit
-                && let Err(error) =
-                    persist_runtime_config_event(permit, |ack| ConfigEvent::DeletePeerGroup {
-                        name: name.clone(),
-                        ack: Some(ack),
+                    ack: Some(ack),
+                },
+                || {
+                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                        PeerManagerCommand::DeletePeerGroup {
+                            name: name.clone(),
+                            reply,
+                        }
                     })
-                    .await
-            {
-                let rollback = match prior {
-                    Some(prior) => {
-                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                            PeerManagerCommand::SetPeerGroup {
-                                name: name.clone(),
-                                definition: prior,
-                                reply,
-                            }
-                        })
-                        .await
-                    }
-                    // Deletes are idempotent (a missing group is not an
-                    // error), so a `None` prior leaves nothing to restore.
-                    None => Ok(()),
-                };
-                return Err(persist_rollback_error("peer-group delete", error, rollback));
-            }
-            Ok(())
+                },
+            )
+            .await
         })
         .await?;
 
@@ -575,58 +525,26 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
         self.run_mutation(
             "PeerGroupService.SetNeighborPeerGroup",
             move || async move {
-                let prior = peer_manager_request(&peer_mgr_tx, |reply| {
-                    PeerManagerCommand::GetNeighborPeerGroupMembership { address, reply }
-                })
-                .await?;
-                apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                    PeerManagerCommand::SetNeighborPeerGroup {
+                // A membership change reshapes the neighbor's session. Stage
+                // the write first so a persistence failure cannot bounce it.
+                persist_then_apply(
+                    persist_permit,
+                    |ack| ConfigEvent::SetNeighborPeerGroup {
                         address,
                         peer_group: peer_group.clone(),
-                        reply,
-                    }
-                })
-                .await?;
-
-                if let Some(permit) = persist_permit
-                    && let Err(error) = persist_runtime_config_event(permit, |ack| {
-                        ConfigEvent::SetNeighborPeerGroup {
-                            address,
-                            peer_group: peer_group.clone(),
-                            ack: Some(ack),
-                        }
-                    })
-                    .await
-                {
-                    let rollback = match prior {
-                        Some(Some(prior)) => {
-                            apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                                PeerManagerCommand::SetNeighborPeerGroup {
-                                    address,
-                                    peer_group: prior,
-                                    reply,
-                                }
-                            })
-                            .await
-                        }
-                        Some(None) => {
-                            apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                                PeerManagerCommand::ClearNeighborPeerGroup { address, reply }
-                            })
-                            .await
-                        }
-                        // The mutation succeeded, so the neighbor was
-                        // configured; an unexpectedly missing prior leaves
-                        // nothing to restore.
-                        None => Ok(()),
-                    };
-                    return Err(persist_rollback_error(
-                        "neighbor peer-group set",
-                        error,
-                        rollback,
-                    ));
-                }
-                Ok(())
+                        ack: Some(ack),
+                    },
+                    || {
+                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                            PeerManagerCommand::SetNeighborPeerGroup {
+                                address,
+                                peer_group: peer_group.clone(),
+                                reply,
+                            }
+                        })
+                    },
+                )
+                .await
             },
         )
         .await?;
@@ -652,46 +570,19 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
         self.run_mutation(
             "PeerGroupService.ClearNeighborPeerGroup",
             move || async move {
-                let prior = peer_manager_request(&peer_mgr_tx, |reply| {
-                    PeerManagerCommand::GetNeighborPeerGroupMembership { address, reply }
-                })
-                .await?;
-                apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                    PeerManagerCommand::ClearNeighborPeerGroup { address, reply }
-                })
-                .await?;
-
-                if let Some(permit) = persist_permit
-                    && let Err(error) = persist_runtime_config_event(permit, |ack| {
-                        ConfigEvent::ClearNeighborPeerGroup {
-                            address,
-                            ack: Some(ack),
-                        }
-                    })
-                    .await
-                {
-                    let rollback = match prior {
-                        Some(Some(prior)) => {
-                            apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                                PeerManagerCommand::SetNeighborPeerGroup {
-                                    address,
-                                    peer_group: prior,
-                                    reply,
-                                }
-                            })
-                            .await
-                        }
-                        // No prior membership (or no neighbor) — the
-                        // cleared state is already the prior state.
-                        Some(None) | None => Ok(()),
-                    };
-                    return Err(persist_rollback_error(
-                        "neighbor peer-group clear",
-                        error,
-                        rollback,
-                    ));
-                }
-                Ok(())
+                persist_then_apply(
+                    persist_permit,
+                    |ack| ConfigEvent::ClearNeighborPeerGroup {
+                        address,
+                        ack: Some(ack),
+                    },
+                    || {
+                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                            PeerManagerCommand::ClearNeighborPeerGroup { address, reply }
+                        })
+                    },
+                )
+                .await
             },
         )
         .await?;
@@ -911,18 +802,27 @@ mod tests {
             while let Some(cmd) = peer_rx.recv().await {
                 match cmd {
                     PeerManagerCommand::GetPeerGroup { reply, .. } => {
-                        let _ = reply.send(None);
+                        let mut stored =
+                            proto_definition_to_input(proto::PeerGroupDefinition::default())
+                                .expect("stored peer group");
+                        stored.md5_password = Some("secret".into());
+                        let _ = reply.send(Some(stored));
                     }
-                    PeerManagerCommand::SetPeerGroupPreserveMd5 {
+                    PeerManagerCommand::SetPeerGroup {
                         name,
-                        mut definition,
+                        definition,
                         reply,
                     } => {
                         assert_eq!(name, "rs-clients");
-                        assert_eq!(definition.md5_password, None);
+                        assert_eq!(
+                            definition
+                                .md5_password
+                                .as_ref()
+                                .map(std::convert::AsRef::as_ref),
+                            Some("secret")
+                        );
                         assert_eq!(definition.families, vec!["ipv6_unicast"]);
-                        definition.md5_password = Some("secret".into());
-                        let _ = reply.send(Ok(definition));
+                        let _ = reply.send(Ok(()));
                     }
                     _ => panic!("unexpected peer-manager command"),
                 }
@@ -961,8 +861,8 @@ mod tests {
                 );
                 assert_eq!(definition.families, vec!["ipv6_unicast"]);
                 ack.expect("persisted mutation must carry an ack")
-                    .send(Ok(()))
-                    .expect("service should await the persistence ack");
+                    .accept()
+                    .await;
             }
             Some(_) => panic!("unexpected config event"),
             None => panic!("missing config event"),
@@ -1050,17 +950,26 @@ mod tests {
             while let Some(cmd) = peer_rx.recv().await {
                 match cmd {
                     PeerManagerCommand::GetPeerGroup { reply, .. } => {
-                        let _ = reply.send(None);
+                        let mut stored =
+                            proto_definition_to_input(proto::PeerGroupDefinition::default())
+                                .expect("stored peer group");
+                        stored.md5_password = Some("secret".into());
+                        let _ = reply.send(Some(stored));
                     }
-                    PeerManagerCommand::SetPeerGroupPreserveMd5 {
+                    PeerManagerCommand::SetPeerGroup {
                         name,
-                        mut definition,
+                        definition,
                         reply,
                     } => {
                         assert_eq!(name, "rs-clients");
-                        assert_eq!(definition.md5_password, None);
-                        definition.md5_password = Some("secret".into());
-                        let _ = reply.send(Ok(definition));
+                        assert_eq!(
+                            definition
+                                .md5_password
+                                .as_ref()
+                                .map(std::convert::AsRef::as_ref),
+                            Some("secret")
+                        );
+                        let _ = reply.send(Ok(()));
                     }
                     _ => panic!("unexpected peer-manager command"),
                 }
@@ -1184,7 +1093,7 @@ mod tests {
     /// definition — including the stored MD5 secret, which read RPCs
     /// redact but the rollback must not lose.
     #[tokio::test]
-    async fn set_peer_group_rolls_back_runtime_when_persist_fails() {
+    async fn set_peer_group_persist_failure_leaves_the_group_alone() {
         let (peer_tx, mut peer_rx) = mpsc::channel(8);
         let (config_tx, mut config_rx) = mpsc::channel(4);
         let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
@@ -1229,8 +1138,7 @@ mod tests {
         match config_rx.recv().await {
             Some(ConfigEvent::SetPeerGroup { ack, .. }) => {
                 ack.expect("persisted mutation must carry an ack")
-                    .send(Err("disk full".to_string()))
-                    .expect("service should await the persistence ack");
+                    .fail_write("disk full");
             }
             Some(_) => panic!("unexpected config event"),
             None => panic!("missing config event"),
@@ -1243,28 +1151,19 @@ mod tests {
         assert_eq!(error.code(), tonic::Code::FailedPrecondition);
         assert!(error.message().contains("config persistence failed"));
 
-        let sets = set_definitions.lock().await;
-        assert_eq!(sets.len(), 2, "mutation then rollback");
-        assert_eq!(
-            sets[0]
-                .md5_password
-                .as_ref()
-                .map(std::convert::AsRef::as_ref),
-            Some("new-secret")
+        // A non-policy-only group edit rebuilds every inheriting member's
+        // session. The old ordering bounced them on the way out and again on
+        // the way back for a request that was rejected; the candidate is
+        // never applied now, so the stored secret is never at risk either.
+        assert!(
+            set_definitions.lock().await.is_empty(),
+            "a rejected peer-group set must not reshape any member session"
         );
-        assert_eq!(
-            sets[1]
-                .md5_password
-                .as_ref()
-                .map(std::convert::AsRef::as_ref),
-            Some("old-secret"),
-            "rollback must restore the prior definition with its stored secret"
-        );
-        assert_eq!(sets[1], prior);
+        drop(prior);
     }
 
     #[tokio::test]
-    async fn delete_peer_group_rolls_back_runtime_when_persist_fails() {
+    async fn delete_peer_group_persist_failure_leaves_the_group_alone() {
         let (peer_tx, mut peer_rx) = mpsc::channel(8);
         let (config_tx, mut config_rx) = mpsc::channel(4);
         let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
@@ -1307,8 +1206,7 @@ mod tests {
         match config_rx.recv().await {
             Some(ConfigEvent::DeletePeerGroup { ack, .. }) => {
                 ack.expect("persisted mutation must carry an ack")
-                    .send(Err("disk full".to_string()))
-                    .expect("service should await the persistence ack");
+                    .fail_write("disk full");
             }
             Some(_) => panic!("unexpected config event"),
             None => panic!("missing config event"),
@@ -1320,16 +1218,16 @@ mod tests {
             .expect_err("delete_peer_group must fail when persistence fails");
         assert_eq!(error.code(), tonic::Code::FailedPrecondition);
 
-        let sets = set_definitions.lock().await;
-        assert_eq!(
-            sets.as_slice(),
-            &[prior],
-            "rollback must re-create the deleted peer group"
+        assert!(
+            set_definitions.lock().await.is_empty(),
+            "a rejected peer-group delete must not re-create anything, because \
+             it never deleted anything"
         );
+        drop(prior);
     }
 
     #[tokio::test]
-    async fn set_neighbor_peer_group_rolls_back_runtime_when_persist_fails() {
+    async fn set_neighbor_peer_group_persist_failure_leaves_membership_alone() {
         let (peer_tx, mut peer_rx) = mpsc::channel(8);
         let (config_tx, mut config_rx) = mpsc::channel(4);
         let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
@@ -1373,8 +1271,7 @@ mod tests {
                 assert_eq!(address.to_string(), "10.0.0.2");
                 assert_eq!(peer_group, "rs-clients");
                 ack.expect("persisted mutation must carry an ack")
-                    .send(Err("disk full".to_string()))
-                    .expect("service should await the persistence ack");
+                    .fail_write("disk full");
             }
             Some(_) => panic!("unexpected config event"),
             None => panic!("missing config event"),
@@ -1386,11 +1283,9 @@ mod tests {
             .expect_err("set_neighbor_peer_group must fail when persistence fails");
         assert_eq!(error.code(), tonic::Code::FailedPrecondition);
 
-        let sets = memberships.lock().await;
-        assert_eq!(
-            sets.as_slice(),
-            &["rs-clients".to_string(), "old-group".to_string()],
-            "rollback must restore the prior membership"
+        assert!(
+            memberships.lock().await.is_empty(),
+            "a rejected membership change must not bounce the session"
         );
     }
 }

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -1265,16 +1265,6 @@ pub enum PeerManagerCommand {
         /// Reply channel for success/failure.
         reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
-    /// Create or replace a peer group while preserving the existing
-    /// MD5 password atomically inside the peer-manager actor.
-    SetPeerGroupPreserveMd5 {
-        /// Peer-group name.
-        name: String,
-        /// Full replacement definition except for the MD5 password.
-        definition: PeerGroupDefinition,
-        /// Reply channel returning the applied definition for persistence.
-        reply: oneshot::Sender<Result<PeerGroupDefinition, CatalogMutationError>>,
-    },
     /// Delete a peer group.
     DeletePeerGroup {
         /// Peer-group name.
@@ -1730,6 +1720,99 @@ pub struct FibTableSnapshot {
     pub maximum_paths_ibgp: Option<u32>,
 }
 
+/// Why a config event never reached the config file. Either way nothing was
+/// written, and — because staging runs before the caller's runtime change —
+/// nothing was mutated.
+#[derive(Debug, Clone)]
+pub enum ConfigPersistError {
+    /// The candidate config did not validate. Staging is now the first thing
+    /// a mutating RPC does, so this is where a bad request is caught; it
+    /// carries the same typed error the runtime apply would have produced, so
+    /// the caller still answers `NOT_FOUND` / `INVALID_ARGUMENT` rather than
+    /// dressing a rejected request up as a persistence fault.
+    Rejected(CatalogMutationError),
+    /// The durable write itself failed (unwritable directory, read-only
+    /// mount, full filesystem).
+    Write(String),
+}
+
+impl std::fmt::Display for ConfigPersistError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rejected(error) => write!(f, "{error}"),
+            Self::Write(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+/// Two-phase persistence acknowledgement carried by a [`ConfigEvent`].
+///
+/// `FAILED_PRECONDITION` from a mutating RPC means the request did nothing.
+/// Honouring that on a persistence failure requires reserving the on-disk
+/// write *before* the runtime change, because the runtime changes a mutating
+/// RPC makes are not undoable: re-adding a deleted neighbor starts a new
+/// session with a new identity, a zeroed uptime, zeroed counters, and a fresh
+/// metric series — the operator's flap accounting never even records it.
+///
+/// So the config bridge folds the event onto the config snapshot, serializes
+/// it, and durably stages the result next to the config file, then reports on
+/// `staged`. Nothing is observable on disk yet. The caller applies its runtime
+/// change and returns its commit channel through `commit`; dropping that
+/// channel discards the staged write instead.
+pub struct ConfigPersistAck {
+    /// Fires once the candidate is durably staged, or with the staging
+    /// failure. A failure here means nothing was written and — because the
+    /// caller has not applied yet — nothing was mutated.
+    pub staged: oneshot::Sender<Result<(), ConfigPersistError>>,
+    /// Carries the caller's reply channel once its runtime change landed,
+    /// which publishes the staged write. Dropping it discards the stage.
+    ///
+    /// `None` requests single-phase persistence: the bridge publishes as soon
+    /// as the candidate is staged and reports the durable outcome on `staged`.
+    /// Used by the paths that own an apply/rollback executor of their own
+    /// (ADR-0076 config transactions, FIB-table CRUD).
+    pub commit: Option<oneshot::Receiver<oneshot::Sender<Result<(), String>>>>,
+}
+
+impl ConfigPersistAck {
+    /// Single-phase acknowledgement: stage and publish in one step, reporting
+    /// the durable outcome on the supplied channel.
+    #[must_use]
+    pub fn immediate(staged: oneshot::Sender<Result<(), ConfigPersistError>>) -> Self {
+        Self {
+            staged,
+            commit: None,
+        }
+    }
+
+    /// Drive the handshake to a successful persist, the way the config bridge
+    /// does: acknowledge the stage, then acknowledge the caller's commit.
+    ///
+    /// Returns whether the caller committed. `false` means it dropped the
+    /// staged write, so nothing was persisted.
+    pub async fn accept(self) -> bool {
+        let _ = self.staged.send(Ok(()));
+        let Some(commit) = self.commit else {
+            return true;
+        };
+        match commit.await {
+            Ok(reply) => {
+                let _ = reply.send(Ok(()));
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Fail the handshake the way an unwritable config file does: the durable
+    /// write never landed, and the caller has not mutated anything yet.
+    pub fn fail_write(self, message: impl Into<String>) {
+        let _ = self
+            .staged
+            .send(Err(ConfigPersistError::Write(message.into())));
+    }
+}
+
 /// A config persistence event sent after successful peer add/delete.
 ///
 /// The binary crate converts these into config file mutations.
@@ -1744,7 +1827,7 @@ pub enum ConfigEvent {
         /// Full accepted table set.
         tables: Vec<FibTableSnapshot>,
         /// Optional persistence acknowledgement.
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// A neighbor was successfully added at runtime.
     NeighborAdded {
@@ -1753,14 +1836,14 @@ pub enum ConfigEvent {
         /// Optional persistence acknowledgement. Runtime CRUD paths hold the
         /// shared runtime-config lock until this fires, so SIGHUP cannot read a
         /// stale TOML between runtime mutation and on-disk commit.
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// A neighbor was successfully deleted at runtime.
     NeighborDeleted {
         /// Peer identity that was deleted.
         peer: PeerKey,
         /// Optional persistence acknowledgement (see `NeighborAdded`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// A dynamic neighbor range was successfully added at runtime.
     DynamicNeighborAdded {
@@ -1776,14 +1859,14 @@ pub enum ConfigEvent {
         /// holds the shared runtime-config lock until this fires, so a SIGHUP
         /// reload cannot read a stale TOML between the runtime mutation and the
         /// on-disk commit.
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// A dynamic neighbor range was successfully removed at runtime.
     DynamicNeighborDeleted {
         /// IP prefix range that was removed (matched by effective prefix).
         prefix: String,
         /// Optional persistence acknowledgement (see `DynamicNeighborAdded`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// A config transaction committed a full candidate snapshot. This event is
     /// daemon-internal: transaction apply has already proven the live diff is a
@@ -1793,7 +1876,7 @@ pub enum ConfigEvent {
         /// Complete candidate TOML to parse, validate, and persist.
         candidate_toml: String,
         /// Optional persistence acknowledgement.
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// Create or replace a named policy definition.
     SetPolicy {
@@ -1804,14 +1887,14 @@ pub enum ConfigEvent {
         /// Optional persistence acknowledgement. Catalog CRUD paths hold
         /// the shared runtime-config lock until this fires (see
         /// `NeighborAdded`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// Delete a named policy definition.
     DeletePolicy {
         /// Policy definition name.
         name: String,
         /// Optional persistence acknowledgement (see `SetPolicy`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// Create or replace a named neighbor set.
     SetNeighborSet {
@@ -1820,38 +1903,38 @@ pub enum ConfigEvent {
         /// Full replacement definition.
         definition: NeighborSetDefinition,
         /// Optional persistence acknowledgement (see `SetPolicy`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// Delete a named neighbor set.
     DeleteNeighborSet {
         /// Neighbor-set name.
         name: String,
         /// Optional persistence acknowledgement (see `SetPolicy`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// Replace the global import policy chain.
     SetGlobalImportChain {
         /// Ordered policy names.
         policy_names: Vec<String>,
         /// Optional persistence acknowledgement (see `SetPolicy`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// Replace the global export policy chain.
     SetGlobalExportChain {
         /// Ordered policy names.
         policy_names: Vec<String>,
         /// Optional persistence acknowledgement (see `SetPolicy`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// Clear the global import policy chain.
     ClearGlobalImportChain {
         /// Optional persistence acknowledgement (see `SetPolicy`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// Clear the global export policy chain.
     ClearGlobalExportChain {
         /// Optional persistence acknowledgement (see `SetPolicy`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// Replace the per-neighbor import policy chain.
     SetNeighborImportChain {
@@ -1860,7 +1943,7 @@ pub enum ConfigEvent {
         /// Ordered policy names.
         policy_names: Vec<String>,
         /// Optional persistence acknowledgement (see `SetPolicy`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// Replace the per-neighbor export policy chain.
     SetNeighborExportChain {
@@ -1869,21 +1952,21 @@ pub enum ConfigEvent {
         /// Ordered policy names.
         policy_names: Vec<String>,
         /// Optional persistence acknowledgement (see `SetPolicy`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// Clear the per-neighbor import policy chain.
     ClearNeighborImportChain {
         /// Neighbor address.
         address: IpAddr,
         /// Optional persistence acknowledgement (see `SetPolicy`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// Clear the per-neighbor export policy chain.
     ClearNeighborExportChain {
         /// Neighbor address.
         address: IpAddr,
         /// Optional persistence acknowledgement (see `SetPolicy`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// Create or replace a peer-group definition.
     SetPeerGroup {
@@ -1892,14 +1975,14 @@ pub enum ConfigEvent {
         /// Full replacement definition.
         definition: PeerGroupDefinition,
         /// Optional persistence acknowledgement (see `SetPolicy`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// Delete a peer-group definition.
     DeletePeerGroup {
         /// Peer-group name.
         name: String,
         /// Optional persistence acknowledgement (see `SetPolicy`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// Set a neighbor's peer-group membership.
     SetNeighborPeerGroup {
@@ -1908,14 +1991,14 @@ pub enum ConfigEvent {
         /// Peer-group name.
         peer_group: String,
         /// Optional persistence acknowledgement (see `SetPolicy`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
     /// Clear a neighbor's peer-group membership.
     ClearNeighborPeerGroup {
         /// Neighbor address.
         address: IpAddr,
         /// Optional persistence acknowledgement (see `SetPolicy`).
-        ack: Option<oneshot::Sender<Result<(), String>>>,
+        ack: Option<ConfigPersistAck>,
     },
 }
 

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -17,8 +17,7 @@ use crate::policy_helpers::{proto_statement_to_input, validate_policy_action};
 use crate::proto;
 use crate::server::{
     AccessMode, ConfigMutationGateFn, apply_catalog_mutation, catalog_mutation_error_to_status,
-    peer_manager_request, persist_rollback_error, persist_runtime_config_event,
-    read_only_rejection, run_shielded_catalog_mutation,
+    peer_manager_request, persist_then_apply, read_only_rejection, run_shielded_catalog_mutation,
 };
 use std::sync::Arc;
 
@@ -355,23 +354,6 @@ impl PolicyService {
     }
 }
 
-async fn get_policy_definition(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    name: String,
-) -> Result<Option<NamedPolicyDefinition>, Status> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(PeerManagerCommand::GetPolicy {
-            name,
-            reply: reply_tx,
-        })
-        .await
-        .map_err(|_| Status::internal("peer manager unavailable"))?;
-    reply_rx
-        .await
-        .map_err(|_| Status::internal("peer manager dropped reply"))
-}
-
 async fn set_policy_definition(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     name: String,
@@ -410,97 +392,22 @@ async fn delete_policy_definition(
         .map_err(|error| catalog_mutation_error_to_status(&error))
 }
 
-/// Restore a prior global import chain. An empty prior chain and a
-/// cleared chain are the same config state (`policy.import_chain`), so
-/// an empty restore issues the clear command.
-async fn restore_global_import_chain(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    prior: Vec<String>,
-) -> Result<(), Status> {
-    if prior.is_empty() {
-        apply_catalog_mutation(peer_mgr_tx, |reply| {
-            PeerManagerCommand::ClearGlobalImportChain { reply }
-        })
-        .await
-    } else {
-        apply_catalog_mutation(peer_mgr_tx, |reply| {
-            PeerManagerCommand::SetGlobalImportChain {
-                policy_names: prior,
-                reply,
-            }
-        })
-        .await
-    }
-}
-
-/// Restore a prior global export chain (see `restore_global_import_chain`
-/// for the empty-chain equivalence).
-async fn restore_global_export_chain(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    prior: Vec<String>,
-) -> Result<(), Status> {
-    if prior.is_empty() {
-        apply_catalog_mutation(peer_mgr_tx, |reply| {
-            PeerManagerCommand::ClearGlobalExportChain { reply }
-        })
-        .await
-    } else {
-        apply_catalog_mutation(peer_mgr_tx, |reply| {
-            PeerManagerCommand::SetGlobalExportChain {
-                policy_names: prior,
-                reply,
-            }
-        })
-        .await
-    }
-}
-
-/// Restore a prior per-neighbor import chain (see
-/// `restore_global_import_chain` for the empty-chain equivalence).
-async fn restore_neighbor_import_chain(
+/// Reject a chain mutation for a neighbor that is not configured, without
+/// mutating anything.
+///
+/// The mutators used to discover this from the runtime apply. Staging now
+/// runs first, so the check has to run before it — a request naming an
+/// unknown neighbor is `NOT_FOUND`, not a persistence failure.
+async fn require_configured_neighbor(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     address: IpAddr,
-    prior: Vec<String>,
 ) -> Result<(), Status> {
-    if prior.is_empty() {
-        apply_catalog_mutation(peer_mgr_tx, |reply| {
-            PeerManagerCommand::ClearNeighborImportChain { address, reply }
-        })
-        .await
-    } else {
-        apply_catalog_mutation(peer_mgr_tx, |reply| {
-            PeerManagerCommand::SetNeighborImportChain {
-                address,
-                policy_names: prior,
-                reply,
-            }
-        })
-        .await
-    }
-}
-
-/// Restore a prior per-neighbor export chain (see
-/// `restore_global_import_chain` for the empty-chain equivalence).
-async fn restore_neighbor_export_chain(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    address: IpAddr,
-    prior: Vec<String>,
-) -> Result<(), Status> {
-    if prior.is_empty() {
-        apply_catalog_mutation(peer_mgr_tx, |reply| {
-            PeerManagerCommand::ClearNeighborExportChain { address, reply }
-        })
-        .await
-    } else {
-        apply_catalog_mutation(peer_mgr_tx, |reply| {
-            PeerManagerCommand::SetNeighborExportChain {
-                address,
-                policy_names: prior,
-                reply,
-            }
-        })
-        .await
-    }
+    peer_manager_request(peer_mgr_tx, |reply| {
+        PeerManagerCommand::GetNeighborPolicyChains { address, reply }
+    })
+    .await?
+    .ok_or_else(|| Status::not_found(format!("neighbor {address} not found")))
+    .map(|_| ())
 }
 
 #[tonic::async_trait]
@@ -574,28 +481,20 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         let name = req.name;
         self.run_mutation("PolicyService.SetPolicy", move || async move {
-            // Prior state is read inside the runtime-config lock, so it
-            // cannot race another catalog writer (all of them take this
-            // lock); it becomes the rollback target if persistence fails.
-            let prior = get_policy_definition(&peer_mgr_tx, name.clone()).await?;
-            set_policy_definition(&peer_mgr_tx, name.clone(), definition.clone()).await?;
-
-            if let Some(permit) = persist_permit
-                && let Err(error) =
-                    persist_runtime_config_event(permit, |ack| ConfigEvent::SetPolicy {
-                        name: name.clone(),
-                        definition: definition.clone(),
-                        ack: Some(ack),
-                    })
-                    .await
-            {
-                let rollback = match prior {
-                    Some(prior) => set_policy_definition(&peer_mgr_tx, name.clone(), prior).await,
-                    None => delete_policy_definition(&peer_mgr_tx, name.clone()).await,
-                };
-                return Err(persist_rollback_error("policy set", error, rollback));
-            }
-            Ok(())
+            // A policy edit re-evaluates live sessions: it rewrites
+            // Adj-RIB-Out and drives a Route Refresh. Stage the write first
+            // so a persistence failure does not put that churn on the wire
+            // and then a second round of it as "rollback".
+            persist_then_apply(
+                persist_permit,
+                |ack| ConfigEvent::SetPolicy {
+                    name: name.clone(),
+                    definition: definition.clone(),
+                    ack: Some(ack),
+                },
+                || set_policy_definition(&peer_mgr_tx, name.clone(), definition.clone()),
+            )
+            .await
         })
         .await?;
 
@@ -618,26 +517,15 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         let name = req.name;
         self.run_mutation("PolicyService.DeletePolicy", move || async move {
-            let prior = get_policy_definition(&peer_mgr_tx, name.clone()).await?;
-            delete_policy_definition(&peer_mgr_tx, name.clone()).await?;
-
-            if let Some(permit) = persist_permit
-                && let Err(error) =
-                    persist_runtime_config_event(permit, |ack| ConfigEvent::DeletePolicy {
-                        name: name.clone(),
-                        ack: Some(ack),
-                    })
-                    .await
-            {
-                let rollback = match prior {
-                    Some(prior) => set_policy_definition(&peer_mgr_tx, name.clone(), prior).await,
-                    // Deletes are idempotent (a missing policy is not an
-                    // error), so a `None` prior leaves nothing to restore.
-                    None => Ok(()),
-                };
-                return Err(persist_rollback_error("policy delete", error, rollback));
-            }
-            Ok(())
+            persist_then_apply(
+                persist_permit,
+                |ack| ConfigEvent::DeletePolicy {
+                    name: name.clone(),
+                    ack: Some(ack),
+                },
+                || delete_policy_definition(&peer_mgr_tx, name.clone()),
+            )
+            .await
         })
         .await?;
 
@@ -725,52 +613,24 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         let name = req.name;
         self.run_mutation("PolicyService.SetNeighborSet", move || async move {
-            let prior =
-                peer_manager_request(&peer_mgr_tx, |reply| PeerManagerCommand::GetNeighborSet {
+            persist_then_apply(
+                persist_permit,
+                |ack| ConfigEvent::SetNeighborSet {
                     name: name.clone(),
-                    reply,
-                })
-                .await?;
-            apply_catalog_mutation(&peer_mgr_tx, |reply| PeerManagerCommand::SetNeighborSet {
-                name: name.clone(),
-                definition: definition.clone(),
-                reply,
-            })
-            .await?;
-
-            if let Some(permit) = persist_permit
-                && let Err(error) =
-                    persist_runtime_config_event(permit, |ack| ConfigEvent::SetNeighborSet {
-                        name: name.clone(),
-                        definition: definition.clone(),
-                        ack: Some(ack),
+                    definition: definition.clone(),
+                    ack: Some(ack),
+                },
+                || {
+                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                        PeerManagerCommand::SetNeighborSet {
+                            name: name.clone(),
+                            definition: definition.clone(),
+                            reply,
+                        }
                     })
-                    .await
-            {
-                let rollback = match prior {
-                    Some(prior) => {
-                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                            PeerManagerCommand::SetNeighborSet {
-                                name: name.clone(),
-                                definition: prior,
-                                reply,
-                            }
-                        })
-                        .await
-                    }
-                    None => {
-                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                            PeerManagerCommand::DeleteNeighborSet {
-                                name: name.clone(),
-                                reply,
-                            }
-                        })
-                        .await
-                    }
-                };
-                return Err(persist_rollback_error("neighbor-set set", error, rollback));
-            }
-            Ok(())
+                },
+            )
+            .await
         })
         .await?;
 
@@ -793,50 +653,22 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         let name = req.name;
         self.run_mutation("PolicyService.DeleteNeighborSet", move || async move {
-            let prior =
-                peer_manager_request(&peer_mgr_tx, |reply| PeerManagerCommand::GetNeighborSet {
+            persist_then_apply(
+                persist_permit,
+                |ack| ConfigEvent::DeleteNeighborSet {
                     name: name.clone(),
-                    reply,
-                })
-                .await?;
-            apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                PeerManagerCommand::DeleteNeighborSet {
-                    name: name.clone(),
-                    reply,
-                }
-            })
-            .await?;
-
-            if let Some(permit) = persist_permit
-                && let Err(error) =
-                    persist_runtime_config_event(permit, |ack| ConfigEvent::DeleteNeighborSet {
-                        name: name.clone(),
-                        ack: Some(ack),
+                    ack: Some(ack),
+                },
+                || {
+                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                        PeerManagerCommand::DeleteNeighborSet {
+                            name: name.clone(),
+                            reply,
+                        }
                     })
-                    .await
-            {
-                let rollback = match prior {
-                    Some(prior) => {
-                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                            PeerManagerCommand::SetNeighborSet {
-                                name: name.clone(),
-                                definition: prior,
-                                reply,
-                            }
-                        })
-                        .await
-                    }
-                    // Deletes are idempotent (a missing set is not an
-                    // error), so a `None` prior leaves nothing to restore.
-                    None => Ok(()),
-                };
-                return Err(persist_rollback_error(
-                    "neighbor-set delete",
-                    error,
-                    rollback,
-                ));
-            }
-            Ok(())
+                },
+            )
+            .await
         })
         .await?;
 
@@ -873,35 +705,22 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         let policy_names = req.policy_names;
         self.run_mutation("PolicyService.SetGlobalImportChain", move || async move {
-            let prior = peer_manager_request(&peer_mgr_tx, |reply| {
-                PeerManagerCommand::GetGlobalPolicyChains { reply }
-            })
-            .await?;
-            apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                PeerManagerCommand::SetGlobalImportChain {
+            persist_then_apply(
+                persist_permit,
+                |ack| ConfigEvent::SetGlobalImportChain {
                     policy_names: policy_names.clone(),
-                    reply,
-                }
-            })
-            .await?;
-
-            if let Some(permit) = persist_permit
-                && let Err(error) =
-                    persist_runtime_config_event(permit, |ack| ConfigEvent::SetGlobalImportChain {
-                        policy_names: policy_names.clone(),
-                        ack: Some(ack),
+                    ack: Some(ack),
+                },
+                || {
+                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                        PeerManagerCommand::SetGlobalImportChain {
+                            policy_names: policy_names.clone(),
+                            reply,
+                        }
                     })
-                    .await
-            {
-                let rollback =
-                    restore_global_import_chain(&peer_mgr_tx, prior.import_policy_names).await;
-                return Err(persist_rollback_error(
-                    "global import-chain set",
-                    error,
-                    rollback,
-                ));
-            }
-            Ok(())
+                },
+            )
+            .await
         })
         .await?;
 
@@ -920,35 +739,22 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         let policy_names = req.policy_names;
         self.run_mutation("PolicyService.SetGlobalExportChain", move || async move {
-            let prior = peer_manager_request(&peer_mgr_tx, |reply| {
-                PeerManagerCommand::GetGlobalPolicyChains { reply }
-            })
-            .await?;
-            apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                PeerManagerCommand::SetGlobalExportChain {
+            persist_then_apply(
+                persist_permit,
+                |ack| ConfigEvent::SetGlobalExportChain {
                     policy_names: policy_names.clone(),
-                    reply,
-                }
-            })
-            .await?;
-
-            if let Some(permit) = persist_permit
-                && let Err(error) =
-                    persist_runtime_config_event(permit, |ack| ConfigEvent::SetGlobalExportChain {
-                        policy_names: policy_names.clone(),
-                        ack: Some(ack),
+                    ack: Some(ack),
+                },
+                || {
+                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                        PeerManagerCommand::SetGlobalExportChain {
+                            policy_names: policy_names.clone(),
+                            reply,
+                        }
                     })
-                    .await
-            {
-                let rollback =
-                    restore_global_export_chain(&peer_mgr_tx, prior.export_policy_names).await;
-                return Err(persist_rollback_error(
-                    "global export-chain set",
-                    error,
-                    rollback,
-                ));
-            }
-            Ok(())
+                },
+            )
+            .await
         })
         .await?;
 
@@ -965,30 +771,16 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         self.run_mutation("PolicyService.ClearGlobalImportChain", move || async move {
-            let prior = peer_manager_request(&peer_mgr_tx, |reply| {
-                PeerManagerCommand::GetGlobalPolicyChains { reply }
-            })
-            .await?;
-            apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                PeerManagerCommand::ClearGlobalImportChain { reply }
-            })
-            .await?;
-
-            if let Some(permit) = persist_permit
-                && let Err(error) = persist_runtime_config_event(permit, |ack| {
-                    ConfigEvent::ClearGlobalImportChain { ack: Some(ack) }
-                })
-                .await
-            {
-                let rollback =
-                    restore_global_import_chain(&peer_mgr_tx, prior.import_policy_names).await;
-                return Err(persist_rollback_error(
-                    "global import-chain clear",
-                    error,
-                    rollback,
-                ));
-            }
-            Ok(())
+            persist_then_apply(
+                persist_permit,
+                |ack| ConfigEvent::ClearGlobalImportChain { ack: Some(ack) },
+                || {
+                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                        PeerManagerCommand::ClearGlobalImportChain { reply }
+                    })
+                },
+            )
+            .await
         })
         .await?;
 
@@ -1005,30 +797,16 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         self.run_mutation("PolicyService.ClearGlobalExportChain", move || async move {
-            let prior = peer_manager_request(&peer_mgr_tx, |reply| {
-                PeerManagerCommand::GetGlobalPolicyChains { reply }
-            })
-            .await?;
-            apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                PeerManagerCommand::ClearGlobalExportChain { reply }
-            })
-            .await?;
-
-            if let Some(permit) = persist_permit
-                && let Err(error) = persist_runtime_config_event(permit, |ack| {
-                    ConfigEvent::ClearGlobalExportChain { ack: Some(ack) }
-                })
-                .await
-            {
-                let rollback =
-                    restore_global_export_chain(&peer_mgr_tx, prior.export_policy_names).await;
-                return Err(persist_rollback_error(
-                    "global export-chain clear",
-                    error,
-                    rollback,
-                ));
-            }
-            Ok(())
+            persist_then_apply(
+                persist_permit,
+                |ack| ConfigEvent::ClearGlobalExportChain { ack: Some(ack) },
+                || {
+                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                        PeerManagerCommand::ClearGlobalExportChain { reply }
+                    })
+                },
+            )
+            .await
         })
         .await?;
 
@@ -1079,50 +857,25 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         let policy_names = req.policy_names;
         self.run_mutation("PolicyService.SetNeighborImportChain", move || async move {
-            let prior = peer_manager_request(&peer_mgr_tx, |reply| {
-                PeerManagerCommand::GetNeighborPolicyChains { address, reply }
-            })
-            .await?;
-            apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                PeerManagerCommand::SetNeighborImportChain {
+            require_configured_neighbor(&peer_mgr_tx, address).await?;
+            persist_then_apply(
+                persist_permit,
+                |ack| ConfigEvent::SetNeighborImportChain {
                     address,
                     policy_names: policy_names.clone(),
-                    reply,
-                }
-            })
-            .await?;
-
-            if let Some(permit) = persist_permit
-                && let Err(error) = persist_runtime_config_event(permit, |ack| {
-                    ConfigEvent::SetNeighborImportChain {
-                        address,
-                        policy_names: policy_names.clone(),
-                        ack: Some(ack),
-                    }
-                })
-                .await
-            {
-                let rollback = match prior {
-                    Some(prior) => {
-                        restore_neighbor_import_chain(
-                            &peer_mgr_tx,
+                    ack: Some(ack),
+                },
+                || {
+                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                        PeerManagerCommand::SetNeighborImportChain {
                             address,
-                            prior.import_policy_names,
-                        )
-                        .await
-                    }
-                    // The mutation succeeded, so the neighbor was
-                    // configured; an unexpectedly missing prior leaves
-                    // nothing to restore.
-                    None => Ok(()),
-                };
-                return Err(persist_rollback_error(
-                    "neighbor import-chain set",
-                    error,
-                    rollback,
-                ));
-            }
-            Ok(())
+                            policy_names: policy_names.clone(),
+                            reply,
+                        }
+                    })
+                },
+            )
+            .await
         })
         .await?;
 
@@ -1145,47 +898,25 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         let peer_mgr_tx = self.peer_mgr_tx.clone();
         let policy_names = req.policy_names;
         self.run_mutation("PolicyService.SetNeighborExportChain", move || async move {
-            let prior = peer_manager_request(&peer_mgr_tx, |reply| {
-                PeerManagerCommand::GetNeighborPolicyChains { address, reply }
-            })
-            .await?;
-            apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                PeerManagerCommand::SetNeighborExportChain {
+            require_configured_neighbor(&peer_mgr_tx, address).await?;
+            persist_then_apply(
+                persist_permit,
+                |ack| ConfigEvent::SetNeighborExportChain {
                     address,
                     policy_names: policy_names.clone(),
-                    reply,
-                }
-            })
-            .await?;
-
-            if let Some(permit) = persist_permit
-                && let Err(error) = persist_runtime_config_event(permit, |ack| {
-                    ConfigEvent::SetNeighborExportChain {
-                        address,
-                        policy_names: policy_names.clone(),
-                        ack: Some(ack),
-                    }
-                })
-                .await
-            {
-                let rollback = match prior {
-                    Some(prior) => {
-                        restore_neighbor_export_chain(
-                            &peer_mgr_tx,
+                    ack: Some(ack),
+                },
+                || {
+                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                        PeerManagerCommand::SetNeighborExportChain {
                             address,
-                            prior.export_policy_names,
-                        )
-                        .await
-                    }
-                    None => Ok(()),
-                };
-                return Err(persist_rollback_error(
-                    "neighbor export-chain set",
-                    error,
-                    rollback,
-                ));
-            }
-            Ok(())
+                            policy_names: policy_names.clone(),
+                            reply,
+                        }
+                    })
+                },
+            )
+            .await
         })
         .await?;
 
@@ -1209,42 +940,20 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         self.run_mutation(
             "PolicyService.ClearNeighborImportChain",
             move || async move {
-                let prior = peer_manager_request(&peer_mgr_tx, |reply| {
-                    PeerManagerCommand::GetNeighborPolicyChains { address, reply }
-                })
-                .await?;
-                apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                    PeerManagerCommand::ClearNeighborImportChain { address, reply }
-                })
-                .await?;
-
-                if let Some(permit) = persist_permit
-                    && let Err(error) = persist_runtime_config_event(permit, |ack| {
-                        ConfigEvent::ClearNeighborImportChain {
-                            address,
-                            ack: Some(ack),
-                        }
-                    })
-                    .await
-                {
-                    let rollback = match prior {
-                        Some(prior) => {
-                            restore_neighbor_import_chain(
-                                &peer_mgr_tx,
-                                address,
-                                prior.import_policy_names,
-                            )
-                            .await
-                        }
-                        None => Ok(()),
-                    };
-                    return Err(persist_rollback_error(
-                        "neighbor import-chain clear",
-                        error,
-                        rollback,
-                    ));
-                }
-                Ok(())
+                require_configured_neighbor(&peer_mgr_tx, address).await?;
+                persist_then_apply(
+                    persist_permit,
+                    |ack| ConfigEvent::ClearNeighborImportChain {
+                        address,
+                        ack: Some(ack),
+                    },
+                    || {
+                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                            PeerManagerCommand::ClearNeighborImportChain { address, reply }
+                        })
+                    },
+                )
+                .await
             },
         )
         .await?;
@@ -1269,42 +978,20 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         self.run_mutation(
             "PolicyService.ClearNeighborExportChain",
             move || async move {
-                let prior = peer_manager_request(&peer_mgr_tx, |reply| {
-                    PeerManagerCommand::GetNeighborPolicyChains { address, reply }
-                })
-                .await?;
-                apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                    PeerManagerCommand::ClearNeighborExportChain { address, reply }
-                })
-                .await?;
-
-                if let Some(permit) = persist_permit
-                    && let Err(error) = persist_runtime_config_event(permit, |ack| {
-                        ConfigEvent::ClearNeighborExportChain {
-                            address,
-                            ack: Some(ack),
-                        }
-                    })
-                    .await
-                {
-                    let rollback = match prior {
-                        Some(prior) => {
-                            restore_neighbor_export_chain(
-                                &peer_mgr_tx,
-                                address,
-                                prior.export_policy_names,
-                            )
-                            .await
-                        }
-                        None => Ok(()),
-                    };
-                    return Err(persist_rollback_error(
-                        "neighbor export-chain clear",
-                        error,
-                        rollback,
-                    ));
-                }
-                Ok(())
+                require_configured_neighbor(&peer_mgr_tx, address).await?;
+                persist_then_apply(
+                    persist_permit,
+                    |ack| ConfigEvent::ClearNeighborExportChain {
+                        address,
+                        ack: Some(ack),
+                    },
+                    || {
+                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
+                            PeerManagerCommand::ClearNeighborExportChain { address, reply }
+                        })
+                    },
+                )
+                .await
             },
         )
         .await?;
@@ -2279,8 +1966,8 @@ mod tests {
                 assert_eq!(definition.default_action, "permit");
                 assert_eq!(definition.statements.len(), 1);
                 ack.expect("persisted mutation must carry an ack")
-                    .send(Ok(()))
-                    .expect("service should await the persistence ack");
+                    .accept()
+                    .await;
             }
             Some(_) => panic!("unexpected config event"),
             None => panic!("missing config event"),
@@ -2294,7 +1981,7 @@ mod tests {
     /// back to the captured prior definition, so the RPC failure means
     /// "nothing changed" instead of leaving runtime ahead of disk.
     #[tokio::test]
-    async fn set_policy_rolls_back_runtime_when_persist_fails() {
+    async fn set_policy_persist_failure_leaves_the_catalog_alone() {
         let (peer_tx, mut peer_rx) = mpsc::channel(8);
         let (config_tx, mut config_rx) = mpsc::channel(4);
         let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
@@ -2337,8 +2024,7 @@ mod tests {
         match config_rx.recv().await {
             Some(ConfigEvent::SetPolicy { ack, .. }) => {
                 ack.expect("persisted mutation must carry an ack")
-                    .send(Err("disk full".to_string()))
-                    .expect("service should await the persistence ack");
+                    .fail_write("disk full");
             }
             Some(_) => panic!("unexpected config event"),
             None => panic!("missing config event"),
@@ -2351,12 +2037,13 @@ mod tests {
         assert_eq!(error.code(), tonic::Code::FailedPrecondition);
         assert!(error.message().contains("config persistence failed"));
 
-        let sets = set_definitions.lock().await;
-        assert_eq!(sets.len(), 2, "mutation then rollback");
-        assert_eq!(sets[0].default_action, "permit");
-        assert_eq!(
-            sets[1].default_action, "deny",
-            "rollback must restore the captured prior definition"
+        // The old ordering applied the policy — re-evaluating live sessions
+        // and driving a Route Refresh — and then applied the prior definition
+        // as "rollback", so peers saw two rounds of churn for a request that
+        // was rejected. The candidate is never applied now.
+        assert!(
+            set_definitions.lock().await.is_empty(),
+            "a rejected policy set must not reach any live session"
         );
     }
 
@@ -2548,8 +2235,21 @@ mod tests {
             }
         });
 
-        // The runtime mutation fails before persistence, so the RPC
-        // returns directly without an ack handshake.
+        // The write is staged first, so this also proves the other half of
+        // the handshake: a runtime mutation the peer manager refuses discards
+        // the staged write instead of publishing it.
+        let staged = tokio::spawn(async move {
+            match config_rx.recv().await {
+                Some(ConfigEvent::DeletePolicy { ack, .. }) => {
+                    ack.expect("persisted mutation must carry an ack")
+                        .accept()
+                        .await
+                }
+                Some(_) => panic!("unexpected config event"),
+                None => panic!("missing config event"),
+            }
+        });
+
         let error = PolicyServiceRpc::delete_policy(
             &svc,
             Request::new(proto::DeletePolicyRequest {
@@ -2559,11 +2259,14 @@ mod tests {
         .await
         .unwrap_err();
         assert_eq!(error.code(), tonic::Code::FailedPrecondition);
-        assert!(matches!(config_rx.try_recv(), Err(TryRecvError::Empty)));
+        assert!(
+            !staged.await.expect("config task must not panic"),
+            "a refused runtime delete must discard the staged write"
+        );
     }
 
     #[tokio::test]
-    async fn delete_policy_rolls_back_runtime_when_persist_fails() {
+    async fn delete_policy_persist_failure_leaves_the_catalog_alone() {
         let (peer_tx, mut peer_rx) = mpsc::channel(8);
         let (config_tx, mut config_rx) = mpsc::channel(4);
         let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
@@ -2608,8 +2311,7 @@ mod tests {
         match config_rx.recv().await {
             Some(ConfigEvent::DeletePolicy { ack, .. }) => {
                 ack.expect("persisted mutation must carry an ack")
-                    .send(Err("disk full".to_string()))
-                    .expect("service should await the persistence ack");
+                    .fail_write("disk full");
             }
             Some(_) => panic!("unexpected config event"),
             None => panic!("missing config event"),
@@ -2621,16 +2323,16 @@ mod tests {
             .expect_err("delete_policy must fail when persistence fails");
         assert_eq!(error.code(), tonic::Code::FailedPrecondition);
 
-        let sets = set_definitions.lock().await;
-        assert_eq!(
-            sets.as_slice(),
-            &[prior],
-            "rollback must re-create the deleted policy"
+        assert!(
+            set_definitions.lock().await.is_empty(),
+            "a rejected policy delete must not re-create anything, because it \
+             never deleted anything"
         );
+        drop(prior);
     }
 
     #[tokio::test]
-    async fn set_global_import_chain_rolls_back_to_prior_chain_when_persist_fails() {
+    async fn set_global_import_chain_persist_failure_leaves_the_chain_alone() {
         let (peer_tx, mut peer_rx) = mpsc::channel(8);
         let (config_tx, mut config_rx) = mpsc::channel(4);
         let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
@@ -2672,8 +2374,7 @@ mod tests {
             Some(ConfigEvent::SetGlobalImportChain { policy_names, ack }) => {
                 assert_eq!(policy_names, vec!["tag-internal".to_string()]);
                 ack.expect("persisted mutation must carry an ack")
-                    .send(Err("disk full".to_string()))
-                    .expect("service should await the persistence ack");
+                    .fail_write("disk full");
             }
             Some(_) => panic!("unexpected config event"),
             None => panic!("missing config event"),
@@ -2685,22 +2386,16 @@ mod tests {
             .expect_err("set_global_import_chain must fail when persistence fails");
         assert_eq!(error.code(), tonic::Code::FailedPrecondition);
 
-        let sets = set_chains.lock().await;
-        assert_eq!(
-            sets.as_slice(),
-            &[
-                vec!["tag-internal".to_string()],
-                vec!["prior-import".to_string()]
-            ],
-            "rollback must re-set the prior chain"
+        assert!(
+            set_chains.lock().await.is_empty(),
+            "a rejected chain set must not reach any live session"
         );
     }
 
-    /// An empty prior chain and a cleared chain are the same config
-    /// state, so rolling back from an empty prior issues the clear
-    /// command rather than an empty set.
+    /// The staged write is discarded rather than compensated, so an empty
+    /// prior chain needs no clear command to restore it.
     #[tokio::test]
-    async fn set_global_import_chain_rolls_back_via_clear_when_prior_empty() {
+    async fn set_global_import_chain_persist_failure_issues_no_clear() {
         let (peer_tx, mut peer_rx) = mpsc::channel(8);
         let (config_tx, mut config_rx) = mpsc::channel(4);
         let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
@@ -2738,8 +2433,7 @@ mod tests {
         match config_rx.recv().await {
             Some(ConfigEvent::SetGlobalImportChain { ack, .. }) => {
                 ack.expect("persisted mutation must carry an ack")
-                    .send(Err("disk full".to_string()))
-                    .expect("service should await the persistence ack");
+                    .fail_write("disk full");
             }
             Some(_) => panic!("unexpected config event"),
             None => panic!("missing config event"),
@@ -2750,11 +2444,15 @@ mod tests {
             .expect("call task must not panic")
             .expect_err("set_global_import_chain must fail when persistence fails");
         assert_eq!(error.code(), tonic::Code::FailedPrecondition);
-        assert_eq!(*cleared.lock().await, 1, "rollback must clear the chain");
+        assert_eq!(
+            *cleared.lock().await,
+            0,
+            "nothing was applied, so nothing needs clearing"
+        );
     }
 
     #[tokio::test]
-    async fn set_neighbor_import_chain_rolls_back_runtime_when_persist_fails() {
+    async fn set_neighbor_import_chain_persist_failure_leaves_the_chain_alone() {
         let (peer_tx, mut peer_rx) = mpsc::channel(8);
         let (config_tx, mut config_rx) = mpsc::channel(4);
         let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
@@ -2804,8 +2502,7 @@ mod tests {
                 assert_eq!(address.to_string(), "10.0.0.2");
                 assert_eq!(policy_names, vec!["tag-internal".to_string()]);
                 ack.expect("persisted mutation must carry an ack")
-                    .send(Err("disk full".to_string()))
-                    .expect("service should await the persistence ack");
+                    .fail_write("disk full");
             }
             Some(_) => panic!("unexpected config event"),
             None => panic!("missing config event"),
@@ -2817,14 +2514,9 @@ mod tests {
             .expect_err("set_neighbor_import_chain must fail when persistence fails");
         assert_eq!(error.code(), tonic::Code::FailedPrecondition);
 
-        let sets = set_chains.lock().await;
-        assert_eq!(
-            sets.as_slice(),
-            &[
-                vec!["tag-internal".to_string()],
-                vec!["prior-import".to_string()]
-            ],
-            "rollback must re-set the prior per-neighbor chain"
+        assert!(
+            set_chains.lock().await.is_empty(),
+            "a rejected per-neighbor chain set must not reach the session"
         );
     }
 

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -378,25 +378,116 @@ pub async fn check_config_mutation_gate(
     Ok(())
 }
 
-/// Queue a runtime-config event through a reserved persistence slot and
-/// wait for the config bridge to acknowledge the on-disk write.
+/// A durable config write that is written and fsynced but not yet published.
 ///
-/// Shared by every persisted runtime CRUD path (neighbors, dynamic
-/// ranges, policy/peer-group catalogs): the caller holds the shared
-/// runtime-config lock across this await so a SIGHUP reload cannot read
-/// a stale TOML between the runtime mutation and the disk commit.
-pub(crate) async fn persist_runtime_config_event(
+/// Holding one means the persistence failure modes an operator actually hits
+/// — an unwritable config directory, a read-only mount, a full filesystem —
+/// have already been ruled out. Committing it is a rename; dropping it
+/// discards the write with no trace.
+#[must_use = "a staged config write must be committed or explicitly dropped"]
+pub(crate) struct StagedConfigWrite {
+    commit_tx: tokio::sync::oneshot::Sender<tokio::sync::oneshot::Sender<Result<(), String>>>,
+}
+
+impl StagedConfigWrite {
+    /// Publish the staged write. Call only once the runtime change landed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `INTERNAL` if publishing fails after the runtime change was
+    /// already applied: runtime and disk have drifted and only SIGHUP or a
+    /// restart reconciles them.
+    pub(crate) async fn commit(self) -> Result<(), Status> {
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+        self.commit_tx
+            .send(ack_tx)
+            .map_err(|_| Status::internal(COMMIT_LOST))?;
+        ack_rx
+            .await
+            .map_err(|_| Status::internal(COMMIT_LOST))?
+            .map_err(|error| {
+                Status::internal(format!(
+                    "config persistence commit failed after the runtime change was applied \
+                     (runtime and persisted config have drifted — SIGHUP or restart to \
+                     reconcile): {error}"
+                ))
+            })
+    }
+}
+
+const COMMIT_LOST: &str = "config bridge dropped the staged config write after the runtime change \
+                           was applied (runtime and persisted config have drifted — SIGHUP or \
+                           restart to reconcile)";
+
+/// Reserve the on-disk write for a runtime-config event *before* the caller
+/// mutates anything.
+///
+/// Shared by every persisted runtime CRUD path (neighbors, dynamic ranges,
+/// policy/peer-group catalogs). The config bridge folds the event onto the
+/// config snapshot, serializes it, and durably stages the result next to the
+/// config file; this returns once that succeeded. Nothing is observable on
+/// disk or on the wire yet.
+///
+/// That ordering is the contract: `FAILED_PRECONDITION` from a mutating RPC
+/// means the request did nothing. Applying first and compensating afterwards
+/// cannot honour it — re-adding a deleted neighbor produces a *new* session
+/// with a new identity, a zeroed uptime, zeroed counters, and a fresh metric
+/// series, and the teardown never even appears in the operator's flap count.
+///
+/// The caller holds the shared runtime-config lock across the whole
+/// stage/apply/commit window, so a SIGHUP reload cannot read a stale TOML in
+/// the middle of it.
+///
+/// # Errors
+///
+/// Returns `FAILED_PRECONDITION` when the candidate cannot be written. The
+/// caller has not mutated anything at that point, and must not.
+pub(crate) async fn stage_runtime_config_event(
     permit: tokio::sync::mpsc::OwnedPermit<crate::peer_types::ConfigEvent>,
-    build_event: impl FnOnce(
-        tokio::sync::oneshot::Sender<Result<(), String>>,
-    ) -> crate::peer_types::ConfigEvent,
-) -> Result<(), Status> {
-    let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
-    permit.send(build_event(ack_tx));
-    ack_rx
+    build_event: impl FnOnce(crate::peer_types::ConfigPersistAck) -> crate::peer_types::ConfigEvent,
+) -> Result<StagedConfigWrite, Status> {
+    let (staged_tx, staged_rx) = tokio::sync::oneshot::channel();
+    let (commit_tx, commit_rx) = tokio::sync::oneshot::channel();
+    permit.send(build_event(crate::peer_types::ConfigPersistAck {
+        staged: staged_tx,
+        commit: Some(commit_rx),
+    }));
+    staged_rx
         .await
         .map_err(|_| Status::internal("config bridge dropped persistence acknowledgement"))?
-        .map_err(|error| Status::failed_precondition(format!("config persistence failed: {error}")))
+        .map_err(|error| match error {
+            crate::peer_types::ConfigPersistError::Rejected(error) => {
+                catalog_mutation_error_to_status(&error)
+            }
+            crate::peer_types::ConfigPersistError::Write(message) => {
+                Status::failed_precondition(format!("config persistence failed: {message}"))
+            }
+        })?;
+    Ok(StagedConfigWrite { commit_tx })
+}
+
+/// Stage a runtime-config event, run `apply`, then publish the write.
+///
+/// A staging failure returns before `apply` runs at all; an `apply` failure
+/// drops the stage, so the config file is never written. `persist_permit` is
+/// `None` when the daemon has no config file to persist to, in which case
+/// only `apply` runs.
+pub(crate) async fn persist_then_apply<F, Fut>(
+    persist_permit: Option<tokio::sync::mpsc::OwnedPermit<crate::peer_types::ConfigEvent>>,
+    build_event: impl FnOnce(crate::peer_types::ConfigPersistAck) -> crate::peer_types::ConfigEvent,
+    apply: F,
+) -> Result<(), Status>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<(), Status>>,
+{
+    let Some(permit) = persist_permit else {
+        return apply().await;
+    };
+    let staged = stage_runtime_config_event(permit, build_event).await?;
+    // `staged` drops here on an apply failure, discarding the write.
+    apply().await?;
+    staged.commit().await
 }
 
 /// Run a persisted catalog mutation on a detached task: take the shared
@@ -460,25 +551,6 @@ pub(crate) async fn apply_catalog_mutation(
     peer_manager_request(peer_mgr_tx, build_command)
         .await?
         .map_err(|error| catalog_mutation_error_to_status(&error))
-}
-
-/// Compose the persist failure with a rollback failure, if any: a failed
-/// rollback means runtime and disk have drifted and only a restart or
-/// SIGHUP repair reconciles them — the error must say so.
-pub(crate) fn persist_rollback_error(
-    operation: &str,
-    error: Status,
-    rollback: Result<(), Status>,
-) -> Status {
-    match rollback {
-        Ok(()) => error,
-        Err(rollback_error) => Status::internal(format!(
-            "{}; rollback of {operation} failed (runtime and persisted config have drifted — \
-             SIGHUP or restart to reconcile): {}",
-            error.message(),
-            rollback_error.message()
-        )),
-    }
 }
 
 /// Configuration for the gRPC server beyond basic connectivity.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -162,6 +162,17 @@ allow_blackhole_broad_prefixes = false
 non-root deployments, override the default to a mounted writable path (for
 example `/var/lib/rustbgpd` on a volume, or `/data/rustbgpd`).
 
+The **directory holding the config file** must also be writable by the
+rustbgpd process if you use runtime mutation. Every accepted `rbgp neighbor
+add` / `delete`, policy or peer-group edit, dynamic-range change, gNMI `Set`,
+and `rbgp config apply` is written back to the config file with a temp-file +
+rename, which creates `<config>.tmp` alongside it. Without a writable
+directory those RPCs are rejected with `FAILED_PRECONDITION` before they
+change anything — the session, its counters, and the wire are untouched. A
+config directory that is read-only on purpose (external configuration
+management, SIGHUP-only reload) is supported; the rejection is the contract,
+not a failure mode to work around.
+
 `warm_cache_checkpoint_on_shutdown` is an opt-in, restart-required publication
 step. During a coordinated shutdown, rustbgpd has up to 30 seconds to capture
 eligible established static peers' post-import-policy Adj-RIB-In views and

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -171,11 +171,23 @@ produces the same lean runtime image locally.
 
 ```bash
 docker run -d --name rustbgpd \
-  -v "$(pwd)/config.toml":/etc/rustbgpd/config.toml:ro \
+  -v "$(pwd)/config.toml":/etc/rustbgpd/config.template.toml:ro \
   -v rustbgpd-state:/var/lib/rustbgpd \
   -p 179:179 -p 9179:9179 \
-  rustbgpd
+  rustbgpd \
+  /bin/sh -c 'cp -n /etc/rustbgpd/config.template.toml /var/lib/rustbgpd/config.toml && exec rustbgpd /var/lib/rustbgpd/config.toml'
 ```
+
+The config is seeded from a read-only template into the writable state volume
+rather than bind-mounted in place. Config persistence rewrites the file with a
+temp-file + rename, so the config's **directory** must be writable by the
+daemon user: mount the file read-only and every mutating command
+(`rbgp neighbor add`, policy edits, gNMI `Set`, `rbgp config apply`) is
+rejected. Mount it read-write and the write still fails, because the image's
+`/etc/rustbgpd` is root-owned and the daemon runs unprivileged.
+
+Deployments that manage the config exclusively from the outside — SIGHUP after
+an external edit, no runtime mutation — can mount it read-only and skip this.
 
 Or use systemd with
 [`examples/systemd/rustbgpd.service`](../examples/systemd/rustbgpd.service).

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -526,7 +526,11 @@ topology:
       kind: linux
       image: rustbgpd:latest
       binds:
-        - config.toml:/etc/rustbgpd/config.toml:ro
+        # Template + copy, not a read-only bind: config persistence rewrites
+        # this file, so runtime mutation needs a writable config directory.
+        - config.toml:/etc/rustbgpd/config.template.toml:ro
+      exec:
+        - cp -n /etc/rustbgpd/config.template.toml /etc/rustbgpd/config.toml
     frr:
       kind: linux
       image: quay.io/frrouting/frr:10.3.1

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -283,7 +283,7 @@ For your own deployment:
   ```sh
   docker run --rm -d \
     --name rustbgpd \
-    -v /etc/rustbgpd:/etc/rustbgpd:ro \
+    -v /etc/rustbgpd:/etc/rustbgpd \
     -v /var/lib/rustbgpd:/var/lib/rustbgpd \
     -p 179:179 \
     -p 9179:9179 \
@@ -291,6 +291,15 @@ For your own deployment:
     --cap-add=NET_ADMIN \
     ghcr.io/lance0/rustbgpd:0.45
   ```
+
+- **Writable config directory**: mount `/etc/rustbgpd` read-write and
+  make it owned by the daemon user (`chown` the host directory to the
+  container's `rustbgpd` uid) if you use runtime mutation — `rbgp
+  neighbor add`, policy edits, gNMI `Set`, `rbgp config apply`. Config
+  persistence rewrites the file with a temp-file + rename, so the
+  *directory*, not just the file, has to be writable, and every mutating
+  RPC is rejected without it. Mount it `:ro` only when the config is
+  managed entirely from outside and reloaded with SIGHUP.
 
 - **Logs**: structured JSON when `[global.telemetry] log_format =
   "json"` is set; pipe to your log aggregator.

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -28,8 +28,27 @@ cargo run -p rustbgpctl --bin rbgp -- -s http://127.0.0.1:50051 neighbor
 cargo run -p rustbgpctl --bin rbgp -- -s http://127.0.0.1:50051 top
 ```
 
+## Change it without restarting
+
+Runtime mutations are persisted back to the config file, so they survive a
+restart:
+
+```bash
+docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 \
+  neighbor 10.99.0.30 add --remote-as 65003
+docker compose exec rustbgpd cat /var/lib/rustbgpd/config.toml
+```
+
+`rustbgpd.toml` in this directory is a **template**. The daemon copies it into
+its writable state volume on first start and runs from
+`/var/lib/rustbgpd/config.toml` — a read-only bind mount cannot accept the
+temp-file + rename write that config persistence uses, and every mutating
+command would fail. Edit the template and `docker compose down -v` to start
+over from it.
+
 ## Stop
 
 ```bash
-docker compose down
+docker compose down       # keeps runtime config edits
+docker compose down -v    # discards them, next start reseeds from the template
 ```

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -17,8 +17,24 @@
 services:
   rustbgpd:
     build: ../..
+    # The daemon persists runtime mutations (`rbgp neighbor add`, policy edits,
+    # gNMI Set) back to its config file with a temp-file + rename write, so the
+    # config must live in a directory the daemon user can write. A bind-mounted
+    # file cannot be one: the mount is read-only and its parent is the image's
+    # root-owned /etc. So the checked-in file is mounted as a template and
+    # copied once into the daemon's writable state directory, which is where
+    # the running config lives. `-n` keeps a restart from discarding runtime
+    # edits already made in the volume.
+    command:
+      - /bin/sh
+      - -c
+      - cp -n /etc/rustbgpd/config.template.toml /var/lib/rustbgpd/config.toml
+        && exec rustbgpd /var/lib/rustbgpd/config.toml
     volumes:
-      - ./rustbgpd.toml:/etc/rustbgpd/config.toml:ro
+      - ./rustbgpd.toml:/etc/rustbgpd/config.template.toml:ro
+      # Named volume so runtime config edits survive `docker compose restart`.
+      # It inherits the image directory's rustbgpd ownership on first use.
+      - rustbgpd-state:/var/lib/rustbgpd
       # Public test-only credential shared with the interop harness. It is a
       # runnable example, never a production secret.
       - ../../tests/fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
@@ -56,3 +72,6 @@ networks:
       config:
         - subnet: 10.99.0.0/24
         - subnet: fd99::/64
+
+volumes:
+  rustbgpd-state:

--- a/src/config_persister.rs
+++ b/src/config_persister.rs
@@ -24,6 +24,18 @@ pub enum ConfigMutation {
     /// Replace the entire config snapshot, persist it to disk, then acknowledge
     /// the result to a caller that must not proceed until the write has settled.
     ReplaceConfigAck(Box<Config>, oneshot::Sender<Result<(), String>>),
+    /// Durably stage a replacement snapshot without publishing it, then
+    /// acknowledge whether the write can land. Every persistence failure an
+    /// operator actually hits (unwritable directory, read-only mount, full
+    /// filesystem) surfaces here, before the caller mutates any runtime state.
+    ///
+    /// Exactly one stage may be outstanding; a second replaces the first.
+    StageConfigAck(Box<Config>, oneshot::Sender<Result<(), String>>),
+    /// Publish the staged snapshot: rename it into place and adopt it.
+    CommitStagedConfig(oneshot::Sender<Result<(), String>>),
+    /// Drop the staged snapshot. The caller's runtime change did not land, so
+    /// neither may the write.
+    DiscardStagedConfig,
     /// Refresh the persister's base snapshot without writing to disk.
     ///
     /// SIGHUP reload uses this for operator-authored TOML that
@@ -42,6 +54,8 @@ pub struct ConfigPersister {
     /// Applied-config history directory (`config_history` module). `None`
     /// disables recording (unit tests, embedders without a state dir).
     history_dir: Option<PathBuf>,
+    /// Durably written but unpublished snapshot, awaiting commit or discard.
+    staged: Option<(crate::confirm_journal::StagedWrite, Config, String)>,
 }
 
 impl ConfigPersister {
@@ -56,6 +70,7 @@ impl ConfigPersister {
             config_path,
             current,
             history_dir,
+            staged: None,
         }
     }
 
@@ -68,23 +83,42 @@ impl ConfigPersister {
         // edits the file between startup validation and this task starting.
         self.record_current_history();
         while let Some(mutation) = self.rx.recv().await {
-            if let ConfigMutation::ReplaceConfigAck(new_config, ack) = mutation {
-                let previous = self.current.clone();
-                info!("replacing persister config snapshot and persisting it");
-                self.current = *new_config;
-                let result = self.persist().map_err(|e| e.to_string());
-                if let Err(e) = &result {
-                    self.current = previous;
-                    error!(
-                        path = %self.config_path.display(),
-                        error = %e,
-                        "failed to persist config — persister snapshot rolled back to previous state"
-                    );
+            match mutation {
+                ConfigMutation::ReplaceConfigAck(new_config, ack) => {
+                    self.discard_staged();
+                    let previous = self.current.clone();
+                    info!("replacing persister config snapshot and persisting it");
+                    self.current = *new_config;
+                    let result = self.persist().map_err(|e| e.to_string());
+                    if let Err(e) = &result {
+                        self.current = previous;
+                        error!(
+                            path = %self.config_path.display(),
+                            error = %e,
+                            "failed to persist config — persister snapshot rolled back to previous state"
+                        );
+                    }
+                    let _ = ack.send(result);
+                    continue;
                 }
-                let _ = ack.send(result);
-                continue;
+                ConfigMutation::StageConfigAck(new_config, ack) => {
+                    let _ = ack.send(self.stage(*new_config).map_err(|e| e.to_string()));
+                    continue;
+                }
+                ConfigMutation::CommitStagedConfig(ack) => {
+                    let _ = ack.send(self.commit_staged());
+                    continue;
+                }
+                ConfigMutation::DiscardStagedConfig => {
+                    self.discard_staged();
+                    continue;
+                }
+                _ => {}
             }
 
+            // Any other durable write reuses the same temp path, so a stage
+            // that is still outstanding here can no longer be published.
+            self.discard_staged();
             let should_persist = self.apply(mutation);
             if should_persist && let Err(e) = self.persist() {
                 error!(
@@ -96,8 +130,59 @@ impl ConfigPersister {
         }
     }
 
+    /// Durably write a candidate next to the config file without publishing
+    /// it. A failure here is the whole point of the two-phase handshake: the
+    /// caller learns the write cannot land while its runtime state is still
+    /// untouched.
+    fn stage(&mut self, new_config: Config) -> std::io::Result<()> {
+        // A superseded stage is discarded, never published: its caller either
+        // failed its apply or is gone.
+        self.discard_staged();
+        let toml_str = toml::to_string_pretty(&new_config).map_err(std::io::Error::other)?;
+        let staged = crate::confirm_journal::stage_atomic(&self.config_path, toml_str.as_bytes())?;
+        info!(
+            path = %self.config_path.display(),
+            "staged config write, awaiting commit"
+        );
+        self.staged = Some((staged, new_config, toml_str));
+        Ok(())
+    }
+
+    /// Publish the staged candidate and adopt it as the persister snapshot.
+    fn commit_staged(&mut self) -> Result<(), String> {
+        let Some((staged, config, toml_str)) = self.staged.take() else {
+            return Err("no staged config write to commit".to_string());
+        };
+        if let Err(error) = staged.commit() {
+            error!(
+                path = %self.config_path.display(),
+                error = %error,
+                "failed to publish the staged config write"
+            );
+            return Err(error.to_string());
+        }
+        self.current = config;
+        self.record_history(&toml_str);
+        Ok(())
+    }
+
+    fn discard_staged(&mut self) {
+        if let Some((staged, ..)) = self.staged.take() {
+            info!(
+                path = %self.config_path.display(),
+                "discarding the staged config write"
+            );
+            staged.discard();
+        }
+    }
+
     fn apply(&mut self, mutation: ConfigMutation) -> bool {
         match mutation {
+            // Handled directly in `run`; a staging mutation never reaches the
+            // single-phase applier.
+            ConfigMutation::StageConfigAck(..)
+            | ConfigMutation::CommitStagedConfig(_)
+            | ConfigMutation::DiscardStagedConfig => false,
             ConfigMutation::AddNeighbor(neighbor) => {
                 if self
                     .current

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -11,8 +11,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex, mpsc, oneshot};
 
 use rustbgpd_api::peer_types::{
-    ConfigEvent, DynamicPeerBounceOutcome, DynamicRangeTarget, PeerKey, PeerLifecycleError,
-    PeerManagerCommand, PeerManagerNeighborConfig, ResolvedPeerPolicy,
+    ConfigEvent, ConfigPersistAck, DynamicPeerBounceOutcome, DynamicRangeTarget, PeerKey,
+    PeerLifecycleError, PeerManagerCommand, PeerManagerNeighborConfig, ResolvedPeerPolicy,
     RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus, StageConfigSnapshotError,
 };
 use rustbgpd_api::proto;
@@ -2547,15 +2547,20 @@ async fn persist_candidate_config(
     candidate_toml: String,
 ) -> Result<(), ApplyFailure> {
     let (ack_tx, ack_rx) = oneshot::channel();
+    // Single-phase on purpose: the ADR-0076 executor owns its own
+    // apply/rollback and ambiguous-outcome reporting, and ADR-0113 already
+    // inverted the one family whose apply is not undoable.
     permit.send(ConfigEvent::ConfigTransactionCommitted {
         candidate_toml,
-        ack: Some(ack_tx),
+        ack: Some(ConfigPersistAck::immediate(ack_tx)),
     });
     match ack_rx.await {
         Ok(Ok(())) => Ok(()),
         // The persister reported failure: the atomic write did not replace the
         // config file, so disk provably still holds the previous config.
-        Ok(Err(message)) => Err(ConfigTransactionApplyError::FailedPrecondition(message).into()),
+        Ok(Err(error)) => {
+            Err(ConfigTransactionApplyError::FailedPrecondition(error.to_string()).into())
+        }
         // LAN-277 window (b): the acknowledgement was lost. The persister may
         // or may not have written the candidate — the on-disk outcome is
         // unknowable from here.
@@ -2939,7 +2944,7 @@ mod tests {
         let peer_manager_tests = include_str!("peer_manager/tests.rs");
         assert!(!peer_manager_tests.contains(legacy_toml));
         assert!(!peer_manager_tests.contains(legacy_variant));
-        assert_eq!(peer_manager_tests.matches(helper).count(), 4);
+        assert_eq!(peer_manager_tests.matches(helper).count(), 5);
     }
 
     fn base_toml(extra: &str) -> String {
@@ -4160,7 +4165,7 @@ remote_asn = 65010
             }) = config_rx.recv().await
             {
                 assert!(candidate_toml.contains("[[dynamic_neighbors]]"));
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
 
@@ -4190,7 +4195,7 @@ remote_asn = 65010
         while let Some(ConfigEvent::ConfigTransactionCommitted { ack, .. }) = config_rx.recv().await
         {
             if let Some(ack) = ack {
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         }
     }
@@ -4201,7 +4206,7 @@ remote_asn = 65010
         while let Some(ConfigEvent::ConfigTransactionCommitted { ack, .. }) = config_rx.recv().await
         {
             if let Some(ack) = ack {
-                let _ = ack.send(Err("persist rejected by test".to_string()));
+                ack.fail_write("persist rejected by test");
             }
         }
     }
@@ -5587,7 +5592,7 @@ default_action = "permit"
             {
                 assert!(candidate_toml.contains("[policy.definitions.prep-only]"));
                 assert!(candidate_toml.contains("[peer_groups.prep-only]"));
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
 
@@ -5710,7 +5715,7 @@ default_action = "permit"
             if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
 
@@ -5788,7 +5793,7 @@ default_action = "permit"
             if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
 
@@ -5852,7 +5857,7 @@ default_action = "permit"
             }) = config_rx.recv().await
             {
                 assert!(candidate_toml.contains("hold_time = 45"));
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
 
@@ -5916,7 +5921,7 @@ default_action = "permit"
             }) = config_rx.recv().await
             {
                 assert!(candidate_toml.contains("peer_group = \"core\""));
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
 
@@ -5972,7 +5977,7 @@ default_action = "permit"
             }) = config_rx.recv().await
             {
                 assert!(candidate_toml.contains("hold_time = 45"));
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
 
@@ -6038,7 +6043,7 @@ default_action = "permit"
             }) = config_rx.recv().await
             {
                 assert!(candidate_toml.contains("required_families = [\"ipv6_unicast\"]"));
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
 
@@ -6092,7 +6097,7 @@ default_action = "permit"
             }) = config_rx.recv().await
             {
                 assert!(candidate_toml.contains("hold_time = 45"));
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
 
@@ -6160,7 +6165,7 @@ default_action = "permit"
             if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Err("persist failed".to_string()));
+                ack.fail_write("persist failed");
             }
         });
 
@@ -6208,7 +6213,7 @@ default_action = "permit"
             if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Err("persist failed".to_string()));
+                ack.fail_write("persist failed");
             }
         });
 
@@ -6264,7 +6269,7 @@ default_action = "permit"
             if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Err("persist failed".to_string()));
+                ack.fail_write("persist failed");
             }
         });
 
@@ -6390,7 +6395,7 @@ default_action = "permit"
             if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Err("persist failed".to_string()));
+                ack.fail_write("persist failed");
             }
         });
 
@@ -6443,7 +6448,7 @@ default_action = "permit"
             if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Err("persist failed".to_string()));
+                ack.fail_write("persist failed");
             }
         });
 
@@ -6497,7 +6502,7 @@ peer_group = "ix-members"
             if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Err("persist failed".to_string()));
+                ack.fail_write("persist failed");
             }
         });
 
@@ -6558,7 +6563,7 @@ peer_group = "ix-members"
             if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Err("persist failed".to_string()));
+                ack.fail_write("persist failed");
             }
         });
 
@@ -6615,7 +6620,7 @@ remote_asn = 65003
             }) = config_rx.recv().await
             {
                 assert!(candidate_toml.contains("10.0.0.3"));
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
 
@@ -6668,7 +6673,7 @@ remote_asn = 65003
             }) = config_rx.recv().await
             {
                 *persisted_task.lock().await = candidate_toml;
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
         let controller = ConfigTransactionController::new(
@@ -6715,7 +6720,7 @@ remote_asn = 65003
             }) = config_rx.recv().await
             {
                 *persisted_task.lock().await = candidate_toml;
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
         let controller = ConfigTransactionController::new(
@@ -6763,7 +6768,7 @@ remote_asn = 65003
             }) = config_rx.recv().await
             {
                 *persisted_task.lock().await = candidate_toml;
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
         let controller = ConfigTransactionController::new(
@@ -6804,7 +6809,7 @@ remote_asn = 65003
             while let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
         let controller = ConfigTransactionController::new(
@@ -6854,7 +6859,7 @@ remote_asn = 65003
             while let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
         let controller = ConfigTransactionController::new(
@@ -6907,7 +6912,7 @@ remote_asn = 65003
             while let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
         let controller = ConfigTransactionController::new(
@@ -7075,7 +7080,7 @@ remote_asn = 65010
             while let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
         let controller = ConfigTransactionController::new(
@@ -7133,7 +7138,7 @@ remote_asn = 65003
             if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
 
@@ -7186,7 +7191,7 @@ remote_asn = 65003
             }) = config_rx.recv().await
             {
                 assert!(candidate_toml.contains("hold_time = 45"));
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
 
@@ -7239,7 +7244,7 @@ remote_asn = 65003
             if let Some(ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Err("persist failed".to_string()));
+                ack.fail_write("persist failed");
             }
         });
 
@@ -7351,7 +7356,7 @@ remote_asn = 65004
             {
                 assert_eq!(tables.len(), 1);
                 assert_eq!(tables[0].name, "core");
-                let _ = ack.send(Ok(()));
+                ack.accept().await;
             }
         });
 
@@ -7411,7 +7416,7 @@ families = ["ipv4_unicast"]
                 ..
             }) = config_rx.recv().await
             {
-                let _ = ack.send(Err("persist failed".to_string()));
+                ack.fail_write("persist failed");
             }
         });
 
@@ -7817,7 +7822,7 @@ peer_group = "ge"
                 panic!("expected persisted config transaction event");
             };
             *persisted_task.lock().await = Some(candidate_toml);
-            let _ = ack.send(Ok(()));
+            ack.accept().await;
         });
 
         let expected_apply_impact =

--- a/src/confirm_journal.rs
+++ b/src/confirm_journal.rs
@@ -384,15 +384,59 @@ fn refuse_after_revert_message(
 /// directory (os error 2)") is useless to an operator who doesn't know
 /// which file the daemon was writing.
 pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
-    write_atomic_inner(path, bytes).map_err(|error| {
-        io::Error::new(
-            error.kind(),
-            format!("failed to write {}: {error}", path.display()),
-        )
-    })
+    stage_atomic(path, bytes)?.commit()
 }
 
-fn write_atomic_inner(path: &Path, bytes: &[u8]) -> io::Result<()> {
+/// A durable write that has been fully written and fsynced next to its
+/// destination but not yet published. Every failure mode an operator hits in
+/// practice — an unwritable directory, a read-only mount, a full filesystem —
+/// is consumed by [`stage_atomic`], so a staged write can be committed with
+/// only a `rename(2)` left to do, or discarded with no trace.
+///
+/// This is what lets runtime config mutations reserve their on-disk write
+/// *before* touching a live BGP session: a staging failure has changed
+/// nothing anywhere, and discarding costs nothing.
+pub(crate) struct StagedWrite {
+    tmp: PathBuf,
+    target: PathBuf,
+}
+
+impl StagedWrite {
+    /// Publish the staged bytes: rename into place and fsync the directory.
+    pub(crate) fn commit(self) -> io::Result<()> {
+        commit_staged(&self.tmp, &self.target)
+            .map_err(|error| name_write_failure(&self.target, &error))
+    }
+
+    /// Drop the staged bytes. Best effort: a leftover temp file is harmless
+    /// (the next stage truncates it) and there is nothing useful to report.
+    pub(crate) fn discard(self) {
+        let _ = fs::remove_file(&self.tmp);
+    }
+}
+
+/// Write temp file + fsync, stopping short of the rename that publishes it.
+///
+/// Failures name the destination path: a bare io error ("No such file or
+/// directory (os error 2)") is useless to an operator who doesn't know
+/// which file the daemon was writing.
+pub(crate) fn stage_atomic(path: &Path, bytes: &[u8]) -> io::Result<StagedWrite> {
+    stage_atomic_inner(path, bytes).map_err(|error| name_write_failure(path, &error))
+}
+
+fn name_write_failure(path: &Path, error: &io::Error) -> io::Error {
+    io::Error::new(
+        error.kind(),
+        format!("failed to write {}: {error}", path.display()),
+    )
+}
+
+fn commit_staged(tmp: &Path, target: &Path) -> io::Result<()> {
+    fs::rename(tmp, target)?;
+    fsync_dir(parent_dir(target)?)
+}
+
+fn stage_atomic_inner(path: &Path, bytes: &[u8]) -> io::Result<StagedWrite> {
     // Resolve symlinks so the write lands on the REAL file: `rename(2)` over
     // a symlink replaces the symlink itself (orphaning its target), and
     // resolving at write time means the rename cannot be redirected by a
@@ -433,8 +477,7 @@ fn write_atomic_inner(path: &Path, bytes: &[u8]) -> io::Result<()> {
     file.write_all(bytes)?;
     file.sync_all()?;
     drop(file);
-    fs::rename(&tmp, &target)?;
-    fsync_dir(parent_dir(&target)?)
+    Ok(StagedWrite { tmp, target })
 }
 
 fn parent_dir(path: &Path) -> io::Result<&Path> {

--- a/src/fib_table_control.rs
+++ b/src/fib_table_control.rs
@@ -29,7 +29,9 @@ use std::time::Duration;
 
 use tokio::sync::{Mutex, mpsc, oneshot};
 
-use rustbgpd_api::peer_types::{ConfigEvent, FibTableSnapshot, PeerManagerCommand};
+use rustbgpd_api::peer_types::{
+    ConfigEvent, ConfigPersistAck, FibTableSnapshot, PeerManagerCommand,
+};
 use rustbgpd_api::proto;
 use rustbgpd_api::rib_service::{
     FibTableControlError, FibTableControlFn, FibTableControlFuture, FibTableControlRequest,
@@ -260,9 +262,12 @@ pub(crate) async fn commit_fib_tables_locked(
     // an immediate SIGHUP can reload stale disk and overwrite the accepted
     // runtime snapshot.
     let (persist_ack_tx, persist_ack_rx) = oneshot::channel();
+    // Single-phase on purpose: FIB-table CRUD owns a rollback that restores
+    // the exact prior table set and already reports an ambiguous outcome when
+    // it cannot.
     permit.send(ConfigEvent::FibTablesReplaced {
         tables: snapshots,
-        ack: Some(persist_ack_tx),
+        ack: Some(ConfigPersistAck::immediate(persist_ack_tx)),
     });
     // LAN-277 window (b): a lost acknowledgement means the on-disk outcome of
     // the persistence attempt is unknowable from here.
@@ -280,7 +285,7 @@ pub(crate) async fn commit_fib_tables_locked(
             peer_mgr_tx,
             previous_tables,
             previous_snapshots,
-            FibTableControlError::FailedPrecondition(error).into(),
+            FibTableControlError::FailedPrecondition(error.to_string()).into(),
         )
         .await);
     }
@@ -612,7 +617,7 @@ mod tests {
             if let Some(ConfigEvent::FibTablesReplaced { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Err("desired config validation failed".to_string()));
+                ack.fail_write("desired config validation failed");
             }
         });
 
@@ -683,7 +688,7 @@ mod tests {
             if let Some(ConfigEvent::FibTablesReplaced { ack: Some(ack), .. }) =
                 config_rx.recv().await
             {
-                let _ = ack.send(Err("desired config validation failed".to_string()));
+                ack.fail_write("desired config validation failed");
             }
         });
 

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -1308,37 +1308,6 @@ impl PeerManager {
                             };
                             let _ = reply.send(result);
                         }
-                        PeerManagerCommand::SetPeerGroupPreserveMd5 { name, mut definition, reply } => {
-                            let result = match named_peer_group_from_config(&self.current_config, &name) {
-                                Some(existing) => {
-                                    definition.md5_password = existing.md5_password;
-                                    let applied_definition = definition.clone();
-                                    let event = ConfigEvent::SetPeerGroup {
-                                        name: name.clone(),
-                                        definition: definition.clone(),
-                                        ack: None,
-                                    };
-                                    if self.peer_group_policy_only_update(&name, &definition) {
-                                        self.apply_policy_change(event, None).await
-                                    } else {
-                                        let affected: Vec<IpAddr> = self.current_config
-                                            .neighbors
-                                            .iter()
-                                            .filter(|neighbor| {
-                                                neighbor.peer_group.as_deref() == Some(name.as_str())
-                                            })
-                                            .filter_map(|neighbor| neighbor.address.parse().ok())
-                                            .collect();
-                                        self.apply_peer_group_change(event, affected).await
-                                    }
-                                    .map(|()| applied_definition)
-                                }
-                                None => Err(rustbgpd_api::peer_types::CatalogMutationError::not_found(
-                                    format!("peer group {name} not found"),
-                                )),
-                            };
-                            let _ = reply.send(result);
-                        }
                         PeerManagerCommand::DeletePeerGroup { name, reply } => {
                             let result = self.apply_peer_group_change(
                                 ConfigEvent::DeletePeerGroup { name, ack: None },

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -18,30 +18,13 @@ use rustbgpd_telemetry::BgpMetrics;
 use tokio::sync::oneshot;
 use tracing::{info, warn};
 
-use crate::config::{Config, ConfigError};
+use crate::config::Config;
 use crate::policy_admin::{
-    NEIGHBOR_NOT_FOUND_REASON, api_peer_group_to_config, apply_config_event,
-    neighbor_set_references, peer_group_references, policy_references,
+    api_peer_group_to_config, apply_config_event, catalog_config_error, neighbor_set_references,
+    peer_group_references, policy_references,
 };
 
 use super::{ManagedPeer, PEER_POLICY_UPDATE_TIMEOUT, PEER_QUERY_TIMEOUT, PeerManager};
-
-fn catalog_config_error(error: ConfigError) -> CatalogMutationError {
-    match error {
-        ConfigError::InvalidNeighborAddress { value, reason }
-            if reason == NEIGHBOR_NOT_FOUND_REASON =>
-        {
-            CatalogMutationError::not_found(format!("neighbor {value} not found"))
-        }
-        ConfigError::UndefinedPolicy { name } => {
-            CatalogMutationError::not_found(format!("policy {name} not found"))
-        }
-        ConfigError::UndefinedPeerGroup { name } => {
-            CatalogMutationError::not_found(format!("peer group {name} not found"))
-        }
-        other => CatalogMutationError::invalid(other.to_string()),
-    }
-}
 
 /// How `update_runtime_policies_for_peer_key` reacts when the Route Refresh
 /// send fails after the session already acked the new policy.

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -18328,3 +18328,461 @@ async fn rfc8212_status_never_calls_a_governed_absent_chain_present() {
         rustbgpd_api::peer_types::Rfc8212PolicyStatus::Unknown
     );
 }
+
+// ---------------------------------------------------------------------------
+// A rejected mutation leaves no observable trace.
+//
+// `FAILED_PRECONDITION` from a mutating RPC means the request did nothing.
+// These drive the real pipeline end to end — peer-manager actor, gRPC neighbor
+// service, config bridge, config persister — against a config directory the
+// process cannot write, which is the persistence failure an operator actually
+// hits on a read-only or root-owned config mount.
+// ---------------------------------------------------------------------------
+
+/// A session task that answers `QueryState` with a fixed, non-zero identity.
+///
+/// A torn-down-and-recreated session cannot reproduce these values: rebuilding
+/// the peer installs a real session task reporting a zeroed uptime and zeroed
+/// counters, so a teardown stays visible in the peer list even when the peer
+/// address comes back.
+fn persistence_probe_handle(peer_addr: IpAddr) -> PeerHandle {
+    use rustbgpd_transport::PeerCommand;
+
+    let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(8);
+    let task = tokio::spawn(async move {
+        while let Some(cmd) = session_rx.recv().await {
+            match cmd {
+                PeerCommand::QueryState { reply } => {
+                    let _ = reply.send(PeerSessionState {
+                        fsm_state: SessionState::Established,
+                        peer_ip: peer_addr,
+                        peer_asn: Some(65002),
+                        prefix_count: 17,
+                        max_prefix: MaxPrefixState::default(),
+                        negotiated_hold_time: Some(90),
+                        four_octet_as: Some(true),
+                        remote_router_id: Some(Ipv4Addr::new(10, 0, 0, 2)),
+                        negotiated_session: None,
+                        local_role: None,
+                        remote_role: None,
+                        role_negotiated: false,
+                        peer_paths_limits: Vec::new(),
+                        effective_add_path_send_limits: Vec::new(),
+                        updates_received: 4_242,
+                        updates_sent: 1_337,
+                        notifications_received: 0,
+                        notifications_sent: 0,
+                        messages_received: 9_001,
+                        messages_sent: 8_128,
+                        otc_routes_blocked: 0,
+                        import_policy_routes_permitted: 0,
+                        import_policy_routes_denied: 0,
+                        flap_count: 3,
+                        uptime_secs: 86_400,
+                        last_error: String::new(),
+                        tcp_ao_info: None,
+                        tcp_ao_protected: false,
+                        slow_peer: false,
+                    });
+                }
+                PeerCommand::Shutdown | PeerCommand::Stop { .. } | PeerCommand::CollisionDump => {
+                    break;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    PeerHandle::from_parts(session_tx, task)
+}
+
+/// The session identity and counters an operator watches: every one of these
+/// changes when a session is torn down and rebuilt, and none of them changes
+/// while it is left alone.
+fn observable_session(
+    info: &rustbgpd_api::peer_types::PeerInfo,
+) -> (SessionState, u64, u64, u64, u64, u64, u64, usize, bool) {
+    (
+        info.state,
+        info.updates_received,
+        info.updates_sent,
+        info.messages_received,
+        info.messages_sent,
+        info.flap_count,
+        info.uptime_secs,
+        info.prefix_count,
+        info.stale,
+    )
+}
+
+/// Peer-manager actor, config bridge, config persister, and neighbor service —
+/// all real — wired to a config file inside a temp directory.
+struct PersistenceRig {
+    dir: tempfile::TempDir,
+    config_path: std::path::PathBuf,
+    peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+    rib_rx: mpsc::Receiver<RibUpdate>,
+    service: rustbgpd_api::NeighborService,
+}
+
+impl PersistenceRig {
+    /// The peer that exists both on disk and as a live Established session.
+    const PEER: &'static str = "10.0.0.2";
+    /// A second configured neighbor, so deleting `PEER` is a targeted removal
+    /// rather than emptying the file.
+    const OTHER_PEER: &'static str = "10.0.0.4";
+
+    /// Not `async`: everything here is either synchronous or a `tokio::spawn`,
+    /// which only needs the caller's runtime, so the rig is fully wired the
+    /// moment this returns.
+    fn start() -> Self {
+        let dir = tempfile::tempdir().expect("temp config dir");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            crate::test_support::tier_authorized_uds_test_config(
+                r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+hold_time = 90
+
+[[neighbors]]
+address = "10.0.0.4"
+remote_asn = 65004
+hold_time = 90
+"#,
+            ),
+        )
+        .expect("seed config file");
+        let config = Config::load_with_diagnostics(config_path.to_str().unwrap())
+            .expect("seed config parses");
+        assert_tier_authorized_test_config(&config);
+
+        // Real persister writing to the real path, behind the real bridge.
+        let (mutation_tx, mutation_rx) = mpsc::channel(8);
+        tokio::spawn(
+            crate::config_persister::ConfigPersister::new(
+                mutation_rx,
+                config_path.clone(),
+                config.clone(),
+                None,
+            )
+            .run(),
+        );
+        let (event_tx, event_rx) = mpsc::channel::<ConfigEvent>(8);
+        let (_replace_tx, replace_rx) = mpsc::unbounded_channel::<Box<Config>>();
+        tokio::spawn(crate::reload::run_config_bridge(
+            event_rx,
+            replace_rx,
+            mutation_tx,
+            config,
+        ));
+
+        // Real peer-manager actor holding one Established session.
+        let (peer_mgr_tx, peer_mgr_rx) = mpsc::channel(16);
+        let (rib_tx, rib_rx) = mpsc::channel(64);
+        let mut mgr = PeerManager::new(
+            peer_mgr_rx,
+            65001,
+            Ipv4Addr::new(10, 0, 0, 1),
+            None,
+            None,
+            BgpMetrics::new(),
+            rib_tx.clone(),
+            None,
+        );
+        let peer_addr: IpAddr = Self::PEER.parse().unwrap();
+        insert_test_managed_peer_with_asn(
+            &mut mgr,
+            peer_addr,
+            65002,
+            persistence_probe_handle(peer_addr),
+            false,
+        );
+        tokio::spawn(mgr.run());
+
+        let service = rustbgpd_api::NeighborService::with_runtime_config_lock(
+            65001,
+            rustbgpd_api::server::AccessMode::ReadWrite,
+            peer_mgr_tx.clone(),
+            rib_tx,
+            Some(event_tx),
+            Arc::new(tokio::sync::Mutex::new(())),
+            None,
+        );
+
+        Self {
+            dir,
+            config_path,
+            peer_mgr_tx,
+            rib_rx,
+            service,
+        }
+    }
+
+    async fn list_peers(&self) -> Vec<rustbgpd_api::peer_types::PeerInfo> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.peer_mgr_tx
+            .send(PeerManagerCommand::ListPeers { reply: reply_tx })
+            .await
+            .expect("peer-manager actor alive");
+        tokio::time::timeout(Duration::from_secs(5), reply_rx)
+            .await
+            .expect("peer-manager actor answered ListPeers")
+            .expect("peer-manager actor kept the reply channel")
+    }
+
+    async fn peer(&self, address: &str) -> Option<rustbgpd_api::peer_types::PeerInfo> {
+        let wanted: IpAddr = address.parse().unwrap();
+        self.list_peers()
+            .await
+            .into_iter()
+            .find(|info| info.address == wanted)
+    }
+
+    fn config_bytes(&self) -> Vec<u8> {
+        std::fs::read(&self.config_path).expect("config file readable")
+    }
+
+    fn staged_temp_path(&self) -> std::path::PathBuf {
+        self.dir.path().join("config.toml.tmp")
+    }
+
+    /// Take write permission away from the config *directory* so the real
+    /// staging write fails with `EACCES`.
+    ///
+    /// Returns `false` when the mode bits do not bind — uid 0 ignores them —
+    /// so the caller skips instead of asserting a failure the kernel will not
+    /// produce. Probing with an actual write is the honest check: the whole
+    /// premise is that writing fails, so ask the filesystem rather than
+    /// guessing from the effective uid.
+    fn seal_config_dir(&self) -> bool {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(self.dir.path(), std::fs::Permissions::from_mode(0o500))
+            .expect("seal config dir");
+        let probe = self.dir.path().join("write-probe");
+        if std::fs::write(&probe, b"probe").is_ok() {
+            std::fs::remove_file(&probe).ok();
+            self.unseal_config_dir();
+            return false;
+        }
+        true
+    }
+
+    /// Restore write permission so the temp directory can be cleaned up.
+    fn unseal_config_dir(&self) {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(self.dir.path(), std::fs::Permissions::from_mode(0o700))
+            .expect("unseal config dir");
+    }
+
+    /// Nothing peer-deleting reached the RIB.
+    fn assert_no_rib_peer_deletion(&mut self, peer: IpAddr) {
+        while let Ok(update) = self.rib_rx.try_recv() {
+            assert!(
+                !matches!(update, RibUpdate::PeerDeleted { peer: deleted } if deleted == peer),
+                "a rejected mutation must not reap the peer's RIB state"
+            );
+        }
+    }
+
+    async fn delete_neighbor(&self, address: &str) -> Result<(), tonic::Status> {
+        use rustbgpd_api::proto::neighbor_service_server::NeighborService as _;
+
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            self.service.delete_neighbor(tonic::Request::new(
+                rustbgpd_api::proto::DeleteNeighborRequest {
+                    address: address.to_string(),
+                    interface: String::new(),
+                },
+            )),
+        )
+        .await
+        .expect("delete_neighbor must answer, not hang")
+        .map(|_| ())
+    }
+
+    async fn add_neighbor(&self, address: &str, remote_asn: u32) -> Result<(), tonic::Status> {
+        use rustbgpd_api::proto::neighbor_service_server::NeighborService as _;
+
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            self.service.add_neighbor(tonic::Request::new(
+                rustbgpd_api::proto::AddNeighborRequest {
+                    config: Some(rustbgpd_api::proto::NeighborConfig {
+                        address: address.to_string(),
+                        remote_asn,
+                        hold_time: 90,
+                        ..Default::default()
+                    }),
+                },
+            )),
+        )
+        .await
+        .expect("add_neighbor must answer, not hang")
+        .map(|_| ())
+    }
+}
+
+/// A `DeleteNeighbor` that cannot persist must return without touching the
+/// session. Applying first and compensating afterwards cannot satisfy this:
+/// the re-added peer is a *new* session with a new identity, a zeroed uptime,
+/// zeroed counters, and a fresh metric series, and the teardown never reaches
+/// the operator's flap count.
+#[tokio::test]
+async fn neighbor_delete_persistence_failure_leaves_the_session_untouched() {
+    let mut rig = PersistenceRig::start();
+    let peer_addr: IpAddr = PersistenceRig::PEER.parse().unwrap();
+
+    let before = rig
+        .peer(PersistenceRig::PEER)
+        .await
+        .expect("peer is present before the rejected delete");
+    assert_eq!(before.state, SessionState::Established);
+    assert!(
+        before.updates_received > 0 && before.updates_sent > 0,
+        "the probe session must carry counters a rebuilt session could not reproduce"
+    );
+    let before_observable = observable_session(&before);
+    let config_before = rig.config_bytes();
+
+    if !rig.seal_config_dir() {
+        return;
+    }
+
+    let error = rig
+        .delete_neighbor(PersistenceRig::PEER)
+        .await
+        .expect_err("an unwritable config directory must reject the delete");
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition, "{error}");
+    assert!(
+        error.message().contains("config persistence failed"),
+        "{}",
+        error.message()
+    );
+
+    let after = rig
+        .peer(PersistenceRig::PEER)
+        .await
+        .expect("the rejected delete must leave the peer in the list");
+    assert_eq!(
+        observable_session(&after),
+        before_observable,
+        "the session must be untouched, not restored: a rebuilt session reports a \
+         zeroed uptime and zeroed counters"
+    );
+    assert_eq!(after.remote_asn, before.remote_asn);
+    assert_eq!(after.description, before.description);
+
+    rig.assert_no_rib_peer_deletion(peer_addr);
+
+    assert_eq!(
+        rig.config_bytes(),
+        config_before,
+        "the config file must be byte-for-byte unchanged"
+    );
+    let staged = rig.staged_temp_path();
+    rig.unseal_config_dir();
+    assert!(
+        !staged.exists(),
+        "no staged temp file may be left behind: {}",
+        staged.display()
+    );
+}
+
+/// An `AddNeighbor` that cannot persist must create nothing at all — not a
+/// peer that is created and then deleted again, and not a config file edit.
+#[tokio::test]
+async fn neighbor_add_persistence_failure_creates_no_session() {
+    const NEW_PEER: &str = "10.0.0.9";
+
+    let rig = PersistenceRig::start();
+    let existing_before = observable_session(
+        &rig.peer(PersistenceRig::PEER)
+            .await
+            .expect("pre-existing peer is present"),
+    );
+    let config_before = rig.config_bytes();
+
+    if !rig.seal_config_dir() {
+        return;
+    }
+
+    let error = rig
+        .add_neighbor(NEW_PEER, 65009)
+        .await
+        .expect_err("an unwritable config directory must reject the add");
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition, "{error}");
+    assert!(
+        error.message().contains("config persistence failed"),
+        "{}",
+        error.message()
+    );
+
+    assert!(
+        rig.peer(NEW_PEER).await.is_none(),
+        "the rejected add must never create the peer — not even briefly"
+    );
+    assert_eq!(
+        observable_session(
+            &rig.peer(PersistenceRig::PEER)
+                .await
+                .expect("pre-existing peer survives an unrelated rejected add")
+        ),
+        existing_before,
+        "an unrelated peer must not be disturbed by a rejected add"
+    );
+
+    assert_eq!(
+        rig.config_bytes(),
+        config_before,
+        "the config file must be byte-for-byte unchanged"
+    );
+    let staged = rig.staged_temp_path();
+    rig.unseal_config_dir();
+    assert!(
+        !staged.exists(),
+        "no staged temp file may be left behind: {}",
+        staged.display()
+    );
+}
+
+/// The success path still works: staging before applying must not turn a
+/// writable config into a no-op.
+#[tokio::test]
+async fn neighbor_delete_persists_and_applies_when_the_config_is_writable() {
+    let rig = PersistenceRig::start();
+    assert!(rig.peer(PersistenceRig::PEER).await.is_some());
+
+    rig.delete_neighbor(PersistenceRig::PEER)
+        .await
+        .expect("a writable config directory must accept the delete");
+
+    assert!(
+        rig.peer(PersistenceRig::PEER).await.is_none(),
+        "the accepted delete must remove the session"
+    );
+    let persisted = String::from_utf8(rig.config_bytes()).expect("config is UTF-8");
+    assert!(
+        !persisted.contains(PersistenceRig::PEER),
+        "the accepted delete must remove the neighbor from disk: {persisted}"
+    );
+    assert!(
+        persisted.contains(PersistenceRig::OTHER_PEER),
+        "the accepted delete must not disturb the other neighbor: {persisted}"
+    );
+    assert!(
+        !rig.staged_temp_path().exists(),
+        "the staged temp file must be renamed into place, not left behind"
+    );
+}

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -3,9 +3,9 @@
 use std::net::IpAddr;
 
 use rustbgpd_api::peer_types::{
-    AddPathDefinition, ConfigEvent, FibTableSnapshot, NamedNeighborSetSnapshot,
-    NamedPeerGroupSnapshot, NamedPolicyDefinition, NamedPolicySnapshot, NeighborSetDefinition,
-    PeerGroupDefinition, PolicyAsPathPrependConfig, PolicyChainAssignment,
+    AddPathDefinition, CatalogMutationError, ConfigEvent, FibTableSnapshot,
+    NamedNeighborSetSnapshot, NamedPeerGroupSnapshot, NamedPolicyDefinition, NamedPolicySnapshot,
+    NeighborSetDefinition, PeerGroupDefinition, PolicyAsPathPrependConfig, PolicyChainAssignment,
     PolicyStatementDefinition,
 };
 
@@ -413,6 +413,28 @@ pub(crate) fn fib_table_snapshot_to_config(snapshot: &FibTableSnapshot) -> FibTa
         maximum_paths: snapshot.maximum_paths,
         maximum_paths_ebgp: snapshot.maximum_paths_ebgp,
         maximum_paths_ibgp: snapshot.maximum_paths_ibgp,
+    }
+}
+
+/// Map a config validation failure onto the typed catalog error surface.
+///
+/// Shared by the runtime catalog mutators and the config bridge: both fold an
+/// event onto a candidate config and validate it, and both must answer with
+/// the same gRPC code for the same bad request.
+pub(crate) fn catalog_config_error(error: ConfigError) -> CatalogMutationError {
+    match error {
+        ConfigError::InvalidNeighborAddress { value, reason }
+            if reason == NEIGHBOR_NOT_FOUND_REASON =>
+        {
+            CatalogMutationError::not_found(format!("neighbor {value} not found"))
+        }
+        ConfigError::UndefinedPolicy { name } => {
+            CatalogMutationError::not_found(format!("policy {name} not found"))
+        }
+        ConfigError::UndefinedPeerGroup { name } => {
+            CatalogMutationError::not_found(format!("peer group {name} not found"))
+        }
+        other => CatalogMutationError::invalid(other.to_string()),
     }
 }
 

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -10,8 +10,8 @@ use std::net::IpAddr;
 use std::ops::Deref;
 
 use rustbgpd_api::peer_types::{
-    CatalogMutationError, ConfigEvent, FibTableSnapshot, PeerManagerCommand,
-    PeerManagerNeighborConfig,
+    CatalogMutationError, ConfigEvent, ConfigPersistAck, ConfigPersistError, FibTableSnapshot,
+    PeerManagerCommand, PeerManagerNeighborConfig,
 };
 use rustbgpd_policy::PolicyChain;
 use tokio::sync::{mpsc, oneshot};
@@ -28,7 +28,7 @@ use crate::config_persister::ConfigMutation;
 use crate::evpn_runtime_converger::EvpnRuntimeReloadApply;
 use crate::fib_runtime::FibRuntimeCommand;
 use crate::peer_manager::InternalCommand;
-use crate::policy_admin::{self, apply_config_event};
+use crate::policy_admin::{self, apply_config_event, catalog_config_error};
 
 /// Monotonic identity for one outbound prefix-limit transaction. Activation
 /// is idempotent by it, so a retry cannot apply two recovery transitions.
@@ -705,7 +705,7 @@ fn fib_table_snapshots(tables: &[config::FibTableConfig]) -> Vec<FibTableSnapsho
         .collect()
 }
 
-fn take_config_event_ack(event: &mut ConfigEvent) -> Option<oneshot::Sender<Result<(), String>>> {
+fn take_config_event_ack(event: &mut ConfigEvent) -> Option<ConfigPersistAck> {
     match event {
         ConfigEvent::FibTablesReplaced { ack, .. }
         | ConfigEvent::NeighborAdded { ack, .. }
@@ -747,6 +747,111 @@ async fn set_pm_fib_tables_snapshot(
     reply_rx
         .await
         .map_err(|e| format!("peer manager dropped reply: {e}"))
+}
+
+/// What the bridge should do with its held snapshot after an acknowledged
+/// config event.
+enum AckedPersistOutcome {
+    /// The candidate is on disk; adopt it as the bridge snapshot.
+    Applied,
+    /// Nothing was written; keep the previous snapshot.
+    Rejected,
+    /// The persister is gone; the bridge has nothing left to do.
+    PersisterLost,
+}
+
+async fn persister_round_trip(rx: oneshot::Receiver<Result<(), String>>) -> Result<(), String> {
+    rx.await
+        .map_err(|_| "config persister dropped persistence acknowledgement".to_string())
+        .and_then(|result| result)
+}
+
+/// Drive one acknowledged config event through the persister.
+///
+/// The two-phase form is the contract that makes a rejected mutation
+/// invisible: the candidate is durably staged and acknowledged *before* the
+/// caller touches runtime state, so a persistence failure is reported while
+/// the live sessions, their counters, and their metric series are still
+/// untouched. The caller then either returns its commit channel — publishing
+/// the staged write — or drops it, discarding the stage.
+async fn persist_acknowledged(
+    mutation_tx: &mpsc::Sender<ConfigMutation>,
+    candidate: Config,
+    ack: ConfigPersistAck,
+) -> AckedPersistOutcome {
+    let ConfigPersistAck { staged, commit } = ack;
+    let Some(commit) = commit else {
+        // Single-phase: the caller owns its own apply/rollback executor and
+        // asked for one durable write with one acknowledgement.
+        let (persist_ack_tx, persist_ack_rx) = oneshot::channel();
+        if mutation_tx
+            .send(ConfigMutation::ReplaceConfigAck(
+                Box::new(candidate),
+                persist_ack_tx,
+            ))
+            .await
+            .is_err()
+        {
+            let _ = staged.send(Err(ConfigPersistError::Write(
+                "config persister unavailable".to_string(),
+            )));
+            return AckedPersistOutcome::PersisterLost;
+        }
+        let result = persister_round_trip(persist_ack_rx).await;
+        let applied = result.is_ok();
+        let _ = staged.send(result.map_err(ConfigPersistError::Write));
+        return if applied {
+            AckedPersistOutcome::Applied
+        } else {
+            AckedPersistOutcome::Rejected
+        };
+    };
+
+    let (stage_ack_tx, stage_ack_rx) = oneshot::channel();
+    if mutation_tx
+        .send(ConfigMutation::StageConfigAck(
+            Box::new(candidate),
+            stage_ack_tx,
+        ))
+        .await
+        .is_err()
+    {
+        let _ = staged.send(Err(ConfigPersistError::Write(
+            "config persister unavailable".to_string(),
+        )));
+        return AckedPersistOutcome::PersisterLost;
+    }
+    let stage_result = persister_round_trip(stage_ack_rx).await;
+    let stage_ok = stage_result.is_ok();
+    let _ = staged.send(stage_result.map_err(ConfigPersistError::Write));
+    if !stage_ok {
+        return AckedPersistOutcome::Rejected;
+    }
+
+    // The caller is applying its runtime change. A dropped commit channel
+    // means that apply failed, or the caller is gone: either way the staged
+    // write must not land.
+    let Ok(commit_reply) = commit.await else {
+        let _ = mutation_tx.send(ConfigMutation::DiscardStagedConfig).await;
+        return AckedPersistOutcome::Rejected;
+    };
+    let (commit_ack_tx, commit_ack_rx) = oneshot::channel();
+    if mutation_tx
+        .send(ConfigMutation::CommitStagedConfig(commit_ack_tx))
+        .await
+        .is_err()
+    {
+        let _ = commit_reply.send(Err("config persister unavailable".to_string()));
+        return AckedPersistOutcome::PersisterLost;
+    }
+    let result = persister_round_trip(commit_ack_rx).await;
+    let applied = result.is_ok();
+    let _ = commit_reply.send(result);
+    if applied {
+        AckedPersistOutcome::Applied
+    } else {
+        AckedPersistOutcome::Rejected
+    }
 }
 
 /// Bridge between gRPC config events, SIGHUP-driven snapshot
@@ -825,44 +930,37 @@ pub(crate) async fn run_config_bridge(
                                 candidate_toml,
                                 "committed config transaction",
                             )
-                            .map_err(|error| error.clone())
+                            .map_err(|error| CatalogMutationError::invalid(error.clone()))
                         } else {
                             let mut candidate = current_config.clone();
                             match apply_config_event(&mut candidate, &event) {
                                 Ok(()) => Ok(candidate),
-                                Err(error) => Err(error.to_string()),
+                                // Staging now runs before the caller's runtime
+                                // change, so this is where a bad request is
+                                // caught. Carry the same typed error the
+                                // runtime apply would have produced so the
+                                // caller keeps its NOT_FOUND / INVALID_ARGUMENT
+                                // answer instead of reporting a persistence
+                                // fault for a request that was simply wrong.
+                                Err(error) => Err(catalog_config_error(error)),
                             }
                         };
                         let candidate = match candidate_result {
                             Ok(candidate) => candidate,
                             Err(error) => {
-                            error!(error = %error, "failed to apply config event before persistence");
+                            error!(error = %error, "rejected config event before persistence");
                             if let Some(ack) = event_ack {
-                                let _ = ack.send(Err(error.clone()));
+                                let _ = ack.staged.send(Err(ConfigPersistError::Rejected(error)));
                             }
                             continue;
                             }
                         };
                         if let Some(ack) = event_ack {
-                            let (persist_ack_tx, persist_ack_rx) = oneshot::channel();
-                            if mutation_tx
-                                .send(ConfigMutation::ReplaceConfigAck(
-                                    Box::new(candidate.clone()),
-                                    persist_ack_tx,
-                                ))
-                                .await
-                                .is_err()
-                            {
-                                let _ = ack.send(Err("config persister unavailable".to_string()));
-                                break;
+                            match persist_acknowledged(&mutation_tx, candidate.clone(), ack).await {
+                                AckedPersistOutcome::Applied => current_config = candidate,
+                                AckedPersistOutcome::Rejected => {}
+                                AckedPersistOutcome::PersisterLost => break,
                             }
-                            let result = persist_ack_rx.await.map_err(|_| {
-                                "config persister dropped persistence acknowledgement".to_string()
-                            }).and_then(|result| result);
-                            if result.is_ok() {
-                                current_config = candidate;
-                            }
-                            let _ = ack.send(result);
                         } else {
                             current_config = candidate;
                             if mutation_tx
@@ -6870,7 +6968,7 @@ peer_group = "secure"
                     maximum_paths_ebgp: None,
                     maximum_paths_ibgp: None,
                 }],
-                ack: Some(ack_tx),
+                ack: Some(ConfigPersistAck::immediate(ack_tx)),
             })
             .await
             .unwrap();
@@ -6887,13 +6985,13 @@ peer_group = "secure"
             matches!(ack_rx.try_recv(), Err(TryRecvError::Empty),),
             "bridge must not acknowledge the FIB event before the persister replies"
         );
-        persist_ack.send(Ok(())).unwrap();
-        assert_eq!(
+        let _ = persist_ack.send(Ok(()));
+        assert!(
             timeout(Duration::from_secs(1), ack_rx)
                 .await
                 .unwrap()
-                .unwrap(),
-            Ok(()),
+                .unwrap()
+                .is_ok(),
             "FIB event ack should reflect the persister result"
         );
 
@@ -6939,7 +7037,7 @@ remote_asn = 65002
         event_tx
             .send(ConfigEvent::ConfigTransactionCommitted {
                 candidate_toml,
-                ack: Some(ack_tx),
+                ack: Some(ConfigPersistAck::immediate(ack_tx)),
             })
             .await
             .unwrap();
@@ -6957,13 +7055,13 @@ remote_asn = 65002
             matches!(ack_rx.try_recv(), Err(TryRecvError::Empty),),
             "bridge must not acknowledge the config transaction before the persister replies"
         );
-        persist_ack.send(Ok(())).unwrap();
-        assert_eq!(
+        let _ = persist_ack.send(Ok(()));
+        assert!(
             timeout(Duration::from_secs(1), ack_rx)
                 .await
                 .unwrap()
-                .unwrap(),
-            Ok(()),
+                .unwrap()
+                .is_ok(),
             "config transaction ack should reflect the persister result"
         );
 
@@ -7044,7 +7142,7 @@ remote_asn = 65002
                     import_policy: None,
                     export_policy: None,
                 },
-                ack: Some(ack_tx),
+                ack: Some(ConfigPersistAck::immediate(ack_tx)),
             })
             .await
             .unwrap();
@@ -7066,13 +7164,13 @@ remote_asn = 65002
             matches!(ack_rx.try_recv(), Err(TryRecvError::Empty),),
             "bridge must not acknowledge the static-neighbor event before the persister replies"
         );
-        persist_ack.send(Ok(())).unwrap();
-        assert_eq!(
+        let _ = persist_ack.send(Ok(()));
+        assert!(
             timeout(Duration::from_secs(1), ack_rx)
                 .await
                 .unwrap()
-                .unwrap(),
-            Ok(()),
+                .unwrap()
+                .is_ok(),
             "static-neighbor event ack should reflect the persister result"
         );
 
@@ -7153,7 +7251,7 @@ remote_asn = 65002
                     import_policy: None,
                     export_policy: None,
                 },
-                ack: Some(ack_tx),
+                ack: Some(ConfigPersistAck::immediate(ack_tx)),
             })
             .await
             .unwrap();
@@ -7170,13 +7268,15 @@ remote_asn = 65002
                 .iter()
                 .any(|neighbor| neighbor.address == "10.0.0.9")
         );
-        persist_ack.send(Err("disk full".to_string())).unwrap();
+        let _ = persist_ack.send(Err("disk full".to_string()));
         assert_eq!(
             timeout(Duration::from_secs(1), ack_rx)
                 .await
                 .unwrap()
-                .unwrap(),
-            Err("disk full".to_string())
+                .unwrap()
+                .unwrap_err()
+                .to_string(),
+            "disk full"
         );
 
         event_tx
@@ -7243,7 +7343,7 @@ remote_asn = 65002
                 peer_group: "fabric".to_string(),
                 remote_asn: 65002,
                 description: Some("lab range".to_string()),
-                ack: Some(ack_tx),
+                ack: Some(ConfigPersistAck::immediate(ack_tx)),
             })
             .await
             .unwrap();
@@ -7260,13 +7360,13 @@ remote_asn = 65002
             matches!(ack_rx.try_recv(), Err(TryRecvError::Empty),),
             "bridge must not acknowledge the dynamic-neighbor event before the persister replies"
         );
-        persist_ack.send(Ok(())).unwrap();
-        assert_eq!(
+        let _ = persist_ack.send(Ok(()));
+        assert!(
             timeout(Duration::from_secs(1), ack_rx)
                 .await
                 .unwrap()
-                .unwrap(),
-            Ok(()),
+                .unwrap()
+                .is_ok(),
             "dynamic-neighbor event ack should reflect the persister result"
         );
 
@@ -7308,7 +7408,7 @@ remote_asn = 65002
                 peer_group: "fabric".to_string(),
                 remote_asn: 65002,
                 description: None,
-                ack: Some(ack_tx),
+                ack: Some(ConfigPersistAck::immediate(ack_tx)),
             })
             .await
             .unwrap();
@@ -7320,13 +7420,15 @@ remote_asn = 65002
             panic!("acked event must request acknowledged persist");
         };
         assert_eq!(first_candidate.dynamic_neighbors.len(), 1);
-        persist_ack.send(Err("disk full".to_string())).unwrap();
+        let _ = persist_ack.send(Err("disk full".to_string()));
         assert_eq!(
             timeout(Duration::from_secs(1), ack_rx)
                 .await
                 .unwrap()
-                .unwrap(),
-            Err("disk full".to_string())
+                .unwrap()
+                .unwrap_err()
+                .to_string(),
+            "disk full"
         );
 
         event_tx

--- a/tests/interop/m54-gnmi-openconfig.clab.yml
+++ b/tests/interop/m54-gnmi-openconfig.clab.yml
@@ -8,9 +8,13 @@
 #
 # The config is mounted read-only as a template and copied to a
 # container-local writable path so the gNMI Set / ADR-0076 atomic
-# config persist (write `.config.toml.tmp` + rename over `config.toml`)
-# succeeds — renaming over a single read-only bind-mounted file fails
-# with EBUSY.
+# config persist (write `config.toml.tmp` alongside the config, then
+# rename it over `config.toml`) succeeds. Both halves need a writable
+# config *directory*: renaming over a read-only bind-mounted file fails
+# with EBUSY, and creating the temp file in a directory the daemon user
+# cannot write fails with EACCES first. Either way the mutation is
+# rejected with FAILED_PRECONDITION and nothing changes, so the lab
+# would see no Set take effect rather than a partial one.
 #
 # Usage:
 #   docker build --target dev -t rustbgpd:dev .
@@ -33,8 +37,8 @@ topology:
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         # Copy the read-only template to a writable container-local path so the
-        # gNMI Set / ADR-0076 atomic config persist (temp + rename) works; see
-        # the header note.
+        # gNMI Set / ADR-0076 atomic config persist (temp file + rename in the
+        # config's own directory) works; see the header note.
         - cp /etc/rustbgpd/config.template.toml /etc/rustbgpd/config.toml
       env:
         RUST_LOG: info,rustbgpd_api=debug


### PR DESCRIPTION
## The defect

`rbgp neighbor <addr> delete` returned `FAILED_PRECONDITION` when config
persistence failed — which reads as "nothing happened" — but the session was
already gone:

```
BEFORE:  10.99.0.20 65002 Established 00:09:43  7 0  frr-peer  25 23  Flaps 0
$ rbgp neighbor 10.99.0.20 delete
Error: precondition failed: config persistence failed: failed to write
       /etc/rustbgpd/config.toml: Permission denied (os error 13)
AFTER:   10.99.0.20 65002 Established 00:00:06  7 0  frr-peer   6  3  Flaps 0
```

The runtime change was applied first and the "rollback" was a compensating
re-add, so the operator got a *different* session: new identity, uptime back to
zero, cumulative counters back to zero, and metric series reaped and restarted.
`Flaps` still read 0, so the event was invisible in the operator's own flap
accounting, and `rate()` / `increase()` across the window was silently wrong
because the series had been rebased.

`FAILED_PRECONDITION` from a mutating RPC must mean no externally visible
mutation. A compensating inverse cannot deliver that for anything carrying
identity, wire continuity, or history.

## Root cause and scope

The ordering was not specific to `neighbor delete`. Every persisted mutating RPC
routed through one shared helper (`persist_runtime_config_event`) that applied
the runtime change, then persisted, then applied the inverse on failure. Twenty
RPCs shared it:

| RPC | Externally visible mutation before the failure was known |
| --- | --- |
| `NeighborService.AddNeighbor` | new session dials out; rollback tears it down |
| `NeighborService.DeleteNeighbor` | session torn down; rollback builds a new one |
| `NeighborService.AddDynamicNeighbor` | accept range live |
| `NeighborService.DeleteDynamicNeighbor` | accept range withdrawn |
| `PeerGroupService.SetPeerGroup` | every inheriting member reshaped — bounced forward, bounced again on rollback |
| `PeerGroupService.DeletePeerGroup` | catalog only (a referenced group cannot be deleted) |
| `PeerGroupService.SetNeighborPeerGroup` | membership reshape — double session bounce |
| `PeerGroupService.ClearNeighborPeerGroup` | membership reshape — double session bounce |
| `PolicyService.SetPolicy` / `DeletePolicy` | Adj-RIB-Out rewrite + RFC 2918 Route Refresh, twice |
| `PolicyService.SetNeighborSet` / `DeleteNeighborSet` | same |
| `PolicyService.SetGlobalImportChain` / `SetGlobalExportChain` | same |
| `PolicyService.ClearGlobalImportChain` / `ClearGlobalExportChain` | same |
| `PolicyService.SetNeighborImportChain` / `SetNeighborExportChain` | same |
| `PolicyService.ClearNeighborImportChain` / `ClearNeighborExportChain` | same |

The peer-group and policy rollbacks restored *config state* exactly, so they
looked correct. What they could not restore is wire history: the forward apply
had already put a Route Refresh and an Adj-RIB-Out delta on the wire, or already
bounced N member sessions, and the rollback emitted a second round of the same
churn — for a request the operator was told had been rejected.

## The fix: a reservation, not a compensation

Persistence is now two-phase, at the one seam all twenty share.

1. **Stage.** The config bridge folds the event onto the config snapshot,
   serializes it, and writes it durably (`config.toml.tmp`, fsynced) next to the
   config file. Every persistence failure an operator actually hits — unwritable
   directory, read-only mount, full filesystem — surfaces here. Nothing is
   observable on disk or on the wire.
2. **Apply.** The runtime change runs only once staging succeeded.
3. **Commit.** The staged write is published with a rename.

A staging failure returns `FAILED_PRECONDITION` before anything is touched. An
apply failure drops the staged write — `StagedConfigWrite`'s commit channel
closes and the bridge discards the temp file — so a runtime rejection leaves no
write on disk either. Only the rename remains after the apply, and its failure
modes were all consumed by the stage.

This deletes the compensation apparatus rather than adding to it:
`persist_rollback_error`, the four `restore_*` chain helpers, and every
`let prior = ...; apply; if persist fails { restore }` block are gone.
`PeerManagerCommand::SetPeerGroupPreserveMd5` goes with them — the stored secret
is carried forward from the prior definition under the same runtime-config lock
the merge already required, which leaves one definition to both stage and apply.

Rejections keep their own status codes. Staging now runs before the apply, so it
is where a bad request is caught; it carries the same typed `CatalogMutationError`
the runtime apply would have produced, so an unknown policy is still `NOT_FOUND`
and a malformed one is still `INVALID_ARGUMENT` rather than being dressed up as a
persistence fault. The neighbor-scoped chain mutators keep an explicit
not-found preflight for the same reason.

The model is #1132's prepared-inactive executor for ADR-0113, generalized: that
change inverted the order for the one family whose apply could not be undone,
and this does the same for every mutator whose apply cannot be undone either.

### What is deliberately not reordered

Two paths keep single-phase persistence, and say so in code:

- **`RibService.SetFibTable` / `DeleteFibTable`** — the FIB-table executor owns a
  rollback that restores the exact prior table set from captured snapshots and
  already reports an ambiguous outcome when a leg of it fails.
- **`ConfigService.ApplyConfigTransaction`** (and `Confirm` / `Abort` /
  `Rollback`, and gNMI `Set`, which all route through it) — ADR-0076 defines
  apply-then-persist-with-rollback as the transaction contract, backed by a
  durable revert journal and ambiguous-outcome reporting, and ADR-0113 already
  inverted the one family whose apply is not undoable. Reordering the whole
  executor is a change to that ADR, not to this seam.

Both keep working through the same bridge via `ConfigPersistAck::immediate`.

## The shipped quickstart

`examples/docker-compose` mounted the config `:ro`, which is what made every
mutating RPC fail — so the README's "No restarts to add peers, change policy, or
inject routes" was false out of the box. A read-write bind mount would not have
fixed it either: persistence writes `<config>.tmp` alongside the config and
renames, so the *directory* must be writable, and the image's `/etc/rustbgpd` is
root-owned while the daemon runs unprivileged.

The config now ships as a template and is copied once into the daemon's writable
state volume, following the template-copy pattern the interop labs already use.
Runtime edits survive `docker compose restart`; `down -v` reseeds from the
template. The standalone `docker run`, the containerlab example, and the
deployment guide carry the same correction, and `docs/CONFIGURATION.md` states
the requirement directly — including that a deliberately read-only config
directory is supported, with rejection as the contract rather than a fault.

The gNMI Set note in `tests/interop/m54-gnmi-openconfig.clab.yml` was stale: it
named the temp file `.config.toml.tmp` (it is `config.toml.tmp`) and gave EBUSY
as the cause, which is only the root-in-containerlab case. Unprivileged
deployments fail earlier, with EACCES creating the temp file. Both are named now,
along with what an operator sees.

## Verification

Real-session receipt on the shipped quickstart, sealing the config directory to
reproduce the exact reported failure:

```
$ rbgp neighbor            10.99.0.20 65002 Established 00:00:25  7 0  frr-peer
$ rbgp neighbor 10.99.0.20 delete
Error: precondition failed: config persistence failed: failed to write
       /var/lib/rustbgpd/config.toml: Permission denied (os error 13)
$ rbgp neighbor            10.99.0.20 65002 Established 00:00:36  7 0  frr-peer
```

Uptime is monotonic across the rejection, prefix counts are unchanged, and the
daemon log carries no session-down, peer-deleted, or peer-added record for that
peer. With a writable config the same lab adds a neighbor at runtime, the row
lands in `config.toml`, and the established session is untouched.

New tests, each red-proven against the pre-fix ordering:

- `neighbor_delete_persistence_failure_leaves_the_session_untouched` — real
  peer-manager actor, real config bridge and persister, real neighbor service,
  against a config directory the process cannot write. Asserts the session
  identity tuple (state, updates and messages sent/received, flap count, uptime,
  prefix count, stale) is *unchanged*, that the RIB saw no peer deletion, that
  the config file is byte-for-byte identical, and that no staged temp file
  survives. Red: `the rejected delete must leave the peer in the list`.
- `neighbor_add_persistence_failure_creates_no_session` — the peer is never
  created, not even briefly, and an unrelated session is undisturbed. Red:
  `the rejected add must never create the peer — not even briefly`.
- `neighbor_delete_persists_and_applies_when_the_config_is_writable` — the
  success path still persists and applies. Green under both orderings, which is
  what makes it a guard rather than a discriminator.
- Sibling coverage: `set_policy`, `set_peer_group`, `set_neighbor_peer_group`,
  both dynamic-range RPCs, and both neighbor RPCs assert the peer manager
  receives nothing at all on a rejected mutation, and the success-path tests
  assert the write is staged *before* the first runtime command.
  `delete_policy_in_use_maps_to_failed_precondition` now also proves the other
  half: a runtime rejection discards the staged write.
