### PR TITLE
fix(bench): restore the wire codec bench and smoke every bench target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,14 @@ jobs:
       - run: cargo check -p rustbgpd-transport --features bench-internals --benches
       # API owns the feature-gated event-history producer bench.
       - run: cargo check -p rustbgpd-api --features bench-internals --benches
+      # `--no-run` above proves the bench targets compile, not that they run.
+      # A fixture the codec later made illegal (RFC 9774 AS_SET in the wire
+      # `rich` AS_PATH) compiled clean and panicked on first iteration, so two
+      # benchmark groups stopped executing without any gate noticing. Criterion
+      # `--test` mode runs every benchmark body once, unmeasured, which is what
+      # separates "broken" from "nobody ran it". Smoke only — no timings.
+      - name: Smoke every criterion bench target
+        run: bash bench/smoke-benches.sh
       # LAN-572 keeps the real MRT snapshot encoder benchmark usable in both
       # deliberately incompatible builds: bare-jemalloc timing, and opt-in
       # allocation/growth diagnostics.  `--smoke` bounds both executions for
@@ -129,6 +137,7 @@ jobs:
             --locked --all-targets -- -D warnings
           cargo test --test reloadstall_scenario_emitted_check
           bash -n bench/compare-criterion.sh
+          shellcheck bench/smoke-benches.sh
           bash -n bench/scale/route-server-1000/run-receipt.sh
           bash -n bench/scale/outbound-prefix-limits/run-receipt.sh
           bash -n bench/scale/config-persistence/run-receipt.sh

--- a/bench/smoke-benches.sh
+++ b/bench/smoke-benches.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Prove every criterion bench target still *executes*.
+#
+# Benches are outside the gate battery, so a bench that panics on its first
+# iteration is indistinguishable from one nobody ran. `cargo bench --no-run`
+# does not close that: an attribute fixture that a codec change made illegal
+# compiles fine and only fails when the body runs. `cargo test --bench` puts
+# criterion in `--test` mode — every benchmark body runs exactly once with no
+# measurement, which is the cheapest thing that actually catches it.
+#
+# This is a smoke check, not a measurement. It reports pass/fail only; any
+# timing it happens to produce is meaningless and is not reported.
+#
+# The target list comes from `cargo metadata`, so a bench target is covered the
+# day it lands rather than when someone remembers to register it here. The two
+# non-criterion harnesses are excluded by name; renaming one drops its
+# exclusion and this script then fails loudly instead of skipping it silently.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Excluded — standalone measurement harnesses with their own CLIs rather than
+# criterion, so they reject criterion's `--test` flag:
+#
+#   snapshot_allocation  needs a `timing|diagnostic` mode plus --commit and
+#                        --output. CI smokes both modes separately through the
+#                        harness's own `--smoke` bound.
+#   route_paging         CSV receipt harness; one complete traversal per
+#                        process, driven by --route-count/--output.
+EXCLUDED=(snapshot_allocation route_paging)
+
+mapfile -t targets < <(
+  cargo metadata --no-deps --format-version 1 | python3 -c '
+import json, sys
+
+for package in json.load(sys.stdin)["packages"]:
+    for target in package["targets"]:
+        if "bench" in target["kind"]:
+            features = ",".join(target.get("required-features") or [])
+            print(package["name"], target["name"], features)
+' | sort
+)
+
+if [ "${#targets[@]}" -eq 0 ]; then
+  echo "no bench targets found — cargo metadata parse is broken" >&2
+  exit 1
+fi
+
+status=0
+for target in "${targets[@]}"; do
+  read -r package name features <<<"$target"
+
+  skip=
+  for excluded in "${EXCLUDED[@]}"; do
+    if [ "$name" = "$excluded" ]; then
+      skip=1
+      break
+    fi
+  done
+  if [ -n "$skip" ]; then
+    echo "skip  $package/$name (not a criterion harness)"
+    continue
+  fi
+
+  feature_args=()
+  if [ -n "$features" ]; then
+    feature_args=(--features "$features")
+  fi
+
+  echo "smoke $package/$name ${features:+[$features]}"
+  if ! cargo test -p "$package" --bench "$name" "${feature_args[@]}"; then
+    echo "::error::bench target $package/$name failed to execute" >&2
+    status=1
+  fi
+done
+
+exit "$status"

