### PR TITLE
Cover the production revised attribute decoder in benchmarks

### DIFF
--- a/crates/wire/benches/codec.rs
+++ b/crates/wire/benches/codec.rs
@@ -389,6 +389,45 @@ fn bench_attr_decode(c: &mut Criterion) {
 }
 
 #[cfg(not(feature = "codec-allocation-diagnostics"))]
+fn bench_attr_decode_revised(c: &mut Criterion) {
+    let mut group = c.benchmark_group("attr_decode_revised");
+
+    let typical = typical_attributes();
+    assert_eq!(
+        typical.len(),
+        6,
+        "typical fixture must retain six attributes"
+    );
+    let mut typical_buf = Vec::new();
+    encode_path_attributes(&typical, &mut typical_buf, true, false).unwrap();
+    let decoded = decode_path_attributes_revised(&typical_buf, true, false, &[]).unwrap();
+    assert_eq!(decoded.attributes, typical);
+    assert!(decoded.malformed.is_empty());
+    assert_eq!(decoded.bgpls_nlri_discarded, 0);
+    group.bench_with_input(
+        BenchmarkId::new("typical", typical.len()),
+        &typical_buf,
+        |b, buf| {
+            b.iter(|| decode_path_attributes_revised(buf, true, false, &[]).unwrap());
+        },
+    );
+
+    let rich = rich_attributes();
+    assert_eq!(rich.len(), 11, "rich fixture must retain eleven attributes");
+    let mut rich_buf = Vec::new();
+    encode_path_attributes(&rich, &mut rich_buf, true, false).unwrap();
+    let decoded = decode_path_attributes_revised(&rich_buf, true, false, &[]).unwrap();
+    assert_eq!(decoded.attributes, rich);
+    assert!(decoded.malformed.is_empty());
+    assert_eq!(decoded.bgpls_nlri_discarded, 0);
+    group.bench_with_input(BenchmarkId::new("rich", rich.len()), &rich_buf, |b, buf| {
+        b.iter(|| decode_path_attributes_revised(buf, true, false, &[]).unwrap());
+    });
+
+    group.finish();
+}
+
+#[cfg(not(feature = "codec-allocation-diagnostics"))]
 fn bench_attr_encode(c: &mut Criterion) {
     let mut group = c.benchmark_group("attr_encode");
 
@@ -783,6 +822,7 @@ criterion_group!(
     bench_update_parse,
     bench_update_parse_revised,
     bench_attr_decode,
+    bench_attr_decode_revised,
     bench_attr_encode,
     bench_validate_update,
 );

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -437,9 +437,25 @@ checksums are retained under
 "Typical" = Origin, AS_PATH (3 ASNs), NextHop, LocalPref, MED, Communities (2).
 The rich fixture includes 128 standard communities, forcing the
 extended-length attribute header. The dedicated `as_set_revised` row exercises
-the RFC 7606 revised decoder; the typical and rich decode rows still call the
-legacy attribute decoder. These rows used the same pinned contract and
-benchmark-code commit as the production UPDATE table.
+the RFC 7606 revised decoder. The legacy `attr_decode/rich/11` row remains a
+control, while `attr_decode_revised/typical/6` and
+`attr_decode_revised/rich/11` directly cover the live revised attribute
+decoder with the same encoded typical and rich fixtures.
+
+Before Criterion times either revised row, a preflight requires the exact
+fixture count and ordered decoded attributes, no malformed-attribute recovery,
+and zero discarded BGP-LS NLRI. The timed closure contains only
+`decode_path_attributes_revised(...).unwrap()`. Run just these structural
+coverage rows with:
+
+```console
+cargo bench -p rustbgpd-wire --bench codec -- \
+  '^attr_decode_revised/(typical/6|rich/11)$'
+```
+
+No timing or performance conclusion is implied by adding these rows. The
+existing measured rows used the pinned contract and benchmark-code commit
+stated above.
 
 ### Validation
 


### PR DESCRIPTION
## Summary

Add Criterion coverage for the revised path-attribute decoder used by daemon ingress. This is an instrument-only change and makes no timing or performance claim.

## Changes

- add revised-decoder rows for the existing typical six-attribute and rich eleven-attribute fixtures
- require exact fixture counts, ordered decoded attributes, no malformed recovery, and zero discarded BGP-LS NLRI before timing starts
- retain the legacy rich decoder row as the matched control
- document the new structural coverage and focused selector without altering older pinned measurement provenance

## Testing

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Relevant interop test intentionally not applicable; no protocol or transport behavior changes
- [x] Performance claim intentionally not applicable; this PR adds measurement coverage but publishes no result
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` clean
- [x] codec benchmark compiles and both exact revised rows complete a focused smoke

Load-bearing path proof:

- a temporary nominal 25 microsecond delay at the revised decoder entry moved both revised rows to microsecond scale while the legacy control stayed at nanosecond scale
- bypassing the revised call under the same delay kept the labeled rows at nanosecond scale, making the sensitivity verdict red
- the production source was restored checksum-exact before commit

## Docs / release notes

- [x] CHANGELOG.md intentionally not needed; no shipped behavior changes
- [x] ROADMAP.md intentionally not needed
- [x] BENCHMARKS.md updated with structural coverage only
- [x] No hot tracking document changed

## Related issues

No GitHub issue.
