### PR TITLE
Remove shipped work from the roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1641,16 +1641,14 @@ an ADR "Deferred" section that points back here. Tightened, not dropped.
 
 - **Wire / API strictness items.** Continue typed error variants where
   API-visible peer-manager / RIB boundaries still return opaque `String`
-  errors; large-community duplicate normalization on receipt/encode (stored and
-  re-advertised unchanged today); MRT snapshot encode allocation pressure on
-  very large dumps. FlowSpec unknown component pass-through was investigated and
-  rejected: RFC 8955 treats unknown component types as malformed NLRI. Inbound
-  BoRR/EoRR channel-full retry was also investigated and rejected: the receive
-  path already backpressures with `send().await`.
-  observation; SIGHUP reconcile rollback semantics (reports structured per-peer
-  failures and keeps the prior snapshot, but does not roll back already-applied
-  runtime peer changes); dynamic-neighbor `handle_inbound` split for readability;
-  config snippets / examples in gRPC validation error detail.
+  errors. FlowSpec unknown component pass-through was investigated and rejected:
+  RFC 8955 treats unknown component types as malformed NLRI. Inbound BoRR/EoRR
+  channel-full retry was also investigated and rejected: the receive path already
+  backpressures with `send().await`. Remaining work also includes SIGHUP reconcile
+  rollback semantics (reports structured per-peer failures and keeps the prior
+  snapshot, but does not roll back already-applied runtime peer changes);
+  dynamic-neighbor `handle_inbound` split for readability; config snippets /
+  examples in gRPC validation error detail.
 
 ---
 


### PR DESCRIPTION
## Summary

- remove the stale Large Community duplicate-normalization item now that receive and encode boundaries both normalize duplicates
- remove the stale ordinary MRT snapshot-allocation item now that bounded top-level output growth and its retained receipt shipped
- remove an orphaned fragment while retaining every still-open Wire/API strictness item unchanged in substance

This intentionally does not restate broader Large Community storage or MRT semantics; it only stops presenting two shipped changes as future work.

## Verification

- exact one-file diff: `ROADMAP.md`
- 8 additions / 10 deletions (18 changed lines, within the 20-line cap)
- `git diff --check`
- stale clauses and `observation;` absent
- typed errors, FlowSpec rejection, BoRR/EoRR backpressure, SIGHUP rollback, dynamic-neighbor split, and gRPC validation snippets retained

Tests and destructive proof: N/A for this documentation-only truth-up.
