### PR TITLE
Expose complete native RIB route facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Native `rbgp rib` JSON now exposes raw ordered `extended_communities`,
+  `aspa_state` when the daemon supplies it, and
+  `received_at_epoch_seconds` (including the zero unknown sentinel) for best,
+  received, advertised, and embedded best-path-explain routes. Human best,
+  received, and advertised tables accept `--age` to append the original route
+  receive age without changing the default table.
+
 - `rbgp rib --count`, `rbgp rib received PEER --count`, and
   `rbgp rib advertised PEER --count` report the exact filtered route count
   without transferring a full route listing. Each count uses one view-correct

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -70,11 +70,14 @@ rbgp bfd show <addr>
 
 ```bash
 rbgp rib
+rbgp rib --age                              # append original receive age
 rbgp rib --count                            # best-route count only
 rbgp rib received <addr>
+rbgp rib received <addr> --age
 rbgp rib received <addr> --count
 rbgp rib recv <addr>                        # alias
 rbgp rib advertised <addr>
+rbgp rib advertised <addr> --age
 rbgp rib advertised <addr> --count
 rbgp rib sent <addr>                        # alias
 rbgp rib --prefix <prefix> --explain
@@ -116,6 +119,15 @@ route row, rendering `Total matching routes: N` or `{"total_count":N}` with
 `--json`. A filtered count still scans the matching backend view to compute the
 exact total; `--count` bounds response transfer, not server-side query work. It
 cannot be combined with the rejected-route or explain views.
+
+`--age` appends an `Age` column to the human best, received, or advertised
+route table. It is the age of the original RIB receive event, including in the
+advertised view; it is not the age of the advertisement. Unknown timestamps
+render as `-`, and future timestamps clamp to `00:00:00`. Because the daemon
+supplies an epoch timestamp and the CLI reads its local clock, running the CLI
+on another host can expose clock skew. `--age` cannot be combined with
+`--count`, rejected-route output, or either explain view. JSON is unchanged by
+the flag and always includes the raw `received_at_epoch_seconds` field.
 
 ### EVPN
 

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -306,13 +306,17 @@ fn make_labeled_request(
     })
 }
 
-fn print_routes(routes: &[crate::proto::Route], json: bool) -> Result<(), CliError> {
+fn print_routes(
+    routes: &[crate::proto::Route],
+    show_age: bool,
+    json: bool,
+) -> Result<(), CliError> {
     if json {
         output::print_json_pretty(&JsonRoutes(routes))?;
     } else if routes.is_empty() {
         println!("No routes");
     } else {
-        output::print_route_table(routes);
+        output::print_route_table(routes, show_age);
     }
     Ok(())
 }
@@ -752,11 +756,14 @@ impl Serialize for JsonRouteRef<'_> {
         S: Serializer,
     {
         let route = self.route;
-        let mut len = 10;
+        let mut len = 12;
         if route.path_id != 0 {
             len += 1;
         }
         if !route.validation_state.is_empty() {
+            len += 1;
+        }
+        if !route.aspa_state.is_empty() {
             len += 1;
         }
         if route.stale {
@@ -786,6 +793,7 @@ impl Serialize for JsonRouteRef<'_> {
         map.serialize_entry("best", &route.best)?;
         map.serialize_entry("peer_address", &route.peer_address)?;
         map.serialize_entry("communities", &JsonCommunities(&route.communities))?;
+        map.serialize_entry("extended_communities", &route.extended_communities)?;
         map.serialize_entry("large_communities", &route.large_communities)?;
         if route.path_id != 0 {
             map.serialize_entry("path_id", &route.path_id)?;
@@ -793,6 +801,13 @@ impl Serialize for JsonRouteRef<'_> {
         if !route.validation_state.is_empty() {
             map.serialize_entry("validation_state", &route.validation_state)?;
         }
+        if !route.aspa_state.is_empty() {
+            map.serialize_entry("aspa_state", &route.aspa_state)?;
+        }
+        map.serialize_entry(
+            "received_at_epoch_seconds",
+            &route.received_at_epoch_seconds,
+        )?;
         if route.stale {
             map.serialize_entry("stale", &route.stale)?;
         }
@@ -1637,6 +1652,7 @@ pub async fn best(
     connection: Connection,
     family: Option<i32>,
     filters: &RouteFilterOpts,
+    show_age: bool,
     json: bool,
 ) -> Result<(), CliError> {
     let mut client =
@@ -1647,7 +1663,7 @@ pub async fn best(
         make_route_request(None, family, filters)?,
     )
     .await?;
-    print_routes(&routes, json)
+    print_routes(&routes, show_age, json)
 }
 
 pub async fn count_best(
@@ -1746,6 +1762,7 @@ pub async fn received(
     address: &str,
     family: Option<i32>,
     filters: &RouteFilterOpts,
+    show_age: bool,
     json: bool,
 ) -> Result<(), CliError> {
     let mut client =
@@ -1756,7 +1773,7 @@ pub async fn received(
         make_route_request(Some(address), family, filters)?,
     )
     .await?;
-    print_routes(&routes, json)
+    print_routes(&routes, show_age, json)
 }
 
 pub async fn count_received(
@@ -1918,6 +1935,7 @@ pub async fn advertised(
     address: &str,
     family: Option<i32>,
     filters: &RouteFilterOpts,
+    show_age: bool,
     json: bool,
 ) -> Result<(), CliError> {
     let mut client =
@@ -1928,7 +1946,7 @@ pub async fn advertised(
         make_route_request(Some(address), family, filters)?,
     )
     .await?;
-    print_routes(&routes, json)
+    print_routes(&routes, show_age, json)
 }
 
 pub async fn count_advertised(
@@ -2068,9 +2086,12 @@ mod tests {
                 .iter()
                 .map(|c| output::format_community(*c))
                 .collect(),
+            extended_communities: r.extended_communities.clone(),
             large_communities: r.large_communities.clone(),
             path_id: r.path_id,
             validation_state: r.validation_state.clone(),
+            aspa_state: r.aspa_state.clone(),
+            received_at_epoch_seconds: r.received_at_epoch_seconds,
         }
     }
 
@@ -2136,9 +2157,12 @@ mod tests {
             best: true,
             peer_address: "192.0.2.1".to_string(),
             communities: vec![rustbgpd_wire::COMMUNITY_NO_EXPORT, (64512_u32 << 16) | 100],
+            extended_communities: vec![0x0002_fc00_0000_0064, 0x4004_c000_0201_0032],
             large_communities: vec!["64512:1:100".to_string()],
             path_id,
             validation_state: validation_state.to_string(),
+            aspa_state: "valid".to_string(),
+            received_at_epoch_seconds: 1_750_000_000,
             ..Default::default()
         }
     }
@@ -2793,6 +2817,34 @@ mod tests {
         assert_eq!(direct, legacy);
     }
 
+    /// Load-bearing native-route fact proof: dropping the raw extended
+    /// communities or receive epoch, reordering the extended communities,
+    /// omitting the genuine ASPA `unknown` state, or emitting the empty
+    /// compatibility sentinel makes an exact assertion red.
+    #[test]
+    fn route_list_json_exposes_native_route_facts_without_collapsing_unknowns() {
+        let mut absent = route_for_json(0, "");
+        absent.extended_communities = vec![9, 3, 7];
+        absent.aspa_state.clear();
+        absent.received_at_epoch_seconds = 0;
+        let mut unknown = route_for_json(0, "");
+        unknown.extended_communities = vec![11, 5];
+        unknown.aspa_state = "unknown".to_string();
+        unknown.received_at_epoch_seconds = 42;
+
+        let value: serde_json::Value =
+            serde_json::to_value(JsonRoutes(&[absent, unknown])).unwrap();
+        assert_eq!(
+            value[0]["extended_communities"],
+            serde_json::json!([9, 3, 7])
+        );
+        assert!(value[0].get("aspa_state").is_none());
+        assert_eq!(value[0]["received_at_epoch_seconds"], 0);
+        assert_eq!(value[1]["extended_communities"], serde_json::json!([11, 5]));
+        assert_eq!(value[1]["aspa_state"], "unknown");
+        assert_eq!(value[1]["received_at_epoch_seconds"], 42);
+    }
+
     #[test]
     fn route_list_json_honors_med_absence_marker() {
         // MED-absence-aware daemon: `med_attr` present somewhere in
@@ -3284,9 +3336,16 @@ mod tests {
         }
 
         let connection = connect(&server.addr, None).await.unwrap();
-        received(connection, "192.0.2.1", None, &no_route_filters(), false)
-            .await
-            .unwrap();
+        received(
+            connection,
+            "192.0.2.1",
+            None,
+            &no_route_filters(),
+            false,
+            false,
+        )
+        .await
+        .unwrap();
 
         let requests = server.state.list_route_requests.lock().await;
         assert_eq!(requests.len(), 2, "one RPC per page");
@@ -3306,7 +3365,7 @@ mod tests {
         }
 
         let connection = connect(&server.addr, None).await.unwrap();
-        best(connection, None, &no_route_filters(), false)
+        best(connection, None, &no_route_filters(), false, false)
             .await
             .unwrap();
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -173,8 +173,12 @@ enum Command {
         explain: bool,
 
         /// Print only the number of matching best, received, or advertised routes
-        #[arg(long)]
+        #[arg(long, conflicts_with = "age")]
         count: bool,
+
+        /// Append the original route receive age to best, received, or advertised rows
+        #[arg(long, conflicts_with = "explain")]
+        age: bool,
 
         /// Scope --explain to a specific peer's Add-Path send view.
         /// When set, candidates are filtered by the peer's export
@@ -1135,8 +1139,11 @@ enum RibAction {
         #[arg(short = 'a', long)]
         family: Option<String>,
         /// Print only the number of matching received routes
-        #[arg(long)]
+        #[arg(long, conflicts_with = "age")]
         count: bool,
+        /// Append the original route receive age
+        #[arg(long, conflicts_with = "rejected")]
+        age: bool,
         /// Show the retained rejected routes with their reject reasons
         /// instead of the accepted Adj-RIB-In (the looking-glass
         /// filtered-route view; [policy.reject_retention])
@@ -1152,8 +1159,11 @@ enum RibAction {
         #[arg(short = 'a', long)]
         family: Option<String>,
         /// Print only the number of matching advertised routes
-        #[arg(long)]
+        #[arg(long, conflicts_with = "age")]
         count: bool,
+        /// Append the original route receive age
+        #[arg(long, conflicts_with = "explain")]
+        age: bool,
         /// Explain whether this exact prefix would be advertised to the peer
         #[arg(long, conflicts_with = "count")]
         explain: bool,
@@ -1664,6 +1674,10 @@ fn route_count_requested(parent_count: bool, view_count: bool) -> bool {
     parent_count || view_count
 }
 
+fn route_age_requested(parent_age: bool, view_age: bool) -> bool {
+    parent_age || view_age
+}
+
 fn validate_rib_count_action(command: &Command) -> Result<(), CliError> {
     let Command::Rib { action, count, .. } = command else {
         return Ok(());
@@ -1698,6 +1712,68 @@ fn validate_rib_count_action(command: &Command) -> Result<(), CliError> {
         }
         Some(_) if *count => Err(CliError::Argument(
             "--count is only valid for best, received, or advertised routes".into(),
+        )),
+        Some(_) => Ok(()),
+    }
+}
+
+fn validate_rib_age_action(command: &Command) -> Result<(), CliError> {
+    let Command::Rib {
+        action,
+        count,
+        age,
+        explain: parent_explain,
+        ..
+    } = command
+    else {
+        return Ok(());
+    };
+    match action {
+        None => Ok(()),
+        Some(RibAction::Received {
+            count: view_count,
+            age: view_age,
+            rejected,
+            ..
+        }) => {
+            let age = route_age_requested(*age, *view_age);
+            if age && route_count_requested(*count, *view_count) {
+                Err(CliError::Argument(
+                    "--age cannot be combined with --count".into(),
+                ))
+            } else if age && *parent_explain {
+                Err(CliError::Argument(
+                    "--age cannot be combined with --explain".into(),
+                ))
+            } else if age && *rejected {
+                Err(CliError::Argument(
+                    "--age cannot be combined with --rejected".into(),
+                ))
+            } else {
+                Ok(())
+            }
+        }
+        Some(RibAction::Advertised {
+            count: view_count,
+            age: view_age,
+            explain,
+            ..
+        }) => {
+            let age = route_age_requested(*age, *view_age);
+            if age && route_count_requested(*count, *view_count) {
+                Err(CliError::Argument(
+                    "--age cannot be combined with --count".into(),
+                ))
+            } else if age && (*parent_explain || *explain) {
+                Err(CliError::Argument(
+                    "--age cannot be combined with --explain".into(),
+                ))
+            } else {
+                Ok(())
+            }
+        }
+        Some(_) if *age => Err(CliError::Argument(
+            "--age is only valid for best, received, or advertised routes".into(),
         )),
         Some(_) => Ok(()),
     }
@@ -2074,6 +2150,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
 
     validate_neighbor_compare_action(&cli.command)?;
     validate_rib_count_action(&cli.command)?;
+    validate_rib_age_action(&cli.command)?;
     let connection = connect(&cli.addr, cli.token_file.as_deref()).await?;
     let json = cli.json;
 
@@ -2252,6 +2329,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
             longer,
             explain,
             count,
+            age,
             explain_peer,
             origin_asn,
             community,
@@ -2449,16 +2527,18 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     } else if count {
                         commands::rib::count_best(connection, family_val, &filters, json).await
                     } else {
-                        commands::rib::best(connection, family_val, &filters, json).await
+                        commands::rib::best(connection, family_val, &filters, age, json).await
                     }
                 }
                 Some(RibAction::Received {
                     address,
                     family: fam,
                     count: count_received,
+                    age: age_received,
                     rejected,
                 }) => {
                     let count = route_count_requested(count, count_received);
+                    let age = route_age_requested(age, age_received);
                     if explain {
                         return Err(CliError::Argument(
                             "--explain is only valid for the default best-routes view (rib --prefix X --explain)".into(),
@@ -2471,13 +2551,14 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     if count {
                         commands::rib::count_received(connection, &address, f, &filters, json).await
                     } else {
-                        commands::rib::received(connection, &address, f, &filters, json).await
+                        commands::rib::received(connection, &address, f, &filters, age, json).await
                     }
                 }
                 Some(RibAction::Advertised {
                     address,
                     family: fam,
                     count: count_advertised,
+                    age: age_advertised,
                     explain: explain_advertised,
                     rd,
                     labeled,
@@ -2485,6 +2566,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     source_path_id,
                 }) => {
                     let count = route_count_requested(count, count_advertised);
+                    let age = route_age_requested(age, age_advertised);
                     if explain {
                         return Err(CliError::Argument(
                             "--explain is only valid for the default best-routes view (rib --prefix X --explain)".into(),
@@ -2526,7 +2608,8 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                         commands::rib::count_advertised(connection, &address, f, &filters, json)
                             .await
                     } else {
-                        commands::rib::advertised(connection, &address, f, &filters, json).await
+                        commands::rib::advertised(connection, &address, f, &filters, age, json)
+                            .await
                     }
                 }
                 Some(
@@ -3917,6 +4000,151 @@ mod tests {
             0
         );
         assert!(server.state.last_explain_advertised.lock().await.is_none());
+    }
+
+    /// Load-bearing placement/conflict proof: removing either local age flag,
+    /// making it global, dropping the parent/local OR, or removing a direct
+    /// Clap conflict makes an exact parse or helper assertion red.
+    #[test]
+    fn rib_age_has_natural_view_scoped_placement_and_direct_conflicts() {
+        let best = Cli::try_parse_from(["rbgp", "rib", "--age"]).unwrap();
+        assert!(matches!(
+            best.command,
+            Command::Rib {
+                action: None,
+                age: true,
+                ..
+            }
+        ));
+
+        for args in [
+            "rbgp rib --age received 192.0.2.1",
+            "rbgp rib received 192.0.2.1 --age",
+            "rbgp rib --age advertised 192.0.2.2",
+            "rbgp rib advertised 192.0.2.2 --age",
+        ] {
+            Cli::try_parse_from(args.split_whitespace())
+                .expect("both natural age placements parse");
+        }
+        assert!(route_age_requested(true, false));
+        assert!(route_age_requested(false, true));
+        assert!(!route_age_requested(false, false));
+
+        for args in [
+            "rbgp rib --age --count",
+            "rbgp rib --prefix 203.0.113.0/24 --age --explain",
+            "rbgp rib received 192.0.2.1 --age --count",
+            "rbgp rib received 192.0.2.1 --age --rejected",
+            "rbgp rib advertised 192.0.2.2 --age --explain",
+        ] {
+            assert!(
+                Cli::try_parse_from(args.split_whitespace()).is_err(),
+                "conflicting age shape unexpectedly parsed"
+            );
+        }
+    }
+
+    /// Load-bearing cross-scope proof: removing the pre-connect validator or
+    /// failing to combine parent and local flags makes one exact diagnostic
+    /// disappear.
+    #[test]
+    fn rib_age_rejects_cross_scope_count_rejected_and_explain() {
+        for (args, expected) in [
+            (
+                "rbgp rib --age received 192.0.2.1 --count",
+                "--age cannot be combined with --count",
+            ),
+            (
+                "rbgp rib --count advertised 192.0.2.2 --age",
+                "--age cannot be combined with --count",
+            ),
+            (
+                "rbgp rib --age received 192.0.2.1 --rejected",
+                "--age cannot be combined with --rejected",
+            ),
+            (
+                "rbgp rib --prefix 203.0.113.0/24 --age advertised 192.0.2.2 --explain",
+                "--age cannot be combined with --explain",
+            ),
+            (
+                "rbgp rib --prefix 203.0.113.0/24 --explain received 192.0.2.1 --age",
+                "--age cannot be combined with --explain",
+            ),
+            (
+                "rbgp rib --prefix 203.0.113.0/24 --explain advertised 192.0.2.2 --age",
+                "--age cannot be combined with --explain",
+            ),
+        ] {
+            let cli = Cli::try_parse_from(args.split_whitespace()).unwrap();
+            assert_eq!(
+                validate_rib_age_action(&cli.command)
+                    .unwrap_err()
+                    .to_string(),
+                expected
+            );
+        }
+    }
+
+    /// Load-bearing scope proof: making local age global lets unsupported
+    /// placements parse, while removing the parent action guard makes an
+    /// unsupported command validate.
+    #[test]
+    fn rib_age_is_rejected_by_unrelated_subcommands() {
+        for subcommand in ["blackholes", "fib", "bgpls", "vpn", "labeled", "rtc"] {
+            assert!(
+                Cli::try_parse_from(["rbgp", "rib", subcommand, "--age"]).is_err(),
+                "rib {subcommand} unexpectedly accepted --age"
+            );
+            let parent_form = Cli::try_parse_from(["rbgp", "rib", "--age", subcommand]).unwrap();
+            assert_eq!(
+                validate_rib_age_action(&parent_form.command)
+                    .unwrap_err()
+                    .to_string(),
+                "--age is only valid for best, received, or advertised routes"
+            );
+        }
+    }
+
+    /// Load-bearing preflight proof: bypassing the age validator reaches the
+    /// deliberately unreachable transport for status and mutating actions.
+    #[tokio::test]
+    async fn rib_parent_age_rejects_unrelated_actions_before_transport() {
+        for action in [
+            "blackholes",
+            "fib",
+            "bgpls",
+            "vpn",
+            "labeled",
+            "rtc",
+            "add 203.0.113.0/24 --nexthop 192.0.2.1",
+            "delete 203.0.113.0/24",
+        ] {
+            let args = format!("rbgp --addr http://127.0.0.1:1 rib --age {action}");
+            let cli = Cli::try_parse_from(args.split_whitespace()).unwrap();
+            assert_eq!(
+                run(cli, BINARY_NAME).await.unwrap_err().to_string(),
+                "--age is only valid for best, received, or advertised routes",
+                "rib {action} did not fail before transport"
+            );
+        }
+    }
+
+    /// Load-bearing parent-explain preflight proof: if the age validator
+    /// ignores the parent best-view explain flag, this reaches transport and
+    /// returns a connection error instead of the exact argument error.
+    #[tokio::test]
+    async fn rib_local_age_rejects_parent_explain_before_transport() {
+        for view in ["received 192.0.2.1", "advertised 192.0.2.2"] {
+            let args = format!(
+                "rbgp --addr http://127.0.0.1:1 rib --prefix \
+                 203.0.113.0/24 --explain {view} --age"
+            );
+            let cli = Cli::try_parse_from(args.split_whitespace()).unwrap();
+            assert_eq!(
+                run(cli, BINARY_NAME).await.unwrap_err().to_string(),
+                "--age cannot be combined with --explain"
+            );
+        }
     }
 
     #[test]

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 
 use std::io::{self, Write};
 use std::net::IpAddr;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::CliError;
 use crate::proto;
@@ -474,11 +475,15 @@ pub struct JsonRoute {
     pub best: bool,
     pub peer_address: String,
     pub communities: Vec<String>,
+    pub extended_communities: Vec<u64>,
     pub large_communities: Vec<String>,
     #[serde(skip_serializing_if = "is_zero")]
     pub path_id: u32,
     #[serde(skip_serializing_if = "String::is_empty")]
     pub validation_state: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub aspa_state: String,
+    pub received_at_epoch_seconds: u64,
 }
 
 #[derive(Serialize)]
@@ -812,11 +817,38 @@ fn format_med(med: u32, med_attr: Option<u32>, med_attr_supported: bool) -> Stri
 }
 
 /// Print route table with dynamic column widths and colored best marker.
-pub fn print_route_table(routes: &[proto::Route]) {
-    print!("{}", render_route_table(routes));
+pub fn print_route_table(routes: &[proto::Route], show_age: bool) {
+    print!(
+        "{}",
+        render_route_table_with_clock(routes, show_age, || {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs()
+        })
+    );
 }
 
+fn render_route_table_with_clock<F>(routes: &[proto::Route], show_age: bool, clock: F) -> String
+where
+    F: FnOnce() -> u64,
+{
+    let now_epoch_seconds = if show_age { clock() } else { 0 };
+    render_route_table_at(routes, show_age, now_epoch_seconds)
+}
+
+#[cfg(test)]
 fn render_route_table(routes: &[proto::Route]) -> String {
+    render_route_table_with_clock(routes, false, || {
+        panic!("default route rendering must not read the clock")
+    })
+}
+
+fn render_route_table_at(
+    routes: &[proto::Route],
+    show_age: bool,
+    now_epoch_seconds: u64,
+) -> String {
     use std::fmt::Write as _;
 
     struct Row {
@@ -829,6 +861,7 @@ fn render_route_table(routes: &[proto::Route]) -> String {
         med: String,
         origin: String,
         path_id: String,
+        age: Option<String>,
     }
 
     // GR stale flag column ("S" = stale per RFC 4724, "L" = LLGR stale
@@ -878,6 +911,10 @@ fn render_route_table(routes: &[proto::Route]) -> String {
                 med: format_med(r.med, r.med_attr, med_attr_supported),
                 origin: format_origin(r.origin).to_string(),
                 path_id,
+                age: show_age.then(|| match r.received_at_epoch_seconds {
+                    0 => "-".to_string(),
+                    received_at => format_duration(now_epoch_seconds.saturating_sub(received_at)),
+                }),
             }
         })
         .collect();
@@ -908,30 +945,55 @@ fn render_route_table(routes: &[proto::Route]) -> String {
         .max()
         .unwrap_or(0)
         .max(6);
-
     let mut out = String::new();
     let header_pad = if any_stale { "    " } else { "   " };
-    let _ = writeln!(
-        out,
-        "{header_pad}{:<w_pfx$} {:<w_nh$} {:<w_asp$} {:>w_lp$} {:>w_med$}  {:<w_orig$} PathID",
-        "Prefix", "Next Hop", "AS Path", "LP", "MED", "Origin",
-    );
+    if show_age {
+        let _ = writeln!(
+            out,
+            "{header_pad}{:<w_pfx$} {:<w_nh$} {:<w_asp$} {:>w_lp$} {:>w_med$}  {:<w_orig$} {:<6} Age",
+            "Prefix", "Next Hop", "AS Path", "LP", "MED", "Origin", "PathID",
+        );
+    } else {
+        let _ = writeln!(
+            out,
+            "{header_pad}{:<w_pfx$} {:<w_nh$} {:<w_asp$} {:>w_lp$} {:>w_med$}  {:<w_orig$} PathID",
+            "Prefix", "Next Hop", "AS Path", "LP", "MED", "Origin",
+        );
+    }
 
     for row in &rows {
         let overhead = ansi_overhead(&row.marker_colored, row.marker_plain_len);
         let marker_width = row.marker_plain_len + overhead;
-        let _ = writeln!(
-            out,
-            "{:<marker_width$} {:<w_pfx$} {:<w_nh$} {:<w_asp$} {:>w_lp$} {:>w_med$}  {:<w_orig$} {}",
-            row.marker_colored,
-            row.prefix,
-            row.next_hop,
-            row.as_path,
-            row.lp,
-            row.med,
-            row.origin,
-            row.path_id,
-        );
+        if show_age {
+            let _ = writeln!(
+                out,
+                "{:<marker_width$} {:<w_pfx$} {:<w_nh$} {:<w_asp$} {:>w_lp$} {:>w_med$}  {:<w_orig$} {:<6} {}",
+                row.marker_colored,
+                row.prefix,
+                row.next_hop,
+                row.as_path,
+                row.lp,
+                row.med,
+                row.origin,
+                row.path_id,
+                row.age
+                    .as_deref()
+                    .expect("age is populated when the column is enabled"),
+            );
+        } else {
+            let _ = writeln!(
+                out,
+                "{:<marker_width$} {:<w_pfx$} {:<w_nh$} {:<w_asp$} {:>w_lp$} {:>w_med$}  {:<w_orig$} {}",
+                row.marker_colored,
+                row.prefix,
+                row.next_hop,
+                row.as_path,
+                row.lp,
+                row.med,
+                row.origin,
+                row.path_id,
+            );
+        }
     }
     out
 }
@@ -1875,15 +1937,45 @@ Neighbor    AS    State       Uptime   Rx Pfx Tx Pfx Description    MsgRcvd MsgS
         }
     }
 
-    /// Without any GR-stale route the table keeps its classic 2-char
-    /// marker column — unchanged from the pre-LAN-347 layout.
+    /// Load-bearing default-path proof: reading the injected clock panics;
+    /// enabling the age column unconditionally or changing existing spacing
+    /// makes this byte-for-byte golden red.
     #[test]
     fn route_table_no_stale_layout_unchanged() {
         owo_colors::set_override(false);
         let rendered = render_route_table(&[route_fixture(false, false)]);
-        let mut lines = rendered.lines();
-        assert!(lines.next().unwrap().starts_with("   Prefix"));
-        assert!(lines.next().unwrap().starts_with("*> 10.0.0.0/24"));
+        assert_eq!(
+            rendered,
+            concat!(
+                "   Prefix      Next Hop  AS Path  LP MED  Origin PathID\n",
+                "*> 10.0.0.0/24 192.0.2.1 65001   100   0  igp    \n",
+            )
+        );
+    }
+
+    /// Load-bearing age proof: treating epoch zero as a real timestamp,
+    /// subtracting without saturation, or bypassing the existing duration
+    /// formatter changes one exact row and makes this golden red.
+    #[test]
+    fn route_table_age_marks_unknown_old_and_future_timestamps() {
+        owo_colors::set_override(false);
+        let unknown = route_fixture(false, false);
+        let mut old = route_fixture(false, false);
+        old.prefix = "10.0.1.0".to_string();
+        old.received_at_epoch_seconds = 339;
+        let mut future = route_fixture(false, false);
+        future.prefix = "10.0.2.0".to_string();
+        future.received_at_epoch_seconds = 4_001;
+
+        assert_eq!(
+            render_route_table_at(&[unknown, old, future], true, 4_000),
+            concat!(
+                "   Prefix      Next Hop  AS Path  LP MED  Origin PathID Age\n",
+                "*> 10.0.0.0/24 192.0.2.1 65001   100   0  igp           -\n",
+                "*> 10.0.1.0/24 192.0.2.1 65001   100   0  igp           01:01:01\n",
+                "*> 10.0.2.0/24 192.0.2.1 65001   100   0  igp           00:00:00\n",
+            )
+        );
     }
 
     /// A GR-stale route widens the marker column with an "S" (stale,

--- a/docs/API.md
+++ b/docs/API.md
@@ -958,6 +958,14 @@ Query the routing information base and subscribe to real-time route changes.
 | `WatchRoutes` | Server-streaming: real-time route add / withdraw / best-change / export-policy-filtered events |
 | `WatchRouteEvents` | Server-streaming: real-time route add / withdraw / best-change / export-policy-filtered events wrapped as `BgpEvent`, including explicit lag warnings |
 
+The three unicast route-listing RPCs return raw ordered
+`extended_communities`, the ASPA verification string in `aspa_state`, and
+`received_at_epoch_seconds` on every `Route` (`0` means unknown). Native
+`rbgp --json rib` preserves the raw extended-community values, omits an empty
+`aspa_state` from an older daemon but retains a genuine `"unknown"` state, and
+retains the zero receive-time sentinel. The same native route serializer is
+used by best, received, advertised, and embedded `ExplainBestPath` routes.
+
 ### Runtime observability surfaces
 
 Runtime visibility is intentionally split by access pattern rather than forced

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1863,13 +1863,24 @@ their effective send value is explicitly `inactive`, `unlimited`, or finite.
 
 ```bash
 rbgp rib received 10.0.0.2
