### PR TITLE
Preserve runtime neighbor create intent in rbgp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   that preserves peer-group inheritance and explicit masked `false`, family
   replacement, and Add-Path disable intent across persistence, live apply, and
   restart. Legacy field 1 behavior is unchanged, exactly one carrier is
-  required, and malformed masks fail before mutation. The bundled CLI remains
-  legacy-only pending its explicit negative forms and old-server diagnostics.
+  required, and malformed masks fail before mutation. `rbgp neighbor add` now
+  sends only that wrapper, exposes explicit negative boolean/Add-Path forms,
+  leaves effective prerequisite validation to the server, and fails old-server
+  creation once with an upgrade diagnostic rather than downgrading.
 
 ### Fixed
 

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -1978,19 +1978,18 @@ mod tests {
     }
 
     #[test]
-    fn adr_index_reports_server_implementation_and_cli_boundary() {
+    fn adr_index_reports_fully_shipped_boundary() {
         let index = include_str!("../../../docs/adr/README.md");
         assert!(index.contains(
             "| [0118](0118-presence-preserving-runtime-neighbor-create.md) | \
              Presence-preserving runtime neighbor creation | \
-             Accepted (server implemented; bundled CLI pending) | 2026-07-29 |"
+             Accepted — fully shipped | 2026-07-29 |"
         ));
         let adr =
             include_str!("../../../docs/adr/0118-presence-preserving-runtime-neighbor-create.md");
         assert!(
-            adr.lines().any(
-                |line| line == "**Status:** Accepted (server implemented; bundled CLI pending)"
-            )
+            adr.lines()
+                .any(|line| line == "**Status:** Accepted — fully shipped")
         );
     }
 

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -53,7 +53,7 @@ rbgp config import <source> [--format bird|frr|gobgp] [--out <path>]
 rbgp neighbor
 rbgp summary                                # alias for neighbor list
 rbgp neighbor <addr>
-rbgp neighbor <addr> add --remote-asn <asn> [--peer-group <name>] [--max-prefix-restart-seconds <seconds>] [--role provider|rs|rs-client|customer|peer] [--strict-role] [--route-server-client] [--per-client-best]
+rbgp neighbor <addr> add --remote-asn <asn> [--peer-group <name>] [--families <list>] [--route-server-client|--no-route-server-client] [--per-client-best|--no-per-client-best] [--role <role>] [--strict-role|--no-strict-role] [--no-add-path]
 rbgp neighbor <addr> enable
 rbgp neighbor <addr> disable --reason "maintenance"
 rbgp neighbor <addr> softreset
@@ -78,6 +78,12 @@ rbgp bfd show <addr>
 `dynamic-neighbor add` requires its peer group to exist first. The
 [Quickstart operating example](../../docs/QUICKSTART.md#5-operate) creates the
 passwordless `ix-members` group from ordinary JSON before adding the range.
+
+`neighbor add` preserves omission for peer-group inheritance. Positive and
+`--no-*` forms create explicit boolean overrides; any Add-Path option emits the
+complete atomic block, while `--no-add-path` explicitly disables it. Old
+daemons fail the one wrapper-only RPC with an upgrade diagnostic; the CLI never
+retries with legacy semantics.
 
 ### Routes, Policy, and Dataplane
 

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -8,8 +8,8 @@ use crate::output::{
 use crate::proto::neighbor_service_client::NeighborServiceClient;
 use crate::proto::{
     AddNeighborRequest, DeleteNeighborRequest, DisableNeighborRequest, EnableNeighborRequest,
-    GetNeighborStateRequest, ListNeighborsRequest, NeighborConfig, RefreshOutboundRequest,
-    SetGracefulShutdownRequest, SoftResetInRequest,
+    GetNeighborStateRequest, ListNeighborsRequest, NeighborConfig, NeighborCreateIntent,
+    RefreshOutboundRequest, SetGracefulShutdownRequest, SoftResetInRequest,
 };
 
 pub(super) fn bare_ip_rpc_address(address: &str) -> &str {
@@ -914,29 +914,60 @@ pub struct AddNeighborOpts {
     pub max_prefix_restart_seconds: Option<u32>,
     pub families: Vec<String>,
     pub required_families: Vec<String>,
-    pub route_server_client: bool,
-    pub per_client_best: bool,
+    pub route_server_client: Option<bool>,
+    pub per_client_best: Option<bool>,
     pub role: Option<String>,
-    pub strict_role: bool,
-    pub add_path_receive: bool,
-    pub add_path_send: bool,
-    pub add_path_send_max: u32,
+    pub strict_role: Option<bool>,
+    pub add_path: Option<AddPathOpts>,
+}
+
+pub struct AddPathOpts {
+    pub receive: bool,
+    pub send: bool,
+    pub send_max: u32,
     pub paths_limit_receive_max: u16,
 }
 
-pub async fn add(
-    connection: Connection,
-    address: &str,
-    opts: AddNeighborOpts,
-    json: bool,
-) -> Result<(), CliError> {
-    let mut client =
-        NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let (address_only, interface) = split_scoped_address(address);
-    client
-        .add_neighbor(AddNeighborRequest {
+fn add_neighbor_request(address: &str, opts: AddNeighborOpts) -> AddNeighborRequest {
+    let (address, interface) = split_scoped_address(address);
+    let mut override_paths = Vec::new();
+    if !opts.families.is_empty() {
+        override_paths.push("families".to_string());
+    }
+    if !opts.required_families.is_empty() {
+        override_paths.push("required_families".to_string());
+    }
+    if opts.route_server_client.is_some() {
+        override_paths.push("route_server_client".to_string());
+    }
+    if opts.per_client_best.is_some() {
+        override_paths.push("per_client_best".to_string());
+    }
+    if opts.strict_role.is_some() {
+        override_paths.push("strict_role".to_string());
+    }
+    if opts.add_path.is_some() {
+        override_paths.extend(
+            [
+                "add_path_receive",
+                "add_path_send",
+                "add_path_send_max",
+                "paths_limit_receive_max",
+            ]
+            .map(str::to_string),
+        );
+    }
+    let add_path = opts.add_path.unwrap_or(AddPathOpts {
+        receive: false,
+        send: false,
+        send_max: 0,
+        paths_limit_receive_max: 0,
+    });
+    AddNeighborRequest {
+        config: None,
+        intent: Some(NeighborCreateIntent {
             config: Some(NeighborConfig {
-                address: address_only,
+                address,
                 interface,
                 remote_asn: opts.asn,
                 description: opts.description.unwrap_or_default(),
@@ -948,19 +979,45 @@ pub async fn add(
                 required_families: opts.required_families,
                 peer_group: opts.peer_group.unwrap_or_default(),
                 remove_private_as: String::new(),
-                route_server_client: opts.route_server_client,
-                per_client_best: opts.per_client_best,
+                route_server_client: opts.route_server_client.unwrap_or(false),
+                per_client_best: opts.per_client_best.unwrap_or(false),
                 role: opts.role.unwrap_or_default(),
-                strict_role: opts.strict_role,
-                add_path_receive: opts.add_path_receive,
-                add_path_send: opts.add_path_send,
-                add_path_send_max: opts.add_path_send_max,
-                paths_limit_receive_max: u32::from(opts.paths_limit_receive_max),
+                strict_role: opts.strict_role.unwrap_or(false),
+                add_path_receive: add_path.receive,
+                add_path_send: add_path.send,
+                add_path_send_max: add_path.send_max,
+                paths_limit_receive_max: u32::from(add_path.paths_limit_receive_max),
                 max_prefix_restart_seconds: opts.max_prefix_restart_seconds,
             }),
-            intent: None,
-        })
-        .await?;
+            override_mask: Some(prost_types::FieldMask {
+                paths: override_paths,
+            }),
+        }),
+    }
+}
+
+pub async fn add(
+    connection: Connection,
+    address: &str,
+    opts: AddNeighborOpts,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut client =
+        NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    if let Err(status) = client
+        .add_neighbor(add_neighbor_request(address, opts))
+        .await
+    {
+        if status.code() == tonic::Code::InvalidArgument && status.message() == "config is required"
+        {
+            return Err(CliError::Rpc(
+                "daemon does not support presence-aware neighbor creation; \
+                 upgrade rustbgpd before adding this neighbor"
+                    .into(),
+            ));
+        }
+        return Err(status.into());
+    }
     output::print_result(
         json,
         "add_neighbor",
@@ -1532,93 +1589,145 @@ mod tests {
         assert_eq!(normalized_effective_send(&row(0, Some(0))), (true, 0));
     }
 
+    fn base_add_opts() -> AddNeighborOpts {
+        AddNeighborOpts {
+            asn: 65002,
+            description: None,
+            hold_time: None,
+            min_hold_time: None,
+            send_hold_time: None,
+            max_prefixes: None,
+            peer_group: None,
+            max_prefix_restart_seconds: None,
+            families: Vec::new(),
+            required_families: Vec::new(),
+            route_server_client: None,
+            per_client_best: None,
+            role: None,
+            strict_role: None,
+            add_path: None,
+        }
+    }
+
     #[tokio::test]
-    async fn add_sends_route_server_and_add_path_fields() {
-        // Mutation-red for min_hold_time: removing the request assignment
-        // makes the captured request carry None instead of 30.
+    async fn add_always_sends_wrapper_only_with_a_present_empty_mask() {
+        // Load-bearing: restoring legacy config, dual-carrier transmission,
+        // or an absent mask changes the captured request and makes this red.
         let server = spawn_mock_server(None).await;
         let connection = connect(&server.addr, None).await.unwrap();
-
-        add(
-            connection,
-            "10.0.0.2",
-            AddNeighborOpts {
-                min_hold_time: Some(30),
-                asn: 65002,
-                description: Some("peer-2".to_string()),
-                hold_time: Some(90),
-                send_hold_time: Some(480),
-                max_prefixes: Some(1000),
-                peer_group: Some("rs-members".to_string()),
-                max_prefix_restart_seconds: Some(30),
-                families: vec!["ipv4_unicast".to_string(), "ipv6_unicast".to_string()],
-                required_families: vec!["ipv6_unicast".to_string()],
-                route_server_client: true,
-                per_client_best: false,
-                role: Some("rs".to_string()),
-                strict_role: true,
-                add_path_receive: true,
-                add_path_send: true,
-                add_path_send_max: 4,
-                paths_limit_receive_max: 3,
-            },
-            true,
-        )
-        .await
-        .unwrap();
-
+        add(connection, "fe80::2%eth0", base_add_opts(), true)
+            .await
+            .unwrap();
         let request = server.state.last_add_neighbor.lock().await.clone().unwrap();
-        assert!(request.config.is_some());
-        assert!(request.intent.is_none());
-        let config = request.config.unwrap();
-        assert!(config.route_server_client);
-        assert_eq!(config.role, "rs");
-        assert!(config.strict_role);
-        assert!(config.add_path_receive);
-        assert!(config.add_path_send);
-        assert_eq!(config.add_path_send_max, 4);
-        assert_eq!(config.paths_limit_receive_max, 3);
+        assert!(request.config.is_none());
+        let intent = request.intent.unwrap();
+        assert_eq!(intent.override_mask.unwrap().paths, Vec::<String>::new());
+        let config = intent.config.unwrap();
+        assert_eq!(config.address, "fe80::2");
+        assert_eq!(config.interface, "eth0");
         assert_eq!(config.remote_asn, 65002);
-        assert_eq!(config.min_hold_time, Some(30));
-        assert_eq!(config.required_families, vec!["ipv6_unicast"]);
-        assert_eq!(config.peer_group, "rs-members");
-        assert_eq!(config.max_prefix_restart_seconds, Some(30));
+        assert!(config.families.is_empty());
+        assert!(!config.route_server_client);
+        assert!(!config.add_path_receive);
+        assert_eq!(
+            server
+                .state
+                .add_neighbor_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+    }
 
-        let connection = connect(&server.addr, None).await.unwrap();
-        add(
-            connection,
-            "10.0.0.3",
-            AddNeighborOpts {
-                min_hold_time: None,
-                asn: 65003,
-                description: None,
-                hold_time: None,
-                send_hold_time: None,
-                max_prefixes: None,
-                peer_group: None,
-                max_prefix_restart_seconds: None,
-                families: Vec::new(),
-                required_families: Vec::new(),
-                route_server_client: false,
-                per_client_best: false,
-                role: None,
-                strict_role: false,
-                add_path_receive: false,
-                add_path_send: false,
-                add_path_send_max: 0,
-                paths_limit_receive_max: 0,
-            },
+    #[test]
+    fn add_masks_only_nonempty_families_and_exact_standalone_values() {
+        // Load-bearing: selecting an empty family field, omitting a nonempty
+        // one, or losing explicit false makes an exact assertion red.
+        let mut families = base_add_opts();
+        families.families = vec!["ipv4_unicast".into()];
+        families.required_families = vec!["ipv4_unicast".into()];
+        let intent = add_neighbor_request("10.0.0.2", families).intent.unwrap();
+        assert_eq!(
+            intent.override_mask.unwrap().paths,
+            ["families", "required_families"]
+        );
+
+        for field in ["route_server_client", "per_client_best", "strict_role"] {
+            for value in [false, true] {
+                let mut opts = base_add_opts();
+                match field {
+                    "route_server_client" => opts.route_server_client = Some(value),
+                    "per_client_best" => opts.per_client_best = Some(value),
+                    "strict_role" => opts.strict_role = Some(value),
+                    _ => unreachable!(),
+                }
+                let intent = add_neighbor_request("10.0.0.2", opts).intent.unwrap();
+                assert_eq!(intent.override_mask.unwrap().paths, [field]);
+                let config = intent.config.unwrap();
+                let actual = match field {
+                    "route_server_client" => config.route_server_client,
+                    "per_client_best" => config.per_client_best,
+                    "strict_role" => config.strict_role,
+                    _ => unreachable!(),
+                };
+                assert_eq!(actual, value, "{field} did not preserve {value}");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn add_maps_only_the_exact_old_server_error_without_retrying() {
+        // Load-bearing: changing the exact message match, adding a fallback,
+        // or issuing a mutation probe changes the error/call/request evidence.
+        let old = spawn_mock_server(None).await;
+        *old.state.add_neighbor_error.lock().await =
+            Some((tonic::Code::InvalidArgument, "config is required".into()));
+        let error = add(
+            connect(&old.addr, None).await.unwrap(),
+            "10.0.0.2",
+            base_add_opts(),
             true,
         )
         .await
-        .unwrap();
+        .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "daemon does not support presence-aware neighbor creation; \
+             upgrade rustbgpd before adding this neighbor"
+        );
+        assert_eq!(
+            old.state
+                .add_neighbor_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+        let captured = old.state.last_add_neighbor.lock().await.clone().unwrap();
+        assert!(captured.config.is_none());
+        assert!(captured.intent.is_some());
 
-        let request = server.state.last_add_neighbor.lock().await.clone().unwrap();
-        assert!(request.config.is_some());
-        assert!(request.intent.is_none());
-        let config = request.config.unwrap();
-        assert_eq!(config.peer_group, "");
-        assert_eq!(config.max_prefix_restart_seconds, None);
+        let current = spawn_mock_server(None).await;
+        *current.state.add_neighbor_error.lock().await = Some((
+            tonic::Code::InvalidArgument,
+            "effective per_client_best requires route_server_client".into(),
+        ));
+        let error = add(
+            connect(&current.addr, None).await.unwrap(),
+            "10.0.0.2",
+            base_add_opts(),
+            true,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "invalid argument: effective per_client_best requires route_server_client"
+        );
+        assert_eq!(
+            current
+                .state
+                .add_neighbor_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
     }
 
     /// The zero-peer human output must say what happened AND hand the

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -921,30 +921,45 @@ enum NeighborAction {
         #[arg(long, value_delimiter = ',')]
         required_families: Vec<String>,
         /// Enable transparent route-server client mode (eBGP only)
-        #[arg(long)]
+        #[arg(long, conflicts_with = "no_route_server_client")]
         route_server_client: bool,
+        /// Explicitly disable inherited transparent route-server client mode
+        #[arg(long)]
+        no_route_server_client: bool,
         /// RFC 7947 per-client best-path (path-hiding mitigation);
-        /// requires --route-server-client
-        #[arg(long, requires = "route_server_client")]
+        /// effective route-server-client mode is validated by the daemon
+        #[arg(
+            long,
+            conflicts_with_all = ["no_per_client_best", "no_route_server_client"]
+        )]
         per_client_best: bool,
+        /// Explicitly disable inherited per-client best-path
+        #[arg(long)]
+        no_per_client_best: bool,
         /// Local BGP Role for RFC 9234 route-leak protection
         #[arg(long, value_name = "ROLE")]
         role: Option<String>,
         /// Require the peer to advertise a compatible BGP Role capability
-        #[arg(long, requires = "role")]
+        #[arg(long, conflicts_with = "no_strict_role")]
         strict_role: bool,
-        /// Enable Add-Path receive
+        /// Explicitly disable inherited strict-role enforcement
         #[arg(long)]
+        no_strict_role: bool,
+        /// Enable Add-Path receive
+        #[arg(long, conflicts_with = "no_add_path")]
         add_path_receive: bool,
         /// Enable Add-Path send
-        #[arg(long)]
+        #[arg(long, conflicts_with = "no_add_path")]
         add_path_send: bool,
         /// Max paths per prefix for Add-Path send
-        #[arg(long, default_value = "0")]
-        add_path_send_max: u32,
+        #[arg(long, conflicts_with = "no_add_path")]
+        add_path_send_max: Option<u32>,
         /// Experimental Paths-Limit preference for Add-Path receive families
-        #[arg(long, default_value = "0", requires = "add_path_receive")]
-        paths_limit_receive_max: u16,
+        #[arg(long, conflicts_with = "no_add_path")]
+        paths_limit_receive_max: Option<u16>,
+        /// Explicitly disable the complete inherited Add-Path block
+        #[arg(long)]
+        no_add_path: bool,
     },
     /// Delete this neighbor
     Delete,
@@ -2289,15 +2304,30 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     families,
                     required_families,
                     route_server_client,
+                    no_route_server_client,
                     per_client_best,
+                    no_per_client_best,
                     role,
                     strict_role,
+                    no_strict_role,
                     add_path_receive,
                     add_path_send,
                     add_path_send_max,
                     paths_limit_receive_max,
+                    no_add_path,
                 }),
             ) => {
+                let add_path = (no_add_path
+                    || add_path_receive
+                    || add_path_send
+                    || add_path_send_max.is_some()
+                    || paths_limit_receive_max.is_some())
+                .then_some(commands::neighbor::AddPathOpts {
+                    receive: add_path_receive,
+                    send: add_path_send,
+                    send_max: add_path_send_max.unwrap_or(0),
+                    paths_limit_receive_max: paths_limit_receive_max.unwrap_or(0),
+                });
                 commands::neighbor::add(
                     connection,
                     &addr,
@@ -2312,14 +2342,17 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                         max_prefix_restart_seconds,
                         families,
                         required_families,
-                        route_server_client,
-                        per_client_best,
+                        route_server_client: route_server_client
+                            .then_some(true)
+                            .or_else(|| no_route_server_client.then_some(false)),
+                        per_client_best: per_client_best
+                            .then_some(true)
+                            .or_else(|| no_per_client_best.then_some(false)),
                         role,
-                        strict_role,
-                        add_path_receive,
-                        add_path_send,
-                        add_path_send_max,
-                        paths_limit_receive_max,
+                        strict_role: strict_role
+                            .then_some(true)
+                            .or_else(|| no_strict_role.then_some(false)),
+                        add_path,
                     },
                     json,
                 )
@@ -3478,6 +3511,28 @@ mod tests {
     }
 
     #[test]
+    fn generated_completions_include_presence_negative_flags() {
+        // Load-bearing: omitting a negative flag from Clap removes it from at
+        // least one generated release completion and makes this fence red.
+        for shell in [Shell::Bash, Shell::Zsh, Shell::Fish] {
+            let mut generated = Vec::new();
+            generate_completions(shell, BINARY_NAME, &mut generated);
+            let generated = String::from_utf8(generated).unwrap();
+            for flag in [
+                "--no-route-server-client",
+                "--no-per-client-best",
+                "--no-strict-role",
+                "--no-add-path",
+            ] {
+                assert!(
+                    generated.contains(flag.trim_start_matches("--")),
+                    "{shell} completion does not contain {flag}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn test_man_page_is_roff_and_covers_nested_subcommands() {
         let mut output = Vec::new();
         generate_man(BINARY_NAME, &mut output).unwrap();
@@ -3766,8 +3821,10 @@ mod tests {
     }
 
     #[test]
-    fn test_neighbor_add_requires_role_for_strict_role() {
-        let error = match Cli::try_parse_from([
+    fn test_neighbor_add_allows_inherited_prerequisites_and_explicit_disables() {
+        // Load-bearing: restoring either client-side `requires` check rejects
+        // an override whose prerequisite is inherited and makes this red.
+        let inherited = Cli::try_parse_from([
             "rbgp",
             "neighbor",
             "10.0.0.1",
@@ -3775,15 +3832,134 @@ mod tests {
             "--asn",
             "65001",
             "--strict-role",
-        ]) {
-            Ok(_) => panic!("strict role without a role must fail"),
-            Err(error) => error,
+            "--per-client-best",
+        ])
+        .unwrap();
+        let Command::Neighbor {
+            action:
+                Some(NeighborAction::Add {
+                    role,
+                    strict_role,
+                    route_server_client,
+                    per_client_best,
+                    ..
+                }),
+            ..
+        } = inherited.command
+        else {
+            panic!("expected Neighbor Add command");
         };
+        assert!(role.is_none());
+        assert!(strict_role);
+        assert!(!route_server_client);
+        assert!(per_client_best);
+
+        // These cross-field combinations are intentional, not opposing pairs.
+        Cli::try_parse_from([
+            "rbgp",
+            "neighbor",
+            "10.0.0.2",
+            "add",
+            "--asn",
+            "65002",
+            "--route-server-client",
+            "--no-per-client-best",
+            "--role",
+            "rs",
+            "--no-strict-role",
+        ])
+        .unwrap();
+    }
+
+    #[test]
+    fn test_neighbor_add_rejects_opposing_and_forbidden_flags() {
+        // Load-bearing: removing any conflict admits one contradictory intent.
+        let cases: &[&[&str]] = &[
+            &["--route-server-client", "--no-route-server-client"],
+            &["--per-client-best", "--no-per-client-best"],
+            &["--strict-role", "--no-strict-role"],
+            &["--per-client-best", "--no-route-server-client"],
+            &["--no-add-path", "--add-path-receive"],
+            &["--no-add-path", "--add-path-send"],
+            &["--no-add-path", "--add-path-send-max", "0"],
+            &["--no-add-path", "--paths-limit-receive-max", "0"],
+        ];
+        for conflicting in cases {
+            let mut args = vec!["rbgp", "neighbor", "10.0.0.1", "add", "--asn", "65001"];
+            args.extend_from_slice(conflicting);
+            let error = match Cli::try_parse_from(args) {
+                Ok(_) => panic!("conflicting flags parsed: {conflicting:?}"),
+                Err(error) => error,
+            };
+            assert_eq!(
+                error.kind(),
+                clap::error::ErrorKind::ArgumentConflict,
+                "conflict was not enforced for {conflicting:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_neighbor_add_every_add_path_form_emits_atomic_intent() {
+        // Load-bearing: failing to lift any individual occurrence into an
+        // Add-Path block, or treating --no-add-path as omission, makes its
+        // complete quartet/value assertion red.
+        let server = spawn_mock_server(None).await;
+        type AddPathCase<'a> = (&'a [&'a str], (bool, bool, u32, u32));
+        let cases: &[AddPathCase<'_>] = &[
+            (&["--add-path-receive"], (true, false, 0, 0)),
+            (&["--add-path-send"], (false, true, 0, 0)),
+            (&["--add-path-send-max", "0"], (false, false, 0, 0)),
+            (&["--paths-limit-receive-max", "0"], (false, false, 0, 0)),
+            (&["--no-add-path"], (false, false, 0, 0)),
+        ];
+        for (flags, expected) in cases {
+            let mut args = vec![
+                "rbgp",
+                "--addr",
+                server.addr.as_str(),
+                "neighbor",
+                "10.0.0.1",
+                "add",
+                "--asn",
+                "65001",
+            ];
+            args.extend_from_slice(flags);
+            run(Cli::try_parse_from(args).unwrap(), BINARY_NAME)
+                .await
+                .unwrap();
+            let request = server.state.last_add_neighbor.lock().await.clone().unwrap();
+            assert!(request.config.is_none());
+            let intent = request.intent.unwrap();
+            assert_eq!(
+                intent.override_mask.unwrap().paths,
+                [
+                    "add_path_receive",
+                    "add_path_send",
+                    "add_path_send_max",
+                    "paths_limit_receive_max"
+                ],
+                "wrong mask for {flags:?}"
+            );
+            let config = intent.config.unwrap();
+            assert_eq!(
+                (
+                    config.add_path_receive,
+                    config.add_path_send,
+                    config.add_path_send_max,
+                    config.paths_limit_receive_max,
+                ),
+                *expected,
+                "wrong Add-Path tuple for {flags:?}"
+            );
+        }
         assert_eq!(
-            error.kind(),
-            clap::error::ErrorKind::MissingRequiredArgument
+            server
+                .state
+                .add_neighbor_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            cases.len()
         );
-        assert!(error.to_string().contains("--role"));
     }
 
     #[test]
@@ -3900,6 +4076,36 @@ mod tests {
             }
         }
         panic!("documented command never terminated: {marker}");
+    }
+
+    #[test]
+    fn test_parse_rr_pair_day2_documented_neighbor_add() {
+        // Load-bearing: this documented inheritance command must keep parsing
+        // without materializing any route-reflector settings in the CLI.
+        let runbook = include_str!("../../../docs/cookbook/rr-pair-day2.md");
+        let documented =
+            documented_continued_command(runbook, "rbgp neighbor 10.0.0.42 add --remote-asn 65000");
+        let cli = Cli::try_parse_from(documented.split_whitespace()).unwrap();
+        let Command::Neighbor {
+            address: Some(address),
+            action:
+                Some(NeighborAction::Add {
+                    asn,
+                    description,
+                    peer_group,
+                    families,
+                    ..
+                }),
+            ..
+        } = cli.command
+        else {
+            panic!("expected Neighbor Add command");
+        };
+        assert_eq!(address, "10.0.0.42");
+        assert_eq!(asn, 65000);
+        assert_eq!(description.as_deref(), Some("new-client"));
+        assert_eq!(peer_group.as_deref(), Some("rr-clients"));
+        assert!(families.is_empty());
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3871,6 +3871,57 @@ mod tests {
         .unwrap();
     }
 
+    #[tokio::test]
+    async fn test_neighbor_add_boolean_forms_reach_the_presence_wrapper() {
+        // Load-bearing: dropping any positive/negative dispatch mapping leaves
+        // its parsed flag at the protobuf default or outside the mask, making
+        // that exact CLI-to-RPC row red.
+        let server = spawn_mock_server(None).await;
+        let cases = [
+            ("--route-server-client", "route_server_client", true),
+            ("--no-route-server-client", "route_server_client", false),
+            ("--per-client-best", "per_client_best", true),
+            ("--no-per-client-best", "per_client_best", false),
+            ("--strict-role", "strict_role", true),
+            ("--no-strict-role", "strict_role", false),
+        ];
+        for (flag, path, expected) in cases {
+            let args = [
+                "rbgp",
+                "--addr",
+                server.addr.as_str(),
+                "neighbor",
+                "10.0.0.1",
+                "add",
+                "--asn",
+                "65001",
+                flag,
+            ];
+            run(Cli::try_parse_from(args).unwrap(), BINARY_NAME)
+                .await
+                .unwrap();
+            let request = server.state.last_add_neighbor.lock().await.clone().unwrap();
+            assert!(request.config.is_none(), "{flag} used the legacy carrier");
+            let intent = request.intent.unwrap();
+            assert_eq!(intent.override_mask.unwrap().paths, [path], "{flag}");
+            let config = intent.config.unwrap();
+            let actual = match path {
+                "route_server_client" => config.route_server_client,
+                "per_client_best" => config.per_client_best,
+                "strict_role" => config.strict_role,
+                _ => unreachable!(),
+            };
+            assert_eq!(actual, expected, "{flag}");
+        }
+        assert_eq!(
+            server
+                .state
+                .add_neighbor_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            cases.len()
+        );
+    }
+
     #[test]
     fn test_neighbor_add_rejects_opposing_and_forbidden_flags() {
         // Load-bearing: removing any conflict admits one contradictory intent.

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -49,6 +49,7 @@ pub(crate) struct MockState {
     pub(crate) config_apply_calls: AtomicUsize,
     pub(crate) config_confirm_calls: AtomicUsize,
     pub(crate) config_abort_calls: AtomicUsize,
+    pub(crate) add_neighbor_calls: AtomicUsize,
     pub(crate) config_status_calls: AtomicUsize,
     pub(crate) config_history_calls: AtomicUsize,
     pub(crate) config_rollback_calls: AtomicUsize,
@@ -82,6 +83,7 @@ pub(crate) struct MockState {
     pub(crate) last_config_confirm: Mutex<Option<server_proto::ConfirmConfigTransactionRequest>>,
     pub(crate) last_config_abort: Mutex<Option<server_proto::AbortConfigTransactionRequest>>,
     pub(crate) last_add_neighbor: Mutex<Option<server_proto::AddNeighborRequest>>,
+    pub(crate) add_neighbor_error: Mutex<Option<(Code, String)>>,
     pub(crate) last_get_neighbor_state: Mutex<Option<server_proto::GetNeighborStateRequest>>,
     pub(crate) neighbor_comparison: Mutex<Option<server_proto::UpdateGroupComparison>>,
     pub(crate) last_softreset: Mutex<Option<server_proto::SoftResetInRequest>>,
@@ -797,10 +799,11 @@ impl rustbgpd_api::proto::neighbor_service_server::NeighborService for MockNeigh
         request: Request<server_proto::AddNeighborRequest>,
     ) -> Result<Response<server_proto::AddNeighborResponse>, Status> {
         let request = request.into_inner();
-        if request.config.is_none() {
-            return Err(Status::invalid_argument("config required"));
-        }
+        self.state.add_neighbor_calls.fetch_add(1, Ordering::SeqCst);
         *self.state.last_add_neighbor.lock().await = Some(request);
+        if let Some((code, message)) = self.state.add_neighbor_error.lock().await.clone() {
+            return Err(Status::new(code, message));
+        }
         Ok(Response::new(server_proto::AddNeighborResponse {}))
     }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -689,9 +689,11 @@ returns `INVALID_ARGUMENT` before persistence or runtime mutation. An old
 server skips wrapper field 2 and rejects the request because legacy field 1 is
 absent; clients must not retry or send both.
 
-The bundled `rbgp neighbor add` command remains legacy-only in this server
-tranche. Direct gRPC clients may use the wrapper now; CLI wrapper construction,
-explicit `--no-*` forms, and old-server error wording remain pending.
+The bundled `rbgp neighbor add` command always sends `intent` only, with a
+present mask even when no overrides are selected. It never sends both carriers
+or retries legacy config. An old server's exact `config is required` response
+becomes `daemon does not support presence-aware neighbor creation; upgrade
+rustbgpd before adding this neighbor`; other errors remain unchanged.
 
 The create override mask has a closed top-level path set:
 `families`, `required_families`, `route_server_client`, `per_client_best`,
@@ -701,6 +703,12 @@ Add-Path paths are rejected. The four Add-Path paths are one atomic block.
 Masked booleans preserve explicit `false`; masked family lists replace
 inherited lists and must be non-empty. Values outside the mask must retain
 their protobuf defaults.
+
+CLI positive/negative pairs are mutually exclusive:
+`--[no-]route-server-client`, `--[no-]per-client-best`, and
+`--[no-]strict-role`. Any Add-Path option selects the quartet; explicit numeric
+zero remains an override, and `--no-add-path` emits the all-disabled tuple.
+Effective inherited prerequisites are validated by the server.
 
 Unmasked fields stay absent in the persisted neighbor and inherit through the
 normal config resolver. This includes peer-group TTL security, Graceful

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -738,11 +738,11 @@ disabled Add-Path block remain explicit across restart. Wrapper-only requests
 require an inner config and FieldMask, and the server rejects both/neither
 carriers and invalid masks before mutation.
 
-The bundled `rbgp neighbor add` command still sends legacy
-`AddNeighborRequest.config` in this tranche. Its historical empty-family and
-implicit-boolean behavior is unchanged; use a direct gRPC wrapper client only
-when presence-preserving creation is required. There is no automatic fallback
-from wrapper to legacy.
+The bundled `rbgp neighbor add` command sends only the presence-aware wrapper,
+including an empty mask when every inheritable option is omitted. Its explicit
+`--no-route-server-client`, `--no-per-client-best`, `--no-strict-role`, and
+`--no-add-path` forms preserve false overrides; any Add-Path option selects the
+complete atomic block. There is no probe or automatic legacy fallback.
 
 | Field                  | Type     | Required | Default | Description                                      |
 |------------------------|----------|----------|---------|--------------------------------------------------|

--- a/docs/adr/0118-presence-preserving-runtime-neighbor-create.md
+++ b/docs/adr/0118-presence-preserving-runtime-neighbor-create.md
@@ -1,11 +1,11 @@
 # ADR-0118: Presence-preserving runtime neighbor creation
 
-**Status:** Accepted (server implemented; bundled CLI pending)
+**Status:** Accepted — fully shipped
 **Date:** 2026-07-29
 
-> **Server tranche shipped.** The daemon accepts and preserves the
-> presence-aware wrapper. The bundled CLI deliberately remains on the legacy
-> carrier until its explicit negative forms and compatibility diagnostics land.
+> **Server and CLI tranches shipped.** The daemon preserves the wrapper and
+> `rbgp neighbor add` sends it exclusively with explicit negative forms and a
+> fail-closed old-server diagnostic.
 
 ## Context
 
@@ -246,8 +246,7 @@ runtime/persistence snapshot seam.
 
 ### CLI construction
 
-Once implemented, `rbgp neighbor add` always sends the wrapper, even when its
-mask is empty.
+`rbgp neighbor add` always sends the wrapper, even when its mask is empty.
 
 - A non-empty `--families` or `--required-families` argument adds the
   corresponding path.
@@ -308,9 +307,8 @@ tri-state.
 
 ## Exclusions and documentation fence
 
-This server tranche does not implement:
+This decision does not implement:
 
-- bundled CLI wrapper construction or explicit negative forms;
 - a new service, package, or v2 RPC;
 - a `oneof` migration for the legacy field;
 - automatic legacy fallback;
@@ -318,5 +316,5 @@ This server tranche does not implement:
 - one-off fixes for individual route-server or route-reflector flags.
 
 The API/configuration docs and v1 stable-surface digest describe the reviewed
-additive server graph. CLI help and examples remain legacy until the client
-tranche lands; ROADMAP state is intentionally unchanged.
+additive graph. CLI help, completions, and examples describe the shipped
+presence-aware client; ROADMAP state is intentionally unchanged.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -126,7 +126,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0115](0115-lean-daemon-build-flavors.md) | Lean daemon build flavors | Accepted (no additional flavor) | 2026-07-22 |
 | [0116](0116-rfc-9857-sr-policy-state.md) | RFC 9857 SR Policy state in BGP-LS | Accepted (feature implementation demand-gated) | 2026-07-22 |
 | [0117](0117-authenticated-single-hop-bfd-decision.md) | Authenticated single-hop BFD | Accepted (implementation NO-GO; evidence-gated) | 2026-07-22 |
-| [0118](0118-presence-preserving-runtime-neighbor-create.md) | Presence-preserving runtime neighbor creation | Accepted (server implemented; bundled CLI pending) | 2026-07-29 |
+| [0118](0118-presence-preserving-runtime-neighbor-create.md) | Presence-preserving runtime neighbor creation | Accepted — fully shipped | 2026-07-29 |
 
 ## Template
 

--- a/docs/cookbook/rr-pair-day2.md
+++ b/docs/cookbook/rr-pair-day2.md
@@ -36,14 +36,15 @@ If the fleet auto-accepts via a `[[dynamic_neighbors]]` range, a new
 client inside the range needs nothing. Otherwise:
 
 ```bash
-rbgp neighbor 10.0.0.42 add --remote-asn 65000 --description "new-client"
+rbgp neighbor 10.0.0.42 add --remote-asn 65000 --peer-group rr-clients --description new-client
 # or widen the accept range:
 rbgp dynamic-neighbor add 10.0.9.0/24 --peer-group rr-clients
 ```
 
 Both persist to the daemon's config file — the `CONFIG_PATH` argument,
 or `/etc/rustbgpd/config.toml` when it is omitted — before the RPC
-returns. Verify with `rbgp neighbor --wide`
+returns. The static neighbor inherits RR-client, family, and GR settings from
+`rr-clients` without materializing CLI defaults. Verify with `rbgp neighbor --wide`
 — the `RRC` column marks reflector clients. Uniform clients join the
 existing update group automatically; there is nothing to tune.
 

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -310,16 +310,20 @@ _arguments "${_arguments_options[@]}" : \
 '*--families=[Address families (comma-separated)]:FAMILIES:_default' \
 '*--required-families=[Families that must be negotiated (comma-separated)]:REQUIRED_FAMILIES:_default' \
 '--role=[Local BGP Role for RFC 9234 route-leak protection]:ROLE:_default' \
-'--add-path-send-max=[Max paths per prefix for Add-Path send]:ADD_PATH_SEND_MAX:_default' \
-'--paths-limit-receive-max=[Experimental Paths-Limit preference for Add-Path receive families]:PATHS_LIMIT_RECEIVE_MAX:_default' \
+'(--no-add-path)--add-path-send-max=[Max paths per prefix for Add-Path send]:ADD_PATH_SEND_MAX:_default' \
+'(--no-add-path)--paths-limit-receive-max=[Experimental Paths-Limit preference for Add-Path receive families]:PATHS_LIMIT_RECEIVE_MAX:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
-'--route-server-client[Enable transparent route-server client mode (eBGP only)]' \
-'--per-client-best[RFC 7947 per-client best-path (path-hiding mitigation); requires --route-server-client]' \
-'--strict-role[Require the peer to advertise a compatible BGP Role capability]' \
-'--add-path-receive[Enable Add-Path receive]' \
-'--add-path-send[Enable Add-Path send]' \
+'(--no-route-server-client)--route-server-client[Enable transparent route-server client mode (eBGP only)]' \
+'--no-route-server-client[Explicitly disable inherited transparent route-server client mode]' \
+'(--no-per-client-best --no-route-server-client)--per-client-best[RFC 7947 per-client best-path (path-hiding mitigation); effective route-server-client mode is validated by the daemon]' \
+'--no-per-client-best[Explicitly disable inherited per-client best-path]' \
+'(--no-strict-role)--strict-role[Require the peer to advertise a compatible BGP Role capability]' \
+'--no-strict-role[Explicitly disable inherited strict-role enforcement]' \
+'(--no-add-path)--add-path-receive[Enable Add-Path receive]' \
+'(--no-add-path)--add-path-send[Enable Add-Path send]' \
+'--no-add-path[Explicitly disable the complete inherited Add-Path block]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -475,16 +479,20 @@ _arguments "${_arguments_options[@]}" : \
 '*--families=[Address families (comma-separated)]:FAMILIES:_default' \
 '*--required-families=[Families that must be negotiated (comma-separated)]:REQUIRED_FAMILIES:_default' \
 '--role=[Local BGP Role for RFC 9234 route-leak protection]:ROLE:_default' \
-'--add-path-send-max=[Max paths per prefix for Add-Path send]:ADD_PATH_SEND_MAX:_default' \
-'--paths-limit-receive-max=[Experimental Paths-Limit preference for Add-Path receive families]:PATHS_LIMIT_RECEIVE_MAX:_default' \
+'(--no-add-path)--add-path-send-max=[Max paths per prefix for Add-Path send]:ADD_PATH_SEND_MAX:_default' \
+'(--no-add-path)--paths-limit-receive-max=[Experimental Paths-Limit preference for Add-Path receive families]:PATHS_LIMIT_RECEIVE_MAX:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
-'--route-server-client[Enable transparent route-server client mode (eBGP only)]' \
-'--per-client-best[RFC 7947 per-client best-path (path-hiding mitigation); requires --route-server-client]' \
-'--strict-role[Require the peer to advertise a compatible BGP Role capability]' \
-'--add-path-receive[Enable Add-Path receive]' \
-'--add-path-send[Enable Add-Path send]' \
+'(--no-route-server-client)--route-server-client[Enable transparent route-server client mode (eBGP only)]' \
+'--no-route-server-client[Explicitly disable inherited transparent route-server client mode]' \
+'(--no-per-client-best --no-route-server-client)--per-client-best[RFC 7947 per-client best-path (path-hiding mitigation); effective route-server-client mode is validated by the daemon]' \
+'--no-per-client-best[Explicitly disable inherited per-client best-path]' \
+'(--no-strict-role)--strict-role[Require the peer to advertise a compatible BGP Role capability]' \
+'--no-strict-role[Explicitly disable inherited strict-role enforcement]' \
+'(--no-add-path)--add-path-receive[Enable Add-Path receive]' \
+'(--no-add-path)--add-path-send[Enable Add-Path send]' \
+'--no-add-path[Explicitly disable the complete inherited Add-Path block]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -6167,7 +6167,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__add)
-            opts="-s -j -h --asn --remote-asn --description --hold-time --min-hold-time --send-hold-time --max-prefixes --peer-group --max-prefix-restart-seconds --families --required-families --route-server-client --per-client-best --role --strict-role --add-path-receive --add-path-send --add-path-send-max --paths-limit-receive-max --addr --token-file --json --no-color --help"
+            opts="-s -j -h --asn --remote-asn --description --hold-time --min-hold-time --send-hold-time --max-prefixes --peer-group --max-prefix-restart-seconds --families --required-families --route-server-client --no-route-server-client --per-client-best --no-per-client-best --role --strict-role --no-strict-role --add-path-receive --add-path-send --add-path-send-max --paths-limit-receive-max --no-add-path --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -188,10 +188,14 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subc
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l route-server-client -d 'Enable transparent route-server client mode (eBGP only)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l per-client-best -d 'RFC 7947 per-client best-path (path-hiding mitigation); requires --route-server-client'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l no-route-server-client -d 'Explicitly disable inherited transparent route-server client mode'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l per-client-best -d 'RFC 7947 per-client best-path (path-hiding mitigation); effective route-server-client mode is validated by the daemon'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l no-per-client-best -d 'Explicitly disable inherited per-client best-path'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l strict-role -d 'Require the peer to advertise a compatible BGP Role capability'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l no-strict-role -d 'Explicitly disable inherited strict-role enforcement'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l add-path-receive -d 'Enable Add-Path receive'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l add-path-send -d 'Enable Add-Path send'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l no-add-path -d 'Explicitly disable the complete inherited Add-Path block'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -259,10 +263,14 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l route-server-client -d 'Enable transparent route-server client mode (eBGP only)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l per-client-best -d 'RFC 7947 per-client best-path (path-hiding mitigation); requires --route-server-client'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l no-route-server-client -d 'Explicitly disable inherited transparent route-server client mode'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l per-client-best -d 'RFC 7947 per-client best-path (path-hiding mitigation); effective route-server-client mode is validated by the daemon'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l no-per-client-best -d 'Explicitly disable inherited per-client best-path'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l strict-role -d 'Require the peer to advertise a compatible BGP Role capability'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l no-strict-role -d 'Explicitly disable inherited strict-role enforcement'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l add-path-receive -d 'Enable Add-Path receive'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l add-path-send -d 'Enable Add-Path send'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l no-add-path -d 'Explicitly disable the complete inherited Add-Path block'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'

--- a/examples/route-server/README.md
+++ b/examples/route-server/README.md
@@ -78,3 +78,6 @@ Members can be added atomically as they join — see
 `rbgp neighbor 198.51.100.4 add --remote-asn 64503 --route-server-client \
 --per-client-best --role rs --families ipv4_unicast,ipv6_unicast --max-prefixes 50000 \
 --max-prefix-restart-seconds 30`.
+
+Omit inherited fields when adding through a peer group; use the matching
+`--no-*` flag only to override an inherited true value.


### PR DESCRIPTION
## Summary

- make `rbgp neighbor add` send only the presence-aware create wrapper introduced in #1273, including a present empty mask when every inheritable option is omitted
- add explicit negative route-server, per-client-best, strict-role, and atomic Add-Path forms without probing or retrying legacy semantics
- preserve inherited prerequisites for server-side effective validation and map only the historical old-server rejection to an upgrade diagnostic
- refresh completions, operator docs, CHANGELOG, and ADR-0118 to the fully shipped client/server contract

## Compatibility and scope

The command sends one RPC. Old daemons fail closed with a targeted upgrade message; other errors retain their existing mapping. The aggregate change is 712 hand-authored changed lines across 15 files after excluding mechanically regenerated completions, below the reviewed 750-line cap. The only API-crate change is a test fence for ADR status.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --lib --no-deps`
- `python3 scripts/check-v1-stable-surface.py`
- exact scope, line-budget, patch-identity, and diff checks

Load-bearing proofs cover wrapper-only/one-call construction, present and closed masks, explicit false, atomic Add-Path including numeric zero, inherited prerequisites, conflicts, completions, old-server no-retry behavior, documented commands, and ADR status. A table-driven CLI-to-RPC test covers all six standalone positive/negative boolean forms; independently removing each dispatch mapping makes that test fail.
