### PR TITLE
Report config-validation warnings through the --check warning set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and `--strict` without `--check` is rejected with exit 2 rather than silently
   accepted — that invocation would otherwise start a daemon. `--strict` is
   defined over the whole `--check` warning set, not one warning, so anything
-  `--check` reports in future fails a strict run. Startup-time `tracing`
-  warnings are not part of that set and are unchanged. `--help` and
-  `rustbgpd(8)` now document the exit-status ladder.
+  `--check` reports in future fails a strict run. `--help` and `rustbgpd(8)`
+  now document the exit-status ladder.
 
 - **Per-peer outbound unicast prefix limits (ADR-0113).** New
   `max_prefixes_out_ipv4` / `max_prefixes_out_ipv6` on `[[neighbors]]` and peer
@@ -244,6 +243,34 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   peer-group edits inherited by dynamic peers follow the same rules.
 
 ### Fixed
+
+- **`--check` reports the warnings raised during config validation, which were
+  previously discarded.** `Config::validate` emitted its non-fatal diagnostics
+  through `tracing`, but `Config::load` runs before `init_logging` on every
+  path — `--check` returns long before it, and daemon startup only reaches it
+  later. No subscriber was installed, so those records were written nowhere:
+  the RFC 9107 warning for an `orr_vantage` with no neighbor negotiating
+  `linkstate` — a topology feed that can never fill, leaving every vantage
+  permanently unresolved — was invisible on every path except a SIGHUP reload.
+  It also silently capped `--strict`, because a warning that never surfaces
+  cannot fail a gate however severe it is. Validation diagnostics are now
+  returned rather than logged, so they join the one counted `--check` warning
+  set: framed on stderr, summed into the reported total, failing `--check
+  --strict`, and logged once at daemon startup where a subscriber exists.
+
+- **`security.grpc.enforcement = "legacy"` is reported by `--check`.** It fired
+  only at daemon startup, so a config gate could pass a configuration whose
+  management surface enforces no per-method tier authorization: every
+  authenticated client of a `read_write` listener may call every method up to
+  the listener's `max_tier` cap, including the `operator_only` methods that
+  reconfigure the daemon, and `[security.grpc.roles]` entries deny nothing.
+  Tier enforcement has been the default since v0.24.0 and becomes mandatory,
+  so the warning now states the migration — give every listener a role
+  identity, map each principal to a role, then set `enforcement = "tier"` —
+  rather than only reporting the setting. Plain `--check` still exits 0;
+  `--check --strict` exits 1. The `ebgp_requires_policy` partial-enforcement
+  notice deliberately stays a startup-only record: it reports what this release
+  has not finished building, not a defect in the operator's config.
 
 - **The BGP listener sets `SO_REUSEADDR`, so an ordinary restart under traffic
   no longer fails `EADDRINUSE`.** The listener socket is built through

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -767,24 +767,6 @@ impl Config {
             .collect()
     }
 
