### PR TITLE
Harden VPN query campaign allocation and affinity evidence

### DIFF
--- a/bench/run-vpn-query-campaign.sh
+++ b/bench/run-vpn-query-campaign.sh
@@ -10,18 +10,27 @@ source "$root/docs/perf/event-history-host-fence.sh"
 
 smoke=0
 attempts=1
-if [[ ${1:-} == --smoke ]]; then
-    smoke=1
-    shift
-fi
-if [[ ${1:-} == --retry ]]; then
-    attempts=2
-    shift
+declared_cpu=
+[[ ${1:-} != --smoke ]] || { smoke=1; shift; }
+[[ ${1:-} != --retry ]] || { attempts=2; shift; }
+if [[ ${1:-} == --cpu && $# -ge 2 ]]; then
+    declared_cpu=$2
+    shift 2
 fi
 [[ $# -eq 1 ]] || {
-    echo "usage: $0 [--smoke] [--retry] OUTPUT_DIRECTORY" >&2
+    echo "usage: $0 [--smoke] [--retry] --cpu LOGICAL_CPU OUTPUT_DIRECTORY" >&2
     exit 2
 }
+[[ $declared_cpu =~ ^[0-9]+$ ]] ||
+    { echo "a numeric --cpu is required for every campaign" >&2; exit 2; }
+command -v taskset >/dev/null 2>&1 ||
+    { echo "taskset is required for the declared CPU pin" >&2; exit 2; }
+taskset -c "$declared_cpu" true >/dev/null 2>&1 ||
+    { echo "declared CPU is unavailable: $declared_cpu" >&2; exit 2; }
+linux_affinity=$(taskset -c "$declared_cpu" \
+    grep '^Cpus_allowed_list:' /proc/self/status | cut -f2)
+[[ $linux_affinity == "$declared_cpu" ]] ||
+    { echo "declared CPU and Linux affinity differ" >&2; exit 2; }
 output=$1
 if ((!smoke)) && [[ -v RUSTBGPD_VPN_QUERY_FORCE_CENSOR ]]; then
     echo "RUSTBGPD_VPN_QUERY_FORCE_CENSOR is forbidden for retained campaigns" >&2
@@ -69,13 +78,15 @@ timing_hash=$(sha256sum "$output/bin/vpn_query_timing" | awk '{print $1}')
 allocation_hash=$(sha256sum "$output/bin/vpn_query_allocation" | awk '{print $1}')
 
 python3 - "$output/manifest.json" "$timing_hash" "$allocation_hash" \
-    "$source_commit" "$source_tree" "$toolchain" "$attempts" <<'PY'
+    "$source_commit" "$source_tree" "$toolchain" "$attempts" \
+    "$declared_cpu" "$linux_affinity" <<'PY'
 import json, sys
-path, timing, allocation, commit, tree, rustc, attempts = sys.argv[1:]
+path, timing, allocation, commit, tree, rustc, attempts, cpu, affinity = sys.argv[1:]
 fixed = [f"{case}{i}" for i in range(1, 9) for case in ("U", "F")]
-json.dump({"schema": 2, "base_commit": commit, "rustc": rustc,
+json.dump({"schema": 3, "base_commit": commit, "rustc": rustc,
            "host_fence": "pass", "source_tree_clean": True, "fixed_order": fixed,
            "source_tree": tree, "attempts": int(attempts),
+           "declared_cpu": int(cpu), "linux_affinity": affinity,
            "timing_binary_sha256": timing,
            "allocation_binary_sha256": allocation}, open(path, "w"), indent=2)
 PY
@@ -87,7 +98,7 @@ decorate() {
 import json, sys
 raw, output, binary_hash, ordinal, repetition, timeout, commit, attempt = sys.argv[1:]
 doc = json.load(open(raw))
-doc.update(schema=2, binary_sha256=binary_hash, ordinal=int(ordinal),
+doc.update(schema=3, binary_sha256=binary_hash, ordinal=int(ordinal),
            repetition=int(repetition), timeout_seconds=int(timeout),
            source_commit=commit, attempt=int(attempt))
 json.dump(doc, open(output, "w"), indent=2)
@@ -101,13 +112,16 @@ check_provenance() {
     [[ $(rustc --version --verbose | tr '\n' ';') == "$toolchain" ]]
     [[ $(sha256sum "$output/bin/vpn_query_timing" | awk '{print $1}') == "$timing_hash" ]]
     [[ $(sha256sum "$output/bin/vpn_query_allocation" | awk '{print $1}') == "$allocation_hash" ]]
+    [[ $(taskset -c "$declared_cpu" grep '^Cpus_allowed_list:' \
+        /proc/self/status | cut -f2) == "$linux_affinity" ]]
 }
 
 if ((smoke)); then
     vpn_query_wait_for_idle smoke "$output/host-preflight.tsv"
     for target in timing allocation; do
         raw="$output/$target-raw.json"
-        "$output/bin/vpn_query_$target" smoke U "$raw"
+        taskset -c "$declared_cpu" "$output/bin/vpn_query_$target" \
+            smoke U "$raw" "$declared_cpu"
         decorate "$raw" "$output/$target-smoke.json" \
             "$([[ $target == timing ]] && echo "$timing_hash" || echo "$allocation_hash")" \
             1 1 10 0
@@ -128,7 +142,8 @@ for attempt in $(seq 1 "$attempts"); do
                     "$output/host-preflight.tsv"
                 raw="$output/attempt-$attempt/timing/raw.json"
                 set +e
-                "$output/bin/vpn_query_timing" cell "$size" "$case" "$raw"
+                taskset -c "$declared_cpu" "$output/bin/vpn_query_timing" \
+                    cell "$size" "$case" "$raw" "$declared_cpu"
                 rc=$?
                 set -e
                 if ((rc == 75)); then
@@ -153,7 +168,8 @@ done
 check_provenance
 vpn_query_wait_for_idle allocation "$output/host-preflight.tsv"
 set +e
-"$output/bin/vpn_query_allocation" cell 1000000 U "$output/allocation-raw.json"
+taskset -c "$declared_cpu" "$output/bin/vpn_query_allocation" \
+    cell 1000000 U "$output/allocation-raw.json" "$declared_cpu"
 rc=$?
 set -e
 if ((rc == 75)); then

--- a/bench/tests/test-vpn-query-campaign.sh
+++ b/bench/tests/test-vpn-query-campaign.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016 # Structural literals intentionally retain shell variables.
 set -euo pipefail
 
 root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
@@ -8,6 +9,11 @@ verifier=$root/bench/verify-vpn-query-campaign.py
 bash -n "$runner"
 python3 -m unittest -v "$root/bench/tests/test_verify_vpn_query_campaign.py"
 python3 "$verifier" --help >/dev/null
+[[ $(grep -Fc '.checked_mul(' "$root/crates/api/benches/vpn_query.rs") -eq 2 && $(grep -Fc '.checked_add(' "$root/crates/api/benches/vpn_query.rs") -eq 1 ]]
+[[ $(grep -Fc 'taskset -c "$declared_cpu" "$output/bin/vpn_query_$target"' "$runner") -eq 1 ]]
+[[ $(grep -Fc 'taskset -c "$declared_cpu" "$output/bin/vpn_query_timing"' "$runner") -eq 1 ]]
+[[ $(grep -Fc 'taskset -c "$declared_cpu" "$output/bin/vpn_query_allocation"' "$runner") -eq 1 ]]
+[[ $(grep -Fc '"declared_cpu": int(cpu), "linux_affinity": affinity' "$runner") -eq 1 ]]
 
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT

--- a/bench/tests/test-vpn-query-receipt.sh
+++ b/bench/tests/test-vpn-query-receipt.sh
@@ -8,6 +8,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
 timing_receipt="$tmp_dir/timing.json"
 allocation_receipt="$tmp_dir/allocation.json"
 bench_source="$repo_root/crates/api/benches/vpn_query.rs"
+declared_cpu=$(awk '/^Cpus_allowed_list:/{split($2, a, /[-,]/); print a[1]}' /proc/self/status)
 
 check_allocator_seam() {
   python3 - "$1" <<'PY'
@@ -34,6 +35,16 @@ for contract in (
 ):
     assert contract in source, contract
 assert source.count("let _guard = self.guard();") == 6
+for operation, index in (
+    ("alloc", "ALLOC"), ("alloc_zeroed", "ALLOC_ZEROED"),
+    ("realloc", "REALLOC"), ("dealloc", "DEALLOC"),
+):
+    site = f"self.record_request({index},"
+    field = f'"{operation}_calls": value.calls[{index}]'
+    byte_field = f'"{operation}_requested_bytes": value.requested_bytes[{index}]'
+    assert source.count(site) == 1, site
+    assert source.count(field) == 1, field
+    assert source.count(byte_field) == 1, byte_field
 PY
 sed '/^#\[global_allocator\]$/d' "$bench_source" >"$tmp_dir/no-global-allocator.rs"
 if check_allocator_seam "$tmp_dir/no-global-allocator.rs" >/dev/null 2>&1; then
@@ -41,11 +52,13 @@ if check_allocator_seam "$tmp_dir/no-global-allocator.rs" >/dev/null 2>&1; then
   exit 1
 fi
 
-cargo bench --manifest-path "$repo_root/Cargo.toml" -p rustbgpd-api \
-  --bench vpn_query_timing --features bench-internals -- smoke U "$timing_receipt"
-cargo bench --manifest-path "$repo_root/Cargo.toml" -p rustbgpd-api \
+taskset -c "$declared_cpu" cargo bench --manifest-path "$repo_root/Cargo.toml" \
+  -p rustbgpd-api --bench vpn_query_timing --features bench-internals -- \
+  smoke U "$timing_receipt" "$declared_cpu"
+taskset -c "$declared_cpu" cargo bench --manifest-path "$repo_root/Cargo.toml" \
+  -p rustbgpd-api \
   --bench vpn_query_allocation --features bench-internals,vpn-query-allocation -- \
-  smoke F "$allocation_receipt"
+  smoke F "$allocation_receipt" "$declared_cpu"
 
 verify() {
   python3 - "$1" <<'PY'
@@ -53,13 +66,16 @@ import json
 import sys
 
 doc = json.load(open(sys.argv[1], encoding="utf-8"))
-assert doc["schema"] == 1
+assert doc["schema"] == 2
 assert doc["allocator"] == "tikv-jemallocator"
+assert doc["linux_affinity"] == str(doc["declared_cpu"])
 assert doc["routes"] == 256
 assert doc["peers"] == 16
 query = doc["query"]
 assert query["actor_rows"] == 256
 assert query["actor_capacity"] >= 256
+assert query["actor_snapshot_lower_bound_bytes"] == query["actor_capacity"] * (
+    query["vpn_rib_route_size_bytes"]) + query["actor_rows"] * query["mpls_label_entry_size_bytes"]
 assert query["dispatch"] == 1
 assert query["returned_rows"] == (256 if doc["case"] == "U" else 16)
 assert query["checksum"] == (
@@ -80,17 +96,27 @@ allocation = json.load(open(sys.argv[2]))
 assert timing["mode"] == "timing" and timing["case"] == "U"
 assert timing["query"]["returned_rows"] == 256
 assert timing["peak_live_requested_bytes"] is None
+assert timing["allocation"] is None
 assert allocation["mode"] == "allocation" and allocation["case"] == "F"
 assert allocation["query"]["returned_rows"] == 16
 assert allocation["peak_live_requested_bytes"] > 0
+counts = allocation["allocation"]
+assert all(counts[f"{op}_{field}"] >= 0 for op in (
+    "alloc", "alloc_zeroed", "realloc", "dealloc") for field in ("calls", "requested_bytes"))
+assert counts["peak_live_requested_bytes"] == allocation["peak_live_requested_bytes"]
+assert counts["peak_delta_requested_bytes"] == counts[
+    "peak_live_requested_bytes"] - counts["baseline_live_requested_bytes"]
+assert counts["peak_live_requested_bytes"] >= counts["final_live_requested_bytes"]
+assert counts["peak_delta_requested_bytes"] >= allocation[
+    "query"]["actor_snapshot_lower_bound_bytes"]
 PY
 
 set +e
 mapfile -t timing_bins < <(find "$repo_root/target/release/deps" -maxdepth 1 \
   -type f -perm -0100 -name 'vpn_query_timing-*')
 [[ ${#timing_bins[@]} -eq 1 ]]
-RUSTBGPD_VPN_QUERY_FORCE_CENSOR=1 "${timing_bins[0]}" \
-  smoke U "$tmp_dir/censor.json" >/dev/null 2>&1
+taskset -c "$declared_cpu" env RUSTBGPD_VPN_QUERY_FORCE_CENSOR=1 "${timing_bins[0]}" \
+  smoke U "$tmp_dir/censor.json" "$declared_cpu" >/dev/null 2>&1
 censor_status=$?
 set -e
 [[ $censor_status -eq 75 ]]
@@ -98,7 +124,9 @@ python3 - "$tmp_dir/censor.json" <<'PY'
 import json, sys
 doc = json.load(open(sys.argv[1]))
 assert doc == {
-    "schema": 1, "mode": "timing", "routes": 256, "case": "U",
+    "schema": 2, "mode": "timing", "routes": 256, "case": "U",
+    "declared_cpu": int(doc["linux_affinity"]),
+    "linux_affinity": doc["linux_affinity"],
     "outcome": "capacity_censored", "censor_phase": "forced_fixture",
 }
 PY

--- a/bench/tests/test_verify_vpn_query_campaign.py
+++ b/bench/tests/test_verify_vpn_query_campaign.py
@@ -23,9 +23,10 @@ class VerifyCampaign(unittest.TestCase):
         timing_hash = hashlib.sha256(b"vpn_query_timing").hexdigest()
         allocation_hash = hashlib.sha256(b"vpn_query_allocation").hexdigest()
         manifest = {
-            "schema": 2, "base_commit": "a" * 40, "rustc": "rustc fixture",
+            "schema": 3, "base_commit": "a" * 40, "rustc": "rustc fixture",
             "host_fence": "pass", "source_tree_clean": True,
             "source_tree": "c" * 40, "attempts": 1,
+            "declared_cpu": 8, "linux_affinity": "8",
             "fixed_order": list(VERIFY.CASES),
             "timing_binary_sha256": timing_hash,
             "allocation_binary_sha256": allocation_hash,
@@ -35,8 +36,9 @@ class VerifyCampaign(unittest.TestCase):
             actor = size * 10 + repetition * 10
             service = 300_000_000 + actor
             receipt = {
-                "schema": 2, "mode": "timing", "ordinal": ordinal,
+                "schema": 3, "mode": "timing", "ordinal": ordinal,
                 "routes": size, "case": case, "repetition": repetition,
+                "declared_cpu": 8, "linux_affinity": "8",
                 "binary_sha256": timing_hash,
                 "source_commit": "a" * 40, "timeout_seconds": 120,
                 "attempt": 1,
@@ -44,18 +46,26 @@ class VerifyCampaign(unittest.TestCase):
                     "actor_handler_ns": actor,
                     "service_method_ns": service, "post_actor_ns": 300_000_000,
                     "actor_rows": size, "actor_capacity": size,
+                    "vpn_rib_route_size_bytes": 128, "mpls_label_entry_size_bytes": 4, "actor_snapshot_lower_bound_bytes": size * 132,
                     "returned_rows": size if case == "U" else size // 16,
                     "dispatch": 1, "checksum": VERIFY.CHECKSUMS[(size, case)],
                 },
             }
             self.write(f"attempt-1/timing/{ordinal:02d}.json", receipt)
         self.write("allocation.json", {
-            "schema": 2, "mode": "allocation", "routes": 1_000_000, "case": "U",
-            "binary_sha256": allocation_hash, "peak_live_requested_bytes": 1024,
+            "schema": 3, "mode": "allocation", "routes": 1_000_000, "case": "U",
+            "declared_cpu": 8, "linux_affinity": "8",
+            "binary_sha256": allocation_hash, "peak_live_requested_bytes": 132_000_100,
             "source_commit": "a" * 40, "timeout_seconds": 120,
             "attempt": 1,
             "vmrss_bytes": 999999999999, "vmhwm_bytes": 999999999999,
+            "allocation": {
+                "alloc_calls": 4, "alloc_requested_bytes": 132_000_000, "alloc_zeroed_calls": 1, "alloc_zeroed_requested_bytes": 64,
+                "realloc_calls": 0, "realloc_requested_bytes": 0, "dealloc_calls": 2, "dealloc_requested_bytes": 32,
+                "baseline_live_requested_bytes": 100, "final_live_requested_bytes": 132_000_100, "peak_live_requested_bytes": 132_000_100, "peak_delta_requested_bytes": 132_000_000,
+            },
             "query": {"actor_rows": 1_000_000, "actor_capacity": 1_000_000,
+                      "vpn_rib_route_size_bytes": 128, "mpls_label_entry_size_bytes": 4, "actor_snapshot_lower_bound_bytes": 132_000_000,
                       "returned_rows": 1_000_000,
                       "actor_handler_ns": 10, "service_method_ns": 11,
                       "post_actor_ns": 1,
@@ -82,9 +92,35 @@ class VerifyCampaign(unittest.TestCase):
         callback(value)
         self.write(relative, value)
 
+    def mutate_all_affinity(self, manifest):
+        manifest.update(linux_affinity="8-9")
+        for path in [*(self.root / "attempt-1" / "timing").glob("*.json"), self.root / "allocation.json"]:
+            self.mutate(path.relative_to(self.root), lambda d: d.update(linux_affinity="8-9"))
+
     def test_valid_fixture_and_observational_rss(self):
         result = VERIFY.verify(self.root)
         self.assertEqual(result["classification"], "no_redesign")
+
+    def test_rejects_affinity_allocation_and_lower_bound_drift(self):
+        mutations = [
+            ("manifest.json", self.mutate_all_affinity),
+            ("attempt-1/timing/01.json", lambda d: d.update(declared_cpu=7)),
+            ("attempt-1/timing/01.json", lambda d: d["query"].update(actor_snapshot_lower_bound_bytes=1)),
+            ("allocation.json", lambda d: d.update(linux_affinity="7")),
+            ("allocation.json", lambda d: d["query"].update(vpn_rib_route_size_bytes=129, actor_snapshot_lower_bound_bytes=133_000_000)),
+            ("allocation.json", lambda d: d["allocation"].update(final_live_requested_bytes=10**12)),
+        ]
+        mutations.extend(("allocation.json", lambda d, f=field: d["allocation"].pop(f)) for operation
+                         in ("alloc", "alloc_zeroed", "realloc", "dealloc")
+                         for field in (f"{operation}_calls", f"{operation}_requested_bytes"))
+        for index, (relative, mutation) in enumerate(mutations):
+            with self.subTest(mutation=mutation):
+                self.mutate(relative, mutation)
+                with self.assertRaises(VERIFY.Invalid):
+                    VERIFY.verify(self.root)
+                if index + 1 < len(mutations):
+                    self.tearDown()
+                    self.setUp()
 
     def test_rejects_count_order_dual_case_underflow_and_binary_corruption(self):
         mutations = [
@@ -245,9 +281,10 @@ class VerifyCampaign(unittest.TestCase):
         for ordinal in range(11, 49):
             (self.root / "attempt-1" / "timing" / f"{ordinal:02d}.json").unlink()
         censor = {
-            "schema": 2, "mode": "timing", "outcome": "capacity_censored",
+            "schema": 3, "mode": "timing", "outcome": "capacity_censored",
             "censor_phase": "service_query", "ordinal": 11, "routes": 10_000,
             "case": "U", "repetition": 6, "timeout_seconds": 120,
+            "declared_cpu": 8, "linux_affinity": "8",
             "source_commit": "a" * 40,
             "attempt": 1,
             "binary_sha256": hashlib.sha256(b"vpn_query_timing").hexdigest(),

--- a/bench/verify-vpn-query-campaign.py
+++ b/bench/verify-vpn-query-campaign.py
@@ -53,10 +53,35 @@ def expected_cells():
     ]
 
 
+def verify_affinity(receipt, manifest, label):
+    require((receipt.get("declared_cpu"), receipt.get("linux_affinity"))
+            == (manifest["declared_cpu"], manifest["linux_affinity"]),
+            f"{label}: CPU affinity drift")
+
+
+def verify_query(query, rows, returned, label):
+    require(query.get("actor_rows") == rows, f"{label}: actor rows")
+    capacity = query.get("actor_capacity")
+    require(type(capacity) is int and capacity >= rows, f"{label}: actor capacity")
+    route_size = query.get("vpn_rib_route_size_bytes")
+    label_size = query.get("mpls_label_entry_size_bytes")
+    lower_bound = query.get("actor_snapshot_lower_bound_bytes")
+    require(all(type(value) is int and value > 0
+                for value in (route_size, label_size, lower_bound))
+            and lower_bound == capacity * route_size + rows * label_size,
+            f"{label}: actor snapshot lower bound")
+    require(query.get("returned_rows") == returned, f"{label}: returned rows")
+    return lower_bound
+
+
 def verify_receipt(receipt, expected, manifest, attempt):
     ordinal, size, case, repetition = expected
-    require(receipt.get("schema") == 2, f"receipt {ordinal}: schema")
+    require(receipt.get("schema") == 3, f"receipt {ordinal}: schema")
     require(receipt.get("mode") == "timing", f"receipt {ordinal}: timing mode")
+    require(receipt.get("allocation") is None
+            and receipt.get("peak_live_requested_bytes") is None,
+            f"receipt {ordinal}: allocation evidence contaminated timing mode")
+    verify_affinity(receipt, manifest, f"receipt {ordinal}")
     require(receipt.get("ordinal") == ordinal, f"receipt {ordinal}: ordinal/order")
     require(receipt.get("routes") == size, f"receipt {ordinal}: routes/order")
     require(receipt.get("case") == case, f"receipt {ordinal}: case/order")
@@ -81,9 +106,7 @@ def verify_receipt(receipt, expected, manifest, attempt):
     require(service >= actor, f"receipt {ordinal}: post-actor underflow")
     require(post == service - actor, f"receipt {ordinal}: post-actor decomposition")
     expected_rows = size if case == "U" else size // 16
-    require(query.get("actor_rows") == size, f"receipt {ordinal}: actor rows")
-    require(query.get("actor_capacity", 0) >= size, f"receipt {ordinal}: actor capacity")
-    require(query.get("returned_rows") == expected_rows, f"receipt {ordinal}: returned rows")
+    verify_query(query, size, expected_rows, f"receipt {ordinal}")
     require(query.get("dispatch") == 1, f"receipt {ordinal}: dispatch")
     require(type(query.get("checksum")) is int
             and query["checksum"] == CHECKSUMS[(size, case)],
@@ -147,7 +170,7 @@ def classify(manifest, timings, allocation):
 
 def verify(directory):
     manifest = load(directory / "manifest.json")
-    require(manifest.get("schema") == 2, "manifest schema")
+    require(manifest.get("schema") == 3, "manifest schema")
     require(isinstance(manifest.get("base_commit"), str)
             and re.fullmatch(r"[0-9a-f]{40}", manifest["base_commit"]),
             "invalid base commit provenance")
@@ -159,6 +182,10 @@ def verify(directory):
     require(manifest.get("rustc"), "missing rustc provenance")
     require(manifest.get("host_fence") == "pass", "host fence did not pass")
     require(manifest.get("fixed_order") == list(CASES), "fixed order drift")
+    require(type(manifest.get("declared_cpu")) is int
+            and manifest["declared_cpu"] >= 0, "invalid declared CPU")
+    require(manifest.get("linux_affinity") == str(manifest["declared_cpu"]),
+            "manifest CPU and Linux affinity differ")
     timing_binary = directory / "bin" / "vpn_query_timing"
     allocation_binary = directory / "bin" / "vpn_query_allocation"
     require(timing_binary.is_file() and allocation_binary.is_file(), "missing binaries")
@@ -210,7 +237,8 @@ def verify(directory):
                 for ordinal in range(1, len(receipt_paths) + 1)
             )
             require(censor.get("outcome") == "capacity_censored", "invalid censor outcome")
-            require(censor.get("schema") == 2, "censor schema")
+            require(censor.get("schema") == 3, "censor schema")
+            verify_affinity(censor, manifest, "censor")
             require(censor.get("ordinal") == len(receipt_paths) + 1,
                     "censor must stop the next ordered cell")
             if len(receipt_paths) == 48:
@@ -258,8 +286,9 @@ def verify(directory):
         selected_timings = timings
 
     allocation = load(directory / "allocation.json")
-    require(allocation.get("schema") == 2, "allocation schema")
+    require(allocation.get("schema") == 3, "allocation schema")
     require(allocation.get("mode") == "allocation", "allocation mode")
+    verify_affinity(allocation, manifest, "allocation")
     require(allocation.get("routes") == 1_000_000, "allocation must use 1M routes")
     require(allocation.get("case") == "U", "allocation must use unfiltered cell")
     require(allocation.get("binary_sha256") == manifest["allocation_binary_sha256"],
@@ -269,9 +298,28 @@ def verify(directory):
     require(allocation.get("timeout_seconds") == 120,
             "allocation 120-second censor missing")
     require(allocation.get("attempt") == attempts, "allocation attempt drift")
-    require(isinstance(allocation.get("peak_live_requested_bytes"), int)
-            and allocation["peak_live_requested_bytes"] > 0,
-            "missing absolute allocator evidence")
+    counters = allocation.get("allocation")
+    require(isinstance(counters, dict), "missing whole-query allocator evidence")
+    operation_fields = tuple(f"{operation}_{suffix}"
+                             for operation in ("alloc", "alloc_zeroed", "realloc", "dealloc")
+                             for suffix in ("calls", "requested_bytes"))
+    require(all(type(counters.get(field)) is int and counters[field] >= 0
+                for field in operation_fields),
+            "invalid whole-query allocator operation evidence")
+    require(sum(counters[field] for field in operation_fields if field.endswith("_calls")) > 0
+            and sum(counters[field] for field in operation_fields
+                    if field.endswith("_requested_bytes")) > 0,
+            "empty whole-query allocator operation evidence")
+    baseline, final, peak, delta = (counters.get(field) for field in (
+        "baseline_live_requested_bytes", "final_live_requested_bytes",
+        "peak_live_requested_bytes", "peak_delta_requested_bytes"))
+    require(all(type(value) is int and value >= 0
+                for value in (baseline, final, peak, delta)),
+            "invalid whole-query live-byte evidence")
+    require(peak >= baseline and peak >= final and delta == peak - baseline,
+            "inconsistent whole-query live-byte evidence")
+    require(allocation.get("peak_live_requested_bytes") == peak,
+            "absolute allocator peak disagrees with whole-query evidence")
     query = allocation.get("query")
     require(isinstance(query, dict), "missing allocation query")
     actor, service, post = (query.get(name) for name in
@@ -279,9 +327,9 @@ def verify(directory):
     require(type(actor) is int and actor > 0 and type(service) is int and service > 0
             and type(post) is int and post >= 0 and service - actor == post,
             "allocation timing decomposition")
-    require(query.get("actor_rows") == 1_000_000, "allocation actor rows")
-    require(query.get("actor_capacity", 0) >= 1_000_000, "allocation actor capacity")
-    require(query.get("returned_rows") == 1_000_000, "allocation returned rows")
+    lower_bound = verify_query(query, 1_000_000, 1_000_000, "allocation")
+    require(delta >= lower_bound,
+            "allocation peak delta is below the actor snapshot lower bound")
     require(type(query.get("checksum")) is int
             and query["checksum"] == CHECKSUMS[(1_000_000, "U")],
             "allocation checksum")

--- a/crates/api/benches/vpn_query.rs
+++ b/crates/api/benches/vpn_query.rs
@@ -21,6 +21,15 @@ use serde_json::json;
 use tokio::sync::{mpsc, oneshot};
 use tonic::Request;
 
+#[cfg(feature = "vpn-query-allocation")]
+const ALLOC: usize = 0;
+#[cfg(feature = "vpn-query-allocation")]
+const ALLOC_ZEROED: usize = 1;
+#[cfg(feature = "vpn-query-allocation")]
+const REALLOC: usize = 2;
+#[cfg(feature = "vpn-query-allocation")]
+const DEALLOC: usize = 3;
+
 #[cfg(not(feature = "vpn-query-allocation"))]
 #[global_allocator]
 static ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
@@ -31,7 +40,10 @@ struct TrackingAllocator {
     locked: AtomicBool,
     enabled: AtomicBool,
     live: AtomicUsize,
+    baseline: AtomicUsize,
     peak: AtomicUsize,
+    calls: [AtomicUsize; 4],
+    requested_bytes: [AtomicUsize; 4],
 }
 
 #[cfg(feature = "vpn-query-allocation")]
@@ -42,21 +54,41 @@ impl TrackingAllocator {
             locked: AtomicBool::new(false),
             enabled: AtomicBool::new(false),
             live: AtomicUsize::new(0),
+            baseline: AtomicUsize::new(0),
             peak: AtomicUsize::new(0),
+            calls: [const { AtomicUsize::new(0) }; 4],
+            requested_bytes: [const { AtomicUsize::new(0) }; 4],
         }
     }
 
     fn begin(&self) {
         let _guard = self.guard();
         let live = self.live.load(Ordering::Relaxed);
+        self.baseline.store(live, Ordering::Relaxed);
         self.peak.store(live, Ordering::Relaxed);
+        for counter in self.calls.iter().chain(&self.requested_bytes) {
+            counter.store(0, Ordering::Relaxed);
+        }
         self.enabled.store(true, Ordering::Relaxed);
     }
 
-    fn end(&self) -> usize {
+    fn end(&self) -> AllocationSnapshot {
         let _guard = self.guard();
         self.enabled.store(false, Ordering::Relaxed);
-        self.peak.load(Ordering::Relaxed)
+        let baseline = self.baseline.load(Ordering::Relaxed);
+        let peak = self.peak.load(Ordering::Relaxed);
+        AllocationSnapshot {
+            calls: std::array::from_fn(|index| self.calls[index].load(Ordering::Relaxed)),
+            requested_bytes: std::array::from_fn(|index| {
+                self.requested_bytes[index].load(Ordering::Relaxed)
+            }),
+            baseline_live_requested_bytes: baseline,
+            final_live_requested_bytes: self.live.load(Ordering::Relaxed),
+            peak_live_requested_bytes: peak,
+            peak_delta_requested_bytes: peak
+                .checked_sub(baseline)
+                .expect("allocator peak fell below query baseline"),
+        }
     }
 
     fn guard(&self) -> AllocationGuard<'_> {
@@ -76,6 +108,24 @@ impl TrackingAllocator {
             self.peak.fetch_max(live, Ordering::Relaxed);
         }
     }
+
+    fn record_request(&self, operation: usize, requested: usize) {
+        if self.enabled.load(Ordering::Relaxed) {
+            self.calls[operation].fetch_add(1, Ordering::Relaxed);
+            self.requested_bytes[operation].fetch_add(requested, Ordering::Relaxed);
+        }
+    }
+}
+
+#[cfg(feature = "vpn-query-allocation")]
+#[derive(Debug)]
+struct AllocationSnapshot {
+    calls: [usize; 4],
+    requested_bytes: [usize; 4],
+    baseline_live_requested_bytes: usize,
+    final_live_requested_bytes: usize,
+    peak_live_requested_bytes: usize,
+    peak_delta_requested_bytes: usize,
 }
 
 #[cfg(feature = "vpn-query-allocation")]
@@ -94,6 +144,7 @@ impl Drop for AllocationGuard<'_> {
 unsafe impl GlobalAlloc for TrackingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let _guard = self.guard();
+        self.record_request(ALLOC, layout.size());
         let ptr = unsafe { self.inner.alloc(layout) };
         if !ptr.is_null() {
             self.add(layout.size());
@@ -102,6 +153,7 @@ unsafe impl GlobalAlloc for TrackingAllocator {
     }
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         let _guard = self.guard();
+        self.record_request(ALLOC_ZEROED, layout.size());
         let ptr = unsafe { self.inner.alloc_zeroed(layout) };
         if !ptr.is_null() {
             self.add(layout.size());
@@ -110,6 +162,7 @@ unsafe impl GlobalAlloc for TrackingAllocator {
     }
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
         let _guard = self.guard();
+        self.record_request(REALLOC, new_size);
         let resized = unsafe { self.inner.realloc(ptr, layout, new_size) };
         if !resized.is_null() {
             if new_size >= layout.size() {
@@ -123,6 +176,7 @@ unsafe impl GlobalAlloc for TrackingAllocator {
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         let _guard = self.guard();
+        self.record_request(DEALLOC, layout.size());
         unsafe { self.inner.dealloc(ptr, layout) };
         self.live.fetch_sub(layout.size(), Ordering::Relaxed);
     }
@@ -143,9 +197,20 @@ struct QueryReceipt {
     post_actor_ns: u64,
     actor_rows: usize,
     actor_capacity: usize,
+    actor_snapshot_lower_bound_bytes: usize,
     returned_rows: usize,
     dispatch: u64,
     checksum: u64,
+}
+
+fn actor_snapshot_lower_bound_bytes(rows: usize, capacity: usize) -> usize {
+    capacity
+        .checked_mul(std::mem::size_of::<VpnRibRoute>())
+        .and_then(|route_bytes| {
+            rows.checked_mul(std::mem::size_of::<MplsLabelEntry>())
+                .and_then(|label_bytes| route_bytes.checked_add(label_bytes))
+        })
+        .expect("VPN RIB actor snapshot lower bound overflow")
 }
 
 #[derive(Debug)]
@@ -235,6 +300,8 @@ async fn query(
             .await
             .map_err(|_| CapacityCensored("actor_receipt"))?
             .expect("VPN RIB actor receipt channel closed");
+    let actor_snapshot_lower_bound_bytes =
+        actor_snapshot_lower_bound_bytes(actor_rows, actor_capacity);
     let service_receipt = tokio::time::timeout_at(deadline, service_rx.recv())
         .await
         .map_err(|_| CapacityCensored("service_receipt"))?
@@ -256,6 +323,7 @@ async fn query(
             .expect("service_method_ns underflowed actor_handler_ns"),
         actor_rows,
         actor_capacity,
+        actor_snapshot_lower_bound_bytes,
         returned_rows: service_receipt.returned_rows,
         dispatch,
         checksum,
@@ -266,6 +334,10 @@ fn verify(receipt: &QueryReceipt, routes: usize, filtered: bool, dispatch: u64) 
     let expected_rows = if filtered { routes / PEERS } else { routes };
     assert_eq!(receipt.actor_rows, routes);
     assert!(receipt.actor_capacity >= routes);
+    assert_eq!(
+        receipt.actor_snapshot_lower_bound_bytes,
+        actor_snapshot_lower_bound_bytes(receipt.actor_rows, receipt.actor_capacity)
+    );
     assert_eq!(receipt.returned_rows, expected_rows);
     assert_eq!(receipt.dispatch, dispatch);
     assert_eq!(receipt.checksum, expected_checksum(routes, filtered));
@@ -282,6 +354,8 @@ async fn run(
     case: &str,
     output: &str,
     timeout: Duration,
+    declared_cpu: usize,
+    linux_affinity: &str,
 ) -> Result<(), CapacityCensored> {
     let (primary_tx, primary_rx) = mpsc::channel(32);
     let (query_tx, query_rx) = mpsc::channel(8);
@@ -357,29 +431,38 @@ async fn run(
     #[cfg(feature = "vpn-query-allocation")]
     ALLOCATOR.begin();
     let filtered = case == "F";
-    let receipt = query(
+    let query_result = query(
         &service,
         &mut actor_rx,
         &mut service_rx,
         if filtered { "10.0.0.1" } else { "" },
         timeout,
     )
-    .await?;
+    .await;
+    let allocation = allocation_snapshot();
+    let receipt = query_result?;
     verify(&receipt, routes, filtered, 1);
+    let (allocation_json, peak_live_requested_bytes) = allocation_evidence(
+        allocation.as_ref(),
+        receipt.actor_snapshot_lower_bound_bytes,
+    );
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs();
     let document = json!({
-        "schema": 1,
+        "schema": 2,
         "allocator": "tikv-jemallocator",
         "mode": if cfg!(feature = "vpn-query-allocation") { "allocation" } else { "timing" },
         "timestamp_unix": timestamp,
+        "declared_cpu": declared_cpu,
+        "linux_affinity": linux_affinity,
         "routes": routes,
         "peers": PEERS,
         "case": case,
         "query": receipt_json(&receipt),
-        "peak_live_requested_bytes": peak_live_requested(),
+        "allocation": allocation_json,
+        "peak_live_requested_bytes": peak_live_requested_bytes,
         "vmrss_bytes": read_status_kib("VmRSS").map(|value| value * 1024),
         "vmhwm_bytes": read_status_kib("VmHWM").map(|value| value * 1024),
     });
@@ -389,13 +472,50 @@ async fn run(
 }
 
 #[cfg(feature = "vpn-query-allocation")]
-fn peak_live_requested() -> Option<usize> {
+fn allocation_snapshot() -> Option<AllocationSnapshot> {
     Some(ALLOCATOR.end())
 }
 
 #[cfg(not(feature = "vpn-query-allocation"))]
-fn peak_live_requested() -> Option<usize> {
+fn allocation_snapshot() -> Option<()> {
     None
+}
+
+#[cfg(feature = "vpn-query-allocation")]
+fn allocation_evidence(
+    value: Option<&AllocationSnapshot>,
+    lower_bound: usize,
+) -> (serde_json::Value, Option<usize>) {
+    let value = value.expect("allocation snapshot missing");
+    assert!(
+        value.peak_delta_requested_bytes >= lower_bound,
+        "query peak delta did not retain the actor snapshot lower bound"
+    );
+    (
+        json!({
+            "alloc_calls": value.calls[ALLOC],
+            "alloc_requested_bytes": value.requested_bytes[ALLOC],
+            "alloc_zeroed_calls": value.calls[ALLOC_ZEROED],
+            "alloc_zeroed_requested_bytes": value.requested_bytes[ALLOC_ZEROED],
+            "realloc_calls": value.calls[REALLOC],
+            "realloc_requested_bytes": value.requested_bytes[REALLOC],
+            "dealloc_calls": value.calls[DEALLOC],
+            "dealloc_requested_bytes": value.requested_bytes[DEALLOC],
+            "baseline_live_requested_bytes": value.baseline_live_requested_bytes,
+            "final_live_requested_bytes": value.final_live_requested_bytes,
+            "peak_live_requested_bytes": value.peak_live_requested_bytes,
+            "peak_delta_requested_bytes": value.peak_delta_requested_bytes,
+        }),
+        Some(value.peak_live_requested_bytes),
+    )
+}
+
+#[cfg(not(feature = "vpn-query-allocation"))]
+fn allocation_evidence(
+    _value: Option<&()>,
+    _lower_bound: usize,
+) -> (serde_json::Value, Option<usize>) {
+    (serde_json::Value::Null, None)
 }
 
 fn read_status_kib(field: &str) -> Option<u64> {
@@ -409,6 +529,16 @@ fn read_status_kib(field: &str) -> Option<u64> {
         .ok()
 }
 
+fn read_linux_affinity() -> Option<String> {
+    std::fs::read_to_string("/proc/self/status")
+        .ok()?
+        .lines()
+        .find(|line| line.starts_with("Cpus_allowed_list:"))?
+        .split_whitespace()
+        .nth(1)
+        .map(str::to_owned)
+}
+
 fn receipt_json(value: &QueryReceipt) -> serde_json::Value {
     json!({
         "actor_handler_ns": value.actor_ns,
@@ -416,6 +546,9 @@ fn receipt_json(value: &QueryReceipt) -> serde_json::Value {
         "post_actor_ns": value.post_actor_ns,
         "actor_rows": value.actor_rows,
         "actor_capacity": value.actor_capacity,
+        "vpn_rib_route_size_bytes": std::mem::size_of::<VpnRibRoute>(),
+        "mpls_label_entry_size_bytes": std::mem::size_of::<MplsLabelEntry>(),
+        "actor_snapshot_lower_bound_bytes": value.actor_snapshot_lower_bound_bytes,
         "returned_rows": value.returned_rows,
         "dispatch": value.dispatch,
         "checksum": value.checksum,
@@ -424,14 +557,16 @@ fn receipt_json(value: &QueryReceipt) -> serde_json::Value {
 
 fn main() {
     let args: Vec<_> = std::env::args().filter(|arg| arg != "--bench").collect();
-    let (routes, case, output, timeout) = match args.as_slice() {
-        [_, mode, case, output] if mode == "smoke" && (case == "U" || case == "F") => (
+    let (routes, case, output, timeout, declared_cpu) = match args.as_slice() {
+        [_, mode, case, output, cpu] if mode == "smoke" && (case == "U" || case == "F") => (
             SMOKE_ROUTES,
             case.as_str(),
             output.as_str(),
             Duration::from_secs(10),
+            cpu.parse::<usize>()
+                .expect("declared CPU must be an integer"),
         ),
-        [_, mode, count, case, output] if mode == "cell" && (case == "U" || case == "F") => {
+        [_, mode, count, case, output, cpu] if mode == "cell" && (case == "U" || case == "F") => {
             let routes = count.parse::<usize>().unwrap();
             assert!([10_000, 100_000, 1_000_000].contains(&routes));
             (
@@ -439,14 +574,22 @@ fn main() {
                 case.as_str(),
                 output.as_str(),
                 Duration::from_secs(120),
+                cpu.parse::<usize>()
+                    .expect("declared CPU must be an integer"),
             )
         }
         _ => {
             panic!(
-                "usage: vpn_query smoke U|F OUTPUT | vpn_query cell 10000|100000|1000000 U|F OUTPUT"
+                "usage: vpn_query smoke U|F OUTPUT CPU | vpn_query cell 10000|100000|1000000 U|F OUTPUT CPU"
             )
         }
     };
+    let linux_affinity = read_linux_affinity().expect("Linux CPU affinity is unavailable");
+    assert_eq!(
+        linux_affinity,
+        declared_cpu.to_string(),
+        "Linux affinity differs from the declared CPU"
+    );
     let result = if std::env::var_os("RUSTBGPD_VPN_QUERY_FORCE_CENSOR").is_some() {
         Err(CapacityCensored("forced_fixture"))
     } else {
@@ -454,12 +597,21 @@ fn main() {
             .enable_all()
             .build()
             .unwrap()
-            .block_on(run(routes, case, output, timeout))
+            .block_on(run(
+                routes,
+                case,
+                output,
+                timeout,
+                declared_cpu,
+                &linux_affinity,
+            ))
     };
     if let Err(CapacityCensored(phase)) = result {
         let document = json!({
-            "schema": 1,
+            "schema": 2,
             "mode": if cfg!(feature = "vpn-query-allocation") { "allocation" } else { "timing" },
+            "declared_cpu": declared_cpu,
+            "linux_affinity": linux_affinity,
             "routes": routes,
             "case": case,
             "outcome": "capacity_censored",

--- a/docs/perf/vpn-rib-query-occupancy-method.md
+++ b/docs/perf/vpn-rib-query-occupancy-method.md
@@ -17,7 +17,8 @@ contaminating timing:
 
 - `vpn_query_timing` uses bare jemalloc and emits timing evidence.
 - `vpn_query_allocation` wraps jemalloc with absolute live-requested-byte
-  accounting. `peak_live_requested_bytes > 8 GiB` is capacity-censored.
+  accounting: operation calls/requested bytes and baseline/final/peak/delta
+  live bytes. Above 8 GiB is capacity-censored.
   `/proc` `VmRSS` and `VmHWM` are recorded only as observations and never drive
   classification. Its allocator forwarding and bookkeeping are serialized by
   a no-allocation spin lock, so this mode is diagnostic; its timings are not
@@ -27,9 +28,8 @@ The driver builds each executable once, copies it into the campaign directory,
 records SHA-256, commit, and `rustc` provenance, then refuses missing, changed,
 or corrupt binaries. Commit, Git tree, clean status, toolchain, and binary
 hashes are captured before the locked build and rechecked through completion.
-It acquires the shared retained-performance host lock and
-requires the same load, CPU-governor, and competing-process fence before build
-and every process.
+Every executable is pinned to one required `--cpu`; manifest and receipts require
+the same one-CPU `Cpus_allowed_list`. Host lock/load/governor/process fences apply.
 
 ## Fixed campaign
 
@@ -59,6 +59,9 @@ Every setup/query timeout produces the typed `capacity_censored` process
 outcome. The driver catches only its exit status 75, stops all remaining cells,
 and verifies the censor receipt; every other nonzero exit is a hard failure.
 
+Peak delta must cover `actor_capacity * size_of::<VpnRibRoute>() + actor_rows *
+size_of::<MplsLabelEntry>()`; the label term is one-label deep clone and values agree.
+
 Classifier precedence is exact:
 
 1. `capacity_censored`
@@ -82,7 +85,7 @@ bash bench/tests/test-vpn-query-receipt.sh
 An operator may run the full retained campaign on a dedicated host:
 
 ```console
-bench/run-vpn-query-campaign.sh /uncommitted/output-directory
+bench/run-vpn-query-campaign.sh --cpu 8 /uncommitted/output-directory
 ```
 
 The output is intentionally not a committed result. A valid campaign is checked


### PR DESCRIPTION
## Summary

- pin the VPN query campaign to one declared CPU and record the observed Linux affinity
- record whole-query allocation calls, requested bytes, baseline/final/peak live bytes, and deterministic actor snapshot lower bounds
- compute the lower bound with checked arithmetic and fail explicitly on overflow
- make the receipt verifier reject affinity, allocation, live-byte, and lower-bound drift before any full campaign results are accepted
- document the measurement contract without changing production API, protobuf, or RIB behavior

## Scope

Seven harness, verifier, test, benchmark, and method files; 350 additions and 60 deletions. No full 48-process campaign is run or claimed in this PR.

## Verification

- all 9 Python verifier cases
- focused campaign and receipt shell suites
- two real 256-route release smokes
- ShellCheck and bash syntax
- workspace fmt, all-target/all-feature clippy, all-feature tests, warning-denying rustdoc, diff check, and push hooks
- targeted all-feature benchmark clippy after the review repair

## Load-bearing proofs

- deleting only the actor lower-bound comparison makes exactly the internally consistent lower-bound mutation fail
- deleting only the manifest single-CPU comparison makes exactly the fixture that consistently changes the manifest, all 48 timing receipts, and the allocation receipt to `8-9` fail
- restoring unchecked lower-bound arithmetic makes the structural campaign gate fail
- removing runner affinity, allocator accounting sites, receipt fields, live-byte consistency, or checksum/inventory relationships independently makes retained gates red

No performance result is claimed; this change makes the later measurement trustworthy.