### PR TITLE
Add dynamic-neighbor admission panels to Grafana

### DIFF
--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -135,6 +135,12 @@ inside the bounded window does.
   headroom, and blocking state together. Only query D (`blocking`) uses the
   stepped 0..1 right axis; the cumulative `blocked_total` event counter is
   intentionally excluded.
+- **Dynamic-neighbor admission capacity** plots raw used, limit, and saturating
+  headroom gauges for each selected scrape instance. These daemon metrics are
+  process-global and label-free; they cannot provide a listener- or range-level
+  breakdown.
+- **Dynamic-neighbor admission rejections** plots the non-zero admission
+  rejection rate for each selected scrape instance.
 - Outbound queue depth is an absolute gauge of coalesced UPDATE frames, sampled
   at enqueue-batch and writer-drain boundaries. A short convergence spike is
   not itself a slow peer; `bgp_peer_slow` is the daemon's persistent 0/1 state.
@@ -190,9 +196,10 @@ label; changing either raw selection gauge to a rate; removing step
 rendering; dropping `instance` from a route-safety aggregation; weakening any of the six
 label-rich legends; dropping any seeded-series `> 0` filter; or replacing the
 executable workflow step with only a comment.
-It also pins capacity panel IDs 62/63 and their 12-by-8 layout, the six exact
-raw queries and legends, RFC 8212 0/1 mappings and steps, and the query-D-only
-right-axis override.
+It also pins capacity panel IDs 62–65 and their 12-by-8 layout, the exact
+queries and legends, RFC 8212 0/1 mappings and steps, the query-D-only right-axis
+override, and dynamic-neighbor panel target sets, units, and minima. Removing
+either dynamic-neighbor panel or changing any of its four queries is red.
 
 The slow-peer fixture is red if its `== 1` predicate or five-minute hold is
 changed. The RFC 8212 matrix covers import-only, export-only, and healthy peers;

--- a/docs/grafana/rustbgpd-overview.json
+++ b/docs/grafana/rustbgpd-overview.json
@@ -2774,6 +2774,54 @@
           "refId": "D"
         }
       ]
