### PR TITLE
Fence route-page generations behind session checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   start, with the family named in the error, while a family with no
   sessions is never opened and cannot fail startup.
 
+- Stale `PeerOrfUpdate`, `PeerSlowState`, `SetPeerPolicyContext`, and
+  `RouteRefreshRequest` messages no longer restart advertised-route page cursors.
+
 ## [0.61.0] — 2026-07-27
 
 > **Release framing.** This is the policy-safety line. RFC 8212

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -3098,7 +3098,7 @@ impl RibManager {
                 self.mark_outbound_dirty(peer);
             }
             self.force_outbound_peers.insert(peer);
-            self.distribute_changes(&HashSet::new(), &HashSet::new());
+            self.distribute_changes_after_advertised_page_advance(&HashSet::new(), &HashSet::new());
         }
         let _ = reply.send(Ok(()));
     }
@@ -3572,7 +3572,7 @@ impl RibManager {
         best_changed: &HashSet<Prefix>,
         all_affected: &HashSet<Prefix>,
     ) {
-        self.distribute_changes_inner(best_changed, all_affected, true);
+        self.distribute_changes_inner(best_changed, all_affected, true, false);
     }
 
     pub(super) fn distribute_changes(
@@ -3580,7 +3580,15 @@ impl RibManager {
         best_changed: &HashSet<Prefix>,
         all_affected: &HashSet<Prefix>,
     ) {
-        self.distribute_changes_inner(best_changed, all_affected, false);
+        self.distribute_changes_inner(best_changed, all_affected, false, false);
+    }
+
+    pub(super) fn distribute_changes_after_advertised_page_advance(
+        &mut self,
+        best_changed: &HashSet<Prefix>,
+        all_affected: &HashSet<Prefix>,
+    ) {
+        self.distribute_changes_inner(best_changed, all_affected, false, true);
     }
 
     fn clone_distribution_metrics(
@@ -3605,6 +3613,7 @@ impl RibManager {
         best_changed: &HashSet<Prefix>,
         all_affected: &HashSet<Prefix>,
         service_ingest_readiness: bool,
+        advertised_generation_already_advanced: bool,
     ) {
         self.record_deferred_unicast(best_changed);
         self.record_deferred_unicast(all_affected);
@@ -3629,7 +3638,9 @@ impl RibManager {
         // Group-table commits and member-local exact-export overlay changes
         // happen below. Invalidate every advertised continuation up front;
         // conservative invalidation is safe even if a later send fails.
-        self.advance_advertised_pages();
+        if !advertised_generation_already_advanced {
+            self.advance_advertised_pages();
+        }
 
         let peers: Vec<IpAddr> = self.outbound_peers.keys().copied().collect();
         // Pass-scoped export memo: shares post-modification attribute

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1539,14 +1539,10 @@ impl RibManager {
             // overlays; general queries stay fenced out until it is terminal,
             // so advancing here at acceptance covers the whole transaction.
             RibUpdate::PeerAddPathLimits { .. }
-            | RibUpdate::PeerOrfUpdate { .. }
-            | RibUpdate::PeerSlowState { .. }
-            | RibUpdate::SetPeerPolicyContext { .. }
             | RibUpdate::ReplacePeerExportPolicy { .. }
             | RibUpdate::ReplacePeerExportPolicies { .. }
             | RibUpdate::ApplyOutboundPrefixLimits { .. }
-            | RibUpdate::RefreshPeerOutbound { .. }
-            | RibUpdate::RouteRefreshRequest { .. } => self.advance_advertised_pages(),
+            | RibUpdate::RefreshPeerOutbound { .. } => self.advance_advertised_pages(),
             RibUpdate::PeerUp { .. }
             | RibUpdate::PeerDown { .. }
             | RibUpdate::PeerDeleted { .. }
@@ -2067,6 +2063,7 @@ impl RibManager {
                         "stale ORF update from superseded session {session_id} discarded"
                     )));
                 } else {
+                    self.advance_advertised_pages();
                     self.handle_peer_orf_update(peer, afi, safi, when, &entries, reply);
                 }
             }
@@ -2076,6 +2073,7 @@ impl RibManager {
                 slow,
             } => {
                 if !self.stale_session_message(peer, session_id, "PeerSlowState", "slow_peer") {
+                    self.advance_advertised_pages();
                     self.handle_peer_slow_state(peer, slow);
                 }
             }
@@ -2090,6 +2088,7 @@ impl RibManager {
                     "SetPeerPolicyContext",
                     "policy_context",
                 ) {
+                    self.advance_advertised_pages();
                     self.handle_set_peer_policy_context(peer, peer_group);
                 }
             }
