### PR TITLE
Support scoped link-local route and RIB queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   policy-inspection day-two CLI commands: valid `%interface` zones stay visible
   in operator output but are omitted from bare-address RPC fields.
 
+- Scoped IPv6 link-local filters now work across received, advertised, FIB,
+  BGP-LS, VPN, labeled-unicast, RTC, EVPN, explain, retained-rejected, and
+  Adj-RIB-Out diff queries while preserving matching operator-visible scope.
+
 - `rbgp peer-group set` can now create a missing passwordless peer group from
   ordinary JSON that omits both MD5 fields. The same omission still preserves
   an existing group's secret, explicit `has_md5_password = true` still requires

--- a/crates/cli/src/commands/diff.rs
+++ b/crates/cli/src/commands/diff.rs
@@ -19,6 +19,7 @@ use std::net::IpAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use crate::commands::neighbor::bare_ip_rpc_address;
 use crate::connection::Connection;
 use crate::error::CliError;
 use crate::output;
@@ -210,12 +211,13 @@ async fn run(connection: Connection, opts: &AdvertisedDiffOpts) -> Result<(Strin
             opts.against.display()
         ))
     })?;
-    let mut snapshot = parse_snapshot(file, opts, &family_filter, &peer_filter, &ignored)?;
+    let mut snapshot =
+        parse_snapshot(file, opts, &family_filter, &peer_filter.addresses, &ignored)?;
 
