### PR TITLE
ci: cover every Rust source root in Clippy reason gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,11 +99,12 @@ unknown scenarios, out-of-range operation indices, and overflowing seed ranges
 fail before a manager starts. The corpus uses virtual time and hard caps; it is
 not a replacement for a live or multi-day soak.
 
-The clippy-reason ratchet currently covers the paths listed in
-`DEFAULT_PATHS` in `scripts/check-clippy-reasons.py`. Any
-`#[allow(clippy::...)]` or `#[expect(clippy::...)]` in a ratcheted path must
-include `reason = "..."` explaining why the escape hatch is intentional. When
-another crate is backfilled, add it to `DEFAULT_PATHS`.
+The clippy-reason ratchet discovers every production source tree in the Cargo
+workspace through `cargo metadata`, including the daemon, crates, tools, and
+workspace benchmark packages. Any `#[allow(clippy::...)]` or
+`#[expect(clippy::...)]` there must include `reason = "..."` explaining why
+the escape hatch is intentional. New workspace packages are covered without
+maintaining a second crate list.
 
 ### Pre-commit hooks
 

--- a/bench/evpn-load/src/bin/monitor.rs
+++ b/bench/evpn-load/src/bin/monitor.rs
@@ -9,7 +9,10 @@
 
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
-#![allow(clippy::too_many_lines)]
+#![allow(
+    clippy::too_many_lines,
+    reason = "the monitor binary keeps its command wiring and reporting flow in one entrypoint"
+)]
 
 use std::collections::HashSet;
 use std::net::{Ipv4Addr, SocketAddr};

--- a/bench/evpn-load/src/bin/tester.rs
+++ b/bench/evpn-load/src/bin/tester.rs
@@ -10,7 +10,10 @@
 
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
-#![allow(clippy::too_many_lines)]
+#![allow(
+    clippy::too_many_lines,
+    reason = "the test driver keeps scenario construction and reporting in one entrypoint"
+)]
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::{Duration, Instant};

