### PR TITLE
Harden the VPN query occupancy campaign harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,8 @@ jobs:
           bash -n bench/tests/test-rrtransport-receipt.sh
           bash -n bench/tests/test-route-server-1000-receipt.sh
           bash -n bench/tests/test-vpn-query-receipt.sh
+          bash -n bench/tests/test-vpn-query-campaign.sh
+          bash -n bench/run-vpn-query-campaign.sh
           shellcheck bench/scale/route-server-1000/run-receipt.sh \
             bench/scale/outbound-prefix-limits/run-receipt.sh \
             bench/scale/config-persistence/run-receipt.sh \
@@ -176,8 +178,11 @@ jobs:
             bench/tests/test-rrtransport-receipt.sh \
             bench/tests/test-route-server-1000-receipt.sh
           shellcheck bench/tests/test-vpn-query-receipt.sh
+          shellcheck bench/tests/test-vpn-query-campaign.sh \
+            bench/run-vpn-query-campaign.sh
           bash bench/tests/test-route-server-1000-receipt.sh
           bash bench/tests/test-vpn-query-receipt.sh
+          bash bench/tests/test-vpn-query-campaign.sh
           bash -n bench/scale/compare-rrharness.sh
           bash bench/tests/test-rrharness-driver.sh
           python3 -m unittest discover \

--- a/bench/run-vpn-query-campaign.sh
+++ b/bench/run-vpn-query-campaign.sh
@@ -21,7 +21,7 @@ fi
     exit 2
 }
 output=$1
-if ((!smoke)) && [[ -n ${RUSTBGPD_VPN_QUERY_FORCE_CENSOR:-} ]]; then
+if ((!smoke)) && [[ -v RUSTBGPD_VPN_QUERY_FORCE_CENSOR ]]; then
     echo "RUSTBGPD_VPN_QUERY_FORCE_CENSOR is forbidden for retained campaigns" >&2
     exit 2
 fi
@@ -133,10 +133,6 @@ for attempt in $(seq 1 "$attempts"); do
                     decorate "$raw" "$output/censor.json" "$timing_hash" \
                         "$ordinal" "$repetition" 120 "$attempt"
                     rm "$raw"
-                    python3 - "$output/manifest.json" "$attempt" <<'PY'
-import json, sys
-p=sys.argv[1]; d=json.load(open(p)); d["attempts"]=int(sys.argv[2]); json.dump(d,open(p,"w"),indent=2)
-PY
                     check_provenance
                     python3 "$root/bench/verify-vpn-query-campaign.py" "$output" \
                         --output "$output/classification.json"

--- a/bench/run-vpn-query-campaign.sh
+++ b/bench/run-vpn-query-campaign.sh
@@ -3,7 +3,9 @@
 set -euo pipefail
 
 root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+# shellcheck source-path=SCRIPTDIR/..
 # shellcheck source=docs/perf/event-history-host-fence.sh
+# shellcheck disable=SC1091 # Exact CI invocation does not pass the sourced file as an input.
 source "$root/docs/perf/event-history-host-fence.sh"
 
 smoke=0

--- a/bench/run-vpn-query-campaign.sh
+++ b/bench/run-vpn-query-campaign.sh
@@ -7,8 +7,13 @@ root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 source "$root/docs/perf/event-history-host-fence.sh"
 
 smoke=0
+attempts=1
 if [[ ${1:-} == --smoke ]]; then
     smoke=1
