### PR TITLE
perf: gate zero-reload RSS evidence

### DIFF
--- a/bench/scale/rebaseline/test_classifiers.py
+++ b/bench/scale/rebaseline/test_classifiers.py
@@ -19,6 +19,14 @@ import classify_dhat  # noqa: E402
 
 
 class ClassifierFixtures(unittest.TestCase):
+    def runner_embedded_python(self, marker: str) -> str:
+        runner = HERE.parents[2] / "docs" / "perf" / "run-explain-cache-variant.sh"
+        script = runner.read_text(encoding="utf-8")
+        start = script.index(marker)
+        body_start = script.index("<<'PY'\n", start) + len("<<'PY'\n")
+        body_end = script.index("\nPY\n", body_start)
+        return script[body_start:body_end]
+
     def run_check(self, script: str, source: str, expected: str) -> None:
         subprocess.run(
             [
@@ -58,8 +66,14 @@ class ClassifierFixtures(unittest.TestCase):
             ("oversize", raw + ("x" * (16 * 1024))),
             ("header drift", raw.replace("max cpu %", "cpu max", 1)),
             ("missing field", raw.replace(",0,0,,,\n", ",0,0,,\n")),
-            ("required mismatch", raw.replace(",200000,200000,40,", ",10000,10000,40,")),
-            ("received mismatch", raw.replace(",200000,200000,40,", ",200000,199999,40,")),
+            (
+                "required mismatch",
+                raw.replace(",200000,200000,40,", ",10000,10000,40,"),
+            ),
+            (
+                "received mismatch",
+                raw.replace(",200000,200000,40,", ",200000,199999,40,"),
+            ),
             ("tester error", raw.replace(",0,0,,,\n", ",1,0,,,\n")),
             ("tester timeout", raw.replace(",0,0,,,\n", ",0,1,,,\n")),
             ("failed", raw.replace(",0,0,,,\n", ",0,0,FAILED,,\n")),
@@ -70,7 +84,10 @@ class ClassifierFixtures(unittest.TestCase):
             ("nan metric", raw.replace(",50.25,98,", ",NaN,98,")),
             ("hostile exponent", raw.replace(",50.25,98,", ",1e999999999,98,")),
             ("long hex id", raw.replace("rustbgpd 0.51.0", "deadbeefdeadbeef")),
-            ("zero loaded metrics", raw.replace(",45,5,40,50.25,98,0.321,", ",0,5,40,0,0,0,")),
+            (
+                "zero loaded metrics",
+                raw.replace(",45,5,40,50.25,98,0.321,", ",0,5,40,0,0,0,"),
+            ),
         )
         with tempfile.TemporaryDirectory() as directory:
             for index, (case, text) in enumerate(bad_inputs):
@@ -152,7 +169,9 @@ class ClassifierFixtures(unittest.TestCase):
                         text=True,
                     )
                     self.assertNotEqual(result.returncode, 0)
