### PR TITLE
docs: drop the nonexistent rustbgpd --config flag from two doc sites

### DIFF
--- a/docs/cookbook/rr-pair-day2.md
+++ b/docs/cookbook/rr-pair-day2.md
@@ -41,8 +41,9 @@ rbgp neighbor 10.0.0.42 add --remote-asn 65000 --description "new-client"
 rbgp dynamic-neighbor add 10.0.9.0/24 --peer-group rr-clients
 ```
 
-Both persist to the config file (when the daemon was started with
-`--config`) before the RPC returns. Verify with `rbgp neighbor --wide`
+Both persist to the daemon's config file — the `CONFIG_PATH` argument,
+or `/etc/rustbgpd/config.toml` when it is omitted — before the RPC
+returns. Verify with `rbgp neighbor --wide`
 — the `RRC` column marks reflector clients. Uniform clients join the
 existing update group automatically; there is nothing to tune.
 

--- a/docs/evpn-vtep-troubleshooting.md
+++ b/docs/evpn-vtep-troubleshooting.md
@@ -89,7 +89,7 @@ Expected signals:
 5. Enable targeted debug logging for the Linux classifier:
 
    ```bash
-   RUST_LOG=rustbgpd_evpn_linux=debug,rustbgpd=info rustbgpd --config config.toml
+   RUST_LOG=rustbgpd_evpn_linux=debug,rustbgpd=info rustbgpd config.toml
    ```
 
    Look for local-MAC classifier messages and cache misses. On legacy


### PR DESCRIPTION
`rustbgpd` has no `--config` flag. It takes a positional `CONFIG_PATH`
that defaults to `/etc/rustbgpd/config.toml` and is always handed to the
runtime, so there is also no mode in which runtime changes stay in
memory.

Two doc sites still described the flag:

- `docs/evpn-vtep-troubleshooting.md` — a copy-pasteable debug-logging
  command that exits on argument parsing instead of starting a daemon.
  Corrected to the positional form and verified against the built
  binary: the command now reaches config load and runs.
- `docs/cookbook/rr-pair-day2.md` — runtime neighbor and
  dynamic-neighbor persistence was qualified with "when the daemon was
  started with `--config`". Persistence is unconditional, so the
  qualifier is dropped and the sentence names where the write lands.

Docs-only; no code or behavior change.

Gates: `cargo fmt --all -- --check` 0, `cargo clippy --workspace
--all-targets -- -D warnings` 0, `cargo test --workspace` 0, `cargo doc
--workspace --no-deps` 0.