--- a/crates/wire/benches/codec.rs
+++ b/crates/wire/benches/codec.rs
@@ -2,12 +2,14 @@ use std::net::Ipv4Addr;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 
-use rustbgpd_wire::attribute::{decode_path_attributes, encode_path_attributes};
+use rustbgpd_wire::attribute::{
+    decode_path_attributes, decode_path_attributes_revised, encode_path_attributes,
+};
 use rustbgpd_wire::nlri::{decode_nlri, encode_nlri};
 use rustbgpd_wire::validate::validate_update_attributes;
 use rustbgpd_wire::{
-    AsPath, AsPathSegment, Ipv4NlriEntry, Ipv4Prefix, Ipv4UnicastMode, Origin, PathAttribute,
-    UpdateMessage,
+    Aggregator, AsPath, AsPathSegment, ErrorDisposition, ExtendedCommunity, Ipv4NlriEntry,
+    Ipv4Prefix, Ipv4UnicastMode, LargeCommunity, Origin, PathAttribute, UpdateMessage,
 };
 
 fn generate_ipv4_prefixes(count: usize) -> Vec<Ipv4Prefix> {
@@ -33,22 +35,65 @@ fn typical_attributes() -> Vec<PathAttribute> {
     ]
 }
 
+/// A wider attribute set than [`typical_attributes`]: multi-segment
+/// `AS_PATH`, communities of every flavor, route-reflection attributes, an
+/// aggregator, and an extended-length (>255 B value) attribute.
+///
+/// `AS_SET` is deliberately absent — RFC 9774 §3 prohibits originating it, so
+/// `encode_path_attributes` rejects it and the whole `attr_encode` group would
+/// panic. Multi-segment coverage comes from a second `AS_SEQUENCE` instead;
+/// received-side `AS_SET` coverage lives in [`as_set_as_path_wire`].
 fn rich_attributes() -> Vec<PathAttribute> {
-    let mut attrs = typical_attributes();
-    attrs.push(PathAttribute::AsPath(AsPath {
-        segments: vec![
-            AsPathSegment::AsSequence(vec![65001, 65002, 65003, 65004, 65005]),
-            AsPathSegment::AsSet(vec![65010, 65011]),
-        ],
-    }));
-    attrs.push(PathAttribute::Communities(vec![
-        0xFFFF_0001,
-        0xFFFF_0002,
-        0xFFFF_0003,
-        0x0001_0001,
-        0x0001_0002,
-    ]));
-    attrs
+    vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![
+                AsPathSegment::AsSequence(vec![65001, 65002, 65003, 65004, 65005]),
+                AsPathSegment::AsSequence(vec![65010, 65011]),
+            ],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 1)),
+        PathAttribute::LocalPref(100),
+        PathAttribute::Med(50),
+        // 128 communities = 512-byte value, which forces the extended-length
+        // header path on both encode and decode.
+        PathAttribute::Communities((0..128).map(|i| 0x0001_0000 + i).collect()),
+        PathAttribute::ExtendedCommunities(vec![ExtendedCommunity::new(0x0002_FDE8_0000_0007)]),
+        PathAttribute::LargeCommunities(vec![LargeCommunity {
+            global_admin: 65001,
+            local_data1: 7,
+            local_data2: 9,
+        }]),
+        PathAttribute::OriginatorId(Ipv4Addr::new(10, 0, 0, 9)),
+        PathAttribute::ClusterList(vec![Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::new(10, 0, 0, 2)]),
+        PathAttribute::Aggregator(Aggregator {
+            asn: 65001,
+            router_id: Ipv4Addr::new(10, 0, 0, 9),
+            partial: false,
+        }),
+    ]
+}
+
+/// A hand-framed `AS_PATH` carrying a single `AS_SET` segment.
+///
+/// Framed by hand because `encode_path_attributes` refuses to originate one
+/// (RFC 9774 §3). Receiving one is still a real shape with a defined RFC 7606
+/// treat-as-withdraw disposition, and the raw segment scan that reaches that
+/// verdict runs on every UPDATE, so it stays on the decode side of the bench.
+fn as_set_as_path_wire() -> Vec<u8> {
+    let asns: [u32; 2] = [65010, 65011];
+    let count = u8::try_from(asns.len()).expect("fixture segment fits one octet");
+    let mut buf = vec![
+        0x40,          // flags: well-known transitive
+        2,             // type: AS_PATH
+        2 + count * 4, // value length: segment header + 4-octet ASNs
+        1,             // segment type: AS_SET
+        count,
+    ];
+    for asn in asns {
+        buf.extend_from_slice(&asn.to_be_bytes());
+    }
+    buf
 }
 
 fn bench_nlri_decode(c: &mut Criterion) {
@@ -146,6 +191,29 @@ fn bench_attr_decode(c: &mut Criterion) {
     group.bench_with_input(BenchmarkId::new("rich", rich.len()), &rich_buf, |b, buf| {
         b.iter(|| decode_path_attributes(buf, true, &[]).unwrap());
     });
+
+    // RFC 9774 §3 leaves `AS_SET` un-originatable but still receivable, so the
+    // revised decoder is the only side that can carry the shape. The RFC 7606
+    // treat-as-withdraw verdict is what makes the fixture load-bearing; assert
+    // it once outside the measurement so a silently-clean decode cannot pass
+    // for coverage.
+    let as_set_buf = as_set_as_path_wire();
+    let verdict = decode_path_attributes_revised(&as_set_buf, true, false, &[])
+        .expect("AS_SET in AS_PATH is recoverable, not session-reset");
+    assert!(
+        verdict
+            .malformed
+            .iter()
+            .any(|m| m.disposition == ErrorDisposition::TreatAsWithdraw),
+        "AS_SET fixture must keep its RFC 7606 treat-as-withdraw disposition"
+    );
+    group.bench_with_input(
+        BenchmarkId::new("as_set_revised", 1),
+        &as_set_buf,
+        |b, buf| {
+            b.iter(|| decode_path_attributes_revised(buf, true, false, &[]).unwrap());
+        },
+    );
 
     group.finish();
 }


### PR DESCRIPTION
## Problem

`cargo bench -p rustbgpd-wire --bench codec` panics on `main`:

```
panicked at crates/wire/benches/codec.rs:145:63:
called `Result::unwrap()` on an `Err` value:
ValueOutOfRange { field: "AS_PATH", value: "AS_SET cannot be projected under RFC 9774" }
```

`rich_attributes()` built an `AsPathSegment::AsSet`. RFC 9774 §3 made that
un-originatable, `encode_path_attributes` began rejecting it, and the fixture
was never updated. `attr_decode/rich` and the entire `attr_encode` group have
not executed since. The wire baseline is incomplete and codec regression
tracking has been silently off.

The fixture compiled fine, so no gate saw it: benches are outside the gate
battery, and `cargo bench --no-run` proves compilation, not execution.

## Fixture

`rich` is rebuilt from legal attributes and stays wider than `typical`:
multi-segment `AS_SEQUENCE`, a 512-byte `COMMUNITIES` value that forces the
extended-length header path, extended and large communities, `ORIGINATOR_ID`,
`CLUSTER_LIST`, and an `AGGREGATOR`. It also no longer emits duplicate
`AS_PATH`/`COMMUNITIES` attributes, which the previous push-onto-`typical`
construction did.

`AS_SET` remains covered on the side where it is still legal. A received
`AS_SET` is a real shape with a defined RFC 7606 treat-as-withdraw
disposition, and the raw segment scan that reaches that verdict runs on every
UPDATE. A hand-framed `AS_PATH` now feeds `decode_path_attributes_revised` as
`attr_decode/as_set_revised`, with an assertion outside the measurement that
the treat-as-withdraw verdict still fires — a silently-clean decode cannot
pass for coverage.

## Check

`bench/smoke-benches.sh` enumerates bench targets from `cargo metadata` and
runs each under criterion `--test` mode: every benchmark body executes once,
unmeasured. It reports pass/fail only and records no timings.

The target list is derived, not hand-maintained, so a new criterion bench is
covered the day it lands. Two targets are standalone measurement harnesses
rather than criterion and are excluded by name with their reasons —
`snapshot_allocation` (needs `timing|diagnostic` plus `--commit`/`--output`;
CI already smokes both modes through the harness's own `--smoke` bound) and
`route_paging` (CSV receipt harness). Renaming either drops its exclusion and
the check fails loudly rather than skipping silently.

Wired into the `check` job beside the existing `cargo check --benches` steps,
and added to the shellcheck list.

## Coverage

11 bench targets in the workspace, all verified against `cargo metadata`:

| target | package | smoked |
| --- | --- | --- |
| `codec` | `rustbgpd-wire` | yes |
| `rib_ops` | `rustbgpd-rib` | yes |
| `policy_eval` | `rustbgpd-policy` | yes |
| `explain_snapshot` | `rustbgpd-policy` | yes |
| `validate` | `rustbgpd-rpki` | yes |
| `fanout` | `rustbgpd-transport` | yes (`bench-internals`) |
| `inbound_attrs` | `rustbgpd-transport` | yes (`bench-internals`) |
| `event_history_producer` | `rustbgpd-api` | yes (`bench-internals`) |
| `fib_projection` | `rustbgpd` | yes (`bench-internals`) |
| `snapshot_allocation` | `rustbgpd-mrt` | excluded — not criterion |
| `route_paging` | `rustbgpd-rib` | excluded — not criterion |

Across the nine smoked targets, 164 benchmark bodies execute.

## Red proof

With the `AS_SET` fixture reintroduced:

- `cargo bench -p rustbgpd-wire --bench codec --no-run` — exit 0 (does not catch it)
- `bash bench/smoke-benches.sh` — exit 1, reproducing the original panic

Restored: `bash bench/smoke-benches.sh` — exit 0.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo test --workspace`, `cargo doc --workspace --no-deps` — all exit 0.