### PR TITLE
Include dynamic ranges in RFC 8212 preflight diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- RFC 8212 diagnostics now include dynamic eBGP ranges, peer groups, and `any AS`.
+
 - The shipped BGP session-down alert now uses exact current truth instead of
   inferring state from historical counters. New
   `bgp_peer_admin_enabled{peer,interface}` and

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -432,10 +432,11 @@ reserved policy names. A `[policy.definitions]` entry or `.rpol` policy using
 either is rejected at load, so the reserved chain can never be shadowed and
 neighbor status and explain output can attribute it unambiguously.
 
-**Before the daemon runs.** `rustbgpd --check` names every eBGP neighbor that
-resolves no explicit policy and the direction(s) it is missing, whether the
-knob is on (that direction will carry no routes) or off (that direction is
-unfiltered). It stays a warning — a permit-all route server is a legitimate
+**Before the daemon runs.** `rustbgpd --check` names every configured eBGP
+neighbor or dynamic range lacking explicit policy and names the missing
+directions. Dynamic rows also name the prefix, peer group, and fixed or
+`any AS`; the knob decides whether a missing direction carries no routes or is
+unfiltered. It stays a warning — a permit-all route server is a legitimate
 configuration — but a check with warnings summarizes as `config VALID, <n>
 WARNINGS — NOT a clean check` rather than `config OK`. The exit code is 0
 either way; add `--strict` (see [deployment.md](deployment.md)) to make any

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -75,8 +75,8 @@ Prints rustc-style diagnostics on error, or `config OK` on success.
 A valid config can still be worth flagging. When it is, the summary reads
 `config VALID, <n> WARNINGS — NOT a clean check` instead of `config OK`,
 the warnings are framed on stderr above it, and the exit code stays 0 —
-these are things to look at, not failures. Today that means an eBGP
-neighbor resolving no explicit policy in a direction: unfiltered with
+these are things to look at, not failures. Today this means a configured eBGP
+neighbor or dynamic range with no explicit policy in a direction: unfiltered with
 `[global] ebgp_requires_policy` off, carrying no routes in that direction
 with it on. Both are legitimate configurations; neither should reach
 production unnoticed.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -428,8 +428,8 @@ scaling out.
    A check that finds nothing to flag prints `config OK`. A check that
    flags something still exits 0, but the summary reads
    `config VALID, <n> WARNINGS — NOT a clean check` and the warnings are
-   framed on stderr above it. The one warning today is an eBGP neighbor
-   that resolves no explicit policy in a direction: unfiltered when
+   framed on stderr above it. The warning identifies a configured eBGP neighbor
+   or dynamic range with no explicit policy in a direction: unfiltered when
    `[global] ebgp_requires_policy` is off, and carrying no routes in that
    direction when it is on. Neither is rejected — a permit-all route
    server is a legitimate configuration — but neither should reach

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,6 +27,7 @@ use rustbgpd_wire::{
     MacAddress, Prefix, RouteDistinguisher, Safi,
 };
 
+pub(crate) use resolution::UnpolicedEbgpBoundary;
 #[allow(
     unused_imports,
     reason = "preserve the crate::config helper path for sibling modules; the binary mirror has no local importer"

--- a/src/config/resolution.rs
+++ b/src/config/resolution.rs
@@ -121,6 +121,39 @@ impl Config {
             .collect()
     }
 
