### PR TITLE
Instrument VPN RIB query actor occupancy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,7 @@ jobs:
           bash -n bench/scale/rrtransport/run-receipt.sh
           bash -n bench/tests/test-rrtransport-receipt.sh
           bash -n bench/tests/test-route-server-1000-receipt.sh
+          bash -n bench/tests/test-vpn-query-receipt.sh
           shellcheck bench/scale/route-server-1000/run-receipt.sh \
             bench/scale/outbound-prefix-limits/run-receipt.sh \
             bench/scale/config-persistence/run-receipt.sh \
@@ -174,7 +175,9 @@ jobs:
             bench/scale/rrtransport/run-receipt.sh \
             bench/tests/test-rrtransport-receipt.sh \
             bench/tests/test-route-server-1000-receipt.sh
+          shellcheck bench/tests/test-vpn-query-receipt.sh
           bash bench/tests/test-route-server-1000-receipt.sh
+          bash bench/tests/test-vpn-query-receipt.sh
           bash -n bench/scale/compare-rrharness.sh
           bash bench/tests/test-rrharness-driver.sh
           python3 -m unittest discover \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2914,6 +2914,7 @@ dependencies = [
  "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.19",
+ "tikv-jemallocator",
  "tokio",
  "tokio-rustls",
  "tokio-stream",

--- a/bench/smoke-benches.sh
+++ b/bench/smoke-benches.sh
@@ -13,7 +13,7 @@
 # timing it happens to produce is meaningless and is not reported.
 #
 # The target list comes from `cargo metadata`, so a bench target is covered the
-# day it lands rather than when someone remembers to register it here. The two
+# day it lands rather than when someone remembers to register it here. The three
 # non-criterion harnesses are excluded by name; renaming one drops its
 # exclusion and this script then fails loudly instead of skipping it silently.
 
@@ -29,7 +29,10 @@ cd "$(dirname "$0")/.."
 #                        harness's own `--smoke` bound.
 #   route_paging         CSV receipt harness; one complete traversal per
 #                        process, driven by --route-count/--output.
-EXCLUDED=(snapshot_allocation route_paging)
+#   vpn_query            needs a `smoke|measure` mode plus an output path. CI
+#                        exercises its fixed-shape smoke and verifier
+#                        separately through test-vpn-query-receipt.sh.
+EXCLUDED=(snapshot_allocation route_paging vpn_query)
 
 mapfile -t targets < <(
   cargo metadata --no-deps --format-version 1 | python3 -c '

--- a/bench/tests/test-vpn-query-receipt.sh
+++ b/bench/tests/test-vpn-query-receipt.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+receipt="$tmp_dir/receipt.json"
+cargo bench --manifest-path "$repo_root/Cargo.toml" -p rustbgpd-api \
+  --bench vpn_query --features bench-internals -- smoke "$receipt"
+
+verify() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+doc = json.load(open(sys.argv[1], encoding="utf-8"))
+assert doc["schema"] == 1
+assert doc["allocator"] == "tikv-jemallocator"
+assert doc["mode"] == "timing"
+assert doc["routes"] == 256
+assert doc["peers"] == 16
+all_rows = doc["queries"]["all"]
+peer_rows = doc["queries"]["peer_10_0_0_1"]
+assert all_rows["actor_rows"] == 256
+assert all_rows["actor_capacity"] >= 256
+assert all_rows["returned_rows"] == 256
+assert peer_rows["actor_rows"] == 256
+assert peer_rows["returned_rows"] == 16
+assert all_rows["dispatch"] == 1
+assert peer_rows["dispatch"] == 2
+assert all_rows["checksum"] != 0
+assert peer_rows["checksum"] != 0
+for query in (all_rows, peer_rows):
+    assert query["actor_handler_ns"] > 0
+    assert query["service_method_ns"] > 0
+    assert query["post_actor_ns"] > 0
+PY
+}
+
+verify "$receipt"
+
+python3 - "$receipt" "$tmp_dir/bad-rows.json" "$tmp_dir/bad-checksum.json" <<'PY'
+import json
+import sys
+
+doc = json.load(open(sys.argv[1], encoding="utf-8"))
+bad_rows = json.loads(json.dumps(doc))
+bad_rows["queries"]["peer_10_0_0_1"]["returned_rows"] = 15
+json.dump(bad_rows, open(sys.argv[2], "w", encoding="utf-8"))
+bad_checksum = json.loads(json.dumps(doc))
+bad_checksum["queries"]["all"]["checksum"] = 0
+json.dump(bad_checksum, open(sys.argv[3], "w", encoding="utf-8"))
+PY
+
+if verify "$tmp_dir/bad-rows.json" >/dev/null 2>&1; then
+  echo "row-corrupted receipt unexpectedly passed" >&2
+  exit 1
+fi
+if verify "$tmp_dir/bad-checksum.json" >/dev/null 2>&1; then
+  echo "checksum-corrupted receipt unexpectedly passed" >&2
+  exit 1
+fi

--- a/bench/tests/test-vpn-query-receipt.sh
+++ b/bench/tests/test-vpn-query-receipt.sh
@@ -6,6 +6,30 @@ tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
 receipt="$tmp_dir/receipt.json"
+bench_source="$repo_root/crates/api/benches/vpn_query.rs"
+
+check_allocator_seam() {
+  python3 - "$1" <<'PY'
+import pathlib
+import sys
+
+lines = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+needle = "static ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;"
+matches = [index for index, line in enumerate(lines) if line.strip() == needle]
+assert len(matches) == 1
+index = matches[0]
+assert index > 0
+assert lines[index - 1].strip() == "#[global_allocator]"
+PY
+}
+
+check_allocator_seam "$bench_source"
+sed '/^#\[global_allocator\]$/d' "$bench_source" >"$tmp_dir/no-global-allocator.rs"
+if check_allocator_seam "$tmp_dir/no-global-allocator.rs" >/dev/null 2>&1; then
+  echo "bench source without global allocator unexpectedly passed" >&2
+  exit 1
+fi
+
 cargo bench --manifest-path "$repo_root/Cargo.toml" -p rustbgpd-api \
   --bench vpn_query --features bench-internals -- smoke "$receipt"
 

--- a/bench/tests/test-vpn-query-receipt.sh
+++ b/bench/tests/test-vpn-query-receipt.sh
@@ -53,8 +53,8 @@ assert peer_rows["actor_rows"] == 256
 assert peer_rows["returned_rows"] == 16
 assert all_rows["dispatch"] == 1
 assert peer_rows["dispatch"] == 2
-assert all_rows["checksum"] != 0
-assert peer_rows["checksum"] != 0
+assert all_rows["checksum"] == 5102335214269610730
+assert peer_rows["checksum"] == 7341237881033179096
 for query in (all_rows, peer_rows):
     assert query["actor_handler_ns"] > 0
     assert query["service_method_ns"] > 0
@@ -73,7 +73,7 @@ bad_rows = json.loads(json.dumps(doc))
 bad_rows["queries"]["peer_10_0_0_1"]["returned_rows"] = 15
 json.dump(bad_rows, open(sys.argv[2], "w", encoding="utf-8"))
 bad_checksum = json.loads(json.dumps(doc))
-bad_checksum["queries"]["all"]["checksum"] = 0
+bad_checksum["queries"]["all"]["checksum"] = 5102335214269610731
 json.dump(bad_checksum, open(sys.argv[3], "w", encoding="utf-8"))
 PY
 

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -54,8 +54,14 @@ criterion.workspace = true
 rcgen.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
+tikv-jemallocator.workspace = true
 
 [[bench]]
 name = "event_history_producer"
+harness = false
+required-features = ["bench-internals"]
+
+[[bench]]
+name = "vpn_query"
 harness = false
 required-features = ["bench-internals"]

--- a/crates/api/benches/vpn_query.rs
+++ b/crates/api/benches/vpn_query.rs
@@ -1,0 +1,231 @@
+//! Occupancy and timing receipt for the production VPN RIB query path.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use rustbgpd_api::proto;
+use rustbgpd_api::proto::rib_service_server::RibService as RibServiceTrait;
+use rustbgpd_api::rib_service::{RibService, VpnQueryServiceReceipt};
+use rustbgpd_rib::{RibManager, RibUpdate, RouteOrigin, VpnRibRoute};
+use rustbgpd_telemetry::BgpMetrics;
+use rustbgpd_wire::{
+    AsPath, AsPathSegment, ExtendedCommunity, MplsLabelEntry, Origin, PathAttribute,
+    RouteDistinguisher, VpnNlri, VpnPrefix,
+};
+use serde_json::json;
+use tokio::sync::{mpsc, oneshot};
+use tonic::Request;
+
+#[global_allocator]
+static ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+const PEERS: usize = 16;
+const SMOKE_ROUTES: usize = 256;
+const BATCH: usize = 4_096;
+
+#[derive(Debug)]
+struct QueryReceipt {
+    actor_ns: u64,
+    service_method_ns: u64,
+    post_actor_ns: u64,
+    actor_rows: usize,
+    actor_capacity: usize,
+    returned_rows: usize,
+    dispatch: u64,
+    checksum: u64,
+}
+
+fn mix(mut hash: u64, bytes: &[u8]) -> u64 {
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100_0000_01b3);
+    }
+    hash
+}
+
+fn semantic_hash(rd: &[u8], prefix: &str, peer: &str, label: u32) -> u64 {
+    let hash = mix(0xcbf2_9ce4_8422_2325, rd);
+    let hash = mix(hash, prefix.as_bytes());
+    let hash = mix(hash, peer.as_bytes());
+    mix(hash, &label.to_be_bytes())
+}
+
+fn route(index: usize, attributes: &Arc<Vec<PathAttribute>>) -> VpnRibRoute {
+    let peer_octet = u8::try_from(index % PEERS + 1).unwrap();
+    let peer = Ipv4Addr::new(10, 0, 0, peer_octet);
+    let prefix = Ipv4Addr::from(0x0b00_0000_u32 + u32::try_from(index).unwrap());
+    VpnRibRoute {
+        nlri: VpnNlri {
+            labels: vec![MplsLabelEntry::try_new(300, 0, true).unwrap()],
+            route_distinguisher: RouteDistinguisher([0, 0, 0xfd, 0xe8, 0, 0, 0, 100]),
+            prefix: VpnPrefix::v4(prefix, 32).unwrap(),
+        },
+        next_hop: Ipv4Addr::new(192, 0, 2, 1).into(),
+        link_local_next_hop: None,
+        peer: peer.into(),
+        attributes: Arc::clone(attributes),
+        received_at: Instant::now(),
+        origin_type: RouteOrigin::Ibgp,
+        peer_router_id: peer,
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+    }
+}
+
+fn expected_checksum(routes: usize, filtered: bool) -> u64 {
+    let rd = [0, 0, 0xfd, 0xe8, 0, 0, 0, 100];
+    (0..routes)
+        .filter(|index| !filtered || index % PEERS == 0)
+        .fold(0_u64, |sum, index| {
+            let peer = format!("10.0.0.{}", index % PEERS + 1);
+            let prefix = format!("{}/32", Ipv4Addr::from(0x0b00_0000_u32 + index as u32));
+            sum.wrapping_add(semantic_hash(&rd, &prefix, &peer, 300))
+        })
+}
+
+async fn query(
+    service: &RibService,
+    actor_rx: &mut mpsc::Receiver<(u64, usize, usize, u64)>,
+    service_rx: &mut mpsc::Receiver<VpnQueryServiceReceipt>,
+    peer_filter: &str,
+) -> QueryReceipt {
+    let started = Instant::now();
+    let response = service
+        .list_vpn_routes(Request::new(proto::ListVpnRoutesRequest {
+            afi_safi: String::new(),
+            peer_filter: peer_filter.to_string(),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    let service_method_ns = u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+    let (actor_ns, actor_rows, actor_capacity, dispatch) = actor_rx.recv().await.unwrap();
+    let service_receipt = service_rx.recv().await.unwrap();
+    assert_eq!(service_receipt.returned_rows, response.routes.len());
+    let checksum = response.routes.iter().fold(0_u64, |sum, row| {
+        sum.wrapping_add(semantic_hash(
+            &row.route_distinguisher,
+            &row.prefix,
+            &row.peer_address,
+            row.labels[0],
+        ))
+    });
+    QueryReceipt {
+        actor_ns,
+        service_method_ns,
+        post_actor_ns: service_receipt.post_actor_ns,
+        actor_rows,
+        actor_capacity,
+        returned_rows: service_receipt.returned_rows,
+        dispatch,
+        checksum,
+    }
+}
+
+fn verify(receipt: &QueryReceipt, routes: usize, filtered: bool, dispatch: u64) {
+    let expected_rows = if filtered { routes / PEERS } else { routes };
+    assert_eq!(receipt.actor_rows, routes);
+    assert!(receipt.actor_capacity >= routes);
+    assert_eq!(receipt.returned_rows, expected_rows);
+    assert_eq!(receipt.dispatch, dispatch);
+    assert_eq!(receipt.checksum, expected_checksum(routes, filtered));
+    assert!(receipt.actor_ns > 0);
+    assert!(receipt.service_method_ns > 0);
+    assert!(receipt.post_actor_ns > 0);
+}
+
+async fn run(routes: usize, output: &str) {
+    let (primary_tx, primary_rx) = mpsc::channel(32);
+    let (query_tx, query_rx) = mpsc::channel(8);
+    let (actor_tx, mut actor_rx) = mpsc::channel(4);
+    let manager = RibManager::new(primary_rx, query_rx, None, None, BgpMetrics::new())
+        .with_vpn_query_bench_receipts(actor_tx);
+    let manager_task = tokio::spawn(manager.run());
+    let attributes = Arc::new(vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![64512, 64513])],
+        }),
+        PathAttribute::LocalPref(100),
+        PathAttribute::ExtendedCommunities(vec![ExtendedCommunity::new(0x0002_fde8_0000_0064)]),
+    ]);
+    for start in (0..routes).step_by(BATCH) {
+        let end = (start + BATCH).min(routes);
+        primary_tx
+            .send(RibUpdate::VpnRoutesReceived {
+                peer: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                session_id: 0,
+                announced: (start..end).map(|i| route(i, &attributes)).collect(),
+                withdrawn: Vec::new(),
+            })
+            .await
+            .unwrap();
+    }
+    let (barrier_tx, barrier_rx) = oneshot::channel();
+    primary_tx
+        .send(RibUpdate::QueryLocRibCount { reply: barrier_tx })
+        .await
+        .unwrap();
+    let _ = barrier_rx.await.unwrap();
+
+    let (service_tx, mut service_rx) = mpsc::channel(4);
+    let service = RibService::new(query_tx).with_vpn_query_bench_receipts(service_tx);
+    let all = query(&service, &mut actor_rx, &mut service_rx, "").await;
+    let filtered = query(&service, &mut actor_rx, &mut service_rx, "10.0.0.1").await;
+    verify(&all, routes, false, 1);
+    verify(&filtered, routes, true, 2);
+
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let document = json!({
+        "schema": 1,
+        "allocator": "tikv-jemallocator",
+        "mode": "timing",
+        "timestamp_unix": timestamp,
+        "routes": routes,
+        "peers": PEERS,
+        "queries": {
+            "all": receipt_json(&all),
+            "peer_10_0_0_1": receipt_json(&filtered),
+        }
+    });
+    std::fs::write(output, serde_json::to_vec_pretty(&document).unwrap()).unwrap();
+    manager_task.abort();
+}
+
+fn receipt_json(value: &QueryReceipt) -> serde_json::Value {
+    json!({
+        "actor_handler_ns": value.actor_ns,
+        "service_method_ns": value.service_method_ns,
+        "post_actor_ns": value.post_actor_ns,
+        "actor_rows": value.actor_rows,
+        "actor_capacity": value.actor_capacity,
+        "returned_rows": value.returned_rows,
+        "dispatch": value.dispatch,
+        "checksum": value.checksum,
+    })
+}
+
+fn main() {
+    let args: Vec<_> = std::env::args().filter(|arg| arg != "--bench").collect();
+    let (routes, output) = match args.as_slice() {
+        [_, mode, output] if mode == "smoke" => (SMOKE_ROUTES, output.as_str()),
+        [_, mode, count, output] if mode == "measure" => {
+            let routes = count.parse::<usize>().unwrap();
+            assert!([10_000, 100_000, 1_000_000].contains(&routes));
+            (routes, output.as_str())
+        }
+        _ => {
+            panic!("usage: vpn_query smoke OUTPUT | vpn_query measure 10000|100000|1000000 OUTPUT")
+        }
+    };
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(run(routes, output));
+}

