### PR TITLE
Pre-stage soak-window readiness: gates, preflight, receipt template, rehearsal fixes

### DIFF
--- a/docs/soaks/soak-acceptance-gates.md
+++ b/docs/soaks/soak-acceptance-gates.md
@@ -79,7 +79,8 @@ green slope would not be clean evidence.
 ### 1. GR-restart intern-gc — `run-soak-gr-restart-intern-gc.sh`
 
 Injection: repeated peer daemon restart (`killall -9 bgpd` in the FRR
-container; watchfrr restarts it — never `frrinit.sh stop`, which kills
+container; watchfrr restarts it, harness-supervised past watchfrr's
+restart-abandon threshold — never `frrinit.sh stop`, which kills
 the container's PID 1 and destroys the clab veth) driving rustbgpd
 through session-down → stale-mark → reconnect → EoR → stale-clear →
 intern GC. Analyzer: `analyze-soak-gr-restart.py`.
@@ -211,7 +212,7 @@ scripts), mapped to the daemon guarantee it tests.
 
 | Injection | Mechanism | Scenario(s) | Guarantee under test |
 |-----------|-----------|-------------|----------------------|
-| Peer daemon restart (session loss + GR) | `killall -9 bgpd` in FRR container (watchfrr restarts it) | 1 | GR state machine: stale-mark, EoR, stale-clear, intern GC; bounded re-establish |
+| Peer daemon restart (session loss + GR) | `killall -9 bgpd` in FRR container (watchfrr restarts it, harness-supervised) | 1 | GR state machine: stale-mark, EoR, stale-clear, intern GC; bounded re-establish |
 | Transactional config churn | `rbgp config plan`/`apply` cycles | 2 | Live-apply atomicity; zero session impact; no candidate-world leak |
 | Controller route churn | gRPC AddPath/DeletePath | 3 | Injection path RIB + intern stability; exact announce/withdraw delivery |
 | Route churn at scale (50 k) | tester bulk advertise + sustained churn | 4 | RIB/intern/label-set stability at scale |

--- a/docs/soaks/soak-acceptance-gates.md
+++ b/docs/soaks/soak-acceptance-gates.md
@@ -68,6 +68,14 @@ plateaus of 20–30 MB with slopes ≤ 0.2 MB/h on clean builds), so the
 1.0 MB/h fail line has an order-of-magnitude margin over observed-clean
 while still catching a ~25 MB/day leak.
 
