### PR TITLE
perf(policy): share attribution labels through group staging

### DIFF
--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -168,7 +168,7 @@ fn resolved_match_to_proto(
     // keeps the same historical decision fields but overrides the
     // outcome to STALE so the operator knows the policy has since moved.
     let fill = |m: &mut proto::ImportExplainMatch, d: rustbgpd_transport::CachedDecision| {
-        m.matched_policy = d.matched_policy.unwrap_or_default();
+        m.matched_policy = d.matched_policy.as_deref().unwrap_or_default().to_string();
         m.rpki_validation = d.rpki.to_string();
         m.aspa_validation = d.aspa.to_string();
         m.modifications = Some(explain_modifications_to_proto(&d.modifications));
@@ -1725,6 +1725,7 @@ mod tests {
             proto::AddressFamily::Ipv4Unicast as i32,
             resolved,
         );
+        assert_eq!(m.matched_policy, "edge-import");
         assert_eq!(m.statements.len(), 2);
         let matched = &m.statements[0];
         assert_eq!(matched.policy_index, 0);

--- a/crates/policy/src/compile.rs
+++ b/crates/policy/src/compile.rs
@@ -53,13 +53,13 @@ pub fn compile_chain(chain: &PolicyChain, store: &mut SetStore) -> CompiledChain
                 // Attribute to the configured chain-reference name
                 // (e.g. `"customer-in(200)"`), matching how TOML
                 // members are labeled for metrics / explain.
-                spliced.name.clone_from(&named.name);
+                spliced.name = named.name.clone().map(Arc::from);
                 policies.push(spliced);
             }
             continue;
         }
         policies.push(CompiledPolicy {
-            name: named.name.clone(),
+            name: named.name.clone().map(Arc::from),
             terms: named
                 .policy
                 .entries

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -1218,7 +1218,7 @@ pub struct PolicyEvaluation {
     /// The terminal action — `Permit` or `Deny`.
     pub action: PolicyAction,
     /// Configured name of the terminal-decision policy, if it has one.
-    pub matched_policy: Option<String>,
+    pub matched_policy: Option<Arc<str>>,
     /// Set when the Deny is the fail-closed disposition of an
     /// evaluation error (ADR-0103 Decision 4) rather than a clean
     /// policy verdict — the kind plus the failing policy/term. Always
@@ -1563,7 +1563,7 @@ impl PolicyChain {
             for (term_index, (term, hits)) in policy.terms.iter().zip(hits).enumerate() {
                 rows.push(TermHitRow {
                     policy_index,
-                    policy: policy.name.clone(),
+                    policy: policy.name.as_ref().map(ToString::to_string),
                     term_index,
                     term: term.name.clone(),
                     hits: *hits,
@@ -1593,7 +1593,7 @@ impl PolicyChain {
                         PolicyResult::deny(),
                         PolicyEvaluation {
                             action: PolicyAction::Deny,
-                            matched_policy: named.name.clone(),
+                            matched_policy: named.name.clone().map(Arc::from),
                             eval_error: None,
                         },
                     );
@@ -1604,7 +1604,10 @@ impl PolicyChain {
         // All policies permitted (including an empty chain). Attribute
         // to the last policy in the chain since chain evaluation
         // completes only after every policy permits.
-        let matched_policy = self.policies.last().and_then(|n| n.name.clone());
+        let matched_policy = self
+            .policies
+            .last()
+            .and_then(|n| n.name.clone().map(Arc::from));
         (
             PolicyResult {
                 action: PolicyAction::Permit,

--- a/crates/policy/src/engine/tests/statement_trace.rs
+++ b/crates/policy/src/engine/tests/statement_trace.rs
@@ -502,7 +502,8 @@ fn statement_trace_agrees_with_live_evaluation_across_matrix() {
             // live evaluator attributes the decision to.
             match trace.steps.last() {
                 Some(last) => assert_eq!(
-                    last.policy_name, evaluation.matched_policy,
+                    last.policy_name.as_deref(),
+                    evaluation.matched_policy.as_deref(),
                     "terminal policy diverged for chain={chain_name} ctx={ctx_name}"
                 ),
                 None => assert_eq!(
@@ -735,7 +736,8 @@ fn rpol_statement_trace_agrees_with_live_evaluation_and_recorded_hits() {
             );
             let last = trace.steps.last().expect("non-empty chains");
             assert_eq!(
-                last.policy_name, evaluation.matched_policy,
+                last.policy_name.as_deref(),
+                evaluation.matched_policy.as_deref(),
                 "terminal policy diverged for chain={chain_name} ctx={ctx_name}"
             );
 

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -11,7 +11,7 @@
 //! The no-match / no-modification path allocates nothing: guard
 //! evaluation is all borrows, modifications are cloned only when a
 //! matched permit term actually carries some, and the attribution name
-//! is cloned only when the caller actually asked for attribution
+//! is Arc-cloned only when the caller actually asked for attribution
 //! (the `ATTR` const generic) — the plain [`CompiledChain::evaluate`]
 //! path never touches it.
 
@@ -696,7 +696,7 @@ impl CompiledChain {
                     warn_eval_error(policy.name.as_deref(), term_label.as_deref(), kind);
                     let error = EvalError {
                         kind,
-                        policy: policy.name.clone(),
+                        policy: policy.name.as_ref().map(ToString::to_string),
                         term: term_label,
                     };
                     if COUNT && let Some(hits) = hits {
@@ -1604,6 +1604,40 @@ mod tests {
         }
     }
 
+    /// Attribution is requested for the live metrics path. It must share
+    /// the compiled policy-name allocation rather than reconstructing an
+    /// owned label for every evaluated route.
+    ///
+    /// Red proof: replacing the evaluator's `policy.name.clone()` with
+    /// `Arc::from(policy.name.as_deref().unwrap())` preserves text output
+    /// but allocates a distinct backing buffer, making this assertion fail.
+    #[test]
+    fn attributed_policy_name_shares_compiled_allocation() {
+        let name: Arc<str> = Arc::from("customer-import");
+        let chain = CompiledChain {
+            policies: vec![CompiledPolicy {
+                name: Some(name.clone()),
+                terms: vec![Term {
+                    name: None,
+                    guard: MatchExpr::True,
+                    action: TermAction::Permit(RouteModifications::default()),
+                }],
+                default_action: PolicyAction::Deny,
+                source: PolicySource::Toml,
+            }],
+            ..CompiledChain::empty()
+        };
+
+        let (result, evaluation) = chain.evaluate_with_attribution(&ctx(None));
+        assert_eq!(result.action, PolicyAction::Permit);
+        let attributed = evaluation.matched_policy.expect("named terminal policy");
+        assert_eq!(attributed.as_ref(), "customer-import");
+        assert!(
+            Arc::ptr_eq(&name, &attributed),
+            "attribution must reuse the compiled policy-name allocation"
+        );
+    }
+
     fn v4(addr: [u8; 4], len: u8) -> Prefix {
         Prefix::V4(Ipv4Prefix::new(
             Ipv4Addr::new(addr[0], addr[1], addr[2], addr[3]),
@@ -1664,7 +1698,7 @@ mod tests {
         };
         let chain = CompiledChain {
             policies: vec![CompiledPolicy {
-                name: Some("p".to_string()),
+                name: Some(Arc::from("p")),
                 terms: vec![
                     Term {
                         name: Some("tag".to_string()),
@@ -1806,7 +1840,7 @@ mod tests {
         let big = CompiledChain {
             policies: vec![
                 CompiledPolicy {
-                    name: Some("p0".to_string()),
+                    name: Some(Arc::from("p0")),
                     terms: vec![
                         Term {
                             name: None,
@@ -1823,7 +1857,7 @@ mod tests {
                     source: PolicySource::Toml,
                 },
                 CompiledPolicy {
-                    name: Some("p1".to_string()),
+                    name: Some(Arc::from("p1")),
                     terms: vec![Term {
                         name: None,
                         guard: MatchExpr::True,

--- a/crates/policy/src/ir.rs
+++ b/crates/policy/src/ir.rs
@@ -830,8 +830,10 @@ pub enum PolicySource {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompiledPolicy {
     /// Configured policy name (`None` for inline / anonymous policies);
-    /// carried for chain attribution.
-    pub name: Option<String>,
+    /// carried for chain attribution. Shared with each attributed
+    /// evaluation so the live metrics path does not allocate one owned
+    /// policy label per route.
+    pub name: Option<Arc<str>>,
     /// Ordered terms; the first whose guard matches decides.
     pub terms: Vec<Term>,
     /// Action when no term matches.

--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -473,7 +473,7 @@ impl<'a> Lowerer<'a> {
             }
         }
         CompiledPolicy {
-            name: Some(def.name.node.clone()),
+            name: Some(Arc::from(def.name.node.clone())),
             terms,
             default_action: PolicyAction::Permit,
             source: PolicySource::Rpol,

--- a/crates/policy/tests/attribution_allocations.rs
+++ b/crates/policy/tests/attribution_allocations.rs
@@ -1,0 +1,167 @@
+//! Fixed-operation allocation gate for named policy attribution.
+//!
+//! This is an allocation receipt, not a timing benchmark. The chain is
+//! compiled and its counters are initialized before measurement; the measured
+//! window contains only repeated production
+//! `PolicyChain::evaluate_with_attribution` calls.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use rustbgpd_policy::{
+    NamedPolicy, Policy, PolicyAction, PolicyChain, RouteContext, RouteModifications,
+};
+use rustbgpd_wire::{AspaValidation, RpkiValidation};
+
+const VERDICTS: usize = 256;
+
+struct CountingAllocator {
+    inner: System,
+    enabled: AtomicBool,
+    allocations: AtomicUsize,
+}
+
+impl CountingAllocator {
+    const fn new() -> Self {
+        Self {
+            inner: System,
+            enabled: AtomicBool::new(false),
+            allocations: AtomicUsize::new(0),
+        }
+    }
+
+    fn begin(&self) {
+        self.enabled.store(false, Ordering::Relaxed);
+        self.allocations.store(0, Ordering::Relaxed);
+        self.enabled.store(true, Ordering::Relaxed);
+    }
+
+    fn end(&self) -> usize {
+        self.enabled.store(false, Ordering::Relaxed);
+        self.allocations.load(Ordering::Relaxed)
+    }
+
+    fn count_success(&self, pointer: *mut u8) {
+        if !pointer.is_null() && self.enabled.load(Ordering::Relaxed) {
+            self.allocations.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+// SAFETY: every operation forwards the original pointer/layout contract to the
+// same `System` allocator. The wrapper adds only allocation-free atomic
+// bookkeeping after successful allocation operations.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: `layout` is forwarded unchanged to the wrapped allocator.
+        let pointer = unsafe { self.inner.alloc(layout) };
+        self.count_success(pointer);
+        pointer
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: `layout` is forwarded unchanged to the wrapped allocator.
+        let pointer = unsafe { self.inner.alloc_zeroed(layout) };
+        self.count_success(pointer);
+        pointer
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: the caller's original pointer/layout pair and requested new
+        // size are forwarded unchanged to the allocator that created it.
+        let resized = unsafe { self.inner.realloc(pointer, layout, new_size) };
+        self.count_success(resized);
+        resized
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        // SAFETY: the caller's pointer/layout pair is forwarded unchanged to
+        // the allocator that created it.
+        unsafe { self.inner.dealloc(pointer, layout) };
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator::new();
+
+fn route_context() -> RouteContext<'static> {
+    RouteContext {
+        prefix: None,
+        next_hop: None,
+        extended_communities: &[],
+        communities: &[],
+        large_communities: &[],
+        as_path_str: "",
+        as_path: None,
+        as_path_len: 0,
+        origin_asn: None,
+        validation_state: RpkiValidation::NotFound,
+        aspa_state: AspaValidation::Unknown,
+        peer_address: None,
+        peer_asn: None,
+        peer_group: None,
+        route_type: None,
+        family: None,
+        evpn_route_type: None,
+        local_pref: None,
+        med: None,
+    }
+}
+
+fn named_permit_chain() -> PolicyChain {
+    PolicyChain::from_named(vec![NamedPolicy {
+        name: Some("customer-import".to_string()),
+        policy: Policy {
+            entries: Vec::new(),
+            default_action: PolicyAction::Permit,
+        },
+        rpol: None,
+    }])
+}
+
+/// Red proof: changing the evaluator to rebuild an owned label per verdict
+/// (for example `Arc::from(policy.name.as_deref().unwrap())`) preserves the
+/// asserted text and action but makes the allocation count non-zero.
+#[test]
+fn named_attribution_allocates_no_label_per_verdict() {
+    let chain = named_permit_chain();
+    let context = route_context();
+
+    // Compile the chain and initialize its hit counters before measurement.
+    let (warm_result, warm_evaluation) = chain.evaluate_with_attribution(&context);
+    assert_eq!(warm_result.action, PolicyAction::Permit);
+    let expected_label = warm_evaluation
+        .matched_policy
+        .expect("named policy must produce attributed verdicts");
+    assert_eq!(expected_label.as_ref(), "customer-import");
+
+    let mut attributed_verdicts = 0;
+    ALLOCATOR.begin();
+    for _ in 0..VERDICTS {
+        let (result, evaluation) = chain.evaluate_with_attribution(&context);
+        let label = evaluation
+            .matched_policy
+            .expect("measured verdict must remain attributed");
+        if result.action == PolicyAction::Permit
+            && evaluation.action == PolicyAction::Permit
+            && evaluation.eval_error.is_none()
+            && label.as_ref() == "customer-import"
+        {
+            attributed_verdicts += 1;
+        }
+    }
+    let allocations = ALLOCATOR.end();
+
+    assert_eq!(
+        attributed_verdicts, VERDICTS,
+        "the fixed-operation window must exercise the named attributed path"
+    );
+    assert_eq!(
+        allocations, 0,
+        "named attribution rebuilt {allocations} labels across {VERDICTS} verdicts"
+    );
+
+    // Keep the public result shape explicit: the allocation gate is not
+    // allowed to change policy semantics to buy the count.
+    assert_eq!(RouteModifications::default(), warm_result.modifications);
+}

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -49,6 +49,12 @@ use crate::update::{
 };
 use rustbgpd_wire::{ExtendedCommunity, VpnAddressFamily, VpnRouteKey};
 
+/// A configured policy name retained by shared staging. `Arc` keeps a
+/// group-wide per-route verdict from rebuilding the same owned label at every
+/// accumulator, delta, and residue handoff; metric/output boundaries convert
+/// only when they need an owned string.
+type PolicyLabel = Arc<str>;
+
 /// Fingerprint of every RIB-staging input that makes per-peer staged
 /// output differ (design §1). Per-peer wire preparation (next-hop
 /// rewrite, AS prepend, `ORIGINATOR_ID`/`CLUSTER_LIST` stamping, …) lives
@@ -293,7 +299,7 @@ pub(in crate::manager) struct GroupDelta {
     /// Terminal policy of the permitting evaluation (`None` = inline /
     /// no chain). Retained on the staged entry so a later join can
     /// replay the member's export counters without re-running policy.
-    pub(in crate::manager) policy_label: Option<String>,
+    pub(in crate::manager) policy_label: Option<PolicyLabel>,
     /// Pre-policy SOURCE attributes of an announce delta (`None` for a
     /// withdrawal, or when the source carries no communities). RFC 7947
     /// control decisions — per-target suppression and prepend — are
@@ -535,17 +541,17 @@ impl GroupStageOutput {
 /// prometheus lookups (design §6).
 #[derive(Default)]
 pub(in crate::manager) struct GroupEvalAccumulator {
-    totals: Vec<(Option<String>, PolicyAction, u64)>,
-    per_source: FxHashMap<IpAddr, Vec<(Option<String>, PolicyAction, u64)>>,
+    totals: Vec<(Option<PolicyLabel>, PolicyAction, u64)>,
+    per_source: FxHashMap<IpAddr, Vec<(Option<PolicyLabel>, PolicyAction, u64)>>,
     /// Verdict (and source peer) of the most recent evaluation, consumed
     /// per key by the staging loops to label the staged entry / denial
     /// residue (single-best stages at most one eval per key).
-    last: Option<(Option<String>, PolicyAction, IpAddr)>,
+    last: Option<(Option<PolicyLabel>, PolicyAction, IpAddr)>,
 }
 
 fn bump_eval_row(
-    rows: &mut Vec<(Option<String>, PolicyAction, u64)>,
-    policy: Option<&String>,
+    rows: &mut Vec<(Option<PolicyLabel>, PolicyAction, u64)>,
+    policy: Option<&PolicyLabel>,
     action: PolicyAction,
 ) {
     if let Some((_, _, n)) = rows
@@ -555,6 +561,24 @@ fn bump_eval_row(
         *n += 1;
     } else {
         rows.push((policy.cloned(), action, 1));
+    }
+}
+
+/// Materialize a policy label only at the peer-counter boundary. Group
+/// staging itself retains `PolicyLabel` handles, but telemetry's keyed rows
+/// own their strings after the shared pass is complete.
+fn bump_counter_row(
+    rows: &mut Vec<(Option<String>, PolicyAction, u64)>,
+    policy: Option<&PolicyLabel>,
+    action: PolicyAction,
+) {
+    if let Some((_, _, n)) = rows
+        .iter_mut()
+        .find(|(p, a, _)| *a == action && p.as_deref() == policy.map(AsRef::as_ref))
+    {
+        *n += 1;
+    } else {
+        rows.push((policy.map(ToString::to_string), action, 1));
     }
 }
 
@@ -576,7 +600,7 @@ impl GroupEvalAccumulator {
 
     /// Take (and clear) the last recorded verdict — the staging loop's
     /// per-key label / denial-residue hook.
-    fn take_last(&mut self) -> Option<(Option<String>, PolicyAction, IpAddr)> {
+    fn take_last(&mut self) -> Option<(Option<PolicyLabel>, PolicyAction, IpAddr)> {
         self.last.take()
     }
 }
@@ -709,7 +733,7 @@ pub(in crate::manager) fn emit_rs_tag_transitions(
 /// A persistent group-verdict VPN denial: (source peer, denying policy
 /// label, the denied route's extended communities — the Φ gate input
 /// for an RTC member's join-time counter replay).
-type VpnDenialRecord = (IpAddr, Option<String>, Vec<ExtendedCommunity>);
+type VpnDenialRecord = (IpAddr, Option<PolicyLabel>, Vec<ExtendedCommunity>);
 
 /// One entry of a shared group VPN staging pass. Unlike the unicast
 /// [`GroupDelta`] this carries the full displaced route (`old`), not just
@@ -727,7 +751,7 @@ pub(in crate::manager) struct VpnGroupDelta {
     pub(in crate::manager) old: Option<VpnRibRoute>,
     /// Terminal policy of the permitting evaluation — join-time counter
     /// replay residue, exactly like [`GroupDelta::policy_label`].
-    pub(in crate::manager) policy_label: Option<String>,
+    pub(in crate::manager) policy_label: Option<PolicyLabel>,
 }
 
 /// Result of one shared VPN staging pass over a group: deltas (already
@@ -889,7 +913,7 @@ pub(in crate::manager) struct GroupRibOut {
     /// Persistent group-verdict export-policy denials (target stamped
     /// with [`GROUP_FILTERED_PLACEHOLDER`], restamped per member) with
     /// the denying policy's label for join-time counter replay.
-    policy_filtered: FxHashMap<PolicyFilteredRouteKey, Option<String>>,
+    policy_filtered: FxHashMap<PolicyFilteredRouteKey, Option<PolicyLabel>>,
     /// Terminal policy label per staged entry — join-time counter replay
     /// residue. Entries ONLY for labelled entries: an inline (unlabelled)
     /// entry stores nothing and its key is removed, so absent and
@@ -897,10 +921,10 @@ pub(in crate::manager) struct GroupRibOut {
     /// two, so keep the insert conditional — an unconditional insert
     /// costs a slot per staged route across the whole table for a value
     /// no reader can distinguish from absence.
-    staged_labels: FxHashMap<(Prefix, u32), Option<String>>,
+    staged_labels: FxHashMap<(Prefix, u32), Option<PolicyLabel>>,
     /// VPN sibling of `staged_labels`, keyed by RD+prefix identity, with
     /// the same absent-means-inline invariant.
-    vpn_staged_labels: FxHashMap<VpnRouteKey, Option<String>>,
+    vpn_staged_labels: FxHashMap<VpnRouteKey, Option<PolicyLabel>>,
     /// Persistent group-verdict VPN export-policy denials: denied key →
     /// (source peer, denying policy label, the denied route's extended
     /// communities). The per-peer VPN path keeps no denial *records*
@@ -1368,7 +1392,7 @@ impl GroupRibOut {
     fn record_policy_filtered(
         &mut self,
         staged: &HashSet<Prefix>,
-        current: &[(PolicyFilteredRouteKey, Option<String>)],
+        current: &[(PolicyFilteredRouteKey, Option<PolicyLabel>)],
     ) {
         self.policy_filtered
             .retain(|key, _| !staged.contains(&key.prefix));
@@ -1724,7 +1748,7 @@ impl RibManager {
         memo: &mut super::distribution::ExportMemo,
     ) -> GroupStageOutput {
         let mut out = GroupStageOutput::default();
-        let mut labeled_filtered: Vec<(PolicyFilteredRouteKey, Option<String>)> = Vec::new();
+        let mut labeled_filtered: Vec<(PolicyFilteredRouteKey, Option<PolicyLabel>)> = Vec::new();
         {
             let Some(group) = self.group_ribs.get(&gid) else {
                 return out;
@@ -2220,7 +2244,7 @@ impl RibManager {
                         let key = route.nlri.key();
                         count_delta[GroupRibOut::vpn_count_slot(&key) - 2] += 1;
                         let label = group.vpn_staged_labels.get(&key).cloned().unwrap_or(None);
-                        bump_eval_row(&mut permit_rows, label.as_ref(), PolicyAction::Permit);
+                        bump_counter_row(&mut permit_rows, label.as_ref(), PolicyAction::Permit);
                         vpn_announce.push(route.clone());
                     }
                     (true, false) => {
@@ -2316,7 +2340,11 @@ impl RibManager {
                             .map(|(_, _, n)| *n)
                     })
                     .unwrap_or(0);
-                (policy.clone(), *action, total.saturating_sub(own_n))
+                (
+                    policy.as_ref().map(ToString::to_string),
+                    *action,
+                    total.saturating_sub(own_n),
+                )
             })
             .collect();
         self.bump_export_counters(peer, &rows);
@@ -2345,15 +2373,8 @@ impl RibManager {
             let Some(group) = self.group_ribs.get(&gid) else {
                 return;
             };
-            let mut bump = |policy: &Option<String>, action: PolicyAction| {
-                if let Some((_, _, n)) = rows
-                    .iter_mut()
-                    .find(|(p, a, _)| *a == action && p == policy)
-                {
-                    *n += 1;
-                } else {
-                    rows.push((policy.clone(), action, 1));
-                }
+            let mut bump = |policy: &Option<PolicyLabel>, action: PolicyAction| {
+                bump_counter_row(&mut rows, policy.as_ref(), action);
             };
             let in_family =
                 |prefix: &Prefix| family.is_none_or(|f| super::helpers::prefix_family(prefix) == f);
@@ -4431,10 +4452,10 @@ mod tests {
         // A labelled restage DOES take a slot — the residue still
         // carries what join-time counter replay reads.
         let mut labelled = announce_delta(prefix(1), OTHER1, Some(OTHER1));
-        labelled.policy_label = Some("export-chain".to_owned());
+        labelled.policy_label = Some(Arc::from("export-chain"));
         group.apply_delta(&labelled);
         let mut vpn_labelled = vpn_announce_delta(1, OTHER1, Some(OTHER1));
-        vpn_labelled.policy_label = Some("export-chain".to_owned());
+        vpn_labelled.policy_label = Some(Arc::from("export-chain"));
         group.apply_vpn_delta(&vpn_labelled);
         assert_eq!(
             group.staged_labels.get(&key).and_then(|l| l.as_deref()),
@@ -4444,9 +4465,8 @@ mod tests {
             group
                 .vpn_staged_labels
                 .get(&vpn_key(1))
-                .cloned()
-                .unwrap_or(None),
-            Some("export-chain".to_owned())
+                .and_then(|label| label.as_deref()),
+            Some("export-chain")
         );
 
         // Restaging inline REMOVES the slot rather than retaining the
@@ -4457,6 +4477,39 @@ mod tests {
         assert!(!group.staged_labels.contains_key(&key));
         assert!(!group.vpn_staged_labels.contains_key(&vpn_key(1)));
         assert_eq!(resolved(&group), (true, true));
+    }
+
+    /// Shared staging must retain the evaluator's policy-label allocation from
+    /// one delta through the group-table residue. Two routes ending in the
+    /// same policy therefore share one backing label rather than allocating a
+    /// `String` per staged key.
+    ///
+    /// Red proof: rebuilding either stored label with
+    /// `Arc::from(label.as_ref())` leaves the operator-visible text unchanged
+    /// but makes the pointer-identity assertion fail.
+    #[test]
+    fn staged_policy_labels_share_the_evaluation_allocation() {
+        let mut group = empty_group();
+        let label: Arc<str> = Arc::from("shared-export-policy");
+        for n in [1, 2] {
+            let mut delta = announce_delta(prefix(n), OTHER1, None);
+            delta.policy_label = Some(Arc::clone(&label));
+            group.apply_delta(&delta);
+        }
+
+        let first = group
+            .staged_labels
+            .get(&(prefix(1), 0))
+            .and_then(Option::as_ref)
+            .expect("first route carries its terminal policy");
+        let second = group
+            .staged_labels
+            .get(&(prefix(2), 0))
+            .and_then(Option::as_ref)
+            .expect("second route carries its terminal policy");
+        assert_eq!(first.as_ref(), "shared-export-policy");
+        assert!(Arc::ptr_eq(&label, first));
+        assert!(Arc::ptr_eq(first, second));
     }
 
     /// An RTC membership over a specific Route Target (full 96-bit

--- a/crates/transport/src/session/import_decision_cache.rs
+++ b/crates/transport/src/session/import_decision_cache.rs
@@ -34,6 +34,7 @@
 use std::collections::VecDeque;
 use std::net::IpAddr;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 use std::time::SystemTime;
 
 use lru::LruCache;
@@ -129,7 +130,7 @@ pub struct CachedDecision {
     /// Terminal-decision policy name from
     /// [`rustbgpd_policy::PolicyEvaluation::matched_policy`]. `None` =
     /// inline / anonymous.
-    pub matched_policy: Option<String>,
+    pub matched_policy: Option<Arc<str>>,
     /// RPKI origin-validation state at evaluation time.
     pub rpki: RpkiValidation,
     /// ASPA path-verification state at evaluation time.

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -1898,7 +1898,8 @@ impl PeerSession {
                                 self.build_rejected_route_prototype(reject_proto_attrs)
                             });
                             let mut reject_entry = proto.clone();
-                            reject_entry.detail.clone_from(&evaluation.matched_policy);
+                            reject_entry.detail =
+                                evaluation.matched_policy.as_ref().map(ToString::to_string);
                             reject_entry.next_hop = Some(body_next_hop);
                             reject_entry.rpki = rpki_state;
                             reject_entry.aspa = body_aspa_state;
@@ -2544,7 +2545,8 @@ impl PeerSession {
                                     self.build_rejected_route_prototype(reject_proto_attrs)
                                 });
                                 let mut reject_entry = proto.clone();
-                                reject_entry.detail.clone_from(&evaluation.matched_policy);
+                                reject_entry.detail =
+                                    evaluation.matched_policy.as_ref().map(ToString::to_string);
                                 reject_entry.next_hop = Some(mp.next_hop);
                                 reject_entry.rpki = mp_rpki_state;
                                 reject_entry.aspa = mp_aspa_state;


### PR DESCRIPTION
## Summary

- store compiled and attributed policy names as `Arc<str>`
- carry the shared label through unicast/VPN group accumulators, deltas, staged labels, denial residue, and the import-decision explain cache
- materialize owned strings only at telemetry, retained-diagnostic, and API output boundaries
- preserve label text, counter coalescing, source-subtraction semantics, and public protobuf output
- add an isolated allocation receipt for the public named attributed-evaluation path

This removes the per-evaluation/group-staging label reconstruction mechanism. It makes no timing or end-to-end performance claim.

## Verification

- full pre-push fmt, workspace Clippy, workspace tests, and rustdoc
- full policy/RIB/transport/API package suites
- update-group parity, resync, VPN lifecycle, explain-cache, and API serialization coverage
- allocation receipt repeated 8/8 under independent review
- independent exact-head review: GO

## Load-bearing proof

- attributed evaluation asserts pointer identity with the compiled policy label; reconstructing a text-identical allocation makes it fail
- two staged routes ending in the same policy assert pointer identity through staged/denial residue; rebuilding either label makes it fail
- an isolated one-test binary measures exactly 256 public named `evaluate_with_attribution` verdicts after warm-up: all retain `customer-import` / Permit / no-error semantics with zero allocator calls
- rebuilding the label preserves those semantic assertions but produces exactly 256 allocations and fails the gate
- public policy-name output remains pinned as `edge-import`

## Merge ordering

This is rebased on the prepared v0.61.0 tip. Hold merge until the v0.61.0 tag is immutable; the change is otherwise ready for review.
