### PR TITLE
Propagate CLI stdout flush failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- CLI policy formatting, config diff/plan, and doctor now fail when their
+  buffered stdout cannot be flushed instead of reporting a successful status.
+
 - RPKI cache endpoints now fail configuration validation unless they are unique
   numeric IPv4 or bracketed IPv6 socket addresses; DNS hostnames and equivalent
   duplicate IPv6 spellings are rejected before startup.

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -511,6 +511,16 @@ fn print_policy_json<T: Serialize>(
     }
 }
 
+fn write_formatted_stdout(writer: &mut dyn std::io::Write, formatted: &str) -> i32 {
+    match output::write_bytes(writer, formatted.as_bytes()) {
+        Ok(()) => 0,
+        Err(error) => {
+            output::report_write_error("formatted policy output", &error);
+            1
+        }
+    }
+}
+
 /// `rbgp policy fmt [--check] FILE...` — the canonical `.rpol`
 /// formatter (LAN-323). Rewrites files in place via an atomic
 /// write-temp-rename; `--check` rewrites nothing and prints a diff
@@ -521,7 +531,7 @@ fn print_policy_json<T: Serialize>(
 /// `--check` found differences or any file was unreadable/unformattable
 /// (syntax errors — broken files are refused, never rewritten).
 pub fn fmt_local(files: &[String], check: bool) -> i32 {
-    use std::io::{IsTerminal, Read, Write};
+    use std::io::{IsTerminal, Read};
 
     use rustbgpd_policy::rpol::{FmtError, format_rpol};
 
@@ -576,8 +586,8 @@ pub fn fmt_local(files: &[String], check: bool) -> i32 {
                     eprintln!("<stdin>: needs formatting");
                     failed = true;
                 }
-            } else if std::io::stdout().write_all(formatted.as_bytes()).is_err() {
-                failed = true;
+            } else {
+                failed |= write_formatted_stdout(&mut std::io::stdout(), &formatted) != 0;
             }
             continue;
         }
@@ -1893,6 +1903,58 @@ mod tests {
 
         fn flush(&mut self) -> std::io::Result<()> {
             Ok(())
+        }
+    }
+
+    struct ObservedWriter {
+        bytes: Vec<u8>,
+        flushes: usize,
+        write_error: Option<std::io::ErrorKind>,
+        flush_error: Option<std::io::ErrorKind>,
+    }
+
+    impl Write for ObservedWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            if let Some(kind) = self.write_error {
+                return Err(std::io::Error::from(kind));
+            }
+            self.bytes.extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.flushes += 1;
+            self.flush_error
+                .map_or(Ok(()), |kind| Err(std::io::Error::from(kind)))
+        }
+    }
+
+    #[test]
+    fn formatted_stdout_writes_exact_bytes_and_flushes() {
+        let mut writer = ObservedWriter {
+            bytes: Vec::new(),
+            flushes: 0,
+            write_error: None,
+            flush_error: None,
+        };
+        assert_eq!(write_formatted_stdout(&mut writer, "policy p {}\n"), 0);
+        assert_eq!(writer.bytes, b"policy p {}\n");
+        assert_eq!(writer.flushes, 1);
+    }
+
+    #[test]
+    fn formatted_stdout_write_and_flush_failures_exit_one() {
+        for (write_error, flush_error) in [
+            (Some(std::io::ErrorKind::BrokenPipe), None),
+            (None, Some(std::io::ErrorKind::PermissionDenied)),
+        ] {
+            let mut writer = ObservedWriter {
+                bytes: Vec::new(),
+                flushes: 0,
+                write_error,
+                flush_error,
+            };
+            assert_eq!(write_formatted_stdout(&mut writer, "policy p {}\n"), 1);
         }
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1989,13 +1989,12 @@ fn candidate_file(candidate: Option<String>, from_file: Option<String>) -> Strin
         .expect("clap requires CANDIDATE or --from-file")
 }
 
