### PR TITLE
docs: document injection ORIGIN values in the proto; true up ROADMAP service count

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,7 +51,7 @@ those.
 | Policy: prefix lists, named chains, actions, community/AS_PATH/validation match | Shipped | GoBGP-style chain evaluation |
 | Policy: `.rpol` typed compiled language (ADR-0096) | Shipped | Named sets, `u32` parameters, in-language tests (`rbgp policy check`), live-RIB dry run (`rbgp policy test`), per-term explain traces + live hit counters (`rbgp policy stats`); M80 FRR route-map parity receipt |
 | BFD single-hop async + RFC 5882 coupling | Partial | M51 receipt revalidated green on current main by #1093 (`8b8f76e8`); receive-work budgeting and remote-AdminDown coupling corrections shipped; authentication remains demand/interoperability gated by ADR-0117 |
-| Observability & API: gRPC (11 services), Prometheus, structured logs, durable event history | Shipped | ADR-0072 outbox + `SubscribeFromEvent` |
+| Observability & API: gRPC (12 services), Prometheus, structured logs, durable event history | Shipped | ADR-0072 outbox + `SubscribeFromEvent` |
 | gNMI / OpenConfig telemetry + Set subset | Partial | `Get` / `Subscribe`, BGP state subset; static numbered-neighbor `Set` + commit-confirmed; broader OpenConfig config/state deferred |
 | BMP trio (7854 + 8671 Adj-RIB-Out + 9069 Loc-RIB) + BMPv4/path-marking drafts, MRT dump (6396) | Shipped | Per-collector views + `version = 3\|4`; ADR-0097, M81 receipt |
 | FlowSpec (8955/8956, IPv4/IPv6) | Shipped | All 13 component types |

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -2774,6 +2774,8 @@ message AddPathRequest {
   uint32 prefix_length = 2;
   string next_hop = 3;
   repeated uint32 as_path = 4;
+  // ORIGIN path attribute: 0 = IGP, 1 = EGP, 2 = INCOMPLETE.
+  // Any other value is rejected with INVALID_ARGUMENT.
   uint32 origin = 5;
   optional uint32 local_pref = 6;
   optional uint32 med = 7;


### PR DESCRIPTION
Two truth fixes from the post-merge review:

- `AddPathRequest.origin` gained fail-closed validation in #1226, but the proto comment never stated the accepted mapping. Document 0 = IGP, 1 = EGP, 2 = INCOMPLETE, and that any other value is rejected with `INVALID_ARGUMENT`.
- `ROADMAP.md` still said "gRPC (11 services)" after the count moved to twelve — the one site the #1230 sweep missed.

Comment-only proto change; regenerated codegen from clean and gated: fmt=0, clippy=0, api tests=0, doc=0.