### PR TITLE
Fail startup when the health listener cannot bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   edited desired values for the next restart, preventing later runtime-added
   peers from resolving against an ASN or router ID the daemon never adopted.
 
+- A configured Prometheus HTTP listener that cannot bind now fails startup
+  with exit code 1 and reports the address and operating-system cause, instead
+  of leaving a live daemon without its `/metrics`, `/livez`, and `/readyz`
+  surface. Omitting `prometheus_addr` remains supported.
+
 - The shipped empty Adj-RIB-In alert now checks the current per-session
   Established gauge instead of inferring state from lifetime counters, and
   correctly aggregates scoped siblings to peer identity before joining the

--- a/docs/adr/0022-grpc-server-supervision.md
+++ b/docs/adr/0022-grpc-server-supervision.md
@@ -24,8 +24,8 @@ Options considered:
    restart the entire process.
 
 3. **Log and continue** — not appropriate for the primary management
-   interface. Acceptable for the metrics server (read-only, supplementary)
-   but not for the gRPC control plane.
+   interface. It is also unsafe for a configured telemetry listener now that
+   the same socket carries the deployment `/livez` and `/readyz` probes.
 
 ## Decision
 
@@ -48,6 +48,11 @@ The normal shutdown path (Shutdown RPC) still works because it fires
 `rpc_shutdown_rx` before the gRPC server exits — the select branch for
 `rpc_shutdown_rx` wins the race.
 
+The optional metrics/readiness listener is bound before its serving task is
+spawned. If the configured address cannot be bound, startup exits 1 with the
+address and operating-system cause. Once bound, the read-only HTTP serving task
+remains fire-and-forget; this decision does not add general task supervision.
+
 ## Consequences
 
 **Positive:**
@@ -60,5 +65,7 @@ The normal shutdown path (Shutdown RPC) still works because it fires
 - A transient gRPC failure causes full daemon restart. This is acceptable
   because gRPC failures are not expected in normal operation, and a full
   restart is a clean recovery path.
