### PR TITLE
docs: correct the v0.61 release contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,9 +74,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   full-table explainability anyway — full price for a partial answer.
   Sizing guidance, labelled figures, and the conditions that would
   reopen the decision are under *Changed* and in ADR-0073.
-- **`rustbgpd-wire` 0.16.0 changes decode acceptance in six places**
-  while keeping an additive API. Embedders should read the *Library
-  crates* entry under *Changed* before bumping.
+- **`rustbgpd-wire` 0.16.0 changes binary decode acceptance in six places**
+  and separately accepts the displayed unknown-type Route Distinguisher
+  fallback in its text parser, while keeping an additive API. Embedders should
+  read the *Library crates* entry under *Changed* before bumping.
 
 **Policy safety**
 
@@ -120,8 +121,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `rbgp config import` exits nonzero when its emitted config would fail
   `rustbgpd --check`, route injection rejects out-of-range ORIGIN values
   and the limited-broadcast next hop instead of coercing or accepting
-  them, and full native RIB/EVPN listings decode up to a finite 64 MiB
-  instead of failing near tonic's 4 MiB default.
+  them, and full native RIB listings plus EVPN route-list queries decode up
+  to a finite 64 MiB instead of failing near tonic's 4 MiB default.
 
 **Protocol conformance**
 
@@ -160,9 +161,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 **Library crates**
 
-- `rustbgpd-wire` 0.16.0 (additive API, six decode-acceptance changes)
-  and `rustbgpd-fsm` 0.3.1 (two additive fields on a `#[non_exhaustive]`
-  struct).
+- `rustbgpd-wire` 0.16.0 (additive API, six binary decode-acceptance changes,
+  plus additive unknown-RD text-parser acceptance) and `rustbgpd-fsm` 0.3.1
+  (two additive fields on a `#[non_exhaustive]` struct).
 
 ### Added
 
@@ -885,6 +886,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Decoded-value comparisons must also account for RFC 8092 Large Community
   duplicate normalization, which keeps the first occurrence.
 
+  Separately from those six binary wire-decode changes,
+  `RouteDistinguisher::from_str` now accepts the `Display` fallback for an
+  unknown RD type: `0x` followed by exactly 16 hexadecimal digits. Fallback
+  text for the structured types 0, 1, and 2 remains noncanonical and is
+  rejected. The non-exhaustive public `RouteDistinguisherParseError` enum
+  gains `InvalidHexFallback(String)` for malformed or noncanonical fallback
+  text. This is an additive text-parser acceptance and API change, not a
+  seventh binary decoder change.
+
   `rustbgpd-fsm` 0.3.1 keeps its public API backward-compatible:
   `PeerConfig` gains `min_hold_time: Option<u16>` and
   `required_families: Vec<(Afi, Safi)>`, and `PeerConfig` is
@@ -1475,12 +1485,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   peer-group membership, persisted delete) match a non-canonical on-disk
   spelling. A genuine address change still reconciles as remove+add.
 
-- **Full native RIB and EVPN listings no longer fail with `out of range`
-  near 4 MiB.** The `rbgp` full unary listing surfaces (`rib
-  bgpls|vpn|labeled|rtc|blackholes|fib`, `flowspec`, `evpn list|diagnose`,
-  `topology nodes|links`, `orr`) now decode responses up to a finite 64 MiB
-  ceiling — roughly 0.7-1.3 million rows — instead of tonic's 4 MiB client
-  default. Responses above the ceiling still fail closed as `out of range`;
+- **Full native RIB and EVPN route listings no longer fail with `out of
+  range` near 4 MiB.** The `rbgp` full unary listing surfaces (`rib
+  bgpls|vpn|labeled|rtc|blackholes|fib`, `flowspec`, `evpn list`, the route
+  subqueries made by `evpn diagnose`, `topology nodes|links`, and `orr`) now
+  decode responses up to a finite 64 MiB ceiling instead of tonic's 4 MiB
+  client default. The non-route `evpn diagnose` calls
+  (`ListEvpnInstances` and `GetMetrics`) retain tonic's default ceiling.
+  Responses above the selected ceiling still fail closed as `out of range`;
   paginated unicast listings, streams, and control RPCs keep the default.
   Client-side only: no daemon, protobuf, or pagination change.
 

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -100,6 +100,15 @@ acceptance/type list: duplicate RFC 8092 Large Communities retain only their
 first occurrence. Consumers that compare decoded attribute values should
 account for that stable deduplication too.
 
