### PR TITLE
docs: true up crate READMEs against shipped surfaces

### DIFF
--- a/crates/api/README.md
+++ b/crates/api/README.md
@@ -19,6 +19,7 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 | **InjectionService** | Inject/withdraw unicast, FlowSpec, and EVPN routes |
 | **ControlService** | Health, metrics, shutdown, MRT trigger |
 | **EvpnService** | EVPN runtime read + L2VNI / next-hop / IP-VRF queries, duplicate-MAC quarantine clear, and the mutating `ApplyEvpnRuntime` (no longer read-only) |
+| **gnmi.gNMI** | OpenConfig gNMI: read-only telemetry (Capabilities/Get/Subscribe) plus a transaction-backed Set subset |
 
 See [docs/API.md](../../docs/API.md) for the full RPC reference and examples.
 

--- a/crates/bmp/README.md
+++ b/crates/bmp/README.md
@@ -8,8 +8,9 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 
 ## Features
 
-- All 6 BMP message types: Initiation, Peer Up, Peer Down, Route
-  Monitoring, Stats Report, Termination
+- Six BMP message types: Initiation, Peer Up, Peer Down, Route
+  Monitoring, Stats Report, Termination (Route Mirroring is out of
+  scope)
 - Per-collector async TCP client with automatic reconnect and backoff
 - Fan-out manager distributes events to all connected collectors
 - Peer Up replay on collector reconnect

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -37,6 +37,14 @@ rbgp config status
 rbgp config confirm deploy-123
 rbgp config abort deploy-123
 rbgp config effective                       # dump running post-defaults config (redacted TOML; -j for JSON)
+rbgp config history                         # list applied config transactions
+rbgp config rollback <n>                    # roll back to a prior history entry (1 = previous applied config)
+
+# Translate a BIRD 2 / FRR / GoBGP config (local, no daemon; policy is
+# never translated — skipped constructs are reported with line numbers
+# for hand-translation to .rpol). Exit codes: 0 clean, 1 error,
+# 2 translated with warnings/skips, 3 refused.
+rbgp config import <source> [--format bird|frr|gobgp] [--out <path>]
 ```
 
 ### Peers and BFD
@@ -49,6 +57,7 @@ rbgp neighbor <addr> add --remote-asn <asn> [--role provider|rs|rs-client|custom
 rbgp neighbor <addr> enable
 rbgp neighbor <addr> disable --reason "maintenance"
 rbgp neighbor <addr> softreset
+rbgp neighbor <addr> refresh-out            # re-send this peer's current exportable outbound routes
 rbgp neighbor <addr> delete
 
 rbgp dynamic-neighbor list
@@ -75,6 +84,7 @@ rbgp rib --count                            # best-route count only
 rbgp rib received <addr>
 rbgp rib received <addr> --age
 rbgp rib received <addr> --count
+rbgp rib received <addr> --rejected         # retained rejected routes with reject reasons
 rbgp rib recv <addr>                        # alias
 rbgp rib advertised <addr>
 rbgp rib advertised <addr> --age
@@ -111,6 +121,10 @@ rbgp flowspec
 rbgp fib-table list
 rbgp fib-table set edge --table-id 1000 --metric 200 --families ipv4_unicast,ipv6_unicast
 ```
+
+`policy explain` requires the daemon's import-decision cache, which is
+opt-in: set `[policy.explain] enabled = true` in the daemon config. On a
+stock daemon the command exits nonzero with that hint.
 
 `--count` applies the same family, prefix, longer-prefix, origin-ASN, standard
 community, and large-community filters as the corresponding best, received, or

--- a/crates/event-history/README.md
+++ b/crates/event-history/README.md
@@ -32,7 +32,7 @@ one SQLite transaction, and serves cursor-based replay through the
 - `sequence.rs` — explicit `metadata.last_event_id` allocator and the
   txn-scoped `Allocator::load → next → finalize` lifecycle.
 - `migrations.rs` — schema bootstrap + version-fence downgrade
