### PR TITLE
Pin the scheduled fuzz campaign to the reviewed nightly

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,9 +10,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@nightly
+      # fuzz/rust-nightly.txt holds the single reviewed nightly, shared with
+      # the OSS-Fuzz and ClusterFuzzLite images. A floating `nightly` lets an
+      # upstream compiler regression take the campaign down with no change on
+      # our side, and the failure reads as if it came from this repository.
+      # RUSTUP_TOOLCHAIN then applies the pin to every cargo call below.
+      - name: Select the reviewed nightly
+        id: nightly
+        run: |
+          toolchain=$(cat fuzz/rust-nightly.txt)
+          if [ -z "$toolchain" ]; then
+            echo "fuzz/rust-nightly.txt is empty" >&2
+            exit 1
+          fi
+          echo "toolchain=$toolchain" >> "$GITHUB_OUTPUT"
+          echo "RUSTUP_TOOLCHAIN=$toolchain" >> "$GITHUB_ENV"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.nightly.outputs.toolchain }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo install cargo-fuzz
+      - run: cargo install cargo-fuzz --locked
       # Every target in each fuzz crate, 2 minutes apiece. Seed corpora are
       # tracked under fuzz/seeds/<target>/ (fuzz/corpus/ is gitignored, so a
       # CI run starts from the seeds).
@@ -21,7 +38,7 @@ jobs:
           cd crates/wire
           # `$(cargo fuzz list)` inline would let an errored or empty
           # enumeration silently run zero targets — fail loudly instead.
-          targets=$(cargo +nightly fuzz list)
+          targets=$(cargo fuzz list)
           if [ -z "$targets" ]; then
             echo "fuzz-target enumeration returned no targets" >&2
             exit 1
@@ -30,14 +47,14 @@ jobs:
             mkdir -p "fuzz/corpus/$t"
             seeds=""
             [ -d "fuzz/seeds/$t" ] && seeds="fuzz/seeds/$t"
-            cargo +nightly fuzz run "$t" "fuzz/corpus/$t" $seeds -- -max_total_time=120 -max_len=4096
+            cargo fuzz run "$t" "fuzz/corpus/$t" $seeds -- -max_total_time=120 -max_len=4096
           done
       - name: Fuzz rpol policy frontend (2 minutes per target)
         run: |
           cd crates/policy
           # `$(cargo fuzz list)` inline would let an errored or empty
           # enumeration silently run zero targets — fail loudly instead.
-          targets=$(cargo +nightly fuzz list)
+          targets=$(cargo fuzz list)
           if [ -z "$targets" ]; then
             echo "fuzz-target enumeration returned no targets" >&2
             exit 1
@@ -46,13 +63,13 @@ jobs:
             mkdir -p "fuzz/corpus/$t"
             seeds=""
             [ -d "fuzz/seeds/$t" ] && seeds="fuzz/seeds/$t"
-            cargo +nightly fuzz run "$t" "fuzz/corpus/$t" $seeds -- -max_total_time=120 -max_len=8192
+            cargo fuzz run "$t" "fuzz/corpus/$t" $seeds -- -max_total_time=120 -max_len=8192
           done
       - name: Fuzz EVPN parsers (2 minutes per target)
         run: |
           cd crates/evpn
           # Keep target discovery fail-closed as new EVPN parsers are added.
-          targets=$(cargo +nightly fuzz list)
+          targets=$(cargo fuzz list)
           if [ -z "$targets" ]; then
             echo "fuzz-target enumeration returned no targets" >&2
             exit 1
@@ -65,13 +82,13 @@ jobs:
             mkdir -p "fuzz/corpus/$t"
             seeds=""
             [ -d "fuzz/seeds/$t" ] && seeds="fuzz/seeds/$t"
-            cargo +nightly fuzz run "$t" "fuzz/corpus/$t" $seeds -- -max_total_time=120 -max_len=1024
+            cargo fuzz run "$t" "fuzz/corpus/$t" $seeds -- -max_total_time=120 -max_len=1024
           done
       - name: Fuzz MRT snapshot and warm-bundle readers (2 minutes per target)
         run: |
           cd crates/mrt
           # Keep target discovery fail-closed as new MRT parsers are added.