-    let requested: BTreeSet<IpAddr> = if peer_filter.is_empty() {
+    let requested: BTreeSet<IpAddr> = if peer_filter.addresses.is_empty() {
         snapshot.peers.keys().copied().collect()
     } else {
-        peer_filter
+        peer_filter.addresses
     };
     if requested.is_empty() {
         return Err(op(
@@ -240,7 +242,7 @@ async fn run(connection: Connection, opts: &AdvertisedDiffOpts) -> Result<(Strin
     let mut neighbor_map: BTreeMap<IpAddr, (u32, Vec<String>)> = BTreeMap::new();
     for state in &neighbors.neighbors {
         if let Some(config) = &state.config
-            && let Ok(addr) = config.address.parse::<IpAddr>()
+            && let Ok(addr) = bare_ip_rpc_address(&config.address).parse::<IpAddr>()
         {
             neighbor_map.insert(addr, (config.remote_asn, config.families.clone()));
         }
@@ -276,10 +278,14 @@ async fn run(connection: Connection, opts: &AdvertisedDiffOpts) -> Result<(Strin
     // per side, never both full sides; finer within-peer page-by-page
     // release only if a single peer's full table ever hurts.
     for peer_addr in &requested {
+        let peer_display = peer_filter
+            .scoped_labels
+            .get(peer_addr)
+            .map_or_else(|| peer_addr.to_string(), Clone::clone);
         let snapshot_bucket = snapshot.peers.remove(peer_addr);
         let Some((remote_asn, configured_families)) = neighbor_map.get(peer_addr) else {
             report.incomparable_reasons.push(format!(
-                "peer {peer_addr}: not configured on the daemon; equality refused"
+                "peer {peer_display}: not configured on the daemon; equality refused"
             ));
             continue;
         };
@@ -287,7 +293,7 @@ async fn run(connection: Connection, opts: &AdvertisedDiffOpts) -> Result<(Strin
             && bucket.asn != *remote_asn
         {
             report.incomparable_reasons.push(format!(
-                "peer {peer_addr}: ASN mismatch (snapshot {} vs daemon {remote_asn}); \
+                "peer {peer_display}: ASN mismatch (snapshot {} vs daemon {remote_asn}); \
                  equality refused",
                 bucket.asn
             ));
@@ -298,7 +304,7 @@ async fn run(connection: Connection, opts: &AdvertisedDiffOpts) -> Result<(Strin
             let name = family_name(*family);
             if !configured_families.iter().any(|f| f == name) {
                 report.incomparable_reasons.push(format!(
-                    "peer {peer_addr}: requested family {name} is not configured; \
+                    "peer {peer_display}: requested family {name} is not configured; \
                      equality refused"
                 ));
                 family_unavailable = true;
@@ -350,7 +356,7 @@ async fn run(connection: Connection, opts: &AdvertisedDiffOpts) -> Result<(Strin
             peer_report
                 .incomparable_reasons
                 .into_iter()
-                .map(|r| format!("peer {peer_addr}: {r}")),
+                .map(|r| format!("peer {peer_display}: {r}")),
         );
         report.summaries.extend(peer_report.summaries);
         report.entries.extend(peer_report.entries);
@@ -370,9 +376,15 @@ async fn run(connection: Connection, opts: &AdvertisedDiffOpts) -> Result<(Strin
     };
     let notes = live_source_notes(med_attr_seen);
     let rendered = if opts.json {
-        render_json(&report, &ignored, &notes)?
+        render_json(&report, &ignored, &notes, &peer_filter.scoped_labels)?
     } else {
-        render_human(&report, &ignored, &notes, opts.detail)
+        render_human(
+            &report,
+            &ignored,
+            &notes,
+            opts.detail,
+            &peer_filter.scoped_labels,
+        )
     };
     Ok((rendered, code))
 }
@@ -419,14 +431,39 @@ fn parse_family_filter(families: &[String]) -> Result<Vec<FamilyId>, CliError> {
     Ok(parsed)
 }
 
-fn parse_peer_filter(peers: &[String]) -> Result<BTreeSet<IpAddr>, CliError> {
-    peers
-        .iter()
-        .map(|p| {
-            p.parse::<IpAddr>()
-                .map_err(|e| CliError::Argument(format!("invalid --peer address {p:?}: {e}")))
-        })
-        .collect()
+struct ParsedPeerFilter {
+    addresses: BTreeSet<IpAddr>,
+    scoped_labels: BTreeMap<IpAddr, String>,
+}
+
+fn parse_peer_filter(peers: &[String]) -> Result<ParsedPeerFilter, CliError> {
+    let mut addresses = BTreeSet::new();
+    let mut scoped_labels: BTreeMap<IpAddr, String> = BTreeMap::new();
+    for peer in peers {
+        let bare = bare_ip_rpc_address(peer);
+        let address = bare
+            .parse::<IpAddr>()
+            .map_err(|e| CliError::Argument(format!("invalid --peer address {peer:?}: {e}")))?;
+        addresses.insert(address);
+        if bare != peer {
+            if let Some(existing) = scoped_labels.get(&address) {
+                let existing_zone = existing.split_once('%').map(|(_, zone)| zone);
+                let requested_zone = peer.split_once('%').map(|(_, zone)| zone);
+                if existing_zone != requested_zone {
+                    return Err(CliError::Argument(format!(
+                        "conflicting --peer scopes for {address}: {existing:?} and {peer:?}; \
+                         specify only one scope per link-local address"
+                    )));
+                }
+            } else {
+                scoped_labels.insert(address, peer.to_string());
+            }
+        }
+    }
+    Ok(ParsedPeerFilter {
+        addresses,
+        scoped_labels,
+    })
 }
 
 fn family_name(family: FamilyId) -> &'static str {
@@ -997,8 +1034,29 @@ fn render_json(
     report: &DiffReport,
     ignored: &[String],
     notes: &[&str],
+    scoped_peer_labels: &BTreeMap<IpAddr, String>,
 ) -> Result<String, CliError> {
     let mut value = serde_json::to_value(report)?;
+    for (serialized, summary) in value["summaries"]
+        .as_array_mut()
+        .expect("DiffReport summaries serialize to an array")
+        .iter_mut()
+        .zip(&report.summaries)
+    {
+        if let Some(scoped) = scoped_peer_labels.get(&summary.peer.address) {
+            serialized["peer"]["address"] = serde_json::json!(scoped);
+        }
+    }
+    for (serialized, entry) in value["entries"]
+        .as_array_mut()
+        .expect("DiffReport entries serialize to an array")
+        .iter_mut()
+        .zip(&report.entries)
+    {
+        if let Some(scoped) = scoped_peer_labels.get(&entry.peer.address) {
+            serialized["peer"]["address"] = serde_json::json!(scoped);
+        }
+    }
     let object = value
         .as_object_mut()
         .expect("DiffReport serializes to an object");
@@ -1007,7 +1065,13 @@ fn render_json(
     Ok(format!("{}\n", serde_json::to_string_pretty(&value)?))
 }
 
-fn render_human(report: &DiffReport, ignored: &[String], notes: &[&str], detail: usize) -> String {
+fn render_human(
+    report: &DiffReport,
+    ignored: &[String],
+    notes: &[&str],
+    detail: usize,
+    scoped_peer_labels: &BTreeMap<IpAddr, String>,
+) -> String {
     use std::fmt::Write;
 
     let mut out = String::new();
@@ -1042,11 +1106,14 @@ fn render_human(report: &DiffReport, ignored: &[String], notes: &[&str], detail:
     if !report.summaries.is_empty() {
         out.push_str("per-peer summary:\n");
         for s in &report.summaries {
+            let peer = scoped_peer_labels
+                .get(&s.peer.address)
+                .map_or_else(|| s.peer.address.to_string(), Clone::clone);
             let _ = writeln!(
                 out,
                 "  {} AS{} {}: matched {}, incumbent-only {}, rustbgpd-only {}, \
                  attribute-changed {}, multiplicity-changed {}",
-                s.peer.address,
+                peer,
                 s.peer.asn,
                 family_name(s.family),
                 s.matched,
@@ -1065,6 +1132,9 @@ fn render_human(report: &DiffReport, ignored: &[String], notes: &[&str], detail:
             report.entries.len()
         );
         for entry in report.entries.iter().take(detail) {
+            let peer = scoped_peer_labels
+                .get(&entry.peer.address)
+                .map_or_else(|| entry.peer.address.to_string(), Clone::clone);
             let marker = match entry.class {
                 DiffClass::IncumbentOnly => "-",
                 DiffClass::RustbgpdOnly => "+",
@@ -1088,7 +1158,7 @@ fn render_human(report: &DiffReport, ignored: &[String], notes: &[&str], detail:
             let _ = writeln!(
                 out,
                 "  {marker} {} {} {} [{class}]{detail_text}",
-                entry.peer.address,
+                peer,
                 family_name(entry.family),
                 nlri_str(&entry.nlri)
             );
@@ -2622,6 +2692,72 @@ mod tests {
             assert_eq!(code, EXIT_DIVERGENT, "output was:\n{rendered}");
             assert!(rendered.contains("med: 51 -> 999"));
         }
+    }
+
+    #[tokio::test]
+    async fn scoped_peer_filter_queries_bare_adj_rib_out_address() {
+        let route = serde_json::json!({
+            "record": "route",
+            "peer": "fe80::2",
+            "peer_asn": PEER_ASN,
+            "prefix": "10.0.0.0/24",
+            "origin": 0,
+            "as_path": [65001],
+            "next_hop": "192.0.2.254",
+            "communities": ["64501:100"],
+        })
+        .to_string();
+        let file = snapshot_file(&[header_line(), route, trailer_line(1)]);
+        let server = spawn_mock_server(None).await;
+        *server.state.list_neighbors_response.lock().await =
+            vec![neighbor("fe80::2%eth0", PEER_ASN)];
+        *server.state.list_route_pages.lock().await =
+            vec![page(vec![live_route("10.0.0.0", 0)], "", 1)];
+        let mut filtered = opts(file.path());
+        filtered.peers = vec!["fe80:0:0:0:0:0:0:2%eth0".to_string()];
+
+        let (rendered, code) = run_against(&server, &filtered).await.unwrap();
+        assert_eq!(code, EXIT_IN_SYNC, "output was:\n{rendered}");
+        assert!(
+            rendered.contains("fe80:0:0:0:0:0:0:2%eth0 AS64501"),
+            "output was:\n{rendered}"
+        );
+
+        *server.state.list_route_pages.lock().await =
+            vec![page(vec![live_route("10.0.0.0", 0)], "", 1)];
+        filtered.json = true;
+        let (rendered, code) = run_against(&server, &filtered).await.unwrap();
+        assert_eq!(code, EXIT_IN_SYNC, "output was:\n{rendered}");
+        let report: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(
+            report["summaries"][0]["peer"]["address"],
+            "fe80:0:0:0:0:0:0:2%eth0"
+        );
+
+        let requests = server.state.list_route_requests.lock().await;
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].neighbor_address, "fe80::2");
+        assert_eq!(requests[1].neighbor_address, "fe80::2");
+    }
+
+    /// Red proof: removing the scope-conflict check in `parse_peer_filter`
+    /// makes this return `Ok` and silently assigns the first scope to both
+    /// filters.
+    #[test]
+    fn scoped_peer_filter_rejects_conflicting_labels_for_one_address() {
+        let result = parse_peer_filter(&[
+            "fe80::2%eth0".to_string(),
+            "fe80:0:0:0:0:0:0:2%eth1".to_string(),
+        ]);
+
+        let Err(error) = result else {
+            panic!("conflicting scopes must be rejected");
+        };
+        assert_eq!(
+            error.to_string(),
+            "conflicting --peer scopes for fe80::2: \"fe80::2%eth0\" and \
+             \"fe80:0:0:0:0:0:0:2%eth1\"; specify only one scope per link-local address"
+        );
     }
 
     #[tokio::test]

--- a/crates/cli/src/commands/evpn.rs
+++ b/crates/cli/src/commands/evpn.rs
@@ -1,3 +1,4 @@
+use crate::commands::neighbor::{bare_ip_rpc_address, restore_matching_scoped_address};
 use crate::connection::Connection;
 use crate::error::CliError;
 use crate::output;
@@ -41,14 +42,21 @@ pub async fn list(
     json: bool,
 ) -> Result<(), CliError> {
     let mut client = connection.rib_listing_client();
-    let resp = client
+    let mut resp = client
         .list_evpn_routes(ListEvpnRequest {
             route_type_filter: route_type.unwrap_or(0),
-            peer_filter: peer.unwrap_or_default(),
+            peer_filter: peer
+                .as_deref()
+                .map(bare_ip_rpc_address)
+                .unwrap_or_default()
+                .to_string(),
             rd_filter: rd.unwrap_or_default(),
         })
         .await?
         .into_inner();
+    for route in &mut resp.routes {
+        restore_matching_scoped_address(peer.as_deref(), &mut route.peer_address);
+    }
 
     if json {
         let out: Vec<serde_json::Value> = resp
@@ -1220,6 +1228,7 @@ mod tests {
 
     use crate::proto::ListEvpnInstancesRequest;
     use crate::proto::evpn_service_client::EvpnServiceClient;
+    use crate::test_support::spawn_mock_server;
 
     /// Build a realistic `EvpnInstanceTable` covering the field surface
     /// operators actually use: minimal instance, instance with bridge,
@@ -1255,6 +1264,33 @@ mod tests {
         )
         .unwrap();
         t
+    }
+
+    #[tokio::test]
+    async fn list_scoped_peer_sends_bare_filter() {
+        let server = spawn_mock_server(None).await;
+        let connection = crate::connection::connect(&server.addr, None)
+            .await
+            .unwrap();
+
+        super::list(
+            connection,
+            Some(2),
+            Some("fe80:0:0:0:0:0:0:2%eth0".to_string()),
+            None,
+            true,
+        )
+        .await
+        .unwrap();
+
+        let request = server
+            .state
+            .last_list_evpn
+            .lock()
+            .await
+            .clone()
+            .expect("EVPN request captured");
+        assert_eq!(request.peer_filter, "fe80:0:0:0:0:0:0:2");
     }
 
     fn unique_uds_path() -> (TempDir, PathBuf) {

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -25,6 +25,25 @@ pub(super) fn bare_ip_rpc_address(address: &str) -> &str {
     }
 }
 
+pub(super) fn restore_matching_scoped_address(requested: Option<&str>, response: &mut String) {
+    let Some(address) = requested else {
+        return;
+    };
+    let bare = bare_ip_rpc_address(address);
+    if bare == address {
+        return;
+    }
+    if matches!(
+        (
+            bare.parse::<std::net::IpAddr>(),
+            response.parse::<std::net::IpAddr>(),
+        ),
+        (Ok(requested_ip), Ok(response_ip)) if requested_ip == response_ip
+    ) {
+        address.clone_into(response);
+    }
+}
+
 fn split_scoped_address(address: &str) -> (String, String) {
     address.rsplit_once('%').map_or_else(
         || (address.to_string(), String::new()),
@@ -1145,6 +1164,27 @@ mod tests {
         for (input, expected) in cases {
             assert_eq!(bare_ip_rpc_address(input), expected, "input {input:?}");
         }
+    }
+
+    #[test]
+    fn scoped_output_restores_matching_filtered_identity() {
+        let mut canonical = "fe80::9".to_string();
+        restore_matching_scoped_address(Some("fe80:0:0:0:0:0:0:9%eth0"), &mut canonical);
+        assert_eq!(canonical, "fe80:0:0:0:0:0:0:9%eth0");
+    }
+
+    #[test]
+    fn scoped_output_leaves_unrelated_rows_unchanged() {
+        let mut unrelated = "fe80::10".to_string();
+        restore_matching_scoped_address(Some("fe80::9%eth0"), &mut unrelated);
+        assert_eq!(unrelated, "fe80::10");
+    }
+
+    #[test]
+    fn scoped_output_leaves_unfiltered_rows_unchanged() {
+        let mut unfiltered = "fe80::9".to_string();
+        restore_matching_scoped_address(None, &mut unfiltered);
+        assert_eq!(unfiltered, "fe80::9");
     }
 
     /// ADR-0112 rolling-version contract. Zero is what an older daemon leaves

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -1,3 +1,4 @@
+use crate::commands::neighbor::{bare_ip_rpc_address, restore_matching_scoped_address};
 use crate::connection::Connection;
 use crate::error::CliError;
 use crate::output::{
@@ -53,7 +54,10 @@ fn make_route_request(
     };
 
     Ok(ListRoutesRequest {
-        neighbor_address: neighbor.unwrap_or("").to_string(),
+        neighbor_address: neighbor
+            .map(bare_ip_rpc_address)
+            .unwrap_or_default()
+            .to_string(),
         afi_safi: family.unwrap_or(0),
         page_size: 0,
         page_token: String::new(),
@@ -195,7 +199,7 @@ fn make_fib_request(filters: &FibRouteFilterOpts) -> Result<ListFibRoutesRequest
         (String::new(), 0)
     };
     let peer_address = if let Some(peer) = &filters.peer {
-        let addr: std::net::IpAddr = peer
+        let addr: std::net::IpAddr = bare_ip_rpc_address(peer)
             .parse()
             .map_err(|e| CliError::Argument(format!("invalid --peer address: {e}")))?;
         addr.to_string()
@@ -249,7 +253,11 @@ fn make_bgpls_request(
 ) -> Result<ListBgpLsRequest, CliError> {
     Ok(ListBgpLsRequest {
         afi_safi: parse_bgpls_family(family)?,
-        peer_filter: peer.unwrap_or_default(),
+        peer_filter: peer
+            .as_deref()
+            .map(bare_ip_rpc_address)
+            .unwrap_or_default()
+            .to_string(),
         nlri_type_filter: nlri_type.unwrap_or(0),
     })
 }
@@ -276,7 +284,11 @@ fn make_vpn_request(
 ) -> Result<ListVpnRoutesRequest, CliError> {
     Ok(ListVpnRoutesRequest {
         afi_safi: parse_vpn_family(family)?,
-        peer_filter: peer.unwrap_or_default(),
+        peer_filter: peer
+            .as_deref()
+            .map(bare_ip_rpc_address)
+            .unwrap_or_default()
+            .to_string(),
     })
 }
 
@@ -302,7 +314,11 @@ fn make_labeled_request(
 ) -> Result<ListLabeledRoutesRequest, CliError> {
     Ok(ListLabeledRoutesRequest {
         afi_safi: parse_labeled_family(family)?,
-        peer_filter: peer.unwrap_or_default(),
+        peer_filter: peer
+            .as_deref()
+            .map(bare_ip_rpc_address)
+            .unwrap_or_default()
+            .to_string(),
     })
 }
 
@@ -1637,14 +1653,18 @@ pub async fn explain_best_path(
     let (addr, len) = output::parse_prefix(prefix).map_err(CliError::Argument)?;
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
+    let mut resp = client
         .explain_best_path(ExplainBestPathRequest {
             prefix: addr,
             prefix_length: len,
-            peer_address: peer.unwrap_or("").to_string(),
+            peer_address: peer
+                .map(bare_ip_rpc_address)
+                .unwrap_or_default()
+                .to_string(),
         })
         .await?
         .into_inner();
+    restore_matching_scoped_address(peer, &mut resp.peer_address);
     print_explain_best_path(&resp, json)
 }
 
@@ -1690,10 +1710,13 @@ pub async fn fib(
     json: bool,
 ) -> Result<(), CliError> {
     let mut client = connection.rib_listing_client();
-    let resp = client
+    let mut resp = client
         .list_fib_routes(make_fib_request(&filters)?)
         .await?
         .into_inner();
+    for route in &mut resp.routes {
+        restore_matching_scoped_address(filters.peer.as_deref(), &mut route.peer_address);
+    }
     print_fib_routes(&resp, json, include_fib_page_meta(&filters))
 }
 
@@ -1704,11 +1727,15 @@ pub async fn bgpls(
     nlri_type: Option<u32>,
     json: bool,
 ) -> Result<(), CliError> {
+    let requested_peer = peer.clone();
     let mut client = connection.rib_listing_client();
-    let resp = client
+    let mut resp = client
         .list_bgp_ls_routes(make_bgpls_request(family, peer, nlri_type)?)
         .await?
         .into_inner();
+    for route in &mut resp.routes {
+        restore_matching_scoped_address(requested_peer.as_deref(), &mut route.peer_address);
+    }
     print_bgpls_routes(&resp.routes, json)
 }
 
@@ -1718,11 +1745,15 @@ pub async fn vpn(
     peer: Option<String>,
     json: bool,
 ) -> Result<(), CliError> {
+    let requested_peer = peer.clone();
     let mut client = connection.rib_listing_client();
-    let resp = client
+    let mut resp = client
         .list_vpn_routes(make_vpn_request(family, peer)?)
         .await?
         .into_inner();
+    for route in &mut resp.routes {
+        restore_matching_scoped_address(requested_peer.as_deref(), &mut route.peer_address);
+    }
     print_vpn_routes(&resp.routes, json)
 }
 
@@ -1732,22 +1763,33 @@ pub async fn labeled(
     peer: Option<String>,
     json: bool,
 ) -> Result<(), CliError> {
+    let requested_peer = peer.clone();
     let mut client = connection.rib_listing_client();
-    let resp = client
+    let mut resp = client
         .list_labeled_routes(make_labeled_request(family, peer)?)
         .await?
         .into_inner();
+    for route in &mut resp.routes {
+        restore_matching_scoped_address(requested_peer.as_deref(), &mut route.peer_address);
+    }
     print_labeled_routes(&resp.routes, json)
 }
 
 pub async fn rtc(connection: Connection, peer: Option<String>, json: bool) -> Result<(), CliError> {
     let mut client = connection.rib_listing_client();
-    let resp = client
+    let mut resp = client
         .list_rtc_routes(ListRtcRoutesRequest {
-            peer_filter: peer.unwrap_or_default(),
+            peer_filter: peer
+                .as_deref()
+                .map(bare_ip_rpc_address)
+                .unwrap_or_default()
+                .to_string(),
         })
         .await?
         .into_inner();
+    for route in &mut resp.routes {
+        restore_matching_scoped_address(peer.as_deref(), &mut route.peer_address);
+    }
     print_rtc_routes(&resp.routes, json)
 }
 
@@ -1761,12 +1803,15 @@ pub async fn received(
 ) -> Result<(), CliError> {
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let routes = fetch_all_route_pages(
+    let mut routes = fetch_all_route_pages(
         &mut client,
         &RouteListRpc::Received,
         make_route_request(Some(address), family, filters)?,
     )
     .await?;
+    for route in &mut routes {
+        restore_matching_scoped_address(Some(address), &mut route.peer_address);
+    }
     print_routes(&routes, show_age, json)
 }
 
@@ -1795,12 +1840,13 @@ pub async fn count_received(
 pub async fn rejected(connection: Connection, address: &str, json: bool) -> Result<(), CliError> {
     let mut client =
         PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
+    let mut resp = client
         .list_rejected_routes(ListRejectedRoutesRequest {
-            peer_address: address.to_string(),
+            peer_address: bare_ip_rpc_address(address).to_string(),
         })
         .await?
         .into_inner();
+    restore_matching_scoped_address(Some(address), &mut resp.peer_address);
     print_rejected_routes(&resp, json)
 }
 
@@ -1934,12 +1980,15 @@ pub async fn advertised(
 ) -> Result<(), CliError> {
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let routes = fetch_all_route_pages(
+    let mut routes = fetch_all_route_pages(
         &mut client,
         &RouteListRpc::Advertised,
         make_route_request(Some(address), family, filters)?,
     )
     .await?;
+    for route in &mut routes {
+        restore_matching_scoped_address(Some(address), &mut route.peer_address);
+    }
     print_routes(&routes, show_age, json)
 }
 
@@ -1978,22 +2027,28 @@ pub async fn explain_advertised(
     let (addr, len) = output::parse_prefix(prefix).map_err(CliError::Argument)?;
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
+    let requested_source = source_peer.filter(|_| source_path_id.is_some());
+    let mut resp = client
         .explain_advertised_route(ExplainAdvertisedRouteRequest {
-            peer_address: address.to_string(),
+            peer_address: bare_ip_rpc_address(address).to_string(),
             prefix: addr,
             prefix_length: len,
             rd: rd.unwrap_or_default().to_string(),
             labeled,
             source: source_peer.zip(source_path_id).map(|(peer, path_id)| {
                 crate::proto::RouteSourceIdentity {
-                    peer_address: peer.to_string(),
+                    peer_address: bare_ip_rpc_address(peer).to_string(),
                     path_id,
                 }
             }),
         })
         .await?
         .into_inner();
+    restore_matching_scoped_address(Some(address), &mut resp.peer_address);
+    restore_matching_scoped_address(requested_source, &mut resp.route_peer_address);
+    if let Some(source) = &mut resp.source {
+        restore_matching_scoped_address(requested_source, &mut source.peer_address);
+    }
     print_explain_advertised(&resp, json)
 }
 
@@ -2168,11 +2223,11 @@ mod tests {
 
         explain_advertised(
             connection,
-            "192.0.2.1",
+            "fe80::1%eth0",
             "203.0.113.0/24",
             None,
             false,
-            Some("198.51.100.2"),
+            Some("fe80::2%eth1"),
             Some(0),
             false,
         )
@@ -2186,7 +2241,7 @@ mod tests {
             .await
             .clone()
             .expect("explain request captured");
-        assert_eq!(req.peer_address, "192.0.2.1");
+        assert_eq!(req.peer_address, "fe80::1");
         assert_eq!(req.prefix, "203.0.113.0");
         assert_eq!(req.prefix_length, 24);
         assert_eq!(req.rd, "");
@@ -2195,7 +2250,7 @@ mod tests {
             req.source
                 .as_ref()
                 .map(|source| source.peer_address.as_str()),
-            Some("198.51.100.2")
+            Some("fe80::2")
         );
         // Load-bearing proof: treating zero as absence makes these assertions red.
     }
@@ -2251,6 +2306,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn explain_best_path_scoped_peer_sends_bare_request() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        explain_best_path(
+            connection,
+            "203.0.113.0/24",
+            Some("fe80:0:0:0:0:0:0:1%eth0"),
+            true,
+        )
+        .await
+        .unwrap();
+
+        let req = server
+            .state
+            .last_explain_best_path
+            .lock()
+            .await
+            .clone()
+            .expect("explain best-path request captured");
+        assert_eq!(req.peer_address, "fe80:0:0:0:0:0:0:1");
+    }
+
+    #[tokio::test]
     async fn bgpls_sends_filters_and_renders_raw_bytes() {
         let server = spawn_mock_server(None).await;
         let connection = connect(&server.addr, None).await.unwrap();
@@ -2258,7 +2337,7 @@ mod tests {
         bgpls(
             connection,
             Some("linkstate"),
-            Some("198.51.100.1".to_string()),
+            Some("fe80::1%eth0".to_string()),
             Some(1),
             true,
         )
@@ -2273,7 +2352,7 @@ mod tests {
             .clone()
             .expect("BGP-LS request captured");
         assert_eq!(req.afi_safi, AddressFamily::BgpLs as i32);
-        assert_eq!(req.peer_filter, "198.51.100.1");
+        assert_eq!(req.peer_filter, "fe80::1");
         assert_eq!(req.nlri_type_filter, 1);
     }
 
@@ -2285,7 +2364,7 @@ mod tests {
         labeled(
             connection,
             Some("labeled-v4"),
-            Some("198.51.100.1".to_string()),
+            Some("fe80::1%eth0".to_string()),
             true,
         )
         .await
@@ -2299,7 +2378,7 @@ mod tests {
             .clone()
             .expect("labeled request captured");
         assert_eq!(req.afi_safi, "ipv4_labeled_unicast");
-        assert_eq!(req.peer_filter, "198.51.100.1");
+        assert_eq!(req.peer_filter, "fe80::1");
     }
 
     #[test]
@@ -2324,7 +2403,7 @@ mod tests {
         vpn(
             connection,
             Some("vpnv4"),
-            Some("198.51.100.1".to_string()),
+            Some("fe80::1%eth0".to_string()),
             true,
         )
         .await
@@ -2338,7 +2417,7 @@ mod tests {
             .clone()
             .expect("VPN request captured");
         assert_eq!(req.afi_safi, "l3vpn_ipv4_unicast");
-        assert_eq!(req.peer_filter, "198.51.100.1");
+        assert_eq!(req.peer_filter, "fe80::1");
     }
 
     #[tokio::test]
@@ -2346,7 +2425,7 @@ mod tests {
         let server = spawn_mock_server(None).await;
         let connection = connect(&server.addr, None).await.unwrap();
 
-        rtc(connection, Some("198.51.100.1".to_string()), true)
+        rtc(connection, Some("fe80::1%eth0".to_string()), true)
             .await
             .unwrap();
 
@@ -2357,7 +2436,7 @@ mod tests {
             .await
             .clone()
             .expect("RTC request captured");
-        assert_eq!(req.peer_filter, "198.51.100.1");
+        assert_eq!(req.peer_filter, "fe80::1");
 
         // Row rendering: the default row shows `default` and the locally
         // originated entry (peer 0.0.0.0) renders FROM-PEER as `local`.
@@ -2426,7 +2505,7 @@ mod tests {
                 state: None,
                 reason: None,
                 prefix: None,
-                peer: None,
+                peer: Some("fe80::2%eth0".to_string()),
                 page_size: None,
                 page_token: None,
             },
@@ -2434,6 +2513,15 @@ mod tests {
         )
         .await
         .unwrap();
+
+        let request = server
+            .state
+            .last_list_fib
+            .lock()
+            .await
+            .clone()
+            .expect("FIB request captured");
+        assert_eq!(request.peer_address, "fe80::2");
     }
 
     #[test]
@@ -2443,7 +2531,7 @@ mod tests {
             state: Some("rejected".to_string()),
             reason: Some("route_limit_exceeded".to_string()),
             prefix: Some("203.0.113.0/24".to_string()),
-            peer: Some("198.51.100.2".to_string()),
+            peer: Some("fe80::2%eth0".to_string()),
             page_size: Some(50),
             page_token: Some("100".to_string()),
         })
@@ -2454,7 +2542,7 @@ mod tests {
         assert_eq!(request.reason, "route_limit_exceeded");
         assert_eq!(request.prefix, "203.0.113.0");
         assert_eq!(request.prefix_length, 24);
-        assert_eq!(request.peer_address, "198.51.100.2");
+        assert_eq!(request.peer_address, "fe80::2");
         assert_eq!(request.page_size, 50);
         assert_eq!(request.page_token, "100");
     }
@@ -3273,7 +3361,7 @@ mod tests {
         .unwrap();
         count_received(
             connect(&server.addr, None).await.unwrap(),
-            "fe80::1",
+            "fe80::1%eth0",
             family,
             &filters,
             true,
@@ -3282,7 +3370,7 @@ mod tests {
         .unwrap();
         count_advertised(
             connect(&server.addr, None).await.unwrap(),
-            "fe80::2",
+            "fe80::2%eth1",
             family,
             &filters,
             false,
@@ -3318,6 +3406,54 @@ mod tests {
         assert_count_request(&requests[2], "fe80::2");
     }
 
+    #[tokio::test]
+    async fn scoped_route_lists_and_rejected_query_send_bare_addresses() {
+        let server = spawn_mock_server(None).await;
+        let filters = no_route_filters();
+
+        received(
+            connect(&server.addr, None).await.unwrap(),
+            "fe80::1%eth0",
+            None,
+            &filters,
+            false,
+            true,
+        )
+        .await
+        .unwrap();
+        advertised(
+            connect(&server.addr, None).await.unwrap(),
+            "fe80::2%eth1",
+            None,
+            &filters,
+            false,
+            true,
+        )
+        .await
+        .unwrap();
+        rejected(
+            connect(&server.addr, None).await.unwrap(),
+            "fe80::3%eth2",
+            true,
+        )
+        .await
+        .unwrap();
+
+        let requests = server.state.list_route_requests.lock().await;
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].neighbor_address, "fe80::1");
+        assert_eq!(requests[1].neighbor_address, "fe80::2");
+        drop(requests);
+        let rejected = server
+            .state
+            .last_list_rejected
+            .lock()
+            .await
+            .clone()
+            .expect("rejected-route request captured");
+        assert_eq!(rejected.peer_address, "fe80::3");
+    }
+
     /// `rbgp rib received` follows `next_page_token` until the listing
     /// completes — no silent truncation at the server's page size.
     #[tokio::test]
@@ -3332,7 +3468,7 @@ mod tests {
         let connection = connect(&server.addr, None).await.unwrap();
         received(
             connection,
-            "192.0.2.1",
+            "fe80::1%eth0",
             None,
             &no_route_filters(),
             false,
@@ -3344,6 +3480,7 @@ mod tests {
         let requests = server.state.list_route_requests.lock().await;
         assert_eq!(requests.len(), 2, "one RPC per page");
         assert!(requests[0].page_token.is_empty());
+        assert_eq!(requests[0].neighbor_address, "fe80::1");
         assert!(requests[0].page_size > 0, "CLI requests bounded pages");
         assert_eq!(requests[1].page_token, "10.0.0.0/24|192.0.2.1|0");
     }

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -104,6 +104,7 @@ pub(crate) struct MockState {
     // Canned ListNeighbors response — drives `rbgp diff` peer-availability
     // gating. Empty = no neighbors configured on the daemon.
     pub(crate) list_neighbors_response: Mutex<Vec<server_proto::NeighborState>>,
+    pub(crate) last_list_fib: Mutex<Option<server_proto::ListFibRoutesRequest>>,
     pub(crate) last_list_bgpls: Mutex<Option<server_proto::ListBgpLsRequest>>,
     // Canned ListBgpLsRoutes response — when set, served verbatim so the
     // decode-ceiling tests can push multi-MiB listings through loopback.
@@ -111,6 +112,8 @@ pub(crate) struct MockState {
     pub(crate) last_list_vpn: Mutex<Option<server_proto::ListVpnRoutesRequest>>,
     pub(crate) last_list_labeled: Mutex<Option<server_proto::ListLabeledRoutesRequest>>,
     pub(crate) last_list_rtc: Mutex<Option<server_proto::ListRtcRoutesRequest>>,
+    pub(crate) last_list_evpn: Mutex<Option<server_proto::ListEvpnRequest>>,
+    pub(crate) last_list_rejected: Mutex<Option<server_proto::ListRejectedRoutesRequest>>,
     pub(crate) last_list_topology_nodes: Mutex<Option<server_proto::ListTopologyNodesRequest>>,
     pub(crate) last_list_topology_links: Mutex<Option<server_proto::ListTopologyLinksRequest>>,
     pub(crate) last_list_orr_status: Mutex<Option<server_proto::ListOrrStatusRequest>>,
@@ -166,6 +169,12 @@ fn consume_failure(counter: &AtomicUsize) -> bool {
             remaining.checked_sub(1)
         })
         .is_ok()
+}
+
+fn canonical_ip_or_original(address: &str) -> String {
+    address
+        .parse::<std::net::IpAddr>()
+        .map_or_else(|_| address.to_string(), |address| address.to_string())
 }
 
 pub(crate) struct MockServerHandle {
@@ -1426,6 +1435,7 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
     ) -> Result<Response<server_proto::ExplainBestPathResponse>, Status> {
         let req = request.into_inner();
         *self.state.last_explain_best_path.lock().await = Some(req.clone());
+        let response_peer = canonical_ip_or_original(&req.peer_address);
         Ok(Response::new(server_proto::ExplainBestPathResponse {
             prefix: "203.0.113.0".to_string(),
             prefix_length: 24,
@@ -1450,7 +1460,7 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
                 vs_best_detail: "local_pref 100 < 200".to_string(),
                 multipath: "none".to_string(),
             }],
-            peer_address: req.peer_address,
+            peer_address: response_peer,
             add_path_send_max: 0,
             best_reason: "higher_local_pref".to_string(),
             best_reason_detail: "local_pref 200 > 100".to_string(),
@@ -1461,16 +1471,29 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         &self,
         request: Request<server_proto::ExplainAdvertisedRouteRequest>,
     ) -> Result<Response<server_proto::ExplainAdvertisedRouteResponse>, Status> {
-        *self.state.last_explain_advertised.lock().await = Some(request.into_inner());
+        let req = request.into_inner();
+        *self.state.last_explain_advertised.lock().await = Some(req.clone());
+        let response_peer = canonical_ip_or_original(&req.peer_address);
+        let response_source = req
+            .source
+            .as_ref()
+            .map(|source| server_proto::RouteSourceIdentity {
+                peer_address: canonical_ip_or_original(&source.peer_address),
+                path_id: source.path_id,
+            });
+        let route_peer_address = response_source.as_ref().map_or_else(
+            || "198.51.100.2".to_string(),
+            |source| source.peer_address.clone(),
+        );
         Ok(Response::new(
             server_proto::ExplainAdvertisedRouteResponse {
                 decision: server_proto::ExplainDecision::Advertise as i32,
-                peer_address: "192.0.2.1".to_string(),
+                peer_address: response_peer,
                 prefix: "203.0.113.0".to_string(),
                 prefix_length: 24,
                 next_hop: "198.51.100.1".to_string(),
                 path_id: 0,
-                route_peer_address: "198.51.100.2".to_string(),
+                route_peer_address,
                 route_type: "external".to_string(),
                 reasons: vec![server_proto::ExplainReason {
                     code: "policy_permitted".to_string(),
@@ -1518,7 +1541,7 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
                 update_group_id: Some(1),
                 already_advertised: true,
                 rd: String::new(),
-                source: None,
+                source: response_source,
             },
         ))
     }
@@ -1534,12 +1557,23 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
 
     async fn list_fib_routes(
         &self,
-        _request: Request<server_proto::ListFibRoutesRequest>,
+        request: Request<server_proto::ListFibRoutesRequest>,
     ) -> Result<Response<server_proto::ListFibRoutesResponse>, Status> {
+        let request = request.into_inner();
+        *self.state.last_list_fib.lock().await = Some(request.clone());
+        let routes = if request.peer_address.is_empty() {
+            Vec::new()
+        } else {
+            vec![server_proto::FibRouteStatus {
+                peer_address: canonical_ip_or_original(&request.peer_address),
+                ..Default::default()
+            }]
+        };
+        let total_count = routes.len() as u64;
         Ok(Response::new(server_proto::ListFibRoutesResponse {
-            routes: vec![],
+            routes,
             next_page_token: String::new(),
-            total_count: 0,
+            total_count,
         }))
     }
 
@@ -1547,7 +1581,8 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         &self,
         request: Request<server_proto::ListBgpLsRequest>,
     ) -> Result<Response<server_proto::ListBgpLsResponse>, Status> {
-        *self.state.last_list_bgpls.lock().await = Some(request.into_inner());
+        let request = request.into_inner();
+        *self.state.last_list_bgpls.lock().await = Some(request.clone());
         if let Some(canned) = self.state.list_bgpls_response.lock().await.clone() {
             return Ok(Response::new(canned));
         }
@@ -1561,7 +1596,11 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
                 payload: vec![0x01, 0x02, 0x03],
                 descriptor: vec![0x04, 0x05],
                 next_hop: "192.0.2.1".to_string(),
-                peer_address: "198.51.100.1".to_string(),
+                peer_address: if request.peer_filter.is_empty() {
+                    "198.51.100.1".to_string()
+                } else {
+                    canonical_ip_or_original(&request.peer_filter)
+                },
                 as_path: vec![64512],
                 communities: vec![],
                 extended_communities: vec![],
@@ -1577,7 +1616,8 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         &self,
         request: Request<server_proto::ListVpnRoutesRequest>,
     ) -> Result<Response<server_proto::ListVpnRoutesResponse>, Status> {
-        *self.state.last_list_vpn.lock().await = Some(request.into_inner());
+        let request = request.into_inner();
+        *self.state.last_list_vpn.lock().await = Some(request.clone());
         Ok(Response::new(server_proto::ListVpnRoutesResponse {
             routes: vec![server_proto::VpnRouteEntry {
                 afi_safi: "l3vpn_ipv4_unicast".to_string(),
@@ -1586,7 +1626,11 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
                 prefix: "10.1.0.0/24".to_string(),
                 labels: vec![24017],
                 next_hop: "192.0.2.1".to_string(),
-                peer_address: "198.51.100.1".to_string(),
+                peer_address: if request.peer_filter.is_empty() {
+                    "198.51.100.1".to_string()
+                } else {
+                    canonical_ip_or_original(&request.peer_filter)
+                },
                 as_path: vec![64512],
                 communities: vec![],
                 extended_communities: vec!["RT:65000:1".to_string()],
@@ -1601,14 +1645,19 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         &self,
         request: Request<server_proto::ListLabeledRoutesRequest>,
     ) -> Result<Response<server_proto::ListLabeledRoutesResponse>, Status> {
-        *self.state.last_list_labeled.lock().await = Some(request.into_inner());
+        let request = request.into_inner();
+        *self.state.last_list_labeled.lock().await = Some(request.clone());
         Ok(Response::new(server_proto::ListLabeledRoutesResponse {
             routes: vec![server_proto::LabeledRouteEntry {
                 afi_safi: "ipv4_labeled_unicast".to_string(),
                 prefix: "10.1.0.0/24".to_string(),
                 labels: vec![100],
                 next_hop: "192.0.2.1".to_string(),
-                peer_address: "198.51.100.1".to_string(),
+                peer_address: if request.peer_filter.is_empty() {
+                    "198.51.100.1".to_string()
+                } else {
+                    canonical_ip_or_original(&request.peer_filter)
+                },
                 as_path: vec![64512],
                 communities: vec![],
                 extended_communities: vec![],
@@ -1623,7 +1672,8 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         &self,
         request: Request<server_proto::ListRtcRoutesRequest>,
     ) -> Result<Response<server_proto::ListRtcRoutesResponse>, Status> {
-        *self.state.last_list_rtc.lock().await = Some(request.into_inner());
+        let request = request.into_inner();
+        *self.state.last_list_rtc.lock().await = Some(request.clone());
         Ok(Response::new(server_proto::ListRtcRoutesResponse {
             routes: vec![
                 server_proto::RtcRouteEntry {
@@ -1645,7 +1695,11 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
                     route_target: "RT:65001:100".to_string(),
                     prefix_len: 96,
                     next_hop: "192.0.2.1".to_string(),
-                    peer_address: "198.51.100.1".to_string(),
+                    peer_address: if request.peer_filter.is_empty() {
+                        "198.51.100.1".to_string()
+                    } else {
+                        canonical_ip_or_original(&request.peer_filter)
+                    },
                     as_path: vec![64512],
                     communities: vec![],
                     stale: false,
@@ -1766,13 +1820,21 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         &self,
         request: Request<server_proto::ListEvpnRequest>,
     ) -> Result<Response<server_proto::ListEvpnResponse>, Status> {
-        let filter = request.into_inner().route_type_filter;
+        let request = request.into_inner();
+        *self.state.last_list_evpn.lock().await = Some(request.clone());
+        let filter = request.route_type_filter;
         let mut routes = Vec::new();
         if filter == 0 || filter == 2 {
             routes.push(mock_evpn_route(2));
         }
         if filter == 0 || filter == 3 {
             routes.push(mock_evpn_route(3));
+        }
+        if !request.peer_filter.is_empty() {
+            let peer = canonical_ip_or_original(&request.peer_filter);
+            for route in &mut routes {
+                route.peer_address.clone_from(&peer);
+            }
         }
         Ok(Response::new(server_proto::ListEvpnResponse { routes }))
     }
@@ -2039,8 +2101,9 @@ impl rustbgpd_api::proto::policy_service_server::PolicyService for MockPolicySer
             .list_rejected_route_calls
             .fetch_add(1, Ordering::SeqCst);
         let req = request.into_inner();
+        *self.state.last_list_rejected.lock().await = Some(req.clone());
         Ok(Response::new(server_proto::ListRejectedRoutesResponse {
-            peer_address: req.peer_address,
+            peer_address: canonical_ip_or_original(&req.peer_address),
             retention_enabled: true,
             capacity: 1024,
             routes: Vec::new(),


### PR DESCRIPTION
## Summary

- normalize valid scoped IPv6 link-local peer filters across received, advertised, rejected, explain, FIB, BGP-LS, VPN, labeled-unicast, RTC, EVPN, and Adj-RIB-Out diff queries
- preserve malformed and non-link-local inputs unchanged through the shared guarded CLI seam
- restore the exact operator-provided scope only on semantically matching filtered output while keeping internal route/diff identity address-based
- reject conflicting scopes for repeated filters that canonicalize to the same link-local address instead of silently choosing one label
- add request-capture and human/JSON output isolation coverage for every command family

## Verification

- 17 focused scoped-query request/output tests
- cargo test -p rustbgpctl --bin rbgp
- cargo fmt --all -- --check
- cargo clippy -p rustbgpctl --all-targets -- -D warnings
- git diff --check

## Load-bearing regression proofs

- removing normalization from any query family leaves `%interface` in its address-only RPC request and turns its capture test red
- broad percent stripping fails the inherited malformed/non-link-local preservation matrix
- unconditional scope restoration relabels unrelated or unfiltered rows and turns isolation tests red
- removing the separate diff display map drops scope from human and JSON output while route comparison remains correct, turning both render proofs red
- removing the conflicting-scope guard makes the repeated-filter proof return success and silently assign the first scope to both filters