### PR TITLE
Expose policy and outbound capacity safety state

### DIFF
--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -61,9 +61,9 @@ the next scrape.
 A ready-to-load Prometheus alert-rule pack (session down/flapping,
 empty Adj-RIB-In, max-prefix near-limit and breach, empty RPKI VRP table, event-outbox
 degradation, update-group residue growth, stalled policy transition, a slow
-peer, actor polls above 200ms, exact-export rejection, malformed
-UPDATE disposition, selection-deferral timeout and ledger overflow, and daemon
-down) ships at
+peer, RFC 8212 missing import/export policy, sustained outbound-prefix blocking,
+actor polls above 200ms, exact-export rejection, malformed UPDATE disposition,
+selection-deferral timeout and ledger overflow, and daemon down) ships at
 [`examples/prometheus/rustbgpd-alerts.yml`](../examples/prometheus/rustbgpd-alerts.yml),
 with per-rule unit tests in
 [`rustbgpd-alerts_test.yml`](../examples/prometheus/rustbgpd-alerts_test.yml)
@@ -98,6 +98,13 @@ with per-rule unit tests in
   are intentionally absent for unlimited scopes, and every capacity series is
   absent while the session is down; no-data is therefore distinct from zero
   headroom.
+- **RFC 8212 missing policy** plots both raw directional gauges as 0/1 steps.
+  Both zero-valued series exist for every configured peer even when enforcement
+  is off, and are reaped only when the peer is removed.
+- **Outbound prefix capacity** keeps raw peer/family usage, finite limit,
+  headroom, and blocking state together. Only query D (`blocking`) uses the
+  stepped 0..1 right axis; the cumulative `blocked_total` event counter is
+  intentionally excluded.
 - Outbound queue depth is an absolute gauge of coalesced UPDATE frames, sampled
   at enqueue-batch and writer-drain boundaries. A short convergence spike is
   not itself a slow peer; `bgp_peer_slow` is the daemon's persistent 0/1 state.
@@ -153,12 +160,19 @@ label; changing either raw selection gauge to a rate; removing step
 rendering; dropping `instance` from a route-safety aggregation; weakening any of the six
 label-rich legends; dropping any seeded-series `> 0` filter; or replacing the
 executable workflow step with only a comment.
+It also pins capacity panel IDs 62/63 and their 12-by-8 layout, the six exact
+raw queries and legends, RFC 8212 0/1 mappings and steps, and the query-D-only
+right-axis override.
 
 The slow-peer fixture is red if its `== 1` predicate or five-minute hold is
-changed. The actor fixture is red if `ignoring(le)` is removed, `le="0.2"` is
-moved to `0.5`, `> 0` becomes `>= 0`, raw counters replace `increase`, or
-`job`/`poll_kind` are aggregated away. Its firing observation is in
-`(0.2, 0.5]`; exact-boundary and historical-flat controls remain healthy.
+changed. The RFC 8212 matrix covers import-only, export-only, and healthy peers;
+the outbound-prefix matrix covers sustained, zero, and transient blocking.
+All three new warnings are pending at 4m30s and firing at 5m30s, pinning their
+predicate and five-minute hold. The actor fixture is red if `ignoring(le)` is
+removed, `le="0.2"` is moved to `0.5`, `> 0` becomes `>= 0`, raw counters
+replace `increase`, or `job`/`poll_kind` are aggregated away. Its firing
+observation is in `(0.2, 0.5]`; exact-boundary and historical-flat controls
+remain healthy.
 Each route-safety counter fixture is red if its alert is deleted, its window is
 shortened from 15 to 5 minutes, `increase` becomes a raw counter, or `> 0`
 becomes `> 1`. Malformed UPDATE fixtures cover all three bounded RFC 7606

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -780,25 +780,29 @@ stuck or daemon rejecting everything" pager.
 
 ### RFC 8212 explicit-policy enforcement
 
-Present only when `[global] ebgp_requires_policy = true` (ADR-0112). Both
-gauges are 0/1 and read from the chain each peer currently has installed, so
-they cannot disagree with the `RFC 8212 Policy` block in `rbgp neighbor <addr>`
-or with the `rbgp doctor` verdict. Series are reaped when the peer is removed.
+Both 0/1 gauges exist for every configured peer, including zero-valued series
+while `[global] ebgp_requires_policy = false` (ADR-0112). They are read from the
+chain each peer currently has installed, so they cannot disagree with the
+`RFC 8212 Policy` block in `rbgp neighbor <addr>` or with the `rbgp doctor`
+verdict. Series are reaped when the peer is removed.
 
 | Metric | What it tells you |
 |--------|-------------------|
