### PR TITLE
Exercise IPv4-only BFD without AF_INET6

### DIFF
--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -649,7 +649,12 @@ jobs:
       - name: ADR-0061 FIB runtime netns test
         run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh fib_runtime
 
-      - name: ADR-0067 BFD runtime netns test
+      # This ephemeral hosted invocation denies AF_INET6 to prove the current
+      # IPv4-only BFD actor does not depend on that family. Future selectors
+      # that open address families can reuse the same opt-in harness profile.
+      - name: ADR-0067 BFD runtime netns test (IPv4-only, AF_INET6 absent)
+        env:
+          SECCOMP_PROFILE: crates/evpn-linux/tests/docker/seccomp-deny-af-inet6.json
         run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh bfd_runtime
 
       - name: ADR-0089 VLAN-scoped FDB netns test

--- a/crates/evpn-linux/tests/docker/run-netns-tests.sh
+++ b/crates/evpn-linux/tests/docker/run-netns-tests.sh
@@ -127,6 +127,22 @@ case "${1:-all}" in
         ;;
 esac
 
+SECCOMP_ARGS=()
+if [ -n "${SECCOMP_PROFILE:-}" ]; then
+    if [[ "$SECCOMP_PROFILE" = /* ]]; then
+        SECCOMP_PROFILE_CANDIDATE="$SECCOMP_PROFILE"
+    else
+        SECCOMP_PROFILE_CANDIDATE="$REPO_ROOT/$SECCOMP_PROFILE"
+    fi
+    if ! SECCOMP_PROFILE_RESOLVED="$(realpath -- "$SECCOMP_PROFILE_CANDIDATE" 2>/dev/null)" ||
+        [ ! -f "$SECCOMP_PROFILE_RESOLVED" ] ||
+        [ ! -r "$SECCOMP_PROFILE_RESOLVED" ]; then
+        echo "ERROR: SECCOMP_PROFILE must resolve to a readable regular file: $SECCOMP_PROFILE" >&2
+        exit 2
+    fi
+    SECCOMP_ARGS+=("--security-opt=seccomp=$SECCOMP_PROFILE_RESOLVED")
+fi
+
 if ! command -v docker >/dev/null 2>&1; then
     echo "ERROR: docker not found in PATH" >&2
     exit 2
@@ -187,6 +203,7 @@ DOCKER_ARGS=(
     # SYS_ADMIN don't help — AppArmor's mount mediation runs
     # independently of POSIX caps.
     --security-opt apparmor=unconfined
+    "${SECCOMP_ARGS[@]}"
     -e EVPN_LINUX_NETNS=1
     -e RUST_BACKTRACE=1
     -e CARGO_TERM_COLOR=always

--- a/crates/evpn-linux/tests/docker/seccomp-deny-af-inet6.json
+++ b/crates/evpn-linux/tests/docker/seccomp-deny-af-inet6.json
@@ -1,0 +1,17 @@
+{
+  "defaultAction": "SCMP_ACT_ALLOW",
+  "syscalls": [
+    {
+      "names": ["socket"],
+      "action": "SCMP_ACT_ERRNO",
+      "errnoRet": 97,
+      "args": [
+        {
+          "index": 0,
+          "value": 10,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add an opt-in netns harness profile that makes socket(AF_INET6) return EAFNOSUPPORT
- apply it only to the existing hosted IPv4-only ADR-0067 BFD scenario
- validate profile paths before Docker so invalid input exits 2 without starting work

The profile is intentionally default-allow and is a deterministic negative-capability test, not container hardening or a general security boundary.

## Load-bearing proof

- candidate: the real BFD netns session reaches Up and detects Down under the profile
- historical control: the pre-#1242 parent compiles, loads the same profile, and fails at actor socket startup with Address family not supported by protocol, os error 97
- both the worker and an independent exact-head review reproduced the causal red and current green

## Validation

- exact jq profile assertion and JSON parse
- bash -n and shellcheck
- invalid and directory profile paths exit 2 before Docker
- git diff --check
- exact three-file, 36-line scope
- cargo fmt and clippy hooks
- cargo doc through an isolated writable target