### PR TITLE
Make peer session alerts use current truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The shipped BGP session-down alert now uses exact current truth instead of
+  inferring state from historical counters. New
+  `bgp_peer_admin_enabled{peer,interface}` and
+  `bgp_peer_session_established{peer,interface}` gauges cover enabled peers
+  that never Established, preserve scoped link-local sibling identity, follow
+  collision ownership and administrative changes synchronously, and disappear
+  on peer deletion. Flap alerting remains counter-based.
+
 - Scoped IPv6 link-local neighbors now work with peer-group, policy-chain, and
   policy-inspection day-two CLI commands: valid `%interface` zones stay visible
   in operator output but are omitted from bare-address RPC fields.

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -197,6 +197,8 @@ pub struct BgpMetrics {
     state_transitions: IntCounterVec,
     session_flaps: IntCounterVec,
     session_established: IntCounterVec,
+    peer_admin_enabled: IntGaugeVec,
+    peer_session_established: IntGaugeVec,
     stale_timer_events: IntCounterVec,
 
     // ── BFD (RFC 5880, ADR-0067) ───────────────────────────────────
@@ -451,6 +453,24 @@ impl BgpMetrics {
                 "Total times a BGP session reached Established",
             ),
             &["peer"],
+        )
+        .expect("valid metric definition");
+
+        let peer_admin_enabled = IntGaugeVec::new(
+            Opts::new(
+                "bgp_peer_admin_enabled",
+                "Configured peer administrative intent (1 = enabled, 0 = disabled)",
+            ),
+            &["peer", "interface"],
+        )
+        .expect("valid metric definition");
+
+        let peer_session_established = IntGaugeVec::new(
+            Opts::new(
+                "bgp_peer_session_established",
+                "Active-primary BGP session state (1 = Established, 0 = not Established)",
+            ),
+            &["peer", "interface"],
         )
         .expect("valid metric definition");
 
