### PR TITLE
fix(rib): fence route page generations behind accepted markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **A stale outbound prefix-limit activation no longer discards a newer
   prepared change.** The newer transaction remains available to activate.
 
+- **Convergence-marker page-generation fencing now follows accepted work.**
+  Stale-session End-of-RIB/BoRR/EoRR and inactive EoRR markers no longer
+  invalidate paginated route queries, while accepted End-of-RIB, BoRR, EoRR,
+  and timeout work invalidates each route scope exactly once.
+
 ## [0.61.0] — 2026-07-26
 
 > **Release framing.** This is the policy-safety line. RFC 8212

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1548,10 +1548,7 @@ impl RibManager {
             | RibUpdate::PeerDeleted { .. }
             | RibUpdate::InjectRoute { .. }
             | RibUpdate::WithdrawInjected { .. }
-            | RibUpdate::EndOfRib { .. }
             | RibUpdate::PeerGracefulRestart { .. }
-            | RibUpdate::BeginRouteRefresh { .. }
-            | RibUpdate::EndRouteRefresh { .. }
             | RibUpdate::RpkiCacheUpdate { .. }
             | RibUpdate::AspaTableUpdate { .. } => self.advance_all_route_pages(),
             _ => {}
@@ -2333,6 +2330,7 @@ impl RibManager {
                 safi,
             } => {
                 if !self.stale_session_message(peer, session_id, "EndOfRib", "eor") {
+                    self.advance_all_route_pages();
                     let selection_transition =
                         self.selection_deferral_end_of_rib(peer, session_id, (afi, safi));
                     self.handle_end_of_rib(peer, afi, safi);
@@ -2361,6 +2359,7 @@ impl RibManager {
                 safi,
             } => {
                 if !self.stale_session_message(peer, session_id, "BeginRouteRefresh", "refresh") {
+                    self.advance_all_route_pages();
                     self.handle_begin_route_refresh(peer, afi, safi);
                     if let Some(transition) =
                         self.selection_deferral_begin_route_refresh(peer, session_id, (afi, safi))

--- a/crates/rib/src/manager/tests/paged_query.rs
+++ b/crates/rib/src/manager/tests/paged_query.rs
@@ -1369,6 +1369,157 @@ fn every_direct_timer_mutation_seam_advances_route_page_versions() {
     assert_ne!(versions(&manager), before, "selection-release seam");
 }
 
+fn refresh_test_manager() -> (RibManager, IpAddr) {
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let _outbound_rx = peer_up_direct(&mut manager, peer);
+    (manager, peer)
+}
+
+fn route_page_versions(manager: &RibManager) -> [RoutePageVersion; 3] {
+    [
+        manager
+            .route_page_received_version
+            .expect("received page generation remains available"),
+        manager
+            .route_page_best_version
+            .expect("best page generation remains available"),
+        manager
+            .route_page_advertised_version
+            .expect("advertised page generation remains available"),
+    ]
+}
+
+fn assert_each_route_page_version_advanced_once(
+    before: [RoutePageVersion; 3],
+    after: [RoutePageVersion; 3],
+) {
+    for (before, after) in before.into_iter().zip(after) {
+        assert_eq!(after.epoch, before.epoch);
+        assert_eq!(after.generation, before.generation + 1);
+    }
+}
+
+#[test]
+fn stale_refresh_markers_do_not_invalidate_route_page_continuations() {
+    let (mut manager, peer) = refresh_test_manager();
+    let before = route_page_versions(&manager);
+
+    manager.handle_update(RibUpdate::BeginRouteRefresh {
+        peer,
+        session_id: 1,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    });
+    manager.handle_update(RibUpdate::EndRouteRefresh {
+        peer,
+        session_id: 1,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    });
+
+    assert_eq!(
+        route_page_versions(&manager),
+        before,
+        "destructive break: moving refresh invalidation ahead of the current-session fence makes stale BoRR/EoRR invalidate all continuation scopes"
+    );
+}
+
+#[test]
+fn inactive_eorr_does_not_invalidate_route_page_continuations() {
+    let (mut manager, peer) = refresh_test_manager();
+    let before = route_page_versions(&manager);
+
+    manager.handle_update(RibUpdate::EndRouteRefresh {
+        peer,
+        session_id: 0,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    });
+
+    assert_eq!(
+        route_page_versions(&manager),
+        before,
+        "destructive break: advancing before the active-family gate makes an ignored EoRR invalidate all continuation scopes"
+    );
+}
+
+#[test]
+fn stale_end_of_rib_does_not_invalidate_route_page_continuations() {
+    let (mut manager, peer) = refresh_test_manager();
+    let before = route_page_versions(&manager);
+
+    manager.handle_update(RibUpdate::EndOfRib {
+        peer,
+        session_id: 1,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    });
+
+    assert_eq!(
+        route_page_versions(&manager),
+        before,
+        "destructive break: moving page invalidation ahead of the current-session EoR fence makes a discarded marker invalidate every continuation scope"
+    );
+}
+
+#[test]
+fn accepted_end_of_rib_advances_each_route_page_version_once() {
+    // Destructive break: removing the post-fence advance makes every scope
+    // observe no step for an accepted convergence marker.
+    let (mut manager, peer) = refresh_test_manager();
+    let before = route_page_versions(&manager);
+
+    manager.handle_update(RibUpdate::EndOfRib {
+        peer,
+        session_id: 0,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    });
+
+    assert_each_route_page_version_advanced_once(before, route_page_versions(&manager));
+}
+
+#[test]
+fn accepted_refresh_work_advances_each_route_page_version_once() {
+    // Destructive breaks: removing the post-fence BoRR advance makes the first
+    // assertion red; restoring the dispatcher EoRR advance makes the second
+    // observe two steps; removing the finisher advance makes EoRR/timeout
+    // observe no step.
+    let (mut manager, peer) = refresh_test_manager();
+    let begin = || RibUpdate::BeginRouteRefresh {
+        peer,
+        session_id: 0,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    };
+    let eorr = || RibUpdate::EndRouteRefresh {
+        peer,
+        session_id: 0,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    };
+
+    let before = route_page_versions(&manager);
+    manager.handle_update(begin());
+    assert_each_route_page_version_advanced_once(before, route_page_versions(&manager));
+
+    let before = route_page_versions(&manager);
+    manager.handle_update(eorr());
+    assert_each_route_page_version_advanced_once(before, route_page_versions(&manager));
+
+    manager.handle_update(begin());
+    let before = route_page_versions(&manager);
+    manager.handle_update(RibUpdate::RouteRefreshTimeout {
+        peer,
+        session_id: 0,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    });
+    assert_each_route_page_version_advanced_once(before, route_page_versions(&manager));
+}
+
 /// A shared clean export-policy transition commits its group-membership and
 /// export-overlay flips in `Finalize`, which does not always reach the
 /// distribution-pass fence (no dirty or forced peers). General queries stay


### PR DESCRIPTION
## Summary

- move End-of-RIB and Enhanced Route Refresh page-generation changes behind current-session acceptance
- avoid invalidating paginated route queries for stale-session BoRR/EoRR/EoR and inactive EoRR markers
- preserve exactly one all-scope generation advance for accepted EoR, BoRR, EoRR, and timeout work

## Verification

- `cargo test -p rustbgpd-rib manager::tests::paged_query:: -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

## Load-bearing proofs

- restoring the unconditional pre-pass makes stale marker and inactive-EoRR assertions red
- removing the post-fence EoR or BoRR advance makes accepted-marker assertions red
- restoring the pre-pass EoRR advance makes accepted EoRR advance twice
- removing the finisher advance makes accepted EoRR and timeout observe no step

Originally stacked on #1196 so hosted CI exercised the complete route-refresh seam. #1196 is merged and this PR is now based directly on `main`; its diff is limited to page-generation fencing and regression proofs.