### PR TITLE
Avoid full exact-export scan on collision failover

### DIFF
--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -7,6 +7,7 @@ mod graceful_restart;
 mod helpers;
 mod outbound_prefix_limits;
 mod peer_lifecycle;
+use peer_lifecycle::SessionTeardownDisposition;
 mod route_refresh;
 mod selection_deferral;
 mod update_groups;
@@ -590,6 +591,8 @@ pub struct RibManager {
     test_force_exact_export_slow_path: bool,
     #[cfg(test)]
     test_exact_export_fast_path_hits: u64,
+    #[cfg(test)]
+    test_exact_export_full_prune_calls: u64,
     /// Test/benchmark-only evidence for the explicit clean policy transition.
     #[cfg(any(test, feature = "bench-internals"))]
     policy_transition_stats: PolicyTransitionStats,
@@ -1289,6 +1292,8 @@ impl RibManager {
             test_force_exact_export_slow_path: false,
             #[cfg(test)]
             test_exact_export_fast_path_hits: 0,
+            #[cfg(test)]
+            test_exact_export_full_prune_calls: 0,
             #[cfg(any(test, feature = "bench-internals"))]
             policy_transition_stats: PolicyTransitionStats::default(),
             #[cfg(any(test, feature = "bench-internals"))]
@@ -1966,9 +1971,16 @@ impl RibManager {
             }
             RibUpdate::PeerDown { peer, session_id } => {
                 let page_versions = self.route_page_versions_snapshot();
-                if self.handle_peer_down(peer, session_id) {
-                    self.prune_exact_export_rejections();
-                    self.ensure_all_route_pages_advanced(page_versions);
+                match self.handle_peer_down(peer, session_id) {
+                    SessionTeardownDisposition::DiscardStale => {}
+                    SessionTeardownDisposition::FailOver => {
+                        self.ensure_all_route_pages_advanced(page_versions);
+                    }
+                    SessionTeardownDisposition::NoRegistration
+                    | SessionTeardownDisposition::TeardownActive => {
+                        self.prune_exact_export_rejections();
+                        self.ensure_all_route_pages_advanced(page_versions);
+                    }
                 }
             }
             RibUpdate::PeerDeleted { peer } => self.handle_peer_deleted(peer),
@@ -2551,6 +2563,10 @@ impl RibManager {
     /// infrequent bulk lifecycle sweeps; the UPDATE hot path uses targeted
     /// withdrawal cleanup instead.
     fn prune_exact_export_rejections(&mut self) {
+        #[cfg(test)]
+        {
+            self.test_exact_export_full_prune_calls += 1;
+        }
         if self.peer_unexportable.is_empty() {
             return;
         }

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -7,7 +7,10 @@ use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
 use super::helpers::prefix_family;
-use super::{LiveSessionRecord, MAX_LIVE_SESSIONS_PER_PEER, PolicyFilteredRouteKey, RibManager};
+use super::{
+    ExactExportKey, LiveSessionRecord, MAX_LIVE_SESSIONS_PER_PEER, PolicyFilteredRouteKey,
+    RibManager,
+};
 use crate::adj_rib_out::AdjRibOut;
 use crate::update::OutboundRouteUpdate;
 
@@ -51,19 +54,23 @@ impl RibManager {
     /// collision interleaving: the loser's `PeerUp` replaced the winner's
     /// registration before the loser went down) fails the registration
     /// over to the survivor instead of tearing the peer down.
-    pub(super) fn handle_peer_down(&mut self, peer: IpAddr, session_id: u64) -> bool {
-        match self.classify_session_teardown(peer, session_id, "PeerDown") {
-            SessionTeardownDisposition::DiscardStale => false,
+    pub(super) fn handle_peer_down(
+        &mut self,
+        peer: IpAddr,
+        session_id: u64,
+    ) -> SessionTeardownDisposition {
+        let disposition = self.classify_session_teardown(peer, session_id, "PeerDown");
+        match disposition {
+            SessionTeardownDisposition::DiscardStale => {}
             SessionTeardownDisposition::FailOver => {
                 self.fail_over_registration(peer, session_id, "PeerDown");
-                true
             }
             SessionTeardownDisposition::NoRegistration
             | SessionTeardownDisposition::TeardownActive => {
                 self.peer_down_teardown(peer);
-                true
             }
         }
+        disposition
     }
 
     /// The session-identity dispatch shared by `handle_peer_down` and
@@ -397,6 +404,28 @@ impl RibManager {
         if !rtc_affected.is_empty() {
             self.recompute_rtc_keys(&rtc_affected);
         }
+        self.retire_exact_export_rejections(
+            rib.iter()
+                .map(|route| ExactExportKey::Unicast(route.prefix, route.path_id))
+                .chain(
+                    rib.iter_flowspec()
+                        .map(|route| ExactExportKey::FlowSpec(route.selection_key())),
+                )
+                .chain(
+                    rib.iter_evpn()
+                        .map(|route| ExactExportKey::Evpn(route.key())),
+                )
+                .chain(
+                    rib.iter_bgpls()
+                        .map(|route| ExactExportKey::BgpLs(route.key())),
+                )
+                .chain(rib.iter_vpn().map(|route| ExactExportKey::Vpn(route.key())))
+                .chain(
+                    rib.iter_labeled()
+                        .map(|route| ExactExportKey::Labeled(route.key())),
+                )
+                .chain(rib.iter_rtc().map(|route| ExactExportKey::Rtc(route.key()))),
+        );
         // The removed Adj-RIB-In held the peer's route bodies; dropping it
         // releases their attribute Arcs. Sweep the global intern table now
         // (after the recomputes above dropped any Loc-RIB selected-route

--- a/crates/rib/src/manager/tests/exact_export_lifecycle.rs
+++ b/crates/rib/src/manager/tests/exact_export_lifecycle.rs
@@ -1,0 +1,194 @@
+use super::*;
+
+fn test_manager() -> RibManager {
+    let (_tx, rx) = mpsc::channel(8);
+    RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new())
+}
+
+fn peer_up(manager: &mut RibManager, peer: IpAddr, session_id: u64) {
+    let (outbound_tx, _outbound_rx) = mpsc::channel(8);
+    manager.handle_update(RibUpdate::PeerUp {
+        peer,
+        session_id,
+        peer_asn: 65001,
+        peer_router_id: Ipv4Addr::new(192, 0, 2, 254),
+        outbound_tx,
+        export_policy: None,
+        sendable_families: Vec::new(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        per_client_best: false,
+        interpret_rfc1997: true,
+        add_path_send_families: Vec::new(),
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    });
+}
+
+fn stable_overlay(manager: &mut RibManager) {
+    let source = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 200));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let mut rib = AdjRibIn::new(source);
+    rib.insert(make_route(
+        prefix,
+        match source {
+            IpAddr::V4(source) => source,
+            IpAddr::V6(_) => unreachable!(),
+        },
+    ));
+    manager.ribs.insert(source, rib);
+    manager.register_unicast_announcer(source, Prefix::V4(prefix));
+    manager.peer_unexportable.insert(
+        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 200)),
+        HashSet::from([ExactExportKey::Unicast(Prefix::V4(prefix), 0)]),
+    );
+}
+
+#[test]
+fn collision_and_stale_peer_down_skip_full_exact_export_prune() {
+    let peer = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+    let mut manager = test_manager();
+    stable_overlay(&mut manager);
+    peer_up(&mut manager, peer, 1);
+    peer_up(&mut manager, peer, 2);
+
+    manager.handle_update(RibUpdate::PeerDown {
+        peer,
+        session_id: 1,
+    });
+    assert_eq!(manager.test_exact_export_full_prune_calls, 0);
+
+    peer_up(&mut manager, peer, 3);
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 0, 1, 0), 24);
+    let identity = ExactExportKey::Unicast(Prefix::V4(prefix), 0);
+    let mut rib = AdjRibIn::new(peer);
+    rib.insert(make_route(prefix, Ipv4Addr::new(192, 0, 2, 1)));
+    manager.ribs.insert(peer, rib);
+    manager.register_unicast_announcer(peer, Prefix::V4(prefix));
+    let target = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 202));
+    manager
+        .peer_unexportable
+        .insert(target, HashSet::from([identity]));
+    manager.handle_update(RibUpdate::PeerDown {
+        peer,
+        session_id: 3,
+    });
+    assert_eq!(
+        manager.test_exact_export_full_prune_calls, 0,
+        "collision failover must use targeted retirement, not rebuild every live identity"
+    );
+    assert!(
+        !manager.peer_unexportable.contains_key(&target),
+        "failover must retire the departed session's identity through targeted cleanup"
+    );
+}
+
+#[test]
+fn authoritative_peer_down_keeps_full_exact_export_prune() {
+    let target = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 201));
+    let dead = ExactExportKey::Unicast(
+        Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24)),
+        0,
+    );
+    for (peer, session_id, register) in [
+        (IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)), 7, false),
+        (IpAddr::V4(Ipv4Addr::new(192, 0, 2, 3)), 8, true),
+    ] {
+        let mut manager = test_manager();
+        manager
+            .peer_unexportable
+            .insert(target, HashSet::from([dead.clone()]));
+        if register {
+            peer_up(&mut manager, peer, session_id);
+        }
+        manager.handle_update(RibUpdate::PeerDown { peer, session_id });
+        assert_eq!(manager.test_exact_export_full_prune_calls, 1);
+        assert!(!manager.peer_unexportable.contains_key(&target));
+    }
+}
+
+fn all_family_rib(peer: IpAddr) -> (AdjRibIn, HashSet<ExactExportKey>) {
+    let source = match peer {
+        IpAddr::V4(peer) => peer,
+        IpAddr::V6(_) => unreachable!(),
+    };
+    let unicast = make_route(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 1, 0), 24), source);
+    let flowspec = make_flowspec_route(source);
+    let evpn = make_evpn_imet(source, 101);
+    let bgpls = make_bgpls_route(source, 0x41, 100);
+    let vpn = make_vpn_rib_route(source, 41, 1041, 100);
+    let labeled = make_labeled_rib_route(source, 42, 1042, 100);
+    let rtc = make_rtc_rib_route(source, 43, 100);
+    let identities = HashSet::from([
+        ExactExportKey::Unicast(unicast.prefix, unicast.path_id).nlri_identity(),
+        ExactExportKey::FlowSpec(flowspec.selection_key()).nlri_identity(),
+        ExactExportKey::Evpn(evpn.key()).nlri_identity(),
+        ExactExportKey::BgpLs(bgpls.key()).nlri_identity(),
+        ExactExportKey::Vpn(vpn.key()).nlri_identity(),
+        ExactExportKey::Labeled(labeled.key()).nlri_identity(),
+        ExactExportKey::Rtc(rtc.key()).nlri_identity(),
+    ]);
+    let mut rib = AdjRibIn::new(peer);
+    rib.insert(unicast);
+    rib.insert_flowspec(flowspec);
+    rib.insert_evpn(evpn);
+    rib.insert_bgpls(bgpls);
+    rib.insert_vpn(vpn);
+    rib.insert_labeled(labeled);
+    rib.insert_rtc(rtc);
+    (rib, identities)
+}
+
+#[test]
+fn peer_clear_retires_departing_exact_export_identities_for_all_families() {
+    let source = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 4));
+    let target = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 4));
+    let (rib, identities) = all_family_rib(source);
+    assert_eq!(identities.len(), 7);
+    let mut manager = test_manager();
+    manager.ribs.insert(source, rib);
+    manager.peer_unexportable.insert(target, identities.clone());
+
+    manager.peer_down_teardown(source);
+
+    let retained = manager.peer_unexportable.get(&target);
+    for identity in identities {
+        assert!(
+            retained.is_none_or(|overlay| !overlay.contains(&identity)),
+            "departing family identity remained live: {identity:?}"
+        );
+    }
+    assert_eq!(manager.test_exact_export_full_prune_calls, 0);
+}
+
+#[test]
+fn targeted_retirement_preserves_duplicate_source_identity() {
+    let departing = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 5));
+    let surviving = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 6));
+    let target = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 5));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 0, 5, 0), 24);
+    let identity = ExactExportKey::Unicast(Prefix::V4(prefix), 0);
+    let mut manager = test_manager();
+    for peer in [departing, surviving] {
+        let mut rib = AdjRibIn::new(peer);
+        rib.insert(make_route(
+            prefix,
+            match peer {
+                IpAddr::V4(peer) => peer,
+                IpAddr::V6(_) => unreachable!(),
+            },
+        ));
+        manager.ribs.insert(peer, rib);
+        manager.register_unicast_announcer(peer, Prefix::V4(prefix));
+    }
+    manager
+        .peer_unexportable
+        .insert(target, HashSet::from([identity.clone()]));
+
+    manager.peer_down_teardown(departing);
+
+    assert!(manager.peer_unexportable[&target].contains(&identity));
+    assert_eq!(manager.test_exact_export_full_prune_calls, 0);
+}

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -1075,6 +1075,7 @@ mod bgpls;
 mod bmp;
 mod events_metrics;
 mod evpn;
