### PR TITLE
docs: align operator validation and prefix-limit contracts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -389,6 +389,8 @@ When an Adj-RIB-Out channel is full, the update is dropped and the peer is marke
 
 Per-neighbor `max_prefixes` (aggregate) and the independent per-family `max_prefixes_ipv4` / `max_prefixes_ipv6` caps (ADR-0108) are enforced at Adj-RIB-In insertion. Exceeding any cap produces NOTIFICATION (Cease, Maximum Number of Prefixes Reached) and session teardown. There is no global/aggregate route limit across neighbors.
 
+The current tree also implements the unreleased ADR-0113 outbound contract: distinct `max_prefixes_out_ipv4` and `max_prefixes_out_ipv6` limits count post-export-gate IPv4- and IPv6-unicast prefixes per peer. At a limit, excess net-new prefixes are withheld; existing advertisements remain, and updates to admitted prefixes and withdrawals continue. The session stays Established and no NOTIFICATION is sent. A neighbor value overrides its peer group, an absent neighbor value inherits, and there is no aggregate outbound cap. Live limit edits use one all-peer transactional preflight and activation; an invalid add or lower candidate is rejected before any affected peer's limit changes.
+
 ### Why no locks
 
 The RIB is the hottest data structure. Wrapping it in `Arc<RwLock>` would create contention under UPDATE storms and make reasoning about ordering difficult. Instead, the RIB runs as a single task with exclusive ownership. All access is serialized through the channel. This trades parallelism for simplicity and determinism — the right tradeoff at current scale. The sharding seam (channel boundary) is ready if scale demands splitting.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -75,7 +75,7 @@ the route-server cookbook.
 
 ```bash
 # Validate config without starting the daemon.
-rustbgpd --check config.toml
+rustbgpd --check --strict config.toml
 
 # Preview what a config reload would change.
 rustbgpd --diff new-config.toml config.toml
@@ -176,7 +176,8 @@ An Envoy proxy front-end is also supported for multi-host fan-out; see
 Release images are published to GHCR; `:latest` tracks the newest release and
 `:X.Y` pins a minor series (see
 [deployment.md](deployment.md#container-image) for the full tag table).
-`docker build -t rustbgpd .` produces the same lean runtime image locally.
+`docker build -t rustbgpd .` produces the same lean runtime image under the
+bare `rustbgpd` tag for local use only.
 
 First adapt the `lab` config from step 2 for a container. Two of its values
 are host defaults that do not work under Docker: state under `/tmp` is not on
@@ -199,7 +200,7 @@ docker run -d --name rustbgpd \
   -v rustbgpd-state:/var/lib/rustbgpd \
   -p 179:179 -p 9179:9179 \
   --ulimit nofile=65536:524288 \
-  rustbgpd \
+  ghcr.io/lance0/rustbgpd:latest \
   /bin/sh -c 'cp -n /etc/rustbgpd/config.template.toml /var/lib/rustbgpd/config.toml && exec rustbgpd /var/lib/rustbgpd/config.toml'
 ```
 

--- a/docs/adr/0113-outbound-prefix-limits.md
+++ b/docs/adr/0113-outbound-prefix-limits.md
@@ -1,6 +1,6 @@
 # ADR-0113: Per-peer outbound unicast prefix limits
 
