### PR TITLE
Add --check --strict to fail a check that reported warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`rustbgpd --check --strict`.** `--check` reports a valid-but-risky
+  configuration as a warning and exits 0, so that adding a warning can never
+  break a deployment that meant its configuration — which also means a CI job
+  running `--check` passes a config nobody looked at. `--strict` is the opt-in
+  for gates that cannot accept that: identical output, but any warning exits
+  **1**, the same code `--check` already uses for a config it rejects, since a
+  gate reads both as "this config did not pass". A clean check still exits 0,
+  and `--strict` without `--check` is rejected with exit 2 rather than silently
+  accepted — that invocation would otherwise start a daemon. `--strict` is
+  defined over the whole `--check` warning set, not one warning, so anything
+  `--check` reports in future fails a strict run. Startup-time `tracing`
+  warnings are not part of that set and are unchanged. `--help` and
+  `rustbgpd(8)` now document the exit-status ladder.
+
 - **Per-peer outbound unicast prefix limits (ADR-0113).** New
   `max_prefixes_out_ipv4` / `max_prefixes_out_ipv6` on `[[neighbors]]` and peer
   groups bound how much of the table one client's export policy can grow its

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -435,7 +435,9 @@ knob is on (that direction will carry no routes) or off (that direction is
 unfiltered). It stays a warning — a permit-all route server is a legitimate
 configuration — but a check with warnings summarizes as `config VALID, <n>
 WARNINGS — NOT a clean check` rather than `config OK`. The exit code is 0
-either way. `rbgp config import` sets the knob in every config it generates,
+either way; add `--strict` (see [deployment.md](deployment.md)) to make any
+warning exit 1 in a CI or deployment gate. `rbgp config import` sets the knob
+in every config it generates,
 since it never translates policy; its report says so.
 
 **Observing it.** Each direction is reported independently — `not_required`

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -198,6 +198,7 @@ done
 # Guards must exit non-zero:
 ./target/release/rustbgpd --stdout                              # --stdout without --init-config
 ./target/release/rustbgpd --init-config lab --stdout --check x  # --init-config combined with --check/--diff
