### PR TITLE
Keep fanout benchmarks wire-visible

### DIFF
--- a/crates/transport/benches/fanout.rs
+++ b/crates/transport/benches/fanout.rs
@@ -8,11 +8,14 @@
 //! the `bench-internals` fanout driver (synthetic peer registration + Loc-RIB
 //! seed + `distribute_changes`).
 //!
-//! Shape: seed `CHANGED` best paths, then fan that batch out to N peers, scaling
-//! N to expose the fanout factor. `no_policy` vs `with_policy` isolates the
-//! per-peer export-policy share. The family-gauge target separately prewarms a
-//! first advertise, mutates every route's MED outside accumulated time, and
-//! measures the resulting second changed-route pass on persistent fleets.
+//! Shape: advertise `CHANGED` MED-50 best paths to N peers, drain and verify
+//! that setup, then replace every best path with a MED-51 route outside
+//! accumulated time. One production `distribute_changes` pass is timed and its
+//! receipt and wire envelopes are verified afterward. `no_policy` vs
+//! `with_policy` isolates the per-peer export-policy share. The family-gauge
+//! target separately prewarms a first advertise, mutates every route's MED
+//! outside accumulated time, and measures the resulting second changed-route
+//! pass on persistent fleets.
 //! All peers occupy one update group and ordinary members share the same
 //! unicast route/next-hop payload Arcs. The exact-export path may therefore
 //! encode each route once per compatible wire-profile cohort and reapply each
@@ -41,7 +44,8 @@
 //! Gated behind `bench-internals`; run with:
 //!   cargo bench -p rustbgpd-transport --features bench-internals --bench fanout
 //!
-//! Pinned A/B receipt: `docs/perf/exact-export-fanout-2026-07.md`.
+//! Historical first-advertise A/B receipt:
+//! `docs/perf/exact-export-fanout-2026-07.md`.
 
 use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr};
@@ -209,6 +213,13 @@ type FanoutState = (
     HashSet<Prefix>,
 );
 
+struct ReplacementFanoutState {
+    manager: RibManager,
+    receivers: Vec<mpsc::Receiver<OutboundRouteUpdate>>,
+    changed: HashSet<Prefix>,
+    expected_inventory: HashSet<Prefix>,
+}
+
 /// Build a manager with `n_peers` registered and `CHANGED` best paths seeded.
 /// The receivers are returned so the caller keeps the bounded channels open
 /// across the measured `distribute_changes`.
@@ -267,22 +278,157 @@ fn build_ixp(n_peers: usize, distinct_remote_asns: bool) -> FanoutState {
     (manager, receivers, changed)
 }
 
