### PR TITLE
Expose dormant dynamic-neighbor configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Dormant dynamic-neighbor acceptance is now visible without being mistaken for
+  active peers: startup reports configured range counts, empty human
+  `rbgp neighbor list` distinguishes configured ranges from a first deploy
+  while JSON remains exactly `[]`, and `rbgp doctor` records redacted range
+  inventory or explicit unavailable evidence in its support bundle.
+
 - RFC 8212 diagnostics now include dynamic eBGP ranges, peer groups, and `any AS`.
 
 - Dynamic-neighbor ranges now validate inherited route-reflector, ORR,

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -27,8 +27,8 @@ use crate::proto::global_service_client::GlobalServiceClient;
 use crate::proto::neighbor_service_client::NeighborServiceClient;
 use crate::proto::{
     BfdSession, BfdSessionState, GetBfdSessionsRequest, GetEffectiveConfigRequest,
-    GetGlobalRequest, HealthRequest, ListNeighborsRequest, ListPolicyEventsRequest,
-    ListSessionEventsRequest, MetricsRequest,
+    GetGlobalRequest, HealthRequest, ListDynamicNeighborsRequest, ListNeighborsRequest,
+    ListPolicyEventsRequest, ListSessionEventsRequest, MetricsRequest,
 };
 
 /// Bounded recent slice pulled from each event history for triage. The
