### PR TITLE
test(interop): make route-server receipts tell the truth

### DIFF
--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -1608,7 +1608,7 @@ M19 Transparent Route Server (3-node):
   FRR-A (AS 65002)       rustbgpd RS (AS 65001)       FRR-B (AS 65003)
   eth1: 10.0.0.2/24  ──  eth1: 10.0.0.1/24
   route_server_client     eth2: 10.0.1.1/24  ──  eth1: 10.0.1.2/24
-                          ip_forward=1                 route_server_client
+                                                       route_server_client
 ```
 
 FRR-A advertises: 192.168.1.0/24, 192.168.2.0/24.
@@ -1622,10 +1622,12 @@ Both peers are `route_server_client = true` on rustbgpd.
 (containerlab point-to-point links). Because `route_server_client` preserves
 the original NEXT_HOP, FRR-B receives routes with NH=10.0.0.2 (a different
 subnet). Each FRR peer needs a static route to the other's subnet via
-rustbgpd, and rustbgpd needs `ip_forward=1`.
+rustbgpd so FRR's BGP next-hop tracking can resolve the preserved address.
+M19 sends no data-plane traffic and does not prove packet forwarding through
+rustbgpd.
 
 **FRR enforce-first-as (critical):** FRR 10.x enables `enforce-first-as` by
-default. When rustbgpd (AS 65001) transparently forwards a route with
+default. When rustbgpd (AS 65001) transparently advertises a route with
 AS_PATH `[65002]`, FRR-B rejects it with `"incorrect first AS (must be 65001)"`.
 The fix is `no neighbor X.X.X.X enforce-first-as` **per-neighbor** in each FRR
 config. The global `no bgp enforce-first-as` alone is insufficient in FRR 10.3.1.
@@ -1646,7 +1648,7 @@ Verify routes from FRR-B arrive at FRR-A with AS_PATH `[65003]`.
 
 Verify routes show NEXT_HOP = 10.0.1.2 (FRR-B's original address).
 
-### Test 5: All Prefixes Forwarded
+### Test 5: All Prefixes Advertised and Received
 
 Verify both FRR-A prefixes (192.168.1.0/24, 192.168.2.0/24) are present on FRR-B.
 
@@ -1675,8 +1677,8 @@ Automated test: `bash tests/interop/scripts/test-m19-routeserver-frr.sh` — **1
 | AS_PATH on FRR-A contains 65003 | PASS | Origin AS preserved |
 | AS_PATH on FRR-A no 65001 | PASS | Route server ASN not prepended |
 | NEXT_HOP on FRR-A = 10.0.1.2 | PASS | FRR-B's original NH preserved |
-| 192.168.1.0/24 on FRR-B | PASS | Prefix forwarded |
-| 192.168.2.0/24 on FRR-B | PASS | Prefix forwarded |
+| 192.168.1.0/24 on FRR-B | PASS | Prefix advertised by FRR-A and received by FRR-B |
+| 192.168.2.0/24 on FRR-B | PASS | Prefix advertised by FRR-A and received by FRR-B |
 
 ---
 

--- a/tests/interop/m19-routeserver-frr.clab.yml
+++ b/tests/interop/m19-routeserver-frr.clab.yml
@@ -12,16 +12,12 @@
 #
 #   Peers are on separate /24 subnets (point-to-point links via containerlab).
 #   Because route_server_client preserves the original NEXT_HOP, FRR-B receives
-#   routes with NH=10.0.0.2 (FRR-A's address on a different subnet). Two things
-#   are required for this to work:
+#   routes with NH=10.0.0.2 (FRR-A's address on a different subnet). The
+#   cross-subnet static routes below make those BGP NEXT_HOPs resolvable for
+#   this control-plane receipt. M19 sends no data-plane traffic and does not
+#   prove packet forwarding through rustbgpd.
 #
-#   1. Cross-subnet static routes — each FRR peer needs a route to the other's
-#      subnet via rustbgpd, and rustbgpd needs ip_forward=1. Without this,
-#      FRR's BGP next-hop tracking marks the preserved next-hop as unresolvable
-#      and the route won't be installed in the FIB (though it still appears in
-#      the BGP table).
-#
-#   2. FRR enforce-first-as — FRR 10.x enables enforce-first-as by default.
+#   FRR enforce-first-as — FRR 10.x enables enforce-first-as by default.
 #      In a transparent route server setup, the AS_PATH does NOT start with
 #      the route server's ASN (e.g., FRR-B receives AS_PATH [65002] from
 #      AS 65001). FRR rejects this with "incorrect first AS" unless
@@ -50,7 +46,6 @@ topology:
         - ip link set eth1 up
         - ip addr add 10.0.1.1/24 dev eth2
         - ip link set eth2 up
-        - sysctl -w net.ipv4.ip_forward=1
       env:
         RUST_LOG: info
 

--- a/tests/interop/m83-routeserver-multistack.clab.yml
+++ b/tests/interop/m83-routeserver-multistack.clab.yml
@@ -32,8 +32,9 @@
 #   BIRD 2.0.12: `enforce first as off` (also the default)
 #   GoBGP 3.37:  no first-AS enforcement exists; nothing to disable
 #
-# Cross-subnet static routes + ip_forward on the RS keep the
-# preserved next hops resolvable (M19 note 1).
+# Cross-subnet static routes make the preserved BGP NEXT_HOPs
+# resolvable for this control-plane receipt. M83 sends no data-plane
+# traffic and does not prove packet forwarding through rustbgpd.
 #
 # Usage:
 #   docker build --target dev -t rustbgpd:dev .
@@ -63,7 +64,6 @@ topology:
         - ip link set eth2 up
         - ip addr add 10.83.3.1/24 dev eth3
         - ip link set eth3 up
-        - sysctl -w net.ipv4.ip_forward=1
       env:
         RUST_LOG: info
         RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token

--- a/tests/interop/scripts/test-m19-routeserver-frr.sh
+++ b/tests/interop/scripts/test-m19-routeserver-frr.sh
@@ -207,8 +207,8 @@ test_nexthop_preserved_on_a() {
 # ---------------------------------------------------------------------------
 # Test 5: Both prefixes from FRR-A arrive at FRR-B
 # ---------------------------------------------------------------------------
-test_all_prefixes_forwarded() {
-    log "Test 5: Both FRR-A prefixes forwarded to FRR-B"
+test_all_prefixes_advertised() {
+    log "Test 5: Both FRR-A prefixes advertised to and received by FRR-B"
 
     for prefix in "192.168.1.0" "192.168.2.0"; do
         local frr_b_routes
@@ -237,16 +237,16 @@ main() {
     # Wait for routes from both peers
     wait_routes 3 || true
 
-    # Wait for FRR-B to receive forwarded routes (1 local + 2 from FRR-A = 3)
+    # Wait for FRR-B to receive advertised routes (1 local + 2 from FRR-A = 3)
     wait_frr_routes "$FRR_B" 3 || true
-    # Wait for FRR-A to receive forwarded routes (2 local + 1 from FRR-B = 3)
+    # Wait for FRR-A to receive advertised routes (2 local + 1 from FRR-B = 3)
     wait_frr_routes "$FRR_A" 3 || true
 
     test_no_asn_prepend_on_b
     test_nexthop_preserved_on_b
     test_no_asn_prepend_on_a
     test_nexthop_preserved_on_a
-    test_all_prefixes_forwarded
+    test_all_prefixes_advertised
 
     echo ""
     log "Results: $pass passed, $fail failed"

--- a/tests/interop/scripts/test-m83-routeserver-multistack.sh
+++ b/tests/interop/scripts/test-m83-routeserver-multistack.sh
@@ -370,17 +370,19 @@ stop_capture() {
     local signaled
     if ! signaled=$(docker exec "$BIRD" sh -c '
         found=0
+        capture_pid=
         for file in /proc/[0-9]*/comm; do
             [ "$(cat "$file" 2>/dev/null)" = tshark ] || continue
             pid=${file#/proc/}; pid=${pid%/comm}
-            kill -INT "$pid" || exit 1
+            capture_pid=$pid
             found=$((found + 1))
         done
         [ "$found" -eq 1 ] || {
             echo "expected exactly one tshark capture, found $found" >&2
             exit 1
         }
-        printf "%s\n" "$found"
+        kill -INT "$capture_pid" || exit 1
+        printf "%s\n" "$capture_pid"
     '); then
         fail "could not identify and signal exactly one tshark capture"
         return 1

--- a/tests/interop/scripts/test-m83-routeserver-multistack.sh
+++ b/tests/interop/scripts/test-m83-routeserver-multistack.sh
@@ -68,15 +68,14 @@
 #   40  wire large community 65002:2:2 verbatim
 #   41  wire OTC path attribute (type code 35) present on RS→BIRD
 #       announcements (value pinned as 65500 by assertion 18)
-#   42  EoR: RS→BIRD IPv4-unicast End-of-RIB present, after the first
-#       NLRI-bearing UPDATE (ordering sanity)
+#   42  EoR: exactly one RS→BIRD IPv4-unicast End-of-RIB follows the
+#       final NLRI-bearing UPDATE by (frame, BGP-PDU) order
 #   --- withdraw propagation + reload stability ---
 #   43  BIRD withdraws 203.0.113.0/24 → gone on FRR
 #   44  BIRD withdraws 203.0.113.0/24 → gone on GoBGP
-#   45  policy reload (import-chain LP edit + SIGHUP): FRR session
-#       survives (connectionsEstablished unchanged)
-#   46  after the reload BIRD still holds 100.66.0.0/24 (no spurious
-#       withdraw/churn — the OpenBGPd bug class, negative)
+#   45  policy reload changes still-present FRR route 100.67.0.0/24
+#       from LP 100→110 and bumps its import-chain install generation
+#   46  the FRR session marker remains unchanged across that reload
 #
 # Prerequisites:
 #   - docker build --target dev -t rustbgpd:dev .
@@ -86,6 +85,97 @@
 #
 # Usage:
 #   bash tests/interop/scripts/test-m83-routeserver-multistack.sh
+
+check_ipv4_eor_order() {
+    python3 - "${1:?}" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+root = ET.parse(sys.argv[1]).getroot()
+events = []
+for packet in root.findall("packet"):
+    frame_field = packet.find(".//field[@name='frame.number']")
+    if frame_field is None or frame_field.get("show") is None:
+        raise SystemExit("packet missing frame.number")
+    frame = int(frame_field.get("show"))
+    for index, bgp in enumerate(packet.findall(".//proto[@name='bgp']"), 1):
+        bgp_type = bgp.find(".//field[@name='bgp.type']")
+        if bgp_type is not None:
+            events.append(((frame, index), bgp_type.get("show"), bgp))
+
+opens = [key for key, bgp_type, _ in events if bgp_type == "1"]
+if not opens:
+    raise SystemExit("no RS-to-BIRD OPEN in capture")
+last_open = max(opens)
+
+last_nlri = None
+eors = []
+for key, bgp_type, bgp in events:
+    if key <= last_open or bgp_type != "2":
+        continue
+    classic = bgp.findall(".//field[@name='bgp.nlri_prefix']")
+    if classic:
+        last_nlri = key
+    withdrawn = bgp.find(".//field[@name='bgp.update.withdrawn_routes.length']")
+    attrs = bgp.find(".//field[@name='bgp.update.path_attributes.length']")
+    codes = bgp.findall(".//field[@name='bgp.update.path_attribute.type_code']")
+    if (bgp.get("size") == "23"
+            and withdrawn is not None and withdrawn.get("show") == "0"
+            and attrs is not None and attrs.get("show") == "0"
+            and not codes and not classic):
+        eors.append(key)
+
+if last_nlri is None:
+    raise SystemExit(f"no IPv4 NLRI-bearing UPDATE after final OPEN {last_open}")
+if len(eors) != 1:
+    raise SystemExit(f"{len(eors)} exact IPv4 EoRs after final OPEN {last_open} (want 1)")
+if eors[0] <= last_nlri:
+    raise SystemExit(f"IPv4 EoR {eors[0]} not after final NLRI {last_nlri}")
+print(f"final OPEN {last_open}; final IPv4 NLRI {last_nlri} < EoR {eors[0]}")
+PY
+}
+
+self_test_ipv4_eor_order() {
+    local valid reversed
+    valid=$(mktemp)
+    reversed=$(mktemp)
+    python3 - "$valid" "$reversed" <<'PY'
+from pathlib import Path
+import sys
+
+opening = """<proto name="bgp"><field name="bgp.type" show="1"/></proto>"""
+nlri = """<proto name="bgp"><field name="bgp.type" show="2"/>
+<field name="bgp.nlri_prefix" show="100.67.0.0"/></proto>"""
+eor = """<proto name="bgp" size="23"><field name="bgp.type" show="2"/>
+<field name="bgp.update.withdrawn_routes.length" show="0"/>
+<field name="bgp.update.path_attributes.length" show="0"/></proto>"""
+
+def pdml(first, second):
+    return f"""<pdml>
+<packet><proto name="frame"><field name="frame.number" show="1"/></proto>{opening}</packet>
+<packet><proto name="frame"><field name="frame.number" show="2"/></proto>{first}{second}</packet>
+</pdml>"""
+
+Path(sys.argv[1]).write_text(pdml(nlri, eor))
+Path(sys.argv[2]).write_text(pdml(eor, nlri))
+PY
+    if ! check_ipv4_eor_order "$valid" >/dev/null; then
+        rm -f "$valid" "$reversed"
+        return 1
+    fi
+    if check_ipv4_eor_order "$reversed" >/dev/null 2>&1; then
+        echo "ERROR: same-frame EoR-before-NLRI fixture passed" >&2
+        rm -f "$valid" "$reversed"
+        return 1
+    fi
+    rm -f "$valid" "$reversed"
+    echo "M83 IPv4 EoR tuple-order self-test passed"
+}
+
+if [ "${1:-}" = "--self-test-eor-order" ]; then
+    self_test_ipv4_eor_order
+    exit
+fi
 
 TOPO="m83-routeserver-multistack"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -205,9 +295,40 @@ start_capture() {
 
 stop_capture() {
     log "Stopping tshark capture..."
-    docker exec "$BIRD" sh -c \
-        'pkill -INT tshark >/dev/null 2>&1 || pkill tshark >/dev/null 2>&1 || true'
-    sleep 2
+    local signaled
+    if ! signaled=$(docker exec "$BIRD" sh -c '
+        found=0
+        for file in /proc/[0-9]*/comm; do
+            [ "$(cat "$file" 2>/dev/null)" = tshark ] || continue
+            pid=${file#/proc/}; pid=${pid%/comm}
+            kill -INT "$pid" || exit 1
+            found=$((found + 1))
+        done
+        [ "$found" -eq 1 ] || {
+            echo "expected exactly one tshark capture, found $found" >&2
+            exit 1
+        }
+        printf "%s\n" "$found"
+    '); then
+        fail "could not identify and signal exactly one tshark capture"
+        return 1
+    fi
+
+    for _ in $(seq 1 10); do
+        if ! docker exec "$BIRD" sh -c 'cat /proc/[0-9]*/comm 2>/dev/null' \
+            | grep -qx tshark; then
+            if docker exec "$BIRD" test -s /tmp/m83.pcap \
+                && docker exec "$BIRD" tshark -r /tmp/m83.pcap -c 1 >/dev/null 2>&1; then
+                log "tshark capture $signaled terminated; pcap is nonempty and readable"
+                return 0
+            fi
+            fail "tshark terminated without a nonempty readable /tmp/m83.pcap"
+            return 1
+        fi
+        sleep 1
+    done
+    fail "tshark did not flush and exit within 10s"
+    return 1
 }
 
 start_bird() {
@@ -612,23 +733,21 @@ assert_wire() {
     fi
 
     # EoR ordering over the LAST BIRD session (bounced above over a
-    # full RS table, so the flood-then-EoR order is deterministic —
-    # the very first session's EoR may legitimately precede member
-    # routes that hadn't arrived yet). EoR = empty UPDATE (no
-    # withdrawn routes, no path attributes). >= because rustbgpd may
-    # pack the last UPDATE and the EoR into one TCP segment.
-    local last_open first_eor first_nlri
-    last_open=$(bird_tshark -Y "ip.src == ${RS_BIRD_ADDR} && bgp.type == 1" \
-        -T fields -e frame.number | tail -1)
-    first_eor=$(bird_tshark -Y "$base && frame.number > ${last_open:-0} && bgp.update.withdrawn_routes.length == 0 && bgp.update.path_attributes.length == 0" \
-        -T fields -e frame.number | head -1)
-    first_nlri=$(bird_tshark -Y "$base && frame.number > ${last_open:-0} && bgp.nlri_prefix" \
-        -T fields -e frame.number | head -1)
-    if [ -n "$first_eor" ] && [ -n "$first_nlri" ] && [ "$first_eor" -ge "$first_nlri" ]; then
-        ok "IPv4-unicast EoR after the table flood (session at frame ${last_open}: NLRI $first_nlri → EoR $first_eor)"
+    # full RS table, so the flood-then-EoR order is deterministic).
+    # PDML preserves multiple BGP PDUs within one frame; comparing the
+    # (frame number, PDU index) tuple prevents a coalesced EoR that
+    # precedes the final NLRI from passing on frame equality.
+    local pdml eor_order
+    pdml=$(mktemp)
+    if bird_tshark \
+        -Y "ip.src == ${RS_BIRD_ADDR} && ip.dst == ${BIRD_ADDR} && bgp" \
+        -T pdml >"$pdml" \
+        && eor_order=$(check_ipv4_eor_order "$pdml" 2>&1); then
+        ok "IPv4-unicast EoR follows the final table-flood NLRI by (frame,PDU): $eor_order"
     else
-        fail "EoR ordering check failed (open='$last_open', first NLRI='$first_nlri', first EoR='$first_eor')"
+        fail "EoR ordering check failed: ${eor_order:-PDML export failed}"
     fi
+    rm -f "$pdml"
 }
 
 # Bounce the BIRD session over the now-full RS table so the last
@@ -665,31 +784,69 @@ assert_withdraw_propagation() {
 }
 
 assert_reload_stability() {
-    log "Assertions 45-46: session stability through a policy reload"
-    local estab_before estab_after
-    estab_before=$(docker exec "$FRR" vtysh -c "show bgp neighbors ${RS_FRR_ADDR} json" 2>/dev/null \
+    log "Assertions 45-46: live route change and session stability through a policy reload"
+    local marker_before marker_after lp_before lp_after generation_before generation_after
+    marker_before=$(docker exec "$FRR" vtysh -c "show bgp neighbors ${RS_FRR_ADDR} json" 2>/dev/null \
         | jq -r --arg p "$RS_FRR_ADDR" '.[$p].connectionsEstablished // 0')
-
-    # Content-changing import-chain edit (LP 200 → 210 in
-    # prefer-rpki-valid) + SIGHUP: refresh, not session reset.
-    docker exec "$RUSTBGPD" sh -c \
-        'sed -i "s/set_local_pref = 200/set_local_pref = 210/" /tmp/config.toml'
-    rs_sighup
-    sleep 6
-
-    estab_after=$(docker exec "$FRR" vtysh -c "show bgp neighbors ${RS_FRR_ADDR} json" 2>/dev/null \
-        | jq -r --arg p "$RS_FRR_ADDR" '.[$p].connectionsEstablished // 0')
-    if [ -n "$estab_before" ] && [ "$estab_before" = "$estab_after" ] \
-        && [ "$estab_after" != "0" ]; then
-        ok "FRR session survived the policy reload (connectionsEstablished $estab_before → $estab_after)"
-    else
-        fail "FRR session bounced across the reload ($estab_before → $estab_after)"
+    lp_before=$(rs_ctl rib --prefix 100.67.0.0/24 -j \
+        | jq -er --arg peer "$FRR_ADDR" '
+            [.[] | select(.prefix == "100.67.0.0/24" and .peer_address == $peer)]
+            | if length == 1 then .[0].local_pref
+              else error("FRR probe route is not uniquely present")
+              end')
+    generation_before=$(rs_ctl -j policy stats --peer "$FRR_ADDR" --direction import \
+        | jq -er --arg peer "$FRR_ADDR" '
+            [.chains[] | select(.peer_address == $peer and .direction == "import")]
+            | if length == 1 then .[0].policy_generation
+              else error("FRR import chain is not uniquely installed")
+              end')
+    if [ "$lp_before" != "100" ]; then
+        fail "FRR probe 100.67.0.0/24 pre-reload LP is $lp_before (want 100)"
+        return
     fi
 
-    if birdc_route_all 100.66.0.0/24 | grep -q "BGP.as_path: 65002"; then
-        ok "BIRD still holds 100.66.0.0/24 after the reload (no spurious churn)"
+    # 100.67.0.0/24 is uniquely sourced by FRR and remains present for
+    # this phase. Mutate the not-found term that accepted it, then
+    # require both the live route and installed-chain generation to move.
+    docker exec "$RUSTBGPD" sh -c '
+        set -e
+        [ "$(grep -c "^set_local_pref = 100$" /tmp/config.toml)" -eq 1 ]
+        sed -i "s/^set_local_pref = 100$/set_local_pref = 110/" /tmp/config.toml
+        [ "$(grep -c "^set_local_pref = 110$" /tmp/config.toml)" -eq 1 ]
+    '
+    rs_sighup
+
+    lp_after=$lp_before
+    generation_after=$generation_before
+    for _ in $(seq 1 20); do
+        lp_after=$(rs_ctl rib --prefix 100.67.0.0/24 -j \
+            | jq -er --arg peer "$FRR_ADDR" '
+                [.[] | select(.prefix == "100.67.0.0/24" and .peer_address == $peer)]
+                | if length == 1 then .[0].local_pref
+                  else error("FRR probe route is not uniquely present")
+                  end')
+        generation_after=$(rs_ctl -j policy stats --peer "$FRR_ADDR" --direction import \
+            | jq -er --arg peer "$FRR_ADDR" '
+                [.chains[] | select(.peer_address == $peer and .direction == "import")]
+                | if length == 1 then .[0].policy_generation
+                  else error("FRR import chain is not uniquely installed")
+                  end')
+        [ "$lp_after" = "110" ] && [ "$generation_after" -gt "$generation_before" ] && break
+        sleep 1
+    done
+    if [ "$lp_after" = "110" ] && [ "$generation_after" -gt "$generation_before" ]; then
+        ok "FRR probe stayed present and changed LP 100→110; import generation $generation_before→$generation_after"
     else
-        fail "BIRD lost 100.66.0.0/24 across the policy reload"
+        fail "live reload did not move FRR probe LP/generation (LP $lp_before→$lp_after, generation $generation_before→$generation_after)"
+    fi
+
+    marker_after=$(docker exec "$FRR" vtysh -c "show bgp neighbors ${RS_FRR_ADDR} json" 2>/dev/null \
+        | jq -r --arg p "$RS_FRR_ADDR" '.[$p].connectionsEstablished // 0')
+    if [ -n "$marker_before" ] && [ "$marker_before" = "$marker_after" ] \
+        && [ "$marker_after" != "0" ]; then
+        ok "FRR session marker unchanged across reload (connectionsEstablished=$marker_after)"
+    else
+        fail "FRR session marker moved across reload ($marker_before→$marker_after)"
     fi
 }
 

--- a/tests/interop/scripts/test-m83-routeserver-multistack.sh
+++ b/tests/interop/scripts/test-m83-routeserver-multistack.sh
@@ -75,7 +75,8 @@
 #   44  BIRD withdraws 203.0.113.0/24 → gone on GoBGP
 #   45  policy reload changes still-present FRR route 100.67.0.0/24
 #       from LP 100→110 and bumps its import-chain install generation
-#   46  the FRR session marker remains unchanged across that reload
+#   46  FRR remains authoritatively Established/non-stale with unchanged
+#       flap count, nondecreasing uptime, and cumulative session marker
 #
 # Prerequisites:
 #   - docker build --target dev -t rustbgpd:dev .
@@ -172,10 +173,75 @@ PY
     echo "M83 IPv4 EoR tuple-order self-test passed"
 }
 
-if [ "${1:-}" = "--self-test-eor-order" ]; then
-    self_test_ipv4_eor_order
-    exit
-fi
+authoritative_established_snapshot() {
+    printf '%s\n' "${1:?}" | jq -e '
+        type == "object"
+        and .state == "SESSION_STATE_ESTABLISHED"
+        and ((.stale // false) == false)
+        and ((try ((.flapCount // 0) | tonumber) catch -1) >= 0)
+        and ((try ((.uptimeSeconds // 0) | tonumber) catch -1) >= 0)
+    ' >/dev/null
+}
+
+check_session_continuity() {
+    local before=${1:?} after=${2:?} marker_before=${3:?} marker_after=${4:?}
+    authoritative_established_snapshot "$before" || return 1
+    authoritative_established_snapshot "$after" || return 1
+    jq -en \
+        --argjson before "$before" \
+        --argjson after "$after" \
+        --arg marker_before "$marker_before" \
+        --arg marker_after "$marker_after" '
+        (($before.flapCount // 0) | tonumber)
+            == (($after.flapCount // 0) | tonumber)
+        and (($after.uptimeSeconds // 0) | tonumber)
+            >= (($before.uptimeSeconds // 0) | tonumber)
+        and ($marker_before | test("^[1-9][0-9]*$"))
+        and $marker_after == $marker_before
+    ' >/dev/null
+}
+
+self_test_session_continuity() {
+    local before healthy dropped stale flapped replaced marker_before marker_after
+    before='{"state":"SESSION_STATE_ESTABLISHED","flapCount":2,"uptimeSeconds":120}'
+    healthy='{"state":"SESSION_STATE_ESTABLISHED","flapCount":2,"uptimeSeconds":121}'
+    dropped='{"state":"SESSION_STATE_ACTIVE","flapCount":2,"uptimeSeconds":0}'
+    stale='{"state":"SESSION_STATE_ESTABLISHED","stale":true,"flapCount":2,"uptimeSeconds":121}'
+    flapped='{"state":"SESSION_STATE_ESTABLISHED","flapCount":3,"uptimeSeconds":1}'
+    replaced='{"state":"SESSION_STATE_ESTABLISHED","flapCount":2,"uptimeSeconds":1}'
+    marker_before=7
+    marker_after=7
+
+    # The former proof was only this marker predicate. Demonstrate that it
+    # accepts a peer that dropped and never reconnected before requiring the
+    # production continuity oracle to reject that same fixture.
+    if [ "$marker_before" != "$marker_after" ] || [ "$marker_after" = "0" ]; then
+        echo "ERROR: marker-only discriminator fixture is invalid" >&2
+        return 1
+    fi
+    if ! check_session_continuity "$before" "$healthy" "$marker_before" "$marker_after"; then
+        echo "ERROR: healthy authoritative continuity fixture failed" >&2
+        return 1
+    fi
+    for invalid in "$dropped" "$stale" "$flapped" "$replaced"; do
+        if check_session_continuity "$before" "$invalid" "$marker_before" "$marker_after"; then
+            echo "ERROR: invalid continuity fixture passed: $invalid" >&2
+            return 1
+        fi
+    done
+    echo "M83 authoritative session-continuity self-test passed"
+}
+
+case "${1:-}" in
+    --self-test-eor-order)
+        self_test_ipv4_eor_order
+        exit
+        ;;
+    --self-test-session-continuity)
+        self_test_session_continuity
+        exit
+        ;;
+esac
 
 TOPO="m83-routeserver-multistack"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -201,6 +267,12 @@ FRR_ADDR="10.83.3.2"
 
 rs_ctl() {
     docker exec "$RUSTBGPD" rbgp -s http://127.0.0.1:50051 "$@" 2>/dev/null
+}
+
+rs_neighbor_state() {
+    grpcurl_call \
+        -d "{\"address\": \"${1:?}\"}" \
+        "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>/dev/null
 }
 
 birdc_route_all() {
@@ -785,9 +857,22 @@ assert_withdraw_propagation() {
 
 assert_reload_stability() {
     log "Assertions 45-46: live route change and session stability through a policy reload"
-    local marker_before marker_after lp_before lp_after generation_before generation_after
-    marker_before=$(docker exec "$FRR" vtysh -c "show bgp neighbors ${RS_FRR_ADDR} json" 2>/dev/null \
-        | jq -r --arg p "$RS_FRR_ADDR" '.[$p].connectionsEstablished // 0')
+    local marker_before marker_after state_before state_after
+    local flaps_before flaps_after uptime_before uptime_after
+    local lp_before lp_after generation_before generation_after
+    if ! marker_before=$(docker exec "$FRR" vtysh \
+        -c "show bgp neighbors ${RS_FRR_ADDR} json" 2>/dev/null \
+        | jq -er --arg p "$RS_FRR_ADDR" '.[$p].connectionsEstablished // 0'); then
+        fail "FRR cumulative establishment marker unavailable before reload"
+        return
+    fi
+    if ! state_before=$(rs_neighbor_state "$FRR_ADDR") \
+        || ! authoritative_established_snapshot "$state_before"; then
+        fail "FRR continuity baseline is not an authoritative, non-stale Established snapshot"
+        return
+    fi
+    flaps_before=$(printf '%s\n' "$state_before" | jq -r '(.flapCount // 0) | tonumber')
+    uptime_before=$(printf '%s\n' "$state_before" | jq -r '(.uptimeSeconds // 0) | tonumber')
     lp_before=$(rs_ctl rib --prefix 100.67.0.0/24 -j \
         | jq -er --arg peer "$FRR_ADDR" '
             [.[] | select(.prefix == "100.67.0.0/24" and .peer_address == $peer)]
@@ -840,13 +925,20 @@ assert_reload_stability() {
         fail "live reload did not move FRR probe LP/generation (LP $lp_before→$lp_after, generation $generation_before→$generation_after)"
     fi
 
-    marker_after=$(docker exec "$FRR" vtysh -c "show bgp neighbors ${RS_FRR_ADDR} json" 2>/dev/null \
-        | jq -r --arg p "$RS_FRR_ADDR" '.[$p].connectionsEstablished // 0')
-    if [ -n "$marker_before" ] && [ "$marker_before" = "$marker_after" ] \
-        && [ "$marker_after" != "0" ]; then
-        ok "FRR session marker unchanged across reload (connectionsEstablished=$marker_after)"
+    marker_after=$(docker exec "$FRR" vtysh \
+        -c "show bgp neighbors ${RS_FRR_ADDR} json" 2>/dev/null \
+        | jq -er --arg p "$RS_FRR_ADDR" '.[$p].connectionsEstablished // 0') \
+        || marker_after=""
+    state_after=$(rs_neighbor_state "$FRR_ADDR") || state_after='{}'
+    flaps_after=$(printf '%s\n' "$state_after" | jq -r '(.flapCount // 0) | tonumber' 2>/dev/null) \
+        || flaps_after="unavailable"
+    uptime_after=$(printf '%s\n' "$state_after" | jq -r '(.uptimeSeconds // 0) | tonumber' 2>/dev/null) \
+        || uptime_after="unavailable"
+    if check_session_continuity \
+        "$state_before" "$state_after" "$marker_before" "$marker_after"; then
+        ok "FRR stayed authoritatively Established/non-stale across reload (flapCount $flaps_before→$flaps_after, uptime $uptime_before→$uptime_after, connectionsEstablished=$marker_after)"
     else
-        fail "FRR session marker moved across reload ($marker_before→$marker_after)"
+        fail "FRR session continuity failed across reload (state=$(printf '%s\n' "$state_after" | jq -r '.state // "unavailable"' 2>/dev/null || echo unavailable), stale=$(printf '%s\n' "$state_after" | jq -r '.stale // false' 2>/dev/null || echo unavailable), flapCount $flaps_before→$flaps_after, uptime $uptime_before→$uptime_after, connectionsEstablished $marker_before→${marker_after:-unavailable})"
     fi
 }
 

--- a/tests/interop_topology_commands.rs
+++ b/tests/interop_topology_commands.rs
@@ -122,7 +122,7 @@ fn m83_capture_and_reload_receipts_cannot_become_no_ops() {
 
     for required in [
         "/proc/[0-9]*/comm",
-        "kill -INT \"$pid\"",
+        "kill -INT \"$capture_pid\"",
         "test -s /tmp/m83.pcap",
         "tshark -r /tmp/m83.pcap -c 1",
     ] {
@@ -132,6 +132,23 @@ fn m83_capture_and_reload_receipts_cannot_become_no_ops() {
             script.display()
         );
     }
+    let stop_capture = source
+        .split_once("stop_capture() {")
+        .and_then(|(_, remainder)| remainder.split_once("start_bird() {").map(|(body, _)| body))
+        .expect("M83 capture stop function has a bounded source section");
+    let exact_one = stop_capture
+        .find("[ \"$found\" -eq 1 ]")
+        .expect("capture stop must require exactly one tshark");
+    let signal = stop_capture
+        .find("kill -INT \"$capture_pid\"")
+        .expect("capture stop must signal the selected tshark");
+    // Load-bearing ordering proof: moving the signal back into the scan, before
+    // exact-one validation, makes this assertion red and can kill unrelated
+    // captures before the receipt notices the ambiguity.
+    assert!(
+        exact_one < signal,
+        "M83 must validate exactly one tshark before signaling it"
+    );
 
     let reload = source
         .split_once("assert_reload_stability() {")

--- a/tests/interop_topology_commands.rs
+++ b/tests/interop_topology_commands.rs
@@ -93,6 +93,26 @@ fn m83_eor_order_rejects_same_frame_reversal() {
 }
 
 #[test]
+fn m83_reload_continuity_rejects_a_dropped_peer() {
+    // Destructive red proof: replacing the production continuity oracle with
+    // the former nonzero-and-unchanged connectionsEstablished predicate makes
+    // the script's dropped-not-reconnected fixture pass and this test fail.
+    let script = interop_path("scripts/test-m83-routeserver-multistack.sh");
+    let output = Command::new("bash")
+        .arg(&script)
+        .arg("--self-test-session-continuity")
+        .output()
+        .unwrap_or_else(|error| panic!("run {}: {error}", script.display()));
+    assert!(
+        output.status.success(),
+        "{} --self-test-session-continuity failed\nstdout:\n{}\nstderr:\n{}",
+        script.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn m83_capture_and_reload_receipts_cannot_become_no_ops() {
     // Destructive red proof: deleting the /proc signal, pcap validation, live
     // LP mutation, or generation probe makes the matching source fence fail.
@@ -105,12 +125,28 @@ fn m83_capture_and_reload_receipts_cannot_become_no_ops() {
         "kill -INT \"$pid\"",
         "test -s /tmp/m83.pcap",
         "tshark -r /tmp/m83.pcap -c 1",
-        "s/^set_local_pref = 100$/set_local_pref = 110/",
-        "100.67.0.0/24",
-        ".policy_generation",
     ] {
         assert!(
             source.contains(required),
+            "{} must retain receipt guard `{required}`",
+            script.display()
+        );
+    }
+
+    let reload = source
+        .split_once("assert_reload_stability() {")
+        .and_then(|(_, remainder)| remainder.split_once("# Main").map(|(body, _)| body))
+        .expect("M83 reload receipt function has a bounded source section");
+    for required in [
+        "s/^set_local_pref = 100$/set_local_pref = 110/",
+        "100.67.0.0/24",
+        ".policy_generation",
+        "state_before=$(rs_neighbor_state \"$FRR_ADDR\")",
+        "state_after=$(rs_neighbor_state \"$FRR_ADDR\")",
+        "check_session_continuity",
+    ] {
+        assert!(
+            reload.contains(required),
             "{} must retain receipt guard `{required}`",
             script.display()
         );

--- a/tests/interop_topology_commands.rs
+++ b/tests/interop_topology_commands.rs
@@ -1,0 +1,123 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn interop_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/interop")
+        .join(relative)
+}
+
+fn topology(relative: &str) -> serde_yaml::Value {
+    let path = interop_path(relative);
+    let source = fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    serde_yaml::from_str(&source)
+        .unwrap_or_else(|error| panic!("parse {} as YAML: {error}", path.display()))
+}
+
+fn rustbgpd_image_and_exec(topology: &serde_yaml::Value) -> (&str, Vec<&str>) {
+    let rustbgpd = &topology["topology"]["nodes"]["rustbgpd"];
+    let image = rustbgpd["image"]
+        .as_str()
+        .expect("rustbgpd topology node has a string image");
+    let exec = rustbgpd["exec"]
+        .as_sequence()
+        .expect("rustbgpd topology node has an exec sequence")
+        .iter()
+        .map(|command| {
+            command
+                .as_str()
+                .expect("rustbgpd topology exec command is a string")
+        })
+        .collect();
+    (image, exec)
+}
+
+#[test]
+fn route_server_topologies_have_exact_control_plane_setup() {
+    // Destructive red proof: adding either former `sysctl -w
+    // net.ipv4.ip_forward=1` command makes the corresponding exact exec list
+    // differ and this test fail.
+    let cases = [
+        (
+            "m19-routeserver-frr.clab.yml",
+            vec![
+                "ip addr add 10.0.0.1/24 dev eth1",
+                "ip link set eth1 up",
+                "ip addr add 10.0.1.1/24 dev eth2",
+                "ip link set eth2 up",
+            ],
+        ),
+        (
+            "m83-routeserver-multistack.clab.yml",
+            vec![
+                "ip addr add 10.83.1.1/24 dev eth1",
+                "ip link set eth1 up",
+                "ip addr add 10.83.2.1/24 dev eth2",
+                "ip link set eth2 up",
+                "ip addr add 10.83.3.1/24 dev eth3",
+                "ip link set eth3 up",
+            ],
+        ),
+    ];
+
+    for (relative, expected_exec) in cases {
+        let topology = topology(relative);
+        let (image, exec) = rustbgpd_image_and_exec(&topology);
+        assert_eq!(image, "rustbgpd:dev", "{relative} rustbgpd image drifted");
+        assert_eq!(
+            exec, expected_exec,
+            "{relative} rustbgpd setup must remain control-plane-only"
+        );
+    }
+}
+
+#[test]
+fn m83_eor_order_rejects_same_frame_reversal() {
+    // Destructive red proof: replacing tuple order with frame-only order makes
+    // the script's reversed same-frame fixture pass and this test fail.
+    let script = interop_path("scripts/test-m83-routeserver-multistack.sh");
+    let output = Command::new("bash")
+        .arg(&script)
+        .arg("--self-test-eor-order")
+        .output()
+        .unwrap_or_else(|error| panic!("run {}: {error}", script.display()));
+    assert!(
+        output.status.success(),
+        "{} --self-test-eor-order failed\nstdout:\n{}\nstderr:\n{}",
+        script.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn m83_capture_and_reload_receipts_cannot_become_no_ops() {
+    // Destructive red proof: deleting the /proc signal, pcap validation, live
+    // LP mutation, or generation probe makes the matching source fence fail.
+    let script = interop_path("scripts/test-m83-routeserver-multistack.sh");
+    let source = fs::read_to_string(&script)
+        .unwrap_or_else(|error| panic!("read {}: {error}", script.display()));
+
+    for required in [
+        "/proc/[0-9]*/comm",
+        "kill -INT \"$pid\"",
+        "test -s /tmp/m83.pcap",
+        "tshark -r /tmp/m83.pcap -c 1",
+        "s/^set_local_pref = 100$/set_local_pref = 110/",
+        "100.67.0.0/24",
+        ".policy_generation",
+    ] {
+        assert!(
+            source.contains(required),
+            "{} must retain receipt guard `{required}`",
+            script.display()
+        );
+    }
+    assert!(
+        !source.contains("pkill"),
+        "{} must not depend on procps or broad process signaling",
+        script.display()
+    );
+}


### PR DESCRIPTION
## Summary

- stop and validate the M83 TShark capture without relying on unavailable procps tools
- prove IPv4 EoR follows the final NLRI by `(frame, BGP-PDU)` ordering, including a same-frame reversal fence
- make the M83 reload assertion change a still-present FRR route from local preference 100 to 110, bump the import generation, and preserve the session marker
- remove unsupported `ip_forward` setup and forwarding claims from the control-plane-only M19/M83 route-server labs
- add a per-commit topology and receipt structural fence

## Verification

- M19 live receipt: 14/14
- M83 live receipt: 51/51
- M83 capture terminated; pcap nonempty and readable
- final NLRI `(39, 2)` before EoR `(39, 3)` in the same frame
- FRR route LP 100→110; import generation 0→1; `connectionsEstablished` stayed 3
- clean M19/M83 deploy logs with no `sysctl`, rc127, or missing-executable errors
- both labs destroyed cleanly
- `cargo test --test interop_topology_commands` — 3/3
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- Bash syntax, ShellCheck, and `git diff --check`

## Load-bearing proofs

Each destructive mutation was applied and restored:

- restoring the removed M19 `sysctl` makes the topology inventory test red
- restoring the removed M83 `sysctl` makes the topology inventory test red
- reducing EoR comparison to frame-only makes the same-frame reversal test red
- replacing the required capture SIGINT with TERM makes the capture fence red
- changing the reload edit to 100→100 makes the reload fence red