-  refusal (mirrors the `GR_RESTART_MARKER_VERSION` pattern in
+  refusal (mirrors the `GR_RESTART_MARKER_V*` version-fence pattern in
   `src/main.rs`).
 - `quarantine.rs` — corrupted-DB detection + `.stale` rename for
   `events.db`, `events.db-wal`, and `events.db-shm`, plus diagnostic

--- a/crates/policy/README.md
+++ b/crates/policy/README.md
@@ -1,7 +1,8 @@
 # rustbgpd-policy
 
-Minimal BGP policy engine for rustbgpd — match, modify, and filter
-routes on import and export.
+BGP policy engine for rustbgpd — the TOML match/modify/filter core, the
+`rpol` policy language (ADR-0096), and the attribution/explain surfaces
+the daemon's `explain` features build on.
 
 Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 
@@ -19,6 +20,18 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 - **`RouteContext`**: borrowed struct carrying all match inputs — no API
   churn as match criteria grow
 
+## rpol policy language (ADR-0096)
+
+The crate also ships the `.rpol` policy-language frontend and its
+compilation pipeline:
+
+- **`rpol`** — parser for the `.rpol` source language (modules,
+  imports, in-language `test` blocks)
+- **`ir`** — typed intermediate representation policies compile into
+- **`compile`** — `.rpol` → typed IR → engine `Policy` compilation
+- **`datasets`** / **`sets`** — named prefix-set / community-set /
+  AS-set datasets referenced from policy terms
+
 ## Key types
 
 - **`RouteContext<'a>`** — borrowed match context (prefix, communities, AS_PATH, RPKI state)
@@ -26,6 +39,13 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 - **`PolicyChain`** — ordered list of `Policy`s with chain evaluation semantics
 - **`PolicyResult`** — struct of `action: PolicyAction` (`Permit` / `Deny`) plus `modifications: RouteModifications` (empty on `Deny`)
 - **`evaluate_chain()`** — top-level entry point for policy evaluation
+- **`evaluate_chain_with_attribution()`** / **`PolicyEvaluation`** —
+  evaluation plus the deciding policy/statement attribution backing
+  import explain (ADR-0073)
+- **`explain_chain_statements()`** — per-statement trace of a chain
+  against one route (`ChainStatementTrace` / `StatementAttribution`)
+- **`PolicyHitCounters`** — live per-term hit counters behind
+  `rbgp policy stats`
 
 ## License
 

--- a/crates/rib/README.md
+++ b/crates/rib/README.md
@@ -20,6 +20,10 @@ Single-task ownership — `RibManager` runs as one tokio task with no
   deterministic MED (always-compare), route reflector tiebreakers
 - **Adj-RIB-Out** — per-peer outbound route tracking with split horizon,
   iBGP suppression, route reflector reflection rules
+- **Outbound prefix limits** — per-peer, per-family Adj-RIB-Out prefix
+  ceilings with non-destructive blocking: net-new advertisements are
+  held at the cap without withdrawing existing routes or resetting the
+  session (ADR-0113)
 - **FlowSpec** — parallel storage for FlowSpec rules (SAFI 133)
 - **Multi-path** — Add-Path multi-candidate distribution with
   rank-based path ID assignment

--- a/crates/telemetry/README.md
+++ b/crates/telemetry/README.md
@@ -6,14 +6,11 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 
 ## Metrics
 
-Exposes a `prometheus` HTTP endpoint with gauges and counters covering:
-
-- Peer state (established/down counts)
-- RIB sizes (Adj-RIB-In, Loc-RIB, Adj-RIB-Out per family)
-- UPDATE processing (received, sent, errors)
-- Graceful restart (active peers, stale routes, timer expirations)
-- RPKI (VRP count, validation outcomes)
-- FlowSpec (rule counts per family)
+Exposes a `prometheus` HTTP endpoint with gauges and counters covering
+peer state, RIB sizes, UPDATE processing, policy, graceful restart,
+RPKI, FlowSpec, BMP, EVPN, update-group, and outbound-prefix-limit
+state — see [docs/OPERATIONS.md](../../docs/OPERATIONS.md) for the
+operator-facing metrics coverage.
 
 ## Logging
 

--- a/crates/transport/README.md
+++ b/crates/transport/README.md
@@ -35,6 +35,11 @@ events.
   `[policy.explain] enabled`), because the cache is per session and its
   cost multiplies by session count. Embedders that want the surface set
   the field explicitly after `TransportConfig::new`.
