### PR TITLE
Set SO_REUSEADDR on the BGP listener and exit on a bind failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,34 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The BGP listener sets `SO_REUSEADDR`, so an ordinary restart under traffic
+  no longer fails `EADDRINUSE`.** The listener socket is built through
+  `socket2`, which does not apply the `SO_REUSEADDR` that `std`/`mio` set for
+  the gRPC and metrics listeners. The daemon is normally the active closer at
+  shutdown, so on every restart with sessions up a connection the previous
+  generation accepted still holds the listen port in `FIN_WAIT`/`TIME_WAIT` —
+  and the next generation's bind was rejected. `SO_REUSEADDR` is set before
+  `bind`, ahead of the TCP-AO listener MKT installation, which keeps its
+  bind→install→listen ordering. `SO_REUSEPORT` is deliberately not used: it
+  permits concurrent binds, which would let two daemon generations serve the
+  listen port at once. Because Linux requires the option on both endpoints, the
+  first restart of a daemon whose previous generation predates this fix can
+  still be rejected; every restart after that is clean.
+
+- **A BGP listener bind failure now exits 1 instead of leaving a live daemon
+  that accepts no sessions.** The daemon previously marked itself not-ready and
+  kept serving gRPC. That state had no recovery path — `listen_port` is
+  mandatory, the listener is never rebound without a restart, and the only
+  surface reporting the fault was `/readyz`, which exists only when
+  `prometheus_addr` is configured — so the process parked with its core
+  function dead while its management plane looked healthy. Exit 1 matches the
+  code already used for an unexpected gRPC server exit and for a bind failure
+  with TCP-AO peers configured, so supervisors with `Restart=on-failure` retry;
+  the retry also clears a transient bind failure without an operator, and a
+  permanent one repeats the bind error in the journal. `rbgp doctor` reports
+  the cause (port in use, missing `CAP_NET_BIND_SERVICE`) against the down
+  daemon through its existing `bgp.listener` check.
+
 - **`rbgp config import` no longer splits BIRD constructs that reuse block or
   statement punctuation inside an expression.** Prefix-set range suffixes
   (`[ 0.0.0.0/8{8,32}, ... ]`) were read as block braces, so one `define` was

--- a/crates/api/src/health_probe.rs
+++ b/crates/api/src/health_probe.rs
@@ -19,9 +19,9 @@ pub const CORE_READINESS_DEADLINE: Duration = Duration::from_millis(200);
 /// Two one-way transitions, both set from `main.rs` and observed by the
 /// readiness surface:
 ///
-/// - **not-ready**: a fatal availability fault (BGP listener failed to
-///   bind, coordinated shutdown started). `/readyz` reports 503 with the
-///   first recorded reason until the process restarts.
+/// - **not-ready**: a fatal availability fault (coordinated shutdown
+///   started). `/readyz` reports 503 with the first recorded reason until
+///   the process restarts.
 /// - **shutting-down**: coordinated shutdown has begun; admission paths
 ///   (inbound BGP connections, persisted config mutations) reject new
 ///   work instead of racing the teardown.
