### PR TITLE
chore(api): drop stale large-error suppressions

### DIFF
--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -52,10 +52,6 @@ fn validate_update_group_comparison_scope(
 }
 
 /// Parse a list of family strings from the gRPC proto into `(Afi, Safi)` pairs.
-#[allow(
-    clippy::result_large_err,
-    reason = "tonic::Status is the standard gRPC error type"
-)]
 pub(crate) fn parse_families_proto(families: &[String]) -> Result<Vec<(Afi, Safi)>, Status> {
     if families.is_empty() {
         return Ok(vec![(Afi::Ipv4, Safi::Unicast)]);
@@ -374,10 +370,6 @@ pub(crate) fn family_to_string(afi: Afi, safi: Safi) -> String {
     }
 }
 
-#[allow(
-    clippy::result_large_err,
-    reason = "tonic::Status is the standard gRPC error type"
-)]
 pub(crate) fn parse_remove_private_as_proto(mode: &str) -> Result<RemovePrivateAs, Status> {
     match mode {
         "" => Ok(RemovePrivateAs::Disabled),

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -58,7 +58,6 @@ fn input_statement_to_proto(statement: &PolicyStatementDefinition) -> proto::Pol
 }
 
 #[allow(
-    clippy::result_large_err,
     clippy::too_many_lines,
     reason = "peer-group conversion mirrors the complete protobuf definition"
 )]

--- a/crates/api/src/policy_helpers.rs
+++ b/crates/api/src/policy_helpers.rs
@@ -8,10 +8,6 @@ use tonic::Status;
 use crate::peer_types::{PolicyAsPathPrependConfig, PolicyStatementDefinition};
 use crate::proto;
 
-#[allow(
-    clippy::result_large_err,
-    reason = "tonic::Status is the direct gRPC error type for policy validation"
-)]
 pub(crate) fn validate_policy_action(action: &str) -> Result<(), Status> {
     match action {
         "permit" | "deny" => Ok(()),
@@ -21,10 +17,6 @@ pub(crate) fn validate_policy_action(action: &str) -> Result<(), Status> {
     }
 }
 
-#[allow(
-    clippy::result_large_err,
-    reason = "tonic::Status is the direct gRPC error type for policy statement conversion"
-)]
 pub(crate) fn proto_statement_to_input(
     statement: proto::PolicyStatement,
 ) -> Result<PolicyStatementDefinition, Status> {

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -229,10 +229,6 @@ fn input_statement_to_proto(statement: &PolicyStatementDefinition) -> proto::Pol
     }
 }
 
-#[allow(
-    clippy::result_large_err,
-    reason = "tonic::Status is the standard gRPC error type"
-)]
 fn proto_definition_to_input(
     definition: proto::PolicyDefinition,
 ) -> Result<NamedPolicyDefinition, Status> {

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -302,10 +302,6 @@ impl RibService {
 
 /// Validate the requested unicast route-listing address family.
 /// 0 = UNSPECIFIED (treat as "any"), 1-2 = valid unicast families.
-#[allow(
-    clippy::result_large_err,
-    reason = "tonic::Status is the direct gRPC error type for validation helpers"
-)]
 fn validate_unicast_afi_safi(value: i32) -> Result<(), Status> {
     if value != 0
         && value != proto::AddressFamily::Ipv4Unicast as i32
@@ -320,10 +316,6 @@ fn validate_unicast_afi_safi(value: i32) -> Result<(), Status> {
 
 /// Validate the requested `FlowSpec` route-listing address family.
 /// 0 = UNSPECIFIED (treat as "any"), 3-4 = valid `FlowSpec` families.
-#[allow(
-    clippy::result_large_err,
-    reason = "tonic::Status is the direct gRPC error type for validation helpers"
-)]
 fn validate_flowspec_afi_safi(value: i32) -> Result<(), Status> {
     if value != 0
         && value != proto::AddressFamily::Ipv4Flowspec as i32
@@ -411,10 +403,6 @@ impl<'a> RouteFilterAttrs<'a> {
 }
 
 impl RouteFilters {
-    #[allow(
-        clippy::result_large_err,
-        reason = "tonic::Status keeps route-filter validation errors at the RPC boundary"
-    )]
     fn from_request(req: &proto::ListRoutesRequest) -> Result<Self, Status> {
         let prefix = if req.prefix_filter.is_empty() {
             if req.prefix_filter_length != 0 {
@@ -566,10 +554,6 @@ struct FibRouteFilters {
 }
 
 impl FibRouteFilters {
-    #[allow(
-        clippy::result_large_err,
-        reason = "tonic::Status keeps FIB route-filter validation errors at the RPC boundary"
-    )]
     fn from_request(req: &proto::ListFibRoutesRequest) -> Result<Self, Status> {
         let table_name = (!req.table_name.is_empty()).then(|| req.table_name.clone());
         let reason = (!req.reason.is_empty()).then(|| req.reason.clone());
@@ -727,10 +711,6 @@ const DEFAULT_ROUTE_PAGE_SIZE: usize = 100;
 
 /// Decode the pagination fields of a route-listing request: the resume
 /// cursor (from the opaque `page_token`) and the requested page size.
-#[allow(
-    clippy::result_large_err,
-    reason = "tonic::Status is the direct gRPC error type for validation helpers"
-)]
 fn parse_route_page_params(
     req: &proto::ListRoutesRequest,
     scope: RouteQueryScope,
@@ -882,10 +862,6 @@ fn encode_route_page_token(
     )
 }
 
-#[allow(
-    clippy::result_large_err,
-    reason = "tonic::Status is the direct gRPC error type for validation helpers"
-)]
 fn decode_route_page_token(token: &str) -> Result<RoutePageCursor, Status> {
     let invalid = || Status::invalid_argument("invalid page_token");
     let mut parts = token.split('|');
@@ -980,10 +956,6 @@ fn route_page_to_response(
     }
 }
 
-#[allow(
-    clippy::result_large_err,
-    reason = "tonic::Status is the direct gRPC error type for prefix parsing"
-)]
 fn parse_prefix_request(prefix: &str, prefix_length: u32) -> Result<Prefix, Status> {
     let addr: IpAddr = prefix
         .parse()
@@ -1010,10 +982,6 @@ fn parse_prefix_request(prefix: &str, prefix_length: u32) -> Result<Prefix, Stat
     })
 }
 
-#[allow(
-    clippy::result_large_err,
-    reason = "tonic::Status is the direct gRPC error type for event prefix filters"
-)]
 pub(crate) fn parse_route_event_prefix_filter(
     prefix: &str,
     prefix_length: u32,


### PR DESCRIPTION
## Summary

- remove 14 stale `clippy::result_large_err` allowances from API service code
- retain the one live event-history allowance, where the public overload error carries an `EventEnvelope`
- keep unrelated complexity allowances and their rationales unchanged

This is stacked on #1187 because that PR expands the production Clippy reason gate to every Rust source root.

## Why

Fourteen API methods return `Result<_, tonic::Status>`. In tonic 0.14.6, `Status` is an 8-byte handle whose 176-byte inner value is already boxed, so those suppressions no longer describe a large returned error. The event-history `try_send` path is different: its public `TrySendError<EventEnvelope>` carries a 192-byte envelope and remains intentionally suppressed to avoid changing the public error shape or allocating on overload.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
- 477 API tests
- independent diff review confirmed the stack parent, exact 14-removal accounting, and preservation of unrelated allowances

## Load-bearing proof

N/A. This removes obsolete lint suppressions without adding or changing a test or gate. The production Clippy gate remains the enforcement mechanism for future regressions.
