### PR TITLE
perf(transport): make a disabled explain cache allocation-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -722,6 +722,34 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the tiers the daemon enforces — in place of a file-non-empty check on
   the annex.
 
+- **Turning off `[policy.explain]` now actually costs nothing per peer.**
+  The import-decision cache was built at session construction, so every
+  peer paid for it whether or not explain was enabled: at the default
+  `cache_size = 4096` that is roughly 150 KiB of resident allocation per
+  session — the LRU index sized to capacity up front, plus a 512-entry
+  eviction ring — held for the life of a session that, with explain off,
+  never writes a single entry. On a 1000-peer route reflector that is
+  about 150 MiB reserved for a disabled feature. Both allocations are now
+  built on the first recorded decision instead, so a disabled session
+  holds none of it, and a session that is down releases what it had.
+  Enabled sessions are unaffected: the LRU and the eviction ring still
+  come up together at their full configured sizes, before any eviction
+  can occur. `[policy.explain] enabled` still defaults to on, and its
+  behaviour there is unchanged.
+
+- **Enabling import explain no longer slows down every inbound route.**
+  Explain needs a formatted `AS_PATH` string to re-derive which policy
+  statement decided a route, and the session used to get it by forcing
+  the per-UPDATE string render for *every* inbound route whenever explain
+  was on — re-imposing on ingress the cost that per-chain gating removed
+  on the export side. The cached decision already stores the typed
+  `AS_PATH`, so the string is now rendered from it at explain-query time,
+  with the same formatter that produced it. The render is once per
+  explain query rather than once per route, the cache stops carrying a
+  second copy of the path per entry, and the inbound path builds the
+  string only when the import chain's own `AS_PATH` matches need it.
+  Explain output is unchanged.
+
 ### Fixed
 
 - **A config file the daemon has rewritten now says so.** The first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -725,11 +725,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Turning off `[policy.explain]` now actually costs nothing per peer.**
   The import-decision cache was built at session construction, so every
   peer paid for it whether or not explain was enabled: at the default
-  `cache_size = 4096` that is roughly 150 KiB of resident allocation per
-  session — the LRU index sized to capacity up front, plus a 512-entry
-  eviction ring — held for the life of a session that, with explain off,
-  never writes a single entry. On a 1000-peer route reflector that is
-  about 150 MiB reserved for a disabled feature. Both allocations are now
+  `cache_size = 4096` that is roughly 150 KiB allocated per session — the
+  LRU index sized to capacity up front, plus a 512-entry eviction ring —
+  held for the life of a session that, with explain off, never writes a
+  single entry. On a 1000-peer route reflector that is about 150 MiB
+  allocated for a disabled feature. Most of it is never written, so it is
+  address space and allocator bookkeeping rather than measured RSS, but a
+  disabled feature should reserve neither. Both allocations are now
   built on the first recorded decision instead, so a disabled session
   holds none of it, and a session that is down releases what it had.
   Enabled sessions are unaffected: the LRU and the eviction ring still

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -1610,6 +1610,15 @@ impl PeerSession {
         };
 
         let cached = &decision.policy_context;
+        // Rendered from the cached typed `AS_PATH` with the same
+        // formatter the inbound extractor uses, so the string the
+        // re-derivation matches against is byte-identical to the one
+        // the live evaluation saw — without the cache carrying a
+        // second copy of it per entry.
+        let as_path_str = cached
+            .as_path
+            .as_ref()
+            .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string);
         // Session-identity fields mirror the inbound eval sites: the
         // peer's negotiated ASN and eBGP/iBGP classification are
         // properties of the established session and cannot have
