### PR TITLE
Handle remaining offline stdout failures

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,12 +50,12 @@ mod test_support;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
-use std::io::{Read as _, Write as _};
+use std::io::{self, Read as _, Write as _};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::os::unix::fs::DirBuilderExt as _;
 use std::os::unix::fs::MetadataExt as _;
 use std::path::{Path, PathBuf};
-use std::process;
+use std::process::{self, ExitCode};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant as StdInstant, SystemTime, UNIX_EPOCH};
@@ -1943,7 +1943,7 @@ fn warn_unpoliced_ebgp(config: &Config) -> usize {
     unpoliced.len()
 }
 
-fn print_config_diff(diff: &config::ConfigDiff) {
+fn write_config_diff(writer: &mut dyn io::Write, diff: &config::ConfigDiff) -> io::Result<()> {
     use owo_colors::OwoColorize;
 
     let reload_header = "Reload-applied changes:".green().to_string();
@@ -1961,7 +1961,54 @@ fn print_config_diff(diff: &config::ConfigDiff) {
         restart_marker: restart_marker.into(),
         no_changes: "No changes.".into(),
     };
-    print!("{}", config::format_config_diff_with_style(diff, &style));
+    write!(
+        writer,
+        "{}",
+        config::format_config_diff_with_style(diff, &style)
+    )
+}
+
+#[derive(Debug)]
+enum StdoutWriteError {
+    BrokenPipe,
+    Other(std::io::Error),
+}
+
+impl From<std::io::Error> for StdoutWriteError {
+    fn from(error: std::io::Error) -> Self {
+        if error.kind() == std::io::ErrorKind::BrokenPipe {
+            Self::BrokenPipe
+        } else {
+            Self::Other(error)
+        }
+    }
+}
+
+fn write_stdout_with(
+    writer: &mut dyn std::io::Write,
+    output: impl FnOnce(&mut dyn std::io::Write) -> std::io::Result<()>,
+) -> Result<(), StdoutWriteError> {
+    output(writer)?;
+    writer.flush()?;
+    Ok(())
+}
+
+fn write_stdout(
+    output: impl FnOnce(&mut dyn std::io::Write) -> std::io::Result<()>,
+) -> Result<(), StdoutWriteError> {
+    let stdout = std::io::stdout();
+    write_stdout_with(&mut stdout.lock(), output)
+}
+
+fn stdout_exit(result: Result<(), StdoutWriteError>) -> ExitCode {
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(StdoutWriteError::BrokenPipe) => ExitCode::from(1),
+        Err(StdoutWriteError::Other(error)) => {
+            eprintln!("rustbgpd: failed to write stdout: {error}");
+            ExitCode::from(1)
+        }
+    }
 }
 
 async fn trigger_import_validation_refresh(
@@ -2284,27 +2331,29 @@ Default configuration file.
     clippy::too_many_lines,
     reason = "the daemon entrypoint keeps startup validation and shutdown ownership together"
 )]
-fn main() {
+fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
 
     // Handle --version / -V before anything else.
     if args.iter().any(|a| a == "--version" || a == "-V") {
-        println!("rustbgpd {}", env!("CARGO_PKG_VERSION"));
-        return;
+        return stdout_exit(write_stdout(|writer| {
+            writeln!(writer, "rustbgpd {}", env!("CARGO_PKG_VERSION"))
+        }));
     }
 
     // Handle --man: print the roff man page (section 8) to stdout and
     // exit. Render with `rustbgpd --man | man -l -` or install with
     // `rustbgpd --man > /usr/local/share/man/man8/rustbgpd.8`.
     if args.iter().any(|a| a == "--man") {
-        print!("{}", man_page());
-        return;
+        return stdout_exit(write_stdout(|writer| write!(writer, "{}", man_page())));
     }
 
     // Handle --help / -h.
     if args.iter().any(|a| a == "--help" || a == "-h") {
-        println!(
-            "rustbgpd {} — API-first BGP daemon\n\n\
+        return stdout_exit(write_stdout(|writer| {
+            writeln!(
+                writer,
+                "rustbgpd {} — API-first BGP daemon\n\n\
              Usage: rustbgpd [OPTIONS] [CONFIG_PATH]\n\n\
              Arguments:\n  \
                CONFIG_PATH  Path to TOML config file [default: /etc/rustbgpd/config.toml]\n\n\
@@ -2329,9 +2378,9 @@ fn main() {
                   (BGP or metrics/readiness listener bind, unexpected gRPC server exit)\n  \
                2  Invalid invocation (unknown flag combination, missing argument)\n  \
                70 Internal error",
-            env!("CARGO_PKG_VERSION")
-        );
-        return;
+                env!("CARGO_PKG_VERSION")
+            )
+        }));
     }
 
     // Parse flags and config path from remaining args.
