### PR TITLE
Point security intake at private vulnerability reporting; document security posture

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Security vulnerabilities
-    url: https://github.com/lance0/rustbgpd/blob/main/docs/SECURITY.md
-    about: For security issues, review the security posture doc first. Email security reports privately rather than opening a public issue.
+  - name: Report a security vulnerability
+    url: https://github.com/lance0/rustbgpd/security/advisories/new
+    about: Report vulnerabilities privately via GitHub's security advisory form. Do not open a public issue. See SECURITY.md for the disclosure policy.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
             echo "CI triggers must keep main-only pushes, all PRs, and Markdown ignores" >&2
             exit 1
           fi
+      # The chooser's security link once pointed at a posture doc and a
+      # nonexistent security email; keep it pinned to the private
+      # vulnerability-reporting intake so it cannot silently drift again.
+      - name: Check issue-chooser security link targets private vulnerability reporting
+        run: |
+          grep -q 'https://github.com/lance0/rustbgpd/security/advisories/new' \
+            .github/ISSUE_TEMPLATE/config.yml
       - name: Check pinned grpcurl installer contract
         shell: bash
         run: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,8 @@ logging — see [docs/SECURITY.md](docs/SECURITY.md).
 ## Reporting a Vulnerability
 
 Report security vulnerabilities via
-[GitHub Security Advisories](https://github.com/lance0/rustbgpd/security/advisories/new).
+[GitHub private vulnerability reporting](https://github.com/lance0/rustbgpd/security/advisories/new),
+which is enabled on this repository.
 
 **Do not open a public issue for security vulnerabilities.**
 
@@ -31,6 +32,12 @@ Report security vulnerabilities via
 - **Critical vulnerabilities** (remote crash, session hijack): Patched
   and released within 72 hours of confirmation
 - **Other vulnerabilities:** Patched in the next milestone release
+
+### CVE Assignment
+
+Qualifying vulnerabilities are published as GitHub Security Advisories
+once a fix is released, and a CVE ID is requested for each through
+GitHub's GHSA-to-CVE assignment flow.
 
 ## Security Posture
 
@@ -68,6 +75,48 @@ input from the network. It runs under continuous fuzzing in CI.
   of that code ships in the daemon or in any published library crate.
 - **Structured errors, not strings.** Every failure produces a
   machine-parseable event for forensic analysis.
+
+### Memory Safety
+
+rustbgpd is written in Rust, consistent with product-security guidance
+published by CISA and partner agencies recommending memory-safe languages
+for software that processes untrusted network input. The enforcement
+mechanism is the crate-root `#![deny(unsafe_code)]` invariant described
+under Design Principles above: no `unsafe` in shipped paths beyond the
+two documented, scoped exceptions.
+
+One concrete bound this pins: `AS_PATH` matching is length-bounded under
+RFC 8654 Extended Messages. The policy engine matches the rendered path
+string with no fixed-capacity per-ASN buffer anywhere in the match path;
+`crates/policy/tests/as_path_extended_message_bound.rs` decodes a
+maximum-size (65,533-byte) UPDATE and proves regex and length matching
+see the full ~16,000-ASN path.
+
+### Fuzzing
+
+Four fuzz crates (`crates/wire`, `crates/policy`, `crates/mrt`,
+`crates/evpn`) carry 17 fuzz targets covering the message decoders, the
+policy frontend, MRT snapshot and warm-bundle readers, and EVPN parsing.
+A nightly CI campaign (`.github/workflows/fuzz.yml`) runs every target
+in each crate against tracked seed corpora and fails loudly if target
+enumeration returns nothing. A ClusterFuzzLite workflow builds all
+targets with AddressSanitizer for on-demand campaigns. The target
+inventory is fail-closed: `scripts/check_fuzz_target_inventory.py` runs
+in CI and fails when the inventory drifts from the reviewed list.
+
+### Notes for Integrators
+
+Manufacturers integrating rustbgpd who need to document upstream
+open-source handling (for example under the EU Cyber Resilience Act) can
+point at:
+
+- This coordinated disclosure policy, including the response timelines
+  above.
+- Private vulnerability intake via GitHub private vulnerability
+  reporting, enabled on the repository.
+- CVE assignment for qualifying vulnerabilities via the GHSA flow.
+- Machine-readable dependency inventory: from v0.63 onward, release
+  artifacts include an SBOM.
 
 ### Authentication (v1)
 

--- a/crates/policy/tests/as_path_extended_message_bound.rs
+++ b/crates/policy/tests/as_path_extended_message_bound.rs
@@ -1,0 +1,80 @@
+//! `AS_PATH` matching is length-bounded under RFC 8654 Extended Messages.
+//!
+//! A maximum-size (65,533-byte) UPDATE whose `AS_PATH` fills the extended
+//! message budget decodes, renders, and regex/length-matches without
+//! truncation or a fixed-capacity ceiling. Pins existing behavior: the
+//! policy engine matches the rendered path string, so no fixed-size
+//! per-ASN buffer exists anywhere in the match path.
+
+use rustbgpd_policy::AsPathRegex;
+use rustbgpd_wire::constants::HEADER_LEN;
+use rustbgpd_wire::{EXTENDED_MAX_MESSAGE_LEN, MAX_MESSAGE_LEN, PathAttribute, UpdateMessage};
+
+const ASN_FILLER: u32 = 65000;
+const ORIGIN_ASN: u32 = 65001;
+
+#[test]
+fn as_path_matching_bounded_at_max_extended_message() {
+    // Fill the extended-message budget: header (19) + withdrawn_len (2) +
+    // attrs_len (2) + attribute header (4) leaves 65,508 bytes of AS_PATH
+    // data. Each full AS_SEQUENCE segment is 2 + 255 * 4 bytes.
+    let budget = usize::from(EXTENDED_MAX_MESSAGE_LEN) - HEADER_LEN - 2 - 2 - 4;
+    let mut attr_data: Vec<u8> = Vec::new();
+    let mut asn_count = 0usize;
+    loop {
+        let remaining = budget - attr_data.len();
+        if remaining < 2 + 4 {
+            break;
+        }
+        let seg_len = ((remaining - 2) / 4).min(255);
+        attr_data.push(2); // AS_SEQUENCE
+        attr_data.push(u8::try_from(seg_len).unwrap());
+        for _ in 0..seg_len {
+            attr_data.extend_from_slice(&ASN_FILLER.to_be_bytes());
+            asn_count += 1;
+        }
+    }
+    // Make the final (origin) ASN distinctive.
+    let tail = attr_data.len() - 4;
+    attr_data[tail..].copy_from_slice(&ORIGIN_ASN.to_be_bytes());
+
+    let mut body: Vec<u8> = Vec::new();
+    body.extend_from_slice(&0u16.to_be_bytes()); // withdrawn routes length
+    let attrs_len = u16::try_from(attr_data.len() + 4).unwrap();
+    body.extend_from_slice(&attrs_len.to_be_bytes());
+    body.push(0x50); // TRANSITIVE | EXTENDED_LENGTH
+    body.push(2); // AS_PATH
+    body.extend_from_slice(&u16::try_from(attr_data.len()).unwrap().to_be_bytes());
+    body.extend_from_slice(&attr_data);
+
+    let total = HEADER_LEN + body.len();
+    assert!(
+        total > usize::from(MAX_MESSAGE_LEN),
+        "must exceed the classic 4096-byte limit"
+    );
+    assert!(total <= usize::from(EXTENDED_MAX_MESSAGE_LEN));
+    assert!(
+        asn_count > 16_000,
+        "budget math regressed: only {asn_count} ASNs"
+    );
+
+    let update = UpdateMessage::decode(&mut &body[..], body.len()).unwrap();
+    let parsed = update.parse(true, false, &[]).unwrap();
+    let as_path = parsed
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::AsPath(p) => Some(p),
+            _ => None,
+        })
+        .expect("AS_PATH decodes from a maximum-size extended message");
+
+    // Length matching sees every ASN, not a capped prefix.
+    assert_eq!(as_path.len(), asn_count);
+    assert_eq!(as_path.origin_asn(), Some(ORIGIN_ASN));
+
+    // Regex matching operates on the full rendered path.
+    let rendered = as_path.to_aspath_string();
+    assert!(AsPathRegex::new("_65001$").unwrap().is_match(&rendered));
+    assert!(!AsPathRegex::new("_64999_").unwrap().is_match(&rendered));
+}

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -165,6 +165,11 @@ IPv4/IPv6 `Prefix` routes.
 | Privilege separation | No | No | No | No | Yes |
 | Memory-safe language | Yes | No | No | Yes | No |
 
