### PR TITLE
Render route-server configs that pass a strict check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -576,6 +576,24 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   startup-only; the emitted config carries the same explanation as a
   comment, and deleting the line restores permit-all.
 
+- **`rs-config-render` output passes `rustbgpd --check --strict`.** The
+  renderer is the IXP adoption path — an operator runs it in a cron refresh
+  loop and gates the result before every swap — and every config it
+  produced raised the unpoliced-eBGP warning once per member, because
+  members got an import chain and no export chain at all. The first thing
+  the new gate told an IXP was that the tool we hand them fails it.
+  Rendered configs now carry a declared transparent export chain
+  (permit-all, the RFC 7947 posture, stated rather than inherited) and
+  `[global] ebgp_requires_policy = true`, the same shape and wording as
+  `examples/route-server`, so deleting the chain later stops members
+  receiving routes loudly instead of silently reverting to permit-all. The
+  documented refresh loop, the renderer's own "gate with" hint, and the M90
+  differential gates all run the strict form now, and the workspace test
+  over the emitted config asserts both the strict exit code and the
+  `config OK` summary line — it previously ran a plain `--check` and passed
+  with three warnings, so it had been asserting that output was acceptable
+  while the strict gate correctly rejected it.
+
 - **RFC 6793 legacy-AS migration is lossless end to end.** Sessions
   without capability 65 now normalize received type 2/17 paths and
   type 7/18 aggregators before loop detection, policy, and RIB
@@ -981,6 +999,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `rustbgpd-<arch>.tar.gz` — v0.60.0 tarballs contain only `rustbgpd` and
   `rbgp`. The binary is now packed alongside them, and the tarball content
   assertion checks all three binaries for presence and non-emptiness.
+
+- **The documented install paths install `rs-config-render`.** Every
+  tarball snippet in the README, the quickstart, and `docs/deployment.md`
+  extracted an archive containing three binaries and then installed two of
+  them — `docs/deployment.md` contradicted its own contents listing four
+  lines earlier — so an operator who followed the documented install and
+  then the IXP cookbook hit `rs-config-render: command not found`. Every
+  tarball and from-source path names it now, and the cookbook says the
+  renderer is in the tarball rather than implying a checkout is required.
+  The published container image still omits it deliberately: the refresh
+  loop is a host-side cron job that runs `arouteserver` and the renderer
+  next to each other and hands the daemon a finished config directory, and
+  the deployment guide now says so instead of leaving the gap unexplained.
 
 ## [0.60.0] — 2026-07-18
 

--- a/README.md
+++ b/README.md
@@ -209,21 +209,24 @@ curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/rustbgpd-
 curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/checksums-${SUFFIX}.txt"
 sha256sum -c "checksums-${SUFFIX}.txt"
 tar -xzf "rustbgpd-${SUFFIX}.tar.gz"
-sudo install -m 0755 rustbgpd rbgp /usr/local/bin/
+sudo install -m 0755 rustbgpd rbgp rs-config-render /usr/local/bin/
 ```
 
-The tarball also carries man pages and bash/zsh/fish completions under
-`share/` — the [install walkthrough](docs/deployment.md#install) covers
-installing those and pinning a specific version.
+Three binaries: the daemon, the `rbgp` CLI, and `rs-config-render` (the
+[IXP route-server config renderer](tools/rs-config-render/README.md) —
+harmless if you don't run one). The tarball also carries man pages and
+bash/zsh/fish completions under `share/` — the
+[install walkthrough](docs/deployment.md#install) covers installing those
+and pinning a specific version.
 
 ### From source
 
 ```bash
 # Prerequisites: Rust 1.95+, protobuf-compiler
 sudo apt-get install -y protobuf-compiler   # Debian/Ubuntu
-cargo build --release -p rustbgpd -p rustbgpctl
+cargo build --release -p rustbgpd -p rustbgpctl -p rs-config-render
 
-# Binaries are at target/release/rustbgpd and target/release/rbgp
+# Binaries are at target/release/{rustbgpd,rbgp,rs-config-render}
 ```
 
 ### Docker

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -16,12 +16,16 @@ curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/rustbgpd-
 curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/checksums-${SUFFIX}.txt"
 sha256sum -c "checksums-${SUFFIX}.txt"
 tar -xzf "rustbgpd-${SUFFIX}.tar.gz"
-sudo install -m 0755 rustbgpd rbgp /usr/local/bin/
+sudo install -m 0755 rustbgpd rbgp rs-config-render /usr/local/bin/
 
 rustbgpd --version && rbgp --version
 ```
 
