### PR TITLE
release: prepare v0.61.0 and library crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -796,8 +796,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   because persistence writes `<config>.tmp` alongside it and renames.
 
 - **Library crates: `rustbgpd-wire` 0.16.0 and `rustbgpd-fsm` 0.3.1.** The
-  wire API surface is additive, but **decode acceptance changed in six
-  places** — embedders should diff exactly this list:
+  wire API surface is additive, but **decode acceptance or type
+  classification changed in six places** — embedders should diff exactly
+  this list for those outcomes:
 
   - **Unsupported OPEN Optional Parameter types now error** with OPEN
     Message Error / Unsupported Optional Parameter (2/4) instead of being
@@ -821,10 +822,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     Communities it previously accepted by a looser match no longer resolve
     as link bandwidth.
 
-  `rustbgpd-fsm` 0.3.1 is purely additive: `PeerConfig` gains
-  `min_hold_time: Option<u16>` and `required_families: Vec<(Afi, Safi)>`,
-  and `PeerConfig` is `#[non_exhaustive]`, so external construction through
-  its builder is unaffected.
+  Decoded-value comparisons must also account for RFC 8092 Large Community
+  duplicate normalization, which keeps the first occurrence.
+
+  `rustbgpd-fsm` 0.3.1 keeps its public API backward-compatible:
+  `PeerConfig` gains `min_hold_time: Option<u16>` and
+  `required_families: Vec<(Afi, Safi)>`, and `PeerConfig` is
+  `#[non_exhaustive]`, so external construction through its builder is
+  unaffected. Negotiation behavior also carries conformance fixes: the last
+  duplicate Graceful Restart capability wins, and invalid OPEN identities
+  are rejected.
 
 - **The gRPC threat-model annex now describes the enforced tier system.**
   The pre-v0.24.0 audit-only draft was withdrawn because its attacker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.61.0] — 2026-07-26
+
 > **Release framing.** This is the policy-safety line. RFC 8212
 > explicit-policy enforcement and per-peer outbound prefix limits both
 > ship complete and opt-in, `rustbgpd --check` learns to say when a
@@ -932,7 +934,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   daemon-authored write and a post-start template seed both read clean,
   a genuine external edit still warns with the same validate-and-SIGHUP
   advice, and a daemon that recorded nothing falls back to the previous
-  process-start comparison.
+  process-start comparison. The marker has whole-second precision: an
+  external edit within the same second as the last daemon read or write
+  can compare equal and evade the warning.
 
 - **Three gRPC errors no longer tell operators to pass a `--config` flag
   that does not exist.** `config history`, config transactions, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,7 +3007,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-fsm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "birdwatcher-adapter"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "axum",
  "clap",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "event-bridge"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "clap",
  "rustbgpd-api",
@@ -2754,7 +2754,7 @@ checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rs-config-render"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "clap",
  "serde",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpctl"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "axum",
  "bytes",
@@ -2891,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-api"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2928,7 +2928,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bfd"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "bytes",
  "proptest",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bmp"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "bytes",
  "rustbgpd-telemetry",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-event-history"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "rusqlite",
  "rustbgpd-telemetry",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "rustbgpd-wire",
  "thiserror 2.0.19",
@@ -2973,7 +2973,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn-linux"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "futures",
  "libc",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn-load"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-mrt"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-policy"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "arc-swap",
  "ariadne",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rib"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "bytes",
  "criterion",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rpki"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "criterion",
  "rustbgpd-wire",
@@ -3089,7 +3089,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-telemetry"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "prometheus",
  "thiserror 2.0.19",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-transport"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "bytes",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bytes",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ categories = ["network-programming"]
 
 [workspace.dependencies]
 # Internal crates
