### PR TITLE
Correct strict-peer dual-stack route-server guidance

### DIFF
--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -17093,6 +17093,82 @@ async fn strict_peer_next_hop_rejects_foreign_ipv6_mp_and_withdraws_replacement(
     ));
 }
 
+/// An IPv4 session cannot own an IPv6 `MP_REACH_NLRI` next hop; strict-peer
+/// rejects the replacement as foreign and retires an existing route.
+#[tokio::test]
+async fn strict_peer_ipv4_session_rejects_ipv6_mp_replacement() {
+    use rustbgpd_telemetry::reason_labels::ImportRejectReason;
+    use rustbgpd_wire::{MpReachNlri, NlriEntry};
+
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let prefix = Prefix::V6(Ipv6Prefix::new("2001:db8:737::".parse().unwrap(), 48));
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
+    install_test_negotiated_session(&mut session, negotiated);
+    let attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+        PathAttribute::MpReachNlri(MpReachNlri {
+            afi: Afi::Ipv6,
+            safi: Safi::Unicast,
+            next_hop: "2001:db8::2".parse().unwrap(),
+            link_local_next_hop: None,
+            announced: vec![NlriEntry { path_id: 0, prefix }],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            labeled_announced: vec![],
+            vpn_announced: vec![],
+            rtc_announced: vec![],
+        }),
+    ];
+    session
+        .process_update(UpdateMessage::build(
+            &[],
+            &[],
+            &attrs,
+            true,
+            false,
+            Ipv4UnicastMode::Body,
+        ))
+        .await;
+    let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
+        panic!("expected initial route");
+    };
+    assert_eq!(announced.len(), 1);
+
+    session.config.next_hop_ownership_strict_peer = true;
+    session
+        .process_update(UpdateMessage::build(
+            &[],
+            &[],
+            &attrs,
+            true,
+            false,
+            Ipv4UnicastMode::Body,
+        ))
+        .await;
+
+    let RibUpdate::RoutesReceived {
+        announced,
+        withdrawn,
+        ..
+    } = rib_rx
+        .try_recv()
+        .expect("foreign replacement must withdraw")
+    else {
+        panic!("expected RoutesReceived");
+    };
+    assert!(announced.is_empty());
+    assert_eq!(withdrawn, vec![(prefix, 0)]);
+    let retained = session.rejected_routes.snapshot();
+    assert_eq!(retained.len(), 1);
+    assert_eq!(retained[0].1.reason, ImportRejectReason::NextHopOwnership);
+    assert_eq!(retained[0].1.next_hop, Some("2001:db8::2".parse().unwrap()));
+}
+
 /// ADR-0107 §2: a global + link-local next-hop pair always fails closed
 /// under the strict pilot — the companion cannot be mapped to the single
 /// session address even when the global component matches, and it is

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1612,6 +1612,9 @@ unauthorized next hop — and it is fail-closed:
 
 - classic IPv4 `NEXT_HOP`, IPv6 global, and RFC 8950 IPv4-over-IPv6 forms
   must equal the session address exactly;
+- address-family differences are literal mismatches: for example, an IPv6
+  `MP_REACH_NLRI` next hop on an IPv4 session is always foreign. Use same-AF
+  sessions when applying `strict_peer` to both IPv4 and IPv6 unicast;
 - a global + link-local next-hop pair is always rejected: the session maps
   to one address, so the companion is unverifiable (never silently ignored);
 - a link-local next hop is only accepted from a scoped link-local session

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -138,13 +138,13 @@ address = "198.51.100.2"
 remote_asn = 64501
 description = "member-alpha"
 hold_time = 90
-families = ["ipv4_unicast", "ipv6_unicast"]
+families = ["ipv4_unicast"]
 route_server_client = true     # transparent: no AS prepend, NEXT_HOP preserved
 role = "route_server"          # RFC 9234: attach OTC on egress
 # RFC 7948 §4.8 / ADR-0107: reject announcements whose NEXT_HOP is not the
 # member's own session address (pre-policy, fail-closed). Leave unset for
 # members that legitimately announce another connection's next hop in the
-# same AS — the broader ownership modes are not shipped yet.
+# same AS. Use a separate IPv6 session to apply strict_peer to IPv6 unicast.
 next_hop_ownership = "strict_peer"
 max_prefixes = 50000
 

--- a/tests/starter_configs_check_strict.rs
+++ b/tests/starter_configs_check_strict.rs
@@ -168,3 +168,18 @@ fn every_example_config_passes_check_strict() {
         assert_clean(&config.display().to_string(), code, &stdout, &stderr);
     }
 }
+
+#[test]
+fn route_server_cookbook_does_not_apply_strict_peer_cross_family() {
+    let cookbook = fs::read_to_string(repo_root().join("docs/cookbook/route-server.md"))
+        .expect("read cookbook");
+    let strict_stanza = cookbook
+        .split("[[neighbors]]")
+        .find(|stanza| stanza.contains("next_hop_ownership = \"strict_peer\""))
+        .expect("cookbook must retain a strict_peer example");
+    assert!(
+        !(strict_stanza.contains("\"ipv4_unicast\"") && strict_stanza.contains("\"ipv6_unicast\"")),
+        "strict_peer compares the wire next hop literally with the session address; \
+         the cookbook must use same-AF sessions"
+    );
+}


### PR DESCRIPTION
## Summary

- correct the route-server cookbook so `strict_peer` is demonstrated on a same-address-family session
- document that literal strict-peer ownership rejects a cross-family MP_REACH next hop
- pin the shipped behavior with a production-session regression and a structural cookbook guard

## Verification

- `cargo test -p rustbgpd-transport strict_peer_ipv4_session_rejects_ipv6_mp_replacement`
- `cargo test --test starter_configs_check_strict route_server_cookbook_does_not_apply_strict_peer_cross_family`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `git diff --check`

## Load-bearing proof

Temporarily weakening the production foreign-address comparison made the new session test fail because the IPv6 replacement remained announced. Restoring the contradictory dual-family cookbook stanza made the structural guard fail. Both guarded changes were restored before this candidate.