+fn expected_fanout_receipt(
+    peers: usize,
+    routes_received_dispatches: usize,
+) -> AdjRibOutFanoutBenchReceipt {
+    AdjRibOutFanoutBenchReceipt {
+        update_groups: 1,
+        grouped_peers: peers,
+        ungrouped_peers: 0,
+        dirty_peers: 0,
+        grouped_unicast_routes: CHANGED,
+        private_unicast_routes: 0,
+        routes_received_dispatches,
+        routes_received_withdrawals: 0,
+        exact_probe_batches: 1,
+        exact_probe_candidates: CHANGED,
+        exact_probe_nonzero_encoded_lengths: CHANGED * peers,
+        exact_probe_cache_reuses: CHANGED * peers.saturating_sub(1),
+        successful_commits: peers,
+        successful_enqueues: peers,
+        family_gauge_writes: peers,
+        last_family_gauge_write_mask: 0x01,
+        pristine_otc_reconcile_candidates: peers
+            * if routes_received_dispatches == 0 {
+                1
+            } else {
+                2
+            },
+        first_peer_family_values: [
+            i64::try_from(CHANGED).expect("fixture size fits i64"),
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ],
+    }
+}
+
+fn route_med(route: &Route) -> u32 {
+    route
+        .attributes
+        .iter()
+        .find_map(|attribute| match attribute {
+            PathAttribute::Med(med) => Some(*med),
+            _ => None,
+        })
+        .expect("every fanout route must retain its MED")
+}
+
+fn drain_fanout_envelopes(
+    receivers: &mut [mpsc::Receiver<OutboundRouteUpdate>],
+    expected_inventory: &HashSet<Prefix>,
+    expected_med: u32,
+) {
+    for receiver in receivers {
+        let update = receiver
+            .try_recv()
+            .expect("every fanout member must receive one route-bearing envelope");
+        assert_eq!(update.announce.len(), CHANGED);
+        assert!(update.withdraw.is_empty());
+        assert_unicast_only_envelope(&update);
+        assert_real_transport_snapshot(&update);
+        let actual_inventory = update
+            .announce
+            .iter()
+            .map(|route| {
+                assert_eq!(
+                    route_med(route),
+                    expected_med,
+                    "the envelope must carry the prepared wire-visible replacement"
+                );
+                assert_eq!(route.path_id, 0);
+                route.prefix
+            })
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            actual_inventory, *expected_inventory,
+            "the envelope must contain the exact replacement inventory"
+        );
+        assert!(
+            receiver.try_recv().is_err(),
+            "one distribution pass must leave no second envelope"
+        );
+    }
+}
+
+fn prepare_replacement_fanout(
+    (mut manager, mut receivers, expected_inventory): FanoutState,
+    peers: usize,
+) -> ReplacementFanoutState {
+    assert_eq!(expected_inventory.len(), CHANGED);
+    assert_eq!(
+        manager.bench_adj_rib_out_fanout_receipt(),
+        expected_fanout_receipt(peers, 1),
+        "the production MED-50 seed must populate the exact grouped fixture"
+    );
+    drain_fanout_envelopes(&mut receivers, &expected_inventory, 50);
+
+    let replacements = changed_prefixes()
+        .into_iter()
+        .map(|prefix| make_route_with_med(prefix, 51))
+        .collect();
+    let changed = manager.bench_prepare_unicast_replacement(replacements);
+    assert_eq!(
+        changed, expected_inventory,
+        "every prepared MED-51 best path must be wire-visible"
+    );
+    manager.bench_reset_adj_rib_out_fanout_receipt();
+    ReplacementFanoutState {
+        manager,
+        receivers,
+        changed,
+        expected_inventory,
+    }
+}
+
+fn measure_replacement_fanout<F>(iterations: u64, peers: usize, build: F) -> Duration
+where
+    F: Fn(usize) -> FanoutState,
+{
+    let mut accumulated = Duration::ZERO;
+    for _ in 0..iterations {
+        let mut state = prepare_replacement_fanout(build(peers), peers);
+        let started = Instant::now();
+        state.manager.bench_distribute(&state.changed);
+        accumulated += started.elapsed();
+        assert_eq!(
+            state.manager.bench_adj_rib_out_fanout_receipt(),
+            expected_fanout_receipt(peers, 0),
+            "the timed replacement must use one clean production group and commit every member"
+        );
+        drain_fanout_envelopes(&mut state.receivers, &state.expected_inventory, 51);
+    }
+    accumulated
+}
+
 fn bench_fanout(c: &mut Criterion) {
     let mut group = c.benchmark_group("distribute_fanout");
     for &n in &PEER_COUNTS {
         group.bench_with_input(BenchmarkId::new("no_policy", n), &n, |b, &n| {
-            b.iter_batched_ref(
-                || build(n, None),
-                |(mgr, _recv, changed)| mgr.bench_distribute(changed),
-                BatchSize::PerIteration,
-            );
+            b.iter_custom(|iterations| {
+                measure_replacement_fanout(iterations, n, |peers| build(peers, None))
+            });
         });
         group.bench_with_input(BenchmarkId::new("with_policy", n), &n, |b, &n| {
-            b.iter_batched_ref(
-                || build(n, Some(representative_export_chain())),
-                |(mgr, _recv, changed)| mgr.bench_distribute(changed),
-                BatchSize::PerIteration,
-            );
+            b.iter_custom(|iterations| {
+                measure_replacement_fanout(iterations, n, |peers| {
+                    build(peers, Some(representative_export_chain()))
+                })
+            });
         });
     }
     group.finish();
@@ -295,19 +441,15 @@ fn bench_ixp_exact_export_fanout(c: &mut Criterion) {
             BenchmarkId::new("homogeneous_remote_asn", n),
             &n,
             |b, &n| {
-                b.iter_batched_ref(
-                    || build_ixp(n, false),
-                    |(manager, _receivers, changed)| manager.bench_distribute(changed),
-                    BatchSize::PerIteration,
-                );
+                b.iter_custom(|iterations| {
+                    measure_replacement_fanout(iterations, n, |peers| build_ixp(peers, false))
+                });
             },
         );
         group.bench_with_input(BenchmarkId::new("distinct_remote_asns", n), &n, |b, &n| {
-            b.iter_batched_ref(
-                || build_ixp(n, true),
-                |(manager, _receivers, changed)| manager.bench_distribute(changed),
-                BatchSize::PerIteration,
-            );
+            b.iter_custom(|iterations| {
+                measure_replacement_fanout(iterations, n, |peers| build_ixp(peers, true))
+            });
         });
     }
     group.finish();

