### PR TITLE
True up route-server and operator documentation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,9 +88,10 @@ want an API-first BGP daemon with memory safety and predictable performance.
 One prioritized, forward-looking list. Items are grouped **Immediate** (audited
 correctness and release work), **Next** (committed near-term), **Later**
 (planned, not yet scheduled), and **Maybe / demand-shaped** (deferred until
-operator signal). The current priority call is to finish the transaction
-surface and improve operational proof. Protocol breadth and additional
-performance work stay measurement- or demand-shaped.
+operator signal). The current priority is operational proof: external
+IXP/route-server or route-reflector pilots, with reproducible interop, soak,
+and failure-recovery evidence. Protocol breadth and additional performance
+work stay measurement- or demand-shaped.
 
 Prioritization is **technical-merit first, pilot-aware second**: lead with work
 that deepens rustbgpd's existing identity (a programmable BGP control plane),
@@ -1283,14 +1284,12 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
   RSS climbed 301→555 and 295→639 MiB (two runs) and never returned
   memory — an empty post-teardown daemon held ~500 MiB. The same workload
   on the existing `jemalloc` cargo feature oscillated 270–330 MiB and
-  ended at 229 (background decay returns memory mid-run). Two options on
-  the table, both packaging decisions — not RIB work:
-  - make `jemalloc` the default release/container build (also adds the
-    `jemalloc_*` allocated/active/resident gauges to `/metrics` for free);
-  - or keep stock glibc and document `MALLOC_ARENA_MAX=2` for
-    RSS-sensitive deployments (cheap A/B on a receipt cell first).
-  Either way, the published receipts' RSS honesty notes can then cite the
-  allocator attribution instead of an open question.
+  ended at 229 (background decay returns memory mid-run). Release containers
+  and tarballs have used `jemalloc` since v0.50.0+. Since v0.60.0 it is also
+  the default Cargo allocator feature for plain builds and exposes the
+  `jemalloc_*` allocated/active/resident gauges. Stock glibc remains available
+  with `--no-default-features` for explicit comparison or deployments that
+  prefer the system allocator.
 - **Performance — remaining items.** The scale & memory sprint shipped
   (inlined `SmallVec<[u32; 1]>` Adj-RIB-In prefix index, FxHash route maps,
   coalesced multi-chunk initial-load distribution; #306/#308/#309), as did the
@@ -1402,10 +1401,10 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
     `CachedPolicyContext`, deliberately narrower than a raw
     `Arc<Vec<PathAttribute>>` because explain does not need unrelated
     attributes. Further storage changes are measurement-gated.
-  - Wire codec NLRI allocation cleanup: remove the non-AddPath IPv4 body-NLRI
-    decode-then-map temporary `Vec` in `Update::parse` / build paths if codec
-    benches show a clear win at bulk sizes. Low blast radius, but gate on
-    `update_parse` / `update_build` and decode/proptest coverage.
+  - Wire codec body-NLRI allocation cleanup: LAN-679 measured the proposed
+    non-AddPath IPv4 decode/build rewrite and declined it because it did not
+    produce a meaningful win. Do not revisit without a new profile identifying
+    this allocation as hot and a concrete, separately testable hypothesis.
   - Wire community storage: investigate `SmallVec` for standard / extended /
     large community attribute payloads only if `size_of::<PathAttribute>` does
     not grow and codec / `memory_profile` runs show a real transient-allocation

--- a/docs/API.md
+++ b/docs/API.md
@@ -817,7 +817,10 @@ from the per-session import-decision cache (ADR-0073). Side-effect-free —
 no RIB touch, no counter movement. Omit `path_id` to return every matching
 path. The cache is **opt-in**: without `[policy.explain] enabled = true`
 on the daemon the outcome is `CACHE_DISABLED`, which is deliberately
-distinct from `NOT_SEEN`.
+distinct from `NOT_SEEN`. If the peer has no current session actor, the
+outcome is `NO_SESSION`; this is also distinct from a session that answered
+without a cached decision. `CACHE_DISABLED` and `NO_SESSION` are normal
+explain outcomes, not transport errors.
 
 ```bash
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
@@ -1111,8 +1114,8 @@ they would carry on the wire; everything else stays at `advertised_path_id =
 so the operator can read advertisement intent without cross-referencing the
 peer config. Empty `peer_address` returns the v0.7.0 global Loc-RIB view
 unchanged. Unknown `peer_address` → `NOT_FOUND`. Import explain is available via
-`PolicyService.ExplainImportPolicy` (ADR-0073); exact per-statement
-attribution within a matched policy remains deferred.
+`PolicyService.ExplainImportPolicy` (ADR-0073), including structured
+statement/term traces for matched policies.
 
 ### Address family filtering
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1321,7 +1321,6 @@ during churn, so they are larger than the steady-state route count.
 Measurement environment: AMD Ryzen 9 7950X (64 logical cores), 125 GB
 RAM, Linux 6.17, Docker 27.x, containerlab. Single
 `rustbgpd:dev` container per node, all four nodes on the same host.
-Numbers reproduce within ±10% across runs.
 
 **Notes on methodology:**
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -135,6 +135,22 @@ IPv4/IPv6 `Prefix` routes.
 | In-language policy unit tests | Yes | No | No | No | No |
 | Policy dry-run against the live RIB | Yes | No | No | No | No |
 | Live per-term policy hit counters | Yes | No | No | No | No |
+| RFC 8212 default eBGP policy | Opt-in | Profile-dependent[^rfc8212-frr] | Yes[^rfc8212-bird] | No[^rfc8212-gobgp] | Yes[^rfc8212-openbgpd] |
+
+[^rfc8212-frr]: [FRR latest](https://docs.frrouting.org/en/latest/bgp.html#require-policy-on-ebgp)
+    documents `bgp ebgp-requires-policy` as enabled by default in the
+    traditional profile and disabled by default in the datacenter profile.
+[^rfc8212-bird]: BIRD [3.3.1](https://bird.nic.cz/doc/bird-3.3.1.html) and
+    [2.19.0](https://bird.nic.cz/doc/bird-2.19.0.html) require explicit import
+    and export policy for external BGP; this claim is limited to those release
+    lines.
+[^rfc8212-gobgp]: GoBGP
+    [v4.7.0 policy documentation](https://raw.githubusercontent.com/osrg/gobgp/v4.7.0/docs/sources/policy.md)
+    says unmatched import and export policy defaults to `accept-route`.
+[^rfc8212-openbgpd]: The
+    [OpenBSD-current `bgpd.conf(5)` filter documentation](https://man.openbsd.org/bgpd.conf#FILTER)
+    says BGP UPDATEs are blocked by default and the default filter action is
+    deny.
 
 ## Security
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -79,7 +79,11 @@ Rationale: GoBGP's protos carry Go-specific patterns and years of accumulated fe
 
 ### Service Architecture
 
-Eleven separate gRPC services (Global, Config, Neighbor, Policy, PeerGroup, Rib, Bfd, Event, Injection, Control, Evpn), not one. This forces API boundary clarity, prevents god-service creep, enables permission scoping (for example, read-only listeners for monitoring), and mirrors internal architecture.
+Eleven native `rustbgpd.v1` gRPC services (Global, Config, Neighbor, Policy,
+PeerGroup, Rib, Bfd, Event, Injection, Control, Evpn), plus the separate
+`gnmi.gNMI` service, not one god service. This forces API boundary clarity,
+enables permission scoping (for example, read-only listeners for monitoring),
+and mirrors internal architecture.
 
 ```protobuf
 // Abridged — proto/rustbgpd.proto is authoritative; NeighborService has

--- a/docs/gobgp-parity.md
+++ b/docs/gobgp-parity.md
@@ -106,6 +106,7 @@ releases rather than carried forward from older measurements.
 | Next-hop set/self | Yes | Yes | set_next_hop = "self" or IP |
 | Named policy definitions | Yes | Yes | TOML definitions with configurable default_action |
 | Policy chaining | Yes | Yes | GoBGP-style: permit=continue, deny=stop, implicit permit |
+| Default eBGP policy (RFC 8212) | No | Opt-in | GoBGP v4.7.0 defaults unmatched import/export policy to `accept-route`; rustbgpd requires explicit `ebgp_requires_policy = true` |
 | Scriptable policy language | No | Yes | `.rpol` (ADR-0096): typed + compiled, named prefix/community sets as indexed matchers, parameterized policies, `apply()` composition, in-language unit tests via `rbgp policy check`; route-for-route parity vs FRR route-maps proven in M80 |
 | Policy dry-run against the live RIB | No | Yes | `rbgp policy test` / `TestPolicy` RPC — a candidate `.rpol` policy evaluated read-only over an Adj-RIB-In / Loc-RIB snapshot: counts, per-term hits, before/after diffs |
 | Live per-term policy hit counters | No | Yes | `rbgp policy stats --direction import\|export\|both` / `GetPolicyStats` — since-chain-install counters on installed import and export chains; import rows also carry the session-local policy generation |
@@ -170,7 +171,7 @@ releases rather than carried forward from older measurements.
 | Config formats | TOML/YAML/JSON/HCL | TOML | |
 | Config reload (SIGHUP) | Yes | Yes | Neighbor diff + reconcile; global changes require restart. Measured at route-server scale: sub-second UPDATE stall and ~1.6 s full re-advertisement at 700 clients x 400k routes (docs/perf/reload-stall-2026-07.md) |
 | Config persistence | No | Yes | gRPC mutations atomically persisted to TOML |
-| Prefix limits | Yes | Yes | Cease/1 enforcement |
+| Prefix limits | Yes | Yes | rustbgpd inbound limits are per-family and tear down with Cease/1, latch the peer, and optionally make one generation-fenced restart attempt after a configured hold-down. Outbound per-family limits keep the session Established and withhold net-new advertisements without withdrawals or NOTIFICATION |
 | Embeddable library | Yes (Go) | No | Wire crate is standalone |
 | CLI tool | Yes (gobgp) | Yes | `rbgp` wraps gRPC API |
 | Live TUI dashboard | No | Yes | `rbgp top` — sessions, prefix counts, message rates, route events |

--- a/examples/event-bridge/README.md
+++ b/examples/event-bridge/README.md
@@ -28,6 +28,11 @@ operator's preferred sink. The patterns to preserve are:
 
 ## Build + run
 
+The plaintext TCP command below requires an explicitly configured, suitable
+`[global.telemetry.grpc_tcp]` listener. The default API listener is a Unix
+domain socket, but this reference bridge does not implement UDS, bearer-token,
+or mTLS client transports.
+
 ```sh
 cargo run --release -p event-bridge -- \
     --addr http://127.0.0.1:50051 \

--- a/examples/evpn-vtep-leaf/README.md
+++ b/examples/evpn-vtep-leaf/README.md
@@ -37,12 +37,14 @@ see [`../rr-evpn-fabric/`](../rr-evpn-fabric/).
 ```bash
 # Validate the schema, RD/RT parsing, VTEP-IP unicast check, and
 # uniqueness invariants without starting the daemon.
-rustbgpd --check examples/evpn-vtep-leaf/config.toml
+rustbgpd --check --strict examples/evpn-vtep-leaf/config.toml
 
 # Preview against another config.
 rustbgpd --diff examples/rr-evpn-fabric/config.toml \
                 examples/evpn-vtep-leaf/config.toml
 ```
+
+The starter config is expected to pass strict validation without warnings.
 
 Most `[[evpn_instances]]` edits now **hot-apply** at runtime via the
 ADR-0063 EVPN runtime coordinator — through both SIGHUP file-driven reload

--- a/examples/linux-edge-fib/README.md
+++ b/examples/linux-edge-fib/README.md
@@ -8,8 +8,10 @@ dedicated Linux route table. It does not write the main table.
 ## Validate
 
 ```bash
-rustbgpd --check examples/linux-edge-fib/config.toml
+rustbgpd --check --strict examples/linux-edge-fib/config.toml
 ```
+
+The starter config is expected to pass strict validation without warnings.
 
 ## Kernel Setup
 
@@ -32,7 +34,7 @@ At runtime this example needs enough privilege for the configured surfaces:
 binding TCP/179 requires root or `CAP_NET_BIND_SERVICE`, and programming
 `[[fib_tables]]` routes requires `CAP_NET_ADMIN`. The daemon user must also be
 able to write `runtime_state_dir` and the UDS parent directory so the socket and
-FIB ownership receipts can be created. `rustbgpd --check` validates the TOML
+FIB ownership receipts can be created. `rustbgpd --check --strict` validates the TOML
 shape but does not prove those runtime capabilities or filesystem permissions
 are present.
 


### PR DESCRIPTION
## Summary

- align the roadmap with the shipped allocator default, measured codec decision, and operational-proof priority
- document current RFC 8212 defaults with explicit implementation/version caveats and expand shipped prefix-limit semantics
- correct API, gRPC service inventory, strict starter validation, and event-bridge transport guidance
- remove one unsupported blanket benchmark-repeatability claim

## Verification

- cargo test --locked --test starter_configs_check_strict
- cargo test --locked --test grpc_service_count_docs
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- git diff --check
- reconciled external comparison wording against official FRR, BIRD 3.3.1/2.19.0, OpenBSD-current, GoBGP v4.7.0, and RFC 8212 sources

## Review notes

This is documentation-only. No test or gate changed, so destructive red proof is not applicable; the claims are tied to current source, focused structural tests, or explicitly scoped primary documentation.