+Separately from those six binary wire-decode changes,
+`RouteDistinguisher::from_str` now accepts the `Display` fallback for an
+unknown RD type: `0x` followed by exactly 16 hexadecimal digits. Raw fallback
+text for the structured types 0, 1, and 2 remains noncanonical and is rejected.
+The non-exhaustive public `RouteDistinguisherParseError` enum gains
+`InvalidHexFallback(String)` for malformed or noncanonical fallback text. This
+is an additive text-parser acceptance and API change; it does not change the
+six-item binary decoder list above.
+
 ### 0.15.0 compatibility note
 
 0.15.0 added `Capability::PathsLimit`: code 76 now decodes to typed
@@ -195,7 +204,11 @@ let bytes = encode_message(&Message::Open(open)).expect("encode OPEN");
   `RtcNlri` / `RTC_SAFI` / `RTC_MAX_PREFIX_BITS`, `decode_rtc_nlri` /
   `encode_rtc_nlri` with default-route and prefix-bit bounds
 - **`PmsiTunnel`** / **`PmsiTunnelType`** / **`PmsiTunnelIdentifier`** — PMSI Tunnel attribute (RFC 6514 §5) carried on EVPN Type 3 IMET routes for ingress-replication BUM. Constructor `PmsiTunnel::for_evpn_ingress_replication(vni, ip)` emits the RFC 8365 §5.1.3 wire shape (raw 24-bit VNI in the label field, originator IP as the tunnel identifier).
