### PR TITLE
docs: true up benchmark, comparison, design, and RFC-notes claims

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -132,9 +132,10 @@ runners via the shared `tests/soak/host-lock.sh` helper. A bench
 dispatch refuses to start while a soak is active and a soak refuses to
 start while a bench is mid-attempt; either workload fails fast with a
 clear error rather than producing useless numbers next to a busy host.
-Local dev boxes without that XDG state directory skip the locking
-entirely so this doesn't change anything for laptops / dev boxes that
-aren't shared with a bench runner. The sudo / `$HOME` trap (running soak as
+The scripts always take the lock, creating the state directory if
+needed — an uncontended `flock` is free on a laptop / dev box, and an
+earlier skip-when-absent escape hatch silently disabled the mutex on
+the shared runner. The sudo / `$HOME` trap (running soak as
 root moves the lock to `/root/...` and bypasses the guard) is covered
 in `tests/soak/README.md` under "Host mutex".
 
@@ -143,7 +144,8 @@ in `tests/soak/README.md` under "Host mutex".
 ```bash
 # Default-feature benchmarks. A bare `cargo bench` runs only the targets that
 # build with default features (codec, rib_ops, policy_eval, explain_snapshot,
-# validate); the five `bench-internals`-gated targets (fanout, inbound_attrs,
+# validate, and the mrt snapshot_allocation harness); the five
+# `bench-internals`-gated targets (fanout, inbound_attrs,
 # fib_projection, route_paging, event_history_producer) are skipped and must
 # be run explicitly with `--features bench-internals` as shown below.
 cargo bench
@@ -221,9 +223,11 @@ head-side bias large enough that the raw target percentage is not published as
 a causal speedup. See
 [`perf/revised-update-duplicate-table-2026-07.md`](perf/revised-update-duplicate-table-2026-07.md).
 
-## v0.61.0 release-tip absolute baseline
+## v0.61.0 candidate absolute baseline
 
-The exact release-tip revision `99ee74ba` has a compact absolute baseline at
+The v0.61.0 release-candidate revision `99ee74ba` (measured pre-tag; the
+final v0.61.0 tag landed 87 commits later at `c7066575`) has a compact
+absolute baseline at
 [`perf/v0.61.0-final-performance-2026-07.md`](perf/v0.61.0-final-performance-2026-07.md).
 Three real release-daemon runs at 1,000 eBGP peers × 400 BASE routes measured
 steady process-tree RSS medians of 441.760, 441.215, and 441.131 MiB, with
@@ -236,7 +240,8 @@ The same receipt retains 71 median point estimates and confidence intervals
 from the maintained RIB, codec, and policy Criterion suites under the literal
 baseline `v0.61.0-final-99ee74ba`. It is a single-revision regression anchor:
 it makes no CPU delta claim and does not rewrite the historical `515659b1`
-cross-stack or explain-cache comparisons below.
+cross-stack comparison below or the explain-cache comparison
+([perf/explain-cache-opt-in-2026-07.md](perf/explain-cache-opt-in-2026-07.md)).
 
 ## Manual CI Workflow
 
@@ -917,9 +922,10 @@ treated as allocator/map-capacity noise unless the PR is memory-targeted.
 | Arc + interning | 547 MB | 637 B | 15-29x less |
 
 The 900k×2 figures are the historical allocator-tracked journey; the 547 MB row
-is the last reliable one before the `memory_profile` harness stopped scaling
-past ~100k (see the limitation note above). RIB-structure regression tracking
-now uses the 100k allocator profile; full-daemon RSS at scale uses bgperf2.
+is the last from the pre-RouteSlab harness. The structured
+`memory_profile_high_n` harness (2026-07-17 provenance note above) now measures
+100k/500k/900k directly and is the RIB-structure regression-tracking surface;
+full-daemon RSS at scale uses bgperf2.
 
 ### Optimization History (end-to-end, bgperf2 2p/100k)
 
@@ -947,7 +953,8 @@ above** — they are *full-daemon* process RSS, not the RIB-only figure, and are
 **not a RIB memory regression** (RIB-only structural memory at 100k actually
 improved ~9% — see above). Since the ~257–260 MB era the daemon gained
 substantial always-available operational surfaces (BFD, gNMI, ASPA, BGP
-roles/OTC, the explain cache) and `PathAttribute` grew 72→112 B. The single
+roles/OTC, plus the explain cache — opt-in, default off since v0.61.0) and
+`PathAttribute` grew 72→112 B. The single
 biggest contributor is the durable **event-history outbox** (ADR-0072), which
 persists every route event to SQLite: enabling it
 (`[event_history].enabled = true`) adds **~62 MB** RSS (~284 → ~346 MB) **and
@@ -1185,7 +1192,7 @@ micro-bench that excludes Adj-RIB-Out and so undercounts full-daemon route
 storage. BIRD's radix-tree RIB with global attribute
 deduplication is what makes it an order of magnitude leaner on this same data.
 At full-table scale (900k prefixes, RIB-only micro-bench) rustbgpd's
-Adj-RIB-In + Loc-RIB is ~533 MB vs GoBGP's published 8–16+ GB.
+Adj-RIB-In + Loc-RIB is ~440 MiB vs GoBGP's published 8–16+ GB.
 
 **gRPC under load.** A priority query channel separates read-only gRPC queries
 from the route-processing pipeline, ensuring management API requests are

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -415,7 +415,8 @@ incumbents fills gaps the daemons leave open — native JSON output for
 [bird-users in April 2020](https://bird.network.cz/pipermail/bird-users/2020-April/014524.html)
 with a list of regex-based parser projects standing in for it, and BIRD
 still has no JSON CLI output (see API & Programmability above). rustbgpd
-ships JSON CLI output and a gRPC API today; a bounded BIRD/FRR/GoBGP
-configuration importer — structure only, with a fail-stop report of
-everything left for hand-translation — is planned on the
-[ROADMAP](../ROADMAP.md) operator-experience track and has not shipped.
+ships JSON CLI output, a gRPC API, and `rbgp config import` — a bounded
+BIRD 2 / FRR / GoBGP structural importer that translates the mechanical
+subset (AS, router-id, neighbors, peer groups, families, timers,
+max-prefix) and fail-stops with a line-numbered report of every policy
+construct left for hand-translation to `.rpol`.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -82,6 +82,9 @@ Rationale: GoBGP's protos carry Go-specific patterns and years of accumulated fe
 Eleven separate gRPC services (Global, Config, Neighbor, Policy, PeerGroup, Rib, Bfd, Event, Injection, Control, Evpn), not one. This forces API boundary clarity, prevents god-service creep, enables permission scoping (for example, read-only listeners for monitoring), and mirrors internal architecture.
 
 ```protobuf