-The tarball also ships man pages and shell completions under `share/`;
+The third binary, `rs-config-render`, is the
+[IXP route-server config renderer](../tools/rs-config-render/README.md);
+nothing below uses it, but it is in the same archive, so install it here
+rather than hunting for it the day you stand up a route server. The
+tarball also ships man pages and shell completions under `share/`;
 [deployment.md](deployment.md#install) covers installing those and
 pinning a specific version instead of `latest`.
 
@@ -31,6 +35,7 @@ pinning a specific version instead of `latest`.
 # Debian/Ubuntu build dependency for tonic/prost codegen.
 sudo apt-get install -y protobuf-compiler
 
+# Add -p rs-config-render for the route-server renderer.
 cargo build --release -p rustbgpd -p rustbgpctl
 ```
 

--- a/docs/cookbook/ixp-filter-pipeline.md
+++ b/docs/cookbook/ixp-filter-pipeline.md
@@ -18,7 +18,7 @@ context.yml
         │  rs-config-render                  (fail-stale rendering)
         ▼
 config.toml + policy/*.rpol + render-receipt.json
-        │  rustbgpd --check                  (full config validation)
+        │  rustbgpd --check --strict         (full config validation)
         ▼
 swap + SIGHUP                                (parse-then-swap reload)
         │
@@ -92,9 +92,10 @@ bogons, transit-free, path-length cap, RPKI origin validation),
 `policy/client-<id>.rpol` (the client's IRR-derived prefix/origin
 sets), and `render-receipt.json` (fingerprint, cardinalities,
 warnings). `--rtr-cache` is required whenever the context enables
-RPKI origin validation — the context carries no cache address. Build
-the renderer from this repo with `cargo build --release -p
-rs-config-render`.
+RPKI origin validation — the context carries no cache address. The
+renderer ships in the release tarball alongside `rustbgpd` and `rbgp`
+([install](../deployment.md#install)); from a checkout, build it with
+`cargo build --release -p rs-config-render`.
 
 The renderer is deliberately fail-stale, never fail-open: a refused
 knob (exit 2), an implausibly empty IRR set (exit 3), or context-shape
@@ -141,7 +142,9 @@ configuration stays live:
 arouteserver template-context --output "$STATE/context.yml"
 rs-config-render --context "$STATE/context.yml" \
     --out-dir "$STATE/candidate" --rtr-cache 127.0.0.1:3323
-rustbgpd --check "$STATE/candidate/config.toml"
+# --strict: warnings fail the gate, so a refresh never swaps in a config
+# the daemon had something to say about. Rendered output is clean.
+rustbgpd --check --strict "$STATE/candidate/config.toml"
 rsync -a --delete "$STATE/candidate/" /etc/rustbgpd/
 systemctl reload rustbgpd        # SIGHUP: parse-then-swap
 ```

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -311,7 +311,7 @@ arouteserver `general.yml`/`clients.yml` and render rustbgpd
 configuration from its resolved data model with
 [`tools/rs-config-render/`](../../tools/rs-config-render/README.md)
 (`arouteserver template-context` → `rs-config-render` →
-`rustbgpd --check` → swap → SIGHUP, fail-stale at every step). The
+`rustbgpd --check --strict` → swap → SIGHUP, fail-stale at every step). The
 end-to-end walkthrough — including the Alice-LG looking glass — is
 [ixp-filter-pipeline.md](ixp-filter-pipeline.md). Design and failure
 policy:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -63,7 +63,7 @@ TARBALL=rustbgpd-${SUFFIX}.tar.gz
 curl -fL -o "$TARBALL" \
   "https://github.com/lance0/rustbgpd/releases/latest/download/${TARBALL}"
 tar -xzf "$TARBALL"
-sudo install -m 0755 rustbgpd rbgp /usr/local/bin/
+sudo install -m 0755 rustbgpd rbgp rs-config-render /usr/local/bin/
 sudo install -m 0644 share/man/man1/rbgp.1 /usr/local/share/man/man1/
 sudo install -m 0644 share/man/man8/rustbgpd.8 /usr/local/share/man/man8/
 sudo install -m 0644 share/completions/rbgp.bash \
