### PR TITLE
Validate dynamic peer modes and RR cluster derivation

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1325,6 +1325,11 @@ Validation rules:
 - `peer_group` must reference an existing `[peer_groups.<name>]`
 - `prefix` must be valid CIDR with a family-appropriate prefix length
 - static `[[neighbors]]` cannot use `remote_asn = 0`; that sentinel is reserved for `[[dynamic_neighbors]]`
+- inherited RR/ORR settings require a fixed local-AS `remote_asn`; wildcard
+  `0` is external and cannot form an iBGP route-reflector session
+- inherited route-server mode and BGP Roles require eBGP (`0` remains valid);
+  `per_client_best` and `next_hop_ownership` require route-server mode, while
+  `strict_role` requires a role
 - two ranges covering the **identical** effective prefix (same masked network
   and length) are rejected; overlapping ranges of *different* lengths are
   allowed and resolve by longest-prefix-match at accept time
@@ -1848,9 +1853,10 @@ See the [Policy entries](#policy-entries) section below for field details.
 ### Route Reflector (RFC 4456)
 
 rustbgpd can act as a route reflector, relaxing the iBGP full-mesh requirement.
-When `cluster_id` is set and at least one neighbor has `route_reflector_client = true`,
-iBGP-learned routes from clients are reflected to all iBGP peers, while routes
-from non-clients go to clients only.
+An explicit `cluster_id`, or any valid static or dynamic iBGP client with
+`route_reflector_client = true`, enables route-reflector mode. Without an
+explicit cluster ID, rustbgpd uses `router_id`. iBGP-learned routes from clients
+are reflected to all iBGP peers, while routes from non-clients go to clients only.
 
 ```toml
 [global]

--- a/src/config/resolution.rs
+++ b/src/config/resolution.rs
@@ -43,7 +43,7 @@ impl Config {
         if let Some(ref cid) = self.global.cluster_id {
             return Some(cid.parse().expect("validated in Config::load"));
         }
-        if self.neighbors.iter().any(|n| {
+        let static_rr = self.neighbors.iter().any(|n| {
             n.route_reflector_client.unwrap_or_else(|| {
                 n.peer_group
                     .as_deref()
@@ -51,7 +51,16 @@ impl Config {
                     .and_then(|group| group.route_reflector_client)
                     .unwrap_or(false)
             })
-        }) {
+        });
+        let dynamic_rr = self.dynamic_neighbors.iter().any(|range| {
+            range.remote_asn == self.global.asn
+                && self
+                    .peer_groups
+                    .get(&range.peer_group)
+                    .and_then(|group| group.route_reflector_client)
+                    .unwrap_or(false)
+        });
+        if static_rr || dynamic_rr {
             let router_id: Ipv4Addr = self
                 .global
                 .router_id

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -8103,6 +8103,123 @@ default_action = "deny"
 
 // ── Dynamic neighbor config tests ───────────────────────────────
 
+fn dynamic_modes_toml(group_fields: &str, remote_asn: u32) -> String {
+    format!(
+        r#"
+{base}
+
+[peer_groups.modes]
+{group_fields}
+
+[[dynamic_neighbors]]
+prefix = "10.0.0.0/24"
+peer_group = "modes"
+remote_asn = {remote_asn}
+"#,
+        base = valid_toml()
+    )
+}
+
+fn resolve_dynamic_modes(config: &Config, remote_asn: u32) -> ResolvedNeighbor {
+    config
+        .resolve_dynamic_neighbor(
+            "10.0.0.42".parse().unwrap(),
+            remote_asn,
+            "dynamic",
+            &config.peer_groups["modes"],
+            "modes",
+            false,
+        )
+        .unwrap()
+}
+
+#[test]
+fn dynamic_neighbor_effective_mode_validation_matrix() {
+    // Load-bearing: removing the dynamic shared-validator call makes every
+    // invalid inherited mode below load successfully and turns this test red.
+    let rr = "route_reflector_client = true";
+    let orr = "orr_vantage = \"192.0.2.7\"";
+    let rr_router = "route_reflector_client = true\norr_vantage = \"10.0.0.1\"";
+    let rr_unspecified = "route_reflector_client = true\norr_vantage = \"0.0.0.0\"";
+    let rr_loopback = "route_reflector_client = true\norr_vantage = \"127.0.0.1\"";
+    let cases = [
+        (rr, 65002, "route_reflector_client requires iBGP"),
+        (rr, 0, "route_reflector_client requires iBGP"),
+        (orr, 65002, "orr_vantage requires iBGP"),
+        (orr, 65001, "requires route_reflector_client = true"),
+        (rr_router, 65001, "router_id"),
+        (rr_unspecified, 65001, "unspecified or loopback"),
+        (rr_loopback, 65001, "unspecified or loopback"),
+        ("route_server_client = true", 65001, "requires eBGP"),
+        (
+            "per_client_best = true",
+            65002,
+            "per_client_best on neighbor",
+        ),
+        (
+            "next_hop_ownership = \"strict_peer\"",
+            65002,
+            "next_hop_ownership",
+        ),
+        ("role = \"peer\"", 65001, "BGP Roles require eBGP"),
+        ("strict_role = true", 65002, "strict_role requires role"),
+    ];
+    for (group_fields, remote_asn, expected) in cases {
+        let err = parse(&dynamic_modes_toml(group_fields, remote_asn)).unwrap_err();
+        let ConfigError::InvalidDynamicNeighbor { reason } = err else {
+            panic!("expected dynamic rejection for {group_fields:?}, got {err}");
+        };
+        assert!(reason.contains("dynamic_neighbors[0] prefix \"10.0.0.0/24\""));
+        assert!(reason.contains("peer_group \"modes\""));
+        assert!(reason.contains(expected), "{group_fields:?}: {reason}");
+    }
+}
+
+#[test]
+fn valid_dynamic_peer_modes_resolve_cluster_and_transport() {
+    // Load-bearing: removing the dynamic cluster scan loses both cluster
+    // assertions; treating wildcard ASN 0 as iBGP or dropping group inheritance
+    // breaks the valid route-server controls and resolved transport tuple.
+    let rr = parse(&dynamic_modes_toml(
+        "route_reflector_client = true\norr_vantage = \"192.0.2.7\"",
+        65001,
+    ))
+    .unwrap();
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 1));
+    assert_eq!(rr.cluster_id(), cluster_id);
+    let rr_resolved = resolve_dynamic_modes(&rr, 65001);
+    assert_eq!(
+        (
+            rr_resolved.transport_config.route_reflector_client,
+            rr_resolved.transport_config.orr_vantage,
+            rr_resolved.transport_config.cluster_id,
+        ),
+        (true, Some("192.0.2.7".parse().unwrap()), cluster_id)
+    );
+
+    let rs_fields = "route_server_client = true\nper_client_best = true\n\
+                     next_hop_ownership = \"strict_peer\"\nrole = \"route_server\"\n\
+                     strict_role = true";
+    for (configured_asn, accepted_asn) in [(65002, 65002), (0, 65003)] {
+        let rs = parse(&dynamic_modes_toml(rs_fields, configured_asn)).unwrap();
+        let resolved = resolve_dynamic_modes(&rs, accepted_asn);
+        assert_eq!(
+            (
+                resolved.transport_config.route_server_client,
+                resolved.transport_config.per_client_best,
+                resolved.transport_config.next_hop_ownership_strict_peer,
+                resolved.transport_config.peer.local_role,
+                resolved.transport_config.peer.strict_role,
+            ),
+            (true, true, true, Some(BgpRole::RouteServer), true)
+        );
+    }
+    assert_eq!(
+        parse(&dynamic_modes_toml("", 0)).unwrap().cluster_id(),
+        None
+    );
+}
+
 #[test]
 fn dynamic_neighbor_parses() {
     let toml = r#"

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -14,7 +14,7 @@ use super::schema::{
     ManagedVxlanNetdevConfig,
 };
 use super::{
-    Config, ConfigError, DEFAULT_HOLD_TIME, EventHistoryConfig, GrpcEnforcementConfig,
+    Config, ConfigError, DEFAULT_HOLD_TIME, EventHistoryConfig, GrpcEnforcementConfig, Neighbor,
     PeerGroupConfig, SecurityConfig, TcpAoConfig, TcpAoKeyringConfig, dynamic_prefixes_intersect,
     is_unicast_nonzero_mac, parse_mac_address,
 };
@@ -96,6 +96,179 @@ impl ConfigAdvisory {
         }
         out
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "the independent flags are the closed peer-mode validation tuple"
+)]
+struct EffectivePeerModes {
+    remote_asn: u32,
+    route_reflector_client: bool,
+    orr_vantage: Option<IpAddr>,
+    route_server_client: bool,
+    per_client_best: bool,
+    next_hop_ownership: bool,
+    role: bool,
+    strict_role: bool,
+}
+
+impl EffectivePeerModes {
+    fn for_neighbor(neighbor: &Neighbor, group: Option<&PeerGroupConfig>) -> Self {
+        Self {
+            remote_asn: neighbor.remote_asn,
+            route_reflector_client: neighbor
+                .route_reflector_client
+                .or_else(|| group.and_then(|g| g.route_reflector_client))
+                .unwrap_or(false),
+            orr_vantage: neighbor
+                .orr_vantage
+                .or_else(|| group.and_then(|g| g.orr_vantage)),
+            route_server_client: neighbor
+                .route_server_client
+                .or_else(|| group.and_then(|g| g.route_server_client))
+                .unwrap_or(false),
+            per_client_best: neighbor
+                .per_client_best
+                .or_else(|| group.and_then(|g| g.per_client_best))
+                .unwrap_or(false),
+            next_hop_ownership: neighbor
+                .next_hop_ownership
+                .or_else(|| group.and_then(|g| g.next_hop_ownership))
+                .is_some(),
+            role: neighbor
+                .role
+                .or_else(|| group.and_then(|g| g.role))
+                .is_some(),
+            strict_role: neighbor
+                .strict_role
+                .or_else(|| group.and_then(|g| g.strict_role))
+                .unwrap_or(false),
+        }
+    }
+
+    fn for_dynamic(remote_asn: u32, group: &PeerGroupConfig) -> Self {
+        Self {
+            remote_asn,
+            route_reflector_client: group.route_reflector_client.unwrap_or(false),
+            orr_vantage: group.orr_vantage,
+            route_server_client: group.route_server_client.unwrap_or(false),
+            per_client_best: group.per_client_best.unwrap_or(false),
+            next_hop_ownership: group.next_hop_ownership.is_some(),
+            role: group.role.is_some(),
+            strict_role: group.strict_role.unwrap_or(false),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum PeerModeViolation {
+    RouteReflector(String),
+    RouteServer(String),
+    Neighbor { field: &'static str, reason: String },
+}
+
+impl PeerModeViolation {
+    fn into_static_error(self, address: &str) -> ConfigError {
+        match self {
+            Self::RouteReflector(reason) => ConfigError::InvalidRrConfig { reason },
+            Self::RouteServer(reason) => ConfigError::InvalidRouteServerConfig { reason },
+            Self::Neighbor { field, reason } => ConfigError::InvalidNeighborConfig {
+                address: address.to_string(),
+                field: field.to_string(),
+                reason,
+            },
+        }
+    }
+
+    fn reason(self) -> String {
+        match self {
+            Self::RouteReflector(reason)
+            | Self::RouteServer(reason)
+            | Self::Neighbor { reason, .. } => reason,
+        }
+    }
+}
+
+fn validate_effective_peer_modes(
+    modes: EffectivePeerModes,
+    local_asn: u32,
+    local_router_id: &str,
+    subject: &str,
+    exact_peer_addr: Option<IpAddr>,
+) -> Result<(), PeerModeViolation> {
+    if modes.route_reflector_client && modes.remote_asn != local_asn {
+        return Err(PeerModeViolation::RouteReflector(format!(
+            "route_reflector_client requires iBGP (remote_asn {} != local asn {})",
+            modes.remote_asn, local_asn
+        )));
+    }
+
+    if let Some(vantage) = modes.orr_vantage {
+        if modes.remote_asn != local_asn {
+            return Err(PeerModeViolation::RouteReflector(format!(
+                "orr_vantage requires iBGP (remote_asn {} != local asn {})",
+                modes.remote_asn, local_asn
+            )));
+        }
+        if !modes.route_reflector_client {
+            return Err(PeerModeViolation::RouteReflector(format!(
+                "orr_vantage on neighbor {subject} requires route_reflector_client = true"
+            )));
+        }
+        if exact_peer_addr == Some(vantage) {
+            return Err(PeerModeViolation::RouteReflector(format!(
+                "orr_vantage {vantage} on neighbor {subject} must not equal the \
+                 neighbor's own address"
+            )));
+        }
+        if local_router_id.parse::<IpAddr>().ok() == Some(vantage) {
+            return Err(PeerModeViolation::RouteReflector(format!(
+                "orr_vantage {vantage} on neighbor {subject} must not equal the \
+                 reflector's local router_id {local_router_id}"
+            )));
+        }
+        if vantage.is_unspecified() || vantage.is_loopback() {
+            return Err(PeerModeViolation::RouteReflector(format!(
+                "orr_vantage {vantage} on neighbor {subject} must be a real topology \
+                 address, not an unspecified or loopback address"
+            )));
+        }
+    }
+
+    if modes.route_server_client && modes.remote_asn == local_asn {
+        return Err(PeerModeViolation::RouteServer(format!(
+            "route_server_client requires eBGP (remote_asn {} == local asn {})",
+            modes.remote_asn, local_asn
+        )));
+    }
+    if modes.per_client_best && !modes.route_server_client {
+        return Err(PeerModeViolation::RouteServer(format!(
+            "per_client_best on neighbor {subject} requires route_server_client = true"
+        )));
+    }
+    if modes.next_hop_ownership && !modes.route_server_client {
+        return Err(PeerModeViolation::RouteServer(format!(
+            "next_hop_ownership on neighbor {subject} requires route_server_client = true"
+        )));
+    }
+    if modes.strict_role && !modes.role {
+        return Err(PeerModeViolation::Neighbor {
+            field: "strict_role",
+            reason: "strict_role requires role to be configured".to_string(),
+        });
+    }
+    if modes.role && modes.remote_asn == local_asn {
+        return Err(PeerModeViolation::Neighbor {
+            field: "role",
+            reason: format!(
+                "BGP Roles require eBGP (remote_asn {} == local asn {})",
+                modes.remote_asn, local_asn
+            ),
+        });
+    }
+    Ok(())
 }
 
 impl Config {
@@ -461,151 +634,15 @@ impl Config {
                 return Err(ConfigError::InvalidSlowPeerThreshold { value });
             }
 
-            // Validate route_reflector_client: must be iBGP
-            let route_reflector_client = neighbor
-                .route_reflector_client
-                .or_else(|| group.and_then(|g| g.route_reflector_client))
-                .unwrap_or(false);
-            if route_reflector_client && neighbor.remote_asn != self.global.asn {
-                return Err(ConfigError::InvalidRrConfig {
-                    reason: format!(
-                        "route_reflector_client requires iBGP (remote_asn {} != local asn {})",
-                        neighbor.remote_asn, self.global.asn
-                    ),
-                });
-            }
-
-            // Validate orr_vantage (RFC 9107): ORR is a route-reflector
-            // feature, so the vantage only makes sense on an iBGP
-            // route-reflector-client.
-            let orr_vantage = neighbor
-                .orr_vantage
-                .or_else(|| group.and_then(|g| g.orr_vantage));
-            if let Some(vantage) = orr_vantage {
-                if neighbor.remote_asn != self.global.asn {
-                    return Err(ConfigError::InvalidRrConfig {
-                        reason: format!(
-                            "orr_vantage requires iBGP (remote_asn {} != local asn {})",
-                            neighbor.remote_asn, self.global.asn
-                        ),
-                    });
-                }
-                if !route_reflector_client {
-                    return Err(ConfigError::InvalidRrConfig {
-                        reason: format!(
-                            "orr_vantage on neighbor {} requires route_reflector_client = true",
-                            neighbor.address
-                        ),
-                    });
-                }
-                // RFC 9107: the vantage must identify a *distinct* BGP-LS
-                // topology node. Equal to the client's own peering address
-                // or the reflector's router_id it degenerates to the
-                // reflector's own viewpoint (plain non-ORR reflection) — a
-                // copy-paste misconfiguration. Fail closed at config load.
-                if let Ok(peer_addr) = neighbor.address.parse::<IpAddr>()
-                    && vantage == peer_addr
-                {
-                    return Err(ConfigError::InvalidRrConfig {
-                        reason: format!(
-                            "orr_vantage {vantage} on neighbor {} must not equal the \
-                             neighbor's own address",
-                            neighbor.address
-                        ),
-                    });
-                }
-                if let Ok(local_addr) = self.global.router_id.parse::<IpAddr>()
-                    && vantage == local_addr
-                {
-                    return Err(ConfigError::InvalidRrConfig {
-                        reason: format!(
-                            "orr_vantage {vantage} on neighbor {} must not equal the \
-                             reflector's local router_id {}",
-                            neighbor.address, self.global.router_id
-                        ),
-                    });
-                }
-                // A wildcard (0.0.0.0 / ::) or loopback vantage names no real
-                // BGP-LS topology node, so ORR silently degenerates to plain
-                // reflection. Reject it at load rather than run inert.
-                if vantage.is_unspecified() || vantage.is_loopback() {
-                    return Err(ConfigError::InvalidRrConfig {
-                        reason: format!(
-                            "orr_vantage {vantage} on neighbor {} must be a real topology \
-                             address, not an unspecified or loopback address",
-                            neighbor.address
-                        ),
-                    });
-                }
-            }
-
-            let route_server_client = neighbor
-                .route_server_client
-                .or_else(|| group.and_then(|g| g.route_server_client))
-                .unwrap_or(false);
-            if route_server_client && neighbor.remote_asn == self.global.asn {
-                return Err(ConfigError::InvalidRouteServerConfig {
-                    reason: format!(
-                        "route_server_client requires eBGP (remote_asn {} == local asn {})",
-                        neighbor.remote_asn, self.global.asn
-                    ),
-                });
-            }
-
-            // RFC 7947 §2.3.2 per-client best-path is a route-server
-            // feature (eBGP-only follows transitively; ORR exclusion
-            // too — the vantage requires an iBGP RR client).
-            let per_client_best = neighbor
-                .per_client_best
-                .or_else(|| group.and_then(|g| g.per_client_best))
-                .unwrap_or(false);
-            if per_client_best && !route_server_client {
-                return Err(ConfigError::InvalidRouteServerConfig {
-                    reason: format!(
-                        "per_client_best on neighbor {} requires route_server_client = true",
-                        neighbor.address
-                    ),
-                });
-            }
-
-            // ADR-0107 NEXT_HOP ownership is a route-server ingress
-            // guard: it authorizes a member's announced next hop against
-            // the advertising session, which only makes sense on a
-            // transparent route-server client session.
-            let next_hop_ownership = neighbor
-                .next_hop_ownership
-                .or_else(|| group.and_then(|g| g.next_hop_ownership));
-            if next_hop_ownership.is_some() && !route_server_client {
-                return Err(ConfigError::InvalidRouteServerConfig {
-                    reason: format!(
-                        "next_hop_ownership on neighbor {} requires route_server_client = true",
-                        neighbor.address
-                    ),
-                });
-            }
-
-            let role = neighbor.role.or_else(|| group.and_then(|g| g.role));
-            let strict_role = neighbor
-                .strict_role
-                .or_else(|| group.and_then(|g| g.strict_role))
-                .unwrap_or(false);
-            if strict_role && role.is_none() {
-                return Err(ConfigError::InvalidNeighborConfig {
-                    address: neighbor.address.clone(),
-                    field: "strict_role".to_string(),
-                    reason: "strict_role requires role to be configured".to_string(),
-                });
-            }
-            if role.is_some() && neighbor.remote_asn == self.global.asn {
-                return Err(ConfigError::InvalidNeighborConfig {
-                    address: neighbor.address.clone(),
-                    field: "role".to_string(),
-                    reason: format!(
-                        "BGP Roles require eBGP (remote_asn {} == local asn {})",
-                        neighbor.remote_asn, self.global.asn
-                    ),
-                });
-            }
+            let modes = EffectivePeerModes::for_neighbor(neighbor, group);
+            validate_effective_peer_modes(
+                modes,
+                self.global.asn,
+                &self.global.router_id,
+                &neighbor.address,
+                neighbor.address.parse().ok(),
+            )
+            .map_err(|violation| violation.into_static_error(&neighbor.address))?;
 
             if let Some(mode) = neighbor
                 .remove_private_as
@@ -1014,6 +1051,22 @@ impl Config {
                     ),
                 });
             };
+
+            validate_effective_peer_modes(
+                EffectivePeerModes::for_dynamic(dn.remote_asn, group),
+                self.global.asn,
+                &self.global.router_id,
+                &dn.prefix,
+                None,
+            )
+            .map_err(|violation| ConfigError::InvalidDynamicNeighbor {
+                reason: format!(
+                    "dynamic_neighbors[{i}] prefix {:?} via peer_group {:?}: {}",
+                    dn.prefix,
+                    dn.peer_group,
+                    violation.reason()
+                ),
+            })?;
 
             if !group.required_families.is_empty() {
                 let required = parse_families(&group.required_families).map_err(|err| {


### PR DESCRIPTION
## Summary

- apply the existing RR, ORR, route-server, NEXT_HOP ownership, and BGP Role invariants to dynamic neighbor ranges after peer-group inheritance
- preserve wildcard remote ASN semantics while rejecting invalid iBGP-only modes
- derive route-reflector mode and the default cluster ID from valid dynamic-only RR groups
- document the validation boundary and add focused configuration/transport regressions

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpd --all-targets -- -D warnings`
- `cargo test -p rustbgpd`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `python3 scripts/check-v1-stable-surface.py`
- independent exact-candidate review approved

## Load-bearing regression proofs

- removing only the dynamic validator call compiles, then makes the invalid-mode matrix fail because bad dynamic RR configuration loads
- disabling only dynamic RR cluster detection compiles, then makes the valid dynamic-only RR test fail with no derived cluster ID

Scope: four files, 487 changed lines.