### PR TITLE
perf(transport): allocate rejected-route storage lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -797,6 +797,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   can occur. `[policy.explain] enabled` still defaults to on, and its
   behaviour there is unchanged.
 
+- **A peer with no rejected routes no longer allocates its rejected-route
+  LRU.** The store previously reserved its 1024-entry index when the
+  session was constructed, even if every received route was accepted.
+  The existing corrected
+  [DHAT capture](docs/perf/explain-cache-opt-in-2026-07.md#dhat-attribution)
+  attributes 704,320 allocated bytes to 20 such stores — 35,216 bytes per
+  peer. Those are allocated bytes, not an RSS measurement. The backing
+  LRU is now created on the first retained rejection and released on
+  session reset; listing, replacement, eviction, ordering, counters, and
+  the configured capacity are unchanged.
+
 - **Enabling import explain no longer slows down every inbound route.**
   Explain needs a formatted `AS_PATH` string to re-derive which policy
   statement decided a route, and the session used to get it by forcing

--- a/crates/transport/src/session/rejected_routes.rs
+++ b/crates/transport/src/session/rejected_routes.rs
@@ -26,7 +26,9 @@
 //! Entry count: per-peer LRU cap from `[policy.reject_retention]
 //! capacity` ([`DEFAULT_REJECT_RETENTION_CAPACITY`] = 1024). A reject
 //! storm therefore converges on "the most recent `capacity` rejects",
-//! never unbounded growth.
+//! never unbounded growth. The LRU is allocated on the first retained
+//! rejection, so a healthy session with no rejected routes pays no
+//! backing-store allocation.
 //!
 //! Entry size: [`RejectedRouteStore::insert`] truncates every entry's
 //! wire-derived owned data — a hostile peer with maximal `AS_PATH` /
@@ -192,7 +194,10 @@ pub struct RejectedRoutesReply {
 /// queries on its command path, exactly like the import-decision cache.
 #[derive(Debug)]
 pub struct RejectedRouteStore {
-    entries: LruCache<ImportDecisionKey, RejectedRouteEntry>,
+    /// Built on first insert. `LruCache::new` eagerly reserves its hash
+    /// index at `capacity`, so constructing it with the session would
+    /// charge every peer even when the peer has no rejected routes.
+    entries: Option<LruCache<ImportDecisionKey, RejectedRouteEntry>>,
     capacity: usize,
 }
 
@@ -203,9 +208,15 @@ impl RejectedRouteStore {
     pub fn with_capacity(cap: usize) -> Self {
         let cap = cap.max(1);
         Self {
-            entries: LruCache::new(NonZeroUsize::new(cap).expect("clamped to at least 1")),
+            entries: None,
             capacity: cap,
         }
+    }
+
+    /// The backing LRU, built at its configured size on first use.
+    fn storage(&mut self) -> &mut LruCache<ImportDecisionKey, RejectedRouteEntry> {
+        let capacity = NonZeroUsize::new(self.capacity).expect("capacity is clamped to at least 1");
+        self.entries.get_or_insert_with(|| LruCache::new(capacity))
     }
 
     /// Insert or refresh a rejection. On overflow the least-recently
@@ -216,30 +227,32 @@ impl RejectedRouteStore {
     /// can exceed the documented per-entry budget.
     pub fn insert(&mut self, key: ImportDecisionKey, mut entry: RejectedRouteEntry) {
         entry.enforce_bounds();
-        self.entries.push(key, entry);
+        self.storage().push(key, entry);
     }
 
     /// Remove the entry for an identity that was subsequently accepted
     /// or explicitly withdrawn. No-op when absent.
     pub fn remove(&mut self, key: &ImportDecisionKey) {
-        self.entries.pop(key);
+        if let Some(entries) = self.entries.as_mut() {
+            entries.pop(key);
+        }
     }
 
     /// Drop everything — session reset, same contract as
     /// [`super::import_decision_cache::ImportDecisionCache::clear`].
     pub fn clear(&mut self) {
-        self.entries.clear();
+        self.entries = None;
     }
 
     /// Number of retained rejections (the gauge value).
     #[must_use]
     pub fn len(&self) -> usize {
-        self.entries.len()
+        self.entries.as_ref().map_or(0, LruCache::len)
     }
 
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
+        self.entries.as_ref().is_none_or(LruCache::is_empty)
     }
 
     /// The configured cap, echoed on the query reply.
@@ -253,11 +266,12 @@ impl RejectedRouteStore {
     /// the cap, so the clone is fine for a diagnostic query path.
     #[must_use]
     pub fn snapshot(&self) -> Vec<(ImportDecisionKey, RejectedRouteEntry)> {
-        let mut out: Vec<_> = self
-            .entries
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
+        let mut out: Vec<_> = self.entries.as_ref().map_or_else(Vec::new, |entries| {
+            entries
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect()
+        });
         out.sort_by(|(a, _), (b, _)| {
             (a.afi as u16, a.safi as u8, a.prefix, a.path_id).cmp(&(
                 b.afi as u16,
@@ -267,6 +281,14 @@ impl RejectedRouteStore {
             ))
         });
         out
+    }
+
+    /// Whether the store has no backing LRU allocation. An empty-store
+    /// assertion is insufficient because an eagerly allocated LRU is
+    /// empty too.
+    #[cfg(test)]
+    pub(super) fn is_unallocated(&self) -> bool {
+        self.entries.is_none()
     }
 }
 
@@ -341,13 +363,19 @@ mod tests {
     #[test]
     fn remove_and_clear() {
         let mut store = RejectedRouteStore::with_capacity(4);
+        assert!(store.is_unallocated());
         store.insert(key(1), entry(ImportRejectReason::PolicyReject));
         store.insert(key(2), entry(ImportRejectReason::PolicyReject));
+        assert!(!store.is_unallocated());
         store.remove(&key(1));
         assert_eq!(store.len(), 1);
         store.remove(&key(9)); // absent → no-op
         store.clear();
         assert!(store.is_empty());
+        assert!(
+            store.is_unallocated(),
+            "session reset must release the backing LRU allocation"
+        );
     }
 
     #[test]

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -17745,11 +17745,14 @@ fn rejected_route_prototype_builds(session: &PeerSession) -> usize {
         .load(std::sync::atomic::Ordering::Relaxed)
 }
 
-/// Clean permitted UPDATEs must not construct reject-only diagnostic state.
-/// Break-to-red: eagerly initializing the prototype makes the build-count
-/// assertion fail, while dropping accepted paths fails the state assertions.
+/// Clean permitted UPDATEs must not construct reject-only diagnostic state
+/// or allocate the rejected-route LRU.
+/// Break-to-red: restoring eager `LruCache::new` makes the structural
+/// allocation assertion fail; eagerly initializing the prototype makes the
+/// build-count assertion fail; dropping accepted paths fails the state
+/// assertions.
 #[tokio::test]
-async fn reject_retention_permitted_update_builds_no_prototype() {
+async fn reject_retention_permitted_update_stays_allocation_free() {
     let first = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
     let second = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
     let (mut session, _metrics) = retention_session_with_chain(None, |_| {});
@@ -17760,6 +17763,10 @@ async fn reject_retention_permitted_update_builds_no_prototype() {
 
     assert_eq!(rejected_route_prototype_builds(&session), 0);
     assert!(session.rejected_routes.is_empty());
+    assert!(
+        session.rejected_routes.is_unallocated(),
+        "a session with no retained rejection must hold no LRU allocation"
+    );
     assert_eq!(session.known_prefix_count(), 2);
     assert_eq!(session.import_policy_routes_permitted, 2);
 }


### PR DESCRIPTION
## Summary

- defer the 1,024-entry rejected-route LRU until the first retained rejection
- release the backing allocation on session reset while preserving capacity, ordering, replacement, eviction, listing, counters, and defaults
- add a structural test that distinguishes an unallocated store from an eagerly allocated but empty one

## Evidence boundary

The existing corrected DHAT capture attributes 704,320 allocated bytes across 20 stores, or 35,216 bytes per peer (about 33.6 MiB at 1,000 peers). Those are allocated bytes, not observed RSS, and this change is not claimed to explain the larger historical per-peer RSS upper bound.

## Verification

- focused rejected-route module/listing suite: 9 passed
- focused session-retention suite: 10 passed
- full workspace fmt, Clippy, tests, and rustdoc
- exact rebased head push hooks: fmt, Clippy, workspace-library tests
- `git diff --check`

## Load-bearing proof

Restoring eager `LruCache::new` makes `reject_retention_permitted_update_stays_allocation_free` fail at the structural allocation assertion (exit 101). Restoring the lazy constructor returns it to green.
