### PR TITLE
ci: expand Clippy reason ratchet

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1907,10 +1907,10 @@ branch is between features.
   non-adversarial control-plane maps that show up in `dhat` or Criterion.
 - [ ] **CI gate: `#[allow(clippy::*)]` / `#[expect(clippy::*)]` requires
   `reason = "..."`.** The ratchet exists and CI enforces it for
-  `crates/rib/src`, whose suppressions are backfilled. Remaining work:
-  add more paths to `scripts/check-clippy-reasons.py` as each crate/file
-  group is backfilled; do not flip this to complete until the whole
-  workspace is covered.
+  the 14 backfilled crate source trees named in `DEFAULT_PATHS`. Remaining
+  work: backfill root `src/` and `crates/evpn-linux/src`, then add them to
+  `scripts/check-clippy-reasons.py`; do not flip this to complete until the
+  whole workspace is covered.
 - [x] **`cargo deny` for license / dependency / advisory audit.** Done: the
   dependabot + cargo-audit half of the stale branch had already landed;
   `deny.toml` now gates `cargo deny check advisories bans licenses sources`

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -366,7 +366,10 @@ impl BgpMetrics {
     ///
     /// Panics if metric registration fails.
     #[must_use]
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the constructor keeps the complete metric inventory and registration wiring together"
+    )]
     pub fn with_registry(registry: Registry) -> Self {
         let state_transitions = IntCounterVec::new(
             Opts::new(

--- a/scripts/check-clippy-reasons.py
+++ b/scripts/check-clippy-reasons.py
@@ -21,6 +21,9 @@ DEFAULT_PATHS = (
     "crates/transport/src",
     "crates/wire/src",
     "crates/bmp/src",
+    "crates/bfd/src",
+    "crates/mrt/src",
+    "crates/telemetry/src",
 )
 ATTRIBUTE_HEAD = re.compile(r"#!?\[\s*(?:allow|expect)\s*\(")
 REASON = re.compile(r"\breason\s*=")

--- a/scripts/test_check_clippy_reasons.py
+++ b/scripts/test_check_clippy_reasons.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 
 SCRIPT = Path(__file__).with_name("check-clippy-reasons.py")
+REPO = SCRIPT.parent.parent
 SPEC = importlib.util.spec_from_file_location("check_clippy_reasons", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 checker = importlib.util.module_from_spec(SPEC)
@@ -40,6 +41,19 @@ class ClippyReasonTests(unittest.TestCase):
     def test_cli_and_event_history_are_ratcheted_by_default(self) -> None:
         self.assertIn("crates/cli/src", checker.DEFAULT_PATHS)
         self.assertIn("crates/event-history/src", checker.DEFAULT_PATHS)
+
+    def test_bfd_mrt_and_telemetry_are_ratcheted_and_clean(self) -> None:
+        for path in (
+            "crates/bfd/src",
+            "crates/mrt/src",
+            "crates/telemetry/src",
+        ):
+            with self.subTest(path=path):
+                self.assertIn(path, checker.DEFAULT_PATHS)
+        self.assertEqual(
+            checker.missing_reasons(REPO / "crates/telemetry/src/metrics.rs"),
+            [],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add BFD, MRT, and telemetry source trees to the default Clippy suppression-reason ratchet
- backfill the one missing telemetry rationale
- correct the roadmap coverage statement while leaving the workspace-wide item open

## Verification
- `python3 -m unittest scripts/test_check_clippy_reasons.py`
- `python3 scripts/check-clippy-reasons.py`
- `python3 scripts/check-clippy-reasons.py crates/bfd/src crates/mrt/src crates/telemetry/src`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- `git diff --check`

## Load-bearing proof
Deleting the new `reason` from `BgpMetrics::with_registry` makes both the direct telemetry-source assertion and the default repository checker fail at `crates/telemetry/src/metrics.rs`; restoring the rationale returns them to green.
