### PR TITLE
fix(cli): name the reason on the decode-ceiling constant assertion

### DIFF
--- a/crates/cli/src/connection.rs
+++ b/crates/cli/src/connection.rs
@@ -539,7 +539,10 @@ mod tests {
     // current VPN fixture) while staying finite — never `usize::MAX`.
     // The upper-bound assertion is deliberately constant: it is the
     // fence that goes red if the ceiling is ever made unbounded.
-    #[allow(clippy::assertions_on_constants)]
+    #[allow(
+        clippy::assertions_on_constants,
+        reason = "the constant upper-bound assert is the mutation fence that goes red if the ceiling is ever made unbounded"
+    )]
     #[test]
     fn listing_decode_ceiling_budget_rationale() {
         let widest_row = crate::proto::VpnRouteEntry {


### PR DESCRIPTION
CI's clippy reason-ratchet (`scripts/check-clippy-reasons.py`) rejects the bare `#[allow(clippy::assertions_on_constants)]` that #1229 added on the budget-rationale test — this was the sole CI failure on main since `75f4f80e`. Add the reason string naming the assert as the mutation fence for an unbounded ceiling.

Gates: ratchet=0, fmt=0, clippy=0, targeted test=0.