### PR TITLE
Fix private links in warning-denying rustdoc

### DIFF
--- a/src/config/resolution.rs
+++ b/src/config/resolution.rs
@@ -1203,7 +1203,7 @@ pub(crate) fn reserved_rfc8212_deny_chain(name: &str) -> PolicyChain {
 /// rebuilding from compiled content, and it could not: the reserved deny
 /// replaces the whole direction, so there is no operator policy or implicit
 /// tail left to tell apart. It is an identity test against the one chain
-/// [`reserved_rfc8212_deny_chain`] builds, and [`Config::validate`] refuses
+/// `reserved_rfc8212_deny_chain` builds, and `Config::validate` refuses
 /// both reserved names to operator policies, so nothing configurable compares
 /// equal to it.
 #[must_use]


### PR DESCRIPTION
## Summary

- render two private RFC 8212 helper references as code text in public rustdoc
- restore the all-features warning-denying rustdoc gate without changing visibility or behavior

## Verification

- exact base fails with both expected `rustdoc::private-intra-doc-links` errors
- `RUSTDOCFLAGS="-D warnings" cargo doc -p rustbgpd --all-features --no-deps --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `git diff --check`

## Load-bearing proof

Restoring either private intra-doc link makes the exact warning-denying package gate fail. No behavior, visibility, or API surface changes.