### PR TITLE
docs(compose): build the current checkout in quickstarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,12 @@ peer that advertises sample IPv4 and IPv6 prefixes — no real routers needed.
 
 ```bash
 cd examples/docker-compose
-docker compose up -d
+docker compose up -d --build
 ```
+
+`--build` asks Compose to build from the current checkout before startup.
+Without it, Compose may reuse an older `docker-compose-rustbgpd` image already
+on the host. Cached layers keep unchanged repeat builds quick.
 
 Once both containers are running (a few seconds):
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -294,7 +294,7 @@ prefixes — no real routers required.
 
 ```sh
 cd examples/docker-compose
-docker compose up -d
+docker compose up -d --build
 docker compose exec rustbgpd \
   rbgp -s http://127.0.0.1:50051 neighbor
 docker compose down

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -6,10 +6,14 @@ bridge network. FRR advertises 4 IPv4 and 3 IPv6 sample prefixes.
 ## Start
 
 ```bash
-docker compose up -d
+docker compose up -d --build
 ```
 
-First run builds the rustbgpd image (~60s). Sessions establish within seconds.
+`--build` asks Compose to build from the current checkout before startup.
+Without it, Compose may reuse an older `docker-compose-rustbgpd` image already
+on the host. Cached layers keep unchanged repeat builds quick. The first build
+takes about 60 seconds; sessions establish within seconds.
+
 The committed bearer token is intentionally public and test-only: it keeps the
 quick-start runnable while demonstrating tier authorization. Replace this
 entire credential arrangement in any real deployment.

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -4,7 +4,7 @@
 # Useful for trying out rbgp commands without real routers.
 #
 # Usage:
-#   docker compose up -d
+#   docker compose up -d --build
 # The rustbgpd service sets RUSTBGPD_TOKEN_FILE for in-container rbgp calls.
 #   docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 neighbor
 #   docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 top


### PR DESCRIPTION
## Summary

- make source-tree Compose quickstarts use `docker compose up -d --build`
- explain that plain `up` may reuse a stale locally built image
- keep teardown and the published-image workflow unchanged

## Why

The example service has a build context and no explicit image name. After the first build, plain `docker compose up -d` can reuse the existing local image even when the checkout changed, so the 60-second quickstart may run stale code without saying so.

## Verification

- exact patch identity survived the rebase onto current main
- `docker compose -f examples/docker-compose/docker-compose.yml config --quiet`
- source-tree quickstart inventory contains no remaining unqualified `docker compose up -d` command
- `git diff --check`
- full push gates: workspace fmt, Clippy, tests, and rustdoc

## Receipt

The retained A/B receipt proved plain `up` reused the prior image, while `up -d --build` produced and ran the new image; the resulting BGP session reached Established with seven prefixes and teardown was clean. The Dockerfile, Compose file semantics, and build context have not changed since that receipt.

Docs/config-only; no new test or gate is added, so destructive regression proof is N/A.