+CVE-2026-49943, a stack-based buffer overflow in BIRD's AS-path filter
+matching reachable when RFC 8654 extended messages are enabled (affected
+through 2.19.0), is a recent example of the vulnerability class the
+memory-safe-language row refers to.
+
 [^aspa]: rustbgpd ships RTR v2 ASPA input, role-aware upstream/downstream path
     verification selected by BGP Roles, best-path preference, policy matching
     for IPv4/IPv6 unicast, and targeted import-policy refresh when validation


### PR DESCRIPTION
## Security intake

The issue chooser's security link pointed at `docs/SECURITY.md` (the operational posture doc) and instructed reporters to **email security reports privately** — no security email exists. It now points at the repository's [private vulnerability reporting form](https://github.com/lance0/rustbgpd/security/advisories/new), which is enabled. A CI assertion pins the chooser's link so it cannot silently drift again. SECURITY.md's own reporting link was already correct; it now states that private vulnerability reporting is enabled.

## Posture documentation (SECURITY.md)

- **CVE assignment** — qualifying reports are published as GHSAs with CVE IDs requested via GitHub's GHSA-to-CVE flow.
- **Memory safety** — cites CISA product-security guidance generically and the existing crate-root `#![deny(unsafe_code)]` invariant (with its two documented scoped exceptions), without duplicating the Design Principles text.
- **Fuzzing** — described as it actually runs: 17 targets across the four fuzz crates, nightly campaign (`fuzz.yml`), fail-closed inventory (`scripts/check_fuzz_target_inventory.py` in CI), ClusterFuzzLite ASan builds on dispatch.
- **Notes for integrators** — what a manufacturer (e.g. under the EU CRA) can point at: the disclosure policy and timelines, private intake, CVE assignment, and SBOM in release artifacts from v0.63 onward.

## RFC 8654 AS_PATH bound

New test `as_path_matching_bounded_at_max_extended_message` (`crates/policy/tests/as_path_extended_message_bound.rs`) decodes a maximum-size 65,533-byte extended-message UPDATE whose AS_PATH fills the budget (~16,300 ASNs) and proves regex and length matching operate on the full path — no fixed-capacity ceiling in the match path. Pins existing behavior.

docs/COMPARISON.md adds one sentence under the Security table citing CVE-2026-49943 (BIRD AS-path filter matching stack overflow, affected through 2.19.0, reachable with RFC 8654 extended messages; verified against NVD) as a recent instance of the vulnerability class the memory-safe-language row refers to.

## Gates

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast`, `cargo doc --workspace --no-deps`, `scripts/check-clippy-reasons.py` — all exit 0.