### PR TITLE
Guard the fuzz toolchain pin against silent drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,13 @@ jobs:
         run: |
           python3 -m unittest -v scripts/test_check_fuzz_target_inventory.py
           python3 scripts/check_fuzz_target_inventory.py
+      # A reintroduced floating toolchain stays invisible until an upstream
+      # compiler break takes the scheduled campaign down, and the failure then
+      # reads as if it came from this repository.
+      - name: Prove every fuzz-toolchain consumer reads the reviewed pin
+        run: |
+          python3 -m unittest -v scripts/test_check_fuzz_toolchain_pin.py
+          python3 scripts/check_fuzz_toolchain_pin.py
       - name: Install receipt-tool dependencies
         run: |
           sudo apt-get update

--- a/scripts/check_fuzz_toolchain_pin.py
+++ b/scripts/check_fuzz_toolchain_pin.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Fail closed when a fuzz-toolchain consumer stops reading the reviewed pin.
+
+`fuzz/rust-nightly.txt` names the single reviewed nightly. The scheduled
+campaign, the OSS-Fuzz image, and the ClusterFuzzLite image all install from
+it. Nothing else stops an edit from reintroducing a floating toolchain, and
+the regression stays invisible until an upstream compiler break takes the
+campaign down and the failure reads as if it came from this repository.
+
+Consumers are discovered from the tracked tree rather than a maintained list,
+so a fourth integration is covered the day it lands instead of passing
+vacuously. An empty discovery set is itself a failure: a guard that cannot
+fail is worse than no guard.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PIN_PATH = "fuzz/rust-nightly.txt"
+
+# Prose cannot install a toolchain, and the pin file is the source of truth
+# rather than a consumer of it.
+SKIPPED_SUFFIXES = frozenset({".md"})
+
+# This guard and its mutation proofs quote sample toolchain selections as
+# data. They describe consumers instead of being ones, so they are the only
+# paths exempt from discovery.
+SKIPPED_PATHS = frozenset(
+    {
+        PIN_PATH,
+        "scripts/check_fuzz_toolchain_pin.py",
+        "scripts/test_check_fuzz_toolchain_pin.py",
+    }
+)
+
+# A consumer is a file that both lives on a fuzzing path and selects a Rust
+# toolchain. Either signal alone sweeps in inventory checks and unrelated
+# build scripts.
+FUZZ_MARKER = re.compile(r"cargo[-\s]+fuzz")
+TOOLCHAIN_MARKERS = (
+    re.compile(r"RUSTUP_TOOLCHAIN"),
+    re.compile(r"rustup\s+toolchain\s+install"),
+    re.compile(r"dtolnay/rust-toolchain"),
+    re.compile(r"""cargo\s+["']?\+"""),
+)
+
+# Each rule matches a toolchain selection that does not come from the pin.
+# `dtolnay/rust-toolchain@master` plus an expression-valued `toolchain:` input
+# is the sanctioned workflow form; `cargo "+$var"` is a pin-derived selector.
+VIOLATION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"dtolnay/rust-toolchain@(?!master(?:\b|$))\S+"),
+        "selects a toolchain in the action ref; use "
+        "dtolnay/rust-toolchain@master and pass the pinned value as its "
+        "toolchain input",
+    ),
+    (
+        re.compile(r"^\s*toolchain:[ \t]*(?!\$\{\{)\S+"),
+        f"hardcodes a toolchain input; pass the value read from {PIN_PATH}",
+    ),
+    (
+        re.compile(r"""cargo\s+["']?\+(?!\$)[^\s"']+"""),
+        "overrides the pin with an explicit cargo toolchain selector; export "
+        f"RUSTUP_TOOLCHAIN from {PIN_PATH} instead",
+    ),
+    (
+        re.compile(r"nightly-\d{4}-\d{2}-\d{2}"),
+        f"hardcodes a nightly date; read it from {PIN_PATH}",
+    ),
+)
+
+
+class PinGuardError(RuntimeError):
+    """The fuzz-toolchain consumers could not be enumerated."""
+
+
+def tracked_files() -> list[Path]:
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as error:
+        raise PinGuardError(f"cannot list tracked files: {error}")
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"git ls-files exited {result.returncode}"
+        raise PinGuardError(f"cannot list tracked files: {detail}")
+    paths = [ROOT / name for name in result.stdout.split("\0") if name]
+    if not paths:
+        raise PinGuardError("cannot list tracked files: the tracked tree is empty")
+    return paths
+
+
+def discover_consumers() -> dict[str, str]:
+    """Map each discovered fuzz-toolchain consumer to its text."""
+    consumers: dict[str, str] = {}
+    for path in tracked_files():
+        relative = path.relative_to(ROOT).as_posix()
+        if relative in SKIPPED_PATHS or path.suffix in SKIPPED_SUFFIXES:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if not FUZZ_MARKER.search(text):
+            continue
+        if any(marker.search(text) for marker in TOOLCHAIN_MARKERS):
+            consumers[relative] = text
+    if not consumers:
+        raise PinGuardError(
+            "no fuzz-toolchain consumer was discovered, so the walk is broken: "
+            "the scheduled campaign and the hosted builder images each select "
+            "a Rust toolchain on a fuzzing path"
+        )
+    return dict(sorted(consumers.items()))
+
+
+def audit_consumer(relative: str, text: str) -> list[str]:
+    """Report every way `relative` stops taking its toolchain from the pin."""
+    failures: list[str] = []
+    if PIN_PATH not in text:
+        failures.append(
+            f"{relative} selects a Rust toolchain for fuzzing but no longer "
+            f"reads {PIN_PATH}"
+        )
+    for number, line in enumerate(text.splitlines(), start=1):
+        for pattern, reason in VIOLATION_RULES:
+            match = pattern.search(line)
+            if match:
+                failures.append(f"{relative}:{number} {reason}: {match.group(0)!r}")
+    return failures
+
+
+def main() -> int:
+    try:
+        consumers = discover_consumers()
+    except PinGuardError as error:
+        print(f"fuzz toolchain pin check failed: {error}", file=sys.stderr)
+        return 1
+
+    failures = [
+        failure
+        for relative, text in consumers.items()
+        for failure in audit_consumer(relative, text)
+    ]
+    if failures:
+        for failure in failures:
+            print(f"fuzz toolchain pin check failed: {failure}", file=sys.stderr)
+        return 1
+
+    print(
+        f"fuzz toolchain pin check passed: {len(consumers)} consumers take the "
+        f"toolchain from {PIN_PATH}"
+    )
+    for relative in consumers:
+        print(f"  {relative}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_fuzz_toolchain_pin.py
+++ b/scripts/test_check_fuzz_toolchain_pin.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Mutation proofs for the fail-closed fuzz-toolchain pin gate."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import check_fuzz_toolchain_pin as guard
+
+
+PIN_LINE = f'toolchain="$(cat {guard.PIN_PATH})"'
+
+FLOATING_SELECTIONS = (
+    "      - uses: dtolnay/rust-toolchain@nightly",
+    "      - uses: dtolnay/rust-toolchain@stable",
+    "      - uses: dtolnay/rust-toolchain@beta",
+    "      - uses: dtolnay/rust-toolchain@nightly-2026-07-07",
+    "          toolchain: nightly",
+    "          toolchain: nightly-2026-07-07",
+    "          cargo +nightly fuzz list",
+    "          cargo +nightly-2026-07-07 fuzz run decode_update",
+    '          RUSTUP_TOOLCHAIN=nightly-2026-07-07',
+)
+
+PIN_DERIVED_SELECTIONS = (
+    "      - uses: dtolnay/rust-toolchain@master",
+    "          toolchain: ${{ steps.nightly.outputs.toolchain }}",
+    '    && cargo "+$toolchain" install cargo-fuzz --version 0.13.2 --locked',
+    '        cargo +"$TOOLCHAIN" fuzz build',
+    "        export RUSTUP_TOOLCHAIN",
+)
+
+
+class FuzzToolchainPinTests(unittest.TestCase):
+    def test_repository_consumers_are_discovered_and_clean(self) -> None:
+        consumers = guard.discover_consumers()
+        self.assertTrue(consumers, "consumer discovery must not be empty")
+        self.assertIn(".github/workflows/fuzz.yml", consumers)
+        for relative, text in consumers.items():
+            with self.subTest(consumer=relative):
+                self.assertEqual(guard.audit_consumer(relative, text), [])
+
+    def test_dropped_pin_reference_is_rejected(self) -> None:
+        failures = guard.audit_consumer(
+            "fuzz/oss-fuzz/Dockerfile",
+            'RUN rustup toolchain install "$toolchain" --profile minimal\n',
+        )
+        self.assertTrue(any("no longer reads" in failure for failure in failures))
+
+    def test_every_floating_selection_is_rejected(self) -> None:
+        for line in FLOATING_SELECTIONS:
+            with self.subTest(line=line):
+                failures = guard.audit_consumer(
+                    ".github/workflows/fuzz.yml", f"{PIN_LINE}\n{line}\n"
+                )
+                self.assertTrue(failures, f"{line!r} must be rejected")
+
+    def test_pin_derived_selections_are_accepted(self) -> None:
+        for line in PIN_DERIVED_SELECTIONS:
+            with self.subTest(line=line):
+                failures = guard.audit_consumer(
+                    ".github/workflows/fuzz.yml", f"{PIN_LINE}\n{line}\n"
+                )
+                self.assertEqual(failures, [], f"{line!r} must be accepted")
+
+    def test_broken_walk_fails_loudly(self) -> None:
+        original = guard.tracked_files
+        guard.tracked_files = lambda: []
+        try:
+            with self.assertRaisesRegex(guard.PinGuardError, "walk is broken"):
+                guard.discover_consumers()
+        finally:
+            guard.tracked_files = original
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`fuzz/rust-nightly.txt` names the single reviewed nightly. Three integrations
install from it: the scheduled campaign (`.github/workflows/fuzz.yml`), the
OSS-Fuzz build (`fuzz/build-fuzzers.sh`, `fuzz/oss-fuzz/Dockerfile`), and
ClusterFuzzLite (`.clusterfuzzlite/Dockerfile`).

Nothing prevented the next edit from reintroducing a floating
`dtolnay/rust-toolchain@nightly` or a `cargo +nightly` selector that overrides
the pin. That regression stays invisible until an upstream compiler break takes
the campaign down, and the failure then reads as if it came from this
repository — which is how the original drift was found.

`scripts/check_fuzz_toolchain_pin.py` runs on every push from `ci.yml`:

- **Consumers are discovered from the tracked tree**, not from a list in the
  script. A file is a consumer when it carries both a fuzzing-path marker
  (`cargo fuzz` / `cargo-fuzz`) and a toolchain-selection marker
  (`RUSTUP_TOOLCHAIN`, `rustup toolchain install`, `dtolnay/rust-toolchain`,
  `cargo +…`). A fourth integration is therefore covered the day it lands
  rather than passing vacuously. Markdown is excluded because prose cannot
  install a toolchain; the pin file and this check's own fixtures are the only
  named exemptions.
- **An empty discovery set is a failure**, at both the tracked-file walk and
  the consumer-match layer. A guard that cannot fail is worse than no guard.
- Every discovered consumer must reference `fuzz/rust-nightly.txt`, and
  floating action refs, literal `toolchain:` inputs, explicit `cargo +<name>`
  selectors, and hardcoded `nightly-YYYY-MM-DD` dates are each rejected.
  `dtolnay/rust-toolchain@master` with an expression-valued input and
  `cargo "+$var"` remain accepted as pin-derived forms.

Against the current tree the check discovers exactly the four consumer files
and passes.

## Red proofs

Each mutation applied alone, guard run, tree restored:

| Mutation | Exit |
| --- | --- |
| `dtolnay/rust-toolchain@master` → `@nightly` in the fuzz workflow | 1 |
| single `cargo +nightly fuzz list` reintroduced | 1 |
| pin reference removed from `.clusterfuzzlite/Dockerfile` | 1 |
| tracked-file walk broken (discovery finds zero files) | 1 |
| fuzz marker broken (walk works, zero consumers matched) | 1 |

`scripts/test_check_fuzz_toolchain_pin.py` holds the same proofs as unit
assertions, matching the existing inventory-gate pattern.

## Follow-up, not in this change

`docs/FUZZING.md:124` still says the pin is installed by "both hosted
builders". There are now three consumers of the pin.