### PR TITLE
Keep outbound prefix-limit recovery fair under backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Outbound prefix-limit recovery now rotates after a backpressured peer,
+  allowing other queued peers to recover while preserving the failed peer's
+  transactional retry intent.
+
 - The per-commit real-transport smoke receipt no longer records an empty RSS
   sample when its supervised process exits between liveness and `/proc`
   observation, avoiding a verifier false negative while keeping live

--- a/crates/rib/src/manager/outbound_prefix_limits.rs
+++ b/crates/rib/src/manager/outbound_prefix_limits.rs
@@ -244,6 +244,9 @@ pub(in crate::manager) struct OutboundLimitControl {
     /// Coalesced capacity-recovery intent: at most one resync per peer and
     /// family, regardless of how often capacity opens.
     recovery: BTreeMap<IpAddr, HashSet<Afi>>,
+    /// Peer whose recovery was most recently attempted. Selection resumes
+    /// after it and wraps, so one backpressured peer cannot retain the head.
+    recovery_cursor: Option<IpAddr>,
 }
 
 impl OutboundLimitControl {
@@ -252,6 +255,9 @@ impl OutboundLimitControl {
     /// reconnect resolves them again.
     pub(in crate::manager) fn reap_peer(&mut self, peer: IpAddr) {
         self.recovery.remove(&peer);
+        if self.recovery.is_empty() {
+            self.recovery_cursor = None;
+        }
     }
 }
 
@@ -694,6 +700,9 @@ impl RibManager {
 
     /// Coalesce one family-scoped capacity-recovery resync.
     fn schedule_outbound_limit_recovery(&mut self, peer: IpAddr, afi: Afi) {
+        if self.outbound_limit_control.recovery.is_empty() {
+            self.outbound_limit_control.recovery_cursor = None;
+        }
         self.outbound_limit_control
             .recovery
             .entry(peer)
@@ -701,7 +710,7 @@ impl RibManager {
             .insert(afi);
     }
 
-    /// Select the next runnable family in deterministic peer/family order.
+    /// Select one runnable family after the last attempted peer, then wrap.
     ///
     /// IPv4 precedes IPv6 within a peer, matching [`LIMITED_FAMILIES`].
     /// Empty/corrupt entries and departed peers are discarded rather than
@@ -717,7 +726,14 @@ impl RibManager {
                         .into_iter()
                         .any(|afi| families.contains(&afi))
             });
-        for (&peer, families) in &self.outbound_limit_control.recovery {
+        if self.outbound_limit_control.recovery.is_empty() {
+            self.outbound_limit_control.recovery_cursor = None;
+            return None;
+        }
+        let cursor = self.outbound_limit_control.recovery_cursor;
+        let mut wrapped = None;
+        let mut selected = None;
+        'peers: for (&peer, families) in &self.outbound_limit_control.recovery {
             for afi in LIMITED_FAMILIES {
                 if families.contains(&afi)
                     && !self.selection_convergence_held((afi, Safi::Unicast))
@@ -726,11 +742,19 @@ impl RibManager {
                         .get(&peer)
                         .is_some_and(|pending| pending.contains(&(afi, Safi::Unicast)))
                 {
-                    return Some((peer, afi));
+                    wrapped.get_or_insert((peer, afi));
+                    if cursor.is_none_or(|cursor| peer > cursor) {
+                        selected = Some((peer, afi));
+                        break 'peers;
+                    }
                 }
             }
         }
-        None
+        let selected = selected.or(wrapped);
+        if let Some((peer, _)) = selected {
+            self.outbound_limit_control.recovery_cursor = Some(peer);
+        }
+        selected
     }
 
     /// Remove one recovery only after its replay committed.
@@ -745,6 +769,9 @@ impl RibManager {
             });
         if remove_peer {
             self.outbound_limit_control.recovery.remove(&peer);
+        }
+        if self.outbound_limit_control.recovery.is_empty() {
+            self.outbound_limit_control.recovery_cursor = None;
         }
     }
 

--- a/crates/rib/src/manager/tests/outbound_prefix_limits.rs
+++ b/crates/rib/src/manager/tests/outbound_prefix_limits.rs
@@ -870,6 +870,100 @@ fn recovery_ticks_slice_peers_in_order_and_keep_each_slice_truthful() {
     assert!(!manager.resync_dirty_peers_bounded());
 }
 
