### PR TITLE
Retain synthetic peer listeners through accept

### DIFF
--- a/bench/evpn-load/src/lib.rs
+++ b/bench/evpn-load/src/lib.rs
@@ -132,11 +132,27 @@ pub struct PeerHandle {
 ///
 /// Returns a [`PeerError`] if bind/accept, OPEN exchange, or initial
 /// KEEPALIVE fails.
-#[expect(clippy::too_many_lines, reason = "reader task body is the bulk")]
 pub async fn establish(cfg: PeerConfig) -> Result<PeerHandle, PeerError> {
     validate_hold_time(cfg.hold_time)?;
     let listener = TcpListener::bind(cfg.listen).await?;
-    tracing::info!(listen = %cfg.listen, "evpn-load peer listening for BGP session");
+    establish_on(listener, cfg).await
+}
+
+/// Establish a synthetic peer on an already-bound listener.
+///
+/// The supplied listener is authoritative; `cfg.listen` remains descriptive
+/// input and is never rebound. This lets callers reserve an ephemeral address,
+/// publish its actual port, and transfer the exact socket into the handshake.
+///
+/// # Errors
+///
+/// Returns a [`PeerError`] if local-address inspection, accept, OPEN exchange,
+/// or initial KEEPALIVE fails.
+#[expect(clippy::too_many_lines, reason = "reader task body is the bulk")]
+pub async fn establish_on(listener: TcpListener, cfg: PeerConfig) -> Result<PeerHandle, PeerError> {
+    validate_hold_time(cfg.hold_time)?;
+    let listen = listener.local_addr()?;
+    tracing::info!(%listen, "evpn-load peer listening for BGP session");
     let (mut stream, remote) = listener.accept().await?;
     tracing::info!(%remote, "evpn-load peer accepted inbound BGP connection");
     drop(listener);
@@ -453,5 +469,29 @@ mod tests {
             Err(PeerError::InvalidHoldTime(2))
         ));
         assert!(validate_hold_time(3).is_ok());
+    }
+
+    #[tokio::test]
+    async fn establish_on_accepts_the_supplied_ephemeral_listener() {
+        let configured: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let listener = TcpListener::bind(configured).await.unwrap();
+        let actual = listener.local_addr().unwrap();
+        assert_ne!(actual, configured);
+        let cfg = PeerConfig {
+            listen: configured,
+            local_as: 64512,
+            router_id: Ipv4Addr::LOCALHOST,
+            hold_time: 30,
+            families: vec![(Afi::Ipv4, Safi::Unicast)],
+        };
+
+        let peer = tokio::spawn(establish_on(listener, cfg));
+        let stream = TcpStream::connect(actual).await.unwrap();
+        drop(stream);
+
+        assert!(matches!(
+            peer.await.unwrap(),
+            Err(PeerError::PrematureClose)
+        ));
     }
 }

--- a/bench/evpn-load/src/lib.rs
+++ b/bench/evpn-load/src/lib.rs
@@ -486,8 +486,8 @@ mod tests {
         };
 
         let peer = tokio::spawn(establish_on(listener, cfg));