-- **`RouteDistinguisher`** — RFC 4364 §4.2 8-byte RD, used by EVPN and VPNv4/v6. Implements `Display` + `FromStr` for the standard `asn:val` / `ipv4:val` textual encodings
+- **`RouteDistinguisher`** — RFC 4364 §4.2 8-byte RD, used by EVPN and
+  VPNv4/v6. Implements `Display` + `FromStr` for the structured `asn:val` /
+  `ipv4:val` textual encodings and the exact `0x<16-hex-digits>` display
+  fallback for unknown RD types; malformed or noncanonical fallback text
+  returns `RouteDistinguisherParseError::InvalidHexFallback`
 - **`DfElectionExtendedCommunity`** (`attribute`) — RFC 8584 §2.2 / RFC 9785 §3 DF Election Extended Community: `ExtendedCommunity::as_df_election()` decodes one, `ExtendedCommunity::df_election(algorithm, capabilities, preference: Option<u16>)` constructs it (EVPN DF election algorithm, capabilities, and the RFC 9785 preference / Don't-Preempt fields)
 - **Link Bandwidth** (RFC 10005 §§2, 3.2) — `ExtendedCommunity::as_link_bandwidth()` decodes exact type 0x00/0x40, subtype 0x04, without interpreting the raw AS/float payload; `ExtendedCommunity::link_bandwidth(asn, bytes_per_sec)` continues to construct non-transitive type 0x40
 - **Origin Validation State** (RFC 8097) — `ExtendedCommunity::ORIGIN_VALIDATION_VALID` /

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -73,7 +73,9 @@ Public surface (re-exported at crate root — `crates/wire/src/lib.rs`):
 - **EVPN** (`EvpnRoute`/`EvpnRouteKey`, Types 1–5; route keys implement `Ord`),
   **FlowSpec** (`FlowSpecRule`),
   **VPNv4/v6** (`vpn` module), **BGP-LS** (`bgpls` module), **ORF** (`orf` module),
-  **PMSI Tunnel**, **Route Distinguisher**.
+  **PMSI Tunnel**, **Route Distinguisher** (`Display`/`FromStr` for the three
+  structured RFC 4364 forms and the exact `0x<16-hex-digits>` display fallback
+  for unknown RD types).
 - **Well-known community constants** (`COMMUNITY_NO_EXPORT`, `COMMUNITY_BLACKHOLE`,
   `COMMUNITY_GRACEFUL_SHUTDOWN`, `COMMUNITY_LLGR_STALE`, ...).
 - **`DecodeError` / `EncodeError`** via `thiserror`.
@@ -123,6 +125,11 @@ carries the itemized list under "0.16.0 compatibility note"; diff exactly that
 list before you upgrade a consumer that asserts on acceptance or typed
 variants. Consumers comparing decoded values must also account for RFC 8092
 Large Community duplicate normalization, which keeps the first occurrence.
+Separately, `RouteDistinguisher::from_str` now accepts the displayed
+`0x<16-hex-digits>` fallback for unknown RD types and the non-exhaustive
+`RouteDistinguisherParseError` gains `InvalidHexFallback(String)`. That is an
+additive text-parser acceptance and API change, not a seventh binary
+wire-decode change.
 
 ---
 
@@ -301,7 +308,8 @@ and `policy` are later.**
    with its `PathsLimitFamily` entry type (experimental capability code 76),
    the `Ord` implementation on `EvpnRouteKey`, and `#[non_exhaustive]` across
    the registry-tracking enums. The prepared `0.16.0` is additive at the API
-   level with six decode-acceptance changes (§2.3).
+   level with six binary decode-acceptance changes plus the separate additive
+   Route Distinguisher text-parser change described in §2.3.
 
 2. **`rustbgpd-fsm` (published as `0.3.0`; `0.3.1` prepared).** The prepared
    `0.3.1` keeps the public API backward-compatible: `PeerConfig` gains

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -120,8 +120,8 @@ consequences so future contributors understand *why*, not just *what*.
 | [0109](0109-update-group-shared-encode.md) | Encode-once wire sharing for update-group fanout | Accepted | 2026-07-16 |
 | [0110](0110-irr-peeringdb-filtering-pipeline.md) | IRR/PeeringDB-driven filtering pipeline — ride arouteserver, defer native ingestion | Proposed | 2026-07-17 |
 | [0111](0111-authoritative-policy-replacement-continuation.md) | Actor-owned authoritative export-policy replacement continuation | Rejected (borrow-free Gate 1 NO-GO) | 2026-07-20 |
-| [0112](0112-rfc-8212-ebgp-requires-policy.md) | Opt-in RFC 8212 explicit-policy enforcement for eBGP | Proposed | 2026-07-21 |
-| [0113](0113-outbound-prefix-limits.md) | Per-peer outbound unicast prefix limits | Proposed | 2026-07-21 |
+| [0112](0112-rfc-8212-ebgp-requires-policy.md) | Opt-in RFC 8212 explicit-policy enforcement for eBGP | Accepted — fully shipped | 2026-07-21 |
+| [0113](0113-outbound-prefix-limits.md) | Per-peer outbound unicast prefix limits | Accepted — released in v0.61.0 | 2026-07-21 |
 | [0114](0114-as4-path-migration.md) | RFC 6793 AS4 path migration across legacy peers | Accepted | 2026-07-21 |
 | [0115](0115-lean-daemon-build-flavors.md) | Lean daemon build flavors | Accepted (no additional flavor) | 2026-07-22 |
 | [0116](0116-rfc-9857-sr-policy-state.md) | RFC 9857 SR Policy state in BGP-LS | Accepted (feature implementation demand-gated) | 2026-07-22 |


### PR DESCRIPTION
## Summary

- synchronize ADR-0112 and ADR-0113 index statuses with their shipped records
- document the additive `RouteDistinguisher` unknown-type hex parser and `InvalidHexFallback` API without changing the separate six-item binary decoder count
- scope the 64 MiB `evpn diagnose` claim to its route subqueries and remove the fixture-derived general row estimate

## Why

The v0.61 release packet had drifted from the code after the wire version bump and overstated one CLI decode-ceiling boundary. This keeps the extraction-ready notes and published-crate documentation accurate for operators and embedders.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings` (commit hook)
- `cargo doc --workspace --no-deps`
- `python3 scripts/reflow-release-notes.py --selftest`
- exact 0.61.0 release-note extraction and reflow produced a non-empty 88,525-byte body
- `git diff --check`

Docs-only load-bearing proof: N/A; no executable test or gate changed.