### PR TITLE
fix(rib): preserve superseding prefix-limit transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the daemon identity is available and retains the last-good RPKI VRP count
   through a transient metrics failure.
 
+### Fixed
+
+- **A stale outbound prefix-limit activation no longer discards a newer
+  prepared change.** The newer transaction remains available to activate.
+
 ## [0.61.0] — 2026-07-26
 
 > **Release framing.** This is the policy-safety line. RFC 8212

--- a/crates/rib/src/manager/outbound_prefix_limits.rs
+++ b/crates/rib/src/manager/outbound_prefix_limits.rs
@@ -707,19 +707,30 @@ impl RibManager {
             let _ = reply.send(Ok(()));
             return;
         }
-        let Some(prepared) = self.outbound_limit_control.prepared.take() else {
+        let Some(prepared_txn) = self
+            .outbound_limit_control
+            .prepared
+            .as_ref()
+            .map(|prepared| prepared.txn)
+        else {
             let _ = reply.send(Err(format!(
                 "no prepared outbound prefix-limit transaction {txn}"
             )));
             return;
         };
-        if prepared.txn != txn {
+        if prepared_txn != txn {
             let _ = reply.send(Err(format!(
-                "prepared outbound prefix-limit transaction {} superseded {txn}",
-                prepared.txn
+                "prepared outbound prefix-limit transaction {prepared_txn} superseded {txn}",
             )));
             return;
         }
+        // The transaction identity is checked before consuming the slot so a
+        // stale Apply cannot discard a newer prepared transaction.
+        let prepared = self
+            .outbound_limit_control
+            .prepared
+            .take()
+            .expect("prepared transaction was checked above");
         if prepared.epoch != self.outbound_limit_control.epoch {
             let _ = reply.send(Err(
                 "outbound prefix-limit admission epoch advanced after preparation".to_string(),

--- a/crates/rib/src/manager/tests/outbound_prefix_limits.rs
+++ b/crates/rib/src/manager/tests/outbound_prefix_limits.rs
@@ -699,6 +699,29 @@ fn a_lowering_below_current_usage_rejects_the_whole_edit() {
     assert!(apply(&mut manager, 2, true).is_err());
 }
 
+/// A stale apply must leave the newer prepared transaction available for its
+/// own activation.
+///
+/// Load-bearing break: taking the prepared slot before checking its identity
+/// makes the final activation fail because the stale apply consumed txn 2.
+#[test]
+fn a_stale_apply_preserves_the_newer_prepared_transaction() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    manager.test_force_ungrouped = true;
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 113, 0, 1));
+    let _outbound_rx = register_peer(&mut manager, peer);
+
+    prepare(&mut manager, 1, limit_config(&[(peer, Some(1), None)], &[]))
+        .expect("first preflight passes");
+    prepare(&mut manager, 2, limit_config(&[(peer, Some(2), None)], &[]))
+        .expect("newer preflight replaces the first");
+
+    assert!(apply(&mut manager, 1, true).is_err());
+    apply(&mut manager, 2, true).expect("newer transaction still activates");
+    assert_eq!(ipv4_row(&manager, peer).limit, Some(2));
+}
+
 /// A raise re-derives only the affected family; activation is idempotent by
 /// transaction identity, and a superseded identity is refused.
 ///


### PR DESCRIPTION
## Summary

- reject a stale outbound prefix-limit Apply without consuming the newer prepared transaction
- keep the prepared slot untouched until the transaction identity matches
- prove the exact Prepare(1), Prepare(2), Apply(1), Apply(2) ordering

Current daemon producers serialize prepare/apply through the runtime-config lock or startup sequencing, so this is defensive hardening of the RIB message invariant rather than a claim of current operator exposure.

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- independent diff review: GO after correcting the release-note placement

## Load-bearing proof

Restoring take-before-identity-check makes the focused regression fail at the final transaction 2 activation with `no prepared outbound prefix-limit transaction 2`.

Hold merge until the v0.61.0 release tip is immutable.