+- **Rejected-route retention** — a bounded per-session store of
+  import-rejected routes with canonical reject reasons, backing
+  `PolicyService.ListRejectedRoutes` / `rbgp rib received <peer>
+  --rejected` (`[policy.reject_retention]`); diagnostic state only,
+  resets on session reset
 - **Private AS removal** — strip/replace private ASNs before eBGP export
 - **Route server transparency** — preserve original NEXT_HOP and skip
   local ASN prepend for route-server clients

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -42,8 +42,8 @@ analyzers, test harnesses, MRT readers, etc.
 | 7432 | EVPN: Types 1–4 (EAD, MAC/IP, IMET, Ethernet Segment) including MAC Mobility extended community (§7.7) |
 | 7606 | Revised UPDATE error handling: `UpdateMessage::parse_revised` recovers malformed path attributes without aborting the parse, each carrying its §7 per-attribute disposition (treat-as-withdraw / attribute-discard / session-reset) from `malformed_attr_disposition`; malformed or duplicated `MP_REACH_NLRI` / `MP_UNREACH_NLRI` and unparseable NLRI stay session-reset (§5.3, §7.11) |
 | 7674 | Clarification of MP_REACH_NLRI next-hop encoding |
-| 7999 | `BLACKHOLE` well-known community (`0xFFFF_029A`, rendered as `65535:666`) |
 | 7911 | Add-Path: path ID in NLRI encode/decode |
+| 7999 | `BLACKHOLE` well-known community (`0xFFFF_029A`, rendered as `65535:666`) |
 | 8092 | Large communities (3× u32) |
 | 8097 | Origin Validation State Extended Community (type 0x43): `ORIGIN_VALIDATION_{VALID,NOT_FOUND,INVALID}` `ExtendedCommunity` constants with `OV_*` textual rendering. Codec only — RPKI-to-community stamping lives in the daemon |
 | 8203 | Admin shutdown communication |


### PR DESCRIPTION
Fixes the crate-README findings from the post-v0.61.0 docs audit, each verified against the crate source before editing.

Must-fix:
- **api**: add the served `gnmi.gNMI` service to the services table (`crates/api/src/gnmi_service.rs`).
- **cli**: document `config history`, `config rollback`, and `config import` (with the 0/1/2/3 fail-closed exit contract and never-translated policy note), and `neighbor <addr> refresh-out`.
- **policy**: describe the rpol policy language surface (ADR-0096: `rpol`/`ir`/`compile`/`datasets`/`sets`) and the attribution/explain exports (`evaluate_chain_with_attribution`/`PolicyEvaluation`, `explain_chain_statements`, `PolicyHitCounters`); the opening line no longer claims a minimal match/modify/filter engine only.
- **rib**: add the ADR-0113 outbound prefix limits bullet. Worded per the source semantics (non-destructive blocking at the cap, no withdrawal or session reset) rather than the audit's suggested "warn/teardown enforcement", which does not match `outbound_prefix_limits.rs`.

Nice-to-have:
- **cli**: `rib received <addr> --rejected` in the command listing; note that `policy explain` needs the opt-in `[policy.explain]` cache.
- **transport**: rejected-route retention store bullet (`[policy.reject_retention]`).
- **telemetry**: broaden the metric category list to the shipped families.
- **bmp**: "All 6 BMP message types" -> six of RFC 7854's seven (Route Mirroring out of scope).
- **event-history**: stale `GR_RESTART_MARKER_VERSION` -> `GR_RESTART_MARKER_V*`.
- **wire**: RFC table row order (7911 before 7999). Doc-only; no version bump.

No version bumps; ordinary post-tag doc changes.