### PR TITLE
Bound MRT catch-up and abandoned snapshot work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- **MRT dump work is bounded after delays, impossible output paths, and
+  canceled requests.** Export skips missed ticks, preflights its output path
+  before cloning the RIB, and prevents encode/publication when cancellation is
+  observed while awaiting the RIB reply. A request already canceled when the
+  actor handles it skips materialization; a synchronous clone already running
+  is not interruptible. Failures remain non-fatal and on-time bytes unchanged.
+
 ### Added
 
 - The shipped Prometheus rule pack now pages on outbound BGP work dropped

--- a/crates/mrt/src/manager.rs
+++ b/crates/mrt/src/manager.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use tokio::sync::{mpsc, oneshot};
+use tokio::time::MissedTickBehavior;
 use tracing::{debug, error, info};
 
 use rustbgpd_rib::RibUpdate;
@@ -12,6 +13,12 @@ use rustbgpd_rib::RibUpdate;
 use crate::codec;
 use crate::types::{MrtSnapshotData, MrtWriterConfig};
 use crate::writer;
+
+fn periodic_interval(period: Duration) -> tokio::time::Interval {
+    let mut interval = tokio::time::interval(period);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    interval
+}
 
 /// MRT dump manager. Periodically queries the RIB and writes `TABLE_DUMP_V2` files.
 pub struct MrtManager {
@@ -40,7 +47,7 @@ impl MrtManager {
 
     /// Run the manager loop. Returns when the trigger channel closes.
     pub async fn run(mut self) {
-        let mut interval = tokio::time::interval(Duration::from_secs(self.config.dump_interval));
+        let mut interval = periodic_interval(Duration::from_secs(self.config.dump_interval));
         // Skip the immediate first tick — the first dump will fire after one interval.
         interval.tick().await;
 
@@ -54,12 +61,12 @@ impl MrtManager {
             tokio::select! {
                 _ = interval.tick() => {
                     debug!("MRT periodic dump triggered");
-                    if let Err(e) = self.do_dump().await {
+                    if let Err(e) = self.do_dump(None).await {
                         error!(error = %e, "periodic MRT dump failed");
                     }
                 }
                 maybe_reply = self.trigger_rx.recv() => {
-                    if let Some(reply) = maybe_reply {
+                    if let Some(mut reply) = maybe_reply {
                         // The reply channel doubles as the cancel token: a
                         // request whose caller is gone (e.g. a canceled gRPC
                         // dump request queued behind a slow dump) is skipped
@@ -69,7 +76,7 @@ impl MrtManager {
                             continue;
                         }
                         debug!("MRT on-demand dump triggered");
-                        let result = self.do_dump().await;
+                        let result = self.do_dump(Some(&mut reply)).await;
                         let _ = reply.send(result);
                     } else {
                         debug!("MRT trigger channel closed, shutting down");
@@ -82,8 +89,20 @@ impl MrtManager {
         info!("MRT manager shutting down");
     }
 
-    async fn do_dump(&self) -> Result<PathBuf, String> {
-        let snapshot = self.query_snapshot().await?;
+    async fn do_dump(
+        &self,
+        cancel: Option<&mut oneshot::Sender<Result<PathBuf, String>>>,
+    ) -> Result<PathBuf, String> {
+        // Reject structurally impossible output paths before asking the
+        // RIB actor to clone a full snapshot. Permissions and storage can
+        // still change before publication, so the write remains fallible.
+        let config = self.config.clone();
+        tokio::task::spawn_blocking(move || writer::prepare_output_dir(&config))
+            .await
+            .map_err(|e| format!("output directory preflight join error: {e}"))?
+            .map_err(|e| format!("output directory preflight error: {e}"))?;
+
+        let snapshot = self.query_snapshot(cancel).await?;
 
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -110,15 +129,45 @@ impl MrtManager {
             })
     }
 
-    async fn query_snapshot(&self) -> Result<MrtSnapshotData, String> {
+    async fn query_snapshot(
+        &self,
+        mut cancel: Option<&mut oneshot::Sender<Result<PathBuf, String>>>,
+    ) -> Result<MrtSnapshotData, String> {
         let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::QueryMrtSnapshot { reply: reply_tx })
-            .await
-            .map_err(|e| format!("RIB channel closed: {e}"))?;
-        reply_rx
-            .await
-            .map_err(|e| format!("RIB reply dropped: {e}"))
+        let query = RibUpdate::QueryMrtSnapshot { reply: reply_tx };
+
+        if let Some(cancel) = cancel.as_deref_mut() {
+            tokio::select! {
+                biased;
+                () = cancel.closed() => {
+                    return Err("MRT dump canceled while queueing RIB snapshot".to_string());
+                }
+                result = self.rib_tx.send(query) => {
+                    result.map_err(|e| format!("RIB channel closed: {e}"))?;
+                }
+            }
+        } else {
+            self.rib_tx
+                .send(query)
+                .await
+                .map_err(|e| format!("RIB channel closed: {e}"))?;
+        }
+
+        if let Some(cancel) = cancel {
+            tokio::select! {
+                biased;
+                () = cancel.closed() => {
+                    Err("MRT dump canceled while awaiting RIB snapshot".to_string())
+                }
+                result = reply_rx => {
+                    result.map_err(|e| format!("RIB reply dropped: {e}"))
+                }
+            }
+        } else {
+            reply_rx
+                .await
+                .map_err(|e| format!("RIB reply dropped: {e}"))
+        }
     }
 }
 
@@ -128,6 +177,35 @@ mod tests {
 
     use super::*;
     use crate::types::MrtPeerEntry;
+
+    fn test_config(output_dir: PathBuf) -> MrtWriterConfig {
+        MrtWriterConfig {
+            output_dir,
+            dump_interval: 86400,
+            compress: false,
+            file_prefix: "rib".to_string(),
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn periodic_interval_skips_missed_tick_bursts() {
+        let start = tokio::time::Instant::now();
+        let mut interval = periodic_interval(Duration::from_secs(10));
+        interval.tick().await;
+
+        // A dump held the manager for 35 seconds. Exactly one overdue tick is
+        // consumed; the following tick must be the next cadence boundary, not
+        // another member of the default Burst backlog.
+        tokio::time::advance(Duration::from_secs(35)).await;
+        assert_eq!(
+            interval.tick().await.duration_since(start),
+            Duration::from_secs(10)
+        );
+        assert_eq!(
+            interval.tick().await.duration_since(start),
+            Duration::from_secs(40)
+        );
+    }
 
     #[tokio::test]
     async fn manager_shuts_down_on_trigger_close() {
@@ -251,5 +329,138 @@ mod tests {
         handle.await.unwrap();
         let snapshots = rib_handler.await.unwrap();
         assert_eq!(snapshots, 1, "canceled dump must not query the RIB");
+    }
+
+    #[tokio::test]
+    async fn impossible_output_path_fails_before_rib_snapshot_query() {
+        let dir = tempfile::tempdir().unwrap();
+        let output_file = dir.path().join("not-a-directory");
+        std::fs::write(&output_file, b"occupied").unwrap();
+
+        let (rib_tx, mut rib_rx) = mpsc::channel(16);
+        let (trigger_tx, trigger_rx) = mpsc::channel(16);
+        let manager = MrtManager::new(
+            test_config(output_file.clone()),
+            rib_tx,
+            trigger_rx,
+            Ipv4Addr::LOCALHOST,
+        );
+        let handle = tokio::spawn(manager.run());
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        trigger_tx.send(reply_tx).await.unwrap();
+        let error = tokio::time::timeout(Duration::from_secs(2), reply_rx)
+            .await
+            .expect("output preflight must not wait for the RIB")
+            .expect("manager must return the preflight failure")
+            .expect_err("regular-file output path must be rejected");
+        assert!(error.contains("output directory preflight"), "{error}");
+        assert!(
+            rib_rx.try_recv().is_err(),
+            "structurally impossible output must emit zero RIB queries"
+        );
+
+        drop(trigger_tx);
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancellation_while_awaiting_rib_drops_reply_without_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let output_dir = dir.path().join("lazy-output");
+        let (rib_tx, mut rib_rx) = mpsc::channel(16);
+        let (trigger_tx, trigger_rx) = mpsc::channel(16);
+        let manager = MrtManager::new(
+            test_config(output_dir.clone()),
+            rib_tx,
+            trigger_rx,
+            Ipv4Addr::LOCALHOST,
+        );
+        let handle = tokio::spawn(manager.run());
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        trigger_tx.send(reply_tx).await.unwrap();
+        let RibUpdate::QueryMrtSnapshot {
+            reply: snapshot_reply,
+        } = tokio::time::timeout(Duration::from_secs(2), rib_rx.recv())
+            .await
+            .expect("manager did not query the RIB")
+            .expect("RIB query channel closed")
+        else {
+            panic!("unexpected RIB update");
+        };
+
+        // Cancel after the query is enqueued but before the RIB responds.
+        drop(reply_rx);
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !snapshot_reply.is_closed() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("manager retained the RIB reply after caller cancellation");
+
+        assert!(
+            output_dir.is_dir(),
+            "preflight lazily creates the directory"
+        );
+        assert_eq!(
+            std::fs::read_dir(&output_dir).unwrap().count(),
+            0,
+            "canceled dump must not encode or publish a file"
+        );
+
+        drop(snapshot_reply);
+        drop(trigger_tx);
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancellation_while_queueing_on_full_rib_channel_exits_without_dump() {
+        let dir = tempfile::tempdir().unwrap();
+        let output_dir = dir.path().join("lazy-output");
+        let (rib_tx, rib_rx) = mpsc::channel(1);
+        let (filler_reply, _filler_receiver) = oneshot::channel();
+        rib_tx
+            .send(RibUpdate::QueryMrtSnapshot {
+                reply: filler_reply,
+            })
+            .await
+            .unwrap();
+        let (trigger_tx, trigger_rx) = mpsc::channel(1);
+        let manager = MrtManager::new(
+            test_config(output_dir.clone()),
+            rib_tx,
+            trigger_rx,
+            Ipv4Addr::LOCALHOST,
+        );
+        let handle = tokio::spawn(manager.run());
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        trigger_tx.send(reply_tx).await.unwrap();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !output_dir.is_dir() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("manager did not finish output preflight");
+
+        // Preflight proves the manager passed the initial cancellation check.
+        // With the RIB channel still full, only the cancel-aware send select can
+        // let the manager observe shutdown and return.
+        drop(reply_rx);
+        drop(trigger_tx);
+        tokio::time::timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("canceled dump remained blocked queueing the RIB query")
+            .unwrap();
+
+        assert_eq!(rib_rx.len(), 1, "canceled dump enqueued another RIB query");
+        assert_eq!(
+            std::fs::read_dir(&output_dir).unwrap().count(),
+            0,
+            "canceled dump must not publish a file"
+        );
     }
 }

--- a/crates/mrt/src/writer.rs
+++ b/crates/mrt/src/writer.rs
@@ -8,6 +8,15 @@ use tracing::{debug, info};
 
 use crate::types::MrtWriterConfig;
 
+/// Ensure the configured output path exists as a directory.
+///
+/// The manager calls this before asking the RIB actor to materialize a
+/// snapshot. `write_dump` repeats the check so direct library callers retain
+/// the same lazy-directory-creation contract.
+pub(crate) fn prepare_output_dir(config: &MrtWriterConfig) -> std::io::Result<()> {
+    std::fs::create_dir_all(&config.output_dir)
+}
+
 /// Write MRT data to a file using atomic rename.
 ///
 /// Returns the final file path on success.
@@ -17,7 +26,7 @@ use crate::types::MrtWriterConfig;
 /// Returns an error if the output directory cannot be created or the file
 /// cannot be written.
 pub fn write_dump(config: &MrtWriterConfig, data: &[u8]) -> std::io::Result<PathBuf> {
-    std::fs::create_dir_all(&config.output_dir)?;
+    prepare_output_dir(config)?;
 
     let now = Utc::now();
     let timestamp = now.format("%Y%m%d.%H%M%S");

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -53,6 +53,23 @@ use helpers::{
 };
 pub use selection_deferral::{SelectionDeferralConfig, SelectionDeferralWaiterConfig};
 
+fn send_mrt_snapshot(
+    reply: tokio::sync::oneshot::Sender<MrtSnapshotData>,
+    build: impl FnOnce() -> MrtSnapshotData,
+) {
+    // A canceled on-demand dump drops this receiver while the query waits in
+    // the actor mailbox. Check before cloning any peer or route state.
+    if reply.is_closed() {
+        debug!("MRT snapshot query canceled before materialization");
+        return;
+    }
+
+    let snapshot = build();
+    if reply.send(snapshot).is_err() {
+        warn!("MRT snapshot query caller dropped before receiving response");
+    }
+}
+
 #[cfg(any(test, feature = "bench-internals"))]
 #[derive(Clone, Copy, Debug, Default)]
 struct PolicyTransitionStats {
@@ -4911,40 +4928,39 @@ impl RibManager {
     }
 
     fn handle_query_mrt_snapshot(&mut self, reply: tokio::sync::oneshot::Sender<MrtSnapshotData>) {
-        let peers: Vec<MrtPeerEntry> = self
-            .peer_asn
-            .iter()
-            .map(|(&addr, &asn)| MrtPeerEntry {
-                peer_addr: addr,
-                peer_bgp_id: self
-                    .peer_bgp_id
-                    .get(&addr)
-                    .copied()
-                    .unwrap_or(Ipv4Addr::UNSPECIFIED),
-                peer_asn: asn,
-            })
-            .collect();
+        send_mrt_snapshot(reply, || {
+            let peers: Vec<MrtPeerEntry> = self
+                .peer_asn
+                .iter()
+                .map(|(&addr, &asn)| MrtPeerEntry {
+                    peer_addr: addr,
+                    peer_bgp_id: self
+                        .peer_bgp_id
+                        .get(&addr)
+                        .copied()
+                        .unwrap_or(Ipv4Addr::UNSPECIFIED),
+                    peer_asn: asn,
+                })
+                .collect();
 
-        let routes: Vec<_> = self
-            .ribs
-            .values()
-            .flat_map(|rib| rib.iter().cloned())
-            .collect();
+            let routes: Vec<_> = self
+                .ribs
+                .values()
+                .flat_map(|rib| rib.iter().cloned())
+                .collect();
 
-        let evpn_routes: Vec<_> = self
-            .ribs
-            .values()
-            .flat_map(|rib| rib.iter_evpn().cloned())
-            .collect();
+            let evpn_routes: Vec<_> = self
+                .ribs
+                .values()
+                .flat_map(|rib| rib.iter_evpn().cloned())
+                .collect();
 
-        let snapshot = MrtSnapshotData {
-            peers,
-            routes,
-            evpn_routes,
-        };
-        if reply.send(snapshot).is_err() {
-            warn!("MRT snapshot query caller dropped before receiving response");
-        }
+            MrtSnapshotData {
+                peers,
+                routes,
+                evpn_routes,
+            }
+        });
     }
 
     fn handle_query_warm_mrt_snapshot(

--- a/crates/rib/src/manager/tests/explain_mrt.rs
+++ b/crates/rib/src/manager/tests/explain_mrt.rs
@@ -1,5 +1,15 @@
 use super::*;
 
+#[test]
+fn canceled_mrt_snapshot_skips_builder_before_route_clone() {
+    let (reply, receiver) = oneshot::channel();
+    drop(receiver);
+
+    send_mrt_snapshot(reply, || {
+        panic!("closed MRT query must not materialize the snapshot")
+    });
+}
+
 #[tokio::test]
 async fn warm_mrt_snapshot_rejects_session_generation_change_at_rib_fence() {
     let (tx, rx) = mpsc::channel(64);

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2898,7 +2898,7 @@ file_prefix = "rib"         # filename prefix (default "rib")
 
 | Field           | Type    | Required | Default  | Description                              |
 |-----------------|---------|----------|----------|------------------------------------------|
-| `output_dir`    | string  | yes      | --       | Directory for MRT dump files (must exist and be writable) |
+| `output_dir`    | string  | yes      | --       | Directory for MRT dump files (created lazily; must be writable) |
 | `dump_interval` | u64     | no       | 7200     | Seconds between periodic dumps (must be > 0) |
 | `compress`      | bool    | no       | false    | Compress output files with gzip           |
 | `file_prefix`   | string  | no       | `"rib"`  | Filename prefix for dump files            |
@@ -2933,6 +2933,11 @@ IPv4-with-IPv6-NH `MP_REACH_NLRI`).
 
 Peer metadata is retained during Graceful Restart and LLGR transitions, so
 dumps taken during a peer restart window still include correct peer entries.
+
+The output directory is created lazily and prepared before a full RIB snapshot,
+so an impossible path does not incur full-table materialization. Later failures
+remain non-fatal. Delayed dumps skip missed intervals rather than replaying a
+catch-up burst.
 
 When MRT is not configured, no timer or manager task is spawned — zero
 overhead.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -533,9 +533,19 @@ reconnect; use the durable event cursor for gap-free history).
 
 ### MRT dump failure
 
-If the output directory is not writable, the MRT manager logs an error and
-skips that dump cycle. Periodic dumps continue on the next interval. The
-daemon does not crash on MRT failures.
+The output directory is created lazily when a dump is due. If it cannot be
+prepared as a directory, the manager fails that dump before requesting a
+full-table RIB snapshot. If the directory is not writable, or encode/write
+fails later, a periodic dump logs the error and skips that cycle. An on-demand
+`TriggerMrtDump` failure is returned to its caller while the RPC remains
+connected; only write failures also emit a manager error log. Periodic dumps
+continue on the next interval without replaying missed intervals in a catch-up
+burst. The daemon does not crash on MRT failures.
+
+If an on-demand request is already canceled when the RIB actor handles it, the
+actor skips route materialization. Cancellation observed while the manager
+awaits the RIB reply prevents encode and file publication. Snapshot cloning is
+synchronous actor work: a clone already running cannot be interrupted.
 
 ### Peer max-prefix exceeded
 

--- a/docs/adr/0044-mrt-dump-export.md
+++ b/docs/adr/0044-mrt-dump-export.md
@@ -37,7 +37,8 @@ A new `rustbgpd-mrt` crate with four modules:
 - **`manager.rs`** -- `MrtManager` with `tokio::select!` over a periodic
   interval timer and a trigger channel for on-demand dumps. Queries the
   RIB via `QueryMrtSnapshot`, encodes via `spawn_blocking`, writes
-  atomically.
+  atomically. Missed periodic ticks use `Skip`: a delayed dump does not
+  trigger a burst of back-to-back full-table snapshots.
 
 - **`types.rs`** -- `MrtWriterConfig` and re-exports of `MrtPeerEntry`
   and `MrtSnapshotData` from the rib crate.
@@ -90,6 +91,11 @@ RIB state.
   "rib").
 - **SIGHUP:** MRT config changes logged as warning, require restart
   (same as other global config).
+- **Failure and cancellation:** output preparation precedes
+  `QueryMrtSnapshot`; all dump failures remain non-fatal. Cancellation observed
+  while awaiting the reply prevents encode/publication, and a request already
+  canceled when the actor handles it skips materialization. A synchronous
+  snapshot clone already running is not interruptible.
 
 ### What is not included
 


### PR DESCRIPTION
## Summary

- skip missed MRT interval ticks instead of bursting catch-up dumps
- prepare the lazy output directory before requesting an O(table) snapshot
- cancel while queueing or awaiting the RIB, and avoid cloning when the reply receiver is already closed
- document the exact cancellation boundary: a synchronous clone already executing is not interruptible
- distinguish periodic manager logging from on-demand RPC error propagation

## Verification

- five focused MRT/RIB regressions
- all 102 MRT tests
- CLI documentation conformance
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- full pre-push hooks

## Load-bearing proofs

- removing `MissedTickBehavior::Skip` makes the paused-time cadence test red
- moving output preparation after the RIB query makes the impossible-path test red
- removing cancellation while awaiting the reply makes the abandoned-query test red
- removing the closed-receiver guard makes the no-materialization test red
- replacing the cancel-aware saturated-mailbox send with plain `send().await` makes the queueing-cancellation test time out red

The logging clarification is docs-only and changes no test or gate, so its load-bearing proof is N/A; the prior wording is contradicted directly by the separate periodic and on-demand control paths.

Closes LAN-743.