@@ -1624,7 +1633,7 @@ impl PeerSession {
             extended_communities: &cached.extended_communities,
             communities: &cached.communities,
             large_communities: &cached.large_communities,
-            as_path_str: &cached.as_path_str,
+            as_path_str: &as_path_str,
             as_path: cached.as_path.as_ref(),
             as_path_len: cached.as_path_len,
             origin_asn: cached.origin_asn,

--- a/crates/transport/src/session/import_decision_cache.rs
+++ b/crates/transport/src/session/import_decision_cache.rs
@@ -103,10 +103,17 @@ pub struct CachedPolicyContext {
     pub extended_communities: Vec<ExtendedCommunity>,
     pub communities: Vec<u32>,
     pub large_communities: Vec<LargeCommunity>,
-    pub as_path_str: String,
     /// Typed `AS_PATH` (owned), so an explain re-derivation of a chain
-    /// with `for asn in route.as-path` loops (LAN-303) sees the same
-    /// iteration the live evaluation saw. Explain-enabled path only.
+    /// with `for asn in route.as-path` loops sees the same iteration the
+    /// live evaluation saw. Explain-enabled path only.
+    ///
+    /// The single source of truth for the `AS_PATH` surface: the
+    /// `RouteContext.as_path_str` an explain query needs is rendered
+    /// from this at query time via
+    /// [`rustbgpd_wire::AsPath::to_aspath_string`] — the same formatter
+    /// the inbound extractor uses — rather than stored alongside it.
+    /// `None` renders as the empty string, exactly as the live path's
+    /// `unwrap_or_default` does, so nothing is lost by not storing it.
     pub as_path: Option<rustbgpd_wire::AsPath>,
     pub as_path_len: usize,
     pub origin_asn: Option<u32>,
@@ -210,11 +217,25 @@ pub struct ImportExplainReply {
 /// readers (the explain RPC) go through an `Arc<Mutex<…>>` wrapper.
 #[derive(Debug)]
 pub struct ImportDecisionCache {
-    entries: LruCache<ImportDecisionKey, CachedDecision>,
+    /// Per-peer LRU cap, retained so `entries` can be built on demand.
+    cap: NonZeroUsize,
+    /// `None` until the first `insert`. `LruCache::new` eagerly
+    /// allocates its index (`HashMap::with_capacity(cap)`) plus the two
+    /// sigil nodes of its intrusive list, so building it at session
+    /// construction charges every peer for the cache whether or not
+    /// `[policy.explain] enabled` is set — and a disabled session never
+    /// inserts. Deferring the build keeps a disabled session (and an
+    /// enabled one that has not yet seen an UPDATE) allocation-free.
+    entries: Option<LruCache<ImportDecisionKey, CachedDecision>>,
     /// FIFO of recently-evicted keys. False-positive-only by
     /// construction: every `insert` for a key clears it from this ring
     /// before recording the new entry, so the ring can never mask a
     /// genuine live entry.
+    ///
+    /// Allocated in lockstep with `entries` — see [`Self::storage`] —
+    /// at its full [`EVICTION_TRACKER_CAPACITY`], never grown
+    /// incrementally. An enabled cache therefore has exactly the ring
+    /// it always had by the time any eviction can occur.
     recently_evicted: VecDeque<ImportDecisionKey>,
 }
 
@@ -222,12 +243,15 @@ impl ImportDecisionCache {
     /// Create a cache with the given per-peer capacity. A zero or
     /// otherwise nonsensical input is clamped to `1` — the cache is
     /// always at least nominally usable.
+    ///
+    /// Allocates nothing: both the LRU and the eviction ring are built
+    /// on first use.
     #[must_use]
     pub fn with_capacity(cap: usize) -> Self {
-        let cap = NonZeroUsize::new(cap.max(1)).expect("clamped to at least 1");
         Self {
-            entries: LruCache::new(cap),
-            recently_evicted: VecDeque::with_capacity(EVICTION_TRACKER_CAPACITY),
+            cap: NonZeroUsize::new(cap.max(1)).expect("clamped to at least 1"),
+            entries: None,
+            recently_evicted: VecDeque::new(),
         }
     }
 
@@ -240,9 +264,14 @@ impl ImportDecisionCache {
     /// A reconnecting `PeerSession` is not reconstructed, so without this
     /// a stale decision could answer for any prefix the peer has not yet
     /// re-advertised.
+    ///
+    /// Drops the backing allocations too, returning the cache to the
+    /// state `with_capacity` left it in — a session that is down holds
+    /// no cache memory, and the next `insert` rebuilds both at their
+    /// full configured sizes.
     pub fn clear(&mut self) {
-        self.entries.clear();
-        self.recently_evicted.clear();
+        self.entries = None;
+        self.recently_evicted = VecDeque::new();
     }
 
     /// Insert or replace an entry. On capacity overflow the LRU victim
@@ -254,9 +283,28 @@ impl ImportDecisionCache {
     /// decision rather than spuriously reporting `Evicted`.
     pub fn insert(&mut self, key: ImportDecisionKey, decision: CachedDecision) {
         self.drop_eviction_record(&key);
-        if let Some((victim_key, _)) = self.entries.push(key, decision) {
+        let evicted = self.storage().push(key, decision);
+        if let Some((victim_key, _)) = evicted {
             self.record_eviction(victim_key);
         }
+    }
+
+    /// The backing LRU, built on first write.
+    ///
+    /// Both allocations happen here, together and at their full
+    /// configured sizes, so an enabled cache reaches exactly the shape
+    /// eager construction gave it — only the *moment* moves, from
+    /// session build to the first recorded decision. In particular the
+    /// eviction ring is at `EVICTION_TRACKER_CAPACITY` before the LRU
+    /// can possibly evict anything (that needs `cap` inserts first), so
+    /// eviction behaviour is unchanged.
+    fn storage(&mut self) -> &mut LruCache<ImportDecisionKey, CachedDecision> {
+        if self.entries.is_none() {
+            self.recently_evicted
+                .reserve_exact(EVICTION_TRACKER_CAPACITY);
+        }
+        let cap = self.cap;
+        self.entries.get_or_insert_with(|| LruCache::new(cap))
     }
 
     /// Tombstone the entry under `key` as `Withdrawn`. No-op when the
@@ -272,7 +320,7 @@ impl ImportDecisionCache {
     /// the least useful field for the "why is it gone?" question
     /// anyway.
     pub fn mark_withdrawn(&mut self, key: &ImportDecisionKey) {
-        if let Some(decision) = self.entries.get_mut(key) {
+        if let Some(decision) = self.entries.as_mut().and_then(|e| e.get_mut(key)) {
             decision.outcome = CachedOutcome::Withdrawn;
             decision.policy_context = CachedPolicyContext::default();
             decision.modifications = RouteModifications::default();
@@ -289,7 +337,7 @@ impl ImportDecisionCache {
     /// surprising; the hot write path is the sole owner of recency.
     #[must_use]
     pub fn lookup(&self, key: &ImportDecisionKey, current_generation: u64) -> LookupResult {
-        if let Some(decision) = self.entries.peek(key) {
+        if let Some(decision) = self.entries.as_ref().and_then(|e| e.peek(key)) {
             Self::classify(decision.clone(), current_generation)
         } else if self.recently_evicted.iter().any(|k| k == key) {
             LookupResult::Evicted
@@ -316,6 +364,7 @@ impl ImportDecisionCache {
         let mut matches: Vec<ResolvedMatch> = self
             .entries
             .iter()
+            .flat_map(|entries| entries.iter())
             .filter(|(k, _)| k.afi == afi && k.safi == safi && &k.prefix == prefix)
             .map(|(k, decision)| ResolvedMatch {
                 path_id: k.path_id,
@@ -353,12 +402,22 @@ impl ImportDecisionCache {
     /// it.
     #[cfg(test)]
     fn len(&self) -> usize {
-        self.entries.len()
+        self.entries.as_ref().map_or(0, LruCache::len)
     }
 
     #[cfg(test)]
     fn is_empty(&self) -> bool {
-        self.entries.is_empty()
+        self.entries.as_ref().is_none_or(LruCache::is_empty)
+    }
+
+    /// Whether the cache is holding zero heap allocation — no LRU index
+    /// and no eviction ring. The structural fact a disabled session
+    /// must satisfy: an occupancy assertion (`lookup` returns
+    /// `NotSeen`) is satisfied by an eagerly-allocated empty cache too,
+    /// so it cannot pin this.
+    #[cfg(test)]
+    pub(super) fn is_unallocated(&self) -> bool {
+        self.entries.is_none() && self.recently_evicted.capacity() == 0
     }
 
     fn record_eviction(&mut self, key: ImportDecisionKey) {
@@ -488,7 +547,9 @@ mod tests {
         let mut decision = permit_at(0);
         decision.policy_context = CachedPolicyContext {
             communities: vec![100],
-            as_path_str: "65002".to_string(),
+            as_path: Some(rustbgpd_wire::AsPath {
+                segments: vec![rustbgpd_wire::AsPathSegment::AsSequence(vec![65002])],
+            }),
             as_path_len: 1,
             ..CachedPolicyContext::default()
         };
@@ -653,5 +714,70 @@ mod tests {
         let mut cache = ImportDecisionCache::with_capacity(0);
         cache.insert(key(1, 0), permit_at(0));
         assert!(matches!(cache.lookup(&key(1, 0), 0), LookupResult::Hit(_)));
+    }
+
+    #[test]
+    fn cache_allocates_nothing_until_first_insert() {
+        // Structural, not behavioural: an eagerly-built cache answers
+        // every lookup identically, so only the allocation state can
+        // distinguish the two. A session with `[policy.explain]
+        // enabled = false` never inserts and must therefore cost
+        // nothing.
+        let mut cache = ImportDecisionCache::with_capacity(DEFAULT_EXPLAIN_CACHE_SIZE);
+        assert!(
+            cache.is_unallocated(),
+            "a cache with no entries must hold no LRU index and no eviction ring",
+        );
+        // Reads must not allocate either.
+        let _ = cache.lookup(&key(1, 0), 0);
+        let _ = cache.lookup_all_paths(Afi::Ipv4, Safi::Unicast, &key(1, 0).prefix, 0);
+        cache.mark_withdrawn(&key(1, 0));
+        assert!(
+            cache.is_unallocated(),
+            "lookups and withdraws must not build the cache"
+        );
+
+        cache.insert(key(1, 0), permit_at(0));
+        assert!(!cache.is_unallocated(), "the first insert builds the LRU");
+        assert_eq!(cache.len(), 1);
+
+        // A session reset returns the peer to zero resident cost.
+        cache.clear();
+        assert!(
+            cache.is_unallocated(),
+            "clear releases the backing allocations"
+        );
+        assert!(matches!(cache.lookup(&key(1, 0), 0), LookupResult::NotSeen));
+    }
+
+    #[test]
+    fn enabled_cache_ring_is_full_size_before_any_eviction() {
+        // Deferring construction must not defer the eviction ring into
+        // incremental growth: by the time the LRU can evict anything,
+        // the ring must already be the size eager construction gave it.
+        let mut cache = ImportDecisionCache::with_capacity(4);
+        cache.insert(key(1, 0), permit_at(0));
+        assert!(
+            cache.recently_evicted.is_empty(),
+            "no eviction has happened yet",
+        );
+        assert_eq!(
+            cache.recently_evicted.capacity(),
+            EVICTION_TRACKER_CAPACITY,
+            "the ring is allocated in full on the first insert, not grown",
+        );
+    }
+
+    #[test]
+    fn eviction_ring_stays_bounded_at_its_cap() {
+        let mut cache = ImportDecisionCache::with_capacity(1);
+        for i in 0..(EVICTION_TRACKER_CAPACITY + 50) {
+            cache.insert(
+                key(1, u32::try_from(i).expect("loop bound fits u32")),
+                permit_at(0),
+            );
+        }
+        assert_eq!(cache.recently_evicted.len(), EVICTION_TRACKER_CAPACITY);
+        assert_eq!(cache.recently_evicted.capacity(), EVICTION_TRACKER_CAPACITY);
     }
 }

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -420,7 +420,6 @@ impl<'a> PolicyAttrSummary<'a> {
             extended_communities: self.extended_communities.to_vec(),
             communities: self.communities.to_vec(),
             large_communities: self.large_communities.to_vec(),
-            as_path_str: self.as_path_str.clone(),
             as_path: self.as_path.cloned(),
             as_path_len: self.as_path_len,
             origin_asn: self.origin_asn,

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -200,11 +200,10 @@ pub(crate) struct PeerSession {
     import_policy: Option<PolicyChain>,
     /// Whether the inbound hot path must build the per-UPDATE `AS_PATH`
     /// match string (`PolicyAttrSummary::as_path_str`). Derived from
-    /// the import chain via `PolicyChain::requires_as_path_string`
-    /// (mirroring the export-side gate in the RIB distribution
-    /// modules) plus the explain toggle — cached decisions store the
-    /// evaluation-time context verbatim. Recomputed once per chain
-    /// install (`install_import_policy`), not per UPDATE.
+    /// the import chain via `PolicyChain::requires_as_path_string`,
+    /// mirroring the export-side gate in the RIB distribution modules.
+    /// Recomputed once per chain install (`install_import_policy`), not
+    /// per UPDATE.
     import_needs_as_path_string: bool,
     /// Export policy (sent to RIB manager on `PeerUp` for per-peer filtering).
     export_policy: Option<PolicyChain>,
@@ -1017,7 +1016,7 @@ impl PeerSession {
         let tcp_ao_protected = config.tcp_ao.is_some();
         let tcp_ao_key_metadata = tcp_ao_key_metadata(&config, None, None);
         let import_needs_as_path_string =
-            Self::import_chain_needs_as_path_string(import_policy.as_ref(), explain_enabled);
+            Self::import_chain_needs_as_path_string(import_policy.as_ref());
         let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_BUFFER);
         let max_prefix_metric_lease = MaxPrefixMetricLease::new(
             metrics.clone(),
@@ -1166,7 +1165,7 @@ impl PeerSession {
         let tcp_ao_key_metadata =
             tcp_ao_key_metadata(&config, tcp_ao_info.as_ref(), tcp_ao_selected_owner);
         let import_needs_as_path_string =
-            Self::import_chain_needs_as_path_string(import_policy.as_ref(), explain_enabled);
+            Self::import_chain_needs_as_path_string(import_policy.as_ref());
         let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_BUFFER);
         let max_prefix_metric_lease = MaxPrefixMetricLease::new(
             metrics.clone(),
@@ -1288,14 +1287,15 @@ impl PeerSession {
         }
     }
 
-    /// Whether an import chain (plus the explain toggle) needs the
-    /// per-UPDATE `AS_PATH` match string. See
-    /// [`Self::install_import_policy`].
-    fn import_chain_needs_as_path_string(
-        import_policy: Option<&PolicyChain>,
-        explain_enabled: bool,
-    ) -> bool {
-        explain_enabled || import_policy.is_some_and(PolicyChain::requires_as_path_string)
+    /// Whether an import chain needs the per-UPDATE `AS_PATH` match
+    /// string. See [`Self::install_import_policy`].
+    ///
+    /// The explain toggle is deliberately *not* a term here: the
+    /// explain cache stores the typed `AS_PATH` and renders the string
+    /// at query time, so enabling explain no longer forces the render
+    /// for every inbound route on the session.
+    fn import_chain_needs_as_path_string(import_policy: Option<&PolicyChain>) -> bool {
+        import_policy.is_some_and(PolicyChain::requires_as_path_string)
     }
 
     /// Install (or clear) the import chain, recomputing the cached
@@ -1303,8 +1303,7 @@ impl PeerSession {
     /// `import_policy` after construction — assigning the field
     /// directly would desynchronize the gate.
     pub(super) fn install_import_policy(&mut self, policy: Option<PolicyChain>) {
-        self.import_needs_as_path_string =
-            Self::import_chain_needs_as_path_string(policy.as_ref(), self.import_explain_enabled);
+        self.import_needs_as_path_string = Self::import_chain_needs_as_path_string(policy.as_ref());
         self.import_policy = policy;
     }
 

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -11125,6 +11125,137 @@ async fn explain_disabled_stores_no_decisions() {
         ),
         "explain disabled must store no decision"
     );
+    // Stronger than the lookup above, which an eagerly-allocated empty
+    // cache satisfies just as well: a disabled session must be
+    // allocation-free, not merely insert-free. `LruCache::new` sizes
+    // its index at the configured cap up front, so building it at
+    // session construction charged every peer for a cache it never
+    // writes to.
+    assert!(
+        session.import_decision_cache.is_unallocated(),
+        "explain disabled must hold no cache allocation"
+    );
+}
+
+/// ADR-0073: the cached decision stores the typed `AS_PATH` only; the
+/// `RouteContext.as_path_str` the statement re-derivation matches
+/// against is rendered from it at query time. This drives a real
+/// explain query through the command dispatch whose *rendered output*
+/// exists only if that reconstruction reproduces the evaluation-time
+/// string byte for byte.
+///
+/// The statement's regex is anchored to the exact
+/// `AsPath::to_aspath_string` rendering of a three-ASN path. A
+/// reconstruction that dropped the path, truncated it, or joined it
+/// differently fails the regex, the statement stops matching, and the
+/// trace disappears — so the rendered `matched_conditions` below exist
+/// only if the reconstruction is byte-identical.
+#[tokio::test]
+async fn explain_trace_renders_as_path_from_the_cached_typed_value() {
+    use rustbgpd_policy::NamedPolicy;
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
+    let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    let metrics = BgpMetrics::new();
+    let (_cmd_tx, cmd_rx) = mpsc::channel(8);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    // Matches "65002 65003 65004" and nothing else — in particular not
+    // the empty string a dropped `AS_PATH` would render as.
+    let pattern = "^65002 65003 65004$";
+    let permit_stmt = PolicyStatement {
+        prefix: Some(Prefix::V4(prefix)),
+        ge: None,
+        le: None,
+        action: PolicyAction::Permit,
+        match_community: vec![],
+        match_as_path: Some(AsPathRegex::new(pattern).unwrap()),
+        match_neighbor_set: None,
+        match_route_type: None,
+        match_evpn_route_type: None,
+        match_rpki_validation: None,
+        match_aspa_validation: None,
+        match_as_path_length_ge: None,
+        match_as_path_length_le: None,
+        match_local_pref_ge: None,
+        match_local_pref_le: None,
+        match_med_ge: None,
+        match_med_le: None,
+        match_next_hop: None,
+        modifications: RouteModifications::default(),
+    };
+    let chain = PolicyChain::from_named(vec![NamedPolicy {
+        name: Some("as-path-explain".to_string()),
+        policy: Policy {
+            entries: vec![permit_stmt],
+            default_action: PolicyAction::Deny,
+        },
+        rpol: None,
+    }]);
+    let mut session = PeerSession::new(
+        config,
+        metrics,
+        cmd_rx,
+        rib_tx,
+        Some(chain),
+        None,
+        None,
+        None,
+        None,
+        false,
+    );
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.peer_enhanced_route_refresh = true;
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+    let attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002, 65003, 65004])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+    ];
+    let update = UpdateMessage::build(
+        &[Ipv4NlriEntry { path_id: 0, prefix }],
+        &[],
+        &attrs,
+        true,
+        false,
+        Ipv4UnicastMode::Body,
+    );
+    session.process_update(update).await;
+    // The live evaluation permitted it: the regex matched the string the
+    // inbound extractor rendered.
+    assert_eq!(session.import_policy_routes_permitted, 1);
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let _ = session
+        .handle_command(PeerCommand::ExplainImportPolicy {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            prefix: Prefix::V4(prefix),
+            path_id: None,
+            reply: reply_tx,
+        })
+        .await;
+    let reply = reply_rx.await.expect("session replied");
+    assert_eq!(reply.matches.len(), 1);
+    let steps = &reply.matches[0].statements;
+    assert_eq!(steps.len(), 1, "the hit re-derives a statement trace");
+    assert_eq!(steps[0].action, PolicyAction::Permit);
+    assert_eq!(
+        steps[0].matched_conditions,
+        vec![
+            "prefix 192.0.2.0/24".to_string(),
+            format!("as_path ~ {pattern:?}"),
+        ],
+        "the AS_PATH condition is rendered only if the query-time \
+         reconstruction reproduced \"65002 65003 65004\"",
+    );
 }
 /// LAN-320: the explain reply carries the session's own cache-enabled
 /// flag (snapshotted from `[policy.explain] enabled` at session build)


### PR DESCRIPTION
## Summary

Two memory fixes in the per-session import-decision explain cache.

**A disabled session was allocation-free only in the sense that it never
inserted.** `ImportDecisionCache::with_capacity` was called
unconditionally at both `PeerSession` construction sites, one line below
`import_explain_enabled: explain_enabled`, and never saw the flag.
`lru` 0.18.1's `LruCache::new` builds its index eagerly
(`HashMap::with_capacity(cap)`) plus two sigil `Box`es, and the
512-entry eviction ring was reserved alongside it. At the default
`cache_size = 4096` that is ~150 KiB of resident allocation per peer,
held for the life of a session whose write paths — both `insert` sites
and `mark_withdrawn` — are all gated on `explain_enabled` and therefore
never run.

Both allocations are now built on the first recorded decision and
released on session reset.

**`CachedPolicyContext` stored `as_path_str` next to the typed `as_path`
it is derived from.** Removing it saves a `String` allocation per cached
entry and 24 bytes from every `CachedDecision`. The explain query
renders the string from the typed value through the same formatter.

That removal in turn lets `import_chain_needs_as_path_string` drop its
`explain_enabled ||` term, which was forcing the per-UPDATE `AS_PATH`
string render for **every inbound route on every session** whenever
explain was on — re-imposing on ingress the cost that per-chain gating
removed on the export side. The inbound path now gates on the import
chain's own `AS_PATH` matches, mirroring the export-side gate.

`[policy.explain] enabled` still defaults to on; this changes no
defaults and no explain output.

## Redundancy of `as_path_str`

Both fields are produced by `PolicyAttrSummary::to_cached_context` from
the same `Option<&AsPath>`:

```rust
as_path_str: if needs_as_path_string {
    as_path.map(AsPath::to_aspath_string).unwrap_or_default()
} else {
    String::new()
},
```

So `as_path == None` implies `as_path_str == ""`, and there is no path
on which the stored string carried information the typed value cannot
reconstruct. The cache is session-local and never serialized, so no
entry can outlive the invariant. Producer and reconstructor are the same
function — `AsPath::to_aspath_string` — and `None` renders as
`String::new()` on both sides, so explain output is byte-identical.

The pre-existing latent hazard was the *other* direction: with
`needs_as_path_string = false` and explain on, the cached string would
have been empty while the typed path was present. The `explain_enabled ||`
term is what kept that unreachable. Rendering from the typed value at
query time removes the hazard rather than papering over it, which is
what makes the term safe to drop.

## Eviction semantics

Unchanged for an enabled cache. The LRU and the ring are allocated
together in `storage()`, each at its full configured size, and the ring
reaches `EVICTION_TRACKER_CAPACITY` on the first insert — before the LRU
can evict anything, which requires `cap` inserts. No incremental growth
is introduced.

`import_explain_enabled` is snapshotted at session build and is never
mutated on a live session; a hot reload of `[policy.explain]` applies to
sessions built afterwards, as `src/reload.rs` already documents. There is
no live enable transition. Were one ever added, lazy construction lands
in exactly the state a construction-time enable would.

## Tests

The disabled-cache assertions are structural, not behavioural — a
disabled cache answers every lookup identically whether or not it
allocated, so an occupancy check cannot pin this.

- `cache_allocates_nothing_until_first_insert` — no LRU index and no
  ring before the first insert; lookups and withdraws do not build one;
  `clear` releases both.
- `explain_disabled_stores_no_decisions` — gains an allocation assertion
  on top of its existing `NotSeen` check, at the session level.
- `enabled_cache_ring_is_full_size_before_any_eviction` — the ring is
  allocated in full on the first insert, not grown.
- `explain_trace_renders_as_path_from_the_cached_typed_value` — drives a
  real `ExplainImportPolicy` command whose rendered `matched_conditions`
  exist only if the query-time reconstruction reproduces the
  evaluation-time string; the statement's regex is anchored to the exact
  `to_aspath_string` rendering.

Every new assertion was red-proofed by reverting the corresponding
change in place (exit 101 in each case) and restored to green:
restoring eager `LruCache::new` reddens both allocation tests; removing
the deferred formatter reddens the new AS_PATH test and the pre-existing
`explain_statement_trace_attributes_hit_and_skips_stale`; removing the
lockstep ring reservation reddens the ring-timing test.

## Gates

`cargo fmt --all -- --check` 0 · `cargo clippy --workspace --all-targets
-- -D warnings` 0 · `cargo test --workspace` 0 · `cargo doc --workspace
--no-deps` 0