### PR TITLE
Harden rrtransport observer evidence

### DIFF
--- a/bench/scale/rrtransport/Cargo.lock
+++ b/bench/scale/rrtransport/Cargo.lock
@@ -126,6 +126,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +243,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -450,6 +466,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,10 +588,12 @@ dependencies = [
  "anyhow",
  "rustbgpd-evpn-load",
  "rustbgpd-fsm",
+ "rustbgpd-policy",
  "rustbgpd-rib",
  "rustbgpd-telemetry",
  "rustbgpd-transport",
  "rustbgpd-wire",
+ "tikv-jemallocator",
  "tokio",
 ]
 
@@ -663,6 +687,7 @@ version = "0.61.0"
 dependencies = [
  "prometheus",
  "thiserror 2.0.19",
+ "tikv-jemalloc-ctl",
  "tracing",
  "tracing-subscriber",
 ]
@@ -780,6 +805,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +911,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a184c43b8ab2f41df2733b55556e3f5f632f4aeaa205b1bb018f574b7f5f142"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/bench/scale/rrtransport/Cargo.toml
+++ b/bench/scale/rrtransport/Cargo.toml
@@ -8,10 +8,12 @@ publish = false
 anyhow = "1"
 rustbgpd-evpn-load = { path = "../../evpn-load" }
 rustbgpd-fsm = { path = "../../../crates/fsm" }
+rustbgpd-policy = { path = "../../../crates/policy" }
 rustbgpd-rib = { path = "../../../crates/rib" }
-rustbgpd-telemetry = { path = "../../../crates/telemetry" }
-rustbgpd-transport = { path = "../../../crates/transport" }
+rustbgpd-telemetry = { path = "../../../crates/telemetry", features = ["jemalloc"] }
+rustbgpd-transport = { path = "../../../crates/transport", features = ["bench-internals"] }
 rustbgpd-wire = { path = "../../../crates/wire" }
+tikv-jemallocator = { version = "0.7", features = ["profiling", "stats"] }
 tokio = { version = "1", features = ["full"] }
 
 [workspace]

--- a/bench/scale/rrtransport/README.md
+++ b/bench/scale/rrtransport/README.md
@@ -53,11 +53,24 @@ bench/scale/rrtransport/run-receipt.sh /absolute/output/outside/the/repository
 The runner requires 4,096 file descriptors, 16 GiB available RAM, performance
 CPU governors, a quiet host, no competing BGP daemon, and a clean source tree.
 It owns a host lock, enforces a 2 GiB whole-process RSS ceiling, a 300-second
-per-run guard, and a 20-minute campaign guard. Each run retains phase and
-per-peer evidence, phase-local VmRSS/VmHWM, an independent sampler maximum,
-logs, source/binary provenance, verifier output, and checksums. Results are not
-comparable to the historical unavailable scratch harness and must not be
-published as an A/B.
+per-run guard, and a 20-minute campaign guard.
+
+Before starting the supervised target, the runner executes an explicitly
+untimed grouped-commit correctness leg through the production RIB seam and
+transport-session encoder. Its schema-2 receipt separates the one-dispatch
+65000:100 seed from a fast wire-visible RPOL transition to 65000:200. The
+transition records its native shared plan, exact probes, route-shell
+materialization, and zero authoritative per-peer fallback. Concrete transport
+snapshots plus common group-token and announce-vector identities prove the
+shared envelope path. The full-shape leg runs once and its immutable receipt is
+copied into each attempt.
+
+Each measured target records direct-PID `VmRSS`/`VmHWM` and jemalloc allocated,
+active, resident, and mapped bytes at established, staged, and wire
+checkpoints. The runner's process-tree target sampler remains separately named
+and reported. Receipts also retain per-peer evidence, logs, source/binary
+provenance, verifier output, and checksums. Results are not comparable to the
+historical unavailable scratch harness and must not be published as an A/B.
 
 CI never runs the scale shape. It runs the original smoke, a 4×100 real-TCP
 fixture through the same scale collector/verifier/RSS seams, and destructive

--- a/bench/scale/rrtransport/run-receipt.sh
+++ b/bench/scale/rrtransport/run-receipt.sh
@@ -55,7 +55,7 @@ sample_direct_rss() {
     exited) ;;
     sample)
       (( direct_rss_kib > max_rss )) && max_rss=$direct_rss_kib
-      printf 'sample\t%s\n' "$direct_rss_kib" >>"$output/rss.tsv"
+      printf 'process_tree_target_rss_sample\t%s\n' "$direct_rss_kib" >>"$output/rss.tsv"
       classify_rss "$direct_rss_kib" "$output"
       ;;
     *)