+mod exact_export_lifecycle;
 mod explain_mrt;
 mod export_explain;
 mod exportability;


### PR DESCRIPTION
## Summary

- return the typed PeerDown teardown disposition so collision failover can be distinguished from authoritative teardown
- targeted-retire removed rejection-overlay identities for all seven route families after their lifecycle distribution completes
- skip the full live exact-export set rebuild only for collision failover, while preserving it for unregistered and active-session teardown
- preserve duplicate identities that remain sourced by another peer through the existing liveness-aware retirement seam

## Verification

- four focused exact-export lifecycle tests, each selecting exactly one test
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- independent immutable-SHA review, including one false-green repair and re-review

## Load-bearing proof

- restoring the unconditional full prune makes the collision-failover structural counter test red
- removing targeted retirement leaves departing identities for unicast, FlowSpec, EVPN, BGP-LS, VPN, labeled-unicast, and RTC
- removing authoritative-teardown pruning leaves its full-prune counter and dead identity unchanged
- bypassing liveness removes an identity still sourced by another peer
- removing the real failover Adj-RIB-In clear strands the active session's rejection identity while the full-prune counter remains zero

Each mutation was applied separately; its fully qualified exact test selected one test and failed before restoration.

## Scope

This structurally proves removal of one full live-set scan; it does not claim a daemon-scale CPU gain. GR/LLGR, refresh, generic distribution, route-page invalidation, registration failover, and wire behavior are unchanged.