-          targets=$(cargo +nightly fuzz list)
+          targets=$(cargo fuzz list)
           if [ -z "$targets" ]; then
             echo "fuzz-target enumeration returned no targets" >&2
             exit 1
@@ -84,7 +101,7 @@ jobs:
             mkdir -p "fuzz/corpus/$t"
             seeds=""
             [ -d "fuzz/seeds/$t" ] && seeds="fuzz/seeds/$t"
-            cargo +nightly fuzz run "$t" "fuzz/corpus/$t" $seeds -- -max_total_time=120 -max_len=65536
+            cargo fuzz run "$t" "fuzz/corpus/$t" $seeds -- -max_total_time=120 -max_len=65536
           done
       - name: Upload crash artifacts
         if: failure()


### PR DESCRIPTION
## Problem

The `Fuzz` workflow installed a floating `nightly` (`dtolnay/rust-toolchain@nightly`) and selected it explicitly with `cargo +nightly` on all eight fuzz invocations. `fuzz/rust-nightly.txt` already names a reviewed toolchain, but only the OSS-Fuzz and ClusterFuzzLite images consumed it.

That left the scheduled campaign exposed to upstream compiler regressions with no change in this repository — a rustc ICE ended a recent run before it fuzzed anything, and the failure presented as if it came from our code.

## Change

`.github/workflows/fuzz.yml` — the only file that needed to change:

- Read `fuzz/rust-nightly.txt` into a step output and into `RUSTUP_TOOLCHAIN`, and pass the value to `dtolnay/rust-toolchain@master`. The read fails closed if the pin file is empty.
- Drop the eight `cargo +nightly` selectors so every cargo call in the job inherits `RUSTUP_TOOLCHAIN` instead of overriding it. The pin value is never interpolated into a shell line.
- Install cargo-fuzz with `--locked`, matching both hosted builders, so its dependency resolution cannot drift mid-campaign either.

`fuzz/rust-nightly.txt` remains the single source of truth for all three integrations, so bumping the toolchain stays a one-line reviewed change. As a side effect the `Swatinem/rust-cache` key now tracks a stable compiler version rather than rotating daily.

## Already correct, left alone

- `fuzz/build-fuzzers.sh`, `fuzz/oss-fuzz/Dockerfile`, and `.clusterfuzzlite/Dockerfile` already read the pin.
- `.github/workflows/clusterfuzzlite.yml` and the fuzz-inventory step in `.github/workflows/ci.yml` reach the compiler only through those scaffolding files, or through `cargo metadata`, which needs no nightly.
- The repository has no `rust-toolchain.toml`. Other workflows pin `@stable` or `@1.95` deliberately and are unrelated to fuzzing.
- No workflow invokes cargo-fuzz from the repository root; each step `cd`s into its crate first. The root `fuzz/` directory is OSS-Fuzz scaffolding with no `Cargo.toml`, and `scripts/check_fuzz_target_inventory.py` globs `crates/*/fuzz/Cargo.toml`, which correctly excludes it.

## Verification

Fuzz targets built with the pinned `nightly-2026-07-07`, exit code per crate:

| crate | `cargo fuzz build` |
| --- | --- |
| `crates/wire` | 0 |
| `crates/policy` | 0 |
| `crates/mrt` | 0 |
| `crates/evpn` | 0 |

`cargo fuzz list` was also exercised through `RUSTUP_TOOLCHAIN` rather than a `+toolchain` selector — the form the workflow now uses — and enumerated all 12 wire targets, confirming cargo-fuzz honours the environment variable.

`actionlint` reports the same four pre-existing `SC2086` informational findings on the intentionally unquoted `$seeds` expansion before and after the change; no new findings.

Gates: `cargo fmt --all -- --check` 0, `cargo clippy --workspace --all-targets -- -D warnings` 0, `cargo doc --workspace --no-deps` 0. The workspace test run was skipped because the diff touches no Rust source.

## Follow-up, not in this change

`docs/FUZZING.md` says the reviewed nightly is installed by "both hosted builders"; that is now three consumers including the scheduled workflow. Left to a docs pass to avoid colliding with concurrent work.