+/// A permanently full lowest-address peer spends one turn but cannot retain
+/// the queue head forever. Each healthy successor commits on one of the next
+/// turns, while the failed intent survives the rotation and retries afterward.
+///
+/// Load-bearing breaks: always selecting the first runnable `BTreeMap` entry
+/// or advancing only after commit starves every healthy peer; skipping the
+/// first entry makes the initial failed turn succeed; dropping failed intent
+/// loses both durability checks; draining more than one slice touches a later
+/// receiver early; failing to wrap loses the retry; bypassing transactional
+/// replay or completion breaks its wire truth or leaves pending intent.
+#[test]
+fn backpressured_recovery_rotates_past_healthy_peers_and_retries() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    manager.test_force_ungrouped = true;
+    let peers = [
+        IpAddr::V4(Ipv4Addr::new(10, 113, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 113, 0, 2)),
+        IpAddr::V4(Ipv4Addr::new(10, 113, 0, 3)),
+        IpAddr::V4(Ipv4Addr::new(10, 113, 0, 4)),
+    ];
+    let mut outbound = peers
+        .into_iter()
+        .map(|peer| register_peer(&mut manager, peer))
+        .collect::<Vec<_>>();
+    let limits = |cap| limit_config(&peers.map(|peer| (peer, Some(cap), None)), &[]);
+    install(&mut manager, 1, limits(1));
+    let source = Ipv4Addr::new(192, 0, 2, 120);
+    announce(
+        &mut manager,
+        IpAddr::V4(source),
+        source_routes(source, &[61, 62]),
+    );
+    for receiver in &mut outbound {
+        drop(wire_prefixes(receiver));
+    }
+    install(&mut manager, 2, limits(2));
+
+    let blocked_tx = manager
+        .outbound_peers
+        .get(&peers[0])
+        .expect("lowest-address peer stays registered")
+        .clone();
+    while blocked_tx.try_send(OutboundRouteUpdate::default()).is_ok() {}
+
+    assert!(
+        !manager.drain_outbound_limit_recovery(),
+        "the full peer's one attempted slice must fail"
+    );
+    assert_eq!(
+        manager.outbound_limit_recovery_for(peers[0]),
+        vec![Afi::Ipv4],
+        "failure must retain its durable recovery intent"
+    );
+
+    for healthy_index in 1..peers.len() {
+        assert!(
+            manager.drain_outbound_limit_recovery(),
+            "healthy peer {healthy_index} must commit within N+1 turns"
+        );
+        for (receiver_index, receiver) in outbound.iter_mut().enumerate().skip(1) {
+            assert_eq!(
+                wire_prefixes(receiver).len(),
+                if receiver_index == healthy_index {
+                    2
+                } else {
+                    0
+                },
+                "one turn may replay only healthy peer {healthy_index}"
+            );
+        }
+    }
+    assert_eq!(
+        manager.outbound_limit_recovery_for(peers[0]),
+        vec![Afi::Ipv4],
+        "the failed intent must survive a complete rotation"
+    );
+
+    drop(wire_prefixes(&mut outbound[0]));
+    assert!(
+        manager.drain_outbound_limit_recovery(),
+        "the failed peer must retry after capacity returns"
+    );
+    assert_eq!(
+        wire_prefixes(&mut outbound[0]).len(),
+        2,
+        "the retry must commit its full truthful replay"
+    );
+    assert!(
+        !manager.outbound_limit_recovery_pending(),
+        "all intent must be complete after the retry"
+    );
+}
+
 /// A stale queue head is discarded without spending the tick or disturbing
 /// either live sibling. The next live peer still completes, and its ordered
 /// successor remains queued.


### PR DESCRIPTION
## Summary

- rotate the bounded recovery queue after every attempted peer, including a backpressured failure
- preserve the failed peer's transactional retry intent while healthy peers continue recovering
- keep the actor budget at exactly one recovery slice per tick

## Why

The ordered recovery map always selected its lowest-address runnable peer. If that peer's writer stayed full, its failed intent correctly remained queued but it was selected again on every tick, starving every later peer indefinitely.

## Verification

- parent-red proof: the four-peer regression fails on current main at the first healthy peer
- candidate-green proof: the blocked peer spends one turn, three healthy peers commit one per following tick, and the blocked peer retries after capacity returns
- 31/31 outbound-prefix-limit tests
- 1,028 RIB library tests passed, 2 ignored
- workspace formatting, warning-denying clippy, tests, docs, diff checks, and hooks

The change is limited to the existing recovery controller, its regression test, and one changelog entry.