+The slope gates are precommitted for windows of **24 h or longer**. On
+sub-hour smokes and rehearsals the allocator's settle dominates the
+regression and overshoots the hourly bound (the archived 24 h receipts
+show cumulative slope monotonically tightening from > 1 MB/h at hour 2
+to < 0.2 MB/h at terminal); a short run's red slope gate is a
+small-window artifact, not leak evidence — exactly as a short run's
+green slope would not be clean evidence.
+
 ### 1. GR-restart intern-gc — `run-soak-gr-restart-intern-gc.sh`
 
 Injection: repeated peer daemon restart (`killall -9 bgpd` in the FRR

--- a/docs/soaks/soak-acceptance-gates.md
+++ b/docs/soaks/soak-acceptance-gates.md
@@ -1,0 +1,248 @@
+# Soak Acceptance Gates (precommitted)
+
+Precommitted pass/fail criteria for every soak scenario shipped in
+`tests/soak/`. This document is written **before** a soak window opens;
+a soak receipt quotes the bounds from here (at the receipt's git SHA)
+and publishes measured-vs-precommitted for every gate — **including
+when the verdict is red**. A receipt whose gates were chosen after the
+run is not evidence.
+
+Three standing rules govern every gate in this file:
+
+1. **Gates are precommitted.** The bound, the metric evidencing it, and
+   the abort criteria are fixed here before anything runs. Receipts may
+   publish red; they may not renegotiate bounds.
+2. **A gate's metric must refresh on every scenario path.** Each gate
+   below names the exact metric / CSV column / log that evidences it
+   *and* the scenario action that moves it. A gate on a metric its
+   scenario never updates is a false green. Metric names below are
+   verified against `crates/telemetry/src/metrics.rs` at the time of
+   writing; re-verify on rebase (the per-peer intern gauge was replaced
+   by the daemon-wide `bgp_rib_attr_intern_global_size` long ago —
+   never cite a dead metric).
+3. **Abort criteria preserve evidence.** An aborted soak is a data
+   point, not a discard. See "Abort criteria" below.
+
+Enforced bounds live in the analyzers
+(`tests/soak/analyze-soak-*.py`, `tests/soak/analyze-*.py`); this
+document adds the window-level floors and the evidence mapping. Where
+a bound is chosen here rather than inherited from an analyzer, the
+rationale is stated inline.
+
+## Abort criteria (all scenarios)
+
+A soak stops early — and the run is recorded as **aborted**, never
+silently rerun — when any of the following occurs:
+
+| Abort trigger | Detection |
+|---------------|-----------|
+| Daemon process restart mid-soak | Counter monotonicity break (e.g. `bgp_messages_sent_total` decreases between samples), or the harness's own restart detection. A restart flattens the slope regression and would hide a leak, so the run is invalid as a *pass* but preserved as evidence of the crash. |
+| Harness step fails closed | The runners are `set -euo pipefail` and (since the fail-closed hardening) exit non-zero when required evidence is missing (e.g. GR active/stale not observed, apply cycle fails, injection RPC errors). |
+| Metrics endpoint unreachable for > 5 consecutive samples | `curl` scrape failures in the sampler — a blind sampler cannot certify anything. |
+| Host disk < 5 GB free | Daemon logs grow multi-GB over multi-day windows; running the disk to zero corrupts the evidence it was collecting. |
+| Competing workload appears | Host-lock contention, an unexpected clab topology, or a bench dispatch. The bench/soak `flock` mutex makes this structural, but a manual discovery also aborts. |
+
+**On abort, evidence is preserved, in this order:**
+
+1. Leave the topology **up**. Copy daemon logs out of every container
+   (`docker cp` / `docker logs`) into the run directory *before* any
+   `containerlab destroy`.
+2. Keep the entire `tests/soak/runs/<run-id>/` directory. `samples.csv`
+   is written incrementally, so the partial series survives.
+3. Run the scenario's analyzer over the partial CSV and record its
+   verdict (`fail` is expected and fine).
+4. Fill a receipt from `docs/soaks/soak-receipt-template.md` with the
+   abort record section completed (trigger, UTC time, elapsed, artifacts
+   preserved).
+
+Do not stitch a resumed run onto an aborted CSV — the analyzer slope
+regression would silently re-introduce a warmup window mid-series.
+Rerun from scratch.
+
+## Primary multi-day scenarios
+
+The three fail-closed harnesses below are the pre-designed
+failure-injecting set for multi-day windows. Analyzer bounds were
+calibrated on the archived 24 h receipts under `docs/soaks/` (RSS
+plateaus of 20–30 MB with slopes ≤ 0.2 MB/h on clean builds), so the
+1.0 MB/h fail line has an order-of-magnitude margin over observed-clean
+while still catching a ~25 MB/day leak.
+
+### 1. GR-restart intern-gc — `run-soak-gr-restart-intern-gc.sh`
+
+Injection: repeated peer daemon restart (`killall -9 bgpd` in the FRR
+container; watchfrr restarts it — never `frrinit.sh stop`, which kills
+the container's PID 1 and destroys the clab veth) driving rustbgpd
+through session-down → stale-mark → reconnect → EoR → stale-clear →
+intern GC. Analyzer: `analyze-soak-gr-restart.py`.
+
+| Gate | Precommitted bound | Evidence | Refreshes under scenario via |
+|------|--------------------|----------|------------------------------|
+| Intern-table slope | < 1.0 entries/h | `bgp_rib_attr_intern_global_size` gauge → CSV `intern_size` | Re-announce after every peer restart re-interns attributes; `gc_intern_table` reclaims after stale-clear. The sampler also fires inside the restart routine at the GR-active and post-clear points, so the column moves every cycle. |
+| RSS slope (post-warmup) | < 1.0 MB/h | `/proc/<pid>/status` VmRSS → CSV `rss_mb` | Allocation churn on every restart/re-announce cycle. |
+| Peak RSS | < 512 MB | CSV `rss_mb` max | Same. |
+| Restart cycles completed | ≥ 0.8 × (duration ÷ `RESTART_INTERVAL_SEC`) | CSV `restart_cycles` max | Incremented by the harness on every completed cycle. Analyzer floor is ≥ 1; the window floor (chosen here) rejects a run that silently stalled mid-window. 0.8× rather than 1.0× because per-cycle work (GR polling + re-establish, ~15–45 s) rides on top of the interval — a 72 h run at the 300 s default must show ≥ 691 cycles. |
+| GR evidence ordered | positive `gr_active`+`stale` observed, then both clear, every cycle | `bgp_gr_active_peers`, `bgp_gr_stale_routes` → CSV columns | Set by GR entry on peer death; cleared by EoR + stale-clear. Harness fails closed mid-run if either phase is not observed within 30 s. |
+| Session recovered at end | Established in final samples | FRR `show bgp neighbors` → CSV `bgp_established` | Every restart flips it 1→0→1. |
+| Re-establish latency | ≤ 60 s after peer returns | harness `wait_established 60` (fail-closed), `cycles.log` | Checked every cycle. |
+| Zero crash | no daemon restart | `bgp_messages_sent_total` monotone across samples (abort criterion) | Counter advances with every keepalive/update. |
+
+### 2. Hot-reload (config live-apply churn) — `run-soak-hot-reload.sh`
+
+Injection: transactional config churn — `rbgp config plan` →
+`config apply` with a mutated candidate every `APPLY_INTERVAL_SEC`.
+Analyzer: `analyze-soak-hot-reload.py`.
+
+| Gate | Precommitted bound | Evidence | Refreshes under scenario via |
+|------|--------------------|----------|------------------------------|
+| Intern-table slope | < 1.0 entries/h | `bgp_rib_attr_intern_global_size` → CSV `intern_size` | Config-apply rebuild paths touch attribute interning; the gauge is sampled every 30 s regardless. |
+| RSS slope (post-warmup) | < 1.0 MB/h | VmRSS → CSV `rss_mb` | Every plan/apply allocates a candidate world. |
+| Peak RSS | < 512 MB | CSV `rss_mb` max | Same. |
+| Apply accounting exact | cycles == ok + fail, fail == 0, ok ≥ 1 | CSV `apply_cycles`, `apply_ok`, `apply_fail` | Incremented per apply attempt; a swallowed failure breaks the equality (fail-closed). |
+| Apply cycles completed | ≥ 0.9 × (duration ÷ `APPLY_INTERVAL_SEC`) | CSV `apply_cycles` | Window floor, same stall rationale as scenario 1; 0.9× (tighter than scenario 1) because an apply cycle is seconds of work against a 120 s interval. |
+| Session-flap budget | flap delta == 0 across the whole run | `rbgp neighbor -j` `flap_count` → CSV `flap_count` (backed by `bgp_session_flaps_total`) | Sampled every interval; a live-apply that bounces the session moves it immediately. |
+| Session uptime | nondecreasing | CSV `uptime_seconds` | Resets on any reconnect — catches a flap that lands between flap-count samples. |
+| Session established at end | yes | CSV `bgp_established` | Scraped from FRR every sample. |
+
+### 3. Inject-churn (gRPC route injection) — `run-soak-inject-churn.sh`
+
+Injection: sustained `InjectionService` AddPath/DeletePath churn
+(`rbgp rib add`/`delete`), bounded rotating prefix pool. Analyzer:
+`analyze-soak-inject-churn.py`.
+
+| Gate | Precommitted bound | Evidence | Refreshes under scenario via |
+|------|--------------------|----------|------------------------------|
+| Intern-table slope | < 1.0 entries/h | `bgp_rib_attr_intern_global_size` → CSV `intern_size` | Every injected path interns an attribute set; deletes release. |
+| RSS slope (post-warmup) | < 1.0 MB/h | VmRSS → CSV `rss_mb` | Continuous add/delete allocation churn. |
+| Peak RSS | < 512 MB | CSV `rss_mb` max | Same. |
+| Churn cycles completed | ≥ 0.5 × ((duration − warmup) ÷ `CHURN_INTERVAL_SEC`) | CSV `churn_cycles` | Window floor. 0.5× of nominal because each batch is 2 × `CHURN_BATCH` sequential `docker exec` RPCs whose wall time rides on top of the 5 s interval; the receipt must state the achieved cadence. At defaults a 72 h run must show ≥ 25 908 cycles. |
+| Final consumer convergence | FRR route count == live target, exactly, within 30 s of churn end | FRR `show bgp ipv4 unicast` → CSV `frr_route_count` vs `live_target` | The consumer count tracks every add/delete batch; an off-by-anything at terminal means a lost announce or withdraw. |
+| Session-flap budget | flap delta == 0 | CSV `flap_count` / `uptime_seconds` (as scenario 2) | Sampled every interval. |
+| Session established at end | yes | CSV `bgp_established` | Every sample. |
+| Injection RPC failures | 0 (fail-closed) | harness exit path + `churn.log` | Every `rbgp rib` call is checked; a failed RPC aborts the run. |
+
+## Additional shipped scenarios
+
+These harnesses are part of the suite and can anchor a multi-day window
+when their subsystem is in scope. Bounds are the analyzer / README
+values; window floors follow the same 0.9× rule as above.
+
+### 4. M33 EVPN scale — `run-m33-soak.sh` (`analyze-soak.py`)
+
+50 k EVPN Type 2 routes + continuous tester churn. Gates: RSS slope
+< 1.0 MB/h fail / < 0.5 clean; peak RSS < 512 MB; session-flap delta
+== 0 (flap/drop counters in `samples.csv`); outbound route-drop delta
+== 0; zero gRPC health failures; healthy at end; restart detection via
+counter monotonicity (`bgp_messages_sent_total`). Abort: two
+consecutive gRPC health-check failures.
+
+### 5. M37 local-origination MAC churn — `run-m37-local-origination-churn-soak.sh`
+
+Bounded bridge-FDB churn against the local-MAC origination pipeline.
+Precedent: the 2026-05-18 24 h PASS (`soak-m37-local-origination-churn-24h.md`,
+slope 0.184 MB/h, ledger 430 400 == 430 400). Gates: session
+Established outside deliberate windows; `local_fdb_count` /
+`frr_type2_count` hold at the live target and drain to 0 at terminal;
+`evpn_local_originations_total{action="inject"}` ==
+`{action="withdraw"}` at terminal (ledger balance);
+`evpn_local_origination_errors_total` == 0;
+`evpn_local_observations_dropped_total` == 0;
+`evpn_duplicate_mac_moves_total` == 0 unless deliberately injected;
+post-warmup RSS slope < 1.0 MB/h (precedent says expect ≲ 0.2).
+
+### 6. M67 link-drain churn — `run-m67-link-drain-churn-soak.sh` (`analyze-m67-link-drain-soak.py`)
+
+Repeated real carrier down/up on the active PE's attachment circuit.
+Gates (analyzer defaults): verdict `pass`; per-node RSS slope
+< 1.5 MB/h once past `--min-slope-seconds` (1800 s); peak RSS
+< 512 MB; measured failover blackout ≤ 30 000 ms and drain release
+≤ 30 000 ms per cycle (a `-1` unmeasured sentinel fails the cycle —
+a missing prober log can never read as a perfect 0 ms failover);
+cycle count ≥ floor; session transients ≤ 2 samples; docker restart
+counters flat; `pe1_operator_drain` stays 0 (the link stimulus must
+not leak into the operator-drain reason).
+
+### 7. Gate 8b BUM-state — `run-gate8b-soak.sh` (`analyze-gate8b-soak.py`)
+
+DF flips via in-container daemon process restart (SIGTERM; opt-in
+SIGKILL via `KILL_MODE=kill`). Gates: per-PE RSS slope < 1.5 MB/h;
+peak RSS < 512 MB; DF transition counters (`evpn_df_role_changes_total`)
+monotone — a reset means an unplanned daemon restart; ≥ 1 full flip
+cycle (window floor 0.9× applies); `verify_topology_link` passes before
+and after every flip (fail-loud exit 4 — the tripwire for the
+veth-destroyed false positive documented in the README).
+
+### 8. Gate 8b MAC-churn — `run-gate8b-mac-churn-soak.sh`
+
+Scenario 7 plus sustained FDB churn and RFC 7432 §15.1 mobility moves.
+Analyzer coverage is scenario 7's (`analyze-gate8b-soak.py`); the
+MAC-churn-specific gates are precommitted here and read from
+`samples.csv`: `evpn_local_origination_errors_total` == 0 (CSV
+`pe*_local_orig_errors`); observation drops == 0 (`pe*_local_obs_drops`);
+receiver `extern_learn` FDB count stable around the pool target
+(`pe*_fdb_extern_learn`); duplicate-MAC moves advance **only** with
+harness mobility batches (`pe*_dup_mac_moves` vs `churn_moves_total`);
+drift-recovery counters bounded and `pe*_drift_disabled` == 0.
+Known gap: these are manual-inspection gates until a dedicated
+analyzer exists — a receipt must include the inspection outcome per
+gate, not just the base analyzer verdict.
+
+### 9. Gate 9 slice 6 symmetric IRB — `run-gate9-slice6-soak.sh`
+
+Tenant Type 5 add/del churn. Gates (README): per-PE RSS slope
+< 1.0 MB/h; peak RSS < 400 MB; `bgp_established == 1` on every
+post-warmup sample (flap budget 0); `pe1_installed_routes == 1` on
+every post-warmup sample; `tenant_present` ↔ `pe1_observed_routes`
+agree within one sample interval (wake-path latency ceiling);
+`churn_cycles` strictly monotone.
+
+## Failure-injection inventory
+
+What each scenario actually injects (inventoried from the harness
+scripts), mapped to the daemon guarantee it tests.
+
+| Injection | Mechanism | Scenario(s) | Guarantee under test |
+|-----------|-----------|-------------|----------------------|
+| Peer daemon restart (session loss + GR) | `killall -9 bgpd` in FRR container (watchfrr restarts it) | 1 | GR state machine: stale-mark, EoR, stale-clear, intern GC; bounded re-establish |
+| Transactional config churn | `rbgp config plan`/`apply` cycles | 2 | Live-apply atomicity; zero session impact; no candidate-world leak |
+| Controller route churn | gRPC AddPath/DeletePath | 3 | Injection path RIB + intern stability; exact announce/withdraw delivery |
+| Route churn at scale (50 k) | tester bulk advertise + sustained churn | 4 | RIB/intern/label-set stability at scale |
+| Kernel FDB churn (learn/age) | `bridge fdb add/del` | 5, 8 | Local-MAC observation → Type 2 ledger balance; retained-state plateau |
+| Daemon process restart (orderly) | `pkill -TERM rustbgpd` in-container | 7, 8 | DF re-election, BUM-enforcement re-init, kernel-state reconcile after restart |
+| Daemon crash (SIGKILL) | `KILL_MODE=kill` | 7, 8 (opt-in, non-default) | Same as above minus the orderly-drain mask |
+| MAC mobility move | same MAC deleted on src PE, added on dst PE | 8 | RFC 7432 §15.1 sequence ratchet under concurrent ESI churn |
+| Link carrier down/up | AC interface down/up | 6 | ES drain trigger, DF failover, recovery hold-off, bounded blackout |
+| Tenant route add/del | `ip addr add/del` in VRF | 9 | L3 owned-state transactionality; route-wake path |
+
+### Coverage gaps — guarantees with NO soak injection
+
+Listed explicitly so a window plan cannot mistake absence of red for
+coverage:
+
+1. **Daemon SIGKILL on the plain BGP/RR path.** Crash-style kills are
+   exercised only inside the EVPN Gate 8b harness (and only when
+   `KILL_MODE=kill` is set). Scenarios 1–3 never kill rustbgpd itself —
+   the GR soak restarts the *peer*. Crash-recovery of the core BGP
+   daemon (durable commit-confirm boot-revert included) has test
+   coverage but no soak-duration injection.
+2. **SIGHUP file-reload path.** The daemon handles SIGHUP
+   (`src/main.rs`), but the hot-reload soak drives only the gRPC
+   transactional apply. The signal-driven reload path is unsoaked.
+3. **Listener kill.** No scenario kills or wedges the gRPC listener or
+   the Prometheus exporter mid-soak; listener-death behavior (audit
+   continuity, reconnect handling) is untested at duration.
+4. **RTR / RPKI cache withdrawal.** No soak exercises the rpki path at
+   all — cache restart, serial desync, or mass VRP withdrawal under
+   load are uncovered.
+5. **Rapid peer flap storm.** The fastest failure cadence in the suite
+   is one event per 90 s (scenario 6). Sub-minute repeated flaps
+   (damping/pending-delete pressure) have bench coverage but no soak.
+6. **Prefix-limit trip and timed restart.** No soak drives a peer over
+   a configured max-prefix bound and through the timed-restart cycle.
+7. **Transport-level disturbance.** No packet loss / latency / MTU
+   churn (netem) injection anywhere in the suite.
+8. **BMP / BFD subsystems.** No soak establishes a BMP station or BFD
+   sessions; their long-run stability is uncovered.
+
+A gap being listed here is not a commitment to close it — it is the
+boundary of what a receipt from this suite can honestly claim.

--- a/docs/soaks/soak-receipt-template.md
+++ b/docs/soaks/soak-receipt-template.md
@@ -1,0 +1,98 @@
+# Soak Receipt — <scenario name> <duration>
+
+Copy this template for every soak run — **pass, fail, or aborted**. A
+red receipt is published with the same completeness as a green one.
+Gates and bounds come from `docs/soaks/soak-acceptance-gates.md` at the
+run's git SHA; they are quoted here, never invented here.
+
+Host-shape rule: CPU model, core count, and RAM only. Never hostnames,
+usernames, home paths, or network names — scrub them from any pasted
+command output.
+
+**Status:** <In progress | Complete — verdict: **PASS** | Complete —
+verdict: **FAIL** | **ABORTED**>
+**Run ID:** `tests/soak/runs/<run-dir-name>`
+**Daemon version:** <vX.Y.Z or "unreleased"> at git SHA `<sha>`
+(image `rustbgpd:dev` built from this SHA: <yes/no — if no, state the
+image's SHA>)
+**Scenario config hash:** `<sha256 of run.json>` (pins duration,
+cadence, pool sizes, topology, and container names as executed)
+**Date:** <start UTC> → <end UTC> (<actual duration>)
+
+## Verdict
+
+**<PASS | FAIL | ABORTED>.** <One paragraph: the headline numbers and,
+for FAIL/ABORTED, the failed gate(s) or abort trigger in plain words.>
+
+## Run shape
+
+| Field | Value |
+|-------|-------|
+| Scenario | <name + one-line description> |
+| Harness | `tests/soak/<runner>.sh` |
+| Analyzer | `tests/soak/<analyzer>.py` |
+| Topology | `tests/soak/<topology>.clab.yml` |
+| Host shape | <CPU model>, <N> cores, <M> GB RAM |
+| Duration | target <T> s, actual <T'> s |
+| Sample interval | <N> s |
+| Injection cadence | <e.g. peer restart every 300 s> |
+| Warmup excluded from slopes | <N> s |
+| Total data samples | <N> |
+
+## Injections executed
+
+| Injection | Planned | Executed | Notes |
+|-----------|---------|----------|-------|
+| <e.g. peer daemon restart> | <expected count> | <count from cycles.log / CSV> | <anomalies, or "none"> |
+
+## Gates — measured vs precommitted
+
+One row per gate from the scenario's table in
+`soak-acceptance-gates.md`. No gate may be omitted — a gate that could
+not be measured is a FAIL with the reason stated.
+
+| Gate | Precommitted bound | Measured | Result |
+|------|--------------------|----------|--------|
+| <gate> | <bound> | <value> | **PASS** / **FAIL** |
+
+<N> / <M> gates pass. Analyzer verdict: `<pass|fail>`
+(`verdict.json` / `report.json` archived below).
+
+## Abort record
+
+<Delete this section if the run was not aborted.>
+
+| Field | Value |
+|-------|-------|
+| Trigger | <which abort criterion fired> |
+| UTC time / elapsed | <when> |
+| Evidence preserved | <run dir contents; daemon logs copied before destroy: yes/no> |
+| Partial analyzer verdict | <verdict on the partial CSV> |
+
+## Analysis notes
+
+- <Sample-count accounting; RSS trajectory shape; any single-step
+  anomalies and their disposition; daemon WARN/ERROR log census;
+  host cohabitation events during the window.>
+
+## Artifacts
+
+Repo-archived (small, git-suitable):
+
+| Artifact | Path |
+|----------|------|
+| samples.csv | `docs/artifacts/soak/<run-id>/samples.csv` |
+| run.json | `docs/artifacts/soak/<run-id>/run.json` |
+| verdict/report JSON | `docs/artifacts/soak/<run-id>/<verdict>.json` |
+
+Local-only (too large for git; preserved in the run directory):
+
+| Artifact | Local path | Size |
+|----------|------------|------|
+| <daemon log etc.> | `tests/soak/runs/<run-id>/<file>` | <size> |
+
+## Follow-ups
+
+- [ ] <Actions arising from this run — for a FAIL, the tracked defect;
+      for a PASS, any threshold or harness observations worth folding
+      back into `soak-acceptance-gates.md`.>

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -13,6 +13,16 @@ The shared logic lives in `tests/soak/host-lock.sh`; sourcing it and
 calling `acquire_rustbgpd_host_lock` is a two-line block right after
 log redirection in each runner.
 
+Before opening a soak window, run `bash tests/soak/preflight.sh` —
+it checks tools, competing workloads (including this lock), disk
+headroom, that the daemon builds and the `rustbgpd:dev` image exists,
+and requires explicit operator confirmation of the two manual
+mutexes (bench cron paused; no pushes to main during the window).
+Exit 0 means ready; nonzero prints each failed check as `FAIL:`.
+Precommitted per-scenario acceptance gates and abort criteria live in
+`docs/soaks/soak-acceptance-gates.md`; receipts follow
+`docs/soaks/soak-receipt-template.md`.
+
 **sudo / $HOME trap.** When the soak runs under `sudo`, `$HOME` flips
 to `/root` and the default lock path becomes
 `/root/.local/state/rustbgpd-host.lock` — a different file from the

--- a/tests/soak/configs/frr-bgpd-soak-gr-restart.conf
+++ b/tests/soak/configs/frr-bgpd-soak-gr-restart.conf
@@ -1,0 +1,32 @@
+! Soak variant of frr-bgpd-m16-llgr.conf. The interop original carries
+! a per-neighbor `long-lived-graceful-restart stale-time` line inside
+! the address-family block that FRR 10.3.1 rejects (unknown command).
+! A single restart tolerates the resulting non-zero config-load status,
+! but under the soak's repeated bgpd kills every failed reload
+! escalates watchfrr's restart backoff until bgpd stops coming back
+! inside the harness's re-establish window. This copy drops the
+! invalid line (the valid global stale-time on the `router bgp` level
+! is kept) so watchfrr restarts return 0 and backoff never escalates.
+frr version 10.3.1
+frr defaults traditional
+hostname frr-soak-gr-restart
+log stdout informational
+
+router bgp 65002
+ bgp router-id 10.0.0.2
+ no bgp ebgp-requires-policy
+ bgp graceful-restart
+ bgp graceful-restart restart-time 15
+ bgp long-lived-graceful-restart stale-time 30
+ neighbor 10.0.0.1 remote-as 65001
+ neighbor 10.0.0.1 description rustbgpd-m16-llgr
+ neighbor 10.0.0.1 timers 10 30
+ !
+ address-family ipv4 unicast
+  network 192.168.1.0/24
+  network 192.168.2.0/24
+ exit-address-family
+!
+ip route 192.168.1.0/24 10.0.0.2
+ip route 192.168.2.0/24 10.0.0.2
+!

--- a/tests/soak/preflight.sh
+++ b/tests/soak/preflight.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Soak-window pre-flight. Run once before starting any long soak.
+#
+# Checks, in order:
+#   1. Required tools present.
+#   2. No competing workload: the shared bench/soak host lock is free,
+#      no containerlab process is live, no clab-managed containers are
+#      up, and no rustbgpd process is running on the host itself.
+#   3. Disk headroom on the partition holding tests/soak/runs/.
+#   4. The rustbgpd:dev image exists and the daemon compiles at HEAD.
+#   5. Two manual mutexes confirmed by the operator:
+#        - the nightly bench cron is paused for the soak window
+#        - no pushes to main will land during the soak window
+#      Confirm via CONFIRM_BENCH_CRON_PAUSED=1 and
+#      CONFIRM_NO_MAIN_PUSHES=1, or interactively when run on a TTY.
+#
+# Exit code: 0 = ready. 1 = one or more named failures (each printed
+# as "FAIL: ..."). Failures are collected, not fail-fast, so one run
+# reports everything that needs fixing.
+#
+# Tunables:
+#   SOAK_MIN_DISK_GB   minimum free space required (default 50)
+#   RUSTBGPD_HOST_LOCK lock path (same default as host-lock.sh)
+#   SKIP_BUILD_CHECK=1 skip the cargo compile check (image check stays)
+
+set -uo pipefail
+
+SOAK_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SOAK_SCRIPT_DIR/../.." && pwd)"
+
+SOAK_MIN_DISK_GB="${SOAK_MIN_DISK_GB:-50}"
+HOST_LOCK="${RUSTBGPD_HOST_LOCK:-$HOME/.local/state/rustbgpd-host.lock}"
+
+FAILURES=0
+
+log() {
+    printf '[preflight] %s\n' "$*"
+}
+
+fail() {
+    printf 'FAIL: %s\n' "$*"
+    FAILURES=$((FAILURES + 1))
+}
+
+ok() {
+    printf '  ok: %s\n' "$*"
+}
+
+# --- 1. Required tools ------------------------------------------------
+log "checking required tools"
+for tool in docker containerlab curl jq awk python3 flock git cargo; do
+    if command -v "$tool" >/dev/null 2>&1; then
+        ok "$tool"
+    else
+        fail "required tool '$tool' not in PATH"
+    fi
+done
+
+# --- 2. No competing workload ----------------------------------------
+log "checking for competing workloads"
+
+# The bench/soak host mutex: if held, a bench or another soak is live.
+mkdir -p "$(dirname "$HOST_LOCK")" 2>/dev/null || true
+if exec 9>"$HOST_LOCK" 2>/dev/null; then
+    if flock -n 9; then
+        ok "host lock free ($HOST_LOCK)"
+        flock -u 9
+    else
+        fail "host lock held ($HOST_LOCK) — a bench or soak is already running"
+    fi
+    exec 9>&-
+else
+    fail "cannot open host lock path $HOST_LOCK"
+fi
+
+# PID checks by exact comm — never pgrep -f | head.
+for comm in containerlab rustbgpd; do
+    if pids=$(pgrep -x "$comm"); then
+        fail "live '$comm' process on host (pid(s): ${pids//$'\n'/ })"
+    else
+        ok "no live '$comm' process"
+    fi
+done
+
+# clab-managed containers left over from a previous lab.
+clab_up=$(docker ps --format '{{.Names}}' 2>/dev/null | grep '^clab-' || true)
+if [ -n "$clab_up" ]; then
+    fail "clab containers already running: ${clab_up//$'\n'/ }"
+else
+    ok "no clab containers running"
+fi
+
+# --- 3. Disk headroom -------------------------------------------------
+log "checking disk headroom (need >= ${SOAK_MIN_DISK_GB} GB)"
+avail_gb=$(df -BG --output=avail "$SOAK_SCRIPT_DIR" | tail -1 | tr -dc '0-9')
+if [ -z "$avail_gb" ]; then
+    fail "could not determine free disk space for $SOAK_SCRIPT_DIR"
+elif [ "$avail_gb" -lt "$SOAK_MIN_DISK_GB" ]; then
+    fail "only ${avail_gb} GB free; a multi-day soak writes multi-GB daemon logs"
+else
+    ok "${avail_gb} GB free"
+fi
+
+# --- 4. Daemon builds -------------------------------------------------
+log "checking daemon image and build"
+if docker image inspect rustbgpd:dev >/dev/null 2>&1; then
+    created=$(docker image inspect rustbgpd:dev --format '{{.Created}}')
+    ok "rustbgpd:dev image present (created $created)"
+    head_commit=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)
+    log "  note: verify the image was built from the tip under soak (HEAD is $head_commit)"
+else
+    fail "rustbgpd:dev image missing — run: docker build --target dev -t rustbgpd:dev ."
+fi
+
+if [ "${SKIP_BUILD_CHECK:-0}" = "1" ]; then
+    log "  skipping cargo compile check (SKIP_BUILD_CHECK=1)"
+elif (cd "$REPO_ROOT" && cargo check -q --bin rustbgpd >/dev/null 2>&1); then
+    ok "cargo check --bin rustbgpd"
+else
+    fail "cargo check --bin rustbgpd failed — daemon does not compile at HEAD"
+fi
+
+# --- 5. Manual mutexes (operator confirmations) ----------------------
+log "manual mutexes — these cannot be verified mechanically:"
+log "  (a) the nightly bench cron on this host MUST be paused for the window"
+log "  (b) no pushes to main during the soak window (CI topology collision)"
+
+confirm() {
+    local var_name=$1 prompt=$2 value
+    value="${!var_name:-}"
+    if [ "$value" = "1" ]; then
+        ok "$prompt (confirmed via $var_name=1)"
+        return 0
+    fi
+    if [ -t 0 ]; then
+        printf 'Confirm: %s [y/N] ' "$prompt"
+        read -r reply
+        case "$reply" in
+            y | Y | yes | YES)
+                ok "$prompt (confirmed interactively)"
+                return 0
+                ;;
+        esac
+    fi
+    fail "$prompt — not confirmed (set $var_name=1 or answer y on a TTY)"
+}
+
+confirm CONFIRM_BENCH_CRON_PAUSED "bench-nightly cron is paused for the soak window"
+confirm CONFIRM_NO_MAIN_PUSHES "no pushes to main during the soak window"
+
+# --- verdict ----------------------------------------------------------
+if [ "$FAILURES" -eq 0 ]; then
+    log "READY — all pre-flight checks passed"
+    exit 0
+fi
+log "NOT READY — $FAILURES check(s) failed (listed above as FAIL:)"
+exit 1

--- a/tests/soak/run-soak-gr-restart-intern-gc.sh
+++ b/tests/soak/run-soak-gr-restart-intern-gc.sh
@@ -77,6 +77,30 @@ require_container() {
     fi
 }
 
+daemon_running() {
+    docker exec "$RUSTBGPD" sh -c 'cat /proc/[0-9]*/comm 2>/dev/null' \
+        | grep -qx rustbgpd
+}
+
+# The soak topology launches the container with `cmd: sleep infinity`;
+# start the daemon explicitly. Idempotent so a re-run against a live
+# topology does not double-start it.
+ensure_daemon_running() {
+    if daemon_running; then
+        return 0
+    fi
+    log "rustbgpd not running in $RUSTBGPD; starting"
+    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
+    for _ in $(seq 1 10); do
+        if daemon_running; then
+            return 0
+        fi
+        sleep 1
+    done
+    log "ERROR: rustbgpd failed to start within 10s"
+    return 1
+}
+
 prom_scrape() {
     local ip
     ip=$(docker inspect --format \
@@ -88,9 +112,18 @@ prom_scrape() {
 
 prom_extract_required() {
     local text="$1" metric="$2"
+    # Empty scrape (daemon/exporter unreachable) → nan, which the
+    # analyzer rejects. A successful scrape missing the series → 0:
+    # the GR gauges are lazily registered and legitimately absent
+    # from /metrics until the first GR event, so 0 is their true
+    # value — recording nan there false-reds the whole run.
+    if [ -z "$text" ]; then
+        printf 'nan'
+        return
+    fi
     printf '%s' "$text" | awk -v m="$metric" '
         $0 ~ "^"m"( |\\{)" { print $NF; found=1; exit }
-        END { if (!found) { print "nan" } }
+        END { if (!found) { print 0 } }
     '
 }
 
@@ -134,7 +167,13 @@ wait_established() {
 restart_frr_bgpd() {
     local elapsed=${1:?} cycles=${2:?} active=nan stale=nan prom
     cycle_log "restarting FRR bgpd"
-    docker exec "$FRR" /usr/lib/frr/frrinit.sh stop >/dev/null
+    # Kill only bgpd; watchfrr restarts it. Never use frrinit.sh
+    # stop/start here: it kills the FRR container's PID 1, docker
+    # (restart policy: always) bounces the container, and the clab
+    # veth is destroyed on both sides with no exec re-run — the
+    # topology is unrecoverable after that. Same mechanism as the
+    # M16 interop smoke.
+    docker exec "$FRR" killall -9 bgpd >/dev/null
     for _ in $(seq 1 30); do
         prom=$(prom_scrape) || prom=""
         active=$(prom_extract_required "$prom" bgp_gr_active_peers)
@@ -147,7 +186,7 @@ restart_frr_bgpd() {
     done
     awk "BEGIN {exit !($active > 0 && $stale > 0)}" 2>/dev/null ||
         { log "ERROR: GR active/stale evidence not observed"; return 1; }
-    docker exec "$FRR" /usr/lib/frr/frrinit.sh start >/dev/null
+    # watchfrr restarts bgpd on its own; just wait for re-establish.
     wait_established 60
     for _ in $(seq 1 30); do
         prom=$(prom_scrape) || prom=""
@@ -246,6 +285,7 @@ main() {
     require_tool awk
     require_container "$RUSTBGPD"
     require_container "$FRR"
+    ensure_daemon_running
 
     write_run_json
     start_log_stream

--- a/tests/soak/run-soak-gr-restart-intern-gc.sh
+++ b/tests/soak/run-soak-gr-restart-intern-gc.sh
@@ -90,7 +90,10 @@ ensure_daemon_running() {
         return 0
     fi
     log "rustbgpd not running in $RUSTBGPD; starting"
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
+    # Redirect into the file the log stream tails: a detached exec's
+    # stdout is otherwise discarded and rustbgpd.log stays empty.
+    docker exec -d "$RUSTBGPD" sh -c \
+        '/usr/local/bin/start-rustbgpd.sh >>/var/log/rustbgpd.log 2>&1'
     for _ in $(seq 1 10); do
         if daemon_running; then
             return 0
@@ -150,6 +153,11 @@ frr_established_seen() {
         | grep -q '"bgpState":"Established"'
 }
 
+frr_bgpd_running() {
+    docker exec "$FRR" sh -c 'cat /proc/[0-9]*/comm 2>/dev/null' \
+        | grep -qx bgpd
+}
+
 wait_established() {
     local timeout=${1:-90}
     log "Waiting for BGP session to reach Established (timeout ${timeout}s)..."
@@ -186,7 +194,19 @@ restart_frr_bgpd() {
     done
     awk "BEGIN {exit !($active > 0 && $stale > 0)}" 2>/dev/null ||
         { log "ERROR: GR active/stale evidence not observed"; return 1; }
-    # watchfrr restarts bgpd on its own; just wait for re-establish.
+    # watchfrr normally restarts bgpd within ~5s, but it permanently
+    # abandons a daemon after repeated kills (observed: 4 restarts,
+    # then no further attempt), which a multi-hour soak always
+    # reaches. Supervise the restart ourselves: give watchfrr 10s,
+    # then drive it explicitly. wait_established stays the gate.
+    for _ in $(seq 1 10); do
+        frr_bgpd_running && break
+        sleep 1
+    done
+    if ! frr_bgpd_running; then
+        cycle_log "watchfrr did not restart bgpd; restarting explicitly"
+        docker exec "$FRR" /usr/lib/frr/watchfrr.sh restart bgpd >/dev/null 2>&1 || true
+    fi
     wait_established 60
     for _ in $(seq 1 30); do
         prom=$(prom_scrape) || prom=""

--- a/tests/soak/run-soak-hot-reload.sh
+++ b/tests/soak/run-soak-hot-reload.sh
@@ -78,6 +78,30 @@ require_container() {
     fi
 }
 
+daemon_running() {
+    docker exec "$RUSTBGPD" sh -c 'cat /proc/[0-9]*/comm 2>/dev/null' \
+        | grep -qx rustbgpd
+}
+
+# The soak topology launches the container with `cmd: sleep infinity`;
+# start the daemon explicitly. Idempotent so a re-run against a live
+# topology does not double-start it.
+ensure_daemon_running() {
+    if daemon_running; then
+        return 0
+    fi
+    log "rustbgpd not running in $RUSTBGPD; starting"
+    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
+    for _ in $(seq 1 10); do
+        if daemon_running; then
+            return 0
+        fi
+        sleep 1
+    done
+    log "ERROR: rustbgpd failed to start within 10s"
+    return 1
+}
+
 prom_scrape() {
     local ip
     ip=$(docker inspect --format \
@@ -292,6 +316,7 @@ main() {
     require_tool python3
     require_container "$RUSTBGPD"
     require_container "$FRR"
+    ensure_daemon_running
 
     write_run_json
     start_log_stream

--- a/tests/soak/run-soak-hot-reload.sh
+++ b/tests/soak/run-soak-hot-reload.sh
@@ -91,7 +91,10 @@ ensure_daemon_running() {
         return 0
     fi
     log "rustbgpd not running in $RUSTBGPD; starting"
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
+    # Redirect into the file the log stream tails: a detached exec's
+    # stdout is otherwise discarded and rustbgpd.log stays empty.
+    docker exec -d "$RUSTBGPD" sh -c \
+        '/usr/local/bin/start-rustbgpd.sh >>/var/log/rustbgpd.log 2>&1'
     for _ in $(seq 1 10); do
         if daemon_running; then
             return 0

--- a/tests/soak/run-soak-inject-churn.sh
+++ b/tests/soak/run-soak-inject-churn.sh
@@ -95,7 +95,10 @@ ensure_daemon_running() {
         return 0
     fi
     log "rustbgpd not running in $RUSTBGPD; starting"
-    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
+    # Redirect into the file the log stream tails: a detached exec's
+    # stdout is otherwise discarded and rustbgpd.log stays empty.
+    docker exec -d "$RUSTBGPD" sh -c \
+        '/usr/local/bin/start-rustbgpd.sh >>/var/log/rustbgpd.log 2>&1'
     for _ in $(seq 1 10); do
         if daemon_running; then
             return 0

--- a/tests/soak/run-soak-inject-churn.sh
+++ b/tests/soak/run-soak-inject-churn.sh
@@ -82,6 +82,30 @@ require_container() {
     fi
 }
 
+daemon_running() {
+    docker exec "$RUSTBGPD" sh -c 'cat /proc/[0-9]*/comm 2>/dev/null' \
+        | grep -qx rustbgpd
+}
+
+# The soak topology launches the container with `cmd: sleep infinity`;
+# start the daemon explicitly. Idempotent so a re-run against a live
+# topology does not double-start it.
+ensure_daemon_running() {
+    if daemon_running; then
+        return 0
+    fi
+    log "rustbgpd not running in $RUSTBGPD; starting"
+    docker exec -d "$RUSTBGPD" /usr/local/bin/start-rustbgpd.sh
+    for _ in $(seq 1 10); do
+        if daemon_running; then
+            return 0
+        fi
+        sleep 1
+    done
+    log "ERROR: rustbgpd failed to start within 10s"
+    return 1
+}
+
 format_prefix() {
     local n=${1:?}
     # 10.<high>.<low>.0/24 — unique /24s from the pool index.
@@ -353,6 +377,7 @@ main() {
     require_tool python3
     require_container "$RUSTBGPD"
     require_container "$FRR"
+    ensure_daemon_running
     validate_config
 
     write_run_json

--- a/tests/soak/soak-gr-restart-intern-gc.clab.yml
+++ b/tests/soak/soak-gr-restart-intern-gc.clab.yml
@@ -40,7 +40,7 @@ topology:
       image: quay.io/frrouting/frr:10.3.1
       binds:
         - ../interop/configs/frr-daemons:/etc/frr/daemons:ro
-        - ../interop/configs/frr-bgpd-m16-llgr.conf:/etc/frr/frr.conf:ro
+        - ./configs/frr-bgpd-soak-gr-restart.conf:/etc/frr/frr.conf:ro
       exec:
         - ip addr add 10.0.0.2/24 dev eth1
         - ip link set eth1 up

--- a/tests/soak/soak-gr-restart-intern-gc.clab.yml
+++ b/tests/soak/soak-gr-restart-intern-gc.clab.yml
@@ -27,8 +27,8 @@ topology:
       image: rustbgpd:dev
       cmd: sleep infinity
       binds:
-        - ./configs/rustbgpd-soak-gr-restart.toml:/etc/rustbgpd/config.toml:ro
-        - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../interop/configs/rustbgpd-soak-gr-restart.toml:/etc/rustbgpd/config.toml:ro
+        - ../interop/scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up
@@ -39,8 +39,8 @@ topology:
       kind: linux
       image: quay.io/frrouting/frr:10.3.1
       binds:
-        - ./configs/frr-daemons:/etc/frr/daemons:ro
-        - ./configs/frr-bgpd-m16-llgr.conf:/etc/frr/frr.conf:ro
+        - ../interop/configs/frr-daemons:/etc/frr/daemons:ro
+        - ../interop/configs/frr-bgpd-m16-llgr.conf:/etc/frr/frr.conf:ro
       exec:
         - ip addr add 10.0.0.2/24 dev eth1
         - ip link set eth1 up

--- a/tests/soak/soak-hot-reload.clab.yml
+++ b/tests/soak/soak-hot-reload.clab.yml
@@ -25,8 +25,8 @@ topology:
       image: rustbgpd:dev
       cmd: sleep infinity
       binds:
-        - ./configs/rustbgpd-soak-hot-reload.toml:/etc/rustbgpd/config.toml:ro
-        - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../interop/configs/rustbgpd-soak-hot-reload.toml:/etc/rustbgpd/config.toml:ro
+        - ../interop/scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up
@@ -37,8 +37,8 @@ topology:
       kind: linux
       image: quay.io/frrouting/frr:10.3.1
       binds:
-        - ./configs/frr-daemons:/etc/frr/daemons:ro
-        - ./configs/frr-bgpd-soak-inject-churn.conf:/etc/frr/frr.conf:ro
+        - ../interop/configs/frr-daemons:/etc/frr/daemons:ro
+        - ../interop/configs/frr-bgpd-soak-inject-churn.conf:/etc/frr/frr.conf:ro
       exec:
         - ip addr add 10.0.0.2/24 dev eth1
         - ip link set eth1 up

--- a/tests/soak/soak-inject-churn.clab.yml
+++ b/tests/soak/soak-inject-churn.clab.yml
@@ -23,8 +23,8 @@ topology:
       image: rustbgpd:dev
       cmd: sleep infinity
       binds:
-        - ./configs/rustbgpd-soak-inject-churn.toml:/etc/rustbgpd/config.toml:ro
-        - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+        - ../interop/configs/rustbgpd-soak-inject-churn.toml:/etc/rustbgpd/config.toml:ro
+        - ../interop/scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.0.1/24 dev eth1
         - ip link set eth1 up
@@ -35,8 +35,8 @@ topology:
       kind: linux
       image: quay.io/frrouting/frr:10.3.1
       binds:
-        - ./configs/frr-daemons:/etc/frr/daemons:ro
-        - ./configs/frr-bgpd-soak-inject-churn.conf:/etc/frr/frr.conf:ro
+        - ../interop/configs/frr-daemons:/etc/frr/daemons:ro
+        - ../interop/configs/frr-bgpd-soak-inject-churn.conf:/etc/frr/frr.conf:ro
       exec:
         - ip addr add 10.0.0.2/24 dev eth1
         - ip link set eth1 up


### PR DESCRIPTION
## Summary

Pre-stages soak-window readiness so that when a multi-day failure-injecting window is authorized, the only remaining step is the start command.

- **`docs/soaks/soak-acceptance-gates.md`** — precommitted per-scenario acceptance gates for all nine shipped soak harnesses (GR-restart, hot-reload, inject-churn, M33, M37, M67, Gate 8b, Gate 8b MAC-churn, Gate 9 slice 6): pass/fail bounds, the exact metric/CSV/log evidencing each gate, the scenario path that refreshes each metric, and abort criteria that preserve evidence. Window floors and their rationale stated inline.
- **`tests/soak/preflight.sh`** — pre-window readiness check: tools, competing workloads (shared bench/soak host lock, comm-exact PID checks, live clab containers), disk headroom, daemon build + `rustbgpd:dev` image, and explicit operator confirmation of the two manual mutexes (bench cron paused; no pushes to main during the window). Exit 0 = ready; nonzero with named `FAIL:` lines. Shellcheck-clean; fail-closed path verified.
- **Failure-injection inventory** — in the gates doc: what each scenario actually injects (inventoried from the scripts), mapped to the guarantee tested, plus an explicit list of guarantees with **no** injection coverage.
- **`docs/soaks/soak-receipt-template.md`** — receipt shape for pass, fail, and aborted outcomes; measured-vs-precommitted per gate; host shape as CPU/RAM only; scenario config hash; abort record.
- **30-minute mechanics rehearsal** — run end to end on the GR-restart harness; filled receipt below.

## Rehearsal findings (all fixed here)

The GR/hot-reload/inject-churn trio could not run end to end as committed:

1. **Topology binds pointed at paths that never existed.** All three `tests/soak/soak-*.clab.yml` bound `./configs/…` and `./scripts/…` under `tests/soak/`, but the files live under `tests/interop/`. Deploy created empty directories in their place and the daemon could never read its config. Repointed at the `tests/interop/` sources.
2. **Nothing started the daemon.** The topologies launch the container with `cmd: sleep infinity`; the runners waited for Established without ever starting rustbgpd. Added an idempotent `ensure_daemon_running` step to all three runners.
3. **`frrinit.sh stop` destroyed the topology.** It kills the FRR container's PID 1; docker (`restart: always`) bounces the container and the clab veth is destroyed on both sides with no exec re-run — unrecoverable mid-cycle-one. Replaced with `killall -9 bgpd` (the M16 interop mechanism).
4. **watchfrr permanently abandons bgpd after four kill/restart cycles** (reproduced twice, deterministic at cycle five) — any multi-hour run hits this. The runner now supervises the restart itself: 10 s grace for watchfrr, then explicit `watchfrr.sh restart bgpd`; `wait_established` remains the fail-closed gate.
5. **The M16 FRR config false-fails every reload.** `tests/interop/configs/frr-bgpd-m16-llgr.conf` line 19 (`neighbor … long-lived-graceful-restart stale-time 30` inside the address-family block) is rejected by FRR 10.3.1, so every config load exits non-zero. The soak now uses its own config copy without the dead line. The interop original is untouched (its single-restart smoke tolerates the status); worth a follow-up look since the line is dead config there too.
6. **GR gauges are lazily registered**, so samples taken before the first GR event recorded `nan`, which the strict analyzer rejects — a guaranteed false-red at run end. The sampler now records 0 when the scrape succeeded but the series is not yet registered, keeping `nan` for failed scrapes.
7. **Daemon logs were silently lost** in all three runners: the daemon was started via detached `docker exec`, whose stdout is discarded, while the log stream tailed an empty file. The start step now redirects into the tailed file (verified: 29 KB captured in a follow-up sanity run).

## Injection-coverage gaps (from the inventory)

No soak injection covers: daemon SIGKILL on the plain BGP/RR path (crash-kills exist only in the EVPN Gate 8b harness, opt-in), the SIGHUP file-reload path, listener kill (gRPC/Prometheus), RTR/RPKI cache withdrawal, rapid peer flap storms (fastest cadence in the suite is one event per 90 s), prefix-limit trip + timed restart, transport-level disturbance (netem), and BMP/BFD entirely.

## Mechanics rehearsal — not soak evidence

Filled from the template. This receipt is attached here deliberately instead of being committed under `docs/soaks/`: it is a pipeline rehearsal, not evidence.

---

# Soak Receipt — GR-restart intern-gc 30 min (mechanics rehearsal — not soak evidence)

**Status:** Complete — verdict: **FAIL** (1/6 analyzer gates; expected small-window artifact, see notes)
**Run ID:** `tests/soak/runs/soak-gr-restart-20260730T200440Z`
**Daemon version:** unreleased (v0.62.0 prep) at git SHA `cc545708`; `rustbgpd:dev` built from the branch tip (the run predates the second commit, whose runner fixes were already in the working tree driving it)
**Scenario config hash:** `b9c8de4e816adf062b1d9921980ce03acfd49ee3a291e52bfe8949c6f82eb48a` (sha256 of `run.json`)
**Date:** 2026-07-30T20:04:40Z → 2026-07-30T20:36:45Z (30 m + final convergence/analysis)

## Verdict

**FAIL** on the RSS-slope gate only — 2.40 MB/h against the 1.0 MB/h bound that is precommitted for 24 h+ windows. Absolute RSS movement was 32.7 → 33.9 MB over 30 minutes (allocator settle); the archived 24 h receipts show exactly this shape tightening below 0.2 MB/h at duration. All six restart cycles completed, GR evidence was observed and cleared in order every cycle, re-establish was ≤ 7 s per cycle (13 s on cycle five, which exercised the explicit-restart path after watchfrr gave up), the intern table was bit-flat, and the session was Established at end. The purpose of the rehearsal — prove the pipeline produces a filled, honest receipt end to end, including a red gate — is met.

## Run shape

| Field | Value |
|-------|-------|
| Scenario | GR-restart intern-gc (peer bgpd kill → GR → EoR → stale-clear → intern GC) |
| Harness | `tests/soak/run-soak-gr-restart-intern-gc.sh` |
| Analyzer | `tests/soak/analyze-soak-gr-restart.py` |
| Topology | `tests/soak/soak-gr-restart-intern-gc.clab.yml` |
| Host shape | AMD Ryzen Threadripper 7970X, 32 cores / 64 threads, 125 GB RAM |
| Duration | target 1 800 s, actual 1 800 s |
| Sample interval | 30 s |
| Injection cadence | bgpd kill every 300 s |
| Warmup excluded | 120 s |
| Total data samples | 74 |

## Injections executed

| Injection | Planned | Executed | Notes |
|-----------|---------|----------|-------|
| Peer bgpd kill (`killall -9 bgpd`) | 6 | 6 | Cycles 1–4 recovered via watchfrr (~7 s); cycle 5 via the harness's explicit restart after watchfrr abandonment (13 s); cycle 6 clean |

## Gates — measured vs precommitted

| Gate | Precommitted bound | Measured | Result |
|------|--------------------|----------|--------|
| Intern-table slope | < 1.0 entries/h | 0.0 | **PASS** |
| RSS slope (post-warmup) | < 1.0 MB/h (24 h+ window bound) | 2.405 MB/h | **FAIL** (small-window artifact; RSS 32.668 → 33.867 MB) |
| Peak RSS | < 512 MB | 33.883 MB | **PASS** |
| Restart cycles | ≥ 0.8 × (1800 ÷ 300) = ≥ 5 | 6 | **PASS** |
| GR evidence ordered | active+stale seen, then both clear, every cycle | true (all 6 cycles) | **PASS** |
| Session recovered at end | Established in final samples | true | **PASS** |
| Re-establish latency | ≤ 60 s per cycle | ≤ 13 s worst (cycle 5) | **PASS** |
| Zero crash | daemon counters monotone, no restart | no restart observed | **PASS** |

5 / 6 analyzer gates pass; analyzer verdict `fail` (exit 1), runner exited non-zero — fail-closed as designed.

## Abort record

Not aborted.

## Analysis notes

- 74 samples at 30 s over 1 800 s + per-cycle event samples (the sampler also fires inside the restart routine at the GR-active and post-clear points).
- `intern_size` was 1 on every sample — the intern gate refreshes under the scenario and stayed bit-flat across all six GR cycles.
- Daemon-log capture was empty during this run (finding 7); fixed afterwards and verified in a follow-up 2.5-minute sanity run on a fresh deploy (3 cycles, 29 KB of daemon log captured, same single red slope gate).
- Artifacts remain local under `tests/soak/runs/soak-gr-restart-20260730T200440Z/` (`samples.csv`, `soak.log`, `cycles.log`, `run.json`, `verdict.json`); not committed, per rehearsal labeling.

---

## Verification

- `cargo fmt --all -- --check` → 0
- `cargo clippy --workspace --all-targets -- -D warnings` → 0
- `cargo test --workspace --no-fail-fast` → 0
- `cargo doc --workspace --no-deps` → 0
- `python3 scripts/check-clippy-reasons.py` → 0
- `shellcheck -x` + `bash -n` on all four touched/added shell scripts → 0
- `python3 -m unittest tests/soak/test_intern_churn_analyzers.py` → 0 (9 tests)
- Preflight exercised both ways: READY exit 0 with confirmations; NOT READY exit 1 with named failures when unconfirmed
