### PR TITLE
Fail intern-churn soak evidence closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
           bash bench/tests/test-rrharness-driver.sh
           python3 -m unittest discover \
             -s bench/scale/enhanced-route-refresh -p 'test_*.py'
+          python3 -m unittest -v tests/soak/test_intern_churn_analyzers.py
           python3 bench/scale/rebaseline/test_classifiers.py
           python3 bench/scale/rebaseline/test_parse_rrharness.py
           python3 bench/scale/rebaseline/test_validate_lan395_criterion.py

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -815,7 +815,7 @@ per-cycle events recorded in `churn.log`.
 | Harness | Proves | Topology / analyzer |
 |---------|--------|---------------------|
 | `run-soak-gr-restart-intern-gc.sh` | The attribute intern table does not grow across GR-restart → EoR → stale-clear cycles: `bgp_rib_attr_intern_global_size` slope `< 1.0`/hr | containerlab topology + post-hoc slope analyzer |
-| `run-soak-hot-reload.sh` | Sustained SIGHUP / live-apply config churn leaks no state | containerlab topology + post-hoc analyzer |
+| `run-soak-hot-reload.sh` | Sustained transactional `config plan` / `config apply` churn leaks no state | containerlab topology + post-hoc analyzer |
 | `run-soak-inject-churn.sh` | Sustained gRPC AddPath/DeletePath churn holds RSS + intern-table size flat | containerlab topology + post-hoc analyzer |
 
 Each pairs a containerlab topology with a post-hoc analyzer and runs under the

--- a/tests/soak/analyze-soak-gr-restart.py
+++ b/tests/soak/analyze-soak-gr-restart.py
@@ -25,6 +25,11 @@ import math
 import sys
 from typing import Optional
 
+REQUIRED = {
+    "elapsed_sec", "rss_mb", "intern_size", "gr_active_peers",
+    "gr_stale_routes", "bgp_established", "restart_cycles",
+}
+
 
 def safe_float(value: str | None) -> Optional[float]:
     if value is None or value in ("", "NaN", "nan"):
@@ -54,6 +59,8 @@ def analyze(rows: list[dict[str, str]]) -> dict:
     intern = []
     established_final = []
     max_cycles = 0
+    saw_positive_phase = False
+    cleared_after_positive = False
 
     for row in rows:
         e = safe_float(row.get("elapsed_sec"))
@@ -70,6 +77,11 @@ def analyze(rows: list[dict[str, str]]) -> dict:
             max_cycles = max(max_cycles, int(c))
         est = row.get("bgp_established")
         established_final.append(est)
+        active = safe_float(row.get("gr_active_peers"))
+        stale = safe_float(row.get("gr_stale_routes"))
+        saw_positive_phase = saw_positive_phase or (active > 0 and stale > 0)
+        if saw_positive_phase and active == 0 and stale == 0:
+            cleared_after_positive = True
 
     # Convert to hours for slope-per-hour.
     rss_slope = linreg([e / 3600 for e, _ in rss], [r for _, r in rss]) if rss else float("nan")
@@ -110,6 +122,10 @@ def analyze(rows: list[dict[str, str]]) -> dict:
             "value": final_established,
             "pass": final_established,
         },
+        "gr_active_stale_then_clear": {
+            "value": cleared_after_positive,
+            "pass": cleared_after_positive,
+        },
     }
 
     all_pass = all(g["pass"] for g in gates.values())
@@ -133,7 +149,12 @@ def main() -> int:
     csv_path = f"{args.run_dir}/samples.csv"
     try:
         with open(csv_path, newline="") as f:
-            rows = list(csv.DictReader(f))
+            reader = csv.DictReader(f)
+            missing = REQUIRED - set(reader.fieldnames or [])
+            if missing:
+                print(f"error: missing required columns: {', '.join(sorted(missing))}", file=sys.stderr)
+                return 2
+            rows = list(reader)
     except OSError as e:
         print(f"error reading {csv_path}: {e}", file=sys.stderr)
         return 2
@@ -141,6 +162,14 @@ def main() -> int:
     if not rows:
         print("error: samples.csv is empty", file=sys.stderr)
         return 2
+    for line, row in enumerate(rows, 2):
+        for column in REQUIRED - {"bgp_established"}:
+            if safe_float(row.get(column)) is None:
+                print(f"error: row {line}: invalid {column}", file=sys.stderr)
+                return 2
+        if row["bgp_established"] not in {"0", "1"}:
+            print(f"error: row {line}: invalid bgp_established", file=sys.stderr)
+            return 2
 
     result = analyze(rows)
     out = json.dumps(result, indent=2)

--- a/tests/soak/analyze-soak-gr-restart.py
+++ b/tests/soak/analyze-soak-gr-restart.py
@@ -10,6 +10,7 @@ JSON verdict against the soak-specific gates:
   - RSS slope (steady state, MB/hour) < 1.0
   - peak RSS < 512 MB
   - at least one restart cycle recorded
+  - positive GR-active and stale-route evidence followed by both clearing
   - BGP established observed in the final 3 samples (session recovered)
 
 Stdlib only. Exit code 0 on pass, 1 on any gate failure, 2 on

--- a/tests/soak/analyze-soak-gr-restart.py
+++ b/tests/soak/analyze-soak-gr-restart.py
@@ -29,6 +29,9 @@ REQUIRED = {
     "elapsed_sec", "rss_mb", "intern_size", "gr_active_peers",
     "gr_stale_routes", "bgp_established", "restart_cycles",
 }
+COUNTERS = {
+    "intern_size", "gr_active_peers", "gr_stale_routes", "restart_cycles",
+}
 
 
 def safe_float(value: str | None) -> Optional[float]:
@@ -164,8 +167,12 @@ def main() -> int:
         return 2
     for line, row in enumerate(rows, 2):
         for column in REQUIRED - {"bgp_established"}:
-            if safe_float(row.get(column)) is None:
+            value = safe_float(row.get(column))
+            if value is None:
                 print(f"error: row {line}: invalid {column}", file=sys.stderr)
+                return 2
+            if column in COUNTERS and (value < 0 or not value.is_integer()):
+                print(f"error: row {line}: invalid counter {column}", file=sys.stderr)
                 return 2
         if row["bgp_established"] not in {"0", "1"}:
             print(f"error: row {line}: invalid bgp_established", file=sys.stderr)

--- a/tests/soak/analyze-soak-hot-reload.py
+++ b/tests/soak/analyze-soak-hot-reload.py
@@ -28,6 +28,10 @@ REQUIRED = {
     "elapsed_sec", "rss_mb", "intern_size", "bgp_established",
     "apply_cycles", "apply_ok", "apply_fail", "flap_count", "uptime_seconds",
 }
+COUNTERS = {
+    "intern_size", "apply_cycles", "apply_ok", "apply_fail",
+    "flap_count", "uptime_seconds",
+}
 
 
 def safe_float(value: str | None) -> Optional[float]:
@@ -181,8 +185,12 @@ def main() -> int:
         return 2
     for line, row in enumerate(rows, 2):
         for column in REQUIRED - {"bgp_established"}:
-            if safe_float(row.get(column)) is None:
+            value = safe_float(row.get(column))
+            if value is None:
                 print(f"error: row {line}: invalid {column}", file=sys.stderr)
+                return 2
+            if column in COUNTERS and (value < 0 or not value.is_integer()):
+                print(f"error: row {line}: invalid counter {column}", file=sys.stderr)
                 return 2
         if row["bgp_established"] not in {"0", "1"}:
             print(f"error: row {line}: invalid bgp_established", file=sys.stderr)

--- a/tests/soak/analyze-soak-hot-reload.py
+++ b/tests/soak/analyze-soak-hot-reload.py
@@ -24,6 +24,11 @@ import math
 import sys
 from typing import Optional
 
+REQUIRED = {
+    "elapsed_sec", "rss_mb", "intern_size", "bgp_established",
+    "apply_cycles", "apply_ok", "apply_fail", "flap_count", "uptime_seconds",
+}
+
 
 def safe_float(value: str | None) -> Optional[float]:
     if value is None or value in ("", "NaN", "nan"):
@@ -59,6 +64,7 @@ def analyze(rows: list[dict[str, str]]) -> dict:
     max_cycles = 0
     final_ok = 0
     final_fail = 0
+    first_flaps = first_uptime = final_flaps = final_uptime = 0
 
     for row in rows:
         e = safe_float(row.get("elapsed_sec"))
@@ -78,6 +84,11 @@ def analyze(rows: list[dict[str, str]]) -> dict:
         if fail is not None:
             final_fail = fail
         established_final.append(row.get("bgp_established", ""))