+rbgp rib received 10.0.0.2 --age
 ```
 
 ### View best routes (Loc-RIB)
 
 ```bash
 rbgp rib
+rbgp rib --age
 ```
+
+`--age` appends the time since the route was originally received into the RIB.
+It also works on `rbgp rib advertised PEER --age`, where it remains the
+original RIB receive age rather than the advertisement age. Unknown timestamps
+render as `-`; future timestamps (for example, from CLI/daemon clock skew)
+clamp to `00:00:00`. A remote CLI compares the daemon-supplied epoch timestamp
+with the CLI host's clock. The default human table is unchanged. JSON always
+returns the raw `received_at_epoch_seconds` value and is identical with or
+without `--age`.
 
 ### View general FIB route status
 

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -693,7 +693,8 @@ _arguments "${_arguments_options[@]}" : \
 '-l[Show longer (more specific) prefixes matching --prefix]' \
 '--longer[Show longer (more specific) prefixes matching --prefix]' \
 '(--count)--explain[Show why the best route was selected (requires --prefix)]' \
-'--count[Print only the number of matching best, received, or advertised routes]' \
+'(--age)--count[Print only the number of matching best, received, or advertised routes]' \
+'(--explain)--age[Append the original route receive age to best, received, or advertised rows]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -716,7 +717,8 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
-'--count[Print only the number of matching received routes]' \
+'(--age)--count[Print only the number of matching received routes]' \
+'(--rejected)--age[Append the original route receive age]' \
 '(--count)--rejected[Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; \[policy.reject_retention\])]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
@@ -733,7 +735,8 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
-'--count[Print only the number of matching received routes]' \
+'(--age)--count[Print only the number of matching received routes]' \
+'(--rejected)--age[Append the original route receive age]' \
 '(--count)--rejected[Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; \[policy.reject_retention\])]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
@@ -753,7 +756,8 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
-'--count[Print only the number of matching advertised routes]' \
+'(--age)--count[Print only the number of matching advertised routes]' \
+'(--explain)--age[Append the original route receive age]' \
 '(--count)--explain[Explain whether this exact prefix would be advertised to the peer]' \
 '(--rd)--labeled[Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder]' \
 '-j[Output in JSON format]' \
@@ -774,7 +778,8 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
-'--count[Print only the number of matching advertised routes]' \
+'(--age)--count[Print only the number of matching advertised routes]' \
+'(--explain)--age[Append the original route receive age]' \
 '(--count)--explain[Explain whether this exact prefix would be advertised to the peer]' \
 '(--rd)--labeled[Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder]' \
 '-j[Output in JSON format]' \

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -7687,7 +7687,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib)
-            opts="-a -p -l -c -s -j -h --family --prefix --longer --explain --count --explain-peer --origin-asn --community --large-community --addr --token-file --json --no-color --help received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help"
+            opts="-a -p -l -c -s -j -h --family --prefix --longer --explain --count --age --explain-peer --origin-asn --community --large-community --addr --token-file --json --no-color --help received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7807,7 +7807,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__advertised)
-            opts="-a -s -j -h --family --count --explain --rd --labeled --source-peer --source-path-id --addr --token-file --json --no-color --help"
+            opts="-a -s -j -h --family --count --age --explain --rd --labeled --source-peer --source-path-id --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8223,7 +8223,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__received)
-            opts="-a -s -j -h --family --count --rejected --addr --token-file --json --no-color --help"
+            opts="-a -s -j -h --family --count --age --rejected --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -328,6 +328,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s l -l longer -d 'Show longer (more specific) prefixes matching --prefix'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l explain -d 'Show why the best route was selected (requires --prefix)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l count -d 'Print only the number of matching best, received, or advertised routes'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l age -d 'Append the original route receive age to best, received, or advertised rows'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -349,6 +350,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l count -d 'Print only the number of matching received routes'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l age -d 'Append the original route receive age'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l rejected -d 'Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; [policy.reject_retention])'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l no-color -d 'Disable colored output'
@@ -357,6 +359,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l count -d 'Print only the number of matching received routes'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l age -d 'Append the original route receive age'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l rejected -d 'Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; [policy.reject_retention])'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l no-color -d 'Disable colored output'
@@ -368,6 +371,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l count -d 'Print only the number of matching advertised routes'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l age -d 'Append the original route receive age'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l explain -d 'Explain whether this exact prefix would be advertised to the peer'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l labeled -d 'Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s j -l json -d 'Output in JSON format'
@@ -380,6 +384,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l count -d 'Print only the number of matching advertised routes'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l age -d 'Append the original route receive age'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l explain -d 'Explain whether this exact prefix would be advertised to the peer'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l labeled -d 'Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s j -l json -d 'Output in JSON format'


### PR DESCRIPTION
## Summary

- expose raw ordered extended communities, ASPA state, and receive epochs in native best/received/advertised and embedded best-path-explain JSON route objects
- add an opt-in human `--age` column without changing the default table or reading the clock when disabled
- render unknown timestamps as `-`, clamp future/skewed timestamps to zero age, and reject incompatible or unsupported age forms before transport
- document that advertised-view age is the original RIB receive age, not advertisement age

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `python3 scripts/check-v1-stable-surface.py`
- completion freshness and `git diff --check`
- repository pre-push quartet
- independent final diff review

## Load-bearing regression proof

- removing or reordering extended communities, collapsing empty and genuine `unknown` ASPA states, or replacing the zero receive epoch makes the exact JSON projection assertions red
- bypassing zero handling, the existing duration formatter, or saturating future-time arithmetic makes the age-table golden red
- forcing age work into the default path trips the injected clock panic and/or the byte-for-byte default table golden
- removing parent/local flag composition, direct conflicts, parent-explain handling, or the pre-connect validator makes the focused parser, transport, or mutation-fence proof red
- stale generated completions make the checked-in completion fence red
