### PR TITLE
interop: drop invalid per-neighbor LLGR stale-time from M16 FRR config

### DIFF
--- a/tests/interop/configs/frr-bgpd-m16-llgr.conf
+++ b/tests/interop/configs/frr-bgpd-m16-llgr.conf
@@ -16,7 +16,6 @@ router bgp 65002
  address-family ipv4 unicast
   network 192.168.1.0/24
   network 192.168.2.0/24
-  neighbor 10.0.0.1 long-lived-graceful-restart stale-time 30
  exit-address-family
 !
 ip route 192.168.1.0/24 10.0.0.2


### PR DESCRIPTION
## Defect

`tests/interop/configs/frr-bgpd-m16-llgr.conf` carried a per-neighbor
`long-lived-graceful-restart stale-time` line inside the `address-family ipv4
unicast` block. FRR 10.3.1 rejects it as an unknown command — LLGR stale-time
is only configurable at the `router bgp` level. A single startup tolerates the
resulting non-zero config-load status (M16 passes today), but every repeated
bgpd reload against the file exits non-zero, and under repeated bgpd kills
watchfrr's restart backoff escalates until bgpd stops coming back inside the
harness's re-establish window.

The fix drops the invalid per-neighbor line and keeps the valid global
`bgp long-lived-graceful-restart stale-time 30`, matching the already-corrected
soak variant. `tests/soak/configs/frr-bgpd-soak-gr-restart.conf` is
intentionally kept as a separate copy — it isolates the soak suite from future
interop-config edits.

## Proof (frr:10.3.1 container, M16 topology)

Live rejection of the removed construct:

```
$ vtysh -c 'configure terminal' -c 'router bgp 65002' \
        -c 'address-family ipv4 unicast' \
        -c 'neighbor 10.0.0.1 long-lived-graceful-restart stale-time 30'
% Unknown command: neighbor 10.0.0.1 long-lived-graceful-restart stale-time 30
(exit 1)
```

Config-load status, before vs after:

```
== OLD config ==
line 19: % Unknown command[31]:   neighbor 10.0.0.1 long-lived-graceful-restart stale-time 30
Configuration file[...] processing failure: 2
old check exit: 2

== FIXED config ==
fixed check exit: 0

== vtysh -b (the watchfrr reload path, fixed config) ==
vtysh -b exit: 0
```

Fresh-deployment FRR logs contain zero `Unknown command` / content errors.
(The quay.io frr image still logs a benign `processing failure: 11` —
`CMD_ERR_NO_FILE` for the unmounted `/etc/frr/vtysh.conf`; exit code stays 0,
present on every FRR M-topology, unrelated to config content.)

## Smoke

`tests/interop/scripts/test-m16-llgr-frr.sh` on a fresh deployment:
**9 passed, 0 failed, exit 0** (initial routes, GR→LLGR promotion after GR
timer expiry, LLGR-stale clear on watchfrr-driven reconnect).

Swept `tests/interop/configs/` for the same construct: no other FRR config
carries a per-neighbor LLGR line (the GoBGP TOML `afi-safis.long-lived-
graceful-restart` stanzas are valid GoBGP syntax).

Gates: `cargo fmt --all -- --check` 0; `scripts/check-clippy-reasons.py` 0
(conf-only change, no Rust touched).
