### PR TITLE
Keep dynamic-neighbor limits honest across reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- SIGHUP now keeps the restart-required dynamic-neighbor admission limit pinned
+  to its startup value while retaining the edited desired value for restart.
+
 - Dormant dynamic-neighbor acceptance is now visible without being mistaken for
   active peers: startup reports configured range counts, empty human
   `rbgp neighbor list` distinguishes configured ranges from a first deploy

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -248,7 +248,7 @@ that are stood up once at startup. Two flags are hot-pluggable.
 | `allow_blackhole_broad_prefixes` | restart-required | Same — feeds the discard-spawn gate. |
 | `multipath_relax` | restart-required | RIB best-path tie-break behavior; reconciling mid-flight would require an Adj-RIB-Out rebuild. |
 | `link_bandwidth_weighted` | restart-required | Weighted-multipath behavior (ADR-0068). |
-| `dynamic_neighbor_limit` | restart-required | Pre-allocated cap on dynamic-neighbor slots. |
+| `dynamic_neighbor_limit` | restart-required | Pre-allocated cap on dynamic-neighbor slots. SIGHUP pins the runtime snapshot to the startup value while retaining the edited desired value for restart. |
 | `worker_threads` | restart-required | Tokio runtime worker-thread count; the runtime is built once at startup. Unset caps to `min(CPU parallelism, 8)`; `RUSTBGPD_WORKER_THREADS` overrides. |
 | `runtime_state_dir` | restart-required | File-system paths (`gr-restart.toml`, `fib-owned.json`, `grpc.sock`) are bound at startup. |
 

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -1515,6 +1515,14 @@ pub(crate) async fn reload_config_with_tcp_ao(
         new_config.global.honor_blackhole = current.global.honor_blackhole;
         honor_blackhole_changed = false;
     }
+    if new_config.global.dynamic_neighbor_limit != current.global.dynamic_neighbor_limit {
+        error!(
+            "[global].dynamic_neighbor_limit differs from the live config: dynamic-neighbor \
+             admission capacity is allocated once at startup. Restart rustbgpd to change it. \
+             The runtime snapshot keeps the startup limit for this reload."
+        );
+        new_config.global.dynamic_neighbor_limit = current.global.dynamic_neighbor_limit;
+    }
     if config::pin_ebgp_requires_policy_startup_only(&mut new_config, current) {
         error!(
             "[global].ebgp_requires_policy differs from the live config: the ADR-0112 \
@@ -4864,19 +4872,20 @@ hold_time = 90
         }
     }
 
-    /// Drive a reload against the given initial+next TOML and return
-    /// the commands the mock peer manager observed, in order.
+    /// Drive sequential reloads against the given initial+next TOML and return
+    /// the outcomes plus commands the mock peer manager observed, in order.
     /// Replies `Ok(())` to every command that carries a reply channel.
-    async fn drive_reload(
+    async fn drive_reloads(
         initial_toml: &str,
         new_toml: &str,
-    ) -> (Option<ReloadedConfig>, Vec<String>) {
+        reloads: usize,
+    ) -> (Vec<Option<ReloadedConfig>>, Vec<String>) {
         let path = unique_temp_path("reload-driver");
         write_tier_test_config(&path, initial_toml);
-        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
-        assert_tier_authorized_test_config(&initial);
-        let live_grpc_tcp = initial.global.telemetry.grpc_tcp.clone();
-        let live_grpc_uds = initial.global.telemetry.grpc_uds.clone();
+        let mut current = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        assert_tier_authorized_test_config(&current);
+        let live_grpc_tcp = current.global.telemetry.grpc_tcp.clone();
+        let live_grpc_uds = current.global.telemetry.grpc_uds.clone();
 
         write_tier_test_config(&path, new_toml);
 
@@ -4918,24 +4927,37 @@ hold_time = 90
             tags
         });
 
-        let returned = reload_config(
-            path.to_str().unwrap(),
-            &initial,
-            live_grpc_tcp.as_ref(),
-            live_grpc_uds.as_ref(),
-            &peer_mgr_tx,
-            None,
-            None,
-        )
-        .await;
-        if let Some(config) = returned.as_ref() {
-            assert_tier_authorized_test_config(config);
-            assert_tier_authorized_test_config(&config.desired);
+        let mut outcomes = Vec::with_capacity(reloads);
+        for _ in 0..reloads {
+            let returned = reload_config(
+                path.to_str().unwrap(),
+                &current,
+                live_grpc_tcp.as_ref(),
+                live_grpc_uds.as_ref(),
+                &peer_mgr_tx,
+                None,
+                None,
+            )
+            .await;
+            if let Some(config) = returned.as_ref() {
+                assert_tier_authorized_test_config(config);
+                assert_tier_authorized_test_config(&config.desired);
+                current = config.runtime.clone();
+            }
+            outcomes.push(returned);
         }
         drop(peer_mgr_tx);
         let tags = mock.await.unwrap();
         std::fs::remove_file(&path).ok();
-        (returned, tags)
+        (outcomes, tags)
+    }
+
+    async fn drive_reload(
+        initial_toml: &str,
+        new_toml: &str,
+    ) -> (Option<ReloadedConfig>, Vec<String>) {
+        let (mut outcomes, tags) = drive_reloads(initial_toml, new_toml, 1).await;
+        (outcomes.pop().unwrap(), tags)
     }
 
     /// ADR-0096: an rpol-content-only reload sends `SyncRpolPolicies`