-                    self.assertRegex(result.stderr, "refusing unsanitized|path or address")
+                    self.assertRegex(
+                        result.stderr, "refusing unsanitized|path or address"
+                    )
 
     def test_dhat_current_demangled_adj_rib_in_owner(self) -> None:
         self.assertEqual(
@@ -283,6 +302,20 @@ class ClassifierFixtures(unittest.TestCase):
             (out / "proc-status-final.txt").write_text(
                 "VmRSS:\t2048 kB\nVmHWM:\t4096 kB\n", encoding="utf-8"
             )
+            (out / "settled-proc.env").write_text(
+                "settled_proc_vmrss_kib=2048\n"
+                "settled_proc_vmhwm_kib=4096\n"
+                "settled_proc_vmpeak_kib=8192\n"
+                "settled_proc_vmsize_kib=6144\n",
+                encoding="utf-8",
+            )
+            (out / "settled-metrics.env").write_text(
+                "jemalloc_allocated_bytes=1000\n"
+                "jemalloc_active_bytes=2000\n"
+                "jemalloc_resident_bytes=3000\n"
+                "jemalloc_mapped_bytes=4000\n",
+                encoding="utf-8",
+            )
             subprocess.run(
                 [sys.executable, "-c", python, str(out)],
                 check=True,
@@ -300,6 +333,206 @@ class ClassifierFixtures(unittest.TestCase):
             values["sampled_tree_peak_rss_kib_lower_bound"],
             "2048",
         )
+        self.assertEqual(values["settled_proc_vmrss_kib"], "2048")
+        self.assertEqual(values["settled_proc_vmhwm_kib"], "4096")
+        self.assertEqual(values["settled_proc_vmpeak_kib"], "8192")
+        self.assertEqual(values["settled_proc_vmsize_kib"], "6144")
+        self.assertEqual(values["jemalloc_allocated_bytes"], "1000")
+        self.assertEqual(values["jemalloc_active_bytes"], "2000")
+        self.assertEqual(values["jemalloc_resident_bytes"], "3000")
+        self.assertEqual(values["jemalloc_mapped_bytes"], "4000")
+
+    @staticmethod
+    def settled_metrics_fixture() -> str:
+        return (
+            "bgp_update_groups 1\n"
+            'bgp_update_group_members{group="7"} 2\n'
+            "bgp_update_group_fallback_peers 0\n"
+            "bgp_update_group_residue_entries 0\n"
+            "bgp_rib_outbound_registered_peers 2\n"
+            'bgp_rejected_routes_retained{peer="127.1.0.1"} 0\n'
+            'bgp_rejected_routes_retained{peer="127.1.0.2"} 0\n'
+            'bgp_peer_outbound_queue_depth{peer="127.1.0.1"} 0\n'
+            'bgp_peer_outbound_queue_depth{peer="127.1.0.2"} 0\n'
+            "jemalloc_allocated_bytes 1000\n"
+            "jemalloc_active_bytes 2000\n"
+            "jemalloc_resident_bytes 3000\n"
+            "jemalloc_mapped_bytes 4000\n"
+        )
+
+    def run_settled_metrics_validator(
+        self, fixture: str, *, dhat: int = 0
+    ) -> subprocess.CompletedProcess[str]:
+        python = self.runner_embedded_python(
+            "# LAN-630 settled-state gates: missing metrics are failures, never zero."
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            metrics = Path(directory) / "metrics.prom"
+            metrics.write_text(fixture, encoding="utf-8")
+            return subprocess.run(
+                [sys.executable, "-c", python, str(metrics), "2", str(dhat)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+
+    def test_settled_metrics_validator_rejects_every_false_green(self) -> None:
+        fixture = self.settled_metrics_fixture()
+        valid = self.run_settled_metrics_validator(fixture)
+        self.assertEqual(valid.returncode, 0, valid.stderr)
+        self.assertIn("jemalloc_allocated_bytes=1000", valid.stdout)
+
+        mutations = {
+            "missing group count": fixture.replace("bgp_update_groups 1\n", ""),
+            "wrong group members": fixture.replace(
+                'bgp_update_group_members{group="7"} 2',
+                'bgp_update_group_members{group="7"} 1',
+            ),
+            "fallback peer": fixture.replace(
+                "bgp_update_group_fallback_peers 0",
+                "bgp_update_group_fallback_peers 1",
+            ),
+            "withdrawal residue": fixture.replace(
+                "bgp_update_group_residue_entries 0",
+                "bgp_update_group_residue_entries 1",
+            ),
+            "missing registration": fixture.replace(
+                "bgp_rib_outbound_registered_peers 2",
+                "bgp_rib_outbound_registered_peers 1",
+            ),
+            "missing rejected-route peer": fixture.replace(
+                'bgp_rejected_routes_retained{peer="127.1.0.2"} 0\n', ""
+            ),
+            "retained rejection": fixture.replace(
+                'bgp_rejected_routes_retained{peer="127.1.0.2"} 0',
+                'bgp_rejected_routes_retained{peer="127.1.0.2"} 1',
+            ),
+            "missing writer-depth peer": fixture.replace(
+                'bgp_peer_outbound_queue_depth{peer="127.1.0.2"} 0\n', ""
+            ),
+            "writer backlog": fixture.replace(
+                'bgp_peer_outbound_queue_depth{peer="127.1.0.2"} 0',
+                'bgp_peer_outbound_queue_depth{peer="127.1.0.2"} 1',
+            ),
+            "missing jemalloc": fixture.replace("jemalloc_allocated_bytes 1000\n", ""),
+        }
+        for label, mutation in mutations.items():
+            with self.subTest(label=label):
+                result = self.run_settled_metrics_validator(mutation)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+
+    def test_settled_metrics_validator_does_not_mislabel_dhat_as_jemalloc(
+        self,
+    ) -> None:
+        fixture = "\n".join(
+            line
+            for line in self.settled_metrics_fixture().splitlines()
+            if not line.startswith("jemalloc_")
+        )
+        result = self.run_settled_metrics_validator(fixture, dhat=1)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_settled_proc_validator_requires_every_numeric_kib_field(self) -> None:
+        python = self.runner_embedded_python("validate_settled_proc_status()")
+        valid = (
+            "VmRSS:\t2048 kB\n"
+            "VmHWM:\t4096 kB\n"
+            "VmPeak:\t8192 kB\n"
+            "VmSize:\t6144 kB\n"
+        )
+        mutations = {
+            "valid": (valid, 0),
+            "missing VmRSS": (valid.replace("VmRSS:\t2048 kB\n", ""), 1),
+            "missing VmHWM": (valid.replace("VmHWM:\t4096 kB\n", ""), 1),
+            "missing VmPeak": (valid.replace("VmPeak:\t8192 kB\n", ""), 1),
+            "missing VmSize": (valid.replace("VmSize:\t6144 kB\n", ""), 1),
+            "wrong unit": (valid.replace("VmRSS:\t2048 kB", "VmRSS:\t2048 MB"), 1),
+        }
+        for label, (fixture, expected_rc) in mutations.items():
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as directory:
+                status = Path(directory) / "status"
+                status.write_text(fixture, encoding="utf-8")
+                result = subprocess.run(
+                    [sys.executable, "-c", python, str(status)],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+                self.assertEqual(result.returncode, expected_rc, result.stderr)
+
+    def test_zero_reload_evidence_is_captured_before_stub_release(self) -> None:
+        runner = HERE.parents[2] / "docs" / "perf" / "run-explain-cache-variant.sh"
+        script = runner.read_text(encoding="utf-8")
+        order = [
+            'until [[ -e "$EVIDENCE_DIR/ready" ]]',
+            'mv "$candidate" "$OUT/metrics-after.prom"',
+            'validate_settled_proc_status "$OUT/proc-status-after.txt"',
+            'touch "$EVIDENCE_DIR/ack"',
+            'if wait "$H_PID"',
+        ]
+        positions = [script.index(marker) for marker in order]
+        self.assertEqual(positions, sorted(positions))
+
+        harness = (HERE.parent / "reloadstall" / "src" / "main.rs").read_text(
+            encoding="utf-8"
+        )
+        handshake = harness.rindex(
+            "await_evidence_capture(evidence_dir, EVIDENCE_TIMEOUT)"
+        )
+        done = harness.rindex('println!("done rss_mib={}", rss_mib(pid));')
+        self.assertLess(handshake, done)
+
+    def test_dhat_receipt_requires_allocator_artifact_before_success(self) -> None:
+        runner = HERE.parents[2] / "docs" / "perf" / "run-explain-cache-variant.sh"
+        script = runner.read_text(encoding="utf-8")
+        gate_start = script.index("if ((DHAT != 0)); then")
+        gate_end = script.index("\nfi\n", gate_start) + len("\nfi\n")
+        gate = script[gate_start:gate_end]
+        required = gate_start + gate.index(
+            '[[ -f "$OUT/dhat-heap.json" && -s "$OUT/dhat-heap.json" ]] || {'
+        )
+        summary = script.index("# Summary: steady = median")
+        success = script.index("printf 'status=success\\n'")
+        self.assertLess(required, summary)
+        self.assertLess(required, success)
+
+        with tempfile.TemporaryDirectory() as directory:
+            out = Path(directory)
+            artifact = out / "dhat-heap.json"
+            cases = (
+                ("disabled and absent", "0", 0),
+                ("enabled and absent", "1", 1),
+                ("enabled and empty", "1", 1),
+                ("enabled and directory", "1", 1),
+                ("enabled and nonempty regular", "1", 0),
+            )
+            for label, dhat, expected_rc in cases:
+                with self.subTest(label=label):
+                    if artifact.is_dir():
+                        artifact.rmdir()
+                    else:
+                        artifact.unlink(missing_ok=True)
+                    if label.endswith("empty"):
+                        artifact.touch()
+                    elif label.endswith("directory"):
+                        artifact.mkdir()
+                    elif label.endswith("nonempty regular"):
+                        artifact.write_text("{}\n", encoding="utf-8")
+                    result = subprocess.run(
+                        [
+                            "bash",
+                            "-c",
+                            f"set -euo pipefail\nOUT=$1\nDHAT=$2\n{gate}",
+                            "_",
+                            str(out),
+                            dhat,
+                        ],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                    )
+                    self.assertEqual(result.returncode, expected_rc, result.stderr)
 
     def test_dhat_derivative_bounds_fail_without_partial_output(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/bench/scale/reloadstall/src/main.rs
+++ b/bench/scale/reloadstall/src/main.rs
@@ -36,6 +36,7 @@
 #![allow(dead_code)]
 
 use std::net::{Ipv4Addr, SocketAddr};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -68,6 +69,7 @@ const COMMUNITY_STABLE: u32 = (65_400 << 16) | 9_000;
 const STALL_WINDOW: Duration = Duration::from_secs(120);
 const FLAP_ROUNDS: u32 = 3;
 const FLAP_RECONNECT_SECS: u64 = 10;
+const EVIDENCE_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// What the shared per-observer bitmap is armed to track (flapstorm mode).
 const FLAP_OFF: u32 = 0;
@@ -863,6 +865,38 @@ async fn run_flapstorm(ctx: &Arc<Ctx>, stubs: &mut [Stub], k: u32, pid: i32) {
     }
 }
 
+/// Hold the live stub sessions open while an outer measurement runner captures
+/// its final daemon evidence.
+///
+/// This is deliberately opt-in and file-based: the frozen positional CLI stays
+/// unchanged, while the ready/ack boundary makes it impossible for the runner
+/// to accidentally scrape after dropping every stub socket. The bounded wait
+/// fails the receipt instead of parking the host if the runner disappears.
+async fn await_evidence_capture(evidence_dir: &Path, timeout: Duration) -> std::io::Result<()> {
+    std::fs::create_dir_all(evidence_dir)?;
+    if std::fs::read_dir(evidence_dir)?.next().is_some() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            "final evidence directory is not empty",
+        ));
+    }
+    std::fs::write(evidence_dir.join("ready"), b"ready\n")?;
+    let deadline = Instant::now() + timeout;
+    while !evidence_dir.join("ack").is_file() {
+        if Instant::now() >= deadline {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!(
+                    "final evidence acknowledgement not received within {}s",
+                    timeout.as_secs()
+                ),
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_lines)]
 fn main() {
     let mut a: Vec<String> = std::env::args().collect();
@@ -902,6 +936,7 @@ fn main() {
     let control_secs: u64 = a[9].parse().unwrap();
     let changed_peers: u32 = a.get(10).map_or(n_peers, |value| value.parse().unwrap());
     let reload_cmd: Option<String> = a.get(11).cloned();
+    let evidence_dir = std::env::var_os("RELOADSTALL_EVIDENCE_DIR").map(PathBuf::from);
     assert!(n_peers >= CHURNERS, "n_peers must be at least {CHURNERS}");
     assert!(
         (1..=n_peers).contains(&changed_peers),
@@ -910,6 +945,10 @@ fn main() {
     assert!(
         pid != 0 || reload_cmd.is_some() || flapstorm.is_some(),
         "daemon_pid 0 (outer RSS sampler) requires reload_cmd or --flapstorm"
+    );
+    assert!(
+        evidence_dir.is_none() || (reloads == 0 && flapstorm.is_none()),
+        "RELOADSTALL_EVIDENCE_DIR is only valid for zero-reload measurements"
     );
     if let Some(k) = flapstorm {
         assert!(
@@ -1318,14 +1357,34 @@ fn main() {
             tokio::time::sleep(Duration::from_secs(20)).await;
         }
 
-        println!("done rss_mib={}", rss_mib(pid));
         let parse_errors = ctx.parse_errors.load(Ordering::Relaxed);
-        if parse_errors > 0 {
+        let Some(evidence_dir) = evidence_dir.as_deref() else {
+            println!("done rss_mib={}", rss_mib(pid));
+            if parse_errors > 0 {
+                eprintln!(
+                    "FAIL: {parse_errors} daemon UPDATE decode error(s) — a wire defect; measurement is invalid"
+                );
+                std::process::exit(1);
+            }
+            std::process::exit(0);
+        };
+        let up = ctx
+            .obs
+            .iter()
+            .filter(|observer| observer.established.load(Ordering::Relaxed))
+            .count();
+        if up != n_peers as usize || parse_errors != 0 {
             eprintln!(
-                "FAIL: {parse_errors} daemon UPDATE decode error(s) — a wire defect; measurement is invalid"
+                "FAIL: final integrity check failed: sessions_up={up}/{n_peers}, parse_errors={parse_errors}"
             );
             std::process::exit(1);
         }
+        println!("final sessions_up {up}/{n_peers} parse_errors={parse_errors}");
+        if let Err(error) = await_evidence_capture(evidence_dir, EVIDENCE_TIMEOUT).await {
+            eprintln!("FAIL: final evidence handshake failed: {error}");
+            std::process::exit(1);
+        }
+        println!("done rss_mib={}", rss_mib(pid));
         std::process::exit(0);
     });
 }
@@ -1333,6 +1392,61 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn evidence_test_dir(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "reloadstall-{label}-{}-{}",
+            std::process::id(),
+            wall_us()
+        ))
+    }
+
+    #[tokio::test]
+    async fn evidence_handshake_keeps_boundary_until_ack() {
+        let directory = evidence_test_dir("ack");
+        let writer_dir = directory.clone();
+        let ack_writer = tokio::spawn(async move {
+            while !writer_dir.join("ready").is_file() {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            std::fs::write(writer_dir.join("ack"), b"ack\n").unwrap();
+        });
+
+        await_evidence_capture(&directory, Duration::from_secs(1))
+            .await
+            .unwrap();
+        ack_writer.await.unwrap();
+        assert!(directory.join("ready").is_file());
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[tokio::test]
+    async fn evidence_handshake_timeout_fails_closed() {
+        let directory = evidence_test_dir("timeout");
+        let error = await_evidence_capture(&directory, Duration::from_millis(10))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        assert!(directory.join("ready").is_file());
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[tokio::test]
+    async fn evidence_handshake_rejects_stale_boundary_files() {
+        for marker in ["ready", "ack"] {
+            let directory = evidence_test_dir(marker);
+            std::fs::create_dir_all(&directory).unwrap();
+            std::fs::write(directory.join(marker), b"stale\n").unwrap();
+
+            let error = await_evidence_capture(&directory, Duration::from_millis(10))
+                .await
+                .unwrap_err();
+
+            assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+            std::fs::remove_dir_all(directory).unwrap();
+        }
+    }
 
     #[test]
     fn generation_progress_counts_unique_prefixes_only() {

--- a/docs/perf/run-explain-cache-variant.sh
+++ b/docs/perf/run-explain-cache-variant.sh
@@ -214,13 +214,109 @@ os.kill(int(parent_pid), signal.SIGTERM)
 PY
 }
 
+validate_settled_metrics() {
+    local metrics=$1
+    # LAN-630 settled-state gates: missing metrics are failures, never zero.
+    python3 - "$metrics" "$PEERS" "$DHAT" <<'PY'
+import math
+import pathlib
+import re
+import sys
+
+path, peers_arg, dhat_arg = sys.argv[1:]
+peers = int(peers_arg)
+dhat = int(dhat_arg)
+sample_re = re.compile(
+    r"^([a-zA-Z_:][a-zA-Z0-9_:]*)(?:\{[^}]*\})?\s+"
+    r"([-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][-+]?[0-9]+)?)$"
+)
+samples: dict[str, list[float]] = {}
+for line in pathlib.Path(path).read_text(encoding="utf-8").splitlines():
+    match = sample_re.match(line)
+    if match:
+        samples.setdefault(match.group(1), []).append(float(match.group(2)))
+
+
+def values(name: str, count: int) -> list[float]:
+    found = samples.get(name, [])
+    if len(found) != count:
+        raise SystemExit(f"{name}: expected {count} samples, got {len(found)}")
+    if not all(math.isfinite(value) for value in found):
+        raise SystemExit(f"{name}: non-finite sample")
+    return found
+
+
+def singleton(name: str, expected: int) -> None:
+    value = values(name, 1)[0]
+    if value != expected:
+        raise SystemExit(f"{name}: expected {expected}, got {value:g}")
+
+
+singleton("bgp_update_groups", 1)
+members = values("bgp_update_group_members", 1)
+if sum(members) != peers:
+    raise SystemExit(
+        f"bgp_update_group_members: expected sum {peers}, got {sum(members):g}"
+    )
+singleton("bgp_update_group_fallback_peers", 0)
+singleton("bgp_update_group_residue_entries", 0)
+singleton("bgp_rib_outbound_registered_peers", peers)
+
+rejected = values("bgp_rejected_routes_retained", peers)
+if sum(rejected) != 0:
+    raise SystemExit(
+        f"bgp_rejected_routes_retained: expected sum 0, got {sum(rejected):g}"
+    )
+writer_depth = values("bgp_peer_outbound_queue_depth", peers)
+if sum(writer_depth) != 0 or max(writer_depth) != 0:
+    raise SystemExit(
+        "bgp_peer_outbound_queue_depth: expected every peer settled at 0, "
+        f"got sum={sum(writer_depth):g} max={max(writer_depth):g}"
+    )
+
+if dhat == 0:
+    for name in (
+        "jemalloc_allocated_bytes",
+        "jemalloc_active_bytes",
+        "jemalloc_resident_bytes",
+        "jemalloc_mapped_bytes",
+    ):
+        value = values(name, 1)[0]
+        if value <= 0:
+            raise SystemExit(f"{name}: expected a positive release-build sample")
+        print(f"{name}={int(value)}")
+PY
+}
+
+validate_settled_proc_status() {
+    local status=$1
+    python3 - "$status" <<'PY'
+import pathlib
+import re
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+for field in ("VmRSS", "VmHWM", "VmPeak", "VmSize"):
+    found = re.findall(rf"^{field}:\s+([0-9]+)\s+kB$", text, re.MULTILINE)
+    if len(found) != 1:
+        raise SystemExit(f"{field}: expected one numeric-kB field, got {len(found)}")
+    print(f"settled_proc_{field.lower()}_kib={found[0]}")
+PY
+}
+
 printf 'daemon_start_monotonic=%s\n' "$(monotonic_now)" >>"$OUT/provenance.env"
 cold_deadline=$((SECONDS + COLD_CAP))
 runtime_guard &
 # Used indirectly by cleanup/terminate_pid through a nameref.
 # shellcheck disable=SC2034
 GUARD_PID=$!
-timeout -k 10 "$OVERALL_CAP" "$HARNESS" "$PEERS" "$TOTAL" "$PORT" "$DAEMON_PID" \
+HARNESS_ENV=()
+EVIDENCE_DIR=''
+if ((RELOADS == 0)); then
+    EVIDENCE_DIR="$RUN/final-evidence"
+    HARNESS_ENV=(env "RELOADSTALL_EVIDENCE_DIR=$EVIDENCE_DIR")
+fi
+timeout -k 10 "$OVERALL_CAP" "${HARNESS_ENV[@]}" "$HARNESS" "$PEERS" "$TOTAL" "$PORT" "$DAEMON_PID" \
     "$RUN/member.rpol" "$RUN/gen-a.rpol" "$RUN/gen-b.rpol" "$RELOADS" \
     "$CONTROL_SECS" "$CHANGED" >"$OUT/reloadstall.log" 2>&1 & H_PID=$!
 rss_sampler & RSS_PID=$!
@@ -234,14 +330,45 @@ printf 'converged_monotonic=%s\n' "$(monotonic_now)" >>"$OUT/provenance.env"
 curl -fsS --max-time 2 "http://127.0.0.1:${METRICS_PORT}/metrics" >"$OUT/metrics-converged.prom"
 grep -E '^(VmRSS|VmHWM|VmPeak|VmSize)' "/proc/$DAEMON_PID/status" >"$OUT/proc-status-converged.txt"
 
-while pid_running "$H_PID"; do
-    if grep -q "^reloadstall_csv,${RELOADS}," "$OUT/reloadstall.log"; then
-        curl -fsS --max-time 2 "http://127.0.0.1:${METRICS_PORT}/metrics" >"$OUT/metrics-after.prom"
-        grep -E '^(VmRSS|VmHWM|VmPeak|VmSize)' "/proc/$DAEMON_PID/status" >"$OUT/proc-status-after.txt"
-        break
+if ((RELOADS == 0)); then
+    evidence_deadline=$((SECONDS + CONTROL_SECS + 20))
+    until [[ -e "$EVIDENCE_DIR/ready" ]]; do
+        pid_running "$H_PID" || { echo "harness exited before final evidence boundary" >&2; exit 1; }
+        ((SECONDS < evidence_deadline)) || { echo "final evidence ready timeout" >&2; exit 1; }
+        sleep 0.025
+    done
+    evidence_deadline=$((SECONDS + 10))
+    accepted=0
+    while ((SECONDS < evidence_deadline)); do
+        candidate="$RUN/metrics-candidate.prom"
+        if curl -fsS --max-time 2 "http://127.0.0.1:${METRICS_PORT}/metrics" >"$candidate" &&
+            validate_settled_metrics "$candidate" >"$RUN/settled-metrics.env" \
+                2>"$RUN/settled-metrics.error"; then
+            mv "$candidate" "$OUT/metrics-after.prom"
+            mv "$RUN/settled-metrics.env" "$OUT/settled-metrics.env"
+            accepted=1
+            break
+        fi
+        sleep 0.1
+    done
+    if ((accepted == 0)); then
+        [[ ! -s "$RUN/settled-metrics.error" ]] || cat "$RUN/settled-metrics.error" >&2
+        echo "no settled final metrics scrape accepted before timeout" >&2
+        exit 1
     fi
-    sleep 0.1
-done
+    grep -E '^(VmRSS|VmHWM|VmPeak|VmSize)' "/proc/$DAEMON_PID/status" >"$OUT/proc-status-after.txt"
+    validate_settled_proc_status "$OUT/proc-status-after.txt" >"$OUT/settled-proc.env"
+    touch "$EVIDENCE_DIR/ack"
+else
+    while pid_running "$H_PID"; do
+        if grep -q "^reloadstall_csv,${RELOADS}," "$OUT/reloadstall.log"; then
+            curl -fsS --max-time 2 "http://127.0.0.1:${METRICS_PORT}/metrics" >"$OUT/metrics-after.prom"
+            grep -E '^(VmRSS|VmHWM|VmPeak|VmSize)' "/proc/$DAEMON_PID/status" >"$OUT/proc-status-after.txt"
+            break
+        fi
+        sleep 0.1
+    done
+fi
 if wait "$H_PID"; then hrc=0; else hrc=$?; fi
 H_PID=''
 if wait "$RSS_PID"; then rrc=0; else rrc=$?; fi
@@ -250,7 +377,12 @@ printf 'harness_rc=%s\nrss_sampler_rc=%s\n' "$hrc" "$rrc" >>"$OUT/provenance.env
 grep -E '^(VmRSS|VmHWM|VmPeak|VmSize)' "/proc/$DAEMON_PID/status" >"$OUT/proc-status-final.txt" || true
 terminate_pid DAEMON_PID
 terminate_pid GUARD_PID
-((DHAT == 0)) || [[ -f "$OUT/dhat-heap.json" ]] || echo "warning: no dhat-heap.json produced" >&2
+if ((DHAT != 0)); then
+    [[ -f "$OUT/dhat-heap.json" && -s "$OUT/dhat-heap.json" ]] || {
+        echo "DHAT run produced no non-empty regular dhat-heap.json" >&2
+        exit 1
+    }
+fi
 
 # Summary: steady = median of post-convergence samples; peak = daemon kernel VmHWM.
 python3 - "$OUT" <<'PY'
@@ -284,6 +416,12 @@ summary = {
     "post_convergence_min_kib": min(post) if post else 0,
     "post_convergence_max_kib": max(post) if post else 0,
 }
+for evidence in ("settled-proc.env", "settled-metrics.env"):
+    path = out / evidence
+    if path.exists():
+        for line in path.read_text().splitlines():
+            key, value = line.split("=", 1)
+            summary[key] = int(value)
 out.joinpath("summary.env").write_text(
     "".join(f"{k}={v}\n" for k, v in summary.items()))
 print("\n".join(f"{k}={v}" for k, v in summary.items()))


### PR DESCRIPTION
## Summary

- add an opt-in ready/ack boundary that keeps zero-reload route-server sessions alive until final evidence is captured
- require an exact settled-state metrics scrape plus numeric process-memory fields before accepting the run
- keep release jemalloc evidence distinct from DHAT attribution and fail a DHAT run without a nonempty regular profile
- add executable fixture and ordering proofs for every new fail-closed gate

## Why

LAN-630 needs a controlled peer-versus-route memory campaign before any queue or data-structure change is justified. The existing runner could take its final scrape after the harness had dropped every peer socket, silently coerce missing evidence into an incomplete receipt, and mark DHAT runs successful without their allocator profile.

This patch changes only the measurement harness. It does not add production instrumentation, change queue capacities, make a performance claim, or alter the existing nonzero-reload path.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo test --manifest-path bench/scale/reloadstall/Cargo.toml`
- `python3 -m unittest bench/scale/rebaseline/test_classifiers.py`
- `bash -n docs/perf/run-explain-cache-variant.sh`
- `shellcheck docs/perf/run-explain-cache-variant.sh`
- real release-daemon smoke: 20 peers, 400 routes, `RELOADS=0`, 20/20 sessions, zero parse errors, one 20-member update group, zero fallback/residue/rejections/writer backlog, and all proc/jemalloc fields captured before socket release

## Load-bearing proofs

- deleting the live-socket handshake call makes the evidence-order test red
- deleting the update-group residue gate makes the injected residue case red
- deleting settled summary ingestion makes the expected proc field disappear
- changing the DHAT failure exit to a no-op makes the absent, empty, and directory artifact cases red

The first workspace test run hit one unrelated doctor reachability probe race; that test passed immediately in isolation and the complete workspace rerun passed.

Linear: https://linear.app/lance0/issue/LAN-630/attribute-and-reduce-the-post-1167-per-peer-rss-slope-at-route-server
