### PR TITLE
Make the import-decision explain cache opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or deployment gate can refuse it. Every shipped starter config —
   including both `--init-config` profiles, whose output changed
   accordingly — was rewritten to pass that strict check.
+- **Default change: import-decision explain is now opt-in.**
+  `[policy.explain] enabled` defaults to `false`. A daemon whose config
+  never named that section stops recording import decisions on upgrade:
+  `rbgp policy explain` answers `cache_disabled` and exits nonzero,
+  naming the exact lines to add. **No routing behaviour changes** — the
+  cache is diagnostic retention only, and best-path explain, export
+  explain, and the retained rejected-route view are untouched. To keep
+  the surface, add `[policy.explain] enabled = true`, reload, and let
+  sessions re-establish; an explicit `enabled = true` behaves exactly as
+  before. The reason is that the cache is held **per session**, so its
+  cost multiplies by peer count, and 4096 entries cannot promise
+  full-table explainability anyway — full price for a partial answer.
+  Sizing guidance, labelled figures, and the conditions that would
+  reopen the decision are under *Changed* and in ADR-0073.
 - **`rustbgpd-wire` 0.16.0 changes decode acceptance in six places**
   while keeping an additive API. Embedders should read the *Library
   crates* entry under *Changed* before bumping.
@@ -428,6 +442,54 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   storage, and coverage are not part of this integration.
 
 ### Changed
+
+- **Import-decision explain (`[policy.explain] enabled`) now defaults to
+  `false`.** Both construction paths moved together: the schema default
+  applied when a config file omits `[policy.explain]`, and
+  `TransportConfig::new`, which embedders of `rustbgpd-transport` reach
+  without loading a config file. An explicit `enabled = true` is
+  unchanged in every respect.
+
+  Explain is diagnostic state, never routing correctness — disabling it
+  changes what the daemon can *tell* you, not what it *does*. Its cost,
+  though, is retained **per session**: `cache_size` is one global number
+  applied to every session, and there is no per-peer or per-group
+  override, so the bill multiplies by the defining scale dimension of a
+  route server. And at the default 4096 entries, retention is
+  **partial-table** by construction: a peer announcing more prefixes
+  than that keeps the cache saturated, so a query for an arbitrary
+  prefix of theirs returns `evicted` rather than a decision. Default-on
+  therefore charged in full for a partial answer. Off by default, the
+  choice becomes an informed memory-versus-observability trade the
+  operator makes.
+
+  **The figures, each labelled — none of them is an observed RSS
+  saving.**
+
+  | Figure | Kind |
+  |---|---|
+  | ~610 B per retained entry; ~2.5 MB per saturated session | **measured** — DHAT capture at 2 sessions × 100k prefixes each, `docs/perf/rib-rebaseline-2026-07-13.md` |
+  | ~155 KiB resident per session before a single UPDATE | **measured** (structural) — the LRU index is allocated at capacity |
+  | ~355 MiB retained heap on the 1000×400 route-server receipt | **modeled** from the two measured values above, equivalent to **35–40% of that run's recorded RSS**. It is a model of retained heap, *not* an observed RSS saving |
+  | ~2.5 GB saturation ceiling | **modeled**, and only at one fleet shape: roughly **1000 ingress peers each announcing at least 4096 distinct routes**. It is not the cost of one full-table member |
+
+  **The RSS actually recovered by this change has not been measured
+  yet.** Establishing it needs a separate before/after run of
+  `bench/scale/route-server-1000/run-receipt.sh` on both defaults with
+  the retained RSS sampler streams diffed; that campaign follows this
+  release note, and no saving is claimed here until it does.
+
+  Every shipped starter config and both `--init-config` profiles now
+  state the choice explicitly rather than inheriting it: the lab,
+  minimal, Docker Compose, DDoS-mitigation, and hosting-provider
+  starters set `enabled = true` with the reason on the page; the
+  route-server, route-collector, edge, Linux-edge-FIB, and the two EVPN
+  starters set `enabled = false` with the reason on the page. All of
+  them still pass `rustbgpd --check --strict` with a clean summary.
+  Rationale, measured economics, the rejected smaller-default-cache
+  alternative, and the conditions that would reopen default-on (a global
+  memory budget, per-peer selection, or another bound independent of
+  session count) are in ADR-0073.
 
 - **BREAKING (metrics): the `peer` label is now the bare neighbor address
   on every metric family.** Metric labels are a public API, and this one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -469,7 +469,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   | Figure | Kind |
   |---|---|
   | ~610 B per retained entry; ~2.5 MB per saturated session | **measured** — DHAT capture at 2 sessions × 100k prefixes each, `docs/perf/rib-rebaseline-2026-07-13.md` |
-  | ~155 KiB resident per session before a single UPDATE | **measured** (structural) — the LRU index is allocated at capacity |
+  | ~155 KiB allocated per session before a single UPDATE | **computed** from the allocator's own sizing — the LRU index and the eviction ring are both reserved at capacity up front. Most of it is never written, so it is address space and allocator bookkeeping rather than measured RSS |
   | ~355 MiB retained heap on the 1000×400 route-server receipt | **modeled** from the two measured values above, equivalent to **35–40% of that run's recorded RSS**. It is a model of retained heap, *not* an observed RSS saving |
   | ~2.5 GB saturation ceiling | **modeled**, and only at one fleet shape: roughly **1000 ingress peers each announcing at least 4096 distinct routes**. It is not the cost of one full-table member |
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ automation-heavy control planes. gRPC is the primary interface for all peer
 lifecycle, routing, and policy operations — the config file bootstraps initial
 state, then gRPC owns the truth. No restarts to add peers, change policy, or
 inject routes. And every route decision can explain itself from the live RIB:
-per-peer received / best / advertised views, policy and export-gate explain,
-retained rejected routes with reasons, BMP/MRT/metrics — with receipt-backed
-interop behind each claimed behavior.
+per-peer received / best / advertised views, best-path and export-gate
+explain, opt-in import-decision explain, retained rejected routes with
+reasons, BMP/MRT/metrics — with receipt-backed interop behind each claimed
+behavior.
 
 **Measured, not marketed** — every number below links to its published,
 reproducible receipt:
@@ -127,7 +128,10 @@ config from their existing `general.yml`/`clients.yml`:
   streaming events, all without restarts
 - **Native route explainability** — "why is this route (not) here?" answered
   from the live RIB in one command, where incumbents need an external