@@ -2419,8 +2468,9 @@ fn main() {
             eprintln!("error: --dump-config-schema cannot be combined with other modes");
             process::exit(2);
         }
-        print!("{}", config::config_json_schema());
-        return;
+        return stdout_exit(write_stdout(|writer| {
+            write!(writer, "{}", config::config_json_schema())
+        }));
     }
 
     // `--init-config PROFILE --stdout` prints a curated starter config and
@@ -2451,8 +2501,7 @@ fn main() {
             );
             process::exit(70);
         }
-        print!("{toml}");
-        return;
+        return stdout_exit(write_stdout(|writer| write!(writer, "{toml}")));
     }
 
     // Removed escape hatch: fail loudly rather than silently ignoring it,
@@ -2484,14 +2533,20 @@ fn main() {
         // and otherwise gives way to the count. Without `--strict` the exit
         // code stays 0 either way — these are warnings, not failures.
         let warnings = check_warnings(&config);
-        if warnings == 0 {
-            println!("config OK: {config_path}");
-            return;
+        let output = write_stdout(|writer| {
+            if warnings == 0 {
+                writeln!(writer, "config OK: {config_path}")
+            } else {
+                writeln!(
+                    writer,
+                    "config VALID, {warnings} WARNING{} — NOT a clean check: {config_path}",
+                    if warnings == 1 { "" } else { "S" }
+                )
+            }
+        });
+        if output.is_err() || warnings == 0 {
+            return stdout_exit(output);
         }
-        println!(
-            "config VALID, {warnings} WARNING{} — NOT a clean check: {config_path}",
-            if warnings == 1 { "" } else { "S" }
-        );
         if strict {
             // Exit 1, the same code a `--check` that could not load the
             // config uses: from a gate's point of view both mean "this
@@ -2503,7 +2558,7 @@ fn main() {
             );
             process::exit(1);
         }
-        return;
+        return ExitCode::SUCCESS;
     }
 
     if let Some(ref diff_target) = diff_path {
@@ -2515,19 +2570,22 @@ fn main() {
             }
         };
         let diff = config::diff_config(&config, &new_config);
-        if json_output {
+        let output = if json_output {
             let output = config::config_diff_json_value(&diff);
             match serde_json::to_string_pretty(&output) {
-                Ok(json) => println!("{json}"),
+                Ok(json) => write_stdout(|writer| writeln!(writer, "{json}")),
                 Err(e) => {
                     eprintln!("error: failed to serialize diff: {e}");
                     process::exit(2);
                 }
             }
         } else {
-            print_config_diff(&diff);
+            write_stdout(|writer| write_config_diff(writer, &diff))
+        };
+        if let Err(error) = output {
+            return stdout_exit(Err(error));
         }
-        process::exit(i32::from(diff.has_actionable_changes()));
+        return ExitCode::from(u8::from(diff.has_actionable_changes()));
     }
 
     // Durable commit-confirm (ADR-0076 Decision 6): if the last run stopped
@@ -2588,6 +2646,7 @@ fn main() {
         // Restart=on-failure) this was a component failure, not a clean stop.
         process::exit(1);
     }
+    ExitCode::SUCCESS
 }
 
 /// Number of panic reports retained in `<runtime_state_dir>/crash/`;
