### PR TITLE
Surface optional telemetry freshness in rbgp top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Stale `PeerOrfUpdate`, `PeerSlowState`, `SetPeerPolicyContext`, and
   `RouteRefreshRequest` messages no longer restart advertised-route page cursors.
 
+- `rbgp top` now distinguishes unavailable optional global/RPKI telemetry from
+  a stale retained VRP count without reporting a core disconnect, and clears a
+  previous count after a successful metrics scrape with no RPKI family.
+
 ## [0.61.0] — 2026-07-27
 
 > **Release framing.** This is the policy-safety line. RFC 8212

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -77,12 +77,14 @@ pub(crate) fn neighbor_key(neighbor: &NeighborState) -> Option<String> {
 
 pub struct App {
     pub global: Option<GlobalState>,
+    pub global_freshness: Option<Freshness>,
     pub health: Option<HealthResponse>,
     pub health_fresh: bool,
     pub neighbors: Vec<NeighborState>,
     pub neighbors_freshness: Option<Freshness>,
     pub route_events: VecDeque<RouteEventEntry>,
     pub rpki_vrp_count: Option<u64>,
+    pub metrics_freshness: Option<Freshness>,
 
     prev_counters: HashMap<String, PeerCounters>,
     pub peer_rates: HashMap<String, PeerRates>,
@@ -105,12 +107,14 @@ impl App {
     pub fn new() -> Self {
         Self {
             global: None,
+            global_freshness: None,
             health: None,
             health_fresh: false,
             neighbors: Vec::new(),
             neighbors_freshness: None,
             route_events: VecDeque::new(),
             rpki_vrp_count: None,
+            metrics_freshness: None,
             prev_counters: HashMap::new(),
             peer_rates: HashMap::new(),
             last_rate_calc: Instant::now(),
@@ -201,6 +205,8 @@ impl App {
         self.last_poll = now;
         self.health_fresh = snapshot.health_fresh;
         self.neighbors_freshness = Some(snapshot.neighbors_freshness);
+        self.global_freshness = Some(snapshot.global_freshness);
+        self.metrics_freshness = Some(snapshot.metrics_freshness);
 
         if snapshot.health_fresh {
             self.health = snapshot.health;
@@ -409,6 +415,7 @@ mod tests {
     fn snapshot(neighbors: Vec<NeighborState>) -> DataSnapshot {
         DataSnapshot {
             global: None,
+            global_freshness: Freshness::Unavailable,
             health: Some(HealthResponse {
                 healthy: true,
                 uptime_seconds: 1,
@@ -420,6 +427,7 @@ mod tests {
             neighbors,
             neighbors_freshness: Freshness::Fresh,
             rpki_vrp_count: None,
+            metrics_freshness: Freshness::Unavailable,
             error: None,
         }
     }

--- a/crates/cli/src/tui/data.rs
+++ b/crates/cli/src/tui/data.rs
@@ -17,11 +17,13 @@ use crate::proto::{
 
 pub struct DataSnapshot {
     pub global: Option<GlobalState>,
+    pub global_freshness: Freshness,
     pub health: Option<HealthResponse>,
     pub health_fresh: bool,
     pub neighbors: Vec<NeighborState>,
     pub neighbors_freshness: Freshness,
     pub rpki_vrp_count: Option<u64>,
+    pub metrics_freshness: Freshness,
     pub error: Option<String>,
 }
 
@@ -70,6 +72,7 @@ struct FetcherState {
     health: Option<HealthResponse>,
     neighbors: Option<Vec<NeighborState>>,
     rpki_vrp_count: Option<u64>,
+    metrics_freshness: Freshness,
     next_metrics_poll: Instant,
 }
 
@@ -80,6 +83,7 @@ impl FetcherState {
             health: None,
             neighbors: None,
             rpki_vrp_count: None,
+            metrics_freshness: Freshness::Unavailable,
             next_metrics_poll: Instant::now(),
         }
     }
@@ -110,13 +114,20 @@ pub(super) fn spawn_fetcher(
 async fn poll_once(connection: &Connection, state: &mut FetcherState) -> DataSnapshot {
     let mut error = None;
 
-    if state.global.is_none() {
+    let global_freshness = if state.global.is_some() {
+        Freshness::Fresh
+    } else {
         let mut client =
             GlobalServiceClient::with_interceptor(connection.channel(), connection.interceptor());
         if let Ok(response) = client.get_global(GetGlobalRequest {}).await {
             state.global = Some(response.into_inner());
         }
-    }
+        if state.global.is_some() {
+            Freshness::Fresh
+        } else {
+            Freshness::Unavailable
+        }
+    };
 
     let (health, health_fresh) = {
         let mut client =
@@ -160,18 +171,28 @@ async fn poll_once(connection: &Connection, state: &mut FetcherState) -> DataSna
         state.next_metrics_poll = now + METRICS_POLL_INTERVAL;
         let mut client =
             ControlServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-        if let Ok(response) = client.get_metrics(MetricsRequest {}).await {
-            state.rpki_vrp_count = parse_vrp_count(&response.into_inner().prometheus_text);
+        match client.get_metrics(MetricsRequest {}).await {
+            Ok(response) => {
+                state.rpki_vrp_count = parse_vrp_count(&response.into_inner().prometheus_text);
+                state.metrics_freshness = Freshness::Fresh;
+            }
+            Err(_) => {
+                if state.metrics_freshness != Freshness::Unavailable {
+                    state.metrics_freshness = Freshness::Stale;
+                }
+            }
         }
     }
 
     DataSnapshot {
         global: state.global.clone(),
+        global_freshness,
         health,
         health_fresh,
         neighbors,
         neighbors_freshness,
         rpki_vrp_count: state.rpki_vrp_count,
+        metrics_freshness: state.metrics_freshness,
         error,
     }
 }
@@ -345,15 +366,37 @@ mod tests {
 
         let first = poll_once(&connection, &mut state).await;
         assert!(first.global.is_none());
+        assert_eq!(first.global_freshness, Freshness::Unavailable);
+        assert!(first.error.is_none());
 
         tokio::time::advance(Duration::from_secs(2)).await;
         let second = poll_once(&connection, &mut state).await;
         assert_eq!(second.global.as_ref().map(|global| global.asn), Some(65001));
+        assert_eq!(second.global_freshness, Freshness::Fresh);
 
         tokio::time::advance(Duration::from_secs(2)).await;
         let third = poll_once(&connection, &mut state).await;
         assert_eq!(third.global.as_ref().map(|global| global.asn), Some(65001));
+        assert_eq!(third.global_freshness, Freshness::Fresh);
         assert_eq!(server.state.global_calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn initial_metrics_failure_is_unavailable_without_disconnect() {
+        let server = spawn_mock_server(None).await;
+        server
+            .state
+            .metrics_failures_remaining
+            .store(1, Ordering::SeqCst);
+        let connection = connect(&server.addr, None).await.unwrap();
+        let mut state = FetcherState::new();
+
+        let snapshot = poll_once(&connection, &mut state).await;
+
+        assert_eq!(snapshot.rpki_vrp_count, None);
+        assert_eq!(snapshot.metrics_freshness, Freshness::Unavailable);
+        assert!(snapshot.error.is_none());
+        assert_eq!(server.state.metrics_calls.load(Ordering::SeqCst), 1);
     }
 
     /// Red proof: clearing the cached VRP value on a failed slow scrape makes
@@ -369,6 +412,7 @@ mod tests {
 
         let first = poll_once(&connection, &mut state).await;
         assert_eq!(first.rpki_vrp_count, Some(15));
+        assert_eq!(first.metrics_freshness, Freshness::Fresh);
 
         server
             .state
@@ -378,6 +422,29 @@ mod tests {
         let second = poll_once(&connection, &mut state).await;
 
         assert_eq!(second.rpki_vrp_count, Some(15));
+        assert_eq!(second.metrics_freshness, Freshness::Stale);
+        assert!(second.error.is_none());
+        assert_eq!(server.state.metrics_calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn successful_metrics_without_rpki_family_clears_last_good_count() {
+        let server = spawn_mock_server(None).await;
+        *server.state.metrics_text.lock().await = Some(
+            "bgp_rpki_vrp_count{af=\"ipv4\"} 12\nbgp_rpki_vrp_count{af=\"ipv6\"} 3\n".to_string(),
+        );
+        let connection = connect(&server.addr, None).await.unwrap();
+        let mut state = FetcherState::new();
+
+        let first = poll_once(&connection, &mut state).await;
+        assert_eq!(first.rpki_vrp_count, Some(15));
+        *server.state.metrics_text.lock().await = Some("# HELP other_metric 1\n".to_string());
+        tokio::time::advance(METRICS_POLL_INTERVAL).await;
+        let second = poll_once(&connection, &mut state).await;
+
+        assert_eq!(second.rpki_vrp_count, None);
+        assert_eq!(second.metrics_freshness, Freshness::Fresh);
+        assert!(second.error.is_none());
         assert_eq!(server.state.metrics_calls.load(Ordering::SeqCst), 2);
     }
 

--- a/crates/cli/src/tui/ui.rs
+++ b/crates/cli/src/tui/ui.rs
@@ -95,8 +95,23 @@ fn draw_header(f: &mut Frame, app: &App, area: Rect, theme: &Theme) {
     if !app.health_fresh && app.health.is_some() {
         stale.push("health");
     }
+    if app.metrics_freshness == Some(Freshness::Stale) && app.rpki_vrp_count.is_some() {
+        stale.push("RPKI");
+    }
     if app.neighbors_freshness == Some(Freshness::Stale) {
         stale.push("neighbors");
+    }
+    if app.global_freshness == Some(Freshness::Unavailable) {
+        status_line.push(Span::styled(
+            "global unavailable | ",
+            Style::default().fg(theme.error),
+        ));
+    }
+    if app.metrics_freshness == Some(Freshness::Unavailable) {
+        status_line.push(Span::styled(
+            "RPKI unavailable | ",
+            Style::default().fg(theme.error),
+        ));
     }
     if app.neighbors_freshness == Some(Freshness::Unavailable) {
         status_line.push(Span::styled(
@@ -539,7 +554,8 @@ fn format_number(n: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::proto::{NeighborConfig, NeighborState};
+    use crate::proto::{GlobalState, HealthResponse, NeighborConfig, NeighborState};
+    use crate::tui::data::DataSnapshot;
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
 
@@ -553,10 +569,46 @@ mod tests {
         assert_eq!(format_number(1234567), "1,234,567");
     }
 
-    fn rendered_peer_table(with_neighbor: bool, freshness: Freshness) -> String {
+    fn snapshot(neighbors: Vec<NeighborState>, freshness: Freshness) -> DataSnapshot {
+        DataSnapshot {
+            global: Some(GlobalState {
+                asn: 65001,
+                router_id: "10.0.0.1".into(),
+                ..Default::default()
+            }),
+            global_freshness: Freshness::Fresh,
+            health: Some(HealthResponse {
+                healthy: true,
+                ..Default::default()
+            }),
+            health_fresh: true,
+            neighbors,
+            neighbors_freshness: freshness,
+            rpki_vrp_count: None,
+            metrics_freshness: Freshness::Fresh,
+            error: None,
+        }
+    }
+
+    fn rendered_snapshot(snapshot: DataSnapshot) -> String {
         let mut app = App::new();
-        if with_neighbor {
-            app.neighbors = vec![NeighborState {
+        app.on_data(snapshot);
+        let mut terminal = Terminal::new(TestBackend::new(130, 8)).unwrap();
+        terminal
+            .draw(|frame| draw(frame, &mut app, &Theme::default()))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    fn rendered_peer_table(with_neighbor: bool, freshness: Freshness) -> String {
+        let neighbors = if with_neighbor {
+            vec![NeighborState {
                 config: Some(NeighborConfig {
                     address: "fe80::1".into(),
                     interface: "eth0".into(),
@@ -565,9 +617,15 @@ mod tests {
                     ..Default::default()
                 }),
                 ..Default::default()
-            }];
+            }]
+        } else {
+            Vec::new()
+        };
+        let mut app = App::new();
+        app.on_data(snapshot(neighbors, Freshness::Fresh));
+        if freshness != Freshness::Fresh {
+            app.on_data(snapshot(Vec::new(), freshness));
         }
-        app.neighbors_freshness = Some(freshness);
         let mut terminal = Terminal::new(TestBackend::new(130, 8)).unwrap();
         terminal
             .draw(|frame| draw(frame, &mut app, &Theme::default()))
@@ -607,5 +665,58 @@ mod tests {
         let rendered = rendered_peer_table(false, Freshness::Unavailable);
         assert!(rendered.contains("neighbors unavailable"));
         assert!(!rendered.contains("stale: neighbors"));
+    }
+
+    #[test]
+    fn header_labels_global_unavailable_without_disconnect() {
+        let mut data = snapshot(Vec::new(), Freshness::Unavailable);
+        data.global = None;
+        data.global_freshness = Freshness::Unavailable;
+
+        let rendered = rendered_snapshot(data);
+
+        assert!(rendered.contains("global unavailable"));
+        assert!(rendered.contains("connected"));
+    }
+
+    #[test]
+    fn header_labels_initial_rpki_failure_without_disconnect() {
+        let mut data = snapshot(Vec::new(), Freshness::Unavailable);
+        data.metrics_freshness = Freshness::Unavailable;
+
+        let rendered = rendered_snapshot(data);
+
+        assert!(rendered.contains("RPKI unavailable"));
+        assert!(rendered.contains("connected"));
+    }
+
+    #[test]
+    fn header_labels_retained_rpki_count_as_stale_without_disconnect() {
+        let mut data = snapshot(Vec::new(), Freshness::Unavailable);
+        data.rpki_vrp_count = Some(15);
+        data.metrics_freshness = Freshness::Stale;
+
+        let rendered = rendered_snapshot(data);
+
+        assert!(rendered.contains("VRPs 15"));
+        assert!(rendered.contains("stale: RPKI"));
+        assert!(rendered.contains("connected"));
+    }
+
+    #[test]
+    fn header_is_quiet_after_success_without_rpki_family() {
+        let data = snapshot(Vec::new(), Freshness::Unavailable);
+        let rendered = rendered_snapshot(data);
+
+        assert!(!rendered.contains("RPKI unavailable"));
+        assert!(!rendered.contains("stale: RPKI"));
+        assert!(!rendered.contains("VRPs"));
+        assert!(rendered.contains("connected"));
+
+        let mut data = snapshot(Vec::new(), Freshness::Unavailable);
+        data.metrics_freshness = Freshness::Stale;
+        let rendered = rendered_snapshot(data);
+        assert!(!rendered.contains("RPKI"));
+        assert!(!rendered.contains("VRPs"));
     }
 }

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1729,8 +1729,14 @@ rbgp top -i 5     # 5s poll interval
 
 Shows sessions, prefix counts, message rates, RPKI VRP counts, and
 streaming route events in a terminal UI. The route-event subscription is
-opened only while the events panel is visible (`e`), and stale health or
-neighbor data is labeled while the last-good snapshot remains on screen.
+opened only while the events panel is visible (`e`). Global identity is retried
+on each normal poll until the first successful fetch, then cached; the
+Prometheus metrics scrape runs on a separate 60-second cadence. Before either
+optional source succeeds, the status line reports `global unavailable` or
+`RPKI unavailable` without marking the core connection disconnected. A failed
+metrics scrape retains a known VRP count and labels it stale; a successful
+scrape with no RPKI family clears the count. Stale health or neighbor data is
+likewise labeled while the last-good snapshot remains on screen.
 Press `h` for keybindings.
 
 ### Watch live events


### PR DESCRIPTION
## Summary

- distinguish one-time global metadata availability from the core connection and retry it on normal polls until the first success
- track RPKI metrics as fresh, stale, or unavailable on the existing 60-second scrape lane while retaining the last-good count on failure
- clear an older VRP count after a successful scrape without an RPKI family
- carry both freshness values through DataSnapshot and App into operator-visible header labels
- document the polling and display contract and add an Unreleased changelog entry

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --lib --no-deps
- focused data, App, and TestBackend render suites
- rebased onto main at 87ec4e14, then reran all 25 focused TUI tests
- push hooks reran fmt, clippy, workspace tests, and rustdoc successfully

## Load-bearing proof

Temporary production mutations were applied one at a time and restored:

- labeling the first global failure Fresh failed the retry/cache test
- clearing the retained count after a failed scrape failed with None instead of Some(15)
- retaining the old count after a successful no-family scrape failed with Some(15) instead of None
- removing App freshness propagation failed all three global/RPKI status render tests

The render coverage uses DataSnapshot through App::on_data and a ratatui TestBackend; it does not seed the new App fields directly.

## Scope

The generic connection error, health and neighbor freshness, roster/selection/rate behavior, daemon APIs, RPC cadence, and background-task topology are unchanged. The final diff is 220 changed lines, below the 280-line stop.