### PR TITLE
Normalize scoped link-local day-two CLI requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Scoped IPv6 link-local neighbors now work with peer-group, policy-chain, and
+  policy-inspection day-two CLI commands: valid `%interface` zones stay visible
+  in operator output but are omitted from bare-address RPC fields.
+
 - `rbgp peer-group set` can now create a missing passwordless peer group from
   ordinary JSON that omits both MD5 fields. The same omission still preserves
   an existing group's secret, explicit `has_md5_password = true` still requires

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -12,6 +12,19 @@ use crate::proto::{
     SetGracefulShutdownRequest, SoftResetInRequest,
 };
 
+pub(super) fn bare_ip_rpc_address(address: &str) -> &str {
+    let Some((bare, zone)) = address.split_once('%') else {
+        return address;
+    };
+    if zone.is_empty() || zone.contains('%') {
+        return address;
+    }
+    match bare.parse::<std::net::Ipv6Addr>() {
+        Ok(ip) if ip.is_unicast_link_local() => bare,
+        _ => address,
+    }
+}
+
 fn split_scoped_address(address: &str) -> (String, String) {
     address.rsplit_once('%').map_or_else(
         || (address.to_string(), String::new()),
@@ -1114,6 +1127,25 @@ mod tests {
     use super::*;
     use crate::connection::connect;
     use crate::test_support::spawn_mock_server;
+
+    #[test]
+    fn bare_ip_rpc_address_strips_only_one_valid_link_local_zone() {
+        let cases = [
+            ("fe80::1%eth0", "fe80::1"),
+            ("febf::abcd%swp1", "febf::abcd"),
+            ("FE80::1%Ethernet1", "FE80::1"),
+            ("fe80::1", "fe80::1"),
+            ("fe80::gg%eth0", "fe80::gg%eth0"),
+            ("fe80::1%", "fe80::1%"),
+            ("fe80::1%eth0%extra", "fe80::1%eth0%extra"),
+            ("192.0.2.1%eth0", "192.0.2.1%eth0"),
+            ("2001:db8::1%eth0", "2001:db8::1%eth0"),
+            ("ff02::1%eth0", "ff02::1%eth0"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(bare_ip_rpc_address(input), expected, "input {input:?}");
+        }
+    }
 
     /// ADR-0112 rolling-version contract. Zero is what an older daemon leaves
     /// behind and a future variant is what a newer one may send; both must

--- a/crates/cli/src/commands/peer_group.rs
+++ b/crates/cli/src/commands/peer_group.rs
@@ -7,6 +7,7 @@
 
 use serde::Serialize;
 
+use crate::commands::neighbor::bare_ip_rpc_address;
 use crate::commands::policy_input::{JsonPeerGroupDefinition, load_json};
 use crate::connection::Connection;
 use crate::error::CliError;
@@ -327,7 +328,7 @@ pub async fn attach(
         PeerGroupServiceClient::with_interceptor(connection.channel(), connection.interceptor());
     client
         .set_neighbor_peer_group(SetNeighborPeerGroupRequest {
-            address: address.to_string(),
+            address: bare_ip_rpc_address(address).to_string(),
             peer_group: group.to_string(),
         })
         .await?;
@@ -344,7 +345,7 @@ pub async fn detach(connection: Connection, address: &str, json: bool) -> Result
         PeerGroupServiceClient::with_interceptor(connection.channel(), connection.interceptor());
     client
         .clear_neighbor_peer_group(ClearNeighborPeerGroupRequest {
-            address: address.to_string(),
+            address: bare_ip_rpc_address(address).to_string(),
         })
         .await?;
     output::print_result(
@@ -476,10 +477,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn attach_captures_request() {
+    async fn attach_scoped_link_local_sends_bare_request() {
         let server = spawn_mock_server(None).await;
         let connection = connect(&server.addr, None).await.unwrap();
-        attach(connection, "10.0.0.2", "transit", true)
+        attach(connection, "fe80::2%eth0", "transit", true)
             .await
             .unwrap();
         let captured = server
@@ -489,15 +490,15 @@ mod tests {
             .await
             .clone()
             .unwrap();
-        assert_eq!(captured.address, "10.0.0.2");
+        assert_eq!(captured.address, "fe80::2");
         assert_eq!(captured.peer_group, "transit");
     }
 
     #[tokio::test]
-    async fn detach_captures_request() {
+    async fn detach_scoped_link_local_sends_bare_request() {
         let server = spawn_mock_server(None).await;
         let connection = connect(&server.addr, None).await.unwrap();
-        detach(connection, "10.0.0.2", true).await.unwrap();
+        detach(connection, "fe80::2%eth0", true).await.unwrap();
         let captured = server
             .state
             .last_clear_neighbor_peer_group
@@ -505,6 +506,6 @@ mod tests {
             .await
             .clone()
             .unwrap();
-        assert_eq!(captured.address, "10.0.0.2");
+        assert_eq!(captured.address, "fe80::2");
     }
 }

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -13,6 +13,7 @@
 
 use serde::Serialize;
 
+use crate::commands::neighbor::bare_ip_rpc_address;
 use crate::commands::policy_input::{JsonPolicyDefinition, load_json};
 use crate::connection::Connection;
 use crate::error::CliError;
@@ -706,7 +707,11 @@ pub async fn test(
             rpol_source,
             policy: opts.policy.to_string(),
             direction: opts.direction.to_string(),
-            peer: opts.peer.unwrap_or_default().to_string(),
+            peer: opts
+                .peer
+                .map(bare_ip_rpc_address)
+                .unwrap_or_default()
+                .to_string(),
             afi_safi: afi_safi as i32,
             limit: opts.limit,
             show_changes: opts.show_changes,
@@ -873,7 +878,10 @@ pub async fn stats(
         PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
     let resp = client
         .get_policy_stats(GetPolicyStatsRequest {
-            peer_address: peer.unwrap_or_default().to_string(),
+            peer_address: peer
+                .map(bare_ip_rpc_address)
+                .unwrap_or_default()
+                .to_string(),
             direction: direction.to_string(),
         })
         .await?
@@ -884,7 +892,7 @@ pub async fn stats(
             .chains
             .iter()
             .map(|chain| JsonPolicyStats {
-                peer_address: chain.peer_address.clone(),
+                peer_address: operator_peer_address(peer, &chain.peer_address).to_string(),
                 direction: chain.direction.clone(),
                 routes_evaluated: chain.routes_evaluated,
                 eval_errors: chain.eval_errors,
@@ -937,7 +945,9 @@ pub async fn stats(
         };
         println!(
             "{} {} chain — {} routes evaluated since install{generation}",
-            chain.peer_address, chain.direction, chain.routes_evaluated
+            operator_peer_address(peer, &chain.peer_address),
+            chain.direction,
+            chain.routes_evaluated
         );
         // LAN-301: evaluation errors are fail-closed denies — surface
         // the count and the most recent blame line when nonzero.
@@ -1203,6 +1213,23 @@ fn outcome_has_decision(outcome: i32) -> bool {
     )
 }
 
+fn operator_peer_address<'a>(requested: Option<&'a str>, response: &'a str) -> &'a str {
+    let Some(address) = requested else {
+        return response;
+    };
+    let bare = bare_ip_rpc_address(address);
+    if bare == address {
+        return response;
+    }
+    match (
+        bare.parse::<std::net::IpAddr>(),
+        response.parse::<std::net::IpAddr>(),
+    ) {
+        (Ok(requested_ip), Ok(response_ip)) if requested_ip == response_ip => address,
+        _ => response,
+    }
+}
+
 /// Split a CIDR (`"192.0.2.0/24"` / `"2001:db8::/32"`) into the address
 /// string, prefix length, and the matching `AddressFamily`. ADR-0073
 /// scopes explain to IPv4 / IPv6 unicast, so the address family is
@@ -1242,7 +1269,7 @@ pub async fn explain_import(
         PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
     let resp = client
         .explain_import_policy(ExplainImportPolicyRequest {
-            peer_address: neighbor.to_string(),
+            peer_address: bare_ip_rpc_address(neighbor).to_string(),
             afi_safi: afi_safi as i32,
             prefix: addr,
             prefix_length,
@@ -1261,7 +1288,7 @@ pub async fn explain_import(
 
     if json {
         let out = JsonImportExplain {
-            peer_address: resp.peer_address.clone(),
+            peer_address: operator_peer_address(Some(neighbor), &resp.peer_address).to_string(),
             prefix: format!("{}/{}", resp.prefix, resp.prefix_length),
             afi_safi: address_family_label(resp.afi_safi).to_string(),
             current_policy_generation: resp.current_policy_generation,
@@ -1281,7 +1308,10 @@ pub async fn explain_import(
 
     println!(
         "import policy explain — peer {} prefix {}/{} (policy generation {})",
-        resp.peer_address, resp.prefix, resp.prefix_length, resp.current_policy_generation
+        operator_peer_address(Some(neighbor), &resp.peer_address),
+        resp.prefix,
+        resp.prefix_length,
+        resp.current_policy_generation
     );
     if resp.matches.len() > 1 {
         println!("{} matching paths:", resp.matches.len());
@@ -1484,14 +1514,14 @@ pub async fn chain_show(
         Some(addr) => {
             let resp = client
                 .get_neighbor_policy_chains(GetNeighborPolicyChainsRequest {
-                    address: addr.to_string(),
+                    address: bare_ip_rpc_address(addr).to_string(),
                 })
                 .await?
                 .into_inner();
             (
                 resp.import_policy_names,
                 resp.export_policy_names,
-                Some(resp.address),
+                Some(operator_peer_address(Some(addr), &resp.address).to_string()),
             )
         }
         None => {
@@ -1569,7 +1599,7 @@ pub async fn chain_set(
         (ChainDirection::Import, Some(addr)) => {
             client
                 .set_neighbor_import_chain(SetNeighborImportChainRequest {
-                    address: addr.to_string(),
+                    address: bare_ip_rpc_address(addr).to_string(),
                     policy_names: policy_names.clone(),
                 })
                 .await?;
@@ -1581,7 +1611,7 @@ pub async fn chain_set(
         (ChainDirection::Export, Some(addr)) => {
             client
                 .set_neighbor_export_chain(SetNeighborExportChainRequest {
-                    address: addr.to_string(),
+                    address: bare_ip_rpc_address(addr).to_string(),
                     policy_names: policy_names.clone(),
                 })
                 .await?;
@@ -1633,7 +1663,7 @@ pub async fn chain_clear(
         (ChainDirection::Import, Some(addr)) => {
             client
                 .clear_neighbor_import_chain(ClearNeighborImportChainRequest {
-                    address: addr.to_string(),
+                    address: bare_ip_rpc_address(addr).to_string(),
                 })
                 .await?;
             (
@@ -1644,7 +1674,7 @@ pub async fn chain_clear(
         (ChainDirection::Export, Some(addr)) => {
             client
                 .clear_neighbor_export_chain(ClearNeighborExportChainRequest {
-                    address: addr.to_string(),
+                    address: bare_ip_rpc_address(addr).to_string(),
                 })
                 .await?;
             (
@@ -1747,8 +1777,38 @@ mod tests {
         tmp
     }
 
+    #[test]
+    fn operator_output_restores_scoped_identity_after_response_canonicalization() {
+        assert_eq!(
+            operator_peer_address(Some("fe80:0:0:0:0:0:0:9%eth0"), "fe80::9"),
+            "fe80:0:0:0:0:0:0:9%eth0"
+        );
+    }
+
+    #[test]
+    fn operator_output_preserves_requested_scoped_identity() {
+        assert_eq!(
+            operator_peer_address(Some("fe80::9%eth0"), "fe80::9"),
+            "fe80::9%eth0"
+        );
+    }
+
+    #[test]
+    fn operator_output_leaves_unfiltered_rows_unchanged() {
+        assert_eq!(operator_peer_address(None, "fe80::9"), "fe80::9");
+    }
+
+    #[test]
+    fn operator_output_leaves_unrelated_filtered_rows_unchanged() {
+        assert_eq!(
+            operator_peer_address(Some("fe80::9%eth0"), "fe80::10"),
+            "fe80::10",
+            "a filtered stats row must match before inheriting the requested scope"
+        );
+    }
+
     #[tokio::test]
-    async fn test_sends_source_and_selection_and_renders() {
+    async fn test_scoped_link_local_sends_bare_peer_and_renders() {
         let server = spawn_mock_server(None).await;
         let connection = connect(&server.addr, None).await.unwrap();
         let file = write_rpol("policy p { term t { reject } }");
@@ -1758,7 +1818,7 @@ mod tests {
                 file: file.path().to_str().unwrap(),
                 policy: "customer-in(200)",
                 direction: "import",
-                peer: Some("10.0.0.9"),
+                peer: Some("fe80::9%eth0"),
                 family: Some("ipv4_unicast"),
                 limit: 100,
                 show_changes: 5,
@@ -1771,7 +1831,7 @@ mod tests {
         assert_eq!(captured.rpol_source, "policy p { term t { reject } }");
         assert_eq!(captured.policy, "customer-in(200)");
         assert_eq!(captured.direction, "import");
-        assert_eq!(captured.peer, "10.0.0.9");
+        assert_eq!(captured.peer, "fe80::9");
         assert_eq!(
             captured.afi_safi,
             crate::proto::AddressFamily::Ipv4Unicast as i32
@@ -1997,12 +2057,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn explain_infers_afi_from_prefix_and_sends_request() {
+    async fn explain_scoped_link_local_sends_bare_peer_and_infers_afi() {
         // Pin: the CLI infers AFI from the prefix (no --afi flag) and
         // sends a well-formed request with the parsed address + length.
         let server = spawn_mock_server(None).await;
         let connection = connect(&server.addr, None).await.unwrap();
-        explain_import(connection, "192.0.2.1", "2001:db8::/32", Some(7), true)
+        explain_import(connection, "fe80::1%eth0", "2001:db8::/32", Some(7), true)
             .await
             .unwrap();
         let captured = server
@@ -2012,7 +2072,7 @@ mod tests {
             .await
             .clone()
             .unwrap();
-        assert_eq!(captured.peer_address, "192.0.2.1");
+        assert_eq!(captured.peer_address, "fe80::1");
         assert_eq!(captured.prefix, "2001:db8::");
         assert_eq!(captured.prefix_length, 32);
         assert_eq!(captured.path_id, Some(7));
@@ -2162,12 +2222,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stats_renders_text_and_json() {
+    async fn stats_scoped_link_local_sends_bare_peer_and_renders() {
         let server = spawn_mock_server(None).await;
         let json_conn = connect(&server.addr, None).await.unwrap();
-        stats(json_conn, Some("10.0.0.2"), "export", true)
+        stats(json_conn, Some("fe80:0:0:0:0:0:0:2%eth0"), "export", true)
             .await
             .unwrap();
+        let captured = server
+            .state
+            .last_get_policy_stats
+            .lock()
+            .await
+            .clone()
+            .unwrap();
+        assert_eq!(captured.peer_address, "fe80:0:0:0:0:0:0:2");
+        assert_eq!(captured.direction, "export");
         let text_conn = connect(&server.addr, None).await.unwrap();
         stats(text_conn, None, "export", false).await.unwrap();
     }
@@ -2302,12 +2371,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn chain_show_per_neighbor_prints() {
+    async fn chain_show_scoped_link_local_sends_bare_neighbor() {
         let server = spawn_mock_server(None).await;
         let connection = connect(&server.addr, None).await.unwrap();
-        chain_show(connection, Some("10.0.0.2"), true)
+        chain_show(connection, Some("fe80::2%eth0"), true)
             .await
             .unwrap();
+        let captured = server
+            .state
+            .last_get_neighbor_policy_chains
+            .lock()
+            .await
+            .clone()
+            .unwrap();
+        assert_eq!(captured.address, "fe80::2");
     }
 
     #[tokio::test]
@@ -2337,13 +2414,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn chain_set_neighbor_export_captures_request() {
+    async fn chain_set_neighbor_import_sends_bare_scoped_address() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        chain_set(
+            connection,
+            ChainDirection::Import,
+            Some("fe80::2%eth0"),
+            vec!["x".to_string()],
+            true,
+        )
+        .await
+        .unwrap();
+        let captured = server
+            .state
+            .last_set_neighbor_import_chain
+            .lock()
+            .await
+            .clone()
+            .unwrap();
+        assert_eq!(captured.address, "fe80::2");
+        assert_eq!(captured.policy_names, vec!["x".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn chain_set_neighbor_export_sends_bare_scoped_address() {
         let server = spawn_mock_server(None).await;
         let connection = connect(&server.addr, None).await.unwrap();
         chain_set(
             connection,
             ChainDirection::Export,
-            Some("10.0.0.2"),
+            Some("fe80::2%eth0"),
             vec!["x".to_string()],
             true,
         )
@@ -2356,17 +2457,22 @@ mod tests {
             .await
             .clone()
             .unwrap();
-        assert_eq!(captured.address, "10.0.0.2");
+        assert_eq!(captured.address, "fe80::2");
         assert_eq!(captured.policy_names, vec!["x".to_string()]);
     }
 
     #[tokio::test]
-    async fn chain_clear_neighbor_import_captures_request() {
+    async fn chain_clear_neighbor_import_sends_bare_scoped_address() {
         let server = spawn_mock_server(None).await;
         let connection = connect(&server.addr, None).await.unwrap();
-        chain_clear(connection, ChainDirection::Import, Some("10.0.0.2"), true)
-            .await
-            .unwrap();
+        chain_clear(
+            connection,
+            ChainDirection::Import,
+            Some("fe80::2%eth0"),
+            true,
+        )
+        .await
+        .unwrap();
         let captured = server
             .state
             .last_clear_neighbor_import_chain
@@ -2374,7 +2480,29 @@ mod tests {
             .await
             .clone()
             .unwrap();
-        assert_eq!(captured.address, "10.0.0.2");
+        assert_eq!(captured.address, "fe80::2");
+    }
+
+    #[tokio::test]
+    async fn chain_clear_neighbor_export_sends_bare_scoped_address() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        chain_clear(
+            connection,
+            ChainDirection::Export,
+            Some("fe80::2%eth0"),
+            true,
+        )
+        .await
+        .unwrap();
+        let captured = server
+            .state
+            .last_clear_neighbor_export_chain
+            .lock()
+            .await
+            .clone()
+            .unwrap();
+        assert_eq!(captured.address, "fe80::2");
     }
 
     /// LAN-323: `fmt` rewrites in place (atomically), a second run is

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -125,6 +125,7 @@ pub(crate) struct MockState {
     // not_seen / cache_disabled / no_session CLI pins.
     pub(crate) explain_import_synthetic_outcome: Mutex<Option<server_proto::ImportExplainOutcome>>,
     pub(crate) last_test_policy: Mutex<Option<server_proto::TestPolicyRequest>>,
+    pub(crate) last_get_policy_stats: Mutex<Option<server_proto::GetPolicyStatsRequest>>,
     pub(crate) last_set_neighbor_set: Mutex<Option<server_proto::SetNeighborSetRequest>>,
     pub(crate) last_delete_neighbor_set: Mutex<Option<server_proto::DeleteNeighborSetRequest>>,
     pub(crate) last_add_dynamic_neighbor: Mutex<Option<server_proto::AddDynamicNeighborRequest>>,
@@ -136,6 +137,8 @@ pub(crate) struct MockState {
         Mutex<Option<server_proto::SetGlobalImportChainRequest>>,
     pub(crate) last_set_global_export_chain:
         Mutex<Option<server_proto::SetGlobalExportChainRequest>>,
+    pub(crate) last_get_neighbor_policy_chains:
+        Mutex<Option<server_proto::GetNeighborPolicyChainsRequest>>,
     pub(crate) last_set_neighbor_import_chain:
         Mutex<Option<server_proto::SetNeighborImportChainRequest>>,
     pub(crate) last_set_neighbor_export_chain:
@@ -1979,8 +1982,10 @@ impl rustbgpd_api::proto::policy_service_server::PolicyService for MockPolicySer
         &self,
         request: Request<server_proto::GetNeighborPolicyChainsRequest>,
     ) -> Result<Response<server_proto::NeighborPolicyChains>, Status> {
+        let request = request.into_inner();
+        *self.state.last_get_neighbor_policy_chains.lock().await = Some(request.clone());
         Ok(Response::new(server_proto::NeighborPolicyChains {
-            address: request.into_inner().address,
+            address: request.address,
             import_policy_names: vec!["n-import".to_string()],
             export_policy_names: vec!["n-export".to_string()],
         }))
@@ -2155,8 +2160,16 @@ impl rustbgpd_api::proto::policy_service_server::PolicyService for MockPolicySer
         request: Request<server_proto::GetPolicyStatsRequest>,
     ) -> Result<Response<server_proto::GetPolicyStatsResponse>, Status> {
         let req = request.into_inner();
+        *self.state.last_get_policy_stats.lock().await = Some(req.clone());
+        let peer_address = if req.peer_address.is_empty() {
+            "10.0.0.2".to_string()
+        } else {
+            req.peer_address
+                .parse::<std::net::IpAddr>()
+                .map_or_else(|_| req.peer_address.clone(), |address| address.to_string())
+        };
         let export_chain = server_proto::PolicyChainStats {
-            peer_address: "10.0.0.2".to_string(),
+            peer_address: peer_address.clone(),
             direction: "export".to_string(),
             routes_evaluated: 7,
             policy_generation: 0,
@@ -2180,7 +2193,7 @@ impl rustbgpd_api::proto::policy_service_server::PolicyService for MockPolicySer
             ],
         };
         let import_chain = server_proto::PolicyChainStats {
-            peer_address: "10.0.0.2".to_string(),
+            peer_address,
             direction: "import".to_string(),
             routes_evaluated: 11,
             policy_generation: 3,


### PR DESCRIPTION
## Summary

- normalize valid scoped IPv6 link-local neighbor identities only at address-only peer-group and policy RPC boundaries
- preserve malformed, non-link-local, IPv4, and multi-zone inputs unchanged
- retain the exact operator-provided scope in matching filtered output without relabeling unrelated or unfiltered rows
- add behavioral request-capture and output tests across peer-group, policy-chain, and policy-inspection commands

## Stack

This is a child of #1267. It will be retargeted to `main` after the parent merges.

## Verification

- 15 focused request/output tests
- cargo test -p rustbgpctl --bin rbgp (523 passed)
- cargo fmt --all -- --check
- cargo clippy -p rustbgpctl --all-targets -- -D warnings
- git diff --check

## Load-bearing regression proofs

- removing normalization from each command family leaves `%interface` in the captured address-only request and turns its test red
- broad percent stripping fails the malformed, zoned IPv4/global IPv6, and multi-zone preservation matrix
- bytewise response matching loses scope after production-style IPv6 canonicalization and turns the expanded-address test red
- unconditional output reconstruction relabels unrelated or unfiltered rows and turns both isolation tests red