-        let stream = TcpStream::connect(actual).await.unwrap();
-        drop(stream);
+        let mut stream = TcpStream::connect(actual).await.unwrap();
+        stream.shutdown().await.unwrap();
 
         assert!(matches!(
             peer.await.unwrap(),

--- a/bench/scale/rrtransport/README.md
+++ b/bench/scale/rrtransport/README.md
@@ -5,6 +5,8 @@ route-reflector transport path. It starts a production `RibManager`, two
 production transport sessions over TCP loopback, and the existing
 `rustbgpd-evpn-load` peer handshake/decoder. Four synthetic ingress sources
 inject exactly 100 unique IPv4 `/24` routes through `RibUpdate::RoutesReceived`.
+Each target listener remains bound while its actual ephemeral address is given
+to rustbgpd, then that exact socket is transferred into the peer handshake.
 
 The smoke preloads the RIB before registering either target session, then
 asserts one shared update group, exact staged Adj-RIB-Out counts, and exact

--- a/bench/scale/rrtransport/src/main.rs
+++ b/bench/scale/rrtransport/src/main.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, ensure, Context, Result};
-use rustbgpd_evpn_load::{establish, PeerConfig as StubConfig};
+use rustbgpd_evpn_load::{establish_on, PeerConfig as StubConfig};
 use rustbgpd_fsm::{PeerConfig, SessionState};
 use rustbgpd_rib::route::{Route, RouteOrigin};
 use rustbgpd_rib::update::RibUpdate;
@@ -71,13 +71,6 @@ fn route(prefix: Ipv4Prefix, source: Ipv4Addr) -> Route {
         aspa_state: AspaValidation::Unknown,
         aspa_context: AspaValidationContext::default(),
     }
-}
-
-async fn free_listener(ip: Ipv4Addr) -> Result<SocketAddr> {
-    let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(ip), 0)).await?;
-    let address = listener.local_addr()?;
-    drop(listener);
-    Ok(address)
 }
 
 fn transport_config(remote: SocketAddr) -> TransportConfig {
@@ -322,21 +315,22 @@ async fn smoke() -> Result<()> {
             .await?;
     }
 
-    let addresses = [
-        free_listener(Ipv4Addr::new(127, 0, 0, 2)).await?,
-        free_listener(Ipv4Addr::new(127, 0, 0, 3)).await?,
+    let listeners = [
+        TcpListener::bind((Ipv4Addr::new(127, 0, 0, 2), 0)).await?,
+        TcpListener::bind((Ipv4Addr::new(127, 0, 0, 3), 0)).await?,
     ];
+    let addresses = [listeners[0].local_addr()?, listeners[1].local_addr()?];
     let mut stub_tasks = Vec::new();
     let mut sessions = Vec::new();
-    for (index, address) in addresses.into_iter().enumerate() {
+    for (index, (listener, address)) in listeners.into_iter().zip(addresses).enumerate() {
         let stub_config = StubConfig {
-            listen: address,
+            listen: SocketAddr::new(address.ip(), 0),
             local_as: 64512,
             router_id: Ipv4Addr::new(127, 0, 1, u8::try_from(index + 1).unwrap()),
             hold_time: 30,
             families: vec![(Afi::Ipv4, Safi::Unicast)],
         };
-        stub_tasks.push(tokio::spawn(establish(stub_config)));
+        stub_tasks.push(tokio::spawn(establish_on(listener, stub_config)));
         let session = PeerHandle::spawn(
             transport_config(address),
             metrics.clone(),


### PR DESCRIPTION
## Summary

- remove the bind/read/drop/rebind window from the real-transport RR harness
- add a shared `establish_on(TcpListener, PeerConfig)` entry point that accepts on the exact supplied socket while preserving the existing bind-once compatibility API
- keep each ephemeral listener owned until its actual address is configured in rustbgpd and the same socket enters the synthetic peer handshake

## Root cause

The smoke previously reserved an ephemeral port, dropped the listener, then asked the shared peer stub to bind that address again. Another process could claim the port between those operations. The new path transfers continuous socket ownership; it does not add retries or a fixed-port range.

## Load-bearing proofs

- replacing `establish_on` with discard-and-rebind makes the exact unit test fail; independent review repeated this 20/20 times with zero false greens
- reverting rrtransport to the old compatibility path while dropping the retained listener fails deterministically at the harness aggregate deadline
- the real smoke still proves two sessions, one update group, exact staged and wire 100/100 route sets, both EoRs, and zero withdrawals, duplicates, or decode failures

## Verification

- focused evpn-load exact test, clippy, and warning-denied docs
- rrtransport locked fmt/test/clippy and real smoke
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `git diff --check`