### PR TITLE
Fix rrtransport exit-time RSS sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The per-commit real-transport smoke receipt no longer records an empty RSS
+  sample when its supervised process exits between liveness and `/proc`
+  observation, avoiding a verifier false negative while keeping live
+  non-numeric observations fail closed.
+
 - SIGHUP now pins every daemon-wide restart-required `[global]`, `[rpki]`,
   `[bmp]`, and `[mrt]` value to the running startup snapshot while preserving
   edited desired values for the next restart, preventing later runtime-added

--- a/bench/scale/rrtransport/run-receipt.sh
+++ b/bench/scale/rrtransport/run-receipt.sh
@@ -30,6 +30,41 @@ classify_rss() {
   fi
 }
 
+observe_direct_rss() {
+  local status_file=$1 status state rss
+  direct_rss_action=reject
+  direct_rss_kib=0
+  if ! status=$(command cat -- "$status_file" 2>/dev/null); then
+    direct_rss_action=exited
+    return
+  fi
+  state=$(awk '$1=="State:" {print substr($2,1,1)}' <<<"$status")
+  rss=$(awk '/VmRSS:/ {print $2}' <<<"$status")
+  if [[ $state == X || $state == Z ]]; then
+    direct_rss_action=exited
+  elif [[ -n $state && $rss =~ ^[0-9]+$ ]]; then
+    direct_rss_action=sample
+    direct_rss_kib=$rss
+  fi
+}
+
+sample_direct_rss() {
+  local status_file=$1 output=$2
+  observe_direct_rss "$status_file"
+  case $direct_rss_action in
+    exited) ;;
+    sample)
+      (( direct_rss_kib > max_rss )) && max_rss=$direct_rss_kib
+      printf 'sample\t%s\n' "$direct_rss_kib" >>"$output/rss.tsv"
+      classify_rss "$direct_rss_kib" "$output"
+      ;;
+    *)
+      echo "tiny sampler observed live process without numeric VmRSS" >&2
+      return 1
+      ;;
+  esac
+}
+
 classify_child_observation() {
   local executable=$1 state=$2
   if [[ $state == X || $state == Z ]]; then
@@ -542,6 +577,7 @@ stop_reap_fixture() {
 
 check_seam() {
   local script=$1 outer verify_call verify_body checksums_call checksums_body
+  local direct_rss_call direct_rss_exit
   outer="timeout -k 10 1200 \"\$scr"
   outer+="ipt\" --campaign-inner \"\$output\""
   verify_call="full_ver"
@@ -552,10 +588,13 @@ check_seam() {
   checksums_call+="sums \"\$receipt\""
   checksums_body="sha256sum -c SHA"
   checksums_body+="256SUMS --strict"
+  direct_rss_call="sample_direct_rss \"/proc/\$pid/status\" \"\$receipt\""
+  direct_rss_exit="[[ \$direct_rss_action != exited ]] || break"
   if ! grep -Fq "$outer" "$script" || ! grep -Fq "$verify_call" "$script" ||
     ! grep -Fq "$verify_body" "$script" || ! grep -Fq "$checksums_call" "$script" ||
-    ! grep -Fq "$checksums_body" "$script"; then
-    echo "runner lacks production verifier/checksum seam" >&2
+    ! grep -Fq "$checksums_body" "$script" || ! grep -Fq "$direct_rss_call" "$script" ||
+    ! grep -Fq "$direct_rss_exit" "$script"; then
+    echo "runner lacks production verifier/checksum/RSS seam" >&2
     return 1
   fi
 }
@@ -644,6 +683,22 @@ case ${1:-} in
     classify_child_exe "$2" "$3" "$4"
     exit
     ;;
+  --observe-direct-rss)
+    [[ $# == 2 ]] || exit 2
+    observe_direct_rss "$2"
+    printf '%s\t%s\n' "$direct_rss_action" "$direct_rss_kib"
+    exit
+    ;;
+  --sample-direct-rss-fixture)
+    [[ $# == 3 ]] || exit 2
+    receipt=$3
+    mkdir -p "$receipt"
+    printf 'checkpoint\trss_kib\n' >"$receipt/rss.tsv"
+    max_rss=0
+    sample_direct_rss "$2" "$receipt"
+    printf '%s\t%s\t%s\n' "$direct_rss_action" "$direct_rss_kib" "$max_rss"
+    exit
+    ;;
   --resolve-child-observations)
     (( $# >= 4 )) || exit 2
     diagnostic_log=$2
@@ -702,10 +757,8 @@ case ${1:-} in
       exit 1
     fi
     while kill -0 "$pid" 2>/dev/null; do
-      rss=$(awk '/VmRSS:/ {print $2}' "/proc/$pid/status" 2>/dev/null || echo 0)
-      (( rss > max_rss )) && max_rss=$rss
-      printf 'sample\t%s\n' "$rss" >>"$receipt/rss.tsv"
-      classify_rss "$rss" "$receipt" || exit 1
+      sample_direct_rss "/proc/$pid/status" "$receipt" || exit 1
+      [[ $direct_rss_action != exited ]] || break
       sleep 0.05
     done
     if ! wait "$pid"; then

--- a/bench/tests/test-rrtransport-receipt.sh
+++ b/bench/tests/test-rrtransport-receipt.sh
@@ -113,6 +113,38 @@ expect_red changed-hash mutate -c 'import pathlib,sys;(pathlib.Path(sys.argv[1])
 [[ $("$runner" --classify-child-exe /expected /expected Z) == exited ]]
 [[ $("$runner" --classify-child-exe /expected /expected absent) == retry_expected_absent ]]
 
+printf 'Name:\trrtiny\nState:\tR (running)\nVmRSS:\t1234 kB\n' >"$tmp/live.status"
+printf 'Name:\trrtiny\nState:\tZ (zombie)\n' >"$tmp/zombie.status"
+printf 'Name:\trrtiny\nState:\tR (running)\n' >"$tmp/missing-rss.status"
+printf 'Name:\trrtiny\nVmRSS:\t1234 kB\n' >"$tmp/missing-state.status"
+printf 'Name:\trrtiny\nState:\tR (running)\nVmRSS:\t2097153 kB\n' >"$tmp/over-limit.status"
+[[ $("$runner" --observe-direct-rss "$tmp/live.status") == $'sample\t1234' ]]
+[[ $("$runner" --observe-direct-rss "$tmp/zombie.status") == $'exited\t0' ]]
+[[ $("$runner" --observe-direct-rss "$tmp/missing-rss.status") == $'reject\t0' ]]
+[[ $("$runner" --observe-direct-rss "$tmp/missing-state.status") == $'reject\t0' ]]
+[[ $("$runner" --observe-direct-rss "$tmp/absent.status") == $'exited\t0' ]]
+[[ $("$runner" --sample-direct-rss-fixture "$tmp/live.status" "$tmp/live-rss") == \
+  $'sample\t1234\t1234' ]]
+[[ $(<"$tmp/live-rss/rss.tsv") == $'checkpoint\trss_kib\nsample\t1234' ]]
+[[ $("$runner" --sample-direct-rss-fixture "$tmp/zombie.status" "$tmp/zombie-rss") == \
+  $'exited\t0\t0' ]]
+[[ $(<"$tmp/zombie-rss/rss.tsv") == $'checkpoint\trss_kib' ]]
+if "$runner" --sample-direct-rss-fixture "$tmp/missing-rss.status" "$tmp/missing-rss" \
+  2>"$tmp/missing-rss.stderr"; then
+  echo "live process without VmRSS was accepted" >&2
+  exit 1
+fi
+[[ $(<"$tmp/missing-rss/rss.tsv") == $'checkpoint\trss_kib' ]]
+grep -Fxq "tiny sampler observed live process without numeric VmRSS" \
+  "$tmp/missing-rss.stderr"
+if "$runner" --sample-direct-rss-fixture "$tmp/over-limit.status" "$tmp/over-limit" \
+  >"$tmp/over-limit.stdout" 2>"$tmp/over-limit.stderr"; then
+  echo "production direct sampler bypassed the RSS ceiling" >&2
+  exit 1
+fi
+grep -Fq '"root_failure":"rss_ceiling"' "$tmp/over-limit/failure.json"
+[[ $(<"$tmp/over-limit/rss.tsv") == $'checkpoint\trss_kib\nsample\t2097153' ]]
+
 resolve_observations() {
   local name=$1 seen=$2 expected=$3
   shift 3
@@ -250,7 +282,9 @@ for seam in \
   "full_verify \"\$receipt\"" \
   "python3 \"\$verifier\" \"\$receipt\" --full | tee \"\$receipt/verifier.txt\"" \
   "full_checksums \"\$receipt\"" \
-  "sha256sum -c SHA256SUMS --strict"; do
+  "sha256sum -c SHA256SUMS --strict" \
+  "sample_direct_rss \"/proc/\$pid/status\" \"\$receipt\"" \
+  "[[ \$direct_rss_action != exited ]] || break"; do
   cp "$runner" "$tmp/runner"
   grep -Fv "$seam" "$tmp/runner" >"$tmp/mutated"
   mv "$tmp/mutated" "$tmp/runner"


### PR DESCRIPTION
## Summary

- read each direct `/proc/<pid>/status` observation once
- stop sampling cleanly when the supervised smoke process is absent or terminal
- reject live status snapshots without numeric RSS instead of recording an empty value
- keep the production RSS ceiling on the same helper used by the deterministic fixtures

## Why

The real-transport smoke loop checked `kill -0` before reading `VmRSS`. An exited process can remain visible as a zombie: liveness succeeds, its status contains no `VmRSS`, and `awk` returns an empty value. The runner then wrote `sample<TAB>` and the verifier failed while parsing the empty integer even though the transport receipt itself completed correctly.

## Verification

- 30/30 repeated `--real-smoke` receipts
- `bash bench/tests/test-rrtransport-receipt.sh`
- `cargo test --manifest-path bench/scale/rrtransport/Cargo.toml --locked`
- `cargo clippy --manifest-path bench/scale/rrtransport/Cargo.toml --locked --all-targets -- -D warnings`
- `bash -n` and `shellcheck` for both receipt scripts
- full commit and push hooks

## Load-bearing proofs

- Removing the production terminal-state break makes the receipt gate fail because the required production RSS seam disappears.
- Removing the production `classify_rss` call makes the live over-limit fixture fail with `production direct sampler bypassed the RSS ceiling`.
- A zombie status fixture writes no RSS row; a live status without `VmRSS` is rejected.