+./target/release/rustbgpd --strict /tmp/init-lab.toml           # --strict without --check
 ```
 
 ### README quickstart smoke

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -442,12 +442,13 @@ according to your needs.
 
 ## Config validation workflow
 
-Four flags cover the config lifecycle, from bootstrap to reload:
+These cover the config lifecycle, from bootstrap to reload:
 
 | Command | What it does |
 |---|---|
 | `rustbgpd --init-config <lab\|edge> --stdout` | Print a curated, commented starter TOML to stdout and exit (file output is not yet supported). `lab` is a minimal single-box profile; `edge` is an eBGP edge skeleton with a default-route-dropping import chain. Both use a mode-`0600` local UDS whose filesystem permissions authenticate access and whose stable `operator` principal is tier-authorized. Cannot be combined with `--check` / `--diff`. |
-| `rustbgpd --check <file>` | Parse + validate; print `config OK`, `config VALID, <n> WARNINGS — NOT a clean check` (warnings framed on stderr; still exit 0), or a rustc-style diagnostic. Does not start the daemon. |
+| `rustbgpd --check <file>` | Parse + validate; print `config OK`, `config VALID, <n> WARNINGS — NOT a clean check` (warnings framed on stderr; still exit 0), or a rustc-style diagnostic (exit 1). Does not start the daemon. |
+| `rustbgpd --check --strict <file>` | The same check, but any warning exits 1 instead of 0 — for CI and deployment gates that must not accept a valid-but-risky config. A clean check still exits 0. `--strict` without `--check` is an error (exit 2). |
 | `rustbgpd --diff <file>` | Compute the diff against the running daemon's view; print per-section change list with expected reload class. |
 | `systemctl reload rustbgpd` (or `kill -HUP $(pidof rustbgpd)`) | Apply the diff. Live fields hot-apply; restart-required fields are pinned and logged at `ERROR` (the live values are kept). |
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1837,6 +1837,23 @@ fn tcp_ao_listener_key_for_dynamic_range(
     })
 }
 
+/// Emit every `--check` warning and return the total count.
+///
+/// The single place the check-time warning set is defined. `--strict` turns
+/// this count into the exit code, so a new check warning is covered by
+/// `--strict` the moment it is summed here — there is no per-warning strict
+/// handling to keep in sync.
+///
+/// Startup warnings are deliberately not part of this set. The
+/// `ebgp_requires_policy` partial-enforcement notice reports what this
+/// release has not finished building, not a defect in the operator's config,
+/// and the legacy-`security.grpc.enforcement` warning and the ORR
+/// vantage-without-linkstate warning are `tracing` records emitted after
+/// logging is initialized, which `--check` returns before reaching.
+fn check_warnings(config: &Config) -> usize {
+    warn_unpoliced_ebgp(config)
+}
+
 /// Print the `--check` warning for eBGP neighbors that resolve no explicit
 /// policy, and return how many there are.
 ///
@@ -2113,6 +2130,7 @@ fn bfd_status_to_proto(status: &bfd_runtime::BfdStatus) -> rustbgpd_api::proto::
 /// The `rustbgpd(8)` man page, hand-maintained roff. The daemon's arg
 /// parser is hand-rolled (no clap), so this mirrors the `--help` text
 /// above — keep the two in sync when adding a flag.
+#[expect(clippy::too_many_lines, reason = "one roff document, one literal")]
 fn man_page() -> String {
     format!(
         r#".TH RUSTBGPD 8 "" "rustbgpd {version}" "System Administration"
@@ -2138,7 +2156,20 @@ Path to the TOML config file. Defaults to
 .SH OPTIONS
 .TP
 \fB\-\-check\fR
-Validate the config and exit without starting the daemon.
+Validate the config and exit without starting the daemon. A valid
+config that was warned about still exits 0; see
+.B EXIT STATUS
+and
+.BR \-\-strict .
+.TP
+\fB\-\-strict\fR
+Only with
+.BR \-\-check :
+exit 1 if the check reported any warning, instead of 0. Intended for
+CI and deployment gates that must not accept a valid\-but\-risky
+config. Passing it without
+.B \-\-check
+is an error.
 .TP
 \fB\-\-diff\fR \fIPATH\fR
 Compare the config against \fIPATH\fR and show what SIGHUP would
@@ -2166,6 +2197,28 @@ Print version and exit.
 .TP
 \fB\-\-help\fR, \fB\-h\fR
 Print the help message.
+.SH EXIT STATUS
+.TP
+.B 0
+Success. For
+.BR \-\-check ,
+the config is valid; without
+.B \-\-strict
+this includes a valid config that warnings were reported for.
+.TP
+.B 1
+The config was rejected, or
+.B \-\-check \-\-strict
+reported at least one warning. For
+.BR \-\-diff ,
+1 means the diff carries actionable changes.
+.TP
+.B 2
+Invalid invocation: an unusable flag combination or a missing
+argument.
+.TP
+.B 70
+Internal error.
 .SH SIGNALS
 .TP
 \fBSIGHUP\fR
@@ -2211,6 +2264,8 @@ fn main() {
                CONFIG_PATH  Path to TOML config file [default: /etc/rustbgpd/config.toml]\n\n\
              Options:\n  \
                --check               Validate config and exit without starting the daemon\n  \
+               --strict              With --check, exit 1 if anything was warned about (for CI\n                        \
+                                     and deployment gates). Rejected without --check\n  \
                --diff PATH           Compare config against PATH and show what SIGHUP would change\n  \
                --json                Output diff as JSON (only with --diff)\n  \
                --init-config PROFILE Print a starter config to stdout and exit (needs --stdout).\n                        \
@@ -2219,7 +2274,13 @@ fn main() {
                --dump-config-schema  Print the config JSON Schema to stdout and exit\n  \
                --man                 Print the man page (roff) to stdout and exit\n  \
                --version             Print version and exit\n  \
-               --help                Print this help message",
+               --help                Print this help message\n\n\
+             Exit status:\n  \
+               0  Success. For --check: the config is valid; without --strict this\n     \
+                  includes a valid config that was warned about\n  \
+               1  The config was rejected, or --check --strict found warnings\n  \
+               2  Invalid invocation (unknown flag combination, missing argument)\n  \
+               70 Internal error",
             env!("CARGO_PKG_VERSION")
         );
         return;
@@ -2227,6 +2288,7 @@ fn main() {
 
     // Parse flags and config path from remaining args.
     let mut check_only = false;
+    let mut strict = false;
     let mut diff_path: Option<String> = None;
     let mut json_output = false;
     let mut init_profile: Option<String> = None;
@@ -2244,6 +2306,8 @@ fn main() {
             expect_init_profile = false;
         } else if arg == "--check" {
             check_only = true;
+        } else if arg == "--strict" {
+            strict = true;
         } else if arg == "--diff" {
             expect_diff_path = true;
         } else if arg == "--json" {
@@ -2259,7 +2323,7 @@ fn main() {
         } else {
             eprintln!("error: unknown option: {arg}");
             eprintln!(
-                "usage: rustbgpd [--check] [--diff PATH] [--json] [--init-config PROFILE --stdout] [--dump-config-schema] [--version] [CONFIG_PATH]"
+                "usage: rustbgpd [--check [--strict]] [--diff PATH] [--json] [--init-config PROFILE --stdout] [--dump-config-schema] [--version] [CONFIG_PATH]"
             );
             process::exit(1);
         }
@@ -2277,6 +2341,13 @@ fn main() {
     }
     if json_output && diff_path.is_none() {
         eprintln!("error: --json can only be used with --diff");
+        process::exit(2);
+    }
+    // `--strict` only modifies `--check`. Accepting it silently on a
+    // daemon run would let a CI gate that meant `--check --strict` boot a
+    // daemon instead and still report success.
+    if strict && !check_only {
+        eprintln!("error: --strict can only be used with --check");
         process::exit(2);
     }
     // `--stdout` is only the `--init-config` output target. Without it,
@@ -2362,16 +2433,27 @@ fn main() {
         // The summary line is the only thing some operators read. When
         // anything was flagged it must not be able to pass for a clean
         // result, so `OK` is spent only on a check with nothing to report
-        // and otherwise gives way to the count. The exit code stays 0
-        // either way — these are warnings, not failures.
-        let warnings = warn_unpoliced_ebgp(&config);
+        // and otherwise gives way to the count. Without `--strict` the exit
+        // code stays 0 either way — these are warnings, not failures.
+        let warnings = check_warnings(&config);
         if warnings == 0 {
             println!("config OK: {config_path}");
-        } else {
-            println!(
-                "config VALID, {warnings} WARNING{} — NOT a clean check: {config_path}",
-                if warnings == 1 { "" } else { "S" }
+            return;
+        }
+        println!(
+            "config VALID, {warnings} WARNING{} — NOT a clean check: {config_path}",
+            if warnings == 1 { "" } else { "S" }
+        );
+        if strict {
+            // Exit 1, the same code a `--check` that could not load the
+            // config uses: from a gate's point of view both mean "this
+            // config did not pass". 2 stays reserved for how the command
+            // was invoked.
+            eprintln!(
+                "error: --strict: {warnings} warning{} — not a clean check",
+                if warnings == 1 { "" } else { "s" }
             );
+            process::exit(1);
         }
         return;
     }
@@ -5372,6 +5454,7 @@ mod tests {
         assert!(man.starts_with(".TH RUSTBGPD 8"), "missing roff .TH header");
         for flag in [
             r"\-\-check",
+            r"\-\-strict",
             r"\-\-diff",
             r"\-\-json",
             r"\-\-init\-config",
@@ -5384,6 +5467,12 @@ mod tests {
             assert!(man.contains(flag), "man page missing {flag}");
         }
         assert!(man.contains("SIGHUP"));
+        // `--strict` is only useful if the codes it selects between are
+        // written down where an operator writing a gate will look.
+        assert!(
+            man.contains(".SH EXIT STATUS"),
+            "man page missing the EXIT STATUS section"
+        );
     }
 
     fn tcp_ao_neighbor_toml(address: &str) -> String {

--- a/tests/check_strict.rs
+++ b/tests/check_strict.rs
@@ -1,0 +1,168 @@
+//! Exit-code contract for `rustbgpd --check` and `rustbgpd --check --strict`.
+//!
+//! `--check` is the last gate before a config reaches a production box, and
+//! a valid-but-risky config warns there without failing — deliberately, so
+//! that adding a warning never breaks a deployment that meant it. `--strict`
+//! is the opt-in for gates that cannot accept that: same warnings, nonzero
+//! exit. These tests pin both halves plus the rejection of `--strict` on its
+//! own, because an accepted-but-ignored `--strict` would make a CI gate
+//! report success for a config nobody checked.
+
+use std::process::Command;
+
+/// A config with one eBGP neighbor that resolves no policy in either
+/// direction — valid, and the shape `--check` warns about.
+const WARNS: &str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+runtime_state_dir = "/tmp/rustbgpd-check-strict"
+
+[global.telemetry]
+log_format = "json"
+
+[global.telemetry.grpc_uds]
+enabled = true
+path = "/tmp/rustbgpd-check-strict/grpc.sock"
+mode = 0o600
+principal = "operator"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+operator = "operator"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+"#;
+
+/// The same config with both directions of that neighbor policed: valid
+/// with nothing to warn about, so `--strict` must not change its exit code.
+const CLEAN: &str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+runtime_state_dir = "/tmp/rustbgpd-check-strict"
+
+[global.telemetry]
+log_format = "json"
+
+[global.telemetry.grpc_uds]
+enabled = true
+path = "/tmp/rustbgpd-check-strict/grpc.sock"
+mode = 0o600
+principal = "operator"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+operator = "operator"
+
+[policy.definitions.from-peer]
+default_action = "permit"
+
+[policy.definitions.to-peer]
+default_action = "permit"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+import_policy_chain = ["from-peer"]
+export_policy_chain = ["to-peer"]
+"#;
+
+/// Run the daemon binary with `args` plus a config file holding
+/// `config_toml`; returns `(exit_code, stdout, stderr)`.
+fn run(config_toml: &str, args: &[&str]) -> (Option<i32>, String, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = dir.path().join("config.toml");
+    std::fs::write(&config, config_toml).expect("write config");
+    let output = Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
+        .args(args)
+        .arg(&config)
+        // Warnings are framed for a terminal; keep assertions on text.
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("run rustbgpd");
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// Backward compatibility: warnings alone never fail a plain `--check`.
+#[test]
+fn check_without_strict_exits_zero_on_warnings() {
+    let (code, stdout, stderr) = run(WARNS, &["--check"]);
+    assert_eq!(code, Some(0), "stdout:\n{stdout}\nstderr:\n{stderr}");
+    assert!(
+        stdout.contains("config VALID, 1 WARNING — NOT a clean check"),
+        "summary line did not report the warning:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("WARNING"),
+        "warning was not framed on stderr:\n{stderr}"
+    );
+}
+
+/// The feature: the same config, the same warnings, a failing exit code.
+#[test]
+fn check_strict_exits_nonzero_on_warnings() {
+    let (code, stdout, stderr) = run(WARNS, &["--check", "--strict"]);
+    assert_eq!(code, Some(1), "stdout:\n{stdout}\nstderr:\n{stderr}");
+    // The config is still valid; only the exit code changes.
+    assert!(
+        stdout.contains("config VALID, 1 WARNING — NOT a clean check"),
+        "summary line changed under --strict:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("--strict"),
+        "stderr does not say why the check failed:\n{stderr}"
+    );
+}
+
+/// `--strict` must not fail a check that had nothing to report, or it would
+/// be a gate nobody can pass.
+#[test]
+fn check_strict_exits_zero_on_a_clean_config() {
+    let (code, stdout, stderr) = run(CLEAN, &["--check", "--strict"]);
+    assert_eq!(code, Some(0), "stdout:\n{stdout}\nstderr:\n{stderr}");
+    assert!(
+        stdout.contains("config OK"),
+        "clean check did not print the OK summary:\n{stdout}"
+    );
+}
+
+/// Silently accepting `--strict` without `--check` would start the daemon
+/// for an invocation that meant to validate and exit.
+#[test]
+fn strict_without_check_is_rejected() {
+    let (code, stdout, stderr) = run(CLEAN, &["--strict"]);
+    assert_eq!(code, Some(2), "stdout:\n{stdout}\nstderr:\n{stderr}");
+    assert!(
+        stderr.contains("--strict can only be used with --check"),
+        "rejection did not name the requirement:\n{stderr}"
+    );
+}
+
+/// The exit-code ladder is only usable if it is written down where an
+/// operator wiring a gate will look.
+#[test]
+fn help_documents_the_exit_codes() {
+    let output = Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
+        .arg("--help")
+        .output()
+        .expect("run rustbgpd --help");
+    let help = String::from_utf8_lossy(&output.stdout);
+    assert!(help.contains("--strict"), "help does not list --strict");
+    assert!(
+        help.contains("Exit status:"),
+        "help does not document exit status:\n{help}"
+    );
+}


### PR DESCRIPTION
`rustbgpd --check` reports a valid-but-risky configuration as a warning and
exits 0. That is deliberate — a permit-all route server is a legitimate
deployment, and adding a warning must never break one. The cost is that a CI
job wired to `rustbgpd --check` passes a config nobody looked at: the summary
line says `config VALID, 2 WARNINGS — NOT a clean check` and the gate says
success.

`--strict` is the opt-in for gates that cannot accept that. It changes only
the exit code — same warnings on stderr, same summary line on stdout.

```
$ rustbgpd --check --strict warn.toml
==========================================================================
WARNING: 2 eBGP neighbors resolve no explicit policy.

  10.0.0.2 (AS 65002): no import policy and no export policy
  10.0.0.3 (AS 65003): no import policy and no export policy