-rustbgpd-wire = { path = "crates/wire", version = "0.15.0" }
+rustbgpd-wire = { path = "crates/wire", version = "0.16.0" }
 rustbgpd-bfd = { path = "crates/bfd", version = "0.60.0" }
 rustbgpd-fsm = { path = "crates/fsm", version = "0.3.0" }
 rustbgpd-transport = { path = "crates/transport", version = "0.60.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.60.0"
+version = "0.61.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
@@ -34,19 +34,19 @@ categories = ["network-programming"]
 [workspace.dependencies]
 # Internal crates
 rustbgpd-wire = { path = "crates/wire", version = "0.16.0" }
-rustbgpd-bfd = { path = "crates/bfd", version = "0.60.0" }
+rustbgpd-bfd = { path = "crates/bfd", version = "0.61.0" }
 rustbgpd-fsm = { path = "crates/fsm", version = "0.3.1" }
-rustbgpd-transport = { path = "crates/transport", version = "0.60.0" }
-rustbgpd-rib = { path = "crates/rib", version = "0.60.0" }
-rustbgpd-policy = { path = "crates/policy", version = "0.60.0" }
-rustbgpd-api = { path = "crates/api", version = "0.60.0" }
-rustbgpd-telemetry = { path = "crates/telemetry", version = "0.60.0" }
-rustbgpd-rpki = { path = "crates/rpki", version = "0.60.0" }
-rustbgpd-bmp = { path = "crates/bmp", version = "0.60.0" }
-rustbgpd-mrt = { path = "crates/mrt", version = "0.60.0" }
-rustbgpd-evpn = { path = "crates/evpn", version = "0.60.0" }
-rustbgpd-evpn-linux = { path = "crates/evpn-linux", version = "0.60.0" }
-rustbgpd-event-history = { path = "crates/event-history", version = "0.60.0" }
+rustbgpd-transport = { path = "crates/transport", version = "0.61.0" }
+rustbgpd-rib = { path = "crates/rib", version = "0.61.0" }
+rustbgpd-policy = { path = "crates/policy", version = "0.61.0" }
+rustbgpd-api = { path = "crates/api", version = "0.61.0" }
+rustbgpd-telemetry = { path = "crates/telemetry", version = "0.61.0" }
+rustbgpd-rpki = { path = "crates/rpki", version = "0.61.0" }
+rustbgpd-bmp = { path = "crates/bmp", version = "0.61.0" }
+rustbgpd-mrt = { path = "crates/mrt", version = "0.61.0" }
+rustbgpd-evpn = { path = "crates/evpn", version = "0.61.0" }
+rustbgpd-evpn-linux = { path = "crates/evpn-linux", version = "0.61.0" }
+rustbgpd-event-history = { path = "crates/event-history", version = "0.61.0" }
 
 # External dependencies — pinned across workspace
 bytes = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ categories = ["network-programming"]
 # Internal crates
 rustbgpd-wire = { path = "crates/wire", version = "0.16.0" }
 rustbgpd-bfd = { path = "crates/bfd", version = "0.60.0" }
-rustbgpd-fsm = { path = "crates/fsm", version = "0.3.0" }
+rustbgpd-fsm = { path = "crates/fsm", version = "0.3.1" }
 rustbgpd-transport = { path = "crates/transport", version = "0.60.0" }
 rustbgpd-rib = { path = "crates/rib", version = "0.60.0" }
 rustbgpd-policy = { path = "crates/policy", version = "0.60.0" }

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ cargo build --release -p rustbgpd -p rustbgpctl -p rs-config-render
 ### Docker
 
 Release images are published to GHCR (versioned tags, e.g.
-`ghcr.io/lance0/rustbgpd:0.60.0`), or build locally:
+`ghcr.io/lance0/rustbgpd:0.61.0`), or build locally:
 
 ```bash
 docker build -t rustbgpd .                    # lean runtime: daemon + rbgp, nonroot
@@ -412,7 +412,7 @@ evolving API.**
 | Dimension | Current state |
 |-----------|---------------|
 | **Target use case** | Data-center fabric pilots, IXP route servers, programmable BGP control planes, lab/test environments |
-| **Maturity** | Public alpha (v0.60.0) |
+| **Maturity** | Public alpha (v0.61.0) |
 | **Narrow stable contract** | The machine-pinned [route-server / route-reflector v1 contract](docs/v1-stable-contract.md) covers only its inventoried control-plane roles and surfaces; the project and all unlisted features remain alpha. |
 | **Implemented** | Dual-stack BGP/MP-BGP, Add-Path, GR/LLGR, RPKI/RTR, ASPA path verification, FlowSpec, BMP, MRT, BFD, EVPN/VXLAN (alpha), and full gRPC/CLI management. Linux FIB integration is default-off and scoped to RFC 7999 discard routes and configured unicast tables (including ECMP and weighted multipath); broader routing-suite features remain future work. |
 | **Supported OS** | Linux (primary target). Requires `CAP_NET_BIND_SERVICE` for port 179. |

--- a/bench/scale/config-persistence/Cargo.lock
+++ b/bench/scale/config-persistence/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bytes",
  "thiserror",

--- a/bench/scale/outbound-prefix-limits/Cargo.lock
+++ b/bench/scale/outbound-prefix-limits/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bytes",
  "thiserror",

--- a/bench/scale/reloadstall/Cargo.lock
+++ b/bench/scale/reloadstall/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bytes",
  "thiserror",

--- a/bench/scale/rrharness/Cargo.lock
+++ b/bench/scale/rrharness/Cargo.lock
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-fsm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes",
  "rustbgpd-wire",

--- a/bench/scale/rrharness/Cargo.lock
+++ b/bench/scale/rrharness/Cargo.lock
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bytes",
  "thiserror 2.0.18",

--- a/bench/scale/rrharness/Cargo.lock
+++ b/bench/scale/rrharness/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bmp"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "bytes",
  "rustbgpd-telemetry",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-policy"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "arc-swap",
  "ariadne",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rib"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "bytes",
  "ipnet",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rpki"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "rustbgpd-wire",
  "smallvec",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-telemetry"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "prometheus",
  "thiserror 2.0.18",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-transport"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "bytes",
  "libc",

--- a/crates/fsm/Cargo.toml
+++ b/crates/fsm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbgpd-fsm"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/fsm/README.md
+++ b/crates/fsm/README.md
@@ -30,14 +30,16 @@ exposes wire types, so the incompatible wire dependency required the paired
 additions become non-breaking. `SessionState` remains exhaustively
 matchable: the six RFC 4271 §8 states are fixed by the protocol.
 
-`rustbgpd-fsm 0.3.1` is purely additive and pairs with `rustbgpd-wire 0.16.0`.
-`PeerConfig` gains `min_hold_time: Option<u16>` and
+`rustbgpd-fsm 0.3.1` keeps its public API backward-compatible and pairs with
+`rustbgpd-wire 0.16.0`. `PeerConfig` gains `min_hold_time: Option<u16>` and
 `required_families: Vec<(Afi, Safi)>`; because `PeerConfig` is
 `#[non_exhaustive]`, external construction goes through `PeerConfig::new` and
