### PR TITLE
Make same-peer Add-Path ranking deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   collector cannot be reached by the `rbgp` process. The authoritative BGP
   listener and daemon-side RPKI VRP checks keep their existing semantics.
 
+- Equal unicast routes learned from one Add-Path peer now rank deterministically
+  by inbound path identifier after every BGP decision criterion. Reverse
+  arrival order no longer changes the unicast Loc-RIB winner or outbound
+  unicast Add-Path ranks, and best-path explain reports the identity-only
+  `lower_path_id` tie truthfully.
+
 - The shipped empty Adj-RIB-In alert now checks the current per-session
   Established gauge instead of inferring state from lifetime counters, and
   correctly aggregates scoped siblings to peer identity before joining the

--- a/crates/rib/README.md
+++ b/crates/rib/README.md
@@ -17,7 +17,8 @@ Single-task ownership — `RibManager` runs as one tokio task with no
   per-prefix Add-Path support
 - **Loc-RIB** — best-path selection per RFC 4271 section 9.1.2 with
   extensions: RPKI validation (step 0.5), stale demotion (step 0),
-  deterministic MED (always-compare), route reflector tiebreakers
+  deterministic MED (always-compare), route reflector tiebreakers, and a
+  deterministic same-peer unicast Add-Path identity tie after all BGP criteria
 - **Adj-RIB-Out** — per-peer outbound route tracking with split horizon,
   iBGP suppression, route reflector reflection rules
 - **Outbound prefix limits** — per-peer, per-family Adj-RIB-Out prefix

--- a/crates/rib/src/best_path.rs
+++ b/crates/rib/src/best_path.rs
@@ -67,8 +67,13 @@ pub enum BestPathReason {
     ShorterClusterList,
     /// Step 5.6: lower `ORIGINATOR_ID` wins (RFC 4456).
     LowerOriginatorId,
-    /// Step 6: lower peer address (final tiebreaker).
+    /// Step 6: lower peer address.
     LowerPeerAddress,
+    /// Step 6.1: lower inbound Add-Path identifier as a deterministic
+    /// same-peer route-identity tiebreaker. RFC 7911 gives the identifier
+    /// no preference semantics; it is considered only after every BGP
+    /// decision criterion and the peer address tie.
+    LowerPathId,
     /// EVPN Type 2 only: higher MAC Mobility sequence number wins, with
     /// sticky-MAC preservation (RFC 7432 §15.1).
     EvpnMacMobility,
@@ -92,6 +97,7 @@ impl BestPathReason {
             Self::ShorterClusterList => "shorter_cluster_list",
             Self::LowerOriginatorId => "lower_originator_id",
             Self::LowerPeerAddress => "lower_peer_address",
+            Self::LowerPathId => "lower_path_id",
             Self::EvpnMacMobility => "evpn_mac_mobility",
         }
     }
@@ -162,7 +168,12 @@ pub fn best_path_cmp_with_reason(a: &Route, b: &Route) -> (Ordering, BestPathRea
         }
     }
 
-    (a.peer.cmp(&b.peer), BestPathReason::LowerPeerAddress)
+    let cmp = a.peer.cmp(&b.peer);
+    if cmp != Ordering::Equal {
+        return (cmp, BestPathReason::LowerPeerAddress);
+    }
+
+    (a.path_id.cmp(&b.path_id), BestPathReason::LowerPathId)
 }
 
 /// Compare two routes under RFC 9107 ORR and return the decisive reason.