-  looking-glass stack for less ([docs/explain.md](docs/explain.md))
+  looking-glass stack for less. Best-path, export-gate, and filtered-route
+  views are always on; the **import**-decision surface is opt-in
+  (`[policy.explain] enabled = true`), because it retains a decision cache
+  per session ([docs/explain.md](docs/explain.md))
 - **Update-group fanout** — peers with provably identical staged output share
   one staging pass: ~28x faster 100k-route convergence at 256 uniform RR
   clients (15.1 s to 0.54 s); v2 extends sharing to VPNv4/v6 with per-member

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -1144,8 +1144,11 @@ fn outcome_label(outcome: i32) -> &'static str {
 fn unanswerable_error(outcome: i32, neighbor: &str) -> Option<CliError> {
     match proto::ImportExplainOutcome::try_from(outcome) {
         Ok(proto::ImportExplainOutcome::CacheDisabled) => Some(CliError::Rpc(
-            "import-decision cache is disabled on this daemon\n  \
-             hint: set [policy.explain] enabled = true and reload (memory cost is per cached route)"
+            "import-decision cache is disabled on this daemon (the default)\n  \
+             hint: add `[policy.explain]` with `enabled = true`, reload, and let the \
+             session re-establish\n  \
+             cost: per session, up to `cache_size` (default 4096) entries of retained \
+             decisions"
                 .to_string(),
         )),
         Ok(proto::ImportExplainOutcome::NoSession) => {
@@ -2006,9 +2009,11 @@ mod tests {
             .unwrap();
     }
 
-    /// LAN-320 pin: `cache_disabled` is an error with the config hint
-    /// (nonzero exit via `Err`), in both text and JSON modes — never a
-    /// `not_seen` lookalike.
+    /// `cache_disabled` is an error with the config hint (nonzero exit
+    /// via `Err`), in both text and JSON modes — never a `not_seen`
+    /// lookalike. Import explain is opt-in, so this is the response an
+    /// operator meets on a stock daemon: it has to name the exact
+    /// config lines to add, not just report an empty result.
     #[tokio::test]
     async fn explain_cache_disabled_errors_with_hint() {
         let server = spawn_mock_server(None).await;
@@ -2019,10 +2024,18 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, CliError::Rpc(_)));
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("[policy.explain]") && rendered.contains("enabled = true"),
+            "the disabled response must name the exact config lines to add:\n{rendered}"
+        );
         assert_eq!(
-            err.to_string(),
-            "import-decision cache is disabled on this daemon\n  \
-             hint: set [policy.explain] enabled = true and reload (memory cost is per cached route)"
+            rendered,
+            "import-decision cache is disabled on this daemon (the default)\n  \
+             hint: add `[policy.explain]` with `enabled = true`, reload, and let the \
+             session re-establish\n  \
+             cost: per session, up to `cache_size` (default 4096) entries of retained \
+             decisions"
         );
         // JSON mode prints the body (distinct outcome value) but still
         // returns the error so the exit code stays nonzero.

--- a/crates/transport/README.md
+++ b/crates/transport/README.md
@@ -30,8 +30,11 @@ events.
 - **Import-decision explain** (ADR-0073) — a bounded per-session LRU
   cache of import-policy decisions (permit and deny) backing
   `PolicyService.ExplainImportPolicy` / `rbgp policy explain`;
-  diagnostic state only, resets on session reset / restart, gated by
-  `[policy.explain].enabled`
+  diagnostic state only, resets on session reset / restart. **Opt-in:**
+  `TransportConfig::explain_enabled` defaults to `false` (daemon knob
+  `[policy.explain] enabled`), because the cache is per session and its
+  cost multiplies by session count. Embedders that want the surface set
+  the field explicitly after `TransportConfig::new`.
 - **Private AS removal** — strip/replace private ASNs before eBGP export
 - **Route server transparency** — preserve original NEXT_HOP and skip
   local ASN prepend for route-server clients

--- a/crates/transport/src/config.rs
+++ b/crates/transport/src/config.rs
@@ -482,13 +482,16 @@ pub struct TransportConfig {
     /// route reflector; used for `CLUSTER_LIST` prepend and loop detection.
     pub cluster_id: Option<Ipv4Addr>,
     /// Whether the per-session import-decision cache is populated
-    /// (ADR-0073). When `false`, the inbound UPDATE path skips building
-    /// and storing any decision snapshot — the write-path cost control.
+    /// (ADR-0073). **Defaults to `false`** — import explainability is
+    /// opt-in, because its retention cost multiplies by session count.
+    /// When `false`, the inbound UPDATE path skips building and storing
+    /// any decision snapshot and the session allocates no cache.
     /// Operator knob: `[policy.explain] enabled`.
     pub explain_enabled: bool,
-    /// Per-session import-decision cache capacity (ADR-0073). Bounds the
-    /// number of `(AFI, SAFI, prefix, path_id)` import decisions retained
-    /// for `PolicyService.ExplainImportPolicy`. Operator knob:
+    /// Import-decision cache capacity **per session** (ADR-0073). Bounds
+    /// the number of `(AFI, SAFI, prefix, path_id)` import decisions
+    /// retained for `PolicyService.ExplainImportPolicy`. Only allocated
+    /// when `explain_enabled`. Operator knob:
     /// `[policy.explain] cache_size`.
     pub explain_cache_size: usize,
     /// Whether rejected inbound routes are retained with their reject
@@ -565,7 +568,7 @@ impl TransportConfig {
             rs_control_communities: false,
             remove_private_as: RemovePrivateAs::Disabled,
             cluster_id: None,
-            explain_enabled: true,
+            explain_enabled: false,
             explain_cache_size: crate::session::import_decision_cache::DEFAULT_EXPLAIN_CACHE_SIZE,
             reject_retention_enabled: true,
             reject_retention_capacity:
@@ -606,6 +609,23 @@ mod tests {
         assert_ne!(a, TransportAuthSecret::from("secret-longer"));
         assert_ne!(a, TransportAuthSecret::from(""));
         assert_eq!(TransportAuthSecret::from(""), TransportAuthSecret::from(""));
+    }
+
+    /// ADR-0073: import explain is opt-in, and `TransportConfig::new`
+    /// is the construction path embedders use directly — it never sees
+    /// the daemon's `[policy.explain]` resolution, so its own default
+    /// has to carry the decision. Pinned separately from the config
+    /// schema default for exactly that reason: one flipping back
+    /// without the other silently diverges embedders from the daemon.
+    #[test]
+    fn transport_config_new_leaves_import_explain_disabled() {
+        let peer = PeerConfig::new(65_001, 65_002, Ipv4Addr::new(10, 0, 0, 1));
+        let config = TransportConfig::new(peer, "10.0.0.2:179".parse().unwrap());
+
+        assert!(
+            !config.explain_enabled,
+            "TransportConfig::new must default import explain off"
+        );
     }
 
     #[test]

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -8546,6 +8546,9 @@ async fn ebgp_import_policy_sees_default_local_pref_and_can_set_it() {
     use super::import_decision_cache::{ImportDecisionKey, LookupResult};
 
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    // Import explain is opt-in (ADR-0073); this test exercises the
+    // populated cache, so turn it on explicitly.
+    session.import_explain_enabled = true;
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     session.install_import_policy(Some(PolicyChain::new(vec![Policy {
         entries: vec![
@@ -10382,7 +10385,10 @@ async fn import_decision_cache_records_deny_and_permit_for_explain() {
     peer_config.connect_retry_secs = 30;
     peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
     peer_config.gr_restart_time = 120;
-    let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    let mut config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    // Import explain is opt-in (ADR-0073); this test exercises the
+    // populated cache, so turn it on explicitly.
+    config.explain_enabled = true;
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
@@ -10524,7 +10530,10 @@ async fn session_down_flushes_import_decision_cache() {
     peer_config.connect_retry_secs = 30;
     peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
     peer_config.gr_restart_time = 120;
-    let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    let mut config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    // Import explain is opt-in (ADR-0073); this test exercises the
+    // populated cache, so turn it on explicitly.
+    config.explain_enabled = true;
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
@@ -10620,6 +10629,9 @@ async fn session_down_flushes_import_decision_cache() {
 async fn explain_import_policy_command_does_not_touch_counters() {
     use super::import_decision_cache::{LookupResult, ResolvedMatch};
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    // Import explain is opt-in (ADR-0073); this test exercises the
+    // populated cache, so turn it on explicitly.
+    session.import_explain_enabled = true;
     let mut negotiated = negotiated_session(65002, false);
     negotiated.peer_enhanced_route_refresh = true;
     session
@@ -10843,7 +10855,10 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
     peer_config.connect_retry_secs = 30;
     peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
     peer_config.gr_restart_time = 120;
-    let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    let mut config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    // Import explain is opt-in (ADR-0073); this test exercises the
+    // populated cache, so turn it on explicitly.
+    config.explain_enabled = true;
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
@@ -11022,6 +11037,9 @@ fn fresh_session_import_decision_cache_is_empty() {
 async fn import_decision_cache_records_ipv6_mp_reach() {
     use super::import_decision_cache::{CachedOutcome, ImportDecisionKey, LookupResult};
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    // Import explain is opt-in (ADR-0073); this test exercises the
+    // populated cache, so turn it on explicitly.
+    session.import_explain_enabled = true;
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
     session
@@ -11157,7 +11175,10 @@ async fn explain_trace_renders_as_path_from_the_cached_typed_value() {
     peer_config.connect_retry_secs = 30;
     peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
     peer_config.gr_restart_time = 120;
-    let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    let mut config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    // Import explain is opt-in (ADR-0073); this test exercises the
+    // populated cache, so turn it on explicitly.
+    config.explain_enabled = true;
     let metrics = BgpMetrics::new();
     let (_cmd_tx, cmd_rx) = mpsc::channel(8);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
@@ -11530,6 +11551,9 @@ async fn denied_mp_add_path_replacements_preserve_sibling_and_deduplicate_overla
     use rustbgpd_wire::{MpReachNlri, MpUnreachNlri, NlriEntry};
 
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    // Import explain is opt-in (ADR-0073); this test exercises the
+    // populated cache, so turn it on explicitly.
+    session.import_explain_enabled = true;
     let mut negotiated = negotiated_session(65002, false);
     negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
     negotiated

--- a/docs/API.md
+++ b/docs/API.md
@@ -756,8 +756,9 @@ Policy statements support the same match surface as TOML config:
 Answer "why didn't this prefix come in?" (or "what did the chain do to it?")
 from the per-session import-decision cache (ADR-0073). Side-effect-free —
 no RIB touch, no counter movement. Omit `path_id` to return every matching
-path. Requires `[policy.explain].enabled` on the daemon (otherwise the
-outcome is `NOT_SEEN`).
+path. The cache is **opt-in**: without `[policy.explain] enabled = true`
+on the daemon the outcome is `CACHE_DISABLED`, which is deliberately
+distinct from `NOT_SEEN`.
 
 ```bash
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -129,7 +129,7 @@ IPv4/IPv6 `Prefix` routes.
 | Neighbor/peer matching | Yes | Yes | Yes | Yes | Yes |
 | Named policy definitions | Yes | Yes | Yes | Yes | Yes |
 | Policy chaining | Yes | Yes | Yes | Yes | Yes |
-| Import-policy explain (per-prefix decision trace) | Yes | No | No | No | No |
+| Import-policy explain (per-prefix decision trace) | Yes (opt-in) | No | No | No | No |
 | Custom filter language | Yes | No | Yes | No | Yes |
 | Parameterized policies (templates) | Yes | No | Yes | No | Partial |
 | In-language policy unit tests | Yes | No | No | No | No |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2198,11 +2198,15 @@ path = "/var/lib/rustbgpd/datasets/customers.list"
 
 ### Import-decision explain (`[policy.explain]`)
 
-Optional. Controls the per-session import-decision cache that backs
+**Opt-in.** Controls the per-session import-decision cache that backs
 `PolicyService.ExplainImportPolicy` and `rbgp policy explain`
 (ADR-0073). Every import evaluation — permit **and** deny — is recorded
 at the transport eval site keyed by `(AFI, SAFI, prefix, path_id)`, so a
 prefix that was denied and never reached the RIB stays explainable.
+
+Omitting the section leaves import explain **disabled**: the inbound
+path stores nothing, no cache is allocated, and explain queries answer
+`cache_disabled`.
 
 ```toml
 [policy.explain]
@@ -2212,15 +2216,39 @@ cache_size = 4096
 
 | Field        | Type    | Required | Default | Description |
 |--------------|---------|----------|---------|-------------|
-| `enabled`    | bool    | no       | `true`  | Gates the cache write-path. When `false`, the inbound UPDATE path skips the compact decision/context snapshot entirely (one boolean check, nothing stored) and explain queries answer `cache_disabled` (distinct from `not_seen`; the CLI renders it as an error with a hint). Set `false` on perf-sensitive full-table peers. |
-| `cache_size` | integer | no       | `4096`  | Per-peer LRU capacity, one entry per `(AFI, SAFI, prefix, path_id)`. The 4096 default suits fabric / partial-table peers; raise it for full-table peers. |
+| `enabled`    | bool    | no       | `false` | Gates the cache write-path. When `false` (the default), the inbound UPDATE path skips the compact decision/context snapshot entirely (one boolean check, nothing stored), the session allocates no cache, and explain queries answer `cache_disabled` (distinct from `not_seen`; the CLI renders it as an error naming the config lines to add). |
+| `cache_size` | integer | no       | `4096`  | LRU capacity **per session**, one entry per `(AFI, SAFI, prefix, path_id)`. The 4096 default suits fabric / partial-table peers; a full-table peer keeps it saturated, so raise it toward that peer's retained-prefix count if you need reliable full-table explain. |
+
+**Both settings are global.** There is no per-peer or per-group
+override: `enabled` is on or off for the whole daemon, and `cache_size`
+is one number applied to every session. "Enable it, but not on the hot
+full-table peers" is not a posture this knob offers — it is the whole
+daemon, or nothing.
+
+**Sizing the choice.** Retention at the default size is
+**partial-table**, not complete. Budget roughly:
+
+```
+peers × min(cache_size, distinct prefixes per peer) × ~610 B
+  + peers × ~155 KiB   (the LRU index is allocated at capacity, so this
+                        floor is resident before a single UPDATE)
+```
+
+The ~610 B per entry is **measured**
+([`perf/rib-rebaseline-2026-07-13.md`](perf/rib-rebaseline-2026-07-13.md),
+DHAT, saturated caches). Worked examples, **modeled** from it: 10 peers
+× 4096 entries ≈ 26 MiB; 1000 peers × 400 retained prefixes ≈ 355 MiB;
+1000 peers each announcing at least 4096 distinct routes ≈ 2.5 GB, the
+saturation ceiling for that fleet shape.
 
 This is **diagnostic state only** — it never affects which routes are
 accepted. Scope is IPv4 / IPv6 unicast. The cache resets on peer session
 reset and is **not durable across restart** (for durable history use the
 event-history outbox, ADR-0072). Both fields are **restart-required
-per-peer** on reload; see [`reload-matrix.md`](reload-matrix.md) and the
-"Explain an import decision" runbook in [`OPERATIONS.md`](OPERATIONS.md).
+per-peer** on reload — a session already established keeps its current
+behaviour until it re-establishes; see
+[`reload-matrix.md`](reload-matrix.md) and the "Explain an import
+decision" runbook in [`OPERATIONS.md`](OPERATIONS.md).
 
 ### Rejected-route retention (`[policy.reject_retention]`)
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1605,14 +1605,20 @@ policy counter. The cache is **diagnostic session state**, not durable
 history — it resets on peer flap and daemon restart.
 
 Tuning (`[policy.explain]` in the config, diagnostic retention only —
-never affects which routes are accepted):
+never affects which routes are accepted). Both settings are **global**:
+there is no per-peer or per-group override.
 
-- `enabled` (default `true`) — set `false` on hot full-table peers to
-  skip the write-path cost entirely (the daemon then answers
-  `cache_disabled`, and the CLI errors with a hint).
-- `cache_size` (default `4096`) — a fabric / partial-table size. For
-  reliable full-table explain, raise it toward the peer's
-  expected retained-prefix count and budget the memory.
+- `enabled` (default `false`) — **import explain is opt-in.** On a
+  stock daemon the surface answers `cache_disabled` and the CLI errors
+  with the config lines to add. Turn it on, reload, and let the session
+  re-establish; the value is read when a session is built.
+- `cache_size` (default `4096`) — capacity **per session**, a fabric /
+  partial-table size. For reliable full-table explain, raise it toward
+  the peer's expected retained-prefix count and budget the memory: the
+  number applies to every session, so the bill is
+  `peers × min(cache_size, prefixes per peer) × ~610 B` plus a
+  ~155 KiB per-session floor. See
+  [`CONFIGURATION.md`](CONFIGURATION.md#import-decision-explain-policyexplain).
 
 ### Answer a member's "why is my route filtered?" (LAN-472)
 

--- a/docs/adr/0073-import-policy-explain.md
+++ b/docs/adr/0073-import-policy-explain.md
@@ -1,6 +1,7 @@
 # ADR-0073: Import policy explain via per-session decision cache
 
-**Status:** Accepted
+**Status:** Accepted — retention default **reversed to opt-in**; see
+[Reversal: retention is opt-in](#reversal-retention-is-opt-in)
 **Date:** 2026-05-28
 
 ## Context
@@ -103,18 +104,24 @@ flag on this one.
   - peer down / reconnect → flush the per-session table
   - new policy generation → lazy invalidation on read (stamp
     `STALE`); no eager scan
-- **Enable flag:** `[policy.explain].enabled` (default `true`).
+- **Enable flag:** `[policy.explain].enabled`, **default `false`**
+  (see [Reversal](#reversal-retention-is-opt-in); it shipped `true`).
   This is the load-bearing performance control: the feature's cost
   is on the **write** side (every inbound UPDATE would otherwise
   clone the pre-policy policy-context fields and modifications per NLRI, even
   for denies, even when no operator will ever query). Gating the
-  decision-build behind this flag means a perf-sensitive deployment
-  sets `enabled = false` and the inbound UPDATE path pays a single
-  boolean check and clones nothing. Default-on is justified *only*
-  because the stored payload and cap are conservative (below); an
-  operator who finds the write cost unacceptable on a hot full-table
-  peer turns it off rather than living with it.
-- **Bound:** per-peer cap, **4096 entries**, configurable via
+  decision-build behind this flag means the default deployment pays a
+  single boolean check per UPDATE, clones nothing, and allocates no
+  cache; an operator who wants the surface turns it on.
+
+  The flag is **global**. There is no per-peer or per-group override,
+  so "leave it on but disable it for the hot full-table peers" is not
+  a posture this design offers: the choice is on or off for the whole
+  daemon, and `cache_size` is likewise one number applied to every
+  session. That is what makes the cost multiply by session count, and
+  it is the reason the default is off.
+- **Bound:** a cap of **4096 entries per session** — one number
+  applied to every session, not settable per peer — configurable via
   `[policy.explain] cache_size` (nested under the existing
   `[policy]` section per the convention already established by
   `[policy.definitions.filter]`). The bucket reads as *diagnostic
@@ -134,8 +141,9 @@ flag on this one.
   coin-flip between a real answer and `EVICTED`. This is not a bug —
   it is the bounded-state tradeoff — but it means **operators who
   want reliable full-table explain must raise `cache_size` to near
-  their expected retained-prefix count for that peer and own the
-  memory cost** (each live entry holds a cloned policy-context snapshot). The
+  their expected retained-prefix count and own the memory cost on
+  every session, since the value is global** (each live entry holds a
+  cloned policy-context snapshot). The
   earlier "mirrors the 4096-entry event ring" framing was a weak
   justification: event rings bound event volume over time, this
   bounds prefixes per peer — a different axis. 4096 is a deliberate
@@ -227,8 +235,8 @@ discrimination) and need their own ADRs.
 
 ### Positive
 
-- The operator question "why didn't this route come in?" gets a
-  honest, on-by-default answer.
+- The operator question "why didn't this route come in?" gets an
+  honest answer, for operators who turn the surface on.
 - Symmetric with the existing export-explain surface: both questions
   are first-class.
 - Generation stamping closes a footgun present even in the export
@@ -240,11 +248,13 @@ discrimination) and need their own ADRs.
 
 ### Negative
 
-- New persistent state surface in transport. Memory cost scales
-  with peer count × cache size, roughly `peers × 4096 × ~256 B ≈
-  100 MB` at the proposed defaults with 100 peers. Acceptable on
-  the typical deployment shape but not free; the per-peer cap is
-  the operator's lever.
+- New persistent state surface in transport, **off unless enabled**.
+  When it is enabled the memory cost scales with session count ×
+  cache size. The plan-stage estimate here was `peers × 4096 × ~256 B`;
+  the measured entry cost came in at roughly **610 B** (see the
+  Reversal below), so the real bill is about 2.4× the estimate, and it
+  is the multiplication by session count — not the per-entry size —
+  that decides the outcome at route-server scale.
 - A new contract operators will rely on. Future changes to the
   surface (outcome enum, field set, key shape) carry compatibility
   cost.
@@ -261,6 +271,77 @@ discrimination) and need their own ADRs.
   alongside the durable event outbox (ADR-0072), not in place of
   it.
 
+## Reversal: retention is opt-in
+
+**2026-07-25.** `[policy.explain] enabled` now defaults to **`false`**.
+Both construction paths flipped together — the schema/serde default
+that applies when a config file omits `[policy.explain]`, and
+`TransportConfig::new`, which embedders reach without loading a config
+file at all. Nothing else about the surface changed: an explicit
+`enabled = true` behaves exactly as it did.
+
+### Why
+
+- **Explain is diagnostic state, not routing correctness.** Turning it
+  off changes what the daemon can *tell* you, never what it *does*.
+  Nothing in the import chain, best-path selection, or export path
+  depends on it.
+- **Its cost multiplies by peer count** — the defining scale dimension
+  for an IXP route server, which is the deployment this project aims
+  at. `cache_size` is per session, and the flag is global, so the bill
+  is `sessions × retained entries`, not a fixed daemon overhead.
+- **A 4096-entry cache cannot honestly promise full-table
+  explainability anyway.** The original Bound section already said so.
+  Default-on therefore bought a substantial standing memory cost while
+  delivering only *partial* retention — a query against a full-table
+  peer was already a coin-flip against `EVICTED`. Paying in full for a
+  partial answer is the wrong default.
+- **Operators who need it can make an informed
+  memory-versus-observability choice.** The knob, the `CACHE_DISABLED`
+  outcome, and the CLI's config hint were all already built, so the
+  off state is a first-class, self-explaining state rather than a
+  silent hole.
+
+### Measured economics
+
+Label at the point of use — these are three different kinds of number.
+
+| Figure | Kind | Source |
+|---|---|---|
+| ~610 B per retained entry; ~2.5 MB per saturated session | **measured** | DHAT capture at 2 sessions × 100k prefixes each (both caches saturated at 4096), [`rib-rebaseline-2026-07-13.md`](../perf/rib-rebaseline-2026-07-13.md) — "Transport import-decision cache", 5,002,096 B live at process heap maximum |
+| ~155 KiB resident per session before a single UPDATE | **measured** (structural) | `LruCache::new(4096)` allocates its index at capacity, plus the 512-entry eviction ring |
+| ~355 MiB retained heap at 1000 sessions × 400 routes each | **modeled** | `1000 × (155 KiB floor + 400 × ~536 B)`, against the ~890–926 MiB steady RSS recorded on the 1000×400 route-server receipt — i.e. **35–40% of recorded RSS, not an observed RSS saving** |
+| ~2.5 GB saturation ceiling | **modeled** | `1000 × 2.5 MB`, and only at that fleet shape: roughly 1000 ingress peers **each announcing at least 4096 distinct routes**. It is not the cost of one full-table member |
+
+The RSS actually recovered by this default change is established by a
+separate before/after measurement — re-running
+`bench/scale/route-server-1000/run-receipt.sh` on both defaults and
+diffing the retained RSS sampler stream. **That measurement has not run
+yet**, so no observed-saving figure is claimed here or in the release
+notes.
+
+### Rejected alternative: a smaller default-on cache
+
+Keeping the feature on with a much smaller `cache_size` reduces the
+bill, but it makes eviction more aggressive and the feature *less*
+trustworthy — more queries returning `EVICTED` for prefixes the peer is
+actively announcing. A diagnostic surface that is usually wrong when
+consulted is worse than one an operator knowingly enabled.
+
+### What would reopen this
+
+Default-on becomes defensible again once the cost stops multiplying by
+session count without bound. Any of:
+
+- a **global memory budget** for the cache, with eviction across
+  sessions rather than a fixed per-session cap;
+- **per-peer or per-group selection**, so retention is spent only on
+  the sessions an operator is actually diagnosing;
+- another design that bounds total retained explain state independently
+  of how many sessions are established.
+
+Absent one of those, the default stays off.
+
 ## Decisions baked in
 
 The plan-stage research surfaced six knobs; a post-implementation
@@ -269,12 +350,12 @@ review added the enable flag (7). They are pinned here, not deferred:
 | # | Question | Decision |
 |---|---|---|
 | 1 | Default per-peer cache size | **4096 entries**, a deliberate **fabric / partial-table** starter default (hundreds–low-thousands of prefixes fully observable). **Not** sized for internet full-table retention: a 100k-prefix peer keeps the cache saturated, so explain is a coin-flip vs `EVICTED`. Operators wanting reliable full-table explain raise `cache_size` toward their expected retained-prefix count for that peer and own the memory (each live entry holds a cloned policy-context snapshot). See the Bound section — the old "mirrors the event ring" justification is retracted (different axis). |
-| 2 | Default-on retention | **Yes — but contingent on the conservative payload + cap in (1) and gated by the enable flag in (7).** Explain works out of the box; a deployment that finds the write cost unacceptable on a hot full-table peer sets `enabled = false` rather than living with it. |
+| 2 | Default-on retention | **Reversed — retention is opt-in.** Originally yes, contingent on the conservative payload + cap in (1). The contingency did not hold at the scale this project targets: the cost multiplies by session count and 4096 entries cannot honestly promise full-table explainability. See [Reversal](#reversal-retention-is-opt-in). |
 | 3 | EVICTED tracker | **Yes**, kept compact: lossy recent-eviction key set / bloom-ish ring, false-positive-only. A wrong `EVICTED` is operationally better than a wrong `NOT_SEEN`. |
 | 4 | Withdraw semantics | **`WITHDRAWN`**, retained as a **lighter** tombstone (attrs + mods dropped; outcome + matched policy + timestamp + generation kept) until evicted / stale / session reset. Preserves the "never seen" vs "seen and removed" distinction without letting a churny peer crowd live decisions out of the LRU with full-payload dead entries. |
 | 5 | Add-Path | Include `path_id` in the cache key and the response. CLI accepts optional `--path-id`. Without it, return all matching entries for the prefix (a clear multi-path response), never an arbitrary first hit. |
 | 6 | Statement-level trace | **Shipped.** Originally deferred ("No in v1," terminal `matched_policy` only); the per-statement trace later landed as `repeated ImportExplainStatementStep statements = 13` on the explain response (rendered by the CLI). It is **re-derived at query time** from the cached pre-policy context, **not** stored inside `PolicyEvaluation` — so the live import path records no extra statement-trace state and the out-of-scope item below (storage *inside* `PolicyEvaluation`) still holds. |
-| 7 | Enable flag (added post-review) | **`[policy.explain].enabled`, default `true`.** The load-bearing perf control: the cost is on the write path (per-NLRI policy-context/modification clone on every UPDATE, denies included). The decision-build is gated on this flag, checked *before* any clone, so `enabled = false` costs one boolean per UPDATE and stores nothing. Default-on is only defensible *because* this off-switch exists alongside the conservative cap. |
+| 7 | Enable flag (added post-review) | **`[policy.explain].enabled`, default `false`.** The load-bearing perf control: the cost is on the write path (per-NLRI policy-context/modification clone on every UPDATE, denies included). The decision-build is gated on this flag, checked *before* any clone, so the default costs one boolean per UPDATE, stores nothing, and allocates no cache. The flag is **global** — no per-peer or per-group granularity. Shipped `true`; see [Reversal](#reversal-retention-is-opt-in). |
 
 ## Out of scope
 

--- a/docs/cookbook/ixp-filter-pipeline.md
+++ b/docs/cookbook/ixp-filter-pipeline.md
@@ -199,6 +199,11 @@ rbgp policy stats                     # hygiene/client terms firing
 rbgp policy explain --neighbor 198.51.100.2 --prefix 203.0.113.0/24
 ```
 
+The last one needs `[policy.explain] enabled = true` — import explain is
+opt-in, since the decision cache is per session and its cost multiplies
+by member count. Without it the query answers `cache_disabled` and names
+the lines to add.
+
 ## 5. Member support: the filtered-route view
 
 The daemon retains each member's rejected routes with canonical

--- a/docs/cookbook/peer-flap-triage.md
+++ b/docs/cookbook/peer-flap-triage.md
@@ -73,6 +73,8 @@ a flap:
 ```bash
 rbgp events --limit 50                                  # recent route events
 rbgp policy explain --neighbor 10.0.0.2 --prefix 203.0.113.0/24
+                                                        # opt-in: needs
+                                                        # [policy.explain]
 rbgp rib --prefix 203.0.113.0/24 --explain              # why this best path
 ```
 

--- a/docs/cookbook/policy-quickstart.md
+++ b/docs/cookbook/policy-quickstart.md
@@ -200,7 +200,9 @@ soft-reset auto-fire). Peers on unchanged chains are untouched.
 ```console
 # Import: why was this prefix permitted/denied from this peer?
 # Per-term trace for .rpol members; backed by the per-session
-# decision cache ([policy.explain], on by default — ADR-0073).
+# decision cache, which is OPT-IN (ADR-0073) — set
+# `[policy.explain] enabled = true`, reload, and let the session
+# re-establish, or this answers `cache_disabled`.
 $ rbgp policy explain --neighbor 192.0.2.10 --prefix 203.0.113.0/26
 
 # Export: the full gate ladder toward a peer; the export_policy rung

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -370,6 +370,15 @@ $ rbgp rib received 198.51.100.2 --rejected
 $ rbgp policy explain --neighbor 198.51.100.2 --prefix 203.0.113.0/24
 ```
 
+The first command works on a stock route server. The second needs
+`[policy.explain] enabled = true` — import explain is opt-in and the
+route-server starter turns it off explicitly, because the decision cache
+is per session and its cost multiplies by member count
+([CONFIGURATION.md](../CONFIGURATION.md#import-decision-explain-policyexplain)).
+Enable it, reload, and let the member's session re-establish when you
+need the statement-level trace; the rejected-route view above needs no
+such switch.
+
 The explain names the deciding term — typically `reject-rpki-invalid`
 (fix the member's ROA or your RTR feed) or an `ixp-hygiene` rule
 (AS_SET or ASPA-invalid in the announcement).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -751,7 +751,7 @@ short version for first deployment:
 | Symptom | Where to look |
 |---|---|
 | Session won't establish | `rbgp neighbor <addr>` + `journalctl -u rustbgpd -p warning` |
-| Routes received but not installed | `rbgp rib`, then check the import decision via `rbgp policy explain --neighbor <peer> --prefix <CIDR>` |
+| Routes received but not installed | `rbgp rib`, then `rbgp rib received <peer> --rejected`; for the statement-level trace, `rbgp policy explain --neighbor <peer> --prefix <CIDR>` (opt-in: needs `[policy.explain] enabled = true`) |
 | Reload didn't change behavior | `rustbgpd --diff <file>` + cross-reference [reload matrix](reload-matrix.md) |
 | FIB programming failures | `bgp_fib_kernel_failures_total` Prometheus counter + `journalctl` for `kernel-dataplane` lines |
 | EVPN-specific issues | [`evpn-vtep-troubleshooting.md`](evpn-vtep-troubleshooting.md) |

--- a/docs/explain.md
+++ b/docs/explain.md
@@ -15,7 +15,7 @@ backends.
 |----------|---------|
 | Why was this path selected as best? | `rbgp rib --prefix <cidr> --explain` |
 | Why did/didn't this prefix go to that peer? | `rbgp rib --prefix <cidr> advertised <peer> --explain` |
-| What did import policy decide for this prefix from that peer? | `rbgp policy explain --neighbor <peer> --prefix <cidr>` |
+| What did import policy decide for this prefix from that peer? (opt-in: `[policy.explain] enabled = true`) | `rbgp policy explain --neighbor <peer> --prefix <cidr>` |
 | Which of a member's routes were filtered, and why? | `rbgp rib received <peer> --rejected` |
 | What would this candidate policy do to the live RIB? | `rbgp policy test <file> --policy <name> --direction import` |
 | Which policy terms are actually firing? | `rbgp policy stats` |
@@ -103,8 +103,17 @@ for the legacy winner-oriented explanation.
 
 What did import policy decide when this prefix arrived from this
 peer — including paths that were denied and are therefore *not in the
-RIB anymore*? Requires `[policy.explain] enabled = true` on the
-daemon (a bounded per-session decision cache):
+RIB anymore*?
+
+This one is **opt-in**. It is backed by a bounded decision cache held
+**per session**, so its memory cost multiplies by peer count, and a
+stock daemon does not pay it. Add to the config, reload, and let the
+session re-establish:
+
+```toml
+[policy.explain]
+enabled = true
+```
 
 ```console
 $ rbgp policy explain --neighbor 10.0.0.2 --prefix 10.10.1.0/24
@@ -119,8 +128,21 @@ import policy explain — peer 10.0.0.2 prefix 10.10.1.0/24 (policy generation 3
 
 Outcomes are `permit` / `deny` / `withdrawn` / `not_seen` / `evicted`
 / `stale`; a disabled cache or missing session errors distinctly
-instead of pretending `not_seen`. `--path-id` narrows to one Add-Path
-identity. Details:
+instead of pretending `not_seen` — against a daemon that has not
+enabled the cache, `rbgp policy explain` names the two config lines
+above and exits nonzero. `--path-id` narrows to one Add-Path identity.
+
+`cache_size` (default 4096) is **per session**, and both settings are
+global — there is no per-peer or per-group override. At the default
+size retention is **partial-table**: a peer announcing more than 4096
+distinct prefixes keeps the cache saturated, so a query for an
+arbitrary prefix of theirs answers `evicted` rather than a decision.
+Budget roughly `peers × min(cache_size, prefixes per peer) × ~610 B`,
+plus ~155 KiB per session once enabled, and raise `cache_size` toward
+a peer's retained-prefix count when you need full-table answers.
+Details:
+[CONFIGURATION.md](CONFIGURATION.md#import-decision-explain-policyexplain)
+and
 [OPERATIONS.md](OPERATIONS.md#explain-an-import-decision-adr-0073).
 
 ## The filtered-route view — rejected routes, retained with reasons

--- a/docs/feature-tour.md
+++ b/docs/feature-tour.md
@@ -19,11 +19,13 @@ map: [`crates/cli/README.md`](../crates/cli/README.md).
 ## Native route explainability
 
 Answers "why is this route (not) here?" from the live RIB in one
-command: import explain, best-path explain with decisive-comparison
-attribution, export explain that dry-runs the real per-peer gate
-ladder, and a retained rejected-route view with machine-readable
-reasons — where incumbents need an external looking-glass stack for
-less. Catalog of every explain surface: [explain.md](explain.md).
+command: best-path explain with decisive-comparison attribution, export
+explain that dry-runs the real per-peer gate ladder, a retained
+rejected-route view with machine-readable reasons, and opt-in
+import-decision explain (`[policy.explain] enabled = true`, which
+retains a decision cache per session) — where incumbents need an
+external looking-glass stack for less. Catalog of every explain
+surface: [explain.md](explain.md).
 
 ## Dual-stack and modern protocol support
 

--- a/docs/gobgp-parity.md
+++ b/docs/gobgp-parity.md
@@ -126,7 +126,7 @@ releases rather than carried forward from older measurements.
 | Table statistics | Yes | Partial | Health endpoint |
 | VRF management | Yes | No | |
 | Policy CRUD via API | Yes | Yes | Named policy definition CRUD plus global/per-neighbor chain assignment |
-| Import-policy explain | No | Yes | `ExplainImportPolicy` RPC + `rbgp policy explain` — per-prefix PERMIT/DENY/WITHDRAWN/EVICTED/STALE/NOT_SEEN decision trace at the transport eval site, IPv4/IPv6 unicast (ADR-0073) |
+| Import-policy explain | No | Yes (opt-in) | `ExplainImportPolicy` RPC + `rbgp policy explain` — per-prefix PERMIT/DENY/WITHDRAWN/EVICTED/STALE/NOT_SEEN decision trace at the transport eval site, IPv4/IPv6 unicast (ADR-0073). Off unless `[policy.explain] enabled = true`; the decision cache is per session |
 | RPKI management | Yes | Partial | VRP/cache status via metrics; no gRPC RPKI CRUD |
 | BMP management | Yes | Partial | Config-file only; no runtime gRPC add/remove |
 | MRT control | Yes | Yes | `TriggerMrtDump` RPC |
@@ -258,7 +258,7 @@ Competing head-to-head with GoBGP for all use cases:
   no ASPA support
 - **Unicast FIB ECMP beyond Add-Path** — rustbgpd installs kernel `RTA_MULTIPATH` routes with `maximum_paths`, per-class eBGP/iBGP caps, `multipath_relax`, and Link Bandwidth weighted multipath
 - **gNMI / OpenConfig telemetry + Set subset** — rustbgpd exposes a native `gnmi.gNMI` service for OpenConfig BGP operational state (`Capabilities`, `Get`, `Subscribe` SAMPLE/POLL/ONCE, plus STREAM ON_CHANGE v1 for neighbor `session-state`) and a transaction-backed static-neighbor `Set` subset, verified with `gnmic`; GoBGP exposes its own gRPC API but not an OpenConfig/gNMI target
-- **Import-policy explain** — `ExplainImportPolicy` RPC + `rbgp policy explain` answer "why didn't this prefix come in?" from a per-session import-decision cache that records both permits and denies at the transport eval site (ADR-0073); GoBGP has no per-prefix import-decision diagnostic
+- **Import-policy explain** — `ExplainImportPolicy` RPC + `rbgp policy explain` answer "why didn't this prefix come in?" from a per-session import-decision cache that records both permits and denies at the transport eval site (ADR-0073), opt-in via `[policy.explain] enabled = true` since the cache is retained per session; GoBGP has no per-prefix import-decision diagnostic
 - **Config persistence** — gRPC mutations atomically persisted to TOML; GoBGP doesn't persist runtime changes
 - **Operator packaging** — systemd unit, example configs, operations guide, release checklist, container image CI out of the box
 - **Secure-by-default gRPC** — UDS default listener, optional token auth per listener, read-only/read-write split; GoBGP defaults to open TCP

--- a/docs/perf/route-server-1000-2026-07.md
+++ b/docs/perf/route-server-1000-2026-07.md
@@ -11,6 +11,15 @@ describe this disclosed fleet rather than a universal deployment forecast.
 
 **Measured commit:** `cb2c924f117fe264991f12b24ea44c2b15b132e2`
 
+> **Default drift since this run.** The scenario config declares a bare
+> `[policy]` with no `[policy.explain]` override, so this campaign ran
+> with the import-decision explain cache **enabled** — the default at the
+> time. That default is now `false` (ADR-0073), which means the RSS
+> figures below include retention a current daemon does not pay for by
+> default. How much they would drop is a separate before/after
+> measurement that has not been run; do not read a saving out of this
+> receipt.
+
 ## Result
 
 | Precommitted check | Result |

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -149,7 +149,7 @@
         "definitions": {},
         "explain": {
           "cache_size": 4096,
-          "enabled": true
+          "enabled": false
         },
         "export_chain": [],
         "import_chain": [],
@@ -2512,11 +2512,11 @@
           "default": {}
         },
         "explain": {
-          "description": "Import-decision explain cache tuning (ADR-0073). Diagnostic\nretention only — does not affect which routes are accepted.",
+          "description": "Import-decision explain cache tuning (ADR-0073). **Opt-in** —\nomitting this section leaves import explain disabled. Diagnostic\nretention only — does not affect which routes are accepted.",
           "$ref": "#/$defs/PolicyExplainConfig",
           "default": {
             "cache_size": 4096,
-            "enabled": true
+            "enabled": false
           }
         },
         "export_chain": {
@@ -2571,20 +2571,20 @@
       "additionalProperties": false
     },
     "PolicyExplainConfig": {
-      "description": "Tuning for the per-session import-decision cache that backs\n`rbgp policy explain` / `PolicyService.ExplainImportPolicy`\n(ADR-0073).\n\nThis is **diagnostic retention**, not policy evaluation behaviour:\nshrinking or disabling the cache changes only what the explain\nsurface can answer, never which routes the import chain admits.",
+      "description": "Tuning for the per-session import-decision cache that backs\n`rbgp policy explain` / `PolicyService.ExplainImportPolicy`\n(ADR-0073). **Opt-in** — the cache is off unless `enabled = true`.\n\nThis is **diagnostic retention**, not policy evaluation behaviour:\nshrinking or disabling the cache changes only what the explain\nsurface can answer, never which routes the import chain admits.",
       "type": "object",
       "properties": {
         "cache_size": {
-          "description": "Per-peer cache capacity (entries). Each entry is one\n`(AFI, SAFI, prefix, path_id)` import decision. Default 4096 —\na fabric / partial-table starter size (hundreds–low-thousands\nof prefixes fully observable). It is **not** sized for internet\nfull-table retention: a 100k-prefix peer keeps the cache\nsaturated, so explain becomes a coin-flip versus an evicted\nanswer. Operators who want reliable full-table explain raise\nthis toward their expected retained-prefix count for the peer\nand own the memory cost.",
+          "description": "Cache capacity **per session** (entries). Each entry is one\n`(AFI, SAFI, prefix, path_id)` import decision. Default 4096 —\na fabric / partial-table starter size (hundreds–low-thousands\nof prefixes fully observable). It is **not** sized for internet\nfull-table retention: a 100k-prefix peer keeps the cache\nsaturated, so explain becomes a coin-flip versus an evicted\nanswer. Operators who want reliable full-table explain raise\nthis toward their expected retained-prefix count for the peer\nand own the memory cost.\n\nBudget roughly `peers × min(cache_size, prefixes per peer) ×\n~600 B`, plus a ~155 KiB fixed floor per session once explain is\nenabled (the LRU index is allocated at capacity).",
           "type": "integer",
           "format": "uint",
           "default": 4096,
           "minimum": 0
         },
         "enabled": {
-          "description": "Whether the per-session import-decision cache is populated.\nDefault `true`. This is the performance control: when `false`\nthe inbound UPDATE path skips building and storing any decision\nsnapshot — a single boolean check, no per-NLRI attribute /\nmodification clone. Turn it off on hot full-table peers where\nthe explain surface isn't worth the write-path cost.",
+          "description": "Whether the per-session import-decision cache is populated.\n**Default `false` — import explainability is opt-in.** When\n`false` the inbound UPDATE path skips building and storing any\ndecision snapshot (a single boolean check, no per-NLRI attribute\n/ modification clone) and the session allocates no cache at all;\nexplain queries answer `cache_disabled`.\n\nThe setting is **global** — it applies to every session, and\nthere is no per-peer or per-group override. Turning it on buys\ndiagnostic retention at a cost that multiplies by session count:\nsee `cache_size` for the budget.",
           "type": "boolean",
-          "default": true
+          "default": false
         }
       },
       "additionalProperties": false

--- a/examples/ddos-mitigation/config.toml
+++ b/examples/ddos-mitigation/config.toml
@@ -118,6 +118,16 @@ default_action = "permit"
 import_chain = ["blackhole-host-routes"]
 export_chain = ["distribute-mitigation"]
 
+# Import-decision explain, on. The import chain above rejects blackhole
+# announcements for being too broad or for the wrong next-hop, and "why
+# was my blackhole dropped?" is the question this deployment gets asked
+# during an incident. Explain is opt-in daemon-wide because the cache is
+# per session; a handful of edge routers announcing host routes is a
+# small bill. Raise `cache_size` only if a peer sends more than 4096
+# distinct prefixes.
+[policy.explain]
+enabled = true
+
 # --- Edge routers ---
 # These enforce FlowSpec rules in hardware. Use short hold times so
 # rustbgpd can detect and react to router failures quickly.

--- a/examples/docker-compose/rustbgpd.toml
+++ b/examples/docker-compose/rustbgpd.toml
@@ -52,6 +52,13 @@ default_action = "permit"
 import_chain = ["lab-permit-all-import"]
 export_chain = ["lab-permit-all-export"]
 
+# Import-decision explain, on — this is a two-node quick-start whose whole
+# job is to be poked at, and `rbgp policy explain` is one of the things
+# worth poking. It is opt-in daemon-wide because the cache is per session,
+# so the bill scales with peer count; one FRR peer is a few MiB.
+[policy.explain]
+enabled = true
+
 [[neighbors]]
 address = "10.99.0.20"
 remote_asn = 65002

--- a/examples/evpn-vtep-leaf/config.toml
+++ b/examples/evpn-vtep-leaf/config.toml
@@ -34,6 +34,14 @@ enforcement = "tier"
 [security.grpc.roles]
 operator = "operator"
 
+# Import-decision explain, off. Stated rather than inherited: the cache
+# covers IPv4 / IPv6 unicast only (ADR-0073) and this leaf's session
+# carries `l2vpn_evpn`, so enabling it would allocate per session and
+# answer nothing about the EVPN routes below. Add a unicast family to this
+# neighbor and it becomes worth reconsidering.
+[policy.explain]
+enabled = false
+
 # --- Spine RR peer (single-RR design; replicate for redundancy) ---
 
 [[neighbors]]

--- a/examples/hosting-provider/config.toml
+++ b/examples/hosting-provider/config.toml
@@ -63,6 +63,15 @@ operator = "operator"
 [[rpki.cache_servers]]
 address = "127.0.0.1:3323"
 
+# Import-decision explain, on. The edge routers below are iBGP peers that
+# send back only what this AS originates, so the per-session cache stays
+# small and "why did the provisioning system's prefix not come back?" is
+# answerable per prefix. Explain is opt-in daemon-wide because the cache is
+# per session and multiplies by peer count; at this peer count and table
+# size it is a few MiB.
+[policy.explain]
+enabled = true
+
 # BMP export for audit trail
 [bmp]
 sys_name = "rustbgpd-hosting"

--- a/examples/linux-edge-fib/config.toml
+++ b/examples/linux-edge-fib/config.toml
@@ -70,6 +70,15 @@ prefix = "::/0"
 [policy.definitions.to-transit]
 default_action = "deny"
 
+# Import-decision explain, off. The transit peers below are capped at
+# 100,000 prefixes each; the per-session cache defaults to 4096 entries,
+# so an enabled cache would stay saturated and answer most queries with an
+# evicted result while still being billed per session. Turn it on with
+# `cache_size` raised toward the peer's retained-prefix count when you are
+# actually debugging an import decision.
+[policy.explain]
+enabled = false
+
 # Shared transport / policy defaults for transit peers. The FIB table below
 # also uses this name as an allow-list, so only best routes learned from this
 # peer group are eligible for kernel install. Keep a peer import cap alongside

--- a/examples/minimal/config.toml
+++ b/examples/minimal/config.toml
@@ -60,6 +60,16 @@ default_action = "permit"
 import_chain = ["permit-all-import"]
 export_chain = ["permit-all-export"]
 
+# Import-decision explain, on. `rbgp policy explain --neighbor 10.0.0.2
+# --prefix <cidr>` then answers "what did import policy do to this route?"
+# — including for routes it denied, which never reach the RIB. It is
+# opt-in daemon-wide because the cache is per session and its cost
+# multiplies by peer count; with one peer that is a few MiB, so a
+# single-peer starter takes it. Written out rather than left to the
+# default so the posture is legible either way.
+[policy.explain]
+enabled = true
+
 [[neighbors]]
 address = "10.0.0.2"
 remote_asn = 65002

--- a/examples/route-collector/config.toml
+++ b/examples/route-collector/config.toml
@@ -96,6 +96,17 @@ action = "deny"
 prefix = "::/0"
 le = 128
 
+# Import-decision explain, off. A collector's job is full tables, and the
+# per-session cache defaults to 4096 entries — orders of magnitude short
+# of one, so an explain query here would mostly report an evicted answer
+# while the retention is billed per session anyway. Sizing it honestly for
+# this shape means `cache_size` near the table size, times every upstream:
+# an explicit choice, not a default. MRT dumps and BMP below are the
+# collector-scale record; explain is the point query you switch on for a
+# session while you are debugging one.
+[policy.explain]
+enabled = false
+
 # --- Upstream peers ---
 # Accept full tables. Adjust max_prefixes to your expected table size.
 

--- a/examples/route-server/config.toml
+++ b/examples/route-server/config.toml
@@ -122,6 +122,24 @@ import_chain = [
 ]
 export_chain = ["rs-transparent-export"]
 
+# Import-decision explain, off — stated rather than inherited, because on
+# a route server it is the memory decision that matters most. The cache is
+# per session, so its cost is multiplied by member count, and 4096 entries
+# cannot retain a member's full table anyway: a query for an arbitrary
+# prefix would be a coin-flip against an evicted answer. On a 1000-member
+# fleet whose members each announce more than 4096 prefixes, an enabled
+# cache at the default size saturates in the low gigabytes.
+#
+# For the member-facing "why is my route filtered?" question, prefer
+# `[policy.reject_retention]` (on by default) and
+# `rbgp rib received <member> --rejected` — it enumerates rejections with
+# reasons and does not need the prefix known in advance.
+#
+# Turn this on deliberately, with `cache_size` raised toward the member's
+# retained-prefix count, while you are diagnosing — not as a standing cost.
+[policy.explain]
+enabled = false
+
 # --- IXP member peers ---
 
 # Add-Path-capable member: sees all candidate paths (preferred

--- a/examples/rr-evpn-fabric/config.toml
+++ b/examples/rr-evpn-fabric/config.toml
@@ -38,6 +38,15 @@ enforcement = "tier"
 [security.grpc.roles]
 operator = "operator"
 
+# Import-decision explain, off. Stated rather than inherited so the
+# reason is on the page: the cache covers IPv4 / IPv6 unicast only
+# (ADR-0073), and every session here carries `l2vpn_evpn`, so enabling it
+# would buy a per-session allocation on every VTEP and answer nothing
+# about this fabric's routes. Use `rbgp rib received <vtep>` and the EVPN
+# views instead.
+[policy.explain]
+enabled = false
+
 # --- VTEP peers (all RR clients, all iBGP in AS 65000) ---
 
 [[neighbors]]

--- a/src/config/profiles.rs
+++ b/src/config/profiles.rs
@@ -96,6 +96,15 @@ default_action = "permit"
 import_chain = ["lab-permit-all-import"]
 export_chain = ["lab-permit-all-export"]
 
+# Import-decision explain, on. `rbgp policy explain --neighbor 10.0.0.2
+# --prefix <cidr>` then says what import policy did to a route, including
+# routes it denied — which is most of what a lab is for. Explain is
+# opt-in daemon-wide because the cache is per session and its cost
+# multiplies by peer count; one peer is a few MiB. Spelled out so the
+# posture is visible here rather than inherited.
+[policy.explain]
+enabled = true
+
 # One eBGP neighbor to bring a session up against.
 [[neighbors]]
 address = "10.0.0.2"
@@ -176,6 +185,16 @@ default_action = "deny"
 [policy]
 import_chain = ["from-upstream"]
 export_chain = ["to-upstream"]
+
+# Import-decision explain, off. An upstream transit sends a full table;
+# the per-session cache defaults to 4096 entries, so an enabled cache
+# stays saturated and answers most queries with an evicted result while
+# still costing per session. Turn it on with `cache_size` raised toward
+# the peer's retained-prefix count while you are debugging a specific
+# import decision, and own the memory. Stated rather than inherited so
+# the choice is visible on the page.
+[policy.explain]
+enabled = false
 
 [[neighbors]]
 address = "203.0.113.2"

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1475,7 +1475,8 @@ pub struct PolicyConfig {
     /// Global export policy chain (references named definitions).
     #[serde(default)]
     pub export_chain: Vec<String>,
-    /// Import-decision explain cache tuning (ADR-0073). Diagnostic
+    /// Import-decision explain cache tuning (ADR-0073). **Opt-in** —
+    /// omitting this section leaves import explain disabled. Diagnostic
     /// retention only — does not affect which routes are accepted.
     #[serde(default)]
     pub explain: PolicyExplainConfig,
@@ -1571,7 +1572,7 @@ impl Eq for DatasetLoadEvents {}
 
 /// Tuning for the per-session import-decision cache that backs
 /// `rbgp policy explain` / `PolicyService.ExplainImportPolicy`
-/// (ADR-0073).
+/// (ADR-0073). **Opt-in** — the cache is off unless `enabled = true`.
 ///
 /// This is **diagnostic retention**, not policy evaluation behaviour:
 /// shrinking or disabling the cache changes only what the explain
@@ -1580,14 +1581,19 @@ impl Eq for DatasetLoadEvents {}
 #[serde(deny_unknown_fields)]
 pub struct PolicyExplainConfig {
     /// Whether the per-session import-decision cache is populated.
-    /// Default `true`. This is the performance control: when `false`
-    /// the inbound UPDATE path skips building and storing any decision
-    /// snapshot — a single boolean check, no per-NLRI attribute /
-    /// modification clone. Turn it off on hot full-table peers where
-    /// the explain surface isn't worth the write-path cost.
+    /// **Default `false` — import explainability is opt-in.** When
+    /// `false` the inbound UPDATE path skips building and storing any
+    /// decision snapshot (a single boolean check, no per-NLRI attribute
+    /// / modification clone) and the session allocates no cache at all;
+    /// explain queries answer `cache_disabled`.
+    ///
+    /// The setting is **global** — it applies to every session, and
+    /// there is no per-peer or per-group override. Turning it on buys
+    /// diagnostic retention at a cost that multiplies by session count:
+    /// see `cache_size` for the budget.
     #[serde(default = "default_explain_enabled")]
     pub enabled: bool,
-    /// Per-peer cache capacity (entries). Each entry is one
+    /// Cache capacity **per session** (entries). Each entry is one
     /// `(AFI, SAFI, prefix, path_id)` import decision. Default 4096 —
     /// a fabric / partial-table starter size (hundreds–low-thousands
     /// of prefixes fully observable). It is **not** sized for internet
@@ -1596,12 +1602,16 @@ pub struct PolicyExplainConfig {
     /// answer. Operators who want reliable full-table explain raise
     /// this toward their expected retained-prefix count for the peer
     /// and own the memory cost.
+    ///
+    /// Budget roughly `peers × min(cache_size, prefixes per peer) ×
+    /// ~600 B`, plus a ~155 KiB fixed floor per session once explain is
+    /// enabled (the LRU index is allocated at capacity).
     #[serde(default = "default_explain_cache_size")]
     pub cache_size: usize,
 }
 
 fn default_explain_enabled() -> bool {
-    true
+    false
 }
 
 fn default_explain_cache_size() -> usize {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -6445,6 +6445,52 @@ fn diff_config_flags_tcp_ao_changes_as_restart_required() {
     assert!(!text.contains("new-secret"));
 }
 
+/// ADR-0073 reversal: import explainability is opt-in. A config that
+/// never mentions `[policy.explain]` must resolve to a disabled cache,
+/// and an explicit `enabled = true` must behave exactly as before.
+///
+/// Pinned on the schema/serde default specifically — this is the path a
+/// config file takes, and it is distinct from `TransportConfig::new`
+/// (pinned in `crates/transport/src/config.rs`), which embedders reach
+/// without ever loading a config file. Either default flipping back on
+/// its own leaves the other construction path uncovered, so each gets
+/// its own test.
+#[test]
+fn omitted_policy_explain_block_resolves_to_disabled() {
+    let config = parse(valid_toml()).unwrap();
+    assert!(
+        !config.policy.explain.enabled,
+        "an omitted [policy.explain] block must leave import explain off"
+    );
+    assert!(
+        !config
+            .resolve_neighbor(&config.neighbors[0])
+            .unwrap()
+            .transport_config
+            .explain_enabled,
+        "the disabled schema default must reach the per-session transport config"
+    );
+
+    // Opting in explicitly is unchanged: the cache is populated and
+    // `cache_size` still defaults to the same 4096 entries per session.
+    let opted_in = parse(&format!(
+        "{}\n[policy.explain]\nenabled = true\n",
+        valid_toml()
+    ))
+    .unwrap();
+    assert!(opted_in.policy.explain.enabled);
+    assert_eq!(opted_in.policy.explain.cache_size, 4096);
+    let resolved = opted_in
+        .resolve_neighbor(&opted_in.neighbors[0])
+        .unwrap()
+        .transport_config;
+    assert!(
+        resolved.explain_enabled,
+        "explicit enabled = true must still enable the cache"
+    );
+    assert_eq!(resolved.explain_cache_size, 4096);
+}
+
 #[test]
 fn resolve_neighbor_threads_policy_explain_settings() {
     // ADR-0073: the resolved-neighbor transport path (used by

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -6134,9 +6134,12 @@ import_policy_chain = ["origin-guard"]
         let initial = Config::load_with_diagnostics(config_path.to_str().unwrap()).unwrap();
         let live = std::sync::Arc::clone(initial.policy.dataset_bindings.get("customers").unwrap());
         std::fs::write(dir.path().join("datasets/customers.list"), "64500\n64999\n").unwrap();
+        // Explain is opt-in, so `enabled = true` is the value that
+        // differs from the live snapshot and forces the explain-sync
+        // step this test halts at.
         write_tier_test_config(
             &config_path,
-            &format!("{config_toml}\n[policy.explain]\nenabled = false\n"),
+            &format!("{config_toml}\n[policy.explain]\nenabled = true\n"),
         );
         let (peer_mgr_tx, peer_mgr_rx) = mpsc::channel(1);
         drop(peer_mgr_rx);
@@ -6550,9 +6553,10 @@ peer_group = "secure"
     #[tokio::test]
     async fn reload_syncs_explain_before_peer_reconcile() {
         // Change the neighbor (hold_time) → ReconcilePeers(changed); and
-        // flip [policy.explain] in the same reload.
+        // flip [policy.explain] in the same reload. Explain is opt-in,
+        // so the flip that differs from the baseline is off → on.
         let new_toml = format!(
-            "{}\n[policy.explain]\nenabled = false\n",
+            "{}\n[policy.explain]\nenabled = true\n",
             baseline_toml().replace("hold_time = 90", "hold_time = 120")
         );
         let (returned, tags) = drive_reload(baseline_toml(), &new_toml).await;
@@ -6571,7 +6575,7 @@ peer_group = "secure"
             "explain snapshot must sync before peer reconcile — saw {tags:?}"
         );
         assert!(
-            tags[sync_idx].contains("enabled=false"),
+            tags[sync_idx].contains("enabled=true"),
             "sync must carry the new explain value — saw {tags:?}"
         );
     }


### PR DESCRIPTION
`[policy.explain] enabled` now defaults to `false`. This is an
operator-visible default change to a marketed feature: a daemon whose
config never named that section stops recording import decisions on
upgrade, and `rbgp policy explain` answers `cache_disabled` and exits
nonzero instead of returning a trace.

No routing behaviour changes. The cache is diagnostic retention only —
best-path explain, export explain, and the retained rejected-route view
are untouched, and an explicit `enabled = true` behaves exactly as
before.

## Why

- Explain is diagnostic state, not routing correctness.
- Its cost multiplies by peer count — the defining scale dimension for
  an IXP route server.
- A 4096-entry cache cannot honestly promise full-table explainability
  anyway, so default-on bought substantial memory cost while delivering
  only partial retention.
- Operators who need it can make an informed memory-versus-observability
  choice.

A smaller default-on cache was considered and rejected: it reduces the
bill but makes eviction more aggressive and the feature less
trustworthy. ADR-0073 records the conditions that would reopen
default-on — a global memory budget, per-peer selection, or another
design bounding retained state independently of session count.

## Both construction paths

Two paths set this default and they must agree, or embedders and daemon
configuration diverge:

- `default_explain_enabled()` in `src/config/schema.rs` — the
  schema/serde default applied when a config file omits
  `[policy.explain]`.
- `TransportConfig::new` in `crates/transport/src/config.rs` — reached
  by embedders without ever loading a config file.

Each is pinned by its own test, so reverting either one alone fails the
test covering its own construction path. `docs/rustbgpd.schema.json` was
regenerated through `rustbgpd --dump-config-schema`.

## Starters

Every shipped starter config and both `--init-config` profiles now state
the choice explicitly rather than inheriting it, with the reason on the
page:

- `enabled = true` — `--init-config lab`, `examples/minimal`,
  `examples/docker-compose`, `examples/ddos-mitigation`,
  `examples/hosting-provider`
- `enabled = false` — `--init-config edge`, `examples/route-server`,
  `examples/route-collector`, `examples/linux-edge-fib`,
  `examples/rr-evpn-fabric`, `examples/evpn-vtep-leaf`

All eleven pass `rustbgpd --check --strict` with a clean `config OK`
summary.

## Documentation

ADR-0073 gains a Reversal section with the rationale, the labelled
economics, the rejected alternative, and the reopen conditions. The
README, config reference, explain catalog, operations runbook, API
reference, and the cookbooks that walk an operator through
`rbgp policy explain` all record that the surface is opt-in.

`cache_size` is documented as per session, retention as partial-table at
the default size, with an approximate `peers × cache_size × entry cost`
budget. Prose suggesting operators could disable explain on "hot
full-table peers" while keeping it elsewhere described granularity that
does not exist — the setting is global — and has been corrected rather
than backfilled with a new knob.

`rbgp policy explain` against a disabled daemon already errored
distinctly rather than returning an empty result; its message now names
the exact config lines to add and what enabling costs.

## Numbers

Every figure is labelled at the point of use. The ~355 MiB figure is
**modeled** retained heap, equivalent to 35-40% of the recorded RSS on
the 1000x400 route-server receipt — it is **not** an observed RSS
saving. The RSS actually recovered by this change is established by a
separate before/after measurement that has not run yet, and the release
note says so. The ~2.5 GB saturation ceiling is stated only with the
fleet shape that produces it: roughly 1000 ingress peers each announcing
at least 4096 distinct routes, not the cost of one full-table member.

The 1000-peer receipt now carries a note that it was recorded with the
old default on, so its RSS is not read as current.

## Gates

`cargo fmt --all -- --check` 0 · `cargo clippy --workspace --all-targets
-- -D warnings` 0 · `cargo test --workspace` 0 · `cargo doc --workspace
--no-deps` 0 · `cargo test -p rustbgpd
config_json_schema_committed_copy_is_fresh` 0

No benchmarks were run; a measurement campaign follows this change.