--- a/crates/transport/benches/fanout.rs
+++ b/crates/transport/benches/fanout.rs
@@ -359,8 +359,8 @@ fn drain_fanout_envelopes(
             "the envelope must contain the exact replacement inventory"
         );
         assert!(
-            receiver.try_recv().is_err(),
-            "one distribution pass must leave no second envelope"
+            matches!(receiver.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+            "one distribution pass must leave a live channel with no second envelope"
         );
     }
 }

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -560,9 +560,16 @@ re-advertise them to every peer. Unlike the bench above (bare structs), the
 export-policy evaluation + Adj-RIB-Out staging + bounded-channel send — fanning a
 batch of **64 changed best paths** out to N peers. It is gated behind the
 `bench-internals` feature (a synthetic peer-registration + Loc-RIB-seed driver,
-not reachable in a normal build). Each measured pass is a *first* advertise
-(empty Adj-RIB-Out, so the equality-suppression fast path never fires) — the
-conservative upper bound on per-peer cost.
+not reachable in a normal build). Each current `distribute_fanout` and
+`ixp_exact_export_fanout` pass first advertises and drains a MED-50 inventory,
+prepares a MED-51 best-path replacement outside accumulated time, then times
+exactly one production distribution pass. Post-timing receipts require one
+clean update group, the exact grouped/private inventory, real nonzero
+exact-encoder results with compatible reuse, and one commit, enqueue, and gauge
+write per peer. Receiver inspection proves the exact MED-51 inventory and no
+second envelope, so equality suppression cannot silently turn the row into a
+no-op. This is a replacement-distribution microbenchmark, not an initial-table
+or end-to-end convergence measurement.
 
 The benchmark now belongs to the transport crate so it can install a distinct
 authoritative `SessionExportEncoder` for every synthetic peer without creating
@@ -628,8 +635,12 @@ At 256 and 1,000 peers it improves the measured actor/probe/commit/enqueue
 interval by 11.69% and 14.98%, respectively; both mean-change 95% confidence
 intervals exclude zero.
 
-The July 2026 receipt compares the first real-probe baseline against ordered
-batch probing with the live prepared-attribute memo key:
+The pinned July 2026 receipt below predates `0eef03f6`, when the benchmark seed
+populated the Loc-RIB without distributing it. Those rows therefore remain
+truthful first-advertise measurements and optimization evidence, but are not
+directly comparable to the current replacement-distribution instrument.
+That receipt compares the first real-probe baseline against ordered batch
+probing with the live prepared-attribute memo key:
 
 | Peers | No policy baseline → memo | Change | Policy baseline → memo | Change |
 |-------|---------------------------|--------|------------------------|--------|


### PR DESCRIPTION
## Summary

- repair the legacy fanout Criterion rows so every timed pass contains a wire-visible MED replacement
- verify the exact production fanout receipt and each peer's concrete route-bearing envelope after timing
- distinguish current replacement-distribution rows from the historical first-advertise receipt

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p rustbgpd-transport --features bench-internals --bench fanout`
- focused `distribute_fanout` and `ixp_exact_export_fanout` executions
- optimized Criterion smoke for `distribute_fanout/no_policy/1`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `git diff --check`

## Load-bearing proof

The retained assertions go red if the MED-51 replacement is removed, the MED-50 setup envelope is left queued, the concrete transport snapshot is dropped, or nonzero exact-encoder evidence is zeroed. No performance delta is claimed.
