### PR TITLE
Correct reload roadmap and DeletePolicy contract docs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -365,11 +365,9 @@ new AFI/SAFI and EVPN dataplane expansion.
   transport-side encode wake storm is bound by ADR-0109's progressive
   chunk-publication amendment, so an observer's longest wire silence now
   tracks per-slice encode latency instead of the single-threaded full-table
-  encode. Remaining: gate repeated heterogeneous reloads on completion time,
-  control-query latency, session continuity, and folded advertised-state
-  equivalence. The withdrawn historical `< 1 s` claim is now superseded on
-  every axis by the 2026-07-16 receipt (see its honesty notes for the
-  single-observer worst-case tail).
+  encode. The withdrawn historical `< 1 s` claim is now superseded on every
+  axis by the 2026-07-16 receipt (see its honesty notes for the single-observer
+  worst-case tail).
 - **Keep authoritative replacement readiness design-gated.** A retained
   heterogeneous reload exposed a 200 ms RIB readiness timeout in the per-peer
   remainder after its grouped cohort committed. [ADR-0111](docs/adr/0111-authoritative-policy-replacement-continuation.md)

--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -1012,6 +1012,13 @@ mod tests {
     /// the rows underneath it.
     #[test]
     fn markdown_inventory_matches_machine_readable_export() {
+        assert!(
+            INVENTORY_MD.contains(
+                "| `DeletePolicy` | `mutating` | Per-name. Returns `FAILED_PRECONDITION` if still referenced; the request does nothing. |"
+            ),
+            "DeletePolicy documents its shipped in-use rejection contract"
+        );
+
         let export = serde_json::from_str::<serde_json::Value>(INVENTORY_JSON)
             .expect("docs/grpc-method-inventory.json must be valid JSON");
         let exported = export["methods"]

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -119,7 +119,7 @@ shape itself does not raise the tier.
 | `ListPolicies` | `sensitive_read` | Exposes named policies, statements, actions, communities. |
 | `GetPolicy` | `sensitive_read` | Single-policy detail. |
 | `SetPolicy` | `operator_only` | Replaces a named policy and hot-applies every affected peer; a widely referenced policy can change routing decisions network-wide. |
-| `DeletePolicy` | `mutating` | Per-name. Will fail if still referenced (typed error in the works). |
+| `DeletePolicy` | `mutating` | Per-name. Returns `FAILED_PRECONDITION` if still referenced; the request does nothing. |
 | `ListNeighborSets` | `sensitive_read` | Topology grouping disclosure. |
 | `GetNeighborSet` | `sensitive_read` | Single-set detail. |
 | `SetNeighborSet` | `operator_only` | Replaces a named match set and hot-applies every affected peer; a globally referenced set has network-wide policy impact. |


### PR DESCRIPTION
## Summary

- stop presenting the canceled heterogeneous policy-reload campaign as remaining work while preserving the shipped uniform receipt
- document the shipped DeletePolicy FAILED_PRECONDITION contract and no-op behavior when the policy is still referenced
- extend the existing gRPC inventory fence with an exact deletion-sensitive row assertion

## Load-bearing proof

The new assertion failed against the stale inventory text before the documentation repair. Independent mutation checks also made it fail when the row was deleted, the status changed, or the no-op detail was removed.

## Validation

- cargo test -p rustbgpd-api markdown_inventory_matches_machine_readable_export
- cargo test -p rustbgpd-api delete_policy_in_use_maps_to_failed_precondition
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo doc --workspace --no-deps
- git diff --check