### PR TITLE
Reject invalid and duplicate RPKI cache endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- RPKI cache endpoints now fail configuration validation unless they are unique
+  numeric IPv4 or bracketed IPv6 socket addresses; DNS hostnames and equivalent
+  duplicate IPv6 spellings are rejected before startup.
+
 - Outbound prefix-limit recovery now rotates after a backpressured peer,
   allowing other queued peers to recover while preserving the failed peer's
   transactional retry intent.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2012,23 +2012,24 @@ address = "127.0.0.1:3323"
 
 ### Multiple cache servers (redundancy)
 
-For production, connect to 2+ caches. VRPs are merged (union) across all
-connected caches:
+For production, connect to 2+ caches. Addresses must be numeric IP endpoints;
+DNS hostnames are not supported, and IPv6 addresses must be bracketed. VRPs are
+merged (union) across all connected caches:
 
 ```toml
 [rpki]
 [[rpki.cache_servers]]
-address = "rpki1.example.com:3323"
+address = "192.0.2.10:3323"
 
 [[rpki.cache_servers]]
-address = "rpki2.example.com:3323"
+address = "[2001:db8::10]:3323"
 ```
 
 ### Cache server options
 
 | Field | Type | Required | Default | Description |
 |-------|------|:--------:|:-------:|-------------|
-| `address` | string | yes | -- | Cache server `host:port` |
+| `address` | string | yes | -- | Numeric cache server `IP:port`; bracket IPv6 addresses |
 | `refresh_interval` | u64 | no | 3600 | Seconds between Serial Queries |
 | `retry_interval` | u64 | no | 600 | Seconds before reconnect on failure |
 | `expire_interval` | u64 | no | 7200 | Seconds before discarding stale VRPs |
@@ -3981,6 +3982,7 @@ starting:
 | RT/RO local administrator must be <= 65535 for a 4-octet ASN or dotted IPv4 administrator; numeric ASNs <= 65535 carry a u32 local value | `local admin ... exceeds 65535 for ...` |
 | RPKI `refresh_interval`, `retry_interval`, `expire_interval` must be > 0 | `must be > 0` |
 | RPKI `expire_interval` must be >= `refresh_interval` | `expire_interval must be >= refresh_interval` |