-    /// Emit the startup warning for the pre-ADR-0064 legacy gRPC
-    /// authorization mode, if active. Tier enforcement becomes
-    /// mandatory in a future release.
-    pub fn warn_if_legacy_grpc_enforcement(&self) {
-        if matches!(
-            self.security.grpc.enforcement,
-            schema::GrpcEnforcementConfig::Legacy
-        ) {
-            tracing::warn!(
-                "security.grpc.enforcement = \"legacy\" is active: per-method tier \
-                 authorization is NOT enforced on read_write listeners. Tier \
-                 enforcement becomes mandatory in a future release — migrate to \
-                 enforcement = \"tier\" with [security.grpc.roles]; see \
-                 docs/adr/0064-grpc-authorization.md."
-            );
-        }
-    }
-
     /// Resolve the global import policy chain (named policies referenced
     /// by `[policy] import_chain`). `None` when no chain is configured.
     pub fn import_chain(&self) -> Result<Option<PolicyChain>, ConfigError> {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1804,14 +1804,31 @@ fn explicit_legacy_grpc_enforcement_loads_roles_and_warns() {
         config.security.grpc.roles["operator.example"],
         GrpcRoleConfig::Operator
     );
-    let output = capture_warnings(|| config.warn_if_legacy_grpc_enforcement());
+    let advisory = config
+        .advisories()
+        .into_iter()
+        .find(|a| a.headline.contains("security.grpc.enforcement"))
+        .expect("legacy enforcement must raise an advisory");
+    let text = advisory.one_line();
     assert!(
-        output.contains("WARN") && output.contains("legacy"),
-        "expected a warn-level legacy-enforcement log: {output}"
+        text.contains("mandatory in a future release"),
+        "advisory must name the sunset: {text}"
+    );
+    // Condition, consequence, action — an advisory that only restates the
+    // setting leaves the operator with nothing to do about it.
+    assert!(
+        text.contains("max_tier cap"),
+        "advisory must name the consequence: {text}"
     );
     assert!(
-        output.contains("mandatory in a future release"),
-        "warning must name the sunset: {output}"
+        text.contains("enforcement = \"tier\"")
+            && text.contains("[security.grpc.roles]")
+            && text.contains("principal"),
+        "advisory must give the migration action: {text}"
+    );
+    assert!(
+        text.contains("docs/adr/0064-grpc-authorization.md"),
+        "advisory must cite the migration reference: {text}"
     );
 }
 
@@ -3899,6 +3916,44 @@ fn orr_vantage_warns_without_linkstate_family() {
     // No vantage anywhere → no warning regardless of families.
     let config = parse(&orr_toml("", "")).unwrap();
     assert!(!config.orr_vantage_without_linkstate());
+}
+
+#[test]
+fn orr_vantage_without_linkstate_raises_an_advisory() {
+    let toml = orr_toml(
+        "orr_vantage = \"192.0.2.7\"\nroute_reflector_client = true",
+        "",
+    );
+    let config = parse(&toml).unwrap();
+    let advisory = config
+        .advisories()
+        .into_iter()
+        .find(|a| a.headline.contains("orr_vantage"))
+        .expect("an unresolvable vantage must raise an advisory");
+    let text = advisory.one_line();
+    // Condition, consequence, action.
+    assert!(
+        text.contains("linkstate"),
+        "advisory must name the missing family: {text}"
+    );
+    assert!(
+        text.contains("stays unresolved") && text.contains("no effect"),
+        "advisory must name the consequence: {text}"
+    );
+    assert!(
+        text.contains("Add \"linkstate\" to the families"),
+        "advisory must give the action: {text}"
+    );
+    // One line, so a log record stays one record.
+    assert!(!text.contains('\n'), "one_line kept a newline: {text}");
+
+    // Cleared once a neighbor carries the feed.
+    let toml = orr_toml(
+        "orr_vantage = \"192.0.2.7\"\nroute_reflector_client = true\nfamilies = [\"ipv4_unicast\", \"linkstate\"]",
+        "",
+    );
+    let config = parse(&toml).unwrap();
+    assert!(config.advisories().is_empty(), "{:?}", config.advisories());
 }
 
 #[test]