@@ -170,9 +181,9 @@ pub fn best_path_cmp_with_reason(a: &Route, b: &Route) -> (Ordering, BestPathRea
 /// Same ordering as [`best_path_cmp_orr`], derived by composition rather
 /// than a third hand-maintained ladder: the plain reason ladder decides
 /// unless its decisive step is one of the tiebreakers *below* the ORR
-/// interior-cost step (`CLUSTER_LIST`, `ORIGINATOR_ID`, peer address) —
-/// in that case the vantage cost gets first shot and, when decisive,
-/// yields [`BestPathReason::OrrInteriorCost`].
+/// interior-cost step (`CLUSTER_LIST`, `ORIGINATOR_ID`, peer address,
+/// inbound Add-Path identifier) — in that case the vantage cost gets first
+/// shot and, when decisive, yields [`BestPathReason::OrrInteriorCost`].
 #[must_use]
 pub fn best_path_cmp_orr_with_reason(
     a: &Route,
@@ -186,6 +197,7 @@ pub fn best_path_cmp_orr_with_reason(
         BestPathReason::ShorterClusterList
             | BestPathReason::LowerOriginatorId
             | BestPathReason::LowerPeerAddress
+            | BestPathReason::LowerPathId
     );
     if ord != Ordering::Equal && !below_orr_step {
         return (ord, reason);
@@ -310,6 +322,14 @@ pub fn best_path_reason_detail(reason: BestPathReason, a: &Route, b: &Route) -> 
                 b.peer
             )
         }
+        BestPathReason::LowerPathId => {
+            format!(
+                "path_id {} {} {}",
+                a.path_id,
+                cmp_symbol(&a.path_id, &b.path_id),
+                b.path_id
+            )
+        }
         // Not produced by the unicast ladder; EVPN MAC mobility carries
         // its sequence in EVPN-specific route state, not on `Route`.
         BestPathReason::EvpnMacMobility => "mac_mobility_sequence".to_string(),
@@ -378,6 +398,9 @@ pub fn multipath_eligibility(best: &Route, other: &Route) -> MultipathEligibilit
 ///    5.5. Shortest `CLUSTER_LIST` length (RFC 4456 §9)
 ///    5.6. Lowest `ORIGINATOR_ID` (RFC 4456 §9) — only when both present
 /// 6. Lowest peer address (tiebreaker)
+///    Final identity tie: lowest inbound Add-Path identifier
+///    (deterministic same-peer route identity only; RFC 7911 assigns no
+///    preference semantics).
 #[must_use]
 pub fn best_path_cmp(a: &Route, b: &Route) -> Ordering {
     cmp_chain(a, b, None)
@@ -486,8 +509,10 @@ fn cmp_chain(a: &Route, b: &Route, orr_costs: Option<(Option<u64>, Option<u64>)>
         }
     }
 
-    // 6. Lowest peer address (final tiebreaker)
-    a.peer.cmp(&b.peer)
+    // 6. Lowest peer address, then inbound Add-Path identifier. The
+    // identifier has no preference semantics (RFC 7911 §2); this last
+    // comparison only makes distinct same-peer routes a total order.
+    a.peer.cmp(&b.peer).then_with(|| a.path_id.cmp(&b.path_id))
 }
 
 /// Whether `other` is co-installable with the best route `best` as an
