### PR TITLE
Handle offline CLI stdout failures

### DIFF
--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -162,17 +162,25 @@ pub fn check_local(
     coverage_min: Option<f64>,
     json: bool,
 ) -> i32 {
-    check_local_with_json_writer(path, roots, list_deps, coverage, coverage_min, json, None)
+    check_local_with_writer(
+        path,
+        roots,
+        list_deps,
+        coverage,
+        coverage_min,
+        json,
+        &mut std::io::stdout().lock(),
+    )
 }
 
-fn check_local_with_json_writer(
+fn check_local_with_writer(
     path: &str,
     roots: &[String],
     list_deps: bool,
     coverage: bool,
     coverage_min: Option<f64>,
     json: bool,
-    json_writer: Option<&mut dyn std::io::Write>,
+    stdout: &mut dyn std::io::Write,
 ) -> i32 {
     use std::io::IsTerminal;
     use std::path::PathBuf;
@@ -202,7 +210,7 @@ fn check_local_with_json_writer(
     // --list-deps on a broken graph falls through to the compile
     // diagnostics below (exit 1).
     if list_deps && let Some(file) = &file {
-        return print_deps(path, file, json, json_writer);
+        return print_deps(path, file, json, stdout);
     }
     let want_coverage = coverage || coverage_min.is_some();
     let (tests, cov) = match &file {
@@ -221,7 +229,7 @@ fn check_local_with_json_writer(
             tests.as_ref(),
             cov.as_ref(),
             file.as_ref(),
-            json_writer,
+            stdout,
         ) {
             output::report_write_error("policy JSON output", &error);
             return 1;
@@ -234,22 +242,27 @@ fn check_local_with_json_writer(
             if diagnostics.len() == 1 { "" } else { "s" }
         );
     } else {
+        let mut rendered = String::new();
         if let Some(tests) = &tests {
             if tests.total == 0 {
-                println!("{path}: ok (no tests)");
+                rendered.push_str(&format!("{path}: ok (no tests)\n"));
             } else {
                 for failure in &tests.failures {
                     eprintln!("test {} ... FAILED: {}", failure.name, failure.message);
                 }
-                println!(
+                rendered.push_str(&format!(
                     "{path}: {} passed, {} failed",
                     tests.passed(),
                     tests.failures.len()
-                );
+                ));
+                rendered.push('\n');
             }
         }
         if let (Some(cov), Some(file)) = (&cov, &file) {
-            print_coverage_text(cov, file);
+            render_coverage_text(&mut rendered, cov, file);
+        }
+        if write_policy_stdout(stdout, &rendered) != 0 {
+            return 1;
         }
     }
 
@@ -274,17 +287,19 @@ fn check_local_with_json_writer(
 /// The `--coverage` text report (stdout): the exercised-term headline,
 /// per-policy term table, and lint lines. Policies defined in an
 /// imported module are attributed to their defining file.
-fn print_coverage_text(
+fn render_coverage_text(
+    out: &mut String,
     cov: &rustbgpd_policy::rpol::CoverageReport,
     file: &rustbgpd_policy::rpol::RpolFile,
 ) {
     use rustbgpd_policy::rpol::PolicyTestStatus;
 
-    println!(
+    out.push_str(&format!(
         "coverage: {}/{} terms exercised by tests",
         cov.terms_exercised(),
         cov.terms_total()
-    );
+    ));
+    out.push('\n');
     let module_path = |index: u32| -> &str {
         file.modules()
             .get(index as usize)
@@ -299,20 +314,24 @@ fn print_coverage_text(
         };
         match policy.status {
             PolicyTestStatus::Untested => {
-                println!(
+                out.push_str(&format!(
                     "  policy {}{origin}    never referenced by any test",
                     policy.name
-                );
+                ));
+                out.push('\n');
                 continue;
             }
             PolicyTestStatus::ApplyOnly => {
-                println!(
+                out.push_str(&format!(
                     "  policy {}{origin}    exercised via apply only (terms not attributable)",
                     policy.name
-                );
+                ));
+                out.push('\n');
                 continue;
             }
-            PolicyTestStatus::Tested => println!("  policy {}{origin}", policy.name),
+            PolicyTestStatus::Tested => {
+                out.push_str(&format!("  policy {}{origin}\n", policy.name))
+            }
         }
         let width = policy.terms.iter().map(|t| t.name.len()).max().unwrap_or(0);
         for term in &policy.terms {
@@ -326,11 +345,11 @@ fn print_coverage_text(
             } else {
                 format!("evaluated {}x, matched {}x", term.evaluated, term.matched)
             };
-            println!("    term {:width$}  {facts}", term.name);
+            out.push_str(&format!("    term {:width$}  {facts}\n", term.name));
         }
     }
     for lint in &cov.lints {
-        println!("lint [{}]: {}", lint.kind.label(), lint.message);
+        out.push_str(&format!("lint [{}]: {}\n", lint.kind.label(), lint.message));
     }
 }
 
@@ -342,7 +361,7 @@ fn print_check_json(
     tests: Option<&rustbgpd_policy::rpol::TestReport>,
     cov: Option<&rustbgpd_policy::rpol::CoverageReport>,
     file: Option<&rustbgpd_policy::rpol::RpolFile>,
-    json_writer: Option<&mut dyn std::io::Write>,
+    stdout: &mut dyn std::io::Write,
 ) -> Result<(), CliError> {
     #[derive(Serialize)]
     struct JsonFailure<'a> {
@@ -441,7 +460,7 @@ fn print_check_json(
         }),
         coverage,
     };
-    print_policy_json(json_writer, &out)
+    print_policy_json(Some(stdout), &out)
 }
 
 /// `rbgp policy check --list-deps` output: the resolved module graph
@@ -451,7 +470,7 @@ fn print_deps(
     path: &str,
     file: &rustbgpd_policy::rpol::RpolFile,
     json: bool,
-    json_writer: Option<&mut dyn std::io::Write>,
+    stdout: &mut dyn std::io::Write,
 ) -> i32 {
     let modules = file.modules();
     if json {
@@ -481,24 +500,35 @@ fn print_deps(
                 })
                 .collect(),
         };
-        if let Err(error) = print_policy_json(json_writer, &out) {
+        if let Err(error) = print_policy_json(Some(stdout), &out) {
             output::report_write_error("policy JSON output", &error);
             return 1;
         }
         return 0;
     }
-    println!(
+    let mut rendered = format!(
         "{path}: {} module{}",
         modules.len(),
         if modules.len() == 1 { "" } else { "s" }
     );
+    rendered.push('\n');
     for module in modules {
-        println!("  {} sha256:{}", module.path, module.digest);
+        rendered.push_str(&format!("  {} sha256:{}\n", module.path, module.digest));
         for &id in &module.imports {
-            println!("    imports {}", modules[id as usize].path);
+            rendered.push_str(&format!("    imports {}\n", modules[id as usize].path));
         }
     }
-    0
+    write_policy_stdout(stdout, &rendered)
+}
+
+fn write_policy_stdout(writer: &mut dyn std::io::Write, rendered: &str) -> i32 {
+    match output::write_bytes(writer, rendered.as_bytes()) {
+        Ok(()) => 0,
+        Err(error) => {
+            output::report_write_error("policy output", &error);
+            1
+        }
+    }
 }
 
 fn print_policy_json<T: Serialize>(
@@ -1962,16 +1992,60 @@ mod tests {
     fn check_local_json_write_failure_exits_one() {
         let tmp = write_rpol("policy p { term t { accept } }");
         assert_eq!(
-            check_local_with_json_writer(
+            check_local_with_writer(
                 tmp.path().to_str().unwrap(),
                 &[],
                 false,
                 false,
                 None,
                 true,
-                Some(&mut BrokenWriter),
+                &mut BrokenWriter,
             ),
             1
+        );
+    }
+
+    #[test]
+    fn check_text_paths_preserve_bytes_and_reject_write_failures() {
+        let tmp = write_rpol(
+            "policy p { term t { accept } }\n\
+             test ok { route { prefix 10.0.0.0/24 } expect p == accept }",
+        );
+        let path = tmp.path().to_str().unwrap();
+        for (list_deps, coverage) in [(false, false), (true, false), (false, true)] {
+            assert_eq!(
+                check_local_with_writer(
+                    path,
+                    &[],
+                    list_deps,
+                    coverage,
+                    None,
+                    false,
+                    &mut BrokenWriter
+                ),
+                1
+            );
+            let mut flush = ObservedWriter {
+                bytes: vec![],
+                flushes: 0,
+                write_error: None,
+                flush_error: Some(std::io::ErrorKind::PermissionDenied),
+            };
+            assert_eq!(
+                check_local_with_writer(path, &[], list_deps, coverage, None, false, &mut flush),
+                1
+            );
+        }
+        let mut bytes = Vec::new();
+        assert_eq!(
+            check_local_with_writer(path, &[], false, true, None, false, &mut bytes),
+            0
+        );
+        assert_eq!(
+            String::from_utf8(bytes).unwrap(),
+            format!(
+                "{path}: 1 passed, 0 failed\ncoverage: 1/1 terms exercised by tests\n  policy p\n    term t  evaluated 1x, matched 1x\n"
+            )
         );
     }
 

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -242,26 +242,29 @@ fn check_local_with_writer(
             if diagnostics.len() == 1 { "" } else { "s" }
         );
     } else {
-        let mut rendered = String::new();
-        if let Some(tests) = &tests {
-            if tests.total == 0 {
-                rendered.push_str(&format!("{path}: ok (no tests)\n"));
-            } else {
-                for failure in &tests.failures {
-                    eprintln!("test {} ... FAILED: {}", failure.name, failure.message);
+        let result = (|| -> Result<(), CliError> {
+            if let Some(tests) = &tests {
+                if tests.total == 0 {
+                    writeln!(stdout, "{path}: ok (no tests)")?;
+                } else {
+                    for failure in &tests.failures {
+                        eprintln!("test {} ... FAILED: {}", failure.name, failure.message);
+                    }
+                    writeln!(
+                        stdout,
+                        "{path}: {} passed, {} failed",
+                        tests.passed(),
+                        tests.failures.len()
+                    )?;
                 }
-                rendered.push_str(&format!(
-                    "{path}: {} passed, {} failed",
-                    tests.passed(),
-                    tests.failures.len()
-                ));
-                rendered.push('\n');
             }
-        }
-        if let (Some(cov), Some(file)) = (&cov, &file) {
-            render_coverage_text(&mut rendered, cov, file);
-        }
-        if write_policy_stdout(stdout, &rendered) != 0 {
+            if let (Some(cov), Some(file)) = (&cov, &file) {
+                write_coverage_text(stdout, cov, file)?;
+            }
+            stdout.flush()?;
+            Ok(())
+        })();
+        if report_policy_write_result(result) != 0 {
             return 1;
         }
     }
@@ -287,19 +290,19 @@ fn check_local_with_writer(
 /// The `--coverage` text report (stdout): the exercised-term headline,
 /// per-policy term table, and lint lines. Policies defined in an
 /// imported module are attributed to their defining file.
-fn render_coverage_text(
-    out: &mut String,
+fn write_coverage_text(
+    out: &mut dyn std::io::Write,
     cov: &rustbgpd_policy::rpol::CoverageReport,
     file: &rustbgpd_policy::rpol::RpolFile,
-) {
+) -> Result<(), CliError> {
     use rustbgpd_policy::rpol::PolicyTestStatus;
 
-    out.push_str(&format!(
+    writeln!(
+        out,
         "coverage: {}/{} terms exercised by tests",
         cov.terms_exercised(),
         cov.terms_total()
-    ));
-    out.push('\n');
+    )?;
     let module_path = |index: u32| -> &str {
         file.modules()
             .get(index as usize)
@@ -314,24 +317,22 @@ fn render_coverage_text(
         };
         match policy.status {
             PolicyTestStatus::Untested => {
-                out.push_str(&format!(
+                writeln!(
+                    out,
                     "  policy {}{origin}    never referenced by any test",
                     policy.name
-                ));
-                out.push('\n');
+                )?;
                 continue;
             }
             PolicyTestStatus::ApplyOnly => {
-                out.push_str(&format!(
+                writeln!(
+                    out,
                     "  policy {}{origin}    exercised via apply only (terms not attributable)",
                     policy.name
-                ));
-                out.push('\n');
+                )?;
                 continue;
             }
-            PolicyTestStatus::Tested => {
-                out.push_str(&format!("  policy {}{origin}\n", policy.name))
-            }
+            PolicyTestStatus::Tested => writeln!(out, "  policy {}{origin}", policy.name)?,
         }
         let width = policy.terms.iter().map(|t| t.name.len()).max().unwrap_or(0);
         for term in &policy.terms {
@@ -345,12 +346,13 @@ fn render_coverage_text(
             } else {
                 format!("evaluated {}x, matched {}x", term.evaluated, term.matched)
             };
-            out.push_str(&format!("    term {:width$}  {facts}\n", term.name));
+            writeln!(out, "    term {:width$}  {facts}", term.name)?;
         }
     }
     for lint in &cov.lints {
-        out.push_str(&format!("lint [{}]: {}\n", lint.kind.label(), lint.message));
+        writeln!(out, "lint [{}]: {}", lint.kind.label(), lint.message)?;
     }
+    Ok(())
 }
 
 /// The `-j` form of `rbgp policy check` output (stable keys; the
@@ -465,7 +467,8 @@ fn print_check_json(
 
 /// `rbgp policy check --list-deps` output: the resolved module graph
 /// with content hashes, module 0 first (the main file), imports in
-/// declaration order. Always exit 0 — the graph compiled.
+/// declaration order. Returns 0 when the graph and output succeed, 1
+/// when stdout cannot be written.
 fn print_deps(
     path: &str,
     file: &rustbgpd_policy::rpol::RpolFile,
@@ -506,23 +509,27 @@ fn print_deps(
         }
         return 0;
     }
-    let mut rendered = format!(
-        "{path}: {} module{}",
-        modules.len(),
-        if modules.len() == 1 { "" } else { "s" }
-    );
-    rendered.push('\n');
-    for module in modules {
-        rendered.push_str(&format!("  {} sha256:{}\n", module.path, module.digest));
-        for &id in &module.imports {
-            rendered.push_str(&format!("    imports {}\n", modules[id as usize].path));
+    let result = (|| -> Result<(), CliError> {
+        writeln!(
+            stdout,
+            "{path}: {} module{}",
+            modules.len(),
+            if modules.len() == 1 { "" } else { "s" }
+        )?;
+        for module in modules {
+            writeln!(stdout, "  {} sha256:{}", module.path, module.digest)?;
+            for &id in &module.imports {
+                writeln!(stdout, "    imports {}", modules[id as usize].path)?;
+            }
         }
-    }
-    write_policy_stdout(stdout, &rendered)
+        stdout.flush()?;
+        Ok(())
+    })();
+    report_policy_write_result(result)
 }
 
-fn write_policy_stdout(writer: &mut dyn std::io::Write, rendered: &str) -> i32 {
-    match output::write_bytes(writer, rendered.as_bytes()) {
+fn report_policy_write_result(result: Result<(), CliError>) -> i32 {
+    match result {
         Ok(()) => 0,
         Err(error) => {
             output::report_write_error("policy output", &error);

--- a/crates/cli/src/importer/mod.rs
+++ b/crates/cli/src/importer/mod.rs
@@ -662,19 +662,16 @@ fn emit_toml(
 /// CLI entry: read, translate, write, report. Returns the process exit
 /// code per the module-level ladder.
 pub fn run_import(source: &str, format: Option<&str>, out: Option<&str>, json: bool) -> i32 {
-    if json {
-        let stdout = std::io::stdout();
-        return run_import_with_json_writer(source, format, out, json, Some(&mut stdout.lock()));
-    }
-    run_import_with_json_writer(source, format, out, json, None)
+    let stdout = std::io::stdout();
+    run_import_with_writer(source, format, out, json, &mut stdout.lock())
 }
 
-fn run_import_with_json_writer(
+fn run_import_with_writer(
     source: &str,
     format: Option<&str>,
     out: Option<&str>,
     json: bool,
-    json_writer: Option<&mut dyn IoWrite>,
+    stdout: &mut dyn IoWrite,
 ) -> i32 {
     if json && out.is_none() {
         eprintln!(
@@ -714,7 +711,17 @@ fn run_import_with_json_writer(
                 return 1;
             }
         }
-        None => print!("{}", imported.config_toml),
+        None => {
+            if let Err(error) = stdout
+                .write_all(imported.config_toml.as_bytes())
+                .and_then(|()| stdout.flush())
+            {
+                if error.kind() != std::io::ErrorKind::BrokenPipe {
+                    eprintln!("error: cannot write imported config: {error}");
+                }
+                return 1;
+            }
+        }
     }
     if json {
         let rendered = match serde_json::to_string_pretty(&imported.report) {
@@ -724,14 +731,10 @@ fn run_import_with_json_writer(
                 return 1;
             }
         };
-        let Some(writer) = json_writer else {
-            eprintln!("error: cannot write import JSON output: no output writer");
-            return 1;
-        };
-        if let Err(error) = writer
+        if let Err(error) = stdout
             .write_all(rendered.as_bytes())
-            .and_then(|()| writer.write_all(b"\n"))
-            .and_then(|()| writer.flush())
+            .and_then(|()| stdout.write_all(b"\n"))
+            .and_then(|()| stdout.flush())
         {
             if error.kind() != std::io::ErrorKind::BrokenPipe {
                 eprintln!("error: cannot write import JSON output: {error}");
@@ -772,7 +775,7 @@ mod writer_tests {
         );
         let mut bytes = Vec::new();
 
-        let code = run_import_with_json_writer(&source, None, Some(&out), true, Some(&mut bytes));
+        let code = run_import_with_writer(&source, None, Some(&out), true, &mut bytes);
 
         assert_eq!(code, 2);
         assert_eq!(bytes, expected.as_bytes());
@@ -794,7 +797,7 @@ mod writer_tests {
     fn json_report_write_failure_exits_one() {
         let (_dir, source, out) = paths();
         assert_eq!(
-            run_import_with_json_writer(&source, None, Some(&out), true, Some(&mut BrokenWriter),),
+            run_import_with_writer(&source, None, Some(&out), true, &mut BrokenWriter),
             1
         );
     }
@@ -815,7 +818,27 @@ mod writer_tests {
     fn json_report_flush_failure_exits_one() {
         let (_dir, source, out) = paths();
         assert_eq!(
-            run_import_with_json_writer(&source, None, Some(&out), true, Some(&mut FlushFailure),),
+            run_import_with_writer(&source, None, Some(&out), true, &mut FlushFailure),
+            1
+        );
+    }
+
+    #[test]
+    fn config_stdout_preserves_bytes_and_rejects_write_failures() {
+        let (_dir, source, _out) = paths();
+        let expected = import_source(SourceFormat::Frr, &source, FRR).unwrap();
+        let mut bytes = Vec::new();
+        assert_eq!(
+            run_import_with_writer(&source, None, None, false, &mut bytes),
+            2
+        );
+        assert_eq!(bytes, expected.config_toml.as_bytes());
+        assert_eq!(
+            run_import_with_writer(&source, None, None, false, &mut BrokenWriter),
+            1
+        );
+        assert_eq!(
+            run_import_with_writer(&source, None, None, false, &mut FlushFailure),
             1
         );
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -21,7 +21,7 @@ use crate::connection::connect;
 use crate::error::CliError;
 use crate::output::parse_family;
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
-use clap_complete::Shell;
+use clap_complete::{Generator, Shell};
 use std::path::PathBuf;
 
 const BINARY_NAME: &str = "rbgp";
@@ -1885,8 +1885,15 @@ fn parse_cli(binary_name: &'static str) -> Cli {
     Cli::from_arg_matches(&matches).unwrap_or_else(|error| error.exit())
 }
 
-fn generate_completions(shell: Shell, binary_name: &'static str, output: &mut dyn std::io::Write) {
-    clap_complete::generate(shell, &mut cli_command(binary_name), binary_name, output);
+fn generate_completions(
+    shell: Shell,
+    binary_name: &'static str,
+    output: &mut dyn std::io::Write,
+) -> std::io::Result<()> {
+    let mut command = cli_command(binary_name);
+    command.build();
+    shell.try_generate(&command, output)?;
+    output.flush()
 }
 
 fn validate_neighbor_compare_action(command: &Command) -> Result<(), CliError> {
@@ -2000,7 +2007,7 @@ fn flush_stdout_result<W: std::io::Write + ?Sized>(
 async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
     // Shell completions don't need a gRPC connection.
     if let Command::Completions { shell } = cli.command {
-        generate_completions(shell, binary_name, &mut std::io::stdout());
+        generate_completions(shell, binary_name, &mut std::io::stdout()).map_err(CliError::Io)?;
         return Ok(());
     }
 
@@ -3260,6 +3267,18 @@ mod tests {
     }
 
     #[test]
+    fn completions_propagate_flush_failure() {
+        assert!(
+            generate_completions(
+                Shell::Bash,
+                BINARY_NAME,
+                &mut FlushWriter(Some(std::io::ErrorKind::PermissionDenied))
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
     fn flush_preserves_config_and_doctor_outcomes() {
         for code in [0, 2] {
             assert_eq!(
@@ -3524,7 +3543,7 @@ mod tests {
     #[test]
     fn test_rbgp_completion_uses_short_name() {
         let mut output = Vec::new();
-        generate_completions(Shell::Bash, BINARY_NAME, &mut output);
+        generate_completions(Shell::Bash, BINARY_NAME, &mut output).unwrap();
         let completion = String::from_utf8(output).unwrap();
 
         assert!(completion.contains("_rbgp()"));
@@ -3537,7 +3556,7 @@ mod tests {
         // These three are what the release tarball ships.
         for shell in [Shell::Bash, Shell::Zsh, Shell::Fish] {
             let mut output = Vec::new();
-            generate_completions(shell, BINARY_NAME, &mut output);
+            generate_completions(shell, BINARY_NAME, &mut output).unwrap();
             assert!(!output.is_empty(), "{shell} completions are empty");
         }
     }
@@ -3551,7 +3570,7 @@ mod tests {
             (Shell::Fish, "examples/completions/rbgp.fish"),
         ] {
             let mut generated = Vec::new();
-            generate_completions(shell, BINARY_NAME, &mut generated);
+            generate_completions(shell, BINARY_NAME, &mut generated).unwrap();
             let checked_in = std::fs::read(repository.join(relative_path))
                 .unwrap_or_else(|error| panic!("failed to read {relative_path}: {error}"));
             assert!(
@@ -3567,7 +3586,7 @@ mod tests {
         // least one generated release completion and makes this fence red.
         for shell in [Shell::Bash, Shell::Zsh, Shell::Fish] {
             let mut generated = Vec::new();
-            generate_completions(shell, BINARY_NAME, &mut generated);
+            generate_completions(shell, BINARY_NAME, &mut generated).unwrap();
             let generated = String::from_utf8(generated).unwrap();
             for flag in [
                 "--no-route-server-client",

--- a/crates/cli/tests/stdout_closed.rs
+++ b/crates/cli/tests/stdout_closed.rs
@@ -1,0 +1,43 @@
+#![cfg(unix)]
+
+use std::os::fd::OwnedFd;
+use std::os::unix::net::UnixStream;
+use std::process::{Command, Stdio};
+
+fn run_with_closed_stdout(args: &[&str]) {
+    let (reader, writer) = UnixStream::pair().unwrap();
+    drop(reader);
+    let writer: OwnedFd = writer.into();
+    let output = Command::new(env!("CARGO_BIN_EXE_rbgp"))
+        .args(args)
+        .stdout(Stdio::from(writer))
+        .stderr(Stdio::piped())
+        .env("RUST_BACKTRACE", "1")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(!stderr.contains("panicked"));
+    assert!(!stderr.contains("stack backtrace"));
+}
+
+#[test]
+fn offline_commands_quietly_handle_closed_stdout() {
+    run_with_closed_stdout(&["completions", "bash"]);
+    run_with_closed_stdout(&[
+        "policy",
+        "check",
+        concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/route-server/hygiene.rpol"
+        ),
+    ]);
+    run_with_closed_stdout(&[
+        "config",
+        "import",
+        concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/import/frr.conf"
+        ),
+    ]);
+}


### PR DESCRIPTION
## Summary

- make shell completion generation and flush failures flow through the existing CLI error ladder
- route offline policy check, dependency, and coverage text through typed fallible output while preserving exact successful bytes
- make non-JSON config import use a private writer-injected path without changing the public importer API or detailed exit codes
- prove closed stdout exits 1 quietly instead of panicking for all three command families

## Load-bearing proof

- replacing try_generate with the infallible generator compiled, then the closed-stdout child failed with exit 101 instead of 1
- ignoring the policy output write result compiled, then the injected-writer proof returned 0 instead of 1
- exact completion, policy coverage, and imported-config bytes remain asserted

## Validation

- cargo test -p rustbgpctl
- cargo check -p rustbgpctl --tests
- cargo clippy -p rustbgpctl --all-targets -- -D warnings
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo doc --workspace --no-deps
- git diff --check