### PR TITLE
Improve route-server member onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Static `rbgp neighbor ADDR add` can atomically set a peer group and
+  max-prefix restart delay during route-server member onboarding.
+
 - Deferred initial dumps now honor negotiated per-family Add-Path send limits.
 
 - Unified event watches now reject category/type filters with no possible

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -53,7 +53,7 @@ rbgp config import <source> [--format bird|frr|gobgp] [--out <path>]
 rbgp neighbor
 rbgp summary                                # alias for neighbor list
 rbgp neighbor <addr>
-rbgp neighbor <addr> add --remote-asn <asn> [--role provider|rs|rs-client|customer|peer] [--strict-role] [--route-server-client] [--per-client-best]
+rbgp neighbor <addr> add --remote-asn <asn> [--peer-group <name>] [--max-prefix-restart-seconds <seconds>] [--role provider|rs|rs-client|customer|peer] [--strict-role] [--route-server-client] [--per-client-best]
 rbgp neighbor <addr> enable
 rbgp neighbor <addr> disable --reason "maintenance"
 rbgp neighbor <addr> softreset

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -878,6 +878,8 @@ pub struct AddNeighborOpts {
     pub min_hold_time: Option<u32>,
     pub send_hold_time: Option<u32>,
     pub max_prefixes: Option<u32>,
+    pub peer_group: Option<String>,
+    pub max_prefix_restart_seconds: Option<u32>,
     pub families: Vec<String>,
     pub required_families: Vec<String>,
     pub route_server_client: bool,
@@ -912,7 +914,7 @@ pub async fn add(
                 max_prefixes: opts.max_prefixes.unwrap_or(0),
                 families: opts.families,
                 required_families: opts.required_families,
-                peer_group: String::new(),
+                peer_group: opts.peer_group.unwrap_or_default(),
                 remove_private_as: String::new(),
                 route_server_client: opts.route_server_client,
                 per_client_best: opts.per_client_best,
@@ -922,7 +924,7 @@ pub async fn add(
                 add_path_send: opts.add_path_send,
                 add_path_send_max: opts.add_path_send_max,
                 paths_limit_receive_max: u32::from(opts.paths_limit_receive_max),
-                max_prefix_restart_seconds: None,
+                max_prefix_restart_seconds: opts.max_prefix_restart_seconds,
             }),
         })
         .await?;