@@ -15629,38 +15684,6 @@ fn send_hold_time_change_is_a_runtime_neighbor_change() {
 
 // ── Retired config keys (LAN-194 removal wave) ──────
 
-/// `MakeWriter` capturing tracing output into a shared buffer so the
-/// deprecation-warning tests can assert on emitted (or absent) warns.
-#[derive(Clone, Default)]
-struct CaptureWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
-
-impl std::io::Write for CaptureWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.lock().unwrap().extend_from_slice(buf);
-        Ok(buf.len())
-    }
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
-impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
-    type Writer = CaptureWriter;
-    fn make_writer(&'a self) -> Self::Writer {
-        self.clone()
-    }
-}
-
-fn capture_warnings(f: impl FnOnce()) -> String {
-    let writer = CaptureWriter::default();
-    let subscriber = tracing_subscriber::fmt()
-        .with_writer(writer.clone())
-        .finish();
-    tracing::subscriber::with_default(subscriber, f);
-    let bytes = writer.0.lock().unwrap().clone();
-    String::from_utf8(bytes).unwrap()
-}
-
 #[test]
 fn retired_global_inline_policy_fails_load_with_migration_error() {
     let toml_str = format!(
@@ -15730,8 +15753,11 @@ fn tier_grpc_enforcement_does_not_warn() {
         valid_toml_no_grpc_security()
     );
     let config = parse_strict(&toml_str).unwrap();
-    let output = capture_warnings(|| config.warn_if_legacy_grpc_enforcement());
-    assert!(output.is_empty(), "no warning expected: {output}");
+    assert!(
+        config.advisories().is_empty(),
+        "no advisory expected: {:?}",
+        config.advisories()
+    );
 }
 
 fn assert_raw_default_tier_rejected(error: &str) {
@@ -15789,15 +15815,24 @@ fn config_loader_has_no_test_only_legacy_bypass() {
         !source.contains("test_only_inject_legacy_grpc_security"),
         "production loader source must not contain a test-only auth seam"
     );
+    // The loader itself never branches on Legacy: the only production code
+    // that selects it is the operator-facing advisory in `validation.rs`.
     assert_eq!(
         source.matches("GrpcEnforcementConfig::Legacy").count(),
-        1,
-        "only the startup-warning compatibility branch may select Legacy"
+        0,
+        "the config loader must not select Legacy"
     );
     assert_eq!(
         source.matches(r#"enforcement = \"legacy\""#).count(),
+        0,
+        "the config loader must not name a Legacy setting"
+    );
+    assert_eq!(
+        include_str!("validation.rs")
+            .matches("GrpcEnforcementConfig::Legacy")
+            .count(),
         1,
-        "only the operator-facing compatibility warning may name a Legacy setting"
+        "only the compatibility advisory may select Legacy"
     );
 }
 

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -64,6 +64,40 @@ pub(crate) fn effective_prefix_str(prefix: &str) -> Option<(IpAddr, u8)> {
     Some(effective_prefix(addr, len))
 }
 
+/// A legal configuration with a consequence its operator should see.
+///
+/// Not an error — `Config::load` accepts the config — but reported by
+/// `rustbgpd --check`, counted for `--check --strict`, and logged once at
+/// daemon startup. Each one states the condition (`headline`) and then the
+/// consequence and the action that clears it (`detail`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ConfigAdvisory {
+    /// The condition, as a single sentence.
+    pub(crate) headline: &'static str,
+    /// Consequence, then the action. Hard-wrapped for the framed `--check`
+    /// block; use [`ConfigAdvisory::one_line`] for a log record.
+    pub(crate) detail: &'static str,
+}
+
+impl ConfigAdvisory {
+    /// Headline and detail collapsed onto one line, for `tracing`, where a
+    /// record spanning several lines is a parsing hazard.
+    pub(crate) fn one_line(&self) -> String {
+        let mut out = String::with_capacity(self.headline.len() + self.detail.len() + 1);
+        for word in self
+            .headline
+            .split_whitespace()
+            .chain(self.detail.split_whitespace())
+        {
+            if !out.is_empty() {
+                out.push(' ');
+            }
+            out.push_str(word);
+        }
+        out
+    }
+}
+
 impl Config {
     #[expect(clippy::too_many_lines)]
     pub(crate) fn validate(&self) -> Result<(), ConfigError> {
@@ -1155,18 +1189,6 @@ impl Config {
         validate_fib_tables(self)?;
         validate_bfd(self)?;
 
-        // RFC 9107 ORR: a vantage without a BGP-LS feed can never
-        // resolve — the topology would be permanently empty. Legal
-        // (linkstate peers may be added later), but worth a warning.
-        if self.orr_vantage_without_linkstate() {
-            tracing::warn!(
-                "orr_vantage is configured but no neighbor negotiates the \
-                 \"linkstate\" family — the ORR topology feed will be empty \
-                 and every vantage will stay unresolved (standard best-path \
-                 fallback applies)"
-            );
-        }
-
         Ok(())
     }
 
@@ -1198,6 +1220,68 @@ impl Config {
             };
             effective.iter().any(|f| f == "linkstate")
         })
+    }
+
+    /// Every advisory this configuration raises, in a stable order.
+    ///
+    /// Returning them — rather than logging them where they are detected —
+    /// is what makes them reach an operator at all. `validate()` runs
+    /// inside `Config::load`, which both `--check` and daemon startup call
+    /// *before* `init_logging`: a `tracing::warn!` there has no subscriber
+    /// installed and is discarded, so a validation-time diagnostic was
+    /// invisible on every path except a SIGHUP reload. A returned list is
+    /// countable (the `--check --strict` exit code is that count),
+    /// printable wherever the caller does have an output channel, and
+    /// testable without standing up a subscriber.
+    pub(crate) fn advisories(&self) -> Vec<ConfigAdvisory> {
+        let mut advisories = Vec::new();
+
+        // RFC 9107 ORR: a vantage without a BGP-LS feed can never resolve.
+        // Legal — linkstate peers may be added later — so it warns rather
+        // than rejects.
+        if self.orr_vantage_without_linkstate() {
+            advisories.push(ConfigAdvisory {
+                headline: "orr_vantage is configured but no neighbor negotiates the \
+                           \"linkstate\" family.",
+                detail: "The optimal-route-reflection SPF runs on the BGP-LS topology feed, and\n\
+                         nothing feeds it: the topology stays permanently empty, every vantage\n\
+                         stays unresolved, and best-path selection falls back to the standard\n\
+                         IGP-metric comparison for every client — the orr_vantage settings in\n\
+                         this config have no effect. Add \"linkstate\" to the families of the\n\
+                         neighbor carrying the BGP-LS feed, or remove orr_vantage from the\n\
+                         neighbors and peer groups that set it. See\n\
+                         docs/adr/0095-optimal-route-reflection.md.",
+            });
+        }
+
+        // Pre-ADR-0064 gRPC authorization. Tier enforcement has been the
+        // default since v0.24.0 and becomes mandatory, so an operator still
+        // pinned to `legacy` is carrying both an open management surface and
+        // a config that a future release will reject.
+        if matches!(
+            self.security.grpc.enforcement,
+            GrpcEnforcementConfig::Legacy
+        ) {
+            advisories.push(ConfigAdvisory {
+                headline: "security.grpc.enforcement = \"legacy\" disables per-method tier \
+                           authorization.",
+                detail: "Every authenticated client of a read_write listener may call every\n\
+                         method up to that listener's max_tier cap, including the\n\
+                         operator_only methods that reconfigure the daemon; the\n\
+                         [security.grpc.roles] entries are recorded as audit context and deny\n\
+                         nothing. Tier enforcement is the default since v0.24.0 and becomes\n\
+                         mandatory in a future release, which will reject this config.\n\
+                         \n\
+                         To migrate: give every listener a role identity — mTLS listeners\n\
+                         derive it from the client certificate, bearer-token TCP and UDS\n\
+                         listeners need an explicit `principal` — map each principal in\n\
+                         [security.grpc.roles] to observer, automation, or operator, then set\n\
+                         security.grpc.enforcement = \"tier\". See\n\
+                         docs/adr/0064-grpc-authorization.md and docs/SECURITY.md.",
+            });
+        }
+
+        advisories
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1844,14 +1844,42 @@ fn tcp_ao_listener_key_for_dynamic_range(
 /// `--strict` the moment it is summed here — there is no per-warning strict
 /// handling to keep in sync.
 ///
-/// Startup warnings are deliberately not part of this set. The
-/// `ebgp_requires_policy` partial-enforcement notice reports what this
-/// release has not finished building, not a defect in the operator's config,
-/// and the legacy-`security.grpc.enforcement` warning and the ORR
-/// vantage-without-linkstate warning are `tracing` records emitted after
-/// logging is initialized, which `--check` returns before reaching.
+/// Config-load diagnostics reach this through [`Config::advisories`] rather
+/// than through `tracing`. `Config::load` runs before `init_logging` on
+/// every path, so a warning logged during validation had no subscriber to
+/// write to and was silently dropped — which also capped `--strict`, since a
+/// warning nobody can see can never fail the gate.
+///
+/// The `ebgp_requires_policy` partial-enforcement notice stays out of this
+/// set on purpose: it reports what this release has not finished building,
+/// not a defect in the operator's config, so gating on it would make a
+/// correct deployment unshippable.
 fn check_warnings(config: &Config) -> usize {
-    warn_unpoliced_ebgp(config)
+    let mut warnings = warn_unpoliced_ebgp(config);
+    for advisory in config.advisories() {
+        print_framed_warning(advisory.headline, advisory.detail);
+        warnings += 1;
+    }
+    warnings
+}
+
+/// Print one `--check` warning as a framed stderr block.
+///
+/// Framed and on stderr so the exit-0 summary line on stdout cannot be the
+/// only thing an operator reads. `headline` states the condition; `body`
+/// carries the consequence and the action that clears it.
+fn print_framed_warning(headline: &str, body: &str) {
+    use owo_colors::{OwoColorize, Stream::Stderr};
+
+    let rule = "=".repeat(74);
+    eprintln!("\n{}", rule.if_supports_color(Stderr, OwoColorize::yellow));
+    eprintln!(
+        "{}: {headline}",
+        "WARNING".if_supports_color(Stderr, OwoColorize::yellow)
+    );
+    eprintln!();
+    eprintln!("{body}");
+    eprintln!("{}\n", rule.if_supports_color(Stderr, OwoColorize::yellow));
 }
 
 /// Print the `--check` warning for eBGP neighbors that resolve no explicit
@@ -1861,58 +1889,49 @@ fn check_warnings(config: &Config) -> usize {
 /// production, so a wide-open (or, under `ebgp_requires_policy`, a fully
 /// denied) eBGP edge has to be visible here. It stays a warning: a permit-all
 /// route server is a legitimate configuration and refusing it would break
-/// deployments that mean it. It goes to stderr, framed, so that the exit-0
-/// summary on stdout cannot be the only thing an operator reads.
+/// deployments that mean it.
 fn warn_unpoliced_ebgp(config: &Config) -> usize {
-    use owo_colors::{OwoColorize, Stream::Stderr};
+    use std::fmt::Write as _;
 
     let unpoliced = config.unpoliced_ebgp_neighbors();
     if unpoliced.is_empty() {
         return 0;
     }
-    let rule = "=".repeat(74);
-    eprintln!(
-        "\n{}",
-        rule.if_supports_color(Stderr, owo_colors::OwoColorize::yellow)
-    );
-    eprintln!(
-        "{}: {} eBGP neighbor{} resolve{} no explicit policy.",
-        "WARNING".if_supports_color(Stderr, owo_colors::OwoColorize::yellow),
+    let headline = format!(
+        "{} eBGP neighbor{} resolve{} no explicit policy.",
         unpoliced.len(),
         if unpoliced.len() == 1 { "" } else { "s" },
         if unpoliced.len() == 1 { "s" } else { "" },
     );
-    eprintln!();
+    let mut body = String::new();
     for neighbor in &unpoliced {
-        eprintln!(
+        let _ = writeln!(
+            body,
             "  {} (AS {}): {}",
             neighbor.address,
             neighbor.remote_asn,
             neighbor.missing_phrase()
         );
     }
-    eprintln!();
+    body.push('\n');
     if config.global.ebgp_requires_policy {
-        eprintln!(
+        body.push_str(
             "[global] ebgp_requires_policy = true, so every direction listed above runs the\n\
              RFC 8212 reserved deny: the session establishes and then carries no routes in\n\
              that direction, in any negotiated family. Configure an import_policy_chain /\n\
-             export_policy_chain there to start passing traffic."
+             export_policy_chain there to start passing traffic.",
         );
     } else {
-        eprintln!(
+        body.push_str(
             "Every direction listed above is unfiltered. An unfiltered import direction\n\
              accepts every route the peer sends; an unfiltered export direction re-advertises\n\
              every route selected for that peer, as received. If that is what you meant, this\n\
              is the expected result for a permit-all route server. If it is not, configure an\n\
              import_policy_chain / export_policy_chain there, or set\n\
-             [global] ebgp_requires_policy = true to fail closed until you do."
+             [global] ebgp_requires_policy = true to fail closed until you do.",
         );
     }
-    eprintln!(
-        "{}\n",
-        rule.if_supports_color(Stderr, owo_colors::OwoColorize::yellow)
-    );
+    print_framed_warning(&headline, &body);
     unpoliced.len()
 }
 
@@ -2937,7 +2956,12 @@ async fn run<T>(
         neighbors = config.neighbors.len(),
         "starting rustbgpd"
     );
-    config.warn_if_legacy_grpc_enforcement();
+    // The same set `--check` frames, logged here because this is the first
+    // point on the daemon path with a subscriber installed — `Config::load`
+    // runs before `init_logging`.
+    for advisory in config.advisories() {
+        tracing::warn!("{}", advisory.one_line());
+    }
 
     let metrics = BgpMetrics::new();
     let grpc_listeners = resolve_grpc_listeners(&config).unwrap_or_else(|e| {

--- a/tests/check_strict.rs
+++ b/tests/check_strict.rs
@@ -76,6 +76,90 @@ import_policy_chain = ["from-peer"]
 export_policy_chain = ["to-peer"]
 "#;
 
+/// A validation-origin warning: an iBGP route-reflector client with an ORR
+/// vantage and no neighbor feeding BGP-LS. The condition is detected inside
+/// `Config::validate`, which runs before logging is initialized — so before
+/// this was routed through the collected warning set, `--check` reported
+/// nothing and `--strict` had nothing to fail on. iBGP throughout, so the
+/// unpoliced-eBGP warning cannot contribute to the count.
+const ORR_WARNS: &str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+runtime_state_dir = "/tmp/rustbgpd-check-strict"
+
+[global.telemetry]
+log_format = "json"
+
+[global.telemetry.grpc_uds]
+enabled = true
+path = "/tmp/rustbgpd-check-strict/grpc.sock"
+mode = 0o600
+principal = "operator"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+operator = "operator"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65001
+route_reflector_client = true
+orr_vantage = "192.0.2.7"
+"#;
+
+/// The pre-ADR-0064 gRPC authorization mode. A genuine risk in the
+/// operator's own config, so `--check` reports it and `--strict` fails on
+/// it; iBGP and no ORR vantage, so it is the only warning.
+const LEGACY_GRPC_WARNS: &str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+runtime_state_dir = "/tmp/rustbgpd-check-strict"
+
+[global.telemetry]
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65001
+"#;
+
+/// Three distinct warning kinds at once: an unpoliced eBGP neighbor, an
+/// unresolvable ORR vantage, and legacy gRPC enforcement. The count is what
+/// `--strict` gates on, so a fix that surfaced each warning without summing
+/// them into one total would still report the wrong number here.
+const THREE_KINDS: &str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+runtime_state_dir = "/tmp/rustbgpd-check-strict"
+
+[global.telemetry]
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+
+[[neighbors]]
+address = "10.0.0.3"
+remote_asn = 65001
+route_reflector_client = true
+orr_vantage = "192.0.2.7"
+"#;
+
 /// Run the daemon binary with `args` plus a config file holding
 /// `config_toml`; returns `(exit_code, stdout, stderr)`.
 fn run(config_toml: &str, args: &[&str]) -> (Option<i32>, String, String) {
@@ -137,6 +221,104 @@ fn check_strict_exits_zero_on_a_clean_config() {
         stdout.contains("config OK"),
         "clean check did not print the OK summary:\n{stdout}"
     );
+}
+
+/// A warning raised inside `Config::validate` has to reach the operator.
+/// It is detected before `init_logging` runs, so logging it there wrote to
+/// no subscriber: `--check` printed a clean result for a config with a
+/// permanently inert ORR configuration in it.
+#[test]
+fn check_reports_a_validation_origin_warning() {
+    let (code, stdout, stderr) = run(ORR_WARNS, &["--check"]);
+    assert_eq!(code, Some(0), "stdout:\n{stdout}\nstderr:\n{stderr}");
+    assert!(
+        stdout.contains("config VALID, 1 WARNING — NOT a clean check"),
+        "summary line did not count the validation warning:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("orr_vantage") && stderr.contains("linkstate"),
+        "warning did not name the condition:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Add \"linkstate\" to the families"),
+        "warning did not give the action:\n{stderr}"
+    );
+}
+
+/// The point of routing validation diagnostics through the counted set: a
+/// warning that never surfaced could never fail the gate, whatever its
+/// severity.
+#[test]
+fn check_strict_fails_on_a_validation_origin_warning() {
+    let (code, stdout, stderr) = run(ORR_WARNS, &["--check", "--strict"]);
+    assert_eq!(code, Some(1), "stdout:\n{stdout}\nstderr:\n{stderr}");
+    assert!(
+        stdout.contains("config VALID, 1 WARNING — NOT a clean check"),
+        "summary line changed under --strict:\n{stdout}"
+    );
+}
+
+/// Legacy gRPC enforcement is a risk in the operator's own config, not an
+/// unfinished feature of the release, so `--check` reports it and it must
+/// state the migration action rather than only the state.
+#[test]
+fn check_reports_legacy_grpc_enforcement() {
+    let (code, stdout, stderr) = run(LEGACY_GRPC_WARNS, &["--check"]);
+    assert_eq!(code, Some(0), "stdout:\n{stdout}\nstderr:\n{stderr}");
+    assert!(
+        stdout.contains("config VALID, 1 WARNING — NOT a clean check"),
+        "summary line did not count the legacy-enforcement warning:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("security.grpc.enforcement = \"legacy\""),
+        "warning did not name the condition:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("max_tier cap"),
+        "warning did not name the consequence:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("To migrate:")
+            && stderr.contains("[security.grpc.roles]")
+            && stderr.contains("security.grpc.enforcement = \"tier\""),
+        "warning did not give the migration action:\n{stderr}"
+    );
+}
+
+#[test]
+fn check_strict_fails_on_legacy_grpc_enforcement() {
+    let (code, stdout, stderr) = run(LEGACY_GRPC_WARNS, &["--check", "--strict"]);
+    assert_eq!(code, Some(1), "stdout:\n{stdout}\nstderr:\n{stderr}");
+}
+
+/// The aggregate. `--strict` gates on the total, so every kind has to be
+/// summed into the one count — the case a per-warning fix gets wrong.
+#[test]
+fn check_counts_every_warning_kind_together() {
+    let (code, stdout, stderr) = run(THREE_KINDS, &["--check"]);
+    assert_eq!(code, Some(0), "stdout:\n{stdout}\nstderr:\n{stderr}");
+    assert!(
+        stdout.contains("config VALID, 3 WARNINGS — NOT a clean check"),
+        "the three warning kinds were not summed into one total:\n{stdout}"
+    );
+    for expected in [
+        "eBGP neighbor",
+        "orr_vantage",
+        "security.grpc.enforcement = \"legacy\"",
+    ] {
+        assert!(
+            stderr.contains(expected),
+            "{expected:?} missing from the framed warnings:\n{stderr}"
+        );
+    }
+    assert_eq!(
+        stderr.matches("WARNING:").count(),
+        3,
+        "each kind gets its own framed block:\n{stderr}"
+    );
+
+    let (code, _, _) = run(THREE_KINDS, &["--check", "--strict"]);
+    assert_eq!(code, Some(1), "strict must fail the same config");
 }
 
 /// Silently accepting `--strict` without `--check` would start the daemon


### PR DESCRIPTION
`rustbgpd --check --strict` is about to become the gate every shipped starter
config passes, and it was not a trustworthy one: the warnings raised inside
config validation never reached the operator, and could never fail the gate.

## Validation warnings were discarded

`Config::validate` emitted its non-fatal diagnostics through `tracing`, but
`Config::load` runs before `init_logging` on **every** path — `--check`
returns long before it, and daemon startup only reaches it later. No
subscriber was installed, so those records were written nowhere.

The one instance in the tree today is the RFC 9107 diagnostic for an
`orr_vantage` configured with no neighbor negotiating `linkstate`: the
optimal-route-reflection SPF runs on the BGP-LS topology feed and nothing
feeds it, so the topology stays permanently empty, every vantage stays
unresolved, and the `orr_vantage` settings have no effect. Legal, and exactly
what an operator wants told at check time. It was invisible on every path
except a SIGHUP reload.

The failure was systemic rather than specific to that one warning, and it
silently capped `--strict`: a warning that never surfaces cannot fail the gate
however severe it is.

Sweeping `validate()` and its transitive callees confirms it is the only
`tracing::warn!` reachable from validation today. The other four `warn!` sites
in `src/config/` are the two `warn_if_*` startup notices and two
dataset-refresh warnings that are reachable only through the SIGHUP reload
path, where prior dataset handles exist and a subscriber is installed.

## Fix shape

Validation diagnostics are **returned** — `Config::advisories() ->
Vec<ConfigAdvisory>` — rather than logged where they are detected. That puts
them in the one counted `--check` warning set `check_warnings()` already
sums: framed on stderr, added to the reported total, failing `--check
--strict`, and logged once at daemon startup, which is the first point on that
path with a subscriber installed.

Installing a subscriber ahead of the check path was the alternative. It would
have made the warnings visible but left them uncounted, so `--strict` still
would not gate on them, and the fix would depend on logging-setup order
staying correct forever. Returning them makes the set countable, testable
without standing up a subscriber, and independent of when logging comes up.

Each advisory states the condition, the consequence, and the action that
clears it, in the framed style established for the unpoliced-eBGP warning; the
frame that warning drew inline is now a shared helper so every warning in the
set renders identically.

## Legacy gRPC enforcement is now a check warning

`security.grpc.enforcement = "legacy"` fired only at daemon startup, so a
config gate could pass a configuration whose management surface enforces no
per-method tier authorization: every authenticated client of a `read_write`
listener may call every method up to the listener's `max_tier` cap, including
the `operator_only` methods that reconfigure the daemon, and
`[security.grpc.roles]` entries are recorded as audit context and deny
nothing.

Tier enforcement has been the default since v0.24.0 and becomes mandatory, so
the message now gives the migration — a role identity per listener (mTLS
derives it from the client certificate; bearer-token TCP and UDS listeners
need an explicit `principal`), a role per principal in
`[security.grpc.roles]`, then `enforcement = "tier"` — instead of only
reporting the setting. Plain `--check` still exits 0; `--check --strict` exits
1.

`warn_if_ebgp_requires_policy_partial` is deliberately **not** promoted. It
reports what this release has not finished building, not a defect in the
operator's config, so gating on it would make a correct deployment
unshippable. It remains a startup-only record.

## Tests

`tests/check_strict.rs` covers both new warnings under plain `--check`
(surfaced, exit 0) and `--check --strict` (exit 1), and pins the aggregate
count when three distinct kinds fire at once — an unpoliced eBGP neighbor, an
unresolvable ORR vantage, and legacy enforcement — since that is the case a
per-warning fix gets wrong. Against pre-fix code all five fail: `--check`
prints `config OK` for both single-warning configs and reports `1 WARNING` for
the three-kind config.
