### PR TITLE
fix(doctor): report partial event history

### DIFF
--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -1407,8 +1407,20 @@ pub(crate) async fn run(
                     .iter()
                     .map(|e| bgp_event_json_value(e).map(redact_event))
                     .collect::<Result<Vec<_>, _>>()?,
-                Err(_) => Vec::new(),
+                Err(e) => {
+                    sections.insert(
+                        "session_events",
+                        format!(
+                            "partial: ListSessionEvents RPC failed: {}",
+                            redact_text(&e.to_string())
+                        ),
+                    );
+                    Vec::new()
+                }
             };
+            sections
+                .entry("session_events")
+                .or_insert_with(|| "collected".to_string());
             let policy_events = match events
                 .list_policy_events(ListPolicyEventsRequest {
                     neighbor_address: String::new(),
@@ -1423,8 +1435,20 @@ pub(crate) async fn run(
                     .iter()
                     .map(|e| bgp_event_json_value(e).map(redact_event))
                     .collect::<Result<Vec<_>, _>>()?,
-                Err(_) => Vec::new(),
+                Err(e) => {
+                    sections.insert(
+                        "policy_events",
+                        format!(
+                            "partial: ListPolicyEvents RPC failed: {}",
+                            redact_text(&e.to_string())
+                        ),
+                    );
+                    Vec::new()
+                }
             };
+            sections
+                .entry("policy_events")
+                .or_insert_with(|| "collected".to_string());
             match neighbor.list_neighbors(ListNeighborsRequest {}).await {
                 Ok(resp) => {
                     let neighbors = resp.into_inner();
@@ -1784,6 +1808,7 @@ mod tests {
     use super::*;
     use crate::connection::connect;
     use crate::test_support::spawn_mock_server;
+    use tonic::Code;
 
     /// Load-bearing proof: removing the remote-AdminDown branch makes the
     /// permitted warning red; defaulting absent presence to false makes the
@@ -2640,6 +2665,113 @@ paths = ["x"]
                 && check["status"] == "warn"
                 && detail.contains(r#"bgp_peer_outbound_queue_depth{peer="10.0.0.2"}"#)
         }));
+    }
+
+    #[tokio::test]
+    async fn doctor_marks_session_history_failure_without_discarding_peer_evidence() {
+        let server = spawn_mock_server(None).await;
+        *server.state.list_neighbors_response.lock().await = vec![neighbor(
+            "10.0.0.2",
+            rustbgpd_api::proto::SessionState::Established as i32,
+            0,
+            "peer evidence survives",
+        )];
+        *server.state.session_events_error.lock().await = Some((
+            Code::Unavailable,
+            "upstream bearer must-not-escape".to_string(),
+        ));
+        *server.state.policy_events.lock().await = vec![rustbgpd_api::proto::BgpEvent {
+            timestamp: "200".to_string(),
+            peer_address: "10.0.0.2".to_string(),
+            summary: "policy evidence survives".to_string(),
+            ..Default::default()
+        }];
+        let connection = connect(&server.addr, None).await;
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_path = dir.path().join("bundle.tar.gz");
+
+        run(
+            connection,
+            &DoctorOptions {
+                output: Some(&bundle_path),
+                log_file: None,
+                daemon_address: &server.addr,
+                token_file_configured: false,
+                json: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        let files = extract_bundle(&bundle_path);
+        let manifest: serde_json::Value =
+            serde_json::from_str(find(&files, "manifest.json")).unwrap();
+        let session_status = manifest["sections"]["session_events"].as_str().unwrap();
+        // Load-bearing mutation proof: restoring the old `Err(_) => Vec::new()`
+        // collapse makes this partial-source assertion red.
+        assert!(session_status.contains("partial: ListSessionEvents RPC failed"));
+        assert!(session_status.contains("[REDACTED]"));
+        assert!(!session_status.contains("must-not-escape"));
+        assert_eq!(manifest["sections"]["policy_events"], "collected");
+        assert_eq!(manifest["sections"]["peers"], "collected");
+        let peers: serde_json::Value =
+            serde_json::from_str(find(&files, "peers/neighbors.json")).unwrap();
+        assert_eq!(peers[0]["address"], "10.0.0.2");
+        let events: serde_json::Value =
+            serde_json::from_str(find(&files, "peers/events.json")).unwrap();
+        // Load-bearing mutation proof: discarding the successful policy
+        // vector while the session RPC fails makes this exact evidence
+        // assertion red.
+        assert_eq!(events["policy"][0]["summary"], "policy evidence survives");
+    }
+
+    #[tokio::test]
+    async fn doctor_marks_policy_history_failure_independently() {
+        let server = spawn_mock_server(None).await;
+        *server.state.policy_events_error.lock().await =
+            Some((Code::Unavailable, "policy source unavailable".to_string()));
+        *server.state.session_events.lock().await = vec![rustbgpd_api::proto::BgpEvent {
+            timestamp: "100".to_string(),
+            peer_address: "10.0.0.2".to_string(),
+            summary: "session evidence survives".to_string(),
+            ..Default::default()
+        }];
+        let connection = connect(&server.addr, None).await;
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_path = dir.path().join("bundle.tar.gz");
+
+        run(
+            connection,
+            &DoctorOptions {
+                output: Some(&bundle_path),
+                log_file: None,
+                daemon_address: &server.addr,
+                token_file_configured: false,
+                json: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        let files = extract_bundle(&bundle_path);
+        let manifest: serde_json::Value =
+            serde_json::from_str(find(&files, "manifest.json")).unwrap();
+        // Load-bearing mutation proof: restoring the old `Err(_) => Vec::new()`
+        // collapse makes this independently-named partial-source assertion red.
+        assert!(
+            manifest["sections"]["policy_events"]
+                .as_str()
+                .unwrap()
+                .contains("partial: ListPolicyEvents RPC failed")
+        );
+        assert_eq!(manifest["sections"]["session_events"], "collected");
+        assert_eq!(manifest["sections"]["peers"], "collected");
+        let events: serde_json::Value =
+            serde_json::from_str(find(&files, "peers/events.json")).unwrap();
+        // Load-bearing mutation proof: discarding the successful session
+        // vector while the policy RPC fails makes this exact evidence
+        // assertion red.
+        assert_eq!(events["session"][0]["summary"], "session evidence survives");
     }
 
     /// LAN-482: one full daemon-up run with every first-deploy probe

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -44,12 +44,15 @@ pub(crate) struct MockState {
     pub(crate) last_config_rollback: Mutex<Option<server_proto::RollbackConfigTransactionRequest>>,
     pub(crate) config_effective_calls: AtomicUsize,
     pub(crate) config_effective_error: Mutex<Option<(Code, String)>>,
-    // Doctor-bundle overrides: canned effective-config TOML, metrics
-    // text, and session events so redaction/layout tests can seed
-    // secret-looking material through every collection path.
+    // Doctor-bundle overrides: canned effective-config TOML, metrics,
+    // and event histories so redaction/layout tests can seed material
+    // through every collection path.
     pub(crate) config_effective_toml: Mutex<Option<String>>,
     pub(crate) metrics_text: Mutex<Option<String>>,
     pub(crate) session_events: Mutex<Vec<server_proto::BgpEvent>>,
+    pub(crate) policy_events: Mutex<Vec<server_proto::BgpEvent>>,
+    pub(crate) session_events_error: Mutex<Option<(Code, String)>>,
+    pub(crate) policy_events_error: Mutex<Option<(Code, String)>>,
     pub(crate) config_confirm_error: Mutex<Option<(Code, String)>>,
     pub(crate) config_abort_error: Mutex<Option<(Code, String)>>,
     pub(crate) config_status_error: Mutex<Option<(Code, String)>>,
@@ -1179,6 +1182,9 @@ impl rustbgpd_api::proto::event_service_server::EventService for MockEventServic
         self.state
             .list_session_events_calls
             .fetch_add(1, Ordering::SeqCst);
+        if let Some((code, message)) = self.state.session_events_error.lock().await.clone() {
+            return Err(Status::new(code, message));
+        }
         Ok(Response::new(server_proto::ListSessionEventsResponse {
             events: self.state.session_events.lock().await.clone(),
         }))
@@ -1191,8 +1197,11 @@ impl rustbgpd_api::proto::event_service_server::EventService for MockEventServic
         self.state
             .list_policy_events_calls
             .fetch_add(1, Ordering::SeqCst);
+        if let Some((code, message)) = self.state.policy_events_error.lock().await.clone() {
+            return Err(Status::new(code, message));
+        }
         Ok(Response::new(server_proto::ListPolicyEventsResponse {
-            events: vec![],
+            events: self.state.policy_events.lock().await.clone(),
         }))
     }
 }

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1341,7 +1341,7 @@ addresses only, never copied into the bundle.
 
 ```
 rustbgpd-doctor-<ts>/
-├── manifest.json            # versions, redaction note, per-section collected/unavailable, check results
+├── manifest.json            # versions, redaction note, per-section collected/partial/unavailable status, check results
 ├── config/effective.toml    # the daemon's GetEffectiveConfig dump (defaults materialized, secrets <redacted>)
 ├── peers/bfd.json           # BFD state/diagnostic/strict plus remote-AdminDown bool or null when unknown
 ├── peers/neighbors.json     # per-peer state, counters, flap/slow-peer status
@@ -1350,6 +1350,10 @@ rustbgpd-doctor-<ts>/
 ├── crashes/panic-*.toml     # panic reports swept from <runtime_state_dir>/crash/
 └── system/                  # environment.json, health.json, global.json, metrics.prom, daemon rlimits
 ```
+
+`session_events` and `policy_events` are reported independently in the
+manifest. A failed history RPC marks only its source `partial`; the bundle
+keeps the successful peer, BFD, and other event-history evidence.
 
 Exit codes: `0` no checks red (green and yellow warnings may be present), `1`
 error, `2` bundle written but one or more checks are red. A down-daemon run produces a


### PR DESCRIPTION
## Summary

- stop collapsing failed session-history and policy-history RPCs into indistinguishable empty vectors
- mark each failed source independently as `partial` in the support-bundle manifest with redacted error context
- keep successful neighbor, BFD, and opposite event-history evidence in `peers/events.json`
- keep successful empty histories reported as `collected`
- document the additive manifest status

## Verification

- full pre-push fmt, workspace Clippy, workspace tests, and rustdoc
- all 38 doctor tests
- independent exact-head review: GO

## Load-bearing proof

- session-history failure must report its source partial, redact bearer-bearing error text, preserve neighbor evidence, and retain an exact non-empty policy event
- policy-history failure must report its source partial and retain an exact non-empty session event
- dropping either successful vector or restoring either former `Err(_) => Vec::new()` collapse makes its corresponding test fail

## Compatibility

The support-bundle manifest stays at format 2. `sections` remains an additive object and the archive file schema is unchanged.

## Merge ordering

This is rebased on the prepared v0.61.0 tip. Hold merge until the v0.61.0 tag is immutable; the change is otherwise ready for review.
