### PR TITLE
fix: keep imported configs honest at validation edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1470,13 +1470,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **`rbgp config import` now exits nonzero when the emitted config would be
   rejected by `rustbgpd --check`.** A source router-id that is not a usable
-  IPv4 address (all three frontends copy it verbatim) and a neighbor
-  `peer_group` reference that resolves to no translated peer group are
-  reported as warnings (exit 2) instead of leaving the importer with a clean
-  exit alongside an unloadable translation. Out-of-range numeric fields
-  (GoBGP `peer-as`, `hold-time`, `keepalive-interval`, `max-prefixes`, local
-  `as`; FRR unparseable keepalive) now name the field, the source value, and
-  what was done instead of being silently dropped.
+  IPv4 address (all three frontends copy it verbatim), reserved local or
+  remote AS 0, an unscoped IPv6 link-local neighbor, duplicate typed neighbor
+  identities or peer-group names, and a neighbor `peer_group` reference that
+  resolves to no translated group are reported as warnings (exit 2) instead
+  of leaving the importer with a clean exit alongside an unloadable
+  translation. Group hold times 1–2 are raised to the protocol minimum just
+  like neighbor hold times, and decoded control characters are re-escaped
+  before TOML emission. Out-of-range numeric fields (GoBGP `peer-as`,
+  `hold-time`, `keepalive-interval`, `max-prefixes`, local `as`; FRR
+  unparseable keepalive) now name the field, the source value, and what was
+  done instead of being silently dropped.
 
 - **A cosmetic IPv6 respelling of a static neighbor address no longer tears
   down and re-establishes the session on reload.** Neighbor addresses are

--- a/crates/cli/src/importer/mod.rs
+++ b/crates/cli/src/importer/mod.rs
@@ -308,14 +308,22 @@ fn finish(
         items.append(&mut model.warnings);
         return Err(ImportError::Empty(items));
     };
+    if local_asn == 0 {
+        model.warnings.push(
+            "local AS 0 is reserved; emitted verbatim — `rustbgpd --check` rejects this \
+             config until a non-zero ASN is configured"
+                .to_owned(),
+        );
+    }
 
     // Resolve remote AS down from groups (rustbgpd peer groups carry no
     // remote_asn) and drop neighbors that cannot be emitted, moving
     // each to the skip list — a neighbor silently dropped would be a
     // lie, a neighbor emitted without a remote AS fails `--check`.
     let mut neighbors = Vec::new();