@@ -498,9 +523,10 @@ fn cmp_chain(a: &Route, b: &Route, orr_costs: Option<(Option<u64>, Option<u64>)>
 /// `AS_PATH`, `ORIGIN`, `MED` — **and** are the same eBGP/iBGP class (a group is
 /// never mixed; forwarding across an eBGP and an iBGP path at once is not a
 /// thing operators expect). The tiebreakers `best_path_cmp` applies below this
-/// point (`CLUSTER_LIST` length, `ORIGINATOR_ID`, peer address) are deliberately
-/// *not* compared: those exist precisely to pick one winner among otherwise
-/// co-equal paths, which are exactly the paths we want to bundle.
+/// point (`CLUSTER_LIST` length, `ORIGINATOR_ID`, peer address, inbound Add-Path
+/// identifier) are deliberately *not* compared: those exist precisely to pick
+/// one winner among otherwise co-equal paths, which are exactly the paths we
+/// want to bundle.
 ///
 /// `AS_PATH` is compared for **full equality** (not just length) — the
 /// conservative `maximum-paths` default (matches FRR without
@@ -1018,6 +1044,10 @@ mod tests {
         assert_eq!(best_path_cmp(&fresh, &llgr), Ordering::Less);
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the table intentionally exercises every decisive reason in one agreement loop"
+    )]
     #[test]
     fn with_reason_ordering_matches_plain_cmp_at_every_step() {
         // best_path_cmp_with_reason(..).0 must equal best_path_cmp(..) at
@@ -1101,6 +1131,20 @@ mod tests {
                 base_route(p2),
                 BestPathReason::LowerPeerAddress,
             ),
+            (
+                "path_id",
+                {
+                    let mut route = base_route(p1);
+                    route.path_id = 9;
+                    route
+                },
+                {
+                    let mut route = base_route(p1);
+                    route.path_id = 7;
+                    route
+                },
+                BestPathReason::LowerPathId,
+            ),
         ];
 
         for (label, a, b, expected) in cases {
@@ -1158,6 +1202,34 @@ mod tests {
         assert_eq!(
             best_path_cmp_orr(&a, &b, Some(10), Some(5)),
             Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn orr_cost_precedes_same_peer_path_id_identity_tie() {
+        let mut lower_path_id = base_route(Ipv4Addr::new(1, 0, 0, 1));
+        lower_path_id.path_id = 7;
+        let mut higher_path_id = lower_path_id.clone();
+        higher_path_id.path_id = 9;
+
+        assert_eq!(
+            best_path_cmp_orr(&lower_path_id, &higher_path_id, Some(20), Some(10)),
+            Ordering::Greater,
+            "ORR interior cost remains a real decision criterion above route identity"
+        );
+        assert_eq!(
+            best_path_cmp_orr_with_reason(&lower_path_id, &higher_path_id, Some(20), Some(10)),
+            (Ordering::Greater, BestPathReason::OrrInteriorCost),
+            "the explain ladder must put ORR cost above route identity too"
+        );
+        assert_eq!(
+            best_path_cmp_orr(&lower_path_id, &higher_path_id, Some(10), Some(10)),
+            Ordering::Less,
+            "equal ORR costs fall through to deterministic route identity"
+        );
+        assert_eq!(
+            best_path_cmp_orr_with_reason(&lower_path_id, &higher_path_id, Some(10), Some(10)),
+            (Ordering::Less, BestPathReason::LowerPathId)
         );
     }
 
@@ -1383,6 +1455,15 @@ mod tests {
                 &base_route(p1)
             ),
             "peer 1.0.0.2 > 1.0.0.1"
+        );
+
+        let mut path_9 = base_route(p1);
+        path_9.path_id = 9;
+        let mut path_7 = path_9.clone();
+        path_7.path_id = 7;
+        assert_eq!(
+            best_path_reason_detail(BestPathReason::LowerPathId, &path_9, &path_7),
+            "path_id 9 > 7"
         );
     }
 

--- a/crates/rib/src/bmp_sync.rs
+++ b/crates/rib/src/bmp_sync.rs
@@ -65,6 +65,7 @@ pub fn path_marking_reason_code(reason: BestPathReason) -> Option<u16> {
         | BestPathReason::RpkiPreference
         | BestPathReason::AspaPreference
         | BestPathReason::ShorterClusterList
+        | BestPathReason::LowerPathId
         | BestPathReason::EvpnMacMobility => None,
     }
 }
