### PR TITLE
Add dynamic-neighbor admission alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   across accept, ordinary removal, rollback reap, and retained-disabled
   max-prefix recovery lifecycles.
 
+- Shipped Prometheus rules now warn when dynamic-neighbor admission slots remain
+  at least 80% occupied for ten minutes and page when the full limit rejects a
+  matching inbound connection.
+
 - `NeighborService.AddNeighbor` now accepts an additive presence-aware wrapper
   that preserves peer-group inheritance and explicit masked `false`, family
   replacement, and Add-Path disable intent across persistence, live apply, and

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -62,6 +62,7 @@ A ready-to-load Prometheus alert-rule pack (session down/flapping,
 empty Adj-RIB-In, max-prefix near-limit and breach, empty RPKI VRP table, event-outbox
 degradation, update-group residue growth, stalled policy transition, a slow
 peer, RFC 8212 missing import/export policy, sustained outbound-prefix blocking,
+dynamic-neighbor admission near-limit and rejection,
 actor polls above 200ms, exact-export rejection, malformed UPDATE disposition,
 selection-deferral timeout and ledger overflow, and daemon down) ships at
 [`examples/prometheus/rustbgpd-alerts.yml`](../examples/prometheus/rustbgpd-alerts.yml),
@@ -167,9 +168,15 @@ right-axis override.
 The slow-peer fixture is red if its `== 1` predicate or five-minute hold is
 changed. The RFC 8212 matrix covers import-only, export-only, and healthy peers;
 the outbound-prefix matrix covers sustained, zero, and transient blocking.
-All three new warnings are pending at 4m30s and firing at 5m30s, pinning their
-predicate and five-minute hold. The actor fixture is red if `ignoring(le)` is
-removed, `le="0.2"` is moved to `0.5`, `> 0` becomes `>= 0`, raw counters
+The dynamic-neighbor admission fixture pins the exact 80% ratio and ten-minute
+hold against a 79% control, a zero-limit control, and the pre-hold boundary.
+Its rejection fixture separates an increasing counter from a flat non-zero
+counter, then observes the event after it ages out to pin the ten-minute
+`increase` window and single-event boundary.
+The RFC 8212 import/export and outbound-prefix-blocking warnings are pending at
+4m30s and firing at 5m30s, pinning their predicates and five-minute holds. The
+actor fixture is red if `ignoring(le)` is removed, `le="0.2"` is moved to
+`0.5`, `> 0` becomes `>= 0`, raw counters
 replace `increase`, or `job`/`poll_kind` are aggregated away. Its firing
 observation is in `(0.2, 0.5]`; exact-boundary and historical-flat controls
 remain healthy.

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -135,6 +135,38 @@ groups:
             bgp_max_prefix_headroom and eventually trigger Cease / Maximum
             Number of Prefixes Reached.
 
