### PR TITLE
Add count-only native RIB views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `rbgp rib --count`, `rbgp rib received PEER --count`, and
+  `rbgp rib advertised PEER --count` report the exact filtered route count
+  without transferring a full route listing. Each count uses one view-correct
+  RPC and transfers at most one route row; filtered counts still require the
+  backend to scan the selected view.
+
 - `rbgp neighbor PEER refresh-out` and the
   `NeighborService.RefreshOutbound` RPC re-emit one peer's current exportable
   outbound inventory without resetting the session. The bounded single-peer

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -70,9 +70,12 @@ rbgp bfd show <addr>
 
 ```bash
 rbgp rib
+rbgp rib --count                            # best-route count only
 rbgp rib received <addr>
+rbgp rib received <addr> --count
 rbgp rib recv <addr>                        # alias
 rbgp rib advertised <addr>
+rbgp rib advertised <addr> --count
 rbgp rib sent <addr>                        # alias
 rbgp rib --prefix <prefix> --explain
 rbgp rib blackholes
@@ -105,6 +108,14 @@ rbgp flowspec
 rbgp fib-table list
 rbgp fib-table set edge --table-id 1000 --metric 200 --families ipv4_unicast,ipv6_unicast
 ```
+
+`--count` applies the same family, prefix, longer-prefix, origin-ASN, standard
+community, and large-community filters as the corresponding best, received, or
+advertised route listing. It makes exactly one request and transfers at most one
+route row, rendering `Total matching routes: N` or `{"total_count":N}` with
+`--json`. A filtered count still scans the matching backend view to compute the
+exact total; `--count` bounds response transfer, not server-side query work. It
+cannot be combined with the rejected-route or explain views.
 
 ### EVPN
 
@@ -161,6 +172,7 @@ a non-TTY.
 | Neighbor summary | `rbgp summary` or `rbgp neighbor` |
 | Received routes | `rbgp rib received <peer>` or `rbgp rib recv <peer>` |
 | Advertised routes | `rbgp rib advertised <peer>` or `rbgp rib sent <peer>` |
+| Count matching best/received/advertised routes | add `--count` to the corresponding command |
 | Explain best path | `rbgp rib --prefix <cidr> --explain` |
 | Explain export policy / gates | `rbgp rib --prefix <cidr> advertised <peer> --explain` |
 | Explain import policy | `rbgp policy explain --neighbor <peer> --prefix <cidr>` |

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -109,6 +109,62 @@ async fn fetch_all_route_pages(
     }
 }
 
