### PR TITLE
Add opt-in per-source inbound connection admission rate limiting (ADR-0120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- New opt-in `[inbound_admission]` table (ADR-0120) rate-limits inbound
+  connection accepts per source address, aggregated per-host for IPv4 and
+  per-/64 for IPv6 by default, with configurable rate, burst, aggregation
+  lengths, and a fixed-capacity LRU tracking table. It protects the accept
+  path against churny or abusive sources inside permitted
+  `[[dynamic_neighbors]]` ranges; statically configured neighbors are exempt
+  so a flapping peer can always re-establish. Default off — existing
+  deployments keep their accept behavior unchanged; all fields are
+  restart-required. Accept-path drops are now counted in
+  `bgp_inbound_connections_dropped_total{reason}` with the bounded reasons
+  `unconfigured`, `rate_limited`, and `dynamic_limit` (the `unconfigured`
+  and `dynamic_limit` sites are accounted even while the limiter is off).
+
 - The shipped Prometheus rule pack now pages on outbound BGP work dropped
   before the peer writer and RFC 9687 send-hold session teardowns, and warns
   when a live event-stream consumer misses events and becomes desynchronized.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2914,6 +2914,7 @@ dependencies = [
  "dhat",
  "futures",
  "libc",
+ "lru",
  "netlink-packet-route",
  "nix 0.31.3",
  "owo-colors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,7 @@ prometheus.workspace = true
 thiserror.workspace = true
 bytes.workspace = true
 serde_json.workspace = true
+lru.workspace = true
 sha2.workspace = true
 uuid.workspace = true
 owo-colors.workspace = true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -110,6 +110,16 @@ input from the network. It runs under continuous fuzzing in CI.
   after TCP accept.
 - Dynamic-neighbor admission is capped by `dynamic_neighbor_limit`
   (restart-pinned); connections beyond the cap are dropped and counted.
+- An opt-in per-source accept-rate limiter (`[inbound_admission]`,
+  ADR-0120, default off) token-buckets sources that match a
+  `[[dynamic_neighbors]]` range, keyed by aggregated source address
+  (per-host for IPv4, per-/64 for IPv6 by default; both configurable).
+  Over-rate connections are dropped immediately after accept and counted
+  in `bgp_inbound_connections_dropped_total{reason="rate_limited"}`.
+  Tracking state is a fixed-capacity LRU table, so limiter memory is
+  bounded regardless of offered load. Statically configured neighbor
+  addresses are exempt so a flapping legitimate peer cannot lock itself
+  out of re-establishment.
 - The message-processing path between peer sessions and the RIB uses
   bounded channels, so a fast or abusive peer parks on backpressure
   instead of growing daemon memory (see Design Invariant #3 in

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -206,6 +206,7 @@ pub struct BgpMetrics {
     dynamic_neighbor_slots_limit: IntGauge,
     dynamic_neighbor_slots_headroom: IntGauge,
     dynamic_neighbor_limit_rejections: IntCounter,
+    inbound_connections_dropped: IntCounterVec,
 
     // ── BFD (RFC 5880, ADR-0067) ───────────────────────────────────
     bfd_session_up: IntGaugeVec,
@@ -538,6 +539,15 @@ impl BgpMetrics {
         let dynamic_neighbor_limit_rejections = IntCounter::new(
             "bgp_dynamic_neighbor_limit_rejections_total",
             "Inbound dynamic-neighbor connections dropped because the process-global admission limit was reached.",
+        )
+        .expect("valid metric definition");
+
+        let inbound_connections_dropped = IntCounterVec::new(
+            Opts::new(
+                "bgp_inbound_connections_dropped_total",
+                "Inbound connections dropped by the accept-path admission checks, by bounded reason (ADR-0120): unconfigured source, per-source rate limit, or dynamic-neighbor slot saturation.",
+            ),
+            &["reason"],
         )
         .expect("valid metric definition");
 
@@ -1914,6 +1924,9 @@ impl BgpMetrics {
             .register(Box::new(dynamic_neighbor_limit_rejections.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(inbound_connections_dropped.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(notifications_sent.clone()))
             .expect("metric not already registered");
         registry
@@ -2376,6 +2389,7 @@ impl BgpMetrics {
             dynamic_neighbor_slots_limit,
             dynamic_neighbor_slots_headroom,
             dynamic_neighbor_limit_rejections,
+            inbound_connections_dropped,
             bfd_session_up,
             bfd_session_flaps_total,
             gnmi_dialout_connected,
@@ -2547,6 +2561,18 @@ impl BgpMetrics {
     /// Record an inbound dynamic-neighbor drop caused by slot saturation.
     pub fn record_dynamic_neighbor_limit_rejection(&self) {
         self.dynamic_neighbor_limit_rejections.inc();
+    }
+
+    /// Record an accept-path inbound connection drop by bounded reason
+    /// (ADR-0120). `reason` is the canonical typed admission-drop
+    /// vocabulary — never a source address.
+    pub fn record_inbound_connection_drop(
+        &self,
+        reason: crate::reason_labels::InboundConnectionDropReason,
+    ) {
+        self.inbound_connections_dropped
+            .with_label_values(&[reason.as_str()])
+            .inc();
     }
 
     // ── Per-peer series reaping ────────────────────────────────────

--- a/crates/telemetry/src/reason_labels.rs
+++ b/crates/telemetry/src/reason_labels.rs
@@ -1,4 +1,5 @@
-//! Canonical reason-label vocabulary for UPDATE-path route rejection.
+//! Canonical reason-label vocabulary for UPDATE-path route rejection
+//! and inbound connection admission drops.
 //!
 //! Single source of truth for the `reason` strings that ingress (and
 //! the OTC egress sibling) route-rejection mechanisms report across
@@ -174,6 +175,53 @@ impl RrLoopReason {
 }
 
 impl std::fmt::Display for RrLoopReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Inbound connection admission drop reasons (ADR-0120).
+///
+/// Surfaces sharing this vocabulary:
+///
+/// - `bgp_inbound_connections_dropped_total{reason}` label values
+///   ([`crate::BgpMetrics::record_inbound_connection_drop`]);
+/// - the `reason` token on the peer-manager accept-path log lines;
+/// - the documented values in `docs/OPERATIONS.md` and ADR-0120.
+///
+/// The vocabulary is closed and label-free beyond `reason` — never a
+/// source address, which is unbounded exactly under the flood these
+/// drops account for.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum InboundConnectionDropReason {
+    /// The source matched no configured static neighbor and no
+    /// `[[dynamic_neighbors]]` range.
+    Unconfigured,
+    /// The ADR-0120 per-source token bucket was empty for the source's
+    /// aggregate.
+    RateLimited,
+    /// The process-global `dynamic_neighbor_limit` slots were all
+    /// occupied.
+    DynamicLimit,
+}
+
+impl InboundConnectionDropReason {
+    /// Every canonical inbound drop reason, for vocabulary walks in
+    /// tests and docs.
+    pub const ALL: [Self; 3] = [Self::Unconfigured, Self::RateLimited, Self::DynamicLimit];
+
+    /// The canonical reason string shared by every surface.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unconfigured => "unconfigured",
+            Self::RateLimited => "rate_limited",
+            Self::DynamicLimit => "dynamic_limit",
+        }
+    }
+}
+
+impl std::fmt::Display for InboundConnectionDropReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
     }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1981,6 +1981,49 @@ comparison design.
 
 ---
 
+## `[inbound_admission]`
+
+Per-source inbound accept-rate limiting
+([ADR-0120](adr/0120-inbound-connection-admission.md)). A token bucket
+per aggregated source address bounds how fast a
+`[[dynamic_neighbors]]`-matched source can cycle the passive accept
+path — a churny or abusive member inside a permitted range is bounded
+to `burst` immediate accepts and `rate_per_minute` sustained accepts,
+dropped immediately after TCP accept once over rate. Statically
+configured neighbor addresses are exempt: a flapping legitimate peer
+must never lock itself out of re-establishment. Sources matching no
+configuration at all are dropped by the existing unconfigured-source
+check before the limiter is consulted.
+
+**Opt-in — default off.** An existing deployment's accept behavior is
+unchanged on upgrade. All fields are restart-required; see
+[reload-matrix.md](reload-matrix.md#inbound_admission-adr-0120) for the
+per-field classification.
+
+```toml
+[inbound_admission]
+enabled = false          # default; set true to enforce the accept-rate limit
+rate_per_minute = 12     # sustained accepts per source aggregate per minute (> 0)
+burst = 5                # immediate accepts before the sustained rate applies (> 0)
+v4_aggregation_len = 32  # IPv4 bucket-key prefix length (8-32); 32 = per host
+v6_aggregation_len = 64  # IPv6 bucket-key prefix length (16-128); per-/128 is trivially evadable
+table_capacity = 4096    # tracked source aggregates (64-65536), LRU-evicted at capacity
+```
+
+Accounting is per aggregated source: all hosts inside one aggregate
+(one v6 /64 by default) share a bucket. The tracking table is a
+fixed-capacity LRU, so limiter memory stays bounded (roughly
+`table_capacity` × ~100 bytes) regardless of how many sources probe the
+listener; an evicted aggregate re-enters with a fresh burst allowance.
+
+Drops are counted in
+`bgp_inbound_connections_dropped_total{reason="rate_limited"}`; the
+`unconfigured` and `dynamic_limit` reasons account the pre-existing
+drop sites and are recorded even while the limiter is disabled. See
+`docs/OPERATIONS.md` for the metric reference.
+
+---
+
 ## `[rpki]`
 
 Optional. Configures RPKI origin validation via a persistent RTR client (RFC 8210).

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -711,6 +711,13 @@ Ordinary Idle removal and config-rollback reaping return a slot; a terminal
 max-prefix peer retained disabled for explicit recovery still owns one.
 `bgp_dynamic_neighbor_limit_rejections_total` increments only when a matching
 inbound dynamic connection is dropped because all slots are occupied.
+`bgp_inbound_connections_dropped_total` breaks accept-path drops down by a
+bounded `reason` vocabulary (ADR-0120): `unconfigured` (source matched no
+static neighbor and no dynamic range), `rate_limited` (the opt-in
+`[inbound_admission]` per-source token bucket was empty), and
+`dynamic_limit` (slot saturation, counted alongside the legacy counter).
+There is deliberately no per-source label — source cardinality is unbounded
+exactly under the floods these drops account for.
 
 | Metric | What it tells you |
 |--------|-------------------|
@@ -721,6 +728,7 @@ inbound dynamic connection is dropped because all slots are occupied.
 | `bgp_dynamic_neighbor_slots_limit` | Effective process-global `dynamic_neighbor_limit` |
 | `bgp_dynamic_neighbor_slots_headroom` | Saturating `limit - used`; zero means the next matching dynamic inbound is rejected |
 | `bgp_dynamic_neighbor_limit_rejections_total` | Matching inbound dynamic connections rejected because the slot limit was already full |
+| `bgp_inbound_connections_dropped_total{reason}` | Accept-path inbound connection drops by bounded reason: `unconfigured`, `rate_limited` (ADR-0120 `[inbound_admission]`), or `dynamic_limit` |
 | `bgp_max_prefix_usage{peer,scope}` | Live session-actor max-prefix enforcement count for `aggregate`, `ipv4_unicast`, or `ipv6_unicast`; series are absent while the session is down |
 | `bgp_max_prefix_limit{peer,scope}` | Effective finite bound for the same scope; absent means unlimited, never zero |
 | `bgp_max_prefix_headroom{peer,scope}` | Saturating `limit - usage` for a finite scope; absent when unlimited or disconnected |

--- a/docs/adr/0120-inbound-connection-admission.md
+++ b/docs/adr/0120-inbound-connection-admission.md
@@ -1,0 +1,145 @@
+# ADR-0120: Inbound connection admission rate limiting
+
+**Status:** Accepted
+**Date:** 2026-07-30
+
+## Context
+
+The passive accept path admits inbound TCP connections in three classes:
+sources matching a configured static neighbor, sources matching a
+`[[dynamic_neighbors]]` range, and everything else. Unmatched sources are
+dropped immediately after accept, and dynamic admission is capped by the
+process-global `dynamic_neighbor_limit`. Neither mechanism bounds the *rate*
+at which one source can cycle the accept path: a churny or abusive host
+inside a permitted dynamic range can connect, be admitted, drop, and
+reconnect as fast as TCP allows, burning session-spawn work (task spawn,
+config resolution, OPEN negotiation, teardown) on every cycle. A
+route-server front door with wide member ranges is exactly the deployment
+shape where one misbehaving member should not be able to monopolize the
+accept loop.
+
+SECURITY.md previously claimed per-source inbound TCP rate limiting that did
+not exist; the claim was removed. This ADR adds the real mechanism,
+deliberately scoped.
+
+## Decision
+
+Add an opt-in per-source token-bucket accept-rate limiter to the passive
+accept path, configured by a new top-level `[inbound_admission]` table.
+
+### Identity: aggregated source address
+
+Accounting is per source IP, aggregated to a configurable prefix length:
+`/32` for IPv4 and `/64` for IPv6 by default. Per-/128 IPv6 accounting is
+trivially evadable — one commodity host holds an entire /64 and can rotate
+through 2^64 addresses without ever reusing a bucket — so the v6 default
+aggregates at the standard on-link allocation unit. Both lengths are
+configurable (`v4_aggregation_len` 8–32, `v6_aggregation_len` 16–128) for
+deployments whose members hold larger or smaller allocations. Ports are
+ignored: the identity is the remote host (aggregate), not the flow.
+
+### Scope: post-match, pre-spawn; static neighbors exempt
+
+The limiter runs after the existing admission decisions have classified the
+source and before any session work is spawned:
+
+- **Unmatched sources** are dropped by the existing unconfigured-source
+  check before the limiter is consulted. They never reach session spawn, so
+  rate-limiting them would only re-drop an already-dropped connection.
+- **Dynamic-range-matched sources** are the protected surface. A matched
+  source must pass the token bucket before the dynamic-slot check and
+  session spawn; an over-rate source is dropped even though its range
+  matches.
+- **Statically configured neighbor addresses are exempt.** A static
+  neighbor is an explicit, individually provisioned trust decision, and its
+  failure mode is the opposite of abuse: a legitimate peer flapping through
+  reconnects (link instability, remote restart loop, hold-timer expiry
+  cycles) must never lock itself out of re-establishment — BGP's own
+  recovery depends on the reconnect succeeding. The static path also
+  already bounds its own work (one session per configured peer, collision
+  handling per RFC 4271 §6.8), so the spawn-amplification the limiter
+  exists to stop does not arise there. Exemption is by admission path, not
+  by address comparison: a source that matches a static neighbor takes the
+  static path and never consults the limiter, even when a dynamic range
+  covers the same aggregate.
+
+### Accounting: bounded LRU table owned by the accept-path actor
+
+Buckets live in a fixed-capacity LRU table (`table_capacity`, default 4096,
+bounds 64–65536) keyed by aggregated source address. Inserting into a full
+table evicts the least-recently-used entry, so an attacker rotating source
+aggregates can at worst cycle the table — daemon memory is bounded at
+roughly `table_capacity` × ~100 bytes (≈400 KiB at the default) regardless
+of offered load. Eviction forgetting an old bucket refills that source's
+burst allowance; that is an accepted trade — the alternative (unbounded
+tracking) converts the limiter itself into a memory-exhaustion vector.
+
+The table is a plain field on `PeerManager`, the single-task actor that
+already owns the accept path. No locks, no shared state, no new hot-path
+synchronization — the check is a hash lookup plus arithmetic on the
+already-serialized accept path.
+
+### Behavior on limit: immediate drop
+
+An over-rate connection is dropped immediately after accept (the socket is
+closed by drop). No tarpit, no delayed close, no queueing: the accept loop
+and the peer-manager actor stay non-blocking, and the remote sees an
+ordinary connection close, which well-behaved BGP speakers already handle
+with their connect-retry timer.
+
+### Observability
+
+A new label-bounded counter extends the existing drop accounting:
+
+```text
+bgp_inbound_connections_dropped_total{reason="unconfigured"|"rate_limited"|"dynamic_limit"}
+```
+
+The `reason` vocabulary is closed and low-cardinality; per-source labels are
+deliberately excluded (unbounded cardinality under exactly the attack the
+limiter exists for). `unconfigured` and `dynamic_limit` count the
+pre-existing drop sites — they are recorded even while the limiter is
+disabled, giving operators visibility before opting in — and
+`bgp_dynamic_neighbor_limit_rejections_total` keeps incrementing at the
+slot-saturation site for dashboard compatibility. The rate-limited drop log
+line is itself throttled (at most one per second, with a suppressed-count)
+so the log stream cannot be flooded by the flood it reports.
+
+### Defaults: off
+
+`enabled = false` by default. An existing deployment's accept behavior is
+byte-identical across the upgrade; only the two counters for pre-existing
+drop sites appear. This matches the project's upgrade-caution posture:
+admission behavior changes only when an operator asks for it.
+
+### Reload: restart-required
+
+Every `[inbound_admission]` field is restart-required, pinned by the SIGHUP
+path exactly like `[event_history]`: the reload logs an `ERROR`, the runtime
+snapshot keeps the startup table, and the operator's edit survives in the
+desired config for the next restart. The limiter's state (bucket table,
+sizing, aggregation keying) is built once by the accept-path owner at
+startup; hot-applying an aggregation-length or capacity change would
+invalidate every live bucket and re-open a fresh burst allowance for every
+source mid-attack, and the sibling admission knob
+(`dynamic_neighbor_limit`) is already restart-required — one classification
+for the whole admission surface is easier to operate than a per-field
+split. Live reload is a possible future promotion if operational experience
+demands it; the pinning machinery makes the current classification visible
+on every reload until restart.
+
+## Consequences
+
+- Configs without `[inbound_admission]` behave exactly as before; the new
+  counter reasons for existing drop sites are the only observable change.
+- An abusive source inside a permitted dynamic range is bounded to
+  `burst` immediate accepts and `rate_per_minute` sustained accepts per
+  aggregate, at O(1) cost per inbound connection and bounded memory.
+- A flapping static neighbor is never throttled and keeps its existing
+  re-establishment behavior.
+- Sources sharing an aggregate share a bucket: one abusive host inside a
+  shared v6 /64 can exhaust its aggregate's allowance for well-behaved
+  cohabitants. That is the standard aggregation trade-off and the reason
+  the lengths are configurable.
+- SECURITY.md's inbound-handling section now describes a mechanism that
+  exists.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -128,6 +128,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0117](0117-authenticated-single-hop-bfd-decision.md) | Authenticated single-hop BFD | Accepted (implementation NO-GO; evidence-gated) | 2026-07-22 |
 | [0118](0118-presence-preserving-runtime-neighbor-create.md) | Presence-preserving runtime neighbor creation | Accepted — fully shipped | 2026-07-29 |
 | [0119](0119-rfc-8212-secure-default-config-epoch.md) | RFC 8212 secure-default config epoch | Proposed (representation contract and secure-default activation deferred; owner gate required) | 2026-07-29 |
+| [0120](0120-inbound-connection-admission.md) | Inbound connection admission rate limiting | Accepted | 2026-07-30 |
 
 ## Template
 

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -390,6 +390,24 @@ what's deferred.
 | `batch_size` | restart-required | Batch-commit size threshold. |
 | `batch_interval_ms` | restart-required | Batch-commit time threshold. |
 
+## `[inbound_admission]` (ADR-0120)
+
+The per-source accept-rate limiter is built once by the accept-path
+owner at startup; hot-applying an aggregation-length or capacity change
+would invalidate every live bucket and re-open a fresh burst allowance
+for every source. v1 pins every field as restart-required and surfaces
+the change as an `ERROR`-level log line during reload, matching the
+sibling admission knob `dynamic_neighbor_limit`.
+
+| Field | Class | Notes |
+|---|---|---|
+| `enabled` | restart-required | Off (default) ⇒ accept behavior unchanged; the limiter is never built. |
+| `rate_per_minute` | restart-required | Token-bucket refill rate per source aggregate. |
+| `burst` | restart-required | Token-bucket depth per source aggregate. |
+| `v4_aggregation_len` | restart-required | IPv4 bucket-key prefix length (8–32). |
+| `v6_aggregation_len` | restart-required | IPv6 bucket-key prefix length (16–128); default /64 because per-/128 accounting is trivially evadable. |
+| `table_capacity` | restart-required | Fixed LRU tracking-table capacity (64–65536). |
+
 ## Rejected configurations (parse-time)
 
 These are the `ConfigError` variants in `src/config/validation.rs` that

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -100,6 +100,18 @@
       ],
       "default": null
     },
+    "inbound_admission": {
+      "description": "Per-source inbound accept-rate limiting (ADR-0120). **Opt-in\n(default off)** — existing deployments keep their accept behavior\nunchanged. All fields are restart-required.",
+      "$ref": "#/$defs/InboundAdmissionConfig",
+      "default": {
+        "burst": 5,
+        "enabled": false,
+        "rate_per_minute": 12,
+        "table_capacity": 4096,
+        "v4_aggregation_len": 32,
+        "v6_aggregation_len": 64
+      }
+    },
     "managed_netdevs": {
       "description": "Optional rustbgpd-managed EVPN Linux netdev lifecycle\n(ADR-0091). Empty by default — existing deployments keep the\noperator-provisioned / observe-only contract. Configured rows opt\ninto class-scoped bridge, fixed-VNI VXLAN, SVD VXLAN, VLAN upper,\nVRF, and L3VXLAN create/adopt/reap.",
       "$ref": "#/$defs/ManagedNetdevsConfig",
@@ -1363,6 +1375,55 @@
             "string",
             "null"
           ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "InboundAdmissionConfig": {
+      "description": "Per-source inbound connection admission rate limiting (ADR-0120).\n\nA token bucket per aggregated source address bounds how fast a\ndynamic-range-matched source can cycle the passive accept path.\nStatically configured neighbor addresses are exempt — a flapping\nlegitimate peer must never lock itself out of re-establishment.\nAll fields are restart-required; the reload matrix documents the\nclassification.",
+      "type": "object",
+      "properties": {
+        "burst": {
+          "description": "Accepts a source aggregate may burst before the sustained rate\napplies (token-bucket depth). Must be > 0 when enabled.",
+          "type": "integer",
+          "format": "uint32",
+          "default": 5,
+          "minimum": 0
+        },
+        "enabled": {
+          "description": "Enable the accept-rate limiter. **Default `false`** — when off,\ninbound admission behavior is unchanged and only the\n`bgp_inbound_connections_dropped_total` accounting for the\npre-existing drop sites is recorded.",
+          "type": "boolean",
+          "default": false
+        },
+        "rate_per_minute": {
+          "description": "Sustained accepts allowed per source aggregate per minute\n(token-bucket refill rate). Must be > 0 when enabled.",
+          "type": "integer",
+          "format": "uint32",
+          "default": 12,
+          "minimum": 0
+        },
+        "table_capacity": {
+          "description": "Maximum tracked source aggregates (64–65536). The tracking\ntable evicts least-recently-used entries at capacity, bounding\nlimiter memory regardless of offered load.",
+          "type": "integer",
+          "format": "uint",
+          "default": 4096,
+          "minimum": 0
+        },
+        "v4_aggregation_len": {
+          "description": "IPv4 source aggregation prefix length (8–32). Default 32:\nper-host accounting.",
+          "type": "integer",
+          "format": "uint8",
+          "default": 32,
+          "maximum": 255,
+          "minimum": 0
+        },
+        "v6_aggregation_len": {
+          "description": "IPv6 source aggregation prefix length (16–128). Default 64:\nper-/128 accounting is trivially evadable within one on-link\nallocation, so accounting aggregates at the /64 boundary.",
+          "type": "integer",
+          "format": "uint8",
+          "default": 64,
+          "maximum": 255,
+          "minimum": 0
         }
       },
       "additionalProperties": false

--- a/docs/v1-stable-surface.json
+++ b/docs/v1-stable-surface.json
@@ -126,6 +126,7 @@
       {"path": "Config.evpn_ip_vrfs", "classification": "alpha"},
       {"path": "Config.fib_tables", "classification": "alpha"},
       {"path": "Config.gnmi_dialout", "classification": "outside_v1"},
+      {"path": "Config.inbound_admission", "classification": "alpha"},
       {"path": "Config.managed_netdevs", "classification": "alpha"},
       {"path": "Neighbor.bfd", "classification": "outside_v1"},
       {"path": "Neighbor.interface", "classification": "outside_v1"},

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1787,6 +1787,10 @@ pub struct ConfigDiff {
     /// configured once at startup (all fields are restart-required per
     /// the reload matrix), so edits must remain visible in `--diff`.
     pub event_history_changed: bool,
+    /// `[inbound_admission]` changed. The ADR-0120 accept-path limiter
+    /// is built once at startup (all fields are restart-required per
+    /// the reload matrix), so edits must remain visible in `--diff`.
+    pub inbound_admission_changed: bool,
     /// `[[fib_tables]]` blocks added/removed/modified between old and new.
     /// Reload-applied in the common case: the ADR-0061 general-FIB actor
     /// accepts a runtime table-set swap on SIGHUP
@@ -2048,6 +2052,7 @@ impl ConfigDiff {
             || self.managed_netdevs_changed
             || self.security_grpc_changed
             || self.event_history_changed
+            || self.inbound_admission_changed
     }
 
     /// Changes detected but not applied by current SIGHUP. Empty
@@ -2712,6 +2717,11 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
             .restart_required_sections
             .push("[event_history]".to_string());
     }
+    if diff.inbound_admission_changed {
+        class
+            .restart_required_sections
+            .push("[inbound_admission]".to_string());
+    }
     if diff.apply_bum_enforcement_changed {
         class
             .restart_required_sections
@@ -2879,6 +2889,7 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
             "managed_netdevs_changed": diff.managed_netdevs_changed,
             "security_grpc_changed": diff.security_grpc_changed,
             "event_history_changed": diff.event_history_changed,
+            "inbound_admission_changed": diff.inbound_admission_changed,
             "fib_tables_requires_restart": diff.fib_tables_requires_restart,
             "apply_bum_enforcement_changed": diff.apply_bum_enforcement_changed,
             "blackhole_fib_discard_changed": diff.blackhole_fib_discard_changed,
@@ -3136,6 +3147,9 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
     if diff.event_history_changed {
         restart_sections.push("[event_history]");
     }
+    if diff.inbound_admission_changed {
+        restart_sections.push("[inbound_admission]");
+    }
     if diff.fib_tables_requires_restart {
         restart_sections.push("[[fib_tables]] (start FIB from an empty config)");
     }
@@ -3281,6 +3295,7 @@ pub fn diff_config(old: &Config, new: &Config) -> ConfigDiff {
         managed_netdevs_changed: old.managed_netdevs != new.managed_netdevs,
         security_grpc_changed: old.security != new.security,
         event_history_changed: old.event_history != new.event_history,
+        inbound_admission_changed: old.inbound_admission != new.inbound_admission,
         fib_tables_changed: old.fib_tables != new.fib_tables,
         fib_tables_requires_restart: old.fib_tables.is_empty() && !new.fib_tables.is_empty(),
         dynamic_neighbors_changed: old.dynamic_neighbors != new.dynamic_neighbors,

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -115,9 +115,84 @@ pub struct Config {
     /// restart-safe event replay. All fields are restart-required.
     #[serde(default)]
     pub event_history: EventHistoryConfig,
+    /// Per-source inbound accept-rate limiting (ADR-0120). **Opt-in
+    /// (default off)** — existing deployments keep their accept behavior
+    /// unchanged. All fields are restart-required.
+    #[serde(default)]
+    pub inbound_admission: InboundAdmissionConfig,
     /// Path of the config file (populated by `Config::load`, not serialized).
     #[serde(skip)]
     pub file_path: Option<PathBuf>,
+}
+
+/// Per-source inbound connection admission rate limiting (ADR-0120).
+///
+/// A token bucket per aggregated source address bounds how fast a
+/// dynamic-range-matched source can cycle the passive accept path.
+/// Statically configured neighbor addresses are exempt — a flapping
+/// legitimate peer must never lock itself out of re-establishment.
+/// All fields are restart-required; the reload matrix documents the
+/// classification.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct InboundAdmissionConfig {
+    /// Enable the accept-rate limiter. **Default `false`** — when off,
+    /// inbound admission behavior is unchanged and only the
+    /// `bgp_inbound_connections_dropped_total` accounting for the
+    /// pre-existing drop sites is recorded.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Sustained accepts allowed per source aggregate per minute
+    /// (token-bucket refill rate). Must be > 0 when enabled.
+    #[serde(default = "default_inbound_admission_rate_per_minute")]
+    pub rate_per_minute: u32,
+    /// Accepts a source aggregate may burst before the sustained rate
+    /// applies (token-bucket depth). Must be > 0 when enabled.
+    #[serde(default = "default_inbound_admission_burst")]
+    pub burst: u32,
+    /// IPv4 source aggregation prefix length (8–32). Default 32:
+    /// per-host accounting.
+    #[serde(default = "default_inbound_admission_v4_aggregation_len")]
+    pub v4_aggregation_len: u8,
+    /// IPv6 source aggregation prefix length (16–128). Default 64:
+    /// per-/128 accounting is trivially evadable within one on-link
+    /// allocation, so accounting aggregates at the /64 boundary.
+    #[serde(default = "default_inbound_admission_v6_aggregation_len")]
+    pub v6_aggregation_len: u8,
+    /// Maximum tracked source aggregates (64–65536). The tracking
+    /// table evicts least-recently-used entries at capacity, bounding
+    /// limiter memory regardless of offered load.
+    #[serde(default = "default_inbound_admission_table_capacity")]
+    pub table_capacity: usize,
+}
+
+impl Default for InboundAdmissionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            rate_per_minute: default_inbound_admission_rate_per_minute(),
+            burst: default_inbound_admission_burst(),
+            v4_aggregation_len: default_inbound_admission_v4_aggregation_len(),
+            v6_aggregation_len: default_inbound_admission_v6_aggregation_len(),
+            table_capacity: default_inbound_admission_table_capacity(),
+        }
+    }
+}
+
+fn default_inbound_admission_rate_per_minute() -> u32 {
+    12
+}
+fn default_inbound_admission_burst() -> u32 {
+    5
+}
+fn default_inbound_admission_v4_aggregation_len() -> u8 {
+    32
+}
+fn default_inbound_admission_v6_aggregation_len() -> u8 {
+    64
+}
+fn default_inbound_admission_table_capacity() -> usize {
+    4096
 }
 
 /// Durable event-history outbox configuration (ADR-0072).
@@ -2379,6 +2454,8 @@ pub enum ConfigError {
     InvalidRuntimeStateDir { value: String, reason: String },
     #[error("invalid event_history config: {reason}")]
     InvalidEventHistoryConfig { reason: String },
+    #[error("invalid inbound_admission config: {reason}")]
+    InvalidInboundAdmissionConfig { reason: String },
     #[error("invalid RPKI config: {reason}")]
     InvalidRpkiConfig { reason: String },
     #[error("undefined policy {name:?} referenced in chain")]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -6872,6 +6872,84 @@ fn diff_config_flags_event_history_as_restart_required() {
     );
 }
 
+#[test]
+fn diff_config_flags_inbound_admission_as_restart_required() {
+    // ADR-0120: every `[inbound_admission]` field is restart-required
+    // (the accept-path limiter is built once at startup) — an edit must
+    // classify as restart-required, not vanish from the diff.
+    let old = parse(valid_toml()).unwrap();
+    let mut new = old.clone();
+    new.inbound_admission.enabled = !new.inbound_admission.enabled;
+
+    let diff = super::diff_config(&old, &new);
+    assert!(diff.inbound_admission_changed);
+    assert!(diff.has_restart_required_changes());
+    assert!(
+        !diff.has_reload_applied_changes(),
+        "an inbound-admission-only edit does not hot-apply"
+    );
+
+    let json = super::config_diff_json_value(&diff);
+    assert_eq!(json["restart_required"]["inbound_admission_changed"], true);
+
+    let text = super::format_config_diff_with_style(&diff, &super::ConfigDiffTextStyle::default());
+    assert!(text.contains("[inbound_admission]"), "{text}");
+
+    let sections = super::classify_config_transaction_v1(&diff);
+    assert!(
+        sections
+            .restart_required_sections
+            .contains(&"[inbound_admission]".to_string()),
+        "{sections:?}"
+    );
+}
+
+#[test]
+fn inbound_admission_defaults_off_and_validates_bounds() {
+    // ADR-0120: opt-in — a config without the table parses with the
+    // limiter disabled and the documented defaults.
+    let default = parse(valid_toml()).unwrap();
+    assert!(!default.inbound_admission.enabled);
+    assert_eq!(default.inbound_admission.rate_per_minute, 12);
+    assert_eq!(default.inbound_admission.burst, 5);
+    assert_eq!(default.inbound_admission.v4_aggregation_len, 32);
+    assert_eq!(default.inbound_admission.v6_aggregation_len, 64);
+    assert_eq!(default.inbound_admission.table_capacity, 4096);
+
+    let enabled = |extra: &str| {
+        parse(&format!(
+            "{}\n[inbound_admission]\nenabled = true\n{extra}\n",
+            valid_toml()
+        ))
+    };
+    assert!(enabled("").is_ok());
+    for (rejected, needle) in [
+        ("rate_per_minute = 0", "rate_per_minute"),
+        ("burst = 0", "burst"),
+        ("v4_aggregation_len = 7", "v4_aggregation_len"),
+        ("v4_aggregation_len = 33", "v4_aggregation_len"),
+        ("v6_aggregation_len = 15", "v6_aggregation_len"),
+        ("v6_aggregation_len = 129", "v6_aggregation_len"),
+        ("table_capacity = 63", "table_capacity"),
+        ("table_capacity = 65537", "table_capacity"),
+    ] {
+        let error = enabled(rejected).unwrap_err().to_string();
+        assert!(
+            error.contains("inbound_admission") && error.contains(needle),
+            "{rejected}: {error}"
+        );
+    }
+    // Bounds are enforced only when enabled — a disabled table with
+    // out-of-range values still parses (the limiter is never built).
+    assert!(
+        parse(&format!(
+            "{}\n[inbound_admission]\nrate_per_minute = 0\n",
+            valid_toml()
+        ))
+        .is_ok()
+    );
+}
+
 /// ADR-0112: the RFC 8212 enforcement mode is opt-in and off by default, so an
 /// existing deployment keeps permit-all EBGP behavior without editing anything.
 #[test]

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -14,9 +14,9 @@ use super::schema::{
     ManagedVxlanNetdevConfig,
 };
 use super::{
-    Config, ConfigError, DEFAULT_HOLD_TIME, EventHistoryConfig, GrpcEnforcementConfig, Neighbor,
-    PeerGroupConfig, SecurityConfig, TcpAoConfig, TcpAoKeyringConfig, dynamic_prefixes_intersect,
-    is_unicast_nonzero_mac, parse_mac_address,
+    Config, ConfigError, DEFAULT_HOLD_TIME, EventHistoryConfig, GrpcEnforcementConfig,
+    InboundAdmissionConfig, Neighbor, PeerGroupConfig, SecurityConfig, TcpAoConfig,
+    TcpAoKeyringConfig, dynamic_prefixes_intersect, is_unicast_nonzero_mac, parse_mac_address,
 };
 
 /// Canonical key for a dynamic-neighbor prefix: the network address with all
@@ -314,6 +314,7 @@ impl Config {
 
         validate_reserved_policy_names(self)?;
         validate_event_history(&self.event_history)?;
+        validate_inbound_admission(&self.inbound_admission)?;
         validate_grpc_security(&self.security)?;
         self.validate_no_redacted_secrets()?;
 
@@ -2606,6 +2607,48 @@ fn validate_event_history(cfg: &EventHistoryConfig) -> Result<(), ConfigError> {
     if cfg.max_bytes == 0 {
         return Err(ConfigError::InvalidEventHistoryConfig {
             reason: "max_bytes must be > 0".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_inbound_admission(cfg: &InboundAdmissionConfig) -> Result<(), ConfigError> {
+    if !cfg.enabled {
+        return Ok(());
+    }
+
+    if cfg.rate_per_minute == 0 {
+        return Err(ConfigError::InvalidInboundAdmissionConfig {
+            reason: "rate_per_minute must be > 0".to_string(),
+        });
+    }
+    if cfg.burst == 0 {
+        return Err(ConfigError::InvalidInboundAdmissionConfig {
+            reason: "burst must be > 0".to_string(),
+        });
+    }
+    if !(8..=32).contains(&cfg.v4_aggregation_len) {
+        return Err(ConfigError::InvalidInboundAdmissionConfig {
+            reason: format!(
+                "v4_aggregation_len = {} out of range; expected 8..=32",
+                cfg.v4_aggregation_len
+            ),
+        });
+    }
+    if !(16..=128).contains(&cfg.v6_aggregation_len) {
+        return Err(ConfigError::InvalidInboundAdmissionConfig {
+            reason: format!(
+                "v6_aggregation_len = {} out of range; expected 16..=128",
+                cfg.v6_aggregation_len
+            ),
+        });
+    }
+    if !(64..=65536).contains(&cfg.table_capacity) {
+        return Err(ConfigError::InvalidInboundAdmissionConfig {
+            reason: format!(
+                "table_capacity = {} out of range; expected 64..=65536",
+                cfg.table_capacity
+            ),
         });
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -6937,6 +6937,7 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
             bfd_profiles: Vec::new(),
             apply_bum_enforcement: false,
             event_history: crate::config::EventHistoryConfig::default(),
+            inbound_admission: crate::config::InboundAdmissionConfig::default(),
         };
 
         assert_eq!(max_gr_restart_time_secs(&config), Some(180));

--- a/src/peer_manager/admission.rs
+++ b/src/peer_manager/admission.rs
@@ -1,0 +1,231 @@
+//! Per-source inbound accept-rate limiting (ADR-0120).
+//!
+//! A token bucket per aggregated source address, held in a
+//! fixed-capacity LRU table owned by the `PeerManager` actor. The
+//! accept path consults it for dynamic-range-matched sources only;
+//! statically configured neighbors are exempt by admission path (they
+//! never reach the dynamic arm). All state is single-task-owned — no
+//! locks anywhere near the accept path.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::num::NonZeroUsize;
+
+use lru::LruCache;
+use tokio::time::Instant;
+
+use crate::config::InboundAdmissionConfig;
+
+/// Minimum spacing between rate-limit warn lines, so the log stream
+/// cannot be flooded by the flood it reports.
+const LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Mask `addr` down to its configured aggregation prefix, producing the
+/// bucket key for that source.
+fn aggregate(addr: IpAddr, v4_len: u8, v6_len: u8) -> IpAddr {
+    match addr {
+        IpAddr::V4(v4) => {
+            let mask = u32::MAX << (32 - u32::from(v4_len));
+            IpAddr::V4(Ipv4Addr::from(u32::from(v4) & mask))
+        }
+        IpAddr::V6(v6) => {
+            let mask = if v6_len == 0 {
+                0
+            } else {
+                u128::MAX << (128 - u32::from(v6_len))
+            };
+            IpAddr::V6(Ipv6Addr::from(u128::from(v6) & mask))
+        }
+    }
+}
+
+struct TokenBucket {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+pub(super) struct InboundAdmission {
+    rate_per_second: f64,
+    burst: f64,
+    v4_len: u8,
+    v6_len: u8,
+    buckets: LruCache<IpAddr, TokenBucket>,
+    last_log: Option<Instant>,
+    suppressed_since_last_log: u64,
+}
+
+impl InboundAdmission {
+    /// Build the limiter from config; `None` when disabled. Bounds are
+    /// enforced by config validation before this is reached.
+    pub(super) fn from_config(cfg: &InboundAdmissionConfig) -> Option<Self> {
+        if !cfg.enabled {
+            return None;
+        }
+        Some(Self {
+            rate_per_second: f64::from(cfg.rate_per_minute) / 60.0,
+            burst: f64::from(cfg.burst),
+            v4_len: cfg.v4_aggregation_len,
+            v6_len: cfg.v6_aggregation_len,
+            buckets: LruCache::new(
+                NonZeroUsize::new(cfg.table_capacity.max(1)).expect("capacity is non-zero"),
+            ),
+            last_log: None,
+            suppressed_since_last_log: 0,
+        })
+    }
+
+    /// Take one token for an accept attempt from `source`. Returns
+    /// `true` when the accept is admitted. A source not yet tracked
+    /// starts with a full burst allowance; inserting it may evict the
+    /// least-recently-used aggregate, keeping the table at its fixed
+    /// capacity.
+    pub(super) fn admit(&mut self, source: IpAddr) -> bool {
+        let key = aggregate(source, self.v4_len, self.v6_len);
+        let now = Instant::now();
+        if let Some(bucket) = self.buckets.get_mut(&key) {
+            let elapsed = now.saturating_duration_since(bucket.last_refill);
+            bucket.tokens =
+                (bucket.tokens + elapsed.as_secs_f64() * self.rate_per_second).min(self.burst);
+            bucket.last_refill = now;
+            if bucket.tokens >= 1.0 {
+                bucket.tokens -= 1.0;
+                true
+            } else {
+                false
+            }
+        } else {
+            self.buckets.push(
+                key,
+                TokenBucket {
+                    tokens: self.burst - 1.0,
+                    last_refill: now,
+                },
+            );
+            true
+        }
+    }
+
+    /// Whether a rate-limit drop may emit its warn line now. At most
+    /// one line per [`LOG_INTERVAL`]; returns the number of drops
+    /// suppressed since the last emitted line.
+    pub(super) fn should_log(&mut self) -> Option<u64> {
+        let now = Instant::now();
+        if self
+            .last_log
+            .is_none_or(|last| now.saturating_duration_since(last) >= LOG_INTERVAL)
+        {
+            self.last_log = Some(now);
+            Some(std::mem::take(&mut self.suppressed_since_last_log))
+        } else {
+            self.suppressed_since_last_log += 1;
+            None
+        }
+    }
+
+    /// Tracked source aggregates, for capacity-bound assertions.
+    #[cfg(test)]
+    pub(super) fn tracked(&self) -> usize {
+        self.buckets.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(rate_per_minute: u32, burst: u32, capacity: usize) -> InboundAdmissionConfig {
+        InboundAdmissionConfig {
+            enabled: true,
+            rate_per_minute,
+            burst,
+            table_capacity: capacity,
+            ..InboundAdmissionConfig::default()
+        }
+    }
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn disabled_config_builds_no_limiter() {
+        assert!(InboundAdmission::from_config(&InboundAdmissionConfig::default()).is_none());
+    }
+
+    #[test]
+    fn aggregation_masks_host_bits() {
+        assert_eq!(aggregate(ip("192.0.2.77"), 32, 64), ip("192.0.2.77"));
+        assert_eq!(aggregate(ip("192.0.2.77"), 24, 64), ip("192.0.2.0"));
+        assert_eq!(
+            aggregate(ip("2001:db8:1:2:3:4:5:6"), 32, 64),
+            ip("2001:db8:1:2::")
+        );
+        assert_eq!(
+            aggregate(ip("2001:db8:1:2:3:4:5:6"), 32, 48),
+            ip("2001:db8:1::")
+        );
+        assert_eq!(
+            aggregate(ip("2001:db8:1:2:3:4:5:6"), 32, 128),
+            ip("2001:db8:1:2:3:4:5:6")
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn burst_exhausts_then_refills_at_rate() {
+        let mut admission = InboundAdmission::from_config(&config(60, 2, 64)).unwrap();
+        assert!(admission.admit(ip("192.0.2.1")));
+        assert!(admission.admit(ip("192.0.2.1")));
+        assert!(!admission.admit(ip("192.0.2.1")));
+        // 60/min = 1 token per second.
+        tokio::time::advance(std::time::Duration::from_secs(1)).await;
+        assert!(admission.admit(ip("192.0.2.1")));
+        assert!(!admission.admit(ip("192.0.2.1")));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn v6_sources_in_one_slash64_share_a_bucket() {
+        let mut admission = InboundAdmission::from_config(&config(60, 1, 64)).unwrap();
+        assert!(admission.admit(ip("2001:db8::1")));
+        assert!(
+            !admission.admit(ip("2001:db8::2")),
+            "a rotated interface identifier inside the same /64 must not refill the burst"
+        );
+        assert!(
+            admission.admit(ip("2001:db8:0:1::1")),
+            "a different /64 is a distinct aggregate"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn refill_never_exceeds_burst() {
+        let mut admission = InboundAdmission::from_config(&config(60, 2, 64)).unwrap();
+        assert!(admission.admit(ip("192.0.2.1")));
+        tokio::time::advance(std::time::Duration::from_secs(90)).await;
+        assert!(admission.admit(ip("192.0.2.1")));
+        assert!(admission.admit(ip("192.0.2.1")));
+        assert!(!admission.admit(ip("192.0.2.1")));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn table_never_exceeds_capacity_and_evicts_lru() {
+        let capacity: usize = 64;
+        let mut admission = InboundAdmission::from_config(&config(60, 1, capacity)).unwrap();
+        for i in 0u32..256 {
+            admission.admit(IpAddr::V4(Ipv4Addr::from(0xc000_0200 + i)));
+            assert!(admission.tracked() <= capacity);
+        }
+        assert_eq!(admission.tracked(), capacity);
+        // The earliest source was evicted, so it re-enters with a fresh
+        // burst rather than remembering its spent allowance.
+        assert!(admission.admit(ip("192.0.2.0")));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn rate_limit_log_is_throttled() {
+        let mut admission = InboundAdmission::from_config(&config(60, 1, 64)).unwrap();
+        assert_eq!(admission.should_log(), Some(0));
+        assert_eq!(admission.should_log(), None);
+        assert_eq!(admission.should_log(), None);
+        tokio::time::advance(LOG_INTERVAL).await;
+        assert_eq!(admission.should_log(), Some(2));
+    }
+}

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -2,6 +2,7 @@ use std::net::{Ipv4Addr, SocketAddr};
 
 use rustbgpd_api::peer_types::PeerKey;
 use rustbgpd_fsm::SessionState;
+use rustbgpd_telemetry::reason_labels::InboundConnectionDropReason;
 use rustbgpd_transport::{
     PeerHandle, SessionIdentity, StateQueryOutcome, TcpAoInfoSnapshot, TcpAoRotationGeneration,
 };
@@ -337,16 +338,40 @@ impl PeerManager {
             if let SocketAddr::V6(v6) = peer_addr
                 && v6.ip().segments()[0] & 0xffc0 == 0xfe80
             {
+                self.metrics
+                    .record_inbound_connection_drop(InboundConnectionDropReason::Unconfigured);
                 warn!(
                     %peer_addr,
                     "inbound IPv6 link-local connection did not match a configured scoped neighbor; dynamic acceptance of link-local peers is not supported, dropping"
                 );
                 return;
             }
+            // ADR-0120: per-source accept-rate limit, after the
+            // unconfigured-source classification but before any
+            // session-spawn work. Static neighbors never reach this
+            // arm, so a flapping configured peer is exempt by path.
+            if self.match_dynamic_range(peer_ip).is_some()
+                && let Some(admission) = self.inbound_admission.as_mut()
+                && !admission.admit(peer_ip)
+            {
+                let suppressed = admission.should_log();
+                self.metrics
+                    .record_inbound_connection_drop(InboundConnectionDropReason::RateLimited);
+                if let Some(suppressed) = suppressed {
+                    warn!(
+                        %peer_ip,
+                        suppressed,
+                        "inbound accept rate exceeded for source aggregate, dropping connection"
+                    );
+                }
+                return;
+            }
             if let Some(range) = self.match_dynamic_range(peer_ip) {
                 // Check dynamic peer limit
                 if self.dynamic_peer_count >= self.dynamic_neighbor_limit as usize {
                     self.metrics.record_dynamic_neighbor_limit_rejection();
+                    self.metrics
+                        .record_inbound_connection_drop(InboundConnectionDropReason::DynamicLimit);
                     warn!(
                         %peer_ip,
                         limit = self.dynamic_neighbor_limit,
@@ -569,6 +594,8 @@ impl PeerManager {
             }
 
             // No dynamic range match either — drop with hint
+            self.metrics
+                .record_inbound_connection_drop(InboundConnectionDropReason::Unconfigured);
             warn!(
                 %peer_ip,
                 hint = %format_args!(

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -31,6 +31,7 @@ use crate::policy_admin::{
     neighbor_policy_chains_from_config,
 };
 
+mod admission;
 mod bfd;
 mod dynamic;
 mod events;
@@ -318,6 +319,10 @@ pub struct PeerManager {
     dynamic_peer_count: usize,
     /// Maximum dynamic peers allowed. Default 100.
     dynamic_neighbor_limit: u32,
+    /// ADR-0120 per-source accept-rate limiter. `None` when
+    /// `[inbound_admission]` is disabled (the default); built once at
+    /// startup — every field is restart-required.
+    inbound_admission: Option<admission::InboundAdmission>,
     /// Dead-lettered hot-apply / Route Refresh / `GShut` intent from dynamic
     /// peers auto-removed by `BackToIdle`. Restored on the next inbound
     /// from the same address. Bounded at `dynamic_neighbor_limit` so a
@@ -464,6 +469,7 @@ impl PeerManager {
                 bfd_profiles: Vec::new(),
                 apply_bum_enforcement: false,
                 event_history: crate::config::EventHistoryConfig::default(),
+                inbound_admission: crate::config::InboundAdmissionConfig::default(),
             },
         )
     }
@@ -609,6 +615,9 @@ impl PeerManager {
             dynamic_ranges: Self::parse_dynamic_ranges(&current_config),
             dynamic_peer_count: 0,
             dynamic_neighbor_limit: current_config.effective_dynamic_neighbor_limit(),
+            inbound_admission: admission::InboundAdmission::from_config(
+                &current_config.inbound_admission,
+            ),
             dead_lettered_pending: HashMap::new(),
             dead_lettered_pending_order: VecDeque::new(),
             next_session_id: 1,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -453,6 +453,7 @@ fn make_dynamic_manager_config() -> Config {
         bfd_profiles: Vec::new(),
         apply_bum_enforcement: false,
         event_history: crate::config::EventHistoryConfig::default(),
+        inbound_admission: crate::config::InboundAdmissionConfig::default(),
     };
     assert_tier_authorized_test_config(&config);
     config
@@ -7215,6 +7216,25 @@ fn assert_dynamic_neighbor_capacity(
         ),
         (Some(used), Some(limit), Some(headroom), Some(rejections))
     );
+}
+
+/// `None` when the reason's series does not exist yet — a reason never
+/// recorded has no child, so `None` doubles as "never dropped".
+fn inbound_drop_metric(metrics: &BgpMetrics, reason: &str) -> Option<f64> {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == "bgp_inbound_connections_dropped_total")
+        .and_then(|family| {
+            family.get_metric().iter().find_map(|metric| {
+                metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "reason" && label.value() == reason)
+                    .then(|| metric.get_counter().value())
+            })
+        })
 }
 
 fn peer_identity_gauge(
@@ -17824,11 +17844,213 @@ async fn saturated_dynamic_neighbor_accept_counts_rejection_without_consuming_ca
         .await;
 
     assert_dynamic_neighbor_capacity(&metrics_view, 1.0, 1.0, 0.0, 1.0);
+    assert_eq!(
+        inbound_drop_metric(&metrics_view, "dynamic_limit"),
+        Some(1.0),
+        "slot saturation must also count under the bounded drop-reason vocabulary"
+    );
     assert_eq!(mgr.dynamic_peer_count, 1);
     assert_eq!(mgr.peers.len(), 1);
     assert!(!mgr.peers.contains_key(&key(rejected_addr)));
     drop(first_client);
     drop(rejected_client);
+}
+
+async fn localhost_inbound_stream() -> (TcpStream, TcpStream) {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let listener_addr = listener.local_addr().unwrap();
+    let client = tokio::spawn(async move { TcpStream::connect(listener_addr).await.unwrap() });
+    let (server_stream, _) = listener.accept().await.unwrap();
+    let client_stream = client.await.unwrap();
+    (server_stream, client_stream)
+}
+
+/// Load-bearing unconfigured-source accounting proof (ADR-0120): the
+/// pre-existing unmatched-source drop must count under the bounded
+/// drop-reason vocabulary even with the limiter disabled (the default).
+#[tokio::test]
+async fn unmatched_inbound_source_counts_unconfigured_drop() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let metrics_view = metrics.clone();
+    let mut config = make_dynamic_manager_config();
+    config.dynamic_neighbors.clear();
+    let mut mgr = PeerManager::new_with_config(
+        rx,
+        mpsc::unbounded_channel().1,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+        None,
+        config,
+    );
+
+    let (server_stream, client_stream) = localhost_inbound_stream().await;
+    mgr.handle_inbound(
+        server_stream,
+        sock(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7))),
+        None,
+        None,
+    )
+    .await;
+
+    assert!(mgr.peers.is_empty());
+    assert_eq!(
+        inbound_drop_metric(&metrics_view, "unconfigured"),
+        Some(1.0)
+    );
+    drop(client_stream);
+}
+
+/// ADR-0120 default-off invariant: without `[inbound_admission]`, rapid
+/// re-accept churn from one dynamic source behaves exactly as before —
+/// every cycle is admitted and nothing is rate-limited.
+#[tokio::test]
+async fn inbound_admission_disabled_by_default_admits_rapid_dynamic_reaccepts() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let metrics_view = metrics.clone();
+    let mut mgr = PeerManager::new_with_config(
+        rx,
+        mpsc::unbounded_channel().1,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+        None,
+        make_dynamic_manager_config(),
+    );
+
+    let churny = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 9));
+    let mut client_streams = Vec::new();
+    for cycle in 0..3 {
+        let (server_stream, client_stream) = localhost_inbound_stream().await;
+        client_streams.push(client_stream);
+        mgr.handle_inbound(server_stream, sock(churny), None, None)
+            .await;
+        assert!(
+            mgr.peers.contains_key(&key(churny)),
+            "cycle {cycle}: default config must admit every re-accept"
+        );
+        let session_id = mgr.peers.get(&key(churny)).unwrap().session_id;
+        mgr.handle_session_notification(SessionNotification::BackToIdle {
+            session_id,
+            role: rustbgpd_transport::SessionRole::Primary,
+            peer_addr: churny,
+        })
+        .await;
+        assert!(
+            mgr.peers.is_empty(),
+            "cycle {cycle}: peer should be removed"
+        );
+    }
+    assert_eq!(inbound_drop_metric(&metrics_view, "rate_limited"), None);
+    drop(client_streams);
+}
+
+/// Load-bearing ADR-0120 enforcement proof: with `[inbound_admission]`
+/// enabled at burst 1, a dynamic source's re-accept inside the same v4
+/// aggregate is dropped before session spawn and counted, while a static
+/// neighbor inside the very same aggregate is exempt by admission path.
+#[tokio::test]
+async fn enabled_inbound_admission_rate_limits_dynamic_source_but_exempts_static_neighbor() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let metrics_view = metrics.clone();
+    let mut config = make_dynamic_manager_config();
+    config.inbound_admission = crate::config::InboundAdmissionConfig {
+        enabled: true,
+        rate_per_minute: 1,
+        burst: 1,
+        v4_aggregation_len: 24,
+        v6_aggregation_len: 64,
+        table_capacity: 64,
+    };
+    let mut mgr = PeerManager::new_with_config(
+        rx,
+        mpsc::unbounded_channel().1,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+        None,
+        config,
+    );
+
+    // First accept consumes the aggregate's whole burst.
+    let first_source = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 9));
+    let (server_stream, first_client) = localhost_inbound_stream().await;
+    mgr.handle_inbound(server_stream, sock(first_source), None, None)
+        .await;
+    assert!(
+        mgr.peers.contains_key(&key(first_source)),
+        "the first accept within burst must be admitted"
+    );
+    let session_id = mgr.peers.get(&key(first_source)).unwrap().session_id;
+    mgr.handle_session_notification(SessionNotification::BackToIdle {
+        session_id,
+        role: rustbgpd_transport::SessionRole::Primary,
+        peer_addr: first_source,
+    })
+    .await;
+    assert!(mgr.peers.is_empty());
+
+    // A different host inside the same /24 aggregate shares the empty
+    // bucket: dropped before session spawn, counted, logged.
+    let second_source = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 10));
+    let (server_stream, second_client) = localhost_inbound_stream().await;
+    mgr.handle_inbound(server_stream, sock(second_source), None, None)
+        .await;
+    assert!(
+        mgr.peers.is_empty(),
+        "an over-rate source aggregate must not spawn a session"
+    );
+    assert_eq!(
+        inbound_drop_metric(&metrics_view, "rate_limited"),
+        Some(1.0)
+    );
+    assert_dynamic_neighbor_capacity(&metrics_view, 0.0, 100.0, 100.0, 0.0);
+
+    // A statically configured neighbor inside the very same exhausted
+    // aggregate is exempt: its inbound takes the static path and never
+    // consults the limiter.
+    let static_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 20));
+    insert_test_managed_peer_with_asn(
+        &mut mgr,
+        static_addr,
+        65002,
+        acking_policy_handle(static_addr, SessionState::Established),
+        false,
+    );
+    let (server_stream, static_client) = localhost_inbound_stream().await;
+    mgr.handle_inbound(server_stream, sock(static_addr), None, None)
+        .await;
+    assert!(
+        mgr.peers.contains_key(&key(static_addr)),
+        "static neighbor must survive its inbound untouched"
+    );
+    assert_eq!(
+        inbound_drop_metric(&metrics_view, "rate_limited"),
+        Some(1.0),
+        "the static path must not consult the ADR-0120 limiter"
+    );
+
+    drop(first_client);
+    drop(second_client);
+    drop(static_client);
 }
 
 #[tokio::test]

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -1527,6 +1527,14 @@ pub(crate) async fn reload_config_with_tcp_ao(
         );
         new_config.event_history = current.event_history.clone();
     }
+    if new_config.inbound_admission != current.inbound_admission {
+        error!(
+            "[inbound_admission] changed — the ADR-0120 accept-path limiter is \
+             built once at startup. Restart rustbgpd to apply; inbound admission \
+             keeps its startup configuration until then."
+        );
+        new_config.inbound_admission = current.inbound_admission.clone();
+    }
     if new_config.managed_netdevs != current.managed_netdevs {
         error!(
             "[managed_netdevs] changed — the ADR-0091 managed-netdev lifecycle \
@@ -6109,6 +6117,39 @@ hold_time = 90
         assert!(
             returned.desired.event_history.enabled,
             "desired TOML must preserve the operator's edit for restart"
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_pins_inbound_admission_edits_to_startup_snapshot() {
+        // ADR-0120: every [inbound_admission] field is restart-required
+        // (the accept-path limiter is built once at startup). A SIGHUP
+        // must pin the runtime snapshot back to the startup admission
+        // config — but keep the operator's edit in the desired TOML.
+        let initial = baseline_toml();
+        let new_toml = format!(
+            "{}\n[inbound_admission]\nenabled = true\nrate_per_minute = 6\n",
+            baseline_toml()
+        );
+
+        let (returned, tags) = drive_reload(initial, &new_toml).await;
+        let returned = returned.expect("reload should return pinned runtime config");
+
+        assert!(
+            tags.is_empty(),
+            "inbound-admission-only edits are restart-required and must not reconcile peers: {tags:?}"
+        );
+        assert!(
+            !returned.inbound_admission.enabled,
+            "runtime snapshot must keep the startup (disabled) admission config"
+        );
+        assert!(
+            returned.desired.inbound_admission.enabled,
+            "desired TOML must preserve the operator's edit for restart"
+        );
+        assert_eq!(
+            returned.desired.inbound_admission.rate_per_minute, 6,
+            "desired TOML must carry the edited rate"
         );
     }
 


### PR DESCRIPTION
## Summary

Implements the per-source inbound connection admission control that SECURITY.md
previously (and falsely) claimed existed, together with ADR-0120 documenting
every design axis. Opt-in, default off: an existing deployment's accept
behavior is byte-identical across the upgrade.

## ADR-0120 design axes (docs/adr/0120-inbound-connection-admission.md)

- **Identity** — per-source accounting keyed by aggregated address: /32 for
  IPv4, /64 for IPv6 by default (per-/128 is trivially evadable inside one
  on-link allocation); both lengths configurable.
- **Scope** — token bucket applied to sources that match a
  `[[dynamic_neighbors]]` range, after the existing unconfigured-source drop
  and before any session-spawn work. Statically configured neighbors are
  exempt by admission path: a flapping legitimate peer must never lock itself
  out of re-establishment, and the static path already bounds its own work.
- **Accounting** — fixed-capacity LRU table (default 4096 aggregates, bounds
  64-65536) owned by the single-task accept-path actor. No locks, bounded
  memory regardless of offered load.
- **Behavior on limit** — immediate drop after accept; no tarpit, accept loop
  stays non-blocking.
- **Observability** — new bounded-cardinality counter
  `bgp_inbound_connections_dropped_total{reason="unconfigured"|"rate_limited"|"dynamic_limit"}`;
  no per-source labels. The `unconfigured` and `dynamic_limit` sites are
  accounted even while the limiter is disabled;
  `bgp_dynamic_neighbor_limit_rejections_total` keeps incrementing for
  dashboard compatibility. The rate-limit warn line is itself throttled to
  one per second with a suppressed-count.
- **Defaults / reload** — `[inbound_admission]` is off by default and
  restart-required in full: SIGHUP pins the runtime snapshot back to the
  startup table with an `ERROR` log (same machinery as `[event_history]`),
  the edit survives in the desired config, and the drift is visible in
  `rustbgpd --diff` text + JSON and the v1 transaction classifier.

## Config

```toml
[inbound_admission]
enabled = false          # default
rate_per_minute = 12     # > 0 when enabled
burst = 5                # > 0 when enabled
v4_aggregation_len = 32  # 8..=32
v6_aggregation_len = 64  # 16..=128
table_capacity = 4096    # 64..=65536, LRU-evicted
```

Bounds validated when enabled. The new root is classified `alpha` in the v1
stable-surface inventory (nothing promoted to stable);
`docs/rustbgpd.schema.json` regenerated.

## Red-proof evidence

Behavioral tests were written first and run once against the tree with the
config schema, limiter module, and metrics present but **no enforcement wired
and no reload pin** — every load-bearing claim failed exactly at its
assertion, and the default-off invariant passed:

```text
test peer_manager::tests::inbound_admission_disabled_by_default_admits_rapid_dynamic_reaccepts ... ok
test peer_manager::tests::enabled_inbound_admission_rate_limits_dynamic_source_but_exempts_static_neighbor ... FAILED
test reload::tests::reload_pins_inbound_admission_edits_to_startup_snapshot ... FAILED
test peer_manager::tests::saturated_dynamic_neighbor_accept_counts_rejection_without_consuming_capacity ... FAILED
test peer_manager::tests::unmatched_inbound_source_counts_unconfigured_drop ... FAILED

---- enabled_inbound_admission_rate_limits_dynamic_source_but_exempts_static_neighbor ----
panicked: an over-rate source aggregate must not spawn a session
---- reload_pins_inbound_admission_edits_to_startup_snapshot ----
panicked: runtime snapshot must keep the startup (disabled) admission config
---- saturated_dynamic_neighbor_accept_counts_rejection_without_consuming_capacity ----
panicked: slot saturation must also count under the bounded drop-reason vocabulary (left: 0.0, right: 1.0)
---- unmatched_inbound_source_counts_unconfigured_drop ----
panicked: left: 0.0, right: 1.0
```

All pass after the enforcement + pin landed. Additional coverage: token-bucket
refill/burst-cap unit tests, /64-shared-bucket aggregation keying, LRU table
capacity bound (never exceeds capacity across 4x churn), log throttling,
config bounds rejection, and `--diff` restart-required classification.

## Tests proving the deliverable claims

- (a) disabled by default = behavior unchanged:
  `inbound_admission_disabled_by_default_admits_rapid_dynamic_reaccepts`
  (three immediate re-accept cycles all admitted, no `rate_limited` series).
- (b) enabled: `enabled_inbound_admission_rate_limits_dynamic_source_but_exempts_static_neighbor`
  — an over-rate source in an exhausted /24 aggregate is dropped and counted
  while a static neighbor inside the same aggregate is accepted untouched.
- (c) bounded memory: `admission::tests::table_never_exceeds_capacity_and_evicts_lru`.
- Reload: `reload_pins_inbound_admission_edits_to_startup_snapshot` proves a
  SIGHUP edit is pinned + logged, not silently applied;
  `diff_config_flags_inbound_admission_as_restart_required` pins the `--diff`
  surface.

## Docs

- SECURITY.md "Inbound Connection Handling" now describes the shipped limiter
  (present tense, only what exists).
- docs/CONFIGURATION.md `[inbound_admission]` reference section.
- docs/OPERATIONS.md metric row + reason vocabulary.
- docs/reload-matrix.md `[inbound_admission]` section (all restart-required).
- CHANGELOG.md Unreleased/Added entry.

## Gates

- `cargo fmt --all -- --check` = 0
- `cargo clippy --workspace --all-targets -- -D warnings` = 0
- `cargo test --workspace --no-fail-fast` = 0
- `cargo doc --workspace --no-deps` = 0
- `python3 scripts/check-clippy-reasons.py` = 0
- `python3 scripts/check-v1-stable-surface.py` = 0