--- a/crates/evpn-linux/src/diff.rs
+++ b/crates/evpn-linux/src/diff.rs
@@ -113,7 +113,10 @@ impl Plan {
 ///
 /// See module docs for the foreign-entry preservation invariant.
 #[must_use]
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the diff keeps all dataplane object classes in dependency order"
+)]
 pub fn compute_diff(
     desired: &RemoteMacTable,
     snapshot: &KernelSnapshot,
@@ -417,7 +420,10 @@ fn desired_vlan(instances: &EvpnInstanceTable, vni: EvpnInstanceId) -> Option<u1
 
 /// Pass 1 / IPv6-fallback emission — emit `AddRemoteFdb` /
 /// `UpdateRemoteFdb` for a single-dst entry.
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the pass shares the diff accumulator and its destination context"
+)]
 fn emit_single_dst_pass(
     vni: EvpnInstanceId,
     mac: MacAddress,
@@ -532,7 +538,11 @@ fn emit_single_dst_pass(
 /// aliasing, or ADR-0083 single-active with a backup — the entry's
 /// `single_active_backup_vtep_ip` rides every Install/Update so the
 /// coordinator can pre-create + pin the backup NH).
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    reason = "the FDB/NHG pass keeps its ordered object reconciliation together"
+)]
 fn emit_fdb_nhg_pass(
     vni: EvpnInstanceId,
     mac: MacAddress,
@@ -734,7 +744,10 @@ fn emit_fdb_nhg_pass(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "VLAN conversion needs the shared FDB/NHG reconciliation context"
+)]
 fn emit_fdb_nhg_vlan_conversion(
     vni: EvpnInstanceId,
     mac: MacAddress,
@@ -803,7 +816,10 @@ fn emit_fdb_nhg_vlan_conversion(
 ///    the domain layer.
 /// 6. Foreign static / permanent / `self` entry — operator territory;
 ///    skip without logging at warn level.
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "kernel-entry handling needs the entry, desired state, and diff context"
+)]
 fn handle_existing_kernel_entry(
     vni: EvpnInstanceId,
     mac: MacAddress,

--- a/crates/evpn-linux/src/in_memory.rs
+++ b/crates/evpn-linux/src/in_memory.rs
@@ -364,7 +364,10 @@ impl InMemoryDataplane {
     /// Synchronous half of `apply` — does the fail-injection lookup
     /// and the kernel-state mutation under the same lock so the test
     /// can't observe a partially-applied op.
-    #[allow(clippy::too_many_lines)] // one arm per op shape; splitting obscures the dispatch
+    #[allow(
+        clippy::too_many_lines,
+        reason = "one arm per operation shape keeps the in-memory dispatch mirror readable"
+    )]
     fn apply_inner(&self, op: &DataplaneOp) -> Result<(), DataplaneError> {
         let mut state = self.state.lock().expect("poisoned");
         state.apply_count += 1;
@@ -1247,7 +1250,10 @@ pub struct InMemoryHandle {
 // Every method panics only on Mutex lock-poisoning, which is
 // unrecoverable in this test fake. Documenting `# Panics` on each
 // would be noise; suppress at the impl level.
-#[allow(clippy::missing_panics_doc)]
+#[allow(
+    clippy::missing_panics_doc,
+    reason = "the test-only in-memory handle mirrors the trait's panicking index contract"
+)]
 impl InMemoryHandle {
     /// Pre-load a foreign FDB entry the actor must preserve.
     pub fn pre_load_fdb(&self, vni: EvpnInstanceId, entry: KernelFdbEntry) {

--- a/crates/evpn-linux/src/l3_diff.rs
+++ b/crates/evpn-linux/src/l3_diff.rs
@@ -442,7 +442,10 @@ impl Candidate {
 /// `desired_*` to have been seen during the `want` build. Both
 /// `.expect(...)` sites prove a programmer error, not a runtime
 /// condition.
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the L3 diff keeps all dependent kernel object comparisons in order"
+)]
 #[must_use]
 pub fn compute_l3_diff(
     intent: &RemoteIpPrefixTable,
@@ -1069,7 +1072,10 @@ fn family_matches(prefix: EvpnIpPrefixValue, addr: IpAddr) -> bool {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "the test helper constructs a fixed valid six-octet MAC address"
+)]
 mod tests {
     use super::*;
     use rustbgpd_evpn::ip_vrf::{

--- a/crates/evpn-linux/src/linux/fdb.rs
+++ b/crates/evpn-linux/src/linux/fdb.rs
@@ -675,7 +675,10 @@ mod tests {
     /// "permanent + noarp share the NUD bitmask" relationship so
     /// each test reads as one assertion rather than four bool
     /// fields.
-    #[allow(clippy::struct_excessive_bools)]
+    #[allow(
+        clippy::struct_excessive_bools,
+        reason = "netlink FDB flags are independent kernel bits, not a state enum"
+    )]
     #[derive(Debug, Clone, Copy, Default)]
     struct FlagSet {
         extern_learn: bool,

--- a/crates/evpn-linux/src/linux/routes.rs
+++ b/crates/evpn-linux/src/linux/routes.rs
@@ -124,7 +124,10 @@ pub fn classify(route: ClassifiedRoute) -> Classification {
     // return `Drop(InstalledByRoutingDaemon)` — listing the known
     // protocols documents *why* they're dropped and is easier to
     // extend than spelling the negative case out in the wildcard.
-    #[allow(clippy::match_same_arms)]
+    #[allow(
+        clippy::match_same_arms,
+        reason = "separate route kinds deliberately share the same netlink conversion"
+    )]
     match route.protocol {
         RouteProtocol::Kernel => Classification::Keep(RouteSource::Connected),
         RouteProtocol::Static => Classification::Keep(RouteSource::Static),

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -729,7 +729,10 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     }
 
     /// One reconcile pass: probe → dump → diff → apply → emit report.
-    #[allow(clippy::too_many_lines)]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "one reconciliation pass preserves the plan's ordered safety checks"
+    )]
     async fn reconcile_once(&mut self) {
         self.state.reconcile_generation = self.state.reconcile_generation.saturating_add(1);
 
@@ -1838,7 +1841,10 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     ///    is in the retry schedule and not yet due are skipped; the
     ///    actor's outer `tokio::select!` re-fires on the retry timer
     ///    so a deferred op runs as soon as its backoff elapses.
-    #[allow(clippy::too_many_lines)] // per-op-shape dispatch is naturally long; further extraction hurts readability
+    #[allow(
+        clippy::too_many_lines,
+        reason = "per-operation dispatch preserves the plan's ordering and error boundaries"
+    )]
     async fn apply_plan(
         &mut self,
         plan: &Plan,
@@ -2579,7 +2585,10 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     /// the drift gate entirely — mirrors the startup-adoption
     /// permanent-failure semantics. Transient / conflict failures
     /// leave drift enabled; the next reconcile pass retries.
-    #[allow(clippy::too_many_lines)]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "drift reconciliation keeps detection, repair, and retry ordering together"
+    )]
     async fn reconcile_drift(
         &mut self,
         snapshot: &KernelSnapshot,
@@ -3298,7 +3307,10 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     /// rows that resolve its inner DMAC / tunnel endpoint go away —
     /// the inverse of the install pipeline's resolution-before-route
     /// ordering.
-    #[allow(clippy::too_many_lines)] // three parallel reap surfaces; splitting obscures the shared gate/order
+    #[allow(
+        clippy::too_many_lines,
+        reason = "three reap surfaces share one gate and ordering contract"
+    )]
     async fn reap_adopted_l3(
         &mut self,
         desired: &rustbgpd_evpn::ip_vrf::RemoteIpPrefixTable,
@@ -4017,7 +4029,10 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     /// entries. BUM restoration is best-effort because leaving a CE
     /// port suppressed after the daemon exits is more operator-hostile
     /// than a redundant allow-all write.
-    #[allow(clippy::too_many_lines)]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "drain coordinates ordered withdrawal across all managed object classes"
+    )]
     async fn drain(&mut self) {
         let bum_restore_ops: Vec<_> = if self.config.apply_bum_enforcement {
             self.state
@@ -6599,7 +6614,10 @@ where
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "L3 FDB/NHG removal needs the complete reconciliation operation context"
+)]
 async fn apply_remove_l3_fdb_nhg<D>(
     dataplane: &mut D,
     state: &mut ActorState,
@@ -6689,7 +6707,11 @@ async fn rollback_l3_partial_install<D>(
 /// delete → FDB row. ADR-0059 §5 invariants 1 + 3. Reads
 /// top-to-bottom; further breaking this up would obscure the rollback
 /// ordering.
-#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_lines,
+    clippy::too_many_arguments,
+    reason = "FDB/NHG installation keeps its ordered kernel operations and shared context together"
+)]
 async fn apply_install_fdb_nhg<D>(
     dataplane: &mut D,
     state: &mut ActorState,

--- a/crates/evpn-linux/src/snapshot.rs
+++ b/crates/evpn-linux/src/snapshot.rs
@@ -81,7 +81,10 @@ pub struct KernelLinkInfo {
 
 /// Parsed Linux bridge VLAN flags kept as raw booleans so the snapshot
 /// layer remains independent of the netlink crate's bitflags type.
-#[allow(clippy::struct_excessive_bools)]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "bridge VLAN flags mirror independent kernel flag bits"
+)]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct KernelBridgeVlanFlags {
     /// `BRIDGE_VLAN_INFO_MASTER` / crate `Controller`: operation or row
@@ -389,7 +392,10 @@ impl KernelFdbEntry {
 /// Phase 2 wires only what the diff loop reads. Each field maps 1:1 to
 /// a kernel flag bit, so refactoring into a state enum would lose the
 /// direct correspondence we need at the netlink boundary.
-#[allow(clippy::struct_excessive_bools)]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "FDB flags mirror independent kernel flag bits"
+)]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct KernelFdbFlags {
     /// `NTF_EXT_LEARNED` — set by rustbgpd on entries it programs.

--- a/scripts/check-clippy-reasons.py
+++ b/scripts/check-clippy-reasons.py
@@ -4,40 +4,60 @@
 from __future__ import annotations
 
 import argparse
+import json
 import pathlib
 import re
+import subprocess
 import sys
 
 
-DEFAULT_PATHS = (
-    "crates/cli/src",
-    "crates/event-history/src",
-    "crates/api/src",
-    "crates/rib/src",
-    "crates/fsm/src",
-    "crates/policy/src",
-    "crates/rpki/src",
-    "crates/evpn/src",
-    "crates/transport/src",
-    "crates/wire/src",
-    "crates/bmp/src",
-    "crates/bfd/src",
-    "crates/mrt/src",
-    "crates/telemetry/src",
-)
 ATTRIBUTE_HEAD = re.compile(r"#!?\[\s*(?:allow|expect)\s*\(")
 REASON = re.compile(r"\breason\s*=")
 
 
+def workspace_source_roots(repo: pathlib.Path) -> list[pathlib.Path]:
+    """Return all workspace package source directories from Cargo metadata.
+
+    Target source paths, rather than a maintained crate list, include the daemon,
+    every workspace crate, tools, and workspace benchmark packages as they are
+    added. Test and bench targets are deliberately excluded: this ratchet covers
+    production source trees, while their owning package's ``src`` tree remains in
+    scope.
+    """
+    result = subprocess.run(
+        ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or "cargo exited without an error message"
+        raise RuntimeError(f"cargo metadata failed:\n{detail}")
+    metadata = json.loads(result.stdout)
+    workspace_members = set(metadata["workspace_members"])
+    roots: set[pathlib.Path] = set()
+    for package in metadata["packages"]:
+        if package["id"] not in workspace_members:
+            continue
+        package_dir = pathlib.Path(package["manifest_path"]).parent
+        source_dir = package_dir / "src"
+        for target in package["targets"]:
+            if set(target["kind"]).isdisjoint({"test", "bench", "example"}):
+                source_path = pathlib.Path(target["src_path"])
+                roots.add(source_dir if source_path.is_relative_to(source_dir) else source_path)
+    return sorted(roots)
+
+
 def rust_files(paths: list[pathlib.Path]) -> list[pathlib.Path]:
-    files: list[pathlib.Path] = []
+    files: set[pathlib.Path] = set()
     for path in paths:
         if path.is_file():
             if path.suffix == ".rs":
-                files.append(path)
+                files.add(path)
             continue
         if path.is_dir():
-            files.extend(sorted(path.rglob("*.rs")))
+            files.update(path.rglob("*.rs"))
     return sorted(files)
 
 
@@ -101,16 +121,19 @@ def main() -> int:
         "paths",
         nargs="*",
         type=pathlib.Path,
-        default=[pathlib.Path(path) for path in DEFAULT_PATHS],
-        help=(
-            "Rust files or directories to check "
-            f"(default: {', '.join(DEFAULT_PATHS)})"
-        ),
+        default=None,
+        help="Rust files or directories to check (default: Cargo workspace production roots)",
     )
     args = parser.parse_args()
 
+    try:
+        paths = args.paths or workspace_source_roots(pathlib.Path.cwd())
+    except RuntimeError as error:
+        print(error, file=sys.stderr)
+        return 2
+
     failures: list[str] = []
-    for file in rust_files(args.paths):
+    for file in rust_files(paths):
         for line, attr in missing_reasons(file):
             failures.append(f"{file}:{line}: missing reason on {attr}")
 

--- a/scripts/test_check_clippy_reasons.py
+++ b/scripts/test_check_clippy_reasons.py
@@ -38,18 +38,58 @@ class ClippyReasonTests(unittest.TestCase):
         self.assertIn("#![allow(clippy::module_name_repetitions)]", result.stdout)
         self.assertNotIn("unterminated", result.stdout)
 
-    def test_cli_and_event_history_are_ratcheted_by_default(self) -> None:
-        self.assertIn("crates/cli/src", checker.DEFAULT_PATHS)
-        self.assertIn("crates/event-history/src", checker.DEFAULT_PATHS)
-
-    def test_bfd_mrt_and_telemetry_are_ratcheted_and_clean(self) -> None:
+    def test_workspace_source_roots_include_daemon_and_all_workspace_packages(self) -> None:
+        roots = checker.workspace_source_roots(REPO)
         for path in (
-            "crates/bfd/src",
-            "crates/mrt/src",
-            "crates/telemetry/src",
+            REPO / "src",
+            REPO / "crates/evpn-linux/src",
+            REPO / "bench/evpn-load/src",
+            REPO / "tools/rs-config-render/src",
         ):
             with self.subTest(path=path):
-                self.assertIn(path, checker.DEFAULT_PATHS)
+                self.assertIn(path, roots)
+
+    def test_default_discovery_rejects_a_new_workspace_source_root_without_reason(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            (repo / "src").mkdir()
+            (repo / "Cargo.toml").write_text(
+                "[package]\nname = \"reason-ratchet-fixture\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+                encoding="utf-8",
+            )
+            (repo / "src/lib.rs").write_text(
+                "#[allow(clippy::too_many_lines)]\npub fn fixture() {}\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT)],
+                cwd=repo,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("src/lib.rs:1: missing reason", result.stdout)
+
+    def test_metadata_failure_reports_cargo_diagnostic_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            (repo / "Cargo.toml").write_text("[package\n", encoding="utf-8")
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT)],
+                cwd=repo,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("cargo metadata failed:", result.stderr)
+        self.assertIn("Cargo.toml:1:9", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_existing_ratcheted_source_is_clean(self) -> None:
         self.assertEqual(
             checker.missing_reasons(REPO / "crates/telemetry/src/metrics.rs"),
             [],

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1972,7 +1972,10 @@ impl Config {
     ///
     /// Per-neighbor policy overrides global; if neighbor has no policy entries,
     /// the corresponding value is `None` (caller falls back to global).
-    #[expect(clippy::type_complexity)]
+    #[expect(
+        clippy::type_complexity,
+        reason = "the return preserves peer configuration and validation diagnostics together"
+    )]
     #[cfg(test)]
     pub fn to_peer_configs(
         &self,
@@ -2785,7 +2788,10 @@ impl PolicyDiff {
 }
 
 /// Full config diff result.
-#[expect(clippy::struct_excessive_bools)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "each config change dimension is independently applicable"
+)]
 #[derive(Debug, serde::Serialize)]
 pub struct ConfigDiff {
     pub neighbors: NeighborDiffSummary,

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -495,7 +495,10 @@ fn default_rpki_expire() -> u64 {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
-#[allow(clippy::struct_excessive_bools)]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "global configuration switches are independently meaningful operator settings"
+)]
 #[serde(deny_unknown_fields)]
 pub struct Global {
     /// Local autonomous system number.

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -265,7 +265,10 @@ fn shared_test_only_operator_auth_is_tier_valid_and_wired() {
 }
 
 #[test]
-#[allow(clippy::too_many_lines)] // one frozen inventory keeps config/topology/driver wiring atomic
+#[allow(
+    clippy::too_many_lines,
+    reason = "one frozen inventory keeps config, topology, and driver wiring atomic"
+)]
 fn early_interop_auth_inventory_is_tier_wired() {
     // Load-bearing: reverting a config to legacy, dropping a token bind,
     // downgrading the operator role, bypassing the helper, removing a driver

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -99,7 +99,10 @@ impl ConfigAdvisory {
 }
 
 impl Config {
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "validation keeps related operator diagnostics in one ordered pass"
+    )]
     pub(crate) fn validate(&self) -> Result<(), ConfigError> {
         if self.global.asn == 0 {
             return Err(ConfigError::InvalidLocalAsn {

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -5076,7 +5076,10 @@ remote_asn = 65010
     /// pending (mutation fence closed, second mutations rejected) and a retry
     /// of the abort must be able to resolve it.
     #[tokio::test]
-    #[allow(clippy::too_many_lines)] // full failed-abort → fence → retry → resolution lifecycle
+    #[allow(
+        clippy::too_many_lines,
+        reason = "the test proves the complete failed-abort, fence, retry, and resolution lifecycle"
+    )]
     async fn confirmed_abort_failure_keeps_pending_fence_and_allows_retry() {
         let previous_toml = base_toml("");
         let candidate_toml = base_toml(

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -391,7 +391,10 @@ pub async fn spawn(
 ///
 /// Quarantined `(VNI, MAC)` keys are excluded from remote-FDB intent while
 /// preserving RIB and route-reflector visibility.
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the spawn API keeps each explicit actor dependency visible"
+)]
 pub async fn spawn_with_quarantine(
     config: SupervisorConfig,
     evpn_instances: &Arc<EvpnInstanceTable>,
@@ -504,7 +507,10 @@ where
 
 /// Test/production helper that injects a dataplane implementation and an
 /// external duplicate-MAC quarantine feed.
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the generic dataplane spawn API keeps each explicit actor dependency visible"
+)]
 pub fn spawn_with_dataplane_and_quarantine<D>(
     config: SupervisorConfig,
     evpn_instances: &Arc<EvpnInstanceTable>,
@@ -762,7 +768,10 @@ impl SupervisorIntentState {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "intent publication needs the actor handles and shared generation state"
+)]
 async fn publish_dataplane_intent(
     rib_tx: &mpsc::Sender<RibUpdate>,
     intent_tx: &watch::Sender<Arc<DataplaneIntent>>,
@@ -899,7 +908,11 @@ fn publish_cached_dataplane_intent(
 /// tables. A future coordinator commit can publish a complete effective
 /// L2VNI/IP-VRF snapshot, and the supervisor will re-project
 /// immediately without waiting for the next poll interval.
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)] // Supervisor wiring intentionally keeps actor dependencies explicit.
+#[allow(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    reason = "the supervisor keeps actor dependencies and its ordered lifecycle handling explicit"
+)]
 async fn supervisor_loop(
     poll_interval: Duration,
     mut instances_rx: watch::Receiver<Arc<EvpnInstanceTable>>,

--- a/src/evpn_es_drain.rs
+++ b/src/evpn_es_drain.rs
@@ -298,7 +298,10 @@ pub(crate) enum EsDrainError {
 /// mutation that only recomposed the reason set (e.g. a link failure
 /// on an already operator-drained ES) commits coordinator-side with
 /// no actor traffic — the routes are already withdrawn.
-#[allow(clippy::too_many_arguments)] // the drain dependency spine, mirrored from the ADR-0084 hook
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the drain hook keeps the ADR-0084 dependency spine explicit"
+)]
 pub(crate) async fn apply_ethernet_segment_drain(
     esi: EthernetSegmentIdentifier,
     reason: EsDrainReason,

--- a/src/evpn_originator/duplicate_mac.rs
+++ b/src/evpn_originator/duplicate_mac.rs
@@ -7,7 +7,10 @@ use super::{
 };
 use crate::evpn_originator::rib_write::apply_actions;
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "duplicate-MAC state construction keeps all explicit ownership inputs visible"
+)]
 pub(super) async fn handle_originator_command(
     command: OriginatorCommand,
     state: &mut OriginatorState,
@@ -189,7 +192,10 @@ pub(super) fn record_duplicate_mac_move(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "duplicate-MAC observation handling needs the key, timers, and actor state"
+)]
 pub(super) async fn apply_actions_with_duplicate_policy(
     actions: Vec<OriginationAction>,
     view_present: bool,
@@ -233,7 +239,10 @@ pub(super) async fn apply_actions_with_duplicate_policy(
     .await;
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "duplicate-MAC transition handling needs the key, timers, and actor state"
+)]
 pub(super) async fn suppress_local_originations_for_mac(
     vni: EvpnInstanceId,
     mac: MacAddress,
@@ -273,7 +282,10 @@ pub(super) async fn suppress_local_originations_for_mac(
     .await;
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "duplicate-MAC recovery handling needs the key, timers, and actor state"
+)]
 pub(super) async fn recover_duplicate_macs(
     state: &mut OriginatorState,
     instances: &EvpnInstanceTable,
@@ -316,7 +328,10 @@ pub(super) async fn recover_duplicate_macs(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "duplicate-MAC expiry handling needs the key, timers, and actor state"
+)]
 pub(super) async fn clear_duplicate_mac_quarantine(
     key: DuplicateMacKey,
     state: &mut OriginatorState,
@@ -369,7 +384,10 @@ pub(super) async fn clear_duplicate_mac_quarantine(
     ClearDuplicateMacQuarantineResult::Cleared
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "duplicate-MAC publication needs the observed state and all actor outputs"
+)]
 pub(super) async fn replay_local_mac_after_recovery(
     vni: EvpnInstanceId,
     mac: MacAddress,

--- a/src/evpn_originator/lifecycle.rs
+++ b/src/evpn_originator/lifecycle.rs
@@ -10,7 +10,10 @@ use crate::evpn_originator::duplicate_mac::{
 use crate::evpn_originator::rib_polling::repoll_rib;
 use crate::evpn_originator::rib_write::drain_vni_to_withdraws;
 
-#[allow(clippy::too_many_lines)] // classification + drain + replay are one ordered sequence; splitting hurts the lifecycle story
+#[allow(
+    clippy::too_many_lines,
+    reason = "classification, drain, and replay are one ordered lifecycle sequence"
+)]
 pub(super) async fn apply_runtime_model(
     model: Arc<OriginatorRuntimeModel>,
     state: &mut OriginatorState,

--- a/src/evpn_originator/mod.rs
+++ b/src/evpn_originator/mod.rs
@@ -396,7 +396,10 @@ pub(crate) fn vni_is_drained(
 
 /// Spawn the originator. Returns `None` for RR-only deployments
 /// (empty `evpn_instances`).
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "originator spawn keeps each explicit actor dependency visible"
+)]
 // ESI-aware origination nudged the count over the threshold; the daemon-side spawn is the only caller.
 #[allow(dead_code)]
 #[must_use = "call `EvpnOriginatorHandle::shutdown` to stop the originator — \