@@ -2369,6 +2368,7 @@ impl RibManager {
                 safi,
             } => {
                 if !self.stale_session_message(peer, session_id, "RouteRefreshRequest", "refresh") {
+                    self.advance_advertised_pages();
                     self.handle_route_refresh_request(peer, afi, safi);
                 }
             }

--- a/crates/rib/src/manager/tests/paged_query.rs
+++ b/crates/rib/src/manager/tests/paged_query.rs
@@ -157,6 +157,14 @@ fn direct_advertised_snapshot(manager: &mut RibManager, peer: IpAddr) -> Vec<Rou
 }
 
 fn peer_up_direct(manager: &mut RibManager, peer: IpAddr) -> mpsc::Receiver<OutboundRouteUpdate> {
+    peer_up_direct_with_negotiated_orf(manager, peer, vec![])
+}
+
+fn peer_up_direct_with_negotiated_orf(
+    manager: &mut RibManager,
+    peer: IpAddr,
+    negotiated_orf_recv: Vec<(Afi, Safi)>,
+) -> mpsc::Receiver<OutboundRouteUpdate> {
     let (outbound_tx, outbound_rx) = mpsc::channel(64);
     manager.handle_update(RibUpdate::PeerUp {
         per_client_best: false,
@@ -173,7 +181,7 @@ fn peer_up_direct(manager: &mut RibManager, peer: IpAddr) -> mpsc::Receiver<Outb
         orr_vantage: None,
         add_path_send_families: vec![],
         add_path_send_max: 0,
-        negotiated_orf_recv: vec![],
+        negotiated_orf_recv,
         negotiated_llgr_families: vec![],
     });
     outbound_rx
@@ -1391,6 +1399,15 @@ fn route_page_versions(manager: &RibManager) -> [RoutePageVersion; 3] {
     ]
 }
 