@@ -1834,6 +1854,12 @@ impl BgpMetrics {
             .register(Box::new(session_established.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(peer_admin_enabled.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(peer_session_established.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(bfd_session_up.clone()))
             .expect("metric not already registered");
         registry
@@ -2301,6 +2327,8 @@ impl BgpMetrics {
             state_transitions,
             session_flaps,
             session_established,
+            peer_admin_enabled,
+            peer_session_established,
             stale_timer_events,
             bfd_session_up,
             bfd_session_flaps_total,
@@ -2484,6 +2512,8 @@ impl BgpMetrics {
         Self::reap_peer_series_from_vec(&self.state_transitions, peer);
         Self::reap_peer_series_from_vec(&self.session_flaps, peer);
         Self::reap_peer_series_from_vec(&self.session_established, peer);
+        Self::reap_peer_series_from_vec(&self.peer_admin_enabled, peer);
+        Self::reap_peer_series_from_vec(&self.peer_session_established, peer);
         Self::reap_peer_series_from_vec(&self.stale_timer_events, peer);
         Self::reap_peer_series_from_vec(&self.bfd_session_up, peer);
         Self::reap_peer_series_from_vec(&self.bfd_session_flaps_total, peer);
@@ -2539,6 +2569,16 @@ impl BgpMetrics {
         // lost, exactly as a bare `with_label_values` racing
         // `remove_label_values` could before the memo existed.
         POLICY_ROUTES_REAP_EPOCH.fetch_add(1, Ordering::Release);
+    }
+
+    /// Remove the exact configured-peer gauge identity.
+    ///
+    /// Unlike [`Self::reap_peer_series`], this preserves a scoped sibling
+    /// with the same link-local address on another interface.
+    pub fn reap_peer_identity_series(&self, peer: &str, interface: &str) {
+        let labels = &[peer, interface];
+        let _ = self.peer_admin_enabled.remove_label_values(labels);
+        let _ = self.peer_session_established.remove_label_values(labels);
     }
 
     /// Remove every series of one Vec metric whose `peer` label equals
@@ -2611,6 +2651,20 @@ impl BgpMetrics {
         if to == "established" {
             self.session_established.with_label_values(&[peer]).inc();
         }
+    }
+
+    /// Publish the authoritative configured administrative intent.
+    pub fn set_peer_admin_enabled(&self, peer: &str, interface: &str, enabled: bool) {
+        self.peer_admin_enabled
+            .with_label_values(&[peer, interface])
+            .set(i64::from(enabled));
+    }
+
+    /// Publish whether the active-primary session is Established.
+    pub fn set_peer_session_established(&self, peer: &str, interface: &str, established: bool) {
+        self.peer_session_established
+            .with_label_values(&[peer, interface])
+            .set(i64::from(established));
     }
 
     /// Set the gNMI dial-out connection gauge for a configured target.
@@ -4472,6 +4526,29 @@ mod tests {
     }
 
     #[test]
+    fn peer_truth_gauges_use_exact_identity_and_empty_unscoped_interface() {
+        let m = BgpMetrics::new();
+        m.set_peer_admin_enabled("192.0.2.1", "", true);
+        m.set_peer_session_established("192.0.2.1", "", false);
+        m.set_peer_admin_enabled("fe80::1", "eth0", true);
+        m.set_peer_session_established("fe80::1", "eth0", true);
+        m.set_peer_admin_enabled("fe80::1", "eth1", false);
+        m.set_peer_session_established("fe80::1", "eth1", false);
+
+        let text = gather_text(&m);
+        assert!(text.contains(r#"bgp_peer_admin_enabled{interface="",peer="192.0.2.1"} 1"#));
+        assert!(text.contains(r#"bgp_peer_session_established{interface="",peer="192.0.2.1"} 0"#));
+        assert!(
+            text.contains(r#"bgp_peer_session_established{interface="eth0",peer="fe80::1"} 1"#)
+        );
+
+        m.reap_peer_identity_series("fe80::1", "eth0");
+        let text = gather_text(&m);
+        assert!(!text.contains(r#"interface="eth0",peer="fe80::1""#));
+        assert!(text.contains(r#"interface="eth1",peer="fe80::1""#));
+    }
+
+    #[test]
     fn exact_export_rejections_use_bounded_labels_and_are_peer_reaped() {
         use crate::reason_labels::ExactExportReason;
 
@@ -5873,6 +5950,8 @@ mod tests {
         // state_transitions + session_flaps + session_established
         m.record_state_transition(peer, "open_confirm", "established");
         m.record_state_transition(peer, "established", "idle");
+        m.set_peer_admin_enabled(peer, "", true);
+        m.set_peer_session_established(peer, "", false);
         m.record_stale_timer_event(peer, "idle", "hold");
         m.record_bfd_state(peer, true, false);
         m.record_bfd_state(peer, false, true); // bfd flap counter
@@ -5954,8 +6033,8 @@ mod tests {
         let m = BgpMetrics::new();
         populate_all_peer_families(&m, "10.0.0.1");
         populate_all_peer_families(&m, "10.0.0.2");
-        // 50 peer-labeled families; state transitions hold two series.
-        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 50);
+        // 52 peer-labeled series; state transitions hold two series.
+        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 52);
 
         m.reap_peer_series("10.0.0.1");
 
@@ -5965,7 +6044,7 @@ mod tests {
             "peer-labeled families not reaped: {leftovers:?}"
         );
         // The other peer's series are untouched.
-        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 50);
+        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 52);
     }
 
     /// Load-bearing finite/unlimited proof: removing either finite gauge
@@ -6209,7 +6288,7 @@ mod tests {
     // `gather()`, so no runtime check can catch one that is added and
     // left unpopulated; this list plus the struct doc comment is the
     // practical ceiling.
-    const PEER_LABELED_FAMILIES: [&str; 49] = [
+    const PEER_LABELED_FAMILIES: [&str; 51] = [
         "bfd_session_flaps_total",
         "bfd_session_up",
         "bgp_as_path_loop_detected_total",
@@ -6236,7 +6315,9 @@ mod tests {
         "bgp_outbound_prefix_limit",
         "bgp_outbound_prefix_usage",
         "bgp_outbound_route_drops_total",
+        "bgp_peer_admin_enabled",
         "bgp_peer_outbound_queue_depth",
+        "bgp_peer_session_established",
         "bgp_peer_slow",
         "bgp_peer_update_group",
         "bgp_policy_routes_total",

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -1540,7 +1540,13 @@ impl PeerSession {
                 ControlFlow::Continue(())
             }
             PeerCommand::ActivateMaxPrefixMetrics { reply } => {
+                // The legacy command name predates current-session truth.
+                // Collision promotion activates every metric lease owned only
+                // by the active primary, not just max-prefix capacity.
                 self.max_prefix_metric_lease.active = true;
+                self.session_established_metric_lease.active = true;
+                self.session_established_metric_lease
+                    .set(self.fsm.state() == SessionState::Established);
                 self.sync_max_prefix_capacity_metrics();
                 let _ = reply.send(());
                 ControlFlow::Continue(())

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -292,6 +292,10 @@ impl PeerSession {
                     self.close_tcp();
                 }
                 Action::StateChanged { old, new } => {
+                    if old == SessionState::Established || new == SessionState::Established {
+                        self.session_established_metric_lease
+                            .set(new == SessionState::Established);
+                    }
                     info!(
                         peer = %self.peer_label,
                         from = old.as_str(),

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -92,6 +92,47 @@ impl Drop for MaxPrefixMetricLease {
     }
 }
 
+/// Ownership guard for the current-session truth gauge.
+///
+/// Collision candidates remain inactive until the manager has quiesced the
+/// retiring primary. Dropping an active owner publishes a final zero but keeps
+/// the configured identity present; peer deletion is reaped by `PeerManager`.
+struct SessionEstablishedMetricLease {
+    metrics: BgpMetrics,
+    peer: String,
+    interface: String,
+    active: bool,
+    published: bool,
+}
+
+impl SessionEstablishedMetricLease {
+    fn new(metrics: BgpMetrics, peer: String, interface: String, active: bool) -> Self {
+        Self {
+            metrics,
+            peer,
+            interface,
+            active,
+            published: false,
+        }
+    }
+
+    fn set(&mut self, established: bool) {
+        if self.active {
+            self.metrics
+                .set_peer_session_established(&self.peer, &self.interface, established);
+            self.published = true;
+        }
+    }
+}
+
+impl Drop for SessionEstablishedMetricLease {
+    fn drop(&mut self) {
+        if self.published {
+            self.set(false);
+        }
+    }
+}
+
 /// Runtime for a single BGP peer session.
 ///
 /// Owns the FSM, TCP stream, timers, and read buffer. Runs as a single
@@ -245,6 +286,8 @@ pub(crate) struct PeerSession {
     /// quiesced the old primary, preventing either loser from erasing the
     /// surviving actor's values.
     max_prefix_metric_lease: MaxPrefixMetricLease,
+    /// Active-primary ownership for `bgp_peer_session_established`.
+    session_established_metric_lease: SessionEstablishedMetricLease,
     /// Optional BMP event sender (None when BMP not configured).
     bmp_tx: Option<mpsc::Sender<BmpEvent>>,
     /// A `RouteMonitoring` event for this session was dropped on a full
@@ -1023,6 +1066,12 @@ impl PeerSession {
             peer_label.clone(),
             session_identity.role == SessionRole::Primary,
         );
+        let session_established_metric_lease = SessionEstablishedMetricLease::new(
+            metrics.clone(),
+            peer_label.clone(),
+            config.peer_interface.clone().unwrap_or_default(),
+            session_identity.role == SessionRole::Primary,
+        );
         let export_encoder = Arc::new(SessionExportEncoder::new(SessionExportProfile::initial(
             &config,
             None,
@@ -1064,6 +1113,7 @@ impl PeerSession {
             session_event_tx,
             session_identity,
             max_prefix_metric_lease,
+            session_established_metric_lease,
             bmp_tx,
             bmp_stream_diverged: false,
             bmp_repair_timer: None,
@@ -1172,6 +1222,12 @@ impl PeerSession {
             peer_label.clone(),
             session_identity.role == SessionRole::Primary,
         );
+        let session_established_metric_lease = SessionEstablishedMetricLease::new(
+            metrics.clone(),
+            peer_label.clone(),
+            config.peer_interface.clone().unwrap_or_default(),
+            session_identity.role == SessionRole::Primary,
+        );
         let export_encoder = Arc::new(SessionExportEncoder::new(SessionExportProfile::initial(
             &config,
             stream.local_addr().ok().map(|addr| addr.ip()),
@@ -1225,6 +1281,7 @@ impl PeerSession {
             session_event_tx,
             session_identity,
             max_prefix_metric_lease,
+            session_established_metric_lease,
             bmp_tx,
             bmp_stream_diverged: false,
             bmp_repair_timer: None,

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -707,6 +707,27 @@ fn max_prefix_gauge(metrics: &BgpMetrics, name: &str, peer: &str, scope: &str) -
         })
 }
 
+fn peer_truth_gauge(metrics: &BgpMetrics, name: &str, peer: &str, interface: &str) -> Option<f64> {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == name)
+        .and_then(|family| {
+            family.get_metric().iter().find_map(|metric| {
+                let has_peer = metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "peer" && label.value() == peer);
+                let has_interface = metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "interface" && label.value() == interface);
+                (has_peer && has_interface).then(|| metric.get_gauge().value())
+            })
+        })
+}
+
 fn assert_max_prefix_gauge(session: &PeerSession, name: &str, scope: &str, expected: Option<f64>) {
     assert_eq!(
         max_prefix_gauge(&session.metrics, name, &session.peer_label, scope),
@@ -12611,6 +12632,15 @@ async fn collision_candidate_cannot_overwrite_or_reap_primary_capacity_metrics()
     primary
         .process_update(ipv4_announce(v4_prefix(2), 0, false))
         .await;
+    assert_eq!(
+        peer_truth_gauge(
+            &primary.metrics,
+            "bgp_peer_session_established",
+            &primary.peer_label,
+            ""
+        ),
+        Some(1.0)
+    );
 
     let (candidate_client, _candidate_server) = connected_stream_pair().await;
     candidate.test_install_stream(candidate_client);
@@ -12620,9 +12650,29 @@ async fn collision_candidate_cannot_overwrite_or_reap_primary_capacity_metrics()
         .process_update(ipv4_announce(v4_prefix(3), 0, false))
         .await;
     assert_max_prefix_gauge(&primary, "bgp_max_prefix_usage", "aggregate", Some(2.0));
+    assert_eq!(
+        peer_truth_gauge(
+            &primary.metrics,
+            "bgp_peer_session_established",
+            &primary.peer_label,
+            ""
+        ),
+        Some(1.0),
+        "inactive candidate must not overwrite active-primary truth"
+    );
 
     drop(candidate);
     assert_max_prefix_gauge(&primary, "bgp_max_prefix_usage", "aggregate", Some(2.0));
+    assert_eq!(
+        peer_truth_gauge(
+            &primary.metrics,
+            "bgp_peer_session_established",
+            &primary.peer_label,
+            ""
+        ),
+        Some(1.0),
+        "dropping an inactive candidate must not zero active-primary truth"
+    );
 }
 
 /// Load-bearing promoted-actor proof: removing either the activation command's
@@ -12657,6 +12707,16 @@ async fn promoted_collision_candidate_publishes_after_old_primary_quiesces() {
 
     drop(primary);
     assert_max_prefix_gauge(&candidate, "bgp_max_prefix_usage", "aggregate", None);
+    assert_eq!(
+        peer_truth_gauge(
+            &candidate.metrics,
+            "bgp_peer_session_established",
+            &candidate.peer_label,
+            ""
+        ),
+        Some(0.0),
+        "retiring primary must publish zero before ownership transfer"
+    );
     let (reply, done) = oneshot::channel();
     assert_eq!(
         candidate
@@ -12665,6 +12725,16 @@ async fn promoted_collision_candidate_publishes_after_old_primary_quiesces() {
         ControlFlow::Continue(())
     );
     done.await.unwrap();
+    assert_eq!(
+        peer_truth_gauge(
+            &candidate.metrics,
+            "bgp_peer_session_established",
+            &candidate.peer_label,
+            ""
+        ),
+        Some(1.0),
+        "promotion must synchronously publish the candidate FSM snapshot"
+    );
     assert_max_prefix_gauge(&candidate, "bgp_max_prefix_usage", "aggregate", Some(1.0));
     assert_max_prefix_gauge(
         &candidate,

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -46,7 +46,8 @@ Template variables:
 - **Instance** — Prometheus `instance` label, populated from
   `bgp_rib_outbound_registered_peers` (always exported, even at zero).
 - **Peer** (`$peer`) — the `peer` label, populated from
-  `bgp_session_state_transitions_total`. Every exported metric family
+  `bgp_peer_admin_enabled`, so configured peers appear even before their first
+  FSM transition. Every exported metric family
   identifies a peer the same way, by its bare neighbor address
   (`192.0.2.1`, `2001:db8::1`), so one selector drives every per-peer panel
   and `by (peer)` joins across families match. Supports multiple values
@@ -73,6 +74,13 @@ with per-rule unit tests in
 
 - Counters are plotted with `rate(...[$__rate_interval])`; gauges are
   plotted raw. Single-stats use last-not-null.
+- **Peer administrative / session truth** plots
+  `bgp_peer_admin_enabled{peer,interface}` and
+  `bgp_peer_session_established{peer,interface}` as 0/1 steps. Its interface
+  legends distinguish scoped link-local siblings; unscoped peers carry an
+  empty `interface`. The shipped session-down alert joins these exact labels,
+  so enabled peers that never Established are visible while disabled peers do
+  not page.
 - Exact-export rejection and malformed-UPDATE disposition rates share the
   `$peer` selector, like every other per-peer panel.
   The selection-deferral state panel renders
@@ -108,9 +116,9 @@ with per-rule unit tests in
   boot; rejected reloads also leave the last accepted timestamp unchanged.
 - "Peers registered for distribution" is
   `bgp_rib_outbound_registered_peers` — the closest exported gauge to
-  "currently Established peers". The daemon does not export a per-peer
-  session-state gauge; state history is available via
-  `bgp_session_state_transitions_total`.
+  the distribution-plane count. Current configured-peer health is the
+  administrative/session truth panel above; state history remains available
+  via `bgp_session_state_transitions_total`.
 - Panels for optional subsystems (BFD, BMP, RPKI/ASPA, update groups,
   event outbox, graceful restart) stay empty until the corresponding
   feature is configured; vector metrics only emit series once a label

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -643,9 +643,10 @@ Every `peer`-labeled series — session, RIB, policy, max-prefix, BFD, BMP —
 identifies the peer the same way: by its bare neighbor address, `192.0.2.1`
 or `2001:db8::1`, never the transport endpoint's `addr:port`. `sum by (peer)`
 therefore returns one series per peer, and a `by (peer)` join across any two
-families matches. Neighbor identity is unique by address (config validation
-rejects the same IPv6 link-local address on two interfaces), so no peer needs
-the port to be told apart.
+families matches. The current administrative and session-state gauges add the
+configured `interface` (empty for unscoped peers), so exact
+`on (instance, peer, interface)` joins distinguish the same IPv6 link-local
+address configured on multiple interfaces.
 
 ### Per-peer series lifecycle
 
@@ -664,19 +665,29 @@ dashboards see no negative-rate artifacts. Process-global counters and
 families keyed by other identities (AFI/SAFI, VRF, VNI, BMP collector) are
 never removed.
 
+The exact `bgp_peer_admin_enabled{peer,interface}` and
+`bgp_peer_session_established{peer,interface}` identity is removed after its
+session actor terminates, including abort-on-timeout teardown. If a scoped
+sibling shares the bare address, its exact gauge rows and the shared
+bare-address history remain.
+
 ### Health
 
 | Metric | What it tells you |
 |--------|-------------------|
+| `bgp_peer_admin_enabled{peer,interface}` | Authoritative configured administrative intent: 1 enabled, 0 disabled |
+| `bgp_peer_session_established{peer,interface}` | Current active-primary session truth: 1 Established, 0 otherwise |
 | `bgp_session_established_total` | Cumulative sessions that reached Established (per-process counter; resets on restart) |
 | `bgp_session_flaps_total` | Cumulative session flaps |
 | `bgp_session_state_transitions_total` | FSM state transitions |
 
-The current count of Established peers and daemon uptime are read via
-`ControlService.GetHealth` / `rbgp health` (and `GetMetrics`), not a
-Prometheus gauge. `GetHealth` uses the same 200 ms core-actor deadline as
-`/readyz`, but returns peer and route counts and therefore remains an
-authenticated sensitive-read surface.
+The shipped `BgpSessionNotEstablished` alert requires administrative intent 1
+and Established state 0 for the same `(instance, peer, interface)` for two
+minutes. It therefore covers never-established and previously-down peers
+without paging on disabled peers. Flap-rate alerting remains based on
+`bgp_session_flaps_total`. Aggregate Established counts and daemon uptime are
+also available via `ControlService.GetHealth` / `rbgp health`; that RPC uses
+the same 200 ms core-actor deadline as `/readyz`.
 
 ### Routing
 

--- a/docs/grafana/rustbgpd-overview.json
+++ b/docs/grafana/rustbgpd-overview.json
@@ -51,7 +51,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "query": "label_values(bgp_session_state_transitions_total{instance=~\"$instance\"}, peer)",
+        "query": "label_values(bgp_peer_admin_enabled{instance=~\"$instance\"}, peer)",
         "current": {},
         "includeAll": true,
         "multi": true,
@@ -440,7 +440,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 5
       },
@@ -499,8 +499,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 5
       },
       "fieldConfig": {
@@ -535,6 +535,69 @@
           "expr": "sum by (peer, to) (rate(bgp_session_state_transitions_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
           "legendFormat": "{{peer}} \u2192 {{to}}",
           "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 61,
+      "type": "timeseries",
+      "title": "Peer administrative / session truth",
+      "description": "Exact configured identity truth: administrative intent and active-primary Established state. Interface is empty for unscoped peers.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bgp_peer_admin_enabled{instance=~\"$instance\",peer=~\"$peer\"}",
+          "legendFormat": "admin {{peer}} {{interface}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bgp_peer_session_established{instance=~\"$instance\",peer=~\"$peer\"}",
+          "legendFormat": "session {{peer}} {{interface}}",
+          "refId": "B"
         }
       ]
     },

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -10,11 +10,11 @@
 # from docs/GRAFANA.md (`job_name: rustbgpd`) — adjust the `job` label
 # in RustbgpdDown if yours differs.
 #
-# The daemon does not export a per-peer session-state gauge; session
-# health is derived from the counter pair
-# `bgp_session_established_total` / `bgp_session_flaps_total`
-# (entering Established increments the former, leaving it increments
-# the latter, so an Established peer always reads established = flaps + 1).
+# Current peer health uses the level gauges
+# `bgp_peer_admin_enabled{peer,interface}` and
+# `bgp_peer_session_established{peer,interface}`. The historical
+# `bgp_session_established_total` / `bgp_session_flaps_total` counters remain
+# available for churn and flap-rate analysis.
 # Every `peer` label is the bare neighbor address ("192.0.2.1",
 # "2001:db8::1") in every metric family, so `by (peer)` aggregations and
 # joins across families work without rewriting the label.
@@ -37,21 +37,23 @@ groups:
             unreachable, or `prometheus_addr` is no longer configured.
 
       - alert: BgpSessionNotEstablished
-        # A peer that has left Established and not returned reads
-        # flaps >= established (an Established peer reads
-        # established = flaps + 1). A peer that has never reached
-        # Established since daemon start has neither series and cannot
-        # fire — pair with RustbgpdDown and BgpPeerAdjRibInEmpty.
-        expr: bgp_session_flaps_total >= bgp_session_established_total
+        # Exact configured identity join: catches enabled peers that have never
+        # Established as well as peers that established previously and went
+        # down. Disabled peers and a healthy scoped sibling do not match.
+        expr: >-
+          bgp_peer_admin_enabled == 1
+          and on (instance, peer, interface)
+          bgp_peer_session_established == 0
         for: 2m
         labels:
           severity: critical
         annotations:
           summary: "BGP session to {{ $labels.peer }} not Established"
           description: >-
-            The BGP session to peer {{ $labels.peer }} on
-            {{ $labels.instance }} left Established more than 2 minutes
-            ago and has not re-established.
+            The administratively enabled BGP session to peer
+            {{ $labels.peer }} on interface "{{ $labels.interface }}" at
+            {{ $labels.instance }} has not been Established for more than
+            2 minutes.
 
       - alert: BgpSessionFlapping
         expr: increase(bgp_session_flaps_total[15m]) > 5

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -50,6 +50,10 @@ tests:
   # 192.0.2.4 — Established with prefixes (healthy)
   - interval: 1m
     input_series:
+      - series: 'bgp_peer_admin_enabled{peer="192.0.2.1", interface="", instance="edge1:9179"}'
+        values: "1x30"
+      - series: 'bgp_peer_session_established{peer="192.0.2.1", interface="", instance="edge1:9179"}'
+        values: "0x30"
       - series: 'bgp_session_flaps_total{peer="192.0.2.1", instance="edge1:9179"}'
         values: "1x30"
       - series: 'bgp_session_established_total{peer="192.0.2.1", instance="edge1:9179"}'
@@ -91,9 +95,9 @@ tests:
             exp_annotations:
               summary: "BGP session to 192.0.2.1 not Established"
               description: >-
-                The BGP session to peer 192.0.2.1 on edge1:9179 left
-                Established more than 2 minutes ago and has not
-                re-established.
+                The administratively enabled BGP session to peer
+                192.0.2.1 on interface "" at edge1:9179 has not been
+                Established for more than 2 minutes.
       # Only the churning peer trips the 15-minute flap threshold.
       - eval_time: 16m
         alertname: BgpSessionFlapping
@@ -138,6 +142,88 @@ tests:
                 The session to 2001:db8::2 on edge1:9179 is Established
                 but its Adj-RIB-In has held zero prefixes for 10
                 minutes.
+
+  # Current-truth matrix for BgpSessionNotEstablished. Historical counters
+  # cannot suppress or fabricate the level alert, and interface identity keeps
+  # scoped siblings independent.
+  - interval: 1m
+    input_series:
+      # Enabled and never Established.
+      - series: 'bgp_peer_admin_enabled{peer="192.0.2.10", interface="", instance="edge1:9179"}'
+        values: "1x6"
+      - series: 'bgp_peer_session_established{peer="192.0.2.10", interface="", instance="edge1:9179"}'
+        values: "0x6"
+      # Established previously, now down.
+      - series: 'bgp_peer_admin_enabled{peer="192.0.2.11", interface="", instance="edge1:9179"}'
+        values: "1x6"
+      - series: 'bgp_peer_session_established{peer="192.0.2.11", interface="", instance="edge1:9179"}'
+        values: "0x6"
+      - series: 'bgp_session_established_total{peer="192.0.2.11", instance="edge1:9179"}'
+        values: "1x6"
+      - series: 'bgp_session_flaps_total{peer="192.0.2.11", instance="edge1:9179"}'
+        values: "1x6"
+      # Administratively disabled.
+      - series: 'bgp_peer_admin_enabled{peer="192.0.2.12", interface="", instance="edge1:9179"}'
+        values: "0x6"
+      - series: 'bgp_peer_session_established{peer="192.0.2.12", interface="", instance="edge1:9179"}'
+        values: "0x6"
+      # Healthy Established.
+      - series: 'bgp_peer_admin_enabled{peer="192.0.2.13", interface="", instance="edge1:9179"}'
+        values: "1x6"
+      - series: 'bgp_peer_session_established{peer="192.0.2.13", interface="", instance="edge1:9179"}'
+        values: "1x6"
+      # Recovers before the 2-minute hold expires.
+      - series: 'bgp_peer_admin_enabled{peer="192.0.2.14", interface="", instance="edge1:9179"}'
+        values: "1x6"
+      - series: 'bgp_peer_session_established{peer="192.0.2.14", interface="", instance="edge1:9179"}'
+        values: "0 0 1x4"
+      # Same link-local address on two interfaces: only eth0 is down.
+      - series: 'bgp_peer_admin_enabled{peer="fe80::1", interface="eth0", instance="edge1:9179"}'
+        values: "1x6"
+      - series: 'bgp_peer_session_established{peer="fe80::1", interface="eth0", instance="edge1:9179"}'
+        values: "0x6"
+      - series: 'bgp_peer_admin_enabled{peer="fe80::1", interface="eth1", instance="edge1:9179"}'
+        values: "1x6"
+      - series: 'bgp_peer_session_established{peer="fe80::1", interface="eth1", instance="edge1:9179"}'
+        values: "1x6"
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: BgpSessionNotEstablished
+        exp_alerts: []
+      - eval_time: 3m
+        alertname: BgpSessionNotEstablished
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              peer: 192.0.2.10
+              instance: edge1:9179
+            exp_annotations:
+              summary: "BGP session to 192.0.2.10 not Established"
+              description: >-
+                The administratively enabled BGP session to peer
+                192.0.2.10 on interface "" at edge1:9179 has not been
+                Established for more than 2 minutes.
+          - exp_labels:
+              severity: critical
+              peer: 192.0.2.11
+              instance: edge1:9179
+            exp_annotations:
+              summary: "BGP session to 192.0.2.11 not Established"
+              description: >-
+                The administratively enabled BGP session to peer
+                192.0.2.11 on interface "" at edge1:9179 has not been
+                Established for more than 2 minutes.
+          - exp_labels:
+              severity: critical
+              peer: fe80::1
+              interface: eth0
+              instance: edge1:9179
+            exp_annotations:
+              summary: "BGP session to fe80::1 not Established"
+              description: >-
+                The administratively enabled BGP session to peer
+                fe80::1 on interface "eth0" at edge1:9179 has not been
+                Established for more than 2 minutes.
 
   # ── BgpMaxPrefixLimitExceeded ─────────────────────────────────
   - interval: 1m

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -15,10 +15,16 @@ DASHBOARD = ROOT / "docs/grafana/rustbgpd-overview.json"
 WORKFLOW = ROOT / ".github/workflows/alert-rules.yml"
 
 VARIABLES = {
-    "peer": 'label_values(bgp_session_state_transitions_total{instance=~"$instance"}, peer)',
+    "peer": 'label_values(bgp_peer_admin_enabled{instance=~"$instance"}, peer)',
 }
 
 TARGETS = {
+    ("Peer administrative / session truth", "A"): (
+        'bgp_peer_admin_enabled{instance=~"$instance",peer=~"$peer"}'
+    ),
+    ("Peer administrative / session truth", "B"): (
+        'bgp_peer_session_established{instance=~"$instance",peer=~"$peer"}'
+    ),
     ("Outbound queue by peer", "A"): (
         'bgp_peer_outbound_queue_depth{instance=~"$instance",peer=~"$peer"}'
     ),
@@ -85,6 +91,8 @@ TARGETS = {
 }
 
 ROUTE_SAFETY_LEGENDS = {
+    ("Peer administrative / session truth", "A"): "admin {{peer}} {{interface}}",
+    ("Peer administrative / session truth", "B"): "session {{peer}} {{interface}}",
     ("Export rejections / malformed UPDATEs", "A"): (
         "exact {{instance}} {{peer}} {{family}} {{reason}}"
     ),
@@ -238,6 +246,25 @@ def main() -> None:
         fail("slow-peer state must be pinned to the discrete 0..1 range")
     if slow_defaults.get("custom", {}).get("lineInterpolation") != "stepAfter":
         fail("slow-peer state must use step interpolation")
+
+    truth_panel = next(
+        panel
+        for panel in panels
+        if panel.get("title") == "Peer administrative / session truth"
+    )
+    if truth_panel.get("type") != "timeseries":
+        fail("peer administrative/session truth must use a timeseries panel")
+    if truth_panel.get("gridPos") != {"h": 8, "w": 8, "x": 16, "y": 5}:
+        fail("peer administrative/session truth must remain compact in Session health")
+    truth_defaults = truth_panel.get("fieldConfig", {}).get("defaults", {})
+    if (
+        truth_defaults.get("decimals") != 0
+        or truth_defaults.get("min") != 0
+        or truth_defaults.get("max") != 1
+    ):
+        fail("peer administrative/session truth must be pinned to whole 0..1 values")
+    if truth_defaults.get("custom", {}).get("lineInterpolation") != "stepAfter":
+        fail("peer administrative/session truth must use step interpolation")
 
     route_safety_row = next(
         (panel for panel in panels if panel.get("title") == "Route safety"), None

--- a/src/peer_manager/dynamic.rs
+++ b/src/peer_manager/dynamic.rs
@@ -435,21 +435,15 @@ impl PeerManager {
                     )
                     .await;
             }
-            let shutdown = self
+            let _ = self
                 .shutdown_handle_bounded(
                     peer_key.address,
                     "dynamic rollback primary",
                     managed.handle,
                 )
                 .await;
-            if shutdown.joined() {
-                self.reap_deleted_peer_metric_series(peer_key.address).await;
-            } else {
-                warn!(
-                    peer = %peer_key,
-                    "skipping dynamic-peer metric reap because session shutdown did not join before the deadline"
-                );
-            }
+            self.reap_deleted_peer_metric_series_for_key(&peer_key)
+                .await;
             self.dynamic_peer_count = self.dynamic_peer_count.saturating_sub(1);
             removed += 1;
             info!(

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -487,20 +487,18 @@ impl PeerManager {
                     accepted_generation,
                 );
 
-                if let Err(e) = handle.start_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT).await {
-                    warn!(%peer_addr, error = %e, "failed to start dynamic peer session");
-                    // The session task was already spawned; the handle is never
-                    // stored, so shut it down (abort-on-timeout) rather than
-                    // dropping it and orphaning a wedged task.
-                    let _ = self
-                        .shutdown_handle_bounded(
-                            peer_addr.ip(),
-                            "dynamic peer start failure",
-                            handle,
-                        )
-                        .await;
+                let Ok(handle) = self
+                    .provision_new_peer_session(
+                        &dynamic_peer_key,
+                        true,
+                        true,
+                        handle,
+                        "dynamic peer start failure",
+                    )
+                    .await
+                else {
                     return;
-                }
+                };
 
                 let managed = ManagedPeer {
                     handle,
@@ -537,6 +535,7 @@ impl PeerManager {
                 let peer_key = dynamic_peer_key;
                 self.peers.insert(peer_key.clone(), managed);
                 self.register_session(session_id, &peer_key);
+                self.sync_owned_session_metrics(&peer_key).await;
                 self.dynamic_peer_count += 1;
                 // ADR-0112: the accepted child carries the range's pinned
                 // external classification and its resolved chains.

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -35,6 +35,65 @@ async fn send_max_prefix_start_before(
 }
 
 impl PeerManager {
+    pub(super) fn publish_peer_admin_enabled_metric(&self, peer: &PeerKey, enabled: bool) {
+        self.metrics.set_peer_admin_enabled(
+            &rustbgpd_telemetry::peer_label(peer.address),
+            peer.interface.as_deref().unwrap_or(""),
+            enabled,
+        );
+    }
+
+    pub(super) fn seed_peer_truth_metrics(&self, peer: &PeerKey, enabled: bool) {
+        let peer_label = rustbgpd_telemetry::peer_label(peer.address);
+        let interface = peer.interface.as_deref().unwrap_or("");
+        self.metrics
+            .set_peer_admin_enabled(&peer_label, interface, enabled);
+        self.metrics
+            .set_peer_session_established(&peer_label, interface, false);
+    }
+
+    pub(super) async fn provision_new_peer_session(
+        &self,
+        peer: &PeerKey,
+        enabled: bool,
+        should_start: bool,
+        handle: PeerHandle,
+        context: &'static str,
+    ) -> Result<PeerHandle, PeerCommandError> {
+        self.seed_peer_truth_metrics(peer, enabled);
+        if should_start
+            && let Err(error) = handle.start_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT).await
+        {
+            warn!(peer = %peer, %error, %context, "failed to start new peer session");
+            let _ = self
+                .shutdown_handle_bounded(peer.address, context, handle)
+                .await;
+            self.metrics.reap_peer_identity_series(
+                &rustbgpd_telemetry::peer_label(peer.address),
+                peer.interface.as_deref().unwrap_or(""),
+            );
+            return Err(error);
+        }
+        Ok(handle)
+    }
+
+    pub(super) async fn sync_owned_session_metrics(&self, peer: &PeerKey) {
+        let Some(managed) = self.peers.get(peer) else {
+            return;
+        };
+        if let Err(error) = managed
+            .handle
+            .activate_max_prefix_metrics_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT)
+            .await
+        {
+            warn!(
+                peer = %peer,
+                %error,
+                "failed to synchronize newly owned session metrics"
+            );
+        }
+    }
+
     fn allocate_max_prefix_latch_generation(&mut self) -> u64 {
         let generation = self.next_max_prefix_latch_generation;
         self.next_max_prefix_latch_generation =
@@ -231,6 +290,7 @@ impl PeerManager {
                 if let Some(managed) = self.peers.get_mut(&peer) {
                     managed.enabled = true;
                 }
+                self.publish_peer_admin_enabled_metric(&peer, true);
                 let _ = self.max_prefix_latches.remove(&peer);
                 self.set_bfd_peer_disabled(address, false);
                 self.mark_bfd_withheld(address);
@@ -266,6 +326,7 @@ impl PeerManager {
                     if let Some(managed) = self.peers.get_mut(&peer) {
                         managed.enabled = true;
                     }
+                    self.publish_peer_admin_enabled_metric(&peer, true);
                     let _ = self.max_prefix_latches.remove(&peer);
                     self.set_bfd_peer_disabled(address, false);
                     self.publish_peer_lifecycle_event(
@@ -539,15 +600,18 @@ impl PeerManager {
         // BFD actor confirms the current permitted state through a resync ack
         // or a fresh transition.
         let withhold = enabled && self.bfd_should_withhold(&address);
-        if enabled
-            && !withhold
-            && let Err(e) = handle.start_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT).await
-        {
-            warn!(%address, error = %e, "failed to start peer session");
-            return Err(PeerLifecycleError::Internal(format!(
-                "failed to start peer: {e}"
-            )));
-        }
+        let handle = self
+            .provision_new_peer_session(
+                &peer_key,
+                enabled,
+                enabled && !withhold,
+                handle,
+                "static peer start failure",
+            )
+            .await
+            .map_err(|error| {
+                PeerLifecycleError::Internal(format!("failed to start peer: {error}"))
+            })?;
 
         info!(%address, %remote_asn, "peer added dynamically");
         let tcp_ao_protected = transport.tcp_ao.is_some();
@@ -586,6 +650,7 @@ impl PeerManager {
             },
         );
         self.register_session(session_id, &peer_key);
+        self.sync_owned_session_metrics(&peer_key).await;
 
         if let Some(next_config) = next_config {
             self.current_config = next_config;
@@ -1247,6 +1312,7 @@ impl PeerManager {
             info!(%address, "peer deleted");
         }
 
+        let peer_for_reap = peer.clone();
         if sync_config_snapshot {
             apply_config_event(
                 &mut self.current_config,
@@ -1260,15 +1326,12 @@ impl PeerManager {
 
         // Operator rule: reap per-peer runtime/state metrics for
         // *deleted* peers only — never on a session flap (the session
-        // task records its final transitions before the shutdown join
-        // above, so this runs after the last transport-side emission).
-        if reap_metric_series && shutdown.joined() {
-            self.reap_deleted_peer_metric_series(address).await;
-        } else if reap_metric_series {
-            warn!(
-                %address,
-                "skipping deleted-peer metric reap because session shutdown did not join before the deadline"
-            );
+        // task records its final transitions before bounded shutdown
+        // joins or aborts-and-awaits it, so this runs after the last
+        // transport-side emission).
+        if reap_metric_series {
+            self.reap_deleted_peer_metric_series_for_key(&peer_for_reap)
+                .await;
         }
         Ok(removed_config)
     }
@@ -1278,14 +1341,18 @@ impl PeerManager {
     /// Every emission site — transport session, RIB manager, BFD
     /// runtime — labels `peer` with the canonical bare address, so one
     /// reap covers them all. Call only after the peer has been removed
-    /// from `self.peers` and its session task joined.
-    pub(super) async fn reap_deleted_peer_metric_series(&self, address: std::net::IpAddr) {
+    /// from `self.peers` and its session task joined or was aborted and
+    /// awaited by bounded shutdown.
+    pub(super) async fn reap_deleted_peer_metric_series_for_key(&self, peer: &PeerKey) {
+        let address = peer.address;
+        let peer_label = rustbgpd_telemetry::peer_label(address);
+        self.metrics
+            .reap_peer_identity_series(&peer_label, peer.interface.as_deref().unwrap_or(""));
         // The label can be shared with a surviving peer (the same
         // link-local address on another interface) — leave it alone
         // unless this peer was the last user of the address.
         if self.peer_keys_for_address(address).is_empty() {
-            self.metrics
-                .reap_peer_series(&rustbgpd_telemetry::peer_label(address));
+            self.metrics.reap_peer_series(&peer_label);
             // The RIB manager emits bare-address series from its own
             // task; this marker is queued behind the session's final
             // `PeerDown`, so the RIB manager reaps again *after* its
@@ -1319,6 +1386,7 @@ impl PeerManager {
         // Clear the manager-owned error only after the session accepted Start,
         // so a failed command cannot accidentally reopen passive acceptance.
         managed.enabled = true;
+        self.publish_peer_admin_enabled_metric(&peer, true);
         self.remove_max_prefix_latch(&peer);
         self.publish_peer_lifecycle_event(
             &peer,
@@ -1352,6 +1420,7 @@ impl PeerManager {
             managed.enabled = false;
             managed.pending_inbound.take()
         };
+        self.publish_peer_admin_enabled_metric(&peer, false);
         if let Some(pending) = pending {
             let _ = self
                 .quiesce_retiring_session(

--- a/src/peer_manager/notifications.rs
+++ b/src/peer_manager/notifications.rs
@@ -207,7 +207,7 @@ impl PeerManager {
                                 )
                                 .await;
                         }
-                        let shutdown = self
+                        let _ = self
                             .quiesce_retiring_session(
                                 &peer_key,
                                 primary_session_id,
@@ -243,19 +243,14 @@ impl PeerManager {
                             managed.enabled = false;
                             self.peers.insert(peer_key.clone(), managed);
                             self.register_session(session_id, &peer_key);
+                            self.seed_peer_truth_metrics(&peer_key, false);
                             info!(%peer_addr, "retained dynamic peer disabled after terminal max-prefix signal during retirement");
                         } else {
                             // Auto-removal is authoritative when no terminal
                             // breach was discovered during the join barrier.
                             self.dynamic_peer_count = self.dynamic_peer_count.saturating_sub(1);
-                            if shutdown.joined() {
-                                self.reap_deleted_peer_metric_series(peer_addr).await;
-                            } else {
-                                info!(
-                                    %peer_addr,
-                                    "skipping dynamic-peer metric reap because session shutdown did not join before the deadline"
-                                );
-                            }
+                            self.reap_deleted_peer_metric_series_for_key(&peer_key)
+                                .await;
                         }
                     }
                     // Skip pending inbound logic for removed dynamic peers
@@ -341,6 +336,9 @@ impl PeerManager {
                                 managed.max_prefix_restart_seconds,
                             )
                         });
+                if self.peers.contains_key(&peer_key) {
+                    self.publish_peer_admin_enabled_metric(&peer_key, false);
+                }
                 let installed = self.install_max_prefix_latch(
                     peer_key.clone(),
                     session_id,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -6,7 +6,9 @@ use rustbgpd_api::peer_types::{
 };
 use rustbgpd_fsm::SessionState;
 use rustbgpd_transport::handle::MaxPrefixState;
-use rustbgpd_transport::{PeerSessionState, TcpAoRotationStatus, WarmCheckpointSessionState};
+use rustbgpd_transport::{
+    PeerCommand, PeerSessionState, TcpAoRotationStatus, WarmCheckpointSessionState,
+};
 use rustbgpd_wire::{
     Capability, Message, OpenMessage, decode_message, encode_message, peek_message_length,
 };
@@ -6312,6 +6314,10 @@ async fn remote_wins_collision_preserves_old_primary_terminal_breach() {
     assert!(mgr.retiring_sessions.is_empty());
     assert!(mgr.peer_key_for_session(1).is_none());
     assert_eq!(mgr.peer_key_for_session(2), Some(key(addr)));
+    assert_eq!(
+        peer_identity_gauge(&mgr.metrics, "bgp_peer_admin_enabled", "10.0.0.41", ""),
+        Some(0.0)
+    );
 }
 
 /// Load-bearing Idle replacement proof: the old primary emits max-prefix only
@@ -6691,14 +6697,13 @@ async fn session_event_history_records_events_without_subscriber() {
     assert_eq!(events[0].event_type, SessionLifecycleEventType::PeerEnabled);
 }
 
-/// LAN-668 production incarnation proof: successful configured-peer installs
-/// publish their current admin state only after installation. Removing the
-/// add-path publication leaves the old `PeerDisabled` as the newest retained
-/// intent after delete/re-add and makes doctor's paired regression red.
+/// Successful configured-peer installs publish their current admin event only
+/// after installation; failed duplicate adds must not fabricate one.
 #[tokio::test]
 async fn peer_add_and_readd_publish_current_admin_state_without_failed_add_noise() {
     let mut mgr = test_peer_manager();
     let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let metrics = mgr.metrics.clone();
     let admin_types = [
         SessionLifecycleEventType::PeerEnabled,
         SessionLifecycleEventType::PeerDisabled,
@@ -6707,10 +6712,15 @@ async fn peer_add_and_readd_publish_current_admin_state_without_failed_add_noise
     .collect();
 
     mgr.add_peer(make_config(addr, 65002), false).await.unwrap();
-    assert!(
-        mgr.add_peer(make_config(addr, 65002), false).await.is_err(),
-        "a failed duplicate add must not fabricate an admin event"
+    assert_eq!(
+        peer_identity_gauge(&metrics, "bgp_peer_admin_enabled", "10.0.0.2", ""),
+        Some(1.0)
     );
+    assert_eq!(
+        peer_identity_gauge(&metrics, "bgp_peer_session_established", "10.0.0.2", ""),
+        Some(0.0)
+    );
+    assert!(mgr.add_peer(make_config(addr, 65002), false).await.is_err());
     mgr.disable_peer(key(addr), None).await.unwrap();
     mgr.delete_peer(key(addr), false).await.unwrap();
     mgr.add_peer(make_config(addr, 65002), false).await.unwrap();
@@ -6719,24 +6729,20 @@ async fn peer_add_and_readd_publish_current_admin_state_without_failed_add_noise
         .await
         .unwrap();
 
-    let peers = mgr.list_peers().await;
-    assert_eq!(peers.len(), 1);
-    assert!(!peers[0].enabled);
     let events = query_session_event_history(&mgr, Some(addr), admin_types, 0).await;
-    let event_types: Vec<_> = events.iter().map(|event| event.event_type).collect();
     assert_eq!(
-        event_types,
+        events
+            .iter()
+            .map(|event| event.event_type)
+            .collect::<Vec<_>>(),
         vec![
             SessionLifecycleEventType::PeerEnabled,
             SessionLifecycleEventType::PeerDisabled,
             SessionLifecycleEventType::PeerEnabled,
             SessionLifecycleEventType::PeerDisabled,
-        ],
-        "add, disable, enabled re-add, and disabled re-add must expose exact current intent"
+        ]
     );
-    assert!(events[0].reason.contains("added administratively enabled"));
-    assert!(events[2].reason.contains("added administratively enabled"));
-    assert!(events[3].reason.contains("added administratively disabled"));
+    assert!(!mgr.list_peers().await[0].enabled);
 }
 
 #[tokio::test]
@@ -7017,10 +7023,203 @@ fn peer_metric_series_count(metrics: &BgpMetrics, peer: &str) -> usize {
         .count()
 }
 
+fn peer_identity_gauge(
+    metrics: &BgpMetrics,
+    family_name: &str,
+    peer: &str,
+    interface: &str,
+) -> Option<f64> {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == family_name)
+        .and_then(|family| {
+            family.get_metric().iter().find_map(|metric| {
+                let has_peer = metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "peer" && label.value() == peer);
+                let has_interface = metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "interface" && label.value() == interface);
+                (has_peer && has_interface).then(|| metric.get_gauge().value())
+            })
+        })
+}
+
+fn blocked_truth_observing_start_handle(
+    metrics: BgpMetrics,
+    peer: PeerKey,
+) -> (PeerHandle, Arc<Notify>, oneshot::Receiver<()>) {
+    let (commands, mut command_rx) = mpsc::channel(1);
+    commands.try_send(PeerCommand::Start).unwrap();
+    let gate = Arc::new(Notify::new());
+    let task_gate = gate.clone();
+    let (observed_tx, observed_rx) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        task_gate.notified().await;
+        let _filler = command_rx.recv().await;
+        assert!(matches!(command_rx.recv().await, Some(PeerCommand::Start)));
+        let label = rustbgpd_telemetry::peer_label(peer.address);
+        let interface = peer.interface.as_deref().unwrap_or("");
+        assert_eq!(
+            peer_identity_gauge(&metrics, "bgp_peer_admin_enabled", &label, interface),
+            Some(1.0)
+        );
+        assert_eq!(
+            peer_identity_gauge(&metrics, "bgp_peer_session_established", &label, interface),
+            Some(0.0)
+        );
+        metrics.set_peer_session_established(&label, interface, true);
+        let _ = observed_tx.send(());
+        while let Some(command) = command_rx.recv().await {
+            if matches!(command, PeerCommand::Shutdown) {
+                break;
+            }
+        }
+        Ok(())
+    });
+    (PeerHandle::from_parts(commands, task), gate, observed_rx)
+}
+
+async fn assert_new_peer_start_truth_is_seeded(peer: PeerKey) {
+    let mgr = test_peer_manager();
+    let metrics = mgr.metrics.clone();
+    let label = rustbgpd_telemetry::peer_label(peer.address);
+    let interface = peer.interface.as_deref().unwrap_or("");
+    let (handle, gate, observed) =
+        blocked_truth_observing_start_handle(metrics.clone(), peer.clone());
+    let provision = mgr.provision_new_peer_session(&peer, true, true, handle, "test start");
+    tokio::pin!(provision);
+    tokio::select! {
+        biased;
+        _ = &mut provision => panic!("Start unexpectedly advanced through a full channel"),
+        () = tokio::task::yield_now() => {}
+    }
+    assert_eq!(
+        peer_identity_gauge(&metrics, "bgp_peer_admin_enabled", &label, interface),
+        Some(1.0)
+    );
+    assert_eq!(
+        peer_identity_gauge(&metrics, "bgp_peer_session_established", &label, interface),
+        Some(0.0)
+    );
+    gate.notify_one();
+    let handle = provision.await.unwrap();
+    observed.await.unwrap();
+    assert_eq!(
+        peer_identity_gauge(&metrics, "bgp_peer_session_established", &label, interface),
+        Some(1.0),
+        "ownership preparation must never overwrite a post-Start state"
+    );
+    handle.shutdown().await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn new_peer_provisioning_seeds_truth_before_start_and_never_post_zeros() {
+    assert_new_peer_start_truth_is_seeded(key("192.0.2.10".parse().unwrap())).await;
+}
+
+#[test]
+fn static_add_routes_start_through_truth_provisioning_before_install() {
+    let source = include_str!("lifecycle.rs");
+    let body = source
+        .split_once("pub(super) async fn add_peer_with_admin_state")
+        .unwrap()
+        .1
+        .split_once("pub(super) async fn reconfigure_peer")
+        .unwrap()
+        .0;
+    assert_eq!(body.matches(".provision_new_peer_session(").count(), 1);
+    assert!(
+        body.find(".provision_new_peer_session(").unwrap()
+            < body.find("self.peers.insert(").unwrap()
+    );
+    assert!(!body.contains("seed_peer_truth_metrics"));
+}
+
+#[test]
+fn fresh_dynamic_accept_routes_start_through_truth_provisioning_before_install() {
+    let source = include_str!("inbound.rs");
+    let body = source
+        .split_once("pub(super) async fn handle_inbound")
+        .unwrap()
+        .1
+        .split_once("pub(super) async fn resolve_collision")
+        .unwrap()
+        .0;
+    assert_eq!(body.matches(".provision_new_peer_session(").count(), 1);
+    assert!(
+        body.find(".provision_new_peer_session(").unwrap()
+            < body.find("self.peers.insert(").unwrap()
+    );
+    assert!(!body.contains("seed_peer_truth_metrics"));
+}
+
+#[tokio::test(start_paused = true)]
+async fn failed_start_exact_reaps_provisional_truth_and_preserves_scoped_sibling() {
+    let mgr = test_peer_manager();
+    let metrics = mgr.metrics.clone();
+    let address = "fe80::1".parse().unwrap();
+    let failed = scoped_key(address, "eth0");
+    let dropped = Arc::new(AtomicU32::new(0));
+    mgr.seed_peer_truth_metrics(&scoped_key(address, "eth1"), false);
+
+    assert!(
+        mgr.provision_new_peer_session(
+            &failed,
+            true,
+            true,
+            stalled_shutdown_peer_handle(dropped.clone()).await,
+            "test failed start"
+        )
+        .await
+        .is_err()
+    );
+    assert_eq!(
+        dropped.load(Ordering::SeqCst),
+        1,
+        "failed provisioning must quiesce the provisional actor before returning"
+    );
+    for family in ["bgp_peer_admin_enabled", "bgp_peer_session_established"] {
+        assert_eq!(
+            peer_identity_gauge(&metrics, family, "fe80::1", "eth0"),
+            None
+        );
+        assert_eq!(
+            peer_identity_gauge(&metrics, family, "fe80::1", "eth1"),
+            Some(0.0)
+        );
+    }
+
+    let source = include_str!("lifecycle.rs");
+    let body = source
+        .split_once("pub(super) async fn provision_new_peer_session")
+        .unwrap()
+        .1
+        .split_once("pub(super) async fn sync_owned_session_metrics")
+        .unwrap()
+        .0;
+    assert_eq!(body.matches(".shutdown_handle_bounded(").count(), 1);
+    assert_eq!(body.matches(".reap_peer_identity_series(").count(), 1);
+    assert!(
+        body.find(".shutdown_handle_bounded(").unwrap()
+            < body.find(".reap_peer_identity_series(").unwrap(),
+        "failed provisioning must quiesce the actor before reaping its identity series"
+    );
+}
+
 /// Seed per-peer series across the emitters that own them — session,
 /// RIB, BFD — all under the one canonical bare-address `peer` label.
 fn seed_peer_metric_series(metrics: &BgpMetrics, peer_label: &str) {
+    metrics.initialize_exact_export_rejection_series(peer_label, ["ipv4_unicast"]);
+    metrics.initialize_update_malformed_series(peer_label);
+    metrics.record_state_transition(peer_label, "idle", "connect");
     metrics.record_state_transition(peer_label, "open_confirm", "established");
+    metrics.set_peer_admin_enabled(peer_label, "", true);
+    metrics.set_peer_session_established(peer_label, "", true);
     metrics.record_message_sent(peer_label, "keepalive");
     metrics.set_rib_prefixes(peer_label, "ipv4_unicast", 42);
     metrics.record_bfd_state(peer_label, true, false);
@@ -7074,6 +7273,63 @@ async fn delete_peer_reaps_metric_series() {
     // The ordered RIB-side reap marker was queued.
     let update = rib_rx.try_recv().expect("PeerDeleted queued for the RIB");
     assert!(matches!(update, RibUpdate::PeerDeleted { peer } if peer == peer_addr));
+}
+
+#[tokio::test(start_paused = true)]
+async fn timed_out_dynamic_rollback_exact_reaps_and_preserves_scoped_sibling() {
+    let mut mgr = dynamic_test_manager();
+    mgr.dynamic_ranges.clear();
+    let metrics = mgr.metrics.clone();
+    let address = "fe80::1".parse().unwrap();
+    let stale = scoped_key(address, "eth0");
+    let sibling = scoped_key(address, "eth1");
+    let dropped = Arc::new(AtomicU32::new(0));
+    insert_test_dynamic_managed_peer(
+        &mut mgr,
+        address,
+        89,
+        stalled_shutdown_peer_handle(dropped.clone()).await,
+        true,
+        "2001:db8::".parse().unwrap(),
+        64,
+        "ix-members",
+    );
+    let managed = mgr.peers.remove(&key(address)).unwrap();
+    mgr.unregister_session(89);
+    mgr.peers.insert(stale.clone(), managed);
+    mgr.register_session(89, &stale);
+    mgr.seed_peer_truth_metrics(&stale, true);
+
+    let mut sibling_config = make_config(address, 65002);
+    sibling_config.interface = Some("eth1".to_string());
+    sibling_config.scope_id = Some(2);
+    mgr.add_peer_with_admin_state(sibling_config, false, false)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        mgr.reap_dynamic_peers_not_allowed_by_current_ranges().await,
+        1
+    );
+    assert_eq!(dropped.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        peer_identity_gauge(&metrics, "bgp_peer_session_established", "fe80::1", "eth0"),
+        None
+    );
+    assert_eq!(
+        peer_identity_gauge(&metrics, "bgp_peer_admin_enabled", "fe80::1", "eth0"),
+        None
+    );
+    assert_eq!(
+        peer_identity_gauge(&metrics, "bgp_peer_admin_enabled", "fe80::1", "eth1"),
+        Some(0.0)
+    );
+    assert_eq!(
+        peer_identity_gauge(&metrics, "bgp_peer_session_established", "fe80::1", "eth1"),
+        Some(0.0)
+    );
+    assert!(mgr.peers.contains_key(&sibling));
+    mgr.delete_peer(sibling, false).await.unwrap();
 }
 
 #[tokio::test]
@@ -18339,6 +18595,10 @@ async fn strict_disable_drain_reenable_does_not_leak_bgp_before_fresh_up() {
         "strict re-enable after a local drain must withhold until fresh BFD Up"
     );
     mgr.enable_peer(key(peer)).await.unwrap();
+    assert_eq!(
+        peer_identity_gauge(&mgr.metrics, "bgp_peer_admin_enabled", "10.0.0.2", ""),
+        Some(1.0)
+    );
     assert_eq!(
         counters.start.load(Ordering::SeqCst),
         1,


### PR DESCRIPTION
## Summary

Replace the shipped session-down alert's historical-counter inference with exact current peer truth. This covers enabled peers that have never established, suppresses deliberately disabled peers, and keeps scoped link-local siblings distinct.

## Changes

- export bounded `bgp_peer_admin_enabled{peer,interface}` and `bgp_peer_session_established{peer,interface}` gauges
- transfer Established ownership only across the active primary session and collision promotion boundary
- seed truth before new sessions can start, reconcile after installation, and reap provisional/deleted identities after actor termination
- make dynamic rollback exact for timed-out and scoped sessions
- update the Prometheus alert pack, Grafana peer selector/current-state panel, operator docs, and release notes
- add deterministic startup, failed-start, collision, timeout, scoped-sibling, alert, and dashboard regression proofs

## Testing

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Relevant interop test run (not applicable: no BGP wire/protocol behavior changes; Prometheus and dashboard fixtures pass)
- [x] Performance-affecting changes have a pinned A/B receipt plus a machine-readable summary indexed from `docs/RECEIPTS.md`, or this item is intentionally not applicable (not performance-affecting)
- [x] PeerManager: 279/279
- [x] Telemetry: 85/85
- [x] Transport: 464 passed, 3 ignored, plus focused lifecycle/listener suites
- [x] Promtool 3.4.1: 17 rules and rule-test matrix
- [x] Grafana checker: 61 panels and 19 operator targets

## Load-bearing proofs

- moving truth seeding after `Start` makes the blocked-start ordering proof red
- bypassing either static or fresh-dynamic provisioning makes its call-site fence red
- removing bounded failed-start shutdown leaves the live actor undropped and fails the cleanup proof
- removing exact provisional cleanup leaves the failed interface's truth series present
- removing timeout rollback cleanup leaves both truth series present
- replacing exact scoped cleanup with bare-peer cleanup removes the surviving sibling and fails

## Docs / release notes

- [x] CHANGELOG.md updated
- [x] ROADMAP.md intentionally not needed
- [x] User/operator docs updated
- [x] Hot tracking docs not touched

## Related issues

Linear: LAN-715