@@ -425,7 +428,10 @@ pub fn spawn(
     )
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "quarantine-aware spawn keeps each explicit actor dependency visible"
+)]
 #[must_use = "call `EvpnOriginatorHandle::shutdown` to stop the originator — \
               dropping the handle leaves the task running"]
 /// Spawn the originator with an external duplicate-MAC quarantine publisher.
@@ -610,7 +616,10 @@ impl OriginatorState {
     }
 }
 
-#[allow(clippy::too_many_lines)] // The actor select keeps shutdown, local observations, RIB events, and poll recovery together.
+#[allow(
+    clippy::too_many_lines,
+    reason = "the actor select keeps shutdown, observations, RIB events, and recovery ordered"
+)]
 async fn originator_loop(
     config: OriginatorConfig,
     mut runtime: OriginatorRuntime,

--- a/src/evpn_originator/observation.rs
+++ b/src/evpn_originator/observation.rs
@@ -70,7 +70,10 @@ fn park_pending_ip_binding(
 ///
 /// See `docs/RFC_NOTES.md` for the RFC 9135 §7.2.3 framing and the
 /// FRR mailing-list bugs that motivated this model.
-#[allow(clippy::too_many_arguments)] // ADR-0084 drain gate nudged the count over the threshold; refactoring to a context struct is a separate slice.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the ADR-0084 drain gate shares explicit observation and actor context"
+)]
 pub(super) async fn handle_observation(
     obs: &LocalMacObservation,
     state: &mut OriginatorState,
@@ -295,7 +298,11 @@ fn drop_local_mac_caches(state: &mut OriginatorState, vni: EvpnInstanceId, mac: 
     }
 }
 
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    reason = "observation classification keeps its ordered checks and actor context together"
+)]
 pub(super) async fn handle_learned(
     vni: EvpnInstanceId,
     mac: MacAddress,
@@ -468,7 +475,10 @@ pub(super) async fn handle_learned(
     }
 }
 