+fn assert_only_advertised_page_version_advanced_once(
+    before: [RoutePageVersion; 3],
+    after: [RoutePageVersion; 3],
+) {
+    assert_eq!(after[..2], before[..2], "received/best versions changed");
+    assert_eq!(after[2].epoch, before[2].epoch);
+    assert_eq!(after[2].generation, before[2].generation + 1);
+}
+
 fn assert_each_route_page_version_advanced_once(
     before: [RoutePageVersion; 3],
     after: [RoutePageVersion; 3],
@@ -1399,6 +1416,224 @@ fn assert_each_route_page_version_advanced_once(
         assert_eq!(after.epoch, before.epoch);
         assert_eq!(after.generation, before.generation + 1);
     }
+}
+
+#[test]
+fn stale_peer_orf_update_does_not_advance_advertised_page_version() {
+    let (mut manager, peer) = refresh_test_manager();
+    let before = route_page_versions(&manager);
+    let (reply, _response) = oneshot::channel();
+
+    manager.handle_update(RibUpdate::PeerOrfUpdate {
+        peer,
+        session_id: 1,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+        when: WhenToRefresh::Defer,
+        entries: vec![],
+        reply,
+    });
+
+    assert_eq!(
+        route_page_versions(&manager),
+        before,
+        "a stale PeerOrfUpdate must not advance the advertised-page generation"
+    );
+}
+
+#[test]
+fn accepted_peer_orf_update_advances_advertised_page_version_once() {
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let source_v4 = Ipv4Addr::new(192, 0, 2, 1);
+    let route = make_route(
+        Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24),
+        source_v4,
+    );
+    receive_direct(
+        &mut manager,
+        IpAddr::V4(source_v4),
+        vec![route.clone()],
+        vec![],
+    );
+    let mut outbound_rx =
+        peer_up_direct_with_negotiated_orf(&mut manager, peer, vec![(Afi::Ipv4, Safi::Unicast)]);
+    assert!(
+        manager.grouped_member_of(peer).is_none(),
+        "an ORF-capable peer must remain outside update groups"
+    );
+    let initial = outbound_rx.try_recv().expect("initial EoR remains live");
+    assert!(
+        initial.announce.is_empty(),
+        "ORF gate blocks the initial route"
+    );
+    let before = route_page_versions(&manager);
+    let (reply, mut response) = oneshot::channel();
+
+    manager.handle_update(RibUpdate::PeerOrfUpdate {
+        peer,
+        session_id: 0,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+        when: WhenToRefresh::Immediate,
+        entries: vec![],
+        reply,
+    });
+
+    assert_eq!(
+        response
+            .try_recv()
+            .expect("ORF update replies synchronously"),
+        Ok(())
+    );
+    let forced = outbound_rx
+        .try_recv()
+        .expect("Immediate ORF performs a forced distribution");
+    assert!(
+        forced
+            .announce
+            .iter()
+            .any(|announced| announced.prefix == route.prefix),
+        "forced distribution advertises the route admitted after the ORF gate lifts"
+    );
+    assert_only_advertised_page_version_advanced_once(before, route_page_versions(&manager));
+}
+
+#[test]
+fn stale_peer_slow_state_does_not_advance_advertised_page_version() {
+    let (mut manager, peer) = refresh_test_manager();
+    let before = route_page_versions(&manager);
+
+    manager.handle_update(RibUpdate::PeerSlowState {
+        peer,
+        session_id: 1,
+        slow: true,
+    });
+
+    assert_eq!(
+        route_page_versions(&manager),
+        before,
+        "a stale PeerSlowState must not advance the advertised-page generation"
+    );
+}
+
+#[test]
+fn accepted_peer_slow_state_advances_advertised_page_version_once() {
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let group_mate = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut peer_rx = peer_up_direct(&mut manager, peer);
+    let mut mate_rx = peer_up_direct(&mut manager, group_mate);
+    peer_rx
+        .try_recv()
+        .expect("peer outbound receiver remains live");
+    mate_rx
+        .try_recv()
+        .expect("group-mate outbound receiver remains live");
+    let original_group = manager
+        .grouped_member_of(peer)
+        .expect("peer starts grouped");
+    assert_eq!(manager.grouped_member_of(group_mate), Some(original_group));
+    let mate_advertised = sorted_keys(&direct_advertised_snapshot(&mut manager, group_mate));
+    let before = route_page_versions(&manager);
+
+    manager.handle_update(RibUpdate::PeerSlowState {
+        peer,
+        session_id: 0,
+        slow: true,
+    });
+
+    assert!(matches!(
+        manager.update_groups.membership(peer),
+        Some(crate::manager::update_groups::GroupMembership::SlowPeer)
+    ));
+    assert_eq!(
+        manager.grouped_member_of(group_mate),
+        Some(original_group),
+        "the group-mate stays in its original group"
+    );
+    assert_eq!(
+        sorted_keys(&direct_advertised_snapshot(&mut manager, group_mate)),
+        mate_advertised,
+        "the group-mate's advertised view is unchanged"
+    );
+    assert!(matches!(
+        peer_rx.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+    ));
+    assert!(matches!(
+        mate_rx.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+    ));
+    assert_only_advertised_page_version_advanced_once(before, route_page_versions(&manager));
+}
+
+#[test]
+fn stale_peer_policy_context_does_not_advance_advertised_page_version() {
+    let (mut manager, peer) = refresh_test_manager();
+    let before = route_page_versions(&manager);
+
+    manager.handle_update(RibUpdate::SetPeerPolicyContext {
+        peer,
+        session_id: 1,
+        peer_group: Some("stale".to_string()),
+    });
+
+    assert_eq!(
+        route_page_versions(&manager),
+        before,
+        "a stale SetPeerPolicyContext must not advance the advertised-page generation"
+    );
+}
+
+#[test]
+fn accepted_peer_policy_context_advances_advertised_page_version_once() {
+    let (mut manager, peer) = refresh_test_manager();
+    let before = route_page_versions(&manager);
+
+    manager.handle_update(RibUpdate::SetPeerPolicyContext {
+        peer,
+        session_id: 0,
+        peer_group: Some("active".to_string()),
+    });
+
+    assert_only_advertised_page_version_advanced_once(before, route_page_versions(&manager));
+}
+
+#[test]
+fn stale_route_refresh_request_does_not_advance_advertised_page_version() {
+    let (mut manager, peer) = refresh_test_manager();
+    let before = route_page_versions(&manager);
+
+    manager.handle_update(RibUpdate::RouteRefreshRequest {
+        peer,
+        session_id: 1,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    });
+
+    assert_eq!(
+        route_page_versions(&manager),
+        before,
+        "a stale RouteRefreshRequest must not advance the advertised-page generation"
+    );
+}
+
+#[test]
+fn accepted_route_refresh_request_advances_advertised_page_version_once() {
+    let (mut manager, peer) = refresh_test_manager();
+    let before = route_page_versions(&manager);
+
+    manager.handle_update(RibUpdate::RouteRefreshRequest {
+        peer,
+        session_id: 0,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    });
+
+    assert_only_advertised_page_version_advanced_once(before, route_page_versions(&manager));
 }
 
 #[test]

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -2978,7 +2978,7 @@ impl RibManager {
         if !key_stable {
             self.mark_outbound_dirty(peer);
         }
-        self.distribute_changes(&HashSet::new(), &HashSet::new());
+        self.distribute_changes_after_advertised_page_advance(&HashSet::new(), &HashSet::new());
     }
 
     /// The fingerprint itself: disqualifiers first (design §1), then

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -835,14 +835,16 @@ impl BgpMetrics {
         let rib_stale_session_message_ignored = IntCounterVec::new(
             Opts::new(
                 "bgp_rib_stale_session_message_ignored_total",
-                "Session-scoped RIB messages (RoutesReceived, End-of-RIB, \
-                 route-refresh begin/end/request, ORF updates, or policy \
-                 context updates) discarded \
+                "Session-scoped RIB messages (RoutesReceived, including \
+                 BGP-LS, VPN, labeled-unicast, and RT-Constrain families; \
+                 End-of-RIB; route-refresh begin/end/request; ORF updates; \
+                 or policy context / PeerSlowState slow-peer updates) discarded \
                  because their session id did not match the registered \
                  session for the peer — a message from a superseded session \
                  (collision loser) queued behind the replacement's PeerUp. \
                  The registered session's state is untouched. `kind` is one \
-                 of: routes, eor, refresh, orf, policy_context.",
+                 of: routes, bgpls, vpn, labeled, rtc, eor, refresh, orf, \
+                 policy_context, slow_peer.",
             ),
             &["peer", "kind"],
         )
@@ -3179,19 +3181,29 @@ impl BgpMetrics {
             .inc();
     }
 
-    /// Record a session-scoped RIB message (routes, End-of-RIB,
-    /// route-refresh begin/end/request, ORF update, or policy context
-    /// update) discarded because its session id did not match the
-    /// registered session for the peer (a message from a superseded
-    /// session).
+    /// Record a session-scoped RIB message (routes, including BGP-LS, VPN,
+    /// labeled-unicast, and RT-Constrain families; End-of-RIB; route-refresh
+    /// begin/end/request; ORF update; policy context update; or slow-peer
+    /// state) discarded because its session id did not match the registered
+    /// session for the peer (a message from a superseded session).
     ///
-    /// `kind` is bounded: `"routes"`, `"eor"`, `"refresh"`, `"orf"`,
-    /// or `"policy_context"`.
+    /// `kind` is bounded: `"routes"`, `"bgpls"`, `"vpn"`, `"labeled"`,
+    /// `"rtc"`, `"eor"`, `"refresh"`, `"orf"`, `"policy_context"`, or
+    /// `"slow_peer"`.
     pub fn record_rib_stale_session_message_ignored(&self, peer: &str, kind: &str) {
         debug_assert!(
             matches!(
                 kind,
-                "routes" | "eor" | "refresh" | "orf" | "policy_context"
+                "routes"
+                    | "bgpls"
+                    | "vpn"
+                    | "labeled"
+                    | "rtc"
+                    | "eor"
+                    | "refresh"
+                    | "orf"
+                    | "policy_context"
+                    | "slow_peer"
             ),
             "unbounded stale-session-message kind label: {kind:?}"
         );
@@ -5699,6 +5711,10 @@ mod tests {
         m.record_rib_stale_session_message_ignored("10.0.0.1", "routes");
         m.record_rib_stale_session_message_ignored("10.0.0.1", "eor");
         m.record_rib_stale_session_message_ignored("10.0.0.1", "policy_context");
+        m.record_rib_stale_session_message_ignored("10.0.0.1", "slow_peer");
+        for kind in ["bgpls", "vpn", "labeled", "rtc"] {
+            m.record_rib_stale_session_message_ignored("10.0.0.1", kind);
+        }
         m.record_rib_outbound_registration_failover("10.0.0.1");
         m.record_rib_dirty_resync("still_dirty");
         m.record_rib_dirty_resync("cleared");
@@ -5735,6 +5751,38 @@ mod tests {
                 .get(),
             1
         );
+        assert_eq!(
+            m.rib_stale_session_message_ignored
+                .with_label_values(&["10.0.0.1", "slow_peer"])
+                .get(),
+            1
+        );
+        for kind in ["bgpls", "vpn", "labeled", "rtc"] {
+            assert_eq!(
+                m.rib_stale_session_message_ignored
+                    .with_label_values(&["10.0.0.1", kind])
+                    .get(),
+                1,
+                "live stale-session kind {kind} is recorded"
+            );
+        }
+        let help = m
+            .registry()
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == "bgp_rib_stale_session_message_ignored_total")
+            .expect("stale-session metric is registered")
+            .help()
+            .to_owned();
+        let (_, kind_help) = help
+            .split_once("`kind` is one of:")
+            .expect("metric HELP names the bounded kind inventory");
+        for kind in ["bgpls", "vpn", "labeled", "rtc"] {
+            assert!(
+                kind_help.contains(kind),
+                "metric HELP omits live stale-session kind {kind}"
+            );
+        }
         assert_eq!(
             m.rib_outbound_registration_failover
                 .with_label_values(&["10.0.0.1"])


### PR DESCRIPTION
## Summary

- move `PeerOrfUpdate`, `PeerSlowState`, `SetPeerPolicyContext`, and `RouteRefreshRequest` advertised-page generation advances behind their active-session checks
- preserve exactly-once invalidation when accepted ORF or slow-peer work reaches real downstream distribution
- keep stale collision-session messages from invalidating advertised-route pagination
- complete the bounded stale-message metric inventory for all ten live kinds
- record the operator-visible fix in the changelog

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --lib --no-deps`
- focused 33-test paged-query and telemetry suites
- two independent immutable-SHA reviews

## Load-bearing proof

- restoring the four pre-pass variants makes the eight stale/accepted boundary tests observe an unexpected advance
- routing accepted ORF Immediate or slow-peer regroup through ordinary distribution makes advertised generation advance twice; removing the accepted dispatcher advance makes it advance zero times
- removing any of `bgpls`, `vpn`, `labeled`, or `rtc` from the validator panics the focused telemetry test on the real label record
- removing any of those four from metric HELP fails the exact bounded-inventory assertion

## Scope

Received/best generations, stale-session acceptance rules, production ORF grouping, public APIs, and metric dimensions are unchanged. Public prose synchronization and a structural inventory fence remain tracked separately.