+    pub(crate) fn unpoliced_ebgp_boundaries(&self) -> Vec<UnpolicedEbgpBoundary> {
+        let static_neighbors =
+            self.unpoliced_ebgp_neighbors()
+                .into_iter()
+                .map(|neighbor| UnpolicedEbgpBoundary {
+                    import_missing: neighbor.import_missing,
+                    export_missing: neighbor.export_missing,
+                    subject: UnpolicedEbgpSubject::StaticNeighbor(neighbor),
+                });
+        let dynamic_ranges = self.dynamic_neighbors.iter().filter_map(|range| {
+            let addr = super::dynamic_range_representative_addr(&range.prefix)?;
+            let neighbor = Self::synthetic_dynamic_neighbor(
+                addr,
+                range.remote_asn,
+                range.description.as_deref().unwrap_or(&range.peer_group),
+                &range.peer_group,
+            );
+            let resolved = self.effective_policy_for_neighbor(&neighbor, false).ok()?;
+            (resolved.external && !(resolved.import_explicit && resolved.export_explicit)).then(
+                || UnpolicedEbgpBoundary {
+                    subject: UnpolicedEbgpSubject::DynamicRange {
+                        prefix: range.prefix.clone(),
+                        peer_group: range.peer_group.clone(),
+                        remote_asn: std::num::NonZeroU32::new(range.remote_asn),
+                    },
+                    import_missing: !resolved.import_explicit,
+                    export_missing: !resolved.export_explicit,
+                },
+            )
+        });
+        static_neighbors.chain(dynamic_ranges).collect()
+    }
+
     /// Resolve the global import policy chain (named policies referenced
     /// by `[policy] import_chain`). `None` when no chain is configured.
     #[allow(