@@ -85,7 +85,14 @@ Verify:
 ```sh
 rustbgpd --version
 rbgp --version
+rs-config-render --version
 ```
+
+`rs-config-render` matters only if you run an IXP route server — it turns
+`arouteserver template-context` output into rustbgpd configuration
+([`tools/rs-config-render/`](../tools/rs-config-render/README.md)). It is
+in the archive either way, so install it now rather than discovering it is
+missing from a cron refresh later.
 
 ### From source
 
@@ -94,11 +101,12 @@ rbgp --version
 sudo apt-get install -y protobuf-compiler   # Debian/Ubuntu
 git clone https://github.com/lance0/rustbgpd
 cd rustbgpd
-# Builds exactly what a deployment ships: the daemon + the rbgp CLI.
-# (`--workspace` would also build dev/bench helpers you don't need.)
-cargo build --release -p rustbgpd -p rustbgpctl
+# Builds exactly what a deployment ships: the daemon, the rbgp CLI, and
+# the route-server config renderer. (`--workspace` would also build
+# dev/bench helpers you don't need.)
+cargo build --release -p rustbgpd -p rustbgpctl -p rs-config-render
 sudo install -m 0755 \
-  target/release/rustbgpd target/release/rbgp \
+  target/release/rustbgpd target/release/rbgp target/release/rs-config-render \
   /usr/local/bin/
 ```
 
@@ -124,7 +132,12 @@ docker pull ghcr.io/lance0/rustbgpd:0.45
 
 The published image is the Dockerfile's default `runtime` target:
 lean, daemon + `rbgp` only, running as a nonroot `rustbgpd` user. No
-dev/test/bench helpers are included. If you'd rather build it locally:
+dev/test/bench helpers are included. `rs-config-render` is deliberately
+left out too: the IXP refresh loop is a host-side cron job that runs
+`arouteserver` and the renderer next to each other and hands the daemon a
+finished config directory, so the renderer belongs on the host, not in the
+daemon's image. Install it from the tarball. If you'd rather build the
+image locally:
 
 ```sh
 docker build -t rustbgpd:latest .

--- a/tests/interop/m90-differential/README.md
+++ b/tests/interop/m90-differential/README.md
@@ -45,8 +45,8 @@ containerlab destroy -t tests/interop/m90-differential.clab.yml
 The driver renders both configs itself (nothing is bind-mounted into
 the route-server nodes): `arouteserver bird` in the pinned container
 for BIRD, `cargo run -p rs-config-render` for rustbgpd, followed by
