### PR TITLE
test(interop): restore policy explain receipts after opt-in default

### DIFF
--- a/tests/interop/configs/rustbgpd-m80-policy.toml
+++ b/tests/interop/configs/rustbgpd-m80-policy.toml
@@ -18,6 +18,10 @@ principal = "rustbgpd://operator/test-only"
 [policy]
 rpol_files = ["policies/core.rpol"]
 
+# M80 asserts live import-decision traces; the production default stays off.
+[policy.explain]
+enabled = true
+
 [[neighbors]]
 address = "10.0.0.2"
 remote_asn = 65002

--- a/tests/interop/configs/rustbgpd-m83-rs.toml
+++ b/tests/interop/configs/rustbgpd-m83-rs.toml
@@ -107,6 +107,10 @@ import_chain = [
     "prefer-rpki-valid",
 ]
 
+# M83 asserts the ROV reject term; the production default stays off.
+[policy.explain]
+enabled = true
+
 # --- IXP members ---
 
 # BIRD 2: plain transparent client, tshark capture rides this link.

--- a/tests/interop/m90-differential/policy-explain.toml
+++ b/tests/interop/m90-differential/policy-explain.toml
@@ -1,0 +1,4 @@
+# M90 asserts the deciding policy and term for every rejected route.
+# The production default remains off; this receipt opts into its evidence.
+[policy.explain]
+enabled = true

--- a/tests/interop/scripts/test-m90-differential.sh
+++ b/tests/interop/scripts/test-m90-differential.sh
@@ -54,6 +54,7 @@ source "$SCRIPT_DIR/test-lib.sh"
 
 LAB_DIR="$SCRIPT_DIR/../m90-differential"
 MANIFEST="$LAB_DIR/announcements.json"
+POLICY_EXPLAIN_FRAGMENT="$LAB_DIR/policy-explain.toml"
 
 BIRD="clab-${TOPO}-bird"
 RS_ADDR="192.0.2.9"
@@ -188,6 +189,11 @@ render_rustbgpd_config() {
         fail "rs-config-render failed"
         exit 1
     fi
+
+    # This receipt asserts deciding policy/term attribution for every reject.
+    # Keep the production and renderer defaults off; opt in only in the
+    # generated lab config before its production validation gate.
+    cat "$POLICY_EXPLAIN_FRAGMENT" >>"$RENDER_DIR/config.toml"
 
     # Load-bearing proof: suppressing shutdown-gated limit emission makes this
     # exact receipt/config assertion fail before either

--- a/tests/interop_policy_explain.rs
+++ b/tests/interop_policy_explain.rs
@@ -1,0 +1,104 @@
+//! Structural fence for interop receipts that require import-policy explain.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+const FIXED_CONFIG_RECEIPTS: &[(&str, &str)] = &[
+    (
+        "test-m80-rpol-policy-parity-frr.sh",
+        "configs/rustbgpd-m80-policy.toml",
+    ),
+    (
+        "test-m83-routeserver-multistack.sh",
+        "configs/rustbgpd-m83-rs.toml",
+    ),
+];
+const GENERATED_CONFIG_RECEIPT: &str = "test-m90-differential.sh";
+const GENERATED_CONFIG_FRAGMENT: &str = "m90-differential/policy-explain.toml";
+const GENERATED_CONFIG_APPEND: &str =
+    "cat \"$POLICY_EXPLAIN_FRAGMENT\" >>\"$RENDER_DIR/config.toml\"";
+const GENERATED_CONFIG_COPY: &str =
+    "docker cp \"$RENDER_DIR/config.toml\" \"$RUSTBGPD\":/etc/rustbgpd/config.toml";
+const GENERATED_CONFIG_CHECK: &str = "--check --strict /etc/rustbgpd/config.toml";
+
+fn explain_enabled(source: &str) -> bool {
+    let value: toml::Value = toml::from_str(source).expect("fixture must be valid TOML");
+    value
+        .get("policy")
+        .and_then(|policy| policy.get("explain"))
+        .and_then(|explain| explain.get("enabled"))
+        .and_then(toml::Value::as_bool)
+        == Some(true)
+}
+
+fn invokes_policy_explain(source: &str) -> bool {
+    source.lines().any(|line| {
+        let line = line.trim_start();
+        !line.starts_with('#') && line.contains("policy explain")
+    })
+}
+
+/// Removing any explicit opt-in makes this red before a multi-minute interop
+/// job can reach an explain RPC. A new receipt invocation also fails until its
+/// selected daemon config is added to this exact mapping.
+#[test]
+fn interop_policy_explain_receipts_explicitly_opt_in() {
+    let interop = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/interop");
+    let scripts = interop.join("scripts");
+    let discovered: BTreeSet<String> = fs::read_dir(&scripts)
+        .expect("interop scripts directory must be readable")
+        .map(|entry| entry.expect("interop script entry must be readable").path())
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("sh"))
+        .filter_map(|path| {
+            let source = fs::read_to_string(&path).expect("interop script must be readable");
+            invokes_policy_explain(&source).then(|| {
+                path.file_name()
+                    .expect("script must have a file name")
+                    .to_string_lossy()
+                    .into_owned()
+            })
+        })
+        .collect();
+    let expected: BTreeSet<String> = FIXED_CONFIG_RECEIPTS
+        .iter()
+        .map(|(script, _)| (*script).to_owned())
+        .chain(std::iter::once(GENERATED_CONFIG_RECEIPT.to_owned()))
+        .collect();
+    assert_eq!(
+        discovered, expected,
+        "every interop script invoking `policy explain` needs an explicit config mapping"
+    );
+
+    for (script, config) in FIXED_CONFIG_RECEIPTS {
+        let source = fs::read_to_string(interop.join(config))
+            .unwrap_or_else(|error| panic!("{script} config {config} is unreadable: {error}"));
+        assert!(
+            explain_enabled(&source),
+            "{script} invokes `policy explain`, but {config} does not explicitly set \
+             [policy.explain] enabled = true"
+        );
+    }
+
+    let generated_script =
+        fs::read_to_string(scripts.join(GENERATED_CONFIG_RECEIPT)).expect("M90 script is readable");
+    let fragment = fs::read_to_string(interop.join(GENERATED_CONFIG_FRAGMENT))
+        .expect("M90 explain fragment is readable");
+    assert!(
+        explain_enabled(&fragment),
+        "{GENERATED_CONFIG_FRAGMENT} must explicitly enable policy explain"
+    );
+    let append_pos = generated_script
+        .find(GENERATED_CONFIG_APPEND)
+        .expect("M90 must append its policy-explain fragment");
+    let copy_pos = generated_script
+        .find(GENERATED_CONFIG_COPY)
+        .expect("M90 must copy its rendered config into the daemon container");
+    let check_pos = generated_script
+        .find(GENERATED_CONFIG_CHECK)
+        .expect("M90 must validate its rendered config");
+    assert!(
+        append_pos < copy_pos && append_pos < check_pos,
+        "{GENERATED_CONFIG_RECEIPT} must append its policy-explain fragment before config copy and validation"
+    );
+}