Every direction listed above is unfiltered. [...]
==========================================================================

config VALID, 2 WARNINGS — NOT a clean check: warn.toml
error: --strict: 2 warnings — not a clean check
$ echo $?
1
```

## Exit code

**1**, chosen from the ladder this binary already uses rather than added to
it: `--check` exits 1 for a config it rejects, and `--diff` exits 1 when the
diff carries actionable changes — a gate reads all three as "this did not
pass". 2 stays reserved for how the command was invoked, which is what
`--strict` without `--check` gets. 70 stays `EX_SOFTWARE`.

## Scope of "any warning"

`--strict` is defined over the whole check-time warning set, not over the one
warning that exists today. `check_warnings` is the single place that set is
summed, so a warning added there is covered by `--strict` without touching
`--strict`.

Today that set has exactly one member: the unpoliced-eBGP warning. The other
config warnings in the tree are startup-only and stay out of the set — the
`ebgp_requires_policy` partial-enforcement notice reports what this release
has not finished building rather than a defect in the operator's config, and
it, the legacy-`security.grpc.enforcement` warning and the ORR
vantage-without-linkstate warning are all `tracing` records emitted after
logging is initialized, which `--check` returns before reaching. Promoting any
of them to a check-time warning is a separate change.

## Contract

| Invocation | Warnings | Exit |
|---|---|---|
| `--check` | any | 0 (unchanged) |
| `--check --strict` | none | 0 |
| `--check --strict` | 1 or more | 1 |
| `--strict` (no `--check`) | — | 2, `error: --strict can only be used with --check` |

Rejecting a bare `--strict` matters more than it looks: accepted silently, it
would fall through to normal daemon startup, so a CI runner that meant
`--check --strict` would boot a daemon and the job would still report success.

`tests/check_strict.rs` pins all four rows plus the documented exit ladder.
Against pre-`--strict` `src/main.rs` four of the five fail and only
`check_without_strict_exits_zero_on_warnings` passes — that one is the
backward-compatibility pin and is meant to be green on both sides.

## Documentation

`--help` and `rustbgpd(8)` both gain an exit-status section (the man page is
hand-maintained roff mirroring `--help`; the flag-coverage test now also
requires the section). The config-validation table in `docs/deployment.md`
gains the flag, `docs/CONFIGURATION.md` points at it from the RFC 8212
section, and the release checklist's must-exit-non-zero list gains the new
guard.

The checklist's config-init smoke still runs plain `--check` on the built-in
profiles and still records that both warn — inverting that to
`--check --strict` needs the starter configs to be policy-complete first, so
it is left alone here.