-/// Terminate with the `config diff` / `config plan` detailed exit code:
-/// 0 when the candidate matches the runtime config, 2 when changes are
-/// present (errors take the generic exit-1 path in `main`).
-fn exit_with_change_status(has_changes: bool) -> ! {
-    use std::io::Write as _;
-    let _ = std::io::stdout().flush();
-    std::process::exit(commands::config::change_status_exit_code(has_changes));
+fn flush_stdout_result<W: std::io::Write + ?Sized>(
+    writer: &mut W,
+    result: Result<i32, CliError>,
+) -> Result<i32, CliError> {
+    writer.flush().map_err(CliError::Io)?;
+    result
 }
 
 async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
@@ -2153,7 +2152,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
     // owns a detailed 0/1/2 exit-code contract.
     if let Command::Doctor { output, log_file } = &cli.command {
         let connection = connect(&cli.addr, cli.token_file.as_deref()).await;
-        let code = commands::doctor::run(
+        let result = commands::doctor::run(
             connection,
             &commands::doctor::DoctorOptions {
                 output: output.as_deref(),
@@ -2163,9 +2162,8 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                 json: cli.json,
             },
         )
-        .await?;
-        use std::io::Write as _;
-        let _ = std::io::stdout().flush();
+        .await;
+        let code = flush_stdout_result(&mut std::io::stdout(), result)?;
         std::process::exit(code);
     }
 
@@ -2205,7 +2203,8 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
             } => {
                 let from_file = candidate_file(candidate, from_file);
                 let has_changes = commands::config::diff(connection, &from_file, json).await?;
-                exit_with_change_status(has_changes);
+                let code = commands::config::change_status_exit_code(has_changes);
+                std::process::exit(flush_stdout_result(&mut std::io::stdout(), Ok(code))?);
             }
             ConfigAction::Plan {
                 candidate,
@@ -2220,7 +2219,8 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     json,
                 )
                 .await?;
-                exit_with_change_status(has_changes);
+                let code = commands::config::change_status_exit_code(has_changes);
+                std::process::exit(flush_stdout_result(&mut std::io::stdout(), Ok(code))?);
             }
             ConfigAction::Apply {
                 candidate,
@@ -3245,6 +3245,57 @@ mod tests {
     use super::*;
     use crate::test_support::spawn_mock_server;
     use clap::Parser;
+
+    struct FlushWriter(Option<std::io::ErrorKind>);
+
+    impl std::io::Write for FlushWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.0
+                .map_or(Ok(()), |kind| Err(std::io::Error::from(kind)))
+        }
+    }
+
+    #[test]
+    fn flush_preserves_config_and_doctor_outcomes() {
+        for code in [0, 2] {
+            assert_eq!(
+                flush_stdout_result(&mut FlushWriter(None), Ok(code)).unwrap(),
+                code
+            );
+        }
+        for outcome in [
+            Ok(0),
+            Ok(2),
+            Err(CliError::Argument("doctor failed".into())),
+        ] {
+            let result = flush_stdout_result(&mut FlushWriter(None), outcome);
+            match result {
+                Ok(code) => assert!(matches!(code, 0 | 2)),
+                Err(error) => assert_eq!(error.to_string(), "doctor failed"),
+            }
+        }
+    }
+
+    #[test]
+    fn flush_error_overrides_success_and_original_error() {
+        for kind in [
+            std::io::ErrorKind::BrokenPipe,
+            std::io::ErrorKind::PermissionDenied,
+        ] {
+            for outcome in [
+                Ok(0),
+                Ok(2),
+                Err(CliError::Argument("doctor failed".into())),
+            ] {
+                let error = flush_stdout_result(&mut FlushWriter(Some(kind)), outcome).unwrap_err();
+                assert!(matches!(error, CliError::Io(ref error) if error.kind() == kind));
+            }
+        }
+    }
 
     #[test]
     fn generic_broken_pipe_error_has_no_rendered_diagnostic() {


### PR DESCRIPTION
## Summary

- make policy formatting report stdout write and flush failures through the existing CLI error ladder
- flush config diff/plan and doctor output before returning their detailed outcomes
- preserve successful config and doctor exit semantics while making any flush failure exit 1

## Load-bearing proof

- removing the policy flush fails the flush counter assertion
- swallowing a policy write failure changes the expected exit from 1 to 0
- returning the doctor outcome before flushing fails the flush-error override assertion

All three mutations compile and fail the intended regression test.

## Validation

- cargo fmt --all -- --check
- cargo test --locked -p rustbgpctl
- cargo clippy --locked -p rustbgpctl --all-targets -- -D warnings
- git diff --check