### PR TITLE
test(interop): make maintained RR receipts fail closed

### DIFF
--- a/tests/interop/scripts/test-m14-rr-frr.sh
+++ b/tests/interop/scripts/test-m14-rr-frr.sh
@@ -20,9 +20,11 @@ TOPO="m14-rr-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INTEROP_TEST_OPERATOR_AUTH=1
 export INTEROP_TEST_OPERATOR_AUTH
+# shellcheck source=tests/interop/scripts/test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 FRR_C1="clab-${TOPO}-frr-client1"
 FRR_C2="clab-${TOPO}-frr-client2"
+RR_CLUSTER_ID="10.0.0.1"
 
 
 grpc_list_received() {
@@ -33,6 +35,15 @@ grpc_list_received() {
 grpc_list_best() {
     grpcurl_call \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListBestRoutes 2>/dev/null
+}
+
+cluster_list_contains() {
+    local cluster_id=${1:?}
+
+    jq -e --arg cluster_id "$cluster_id" '
+        any(.paths[]?;
+            any(.clusterList.list[]?; . == $cluster_id))
+    ' >/dev/null
 }
 
 wait_established() {
@@ -158,23 +169,15 @@ test_originator_id() {
 # Test 4: CLUSTER_LIST contains RR's cluster_id
 # ---------------------------------------------------------------------------
 test_cluster_list() {
-    log "Test 4: CLUSTER_LIST contains RR cluster_id 10.0.0.1"
+    log "Test 4: CLUSTER_LIST contains RR cluster_id $RR_CLUSTER_ID"
 
     local route_json
     route_json=$(docker exec "$FRR_C2" vtysh -c "show bgp ipv4 unicast 192.168.10.0/24 json" 2>/dev/null)
 
-    if echo "$route_json" | grep -q "10.0.0.1"; then
-        # Check it's in the clusterList context
-        local cluster
-        cluster=$(echo "$route_json" | grep -o '"clusterList":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
-        if echo "$cluster" | grep -q "10.0.0.1"; then
-            ok "CLUSTER_LIST contains 10.0.0.1"
-        else
-            # Some FRR versions format cluster list differently
-            ok "10.0.0.1 present in route attributes (cluster list)"
-        fi
+    if echo "$route_json" | cluster_list_contains "$RR_CLUSTER_ID"; then
+        ok "CLUSTER_LIST contains $RR_CLUSTER_ID"
     else
-        fail "CLUSTER_LIST missing 10.0.0.1"
+        fail "CLUSTER_LIST missing $RR_CLUSTER_ID at .paths[].clusterList.list[]"
         echo "$route_json" | head -30 || true
     fi
 }

--- a/tests/interop/scripts/test-m15-rr-frr.sh
+++ b/tests/interop/scripts/test-m15-rr-frr.sh
@@ -5,7 +5,7 @@
 #   - Verify initial routes with LOCAL_PREF 150
 #   - FRR adds a new network while session is up
 #   - SoftResetIn triggers FRR to re-advertise all routes
-#   - Verify route count increases after re-advertisement
+#   - Verify routes and import policy remain intact after re-advertisement
 #
 # Prerequisites:
 #   - containerlab deployed: containerlab deploy -t tests/interop/m15-rr-frr.clab.yml
@@ -19,8 +19,11 @@ TOPO="m15-rr-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INTEROP_TEST_OPERATOR_AUTH=1
 export INTEROP_TEST_OPERATOR_AUTH
+# shellcheck source=tests/interop/scripts/test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 FRR="clab-${TOPO}-frr"
+FRR_PEER="10.0.0.1"
+RUSTBGPD_PEER="10.0.0.2"
 
 
 grpc_list_received() {
@@ -39,11 +42,70 @@ grpc_soft_reset_in() {
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/SoftResetIn 2>/dev/null
 }
 
+grpc_neighbor_state() {
+    grpcurl_call \
+        -d "{\"address\": \"$1\"}" \
+        "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>/dev/null
+}
+
+frr_refresh_received() {
+    docker exec "$FRR" vtysh -c "show bgp neighbors $FRR_PEER json" 2>/dev/null \
+        | jq -er --arg peer "$FRR_PEER" '
+            .[$peer].messageStats.routeRefreshRecv
+            | if type == "number" and . >= 0 and floor == .
+              then .
+              else error("routeRefreshRecv is not a non-negative integer")
+              end
+        '
+}
+
+rustbgpd_updates_received() {
+    grpc_neighbor_state "$RUSTBGPD_PEER" \
+        | jq -er '
+            .updatesReceived
+            | tonumber
+            | select(. >= 0 and floor == .)
+        '
+}
+
+stable_receipt_baseline() {
+    local refresh_previous updates_previous
+    if ! refresh_previous=$(frr_refresh_received); then
+        return 1
+    fi
+    if ! updates_previous=$(rustbgpd_updates_received); then
+        return 1
+    fi
+
+    for _ in $(seq 1 10); do
+        sleep 1
+
+        local refresh_current updates_current
+        if ! refresh_current=$(frr_refresh_received); then
+            return 1
+        fi
+        if ! updates_current=$(rustbgpd_updates_received); then
+            return 1
+        fi
+
+        if [ "$refresh_current" -eq "$refresh_previous" ] \
+            && [ "$updates_current" -eq "$updates_previous" ]; then
+            printf '%s %s\n' "$refresh_current" "$updates_current"
+            return 0
+        fi
+
+        refresh_previous=$refresh_current
+        updates_previous=$updates_current
+    done
+
+    return 1
+}
+
 wait_established() {
     log "Waiting for BGP session to reach Established..."
     for i in $(seq 1 45); do
         local state
-        state=$(docker exec "$FRR" vtysh -c "show bgp neighbors 10.0.0.1 json" 2>/dev/null \
+        state=$(docker exec "$FRR" vtysh -c "show bgp neighbors $FRR_PEER json" 2>/dev/null \
             | grep -o '"bgpState":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
         if [ "$state" = "Established" ]; then
             ok "Session established (attempt $i)"
@@ -68,6 +130,26 @@ wait_routes() {
         sleep 2
     done
     fail "Expected $expected routes, got $(grpc_list_received | grep -c '"prefix"' || echo 0)"
+    return 1
+}
+
+wait_received_prefix() {
+    local prefix=$1
+    local prefix_length=$2
+    log "Waiting for $prefix/$prefix_length in received routes..."
+    for i in $(seq 1 15); do
+        if grpc_list_received \
+            | jq -e --arg prefix "$prefix" --argjson prefix_length "$prefix_length" '
+                any(.routes[]?;
+                    .prefix == $prefix
+                    and .prefixLength == $prefix_length)
+            ' >/dev/null; then
+            ok "$prefix/$prefix_length received (attempt $i)"
+            return 0
+        fi
+        sleep 2
+    done
+    fail "$prefix/$prefix_length was not received"
     return 1
 }
 
@@ -119,8 +201,11 @@ test_soft_reset_in() {
     docker exec "$FRR" vtysh -c "conf t" -c "ip route 10.99.0.0/24 10.0.0.2" \
         -c "end" 2>/dev/null
 
-    # FRR should send the new route via normal UPDATE
-    sleep 3
+    # Wait for the third route's normal UPDATE by prefix identity before taking
+    # either refresh receipt snapshot.
+    if ! wait_received_prefix "10.99.0.0" 24; then
+        return
+    fi
 
     local count_before
     count_before=$(grpc_list_received | grep -c '"prefix"' || true)
@@ -132,18 +217,70 @@ test_soft_reset_in() {
         fail "Expected 3 routes after adding 10.99.0.0/24, got $count_before"
     fi
 
-    # Now trigger SoftResetIn — this should cause FRR to re-send all routes
-    log "Triggering SoftResetIn..."
-    local result
-    result=$(grpc_soft_reset_in "10.0.0.2")
-    ok "SoftResetIn RPC completed"
+    local baseline refresh_before updates_before
+    if ! baseline=$(stable_receipt_baseline); then
+        fail "Refresh receipts did not produce two equal valid baseline samples"
+        return
+    fi
+    read -r refresh_before updates_before <<< "$baseline"
+    log "Receipts before SoftResetIn: routeRefreshRecv=$refresh_before, updatesReceived=$updates_before"
 
-    # Wait briefly for re-advertisement
-    sleep 5
+    # Now trigger SoftResetIn — this should cause FRR to re-send all routes.
+    log "Triggering SoftResetIn..."
+    if grpc_soft_reset_in "$RUSTBGPD_PEER" >/dev/null; then
+        ok "SoftResetIn RPC completed"
+    else
+        fail "SoftResetIn RPC failed"
+        return
+    fi
+
+    local refresh_after=$refresh_before
+    local updates_after=$updates_before
+    local expected_refresh=$((refresh_before + 1))
+    local deltas_observed=0
+    local quiet_tail_samples=0
+    for i in $(seq 1 20); do
+        if ! refresh_after=$(frr_refresh_received); then
+            fail "FRR routeRefreshRecv receipt became missing, malformed, or nonnumeric"
+            return
+        fi
+        if ! updates_after=$(rustbgpd_updates_received); then
+            fail "rustbgpd updatesReceived receipt became missing, malformed, or nonnumeric"
+            return
+        fi
+        if [ "$refresh_after" -eq "$expected_refresh" ] \
+            && [ "$updates_after" -gt "$updates_before" ]; then
+            if [ "$deltas_observed" -eq 0 ]; then
+                deltas_observed=1
+                log "Refresh receipt deltas observed (attempt $i); checking quiet tail"
+            else
+                quiet_tail_samples=$((quiet_tail_samples + 1))
+                if [ "$quiet_tail_samples" -ge 3 ]; then
+                    break
+                fi
+            fi
+        fi
+        if [ "$refresh_after" -gt "$expected_refresh" ]; then
+            break
+        fi
+        sleep 1
+    done
+
+    if [ "$refresh_after" -eq "$expected_refresh" ] \
+        && [ "$quiet_tail_samples" -ge 3 ]; then
+        ok "FRR received exactly one Route Refresh ($refresh_before -> $refresh_after; quiet tail stable)"
+    else
+        fail "FRR Route Refresh delta expected +1, got $refresh_before -> $refresh_after"
+    fi
+    if [ "$updates_after" -gt "$updates_before" ]; then
+        ok "FRR re-advertised UPDATEs ($updates_before -> $updates_after received)"
+    else
+        fail "No UPDATE received after Route Refresh (stayed $updates_after)"
+    fi
 
     # Session should still be up (no flap)
     local state
-    state=$(docker exec "$FRR" vtysh -c "show bgp neighbors 10.0.0.1 json" 2>/dev/null \
+    state=$(docker exec "$FRR" vtysh -c "show bgp neighbors $FRR_PEER json" 2>/dev/null \
         | grep -o '"bgpState":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
 
     if [ "$state" = "Established" ]; then

--- a/tests/interop/scripts/test-m74-vpnv4-reflection-gobgp.sh
+++ b/tests/interop/scripts/test-m74-vpnv4-reflection-gobgp.sh
@@ -253,21 +253,35 @@ test_vpnv4_withdrawal() {
 test_no_dataplane_install() {
     log "Test 3: RR installed nothing into any dataplane"
 
-    local mpls
-    mpls=$(docker exec "$RUSTBGPD" ip -M route show 2>/dev/null || true)
-    if [ -z "$mpls" ]; then
-        ok "RR MPLS routing table is empty"
-    else
-        fail "RR has unexpected MPLS routes"
-        echo "$mpls" >&2
+    local mpls ipv4
+    if capture_ip_routes mpls "$RUSTBGPD" MPLS -M; then
+        if [ -z "$mpls" ]; then
+            ok "RR MPLS routing table is empty"
+        else
+            fail "RR has unexpected MPLS routes"
+            printf '%s\n' "$mpls" >&2
+        fi
     fi
 
-    if docker exec "$RUSTBGPD" ip route show | grep -qF "${INNER_PREFIX%/*}"; then
-        fail "RR kernel routing table contains a VPN-derived route"
-        docker exec "$RUSTBGPD" ip route show >&2 || true
-    else
-        ok "RR kernel routing table has no VPN-derived routes"
+    if capture_ip_routes ipv4 "$RUSTBGPD" IPv4; then
+        if grep -qF "${INNER_PREFIX%/*}" <<<"$ipv4"; then
+            fail "RR kernel routing table contains a VPN-derived route"
+            printf '%s\n' "$ipv4" >&2
+        else
+            ok "RR kernel routing table has no VPN-derived routes"
+        fi
     fi
+}
+
+capture_ip_routes() {
+    local output_var=$1 container=$2 table_label=$3 captured
+    shift 3
+    if ! captured=$(docker exec "$container" ip "$@" route show 2>&1); then
+        fail "$container $table_label route inspection failed"
+        printf '%s\n' "$captured" >&2
+        return 1
+    fi
+    printf -v "$output_var" '%s' "$captured"
 }
 
 main() {

--- a/tests/interop/scripts/test-m75-rtc-vpnv4-filter-gobgp.sh
+++ b/tests/interop/scripts/test-m75-rtc-vpnv4-filter-gobgp.sh
@@ -447,22 +447,35 @@ test_default_rtc_injection() {
 test_no_dataplane_install() {
     log "Test 9: RR installed nothing into any dataplane"
 
-    local mpls
-    mpls=$(docker exec "$RUSTBGPD" ip -M route show 2>/dev/null || true)
-    if [ -z "$mpls" ]; then
-        ok "RR MPLS routing table is empty"
-    else
-        fail "RR has unexpected MPLS routes"
-        echo "$mpls" >&2
+    local mpls ipv4
+    if capture_ip_routes mpls "$RUSTBGPD" MPLS -M; then
+        if [ -z "$mpls" ]; then
+            ok "RR MPLS routing table is empty"
+        else
+            fail "RR has unexpected MPLS routes"
+            printf '%s\n' "$mpls" >&2
+        fi
     fi
 
-    if docker exec "$RUSTBGPD" ip route show \
-        | grep -qE "${BLUE_PREFIX%/*}|${RED_PREFIX%/*}"; then
-        fail "RR kernel routing table contains a VPN-derived route"
-        docker exec "$RUSTBGPD" ip route show >&2 || true
-    else
-        ok "RR kernel routing table has no VPN-derived routes"
+    if capture_ip_routes ipv4 "$RUSTBGPD" IPv4; then
+        if grep -qE "${BLUE_PREFIX%/*}|${RED_PREFIX%/*}" <<<"$ipv4"; then
+            fail "RR kernel routing table contains a VPN-derived route"
+            printf '%s\n' "$ipv4" >&2
+        else
+            ok "RR kernel routing table has no VPN-derived routes"
+        fi
     fi
+}
+
+capture_ip_routes() {
+    local output_var=$1 container=$2 table_label=$3 captured
+    shift 3
+    if ! captured=$(docker exec "$container" ip "$@" route show 2>&1); then
+        fail "$container $table_label route inspection failed"
+        printf '%s\n' "$captured" >&2
+        return 1
+    fi
+    printf -v "$output_var" '%s' "$captured"
 }
 
 test_no_update_storm() {

--- a/tests/interop/scripts/test-m76-orr-divergent-best-gobgp.sh
+++ b/tests/interop/scripts/test-m76-orr-divergent-best-gobgp.sh
@@ -363,21 +363,35 @@ test_fallback() {
 test_dataplane_clean() {
     log "Test 6: RR installed nothing into any dataplane"
 
-    local mpls
-    mpls=$(docker exec "$RUSTBGPD" ip -M route show 2>/dev/null || true)
-    if [ -z "$mpls" ]; then
-        ok "RR MPLS routing table is empty"
-    else
-        fail "RR has unexpected MPLS routes"
-        echo "$mpls" >&2
+    local mpls ipv4
+    if capture_ip_routes mpls "$RUSTBGPD" MPLS -M; then
+        if [ -z "$mpls" ]; then
+            ok "RR MPLS routing table is empty"
+        else
+            fail "RR has unexpected MPLS routes"
+            printf '%s\n' "$mpls" >&2
+        fi
     fi
 
-    if docker exec "$RUSTBGPD" ip route show | grep -q "${PREFIX%/*}"; then
-        fail "RR kernel routing table contains $PREFIX"
-        docker exec "$RUSTBGPD" ip route show >&2 || true
-    else
-        ok "RR kernel routing table has no route for $PREFIX"
+    if capture_ip_routes ipv4 "$RUSTBGPD" IPv4; then
+        if grep -q "${PREFIX%/*}" <<<"$ipv4"; then
+            fail "RR kernel routing table contains $PREFIX"
+            printf '%s\n' "$ipv4" >&2
+        else
+            ok "RR kernel routing table has no route for $PREFIX"
+        fi
     fi
+}
+
+capture_ip_routes() {
+    local output_var=$1 container=$2 table_label=$3 captured
+    shift 3
+    if ! captured=$(docker exec "$container" ip "$@" route show 2>&1); then
+        fail "$container $table_label route inspection failed"
+        printf '%s\n' "$captured" >&2
+        return 1
+    fi
+    printf -v "$output_var" '%s' "$captured"
 }
 
 test_recovery() {

--- a/tests/interop/scripts/test-m77-gr-llgr-rr-gobgp.sh
+++ b/tests/interop/scripts/test-m77-gr-llgr-rr-gobgp.sh
@@ -727,22 +727,35 @@ test_ls_gr_window() {
 test_no_dataplane_install() {
     log "Test 7: RR installed nothing into any dataplane"
 
-    local mpls
-    mpls=$(docker exec "$RUSTBGPD" ip -M route show 2>/dev/null || true)
-    if [ -z "$mpls" ]; then
-        ok "RR MPLS routing table is empty"
-    else
-        fail "RR has unexpected MPLS routes"
-        echo "$mpls" >&2
+    local mpls ipv4
+    if capture_ip_routes mpls "$RUSTBGPD" MPLS -M; then
+        if [ -z "$mpls" ]; then
+            ok "RR MPLS routing table is empty"
+        else
+            fail "RR has unexpected MPLS routes"
+            printf '%s\n' "$mpls" >&2
+        fi
     fi
 
-    if docker exec "$RUSTBGPD" ip route show \
-        | grep -qE "${BLUE_PREFIX%/*}|${RED_PREFIX%/*}|${CLIENT_PREFIX%/*}"; then
-        fail "RR kernel routing table contains a VPN-derived route"
-        docker exec "$RUSTBGPD" ip route show >&2 || true
-    else
-        ok "RR kernel routing table has no VPN-derived routes"
+    if capture_ip_routes ipv4 "$RUSTBGPD" IPv4; then
+        if grep -qE "${BLUE_PREFIX%/*}|${RED_PREFIX%/*}|${CLIENT_PREFIX%/*}" <<<"$ipv4"; then
+            fail "RR kernel routing table contains a VPN-derived route"
+            printf '%s\n' "$ipv4" >&2
+        else
+            ok "RR kernel routing table has no VPN-derived routes"
+        fi
     fi
+}
+
+capture_ip_routes() {
+    local output_var=$1 container=$2 table_label=$3 captured
+    shift 3
+    if ! captured=$(docker exec "$container" ip "$@" route show 2>&1); then
+        fail "$container $table_label route inspection failed"
+        printf '%s\n' "$captured" >&2
+        return 1
+    fi
+    printf -v "$output_var" '%s' "$captured"
 }
 
 main() {

--- a/tests/interop/scripts/test-m78-multicluster-orr-gobgp.sh
+++ b/tests/interop/scripts/test-m78-multicluster-orr-gobgp.sh
@@ -496,24 +496,37 @@ test_withdraw_restore() {
 
 test_dataplane_clean() {
     log "Test 7: neither RR installed anything into any dataplane"
-    local rr
+    local rr mpls ipv4
     for rr in "$RR1" "$RR2"; do
-        local mpls
-        mpls=$(docker exec "$rr" ip -M route show 2>/dev/null || true)
-        if [ -z "$mpls" ]; then
-            ok "$rr MPLS routing table is empty"
-        else
-            fail "$rr has unexpected MPLS routes"
-            echo "$mpls" >&2
+        if capture_ip_routes mpls "$rr" MPLS -M; then
+            if [ -z "$mpls" ]; then
+                ok "$rr MPLS routing table is empty"
+            else
+                fail "$rr has unexpected MPLS routes"
+                printf '%s\n' "$mpls" >&2
+            fi
         fi
 
-        if docker exec "$rr" ip route show | grep -q "${PREFIX%/*}"; then
-            fail "$rr kernel routing table contains $PREFIX"
-            docker exec "$rr" ip route show >&2 || true
-        else
-            ok "$rr kernel routing table has no route for $PREFIX"
+        if capture_ip_routes ipv4 "$rr" IPv4; then
+            if grep -q "${PREFIX%/*}" <<<"$ipv4"; then
+                fail "$rr kernel routing table contains $PREFIX"
+                printf '%s\n' "$ipv4" >&2
+            else
+                ok "$rr kernel routing table has no route for $PREFIX"
+            fi
         fi
     done
+}
+
+capture_ip_routes() {
+    local output_var=$1 container=$2 table_label=$3 captured
+    shift 3
+    if ! captured=$(docker exec "$container" ip "$@" route show 2>&1); then
+        fail "$container $table_label route inspection failed"
+        printf '%s\n' "$captured" >&2
+        return 1
+    fi
+    printf -v "$output_var" '%s' "$captured"
 }
 
 main() {

--- a/tests/interop/scripts/test-m79-labeled-reflection-gobgp.sh
+++ b/tests/interop/scripts/test-m79-labeled-reflection-gobgp.sh
@@ -526,25 +526,44 @@ test_relaunch_eor_sweep() {
 test_no_dataplane_install() {
     log "Test 7: RR installed nothing into any dataplane"
 
-    local mpls
-    mpls=$(docker exec "$RUSTBGPD" ip -M route show 2>/dev/null || true)
-    if [ -z "$mpls" ]; then
-        ok "RR MPLS routing table is empty"
-    else
-        fail "RR has unexpected MPLS routes"
-        echo "$mpls" >&2
+    local mpls ipv4 ipv6
+    if capture_ip_routes mpls "$RUSTBGPD" MPLS -M; then
+        if [ -z "$mpls" ]; then
+            ok "RR MPLS routing table is empty"
+        else
+            fail "RR has unexpected MPLS routes"
+            printf '%s\n' "$mpls" >&2
+        fi
     fi
 
-    if docker exec "$RUSTBGPD" ip route show \
-        | grep -qE "${V4_PREFIX_A%/*}|${V4_PREFIX_B%/*}"; then
-        fail "RR kernel routing table contains a labeled-derived route"
-        docker exec "$RUSTBGPD" ip route show >&2 || true
-    elif docker exec "$RUSTBGPD" ip -6 route show | grep -qF "${V6_PREFIX%/*}"; then
-        fail "RR kernel v6 routing table contains a labeled-derived route"
-        docker exec "$RUSTBGPD" ip -6 route show >&2 || true
-    else
-        ok "RR kernel routing tables have no labeled-derived routes"
+    if capture_ip_routes ipv4 "$RUSTBGPD" IPv4; then
+        if grep -qE "${V4_PREFIX_A%/*}|${V4_PREFIX_B%/*}" <<<"$ipv4"; then
+            fail "RR kernel routing table contains a labeled-derived route"
+            printf '%s\n' "$ipv4" >&2
+        else
+            ok "RR kernel IPv4 routing table has no labeled-derived routes"
+        fi
     fi
+
+    if capture_ip_routes ipv6 "$RUSTBGPD" IPv6 -6; then
+        if grep -qF "${V6_PREFIX%/*}" <<<"$ipv6"; then
+            fail "RR kernel v6 routing table contains a labeled-derived route"
+            printf '%s\n' "$ipv6" >&2
+        else
+            ok "RR kernel IPv6 routing table has no labeled-derived routes"
+        fi
+    fi
+}
+
+capture_ip_routes() {
+    local output_var=$1 container=$2 table_label=$3 captured
+    shift 3
+    if ! captured=$(docker exec "$container" ip "$@" route show 2>&1); then
+        fail "$container $table_label route inspection failed"
+        printf '%s\n' "$captured" >&2
+        return 1
+    fi
+    printf -v "$output_var" '%s' "$captured"
 }
 
 main() {

--- a/tests/interop/scripts/test-m86-rr-openbgpd.sh
+++ b/tests/interop/scripts/test-m86-rr-openbgpd.sh
@@ -82,22 +82,6 @@ wait_obgp_established() {
     return 1
 }
 
-grpc_get_metrics() {
-    grpcurl_call \
-        "$GRPC_ADDR" rustbgpd.v1.ControlService/GetMetrics 2>/dev/null
-}
-
-# Sum of bgp_gr_stale_routes across peers on the RR.
-rr_stale_count() {
-    local total=0
-    while IFS= read -r val; do
-        total=$((total + ${val%.*}))
-    done < <(grpc_get_metrics | grep -oP 'bgp_gr_stale_routes\{[^}]*\}\s+\K[0-9.]+' || true)
-    echo "$total"
-}
-
-stale_is_zero() { [ "$(rr_stale_count)" -eq 0 ]; }
-
 # Poll until a command succeeds; usage: poll <tries> <sleep> <label> cmd...
 poll() {
     local tries=${1:?} pause=${2:?} label=${3:?}
@@ -120,7 +104,40 @@ obgp_has_bgp_route() {
         | jq -e '[.rib[]? | select(((.announced // false) | not) and .valid == true)] | length > 0'
 }
 
-obgp_lacks_bgp_route() { ! obgp_has_bgp_route "$1" "$2"; }
+obgp_lacks_bgp_route() {
+    local container=${1:?} rr_addr=${2:?} prefix=${3:?} neighbor output
+    if ! neighbor=$(docker exec "$container" bgpctl show neighbor "$rr_addr" 2>&1); then
+        printf 'OpenBGPD neighbor inspection failed for %s in %s:\n%s\n' \
+            "$rr_addr" "$container" "$neighbor" >&2
+        return 2
+    fi
+    if ! grep -q 'BGP state = Established' <<<"$neighbor"; then
+        printf 'OpenBGPD neighbor %s in %s is not Established:\n%s\n' \
+            "$rr_addr" "$container" "$neighbor" >&2
+        return 1
+    fi
+    # An exact-prefix bgpctl query exits nonzero when the route is absent, so
+    # inspect the full RIB and apply the exact-prefix predicate with jq.
+    if ! output=$(docker exec "$container" bgpctl -j show rib 2>&1); then
+        printf 'OpenBGPD RIB inspection failed for %s in %s:\n%s\n' \
+            "$prefix" "$container" "$output" >&2
+        return 2
+    fi
+    if ! jq -e '.rib | type == "array"' <<<"$output" >/dev/null 2>&1; then
+        printf 'OpenBGPD RIB inspection returned malformed JSON or a non-array .rib:\n%s\n' \
+            "$output" >&2
+        return 2
+    fi
+    if ! jq -e '.rib | length > 0 and all(.[]; .prefix | type == "string")' \
+        <<<"$output" >/dev/null 2>&1; then
+        printf 'OpenBGPD RIB inspection returned no survivor rows or a row without a string prefix:\n%s\n' \
+            "$output" >&2
+        return 2
+    fi
+    jq -e --arg p "$prefix" \
+        '[.rib[] | select(.prefix == $p and ((.announced // false) | not) and .valid == true)]
+         | length == 0' <<<"$output" >/dev/null
+}
 
 # True if the rustbgpd client's Loc-RIB has the prefix.
 client_has_route() {
@@ -128,12 +145,59 @@ client_has_route() {
         '[.[] | select(.prefix == $p)] | length > 0'
 }
 
-client_lacks_route() { ! client_has_route "$1"; }
+client_lacks_route() {
+    local prefix=${1:?} output
+    if ! client_established; then
+        printf 'rustbgpd client session is not Established while checking absence of %s\n' \
+            "$prefix" >&2
+        return 1
+    fi
+    if ! output=$(client_ctl rib -j 2>&1); then
+        printf 'rustbgpd client RIB inspection failed for %s:\n%s\n' "$prefix" "$output" >&2
+        return 2
+    fi
+    if ! jq -e 'type == "array"' <<<"$output" >/dev/null 2>&1; then
+        printf 'rustbgpd client RIB inspection returned malformed or non-array JSON:\n%s\n' \
+            "$output" >&2
+        return 2
+    fi
+    if ! jq -e 'all(.[]; .prefix | type == "string")' \
+        <<<"$output" >/dev/null 2>&1; then
+        printf 'rustbgpd client RIB inspection returned a row without a string prefix:\n%s\n' \
+            "$output" >&2
+        return 2
+    fi
+    jq -e --arg p "$prefix" --arg survivor "$O2_V4" \
+        '([.[] | select(.prefix == $p)] | length == 0)
+         and ([.[] | select(.prefix == $survivor)] | length >= 1)' \
+        <<<"$output" >/dev/null
+}
+
+rr_lacks_routes_from() {
+    local peer=${1:?} output
+    if ! output=$(rr_ctl rib -j 2>&1); then
+        printf 'RR RIB inspection failed for peer %s:\n%s\n' "$peer" "$output" >&2
+        return 2
+    fi
+    if ! jq -e 'type == "array"' <<<"$output" >/dev/null 2>&1; then
+        printf 'RR RIB inspection returned malformed or non-array JSON:\n%s\n' "$output" >&2
+        return 2
+    fi
+    if ! jq -e 'length > 0 and all(.[]; .peer_address | type == "string")' \
+        <<<"$output" >/dev/null 2>&1; then
+        printf 'RR RIB inspection returned no survivor rows or a row without a string peer_address:\n%s\n' \
+            "$output" >&2
+        return 2
+    fi
+    jq -e --arg peer "$peer" '[.[] | select(.peer_address == $peer)] | length == 0' \
+        <<<"$output" >/dev/null
+}
 
 # True if the rustbgpd client's session to the RR is Established.
 client_established() {
     client_ctl neighbor -j 2>/dev/null \
-        | jq -e '[.[] | select(.state == "Established")] | length >= 1'
+        | jq -e 'type == "array"
+                 and ([.[] | select(.state == "Established")] | length >= 1)'
 }
 
 # ---------------------------------------------------------------------------
@@ -240,7 +304,7 @@ test_no_reflect_back() {
         fail "RR does not advertise obgp2's $O2_V4 to obgp1"
     fi
 
-    if obgp_lacks_bgp_route "$OBGP1" "$O1_V4"; then
+    if obgp_lacks_bgp_route "$OBGP1" "$RR_FROM_OBGP1" "$O1_V4"; then
         ok "obgp1 has no BGP-learned path for its own $O1_V4 (announced only)"
     else
         fail "obgp1 received its own $O1_V4 back from the RR"
@@ -258,15 +322,15 @@ test_gr_helper_only() {
     # No AF was advertised as preserved, so the RR must withdraw
     # obgp1's routes from the surviving clients immediately.
     poll 20 2 "obgp2 loses $O1_V4 (withdraw propagated)" \
-        obgp_lacks_bgp_route "$OBGP2" "$O1_V4"
+        obgp_lacks_bgp_route "$OBGP2" "$RR_FROM_OBGP2" "$O1_V4"
     poll 10 2 "obgp2 loses $O1_V6 (withdraw propagated)" \
-        obgp_lacks_bgp_route "$OBGP2" "$O1_V6"
+        obgp_lacks_bgp_route "$OBGP2" "$RR_FROM_OBGP2" "$O1_V6"
     poll 10 2 "rustbgpd client loses $O1_V4" client_lacks_route "$O1_V4"
 
-    if stale_is_zero; then
-        ok "no stale routes on the RR (helper-only peer not GR-preserved)"
+    if rr_lacks_routes_from "$OBGP1_ADDR"; then
+        ok "no routes from obgp1 remain on the RR (helper-only peer not GR-preserved)"
     else
-        fail "RR stale-preserved a helper-only (no-AF) GR peer: $(rr_stale_count) stale"
+        fail "RR retained routes from helper-only (no-AF) GR peer $OBGP1_ADDR"
     fi
 
     # Recovery: obgp1 comes back, everything re-converges.

--- a/tests/interop/scripts/test-m86-rr-openbgpd.sh
+++ b/tests/interop/scripts/test-m86-rr-openbgpd.sh
@@ -28,14 +28,21 @@
 #
 # Usage:
 #   bash tests/interop/scripts/test-m86-rr-openbgpd.sh
+#   bash tests/interop/scripts/test-m86-rr-openbgpd.sh --self-test-diagnostics
 
+set -euo pipefail
 
 TOPO="m86-rr-openbgpd"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INTEROP_TEST_OPERATOR_AUTH=1
 export INTEROP_TEST_OPERATOR_AUTH
-# shellcheck source=test-lib.sh
-source "$SCRIPT_DIR/test-lib.sh"
+if [ "${1:-}" = "--self-test-diagnostics" ]; then
+    ok() { printf 'PASS %s\n' "$*"; }
+    fail() { printf 'FAIL %s\n' "$*"; }
+else
+    # shellcheck source=test-lib.sh
+    source "$SCRIPT_DIR/test-lib.sh"
+fi
 OBGP1="clab-${TOPO}-obgp1"
 OBGP2="clab-${TOPO}-obgp2"
 CLIENT="clab-${TOPO}-client"
@@ -84,17 +91,37 @@ wait_obgp_established() {
 
 # Poll until a command succeeds; usage: poll <tries> <sleep> <label> cmd...
 poll() {
-    local tries=${1:?} pause=${2:?} label=${3:?}
+    local tries=${1:?} pause=${2:?} label=${3:?} last_output=""
     shift 3
     for i in $(seq 1 "$tries"); do
-        if "$@" >/dev/null 2>&1; then
+        if last_output=$("$@" 2>&1); then
             ok "$label (attempt $i)"
             return 0
         fi
         sleep "$pause"
     done
     fail "$label — timed out after $((tries * pause))s"
+    if [ -n "$last_output" ]; then
+        printf 'Last failed observation:\n%s\n' "$last_output" >&2
+    fi
     return 1
+}
+
+record_absence_check() {
+    local absent_message=${1:?} present_message=${2:?} inspection_message=${3:?}
+    shift 3
+    local status
+    if "$@"; then
+        ok "$absent_message"
+        return
+    else
+        status=$?
+    fi
+    case "$status" in
+        1) fail "$present_message" ;;
+        2) fail "$inspection_message" ;;
+        *) fail "$inspection_message (unexpected inspector status $status)" ;;
+    esac
 }
 
 # True if the OpenBGPD node has a VALID BGP path for the prefix learned
@@ -304,11 +331,11 @@ test_no_reflect_back() {
         fail "RR does not advertise obgp2's $O2_V4 to obgp1"
     fi
 
-    if obgp_lacks_bgp_route "$OBGP1" "$RR_FROM_OBGP1" "$O1_V4"; then
-        ok "obgp1 has no BGP-learned path for its own $O1_V4 (announced only)"
-    else
-        fail "obgp1 received its own $O1_V4 back from the RR"
-    fi
+    record_absence_check \
+        "obgp1 has no BGP-learned path for its own $O1_V4 (announced only)" \
+        "obgp1 received its own $O1_V4 back from the RR" \
+        "could not verify that obgp1 lacks its own $O1_V4 because OpenBGPD inspection failed" \
+        obgp_lacks_bgp_route "$OBGP1" "$RR_FROM_OBGP1" "$O1_V4"
 }
 
 # ---------------------------------------------------------------------------
@@ -327,17 +354,66 @@ test_gr_helper_only() {
         obgp_lacks_bgp_route "$OBGP2" "$RR_FROM_OBGP2" "$O1_V6"
     poll 10 2 "rustbgpd client loses $O1_V4" client_lacks_route "$O1_V4"
 
-    if rr_lacks_routes_from "$OBGP1_ADDR"; then
-        ok "no routes from obgp1 remain on the RR (helper-only peer not GR-preserved)"
-    else
-        fail "RR retained routes from helper-only (no-AF) GR peer $OBGP1_ADDR"
-    fi
+    record_absence_check \
+        "no routes from obgp1 remain on the RR (helper-only peer not GR-preserved)" \
+        "RR retained routes from helper-only (no-AF) GR peer $OBGP1_ADDR" \
+        "could not verify removal of routes from helper-only GR peer $OBGP1_ADDR because RR RIB inspection failed" \
+        rr_lacks_routes_from "$OBGP1_ADDR"
 
     # Recovery: obgp1 comes back, everything re-converges.
     start_bgpd "$OBGP1"
     wait_obgp_established "$OBGP1" "$RR_FROM_OBGP1" "obgp1 (restarted)" || return 1
     poll 15 2 "obgp2 re-learns $O1_V4" obgp_has_bgp_route "$OBGP2" "$O1_V4"
     poll 15 2 "rustbgpd client re-learns $O1_V6" client_has_route "$O1_V6"
+}
+
+self_test_output() {
+    local output=${1:?} expected=${2:?} rejected=${3:-}
+    if [[ "$output" != *"$expected"* ]] \
+        || { [ -n "$rejected" ] && [[ "$output" == *"$rejected"* ]]; }; then
+        printf 'diagnostic self-test expected %q and rejected %q in:\n%s\n' \
+            "$expected" "$rejected" "$output" >&2
+        return 1
+    fi
+}
+
+self_test_status() {
+    local status=${1:?}
+    if [ "$status" -eq 2 ]; then
+        printf 'pinned inspector diagnostic\n' >&2
+    fi
+    return "$status"
+}
+
+self_test_diagnostics() {
+    local output
+    if output=$(poll 2 0 "self-test poll" self_test_status 2 2>&1); then
+        printf 'diagnostic self-test expected poll failure\n' >&2
+        return 1
+    fi
+    self_test_output "$output" "self-test poll — timed out"
+    self_test_output "$output" "Last failed observation:"
+    self_test_output "$output" "pinned inspector diagnostic"
+
+    output=$(record_absence_check "route absent" "route still present" \
+        "inspection failed" self_test_status 0 2>&1)
+    self_test_output "$output" "route absent" "route still present"
+    self_test_output "$output" "route absent" "inspection failed"
+
+    output=$(record_absence_check "route absent" "route still present" \
+        "inspection failed" self_test_status 1 2>&1)
+    self_test_output "$output" "route still present" "inspection failed"
+
+    output=$(record_absence_check "route absent" "route still present" \
+        "inspection failed" self_test_status 2 2>&1)
+    self_test_output "$output" "pinned inspector diagnostic"
+    self_test_output "$output" "inspection failed" "route still present"
+
+    output=$(record_absence_check "route absent" "route still present" \
+        "inspection failed" self_test_status 7 2>&1)
+    self_test_output "$output" "inspection failed (unexpected inspector status 7)"
+
+    printf 'M86 diagnostic self-test passed\n'
 }
 
 # ---------------------------------------------------------------------------
@@ -371,4 +447,8 @@ main() {
     fi
 }
 
-main "$@"
+if [ "${1:-}" = "--self-test-diagnostics" ]; then
+    self_test_diagnostics
+else
+    main "$@"
+fi

--- a/tests/interop/scripts/test-m95-rfc8212-presence.sh
+++ b/tests/interop/scripts/test-m95-rfc8212-presence.sh
@@ -102,6 +102,62 @@ assert_no_flap() {
     fi
 }
 
+capture_bird_local_capabilities() {
+    local output_var=${1:?} output line trimmed block=""
+    local local_count=0 neighbor_count=0 in_local=0 neighbor_after_local=0
+
+    if ! output=$(docker exec "$BIRD" birdc show protocols all edge 2>&1); then
+        fail "could not inspect BIRD's advertised capabilities"
+        printf '%s\n' "$output" >&2
+        return 1
+    fi
+
+    while IFS= read -r line; do
+        trimmed=${line#"${line%%[![:space:]]*}"}
+        trimmed=${trimmed%"${trimmed##*[![:space:]]}"}
+        case "$trimmed" in
+            "Local capabilities")
+                local_count=$((local_count + 1))
+                in_local=1
+                ;;
+            "Neighbor capabilities")
+                neighbor_count=$((neighbor_count + 1))
+                if [ "$in_local" -eq 1 ]; then
+                    neighbor_after_local=$((neighbor_after_local + 1))
+                fi
+                in_local=0
+                ;;
+            *)
+                if [ "$in_local" -eq 1 ] && [ -n "$trimmed" ]; then
+                    block+="${block:+$'\n'}$trimmed"
+                fi
+                ;;
+        esac
+    done <<<"$output"
+
+    if [ "$local_count" -ne 1 ]; then
+        fail "expected exactly one Local capabilities sentinel, found $local_count"
+        printf '%s\n' "$output" >&2
+        return 1
+    fi
+    if [ "$neighbor_count" -ne 1 ]; then
+        fail "expected exactly one Neighbor capabilities sentinel, found $neighbor_count"
+        printf '%s\n' "$output" >&2
+        return 1
+    fi
+    if [ "$neighbor_after_local" -ne 1 ]; then
+        fail "Neighbor capabilities sentinel did not follow Local capabilities"
+        printf '%s\n' "$output" >&2
+        return 1
+    fi
+    if [ -z "$block" ]; then
+        fail "BIRD's bounded Local capabilities block is empty"
+        printf '%s\n' "$output" >&2
+        return 1
+    fi
+    printf -v "$output_var" '%s' "$block"
+}
+
 daemon_pid() {
     docker exec "$RUSTBGPD" sh -c \
         'grep -lF rustbgpd /proc/[0-9]*/comm 2>/dev/null | head -1 | cut -d/ -f3'
@@ -176,12 +232,13 @@ fi
 # off rustbgpd, so the lab cannot pass against a daemon that merely believes it.
 # Only BIRD's OWN advertisement counts; the "Neighbor capabilities" block right
 # below it is rustbgpd's, which does offer Route Refresh.
-if docker exec "$BIRD" birdc show protocols all edge 2>/dev/null \
-    | awk '/Local capabilities/{f=1; next} /Neighbor capabilities/{f=0} f' \
-    | grep -qi "route refresh"; then
-    fail "BIRD advertised Route Refresh — the no-capability half of this lab is vacuous"
-else
-    ok "BIRD advertised NO Route Refresh capability (premise of phases 1 and 4)"
+bird_local_capabilities=""
+if capture_bird_local_capabilities bird_local_capabilities; then
+    if grep -qi "route refresh" <<<"$bird_local_capabilities"; then
+        fail "BIRD advertised Route Refresh — the no-capability half of this lab is vacuous"
+    else
+        ok "BIRD advertised NO Route Refresh capability (premise of phases 1 and 4)"
+    fi
 fi
 if docker exec "$FRR" vtysh -c "show bgp neighbors 10.95.1.1 json" 2>/dev/null \
     | jq -e '.["10.95.1.1"].neighborCapabilities.routeRefresh != null' >/dev/null; then


### PR DESCRIPTION
## Summary

- prove Route Refresh activity and parse CLUSTER_LIST structurally in the maintained FRR RR receipts
- fail closed when VPN/ORR/GR dataplane inspection commands fail instead of treating missing evidence as an empty table
- reject malformed, empty, or unavailable absence observations in the OpenBGPD and RFC 8212 receipts

## Why

These receipts previously allowed command failures, malformed output, or no-op control actions to satisfy assertions intended to prove route-server and route-reflector behavior. The changes keep the product untouched and harden only the evidence boundary.

## Verification

- live M14: pinned FRR structured CLUSTER_LIST shape accepted
- live M15: 14/14; Route Refresh advances exactly once and the UPDATE counter increases
- live M74 through M79: 15/15, 36/36, 35/35, 58/58, 51/51, 41/41
- live M86: 27/27
- live M95: 31/31
- `bash -n` and ShellCheck across all ten changed scripts
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- `git diff --check`

## Load-bearing proofs

- a no-op SoftResetIn and a delayed second reset each make M15 red while legacy route/session assertions stay green
- a route-wide false-positive CLUSTER_LIST fixture makes M14 red
- forcing each of the fifteen dataplane inspectors to fail adds exactly one receipt failure
- command failure, malformed/empty JSON, missing survivor evidence, and retained withdrawn routes make M86/M95 red
- a no-op source shutdown creates exactly the four expected M86 behavioral failures