+| RPKI cache addresses must be unique numeric `IP:port` endpoints (bracketed for IPv6) | `invalid address` / `duplicate address` |
 | Named policy referenced in chain must exist in `[policy.definitions]` | `undefined policy` |
 | Inline policy and policy chain cannot both be set for the same neighbor/direction | `mutually exclusive` |
 | `route_server_client` is only valid on eBGP neighbors | `invalid route_server_client` |

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -403,7 +403,7 @@
       "type": "object",
       "properties": {
         "address": {
-          "description": "RTR cache endpoint as `host:port`.",
+          "description": "Numeric RTR cache endpoint as IPv4 `address:port` or bracketed IPv6 `[address]:port`.",
           "type": "string"
         },
         "expire_interval": {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -307,7 +307,7 @@ pub struct RpkiConfig {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct CacheServer {
-    /// RTR cache endpoint as `host:port`.
+    /// Numeric RTR cache endpoint as IPv4 `address:port` or bracketed IPv6 `[address]:port`.
     pub address: String,
     /// RTR refresh interval in seconds. Default 3600.
     #[serde(default = "default_rpki_refresh")]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -5392,21 +5392,61 @@ address = "127.0.0.1:3323"
 }
 
 #[test]
+fn rpki_cache_address_rejects_hostname_with_index_and_value() {
+    let source = rpki_toml("").replace("127.0.0.1:3323", "rpki.example.com:3323");
+    let err = parse(&source).unwrap_err().to_string();
+    assert!(err.contains("cache_servers[0]"), "{err}");
+    assert!(err.contains(r#""rpki.example.com:3323""#), "{err}");
+}
+
+#[test]
+fn rpki_cache_address_rejects_canonical_duplicate() {
+    let mut source = rpki_toml("").replace("127.0.0.1:3323", "[2001:0db8::1]:3323");
+    source.push_str(
+        r#"
+[[rpki.cache_servers]]
+address = "[2001:db8:0:0:0:0:0:1]:3323"
+"#,
+    );
+    let err = parse(&source).unwrap_err().to_string();
+    assert!(err.contains("cache_servers[1]"), "{err}");
+    assert!(err.contains(r#""[2001:db8:0:0:0:0:0:1]:3323""#), "{err}");
+}
+
+#[test]
+fn rpki_cache_address_accepts_unique_numeric_ipv4_and_ipv6() {
+    let mut source = rpki_toml("");
+    source.push_str(
+        r#"
+[[rpki.cache_servers]]
+address = "[2001:db8::1]:3323"
+"#,
+    );
+    assert!(parse(&source).is_ok());
+}
+
+#[test]
 fn rpki_zero_refresh_interval_rejected() {
-    let err = parse(&rpki_toml("refresh_interval = 0")).unwrap_err();
-    assert!(matches!(err, ConfigError::InvalidRpkiConfig { .. }));
+    let err = parse(&rpki_toml("refresh_interval = 0"))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("cache_servers[0]: refresh_interval"), "{err}");
 }
 
 #[test]
 fn rpki_zero_retry_interval_rejected() {
-    let err = parse(&rpki_toml("retry_interval = 0")).unwrap_err();
-    assert!(matches!(err, ConfigError::InvalidRpkiConfig { .. }));
+    let err = parse(&rpki_toml("retry_interval = 0"))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("cache_servers[0]: retry_interval"), "{err}");
 }
 
 #[test]
 fn rpki_zero_expire_interval_rejected() {
-    let err = parse(&rpki_toml("expire_interval = 0")).unwrap_err();
-    assert!(matches!(err, ConfigError::InvalidRpkiConfig { .. }));
+    let err = parse(&rpki_toml("expire_interval = 0"))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("cache_servers[0]: expire_interval"), "{err}");
 }
 
 #[test]
@@ -5414,8 +5454,9 @@ fn rpki_expire_less_than_refresh_rejected() {
     let err = parse(&rpki_toml(
         "refresh_interval = 3600\nexpire_interval = 1800",
     ))
-    .unwrap_err();
-    assert!(matches!(err, ConfigError::InvalidRpkiConfig { .. }));
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("cache_servers[0]: expire_interval"), "{err}");
 }
 
 #[test]

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -890,26 +890,44 @@ impl Config {
 
         // Validate RPKI cache server config
         if let Some(ref rpki) = self.rpki {
+            let mut cache_addresses = HashMap::new();
             for (i, server) in rpki.cache_servers.iter().enumerate() {
+                let address = server.address.parse::<SocketAddr>().map_err(|e| {
+                    ConfigError::InvalidRpkiConfig {
+                        reason: format!(
+                            "cache_servers[{i}]: invalid address {:?}: {e}",
+                            server.address
+                        ),
+                    }
+                })?;
+                if let Some(previous) = cache_addresses.insert(address, i) {
+                    return Err(ConfigError::InvalidRpkiConfig {
+                        reason: format!(
+                            "cache_servers[{i}]: duplicate address {:?}; canonical {address} \
+                             matches cache_servers[{previous}]",
+                            server.address
+                        ),
+                    });
+                }
                 if server.refresh_interval == 0 {
                     return Err(ConfigError::InvalidRpkiConfig {
-                        reason: format!("cache_server[{i}]: refresh_interval must be > 0"),
+                        reason: format!("cache_servers[{i}]: refresh_interval must be > 0"),
                     });
                 }
                 if server.retry_interval == 0 {
                     return Err(ConfigError::InvalidRpkiConfig {
-                        reason: format!("cache_server[{i}]: retry_interval must be > 0"),
+                        reason: format!("cache_servers[{i}]: retry_interval must be > 0"),
                     });
                 }
                 if server.expire_interval == 0 {
                     return Err(ConfigError::InvalidRpkiConfig {
-                        reason: format!("cache_server[{i}]: expire_interval must be > 0"),
+                        reason: format!("cache_servers[{i}]: expire_interval must be > 0"),
                     });
                 }
                 if server.expire_interval < server.refresh_interval {
                     return Err(ConfigError::InvalidRpkiConfig {
                         reason: format!(
-                            "cache_server[{i}]: expire_interval ({}) must be >= refresh_interval ({})",
+                            "cache_servers[{i}]: expire_interval ({}) must be >= refresh_interval ({})",
                             server.expire_interval, server.refresh_interval
                         ),
                     });

--- a/tests/interop_tier_auth_rr.rs
+++ b/tests/interop_tier_auth_rr.rs
@@ -147,8 +147,25 @@ fn rr_and_route_server_interop_is_tier_authenticated_end_to_end() {
             .replace("GOBMP_ADDR", "127.0.0.1")
             .replace("SINK_ADDR", "127.0.0.1")
             .replace("ROUTINATOR_ADDR", "127.0.0.1")
-            .replace("STAYRTR_ADDR", "127.0.0.1")
-            .replace("RTRV2_ADDR", "127.0.0.1");
+            .replace("STAYRTR_ADDR", "127.0.0.2")
+            .replace("RTRV2_ADDR", "127.0.0.3");
+        if name == "rustbgpd-m84-multicache.toml" {
+            let value: toml::Value =
+                toml::from_str(&materialized).unwrap_or_else(|error| panic!("{name}: {error}"));
+            let addresses: BTreeSet<_> = value["rpki"]["cache_servers"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|cache| {
+                    cache["address"]
+                        .as_str()
+                        .unwrap()
+                        .parse::<std::net::SocketAddr>()
+                })
+                .collect::<Result<_, _>>()
+                .unwrap();
+            assert_eq!(addresses.len(), 3, "M84 must retain three distinct caches");
+        }
         let mut staged = tempfile::Builder::new()
             .suffix(".config-check")
             .tempfile_in(&config_dir)


### PR DESCRIPTION
## Summary

- parse every configured RPKI cache endpoint during config validation so `--check` cannot bless a cache startup later skips
- reject canonical duplicate socket addresses, including equivalent IPv6 spellings that would share one VRP-manager state key
- make the numeric IPv4 / bracketed IPv6 contract explicit in schema and operator documentation
- keep startup parsing defensive and leave RTR, VRP merge, DNS, and doctor behavior unchanged

## Verification

- invalid hostname/malformed endpoint rejection
- canonical duplicate IPv6 rejection
- unique numeric IPv4 and bracketed IPv6 acceptance
- schema freshness and direct generated-schema comparison
- M84 materialized config proves three distinct cache endpoints before production `--check`
- v1 stable-surface gate
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- full pre-commit and pre-push hook stages

## Load-bearing proofs

- removing endpoint parsing makes the invalid-hostname regression red
- removing canonical deduplication makes the equivalent-IPv6 regression red
- the unique numeric IPv4/IPv6 test fences accidental over-rejection
- M84's parsed-set assertion goes red if its three logical caches collapse to one address again

Closes LAN-749.
