### PR TITLE
Detect slow-peer runtime edits in neighbor reload reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Editing `slow_peer_threshold_pct`, `slow_peer_duration`, or
+  `slow_peer_isolation` on a static `[[neighbors]]` entry was silently ignored
+  by SIGHUP reload: the change took effect only at the next natural session
+  re-establishment and never appeared in `rustbgpd --diff`. The reconciler now
+  detects the edit, reports it as a session reset in `--diff`, and rebuilds the
+  session immediately so the new value applies right away. Peer-group slow_peer
+  edits keep their existing behavior (members are session-reshaped via the
+  conservative fallback).
+
 - CLI policy formatting, config diff/plan, doctor, and neighbor list — plus
   the daemon's offline commands and rs-config-render — now fail when their
   buffered stdout cannot be flushed instead of reporting a successful status.

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -107,9 +107,9 @@ reload).
 | `hold_time` | live (effective next session) | Negotiated in OPEN. On SIGHUP the reconciler rebuilds the session immediately, so the new value is negotiated right away. |
 | `min_hold_time` | live (effective next session) | Validates the peer's next OPEN proposal. On SIGHUP the reconciler rebuilds the session immediately; existing sessions are not re-evaluated in place. |
 | `send_hold_time` | live (effective next session) | RFC 9687 send hold timer. The per-peer writer task captures the value when its TCP connection is established, so a new value (including 0 = disable) guards the next session; the existing session keeps the old timer. |
-| `slow_peer_threshold_pct` | live (effective next session) | Slow-peer detection backlog threshold (LAN-470), percent of the outbound writer buffer. Captured into the session's transport config; the reconciler rebuilds the session on change. |
-| `slow_peer_duration` | live (effective next session) | Seconds the backlog must persist before the slow-peer flag raises; 0 disables detection. Same capture semantics as the threshold. |
-| `slow_peer_isolation` | live (effective next session) | Move a flagged-slow peer to the per-peer update path. Same capture semantics as the threshold. |
+| `slow_peer_threshold_pct` | live (session reset) | Slow-peer detection backlog threshold, percent of the outbound writer buffer. Captured into the session's transport config; on SIGHUP the reconciler rebuilds the session immediately, so the new value applies right away. Annotated "session reset: session re-establish" by `rustbgpd --diff`. |
+| `slow_peer_duration` | live (session reset) | Seconds the backlog must persist before the slow-peer flag raises; 0 disables detection. Same capture and session-rebuild semantics as the threshold. |
+| `slow_peer_isolation` | live (session reset) | Move a flagged-slow peer to the per-peer update path. Same capture and session-rebuild semantics as the threshold. |
 | `max_prefixes` | live | Threshold re-evaluated on every received UPDATE. |
 | `max_prefixes_ipv4` | live | Per-family IPv4-unicast inbound cap (ADR-0108), enforced independently of the aggregate `max_prefixes`. Hot-applied in place; the new threshold governs the next received UPDATE. |
 | `max_prefixes_ipv6` | live | IPv6-unicast sibling of `max_prefixes_ipv4` (ADR-0108). |
@@ -160,9 +160,9 @@ configure their keyring directly.
 | `hold_time` | live (effective next session) | Same as neighbor. |
 | `min_hold_time` | live (effective next session) | Same as neighbor; static and dynamic group members are session-reshaped. |
 | `send_hold_time` | live (effective next session) | Same as neighbor. |
