### PR TITLE
Make every shipped starter config policy-complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,8 +149,34 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   check with warnings now summarizes as
   `config VALID, <n> WARNINGS — NOT a clean check: <path>` so the summary line
   alone cannot read as a clean result. A check with nothing to flag still
-  prints `config OK: <path>`. Both built-in `--init-config` profiles carry a
-  permit-all eBGP neighbor and are flagged accordingly.
+  prints `config OK: <path>`.
+
+- **Every shipped starter config is policy-complete and passes
+  `rustbgpd --check --strict`.** The warning above immediately found that our
+  own starters were the unpoliced shape it describes: eight of eleven failed a
+  strict check, including both `--init-config` profiles, `examples/minimal`,
+  the Docker Compose quick-start, and the IXP route server. A starter that
+  trips our own safety warning on a first run teaches the operator running it
+  that the warning is noise, so each one now resolves an explicit import and
+  export chain for every eBGP neighbor. Permit-all postures stay permit-all —
+  the `lab` profile, `examples/minimal`, the compose quick-start, the route
+  server's transparent export (RFC 7947), the collector's import, and the
+  mitigation injector's export are all unfiltered by design — but each is now
+  written as a named chain whose comment states that it was chosen and what it
+  is wrong for, rather than being permit-all by omission, which is
+  indistinguishable from having forgotten. The `edge` profile and
+  `examples/linux-edge-fib` gain a default-deny export chain to fill in; the
+  latter attaches both directions to its `transit` peer group, so a new
+  session inherits them. Each of these also sets
+  `[global] ebgp_requires_policy = true`, so deleting a shipped chain fails
+  closed instead of reverting to permit-all; it is startup-only, which each
+  config's comment says where an operator would look. The iBGP-only starters
+  (`hosting-provider`, `rr-evpn-fabric`, `evpn-vtep-leaf`) are unchanged —
+  RFC 8212 scopes the requirement to eBGP. A new workspace test enumerates the
+  profiles from the daemon's own profile list and the examples from the
+  `examples/` tree, then asserts a clean `--check --strict` for each, so a
+  starter added later is covered without editing the test. The release
+  checklist now requires that command instead of documenting the warnings.
 
 - **`rbgp config import` generates configs that fail closed.** The importer
   never translates policy, so every config it emitted came up permit-all on

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -438,7 +438,11 @@ WARNINGS — NOT a clean check` rather than `config OK`. The exit code is 0
 either way; add `--strict` (see [deployment.md](deployment.md)) to make any
 warning exit 1 in a CI or deployment gate. `rbgp config import` sets the knob
 in every config it generates,
-since it never translates policy; its report says so.
+since it never translates policy; its report says so. Every shipped starter —
+both `--init-config` profiles and every config under `examples/` — sets it too
+and passes `--check --strict`, so a first run is genuinely clean; where a
+starter is permit-all by design it says so in a named chain, because
+permit-all by omission is indistinguishable from an oversight.
 
 **Observing it.** Each direction is reported independently — `not_required`
 (enforcement off, or iBGP), `present`, `missing`, or `unknown`:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -50,8 +50,11 @@ $EDITOR config.toml
 ```
 
 Set at least the local ASN, router ID, and peer address. The `edge` profile is
-an eBGP edge skeleton with a default-route-dropping import chain. Each profile
-is validated through the real config loader before it is printed.
+an eBGP edge skeleton with a default-route-dropping import chain and a
+default-deny export chain to fill in. Each profile is validated through the
+real config loader before it is printed, and each passes
+`rustbgpd --check --strict` as emitted: `lab` is permit-all in both
+directions, but says so in an explicit chain rather than by omission.
 
 Prefer a checked-in starter file?
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -185,15 +185,30 @@ kill $DAEMON_PID
 
 ### Config-init smoke
 