-is unaffected by the new fields. The paired wire 0.16.0 API is additive too,
-but its **decode acceptance changed in six places** — see the "0.16.0
-compatibility note" in the `rustbgpd-wire` README, since the FSM surfaces wire
-decode results to its callers.
+is unaffected by the new fields. Negotiation behavior also carries conformance
+fixes: the last duplicate Graceful Restart capability wins, and invalid OPEN
+identities (AS 0, or the local router ID on iBGP) are rejected. The paired wire
+0.16.0 API is additive too, but its **decode acceptance changed in six places**
+— see the "0.16.0 compatibility note" in the `rustbgpd-wire` README, since the
+FSM surfaces wire decode results to its callers.
 
 ## Key types
 

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbgpd-wire"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -71,9 +71,9 @@ analyzers, test harnesses, MRT readers, etc.
 ### 0.16.0 compatibility note
 
 `rustbgpd-wire` 0.16.0 keeps the public API additive, but **decode acceptance
-changed in six places**. Bytes that decoded under 0.15.0 may now be rejected or
-typed differently, so diff exactly this list before upgrading a consumer that
-asserts on decode outcomes:
+or type classification changed in six places**. Bytes that decoded under
+0.15.0 may now be rejected or typed differently, so diff exactly this list
+before upgrading a consumer that asserts on acceptance or typed variants:
 
 - **Unsupported OPEN Optional Parameter types now error** with OPEN Message
   Error / Unsupported Optional Parameter (2/4) instead of being skipped.
@@ -94,6 +94,11 @@ asserts on decode outcomes:
 - **`ExtendedCommunity::as_link_bandwidth()` matches exact types only.**
   Communities it previously accepted by a looser match no longer resolve as
   link bandwidth.
+
+Decoded values have one additional normalization change outside that
+acceptance/type list: duplicate RFC 8092 Large Communities retain only their
+first occurrence. Consumers that compare decoded attribute values should
+account for that stable deduplication too.
 
 ### 0.15.0 compatibility note
 

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -70,10 +70,10 @@ analyzers, test harnesses, MRT readers, etc.
 
 ### 0.16.0 compatibility note
 