-| `slow_peer_threshold_pct` | live (effective next session) | Same as neighbor. |
-| `slow_peer_duration` | live (effective next session) | Same as neighbor. |
-| `slow_peer_isolation` | live (effective next session) | Same as neighbor. |
+| `slow_peer_threshold_pct` | live (session reset) | Same as neighbor; a group slow_peer edit is never all-hot, so static members are session-reshaped via the conservative fallback. |
+| `slow_peer_duration` | live (session reset) | Same as neighbor; same conservative-reshape fallback as the threshold. |
+| `slow_peer_isolation` | live (session reset) | Same as neighbor; same conservative-reshape fallback as the threshold. |
 | `max_prefixes` | live | Same as neighbor. |
 | `max_prefixes_ipv4` | live | Same as neighbor; per-family ADR-0108 cap inherited by group members. |
 | `max_prefixes_ipv6` | live | Same as neighbor. |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1379,7 +1379,10 @@ fn config_field_impact(field: &str) -> Option<(ConfigFieldImpact, &'static str)>
         | "per_client_best"
         | "next_hop_ownership"
         | "interpret_rfc1997"
-        | "rs_control_communities" => (
+        | "rs_control_communities"
+        | "slow_peer_threshold_pct"
+        | "slow_peer_duration"
+        | "slow_peer_isolation" => (
             ConfigFieldImpact::SessionReset,
             "session reset: session re-establish",
         ),
@@ -1505,6 +1508,9 @@ pub fn describe_neighbor_changes(old: &Neighbor, new: &Neighbor) -> Vec<FieldCha
     cmp_field!(hold_time);
     cmp_field!(min_hold_time);
     cmp_field!(send_hold_time);
+    cmp_field!(slow_peer_threshold_pct);
+    cmp_field!(slow_peer_duration);
+    cmp_field!(slow_peer_isolation);
     cmp_field!(max_prefixes);
     cmp_field!(max_prefixes_ipv4);
     cmp_field!(max_prefixes_ipv6);
@@ -1631,6 +1637,9 @@ fn neighbor_runtime_equal(old: &Neighbor, new: &Neighbor) -> bool {
         && old.hold_time == new.hold_time
         && old.min_hold_time == new.min_hold_time
         && old.send_hold_time == new.send_hold_time
+        && old.slow_peer_threshold_pct == new.slow_peer_threshold_pct
+        && old.slow_peer_duration == new.slow_peer_duration
+        && old.slow_peer_isolation == new.slow_peer_isolation
         && old.max_prefixes == new.max_prefixes
         && old.max_prefixes_ipv4 == new.max_prefixes_ipv4
         && old.max_prefixes_ipv6 == new.max_prefixes_ipv6

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -7717,6 +7717,79 @@ fn neighbor_change_hot_applicable_partitions_by_impact_class() {
 }
 
 #[test]
+fn slow_peer_edit_on_static_neighbor_takes_session_rebuild_path() {
+    let old = test_neighbor("10.0.0.2", 65002);
+    let mut new = old.clone();
+    new.slow_peer_threshold_pct = Some(25);
+    new.slow_peer_duration = Some(10);
+    new.slow_peer_isolation = Some(true);
+
+    // Detected: a slow_peer-only edit must be visible to the reconciler
+    // at all — it was silently invisible to `diff_neighbors` before.
+    let diff = super::diff_neighbors(std::slice::from_ref(&old), std::slice::from_ref(&new));
+    assert_eq!(
+        diff.changed.len(),
+        1,
+        "a slow_peer-only edit must be reported by diff_neighbors"
+    );
+
+    // Reported: `--diff` / reload logging must name all three fields,
+    // classed session-reset (captured into the session transport config).
+    let changes = super::describe_neighbor_changes(&old, &new);
+    let fields: Vec<&str> = changes.iter().map(|change| change.field).collect();
+    for field in [
+        "slow_peer_threshold_pct",
+        "slow_peer_duration",
+        "slow_peer_isolation",
+    ] {
+        assert!(
+            fields.contains(&field),
+            "describe_neighbor_changes must name {field}, got {fields:?}"
+        );
+    }
+    assert!(
+        changes
+            .iter()
+            .all(|change| change.impact == Some(super::ConfigFieldImpact::SessionReset)),
+        "slow_peer fields must classify as session reset: {changes:?}"
+    );
+
+    // Applied: the reload partition must take the session-rebuild path,
+    // never hot-apply in place.
+    assert!(
+        !super::neighbor_change_hot_applicable(&old, &new),
+        "a slow_peer edit must rebuild the session, not hot-apply"
+    );
+}
+
+#[test]
+fn slow_peer_edit_on_peer_group_keeps_conservative_reshape() {
+    let old_group = PeerGroupConfig::default();
+    let mut new_group = old_group.clone();
+    new_group.slow_peer_threshold_pct = Some(25);
+    new_group.slow_peer_duration = Some(10);
+    new_group.slow_peer_isolation = Some(true);
+
+    // Detected: diff_peer_groups compares whole structs, so the group
+    // edit is visible.
+    let old_map = std::collections::HashMap::from([("ixp".to_string(), old_group.clone())]);
+    let new_map = std::collections::HashMap::from([("ixp".to_string(), new_group.clone())]);
+    let diff = super::diff_peer_groups(&old_map, &new_map);
+    assert_eq!(
+        diff.changed,
+        vec!["ixp".to_string()],
+        "a group slow_peer edit must be reported as changed"
+    );
+
+    // Applied: the group path stays on the conservative reshape
+    // (delete + re-add) fallback — never hot-applied to members in place.
+    assert!(
+        !super::peer_group_change_hot_applicable(&old_group, &new_group),
+        "a group slow_peer edit must reshape members, not hot-apply"
+    );
+}
+
+#[test]
 fn config_diff_human_output_is_operator_grade() {
     // Mixed diff: one added, one changed (hot + session-reset fields),
     // one untouched neighbor.


### PR DESCRIPTION
## Mechanism

`docs/reload-matrix.md` claimed the reconciler rebuilds the session when `slow_peer_threshold_pct`, `slow_peer_duration`, or `slow_peer_isolation` change on a static neighbor. The code disagreed: `neighbor_runtime_equal()` and `describe_neighbor_changes` omitted the trio, so a slow_peer-only edit was invisible to `diff_neighbors` — SIGHUP applied nothing, `--diff` reported nothing, and the new values only took effect at the next natural session re-establishment.

## The seam inconsistency

The peer-group path already handled the same edit conservatively: `diff_peer_groups` compares whole structs, and `peer_group_change_hot_applicable` returns `false` on a change set `describe_peer_group_changes` doesn't cover, so a group slow_peer edit reshaped members via the delete + re-add fallback. Direct-neighbor edits and inherited-group edits of the same three knobs therefore behaved differently — the bug.

## Fix

- `neighbor_runtime_equal()`: compare the three slow_peer fields, making the edit visible to `diff_neighbors` and the existing `ReconcilePeers` session-rebuild path.
- `describe_neighbor_changes`: report the three fields.
- `config_field_impact`: classify all three as session reset ("session reset: session re-establish") — the values are captured into the session transport config at establishment.
- Peer-group behavior unchanged: `describe_peer_group_changes` still omits the trio deliberately, keeping the conservative reshape fallback; now pinned by a test.

Full seam sweep: every other `Neighbor` field is already covered by `neighbor_runtime_equal` except `tcp_ao` and `bfd`, both deliberate — they flow through the dedicated restart-required channels (`neighbor_tcp_ao_changed`, `bfd_changed` / `pin_bfd_startup_only_runtime`).

## Red proof

Both tests were written and run against the unfixed code first (`cargo test --bin rustbgpd slow_peer_edit_on`, exit 101):

```
test config::tests::slow_peer_edit_on_peer_group_keeps_conservative_reshape ... ok
test config::tests::slow_peer_edit_on_static_neighbor_takes_session_rebuild_path ... FAILED

---- config::tests::slow_peer_edit_on_static_neighbor_takes_session_rebuild_path stdout ----
panicked at src/config/tests.rs:7730:5:
assertion `left == right` failed: a slow_peer-only edit must be reported by diff_neighbors
  left: 0
 right: 1
```

The peer-group test passed pre-fix by design — it pins the existing conservative-reshape behavior. Both pass post-fix.

## Docs

The three `[[neighbors]]` rows and three `[peer_groups.<name>]` rows in `docs/reload-matrix.md` are reclassified from `live (effective next session)` to `live (session reset)`; the group rows note the conservative-reshape fallback. CHANGELOG `[Unreleased]` gains a Fixed entry.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast`, `cargo doc --workspace --no-deps`, `scripts/check-clippy-reasons.py`, `scripts/check-v1-stable-surface.py` — all exit 0.