-#[allow(clippy::too_many_arguments)] // ESI-aware origination nudged the count over the threshold; refactoring to a context struct is a separate slice.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "ESI-aware origination needs explicit observation and actor context"
+)]
 pub(super) async fn handle_aged(
     vni: EvpnInstanceId,
     mac: MacAddress,
@@ -515,7 +525,10 @@ pub(super) async fn handle_aged(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "observation withdrawal needs the complete route and actor context"
+)]
 pub(super) async fn handle_ip_added(
     vni: EvpnInstanceId,
     mac: MacAddress,
@@ -621,7 +634,10 @@ pub(super) async fn handle_ip_added(
         .insert(ip);
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "observation publication needs the complete route and actor context"
+)]
 pub(super) async fn handle_ip_removed(
     vni: EvpnInstanceId,
     mac: MacAddress,

--- a/src/evpn_originator/rib_polling.rs
+++ b/src/evpn_originator/rib_polling.rs
@@ -79,7 +79,10 @@ pub(super) fn drain_ready_evpn_events(
 /// MAC+IP), diff against the cached state, and fire
 /// `on_remote_changed` / `on_remote_ip_changed` for any tracked
 /// `(MAC)` or `(MAC, IP)` whose view changed.
-#[allow(clippy::too_many_lines)] // MAC-only and MAC+IP diffs intentionally stay adjacent for symmetry.
+#[allow(
+    clippy::too_many_lines,
+    reason = "MAC-only and MAC-plus-IP diffs remain adjacent to preserve symmetry"
+)]
 pub(super) async fn repoll_rib(
     instances: &EvpnInstanceTable,
     rib_tx: &mpsc::Sender<RibUpdate>,
@@ -273,7 +276,10 @@ pub(super) async fn handle_evpn_event(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "RIB poll reconciliation needs the snapshot, generation, and actor outputs"
+)]
 pub(super) async fn handle_evpn_event_coalesced(
     event: EvpnRouteEvent,
     rx: &mut Option<broadcast::Receiver<EvpnRouteEvent>>,

--- a/src/evpn_originator/rib_write.rs
+++ b/src/evpn_originator/rib_write.rs
@@ -39,7 +39,10 @@ pub(super) async fn drain_to_withdraws(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "RIB write construction keeps all route ownership inputs explicit"
+)]
 pub(super) async fn drain_vni_to_withdraws(
     state: &mut OriginatorState,
     instances: &EvpnInstanceTable,
@@ -90,7 +93,10 @@ pub(super) async fn drain_vni_to_withdraws(
 /// the same route identity) before its first attempt, and only the
 /// RIB's acknowledgement clears it. Failed attempts stay pending; the
 /// actor's retry arm re-drives them with bounded backoff.
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "RIB write dispatch needs the route, action, and actor outputs"
+)]
 pub(super) async fn apply_actions(
     pending: &mut PendingRibOps,
     actions: Vec<OriginationAction>,
@@ -158,7 +164,10 @@ fn action_key(action: &OriginationAction) -> EvpnRouteKey {
 /// Confirms (and does the success bookkeeping) on ack, defers on any
 /// failure. Shared by the first attempt ([`apply_actions`]) and the
 /// retry path ([`retry_pending_rib_ops`]).
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the action attempt needs its route, retry, and actor context"
+)]
 async fn attempt_action(
     pending: &mut PendingRibOps,
     generation: u64,

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -391,7 +391,10 @@ pub(crate) struct EvpnRuntimeActorConverger {
 }
 
 impl EvpnRuntimeActorConverger {
-    #[allow(clippy::too_many_arguments)] // one optional control per EVPN actor plus the shared drain state
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "one optional control per EVPN actor plus shared drain state is explicit wiring"
+    )]
     pub(crate) fn new(
         rib_tx: mpsc::Sender<RibUpdate>,
         imet_controller: Arc<tokio::sync::Mutex<evpn_imet::EvpnImetController>>,

--- a/src/evpn_segment.rs
+++ b/src/evpn_segment.rs
@@ -73,7 +73,10 @@ use crate::evpn_originator::{LOCAL_PEER, route_target_to_extcomm};
 /// commits publish complete ES snapshots through this control; the
 /// segment actor remains the only Type 1/4 originator.
 #[derive(Clone, Debug)]
-#[allow(clippy::struct_field_names)] // the `_tx` postfix is load-bearing: each field is the sender half of an actor watch
+#[allow(
+    clippy::struct_field_names,
+    reason = "the _tx postfix identifies each field as an actor-watch sender"
+)]
 pub(crate) struct EvpnSegmentRuntimeControl {
     instances_tx: watch::Sender<Arc<EvpnInstanceTable>>,
     segments_tx: watch::Sender<Arc<Vec<EthernetSegment>>>,
@@ -226,7 +229,10 @@ pub fn spawn(
 /// — no dataplane / no binding feed — in which case no bias snapshot
 /// is published / no segment counts as bound.
 #[must_use = "drop the handle to shut down the EVPN segment orchestrator"]
-#[allow(clippy::too_many_arguments)] // actor dependency spine, mirrored from the dataplane supervisor spawn
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the segment actor keeps the dataplane supervisor's dependency spine explicit"
+)]
 pub(crate) fn spawn_with_local_bias(
     instances: &Arc<EvpnInstanceTable>,
     segments: Vec<EthernetSegment>,
@@ -319,7 +325,10 @@ struct SegmentState {
     esi_label: MplsLabel,
 }
 
-#[allow(clippy::too_many_lines)] // setup + main select loop combined; further extraction hurts the lifecycle story
+#[allow(
+    clippy::too_many_lines,
+    reason = "setup and the select loop form one ordered segment lifecycle"
+)]
 async fn segment_loop(
     mut runtime: SegmentRuntime,
     mut instances_rx: watch::Receiver<Arc<EvpnInstanceTable>>,

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -3464,7 +3464,10 @@ mod tests {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "a typed drift event carries all explicit observation and recovery context"
+    )]
     fn drift_event_typed(
         kind: KernelRouteEventKind,
         table_id: u32,
@@ -4702,7 +4705,10 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[tokio::test]
-    #[allow(clippy::too_many_lines)]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "the netns scenario keeps setup, convergence, and cleanup in one receipt"
+    )]
     async fn netns_general_unicast_fib_runtime_round_trip() {
         if !netns_gate() {
             eprintln!("skipping: set EVPN_LINUX_NETNS=1 to run privileged general FIB netns test");
@@ -5033,7 +5039,10 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[tokio::test]
-    #[allow(clippy::too_many_lines)]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "the ECMP netns scenario keeps setup, convergence, and cleanup in one receipt"
+    )]
     async fn netns_general_unicast_fib_ecmp_round_trip() {
         if !netns_gate() {
             eprintln!("skipping: set EVPN_LINUX_NETNS=1 to run privileged ECMP FIB netns test");
@@ -5156,7 +5165,10 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[tokio::test]
-    #[allow(clippy::too_many_lines)]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "the weighted-ECMP netns scenario keeps setup, convergence, and cleanup in one receipt"
+    )]
     async fn netns_general_unicast_fib_weighted_round_trip() {
         if !netns_gate() {
             eprintln!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -2261,7 +2261,10 @@ Default configuration file.
     )
 }
 
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "the daemon entrypoint keeps startup validation and shutdown ownership together"
+)]
 fn main() {
     let args: Vec<String> = std::env::args().collect();
 
@@ -2762,7 +2765,10 @@ fn resolve_rib_channel_capacity_from(env: Option<&str>) -> usize {
     RIB_CHANNEL_CAPACITY
 }
 
-#[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "runtime startup keeps listener, API, and shutdown wiring in one owner"
+)]
 /// Returns `true` when shutdown was caused by the gRPC server exiting
 /// unexpectedly (a component failure — the process must exit non-zero),
 /// `false` for operator-initiated shutdowns (signals, Shutdown RPC).