-The 0.16.0 API surface is additive, but **decode acceptance changed in six
-places**. Bytes that decoded under 0.15.0 may now be rejected or typed
-differently, so diff exactly this list before upgrading a consumer that asserts
-on decode outcomes:
+`rustbgpd-wire` 0.16.0 keeps the public API additive, but **decode acceptance
+changed in six places**. Bytes that decoded under 0.15.0 may now be rejected or
+typed differently, so diff exactly this list before upgrading a consumer that
+asserts on decode outcomes:
 
 - **Unsupported OPEN Optional Parameter types now error** with OPEN Message
   Error / Unsupported Optional Parameter (2/4) instead of being skipped.

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -117,10 +117,12 @@ in a minor release without a semver-major break. Closed-by-construction sets
 carries the full split under "Enum exhaustiveness".
 
 **The prepared 0.16.0 change** is additive at the API level, but **decode
-acceptance changed in six places** — bytes that decoded under 0.15.0 may now be
-rejected or typed differently. `crates/wire/README.md` carries the itemized
-list under "0.16.0 compatibility note"; diff exactly that list before you
-upgrade a consumer that asserts on decode outcomes.
+acceptance or type classification changed in six places** — bytes that decoded
+under 0.15.0 may now be rejected or typed differently. `crates/wire/README.md`
+carries the itemized list under "0.16.0 compatibility note"; diff exactly that
+list before you upgrade a consumer that asserts on acceptance or typed
+variants. Consumers comparing decoded values must also account for RFC 8092
+Large Community duplicate normalization, which keeps the first occurrence.
 
 ---
 
@@ -302,10 +304,12 @@ and `policy` are later.**
    level with six decode-acceptance changes (§2.3).
 
 2. **`rustbgpd-fsm` (published as `0.3.0`; `0.3.1` prepared).** The prepared
-   `0.3.1` is purely additive: `PeerConfig` gains `min_hold_time` and
-   `required_families`, and `PeerConfig` is `#[non_exhaustive]`, so external
-   construction through `PeerConfig::new` is unaffected. Why the FSM was the
-   second published crate:
+   `0.3.1` keeps the public API backward-compatible: `PeerConfig` gains
+   `min_hold_time` and `required_families`, and `PeerConfig` is
+   `#[non_exhaustive]`, so external construction through `PeerConfig::new` is
+   unaffected. Negotiation behavior also carries conformance fixes: the last
+   duplicate Graceful Restart capability wins, and invalid OPEN identities
+   are rejected. Why the FSM was the second published crate:
    - It depends *only* on `rustbgpd-wire` + `thiserror` + `bytes`. Zero
      daemon-tier coupling.
    - It is the smallest, purest building block a second consumer needs. A test

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -652,9 +652,11 @@ do not force an FSM release for every daemon tag.
    - If no: skip. Do not publish a no-op release.
    - If yes: continue.
 2. Decide semver bump:
-   - **Patch**: bug fixes, docs/test improvements, no public API expansion.
-   - **Minor**: additive events/actions/helpers or new non-breaking
-     negotiation surfaces.
+   - **Patch**: bug fixes, docs/test improvements, or backward-compatible
+     fields on an existing `#[non_exhaustive]` config struct when its
+     constructor preserves the prior defaults.
+   - **Minor**: additive events/actions/helpers, new public types, or other
+     non-breaking negotiation surfaces.
    - **Major**: changed method signatures, removed variants, or enum/struct
      shape changes not protected by `#[non_exhaustive]`.
 3. Update `version` in `crates/fsm/Cargo.toml`

--- a/docs/v1-stable-contract.md
+++ b/docs/v1-stable-contract.md
@@ -160,7 +160,10 @@ The v0.51.0 route-server example is staged byte-for-byte under
 `tests/fixtures/v1-stable/v0.51.0/` and exercised by the current parser. The
 v0.60.0 release records that fixture as the accepted v0.51.0-to-v0.60.0
 milestone-jump upgrade exercise, extending the inventory's accepted release
