### PR TITLE
Fix route-server onboarding examples

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3878,6 +3878,110 @@ mod tests {
         assert_eq!(role.as_deref(), Some("rs"));
     }
 
+    fn documented_continued_command(document: &str, marker: &str) -> String {
+        assert_eq!(
+            document.matches(marker).count(),
+            1,
+            "documented command marker must occur exactly once: {marker}"
+        );
+        let start = document.find(marker).unwrap();
+        let mut command = String::new();
+        for line in document[start..].lines() {
+            let line = line.trim();
+            let (fragment, continued) = line
+                .strip_suffix('\\')
+                .map_or((line, false), |fragment| (fragment.trim_end(), true));
+            if !command.is_empty() {
+                command.push(' ');
+            }
+            command.push_str(fragment);
+            if !continued {
+                return command;
+            }
+        }
+        panic!("documented command never terminated: {marker}");
+    }
+
+    #[test]
+    fn test_parse_use_cases_route_server_documented_neighbor_add() {
+        let use_cases = include_str!("../../../docs/USE_CASES.md");
+        let documented = documented_continued_command(
+            use_cases,
+            "rbgp neighbor 198.51.100.10 add --remote-asn 64510",
+        );
+        let cli = Cli::try_parse_from(documented.split_whitespace()).unwrap();
+        let Command::Neighbor {
+            address: Some(address),
+            action:
+                Some(NeighborAction::Add {
+                    asn,
+                    description,
+                    families,
+                    max_prefixes,
+                    peer_group,
+                    max_prefix_restart_seconds,
+                    per_client_best,
+                    role,
+                    route_server_client,
+                    ..
+                }),
+            ..
+        } = cli.command
+        else {
+            panic!("expected Neighbor Add command");
+        };
+        assert_eq!(address, "198.51.100.10");
+        assert_eq!(asn, 64510);
+        assert_eq!(description.as_deref(), Some("new-member"));
+        assert_eq!(families, ["ipv4_unicast", "ipv6_unicast"]);
+        assert_eq!(max_prefixes, Some(10_000));
+        assert!(peer_group.is_none());
+        assert_eq!(max_prefix_restart_seconds, Some(30));
+        assert!(route_server_client);
+        assert!(per_client_best);
+        assert_eq!(role.as_deref(), Some("rs"));
+    }
+
+    #[test]
+    fn test_parse_cookbook_route_server_documented_neighbor_add() {
+        let cookbook = include_str!("../../../docs/cookbook/route-server.md");
+        let documented = documented_continued_command(
+            cookbook,
+            "rbgp neighbor 198.51.100.4 add --remote-asn 64503",
+        );
+        let cli = Cli::try_parse_from(documented.split_whitespace()).unwrap();
+        let Command::Neighbor {
+            address: Some(address),
+            action:
+                Some(NeighborAction::Add {
+                    asn,
+                    description,
+                    families,
+                    max_prefixes,
+                    peer_group,
+                    max_prefix_restart_seconds,
+                    per_client_best,
+                    role,
+                    route_server_client,
+                    ..
+                }),
+            ..
+        } = cli.command
+        else {
+            panic!("expected Neighbor Add command");
+        };
+        assert_eq!(address, "198.51.100.4");
+        assert_eq!(asn, 64503);
+        assert!(description.is_none());
+        assert_eq!(families, ["ipv4_unicast", "ipv6_unicast"]);
+        assert_eq!(max_prefixes, Some(50_000));
+        assert!(peer_group.is_none());
+        assert_eq!(max_prefix_restart_seconds, Some(30));
+        assert!(route_server_client);
+        assert!(per_client_best);
+        assert_eq!(role.as_deref(), Some("rs"));
+    }
+
     #[test]
     fn test_parse_rib_best() {
         let cli = Cli::try_parse_from(["rbgp", "rib"]).unwrap();

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -209,10 +209,10 @@ IXP member C (AS 64503) ──┘
 ```bash
 # Add member at runtime (persisted to config automatically)
 rbgp neighbor 198.51.100.10 add --remote-asn 64510 \
-  --description "new-member" \
+  --description new-member \
+  --route-server-client --per-client-best --role rs \
   --families ipv4_unicast,ipv6_unicast \
   --max-prefixes 10000 \
-  --peer-group rs-members \
   --max-prefix-restart-seconds 30
 
 # Verify the session comes up

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -253,7 +253,9 @@ Members can be added and removed at runtime:
 
 ```console
 $ rbgp neighbor 198.51.100.4 add --remote-asn 64503 \
-    --route-server-client --per-client-best --role rs
+    --route-server-client --per-client-best --role rs \
+    --families ipv4_unicast,ipv6_unicast \
+    --max-prefixes 50000 --max-prefix-restart-seconds 30
 ```
 
 ## Shadow trial


### PR DESCRIPTION
## Summary

- remove the undefined rs-members peer group from the route-server use-case command
- make both remaining runtime onboarding examples explicitly dual-stack route-server clients with path-hiding and prefix-limit safeguards
- parse each literal multiline command and assert every operator-critical field

## Verification

- focused exact parser test for docs/USE_CASES.md
- focused exact parser test for docs/cookbook/route-server.md
- config_examples_parse
- strict starter-config gate
- cargo fmt --all -- --check
- cargo clippy -p rustbgpctl --all-targets -- -D warnings
- git diff --check

## Load-bearing proofs

Twelve independent mutations were made red and restored: the stale peer group, both family regressions, route-server-client/per-client-best/role removals, address, ASN, description, prefix-limit and restart changes, and a duplicate marker. The tests read the shipped snippets literally; no runtime behavior or schema changes are included.