### PR TITLE
ci: enroll the outbound-prefix-limit-scale harness in the standalone gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,16 +132,20 @@ jobs:
           cargo fmt --manifest-path bench/scale/outbound-prefix-limits/Cargo.toml -- --check
           cargo fmt --manifest-path bench/scale/config-persistence/Cargo.toml -- --check
           cargo fmt --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml -- --check
+          cargo fmt --manifest-path bench/scale/outbound-prefix-limit-scale/Cargo.toml -- --check
           cargo test --manifest-path bench/scale/rrharness/Cargo.toml --locked
           cargo test --manifest-path bench/scale/reloadstall/Cargo.toml --locked
           cargo test --manifest-path bench/scale/outbound-prefix-limits/Cargo.toml --locked
           cargo test --manifest-path bench/scale/config-persistence/Cargo.toml --locked
           cargo test --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml --locked
+          cargo test --manifest-path bench/scale/outbound-prefix-limit-scale/Cargo.toml --locked
           cargo clippy --manifest-path bench/scale/outbound-prefix-limits/Cargo.toml \
             --locked --all-targets -- -D warnings
           cargo clippy --manifest-path bench/scale/config-persistence/Cargo.toml \
             --locked --all-targets -- -D warnings
           cargo clippy --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml \
+            --locked --all-targets -- -D warnings
+          cargo clippy --manifest-path bench/scale/outbound-prefix-limit-scale/Cargo.toml \
             --locked --all-targets -- -D warnings
           cargo test --test reloadstall_scenario_emitted_check
           bash -n bench/compare-criterion.sh
@@ -150,11 +154,13 @@ jobs:
           bash -n bench/scale/outbound-prefix-limits/run-receipt.sh
           bash -n bench/scale/config-persistence/run-receipt.sh
           bash -n bench/scale/enhanced-route-refresh/run-receipt.sh
+          bash -n bench/scale/outbound-prefix-limit-scale/run-receipt.sh
           bash -n bench/tests/test-route-server-1000-receipt.sh
           shellcheck bench/scale/route-server-1000/run-receipt.sh \
             bench/scale/outbound-prefix-limits/run-receipt.sh \
             bench/scale/config-persistence/run-receipt.sh \
             bench/scale/enhanced-route-refresh/run-receipt.sh \
+            bench/scale/outbound-prefix-limit-scale/run-receipt.sh \
             bench/tests/test-route-server-1000-receipt.sh
           bash bench/tests/test-route-server-1000-receipt.sh
           bash -n bench/scale/compare-rrharness.sh

--- a/bench/scale/outbound-prefix-limit-scale/src/main.rs
+++ b/bench/scale/outbound-prefix-limit-scale/src/main.rs
@@ -944,10 +944,11 @@ fn histogram_max_bucket_bounds(
 }
 
 fn json_f64_or_null(value: f64) -> String {
-    value
-        .is_finite()
-        .then(|| format!("{value:.9}"))
-        .unwrap_or_else(|| "null".to_string())
+    if value.is_finite() {
+        format!("{value:.9}")
+    } else {
+        "null".to_string()
+    }
 }
 
 fn snapshot_json(label: &str, evidence: &Evidence) -> String {


### PR DESCRIPTION
The `bench/scale/outbound-prefix-limit-scale` harness shipped with five red-proven unit tests, fmt/clippy coverage, and a receipt script, but was not added to the "Check standalone scale harnesses and receipt classifiers" CI step — none of it ran in CI, so it would rot silently.

- Enroll fmt, `--locked` test, `--locked` clippy, and `bash -n` + shellcheck of `run-receipt.sh`, mirroring the sibling harness entries.
- Fix the one `clippy::obfuscated_if_else` lint the enrollment immediately surfaced in `src/main.rs`.

All five enrolled commands verified locally: fmt=0, test=0, clippy=0, bash -n=0, shellcheck=0.