@@ -5243,6 +5302,37 @@ mod tests {
     use crate::test_support::{
         assert_tier_authorized_test_config, tier_authorized_uds_test_config,
     };
+
+    #[derive(Default)]
+    struct FlushFailure {
+        flushes: usize,
+    }
+
+    impl std::io::Write for FlushFailure {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.flushes += 1;
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "injected flush failure",
+            ))
+        }
+    }
+
+    #[test]
+    fn stdout_write_success_flush_failure_and_variants_remain_distinct() {
+        let mut writer = FlushFailure::default();
+        let result = write_stdout_with(&mut writer, |output| output.write_all(b"complete"));
+        assert!(matches!(result, Err(StdoutWriteError::BrokenPipe)));
+        assert_eq!(writer.flushes, 1, "terminal flush must run exactly once");
+        let broken = StdoutWriteError::from(std::io::Error::from(std::io::ErrorKind::BrokenPipe));
+        let other = StdoutWriteError::from(std::io::Error::other("other"));
+        assert!(matches!(broken, StdoutWriteError::BrokenPipe));
+        assert!(matches!(other, StdoutWriteError::Other(_)));
+    }
 
     /// Load-bearing proof: restoring the per-handle relative timeout-and-abort
     /// loop leaves this helper pending after two seconds, before the second and