-the pipeline's own gates (`rustbgpd --check`, `rbgp policy check` on
-every generated `.rpol`).
+the pipeline's own gates (`rustbgpd --check --strict`, `rbgp policy
+check` on every generated `.rpol`).
 
 **Image pin:** the driver runs
 `pierky/arouteserver@sha256:ba0e9c0b541c63acf0765a08fd2e09c2bba9dc64af1f5bbdce7819e8d1c34d66`

--- a/tests/interop/m90-differential/prove-context-ingestion.sh
+++ b/tests/interop/m90-differential/prove-context-ingestion.sh
@@ -9,7 +9,8 @@
 #      bgpq4 stub — the site's AS-SETs are documentation objects);
 #   2. `rs-config-render` directly on that dump (the sectioned report
 #      arouteserver 1.23.2 emits);
-#   3. `rustbgpd --check` + `rbgp policy check` on the rendered output;
+#   3. `rustbgpd --check --strict` + `rbgp policy check` on the rendered
+#      output;
 #
 # and asserts:
 #   - the fresh dump matches the checked-in context-sectioned.yml
@@ -104,9 +105,9 @@ ok "receipts and configs carry identical exact per-client limits"
 
 step "pipeline gates on the real-dump render"
 cargo run -q -p rustbgpd --manifest-path "$REPO_DIR/Cargo.toml" -- \
-    --check "$WORK/render-real/config.toml" \
-    || die "rendered config fails rustbgpd --check"
-ok "rustbgpd --check passes"
+    --check --strict "$WORK/render-real/config.toml" \
+    || die "rendered config fails rustbgpd --check --strict"
+ok "rustbgpd --check --strict passes"
 for rpol in "$WORK"/render-real/policy/*.rpol; do
     cargo run -q -p rustbgpctl --bin rbgp --manifest-path "$REPO_DIR/Cargo.toml" -- \
         policy check "$rpol" \
@@ -116,5 +117,6 @@ done
 
 echo
 echo "PROOF PASS: $pass checks — the advertised pipeline (arouteserver"
-echo "template-context -> rs-config-render -> rustbgpd --check) runs end to"
-echo "end on the real pinned image, and both input forms render identically."
+echo "template-context -> rs-config-render -> rustbgpd --check --strict) runs"
+echo "end to end on the real pinned image, and both input forms render"
+echo "identically."

--- a/tests/interop/scripts/test-m90-differential.sh
+++ b/tests/interop/scripts/test-m90-differential.sh
@@ -32,7 +32,7 @@
 #     makes the attribution deterministic).
 #
 # Also asserted along the way: the rendered rustbgpd config passes
-# `rustbgpd --check`, every generated .rpol file passes its own
+# `rustbgpd --check --strict`, every generated .rpol file passes its own
 # in-language tests under `rbgp policy check`, and the render receipt
 # lists all three members.
 #
@@ -209,11 +209,11 @@ render_rustbgpd_config() {
 
     # The pipeline's own gate (cookbook step 3): the rendered config
     # must pass full validation before it may serve members.
-    if docker exec "$RUSTBGPD" /usr/local/bin/rustbgpd --check /etc/rustbgpd/config.toml >/dev/null 2>&1; then
-        ok "rendered config passes rustbgpd --check"
+    if docker exec "$RUSTBGPD" /usr/local/bin/rustbgpd --check --strict /etc/rustbgpd/config.toml >/dev/null 2>&1; then
+        ok "rendered config passes rustbgpd --check --strict"
     else
-        fail "rendered config FAILS rustbgpd --check"
-        docker exec "$RUSTBGPD" /usr/local/bin/rustbgpd --check /etc/rustbgpd/config.toml >&2 || true
+        fail "rendered config FAILS rustbgpd --check --strict"
+        docker exec "$RUSTBGPD" /usr/local/bin/rustbgpd --check --strict /etc/rustbgpd/config.toml >&2 || true
         exit 1
     fi
 

--- a/tests/rs_config_render_emitted_check.rs
+++ b/tests/rs_config_render_emitted_check.rs
@@ -1,8 +1,14 @@
 //! Emitted-config gate for `tools/rs-config-render`: what the renderer
 //! produces from its checked-in fixture must pass the real daemon's
-//! `rustbgpd --check` (which also compiles every referenced `.rpol`
-//! file), and the fixture's deliberately-empty IRR bundle must abort
-//! the render rather than emit a config at all.
+//! `rustbgpd --check --strict` (which also compiles every referenced
+//! `.rpol` file), and the fixture's deliberately-empty IRR bundle must
+//! abort the render rather than emit a config at all.
+//!
+//! Strict, not plain `--check`: the renderer is the IXP adoption path, so
+//! its output is the config an operator gates in a refresh loop every day.
+//! A plain `--check` here passed while every rendered member session was
+//! warned about for resolving no export policy — the tool taught operators
+//! that the gate they run is noise.
 
 use rs_config_render::{Options, RenderError, render};
 
@@ -28,8 +34,9 @@ fn untouched_fixture_aborts_on_the_empty_irr_bundle() {
 #[test]
 /// Load-bearing proof: dropping the active family ceiling or 37-minute to
 /// 2,220-second conversion breaks the exact assertions; emitting a daemon-
-/// invalid timer breaks the real `rustbgpd --check` invocation.
-fn emitted_config_passes_rustbgpd_check() {
+/// invalid timer, or dropping the rendered export chain, breaks the real
+/// `rustbgpd --check --strict` invocation.
+fn emitted_config_passes_rustbgpd_check_strict() {
     // Drop the abort-proving client, then render the healthy context.
     let mut value: serde_yaml::Value = serde_yaml::from_str(FIXTURE).expect("fixture parses");
     value["clients"]
@@ -69,13 +76,20 @@ fn emitted_config_passes_rustbgpd_check() {
     let config = out_dir.path().join("config.toml");
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
         .arg("--check")
+        .arg("--strict")
         .arg(&config)
         .output()
-        .expect("run rustbgpd --check");
+        .expect("run rustbgpd --check --strict");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         output.status.success(),
-        "rustbgpd --check rejected the emitted config\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
+        "rustbgpd --check --strict rejected the emitted config\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    // Assert the summary line, not just the exit code: a warning that
+    // somehow exited 0 would otherwise pass this gate silently.
+    assert!(
+        stdout.contains("config OK"),
+        "strict check exited 0 without a clean summary\nstdout:\n{stdout}\nstderr:\n{stderr}",
     );
 }

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -16,8 +16,13 @@ adds exactly one render step:
 $ arouteserver template-context --output /var/lib/rs/context.yml
 $ rs-config-render --context /var/lib/rs/context.yml \
     --out-dir /var/lib/rs/candidate --rtr-cache 127.0.0.1:3323
-$ rustbgpd --check /var/lib/rs/candidate/config.toml
+$ rustbgpd --check --strict /var/lib/rs/candidate/config.toml
 ```