@@ -1474,6 +1476,8 @@ mod tests {
                 hold_time: Some(90),
                 send_hold_time: Some(480),
                 max_prefixes: Some(1000),
+                peer_group: Some("rs-members".to_string()),
+                max_prefix_restart_seconds: Some(30),
                 families: vec!["ipv4_unicast".to_string(), "ipv6_unicast".to_string()],
                 required_families: vec!["ipv6_unicast".to_string()],
                 route_server_client: true,
@@ -1501,6 +1505,41 @@ mod tests {
         assert_eq!(request.remote_asn, 65002);
         assert_eq!(request.min_hold_time, Some(30));
         assert_eq!(request.required_families, vec!["ipv6_unicast"]);
+        assert_eq!(request.peer_group, "rs-members");
+        assert_eq!(request.max_prefix_restart_seconds, Some(30));
+
+        let connection = connect(&server.addr, None).await.unwrap();
+        add(
+            connection,
+            "10.0.0.3",
+            AddNeighborOpts {
+                min_hold_time: None,
+                asn: 65003,
+                description: None,
+                hold_time: None,
+                send_hold_time: None,
+                max_prefixes: None,
+                peer_group: None,
+                max_prefix_restart_seconds: None,
+                families: Vec::new(),
+                required_families: Vec::new(),
+                route_server_client: false,
+                per_client_best: false,
+                role: None,
+                strict_role: false,
+                add_path_receive: false,
+                add_path_send: false,
+                add_path_send_max: 0,
+                paths_limit_receive_max: 0,
+            },
+            true,
+        )
+        .await
+        .unwrap();
+
+        let request = server.state.last_add_neighbor.lock().await.clone().unwrap();
+        assert_eq!(request.peer_group, "");
+        assert_eq!(request.max_prefix_restart_seconds, None);
     }
 
     /// The zero-peer human output must say what happened AND hand the

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -908,6 +908,12 @@ enum NeighborAction {
         /// Max prefix limit
         #[arg(long)]
         max_prefixes: Option<u32>,
+        /// Peer group to assign atomically when adding the neighbor
+        #[arg(long)]
+        peer_group: Option<String>,
+        /// Restart delay after a max-prefix teardown (must be greater than zero)
+        #[arg(long, value_parser = clap::value_parser!(u32).range(1..))]
+        max_prefix_restart_seconds: Option<u32>,
         /// Address families (comma-separated)
         #[arg(long, value_delimiter = ',')]
         families: Vec<String>,
@@ -2278,6 +2284,8 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     min_hold_time,
                     send_hold_time,
                     max_prefixes,
+                    peer_group,
+                    max_prefix_restart_seconds,
                     families,
                     required_families,
                     route_server_client,
@@ -2300,6 +2308,8 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                         min_hold_time,
                         send_hold_time,
                         max_prefixes,
+                        peer_group,
+                        max_prefix_restart_seconds,
                         families,
                         required_families,
                         route_server_client,
@@ -3710,6 +3720,10 @@ mod tests {
             "--role",
             "provider",
             "--strict-role",
+            "--peer-group",
+            "rs-members",
+            "--max-prefix-restart-seconds",
+            "30",
         ])
         .unwrap();
         if let Command::Neighbor {
@@ -3719,6 +3733,8 @@ mod tests {
                     asn,
                     role,
                     strict_role,
+                    peer_group,
+                    max_prefix_restart_seconds,
                     ..
                 }),
             ..
@@ -3728,9 +3744,25 @@ mod tests {
             assert_eq!(asn, 65001);
             assert_eq!(role.as_deref(), Some("provider"));
             assert!(strict_role);
+            assert_eq!(peer_group.as_deref(), Some("rs-members"));
+            assert_eq!(max_prefix_restart_seconds, Some(30));
         } else {
             panic!("expected Neighbor Add command");
         }
+
+        assert!(
+            Cli::try_parse_from([
+                "rbgp",
+                "neighbor",
+                "10.0.0.1",
+                "add",
+                "--asn",
+                "65001",
+                "--max-prefix-restart-seconds",
+                "0",
+            ])
+            .is_err()
+        );
     }
 
     #[test]

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -186,8 +186,8 @@ IXP member C (AS 64503) ──┘
 **Key features for IXPs:**
 - **Transparent mode** — preserves original NEXT_HOP, no AS prepend (members
   peer directly via the exchange fabric)
-- **Add-Path send** — members see all candidate paths, not just the best,
-  enabling their own best-path selection
+- **Add-Path send** — members see multiple candidates up to configured and
+  negotiated limits, enabling their own best-path selection
 - **Per-client best-path** (`per_client_best`, RFC 7947 §2.3.2) — the
   path-hiding mitigation for members that cannot do Add-Path: when a
   member's export policy denies the best path, it receives the best
@@ -211,13 +211,9 @@ IXP member C (AS 64503) ──┘
 rbgp neighbor 198.51.100.10 add --remote-asn 64510 \
   --description "new-member" \
   --families ipv4_unicast,ipv6_unicast \