### PR DESCRIPTION
## Summary

- explicitly enable the default-off import-decision cache in the M80 and M83 fixtures whose evidence contracts require `rbgp policy explain`
- append the same receipt-only opt-in to M90 generated config before its production validation and container copy, without changing `rs-config-render` or the daemon default
- add an auto-discovery fence that maps every executable interop `policy explain` invocation to its selected config and proves the M90 append ordering

This repairs the current-main M80/M83 CI regression while preserving the memory-driven default-off behavior for normal deployments.

## Root cause

The explain cache became opt-in, but M80 and M83 still invoked `rbgp policy explain` without enabling it. Both jobs completed all preceding protocol and policy assertions, retried twice, then failed with:

```
Error: import-decision cache is disabled on this daemon (the default)
```

The exhaustive script scan also found M90 had the same latent local-receipt failure.

## Load-bearing proof

The new fence was made red by each distinct break and restored before final gates:

- removing the M80 explicit opt-in fails with the exact script/config mapping named
- removing the M90 append fails the generated-config branch
- moving the M90 append below config copy/validation fails the ordering assertion
- a new unmapped executable `policy explain` invocation fails the discovered-versus-declared inventory

The existing functional receipts remain the runtime proof; none of their explain assertions were skipped or weakened.

## Verification

- M80 real containerlab receipt: 45 passed, 0 failed
- M83 real BIRD 2 + GoBGP + FRR + RTR receipt: 51 passed, 0 failed
- M90 real arouteserver differential receipt: 65 passed, 0 failed
- `cargo test --test interop_policy_explain -- --nocapture`
- `cargo test --test interop_tier_auth_rr rr_and_route_server_interop_is_tier_authenticated_end_to_end -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- `bash -n` and focused ShellCheck for the changed M90 driver

A separate pre-existing M83 deploy warning about an unused `sysctl` command is tracked as LAN-633; it did not affect the 51/51 receipt and is not mixed into this fix.

Linear: LAN-632