-**Status:** Proposed
+**Status:** Accepted — implementation complete on `main`; pending release under [Unreleased](../../CHANGELOG.md#unreleased)
 **Date:** 2026-07-21
 
 ## Context
@@ -45,8 +45,7 @@ intent and can advance before an individual member send, as ADR-0098 specifies.
 
 ## Decision
 
-This ADR proposes an implementation contract. It does not authorize feature
-code in this tranche.
+This decision defines the contract implemented on `main`.
 
 ### Scope and configuration
 

--- a/docs/cookbook/route-server-migration.md
+++ b/docs/cookbook/route-server-migration.md
@@ -399,7 +399,7 @@ cutover blockers.
 
 ## Cutover checklist
 
-1. Build the candidate config and run `rustbgpd --check`.
+1. Build the candidate config and run `rustbgpd --check --strict`.
 2. Run `rbgp policy check` for every `.rpol` file.
 3. Shadow-peer the same members with a non-production listener so no accidental
    TCP/179 collision occurs.

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -35,7 +35,7 @@ Start from the checked-in route-server example:
 ```bash
 cp examples/route-server/config.toml ./rs.toml
 cp examples/route-server/hygiene.rpol ./hygiene.rpol
-rustbgpd --check rs.toml
+rustbgpd --check --strict rs.toml
 rbgp policy check hygiene.rpol
 ```
 
@@ -220,7 +220,7 @@ server from ~1.3 GiB to over 100 GiB of RSS when enabled fleet-wide.
 ## Verify
 
 ```console
-$ rustbgpd --check config.toml          # config + rpol validate offline
+$ rustbgpd --check --strict config.toml # config + rpol validate offline
 $ rbgp policy check hygiene.rpol         # rpol in-language tests
 $ export RUSTBGPD_ADDR=unix:///var/lib/rustbgpd/grpc.sock
 $ rbgp summary                           # both members Established
@@ -325,7 +325,7 @@ Prometheus (`prometheus_addr`, `/metrics`; dashboards in
 | Metric | Healthy shape |
 |--------|---------------|
 | `bgp_session_state_transitions_total` | flat outside member churn |
-| `bgp_rpki_vrp_total` | non-zero once the RTR cache syncs |
+| `sum without (af) (bgp_rpki_vrp_count)` | per-target IPv4 + IPv6 total; non-zero once the RTR cache syncs (`rbgp doctor` warns when configured caches have no visible VRPs) |
 | `bgp_update_group_fallback_peers` | ≥ your `per_client_best` member count (they never group) |
 | `bgp_rib_outbound_registered_peers` | = established member count |
 | `bgp_policy_generation_loaded_timestamp_seconds` | recent — ages past your render/SIGHUP cadence when the filter pipeline is stuck; see "Policy artifact freshness" in [`OPERATIONS.md`](../OPERATIONS.md) for the alert expressions |
@@ -375,9 +375,9 @@ The first command works on a stock route server. The second needs
 route-server starter turns it off explicitly, because the decision cache
 is per session and its cost multiplies by member count
 ([CONFIGURATION.md](../CONFIGURATION.md#import-decision-explain-policyexplain)).
-Enable it, reload, and let the member's session re-establish when you
-need the statement-level trace; the rejected-route view above needs no
-such switch.
+Enable it and reload so future sessions adopt the setting; the target
+member must then re-establish before you query the statement-level trace.
+The rejected-route view above needs no such switch.
 
 The explain names the deciding term — typically `reject-rpki-invalid`
 (fix the member's ROA or your RTR feed) or an `ixp-hygiene` rule

--- a/examples/route-server/README.md
+++ b/examples/route-server/README.md
@@ -26,7 +26,7 @@ the two prefix sets together, then run:
 ```bash
 rbgp policy fmt --check hygiene.rpol
 rbgp policy check hygiene.rpol
-rustbgpd --check config.toml
+rustbgpd --check --strict config.toml
 ```
 
 The long-prefix guard remains a separate, later chain member. If the exchange
@@ -60,7 +60,7 @@ member; plain (non-RS) eBGP neighbors get that enforcement by default.
 
 ```bash
 # Validate the config and the rpol policy (both offline):
-rustbgpd --check config.toml
+rustbgpd --check --strict config.toml
 rbgp policy check hygiene.rpol
 
 # Run, then inspect a member:


### PR DESCRIPTION
## Summary

- make authoritative first-run and predeploy examples use `--check --strict` while preserving intentionally warning-tolerant migration checks
- identify the published GHCR image unambiguously and document the explain-cache re-establishment timing
- correct the route-server VRP query without collapsing Prometheus target labels
- align the architecture, ADR, and route-server docs with the merged-but-unreleased outbound prefix-limit contract

## Integration

#1172 has merged. This branch is rebased directly onto its mainline result; the six-file docs commit is patch-identical to the independently reviewed stacked head.

## Verification

- exactly the six approved operator-documentation files
- `cargo test --test check_strict check_without_strict_exits_zero_on_warnings`
- `cargo test --test check_strict check_strict_exits_nonzero_on_warnings`
- `cargo test --test starter_configs_check_strict every_example_config_passes_check_strict`
- `cargo test --test starter_configs_check_strict every_init_config_profile_passes_check_strict`
- full push gates: workspace fmt, Clippy, tests, and rustdoc
- `git diff --check`

Docs-only; load-bearing regression proof is N/A. The authoritative/tolerant command split was manually inventoried rather than enforced with a brittle global string gate.