--- a/tests/daemon_stdout_closed.rs
+++ b/tests/daemon_stdout_closed.rs
@@ -1,0 +1,166 @@
+//! First-party one-shot stdout is fallible, quiet on a closed peer, and
+//! byte-for-byte stable when healthy.
+
+use std::ffi::OsString;
+use std::os::{fd::OwnedFd, unix::net::UnixStream};
+use std::process::{Command, Output, Stdio};
+
+fn config(port: u16, warned: bool) -> String {
+    let policy = if warned {
+        String::new()
+    } else {
+        "import_policy_chain = [\"allow\"]\nexport_policy_chain = [\"allow\"]\n".into()
+    };
+    format!(
+        r#"[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = {port}
+runtime_state_dir = "/tmp/rustbgpd-daemon-stdout-closed"
+
+[global.telemetry]
+log_format = "json"
+
+[global.telemetry.grpc_uds]
+enabled = true
+path = "/tmp/rustbgpd-daemon-stdout-closed/grpc.sock"
+mode = 0o600
+principal = "operator"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+operator = "operator"
+
+[policy.definitions.allow]
+default_action = "permit"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+{policy}"#
+    )
+}
+
+fn run(args: &[OsString], closed_stdout: bool) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_rustbgpd"));
+    command.args(args).env("NO_COLOR", "1");
+    if closed_stdout {
+        let (peer, stdout) = UnixStream::pair().expect("stdout socket pair");
+        drop(peer);
+        command.stdout(Stdio::from(OwnedFd::from(stdout)));
+    }
+    command.output().expect("run rustbgpd")
+}
+
+fn args(values: &[&str]) -> Vec<OsString> {
+    values.iter().map(OsString::from).collect()
+}
+
+fn fixture() -> (tempfile::TempDir, OsString, OsString, OsString) {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let clean = temp.path().join("clean.toml");
+    let warned = temp.path().join("warned.toml");
+    let changed = temp.path().join("changed.toml");
+    std::fs::write(&clean, config(1179, false)).expect("write clean config");
+    std::fs::write(&warned, config(1179, true)).expect("write warned config");
+    std::fs::write(&changed, config(1180, false)).expect("write changed config");
+    (temp, clean.into(), warned.into(), changed.into())
+}
+
+#[test]
+fn all_nine_daemon_stdout_sites_fail_closed_without_new_stderr() {
+    let (_temp, clean, warned, changed) = fixture();
+    let rows = [
+        ("version", args(&["--version"])),
+        ("man", args(&["--man"])),
+        ("help", args(&["--help"])),
+        ("schema", args(&["--dump-config-schema"])),
+        ("init-lab", args(&["--init-config", "lab", "--stdout"])),
+        ("clean-check", vec!["--check".into(), clean.clone()]),
+        ("warn-check", vec!["--check".into(), warned.clone()]),
+        (
+            "text-diff",
+            vec![clean.clone(), "--diff".into(), changed.clone()],
+        ),
+        (
+            "json-diff",
+            vec![clean, "--diff".into(), changed, "--json".into()],
+        ),
+    ];
+    for (name, row) in rows {
+        let healthy = run(&row, false);
+        assert!(!healthy.stdout.is_empty(), "{name}: no healthy stdout");
+        let closed = run(&row, true);
+        assert_eq!(closed.status.code(), Some(1), "{name}: {closed:?}");
+        assert!(closed.stdout.is_empty(), "{name}: stdout was captured");
+        assert_eq!(
+            closed.stderr, healthy.stderr,
+            "{name}: closed stdout added a diagnostic"
+        );
+    }
+}
+
+#[test]
+fn healthy_check_and_diff_bytes_streams_and_statuses_are_exact() {
+    let (_temp, clean, warned, changed) = fixture();
+    let clean_check = run(&["--check".into(), clean.clone()], false);
+    assert_eq!(clean_check.status.code(), Some(0));
+    assert_eq!(
+        clean_check.stdout,
+        format!("config OK: {}\n", clean.to_string_lossy()).as_bytes()
+    );
+    assert!(clean_check.stderr.is_empty());
+
+    let warn_check = run(&["--check".into(), warned.clone()], false);
+    assert_eq!(warn_check.status.code(), Some(0));
+    assert_eq!(
+        warn_check.stdout,
+        format!(
+            "config VALID, 1 WARNING — NOT a clean check: {}\n",
+            warned.to_string_lossy()
+        )
+        .as_bytes()
+    );
+    let rule = "=".repeat(74);
+    let warning = format!(
+        "\n{rule}\nWARNING: 1 eBGP neighbor resolves no explicit policy.\n\n\
+         \x20\x2010.0.0.2 (AS 65002): no import policy and no export policy\n\n\
+         Every direction listed above is unfiltered. An unfiltered import direction\n\
+         accepts every route the peer sends; an unfiltered export direction re-advertises\n\
+         every route selected for that peer, as received. If that is what you meant, this\n\
+         is the expected result for a permit-all route server. If it is not, configure an\n\
+         import_policy_chain / export_policy_chain there, or set\n\
+         [global] ebgp_requires_policy = true to fail closed until you do.\n{rule}\n\n"
+    );
+    assert_eq!(warn_check.stderr, warning.as_bytes());
+
+    let no_diff = run(&[clean.clone(), "--diff".into(), clean.clone()], false);
+    assert_eq!(no_diff.status.code(), Some(0), "{no_diff:?}");
+    assert!(no_diff.stderr.is_empty());
+    assert_eq!(no_diff.stdout, b"No changes.\n");
+
+    let text = run(&[clean.clone(), "--diff".into(), changed.clone()], false);
+    assert_eq!(text.status.code(), Some(1), "{text:?}");
+    assert!(text.stderr.is_empty());
+    assert_eq!(
+        text.stdout,
+        b"\x1b[33mRestart-required changes:\x1b[39m\n  \x1b[33m!\x1b[39m [global] changed\n\n\
+          Plan: no neighbor changes \xc2\xb7 daemon restart required for some changes\n"
+    );
+
+    let json = run(&[clean, "--diff".into(), changed, "--json".into()], false);
+    assert_eq!(json.status.code(), Some(1), "{json:?}");
+    assert!(json.stderr.is_empty());
+    let value: serde_json::Value =
+        serde_json::from_slice(&json.stdout).expect("complete JSON diff");
+    assert_eq!(value["has_actionable_changes"], true);
+    assert_eq!(value["restart_required"]["global_changed"], true);
+    let mut expected = serde_json::to_vec_pretty(&value).unwrap();
+    expected.push(b'\n');
+    assert_eq!(
+        json.stdout, expected,
+        "JSON bytes or terminal newline drift"
+    );
+}

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -149,13 +149,12 @@ fn main() -> ExitCode {
     }))
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use std::{fs::File, io::BufWriter};
 
     #[test]
