### PR TITLE
Correct the gRPC inventory's authorization model and fence its tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Every shipped starter profile and interop lab now runs under tier
   authorization; `security.grpc.enforcement = "legacy"` is reported by
   `--check` rather than only at daemon startup.
+- The gRPC method inventory an external reviewer reads is now checked
+  against the generated tier export on every test run, so the published
+  classification cannot drift from the one the daemon enforces.
 
 **Library crates**
 

--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -3,8 +3,8 @@
 //! ADR-0064 uses this table as the code-level source of truth for
 //! method risk tiers. Runtime authorization enforces listener-level
 //! `AccessMode` checks in `server.rs`, per-listener `max_tier`
-//! ceilings in `authz_runtime.rs`, and opt-in per-principal role
-//! ceilings when ADR-0064 `enforcement = "tier"` is enabled.
+//! ceilings in `authz_runtime`, and per-principal role ceilings under
+//! ADR-0064 `enforcement = "tier"`, the default since v0.24.0.
 
 /// Authorization tier assigned to one gRPC method.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -751,7 +751,7 @@ pub fn method_count_by_tier(tier: AuthTier) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
+    use std::collections::{BTreeMap, BTreeSet};
 
     use super::{AuthTier, METHODS, method_authz, method_count_by_tier};
     use serde_json::json;
@@ -760,6 +760,7 @@ mod tests {
     const GNMI_PROTO: &str =
         include_str!("../../../proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto");
     const INVENTORY_JSON: &str = include_str!("../../../docs/grpc-method-inventory.json");
+    const INVENTORY_MD: &str = include_str!("../../../docs/grpc-method-inventory.md");
     const AUTHZ_SOURCE_PATH: &str = "crates/api/src/authz.rs";
     const PRIMARY_PROTO_PATH: &str = "proto/rustbgpd.proto";
     const ADDITIONAL_PROTO_PATHS: &[&str] =
@@ -845,6 +846,89 @@ mod tests {
         })
     }
 
