### PR TITLE
test(readyz): accept equal-deadline outcomes

### DIFF
--- a/src/metrics_server.rs
+++ b/src/metrics_server.rs
@@ -279,7 +279,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_readyz_returns_503_when_rib_probe_times_out() {
+    async fn get_readyz_fails_closed_when_rib_probe_reaches_deadline() {
         let (peer_tx, mut peer_rx) = mpsc::channel(1);
         let (rib_tx, mut rib_rx) = mpsc::channel(1);
         let addr = start_server(CoreReadinessProbe::new(peer_tx, rib_tx)).await;
@@ -298,7 +298,21 @@ mod tests {
 
         let response = request(addr, "/readyz").await;
         assert!(response.starts_with("HTTP/1.1 503 Service Unavailable"));
-        assert!(response.ends_with("not ready: RIB manager probe timed out (200ms deadline)\n"));
+        let body = response
+            .split_once("\r\n\r\n")
+            .map(|(_, body)| body)
+            .expect("HTTP response must contain a header/body boundary");
+        // The HTTP guard and the actor probe intentionally share the same
+        // 200 ms deadline. Either timer may win under scheduler load; both
+        // exact bodies are fail-closed, while the status above must stay 503.
+        assert!(
+            matches!(
+                body,
+                "not ready: RIB manager probe timed out (200ms deadline)\n"
+                    | "not ready: readiness probe deadline exceeded\n"
+            ),
+            "unexpected readiness deadline response: {body:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- make the `/readyz` deadline regression assert the actual equal-deadline contract
- continue requiring HTTP 503 while accepting either exact fail-closed diagnostic
- leave production readiness deadlines and behavior unchanged

## Why

The outer HTTP guard and inner RIB probe intentionally share the same 200 ms
deadline. Under scheduler load either timer can win, so requiring only the inner
diagnostic made workspace CI flaky even though both outcomes correctly fail
closed.

## Verification

- independent review: GO; production path byte-identical to main
- focused deadline, stalled-RIB, late-success, and healthy-response tests
- destructive proof: changing the stalled RIB reply to success makes the
  mandatory HTTP 503 assertion fail
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `python3 scripts/check-v1-stable-surface.py`
- `git diff --check`
