### PR TITLE
Propagate neighbor list output failures

### DIFF
--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use crate::connection::Connection;
 use crate::error::CliError;
 use crate::output::{
@@ -116,10 +118,28 @@ pub async fn list(connection: Connection, json: bool, wide: bool) -> Result<(), 
         // `--wide` is display-only: JSON is unaffected by it and may omit
         // optional false healthy-state fields.
         NeighborListView::Json(out) => output::print_json_pretty(&out)?,
-        NeighborListView::Empty(message) => println!("{message}"),
-        NeighborListView::Table(neighbors) => output::print_neighbor_table(&neighbors, wide),
+        human => {
+            let stdout = std::io::stdout();
+            write_human_neighbor_list(&mut stdout.lock(), human, wide)?;
+        }
     }
     Ok(())
+}
+
+fn write_human_neighbor_list<W: Write + ?Sized>(
+    writer: &mut W,
+    view: NeighborListView,
+    wide: bool,
+) -> Result<(), CliError> {
+    match view {
+        NeighborListView::Empty(message) => {
+            output::write_bytes(writer, format!("{message}\n").as_bytes())
+        }
+        NeighborListView::Table(neighbors) => {
+            output::write_neighbor_table(writer, &neighbors, wide)
+        }
+        NeighborListView::Json(_) => unreachable!("JSON is emitted before the human writer"),
+    }
 }
 
 /// Friendly empty state: what happened, plus the one command that
@@ -1352,6 +1372,63 @@ mod tests {
     use super::*;
     use crate::connection::connect;
     use crate::test_support::spawn_mock_server;
+
+    #[derive(Default)]
+    struct TestWriter {
+        bytes: Vec<u8>,
+        flushes: usize,
+        fail_write: bool,
+        fail_flush: bool,
+    }
+
+    impl Write for TestWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            if self.fail_write {
+                return Err(std::io::Error::from(std::io::ErrorKind::BrokenPipe));
+            }
+            self.bytes.extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.flushes += 1;
+            if self.fail_flush {
+                return Err(std::io::Error::other("flush failed"));
+            }
+            Ok(())
+        }
+    }
+
+    fn human_views() -> [NeighborListView; 2] {
+        [
+            NeighborListView::Empty("empty".to_string()),
+            NeighborListView::Table(Vec::new()),
+        ]
+    }
+
+    #[test]
+    fn human_neighbor_list_propagates_writes_and_flushes_once() {
+        for (fail_write, fail_flush) in [(true, false), (false, true)] {
+            for view in human_views() {
+                let mut writer = TestWriter {
+                    fail_write,
+                    fail_flush,
+                    ..Default::default()
+                };
+                let error = write_human_neighbor_list(&mut writer, view, false).unwrap_err();
+                assert!(matches!(error, CliError::Io(_)));
+            }
+        }
+
+        for (index, view) in human_views().into_iter().enumerate() {
+            let mut writer = TestWriter::default();
+            write_human_neighbor_list(&mut writer, view, false).unwrap();
+            assert_eq!(writer.flushes, 1);
+            if index == 0 {
+                assert_eq!(writer.bytes, b"empty\n");
+            }
+        }
+    }
 
     #[test]
     fn bare_ip_rpc_address_strips_only_one_valid_link_local_zone() {

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -675,8 +675,13 @@ fn ansi_overhead(colored: &str, plain_len: usize) -> usize {
 /// (MsgRcvd, MsgSent, Flaps, RRC), a compact slow-peer marker, and the overloaded
 /// `State/PfxRcd` — prefixes-received count when Established, state name
 /// otherwise — as the last column.
-pub fn print_neighbor_table(neighbors: &[proto::NeighborState], wide: bool) {
-    print!("{}", render_neighbor_table(neighbors, wide));
+pub(crate) fn write_neighbor_table<W: Write + ?Sized>(
+    writer: &mut W,
+    neighbors: &[proto::NeighborState],
+    wide: bool,
+) -> Result<(), CliError> {
+    let rendered = render_neighbor_table(neighbors, wide);
+    write_bytes(writer, rendered.as_bytes())
 }
 
 fn render_neighbor_table(neighbors: &[proto::NeighborState], wide: bool) -> String {
@@ -2030,7 +2035,9 @@ mod tests {
 Neighbor    AS    State       Uptime   Rx Pfx Tx Pfx  Description
 10.0.0.1    64512 Established 01:01:40    100      5  core-rr-client
 2001:db8::2 65001 Idle        00:00:00      0      0  \n";
-        assert_eq!(render_neighbor_table(&table_fixture(), false), expected);
+        let mut bytes = Vec::new();
+        write_neighbor_table(&mut bytes, &table_fixture(), false).unwrap();
+        assert_eq!(bytes, expected.as_bytes());
     }
 
     /// Golden wide table: default columns unchanged and in order, then
@@ -2045,7 +2052,9 @@ Neighbor    AS    State       Uptime   Rx Pfx Tx Pfx  Description
 Neighbor    AS    State       Uptime   Rx Pfx Tx Pfx Description    Source                                    MsgRcvd MsgSent Flaps RRC Slow State/PfxRcd
 10.0.0.1    64512 Established 01:01:40    100      5 core-rr-client dynamic (10.0.0.0/24, group core-members)    1234     567     2 *   !    100
 2001:db8::2 65001 Idle        00:00:00      0      0                static                                          0       0     9          Idle\n";
-        assert_eq!(render_neighbor_table(&table_fixture(), true), expected);
+        let mut bytes = Vec::new();
+        write_neighbor_table(&mut bytes, &table_fixture(), true).unwrap();
+        assert_eq!(bytes, expected.as_bytes());
     }
 
     /// A stale row must never render its placeholder state as a


### PR DESCRIPTION
## Summary

- route human `rbgp neighbor list` output through the existing fallible writer contract
- propagate direct-write and terminal-flush errors as `CliError::Io`
- preserve exact empty, default-table, wide-table, and JSON output bytes

## Scope

Two CLI files only. This does not change RPCs, JSON, table formatting, exit-code mapping, stderr, or any other command.

## Load-bearing proofs

- bypassing the injected writer in the Empty arm makes its direct-write test red
- bypassing the injected writer in the Table arm makes its direct-write test red
- removing the terminal flush makes the flush-only test red
- successful Empty and Table writes each flush exactly once; populated default/wide tables retain byte-for-byte goldens

## Verification

- `cargo test -p rustbgpctl human_neighbor_list_propagates_writes_and_flushes_once`
- `cargo test -p rustbgpctl neighbor_table`
- `cargo test -p rustbgpctl empty_json_neighbor_list_stays_exact_and_skips_range_rpc`
- `cargo test -p rustbgpctl`
- `cargo clippy -p rustbgpctl --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- push-hook workspace fmt/clippy/test/doc

Tracks LAN-773.
