### PR TITLE
Honor Add-Path limits during deferred registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Deferred initial dumps now honor negotiated per-family Add-Path send limits.
+
 - Unified event watches now reject category/type filters with no possible
   intersection before subscribing or connecting, while preserving distinct
   live-source and durable-outbox lag semantics.

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2017,33 +2017,42 @@ impl RibManager {
                 // suppresses duplicate delivery; this is not a runtime cap
                 // reconfiguration surface (a decrease requires a new session
                 // so excess advertised path IDs are withdrawn by teardown).
+                let Some(send_families) = self
+                    .newest_live_session_mut(peer, session_id)
+                    .map(|record| record.add_path_send_families.clone())
+                else {
+                    return;
+                };
+                let mut rejected_families = Vec::new();
+                let new_limits: HashMap<_, _> = limits
+                    .into_iter()
+                    .filter(|(family, _)| {
+                        let accepted = send_families.contains(family);
+                        if !accepted {
+                            rejected_families.push(*family);
+                        }
+                        accepted
+                    })
+                    .collect();
+                if !rejected_families.is_empty() {
+                    rejected_families.sort_by_key(|(afi, safi)| (*afi as u16, *safi as u8));
+                    rejected_families.dedup();
+                    warn!(
+                        %peer,
+                        ?rejected_families,
+                        "ignoring Paths-Limit entries outside the negotiated Add-Path send families"
+                    );
+                }
+                // Stage the immutable negotiated map before registration. A
+                // deferred initial dump installs this record later; a stale
+                // superseded session cannot mutate the newest record.
+                self.newest_live_session_mut(peer, session_id)
+                    .expect("newest live session checked above")
+                    .add_path_send_limits
+                    .clone_from(&new_limits);
+
                 if self.outbound_session_ids.get(&peer).copied() == Some(session_id) {
                     let page_versions = self.route_page_versions_snapshot();
-                    let send_families = self
-                        .peer_add_path_send_families
-                        .get(&peer)
-                        .cloned()
-                        .unwrap_or_default();
-                    let mut rejected_families = Vec::new();
-                    let new_limits: HashMap<_, _> = limits
-                        .into_iter()
-                        .filter(|(family, _)| {
-                            let accepted = send_families.contains(family);
-                            if !accepted {
-                                rejected_families.push(*family);
-                            }
-                            accepted
-                        })
-                        .collect();
-                    if !rejected_families.is_empty() {
-                        rejected_families.sort_by_key(|(afi, safi)| (*afi as u16, *safi as u8));
-                        rejected_families.dedup();
-                        warn!(
-                            %peer,
-                            ?rejected_families,
-                            "ignoring Paths-Limit entries outside the negotiated Add-Path send families"
-                        );
-                    }
                     let scalar_limit = self.peer_add_path_send_max.get(&peer).copied().unwrap_or(0);
                     let effective_limit_changed = self
                         .peer_add_path_send_families
@@ -2060,15 +2069,6 @@ impl RibManager {
                                 old != new
                             })
                         });