+/// Fetch only the backend's exact matching-row count for one route
+/// view. A one-row page keeps the response bounded; the continuation
+/// token and row itself are deliberately ignored because `total_count`
+/// describes the complete filtered query.
+async fn fetch_route_count(
+    client: &mut RibClient,
+    rpc: &RouteListRpc,
+    mut req: ListRoutesRequest,
+) -> Result<u64, CliError> {
+    req.page_size = 1;
+    req.page_token.clear();
+    let resp = match rpc {
+        RouteListRpc::Best => client.list_best_routes(req).await?,
+        RouteListRpc::Received => client.list_received_routes(req).await?,
+        RouteListRpc::Advertised => client.list_advertised_routes(req).await?,
+    }
+    .into_inner();
+    Ok(resp.total_count)
+}
+
+fn route_count_message(total_count: u64) -> String {
+    format!("Total matching routes: {total_count}")
+}
+
+fn route_count_json(total_count: u64) -> serde_json::Value {
+    serde_json::json!({ "total_count": total_count })
+}
+
+fn print_route_count(total_count: u64, json: bool) -> Result<(), CliError> {
+    if json {
+        output::print_json_pretty(&route_count_json(total_count))
+    } else {
+        println!("{}", route_count_message(total_count));
+        Ok(())
+    }
+}
+
+async fn count_routes(
+    connection: Connection,
+    rpc: RouteListRpc,
+    neighbor: Option<&str>,
+    family: Option<i32>,
+    filters: &RouteFilterOpts,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut client =
+        RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let total_count = fetch_route_count(
+        &mut client,
+        &rpc,
+        make_route_request(neighbor, family, filters)?,
+    )
+    .await?;
+    print_route_count(total_count, json)
+}
+
 fn parse_fib_state(s: &str) -> Result<i32, CliError> {
     match s {
         "installed" => Ok(FibRouteState::Installed as i32),
@@ -1594,6 +1650,15 @@ pub async fn best(
     print_routes(&routes, json)
 }
 
+pub async fn count_best(
+    connection: Connection,
+    family: Option<i32>,
+    filters: &RouteFilterOpts,
+    json: bool,
+) -> Result<(), CliError> {
+    count_routes(connection, RouteListRpc::Best, None, family, filters, json).await
+}
+
 pub async fn blackholes(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
@@ -1692,6 +1757,24 @@ pub async fn received(
     )
     .await?;
     print_routes(&routes, json)
+}
+
+pub async fn count_received(
+    connection: Connection,
+    address: &str,
+    family: Option<i32>,
+    filters: &RouteFilterOpts,
+    json: bool,
+) -> Result<(), CliError> {
+    count_routes(
+        connection,
+        RouteListRpc::Received,
+        Some(address),
+        family,
+        filters,
+        json,
+    )
+    .await
 }
 
 /// LAN-472: list the retained rejected routes for a peer with their
@@ -1846,6 +1929,24 @@ pub async fn advertised(
     )
     .await?;
     print_routes(&routes, json)
+}
+
+pub async fn count_advertised(
+    connection: Connection,
+    address: &str,
+    family: Option<i32>,
+    filters: &RouteFilterOpts,
+    json: bool,
+) -> Result<(), CliError> {
+    count_routes(
+        connection,
+        RouteListRpc::Advertised,
+        Some(address),
+        family,
+        filters,
+        json,
+    )
+    .await
 }
 
 #[expect(
@@ -3001,6 +3102,174 @@ mod tests {
             next_page_token: next_page_token.to_string(),
             total_count: 2,
         }
+    }
+
+    fn count_filters() -> RouteFilterOpts {
+        RouteFilterOpts {
+            prefix: Some("2001:db8::/32".to_string()),
+            longer: true,
+            origin_asn: Some(64512),
+            community: vec![(64512_u32 << 16) | 100],
+            large_community: vec!["64512:1:100".to_string()],
+        }
+    }
+
+    fn count_page(total_count: u64) -> rustbgpd_api::proto::ListRoutesResponse {
+        rustbgpd_api::proto::ListRoutesResponse {
+            routes: vec![rustbgpd_api::proto::Route {
+                prefix: "2001:db8::".to_string(),
+                prefix_length: 32,
+                ..Default::default()
+            }],
+            // A count client must not follow this deliberately poisoned
+            // continuation: `total_count` already covers the query.
+            next_page_token: "poison-if-followed".to_string(),
+            total_count,
+        }
+    }
+
+    fn assert_count_request(request: &rustbgpd_api::proto::ListRoutesRequest, neighbor: &str) {
+        assert_eq!(request.neighbor_address, neighbor);
+        assert_eq!(request.afi_safi, AddressFamily::Ipv6Unicast as i32);
+        assert_eq!(request.page_size, 1);
+        assert!(request.page_token.is_empty());
+        assert_eq!(request.prefix_filter, "2001:db8::");
+        assert_eq!(request.prefix_filter_length, 32);
+        assert!(request.longer_prefixes);
+        assert_eq!(request.origin_asn, 64512);
+        assert_eq!(request.community_filter, vec![(64512_u32 << 16) | 100]);
+        assert_eq!(request.large_community_filter, vec!["64512:1:100"]);
+    }
+
+    /// Load-bearing output proof: changing the human label, JSON key, or
+    /// dropping a zero count makes these exact assertions red.
+    #[test]
+    fn route_count_output_is_exact_for_zero_and_nonzero_totals() {
+        assert_eq!(route_count_message(0), "Total matching routes: 0");
+        assert_eq!(route_count_message(27), "Total matching routes: 27");
+        assert_eq!(route_count_json(0), serde_json::json!({ "total_count": 0 }));
+        assert_eq!(
+            route_count_json(27),
+            serde_json::json!({ "total_count": 27 })
+        );
+    }
+
+    /// Load-bearing response proof: replacing the backend total with the
+    /// returned row count (one) or following the poison continuation makes
+    /// the value/call-count assertions red.
+    #[tokio::test]
+    async fn route_count_uses_backend_total_not_returned_row_count() {
+        let server = spawn_mock_server(None).await;
+        server
+            .state
+            .list_route_pages
+            .lock()
+            .await
+            .push(count_page(73));
+        server
+            .state
+            .list_route_pages
+            .lock()
+            .await
+            .push(count_page(999));
+        let connection = connect(&server.addr, None).await.unwrap();
+        let mut client =
+            RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+
+        let total = fetch_route_count(
+            &mut client,
+            &RouteListRpc::Best,
+            make_route_request(
+                None,
+                Some(AddressFamily::Ipv6Unicast as i32),
+                &count_filters(),
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(total, 73);
+        assert_eq!(
+            server
+                .state
+                .list_best_route_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+        let remaining = server.state.list_route_pages.lock().await;
+        assert_eq!(remaining.len(), 1, "poison continuation was consumed");
+        assert_eq!(remaining[0].total_count, 999);
+    }
+
+    /// Load-bearing transport proof: selecting the wrong RPC, requesting
+    /// more than one row, dropping any filter/scope, or following the poison
+    /// continuation changes a counter/request assertion and makes this red.
+    #[tokio::test]
+    async fn count_uses_one_view_correct_filtered_rpc_for_each_route_view() {
+        let server = spawn_mock_server(None).await;
+        {
+            let mut pages = server.state.list_route_pages.lock().await;
+            pages.push(count_page(11));
+            pages.push(count_page(22));
+            pages.push(count_page(33));
+        }
+        let family = Some(AddressFamily::Ipv6Unicast as i32);
+        let filters = count_filters();
+
+        count_best(
+            connect(&server.addr, None).await.unwrap(),
+            family,
+            &filters,
+            false,
+        )
+        .await
+        .unwrap();
+        count_received(
+            connect(&server.addr, None).await.unwrap(),
+            "fe80::1",
+            family,
+            &filters,
+            true,
+        )
+        .await
+        .unwrap();
+        count_advertised(
+            connect(&server.addr, None).await.unwrap(),
+            "fe80::2",
+            family,
+            &filters,
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            server
+                .state
+                .list_best_route_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+        assert_eq!(
+            server
+                .state
+                .list_received_route_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+        assert_eq!(
+            server
+                .state
+                .list_advertised_route_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+        let requests = server.state.list_route_requests.lock().await;
+        assert_eq!(requests.len(), 3, "exactly one request per view");
+        assert_count_request(&requests[0], "");
+        assert_count_request(&requests[1], "fe80::1");
+        assert_count_request(&requests[2], "fe80::2");
     }
 
     /// `rbgp rib received` follows `next_page_token` until the listing

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -169,8 +169,12 @@ enum Command {
         longer: bool,
 
         /// Show why the best route was selected (requires --prefix)
-        #[arg(long, requires = "prefix")]
+        #[arg(long, requires = "prefix", conflicts_with = "count")]
         explain: bool,
+
+        /// Print only the number of matching best, received, or advertised routes
+        #[arg(long)]
+        count: bool,
 
         /// Scope --explain to a specific peer's Add-Path send view.
         /// When set, candidates are filtered by the peer's export
@@ -1130,10 +1134,13 @@ enum RibAction {
         /// Address family filter
         #[arg(short = 'a', long)]
         family: Option<String>,
+        /// Print only the number of matching received routes
+        #[arg(long)]
+        count: bool,
         /// Show the retained rejected routes with their reject reasons
         /// instead of the accepted Adj-RIB-In (the looking-glass
         /// filtered-route view; [policy.reject_retention])
-        #[arg(long)]
+        #[arg(long, conflicts_with = "count")]
         rejected: bool,
     },
     /// Show advertised routes to a neighbor
@@ -1144,8 +1151,11 @@ enum RibAction {
         /// Address family filter
         #[arg(short = 'a', long)]
         family: Option<String>,
-        /// Explain whether this exact prefix would be advertised to the peer
+        /// Print only the number of matching advertised routes
         #[arg(long)]
+        count: bool,
+        /// Explain whether this exact prefix would be advertised to the peer
+        #[arg(long, conflicts_with = "count")]
         explain: bool,
         /// Route Distinguisher ("asn:nn" or "ip:nn") - explain the
         /// VPNv4/VPNv6 export ladder for the (RD, prefix) identity,
@@ -1650,6 +1660,49 @@ fn reject_rib_status_filters(
     Ok(())
 }
 
+fn route_count_requested(parent_count: bool, view_count: bool) -> bool {
+    parent_count || view_count
+}
+
+fn validate_rib_count_action(command: &Command) -> Result<(), CliError> {
+    let Command::Rib { action, count, .. } = command else {
+        return Ok(());
+    };
+    match action {
+        None => Ok(()),
+        Some(RibAction::Received {
+            count: view_count,
+            rejected,
+            ..
+        }) => {
+            if route_count_requested(*count, *view_count) && *rejected {
+                Err(CliError::Argument(
+                    "--count cannot be combined with --rejected".into(),
+                ))
+            } else {
+                Ok(())
+            }
+        }
+        Some(RibAction::Advertised {
+            count: view_count,
+            explain,
+            ..
+        }) => {
+            if route_count_requested(*count, *view_count) && *explain {
+                Err(CliError::Argument(
+                    "--count cannot be combined with --explain".into(),
+                ))
+            } else {
+                Ok(())
+            }
+        }
+        Some(_) if *count => Err(CliError::Argument(
+            "--count is only valid for best, received, or advertised routes".into(),
+        )),
+        Some(_) => Ok(()),
+    }
+}
+
 fn reject_events_parent_filters_for_subcommand(
     subcommand: &str,
     address: &Option<String>,
@@ -2020,6 +2073,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
     }
 
     validate_neighbor_compare_action(&cli.command)?;
+    validate_rib_count_action(&cli.command)?;
     let connection = connect(&cli.addr, cli.token_file.as_deref()).await?;
     let json = cli.json;
 
@@ -2197,6 +2251,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
             prefix,
             longer,
             explain,
+            count,
             explain_peer,
             origin_asn,
             community,
@@ -2391,6 +2446,8 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                             json,
                         )
                         .await
+                    } else if count {
+                        commands::rib::count_best(connection, family_val, &filters, json).await
                     } else {
                         commands::rib::best(connection, family_val, &filters, json).await
                     }
@@ -2398,8 +2455,10 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                 Some(RibAction::Received {
                     address,
                     family: fam,
+                    count: count_received,
                     rejected,
                 }) => {
+                    let count = route_count_requested(count, count_received);
                     if explain {
                         return Err(CliError::Argument(
                             "--explain is only valid for the default best-routes view (rib --prefix X --explain)".into(),
@@ -2409,17 +2468,23 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                         return commands::rib::rejected(connection, &address, json).await;
                     }
                     let f = resolve_family(&fam.or(family))?;
-                    commands::rib::received(connection, &address, f, &filters, json).await
+                    if count {
+                        commands::rib::count_received(connection, &address, f, &filters, json).await
+                    } else {
+                        commands::rib::received(connection, &address, f, &filters, json).await
+                    }
                 }
                 Some(RibAction::Advertised {
                     address,
                     family: fam,
+                    count: count_advertised,
                     explain: explain_advertised,
                     rd,
                     labeled,
                     source_peer,
                     source_path_id,
                 }) => {
+                    let count = route_count_requested(count, count_advertised);
                     if explain {
                         return Err(CliError::Argument(
                             "--explain is only valid for the default best-routes view (rib --prefix X --explain)".into(),
@@ -2457,6 +2522,9 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                             json,
                         )
                         .await
+                    } else if count {
+                        commands::rib::count_advertised(connection, &address, f, &filters, json)
+                            .await
                     } else {
                         commands::rib::advertised(connection, &address, f, &filters, json).await
                     }
@@ -3036,6 +3104,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::spawn_mock_server;
     use clap::Parser;
 
     #[test]
@@ -3611,6 +3680,243 @@ mod tests {
         } else {
             panic!("expected Rib Received command");
         }
+    }
+
+    /// Load-bearing parser proof: removing either local flag, making
+    /// `--count` global, or dropping a conflict makes one of these accepted
+    /// shapes or rejection assertions red.
+    #[test]
+    fn rib_count_has_natural_view_scoped_placement_and_conflicts() {
+        let best = Cli::try_parse_from(["rbgp", "rib", "--count"]).unwrap();
+        assert!(matches!(
+            best.command,
+            Command::Rib {
+                action: None,
+                count: true,
+                ..
+            }
+        ));
+
+        for args in [
+            vec!["rbgp", "rib", "--count", "received", "192.0.2.1"],
+            vec!["rbgp", "rib", "received", "192.0.2.1", "--count"],
+            vec!["rbgp", "rib", "--count", "advertised", "192.0.2.2"],
+            vec!["rbgp", "rib", "advertised", "192.0.2.2", "--count"],
+        ] {
+            Cli::try_parse_from(args).expect("both natural count placements parse");
+        }
+        assert!(route_count_requested(true, false));
+        assert!(route_count_requested(false, true));
+        assert!(!route_count_requested(false, false));
+
+        assert!(
+            Cli::try_parse_from([
+                "rbgp",
+                "rib",
+                "--prefix",
+                "203.0.113.0/24",
+                "--count",
+                "--explain",
+            ])
+            .is_err()
+        );
+        assert!(
+            Cli::try_parse_from([
+                "rbgp",
+                "rib",
+                "received",
+                "192.0.2.1",
+                "--count",
+                "--rejected",
+            ])
+            .is_err()
+        );
+        assert!(
+            Cli::try_parse_from([
+                "rbgp",
+                "rib",
+                "advertised",
+                "192.0.2.2",
+                "--count",
+                "--explain",
+            ])
+            .is_err()
+        );
+
+        let parent_received = Cli::try_parse_from([
+            "rbgp",
+            "rib",
+            "--count",
+            "received",
+            "192.0.2.1",
+            "--rejected",
+        ])
+        .unwrap();
+        assert_eq!(
+            validate_rib_count_action(&parent_received.command)
+                .unwrap_err()
+                .to_string(),
+            "--count cannot be combined with --rejected"
+        );
+        let parent_advertised = Cli::try_parse_from([
+            "rbgp",
+            "rib",
+            "--prefix",
+            "203.0.113.0/24",
+            "--count",
+            "advertised",
+            "192.0.2.2",
+            "--explain",
+        ])
+        .unwrap();
+        assert_eq!(
+            validate_rib_count_action(&parent_advertised.command)
+                .unwrap_err()
+                .to_string(),
+            "--count cannot be combined with --explain"
+        );
+    }
+
+    /// Load-bearing scope proof: making the local flag global lets unsupported
+    /// local placements parse, while deleting a parent action guard makes its
+    /// validator assertion succeed unexpectedly.
+    #[test]
+    fn rib_count_is_rejected_by_unrelated_subcommands() {
+        for subcommand in ["blackholes", "fib", "bgpls", "vpn", "labeled", "rtc"] {
+            assert!(
+                Cli::try_parse_from(["rbgp", "rib", subcommand, "--count"]).is_err(),
+                "rib {subcommand} unexpectedly accepted --count"
+            );
+            let parent_form = Cli::try_parse_from(["rbgp", "rib", "--count", subcommand]).unwrap();
+            assert_eq!(
+                validate_rib_count_action(&parent_form.command)
+                    .unwrap_err()
+                    .to_string(),
+                "--count is only valid for best, received, or advertised routes"
+            );
+        }
+    }
+
+    /// Load-bearing preflight proof: bypassing the validator reaches the
+    /// deliberately unreachable transport instead of returning this argument
+    /// error for each unsupported RIB action class.
+    #[tokio::test]
+    async fn rib_parent_count_rejects_unrelated_actions_before_transport() {
+        for subcommand in ["blackholes", "fib", "bgpls", "vpn", "labeled", "rtc"] {
+            let cli = Cli::try_parse_from([
+                "rbgp",
+                "--addr",
+                "http://127.0.0.1:1",
+                "rib",
+                "--count",
+                subcommand,
+            ])
+            .unwrap();
+            assert_eq!(
+                run(cli, BINARY_NAME).await.unwrap_err().to_string(),
+                "--count is only valid for best, received, or advertised routes",
+                "rib {subcommand} did not fail before transport"
+            );
+        }
+    }
+
+    /// Load-bearing fail-closed proof: removing the pre-connect count
+    /// validator makes these commands reach AddPath/DeletePath and increments
+    /// the corresponding mutation counter.
+    #[tokio::test]
+    async fn rib_parent_count_never_reaches_route_mutation_rpcs() {
+        let server = spawn_mock_server(None).await;
+        let add = Cli::try_parse_from([
+            "rbgp",
+            "--addr",
+            &server.addr,
+            "rib",
+            "--count",
+            "add",
+            "203.0.113.0/24",
+            "--nexthop",
+            "192.0.2.1",
+        ])
+        .unwrap();
+        assert_eq!(
+            run(add, BINARY_NAME).await.unwrap_err().to_string(),
+            "--count is only valid for best, received, or advertised routes"
+        );
+        let delete = Cli::try_parse_from([
+            "rbgp",
+            "--addr",
+            &server.addr,
+            "rib",
+            "--count",
+            "delete",
+            "203.0.113.0/24",
+        ])
+        .unwrap();
+        assert_eq!(
+            run(delete, BINARY_NAME).await.unwrap_err().to_string(),
+            "--count is only valid for best, received, or advertised routes"
+        );
+        assert_eq!(
+            server
+                .state
+                .add_path_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+        assert_eq!(
+            server
+                .state
+                .delete_path_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+    }
+
+    /// Load-bearing parent-conflict proof: bypassing the pre-connect
+    /// validator makes rejected-route or export-explain RPC evidence appear.
+    #[tokio::test]
+    async fn rib_parent_count_conflicts_before_rejected_or_explain_rpcs() {
+        let server = spawn_mock_server(None).await;
+        let received = Cli::try_parse_from([
+            "rbgp",
+            "--addr",
+            &server.addr,
+            "rib",
+            "--count",
+            "received",
+            "192.0.2.1",
+            "--rejected",
+        ])
+        .unwrap();
+        assert_eq!(
+            run(received, BINARY_NAME).await.unwrap_err().to_string(),
+            "--count cannot be combined with --rejected"
+        );
+        let advertised = Cli::try_parse_from([
+            "rbgp",
+            "--addr",
+            &server.addr,
+            "rib",
+            "--prefix",
+            "203.0.113.0/24",
+            "--count",
+            "advertised",
+            "192.0.2.2",
+            "--explain",
+        ])
+        .unwrap();
+        assert_eq!(
+            run(advertised, BINARY_NAME).await.unwrap_err().to_string(),
+            "--count cannot be combined with --explain"
+        );
+        assert_eq!(
+            server
+                .state
+                .list_rejected_route_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+        assert!(server.state.last_explain_advertised.lock().await.is_none());
     }
 
     #[test]

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -20,6 +20,7 @@ use rustbgpd_api::proto::control_service_server::ControlServiceServer;
 use rustbgpd_api::proto::event_service_server::EventServiceServer;
 use rustbgpd_api::proto::evpn_service_server::EvpnServiceServer;
 use rustbgpd_api::proto::global_service_server::GlobalServiceServer;
+use rustbgpd_api::proto::injection_service_server::InjectionServiceServer;
 use rustbgpd_api::proto::neighbor_service_server::NeighborServiceServer;
 use rustbgpd_api::proto::peer_group_service_server::PeerGroupServiceServer;
 use rustbgpd_api::proto::policy_service_server::PolicyServiceServer;
@@ -94,6 +95,12 @@ pub(crate) struct MockState {
     // Empty = every call returns an empty final page.
     pub(crate) list_route_pages: Mutex<Vec<server_proto::ListRoutesResponse>>,
     pub(crate) list_route_requests: Mutex<Vec<server_proto::ListRoutesRequest>>,
+    pub(crate) list_best_route_calls: AtomicUsize,
+    pub(crate) list_received_route_calls: AtomicUsize,
+    pub(crate) list_advertised_route_calls: AtomicUsize,
+    pub(crate) add_path_calls: AtomicUsize,
+    pub(crate) delete_path_calls: AtomicUsize,
+    pub(crate) list_rejected_route_calls: AtomicUsize,
     // Canned ListNeighbors response — drives `rbgp diff` peer-availability
     // gating. Empty = no neighbors configured on the daemon.
     pub(crate) list_neighbors_response: Mutex<Vec<server_proto::NeighborState>>,
@@ -223,6 +230,9 @@ pub(crate) async fn spawn_mock_server(auth_token: Option<&str>) -> MockServerHan
     let rib = MockRibService {
         state: Arc::clone(&state),
     };
+    let injection = MockInjectionService {
+        state: Arc::clone(&state),
+    };
     let evpn = MockEvpnService;
     let event = MockEventService {
         state: Arc::clone(&state),
@@ -254,6 +264,10 @@ pub(crate) async fn spawn_mock_server(auth_token: Option<&str>) -> MockServerHan
                 interceptor.clone(),
             ))
             .add_service(RibServiceServer::with_interceptor(rib, interceptor.clone()))
+            .add_service(InjectionServiceServer::with_interceptor(
+                injection,
+                interceptor.clone(),
+            ))
             .add_service(EvpnServiceServer::with_interceptor(
                 evpn,
                 interceptor.clone(),
@@ -316,6 +330,9 @@ pub(crate) async fn spawn_mock_uds_server(
     let rib = MockRibService {
         state: Arc::clone(&state),
     };
+    let injection = MockInjectionService {
+        state: Arc::clone(&state),
+    };
     let evpn = MockEvpnService;
     let event = MockEventService {
         state: Arc::clone(&state),
@@ -347,6 +364,10 @@ pub(crate) async fn spawn_mock_uds_server(
                 interceptor.clone(),
             ))
             .add_service(RibServiceServer::with_interceptor(rib, interceptor.clone()))
+            .add_service(InjectionServiceServer::with_interceptor(
+                injection,
+                interceptor.clone(),
+            ))
             .add_service(EvpnServiceServer::with_interceptor(
                 evpn,
                 interceptor.clone(),
@@ -981,6 +1002,61 @@ struct MockRibService {
     state: Arc<MockState>,
 }
 
+struct MockInjectionService {
+    state: Arc<MockState>,
+}
+
+#[tonic::async_trait]
+impl rustbgpd_api::proto::injection_service_server::InjectionService for MockInjectionService {
+    async fn add_path(
+        &self,
+        _request: Request<server_proto::AddPathRequest>,
+    ) -> Result<Response<server_proto::AddPathResponse>, Status> {
+        self.state.add_path_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(Response::new(server_proto::AddPathResponse::default()))
+    }
+
+    async fn delete_path(
+        &self,
+        _request: Request<server_proto::DeletePathRequest>,
+    ) -> Result<Response<server_proto::DeletePathResponse>, Status> {
+        self.state.delete_path_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(Response::new(server_proto::DeletePathResponse::default()))
+    }
+
+    async fn add_flow_spec(
+        &self,
+        _request: Request<server_proto::AddFlowSpecRequest>,
+    ) -> Result<Response<server_proto::AddFlowSpecResponse>, Status> {
+        Ok(Response::new(server_proto::AddFlowSpecResponse::default()))
+    }
+
+    async fn delete_flow_spec(
+        &self,
+        _request: Request<server_proto::DeleteFlowSpecRequest>,
+    ) -> Result<Response<server_proto::DeleteFlowSpecResponse>, Status> {
+        Ok(Response::new(
+            server_proto::DeleteFlowSpecResponse::default(),
+        ))
+    }
+
+    async fn add_evpn_route(
+        &self,
+        _request: Request<server_proto::AddEvpnRouteRequest>,
+    ) -> Result<Response<server_proto::AddEvpnRouteResponse>, Status> {
+        Ok(Response::new(server_proto::AddEvpnRouteResponse::default()))
+    }
+
+    async fn delete_evpn_route(
+        &self,
+        _request: Request<server_proto::DeleteEvpnRouteRequest>,
+    ) -> Result<Response<server_proto::DeleteEvpnRouteResponse>, Status> {
+        Ok(Response::new(
+            server_proto::DeleteEvpnRouteResponse::default(),
+        ))
+    }
+}
+
 struct MockWatchRoutesStream {
     state: Arc<MockState>,
     clean_end: bool,
@@ -1306,6 +1382,9 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         &self,
         request: Request<server_proto::ListRoutesRequest>,
     ) -> Result<Response<server_proto::ListRoutesResponse>, Status> {
+        self.state
+            .list_received_route_calls
+            .fetch_add(1, Ordering::SeqCst);
         Ok(Response::new(
             self.next_route_page(request.into_inner()).await,
         ))
@@ -1315,6 +1394,9 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         &self,
         request: Request<server_proto::ListRoutesRequest>,
     ) -> Result<Response<server_proto::ListRoutesResponse>, Status> {
+        self.state
+            .list_best_route_calls
+            .fetch_add(1, Ordering::SeqCst);
         Ok(Response::new(
             self.next_route_page(request.into_inner()).await,
         ))
@@ -1324,6 +1406,9 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         &self,
         request: Request<server_proto::ListRoutesRequest>,
     ) -> Result<Response<server_proto::ListRoutesResponse>, Status> {
+        self.state
+            .list_advertised_route_calls
+            .fetch_add(1, Ordering::SeqCst);
         Ok(Response::new(
             self.next_route_page(request.into_inner()).await,
         ))
@@ -1939,6 +2024,9 @@ impl rustbgpd_api::proto::policy_service_server::PolicyService for MockPolicySer
         &self,
         request: Request<server_proto::ListRejectedRoutesRequest>,
     ) -> Result<Response<server_proto::ListRejectedRoutesResponse>, Status> {
+        self.state
+            .list_rejected_route_calls
+            .fetch_add(1, Ordering::SeqCst);
         let req = request.into_inner();
         Ok(Response::new(server_proto::ListRejectedRoutesResponse {
             peer_address: req.peer_address,

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -692,7 +692,8 @@ _arguments "${_arguments_options[@]}" : \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '-l[Show longer (more specific) prefixes matching --prefix]' \
 '--longer[Show longer (more specific) prefixes matching --prefix]' \
-'--explain[Show why the best route was selected (requires --prefix)]' \
+'(--count)--explain[Show why the best route was selected (requires --prefix)]' \
+'--count[Print only the number of matching best, received, or advertised routes]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -715,7 +716,8 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
-'--rejected[Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; \[policy.reject_retention\])]' \
+'--count[Print only the number of matching received routes]' \
+'(--count)--rejected[Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; \[policy.reject_retention\])]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -731,7 +733,8 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
-'--rejected[Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; \[policy.reject_retention\])]' \
+'--count[Print only the number of matching received routes]' \
+'(--count)--rejected[Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; \[policy.reject_retention\])]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -750,7 +753,8 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
-'--explain[Explain whether this exact prefix would be advertised to the peer]' \
+'--count[Print only the number of matching advertised routes]' \
+'(--count)--explain[Explain whether this exact prefix would be advertised to the peer]' \
 '(--rd)--labeled[Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
@@ -770,7 +774,8 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
-'--explain[Explain whether this exact prefix would be advertised to the peer]' \
+'--count[Print only the number of matching advertised routes]' \
+'(--count)--explain[Explain whether this exact prefix would be advertised to the peer]' \
 '(--rd)--labeled[Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -7687,7 +7687,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib)
-            opts="-a -p -l -c -s -j -h --family --prefix --longer --explain --explain-peer --origin-asn --community --large-community --addr --token-file --json --no-color --help received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help"
+            opts="-a -p -l -c -s -j -h --family --prefix --longer --explain --count --explain-peer --origin-asn --community --large-community --addr --token-file --json --no-color --help received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7807,7 +7807,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__advertised)
-            opts="-a -s -j -h --family --explain --rd --labeled --source-peer --source-path-id --addr --token-file --json --no-color --help"
+            opts="-a -s -j -h --family --count --explain --rd --labeled --source-peer --source-path-id --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8223,7 +8223,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__received)
-            opts="-a -s -j -h --family --rejected --addr --token-file --json --no-color --help"
+            opts="-a -s -j -h --family --count --rejected --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -327,6 +327,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s l -l longer -d 'Show longer (more specific) prefixes matching --prefix'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l explain -d 'Show why the best route was selected (requires --prefix)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l count -d 'Print only the number of matching best, received, or advertised routes'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -347,6 +348,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s a -l family -d 'Address family filter' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l count -d 'Print only the number of matching received routes'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l rejected -d 'Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; [policy.reject_retention])'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l no-color -d 'Disable colored output'
@@ -354,6 +356,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s a -l family -d 'Address family filter' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l count -d 'Print only the number of matching received routes'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l rejected -d 'Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; [policy.reject_retention])'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l no-color -d 'Disable colored output'
@@ -364,6 +367,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l source-path-id -d 'Inbound RFC 7911 path identifier of the exact source candidate; zero is valid and distinct from omitting the selector' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l count -d 'Print only the number of matching advertised routes'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l explain -d 'Explain whether this exact prefix would be advertised to the peer'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l labeled -d 'Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s j -l json -d 'Output in JSON format'
@@ -375,6 +379,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l source-path-id -d 'Inbound RFC 7911 path identifier of the exact source candidate; zero is valid and distinct from omitting the selector' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l count -d 'Print only the number of matching advertised routes'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l explain -d 'Explain whether this exact prefix would be advertised to the peer'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l labeled -d 'Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s j -l json -d 'Output in JSON format'


### PR DESCRIPTION
## Summary

- add count-only output for native best, received, and advertised RIB views
- issue one view-correct route-list RPC with `page_size = 1`, preserve every active filter and peer scope, and use the backend's exact `total_count`
- reject incompatible, unsupported, and mutating parent-form `--count` commands before transport or RPC dispatch
- document the response-transfer bound and the remaining backend scan cost

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-v1-stable-surface.py`
- `git diff --check`
- repository pre-push quartet
- independent final diff review

## Load-bearing regression proof

- changing the count request to `page_size = 2`, selecting the wrong view RPC, or dropping a filter makes the exact request and per-view call-count assertions red
- following the deliberately poisoned continuation token or using the returned row count instead of `total_count` makes the response proof red
- changing the human label or JSON key makes the exact zero/nonzero output assertions red
- bypassing the pre-connect validator makes Add/Delete reach the mock mutation service, rejected/export-explain reach their RPCs, and unsupported status actions reach transport