@@ -5623,6 +5645,100 @@ tcp_ao = [
         );
         assert!(rendered.contains("honor_graceful_shutdown"), "{rendered}");
         assert!(rendered.contains("honor_blackhole"), "{rendered}");
+    }
+
+    #[tokio::test]
+    async fn reload_pins_dynamic_neighbor_limit_and_preserves_desired_value() {
+        let desired = baseline_toml().replace(
+            "listen_port = 179",
+            "listen_port = 179\ndynamic_neighbor_limit = 17",
+        );
+
+        let (returned, tags) = drive_reload(baseline_toml(), &desired).await;
+        let returned = returned.expect("limit-only reload should return a config");
+
+        assert!(
+            tags.is_empty(),
+            "restart-required limit edit must not send peer-manager commands: {tags:?}"
+        );
+        assert_eq!(
+            returned.global.dynamic_neighbor_limit, None,
+            "runtime snapshot must preserve the omitted startup value exactly"
+        );
+        assert_eq!(
+            returned.effective_dynamic_neighbor_limit(),
+            100,
+            "pinning must not materialize the effective default into runtime config"
+        );
+        assert_eq!(
+            returned.desired.global.dynamic_neighbor_limit,
+            Some(17),
+            "desired snapshot must preserve the edited value for restart"
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_reload_applies_neighbor_edit_but_pins_dynamic_neighbor_limit() {
+        let initial = baseline_toml().replace(
+            "listen_port = 179",
+            "listen_port = 179\ndynamic_neighbor_limit = 100",
+        );
+        let desired = initial
+            .replace(
+                "dynamic_neighbor_limit = 100",
+                "dynamic_neighbor_limit = 17",
+            )
+            .replace("hold_time = 90", "hold_time = 45");
+
+        let (returned, tags) = drive_reloads(&initial, &desired, 2).await;
+
+        assert_eq!(
+            tags,
+            vec!["ReconcilePeers(+0,-0,~1)"],
+            "the independently reloadable neighbor edit must still reconcile"
+        );
+        for returned in returned {
+            let returned = returned.expect("mixed reload should return a config");
+            assert_eq!(returned.neighbors[0].hold_time, Some(45));
+            assert_eq!(
+                returned.global.dynamic_neighbor_limit,
+                Some(100),
+                "mixed reload must not advance the startup-pinned admission limit"
+            );
+            assert_eq!(
+                returned.desired.global.dynamic_neighbor_limit,
+                Some(17),
+                "mixed reload must retain the edited limit as desired state"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn repeated_identical_reload_keeps_dynamic_neighbor_limit_delta_observable() {
+        let initial = baseline_toml().replace(
+            "listen_port = 179",
+            "listen_port = 179\ndynamic_neighbor_limit = 100",
+        );
+        let desired = initial.replace(
+            "dynamic_neighbor_limit = 100",
+            "dynamic_neighbor_limit = 17",
+        );
+        let (returned, tags) = drive_reloads(&initial, &desired, 2).await;
+
+        assert!(tags.is_empty(), "limit-only reloads must have no live work");
+        for returned in returned {
+            let returned = returned.expect("limit-only reload should return a config");
+            assert_eq!(
+                returned.global.dynamic_neighbor_limit,
+                Some(100),
+                "each runtime snapshot must retain the startup admission limit"
+            );
+            assert_eq!(
+                returned.desired.global.dynamic_neighbor_limit,
+                Some(17),
+                "the unapplied edit must remain observable as desired drift"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- keep the restart-required dynamic-neighbor admission cap pinned to its startup value in SIGHUP runtime snapshots
- preserve the operator's edited desired value so the next process restart still adopts it
- keep the unapplied delta visible across repeated reloads while allowing unrelated hot neighbor changes to reconcile normally
- document the runtime/desired split in the reload matrix and changelog

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpd --all-targets --all-features -- -D warnings`
- `cargo test -p rustbgpd`
- `git diff --check`
- commit and push hooks: workspace fmt, clippy, tests, and rustdoc

## Load-bearing regression proof

Removing only the eight-line production pin makes all three regressions fail independently:

- limit-only reload advances the runtime snapshot from the startup limit to the desired limit
- mixed reload advances the limit while applying the unrelated peer edit
- a repeated identical reload loses the persistent runtime/desired drift

The candidate was independently reviewed before and after replay onto current main. Exact scope is three files and 165 changed lines; no live-cap, peer-manager, metric, transaction, or unrelated global behavior changes.
