### PR TITLE
Validate runtime neighbor onboarding flags

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -931,7 +931,7 @@ enum NeighborAction {
         #[arg(long, value_name = "ROLE")]
         role: Option<String>,
         /// Require the peer to advertise a compatible BGP Role capability
-        #[arg(long)]
+        #[arg(long, requires = "role")]
         strict_role: bool,
         /// Enable Add-Path receive
         #[arg(long)]
@@ -3763,6 +3763,119 @@ mod tests {
             ])
             .is_err()
         );
+    }
+
+    #[test]
+    fn test_neighbor_add_requires_role_for_strict_role() {
+        let error = match Cli::try_parse_from([
+            "rbgp",
+            "neighbor",
+            "10.0.0.1",
+            "add",
+            "--asn",
+            "65001",
+            "--strict-role",
+        ]) {
+            Ok(_) => panic!("strict role without a role must fail"),
+            Err(error) => error,
+        };
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+        assert!(error.to_string().contains("--role"));
+    }
+
+    #[test]
+    fn test_neighbor_add_role_strict_role_without_family_flags() {
+        let cli = Cli::try_parse_from([
+            "rbgp",
+            "neighbor",
+            "10.0.0.1",
+            "add",
+            "--asn",
+            "65001",
+            "--role",
+            "provider",
+            "--strict-role",
+        ])
+        .unwrap();
+        let Command::Neighbor {
+            action: Some(NeighborAction::Add {
+                role, strict_role, ..
+            }),
+            ..
+        } = cli.command
+        else {
+            panic!("expected Neighbor Add command");
+        };
+        assert_eq!(role.as_deref(), Some("provider"));
+        assert!(strict_role);
+    }
+
+    #[test]
+    fn test_neighbor_add_required_ipv4_without_families() {
+        let cli = Cli::try_parse_from([
+            "rbgp",
+            "neighbor",
+            "10.0.0.1",
+            "add",
+            "--asn",
+            "65001",
+            "--required-families",
+            "ipv4_unicast",
+        ])
+        .unwrap();
+        let Command::Neighbor {
+            action:
+                Some(NeighborAction::Add {
+                    families,
+                    required_families,
+                    ..
+                }),
+            ..
+        } = cli.command
+        else {
+            panic!("expected Neighbor Add command");
+        };
+        assert!(families.is_empty());
+        assert_eq!(required_families, ["ipv4_unicast"]);
+    }
+
+    #[test]
+    fn test_parse_route_server_documented_neighbor_add() {
+        let readme = include_str!("../../../examples/route-server/README.md");
+        let marker = "`rbgp neighbor 198.51.100.4 add";
+        let start = readme.find(marker).unwrap() + 1;
+        let end = start + readme[start..].find('`').unwrap();
+        let documented = readme[start..end].replace("\\\n", " ");
+        let cli = Cli::try_parse_from(documented.split_whitespace()).unwrap();
+        let Command::Neighbor {
+            address: Some(address),
+            action:
+                Some(NeighborAction::Add {
+                    asn,
+                    families,
+                    max_prefixes,
+                    max_prefix_restart_seconds,
+                    per_client_best,
+                    role,
+                    route_server_client,
+                    ..
+                }),
+            ..
+        } = cli.command
+        else {
+            panic!("expected Neighbor Add command");
+        };
+        assert_eq!(address, "198.51.100.4");
+        assert_eq!(asn, 64503);
+        assert_eq!(families, ["ipv4_unicast", "ipv6_unicast"]);
+        assert_eq!(max_prefixes, Some(50_000));
+        assert_eq!(max_prefix_restart_seconds, Some(30));
+        assert!(route_server_client);
+        assert!(per_client_best);
+        assert_eq!(role.as_deref(), Some("rs"));
     }
 
     #[test]

--- a/examples/route-server/README.md
+++ b/examples/route-server/README.md
@@ -75,6 +75,6 @@ ladder with per-candidate export-policy verdicts (which candidates were
 denied by which policy term, and which one was advertised).
 
 Members can be added atomically as they join — see
-`rbgp neighbor <addr> add --remote-asn <asn> --route-server-client \
---per-client-best --role rs --max-prefixes 50000 \
+`rbgp neighbor 198.51.100.4 add --remote-asn 64503 --route-server-client \
+--per-client-best --role rs --families ipv4_unicast,ipv6_unicast --max-prefixes 50000 \
 --max-prefix-restart-seconds 30`.


### PR DESCRIPTION
## Summary

- reject `rbgp neighbor add --strict-role` locally unless `--role` is present
- preserve the valid default-family form `--required-families ipv4_unicast` without explicit `--families`
- make the shipped route-server runtime-add example explicitly dual-stack and parse-gate the exact documented command

## Scope

This moves an already-invalid strict-role request from a remote RPC rejection to local CLI validation and corrects one operator example. It does not change proto/API/schema/daemon validation, family defaults, session behavior, or protocol behavior.

## Verification

- focused runtime-neighbor parser tests
- workspace fmt, clippy, tests, and warning-denied rustdoc
- diff checks

## Load-bearing proofs

- removing `strict_role -> role` makes the exact invalid-form test red
- swapping the dependency to `families` makes the isolated role/strict positive control red
- required IPv4 without explicit families remains accepted with an empty explicit family list
- removing dual-stack families or restoring an already-configured member in the README makes the exact-command test red
