### PR TITLE
Fix rrtransport sampler child-exit race

### DIFF
--- a/bench/scale/rrtransport/run-receipt.sh
+++ b/bench/scale/rrtransport/run-receipt.sh
@@ -30,8 +30,19 @@ classify_rss() {
   fi
 }
 
+classify_child_exe() {
+  local expected=$1 actual=$2 state=$3
+  if [[ $actual == "$expected" ]]; then
+    echo sample
+  elif [[ -z $actual && ($state == Z || $state == absent) ]]; then
+    echo exited
+  else
+    echo reject
+  fi
+}
+
 check_seam() {
-  local script=$1 outer verify_call verify_body checksums_call checksums_body
+  local script=$1 outer verify_call verify_body checksums_call checksums_body classifier_call
   outer="timeout -k 10 1200 \"\$scr"
   outer+="ipt\" --campaign-inner \"\$output\""
   verify_call="full_ver"
@@ -42,9 +53,10 @@ check_seam() {
   checksums_call+="sums \"\$receipt\""
   checksums_body="sha256sum -c SHA"
   checksums_body+="256SUMS --strict"
+  classifier_call="classification=\$(classify_child_exe \"\$binary\" \"\$child_exe\" \"\$child_state\")"
   if ! grep -Fq "$outer" "$script" || ! grep -Fq "$verify_call" "$script" ||
     ! grep -Fq "$verify_body" "$script" || ! grep -Fq "$checksums_call" "$script" ||
-    ! grep -Fq "$checksums_body" "$script"; then
+    ! grep -Fq "$checksums_body" "$script" || ! grep -Fq "$classifier_call" "$script"; then
     echo "runner lacks production verifier/checksum seam" >&2
     return 1
   fi
@@ -127,6 +139,11 @@ case ${1:-} in
   --classify-rss)
     [[ $# == 3 ]] || exit 2
     classify_rss "$2" "$3"
+    exit
+    ;;
+  --classify-child-exe)
+    [[ $# == 4 ]] || exit 2
+    classify_child_exe "$2" "$3" "$4"
     exit
     ;;
   --verify-fixture)
@@ -233,7 +250,12 @@ for run in 1 2 3; do
   while kill -0 "$pid" 2>/dev/null; do
     child=$(pgrep -P "$pid" -n || true)
     [[ -n $child ]] || { sleep 0.05; continue; }
-    [[ $(readlink -f "/proc/$child/exe") == "$binary" ]] || { echo "sampler child executable mismatch" >&2; exit 1; }
+    child_exe=$(readlink -f "/proc/$child/exe" 2>/dev/null || true)
+    child_state=$(awk '$1=="State:" {print substr($2,1,1)}' "/proc/$child/status" 2>/dev/null || true)
+    [[ -n $child_state ]] || child_state=absent
+    classification=$(classify_child_exe "$binary" "$child_exe" "$child_state")
+    [[ $classification == exited ]] && break
+    [[ $classification == sample ]] || { echo "sampler child executable mismatch" >&2; exit 1; }
     rss=$(awk '/VmRSS:/ {print $2}' "/proc/$child/status" 2>/dev/null || echo 0)
     (( rss > max_rss )) && max_rss=$rss
     printf 'sample\t%s\n' "$rss" >>"$receipt/rss.tsv"

--- a/bench/scale/rrtransport/run-receipt.sh
+++ b/bench/scale/rrtransport/run-receipt.sh
@@ -57,7 +57,7 @@ check_seam() {
   if ! grep -Fq "$outer" "$script" || ! grep -Fq "$verify_call" "$script" ||
     ! grep -Fq "$verify_body" "$script" || ! grep -Fq "$checksums_call" "$script" ||
     ! grep -Fq "$checksums_body" "$script" || ! grep -Fq "$classifier_call" "$script"; then
-    echo "runner lacks production verifier/checksum seam" >&2
+    echo "runner lacks production verifier/checksum/classifier seam" >&2
     return 1
   fi
 }

--- a/bench/tests/test-rrtransport-receipt.sh
+++ b/bench/tests/test-rrtransport-receipt.sh
@@ -63,12 +63,18 @@ grep -q '"root_failure":"rss_ceiling"' "$tmp/rss-over/failure.json"
 expect_red changed-head mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"provenance.json";d=json.loads(p.read_text());d["head_after"]="changed";p.write_text(json.dumps(d))'
 expect_red changed-hash mutate -c 'import pathlib,sys;(pathlib.Path(sys.argv[1])/"source.snapshot").write_bytes(b"changed")'
 "$runner" --check-seam "$runner"
+[[ $("$runner" --classify-child-exe /expected /expected R) == sample ]]
+[[ $("$runner" --classify-child-exe /expected /foreign R) == reject ]]
+[[ $("$runner" --classify-child-exe /expected "" R) == reject ]]
+[[ $("$runner" --classify-child-exe /expected "" Z) == exited ]]
+[[ $("$runner" --classify-child-exe /expected "" absent) == exited ]]
 for seam in \
   "timeout -k 10 1200 \"\$script\" --campaign-inner \"\$output\"" \
   "full_verify \"\$receipt\"" \
   "python3 \"\$verifier\" \"\$receipt\" --full | tee \"\$receipt/verifier.txt\"" \
   "full_checksums \"\$receipt\"" \
-  "sha256sum -c SHA256SUMS --strict"; do
+  "sha256sum -c SHA256SUMS --strict" \
+  "classification=\$(classify_child_exe \"\$binary\" \"\$child_exe\" \"\$child_state\")"; do
   cp "$runner" "$tmp/runner"
   grep -Fv "$seam" "$tmp/runner" >"$tmp/mutated"
   mv "$tmp/mutated" "$tmp/runner"


### PR DESCRIPTION
## Summary

- distinguish a normal zombie/gone child exit from a live sampler ownership mismatch
- keep live foreign executables and live unreadable executables fail-closed
- require the production sampler loop to call the classifier and cover the full decision matrix

## Context

The first full 1,000-peer × 100,000-route campaign completed one attempt, then stopped during the second after the rrtransport child exited and `/proc/<pid>/exe` became unreadable before the timeout supervisor reaped it. The partial campaign remains failure evidence only and is not used for a result.

## Verification

- exact classifier matrix: match samples; live mismatch rejects; live empty rejects; zombie/gone empty exits
- deleting only the production classifier call makes the structural seam gate fail
- original rrtransport receipt mechanics and destructive proofs
- real-TCP tiny receipt
- bash syntax, shellcheck, standalone fmt/check/clippy/test/docs, workspace formatting, and diff checks

This PR changes only sampler exit classification. It does not change the campaign shape, `first_exact_bitmap` completion semantics, resource limits, receipt verifier, or publish a performance claim.