+    /// Strip markdown code ticks and emphasis from one table cell.
+    fn cell_text(cell: &str) -> String {
+        cell.replace(['`', '*'], "").trim().to_owned()
+    }
+
+    /// One documented row: `(method path, tier)`.
+    type InventoryRow = (String, String);
+    /// One `### Service (N RPCs)` heading: `(service, claimed, listed)`.
+    type ServiceHeading = (String, usize, usize);
+
+    /// Per-service table rows of `docs/grpc-method-inventory.md`, plus the
+    /// claimed and listed RPC count of every per-service heading.
+    fn markdown_inventory() -> (BTreeSet<InventoryRow>, Vec<ServiceHeading>) {
+        let mut rows = BTreeSet::new();
+        let mut headings = Vec::new();
+        let mut section: Option<ServiceHeading> = None;
+        for line in INVENTORY_MD.lines() {
+            if let Some(rest) = line.strip_prefix("### ") {
+                headings.extend(section.take());
+                let (name, claimed) = rest
+                    .split_once(" (")
+                    .expect("per-service heading states its RPC count");
+                let claimed = claimed
+                    .split_whitespace()
+                    .next()
+                    .and_then(|count| count.parse().ok())
+                    .expect("per-service heading states its RPC count");
+                let service = if name.contains('.') {
+                    name.to_owned()
+                } else {
+                    format!("rustbgpd.v1.{name}")
+                };
+                section = Some((service, claimed, 0));
+                continue;
+            }
+            if line.starts_with("## ") {
+                headings.extend(section.take());
+                continue;
+            }
+            let Some((service, _, listed)) = section.as_mut() else {
+                continue;
+            };
+            if !line.starts_with("| `") {
+                continue;
+            }
+            let mut cells = line.split('|').skip(1).map(cell_text);
+            let method = cells.next().expect("inventory row has a method cell");
+            let method = method.strip_suffix(" (stream)").unwrap_or(&method);
+            let tier = cells.next().expect("inventory row has a tier cell");
+            *listed += 1;
+            assert!(
+                rows.insert((format!("/{service}/{method}"), tier)),
+                "duplicate inventory row for {service}/{method}"
+            );
+        }
+        headings.extend(section);
+        (rows, headings)
+    }
+
+    /// The `## Totals` table of `docs/grpc-method-inventory.md`, keyed by tier
+    /// label plus the `Total` row.
+    fn markdown_totals() -> BTreeMap<String, usize> {
+        let mut totals = BTreeMap::new();
+        let mut in_totals = false;
+        for line in INVENTORY_MD.lines() {
+            if line.starts_with("## ") {
+                in_totals = line == "## Totals";
+                continue;
+            }
+            if !in_totals || !line.starts_with('|') {
+                continue;
+            }
+            let mut cells = line.split('|').skip(1).map(cell_text);
+            let (Some(label), Some(count)) = (cells.next(), cells.next()) else {
+                continue;
+            };
+            if let Ok(count) = count.parse() {
+                totals.insert(label, count);
+            }
+        }
+        totals
+    }
+
     fn brace_delta(line: &str) -> i32 {
         let opens = i32::try_from(line.chars().filter(|ch| *ch == '{').count())
             .expect("proto line has more than i32::MAX opening braces");
@@ -913,6 +997,66 @@ mod tests {
         let actual = serde_json::from_str::<serde_json::Value>(INVENTORY_JSON)
             .expect("docs/grpc-method-inventory.json must be valid JSON");
         assert_eq!(actual, expected_inventory_json());
+    }
+
+    /// `docs/grpc-method-inventory.md` is external-review evidence, so it is
+    /// fenced to the generated export by set equality in both directions: an
+    /// RPC missing from the prose and a stale row surviving in it both fail
+    /// here, as does a per-service heading or totals count that stops matching
+    /// the rows underneath it.
+    #[test]
+    fn markdown_inventory_matches_machine_readable_export() {
+        let export = serde_json::from_str::<serde_json::Value>(INVENTORY_JSON)
+            .expect("docs/grpc-method-inventory.json must be valid JSON");
+        let exported = export["methods"]
+            .as_array()
+            .expect("export lists methods")
+            .iter()
+            .map(|method| {
+                (
+                    method["path"].as_str().expect("method path").to_owned(),
+                    method["tier"].as_str().expect("method tier").to_owned(),
+                )
+            })
+            .collect::<BTreeSet<_>>();
+        let method_count = usize::try_from(
+            export["method_count"]
+                .as_u64()
+                .expect("export method_count"),
+        )
+        .expect("method count fits usize");
+
+        let (documented, headings) = markdown_inventory();
+        let missing = exported.difference(&documented).collect::<Vec<_>>();
+        assert!(
+            missing.is_empty(),
+            "RPCs absent from the tables: {missing:?}"
+        );
+        let stale = documented.difference(&exported).collect::<Vec<_>>();
+        assert!(stale.is_empty(), "rows absent from the export: {stale:?}");
+        assert_eq!(documented.len(), method_count);
+
+        for (service, claimed, listed) in headings {
+            assert_eq!(
+                claimed, listed,
+                "{service} heading claims {claimed} RPCs but lists {listed} rows"
+            );
+        }
+
+        let mut expected_totals = export["tier_counts"]
+            .as_object()
+            .expect("export tier_counts")
+            .iter()
+            .map(|(tier, count)| {
+                (
+                    tier.clone(),
+                    usize::try_from(count.as_u64().expect("tier count"))
+                        .expect("tier count fits usize"),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        expected_totals.insert("Total".to_owned(), method_count);
+        assert_eq!(markdown_totals(), expected_totals);
     }
 
     #[test]

--- a/docs/adr/0064-threat-model.md
+++ b/docs/adr/0064-threat-model.md
@@ -26,7 +26,7 @@ External context:
 
 The highest-risk area is the privileged gRPC management surface. rustbgpd
 already has safe listener defaults, optional bearer-token auth, native mTLS,
-UDS permissions, read-only listener mode, a checked 66-RPC method-tier matrix,
+UDS permissions, read-only listener mode, a checked 101-RPC method-tier matrix,
 runtime tier telemetry, and enforced listener `max_tier` caps. The remaining
 v1.0 security work is to turn that matrix into real principal-aware
 enforcement: extract mTLS principals, assign roles, deny over-role calls, and
@@ -45,7 +45,7 @@ In scope:
   `access_mode`.
 - ADR-0064 method-tier inventory and runtime tier-decision layer:
   `docs/grpc-method-inventory.md`, `crates/api/src/authz.rs`,
-  `crates/api/src/authz_runtime.rs`, and
+  `crates/api/src/authz_runtime/`, and
   `crates/telemetry/src/metrics.rs`.
 - gRPC services and high-risk RPCs in `proto/rustbgpd.proto` and
   `crates/api/src/*_service.rs`.
@@ -94,9 +94,9 @@ Open questions that could change risk ranking:
 | Bearer interceptor | Per-call token check for listeners with `token_file` | `crates/api/src/server.rs::AuthInterceptor` |
 | Service handlers | Implement Global, Config, Neighbor, Policy, PeerGroup, RIB, Event, Injection, Control, and EVPN RPCs | `proto/rustbgpd.proto`, `crates/api/src/*_service.rs` |
 | Access mode guard | Per-service mutating RPC rejection on read-only listeners | `crates/api/src/server.rs::read_only_rejection` |
-| Method-tier matrix | Static ADR-0064 classification for all 66 RPCs | `crates/api/src/authz.rs`, `docs/grpc-method-inventory.md`, `docs/grpc-method-inventory.json` |
-| Audit runtime layer | Audit-only method-tier lookup, structured logs, bounded metric | `crates/api/src/authz_runtime.rs`, `crates/telemetry/src/metrics.rs` |
-| Core actors | PeerManager, RIB, dataplane, config persistence, and shutdown actors behind RPC handlers | `src/main.rs`, `src/peer_manager.rs`, `crates/rib/src/manager` |
+| Method-tier matrix | Static ADR-0064 classification for all 101 RPCs | `crates/api/src/authz.rs`, `docs/grpc-method-inventory.md`, `docs/grpc-method-inventory.json` |
+| Audit runtime layer | Audit-only method-tier lookup, structured logs, bounded metric | `crates/api/src/authz_runtime/`, `crates/telemetry/src/metrics.rs` |
+| Core actors | PeerManager, RIB, dataplane, config persistence, and shutdown actors behind RPC handlers | `src/main.rs`, `src/peer_manager/`, `crates/rib/src/manager` |
 
 ### Data flows and trust boundaries
 
@@ -297,7 +297,7 @@ External reviewers should be able to verify:
 |------|----------------|-----------------|
 | `crates/api/src/server.rs` | Listener setup, bearer interceptor, mTLS config, access mode, audit layer wiring | TM-001, TM-002, TM-003, TM-004, TM-006 |
 | `crates/api/src/authz.rs` | Source of truth for per-method tiers | TM-001, TM-008 |
-| `crates/api/src/authz_runtime.rs` | Audit-only decision path and structured log fields | TM-001, TM-005, TM-009 |
+| `crates/api/src/authz_runtime/` | Audit-only decision path and structured log fields | TM-001, TM-005, TM-009 |
 | `crates/telemetry/src/metrics.rs` | Bounded authz metric labels and evidence surface | TM-007, TM-009 |
 | `crates/api/src/injection_service.rs` | High-blast-radius route, FlowSpec, EVPN injection | TM-001 |
 | `crates/api/src/control_service.rs` | Shutdown and MRT trigger controls | TM-001 |

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -11,20 +11,42 @@ assignment.
 
 ## Purpose
 
-Today, gRPC authorization is listener-level. A configured
-`access_mode = "read_only"` listener rejects mutating handlers, while
-`access_mode = "read_write"` exposes the full service surface to any
-client accepted by that listener's transport authentication (UDS
-permissions, bearer token, and/or mTLS). ROADMAP P0 ("gRPC security
-audit + authorization split") needs a method-level risk boundary, and
-the v1.0 external security review needs a documented per-method
-classification to audit.
+gRPC authorization is per-method. The runtime authorization layer
+(`crates/api/src/authz_runtime/`) resolves the tier of every call from
+this inventory before the handler runs, and applies two checks in order:
 
-This document is the inventory the ADR-0064 enforcement model maps
-against. It does not pick the enforcement mechanism (RBAC vs.
-capability tokens vs. proto-annotation tags vs. listener-tier split)
-— that is the ADR's job. It only fixes the classification of each
-RPC so the model has something concrete to assign roles to.
+1. **Listener ceiling.** A listener's `max_tier` is a hard cap on the
+   tiers it serves at all, regardless of who is calling; a call above the
+   cap is rejected `PERMISSION_DENIED` with the bounded audit result
+   `listener_tier_denied`. `access_mode = "read_only"` translates to a
+   `sensitive_read` ceiling and the stricter of the two wins, so the
+   binary access mode is a compatibility ceiling layered over the tier
+   model rather than the mechanism behind it.
+2. **Principal role.** With `[security.grpc].enforcement = "tier"` — the
+   default since v0.24.0 — the call's authenticated principal is looked
+   up in `[security.grpc.roles]` and the role's ceiling must reach the
+   method's tier: `observer` reaches `sensitive_read`, `automation`
+   reaches `mutating`, `operator` reaches `operator_only`. A principal
+   with no role entry is denied (`principal_unmapped`); a principal whose
+   role sits below the method tier is denied (`role_tier_denied`).
+   `enforcement = "legacy"` remains a supported opt-out in which roles
+   are audit context only and the listener ceiling is the sole tier
+   check.
+
+Principals come from the listener's authenticated identity: native mTLS
+listeners derive them from the validated client certificate (`rustbgpd:`
+URI SAN, then email SAN, then Subject CN), while bearer-token and UDS
+listeners carry an explicit configured `principal` label. Under tier
+enforcement, startup validation rejects a listener that offers neither
+rather than falling back open.
+
+The tier assigned to each RPC below is therefore load-bearing: it is the
+floor a caller's role must reach and the value a listener cap is compared
+against. A method path that is missing from the matrix fails closed as
+`operator_only`. This document is the human-auditable form of that
+assignment; `crates/api/src/authz.rs` is the source of truth the daemon
+reads, and `docs/grpc-method-inventory.json` is the machine-readable
+export.
 
 For external review, read this inventory together with
 `docs/adr/0064-grpc-authorization.md` and
@@ -33,7 +55,8 @@ management-plane assets, trust boundaries, abuse paths, current controls,
 and residual enforcement gaps behind the tier assignments.
 Auditors and generated-client authors can consume the same classification from
 `docs/grpc-method-inventory.json`; CI checks that JSON artifact against the
-Rust source-of-truth table.
+Rust source-of-truth table, and checks the per-service tables below against
+the JSON artifact.
 
 ## Classification scheme
 
@@ -247,12 +270,12 @@ specific method if the model warrants it.
    (including `SetFibTable` / `DeleteFibTable`). The 4-tier scheme allows
    richer enforcement (e.g., per-method capability tokens) but the
    per-service split is the cheapest first step.
-2. **`operator_only` is small enough to gate by principal role.** 22
+2. **`operator_only` is small enough to gate by principal role.** 23
    methods total; carving these out into a separate listener or
    requiring a distinct principal role (`operator` vs. `automation`) has
    low operational cost and high blast-radius reduction.
 3. **InjectionService is uniformly `operator_only`.** Six of the
-   twenty-two `operator_only` methods live here. The simplest model is
+   twenty-three `operator_only` methods live here. The simplest model is
    to make the whole service gated behind an `inject` capability or a
    dedicated listener — operators rarely use it for automation, and
    when they do it should be a deliberate channel.
@@ -291,7 +314,7 @@ specific method if the model warrants it.
    `handler_invalid_argument`. mTLS listeners derive the audit principal from
    the client certificate (URI SAN → email SAN → Subject CN); non-mTLS
    listeners still emit operator-controlled principal labels.
-   In opt-in tier mode, `principal_unmapped` and `role_tier_denied`
+   In tier mode, `principal_unmapped` and `role_tier_denied`
    distinguish role-map denials from listener caps. `DiffRuntimeConfig`,
    `PlanConfigTransaction`, `ApplyConfigTransaction`, and `SetPeerGroup`
    request summaries mask credential-bearing fields, including candidate TOML
@@ -306,13 +329,16 @@ as a static Rust table. `docs/grpc-method-inventory.json` is the
 machine-readable export for auditors, tooling, and generated clients. The
 `authz` tests parse `proto/rustbgpd.proto` and fail if a new RPC is added
 without a tier assignment; they also parse the JSON export and fail if it drifts
-from `crates/api/src/authz.rs`.
+from `crates/api/src/authz.rs`, and parse the per-service tables above and fail
+if this document's rows, per-service heading counts, or totals drift from the
+JSON export.
 
 ## Maintenance
 
 When adding a new RPC:
 
-1. Add the row to the appropriate per-service table.
+1. Add the row to the appropriate per-service table, bump that
+   service's heading count, and bump the `## Totals` table.
 2. Pick the tier defensively (higher when in doubt; the ADR will
    negotiate down if warranted).
 3. Add the corresponding row to `docs/grpc-method-inventory.json` and bump


### PR DESCRIPTION
The external security-review packet disagreed with the daemon it
describes. `docs/grpc-method-inventory.md` contradicted itself: its
introduction described listener-only authorization, while its own
per-service tables and totals already carried the enforced 101-method
tier matrix.

## Inventory

The introduction now describes the model that exists: per-method tiers
resolved before the handler runs, the listener `max_tier` ceiling as a
hard cap rather than the mechanism (with `access_mode = "read_only"` as
a `sensitive_read` compatibility ceiling), per-principal role
enforcement under the default `enforcement = "tier"` with the
`observer` / `automation` / `operator` ladder and its
`principal_unmapped` / `role_tier_denied` denials, where principals come
from on mTLS and non-mTLS listeners, and the fail-closed treatment of an
unclassified method path. Three stale counts elsewhere in the document
were corrected to match the matrix.

## Structural check

The tables were hand-maintained, so nothing stopped them from drifting
again. `cargo test -p rustbgpd-api authz` now parses the per-service
tables and compares them with `docs/grpc-method-inventory.json` — the
export already fenced against `crates/api/src/authz.rs` — by set
equality in both directions: an RPC absent from the prose and a stale
row surviving in it each fail, as does a per-service heading count or a
totals row that stops matching the rows beneath it. Red-proved against
four perturbations: a renamed row, an added row, a bumped heading count,
and a changed totals figure.

## Threat model

`docs/adr/0064-threat-model.md` makes security claims and several are
stale at HEAD, so only mechanical corrections are included here: the
66-RPC count in the executive summary and the system-model table (101 at
HEAD), and two module paths that no longer exist
(`crates/api/src/authz_runtime.rs`, `src/peer_manager.rs`, both now
directories). Every statement about enforcement coverage, residual risk,
trust boundaries, and follow-up issue state is left as written for owner
review.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --
-D warnings`, `cargo test --workspace --no-fail-fast`, `cargo doc
--workspace --no-deps`, and `cargo test -p rustbgpd-api authz` all exit
0.
