### PR TITLE
docs: rewrite the gRPC tier-auth threat model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -802,22 +802,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and `PeerConfig` is `#[non_exhaustive]`, so external construction through
   its builder is unaffected.
 
-- **The gRPC threat-model annex is withdrawn; stop citing it as security
-  evidence.** `docs/adr/0064-threat-model.md` described the management
-  plane as it stood before v0.24.0 — tier enforcement audit-only and off
-  by default, principal mapping unimplemented, and any accepted credential
-  reaching the whole read-write surface. Tier enforcement has been the
-  default since v0.24.0, so a reviewer working from that document
-  prioritised threats the daemon already denies before the handler runs.
-  Its risk rankings were all derived from the superseded assumption and
-  could not be repaired by editing the prose around them, so the file is
-  now a stub that says so and points at the surfaces that are current;
-  the rewrite is slice 7 of ADR-0064. `docs/API.md`, `docs/SECURITY.md`,
-  and the method inventory no longer present it as an external-review
-  packet, and the release checklist now audits the inventory's structural
-  fence — the tests that hold `grpc-method-inventory.md` and `.json` to
-  the tiers the daemon enforces — in place of a file-non-empty check on
-  the annex.
+- **The gRPC threat-model annex now describes the enforced tier system.**
+  The pre-v0.24.0 audit-only draft was withdrawn because its attacker
+  assumptions and risk rankings no longer matched the daemon. The replacement
+  re-derives the authorization path, trust boundaries, and residual risks from
+  the current listener-cap plus principal-role enforcement, including the
+  explicit `legacy` opt-out, live credential rotation, accepted-client and
+  unauthenticated resource abuse, and audit-retention limits. The release
+  checklist keeps the mechanically fenced method inventory separate from the
+  required manual review of the threat model's assumptions and rankings.
 
 - **Turning off `[policy.explain]` now actually costs nothing per peer.**
   The import-decision cache was built at session construction, so every

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -321,10 +321,11 @@ failing:
 cargo test -p rustbgpd-api authz
 ```
 
-`docs/adr/0064-threat-model.md` is withdrawn pending rewrite and is deliberately
-not audited here. It is prose with no code fence; the `test -s` check it used to
-carry proved only that the file was non-empty, which is why it outlived its own
-accuracy.
+`docs/adr/0064-threat-model.md` is prose, so the structural inventory tests do
+not prove its attacker assumptions or risk rankings. Review its authorization
+path and residual-risk claims against the source paths named in its
+**Evidence and review focus** section; do not substitute a non-empty-file check
+for that review.
 
 ### Interop smoke (requires Docker + containerlab)
 

--- a/docs/adr/0064-grpc-authorization.md
+++ b/docs/adr/0064-grpc-authorization.md
@@ -349,10 +349,10 @@ review/rollback unit.
    operators need configurable sampling.
 7. **External-review prep.** Threat-model doc, per-slice security
    sign-off, external auditor packet (inventory + ADR + threat model
-   + audit-log sample). The draft written against the pre-v0.24.0
-   audit-only posture is withdrawn — `docs/adr/0064-threat-model.md` is
-   a stub recording that and pointing at the surfaces that are current —
-   so this slice starts from the enforced model.
+   + audit-log sample). `docs/adr/0064-threat-model.md` now models the
+   enforced tier system and re-derives the residual risks from that
+   posture. Per-slice sign-off and assembly of an external auditor packet
+   remain follow-up work.
 
 Slices 1–5 are the v1.0 blocker; slice 6 is hardening that should
 land in the same release window; slice 7 is the gate the external
@@ -377,9 +377,11 @@ own migration window.
   operational network controls. Per-principal or per-listener request/stream
   budgets remain future work if production evidence shows the existing signals
   are insufficient.
-- **Dynamic role updates.** Slice 2 reads the role map at startup
-  and on SIGHUP. Live role revocation without a SIGHUP (e.g. a
-  "kick this principal" RPC) is not v1.
+- **Dynamic role updates.** Listeners read the role map at startup. SIGHUP
+  keeps the live startup authorization pinned and requires a restart for role,
+  principal, enforcement, listener, or access changes. Live role revocation
+  without rebuilding the listener (for example, a "kick this principal" RPC)
+  is not v1.
 - **Capability-token alternative.** A future model could replace
   static principal role mapping with short-lived capability tokens minted by
   an external IAM. This ADR's principal-lookup mechanism does not
@@ -396,23 +398,22 @@ implemented by the runtime tier-decision layer: method-path lookup, structured
 `[security.grpc.roles]`, `enforcement = "legacy"`, and explicit non-mTLS
 listener principal labels for bearer-token TCP and UDS audit identity.
 Slice 4a adds enforced per-listener `max_tier` caps while preserving
-`access_mode` as a compatibility ceiling. Slice 3b adds audit-only native mTLS
-certificate principal extraction (`rustbgpd:` URI SAN, then email SAN, then
-Subject CN). Slice 5a adds opt-in per-principal role enforcement while leaving
-`legacy` as the default. Slice 6a adds result-aware audit records and
-credential-masked request summaries for `DiffRuntimeConfig`, `SetPeerGroup`,
-`PlanConfigTransaction`, and `ApplyConfigTransaction`.
-Slice 5b adds migration guidance and config-test coverage for staged tier-mode
-UDS / bearer-token deployments without flipping the default. Later slices
-implement the default enforcement flip, durable audit-sink guidance, and
-optional proto credential markers.
+`access_mode` as a compatibility ceiling. Slice 3b adds native mTLS certificate
+principal extraction (`rustbgpd:` URI SAN, then email SAN, then Subject CN);
+slice 5 uses that principal for enforced authorization. Slice 5a adds opt-in
+per-principal role enforcement, slice 5b adds migration guidance and config
+coverage, and the final phase makes `tier` the default. Slice 6a adds
+result-aware audit records and credential-masked request summaries for
+`DiffRuntimeConfig`, `SetPeerGroup`, `PlanConfigTransaction`, and
+`ApplyConfigTransaction`. Durable in-daemon audit-sink semantics and optional
+proto credential markers remain deferred.
 
 | Slice | Status |
 |-------|--------|
 | 1. Foundation | Implemented by the checked method-matrix PR + machine-readable JSON export |
-| 2. Audit-only runtime path | Implemented by the runtime audit-layer PR |
-| 3. Identity + roles | Partial: roles config + bearer/UDS principals + mTLS audit principal extraction |
+| 2. Audit/runtime path | Done: decision/audit layer, used by the enforced cap and role checks |
+| 3. Identity + roles | Done: roles config + bearer/UDS principals + mTLS principal extraction |
 | 4. Listener tier cap | Done: `max_tier` listener cap enforced |
 | 5. Enforcement + default flip | Done in v0.24.0: opt-in `tier` role enforcement (slice 4a) + migration prep + default flip from `legacy` to `tier` (slice 4b, closes #164) |
 | 6. Audit log hardening | Partial: result-aware records + explicit credential masking table + operations guidance for audit retention and resource guardrails |
-| 7. External-review prep | Not started |
+| 7. External-review prep | Partial: current enforced-system threat model; external sign-off and auditor packet remain |

--- a/docs/adr/0064-threat-model.md
+++ b/docs/adr/0064-threat-model.md
@@ -1,57 +1,180 @@
 # ADR-0064 gRPC authorization threat model
 
-**Status:** Withdrawn — pending rewrite
-**Date:** 2026-05-18 (withdrawn 2026-07-25)
-**Scope:** gRPC management-plane authentication, authorization, audit
-logging, and per-method tier enforcement.
+**Status:** Current
+**Date:** 2026-07-26
+**Scope:** The production gRPC management plane: listener admission, method-tier
+authorization, principal-to-role authorization, and its audit and resource
+boundaries. BGP transport, the CLI, build/release systems, and non-gRPC APIs are
+out of scope.
 
-This annex has been withdrawn. It does not describe the shipped system
-and must not be cited as security evidence.
+## Executive summary
 
-## Why it was withdrawn
+The shipped posture is enforced tier authorization, not an audit-only overlay.
+Every gRPC call is classified by a checked method matrix and constrained by the
+listener's `max_tier`; in the default `tier` mode the authorization layer also
+applies the configured role ceiling before dispatch. Bearer authentication is
+still enforced by the listener's interceptor before the handler runs. The
+important remaining risks are the blast radius of a valid accepted credential,
+operators' collection of the audit trail, resource consumption by accepted
+clients, and request/log floods from network-reachable callers before
+authentication succeeds. This document does not assume that one accepted
+credential reaches the entire read-write surface.
 
-The draft modeled the management plane as it stood before v0.24.0: tier
-enforcement audit-only and off by default, principal mapping
-unimplemented, and any accepted credential reaching the whole read-write
-surface. None of that holds today. `enforcement = "tier"` is the
-default; the runtime resolves each call's tier before the handler runs
-and denies it when the listener ceiling or the authenticated principal's
-role does not reach that tier; and under tier enforcement startup
-validation rejects a listener that can produce no principal at all,
-rather than falling back open.
+## Scope and assumptions
 
-Every risk ranking in the draft was derived from that superseded
-assumption, so the rankings cannot be repaired by correcting the prose
-around them — they have to be re-derived against the enforced model.
-That rewrite is slice 7 of [ADR-0064](0064-grpc-authorization.md), and is
-deliberately not improvised here. Until it lands this repository
-publishes no gRPC threat model, and the documents below carry the
-security surface instead.
+- `security.grpc.enforcement = "tier"` is the default. `legacy` remains an
+  explicit compatibility opt-out and deliberately does not get the principal
+  role check; listener caps still apply.
+- The daemon is deployed on a management network. Network reachability,
+  certificate issuance, bearer-token distribution, UDS permissions, and log
+  collection are operator responsibilities outside this process.
+- The threat model treats the checked matrix as the current contract rather
+  than duplicating its method list. The matrix and both published inventories
+  are test-fenced in both directions.
+- No claim here treats configuration validation as a substitute for protecting
+  the management network or for promptly rotating compromised credentials.
 
-## What to read instead
+Open deployment questions that affect the likelihood ratings are whether TCP
+listeners are reachable outside the management network, how client credentials
+are issued and revoked, and where `grpc_authz` logs are retained and who may
+query them.
 
-| Question | Source |
-|----------|--------|
-| How the tier model is designed, and which slices remain open | [ADR-0064](0064-grpc-authorization.md) |
-| Which tier each RPC carries, and why | [`docs/grpc-method-inventory.md`](../grpc-method-inventory.md) |
-| Deployment hardening, listener posture, credential handling | [`docs/SECURITY.md`](../SECURITY.md) |
-| Listener access matrix, audit-record fields, migration steps | [`docs/API.md`](../API.md) |
-| How to report a vulnerability | [`SECURITY.md`](../../SECURITY.md) |
+## System model
 
-Of these, the inventory is the one an auditor can trust mechanically:
-`cargo test -p rustbgpd-api authz` fences its per-service tables and
-totals against [`grpc-method-inventory.json`](../grpc-method-inventory.json)
-in both directions, and fences that export against the `METHODS` matrix
-the daemon actually enforces. A tier that drifts from the code fails the
-build. The remaining documents are prose and carry no such guarantee.
+### Authorization path
 
-## What a rewrite has to cover
+1. A client reaches a configured TCP or UDS gRPC listener. Tier-mode validation
+   rejects an implicit listener, an unauthenticated TCP listener, a bearer or
+   UDS listener without a configured and mapped principal, and an attempt to
+   map the reserved `mtls-unresolved` principal.
+2. The listener supplies an identity: mTLS derives one from an already
+   validated peer certificate (`rustbgpd` URI SAN, then email SAN, then Subject
+   CN), skipping an unsafe candidate in favor of a later safe field.
+   Bearer-token TCP and UDS listeners use an explicit configured principal. If
+   no usable mTLS identity remains, extraction becomes `mtls-unresolved`.
+3. `GrpcAuthzLayer` looks up the request path. A known method gets its checked
+   tier; an unknown path is `operator_only`. Before returning a listener-cap or
+   role denial for a bearer listener, the layer authenticates the credential
+   itself so an invalid caller cannot use `PERMISSION_DENIED` as a tier oracle.
+   After that preflight, it rejects tiers above the listener `max_tier`, then,
+   in `tier` mode, rejects an unmapped principal or one whose role ceiling is
+   too low. Those paths return before dispatching to the handler.
+4. A call that passes the layer still traverses the per-service bearer
+   interceptor before its handler. Forwarded calls receive a result-aware
+   `grpc_authz` record for handler admission and the initial response; denied
+   calls also receive a decision record and bounded-label metric.
+   Credential-bearing request summaries are masked by the audit helpers.
 
-- The enforced two-check model — listener ceiling then principal role —
-  as the baseline, not as future work.
-- Where a principal comes from on each listener kind, and what the
-  daemon does when one cannot be derived.
-- Residual risk that survives tier enforcement: shared-credential blast
-  radius within a role, durable audit sink and retention, and
-  resource-abuse guardrails on streams and queries.
-- Risk rankings derived from that model rather than carried over.
+```mermaid
+flowchart LR
+    C["Management client"] --> T["TCP or UDS listener"]
+    T --> I["Credential and principal"]
+    I --> A["Credential preflight and tier authorization"]
+    A --> H["gRPC handler"]
+    A --> L["Audit logs and metrics"]
+    H --> L
+```
+
+### Trust boundaries and assets
+
+| Boundary or asset | Security objective | Evidence |
+| --- | --- | --- |
+| Client to TCP/UDS listener | Admit only a configured identity path; avoid an anonymous tier-mode listener | `src/config/validation.rs::validate_grpc_tier_enforcement` |
+| Listener to authorization layer | Enforce the listener ceiling independently of role mapping | `crates/api/src/authz_runtime/layer.rs::GrpcAuthzService::call` |
+| Principal to role map | Restrict the accepted identity to `observer`, `automation`, or `operator` authority | `crates/api/src/authz.rs::PrincipalRole`; `authz_runtime/context.rs::role_denial` |
+| Method matrix and published inventory | Keep authorization classification complete and reviewable | `crates/api/src/authz.rs::METHODS` and its inventory tests |
+| Route, topology, policy, and configuration data | Preserve confidentiality and integrity of operational state | `docs/grpc-method-inventory.md` |
+| Mutating and operator-only RPCs | Prevent unauthorized session, policy, configuration, route-injection, and dataplane changes | `docs/grpc-method-inventory.md` |
+| `grpc_authz` records and decision metrics | Support attribution and detection without exposing credentials | `crates/api/src/authz_runtime/decision.rs`; `crates/api/src/audit.rs` |
+
+## Attacker model
+
+### Capabilities
+
+- A network-reachable caller can attempt arbitrary gRPC paths and malformed or
+  missing bearer credentials.
+- A caller holding a valid credential, UDS access, or an accepted mTLS
+  certificate can exercise only the permissions associated with that identity,
+  listener, and method tier.
+- A malicious or faulty accepted client can retain streams, issue expensive
+  sensitive reads, or generate audit volume within its role in `tier` mode or
+  the listener cap in `legacy`.
+
+### Non-capabilities
+
+- An unauthenticated caller is not assumed to bypass mTLS, bearer verification,
+  UDS permissions, or tier-mode startup validation.
+- A credential accepted by one listener is not assumed to bypass that
+  listener's `max_tier`. Under the default `tier` mode it is also not assumed
+  to gain tiers above its configured role; `legacy` is modeled separately
+  below because it intentionally omits that role check.
+- Unknown gRPC paths are not assumed to inherit a permissive default: they are
+  classified as `operator_only`.
+
+## Threat model
+
+| ID | Abuse path and impact | Existing controls | Residual gap and priority |
+| --- | --- | --- | --- |
+| TM-001 | A stolen or wrongly issued credential performs operations permitted to its role, potentially changing peers, policy, configuration, route injection, or FIB state. Impact is high when the identity is `operator`. | mTLS/bearer/UDS identity paths; role ceilings; listener `max_tier`; `operator_only` classification. | Role scope is intentionally coarse and operator-controlled. **High**: likelihood depends on credential handling, impact is high for operator identities. Prefer small listener ceilings and separate identities by duty. |
+| TM-002 | A role or listener configuration maps an identity more broadly than intended, turning a normal accepted client into a higher-tier principal. | Tier-mode validation requires mapped explicit non-mTLS principals; unmapped identities are denied; a separately narrower listener ceiling is defense in depth. | Role-map review and credential issuance happen outside the request path. **Medium**: configuration error is plausible, and the listener ceiling reduces impact only when it is independently stricter than the mistaken role or listener configuration. Review both with the same care as privileged configuration changes. |
+| TM-003 | An accepted `sensitive_read` client repeatedly opens streams or requests large snapshots, consuming CPU, memory, sockets, or log capacity. | Method tiers, pagination/bounded histories, stream lag and subscriber metrics; the `GnmiService` has a 64-stream `Subscribe` semaphore. | That semaphore is not a per-principal budget, and there is no general per-principal request-rate or stream-count budget. **Medium**: an accepted client is required, but availability impact can be material. Use management-network and upstream rate controls; alert on stream and authz metrics. Client deadlines help with faulty or cooperative clients, not a malicious one. |
+| TM-004 | Audit records are unavailable, insufficiently retained, or accessed by the wrong party after a management-plane event, impairing attribution or disclosing operational metadata. | Structured records, bounded result labels, and masked credential-bearing summaries; forwarded records include handler admission and the initial response. | Streaming records do not attest to the terminal stream outcome. The daemon relies on journald, syslog, or an external agent; a durable in-daemon audit sink and its backpressure semantics are intentionally deferred. **Medium**: impact is primarily detection/forensics, but it affects every management-plane action. |
+| TM-005 | Authorization or credential material changes while accepted calls, streams, or TLS connections remain live. | Listener shape, auth mode, principal, roles, and access settings are restart-required and remain pinned to the startup generation. SIGHUP rotates bearer and mTLS material at unchanged paths; new bearer RPCs use the new token generation and new TLS connections use the new certificate generation. | Admitted streams continue, and an existing mTLS connection remains accepted and can make further calls. **Medium**: immediate role revocation requires restart; immediate mTLS revocation also requires ending existing connections. Client deadlines can bound cooperative streams but are not forced revocation. |
+| TM-006 | An unauthenticated network-reachable caller floods bearer requests, TLS connections, or malformed paths, consuming request processing and audit/log capacity. | Invalid bearer requests fail authentication; mTLS handshakes have concurrency and time bounds; unknown paths are `operator_only`. | There is no general connection or request rate limiter, and bearer failures still emit `grpc_authz` records. **Medium** when a listener is broadly reachable; keep it on a restricted management network and enforce upstream connection/request limits. |
+| TM-007 | A new RPC or generated route evades a low-risk classification and is exposed through a less restrictive listener. | The static matrix is checked against both protobuf inputs and the JSON/Markdown exports; unknown paths fail closed as `operator_only`. | Classification correctness still depends on review of a new method's semantics. **Low**: the structural fence makes omission fail closed, but a wrongly chosen known tier remains a review risk. |
+| TM-008 | An operator enables the supported `legacy` compatibility mode and assumes configured roles still constrain calls. Any authenticated identity can instead use every method permitted by that listener's `max_tier`. | `legacy` is an explicit non-default opt-out; validation and `--check` warn about the weaker posture; listener caps and authentication remain enforced. | Role mappings are audit context only in this mode. **Medium**: activation is deliberate, but a broad listener can give one accepted credential the full capped surface. Keep `legacy` time-bounded for migration and set a deliberately narrow `max_tier`. |
+
+## Operational mitigations and detection
+
+- Configure every remote listener with the smallest `max_tier` it needs; use
+  separate listeners and principals for observation, automation, and operator
+  actions.
+- Treat `[security.grpc.roles]`, listener `principal`, mTLS client issuance,
+  bearer-token files, and UDS permissions as privileged configuration. Do not
+  use `legacy` except as a documented migration exception.
+- Collect and protect `grpc_authz` structured records; alert on
+  `listener_tier_denied`, `principal_unmapped`, `role_tier_denied`,
+  both `authn_failed` and `handler_unauthenticated` authentication failures,
+  and unexpected operator-tier calls.
+- Monitor `bgp_grpc_authz_decisions_total`,
+  `bgp_event_stream_subscribers`, and `bgp_event_stream_lagged_total`.
+  Nonzero lag means a live event subscriber missed data; it is not a durable
+  queue guarantee.
+- Use management-network and upstream rate restrictions to constrain malicious
+  request floods. Use client deadlines to bound cooperative or faulty callers
+  until a per-principal budget design is justified.
+
+## Evidence and review focus
+
+| Path | Why it matters |
+| --- | --- |
+| `crates/api/src/authz.rs` | The method matrix, tier ordering, roles, and tests that fence the published inventory. |
+| `crates/api/src/authz_runtime/layer.rs` | Ordering of authentication, listener-cap, role-denial, handler dispatch, and audit recording. |
+| `crates/api/src/authz_runtime/context.rs` | Principal resolution and tier-mode role denial behavior. |
+| `crates/api/src/authz_principal.rs` | mTLS principal extraction and sanitization. |
+| `src/config/validation.rs` | Startup rejection of unsafe tier-mode listener configurations. |
+| `crates/api/src/audit.rs` | Credential masking and request-summary boundaries. |
+| `docs/grpc-method-inventory.json` | Machine-readable review artifact, fenced to the runtime matrix. |
+| `docs/OPERATIONS.md` | Audit collection, stream metrics, and accepted-client operational guardrails. |
+
+## Verification notes
+
+This is a docs-only change; no new runtime test is added, so a load-bearing
+red-proof is **N/A**. The factual baseline was checked directly against:
+
+- `GrpcAuthzService::call`, which performs both denials before `inner.call`;
+- `GrpcAuthAuditContext::role_denial`, which denies unmapped principals in
+  `tier` mode;
+- `validate_grpc_tier_enforcement`, which rejects unsafe tier-mode listener
+  configurations, and `validate_grpc_security`, which disallows a role mapping
+  for `mtls-unresolved` in every mode;
+- the `authz` tests that compare `METHODS` with both protobuf inputs and both
+  published inventories; and
+- the documented operational limits and signals in `docs/SECURITY.md` and
+  `docs/OPERATIONS.md`.
+
+The key review rule is therefore explicit: under the default `tier` mode, a
+valid accepted management-plane identity can use only the method tiers granted
+by both its role and listener. Under the supported `legacy` opt-out, the
+listener ceiling is the authorization boundary and role mappings are audit
+context only. Neither baseline assumes an audit-only listener-cap layer.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -72,7 +72,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0062](0062-tcp-ao-foundation.md) | TCP-AO foundation | Accepted | 2026-05-16 |
 | [0063](0063-evpn-runtime-instance-mutation.md) | EVPN runtime instance mutation semantics | Accepted | 2026-05-17 |
 | [0064](0064-grpc-authorization.md) | gRPC per-method authorization | Accepted | 2026-05-18 |
-| [0064-annex](0064-threat-model.md) | gRPC management-plane threat model (ADR-0064 annex) | Withdrawn — pending rewrite | 2026-05-18 |
+| [0064-annex](0064-threat-model.md) | gRPC management-plane threat model (ADR-0064 annex) | Current | 2026-07-26 |
 | [0065](0065-evpn-localbias-split-horizon.md) | EVPN VXLAN local-bias split-horizon (spike-gated) | Accepted | 2026-05-22 |
 | [0066](0066-unicast-multipath-ecmp-fib.md) | Unicast multipath / ECMP FIB install | Accepted | 2026-05-24 |
 | [0067](0067-bfd-single-hop.md) | Single-hop asynchronous BFD for BGP | Accepted | 2026-05-24 |


### PR DESCRIPTION
## Summary

- replace the withdrawn pre-v0.24 audit-only annex with a current model of listener-cap and principal-role enforcement
- document credential/authentication ordering, legacy-mode scope, live rotation and restart boundaries, audit limits, and accepted/unauthenticated resource risks
- true up ADR status, the release checklist, ADR index, and Unreleased notes

## Review focus

The model distinguishes the default tier posture from the supported legacy opt-out. It treats the mechanically fenced method inventory as separate evidence from the prose attacker assumptions and risk rankings.

## Verification

- `cargo test --locked -p rustbgpd-api authz` (38 passed)
- `cargo test -p rustbgpd config::tests::diff_config_flags_security_grpc_as_restart_required -- --exact`
- `git diff --check`
- independent source-level falsification review: GO after correcting bearer ordering, restart/rotation semantics, legacy scope, and resource-abuse gaps

Docs-only change: no new runtime test, so destructive red proof is N/A.