### PR TITLE
Fence lifecycle route pages after session acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   start, with the family named in the error, while a family with no
   sessions is never opened and cannot fail startup.
 
-- Stale `PeerOrfUpdate`, `PeerSlowState`, `SetPeerPolicyContext`, and
-  `RouteRefreshRequest` messages no longer restart advertised-route page cursors.
+- Stale `PeerAddPathLimits`, `PeerDown`, `PeerGracefulRestart`, `PeerOrfUpdate`, `PeerSlowState`,
+  `SetPeerPolicyContext`, and `RouteRefreshRequest` messages no longer restart route-page cursors.
 
 - `rbgp top` now distinguishes unavailable optional global/RPKI telemetry from
   a stale retained VRP count without reporting a core disconnect, and clears a

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -29,7 +29,7 @@ impl RibManager {
         peer_llgr_capable: bool,
         peer_llgr_families: Vec<rustbgpd_wire::LlgrFamily>,
         llgr_stale_time: u32,
-    ) {
+    ) -> bool {
         // Same session-identity dispatch as `handle_peer_down`: a GR-down
         // from a superseded session (RFC 4271 §6.8 collision loser
         // processed after the winner's `PeerUp`) must not mark the
@@ -45,10 +45,10 @@ impl RibManager {
         // exactly as before stamping.
         use super::peer_lifecycle::SessionTeardownDisposition;
         match self.classify_session_teardown(peer, session_id, "PeerGracefulRestart") {
-            SessionTeardownDisposition::DiscardStale => return,
+            SessionTeardownDisposition::DiscardStale => return false,
             SessionTeardownDisposition::FailOver => {
                 self.fail_over_registration(peer, session_id, "PeerGracefulRestart");
-                return;
+                return true;
             }
             SessionTeardownDisposition::NoRegistration
             | SessionTeardownDisposition::TeardownActive => {}
@@ -299,6 +299,7 @@ impl RibManager {
         });
         self.metrics
             .set_gr_stale_routes(&peer_label, gauge_val(stale_count));
+        true
     }
 
     pub(super) fn handle_rpki_cache_update(&mut self, table: Arc<VrpTable>) {

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1520,6 +1520,31 @@ impl RibManager {
         self.advance_advertised_pages();
     }
 
+    fn route_page_versions_snapshot(&self) -> [Option<RoutePageVersion>; 3] {
+        [
+            self.route_page_received_version,
+            self.route_page_best_version,
+            self.route_page_advertised_version,
+        ]
+    }
+
+    fn ensure_advertised_pages_advanced(&mut self, snapshot: [Option<RoutePageVersion>; 3]) {
+        // Cover untouched scopes; synchronous internal distribution passes remain uncoalesced.
+        if self.route_page_advertised_version == snapshot[2] {
+            self.advance_advertised_pages();
+        }
+    }
+
+    fn ensure_all_route_pages_advanced(&mut self, snapshot: [Option<RoutePageVersion>; 3]) {
+        if self.route_page_received_version == snapshot[0] {
+            self.advance_received_pages();
+        }
+        if self.route_page_best_version == snapshot[1] {
+            self.advance_best_pages();
+        }
+        self.ensure_advertised_pages_advanced(snapshot);
+    }
+
     fn route_page_version(
         &self,
         scope: RouteQueryScope,
@@ -1538,17 +1563,14 @@ impl RibManager {
             // transition whose `Finalize` flips group memberships and export
             // overlays; general queries stay fenced out until it is terminal,
             // so advancing here at acceptance covers the whole transaction.
-            RibUpdate::PeerAddPathLimits { .. }
-            | RibUpdate::ReplacePeerExportPolicy { .. }
+            RibUpdate::ReplacePeerExportPolicy { .. }
             | RibUpdate::ReplacePeerExportPolicies { .. }
             | RibUpdate::ApplyOutboundPrefixLimits { .. }
             | RibUpdate::RefreshPeerOutbound { .. } => self.advance_advertised_pages(),
             RibUpdate::PeerUp { .. }
-            | RibUpdate::PeerDown { .. }
             | RibUpdate::PeerDeleted { .. }
             | RibUpdate::InjectRoute { .. }
             | RibUpdate::WithdrawInjected { .. }
-            | RibUpdate::PeerGracefulRestart { .. }
             | RibUpdate::RpkiCacheUpdate { .. }
             | RibUpdate::AspaTableUpdate { .. } => self.advance_all_route_pages(),
             _ => {}
@@ -1943,8 +1965,11 @@ impl RibManager {
                 }
             }
             RibUpdate::PeerDown { peer, session_id } => {
-                self.handle_peer_down(peer, session_id);
-                self.prune_exact_export_rejections();
+                let page_versions = self.route_page_versions_snapshot();
+                if self.handle_peer_down(peer, session_id) {
+                    self.prune_exact_export_rejections();
+                    self.ensure_all_route_pages_advanced(page_versions);
+                }
             }
             RibUpdate::PeerDeleted { peer } => self.handle_peer_deleted(peer),
             RibUpdate::PeerUp {
@@ -1993,6 +2018,7 @@ impl RibManager {
                 // reconfiguration surface (a decrease requires a new session
                 // so excess advertised path IDs are withdrawn by teardown).
                 if self.outbound_session_ids.get(&peer).copied() == Some(session_id) {
+                    let page_versions = self.route_page_versions_snapshot();
                     let send_families = self
                         .peer_add_path_send_families
                         .get(&peer)
@@ -2047,6 +2073,7 @@ impl RibManager {
                     if effective_limit_changed {
                         self.send_initial_table(peer);
                     }
+                    self.ensure_advertised_pages_advanced(page_versions);
                 }
             }
             RibUpdate::PeerOrfUpdate {
@@ -2428,16 +2455,21 @@ impl RibManager {
                 peer_llgr_capable,
                 peer_llgr_families,
                 llgr_stale_time,
-            } => self.handle_peer_graceful_restart(
-                peer,
-                session_id,
-                restart_time,
-                stale_routes_time,
-                gr_families,
-                peer_llgr_capable,
-                peer_llgr_families,
-                llgr_stale_time,
-            ),
+            } => {
+                let page_versions = self.route_page_versions_snapshot();
+                if self.handle_peer_graceful_restart(
+                    peer,
+                    session_id,
+                    restart_time,
+                    stale_routes_time,
+                    gr_families,
+                    peer_llgr_capable,
+                    peer_llgr_families,
+                    llgr_stale_time,
+                ) {
+                    self.ensure_all_route_pages_advanced(page_versions);
+                }
+            }
             RibUpdate::RpkiCacheUpdate { table } => self.handle_rpki_cache_update(table),
             RibUpdate::AspaTableUpdate { table } => self.handle_aspa_cache_update(table),
             RibUpdate::InjectFlowSpec { route, reply } => self.handle_inject_flowspec(route, reply),

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -51,14 +51,18 @@ impl RibManager {
     /// collision interleaving: the loser's `PeerUp` replaced the winner's
     /// registration before the loser went down) fails the registration
     /// over to the survivor instead of tearing the peer down.
-    pub(super) fn handle_peer_down(&mut self, peer: IpAddr, session_id: u64) {
+    pub(super) fn handle_peer_down(&mut self, peer: IpAddr, session_id: u64) -> bool {
         match self.classify_session_teardown(peer, session_id, "PeerDown") {
-            SessionTeardownDisposition::DiscardStale => {}
+            SessionTeardownDisposition::DiscardStale => false,
             SessionTeardownDisposition::FailOver => {
                 self.fail_over_registration(peer, session_id, "PeerDown");
+                true
             }
             SessionTeardownDisposition::NoRegistration
-            | SessionTeardownDisposition::TeardownActive => self.peer_down_teardown(peer),
+            | SessionTeardownDisposition::TeardownActive => {
+                self.peer_down_teardown(peer);
+                true
+            }
         }
     }
 

--- a/crates/rib/src/manager/tests/paged_query.rs
+++ b/crates/rib/src/manager/tests/paged_query.rs
@@ -165,11 +165,22 @@ fn peer_up_direct_with_negotiated_orf(
     peer: IpAddr,
     negotiated_orf_recv: Vec<(Afi, Safi)>,
 ) -> mpsc::Receiver<OutboundRouteUpdate> {
+    peer_up_direct_with_options(manager, peer, 0, vec![], 0, negotiated_orf_recv)
+}
+
+fn peer_up_direct_with_options(
+    manager: &mut RibManager,
+    peer: IpAddr,
+    session_id: u64,
+    add_path_send_families: Vec<(Afi, Safi)>,
+    add_path_send_max: u32,
+    negotiated_orf_recv: Vec<(Afi, Safi)>,
+) -> mpsc::Receiver<OutboundRouteUpdate> {
     let (outbound_tx, outbound_rx) = mpsc::channel(64);
     manager.handle_update(RibUpdate::PeerUp {
         per_client_best: false,
         interpret_rfc1997: true,
-        session_id: 0,
+        session_id,
         peer,
         peer_asn: 65000,
         peer_router_id: Ipv4Addr::UNSPECIFIED,
@@ -179,8 +190,8 @@ fn peer_up_direct_with_negotiated_orf(
         is_ebgp: false,
         route_reflector_client: false,
         orr_vantage: None,
-        add_path_send_families: vec![],
-        add_path_send_max: 0,
+        add_path_send_families,
+        add_path_send_max,
         negotiated_orf_recv,
         negotiated_llgr_families: vec![],
     });
@@ -193,9 +204,14 @@ fn receive_direct(
     announced: Vec<Route>,
     withdrawn: Vec<(Prefix, u32)>,
 ) {
+    let session_id = manager
+        .outbound_session_ids
+        .get(&peer)
+        .copied()
+        .unwrap_or(0);
     manager.handle_update(RibUpdate::RoutesReceived {
         peer,
-        session_id: 0,
+        session_id,
         announced,
         withdrawn,
         flowspec_announced: vec![],
@@ -1416,6 +1432,277 @@ fn assert_each_route_page_version_advanced_once(
         assert_eq!(after.epoch, before.epoch);
         assert_eq!(after.generation, before.generation + 1);
     }
+}
+
+fn drain_outbound(rx: &mut mpsc::Receiver<OutboundRouteUpdate>) -> Vec<OutboundRouteUpdate> {
+    std::iter::from_fn(|| rx.try_recv().ok()).collect()
+}
+
+fn best_peer(manager: &RibManager, prefix: Ipv4Prefix) -> IpAddr {
+    manager.loc_rib.get(&Prefix::V4(prefix)).unwrap().peer
+}
+
+fn peer_graceful_restart(peer: IpAddr, session_id: u64) -> RibUpdate {
+    RibUpdate::PeerGracefulRestart {
+        peer,
+        session_id,
+        restart_time: 90,
+        stale_routes_time: 120,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    }
+}
+
+fn add_path_page_fixture() -> (
+    RibManager,
+    IpAddr,
+    Ipv4Prefix,
+    mpsc::Receiver<OutboundRouteUpdate>,
+) {
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    for (octet, local_pref) in [(11, 200), (12, 100)] {
+        let source = Ipv4Addr::new(10, 0, 0, octet);
+        receive_direct(
+            &mut manager,
+            IpAddr::V4(source),
+            vec![make_multipath_route(
+                prefix,
+                source,
+                vec![65000 + u32::from(octet)],
+                local_pref,
+            )],
+            vec![],
+        );
+    }
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 99));
+    let mut target_rx = peer_up_direct_with_options(
+        &mut manager,
+        target,
+        0,
+        vec![(Afi::Ipv4, Safi::Unicast)],
+        1,
+        vec![],
+    );
+    let _ = drain_outbound(&mut target_rx);
+    (manager, target, prefix, target_rx)
+}
+
+struct LifecyclePageFixture {
+    manager: RibManager,
+    departing: IpAddr,
+    fallback: IpAddr,
+    shared: Ipv4Prefix,
+    departing_rx: Vec<mpsc::Receiver<OutboundRouteUpdate>>,
+    _fallback_rx: mpsc::Receiver<OutboundRouteUpdate>,
+    target_rx: mpsc::Receiver<OutboundRouteUpdate>,
+}
+
+fn lifecycle_page_fixture(collision: bool) -> LifecyclePageFixture {
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let departing_v4 = Ipv4Addr::new(10, 0, 0, 11);
+    let fallback_v4 = Ipv4Addr::new(10, 0, 0, 12);
+    let departing = IpAddr::V4(departing_v4);
+    let fallback = IpAddr::V4(fallback_v4);
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 99));
+    let shared = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let mut departing_rx = vec![peer_up_direct(&mut manager, departing)];
+    if collision {
+        departing_rx.push(peer_up_direct_with_options(
+            &mut manager,
+            departing,
+            1,
+            vec![],
+            0,
+            vec![],
+        ));
+    }
+    let mut fallback_rx = peer_up_direct(&mut manager, fallback);
+    let mut target_rx = peer_up_direct(&mut manager, target);
+    for rx in &mut departing_rx {
+        let _ = drain_outbound(rx);
+    }
+    let _ = drain_outbound(&mut fallback_rx);
+    let _ = drain_outbound(&mut target_rx);
+    receive_direct(
+        &mut manager,
+        departing,
+        vec![make_multipath_route(shared, departing_v4, vec![65100], 200)],
+        vec![],
+    );
+    receive_direct(
+        &mut manager,
+        fallback,
+        vec![make_multipath_route(shared, fallback_v4, vec![65200], 100)],
+        vec![],
+    );
+    for rx in &mut departing_rx {
+        let _ = drain_outbound(rx);
+    }
+    let _ = drain_outbound(&mut fallback_rx);
+    let _ = drain_outbound(&mut target_rx);
+    let live_session_count = departing_rx.iter().filter(|rx| !rx.is_closed()).count();
+    assert_eq!(live_session_count, if collision { 2 } else { 1 });
+    if collision {
+        let sessions = &manager.live_sessions[&departing];
+        assert_eq!((sessions[0].session_id, sessions[1].session_id), (0, 1));
+        assert_eq!(manager.outbound_session_ids[&departing], 1);
+    }
+    LifecyclePageFixture {
+        manager,
+        departing,
+        fallback,
+        shared,
+        departing_rx,
+        _fallback_rx: fallback_rx,
+        target_rx,
+    }
+}
+
+#[test]
+fn stale_peer_add_path_limits_leave_all_page_versions_unchanged() {
+    let (mut manager, target, _prefix, mut target_rx) = add_path_page_fixture();
+    let before = route_page_versions(&manager);
+
+    manager.handle_update(RibUpdate::PeerAddPathLimits {
+        peer: target,
+        session_id: 1,
+        limits: vec![((Afi::Ipv4, Safi::Unicast), 2)],
+    });
+
+    assert_eq!(route_page_versions(&manager), before);
+    assert!(drain_outbound(&mut target_rx).is_empty());
+}
+
+#[test]
+fn accepted_peer_add_path_limits_advance_advertised_after_two_path_replay() {
+    let (mut manager, target, prefix, mut target_rx) = add_path_page_fixture();
+    let before = route_page_versions(&manager);
+
+    manager.handle_update(RibUpdate::PeerAddPathLimits {
+        peer: target,
+        session_id: 0,
+        limits: vec![((Afi::Ipv4, Safi::Unicast), 2)],
+    });
+
+    let after = route_page_versions(&manager);
+    assert_eq!((after[0], after[1]), (before[0], before[1]));
+    assert_ne!(after[2], before[2]);
+    let mut replayed_ids: Vec<_> = drain_outbound(&mut target_rx)
+        .iter()
+        .flat_map(|update| update.announce.iter())
+        .filter(|route| route.prefix == Prefix::V4(prefix))
+        .map(|route| route.path_id)
+        .collect();
+    replayed_ids.sort_unstable();
+    assert_eq!(
+        replayed_ids,
+        vec![1, 2],
+        "effective limit replays two real paths"
+    );
+}
+
+#[test]
+fn stale_peer_down_leaves_real_route_state_and_page_versions_unchanged() {
+    let mut fixture = lifecycle_page_fixture(true);
+    let before = route_page_versions(&fixture.manager);
+
+    fixture.manager.handle_update(RibUpdate::PeerDown {
+        peer: fixture.departing,
+        session_id: 0,
+    });
+
+    assert_eq!(route_page_versions(&fixture.manager), before);
+    assert_eq!(fixture.manager.ribs[&fixture.departing].len(), 1);
+    assert_eq!(
+        best_peer(&fixture.manager, fixture.shared),
+        fixture.departing
+    );
+    assert_eq!(fixture.manager.outbound_session_ids[&fixture.departing], 1);
+    assert!(!fixture.departing_rx[1].is_closed());
+    assert!(drain_outbound(&mut fixture.target_rx).is_empty());
+}
+
+#[test]
+fn accepted_peer_down_advances_all_with_route_removal_and_fallback() {
+    let mut fixture = lifecycle_page_fixture(false);
+    let before = route_page_versions(&fixture.manager);
+
+    fixture.manager.handle_update(RibUpdate::PeerDown {
+        peer: fixture.departing,
+        session_id: 0,
+    });
+
+    let after = route_page_versions(&fixture.manager);
+    assert!((0..3).all(|index| before[index] != after[index]));
+    assert!(!fixture.manager.ribs.contains_key(&fixture.departing));
+    let updates = drain_outbound(&mut fixture.target_rx);
+    assert!(
+        updates
+            .iter()
+            .flat_map(|update| update.announce.iter())
+            .any(|route| {
+                route.prefix == Prefix::V4(fixture.shared) && route.peer == fixture.fallback
+            })
+    );
+}
+
+#[test]
+fn stale_peer_graceful_restart_leaves_real_route_state_and_page_versions_unchanged() {
+    let mut fixture = lifecycle_page_fixture(true);
+    let before = route_page_versions(&fixture.manager);
+
+    fixture
+        .manager
+        .handle_update(peer_graceful_restart(fixture.departing, 0));
+
+    assert_eq!(route_page_versions(&fixture.manager), before);
+    assert!(
+        fixture.manager.ribs[&fixture.departing]
+            .iter()
+            .all(|route| !route.is_stale)
+    );
+    assert_eq!(
+        best_peer(&fixture.manager, fixture.shared),
+        fixture.departing
+    );
+    assert_eq!(fixture.manager.outbound_session_ids[&fixture.departing], 1);
+    assert!(!fixture.departing_rx[1].is_closed());
+    assert!(drain_outbound(&mut fixture.target_rx).is_empty());
+}
+
+#[test]
+fn accepted_peer_graceful_restart_advances_all_and_advertises_live_fallback() {
+    let mut fixture = lifecycle_page_fixture(false);
+    let before = route_page_versions(&fixture.manager);
+
+    fixture
+        .manager
+        .handle_update(peer_graceful_restart(fixture.departing, 0));
+
+    let after = route_page_versions(&fixture.manager);
+    assert!((0..3).all(|index| before[index] != after[index]));
+    assert!(
+        fixture.manager.ribs[&fixture.departing]
+            .iter()
+            .any(|route| route.prefix == Prefix::V4(fixture.shared) && route.is_stale)
+    );
+    assert_eq!(
+        best_peer(&fixture.manager, fixture.shared),
+        fixture.fallback
+    );
+    assert!(
+        drain_outbound(&mut fixture.target_rx)
+            .iter()
+            .flat_map(|update| update.announce.iter())
+            .any(|route| {
+                route.prefix == Prefix::V4(fixture.shared) && route.peer == fixture.fallback
+            })
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- move `PeerAddPathLimits`, `PeerDown`, and `PeerGracefulRestart` route-page invalidation behind their session/lifecycle acceptance boundaries
- keep stale collision-session messages from changing received, best, or advertised page generations
- ensure accepted work invalidates every required scope after real replay, teardown, or graceful-restart redistribution completes
- preserve generic distribution ownership; multiple synchronous internal passes remain deliberately uncoalesced

## Verification

- six new stale/accepted boundary tests run individually
- existing Add-Path collision, stale teardown, teardown failover, stale GR, and GR failover regressions
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --lib`
- independent immutable-SHA review

## Load-bearing proof

- restoring each dispatcher pre-pass arm makes its real stale-session generation-equality test fail
- removing each post-acceptance ensure leaves a required accepted scope unchanged
- suppressing real replay/distribution empties the Add-Path two-path receipt or the teardown/GR fallback output
- collision fixtures retain both session channels, assert the replacement registration, and dispatch the old session message

## Stack

This PR is based on #1243 and must merge after it. After #1243 lands, this branch will be rebased onto `main`, retargeted, and fully regated.

## Scope

The product contract is exact zero invalidation for rejected stale work and at least one invalidation per required scope for accepted work. The RIB actor cannot interleave a query inside one handler, so legal multi-family distribution passes are not coalesced solely to preserve a numeric +1 invariant.