### PR TITLE
Fix rrtransport dead-state sampler race

### DIFF
--- a/bench/scale/rrtransport/run-receipt.sh
+++ b/bench/scale/rrtransport/run-receipt.sh
@@ -34,7 +34,7 @@ classify_child_exe() {
   local expected=$1 actual=$2 state=$3
   if [[ $actual == "$expected" ]]; then
     echo sample
-  elif [[ -z $actual && ($state == Z || $state == absent) ]]; then
+  elif [[ -z $actual && ($state == X || $state == Z || $state == absent) ]]; then
     echo exited
   else
     echo reject
@@ -42,7 +42,7 @@ classify_child_exe() {
 }
 
 check_seam() {
-  local script=$1 outer verify_call verify_body checksums_call checksums_body classifier_call
+  local script=$1 outer verify_call verify_body checksums_call checksums_body classifier_call supervisor_wait
   outer="timeout -k 10 1200 \"\$scr"
   outer+="ipt\" --campaign-inner \"\$output\""
   verify_call="full_ver"
@@ -54,10 +54,12 @@ check_seam() {
   checksums_body="sha256sum -c SHA"
   checksums_body+="256SUMS --strict"
   classifier_call="classification=\$(classify_child_exe \"\$binary\" \"\$child_exe\" \"\$child_state\")"
+  supervisor_wait="if ! wait \"\$pid\"; then echo \"rr1000 attempt failed\" >&2; pid=; exit 1; fi"
   if ! grep -Fq "$outer" "$script" || ! grep -Fq "$verify_call" "$script" ||
     ! grep -Fq "$verify_body" "$script" || ! grep -Fq "$checksums_call" "$script" ||
-    ! grep -Fq "$checksums_body" "$script" || ! grep -Fq "$classifier_call" "$script"; then
-    echo "runner lacks production verifier/checksum/classifier seam" >&2
+    ! grep -Fq "$checksums_body" "$script" || ! grep -Fq "$classifier_call" "$script" ||
+    ! grep -Fq "$supervisor_wait" "$script"; then
+    echo "runner lacks production verifier/checksum/classifier/supervisor seam" >&2
     return 1
   fi
 }

--- a/bench/tests/test-rrtransport-receipt.sh
+++ b/bench/tests/test-rrtransport-receipt.sh
@@ -65,7 +65,9 @@ expect_red changed-hash mutate -c 'import pathlib,sys;(pathlib.Path(sys.argv[1])
 "$runner" --check-seam "$runner"
 [[ $("$runner" --classify-child-exe /expected /expected R) == sample ]]
 [[ $("$runner" --classify-child-exe /expected /foreign R) == reject ]]
+[[ $("$runner" --classify-child-exe /expected /foreign X) == reject ]]
 [[ $("$runner" --classify-child-exe /expected "" R) == reject ]]
+[[ $("$runner" --classify-child-exe /expected "" X) == exited ]]
 [[ $("$runner" --classify-child-exe /expected "" Z) == exited ]]
 [[ $("$runner" --classify-child-exe /expected "" absent) == exited ]]
 for seam in \
@@ -74,7 +76,8 @@ for seam in \
   "python3 \"\$verifier\" \"\$receipt\" --full | tee \"\$receipt/verifier.txt\"" \
   "full_checksums \"\$receipt\"" \
   "sha256sum -c SHA256SUMS --strict" \
-  "classification=\$(classify_child_exe \"\$binary\" \"\$child_exe\" \"\$child_state\")"; do
+  "classification=\$(classify_child_exe \"\$binary\" \"\$child_exe\" \"\$child_state\")" \
+  "if ! wait \"\$pid\"; then echo \"rr1000 attempt failed\" >&2; pid=; exit 1; fi"; do
   cp "$runner" "$tmp/runner"
   grep -Fv "$seam" "$tmp/runner" >"$tmp/mutated"
   mv "$tmp/mutated" "$tmp/runner"


### PR DESCRIPTION
## Summary

- accept Linux `X (dead)` as a terminal sampler state only when `/proc/<pid>/exe` is already unreadable
- keep every live or foreign executable fail-closed, including a foreign executable reported with state `X`
- structurally require the timeout wrapper's existing `wait` so terminal classification cannot bypass command-status authority

## Scope

This repairs benchmark receipt mechanics only. It does not change daemon behavior, rerun or publish the rr1000 campaign, modify preserved artifacts, or make a performance claim.

## Verification

- rrtransport receipt mechanics and fresh real-TCP smoke
- bash syntax and shellcheck
- standalone locked fmt/check/clippy/test/rustdoc with warnings denied
- workspace formatting and diff checks

## Load-bearing proofs

- removing only `X` from the production terminal predicate makes the exact empty-executable/`X` case red
- deleting only the production timeout-wrapper `wait` makes the structural seam deletion proof red
- a foreign executable with state `X` remains `reject`