@@ -862,18 +895,13 @@ impl Config {
     /// OPEN must set `external_pinned` from the session's pinned
     /// classification, or a wildcard-accepted child could be re-resolved as
     /// iBGP mid-session.
-    pub(crate) fn resolve_dynamic_neighbor(
-        &self,
+    fn synthetic_dynamic_neighbor(
         addr: IpAddr,
         remote_asn: u32,
         description: &str,
-        _group: &PeerGroupConfig,
         peer_group_name: &str,
-        external_pinned: bool,
-    ) -> Result<ResolvedNeighbor, ConfigError> {
-        // Build a synthetic Neighbor that references the peer group.
-        // All fields come from the group via the normal resolution path.
-        let neighbor = Neighbor {
+    ) -> Neighbor {
+        Neighbor {
             min_hold_time: None,
             address: addr.to_string(),
             interface: None,
@@ -921,7 +949,22 @@ impl Config {
             export_policy: Vec::new(),
             import_policy_chain: Vec::new(),
             export_policy_chain: Vec::new(),
-        };
+        }
+    }
+
+    pub(crate) fn resolve_dynamic_neighbor(
+        &self,
+        addr: IpAddr,
+        remote_asn: u32,
+        description: &str,
+        _group: &PeerGroupConfig,
+        peer_group_name: &str,
+        external_pinned: bool,
+    ) -> Result<ResolvedNeighbor, ConfigError> {
+        // Build a synthetic Neighbor that references the peer group.
+        // All fields come from the group via the normal resolution path.
+        let neighbor =
+            Self::synthetic_dynamic_neighbor(addr, remote_asn, description, peer_group_name);
         self.resolve_neighbor_pinned(&neighbor, external_pinned)
     }
 
@@ -1182,6 +1225,61 @@ impl UnpolicedEbgpNeighbor {
     /// The missing direction(s) as a report phrase.
     #[must_use]
     pub fn missing_phrase(&self) -> &'static str {
+        match (self.import_missing, self.export_missing) {
+            (true, true) => "no import policy and no export policy",
+            (true, false) => "no import policy",
+            (false, true) => "no export policy",
+            // Not constructed: the resolver only yields a record when at
+            // least one direction is missing.
+            (false, false) => "",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum UnpolicedEbgpSubject {
+    StaticNeighbor(UnpolicedEbgpNeighbor),
+    DynamicRange {
+        prefix: String,
+        peer_group: String,
+        /// `None` is the configured wildcard, rendered as `any AS`.
+        remote_asn: Option<std::num::NonZeroU32>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct UnpolicedEbgpBoundary {
+    subject: UnpolicedEbgpSubject,
+    import_missing: bool,
+    export_missing: bool,
+}
+
+impl UnpolicedEbgpBoundary {
+    pub(crate) fn is_dynamic_range(&self) -> bool {
+        matches!(self.subject, UnpolicedEbgpSubject::DynamicRange { .. })
+    }
+
+    pub(crate) fn identity_phrase(&self) -> String {
+        match &self.subject {
+            UnpolicedEbgpSubject::StaticNeighbor(neighbor) => {
+                format!("{} (AS {})", neighbor.address, neighbor.remote_asn)
+            }
+            UnpolicedEbgpSubject::DynamicRange {
+                prefix,
+                peer_group,
+                remote_asn,
+            } => {
+                let asn =
+                    remote_asn.map_or_else(|| "any AS".to_string(), |asn| format!("AS {asn}"));
+                format!("dynamic range {prefix} via peer group {peer_group:?} ({asn})")
+            }
+        }
+    }
+
+    pub(crate) fn missing_phrase(&self) -> &'static str {
+        if let UnpolicedEbgpSubject::StaticNeighbor(neighbor) = &self.subject {
+            return neighbor.missing_phrase();
+        }
         match (self.import_missing, self.export_missing) {
             (true, true) => "no import policy and no export policy",
             (true, false) => "no import policy",

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -17370,3 +17370,35 @@ fn unpoliced_ebgp_neighbors_names_the_missing_directions() {
     );
     assert!(unpoliced(&rfc8212_toml("", "", 65001, "")).is_empty());
 }
+
+#[test]
+fn unpoliced_ebgp_boundaries_include_dynamic_ranges() {
+    let unpoliced = |toml: &str| parse(toml).unwrap().unpoliced_ebgp_boundaries();
+    let dynamic = |global: &str, static_asn, range_asn, group: &str| {
+        format!(
+            "{}\n[peer_groups.ix]\n{group}\n[[dynamic_neighbors]]\n\
+             prefix = \"192.0.2.0/24\"\npeer_group = \"ix\"\nremote_asn = {range_asn}\n",
+            rfc8212_toml(global, "", static_asn, "")
+        )
+    };
+    let wildcard = unpoliced(&dynamic("", 65001, 0, ""));
+    assert!(wildcard[0].identity_phrase().ends_with("(any AS)"));
+    assert_eq!(
+        unpoliced(&dynamic("ebgp_requires_policy = true", 65001, 0, "")),
+        wildcard
+    );
+    let fixed = unpoliced(&dynamic("", 65001, 65002, ""));
+    assert!(fixed[0].identity_phrase().ends_with("(AS 65002)"));
+    assert!(unpoliced(&dynamic("", 65001, 65001, "")).is_empty());
+    let import = "import_policy = [{ action = \"permit\", prefix = \"0.0.0.0/0\", le = 32 }]";
+    assert_eq!(
+        unpoliced(&dynamic("", 65001, 0, import))[0].missing_phrase(),
+        "no export policy"
+    );
+    let export = "export_policy = [{ action = \"permit\", prefix = \"0.0.0.0/0\" }]";
+    let complete = format!("{import}\n{export}");
+    assert!(unpoliced(&dynamic("", 65001, 0, &complete)).is_empty());
+    let mixed = unpoliced(&dynamic("", 65002, 0, ""));
+    assert!(mixed[0].identity_phrase().starts_with("10.0.0.2"));
+    assert!(mixed[1].identity_phrase().starts_with("dynamic range"));
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,7 @@ use tracing::{error, info, warn};
 
 use crate::config::{
     Config, GrpcAccessMode, GrpcEnforcementConfig, GrpcListener, GrpcMaxTier, GrpcRoleConfig,
+    UnpolicedEbgpBoundary,
 };
 use crate::config_persister::{ConfigMutation, ConfigPersister};
 use crate::peer_manager::PeerManager;
@@ -1882,8 +1883,8 @@ fn print_framed_warning(headline: &str, body: &str) {
     eprintln!("{}\n", rule.if_supports_color(Stderr, OwoColorize::yellow));
 }
 
-/// Print the `--check` warning for eBGP neighbors that resolve no explicit
-/// policy, and return how many there are.
+/// Print the `--check` warning for configured eBGP boundaries that resolve no
+/// explicit policy, and return how many there are.
 ///
 /// `--check` is the last gate before an operator copies a config to
 /// production, so a wide-open (or, under `ebgp_requires_policy`, a fully
@@ -1893,24 +1894,31 @@ fn print_framed_warning(headline: &str, body: &str) {
 fn warn_unpoliced_ebgp(config: &Config) -> usize {
     use std::fmt::Write as _;
 
-    let unpoliced = config.unpoliced_ebgp_neighbors();
+    let unpoliced = config.unpoliced_ebgp_boundaries();
     if unpoliced.is_empty() {
         return 0;
     }
+    let has_dynamic_range = unpoliced
+        .iter()
+        .any(UnpolicedEbgpBoundary::is_dynamic_range);
+    let subject = match (has_dynamic_range, unpoliced.len()) {
+        (false, 1) => "eBGP neighbor",
+        (false, _) => "eBGP neighbors",
+        (true, 1) => "configured eBGP policy boundary",
+        (true, _) => "configured eBGP policy boundaries",
+    };
     let headline = format!(
-        "{} eBGP neighbor{} resolve{} no explicit policy.",
+        "{} {subject} resolve{} no explicit policy.",
         unpoliced.len(),
-        if unpoliced.len() == 1 { "" } else { "s" },
         if unpoliced.len() == 1 { "s" } else { "" },
     );
     let mut body = String::new();
-    for neighbor in &unpoliced {
+    for boundary in &unpoliced {
         let _ = writeln!(
             body,
-            "  {} (AS {}): {}",
-            neighbor.address,
-            neighbor.remote_asn,
-            neighbor.missing_phrase()
+            "  {}: {}",
+            boundary.identity_phrase(),
+            boundary.missing_phrase()
         );
     }
     body.push('\n');
@@ -2972,18 +2980,40 @@ async fn run<T>(
     // deployment, but a runtime config mutation rewrites the file
     // canonically and takes any banner the operator wrote with it — the log
     // is then the only place the posture is still stated.
-    let unpoliced_ebgp = config.unpoliced_ebgp_neighbors().len();
-    if unpoliced_ebgp > 0 {
-        tracing::warn!(
-            neighbors = unpoliced_ebgp,
-            ebgp_requires_policy = config.global.ebgp_requires_policy,
-            "eBGP policy posture: {unpoliced_ebgp} neighbor(s) resolve no explicit policy — {}",
-            if config.global.ebgp_requires_policy {
+    let unpoliced_ebgp = config.unpoliced_ebgp_boundaries();
+    if !unpoliced_ebgp.is_empty() {
+        let dynamic_ranges = unpoliced_ebgp
+            .iter()
+            .filter(|boundary| boundary.is_dynamic_range())
+            .count();
+        if dynamic_ranges == 0 {
+            let unpoliced_ebgp = unpoliced_ebgp.len();
+            tracing::warn!(
+                neighbors = unpoliced_ebgp,
+                ebgp_requires_policy = config.global.ebgp_requires_policy,
+                "eBGP policy posture: {unpoliced_ebgp} neighbor(s) resolve no explicit policy — {}",
+                if config.global.ebgp_requires_policy {
+                    "those directions carry no routes (RFC 8212 reserved deny)"
+                } else {
+                    "those directions are unfiltered (permit all)"
+                }
+            );
+        } else {
+            let policy_boundaries = unpoliced_ebgp.len();
+            let neighbors = policy_boundaries - dynamic_ranges;
+            let consequence = if config.global.ebgp_requires_policy {
                 "those directions carry no routes (RFC 8212 reserved deny)"
             } else {
                 "those directions are unfiltered (permit all)"
-            }
-        );
+            };
+            tracing::warn!(
+                policy_boundaries,
+                neighbors,
+                dynamic_ranges,
+                ebgp_requires_policy = config.global.ebgp_requires_policy,
+                "eBGP policy posture: configured boundaries resolving no explicit policy: {policy_boundaries} — {consequence}"
+            );
+        }
     }
 
     let metrics = BgpMetrics::new();

--- a/tests/check_strict.rs
+++ b/tests/check_strict.rs
@@ -180,6 +180,67 @@ fn run(config_toml: &str, args: &[&str]) -> (Option<i32>, String, String) {
     )
 }
 
+fn dynamic_config(enforced: bool, policy_complete: bool) -> String {
+    let group_policy = if policy_complete {
+        "import_policy = [{ action = \"permit\", prefix = \"0.0.0.0/0\", le = 32 }]\n\
+         export_policy = [{ action = \"permit\", prefix = \"0.0.0.0/0\", le = 32 }]"
+    } else {
+        ""
+    };
+    let mut config = format!(
+        r#"
+{base}
+[peer_groups.ix]
+{group_policy}
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix"
+remote_asn = 0
+"#,
+        base = WARNS.replace(
+            "[[neighbors]]\naddress = \"10.0.0.2\"\nremote_asn = 65002",
+            ""
+        )
+    );
+    if enforced {
+        config = config.replacen(
+            "runtime_state_dir = \"/tmp/rustbgpd-check-strict\"",
+            "runtime_state_dir = \"/tmp/rustbgpd-check-strict\"\nebgp_requires_policy = true",
+            1,
+        );
+    }
+    config
+}
+
+#[test]
+fn check_dynamic_range_policy_warning_matrix() {
+    for (enforced, consequence) in [(false, "unfiltered"), (true, "reserved deny")] {
+        let config = dynamic_config(enforced, false);
+        let (code, stdout, stderr) = run(&config, &["--check"]);
+        assert_eq!(code, Some(0), "stdout:\n{stdout}\nstderr:\n{stderr}");
+        assert!(stdout.contains("config VALID, 1 WARNING — NOT a clean check"));
+        assert!(stderr.contains(consequence), "{stderr}");
+        assert!(stderr.contains(
+            "dynamic range 192.0.2.0/24 via peer group \"ix\" (any AS): \
+             no import policy and no export policy"
+        ));
+        assert!(!stderr.contains("AS 0"), "{stderr}");
+
+        let (code, stdout, stderr) = run(&config, &["--check", "--strict"]);
+        assert_eq!(code, Some(1), "stdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+    for enforced in [false, true] {
+        let clean = dynamic_config(enforced, true);
+        for args in [&["--check"][..], &["--check", "--strict"][..]] {
+            let (code, stdout, stderr) = run(&clean, args);
+            assert_eq!(code, Some(0), "stdout:\n{stdout}\nstderr:\n{stderr}");
+            assert!(stdout.contains("config OK"), "{stdout}");
+            assert!(!stderr.contains("WARNING"), "{stderr}");
+        }
+    }
+}
+
 /// Backward compatibility: warnings alone never fail a plain `--check`.
 #[test]
 fn check_without_strict_exits_zero_on_warnings() {
@@ -193,6 +254,8 @@ fn check_without_strict_exits_zero_on_warnings() {
         stderr.contains("WARNING"),
         "warning was not framed on stderr:\n{stderr}"
     );
+    assert!(stderr.contains("1 eBGP neighbor resolves no explicit policy."));
+    assert!(stderr.contains("  10.0.0.2 (AS 65002): no import policy and no export policy"));
 }
 
 /// The feature: the same config, the same warnings, a failing exit code.


### PR DESCRIPTION
## Summary

- include configured dynamic eBGP acceptance ranges in RFC 8212 preflight and startup posture diagnostics
- identify each range by prefix, peer group, and fixed or `any AS` semantics while never exposing wildcard sentinel `AS 0`
- reuse the production dynamic-neighbor policy resolver and explicit-policy provenance
- preserve the existing public static helper API, static-only check text, and static-only startup tracing fields/message

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpd --all-targets --all-features -- -D warnings`
- `cargo test -p rustbgpd`
- focused config and `--check --strict` matrices under enforcement off/on
- `python3 scripts/check-v1-stable-surface.py`
- independent exact-candidate review approved

## Load-bearing regression proofs

Each isolated mutation compiled and made the focused CLI regression fail at the intended assertion:

- removing dynamic enumeration returned the configuration to false-clean
- rendering wildcard ASN as `AS 0` broke the exact `any AS` row
- using compiled-chain presence instead of explicit provenance hid the enforcement-on warning
- omitting the peer group broke the exact operator identity row

Scope: nine files, 299 changed lines.