### PR TITLE
docs: make the documented Docker paths runnable as printed

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -113,8 +113,8 @@ With the systemd unit, the default CLI address is already
 ## 5. Operate
 
 ```bash
-# Add static peers at runtime; persisted to config when the daemon was started
-# with --config.
+# Add static peers at runtime. These are persisted back to the config file,
+# which is rewritten in canonical form — see CONFIGURATION.md.
 rbgp neighbor 10.0.0.5 add --remote-asn 65005
 rbgp neighbor 203.0.113.2 add --remote-asn 65002 --role provider --strict-role
 rbgp neighbor fe80::5054:ff:fe00:1%eth1 add --remote-asn 65101

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -173,18 +173,59 @@ An Envoy proxy front-end is also supported for multi-host fan-out; see
 
 ## Docker standalone
 
-Release images are published to GHCR with versioned tags
-(e.g. `ghcr.io/lance0/rustbgpd:0.51.0`); `docker build -t rustbgpd .`
-produces the same lean runtime image locally.
+Release images are published to GHCR; `:latest` tracks the newest release and
+`:X.Y` pins a minor series (see
+[deployment.md](deployment.md#container-image) for the full tag table).
+`docker build -t rustbgpd .` produces the same lean runtime image locally.
+
+First adapt the `lab` config from step 2 for a container. Two of its values
+are host defaults that do not work under Docker: state under `/tmp` is not on
+the volume, and a `127.0.0.1` metrics bind is unreachable from a published
+port.
+
+```bash
+sed -i \
+  -e 's#/tmp/rustbgpd#/var/lib/rustbgpd#g' \
+  -e 's#^prometheus_addr = .*#prometheus_addr = "0.0.0.0:9179"#' \
+  config.toml
+```
+
+The `edge` profile already ships both values in their container form, so
+starting from `--init-config edge` needs no such edit.
 
 ```bash
 docker run -d --name rustbgpd \
   -v "$(pwd)/config.toml":/etc/rustbgpd/config.template.toml:ro \
   -v rustbgpd-state:/var/lib/rustbgpd \
   -p 179:179 -p 9179:9179 \
+  --ulimit nofile=65536:524288 \
   rustbgpd \
   /bin/sh -c 'cp -n /etc/rustbgpd/config.template.toml /var/lib/rustbgpd/config.toml && exec rustbgpd /var/lib/rustbgpd/config.toml'
 ```
+
+`--ulimit` is required, not tuning: the Docker default soft `nofile` is 1024,
+which `rbgp doctor` fails outright because peers exhaust file descriptors at
+scale.
+
+Verify from the host over the published metrics port, and drive `rbgp` with
+`docker exec` — the gRPC socket is a Unix socket inside the container, and the
+runtime image is the only place an `rbgp` binary exists:
+
+```bash
+curl -fsS http://127.0.0.1:9179/livez    # ok
+curl -fsS http://127.0.0.1:9179/readyz   # ready
+
+docker exec rustbgpd rbgp health
+docker exec rustbgpd rbgp summary
+docker exec rustbgpd rbgp doctor
+```
+
+No `RUSTBGPD_ADDR` is needed: after the `sed`, the socket is at the CLI's
+default `unix:///var/lib/rustbgpd/grpc.sock`.
+
+Because the state directory now *is* the mounted volume, a `docker restart`
+keeps the gRPC socket path, `config-history/`, the graceful-restart marker,
+crash reports, and the event DB — not just the copied `config.toml`.
 
 The config is seeded from a read-only template into the writable state volume
 rather than bind-mounted in place. Config persistence rewrites the file with a

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -119,15 +119,17 @@ GHCR. Three tag flavors are available per the
 
 | Tag | Resolves to | Updates on |
 |-----|-------------|------------|
-| `:0.45.0` | exact version | nothing (immutable) |
-| `:0.45` | latest patch in the 0.45 minor | each 0.45.x release |
+| `:X.Y.Z` | exact version | nothing (immutable) |
+| `:X.Y` | latest patch in the X.Y minor | each X.Y.z release |
 | `:latest` | latest non-prerelease release | each minor or patch release |
 
 Major-minor is the usual operator default — auto-receives bug-fix
