### PR TITLE
Pin the supervised GR peer-restart contract in the soak analyzer tests

### DIFF
--- a/tests/soak/test_intern_churn_analyzers.py
+++ b/tests/soak/test_intern_churn_analyzers.py
@@ -135,9 +135,17 @@ class AnalyzerContracts(unittest.TestCase):
         )
 
     def test_gr_runner_requires_complete_ordered_restart(self):
+        # The restart kills only bgpd (never the container's PID 1) and
+        # supervises the comeback itself when watchfrr abandons the
+        # daemon: kill -> GR-positive evidence + sample -> explicit
+        # watchfrr restart (bgpd observed not running) -> established ->
+        # stale-clear evidence + sample.
         body = r'''
 state=$(mktemp); events=$(mktemp); echo 0 >"$state"
-docker() { case "$*" in *" stop") echo stop;; *" start") echo start;; esac >>"$events"; }
+docker() { case "$*" in
+ *killall*bgpd*) echo kill >>"$events";;
+ *watchfrr.sh\ restart*) echo supervise >>"$events";;
+esac; }
 sleep() { :; }; wait_established() { echo established >>"$events"; }
 cycle_log() { :; }
 prom_scrape() { n=$(cat "$state"); echo $((n+1)) >"$state"; if [ "$n" = 0 ]; then
@@ -150,7 +158,7 @@ restart_frr_bgpd 7 0; cat "$events"
         result = self.bash("run-soak-gr-restart-intern-gc.sh", body)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.splitlines(), [
-            "stop", "positive", "sample:0", "start", "established",
+            "kill", "positive", "sample:0", "supervise", "established",
             "clear", "sample:0",
         ])
 


### PR DESCRIPTION
The standalone-harness CI job is red on main: #1332 changed the GR soak runner's peer restart from `frrinit.sh stop/start` to `killall -9 bgpd` with harness-side supervision past watchfrr's restart-abandon threshold, but `test_gr_runner_requires_complete_ordered_restart` still pinned the old stop/start marker sequence.

This updates the contract test to the new restart shape: kill → GR-positive evidence + sample → explicit supervised restart (bgpd observed not running) → established → stale-clear + sample. The mock reports bgpd as down after the kill so the supervision branch itself is pinned, not just tolerated.

`python3 -m unittest -v tests/soak/test_intern_churn_analyzers.py`: 9/9 pass (the exact CI invocation).