-    #[cfg(unix)]
     fn stdout_exit_distinguishes_quiet_broken_pipe_from_other_flush_error() {
         let file = tempfile::NamedTempFile::new().unwrap();
         let mut writer = BufWriter::new(File::open(file.path()).unwrap());

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -38,6 +38,55 @@ struct Cli {
     allow_shape_drift: bool,
 }
 
+#[derive(Debug)]
+enum StdoutWriteError {
+    BrokenPipe,
+    Other(std::io::Error),
+}
+impl From<std::io::Error> for StdoutWriteError {
+    fn from(error: std::io::Error) -> Self {
+        if error.kind() == std::io::ErrorKind::BrokenPipe {
+            Self::BrokenPipe
+        } else {
+            Self::Other(error)
+        }
+    }
+}
+fn write_stdout_with(
+    writer: &mut dyn std::io::Write,
+    output: impl FnOnce(&mut dyn std::io::Write) -> std::io::Result<()>,
+) -> Result<(), StdoutWriteError> {
+    output(writer)?;
+    writer.flush()?;
+    Ok(())
+}
+fn write_stdout(
+    output: impl FnOnce(&mut dyn std::io::Write) -> std::io::Result<()>,
+) -> Result<(), StdoutWriteError> {
+    let stdout = std::io::stdout();
+    write_stdout_with(&mut stdout.lock(), output)
+}
+fn stdout_exit_with(
+    result: Result<(), StdoutWriteError>,
+    diagnostic: &mut dyn std::io::Write,
+) -> ExitCode {
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(StdoutWriteError::BrokenPipe) => ExitCode::from(1),
+        Err(StdoutWriteError::Other(error)) => {
+            let _ = writeln!(
+                diagnostic,
+                "rs-config-render: failed to write stdout: {error}"
+            );
+            ExitCode::from(1)
+        }
+    }
+}
+fn stdout_exit(result: Result<(), StdoutWriteError>) -> ExitCode {
+    let stderr = std::io::stderr();
+    stdout_exit_with(result, &mut stderr.lock())
+}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
     let context = match std::fs::read_to_string(&cli.context) {
@@ -89,11 +138,37 @@ fn main() -> ExitCode {
         );
         return ExitCode::from(1);
     }
-    println!(
-        "rendered {} file(s) + receipt into {} — gate with `rustbgpd --check --strict {}` before swapping",
-        rendered.files.len(),
-        cli.out_dir.display(),
-        cli.out_dir.join("config.toml").display()
-    );
-    ExitCode::SUCCESS
+    stdout_exit(write_stdout(|writer| {
+        writeln!(
+            writer,
+            "rendered {} file(s) + receipt into {} — gate with `rustbgpd --check --strict {}` before swapping",
+            rendered.files.len(),
+            cli.out_dir.display(),
+            cli.out_dir.join("config.toml").display()
+        )
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs::File, io::BufWriter};
+
+    #[test]
+    #[cfg(unix)]
+    fn stdout_exit_distinguishes_quiet_broken_pipe_from_other_flush_error() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let mut writer = BufWriter::new(File::open(file.path()).unwrap());
+        let result = write_stdout_with(&mut writer, |out| out.write_all(b"complete"));
+        assert_eq!(writer.buffer(), b"complete");
+        let mut err = Vec::new();
+        assert_eq!(stdout_exit_with(result, &mut err), ExitCode::from(1));
+        let err_text = String::from_utf8(err.clone()).unwrap();
+        assert!(err_text.starts_with("rs-config-render: failed to write stdout: "));
+        assert!(err_text.ends_with('\n'));
+        err.clear();
+        let broken = stdout_exit_with(Err(StdoutWriteError::BrokenPipe), &mut err);
+        assert_eq!(broken, ExitCode::from(1));
+        assert!(err.is_empty());
+    }
 }

--- a/tools/rs-config-render/tests/golden.rs
+++ b/tools/rs-config-render/tests/golden.rs
@@ -147,6 +147,7 @@ fn receipt_carries_cardinalities_and_fingerprint() {
     assert!(receipt["rendered_at_utc"].as_str().unwrap().ends_with('Z'));
 }
 