+// Abridged — proto/rustbgpd.proto is authoritative; NeighborService has
+// 12 RPCs and RibService 22, only representative subsets are shown here.
+
 // Global daemon configuration and identity
 service GlobalService {
   rpc GetGlobal(GetGlobalRequest)     returns (GlobalState);
@@ -120,7 +123,7 @@ service InjectionService {
 }
 
 // Policy CRUD, chain assignment, and import-policy explain
-service PolicyService { /* 21 RPCs: policies, neighbor sets, chains, ExplainImportPolicy, TestPolicy (dry-run), GetPolicyStats */ }
+service PolicyService { /* 22 RPCs: policies, neighbor sets, chains, ExplainImportPolicy, ListRejectedRoutes, TestPolicy (dry-run), GetPolicyStats */ }
 
 // Peer group CRUD
 service PeerGroupService { /* 6 RPCs: List/Get/Set/Delete groups, Set/Clear neighbor membership */ }
@@ -628,6 +631,7 @@ Bounded channels, prefix limits, and backpressure behavior are detailed in [ARCH
 | Max message size | 4096 bytes (65535 with RFC 8654) | 4096 by default; raised per-session only when Extended Messages is negotiated |
 | Max attributes per UPDATE | 256 | Safety bound |
 | Max prefixes per neighbor | none (unbounded) | `max_prefixes` (aggregate) and the independent `max_prefixes_ipv4` / `max_prefixes_ipv6` per-family caps (ADR-0108) default to `None`; exceeding a cap latches the peer down and sends bare Cease/1 per RFC 4486, or RFC 8538 Cease/9 encapsulating that Cease/1 when Notification GR was negotiated |
+| Max advertised prefixes per neighbor (outbound) | none (unbounded) | `max_prefixes_out_ipv4` / `max_prefixes_out_ipv6` (ADR-0113) bound one peer's advertised-state growth: excess net-new prefixes are withheld while the session stays Established — nothing already advertised is withdrawn and no NOTIFICATION is sent. Blocking state plus usage/limit/headroom are on neighbor detail, JSON, and Prometheus (`bgp_outbound_prefix_{usage,limit,headroom,blocking,blocked_total}`) |
 | Max-prefix restart hold-down | none (indefinite latch) | A non-zero `max_prefix_restart_seconds` opts into one generation-fenced automatic attempt after the hold-down. Failure to deliver `PeerCommand::Start` consumes that attempt and leaves the peer latched until explicit enable; successful delivery removes the latch and returns the session to ordinary TCP/OPEN retry. `rbgp neighbor <addr>` exposes the effective action and active countdown |
 | Bounded channel size | 4096 | Per-session and RIB channels |
 | Connect retry interval | 1s for the first two refused TCP dials, then 5s exponential backoff capped at 300s | Applies to prompt TCP failures where the peer is not listening yet; OPEN/config failures use the slower Idle reconnect guard. The 1s floor and two-attempt count are fixed daemon defaults. |

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -19,6 +19,7 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 | MP-BGP + extensions | RFC 4760, RFC 7911 (Add-Path), RFC 8654 (Extended Messages), RFC 8950 (Extended Next Hop) | Multiprotocol negotiation and modern capability set |
 | Route refresh / filtering | RFC 2918, RFC 7313 (Enhanced RR), RFC 5291/5292 (ORF) | Receive-side Address-Prefix ORF |
 | Communities | RFC 1997 (well-known), RFC 4360 (Extended), RFC 8092 (Large) | Match plus policy set/remove; `NO_ADVERTISE`, `NO_EXPORT`, and `NO_EXPORT_SUBCONFED` egress enforcement for unicast, VPNv4/VPNv6, labeled-unicast, RTC, BGP-LS, EVPN, and FlowSpec |
+| eBGP default policy | RFC 8212 | Opt-in `ebgp_requires_policy`: an eBGP direction with no explicit operator policy runs a reserved internal deny |
 | Route reflection | RFC 4456, RFC 9107 (ORR, ADR-0095) | Per-client best paths via BGP-LS-sourced SPF |
 | Route server (IXP) | RFC 7947 (ADR-0039/0101), RFC 8195 | Transparent redistribution, §2.3.2 per-client best-path, member-set control communities (per-target announce/prepend steering, scrubbed on egress) |
 | Graceful restart | RFC 4724 (GR helper), RFC 9494 (LLGR) | Stale retention across all RR families; no forwarding-state preservation |
@@ -116,6 +117,33 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
   update-groups: the filter is route-granular at emit (ADR-0101 Decision 3),
   so only routes carrying a control-form community pay per-target divergence
   while untagged routes share staging and encoding fleet-wide.
+
+---
+
+## RFC 8212 — Default eBGP route handling
+
+- RFC 8212 makes an eBGP route without an explicit import policy ineligible
+  for the decision process and keeps a route without an explicit export
+  policy out of that peer's Adj-RIB-Out. rustbgpd implements the boundary
+  behind the opt-in `[global] ebgp_requires_policy` knob (restart-required):
+  when on, an eBGP session that resolves no explicit operator policy in a
+  direction runs a reserved internal deny-all chain
+  (`rfc8212_missing_import_policy` / `rfc8212_missing_export_policy` — both
+  reserved names that operator policy cannot shadow) in that direction. The
+  two directions are independent, and the session stays Established, so the
+  gap is repairable without transport churn.
+- **Deviation:** the RFC mandates this as default behavior; rustbgpd ships it
+  opt-in (default `false`). The historical default is permit-all when a
+  session resolves no policy chain, and flipping the default would make an
+  upgrade silently drop routes in a way indistinguishable from a policy
+  change — the warn-first posture RFC 8212 Appendix A.1 describes for
+  implementations with an installed base. `rustbgpd --check` warns on every
+  eBGP neighbor missing explicit policy whether the knob is on or off, and
+  every shipped starter config sets the knob.
+- Full knob semantics, what counts as explicit policy, and the observability
+  surfaces (neighbor detail, Prometheus, doctor, export explain) are in
+  [docs/CONFIGURATION.md](CONFIGURATION.md) under
+  "`ebgp_requires_policy` — RFC 8212 explicit policy on eBGP".
 
 ---
 
@@ -1190,8 +1218,9 @@ while retaining the legacy raw unlimited sentinel for rolling compatibility.
   `RouteOrigin::Local` that flows through the same reflection
   pipeline as iBGP-learned routes. `rbgp evpn add-mac-ip /
   add-imet / delete-mac-ip / delete-imet` CLI subcommands cover
-  the operator-facing surface. Type 5 IP-Prefix injection is
-  deferred pending use-case signal. Native Type 1/4 multi-homing
+  the operator-facing surface. Type 5 IP-Prefix injection was
+  deferred at this gate pending use-case signal; it shipped later
+  (v0.25.0, M45). Native Type 1/4 multi-homing
   origination ships through `[[ethernet_segments]]`; controller
   injection for those route types is not exposed.
 - **Multi-homing Type 1 EAD + Type 4 ES reflection interop** (RFC 7432 §8):

--- a/docs/perf/v0.61.0-final-performance-2026-07.md
+++ b/docs/perf/v0.61.0-final-performance-2026-07.md
@@ -1,8 +1,9 @@
 # v0.61.0 final performance baseline — 2026-07
 
-This receipt freezes an absolute performance baseline for the v0.61.0 release
-tip at commit `99ee74ba67ec24ce8e09c0c18a83b652da35712b`, tree
-`c6ef0d7da50b8be28ff62b8edb749f0fae0bd21f`. It is a release reference,
+This receipt freezes an absolute performance baseline for the v0.61.0
+release candidate at commit `99ee74ba67ec24ce8e09c0c18a83b652da35712b`, tree
+`c6ef0d7da50b8be28ff62b8edb749f0fae0bd21f` (measured pre-tag; the final
+v0.61.0 tag landed 87 commits later at `c7066575`). It is a release reference,
 not an A/B optimization receipt: there is no CPU delta claim, and it does not
 replace the historical cross-stack or explain-cache comparisons.
 


### PR DESCRIPTION
Fixes documentation-audit findings in docs/BENCHMARKS.md, docs/COMPARISON.md, docs/DESIGN.md, docs/RFC_NOTES.md, and docs/perf/v0.61.0-final-performance-2026-07.md. Each claim was re-verified against the current scripts, Cargo metadata, proto definitions, and CHANGELOG before editing.

**BENCHMARKS.md**
- Host-coexistence section documented the removed skip-when-absent lock behavior; `bench/compare-criterion.sh` and `tests/soak/host-lock.sh` now always take the flock, creating the state directory if needed.
- Bare `cargo bench` also runs the mrt `snapshot_allocation` harness (sixth default-feature target, verified against Cargo.toml bench declarations).
- The v0.61.0 absolute baseline was measured at release-candidate revision `99ee74ba`, 87 commits before the final tag at `c7066575`; section retitled and both the doc and the perf receipt now say so. The literal Criterion baseline name is unchanged.
- Explain-cache comparison pointer now names its receipt (`perf/explain-cache-opt-in-2026-07.md`) instead of claiming it is in this document.
- Optimization-history paragraph no longer references a deleted limitation note; it points at the `memory_profile_high_n` harness (100k/500k/900k) as the regression-tracking surface.
- Explain cache annotated opt-in / default off (v0.61.0); stale `~533 MB` 900k RIB-only figure aligned with the 2026-07-17 Full RIB table (`~440 MiB`).

**COMPARISON.md** — the bounded BIRD 2 / FRR / GoBGP structural importer shipped as `rbgp config import`; the closing paragraph no longer calls it planned.

**DESIGN.md** — PolicyService comment corrected to 22 RPCs (adds `ListRejectedRoutes`); abridgement note added above the proto snippets (NeighborService 12, RibService 22); configurable-limits table gains the ADR-0113 outbound prefix-limit row with the real metric names.

**RFC_NOTES.md** — RFC 8212 added to the at-a-glance table plus a section covering the reserved deny chains, Established-session semantics, and the deliberate opt-in deviation, cross-referencing CONFIGURATION.md; the Gate 6 Type 5 injection deferral reworded to historical framing (shipped v0.25.0, M45).

Not changed: the proposed RFC 8212 row for the COMPARISON.md Core Protocol table is omitted — competitor default-on cells need independent verification first.