### PR TITLE
Document adopter support and proof boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ evolving API.**
 |-----------|---------------|
 | **Target use case** | Data-center fabric pilots, IXP route servers, programmable BGP control planes, lab/test environments |
 | **Maturity** | Public alpha (v0.61.0) |
+| **Adopter support** | Reporting channels, compatibility boundaries, and proof limits are documented in [SUPPORT.md](SUPPORT.md). |
 | **Narrow stable contract** | The machine-pinned [route-server / route-reflector v1 contract](docs/v1-stable-contract.md) covers only its inventoried control-plane roles and surfaces; the project and all unlisted features remain alpha. |
 | **Implemented** | Dual-stack BGP/MP-BGP, Add-Path, GR/LLGR, RPKI/RTR, ASPA path verification, FlowSpec, BMP, MRT, BFD, EVPN/VXLAN (alpha), and full gRPC/CLI management. Linux FIB integration is default-off and scoped to RFC 7999 discard routes and configured unicast tables (including ECMP and weighted multipath); broader routing-suite features remain future work. |
 | **Supported OS** | Linux (primary target). Requires `CAP_NET_BIND_SERVICE` for port 179. |

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,56 @@
+# Adopter support
+
+rustbgpd is public alpha overall, including its route-reflector and IXP
+route-server niche. This document explains how adopters can report problems
+and how to interpret the project's compatibility and proof claims. It does not
+declare production readiness.
+
+## Compatibility boundary
+
+The only narrow compatibility promise is the machine-inventoried
+[route-server / route-reflector v1 contract](docs/v1-stable-contract.md).
+That promise applies only to the roles and surfaces listed by its inventory.
+The rest of the project remains alpha and may change between minor releases.
+
+RFC 8212 enforcement remains opt-in under
+[ADR-0112](docs/adr/0112-rfc-8212-ebgp-requires-policy.md).
+[ADR-0119](docs/adr/0119-rfc-8212-secure-default-config-epoch.md) is Proposed;
+it does not activate a secure default.
+
+## Reporting an ordinary bug
+
+Open an issue with the
+[bug report template](.github/ISSUE_TEMPLATE/bug_report.md). Include:
+
+- the rustbgpd version or commit;
+- the OS, kernel, and peer implementation versions;
+- minimal reproduction steps, expected behavior, and observed behavior; and
+- relevant redacted logs or configuration snippets.
+
+When possible, attach the redacted support bundle produced by `rbgp doctor`;
+the [operations guide](docs/OPERATIONS.md#support-bundles-and-triage-checks-rbgp-doctor)
+describes its contents and collection options. Review attachments for
+environment-specific sensitive information before publishing them.
+
+No response time, resolution time, maintenance window, backport policy, or
+release cadence is promised for ordinary reports.
+
+## Reporting a vulnerability
+
+Follow the root [security policy](SECURITY.md) and use its private reporting
+channel. Never report a vulnerability in a public issue. The security policy's
+separate handling timeline applies only to qualifying vulnerability reports;
+it is not an ordinary-support commitment.
+
+## Releases and proof
+
+The [changelog](CHANGELOG.md) records release history and notable changes. The
+[release checklist](docs/RELEASE_CHECKLIST.md) defines gates that must pass
+before a tag; neither document is a release schedule.
+
+Proof receipts establish only the named fixtures, software versions,
+environments, and assertions recorded in each receipt. They do not establish
+general production support. Start with the
+[operational proof index](docs/OPERATIONAL_PROOF.md) and inspect the linked
+[receipt catalog](docs/RECEIPTS.md), [interoperability matrix](docs/INTEROP.md),
+and methodology before applying a result to a different environment.


### PR DESCRIPTION
## Summary

- add a concise adopter-facing support index for the route-server and route-reflector niche
- distinguish the narrow machine-inventoried compatibility contract from the project's overall alpha status
- document ordinary bug and private vulnerability intake without creating staffing, SLA, cadence, backport, or production-support promises
- state the current RFC 8212 opt-in boundary and the fixture-scoped meaning of proof receipts

## Verification

- all 11 relative links and the operations-guide anchor resolve
- deleting `SUPPORT.md` or corrupting its anchored link makes the structural validation fail
- exactly one README Project Status link to `SUPPORT.md`
- source-claim and prohibited-promise audit
- 57 changed lines across two files; no changelog entry
- diff checks and native hooks

This is documentation-only; behavioral red proof is not applicable.
