### PR TITLE
fix: report strict RFC 9003 shutdown communications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   older daemon; the existing negotiation status remains authoritative when no
   Established-session snapshot is available.
 
+- **Strict RFC 9003 shutdown-communication visibility.** Received and locally
+  sent notification events now retain valid Administrative Shutdown/Reset text,
+  including one RFC 8538 Hard Reset envelope. Malformed lengths, trailing data,
+  invalid UTF-8, nested envelopes, and unrelated notification subcodes remain
+  uninterpreted; locally encoded reasons retain the existing 128-byte cap.
+
 - **RFC 8212 explicit-policy enforcement — `[global] ebgp_requires_policy`
   (ADR-0112).** Opt-in, default `false`, restart-required, and pinned to
   the startup value across SIGHUP: a reload logs an `ERROR`, keeps the

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -199,6 +199,21 @@ impl PeerSession {
                 Action::SendNotification(notif) => {
                     let code = notif.code;
                     let subcode = notif.subcode;
+                    let shutdown_reason =
+                        match rustbgpd_wire::notification::extract_shutdown_communication(&notif) {
+                            Ok(reason) => reason.map(str::to_owned),
+                            Err(error) => {
+                                warn!(
+                                    peer = %self.peer_label,
+                                    direction = "sent",
+                                    code = code.as_u8(),
+                                    subcode,
+                                    error_category = error.category(),
+                                    "ignored malformed BGP shutdown communication"
+                                );
+                                None
+                            }
+                        };
                     self.record_notification_cause(SessionNotificationDirection::Sent, &notif);
                     // RFC 8538: track outbound Hard Reset to bypass GR
                     if code == NotificationCode::Cease && subcode == cease_subcode::HARD_RESET {
@@ -222,7 +237,7 @@ impl PeerSession {
                             Message::Notification(notif) => notif,
                             _ => unreachable!("constructed as notification"),
                         },
-                        None,
+                        shutdown_reason,
                     );
                     self.notifications_sent += 1;
                     self.metrics.record_notification_sent(

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -564,16 +564,23 @@ impl PeerSession {
                             Event::KeepaliveReceived
                         }
                         Message::Notification(notif) => {
-                            let shutdown_reason = if notif.code == NotificationCode::Cease
-                                && (notif.subcode == cease_subcode::ADMINISTRATIVE_SHUTDOWN
-                                    || notif.subcode == cease_subcode::ADMINISTRATIVE_RESET)
-                            {
-                                rustbgpd_wire::notification::decode_shutdown_communication(
-                                    &notif.data,
-                                )
-                            } else {
-                                None
-                            };
+                            let shutdown_reason =
+                                match rustbgpd_wire::notification::extract_shutdown_communication(
+                                    &notif,
+                                ) {
+                                    Ok(reason) => reason.map(str::to_owned),
+                                    Err(error) => {
+                                        warn!(
+                                            peer = %self.peer_label,
+                                            direction = "received",
+                                            code = notif.code.as_u8(),
+                                            subcode = notif.subcode,
+                                            error_category = error.category(),
+                                            "ignored malformed BGP shutdown communication"
+                                        );
+                                        None
+                                    }
+                                };
                             // Cache raw NOTIFICATION PDU for BMP Peer Down (reason 3: remote sent NOTIFICATION)
                             if self.bmp_tx.is_some() {
                                 self.last_down_reason =
@@ -591,10 +598,18 @@ impl PeerSession {
                             );
                             self.metrics
                                 .record_message_received(&self.peer_label, "notification");
+                            // Log shutdown communication reason (RFC 9003)
+                            if let Some(reason) = shutdown_reason.as_deref() {
+                                info!(
+                                    peer = %self.peer_label,
+                                    reason,
+                                    "peer sent shutdown communication"
+                                );
+                            }
                             self.emit_notification_event(
                                 SessionNotificationDirection::Received,
                                 &notif,
-                                shutdown_reason.clone(),
+                                shutdown_reason,
                             );
                             // RFC 8538: detect Cease/Hard Reset to bypass GR
                             if notif.code == NotificationCode::Cease
@@ -605,14 +620,6 @@ impl PeerSession {
                                     "peer sent Cease/Hard Reset, GR will be skipped"
                                 );
                                 self.received_hard_reset = true;
-                            }
-                            // Log shutdown communication reason (RFC 8203)
-                            if let Some(reason) = shutdown_reason {
-                                info!(
-                                    peer = %self.peer_label,
-                                    reason = %reason,
-                                    "peer sent shutdown communication"
-                                );
                             }
                             Event::NotificationReceived(notif)
                         }

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -2984,6 +2984,198 @@ async fn received_notification_reports_direction_and_description() {
         "received NOTIFICATION 6/8 (Out of Resources)"
     );
 }
+/// Load-bearing RFC 9003/RFC 8538 receive proof: restoring the direct-only
+/// decoder drops the Hard Reset reason, while omitting either administrative
+/// subcode drops that direct reason. The event retains the actual outer
+/// notification code/subcode so extracting the reason cannot disguise teardown
+/// semantics.
+#[tokio::test]
+async fn received_notification_events_report_direct_and_hard_reset_shutdown_reasons() {
+    let reason = "planned maintenance";
+    let encoded_reason = rustbgpd_wire::notification::encode_shutdown_communication(reason);
+    let mut hard_reset_data = vec![
+        NotificationCode::Cease.as_u8(),
+        cease_subcode::ADMINISTRATIVE_RESET,
+    ];
+    hard_reset_data.extend_from_slice(&encoded_reason);
+
+    for notification in [
+        NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+            encoded_reason.clone(),
+        ),
+        NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::ADMINISTRATIVE_RESET,
+            encoded_reason.clone(),
+        ),
+        NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::HARD_RESET,
+            hard_reset_data.into(),
+        ),
+    ] {
+        let expected_subcode = notification.subcode;
+        let mut session = make_test_session(65001, 65002);
+        let (event_tx, mut event_rx) = mpsc::channel(2);
+        session.session_event_tx = Some(event_tx);
+        session.read_buf.buf.extend_from_slice(
+            &rustbgpd_wire::encode_message(&Message::Notification(notification)).unwrap(),
+        );
+
+        session.process_read_buffer().await;
+
+        let event = event_rx
+            .try_recv()
+            .expect("one received-notification event");
+        assert_eq!(event.direction, SessionNotificationDirection::Received);
+        assert_eq!(event.code, NotificationCode::Cease.as_u8());
+        assert_eq!(event.subcode, expected_subcode);
+        assert_eq!(event.shutdown_reason.as_deref(), Some(reason));
+    }
+}
+
+/// Load-bearing malformed-input boundary proof: switching the strict decoder
+/// to lossy UTF-8 or accepting trailing data produces a reason in these events;
+/// dropping the typed-error mapping prevents the event entirely. Every case
+/// still reports and tears down for the actual outer NOTIFICATION, including a
+/// short Hard Reset envelope.
+#[tokio::test]
+async fn malformed_shutdown_communication_is_not_interpreted_or_exempted_from_teardown() {
+    for notification in [
+        NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+            Bytes::from_static(&[1, 0xff]),
+        ),
+        NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::ADMINISTRATIVE_RESET,
+            Bytes::from_static(&[1, b'x', b'y']),
+        ),
+        NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::HARD_RESET,
+            Bytes::from_static(&[6]),
+        ),
+    ] {
+        let expected_subcode = notification.subcode;
+        let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+        let (client, _server) = connected_stream_pair().await;
+        session.test_install_stream(client);
+        establish_test_session(&mut session, 65002).await;
+        while rib_rx.try_recv().is_ok() {}
+        let (event_tx, mut event_rx) = mpsc::channel(2);
+        session.session_event_tx = Some(event_tx);
+        session.read_buf.buf.extend_from_slice(
+            &rustbgpd_wire::encode_message(&Message::Notification(notification)).unwrap(),
+        );
+
+        session.process_read_buffer().await;
+
+        let event = event_rx
+            .try_recv()
+            .expect("malformed communication still emits the outer notification");
+        assert_eq!(event.direction, SessionNotificationDirection::Received);
+        assert_eq!(event.code, NotificationCode::Cease.as_u8());
+        assert_eq!(event.subcode, expected_subcode);
+        assert_eq!(event.shutdown_reason, None);
+        assert!(
+            matches!(rib_rx.try_recv(), Ok(RibUpdate::PeerDown { .. })),
+            "malformed optional data must still drive the normal PeerDown path"
+        );
+        assert_eq!(session.fsm.state(), SessionState::Idle);
+    }
+}
+
+/// Load-bearing local-event proof: replacing the extractor result with `None`
+/// makes every reason assertion red. The direct Administrative Shutdown/Reset
+/// cases and single RFC 8538 envelope also prove the sent-event path reports
+/// the final on-wire notification without lossy reconstruction.
+#[tokio::test]
+async fn locally_sent_notification_events_report_direct_and_hard_reset_shutdown_reasons() {
+    let reason = "operator requested";
+    let encoded_reason = rustbgpd_wire::notification::encode_shutdown_communication(reason);
+    let mut hard_reset_data = vec![
+        NotificationCode::Cease.as_u8(),
+        cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+    ];
+    hard_reset_data.extend_from_slice(&encoded_reason);
+
+    for notification in [
+        NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+            encoded_reason.clone(),
+        ),
+        NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::ADMINISTRATIVE_RESET,
+            encoded_reason.clone(),
+        ),
+        NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::HARD_RESET,
+            hard_reset_data.into(),
+        ),
+    ] {
+        let expected_subcode = notification.subcode;
+        let mut session = make_test_session(65001, 65002);
+        let (event_tx, mut event_rx) = mpsc::channel(2);
+        session.session_event_tx = Some(event_tx);
+
+        session
+            .execute_actions(vec![Action::SendNotification(notification)])
+            .await;
+
+        let event = event_rx.try_recv().expect("one sent-notification event");
+        assert_eq!(event.direction, SessionNotificationDirection::Sent);
+        assert_eq!(event.code, NotificationCode::Cease.as_u8());
+        assert_eq!(event.subcode, expected_subcode);
+        assert_eq!(event.shutdown_reason.as_deref(), Some(reason));
+    }
+}
+
+/// Load-bearing shipped-command proof: dropping the reason while translating
+/// `PeerCommand::Stop` to `ManualStop`, or replacing the sent-event extractor
+/// result with `None`, loses the exact event reason; dropping the FSM payload
+/// propagation changes the on-wire data assertion.
+#[tokio::test]
+async fn stop_command_sends_and_reports_exact_shutdown_communication() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    while rib_rx.try_recv().is_ok() {}
+    let (event_tx, mut event_rx) = mpsc::channel(2);
+    session.session_event_tx = Some(event_tx);
+    let encoded_reason =
+        rustbgpd_wire::notification::encode_shutdown_communication("planned maintenance");
+
+    assert_eq!(
+        session
+            .handle_command(PeerCommand::Stop {
+                reason: Some(encoded_reason.clone()),
+            })
+            .await,
+        ControlFlow::Continue(())
+    );
+
+    let event = event_rx.try_recv().expect("one sent-notification event");
+    assert_eq!(event.direction, SessionNotificationDirection::Sent);
+    assert_eq!(event.code, NotificationCode::Cease.as_u8());
+    assert_eq!(event.subcode, cease_subcode::ADMINISTRATIVE_SHUTDOWN);
+    assert_eq!(
+        event.shutdown_reason.as_deref(),
+        Some("planned maintenance")
+    );
+    let notification = read_until_notification(&mut server).await;
+    assert_eq!(notification.code, NotificationCode::Cease);
+    assert_eq!(notification.subcode, cease_subcode::ADMINISTRATIVE_SHUTDOWN);
+    assert_eq!(notification.data, encoded_reason);
+}
+
 /// Mutant: removing the sent-admin guard mislabels intentional local maintenance.
 #[test]
 fn administrative_notifications_keep_directional_maintenance_semantics() {

--- a/crates/wire/src/notification.rs
+++ b/crates/wire/src/notification.rs
@@ -131,11 +131,11 @@ pub mod update_subcode {
 pub mod cease_subcode {
     /// Subcode 1: Maximum Number of Prefixes Reached.
     pub const MAX_PREFIXES: u8 = 1;
-    /// Subcode 2: Administrative Shutdown (RFC 8203).
+    /// Subcode 2: Administrative Shutdown (RFC 9003).
     pub const ADMINISTRATIVE_SHUTDOWN: u8 = 2;
     /// Subcode 3: Peer De-configured.
     pub const PEER_DECONFIGURED: u8 = 3;
-    /// Subcode 4: Administrative Reset (RFC 8203).
+    /// Subcode 4: Administrative Reset (RFC 9003).
     pub const ADMINISTRATIVE_RESET: u8 = 4;
     /// Subcode 8: Out of Resources.
     pub const OUT_OF_RESOURCES: u8 = 8;
@@ -145,7 +145,7 @@ pub mod cease_subcode {
     pub const HARD_RESET: u8 = 9;
 }
 
-/// Encode a shutdown communication reason string (RFC 8203).
+/// Encode a shutdown communication reason string (RFC 9003).
 ///
 /// The format is: 1-byte length prefix + UTF-8 string, max 128 bytes.
 /// If the reason exceeds 128 bytes, it is truncated at a char boundary.
@@ -170,22 +170,108 @@ pub fn encode_shutdown_communication(reason: &str) -> bytes::Bytes {
     bytes::Bytes::from(buf)
 }
 
-/// Decode a shutdown communication reason string from NOTIFICATION data (RFC 8203).
+/// A bounded reason why an RFC 9003 shutdown communication was not decoded.
 ///
-/// Returns `None` if the data is empty or the length prefix is inconsistent.
-/// Extra trailing bytes after the declared shutdown-communication string are ignored.
-/// Invalid UTF-8 is replaced with the Unicode replacement character.
+/// The variants intentionally classify malformed input without retaining or
+/// formatting attacker-controlled bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ShutdownCommunicationError {
+    /// The length octet is absent or does not consume the complete data field.
+    InvalidLength,
+    /// The declared communication is not valid UTF-8.
+    InvalidUtf8,
+    /// An RFC 8538 Hard Reset does not contain its inner code and subcode.
+    MalformedHardResetEnvelope,
+}
+
+impl ShutdownCommunicationError {
+    /// Return a stable, bounded category suitable for structured logs.
+    #[must_use]
+    pub const fn category(self) -> &'static str {
+        match self {
+            Self::InvalidLength => "invalid_length",
+            Self::InvalidUtf8 => "invalid_utf8",
+            Self::MalformedHardResetEnvelope => "malformed_hard_reset_envelope",
+        }
+    }
+}
+
+/// Decode a shutdown communication reason string from NOTIFICATION data (RFC 9003).
+///
+/// Returns `None` unless the length-prefixed field consumes all of `data` and
+/// contains valid UTF-8. RFC 9003 requires malformed data to remain
+/// uninterpreted rather than exposing a partial or replacement-character
+/// reason.
 #[must_use]
 pub fn decode_shutdown_communication(data: &[u8]) -> Option<String> {
-    if data.is_empty() {
-        return None;
+    decode_shutdown_communication_strict(data)
+        .ok()
+        .map(str::to_owned)
+}
+
+fn decode_shutdown_communication_strict(data: &[u8]) -> Result<&str, ShutdownCommunicationError> {
+    let (&declared_len, reason) = data
+        .split_first()
+        .ok_or(ShutdownCommunicationError::InvalidLength)?;
+    if reason.len() != usize::from(declared_len) {
+        return Err(ShutdownCommunicationError::InvalidLength);
     }
-    let len = data[0] as usize;
-    if data.len() < 1 + len {
-        return None;
+    std::str::from_utf8(reason).map_err(|_| ShutdownCommunicationError::InvalidUtf8)
+}
+
+/// Extract an RFC 9003 shutdown communication from a complete NOTIFICATION.
+///
+/// Administrative Shutdown and Administrative Reset carry the
+/// length-prefixed field directly. RFC 8538 Hard Reset carries exactly one
+/// encapsulated NOTIFICATION tuple (`code`, `subcode`, `data`); only an
+/// encapsulated Administrative Shutdown or Administrative Reset is eligible.
+/// Nested Hard Reset envelopes and malformed shutdown data are not
+/// interpreted.
+///
+/// # Errors
+///
+/// Returns [`ShutdownCommunicationError`] when an eligible direct or
+/// encapsulated communication has inconsistent length, invalid UTF-8, or an
+/// incomplete RFC 8538 envelope.
+pub fn extract_shutdown_communication(
+    notification: &crate::NotificationMessage,
+) -> Result<Option<&str>, ShutdownCommunicationError> {
+    if notification.code != NotificationCode::Cease {
+        return Ok(None);
     }
-    let raw = &data[1..=len];
-    Some(String::from_utf8_lossy(raw).into_owned())
+
+    let communication_data = match notification.subcode {
+        cease_subcode::ADMINISTRATIVE_SHUTDOWN | cease_subcode::ADMINISTRATIVE_RESET => {
+            notification.data.as_ref()
+        }
+        cease_subcode::HARD_RESET => {
+            let Some((&inner_code, encapsulated)) = notification.data.split_first() else {
+                return Err(ShutdownCommunicationError::MalformedHardResetEnvelope);
+            };
+            let Some((&inner_subcode, inner_data)) = encapsulated.split_first() else {
+                return Err(ShutdownCommunicationError::MalformedHardResetEnvelope);
+            };
+            if NotificationCode::from_u8(inner_code) != NotificationCode::Cease
+                || !matches!(
+                    inner_subcode,
+                    cease_subcode::ADMINISTRATIVE_SHUTDOWN | cease_subcode::ADMINISTRATIVE_RESET
+                )
+            {
+                return Ok(None);
+            }
+            inner_data
+        }
+        _ => return Ok(None),
+    };
+
+    // RFC 9003 makes the communication optional. A bare administrative
+    // NOTIFICATION has no communication field; an explicit `[0]` remains a
+    // present, empty communication for compatibility with the public decoder.
+    if communication_data.is_empty() {
+        return Ok(None);
+    }
+    decode_shutdown_communication_strict(communication_data).map(Some)
 }
 
 /// Human-readable description for a NOTIFICATION code/subcode pair.
@@ -311,6 +397,31 @@ mod tests {
         assert_eq!(decoded.len(), 128);
     }
 
+    /// Load-bearing RFC 9003 compatibility proof: imposing the encoder's
+    /// conservative 128-octet interoperability cap on received communications
+    /// makes both assertions reject a standards-valid 255-octet field.
+    #[test]
+    fn shutdown_communication_accepts_255_octets_on_receive() {
+        let reason = "a".repeat(255);
+        let mut data = Vec::with_capacity(256);
+        data.push(255);
+        data.extend_from_slice(reason.as_bytes());
+
+        assert_eq!(
+            decode_shutdown_communication(&data).as_deref(),
+            Some(reason.as_str())
+        );
+        let notification = crate::NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+            data.into(),
+        );
+        assert_eq!(
+            extract_shutdown_communication(&notification),
+            Ok(Some(reason.as_str()))
+        );
+    }
+
     #[test]
     fn shutdown_communication_truncates_at_char_boundary() {
         // 'é' is 2 bytes in UTF-8. Fill 127 bytes + 'é' = 129 bytes total → truncate
@@ -327,13 +438,187 @@ mod tests {
     fn shutdown_communication_invalid_utf8() {
         // Length 3 + 3 bytes of invalid UTF-8
         let data = [3, 0xff, 0xfe, 0xfd];
-        let decoded = decode_shutdown_communication(&data).unwrap();
-        assert!(decoded.contains('\u{FFFD}')); // replacement char
+        assert_eq!(decode_shutdown_communication(&data), None);
     }
 
     #[test]
-    fn shutdown_communication_ignores_trailing_bytes() {
+    fn shutdown_communication_rejects_trailing_bytes() {
         let data = [3, b'f', b'o', b'o', b'x'];
-        assert_eq!(decode_shutdown_communication(&data).as_deref(), Some("foo"));
+        assert_eq!(decode_shutdown_communication(&data), None);
+    }
+
+    /// Load-bearing RFC 9003 proof: accepting a prefix instead of the complete
+    /// length-delimited field makes the trailing-byte cases return a reason;
+    /// lossy UTF-8 decoding makes the invalid-byte cases return invented text.
+    #[test]
+    fn shutdown_communication_rejects_every_malformed_field_shape() {
+        for data in [
+            &[][..],
+            &[1][..],
+            &[2, b'a'][..],
+            &[0, b'x'][..],
+            &[1, b'x', b'y'][..],
+            &[1, 0xff][..],
+        ] {
+            assert_eq!(
+                decode_shutdown_communication(data),
+                None,
+                "malformed field must remain uninterpreted: {data:?}"
+            );
+        }
+    }
+
+    /// Load-bearing RFC 9003/RFC 8538 proof: removing either direct subcode,
+    /// accepting a second Hard Reset envelope, or dropping the single-envelope
+    /// branch changes one of these exact results.
+    #[test]
+    fn shutdown_communication_extractor_accepts_direct_and_one_hard_reset_envelope() {
+        for subcode in [
+            cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+            cease_subcode::ADMINISTRATIVE_RESET,
+        ] {
+            let direct = crate::NotificationMessage::new(
+                NotificationCode::Cease,
+                subcode,
+                encode_shutdown_communication("planned work"),
+            );
+            assert_eq!(
+                extract_shutdown_communication(&direct),
+                Ok(Some("planned work"))
+            );
+
+            let mut hard_reset_data = vec![NotificationCode::Cease.as_u8(), subcode];
+            hard_reset_data.extend_from_slice(&encode_shutdown_communication("planned work"));
+            let hard_reset = crate::NotificationMessage::new(
+                NotificationCode::Cease,
+                cease_subcode::HARD_RESET,
+                hard_reset_data.into(),
+            );
+            assert_eq!(
+                extract_shutdown_communication(&hard_reset),
+                Ok(Some("planned work"))
+            );
+        }
+
+        let empty_direct = crate::NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+            bytes::Bytes::from_static(&[0]),
+        );
+        assert_eq!(extract_shutdown_communication(&empty_direct), Ok(Some("")));
+        let empty_hard_reset = crate::NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::HARD_RESET,
+            bytes::Bytes::from_static(&[6, cease_subcode::ADMINISTRATIVE_RESET, 0]),
+        );
+        assert_eq!(
+            extract_shutdown_communication(&empty_hard_reset),
+            Ok(Some(""))
+        );
+
+        let nested = crate::NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::HARD_RESET,
+            bytes::Bytes::from_static(&[
+                6,
+                cease_subcode::HARD_RESET,
+                6,
+                cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+                1,
+                b'x',
+            ]),
+        );
+        assert_eq!(extract_shutdown_communication(&nested), Ok(None));
+    }
+
+    /// Load-bearing eligibility proof: widening either the outer or
+    /// encapsulated code/subcode check turns one of these non-administrative
+    /// notifications into shutdown communication.
+    #[test]
+    fn shutdown_communication_extractor_rejects_ineligible_notifications() {
+        let reason = encode_shutdown_communication("not administrative");
+        for notification in [
+            crate::NotificationMessage::new(
+                NotificationCode::OpenMessage,
+                cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+                reason.clone(),
+            ),
+            crate::NotificationMessage::new(
+                NotificationCode::Cease,
+                cease_subcode::OUT_OF_RESOURCES,
+                reason.clone(),
+            ),
+            crate::NotificationMessage::new(
+                NotificationCode::Cease,
+                cease_subcode::HARD_RESET,
+                bytes::Bytes::from_static(&[2, cease_subcode::ADMINISTRATIVE_SHUTDOWN, 1, b'x']),
+            ),
+            crate::NotificationMessage::new(
+                NotificationCode::Cease,
+                cease_subcode::HARD_RESET,
+                bytes::Bytes::from_static(&[6, cease_subcode::OUT_OF_RESOURCES, 1, b'x']),
+            ),
+        ] {
+            assert_eq!(extract_shutdown_communication(&notification), Ok(None));
+        }
+    }
+
+    /// Load-bearing typed-error proof: collapsing errors into absence, accepting
+    /// a prefix, using lossy UTF-8, or treating a short RFC 8538 tuple as a
+    /// complete envelope changes the corresponding exact error category.
+    #[test]
+    fn shutdown_communication_extractor_classifies_malformed_input() {
+        for data in [
+            bytes::Bytes::from_static(&[2, b'x']),
+            bytes::Bytes::from_static(&[1, b'x', b'y']),
+        ] {
+            let notification = crate::NotificationMessage::new(
+                NotificationCode::Cease,
+                cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+                data,
+            );
+            assert_eq!(
+                extract_shutdown_communication(&notification),
+                Err(ShutdownCommunicationError::InvalidLength)
+            );
+        }
+
+        let invalid_utf8 = crate::NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::ADMINISTRATIVE_RESET,
+            bytes::Bytes::from_static(&[1, 0xff]),
+        );
+        assert_eq!(
+            extract_shutdown_communication(&invalid_utf8),
+            Err(ShutdownCommunicationError::InvalidUtf8)
+        );
+
+        for data in [
+            bytes::Bytes::new(),
+            bytes::Bytes::from(vec![NotificationCode::Cease.as_u8()]),
+        ] {
+            let hard_reset = crate::NotificationMessage::new(
+                NotificationCode::Cease,
+                cease_subcode::HARD_RESET,
+                data,
+            );
+            assert_eq!(
+                extract_shutdown_communication(&hard_reset),
+                Err(ShutdownCommunicationError::MalformedHardResetEnvelope)
+            );
+        }
+
+        assert_eq!(
+            ShutdownCommunicationError::InvalidLength.category(),
+            "invalid_length"
+        );
+        assert_eq!(
+            ShutdownCommunicationError::InvalidUtf8.category(),
+            "invalid_utf8"
+        );
+        assert_eq!(
+            ShutdownCommunicationError::MalformedHardResetEnvelope.category(),
+            "malformed_hard_reset_envelope"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- decode RFC 9003 Shutdown Communications only when the complete length-delimited field is valid UTF-8
- extract reasons from direct Cease/2 and Cease/4 notifications and exactly one RFC 8538 Cease/9 envelope
- report exact reasons for both received and locally sent notification events while preserving the actual outer code/subcode
- classify malformed optional data with bounded log fields, without logging payload bytes or weakening normal notification teardown
- accept standards-valid 255-octet communications on receive while retaining the conservative 128-octet sender cap for legacy-peer interoperability

The existing public compatibility decoder keeps its signature and its established empty-value semantics (`[]` is absent; `[0]` is an explicit empty communication). No API, protobuf, or event-history schema changes are included.

## Correctness

The extractor follows [RFC 9003](https://datatracker.ietf.org/doc/html/rfc9003) length and UTF-8 requirements. RFC 8538 Hard Reset data is unwrapped once as `[code, subcode, data...]`; nested Hard Reset envelopes are not recursively interpreted. Malformed communication data remains optional metadata: the outer NOTIFICATION still drives the existing Idle/PeerDown or GR behavior.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

Load-bearing regression proofs cover strict length and UTF-8 handling, direct and single-envelope eligibility, preserved outer teardown semantics, exact received and sent event reasons, the real `PeerCommand::Stop` wire seam, the 128-octet sender cap, and 255-octet receive compatibility. Each guarded behavior was mutation-tested to red before restoration.