### PR TITLE
Harden rrtransport tiny startup observation

### DIFF
--- a/bench/scale/rrtransport/run-receipt.sh
+++ b/bench/scale/rrtransport/run-receipt.sh
@@ -63,6 +63,7 @@ child_identity() {
   read -r -a stat_fields <<<"$stat_line"
   (( ${#stat_fields[@]} >= 20 )) || return 1
   identity_ppid=${stat_fields[1]}
+  identity_pgrp=${stat_fields[2]}
   identity_starttime=${stat_fields[19]}
 }
 
@@ -223,6 +224,80 @@ launch_supervised() {
   pid=$!
 }
 
+validate_tiny_gate_identity() {
+  local supervisor=$1 expected=$2 ready_pid=$3 ready_exe=$4
+  local expected_exe actual_exe state start_before start_after pgrp_before pgrp_after rss
+  [[ $ready_pid =~ ^[0-9]+$ && $ready_pid == "$supervisor" ]] || return 1
+  kill -0 "$ready_pid" 2>/dev/null || return 1
+  state=$(awk '$1=="State:" {print substr($2,1,1)}' "/proc/$ready_pid/status" 2>/dev/null || true)
+  [[ -n $state && $state != X && $state != Z ]] || return 1
+  child_identity "$ready_pid" || return 1
+  start_before=$identity_starttime
+  pgrp_before=$identity_pgrp
+  expected_exe=$(readlink -f "$expected") || return 1
+  actual_exe=$(readlink -f "/proc/$ready_pid/exe") || return 1
+  rss=$(awk '/VmRSS:/ {print $2}' "/proc/$ready_pid/status") || return 1
+  [[ $rss =~ ^[0-9]+$ ]] || return 1
+  child_identity "$ready_pid" || return 1
+  start_after=$identity_starttime
+  pgrp_after=$identity_pgrp
+  [[ $ready_exe == "$expected_exe" && $actual_exe == "$expected_exe" &&
+    $start_before == "$start_after" && $pgrp_before == "$supervisor" &&
+    $pgrp_after == "$supervisor" ]] || return 1
+  tiny_validated_rss=$rss
+}
+
+await_tiny_startup_gate() {
+  local supervisor=$1 expected=$2 ready=$3 go=$4 receipt=$5
+  local state identity_status=0 rss go_tmp
+  local -a ready_fields=()
+  tiny_gate_reason=startup_timeout
+  tiny_gate_stop=true
+  for _ in {1..1000}; do
+    [[ -s $ready ]] && break
+    state=$(awk '$1=="State:" {print substr($2,1,1)}' \
+      "/proc/$supervisor/status" 2>/dev/null || true)
+    if [[ $state == X || $state == Z ]] || ! kill -0 "$supervisor" 2>/dev/null; then
+      tiny_gate_reason=pre_ready_exit
+      tiny_gate_stop=false
+      return 1
+    fi
+    sleep 0.01
+  done
+  [[ -s $ready ]] || return 1
+  mapfile -t ready_fields <"$ready"
+  if (( ${#ready_fields[@]} != 2 )); then
+    tiny_gate_reason=invalid_ready_record
+    return 1
+  fi
+  ready_pid=${ready_fields[0]}
+  ready_exe=${ready_fields[1]}
+  validate_tiny_gate_identity "$supervisor" "$expected" "$ready_pid" "$ready_exe" ||
+    identity_status=$?
+  if (( identity_status != 0 )); then
+    tiny_gate_reason=identity_rejected
+    return 1
+  fi
+  rss=$tiny_validated_rss
+  (( rss > max_rss )) && max_rss=$rss
+  printf 'sample\t%s\n' "$rss" >>"$receipt/rss.tsv"
+  if ! classify_rss "$rss" "$receipt"; then
+    tiny_gate_reason=rss_ceiling
+    return 1
+  fi
+  go_tmp="$go.tmp.$$"
+  printf 'go\n' >"$go_tmp"
+  mv "$go_tmp" "$go"
+  printf 'startup_gate resolution=release pid=%s process_group=%s initial_rss_kib=%s\n' \
+    "$ready_pid" "$supervisor" "$rss" >>"$receipt/harness.log"
+}
+
+gate_tiny_supervisor() {
+  tiny_gate_reason=gate_wait_failed
+  tiny_gate_stop=true
+  await_tiny_startup_gate "$pid" "$tiny_expected" "$tiny_ready" "$tiny_go" "$receipt"
+}
+
 stop_and_reap() {
   local stop=$1 reason=$2 state message
   if [[ $stop == true ]] && kill -0 "$pid" 2>/dev/null; then
@@ -245,10 +320,88 @@ stop_and_reap() {
   printf '%s\n' "$message" >>"$supervisor_log"
 }
 
+report_tiny_startup_failure() {
+  local receipt=$1 reason=$tiny_gate_reason
+  stop_and_reap "$tiny_gate_stop" "startup_gate_$reason"
+  printf 'startup_gate_failure reason=%s child_status=%s\n' \
+    "$reason" "$attempt_wait_status" | tee -a "$receipt/harness.log" >&2
+  cat "$receipt/harness.log" >&2
+  return 1
+}
+
 fail_supervised_attempt() {
   local reason=$1
   stop_and_reap true "$reason"
   return 1
+}
+
+startup_gate_fixture() {
+  local mode=$1 fixture_dir=$2 wrong_binary result group_pid live_members
+  rm -rf "$fixture_dir"
+  mkdir -p "$fixture_dir/receipt" "$fixture_dir/gate"
+  receipt=$fixture_dir/receipt
+  tiny_ready=$fixture_dir/gate/ready
+  tiny_go=$fixture_dir/gate/go
+  tiny_expected="$root/bench/scale/rrtransport/target/debug/rrtransport"
+  printf 'checkpoint\trss_kib\n' >"$receipt/rss.tsv"
+  max_rss=0
+  case $mode in
+    delayed-expected)
+      # Deliberately exceed the retired wait_exe one-second observation window.
+      # shellcheck disable=SC2016 # Expanded by the fixture's bash.
+      launch_supervised "$receipt/harness.log" env \
+        RRTRANSPORT_STARTUP_READY="$tiny_ready" RRTRANSPORT_STARTUP_GO="$tiny_go" \
+        bash -c 'sleep 1.2; exec "$1" rrtiny "$2"' bash "$tiny_expected" "$receipt"
+      printf '%s\n' "$pid" >"$fixture_dir/group.pid"
+      if ! gate_tiny_supervisor; then
+        report_tiny_startup_failure "$receipt" || true
+        return 1
+      fi
+      if wait "$pid"; then result=0; else result=$?; fi
+      pid=
+      [[ $result == 0 && -s $receipt/phase.json && -e $tiny_go ]]
+      ;;
+    stable-wrong)
+      wrong_binary=$fixture_dir/wrong-rrtransport
+      cp "$tiny_expected" "$wrong_binary"
+      chmod +x "$wrong_binary"
+      # shellcheck disable=SC2016 # Expanded by the fixture's bash.
+      launch_supervised "$receipt/harness.log" env \
+        RRTRANSPORT_STARTUP_READY="$tiny_ready" RRTRANSPORT_STARTUP_GO="$tiny_go" \
+        bash -c 'sleep 1.2; exec "$1" rrtiny "$2"' bash "$wrong_binary" "$receipt"
+      group_pid=$pid
+      printf '%s\n' "$group_pid" >"$fixture_dir/group.pid"
+      if gate_tiny_supervisor; then
+        stop_and_reap true false_green_wrong_executable
+        echo "stable wrong executable was released" >&2
+        return 1
+      fi
+      report_tiny_startup_failure "$receipt" || true
+      printf '%s\n' "$attempt_wait_status" >"$fixture_dir/child.status"
+      [[ $tiny_gate_reason == identity_rejected && ! -e $tiny_go && -z $pid ]]
+      live_members=$(ps -eo pgid=,stat= --no-headers |
+        awk -v group="$group_pid" '$1 == group && $2 !~ /^[XZ]/ {print}')
+      [[ -z $live_members ]]
+      ;;
+    pre-ready-exit)
+      launch_supervised "$receipt/harness.log" bash -c \
+        'sleep 0.05; printf "pre-ready fixture diagnostic\n"; exit 37'
+      printf '%s\n' "$pid" >"$fixture_dir/group.pid"
+      if gate_tiny_supervisor; then
+        stop_and_reap true false_green_pre_ready_exit
+        echo "pre-ready exit was released" >&2
+        return 1
+      fi
+      report_tiny_startup_failure "$receipt" || true
+      printf '%s\n' "$attempt_wait_status" >"$fixture_dir/child.status"
+      [[ $tiny_gate_reason == pre_ready_exit && $attempt_wait_status == 37 &&
+        ! -e $tiny_go && -z $pid ]]
+      ;;
+    *)
+      return 2
+      ;;
+  esac
+  printf '%s\tpass\n' "$mode"
 }
 
 sample_supervisor() {
@@ -513,6 +666,12 @@ case ${1:-} in
     stop_reap_fixture "$2" "$3" "$4"
     exit
     ;;
+  --startup-gate-fixture)
+    [[ $# == 3 ]] || exit 2
+    cargo build --manifest-path "$manifest" --locked
+    startup_gate_fixture "$2" "$3"
+    exit
+    ;;
   --verify-fixture)
     [[ $# == 3 ]] || exit 2
     rm -rf "$3"
@@ -531,9 +690,17 @@ case ${1:-} in
     mkdir -p "$receipt"
     tiny_binary="$root/bench/scale/rrtransport/target/debug/rrtransport"
     printf 'checkpoint\trss_kib\n' >"$receipt/rss.tsv"
-    setsid "$tiny_binary" rrtiny "$receipt" >"$receipt/harness.log" 2>&1 &
-    pid=$!; max_rss=0
-    wait_exe "$pid" "$tiny_binary"
+    tiny_ready=$receipt/.startup-ready
+    tiny_go=$receipt/.startup-go
+    tiny_expected=$tiny_binary
+    launch_supervised "$receipt/harness.log" env \
+      RRTRANSPORT_STARTUP_READY="$tiny_ready" RRTRANSPORT_STARTUP_GO="$tiny_go" \
+      "$tiny_binary" rrtiny "$receipt"
+    max_rss=0
+    if ! gate_tiny_supervisor; then
+      report_tiny_startup_failure "$receipt" || true
+      exit 1
+    fi
     while kill -0 "$pid" 2>/dev/null; do
       rss=$(awk '/VmRSS:/ {print $2}' "/proc/$pid/status" 2>/dev/null || echo 0)
       (( rss > max_rss )) && max_rss=$rss
@@ -548,6 +715,7 @@ case ${1:-} in
       exit 1
     fi
     pid=
+    rm -f "$tiny_ready" "$tiny_go"
     cp "$tiny_binary" "$receipt/rrtransport.bin"
     source_snapshot >"$receipt/source.snapshot"
     cp "$receipt/phase.json" "$receipt/phase.saved"

--- a/bench/scale/rrtransport/src/main.rs
+++ b/bench/scale/rrtransport/src/main.rs
@@ -1,6 +1,10 @@
 use std::collections::{BTreeSet, HashMap};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::path::Path;
 use std::sync::Arc;
+use std::thread;
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, ensure, Context, Result};
@@ -28,6 +32,59 @@ const PEERS: usize = 2;
 const PREFIXES: usize = 100;
 const SOURCES: usize = 4;
 const DEADLINE: Duration = Duration::from_secs(20);
+const STARTUP_GATE_TIMEOUT: Duration = Duration::from_secs(10);
+const STARTUP_READY_ENV: &str = "RRTRANSPORT_STARTUP_READY";
+const STARTUP_GO_ENV: &str = "RRTRANSPORT_STARTUP_GO";
+
+fn startup_gate_from_env() -> Result<()> {
+    let ready = std::env::var_os(STARTUP_READY_ENV);
+    let go = std::env::var_os(STARTUP_GO_ENV);
+    match (ready, go) {
+        (None, None) => Ok(()),
+        (Some(ready), Some(go)) => {
+            startup_gate(Path::new(&ready), Path::new(&go), STARTUP_GATE_TIMEOUT)
+        }
+        _ => bail!("{STARTUP_READY_ENV} and {STARTUP_GO_ENV} must be set together"),
+    }
+}
+
+fn startup_gate(ready: &Path, go: &Path, timeout: Duration) -> Result<()> {
+    let executable = std::env::current_exe()
+        .context("resolve rrtransport current executable")?
+        .canonicalize()
+        .context("canonicalize rrtransport current executable")?;
+    let pid = std::process::id();
+    let ready_tmp = ready.with_extension(format!("tmp.{pid}"));
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&ready_tmp)
+        .with_context(|| format!("create startup-ready temp file {}", ready_tmp.display()))?;
+    writeln!(file, "{pid}")?;
+    writeln!(file, "{}", executable.display())?;
+    file.sync_all()?;
+    drop(file);
+    if let Err(error) = fs::rename(&ready_tmp, ready) {
+        let _ = fs::remove_file(&ready_tmp);
+        return Err(error).context("publish startup-ready identity");
+    }
+
+    wait_for_startup_release(go, timeout)
+}
+
+fn wait_for_startup_release(go: &Path, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if go.try_exists().context("inspect startup release signal")? {
+            return Ok(());
+        }
+        ensure!(
+            Instant::now() < deadline,
+            "timed out waiting for rrtransport startup release"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
 
 #[derive(Default)]
 struct WireStats {
@@ -440,10 +497,61 @@ fn main() -> Result<()> {
             rr1000_support::runtime(12)?.block_on(rr1000::run(output, false))
         }
         [mode, output] if mode == "rrtiny" => {
+            startup_gate_from_env()?;
             rr1000_support::runtime(12)?.block_on(rr1000::run(output, true))
         }
         _ => bail!(
             "usage: rrtransport smoke | rrtransport rr1000 <output-dir> | rrtransport rrtiny <output-dir>"
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn startup_gate_blocks_until_parent_release() {
+        let directory = std::env::temp_dir().join(format!(
+            "rrtransport-startup-gate-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir(&directory).unwrap();
+        let ready = directory.join("ready");
+        let go = directory.join("go");
+        let ready_for_target = ready.clone();
+        let go_for_target = go.clone();
+        let target = thread::spawn(move || {
+            startup_gate(&ready_for_target, &go_for_target, STARTUP_GATE_TIMEOUT)
+        });
+
+        // Keep the parent's observation bound comfortably inside the target's
+        // release bound so a loaded runner cannot make both expire together.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !ready.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "target did not publish readiness"
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+        assert!(
+            !target.is_finished(),
+            "target advanced before the parent release"
+        );
+        let fields = fs::read_to_string(&ready).unwrap();
+        assert_eq!(fields.lines().count(), 2);
+        assert_eq!(
+            fields.lines().next().unwrap(),
+            std::process::id().to_string()
+        );
+
+        fs::write(&go, b"go\n").unwrap();
+        target.join().unwrap().unwrap();
+        fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/bench/tests/test-rrtransport-receipt.sh
+++ b/bench/tests/test-rrtransport-receipt.sh
@@ -6,6 +6,46 @@ runner="$root/bench/scale/rrtransport/run-receipt.sh"
 verifier="$root/bench/scale/rrtransport/verify_receipt.py"
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
+mutate() { python3 "$@"; }
+
+parent_validation_mutation_proof() {
+  local mutated="$tmp/no-parent-gate-validation"
+  local fixture_dir="$tmp/no-parent-validation-fixture"
+  local stdout="$tmp/no-parent-validation.stdout"
+  local stderr="$tmp/no-parent-validation.stderr"
+  local status
+  cp "$runner" "$mutated"
+  # Replace validation with a deliberate bypass that preserves the value its
+  # success path supplies. An unset-variable crash is not proof.
+  # shellcheck disable=SC2016 # Exact production source text for destructive proof.
+  mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1]);s=p.read_text();seam='\''  validate_tiny_gate_identity "$supervisor" "$expected" "$ready_pid" "$ready_exe" ||\n    identity_status=$?\n'\'';replacement='\''  tiny_validated_rss=1\n'\'';assert s.count(seam)==1;p.write_text(s.replace(seam,replacement,1))' \
+    "$mutated"
+  chmod +x "$mutated"
+  if "$mutated" --startup-gate-fixture stable-wrong "$fixture_dir" \
+    >"$stdout" 2>"$stderr"; then
+    echo "parent-validation bypass unexpectedly succeeded" >&2
+    return 1
+  else
+    status=$?
+  fi
+  if [[ $status != 1 ]] ||
+    ! grep -Fxq "stable wrong executable was released" "$stderr" ||
+    grep -Fq "unbound variable" "$stderr" ||
+    [[ ! -s $fixture_dir/gate/go || $(<"$fixture_dir/gate/go") != go ]] ||
+    ! grep -Fq "startup_gate resolution=release" "$fixture_dir/receipt/harness.log"; then
+    echo "parent-validation bypass failed without proving wrong-target release" >&2
+    cat "$stderr" >&2
+    return 1
+  fi
+  echo "PASS: parent-validation bypass released wrong target and published Go"
+}
+
+if [[ ${1:-} == --parent-validation-proof ]]; then
+  [[ $# == 1 ]] || exit 2
+  parent_validation_mutation_proof
+  exit
+fi
+
 fixture="$tmp/fixture"
 mkdir -p "$fixture"
 
@@ -45,7 +85,6 @@ expect_red() {
     exit 1
   fi
 }
-mutate() { python3 "$@"; }
 
 "$runner" --verify-fixture "$fixture" "$tmp/accepted"
 expect_red staged-count mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"per-peer.tsv";r=p.read_text().splitlines();h=r[0].split("\t").index("staged");x=r[1].split("\t");x[h]="99999";r[1]="\t".join(x);p.write_text("\n".join(r)+"\n")'
@@ -176,6 +215,35 @@ diagnostic_line=$(grep -nF "resolution=reject reason=foreign_executable" \
 after_line=$(grep -nF harness-after "$tmp/control-rejected/harness.log" | cut -d: -f1)
 (( before_line < diagnostic_line && diagnostic_line < after_line ))
 grep -Fq '"root_failure":"rss_ceiling"' "$tmp/control-rss/failure.json"
+
+"$runner" --startup-gate-fixture delayed-expected "$tmp/startup-delayed"
+grep -Fq "startup_gate resolution=release" "$tmp/startup-delayed/receipt/harness.log"
+[[ -s $tmp/startup-delayed/receipt/phase.json ]]
+"$runner" --startup-gate-fixture stable-wrong "$tmp/startup-wrong" \
+  2>"$tmp/startup-wrong.stderr"
+grep -Fq "startup_gate_failure reason=identity_rejected child_status=" \
+  "$tmp/startup-wrong.stderr"
+[[ ! -e $tmp/startup-wrong/gate/go ]]
+"$runner" --startup-gate-fixture pre-ready-exit "$tmp/startup-pre-exit" \
+  2>"$tmp/startup-pre-exit.stderr"
+grep -Fq "startup_gate_failure reason=pre_ready_exit child_status=37" \
+  "$tmp/startup-pre-exit.stderr"
+grep -Fq "pre-ready fixture diagnostic" "$tmp/startup-pre-exit.stderr"
+[[ $(<"$tmp/startup-pre-exit/child.status") == 37 ]]
+[[ ! -e $tmp/startup-pre-exit/gate/go ]]
+
+parent_validation_mutation_proof
+
+cp "$runner" "$tmp/legacy-wait-exe"
+# shellcheck disable=SC2016 # Exact production source text for destructive proof.
+mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1]);s=p.read_text();seam='\''  await_tiny_startup_gate "$pid" "$tiny_expected" "$tiny_ready" "$tiny_go" "$receipt"\n'\'';replacement='\''  wait_exe "$pid" "$tiny_expected"\n'\'';assert s.count(seam)==1;p.write_text(s.replace(seam,replacement,1))' \
+  "$tmp/legacy-wait-exe"
+chmod +x "$tmp/legacy-wait-exe"
+if "$tmp/legacy-wait-exe" --startup-gate-fixture delayed-expected \
+  "$tmp/legacy-wait-fixture" >"$tmp/legacy-wait.stdout" 2>"$tmp/legacy-wait.stderr"; then
+  echo "false green startup gate: legacy wait_exe polling" >&2
+  exit 1
+fi
 
 for seam in \
   "timeout -k 10 1200 \"\$script\" --campaign-inner \"\$output\"" \


### PR DESCRIPTION
## Summary

- replace the short-lived `rrtiny` `/proc/$pid/exe` polling race with a target-owned, bounded ready/go handshake
- atomically publish the target PID and canonical executable, then release it only after the parent validates live identity, stable start time, process-group ownership, and initial RSS
- fail closed and reap on pre-ready exit, wrong executable, timeout, or identity drift while leaving the full rr1000 sampler unchanged
- add lifecycle and destructive mechanics proofs for delayed startup, wrong targets, release ordering, diagnostics, and cleanup

## Why

The old one-second parent poll could miss a correct short-lived target under scheduler delay. The same exact-SHA CI attempt then passed on retry, proving an observation false negative rather than a product failure. Lengthening the sleep would retain the race; the handshake gives the target an explicit bounded observation point.

## Verification

- exact rrtransport mechanics suite
- standalone target blocking/release unit
- 2-peer × 100-route smoke
- 4-peer × 100-route real-smoke
- cargo fmt and strict standalone clippy
- bash syntax and ShellCheck
- workspace pre-push fmt, clippy, tests, and docs
- git diff --check

## Load-bearing regression proofs

- restoring the old `wait_exe` poll makes the delayed 1.2-second expected-target fixture fail
- removing target-side waiting makes the target advance before parent release and fails the focused unit
- bypassing parent validation releases the stable wrong target; the proof requires the exact diagnostic, published Go signal, release receipt, and expected status
- replaying the former unset-RSS crash is rejected explicitly, so a generic nonzero exit cannot satisfy the identity-guard proof

## Boundaries

This changes only the short `rrtiny` startup seam. `rr1000.rs`, the full campaign sampler, dependencies, measurement artifacts, benchmark headlines, and production daemon behavior are unchanged.