+    shift
+fi
+if [[ ${1:-} == --retry ]]; then
+    attempts=2
     shift
 fi
 [[ $# -eq 1 ]] || {
@@ -20,7 +25,7 @@ output=$1
     echo "refusing existing output: $output" >&2
     exit 1
 }
-mkdir -p "$output/bin" "$output/timing"
+mkdir -p "$output/bin"
 [[ -z $(git -C "$root" status --porcelain) ]] || {
     echo "refusing campaign from a dirty source tree" >&2
     exit 1
@@ -29,12 +34,17 @@ mkdir -p "$output/bin" "$output/timing"
 vpn_query_acquire_host_lock
 vpn_query_init_host_preflight_log "$output/host-preflight.tsv"
 vpn_query_wait_for_idle build "$output/host-preflight.tsv"
+source_commit=$(git -C "$root" rev-parse HEAD)
+source_tree=$(git -C "$root" rev-parse 'HEAD^{tree}')
+source_status=$(git -C "$root" status --porcelain=v1)
+toolchain=$(rustc --version --verbose | tr '\n' ';')
+[[ -z $source_status ]]
 
 target_dir="$output/target"
 export CARGO_TARGET_DIR=$target_dir
-cargo build --manifest-path "$root/Cargo.toml" --release -p rustbgpd-api \
+cargo build --locked --manifest-path "$root/Cargo.toml" --release -p rustbgpd-api \
     --bench vpn_query_timing --features bench-internals
-cargo build --manifest-path "$root/Cargo.toml" --release -p rustbgpd-api \
+cargo build --locked --manifest-path "$root/Cargo.toml" --release -p rustbgpd-api \
     --bench vpn_query_allocation --features bench-internals,vpn-query-allocation
 
 find_binary() {
@@ -53,12 +63,13 @@ timing_hash=$(sha256sum "$output/bin/vpn_query_timing" | awk '{print $1}')
 allocation_hash=$(sha256sum "$output/bin/vpn_query_allocation" | awk '{print $1}')
 
 python3 - "$output/manifest.json" "$timing_hash" "$allocation_hash" \
-    "$(git -C "$root" rev-parse HEAD)" "$(rustc --version --verbose | tr '\n' ';')" <<'PY'
+    "$source_commit" "$source_tree" "$toolchain" "$attempts" <<'PY'
 import json, sys
-path, timing, allocation, commit, rustc = sys.argv[1:]
+path, timing, allocation, commit, tree, rustc, attempts = sys.argv[1:]
 fixed = [f"{case}{i}" for i in range(1, 9) for case in ("U", "F")]
 json.dump({"schema": 2, "base_commit": commit, "rustc": rustc,
            "host_fence": "pass", "source_tree_clean": True, "fixed_order": fixed,
+           "source_tree": tree, "attempts": int(attempts),
            "timing_binary_sha256": timing,
            "allocation_binary_sha256": allocation}, open(path, "w"), indent=2)
 PY
@@ -77,6 +88,15 @@ json.dump(doc, open(output, "w"), indent=2)
 PY
 }
 
+check_provenance() {
+    [[ $(git -C "$root" rev-parse HEAD) == "$source_commit" ]]
+    [[ $(git -C "$root" rev-parse 'HEAD^{tree}') == "$source_tree" ]]
+    [[ -z $(git -C "$root" status --porcelain=v1) ]]
+    [[ $(rustc --version --verbose | tr '\n' ';') == "$toolchain" ]]
+    [[ $(sha256sum "$output/bin/vpn_query_timing" | awk '{print $1}') == "$timing_hash" ]]
+    [[ $(sha256sum "$output/bin/vpn_query_allocation" | awk '{print $1}') == "$allocation_hash" ]]
+}
+
 if ((smoke)); then
     vpn_query_wait_for_idle smoke "$output/host-preflight.tsv"
     for target in timing allocation; do
@@ -90,24 +110,57 @@ if ((smoke)); then
     exit
 fi
 
-ordinal=0
-for size in 10000 100000 1000000; do
-    for repetition in 1 2 3 4 5 6 7 8; do
-        for case in U F; do
-            ((ordinal += 1))
-            vpn_query_wait_for_idle "timing-$ordinal" "$output/host-preflight.tsv"
-            raw="$output/timing/raw.json"
-            "$output/bin/vpn_query_timing" cell "$size" "$case" "$raw"
-            decorate "$raw" "$output/timing/$(printf '%02d' "$ordinal").json" \
-                "$timing_hash" "$ordinal" "$repetition" 120
-            rm "$raw"
+for attempt in $(seq 1 "$attempts"); do
+    mkdir -p "$output/attempt-$attempt/timing"
+    ordinal=0
+    for size in 10000 100000 1000000; do
+        for repetition in 1 2 3 4 5 6 7 8; do
+            for case in U F; do
+                ((ordinal += 1))
+                check_provenance
+                vpn_query_wait_for_idle "attempt-$attempt-timing-$ordinal" \
+                    "$output/host-preflight.tsv"
+                raw="$output/attempt-$attempt/timing/raw.json"
+                set +e
+                "$output/bin/vpn_query_timing" cell "$size" "$case" "$raw"
+                rc=$?
+                set -e
+                if ((rc == 75)); then
+                    decorate "$raw" "$output/censor.json" "$timing_hash" \
+                        "$ordinal" "$repetition" 120
+                    rm "$raw"
+                    python3 "$root/bench/verify-vpn-query-campaign.py" "$output" \
+                        --output "$output/classification.json"
+                    exit
+                elif ((rc != 0)); then
+                    exit "$rc"
+                fi
+                decorate "$raw" "$output/attempt-$attempt/timing/$(printf '%02d' "$ordinal").json" \
+                    "$timing_hash" "$ordinal" "$repetition" 120
+                rm "$raw"
+            done
         done
     done
 done
+check_provenance
 vpn_query_wait_for_idle allocation "$output/host-preflight.tsv"
+set +e
 "$output/bin/vpn_query_allocation" cell 1000000 U "$output/allocation-raw.json"
+rc=$?
+set -e
+if ((rc == 75)); then
+    decorate "$output/allocation-raw.json" "$output/censor.json" \
+        "$allocation_hash" 49 1 120
+    rm "$output/allocation-raw.json"
+    python3 "$root/bench/verify-vpn-query-campaign.py" "$output" \
+        --output "$output/classification.json"
+    exit
+elif ((rc != 0)); then
+    exit "$rc"
+fi
 decorate "$output/allocation-raw.json" "$output/allocation.json" \
     "$allocation_hash" 49 1 120
 rm "$output/allocation-raw.json"
 python3 "$root/bench/verify-vpn-query-campaign.py" "$output" \
     --output "$output/classification.json"
+check_provenance

--- a/bench/run-vpn-query-campaign.sh
+++ b/bench/run-vpn-query-campaign.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Retained VPN query campaign driver. CI may invoke only --smoke.
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+# shellcheck source=docs/perf/event-history-host-fence.sh
+source "$root/docs/perf/event-history-host-fence.sh"
+
+smoke=0
+if [[ ${1:-} == --smoke ]]; then
+    smoke=1
+    shift
+fi
+[[ $# -eq 1 ]] || {
+    echo "usage: $0 [--smoke] OUTPUT_DIRECTORY" >&2
+    exit 2
+}
+output=$1
+[[ ! -e "$output" ]] || {
+    echo "refusing existing output: $output" >&2
+    exit 1
+}
+mkdir -p "$output/bin" "$output/timing"
+[[ -z $(git -C "$root" status --porcelain) ]] || {
+    echo "refusing campaign from a dirty source tree" >&2
+    exit 1
+}
+
+vpn_query_acquire_host_lock
+vpn_query_init_host_preflight_log "$output/host-preflight.tsv"
+vpn_query_wait_for_idle build "$output/host-preflight.tsv"
+
+target_dir="$output/target"
+export CARGO_TARGET_DIR=$target_dir
+cargo build --manifest-path "$root/Cargo.toml" --release -p rustbgpd-api \
+    --bench vpn_query_timing --features bench-internals
+cargo build --manifest-path "$root/Cargo.toml" --release -p rustbgpd-api \
+    --bench vpn_query_allocation --features bench-internals,vpn-query-allocation
+
+find_binary() {
+    local name=$1
+    mapfile -t matches < <(find "$target_dir/release/deps" -maxdepth 1 -type f \
+        -perm -0100 -name "$name-*" | sort)
+    ((${#matches[@]} == 1)) || {
+        printf 'expected one %s binary, found %s\n' "$name" "${#matches[@]}" >&2
+        return 1
+    }
+    printf '%s\n' "${matches[0]}"
+}
+cp "$(find_binary vpn_query_timing)" "$output/bin/vpn_query_timing"
+cp "$(find_binary vpn_query_allocation)" "$output/bin/vpn_query_allocation"
+timing_hash=$(sha256sum "$output/bin/vpn_query_timing" | awk '{print $1}')
+allocation_hash=$(sha256sum "$output/bin/vpn_query_allocation" | awk '{print $1}')
+
+python3 - "$output/manifest.json" "$timing_hash" "$allocation_hash" \
+    "$(git -C "$root" rev-parse HEAD)" "$(rustc --version --verbose | tr '\n' ';')" <<'PY'
+import json, sys
+path, timing, allocation, commit, rustc = sys.argv[1:]
+fixed = [f"{case}{i}" for i in range(1, 9) for case in ("U", "F")]
+json.dump({"schema": 2, "base_commit": commit, "rustc": rustc,
+           "host_fence": "pass", "source_tree_clean": True, "fixed_order": fixed,
+           "timing_binary_sha256": timing,
+           "allocation_binary_sha256": allocation}, open(path, "w"), indent=2)
+PY
+
+decorate() {
+    local raw=$1 output_path=$2 binary_hash=$3 ordinal=$4 repetition=$5 timeout=$6
+    python3 - "$raw" "$output_path" "$binary_hash" "$ordinal" "$repetition" \
+        "$timeout" "$(git -C "$root" rev-parse HEAD)" <<'PY'
+import json, sys
+raw, output, binary_hash, ordinal, repetition, timeout, commit = sys.argv[1:]
+doc = json.load(open(raw))
+doc.update(schema=2, binary_sha256=binary_hash, ordinal=int(ordinal),
+           repetition=int(repetition), timeout_seconds=int(timeout),
+           source_commit=commit)
+json.dump(doc, open(output, "w"), indent=2)
+PY
+}
+
+if ((smoke)); then
+    vpn_query_wait_for_idle smoke "$output/host-preflight.tsv"
+    for target in timing allocation; do
+        raw="$output/$target-raw.json"
+        "$output/bin/vpn_query_$target" smoke U "$raw"
+        decorate "$raw" "$output/$target-smoke.json" \
+            "$([[ $target == timing ]] && echo "$timing_hash" || echo "$allocation_hash")" 1 1 10
+        rm "$raw"
+    done
+    echo "VPN query 256-route smoke passed"
+    exit
+fi
+
+ordinal=0
+for size in 10000 100000 1000000; do
+    for repetition in 1 2 3 4 5 6 7 8; do
+        for case in U F; do
+            ((ordinal += 1))
+            vpn_query_wait_for_idle "timing-$ordinal" "$output/host-preflight.tsv"
+            raw="$output/timing/raw.json"
+            "$output/bin/vpn_query_timing" cell "$size" "$case" "$raw"
+            decorate "$raw" "$output/timing/$(printf '%02d' "$ordinal").json" \
+                "$timing_hash" "$ordinal" "$repetition" 120
+            rm "$raw"
+        done
+    done
+done
+vpn_query_wait_for_idle allocation "$output/host-preflight.tsv"
+"$output/bin/vpn_query_allocation" cell 1000000 U "$output/allocation-raw.json"
+decorate "$output/allocation-raw.json" "$output/allocation.json" \
+    "$allocation_hash" 49 1 120
+rm "$output/allocation-raw.json"
+python3 "$root/bench/verify-vpn-query-campaign.py" "$output" \
+    --output "$output/classification.json"

--- a/bench/run-vpn-query-campaign.sh
+++ b/bench/run-vpn-query-campaign.sh
@@ -17,10 +17,14 @@ if [[ ${1:-} == --retry ]]; then
     shift
 fi
 [[ $# -eq 1 ]] || {
-    echo "usage: $0 [--smoke] OUTPUT_DIRECTORY" >&2
+    echo "usage: $0 [--smoke] [--retry] OUTPUT_DIRECTORY" >&2
     exit 2
 }
 output=$1
+if ((!smoke)) && [[ -n ${RUSTBGPD_VPN_QUERY_FORCE_CENSOR:-} ]]; then
+    echo "RUSTBGPD_VPN_QUERY_FORCE_CENSOR is forbidden for retained campaigns" >&2
+    exit 2
+fi
 [[ ! -e "$output" ]] || {
     echo "refusing existing output: $output" >&2
     exit 1
@@ -75,15 +79,15 @@ json.dump({"schema": 2, "base_commit": commit, "rustc": rustc,
 PY
 
 decorate() {
-    local raw=$1 output_path=$2 binary_hash=$3 ordinal=$4 repetition=$5 timeout=$6
+    local raw=$1 output_path=$2 binary_hash=$3 ordinal=$4 repetition=$5 timeout=$6 attempt=$7
     python3 - "$raw" "$output_path" "$binary_hash" "$ordinal" "$repetition" \
-        "$timeout" "$(git -C "$root" rev-parse HEAD)" <<'PY'
+        "$timeout" "$(git -C "$root" rev-parse HEAD)" "$attempt" <<'PY'
 import json, sys
-raw, output, binary_hash, ordinal, repetition, timeout, commit = sys.argv[1:]
+raw, output, binary_hash, ordinal, repetition, timeout, commit, attempt = sys.argv[1:]
 doc = json.load(open(raw))
 doc.update(schema=2, binary_sha256=binary_hash, ordinal=int(ordinal),
            repetition=int(repetition), timeout_seconds=int(timeout),
-           source_commit=commit)
+           source_commit=commit, attempt=int(attempt))
 json.dump(doc, open(output, "w"), indent=2)
 PY
 }
@@ -103,13 +107,13 @@ if ((smoke)); then
         raw="$output/$target-raw.json"
         "$output/bin/vpn_query_$target" smoke U "$raw"
         decorate "$raw" "$output/$target-smoke.json" \
-            "$([[ $target == timing ]] && echo "$timing_hash" || echo "$allocation_hash")" 1 1 10
+            "$([[ $target == timing ]] && echo "$timing_hash" || echo "$allocation_hash")" \
+            1 1 10 0
         rm "$raw"
     done
     echo "VPN query 256-route smoke passed"
     exit
 fi
-
 for attempt in $(seq 1 "$attempts"); do
     mkdir -p "$output/attempt-$attempt/timing"
     ordinal=0
@@ -127,16 +131,22 @@ for attempt in $(seq 1 "$attempts"); do
                 set -e
                 if ((rc == 75)); then
                     decorate "$raw" "$output/censor.json" "$timing_hash" \
-                        "$ordinal" "$repetition" 120
+                        "$ordinal" "$repetition" 120 "$attempt"
                     rm "$raw"
+                    python3 - "$output/manifest.json" "$attempt" <<'PY'
+import json, sys
+p=sys.argv[1]; d=json.load(open(p)); d["attempts"]=int(sys.argv[2]); json.dump(d,open(p,"w"),indent=2)
+PY
+                    check_provenance
                     python3 "$root/bench/verify-vpn-query-campaign.py" "$output" \
                         --output "$output/classification.json"
+                    check_provenance
                     exit
                 elif ((rc != 0)); then
                     exit "$rc"
                 fi
                 decorate "$raw" "$output/attempt-$attempt/timing/$(printf '%02d' "$ordinal").json" \
-                    "$timing_hash" "$ordinal" "$repetition" 120
+                    "$timing_hash" "$ordinal" "$repetition" 120 "$attempt"
                 rm "$raw"
             done
         done
@@ -150,16 +160,18 @@ rc=$?
 set -e
 if ((rc == 75)); then
     decorate "$output/allocation-raw.json" "$output/censor.json" \
-        "$allocation_hash" 49 1 120
+        "$allocation_hash" 49 1 120 "$attempts"
     rm "$output/allocation-raw.json"
+    check_provenance
     python3 "$root/bench/verify-vpn-query-campaign.py" "$output" \
         --output "$output/classification.json"
+    check_provenance
     exit
 elif ((rc != 0)); then
     exit "$rc"
 fi
 decorate "$output/allocation-raw.json" "$output/allocation.json" \
-    "$allocation_hash" 49 1 120
+    "$allocation_hash" 49 1 120 "$attempts"
 rm "$output/allocation-raw.json"
 python3 "$root/bench/verify-vpn-query-campaign.py" "$output" \
     --output "$output/classification.json"

--- a/bench/smoke-benches.sh
+++ b/bench/smoke-benches.sh
@@ -29,10 +29,9 @@ cd "$(dirname "$0")/.."
 #                        harness's own `--smoke` bound.
 #   route_paging         CSV receipt harness; one complete traversal per
 #                        process, driven by --route-count/--output.
-#   vpn_query            needs a `smoke|measure` mode plus an output path. CI
-#                        exercises its fixed-shape smoke and verifier
-#                        separately through test-vpn-query-receipt.sh.
-EXCLUDED=(snapshot_allocation route_paging vpn_query)
+#   vpn_query_*          are one-cell timing/allocation executables. CI runs
+#                        their exact 256-route smoke separately.
+EXCLUDED=(snapshot_allocation route_paging vpn_query_timing vpn_query_allocation)
 
 mapfile -t targets < <(
   cargo metadata --no-deps --format-version 1 | python3 -c '

--- a/bench/tests/test-vpn-query-campaign.sh
+++ b/bench/tests/test-vpn-query-campaign.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+runner=$root/bench/run-vpn-query-campaign.sh
+verifier=$root/bench/verify-vpn-query-campaign.py
+
+bash -n "$runner"
+python3 -m unittest -v "$root/bench/tests/test_verify_vpn_query_campaign.py"
+
+grep -F 'for size in 10000 100000 1000000' "$runner" >/dev/null
+grep -F 'for repetition in 1 2 3 4 5 6 7 8' "$runner" >/dev/null
+grep -F 'for case in U F' "$runner" >/dev/null
+grep -F 'campaign must contain exactly 48 timing receipts' "$verifier" >/dev/null
+
+mutated=$(mktemp)
+trap 'rm -f "$mutated"' EXIT
+sed 's/for case in U F/for case in F U/' "$runner" >"$mutated"
+if grep -F 'for case in U F' "$mutated" >/dev/null; then
+    echo "reordered campaign unexpectedly passed fixed-order gate" >&2
+    exit 1
+fi

--- a/bench/tests/test-vpn-query-campaign.sh
+++ b/bench/tests/test-vpn-query-campaign.sh
@@ -8,3 +8,12 @@ verifier=$root/bench/verify-vpn-query-campaign.py
 bash -n "$runner"
 python3 -m unittest -v "$root/bench/tests/test_verify_vpn_query_campaign.py"
 python3 "$verifier" --help >/dev/null
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+set +e
+env RUSTBGPD_VPN_QUERY_FORCE_CENSOR= "$runner" "$tmp_dir/output" >/dev/null 2>&1
+status=$?
+set -e
+[[ $status -eq 2 ]]
+[[ ! -e "$tmp_dir/output" ]]

--- a/bench/tests/test-vpn-query-campaign.sh
+++ b/bench/tests/test-vpn-query-campaign.sh
@@ -7,16 +7,4 @@ verifier=$root/bench/verify-vpn-query-campaign.py
 
 bash -n "$runner"
 python3 -m unittest -v "$root/bench/tests/test_verify_vpn_query_campaign.py"
-
-grep -F 'for size in 10000 100000 1000000' "$runner" >/dev/null
-grep -F 'for repetition in 1 2 3 4 5 6 7 8' "$runner" >/dev/null
-grep -F 'for case in U F' "$runner" >/dev/null
-grep -F 'campaign must contain exactly 48 timing receipts' "$verifier" >/dev/null
-
-mutated=$(mktemp)
-trap 'rm -f "$mutated"' EXIT
-sed 's/for case in U F/for case in F U/' "$runner" >"$mutated"
-if grep -F 'for case in U F' "$mutated" >/dev/null; then
-    echo "reordered campaign unexpectedly passed fixed-order gate" >&2
-    exit 1
-fi
+python3 "$verifier" --help >/dev/null

--- a/bench/tests/test-vpn-query-receipt.sh
+++ b/bench/tests/test-vpn-query-receipt.sh
@@ -75,6 +75,24 @@ assert allocation["query"]["returned_rows"] == 16
 assert allocation["peak_live_requested_bytes"] > 0
 PY
 
+set +e
+mapfile -t timing_bins < <(find "$repo_root/target/release/deps" -maxdepth 1 \
+  -type f -perm -0100 -name 'vpn_query_timing-*')
+[[ ${#timing_bins[@]} -eq 1 ]]
+RUSTBGPD_VPN_QUERY_FORCE_CENSOR=1 "${timing_bins[0]}" \
+  smoke U "$tmp_dir/censor.json" >/dev/null 2>&1
+censor_status=$?
+set -e
+[[ $censor_status -eq 75 ]]
+python3 - "$tmp_dir/censor.json" <<'PY'
+import json, sys
+doc = json.load(open(sys.argv[1]))
+assert doc == {
+    "schema": 1, "mode": "timing", "routes": 256, "case": "U",
+    "outcome": "capacity_censored", "censor_phase": "forced_fixture",
+}
+PY
+
 python3 - "$timing_receipt" "$tmp_dir/bad-rows.json" "$tmp_dir/bad-checksum.json" <<'PY'
 import json
 import sys

--- a/bench/tests/test-vpn-query-receipt.sh
+++ b/bench/tests/test-vpn-query-receipt.sh
@@ -25,6 +25,16 @@ PY
 }
 
 check_allocator_seam "$bench_source"
+python3 - "$bench_source" <<'PY'
+import pathlib, sys
+source = pathlib.Path(sys.argv[1]).read_text()
+for contract in (
+    "compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)",
+    "locked.store(false, Ordering::Release)",
+):
+    assert contract in source, contract
+assert source.count("let _guard = self.guard();") == 6
+PY
 sed '/^#\[global_allocator\]$/d' "$bench_source" >"$tmp_dir/no-global-allocator.rs"
 if check_allocator_seam "$tmp_dir/no-global-allocator.rs" >/dev/null 2>&1; then
   echo "bench source without global allocator unexpectedly passed" >&2

--- a/bench/tests/test-vpn-query-receipt.sh
+++ b/bench/tests/test-vpn-query-receipt.sh
@@ -5,7 +5,8 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
-receipt="$tmp_dir/receipt.json"
+timing_receipt="$tmp_dir/timing.json"
+allocation_receipt="$tmp_dir/allocation.json"
 bench_source="$repo_root/crates/api/benches/vpn_query.rs"
 
 check_allocator_seam() {
@@ -31,7 +32,10 @@ if check_allocator_seam "$tmp_dir/no-global-allocator.rs" >/dev/null 2>&1; then
 fi
 
 cargo bench --manifest-path "$repo_root/Cargo.toml" -p rustbgpd-api \
-  --bench vpn_query --features bench-internals -- smoke "$receipt"
+  --bench vpn_query_timing --features bench-internals -- smoke U "$timing_receipt"
+cargo bench --manifest-path "$repo_root/Cargo.toml" -p rustbgpd-api \
+  --bench vpn_query_allocation --features bench-internals,vpn-query-allocation -- \
+  smoke F "$allocation_receipt"
 
 verify() {
   python3 - "$1" <<'PY'
@@ -41,39 +45,46 @@ import sys
 doc = json.load(open(sys.argv[1], encoding="utf-8"))
 assert doc["schema"] == 1
 assert doc["allocator"] == "tikv-jemallocator"
-assert doc["mode"] == "timing"
 assert doc["routes"] == 256
 assert doc["peers"] == 16
-all_rows = doc["queries"]["all"]
-peer_rows = doc["queries"]["peer_10_0_0_1"]
-assert all_rows["actor_rows"] == 256
-assert all_rows["actor_capacity"] >= 256
-assert all_rows["returned_rows"] == 256
-assert peer_rows["actor_rows"] == 256
-assert peer_rows["returned_rows"] == 16
-assert all_rows["dispatch"] == 1
-assert peer_rows["dispatch"] == 2
-assert all_rows["checksum"] == 5102335214269610730
-assert peer_rows["checksum"] == 7341237881033179096
-for query in (all_rows, peer_rows):
-    assert query["actor_handler_ns"] > 0
-    assert query["service_method_ns"] > 0
-    assert query["post_actor_ns"] > 0
+query = doc["query"]
+assert query["actor_rows"] == 256
+assert query["actor_capacity"] >= 256
+assert query["dispatch"] == 1
+assert query["returned_rows"] == (256 if doc["case"] == "U" else 16)
+assert query["checksum"] == (
+    5102335214269610730 if doc["case"] == "U" else 7341237881033179096
+)
+assert query["actor_handler_ns"] > 0
+assert query["service_method_ns"] >= query["actor_handler_ns"]
+assert query["post_actor_ns"] == query["service_method_ns"] - query["actor_handler_ns"]
 PY
 }
 
-verify "$receipt"
+verify "$timing_receipt"
+verify "$allocation_receipt"
+python3 - "$timing_receipt" "$allocation_receipt" <<'PY'
+import json, sys
+timing = json.load(open(sys.argv[1]))
+allocation = json.load(open(sys.argv[2]))
+assert timing["mode"] == "timing" and timing["case"] == "U"
+assert timing["query"]["returned_rows"] == 256
+assert timing["peak_live_requested_bytes"] is None
+assert allocation["mode"] == "allocation" and allocation["case"] == "F"
+assert allocation["query"]["returned_rows"] == 16
+assert allocation["peak_live_requested_bytes"] > 0
+PY
 
-python3 - "$receipt" "$tmp_dir/bad-rows.json" "$tmp_dir/bad-checksum.json" <<'PY'
+python3 - "$timing_receipt" "$tmp_dir/bad-rows.json" "$tmp_dir/bad-checksum.json" <<'PY'
 import json
 import sys
 
 doc = json.load(open(sys.argv[1], encoding="utf-8"))
 bad_rows = json.loads(json.dumps(doc))
-bad_rows["queries"]["peer_10_0_0_1"]["returned_rows"] = 15
+bad_rows["query"]["returned_rows"] = 15
 json.dump(bad_rows, open(sys.argv[2], "w", encoding="utf-8"))
 bad_checksum = json.loads(json.dumps(doc))
-bad_checksum["queries"]["all"]["checksum"] = 5102335214269610731
+bad_checksum["query"]["checksum"] += 1
 json.dump(bad_checksum, open(sys.argv[3], "w", encoding="utf-8"))
 PY
 

--- a/bench/tests/test_verify_vpn_query_campaign.py
+++ b/bench/tests/test_verify_vpn_query_campaign.py
@@ -249,6 +249,7 @@ class VerifyCampaign(unittest.TestCase):
             "binary_sha256": hashlib.sha256(b"vpn_query_timing").hexdigest(),
         }
         self.write("censor.json", censor)
+        self.mutate("manifest.json", lambda d: d.update(attempts=2))
         (self.root / "allocation.json").unlink()
         lines = (self.root / "host-preflight.tsv").read_text().splitlines()
         def retained_phase(line):
@@ -263,6 +264,19 @@ class VerifyCampaign(unittest.TestCase):
         (self.root / "host-preflight.tsv").write_text("\n".join(kept) + "\n")
         self.assertEqual(VERIFY.verify(self.root)["classification"],
                          "capacity_censored")
+        (self.root / "attempt-2").mkdir()
+        with self.assertRaises(VERIFY.Invalid):
+            VERIFY.verify(self.root)
+        (self.root / "attempt-2").rmdir()
+        for field, value in (("schema", 1), ("censor_phase", ""),
+                             ("censor_phase", "unknown"),
+                             ("censor_phase", "forced_fixture")):
+            original = censor[field]
+            self.mutate("censor.json", lambda d, f=field, v=value: d.update({f: v}))
+            with self.assertRaises(VERIFY.Invalid):
+                VERIFY.verify(self.root)
+            self.mutate("censor.json",
+                        lambda d, f=field, v=original: d.update({f: v}))
 
     def test_provenance_and_preflight_corruption(self):
         self.mutate("manifest.json", lambda d: d.update(source_tree="bad"))

--- a/bench/tests/test_verify_vpn_query_campaign.py
+++ b/bench/tests/test_verify_vpn_query_campaign.py
@@ -238,6 +238,10 @@ class VerifyCampaign(unittest.TestCase):
 
         self.tearDown()
         self.setUp()
+        full_receipts = {
+            ordinal: (self.root / "attempt-1" / "timing" / f"{ordinal:02d}.json").read_text()
+            for ordinal in range(11, 49)
+        }
         for ordinal in range(11, 49):
             (self.root / "attempt-1" / "timing" / f"{ordinal:02d}.json").unlink()
         censor = {
@@ -264,6 +268,15 @@ class VerifyCampaign(unittest.TestCase):
         (self.root / "host-preflight.tsv").write_text("\n".join(kept) + "\n")
         self.assertEqual(VERIFY.verify(self.root)["classification"],
                          "capacity_censored")
+        for ordinal in range(11, 50):
+            content = full_receipts.get(ordinal, full_receipts[48])
+            (self.root / "attempt-1" / "timing" / f"{ordinal:02d}.json").write_text(content)
+        self.mutate("censor.json", lambda d: d.update(ordinal=50))
+        with self.assertRaises(VERIFY.Invalid):
+            VERIFY.verify(self.root)
+        self.mutate("censor.json", lambda d: d.update(ordinal=11))
+        for ordinal in range(11, 50):
+            (self.root / "attempt-1" / "timing" / f"{ordinal:02d}.json").unlink()
         (self.root / "attempt-2").mkdir()
         with self.assertRaises(VERIFY.Invalid):
             VERIFY.verify(self.root)

--- a/bench/tests/test_verify_vpn_query_campaign.py
+++ b/bench/tests/test_verify_vpn_query_campaign.py
@@ -2,6 +2,7 @@ import hashlib
 import importlib.util
 import json
 import pathlib
+import shutil
 import tempfile
 import unittest
 
@@ -16,7 +17,7 @@ class VerifyCampaign(unittest.TestCase):
         self.temp = tempfile.TemporaryDirectory()
         self.root = pathlib.Path(self.temp.name)
         (self.root / "bin").mkdir()
-        (self.root / "timing").mkdir()
+        (self.root / "attempt-1" / "timing").mkdir(parents=True)
         for name in ("vpn_query_timing", "vpn_query_allocation"):
             (self.root / "bin" / name).write_bytes(name.encode())
         timing_hash = hashlib.sha256(b"vpn_query_timing").hexdigest()
@@ -24,13 +25,14 @@ class VerifyCampaign(unittest.TestCase):
         manifest = {
             "schema": 2, "base_commit": "a" * 40, "rustc": "rustc fixture",
             "host_fence": "pass", "source_tree_clean": True,
+            "source_tree": "c" * 40, "attempts": 1,
             "fixed_order": list(VERIFY.CASES),
             "timing_binary_sha256": timing_hash,
             "allocation_binary_sha256": allocation_hash,
         }
         self.write("manifest.json", manifest)
         for ordinal, size, case, repetition in VERIFY.expected_cells():
-            actor = 10_000_000 + repetition * 10
+            actor = size * 10 + repetition * 10
             service = 300_000_000 + actor
             receipt = {
                 "schema": 2, "mode": "timing", "ordinal": ordinal,
@@ -42,16 +44,26 @@ class VerifyCampaign(unittest.TestCase):
                     "service_method_ns": service, "post_actor_ns": 300_000_000,
                     "actor_rows": size, "actor_capacity": size,
                     "returned_rows": size if case == "U" else size // 16,
-                    "dispatch": 1, "checksum": ordinal,
+                    "dispatch": 1, "checksum": size + (case == "F"),
                 },
             }
-            self.write(f"timing/{ordinal:02d}.json", receipt)
+            self.write(f"attempt-1/timing/{ordinal:02d}.json", receipt)
         self.write("allocation.json", {
             "schema": 2, "mode": "allocation", "routes": 1_000_000, "case": "U",
             "binary_sha256": allocation_hash, "peak_live_requested_bytes": 1024,
             "source_commit": "a" * 40, "timeout_seconds": 120,
             "vmrss_bytes": 999999999999, "vmhwm_bytes": 999999999999,
+            "query": {"actor_rows": 1_000_000, "actor_capacity": 1_000_000,
+                      "returned_rows": 1_000_000, "checksum": 7, "dispatch": 1},
         })
+        phases = ["build"] + [f"attempt-1-timing-{i}" for i in range(1, 49)] + [
+            "allocation"
+        ]
+        header = ("phase\tattempt\tutc\tload_1m\tload_1m_max\tgovernor\t"
+                  "required_governor\tcompeting_process_count\tcompeting_processes\tstatus\n")
+        rows = "".join(f"{phase}\t1\tnow\t0\t2\tperformance\tperformance\t0\tnone\tpass\n"
+                       for phase in phases)
+        (self.root / "host-preflight.tsv").write_text(header + rows)
 
     def tearDown(self):
         self.temp.cleanup()
@@ -71,20 +83,26 @@ class VerifyCampaign(unittest.TestCase):
 
     def test_rejects_count_order_dual_case_underflow_and_binary_corruption(self):
         mutations = [
-            ("timing/48.json", lambda: (self.root / "timing/48.json").unlink()),
-            ("timing/02.json", lambda: self.mutate("timing/02.json",
+            ("attempt-1/timing/48.json", lambda: (self.root / "attempt-1/timing/48.json").unlink()),
+            ("attempt-1/timing/02.json", lambda: self.mutate("attempt-1/timing/02.json",
                                                    lambda d: d.update(ordinal=3))),
-            ("timing/01.json", lambda: self.mutate("timing/01.json",
+            ("attempt-1/timing/01.json", lambda: self.mutate("attempt-1/timing/01.json",
                                                    lambda d: d.update(queries={}))),
-            ("timing/01.json", lambda: self.mutate("timing/01.json",
+            ("attempt-1/timing/01.json", lambda: self.mutate("attempt-1/timing/01.json",
                                                    lambda d: d["query"].update(
                                                        actor_handler_ns=20_000_000))),
-            ("timing/01.json", lambda: self.mutate("timing/01.json",
+            ("attempt-1/timing/01.json", lambda: self.mutate("attempt-1/timing/01.json",
                                                    lambda d: d.update(timeout_seconds=121))),
-            ("timing/01.json", lambda: self.mutate("timing/01.json",
+            ("attempt-1/timing/01.json", lambda: self.mutate("attempt-1/timing/01.json",
                                                    lambda d: d.update(source_commit="b" * 40))),
             ("bin/vpn_query_timing", lambda: (self.root / "bin/vpn_query_timing")
              .write_bytes(b"corrupt")),
+            ("attempt-1/timing/01.json",
+             lambda: self.mutate("attempt-1/timing/01.json",
+                                 lambda d: d["query"].update(checksum=999))),
+            ("allocation.json",
+             lambda: self.mutate("allocation.json",
+                                 lambda d: d["query"].update(returned_rows=999))),
         ]
         for index, (_, mutation) in enumerate(mutations):
             with self.subTest(mutation=mutation):
@@ -111,10 +129,18 @@ class VerifyCampaign(unittest.TestCase):
         timings[(1_000_000, "F")] = [25_000_003] * 8
         self.assertEqual(VERIFY.classify({}, timings, allocation)["classification"],
                          "design_followup")
-        for key in timings:
-            timings[key] = [200_000_001] * 8
+        for index, size in enumerate(VERIFY.SIZES):
+            for case in ("U", "F"):
+                timings[(size, case)] = [200_000_001 + index] * 8
         self.assertEqual(VERIFY.classify({}, timings, allocation)["classification"], "urgent")
         timings[(10_000, "F")] = [100_000_000] * 8
+        self.assertEqual(VERIFY.classify({}, timings, allocation)["classification"],
+                         "instrumentation_suspect")
+
+        timings = {
+            (size, case): [100] * 8
+            for size in VERIFY.SIZES for case in ("U", "F")
+        }
         self.assertEqual(VERIFY.classify({}, timings, allocation)["classification"],
                          "instrumentation_suspect")
         timings[(10_000, "F")] = [200_000_001] * 8
@@ -128,10 +154,11 @@ class VerifyCampaign(unittest.TestCase):
     def test_size_specific_noise_and_monotonic_instrumentation(self):
         allocation = {"peak_live_requested_bytes": 1}
         timings = {
-            (size, case): [100] * 8 for size in VERIFY.SIZES for case in ("U", "F")
+            (size, case): [100 * (index + 1)] * 8
+            for index, size in enumerate(VERIFY.SIZES) for case in ("U", "F")
         }
-        timings[(1_000_000, "U")] = [100, 106] * 4
-        timings[(1_000_000, "F")] = [100, 106] * 4
+        timings[(1_000_000, "U")] = [300, 318] * 4
+        timings[(1_000_000, "F")] = [300, 318] * 4
         self.assertEqual(VERIFY.classify({}, timings, allocation)["classification"],
                          "no_redesign")
         timings[(10_000, "U")] = [100, 106] * 4
@@ -144,6 +171,62 @@ class VerifyCampaign(unittest.TestCase):
         }
         self.assertEqual(VERIFY.classify({}, timings, allocation)["classification"],
                          "instrumentation_suspect")
+
+    def test_complete_retry_and_typed_capacity_censor(self):
+        shutil.copytree(self.root / "attempt-1", self.root / "attempt-2")
+        self.mutate("manifest.json", lambda d: d.update(attempts=2))
+        with (self.root / "host-preflight.tsv").open("a") as stream:
+            for ordinal in range(1, 49):
+                stream.write(
+                    f"attempt-2-timing-{ordinal}\t1\tnow\t0\t2\tperformance\t"
+                    "performance\t0\tnone\tpass\n"
+                )
+        self.assertEqual(VERIFY.verify(self.root)["classification"], "no_redesign")
+        (self.root / "attempt-2" / "timing" / "48.json").unlink()
+        with self.assertRaises(VERIFY.Invalid):
+            VERIFY.verify(self.root)
+        shutil.copy(self.root / "attempt-1" / "timing" / "48.json",
+                    self.root / "attempt-2" / "timing" / "48.json")
+        (self.root / "attempt-3").mkdir()
+        with self.assertRaises(VERIFY.Invalid):
+            VERIFY.verify(self.root)
+
+        self.tearDown()
+        self.setUp()
+        for ordinal in range(11, 49):
+            (self.root / "attempt-1" / "timing" / f"{ordinal:02d}.json").unlink()
+        censor = {
+            "schema": 2, "mode": "timing", "outcome": "capacity_censored",
+            "censor_phase": "service_query", "ordinal": 11, "routes": 10_000,
+            "case": "U", "repetition": 6, "timeout_seconds": 120,
+            "source_commit": "a" * 40,
+            "binary_sha256": hashlib.sha256(b"vpn_query_timing").hexdigest(),
+        }
+        self.write("censor.json", censor)
+        (self.root / "allocation.json").unlink()
+        lines = (self.root / "host-preflight.tsv").read_text().splitlines()
+        def retained_phase(line):
+            phase = line.split("\t")[0]
+            return phase == "build" or (
+                phase.startswith("attempt-1-timing-")
+                and int(phase.rsplit("-", 1)[1]) <= 11
+            )
+        kept = [lines[0]] + [
+            line for line in lines[1:] if retained_phase(line)
+        ]
+        (self.root / "host-preflight.tsv").write_text("\n".join(kept) + "\n")
+        self.assertEqual(VERIFY.verify(self.root)["classification"],
+                         "capacity_censored")
+
+    def test_provenance_and_preflight_corruption(self):
+        self.mutate("manifest.json", lambda d: d.update(source_tree="bad"))
+        with self.assertRaises(VERIFY.Invalid):
+            VERIFY.verify(self.root)
+        self.mutate("manifest.json", lambda d: d.update(source_tree="c" * 40))
+        log = self.root / "host-preflight.tsv"
+        log.write_text(log.read_text().replace("allocation\t1\t", "unexpected\t1\t"))
+        with self.assertRaises(VERIFY.Invalid):
+            VERIFY.verify(self.root)
 
 
 if __name__ == "__main__":

--- a/bench/tests/test_verify_vpn_query_campaign.py
+++ b/bench/tests/test_verify_vpn_query_campaign.py
@@ -1,0 +1,150 @@
+import hashlib
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+
+SCRIPT = pathlib.Path(__file__).parents[1] / "verify-vpn-query-campaign.py"
+SPEC = importlib.util.spec_from_file_location("vpn_verify", SCRIPT)
+VERIFY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VERIFY)
+
+
+class VerifyCampaign(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temp.name)
+        (self.root / "bin").mkdir()
+        (self.root / "timing").mkdir()
+        for name in ("vpn_query_timing", "vpn_query_allocation"):
+            (self.root / "bin" / name).write_bytes(name.encode())
+        timing_hash = hashlib.sha256(b"vpn_query_timing").hexdigest()
+        allocation_hash = hashlib.sha256(b"vpn_query_allocation").hexdigest()
+        manifest = {
+            "schema": 2, "base_commit": "a" * 40, "rustc": "rustc fixture",
+            "host_fence": "pass", "source_tree_clean": True,
+            "fixed_order": list(VERIFY.CASES),
+            "timing_binary_sha256": timing_hash,
+            "allocation_binary_sha256": allocation_hash,
+        }
+        self.write("manifest.json", manifest)
+        for ordinal, size, case, repetition in VERIFY.expected_cells():
+            actor = 10_000_000 + repetition * 10
+            service = 300_000_000 + actor
+            receipt = {
+                "schema": 2, "mode": "timing", "ordinal": ordinal,
+                "routes": size, "case": case, "repetition": repetition,
+                "binary_sha256": timing_hash,
+                "source_commit": "a" * 40, "timeout_seconds": 120,
+                "query": {
+                    "actor_handler_ns": actor,
+                    "service_method_ns": service, "post_actor_ns": 300_000_000,
+                    "actor_rows": size, "actor_capacity": size,
+                    "returned_rows": size if case == "U" else size // 16,
+                    "dispatch": 1, "checksum": ordinal,
+                },
+            }
+            self.write(f"timing/{ordinal:02d}.json", receipt)
+        self.write("allocation.json", {
+            "schema": 2, "mode": "allocation", "routes": 1_000_000, "case": "U",
+            "binary_sha256": allocation_hash, "peak_live_requested_bytes": 1024,
+            "source_commit": "a" * 40, "timeout_seconds": 120,
+            "vmrss_bytes": 999999999999, "vmhwm_bytes": 999999999999,
+        })
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def write(self, relative, value):
+        (self.root / relative).write_text(json.dumps(value), encoding="utf-8")
+
+    def mutate(self, relative, callback):
+        path = self.root / relative
+        value = json.loads(path.read_text())
+        callback(value)
+        self.write(relative, value)
+
+    def test_valid_fixture_and_observational_rss(self):
+        result = VERIFY.verify(self.root)
+        self.assertEqual(result["classification"], "no_redesign")
+
+    def test_rejects_count_order_dual_case_underflow_and_binary_corruption(self):
+        mutations = [
+            ("timing/48.json", lambda: (self.root / "timing/48.json").unlink()),
+            ("timing/02.json", lambda: self.mutate("timing/02.json",
+                                                   lambda d: d.update(ordinal=3))),
+            ("timing/01.json", lambda: self.mutate("timing/01.json",
+                                                   lambda d: d.update(queries={}))),
+            ("timing/01.json", lambda: self.mutate("timing/01.json",
+                                                   lambda d: d["query"].update(
+                                                       actor_handler_ns=20_000_000))),
+            ("timing/01.json", lambda: self.mutate("timing/01.json",
+                                                   lambda d: d.update(timeout_seconds=121))),
+            ("timing/01.json", lambda: self.mutate("timing/01.json",
+                                                   lambda d: d.update(source_commit="b" * 40))),
+            ("bin/vpn_query_timing", lambda: (self.root / "bin/vpn_query_timing")
+             .write_bytes(b"corrupt")),
+        ]
+        for index, (_, mutation) in enumerate(mutations):
+            with self.subTest(mutation=mutation):
+                mutation()
+                with self.assertRaises(VERIFY.Invalid):
+                    VERIFY.verify(self.root)
+                if index + 1 < len(mutations):
+                    self.tearDown()
+                    self.setUp()
+
+    def test_classifier_precedence_and_thresholds(self):
+        timings = {
+            (size, case): [10 * (index + 1)] * 8
+            for index, size in enumerate(VERIFY.SIZES) for case in ("U", "F")
+        }
+        allocation = {"peak_live_requested_bytes": 1}
+        self.assertEqual(VERIFY.classify({}, timings, allocation)["classification"],
+                         "no_redesign")
+        timings[(10_000, "U")] = [25_000_001] * 8
+        timings[(10_000, "F")] = [25_000_001] * 8
+        timings[(100_000, "U")] = [25_000_002] * 8
+        timings[(100_000, "F")] = [25_000_002] * 8
+        timings[(1_000_000, "U")] = [25_000_003] * 8
+        timings[(1_000_000, "F")] = [25_000_003] * 8
+        self.assertEqual(VERIFY.classify({}, timings, allocation)["classification"],
+                         "design_followup")
+        for key in timings:
+            timings[key] = [200_000_001] * 8
+        self.assertEqual(VERIFY.classify({}, timings, allocation)["classification"], "urgent")
+        timings[(10_000, "F")] = [100_000_000] * 8
+        self.assertEqual(VERIFY.classify({}, timings, allocation)["classification"],
+                         "instrumentation_suspect")
+        timings[(10_000, "F")] = [200_000_001] * 8
+        timings[(10_000, "U")][1] *= 2
+        self.assertEqual(VERIFY.classify({}, timings, allocation)["classification"],
+                         "inconclusive")
+        allocation["peak_live_requested_bytes"] = VERIFY.CAPACITY + 1
+        self.assertEqual(VERIFY.classify({}, timings, allocation)["classification"],
+                         "capacity_censored")
+
+    def test_size_specific_noise_and_monotonic_instrumentation(self):
+        allocation = {"peak_live_requested_bytes": 1}
+        timings = {
+            (size, case): [100] * 8 for size in VERIFY.SIZES for case in ("U", "F")
+        }
+        timings[(1_000_000, "U")] = [100, 106] * 4
+        timings[(1_000_000, "F")] = [100, 106] * 4
+        self.assertEqual(VERIFY.classify({}, timings, allocation)["classification"],
+                         "no_redesign")
+        timings[(10_000, "U")] = [100, 106] * 4
+        timings[(10_000, "F")] = [100, 106] * 4
+        self.assertEqual(VERIFY.classify({}, timings, allocation)["classification"],
+                         "inconclusive")
+        timings = {
+            (size, case): [300 - index * 100] * 8
+            for index, size in enumerate(VERIFY.SIZES) for case in ("U", "F")
+        }
+        self.assertEqual(VERIFY.classify({}, timings, allocation)["classification"],
+                         "instrumentation_suspect")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/tests/test_verify_vpn_query_campaign.py
+++ b/bench/tests/test_verify_vpn_query_campaign.py
@@ -39,12 +39,13 @@ class VerifyCampaign(unittest.TestCase):
                 "routes": size, "case": case, "repetition": repetition,
                 "binary_sha256": timing_hash,
                 "source_commit": "a" * 40, "timeout_seconds": 120,
+                "attempt": 1,
                 "query": {
                     "actor_handler_ns": actor,
                     "service_method_ns": service, "post_actor_ns": 300_000_000,
                     "actor_rows": size, "actor_capacity": size,
                     "returned_rows": size if case == "U" else size // 16,
-                    "dispatch": 1, "checksum": size + (case == "F"),
+                    "dispatch": 1, "checksum": VERIFY.CHECKSUMS[(size, case)],
                 },
             }
             self.write(f"attempt-1/timing/{ordinal:02d}.json", receipt)
@@ -52,9 +53,13 @@ class VerifyCampaign(unittest.TestCase):
             "schema": 2, "mode": "allocation", "routes": 1_000_000, "case": "U",
             "binary_sha256": allocation_hash, "peak_live_requested_bytes": 1024,
             "source_commit": "a" * 40, "timeout_seconds": 120,
+            "attempt": 1,
             "vmrss_bytes": 999999999999, "vmhwm_bytes": 999999999999,
             "query": {"actor_rows": 1_000_000, "actor_capacity": 1_000_000,
-                      "returned_rows": 1_000_000, "checksum": 7, "dispatch": 1},
+                      "returned_rows": 1_000_000,
+                      "actor_handler_ns": 10, "service_method_ns": 11,
+                      "post_actor_ns": 1,
+                      "checksum": VERIFY.CHECKSUMS[(1_000_000, "U")], "dispatch": 1},
         })
         phases = ["build"] + [f"attempt-1-timing-{i}" for i in range(1, 49)] + [
             "allocation"
@@ -103,6 +108,12 @@ class VerifyCampaign(unittest.TestCase):
             ("allocation.json",
              lambda: self.mutate("allocation.json",
                                  lambda d: d["query"].update(returned_rows=999))),
+            ("allocation.json",
+             lambda: self.mutate("allocation.json",
+                                 lambda d: d["query"].update(checksum=999))),
+            ("allocation.json",
+             lambda: self.mutate("allocation.json",
+                                 lambda d: d["query"].update(post_actor_ns=2))),
         ]
         for index, (_, mutation) in enumerate(mutations):
             with self.subTest(mutation=mutation):
@@ -175,6 +186,11 @@ class VerifyCampaign(unittest.TestCase):
     def test_complete_retry_and_typed_capacity_censor(self):
         shutil.copytree(self.root / "attempt-1", self.root / "attempt-2")
         self.mutate("manifest.json", lambda d: d.update(attempts=2))
+        self.mutate("allocation.json", lambda d: d.update(attempt=2))
+        for path in (self.root / "attempt-2" / "timing").glob("*.json"):
+            value = json.loads(path.read_text())
+            value["attempt"] = 2
+            path.write_text(json.dumps(value))
         with (self.root / "host-preflight.tsv").open("a") as stream:
             for ordinal in range(1, 49):
                 stream.write(
@@ -182,6 +198,17 @@ class VerifyCampaign(unittest.TestCase):
                     "performance\t0\tnone\tpass\n"
                 )
         self.assertEqual(VERIFY.verify(self.root)["classification"], "no_redesign")
+        allocation = json.loads((self.root / "allocation.json").read_text())
+        allocation.update(outcome="capacity_censored", censor_phase="service_query",
+                          ordinal=49, repetition=1)
+        self.write("censor.json", allocation)
+        (self.root / "allocation.json").unlink()
+        self.assertEqual(VERIFY.verify(self.root)["classification"],
+                         "capacity_censored")
+        (self.root / "censor.json").unlink()
+        self.write("allocation.json", {k: v for k, v in allocation.items()
+                                      if k not in ("outcome", "censor_phase", "ordinal",
+                                                   "repetition")})
         (self.root / "attempt-2" / "timing" / "48.json").unlink()
         with self.assertRaises(VERIFY.Invalid):
             VERIFY.verify(self.root)
@@ -190,6 +217,24 @@ class VerifyCampaign(unittest.TestCase):
         (self.root / "attempt-3").mkdir()
         with self.assertRaises(VERIFY.Invalid):
             VERIFY.verify(self.root)
+        (self.root / "attempt-3").rmdir()
+        censor = json.loads(
+            (self.root / "attempt-2" / "timing" / "11.json").read_text())
+        censor.pop("query")
+        censor.update(outcome="capacity_censored", censor_phase="actor_receipt")
+        self.write("censor.json", censor)
+        for ordinal in range(11, 49):
+            (self.root / "attempt-2" / "timing" / f"{ordinal:02d}.json").unlink()
+        (self.root / "allocation.json").unlink()
+        log = self.root / "host-preflight.tsv"
+        log.write_text("\n".join(
+            line for line in log.read_text().splitlines()
+            if not line.startswith("allocation\t")
+            and not (line.startswith("attempt-2-timing-")
+                     and int(line.split("\t")[0].rsplit("-", 1)[1]) > 11)
+        ) + "\n")
+        self.assertEqual(VERIFY.verify(self.root)["classification"],
+                         "capacity_censored")
 
         self.tearDown()
         self.setUp()
@@ -200,6 +245,7 @@ class VerifyCampaign(unittest.TestCase):
             "censor_phase": "service_query", "ordinal": 11, "routes": 10_000,
             "case": "U", "repetition": 6, "timeout_seconds": 120,
             "source_commit": "a" * 40,
+            "attempt": 1,
             "binary_sha256": hashlib.sha256(b"vpn_query_timing").hexdigest(),
         }
         self.write("censor.json", censor)
@@ -225,6 +271,27 @@ class VerifyCampaign(unittest.TestCase):
         self.mutate("manifest.json", lambda d: d.update(source_tree="c" * 40))
         log = self.root / "host-preflight.tsv"
         log.write_text(log.read_text().replace("allocation\t1\t", "unexpected\t1\t"))
+        with self.assertRaises(VERIFY.Invalid):
+            VERIFY.verify(self.root)
+        log.write_text(log.read_text().replace(
+            "unexpected\t1\tnow\t0\t2\tperformance\tperformance\t0\tnone\tpass",
+            "allocation\t1\tnow\t0\t2\tpowersave\tperformance\t1\tvpn_query_timi\tpass"))
+        with self.assertRaises(VERIFY.Invalid):
+            VERIFY.verify(self.root)
+
+    def test_attempt_inventory_rejects_undeclared_and_malformed(self):
+        (self.root / "attempt-2").mkdir()
+        with self.assertRaises(VERIFY.Invalid):
+            VERIFY.verify(self.root)
+        (self.root / "attempt-2").rename(self.root / "attempt-extra")
+        with self.assertRaises(VERIFY.Invalid):
+            VERIFY.verify(self.root)
+
+    def test_all_cell_same_checksum_corruption(self):
+        for path in (self.root / "attempt-1" / "timing").glob("*.json"):
+            value = json.loads(path.read_text())
+            value["query"]["checksum"] = 7
+            path.write_text(json.dumps(value))
         with self.assertRaises(VERIFY.Invalid):
             VERIFY.verify(self.root)
 

--- a/bench/verify-vpn-query-campaign.py
+++ b/bench/verify-vpn-query-campaign.py
@@ -186,18 +186,21 @@ def verify(directory):
 
     attempts = manifest.get("attempts")
     require(attempts in (1, 2), "campaign permits exactly one attempt and one retry")
+    censor_path = directory / "censor.json"
+    censor = load(censor_path) if censor_path.exists() else None
+    censor_attempt = censor.get("attempt") if censor else attempts
+    require(type(censor_attempt) is int and 1 <= censor_attempt <= attempts,
+            "censor attempt outside requested attempts")
     entries = {p.name: p for p in directory.iterdir() if p.name.startswith("attempt")}
-    expected_attempts = {f"attempt-{n}" for n in range(1, attempts + 1)}
+    expected_attempts = {f"attempt-{n}" for n in range(1, censor_attempt + 1)}
     require(set(entries) == expected_attempts
             and all(path.is_dir() for path in entries.values()),
             "attempt filesystem inventory drift")
     expected_phases = {"build"}
     selected_timings = None
-    for attempt in range(1, attempts + 1):
+    for attempt in range(1, censor_attempt + 1):
         receipt_paths = sorted((directory / f"attempt-{attempt}" / "timing").glob("*.json"))
-        censor_path = directory / "censor.json"
-        if censor_path.exists() and load(censor_path).get("attempt") == attempt:
-            censor = load(censor_path)
+        if censor and censor_attempt == attempt:
             for path, completed in zip(receipt_paths, expected_cells()):
                 verify_receipt(load(path), completed, manifest, attempt)
             expected_phases.update(
@@ -205,6 +208,7 @@ def verify(directory):
                 for ordinal in range(1, len(receipt_paths) + 1)
             )
             require(censor.get("outcome") == "capacity_censored", "invalid censor outcome")
+            require(censor.get("schema") == 2, "censor schema")
             require(censor.get("ordinal") == len(receipt_paths) + 1,
                     "censor must stop the next ordered cell")
             if len(receipt_paths) == 48:
@@ -231,8 +235,11 @@ def verify(directory):
                     "censor source drift")
             require(censor.get("timeout_seconds") == 120, "censor timeout drift")
             require(censor.get("attempt") == attempt, "censor attempt drift")
-            require(isinstance(censor.get("censor_phase"), str), "missing censor phase")
-            require(attempt == attempts, "censor must terminate declared attempts")
+            require(censor.get("censor_phase") in {
+                "seed_send", "barrier_send", "barrier_reply", "service_query",
+                "actor_receipt", "service_receipt",
+            }, "invalid censor phase")
+            require(attempt == censor_attempt, "censor attempt binding")
             require(not (directory / "allocation.json").exists(),
                     "allocation must not run after timeout censor")
             verify_phases(expected_phases)

--- a/bench/verify-vpn-query-campaign.py
+++ b/bench/verify-vpn-query-campaign.py
@@ -12,6 +12,12 @@ import sys
 SIZES = (10_000, 100_000, 1_000_000)
 CASES = tuple(case for pair in range(1, 9) for case in (f"U{pair}", f"F{pair}"))
 CAPACITY = 8 * 1024**3
+CHECKSUMS = {
+    (10_000, "U"): 11130280336100770277, (10_000, "F"): 7650825114892061189,
+    (100_000, "U"): 14231629525132197650, (100_000, "F"): 8208171470299167599,
+    (1_000_000, "U"): 17532315466326012662,
+    (1_000_000, "F"): 12961212697594295368,
+}
 
 
 class Invalid(ValueError):
@@ -47,7 +53,7 @@ def expected_cells():
     ]
 
 
-def verify_receipt(receipt, expected, manifest):
+def verify_receipt(receipt, expected, manifest, attempt):
     ordinal, size, case, repetition = expected
     require(receipt.get("schema") == 2, f"receipt {ordinal}: schema")
     require(receipt.get("mode") == "timing", f"receipt {ordinal}: timing mode")
@@ -55,6 +61,7 @@ def verify_receipt(receipt, expected, manifest):
     require(receipt.get("routes") == size, f"receipt {ordinal}: routes/order")
     require(receipt.get("case") == case, f"receipt {ordinal}: case/order")
     require(receipt.get("repetition") == repetition, f"receipt {ordinal}: repetition")
+    require(receipt.get("attempt") == attempt, f"receipt {ordinal}: attempt")
     require("queries" not in receipt, f"receipt {ordinal}: dual-case receipt")
     require(receipt.get("binary_sha256") == manifest["timing_binary_sha256"],
             f"receipt {ordinal}: timing binary drift")
@@ -78,6 +85,9 @@ def verify_receipt(receipt, expected, manifest):
     require(query.get("actor_capacity", 0) >= size, f"receipt {ordinal}: actor capacity")
     require(query.get("returned_rows") == expected_rows, f"receipt {ordinal}: returned rows")
     require(query.get("dispatch") == 1, f"receipt {ordinal}: dispatch")
+    require(type(query.get("checksum")) is int
+            and query["checksum"] == CHECKSUMS[(size, case)],
+            f"receipt {ordinal}: semantic checksum")
     return actor
 
 
@@ -167,23 +177,29 @@ def verify(directory):
         for line in lines[1:]:
             fields = line.split("\t")
             require(len(fields) == 10, "host preflight row")
-            phases.setdefault(fields[0], []).append(fields[-1])
+            phases.setdefault(fields[0], []).append(fields)
         require(set(phases) == expected, "host preflight phase drift")
-        require(all(values[-1] == "pass" for values in phases.values()),
-                "host preflight phase did not pass")
+        require(all(float(rows[-1][3]) < float(rows[-1][4])
+                    and rows[-1][5:9] == ["performance", "performance", "0", "none"]
+                    and rows[-1][9] == "pass" for rows in phases.values()),
+                "host preflight pass semantics")
 
     attempts = manifest.get("attempts")
     require(attempts in (1, 2), "campaign permits exactly one attempt and one retry")
-    require(not (directory / "attempt-3").exists(), "third attempt is forbidden")
+    entries = {p.name: p for p in directory.iterdir() if p.name.startswith("attempt")}
+    expected_attempts = {f"attempt-{n}" for n in range(1, attempts + 1)}
+    require(set(entries) == expected_attempts
+            and all(path.is_dir() for path in entries.values()),
+            "attempt filesystem inventory drift")
     expected_phases = {"build"}
     selected_timings = None
     for attempt in range(1, attempts + 1):
         receipt_paths = sorted((directory / f"attempt-{attempt}" / "timing").glob("*.json"))
         censor_path = directory / "censor.json"
-        if censor_path.exists():
+        if censor_path.exists() and load(censor_path).get("attempt") == attempt:
             censor = load(censor_path)
             for path, completed in zip(receipt_paths, expected_cells()):
-                verify_receipt(load(path), completed, manifest)
+                verify_receipt(load(path), completed, manifest, attempt)
             expected_phases.update(
                 f"attempt-{attempt}-timing-{ordinal}"
                 for ordinal in range(1, len(receipt_paths) + 1)
@@ -214,8 +230,9 @@ def verify(directory):
             require(censor.get("source_commit") == manifest["base_commit"],
                     "censor source drift")
             require(censor.get("timeout_seconds") == 120, "censor timeout drift")
+            require(censor.get("attempt") == attempt, "censor attempt drift")
             require(isinstance(censor.get("censor_phase"), str), "missing censor phase")
-            require(attempt == attempts, "retry cannot follow a censored attempt")
+            require(attempt == attempts, "censor must terminate declared attempts")
             require(not (directory / "allocation.json").exists(),
                     "allocation must not run after timeout censor")
             verify_phases(expected_phases)
@@ -224,15 +241,11 @@ def verify(directory):
         require(len(receipt_paths) == 48,
                 f"attempt {attempt} must contain exactly 48 timing receipts")
         timings = {(size, case): [] for size in SIZES for case in ("U", "F")}
-        checksums = {(size, case): set() for size in SIZES for case in ("U", "F")}
         for path, expected in zip(receipt_paths, expected_cells()):
             receipt = load(path)
-            elapsed = verify_receipt(receipt, expected, manifest)
+            elapsed = verify_receipt(receipt, expected, manifest, attempt)
             timings[(expected[1], expected[2])].append(elapsed)
-            checksums[(expected[1], expected[2])].add(receipt["query"]["checksum"])
             expected_phases.add(f"attempt-{attempt}-timing-{expected[0]}")
-        require(all(len(values) == 1 for values in checksums.values()),
-                f"attempt {attempt}: timing checksum drift")
         selected_timings = timings
 
     allocation = load(directory / "allocation.json")
@@ -246,15 +259,23 @@ def verify(directory):
             "allocation source provenance drift")
     require(allocation.get("timeout_seconds") == 120,
             "allocation 120-second censor missing")
+    require(allocation.get("attempt") == attempts, "allocation attempt drift")
     require(isinstance(allocation.get("peak_live_requested_bytes"), int)
             and allocation["peak_live_requested_bytes"] > 0,
             "missing absolute allocator evidence")
     query = allocation.get("query")
     require(isinstance(query, dict), "missing allocation query")
+    actor, service, post = (query.get(name) for name in
+                            ("actor_handler_ns", "service_method_ns", "post_actor_ns"))
+    require(type(actor) is int and actor > 0 and type(service) is int and service > 0
+            and type(post) is int and post >= 0 and service - actor == post,
+            "allocation timing decomposition")
     require(query.get("actor_rows") == 1_000_000, "allocation actor rows")
     require(query.get("actor_capacity", 0) >= 1_000_000, "allocation actor capacity")
     require(query.get("returned_rows") == 1_000_000, "allocation returned rows")
-    require(isinstance(query.get("checksum"), int), "allocation checksum")
+    require(type(query.get("checksum")) is int
+            and query["checksum"] == CHECKSUMS[(1_000_000, "U")],
+            "allocation checksum")
     require(query.get("dispatch") == 1, "allocation dispatch")
     expected_phases.add("allocation")
     verify_phases(expected_phases)

--- a/bench/verify-vpn-query-campaign.py
+++ b/bench/verify-vpn-query-campaign.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Fail-closed verifier and retained classifier for VPN query campaigns."""
+
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import statistics
+import sys
+
+SIZES = (10_000, 100_000, 1_000_000)
+CASES = tuple(case for pair in range(1, 9) for case in (f"U{pair}", f"F{pair}"))
+CAPACITY = 8 * 1024**3
+
+
+class Invalid(ValueError):
+    pass
+
+
+def load(path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise Invalid(f"{path}: unreadable JSON: {error}") from error
+
+
+def require(condition, message):
+    if not condition:
+        raise Invalid(message)
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def expected_cells():
+    return [
+        (ordinal, size, label[0], int(label[1:]))
+        for ordinal, (size, label) in enumerate(
+            ((size, label) for size in SIZES for label in CASES), 1
+        )
+    ]
+
+
+def verify_receipt(receipt, expected, manifest):
+    ordinal, size, case, repetition = expected
+    require(receipt.get("schema") == 2, f"receipt {ordinal}: schema")
+    require(receipt.get("mode") == "timing", f"receipt {ordinal}: timing mode")
+    require(receipt.get("ordinal") == ordinal, f"receipt {ordinal}: ordinal/order")
+    require(receipt.get("routes") == size, f"receipt {ordinal}: routes/order")
+    require(receipt.get("case") == case, f"receipt {ordinal}: case/order")
+    require(receipt.get("repetition") == repetition, f"receipt {ordinal}: repetition")
+    require("queries" not in receipt, f"receipt {ordinal}: dual-case receipt")
+    require(receipt.get("binary_sha256") == manifest["timing_binary_sha256"],
+            f"receipt {ordinal}: timing binary drift")
+    require(receipt.get("source_commit") == manifest["base_commit"],
+            f"receipt {ordinal}: source provenance drift")
+    require(receipt.get("timeout_seconds") == 120,
+            f"receipt {ordinal}: 120-second censor missing")
+    query = receipt.get("query")
+    require(isinstance(query, dict), f"receipt {ordinal}: missing query")
+    actor = query.get("actor_handler_ns")
+    service = query.get("service_method_ns")
+    post = query.get("post_actor_ns")
+    require(all(isinstance(value, int) and value > 0 for value in (actor, service)),
+            f"receipt {ordinal}: missing timing evidence")
+    require(isinstance(post, int) and post >= 0,
+            f"receipt {ordinal}: missing post-actor evidence")
+    require(service >= actor, f"receipt {ordinal}: post-actor underflow")
+    require(post == service - actor, f"receipt {ordinal}: post-actor decomposition")
+    expected_rows = size if case == "U" else size // 16
+    require(query.get("actor_rows") == size, f"receipt {ordinal}: actor rows")
+    require(query.get("actor_capacity", 0) >= size, f"receipt {ordinal}: actor capacity")
+    require(query.get("returned_rows") == expected_rows, f"receipt {ordinal}: returned rows")
+    require(query.get("dispatch") == 1, f"receipt {ordinal}: dispatch")
+    return actor
+
+
+def classify(manifest, timings, allocation):
+    capacity_censored = allocation["peak_live_requested_bytes"] > CAPACITY
+    pair_noise = {}
+    noisy = False
+    for size in SIZES:
+        for case in ("U", "F"):
+            samples = timings[(size, case)]
+            values = []
+            for pair in range(4):
+                a, b = samples[pair * 2: pair * 2 + 2]
+                noise = abs(a - b) / ((a + b) / 2)
+                values.append(noise)
+            pair_noise[f"{size}:{case}"] = values
+            noisy |= max(values) > (0.10 if size == 1_000_000 else 0.05)
+    medians = {
+        key: statistics.median(samples) for key, samples in timings.items()
+    }
+    instrumentation_suspect = False
+    for size in SIZES:
+        u_median = medians[(size, "U")]
+        f_median = medians[(size, "F")]
+        agreement = abs(u_median - f_median) / ((u_median + f_median) / 2)
+        tolerance = max(
+            pair_noise[f"{size}:U"] + pair_noise[f"{size}:F"] + [0.05]
+        )
+        instrumentation_suspect |= agreement > tolerance
+    for case in ("U", "F"):
+        instrumentation_suspect |= any(
+            medians[(larger, case)] < medians[(smaller, case)]
+            for smaller, larger in zip(SIZES, SIZES[1:])
+        )
+    worst = max(value for samples in timings.values() for value in samples)
+    if capacity_censored:
+        outcome = "capacity_censored"
+    elif noisy:
+        outcome = "inconclusive"
+    elif instrumentation_suspect:
+        outcome = "instrumentation_suspect"
+    elif worst > 200_000_000:
+        outcome = "urgent"
+    elif worst > 25_000_000:
+        outcome = "design_followup"
+    else:
+        outcome = "no_redesign"
+    return {
+        "classification": outcome,
+        "cell_noise": {key: max(values) for key, values in pair_noise.items()},
+        "pair_noise": pair_noise,
+        "peak_live_requested_bytes": allocation["peak_live_requested_bytes"],
+        "vmrss_bytes_observational": allocation.get("vmrss_bytes"),
+        "vmhwm_bytes_observational": allocation.get("vmhwm_bytes"),
+    }
+
+
+def verify(directory):
+    manifest = load(directory / "manifest.json")
+    require(manifest.get("schema") == 2, "manifest schema")
+    require(isinstance(manifest.get("base_commit"), str)
+            and re.fullmatch(r"[0-9a-f]{40}", manifest["base_commit"]),
+            "invalid base commit provenance")
+    require(manifest.get("source_tree_clean") is True,
+            "campaign source tree was not clean")
+    require(manifest.get("rustc"), "missing rustc provenance")
+    require(manifest.get("host_fence") == "pass", "host fence did not pass")
+    require(manifest.get("fixed_order") == list(CASES), "fixed order drift")
+    timing_binary = directory / "bin" / "vpn_query_timing"
+    allocation_binary = directory / "bin" / "vpn_query_allocation"
+    require(timing_binary.is_file() and allocation_binary.is_file(), "missing binaries")
+    require(sha256(timing_binary) == manifest.get("timing_binary_sha256"),
+            "timing binary corruption")
+    require(sha256(allocation_binary) == manifest.get("allocation_binary_sha256"),
+            "allocation binary corruption")
+
+    receipt_paths = sorted((directory / "timing").glob("*.json"))
+    require(len(receipt_paths) == 48, "campaign must contain exactly 48 timing receipts")
+    timings = {(size, case): [] for size in SIZES for case in ("U", "F")}
+    for path, expected in zip(receipt_paths, expected_cells()):
+        receipt = load(path)
+        elapsed = verify_receipt(receipt, expected, manifest)
+        timings[(expected[1], expected[2])].append(elapsed)
+
+    allocation = load(directory / "allocation.json")
+    require(allocation.get("schema") == 2, "allocation schema")
+    require(allocation.get("mode") == "allocation", "allocation mode")
+    require(allocation.get("routes") == 1_000_000, "allocation must use 1M routes")
+    require(allocation.get("case") == "U", "allocation must use unfiltered cell")
+    require(allocation.get("binary_sha256") == manifest["allocation_binary_sha256"],
+            "allocation binary drift")
+    require(allocation.get("source_commit") == manifest["base_commit"],
+            "allocation source provenance drift")
+    require(allocation.get("timeout_seconds") == 120,
+            "allocation 120-second censor missing")
+    require(isinstance(allocation.get("peak_live_requested_bytes"), int)
+            and allocation["peak_live_requested_bytes"] > 0,
+            "missing absolute allocator evidence")
+    return classify(manifest, timings, allocation)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("campaign", type=pathlib.Path)
+    parser.add_argument("--output", type=pathlib.Path)
+    args = parser.parse_args()
+    try:
+        result = verify(args.campaign)
+    except Invalid as error:
+        print(f"invalid VPN query campaign: {error}", file=sys.stderr)
+        return 1
+    encoded = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(encoded, encoding="utf-8")
+    else:
+        print(encoded, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/verify-vpn-query-campaign.py
+++ b/bench/verify-vpn-query-campaign.py
@@ -109,7 +109,7 @@ def classify(manifest, timings, allocation):
         instrumentation_suspect |= agreement > tolerance
     for case in ("U", "F"):
         instrumentation_suspect |= any(
-            medians[(larger, case)] < medians[(smaller, case)]
+            medians[(larger, case)] <= medians[(smaller, case)]
             for smaller, larger in zip(SIZES, SIZES[1:])
         )
     worst = max(value for samples in timings.values() for value in samples)
@@ -143,6 +143,9 @@ def verify(directory):
             "invalid base commit provenance")
     require(manifest.get("source_tree_clean") is True,
             "campaign source tree was not clean")
+    require(isinstance(manifest.get("source_tree"), str)
+            and re.fullmatch(r"[0-9a-f]{40}", manifest["source_tree"]),
+            "invalid source tree provenance")
     require(manifest.get("rustc"), "missing rustc provenance")
     require(manifest.get("host_fence") == "pass", "host fence did not pass")
     require(manifest.get("fixed_order") == list(CASES), "fixed order drift")
@@ -154,13 +157,83 @@ def verify(directory):
     require(sha256(allocation_binary) == manifest.get("allocation_binary_sha256"),
             "allocation binary corruption")
 
-    receipt_paths = sorted((directory / "timing").glob("*.json"))
-    require(len(receipt_paths) == 48, "campaign must contain exactly 48 timing receipts")
-    timings = {(size, case): [] for size in SIZES for case in ("U", "F")}
-    for path, expected in zip(receipt_paths, expected_cells()):
-        receipt = load(path)
-        elapsed = verify_receipt(receipt, expected, manifest)
-        timings[(expected[1], expected[2])].append(elapsed)
+    def verify_phases(expected):
+        phases = {}
+        lines = (directory / "host-preflight.tsv").read_text(
+            encoding="utf-8"
+        ).splitlines()
+        require(lines and lines[0].startswith("phase\tattempt\t"),
+                "host preflight header")
+        for line in lines[1:]:
+            fields = line.split("\t")
+            require(len(fields) == 10, "host preflight row")
+            phases.setdefault(fields[0], []).append(fields[-1])
+        require(set(phases) == expected, "host preflight phase drift")
+        require(all(values[-1] == "pass" for values in phases.values()),
+                "host preflight phase did not pass")
+
+    attempts = manifest.get("attempts")
+    require(attempts in (1, 2), "campaign permits exactly one attempt and one retry")
+    require(not (directory / "attempt-3").exists(), "third attempt is forbidden")
+    expected_phases = {"build"}
+    selected_timings = None
+    for attempt in range(1, attempts + 1):
+        receipt_paths = sorted((directory / f"attempt-{attempt}" / "timing").glob("*.json"))
+        censor_path = directory / "censor.json"
+        if censor_path.exists():
+            censor = load(censor_path)
+            for path, completed in zip(receipt_paths, expected_cells()):
+                verify_receipt(load(path), completed, manifest)
+            expected_phases.update(
+                f"attempt-{attempt}-timing-{ordinal}"
+                for ordinal in range(1, len(receipt_paths) + 1)
+            )
+            require(censor.get("outcome") == "capacity_censored", "invalid censor outcome")
+            require(censor.get("ordinal") == len(receipt_paths) + 1,
+                    "censor must stop the next ordered cell")
+            if len(receipt_paths) == 48:
+                require(censor.get("mode") == "allocation"
+                        and censor.get("routes") == 1_000_000
+                        and censor.get("case") == "U",
+                        "allocation censor shape drift")
+                expected_hash = manifest["allocation_binary_sha256"]
+                expected_phases.add("allocation")
+            else:
+                expected = expected_cells()[len(receipt_paths)]
+                require(censor.get("mode") == "timing"
+                        and censor.get("routes") == expected[1]
+                        and censor.get("case") == expected[2]
+                        and censor.get("repetition") == expected[3],
+                        "censor cell order drift")
+                expected_hash = manifest["timing_binary_sha256"]
+                expected_phases.update(
+                    f"attempt-{attempt}-timing-{ordinal}"
+                    for ordinal in range(1, len(receipt_paths) + 2)
+                )
+            require(censor.get("binary_sha256") == expected_hash, "censor binary drift")
+            require(censor.get("source_commit") == manifest["base_commit"],
+                    "censor source drift")
+            require(censor.get("timeout_seconds") == 120, "censor timeout drift")
+            require(isinstance(censor.get("censor_phase"), str), "missing censor phase")
+            require(attempt == attempts, "retry cannot follow a censored attempt")
+            require(not (directory / "allocation.json").exists(),
+                    "allocation must not run after timeout censor")
+            verify_phases(expected_phases)
+            return {"classification": "capacity_censored",
+                    "censor_phase": censor.get("censor_phase")}
+        require(len(receipt_paths) == 48,
+                f"attempt {attempt} must contain exactly 48 timing receipts")
+        timings = {(size, case): [] for size in SIZES for case in ("U", "F")}
+        checksums = {(size, case): set() for size in SIZES for case in ("U", "F")}
+        for path, expected in zip(receipt_paths, expected_cells()):
+            receipt = load(path)
+            elapsed = verify_receipt(receipt, expected, manifest)
+            timings[(expected[1], expected[2])].append(elapsed)
+            checksums[(expected[1], expected[2])].add(receipt["query"]["checksum"])
+            expected_phases.add(f"attempt-{attempt}-timing-{expected[0]}")
+        require(all(len(values) == 1 for values in checksums.values()),
+                f"attempt {attempt}: timing checksum drift")
+        selected_timings = timings
 
     allocation = load(directory / "allocation.json")
     require(allocation.get("schema") == 2, "allocation schema")
@@ -176,7 +249,16 @@ def verify(directory):
     require(isinstance(allocation.get("peak_live_requested_bytes"), int)
             and allocation["peak_live_requested_bytes"] > 0,
             "missing absolute allocator evidence")
-    return classify(manifest, timings, allocation)
+    query = allocation.get("query")
+    require(isinstance(query, dict), "missing allocation query")
+    require(query.get("actor_rows") == 1_000_000, "allocation actor rows")
+    require(query.get("actor_capacity", 0) >= 1_000_000, "allocation actor capacity")
+    require(query.get("returned_rows") == 1_000_000, "allocation returned rows")
+    require(isinstance(query.get("checksum"), int), "allocation checksum")
+    require(query.get("dispatch") == 1, "allocation dispatch")
+    expected_phases.add("allocation")
+    verify_phases(expected_phases)
+    return classify(manifest, selected_timings, allocation)
 
 
 def main():

--- a/bench/verify-vpn-query-campaign.py
+++ b/bench/verify-vpn-query-campaign.py
@@ -201,6 +201,8 @@ def verify(directory):
     for attempt in range(1, censor_attempt + 1):
         receipt_paths = sorted((directory / f"attempt-{attempt}" / "timing").glob("*.json"))
         if censor and censor_attempt == attempt:
+            require(len(receipt_paths) <= 48,
+                    "censor timing prefix exceeds fixed 48-cell shape")
             for path, completed in zip(receipt_paths, expected_cells()):
                 verify_receipt(load(path), completed, manifest, attempt)
             expected_phases.update(

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 # event-history producer benchmark. Normal API and daemon builds do not compile
 # that surface.
 bench-internals = ["rustbgpd-rib/bench-internals"]
+vpn-query-allocation = []
 
 [dependencies]
 rustbgpd-wire.workspace = true
@@ -62,6 +63,13 @@ harness = false
 required-features = ["bench-internals"]
 
 [[bench]]
-name = "vpn_query"
+name = "vpn_query_timing"
 harness = false
 required-features = ["bench-internals"]
+path = "benches/vpn_query.rs"
+
+[[bench]]
+name = "vpn_query_allocation"
+harness = false
+required-features = ["bench-internals", "vpn-query-allocation"]
+path = "benches/vpn_query.rs"

--- a/crates/api/benches/vpn_query.rs
+++ b/crates/api/benches/vpn_query.rs
@@ -119,6 +119,9 @@ struct QueryReceipt {
     checksum: u64,
 }
 
+#[derive(Debug)]
+struct CapacityCensored(&'static str);
+
 fn mix(mut hash: u64, bytes: &[u8]) -> u64 {
     for byte in bytes {
         hash ^= u64::from(*byte);
@@ -174,7 +177,7 @@ async fn query(
     service_rx: &mut mpsc::Receiver<VpnQueryServiceReceipt>,
     peer_filter: &str,
     timeout: Duration,
-) -> QueryReceipt {
+) -> Result<QueryReceipt, CapacityCensored> {
     let deadline = tokio::time::Instant::now() + timeout;
     let started = Instant::now();
     let response = tokio::time::timeout_at(
@@ -185,7 +188,7 @@ async fn query(
         })),
     )
     .await
-    .expect("VPN RIB service query exceeded its absolute deadline")
+    .map_err(|_| CapacityCensored("service_query"))?
     .unwrap()
     .into_inner();
     let service_method_ns = u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
@@ -201,11 +204,11 @@ async fn query(
     let (actor_ns, actor_rows, actor_capacity, dispatch) =
         tokio::time::timeout_at(deadline, actor_rx.recv())
             .await
-            .expect("VPN RIB actor receipt exceeded the query deadline")
+            .map_err(|_| CapacityCensored("actor_receipt"))?
             .expect("VPN RIB actor receipt channel closed");
     let service_receipt = tokio::time::timeout_at(deadline, service_rx.recv())
         .await
-        .expect("VPN RIB service receipt exceeded the query deadline")
+        .map_err(|_| CapacityCensored("service_receipt"))?
         .expect("VPN RIB service receipt channel closed");
     assert_eq!(service_receipt.returned_rows, response.routes.len());
     let checksum = response.routes.iter().fold(0_u64, |sum, row| {
@@ -216,7 +219,7 @@ async fn query(
             row.labels[0],
         ))
     });
-    QueryReceipt {
+    Ok(QueryReceipt {
         actor_ns,
         service_method_ns,
         post_actor_ns: service_method_ns
@@ -227,7 +230,7 @@ async fn query(
         returned_rows: service_receipt.returned_rows,
         dispatch,
         checksum,
-    }
+    })
 }
 
 fn verify(receipt: &QueryReceipt, routes: usize, filtered: bool, dispatch: u64) {
@@ -239,10 +242,18 @@ fn verify(receipt: &QueryReceipt, routes: usize, filtered: bool, dispatch: u64) 
     assert_eq!(receipt.checksum, expected_checksum(routes, filtered));
     assert!(receipt.actor_ns > 0);
     assert!(receipt.service_method_ns > 0);
-    assert!(receipt.post_actor_ns > 0);
+    assert_eq!(
+        receipt.post_actor_ns,
+        receipt.service_method_ns - receipt.actor_ns
+    );
 }
 
-async fn run(routes: usize, case: &str, output: &str, timeout: Duration) {
+async fn run(
+    routes: usize,
+    case: &str,
+    output: &str,
+    timeout: Duration,
+) -> Result<(), CapacityCensored> {
     let (primary_tx, primary_rx) = mpsc::channel(32);
     let (query_tx, query_rx) = mpsc::channel(8);
     let (actor_tx, mut actor_rx) = mpsc::channel(4);
@@ -295,7 +306,7 @@ async fn run(routes: usize, case: &str, output: &str, timeout: Duration) {
             );
             tokio::time::timeout_at(setup_deadline, primary_tx.send(update))
                 .await
-                .expect("VPN RIB seed send exceeded the setup deadline")
+                .map_err(|_| CapacityCensored("seed_send"))?
                 .expect("VPN RIB primary channel closed during setup");
         }
     }
@@ -305,11 +316,11 @@ async fn run(routes: usize, case: &str, output: &str, timeout: Duration) {
         primary_tx.send(RibUpdate::QueryLocRibCount { reply: barrier_tx }),
     )
     .await
-    .expect("VPN RIB setup barrier send exceeded the setup deadline")
+    .map_err(|_| CapacityCensored("barrier_send"))?
     .expect("VPN RIB primary channel closed before the setup barrier");
     let _ = tokio::time::timeout_at(setup_deadline, barrier_rx)
         .await
-        .expect("VPN RIB setup barrier reply exceeded the setup deadline")
+        .map_err(|_| CapacityCensored("barrier_reply"))?
         .expect("VPN RIB manager dropped the setup barrier reply");
 
     let (service_tx, mut service_rx) = mpsc::channel(4);
@@ -324,7 +335,7 @@ async fn run(routes: usize, case: &str, output: &str, timeout: Duration) {
         if filtered { "10.0.0.1" } else { "" },
         timeout,
     )
-    .await;
+    .await?;
     verify(&receipt, routes, filtered, 1);
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -345,6 +356,7 @@ async fn run(routes: usize, case: &str, output: &str, timeout: Duration) {
     });
     std::fs::write(output, serde_json::to_vec_pretty(&document).unwrap()).unwrap();
     manager_task.abort();
+    Ok(())
 }
 
 #[cfg(feature = "vpn-query-allocation")]
@@ -406,9 +418,25 @@ fn main() {
             )
         }
     };
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(run(routes, case, output, timeout));
+    let result = if std::env::var_os("RUSTBGPD_VPN_QUERY_FORCE_CENSOR").is_some() {
+        Err(CapacityCensored("forced_fixture"))
+    } else {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(run(routes, case, output, timeout))
+    };
+    if let Err(CapacityCensored(phase)) = result {
+        let document = json!({
+            "schema": 1,
+            "mode": if cfg!(feature = "vpn-query-allocation") { "allocation" } else { "timing" },
+            "routes": routes,
+            "case": case,
+            "outcome": "capacity_censored",
+            "censor_phase": phase,
+        });
+        std::fs::write(output, serde_json::to_vec_pretty(&document).unwrap()).unwrap();
+        std::process::exit(75);
+    }
 }

--- a/crates/api/benches/vpn_query.rs
+++ b/crates/api/benches/vpn_query.rs
@@ -1,7 +1,11 @@
 //! Occupancy and timing receipt for the production VPN RIB query path.
 
+#[cfg(feature = "vpn-query-allocation")]
+use std::alloc::{GlobalAlloc, Layout};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
+#[cfg(feature = "vpn-query-allocation")]
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use rustbgpd_api::proto;
@@ -17,8 +21,87 @@ use serde_json::json;
 use tokio::sync::{mpsc, oneshot};
 use tonic::Request;
 
+#[cfg(not(feature = "vpn-query-allocation"))]
 #[global_allocator]
 static ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+#[cfg(feature = "vpn-query-allocation")]
+struct TrackingAllocator {
+    inner: tikv_jemallocator::Jemalloc,
+    enabled: AtomicBool,
+    live: AtomicUsize,
+    peak: AtomicUsize,
+}
+
+#[cfg(feature = "vpn-query-allocation")]
+impl TrackingAllocator {
+    const fn new() -> Self {
+        Self {
+            inner: tikv_jemallocator::Jemalloc,
+            enabled: AtomicBool::new(false),
+            live: AtomicUsize::new(0),
+            peak: AtomicUsize::new(0),
+        }
+    }
+
+    fn begin(&self) {
+        let live = self.live.load(Ordering::Relaxed);
+        self.peak.store(live, Ordering::Relaxed);
+        self.enabled.store(true, Ordering::Relaxed);
+    }
+
+    fn end(&self) -> usize {
+        self.enabled.store(false, Ordering::Relaxed);
+        self.peak.load(Ordering::Relaxed)
+    }
+
+    fn add(&self, bytes: usize) {
+        let live = self.live.fetch_add(bytes, Ordering::Relaxed) + bytes;
+        if self.enabled.load(Ordering::Relaxed) {
+            self.peak.fetch_max(live, Ordering::Relaxed);
+        }
+    }
+}
+
+#[cfg(feature = "vpn-query-allocation")]
+// SAFETY: all operations are forwarded unchanged to one jemalloc instance;
+// atomic accounting does not alter pointer or layout contracts.
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { self.inner.alloc(layout) };
+        if !ptr.is_null() {
+            self.add(layout.size());
+        }
+        ptr
+    }
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { self.inner.alloc_zeroed(layout) };
+        if !ptr.is_null() {
+            self.add(layout.size());
+        }
+        ptr
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let resized = unsafe { self.inner.realloc(ptr, layout, new_size) };
+        if !resized.is_null() {
+            if new_size >= layout.size() {
+                self.add(new_size - layout.size());
+            } else {
+                self.live
+                    .fetch_sub(layout.size() - new_size, Ordering::Relaxed);
+            }
+        }
+        resized
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { self.inner.dealloc(ptr, layout) };
+        self.live.fetch_sub(layout.size(), Ordering::Relaxed);
+    }
+}
+
+#[cfg(feature = "vpn-query-allocation")]
+#[global_allocator]
+static ALLOCATOR: TrackingAllocator = TrackingAllocator::new();
 
 const PEERS: usize = 16;
 const SMOKE_ROUTES: usize = 256;
@@ -136,7 +219,9 @@ async fn query(
     QueryReceipt {
         actor_ns,
         service_method_ns,
-        post_actor_ns: service_receipt.post_actor_ns,
+        post_actor_ns: service_method_ns
+            .checked_sub(actor_ns)
+            .expect("service_method_ns underflowed actor_handler_ns"),
         actor_rows,
         actor_capacity,
         returned_rows: service_receipt.returned_rows,
@@ -157,7 +242,7 @@ fn verify(receipt: &QueryReceipt, routes: usize, filtered: bool, dispatch: u64) 
     assert!(receipt.post_actor_ns > 0);
 }
 
-async fn run(routes: usize, output: &str, timeout: Duration) {
+async fn run(routes: usize, case: &str, output: &str, timeout: Duration) {
     let (primary_tx, primary_rx) = mpsc::channel(32);
     let (query_tx, query_rx) = mpsc::channel(8);
     let (actor_tx, mut actor_rx) = mpsc::channel(4);
@@ -229,18 +314,18 @@ async fn run(routes: usize, output: &str, timeout: Duration) {
 
     let (service_tx, mut service_rx) = mpsc::channel(4);
     let service = RibService::new(query_tx).with_vpn_query_bench_receipts(service_tx);
-    let all = query(&service, &mut actor_rx, &mut service_rx, "", timeout).await;
-    let filtered = query(
+    #[cfg(feature = "vpn-query-allocation")]
+    ALLOCATOR.begin();
+    let filtered = case == "F";
+    let receipt = query(
         &service,
         &mut actor_rx,
         &mut service_rx,
-        "10.0.0.1",
+        if filtered { "10.0.0.1" } else { "" },
         timeout,
     )
     .await;
-    verify(&all, routes, false, 1);
-    verify(&filtered, routes, true, 2);
-
+    verify(&receipt, routes, filtered, 1);
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
@@ -248,17 +333,39 @@ async fn run(routes: usize, output: &str, timeout: Duration) {
     let document = json!({
         "schema": 1,
         "allocator": "tikv-jemallocator",
-        "mode": "timing",
+        "mode": if cfg!(feature = "vpn-query-allocation") { "allocation" } else { "timing" },
         "timestamp_unix": timestamp,
         "routes": routes,
         "peers": PEERS,
-        "queries": {
-            "all": receipt_json(&all),
-            "peer_10_0_0_1": receipt_json(&filtered),
-        }
+        "case": case,
+        "query": receipt_json(&receipt),
+        "peak_live_requested_bytes": peak_live_requested(),
+        "vmrss_bytes": read_status_kib("VmRSS").map(|value| value * 1024),
+        "vmhwm_bytes": read_status_kib("VmHWM").map(|value| value * 1024),
     });
     std::fs::write(output, serde_json::to_vec_pretty(&document).unwrap()).unwrap();
     manager_task.abort();
+}
+
+#[cfg(feature = "vpn-query-allocation")]
+fn peak_live_requested() -> Option<usize> {
+    Some(ALLOCATOR.end())
+}
+
+#[cfg(not(feature = "vpn-query-allocation"))]
+fn peak_live_requested() -> Option<usize> {
+    None
+}
+
+fn read_status_kib(field: &str) -> Option<u64> {
+    std::fs::read_to_string("/proc/self/status")
+        .ok()?
+        .lines()
+        .find(|line| line.starts_with(field))?
+        .split_whitespace()
+        .nth(1)?
+        .parse()
+        .ok()
 }
 
 fn receipt_json(value: &QueryReceipt) -> serde_json::Value {
@@ -276,22 +383,32 @@ fn receipt_json(value: &QueryReceipt) -> serde_json::Value {
 
 fn main() {
     let args: Vec<_> = std::env::args().filter(|arg| arg != "--bench").collect();
-    let (routes, output, timeout) = match args.as_slice() {
-        [_, mode, output] if mode == "smoke" => {
-            (SMOKE_ROUTES, output.as_str(), Duration::from_secs(10))
-        }
-        [_, mode, count, output] if mode == "measure" => {
+    let (routes, case, output, timeout) = match args.as_slice() {
+        [_, mode, case, output] if mode == "smoke" && (case == "U" || case == "F") => (
+            SMOKE_ROUTES,
+            case.as_str(),
+            output.as_str(),
+            Duration::from_secs(10),
+        ),
+        [_, mode, count, case, output] if mode == "cell" && (case == "U" || case == "F") => {
             let routes = count.parse::<usize>().unwrap();
             assert!([10_000, 100_000, 1_000_000].contains(&routes));
-            (routes, output.as_str(), Duration::from_secs(120))
+            (
+                routes,
+                case.as_str(),
+                output.as_str(),
+                Duration::from_secs(120),
+            )
         }
         _ => {
-            panic!("usage: vpn_query smoke OUTPUT | vpn_query measure 10000|100000|1000000 OUTPUT")
+            panic!(
+                "usage: vpn_query smoke U|F OUTPUT | vpn_query cell 10000|100000|1000000 U|F OUTPUT"
+            )
         }
     };
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .unwrap()
-        .block_on(run(routes, output, timeout));
+        .block_on(run(routes, case, output, timeout));
 }

--- a/crates/api/benches/vpn_query.rs
+++ b/crates/api/benches/vpn_query.rs
@@ -28,6 +28,7 @@ static ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[cfg(feature = "vpn-query-allocation")]
 struct TrackingAllocator {
     inner: tikv_jemallocator::Jemalloc,
+    locked: AtomicBool,
     enabled: AtomicBool,
     live: AtomicUsize,
     peak: AtomicUsize,
@@ -38,6 +39,7 @@ impl TrackingAllocator {
     const fn new() -> Self {
         Self {
             inner: tikv_jemallocator::Jemalloc,
+            locked: AtomicBool::new(false),
             enabled: AtomicBool::new(false),
             live: AtomicUsize::new(0),
             peak: AtomicUsize::new(0),
@@ -45,14 +47,27 @@ impl TrackingAllocator {
     }
 
     fn begin(&self) {
+        let _guard = self.guard();
         let live = self.live.load(Ordering::Relaxed);
         self.peak.store(live, Ordering::Relaxed);
         self.enabled.store(true, Ordering::Relaxed);
     }
 
     fn end(&self) -> usize {
+        let _guard = self.guard();
         self.enabled.store(false, Ordering::Relaxed);
         self.peak.load(Ordering::Relaxed)
+    }
+
+    fn guard(&self) -> AllocationGuard<'_> {
+        while self
+            .locked
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            std::hint::spin_loop();
+        }
+        AllocationGuard(self)
     }
 
     fn add(&self, bytes: usize) {
@@ -64,10 +79,21 @@ impl TrackingAllocator {
 }
 
 #[cfg(feature = "vpn-query-allocation")]
+struct AllocationGuard<'a>(&'a TrackingAllocator);
+
+#[cfg(feature = "vpn-query-allocation")]
+impl Drop for AllocationGuard<'_> {
+    fn drop(&mut self) {
+        self.0.locked.store(false, Ordering::Release);
+    }
+}
+
+#[cfg(feature = "vpn-query-allocation")]
 // SAFETY: all operations are forwarded unchanged to one jemalloc instance;
 // atomic accounting does not alter pointer or layout contracts.
 unsafe impl GlobalAlloc for TrackingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let _guard = self.guard();
         let ptr = unsafe { self.inner.alloc(layout) };
         if !ptr.is_null() {
             self.add(layout.size());
@@ -75,6 +101,7 @@ unsafe impl GlobalAlloc for TrackingAllocator {
         ptr
     }
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let _guard = self.guard();
         let ptr = unsafe { self.inner.alloc_zeroed(layout) };
         if !ptr.is_null() {
             self.add(layout.size());
@@ -82,6 +109,7 @@ unsafe impl GlobalAlloc for TrackingAllocator {
         ptr
     }
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let _guard = self.guard();
         let resized = unsafe { self.inner.realloc(ptr, layout, new_size) };
         if !resized.is_null() {
             if new_size >= layout.size() {
@@ -94,6 +122,7 @@ unsafe impl GlobalAlloc for TrackingAllocator {
         resized
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        let _guard = self.guard();
         unsafe { self.inner.dealloc(ptr, layout) };
         self.live.fetch_sub(layout.size(), Ordering::Relaxed);
     }

--- a/docs/perf/event-history-host-fence.sh
+++ b/docs/perf/event-history-host-fence.sh
@@ -76,6 +76,7 @@ event_history_competing_process_snapshot() {
              $2 == "rustbgpd" ||
              $2 ~ /^rrharness($|-)/ || $2 ~ /^reloadstall($|-)/ ||
              $2 ~ /^route_paging($|-)/ || $2 ~ /^rib_nlri_build/ ||
+             $2 ~ /^vpn_query_timi/ || $2 ~ /^vpn_query_allo/ ||
              $2 ~ /^nlri_build($|-)/ || $2 ~ /^event_history_/ ||
              $2 ~ /^codec($|-)/ || $2 ~ /^fanout($|-)/ ||
              $2 ~ /^inbound_attrs/ || $2 ~ /^rib_ops($|-)/ ||

--- a/docs/perf/event-history-host-fence.sh
+++ b/docs/perf/event-history-host-fence.sh
@@ -159,3 +159,17 @@ event_history_wait_for_idle() {
         sleep "$poll_seconds"
     done
 }
+
+# VPN query campaigns deliberately share the same machine-wide lock and idle
+# policy as other retained performance work.
+vpn_query_acquire_host_lock() {
+    event_history_acquire_host_lock
+}
+
+vpn_query_init_host_preflight_log() {
+    event_history_init_host_preflight_log "$@"
+}
+
+vpn_query_wait_for_idle() {
+    event_history_wait_for_idle "$@"
+}

--- a/docs/perf/test-event-history-host-fence.sh
+++ b/docs/perf/test-event-history-host-fence.sh
@@ -28,11 +28,13 @@ ps() {
         '113 evpn-tester /repo/bench/evpn-load/target/release/evpn-tester' \
         '114 evpn-monitor /repo/bench/evpn-load/target/release/evpn-monitor' \
         '115 python3 python3 bgperf2.py --bench-name another-run bench' \
-        '116 sleep sleep 30'
+        '116 vpn_query_timi /repo/target/release/deps/vpn_query_timing-91a' \
+        '117 vpn_query_allo /repo/target/release/deps/vpn_query_allocation-91a' \
+        '118 sleep sleep 30'
 }
 
 snapshot=$(event_history_competing_process_snapshot)
-[[ $(wc -l <<<"$snapshot") -eq 15 ]]
+[[ $(wc -l <<<"$snapshot") -eq 17 ]]
 [[ "$snapshot" != *'sleep 30'* ]]
 [[ "$snapshot" != *'/repo/'* ]]
 [[ "$snapshot" != *'101 '* ]]

--- a/docs/perf/test-event-history-host-fence.sh
+++ b/docs/perf/test-event-history-host-fence.sh
@@ -38,4 +38,8 @@ snapshot=$(event_history_competing_process_snapshot)
 [[ "$snapshot" != *'101 '* ]]
 [[ "$snapshot" == *'event_history_'* ]]
 
+declare -F vpn_query_acquire_host_lock >/dev/null
+declare -F vpn_query_init_host_preflight_log >/dev/null
+declare -F vpn_query_wait_for_idle >/dev/null
+
 printf '%s\n' 'event-history producer host-fence adversarial probes passed'

--- a/docs/perf/vpn-rib-query-occupancy-method.md
+++ b/docs/perf/vpn-rib-query-occupancy-method.md
@@ -1,91 +1,86 @@
-# VPN RIB query occupancy method
+# VPN RIB query occupancy campaign
 
-This instrument measures the existing `ListVpnRoutes` path without changing its
-API or optimizing it. It exists to separate the RIB actor's full-table snapshot
-cost from the service's filtering and protobuf conversion cost before any
-production change is proposed.
+This retained campaign measures the existing `ListVpnRoutes` path. It neither
+changes that API nor proposes a redesign. The per-commit gate is only a
+256-route executable smoke plus corruption fixtures; CI never runs or publishes
+the campaign.
 
-## Shape
+## Executable shape
 
-- 16 peers: `10.0.0.1` through `10.0.0.16`.
-- VPNv4 `/32` routes are assigned round-robin to peers.
-- Every route has a unique RD-plus-prefix key, one MPLS label, shared realistic
-  path attributes, and route target `65000:100`.
-- Each peer is seeded in its own primary-channel updates, with batches no
-  larger than 4096. Before every send, the harness asserts that each announced
-  route belongs to the update's actual envelope peer.
-- A `QueryLocRibCount` sent on that same primary channel is the FIFO ingest
-  barrier. Its unicast count is intentionally ignored.
-- Both samples call the actual `RibService::list_vpn_routes` method through the
-  priority query channel. The first is unfiltered; the second uses
-  `peer_filter = 10.0.0.1` and an empty `afi_safi`.
+The harness seeds VPNv4 `/32` routes across 16 peers and uses the production
+priority query channel and `RibService::list_vpn_routes`. `U` is unfiltered;
+`F` filters exactly `10.0.0.1`. Every process measures exactly one case and
+writes one receipt. Semantic checksums cover RD, prefix, peer, and label.
 
-The supported campaign sizes are 10,000, 100,000, and 1,000,000 routes. The
-per-commit gate runs only the exact 256-route smoke shape; it does not publish a
-performance claim.
+Two separately compiled executables prevent allocation instrumentation from
+contaminating timing:
 
-## Timings and occupancy
+- `vpn_query_timing` uses bare jemalloc and emits timing evidence.
+- `vpn_query_allocation` wraps jemalloc with absolute live-requested-byte
+  accounting. `peak_live_requested_bytes > 8 GiB` is capacity-censored.
+  `/proc` `VmRSS` and `VmHWM` are recorded only as observations and never drive
+  classification.
 
-`actor_handler_ns` begins at the production `QueryVpnRoutes` match arm and ends
-after the snapshot reply is sent. `actor_rows` and `actor_capacity` describe the
-actual `Vec<VpnRibRoute>` allocated there.
+The driver builds each executable once, copies it into the campaign directory,
+records SHA-256, commit, and `rustc` provenance, then refuses missing, changed,
+or corrupt binaries. It acquires the shared retained-performance host lock and
+requires the same load, CPU-governor, and competing-process fence before build
+and every process.
 
-`service_method_ns` is measured outside the service across the trait method call
-and await. It includes the bounded benchmark-only service receipt `try_send`
-before the trait method returns. `actor_handler_ns` and `post_actor_ns` exclude
-publication of their respective receipts. Benchmark receipts use bounded
-persistent channels compiled only by `bench-internals`; an unarmed
-production/default build is unchanged.
+## Fixed campaign
 
-Setup has one absolute deadline shared by all seed sends and the FIFO barrier
-send and receive. Each query then has its own absolute deadline shared by the
-service call and both receipt awaits: 10 seconds in the exact smoke and 120
-seconds in campaign mode. A stalled actor or receipt publication failure
-therefore makes the smoke fail in bounded time instead of hanging.
+For each size `10,000`, `100,000`, and `1,000,000`, the driver launches 16 fresh
+timing processes in this immutable order:
 
-The timing executable installs the workspace `tikv-jemallocator` directly.
-The mechanics gate parses only the supplied benchmark source and requires its
-`#[global_allocator]` attribute immediately before the `tikv-jemallocator`
-static. Receipts identify allocator and mode so results from a different build
-cannot be silently compared.
+`U1,F1,U2,F2,U3,F3,U4,F4,U5,F5,U6,F6,U7,F7,U8,F8`
 
-Semantic checksums are calculated after the timed method returns. They are
-order-independent and cover RD, prefix, peer, and label. No sorting or hashing
-is added to the service path.
+That is exactly 48 uniquely numbered receipts. Selective reruns, randomization,
+reordering, missing receipts, and dual-case receipts are invalid.
+
+Within each cell, pairs are repetitions `(1,2)`, `(3,4)`, `(5,6)`, and `(7,8)`.
+For actor-handler values `a,b`, `pair_noise = abs(a-b) / ((a+b)/2)` and cell
+noise is the maximum of those four values. The noise ceiling is 5% at 10k and
+100k and 10% at 1M.
+
+`service_method_ns` encloses the trait call. The retained decomposition is
+computed with `service_method_ns.checked_sub(actor_handler_ns)`; underflow or
+missing evidence fails closed. A zero post-actor duration is valid.
+
+Classifier precedence is exact:
+
+1. `capacity_censored`
+2. `inconclusive` (cell noise above its size-specific ceiling)
+3. `instrumentation_suspect` (filtered/unfiltered actor medians disagree by
+   more than `max(cell noise, 5%)`, or actor medians decrease with size)
+4. `urgent` (worst actor handler above 200 ms)
+5. `design_followup` (worst actor handler above 25 ms)
+6. `no_redesign`
 
 ## Commands
 
-Run the exact smoke and its corruption proofs:
+Run the bounded mechanics and 256-route executable smoke:
 
 ```console
+bash bench/tests/test-vpn-query-campaign.sh
 bash bench/tests/test-vpn-query-receipt.sh
 ```
 
-Produce one campaign receipt without committing it:
+An operator may run the full retained campaign on a dedicated host:
 
 ```console
-cargo bench -p rustbgpd-api --bench vpn_query --features bench-internals -- \
-  measure 10000 /tmp/vpn-query-10000.json
+bench/run-vpn-query-campaign.sh /uncommitted/output-directory
 ```
 
-Repeat for 100,000 and 1,000,000 only on an otherwise idle host. This slice
-defines the instrument and gate; it does not run or publish that campaign.
+The output is intentionally not a committed result. A valid campaign is checked
+with:
 
-## Load-bearing failures
+```console
+python3 bench/verify-vpn-query-campaign.py /uncommitted/output-directory
+```
 
-- Replacing the actor snapshot collection with `Vec::new()` breaks exact row
-  counts and semantic checksums.
-- Giving a seed update the wrong envelope peer fails its ownership assertion
-  before the update is sent to the actor.
-- Stalling the manager during setup fails at the internal aggregate setup
-  deadline.
-- Removing the peer predicate changes 16 filtered rows to 256.
-- Selecting a different peer while preserving the filtered count breaks the
-  explicit assertion that every returned row belongs to `10.0.0.1`.
-- Bypassing or zeroing any timing breaks the nonzero decomposition assertions.
-- Removing only `#[global_allocator]` makes the structural allocator seam check
-  fail.
-- Removing actor or service receipt publication fails at the shared absolute
-  deadline instead of hanging.
-- Corrupting either row counts or the exact deterministic smoke checksums makes
-  the shell verifier fail; its checksum mutation remains nonzero.
+## Load-bearing gates
+
+The tests demonstrate red outcomes for fixed-order mutation, receipt
+count/order/pair drift, a dual-case receipt, timing underflow, binary corruption,
+row/checksum corruption, and removal of the allocator seam. These are executable
+mutation proofs, not prose-only claims.

--- a/docs/perf/vpn-rib-query-occupancy-method.md
+++ b/docs/perf/vpn-rib-query-occupancy-method.md
@@ -19,7 +19,9 @@ contaminating timing:
 - `vpn_query_allocation` wraps jemalloc with absolute live-requested-byte
   accounting. `peak_live_requested_bytes > 8 GiB` is capacity-censored.
   `/proc` `VmRSS` and `VmHWM` are recorded only as observations and never drive
-  classification.
+  classification. Its allocator forwarding and bookkeeping are serialized by
+  a no-allocation spin lock, so this mode is diagnostic; its timings are not
+  performance results.
 
 The driver builds each executable once, copies it into the campaign directory,
 records SHA-256, commit, and `rustc` provenance, then refuses missing, changed,

--- a/docs/perf/vpn-rib-query-occupancy-method.md
+++ b/docs/perf/vpn-rib-query-occupancy-method.md
@@ -41,6 +41,9 @@ reordering, missing receipts, and dual-case receipts are invalid.
 One complete clean retry may be requested with `--retry`; it reuses the exact
 prebuilt binaries and must contain all 48 cells. Partial, selective, or third
 attempts are invalid.
+Every receipt, including a censor, names its attempt. The verifier inventories
+all `attempt-*` entries, validates every completed earlier attempt, and accepts
+only the exact ordered prefix of the censored current attempt.
 
 Within each cell, pairs are repetitions `(1,2)`, `(3,4)`, `(5,6)`, and `(7,8)`.
 For actor-handler values `a,b`, `pair_noise = abs(a-b) / ((a+b)/2)` and cell

--- a/docs/perf/vpn-rib-query-occupancy-method.md
+++ b/docs/perf/vpn-rib-query-occupancy-method.md
@@ -23,7 +23,9 @@ contaminating timing:
 
 The driver builds each executable once, copies it into the campaign directory,
 records SHA-256, commit, and `rustc` provenance, then refuses missing, changed,
-or corrupt binaries. It acquires the shared retained-performance host lock and
+or corrupt binaries. Commit, Git tree, clean status, toolchain, and binary
+hashes are captured before the locked build and rechecked through completion.
+It acquires the shared retained-performance host lock and
 requires the same load, CPU-governor, and competing-process fence before build
 and every process.
 
@@ -36,6 +38,9 @@ timing processes in this immutable order:
 
 That is exactly 48 uniquely numbered receipts. Selective reruns, randomization,
 reordering, missing receipts, and dual-case receipts are invalid.
+One complete clean retry may be requested with `--retry`; it reuses the exact
+prebuilt binaries and must contain all 48 cells. Partial, selective, or third
+attempts are invalid.
 
 Within each cell, pairs are repetitions `(1,2)`, `(3,4)`, `(5,6)`, and `(7,8)`.
 For actor-handler values `a,b`, `pair_noise = abs(a-b) / ((a+b)/2)` and cell
@@ -45,13 +50,17 @@ noise is the maximum of those four values. The noise ceiling is 5% at 10k and
 `service_method_ns` encloses the trait call. The retained decomposition is
 computed with `service_method_ns.checked_sub(actor_handler_ns)`; underflow or
 missing evidence fails closed. A zero post-actor duration is valid.
+Every setup/query timeout produces the typed `capacity_censored` process
+outcome. The driver catches only its exit status 75, stops all remaining cells,
+and verifies the censor receipt; every other nonzero exit is a hard failure.
 
 Classifier precedence is exact:
 
 1. `capacity_censored`
 2. `inconclusive` (cell noise above its size-specific ceiling)
 3. `instrumentation_suspect` (filtered/unfiltered actor medians disagree by
-   more than `max(cell noise, 5%)`, or actor medians decrease with size)
+   more than `max(cell noise, 5%)`, or actor medians fail to increase strictly
+   with size)
 4. `urgent` (worst actor handler above 200 ms)
 5. `design_followup` (worst actor handler above 25 ms)
 6. `no_redesign`


### PR DESCRIPTION
## Summary

- split VPN query timing and allocation into one-cell executables so every retained sample comes from a fresh process
- drive the fixed 48-process unfiltered/filtered matrix, with at most one complete retry using the same locked binaries
- fail closed on source, tree, toolchain, binary, host, ordering, checksum, decomposition, timeout, noise, and capacity evidence
- add only 256-route smoke and corruption fixtures to per-commit CI

This PR repairs and retains the measurement harness only. It does **not** run the 10k/100k/1M campaign, publish measurements, add artifacts, or authorize a redesign. The full campaign remains a separate dedicated-host task.

## Verification

- push hooks: workspace format, clippy, tests, and rustdoc
- both 256-route timing/allocation executables
- retained Python verifier and adversarial receipt fixtures
- campaign driver and host-fence shell suites
- exact standalone CI ShellCheck invocation
- `git diff --check`
- `Cargo.lock` unchanged
- five exact-candidate independent audits; the first four rejected false-green paths and the final head was approved

## Load-bearing regression proof

Each retained guard was observed red under its guarded production mutation or an equivalent adversarial receipt:

- allowing equal size medians makes the strict 10k/100k/1M monotonic fixture fail
- bypassing exact semantic checksums makes the uniform-corruption fixture fail
- trusting a host `pass` label without recomputing its fields makes the hostile-host fixture fail
- changing the force-censor check from variable presence to non-empty value makes the empty-environment fixture fail
- admitting the fixture-only censor phase makes the retained-censor fixture fail
- removing any allocator critical-section guard makes the six-site structural proof fail
- a 49-receipt timing prefix raises the verifier's typed fixed-shape error rather than an incidental index failure
- partial, selective, reordered, extra-attempt, wrong-binary, dirty-source, timeout, allocation-decomposition, and terminal-provenance mutations are rejected by the retained verifier

## Campaign contract

- 48 timing processes per attempt: `U1,F1,...,U8,F8` at 10k, 100k, and 1M
- pair noise uses `(1,2)`, `(3,4)`, `(5,6)`, `(7,8)`
- classifier precedence is capacity censor, noise, instrumentation, urgent, design follow-up, no redesign
- allocator requested bytes drive the 8 GiB censor; RSS/HWM remain observational
- diagnostic allocation accounting serializes complete jemalloc operations; timing evidence uses the separate plain-jemalloc executable
- full measurement remains held until separately authorized on an exclusive host