+Every shipped starter — both `--init-config` profiles and every config
+under `examples/` — must pass `rustbgpd --check --strict`, exit 0, summary
+`config OK`. Shipping a starter that trips our own unpoliced-eBGP warning
+teaches the operator who runs it first that the warning is noise. Permit-all
+starters stay permit-all; they say so in an explicit chain instead of by
+omission.
+
 ```bash
-# Each built-in profile emits a starter config that loads cleanly.
+# Each built-in profile emits a starter config that passes the strict gate.
 for p in lab edge; do
   ./target/release/rustbgpd --init-config "$p" --stdout > "/tmp/init-$p.toml"
-  # Expect exit 0. Both profiles ship a permit-all eBGP neighbor, so both
-  # summarize as `config VALID, 1 WARNING — NOT a clean check` with the
-  # unpoliced-neighbor warning framed on stderr.
-  ./target/release/rustbgpd --check "/tmp/init-$p.toml"
+  ./target/release/rustbgpd --check --strict "/tmp/init-$p.toml"  # expect: config OK
 done
+
+# Every example config, checked in place so relative `rpol_files` resolve.
+for c in examples/*/config.toml; do
+  ./target/release/rustbgpd --check --strict "$c"                 # expect: config OK
+done
+
+# The compose starter (examples/docker-compose/rustbgpd.toml) names a token
+# path that only exists inside the container; repoint it to check it here.
+sed "s#/run/rustbgpd/grpc-test-only-operator.token#$PWD/tests/fixtures/grpc-test-only-operator.token#" \
+  examples/docker-compose/rustbgpd.toml > /tmp/compose-check.toml
+./target/release/rustbgpd --check --strict /tmp/compose-check.toml # expect: config OK
 
 # Guards must exit non-zero:
 ./target/release/rustbgpd --stdout                              # --stdout without --init-config

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -457,7 +457,7 @@ These cover the config lifecycle, from bootstrap to reload:
 
 | Command | What it does |
 |---|---|
-| `rustbgpd --init-config <lab\|edge> --stdout` | Print a curated, commented starter TOML to stdout and exit (file output is not yet supported). `lab` is a minimal single-box profile; `edge` is an eBGP edge skeleton with a default-route-dropping import chain. Both use a mode-`0600` local UDS whose filesystem permissions authenticate access and whose stable `operator` principal is tier-authorized. Cannot be combined with `--check` / `--diff`. |
+| `rustbgpd --init-config <lab\|edge> --stdout` | Print a curated, commented starter TOML to stdout and exit (file output is not yet supported). `lab` is a minimal single-box profile; `edge` is an eBGP edge skeleton with a default-route-dropping import chain and a default-deny export chain to fill in. Both use a mode-`0600` local UDS whose filesystem permissions authenticate access and whose stable `operator` principal is tier-authorized, set `[global] ebgp_requires_policy = true`, and pass `--check --strict` as emitted. Cannot be combined with `--check` / `--diff`. |
 | `rustbgpd --check <file>` | Parse + validate; print `config OK`, `config VALID, <n> WARNINGS — NOT a clean check` (warnings framed on stderr; still exit 0), or a rustc-style diagnostic (exit 1). Does not start the daemon. |
 | `rustbgpd --check --strict <file>` | The same check, but any warning exits 1 instead of 0 — for CI and deployment gates that must not accept a valid-but-risky config. A clean check still exits 0. `--strict` without `--check` is an error (exit 2). |
 | `rustbgpd --diff <file>` | Compute the diff against the running daemon's view; print per-section change list with expected reload class. |

--- a/examples/ddos-mitigation/config.toml
+++ b/examples/ddos-mitigation/config.toml
@@ -23,6 +23,13 @@ listen_port = 179
 # set install_blackhole_discard = true; broad prefixes remain rejected unless
 # allow_blackhole_broad_prefixes is also enabled.
 honor_blackhole = true
+# RFC 8212: an eBGP neighbor with no explicit policy carries nothing in
+# that direction. Deleting either chain below stops mitigation rules
+# reaching the edge routers — visibly — instead of silently reverting to
+# permit-all on a config whose whole job is controlled distribution.
+# Startup-only — SIGHUP keeps the running value, so changing it takes a
+# daemon restart.
+ebgp_requires_policy = true
 
 [global.telemetry]
 prometheus_addr = "127.0.0.1:9179"
@@ -95,8 +102,21 @@ le = 127
 match_community = ["BLACKHOLE"]
 action = "deny"
 
+# --- Export policy: permit-all, on purpose ---
+# This daemon exists to push FlowSpec rules and RTBH routes to the edge
+# routers below, so the export direction is deliberately unfiltered: what
+# the mitigation platform injects is what the edge enforces. The scoping
+# that keeps it inside the mitigation domain is on the routes themselves —
+# `honor_blackhole` above adds NO_ADVERTISE to accepted BLACKHOLE routes,
+# and the import chain rejects broad BLACKHOLE prefixes before they ever
+# reach this direction. Stated rather than omitted so the unfiltered
+# egress of a blackhole injector reads as a decision, not an oversight.
+[policy.definitions.distribute-mitigation]
+default_action = "permit"
+
 [policy]
 import_chain = ["blackhole-host-routes"]
+export_chain = ["distribute-mitigation"]
 
 # --- Edge routers ---
 # These enforce FlowSpec rules in hardware. Use short hold times so

--- a/examples/docker-compose/rustbgpd.toml
+++ b/examples/docker-compose/rustbgpd.toml
@@ -6,6 +6,14 @@
 asn = 65001
 router_id = "10.99.0.10"
 listen_port = 179
+# RFC 8212: an eBGP neighbor with no explicit policy carries nothing in
+# that direction. Deleting a chain below therefore leaves the FRR session
+# established and empty — a visible failure — rather than silently
+# permit-all. Startup-only: SIGHUP keeps the running value, so changing it
+# needs `docker compose restart rustbgpd`. Note this file is a template;
+# the running config is the copy in the state volume (see the compose
+# file), so edit it there or recreate the volume.
+ebgp_requires_policy = true
 
 [global.telemetry]
 prometheus_addr = "0.0.0.0:9179"
@@ -25,6 +33,24 @@ enforcement = "tier"
 
 [security.grpc.roles]
 "rustbgpd://operator/test-only" = "operator"
+
+# ==========================================================================
+# DELIBERATE QUICK-START POSTURE: PERMIT ALL, BOTH DIRECTIONS.
+# NOT FOR PRODUCTION.
+# ==========================================================================
+# The whole point of this lab is to watch FRR's sample prefixes arrive and
+# come back, so nothing is filtered in either direction. Written out rather
+# than left off: omitting the chains gives the same behavior by accident,
+# and this file is where someone copying a "working config" starts.
+[policy.definitions.lab-permit-all-import]
+default_action = "permit"
+
+[policy.definitions.lab-permit-all-export]
+default_action = "permit"
+
+[policy]
+import_chain = ["lab-permit-all-import"]
+export_chain = ["lab-permit-all-export"]
 
 [[neighbors]]
 address = "10.99.0.20"

--- a/examples/linux-edge-fib/config.toml
+++ b/examples/linux-edge-fib/config.toml
@@ -13,6 +13,13 @@ asn = 65010
 router_id = "192.0.2.10"
 listen_port = 179
 runtime_state_dir = "/var/lib/rustbgpd"
+# RFC 8212: an eBGP neighbor with no explicit policy carries nothing in
+# that direction. On a box that programs the kernel FIB, deleting the
+# import chain must not quietly mean "install whatever arrives" and
+# deleting the export chain must not quietly mean "announce transit to
+# transit" — with this on, both fail closed. Startup-only — SIGHUP keeps
+# the running value, so changing it takes a daemon restart.
+ebgp_requires_policy = true
 
 [global.telemetry]
 prometheus_addr = "127.0.0.1:9179"
@@ -35,13 +42,45 @@ enforcement = "tier"
 [security.grpc.roles]
 operator = "operator"
 
+# --- Policy for transit peers ---
+#
+# Import: accept what transit sends minus the default route. A box that
+# installs best routes into the kernel has no business taking 0.0.0.0/0 or
+# ::/0 from a transit session by accident; add RPKI, AS_PATH, and bogon
+# rules here as your filtering matures.
+[policy.definitions.from-transit]
+default_action = "permit"
+
+[[policy.definitions.from-transit.statements]]
+action = "deny"
+prefix = "0.0.0.0/0"
+
+[[policy.definitions.from-transit.statements]]
+action = "deny"
+prefix = "::/0"
+
+# Export: deny by default, and empty on purpose. This is an edge box, not
+# a transit provider — re-advertising one transit's table to the other is
+# the classic leak, and an empty deny-all chain cannot do it. Add one
+# permit statement per prefix this AS originates:
+#
+#   [[policy.definitions.to-transit.statements]]
+#   action = "permit"
+#   prefix = "192.0.2.0/24"
+[policy.definitions.to-transit]
+default_action = "deny"
+
 # Shared transport / policy defaults for transit peers. The FIB table below
 # also uses this name as an allow-list, so only best routes learned from this
 # peer group are eligible for kernel install. Keep a peer import cap alongside
 # the FIB max_routes guardrail so route leaks are bounded before kernel export.
+# The chains attach here rather than per neighbor so a new transit session
+# inherits both directions by joining the group.
 [peer_groups.transit]
 hold_time = 90
 max_prefixes = 100000
+import_policy_chain = ["from-transit"]
+export_policy_chain = ["to-transit"]
 
 [[neighbors]]
 address = "198.51.100.1"

--- a/examples/minimal/config.toml
+++ b/examples/minimal/config.toml
@@ -3,6 +3,11 @@
 # This is the smallest working config for a single eBGP peer.
 # gRPC defaults to a Unix domain socket at <runtime_state_dir>/grpc.sock.
 #
+# "Minimal" includes policy. An eBGP session with no policy is not a
+# smaller config, it is an unfiltered one, and leaving it out here would
+# only teach the shape that `rustbgpd --check` exists to flag. The two
+# chains below are the minimum: explicit, permit-all, and labeled.
+#
 # For local development, runtime_state_dir points to /tmp/rustbgpd so no
 # root access is needed. For production, use /var/lib/rustbgpd with the
 # systemd unit (examples/systemd/) which creates and owns that directory.
@@ -12,6 +17,11 @@ asn = 65001
 router_id = "10.0.0.1"
 listen_port = 179
 runtime_state_dir = "/tmp/rustbgpd"
+# RFC 8212: an eBGP neighbor with no explicit policy carries nothing in
+# that direction, so deleting a chain below fails closed instead of
+# silently reverting to permit-all. Startup-only — SIGHUP keeps the
+# running value, so changing it takes a daemon restart.
+ebgp_requires_policy = true
 
 [global.telemetry]
 prometheus_addr = "127.0.0.1:9179"
@@ -30,6 +40,25 @@ enforcement = "tier"
 
 [security.grpc.roles]
 operator = "operator"
+
+# ==========================================================================
+# DELIBERATE DEVELOPMENT POSTURE: PERMIT ALL, BOTH DIRECTIONS.
+# NOT A PRODUCTION EDGE POLICY.
+# ==========================================================================
+# Accept every route the peer sends, re-advertise every route selected for
+# it, unchanged. Fine for a single peer on a dev box; wrong the moment this
+# config faces a network you do not own. Replace both chains with real
+# prefix / AS_PATH / community rules before then — see
+# `rustbgpd --init-config edge --stdout` for a filtered starting point.
+[policy.definitions.permit-all-import]
+default_action = "permit"
+
+[policy.definitions.permit-all-export]
+default_action = "permit"
+
+[policy]
+import_chain = ["permit-all-import"]
+export_chain = ["permit-all-export"]
 
 [[neighbors]]
 address = "10.0.0.2"

--- a/examples/route-collector/config.toml
+++ b/examples/route-collector/config.toml
@@ -13,6 +13,12 @@
 asn = 65534                      # Collector ASN (private, or use your own)
 router_id = "10.255.0.1"
 listen_port = 179
+# RFC 8212: an eBGP neighbor with no explicit policy carries nothing in
+# that direction. Both directions are spelled out below, so losing the
+# export chain leaves a silent collector rather than a collector that
+# re-advertises its upstreams to each other. Startup-only — SIGHUP keeps
+# the running value, so changing it takes a daemon restart.
+ebgp_requires_policy = true
 
 [global.telemetry]
 prometheus_addr = "0.0.0.0:9179"
@@ -61,10 +67,22 @@ sys_name = "rustbgpd-collector"
 [[bmp.collectors]]
 address = "10.0.0.100:5000"
 
+# --- Global import policy: accept everything, on purpose ---
+# A collector's job is to observe the table as its peers actually send it,
+# so filtering on import would corrupt the archive it exists to produce.
+# Permit-all is therefore the right import posture here — and it is stated
+# rather than left off, so nothing downstream has to guess whether an
+# unfiltered collector was intended. Add denies here only for data you
+# deliberately refuse to record.
+
+[policy.definitions.observe-all]
+default_action = "permit"
+
 # --- Global export policy: deny everything ---
 # A collector never advertises routes to peers.
 
 [policy]
+import_chain = ["observe-all"]
 export_chain = ["deny-all"]
 
 [policy.definitions.deny-all]

--- a/examples/route-server/config.toml
+++ b/examples/route-server/config.toml
@@ -24,6 +24,13 @@
 asn = 65500
 router_id = "198.51.100.1"
 listen_port = 179
+# RFC 8212: a member session with no explicit policy carries nothing in
+# that direction. The export chain below is deliberately permit-all, and
+# this knob is what keeps that a decision: delete the chain and members
+# stop receiving routes, loudly, instead of inheriting the same permit-all
+# by omission. Startup-only — SIGHUP keeps the running value, so changing
+# it takes a daemon restart.
+ebgp_requires_policy = true
 
 [global.telemetry]
 prometheus_addr = "127.0.0.1:9179"
@@ -84,6 +91,24 @@ match_rpki_validation = "not_found"
 action = "permit"
 set_local_pref = 100
 
+# --- Export policy: permit-all, on purpose ---
+#
+# An IX route server is transparent by design (RFC 7947): it hands each
+# member what that member's own filters selected, without imposing the
+# route server's opinion on top. So permit-all is the correct export
+# posture here — but it is *declared*, not inherited. A route server that
+# is permit-all because nobody wrote an export chain behaves identically
+# on the wire; only this chain, and this comment, record that it was a
+# choice rather than an omission.
+#
+# Per-member filtering (a member that wants a subset, or a bilateral
+# arrangement) belongs in that neighbor's `export_policy_chain`, which
+# overrides this globally applied one. member-beta's `per_client_best`
+# below is what makes such a per-member denial advertise the best
+# permitted candidate rather than hide the prefix.
+[policy.definitions.rs-transparent-export]
+default_action = "permit"
+
 [policy]
 # ixp-hygiene and reject-special-purpose live in hygiene.rpol; rpol and
 # TOML policies share one namespace and compose in one ordered chain.
@@ -95,6 +120,7 @@ import_chain = [
     "reject-long-prefixes",
     "prefer-rpki-valid",
 ]
+export_chain = ["rs-transparent-export"]
 
 # --- IXP member peers ---
 

--- a/src/config/profiles.rs
+++ b/src/config/profiles.rs
@@ -28,7 +28,9 @@ pub fn profile_toml(name: &str) -> Option<&'static str> {
 /// `lab` — a minimal single-box setup for experimenting locally: one
 /// eBGP neighbor, gRPC over a local Unix socket, runtime state under
 /// `/tmp`. Local gRPC access is authenticated by Unix-socket filesystem
-/// permissions and authorized through a stable operator principal.
+/// permissions and authorized through a stable operator principal. Its
+/// permit-all policy is written out and labeled rather than left to
+/// omission, so `--check --strict` is clean and the posture is a choice.
 const LAB: &str = r#"# rustbgpd "lab" profile — a minimal local setup for experimenting on
 # one machine. Edit the ASNs and addresses for your topology, then:
 #   rustbgpd config-lab.toml          # (after saving this output)
@@ -41,6 +43,12 @@ listen_port = 179
 # Runtime state (gRPC socket, GR markers, event DB) lives here. /tmp is
 # fine for a throwaway lab; use a persistent path in any real deployment.
 runtime_state_dir = "/tmp/rustbgpd"
+# RFC 8212: an eBGP neighbor with no explicit policy carries nothing in
+# that direction. The chains below are what make this session pass
+# traffic, so deleting one stops the session instead of quietly falling
+# back to permit-all. Startup-only — SIGHUP keeps the running value, so
+# changing it takes a daemon restart.
+ebgp_requires_policy = true
 
 [global.telemetry]
 prometheus_addr = "127.0.0.1:9179"
@@ -64,6 +72,30 @@ enforcement = "tier"
 [security.grpc.roles]
 operator = "operator"
 
+# ==========================================================================
+# DELIBERATE LAB POSTURE: PERMIT ALL, BOTH DIRECTIONS. NOT FOR PRODUCTION.
+# ==========================================================================
+# These two chains accept every route the peer sends and re-advertise every
+# route selected for it, unchanged. That is the point of a lab — see traffic,
+# filter nothing — and it is exactly what must not reach a production edge.
+# Replace both with real prefix / AS_PATH / community rules before this
+# config peers with anything you do not own.
+#
+# They are spelled out rather than omitted on purpose: omitting them is the
+# same permit-all, and nothing downstream can then tell an operator who meant
+# it from one who forgot. Written out, `rustbgpd --check --strict` is clean
+# and this comment is the record of the choice.
+[policy.definitions.lab-permit-all-import]
+default_action = "permit"
+
+[policy.definitions.lab-permit-all-export]
+default_action = "permit"
+
+# Apply the named chains globally (every neighbor without an override).
+[policy]
+import_chain = ["lab-permit-all-import"]
+export_chain = ["lab-permit-all-export"]
+
 # One eBGP neighbor to bring a session up against.
 [[neighbors]]
 address = "10.0.0.2"
@@ -73,18 +105,26 @@ hold_time = 90
 "#;
 
 /// `edge` — an eBGP edge skeleton: one upstream neighbor with a named
-/// import-policy chain that drops the default route. Fill in your ASN,
-/// neighbor, and prefix filters.
+/// import-policy chain that drops the default route and a default-deny
+/// export chain the operator fills in. Fill in your ASN, neighbor, and
+/// prefix filters.
 const EDGE: &str = r#"# rustbgpd "edge" profile — an eBGP edge skeleton: one upstream
-# transit/peer neighbor with a named import-policy chain. Replace the
-# ASN, neighbor address, and extend the filter with your own
-# prefix / AS_PATH / community rules.
+# transit/peer neighbor with a named import-policy chain and a
+# default-deny export chain to fill in. Replace the ASN, neighbor
+# address, and extend the filters with your own prefix / AS_PATH /
+# community rules.
 
 [global]
 asn = 65100
 router_id = "203.0.113.1"
 listen_port = 179
 runtime_state_dir = "/var/lib/rustbgpd"
+# RFC 8212: an eBGP neighbor with no explicit policy carries nothing in
+# that direction. Deleting either chain below therefore fails closed
+# rather than quietly reverting to permit-all — on an edge that is the
+# difference between an outage and a route leak. Startup-only — SIGHUP
+# keeps the running value, so changing it takes a daemon restart.
+ebgp_requires_policy = true
 
 [global.telemetry]
 prometheus_addr = "0.0.0.0:9179"
@@ -118,9 +158,24 @@ default_action = "permit"
 action = "deny"
 prefix = "0.0.0.0/0"
 
-# Apply the named chain globally (every neighbor without an override).
+# Named export policy: deny by default, and empty on purpose. Add one
+# permit statement per prefix this AS originates, for example:
+#
+#   [[policy.definitions.to-upstream.statements]]
+#   action = "permit"
+#   prefix = "203.0.113.0/24"
+#
+# Bare `prefix` is an exact match; add `ge`/`le` only where you mean to
+# announce more-specifics. Until a statement is added the upstream is
+# advertised nothing, which is the direction a skeleton should fail in —
+# an export chain filled in by guesswork is how a leak ships.
+[policy.definitions.to-upstream]
+default_action = "deny"
+
+# Apply the named chains globally (every neighbor without an override).
 [policy]
 import_chain = ["from-upstream"]
+export_chain = ["to-upstream"]
 
 [[neighbors]]
 address = "203.0.113.2"

--- a/tests/starter_configs_check_strict.rs
+++ b/tests/starter_configs_check_strict.rs
@@ -1,0 +1,170 @@
+//! Every shipped starter config passes `rustbgpd --check --strict`.
+//!
+//! `--check` warns about an eBGP neighbor that resolves no explicit policy,
+//! and `--strict` turns that warning into a failing exit code. A starter that
+//! trips our own safety warning teaches the operator who runs it first that
+//! the warning is noise, which is the one thing that makes the warning
+//! worthless. So the starters are held to the strict gate: a first run of a
+//! shipped config is clean, or this test is red.
+//!
+//! Both sides are enumerated rather than listed. Examples come from the
+//! `examples/` tree, profiles come from the daemon's own "available:" line,
+//! so a starter added later is covered without editing this file — a
+//! hand-maintained array here would go stale exactly when it mattered.
+
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// The repo's public test-only bearer token, substituted for a starter's
+/// `token_file` when that path only exists inside a container.
+const TOKEN_FIXTURE: &str = "tests/fixtures/grpc-test-only-operator.token";
+
+fn repo_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Run the daemon binary and return `(exit_code, stdout, stderr)`.
+fn run(args: &[&str]) -> (Option<i32>, String, String) {
+    let output = Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
+        .args(args)
+        // Warnings are framed for a terminal; keep assertions on text.
+        .env("NO_COLOR", "1")
+        .current_dir(repo_root())
+        .output()
+        .expect("run rustbgpd");
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// The `--init-config` profile names, read off the daemon's own rejection of
+/// an unknown profile (`available: lab, edge`). That message is generated
+/// from `PROFILE_NAMES`, so adding a profile adds it here too — and the
+/// binary is the only place an integration test can see that list, since the
+/// `config` module is a lib export only under `bench-internals`.
+fn profile_names() -> Vec<String> {
+    let (code, _, stderr) = run(&["--init-config", "no-such-profile", "--stdout"]);
+    assert_eq!(code, Some(2), "unknown profile must be rejected: {stderr}");
+    let listed = stderr
+        .split_once("available: ")
+        .unwrap_or_else(|| panic!("profile rejection no longer lists the profiles:\n{stderr}"))
+        .1;
+    listed
+        .trim()
+        .split(", ")
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Every TOML config under `examples/`. `Cargo.toml` is the only other kind
+/// of TOML that lives there (the two runnable adapter crates), so excluding
+/// it by name keeps this an enumeration rather than an allowlist.
+fn example_configs() -> Vec<PathBuf> {
+    let mut configs = Vec::new();
+    for entry in fs::read_dir(repo_root().join("examples")).expect("read examples/") {
+        let dir = entry.expect("examples/ entry").path();
+        if !dir.is_dir() {
+            continue;
+        }
+        for entry in fs::read_dir(&dir).expect("read example dir") {
+            let file = entry.expect("example dir entry").path();
+            if file.extension().is_some_and(|ext| ext == "toml")
+                && file.file_name().is_some_and(|name| name != "Cargo.toml")
+            {
+                configs.push(file);
+            }
+        }
+    }
+    configs.sort();
+    configs
+}
+
+/// Assert a clean strict check and say which starter failed if not.
+fn assert_clean(label: &str, code: Option<i32>, stdout: &str, stderr: &str) {
+    assert_eq!(
+        code,
+        Some(0),
+        "{label} does not pass `rustbgpd --check --strict`.\n\
+         A shipped starter must be policy-complete: give every eBGP neighbor \
+         an explicit import and export chain (permit-all is fine when the \
+         comment says it is deliberate).\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("config OK"),
+        "{label} exited 0 without a clean summary:\n{stdout}"
+    );
+}
+
+#[test]
+fn every_init_config_profile_passes_check_strict() {
+    let profiles = profile_names();
+    assert!(!profiles.is_empty(), "enumerated no profiles");
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    for profile in &profiles {
+        let (code, toml, stderr) = run(&["--init-config", profile, "--stdout"]);
+        assert_eq!(code, Some(0), "--init-config {profile} failed:\n{stderr}");
+        let path = dir.path().join(format!("{profile}.toml"));
+        fs::write(&path, toml).expect("write emitted profile");
+
+        let path = path.to_str().expect("utf-8 temp path");
+        let (code, stdout, stderr) = run(&["--check", "--strict", path]);
+        assert_clean(&format!("--init-config {profile}"), code, &stdout, &stderr);
+    }
+}
+
+/// A `[global.telemetry.grpc_tcp] token_file` this host cannot read, if the
+/// starter names one. The compose starter's token is bind-mounted at run
+/// time, so on a checkout it points at a path that does not exist —
+/// `--check` rejects the config before it ever reaches the policy warnings
+/// this test is about.
+fn unreadable_token_file(source: &str) -> Option<String> {
+    let value: toml::Value = toml::from_str(source).ok()?;
+    let token = value
+        .get("global")?
+        .get("telemetry")?
+        .get("grpc_tcp")?
+        .get("token_file")?
+        .as_str()?;
+    (!Path::new(token).exists()).then(|| token.to_owned())
+}
+
+#[test]
+fn every_example_config_passes_check_strict() {
+    let configs = example_configs();
+    assert!(!configs.is_empty(), "enumerated no example configs");
+
+    for config in &configs {
+        let source = fs::read_to_string(config).expect("read example config");
+        // Staged beside the original, never elsewhere: `[policy] rpol_files`
+        // and other resource paths resolve relative to the config's own
+        // directory. Held alive until the check has run.
+        let staged = unreadable_token_file(&source).map(|token| {
+            let mut file = tempfile::Builder::new()
+                .suffix(".config-check")
+                .tempfile_in(config.parent().expect("config has a parent directory"))
+                .expect("stage config beside its relative resources");
+            let host_token = repo_root().join(TOKEN_FIXTURE);
+            file.write_all(
+                source
+                    .replace(&token, &host_token.display().to_string())
+                    .as_bytes(),
+            )
+            .expect("write staged config");
+            file
+        });
+        let checked = staged
+            .as_ref()
+            .map_or(config.as_path(), tempfile::NamedTempFile::path);
+
+        let path = checked.to_str().expect("utf-8 example path");
+        let (code, stdout, stderr) = run(&["--check", "--strict", path]);
+        assert_clean(&config.display().to_string(), code, &stdout, &stderr);
+    }
+}


### PR DESCRIPTION
`rustbgpd --check` now warns when an eBGP neighbor resolves no explicit
policy, and `--check --strict` turns that warning into a failing exit code.
The first thing the new warning found was our own starters: eight of the
eleven shipped configs failed `rustbgpd --check --strict`.

```
--init-config lab                     1 warning   (no import, no export)
--init-config edge                    1 warning   (no export)
examples/minimal/config.toml          1 warning   (no import, no export)
examples/docker-compose/rustbgpd.toml 2 warnings  (no import, no export)
examples/route-server/config.toml     2 warnings  (no export)
examples/route-collector/config.toml  2 warnings  (no import)
examples/ddos-mitigation/config.toml  2 warnings  (no export)
examples/linux-edge-fib/config.toml   2 warnings  (no import, no export)
```

Shipping starters that trip our own safety warning teaches the operator
running one first that the warning is noise. The warning is only worth
anything if a clean first run is genuinely clean.

## What changed

Every eBGP neighbor in every starter now resolves an explicit chain in both
directions. Where the posture is permit-all it stays permit-all — the `lab`
profile, `examples/minimal`, the compose quick-start, the route server's
transparent export (RFC 7947), the collector's import, and the mitigation
injector's export are all unfiltered by design — but each is now a named
chain whose comment states that it was a choice and what it is wrong for.
Permit-all by omission behaves identically on the wire and is
indistinguishable from having forgotten, which is the distinction this
change exists to make.

- **`lab`** — permit-all both directions under a loud "NOT FOR PRODUCTION"
  banner.
- **`edge`** — keeps the default-route-dropping import chain, gains a
  `default_action = "deny"` export chain with a commented statement shape to
  fill in. Empty on purpose: an export chain filled in by guesswork is how a
  leak ships.
- **`examples/minimal`** — the minimum now includes policy. An eBGP session
  with no policy is not a smaller config, it is an unfiltered one.
- **`examples/docker-compose`** — permit-all both directions, labeled. Still
  a template copied into the writable state volume; unchanged there.
- **`examples/route-server`** — an explicit `rs-transparent-export`
  permit-all chain. The deliberate case: RFC 7947 transparency is the right
  export posture for an IX route server, and it is now declared rather than
  inherited.
- **`examples/route-collector`** — explicit permit-all import next to the
  existing `deny-all` export.
- **`examples/ddos-mitigation`** — explicit permit-all export next to the
  existing BLACKHOLE import guard.
- **`examples/linux-edge-fib`** — a default-route-dropping import chain and
  a default-deny export chain, attached to the `transit` peer group so a new
  session inherits both.

Each of these also sets `[global] ebgp_requires_policy = true`, so deleting
a shipped chain fails closed instead of reverting to permit-all. ADR-0112
enforcement is complete, so live presence transitions are safe. It is
startup-only; each config's comment says so where an operator reading that
chain would see it.

`examples/hosting-provider`, `examples/rr-evpn-fabric`, and
`examples/evpn-vtep-leaf` are untouched — all iBGP, all already clean, and
RFC 8212 scopes the requirement to eBGP.

## The test

`tests/starter_configs_check_strict.rs` enumerates both sides rather than
listing them, so a starter added later is covered without editing it:

- profiles from the daemon's own `--init-config` rejection line
  (`available: lab, edge`), which is generated from `PROFILE_NAMES`;
- examples from a directory walk of `examples/`, excluding `Cargo.toml`.

Each is run through the real binary with `--check --strict` and asserted to
exit 0 with a `config OK` summary. The compose starter names a bind-mounted
token path, so it is staged beside its original with that path repointed at
the repo's public test-only fixture; otherwise `--check` rejects it on the
filesystem before reaching any policy warning. Examples are checked in
their own directory so relative `rpol_files` resolve.

Red-proved: against the starters at the parent commit, both tests fail
(`test result: FAILED. 0 passed; 2 failed`).

## Release checklist

`docs/RELEASE_CHECKLIST.md` previously institutionalized the warnings — it
had been updated to expect `config VALID, 1 WARNING` from both profiles.
That is inverted: it now requires `rustbgpd --check --strict` over every
shipped starter, with the command spelled out for the profiles, the
`examples/*/config.toml` set, and the compose template.

## Verification

- `cargo fmt --all -- --check` → 0
- `cargo clippy --workspace --all-targets -- -D warnings` → 0
- `cargo test --workspace --no-fail-fast` → 0
- `cargo doc --workspace --no-deps` → 0
- `rustbgpd --check --strict` against all 11 starters → `config OK`, exit 0
- `docker compose up -d` in `examples/docker-compose` → session Established,
  7 prefixes received from FRR; torn down with `down -v` afterwards

## Related, not in this change

`tools/rs-config-render` emits per-neighbor `import_policy_chain` but no
export chain, so the configs it generates carry the same warning. What an
RS renderer should emit for export is a design question rather than a fix,
so it is left alone here.