+#[cfg(unix)]
 #[test]
 fn cli_stdout_matrix_retains_files_and_receipt() {
     use std::os::{fd::OwnedFd, unix::net::UnixStream};

--- a/tools/rs-config-render/tests/golden.rs
+++ b/tools/rs-config-render/tests/golden.rs
@@ -148,6 +148,72 @@ fn receipt_carries_cardinalities_and_fingerprint() {
 }
 
 #[test]
+fn cli_stdout_matrix_retains_files_and_receipt() {
+    use std::os::{fd::OwnedFd, unix::net::UnixStream};
+    use std::process::{Command, Stdio};
+
+    fn command(context: &std::path::Path, out: &std::path::Path) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_rs-config-render"));
+        command
+            .arg("--context")
+            .arg(context)
+            .arg("--out-dir")
+            .arg(out)
+            .arg("--rtr-cache")
+            .arg("127.0.0.1:3323");
+        command
+    }
+
+    fn assert_outputs(out: &std::path::Path) {
+        for path in [
+            "config.toml",
+            "policy/rs-hygiene.rpol",
+            "policy/client-as4242-1.rpol",
+            "policy/client-as197000-1.rpol",
+            "render-receipt.json",
+        ] {
+            assert!(out.join(path).is_file(), "missing retained {path}");
+        }
+        let receipt: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(out.join("render-receipt.json")).unwrap())
+                .unwrap();
+        assert_eq!(receipt["clients"].as_array().unwrap().len(), 2);
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let context = temp.path().join("context.yml");
+    std::fs::write(&context, to_yaml(&healthy_value())).unwrap();
+
+    let healthy_dir = temp.path().join("healthy");
+    let healthy = command(&context, &healthy_dir).output().unwrap();
+    assert_eq!(healthy.status.code(), Some(0), "{healthy:?}");
+    assert!(healthy.stderr.is_empty(), "{healthy:?}");
+    assert_eq!(
+        healthy.stdout,
+        format!(
+            "rendered 4 file(s) + receipt into {} — gate with `rustbgpd --check --strict {}` before swapping\n",
+            healthy_dir.display(),
+            healthy_dir.join("config.toml").display()
+        )
+        .as_bytes()
+    );
+    assert_outputs(&healthy_dir);
+
+    let closed_dir = temp.path().join("closed");
+    let (peer, stdout) = UnixStream::pair().unwrap();
+    drop(peer);
+    let mut closed_command = command(&context, &closed_dir);
+    closed_command.stdout(Stdio::from(OwnedFd::from(stdout)));
+    let closed = closed_command.output().unwrap();
+    assert_eq!(closed.status.code(), Some(1), "{closed:?}");
+    assert!(
+        closed.stdout.is_empty() && closed.stderr.is_empty(),
+        "{closed:?}"
+    );
+    assert_outputs(&closed_dir);
+}
+
+#[test]
 fn empty_prefix_set_aborts_the_render() {
     // The untouched fixture: client AS51325_1 resolved zero IRR prefixes.
     match render(FIXTURE, &rtr_options()) {


### PR DESCRIPTION
## Summary

- route the daemon's nine remaining offline one-shot stdout families through binary-local fallible writers with an explicit terminal flush
- preserve existing successful bytes, streams, color, side effects, and detailed exit statuses while making BrokenPipe a quiet exit 1 and other stdout failures actionable
- apply the same contract to rs-config-render's final status after its generated files and receipt are durable

## Load-bearing proof

- restoring the daemon `--version` direct `println!` makes the nine-row closed-peer matrix panic/exit 101 instead of 1
- removing the renderer terminal flush makes the injected write-success/flush-failure proof return 0 instead of 1
- collapsing non-BrokenPipe errors into BrokenPipe removes the required renderer diagnostic
- the healthy matrix fixes exact clean/warn check output plus no-op/actionable text and JSON diff bytes/statuses; the existing `check_strict` suite caught and prevented a clean-config exit regression during implementation

Stable Rust intentionally treats stdout `EBADF` as a successful no-op, so the non-BrokenPipe terminal-flush branch is proven with a private `BufWriter` over a read-only tempfile. Real closed-peer behavior is separately exercised through `UnixStream::pair`, including retained rs-config-render files and receipt.

## Verification

- `cargo fmt --all -- --check`
- focused daemon closed-peer/healthy-output, daemon flush/variant, renderer flush/variant, renderer side-effect, and `check_strict` tests
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
- push hooks: fmt, clippy, workspace tests, rustdoc

Documentation and CHANGELOG are intentionally unchanged because this completes the established stdout/exit contract without changing documented behavior.