--- a/crates/api/benches/vpn_query.rs
+++ b/crates/api/benches/vpn_query.rs
@@ -172,24 +172,60 @@ async fn run(routes: usize, output: &str, timeout: Duration) {
         PathAttribute::LocalPref(100),
         PathAttribute::ExtendedCommunities(vec![ExtendedCommunity::new(0x0002_fde8_0000_0064)]),
     ]);
-    for start in (0..routes).step_by(BATCH) {
-        let end = (start + BATCH).min(routes);
-        primary_tx
-            .send(RibUpdate::VpnRoutesReceived {
-                peer: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+    let setup_deadline = tokio::time::Instant::now() + timeout;
+    for peer_index in 0..PEERS {
+        let peer = IpAddr::V4(Ipv4Addr::new(
+            10,
+            0,
+            0,
+            u8::try_from(peer_index + 1).unwrap(),
+        ));
+        let mut indices = (peer_index..routes).step_by(PEERS);
+        loop {
+            let announced: Vec<_> = indices
+                .by_ref()
+                .take(BATCH)
+                .map(|index| route(index, &attributes))
+                .collect();
+            if announced.is_empty() {
+                break;
+            }
+            let update = RibUpdate::VpnRoutesReceived {
+                peer,
                 session_id: 0,
-                announced: (start..end).map(|i| route(i, &attributes)).collect(),
+                announced,
                 withdrawn: Vec::new(),
-            })
-            .await
-            .unwrap();
+            };
+            let RibUpdate::VpnRoutesReceived {
+                peer: envelope_peer,
+                announced,
+                ..
+            } = &update
+            else {
+                unreachable!("constructed VPN seed update changed variant");
+            };
+            assert!(
+                announced.iter().all(|route| route.peer == *envelope_peer),
+                "VPN seed route ownership differs from its update envelope"
+            );
+            tokio::time::timeout_at(setup_deadline, primary_tx.send(update))
+                .await
+                .expect("VPN RIB seed send exceeded the setup deadline")
+                .expect("VPN RIB primary channel closed during setup");
+        }
     }
     let (barrier_tx, barrier_rx) = oneshot::channel();
-    primary_tx
-        .send(RibUpdate::QueryLocRibCount { reply: barrier_tx })
+    tokio::time::timeout_at(
+        setup_deadline,
+        primary_tx.send(RibUpdate::QueryLocRibCount { reply: barrier_tx }),
+    )
+    .await
+    .expect("VPN RIB setup barrier send exceeded the setup deadline")
+    .expect("VPN RIB primary channel closed before the setup barrier");
+    let _ = tokio::time::timeout_at(setup_deadline, barrier_rx)
         .await
-        .unwrap();
-    let _ = barrier_rx.await.unwrap();
+        .expect("VPN RIB setup barrier reply exceeded the setup deadline")
+        .expect("VPN RIB manager dropped the setup barrier reply");
 
     let (service_tx, mut service_rx) = mpsc::channel(4);
     let service = RibService::new(query_tx).with_vpn_query_bench_receipts(service_tx);

--- a/crates/api/benches/vpn_query.rs
+++ b/crates/api/benches/vpn_query.rs
@@ -2,7 +2,7 @@
 
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use rustbgpd_api::proto;
 use rustbgpd_api::proto::rib_service_server::RibService as RibServiceTrait;
@@ -90,19 +90,40 @@ async fn query(
     actor_rx: &mut mpsc::Receiver<(u64, usize, usize, u64)>,
     service_rx: &mut mpsc::Receiver<VpnQueryServiceReceipt>,
     peer_filter: &str,
+    timeout: Duration,
 ) -> QueryReceipt {
+    let deadline = tokio::time::Instant::now() + timeout;
     let started = Instant::now();
-    let response = service
-        .list_vpn_routes(Request::new(proto::ListVpnRoutesRequest {
+    let response = tokio::time::timeout_at(
+        deadline,
+        service.list_vpn_routes(Request::new(proto::ListVpnRoutesRequest {
             afi_safi: String::new(),
             peer_filter: peer_filter.to_string(),
-        }))
-        .await
-        .unwrap()
-        .into_inner();
+        })),
+    )
+    .await
+    .expect("VPN RIB service query exceeded its absolute deadline")
+    .unwrap()
+    .into_inner();
     let service_method_ns = u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
-    let (actor_ns, actor_rows, actor_capacity, dispatch) = actor_rx.recv().await.unwrap();
-    let service_receipt = service_rx.recv().await.unwrap();
+    if !peer_filter.is_empty() {
+        assert!(
+            response
+                .routes
+                .iter()
+                .all(|route| route.peer_address == peer_filter),
+            "filtered VPN query returned a route from another peer"
+        );
+    }
+    let (actor_ns, actor_rows, actor_capacity, dispatch) =
+        tokio::time::timeout_at(deadline, actor_rx.recv())
+            .await
+            .expect("VPN RIB actor receipt exceeded the query deadline")
+            .expect("VPN RIB actor receipt channel closed");
+    let service_receipt = tokio::time::timeout_at(deadline, service_rx.recv())
+        .await
+        .expect("VPN RIB service receipt exceeded the query deadline")
+        .expect("VPN RIB service receipt channel closed");
     assert_eq!(service_receipt.returned_rows, response.routes.len());
     let checksum = response.routes.iter().fold(0_u64, |sum, row| {
         sum.wrapping_add(semantic_hash(
@@ -136,7 +157,7 @@ fn verify(receipt: &QueryReceipt, routes: usize, filtered: bool, dispatch: u64) 
     assert!(receipt.post_actor_ns > 0);
 }
 
-async fn run(routes: usize, output: &str) {
+async fn run(routes: usize, output: &str, timeout: Duration) {
     let (primary_tx, primary_rx) = mpsc::channel(32);
     let (query_tx, query_rx) = mpsc::channel(8);
     let (actor_tx, mut actor_rx) = mpsc::channel(4);
@@ -172,8 +193,15 @@ async fn run(routes: usize, output: &str) {
 
     let (service_tx, mut service_rx) = mpsc::channel(4);
     let service = RibService::new(query_tx).with_vpn_query_bench_receipts(service_tx);
-    let all = query(&service, &mut actor_rx, &mut service_rx, "").await;
-    let filtered = query(&service, &mut actor_rx, &mut service_rx, "10.0.0.1").await;
+    let all = query(&service, &mut actor_rx, &mut service_rx, "", timeout).await;
+    let filtered = query(
+        &service,
+        &mut actor_rx,
+        &mut service_rx,
+        "10.0.0.1",
+        timeout,
+    )
+    .await;
     verify(&all, routes, false, 1);
     verify(&filtered, routes, true, 2);
 
@@ -212,12 +240,14 @@ fn receipt_json(value: &QueryReceipt) -> serde_json::Value {
 
 fn main() {
     let args: Vec<_> = std::env::args().filter(|arg| arg != "--bench").collect();
-    let (routes, output) = match args.as_slice() {
-        [_, mode, output] if mode == "smoke" => (SMOKE_ROUTES, output.as_str()),
+    let (routes, output, timeout) = match args.as_slice() {
+        [_, mode, output] if mode == "smoke" => {
+            (SMOKE_ROUTES, output.as_str(), Duration::from_secs(10))
+        }
         [_, mode, count, output] if mode == "measure" => {
             let routes = count.parse::<usize>().unwrap();
             assert!([10_000, 100_000, 1_000_000].contains(&routes));
-            (routes, output.as_str())
+            (routes, output.as_str(), Duration::from_secs(120))
         }
         _ => {
             panic!("usage: vpn_query smoke OUTPUT | vpn_query measure 10000|100000|1000000 OUTPUT")
@@ -227,5 +257,5 @@ fn main() {
         .enable_all()
         .build()
         .unwrap()
-        .block_on(run(routes, output));
+        .block_on(run(routes, output, timeout));
 }

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -2,6 +2,8 @@
 
 use std::net::IpAddr;
 use std::pin::Pin;
+#[cfg(feature = "bench-internals")]
+use std::time::Instant;
 
 use sha2::{Digest, Sha256};
 use tokio::sync::{mpsc, oneshot};
@@ -124,6 +126,14 @@ pub type FibTableControlFuture = Pin<
 pub type FibTableControlFn =
     std::sync::Arc<dyn Fn(FibTableControlRequest) -> FibTableControlFuture + Send + Sync + 'static>;
 
+/// Benchmark-only receipt for work performed after the RIB actor snapshot.
+#[cfg(feature = "bench-internals")]
+#[derive(Debug, Clone, Copy)]
+pub struct VpnQueryServiceReceipt {
+    pub post_actor_ns: u64,
+    pub returned_rows: usize,
+}
+
 /// gRPC service for querying the RIB (received, best, advertised routes).
 pub struct RibService {
     rib_tx: mpsc::Sender<RibUpdate>,
@@ -137,6 +147,8 @@ pub struct RibService {
     /// it (tests, or a build without FIB control) — the mutating RPCs then
     /// return `FAILED_PRECONDITION`.
     fib_table_control: Option<FibTableControlFn>,
+    #[cfg(feature = "bench-internals")]
+    vpn_query_bench_receipts: Option<mpsc::Sender<VpnQueryServiceReceipt>>,
 }
 
 impl RibService {
@@ -151,6 +163,8 @@ impl RibService {
             // Fail closed: callers opt into mutations via `with_fib_table_control`.
             access_mode: crate::server::AccessMode::ReadOnly,
             fib_table_control: None,
+            #[cfg(feature = "bench-internals")]
+            vpn_query_bench_receipts: None,
         }
     }
 
@@ -184,7 +198,20 @@ impl RibService {
             metrics,
             access_mode: crate::server::AccessMode::ReadOnly,
             fib_table_control: None,
+            #[cfg(feature = "bench-internals")]
+            vpn_query_bench_receipts: None,
         }
+    }
+
+    /// Arm bounded benchmark receipts for VPN query post-actor work.
+    #[cfg(feature = "bench-internals")]
+    #[must_use]
+    pub fn with_vpn_query_bench_receipts(
+        mut self,
+        receipts: mpsc::Sender<VpnQueryServiceReceipt>,
+    ) -> Self {
+        self.vpn_query_bench_receipts = Some(receipts);
+        self
     }
 
     /// Attach the per-listener access mode and the daemon FIB-table CRUD hook,
@@ -1885,8 +1912,10 @@ impl proto::rib_service_server::RibService for RibService {
             .await
             .map_err(|_| Status::internal("RIB manager dropped reply"))?;
 
+        #[cfg(feature = "bench-internals")]
+        let post_actor_started = Instant::now();
         let family_filter = req.afi_safi;
-        let routes = all_routes
+        let routes: Vec<_> = all_routes
             .iter()
             .filter(|route| {
                 if !family_filter.is_empty() && vpn_family_label(route) != family_filter {
@@ -1899,6 +1928,15 @@ impl proto::rib_service_server::RibService for RibService {
             })
             .map(vpn_route_to_proto)
             .collect();
+        #[cfg(feature = "bench-internals")]
+        if let Some(receipts) = &self.vpn_query_bench_receipts {
+            let post_actor_ns =
+                u64::try_from(post_actor_started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+            let _ = receipts.try_send(VpnQueryServiceReceipt {
+                post_actor_ns,
+                returned_rows: routes.len(),
+            });
+        }
 
         Ok(Response::new(proto::ListVpnRoutesResponse { routes }))
     }

--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -132,7 +132,7 @@ impl RibManager {
     ///
     /// The caller constructs the bounded channel and authoritative encoder
     /// before starting its timer, then inspects the receiver after registration
-    /// to prove the timed call sent the expected route inventory and EoR. This
+    /// to prove the timed call sent the expected route inventory and `EoR`. This
     /// keeps Loc-RIB fixture construction, channel allocation, and encoder
     /// construction outside an initial-table join measurement while still
     /// driving the same `PeerUp` registration, first update-group construction,
@@ -425,7 +425,11 @@ impl RibManager {
                 .values()
                 .map(|group| group.table.len())
                 .sum(),
-            private_unicast_routes: self.adj_ribs_out.values().map(|rib| rib.len()).sum(),
+            private_unicast_routes: self
+                .adj_ribs_out
+                .values()
+                .map(super::super::adj_rib_out::AdjRibOut::len)
+                .sum(),
             routes_received_dispatches: stats.routes_received_dispatches,
             routes_received_withdrawals: stats.routes_received_withdrawals,
             exact_probe_batches: stats.exact_probe_batches,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -603,6 +603,10 @@ pub struct RibManager {
     /// Test/benchmark-only evidence from the authoritative outbound commit.
     #[cfg(any(test, feature = "bench-internals"))]
     adj_rib_out_commit_stats: AdjRibOutCommitStats,
+    #[cfg(feature = "bench-internals")]
+    vpn_query_bench_receipts: Option<mpsc::Sender<(u64, usize, usize, u64)>>,
+    #[cfg(feature = "bench-internals")]
+    vpn_query_bench_dispatches: u64,
 }
 
 /// Bound on `live_sessions` entries per peer address. The RFC 4271 §6.8
@@ -1302,6 +1306,10 @@ impl RibManager {
             policy_transition_stats: PolicyTransitionStats::default(),
             #[cfg(any(test, feature = "bench-internals"))]
             adj_rib_out_commit_stats: AdjRibOutCommitStats::default(),
+            #[cfg(feature = "bench-internals")]
+            vpn_query_bench_receipts: None,
+            #[cfg(feature = "bench-internals")]
+            vpn_query_bench_dispatches: 0,
             vrp_table: None,
             aspa_table: None,
             route_events_tx,
@@ -1330,6 +1338,17 @@ impl RibManager {
             route_page_advertised_version: Some(initial_route_page_version()),
             test_ingest_stall,
         }
+    }
+
+    /// Arm bounded benchmark receipts for the real VPN snapshot query arm.
+    #[cfg(feature = "bench-internals")]
+    #[must_use]
+    pub fn with_vpn_query_bench_receipts(
+        mut self,
+        receipts: mpsc::Sender<(u64, usize, usize, u64)>,
+    ) -> Self {
+        self.vpn_query_bench_receipts = Some(receipts);
+        self
     }
 
     /// Install the dedicated type-narrow RIB readiness-query receiver.
@@ -2517,9 +2536,24 @@ impl RibManager {
                 let _ = reply.send(routes);
             }
             RibUpdate::QueryVpnRoutes { reply } => {
+                #[cfg(feature = "bench-internals")]
+                let started = std::time::Instant::now();
                 let routes: Vec<crate::route::VpnRibRoute> =
                     self.loc_rib.iter_vpn().cloned().collect();
+                #[cfg(feature = "bench-internals")]
+                let (rows, capacity) = (routes.len(), routes.capacity());
                 let _ = reply.send(routes);
+                #[cfg(feature = "bench-internals")]
+                if let Some(receipts) = &self.vpn_query_bench_receipts {
+                    self.vpn_query_bench_dispatches =
+                        self.vpn_query_bench_dispatches.saturating_add(1);
+                    let _ = receipts.try_send((
+                        u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX),
+                        rows,
+                        capacity,
+                        self.vpn_query_bench_dispatches,
+                    ));
+                }
             }
             RibUpdate::QueryRtcRoutes { reply } => {
                 let routes: Vec<crate::route::RtcRibRoute> =

--- a/docs/perf/vpn-rib-query-occupancy-method.md
+++ b/docs/perf/vpn-rib-query-occupancy-method.md
@@ -11,7 +11,9 @@ production change is proposed.
 - VPNv4 `/32` routes are assigned round-robin to peers.
 - Every route has a unique RD-plus-prefix key, one MPLS label, shared realistic
   path attributes, and route target `65000:100`.
-- Seeding uses the primary actor channel in batches no larger than 4096.
+- Each peer is seeded in its own primary-channel updates, with batches no
+  larger than 4096. Before every send, the harness asserts that each announced
+  route belongs to the update's actual envelope peer.
 - A `QueryLocRibCount` sent on that same primary channel is the FIFO ingest
   barrier. Its unicast count is intentionally ignored.
 - Both samples call the actual `RibService::list_vpn_routes` method through the
@@ -35,10 +37,11 @@ publication of their respective receipts. Benchmark receipts use bounded
 persistent channels compiled only by `bench-internals`; an unarmed
 production/default build is unchanged.
 
-Each query has one absolute deadline shared by the service call and both receipt
-awaits: 10 seconds in the exact smoke and 120 seconds in campaign mode. Receipt
-publication failure therefore makes the smoke fail in bounded time instead of
-hanging.
+Setup has one absolute deadline shared by all seed sends and the FIFO barrier
+send and receive. Each query then has its own absolute deadline shared by the
+service call and both receipt awaits: 10 seconds in the exact smoke and 120
+seconds in campaign mode. A stalled actor or receipt publication failure
+therefore makes the smoke fail in bounded time instead of hanging.
 
 The timing executable installs the workspace `tikv-jemallocator` directly.
 The mechanics gate parses only the supplied benchmark source and requires its
@@ -72,6 +75,10 @@ defines the instrument and gate; it does not run or publish that campaign.
 
 - Replacing the actor snapshot collection with `Vec::new()` breaks exact row
   counts and semantic checksums.
+- Giving a seed update the wrong envelope peer fails its ownership assertion
+  before the update is sent to the actor.
+- Stalling the manager during setup fails at the internal aggregate setup
+  deadline.
 - Removing the peer predicate changes 16 filtered rows to 256.
 - Selecting a different peer while preserving the filtered count breaks the
   explicit assertion that every returned row belongs to `10.0.0.1`.
@@ -80,5 +87,5 @@ defines the instrument and gate; it does not run or publish that campaign.
   fail.
 - Removing actor or service receipt publication fails at the shared absolute
   deadline instead of hanging.
-- Corrupting either row counts or checksums makes the shell verifier fail; the
-  gate proves both mutations explicitly.
+- Corrupting either row counts or the exact deterministic smoke checksums makes
+  the shell verifier fail; its checksum mutation remains nonzero.

--- a/docs/perf/vpn-rib-query-occupancy-method.md
+++ b/docs/perf/vpn-rib-query-occupancy-method.md
@@ -29,13 +29,22 @@ after the snapshot reply is sent. `actor_rows` and `actor_capacity` describe the
 actual `Vec<VpnRibRoute>` allocated there.
 
 `service_method_ns` is measured outside the service across the trait method call
-and await. `post_actor_ns` covers only the service's post-reply filter, mapping,
-and collection. Benchmark receipts use bounded persistent channels compiled
-only by `bench-internals`; an unarmed production/default build is unchanged.
+and await. It includes the bounded benchmark-only service receipt `try_send`
+before the trait method returns. `actor_handler_ns` and `post_actor_ns` exclude
+publication of their respective receipts. Benchmark receipts use bounded
+persistent channels compiled only by `bench-internals`; an unarmed
+production/default build is unchanged.
+
+Each query has one absolute deadline shared by the service call and both receipt
+awaits: 10 seconds in the exact smoke and 120 seconds in campaign mode. Receipt
+publication failure therefore makes the smoke fail in bounded time instead of
+hanging.
 
 The timing executable installs the workspace `tikv-jemallocator` directly.
-Receipts identify allocator and mode so results from a different build cannot
-be silently compared.
+The mechanics gate parses only the supplied benchmark source and requires its
+`#[global_allocator]` attribute immediately before the `tikv-jemallocator`
+static. Receipts identify allocator and mode so results from a different build
+cannot be silently compared.
 
 Semantic checksums are calculated after the timed method returns. They are
 order-independent and cover RD, prefix, peer, and label. No sorting or hashing
@@ -64,8 +73,12 @@ defines the instrument and gate; it does not run or publish that campaign.
 - Replacing the actor snapshot collection with `Vec::new()` breaks exact row
   counts and semantic checksums.
 - Removing the peer predicate changes 16 filtered rows to 256.
+- Selecting a different peer while preserving the filtered count breaks the
+  explicit assertion that every returned row belongs to `10.0.0.1`.
 - Bypassing or zeroing any timing breaks the nonzero decomposition assertions.
-- Changing the timing binary away from the declared allocator makes the
-  allocator identity false and must be rejected during review.
+- Removing only `#[global_allocator]` makes the structural allocator seam check
+  fail.
+- Removing actor or service receipt publication fails at the shared absolute
+  deadline instead of hanging.
 - Corrupting either row counts or checksums makes the shell verifier fail; the
   gate proves both mutations explicitly.

--- a/docs/perf/vpn-rib-query-occupancy-method.md
+++ b/docs/perf/vpn-rib-query-occupancy-method.md
@@ -1,0 +1,71 @@
+# VPN RIB query occupancy method
+
+This instrument measures the existing `ListVpnRoutes` path without changing its
+API or optimizing it. It exists to separate the RIB actor's full-table snapshot
+cost from the service's filtering and protobuf conversion cost before any
+production change is proposed.
+
+## Shape
+
+- 16 peers: `10.0.0.1` through `10.0.0.16`.
+- VPNv4 `/32` routes are assigned round-robin to peers.
+- Every route has a unique RD-plus-prefix key, one MPLS label, shared realistic
+  path attributes, and route target `65000:100`.
+- Seeding uses the primary actor channel in batches no larger than 4096.
+- A `QueryLocRibCount` sent on that same primary channel is the FIFO ingest
+  barrier. Its unicast count is intentionally ignored.
+- Both samples call the actual `RibService::list_vpn_routes` method through the
+  priority query channel. The first is unfiltered; the second uses
+  `peer_filter = 10.0.0.1` and an empty `afi_safi`.
+
+The supported campaign sizes are 10,000, 100,000, and 1,000,000 routes. The
+per-commit gate runs only the exact 256-route smoke shape; it does not publish a
+performance claim.
+
+## Timings and occupancy
+
+`actor_handler_ns` begins at the production `QueryVpnRoutes` match arm and ends
+after the snapshot reply is sent. `actor_rows` and `actor_capacity` describe the
+actual `Vec<VpnRibRoute>` allocated there.
+
+`service_method_ns` is measured outside the service across the trait method call
+and await. `post_actor_ns` covers only the service's post-reply filter, mapping,
+and collection. Benchmark receipts use bounded persistent channels compiled
+only by `bench-internals`; an unarmed production/default build is unchanged.
+
+The timing executable installs the workspace `tikv-jemallocator` directly.
+Receipts identify allocator and mode so results from a different build cannot
+be silently compared.
+
+Semantic checksums are calculated after the timed method returns. They are
+order-independent and cover RD, prefix, peer, and label. No sorting or hashing
+is added to the service path.
+
+## Commands
+
+Run the exact smoke and its corruption proofs:
+
+```console
+bash bench/tests/test-vpn-query-receipt.sh
+```
+
+Produce one campaign receipt without committing it:
+
+```console
+cargo bench -p rustbgpd-api --bench vpn_query --features bench-internals -- \
+  measure 10000 /tmp/vpn-query-10000.json
+```
+
+Repeat for 100,000 and 1,000,000 only on an otherwise idle host. This slice
+defines the instrument and gate; it does not run or publish that campaign.
+
+## Load-bearing failures
+
+- Replacing the actor snapshot collection with `Vec::new()` breaks exact row
+  counts and semantic checksums.
+- Removing the peer predicate changes 16 filtered rows to 256.
+- Bypassing or zeroing any timing breaks the nonzero decomposition assertions.
+- Changing the timing binary away from the declared allocator makes the
+  allocator identity false and must be rejected during review.
+- Corrupting either row counts or checksums makes the shell verifier fail; the
+  gate proves both mutations explicitly.


### PR DESCRIPTION
## Summary

- add a bench-only instrument around the real `RibService::list_vpn_routes` → priority `QueryVpnRoutes` → `RibManager` path
- seed a fixed sixteen-peer VPNv4 fixture through production updates and separate actor snapshot, post-actor, and caller-observed method timing
- use the daemon's Jemalloc, bounded setup/query deadlines, peer-owned batches, exact semantic checksums, and fail-closed receipt mechanics
- enroll only the exact 256-route smoke in per-commit CI

## Scope

This PR adds the measurement instrument only. It does not run the 10k/100k/1M campaign, publish a performance result, change the API/proto, add pagination or production telemetry, or optimize the query path.

## Verification

- exact 256-route real service/actor smoke and receipt corruption mechanics
- focused `bench-internals` check and clippy
- workspace fmt, clippy, tests, and warning-denied docs
- shellcheck and diff checks
- post-rebase rrtransport mechanics and real-TCP smoke

## Load-bearing proofs

- empty actor snapshot breaks exact response evidence
- removed and same-cardinality wrong peer predicates break count/identity evidence
- zeroed timings break receipt assertions
- missing receipt publication fails at the internal query deadline
- wrong envelope ownership fails before actor ingestion
- a stalled manager fails at the internal setup deadline
- removing `#[global_allocator]` fails the structural allocator gate
- wrong row counts and a different nonzero checksum fail the external verifier