### PR TITLE
fix(cli): restore RPKI VRP operator visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -812,6 +812,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **RPKI VRP visibility now follows the exported metric family.** The TUI sums
+  IPv4 and IPv6 `bgp_rpki_vrp_count` samples, and `rbgp doctor` warns when
+  configured caches have a zero, missing, malformed, or unavailable snapshot.
+
 - **A config file the daemon has rewritten now says so.** The first
   runtime mutation — `rbgp neighbor add`, a config transaction, a gNMI
   `Set` — rewrites the config file in canonical form, and always has:

--- a/crates/cli/src/commands/control.rs
+++ b/crates/cli/src/commands/control.rs
@@ -4,6 +4,47 @@ use crate::output::{self, JsonHealth};
 use crate::proto::control_service_client::ControlServiceClient;
 use crate::proto::{HealthRequest, MetricsRequest, ShutdownRequest, TriggerMrtDumpRequest};
 
+/// Sum a complete, unique, valid IPv4 + IPv6 RPKI VRP gauge snapshot.
+/// `Some(0)` distinguishes a synchronized empty table from an unusable snapshot.
+pub(crate) fn rpki_vrp_count_sum(prometheus_text: &str) -> Option<u64> {
+    const NAME: &str = "bgp_rpki_vrp_count";
+
+    let mut by_family = [None, None];
+    for line in prometheus_text.lines().map(str::trim) {
+        let Some(rest) = line.strip_prefix(NAME) else {
+            continue;
+        };
+        let family = if let Some(value) = rest.strip_prefix(r#"{af="ipv4"}"#) {
+            Some((0, value))
+        } else if let Some(value) = rest.strip_prefix(r#"{af="ipv6"}"#) {
+            Some((1, value))
+        } else if rest.is_empty()
+            || rest.starts_with('{')
+            || rest.as_bytes().first().is_some_and(u8::is_ascii_whitespace)
+        {
+            return None;
+        } else {
+            continue;
+        };
+        let (index, value_text) = family?;
+        if by_family[index].is_some()
+            || !value_text
+                .as_bytes()
+                .first()
+                .is_some_and(u8::is_ascii_whitespace)
+        {
+            return None;
+        };
+        let mut fields = value_text.split_ascii_whitespace();
+        let value = fields.next()?.parse::<u64>().ok()?;
+        if fields.next().is_some() {
+            return None;
+        }
+        by_family[index] = Some(value);
+    }
+    by_family[0]?.checked_add(by_family[1]?)
+}
+
 pub async fn health(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         ControlServiceClient::with_interceptor(connection.channel(), connection.interceptor());
@@ -97,5 +138,39 @@ mod tests {
         health(connection, true).await.unwrap();
 
         assert_eq!(server.state.health_calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// Red proof: the old unprefixed, single-sample parser fails this aggregate.
+    #[test]
+    fn rpki_vrp_count_sums_only_valid_exact_name_samples() {
+        let production = r#"
+# HELP bgp_rpki_vrp_count Number of RPKI VRP entries by address family
+# TYPE bgp_rpki_vrp_count gauge
+bgp_rpki_vrp_count{af="ipv4"} 120
+bgp_rpki_vrp_count{af="ipv6"} 30
+bgp_rpki_vrp_count_total{af="ipv4"} 9000
+unrelated_metric 7
+"#;
+        assert_eq!(rpki_vrp_count_sum(production), Some(150));
+        assert_eq!(
+            rpki_vrp_count_sum("bgp_rpki_vrp_counting 9\nbgp_rpki_vrp_count_extra{af=\"ipv4\"} 8"),
+            None
+        );
+        assert_eq!(
+            rpki_vrp_count_sum(
+                "bgp_rpki_vrp_count{af=\"ipv4\"} 0\nbgp_rpki_vrp_count{af=\"ipv6\"} 0"
+            ),
+            Some(0)
+        );
+        for invalid in [
+            "bgp_rpki_vrp_count{af=\"ipv4\"} 1",
+            "bgp_rpki_vrp_count{af=\"ipv4\"} 1\nbgp_rpki_vrp_count{af=\"ipv4\"} 2\nbgp_rpki_vrp_count{af=\"ipv6\"} 3",
+            "bgp_rpki_vrp_count{af=\"other\"} 1",
+            "bgp_rpki_vrp_count 1",
+            "bgp_rpki_vrp_count{af=\"ipv4\" not-a-number",
+            "bgp_rpki_vrp_count{af=\"ipv4\"} 18446744073709551615\nbgp_rpki_vrp_count{af=\"ipv6\"} 1",
+        ] {
+            assert_eq!(rpki_vrp_count_sum(invalid), None, "{invalid}");
+        }
     }
 }

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -758,6 +758,42 @@ fn deploy_targets(toml_text: &str) -> DeployTargets {
     }
 }
 
+fn rpki_vrp_table_check(configured: bool, metrics: Option<&str>) -> Option<Check> {
+    if !configured {
+        return None;
+    }
+    let count = metrics.and_then(crate::commands::control::rpki_vrp_count_sum);
+    let (status, detail) = match count {
+        Some(count @ 1..) => (
+            CheckStatus::Ok,
+            format!("RPKI VRP table contains {count} IPv4+IPv6 entries"),
+        ),
+        Some(0) => (
+            CheckStatus::Warn,
+            "RPKI caches are configured but the daemon reports 0 VRPs; \
+             verify RTR synchronization before relying on NotFound decisions"
+                .to_string(),
+        ),
+        None if metrics.is_some() => (
+            CheckStatus::Warn,
+            "RPKI caches are configured but bgp_rpki_vrp_count is absent or malformed; \
+             inspect /metrics and RTR synchronization"
+                .to_string(),
+        ),
+        None => (
+            CheckStatus::Warn,
+            "RPKI caches are configured but the metrics snapshot is unavailable; \
+             rerun doctor after the metrics RPC succeeds"
+                .to_string(),
+        ),
+    };
+    Some(Check {
+        name: "rpki.vrp_table".to_string(),
+        status,
+        detail,
+    })
+}
+
 /// One bounded TCP connect, immediately dropped on success.
 async fn probe_tcp(addr: String) -> Result<(), String> {
     match tokio::time::timeout(
@@ -1177,6 +1213,7 @@ pub(crate) async fn run(
     let mut daemon_version: Option<String> = None;
     let mut state_dir: Option<String> = None;
     let mut effective_toml: Option<String> = None;
+    let mut metrics_text: Option<String> = None;
     let mut tcp_ao_support = crate::proto::TcpAoSupport::Unspecified.into();
     let daemon_reachable = connection.is_ok();
 
@@ -1278,10 +1315,9 @@ pub(crate) async fn run(
             // system/metrics.prom.
             match control.get_metrics(MetricsRequest {}).await {
                 Ok(resp) => {
-                    bundle.add(
-                        "system/metrics.prom",
-                        redact_text(&resp.into_inner().prometheus_text).into_bytes(),
-                    );
+                    let text = resp.into_inner().prometheus_text;
+                    bundle.add("system/metrics.prom", redact_text(&text).into_bytes());
+                    metrics_text = Some(text);
                 }
                 Err(e) => {
                     sections.insert("system", format!("partial: metrics RPC failed: {e}"));
@@ -1301,6 +1337,12 @@ pub(crate) async fn run(
                 Ok(resp) => {
                     let toml_text = resp.into_inner().toml;
                     for check in tcp_ao_capability_checks(&toml_text, tcp_ao_support) {
+                        reporter.record(check.name, check.status, check.detail);
+                    }
+                    if let Some(check) = rpki_vrp_table_check(
+                        !deploy_targets(&toml_text).rpki_caches.is_empty(),
+                        metrics_text.as_deref(),
+                    ) {
                         reporter.record(check.name, check.status, check.detail);
                     }
                     state_dir = parse_state_dir(&toml_text);
@@ -2179,6 +2221,36 @@ paths = ["x"]
         assert!(empty.gnmi_collectors.is_empty());
     }
 
+    /// Red proofs: zero-as-OK and dropping the configured guard fail below.
+    #[test]
+    fn rpki_vrp_table_check_distinguishes_configuration_and_snapshot_state() {
+        assert!(rpki_vrp_table_check(false, None).is_none());
+
+        let nonzero = rpki_vrp_table_check(
+            true,
+            Some("bgp_rpki_vrp_count{af=\"ipv4\"} 1\nbgp_rpki_vrp_count{af=\"ipv6\"} 2"),
+        )
+        .unwrap();
+        assert_eq!(nonzero.status, CheckStatus::Ok);
+
+        let zero = rpki_vrp_table_check(
+            true,
+            Some("bgp_rpki_vrp_count{af=\"ipv4\"} 0\nbgp_rpki_vrp_count{af=\"ipv6\"} 0"),
+        )
+        .unwrap();
+        assert_eq!(zero.status, CheckStatus::Warn);
+        assert_eq!(
+            rpki_vrp_table_check(true, Some("unrelated_metric 1"))
+                .unwrap()
+                .status,
+            CheckStatus::Warn
+        );
+        assert_eq!(
+            rpki_vrp_table_check(true, None).unwrap().status,
+            CheckStatus::Warn
+        );
+    }
+
     #[tokio::test]
     async fn reachability_probe_is_green_for_listening_and_red_for_refused() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -2610,6 +2682,9 @@ paths = ["x"]
 "#,
             state = state_dir.path().display()
         ));
+        *server.state.metrics_text.lock().await = Some(
+            "bgp_rpki_vrp_count{af=\"ipv4\"} 0\nbgp_rpki_vrp_count{af=\"ipv6\"} 0\n".to_string(),
+        );
         let connection = connect(&server.addr, None).await;
         let dir = tempfile::tempdir().unwrap();
         let bundle_path = dir.path().join("bundle.tar.gz");
@@ -2649,6 +2724,8 @@ paths = ["x"]
             status_of(&format!("rpki.cache.127.0.0.1:{live_port}.reachable")),
             "ok"
         );
+        // Red proof: removing effective-config/metrics wiring removes this check.
+        assert_eq!(status_of("rpki.vrp_table"), "warn");
         assert_eq!(status_of(&format!("rpki.cache.{dead}.reachable")), "fail");
         assert_eq!(
             status_of(&format!("bmp.collector.{dead}.reachable")),

--- a/crates/cli/src/tui/data.rs
+++ b/crates/cli/src/tui/data.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
+use crate::commands::control::rpki_vrp_count_sum;
 use crate::connection::Connection;
 use crate::proto::control_service_client::ControlServiceClient;
 use crate::proto::global_service_client::GlobalServiceClient;
@@ -39,12 +40,7 @@ fn format_event_type(t: i32) -> &'static str {
 }
 
 fn parse_vrp_count(prometheus_text: &str) -> Option<u64> {
-    for line in prometheus_text.lines() {
-        if let Some(rest) = line.strip_prefix("rpki_vrp_count ") {
-            return rest.trim().parse().ok();
-        }
-    }
-    None
+    rpki_vrp_count_sum(prometheus_text)
 }
 
 pub fn spawn_fetcher(
@@ -164,4 +160,22 @@ async fn stream_routes(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::connect;
+    use crate::test_support::spawn_mock_server;
+
+    /// Red proof: the old polling parser loses this production-shaped value.
+    #[tokio::test]
+    async fn rpki_vrp_count_uses_the_exported_family() {
+        let server = spawn_mock_server(None).await;
+        *server.state.metrics_text.lock().await = Some(
+            "bgp_rpki_vrp_count{af=\"ipv4\"} 12\nbgp_rpki_vrp_count{af=\"ipv6\"} 3\n".to_string(),
+        );
+        let connection = connect(&server.addr, None).await.unwrap();
+        assert_eq!(poll_once(&connection, None).await.rpki_vrp_count, Some(15));
+    }
 }

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1321,11 +1321,12 @@ does not expose the status, because "no evidence" is not "no problem". A red
 verdict here never affects `/readyz`: missing operator policy is a
 configuration state to repair, not a daemon that cannot serve traffic.
 
-First-deploy probes (each bounded to a 2s timeout, read-only):
+First-deploy checks (network probes are bounded to a 2s timeout; all are read-only):
 
 | Check | What it probes | Red/yellow advice |
 |-------|----------------|-------------------|
 | `bgp.listener` | Daemon up: TCP connect to the BGP listen port. Daemon down: test-bind the port and release it | `CAP_NET_BIND_SERVICE` for ports below 1024; port-in-use is yellow (an unreachable daemon may hold it) |
+| `rpki.vrp_table` | With configured caches and a reachable daemon, sums the complete IPv4 + IPv6 `bgp_rpki_vrp_count` snapshot | yellow when the merged table is zero, missing, malformed, or unavailable; verify RTR synchronization and `/metrics` |
 | `rpki.cache.<addr>.reachable` | TCP connect to each `[rpki] cache_servers` entry | origin validation stays degraded until the cache connects |
 | `bmp.collector.<addr>.reachable` | TCP connect to each `[bmp] collectors` entry | monitoring export is down; the daemon retries on its reconnect interval |
 | `gnmi_dialout.<name>.reachable` | TCP connect to each `[gnmi_dialout] targets` entry | dial-out telemetry backs off and retries |
@@ -1350,8 +1351,8 @@ rustbgpd-doctor-<ts>/
 └── system/                  # environment.json, health.json, global.json, metrics.prom, daemon rlimits
 ```
 
-Exit codes: `0` all checks green, `1` error, `2` bundle written but one or
-more checks are red. A doctor run against a down daemon still produces a
+Exit codes: `0` no checks red (green and yellow warnings may be present), `1`
+error, `2` bundle written but one or more checks are red. A down-daemon run produces a
 bundle (system facts + crash reports) and the manifest records which
 sections are missing.
 


### PR DESCRIPTION
## Summary

- parse and aggregate the production family-labelled `bgp_rpki_vrp_count` metric in one narrow CLI helper
- show the aggregate in the TUI and warn from `rbgp doctor` when configured caches have no observable complete VRP snapshot
- document the new doctor check and the existing warning-preserving exit semantics in the central operations guide

## Why

The daemon exports separate IPv4 and IPv6 VRP gauges, but the TUI consumed a metric name that does not exist. Doctor could also report reachable RTR caches without surfacing a zero, missing, malformed, or unavailable merged table, while the operations guide incorrectly equated exit 0 with an all-green report.

## Verification

- five files and 197 total changed lines, within the issue kill gates
- `cargo test -p rustbgpctl commands::control::tests::rpki_vrp`
- `cargo test -p rustbgpctl commands::doctor::tests::rpki_vrp`
- `cargo test -p rustbgpctl rpki_vrp_count_uses_the_exported_family`
- `cargo test -p rustbgpctl commands::doctor::tests::doctor_first_deploy_probes_daemon_up`
- full push gates: workspace fmt, Clippy, tests, and rustdoc
- `git diff --check`

## Load-bearing proofs

- restoring the old unprefixed parser makes the production-shaped aggregate test red
- restoring the old TUI parser removes the production-family header value
- treating zero VRPs as OK makes the verdict test red
- removing the effective-config/metrics wiring removes `rpki.vrp_table` from the doctor manifest
