### PR TITLE
Reject incompatible unified event filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Unified event watches now reject category/type filters with no possible
+  intersection before subscribing or connecting, while preserving distinct
+  live-source and durable-outbox lag semantics.
+
 - An IPv4-only BFD configuration no longer prevents the daemon from
   starting on hosts without IPv6 support (e.g. `ipv6.disable=1`). BFD
   sockets are now opened only for the address families that actually have

--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -793,6 +793,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn incompatible_live_filter_fails_before_subscribing() {
+        let (rib_tx, route_events) = spawn_fake_rib();
+        let (peer_tx, session_events, _) = spawn_fake_peer_manager();
+        let service = EventService::new(rib_tx, peer_tx);
+        let request = proto::WatchEventsRequest {
+            categories: vec![proto::EventCategory::Session as i32],
+            event_types: vec![proto::BgpEventType::RouteAdded as i32],
+            ..Default::default()
+        };
+        let Err(status) = service.watch_events(Request::new(request)).await else {
+            panic!("incompatible filter accepted");
+        };
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert_eq!(route_events.receiver_count(), 0);
+        assert_eq!(session_events.receiver_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn mixed_live_filter_subscribes_only_to_intersection() {
+        let (rib_tx, route_events) = spawn_fake_rib();
+        let (peer_tx, session_events, _) = spawn_fake_peer_manager();
+        let service = EventService::new(rib_tx, peer_tx);
+        let response = service
+            .watch_events(Request::new(proto::WatchEventsRequest {
+                categories: vec![
+                    proto::EventCategory::Route as i32,
+                    proto::EventCategory::Session as i32,
+                ],
+                event_types: vec![proto::BgpEventType::RouteAdded as i32],
+                ..Default::default()
+            }))
+            .await
+            .unwrap();
+        assert_eq!(route_events.receiver_count(), 1);
+        assert_eq!(session_events.receiver_count(), 0);
+        drop(response);
+    }
+
+    #[tokio::test]
     async fn evpn_event_bridge_emits_bgp_event() {
         let (rib_tx, evpn_events_tx) = spawn_fake_evpn_rib();
         let (peer_tx, _, _) = spawn_fake_peer_manager();
@@ -2181,7 +2220,11 @@ mod tests {
         let service = EventService::new(rib_tx, peer_tx);
 
         match service
-            .subscribe_from_event(Request::new(proto::SubscribeFromEventRequest::default()))
+            .subscribe_from_event(Request::new(proto::SubscribeFromEventRequest {
+                categories: vec![proto::EventCategory::Session as i32],
+                event_types: vec![proto::BgpEventType::OtcRouteBlocked as i32],
+                ..Default::default()
+            }))
             .await
         {
             Ok(_) => panic!("subscribe_from_event must error when EHM is None"),

--- a/crates/api/src/event_service/cursor.rs
+++ b/crates/api/src/event_service/cursor.rs
@@ -73,6 +73,7 @@ impl ProtoFilter {
     pub(crate) fn from_request(req: &proto::SubscribeFromEventRequest) -> Result<Self, Status> {
         let categories = parse_categories(&req.categories)?;
         let event_types = parse_event_types(&req.event_types)?;
+        validate_durable_category_event_types(&categories, &event_types)?;
         let neighbor = if req.neighbor_address.is_empty() {
             None
         } else {
@@ -165,6 +166,70 @@ impl ProtoFilter {
             return false;
         };
         self.event_types.contains(&t)
+    }
+}
+
+fn validate_durable_category_event_types(
+    categories: &[proto::EventCategory],
+    event_types: &[proto::BgpEventType],
+) -> Result<(), Status> {
+    if event_types.is_empty() {
+        return Ok(());
+    }
+    let categories = categories
+        .iter()
+        .fold(0, |mask, category| mask | category_mask(*category));
+    let categories = if categories == 0 { 0x3f } else { categories };
+    let event_types = event_types.iter().fold(0, |mask, event_type| {
+        mask | durable_event_type_mask(*event_type)
+    });
+    if categories & event_types != 0 {
+        Ok(())
+    } else {
+        Err(Status::invalid_argument(
+            "event category/type filters have no possible intersection for SubscribeFromEvent",
+        ))
+    }
+}
+
+fn category_mask(category: proto::EventCategory) -> u8 {
+    match category {
+        proto::EventCategory::Unspecified => 0,
+        proto::EventCategory::Route => 1,
+        proto::EventCategory::Session => 2,
+        proto::EventCategory::Policy => 4,
+        proto::EventCategory::Dataplane => 8,
+        proto::EventCategory::Evpn => 16,
+        proto::EventCategory::Bfd => 32,
+    }
+}
+
+fn durable_event_type_mask(event_type: proto::BgpEventType) -> u8 {
+    match event_type {
+        proto::BgpEventType::Unspecified => 0,
+        proto::BgpEventType::RouteAdded
+        | proto::BgpEventType::RouteWithdrawn
+        | proto::BgpEventType::RouteBestChanged
+        | proto::BgpEventType::RoutePolicyFiltered => 1,
+        proto::BgpEventType::SessionStateChanged
+        | proto::BgpEventType::SessionEstablished
+        | proto::BgpEventType::SessionLost
+        | proto::BgpEventType::PeerEnabled
+        | proto::BgpEventType::PeerDisabled
+        | proto::BgpEventType::NotificationSent
+        | proto::BgpEventType::NotificationReceived => 2,
+        proto::BgpEventType::PolicyChanged | proto::BgpEventType::OtcRouteBlocked => 4,
+        proto::BgpEventType::DataplaneStatusChanged
+        | proto::BgpEventType::DataplaneRouteInstalled
+        | proto::BgpEventType::DataplaneRouteWithdrawn
+        | proto::BgpEventType::DataplaneRouteFailed => 8,
+        proto::BgpEventType::EvpnRouteAdded
+        | proto::BgpEventType::EvpnRouteWithdrawn
+        | proto::BgpEventType::EvpnRouteBestChanged => 16,
+        proto::BgpEventType::BfdSessionUp
+        | proto::BgpEventType::BfdSessionDown
+        | proto::BgpEventType::BfdSessionStateChanged => 32,
+        proto::BgpEventType::StreamLagged => 0x3f,
     }
 }
 
@@ -445,6 +510,18 @@ async fn run_drain(
 pub(crate) type SubscribeFromEventStream =
     Pin<Box<dyn Stream<Item = Result<proto::BgpEvent, Status>> + Send + 'static>>;
 
+fn parse_filter_when_available(
+    pass_through: bool,
+    request: &proto::SubscribeFromEventRequest,
+) -> Result<ProtoFilter, Status> {
+    if pass_through {
+        return Err(Status::failed_precondition(
+            "event history in pass-through mode; durable cursor unavailable",
+        ));
+    }
+    ProtoFilter::from_request(request)
+}
+
 /// Public entry point called by the tonic handler. Performs the
 /// availability checks, the subscribe, and spawns the drain task.
 /// Non-async because the underlying handle's `subscribe_from_event`
@@ -455,12 +532,7 @@ pub(crate) fn subscribe(
     request: &proto::SubscribeFromEventRequest,
     metrics: BgpMetrics,
 ) -> Result<SubscribeFromEventStream, Status> {
-    if handle.state().pass_through() {
-        return Err(Status::failed_precondition(
-            "event history in pass-through mode; durable cursor unavailable",
-        ));
-    }
-    let filter = ProtoFilter::from_request(request)?;
+    let filter = parse_filter_when_available(handle.state().pass_through(), request)?;
     let cursor = request.from_event_id;
 
     let subscribe_req = SubscribeRequest {
@@ -527,5 +599,56 @@ mod tests {
         })
         .unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn durable_event_type_matrix_is_exhaustive() {
+        for raw in 0..=100 {
+            let Ok(event_type) = proto::BgpEventType::try_from(raw) else {
+                continue;
+            };
+            let expected = match raw {
+                1..=4 => 1,
+                10..=14 | 20..=21 => 2,
+                22..=23 => 4,
+                30..=33 => 8,
+                40..=42 => 16,
+                50..=52 => 32,
+                100 => 0x3f,
+                0 => 0,
+                _ => unreachable!("known enum value covered"),
+            };
+            assert_eq!(
+                durable_event_type_mask(event_type),
+                expected,
+                "{event_type:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn availability_precedes_impossible_filter_validation() {
+        let request = proto::SubscribeFromEventRequest {
+            categories: vec![proto::EventCategory::Session as i32],
+            event_types: vec![proto::BgpEventType::OtcRouteBlocked as i32],
+            ..Default::default()
+        };
+        let unavailable = parse_filter_when_available(true, &request).unwrap_err();
+        assert_eq!(unavailable.code(), tonic::Code::FailedPrecondition);
+        let available = parse_filter_when_available(false, &request).unwrap_err();
+        assert_eq!(available.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn durable_mixed_sets_accept_any_intersection() {
+        let request = proto::SubscribeFromEventRequest {
+            categories: vec![
+                proto::EventCategory::Route as i32,
+                proto::EventCategory::Session as i32,
+            ],
+            event_types: vec![proto::BgpEventType::RouteAdded as i32],
+            ..Default::default()
+        };
+        ProtoFilter::from_request(&request).expect("one compatible category/type pair is enough");
     }
 }

--- a/crates/api/src/event_service/filters.rs
+++ b/crates/api/src/event_service/filters.rs
@@ -675,6 +675,7 @@ pub(super) fn parse_watch_events_filter(
 ) -> Result<WatchEventsFilter, Status> {
     let categories = parse_category_filter(&req.categories)?;
     let event_types = parse_event_type_filter(&req.event_types)?;
+    validate_live_category_event_types(&categories, &event_types)?;
     let afi = route_event_afi_filter(req.afi_safi)?;
     let prefix = parse_route_event_prefix_filter(&req.prefix, req.prefix_length, afi)?;
     let peer = if req.neighbor_address.is_empty() {
@@ -694,6 +695,70 @@ pub(super) fn parse_watch_events_filter(
         afi,
         prefix,
     })
+}
+
+fn validate_live_category_event_types(
+    categories: &BTreeSet<i32>,
+    event_types: &BTreeSet<i32>,
+) -> Result<(), Status> {
+    if event_types.is_empty() {
+        return Ok(());
+    }
+    let categories = categories.iter().fold(0, |mask, value| {
+        mask | category_mask(proto::EventCategory::try_from(*value).expect("parsed category"))
+    });
+    let categories = if categories == 0 { 0x3f } else { categories };
+    let event_types = event_types.iter().fold(0, |mask, value| {
+        mask | live_event_type_mask(proto::BgpEventType::try_from(*value).expect("parsed type"))
+    });
+    if categories & event_types != 0 {
+        Ok(())
+    } else {
+        Err(Status::invalid_argument(
+            "event category/type filters have no possible intersection for WatchEvents",
+        ))
+    }
+}
+
+fn category_mask(category: proto::EventCategory) -> u8 {
+    match category {
+        proto::EventCategory::Unspecified => 0,
+        proto::EventCategory::Route => 1,
+        proto::EventCategory::Session => 2,
+        proto::EventCategory::Policy => 4,
+        proto::EventCategory::Dataplane => 8,
+        proto::EventCategory::Evpn => 16,
+        proto::EventCategory::Bfd => 32,
+    }
+}
+
+fn live_event_type_mask(event_type: proto::BgpEventType) -> u8 {
+    match event_type {
+        proto::BgpEventType::Unspecified | proto::BgpEventType::OtcRouteBlocked => 0,
+        proto::BgpEventType::RouteAdded
+        | proto::BgpEventType::RouteWithdrawn
+        | proto::BgpEventType::RouteBestChanged
+        | proto::BgpEventType::RoutePolicyFiltered => 1,
+        proto::BgpEventType::SessionStateChanged
+        | proto::BgpEventType::SessionEstablished
+        | proto::BgpEventType::SessionLost
+        | proto::BgpEventType::PeerEnabled
+        | proto::BgpEventType::PeerDisabled
+        | proto::BgpEventType::NotificationSent
+        | proto::BgpEventType::NotificationReceived => 2,
+        proto::BgpEventType::PolicyChanged => 4,
+        proto::BgpEventType::DataplaneStatusChanged
+        | proto::BgpEventType::DataplaneRouteInstalled
+        | proto::BgpEventType::DataplaneRouteWithdrawn
+        | proto::BgpEventType::DataplaneRouteFailed => 8,
+        proto::BgpEventType::EvpnRouteAdded
+        | proto::BgpEventType::EvpnRouteWithdrawn
+        | proto::BgpEventType::EvpnRouteBestChanged => 16,
+        proto::BgpEventType::BfdSessionUp
+        | proto::BgpEventType::BfdSessionDown
+        | proto::BgpEventType::BfdSessionStateChanged => 32,
+        proto::BgpEventType::StreamLagged => 1 | 2 | 8 | 16 | 32,
+    }
 }
 
 pub(super) fn parse_list_session_events_filter(
@@ -758,4 +823,30 @@ pub(super) fn parse_list_evpn_events_filter(
         rd: parse_evpn_rd_filter(&req.rd_filter)?,
         limit: req.limit as usize,
     })
+}
+
+#[cfg(test)]
+mod compatibility_tests {
+    use super::*;
+
+    #[test]
+    fn live_event_type_matrix_is_exhaustive() {
+        for raw in 0..=100 {
+            let Ok(event_type) = proto::BgpEventType::try_from(raw) else {
+                continue;
+            };
+            let expected = match raw {
+                1..=4 => 1,
+                10..=14 | 20..=21 => 2,
+                22 => 4,
+                30..=33 => 8,
+                40..=42 => 16,
+                50..=52 => 32,
+                100 => 1 | 2 | 8 | 16 | 32,
+                0 | 23 => 0,
+                _ => unreachable!("known enum value covered"),
+            };
+            assert_eq!(live_event_type_mask(event_type), expected, "{event_type:?}");
+        }
+    }
 }

--- a/crates/cli/src/commands/watch.rs
+++ b/crates/cli/src/commands/watch.rs
@@ -805,6 +805,132 @@ fn validate_event_filter_categories(
     Ok(())
 }
 
+pub fn validate_events_watch_filter(
+    categories: &[String],
+    event_types: &[String],
+    from_event_id: Option<u64>,
+) -> Result<(), CliError> {
+    let categories = categories
+        .iter()
+        .map(String::as_str)
+        .map(parse_event_category)
+        .collect::<Result<Vec<_>, _>>()?;
+    let event_types = event_types
+        .iter()
+        .map(String::as_str)
+        .map(parse_bgp_event_type)
+        .collect::<Result<Vec<_>, _>>()?;
+    validate_category_event_types(
+        &categories,
+        &event_types,
+        from_event_id.is_some() || event_types.contains(&(BgpEventType::OtcRouteBlocked as i32)),
+    )
+}
+
+fn validate_category_event_types(
+    categories: &[i32],
+    event_types: &[i32],
+    durable: bool,
+) -> Result<(), CliError> {
+    if event_types.is_empty() {
+        return Ok(());
+    }
+    let categories = categories.iter().fold(0, |mask, value| {
+        mask | category_mask(EventCategory::try_from(*value).expect("parsed category"))
+    });
+    let categories = if categories == 0 { 0x3f } else { categories };
+    let event_types = event_types.iter().fold(0, |mask, value| {
+        let event_type = BgpEventType::try_from(*value).expect("parsed event type");
+        mask | if durable {
+            durable_event_type_mask(event_type)
+        } else {
+            live_event_type_mask(event_type)
+        }
+    });
+    if categories & event_types != 0 {
+        Ok(())
+    } else {
+        let surface = if durable {
+            "durable SubscribeFromEvent"
+        } else {
+            "live WatchEvents"
+        };
+        Err(CliError::Argument(format!(
+            "event category/type filters have no possible intersection for the {surface} stream"
+        )))
+    }
+}
+
+fn category_mask(category: EventCategory) -> u8 {
+    match category {
+        EventCategory::Unspecified => 0,
+        EventCategory::Route => 1,
+        EventCategory::Session => 2,
+        EventCategory::Policy => 4,
+        EventCategory::Dataplane => 8,
+        EventCategory::Evpn => 16,
+        EventCategory::Bfd => 32,
+    }
+}
+
+fn live_event_type_mask(event_type: BgpEventType) -> u8 {
+    match event_type {
+        BgpEventType::Unspecified | BgpEventType::OtcRouteBlocked => 0,
+        BgpEventType::RouteAdded
+        | BgpEventType::RouteWithdrawn
+        | BgpEventType::RouteBestChanged
+        | BgpEventType::RoutePolicyFiltered => 1,
+        BgpEventType::SessionStateChanged
+        | BgpEventType::SessionEstablished
+        | BgpEventType::SessionLost
+        | BgpEventType::PeerEnabled
+        | BgpEventType::PeerDisabled
+        | BgpEventType::NotificationSent
+        | BgpEventType::NotificationReceived => 2,
+        BgpEventType::PolicyChanged => 4,
+        BgpEventType::DataplaneStatusChanged
+        | BgpEventType::DataplaneRouteInstalled
+        | BgpEventType::DataplaneRouteWithdrawn
+        | BgpEventType::DataplaneRouteFailed => 8,
+        BgpEventType::EvpnRouteAdded
+        | BgpEventType::EvpnRouteWithdrawn
+        | BgpEventType::EvpnRouteBestChanged => 16,
+        BgpEventType::BfdSessionUp
+        | BgpEventType::BfdSessionDown
+        | BgpEventType::BfdSessionStateChanged => 32,
+        BgpEventType::StreamLagged => 1 | 2 | 8 | 16 | 32,
+    }
+}
+
+fn durable_event_type_mask(event_type: BgpEventType) -> u8 {
+    match event_type {
+        BgpEventType::Unspecified => 0,
+        BgpEventType::RouteAdded
+        | BgpEventType::RouteWithdrawn
+        | BgpEventType::RouteBestChanged
+        | BgpEventType::RoutePolicyFiltered => 1,
+        BgpEventType::SessionStateChanged
+        | BgpEventType::SessionEstablished
+        | BgpEventType::SessionLost
+        | BgpEventType::PeerEnabled
+        | BgpEventType::PeerDisabled
+        | BgpEventType::NotificationSent
+        | BgpEventType::NotificationReceived => 2,
+        BgpEventType::PolicyChanged | BgpEventType::OtcRouteBlocked => 4,
+        BgpEventType::DataplaneStatusChanged
+        | BgpEventType::DataplaneRouteInstalled
+        | BgpEventType::DataplaneRouteWithdrawn
+        | BgpEventType::DataplaneRouteFailed => 8,
+        BgpEventType::EvpnRouteAdded
+        | BgpEventType::EvpnRouteWithdrawn
+        | BgpEventType::EvpnRouteBestChanged => 16,
+        BgpEventType::BfdSessionUp
+        | BgpEventType::BfdSessionDown
+        | BgpEventType::BfdSessionStateChanged => 32,
+        BgpEventType::StreamLagged => 0x3f,
+    }
+}
+
 pub async fn run(
     connection: Connection,
     neighbor: Option<String>,
@@ -831,6 +957,11 @@ pub async fn events_watch(
     connection: Connection,
     options: EventsWatchOptions,
 ) -> Result<(), CliError> {
+    validate_events_watch_filter(
+        &options.categories,
+        &options.event_types,
+        options.from_event_id,
+    )?;
     let EventsWatchOptions {
         categories,
         neighbor,
@@ -848,7 +979,6 @@ pub async fn events_watch(
         .map(parse_event_category)
         .collect::<Result<Vec<_>, _>>()?;
     validate_event_filter_categories(&categories, &neighbor, family, &prefix)?;
-
     let event_types = event_types
         .iter()
         .map(String::as_str)
@@ -2553,6 +2683,34 @@ mod tests {
             BgpEventType::PolicyChanged as i32,
         ];
         validate_route_only_filters(&[], &event_types, None, Some("203.0.113.0/24")).unwrap();
+    }
+
+    #[test]
+    fn unified_filter_live_and_durable_matrices_are_exhaustive() {
+        for raw in 0..=100 {
+            let Ok(event_type) = BgpEventType::try_from(raw) else {
+                continue;
+            };
+            let (live, durable) = match raw {
+                1..=4 => (1, 1),
+                10..=14 | 20..=21 => (2, 2),
+                22 => (4, 4),
+                23 => (0, 4),
+                30..=33 => (8, 8),
+                40..=42 => (16, 16),
+                50..=52 => (32, 32),
+                100 => (1 | 2 | 8 | 16 | 32, 0x3f),
+                0 => (0, 0),
+                _ => unreachable!("known enum value covered"),
+            };
+            assert_eq!(live_event_type_mask(event_type), live);
+            assert_eq!(durable_event_type_mask(event_type), durable);
+        }
+        let policy = [EventCategory::Policy as i32];
+        assert!(validate_category_event_types(&policy, &[22, 100], false).is_ok());
+        assert!(validate_category_event_types(&[1, 2], &[1], false).is_ok());
+        assert!(validate_category_event_types(&policy, &[100], false).is_err());
+        assert!(validate_category_event_types(&[2], &[23], true).is_err());
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2151,6 +2151,19 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
     validate_neighbor_compare_action(&cli.command)?;
     validate_rib_count_action(&cli.command)?;
     validate_rib_age_action(&cli.command)?;
+    if let Command::Events {
+        action:
+            Some(EventsAction::Watch {
+                categories,
+                event_types,
+                from_event_id,
+                ..
+            }),
+        ..
+    } = &cli.command
+    {
+        commands::watch::validate_events_watch_filter(categories, event_types, *from_event_id)?;
+    }
     let connection = connect(&cli.addr, cli.token_file.as_deref()).await?;
     let json = cli.json;
 
@@ -4844,6 +4857,35 @@ mod tests {
                 ..
             } if categories == &vec!["policy".to_string()] && event_types == &vec!["policy_changed".to_string()]
         ));
+    }
+
+    #[tokio::test]
+    async fn events_watch_rejects_impossible_filters_before_connect() {
+        for tail in [
+            "--category session --type added",
+            "--from-event-id 0 --category session --type added",
+            "--category session --type otc_route_blocked",
+        ] {
+            let args = format!("rbgp --addr http://127.0.0.1:1 events watch {tail}");
+            let cli = Cli::try_parse_from(args.split_whitespace()).unwrap();
+            assert!(
+                run(cli, BINARY_NAME)
+                    .await
+                    .unwrap_err()
+                    .to_string()
+                    .contains("no possible intersection"),
+                "{tail} reached transport"
+            );
+        }
+        let args = "rbgp --addr http://127.0.0.1:1 events watch \
+                    --category route,session --type added";
+        let err = run(
+            Cli::try_parse_from(args.split_whitespace()).unwrap(),
+            BINARY_NAME,
+        )
+        .await
+        .unwrap_err();
+        assert!(!err.to_string().contains("no possible intersection"));
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -1483,11 +1483,43 @@ Dataplane summary and per-route FIB apply events remain live on `WatchEvents`
 and are also replayable through `SubscribeFromEvent` when event history is
 enabled. When event history is disabled or unavailable, the RPC returns
 `FAILED_PRECONDITION`; legacy live and `List*Events` RPCs are unaffected.
+That availability result takes precedence over filter validation.
 
-Filters compose
-AND-wise across category, type, peer, family, and exact prefix. Repeated
-category and type filters are OR-matched within their own dimension. Route
-events are sourced from the same structured RIB broadcast as `WatchRoutes`,
+Filters compose AND-wise across category, type, peer, family, and exact prefix.
+Repeated categories are ORed, repeated types are ORed, and the two dimensions
+are ANDed. A request is accepted when any selected category/type pair is real;
+no intersection returns `INVALID_ARGUMENT`. An empty category or type dimension
+is a wildcard for compatibility validation (the live default/opt-in selection
+rules below still apply).
+
+Synthetic `BGP_EVENT_TYPE_STREAM_LAGGED` control frames bypass ordinary
+category, type, peer, family, and prefix filters after compatibility validation.
+
+Live `WatchEvents` compatibility:
+
+| Category | Compatible event types |
+|----------|------------------------|
+| Route | `BGP_EVENT_TYPE_ROUTE_ADDED`, `BGP_EVENT_TYPE_ROUTE_WITHDRAWN`, `BGP_EVENT_TYPE_ROUTE_BEST_CHANGED`, `BGP_EVENT_TYPE_ROUTE_POLICY_FILTERED`, `BGP_EVENT_TYPE_STREAM_LAGGED` |
+| Session | `BGP_EVENT_TYPE_SESSION_STATE_CHANGED`, `BGP_EVENT_TYPE_SESSION_ESTABLISHED`, `BGP_EVENT_TYPE_SESSION_LOST`, `BGP_EVENT_TYPE_PEER_ENABLED`, `BGP_EVENT_TYPE_PEER_DISABLED`, `BGP_EVENT_TYPE_NOTIFICATION_SENT`, `BGP_EVENT_TYPE_NOTIFICATION_RECEIVED`, `BGP_EVENT_TYPE_STREAM_LAGGED` |
+| Policy | `BGP_EVENT_TYPE_POLICY_CHANGED` (never `BGP_EVENT_TYPE_STREAM_LAGGED`) |
+| Dataplane | `BGP_EVENT_TYPE_DATAPLANE_STATUS_CHANGED`, `BGP_EVENT_TYPE_DATAPLANE_ROUTE_INSTALLED`, `BGP_EVENT_TYPE_DATAPLANE_ROUTE_WITHDRAWN`, `BGP_EVENT_TYPE_DATAPLANE_ROUTE_FAILED`, plus `BGP_EVENT_TYPE_STREAM_LAGGED` only for the per-route source (not the peerless summary source) |
+| EVPN | `BGP_EVENT_TYPE_EVPN_ROUTE_ADDED`, `BGP_EVENT_TYPE_EVPN_ROUTE_WITHDRAWN`, `BGP_EVENT_TYPE_EVPN_ROUTE_BEST_CHANGED`, `BGP_EVENT_TYPE_STREAM_LAGGED` |
+| BFD | `BGP_EVENT_TYPE_BFD_SESSION_UP`, `BGP_EVENT_TYPE_BFD_SESSION_DOWN`, `BGP_EVENT_TYPE_BFD_SESSION_STATE_CHANGED`, `BGP_EVENT_TYPE_STREAM_LAGGED` |
+
+Durable `SubscribeFromEvent` compatibility:
+
+| Category | Compatible event types |
+|----------|------------------------|
+| Route | `BGP_EVENT_TYPE_ROUTE_ADDED`, `BGP_EVENT_TYPE_ROUTE_WITHDRAWN`, `BGP_EVENT_TYPE_ROUTE_BEST_CHANGED`, `BGP_EVENT_TYPE_ROUTE_POLICY_FILTERED`, global `BGP_EVENT_TYPE_STREAM_LAGGED` |
+| Session | `BGP_EVENT_TYPE_SESSION_STATE_CHANGED`, `BGP_EVENT_TYPE_SESSION_ESTABLISHED`, `BGP_EVENT_TYPE_SESSION_LOST`, `BGP_EVENT_TYPE_PEER_ENABLED`, `BGP_EVENT_TYPE_PEER_DISABLED`, `BGP_EVENT_TYPE_NOTIFICATION_SENT`, `BGP_EVENT_TYPE_NOTIFICATION_RECEIVED`, global `BGP_EVENT_TYPE_STREAM_LAGGED` |
+| Policy | `BGP_EVENT_TYPE_POLICY_CHANGED`, `BGP_EVENT_TYPE_OTC_ROUTE_BLOCKED`, global `BGP_EVENT_TYPE_STREAM_LAGGED` |
+| Dataplane | `BGP_EVENT_TYPE_DATAPLANE_STATUS_CHANGED`, `BGP_EVENT_TYPE_DATAPLANE_ROUTE_INSTALLED`, `BGP_EVENT_TYPE_DATAPLANE_ROUTE_WITHDRAWN`, `BGP_EVENT_TYPE_DATAPLANE_ROUTE_FAILED`, global `BGP_EVENT_TYPE_STREAM_LAGGED` |
+| EVPN | `BGP_EVENT_TYPE_EVPN_ROUTE_ADDED`, `BGP_EVENT_TYPE_EVPN_ROUTE_WITHDRAWN`, `BGP_EVENT_TYPE_EVPN_ROUTE_BEST_CHANGED`, global `BGP_EVENT_TYPE_STREAM_LAGGED` |
+| BFD | `BGP_EVENT_TYPE_BFD_SESSION_UP`, `BGP_EVENT_TYPE_BFD_SESSION_DOWN`, `BGP_EVENT_TYPE_BFD_SESSION_STATE_CHANGED`, global `BGP_EVENT_TYPE_STREAM_LAGGED` |
+
+`OTC_ROUTE_BLOCKED` is durable Policy only. Durable `STREAM_LAGGED` describes a
+global committed-stream gap and is therefore compatible with every category.
+Route events are sourced from the same structured RIB broadcast as `WatchRoutes`,
 including export-policy denial events (`route_policy_filtered`) for unicast
 routes present in Loc-RIB but filtered from an outbound peer;
 session events are sourced from the peer manager's session broadcast and cover
@@ -1516,10 +1548,9 @@ with empty categories selects the corresponding opt-in stream, and
 state-change lifecycle events over
 a bounded channel that is separate from the lossless TCP collision-coordination
 path, so high churn can drop observability events without risking collision
-handling. If a subscriber falls behind any subscribed bounded source, the stream
-emits a `stream_lagged` warning event with the source category and missed
-count; lag warnings are delivered for subscribed source categories even when
-the request's event-type filter is otherwise restrictive. Prefix and family
+handling. Live lag warnings emit for route, session, per-route dataplane, EVPN,
+and BFD sources, but not policy or peerless dataplane; durable lag is global.
+Prefix and family
 filters match unicast route events and per-route FIB dataplane events; session,
 policy, EVPN, BFD, and peerless dataplane summary events do not match requests
 that set `prefix` or `afi_safi`. Peer filters match route, session, EVPN, BFD,
@@ -1571,8 +1602,10 @@ Slow live-stream consumers do not block the daemon. If a `WatchEvents`,
 `WatchRouteEvents`, or `WatchRoutes` subscriber falls behind the bounded
 broadcast channel, missed events are skipped and
 `bgp_event_stream_lagged_total{service,source}` records the missed count.
-`WatchRouteEvents` and `WatchEvents` also emit an in-band `stream_lagged`
-warning to the affected subscriber. Use
+`WatchRouteEvents` emits an in-band `stream_lagged` warning; `WatchEvents`
+emits one for route, session, per-route dataplane, EVPN, and BFD sources.
+Policy and peerless dataplane lag is metric-only and discarded without an
+in-band warning. Use
 `bgp_event_stream_subscribers{service,source}` to see active stream readers and
 `bgp_route_event_history_depth` /
 `bgp_route_event_history_capacity` to understand how much recent unicast route
@@ -1610,7 +1643,7 @@ Stream health event types:
 
 | Type | Meaning |
 |------|---------|
-| `BGP_EVENT_TYPE_STREAM_LAGGED` | This subscriber missed one or more route or session events from a bounded source stream. See `StreamLagEvent.source_category` and `missed_count`. |
+| `BGP_EVENT_TYPE_STREAM_LAGGED` | Live: source-scoped route, session, per-route dataplane, EVPN, or BFD loss. Durable: a global outbox gap compatible with every category. |
 
 Policy event types:
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -824,7 +824,7 @@ signal.
 
 | Metric | What it tells you |
 |--------|-------------------|
-| `bgp_event_stream_lagged_total{service,source}` | Events skipped because a live stream subscriber fell behind the bounded broadcast channel. `service` is `watch_events`, `watch_route_events`, or `watch_routes`; `source` is `route`, `session`, `evpn`, `dataplane`, or `dataplane_route` where applicable |
+| `bgp_event_stream_lagged_total{service,source}` | Events skipped because a live stream subscriber fell behind the bounded broadcast channel. `service` is `watch_events`, `watch_route_events`, or `watch_routes`; `source` is `route`, `session`, `policy`, `evpn`, `dataplane`, `dataplane_route`, or `bfd` where applicable |
 | `bgp_event_stream_subscribers{service,source}` | Current live stream subscriber count by service/source |
 | `bgp_route_event_history_depth` | Current number of unicast route events retained for `ListRouteEvents` / `rbgp events` history queries |
 | `bgp_route_event_history_capacity` | Fixed capacity of the bounded unicast route-event history ring |
@@ -1786,14 +1786,24 @@ config-file persistence is separate. Session state-change events use a bounded
 observability channel separate from the lossless TCP collision-coordination
 path, so a saturated watch stream can miss lifecycle events without blocking
 BGP collision handling. If the client falls behind a bounded route, session,
-policy, EVPN, dataplane, or BFD source stream, `events watch` prints a
+EVPN, per-route dataplane, or BFD source stream, `events watch` prints a
 `stream_lagged` warning with the missed count; treat subsequent output as a
-live tail after a gap. Use `--backfill N`
+live tail after a gap. Policy and peerless dataplane lag is metric-only, with
+no in-band warning. Use `--backfill N`
 to print recent matching route history before the live tail starts. Backfill
 is route-history only; session, policy, EVPN, dataplane, and BFD events are not
-backfilled through the live stream command. Per-route FIB dataplane events are
-live-only; use `rbgp rib fib` for the current route ownership snapshot
-after a reconnect.
+backfilled from process-local history through the live stream command. When
+EHM is enabled, those categories — including per-route FIB dataplane events —
+can instead be replayed durably with `SubscribeFromEvent` or
+`rbgp events watch --from-event-id <N>`. Use `rbgp rib fib` for the current
+route ownership snapshot after a reconnect.
+
+Category/type values are ORed within each dimension and ANDed across them. The
+CLI rejects impossible combinations locally before connecting. On the server,
+a missing EHM or an EHM in pass-through mode returns `FAILED_PRECONDITION`
+before category/type parsing. Durable lag is global for every category; OTC is
+durable-policy only.
+
 Backfilled route events use the same output shape as live route events, but
 the command still prints a history block followed by the live tail rather than
 merging the two by wall-clock timestamp.

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -1764,13 +1764,16 @@ service EventService {
   // enforced. The same payload bytes go to both halves of the stream
   // (the byte-equality invariant from ADR-0072).
   //
-  // The `from_event_id` field uses proto3 explicit-presence: absent ⇒
-  // live-only (matches WatchEvents); value 0 ⇒ replay everything
-  // retained, then live (fresh-collector case); value N > 0 ⇒ replay
-  // event_id > N, then live (normal reconnect case).
+  // The `from_event_id` field uses proto3 explicit-presence: absent ⇒ attach
+  // to the durable committed live tail without replay; value 0 ⇒ replay
+  // everything retained, then live (fresh-collector case); value N > 0 ⇒
+  // replay event_id > N, then live (normal reconnect case). Empty filters use
+  // SubscribeFromEvent semantics (all EHM-fed categories), not WatchEvents
+  // live-stream defaults.
   //
-  // Returns UNIMPLEMENTED until the daemon wires EventHistoryManager
-  // into the service.
+  // Returns FAILED_PRECONDITION when durable history is disabled, unavailable,
+  // or in pass-through mode. Availability is checked before category/type
+  // filter validation.
   rpc SubscribeFromEvent(SubscribeFromEventRequest) returns (stream BgpEvent);
 }
 
@@ -2359,9 +2362,9 @@ enum BgpEventType {
   BGP_EVENT_TYPE_BFD_SESSION_UP = 50;
   BGP_EVENT_TYPE_BFD_SESSION_DOWN = 51;
   BGP_EVENT_TYPE_BFD_SESSION_STATE_CHANGED = 52;
-  // A WatchEvents subscriber fell behind a bounded source stream and
-  // missed one or more events. The payload identifies the source
-  // category and missed count.
+  // A stream gap: WatchEvents reports a bounded-source gap and identifies
+  // that source category; SubscribeFromEvent reports a global committed-stream
+  // gap with both category and source_category UNSPECIFIED.
   BGP_EVENT_TYPE_STREAM_LAGGED = 100;
 }
 
@@ -2373,6 +2376,8 @@ enum EventSeverity {
 }
 
 message WatchEventsRequest {
+  // Repeated values are OR-matched within each field and AND-matched
+  // across category/type. A combination with no live source is invalid.
   // Empty categories with empty event_types = default live categories
   // (route + session). A non-empty event_types filter narrows the
   // result; BGP_EVENT_TYPE_POLICY_CHANGED,
@@ -2423,6 +2428,8 @@ message SubscribeFromEventRequest {
   optional uint64 from_event_id = 1;
 
   // Filters. All set filters are AND-combined.
+  // Repeated categories/types are OR-matched within their dimension;
+  // combinations with no durable producer return INVALID_ARGUMENT.
   //
   // Default-filter semantics diverge from WatchEventsRequest on
   // purpose: SubscribeFromEvent treats an empty `categories` +
@@ -2533,13 +2540,13 @@ message SessionEvent {
 }
 
 message StreamLagEvent {
-  // Source stream that lagged. This is the same value copied into the
-  // top-level BgpEvent.category field so category-agnostic clients can
-  // filter without unpacking the payload.
+  // WatchEvents mirrors the bounded source into this field and the top-level
+  // BgpEvent.category. SubscribeFromEvent uses UNSPECIFIED because its gap is
+  // global across the committed stream and bypasses the category filter.
   EventCategory source_category = 1;
-  // Count reported by tokio broadcast lag detection. It is the number
-  // of source events skipped by this subscriber, before any
-  // WatchEvents filters could be applied.
+  // WatchEvents counts skipped source events before filtering.
+  // SubscribeFromEvent counts skipped committed global-outbox events, not the
+  // filtered subset.
   uint64 missed_count = 2;
   // Stable operator-facing reason/summary string for this event.
   string reason = 3;
@@ -2722,15 +2729,12 @@ message BgpEvent {
   // level rather than duplicated onto every nested payload — see
   // the ADR's "Envelope strategy" section for the rationale.
   //
-  // `optional uint64` (proto3 explicit-presence) so clients can
-  // tell whether the daemon emitted this event through the durable
-  // outbox. Events from EHM-fed broadcasts (PR5+) set the field on
-  // every event. Events from pre-ADR-0072 surfaces — including the
-  // legacy in-memory ring path used by ListRouteEvents and the
-  // existing WatchEvents stream until producer wiring lands — omit
-  // the field. The allocator starts at 0 and the first committed
-  // event gets id 1, so a present-but-zero value should never
-  // appear on an emitted BgpEvent in practice.
+  // `optional uint64` (proto3 explicit-presence) so clients can tell whether
+  // the daemon emitted a committed SubscribeFromEvent envelope. Every
+  // committed envelope on that RPC sets the field. Synthetic durable lag
+  // frames and legacy WatchEvents / List*Events responses omit it. The
+  // allocator starts at 0 and the first committed event gets id 1, so a
+  // present-but-zero value should never appear on an emitted BgpEvent.
   //
   // RouteEvent.event_id continues to mirror this value for wire
   // backwards-compatibility with route-only consumers, but the


### PR DESCRIPTION
## Summary

- reject category/type combinations with no possible intersection on both live WatchEvents and durable SubscribeFromEvent surfaces
- preserve any-intersection semantics for mixed sets, source-specific live lag, global durable lag, OTC durable-policy routing, and availability-first server errors
- validate rbgp events watch before its global connection while retaining server-side validation before subscriptions
- document the exact live and durable compatibility matrices and correct stale lag, replay, and cursor comments

## Verification

- cargo fmt --all -- --check
- cargo check -p rustbgpd-api -p rustbgpctl
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
- focused API event-service suite: 59 passed
- focused CLI matrix, pre-connect, and completion-freshness tests
- push hooks reran fmt, clippy, workspace tests, and rustdoc successfully
- independent final review found no remaining findings

## Load-bearing proof

Temporary production mutations were applied one at a time and restored:

- removing live validation accepted an impossible live request
- removing durable validation accepted an impossible durable request
- removing CLI pre-connect validation reached the deliberately unreachable transport
- replacing any-intersection with strict mask equality rejected valid mixed sets on both surfaces
- admitting live policy lag and removing durable global lag each failed the exhaustive matrix tests
- parsing before missing or pass-through availability changed FAILED_PRECONDITION to INVALID_ARGUMENT

The subscription test also pins zero receiver installation for a rejected live request. Proto declarations are byte-identical after stripping comment-only lines.

## Scope

No event production, lag emission, retention, replay, wire declarations, valid-filter behavior, or generated artifacts changed. The final diff is 608 changed lines, within the reviewed 610-line cap.