-| `bgp_rfc8212_missing_import_policy{peer}` | 1 when this external session has no explicit operator import policy, so the reserved internal deny is installed and no route it announces becomes eligible, in any negotiated family. 0 for iBGP and while enforcement is off |
-| `bgp_rfc8212_missing_export_policy{peer}` | 1 when this external session has no explicit operator export policy, so nothing enters its Adj-RIB-Out in any negotiated family |
+| `bgp_rfc8212_missing_import_policy{peer}` | 1 when this external session has no explicit operator import policy, so the reserved internal deny is installed and no route it announces becomes eligible, in any negotiated family. 0 otherwise, including for iBGP and while enforcement is off |
+| `bgp_rfc8212_missing_export_policy{peer}` | 1 when this external session has no explicit operator export policy, so nothing enters its Adj-RIB-Out in any negotiated family. 0 otherwise, including for iBGP and while enforcement is off |
 
 ```promql
-# Any eBGP peer fail-closed on a missing operator policy.
-max by (peer) (
-  bgp_rfc8212_missing_import_policy or bgp_rfc8212_missing_export_policy
-) > 0
+# Any peer fail-closed on a missing operator policy in either direction.
+(bgp_rfc8212_missing_import_policy
+ + bgp_rfc8212_missing_export_policy) > 0
 ```
 
-Alert on this rather than on readiness: `/readyz` stays green for a healthy
-daemon whose reserved deny is doing exactly what it was configured to do.
+PromQL's bare `or` is a left-biased set union, not a boolean OR of sample
+values; because both directional series have the same labels, it would hide an
+export value of 1 behind an import value of 0. The shipped directional warnings
+use `== 1` with a five-minute hold. Alert on those rather than on readiness:
+`/readyz` stays green for a healthy daemon whose reserved deny is doing exactly
+what it was configured to do.
 
 ### Ingress rejection / route-leak detection
 

--- a/docs/grafana/rustbgpd-overview.json
+++ b/docs/grafana/rustbgpd-overview.json
@@ -2684,6 +2684,96 @@
           "refId": "B"
         }
       ]
