### PR TITLE
Expose dynamic-neighbor capacity metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Four label-free process-global metrics now expose dynamic-neighbor slots
+  used, configured limit, remaining headroom, and admission-limit rejections
+  across accept, ordinary removal, rollback reap, and retained-disabled
+  max-prefix recovery lifecycles.
+
 - `NeighborService.AddNeighbor` now accepts an additive presence-aware wrapper
   that preserves peer-group inheritance and explicit masked `false`, family
   replacement, and Add-Path disable intent across persistence, live apply, and

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -201,6 +201,12 @@ pub struct BgpMetrics {
     peer_session_established: IntGaugeVec,
     stale_timer_events: IntCounterVec,
 
+    // ── Dynamic-neighbor capacity ─────────────────────────────────
+    dynamic_neighbor_slots_used: IntGauge,
+    dynamic_neighbor_slots_limit: IntGauge,
+    dynamic_neighbor_slots_headroom: IntGauge,
+    dynamic_neighbor_limit_rejections: IntCounter,
+
     // ── BFD (RFC 5880, ADR-0067) ───────────────────────────────────
     bfd_session_up: IntGaugeVec,
     bfd_session_flaps_total: IntCounterVec,
@@ -508,6 +514,30 @@ impl BgpMetrics {
                 "FSM timer-expired events that arrived in a state where the corresponding timer should not be running. Non-zero values point at a daemon-side timer-management bug; the FSM ignores these events rather than tearing the session down.",
             ),
             &["peer", "state", "timer"],
+        )
+        .expect("valid metric definition");
+
+        let dynamic_neighbor_slots_used = IntGauge::new(
+            "bgp_dynamic_neighbor_slots_used",
+            "Dynamic neighbors currently consuming process-global admission slots, including disabled max-prefix recovery targets.",
+        )
+        .expect("valid metric definition");
+
+        let dynamic_neighbor_slots_limit = IntGauge::new(
+            "bgp_dynamic_neighbor_slots_limit",
+            "Configured process-global dynamic-neighbor admission limit.",
+        )
+        .expect("valid metric definition");
+
+        let dynamic_neighbor_slots_headroom = IntGauge::new(
+            "bgp_dynamic_neighbor_slots_headroom",
+            "Remaining process-global dynamic-neighbor admission slots before the configured limit.",
+        )
+        .expect("valid metric definition");
+
+        let dynamic_neighbor_limit_rejections = IntCounter::new(
+            "bgp_dynamic_neighbor_limit_rejections_total",
+            "Inbound dynamic-neighbor connections dropped because the process-global admission limit was reached.",
         )
         .expect("valid metric definition");
 