@@ -241,6 +241,25 @@ struct GlobalSnapshot {
     listen_port: u32,
     tcp_ao_support: String,
     tcp_ao_detail: String,
+}
+
+#[derive(Serialize)]
+struct DynamicNeighborSnapshot {
+    prefix: String,
+    peer_group: String,
+    remote_asn: u32,
+    description: String,
+}
+
+impl From<&crate::proto::DynamicNeighborRange> for DynamicNeighborSnapshot {
+    fn from(range: &crate::proto::DynamicNeighborRange) -> Self {
+        Self {
+            prefix: range.prefix.clone(),
+            peer_group: range.peer_group.clone(),
+            remote_asn: range.remote_asn,
+            description: redact_text(&range.description),
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -1558,6 +1577,32 @@ pub(crate) async fn run(
             // non-Established state, the later history query includes the
             // disable evidence.
             let neighbor_snapshot = neighbor.list_neighbors(ListNeighborsRequest {}).await;
+            let dynamic_neighbor_snapshot = match neighbor
+                .list_dynamic_neighbors(ListDynamicNeighborsRequest {})
+                .await
+            {
+                Ok(resp) => {
+                    let snapshots: Vec<DynamicNeighborSnapshot> = resp
+                        .into_inner()
+                        .ranges
+                        .iter()
+                        .map(DynamicNeighborSnapshot::from)
+                        .collect();
+                    bundle.add_json("peers/dynamic-neighbors.json", &snapshots)?;
+                    sections.insert("dynamic_neighbors", "collected".to_string());
+                    Some(snapshots)
+                }
+                Err(e) => {
+                    sections.insert(
+                        "dynamic_neighbors",
+                        format!(
+                            "unavailable: ListDynamicNeighbors RPC failed: {}",
+                            redact_text(&e.to_string())
+                        ),
+                    );
+                    None
+                }
+            };
             let (session_events, session_history_available) = match events
                 .list_session_events(ListSessionEventsRequest {
                     neighbor_address: String::new(),
@@ -1650,11 +1695,27 @@ pub(crate) async fn run(
                         })
                         .collect();
                     if snapshots.is_empty() {
-                        reporter.record(
-                            "peers.configured",
-                            CheckStatus::Warn,
-                            "no neighbors configured",
-                        );
+                        match dynamic_neighbor_snapshot.as_ref() {
+                            Some(ranges) if ranges.is_empty() => reporter.record(
+                                "peers.configured",
+                                CheckStatus::Warn,
+                                "no active neighbor sessions and no dynamic-neighbor ranges configured",
+                            ),
+                            Some(ranges) => reporter.record(
+                                "peers.configured",
+                                CheckStatus::Ok,
+                                format!(
+                                    "no active neighbor sessions; {} dynamic-neighbor range{} configured for future acceptance",
+                                    ranges.len(),
+                                    if ranges.len() == 1 { "" } else { "s" }
+                                ),
+                            ),
+                            None => reporter.record(
+                                "peers.configured",
+                                CheckStatus::Warn,
+                                "no active neighbor sessions; dynamic-neighbor range inventory unavailable",
+                            ),
+                        }
                     }
                     for n in &neighbors.neighbors {
                         let address = n.config.as_ref().map_or_else(String::new, |config| {
@@ -1727,6 +1788,10 @@ pub(crate) async fn run(
             );
             sections.insert("config", "unavailable: daemon unreachable".to_string());
             sections.insert("peers", "unavailable: daemon unreachable".to_string());
+            sections.insert(
+                "dynamic_neighbors",
+                "unavailable: daemon unreachable".to_string(),
+            );
             sections.insert(
                 "system",
                 "partial: daemon unreachable (host facts only)".to_string(),
@@ -2975,6 +3040,15 @@ paths = ["x"]
             .1
     }
 
+    fn manifest_check<'a>(manifest: &'a serde_json::Value, name: &str) -> &'a serde_json::Value {
+        manifest["checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|check| check["name"] == name)
+            .unwrap_or_else(|| panic!("manifest missing check {name}"))
+    }
+
     fn neighbor(
         address: &str,
         state: i32,
@@ -3061,6 +3135,7 @@ paths = ["x"]
             "manifest.json",
             "config/effective.toml",
             "peers/bfd.json",
+            "peers/dynamic-neighbors.json",
             "peers/neighbors.json",
             "peers/events.json",
             "system/environment.json",
@@ -3080,6 +3155,7 @@ paths = ["x"]
         assert_eq!(manifest["cli_version"], env!("CARGO_PKG_VERSION"));
         assert_eq!(manifest["daemon_version"], "0.0.0-mock");
         assert_eq!(manifest["sections"]["peers"], "collected");
+        assert_eq!(manifest["sections"]["dynamic_neighbors"], "collected");
         assert!(
             manifest["sections"]["logs"]
                 .as_str()
@@ -3105,6 +3181,9 @@ paths = ["x"]
         assert!(find(&files, "config/effective.toml").contains("asn = 65000"));
         let peers: serde_json::Value =
             serde_json::from_str(find(&files, "peers/neighbors.json")).unwrap();
+        let dynamic_neighbors: serde_json::Value =
+            serde_json::from_str(find(&files, "peers/dynamic-neighbors.json")).unwrap();
+        assert_eq!(dynamic_neighbors, serde_json::json!([]));
         // Load-bearing mutation proof: dropping `slow_peer: n.slow_peer` from
         // the support snapshot makes this projection assertion red.
         assert_eq!(peers[0]["slow_peer"], true);
@@ -3148,6 +3227,155 @@ paths = ["x"]
                     .as_str()
                     .is_some_and(|detail| detail.contains("retained history shows a session loss"))
         }));
+    }
+
+    /// Load-bearing zero-inventory proof: omitting the range snapshot removes
+    /// the bundle file, while treating a truly unconfigured daemon as healthy
+    /// weakens the existing first-deploy warning.
+    #[tokio::test]
+    async fn doctor_records_zero_live_neighbors_and_zero_dynamic_ranges() {
+        let server = spawn_mock_server(None).await;
+        *server.state.config_effective_toml.lock().await =
+            Some("[global]\nasn = 65000\nrouter_id = \"192.0.2.1\"\n".to_string());
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_path = dir.path().join("bundle.tar.gz");
+
+        run(
+            connect(&server.addr, None).await,
+            &DoctorOptions {
+                output: Some(&bundle_path),
+                log_file: None,
+                daemon_address: &server.addr,
+                token_file_configured: false,
+                json: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        let files = extract_bundle(&bundle_path);
+        let dynamic_neighbors: serde_json::Value =
+            serde_json::from_str(find(&files, "peers/dynamic-neighbors.json")).unwrap();
+        assert_eq!(dynamic_neighbors, serde_json::json!([]));
+        let manifest: serde_json::Value =
+            serde_json::from_str(find(&files, "manifest.json")).unwrap();
+        assert_eq!(manifest["sections"]["dynamic_neighbors"], "collected");
+        let inventory = manifest_check(&manifest, "peers.configured");
+        assert_eq!(inventory["status"], "warn");
+        assert_eq!(
+            inventory["detail"],
+            "no active neighbor sessions and no dynamic-neighbor ranges configured"
+        );
+    }
+
+    /// Load-bearing dormant-range proof: deleting the range RPC projection or
+    /// correlating only the empty live-neighbor list loses both the redacted
+    /// range evidence and the exact configured-range count.
+    #[tokio::test]
+    async fn doctor_records_dormant_dynamic_neighbor_inventory() {
+        let server = spawn_mock_server(None).await;
+        *server.state.config_effective_toml.lock().await =
+            Some("[global]\nasn = 65000\nrouter_id = \"192.0.2.1\"\n".to_string());
+        *server.state.list_dynamic_neighbors_response.lock().await = vec![
+            rustbgpd_api::proto::DynamicNeighborRange {
+                prefix: "192.0.2.0/24".to_string(),
+                peer_group: "edge".to_string(),
+                remote_asn: 65002,
+                description: "password=must-not-escape".to_string(),
+            },
+            rustbgpd_api::proto::DynamicNeighborRange {
+                prefix: "198.51.100.0/24".to_string(),
+                peer_group: "edge".to_string(),
+                remote_asn: 65003,
+                description: "secondary range".to_string(),
+            },
+        ];
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_path = dir.path().join("bundle.tar.gz");
+
+        run(
+            connect(&server.addr, None).await,
+            &DoctorOptions {
+                output: Some(&bundle_path),
+                log_file: None,
+                daemon_address: &server.addr,
+                token_file_configured: false,
+                json: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        let files = extract_bundle(&bundle_path);
+        let dynamic_text = find(&files, "peers/dynamic-neighbors.json");
+        assert!(!dynamic_text.contains("must-not-escape"));
+        let dynamic_neighbors: serde_json::Value = serde_json::from_str(dynamic_text).unwrap();
+        assert_eq!(dynamic_neighbors.as_array().unwrap().len(), 2);
+        assert_eq!(dynamic_neighbors[0]["prefix"], "192.0.2.0/24");
+        let manifest: serde_json::Value =
+            serde_json::from_str(find(&files, "manifest.json")).unwrap();
+        assert!(
+            manifest["files"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|path| path == "peers/dynamic-neighbors.json")
+        );
+        let inventory = manifest_check(&manifest, "peers.configured");
+        assert_eq!(inventory["status"], "ok");
+        assert_eq!(
+            inventory["detail"],
+            "no active neighbor sessions; 2 dynamic-neighbor ranges configured for future acceptance"
+        );
+    }
+
+    /// Load-bearing unavailable-evidence proof: converting the range RPC error
+    /// to an empty vector fabricates zero inventory and drops the explicit
+    /// partial-evidence receipt.
+    #[tokio::test]
+    async fn doctor_marks_dynamic_neighbor_inventory_rpc_unavailable() {
+        let server = spawn_mock_server(None).await;
+        *server.state.config_effective_toml.lock().await =
+            Some("[global]\nasn = 65000\nrouter_id = \"192.0.2.1\"\n".to_string());
+        *server.state.list_dynamic_neighbors_error.lock().await =
+            Some((Code::Unavailable, "range inventory offline".to_string()));
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_path = dir.path().join("bundle.tar.gz");
+
+        run(
+            connect(&server.addr, None).await,
+            &DoctorOptions {
+                output: Some(&bundle_path),
+                log_file: None,
+                daemon_address: &server.addr,
+                token_file_configured: false,
+                json: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        let files = extract_bundle(&bundle_path);
+        assert!(
+            !files
+                .iter()
+                .any(|(path, _)| path == "peers/dynamic-neighbors.json")
+        );
+        let manifest: serde_json::Value =
+            serde_json::from_str(find(&files, "manifest.json")).unwrap();
+        assert!(
+            manifest["sections"]["dynamic_neighbors"]
+                .as_str()
+                .is_some_and(
+                    |status| status.contains("unavailable: ListDynamicNeighbors RPC failed")
+                )
+        );
+        let inventory = manifest_check(&manifest, "peers.configured");
+        assert_eq!(inventory["status"], "warn");
+        let detail = inventory["detail"].as_str().unwrap();
+        assert!(detail.contains("no active neighbor sessions"));
+        assert!(detail.contains("dynamic-neighbor range inventory unavailable"));
+        assert!(!detail.contains("0 dynamic-neighbor"));
     }
 
     #[tokio::test]
@@ -3701,6 +3929,10 @@ paths = ["x"]
         );
         assert_eq!(
             manifest["sections"]["peers"],
+            "unavailable: daemon unreachable"
+        );
+        assert_eq!(
+            manifest["sections"]["dynamic_neighbors"],
             "unavailable: daemon unreachable"
         );
         assert!(

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -8,8 +8,8 @@ use crate::output::{
 use crate::proto::neighbor_service_client::NeighborServiceClient;
 use crate::proto::{
     AddNeighborRequest, DeleteNeighborRequest, DisableNeighborRequest, EnableNeighborRequest,
-    GetNeighborStateRequest, ListNeighborsRequest, NeighborConfig, NeighborCreateIntent,
-    RefreshOutboundRequest, SetGracefulShutdownRequest, SoftResetInRequest,
+    GetNeighborStateRequest, ListDynamicNeighborsRequest, ListNeighborsRequest, NeighborConfig,
+    NeighborCreateIntent, RefreshOutboundRequest, SetGracefulShutdownRequest, SoftResetInRequest,
 };
 
 pub(super) fn bare_ip_rpc_address(address: &str) -> &str {
@@ -72,7 +72,16 @@ fn json_neighbor(n: &crate::proto::NeighborState) -> JsonNeighbor {
     }
 }
 
-pub async fn list(connection: Connection, json: bool, wide: bool) -> Result<(), CliError> {
+enum NeighborListView {
+    Json(Vec<JsonNeighbor>),
+    Empty(String),
+    Table(Vec<crate::proto::NeighborState>),
+}
+
+async fn neighbor_list_view(
+    connection: Connection,
+    json: bool,
+) -> Result<NeighborListView, CliError> {
     let mut client =
         NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
     let resp = client
@@ -81,14 +90,30 @@ pub async fn list(connection: Connection, json: bool, wide: bool) -> Result<(), 
         .into_inner();
 
     if json {
+        let out: Vec<JsonNeighbor> = resp.neighbors.iter().map(json_neighbor).collect();
+        Ok(NeighborListView::Json(out))
+    } else if resp.neighbors.is_empty() {
+        let dynamic_range_count = client
+            .list_dynamic_neighbors(ListDynamicNeighborsRequest {})
+            .await?
+            .into_inner()
+            .ranges
+            .len();
+        Ok(NeighborListView::Empty(empty_neighbor_list_message(
+            dynamic_range_count,
+        )))
+    } else {
+        Ok(NeighborListView::Table(resp.neighbors))
+    }
+}
+
+pub async fn list(connection: Connection, json: bool, wide: bool) -> Result<(), CliError> {
+    match neighbor_list_view(connection, json).await? {
         // `--wide` is display-only: JSON is unaffected by it and may omit
         // optional false healthy-state fields.
-        let out: Vec<JsonNeighbor> = resp.neighbors.iter().map(json_neighbor).collect();
-        output::print_json_pretty(&out)?;
-    } else if resp.neighbors.is_empty() {
-        println!("{EMPTY_NEIGHBOR_LIST}");
-    } else {
-        output::print_neighbor_table(&resp.neighbors, wide);
+        NeighborListView::Json(out) => output::print_json_pretty(&out)?,
+        NeighborListView::Empty(message) => println!("{message}"),
+        NeighborListView::Table(neighbors) => output::print_neighbor_table(&neighbors, wide),
     }
     Ok(())
 }
@@ -97,6 +122,16 @@ pub async fn list(connection: Connection, json: bool, wide: bool) -> Result<(), 
 /// changes it.
 const EMPTY_NEIGHBOR_LIST: &str =
     "no neighbors configured — add one: rbgp neighbor <addr> add --remote-asn <asn>";
+
+fn empty_neighbor_list_message(dynamic_range_count: usize) -> String {
+    match dynamic_range_count {
+        0 => EMPTY_NEIGHBOR_LIST.to_string(),
+        1 => "no active neighbors; 1 dynamic-neighbor acceptance range configured".to_string(),
+        count => {
+            format!("no active neighbors; {count} dynamic-neighbor acceptance ranges configured")
+        }
+    }
+}
 
 fn json_update_group_comparison(
     primary_neighbor: &str,
@@ -1730,17 +1765,97 @@ mod tests {
         );
     }
 
-    /// The zero-peer human output must say what happened AND hand the
-    /// operator the exact next command; `-j` mode bypasses it entirely
-    /// and serializes the empty list as `[]`.
-    #[test]
-    fn empty_state_names_the_add_command_and_json_stays_pure() {
+    /// Load-bearing human empty-state proof: removing the conditional range
+    /// query leaves its counter at zero; treating zero ranges as dormant
+    /// changes the exact first-deploy guidance.
+    #[tokio::test]
+    async fn empty_human_neighbor_list_distinguishes_zero_ranges() {
+        let server = spawn_mock_server(None).await;
+        let view = neighbor_list_view(connect(&server.addr, None).await.unwrap(), false)
+            .await
+            .unwrap();
         assert_eq!(
-            EMPTY_NEIGHBOR_LIST,
+            server
+                .state
+                .list_dynamic_neighbors_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+        let NeighborListView::Empty(message) = view else {
+            panic!("empty human result must render the empty-state message")
+        };
+        assert_eq!(
+            message,
             "no neighbors configured — add one: rbgp neighbor <addr> add --remote-asn <asn>"
         );
-        let json = serde_json::to_string_pretty(&Vec::<crate::output::JsonNeighbor>::new())
-            .expect("serialize");
+    }
+
+    /// Load-bearing dormant-range proof: deleting the range RPC or ignoring
+    /// its result emits first-deploy guidance for an already configured
+    /// dynamic-only daemon.
+    #[tokio::test]
+    async fn empty_human_neighbor_list_reports_dormant_dynamic_ranges() {
+        let server = spawn_mock_server(None).await;
+        *server.state.list_dynamic_neighbors_response.lock().await = vec![
+            rustbgpd_api::proto::DynamicNeighborRange {
+                prefix: "192.0.2.0/24".to_string(),
+                peer_group: "edge".to_string(),
+                remote_asn: 65002,
+                description: String::new(),
+            },
+            rustbgpd_api::proto::DynamicNeighborRange {
+                prefix: "198.51.100.0/24".to_string(),
+                peer_group: "edge".to_string(),
+                remote_asn: 65003,
+                description: String::new(),
+            },
+        ];
+        let view = neighbor_list_view(connect(&server.addr, None).await.unwrap(), false)
+            .await
+            .unwrap();
+        assert_eq!(
+            server
+                .state
+                .list_dynamic_neighbors_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+        let NeighborListView::Empty(message) = view else {
+            panic!("dormant human result must render the empty-state message")
+        };
+        assert_eq!(
+            message,
+            "no active neighbors; 2 dynamic-neighbor acceptance ranges configured"
+        );
+    }
+
+    /// Load-bearing JSON compatibility proof: moving the range query before
+    /// JSON dispatch increments the counter, while any appended human context
+    /// changes the pinned empty payload away from `[]`.
+    #[tokio::test]
+    async fn empty_json_neighbor_list_stays_exact_and_skips_range_rpc() {
+        let server = spawn_mock_server(None).await;
+        *server.state.list_dynamic_neighbors_response.lock().await =
+            vec![rustbgpd_api::proto::DynamicNeighborRange {
+                prefix: "192.0.2.0/24".to_string(),
+                peer_group: "edge".to_string(),
+                remote_asn: 65002,
+                description: String::new(),
+            }];
+        let view = neighbor_list_view(connect(&server.addr, None).await.unwrap(), true)
+            .await
+            .unwrap();
+        assert_eq!(
+            server
+                .state
+                .list_dynamic_neighbors_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+        let NeighborListView::Json(neighbors) = view else {
+            panic!("JSON result must bypass human empty-state rendering")
+        };
+        let json = serde_json::to_string_pretty(&neighbors).expect("serialize");
         assert_eq!(json, "[]");
     }
 

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -37,6 +37,7 @@ pub(crate) struct MockState {
     pub(crate) global_failures_remaining: AtomicUsize,
     pub(crate) list_neighbors_calls: AtomicUsize,
     pub(crate) list_neighbors_failures_remaining: AtomicUsize,
+    pub(crate) list_dynamic_neighbors_calls: AtomicUsize,
     pub(crate) watch_routes_calls: AtomicUsize,
     pub(crate) watch_routes_active: AtomicUsize,
     pub(crate) watch_routes_clean_end: AtomicBool,
@@ -106,6 +107,8 @@ pub(crate) struct MockState {
     // Canned ListNeighbors response — drives `rbgp diff` peer-availability
     // gating. Empty = no neighbors configured on the daemon.
     pub(crate) list_neighbors_response: Mutex<Vec<server_proto::NeighborState>>,
+    pub(crate) list_dynamic_neighbors_response: Mutex<Vec<server_proto::DynamicNeighborRange>>,
+    pub(crate) list_dynamic_neighbors_error: Mutex<Option<(Code, String)>>,
     pub(crate) last_list_fib: Mutex<Option<server_proto::ListFibRoutesRequest>>,
     pub(crate) last_list_bgpls: Mutex<Option<server_proto::ListBgpLsRequest>>,
     // Canned ListBgpLsRoutes response — when set, served verbatim so the
@@ -985,8 +988,20 @@ impl rustbgpd_api::proto::neighbor_service_server::NeighborService for MockNeigh
         &self,
         _request: Request<server_proto::ListDynamicNeighborsRequest>,
     ) -> Result<Response<server_proto::ListDynamicNeighborsResponse>, Status> {
+        self.state
+            .list_dynamic_neighbors_calls
+            .fetch_add(1, Ordering::SeqCst);
+        if let Some((code, message)) = self.state.list_dynamic_neighbors_error.lock().await.clone()
+        {
+            return Err(Status::new(code, message));
+        }
         Ok(Response::new(server_proto::ListDynamicNeighborsResponse {
-            ranges: Vec::new(),
+            ranges: self
+                .state
+                .list_dynamic_neighbors_response
+                .lock()
+                .await
+                .clone(),
         }))
     }
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1402,6 +1402,7 @@ rustbgpd-doctor-<ts>/
 ├── manifest.json            # versions, redaction note, per-section collected/partial/unavailable status, check results
 ├── config/effective.toml    # the daemon's GetEffectiveConfig dump (defaults materialized, secrets <redacted>)
 ├── peers/bfd.json           # BFD state/diagnostic/strict plus remote-AdminDown bool or null when unknown
+├── peers/dynamic-neighbors.json # configured acceptance ranges; descriptions scrubbed client-side
 ├── peers/neighbors.json     # per-peer state, counters, flap/slow-peer status
 ├── peers/events.json        # recent session + policy events (free text scrubbed)
 ├── logs/tail-1000.jsonl     # only with --log-file; see below
@@ -1412,6 +1413,13 @@ rustbgpd-doctor-<ts>/
 `session_events` and `policy_events` are reported independently in the
 manifest. A failed history RPC marks only its source `partial`; the bundle
 keeps the successful peer, BFD, and other event-history evidence.
+Dynamic-neighbor range inventory is likewise independent evidence. With no
+active neighbor sessions, doctor distinguishes zero configured ranges from
+configured ranges waiting for a future inbound connection. Zero-and-zero keeps
+the existing yellow first-deploy warning; dormant configured ranges are
+inventory evidence, not a health failure. If `ListDynamicNeighbors` fails, the
+manifest records the inventory as `unavailable` and the check stays yellow
+instead of fabricating a zero-range result.
 
 Exit codes: `0` no checks red (green and yellow warnings may be present), `1`
 error, `2` bundle written but one or more checks are red. A down-daemon run produces a
@@ -1553,6 +1561,11 @@ object, and optional `effective_retention_time_seconds`. Scalar presence is
 meaningful: a negotiated hold or Restart Time of zero and
 `four_octet_as = false` are explicit values, not missing data.
 
+At startup, the topology banner reports configured static neighbors separately
+from dynamic-neighbor acceptance ranges. A dynamic-only configuration reports
+the range count; zero static neighbors and zero ranges is identified as
+unconfigured rather than mislabeled dynamic-only.
+
 ### Add a peer at runtime
 
 ```bash
@@ -1592,6 +1605,12 @@ peer's OPEN. Changes persist to the TOML file (atomic write) before the RPC
 returns and survive a restart.
 The live mutation path is serialized with SIGHUP reload, so a reload cannot
 drop an accepted-but-not-yet-persisted range.
+
+When `rbgp neighbor list` has no live neighbor rows, human output queries the
+range inventory and distinguishes an unconfigured daemon from configured
+ranges that have not accepted a peer yet. JSON compatibility is unchanged:
+the same empty live-neighbor result is exactly `[]`, with no range lookup or
+extra inventory fields; use `rbgp dynamic-neighbor list -j` for range JSON.
 
 ### Soft reset (re-evaluate import policy)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1999,6 +1999,17 @@ async fn trigger_import_validation_refresh(
     }
 }
 
+fn zero_static_peer_summary(dynamic_range_count: usize) -> String {
+    if dynamic_range_count == 0 {
+        "0 configured static neighbors; 0 dynamic-neighbor acceptance ranges".to_string()
+    } else {
+        format!(
+            "0 configured static neighbors; {dynamic_range_count} dynamic-neighbor acceptance range{} (dynamic-only)",
+            if dynamic_range_count == 1 { "" } else { "s" }
+        )
+    }
+}
+
 fn print_startup_banner(config: &Config, grpc_listeners: &[GrpcListenerConfig]) {
     let ebgp = config
         .neighbors
@@ -2027,7 +2038,7 @@ fn print_startup_banner(config: &Config, grpc_listeners: &[GrpcListenerConfig]) 
         peer_parts.push(format!("{ibgp} iBGP"));
     }
     let peer_summary = if peer_parts.is_empty() {
-        "0 peers (dynamic-only)".to_string()
+        zero_static_peer_summary(config.dynamic_neighbors.len())
     } else {
         format!(
             "{} peers ({})",
@@ -2968,6 +2979,7 @@ async fn run<T>(
         asn = config.global.asn,
         router_id = %config.global.router_id,
         neighbors = config.neighbors.len(),
+        dynamic_neighbor_ranges = config.dynamic_neighbors.len(),
         "starting rustbgpd"
     );
     // The same set `--check` frames, logged here because this is the first
@@ -5446,6 +5458,21 @@ mod tests {
         assert_tier_authorized_test_config(&config);
         std::fs::remove_file(&path).ok();
         config
+    }
+
+    /// Load-bearing startup truth proof: collapsing either zero-static case
+    /// back to the old "dynamic-only" label makes an exact summary red, and
+    /// counting ranges as peers breaks the dormant-range wording.
+    #[test]
+    fn startup_peer_summary_distinguishes_unconfigured_from_dynamic_only() {
+        assert_eq!(
+            zero_static_peer_summary(0),
+            "0 configured static neighbors; 0 dynamic-neighbor acceptance ranges"
+        );
+        assert_eq!(
+            zero_static_peer_summary(2),
+            "0 configured static neighbors; 2 dynamic-neighbor acceptance ranges (dynamic-only)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- distinguish a truly unconfigured daemon from dynamic-only acceptance in the startup banner
- make empty human neighbor lists report configured dormant ranges while preserving JSON as exact `[]` with no extra RPC
- include redacted dynamic-neighbor range inventory and explicit unavailable evidence in doctor support bundles
- retain the existing warning for zero peers and zero ranges while treating configured dormant ranges as inventory, not a health failure

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpctl --all-targets --all-features -- -D warnings`
- `cargo clippy -p rustbgpd --all-targets --all-features -- -D warnings`
- `cargo test -p rustbgpctl`
- `cargo test -p rustbgpd`
- `python3 scripts/check-v1-stable-surface.py`
- `git diff --check`

## Load-bearing regression proof

Seven isolated mutations went red at their intended assertions:

- restore the old startup text
- query but ignore the human range result
- perform the range RPC on the JSON path
- omit the doctor bundle projection
- ignore dormant ranges during diagnosis
- fabricate zero ranges on RPC failure
- weaken the genuine zero-and-zero warning

The candidate was independently reviewed after replay onto current main; exact scope is six files and 464 changed lines.