-- The metrics server remains unsupervised (fire-and-forget). This is
-  intentional — the metrics endpoint is supplementary and read-only.
+- The metrics/readiness serving task remains unsupervised after its startup
+  bind succeeds. This is intentional: the narrow startup invariant prevents a
+  daemon from starting without its configured health surface without turning
+  this ADR into general task supervision.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2326,7 +2326,7 @@ fn main() {
                   includes a valid config that was warned about\n  \
                1  The config was rejected, or --check --strict found warnings.\n     \
                   A running daemon exits 1 on a component failure that ends it\n     \
-                  (BGP listener bind, unexpected gRPC server exit)\n  \
+                  (BGP or metrics/readiness listener bind, unexpected gRPC server exit)\n  \
                2  Invalid invocation (unknown flag combination, missing argument)\n  \
                70 Internal error",
             env!("CARGO_PKG_VERSION")
@@ -4629,6 +4629,14 @@ async fn run<T>(
     // Spawn after startup wiring and initial peer registration so readiness
     // cannot go green while initialization is still in progress.
     if let Some(prometheus_addr) = config.prometheus_addr() {
+        let metrics_listener = metrics_server::MetricsListener::bind(prometheus_addr)
+            .await
+            .unwrap_or_else(|error| {
+                fatal_startup_error(
+                    "failed to bind configured metrics/readiness listener",
+                    error,
+                )
+            });
         let metrics_clone = metrics.clone();
         let readiness_probe = rustbgpd_api::health_probe::CoreReadinessProbe::new(
             peer_mgr_tx.clone(),
@@ -4638,7 +4646,7 @@ async fn run<T>(
         .with_rib_readiness(rib_readiness_tx.clone())
         .with_gate(daemon_gate.clone());
         tokio::spawn(async move {
-            metrics_server::serve_metrics(prometheus_addr, metrics_clone, readiness_probe).await;
+            metrics_server::serve_metrics(metrics_listener, metrics_clone, readiness_probe).await;
         });
     }
 

--- a/src/metrics_server.rs
+++ b/src/metrics_server.rs
@@ -15,21 +15,36 @@ const READ_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_REQUEST_LINE: usize = 8192;
 const MAX_CONNECTIONS: usize = 64;
 
-pub async fn serve_metrics(
+pub struct MetricsListener {
     addr: SocketAddr,
+    listener: TcpListener,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("address {addr}: {source}")]
+pub struct MetricsListenerBindError {
+    addr: SocketAddr,
+    #[source]
+    source: std::io::Error,
+}
+
+impl MetricsListener {
+    pub async fn bind(addr: SocketAddr) -> Result<Self, MetricsListenerBindError> {
+        let listener = TcpListener::bind(addr)
+            .await
+            .map_err(|source| MetricsListenerBindError { addr, source })?;
+        let addr = listener.local_addr().unwrap_or(addr);
+        Ok(Self { addr, listener })
+    }
+}
+
+pub async fn serve_metrics(
+    server: MetricsListener,
     metrics: BgpMetrics,
     readiness_probe: CoreReadinessProbe,
 ) {
-    let listener = match TcpListener::bind(addr).await {
-        Ok(l) => {
-            info!(%addr, "metrics server listening");
-            l
-        }
-        Err(e) => {
-            error!(%addr, error = %e, "failed to bind metrics server");
-            return;
-        }
-    };
+    let MetricsListener { addr, listener } = server;
+    info!(%addr, "metrics server listening");
 
     let semaphore = Arc::new(Semaphore::new(MAX_CONNECTIONS));
 
@@ -184,21 +199,13 @@ mod tests {
 
     async fn start_server(readiness_probe: CoreReadinessProbe) -> SocketAddr {
         let metrics = BgpMetrics::new();
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let semaphore = Arc::new(Semaphore::new(MAX_CONNECTIONS));
-
+        let server = MetricsListener::bind("127.0.0.1:0".parse().unwrap())
+            .await
+            .unwrap();
+        let addr = server.listener.local_addr().unwrap();
+        assert_eq!(server.addr, addr);
         tokio::spawn(async move {
-            loop {
-                let permit = semaphore.clone().acquire_owned().await.unwrap();
-                let (stream, _) = listener.accept().await.unwrap();
-                let m = metrics.clone();
-                let probe = readiness_probe.clone();
-                tokio::spawn(async move {
-                    let _ = handle_connection(stream, &m, &probe).await;
-                    drop(permit);
-                });
-            }
+            serve_metrics(server, metrics, readiness_probe).await;
         });
 
         addr

--- a/tests/grpc_failure_exit_code.rs
+++ b/tests/grpc_failure_exit_code.rs
@@ -2,10 +2,10 @@
 //!
 //! Operator-initiated shutdown (SIGTERM) exits 0; a component failure
 //! exits non-zero, so supervisors like systemd with `Restart=on-failure`
-//! restart the daemon instead of treating it as a clean stop. Two
-//! component failures are covered, both provoked by holding the port the
-//! daemon needs: the gRPC server exiting unexpectedly, and the BGP
-//! listener failing to bind.
+//! restart the daemon instead of treating it as a clean stop. Three
+//! component failures are covered, all provoked by holding the port the
+//! daemon needs: the gRPC server exiting unexpectedly, the BGP listener
+//! failing to bind, and the metrics/readiness listener failing to bind.
 
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
@@ -55,12 +55,20 @@ impl Drop for Daemon {
     }
 }
 
-fn write_config(dir: &Path, grpc_port: u16, bgp_port: u16) -> PathBuf {
+fn write_config_with_metrics(
+    dir: &Path,
+    grpc_port: u16,
+    bgp_port: u16,
+    metrics_port: Option<u16>,
+) -> PathBuf {
     let runtime_dir = dir.join("runtime");
     std::fs::create_dir_all(&runtime_dir).expect("create runtime dir");
     let token_path = dir.join("grpc-token");
     std::fs::write(&token_path, "exit-code-test-token\n").expect("write test token");
     let config_path = dir.join("rustbgpd.toml");
+    let prometheus_addr = metrics_port
+        .map(|port| format!("prometheus_addr = \"127.0.0.1:{port}\""))
+        .unwrap_or_default();
     let config = format!(
         r#"
 [security.grpc]
@@ -77,6 +85,7 @@ runtime_state_dir = "{runtime_dir}"
 
 [global.telemetry]
 log_format = "json"
+{prometheus_addr}
 
 [global.telemetry.grpc_tcp]
 address = "127.0.0.1:{grpc_port}"
@@ -88,6 +97,10 @@ principal = "rustbgpd://observer/exit-code-test"
     );
     std::fs::write(&config_path, config).expect("write test config");
     config_path
+}
+
+fn write_config(dir: &Path, grpc_port: u16, bgp_port: u16) -> PathBuf {
+    write_config_with_metrics(dir, grpc_port, bgp_port, None)
 }
 
 fn spawn_daemon(dir: &Path, config_path: &Path) -> Daemon {
@@ -135,6 +148,36 @@ fn grpc_bind_failure_exits_nonzero() {
         Some(1),
         "gRPC server failure must exit 1, got {status}\n{}",
         daemon.logs()
+    );
+}
+
+#[test]
+fn metrics_listener_bind_failure_exits_nonzero() {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let occupied = TcpListener::bind("127.0.0.1:0").expect("bind occupied metrics port");
+    let metrics_port = occupied.local_addr().unwrap().port();
+    let config_path =
+        write_config_with_metrics(temp.path(), free_port(), free_port(), Some(metrics_port));
+
+    let mut daemon = spawn_daemon(temp.path(), &config_path);
+    let status = daemon.wait_within(Duration::from_secs(30));
+    let logs = daemon.logs();
+    assert!(
+        logs.contains("failed to bind configured metrics/readiness listener"),
+        "the diagnostic must identify the configured health surface\n{logs}"
+    );
+    assert!(
+        logs.contains(&format!("127.0.0.1:{metrics_port}")),
+        "the diagnostic must identify the configured address\n{logs}"
+    );
+    assert!(
+        logs.contains("Address already in use"),
+        "the diagnostic must preserve the bind cause\n{logs}"
+    );
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "metrics/readiness bind failure must exit 1, got {status}\n{logs}"
     );
 }
 


### PR DESCRIPTION
## Summary

- bind the configured metrics/readiness listener synchronously before task spawn
- preserve the configured address and operating-system cause in startup errors
- record the actual bound local address after success so ephemeral-port logs are truthful
- exit with status 1 when the configured listener cannot bind instead of running without `/metrics`, `/livez`, and `/readyz`
- keep omitted `prometheus_addr` optional and hand the successfully bound socket into the unchanged serving loop
- align the supervision ADR and changelog with the shipped startup contract

## Scope

Five files, 106 additions and 36 deletions. No general task-supervision redesign, protocol/API change, or new HTTP stack.

## Verification

- startup exit-code integration: 4/4
- metrics server endpoint and resource-bound tests: 12/12
- workspace fmt, clippy with warnings denied, full tests, warning-denying rustdoc, diff check, and push hooks

## Load-bearing proofs

- exact old main rebuilt in an isolated target stays alive for 30 seconds after logging `AddrInUse`; the new regression fails there
- reverting fatal propagation makes the startup-failure integration time out
- dropping the handed bound listener makes the live `/livez` endpoint test fail
- restoring requested-address storage makes the endpoint test fail with `127.0.0.1:0` versus the actual ephemeral port

Omitted configuration and all existing endpoint behavior remain unchanged.