### PR TITLE
Add a fail-closed MRT growth campaign contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,7 @@ jobs:
           python3 bench/scale/rebaseline/test_classifiers.py
           python3 bench/scale/rebaseline/test_parse_rrharness.py
           python3 bench/scale/rebaseline/test_validate_lan395_criterion.py
+          python3 bench/tests/test_verify_mrt_growth_campaign.py
           (
             cd docs/perf/artifacts/enhanced-route-refresh-2026-07
             sha256sum -c SHA256SUMS

--- a/bench/tests/test_verify_mrt_growth_campaign.py
+++ b/bench/tests/test_verify_mrt_growth_campaign.py
@@ -1,0 +1,73 @@
+import copy, importlib.util, pathlib, unittest
+
+SCRIPT = pathlib.Path(__file__).parents[1] / "verify-mrt-growth-campaign.py"
+SPEC = importlib.util.spec_from_file_location("mrt_growth_verify", SCRIPT)
+VERIFY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VERIFY)
+
+def fixture():
+    rows = []
+    for block in range(1, 5):
+        for slot, variant in enumerate(VERIFY.ORDER, 1):
+            for shape, (paths, _, _) in VERIFY.SHAPES.items():
+                candidate = variant == "candidate"
+                rows.append({
+                    "schema": 1, "block": block, "slot": slot, "variant": variant,
+                    "source_commit": ("b" if candidate else "a") * 40,
+                    "source_tree": ("d" if candidate else "c") * 40,
+                    "harness_sha256": "e" * 64,
+                    "timing_binary_sha256": ("2" if candidate else "1") * 64,
+                    "diagnostic_binary_sha256": ("4" if candidate else "3") * 64,
+                    "growth_path_assertion": ("bounded-growth-observed" if candidate
+                                              else "ordinary-unbounded-observed"),
+                    "shape": shape, "timing_ns": [90 if candidate else 100] * 7,
+                    "allocator_calls": 70 if candidate else 100, "requested_bytes": 40 if candidate else 100,
+                    "output_growth_misses": 1 if candidate else paths,
+                    "output_len_bytes": paths * 80,
+                    "output_capacity_bytes": paths * (81 if candidate else 80),
+                    "peak_live_overhead_bytes": paths,
+                    "decoded_entry_count": paths, "raw_sha256": "5" * 64,
+                    "semantic_sha256": "6" * 64,
+                })
+    return rows
+
+class CampaignContract(unittest.TestCase):
+    def test_valid_fixture(self):
+        self.assertEqual(VERIFY.verify(fixture())["classification"], "go")
+
+    def test_destructive_red_proofs(self):
+        source, pattern = (SCRIPT.parents[1] / "crates/mrt/benches/snapshot_allocation.rs").read_text(), r'(?s)let growth_path_assertion = encoded\.growth\.as_ref\(\)\.map\(\|growth\| \{\s*growth_path_assertion\(\s*args\.candidate,\s*growth\.top_level_unbounded_capacity_misses,\s*fixture\.routes\.len\(\) as u64,\s*\)\s*\.expect\("diagnostic growth path must match the declared variant"\)\s*\}\);'
+        self.assertRegex(source, pattern)
+        self.assertNotRegex(source.replace('.expect("diagnostic growth path must match the declared variant")', '.expect("diagnostic growth path must match the declared variant"); "ordinary-unbounded-observed"'), pattern)
+        mutations = (
+            lambda rows: rows[0].pop("timing_binary_sha256"), lambda rows: rows[2].update(variant="control"),
+            lambda rows: rows[2].update(growth_path_assertion="ordinary-unbounded-observed"),
+            lambda rows: rows.pop(),
+            lambda rows: rows[0].update(output_growth_misses=1),
+            lambda rows: rows[2].update(output_growth_misses=65),
+            lambda rows: [rows[index].update(allocator_calls=0) for index in (0, 6)],
+            lambda rows: [rows[index].update(requested_bytes=0) for index in (0, 6)],
+            lambda rows: rows[2].update(allocator_calls=100),
+            lambda rows: rows[2].update(requested_bytes=70),
+            lambda rows: rows[2].update(timing_ns=[101] * 7),
+            lambda rows: rows[2].update(timing_ns=[1, 100, 100, 100, 100, 100, 100]),
+            lambda rows: [rows[index].update(raw_sha256="7" * 64) for index in (8, 10, 12, 14)],
+            lambda rows: [rows[index].update(semantic_sha256="8" * 64) for index in (8, 10, 12, 14)],
+            lambda rows: [rows[index].update(output_len_bytes=rows[index]["output_len_bytes"] - 1) for index in (8, 10, 12, 14)],
+            lambda rows: [row.update(source_tree="c" * 40) for row in rows if row["variant"] == "candidate"],
+            lambda rows: rows[0].update(harness_sha256="9" * 64),
+            lambda rows: rows[0].update(timing_binary_sha256="9" * 64),
+            lambda rows: rows[0].update(schema=True),
+            lambda rows: rows[0].update(output_len_bytes=1.0),
+            lambda rows: rows[2].update(output_capacity_bytes=rows[2]["output_len_bytes"] * 2),
+            lambda rows: rows[2].update(peak_live_overhead_bytes=32 * 1024**2 + 1),
+        )
+        for mutate in mutations:
+            with self.subTest(mutate=mutate):
+                rows = copy.deepcopy(fixture())
+                mutate(rows)
+                with self.assertRaises(VERIFY.Invalid):
+                    VERIFY.verify(rows)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/verify-mrt-growth-campaign.py
+++ b/bench/verify-mrt-growth-campaign.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Fail closed on ordinary-MRT output-growth A/B campaign receipts."""
+
+import argparse
+import json
+import pathlib
+import re
+import statistics
+ORDER = ("control", "candidate", "candidate", "control")
+SHAPES = {"ixp-700": (400_400, 400_400, 700), "dual-full-feed": (800_800, 400_400, 2)}
+HEX40 = re.compile(r"[0-9a-f]{40}\Z")
+HEX64 = re.compile(r"[0-9a-f]{64}\Z")
+FIELDS = set(("schema block slot variant source_commit source_tree harness_sha256 "
+              "timing_binary_sha256 diagnostic_binary_sha256 growth_path_assertion shape timing_ns "
+              "allocator_calls requested_bytes output_growth_misses output_len_bytes "
+              "output_capacity_bytes peak_live_overhead_bytes decoded_entry_count raw_sha256 semantic_sha256").split())
+NUMERIC = ("schema block slot allocator_calls requested_bytes output_growth_misses "
+           "output_len_bytes output_capacity_bytes peak_live_overhead_bytes decoded_entry_count").split()
+
+class Invalid(ValueError): pass
+def require(condition, message):
+    if not condition:
+        raise Invalid(message)
+
+def verify(rows):
+    require(len(rows) == 32, "campaign must contain four complete ABBA blocks")
+    cells, identities = {}, {"control": set(), "candidate": set()}
+    harnesses = set()
+    for row in rows:
+        require(type(row) is dict and set(row) == FIELDS, "closed row schema")
+        block, slot, shape = row["block"], row["slot"], row["shape"]
+        require(all(type(row[field]) is int and row[field] >= 0 for field in NUMERIC),
+                "numeric fields must be non-negative integers")
+        require(row["schema"] == 1 and block in range(1, 5) and slot in range(1, 5) and shape in SHAPES,
+                "block, slot, or shape outside the fixed matrix")
+        variant = row["variant"]
+        require(variant == ORDER[slot - 1], "ABBA variant identity/order")
+        key = (block, slot, shape)
+        require(key not in cells, "duplicate ABBA cell")
+        cells[key] = row
+        commit, tree = row["source_commit"], row["source_tree"]
+        hashes = (row["harness_sha256"], row["timing_binary_sha256"], row["diagnostic_binary_sha256"], row["raw_sha256"],
+                  row["semantic_sha256"])
+        require(all(type(value) is str for value in (commit, tree, *hashes)), "identity fields must be strings")
+        require(HEX40.fullmatch(commit) and HEX40.fullmatch(tree) and all(HEX64.fullmatch(value) for value in hashes),
+                "source/binary identity")
+        identities[variant].add((commit, tree, hashes[1], hashes[2]))
+        harnesses.add(hashes[0])
+        require(row["growth_path_assertion"] == ("ordinary-unbounded-observed" if variant == "control"
+                                                 else "bounded-growth-observed"), "growth-path assertion")
+        paths, _, _ = SHAPES[shape]
+        require(row["decoded_entry_count"] == paths and row["output_len_bytes"] > 0, "decoded count or output length")
+        require(type(row["timing_ns"]) is list and len(row["timing_ns"]) == 7
+                and all(type(value) is int and value > 0 for value in row["timing_ns"]),
+                "seven positive timing samples")
+        require(statistics.pstdev(row["timing_ns"]) / statistics.mean(row["timing_ns"]) <= .05, "timing CV")
+        require(row["output_growth_misses"] >= paths if variant == "control" else
+                row["output_growth_misses"] <= 64, "growth-path count")
+        require(row["output_capacity_bytes"] >= row["output_len_bytes"], "capacity underflow")
+    require(all(len(value) == 1 for value in identities.values()), "variant identity drift")
+    control, candidate = (next(iter(identities[name])) for name in ORDER[:2])
+    require(control[0] != candidate[0] and control[1] != candidate[1], "source commit/tree must differ")
+    require(len(harnesses) == 1, "harness source drift")
+    for shape in SHAPES:
+        group = [row for row in cells.values() if row["shape"] == shape]
+        require(len({(row["raw_sha256"], row["semantic_sha256"], row["decoded_entry_count"], row["output_len_bytes"])
+                     for row in group}) == 1, "cross-block encoded identity drift")
+    for block in range(1, 5):
+        for shape in SHAPES:
+            group = [cells[block, slot, shape] for slot in range(1, 5)]
+            control, candidate = group[::3], group[1:3]
+            aggregate = lambda side, field: sum(row[field] for row in side)
+            timing = lambda side: statistics.median(statistics.median(row["timing_ns"]) for row in side)
+            require(timing(candidate) * 100 <= timing(control) * 95, "five-percent timing gate")
+            require(aggregate(candidate, "output_growth_misses") * 100
+                    <= aggregate(control, "output_growth_misses"),
+                    "output-growth reservation gate")
+            require(aggregate(control, "allocator_calls") > 0 and aggregate(candidate, "allocator_calls") * 100
+                    <= aggregate(control, "allocator_calls") * 80, "allocator-call gate")
+            require(aggregate(control, "requested_bytes") > 0 and aggregate(candidate, "requested_bytes") * 2
+                    <= aggregate(control, "requested_bytes"), "requested-byte gate")
+            for row in candidate:
+                require(row["output_capacity_bytes"] - row["output_len_bytes"] <= row["output_len_bytes"] // 4,
+                        "capacity-slack gate")
+                require(row["peak_live_overhead_bytes"] <= min(row["output_len_bytes"] // 4, 32 * 1024**2),
+                        "peak-overhead gate")
+    return {"classification": "go", "blocks": 4, "rows": 32}
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("receipt", type=pathlib.Path)
+    args = parser.parse_args()
+    try:
+        rows = [json.loads(line) for line in args.receipt.read_text().splitlines() if line]
+        print(json.dumps(verify(rows), sort_keys=True))
+    except (OSError, json.JSONDecodeError, Invalid) as error:
+        parser.error(str(error))
+
+if __name__ == "__main__":
+    main()

--- a/crates/mrt/benches/snapshot_allocation.rs
+++ b/crates/mrt/benches/snapshot_allocation.rs
@@ -276,6 +276,7 @@ fn prove_shape_contract() {
 #[derive(Debug)]
 struct Args {
     mode: Mode,
+    candidate: bool,
     smoke: bool,
     shape: Option<Shape>,
     commit: String,
@@ -286,6 +287,7 @@ impl Args {
     fn parse() -> AnyResult<Self> {
         let mut raw = std::env::args().skip(1);
         let mut mode = None;
+        let mut candidate = false;
         let mut smoke = false;
         let mut shape = None;
         let mut commit = None;
@@ -298,6 +300,7 @@ impl Args {
                 "timing" | "diagnostic" if mode.is_none() => {
                     mode = Some(Mode::parse(&argument)?);
                 }
+                "--candidate" => candidate = true,
                 "--smoke" => smoke = true,
                 "--shape" => {
                     shape = Some(Shape::parse(
@@ -319,7 +322,7 @@ impl Args {
                 }
                 "--help" | "-h" => {
                     println!(
-                        "snapshot_allocation <timing|diagnostic> [--smoke] \
+                        "snapshot_allocation <timing|diagnostic> [--candidate] [--smoke] \
                          [--shape <ixp-700|dual-full-feed>] [--commit SHA] \
                          [--output FILE]"
                     );
@@ -333,6 +336,7 @@ impl Args {
         let commit = validate_retention_args(smoke, commit, output.is_some())?;
         Ok(Self {
             mode,
+            candidate,
             smoke,
             shape,
             commit,
@@ -381,6 +385,16 @@ fn prove_commit_contract() {
     assert!(validate_retention_args(false, Some(exact.to_string()), true).is_ok());
     assert!(validate_retention_args(false, Some("main".to_string()), true).is_err());
     assert!(validate_retention_args(false, Some(exact.to_string()), false).is_err());
+    assert!(growth_path_assertion(false, 0, 1).is_none());
+    assert!(growth_path_assertion(true, 65, 1).is_none());
+}
+
+fn growth_path_assertion(candidate: bool, misses: u64, paths: u64) -> Option<&'static str> {
+    ((candidate && misses <= 64) || (!candidate && misses >= paths)).then_some(if candidate {
+        "bounded-growth-observed"
+    } else {
+        "ordinary-unbounded-observed"
+    })
 }
 
 fn invalid(message: impl Into<String>) -> Box<dyn Error> {
@@ -588,10 +602,6 @@ fn encode(fixture: &Fixture, mode: Mode, fixed_originated_time: u32) -> AnyResul
                     allocator.peak_live_overhead_bytes,
                     allocator.peak_live_delta_bytes.saturating_sub(bytes.len()),
                     "reported peak overhead must exclude the retained output length",
-                );
-                assert!(
-                    diagnostics.ordinary_output_growth_reservations >= fixture.routes.len() as u64,
-                    "ordinary output-growth probe must execute at least once per encoded path"
                 );
                 Ok(EncodedSample {
                     bytes,
@@ -884,6 +894,7 @@ struct ReceiptRow<'a> {
     semantic_sha256: String,
     allocator: Option<AllocatorReceipt>,
     growth: Option<GrowthReceipt>,
+    growth_path_assertion: Option<&'static str>,
 }
 
 #[cfg(feature = "snapshot-allocation-diagnostics")]
@@ -1014,9 +1025,21 @@ fn run_shape(args: &Args, shape: Shape, output: &mut dyn Write) -> AnyResult<()>
         if args.mode == Mode::Diagnostic && raw_sha256 != first_raw {
             return Err(invalid("fixed-time diagnostic bytes are not deterministic"));
         }
+        let growth_path_assertion = encoded.growth.as_ref().map(|growth| {
+            growth_path_assertion(
+                args.candidate,
+                growth.top_level_unbounded_capacity_misses,
+                fixture.routes.len() as u64,
+            )
+            .expect("diagnostic growth path must match the declared variant")
+        });
         let row = ReceiptRow {
-            schema_version: 1,
-            variant: "control",
+            schema_version: 2,
+            variant: if args.candidate {
+                "candidate"
+            } else {
+                "control"
+            },
             commit: &args.commit,
             mode: args.mode.as_str(),
             shape: shape.as_str(),
@@ -1034,6 +1057,7 @@ fn run_shape(args: &Args, shape: Shape, output: &mut dyn Write) -> AnyResult<()>
             semantic_sha256: validation.semantic_sha256,
             allocator: encoded.allocator,
             growth: encoded.growth,
+            growth_path_assertion,
         };
         serde_json::to_writer(&mut *output, &row)?;
         output.write_all(b"\n")?;

--- a/docs/perf/mrt-snapshot-allocation-2026-07.md
+++ b/docs/perf/mrt-snapshot-allocation-2026-07.md
@@ -225,6 +225,14 @@ silently replace one side. Compute the paired median within each block before
 the four-block decision, and retain that campaign in its own comparison
 artifact/schema extension.
 
+```bash
+python3 bench/tests/test_verify_mrt_growth_campaign.py
+python3 bench/verify-mrt-growth-campaign.py comparison.jsonl
+```
+
+The closed 32-row contract pins both shapes in four ABBA blocks, source/tree, binaries, one harness, seven timings, decoded byte identity, allocations, growth, slack, and peak overhead.
+Control and `--candidate` diagnostics assert their declared path before emitting it; any drift or threshold miss is red. Attested raw rows use schema 2; the retained control remains schema 1.
+
 Acquire the repository's shared benchmark/soak host lock before building or
 running the control or either future revision. For every retained phase, record
 UTC time, logical CPU affinity, CPU governor, one-minute load, toolchain, kernel,


### PR DESCRIPTION
## Summary

- add an instrumentation-only control/candidate attestation to the existing ordinary-MRT allocation benchmark
- add a closed 32-row, four-block ABBA validator for two fixed deployment shapes
- enroll its load-bearing fixture gate in per-commit CI and document the retained campaign contract

No `crates/mrt/src` production behavior changes in this PR. The later bounded-growth product change remains separately measurement-gated.

## Contract

The validator pins source commit/tree, timing and diagnostic binaries, one harness digest, exact output identity and decoded counts, allocation totals, output-growth misses, capacity slack, peak overhead, and seven-sample timing stability. It requires:

- candidate growth misses at most 64 per row and at least 99% aggregate reduction
- at least 20% fewer allocator calls
- at least 50% fewer requested bytes
- at least 5% faster in every ABBA block
- at most 25% retained capacity slack and bounded peak overhead

## Load-bearing proofs

The enrolled test makes impossible control counts, zero-over-zero reductions, incomplete or reordered ABBA cells, cross-block output drift, bool/float evidence, source/tree/binary/harness drift, threshold misses, and capacity/peak violations red. It also structurally requires the live diagnostic value to flow through the fail-closed path assertion; ignored-result and post-assertion label bypasses are red.

Running the current ordinary-growth control as `--candidate` aborts before it can emit bounded-path evidence.

## Verification

- `python3 bench/tests/test_verify_mrt_growth_campaign.py`
- validator CLI valid fixture and Python compile
- timing and diagnostic benchmark smokes
- current-control `--candidate` negative smoke
- 102 MRT tests and warning-denying MRT docs
- feature-on benchmark clippy
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-commit and pre-push hooks