-chain to the v0.60.0 anchor.
+chain to the v0.60.0 anchor. The v0.60.0 route-server example is likewise
+archived under `tests/fixtures/v1-stable/v0.60.0/`; the v0.61.0 release records
+it as the accepted consecutive v0.60.0-to-v0.61.0 exercise and proves it with
+the current parser.
 
 ## Release gate
 
@@ -171,6 +174,7 @@ python3 scripts/check-v1-stable-surface.py
 cargo test -p rustbgpctl v1_stable_cli_command_inventory_matches_clap_tree
 cargo test -p rustbgpd v1_stable_v0_50_route_server_fixture_parses
 cargo test -p rustbgpd v1_stable_v0_51_route_server_fixture_parses
+cargo test -p rustbgpd v1_stable_v0_60_route_server_fixture_parses
 cargo test -p rustbgpd v1_stable_effective_defaults_match_runtime_resolution
 ```
 

--- a/docs/v1-stable-surface.json
+++ b/docs/v1-stable-surface.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract": "rustbgpd-rs-rr-v1",
-  "baseline_release": "v0.60.0",
+  "baseline_release": "v0.61.0",
   "scope": "Narrow route-server and route-reflector product contract; unlisted surfaces are not stable by implication.",
   "roles": [
     {
@@ -295,6 +295,20 @@
       "semantic_toml_sha256": "064865a2dd6cf266d674a62f2f1dec70bf08b7cc01e81e742878a44440621626",
       "validation_source": "src/config/tests.rs",
       "validation_test": "config::tests::v1_stable_v0_51_route_server_fixture_parses",
+      "result": "accepted_without_config_migration"
+    },
+    {
+      "from_release": "v0.60.0",
+      "to_release": "v0.61.0",
+      "fixture_directory": "tests/fixtures/v1-stable/v0.60.0/route-server",
+      "source_directory": "examples/route-server",
+      "files": [
+        {"path": "config.toml", "sha256": "a4c4835359f8f5d70da66fc36e0e377259bc3bc9650317e05eeb87d305166ebc"},
+        {"path": "hygiene.rpol", "sha256": "9035313c7813273a64856780be66d790f25cafcb8a7f04e44ada16efb083e515"}
+      ],
+      "semantic_toml_sha256": "ee265b2761539f3c88c0c0d449c9a44c8350cda99c742b14227cc0b7130beda9",
+      "validation_source": "src/config/tests.rs",
+      "validation_test": "config::tests::v1_stable_v0_60_route_server_fixture_parses",
       "result": "accepted_without_config_migration"
     }
   ]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -865,6 +865,27 @@ fn v1_stable_v0_51_route_server_fixture_parses() {
         .unwrap_or_else(|err| panic!("v0.51.0 route-server config no longer validates: {err}"));
 }
 
+#[test]
+fn v1_stable_v0_60_route_server_fixture_parses() {
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/v1-stable/v0.60.0/route-server");
+    let config_path = fixture.join("config.toml");
+    let source = fs::read_to_string(&config_path).unwrap_or_else(|err| {
+        panic!(
+            "failed to read immutable v0.60.0 route-server fixture {}: {err}",
+            config_path.display()
+        );
+    });
+    let mut config: Config = toml::from_str(&source)
+        .unwrap_or_else(|err| panic!("v0.60.0 route-server config no longer parses: {err}"));
+    config
+        .load_rpol_files(Some(&fixture))
+        .unwrap_or_else(|err| panic!("v0.60.0 route-server rpol no longer loads: {err}"));
+    config
+        .validate()
+        .unwrap_or_else(|err| panic!("v0.60.0 route-server config no longer validates: {err}"));
+}
+
 const V1_EFFECTIVE_DEFAULTS_TOML: &str = r#"
 [global]
 asn = 65001

--- a/tests/fixtures/v1-stable/v0.60.0/route-server/config.toml
+++ b/tests/fixtures/v1-stable/v0.60.0/route-server/config.toml
@@ -1,0 +1,129 @@
+# IXP route server configuration
+#
+# rustbgpd as an IX route server with two members. Every member gets:
+# - transparent route-server mode (preserve original NEXT_HOP, no AS prepend)
+# - local BGP role "route_server" (RFC 9234: OTC attached on egress,
+#   role capability negotiated when the member also sets its role)
+# - dual-stack (IPv4 + IPv6 unicast)
+# - RPKI origin validation (drop invalid, prefer valid) and import
+#   hygiene (reject AS_SET, ASPA-invalid, and a dated dual-stack
+#   special-purpose prefix snapshot — see hygiene.rpol)
+#
+# Path-hiding mitigation (RFC 7947 §2.3.2), both flavors:
+# - member-alpha negotiates Add-Path send: it sees all candidate paths
+#   and runs its own selection (the preferred mitigation);
+# - member-beta cannot do Add-Path, so it opts into per_client_best:
+#   when its export policy denies the best path, the route server
+#   advertises the best *permitted* candidate instead of hiding the
+#   prefix (the BIRD-`secondary` equivalent).
+#
+# Add more [[neighbors]] blocks for additional IXP members, or manage
+# them dynamically via gRPC at runtime.
+
+[global]
+asn = 65500
+router_id = "198.51.100.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+# For remote management, prefer an mTLS proxy (see examples/envoy-mtls/).
+# Uncomment below only for trusted management networks:
+# [global.telemetry.grpc_tcp]
+# address = "127.0.0.1:50051"
+
+[global.telemetry.grpc_uds]
+path = "/var/lib/rustbgpd/grpc.sock"
+# Audit principal for this local socket (UDS access is gated by file perms);
+# mapped to a role in [security.grpc.roles] below.
+principal = "operator"
+
+[security.grpc]
+# Per-principal gRPC authorization (ADR-0064; default since v0.24.0).
+# Roles: observer (sensitive_read) | automation (mutating) | operator (operator_only)
+enforcement = "tier"
+
+[security.grpc.roles]
+operator = "operator"
+
+# --- RPKI origin validation ---
+
+[rpki]
+[[rpki.cache_servers]]
+address = "127.0.0.1:3323"       # Routinator, rpki-client, etc.
+
+# --- Named policy definitions ---
+
+[policy.definitions.reject-rpki-invalid]
+[[policy.definitions.reject-rpki-invalid.statements]]
+match_rpki_validation = "invalid"
+action = "deny"
+
+[policy.definitions.reject-long-prefixes]
+default_action = "permit"
+[[policy.definitions.reject-long-prefixes.statements]]
+prefix = "0.0.0.0/0"
+ge = 25
+le = 32
+action = "deny"
+[[policy.definitions.reject-long-prefixes.statements]]
+prefix = "::/0"
+ge = 49
+le = 128
+action = "deny"
+
+[policy.definitions.prefer-rpki-valid]
+[[policy.definitions.prefer-rpki-valid.statements]]
+match_rpki_validation = "valid"
+action = "permit"
+set_local_pref = 200
+[[policy.definitions.prefer-rpki-valid.statements]]
+match_rpki_validation = "not_found"
+action = "permit"
+set_local_pref = 100
+
+[policy]
+# ixp-hygiene and reject-special-purpose live in hygiene.rpol; rpol and
+# TOML policies share one namespace and compose in one ordered chain.
+rpol_files = ["hygiene.rpol"]
+import_chain = [
+    "reject-rpki-invalid",
+    "ixp-hygiene",
+    "reject-special-purpose",
+    "reject-long-prefixes",
+    "prefer-rpki-valid",
+]
+
+# --- IXP member peers ---
+
+# Add-Path-capable member: sees all candidate paths (preferred
+# path-hiding mitigation) and stays update-group-shareable.
+[[neighbors]]
+address = "198.51.100.2"
+remote_asn = 64501
+description = "member-alpha"
+hold_time = 90
+families = ["ipv4_unicast", "ipv6_unicast"]
+route_server_client = true
+role = "route_server"
+max_prefixes = 50000
+
+[neighbors.add_path]
+send = true
+send_max = 8
+
+# Member without Add-Path: per_client_best advertises the best
+# export-policy-permitted candidate when the overall best is denied
+# (RFC 7947 §2.3.2 per-client best-path). Requires route_server_client.
+[[neighbors]]
+address = "198.51.100.3"
+remote_asn = 64502
+description = "member-beta"
+hold_time = 90
+families = ["ipv4_unicast", "ipv6_unicast"]
+route_server_client = true
+per_client_best = true
+role = "route_server"
+max_prefixes = 50000

--- a/tests/fixtures/v1-stable/v0.60.0/route-server/hygiene.rpol
+++ b/tests/fixtures/v1-stable/v0.60.0/route-server/hygiene.rpol
@@ -1,0 +1,166 @@
+# IXP import hygiene (rpol policy language, ADR-0096).
+#
+# Referenced from config.toml via `[policy] rpol_files` and the import
+# chain; edits hot-apply via SIGHUP. Run the in-language tests below
+# with `rbgp policy check hygiene.rpol`.
+
+# Dated starter snapshot of the IANA IPv4 and IPv6 Special-Purpose Address
+# Registries (both updated 2025-10-09; reviewed here 2026-07-15). The reject
+# set contains the two default routes plus active rows whose "Globally
+# Reachable" value is False. It is deliberately not a complete bogon feed:
+# terminated rows, unallocated space, multicast, and True/N/A rows outside a
+# rejected parent are omitted. Active True/N/A children of a rejected parent
+# must stay in this first set so the policy accepts them before the broad deny.
+prefix-set special-purpose-parent-exceptions {
+    192.0.0.9/32,
+    192.0.0.10/32,
+    2001::/32 le 128,
+    2001:1::1/128,
+    2001:1::2/128,
+    2001:1::3/128,
+    2001:3::/32 le 128,
+    2001:4:112::/48 le 128,
+    2001:20::/28 le 128,
+    2001:30::/28 le 128,
+}
+
+prefix-set non-global-special-purpose {
+    0.0.0.0/0,
+    0.0.0.0/8 le 32,
+    10.0.0.0/8 le 32,
+    100.64.0.0/10 le 32,
+    127.0.0.0/8 le 32,
+    169.254.0.0/16 le 32,
+    172.16.0.0/12 le 32,
+    192.0.0.0/24 le 32,
+    192.0.2.0/24 le 32,
+    192.88.99.2/32,
+    192.168.0.0/16 le 32,
+    198.18.0.0/15 le 32,
+    198.51.100.0/24 le 32,
+    203.0.113.0/24 le 32,
+    240.0.0.0/4 le 32,
+    ::/0,
+    ::/128,
+    ::1/128,
+    ::ffff:0:0/96 le 128,
+    64:ff9b:1::/48 le 128,
+    100::/64 le 128,
+    100:0:0:1::/64 le 128,
+    2001::/23 le 128,
+    2001:db8::/32 le 128,
+    3fff::/20 le 128,
+    5f00::/16 le 128,
+    fc00::/7 le 128,
+    fe80::/10 le 128,
+}
+
+policy reject-special-purpose {
+    term preserve-active-parent-exception {
+        if route.prefix in special-purpose-parent-exceptions { accept }
+    }
+    term reject-non-global { if route.prefix in non-global-special-purpose { reject } }
+}
+
+policy ixp-hygiene {
+    # Reject routes carrying an AS_SET (deprecated by RFC 9774; common
+    # IXP hygiene, arouteserver rejects them too). AS_PATHs render
+    # AS_SETs in braces — "65001 {65002 65003}" — so a literal `{`
+    # (escaped for the regex) matches any AS_SET segment.
+    term reject-as-set { if route.as-path matches "\\{" { reject } }
+    # Reject ASPA-invalid AS paths (draft-ietf-sidrops-aspa-verification).
+    # Inert (state = unknown) until ASPA objects are loaded from the
+    # RPKI cache; activates automatically once they are.
+    term reject-aspa-invalid { if route.aspa == invalid { reject } }
+    # Tag the RPKI origin-validation outcome as an RFC 8097 extended
+    # community (non-transitive opaque, type 0x43) so route-server
+    # clients can act on it without running their own validator.
+    # OV_INVALID never reaches clients here — the TOML import chain
+    # drops rpki-invalid routes — but tagging is harmless and keeps
+    # the terms uniform if that drop is ever relaxed.
+    term tag-ov-valid { if route.rpki == valid { add ext-community OV_VALID } }
+    term tag-ov-not-found { if route.rpki == not-found { add ext-community OV_NOT_FOUND } }
+    term tag-ov-invalid { if route.rpki == invalid { add ext-community OV_INVALID } }
+}
+
+test as-set-is-rejected {
+    route { prefix 203.0.113.0/24; as-path "64501 {64502 64503}" }
+    expect ixp-hygiene == reject
+}
+
+test aspa-invalid-is-rejected {
+    route { prefix 203.0.113.0/24; as-path "64501"; aspa invalid }
+    expect ixp-hygiene == reject
+}
+
+test clean-route-falls-through {
+    route { prefix 203.0.113.0/24; as-path "64501 64510" }
+    expect ixp-hygiene == accept
+}
+
+test rpki-valid-is-tagged-ov-valid {
+    route { prefix 203.0.113.0/24; as-path "64501"; rpki valid }
+    expect ixp-hygiene == accept with ext-community OV_VALID
+}
+
+test rpki-not-found-is-tagged-ov-not-found {
+    route { prefix 203.0.113.0/24; as-path "64501" }
+    expect ixp-hygiene == accept with ext-community OV_NOT_FOUND
+}
+
+test rpki-invalid-is-tagged-ov-invalid {
+    route { prefix 203.0.113.0/24; as-path "64501"; rpki invalid }
+    expect ixp-hygiene == accept with ext-community OV_INVALID
+}
+
+test ipv4-default-is-rejected {
+    route { prefix 0.0.0.0/0 }
+    expect reject-special-purpose == reject
+}
+
+test ipv6-default-is-rejected {
+    route { prefix ::/0 }
+    expect reject-special-purpose == reject
+}
+
+test shared-address-more-specific-is-rejected {
+    route { prefix 100.65.0.0/24 }
+    expect reject-special-purpose == reject
+}
+
+test unique-local-more-specific-is-rejected {
+    route { prefix fd00:1::/48 }
+    expect reject-special-purpose == reject
+}
+
+test pcp-parent-exception-is-preserved {
+    route { prefix 192.0.0.9/32 }
+    expect reject-special-purpose == accept
+}
+
+test teredo-parent-exception-is-preserved {
+    route { prefix 2001:0:1234::/48 }
+    expect reject-special-purpose == accept
+}
+
+test as112-parent-exception-is-preserved {
+    route { prefix 2001:4:112::/48 }
+    expect reject-special-purpose == accept
+}
+
+test ordinary-global-ipv4-falls-through {
+    route { prefix 8.8.8.0/24 }
+    expect reject-special-purpose == accept
+}
+
+test ordinary-global-ipv6-falls-through {
+    route { prefix 2001:4860::/32 }
+    expect reject-special-purpose == accept
+}
+
+# This policy only classifies the dated special-purpose snapshot. The later
+# reject-long-prefixes chain member remains responsible for prefix-length caps.
+test too-long-parent-exception-falls-through {
+    route { prefix 2001:4:112::1/128 }
+    expect reject-special-purpose == accept
+}


### PR DESCRIPTION
## Summary

- prepare `rustbgpd-wire` 0.16.0 and document its six decode acceptance/type changes plus RFC 8092 value normalization
- prepare `rustbgpd-fsm` 0.3.1 with backward-compatible `#[non_exhaustive]` configuration growth and documented negotiation conformance changes
- bump the workspace and internal dependency pins to 0.61.0, refresh every checked-in lockfile, and roll the curated policy-safety CHANGELOG section
- advance the v1 stable-surface baseline to v0.61 and archive the exact v0.60 route-server fixture with a current-parser compatibility proof

## Release receipts

- full fmt, Clippy (`-D warnings`), workspace tests, rustdoc (`-D warnings`), and release build
- stable-surface and Clippy-reason gates
- `cargo audit` and `cargo deny check`
- all isolated fuzz crates: 17 targets total
- `cargo publish -p rustbgpd-wire --dry-run --locked`
- local amd64 release payload: all 11 required entries nonempty; all binaries report 0.61.0
- source archive inventory: 2,924 entries with required release sources
- default nonroot release image against FRR 10.3.1: session Established, seven routes learned, doctor bundle written, runtime mutation persisted across restart, and clean restart reconverged to seven routes
- independent compatibility review found and resolved the FSM semver-policy wording, immutable README behavior wording, and wire decoded-value normalization omission

## Load-bearing proof

- rolling the declared stable baseline back to v0.60 makes the stable-surface checker fail on the version mismatch
- making the archived v0.60 fixture incompatible makes the new parser test fail while loading the historical configuration; the unchanged fixture is byte-identical to tag v0.60.0

No crate has been published and no release tag has been created. Registry publication remains ordered `wire -> fsm -> daemon tag` after review.