@@ -6581,7 +6587,10 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
     }
 
     #[test]
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the regression inventory keeps all restart-time combinations in one oracle"
+    )]
     fn max_gr_restart_time_uses_largest_enabled_peer() {
         let config = crate::config::Config {
             global: crate::config::Global {

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -285,7 +285,10 @@ impl PeerManager {
         self.peers.contains_key(&key).then_some(key)
     }
 
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the inbound candidate regression keeps all collision and fencing assertions together"
+    )]
     pub(super) async fn handle_inbound(
         &mut self,
         stream: TcpStream,

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -113,7 +113,10 @@ pub(crate) enum InternalCommand {
     },
 }
 
-#[allow(clippy::struct_excessive_bools)]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "peer lifecycle capabilities are independent negotiated and runtime states"
+)]
 struct ManagedPeer {
     handle: PeerHandle,
     session_id: u64,
@@ -373,7 +376,10 @@ pub struct PeerManager {
 
 impl PeerManager {
     #[cfg(test)]
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "peer construction keeps all explicit lifecycle dependencies visible"
+    )]
     pub fn new(
         rx: mpsc::Receiver<PeerManagerCommand>,
         local_asn: u32,
@@ -534,7 +540,10 @@ impl PeerManager {
         }
     }
 
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "configured peer construction keeps all explicit lifecycle dependencies visible"
+    )]
     pub fn new_with_config(
         rx: mpsc::Receiver<PeerManagerCommand>,
         internal_rx: mpsc::UnboundedReceiver<InternalCommand>,

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -1887,7 +1887,10 @@ impl PeerManager {
         result
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "runtime policy application keeps ordered import and export transitions together"
+    )]
     async fn apply_runtime_policies_for_peer_key(
         &mut self,
         peer_key: PeerKey,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -6890,7 +6890,10 @@ fn build_transport_config_preserves_local_role_for_otc() {
 ///    default would pass a weaker test even with the copy missing, so the
 ///    sentinels are chosen to differ from those defaults.
 #[test]
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the inventory test keeps every transport field in one exact assertion"
+)]
 fn build_transport_config_reflects_every_transport_field() {
     let (_, rx) = mpsc::channel(16);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
@@ -9226,7 +9229,10 @@ enum NonEstablishedRollbackRibOutcome {
     Internal,
 }
 
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the rollback helper keeps all peer and RIB outcome assertions together"
+)]
 async fn assert_non_established_rollback_rib_outcome(
     rollback_outcome: NonEstablishedRollbackRibOutcome,
 ) {
@@ -9950,7 +9956,10 @@ async fn apply_resolved_policy_snapshot_rearms_refresh_on_compound_rollback_fail
     rib_drainer.abort();
 }
 
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the regression drives both updates through one complete pending-refresh receipt"
+)]
 #[tokio::test]
 async fn back_to_back_updates_do_not_lose_pending_refresh() {
     use rustbgpd_transport::PeerCommand;
@@ -10189,7 +10198,10 @@ async fn peer_deletion_after_failed_update_drops_pending_retry_cleanly() {
 /// whose chains didn't change) — and no RIB `ReplacePeerExportPolicy`.
 /// The peer whose content moved gets exactly the prior behavior:
 /// session installs, RIB replace, and a Route Refresh.
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the fanout regression keeps affected and unaffected peer assertions together"
+)]
 #[tokio::test]
 async fn content_equal_policy_fanout_skips_unaffected_peers() {
     use rustbgpd_api::peer_types::ResolvedPeerPolicy;
@@ -13668,7 +13680,10 @@ async fn gshut_toggle_times_out_when_rib_reply_wedges() {
     );
 }
 
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the timeout regression keeps its full transaction and recovery receipt together"
+)]
 #[tokio::test(start_paused = true)]
 async fn export_policy_apply_times_out_when_rib_reply_wedges() {
     use rustbgpd_transport::PeerCommand;
@@ -13799,7 +13814,10 @@ async fn gshut_not_found_preserves_scoped_peer_label() {
     assert_eq!(err.to_string(), "peer fe80::2%eth1 not found");
 }
 
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the hot-apply regression keeps all eBGP and iBGP peer assertions together"
+)]
 #[tokio::test]
 async fn honor_graceful_shutdown_hot_apply_targets_ebgp_only() {
     use rustbgpd_transport::PeerCommand;
@@ -13970,7 +13988,10 @@ async fn honor_graceful_shutdown_hot_apply_targets_ebgp_only() {
 /// the production race: the session task can drop a reply
 /// mid-shutdown while the FSM is still reporting Established
 /// for one more poll.
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the failure regression keeps the rejected import and no-refresh receipt together"
+)]
 #[tokio::test]
 async fn import_apply_failure_on_established_peer_bails_without_refresh() {
     use rustbgpd_policy::{Policy, PolicyAction};
@@ -14163,7 +14184,10 @@ async fn import_apply_failure_on_established_peer_bails_without_refresh() {
 /// `pending_refresh = true`, leave `managed.import_policy` at
 /// the prior value, and (because peer is Idle) NOT fire Route
 /// Refresh.
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the idle-peer failure regression keeps pending-refresh state and wire assertions together"
+)]
 #[tokio::test]
 async fn import_apply_failure_on_idle_peer_bails_and_sets_pending_refresh() {
     use rustbgpd_policy::{Policy, PolicyAction};
@@ -14334,7 +14358,10 @@ async fn import_apply_failure_on_idle_peer_bails_and_sets_pending_refresh() {
 /// holds. Failure must propagate, the bookkeeping must not
 /// advance, and `pending_export_apply` must be set so the next
 /// call retries.
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the export failure regression keeps bookkeeping and wire assertions together"
+)]
 #[tokio::test]
 async fn export_apply_failure_bails_without_advancing_bookkeeping() {
     use rustbgpd_policy::{Policy, PolicyAction};
@@ -14546,7 +14573,10 @@ async fn export_apply_failure_bails_without_advancing_bookkeeping() {
 ///
 /// Asserts: first call returns Err with both flags set; second
 /// call returns Ok with `route_refresh_calls > 0`.
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the retry regression keeps import, export failure, and refresh receipt together"
+)]
 #[tokio::test]
 async fn import_succeeds_export_fails_then_retry_fires_refresh() {
     use rustbgpd_policy::{Policy, PolicyAction};
@@ -14784,7 +14814,10 @@ async fn import_succeeds_export_fails_then_retry_fires_refresh() {
 /// import-side intent independently re-arms `pending_refresh`. A
 /// content-equal retry must therefore revisit the RIB, then refresh
 /// Adj-RIB-In and clear both intents after success.
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the RIB failure regression keeps transaction and retry state together"
+)]
 #[tokio::test]
 async fn rib_failure_preserves_pending_refresh_for_retry() {
     use rustbgpd_policy::{Policy, PolicyAction};
@@ -15007,7 +15040,10 @@ async fn rib_failure_preserves_pending_refresh_for_retry() {
 /// small (Route Refresh against an empty `AdjRibIn` is a no-op
 /// on the wire) and is the right tradeoff against silent
 /// stale-routes.
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the stale-query regression keeps fencing and retry assertions together"
+)]
 #[tokio::test]
 async fn stale_query_state_re_arms_pending_refresh() {
     use rustbgpd_policy::{Policy, PolicyAction};
@@ -15151,7 +15187,10 @@ fn collision_remote_wins() {
     assert!(local_id < remote_id, "remote should win collision");
 }
 
-#[allow(clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the active-open regression keeps both candidate paths and fencing assertions together"
+)]
 #[tokio::test]
 async fn simultaneous_active_open_runs_inbound_candidate_before_primary_idle() {
     use rustbgpd_transport::PeerCommand;

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -798,7 +798,10 @@ pub fn global_policy_chains_from_config(config: &Config) -> PolicyChainAssignmen
 /// Return a neighbor's configured peer-group membership. Outer `None` =
 /// neighbor not configured; inner `None` = no membership.
 #[must_use]
-#[allow(clippy::option_option)] // the two None levels are distinct contract states
+#[allow(
+    clippy::option_option,
+    reason = "the two None levels distinguish absent peer from an ungrouped peer"
+)]
 pub fn neighbor_peer_group_from_config(config: &Config, address: IpAddr) -> Option<Option<String>> {
     config
         .neighbors

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -7186,7 +7186,10 @@ remote_asn = 65002
     }
 
     #[tokio::test]
