### PR TITLE
perf(cli): bound rbgp top metrics polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- `rbgp top` keeps health and neighbor polling on the operator-selected
+  interval while moving the full Prometheus metrics scrape to a separate
+  60-second cadence. It now retries transient global-metadata failures until
+  the daemon identity is available and retains the last-good RPKI VRP count
+  through a transient metrics failure.
+
 ## [0.61.0] — 2026-07-26
 
 > **Release framing.** This is the policy-safety line. RFC 8212

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -52,6 +52,7 @@ tonic-prost-build.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 tokio-stream = { workspace = true, features = ["net"] }
 rustbgpd-api.workspace = true
 rustbgpd-evpn.workspace = true

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -29,6 +29,8 @@ pub(crate) struct MockState {
     pub(crate) health_calls: AtomicUsize,
     pub(crate) metrics_calls: AtomicUsize,
     pub(crate) global_calls: AtomicUsize,
+    pub(crate) metrics_failures_remaining: AtomicUsize,
+    pub(crate) global_failures_remaining: AtomicUsize,
     pub(crate) list_neighbors_calls: AtomicUsize,
     pub(crate) list_session_events_calls: AtomicUsize,
     pub(crate) list_policy_events_calls: AtomicUsize,
@@ -606,6 +608,16 @@ impl rustbgpd_api::proto::global_service_server::GlobalService for MockGlobalSer
         _request: Request<server_proto::GetGlobalRequest>,
     ) -> Result<Response<server_proto::GlobalState>, Status> {
         self.state.global_calls.fetch_add(1, Ordering::SeqCst);
+        if self
+            .state
+            .global_failures_remaining
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(Status::unavailable("transient global failure"));
+        }
         Ok(Response::new(server_proto::GlobalState {
             asn: 65001,
             router_id: "10.0.0.1".to_string(),
@@ -667,6 +679,16 @@ impl rustbgpd_api::proto::control_service_server::ControlService for MockControl
         _request: Request<server_proto::MetricsRequest>,
     ) -> Result<Response<server_proto::MetricsResponse>, Status> {
         self.state.metrics_calls.fetch_add(1, Ordering::SeqCst);
+        if self
+            .state
+            .metrics_failures_remaining
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(Status::unavailable("transient metrics failure"));
+        }
         let prometheus_text = self
             .state
             .metrics_text

--- a/crates/cli/src/tui/data.rs
+++ b/crates/cli/src/tui/data.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
+use tokio::time::Instant;
 
 use crate::commands::control::rpki_vrp_count_sum;
 use crate::connection::Connection;
@@ -43,6 +44,24 @@ fn parse_vrp_count(prometheus_text: &str) -> Option<u64> {
     rpki_vrp_count_sum(prometheus_text)
 }
 
+const METRICS_POLL_INTERVAL: Duration = Duration::from_secs(60);
+
+struct FetcherState {
+    global: Option<GlobalState>,
+    rpki_vrp_count: Option<u64>,
+    next_metrics_poll: Instant,
+}
+
+impl FetcherState {
+    fn new() -> Self {
+        Self {
+            global: None,
+            rpki_vrp_count: None,
+            next_metrics_poll: Instant::now(),
+        }
+    }
+}
+
 pub fn spawn_fetcher(
     connection: Connection,
     interval: Duration,
@@ -50,19 +69,6 @@ pub fn spawn_fetcher(
     event_tx: mpsc::Sender<RouteEventEntry>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
-        // Fetch global once
-        let global = {
-            let mut client = GlobalServiceClient::with_interceptor(
-                connection.channel(),
-                connection.interceptor(),
-            );
-            client
-                .get_global(GetGlobalRequest {})
-                .await
-                .ok()
-                .map(|r| r.into_inner())
-        };
-
         // Spawn WatchRoutes stream in a sub-task
         let conn2 = connection.clone();
         let event_tx2 = event_tx.clone();
@@ -76,8 +82,9 @@ pub fn spawn_fetcher(
         });
 
         // Poll loop
+        let mut state = FetcherState::new();
         loop {
-            let snapshot = poll_once(&connection, global.clone()).await;
+            let snapshot = poll_once(&connection, &mut state).await;
             if data_tx.send(snapshot).await.is_err() {
                 break;
             }
@@ -86,8 +93,16 @@ pub fn spawn_fetcher(
     })
 }
 
-async fn poll_once(connection: &Connection, global: Option<GlobalState>) -> DataSnapshot {
+async fn poll_once(connection: &Connection, state: &mut FetcherState) -> DataSnapshot {
     let mut error = None;
+
+    if state.global.is_none() {
+        let mut client =
+            GlobalServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+        if let Ok(response) = client.get_global(GetGlobalRequest {}).await {
+            state.global = Some(response.into_inner());
+        }
+    }
 
     let health = {
         let mut client =
@@ -115,20 +130,21 @@ async fn poll_once(connection: &Connection, global: Option<GlobalState>) -> Data
         }
     };
 
-    let rpki_vrp_count = {
+    let now = Instant::now();
+    if now >= state.next_metrics_poll {
+        state.next_metrics_poll = now + METRICS_POLL_INTERVAL;
         let mut client =
             ControlServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-        match client.get_metrics(MetricsRequest {}).await {
-            Ok(r) => parse_vrp_count(&r.into_inner().prometheus_text),
-            Err(_) => None,
+        if let Ok(response) = client.get_metrics(MetricsRequest {}).await {
+            state.rpki_vrp_count = parse_vrp_count(&response.into_inner().prometheus_text);
         }
-    };
+    }
 
     DataSnapshot {
-        global,
+        global: state.global.clone(),
         health,
         neighbors,
-        rpki_vrp_count,
+        rpki_vrp_count: state.rpki_vrp_count,
         error,
     }
 }
@@ -164,6 +180,8 @@ async fn stream_routes(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::Ordering;
+
     use super::*;
     use crate::connection::connect;
     use crate::test_support::spawn_mock_server;
@@ -176,6 +194,83 @@ mod tests {
             "bgp_rpki_vrp_count{af=\"ipv4\"} 12\nbgp_rpki_vrp_count{af=\"ipv6\"} 3\n".to_string(),
         );
         let connection = connect(&server.addr, None).await.unwrap();
-        assert_eq!(poll_once(&connection, None).await.rpki_vrp_count, Some(15));
+        let mut state = FetcherState::new();
+        assert_eq!(
+            poll_once(&connection, &mut state).await.rpki_vrp_count,
+            Some(15)
+        );
+    }
+
+    /// Red proof: putting `GetMetrics` back in every fast poll raises the
+    /// pre-deadline call count from one to thirty.
+    #[tokio::test(start_paused = true)]
+    async fn metrics_scrape_has_an_independent_slow_cadence() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        let mut state = FetcherState::new();
+
+        poll_once(&connection, &mut state).await;
+        for _ in 0..29 {
+            tokio::time::advance(Duration::from_secs(2)).await;
+            poll_once(&connection, &mut state).await;
+        }
+
+        assert_eq!(server.state.metrics_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(server.state.health_calls.load(Ordering::SeqCst), 30);
+        assert_eq!(server.state.list_neighbors_calls.load(Ordering::SeqCst), 30);
+
+        tokio::time::advance(Duration::from_secs(2)).await;
+        poll_once(&connection, &mut state).await;
+        assert_eq!(server.state.metrics_calls.load(Ordering::SeqCst), 2);
+    }
+
+    /// Red proof: restoring the one-shot startup fetch leaves the second
+    /// snapshot's global metadata absent after the first RPC fails.
+    #[tokio::test(start_paused = true)]
+    async fn global_metadata_retries_until_success_then_stays_cached() {
+        let server = spawn_mock_server(None).await;
+        server
+            .state
+            .global_failures_remaining
+            .store(1, Ordering::SeqCst);
+        let connection = connect(&server.addr, None).await.unwrap();
+        let mut state = FetcherState::new();
+
+        let first = poll_once(&connection, &mut state).await;
+        assert!(first.global.is_none());
+
+        tokio::time::advance(Duration::from_secs(2)).await;
+        let second = poll_once(&connection, &mut state).await;
+        assert_eq!(second.global.as_ref().map(|global| global.asn), Some(65001));
+
+        tokio::time::advance(Duration::from_secs(2)).await;
+        let third = poll_once(&connection, &mut state).await;
+        assert_eq!(third.global.as_ref().map(|global| global.asn), Some(65001));
+        assert_eq!(server.state.global_calls.load(Ordering::SeqCst), 2);
+    }
+
+    /// Red proof: clearing the cached VRP value on a failed slow scrape makes
+    /// the second snapshot report `None` instead of the last-good count.
+    #[tokio::test(start_paused = true)]
+    async fn metrics_failure_retains_last_good_vrp_count() {
+        let server = spawn_mock_server(None).await;
+        *server.state.metrics_text.lock().await = Some(
+            "bgp_rpki_vrp_count{af=\"ipv4\"} 12\nbgp_rpki_vrp_count{af=\"ipv6\"} 3\n".to_string(),
+        );
+        let connection = connect(&server.addr, None).await.unwrap();
+        let mut state = FetcherState::new();
+
+        let first = poll_once(&connection, &mut state).await;
+        assert_eq!(first.rpki_vrp_count, Some(15));
+
+        server
+            .state
+            .metrics_failures_remaining
+            .store(1, Ordering::SeqCst);
+        tokio::time::advance(METRICS_POLL_INTERVAL).await;
+        let second = poll_once(&connection, &mut state).await;
+
+        assert_eq!(second.rpki_vrp_count, Some(15));
+        assert_eq!(server.state.metrics_calls.load(Ordering::SeqCst), 2);
     }
 }


### PR DESCRIPTION
## Summary

- keep `rbgp top` health and neighbor queries on the operator-selected refresh interval
- scrape the daemon's full Prometheus registry immediately, then at most once every 60 seconds
- retry transient `GetGlobal` failures until daemon identity is available, then cache it
- retain the last-good RPKI VRP count through transient metrics RPC failures

No protobuf or public API changes are included.

## Why

The TUI only needs one VRP scalar from `GetMetrics`, but that RPC gathers and Prometheus-encodes the complete registry. At the retained 1,000-peer route-server shape, the published scrape is 2,153,918 uncompressed bytes with 30,000 peer-labelled samples. A default two-second TUI therefore requested roughly 1.08 MB/s of metrics payload and forced a full gather/encode on every refresh. This is payload arithmetic from the retained fleet artifact, not a current-tip CPU claim.

The startup-only `GetGlobal` call also discarded a transient failure permanently, leaving daemon metadata absent for the lifetime of the TUI.

## Load-bearing proofs

All tests exercise the production `poll_once` path through real tonic mocks and were mutation-checked:

- restoring metrics scraping on every fast poll changes the pre-deadline call count from 1 to 30
- restoring startup-only global retrieval leaves the second snapshot without ASN 65001
- clearing cached VRP state on a metrics RPC failure changes `Some(15)` to `None`
- disabling the production-family parser leaves the existing VRP test at `None` instead of `Some(15)`

The cadence test also proves health and neighbor calls remain 30/30 and the second metrics scrape occurs exactly at t=60.

## Verification

- four focused TUI data tests
- all rustbgpctl tests: 18 library, 438 binary, and 23 integration tests
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- full pre-push hooks
- independent exact-commit review: GO
