### PR TITLE
Alert on outbound BGP work loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- The shipped Prometheus rule pack now pages on outbound BGP work dropped
+  before the peer writer and RFC 9687 send-hold session teardowns, and warns
+  when a live event-stream consumer misses events and becomes desynchronized.
+  Each alert preserves its native peer or service/source identity and gives
+  a bounded recovery action for the failed path.
+
 - Dynamic peers now report the canonical `[[dynamic_neighbors]]` prefix and
   peer group that accepted their session. The provenance is captured at
   accept time, survives later matcher edits while the session remains live,

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -64,12 +64,37 @@ degradation, update-group residue growth, stalled policy transition, a slow
 peer, RFC 8212 missing import/export policy, sustained outbound-prefix blocking,
 dynamic-neighbor admission near-limit and rejection,
 actor polls above 200ms, exact-export rejection, malformed UPDATE disposition,
-selection-deferral timeout and ledger overflow, and daemon down) ships at
+selection-deferral timeout and ledger overflow, outbound route loss, RFC 9687
+send-hold teardown, live event-stream lag/desynchronization, and daemon down)
+ships at
 [`examples/prometheus/rustbgpd-alerts.yml`](../examples/prometheus/rustbgpd-alerts.yml),
 with per-rule unit tests in
 [`rustbgpd-alerts_test.yml`](../examples/prometheus/rustbgpd-alerts_test.yml)
 (`promtool test rules`). It assumes the scrape config above
 (`job_name: rustbgpd`).
+
+The three loss alerts use a 10-minute counter-increase window and clear after
+the last increment ages out:
+
+- `BgpOutboundRouteDrops` is critical because the full outbound distribution
+  channel has already discarded outbound BGP work. Inspect the peer writer,
+  daemon log, and last error to identify the failed path and correct the
+  bottleneck. Then refresh outbound for a missed advertised view, or soft reset
+  inbound for a missed inbound ROUTE-REFRESH request.
+- `BgpSendHoldExpired` is critical because RFC 9687 expiry has already torn
+  down the session without a NOTIFICATION after the remote endpoint stopped
+  draining TCP. Inspect the writer and peer before allowing the session to
+  recover; repeated increments indicate the receiver or path is still wedged.
+- `BgpEventStreamLagged` is warning severity because the daemon and routing
+  sessions remain live, but the named `service`/`source` consumer missed
+  incremental events. Treat that consumer's local view as desynchronized:
+  take a fresh authoritative snapshot for the named service and source, then
+  restart the live watch. Use a durable cursor only when that API supports one.
+
+The rules intentionally alert on the exported loss counters, not adjacent
+queue-depth, subscriber-count, or slow-peer gauges. A flat non-zero counter is
+historical evidence and does not keep an alert firing; only a new increment
+inside the bounded window does.
 
 ## Reading notes
 
@@ -84,6 +109,10 @@ with per-rule unit tests in
   not page.
 - Exact-export rejection and malformed-UPDATE disposition rates share the
   `$peer` selector, like every other per-peer panel.
+  Outbound route-drop and RFC 9687 send-hold alerts preserve that same `peer`
+  identity. The live event-stream lag alert instead preserves the metric's
+  native `service` and `source` labels so operators can resnapshot and restart
+  the affected watch.
   The selection-deferral state panel renders
   the raw `active` and `waiters` gauges as steps because their discrete changes
   are normal convergence activity. Only timeout and bounded-ledger-overflow

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -296,6 +296,59 @@ groups:
             concurrent readiness probe and other RIB work; inspect the
             dashboard p99 and transition state before retrying a reload.
 