+    },
+    {
+      "id": 64,
+      "type": "timeseries",
+      "title": "Dynamic-neighbor admission capacity",
+      "description": "Process-global dynamic-neighbor slots per selected scrape instance. The daemon metrics are label-free: no listener- or range-level breakdown exists.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 169 },
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "min": 0 }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_dynamic_neighbor_slots_used{instance=~\"$instance\"}",
+          "legendFormat": "{{instance}} used",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_dynamic_neighbor_slots_limit{instance=~\"$instance\"}",
+          "legendFormat": "{{instance}} limit",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "bgp_dynamic_neighbor_slots_headroom{instance=~\"$instance\"}",
+          "legendFormat": "{{instance}} headroom",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 65,
+      "type": "timeseries",
+      "title": "Dynamic-neighbor admission rejections",
+      "description": "Per-instance rate of matching inbound dynamic connections rejected because the process-global slot limit was full. Zero-valued series are suppressed.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 169 },
+      "fieldConfig": { "defaults": { "unit": "ops", "min": 0 }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(bgp_dynamic_neighbor_limit_rejections_total{instance=~\"$instance\"}[$__rate_interval]) > 0",
+          "legendFormat": "{{instance}} rejected",
+          "refId": "A"
+        }
+      ]
     }
   ]
 }

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -117,6 +117,19 @@ TARGETS = {
     ("Outbound prefix capacity", "D"): (
         'bgp_outbound_prefix_blocking{instance=~"$instance",peer=~"$peer"}'
     ),
+    ("Dynamic-neighbor admission capacity", "A"): (
+        'bgp_dynamic_neighbor_slots_used{instance=~"$instance"}'
+    ),
+    ("Dynamic-neighbor admission capacity", "B"): (
+        'bgp_dynamic_neighbor_slots_limit{instance=~"$instance"}'
+    ),
+    ("Dynamic-neighbor admission capacity", "C"): (
+        'bgp_dynamic_neighbor_slots_headroom{instance=~"$instance"}'
+    ),
+    ("Dynamic-neighbor admission rejections", "A"): (
+        "rate(bgp_dynamic_neighbor_limit_rejections_total"
+        '{instance=~"$instance"}[$__rate_interval]) > 0'
+    ),
 }
 
 REQUIRED_LEGENDS = {
@@ -140,6 +153,10 @@ REQUIRED_LEGENDS = {
     ("Outbound prefix capacity", "B"): "{{peer}} {{family}} limit",
     ("Outbound prefix capacity", "C"): "{{peer}} {{family}} headroom",
     ("Outbound prefix capacity", "D"): "{{peer}} {{family}} blocking",
+    ("Dynamic-neighbor admission capacity", "A"): "{{instance}} used",
+    ("Dynamic-neighbor admission capacity", "B"): "{{instance}} limit",
+    ("Dynamic-neighbor admission capacity", "C"): "{{instance}} headroom",
+    ("Dynamic-neighbor admission rejections", "A"): "{{instance}} rejected",
     ("RIB ingest pressure", "B"): "inbound safely parked {{peer}}",
     ("RIB ingest pressure", "C"): "outbound work lost {{peer}}",
 }
@@ -164,8 +181,10 @@ ROUTE_SAFETY_PANELS = {
 }
 
 CAPACITY_PANELS = {
-    "RFC 8212 missing policy": (62, 0),
-    "Outbound prefix capacity": (63, 12),
+    "RFC 8212 missing policy": (62, 0, 161),
+    "Outbound prefix capacity": (63, 12, 161),
+    "Dynamic-neighbor admission capacity": (64, 0, 169),
+    "Dynamic-neighbor admission rejections": (65, 12, 169),
 }
 
 WORKFLOW_PATHS = {
@@ -355,13 +374,13 @@ def main() -> None:
     if selection_defaults.get("custom", {}).get("lineInterpolation") != "stepAfter":
         fail("selection-deferral state must use step interpolation")
 
-    for title, (expected_id, expected_x) in CAPACITY_PANELS.items():
+    for title, (expected_id, expected_x, expected_y) in CAPACITY_PANELS.items():
         panel = next((item for item in panels if item.get("title") == title), None)
         if panel is None or panel.get("type") != "timeseries":
             fail(f"{title} must exist as a timeseries panel")
         if panel.get("id") != expected_id:
             fail(f"{title} must use panel id {expected_id}")
-        expected_position = {"h": 8, "w": 12, "x": expected_x, "y": 161}
+        expected_position = {"h": 8, "w": 12, "x": expected_x, "y": expected_y}
         if panel.get("gridPos") != expected_position:
             fail(f"{title} must use compact grid position {expected_position}")
 
@@ -418,6 +437,38 @@ def main() -> None:
     ]
     if outbound_panel.get("fieldConfig", {}).get("overrides") != expected_overrides:
         fail("only outbound blocking target D must use a stepped 0..1 right axis")
+
+    dynamic_capacity_panel = next(
+        panel
+        for panel in panels
+        if panel.get("title") == "Dynamic-neighbor admission capacity"
+    )
+    dynamic_capacity_refs = [
+        target.get("refId") for target in dynamic_capacity_panel.get("targets", [])
+    ]
+    if dynamic_capacity_refs != ["A", "B", "C"]:
+        fail("dynamic-neighbor capacity panel must contain exactly targets A through C")
+    dynamic_capacity_defaults = dynamic_capacity_panel.get("fieldConfig", {}).get(
+        "defaults", {}
+    )
+    if dynamic_capacity_defaults != {"unit": "short", "decimals": 0, "min": 0}:
+        fail("dynamic-neighbor capacity must render as nonnegative whole values")
+
+    dynamic_rejections_panel = next(
+        panel
+        for panel in panels
+        if panel.get("title") == "Dynamic-neighbor admission rejections"
+    )
+    dynamic_rejection_refs = [
+        target.get("refId") for target in dynamic_rejections_panel.get("targets", [])
+    ]
+    if dynamic_rejection_refs != ["A"]:
+        fail("dynamic-neighbor rejections panel must contain exactly target A")
+    dynamic_rejection_defaults = dynamic_rejections_panel.get("fieldConfig", {}).get(
+        "defaults", {}
+    )
+    if dynamic_rejection_defaults != {"unit": "ops", "min": 0}:
+        fail("dynamic-neighbor rejection rate must render as nonnegative operations")
 
     try:
         workflow_text = WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add process-global dynamic-neighbor slot used, limit, and headroom to the shipped Grafana dashboard
- add the dynamic-neighbor admission rejection rate with zero-series suppression
- extend the dashboard checker to pin panel identity, placement, queries, legends, target arrays, units, and minima

## Boundary

The daemon metrics are label-free process globals. The panels split only by the Prometheus scrape `instance`; they do not claim listener- or range-level visibility.

## Verification

- dashboard checker: 65 unique panels and 32 operator targets
- JSON parsing and Python compilation
- 31 destructive checks covering the baseline dashboard, both panel deletions, every query removal/mutation, legends, refs, IDs, positions, types, units, minima, and extra targets
- diff checks and native hooks

The change is limited to the dashboard JSON, its structural checker, and the Grafana operator guide.