+
+Rendered output passes `--strict` — every member session carries an
+explicit import chain and the declared transparent export chain (RFC 7947
+permit-all, plus `ebgp_requires_policy` so deleting it fails closed) — so
+the refresh loop can gate on warnings, not just on rejection.
 
 [arouteserver]: https://github.com/pierky/arouteserver
 
@@ -56,7 +61,7 @@ and against a live run of the pinned arouteserver image by
 
 | File | Contents |
 |---|---|
-| `config.toml` | RS globals, RPKI cache servers, one `[[neighbors]]` per client: transparent `route_server_client` session, `role = "route_server"`, strict next-hop ownership, per-family max-prefix ceilings and OpenBGPD-style timed restart, per-client import policy chain, `per_client_best` (or Add-Path when the context enables it) |
+| `config.toml` | RS globals, RPKI cache servers, one `[[neighbors]]` per client: transparent `route_server_client` session, `role = "route_server"`, strict next-hop ownership, per-family max-prefix ceilings and OpenBGPD-style timed restart, per-client import policy chain, `per_client_best` (or Add-Path when the context enables it); plus `ebgp_requires_policy = true` and a declared transparent (permit-all) export chain, the RFC 7947 posture stated rather than inherited |
 | `policy/rs-hygiene.rpol` | Shared import hygiene: reject AS_SET segments (always the first term), invalid/private/reserved ASNs in the path, transit-free and never-via-route-servers ASNs, AS_PATH length cap, bogon and black-list prefixes, prefix-length windows, RPKI origin validation with RFC 8097 tagging |
 | `policy/client-<id>.rpol` | The client's IRR-derived `prefix-set` and origin `asn-set`, one accept term (`route.origin-as in … && route.prefix in …`), and an unconditional reject tail |
 | `render-receipt.json` | Render timestamp, context fingerprint, per-client set cardinalities, max-prefix ceilings and restart seconds, warnings |
@@ -81,13 +86,14 @@ transfers verbatim:
 arouteserver template-context --output "$STATE/context.yml"
 rs-config-render --context "$STATE/context.yml" \
     --out-dir "$STATE/candidate" --rtr-cache 127.0.0.1:3323