+    },
+    {
+      "id": 62,
+      "type": "timeseries",
+      "title": "RFC 8212 missing policy",
+      "description": "Raw configured-peer state by direction. Zero-valued series remain present while enforcement is off; 1 means the reserved fail-closed policy is installed for that direction.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 161 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "max": 1,
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "not missing", "color": "green" },
+                "1": { "text": "missing", "color": "red" }
+              }
+            }
+          ],
+          "custom": { "lineInterpolation": "stepAfter" }
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_rfc8212_missing_import_policy{instance=~\"$instance\",peer=~\"$peer\"}",
+          "legendFormat": "{{peer}} missing import",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_rfc8212_missing_export_policy{instance=~\"$instance\",peer=~\"$peer\"}",
+          "legendFormat": "{{peer}} missing export",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 63,
+      "type": "timeseries",
+      "title": "Outbound prefix capacity",
+      "description": "Current peer/family usage, finite limit, saturating headroom, and 0/1 blocking state. Limit and headroom are absent when unlimited; cumulative blocked events are intentionally excluded.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 161 },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 0, "min": 0 },
+        "overrides": [
+          {
+            "matcher": { "id": "byFrameRefID", "options": "D" },
+            "properties": [
+              { "id": "custom.axisPlacement", "value": "right" },
+              { "id": "custom.lineInterpolation", "value": "stepAfter" },
+              { "id": "max", "value": 1 }
+            ]
+          }
+        ]
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_outbound_prefix_usage{instance=~\"$instance\",peer=~\"$peer\"}",
+          "legendFormat": "{{peer}} {{family}} usage",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_outbound_prefix_limit{instance=~\"$instance\",peer=~\"$peer\"}",
+          "legendFormat": "{{peer}} {{family}} limit",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_outbound_prefix_headroom{instance=~\"$instance\",peer=~\"$peer\"}",
+          "legendFormat": "{{peer}} {{family}} headroom",
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_outbound_prefix_blocking{instance=~\"$instance\",peer=~\"$peer\"}",
+          "legendFormat": "{{peer}} {{family}} blocking",
+          "refId": "D"
+        }
+      ]
     }
   ]
 }

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -135,6 +135,45 @@ groups:
             bgp_max_prefix_headroom and eventually trigger Cease / Maximum
             Number of Prefixes Reached.
 
+      - alert: BgpRfc8212MissingImportPolicy
+        expr: bgp_rfc8212_missing_import_policy == 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Peer {{ $labels.peer }} is missing an RFC 8212 import policy"
+          description: >-
+            The RFC 8212 missing-import gauge for {{ $labels.peer }} on
+            {{ $labels.instance }} has remained 1 for 5 minutes; inbound
+            routes are failing closed.
+
+      - alert: BgpRfc8212MissingExportPolicy
+        expr: bgp_rfc8212_missing_export_policy == 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Peer {{ $labels.peer }} is missing an RFC 8212 export policy"
+          description: >-
+            The RFC 8212 missing-export gauge for {{ $labels.peer }} on
+            {{ $labels.instance }} has remained 1 for 5 minutes; outbound
+            routes are failing closed.
+
+      - alert: BgpOutboundPrefixBlocking
+        expr: bgp_outbound_prefix_blocking == 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            Outbound prefix blocking for {{ $labels.peer }}
+            ({{ $labels.family }})
+          description: >-
+            The outbound prefix-limit blocking gauge for {{ $labels.peer }}
+            ({{ $labels.family }}) on {{ $labels.instance }} has remained 1
+            for 5 minutes; its advertised view is intentionally below group
+            intent.
+
       - alert: RpkiVrpTableEmpty
         # Series only exist once an RTR cache has delivered data, so
         # this cannot fire on deployments without RPKI configured. An

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -318,6 +318,82 @@ tests:
                 and the remote receiver before the backlog reaches its
                 bound.
 
+  # ── RFC 8212 / outbound prefix-limit state ───────────────────
+  # Load-bearing: each warning is pending at 4m30s and firing at 5m30s.
+  # The RFC matrix separates import-only, export-only, and healthy peers.
+  # Blocking covers sustained, zero, and transient episodes independently.
+  - interval: 30s
+    input_series:
+      - series: 'bgp_rfc8212_missing_import_policy{peer="192.0.2.20", instance="edge1:9179"}'
+        values: "1x14"
+      - series: 'bgp_rfc8212_missing_export_policy{peer="192.0.2.20", instance="edge1:9179"}'
+        values: "0x14"
+      - series: 'bgp_rfc8212_missing_import_policy{peer="192.0.2.21", instance="edge1:9179"}'
+        values: "0x14"
+      - series: 'bgp_rfc8212_missing_export_policy{peer="192.0.2.21", instance="edge1:9179"}'
+        values: "1x14"
+      - series: 'bgp_rfc8212_missing_import_policy{peer="192.0.2.22", instance="edge1:9179"}'
+        values: "0x14"
+      - series: 'bgp_rfc8212_missing_export_policy{peer="192.0.2.22", instance="edge1:9179"}'
+        values: "0x14"
+      - series: 'bgp_outbound_prefix_blocking{peer="192.0.2.30", family="ipv4_unicast", instance="edge1:9179"}'
+        values: "1x14"
+      - series: 'bgp_outbound_prefix_blocking{peer="192.0.2.31", family="ipv6_unicast", instance="edge1:9179"}'
+        values: "0x14"
+      - series: 'bgp_outbound_prefix_blocking{peer="192.0.2.32", family="ipv4_unicast", instance="edge1:9179"}'
+        values: "1 1 1 1 1 1 0x8"
+    alert_rule_test:
+      - eval_time: 4m30s
+        alertname: BgpRfc8212MissingImportPolicy
+        exp_alerts: []
+      - eval_time: 5m30s
+        alertname: BgpRfc8212MissingImportPolicy
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              peer: 192.0.2.20
+              instance: edge1:9179
+            exp_annotations:
+              summary: "Peer 192.0.2.20 is missing an RFC 8212 import policy"
+              description: >-
+                The RFC 8212 missing-import gauge for 192.0.2.20 on
+                edge1:9179 has remained 1 for 5 minutes; inbound routes are
+                failing closed.
+      - eval_time: 4m30s
+        alertname: BgpRfc8212MissingExportPolicy
+        exp_alerts: []
+      - eval_time: 5m30s
+        alertname: BgpRfc8212MissingExportPolicy
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              peer: 192.0.2.21
+              instance: edge1:9179
+            exp_annotations:
+              summary: "Peer 192.0.2.21 is missing an RFC 8212 export policy"
+              description: >-
+                The RFC 8212 missing-export gauge for 192.0.2.21 on
+                edge1:9179 has remained 1 for 5 minutes; outbound routes are
+                failing closed.
+      - eval_time: 4m30s
+        alertname: BgpOutboundPrefixBlocking
+        exp_alerts: []
+      - eval_time: 5m30s
+        alertname: BgpOutboundPrefixBlocking
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              peer: 192.0.2.30
+              family: ipv4_unicast
+              instance: edge1:9179
+            exp_annotations:
+              summary: >-
+                Outbound prefix blocking for 192.0.2.30 (ipv4_unicast)
+              description: >-
+                The outbound prefix-limit blocking gauge for 192.0.2.30
+                (ipv4_unicast) on edge1:9179 has remained 1 for 5 minutes; its
+                advertised view is intentionally below group intent.
+
   # ── RpkiVrpTableEmpty ─────────────────────────────────────────
   - interval: 1m
     input_series:

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -88,9 +88,27 @@ TARGETS = {
         "(rate(bgp_selection_deferral_ledger_overflows_total"
         '{instance=~"$instance"}[$__rate_interval])) > 0'
     ),
+    ("RFC 8212 missing policy", "A"): (
+        'bgp_rfc8212_missing_import_policy{instance=~"$instance",peer=~"$peer"}'
+    ),
+    ("RFC 8212 missing policy", "B"): (
+        'bgp_rfc8212_missing_export_policy{instance=~"$instance",peer=~"$peer"}'
+    ),
+    ("Outbound prefix capacity", "A"): (
+        'bgp_outbound_prefix_usage{instance=~"$instance",peer=~"$peer"}'
+    ),
+    ("Outbound prefix capacity", "B"): (
+        'bgp_outbound_prefix_limit{instance=~"$instance",peer=~"$peer"}'
+    ),
+    ("Outbound prefix capacity", "C"): (
+        'bgp_outbound_prefix_headroom{instance=~"$instance",peer=~"$peer"}'
+    ),
+    ("Outbound prefix capacity", "D"): (
+        'bgp_outbound_prefix_blocking{instance=~"$instance",peer=~"$peer"}'
+    ),
 }
 
