### PR TITLE
Include dynamic neighbor groups in ORR topology advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - RFC 8212 diagnostics now include dynamic eBGP ranges, peer groups, and `any AS`.
 
+- Dynamic-neighbor ranges now validate inherited route-reflector, ORR,
+  route-server, and BGP Role combinations, contribute fixed local-AS RR clients
+  to implicit cluster-ID selection, and count referenced BGP-LS peer groups in
+  ORR topology advisories.
+
 - The shipped BGP session-down alert now uses exact current truth instead of
   inferring state from historical counters. New
   `bgp_peer_admin_enabled{peer,interface}` and

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3780,6 +3780,23 @@ peer_group = "clients"
     )
 }
 
+fn orr_dynamic_toml(neighbor_fields: &str, dynamic_group_fields: &str) -> String {
+    format!(
+        r#"
+{base}
+
+[peer_groups.dynamic]
+{dynamic_group_fields}
+
+[[dynamic_neighbors]]
+prefix = "10.0.1.0/24"
+peer_group = "dynamic"
+remote_asn = 65001
+"#,
+        base = orr_toml(neighbor_fields, "")
+    )
+}
+
 #[test]
 fn orr_vantage_inherits_from_peer_group() {
     let toml = orr_toml(
@@ -3971,6 +3988,14 @@ fn orr_vantage_without_linkstate_raises_an_advisory() {
     // One line, so a log record stays one record.
     assert!(!text.contains('\n'), "one_line kept a newline: {text}");
 
+    // Static peer-group inheritance raises the identical final advisory.
+    let inherited = parse(&orr_toml(
+        "",
+        "orr_vantage = \"192.0.2.7\"\nroute_reflector_client = true",
+    ))
+    .unwrap();
+    assert_eq!(inherited.advisories(), vec![advisory]);
+
     // Cleared once a neighbor carries the feed.
     let toml = orr_toml(
         "orr_vantage = \"192.0.2.7\"\nroute_reflector_client = true\nfamilies = [\"ipv4_unicast\", \"linkstate\"]",
@@ -3978,6 +4003,44 @@ fn orr_vantage_without_linkstate_raises_an_advisory() {
     );
     let config = parse(&toml).unwrap();
     assert!(config.advisories().is_empty(), "{:?}", config.advisories());
+}
+
+#[test]
+fn orr_advisory_accounts_for_dynamic_peer_group_topology() {
+    // Load-bearing metamorphic matrix: removing dynamic-range enumeration
+    // misses the dynamic-only warning and the dynamic feed, while adding a
+    // static feed to the same dynamic vantage must clear the warning.
+    let vantage = "orr_vantage = \"192.0.2.7\"\nroute_reflector_client = true";
+    let vantage_and_feed = format!("{vantage}\nfamilies = [\"linkstate\"]");
+    let cases = [
+        ("dynamic vantage without feed warns", "", vantage, true),
+        (
+            "dynamic vantage with static feed clears",
+            "families = [\"linkstate\"]",
+            vantage,
+            false,
+        ),
+        (
+            "static vantage with dynamic feed clears",
+            vantage,
+            "families = [\"linkstate\"]",
+            false,
+        ),
+        (
+            "dynamic vantage with dynamic feed clears",
+            "",
+            &vantage_and_feed,
+            false,
+        ),
+    ];
+    for (case, static_fields, dynamic_fields, expected) in cases {
+        let config = parse(&orr_dynamic_toml(static_fields, dynamic_fields)).unwrap();
+        let advisories = config.advisories();
+        let actual = advisories
+            .iter()
+            .any(|advisory| advisory.headline.contains("orr_vantage"));
+        assert_eq!(actual, expected, "{case}: {advisories:?}");
+    }
 }
 
 #[test]

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -1248,10 +1248,10 @@ impl Config {
         Ok(())
     }
 
-    /// True when any neighbor (directly or via its peer group) has an
-    /// effective `orr_vantage` but NO neighbor's effective `families`
-    /// include `"linkstate"` — i.e. the BGP-LS topology feed the ORR SPF
-    /// needs would be empty. Pure so the warning condition is testable.
+    /// True when any static neighbor or dynamic range's referenced peer group
+    /// has an effective `orr_vantage`, but none has `"linkstate"` in its
+    /// effective `families` — i.e. the BGP-LS topology feed the ORR SPF needs
+    /// would be empty. Pure so the warning condition is testable.
     pub(crate) fn orr_vantage_without_linkstate(&self) -> bool {
         let group_of = |neighbor: &super::Neighbor| {
             neighbor
@@ -1259,15 +1259,20 @@ impl Config {
                 .as_deref()
                 .and_then(|name| self.peer_groups.get(name))
         };
+        let dynamic_groups = || {
+            self.dynamic_neighbors
+                .iter()
+                .filter_map(|range| self.peer_groups.get(&range.peer_group))
+        };
         let any_vantage = self.neighbors.iter().any(|n| {
             n.orr_vantage
                 .or_else(|| group_of(n).and_then(|g| g.orr_vantage))
                 .is_some()
-        });
+        }) || dynamic_groups().any(|group| group.orr_vantage.is_some());
         if !any_vantage {
             return false;
         }
-        !self.neighbors.iter().any(|n| {
+        let static_linkstate = self.neighbors.iter().any(|n| {
             let own = &n.families;
             let effective: &[String] = if own.is_empty() {
                 group_of(n).map_or(&[], |g| g.families.as_slice())
@@ -1275,7 +1280,10 @@ impl Config {
                 own.as_slice()
             };
             effective.iter().any(|f| f == "linkstate")
-        })
+        });
+        let dynamic_linkstate =
+            dynamic_groups().any(|group| group.families.iter().any(|f| f == "linkstate"));
+        !(static_linkstate || dynamic_linkstate)
     }
 
     /// Every advisory this configuration raises, in a stable order.


### PR DESCRIPTION
## Summary

- include peer groups referenced by dynamic neighbor ranges when deciding whether configured ORR vantages have a BGP-LS feed
- clear false advisories for static-vantage/dynamic-feed and dynamic-vantage/static-feed configurations
- preserve the existing static effective-neighbor path, advisory value, ordering, and all runtime ORR/BGP-LS behavior
- record the dynamic RR validation, implicit cluster-ID, and advisory corrections in the Unreleased notes

## Stack status

The prerequisite #1277 is merged. This branch is rebased directly onto `main`; the child patch ID is unchanged from the independently reviewed stack.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpd --all-targets --all-features -- -D warnings`
- `cargo test -p rustbgpd`
- all focused ORR advisory tests
- `python3 scripts/check-v1-stable-surface.py`
- independent exact-candidate and exact-stack reviews approved

## Load-bearing regression proof

Removing only dynamic-range peer-group enumeration compiles, then makes the final-advisory matrix fail because the dynamic-vantage/no-feed warning disappears. The feed-present clear cases remain paired in that same load-bearing behavior test without asserting helper internals.

Scope: three files, 90 changed lines.