### PR TITLE
fix(config): canonicalize static neighbor addresses at load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `as`; FRR unparseable keepalive) now name the field, the source value, and
   what was done instead of being silently dropped.
 
+- **A cosmetic IPv6 respelling of a static neighbor address no longer tears
+  down and re-establishes the session on reload.** Neighbor addresses are
+  canonicalized at config load, so rewriting `2001:DB8:0:0:0:0:0:1` as
+  `2001:db8::1` diffs as no change, and runtime lookups (policy chains,
+  peer-group membership, persisted delete) match a non-canonical on-disk
+  spelling. A genuine address change still reconciles as remove+add.
+
 ## [0.61.0] — 2026-07-26
 
 > **Release framing.** This is the policy-safety line. RFC 8212

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -177,6 +177,19 @@ impl Config {
             return Err(diagnostic::render_diagnostic(content, source_name, &error)
                 .unwrap_or_else(|| format!("error: {error}")));
         }
+        // Canonicalize static neighbor address spellings. Reload diffs and
+        // runtime lookups compare the config string against
+        // `IpAddr::to_string()`, so a representation-only respelling
+        // (`2001:DB8:0:0:0:0:0:1` vs `2001:db8::1`) would otherwise read
+        // as remove+add — a real session teardown — or silently miss.
+        // Validation already rejected any unparseable static address and
+        // duplicate detection already keys on the parsed `IpAddr`, so this
+        // cannot fail or create collisions.
+        for neighbor in &mut config.neighbors {
+            if let Ok(address) = neighbor.address.parse::<IpAddr>() {
+                neighbor.address = address.to_string();
+            }
+        }
         Ok(config)
     }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -6358,6 +6358,98 @@ fn diff_neighbors_no_changes() {
     assert!(diff.changed.is_empty());
 }
 
+fn loaded_config_with_neighbor_address(address: &str) -> Config {
+    let toml_str = tier_authorized_uds_test_config(&format!(
+        r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[[neighbors]]
+address = "{address}"
+remote_asn = 65002
+"#
+    ));
+    Config::load_toml_with_diagnostics(&toml_str, "canonicalization test").unwrap()
+}
+
+#[test]
+fn load_canonicalizes_static_neighbor_address_spelling() {
+    // Uppercase, zero-expanded, and fully-expanded spellings all load as
+    // the one canonical form, so raw-string address comparisons against
+    // `IpAddr::to_string()` cannot silently miss.
+    for spelling in [
+        "2001:db8::1",
+        "2001:DB8::1",
+        "2001:db8:0:0:0:0:0:1",
+        "2001:0db8:0000:0000:0000:0000:0000:0001",
+    ] {
+        let config = loaded_config_with_neighbor_address(spelling);
+        assert_eq!(
+            config.neighbors[0].address, "2001:db8::1",
+            "spelling {spelling} must canonicalize"
+        );
+    }
+}
+
+#[test]
+fn reload_with_respelled_ipv6_neighbor_diffs_empty() {
+    // A representation-only respelling of the same IPv6 address is the
+    // same peer: reload must plan no session teardown (no removed+added
+    // pair) and no change.
+    let old = loaded_config_with_neighbor_address("2001:db8::1");
+    for respelled in [
+        "2001:DB8::1",
+        "2001:db8:0:0:0:0:0:1",
+        "2001:0db8:0000:0000:0000:0000:0000:0001",
+    ] {
+        let new = loaded_config_with_neighbor_address(respelled);
+        let diff = super::diff_neighbors(&old.neighbors, &new.neighbors);
+        assert!(
+            diff.removed.is_empty(),
+            "{respelled}: respelling must not plan a session teardown: {:?}",
+            diff.removed
+        );
+        assert!(
+            diff.added.is_empty(),
+            "{respelled}: respelling must not plan a session add: {:?}",
+            diff.added
+        );
+        assert!(
+            diff.changed.is_empty(),
+            "{respelled}: respelling is not a neighbor change"
+        );
+    }
+}
+
+#[test]
+fn genuine_ipv6_address_change_still_diffs_removed_and_added() {
+    // Canonicalization must not mask a real address change.
+    let old = loaded_config_with_neighbor_address("2001:db8::1");
+    let new = loaded_config_with_neighbor_address("2001:db8::2");
+    let diff = super::diff_neighbors(&old.neighbors, &new.neighbors);
+    assert_eq!(diff.removed.len(), 1);
+    assert_eq!(
+        diff.removed[0],
+        PeerKey::new("2001:db8::1".parse::<IpAddr>().unwrap(), None)
+    );
+    assert_eq!(diff.added.len(), 1);
+    assert_eq!(diff.added[0].address, "2001:db8::2");
+    assert!(diff.changed.is_empty());
+}
+
+#[test]
+fn ipv4_neighbor_address_load_is_identity() {
+    // `IpAddr` round-trip is the identity for a valid dotted quad; pin it.
+    let config = loaded_config_with_neighbor_address("192.0.2.1");
+    assert_eq!(config.neighbors[0].address, "192.0.2.1");
+}
+
 #[test]
 fn diff_neighbors_ignores_tcp_ao_only_changes_because_reload_pins_them() {
     let old = vec![test_neighbor("10.0.0.1", 65001)];

--- a/src/config_persister.rs
+++ b/src/config_persister.rs
@@ -451,6 +451,54 @@ log_format = "json"
     }
 
     #[tokio::test]
