### PR TITLE
fix(import): fail closed on configs the daemon would reject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and EVPN injection — matching the scrutiny already applied to
   peer-received routes.
 
+- **`rbgp config import` now exits nonzero when the emitted config would be
+  rejected by `rustbgpd --check`.** A source router-id that is not a usable
+  IPv4 address (all three frontends copy it verbatim) and a neighbor
+  `peer_group` reference that resolves to no translated peer group are
+  reported as warnings (exit 2) instead of leaving the importer with a clean
+  exit alongside an unloadable translation. Out-of-range numeric fields
+  (GoBGP `peer-as`, `hold-time`, `keepalive-interval`, `max-prefixes`, local
+  `as`; FRR unparseable keepalive) now name the field, the source value, and
+  what was done instead of being silently dropped.
+
 ## [0.61.0] — 2026-07-26
 
 > **Release framing.** This is the policy-safety line. RFC 8212

--- a/crates/cli/src/importer/frr.rs
+++ b/crates/cli/src/importer/frr.rs
@@ -434,12 +434,17 @@ impl Entry<'_> {
 /// rustbgpd derives keepalive as hold/3; note when the source chose a
 /// different ratio.
 fn warn_keepalive(model: &mut Model, scope: &str, keepalive: &str, hold: u16) {
-    if let Ok(keepalive) = keepalive.parse::<u16>()
-        && u32::from(keepalive) * 3 != u32::from(hold)
-    {
-        model.warnings.push(format!(
-            "{scope}: keepalive {keepalive}s is not hold/3 ({hold}/3); rustbgpd always \
-             derives keepalive as hold_time/3"
-        ));
+    match keepalive.parse::<u16>() {
+        Ok(keepalive) if u32::from(keepalive) * 3 != u32::from(hold) => {
+            model.warnings.push(format!(
+                "{scope}: keepalive {keepalive}s is not hold/3 ({hold}/3); rustbgpd always \
+                 derives keepalive as hold_time/3"
+            ));
+        }
+        Ok(_) => {}
+        Err(_) => model.warnings.push(format!(
+            "{scope}: keepalive {keepalive:?} is not a valid number (0..=65535); dropped — \
+             rustbgpd derives keepalive as hold_time/3 from the kept hold time {hold}"
+        )),
     }
 }

--- a/crates/cli/src/importer/gobgp.rs
+++ b/crates/cli/src/importer/gobgp.rs
@@ -74,6 +74,31 @@ fn as_u32(value: &toml::Value) -> Option<u32> {
     }
 }
 