@@ -1872,6 +1902,18 @@ impl BgpMetrics {
             .register(Box::new(stale_timer_events.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(dynamic_neighbor_slots_used.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(dynamic_neighbor_slots_limit.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(dynamic_neighbor_slots_headroom.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(dynamic_neighbor_limit_rejections.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(notifications_sent.clone()))
             .expect("metric not already registered");
         registry
@@ -2330,6 +2372,10 @@ impl BgpMetrics {
             peer_admin_enabled,
             peer_session_established,
             stale_timer_events,
+            dynamic_neighbor_slots_used,
+            dynamic_neighbor_slots_limit,
+            dynamic_neighbor_slots_headroom,
+            dynamic_neighbor_limit_rejections,
             bfd_session_up,
             bfd_session_flaps_total,
             gnmi_dialout_connected,
@@ -2486,6 +2532,21 @@ impl BgpMetrics {
     #[must_use]
     pub fn registry(&self) -> &Registry {
         &self.registry
+    }
+
+    /// Publish the authoritative process-global dynamic-neighbor slot state.
+    pub fn set_dynamic_neighbor_capacity(&self, used: usize, limit: u32) {
+        let used = i64::try_from(used).unwrap_or(i64::MAX);
+        self.dynamic_neighbor_slots_used.set(used);
+        self.dynamic_neighbor_slots_limit.set(i64::from(limit));
+        self.dynamic_neighbor_slots_headroom.set(i64::from(
+            limit.saturating_sub(u32::try_from(used).unwrap_or(u32::MAX)),
+        ));
+    }
+
+    /// Record an inbound dynamic-neighbor drop caused by slot saturation.
+    pub fn record_dynamic_neighbor_limit_rejection(&self) {
+        self.dynamic_neighbor_limit_rejections.inc();
     }
 
     // ── Per-peer series reaping ────────────────────────────────────
@@ -4449,6 +4510,52 @@ mod tests {
         let text = gather_text(&m);
         // Dynamic peer-label vectors remain absent until observed.
         assert!(!text.contains("bgp_session_state_transitions_total"));
+    }
+
+    /// Load-bearing registration proof: removing any one scalar metric makes
+    /// its required process-global family disappear from the gathered surface.
+    #[test]
+    fn dynamic_neighbor_capacity_metric_families_are_process_global() {
+        let metrics = BgpMetrics::new();
+        let families = metrics.registry().gather();
+        for name in [
+            "bgp_dynamic_neighbor_slots_used",
+            "bgp_dynamic_neighbor_slots_limit",
+            "bgp_dynamic_neighbor_slots_headroom",
+            "bgp_dynamic_neighbor_limit_rejections_total",
+        ] {
+            let family = families
+                .iter()
+                .find(|family| family.name() == name)
+                .unwrap_or_else(|| panic!("{name} must be registered"));
+            assert_eq!(family.get_metric().len(), 1, "{name} has one global series");
+            assert!(
+                family.get_metric()[0].get_label().is_empty(),
+                "{name} must remain label-free"
+            );
+        }
+    }
+
+    /// Load-bearing telemetry API proof: removing the setter, saturating
+    /// headroom calculation, or rejection increment breaks an exact scalar.
+    #[test]
+    fn dynamic_neighbor_capacity_metrics_publish_values_and_rejections() {
+        let metrics = BgpMetrics::new();
+        metrics.set_dynamic_neighbor_capacity(3, 5);
+        metrics.record_dynamic_neighbor_limit_rejection();
+        metrics.record_dynamic_neighbor_limit_rejection();
+
+        assert_eq!(metrics.dynamic_neighbor_slots_used.get(), 3);
+        assert_eq!(metrics.dynamic_neighbor_slots_limit.get(), 5);
+        assert_eq!(metrics.dynamic_neighbor_slots_headroom.get(), 2);
+        assert_eq!(metrics.dynamic_neighbor_limit_rejections.get(), 2);
+
+        metrics.set_dynamic_neighbor_capacity(6, 5);
+        assert_eq!(
+            metrics.dynamic_neighbor_slots_headroom.get(),
+            0,
+            "headroom saturates instead of reporting a negative capacity"
+        );
     }
 
     #[test]

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -691,11 +691,24 @@ the same 200 ms core-actor deadline as `/readyz`.
 
 ### Routing
 
+Dynamic-neighbor admission capacity is process-global and deliberately
+label-free. The three slot gauges are materialized when `PeerManager` starts:
+`used` counts accepted dynamic peers that still own a slot, `limit` mirrors
+`global.dynamic_neighbor_limit`, and `headroom` is the saturating difference.
+Ordinary Idle removal and config-rollback reaping return a slot; a terminal
+max-prefix peer retained disabled for explicit recovery still owns one.
+`bgp_dynamic_neighbor_limit_rejections_total` increments only when a matching
+inbound dynamic connection is dropped because all slots are occupied.
+
 | Metric | What it tells you |
 |--------|-------------------|
 | `bgp_rib_loc_prefixes{afi_safi}` | Loc-RIB size (best paths) per AFI/SAFI |
 | `bgp_rib_prefixes{peer,afi_safi}` | Adj-RIB-In size per peer + AFI/SAFI (received) |
 | `bgp_rib_adj_out_prefixes{peer,afi_safi}` | Adj-RIB-Out size per peer + AFI/SAFI (advertised) |
+| `bgp_dynamic_neighbor_slots_used` | Dynamic peers currently consuming the process-global admission limit, including retained disabled max-prefix recovery targets |
+| `bgp_dynamic_neighbor_slots_limit` | Effective process-global `dynamic_neighbor_limit` |
+| `bgp_dynamic_neighbor_slots_headroom` | Saturating `limit - used`; zero means the next matching dynamic inbound is rejected |
+| `bgp_dynamic_neighbor_limit_rejections_total` | Matching inbound dynamic connections rejected because the slot limit was already full |
 | `bgp_max_prefix_usage{peer,scope}` | Live session-actor max-prefix enforcement count for `aggregate`, `ipv4_unicast`, or `ipv6_unicast`; series are absent while the session is down |
 | `bgp_max_prefix_limit{peer,scope}` | Effective finite bound for the same scope; absent means unlimited, never zero |
 | `bgp_max_prefix_headroom{peer,scope}` | Saturating `limit - usage` for a finite scope; absent when unlimited or disconnected |

--- a/src/peer_manager/dynamic.rs
+++ b/src/peer_manager/dynamic.rs
@@ -445,6 +445,7 @@ impl PeerManager {
             self.reap_deleted_peer_metric_series_for_key(&peer_key)
                 .await;
             self.dynamic_peer_count = self.dynamic_peer_count.saturating_sub(1);
+            self.refresh_dynamic_neighbor_capacity_metrics();
             removed += 1;
             info!(
                 peer = %peer_key,

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -346,6 +346,7 @@ impl PeerManager {
             if let Some(range) = self.match_dynamic_range(peer_ip) {
                 // Check dynamic peer limit
                 if self.dynamic_peer_count >= self.dynamic_neighbor_limit as usize {
+                    self.metrics.record_dynamic_neighbor_limit_rejection();
                     warn!(
                         %peer_ip,
                         limit = self.dynamic_neighbor_limit,
@@ -537,6 +538,7 @@ impl PeerManager {
                 self.register_session(session_id, &peer_key);
                 self.sync_owned_session_metrics(&peer_key).await;
                 self.dynamic_peer_count += 1;
+                self.refresh_dynamic_neighbor_capacity_metrics();
                 // ADR-0112: the accepted child carries the range's pinned
                 // external classification and its resolved chains.
                 self.refresh_rfc8212_policy_metrics(&peer_key);

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -573,6 +573,10 @@ impl PeerManager {
         for handle in current_config.policy.dataset_bindings.handles() {
             metrics.record_policy_dataset_loaded(handle.name());
         }
+        metrics.set_dynamic_neighbor_capacity(
+            0,
+            Config::effective_dynamic_neighbor_limit(&current_config),
+        );
         Self {
             peers: HashMap::new(),
             max_prefix_latches: HashMap::new(),
@@ -661,6 +665,11 @@ impl PeerManager {
         // remains visibly outside the peer-manager allocated range.
         self.next_session_id = self.next_session_id.wrapping_add(1).max(1);
         id
+    }
+
+    pub(super) fn refresh_dynamic_neighbor_capacity_metrics(&self) {
+        self.metrics
+            .set_dynamic_neighbor_capacity(self.dynamic_peer_count, self.dynamic_neighbor_limit);
     }
 
     pub(super) fn register_session(&mut self, session_id: u64, peer: &PeerKey) {

--- a/src/peer_manager/notifications.rs
+++ b/src/peer_manager/notifications.rs
@@ -249,6 +249,7 @@ impl PeerManager {
                             // Auto-removal is authoritative when no terminal
                             // breach was discovered during the join barrier.
                             self.dynamic_peer_count = self.dynamic_peer_count.saturating_sub(1);
+                            self.refresh_dynamic_neighbor_capacity_metrics();
                             self.reap_deleted_peer_metric_series_for_key(&peer_key)
                                 .await;
                         }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -4382,6 +4382,7 @@ fn insert_test_dynamic_managed_peer(
     );
     mgr.register_session(session_id, &peer_key);
     mgr.dynamic_peer_count += 1;
+    mgr.refresh_dynamic_neighbor_capacity_metrics();
 }
 
 #[tokio::test]
@@ -4481,6 +4482,8 @@ async fn rollback_reap_keeps_dynamic_peer_for_host_bit_range_prefix() {
 /// Load-bearing dynamic lifecycle proof: removing the latch cleanup from the
 /// authoritative rollback reap leaves a stale error keyed to the address, so a
 /// future dynamic accept at that address can inherit state from a dead peer.
+/// Removing the rollback capacity refresh leaves the process-global used gauge
+/// pinned at one after the same authoritative reap.
 #[tokio::test]
 async fn rollback_reap_clears_dynamic_max_prefix_latch() {
     let mut mgr = dynamic_test_manager();
@@ -4507,6 +4510,7 @@ async fn rollback_reap_clears_dynamic_max_prefix_latch() {
         "max-prefix limit exceeded: 501 accepted, bound 500".to_string(),
         None,
     );
+    assert_dynamic_neighbor_capacity(&mgr.metrics, 1.0, 100.0, 99.0, 0.0);
 
     assert_eq!(
         mgr.reap_dynamic_peers_not_allowed_by_current_ranges().await,
@@ -4517,6 +4521,7 @@ async fn rollback_reap_clears_dynamic_max_prefix_latch() {
         !mgr.max_prefix_latches.contains_key(&key(peer_addr)),
         "authoritative dynamic removal must reap its manager-owned latch"
     );
+    assert_dynamic_neighbor_capacity(&mgr.metrics, 0.0, 100.0, 100.0, 0.0);
 }
 
 /// Load-bearing transaction-bounce proof: removing the pre-filter policy sync
@@ -6373,7 +6378,9 @@ async fn inbound_replace_preserves_old_primary_terminal_breach() {
 
 /// Load-bearing dynamic-retirement proof: the actor emits max-prefix only from
 /// Shutdown after an older `BackToIdle` was queued. Removing the retirement
-/// barrier auto-removes the peer and leaves no explicit-Enable recovery target.
+/// barrier auto-removes the peer and leaves no explicit-Enable recovery target;
+/// decrementing or refreshing the slot on the retained branch loses its
+/// process-global capacity ownership.
 #[tokio::test]
 async fn dynamic_back_to_idle_retains_recovery_target_for_late_terminal_breach() {
     let mut mgr = test_peer_manager();
@@ -6396,6 +6403,8 @@ async fn dynamic_back_to_idle_retains_recovery_target_for_late_terminal_breach()
     );
     mgr.peers.get_mut(&key(addr)).unwrap().is_dynamic = true;
     mgr.dynamic_peer_count = 1;
+    mgr.refresh_dynamic_neighbor_capacity_metrics();
+    assert_dynamic_neighbor_capacity(&mgr.metrics, 1.0, 100.0, 99.0, 0.0);
     mgr.session_notify_tx
         .send(SessionNotification::BackToIdle {
             session_id: 1,
@@ -6416,6 +6425,7 @@ async fn dynamic_back_to_idle_retains_recovery_target_for_late_terminal_breach()
     assert!(mgr.retiring_sessions.is_empty());
     assert!(mgr.peer_key_for_session(1).is_none());
     assert_eq!(mgr.peer_key_for_session(2), Some(key(addr)));
+    assert_dynamic_neighbor_capacity(&mgr.metrics, 1.0, 100.0, 99.0, 0.0);
 
     mgr.enable_peer(key(addr)).await.unwrap();
     assert!(mgr.peers.get(&key(addr)).unwrap().enabled);
@@ -7021,6 +7031,45 @@ fn peer_metric_series_count(metrics: &BgpMetrics, peer: &str) -> usize {
                 .any(|label| label.name() == "peer" && label.value() == peer)
         })
         .count()
+}
+
+fn process_global_metric(metrics: &BgpMetrics, family_name: &str) -> Option<f64> {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == family_name)
+        .map(|family| {
+            assert_eq!(family.get_metric().len(), 1, "{family_name} series count");
+            let metric = &family.get_metric()[0];
+            assert!(
+                metric.get_label().is_empty(),
+                "{family_name} must remain label-free"
+            );
+            if family_name.ends_with("_total") {
+                metric.get_counter().value()
+            } else {
+                metric.get_gauge().value()
+            }
+        })
+}
+
+fn assert_dynamic_neighbor_capacity(
+    metrics: &BgpMetrics,
+    used: f64,
+    limit: f64,
+    headroom: f64,
+    rejections: f64,
+) {
+    assert_eq!(
+        (
+            process_global_metric(metrics, "bgp_dynamic_neighbor_slots_used"),
+            process_global_metric(metrics, "bgp_dynamic_neighbor_slots_limit"),
+            process_global_metric(metrics, "bgp_dynamic_neighbor_slots_headroom"),
+            process_global_metric(metrics, "bgp_dynamic_neighbor_limit_rejections_total"),
+        ),
+        (Some(used), Some(limit), Some(headroom), Some(rejections))
+    );
 }
 
 fn peer_identity_gauge(
@@ -17503,11 +17552,15 @@ async fn inbound_during_established_dropped() {
     handle.await.unwrap();
 }
 
+/// Load-bearing capacity telemetry proof: removing the constructor seed, the
+/// successful-accept refresh, or the ordinary `BackToIdle` removal refresh
+/// breaks the exact 0 → 1 → 0 process-global gauge sequence.
 #[tokio::test]
 async fn dynamic_inbound_peer_is_created_and_removed_on_back_to_idle() {
     let (_tx, rx) = mpsc::channel(16);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
     let metrics = BgpMetrics::new();
+    let metrics_view = metrics.clone();
     let mut mgr = PeerManager::new_with_config(
         rx,
         mpsc::unbounded_channel().1,
@@ -17521,6 +17574,7 @@ async fn dynamic_inbound_peer_is_created_and_removed_on_back_to_idle() {
         None,
         make_dynamic_manager_config(),
     );
+    assert_dynamic_neighbor_capacity(&metrics_view, 0.0, 100.0, 100.0, 0.0);
     mgr.tcp_ao_rotation = TcpAoRotationStatus {
         desired: rustbgpd_transport::TcpAoRotationGeneration::STARTUP
             .next()
@@ -17544,6 +17598,7 @@ async fn dynamic_inbound_peer_is_created_and_removed_on_back_to_idle() {
         mgr.dynamic_peer_count, 1,
         "dynamic peer count should increment"
     );
+    assert_dynamic_neighbor_capacity(&metrics_view, 1.0, 100.0, 99.0, 0.0);
     let info = mgr.get_peer_info(&key(peer_addr)).await.unwrap();
     assert!(info.is_dynamic, "peer should be marked dynamic");
     assert_eq!(info.peer_group.as_deref(), Some("ix-members"));
@@ -17575,8 +17630,60 @@ async fn dynamic_inbound_peer_is_created_and_removed_on_back_to_idle() {
         "dynamic peer should be removed when it goes idle"
     );
     assert!(mgr.peers.is_empty(), "dynamic peer table should be empty");
+    assert_dynamic_neighbor_capacity(&metrics_view, 0.0, 100.0, 100.0, 0.0);
 
     drop(client_stream);
+}
+
+/// Load-bearing saturated-drop proof: removing the rejection increment leaves
+/// the counter at zero; mutating capacity or installing the rejected peer
+/// breaks the unchanged gauge and peer-table assertions.
+#[tokio::test]
+async fn saturated_dynamic_neighbor_accept_counts_rejection_without_consuming_capacity() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let metrics_view = metrics.clone();
+    let mut config = make_dynamic_manager_config();
+    config.global.dynamic_neighbor_limit = Some(1);
+    let mut mgr = PeerManager::new_with_config(
+        rx,
+        mpsc::unbounded_channel().1,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+        None,
+        config,
+    );
+
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let listener_addr = listener.local_addr().unwrap();
+    let client = tokio::spawn(async move { TcpStream::connect(listener_addr).await.unwrap() });
+    let (first_stream, first_addr) = listener.accept().await.unwrap();
+    let first_client = client.await.unwrap();
+    mgr.handle_inbound(first_stream, first_addr, None, None)
+        .await;
+    assert_dynamic_neighbor_capacity(&metrics_view, 1.0, 1.0, 0.0, 0.0);
+
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let listener_addr = listener.local_addr().unwrap();
+    let client = tokio::spawn(async move { TcpStream::connect(listener_addr).await.unwrap() });
+    let (rejected_stream, _) = listener.accept().await.unwrap();
+    let rejected_client = client.await.unwrap();
+    let rejected_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
+    mgr.handle_inbound(rejected_stream, sock(rejected_addr), None, None)
+        .await;
+
+    assert_dynamic_neighbor_capacity(&metrics_view, 1.0, 1.0, 0.0, 1.0);
+    assert_eq!(mgr.dynamic_peer_count, 1);
+    assert_eq!(mgr.peers.len(), 1);
+    assert!(!mgr.peers.contains_key(&key(rejected_addr)));
+    drop(first_client);
+    drop(rejected_client);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- publish process-global dynamic-neighbor slot usage, configured limit, and remaining headroom
- count matching inbound sessions rejected because the dynamic-neighbor cap is full
- keep capacity accounting synchronized across accept, ordinary removal, rollback reap, and retained-disabled recovery targets
- document the label-free metrics and their lifecycle semantics

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpd --all-targets --all-features -- -D warnings`
- `cargo test -p rustbgpd`
- `cargo test --locked -p rustbgpd-telemetry`
- `scripts/check-v1-stable-surface.sh`
- `git diff --check`

## Load-bearing regression proof

- removing constructor seeding or the successful-accept / ordinary-removal refresh breaks the asserted 0 -> 1 -> 0 gauge sequence
- removing the rollback-reap refresh leaves the used gauge pinned at one
- removing the saturated-drop increment leaves the rejection counter at zero
- decrementing the retained-disabled max-prefix branch breaks both slot-count and gauge assertions

Each production mutation was removed in isolation and its named assertion went red.