-  --max-prefixes 10000
-
-# Assign to a peer group for shared policy via gRPC
-grpcurl -plaintext -d '{
-  "address": "198.51.100.10",
-  "peer_group": "rs-members"
-}' localhost:50051 rustbgpd.v1.PeerGroupService/SetNeighborPeerGroup
+  --max-prefixes 10000 \
+  --peer-group rs-members \
+  --max-prefix-restart-seconds 30
 
 # Verify the session comes up
 rbgp neighbor 198.51.100.10

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -129,9 +129,10 @@ import_chain = [
 
 # --- Members ---
 
-# Add-Path-capable member: receives every candidate path and runs its own
-# best-path selection (the preferred path-hiding mitigation). These peers
-# stay update-group-shareable.
+# Add-Path-capable member: receives up to the eight best export-permitted
+# candidates, subject to configured and negotiated Paths-Limit, and runs
+# its own best-path selection (the preferred path-hiding mitigation).
+# These peers stay update-group-shareable.
 [[neighbors]]
 address = "198.51.100.2"
 remote_asn = 64501

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -305,6 +305,8 @@ _arguments "${_arguments_options[@]}" : \
 '--min-hold-time=[Minimum hold time accepted from the peer (3..=65535)]:MIN_HOLD_TIME:_default' \
 '--send-hold-time=[RFC 9687 send hold time in seconds (0 disables; must exceed the hold time; default\: max(480, 2 x hold time))]:SEND_HOLD_TIME:_default' \
 '--max-prefixes=[Max prefix limit]:MAX_PREFIXES:_default' \
+'--peer-group=[Peer group to assign atomically when adding the neighbor]:PEER_GROUP:_default' \
+'--max-prefix-restart-seconds=[Restart delay after a max-prefix teardown (must be greater than zero)]:MAX_PREFIX_RESTART_SECONDS:_default' \
 '*--families=[Address families (comma-separated)]:FAMILIES:_default' \
 '*--required-families=[Families that must be negotiated (comma-separated)]:REQUIRED_FAMILIES:_default' \
 '--role=[Local BGP Role for RFC 9234 route-leak protection]:ROLE:_default' \
@@ -468,6 +470,8 @@ _arguments "${_arguments_options[@]}" : \
 '--min-hold-time=[Minimum hold time accepted from the peer (3..=65535)]:MIN_HOLD_TIME:_default' \
 '--send-hold-time=[RFC 9687 send hold time in seconds (0 disables; must exceed the hold time; default\: max(480, 2 x hold time))]:SEND_HOLD_TIME:_default' \
 '--max-prefixes=[Max prefix limit]:MAX_PREFIXES:_default' \
+'--peer-group=[Peer group to assign atomically when adding the neighbor]:PEER_GROUP:_default' \
+'--max-prefix-restart-seconds=[Restart delay after a max-prefix teardown (must be greater than zero)]:MAX_PREFIX_RESTART_SECONDS:_default' \
 '*--families=[Address families (comma-separated)]:FAMILIES:_default' \
 '*--required-families=[Families that must be negotiated (comma-separated)]:REQUIRED_FAMILIES:_default' \
 '--role=[Local BGP Role for RFC 9234 route-leak protection]:ROLE:_default' \

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -6167,7 +6167,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__add)
-            opts="-s -j -h --asn --remote-asn --description --hold-time --min-hold-time --send-hold-time --max-prefixes --families --required-families --route-server-client --per-client-best --role --strict-role --add-path-receive --add-path-send --add-path-send-max --paths-limit-receive-max --addr --token-file --json --no-color --help"
+            opts="-s -j -h --asn --remote-asn --description --hold-time --min-hold-time --send-hold-time --max-prefixes --peer-group --max-prefix-restart-seconds --families --required-families --route-server-client --per-client-best --role --strict-role --add-path-receive --add-path-send --add-path-send-max --paths-limit-receive-max --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6198,6 +6198,14 @@ _rbgp() {
                     return 0
                     ;;
                 --max-prefixes)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer-group)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --max-prefix-restart-seconds)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -178,6 +178,8 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subc
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l min-hold-time -d 'Minimum hold time accepted from the peer (3..=65535)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l send-hold-time -d 'RFC 9687 send hold time in seconds (0 disables; must exceed the hold time; default: max(480, 2 x hold time))' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l max-prefixes -d 'Max prefix limit' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l peer-group -d 'Peer group to assign atomically when adding the neighbor' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l max-prefix-restart-seconds -d 'Restart delay after a max-prefix teardown (must be greater than zero)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l families -d 'Address families (comma-separated)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l required-families -d 'Families that must be negotiated (comma-separated)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l role -d 'Local BGP Role for RFC 9234 route-leak protection' -r
@@ -247,6 +249,8 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l min-hold-time -d 'Minimum hold time accepted from the peer (3..=65535)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l send-hold-time -d 'RFC 9687 send hold time in seconds (0 disables; must exceed the hold time; default: max(480, 2 x hold time))' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l max-prefixes -d 'Max prefix limit' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l peer-group -d 'Peer group to assign atomically when adding the neighbor' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l max-prefix-restart-seconds -d 'Restart delay after a max-prefix teardown (must be greater than zero)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l families -d 'Address families (comma-separated)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l required-families -d 'Families that must be negotiated (comma-separated)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l role -d 'Local BGP Role for RFC 9234 route-leak protection' -r