+    async fn delete_neighbor_matches_noncanonical_on_disk_spelling() {
+        // The delete path compares the config string against
+        // `IpAddr::to_string()`; a non-canonical on-disk spelling must
+        // still delete the same neighbor.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let toml_str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[[neighbors]]
+address = "2001:DB8:0:0:0:0:0:1"
+remote_asn = 65002
+"#;
+        std::fs::write(&path, toml_str).unwrap();
+        let config = Config::load_toml_with_diagnostics(
+            &crate::test_support::tier_authorized_uds_test_config(toml_str),
+            "noncanonical spelling test",
+        )
+        .unwrap();
+
+        let (tx, rx) = mpsc::channel(16);
+        let persister = ConfigPersister::new(rx, path.clone(), config, None);
+        let handle = tokio::spawn(persister.run());
+
+        tx.send(ConfigMutation::DeleteNeighbor(
+            "2001:db8::1".parse().unwrap(),
+        ))
+        .await
+        .unwrap();
+        drop(tx);
+        handle.await.unwrap();
+
+        let reloaded: Config = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(
+            reloaded.neighbors.is_empty(),
+            "delete must match the respelled neighbor: {:?}",
+            reloaded.neighbors
+        );
+    }
+
+    #[tokio::test]
     async fn add_then_delete_round_trips() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -2930,7 +2930,7 @@ mod tests {
             ("confirm_journal.rs", include_str!("confirm_journal.rs"), 2),
             ("gnmi_set_bridge.rs", include_str!("gnmi_set_bridge.rs"), 2),
             ("main.rs", include_str!("main.rs"), 2),
-            ("policy_admin.rs", include_str!("policy_admin.rs"), 2),
+            ("policy_admin.rs", include_str!("policy_admin.rs"), 3),
         ];
 
         for (path, source, helper_count) in module_sources {

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -931,6 +931,41 @@ remote_asn = 65002
     }
 
     #[test]
+    fn neighbor_lookup_matches_noncanonical_config_spelling() {
+        // The lookup compares the config string against
+        // `IpAddr::to_string()`; a non-canonical on-disk spelling must
+        // still resolve to the same neighbor.
+        let toml = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+[peer_groups.fabric]
+
+[[neighbors]]
+address = "2001:DB8:0:0:0:0:0:1"
+remote_asn = 65002
+peer_group = "fabric"
+"#;
+        let config = Config::load_toml_with_diagnostics(
+            &tier_authorized_uds_test_config(toml),
+            "noncanonical spelling test",
+        )
+        .unwrap();
+        let address: IpAddr = "2001:db8::1".parse().unwrap();
+        assert_eq!(
+            neighbor_peer_group_from_config(&config, address),
+            Some(Some("fabric".to_string()))
+        );
+        assert!(neighbor_policy_chains_from_config(&config, address).is_some());
+    }
+
+    #[test]
     fn neighbor_added_event_preserves_session_fields() {
         // Mutation-red for min_hold_time: deleting persistence projection
         // leaves the inserted neighbor at None instead of 30.


### PR DESCRIPTION
## Problem

`diff_neighbors` keys on the raw config string `(address, interface)`, so a representation-only IPv6 respelling of a static neighbor — `2001:DB8:0:0:0:0:0:1` rewritten as `2001:db8::1` — diffed as removed+added and tore down a real established session on reload. If the compensating re-add then failed, the peer was stranded with the failure only logged. Roughly ten more sites compare the raw config string against `IpAddr::to_string()` and silently missed non-canonical spellings: policy-chain and peer-group lookups (`src/peer_manager/policy.rs`, `src/policy_admin.rs`, `src/peer_manager/lifecycle.rs`) and persisted neighbor delete (`src/config_persister.rs`).

## Fix

Rewrite each static `neighbor.address` to its canonical `IpAddr` form at the single config-load choke point (`load_from_toml_source_with_datasets`), immediately after validation succeeds. Every config entry path — initial load, SIGHUP reload, staged-dataset reload, candidate/transaction TOML, runtime snapshots, gNMI candidates — routes through that function, and runtime-constructed neighbors already render their address from an `IpAddr`, so one rewrite covers every comparison site. Validation has already rejected unparseable static addresses and keys duplicate detection on the parsed `IpAddr`, so canonicalization cannot fail or create collisions. Interface scope and dynamic-neighbor prefixes are untouched.

## Red proof

All four behavior tests were written first and run against the unfixed tree:

- `config::tests::reload_with_respelled_ipv6_neighbor_diffs_empty` — FAILED: `2001:DB8::1: respelling must not plan a session teardown: [PeerKey { address: 2001:db8::1, interface: None }]`
- `config::tests::load_canonicalizes_static_neighbor_address_spelling` — FAILED: `left: "2001:DB8::1" / right: "2001:db8::1"`
- `policy_admin::tests::neighbor_lookup_matches_noncanonical_config_spelling` — FAILED: `left: None / right: Some(Some("fabric"))`
- `config_persister::tests::delete_neighbor_matches_noncanonical_on_disk_spelling` — FAILED: `delete must match the respelled neighbor: [Neighbor { address: "2001:DB8:0:0:0:0:0:1", ... }]`

Two invariant pins passed both before and after, as intended: a genuine address change still diffs as removed+added (`genuine_ipv6_address_change_still_diffs_removed_and_added`), and IPv4 dotted-quad load is the identity (`ipv4_neighbor_address_load_is_identity`). All six are green with the fix.

## Gates

- `cargo fmt --all -- --check` → 0
- `cargo clippy --workspace --all-targets -- -D warnings` → 0
- `cargo test --workspace --no-fail-fast` → 0
- `cargo doc --workspace --no-deps` → 0
- `python3 scripts/check-v1-stable-surface.py` → 0