-ROUTE_SAFETY_LEGENDS = {
+REQUIRED_LEGENDS = {
     ("Peer administrative / session truth", "A"): "admin {{peer}} {{interface}}",
     ("Peer administrative / session truth", "B"): "session {{peer}} {{interface}}",
     ("Export rejections / malformed UPDATEs", "A"): (
@@ -105,12 +123,23 @@ ROUTE_SAFETY_LEGENDS = {
     ("Selection-deferral exceptional events", "B"): (
         "{{instance}} {{afi_safi}} ledger overflow"
     ),
+    ("RFC 8212 missing policy", "A"): "{{peer}} missing import",
+    ("RFC 8212 missing policy", "B"): "{{peer}} missing export",
+    ("Outbound prefix capacity", "A"): "{{peer}} {{family}} usage",
+    ("Outbound prefix capacity", "B"): "{{peer}} {{family}} limit",
+    ("Outbound prefix capacity", "C"): "{{peer}} {{family}} headroom",
+    ("Outbound prefix capacity", "D"): "{{peer}} {{family}} blocking",
 }
 
 ROUTE_SAFETY_PANELS = {
     "Export rejections / malformed UPDATEs": 0,
     "Selection-deferral state": 8,
     "Selection-deferral exceptional events": 16,
+}
+
+CAPACITY_PANELS = {
+    "RFC 8212 missing policy": (62, 0),
+    "Outbound prefix capacity": (63, 12),
 }
 
 WORKFLOW_PATHS = {
@@ -224,7 +253,7 @@ def main() -> None:
         if actual != expected:
             fail(f"target {key[0]!r}/{key[1]} must equal {expected[0]!r}; got {actual!r}")
 
-    for key, expected in ROUTE_SAFETY_LEGENDS.items():
+    for key, expected in REQUIRED_LEGENDS.items():
         actual = legends.get(key, [])
         if actual != [expected]:
             fail(f"target {key[0]!r}/{key[1]} must use legend {expected!r}; got {actual!r}")
@@ -294,6 +323,70 @@ def main() -> None:
         fail("selection-deferral state must render as nonnegative whole values")
     if selection_defaults.get("custom", {}).get("lineInterpolation") != "stepAfter":
         fail("selection-deferral state must use step interpolation")
+
+    for title, (expected_id, expected_x) in CAPACITY_PANELS.items():
+        panel = next((item for item in panels if item.get("title") == title), None)
+        if panel is None or panel.get("type") != "timeseries":
+            fail(f"{title} must exist as a timeseries panel")
+        if panel.get("id") != expected_id:
+            fail(f"{title} must use panel id {expected_id}")
+        expected_position = {"h": 8, "w": 12, "x": expected_x, "y": 161}
+        if panel.get("gridPos") != expected_position:
+            fail(f"{title} must use compact grid position {expected_position}")
+
+    rfc8212_panel = next(
+        panel for panel in panels if panel.get("title") == "RFC 8212 missing policy"
+    )
+    rfc8212_refs = [target.get("refId") for target in rfc8212_panel.get("targets", [])]
+    if rfc8212_refs != ["A", "B"]:
+        fail("RFC 8212 panel must contain exactly targets A and B")
+    rfc8212_defaults = rfc8212_panel.get("fieldConfig", {}).get("defaults", {})
+    if (
+        rfc8212_defaults.get("decimals") != 0
+        or rfc8212_defaults.get("min") != 0
+        or rfc8212_defaults.get("max") != 1
+    ):
+        fail("RFC 8212 state must be pinned to whole 0..1 values")
+    if rfc8212_defaults.get("custom", {}).get("lineInterpolation") != "stepAfter":
+        fail("RFC 8212 state must use step interpolation")
+    expected_mappings = [
+        {
+            "type": "value",
+            "options": {
+                "0": {"text": "not missing", "color": "green"},
+                "1": {"text": "missing", "color": "red"},
+            },
+        }
+    ]
+    if rfc8212_defaults.get("mappings") != expected_mappings:
+        fail("RFC 8212 state must map 0 to not missing and 1 to missing")
+
+    outbound_panel = next(
+        panel for panel in panels if panel.get("title") == "Outbound prefix capacity"
+    )
+    outbound_refs = [target.get("refId") for target in outbound_panel.get("targets", [])]
+    if outbound_refs != ["A", "B", "C", "D"]:
+        fail("outbound capacity panel must contain exactly targets A through D")
+    if any(
+        "bgp_outbound_prefix_blocked_total" in target.get("expr", "")
+        for target in outbound_panel.get("targets", [])
+    ):
+        fail("outbound capacity panel must exclude the cumulative blocked counter")
+    outbound_defaults = outbound_panel.get("fieldConfig", {}).get("defaults", {})
+    if outbound_defaults.get("decimals") != 0 or outbound_defaults.get("min") != 0:
+        fail("outbound capacity counts must render as nonnegative whole values")
+    expected_overrides = [
+        {
+            "matcher": {"id": "byFrameRefID", "options": "D"},
+            "properties": [
+                {"id": "custom.axisPlacement", "value": "right"},
+                {"id": "custom.lineInterpolation", "value": "stepAfter"},
+                {"id": "max", "value": 1},
+            ],
+        }
+    ]
+    if outbound_panel.get("fieldConfig", {}).get("overrides") != expected_overrides:
+        fail("only outbound blocking target D must use a stepped 0..1 right axis")
 
     try:
         workflow_text = WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add compact Grafana panels for directional RFC 8212 missing-policy state and outbound-prefix usage, limit, headroom, and blocking
- add five-minute warning alerts with fixtures for missing import policy, missing export policy, and sustained outbound blocking
- correct the operator documentation for PromQL set-union semantics and the lifecycle of zero-valued RFC 8212 gauges

## Verification

- `python3 scripts/check-grafana-dashboard.py`
- `jq empty docs/grafana/rustbgpd-overview.json`
- Prometheus 3.4.1 `promtool check rules` and `promtool test rules` (20 rules)
- focused outbound-capacity telemetry test
- focused live RFC 8212 policy-gauge test
- `cargo fmt --all -- --check`
- `git diff --check`
- push hooks: documentation gate

## Load-bearing proofs

- dashboard checker fails when the exact metric, peer bound, legend, state mapping, axis override, layout, or panel ID is changed
- alert fixtures fail when an alert is deleted, its predicate is removed, or its five-minute hold is shortened
- fixtures distinguish import-only, export-only, healthy, sustained blocking, zero blocking, and transient blocking states, including pending at 4m30s and firing at 5m30s

The change is limited to the two shipped operator states: no runtime metrics, readiness semantics, or capacity thresholds are added.