+/// `as_u32` with the drop made visible: a value that is present but
+/// unusable becomes a report warning (exit 2) instead of vanishing.
+fn u32_field(model: &mut Model, field: &str, value: &toml::Value) -> Option<u32> {
+    let parsed = as_u32(value);
+    if parsed.is_none() {
+        model.warnings.push(format!(
+            "{field} = {value} is not a valid u32 (0..=4294967295); dropped — carry it \
+             over by hand if needed"
+        ));
+    }
+    parsed
+}
+
+/// As `u32_field`, for fields rustbgpd bounds to u16 (hold_time).
+fn u16_field(model: &mut Model, field: &str, value: &toml::Value) -> Option<u16> {
+    let parsed = as_u32(value).and_then(|v| u16::try_from(v).ok());
+    if parsed.is_none() {
+        model.warnings.push(format!(
+            "{field} = {value} is not a valid u16 (0..=65535); dropped — the rustbgpd \
+             default applies"
+        ));
+    }
+    parsed
+}
+
 /// First 1-based source line containing `needle`.
 fn line_of(source: &str, needle: &str) -> Option<usize> {
     source
@@ -102,7 +127,7 @@ fn global(model: &mut Model, source: &str, value: &toml::Value) {
                 };
                 for (ckey, cval) in config {
                     match ckey.as_str() {
-                        "as" => model.local_asn = as_u32(cval),
+                        "as" => model.local_asn = u32_field(model, "global.config.as", cval),
                         "router-id" => {
                             model.router_id = cval.as_str().map(str::to_owned);
                         }
@@ -172,7 +197,10 @@ fn session(
                     match ckey.as_str() {
                         "neighbor-address" => s.address = cval.as_str().map(str::to_owned),
                         "peer-group-name" => s.group_name = cval.as_str().map(str::to_owned),
-                        "peer-as" => s.remote_asn = as_u32(cval),
+                        "peer-as" => {
+                            s.remote_asn =
+                                u32_field(model, &format!("{label}: config.peer-as"), cval);
+                        }
                         "description" => s.description = cval.as_str().map(str::to_owned),
                         "peer-group" => s.peer_group = cval.as_str().map(str::to_owned),
                         "auth-password" => {
@@ -191,11 +219,21 @@ fn session(
             "timers" => {
                 let config = val.get("config").and_then(toml::Value::as_table);
                 let Some(config) = config else { continue };
-                let keepalive = config.get("keepalive-interval").and_then(as_u32);
+                let keepalive = config.get("keepalive-interval").and_then(|v| {
+                    u32_field(
+                        model,
+                        &format!("{label}: timers.config.keepalive-interval"),
+                        v,
+                    )
+                });
                 for (tkey, tval) in config {
                     match tkey.as_str() {
                         "hold-time" => {
-                            s.hold_time = as_u32(tval).and_then(|h| u16::try_from(h).ok());
+                            s.hold_time = u16_field(
+                                model,
+                                &format!("{label}: timers.config.hold-time"),
+                                tval,
+                            );
                         }
                         "keepalive-interval" => {}
                         other => skip_key(
@@ -265,7 +303,8 @@ fn afi_safi(model: &mut Model, source: &str, label: &str, value: &toml::Value, s
         .get("prefix-limit")
         .and_then(|p| p.get("config"))
         .and_then(|c| c.get("max-prefixes"))
-        .and_then(as_u32)
+        .and_then(|v| u32_field(model, &format!("{label}: prefix-limit max-prefixes"), v))
+        // GoBGP treats 0 as "no limit"; dropping it is a translation, not a loss.
         .filter(|limit| *limit > 0)
     {
         if ipv6 {

--- a/crates/cli/src/importer/mod.rs
+++ b/crates/cli/src/importer/mod.rs
@@ -299,10 +299,14 @@ fn finish(
     mut model: Model,
 ) -> Result<Imported, ImportError> {
     let Some(local_asn) = model.local_asn else {
-        return Err(ImportError::Empty(vec![format!(
+        let mut items = vec![format!(
             "no local AS found in the {} source (router bgp / local as / global.config.as)",
             format.name()
-        )]));
+        )];
+        // Frontend warnings (an out-of-range `as`, for one) explain *why*
+        // there is no local AS; a refusal must not swallow them.
+        items.append(&mut model.warnings);
+        return Err(ImportError::Empty(items));
     };
 
     // Resolve remote AS down from groups (rustbgpd peer groups carry no
@@ -352,13 +356,43 @@ fn finish(
         neighbors.push(neighbor);
     }
     if neighbors.is_empty() {
-        return Err(ImportError::Empty(vec![format!(
+        let mut items = vec![format!(
             "no translatable neighbors found in the {} source",
             format.name()
-        )]));
+        )];
+        items.append(&mut model.warnings);
+        return Err(ImportError::Empty(items));
     }
     for group in &mut model.groups {
         dedupe(&mut group.families);
+    }
+
+    // Fail closed on fields the daemon's `--check` rejects wholesale: a
+    // clean exit alongside a translation validation refuses would break
+    // the ladder's "operator attention is non-zero by construction"
+    // contract. The values are still emitted verbatim — the report names
+    // them, the exit code forces the review.
+    if let Some(id) = &model.router_id {
+        match id.parse::<std::net::Ipv4Addr>() {
+            Ok(ip) if !ip.is_unspecified() => {}
+            _ => model.warnings.push(format!(
+                "router-id {id:?} is not a usable IPv4 router_id (rustbgpd requires a \
+                 non-zero IPv4 address); emitted verbatim — `rustbgpd --check` rejects \
+                 this config until it is corrected"
+            )),
+        }
+    }
+    for neighbor in &neighbors {
+        if let Some(group) = &neighbor.peer_group
+            && !model.groups.iter().any(|g| &g.name == group)
+        {
+            model.warnings.push(format!(
+                "neighbor {}: peer_group {group:?} does not match any translated peer \
+                 group; emitted verbatim — `rustbgpd --check` rejects this config until \
+                 the group is defined or the reference removed",
+                neighbor.address
+            ));
+        }
     }
 
     let router_id_placeholder = model.router_id.is_none();

--- a/crates/cli/tests/config_import.rs
+++ b/crates/cli/tests/config_import.rs
@@ -562,6 +562,218 @@ peer-as = 64496
     assert!(matches!(error, ImportError::Empty(_)), "{error:?}");
 }
 
+// ---------------------------------------------------------------------------
+// Fail-closed on fields the daemon's `--check` rejects: a config the
+// daemon refuses wholesale must never leave the importer with exit 0.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unparseable_router_id_warns_in_every_frontend() {
+    for (format, path, source, bad) in [
+        (
+            SourceFormat::Frr,
+            "frr-badrid.conf",
+            "router bgp 64500\n bgp router-id 2001:db8::1\n neighbor 192.0.2.1 remote-as 64496\n!\n",
+            "2001:db8::1",
+        ),
+        (
+            SourceFormat::Bird,
+            "bird-badrid.conf",
+            "router id fe80::1;\nprotocol bgp up { local as 64500; \
+             neighbor 192.0.2.1 as 64496; }\n",
+            "fe80::1",
+        ),
+        (
+            SourceFormat::Gobgp,
+            "gobgp-badrid.toml",
+            "[global.config]\nas = 64500\nrouter-id = \"not-an-ip\"\n[[neighbors]]\n\
+             [neighbors.config]\nneighbor-address = \"192.0.2.1\"\npeer-as = 64496\n",
+            "not-an-ip",
+        ),
+        // The daemon also refuses the unspecified address.
+        (
+            SourceFormat::Frr,
+            "frr-zerorid.conf",
+            "router bgp 64500\n bgp router-id 0.0.0.0\n neighbor 192.0.2.1 remote-as 64496\n!\n",
+            "0.0.0.0",
+        ),
+    ] {
+        let imported = import_source(format, path, source).expect("translates");
+        assert_eq!(imported.report.exit_code, 2, "{path}");
+        assert!(
+            imported
+                .report
+                .warnings
+                .iter()
+                .any(|w| w.contains("router-id") && w.contains(bad) && w.contains("--check")),
+            "{path}: {:?}",
+            imported.report.warnings
+        );
+    }
+}
+
+#[test]
+fn dangling_peer_group_reference_warns_in_every_frontend() {
+    for (format, path, source, group) in [
+        (
+            SourceFormat::Frr,
+            "frr-dangling.conf",
+            "router bgp 64500\n bgp router-id 192.0.2.10\n \
+             neighbor 192.0.2.1 remote-as 64496\n \
+             neighbor 192.0.2.1 peer-group CORE\n!\n",
+            "CORE",
+        ),
+        (
+            SourceFormat::Bird,
+            "bird-dangling.conf",
+            "router id 192.0.2.10;\nprotocol bgp up from missing_tmpl { local as 64500; \
+             neighbor 192.0.2.1 as 64496; }\n",
+            "missing_tmpl",
+        ),
+        (
+            SourceFormat::Gobgp,
+            "gobgp-dangling.toml",
+            "[global.config]\nas = 64500\nrouter-id = \"192.0.2.10\"\n[[neighbors]]\n\
+             [neighbors.config]\nneighbor-address = \"192.0.2.1\"\npeer-as = 64496\n\
+             peer-group = \"CORE\"\n",
+            "CORE",
+        ),
+    ] {
+        let imported = import_source(format, path, source).expect("translates");
+        assert_eq!(imported.report.exit_code, 2, "{path}");
+        assert!(
+            imported
+                .report
+                .warnings
+                .iter()
+                .any(|w| w.contains("192.0.2.1") && w.contains(group) && w.contains("--check")),
+            "{path}: {:?}",
+            imported.report.warnings
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Out-of-range numerics are reported, never silently dropped
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gobgp_out_of_range_hold_time_warns_and_is_not_emitted() {
+    let source = "[global.config]\nas = 64500\nrouter-id = \"192.0.2.10\"\n[[neighbors]]\n\
+                  [neighbors.config]\nneighbor-address = \"192.0.2.1\"\npeer-as = 64496\n\
+                  [neighbors.timers.config]\nhold-time = 70000\n";
+    let imported = import_source(SourceFormat::Gobgp, "hold.toml", source).expect("translates");
+    assert!(!imported.config_toml.contains("hold_time"));
+    assert_eq!(imported.report.exit_code, 2);
+    assert!(
+        imported
+            .report
+            .warnings
+            .iter()
+            .any(|w| w.contains("hold-time") && w.contains("70000")),
+        "{:?}",
+        imported.report.warnings
+    );
+}
+
+#[test]
+fn gobgp_out_of_range_peer_as_warns_alongside_the_skip() {
+    let source = "[global.config]\nas = 64500\nrouter-id = \"192.0.2.10\"\n[[neighbors]]\n\
+                  [neighbors.config]\nneighbor-address = \"192.0.2.1\"\npeer-as = 64496\n\
+                  [[neighbors]]\n[neighbors.config]\n\
+                  neighbor-address = \"192.0.2.2\"\npeer-as = 4294967296\n";
+    let imported = import_source(SourceFormat::Gobgp, "peeras.toml", source).expect("translates");
+    assert_eq!(imported.report.exit_code, 2);
+    assert!(
+        imported
+            .report
+            .warnings
+            .iter()
+            .any(|w| w.contains("peer-as") && w.contains("4294967296")),
+        "{:?}",
+        imported.report.warnings
+    );
+    // The undeterminable neighbor still lands on the skip ladder.
+    assert!(
+        imported
+            .report
+            .skipped
+            .iter()
+            .any(|s| s.stanza.contains("192.0.2.2"))
+    );
+}
+
+#[test]
+fn gobgp_out_of_range_local_as_is_named_in_the_refusal() {
+    let source = "[global.config]\nas = 4294967296\nrouter-id = \"192.0.2.10\"\n[[neighbors]]\n\
+                  [neighbors.config]\nneighbor-address = \"192.0.2.1\"\npeer-as = 64496\n";
+    let error = import_source(SourceFormat::Gobgp, "localas.toml", source).unwrap_err();
+    assert!(matches!(error, ImportError::Empty(_)), "{error:?}");
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("global.config.as") && rendered.contains("4294967296"),
+        "the refusal must name the dropped field and value: {rendered}"
+    );
+}
+
+#[test]
+fn gobgp_out_of_range_max_prefixes_warns() {
+    let source = "[global.config]\nas = 64500\nrouter-id = \"192.0.2.10\"\n[[neighbors]]\n\
+                  [neighbors.config]\nneighbor-address = \"192.0.2.1\"\npeer-as = 64496\n\
+                  [[neighbors.afi-safis]]\n[neighbors.afi-safis.config]\n\
+                  afi-safi-name = \"ipv4-unicast\"\n\
+                  [neighbors.afi-safis.prefix-limit.config]\nmax-prefixes = -5\n";
+    let imported = import_source(SourceFormat::Gobgp, "maxpfx.toml", source).expect("translates");
+    assert!(!imported.config_toml.contains("max_prefixes"));
+    assert_eq!(imported.report.exit_code, 2);
+    assert!(
+        imported
+            .report
+            .warnings
+            .iter()
+            .any(|w| w.contains("max-prefixes") && w.contains("-5")),
+        "{:?}",
+        imported.report.warnings
+    );
+}
+
+#[test]
+fn frr_unparseable_keepalive_warns_instead_of_skipping_the_ratio_check() {
+    let source = "router bgp 64500\n bgp router-id 192.0.2.10\n \
+                  neighbor 192.0.2.1 remote-as 64496\n \
+                  neighbor 192.0.2.1 timers garbage 180\n!\n";
+    let imported = import_source(SourceFormat::Frr, "keepalive.conf", source).expect("translates");
+    assert_eq!(imported.report.exit_code, 2);
+    assert!(
+        imported
+            .report
+            .warnings
+            .iter()
+            .any(|w| w.contains("keepalive") && w.contains("garbage")),
+        "{:?}",
+        imported.report.warnings
+    );
+}
+
+/// BIRD numeric parse failures already land on the skip ladder; pin it.
+#[test]
+fn bird_out_of_range_hold_time_lands_on_the_skip_ladder() {
+    let source = "router id 192.0.2.10;\nprotocol bgp up { local as 64500; \
+                  neighbor 192.0.2.1 as 64496; hold time 70000; }\n";
+    let imported = import_source(SourceFormat::Bird, "hold.conf", source).expect("translates");
+    assert_eq!(imported.report.exit_code, 2);
+    assert!(
+        imported
+            .report
+            .skipped
+            .iter()
+            .any(|s| s.stanza.contains("hold time 70000")),
+        "{:?}",
+        imported.report.skipped
+    );
+    assert!(!imported.config_toml.contains("hold_time"));
+}
+
 #[test]
 fn keepalive_mismatch_is_warned_never_guessed() {
     for (format, path, contents, needle) in [

--- a/tests/config_import_emitted_check.rs
+++ b/tests/config_import_emitted_check.rs
@@ -61,6 +61,44 @@ fn emitted_configs_pass_rustbgpd_check() {
     }
 }
 
+/// Fail-closed exit contract: when the emitted config is one the daemon's
+/// `--check` rejects (unparseable router-id, dangling peer-group reference),
+/// the import itself must exit nonzero — a clean exit 0 alongside a rejected
+/// translation would break the ladder's "operator attention is non-zero by
+/// construction" promise.
+#[test]
+fn import_exits_nonzero_when_emitted_config_fails_check() {
+    for (format, path, source) in [
+        (
+            SourceFormat::Frr,
+            "frr-badrid.conf",
+            "router bgp 64500\n bgp router-id 2001:db8::1\n \
+             neighbor 192.0.2.1 remote-as 64496\n!\n",
+        ),
+        (
+            SourceFormat::Gobgp,
+            "gobgp-dangling.toml",
+            "[global.config]\nas = 64500\nrouter-id = \"192.0.2.10\"\n[[neighbors]]\n\
+             [neighbors.config]\nneighbor-address = \"192.0.2.1\"\npeer-as = 64496\n\
+             peer-group = \"CORE\"\n",
+        ),
+    ] {
+        let imported = import_source(format, path, source)
+            .unwrap_or_else(|e| panic!("{path}: import failed: {e}"));
+        let (code, _stdout, stderr) = run_check(&imported.config_toml);
+        assert_ne!(
+            code,
+            Some(0),
+            "{path}: precondition — the emitted config must fail --check:\n{stderr}"
+        );
+        assert_ne!(
+            imported.report.exit_code, 0,
+            "{path}: import exited 0 while emitting a --check-rejected config:\n{}",
+            imported.config_toml
+        );
+    }
+}
+
 /// The defect this gate exists for: an imported config has no policy, and
 /// `--check` is the last thing an operator runs before copying it to a
 /// production box. It must name the unpoliced neighbors, and its summary


### PR DESCRIPTION
## Mechanism

`rbgp config import` could exit 0 while emitting a config that `rustbgpd --check` refuses to load, violating the importer's printed exit-code contract ("anything requiring operator attention is non-zero by construction"). Three mechanisms:

1. **router-id copied verbatim, never parsed** — all three frontends (BIRD `router id`, FRR `bgp router-id`, GoBGP `router-id`) copy the value straight through; a non-IPv4 or unspecified (`0.0.0.0`) value passed silently and was rejected by daemon validation at check time.
2. **Dangling peer-group references** — neighbor `peer_group` was emitted with no cross-check against the set of translated groups (the group list was consulted only for the remote-AS fallback); the daemon rejects via `UndefinedPeerGroup`.
3. **Silent numeric drops** — GoBGP's `as_u32`/`u16::try_from(...).ok()` conversions dropped oversized or negative `peer-as`, `hold-time`, `keepalive-interval`, `max-prefixes`, and local `as` values without a trace; FRR's keepalive ratio check silently no-opped on an unparseable keepalive. (BIRD numeric parse failures already landed on the skip ladder; now pinned by test.)

## Fix

Importer-local, no new exit codes. Both `--check`-rejection mechanisms are guarded once at the shared `finish()` seam in `crates/cli/src/importer/mod.rs`, covering all three frontends: the guard feeds the existing warning ladder (exit 2), names the offending value, and states that `--check` rejects the config until it is fixed. Values are still emitted verbatim — the report names them, the exit code forces the review.

Every numeric drop now produces a warning naming the field, the source value, and what was done (`u32_field`/`u16_field` wrappers in `gobgp.rs`; the `Err` arm of `warn_keepalive` in `frr.rs`). Refusal errors (exit 3) now carry the frontend warnings that explain them — an out-of-range local `as` no longer reads as "no local AS found" with no cause.

## Red-proof

Each new test was run against the unfixed tree first:

- 7 of 8 new `crates/cli/tests/config_import.rs` tests failed pre-fix (exit code 0 where 2 was required; missing warnings; refusal message omitting the dropped field). The eighth (`bird_out_of_range_hold_time_lands_on_the_skip_ladder`) is a pin of existing correct behavior and passed pre-fix by design.
- The new end-to-end test `import_exits_nonzero_when_emitted_config_fails_check` (workspace `tests/config_import_emitted_check.rs`) failed pre-fix with the exact defect: `import exited 0 while emitting a --check-rejected config` containing `router_id = "2001:db8::1"`, after its precondition confirmed the real daemon's `--check` rejects that config.

All fail with the fix reverted; all pass with it applied.

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test --workspace --no-fail-fast` — exit 0
- `cargo doc --workspace --no-deps` — exit 0