### PR TITLE
fix(api): reject invalid injection origin and broadcast next hops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   invalidate paginated route queries, while accepted End-of-RIB, BoRR, EoRR,
   and timeout work invalidates each route scope exactly once.
 
+- Route injection now rejects ORIGIN values outside 0–2 with
+  `INVALID_ARGUMENT` instead of silently coercing them to INCOMPLETE, and
+  rejects the limited-broadcast next hop `255.255.255.255` on both unicast
+  and EVPN injection — matching the scrutiny already applied to
+  peer-received routes.
+
 ## [0.61.0] — 2026-07-26
 
 > **Release framing.** This is the policy-safety line. RFC 8212

--- a/crates/api/src/injection_service.rs
+++ b/crates/api/src/injection_service.rs
@@ -142,9 +142,9 @@ fn parse_type5_gateway(
     Ok(gateway)
 }
 
-/// Parse a unicast next-hop string and reject unspecified / multicast values.
-/// Shared by `AddPath`, `AddFlowSpec`, and `AddEvpnRoute` so all injection
-/// surfaces apply the same guardrails.
+/// Parse a unicast next-hop string and reject unspecified / multicast /
+/// broadcast values. Shared by `AddPath` and `AddEvpnRoute` so all
+/// next-hop-carrying injection surfaces apply the same guardrails.
 fn parse_unicast_nexthop(s: &str) -> Result<IpAddr, Status> {
     let nh: IpAddr = s
         .parse()
@@ -156,6 +156,11 @@ fn parse_unicast_nexthop(s: &str) -> Result<IpAddr, Status> {
             }
             if v4.is_multicast() {
                 return Err(Status::invalid_argument("next_hop must not be multicast"));
+            }
+            if v4.is_broadcast() {
+                return Err(Status::invalid_argument(
+                    "next_hop must not be 255.255.255.255",
+                ));
             }
         }
         IpAddr::V6(v6) => {
@@ -213,7 +218,12 @@ impl proto::injection_service_server::InjectionService for InjectionService {
         let origin = match req.origin {
             0 => Origin::Igp,
             1 => Origin::Egp,
-            _ => Origin::Incomplete,
+            2 => Origin::Incomplete,
+            other => {
+                return Err(Status::invalid_argument(format!(
+                    "origin must be 0 (igp), 1 (egp), or 2 (incomplete); got {other}"
+                )));
+            }
         };
 
         let mut attributes = vec![PathAttribute::Origin(origin)];
@@ -1252,6 +1262,22 @@ mod tests {
         (InjectionService::new(tx, AccessMode::ReadWrite), rx)
     }
 
+    fn add_path_request(origin: u32, next_hop: &str) -> Request<proto::AddPathRequest> {
+        Request::new(proto::AddPathRequest {
+            prefix: "10.0.0.0".into(),
+            prefix_length: 24,
+            next_hop: next_hop.into(),
+            origin,
+            as_path: vec![],
+            local_pref: None,
+            med: None,
+            communities: vec![],
+            extended_communities: vec![],
+            large_communities: vec![],
+            path_id: 0,
+        })
+    }
+
     fn oversized_flowspec_component() -> proto::FlowSpecComponent {
         let value = (0..2_200)
             .map(|i| format!("={i}"))
@@ -1386,6 +1412,89 @@ mod tests {
         let err = svc.add_path(req).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
         assert!(err.message().contains("multicast"));
+    }
+
+    #[tokio::test]
+    async fn add_path_rejects_origin_above_two() {
+        let svc = make_service();
+        for origin in [3u32, 255] {
+            let err = svc
+                .add_path(add_path_request(origin, "10.0.0.1"))
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument, "origin {origin}");
+            assert!(
+                err.message().contains("origin"),
+                "message must name the field: {}",
+                err.message()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn add_path_accepts_valid_origins() {
+        for (origin, expected) in [
+            (0u32, Origin::Igp),
+            (1, Origin::Egp),
+            (2, Origin::Incomplete),
+        ] {
+            let (svc, mut rx) = make_service_with_rx();
+            let reply_task = tokio::spawn(async move {
+                match rx.recv().await.expect("one RibUpdate") {
+                    RibUpdate::InjectRoute { route, reply } => {
+                        reply.send(Ok(())).ok();
+                        route
+                    }
+                    _ => panic!("expected InjectRoute"),
+                }
+            });
+            svc.add_path(add_path_request(origin, "10.0.0.1"))
+                .await
+                .unwrap();
+            let route = reply_task.await.unwrap();
+            assert!(
+                route
+                    .attributes
+                    .iter()
+                    .any(|a| matches!(a, PathAttribute::Origin(o) if *o == expected)),
+                "origin {origin} must map to {expected:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn add_path_rejects_broadcast_next_hop() {
+        let svc = make_service();
+        let err = svc
+            .add_path(add_path_request(0, "255.255.255.255"))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("255.255.255.255"));
+    }
+
+    #[tokio::test]
+    async fn add_evpn_route_rejects_broadcast_next_hop() {
+        let svc = make_service();
+        let req = Request::new(proto::AddEvpnRouteRequest {
+            route_type: 2,
+            rd: "65000:100".into(),
+            ethernet_tag: 0,
+            mac: "02:00:00:aa:bb:cc".into(),
+            ip: String::new(),
+            label: 100,
+            label2: 0,
+            next_hop: "255.255.255.255".into(),
+            route_targets: vec![],
+            disable_vxlan_encap: false,
+            prefix: String::new(),
+            prefix_length: 0,
+            router_mac: String::new(),
+            gateway: String::new(),
+        });
+        let err = svc.add_evpn_route(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("255.255.255.255"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Route injection previously coerced any ORIGIN value above 2 to INCOMPLETE silently and accepted `255.255.255.255` as a unicast next hop. Locally injected routes got less scrutiny than peer-received ones: the wire-path UPDATE validator (`crates/wire/src/validate.rs`, `check_next_hop`) already rejects broadcast next hops from peers, and the EVPN Type 5 gateway check in the injection service already rejects broadcast gateways.

## Changes

- `AddPath` now maps origin `2` to INCOMPLETE explicitly and returns `INVALID_ARGUMENT` naming the field and the accepted range for any value above 2, matching the CLI help (`0=igp, 1=egp, 2=incomplete`).
- `parse_unicast_nexthop` rejects `255.255.255.255`, mirroring the wire validator's `is_broadcast()` semantics. The helper is shared by `AddPath` and `AddEvpnRoute`, so both next-hop-carrying injection surfaces get the rejection; FlowSpec injection carries no next hop. Its stale doc comment (which named `AddFlowSpec`) is corrected.

## Tests

New tests were run against the unfixed code first and failed as expected (requests flowed through to the RIB channel instead of returning `INVALID_ARGUMENT`):

- origin 3 and 255 rejected with `INVALID_ARGUMENT` naming the field
- origin 0/1/2 accepted, mapping to IGP/EGP/INCOMPLETE in the injected route's attributes
- `255.255.255.255` rejected on both `AddPath` and `AddEvpnRoute`
- existing valid next hops still accepted (covered by the acceptance test and existing EVPN tests)

Gates: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast`, `cargo doc --workspace --no-deps` — all exit 0.