@@ -815,6 +816,7 @@ mod tests {
             (R::RpkiPreference, None),
             (R::AspaPreference, None),
             (R::ShorterClusterList, None),
+            (R::LowerPathId, None),
             (R::EvpnMacMobility, None),
         ];
         for (reason, expected) in cases {
@@ -828,6 +830,7 @@ mod tests {
         // bmp crate cannot silently shift the wire values.
         assert_eq!(path_marking_reason_code(R::HigherLocalPref), Some(0x0003));
         assert_eq!(path_marking_reason_code(R::LowerPeerAddress), Some(0x000A));
+        assert_eq!(path_marking_reason_code(R::LowerPathId), None);
     }
 
     /// path-marking-05 §3.1: Loc-RIB payloads always carry Best

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -117,7 +117,7 @@ impl LocRib {
         if let Some(new_best) = best {
             // Detect preference-relevant changes AND same-peer payload
             // churn. `best_path_cmp` compares only the fields that drive
-            // selection and tiebreaks on the peer address, so the same
+            // selection and tiebreaks on route identity, so the same
             // peer re-advertising the prefix with a new next-hop or
             // changed attributes (communities, equal-length AS_PATH
             // content, ...) would compare Equal and the stale payload
@@ -2499,6 +2499,40 @@ mod tests {
         );
         // Same input again — no change.
         assert!(!loc.recompute(prefix, [&r_attr.clone()].into_iter()));
+    }
+
+    #[test]
+    fn unicast_same_peer_add_path_rank_survives_order_and_replacement() {
+        let v4 = Ipv4Prefix::new(Ipv4Addr::new(10, 0, 7, 0), 24);
+        let prefix = Prefix::V4(v4);
+        let mut path_7 = make_route(1, v4, 100);
+        path_7.path_id = 7;
+        path_7.next_hop = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7));
+        let mut path_9 = path_7.clone();
+        path_9.path_id = 9;
+        path_9.next_hop = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 9));
+
+        let mut loc = LocRib::new();
+        assert!(loc.recompute(prefix, [&path_9, &path_7].into_iter()));
+        assert_eq!(loc.get(&prefix).unwrap().path_id, 7);
+        assert!(
+            !loc.recompute(prefix, [&path_7, &path_9].into_iter()),
+            "reversing candidate order must not move the winner"
+        );
+
+        let mut replacement = path_7.clone();
+        replacement.next_hop = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 77));
+        assert!(loc.recompute(prefix, [&path_9, &replacement].into_iter()));
+        assert_eq!(
+            loc.get(&prefix).unwrap().next_hop,
+            replacement.next_hop,
+            "same-identity payload replacement remains the deterministic winner"
+        );
+
+        assert!(loc.recompute(prefix, [&path_9].into_iter()));
+        assert_eq!(loc.get(&prefix).unwrap().path_id, 9);
+        assert!(loc.recompute(prefix, [&replacement, &path_9].into_iter()));
+        assert_eq!(loc.get(&prefix).unwrap().path_id, 7);
     }
 
     /// Regression: `recompute_flowspec` must report change when the same

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -3280,11 +3280,11 @@ impl RibManager {
     ///    iff any candidate exists" invariant cheaply — few candidates).
     /// 2. The announcing peer OWNS the current best → full rescan: the
     ///    best itself may have been replaced (payload change, possibly now
-    ///    losing to another candidate), and same-peer Add-Path candidates
-    ///    are the only ones that can TIE it (`best_path_cmp` is a total
-    ///    order whose final step compares peer addresses), which only the
-    ///    full enumeration + `LocRib::recompute` payload arbitration
-    ///    resolves.
+    ///    losing to another candidate). `best_path_cmp` now totally orders
+    ///    distinct same-peer Add-Path candidates by their inbound path ID,
+    ///    but a replacement with the same peer/path identity still compares
+    ///    equal; only full enumeration + `LocRib::recompute` payload
+    ///    arbitration resolves that case.
     /// 3. The current best's own Adj-RIB-In entry is missing → full rescan
     ///    (defensive; unreachable while every mutation seam recomputes its
     ///    affected set).
@@ -3297,15 +3297,16 @@ impl RibManager {
     /// 5. The challenger strictly BEATS the rib-resident best → install it
     ///    directly, no rescan: it beats the old minimum, hence every
     ///    untouched candidate, and its own peer's other candidates by
-    ///    construction (within-peer ties resolve to the same first-in-
-    ///    `iter_prefix`-order object a full scan would pick, cross-peer
-    ///    ties are impossible) — so it IS the full scan's winner.
+    ///    construction. Distinct unicast candidates are totally ordered
+    ///    through peer address and, within one peer, inbound path ID, so
+    ///    there is no iteration-order tie — it IS the full scan's winner.
     ///    `LocRib::recompute` over the singleton keeps the change
     ///    detection identical. Only taken with the BMP Loc-RIB tap off:
     ///    BMP path-marking needs the runner-up, which requires the full
     ///    candidate enumeration anyway.
-    /// 6. Challenger ties the best → unreachable cross-peer (case 2 covers
-    ///    same-peer) → conservative full rescan.
+    /// 6. Challenger ties the best → only possible for the same peer/path
+    ///    identity (case 2 covers that owner) and unreachable cross-peer →
+    ///    conservative full rescan.
     pub(super) fn recompute_best_after_announce(
         &mut self,
         peer: IpAddr,

--- a/crates/rib/src/manager/tests/multipath_fib.rs
+++ b/crates/rib/src/manager/tests/multipath_fib.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::best_path::BestPathReason;
 
 /// Helper: build an IPv6 route with specific peer, AS path, and
 /// `LOCAL_PREF` for dual-stack Add-Path tests.
@@ -118,6 +119,145 @@ async fn multipath_send_advertises_multiple_routes() {
     // Higher LOCAL_PREF route should be path_id 1 (best)
     let best = update.announce.iter().find(|r| r.path_id == 1).unwrap();
     assert_eq!(best.next_hop, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "one live session proves initial rank, payload replacement, explain, and withdrawal compaction"
+)]
+#[tokio::test]
+async fn same_peer_add_path_rank_is_stable_across_order_and_replacement() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 7, 1));
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 7, 2));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+
+    let mut path_7 = make_multipath_route(prefix, Ipv4Addr::new(10, 0, 7, 1), vec![65001], 100);
+    path_7.path_id = 7;
+    path_7.next_hop = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7));
+    let mut path_9 = path_7.clone();
+    path_9.path_id = 9;
+    path_9.next_hop = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 9));
+
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![path_9.clone(), path_7.clone()],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        interpret_rfc1997: true,
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: ipv4_sendable(),
+        add_path_send_max: 2,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    })
+    .await
+    .unwrap();
+
+    let initial = out_rx.recv().await.unwrap();
+    assert_eq!(initial.announce.len(), 2);
+    assert_eq!(
+        initial
+            .announce
+            .iter()
+            .find(|route| route.path_id == 1)
+            .unwrap()
+            .next_hop,
+        path_7.next_hop,
+        "reverse insertion order must not assign rank 1 to path 9"
+    );
+    drain_eor(&mut out_rx).await;
+
+    let explain = query_explain_best_path_for_peer(&tx, Prefix::V4(prefix), target)
+        .await
+        .unwrap();
+    assert_eq!(explain.best.as_ref().unwrap().path_id, 7);
+    assert_eq!(explain.best_reason, Some(BestPathReason::LowerPathId));
+    assert_eq!(explain.best_reason_detail, "path_id 7 < 9");
+    assert_eq!(
+        explain.candidates[0].vs_best_reason,
+        BestPathReason::LowerPathId
+    );
+    assert_eq!(explain.candidates[0].vs_best_detail, "path_id 9 > 7");
+    assert_eq!(explain.candidates[0].advertised_path_id, 2);
+
+    path_7.next_hop = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 77));
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![path_7.clone()],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_best_routes(&tx).await;
+    let replacement = tokio::time::timeout(Duration::from_secs(2), out_rx.recv())
+        .await
+        .expect("replacement update must arrive")
+        .expect("outbound channel must stay open");
+    assert_eq!(replacement.announce.len(), 1);
+    assert_eq!(replacement.announce[0].path_id, 1);
+    assert_eq!(replacement.announce[0].next_hop, path_7.next_hop);
+    assert!(replacement.withdraw.is_empty());
+    assert!(
+        matches!(out_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+        "replacement must produce one exact outbound update"
+    );
+
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![(Prefix::V4(prefix), 7)],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_best_routes(&tx).await;
+    let reranked = tokio::time::timeout(Duration::from_secs(2), out_rx.recv())
+        .await
+        .expect("rerank update must arrive")
+        .expect("outbound channel must stay open");
+    assert_eq!(reranked.announce.len(), 1);
+    assert_eq!(reranked.announce[0].path_id, 1);
+    assert_eq!(reranked.announce[0].next_hop, path_9.next_hop);
+    assert_eq!(reranked.withdraw, vec![(Prefix::V4(prefix), 2)]);
+    assert!(
+        matches!(out_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+        "withdrawal must produce one exact rerank update"
+    );
 
     drop(tx);
     handle.await.unwrap();

--- a/docs/explain.md
+++ b/docs/explain.md
@@ -30,7 +30,8 @@ translates the usual show-commands into these.
 Why did this path win? Every losing candidate is annotated with the
 decisive comparison step (`only_path`, `higher_local_pref`,
 `shorter_as_path`, `lower_origin`, `lower_med`, ... down to
-`lower_peer_address`) and the compared values behind it, plus its
+`lower_peer_address` and the same-peer Add-Path identity tie
+`lower_path_id`) and the compared values behind it, plus its
 equal-cost multipath classification:
 
 ```console

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -2045,6 +2045,8 @@ message ExplainBestPathRequest {
 
 message BestPathCandidate {
   Route route = 1;
+  // Decisive best-path step in stable snake_case vocabulary, including
+  // lower_path_id when otherwise-equal routes came from one Add-Path peer.
   string vs_best_reason = 2;
   string vs_best_ordering = 3;
   // Compared values behind vs_best_reason, candidate's value first,
@@ -2103,10 +2105,10 @@ message ExplainBestPathResponse {
   // (stale_preference, rpki_preference, aspa_preference,
   // higher_local_pref, shorter_as_path, lower_origin, lower_med,
   // ebgp_over_ibgp, shorter_cluster_list, lower_originator_id,
-  // lower_peer_address). "only_path" when the prefix has exactly one
-  // path (trivial winner, no competing candidates). A prefix with no
-  // paths at all is NOT_FOUND at the RPC layer, so this field is never
-  // empty on a successful response.
+  // lower_peer_address, lower_path_id). "only_path" when the prefix has
+  // exactly one path (trivial winner, no competing candidates). A prefix
+  // with no paths at all is NOT_FOUND at the RPC layer, so this field is
+  // never empty on a successful response.
   string best_reason = 7;
   // Compared values behind best_reason, winner's value first
   // (e.g. "local_pref 200 > 100"). Empty when best_reason is


### PR DESCRIPTION
## Summary

- add inbound Path ID as the final identity-only tie-break for equal unicast routes from one Add-Path peer
- keep every BGP and ORR criterion above that tie-break; the numeric ID carries no preference semantics
- expose the local decision as `lower_path_id` while mapping it to no standardized BMP reason
- cover reverse insertion, replacement, withdrawal reranking, rank compaction, ORR parity, and live explain output

## Verification

- full RIB tests: 1026 passed, 2 ignored
- focused live Add-Path, ORR, reason, and BMP mapping tests
- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpd-rib --all-targets -- -D warnings`
- warning-denying RIB rustdoc
- v1 stable-surface gate
- full pre-push hooks

## Load-bearing proofs

- removing the final Path-ID tie makes order and replacement regressions red
- omitting its explain reason makes comparator and live explain assertions red
- moving Path ID above ORR cost makes the ORR ordering regression red
- mapping the local identity reason to a BMP wire code makes the exhaustive mapping test red

The finite `send_max` selection optimization remains separately scoped and blocked on this correctness contract.

Closes LAN-745.