-    #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the regression keeps persistence failure and snapshot-fence assertions together"
+    )]
     async fn config_bridge_does_not_advance_snapshot_on_acked_static_neighbor_persist_failure() {
         use rustbgpd_api::peer_types::{ConfigEvent, PeerManagerNeighborConfig};
         use rustbgpd_transport::RemovePrivateAs;


### PR DESCRIPTION
## Summary

- derive maintained production Rust source roots from `cargo metadata` instead of a static crate list
- cover all 22 workspace roots / 391 Rust files, including zero-suppression roots that must remain enrolled as the workspace grows
- add specific reasons to the 84 suppressions exposed by complete coverage
- preserve Cargo's actionable diagnostic and return exit 2 when metadata discovery fails
- document the dynamic gate contract for contributors

## Verification

- full pre-push fmt, workspace Clippy, workspace tests, and rustdoc
- checker unit suite: 5/5
- default Clippy-reason checker
- independent exact-head review: GO

## Load-bearing proof

- a synthetic Cargo workspace source root with an unreasoned Clippy attribute passes the former static-root logic and fails the production dynamic checker
- removing a newly covered reason from the EVPN load tools fails the default checker
- malformed Cargo metadata exits 2 with Cargo's diagnostic and no traceback; reverting the error handler makes the regression test fail

## Merge ordering

This is rebased on the prepared v0.61.0 tip. Hold merge until the v0.61.0 tag is immutable; the change is otherwise ready for review.
