### PR TITLE
Announce canonical config rewrites and stop doctor flagging them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -724,6 +724,53 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A config file the daemon has rewritten now says so.** The first
+  runtime mutation — `rbgp neighbor add`, a config transaction, a gNMI
+  `Set` — rewrites the config file in canonical form, and always has:
+  comments and key order from the previous file are gone and defaulted
+  fields are written out explicitly. Nothing on disk said that had
+  happened, so an annotated starter config could come back with its
+  comments silently dropped, including the `DELIBERATE DEVELOPMENT
+  POSTURE: PERMIT ALL, BOTH DIRECTIONS` banner the lab starter carries.
+  Every file the daemon writes now opens with a short header stating
+  that it is maintained by rustbgpd, that the previous file's comments
+  and formatting are not preserved, and that an annotated copy belongs
+  in version control. The header carries no version and no timestamp, so
+  it does not churn the file or add noise to config-history diffs, and
+  rewriting the file repeatedly leaves exactly one of them. Nothing else
+  about the write changed — same canonicalization, same crash-safe
+  atomic write, same `0600` mode.
+
+- **The daemon now states its eBGP policy posture in the log at
+  startup.** `rustbgpd --check` framed this before deployment, but an
+  operator whose banner was flattened by a runtime rewrite had nowhere
+  left to see it. When any eBGP neighbor resolves no explicit policy,
+  startup logs one line naming how many, and whether those directions
+  are unfiltered or are carrying no routes under `ebgp_requires_policy`.
+
+- **`rbgp doctor` no longer reports the daemon's own config write as an
+  unapplied external edit.** The config-freshness check compared the
+  file's mtime against daemon process start, so any deployment following
+  the documented runtime-mutation workflow warned permanently —
+  `config … was modified after daemon pid 1 started — on-disk changes are
+  not applied` — about a change the daemon itself had made and applied.
+  Container deployments whose entrypoint seeds a config template after
+  the process starts hit the same false warning. A permanent yellow
+  trains operators to ignore yellow, which is the whole value of the
+  check. The daemon now records the config file's timestamp whenever it
+  reads or writes that file, and doctor judges against that record: a
+  daemon-authored write and a post-start template seed both read clean,
+  a genuine external edit still warns with the same validate-and-SIGHUP
+  advice, and a daemon that recorded nothing falls back to the previous
+  process-start comparison.
+
+- **Three gRPC errors no longer tell operators to pass a `--config` flag
+  that does not exist.** `config history`, config transactions, and
+  FIB-table CRUD each answered their unavailable case with "start
+  rustbgpd with `--config`"; the daemon takes its config path as a
+  positional argument and rejects that flag. Each now states the real
+  condition instead.
+
 - **A rejected runtime mutation no longer causes any externally visible
   change.** When config persistence failed — an unwritable config
   directory, a read-only mount, a full filesystem — every persisted

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -1102,27 +1102,58 @@ fn mtime_unix(path: &Path) -> Option<u64> {
         .map(|d| d.as_secs())
 }
 