@@ -315,7 +315,7 @@ await_tiny_startup_gate() {
   fi
   rss=$tiny_validated_rss
   (( rss > max_rss )) && max_rss=$rss
-  printf 'sample\t%s\n' "$rss" >>"$receipt/rss.tsv"
+  printf 'process_tree_target_rss_sample\t%s\n' "$rss" >>"$receipt/rss.tsv"
   if ! classify_rss "$rss" "$receipt"; then
     tiny_gate_reason=rss_ceiling
     return 1
@@ -378,7 +378,7 @@ startup_gate_fixture() {
   tiny_ready=$fixture_dir/gate/ready
   tiny_go=$fixture_dir/gate/go
   tiny_expected="$root/bench/scale/rrtransport/target/debug/rrtransport"
-  printf 'checkpoint\trss_kib\n' >"$receipt/rss.tsv"
+  printf 'observer\trss_kib\n' >"$receipt/rss.tsv"
   max_rss=0
   case $mode in
     delayed-expected)
@@ -454,7 +454,7 @@ sample_supervisor() {
     seen_expected_child=true
     rss=$sampler_rss
     (( rss > max_rss )) && max_rss=$rss
-    printf 'sample\t%s\n' "$rss" >>"$receipt/rss.tsv"
+    printf 'process_tree_target_rss_sample\t%s\n' "$rss" >>"$receipt/rss.tsv"
     if ! classify_rss "$rss" "$receipt"; then
       fail_supervised_attempt rss_ceiling
       return 1
@@ -472,7 +472,7 @@ sampler_control_fixture() {
   local mode=$1 expected_status=$2 fixture_dir=$3 result
   mkdir -p "$fixture_dir"
   receipt=$fixture_dir
-  printf 'checkpoint\trss_kib\n' >"$receipt/rss.tsv"
+  printf 'observer\trss_kib\n' >"$receipt/rss.tsv"
   if [[ $mode == normal ]]; then
     # shellcheck disable=SC2016 # Expanded by the fixture's bash.
     launch_supervised "$receipt/harness.log" bash -c \
@@ -604,10 +604,18 @@ full_verify() {
   python3 "$verifier" "$receipt" --full | tee "$receipt/verifier.txt"
 }
 
+run_grouped_commit_fixture() {
+  RRTRANSPORT_GROUPED_COMMIT_OUTPUT="$1/grouped-commit.json" \
+    RRTRANSPORT_GROUPED_COMMIT_PEERS="$2" RRTRANSPORT_GROUPED_COMMIT_PREFIXES="$3" \
+    cargo test --manifest-path "$manifest" --locked \
+      rr1000::tests::grouped_commit_receipt_fixture -- --exact
+  [[ -s $1/grouped-commit.json ]]
+}
+
 full_checksums() {
   local receipt=$1
-  (cd "$receipt" && sha256sum phase.json per-peer.tsv rss.json rss.tsv provenance.json \
-    source.snapshot rrtransport.bin verifier.txt harness.log >SHA256SUMS &&
+  (cd "$receipt" && sha256sum phase.json grouped-commit.json per-peer.tsv rss.json rss.tsv \
+    provenance.json source.snapshot rrtransport.bin verifier.txt harness.log >SHA256SUMS &&
     sha256sum -c SHA256SUMS --strict)
 }
 
@@ -733,8 +741,9 @@ case ${1:-} in
     cp -a "$2" "$3"
     receipt=$3
     python3 "$verifier" "$receipt" | tee "$receipt/verifier.txt"
-    (cd "$receipt" && sha256sum phase.json per-peer.tsv rss.json rss.tsv provenance.json \
-      source.snapshot rrtransport.bin verifier.txt >SHA256SUMS && sha256sum -c SHA256SUMS)
+    (cd "$receipt" && sha256sum phase.json grouped-commit.json per-peer.tsv rss.json rss.tsv \
+      provenance.json source.snapshot rrtransport.bin verifier.txt >SHA256SUMS &&
+      sha256sum -c SHA256SUMS --strict)
     exit
     ;;
   --real-smoke)
@@ -744,7 +753,8 @@ case ${1:-} in
     rm -rf "$receipt"
     mkdir -p "$receipt"
     tiny_binary="$root/bench/scale/rrtransport/target/debug/rrtransport"
-    printf 'checkpoint\trss_kib\n' >"$receipt/rss.tsv"
+    run_grouped_commit_fixture "$receipt" 4 100
+    printf 'observer\trss_kib\n' >"$receipt/rss.tsv"
     tiny_ready=$receipt/.startup-ready
     tiny_go=$receipt/.startup-go
     tiny_expected=$tiny_binary
@@ -772,16 +782,7 @@ case ${1:-} in
     cp "$tiny_binary" "$receipt/rrtransport.bin"
     source_snapshot >"$receipt/source.snapshot"
     cp "$receipt/phase.json" "$receipt/phase.saved"
-    python3 - "$receipt" "$max_rss" <<'PY'
-import json,pathlib,sys
-d=pathlib.Path(sys.argv[1]); p=json.loads((d/"phase.json").read_text())
-with (d/"rss.tsv").open("a") as f:
- for name in ("established","staged","wire"): f.write(f"{name}\t{p[name+'_rss_kib']}\n")
-(d/"rss.json").write_text(json.dumps({"established_kib":p["established_rss_kib"],
- "staged_kib":p["staged_rss_kib"],"wire_kib":p["wire_rss_kib"],
- "established_vmhwm_kib":p["established_vmhwm_kib"],"staged_vmhwm_kib":p["staged_vmhwm_kib"],
- "wire_vmhwm_kib":p["wire_vmhwm_kib"],"sampler_max_kib":int(sys.argv[2])})+"\n")
-PY
+    python3 "$verifier" "$receipt" --write-rss "$max_rss"
     head=$(git -C "$root" rev-parse HEAD); tree=$(git -C "$root" write-tree)
     source_hash=$(sha256sum "$receipt/source.snapshot"|cut -d' ' -f1)
     binary_hash=$(sha256sum "$receipt/rrtransport.bin"|cut -d' ' -f1)
@@ -819,6 +820,8 @@ head_before=$(git -C "$root" rev-parse HEAD); tree_before=$(git -C "$root" write
 source_before=$(source_snapshot)
 timeout -k 10 300 cargo build --manifest-path "$manifest" --locked --release
 mkdir -p "$output"; campaign_started=$SECONDS
+run_grouped_commit_fixture "$output" 1000 100000
+chmod 0444 "$output/grouped-commit.json"
 before_load=''
 after_load=''
 before_pswpin=''
@@ -831,21 +834,13 @@ for run in 1 2 3; do
   require_quiet before || { echo "host not quiet before attempt" >&2; exit 1; }
   receipt="$output/run-$run"; mkdir -p "$receipt"
   printf '%s\n' "$source_before" >"$receipt/source.snapshot"; cp "$binary" "$receipt/rrtransport.bin"
-  printf 'checkpoint\trss_kib\n' >"$receipt/rss.tsv"
+  cp "$output/grouped-commit.json" "$receipt/grouped-commit.json"
+  printf 'observer\trss_kib\n' >"$receipt/rss.tsv"
   launch_supervised "$receipt/harness.log" timeout -k 10 300 "$binary" rr1000 "$receipt"
   wait_exe "$pid" "$(command -v timeout)"
   sampler_observation_reader=read_live_sampler_observation
   sample_supervisor "$binary" "$receipt" "$run" || exit 1
-  python3 - "$receipt" "$max_rss" <<'PY'
-import json,pathlib,sys
-d=pathlib.Path(sys.argv[1]); p=json.loads((d/"phase.json").read_text())
-with (d/"rss.tsv").open("a") as f:
- for name in ("established","staged","wire"): f.write(f"{name}\t{p[name+'_rss_kib']}\n")
-(d/"rss.json").write_text(json.dumps({"established_kib":p["established_rss_kib"],
- "staged_kib":p["staged_rss_kib"],"wire_kib":p["wire_rss_kib"],
- "established_vmhwm_kib":p["established_vmhwm_kib"],"staged_vmhwm_kib":p["staged_vmhwm_kib"],
- "wire_vmhwm_kib":p["wire_vmhwm_kib"],"sampler_max_kib":int(sys.argv[2])})+"\n")
-PY
+  python3 "$verifier" "$receipt" --write-rss "$max_rss"
   head_after=$(git -C "$root" rev-parse HEAD); tree_after=$(git -C "$root" write-tree)
   source_after=$(source_snapshot)
   [[ -z $(git -C "$root" status --porcelain) ]] || { echo "tree dirtied during run" >&2; exit 1; }

--- a/bench/scale/rrtransport/src/rr1000.rs
+++ b/bench/scale/rrtransport/src/rr1000.rs
@@ -1,6 +1,7 @@
 use super::{
     rr1000_support::{
-        assert_established, is_eor, rss_kib, send_before, shutdown, start_after_keepalives,
+        assert_established, checkpoint, is_eor, send_before, shutdown, start_after_keepalives,
+        Checkpoint,
     },
     transport_config,
 };
@@ -35,6 +36,10 @@ const SHAPE_DIGEST: &str = "109e38772e3bd819";
 const BITMAP_DIGEST: &str = "7c50a897bc4a4e51";
 const TINY_SHAPE: &str =
     "rrtiny-v1:peers=4;prefixes=100;sources=4;workers=12;afi=ipv4-unicast;role=ibgp-rr";
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 #[derive(Clone, Copy)]
 struct Shape {
     peers: usize,
@@ -149,6 +154,21 @@ fn route(prefix: Ipv4Prefix, peer: Ipv4Addr) -> Route {
         aspa_context: AspaValidationContext::default(),
     }
 }
+
+fn checkpoint_json(name: &str, value: Checkpoint) -> String {
+    format!(
+        "\"{name}\":{{\"direct_pid_vmrss_kib\":{},\"direct_pid_vmhwm_kib\":{},\
+         \"jemalloc_allocated_bytes\":{},\"jemalloc_active_bytes\":{},\
+         \"jemalloc_resident_bytes\":{},\"jemalloc_mapped_bytes\":{}}}",
+        value.direct_pid_vmrss_kib,
+        value.direct_pid_vmhwm_kib,
+        value.jemalloc_allocated_bytes,
+        value.jemalloc_active_bytes,
+        value.jemalloc_resident_bytes,
+        value.jemalloc_mapped_bytes,
+    )
+}
+
 async fn collect(
     peer: IpAddr,
     mut rx: mpsc::Receiver<Message>,
@@ -310,7 +330,7 @@ pub async fn run(output: &str, tiny: bool) -> Result<()> {
         stubs.push(tokio::time::timeout_at(run_deadline, task).await???);
     }
     assert_established(&sessions, run_deadline).await?;
-    let established_rss = rss_kib()?;
+    let established_resources = checkpoint(&metrics)?;
     let peers = addresses
         .iter()
         .map(|address| address.ip())
@@ -388,7 +408,7 @@ pub async fn run(output: &str, tiny: bool) -> Result<()> {
         tokio::time::sleep(Duration::from_millis(10)).await;
     };
     let staged_ms = t0.elapsed().as_millis();
-    let staged_rss = rss_kib()?;
+    let staged_resources = checkpoint(&metrics)?;
     let mut rows = Vec::with_capacity(shape.peers);
     for collector in collectors {
         rows.push(tokio::time::timeout_at(run_deadline, collector).await???);
@@ -400,7 +420,7 @@ pub async fn run(output: &str, tiny: bool) -> Result<()> {
                 .all(|row| format!("{:016x}", row.bitmap.digest()) == shape.bitmap_digest)
     );
     let wire_ms = rows.iter().map(|row| row.wire_ms).max().unwrap_or_default();
-    let wire_rss = rss_kib()?;
+    let wire_resources = checkpoint(&metrics)?;
     assert_established(&sessions, run_deadline).await?;
     let mut file = BufWriter::new(File::create(output.join("per-peer.tsv"))?);
     writeln!(file, "peer\tstaged\tnlri\tmessages\twithdrawals\tduplicates\toutside\tdecode_failures\tcoverage\tbitmap_digest\tinitial_eor\twire_ms")?;
@@ -422,9 +442,11 @@ pub async fn run(output: &str, tiny: bool) -> Result<()> {
         )?;
     }
     fs::write(output.join("phase.json"), format!(
-        "{{\"schema\":1,\"shape\":\"{}\",\"shape_digest\":\"{}\",\"wire_completion\":\"first_exact_bitmap\",\"sessions\":{},\"established_before\":{},\"established_after\":{},\"prefixes\":{},\"sources\":{SOURCES},\"workers\":{WORKERS},\"groups\":1,\"initial_eors\":{},\"injection_ms\":{injection_ms},\"staged_ms\":{staged_ms},\"wire_ms\":{wire_ms},\"established_rss_kib\":{},\"established_vmhwm_kib\":{},\"staged_rss_kib\":{},\"staged_vmhwm_kib\":{},\"wire_rss_kib\":{},\"wire_vmhwm_kib\":{}}}\n",
+        "{{\"schema\":2,\"shape\":\"{}\",\"shape_digest\":\"{}\",\"wire_completion\":\"first_exact_bitmap\",\"sessions\":{},\"established_before\":{},\"established_after\":{},\"prefixes\":{},\"sources\":{SOURCES},\"workers\":{WORKERS},\"groups\":1,\"initial_eors\":{},\"injection_ms\":{injection_ms},\"staged_ms\":{staged_ms},\"wire_ms\":{wire_ms},\"resource_observer_schema\":1,\"resource_observer\":{{{},{},{}}}}}\n",
         shape.name, shape.digest, shape.peers, shape.peers, shape.peers, shape.prefixes, shape.peers,
-        established_rss.0, established_rss.1, staged_rss.0, staged_rss.1, wire_rss.0, wire_rss.1))?;
+        checkpoint_json("established", established_resources),
+        checkpoint_json("staged", staged_resources),
+        checkpoint_json("wire", wire_resources)))?;
     shutdown(sessions, run_deadline).await?;
     drop(rib_tx);
     drop(query_tx);
@@ -434,13 +456,169 @@ pub async fn run(output: &str, tiny: bool) -> Result<()> {
 }
 
 #[cfg(test)]
-#[test]
-fn bitmap_coverage_counts_only_unique_in_range_prefixes() {
-    let mut bitmap = Bitmap::new(2);
-    bitmap.observe(value(0));
-    assert_eq!(bitmap.coverage(), 1);
-    bitmap.observe(value(0));
-    assert_eq!((bitmap.coverage(), bitmap.duplicates), (1, 1));
-    bitmap.observe(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24));
-    assert_eq!((bitmap.coverage(), bitmap.outside), (1, 1));
+mod tests {
+    use super::*;
+    use rustbgpd_policy::{rpol::RpolFile, sets::SetStore, NamedPolicy, PolicyChain};
+    use rustbgpd_transport::{fanout_bench_export_encoder, fanout_bench_export_snapshot_evidence};
+
+    fn community_chain(value: u16) -> PolicyChain {
+        let source = format!("policy p {{ term t {{ add community 65000:{value}; accept }} }}");
+        let file = RpolFile::parse(&source).unwrap();
+        let compiled = file.compile_policy("p", &[], &mut SetStore::new()).unwrap();
+        PolicyChain::from_named(vec![NamedPolicy::from_rpol("p".into(), Arc::new(compiled))])
+    }
+
+    fn assert_exact_communities(routes: &[Route], expected: u32) {
+        for route in routes {
+            let mut communities = route.attributes.iter().filter_map(|attribute| {
+                if let PathAttribute::Communities(values) = attribute {
+                    Some(values)
+                } else {
+                    None
+                }
+            });
+            assert_eq!(communities.next().unwrap().as_slice(), [expected]);
+            assert!(communities.next().is_none());
+        }
+    }
+
+    #[test]
+    fn bitmap_coverage_counts_only_unique_in_range_prefixes() {
+        let mut bitmap = Bitmap::new(2);
+        bitmap.observe(value(0));
+        assert_eq!(bitmap.coverage(), 1);
+        bitmap.observe(value(0));
+        assert_eq!((bitmap.coverage(), bitmap.duplicates), (1, 1));
+        bitmap.observe(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24));
+        assert_eq!((bitmap.coverage(), bitmap.outside), (1, 1));
+    }
+
+    #[test]
+    fn grouped_commit_receipt_fixture() {
+        let output = std::env::var_os("RRTRANSPORT_GROUPED_COMMIT_OUTPUT");
+        let peers = std::env::var("RRTRANSPORT_GROUPED_COMMIT_PEERS")
+            .map_or(Ok(4), |value| value.parse())
+            .unwrap();
+        let prefixes = std::env::var("RRTRANSPORT_GROUPED_COMMIT_PREFIXES")
+            .map_or(Ok(100), |value| value.parse())
+            .unwrap();
+        let (_rib_tx, rib_rx) = mpsc::channel(1);
+        let (_query_tx, query_rx) = mpsc::channel(1);
+        let mut manager = RibManager::new(
+            rib_rx,
+            query_rx,
+            None,
+            Some(Ipv4Addr::new(127, 255, 0, 1)),
+            BgpMetrics::new(),
+        );
+        let old = community_chain(100);
+        let mut receivers =
+            manager.bench_register_peers(peers, Some(&old), true, 2, fanout_bench_export_encoder);
+        manager.bench_reset_adj_rib_out_fanout_receipt();
+        manager.bench_seed_loc_rib(
+            (0..prefixes)
+                .map(|index| route(value(index), source(0)))
+                .collect(),
+        );
+        let mut seed_inventory = None;
+        for receiver in &mut receivers {
+            let seeded = receiver.try_recv().unwrap();
+            assert_eq!(seeded.announce.len(), prefixes);
+            assert!(seeded.shared_group_encode.is_none());
+            if let Some(first) = &seed_inventory {
+                assert!(Arc::ptr_eq(first, &seeded.announce));
+            } else {
+                seed_inventory = Some(Arc::clone(&seeded.announce));
+            }
+            assert!(receiver.try_recv().is_err());
+        }
+        let seed_receipt = manager.bench_adj_rib_out_fanout_receipt();
+        let seed_inventory = seed_inventory.unwrap();
+        assert_exact_communities(&seed_inventory, (65_000 << 16) | 100);
+        manager.bench_reset_adj_rib_out_fanout_receipt();
+        let fast_path = manager.bench_replace_export_policy_cohort(peers, &community_chain(200));
+        assert!(fast_path);
+        let mut shared_encode = None;
+        let mut shared_announce = None;
+        for receiver in &mut receivers {
+            let update = receiver.try_recv().unwrap();
+            assert_eq!(update.announce.len(), prefixes);
+            assert_ne!(update.announce[0].attributes, seed_inventory[0].attributes);
+            let evidence = fanout_bench_export_snapshot_evidence(
+                update.exact_export_snapshot.as_deref().unwrap(),
+            )
+            .unwrap();
+            assert!(
+                evidence.owner_id != 0
+                    && evidence.generation == 0
+                    && evidence.max_message_len == usize::from(rustbgpd_wire::MAX_MESSAGE_LEN)
+                    && !evidence.add_path_ipv4_unicast
+            );
+            let encode = update.shared_group_encode.as_ref().unwrap();
+            let announce = &update.announce;
+            if let (Some(first_encode), Some(first_announce)) = (&shared_encode, &shared_announce) {
+                assert!(Arc::ptr_eq(first_encode, encode) && Arc::ptr_eq(first_announce, announce));
+            } else {
+                shared_encode = Some(Arc::clone(encode));
+                shared_announce = Some(Arc::clone(announce));
+            }
+            assert!(receiver.try_recv().is_err());
+        }
+        assert_exact_communities(shared_announce.as_deref().unwrap(), (65_000 << 16) | 200);
+        let transition_receipt = manager.bench_adj_rib_out_fanout_receipt();
+        let policy_receipt = manager.bench_policy_transition_receipt();
+        assert_eq!(seed_receipt.routes_received_dispatches, 1);
+        assert_eq!(seed_receipt.routes_received_withdrawals, 0);
+        assert_eq!(transition_receipt.update_groups, 1);
+        assert_eq!(transition_receipt.grouped_peers, peers);
+        assert_eq!(transition_receipt.ungrouped_peers, 0);
+        assert_eq!(transition_receipt.dirty_peers, 0);
+        assert_eq!(transition_receipt.grouped_unicast_routes, prefixes);
+        assert_eq!(transition_receipt.private_unicast_routes, 0);
+        assert_eq!(transition_receipt.routes_received_dispatches, 0);
+        assert_eq!(transition_receipt.routes_received_withdrawals, 0);
+        assert_eq!(policy_receipt.plan_builds, 1);
+        assert_eq!(policy_receipt.full_exact_probes, prefixes);
+        assert_eq!(policy_receipt.route_shell_materializations, prefixes);
+        assert_eq!(policy_receipt.authoritative_peer_applies, 0);
+        if let Some(output) = output {
+            fs::write(
+                output,
+                format!(
+                    "{{\"schema\":2,\"timing\":\"test_profile_untimed_rpol_community_transition\",\
+                     \"fixture_peers\":{peers},\"fixture_prefixes\":{prefixes},\
+                     \"seed\":{{\"routes_received_dispatches\":1,\"routes_received_withdrawals\":0,\
+                     \"envelopes\":{peers},\"routes_per_envelope\":{prefixes},\
+                     \"shared_group_encode\":false,\"community\":\"65000:100\"}},\
+                     \"transition\":{{\"fast_path\":{fast_path},\"routes_received_dispatches\":0,\
+                     \"routes_received_withdrawals\":0,\
+                     \"probe_accounting\":\"policy_transition_receipt\",\
+                     \"plan_builds\":{},\"full_exact_probes\":{},\
+                     \"route_shell_materializations\":{},\"authoritative_peer_applies\":{},\
+                     \"envelopes\":{peers},\"routes_per_envelope\":{prefixes},\
+                     \"shared_encode_proof\":\"collected\",\
+                     \"snapshot_classification\":\"concrete_transport_session\",\
+                     \"snapshot_owner_nonzero\":true,\"snapshot_generation\":0,\
+                     \"snapshot_max_message_len\":4096,\"snapshot_add_path\":false,\
+                     \"shared_group_encode_classification\":\"one_arc_all_members\",\
+                     \"shared_announce_classification\":\"one_arc_all_members\",\
+                     \"shared_route_count\":{prefixes},\"community\":\"65000:200\",\
+                     \"update_groups\":{},\"grouped_peers\":{},\"ungrouped_peers\":{},\
+                     \"dirty_peers\":{},\"grouped_unicast_routes\":{},\
+                     \"private_unicast_routes\":{}}}}}\n",
+                    policy_receipt.plan_builds,
+                    policy_receipt.full_exact_probes,
+                    policy_receipt.route_shell_materializations,
+                    policy_receipt.authoritative_peer_applies,
+                    transition_receipt.update_groups,
+                    transition_receipt.grouped_peers,
+                    transition_receipt.ungrouped_peers,
+                    transition_receipt.dirty_peers,
+                    transition_receipt.grouped_unicast_routes,
+                    transition_receipt.private_unicast_routes,
+                ),
+            )
+            .unwrap();
+        }
+    }
 }

--- a/bench/scale/rrtransport/src/rr1000_support.rs
+++ b/bench/scale/rrtransport/src/rr1000_support.rs
@@ -2,9 +2,58 @@ use std::fs;
 
 use anyhow::{ensure, Context, Result};
 use rustbgpd_fsm::SessionState;
+use rustbgpd_telemetry::BgpMetrics;
 use rustbgpd_transport::PeerHandle;
 use rustbgpd_wire::{Message, UpdateMessage};
 use tokio::sync::{mpsc, oneshot};
+
+#[derive(Clone, Copy)]
+pub struct Checkpoint {
+    pub direct_pid_vmrss_kib: u64,
+    pub direct_pid_vmhwm_kib: u64,
+    pub jemalloc_allocated_bytes: u64,
+    pub jemalloc_active_bytes: u64,
+    pub jemalloc_resident_bytes: u64,
+    pub jemalloc_mapped_bytes: u64,
+}
+
+pub fn checkpoint(metrics: &BgpMetrics) -> Result<Checkpoint> {
+    let gathered = metrics.registry().gather();
+    let integer_gauge = |name: &str| -> Result<u64> {
+        let family = gathered
+            .iter()
+            .find(|family| family.name() == name)
+            .with_context(|| format!("missing allocator metric {name}"))?;
+        ensure!(
+            family.metric.len() == 1,
+            "allocator metric {name} has unexpected cardinality"
+        );
+        let value = family.metric[0].get_gauge().value();
+        ensure!(
+            value.is_finite() && value > 0.0 && value.fract() == 0.0,
+            "allocator metric {name} is not a positive integer"
+        );
+        value
+            .to_string()
+            .parse()
+            .with_context(|| format!("allocator metric {name} is outside u64"))
+    };
+    let allocated = integer_gauge("jemalloc_allocated_bytes")?;
+    let active = integer_gauge("jemalloc_active_bytes")?;
+    ensure!(
+        allocated <= active,
+        "jemalloc allocated bytes exceed active bytes"
+    );
+    let (vmrss, vmhwm) = rss_kib()?;
+    Ok(Checkpoint {
+        direct_pid_vmrss_kib: vmrss,
+        direct_pid_vmhwm_kib: vmhwm,
+        jemalloc_allocated_bytes: allocated,
+        jemalloc_active_bytes: active,
+        jemalloc_resident_bytes: integer_gauge("jemalloc_resident_bytes")?,
+        jemalloc_mapped_bytes: integer_gauge("jemalloc_mapped_bytes")?,
+    })
+}
 
 pub fn runtime(workers: usize) -> Result<tokio::runtime::Runtime> {
     Ok(tokio::runtime::Builder::new_multi_thread()

--- a/bench/scale/rrtransport/verify_receipt.py
+++ b/bench/scale/rrtransport/verify_receipt.py
@@ -30,6 +30,27 @@ def load(path):
         return json.load(stream)
 
 
+def write_rss(directory, sampler_max):
+    directory = pathlib.Path(directory)
+    phase = load(directory / "phase.json")
+    checkpoints = phase.get("resource_observer")
+    if phase.get("resource_observer_schema") != 1 or not isinstance(checkpoints, dict):
+        fail("phase resource observer is missing or invalid")
+    with (directory / "rss.tsv").open("r+", encoding="utf-8") as stream:
+        if stream.readline() != "observer\trss_kib\n":
+            fail("RSS TSV is missing its observer header")
+        stream.seek(0, 2)
+        for name in ("established", "staged", "wire"):
+            stream.write(
+                f"direct_pid_{name}_vmrss\t{checkpoints[name]['direct_pid_vmrss_kib']}\n"
+            )
+    (directory / "rss.json").write_text(
+        json.dumps({"schema": 2, "checkpoints": checkpoints,
+                    "process_tree_sampler_max_rss_kib": int(sampler_max)}) + "\n",
+        encoding="utf-8",
+    )
+
+
 def verify(directory, tiny=False):
     directory = pathlib.Path(directory)
     peers = 4 if tiny else PEERS
@@ -39,6 +60,7 @@ def verify(directory, tiny=False):
     bitmap_digest = "d4e22dcde16f2746" if tiny else BITMAP_DIGEST
     required = {
         "phase.json",
+        "grouped-commit.json",
         "per-peer.tsv",
         "rss.tsv",
         "rss.json",
@@ -51,7 +73,7 @@ def verify(directory, tiny=False):
 
     phase = load(directory / "phase.json")
     expected_phase = {
-        "schema": 1,
+        "schema": 2,
         "shape": shape,
         "shape_digest": shape_digest,
         "sessions": peers,
@@ -72,6 +94,53 @@ def verify(directory, tiny=False):
             fail(f"phase {key} is missing or invalid")
     if phase["injection_ms"] > min(phase["staged_ms"], phase["wire_ms"]):
         fail("injection completion follows a convergence timestamp")
+
+    grouped = load(directory / "grouped-commit.json")
+    expected_grouped = {
+        "schema": 2,
+        "timing": "test_profile_untimed_rpol_community_transition",
+        "fixture_peers": peers,
+        "fixture_prefixes": prefixes,
+        "seed": {
+            "routes_received_dispatches": 1,
+            "routes_received_withdrawals": 0,
+            "envelopes": peers,
+            "routes_per_envelope": prefixes,
+            "shared_group_encode": False,
+            "community": "65000:100",
+        },
+        "transition": {
+            "fast_path": True,
+            "routes_received_dispatches": 0,
+            "routes_received_withdrawals": 0,
+            "probe_accounting": "policy_transition_receipt",
+            "plan_builds": 1,
+            "full_exact_probes": prefixes,
+            "route_shell_materializations": prefixes,
+            "authoritative_peer_applies": 0,
+            "envelopes": peers,
+            "routes_per_envelope": prefixes,
+            "shared_encode_proof": "collected",
+            "snapshot_classification": "concrete_transport_session",
+            "snapshot_owner_nonzero": True,
+            "snapshot_generation": 0,
+            "snapshot_max_message_len": 4096,
+            "snapshot_add_path": False,
+            "shared_group_encode_classification": "one_arc_all_members",
+            "shared_announce_classification": "one_arc_all_members",
+            "shared_route_count": prefixes,
+            "community": "65000:200",
+            "update_groups": 1,
+            "grouped_peers": peers,
+            "ungrouped_peers": 0,
+            "dirty_peers": 0,
+            "grouped_unicast_routes": prefixes,
+            "private_unicast_routes": 0,
+        },
+    }
+    for key, expected in expected_grouped.items():
+        if grouped.get(key) != expected:
+            fail(f"grouped commit {key}: expected {expected!r}, got {grouped.get(key)!r}")
 
     with (directory / "per-peer.tsv").open(encoding="utf-8", newline="") as stream:
         rows = list(csv.DictReader(stream, delimiter="\t"))
@@ -105,35 +174,67 @@ def verify(directory, tiny=False):
         if totals[key] != 0:
             fail(f"{key} must be zero, got {totals[key]}")
 
-    rss = load(directory / "rss.json")
-    for key in ("established_kib", "staged_kib", "wire_kib", "established_vmhwm_kib",
-                "staged_vmhwm_kib", "wire_vmhwm_kib", "sampler_max_kib"):
-        if not isinstance(rss.get(key), int) or rss[key] <= 0:
-            fail(f"RSS evidence {key} is missing or invalid")
-        if rss[key] > RSS_LIMIT_KIB:
-            fail(f"RSS ceiling exceeded: {key}={rss[key]} KiB")
-    pairs = (
-        ("established_kib", "established_rss_kib"),
-        ("staged_kib", "staged_rss_kib"),
-        ("wire_kib", "wire_rss_kib"),
-        ("established_vmhwm_kib", "established_vmhwm_kib"),
-        ("staged_vmhwm_kib", "staged_vmhwm_kib"),
-        ("wire_vmhwm_kib", "wire_vmhwm_kib"),
+    observer = phase.get("resource_observer")
+    if phase.get("resource_observer_schema") != 1 or not isinstance(observer, dict):
+        fail("phase resource observer is missing or invalid")
+    allocator_keys = (
+        "jemalloc_allocated_bytes",
+        "jemalloc_active_bytes",
+        "jemalloc_resident_bytes",
+        "jemalloc_mapped_bytes",
     )
-    if any(rss[left] != phase[right] for left, right in pairs):
-        fail("phase and RSS JSON checkpoints disagree")
-    hwms = [rss[key] for key in ("established_vmhwm_kib", "staged_vmhwm_kib", "wire_vmhwm_kib")]
-    if hwms != sorted(hwms) or any(hwm < value for hwm, value in zip(hwms, (
-        rss["established_kib"], rss["staged_kib"], rss["wire_kib"]))):
+    for name in ("established", "staged", "wire"):
+        point = observer.get(name)
+        if not isinstance(point, dict):
+            fail(f"resource checkpoint {name} is missing or invalid")
+        for key in ("direct_pid_vmrss_kib", "direct_pid_vmhwm_kib"):
+            if type(point.get(key)) is not int or point[key] <= 0:
+                fail(f"resource checkpoint {name}.{key} is missing or invalid")
+            if point[key] > RSS_LIMIT_KIB:
+                fail(f"RSS ceiling exceeded: {name}.{key}={point[key]} KiB")
+        for key in allocator_keys:
+            if type(point.get(key)) is not int or point[key] <= 0:
+                fail(f"resource checkpoint {name}.{key} is missing or invalid")
+        if point["jemalloc_allocated_bytes"] > point["jemalloc_active_bytes"]:
+            fail(f"resource checkpoint {name} has allocated bytes above active bytes")
+    rss = load(directory / "rss.json")
+    if rss.get("schema") != 2 or rss.get("checkpoints") != observer:
+        fail("phase and RSS JSON resource checkpoints disagree")
+    sampler_max = rss.get("process_tree_sampler_max_rss_kib")
+    if type(sampler_max) is not int or sampler_max <= 0:
+        fail("process-tree RSS maximum is missing or invalid")
+    if sampler_max > RSS_LIMIT_KIB:
+        fail(f"RSS ceiling exceeded: process_tree_sampler_max_rss_kib={sampler_max} KiB")
+    hwms = [observer[name]["direct_pid_vmhwm_kib"] for name in ("established", "staged", "wire")]
+    values = [observer[name]["direct_pid_vmrss_kib"] for name in ("established", "staged", "wire")]
+    if hwms != sorted(hwms) or any(hwm < value for hwm, value in zip(hwms, values)):
         fail("VmHWM is non-monotonic or below VmRSS")
     with (directory / "rss.tsv").open(encoding="utf-8") as stream:
-        samples = [line.split("\t") for line in stream.read().splitlines()[1:]]
-    external = [int(value) for kind, value in samples if kind == "sample"]
-    checkpoints = {kind: int(value) for kind, value in samples if kind != "sample"}
-    if not external or max(external) != rss["sampler_max_kib"]:
-        fail("external RSS samples are absent or their maximum disagrees")
-    if checkpoints != {name: rss[f"{name}_kib"] for name in ("established", "staged", "wire")}:
-        fail("RSS TSV phase checkpoints disagree")
+        lines = stream.read().splitlines()
+    if not lines or lines[0] != "observer\trss_kib":
+        fail("RSS TSV is missing its observer header")
+    samples = [line.split("\t") for line in lines[1:]]
+    try:
+        external = [
+            int(value)
+            for kind, value in samples
+            if kind == "process_tree_target_rss_sample"
+        ]
+        checkpoints = {
+            kind: int(value)
+            for kind, value in samples
+            if kind != "process_tree_target_rss_sample"
+        }
+    except (TypeError, ValueError) as error:
+        fail(f"invalid RSS TSV value: {error}")
+    if not external or max(external) != sampler_max:
+        fail("process-tree RSS samples are absent or their maximum disagrees")
+    expected_checkpoints = {
+        f"direct_pid_{name}_vmrss": observer[name]["direct_pid_vmrss_kib"]
+        for name in ("established", "staged", "wire")
+    }
+    if checkpoints != expected_checkpoints:
+        fail("direct-PID RSS TSV checkpoints disagree")
 
     provenance = load(directory / "provenance.json")
     for key in ("head_before", "head_after", "tree_before", "tree_after", "source_sha256",
@@ -166,8 +267,11 @@ def verify(directory, tiny=False):
 
 if __name__ == "__main__":
     try:
+        if len(sys.argv) == 4 and sys.argv[2] == "--write-rss":
+            write_rss(sys.argv[1], sys.argv[3])
+            sys.exit()
         if len(sys.argv) not in (2, 3) or (len(sys.argv) == 3 and sys.argv[2] not in ("--tiny", "--full")):
-            fail("usage: verify_receipt.py RECEIPT [--tiny|--full]")
+            fail("usage: verify_receipt.py RECEIPT [--tiny|--full] | RECEIPT --write-rss SAMPLER_MAX")
         verify(sys.argv[1], len(sys.argv) == 3 and sys.argv[2] == "--tiny")
     except (OSError, ValueError, json.JSONDecodeError) as error:
         print(f"FAIL: {error}")

--- a/bench/tests/test-rrtransport-receipt.sh
+++ b/bench/tests/test-rrtransport-receipt.sh
@@ -53,16 +53,40 @@ python3 - "$fixture" <<'PY'
 import hashlib, json, pathlib, sys
 d = pathlib.Path(sys.argv[1])
 shape = "rr1000-v1:peers=1000;prefixes=100000;sources=4;workers=12;afi=ipv4-unicast;role=ibgp-rr"
-(d/"phase.json").write_text(json.dumps({"schema":1,"shape":shape,"shape_digest":"109e38772e3bd819",
+def point(rss, hwm, allocated, active, resident, mapped):
+ return {"direct_pid_vmrss_kib":rss,"direct_pid_vmhwm_kib":hwm,
+  "jemalloc_allocated_bytes":allocated,"jemalloc_active_bytes":active,
+  "jemalloc_resident_bytes":resident,"jemalloc_mapped_bytes":mapped}
+checkpoints={"established":point(100,105,1000,1100,1200,1300),
+ "staged":point(110,115,2000,2100,2200,2300),
+ "wire":point(120,125,3000,3100,3200,3300)}
+(d/"phase.json").write_text(json.dumps({"schema":2,"shape":shape,"shape_digest":"109e38772e3bd819",
  "wire_completion":"first_exact_bitmap","sessions":1000,"established_before":1000,"established_after":1000,"prefixes":100000,"sources":4,"workers":12,"groups":1,"initial_eors":1000,
- "injection_ms":1,"staged_ms":2,"wire_ms":3,"established_rss_kib":100,
- "staged_rss_kib":110,"wire_rss_kib":120,"established_vmhwm_kib":105,
- "staged_vmhwm_kib":115,"wire_vmhwm_kib":125})+"\n")
+ "injection_ms":1,"staged_ms":2,"wire_ms":3,"resource_observer_schema":1,
+ "resource_observer":checkpoints})+"\n")
+(d/"grouped-commit.json").write_text(json.dumps({"schema":2,
+ "timing":"test_profile_untimed_rpol_community_transition",
+ "fixture_peers":1000,"fixture_prefixes":100000,
+ "seed":{"routes_received_dispatches":1,"routes_received_withdrawals":0,
+  "envelopes":1000,"routes_per_envelope":100000,"shared_group_encode":False,
+  "community":"65000:100"},
+ "transition":{"fast_path":True,"routes_received_dispatches":0,
+  "routes_received_withdrawals":0,"probe_accounting":"policy_transition_receipt",
+  "plan_builds":1,"full_exact_probes":100000,"route_shell_materializations":100000,
+  "authoritative_peer_applies":0,"envelopes":1000,"routes_per_envelope":100000,
+  "shared_encode_proof":"collected","snapshot_classification":"concrete_transport_session",
+  "snapshot_owner_nonzero":True,"snapshot_generation":0,"snapshot_max_message_len":4096,
+  "snapshot_add_path":False,"shared_group_encode_classification":"one_arc_all_members",
+  "shared_announce_classification":"one_arc_all_members","shared_route_count":100000,
+  "community":"65000:200","update_groups":1,"grouped_peers":1000,
+  "ungrouped_peers":0,"dirty_peers":0,"grouped_unicast_routes":100000,
+  "private_unicast_routes":0}})+"\n")
 header="peer\tstaged\tnlri\tmessages\twithdrawals\tduplicates\toutside\tdecode_failures\tcoverage\tbitmap_digest\tinitial_eor\twire_ms\n"
 rows=[f"127.{2+i//254}.{1+i%254}.1\t100000\t100000\t391\t0\t0\t0\t0\t100000\t7c50a897bc4a4e51\ttrue\t3\n" for i in range(1000)]
 (d/"per-peer.tsv").write_text(header+"".join(rows))
-(d/"rss.tsv").write_text("checkpoint\trss_kib\nsample\t90\nsample\t125\nestablished\t100\nstaged\t110\nwire\t120\n")
-(d/"rss.json").write_text('{"established_kib":100,"staged_kib":110,"wire_kib":120,"established_vmhwm_kib":105,"staged_vmhwm_kib":115,"wire_vmhwm_kib":125,"sampler_max_kib":125}\n')
+(d/"rss.tsv").write_text("observer\trss_kib\nprocess_tree_target_rss_sample\t90\nprocess_tree_target_rss_sample\t125\ndirect_pid_established_vmrss\t100\ndirect_pid_staged_vmrss\t110\ndirect_pid_wire_vmrss\t120\n")
+(d/"rss.json").write_text(json.dumps({"schema":2,"checkpoints":checkpoints,
+ "process_tree_sampler_max_rss_kib":125})+"\n")
 (d/"source.snapshot").write_bytes(b"source")
 (d/"rrtransport.bin").write_bytes(b"binary")
 h=lambda p: hashlib.sha256((d/p).read_bytes()).hexdigest()
@@ -87,6 +111,42 @@ expect_red() {
 }
 
 "$runner" --verify-fixture "$fixture" "$tmp/accepted"
+expect_red missing-internal-receipt mutate -c 'import pathlib,sys;(pathlib.Path(sys.argv[1])/"grouped-commit.json").unlink()'
+for field in routes_received_dispatches routes_received_withdrawals envelopes \
+  routes_per_envelope; do
+  expect_red "seed-$field" mutate -c "import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/'grouped-commit.json';d=json.loads(p.read_text());d['seed']['$field']+=1;p.write_text(json.dumps(d))"
+done
+for field in routes_received_dispatches routes_received_withdrawals plan_builds \
+  full_exact_probes route_shell_materializations authoritative_peer_applies \
+  envelopes routes_per_envelope shared_route_count update_groups grouped_peers \
+  ungrouped_peers dirty_peers grouped_unicast_routes private_unicast_routes; do
+  expect_red "transition-$field" mutate -c "import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/'grouped-commit.json';d=json.loads(p.read_text());d['transition']['$field']+=1;p.write_text(json.dumps(d))"
+done
+for field in fast_path probe_accounting snapshot_classification snapshot_owner_nonzero snapshot_generation \
+  snapshot_max_message_len snapshot_add_path shared_group_encode_classification \
+  shared_announce_classification shared_route_count shared_encode_proof; do
+  expect_red "transition-$field" mutate -c "import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/'grouped-commit.json';d=json.loads(p.read_text());d['transition']['$field']=None;p.write_text(json.dumps(d))"
+done
+for phase in seed transition; do
+  expect_red "$phase-community" mutate -c "import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/'grouped-commit.json';d=json.loads(p.read_text());d['$phase']['community']='wrong';p.write_text(json.dumps(d))"
+done
+expect_red seed-shared-encode mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"grouped-commit.json";d=json.loads(p.read_text());d["seed"]["shared_group_encode"]=True;p.write_text(json.dumps(d))'
+for checkpoint in established staged wire; do
+  for series in jemalloc_allocated_bytes jemalloc_active_bytes \
+    jemalloc_resident_bytes jemalloc_mapped_bytes; do
+    expect_red "missing-$checkpoint-$series" mutate -c "import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/'phase.json';d=json.loads(p.read_text());del d['resource_observer']['$checkpoint']['$series'];p.write_text(json.dumps(d))"
+  done
+done
+expect_red allocator-phase-mismatch mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"rss.json";d=json.loads(p.read_text());d["checkpoints"]["staged"]["jemalloc_mapped_bytes"]+=1;p.write_text(json.dumps(d))'
+expect_red allocator-nonnumeric mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"phase.json";d=json.loads(p.read_text());d["resource_observer"]["wire"]["jemalloc_resident_bytes"]="invalid";p.write_text(json.dumps(d))'
+expect_red allocator-zero mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"phase.json";d=json.loads(p.read_text());d["resource_observer"]["established"]["jemalloc_mapped_bytes"]=0;p.write_text(json.dumps(d))'
+expect_red allocator-relation mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"phase.json";d=json.loads(p.read_text());d["resource_observer"]["staged"]["jemalloc_allocated_bytes"]=2200;p.write_text(json.dumps(d))'
+cp -a "$tmp/accepted" "$tmp/stale-checksum"
+printf '\n' >>"$tmp/stale-checksum/grouped-commit.json"
+if (cd "$tmp/stale-checksum" && sha256sum -c SHA256SUMS --strict >/dev/null 2>&1); then
+  echo "false green: stale checksum" >&2
+  exit 1
+fi
 expect_red staged-count mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"per-peer.tsv";r=p.read_text().splitlines();h=r[0].split("\t").index("staged");x=r[1].split("\t");x[h]="99999";r[1]="\t".join(x);p.write_text("\n".join(r)+"\n")'
 expect_red nlri-count mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"per-peer.tsv";r=p.read_text().splitlines();h=r[0].split("\t").index("nlri");x=r[1].split("\t");x[h]="99999";r[1]="\t".join(x);p.write_text("\n".join(r)+"\n")'
 expect_red corrupt-prefix mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"per-peer.tsv";s=p.read_text();p.write_text(s.replace("7c50a897bc4a4e51","0000000000000000",1))'
@@ -97,6 +157,36 @@ for field in withdrawals duplicates outside decode_failures; do
   expect_red "$field" mutate -c "import pathlib,sys;p=pathlib.Path(sys.argv[1])/'per-peer.tsv';s=p.read_text();h=s.splitlines()[0].split('\\t').index('$field');r=s.splitlines();x=r[1].split('\\t');x[h]='1';r[1]='\\t'.join(x);p.write_text('\\n'.join(r)+'\\n')"
 done
 expect_red missing-final-rss mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"rss.tsv";p.write_text("\n".join(p.read_text().splitlines()[:-1])+"\n")'
+expect_red wrong-final-rss-header mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"rss.tsv";s=p.read_text();p.write_text(s.replace("observer\trss_kib","wrong\trss_kib",1))'
+cp -a "$tmp/accepted" "$tmp/missing-rss-header"
+rm "$tmp/missing-rss-header/rss.tsv"
+if python3 "$verifier" "$tmp/missing-rss-header" --write-rss 125 \
+  >"$tmp/missing-rss-header.stdout" 2>&1; then
+  echo "false green: write-rss accepted a missing observer header" >&2
+  exit 1
+fi
+grep -Fq "FAIL: [Errno 2]" "$tmp/missing-rss-header.stdout"
+cp -a "$tmp/accepted" "$tmp/wrong-rss-header"
+sed -i '1s/^observer/wrong/' "$tmp/wrong-rss-header/rss.tsv"
+if python3 "$verifier" "$tmp/wrong-rss-header" --write-rss 125 \
+  >"$tmp/wrong-rss-header.stdout" 2>&1; then
+  echo "false green: write-rss accepted the wrong observer header" >&2
+  exit 1
+fi
+grep -Fq "FAIL: RSS TSV is missing its observer header" "$tmp/wrong-rss-header.stdout"
+cp -a "$tmp/accepted" "$tmp/missing-resource-observer"
+mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"phase.json";d=json.loads(p.read_text());del d["resource_observer"];p.write_text(json.dumps(d))' \
+  "$tmp/missing-resource-observer"
+if python3 "$verifier" "$tmp/missing-resource-observer" --write-rss 125 \
+  >"$tmp/missing-resource-observer.stdout" 2>&1; then
+  echo "false green: write-rss accepted a missing resource observer" >&2
+  exit 1
+fi
+if ! grep -Fxq "FAIL: phase resource observer is missing or invalid" \
+  "$tmp/missing-resource-observer.stdout"; then
+  echo "write-rss did not report the missing resource observer cleanly" >&2
+  exit 1
+fi
 if "$runner" --classify-rss 2097153 "$tmp/rss-over"; then echo "false green: rss ceiling" >&2; exit 1; fi
 grep -q '"root_failure":"rss_ceiling"' "$tmp/rss-over/failure.json"
 expect_red changed-head mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"provenance.json";d=json.loads(p.read_text());d["head_after"]="changed";p.write_text(json.dumps(d))'
@@ -125,7 +215,8 @@ printf 'Name:\trrtiny\nState:\tR (running)\nVmRSS:\t2097153 kB\n' >"$tmp/over-li
 [[ $("$runner" --observe-direct-rss "$tmp/absent.status") == $'exited\t0' ]]
 [[ $("$runner" --sample-direct-rss-fixture "$tmp/live.status" "$tmp/live-rss") == \
   $'sample\t1234\t1234' ]]
-[[ $(<"$tmp/live-rss/rss.tsv") == $'checkpoint\trss_kib\nsample\t1234' ]]
+[[ $(<"$tmp/live-rss/rss.tsv") == \
+  $'checkpoint\trss_kib\nprocess_tree_target_rss_sample\t1234' ]]
 [[ $("$runner" --sample-direct-rss-fixture "$tmp/zombie.status" "$tmp/zombie-rss") == \
   $'exited\t0\t0' ]]
 [[ $(<"$tmp/zombie-rss/rss.tsv") == $'checkpoint\trss_kib' ]]
@@ -143,7 +234,8 @@ if "$runner" --sample-direct-rss-fixture "$tmp/over-limit.status" "$tmp/over-lim
   exit 1
 fi
 grep -Fq '"root_failure":"rss_ceiling"' "$tmp/over-limit/failure.json"
-[[ $(<"$tmp/over-limit/rss.tsv") == $'checkpoint\trss_kib\nsample\t2097153' ]]
+[[ $(<"$tmp/over-limit/rss.tsv") == \
+  $'checkpoint\trss_kib\nprocess_tree_target_rss_sample\t2097153' ]]
 
 resolve_observations() {
   local name=$1 seen=$2 expected=$3
@@ -342,10 +434,11 @@ for spec in messages:0 wire_ms:-1; do
 done
 expect_red wrong-peer mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"per-peer.tsv";s=p.read_text();p.write_text(s.replace("127.2.1.1","192.0.2.1",1))'
 expect_red wire-max mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"phase.json";d=json.loads(p.read_text());d["wire_ms"]=4;p.write_text(json.dumps(d))'
-expect_red phase-rss mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"phase.json";d=json.loads(p.read_text());d["staged_rss_kib"]=111;p.write_text(json.dumps(d))'
-expect_red hwm-below-rss mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1]);[(lambda f,d:(d.__setitem__("wire_vmhwm_kib",119),f.write_text(json.dumps(d))))(f,json.loads(f.read_text())) for f in (p/"rss.json",p/"phase.json")]'
-expect_red hwm-nonmonotonic mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1]);[(lambda f,d:(d.__setitem__("staged_vmhwm_kib",126),f.write_text(json.dumps(d))))(f,json.loads(f.read_text())) for f in (p/"rss.json",p/"phase.json")]'
-expect_red no-external-sample mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"rss.tsv";p.write_text("\n".join(x for x in p.read_text().splitlines() if not x.startswith("sample"))+"\n")'
-expect_red sampler-max mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"rss.json";d=json.loads(p.read_text());d["sampler_max_kib"]=124;p.write_text(json.dumps(d))'
-expect_red tsv-checkpoint mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"rss.tsv";s=p.read_text();p.write_text(s.replace("staged\t110","staged\t111"))'
+expect_red phase-rss mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"phase.json";d=json.loads(p.read_text());d["resource_observer"]["staged"]["direct_pid_vmrss_kib"]=111;p.write_text(json.dumps(d))'
+expect_red hwm-below-rss mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1]);[(lambda f,d:(d["checkpoints" if f.name=="rss.json" else "resource_observer"]["wire"].__setitem__("direct_pid_vmhwm_kib",119),f.write_text(json.dumps(d))))(f,json.loads(f.read_text())) for f in (p/"rss.json",p/"phase.json")]'
+expect_red hwm-nonmonotonic mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1]);[(lambda f,d:(d["checkpoints" if f.name=="rss.json" else "resource_observer"]["staged"].__setitem__("direct_pid_vmhwm_kib",126),f.write_text(json.dumps(d))))(f,json.loads(f.read_text())) for f in (p/"rss.json",p/"phase.json")]'
+expect_red no-external-sample mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"rss.tsv";p.write_text("\n".join(x for x in p.read_text().splitlines() if not x.startswith("process_tree_target_rss_sample"))+"\n")'
+expect_red legacy-sample-name mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"rss.tsv";s=p.read_text();p.write_text(s.replace("process_tree_target_rss_sample","sample",1))'
+expect_red sampler-max mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"rss.json";d=json.loads(p.read_text());d["process_tree_sampler_max_rss_kib"]=124;p.write_text(json.dumps(d))'
+expect_red tsv-checkpoint mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"rss.tsv";s=p.read_text();p.write_text(s.replace("direct_pid_staged_vmrss\t110","direct_pid_staged_vmrss\t111"))'
 echo "PASS: rrtransport receipt mechanics and destructive proofs"


### PR DESCRIPTION
## Summary

- add allocator-backed allocated, active, resident, and mapped checkpoints beside separately named direct-PID and process-tree RSS evidence
- add a one-time untimed 4-peer/100-prefix real-TCP grouped policy transition fixture using a real RPOL community rewrite
- harden the receipt schema and verifier around seed ownership, transition accounting, shared payload identity, exact all-route content, and observer provenance

## Scope

Observer and harness hardening only. This does not run or publish a scale campaign, change production code or APIs, or make a performance, convergence, full-table, or comparative claim.

## Load-bearing proofs

- removing or corrupting any required allocator series/checkpoint, grouped-transition equation, encode mode, observer schema field, or checksum makes the destructive verifier suite fail
- replacing a middle transition route with an extra community fails the exact all-route payload proof
- the real 4x100 smoke must complete the RPOL `65000:100` to `65000:200` transition with one shared encode payload and one shared announce payload across the group
- legacy process-tree `sample` rows are rejected by schema 2

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo clippy --manifest-path bench/scale/rrtransport/Cargo.toml --locked --all-targets -- -D warnings`
- `cargo test --manifest-path bench/scale/rrtransport/Cargo.toml --locked`
- `bash bench/tests/test-rrtransport-receipt.sh`
- real 4x100 receipt smoke via `run-receipt.sh`

Tracks LAN-694.