+    let mut seen_neighbor_addresses = std::collections::HashSet::new();
     for mut neighbor in std::mem::take(&mut model.neighbors) {
-        if neighbor.address.parse::<std::net::IpAddr>().is_err() {
+        let Ok(address) = neighbor.address.parse::<std::net::IpAddr>() else {
             model.skips.push(Skip {
                 line: line_opt(neighbor.source_line),
                 stanza: format!("neighbor {}", neighbor.address),
@@ -324,7 +332,7 @@ fn finish(
                     .to_owned(),
             });
             continue;
-        }
+        };
         if neighbor.remote_asn.is_none() {
             neighbor.remote_asn = neighbor
                 .peer_group
@@ -341,6 +349,29 @@ fn finish(
                     .to_owned(),
             });
             continue;
+        }
+        if matches!(address, std::net::IpAddr::V6(ip) if ip.is_unicast_link_local()) {
+            model.warnings.push(format!(
+                "neighbor {} is IPv6 link-local, but the importer cannot preserve its \
+                 required interface scope; emitted without an interface — `rustbgpd \
+                 --check` rejects this config until the interface is added",
+                neighbor.address
+            ));
+        }
+        if !seen_neighbor_addresses.insert(address) {
+            model.warnings.push(format!(
+                "duplicate neighbor {} resolves to the same IP address as an earlier \
+                 neighbor; emitted verbatim — `rustbgpd --check` rejects duplicate \
+                 neighbor identities until one is removed",
+                neighbor.address
+            ));
+        }
+        if neighbor.remote_asn == Some(0) {
+            model.warnings.push(format!(
+                "neighbor {}: remote AS 0 is reserved; emitted verbatim — `rustbgpd \
+                 --check` rejects this config until a non-zero remote_asn is configured",
+                neighbor.address
+            ));
         }
         if let Some(hold) = neighbor.hold_time
             && hold != 0
@@ -363,7 +394,25 @@ fn finish(
         items.append(&mut model.warnings);
         return Err(ImportError::Empty(items));
     }
+    let mut seen_group_names = std::collections::HashSet::new();
     for group in &mut model.groups {
+        if !seen_group_names.insert(group.name.clone()) {
+            model.warnings.push(format!(
+                "duplicate peer group {:?} would emit the same TOML table twice; \
+                 `rustbgpd --check` rejects this config until one definition is removed",
+                group.name
+            ));
+        }
+        if let Some(hold) = group.hold_time
+            && hold != 0
+            && hold < 3
+        {
+            model.warnings.push(format!(
+                "peer group {}: hold time {hold} raised to the protocol minimum 3",
+                group.name
+            ));
+            group.hold_time = Some(3);
+        }
         dedupe(&mut group.families);
     }
 
@@ -470,9 +519,21 @@ fn dedupe(families: &mut Vec<String>) {
 }
 
 fn toml_escape(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace(['\n', '\r'], " ")
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            ch if ch.is_control() => {
+                let _ = write!(out, "\\u{:04X}", u32::from(ch));
+            }
+            ch => out.push(ch),
+        }
+    }
+    out
 }
 
 fn write_families(out: &mut String, families: &[String]) {

--- a/tests/config_import_emitted_check.rs
+++ b/tests/config_import_emitted_check.rs
@@ -62,18 +62,21 @@ fn emitted_configs_pass_rustbgpd_check() {
 }
 
 /// Fail-closed exit contract: when the emitted config is one the daemon's
-/// `--check` rejects (unparseable router-id, dangling peer-group reference),
-/// the import itself must exit nonzero — a clean exit 0 alongside a rejected
-/// translation would break the ladder's "operator attention is non-zero by
-/// construction" promise.
+/// `--check` rejects, the import itself must exit nonzero — a clean exit 0
+/// alongside a rejected translation would break the ladder's "operator
+/// attention is non-zero by construction" promise.
+///
+/// Load-bearing proof: removing any corresponding `finish` guard makes that
+/// case return exit 0 while the real daemon still rejects its output.
 #[test]
 fn import_exits_nonzero_when_emitted_config_fails_check() {
-    for (format, path, source) in [
+    for (format, path, source, warning) in [
         (
             SourceFormat::Frr,
             "frr-badrid.conf",
             "router bgp 64500\n bgp router-id 2001:db8::1\n \
              neighbor 192.0.2.1 remote-as 64496\n!\n",
+            "router-id",
         ),
         (
             SourceFormat::Gobgp,
@@ -81,6 +84,84 @@ fn import_exits_nonzero_when_emitted_config_fails_check() {
             "[global.config]\nas = 64500\nrouter-id = \"192.0.2.10\"\n[[neighbors]]\n\
              [neighbors.config]\nneighbor-address = \"192.0.2.1\"\npeer-as = 64496\n\
              peer-group = \"CORE\"\n",
+            "CORE",
+        ),
+        (
+            SourceFormat::Frr,
+            "frr-local-as-zero.conf",
+            "router bgp 0\n bgp router-id 192.0.2.10\n \
+             neighbor 192.0.2.1 remote-as 64496\n!\n",
+            "local AS 0",
+        ),
+        (
+            SourceFormat::Frr,
+            "frr-remote-as-zero.conf",
+            "router bgp 64500\n bgp router-id 192.0.2.10\n \
+             neighbor 192.0.2.1 remote-as 0\n!\n",
+            "remote AS 0",
+        ),
+        (
+            SourceFormat::Gobgp,
+            "gobgp-inherited-remote-as-zero.toml",
+            "[global.config]\nas = 64500\nrouter-id = \"192.0.2.10\"\n\
+             [[peer-groups]]\n[peer-groups.config]\npeer-group-name = \"ixp\"\n\
+             peer-as = 0\n[[neighbors]]\n[neighbors.config]\n\
+             neighbor-address = \"192.0.2.1\"\npeer-group = \"ixp\"\n",
+            "remote AS 0",
+        ),
+        (
+            SourceFormat::Frr,
+            "frr-link-local.conf",
+            "router bgp 64500\n bgp router-id 192.0.2.10\n \
+             neighbor fe80::1 remote-as 64496\n!\n",
+            "link-local",
+        ),
+        (
+            SourceFormat::Frr,
+            "frr-duplicate-neighbor.conf",
+            "router bgp 64500\n bgp router-id 192.0.2.10\n \
+             neighbor 2001:0db8:0:0:0:0:0:1 remote-as 64496\n \
+             neighbor 2001:db8::1 remote-as 64497\n!\n",
+            "duplicate neighbor",
+        ),
+        (
+            SourceFormat::Bird,
+            "bird-duplicate-neighbor.conf",
+            "router id 192.0.2.10;\n\
+             protocol bgp n1 { local as 64500; \
+             neighbor 2001:0db8:0:0:0:0:0:1 as 64496; }\n\
+             protocol bgp n2 { local as 64500; neighbor 2001:db8::1 as 64497; }\n",
+            "duplicate neighbor",
+        ),
+        (
+            SourceFormat::Gobgp,
+            "gobgp-duplicate-neighbor.toml",
+            "[global.config]\nas = 64500\nrouter-id = \"192.0.2.10\"\n\
+             [[neighbors]]\n[neighbors.config]\n\
+             neighbor-address = \"2001:0db8:0:0:0:0:0:1\"\npeer-as = 64496\n\
+             [[neighbors]]\n[neighbors.config]\n\
+             neighbor-address = \"2001:db8::1\"\npeer-as = 64497\n",
+            "duplicate neighbor",
+        ),
+        (
+            SourceFormat::Bird,
+            "bird-duplicate-group.conf",
+            "router id 192.0.2.10;\n\
+             template bgp ixp { local as 64500; }\n\
+             template bgp ixp { local as 64500; }\n\
+             protocol bgp member from ixp { neighbor 192.0.2.1 as 64496; }\n",
+            "duplicate peer group",
+        ),
+        (
+            SourceFormat::Gobgp,
+            "gobgp-duplicate-group.toml",
+            "[global.config]\nas = 64500\nrouter-id = \"192.0.2.10\"\n\
+             [[peer-groups]]\n[peer-groups.config]\npeer-group-name = \"ixp\"\n\
+             peer-as = 64496\n[[peer-groups]]\n[peer-groups.config]\n\
+             peer-group-name = \"ixp\"\npeer-as = 64497\n[[neighbors]]\n\
+             [neighbors.config]\nneighbor-address = \"192.0.2.1\"\n\
+             peer-group = \"ixp\"\n",
+            "duplicate peer group",
         ),
     ] {
         let imported = import_source(format, path, source)
@@ -96,7 +177,149 @@ fn import_exits_nonzero_when_emitted_config_fails_check() {
             "{path}: import exited 0 while emitting a --check-rejected config:\n{}",
             imported.config_toml
         );
+        assert!(
+            imported
+                .report
+                .warnings
+                .iter()
+                .any(|message| message.contains(warning)),
+            "{path}: report did not name {warning:?}: {:?}",
+            imported.report.warnings
+        );
     }
+}
+
+/// Identity diagnostics apply only to neighbors that survive translation.
+///
+/// Load-bearing proof: moving link-local/duplicate checks ahead of the
+/// missing-AS skip reports two nonexistent emitted rows; the warning
+/// assertions fail even though the retained config remains daemon-valid.
+#[test]
+fn skipped_neighbors_do_not_poison_emitted_identity_checks() {
+    let source = "[global.config]\nas = 64500\nrouter-id = \"192.0.2.10\"\n\
+                  [[neighbors]]\n[neighbors.config]\nneighbor-address = \"fe80::1\"\n\
+                  [[neighbors]]\n[neighbors.config]\n\
+                  neighbor-address = \"2001:0db8:0:0:0:0:0:1\"\n\
+                  [[neighbors]]\n[neighbors.config]\n\
+                  neighbor-address = \"2001:db8::1\"\npeer-as = 64496\n";
+    let imported =
+        import_source(SourceFormat::Gobgp, "gobgp-skipped-identity.toml", source).expect("import");
+    assert_eq!(imported.report.skipped.len(), 2);
+    assert!(
+        imported
+            .report
+            .warnings
+            .iter()
+            .all(|message| !message.contains("link-local")
+                && !message.contains("duplicate neighbor")),
+        "{:?}",
+        imported.report.warnings
+    );
+    let (code, stdout, stderr) = run_check(&imported.config_toml);
+    assert_eq!(
+        code,
+        Some(0),
+        "retained config failed --check\nstdout:\n{stdout}\nstderr:\n{stderr}\nconfig:\n{}",
+        imported.config_toml
+    );
+}
+
+/// Group timers share the daemon's hold-time constraint with neighbors.
+///
+/// Load-bearing proof: removing the group normalization emits `hold_time = 2`,
+/// returns exit 0, and makes the real daemon reject the translation.
+#[test]
+fn invalid_group_hold_time_is_repaired_and_requires_review() {
+    let source = "[global.config]\nas = 64500\nrouter-id = \"192.0.2.10\"\n\
+                  [[peer-groups]]\n[peer-groups.config]\npeer-group-name = \"ixp\"\n\
+                  peer-as = 64496\n[peer-groups.timers.config]\nhold-time = 2\n\
+                  [[neighbors]]\n[neighbors.config]\n\
+                  neighbor-address = \"192.0.2.1\"\npeer-group = \"ixp\"\n";
+    let imported =
+        import_source(SourceFormat::Gobgp, "gobgp-group-hold.toml", source).expect("import");
+    let (code, stdout, stderr) = run_check(&imported.config_toml);
+    assert_eq!(
+        code,
+        Some(0),
+        "repaired config failed --check\nstdout:\n{stdout}\nstderr:\n{stderr}\nconfig:\n{}",
+        imported.config_toml
+    );
+    assert!(imported.config_toml.contains("hold_time = 3"));
+    assert_eq!(imported.report.exit_code, 2);
+    assert!(
+        imported
+            .report
+            .warnings
+            .iter()
+            .any(|message| message.contains("peer group ixp")
+                && message.contains("hold time 2")
+                && message.contains("minimum 3")),
+        "{:?}",
+        imported.report.warnings
+    );
+}
+
+/// TOML-decoded control characters must be re-encoded as valid TOML escapes.
+///
+/// Load-bearing proof: restoring the old hand-escaper writes a raw U+0001,
+/// so the structural escape assertion and the real daemon check both fail.
+#[test]
+fn imported_control_characters_are_toml_escaped() {
+    let source = "[global.config]\nas = 64500\nrouter-id = \"192.0.2.10\"\n\
+                  [[neighbors]]\n[neighbors.config]\n\
+                  neighbor-address = \"192.0.2.1\"\npeer-as = 64496\n\
+                  description = \"\\u0001\\t\"\n";
+    let imported =
+        import_source(SourceFormat::Gobgp, "gobgp-control.toml", source).expect("import");
+    assert_eq!(imported.report.exit_code, 0);
+    assert!(
+        imported
+            .config_toml
+            .contains("description = \"\\u0001\\t\""),
+        "{}",
+        imported.config_toml
+    );
+    let (code, stdout, stderr) = run_check(&imported.config_toml);
+    assert_eq!(
+        code,
+        Some(0),
+        "escaped config failed --check\nstdout:\n{stdout}\nstderr:\n{stderr}\nconfig:\n{}",
+        imported.config_toml
+    );
+}
+
+/// Distinct decoded strings must remain distinct TOML keys after emission.
+///
+/// Load-bearing proof: replacing LF/CR with spaces collapses all three group
+/// names onto one TOML table, so the key assertions and real daemon check fail.
+#[test]
+fn escaped_group_names_do_not_collapse_onto_space() {
+    let source = "[global.config]\nas = 64500\nrouter-id = \"192.0.2.10\"\n\
+                  [[peer-groups]]\n[peer-groups.config]\n\
+                  peer-group-name = \"ixp\\nred\"\npeer-as = 64496\n\
+                  [[peer-groups]]\n[peer-groups.config]\n\
+                  peer-group-name = \"ixp\\rred\"\npeer-as = 64497\n\
+                  [[peer-groups]]\n[peer-groups.config]\n\
+                  peer-group-name = \"ixp red\"\npeer-as = 64498\n\
+                  [[neighbors]]\n[neighbors.config]\n\
+                  neighbor-address = \"192.0.2.1\"\npeer-as = 64499\n";
+    let imported =
+        import_source(SourceFormat::Gobgp, "gobgp-group-controls.toml", source).expect("import");
+    assert_eq!(imported.report.exit_code, 0);
+    for key in [
+        "[peer_groups.\"ixp\\nred\"]",
+        "[peer_groups.\"ixp\\rred\"]",
+        "[peer_groups.\"ixp red\"]",
+    ] {
+        assert!(imported.config_toml.contains(key), "missing {key:?}");
+    }
+    let (code, stdout, stderr) = run_check(&imported.config_toml);
+    assert_eq!(
+        code,
+        Some(0),
+        "escaped config failed --check\nstdout:\n{stdout}\nstderr:\n{stderr}\nconfig:\n{}",
+        imported.config_toml
+    );
 }
 
 /// The defect this gate exists for: an imported config has no policy, and


### PR DESCRIPTION
## Summary

- make every daemon-rejected field reachable from the bounded BIRD, FRR, and GoBGP importer force review instead of returning a false clean exit
- normalize group hold times like neighbor hold times and emit all TOML control characters losslessly
- extend the real importer-to-daemon gate across canonical duplicate peers, ASN 0, link-local scope, duplicate groups, skipped rows, and escaping collisions

## Why

The v0.61 release notes promise that `rbgp config import` exits nonzero whenever its emitted config would fail `rustbgpd --check`. The finishing pass covered only invalid router IDs and dangling peer groups. Several other source-valid shapes still returned exit 0 beside an unloadable translation.

## Load-bearing regression proof

- `import_exits_nonzero_when_emitted_config_fails_check`: before this change, every new invariant fixture produces importer/check statuses `0/1`; removing its matching ASN, link-local, typed-neighbor, or peer-group guard restores that false green. Canonical-equivalent IPv6 duplicates are exercised through BIRD, FRR, and GoBGP, and remote AS 0 covers direct and inherited values.
- `skipped_neighbors_do_not_poison_emitted_identity_checks`: moving identity checks ahead of the missing-AS skip recreates false link-local and duplicate warnings for rows that are not emitted.
- `invalid_group_hold_time_is_repaired_and_requires_review`: removing group normalization emits `hold_time = 2`, returns exit 0, and makes the real daemon reject the translation.
- `imported_control_characters_are_toml_escaped`: restoring the raw control output breaks the structural assertion and daemon parse.
- `escaped_group_names_do_not_collapse_onto_space`: restoring lossy LF/CR replacement collapses three distinct source group names onto the same TOML table and makes the daemon reject an exit-0 import.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked`
- `cargo test --locked -p rustbgpctl --test config_import`
- `cargo test --locked --test config_import_emitted_check`
- `python3 scripts/check-v1-stable-surface.py`
- `python3 scripts/reflow-release-notes.py --selftest`
- independent self-review: merge, no blockers or nits