-rustbgpd --check "$STATE/candidate/config.toml"
+rustbgpd --check --strict "$STATE/candidate/config.toml"
 rsync -a --delete "$STATE/candidate/" /etc/rustbgpd/
 systemctl reload rustbgpd        # SIGHUP: parse-then-swap
 ```
 
-Any step failing (arouteserver exit, render refusal/abort, `--check`
-rejection) leaves the previous configuration running untouched; the
+Any step failing (arouteserver exit, render refusal/abort, `--check
+--strict` rejection or warning) leaves the previous configuration
+running untouched; the
 daemon's own reload seam guarantees a bad swap can never evict working
 policy either. Alert on the age of `render-receipt.json` — a pipeline
 stuck for more than a couple of refresh intervals should page, not rot.

--- a/tools/rs-config-render/src/lib.rs
+++ b/tools/rs-config-render/src/lib.rs
@@ -1368,6 +1368,15 @@ fn render_toml(
         );
     }
     out.push_str(
+        "# RFC 8212: a member session with no explicit policy carries nothing in\n\
+         # that direction. The export chain below is deliberately permit-all, and\n\
+         # this knob is what keeps that a decision: delete the chain and members\n\
+         # stop receiving routes, loudly, instead of inheriting the same permit-all\n\
+         # by omission. Startup-only — SIGHUP keeps the running value, so changing\n\
+         # it takes a daemon restart.\n\
+         ebgp_requires_policy = true\n",
+    );
+    out.push_str(
         "\n# Local management surface (`rbgp` over UDS, file-permission gated) —\n\
          # the same shape as examples/route-server/. Add prometheus_addr here to\n\
          # scrape metrics.\n\
@@ -1388,11 +1397,33 @@ fn render_toml(
         }
     }
 
+    // Export policy: permit-all, on purpose — and declared rather than
+    // inherited, so `ebgp_requires_policy` above has something to enforce.
+    out.push_str(
+        "\n# --- Export policy: permit-all, on purpose ---\n\
+         #\n\
+         # An IX route server is transparent by design (RFC 7947): it hands each\n\
+         # member what that member's own filters selected, without imposing the\n\
+         # route server's opinion on top. So permit-all is the correct export\n\
+         # posture here — but it is *declared*, not inherited. A route server that\n\
+         # is permit-all because nobody wrote an export chain behaves identically\n\
+         # on the wire; only this chain, and this comment, record that it was a\n\
+         # choice rather than an omission.\n\
+         #\n\
+         # Per-member filtering belongs in that member's arouteserver\n\
+         # configuration, which renders into the per-client import chain below —\n\
+         # editing this file loses the change on the next refresh. The per-client\n\
+         # best-path handling below (`per_client_best`, or Add-Path where the\n\
+         # context enables it) is what makes such a per-member denial advertise\n\
+         # the best permitted candidate rather than hide the prefix.\n\
+         [policy.definitions.rs-transparent-export]\ndefault_action = \"permit\"\n",
+    );
+
     out.push_str("\n[policy]\nrpol_files = [\n    \"policy/rs-hygiene.rpol\",\n");
     for rc in clients {
         let _ = writeln!(out, "    \"policy/client-{}.rpol\",", rc.slug);
     }
-    out.push_str("]\n");
+    out.push_str("]\nexport_chain = [\"rs-transparent-export\"]\n");
 
     for rc in clients {
         let family = if rc.client.ip.contains(':') {

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -1,5 +1,5 @@
 //! CLI wrapper around the renderer library. See `README.md` for the
-//! refresh loop (`render → rustbgpd --check → swap → SIGHUP`).
+//! refresh loop (`render → rustbgpd --check --strict → swap → SIGHUP`).
 
 #![deny(unsafe_code)]
 
@@ -90,7 +90,7 @@ fn main() -> ExitCode {
         return ExitCode::from(1);
     }
     println!(
-        "rendered {} file(s) + receipt into {} — gate with `rustbgpd --check {}` before swapping",
+        "rendered {} file(s) + receipt into {} — gate with `rustbgpd --check --strict {}` before swapping",
         rendered.files.len(),
         cli.out_dir.display(),
         cli.out_dir.join("config.toml").display()

--- a/tools/rs-config-render/tests/golden.rs
+++ b/tools/rs-config-render/tests/golden.rs
@@ -472,7 +472,9 @@ fn add_path_replaces_per_client_best() {
     let rendered = render(&to_yaml(&value), &rtr_options()).expect("render");
     let toml = &rendered.files["config.toml"];
     assert!(toml.contains("[neighbors.add_path]"), "{toml}");
-    assert!(!toml.contains("per_client_best"), "{toml}");
+    // The assignment, not the bare name: the export-policy comment block
+    // names the knob prose-side in every render.
+    assert!(!toml.contains("per_client_best = true"), "{toml}");
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/rs-config-render/tests/golden/config.toml
+++ b/tools/rs-config-render/tests/golden/config.toml
@@ -8,6 +8,13 @@ router_id = "192.0.2.1"
 listen_port = 179
 # RFC 8326: honor GRACEFUL_SHUTDOWN from members (local-pref 0 chain tail).
 honor_graceful_shutdown = true
+# RFC 8212: a member session with no explicit policy carries nothing in
+# that direction. The export chain below is deliberately permit-all, and
+# this knob is what keeps that a decision: delete the chain and members
+# stop receiving routes, loudly, instead of inheriting the same permit-all
+# by omission. Startup-only — SIGHUP keeps the running value, so changing
+# it takes a daemon restart.
+ebgp_requires_policy = true
 
 # Local management surface (`rbgp` over UDS, file-permission gated) —
 # the same shape as examples/route-server/. Add prometheus_addr here to
@@ -29,12 +36,32 @@ operator = "operator"
 [[rpki.cache_servers]]
 address = "127.0.0.1:3323"
 
+# --- Export policy: permit-all, on purpose ---
+#
+# An IX route server is transparent by design (RFC 7947): it hands each
+# member what that member's own filters selected, without imposing the
+# route server's opinion on top. So permit-all is the correct export
+# posture here — but it is *declared*, not inherited. A route server that
+# is permit-all because nobody wrote an export chain behaves identically
+# on the wire; only this chain, and this comment, record that it was a
+# choice rather than an omission.
+#
+# Per-member filtering belongs in that member's arouteserver
+# configuration, which renders into the per-client import chain below —
+# editing this file loses the change on the next refresh. The per-client
+# best-path handling below (`per_client_best`, or Add-Path where the
+# context enables it) is what makes such a per-member denial advertise
+# the best permitted candidate rather than hide the prefix.
+[policy.definitions.rs-transparent-export]
+default_action = "permit"
+
 [policy]
 rpol_files = [
     "policy/rs-hygiene.rpol",
     "policy/client-as4242-1.rpol",
     "policy/client-as197000-1.rpol",
 ]
+export_chain = ["rs-transparent-export"]
 
 [[neighbors]]
 address = "192.0.2.11"


### PR DESCRIPTION
`rs-config-render` is the IXP adoption path — the ARouteServer / IXP Manager
bridge an operator runs in a cron refresh loop and gates before every swap.
Every config it emitted gave each member an import chain and no export chain
at all, so `rustbgpd --check --strict` raised the unpoliced-eBGP warning once
per member and rejected the render. The first thing the gate this release
makes authoritative told an IXP was that the tool we hand them fails it, which
is how a gate turns into noise.

Against the renderer's own fixture, before:

```
WARNING: 3 eBGP neighbors resolve no explicit policy.

  192.0.2.11 (AS 64500): no export policy
  192.0.2.12 (AS 64501): no export policy
  192.0.2.13 (AS 64502): no export policy

