### PR TITLE
perf(rib): skip the LLGR tag lookup when no tags are held

### DIFF
--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -158,8 +158,16 @@ impl AdjRibIn {
     /// manager). A first-time insert orphans nothing, so the initial-load
     /// flood skips the GC.
     pub fn insert(&mut self, route: Route) -> bool {
-        self.llgr_stale_local_tags
-            .remove(&(route.prefix, route.path_id));
+        // The tag set is populated only by `promote_to_llgr_stale`, i.e. only
+        // while a down peer sits in its LLGR window, so it is empty for
+        // essentially every insert. `remove` hashes the key before it touches
+        // the table and has no empty fast path, so on the daemon's hottest
+        // loop that is a per-route hash plus group probe for nothing. Every
+        // family below guards the same way.
+        if !self.llgr_stale_local_tags.is_empty() {
+            self.llgr_stale_local_tags
+                .remove(&(route.prefix, route.path_id));
+        }
 
         let path_id = route.path_id;
         let ids = self.prefix_index.entry_or_default(route.prefix);
@@ -175,7 +183,9 @@ impl AdjRibIn {
 
     /// Withdraw a route by prefix and path ID. Returns `true` if it existed.
     pub fn withdraw(&mut self, prefix: &Prefix, path_id: u32) -> bool {
-        self.llgr_stale_local_tags.remove(&(*prefix, path_id));
+        if !self.llgr_stale_local_tags.is_empty() {
+            self.llgr_stale_local_tags.remove(&(*prefix, path_id));
+        }
         self.remove_route_entry(prefix, path_id).is_some()
     }
 
@@ -536,13 +546,17 @@ impl AdjRibIn {
 
     /// Insert or replace a `FlowSpec` route.
     pub fn insert_flowspec(&mut self, route: FlowSpecRoute) {
-        self.flowspec_llgr_stale_local_tags.remove(&route.key());
+        if !self.flowspec_llgr_stale_local_tags.is_empty() {
+            self.flowspec_llgr_stale_local_tags.remove(&route.key());
+        }
         self.flowspec_routes.insert(route.key(), route);
     }
 
     /// Withdraw a `FlowSpec` route by family-complete key.
     pub fn withdraw_flowspec(&mut self, key: &FlowSpecRouteKey) -> bool {
-        self.flowspec_llgr_stale_local_tags.remove(key);
+        if !self.flowspec_llgr_stale_local_tags.is_empty() {
+            self.flowspec_llgr_stale_local_tags.remove(key);
+        }
         self.flowspec_routes.remove(key).is_some()
     }
 
@@ -576,7 +590,9 @@ impl AdjRibIn {
         // and FlowSpec `insert_flowspec` clear their stale tags. Without this,
         // a later EoR (`clear_llgr_stale_evpn`) would treat this fresh route as
         // locally tagged and strip a peer-originated LLGR_STALE off it.
-        self.evpn_llgr_stale_local_tags.remove(&key);
+        if !self.evpn_llgr_stale_local_tags.is_empty() {
+            self.evpn_llgr_stale_local_tags.remove(&key);
+        }
         self.evpn_routes.insert(key, route).is_some()
     }
 
@@ -584,7 +600,9 @@ impl AdjRibIn {
     pub fn withdraw_evpn(&mut self, key: &EvpnRouteKey) -> bool {
         // Mirror unicast `withdraw` / FlowSpec `withdraw_flowspec`: a withdrawn
         // key can no longer carry a locally-injected LLGR_STALE tag.
-        self.evpn_llgr_stale_local_tags.remove(key);
+        if !self.evpn_llgr_stale_local_tags.is_empty() {
+            self.evpn_llgr_stale_local_tags.remove(key);
+        }
         self.evpn_routes.remove(key).is_some()
     }
 
@@ -798,14 +816,18 @@ impl AdjRibIn {
         // Mirror unicast `insert` / `insert_evpn`: a re-advertised key drops
         // any record that *we* locally injected LLGR_STALE on its prior
         // version, so a later EoR never strips a peer-originated community.
-        self.bgpls_llgr_stale_local_tags.remove(&key);
+        if !self.bgpls_llgr_stale_local_tags.is_empty() {
+            self.bgpls_llgr_stale_local_tags.remove(&key);
+        }
         self.bgpls_routes.insert(key, route).is_some()
     }
 
     /// Withdraw a BGP-LS route. Returns `true` if it existed.
     pub fn withdraw_bgpls(&mut self, key: &BgpLsRouteKey) -> bool {
         // A withdrawn key can no longer carry a locally-injected LLGR_STALE tag.
-        self.bgpls_llgr_stale_local_tags.remove(key);
+        if !self.bgpls_llgr_stale_local_tags.is_empty() {
+            self.bgpls_llgr_stale_local_tags.remove(key);
+        }
         self.bgpls_routes.remove(key).is_some()
     }
 
@@ -1073,7 +1095,9 @@ impl AdjRibIn {
         // Mirror unicast `insert` / `insert_evpn`: a re-advertised key drops
         // any record that *we* locally injected LLGR_STALE on its prior
         // version, so a later EoR never strips a peer-originated community.
-        self.vpn_llgr_stale_local_tags.remove(&key);
+        if !self.vpn_llgr_stale_local_tags.is_empty() {
+            self.vpn_llgr_stale_local_tags.remove(&key);
+        }
         let ids = self.vpn_key_index.entry(key.nlri_key).or_default();
         if !ids.contains(&key.path_id) {
             ids.push(key.path_id);
@@ -1092,7 +1116,9 @@ impl AdjRibIn {
     /// index never dangles.
     fn remove_vpn_entry(&mut self, key: &VpnRibRouteKey) -> bool {
         // A removed key can no longer carry a locally-injected LLGR_STALE tag.
-        self.vpn_llgr_stale_local_tags.remove(key);
+        if !self.vpn_llgr_stale_local_tags.is_empty() {
+            self.vpn_llgr_stale_local_tags.remove(key);
+        }
         let removed = self.vpn_routes.remove(key).is_some();
         if removed && let Some(ids) = self.vpn_key_index.get_mut(&key.nlri_key) {
             ids.retain(|id| *id != key.path_id);
@@ -1382,7 +1408,9 @@ impl AdjRibIn {
         // Mirror unicast `insert` / `insert_vpn`: a re-advertised key drops
         // any record that *we* locally injected LLGR_STALE on its prior
         // version, so a later EoR never strips a peer-originated community.
-        self.labeled_llgr_stale_local_tags.remove(&key);
+        if !self.labeled_llgr_stale_local_tags.is_empty() {
+            self.labeled_llgr_stale_local_tags.remove(&key);
+        }
         let ids = self.labeled_key_index.entry(key.prefix).or_default();
         if !ids.contains(&key.path_id) {
             ids.push(key.path_id);
@@ -1401,7 +1429,9 @@ impl AdjRibIn {
     /// the secondary index never dangles.
     fn remove_labeled_entry(&mut self, key: &LabeledRibRouteKey) -> bool {
         // A removed key can no longer carry a locally-injected LLGR_STALE tag.
-        self.labeled_llgr_stale_local_tags.remove(key);
+        if !self.labeled_llgr_stale_local_tags.is_empty() {
+            self.labeled_llgr_stale_local_tags.remove(key);
+        }
         let removed = self.labeled_routes.remove(key).is_some();
         if removed && let Some(ids) = self.labeled_key_index.get_mut(&key.prefix) {
             ids.retain(|id| *id != key.path_id);
@@ -1683,14 +1713,18 @@ impl AdjRibIn {
         // Mirror unicast `insert` / `insert_evpn`: a re-advertised key drops
         // any record that *we* locally injected LLGR_STALE on its prior
         // version, so a later EoR never strips a peer-originated community.
-        self.rtc_llgr_stale_local_tags.remove(&key);
+        if !self.rtc_llgr_stale_local_tags.is_empty() {
+            self.rtc_llgr_stale_local_tags.remove(&key);
+        }
         self.rtc_routes.insert(key, route).is_some()
     }
 
     /// Withdraw an RTC route. Returns `true` if it existed.
     pub fn withdraw_rtc(&mut self, key: &RtcRibRouteKey) -> bool {
         // A withdrawn key can no longer carry a locally-injected LLGR_STALE tag.
-        self.rtc_llgr_stale_local_tags.remove(key);
+        if !self.rtc_llgr_stale_local_tags.is_empty() {
+            self.rtc_llgr_stale_local_tags.remove(key);
+        }
         self.rtc_routes.remove(key).is_some()
     }
 


### PR DESCRIPTION
## Problem

`AdjRibIn::insert` — the per-NLRI hot path behind `RoutesReceived` →
`RibManager::handle_routes_received` → `process_next_route_chunk` — opened with an
unconditional lookup:

```rust
self.llgr_stale_local_tags.remove(&(route.prefix, route.path_id));
```

`llgr_stale_local_tags` records keys where *this daemon* injected `LLGR_STALE`
locally. Its only writers are the `promote_to_llgr_stale*` family, and their only
production caller is the GR-timer expiry in `manager/graceful_restart.rs`, reached
when a down peer's graceful-restart window rolls over into LLGR. Outside that window
the set is empty, which is the state ordinary ingest is always in.

`HashSet::remove` computes the key's hash before it touches the table and has no
`is_empty()` fast path, so every route inserted on a healthy session paid an `FxHash`
of a `Prefix` plus a group probe to look up a key in a table that could not contain it.

## Change

Guard the lookup with `is_empty()` in `insert` and `withdraw`, and in the FlowSpec,
EVPN, BGP-LS, VPN, labeled-unicast, and RTC insert/remove equivalents — 14 sites — so
the shape is identical in every family rather than leaving a reader to wonder why one
is guarded and the others are not.

This is a fast path, not a semantic change. Removing from an empty set is a no-op and
the return value was already discarded. During an actual LLGR window the set is
non-empty, the guard falls through, and the clear happens exactly as before.

The VPN and labeled guards sit in the shared `remove_vpn_entry` / `remove_labeled_entry`
helpers, so they cover the withdraw path and the GR/LLGR sweeps in one place.

## Verification

The clear-on-readvertise behaviour is directly asserted by existing tests, which
populate the tag set and then require the clear — they fail loudly if a guard is ever
wrong. All 12 ran green:

- `insert_{evpn,vpn,labeled,bgpls,rtc}_clears_llgr_stale_local_tag_on_readvertise`
- `withdraw_{evpn,vpn,labeled,bgpls,rtc}_clears_llgr_stale_local_tag`
- `clear_resets_llgr_stale_local_tags_for_vpn_bgpls_rtc`
- `withdraw_all_resets_llgr_stale_local_tags_per_family`

Gates, all exit 0: `cargo fmt --all -- --check`, `cargo clippy --workspace
--all-targets -- -D warnings`, `cargo test --workspace`, `cargo doc --workspace
--no-deps`, `cargo check -p rustbgpd-rib --features bench-internals --benches`.

No benchmarks were run. `adj_rib_in_insert`, `bulk_initial_load`, and `rib_pipeline`
all measure this loop directly and grade the change; measurement belongs in a
controlled window against the documented same-SHA noise floor, so this describes the
mechanism only and claims no number.