+      - alert: BgpDynamicNeighborSlotsNearLimit
+        # Both gauges are process-global and label-free before scrape labels.
+        # Require a positive configured limit explicitly so an absent or zero
+        # limit cannot produce a capacity warning.
+        expr: >-
+          bgp_dynamic_neighbor_slots_used
+          / bgp_dynamic_neighbor_slots_limit >= 0.8
+          and bgp_dynamic_neighbor_slots_limit > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Dynamic-neighbor admission slots are nearly exhausted"
+          description: >-
+            Dynamic-neighbor admission-slot usage on {{ $labels.instance }}
+            has remained at or above 80% of its process-global limit for
+            10 minutes. Inspect bgp_dynamic_neighbor_slots_headroom before
+            new matching inbound sessions are rejected.
+
+      - alert: BgpDynamicNeighborLimitRejected
+        expr: increase(bgp_dynamic_neighbor_limit_rejections_total[10m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Dynamic-neighbor admission rejected"
+          description: >-
+            Dynamic-neighbor admission on {{ $labels.instance }} rejected
+            {{ $value | printf "%.0f" }} matching inbound connection(s) in
+            the last 10 minutes because the process-global slot limit was
+            full.
+
       - alert: BgpRfc8212MissingImportPolicy
         expr: bgp_rfc8212_missing_import_policy == 1
         for: 5m

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -286,6 +286,80 @@ tests:
                 bgp_max_prefix_headroom and eventually trigger Cease / Maximum
                 Number of Prefixes Reached.
 
+  # ── Dynamic-neighbor admission capacity ──────────────────────
+  # Load-bearing: the exact 79%/80% boundary and pending/firing observations
+  # pin the ratio and ten-minute hold. The zero-limit control proves the
+  # warning fails closed. The rejection pair pins increase, its 10m range,
+  # and the > 0 boundary; deleting either alert makes its firing case red.
+  - interval: 1m
+    input_series:
+      - series: 'bgp_dynamic_neighbor_slots_used{instance="edge1:9179"}'
+        values: "80x13"
+      - series: 'bgp_dynamic_neighbor_slots_limit{instance="edge1:9179"}'
+        values: "100x13"
+      - series: 'bgp_dynamic_neighbor_slots_used{instance="edge2:9179"}'
+        values: "79x13"
+      - series: 'bgp_dynamic_neighbor_slots_limit{instance="edge2:9179"}'
+        values: "100x13"
+      - series: 'bgp_dynamic_neighbor_slots_used{instance="edge3:9179"}'
+        values: "1x13"
+      - series: 'bgp_dynamic_neighbor_slots_limit{instance="edge3:9179"}'
+        values: "0x13"
+      - series: 'bgp_dynamic_neighbor_limit_rejections_total{instance="edge1:9179"}'
+        values: "0 0 0 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_dynamic_neighbor_limit_rejections_total{instance="edge2:9179"}'
+        values: "4x13"
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: BgpDynamicNeighborSlotsNearLimit
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: BgpDynamicNeighborSlotsNearLimit
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: edge1:9179
+            exp_annotations:
+              summary: "Dynamic-neighbor admission slots are nearly exhausted"
+              description: >-
+                Dynamic-neighbor admission-slot usage on edge1:9179 has
+                remained at or above 80% of its process-global limit for
+                10 minutes. Inspect bgp_dynamic_neighbor_slots_headroom before
+                new matching inbound sessions are rejected.
+      - eval_time: 2m
+        alertname: BgpDynamicNeighborLimitRejected
+        exp_alerts: []
+      - eval_time: 3m
+        alertname: BgpDynamicNeighborLimitRejected
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              instance: edge1:9179
+            exp_annotations:
+              summary: "Dynamic-neighbor admission rejected"
+              description: >-
+                Dynamic-neighbor admission on edge1:9179 rejected 1 matching
+                inbound connection(s) in the last 10 minutes because the
+                process-global slot limit was full.
+      # The t=3m increment is outside [5m] at t=9m but remains inside [10m].
+      - eval_time: 9m
+        alertname: BgpDynamicNeighborLimitRejected
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              instance: edge1:9179
+            exp_annotations:
+              summary: "Dynamic-neighbor admission rejected"
+              description: >-
+                Dynamic-neighbor admission on edge1:9179 rejected 1 matching
+                inbound connection(s) in the last 10 minutes because the
+                process-global slot limit was full.
+      # Prometheus ranges are left-open: at 12m, [10m] excludes the t=2m
+      # zero sample needed to observe the increment at t=3m; [11m] includes it.
+      - eval_time: 12m
+        alertname: BgpDynamicNeighborLimitRejected
+        exp_alerts: []
+
   # ── BgpPeerSlow ───────────────────────────────────────────────
   # Load-bearing: reverting `== 1`, shortening/lengthening `for: 5m`,
   # or aggregating away the endpoint makes one of these exact boundary


### PR DESCRIPTION
## Summary

- warn when process-global dynamic-neighbor slots remain at least 80% occupied for 10 minutes
- page immediately when a matching inbound connection is rejected at the global slot limit
- document both rules and retain exact Prometheus boundary fixtures

## Load-bearing proof

The retained promtool fixture fails if either alert is removed or if the guarded threshold, hold, zero-limit condition, rejection range, immediate firing, counter semantics, or rejection boundary changes. It covers 79% healthy, 80% pending/firing, non-zero used with zero limit, a real increment, a flat non-zero counter, and both sides of the 10-minute range window.

## Verification

- `promtool check rules examples/prometheus/rustbgpd-alerts.yml`
- `(cd examples/prometheus && promtool test rules rustbgpd-alerts_test.yml)`
- `python3 scripts/check-grafana-dashboard.py`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `git diff --check`

Linear: LAN-730