+      - alert: BgpOutboundRouteDrops
+        # A full outbound distribution channel drops BGP work instead of
+        # delaying it; the failed path can be advertisement or refresh work.
+        expr: increase(bgp_outbound_route_drops_total[10m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Outbound BGP work dropped for {{ $labels.peer }}"
+          description: >-
+            bgp_outbound_route_drops_total for peer {{ $labels.peer }} on
+            {{ $labels.instance }} increased by
+            {{ $value | printf "%.0f" }} in the last 10 minutes. Outbound BGP
+            work was lost before reaching the peer writer; inspect the writer,
+            peer, daemon log, and last error to identify the failed path. Once
+            healthy, refresh outbound for a missed advertised view or soft
+            reset inbound for a missed inbound ROUTE-REFRESH request.
+
+      - alert: BgpSendHoldExpired
+        # RFC 9687 expiry means the remote peer stopped draining TCP long
+        # enough for rustbgpd to tear down the session without a NOTIFICATION.
+        expr: increase(bgp_send_hold_expirations_total[10m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Send-hold timer expired for {{ $labels.peer }}"
+          description: >-
+            bgp_send_hold_expirations_total for peer {{ $labels.peer }} on
+            {{ $labels.instance }} increased by
+            {{ $value | printf "%.0f" }} in the last 10 minutes. The RFC 9687
+            send-hold timer expired because the peer stopped draining its TCP
+            socket, so rustbgpd tore down the session without a NOTIFICATION;
+            inspect the writer and peer before allowing the session to recover.
+
+      - alert: BgpEventStreamLagged
+        # A live subscriber that falls behind misses events and can no longer
+        # treat its incremental view as synchronized with daemon state.
+        expr: increase(bgp_event_stream_lagged_total[10m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            Live event stream lagged ({{ $labels.service }}/{{ $labels.source }})
+          description: >-
+            bgp_event_stream_lagged_total for {{ $labels.service }} consuming
+            {{ $labels.source }} events on {{ $labels.instance }} increased by
+            {{ $value | printf "%.0f" }} in the last 10 minutes. The live
+            consumer missed events and its incremental view is desynchronized;
+            take a fresh authoritative snapshot for this service and source,
+            then restart the live watch.
+
       - alert: BgpPolicyEvalErrors
         # An evaluation error makes the policy engine treat the
         # affected route as Deny (uniform eval-error rails), so every

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -923,3 +923,211 @@ tests:
                 minutes. The family exceeded the bounded identity ledger and
                 used a complete release sweep; inspect table scale and
                 retained-key pressure.
+
+  # ── BgpOutboundRouteDrops ─────────────────────────────────
+  # Load-bearing: the old increment pins 10m versus 5m, the reset then
+  # increment pins reset-safe increase versus delta, and the same-evaluation
+  # increment pins for: 0m. Every firing increment is exactly 1, pinning > 0.
+  # Flat history rejects a raw-counter query; the late evaluation pins recovery.
+  - interval: 1m
+    input_series:
+      - series: 'bgp_outbound_route_drops_total{peer="192.0.2.40", instance="edge1:9179"}'
+        values: "0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_outbound_route_drops_total{peer="192.0.2.41", instance="edge1:9179"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_outbound_route_drops_total{peer="192.0.2.42", instance="edge1:9179"}'
+        values: "10 10 10 10 10 10 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_outbound_route_drops_total{peer="192.0.2.43", instance="edge1:9179"}'
+        values: "7x22"
+      # A different loss counter must not satisfy the outbound-writer rule.
+      - series: 'bgp_event_outbox_dropped_total{category="route", reason="queue_full", instance="edge1:9179"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: BgpOutboundRouteDrops
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: BgpOutboundRouteDrops
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              peer: 192.0.2.40
+              instance: edge1:9179
+            exp_annotations:
+              summary: "Outbound BGP work dropped for 192.0.2.40"
+              description: >-
+                bgp_outbound_route_drops_total for peer 192.0.2.40 on
+                edge1:9179 increased by 1 in the last 10 minutes. Outbound BGP
+                work was lost before reaching the peer writer; inspect the
+                writer, peer, daemon log, and last error to identify the failed
+                path. Once healthy, refresh outbound for a missed advertised
+                view or soft reset inbound for a missed inbound ROUTE-REFRESH
+                request.
+          - exp_labels:
+              severity: critical
+              peer: 192.0.2.41
+              instance: edge1:9179
+            exp_annotations:
+              summary: "Outbound BGP work dropped for 192.0.2.41"
+              description: >-
+                bgp_outbound_route_drops_total for peer 192.0.2.41 on
+                edge1:9179 increased by 1 in the last 10 minutes. Outbound BGP
+                work was lost before reaching the peer writer; inspect the
+                writer, peer, daemon log, and last error to identify the failed
+                path. Once healthy, refresh outbound for a missed advertised
+                view or soft reset inbound for a missed inbound ROUTE-REFRESH
+                request.
+          - exp_labels:
+              severity: critical
+              peer: 192.0.2.42
+              instance: edge1:9179
+            exp_annotations:
+              summary: "Outbound BGP work dropped for 192.0.2.42"
+              description: >-
+                bgp_outbound_route_drops_total for peer 192.0.2.42 on
+                edge1:9179 increased by 1 in the last 10 minutes. Outbound BGP
+                work was lost before reaching the peer writer; inspect the
+                writer, peer, daemon log, and last error to identify the failed
+                path. Once healthy, refresh outbound for a missed advertised
+                view or soft reset inbound for a missed inbound ROUTE-REFRESH
+                request.
+      - eval_time: 21m
+        alertname: BgpOutboundRouteDrops
+        exp_alerts: []
+
+  # ── BgpSendHoldExpired ────────────────────────────────────
+  # Load-bearing: the old increment pins 10m versus 5m, the reset then
+  # increment pins reset-safe increase versus delta, and the same-evaluation
+  # increment pins for: 0m. Every firing increment is exactly 1, pinning > 0.
+  # Flat history and an aged-out expiration must remain quiet.
+  - interval: 1m
+    input_series:
+      - series: 'bgp_send_hold_expirations_total{peer="192.0.2.50", instance="edge1:9179"}'
+        values: "0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_send_hold_expirations_total{peer="192.0.2.51", instance="edge1:9179"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_send_hold_expirations_total{peer="192.0.2.52", instance="edge1:9179"}'
+        values: "10 10 10 10 10 10 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_send_hold_expirations_total{peer="192.0.2.53", instance="edge1:9179"}'
+        values: "4x22"
+      # Hold re-arms are not send-hold teardown and must not satisfy the rule.
+      - series: 'bgp_hold_timer_rearmed_pending_input_total{peer="192.0.2.54", instance="edge1:9179"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: BgpSendHoldExpired
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: BgpSendHoldExpired
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              peer: 192.0.2.50
+              instance: edge1:9179
+            exp_annotations:
+              summary: "Send-hold timer expired for 192.0.2.50"
+              description: >-
+                bgp_send_hold_expirations_total for peer 192.0.2.50 on
+                edge1:9179 increased by 1 in the last 10 minutes. The RFC 9687
+                send-hold timer expired because the peer stopped draining its
+                TCP socket, so rustbgpd tore down the session without a
+                NOTIFICATION; inspect the writer and peer before allowing the
+                session to recover.
+          - exp_labels:
+              severity: critical
+              peer: 192.0.2.51
+              instance: edge1:9179
+            exp_annotations:
+              summary: "Send-hold timer expired for 192.0.2.51"
+              description: >-
+                bgp_send_hold_expirations_total for peer 192.0.2.51 on
+                edge1:9179 increased by 1 in the last 10 minutes. The RFC 9687
+                send-hold timer expired because the peer stopped draining its
+                TCP socket, so rustbgpd tore down the session without a
+                NOTIFICATION; inspect the writer and peer before allowing the
+                session to recover.
+          - exp_labels:
+              severity: critical
+              peer: 192.0.2.52
+              instance: edge1:9179
+            exp_annotations:
+              summary: "Send-hold timer expired for 192.0.2.52"
+              description: >-
+                bgp_send_hold_expirations_total for peer 192.0.2.52 on
+                edge1:9179 increased by 1 in the last 10 minutes. The RFC 9687
+                send-hold timer expired because the peer stopped draining its
+                TCP socket, so rustbgpd tore down the session without a
+                NOTIFICATION; inspect the writer and peer before allowing the
+                session to recover.
+      - eval_time: 21m
+        alertname: BgpSendHoldExpired
+        exp_alerts: []
+
+  # ── BgpEventStreamLagged ──────────────────────────────────
+  # Load-bearing: the old increment pins 10m versus 5m, the reset then
+  # increment pins reset-safe increase versus delta, and the same-evaluation
+  # increment pins for: 0m. Every firing missed count is exactly 1, pinning
+  # > 0. Flat history and aged-out lag stay quiet.
+  - interval: 1m
+    input_series:
+      - series: 'bgp_event_stream_lagged_total{service="watch_events", source="route", instance="edge1:9179"}'
+        values: "0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_event_stream_lagged_total{service="watch_route_events", source="route", instance="edge2:9179"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_event_stream_lagged_total{service="watch_routes", source="route", instance="edge3:9179"}'
+        values: "10 10 10 10 10 10 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'bgp_event_stream_lagged_total{service="watch_events", source="session", instance="edge1:9179"}'
+        values: "9x22"
+      # Subscriber count is live capacity, not evidence of missed events.
+      - series: 'bgp_event_stream_subscribers{service="watch_events", source="route", instance="edge3:9179"}'
+        values: "0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: BgpEventStreamLagged
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: BgpEventStreamLagged
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              service: watch_events
+              source: route
+              instance: edge1:9179
+            exp_annotations:
+              summary: "Live event stream lagged (watch_events/route)"
+              description: >-
+                bgp_event_stream_lagged_total for watch_events consuming route
+                events on edge1:9179 increased by 1 in the last 10 minutes.
+                The live consumer missed events and its incremental view is
+                desynchronized; take a fresh authoritative snapshot for this
+                service and source, then restart the live watch.
+          - exp_labels:
+              severity: warning
+              service: watch_route_events
+              source: route
+              instance: edge2:9179
+            exp_annotations:
+              summary: >-
+                Live event stream lagged (watch_route_events/route)
+              description: >-
+                bgp_event_stream_lagged_total for watch_route_events consuming
+                route events on edge2:9179 increased by 1 in the last 10
+                minutes. The live consumer missed events and its incremental
+                view is desynchronized; take a fresh authoritative snapshot
+                for this service and source, then restart the live watch.
+          - exp_labels:
+              severity: warning
+              service: watch_routes
+              source: route
+              instance: edge3:9179
+            exp_annotations:
+              summary: "Live event stream lagged (watch_routes/route)"
+              description: >-
+                bgp_event_stream_lagged_total for watch_routes consuming route
+                events on edge3:9179 increased by 1 in the last 10 minutes.
+                The live consumer missed events and its incremental view is
+                desynchronized; take a fresh authoritative snapshot for this
+                service and source, then restart the live watch.
+      - eval_time: 21m
+        alertname: BgpEventStreamLagged
+        exp_alerts: []


### PR DESCRIPTION
## Summary

- page on outbound BGP work lost before a peer writer and on RFC 9687 send-hold session teardown
- warn when a live event-stream consumer misses events and must resnapshot
- preserve native peer or service/source identity and give path-specific recovery for advertised-view versus ROUTE-REFRESH loss
- document the bounded 10-minute counter-increase semantics and recovery behavior

## Verification

- `promtool check rules examples/prometheus/rustbgpd-alerts.yml`
- `(cd examples/prometheus && promtool test rules rustbgpd-alerts_test.yml)`
- `python3 scripts/check-grafana-dashboard.py`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `git diff --check`

## Load-bearing proof

Each of the three rules was independently mutated for deletion, adjacent metric identity, `[10m]` to `[5m]`, `increase` to `delta`, `> 0` to `> 1`, and `for: 0m` to `for: 1m`. All 18 mutations made the retained promtool fixtures fail. The fixtures separately pin a six-minute-old event, reset-safe increase behavior, same-evaluation firing, exact one-event predicates, flat history, and recovery after the window.