### PR TITLE
fix(ci): follow config resolution linkage

### DIFF
--- a/scripts/check-v1-stable-surface.py
+++ b/scripts/check-v1-stable-surface.py
@@ -378,9 +378,25 @@ def check_effective_defaults(
                 f"effective-default validation test {test!r} does not exercise {linkage[:-1]}"
             )
 
-    config_source = (ROOT / "src/config/mod.rs").read_text()
+    config_source = "\n".join(
+        (ROOT / path).read_text()
+        for path in ("src/config/mod.rs", "src/config/resolution.rs")
+    )
     peer_manager_source = (ROOT / "src/peer_manager/mod.rs").read_text()
     check_dynamic_neighbor_limit_linkage(config_source, peer_manager_source)
+    expect_checker_failure(
+        lambda: check_dynamic_neighbor_limit_linkage(
+            config_source.replace(
+                ".unwrap_or(DEFAULT_DYNAMIC_NEIGHBOR_LIMIT)",
+                ".unwrap_or(100)",
+                1,
+            ),
+            peer_manager_source,
+        ),
+        "Config::effective_dynamic_neighbor_limit must resolve the shared "
+        "DEFAULT_DYNAMIC_NEIGHBOR_LIMIT",
+        "literal dynamic-neighbor-limit fallback",
+    )
     expect_checker_failure(
         lambda: check_dynamic_neighbor_limit_linkage(
             config_source,


### PR DESCRIPTION
## Summary

- follow the `Config` resolution implementation after it moved into `src/config/resolution.rs`
- keep the existing v1 default-linkage check strict across the module split
- prove the gate rejects a literal fallback that bypasses `DEFAULT_DYNAMIC_NEIGHBOR_LIMIT`

## Red proof

The new injection replaces `.unwrap_or(DEFAULT_DYNAMIC_NEIGHBOR_LIMIT)` with `.unwrap_or(100)`. The checker must fail with the existing linkage diagnostic; without the updated source inventory, the gate fails on the current production implementation instead.

## Verification

- `python3 scripts/check-v1-stable-surface.py`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