-/// Pure freshness verdict: the config file was modified after the daemon
-/// started, so on-disk edits are pending until a reload.
+/// File the daemon writes under `runtime_state_dir` holding the config file's
+/// mtime as of its own last read or write of that file. Written by the
+/// daemon's `config_persister` — keep the name in step with it.
+const LAST_PERSIST_FILE: &str = "config-last-persist";
+
+/// The daemon's own record of the config file as it last read or wrote it.
+fn last_persist_unix(state_dir: &Path) -> Option<u64> {
+    fs::read_to_string(state_dir.join(LAST_PERSIST_FILE))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
+/// The timestamp a config-file mtime is judged against.
+///
+/// Process start is the wrong reference: the daemon rewrites its own config
+/// file on every runtime mutation (`rbgp neighbor add`, a config transaction,
+/// gNMI Set), and a container entrypoint may seed the file after the process
+/// has started. Both leave an mtime past process start with nothing pending,
+/// so the check warned permanently on every deployment that used the
+/// documented runtime-mutation workflow.
+///
+/// The daemon's own last-persist marker is the honest reference — it advances
+/// exactly when the daemon reads or writes the file, and not when an operator
+/// edits it. Process start remains the fallback for a daemon that wrote no
+/// marker (no writable state dir, or an older build).
+fn config_freshness_reference(state_dir: &Path, pid: u32) -> Option<u64> {
+    last_persist_unix(state_dir).or_else(|| proc_start_unix(pid))
+}
+
+/// Pure freshness verdict: the config file was modified after the daemon last
+/// read or wrote it, so on-disk edits are pending until a reload.
 fn config_freshness_check(
     pid: u32,
     config_path: &str,
     config_mtime_unix: u64,
-    daemon_start_unix: u64,
+    daemon_sync_unix: u64,
 ) -> Check {
-    let (status, detail) = if config_mtime_unix > daemon_start_unix {
+    let (status, detail) = if config_mtime_unix > daemon_sync_unix {
         (
             CheckStatus::Warn,
             format!(
-                "config {config_path} was modified after daemon pid {pid} started — on-disk \
-                 changes are not applied; validate with `rustbgpd --check {config_path}` and \
-                 reload with SIGHUP (systemctl reload rustbgpd)"
+                "config {config_path} was modified after daemon pid {pid} last applied it — \
+                 on-disk changes are not applied; validate with `rustbgpd --check \
+                 {config_path}` and reload with SIGHUP (systemctl reload rustbgpd)"
             ),
         )
     } else {
         (
             CheckStatus::Ok,
-            format!("config {config_path} unchanged since daemon pid {pid} started"),
+            format!("config {config_path} matches what daemon pid {pid} last applied"),
         )
     };
     Check {
@@ -1564,14 +1595,19 @@ pub(crate) async fn run(
     }
 
     // ---- config freshness (local daemon processes only) ---------------
+    let freshness_state_dir = PathBuf::from(state_dir.as_deref().unwrap_or(DEFAULT_STATE_DIR));
     for (pid, _) in &daemon_limits {
         let Some(config_path) = proc_cmdline_config_path(*pid) else {
             continue;
         };
-        let (Some(mtime), Some(start)) = (mtime_unix(&config_path), proc_start_unix(*pid)) else {
+        let (Some(mtime), Some(reference)) = (
+            mtime_unix(&config_path),
+            config_freshness_reference(&freshness_state_dir, *pid),
+        ) else {
             continue;
         };
-        let check = config_freshness_check(*pid, &config_path.display().to_string(), mtime, start);
+        let check =
+            config_freshness_check(*pid, &config_path.display().to_string(), mtime, reference);
         reporter.record(check.name, check.status, check.detail);
     }
 
@@ -2314,6 +2350,61 @@ paths = ["x"]
         assert!(stale.detail.contains("--check"), "{}", stale.detail);
         let fresh = config_freshness_check(7, "/etc/rustbgpd/config.toml", 1_000, 1_000);
         assert_eq!(fresh.status, CheckStatus::Ok);
+    }
+
+    /// The regression: the daemon rewrites its own config file on every
+    /// runtime mutation, so a mtime past process start is not evidence of an
+    /// operator edit. The check must judge against the daemon's own
+    /// last-persist marker — and must still warn when the file really did
+    /// move past it.
+    #[test]
+    fn freshness_reference_prefers_the_daemon_last_persist_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(LAST_PERSIST_FILE), "2000\n").unwrap();
+
+        // The marker wins over process start: an unusable pid cannot
+        // contribute a fallback, so the reference can only be the marker.
+        assert_eq!(
+            config_freshness_reference(dir.path(), u32::MAX),
+            Some(2_000)
+        );
+
+        // A daemon-authored write leaves the config mtime AT the marker.
+        let after_daemon_write =
+            config_freshness_check(1, "/var/lib/rustbgpd/config.toml", 2_000, 2_000);
+        assert_eq!(
+            after_daemon_write.status,
+            CheckStatus::Ok,
+            "{}",
+            after_daemon_write.detail
+        );
+
+        // A genuine external edit lands past it and must still be yellow.
+        let after_external_edit =
+            config_freshness_check(1, "/var/lib/rustbgpd/config.toml", 2_001, 2_000);
+        assert_eq!(
+            after_external_edit.status,
+            CheckStatus::Warn,
+            "{}",
+            after_external_edit.detail
+        );
+        assert!(
+            after_external_edit.detail.contains("SIGHUP"),
+            "{}",
+            after_external_edit.detail
+        );
+    }
+
+    /// No marker (no writable state dir, or an older daemon) degrades to the
+    /// previous behaviour rather than skipping the check.
+    #[test]
+    fn freshness_reference_falls_back_to_process_start_without_a_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(last_persist_unix(dir.path()), None);
+        assert_eq!(
+            config_freshness_reference(dir.path(), std::process::id()),
+            proc_start_unix(std::process::id())
+        );
     }
 
     // ---- bundle integration ------------------------------------------

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3332,6 +3332,46 @@ impl RuntimeSnapshotKey {
 /// live credential.
 pub const REDACTED_SECRET: &str = "<redacted>";
 
+/// Header the daemon writes at the top of every config file it maintains.
+///
+/// A runtime mutation rewrites the operator's file in canonical form: the
+/// comments and formatting they wrote are gone and defaulted fields are
+/// materialized. The file itself is the only place that fact is guaranteed to
+/// reach whoever opens it next, so it says so.
+///
+/// Deliberately carries no version and no timestamp — either would change the
+/// bytes on every write, defeating the applied-config history's content-hash
+/// dedup and adding noise to every history diff.
+pub const PERSISTED_CONFIG_HEADER: &str = "\
+# This file is maintained by rustbgpd. Runtime configuration changes
+# rewrite it in canonical form: comments and formatting from the
+# previous file are not preserved, and defaulted fields are written
+# out explicitly. Keep an annotated copy under version control if you
+# need one.
+";
+
+/// The exact document the daemon writes for `config`:
+/// [`PERSISTED_CONFIG_HEADER`] followed by the canonical TOML rendering.
+///
+/// Every durable config write and every applied-config history entry goes
+/// through here, so a new persist call site cannot omit the header.
+///
+/// The header cannot be duplicated by construction: the input is a `Config`,
+/// never a document. Re-persisting a file that already carries a header
+/// regenerates the whole document from the parsed struct — TOML comments do
+/// not survive parsing — rather than prepending to existing text, so there is
+/// no strip step for a slightly different prior header to defeat.
+///
+/// # Errors
+///
+/// Returns the TOML serialization error.
+pub fn persisted_config_document(config: &Config) -> Result<String, toml::ser::Error> {
+    Ok(format!(
+        "{PERSISTED_CONFIG_HEADER}\n{}",
+        toml::to_string_pretty(config)?
+    ))
+}
+
 impl Config {
     /// The running post-defaults config for `rbgp config effective`:
     /// a clone of this config with per-neighbor session defaults

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -12190,6 +12190,52 @@ fn runtime_snapshot_token_is_stable_and_changes_with_config() {
     assert!(token_a.starts_with("kv1:"));
 }
 
+/// The maintenance header belongs to files the daemon writes, and nowhere
+/// else. Two neighbouring canonical renderings sit right next to the persist
+/// path and must stay clean of it: the commit-confirm snapshot token and the
+/// `GetEffectiveConfig` response body, which is an API payload, not a file.
+///
+/// The header is inert comment text, so everything derived from a persisted
+/// file must be identical to the same thing derived from a header-free
+/// rendering — a header that stopped being inert, or that leaked into a
+/// derived surface, shows up here.
+#[test]
+fn persisted_config_header_stays_out_of_the_token_and_the_effective_dump() {
+    let config = parse(valid_toml()).unwrap();
+    let document = persisted_config_document(&config).unwrap();
+    assert!(document.starts_with(PERSISTED_CONFIG_HEADER));
+
+    let bare = toml::to_string_pretty(&config).unwrap();
+    assert!(
+        !bare.contains("maintained by rustbgpd"),
+        "the bare canonical rendering must carry no header"
+    );
+
+    // Same config, one document with the header and one without. Everything
+    // downstream must agree.
+    let from_persisted = Config::load_toml_with_diagnostics(&document, "persisted.toml")
+        .expect("the header must stay inert TOML that the loader ignores");
+    let from_bare = Config::load_toml_with_diagnostics(&bare, "bare.toml").unwrap();
+
+    let key = RuntimeSnapshotKey::random();
+    assert_eq!(
+        key.token(&from_persisted).unwrap(),
+        key.token(&from_bare).unwrap(),
+        "the snapshot token must follow the config, not the document it was read from"
+    );
+
+    let effective = from_persisted.effective_redacted_toml().unwrap();
+    assert_eq!(
+        effective,
+        from_bare.effective_redacted_toml().unwrap(),
+        "the effective dump must not vary with the file header"
+    );
+    assert!(
+        !effective.contains("maintained by rustbgpd"),
+        "the effective-config API response must not carry the file header:\n{effective}"
+    );
+}
+
 #[test]
 fn runtime_snapshot_token_changes_when_only_a_secret_rotates() {
     // The token hashes the full config, secrets included, so a bare secret

--- a/src/config_persister.rs
+++ b/src/config_persister.rs
@@ -766,4 +766,48 @@ log_format = "json"
              or doctor reads the daemon's own write as an external edit"
         );
     }
+
+    /// The marker filename is agreed on across two crates by name alone: the
+    /// daemon writes it, `rbgp doctor` reads it, and `crates/cli` cannot share
+    /// a constant with the daemon without an unnatural dependency.
+    ///
+    /// Nothing else holds the halves together. If either side is renamed,
+    /// doctor's read misses, the check falls back to comparing against process
+    /// start, and the permanent-warn defect returns — with both crates' own
+    /// tests still green, because each exercises only its own literal. So the
+    /// agreement is fenced here, the way the gRPC authz inventory fences its
+    /// own cross-artifact agreement.
+    #[test]
+    fn doctor_reads_the_marker_filename_the_persister_writes() {
+        const DOCTOR_SOURCE: &str = include_str!("../crates/cli/src/commands/doctor.rs");
+
+        // Extract the literal doctor actually assigns — never search the
+        // source for the current value. A containment check would still pass
+        // after the daemon's constant alone changed, which is precisely the
+        // drift that breaks the agreement.
+        let declared = DOCTOR_SOURCE
+            .lines()
+            .find_map(|line| {
+                line.trim_start()
+                    .strip_prefix("const LAST_PERSIST_FILE: &str = ")
+            })
+            .and_then(|rest| rest.trim_end().strip_suffix(';'))
+            .and_then(|literal| literal.strip_prefix('"'))
+            .and_then(|literal| literal.strip_suffix('"'));
+
+        // Its own step: a reformatted declaration must fail loudly here rather
+        // than leave the comparison below matching against nothing.
+        let declared = declared.expect(
+            "could not find `const LAST_PERSIST_FILE: &str = \"…\";` in \
+             crates/cli/src/commands/doctor.rs — if the declaration was \
+             reformatted, update this extraction; do not delete the check",
+        );
+
+        assert_eq!(
+            declared, LAST_PERSIST_FILE,
+            "`rbgp doctor` reads a different marker filename than the persister \
+             writes — the config-freshness check will silently fall back to \
+             process start and warn forever after the first runtime mutation"
+        );
+    }
 }

--- a/src/config_persister.rs
+++ b/src/config_persister.rs
@@ -12,7 +12,16 @@ use std::path::PathBuf;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{error, info, warn};
 
-use crate::config::{Config, Neighbor};
+use crate::config::{Config, Neighbor, persisted_config_document};
+
+/// File under `runtime_state_dir` recording the config file's mtime as of the
+/// daemon's last read or write of it.
+///
+/// `rbgp doctor`'s config-freshness check reads it to tell the daemon's own
+/// canonical rewrite from an operator's editor; without it the check compares
+/// against process start and warns forever after the first runtime mutation.
+/// The reader is `crates/cli/src/commands/doctor.rs` — keep the name in step.
+pub const LAST_PERSIST_FILE: &str = "config-last-persist";
 
 /// A mutation to apply to the persisted config.
 #[allow(dead_code)]
@@ -51,9 +60,10 @@ pub struct ConfigPersister {
     rx: mpsc::Receiver<ConfigMutation>,
     config_path: PathBuf,
     current: Config,
-    /// Applied-config history directory (`config_history` module). `None`
-    /// disables recording (unit tests, embedders without a state dir).
-    history_dir: Option<PathBuf>,
+    /// `runtime_state_dir`, the home of the applied-config history
+    /// (`config_history`) and the last-persist marker. `None` disables both
+    /// (unit tests, embedders without a state dir).
+    state_dir: Option<PathBuf>,
     /// Durably written but unpublished snapshot, awaiting commit or discard.
     staged: Option<(crate::confirm_journal::StagedWrite, Config, String)>,
 }
@@ -63,13 +73,13 @@ impl ConfigPersister {
         rx: mpsc::Receiver<ConfigMutation>,
         config_path: PathBuf,
         current: Config,
-        history_dir: Option<PathBuf>,
+        state_dir: Option<PathBuf>,
     ) -> Self {
         Self {
             rx,
             config_path,
             current,
-            history_dir,
+            state_dir,
             staged: None,
         }
     }
@@ -138,7 +148,7 @@ impl ConfigPersister {
         // A superseded stage is discarded, never published: its caller either
         // failed its apply or is gone.
         self.discard_staged();
-        let toml_str = toml::to_string_pretty(&new_config).map_err(std::io::Error::other)?;
+        let toml_str = persisted_config_document(&new_config).map_err(std::io::Error::other)?;
         let staged = crate::confirm_journal::stage_atomic(&self.config_path, toml_str.as_bytes())?;
         info!(
             path = %self.config_path.display(),
@@ -233,7 +243,7 @@ impl ConfigPersister {
     }
 
     fn persist(&self) -> std::io::Result<()> {
-        let toml_str = toml::to_string_pretty(&self.current).map_err(std::io::Error::other)?;
+        let toml_str = persisted_config_document(&self.current).map_err(std::io::Error::other)?;
 
         // Durable atomic write: temp file → fsync → rename → fsync parent dir.
         // Reuses the commit-confirm journal's proven primitive so a crash in the
@@ -246,12 +256,22 @@ impl ConfigPersister {
         Ok(())
     }
 
-    /// Best-effort applied-config history recording. A history failure must
-    /// never fail the persist that already succeeded — the config on disk is
-    /// authoritative; history is the rollback convenience layer.
+    /// Best-effort recording of an applied config: the rollback history entry
+    /// and the last-persist marker.
+    ///
+    /// Both are best-effort by design. A failure here must never fail the
+    /// persist that already succeeded — the config on disk is authoritative;
+    /// history is the rollback convenience layer and the marker is a hint for
+    /// `rbgp doctor`.
+    ///
+    /// Every point at which the daemon's view of the config file becomes
+    /// current — boot, every durable write, and a SIGHUP snapshot refresh —
+    /// already funnels here, which is why the marker is recorded here too
+    /// rather than at each call site.
     fn record_history(&self, toml_str: &str) {
-        if let Some(dir) = &self.history_dir
-            && let Err(error) = crate::config_history::record(dir, toml_str)
+        self.record_last_persist();
+        if let Some(dir) = self.history_dir()
+            && let Err(error) = crate::config_history::record(&dir, toml_str)
         {
             warn!(
                 dir = %dir.display(),
@@ -261,8 +281,47 @@ impl ConfigPersister {
         }
     }
 
+    fn history_dir(&self) -> Option<PathBuf> {
+        self.state_dir
+            .as_deref()
+            .map(crate::config_history::history_dir)
+    }
+
+    /// Record the config file's mtime as the daemon's own last-persist stamp.
+    ///
+    /// The value is the file's mtime rather than wall-clock now, so it
+    /// compares byte-for-byte against the mtime `rbgp doctor` reads from the
+    /// same file — no clock skew or rounding in between. A later external edit
+    /// necessarily carries a higher mtime and still warns.
+    fn record_last_persist(&self) {
+        let Some(dir) = &self.state_dir else {
+            return;
+        };
+        let Some(mtime) = std::fs::metadata(&self.config_path)
+            .and_then(|meta| meta.modified())
+            .ok()
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|since| since.as_secs())
+        else {
+            return;
+        };
+        let path = dir.join(LAST_PERSIST_FILE);
+        // A plain write is enough: a torn or missing marker only degrades the
+        // freshness check to comparing against process start, which is what it
+        // did before the marker existed.
+        if let Err(error) =
+            std::fs::create_dir_all(dir).and_then(|()| std::fs::write(&path, format!("{mtime}\n")))
+        {
+            warn!(
+                path = %path.display(),
+                error = %error,
+                "failed to record the config last-persist marker — `rbgp doctor` may report the daemon's own config write as an external edit"
+            );
+        }
+    }
+
     fn record_current_history(&self) {
-        match toml::to_string_pretty(&self.current) {
+        match persisted_config_document(&self.current) {
             Ok(toml_str) => self.record_history(&toml_str),
             Err(error) => warn!(
                 error = %error,
@@ -453,13 +512,14 @@ log_format = "json"
     async fn persister_records_history_at_boot_and_on_every_persist() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
-        let history = dir.path().join("config-history");
+        let state_dir = dir.path().to_path_buf();
+        let history = crate::config_history::history_dir(&state_dir);
         let config = minimal_config();
         std::fs::write(&path, toml::to_string_pretty(&config).unwrap()).unwrap();
 
         let (tx, rx) = mpsc::channel(16);
         let persister =
-            ConfigPersister::new(rx, path.clone(), config.clone(), Some(history.clone()));
+            ConfigPersister::new(rx, path.clone(), config.clone(), Some(state_dir.clone()));
         let handle = tokio::spawn(persister.run());
         tx.send(ConfigMutation::AddNeighbor(Box::new(test_neighbor(
             "10.0.0.2", 65002,
@@ -476,13 +536,13 @@ log_format = "json"
         let (_, newest) = crate::config_history::read_entry(&history, 0).unwrap();
         assert_eq!(newest, std::fs::read_to_string(&path).unwrap());
         let (_, previous) = crate::config_history::read_entry(&history, 1).unwrap();
-        assert_eq!(previous, toml::to_string_pretty(&config).unwrap());
+        assert_eq!(previous, persisted_config_document(&config).unwrap());
 
         // "Restart": a fresh persister over the same state boot-records the
         // unchanged config — dedup keeps history from growing.
         let restarted: Config = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         let (tx, rx) = mpsc::channel(16);
-        let persister = ConfigPersister::new(rx, path.clone(), restarted, Some(history.clone()));
+        let persister = ConfigPersister::new(rx, path.clone(), restarted, Some(state_dir.clone()));
         let handle = tokio::spawn(persister.run());
         drop(tx);
         handle.await.unwrap();
@@ -497,12 +557,13 @@ log_format = "json"
     fn refresh_snapshot_no_persist_records_validated_config_history() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
-        let history = dir.path().join("config-history");
+        let state_dir = dir.path().to_path_buf();
+        let history = crate::config_history::history_dir(&state_dir);
         let config = minimal_config();
         std::fs::write(&path, toml::to_string_pretty(&config).unwrap()).unwrap();
 
         let (_tx, rx) = mpsc::channel(1);
-        let mut persister = ConfigPersister::new(rx, path, config, Some(history.clone()));
+        let mut persister = ConfigPersister::new(rx, path, config, Some(state_dir));
         persister.record_current_history();
 
         let mut refreshed = minimal_config();
@@ -516,7 +577,7 @@ log_format = "json"
         let entries = crate::config_history::list(&history).unwrap();
         assert_eq!(entries.len(), 2);
         let newest = crate::config_history::read(&entries[0]).unwrap();
-        assert_eq!(newest, toml::to_string_pretty(&refreshed).unwrap());
+        assert_eq!(newest, persisted_config_document(&refreshed).unwrap());
     }
 
     #[tokio::test]
@@ -554,5 +615,155 @@ log_format = "json"
         );
         assert_eq!(reloaded.neighbors[0].address, "10.0.0.2");
         assert_eq!(reloaded.neighbors[1].address, "10.0.0.3");
+    }
+
+    /// The first runtime mutation rewrites the operator's file canonically:
+    /// their comments, their key order, and any posture banner they wrote are
+    /// gone. The file has to say so itself — and say it exactly once, however
+    /// many times it is rewritten.
+    #[tokio::test]
+    async fn persisted_config_carries_exactly_one_maintenance_header() {
+        use crate::config::PERSISTED_CONFIG_HEADER;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let config = minimal_config();
+        std::fs::write(&path, toml::to_string_pretty(&config).unwrap()).unwrap();
+
+        let (tx, rx) = mpsc::channel(16);
+        let persister = ConfigPersister::new(rx, path.clone(), config, None);
+        let handle = tokio::spawn(persister.run());
+        // Two durable writes, so a second header would have somewhere to land.
+        tx.send(ConfigMutation::AddNeighbor(Box::new(test_neighbor(
+            "10.0.0.2", 65002,
+        ))))
+        .await
+        .unwrap();
+        tx.send(ConfigMutation::AddNeighbor(Box::new(test_neighbor(
+            "10.0.0.3", 65003,
+        ))))
+        .await
+        .unwrap();
+        drop(tx);
+        handle.await.unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            written.starts_with(PERSISTED_CONFIG_HEADER),
+            "the header must be the first lines of the file, got:\n{written}"
+        );
+        assert_eq!(
+            written.matches(PERSISTED_CONFIG_HEADER).count(),
+            1,
+            "persisting twice must leave exactly one header, got:\n{written}"
+        );
+    }
+
+    /// A persisted file is a file the daemon must be able to boot from: it
+    /// loads through the same gate `rustbgpd --check` uses, and persisting it
+    /// again is byte-identical — the header does not accumulate and the body
+    /// does not drift.
+    #[tokio::test]
+    async fn persisted_config_round_trips_through_load_and_persist() {
+        use crate::config::PERSISTED_CONFIG_HEADER;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        // A config the daemon would really boot from: full validation, not
+        // bare deserialization, so the reload below exercises the same gate
+        // `rustbgpd --check` runs.
+        std::fs::write(
+            &path,
+            crate::test_support::tier_authorized_uds_test_config(
+                r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+"#,
+            ),
+        )
+        .unwrap();
+        let config = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+
+        let (tx, rx) = mpsc::channel(16);
+        let persister = ConfigPersister::new(rx, path.clone(), config, None);
+        let handle = tokio::spawn(persister.run());
+        tx.send(ConfigMutation::AddNeighbor(Box::new(test_neighbor(
+            "10.0.0.2", 65002,
+        ))))
+        .await
+        .unwrap();
+        drop(tx);
+        handle.await.unwrap();
+        let first = std::fs::read_to_string(&path).unwrap();
+
+        // `--check` and daemon boot both start here; a header that broke
+        // parsing would fail this line.
+        let reloaded = Config::load_with_diagnostics(path.to_str().unwrap())
+            .expect("a persisted config must load through the daemon's own gate");
+
+        // Restart over the persisted file and persist it again unchanged.
+        let (tx, rx) = mpsc::channel(16);
+        let persister = ConfigPersister::new(rx, path.clone(), reloaded.clone(), None);
+        let handle = tokio::spawn(persister.run());
+        tx.send(ConfigMutation::ReplaceConfig(Box::new(reloaded)))
+            .await
+            .unwrap();
+        drop(tx);
+        handle.await.unwrap();
+        let second = std::fs::read_to_string(&path).unwrap();
+
+        assert_eq!(
+            first, second,
+            "load → persist must not drift the persisted document"
+        );
+        assert_eq!(second.matches(PERSISTED_CONFIG_HEADER).count(), 1);
+    }
+
+    /// `rbgp doctor` needs to tell the daemon's own canonical rewrite from an
+    /// operator's editor. The marker is that evidence: after a daemon write it
+    /// holds the config file's own mtime, so the freshness check reads equal
+    /// (clean) rather than greater (a pending external edit).
+    #[tokio::test]
+    async fn last_persist_marker_records_the_config_file_mtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let state_dir = dir.path().join("state");
+        let config = minimal_config();
+        std::fs::write(&path, toml::to_string_pretty(&config).unwrap()).unwrap();
+
+        let (tx, rx) = mpsc::channel(16);
+        let persister = ConfigPersister::new(rx, path.clone(), config, Some(state_dir.clone()));
+        let handle = tokio::spawn(persister.run());
+        tx.send(ConfigMutation::AddNeighbor(Box::new(test_neighbor(
+            "10.0.0.2", 65002,
+        ))))
+        .await
+        .unwrap();
+        drop(tx);
+        handle.await.unwrap();
+
+        let recorded: u64 = std::fs::read_to_string(state_dir.join(LAST_PERSIST_FILE))
+            .expect("a durable write must record the last-persist marker")
+            .trim()
+            .parse()
+            .expect("the marker holds unix seconds");
+        let mtime = std::fs::metadata(&path)
+            .unwrap()
+            .modified()
+            .unwrap()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert_eq!(
+            recorded, mtime,
+            "the marker must hold the mtime of the file the daemon just wrote, \
+             or doctor reads the daemon's own write as an external edit"
+        );
     }
 }

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -365,11 +365,15 @@ impl ConfigTransactionController {
         let rollback_config = runtime_config_snapshot(&self.deps.peer_mgr_tx)
             .await
             .map_err(ConfigTransactionApplyError::Unavailable)?;
-        let rollback_toml = toml::to_string_pretty(&rollback_config).map_err(|error| {
-            ConfigTransactionApplyError::Internal(format!(
-                "failed to serialize confirmed transaction rollback snapshot: {error}"
-            ))
-        })?;
+        // Rendered as a persisted document, not a bare snapshot: the boot-time
+        // revert writes these bytes straight back over the operator's config
+        // file, so they have to be a file the daemon would have written.
+        let rollback_toml =
+            crate::config::persisted_config_document(&rollback_config).map_err(|error| {
+                ConfigTransactionApplyError::Internal(format!(
+                    "failed to serialize confirmed transaction rollback snapshot: {error}"
+                ))
+            })?;
 
         // ADR-0113: a confirmed transaction may TIGHTEN an outbound prefix
         // maximum, because its automatic undo only loosens and a loosening is
@@ -818,7 +822,8 @@ impl ConfigTransactionController {
     fn history_dir(&self) -> Result<&std::path::Path, ConfigTransactionApplyError> {
         self.deps.config_history_dir.as_deref().ok_or_else(|| {
             ConfigTransactionApplyError::FailedPrecondition(
-                "config history requires a persisted config (start rustbgpd with --config)"
+                "config history is unavailable: this daemon is running without an \
+                 applied-config history directory"
                     .to_string(),
             )
         })
@@ -1407,7 +1412,8 @@ async fn apply_config_transaction_locked(
             .map_err(ConfigTransactionApplyError::InvalidArgument)?;
     let config_tx = deps.config_tx.clone().ok_or_else(|| {
         ConfigTransactionApplyError::FailedPrecondition(
-            "config transactions require a persisted config (start rustbgpd with --config)"
+            "config transactions are unavailable: this daemon is running without config \
+             persistence"
                 .to_string(),
         )
     })?;
@@ -8419,7 +8425,7 @@ log_format = "json"
             .expect_err("history without a state dir must fail closed");
         assert!(
             matches!(err, ConfigTransactionApplyError::FailedPrecondition(ref message)
-                if message.contains("--config")),
+                if message.contains("applied-config history directory")),
             "{err:?}"
         );
         let err = controller
@@ -8436,7 +8442,7 @@ log_format = "json"
             .expect_err("rollback without a state dir must fail closed");
         assert!(
             matches!(err, ConfigTransactionApplyError::FailedPrecondition(ref message)
-                if message.contains("--config")),
+                if message.contains("applied-config history directory")),
             "{err:?}"
         );
     }

--- a/src/fib_table_control.rs
+++ b/src/fib_table_control.rs
@@ -57,8 +57,9 @@ pub struct FibTableControlDeps {
     /// admission. `None` disables the prepared limit transaction (unit tests
     /// and non-transaction consumers of these deps).
     pub rib_tx: Option<mpsc::Sender<rustbgpd_rib::RibUpdate>>,
-    /// Config-persistence channel. `None` when the daemon was started without
-    /// `--config` (nothing to persist to).
+    /// Config-persistence channel. `None` when the control surface is wired
+    /// without a persistence sink (unit tests, embedders). The daemon always
+    /// loads its config from a file, so it always supplies one.
     pub config_tx: Option<mpsc::Sender<ConfigEvent>>,
     /// Coordinator lock shared with the SIGHUP reload FIB step.
     pub lock: Arc<Mutex<()>>,
@@ -169,7 +170,8 @@ async fn mutate(
         .ok_or_else(|| runtime_unavailable_error(!deps.startup_tables.is_empty()))?;
     let config_tx = deps.config_tx.clone().ok_or_else(|| {
         FibTableControlError::FailedPrecondition(
-            "FIB-table CRUD requires a persisted config (start rustbgpd with --config)".to_string(),
+            "FIB-table CRUD is unavailable: this daemon is running without config persistence"
+                .to_string(),
         )
     })?;
     let peer_mgr_tx = deps.peer_mgr_tx.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2962,6 +2962,23 @@ async fn run<T>(
     for advisory in config.advisories() {
         tracing::warn!("{}", advisory.one_line());
     }
+    // The eBGP policy posture, in the log. `--check` frames this before
+    // deployment, but a runtime config mutation rewrites the file
+    // canonically and takes any banner the operator wrote with it — the log
+    // is then the only place the posture is still stated.
+    let unpoliced_ebgp = config.unpoliced_ebgp_neighbors().len();
+    if unpoliced_ebgp > 0 {
+        tracing::warn!(
+            neighbors = unpoliced_ebgp,
+            ebgp_requires_policy = config.global.ebgp_requires_policy,
+            "eBGP policy posture: {unpoliced_ebgp} neighbor(s) resolve no explicit policy — {}",
+            if config.global.ebgp_requires_policy {
+                "those directions carry no routes (RFC 8212 reserved deny)"
+            } else {
+                "those directions are unfiltered (permit all)"
+            }
+        );
+    }
 
     let metrics = BgpMetrics::new();
     let grpc_listeners = resolve_grpc_listeners(&config).unwrap_or_else(|e| {
@@ -3434,7 +3451,7 @@ async fn run<T>(
             mutation_rx,
             path.clone(),
             config.clone(),
-            Some(config_history::history_dir(&config.runtime_state_dir())),
+            Some(config.runtime_state_dir()),
         );
         tokio::spawn(persister.run());
         tokio::spawn(run_config_bridge(
@@ -4169,12 +4186,11 @@ async fn run<T>(
                     &config.runtime_state_dir(),
                 )),
                 // Rollback resolution reads the history the config persister
-                // records; without --config there is no persister and the
-                // history/rollback RPCs fail closed.
-                config_history_dir: config
-                    .file_path
-                    .is_some()
-                    .then(|| config_history::history_dir(&config.runtime_state_dir())),
+                // records. The daemon always loads its config from a file, so
+                // the history directory is always wired here; the field stays
+                // optional for the FIB-CRUD deps below and for embedders that
+                // run the control surface without persistence.
+                config_history_dir: Some(config_history::history_dir(&config.runtime_state_dir())),
             },
             metrics.clone(),
         );

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -6793,11 +6793,10 @@ peer_group = "secure"
         );
     }
 
-    /// Bridge-disabled mode (no `file_path`, so no persister and no
-    /// bridge) must succeed: the helper takes `Option<&Sender>`, and a
-    /// `None` bridge is the runtime configuration when rustbgpd starts
-    /// without a `--config` file (gRPC mutations are non-persistent in
-    /// that mode by design).
+    /// Bridge-disabled mode (no persister, so no bridge) must succeed: the
+    /// helper takes `Option<&Sender>`, and a `None` bridge is the shape an
+    /// embedder or a unit test wires when nothing persists gRPC mutations.
+    /// The daemon itself always has a bridge.
     #[tokio::test]
     async fn apply_reload_outcome_succeeds_without_bridge() {
         let (peer_mgr_internal_tx, mut peer_mgr_internal_rx) =


### PR DESCRIPTION
## Defect 1 — the canonical write was silent about what it did

Runtime config persistence rewrites the operator's file in canonical form:
comments and formatting from the previous file are gone, key order is lost,
and defaulted fields are materialized. Nothing on disk said so, so an
annotated starter config could come back stripped — including the
`DELIBERATE DEVELOPMENT POSTURE: PERMIT ALL, BOTH DIRECTIONS` banner the lab
starter carries — with no explanation.

Every file the daemon writes now opens with a fixed header naming that
behaviour. Canonicalization, the crash-safe temp-file + rename, and the
`0600` mode are unchanged; no `toml_edit`.

**Where the header is emitted.** The persist path is `src/config_persister.rs`,
which has three whole-config serializations, all routed through one helper:

| site | writes | header |
| --- | --- | --- |
| `stage()` | `<config>.tmp`, later renamed over the config file | yes |
| `persist()` | the config file | yes |
| `record_current_history()` | an applied-config history entry | yes — must match the bytes `persist()` records, or content-hash dedup breaks and every restart grows history |

A fourth production site, the commit-confirm rollback snapshot in
`config_transaction_control.rs`, is routed too: `confirm_journal::boot_revert_check`
writes those bytes straight back over the operator's config file.

**Idempotence is structural.** `config::persisted_config_document` takes a
`Config`, never a document. Re-persisting a file that already carries a header
regenerates the whole document from the parsed struct — TOML comments do not
survive parsing — so there is no strip step for a slightly different prior
header to defeat.

The header carries no version and no timestamp. Beyond the stated reason,
both would defeat the applied-config history's content-hash dedup; the
red-check below demonstrates that directly.

**Startup posture line.** The daemon did *not* announce a permit-all posture
at startup — `warn_unpoliced_ebgp` is reached only from the `--check` path.
Startup now logs one line naming the posture when any eBGP neighbor resolves
no explicit policy.

## Defect 2 — doctor could not tell the daemon's own write from an external edit

The config-freshness check compared file mtime against process start, so every
deployment using the documented runtime-mutation workflow warned permanently
about a change the daemon itself had made and applied. Container entrypoints
that seed a template after the process starts hit the same false warning.

The persister now records the config file's mtime under `runtime_state_dir` at
every point where the daemon's view of that file becomes current — boot, every
durable write, and a SIGHUP snapshot refresh — and doctor judges against that
record, falling back to process start when there is none. Recording the file's
own mtime rather than wall-clock now means the two sides compare exactly, with
no clock skew or rounding in between.

`ConfigPersister::new` now takes the state dir instead of the history dir and
derives both artifacts from it.

## Also in scope: a `--config` flag that does not exist

The daemon takes its config path as a positional argument and rejects
`--config`. Three gRPC errors told operators to pass it; each now states its
real precondition. Two assertions that pinned the old wording were updated to
pin the new wording rather than weakened. Two doc comments describing the same
nonexistent mode were corrected.

The `config.file_path.is_some()` gate in `main.rs` is dead: `config_path` is
always a `String` and `load_with_diagnostics` — the only path `main` reaches
the runtime through — sets `file_path` unconditionally. The gate and its
comment are removed.

The `FailedPrecondition` branch behind it is *not* deleted. It is unreachable
in the daemon but reachable from tests, and `config_history_dir` must stay
optional for the FIB-CRUD deps that legitimately carry none. It is reworded,
not removed.

## Evidence each new test can fail

Every new test was watched going red against a deliberately broken
implementation, then restored.

| break | test that went red |
| --- | --- |
| header dropped from `persisted_config_document` | `persisted_config_carries_exactly_one_maintenance_header`, `persisted_config_round_trips_through_load_and_persist` |
| header emitted twice, as a strip-then-prepend bug would | `persisted_config_carries_exactly_one_maintenance_header` — *"persisting twice must leave exactly one header"* |
| per-write counter added to the header (the churn the header must not have) | `persisted_config_round_trips_through_load_and_persist` — *"load → persist must not drift"*, plus both pre-existing history-dedup tests |
| `record_last_persist` returns early | `last_persist_marker_records_the_config_file_mtime` — marker absent |
| marker records `mtime + 1` | `last_persist_marker_records_the_config_file_mtime` — equality, not mere existence |
| freshness reference reverted to process-start only | `freshness_reference_prefers_the_daemon_last_persist_marker` |
| freshness check silenced unconditionally | `freshness_reference_prefers_the_daemon_last_persist_marker` **and** the pre-existing yellow test — the load-bearing external-edit assertion still bites |
| header made non-comment text | `persisted_config_header_stays_out_of_the_token_and_the_effective_dump` |
| header prepended to `effective_redacted_toml` | same test — *"the effective-config API response must not carry the file header"* |

One note on the leak guard: a header injected uniformly into the snapshot-token
hasher is **not** observable, because a constant prefix on a keyed hash input
changes nothing an in-process comparison can see. That break did not go red, so
the test does not claim to catch it. It pins what is checkable and does bite:
the header stays inert TOML, and everything derived from a persisted file —
token and effective dump — is identical to the same thing derived from a
header-free rendering.

## Gates

| gate | exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `timeout 2400 cargo test --workspace` | 0 |
| `cargo doc --workspace --no-deps` | 0 |

## Not touched

No file under `docs/` and nothing in `examples/docker-compose/`.
`tests/interop/scripts/test-m58-fib-table-crud-frr.sh:193` repeats the
`--config` claim in a comment, and `CHANGELOG.md:7192,7204` carry it in
already-released historical entries; both left as-is.