-                    // Mirror the accepted map into the live-session record —
-                    // the single registration truth an outbound failover
-                    // replays from. Without this, a collision failback would
-                    // permanently clamp every family to the scalar limit.
-                    if let Some(record) = self.live_sessions.get_mut(&peer).and_then(|sessions| {
-                        sessions.iter_mut().find(|s| s.session_id == session_id)
-                    }) {
-                        record.add_path_send_limits.clone_from(&new_limits);
-                    }
                     self.peer_add_path_send_limits.insert(peer, new_limits);
                     if effective_limit_changed {
                         self.send_initial_table(peer);

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -681,6 +681,18 @@ impl RibManager {
         self.register_active_session(peer, ActiveSessionRegistration::PeerUp);
     }
 
+    /// Resolve Paths-Limit against only the newest live session.
+    pub(super) fn newest_live_session_mut(
+        &mut self,
+        peer: IpAddr,
+        session_id: u64,
+    ) -> Option<&mut LiveSessionRecord> {
+        self.live_sessions
+            .get_mut(&peer)
+            .and_then(|sessions| sessions.last_mut())
+            .filter(|record| record.session_id == session_id)
+    }
+
     /// Register the most recent live session (the last `live_sessions`
     /// entry) as the peer's active outbound registration and send it the
     /// initial table dump. Shared by `handle_peer_up` and collision failback;

--- a/crates/rib/src/manager/tests/unicast.rs
+++ b/crates/rib/src/manager/tests/unicast.rs
@@ -80,6 +80,181 @@ fn drain_unicast_state(
     state
 }
 
+async fn seed_three_dual_stack_candidates(
+    tx: &mpsc::Sender<RibUpdate>,
+) -> (Ipv4Prefix, Ipv6Prefix) {
+    fn received(route: Route) -> RibUpdate {
+        RibUpdate::RoutesReceived {
+            session_id: 0,
+            peer: route.peer,
+            announced: vec![route],
+            withdrawn: vec![],
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![],
+            evpn_withdrawn: vec![],
+        }
+    }
+
+    let v4 = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let v6 = Ipv6Prefix::new("2001:db8:700::".parse().unwrap(), 48);
+    for host in 1..=3 {
+        let v4_route = make_route(v4, Ipv4Addr::new(10, 0, 0, host));
+        tx.send(received(v4_route)).await.unwrap();
+        let v6_route = make_v6_route(v6, format!("2001:db8:700::{host}").parse().unwrap());
+        tx.send(received(v6_route)).await.unwrap();
+    }
+    let (reply, result) = oneshot::channel();
+    tx.send(RibUpdate::QueryLocRibCount { reply })
+        .await
+        .unwrap();
+    assert_eq!(result.await.unwrap(), 2);
+    (v4, v6)
+}
+
+fn dual_stack_add_path_peer_up(
+    peer: IpAddr,
+    session_id: u64,
+    outbound_tx: mpsc::Sender<OutboundRouteUpdate>,
+) -> RibUpdate {
+    RibUpdate::PeerUp {
+        peer,
+        session_id,
+        peer_asn: 65100,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx,
+        export_policy: None,
+        sendable_families: dual_stack_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        per_client_best: false,
+        interpret_rfc1997: true,
+        add_path_send_families: dual_stack_sendable(),
+        add_path_send_max: 1,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    }
+}
+
+async fn receive_dual_stack_dump(
+    rx: &mut mpsc::Receiver<OutboundRouteUpdate>,
+) -> HashMap<(Prefix, u32), Route> {
+    let mut state = HashMap::new();
+    let mut eor = HashSet::new();
+    while eor.len() < 2 {
+        let update = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("deferred initial dump should complete")
+            .expect("outbound channel should stay open");
+        for route in update.announce.iter() {
+            state.insert((route.prefix, route.path_id), route.clone());
+        }
+        for withdrawn in update.withdraw {
+            state.remove(&withdrawn);
+        }
+        eor.extend(update.end_of_rib);
+    }
+    state
+}
+
+fn path_count(state: &HashMap<(Prefix, u32), Route>, prefix: Prefix) -> usize {
+    state
+        .keys()
+        .filter(|(candidate, _)| *candidate == prefix)
+        .count()
+}
+
+/// Restoring the `outbound_session_ids`-only acceptance guard makes the IPv6
+/// assertion red: the deferred first dump falls back to the scalar limit.
+#[tokio::test]
+async fn deferred_registration_stages_current_session_paths_limit() {
+    let (tx, rx) = mpsc::channel(64);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    manager.initial_dump_defer_min_routes = 0;
+    let handle = tokio::spawn(manager.run());
+    let (v4, v6) = seed_three_dual_stack_candidates(&tx).await;
+    let peer: IpAddr = "192.0.2.70".parse().unwrap();
+    let (out_tx, mut out_rx) = mpsc::channel(32);
+
+    tx.try_send(dual_stack_add_path_peer_up(peer, 7, out_tx))
+        .unwrap();
+    tx.try_send(RibUpdate::PeerAddPathLimits {
+        peer,
+        session_id: 7,
+        limits: vec![
+            ((Afi::Ipv4, Safi::Unicast), 1),
+            ((Afi::Ipv6, Safi::Unicast), 2),
+        ],
+    })
+    .unwrap();
+
+    let initial = receive_dual_stack_dump(&mut out_rx).await;
+    assert_eq!(path_count(&initial, Prefix::V4(v4)), 1);
+    assert_eq!(path_count(&initial, Prefix::V6(v6)), 2);
+    assert!(out_rx.try_recv().is_err(), "the first dump must run once");
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Weakening newest-record ownership to ignore session identity makes the
+/// IPv6 assertions red: a superseded session stages its limit into the winner.
+#[tokio::test]
+async fn deferred_registration_rejects_superseded_session_paths_limit() {
+    let (tx, rx) = mpsc::channel(64);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    manager.initial_dump_defer_min_routes = 0;
+    let handle = tokio::spawn(manager.run());
+    let (v4, v6) = seed_three_dual_stack_candidates(&tx).await;
+    let peer: IpAddr = "192.0.2.71".parse().unwrap();
+    let (old_tx, mut old_rx) = mpsc::channel(32);
+    let (new_tx, mut new_rx) = mpsc::channel(32);
+
+    tx.try_send(dual_stack_add_path_peer_up(peer, 7, old_tx))
+        .unwrap();
+    tx.try_send(dual_stack_add_path_peer_up(peer, 8, new_tx))
+        .unwrap();
+    tx.try_send(RibUpdate::PeerAddPathLimits {
+        peer,
+        session_id: 8,
+        limits: vec![
+            ((Afi::Ipv4, Safi::Unicast), 1),
+            ((Afi::Ipv6, Safi::Unicast), 1),
+        ],
+    })
+    .unwrap();
+    tx.try_send(RibUpdate::PeerAddPathLimits {
+        peer,
+        session_id: 7,
+        limits: vec![((Afi::Ipv6, Safi::Unicast), 2)],
+    })
+    .unwrap();
+
+    let initial = receive_dual_stack_dump(&mut new_rx).await;
+    assert_eq!(path_count(&initial, Prefix::V4(v4)), 1);
+    assert_eq!(path_count(&initial, Prefix::V6(v6)), 1);
+    assert!(
+        old_rx.try_recv().is_err(),
+        "superseded session emitted a dump"
+    );
+
+    for (afi, safi) in dual_stack_sendable() {
+        tx.send(RibUpdate::RouteRefreshRequest {
+            peer,
+            session_id: 8,
+            afi,
+            safi,
+        })
+        .await
+        .unwrap();
+    }
+    let refreshed = receive_dual_stack_dump(&mut new_rx).await;
+    assert_eq!(path_count(&refreshed, Prefix::V4(v4)), 1);
+    assert_eq!(path_count(&refreshed, Prefix::V6(v6)), 1);
+    drop(tx);
+    handle.await.unwrap();
+}
+
 /// Operator-triggered outbound refresh is a one-peer replay of the exact
 /// currently exportable inventory. Removing the force insertion makes the
 /// target announcement assertion time out (ordinary equality suppression wins);


### PR DESCRIPTION
## Summary

- accept negotiated per-family Add-Path send limits against the newest live-session record while outbound registration is deferred
- stage the filtered limits for the eventual first dump without mutating installed state, resyncing, sending, or advancing route-page generations early
- preserve registered-session filtering, idempotency, effective-change resync, collision failback, and the route-page lifecycle fence

## Verification

- two new real `RibManager::run` dual-stack actor regressions, each selecting exactly one test
- existing registered effective-change, collision-failback, deferred-registration, foreign-family, and route-page lifecycle regressions
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- independent immutable-SHA review

## Load-bearing proof

- restoring the registered-only acceptance gate makes the deferred first dump advertise one IPv6 path instead of its negotiated two
- weakening newest-record session identity lets the superseded session overwrite the replacement limit, advertising two IPv6 paths instead of one
- each mutation was applied separately; its exact actor test selected one test and failed with the expected path-count mismatch before the production code was restored

## Scope

This is a four-file lifecycle correction. It does not reorder transport messages or change Add-Path negotiation, route-page policy, GR/LLGR, collision selection, receive behavior, or update groups.
