### PR TITLE
Perf-claim freshness gate + RR-scale stamp; deflake attribution allocation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ reproducible receipt:
   **4.7–5.0 s** vs 61.6–65.3 s (BIRD) and 338.8–422.1 s (OpenBGPD) —
   [same matrix](docs/perf/ixp-matrix-2026-07.md#s1--cold-convergence)
 - **Route-reflector scale**: 1,000 RR clients × 100k routes converge on the
-  wire in **1.82 s** at **419 MiB** whole-process RSS —
+  wire in **1.82 s** at **419 MiB** whole-process RSS — measured 2026-07-03
+  at the close of the update-groups arc,
   [1000-peer scale receipt](docs/perf/scale-receipt-2026-07.md)
 - **The losses, stated plainly**: OpenBGPD holds a smaller reload stall
   (p50 0.24–0.28 s vs rustbgpd's 0.42–0.73 s), and BIRD keeps the settled-RSS

--- a/crates/policy/tests/attribution_allocations.rs
+++ b/crates/policy/tests/attribution_allocations.rs
@@ -6,7 +6,8 @@
 //! `PolicyChain::evaluate_with_attribution` calls.
 
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::cell::Cell;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rustbgpd_policy::{
     NamedPolicy, Policy, PolicyAction, PolicyChain, RouteContext, RouteModifications,
@@ -15,9 +16,19 @@ use rustbgpd_wire::{AspaValidation, RpkiValidation};
 
 const VERDICTS: usize = 256;
 
+// Counting is scoped to the measuring thread, not the process. The
+// evaluation under test runs entirely on the test thread, but the test
+// process also hosts libtest-harness threads whose incidental allocations
+// (progress plumbing, timing) land inside the measured window when a
+// loaded host stretches its wall-clock span — a handful of phantom
+// "label rebuilds" that no policy code performed. A per-verdict label
+// rebuild happens on this thread and still counts exactly.
+thread_local! {
+    static COUNTING: Cell<bool> = const { Cell::new(false) };
+}
+
 struct CountingAllocator {
     inner: System,
-    enabled: AtomicBool,
     allocations: AtomicUsize,
 }
 
@@ -25,24 +36,24 @@ impl CountingAllocator {
     const fn new() -> Self {
         Self {
             inner: System,
-            enabled: AtomicBool::new(false),
             allocations: AtomicUsize::new(0),
         }
     }
 
     fn begin(&self) {
-        self.enabled.store(false, Ordering::Relaxed);
         self.allocations.store(0, Ordering::Relaxed);
-        self.enabled.store(true, Ordering::Relaxed);
+        COUNTING.set(true);
     }
 
     fn end(&self) -> usize {
-        self.enabled.store(false, Ordering::Relaxed);
+        COUNTING.set(false);
         self.allocations.load(Ordering::Relaxed)
     }
 
     fn count_success(&self, pointer: *mut u8) {
-        if !pointer.is_null() && self.enabled.load(Ordering::Relaxed) {
+        // `try_with` (not `with`): the allocator is reachable from TLS
+        // destructors on exiting threads, where key access would panic.
+        if !pointer.is_null() && COUNTING.try_with(Cell::get).unwrap_or(false) {
             self.allocations.fetch_add(1, Ordering::Relaxed);
         }
     }

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -57,6 +57,10 @@ convention in `CONTRIBUTING.md`:
       docs, and tests all move together.
 - [ ] Process-only documentation changes intentionally omit CHANGELOG entries
       unless they affect users or operators.
+- [ ] Every README front-matter performance claim cites a receipt measured
+      within the last three releases, or carries an explicit measured-on date
+      in the claim text (e.g. "measured 2026-07-03"). Older numbers stay
+      quotable with their date; undated stale numbers do not ship.
 
 ## Narrow v1 RS/RR compatibility gate
 


### PR DESCRIPTION
## What

Two hygiene items: a perf-claim freshness gate applied to the README, and a deflake of the attribution allocation test.

### Perf-claim freshness gate

`docs/RELEASE_CHECKLIST.md` (Documentation hygiene) now requires every README front-matter performance claim to cite a receipt measured within the last three releases, or to carry an explicit measured-on date in the claim text. Applied: the route-reflector scale claim (1.82 s / 419 MiB) now reads "measured 2026-07-03 at the close of the update-groups arc", matching the date and provenance in `docs/perf/scale-receipt-2026-07.md`. The IXP matrix bullets are already covered by the existing "v0.61.0 same-host refresh (2026-07-27)" provenance line.

### Deflake `named_attribution_allocates_no_label_per_verdict`

The test's counting allocator gated on a process-global `AtomicBool`, so any allocation from any thread in the test process during the measured window counted as a "label rebuild". Locally the 256-verdict window is microseconds and nothing else allocates; on a loaded hosted runner the window stretches and libtest-harness thread activity lands inside it — the observed "rebuilt 4 labels across 256 verdicts" with no policy code involved.

Counting is now scoped to the measuring thread via a const-initialized `thread_local!` flag (`try_with` so allocator reentry from TLS destructors on exiting threads cannot panic). The invariant is unchanged: expected allocations stay exactly 0, and an injected per-verdict `String` rebuild on the test thread still fails with "rebuilt 256 labels across 256 verdicts" (verified red before landing).

## Gates

- `cargo fmt --all -- --check` — 0
- `cargo clippy --workspace --all-targets -- -D warnings` — 0
- `cargo test --workspace --no-fail-fast` — 0 (93 test targets, no failures)
- `cargo doc --workspace --no-deps` — 0
- `python3 scripts/check-clippy-reasons.py` — 0
- 20x `cargo test -p rustbgpd-policy --test attribution_allocations` — 20/20 green