config VALID, 3 WARNINGS — NOT a clean check: config.toml
error: --strict: 3 warnings — not a clean check
```

after: `config OK: config.toml`.

## The render

Emit a declared transparent export chain plus `[global] ebgp_requires_policy
= true`, matching the shape and comment wording `examples/route-server` got in
#1145 so the renderer's output and the shipped starter agree. Permit-all is
the correct export posture for a route server under RFC 7947; permit-all *by
omission* is what the warning objects to, and it is indistinguishable on the
wire from having forgotten. Emitting the knob means deleting the declared
chain later fails closed rather than silently reverting to permit-all — the
same reasoning `rbgp config import` follows since #1137. The golden fixture is
regenerated to match.

## The test was false green

`tests/rs_config_render_emitted_check.rs` invoked plain `--check`, which exits
0 with three missing-export-policy warnings. It was asserting the emitted
config was acceptable while the strict gate correctly rejected it. It now runs
`--check --strict` and asserts the `config OK` summary line as well as the
exit code, so a future warning that somehow exits 0 still fails the test.

Red-proved: with the emitter reverted and the new test in place, the test
fails with `config VALID, 2 WARNINGS — NOT a clean check`.

## Other gates over rendered output

All moved to the strict form: the M90 differential's in-container check, the
context-ingestion proof script, the renderer's own "gate with" hint line, and
the documented refresh loop in the tool README, the IXP cookbook, and the
route-server cookbook.

Deliberately left non-strict: `tests/config_import_emitted_check.rs` — the
importer translates no policy by construction, so its generated configs *must*
warn, and that test already asserts the warning is present and that the summary
does not read as clean. The bench-harness scenario gate
(`tests/reloadstall_scenario_emitted_check.rs`) is also left alone: its config
shape is a measurement input pinned to a published receipt, not operator-facing
output.

## Install docs

The release tarball carries `rs-config-render`, but the README, quickstart, and
`docs/deployment.md` install snippets all extracted that archive and installed
two of its three binaries — `docs/deployment.md` contradicted its own contents
listing four lines earlier. Following the documented install and then the IXP
cookbook ended in `rs-config-render: command not found`. Every tarball and
from-source path names it now, and the cookbook says the renderer is in the
tarball rather than implying a checkout is required.

The published container image still omits it deliberately, and the deployment
guide now says why instead of leaving the gap unexplained: the refresh loop is
a host-side cron job that runs `arouteserver` and the renderer next to each
other and hands the daemon a finished config directory.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D
warnings`, `cargo test --workspace --no-fail-fast`, `cargo doc --workspace
--no-deps` — all 0.