-releases but pins against minor-version churn:
+releases but pins against minor-version churn. The examples in this
+document use `:latest` so they stay copy-pasteable across releases;
+substitute the major-minor tag of the series you standardize on:
 
 ```sh
-docker pull ghcr.io/lance0/rustbgpd:0.45
+docker pull ghcr.io/lance0/rustbgpd:latest
 ```
 
 The published image is the Dockerfile's default `runtime` target:
@@ -302,19 +304,39 @@ For your own deployment:
 
 - **State**: mount a volume at the daemon's `runtime_state_dir` so the
   GR restart marker and FIB ownership receipt survive container
-  restarts:
+  restarts. The daemon runs as uid/gid 999 and rewrites its config in
+  place, so both host directories must be owned by that uid and the
+  config must already exist — the image's default command is
+  `rustbgpd /etc/rustbgpd/config.toml` and it will not create one:
 
   ```sh
+  # One-time host prep.
+  sudo install -d -o 999 -g 999 /etc/rustbgpd /var/lib/rustbgpd
+  docker run --rm ghcr.io/lance0/rustbgpd:latest \
+    rustbgpd --init-config edge --stdout > config.toml
+  # Edit config.toml for your ASN, router ID, peers, and policy.
+  sudo install -o 999 -g 999 -m 0600 config.toml /etc/rustbgpd/config.toml
+
   docker run --rm -d \
     --name rustbgpd \
     -v /etc/rustbgpd:/etc/rustbgpd \
     -v /var/lib/rustbgpd:/var/lib/rustbgpd \
     -p 179:179 \
     -p 9179:9179 \
+    --ulimit nofile=65536:524288 \
     --cap-add=NET_BIND_SERVICE \
     --cap-add=NET_ADMIN \
-    ghcr.io/lance0/rustbgpd:0.45
+    ghcr.io/lance0/rustbgpd:latest
   ```