@@ -574,15 +574,15 @@ mod tests {
 
     #[tokio::test]
     async fn gated_probe_fails_without_touching_core_actors() {
-        // BGP-listener bind failure: readiness must go red even though
-        // both core actors would answer (nothing replies here and the
-        // probe must not need them to).
+        // A recorded availability fault must turn readiness red even
+        // though both core actors would answer (nothing replies here and
+        // the probe must not need them to).
         let (peer_tx, _peer_rx) = mpsc::channel(1);
         let (rib_tx, _rib_rx) = mpsc::channel(1);
         let gate = DaemonGate::new();
         let probe = CoreReadinessProbe::new(peer_tx, rib_tx).with_gate(gate.clone());
 
-        gate.mark_not_ready("BGP listener failed to bind");
+        gate.mark_not_ready("fatal availability fault");
 
         let err = probe
             .check()
@@ -590,12 +590,12 @@ mod tests {
             .expect_err("tripped gate must fail readiness");
         assert_eq!(
             err,
-            CoreReadinessError::DaemonUnavailable("BGP listener failed to bind")
+            CoreReadinessError::DaemonUnavailable("fatal availability fault")
         );
-        assert_eq!(err.to_string(), "BGP listener failed to bind");
+        assert_eq!(err.to_string(), "fatal availability fault");
         assert!(
             !gate.is_shutting_down(),
-            "a bind fault must not flip the shutdown admission gate"
+            "a non-shutdown fault must not flip the shutdown admission gate"
         );
     }
 
@@ -621,11 +621,11 @@ mod tests {
     #[test]
     fn first_not_ready_reason_wins() {
         let gate = DaemonGate::new();
-        gate.mark_not_ready("BGP listener failed to bind");
+        gate.mark_not_ready("fatal availability fault");
         gate.begin_shutdown();
         assert_eq!(
             gate.not_ready_reason(),
-            Some("BGP listener failed to bind"),
+            Some("fatal availability fault"),
             "the root-cause fault must stay visible across later transitions"
         );
     }

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -2277,6 +2277,17 @@ where
         Domain::IPV6
     };
     let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+    // Must precede bind(). The daemon is normally the active closer at
+    // shutdown, so on an ordinary restart-under-traffic a connection the
+    // previous generation accepted still holds the listen port in
+    // FIN_WAIT/TIME_WAIT and the bind fails EADDRINUSE. `socket2` builds a
+    // raw socket, so it does not get the SO_REUSEADDR that `std`/`mio`
+    // apply for us on the gRPC and metrics listeners.
+    //
+    // SO_REUSEADDR only, never SO_REUSEPORT: SO_REUSEPORT permits
+    // concurrent binds, which would let two daemon generations serve the
+    // listen port at once and split inbound sessions between them.
+    socket.set_reuse_address(true)?;
     socket.bind(&SockAddr::from(addr))?;
     for key in &options.tcp_ao_keys {
         // This installs a peer-specific MKT, not the socket-wide
@@ -3631,6 +3642,31 @@ mod tests {
         assert!(listener.local_addr().unwrap().port() > 0);
         assert_eq!(installed.into_inner(), vec![1, 2]);
         tokio::task::yield_now().await;
+    }
+
+    /// Restart-under-traffic: the daemon is the active closer at shutdown,
+    /// so a connection it accepted on the listen port lingers in
+    /// `FIN_WAIT`/`TIME_WAIT` while the next generation binds. Without
+    /// `SO_REUSEADDR` on both generations that bind fails `EADDRINUSE`.
+    #[tokio::test]
+    async fn bind_socket2_listener_rebinds_over_a_lingering_accepted_connection() {
+        let options = ListenerSocketOptions::default();
+        let listener = bind_socket2_listener("127.0.0.1:0".parse().unwrap(), &options)
+            .expect("first generation binds");
+        let addr = listener.local_addr().expect("listener local addr");
+
+        let client = std::net::TcpStream::connect(addr).expect("inbound connection");
+        let (accepted, _) = listener.accept().await.expect("accept the connection");
+
+        // Close the accepted socket first (daemon-as-active-closer), then
+        // the peer, then the listener: the accepted endpoint is left
+        // holding `addr` in a post-close state.
+        drop(accepted);
+        drop(client);
+        drop(listener);
+
+        bind_socket2_listener(addr, &options)
+            .expect("second generation rebinds over the lingering connection");
     }
 
     #[tokio::test]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -160,6 +160,17 @@ Notes on the sandbox:
 - `ExecReload=kill -HUP` is the supported reload path. See the
   [reload matrix](reload-matrix.md) for which fields hot-apply vs.
   need a restart.
+- `Restart=on-failure` is load-bearing. The daemon exits `0` only on an
+  operator-initiated shutdown (SIGINT/SIGTERM, the `Shutdown` RPC) and
+  `1` on a component failure it cannot recover from in place — the BGP
+  listener failing to bind, or the gRPC server exiting unexpectedly.
+  Neither listener is rebound without a restart, so the daemon exits
+  rather than run on deaf; the supervisor's retry is the recovery path.
+  With `RestartSec=5` a transient bind failure clears on the next
+  attempt, and a permanent one (port held by another speaker, missing
+  `CAP_NET_BIND_SERVICE`) repeats the bind error in the journal on every
+  attempt. `rbgp doctor` reports the same cause against the down daemon
+  through its `bgp.listener` check.
 
 ### Installation
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2211,7 +2211,12 @@ The config was rejected, or
 .B \-\-check \-\-strict
 reported at least one warning. For
 .BR \-\-diff ,
-1 means the diff carries actionable changes.
+1 means the diff carries actionable changes. A running daemon also exits
+1 when a component failure ends it (the BGP listener failed to bind, or
+the gRPC server exited unexpectedly), so that a supervisor configured
+with
+.B Restart=on\-failure
+restarts it. An operator\-initiated shutdown exits 0.
 .TP
 .B 2
 Invalid invocation: an unusable flag combination or a missing
@@ -2278,7 +2283,9 @@ fn main() {
              Exit status:\n  \
                0  Success. For --check: the config is valid; without --strict this\n     \
                   includes a valid config that was warned about\n  \
-               1  The config was rejected, or --check --strict found warnings\n  \
+               1  The config was rejected, or --check --strict found warnings.\n     \
+                  A running daemon exits 1 on a component failure that ends it\n     \
+                  (BGP listener bind, unexpected gRPC server exit)\n  \
                2  Invalid invocation (unknown flag combination, missing argument)\n  \
                70 Internal error",
             env!("CARGO_PKG_VERSION")
@@ -4394,61 +4401,58 @@ async fn run<T>(
             .collect(),
     };
 
-    let tcp_ao_listener_required = !listener_options.tcp_ao_keys.is_empty();
     let (accept_tx, mut accept_rx) = mpsc::channel::<rustbgpd_transport::AcceptedConnection>(64);
-    let mut tcp_ao_listener_handle = None;
-    match BgpListener::bind_with_options(listen_addr, accept_tx, listener_options).await {
-        Ok(listener) => {
-            tcp_ao_listener_handle = Some(listener.tcp_ao_rotation_handle());
-            let listener_peer_mgr_tx = peer_mgr_tx.clone();
-            let listener_gate = daemon_gate.clone();
-            tokio::spawn(async move {
-                while let Some(conn) = accept_rx.recv().await {
-                    // Coordinated shutdown has begun: drop (close) the
-                    // socket instead of admitting a session into teardown.
-                    if listener_gate.is_shutting_down() {
-                        info!(
-                            peer = %conn.peer_addr,
-                            "rejecting inbound BGP connection: daemon is shutting down"
-                        );
-                        continue;
-                    }
-                    if let Err(e) = listener_peer_mgr_tx
-                        .send(PeerManagerCommand::AcceptInbound {
-                            stream: conn.stream,
-                            peer_addr: conn.peer_addr,
-                            tcp_ao_info: conn.tcp_ao_info,
-                            tcp_ao_generation: conn.tcp_ao_generation,
-                        })
-                        .await
-                    {
-                        warn!(error = %e, "failed to forward inbound connection to peer manager");
-                    }
-                }
-            });
-            tokio::spawn(listener.run());
-        }
-        Err(e) => {
-            if tcp_ao_listener_required {
+    let listener =
+        match BgpListener::bind_with_options(listen_addr, accept_tx, listener_options).await {
+            Ok(listener) => listener,
+            Err(e) => {
+                // Fatal. `listen_port` is mandatory, the listener is never
+                // rebound without a restart, and outbound-only operation
+                // silently drops every passive peer, every dynamic-neighbor
+                // range, and every peer that wins the connect race. Staying up
+                // in that state offered no recovery the operator could reach,
+                // and `/readyz` — the only surface that reported it — exists
+                // only when `prometheus_addr` is configured. Exit 1 (the same
+                // code as an unexpected gRPC server exit) so supervisors with
+                // Restart=on-failure retry, which also clears a transient bind
+                // failure without an operator. On the down daemon `rbgp doctor`
+                // names the cause (port in use, missing CAP_NET_BIND_SERVICE).
                 error!(
                     %listen_addr,
                     error = %e,
-                    "failed to start BGP listener with TCP-AO-protected peers configured; refusing to run partially protected"
+                    "failed to bind BGP listener; inbound BGP sessions cannot be accepted — exiting"
                 );
                 process::exit(1);
             }
-            // The daemon can still open outbound sessions, but it is
-            // unreachable for inbound peers — surface that on /readyz
-            // instead of running silently unreachable.
-            error!(
-                %listen_addr,
-                error = %e,
-                "failed to bind BGP listener; inbound BGP sessions cannot be accepted — \
-                 readiness reports not-ready until the daemon is restarted"
-            );
-            daemon_gate.mark_not_ready("BGP listener failed to bind");
+        };
+    let tcp_ao_listener_handle = Some(listener.tcp_ao_rotation_handle());
+    let listener_peer_mgr_tx = peer_mgr_tx.clone();
+    let listener_gate = daemon_gate.clone();
+    tokio::spawn(async move {
+        while let Some(conn) = accept_rx.recv().await {
+            // Coordinated shutdown has begun: drop (close) the socket
+            // instead of admitting a session into teardown.
+            if listener_gate.is_shutting_down() {
+                info!(
+                    peer = %conn.peer_addr,
+                    "rejecting inbound BGP connection: daemon is shutting down"
+                );
+                continue;
+            }
+            if let Err(e) = listener_peer_mgr_tx
+                .send(PeerManagerCommand::AcceptInbound {
+                    stream: conn.stream,
+                    peer_addr: conn.peer_addr,
+                    tcp_ao_info: conn.tcp_ao_info,
+                    tcp_ao_generation: conn.tcp_ao_generation,
+                })
+                .await
+            {
+                warn!(error = %e, "failed to forward inbound connection to peer manager");
+            }
         }
-    }
+    });
+    tokio::spawn(listener.run());
 
     // ADR-0113: install the configured outbound prefix maxima before the
     // first session can register, so a limited peer admits its initial feed

--- a/tests/grpc_failure_exit_code.rs
+++ b/tests/grpc_failure_exit_code.rs
@@ -1,11 +1,11 @@
 //! Exit-code contract for daemon shutdown causes.
 //!
-//! Operator-initiated shutdown (SIGTERM) exits 0; shutdown caused by the
-//! gRPC server exiting unexpectedly (here: the TCP listener losing its
-//! bind because the port is already taken) runs the same coordinated
-//! teardown but exits non-zero, so supervisors like systemd with
-//! `Restart=on-failure` restart the daemon instead of treating the
-//! component failure as a clean stop.
+//! Operator-initiated shutdown (SIGTERM) exits 0; a component failure
+//! exits non-zero, so supervisors like systemd with `Restart=on-failure`
+//! restart the daemon instead of treating it as a clean stop. Two
+//! component failures are covered, both provoked by holding the port the
+//! daemon needs: the gRPC server exiting unexpectedly, and the BGP
+//! listener failing to bind.
 
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
@@ -135,6 +135,31 @@ fn grpc_bind_failure_exits_nonzero() {
         Some(1),
         "gRPC server failure must exit 1, got {status}\n{}",
         daemon.logs()
+    );
+}
+
+#[test]
+fn bgp_listener_bind_failure_exits_nonzero() {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    // Hold the BGP listen port with a live listener. SO_REUSEADDR lets a
+    // new generation rebind over a closed-but-lingering endpoint, never
+    // over an active LISTEN, so this bind genuinely fails — and a daemon
+    // that cannot accept inbound sessions must exit rather than run deaf.
+    let occupied = TcpListener::bind("0.0.0.0:0").expect("bind occupied port");
+    let bgp_port = occupied.local_addr().unwrap().port();
+    let config_path = write_config(temp.path(), free_port(), bgp_port);
+
+    let mut daemon = spawn_daemon(temp.path(), &config_path);
+    let status = daemon.wait_within(Duration::from_secs(120));
+    let logs = daemon.logs();
+    assert!(
+        logs.contains("failed to bind BGP listener"),
+        "the daemon must exit for the BGP listener, not some other cause\n{logs}"
+    );
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "BGP listener bind failure must exit 1, got {status}\n{logs}"
     );
 }
 


### PR DESCRIPTION
## Part 1 — `SO_REUSEADDR` on the BGP listener

`bind_socket2_listener_with` builds its socket through `socket2`, which does
not apply the `SO_REUSEADDR` that `std`/`mio` set for us on every other
listener. The daemon is normally the active closer at shutdown, so on an
ordinary restart under traffic a connection the previous generation accepted
still holds the listen port in `FIN_WAIT`/`TIME_WAIT`, and the next
generation's bind is rejected with `EADDRINUSE`. This is the plain
restart-with-sessions-up case, not an edge case.

The option is set before `bind`, ahead of the TCP-AO listener MKT
installation, so the pinned `bind` → install keys → `listen` ordering is
unchanged (`bind_socket2_listener_installs_tcp_ao_keys_before_listen` still
passes).

`SO_REUSEPORT` is deliberately **not** used. It permits concurrent binds,
which here would let two daemon generations serve the listen port at the same
time and split inbound sessions between them.

Linux requires `SO_REUSEADDR` on both endpoints of the conflict, and an
accepted socket inherits it from its listener. The first restart of a daemon
whose previous generation predates this fix can therefore still be rejected;
every restart after that is clean.

### Bind paths checked

| Path | Disposition |
|---|---|
| `crates/transport/src/listener.rs` `bind_socket2_listener_with` (BGP listener) | **Fixed** — raw `socket2` socket, the only production listener missing the option |
| `crates/api/src/server.rs:1239` gRPC TCP listener | No change — `tokio::net::TcpListener::bind` goes through `mio`, which sets `SO_REUSEADDR` on Unix |
| `src/metrics_server.rs:23` Prometheus / `/livez` / `/readyz` listener | No change — same `tokio`/`mio` path |
| `crates/api/src/server.rs:1681` gRPC UDS listener | No change — `SO_REUSEADDR` is meaningless for `AF_UNIX`; stale-socket removal is handled separately |
| `src/bfd_runtime.rs:1107` BFD UDP socket | No change — already sets `set_reuse_address(true)` before bind |
| `crates/transport/src/socket_opts.rs` binds | No change — test-only, and outbound source binds on port 0, where the option has no effect |
| `crates/evpn-linux/tests/netns_bgp_unnumbered.rs:242` | No change — test helper inside a netns, not a production listener |

No other production code calls `listen(2)`.

## Part 2 — a bind failure now exits 1

Previously the daemon logged, called `mark_not_ready("BGP listener failed to
bind")`, and kept running: gRPC up, config held, peers listed, every inbound
BGP connection refused.

That stay-alive behaviour was deliberate — the code comment, a CHANGELOG entry,
and two `health_probe.rs` tests all pin it, and it was itself an improvement
over an earlier version that ran unreachable behind a lone warning. It is
changed anyway, for four reasons:

1. **The implied recovery does not exist.** `listen_port` is mandatory, the
   listener is never rebound on SIGHUP, and `DaemonGate`'s not-ready reason is
   a `OnceLock` that never clears. The daemon's own error message said
   "until the daemon is restarted" — so it parked itself in a state whose only
   exit was the restart it had just declined to trigger.
2. **The mitigation is optional.** `/readyz` only exists when
   `[global.telemetry] prometheus_addr` is configured. With it unset — the
   default — a deaf daemon had no red surface at all and looked perfectly
   healthy to systemd.
3. **It was inconsistent with both neighbours.** The TCP-AO arm four lines up
   already exited 1, and #1121 exits 1 when the gRPC server dies. Treating a
   failure of the management interface more severely than a failure of the core
   function inverts the priority.
4. **The gRPC asymmetry does not rescue it.** gRPC must exit because a dead
   gRPC server can no longer report anything. That argument would justify
   staying alive here only if the reporting channel were guaranteed and the
   state recoverable; neither holds.

Outbound sessions surviving is not enough to keep the process: a speaker that
cannot accept inbound is broken for every passive peer, every
`[[dynamic_neighbors]]` range, and every peer that wins the connect race.

Exit 1 matches #1121 and the existing runtime-failure convention (2 =
config/usage, 70 = internal). With the shipped unit's `Restart=on-failure` +
`RestartSec=5`, a transient bind failure clears on a later attempt with no
operator involved, and a permanent one (port held by another speaker, missing
`CAP_NET_BIND_SERVICE`) repeats the bind error in the journal every five
seconds — the recurring loud signal the stay-alive path never had.

### What an operator sees

- The daemon is down and the journal names the bind error and the address.
- `rbgp doctor` already covers the down-daemon case: its `bgp.listener` check
  test-binds the port and reports port-in-use or the missing
  `CAP_NET_BIND_SERVICE` with advice. No change needed there.
- `docs/deployment.md` (systemd section) and the `rustbgpd(8)` / `--help`
  exit-status ladder now state the contract: 0 for an operator-initiated
  shutdown, 1 for a component failure that ends the daemon.

`DaemonGate::mark_not_ready` stays — `begin_shutdown` still uses it. The two
`health_probe.rs` tests that used the listener string as sample data now use a
generic reason instead of naming a code path that no longer exists.

## Tests

`bind_socket2_listener_rebinds_over_a_lingering_accepted_connection` binds a
listener, accepts a connection, closes the accepted socket first
(daemon-as-active-closer), then the peer and the listener, and rebinds the same
address. Red against pre-fix code:

```
thread 'listener::tests::bind_socket2_listener_rebinds_over_a_lingering_accepted_connection'
panicked at crates/transport/src/listener.rs:3658:14:
second generation rebinds over the lingering connection:
Os { code: 98, kind: AddrInUse, message: "Address already in use" }

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 450 filtered out
```

`bgp_listener_bind_failure_exits_nonzero` joins the existing exit-code contract
suite: holding the listen port with a live listener (which `SO_REUSEADDR` never
overrides) makes the daemon log the listener bind failure and exit 1.

## Gates

```
cargo fmt --all -- --check                            = 0
cargo clippy --workspace --all-targets -- -D warnings = 0
cargo test --workspace --no-fail-fast                 = 0
cargo doc --workspace --no-deps                       = 0
```
