### PR TITLE
Surface dormant dynamic ranges in rbgp top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- An empty `rbgp top` roster now distinguishes configured dormant
+  dynamic-neighbor ranges, a proven unconfigured daemon, unavailable inventory,
+  and a retained stale count without marking the core connection disconnected.
+
 - SIGHUP now keeps the restart-required dynamic-neighbor admission limit pinned
   to its startup value while retaining the edited desired value for restart.
 

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -82,6 +82,8 @@ pub struct App {
     pub health_fresh: bool,
     pub neighbors: Vec<NeighborState>,
     pub neighbors_freshness: Option<Freshness>,
+    pub dynamic_range_count: Option<usize>,
+    pub dynamic_ranges_freshness: Option<Freshness>,
     pub route_events: VecDeque<RouteEventEntry>,
     pub rpki_vrp_count: Option<u64>,
     pub metrics_freshness: Option<Freshness>,
@@ -112,6 +114,8 @@ impl App {
             health_fresh: false,
             neighbors: Vec::new(),
             neighbors_freshness: None,
+            dynamic_range_count: None,
+            dynamic_ranges_freshness: None,
             route_events: VecDeque::new(),
             rpki_vrp_count: None,
             metrics_freshness: None,
@@ -205,6 +209,8 @@ impl App {
         self.last_poll = now;
         self.health_fresh = snapshot.health_fresh;
         self.neighbors_freshness = Some(snapshot.neighbors_freshness);
+        self.dynamic_range_count = snapshot.dynamic_range_count;
+        self.dynamic_ranges_freshness = Some(snapshot.dynamic_ranges_freshness);
         self.global_freshness = Some(snapshot.global_freshness);
         self.metrics_freshness = Some(snapshot.metrics_freshness);
 
@@ -426,6 +432,8 @@ mod tests {
             health_fresh: true,
             neighbors,
             neighbors_freshness: Freshness::Fresh,
+            dynamic_range_count: Some(0),
+            dynamic_ranges_freshness: Freshness::Fresh,
             rpki_vrp_count: None,
             metrics_freshness: Freshness::Unavailable,
             error: None,
@@ -567,6 +575,22 @@ mod tests {
             start + std::time::Duration::from_secs(3),
         );
         assert_eq!(app.peer_update_rate("198.51.100.1"), 10.0);
+    }
+
+    /// Red proof: moving range-state updates below the freshness guard leaves
+    /// an empty retained roster showing the prior range posture.
+    #[test]
+    fn stale_roster_snapshot_still_updates_dynamic_range_posture() {
+        let mut app = App::new();
+        let mut data = snapshot(Vec::new());
+        data.neighbors_freshness = Freshness::Stale;
+        data.dynamic_range_count = Some(3);
+        data.dynamic_ranges_freshness = Freshness::Stale;
+
+        app.on_data(data);
+
+        assert_eq!(app.dynamic_range_count, Some(3));
+        assert_eq!(app.dynamic_ranges_freshness, Some(Freshness::Stale));
     }
 
     /// Red proof: removing fresh-roster pruning retains both departed-peer maps.

--- a/crates/cli/src/tui/data.rs
+++ b/crates/cli/src/tui/data.rs
@@ -11,8 +11,8 @@ use crate::proto::global_service_client::GlobalServiceClient;
 use crate::proto::neighbor_service_client::NeighborServiceClient;
 use crate::proto::rib_service_client::RibServiceClient;
 use crate::proto::{
-    GetGlobalRequest, GlobalState, HealthRequest, HealthResponse, ListNeighborsRequest,
-    MetricsRequest, NeighborState, WatchRoutesRequest,
+    GetGlobalRequest, GlobalState, HealthRequest, HealthResponse, ListDynamicNeighborsRequest,
+    ListNeighborsRequest, MetricsRequest, NeighborState, WatchRoutesRequest,
 };
 
 pub struct DataSnapshot {
@@ -22,6 +22,8 @@ pub struct DataSnapshot {
     pub health_fresh: bool,
     pub neighbors: Vec<NeighborState>,
     pub neighbors_freshness: Freshness,
+    pub dynamic_range_count: Option<usize>,
+    pub dynamic_ranges_freshness: Freshness,
     pub rpki_vrp_count: Option<u64>,
     pub metrics_freshness: Freshness,
     pub error: Option<String>,
@@ -65,12 +67,16 @@ fn parse_vrp_count(prometheus_text: &str) -> Option<u64> {
 }
 
 const METRICS_POLL_INTERVAL: Duration = Duration::from_secs(60);
+const DYNAMIC_RANGES_POLL_INTERVAL: Duration = Duration::from_secs(60);
 const ROUTE_STREAM_RECONNECT_BACKOFF: Duration = Duration::from_secs(2);
 
 struct FetcherState {
     global: Option<GlobalState>,
     health: Option<HealthResponse>,
     neighbors: Option<Vec<NeighborState>>,
+    dynamic_range_count: Option<usize>,
+    dynamic_ranges_freshness: Freshness,
+    next_dynamic_ranges_poll: Instant,
     rpki_vrp_count: Option<u64>,
     metrics_freshness: Freshness,
     next_metrics_poll: Instant,
@@ -82,6 +88,9 @@ impl FetcherState {
             global: None,
             health: None,
             neighbors: None,
+            dynamic_range_count: None,
+            dynamic_ranges_freshness: Freshness::Unavailable,
+            next_dynamic_ranges_poll: Instant::now(),
             rpki_vrp_count: None,
             metrics_freshness: Freshness::Unavailable,
             next_metrics_poll: Instant::now(),
@@ -167,6 +176,38 @@ async fn poll_once(connection: &Connection, state: &mut FetcherState) -> DataSna
     let neighbors = state.neighbors.clone().unwrap_or_default();
 
     let now = Instant::now();
+    if neighbors_freshness == Freshness::Fresh {
+        if neighbors.is_empty() {
+            if now >= state.next_dynamic_ranges_poll {
+                state.next_dynamic_ranges_poll = now + DYNAMIC_RANGES_POLL_INTERVAL;
+                let mut client = NeighborServiceClient::with_interceptor(
+                    connection.channel(),
+                    connection.interceptor(),
+                );
+                match client
+                    .list_dynamic_neighbors(ListDynamicNeighborsRequest {})
+                    .await
+                {
+                    Ok(response) => {
+                        state.dynamic_range_count = Some(response.into_inner().ranges.len());
+                        state.dynamic_ranges_freshness = Freshness::Fresh;
+                    }
+                    Err(_) => {
+                        state.dynamic_ranges_freshness = if state.dynamic_range_count.is_some() {
+                            Freshness::Stale
+                        } else {
+                            Freshness::Unavailable
+                        };
+                    }
+                }
+            }
+        } else {
+            // A live roster does not need dormant-range inventory. Re-arm the
+            // deadline so the next fresh transition to empty fetches at once.
+            state.next_dynamic_ranges_poll = now;
+        }
+    }
+
     if now >= state.next_metrics_poll {
         state.next_metrics_poll = now + METRICS_POLL_INTERVAL;
         let mut client =
@@ -191,6 +232,8 @@ async fn poll_once(connection: &Connection, state: &mut FetcherState) -> DataSna
         health_fresh,
         neighbors,
         neighbors_freshness,
+        dynamic_range_count: state.dynamic_range_count,
+        dynamic_ranges_freshness: state.dynamic_ranges_freshness,
         rpki_vrp_count: state.rpki_vrp_count,
         metrics_freshness: state.metrics_freshness,
         error,
@@ -286,6 +329,13 @@ mod tests {
         }
     }
 
+    fn dynamic_range_calls(server: &crate::test_support::MockServerHandle) -> usize {
+        server
+            .state
+            .list_dynamic_neighbors_calls
+            .load(Ordering::SeqCst)
+    }
+
     async fn assert_route_reconnect_backoff(server: &crate::test_support::MockServerHandle) {
         let connection = connect(&server.addr, None).await.unwrap();
         let (enabled_tx, enabled_rx) = watch::channel(true);
@@ -350,6 +400,117 @@ mod tests {
         tokio::time::advance(Duration::from_secs(2)).await;
         poll_once(&connection, &mut state).await;
         assert_eq!(server.state.metrics_calls.load(Ordering::SeqCst), 2);
+    }
+
+    /// Red proof: polling dormant inventory on the normal two-second cadence
+    /// raises the pre-deadline call count from one to thirty.
+    #[tokio::test(start_paused = true)]
+    async fn dynamic_ranges_fetch_immediately_then_use_a_slow_empty_cadence() {
+        let server = spawn_mock_server(None).await;
+        *server.state.list_dynamic_neighbors_response.lock().await =
+            vec![rustbgpd_api::proto::DynamicNeighborRange::default(); 2];
+        let connection = connect(&server.addr, None).await.unwrap();
+        let mut state = FetcherState::new();
+
+        let first = poll_once(&connection, &mut state).await;
+        assert_eq!(first.dynamic_range_count, Some(2));
+        assert_eq!(first.dynamic_ranges_freshness, Freshness::Fresh);
+        for _ in 0..29 {
+            tokio::time::advance(Duration::from_secs(2)).await;
+            poll_once(&connection, &mut state).await;
+        }
+        assert_eq!(dynamic_range_calls(&server), 1);
+
+        tokio::time::advance(Duration::from_secs(2)).await;
+        poll_once(&connection, &mut state).await;
+        assert_eq!(dynamic_range_calls(&server), 2);
+    }
+
+    /// Red proof: querying with a live roster increments the first assertion;
+    /// removing the re-arm leaves the transition-to-empty count at zero.
+    #[tokio::test(start_paused = true)]
+    async fn nonempty_roster_skips_dynamic_ranges_and_rearms_next_empty_fetch() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        let mut state = FetcherState::new();
+
+        server
+            .state
+            .list_neighbors_failures_remaining
+            .store(1, Ordering::SeqCst);
+        poll_once(&connection, &mut state).await;
+        assert_eq!(dynamic_range_calls(&server), 0);
+
+        *server.state.list_neighbors_response.lock().await =
+            vec![rustbgpd_api::proto::NeighborState::default()];
+        poll_once(&connection, &mut state).await;
+        assert_eq!(dynamic_range_calls(&server), 0);
+
+        server.state.list_neighbors_response.lock().await.clear();
+        poll_once(&connection, &mut state).await;
+        assert_eq!(dynamic_range_calls(&server), 1);
+
+        tokio::time::advance(Duration::from_secs(2)).await;
+        *server.state.list_neighbors_response.lock().await =
+            vec![rustbgpd_api::proto::NeighborState::default()];
+        poll_once(&connection, &mut state).await;
+        assert_eq!(dynamic_range_calls(&server), 1);
+
+        server.state.list_neighbors_response.lock().await.clear();
+        poll_once(&connection, &mut state).await;
+        assert_eq!(dynamic_range_calls(&server), 2);
+    }
+
+    /// Red proof: folding the optional RPC into the core error path marks this
+    /// otherwise healthy snapshot disconnected.
+    #[tokio::test(start_paused = true)]
+    async fn initial_dynamic_range_failure_is_unavailable_without_disconnect() {
+        let server = spawn_mock_server(None).await;
+        *server.state.list_dynamic_neighbors_error.lock().await = Some((
+            tonic::Code::Unavailable,
+            "range inventory unavailable".into(),
+        ));
+        let connection = connect(&server.addr, None).await.unwrap();
+        let mut state = FetcherState::new();
+
+        let snapshot = poll_once(&connection, &mut state).await;
+
+        assert_eq!(snapshot.dynamic_range_count, None);
+        assert_eq!(snapshot.dynamic_ranges_freshness, Freshness::Unavailable);
+        assert!(snapshot.error.is_none());
+        assert_eq!(dynamic_range_calls(&server), 1);
+
+        tokio::time::advance(DYNAMIC_RANGES_POLL_INTERVAL - Duration::from_millis(1)).await;
+        poll_once(&connection, &mut state).await;
+        assert_eq!(dynamic_range_calls(&server), 1);
+
+        tokio::time::advance(Duration::from_millis(1)).await;
+        poll_once(&connection, &mut state).await;
+        assert_eq!(dynamic_range_calls(&server), 2);
+    }
+
+    /// Red proof: clearing the last-good zero on failure makes an unknown
+    /// inventory indistinguishable from a proven unconfigured daemon.
+    #[tokio::test(start_paused = true)]
+    async fn dynamic_range_failure_retains_last_good_zero_as_stale() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        let mut state = FetcherState::new();
+
+        let first = poll_once(&connection, &mut state).await;
+        assert_eq!(first.dynamic_range_count, Some(0));
+        assert_eq!(first.dynamic_ranges_freshness, Freshness::Fresh);
+
+        *server.state.list_dynamic_neighbors_error.lock().await = Some((
+            tonic::Code::Unavailable,
+            "range inventory unavailable".into(),
+        ));
+        tokio::time::advance(DYNAMIC_RANGES_POLL_INTERVAL).await;
+        let failed = poll_once(&connection, &mut state).await;
+
+        assert_eq!(failed.dynamic_range_count, Some(0));
+        assert_eq!(failed.dynamic_ranges_freshness, Freshness::Stale);
+        assert!(failed.error.is_none());
     }
 
     /// Red proof: restoring the one-shot startup fetch leaves the second

--- a/crates/cli/src/tui/ui.rs
+++ b/crates/cli/src/tui/ui.rs
@@ -132,6 +132,17 @@ fn draw_header(f: &mut Frame, app: &App, area: Rect, theme: &Theme) {
 }
 
 fn draw_peer_table(f: &mut Frame, app: &mut App, area: Rect, theme: &Theme) {
+    if app.neighbors.is_empty() {
+        let block = Block::default()
+            .borders(Borders::LEFT | Borders::RIGHT)
+            .border_style(Style::default().fg(theme.border));
+        let empty = Paragraph::new(empty_peer_message(app))
+            .alignment(Alignment::Center)
+            .block(block);
+        f.render_widget(empty, area);
+        return;
+    }
+
     let sort_col = app.sort_column;
     let sort_asc = app.sort_ascending;
 
@@ -227,6 +238,28 @@ fn draw_peer_table(f: &mut Frame, app: &mut App, area: Rect, theme: &Theme) {
         .highlight_symbol("> ");
 
     f.render_stateful_widget(table, area, &mut app.peer_table_state);
+}
+
+fn empty_peer_message(app: &App) -> String {
+    match app.neighbors_freshness {
+        None => "loading peer inventory".to_string(),
+        Some(Freshness::Unavailable) => "peer roster unavailable".to_string(),
+        _ => match (app.dynamic_ranges_freshness, app.dynamic_range_count) {
+            (Some(Freshness::Fresh), Some(0)) => {
+                "0 active peers; no peers or dynamic ranges configured".to_string()
+            }
+            (Some(Freshness::Fresh), Some(1)) => {
+                "0 active peers; 1 dynamic range configured".to_string()
+            }
+            (Some(Freshness::Fresh), Some(count)) => {
+                format!("0 active peers; {count} dynamic ranges configured")
+            }
+            (Some(Freshness::Stale), Some(count)) => {
+                format!("0 active peers; last known dynamic range count: {count} (stale)")
+            }
+            _ => "0 active peers; dynamic ranges unavailable".to_string(),
+        },
+    }
 }
 
 fn draw_events(f: &mut Frame, app: &App, area: Rect, theme: &Theme) {
@@ -584,6 +617,8 @@ mod tests {
             health_fresh: true,
             neighbors,
             neighbors_freshness: freshness,
+            dynamic_range_count: Some(0),
+            dynamic_ranges_freshness: Freshness::Fresh,
             rpki_vrp_count: None,
             metrics_freshness: Freshness::Fresh,
             error: None,
@@ -718,5 +753,53 @@ mod tests {
         let rendered = rendered_snapshot(data);
         assert!(!rendered.contains("RPKI"));
         assert!(!rendered.contains("VRPs"));
+    }
+
+    #[test]
+    fn empty_roster_renders_fresh_dynamic_range_count_and_proven_zero() {
+        let mut configured = snapshot(Vec::new(), Freshness::Fresh);
+        configured.dynamic_range_count = Some(2);
+        assert!(
+            rendered_snapshot(configured).contains("0 active peers; 2 dynamic ranges configured")
+        );
+
+        let unconfigured = rendered_snapshot(snapshot(Vec::new(), Freshness::Fresh));
+        assert!(unconfigured.contains("0 active peers; no peers or dynamic ranges configured"));
+    }
+
+    #[test]
+    fn initial_dynamic_range_failure_is_unavailable_but_connected() {
+        let mut data = snapshot(Vec::new(), Freshness::Fresh);
+        data.dynamic_range_count = None;
+        data.dynamic_ranges_freshness = Freshness::Unavailable;
+
+        let rendered = rendered_snapshot(data);
+
+        assert!(rendered.contains("0 active peers; dynamic ranges unavailable"));
+        assert!(rendered.contains("connected"));
+        assert!(!rendered.contains("disconnected"));
+    }
+
+    #[test]
+    fn stale_dynamic_range_count_retains_nonzero_and_zero_without_false_proof() {
+        for (count, expected) in [
+            (
+                2,
+                "0 active peers; last known dynamic range count: 2 (stale)",
+            ),
+            (
+                0,
+                "0 active peers; last known dynamic range count: 0 (stale)",
+            ),
+        ] {
+            let mut data = snapshot(Vec::new(), Freshness::Fresh);
+            data.dynamic_range_count = Some(count);
+            data.dynamic_ranges_freshness = Freshness::Stale;
+            let rendered = rendered_snapshot(data);
+            assert!(rendered.contains(expected));
+            if count == 0 {
+                assert!(!rendered.contains("no peers or dynamic ranges configured"));
+            }
+        }
     }
 }

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1792,6 +1792,11 @@ optional source succeeds, the status line reports `global unavailable` or
 metrics scrape retains a known VRP count and labels it stale; a successful
 scrape with no RPKI family clears the count. Stale health or neighbor data is
 likewise labeled while the last-good snapshot remains on screen.
+When the peer roster is empty, the dashboard fetches dynamic-neighbor range
+inventory immediately and then every 60 seconds while it remains empty. It
+distinguishes configured dormant ranges, a proven unconfigured daemon, an
+initially unavailable inventory, and a retained stale count; failure of this
+optional inventory does not mark the core connection disconnected.
 Press `h` for keybindings.
 
 ### Watch live events


### PR DESCRIPTION
## Summary

- expose configured dynamic neighbor ranges in `rbgp top` when the active neighbor roster is empty
- fetch immediately, refresh every 60 seconds on success or failure, suppress unnecessary RPCs while peers are present, and re-arm after the roster empties again
- preserve fresh, stale, and unavailable inventory states so the TUI does not confuse a daemon/API failure with an unconfigured instance
- render an exact empty-roster inventory table without changing daemon, API, or routing behavior

## Verification

- `cargo test -p rustbgpd-cli --lib`
- `cargo test -p rustbgpd-cli --test tui`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo fmt --all -- --check`
- `bash scripts/check-v1-stable-surface.sh`
- `git diff --check`
- push-hook workspace formatting, Clippy, tests, and rustdoc

## Load-bearing proof

Twelve independent mutations were exercised and restored. The focused tests went red when immediate first fetch, the 60-second success or failure cadence, empty-roster gating, nonempty suppression, next-empty re-arming, last-good stale retention, core connection-error isolation, or the App/UI state boundary was removed or flattened.

The final patch was replayed onto current `main` with patch identity preserved. The replayed TUI suite passes 33/33.