+
+  The `edge` profile is used because its `runtime_state_dir`,
+  `grpc_uds` path, and `0.0.0.0` metrics bind are already the container
+  forms; the `lab` profile's `/tmp` state directory and `127.0.0.1`
+  metrics bind both need editing first.
+
+- **File descriptors**: `--ulimit nofile` is required, not tuning. The
+  Docker default soft limit is 1024, well under the 4096 floor
+  `rbgp doctor` enforces, and peers exhaust descriptors at scale.
 
 - **Writable config directory**: mount `/etc/rustbgpd` read-write and
   make it owned by the daemon user (`chown` the host directory to the

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -35,7 +35,7 @@ restart:
 
 ```bash
 docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 \
-  neighbor 10.99.0.30 add --remote-as 65003
+  neighbor 10.99.0.30 add --remote-asn 65003
 docker compose exec rustbgpd cat /var/lib/rustbgpd/config.toml
 ```
 

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -49,6 +49,13 @@ services:
       - "127.0.0.1:9179:9179"     # Prometheus metrics
     cap_add:
       - NET_BIND_SERVICE
+    # Docker's default soft nofile limit is 1024, under the 4096 floor
+    # `rbgp doctor` enforces — a peer costs sockets plus per-session
+    # handles, so the default fails the first doctor run out of the box.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 524288
 
   frr:
     image: quay.io/frrouting/frr:10.3.1


### PR DESCRIPTION
Every container instruction in the quickstart and deployment guides was
verified against the shipped runtime image (`docker build -t rustbgpd:verify .`,
default target). Each item below failed as printed and now passes.

## 1. QUICKSTART Docker standalone could not be verified

Step 2 generates a config from the `lab` profile, which sets
`prometheus_addr = "127.0.0.1:9179"`. The standalone block then published
`-p 9179:9179`, which cannot reach a container-loopback bind, so both
documented probes failed. The section also gave no working way to reach
`rbgp`: the `RUSTBGPD_ADDR` value from step 4 names a socket inside the
container, and the runtime image is the only place an `rbgp` binary exists.

**Chosen fix: bind `0.0.0.0` for metrics, and route `rbgp` through
`docker exec`.** The two are not alternatives — each surface only has one
workable answer. The runtime image ships no HTTP client (no `curl`, no
`wget`), so a metrics probe can only come from the host, which requires the
`0.0.0.0` bind; and `rbgp` speaks to a Unix socket with no host-side binary
to run, so it can only be driven with `docker exec`. This also matches the
Compose starter, which already gets both right.

The adaptation is two `sed` expressions on the generated config rather than a
change to the `lab` profile itself: `lab` is documented as a host profile, and
the `edge` profile already ships both values in their container form.

## 2. The state volume held no runtime state

`-v rustbgpd-state:/var/lib/rustbgpd` combined with `lab`'s
`runtime_state_dir = "/tmp/rustbgpd"` persisted only the copied `config.toml`.
The gRPC socket, `config-history/`, the GR marker, crash reports, and the
event DB all lived in the ephemeral `/tmp/rustbgpd`, contradicting the
deployment guide's instruction to mount a volume at `runtime_state_dir`.

The same `sed` rewrites `/tmp/rustbgpd` to `/var/lib/rustbgpd` throughout,
which covers both `runtime_state_dir` and the `grpc_uds` path. A side benefit:
the socket then lands on the CLI's default address, so no `RUSTBGPD_ADDR` is
needed inside the container.

## 3. The deployment guide's `docker run` could not persist

The daemon runs as uid 999 and rewrites its config in place. Against a host
`/etc/rustbgpd` not owned by that uid the daemon exits non-zero, and the
example never said a `config.toml` had to exist first — the image's default
command is `rustbgpd /etc/rustbgpd/config.toml` and it will not create one.
The ownership requirement was only in prose *below* the command. Both are now
part of the copy-pasteable block.

## 4. Rejected flag in the Compose example

`--remote-as` is not accepted; the CLI suggests `--remote-asn`.

## 5. `nofile` was 1024 on every shipped Docker path

Nothing in the repo set `--ulimit nofile` or `ulimits:`, so the first
`rbgp doctor` a new operator ran exited 2 on the rlimit check. Set to
`65536:524288` in the Compose service and in both documented `docker run`
invocations. The doctor check itself is unchanged.

## 6. Stale image tags

`:0.45` and `:0.51.0` replaced with forms that do not re-stale each release:
the tag table now describes flavors as `:X.Y.Z` / `:X.Y` / `:latest`, and the
runnable examples use `:latest` with the major-minor pinning advice kept as
prose.

## Verification

Corrected instructions executed verbatim against `rustbgpd:verify`.

Standalone (items 1, 2, 5, 6):

```
$ curl -fsS http://127.0.0.1:9179/livez     -> ok
$ curl -fsS http://127.0.0.1:9179/readyz    -> ready
$ docker exec rustbgpd rbgp health          -> Status: healthy
$ docker exec rustbgpd rbgp doctor          -> exit 0
                        ok  daemon pid 1 rlimit nofile soft 65536 hard 524288: ok
$ docker exec rustbgpd ls -1 /var/lib/rustbgpd   # after docker restart
  config-history  config.toml  gr-restart.toml  grpc.sock
$ docker exec rustbgpd ls -1a /tmp          -> empty
```

Deployment `docker run` (item 3), before and after the ownership prep:

```
before: exit 1
  "runtime-state directory /var/lib/rustbgpd has unsafe type, owner, or mode
   (is_dir=true, uid=1000, expected_uid=999, mode=775)"
  "failed to bind UDS listener /var/lib/rustbgpd/grpc.sock: Permission denied"

after:  running=true, rbgp health -> healthy, rbgp doctor -> exit 0
        rbgp neighbor 10.0.0.5 add --remote-asn 65005 -> "Neighbor 10.0.0.5 added"
        grep -c 10.0.0.5 /etc/rustbgpd/config.toml -> 1   (persisted to the host mount)
```

Compose (items 4, 5):

```
$ docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 \
    neighbor 10.99.0.30 add --remote-asn 65003   -> "Neighbor 10.99.0.30 added", exit 0
$ docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 doctor -> exit 0
                        ok  daemon pid 1 rlimit nofile soft 65536 hard 524288: ok
$ docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 neighbor
  10.99.0.20 65002 Established 00:00:32 7 0 frr-peer
```

Gates: `cargo fmt --all -- --check` 0, `cargo clippy --workspace --all-targets
-- -D warnings` 0, `cargo test --workspace` 0, `cargo doc --workspace
--no-deps` 0.