--- a/examples/route-server/README.md
+++ b/examples/route-server/README.md
@@ -36,9 +36,11 @@ its generic deny, and test both the exception and an unauthorized control.
 
 ## Path-hiding (RFC 7947 §2.3), both mitigations
 
-- **member-alpha** negotiates **Add-Path send**: it receives all candidate
-  paths and runs its own best-path selection. Preferred where the member
-  edge supports Add-Path receive — these peers stay update-group-shareable.
+- **member-alpha** negotiates **Add-Path send**: it receives up to the eight
+  best export-permitted candidates, subject to configured and negotiated
+  Paths-Limit, and runs its own best-path selection. Preferred where the
+  member edge supports Add-Path receive — these peers stay
+  update-group-shareable.
 - **member-beta** cannot do Add-Path, so it sets **`per_client_best = true`**
   (requires `route_server_client`): when its export policy denies the best
   path, the route server advertises the best *permitted* candidate instead
@@ -72,6 +74,7 @@ The explain output for a per-client-best member shows the ranked candidate
 ladder with per-candidate export-policy verdicts (which candidates were
 denied by which policy term, and which one was advertised).
 
-Members are managed dynamically via gRPC as they join and leave — see
+Members can be added atomically as they join — see
 `rbgp neighbor <addr> add --remote-asn <asn> --route-server-client \
---per-client-best --role rs`.
+--per-client-best --role rs --max-prefixes 50000 \
+--max-prefix-restart-seconds 30`.

--- a/examples/route-server/config.toml
+++ b/examples/route-server/config.toml
@@ -10,8 +10,9 @@
 #   special-purpose prefix snapshot — see hygiene.rpol)
 #
 # Path-hiding mitigation (RFC 7947 §2.3.2), both flavors:
-# - member-alpha negotiates Add-Path send: it sees all candidate paths
-#   and runs its own selection (the preferred mitigation);
+# - member-alpha negotiates Add-Path send: it sees up to the eight best
+#   export-permitted candidates, subject to configured and negotiated
+#   Paths-Limit, and runs its own selection (the preferred mitigation);
 # - member-beta cannot do Add-Path, so it opts into per_client_best:
 #   when its export policy denies the best path, the route server
 #   advertises the best *permitted* candidate instead of hiding the
@@ -142,8 +143,9 @@ enabled = false
 
 # --- IXP member peers ---
 
-# Add-Path-capable member: sees all candidate paths (preferred
-# path-hiding mitigation) and stays update-group-shareable.
+# Add-Path-capable member: sees up to the eight best export-permitted
+# candidates, subject to configured and negotiated Paths-Limit (preferred
+# path-hiding mitigation), and stays update-group-shareable.
 [[neighbors]]
 address = "198.51.100.2"
 remote_asn = 64501


### PR DESCRIPTION
## Summary

Make route-server member onboarding atomic at the CLI boundary and correct the starter documentation's Add-Path promise.

## Changes

- expose the existing peer-group and timed max-prefix restart fields on `rbgp neighbor <addr> add`
- forward both fields in the existing AddNeighbor request while preserving the omitted empty/None wire defaults
- reject a zero restart delay locally, matching the existing API's greater-than-zero contract
- update route-server examples to add a member with its group and restart policy in one operation
- describe the starter's bounded Add-Path behavior as up to eight best export-permitted candidates, subject to configured and negotiated limits
- regenerate tracked shell completions

## Testing

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Relevant interop test intentionally not applicable; no protocol or transport behavior changes
- [x] Performance receipt intentionally not applicable; no performance-affecting behavior changes
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` clean
- [x] checked-in completions match the current CLI
- [x] `rustbgpd --check --strict examples/route-server/config.toml` passes

Load-bearing proofs:

- removing either new Clap field makes the focused parse assertion fail
- replacing either request assignment with its omitted default makes the request-capture assertion fail
- the request-capture test separately pins omission to an empty peer-group and no restart delay
- removing the greater-than-zero parser makes the zero-rejection assertion fail

## Docs / release notes

- [x] CHANGELOG.md updated
- [x] ROADMAP.md intentionally not needed
- [x] User/operator docs updated
- [x] No hot tracking document changed

## Related issues

No GitHub issue.