+        flaps = safe_int(row.get("flap_count"))
+        uptime = safe_int(row.get("uptime_seconds"))
+        if not rss_pts or len(established_final) == 1:
+            first_flaps, first_uptime = flaps, uptime
+        final_flaps, final_uptime = flaps, uptime
 
     rss_slope = (
         linreg([e / 3600 for e, _ in rss_pts], [r for _, r in rss_pts])
@@ -95,8 +106,6 @@ def analyze(rows: list[dict[str, str]]) -> dict:
     final_established = tail.count("1") > 0 if tail else False
 
     total_applies = final_ok + final_fail
-    fail_rate = (final_fail / total_applies) if total_applies > 0 else 1.0
-
     gates = {
         "intern_slope_per_hour": {
             "value": intern_slope if not math.isnan(intern_slope) else None,
@@ -116,16 +125,21 @@ def analyze(rows: list[dict[str, str]]) -> dict:
         "apply_cycles": {
             "value": max_cycles,
             "limit": 1,
-            "pass": max_cycles >= 1,
+            "pass": max_cycles >= 1 and max_cycles == total_applies,
         },
         "final_session_established": {
             "value": final_established,
             "pass": final_established,
         },
-        "apply_failure_rate": {
-            "value": fail_rate,
-            "limit": 0.5,
-            "pass": fail_rate < 0.5,
+        "apply_failures": {
+            "value": final_fail,
+            "limit": 0,
+            "pass": final_ok >= 1 and final_fail == 0,
+        },
+        "session_continuity": {
+            "value": {"flap_delta": final_flaps - first_flaps,
+                      "uptime_delta": final_uptime - first_uptime},
+            "pass": final_flaps == first_flaps and final_uptime >= first_uptime,
         },
     }
 
@@ -135,7 +149,6 @@ def analyze(rows: list[dict[str, str]]) -> dict:
         "apply_cycles": max_cycles,
         "apply_ok": final_ok,
         "apply_fail": final_fail,
-        "apply_failure_rate": fail_rate,
         "intern_slope_per_hour": intern_slope if not math.isnan(intern_slope) else None,
         "rss_slope_per_hour": rss_slope if not math.isnan(rss_slope) else None,
         "peak_rss_mb": peak_rss if not math.isnan(peak_rss) else None,
@@ -153,7 +166,12 @@ def main() -> int:
     csv_path = f"{args.run_dir}/samples.csv"
     try:
         with open(csv_path, newline="") as f:
-            rows = list(csv.DictReader(f))
+            reader = csv.DictReader(f)
+            missing = REQUIRED - set(reader.fieldnames or [])
+            if missing:
+                print(f"error: missing required columns: {', '.join(sorted(missing))}", file=sys.stderr)
+                return 2
+            rows = list(reader)
     except OSError as e:
         print(f"error reading {csv_path}: {e}", file=sys.stderr)
         return 2
@@ -161,6 +179,14 @@ def main() -> int:
     if not rows:
         print("error: samples.csv is empty", file=sys.stderr)
         return 2
+    for line, row in enumerate(rows, 2):
+        for column in REQUIRED - {"bgp_established"}:
+            if safe_float(row.get(column)) is None:
+                print(f"error: row {line}: invalid {column}", file=sys.stderr)
+                return 2
+        if row["bgp_established"] not in {"0", "1"}:
+            print(f"error: row {line}: invalid bgp_established", file=sys.stderr)
+            return 2
 
     result = analyze(rows)
     out = json.dumps(result, indent=2)

--- a/tests/soak/analyze-soak-hot-reload.py
+++ b/tests/soak/analyze-soak-hot-reload.py
@@ -8,8 +8,8 @@ verdict against the soak-specific gates:
   - intern table size (bgp_rib_attr_intern_global_size) slope per hour < 1.0
   - peak RSS < 512 MB
   - session established in final 3 samples (no flap from live-apply)
-  - at least one apply cycle recorded
-  - apply failure rate < 50% (live-apply path must be functional)
+  - at least one successful apply, zero failures, and exact apply accounting
+  - unchanged flap count and nondecreasing session uptime
 
 Stdlib only. Exit code 0 on pass, 1 on any gate failure, 2 on
 harness/input error.

--- a/tests/soak/analyze-soak-inject-churn.py
+++ b/tests/soak/analyze-soak-inject-churn.py
@@ -23,6 +23,12 @@ import math
 import sys
 from typing import Optional
 
+REQUIRED = {
+    "elapsed_sec", "rss_mb", "intern_size", "live_target", "frr_route_count",
+    "bgp_established", "churn_cycles", "add_total", "del_total",
+    "flap_count", "uptime_seconds",
+}
+
 
 def safe_float(value: str | None) -> Optional[float]:
     if value is None or value in ("", "NaN", "nan"):
@@ -51,6 +57,8 @@ def analyze(rows: list[dict[str, str]]) -> dict:
     intern_pts: list[tuple[float, float]] = []
     established_final: list[str] = []
     max_cycles = 0
+    first_flaps = first_uptime = final_flaps = final_uptime = 0
+    final_target = final_routes = 0
 
     for row in rows:
         e = safe_float(row.get("elapsed_sec"))
@@ -64,6 +72,13 @@ def analyze(rows: list[dict[str, str]]) -> dict:
         if c is not None:
             max_cycles = max(max_cycles, int(c))
         established_final.append(row.get("bgp_established", ""))
+        flaps = int(safe_float(row.get("flap_count")))
+        uptime = int(safe_float(row.get("uptime_seconds")))
+        if len(established_final) == 1:
+            first_flaps, first_uptime = flaps, uptime
+        final_flaps, final_uptime = flaps, uptime
+        final_target = int(safe_float(row.get("live_target")))
+        final_routes = int(safe_float(row.get("frr_route_count")))
 
     rss_slope = (
         linreg([e / 3600 for e, _ in rss_pts], [r for _, r in rss_pts])
@@ -105,6 +120,15 @@ def analyze(rows: list[dict[str, str]]) -> dict:
             "value": final_established,
             "pass": final_established,
         },
+        "final_consumer_convergence": {
+            "value": {"target": final_target, "routes": final_routes},
+            "pass": final_target > 0 and final_routes == final_target,
+        },
+        "session_continuity": {
+            "value": {"flap_delta": final_flaps - first_flaps,
+                      "uptime_delta": final_uptime - first_uptime},
+            "pass": final_flaps == first_flaps and final_uptime >= first_uptime,
+        },
     }
 
     all_pass = all(g["pass"] for g in gates.values())
@@ -128,7 +152,12 @@ def main() -> int:
     csv_path = f"{args.run_dir}/samples.csv"
     try:
         with open(csv_path, newline="") as f:
-            rows = list(csv.DictReader(f))
+            reader = csv.DictReader(f)
+            missing = REQUIRED - set(reader.fieldnames or [])
+            if missing:
+                print(f"error: missing required columns: {', '.join(sorted(missing))}", file=sys.stderr)
+                return 2
+            rows = list(reader)
     except OSError as e:
         print(f"error reading {csv_path}: {e}", file=sys.stderr)
         return 2
@@ -136,6 +165,14 @@ def main() -> int:
     if not rows:
         print("error: samples.csv is empty", file=sys.stderr)
         return 2
+    for line, row in enumerate(rows, 2):
+        for column in REQUIRED - {"bgp_established"}:
+            if safe_float(row.get(column)) is None:
+                print(f"error: row {line}: invalid {column}", file=sys.stderr)
+                return 2
+        if row["bgp_established"] not in {"0", "1"}:
+            print(f"error: row {line}: invalid bgp_established", file=sys.stderr)
+            return 2
 
     result = analyze(rows)
     out = json.dumps(result, indent=2)

--- a/tests/soak/analyze-soak-inject-churn.py
+++ b/tests/soak/analyze-soak-inject-churn.py
@@ -28,6 +28,7 @@ REQUIRED = {
     "bgp_established", "churn_cycles", "add_total", "del_total",
     "flap_count", "uptime_seconds",
 }
+COUNTERS = REQUIRED - {"elapsed_sec", "rss_mb", "bgp_established"}
 
 
 def safe_float(value: str | None) -> Optional[float]:
@@ -167,8 +168,12 @@ def main() -> int:
         return 2
     for line, row in enumerate(rows, 2):
         for column in REQUIRED - {"bgp_established"}:
-            if safe_float(row.get(column)) is None:
+            value = safe_float(row.get(column))
+            if value is None:
                 print(f"error: row {line}: invalid {column}", file=sys.stderr)
+                return 2
+            if column in COUNTERS and (value < 0 or not value.is_integer()):
+                print(f"error: row {line}: invalid counter {column}", file=sys.stderr)
                 return 2
         if row["bgp_established"] not in {"0", "1"}:
             print(f"error: row {line}: invalid bgp_established", file=sys.stderr)

--- a/tests/soak/analyze-soak-inject-churn.py
+++ b/tests/soak/analyze-soak-inject-churn.py
@@ -9,6 +9,8 @@ verdict against the soak-specific gates:
   - peak RSS < 512 MB
   - session established in final 3 samples (no flap)
   - at least one churn cycle recorded
+  - final consumer route count exactly matches the live target
+  - unchanged flap count and nondecreasing session uptime
 
 Stdlib only. Exit code 0 on pass, 1 on any gate failure, 2 on
 harness/input error.

--- a/tests/soak/run-soak-gr-restart-intern-gc.sh
+++ b/tests/soak/run-soak-gr-restart-intern-gc.sh
@@ -26,7 +26,7 @@
 
 set -euo pipefail
 
-SOAK_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SOAK_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SOAK_SCRIPT_DIR/../.." && pwd)"
 TOPOLOGY="${TOPOLOGY:-$REPO_ROOT/tests/soak/soak-gr-restart-intern-gc.clab.yml}"
 
@@ -45,7 +45,6 @@ FRR_IP="${FRR_IP:-10.0.0.2}"
 
 RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
 RUN_DIR="${RUN_DIR_OVERRIDE:-$SOAK_SCRIPT_DIR/runs/soak-gr-restart-$RUN_ID}"
-mkdir -p "$RUN_DIR"
 
 SAMPLES_CSV="$RUN_DIR/samples.csv"
 SOAK_LOG="$RUN_DIR/soak.log"
@@ -53,11 +52,8 @@ CYCLES_LOG="$RUN_DIR/cycles.log"
 RUN_JSON="$RUN_DIR/run.json"
 RUSTBGPD_LOG="$RUN_DIR/rustbgpd.log"
 
-exec > >(tee -a "$SOAK_LOG") 2>&1
-
-# shellcheck source=./host-lock.sh
+# shellcheck source=tests/soak/host-lock.sh
 source "$SOAK_SCRIPT_DIR/host-lock.sh"
-acquire_rustbgpd_host_lock
 
 log() {
     printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
@@ -90,11 +86,11 @@ prom_scrape() {
     curl -sfm 5 "http://${ip}:9179/metrics" 2>/dev/null || true
 }
 
-prom_extract_or_zero() {
+prom_extract_required() {
     local text="$1" metric="$2"
     printf '%s' "$text" | awk -v m="$metric" '
         $0 ~ "^"m"( |\\{)" { print $NF; found=1; exit }
-        END { if (!found) { print "0" } }
+        END { if (!found) { print "nan" } }
     '
 }
 
@@ -102,8 +98,8 @@ prom_extract_or_zero() {
 prom_extract_sum() {
     local prom="$1" name="$2"
     awk -v n="$name" '
-        $0 ~ "^"n"[{ ]" { s += $NF }
-        END { printf "%d", s+0 }
+        $0 ~ "^"n"[{ ]" { s += $NF; found=1 }
+        END { if (!found) print "nan"; else printf "%d", s }
     ' <<<"$prom"
 }
 
@@ -143,13 +139,36 @@ wait_established() {
 }
 
 restart_frr_bgpd() {
+    local elapsed=${1:?} cycles=${2:?} active=nan stale=nan prom
     cycle_log "restarting FRR bgpd"
-    # Stop bgpd, wait for rustbgpd to notice the session drop and mark stale.
-    docker exec "$FRR" /usr/lib/frr/frrinit.sh stop >/dev/null 2>&1 || true
-    sleep 5
-    # Start bgpd again; rustbgpd will see reconnect + EoR + stale-clear + gc.
-    docker exec "$FRR" /usr/lib/frr/frrinit.sh start >/dev/null 2>&1 || true
-    cycle_log "FRR bgpd restart initiated"
+    docker exec "$FRR" /usr/lib/frr/frrinit.sh stop >/dev/null
+    for _ in $(seq 1 30); do
+        prom=$(prom_scrape) || prom=""
+        active=$(prom_extract_required "$prom" bgp_gr_active_peers)
+        stale=$(prom_extract_required "$prom" bgp_gr_stale_routes)
+        if awk "BEGIN {exit !($active > 0 && $stale > 0)}" 2>/dev/null; then
+            sample_row "$elapsed" "$cycles"
+            break
+        fi
+        sleep 1
+    done
+    awk "BEGIN {exit !($active > 0 && $stale > 0)}" 2>/dev/null ||
+        { log "ERROR: GR active/stale evidence not observed"; return 1; }
+    docker exec "$FRR" /usr/lib/frr/frrinit.sh start >/dev/null
+    wait_established 60
+    for _ in $(seq 1 30); do
+        prom=$(prom_scrape) || prom=""
+        active=$(prom_extract_required "$prom" bgp_gr_active_peers)
+        stale=$(prom_extract_required "$prom" bgp_gr_stale_routes)
+        if [ "$active" = "0" ] && [ "$stale" = "0" ]; then
+            sample_row "$elapsed" "$cycles"
+            cycle_log "FRR bgpd restart completed"
+            return 0
+        fi
+        sleep 1
+    done
+    log "ERROR: GR active/stale evidence did not clear"
+    return 1
 }
 
 write_run_json() {
@@ -193,33 +212,38 @@ cleanup() {
     exit "$exit_code"
 }
 
-trap cleanup EXIT INT TERM HUP
-
 sample_row() {
     local elapsed=${1:?}
     local cycles=${2:?}
     local prom rss intern_size gr_active established
-    prom=$(prom_scrape)
+    prom=$(prom_scrape) || prom=""
     rss=$(container_rss_mb)
     intern_size=$(prom_extract_sum "$prom" bgp_rib_attr_intern_global_size)
-    gr_active=$(prom_extract_or_zero "$prom" bgp_gr_active_peers)
+    gr_active=$(prom_extract_required "$prom" bgp_gr_active_peers)
+    local gr_stale
+    gr_stale=$(prom_extract_required "$prom" bgp_gr_stale_routes)
     if frr_established_seen; then
         established=1
     else
         established=0
     fi
-    printf '%s,%s,%s,%s,%s,%s,%s\n' \
+    printf '%s,%s,%s,%s,%s,%s,%s,%s\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
         "$elapsed" \
         "${rss:-nan}" \
         "$intern_size" \
         "$gr_active" \
+        "$gr_stale" \
         "$established" \
         "$cycles" \
         >>"$SAMPLES_CSV"
 }
 
 main() {
+    mkdir -p "$RUN_DIR"
+    exec > >(tee -a "$SOAK_LOG") 2>&1
+    acquire_rustbgpd_host_lock
+    trap cleanup EXIT INT TERM HUP
     require_tool docker
     require_tool curl
     require_tool awk
@@ -241,7 +265,7 @@ main() {
     log "Warmup: waiting ${WARMUP_SEC}s for initial convergence"
     sleep "$WARMUP_SEC"
 
-    echo "timestamp,elapsed_sec,rss_mb,intern_size,gr_active_peers,bgp_established,restart_cycles" >"$SAMPLES_CSV"
+    echo "timestamp,elapsed_sec,rss_mb,intern_size,gr_active_peers,gr_stale_routes,bgp_established,restart_cycles" >"$SAMPLES_CSV"
 
     local start_epoch end_epoch next_sample next_restart cycles
     start_epoch=$(date +%s)
@@ -255,11 +279,9 @@ main() {
     while [ "$(date +%s)" -lt "$end_epoch" ]; do
         now=$(date +%s)
         if [ "$now" -ge "$next_restart" ]; then
-            restart_frr_bgpd
+            restart_frr_bgpd "$((now - start_epoch))" "$cycles"
             cycles=$((cycles + 1))
             next_restart=$((now + RESTART_INTERVAL_SEC))
-            # Wait for re-establishment so the cycle is well-formed.
-            wait_established 60 || log "WARN: session did not re-establish after cycle $cycles"
         fi
         if [ "$now" -ge "$next_sample" ]; then
             local elapsed=$((now - start_epoch))
@@ -272,7 +294,9 @@ main() {
     local final_elapsed=$(( $(date +%s) - start_epoch ))
     sample_row "$final_elapsed" "$cycles"
     log "soak loop completed; $cycles restart cycles; final samples in $SAMPLES_CSV"
-    log "Run the analyzer: python3 tests/soak/analyze-soak-gr-restart.py $RUN_DIR"
+    python3 "$SOAK_SCRIPT_DIR/analyze-soak-gr-restart.py" "$RUN_DIR" --output "$RUN_DIR/verdict.json"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/tests/soak/run-soak-gr-restart-intern-gc.sh
+++ b/tests/soak/run-soak-gr-restart-intern-gc.sh
@@ -112,13 +112,6 @@ container_rss_mb() {
     ' 2>/dev/null || true
 }
 
-rb_gr_active() {
-    local prom
-    prom=$(prom_scrape)
-    [ -z "$prom" ] && { echo 0; return; }
-    prom_extract_or_zero "$prom" bgp_gr_active_peers
-}
-
 frr_established_seen() {
     docker exec "$FRR" vtysh -c "show bgp neighbors $RUSTBGPD_IP json" 2>/dev/null \
         | grep -q '"bgpState":"Established"'
@@ -169,6 +162,10 @@ restart_frr_bgpd() {
     done
     log "ERROR: GR active/stale evidence did not clear"
     return 1
+}
+
+run_analyzer() {
+    python3 "$SOAK_SCRIPT_DIR/analyze-soak-gr-restart.py" "$RUN_DIR" --output "$RUN_DIR/verdict.json"
 }
 
 write_run_json() {
@@ -294,7 +291,7 @@ main() {
     local final_elapsed=$(( $(date +%s) - start_epoch ))
     sample_row "$final_elapsed" "$cycles"
     log "soak loop completed; $cycles restart cycles; final samples in $SAMPLES_CSV"
-    python3 "$SOAK_SCRIPT_DIR/analyze-soak-gr-restart.py" "$RUN_DIR" --output "$RUN_DIR/verdict.json"
+    run_analyzer
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/tests/soak/run-soak-hot-reload.sh
+++ b/tests/soak/run-soak-hot-reload.sh
@@ -168,9 +168,14 @@ EOF
 
 # Plan a candidate config, extract the runtime_snapshot_token from JSON.
 plan_and_extract_token() {
-    docker exec "$RUSTBGPD" rbgp -s "$GRPC_ADDR" config plan \
-        --from-file /tmp/candidate.toml -j |
-        python3 -c 'import json,sys
+    local output status
+    set +e
+    output=$(docker exec "$RUSTBGPD" rbgp -s "$GRPC_ADDR" config plan \
+        --from-file /tmp/candidate.toml -j)
+    status=$?
+    set -e
+    case "$status" in 0|2) ;; *) return "$status";; esac
+    printf '%s' "$output" | python3 -c 'import json,sys
 d=json.load(sys.stdin)
 t=d.get("runtime_snapshot_token")
 if not isinstance(t, str) or not t: raise SystemExit(2)
@@ -254,7 +259,9 @@ sample_row() {
     prom=$(prom_scrape) || prom=""
     rss=$(container_rss_mb)
     intern_size=$(prom_extract_sum "$prom" bgp_rib_attr_intern_global_size)
-    read -r flap_count uptime_seconds < <(neighbor_state)
+    local neighbor
+    neighbor=$(neighbor_state)
+    read -r flap_count uptime_seconds <<<"$neighbor"
     if frr_established_seen; then
         established=1
     else

--- a/tests/soak/run-soak-hot-reload.sh
+++ b/tests/soak/run-soak-hot-reload.sh
@@ -168,13 +168,17 @@ EOF
 
 # Plan a candidate config, extract the runtime_snapshot_token from JSON.
 plan_and_extract_token() {
-    local token
-    token=$(docker exec "$RUSTBGPD" rbgp -s "$GRPC_ADDR" config plan \
-        --from-file /tmp/candidate.toml -j 2>/dev/null \
-        | grep -o '"runtime_snapshot_token":"[^"]*"' \
-        | head -1 \
-        | sed 's/"runtime_snapshot_token":"//;s/"//')
-    printf '%s' "$token"
+    docker exec "$RUSTBGPD" rbgp -s "$GRPC_ADDR" config plan \
+        --from-file /tmp/candidate.toml -j |
+        python3 -c 'import json,sys
+d=json.load(sys.stdin)
+t=d.get("runtime_snapshot_token")
+if not isinstance(t, str) or not t: raise SystemExit(2)
+print(t)'
+}
+
+run_analyzer() {
+    python3 "$SOAK_SCRIPT_DIR/analyze-soak-hot-reload.py" "$RUN_DIR" --output "$RUN_DIR/verdict.json"
 }
 
 run_apply_cycle() {
@@ -329,7 +333,7 @@ main() {
     local final_elapsed=$(( $(date +%s) - start_epoch ))
     sample_row "$final_elapsed" "$cycles" "$apply_ok" "$apply_fail"
     log "soak loop completed; $cycles apply cycles ($apply_ok ok, $apply_fail fail); final samples in $SAMPLES_CSV"
-    python3 "$SOAK_SCRIPT_DIR/analyze-soak-hot-reload.py" "$RUN_DIR" --output "$RUN_DIR/verdict.json"
+    run_analyzer
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/tests/soak/run-soak-hot-reload.sh
+++ b/tests/soak/run-soak-hot-reload.sh
@@ -25,7 +25,7 @@
 
 set -euo pipefail
 
-SOAK_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SOAK_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SOAK_SCRIPT_DIR/../.." && pwd)"
 TOPOLOGY="${TOPOLOGY:-$REPO_ROOT/tests/soak/soak-hot-reload.clab.yml}"
 
@@ -45,7 +45,6 @@ GRPC_ADDR="${GRPC_ADDR:-http://127.0.0.1:50051}"
 
 RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
 RUN_DIR="${RUN_DIR_OVERRIDE:-$SOAK_SCRIPT_DIR/runs/soak-hot-reload-$RUN_ID}"
-mkdir -p "$RUN_DIR"
 
 SAMPLES_CSV="$RUN_DIR/samples.csv"
 SOAK_LOG="$RUN_DIR/soak.log"
@@ -54,11 +53,8 @@ RUN_JSON="$RUN_DIR/run.json"
 RUSTBGPD_LOG="$RUN_DIR/rustbgpd.log"
 CANDIDATE_TOML="$RUN_DIR/candidate.toml"
 
-exec > >(tee -a "$SOAK_LOG") 2>&1
-
-# shellcheck source=./host-lock.sh
+# shellcheck source=tests/soak/host-lock.sh
 source "$SOAK_SCRIPT_DIR/host-lock.sh"
-acquire_rustbgpd_host_lock
 
 log() {
     printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
@@ -91,11 +87,11 @@ prom_scrape() {
     curl -sfm 5 "http://${ip}:9179/metrics" 2>/dev/null || true
 }
 
-prom_extract_or_zero() {
+prom_extract_required() {
     local text="$1" metric="$2"
     printf '%s' "$text" | awk -v m="$metric" '
         $0 ~ "^"m"( |\\{)" { print $NF; found=1; exit }
-        END { if (!found) { print "0" } }
+        END { if (!found) { print "nan" } }
     '
 }
 
@@ -103,8 +99,8 @@ prom_extract_or_zero() {
 prom_extract_sum() {
     local prom="$1" name="$2"
     awk -v n="$name" '
-        $0 ~ "^"n"[{ ]" { s += $NF }
-        END { printf "%d", s+0 }
+        $0 ~ "^"n"[{ ]" { s += $NF; found=1 }
+        END { if (!found) print "nan"; else printf "%d", s }
     ' <<<"$prom"
 }
 
@@ -124,6 +120,11 @@ frr_vtysh() {
 frr_established_seen() {
     frr_vtysh "show bgp neighbors $RUSTBGPD_IP json" \
         | grep -q '"bgpState":"Established"'
+}
+
+neighbor_state() {
+    docker exec "$RUSTBGPD" rbgp -s "$GRPC_ADDR" neighbor -j |
+        python3 -c 'import json,sys; n=json.load(sys.stdin)[0]; print(n["flap_count"], n["uptime_seconds"])'
 }
 
 wait_established() {
@@ -181,7 +182,7 @@ run_apply_cycle() {
     write_candidate_toml "$cycle"
     cycle_log "cycle $cycle: writing candidate TOML"
     # Copy candidate into the container (rbgp reads from_file locally).
-    docker cp "$CANDIDATE_TOML" "$RUSTBGPD:/tmp/candidate.toml" >/dev/null 2>&1
+    docker cp "$CANDIDATE_TOML" "$RUSTBGPD:/tmp/candidate.toml" >/dev/null
     local token
     token=$(plan_and_extract_token)
     if [ -z "$token" ]; then
@@ -240,23 +241,22 @@ cleanup() {
     exit "$exit_code"
 }
 
-trap cleanup EXIT INT TERM HUP
-
 sample_row() {
     local elapsed=${1:?}
     local cycles=${2:?}
     local apply_ok=${3:?}
     local apply_fail=${4:?}
-    local prom rss intern_size established
-    prom=$(prom_scrape)
+    local prom rss intern_size established flap_count uptime_seconds
+    prom=$(prom_scrape) || prom=""
     rss=$(container_rss_mb)
     intern_size=$(prom_extract_sum "$prom" bgp_rib_attr_intern_global_size)
+    read -r flap_count uptime_seconds < <(neighbor_state)
     if frr_established_seen; then
         established=1
     else
         established=0
     fi
-    printf '%s,%s,%s,%s,%s,%s,%s,%s\n' \
+    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
         "$elapsed" \
         "${rss:-nan}" \
@@ -265,13 +265,20 @@ sample_row() {
         "$cycles" \
         "$apply_ok" \
         "$apply_fail" \
+        "$flap_count" \
+        "$uptime_seconds" \
         >>"$SAMPLES_CSV"
 }
 
 main() {
+    mkdir -p "$RUN_DIR"
+    exec > >(tee -a "$SOAK_LOG") 2>&1
+    acquire_rustbgpd_host_lock
+    trap cleanup EXIT INT TERM HUP
     require_tool docker
     require_tool curl
     require_tool awk
+    require_tool python3
     require_container "$RUSTBGPD"
     require_container "$FRR"
 
@@ -290,7 +297,7 @@ main() {
     log "Warmup: waiting ${WARMUP_SEC}s"
     sleep "$WARMUP_SEC"
 
-    echo "timestamp,elapsed_sec,rss_mb,intern_size,bgp_established,apply_cycles,apply_ok,apply_fail" >"$SAMPLES_CSV"
+    echo "timestamp,elapsed_sec,rss_mb,intern_size,bgp_established,apply_cycles,apply_ok,apply_fail,flap_count,uptime_seconds" >"$SAMPLES_CSV"
 
     local start_epoch end_epoch next_sample next_apply cycles apply_ok apply_fail
     start_epoch=$(date +%s)
@@ -307,11 +314,8 @@ main() {
         now=$(date +%s)
         if [ "$now" -ge "$next_apply" ]; then
             cycles=$((cycles + 1))
-            if run_apply_cycle "$cycles"; then
-                apply_ok=$((apply_ok + 1))
-            else
-                apply_fail=$((apply_fail + 1))
-            fi
+            run_apply_cycle "$cycles"
+            apply_ok=$((apply_ok + 1))
             next_apply=$((now + APPLY_INTERVAL_SEC))
         fi
         if [ "$now" -ge "$next_sample" ]; then
@@ -325,7 +329,9 @@ main() {
     local final_elapsed=$(( $(date +%s) - start_epoch ))
     sample_row "$final_elapsed" "$cycles" "$apply_ok" "$apply_fail"
     log "soak loop completed; $cycles apply cycles ($apply_ok ok, $apply_fail fail); final samples in $SAMPLES_CSV"
-    log "Run the analyzer: python3 tests/soak/analyze-soak-hot-reload.py $RUN_DIR"
+    python3 "$SOAK_SCRIPT_DIR/analyze-soak-hot-reload.py" "$RUN_DIR" --output "$RUN_DIR/verdict.json"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/tests/soak/run-soak-inject-churn.sh
+++ b/tests/soak/run-soak-inject-churn.sh
@@ -156,14 +156,6 @@ prom_extract_sum() {
     ' <<<"$prom"
 }
 
-prom_sum() {
-    local text="$1" metric="$2"
-    printf '%s' "$text" | awk -v m="$metric" '
-        $0 ~ "^"m"( |\\{)" { sum += $NF }
-        END { if (sum == "") { print "0" } else { print sum } }
-    '
-}
-
 container_rss_mb() {
     docker exec "$RUSTBGPD" sh -c '
         pid=$(pidof rustbgpd 2>/dev/null || true)
@@ -304,7 +296,9 @@ sample_row() {
         established=0
     fi
     intern_size=$(prom_extract_sum "$prom" bgp_rib_attr_intern_global_size)
-    read -r flap_count uptime_seconds < <(neighbor_state)
+    local neighbor
+    neighbor=$(neighbor_state)
+    read -r flap_count uptime_seconds <<<"$neighbor"
     printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
         "$elapsed" \

--- a/tests/soak/run-soak-inject-churn.sh
+++ b/tests/soak/run-soak-inject-churn.sh
@@ -25,7 +25,7 @@
 
 set -euo pipefail
 
-SOAK_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SOAK_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SOAK_SCRIPT_DIR/../.." && pwd)"
 TOPOLOGY="${TOPOLOGY:-$REPO_ROOT/tests/soak/soak-inject-churn.clab.yml}"
 
@@ -49,7 +49,6 @@ NEXTHOP="${NEXTHOP:-10.0.0.1}"
 
 RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
 RUN_DIR="${RUN_DIR_OVERRIDE:-$SOAK_SCRIPT_DIR/runs/soak-inject-churn-$RUN_ID}"
-mkdir -p "$RUN_DIR"
 
 SAMPLES_CSV="$RUN_DIR/samples.csv"
 SOAK_LOG="$RUN_DIR/soak.log"
@@ -58,11 +57,8 @@ RUN_JSON="$RUN_DIR/run.json"
 RUSTBGPD_LOG="$RUN_DIR/rustbgpd.log"
 LIVE_SET_FILE="$RUN_DIR/live-prefix-indexes.txt"
 
-exec > >(tee -a "$SOAK_LOG") 2>&1
-
-# shellcheck source=./host-lock.sh
+# shellcheck source=tests/soak/host-lock.sh
 source "$SOAK_SCRIPT_DIR/host-lock.sh"
-acquire_rustbgpd_host_lock
 
 log() {
     printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
@@ -103,17 +99,17 @@ wrap_index() {
 rb_inject_add() {
     local prefix=${1:?}
     docker exec "$RUSTBGPD" rbgp -s "$GRPC_ADDR" rib add "$prefix" \
-        --nexthop "$NEXTHOP" >/dev/null 2>&1 || true
+        --nexthop "$NEXTHOP" >/dev/null
 }
 
 rb_inject_del() {
     local prefix=${1:?}
     docker exec "$RUSTBGPD" rbgp -s "$GRPC_ADDR" rib delete "$prefix" \
-        >/dev/null 2>&1 || true
+        >/dev/null
 }
 
 frr_vtysh() {
-    docker exec "$FRR" vtysh -c "$1" 2>/dev/null || true
+    docker exec "$FRR" vtysh -c "$1"
 }
 
 frr_established_seen() {
@@ -143,11 +139,11 @@ prom_scrape() {
     curl -sfm 5 "http://${ip}:9179/metrics" 2>/dev/null || true
 }
 
-prom_extract_or_zero() {
+prom_extract_required() {
     local text="$1" metric="$2"
     printf '%s' "$text" | awk -v m="$metric" '
         $0 ~ "^"m"( |\\{)" { print $NF; found=1; exit }
-        END { if (!found) { print "0" } }
+        END { if (!found) { print "nan" } }
     '
 }
 
@@ -155,8 +151,8 @@ prom_extract_or_zero() {
 prom_extract_sum() {
     local prom="$1" name="$2"
     awk -v n="$name" '
-        $0 ~ "^"n"[{ ]" { s += $NF }
-        END { printf "%d", s+0 }
+        $0 ~ "^"n"[{ ]" { s += $NF; found=1 }
+        END { if (!found) print "nan"; else printf "%d", s }
     ' <<<"$prom"
 }
 
@@ -179,7 +175,23 @@ container_rss_mb() {
 
 frr_route_count() {
     frr_vtysh "show bgp ipv4 unicast" \
-        | grep -c '10\.' || true
+        | awk '/10\\./ {count++} END {print count+0}'
+}
+
+neighbor_state() {
+    docker exec "$RUSTBGPD" rbgp -s "$GRPC_ADDR" neighbor -j |
+        python3 -c 'import json,sys; n=json.load(sys.stdin)[0]; print(n["flap_count"], n["uptime_seconds"])'
+}
+
+wait_final_routes() {
+    local count
+    for _ in $(seq 1 30); do
+        count=$(frr_route_count)
+        [ "$count" -eq "$LIVE_TARGET_PREFIXES" ] && return 0
+        sleep 1
+    done
+    log "ERROR: FRR route count ${count:-unknown}, expected $LIVE_TARGET_PREFIXES"
+    return 1
 }
 
 write_run_json() {
@@ -239,8 +251,6 @@ cleanup() {
     exit "$exit_code"
 }
 
-trap cleanup EXIT INT TERM HUP
-
 validate_config() {
     if [ "$PREFIX_POOL_SIZE" -le "$LIVE_TARGET_PREFIXES" ]; then
         log "ERROR: PREFIX_POOL_SIZE must be greater than LIVE_TARGET_PREFIXES"
@@ -266,8 +276,8 @@ prefill_live_set() {
     log "Prefilling $LIVE_TARGET_PREFIXES injected prefixes"
     local idx
     for idx in $(seq 1 "$LIVE_TARGET_PREFIXES"); do
-        printf '%s\n' "$idx" >>"$LIVE_SET_FILE"
         rb_inject_add "$(format_prefix "$idx")"
+        printf '%s\n' "$idx" >>"$LIVE_SET_FILE"
     done
 }
 
@@ -276,8 +286,8 @@ sample_row() {
     local cycles=${2:?}
     local add_total=${3:?}
     local del_total=${4:?}
-    local prom rss frr_count established intern_size
-    prom=$(prom_scrape)
+    local prom rss frr_count established intern_size flap_count uptime_seconds
+    prom=$(prom_scrape) || prom=""
     rss=$(container_rss_mb)
     frr_count=$(frr_route_count)
     if frr_established_seen; then
@@ -286,7 +296,8 @@ sample_row() {
         established=0
     fi
     intern_size=$(prom_extract_sum "$prom" bgp_rib_attr_intern_global_size)
-    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+    read -r flap_count uptime_seconds < <(neighbor_state)
+    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
         "$elapsed" \
         "${rss:-nan}" \
@@ -297,6 +308,8 @@ sample_row() {
         "$cycles" \
         "$add_total" \
         "$del_total" \
+        "$flap_count" \
+        "$uptime_seconds" \
         >>"$SAMPLES_CSV"
 }
 
@@ -317,8 +330,8 @@ run_churn_cycle() {
 
     for i in $(seq 1 "$CHURN_BATCH"); do
         prefix=$(format_prefix "$add_idx")
-        printf '%s\n' "$add_idx" >>"$LIVE_SET_FILE"
         rb_inject_add "$prefix"
+        printf '%s\n' "$add_idx" >>"$LIVE_SET_FILE"
         churn_log "add $prefix"
         add_idx=$(wrap_index $((add_idx + 1)))
     done
@@ -328,9 +341,14 @@ run_churn_cycle() {
 }
 
 main() {
+    mkdir -p "$RUN_DIR"
+    exec > >(tee -a "$SOAK_LOG") 2>&1
+    acquire_rustbgpd_host_lock
+    trap cleanup EXIT INT TERM HUP
     require_tool docker
     require_tool curl
     require_tool awk
+    require_tool python3
     require_container "$RUSTBGPD"
     require_container "$FRR"
     validate_config
@@ -348,7 +366,7 @@ main() {
     wait_established
     prefill_live_set
 
-    echo "timestamp,elapsed_sec,rss_mb,intern_size,live_target,frr_route_count,bgp_established,churn_cycles,add_total,del_total" >"$SAMPLES_CSV"
+    echo "timestamp,elapsed_sec,rss_mb,intern_size,live_target,frr_route_count,bgp_established,churn_cycles,add_total,del_total,flap_count,uptime_seconds" >"$SAMPLES_CSV"
 
     local start_epoch end_epoch next_sample next_churn cycles add_total del_total
     local del_idx_file add_idx_file now
@@ -384,9 +402,12 @@ main() {
     done
 
     local final_elapsed=$(( $(date +%s) - start_epoch ))
+    wait_final_routes
     sample_row "$final_elapsed" "$cycles" "$add_total" "$del_total"
     log "soak loop completed; $cycles churn cycles; final samples in $SAMPLES_CSV"
-    log "Run the analyzer: python3 tests/soak/analyze-soak-inject-churn.py $RUN_DIR"
+    python3 "$SOAK_SCRIPT_DIR/analyze-soak-inject-churn.py" "$RUN_DIR" --output "$RUN_DIR/verdict.json"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/tests/soak/run-soak-inject-churn.sh
+++ b/tests/soak/run-soak-inject-churn.sh
@@ -174,8 +174,16 @@ container_rss_mb() {
 }
 
 frr_route_count() {
-    frr_vtysh "show bgp ipv4 unicast" \
-        | awk '/10\\./ {count++} END {print count+0}'
+    frr_vtysh "show bgp ipv4 unicast json" |
+        python3 -c 'import json,sys
+d=json.load(sys.stdin)
+r=d.get("routes")
+if not isinstance(r, dict): raise SystemExit(2)
+print(len(r))'
+}
+
+run_analyzer() {
+    python3 "$SOAK_SCRIPT_DIR/analyze-soak-inject-churn.py" "$RUN_DIR" --output "$RUN_DIR/verdict.json"
 }
 
 neighbor_state() {
@@ -405,7 +413,7 @@ main() {
     wait_final_routes
     sample_row "$final_elapsed" "$cycles" "$add_total" "$del_total"
     log "soak loop completed; $cycles churn cycles; final samples in $SAMPLES_CSV"
-    python3 "$SOAK_SCRIPT_DIR/analyze-soak-inject-churn.py" "$RUN_DIR" --output "$RUN_DIR/verdict.json"
+    run_analyzer
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/tests/soak/test_intern_churn_analyzers.py
+++ b/tests/soak/test_intern_churn_analyzers.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Cheap fail-closed contracts for the intern/churn soak evidence."""
+
+import csv
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+HERE = Path(__file__).parent
+
+
+def run_analyzer(name, fields, rows):
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "samples.csv"
+        with path.open("w", newline="") as stream:
+            writer = csv.DictWriter(stream, fieldnames=fields)
+            writer.writeheader()
+            writer.writerows(rows)
+        return subprocess.run(
+            ["python3", str(HERE / name), tmp],
+            text=True, capture_output=True, check=False,
+        )
+
+
+BASE = {
+    "timestamp": "2026-01-01T00:00:00Z",
+    "rss_mb": "10", "intern_size": "5", "bgp_established": "1",
+}
+
+
+class AnalyzerContracts(unittest.TestCase):
+    def test_gr_requires_ordered_positive_phase_and_clear(self):
+        fields = [*BASE, "elapsed_sec", "gr_active_peers", "gr_stale_routes",
+                  "restart_cycles"]
+        rows = [
+            {**BASE, "elapsed_sec": "0", "gr_active_peers": "0",
+             "gr_stale_routes": "0", "restart_cycles": "0"},
+            {**BASE, "elapsed_sec": "3600", "gr_active_peers": "1",
+             "gr_stale_routes": "2", "restart_cycles": "0"},
+            {**BASE, "elapsed_sec": "7200", "gr_active_peers": "0",
+             "gr_stale_routes": "0", "restart_cycles": "1"},
+        ]
+        result = run_analyzer("analyze-soak-gr-restart.py", fields, rows)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        rows[1]["gr_active_peers"] = rows[1]["gr_stale_routes"] = "0"
+        result = run_analyzer("analyze-soak-gr-restart.py", fields, rows)
+        self.assertEqual(result.returncode, 1)
+
+    def test_hot_reload_requires_exact_success_and_continuity(self):
+        fields = [*BASE, "elapsed_sec", "apply_cycles", "apply_ok", "apply_fail",
+                  "flap_count", "uptime_seconds"]
+        rows = [
+            {**BASE, "elapsed_sec": "0", "apply_cycles": "0", "apply_ok": "0",
+             "apply_fail": "0", "flap_count": "3", "uptime_seconds": "10"},
+            {**BASE, "elapsed_sec": "3600", "apply_cycles": "1", "apply_ok": "1",
+             "apply_fail": "0", "flap_count": "3", "uptime_seconds": "3610"},
+        ]
+        result = run_analyzer("analyze-soak-hot-reload.py", fields, rows)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        rows[-1]["apply_cycles"], rows[-1]["apply_fail"] = "2", "1"
+        self.assertEqual(
+            run_analyzer("analyze-soak-hot-reload.py", fields, rows).returncode, 1
+        )
+        rows[-1]["apply_cycles"], rows[-1]["apply_fail"] = "1", "0"
+        rows[-1]["flap_count"] = "4"
+        self.assertEqual(
+            run_analyzer("analyze-soak-hot-reload.py", fields, rows).returncode, 1
+        )
+
+    def test_injection_requires_exact_final_consumer_and_continuity(self):
+        fields = [*BASE, "elapsed_sec", "live_target", "frr_route_count",
+                  "churn_cycles", "add_total", "del_total", "flap_count",
+                  "uptime_seconds"]
+        rows = [
+            {**BASE, "elapsed_sec": "0", "live_target": "1024",
+             "frr_route_count": "0", "churn_cycles": "0", "add_total": "1024",
+             "del_total": "0", "flap_count": "0", "uptime_seconds": "10"},
+            {**BASE, "elapsed_sec": "3600", "live_target": "1024",
+             "frr_route_count": "1024", "churn_cycles": "1", "add_total": "1049",
+             "del_total": "25", "flap_count": "0", "uptime_seconds": "3610"},
+        ]
+        result = run_analyzer("analyze-soak-inject-churn.py", fields, rows)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        rows[-1]["frr_route_count"] = "0"
+        self.assertEqual(
+            run_analyzer("analyze-soak-inject-churn.py", fields, rows).returncode, 1
+        )
+        rows[-1]["frr_route_count"], rows[-1]["flap_count"] = "1024", "1"
+        self.assertEqual(
+            run_analyzer("analyze-soak-inject-churn.py", fields, rows).returncode, 1
+        )
+
+    def test_missing_or_malformed_required_evidence_is_input_error(self):
+        cases = [
+            ("analyze-soak-gr-restart.py", "gr_stale_routes",
+             ["elapsed_sec", "rss_mb", "intern_size", "gr_active_peers",
+              "gr_stale_routes", "bgp_established", "restart_cycles"]),
+            ("analyze-soak-hot-reload.py", "flap_count",
+             ["elapsed_sec", "rss_mb", "intern_size", "bgp_established",
+              "apply_cycles", "apply_ok", "apply_fail", "flap_count",
+              "uptime_seconds"]),
+            ("analyze-soak-inject-churn.py", "frr_route_count",
+             ["elapsed_sec", "rss_mb", "intern_size", "live_target",
+              "frr_route_count", "bgp_established", "churn_cycles",
+              "add_total", "del_total", "flap_count", "uptime_seconds"]),
+        ]
+        for analyzer, required, fields in cases:
+            with self.subTest(analyzer=analyzer):
+                row = {field: "0" for field in fields}
+                present = [field for field in fields if field != required]
+                result = run_analyzer(
+                    analyzer, present, [{field: row[field] for field in present}]
+                )
+                self.assertEqual(result.returncode, 2)
+                row[required] = "not-a-number"
+                result = run_analyzer(analyzer, fields, [row])
+                self.assertEqual(result.returncode, 2)
+
+    def test_injection_commands_propagate_failure(self):
+        script = HERE / "run-soak-inject-churn.sh"
+        command = f"""
+source {script!s}
+docker() {{ return 17; }}
+rb_inject_add 10.0.0.0/24
+"""
+        result = subprocess.run(
+            ["bash", "-c", command], text=True, capture_output=True, check=False
+        )
+        self.assertEqual(result.returncode, 17)
+
+    def test_runners_are_sourceable_and_end_with_analyzer_gate(self):
+        for script in (
+            "run-soak-gr-restart-intern-gc.sh",
+            "run-soak-hot-reload.sh",
+            "run-soak-inject-churn.sh",
+        ):
+            with self.subTest(script=script):
+                path = HERE / script
+                result = subprocess.run(
+                    ["bash", "-c", f"source {path!s}"],
+                    text=True, capture_output=True, check=False,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                text = path.read_text()
+                self.assertRegex(text, r'python3 .*analyze-soak-.* --output ')
+                self.assertIn('BASH_SOURCE[0]', text)
+
+    def test_runner_commands_are_load_bearing(self):
+        inject = (HERE / "run-soak-inject-churn.sh").read_text()
+        self.assertNotRegex(
+            inject, r'rbgp .* rib (?:add|delete).*?(?:\|\| true)',
+        )
+        self.assertIn('count=$(frr_route_count)', inject)
+        hot = (HERE / "run-soak-hot-reload.sh").read_text()
+        self.assertIn(
+            'docker cp "$CANDIDATE_TOML" "$RUSTBGPD:/tmp/candidate.toml"',
+            hot,
+        )
+        self.assertIn('run_apply_cycle "$cycles"', hot)
+        gr = (HERE / "run-soak-gr-restart-intern-gc.sh").read_text()
+        self.assertIn('frrinit.sh stop >/dev/null', gr)
+        self.assertIn('frrinit.sh start >/dev/null', gr)
+        self.assertNotIn('frrinit.sh stop >/dev/null 2>&1 || true', gr)
+        self.assertNotIn('frrinit.sh start >/dev/null 2>&1 || true', gr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/soak/test_intern_churn_analyzers.py
+++ b/tests/soak/test_intern_churn_analyzers.py
@@ -136,22 +136,23 @@ class AnalyzerContracts(unittest.TestCase):
 
     def test_gr_runner_requires_complete_ordered_restart(self):
         body = r'''
-state=$(mktemp); echo 0 >"$state"
-docker() { echo "$*" >&2; }
-sleep() { :; }; wait_established() { echo established >&2; }
+state=$(mktemp); events=$(mktemp); echo 0 >"$state"
+docker() { case "$*" in *" stop") echo stop;; *" start") echo start;; esac >>"$events"; }
+sleep() { :; }; wait_established() { echo established >>"$events"; }
 cycle_log() { :; }
 prom_scrape() { n=$(cat "$state"); echo $((n+1)) >"$state"; if [ "$n" = 0 ]; then
+ echo positive >>"$events"
  echo "bgp_gr_active_peers 1"; echo "bgp_gr_stale_routes 2"
-else echo "bgp_gr_active_peers 0"; echo "bgp_gr_stale_routes 0"; fi; }
-sample_row() { echo "sample:$2"; }
-restart_frr_bgpd 7 0
+else echo clear >>"$events"; echo "bgp_gr_active_peers 0"; echo "bgp_gr_stale_routes 0"; fi; }
+sample_row() { echo "sample:$2" >>"$events"; }
+restart_frr_bgpd 7 0; cat "$events"
 '''
         result = self.bash("run-soak-gr-restart-intern-gc.sh", body)
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.splitlines(), ["sample:0", "sample:0"])
-        self.assertIn(" stop", result.stderr)
-        self.assertIn(" start", result.stderr)
-        self.assertIn("established", result.stderr)
+        self.assertEqual(result.stdout.splitlines(), [
+            "stop", "positive", "sample:0", "start", "established",
+            "clear", "sample:0",
+        ])
 
     def test_hot_runner_cp_plan_and_apply_fail_closed(self):
         body = r'''
@@ -161,6 +162,7 @@ docker() {
  cp:cp*) return 11;;
  malformed:*config\ plan*) echo '{bad';;
  missing:*config\ plan*) echo '{}';;
+ exit2:*config\ plan*) printf '{\n "runtime_snapshot_token": "token"\n}\n'; return 2;;
  apply:*config\ plan*) printf '{\n "runtime_snapshot_token": "token"\n}\n';;
  apply:*config\ apply*) return 13;;
  good:*config\ plan*) printf '{\n "runtime_snapshot_token": "token"\n}\n';;
@@ -168,7 +170,7 @@ docker() {
 }
 run_apply_cycle 1
 '''
-        for mode, code in (("cp", 11), ("malformed", 1), ("missing", 2),
+        for mode, code in (("cp", 11), ("malformed", 1), ("missing", 2), ("exit2", 0),
                            ("apply", 1), ("good", 0)):
             with self.subTest(mode=mode):
                 result = self.bash("run-soak-hot-reload.sh", f"MODE={mode}\n{body}")
@@ -205,6 +207,14 @@ run_churn_cycle "$d" "$a"
             )
             self.assertEqual(result.returncode, 23)
 
+    def test_neighbor_state_failure_after_output_propagates(self):
+        body = r'''SAMPLES_CSV=/dev/null; LIVE_TARGET_PREFIXES=1
+prom_scrape() { echo metric; }; container_rss_mb() { echo 1; }
+prom_extract_sum() { echo 1; }; frr_route_count() { echo 1; }
+frr_established_seen() { return 0; }; neighbor_state() { echo "0 10"; return 19; }
+sample_row 0 0 0 0'''
+        for script in ("hot-reload", "inject-churn"):
+            self.assertEqual(self.bash(f"run-soak-{script}.sh", body).returncode, 19)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/soak/test_intern_churn_analyzers.py
+++ b/tests/soak/test_intern_churn_analyzers.py
@@ -60,14 +60,21 @@ class AnalyzerContracts(unittest.TestCase):
         result = run_analyzer("analyze-soak-hot-reload.py", fields, rows)
         self.assertEqual(result.returncode, 0, result.stderr)
         rows[-1]["apply_cycles"], rows[-1]["apply_fail"] = "2", "1"
-        self.assertEqual(
-            run_analyzer("analyze-soak-hot-reload.py", fields, rows).returncode, 1
-        )
+        result = run_analyzer("analyze-soak-hot-reload.py", fields, rows)
+        self.assertFalse(json.loads(result.stdout)["gates"]["apply_failures"]["pass"])
+        self.assertTrue(json.loads(result.stdout)["gates"]["apply_cycles"]["pass"])
         rows[-1]["apply_cycles"], rows[-1]["apply_fail"] = "1", "0"
         rows[-1]["flap_count"] = "4"
         self.assertEqual(
             run_analyzer("analyze-soak-hot-reload.py", fields, rows).returncode, 1
         )
+        rows[-1]["flap_count"], rows[-1]["apply_cycles"] = "3", "2"
+        result = run_analyzer("analyze-soak-hot-reload.py", fields, rows)
+        self.assertFalse(json.loads(result.stdout)["gates"]["apply_cycles"]["pass"])
+        self.assertTrue(json.loads(result.stdout)["gates"]["apply_failures"]["pass"])
+        rows[-1]["apply_cycles"] = rows[-1]["apply_ok"] = "0"
+        result = run_analyzer("analyze-soak-hot-reload.py", fields, rows)
+        self.assertFalse(json.loads(result.stdout)["gates"]["apply_failures"]["pass"])
 
     def test_injection_requires_exact_final_consumer_and_continuity(self):
         fields = [*BASE, "elapsed_sec", "live_target", "frr_route_count",
@@ -117,53 +124,86 @@ class AnalyzerContracts(unittest.TestCase):
                 row[required] = "not-a-number"
                 result = run_analyzer(analyzer, fields, [row])
                 self.assertEqual(result.returncode, 2)
+                for invalid in ("-1", "1.5"):
+                    row[required] = invalid
+                    self.assertEqual(run_analyzer(analyzer, fields, [row]).returncode, 2)
 
-    def test_injection_commands_propagate_failure(self):
-        script = HERE / "run-soak-inject-churn.sh"
-        command = f"""
-source {script!s}
-docker() {{ return 17; }}
-rb_inject_add 10.0.0.0/24
-"""
-        result = subprocess.run(
-            ["bash", "-c", command], text=True, capture_output=True, check=False
+    def bash(self, script, body):
+        return subprocess.run(
+            ["bash", "-c", f"source {HERE / script}\n{body}"],
+            text=True, capture_output=True, check=False,
         )
+
+    def test_gr_runner_requires_complete_ordered_restart(self):
+        body = r'''
+state=$(mktemp); echo 0 >"$state"
+docker() { echo "$*" >&2; }
+sleep() { :; }; wait_established() { echo established >&2; }
+cycle_log() { :; }
+prom_scrape() { n=$(cat "$state"); echo $((n+1)) >"$state"; if [ "$n" = 0 ]; then
+ echo "bgp_gr_active_peers 1"; echo "bgp_gr_stale_routes 2"
+else echo "bgp_gr_active_peers 0"; echo "bgp_gr_stale_routes 0"; fi; }
+sample_row() { echo "sample:$2"; }
+restart_frr_bgpd 7 0
+'''
+        result = self.bash("run-soak-gr-restart-intern-gc.sh", body)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.splitlines(), ["sample:0", "sample:0"])
+        self.assertIn(" stop", result.stderr)
+        self.assertIn(" start", result.stderr)
+        self.assertIn("established", result.stderr)
+
+    def test_hot_runner_cp_plan_and_apply_fail_closed(self):
+        body = r'''
+CANDIDATE_TOML=/tmp/candidate; cycle_log() { :; }; write_candidate_toml() { :; }
+docker() {
+ case "$MODE:$*" in
+ cp:cp*) return 11;;
+ malformed:*config\ plan*) echo '{bad';;
+ missing:*config\ plan*) echo '{}';;
+ apply:*config\ plan*) printf '{\n "runtime_snapshot_token": "token"\n}\n';;
+ apply:*config\ apply*) return 13;;
+ good:*config\ plan*) printf '{\n "runtime_snapshot_token": "token"\n}\n';;
+ esac
+}
+run_apply_cycle 1
+'''
+        for mode, code in (("cp", 11), ("malformed", 1), ("missing", 2),
+                           ("apply", 1), ("good", 0)):
+            with self.subTest(mode=mode):
+                result = self.bash("run-soak-hot-reload.sh", f"MODE={mode}\n{body}")
+                self.assertEqual(result.returncode, code, result.stderr)
+
+    def test_injection_mutates_counts_only_after_commands_succeed(self):
+        body = r'''
+CHURN_BATCH=1; LIVE_SET_FILE=$(mktemp); echo 1 >"$LIVE_SET_FILE"
+d=$(mktemp); a=$(mktemp); echo 1 >"$d"; echo 2 >"$a"
+rb_inject_del() { [ "$MODE" != del ]; }
+rb_inject_add() { [ "$MODE" != add ]; }
+churn_log() { :; }
+trap 'tr -d "\n" <"$LIVE_SET_FILE"' EXIT
+run_churn_cycle "$d" "$a"
+'''
+        for mode, expected in (("del", "1"), ("add", "")):
+            result = self.bash("run-soak-inject-churn.sh", f"MODE={mode}\n{body}")
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, expected)
+        result = self.bash("run-soak-inject-churn.sh", "docker() { return 17; }\nrb_inject_add x")
         self.assertEqual(result.returncode, 17)
+        result = self.bash("run-soak-inject-churn.sh", "docker() { return 18; }\nrb_inject_del x")
+        self.assertEqual(result.returncode, 18)
 
-    def test_runners_are_sourceable_and_end_with_analyzer_gate(self):
-        for script in (
-            "run-soak-gr-restart-intern-gc.sh",
-            "run-soak-hot-reload.sh",
+    def test_frr_query_and_final_analyzer_failures_propagate(self):
+        result = self.bash(
             "run-soak-inject-churn.sh",
-        ):
-            with self.subTest(script=script):
-                path = HERE / script
-                result = subprocess.run(
-                    ["bash", "-c", f"source {path!s}"],
-                    text=True, capture_output=True, check=False,
-                )
-                self.assertEqual(result.returncode, 0, result.stderr)
-                text = path.read_text()
-                self.assertRegex(text, r'python3 .*analyze-soak-.* --output ')
-                self.assertIn('BASH_SOURCE[0]', text)
-
-    def test_runner_commands_are_load_bearing(self):
-        inject = (HERE / "run-soak-inject-churn.sh").read_text()
-        self.assertNotRegex(
-            inject, r'rbgp .* rib (?:add|delete).*?(?:\|\| true)',
+            "frr_vtysh() { return 19; }\nfrr_route_count",
         )
-        self.assertIn('count=$(frr_route_count)', inject)
-        hot = (HERE / "run-soak-hot-reload.sh").read_text()
-        self.assertIn(
-            'docker cp "$CANDIDATE_TOML" "$RUSTBGPD:/tmp/candidate.toml"',
-            hot,
-        )
-        self.assertIn('run_apply_cycle "$cycles"', hot)
-        gr = (HERE / "run-soak-gr-restart-intern-gc.sh").read_text()
-        self.assertIn('frrinit.sh stop >/dev/null', gr)
-        self.assertIn('frrinit.sh start >/dev/null', gr)
-        self.assertNotIn('frrinit.sh stop >/dev/null 2>&1 || true', gr)
-        self.assertNotIn('frrinit.sh start >/dev/null 2>&1 || true', gr)
+        self.assertNotEqual(result.returncode, 0)
+        for script in ("gr-restart-intern-gc", "hot-reload", "inject-churn"):
+            result = self.bash(
+                f"run-soak-{script}.sh", "python3() { return 23; }\nrun_analyzer"
+            )
+            self.assertEqual(result.returncode, 23)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- make GR, transactional reload, and injection-churn soak runners fail closed on missing evidence and command failures
- require ordered GR restart evidence, exact apply accounting, session continuity, and final consumer convergence
- validate analyzer schemas/counters and run deterministic behavioral contracts in per-commit CI

## Verification

- `python3 -m unittest -v tests/soak/test_intern_churn_analyzers.py` (9 tests)
- `bash -n` and `shellcheck -x` for all three runners
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- push-hook rustdoc gate

## Load-bearing proof

Isolated mutations make the deterministic suite red when the GR sequence is reordered or bypassed, a committable plan exit status is rejected, reload/injection failures are swallowed, neighbor-state producer errors are masked, apply accounting is weakened, final consumer convergence is removed, or analyzer failures are ignored.

No long soak or performance claim is included.