### PR TITLE
docs: IXP evaluator pack — evaluation matrix, MANRS Action 1 mapping, paired-RS runbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,8 @@ Start here if you have never run the daemon.
 | [cookbook/rr-pair-day2.md](cookbook/rr-pair-day2.md) | Runbook: day-2 operations on a redundant RR pair — GR sanity, adding clients, safe config edits |
 | [cookbook/route-server-migration.md](cookbook/route-server-migration.md) | Shadow cutover runbook: map FRR/BIRD/ARouteServer concepts, run the shadow trial, gate cutover on `rbgp diff advertised` |
 | [cookbook/ixp-filter-pipeline.md](cookbook/ixp-filter-pipeline.md) | End-to-end IXP toolchain: arouteserver → `rs-config-render` → validated reload → Alice-LG looking glass |
+| [cookbook/manrs-ixp-action1.md](cookbook/manrs-ixp-action1.md) | MANRS IXP Programme Action 1, mapped requirement-by-requirement to validated config and member-verifiable surfaces |
+| [cookbook/paired-route-servers.md](cookbook/paired-route-servers.md) | Runbook: two independent route servers — staggered updates, inter-RS consistency diff, maintenance-window drain |
 | [explain.md](explain.md) | Answer "why is this route (not) here?": the catalog of every explain surface, with the support-ticket workflow |
 | [deployment.md](deployment.md) | End-to-end install + lifecycle: systemd, Docker, containerlab, validate, reload, upgrade |
 | [ribdiff.md](ribdiff.md) | Drive `rbgp diff advertised` for the shadow trial (also the `rbgp-ribsnap/1` snapshot-format reference) |
@@ -58,6 +60,7 @@ Start here if you have never run the daemon.
 | [gobgp-parity.md](gobgp-parity.md) | Feature-by-feature parity table against GoBGP |
 | [../crates/cli/README.md#familiar-command-map](../crates/cli/README.md#familiar-command-map) | Familiar command map: the FRR/BIRD show-command mental model translated to `rbgp` |
 | [COMPARISON.md](COMPARISON.md) | Feature comparison across open-source BGP daemons |
+| [ixp-evaluation.md](ixp-evaluation.md) | One-page IXP route-server evaluation matrix: capability status with the receipt or config behind each row |
 | [kernel-dataplane-runner.md](kernel-dataplane-runner.md) | How the privileged Linux dataplane CI workflow runs |
 | [grafana/](grafana/) | The importable Grafana dashboard JSON |
 

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -16,6 +16,7 @@ receipts that prove its scenario ([`RECEIPTS.md`](../RECEIPTS.md)).
 | [Route-server migration](route-server-migration.md) | Map FRR, BIRD, and ARouteServer concepts into rustbgpd and run a shadow-trial cutover | M19, M83 |
 | [Route-server shadow pilot](route-server-shadow-pilot.md) | Run rustbgpd for weeks as a receive-only, non-authoritative second route server beside production BIRD/OpenBGPD — standing comparison loop, data-return contract, clean teardown | M19, M83, [IXP receipt matrix](../perf/ixp-matrix-2026-07.md) |
 | [IXP filter pipeline](ixp-filter-pipeline.md) | Keep your arouteserver `general.yml`/`clients.yml`: render member filters with `rs-config-render`, reload fail-stale, serve Alice-LG | M19, M83 |
+| [MANRS IXP Action 1](manrs-ixp-action1.md) | Document your MANRS IXP Programme participation: Action 1 mapped requirement-by-requirement to validated config and member-verifiable surfaces | M83, fragments pass `rustbgpd --check --strict` |
 | [Controller / monitoring feed](monitoring-feed.md) | Streaming BMP, durable events, and MRT into a controller or collector stack | M24, M81 |
 | [EVPN fabric route reflector](evpn-fabric-rr.md) | Control-plane-only RR for a VXLAN-EVPN leaf/spine fabric | M29, M30, M82, M33 |
 | [Policy quickstart (`.rpol`)](policy-quickstart.md) | First typed policy: tests, dry-run, hot swap, explain | M80, M34 |
@@ -26,6 +27,7 @@ Operator runbooks — short, ordered checklists for a live daemon:
 |---------|----------------------|
 | [Peer-flap triage](peer-flap-triage.md) | A session keeps cycling: confirm, read events, match the teardown reason, contain |
 | [RR pair day-2](rr-pair-day2.md) | Routine changes on a redundant RR pair: GR sanity, adding clients, hot vs session-reset edits, commit-confirm |
+| [Paired route servers](paired-route-servers.md) | Two independent RS instances: staggered config rollout, inter-RS consistency via `rbgp diff advertised`, RFC 8326 maintenance drain |
 | Shadow cutover | The step-by-step shadow trial lives in [route-server-migration.md](route-server-migration.md); the comparison tool it gates on is [`rbgp diff advertised`](../ribdiff.md) |
 
 Conventions:

--- a/docs/cookbook/manrs-ixp-action1.md
+++ b/docs/cookbook/manrs-ixp-action1.md
@@ -1,0 +1,246 @@
+# MANRS IXP Programme Action 1 on rustbgpd
+
+**When this is you:** your exchange participates in (or is applying to)
+the MANRS IXP Programme and you need to show, control by control, how a
+rustbgpd route server implements Action 1 — and how members can verify
+each control from the outside.
+
+The normative source is
+[MANRS-004.01, "MANRS Actions for IXP Program"](https://manrs.org/specifications/MANRS-004/01/).
+Action 1 is mandatory for programme participation:
+
+> **Action 1. Prevent propagation of incorrect routing information.
+> (Mandatory)**
+> The IXP implements filtering of route announcements at the Route
+> Server based on routing information data (IRR and/or RPKI). Based on
+> the outcome of the validation process, the invalid announcements are
+> filtered in accordance with the IXP published policy.
+
+The specification's guidance names the usual validation inputs: IRR
+data (resolving the member's AS-SET), RPKI data (ROA objects or a
+validated cache), and checking announcements against bogons/martians —
+prefixes per RFC 1918, RFC 5735, RFC 6598, and ASNs in the AS_PATH per
+RFC 5398, RFC 6793, RFC 6996, RFC 7300, RFC 7607.
+
+This page maps each element to the config that implements it and the
+surface that proves it. Every fragment below is drawn from a complete
+configuration that passes `rustbgpd --check --strict` (the
+[full example](#complete-example) is at the end).
+
+## Requirement map
+
+| Action 1 element | rustbgpd implementation | Verify with |
+|------------------|-------------------------|-------------|
+| RPKI-based filtering (validated cache) | [`[rpki]`](../CONFIGURATION.md#rpki) RTR client + a one-statement deny policy; `maxLength` is enforced in the Invalid determination (RFC 6811) | `rbgp policy explain`, looking-glass filtered view |
+| IRR-based filtering (AS-SET resolution) | Per-member prefix/origin sets rendered from arouteserver's resolved IRR data ([IXP filter pipeline](ixp-filter-pipeline.md)) | render receipt + looking-glass filtered view |
+| Bogon / martian hygiene | Shared hygiene chain: special-purpose prefix rejection, AS_SET reject, ASPA-invalid reject ([`examples/route-server/hygiene.rpol`](../../examples/route-server/hygiene.rpol)); the rendered `rs-hygiene.rpol` adds transit-free and path-length caps | `rbgp rib received <member> --rejected` |
+| Filtering per published policy, fail-closed | RFC 8212 posture (`ebgp_requires_policy`), fail-stale rendering, parse-then-swap reload | `rustbgpd --check --strict`, `rbgp policy` surfaces |
+| Containment of misbehaving members | Per-family max-prefix ceilings with latched teardown ([ADR-0108](../adr/0108-per-family-max-prefix-limits.md)), outbound mirrors ([ADR-0113](../adr/0113-outbound-prefix-limits.md)) | `rbgp neighbor <ip>` limit state, metrics |
+| Member-visible transparency | Reject-retention store + looking-glass filtered view with reject-reason communities | Alice-LG, `rbgp rib received --rejected` |
+
+## RPKI: invalid = reject
+
+Connect to your validated cache (Routinator, rpki-client, StayRTR,
+OctoRPKI — anything speaking RTR) and deny Invalid at import. A route
+is Invalid when a covering VRP exists but the origin AS does not match
+**or the announced prefix exceeds the VRP's `maxLength`** — so
+maxLength violations are rejected by the same statement, per RFC 6811:
+
+```toml
+[rpki]
+[[rpki.cache_servers]]
+address = "127.0.0.1:3323"
+
+[policy.definitions.reject-rpki-invalid]
+[[policy.definitions.reject-rpki-invalid.statements]]
+match_rpki_validation = "invalid"
+action = "deny"
+```
+
+Later VRP updates trigger an inbound Route Refresh for established
+members whose import policy depends on validation state, so verdicts
+track the cache rather than freezing at ingress time. Details:
+[`[rpki]` reference](../CONFIGURATION.md#rpki),
+[ADR-0034](../adr/0034-rpki-origin-validation.md). Reject-at-import
+against a live RTR cache is exercised in the M83 interop lab
+([RECEIPTS.md](../RECEIPTS.md)).
+
+## IRR filtering: the pipeline
+
+Action 1's IRR half expects each member's announcements checked
+against its registered AS-SET. rustbgpd's supported path is the
+[IXP filter pipeline](ixp-filter-pipeline.md): keep your existing
+arouteserver `general.yml` / `clients.yml`, dump the resolved data
+model with `arouteserver template-context`, and render per-member
+`.rpol` prefix/origin sets plus per-family max-prefix ceilings with
+`rs-config-render`. The render is fail-stale, never fail-open: a
+broken or implausibly empty IRR answer aborts the whole render and the
+last good filters stay live
+([ADR-0110](../adr/0110-irr-peeringdb-filtering-pipeline.md)).
+
+Honesty note for your MANRS documentation: the daemon has no native
+IRRd/bgpq4 client — IRR ingest rides arouteserver's resolver, caches,
+and refresh cadence. That is the same ingest incumbent route servers
+use; the rustbgpd-specific part is the render step, maintained in this
+repository.
+
+## Bogons, martians, and path hygiene
+
+The checked-in starter hygiene chain
+([`examples/route-server/hygiene.rpol`](../../examples/route-server/hygiene.rpol))
+rejects announcements carrying AS_SET segments, rejects ASPA-invalid
+paths, and applies a dated dual-stack special-purpose (bogon/martian)
+prefix snapshot; the rendered pipeline's `rs-hygiene.rpol` adds
+transit-free rejection and a path-length cap, with RPKI origin
+validation folded in. Wire it into
+the import chain ahead of member-specific filters, as the
+[route-server cookbook](route-server.md) does.
+
+## The RFC 8212 posture
+
+Action 1 requires that what the route server propagates is a policy
+decision, not a default. With `ebgp_requires_policy = true`, an eBGP
+direction that resolves no explicit operator policy runs a reserved
+internal deny — deleting the filter chain makes members stop receiving
+routes loudly instead of inheriting permit-all by omission:
+
+```toml
+[global]
+asn = 64500
+router_id = "192.0.2.1"
+ebgp_requires_policy = true
+```
+
+Stated plainly: this is opt-in, not the daemon's out-of-the-box
+default. Turn it on for a MANRS route server. It is restart-required,
+and `--check` names every eBGP neighbor still resolving no explicit
+policy — `--strict` turns those warnings into a failing exit. See
+[ADR-0112](../adr/0112-rfc-8212-ebgp-requires-policy.md) and the
+[`ebgp_requires_policy` reference](../CONFIGURATION.md#ebgp_requires_policy--rfc-8212-explicit-policy-on-ebgp).
+
+## Per-member prefix limits
+
+Contain a member that de-aggregates or leaks past its registered
+ceiling. Limits are per family, enforced on accepted routes, and latch
+the session off on breach until explicit re-enable (optionally with
+one timed restart attempt):
+
+```toml
+[[neighbors]]
+address = "192.0.2.10"
+remote_asn = 64501
+route_server_client = true
+role = "route_server"
+import_policy_chain = ["reject-rpki-invalid", "member-a-irr"]
+max_prefixes_ipv4 = 10000
+max_prefixes_ipv6 = 2000
+max_prefix_restart_seconds = 900
+```
+
+The pipeline sources these ceilings from PeeringDB via arouteserver's
+resolved context. References:
+[ADR-0108](../adr/0108-per-family-max-prefix-limits.md) (per-family
+inbound), [ADR-0113](../adr/0113-outbound-prefix-limits.md) (outbound
+mirrors), [neighbor options](../CONFIGURATION.md#neighbors).
+
+## What members can verify
+
+Action 1 filtering is only credible if members can see it working:
+
+- **Looking glass** ([`examples/birdwatcher-adapter/`](../../examples/birdwatcher-adapter/README.md)
+  + Alice-LG): accepted routes per member, and a **filtered-routes
+  view** served from the daemon's reject-retention store, each
+  rejection carrying machine-readable reject-reason communities
+  Alice-LG renders as human-readable causes. This also satisfies the
+  programme's Action 5 (provide monitoring and debugging tools — a
+  route-server looking glass for members).
+- **`rbgp rib received <member> --rejected`**: enumerates a member's
+  rejected announcements with reasons, without needing the prefix
+  known in advance.
+- **`rbgp policy explain`**: replays a specific prefix through the
+  import ladder and names the statement that rejected it — the
+  support-ticket workflow is in [explain.md](../explain.md).
+
+## Complete example
+
+A minimal self-contained Action 1 shape — RPKI invalid = reject,
+inline stand-ins for rendered IRR sets, hygiene ordering, RFC 8212 on,
+per-family limits. In production the member prefix statements and
+ceilings come from the pipeline render; the checked-in
+[`examples/route-server/`](../../examples/route-server/) starter adds
+the `.rpol` hygiene chain, RPKI-valid preference, dual-stack members,
+and Add-Path / per-client-best path-hiding mitigation.
+
+```toml
+[global]
+asn = 64500
+router_id = "192.0.2.1"
+listen_port = 179
+ebgp_requires_policy = true
+
+[global.telemetry]
+log_format = "json"
+
+[global.telemetry.grpc_uds]
+path = "/var/lib/rustbgpd/grpc.sock"
+principal = "operator"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+operator = "operator"
+
+[rpki]
+[[rpki.cache_servers]]
+address = "127.0.0.1:3323"
+
+[policy.definitions.reject-rpki-invalid]
+[[policy.definitions.reject-rpki-invalid.statements]]
+match_rpki_validation = "invalid"
+action = "deny"
+
+# Stand-in for a rendered per-member IRR set: permit only what the
+# member's AS-SET resolves to, deny the rest.
+[policy.definitions.member-a-irr]
+default_action = "deny"
+[[policy.definitions.member-a-irr.statements]]
+prefix = "203.0.113.0/24"
+action = "permit"
+
+# Transparent export is a declared decision (RFC 7947), not an omission.
+[policy.definitions.rs-transparent-export]
+default_action = "permit"
+
+[policy]
+export_chain = ["rs-transparent-export"]
+
+[[neighbors]]
+address = "192.0.2.10"
+remote_asn = 64501
+description = "member-a"
+route_server_client = true
+role = "route_server"
+families = ["ipv4_unicast"]
+max_prefixes_ipv4 = 10000
+max_prefix_restart_seconds = 900
+import_policy_chain = ["reject-rpki-invalid", "member-a-irr"]
+```
+
+Validate before anything touches the wire — this exact configuration
+exits 0:
+
+```bash
+rustbgpd --check --strict manrs-action1.toml
+```
+
+## Publishing your policy
+
+MANRS asks for the filtering policy to be published (or at least
+member-visible). The pieces to link from your IXP policy page: which
+inputs you filter on (IRR via your arouteserver site files, RPKI
+invalid = reject including maxLength, the bogon snapshot), the
+max-prefix action and restart window, and where members can see their
+own filtered routes (your Alice-LG instance). The
+[evaluation matrix](../ixp-evaluation.md) is the capability-level
+summary; this page is the per-control detail behind it.

--- a/docs/cookbook/paired-route-servers.md
+++ b/docs/cookbook/paired-route-servers.md
@@ -1,0 +1,126 @@
+# Paired route servers — staggered updates and maintenance windows
+
+**When this is you:** your exchange runs (or should run) two route
+servers, every member peers with both, and you want the operational
+discipline that makes the pair actually redundant: independent
+instances, staggered config rollout, a mechanical inter-RS consistency
+check, and a drain flow for maintenance.
+
+## Why two, and why members peer with both
+
+A route server is a single point of failure for multilateral peering:
+when it goes down, members lose every route learned through it. The
+standard remedy is two route servers on separate hosts (ideally
+separate power/switch domains), with every member holding a session to
+each. Both carry the same policy and advertise the same routes, so a
+member losing RS1 converges onto identical paths already learned from
+RS2 — the fabric forwards through the same next hops throughout
+(RFC 7947 transparency: the route server is not in the data path).
+Redundancy only holds if members actually configure both sessions;
+make dual sessions part of member onboarding, not an option.
+
+## Independence rules
+
+- **Two instances, two hosts, zero shared runtime state.** The
+  instances never talk to each other; consistency comes from feeding
+  both the same policy inputs, not from synchronization.
+- **One policy source, two renders.** With the
+  [IXP filter pipeline](ixp-filter-pipeline.md), both route servers
+  render from the same arouteserver `general.yml` / `clients.yml` —
+  run the render per host (or distribute one render's output), and
+  keep each host's `rustbgpd --check --strict` gate local so a corrupt
+  copy cannot pass.
+- **Distinct `router_id`s**, same ASN, same member ACLs. Members see
+  two ordinary sessions to one route-server AS.
+- **Independent RPKI feeds.** Point each instance at the RTR
+  cache set directly ([`[rpki]`](../CONFIGURATION.md#rpki) takes
+  multiple `cache_servers`); do not proxy one instance's view through
+  the other's host.
+
+## Staggered config updates
+
+Never reload both route servers in the same step — the second instance
+is your rollback while the first proves the change. Per update:
+
+1. **Validate everywhere first:** `rustbgpd --check --strict` on the
+   candidate config on both hosts (exit 0 or stop), and check the
+   [reload matrix](../reload-matrix.md) for whether any touched field
+   is restart-required.
+2. **Reload RS1 only** (SIGHUP; parse-then-swap — a rejected candidate
+   leaves the running config untouched).
+3. **Verify RS1:** sessions established (`rbgp summary`), spot-check a
+   member's view (`rbgp rib sent <member>`), no alert movement.
+4. **Soak** for an operator-chosen window (long enough for a full
+   member announcement cycle and your monitoring interval).
+5. **Reload RS2**, re-verify, then run the consistency check below.
+
+The same stagger applies to daemon upgrades, with the
+[maintenance drain](#maintenance-window-flow) around each restart.
+
+## Inter-RS consistency: `rbgp diff advertised`
+
+Two independently rendered route servers can drift — a stale render on
+one host, a reload that never happened, a member session down on one
+side. The check is mechanical and fail-closed
+([`docs/ribdiff.md`](../ribdiff.md)): snapshot what RS2 advertises,
+compare RS1's live Adj-RIB-Out against it, gate on the exit code.
+
+Capture RS2's advertised view from its own BMP feed — wire-true,
+including attributes no CLI view renders. Enable the RFC 8671
+post-policy stream on RS2 (restart-required, so make it part of the
+standing config rather than a per-check toggle; see
+[`[bmp]`](../CONFIGURATION.md#bmp)):
+
+```toml
+[[bmp.collectors]]
+address = "192.0.2.100:11019"          # your capture/collector host
+monitor = ["rib_out_post"]
+```
+
+Then, on the capture host:
+
+```bash
+# Capture from BMP session start (Peer Ups carry the negotiated OPENs),
+# stop after every peer's dump completes, then convert and compare:
+nc -l 11019 > rs2-adjout.bmp
+rbgp diff snapshot from-bmp rs2-adjout.bmp > rs2.ndjson
+rbgp diff advertised --against rs2.ndjson    # pointed at RS1's gRPC socket
+echo $?   # 0 in sync, 1 divergent (listed), 2 comparison refused
+```
+
+Run it after every staggered rollout completes, and on a schedule
+between rollouts; archive the `--json` report. Expected divergence,
+not a finding: a member session down on exactly one instance makes
+that member's routes one-sided everywhere. Anything else is drift —
+diff the two hosts' render receipts and reload timestamps first.
+
+## Maintenance-window flow
+
+Taking RS1 down (upgrade, host maintenance) without a member-visible
+routing gap — RFC 8326 graceful shutdown, initiator side (full
+semantics and verification in
+[OPERATIONS.md](../OPERATIONS.md#rfc-8326-graceful-shutdown-community-planned-maintenance)):
+
+1. **Confirm RS2 is healthy and consistent** (the diff above, all
+   member sessions established). Two-instance redundancy means never
+   starting maintenance while the survivor is degraded.
+2. **Drain RS1:** `rbgp gshut` (all peers). Outbound paths get the
+   `GRACEFUL_SHUTDOWN` community; members honoring it demote those
+   paths, so the RS2-learned copies win *before* anything closes.
+3. **Wait for the shift** (operator-defined; verify on a member:
+   the RS1-learned paths show demoted preference, best paths point at
+   RS2-learned copies).
+4. **Do the maintenance.** Members stay converged via RS2.
+5. **Restore RS1**, wait for sessions and full table
+   (`rbgp summary`, `rbgp rib sent <member> --count` plausible).
+6. **Clear the drain:** `rbgp gshut --clear` (the toggle does not
+   persist across restart by design — after a restart-type
+   maintenance, step 6 is a no-op, but run it when the daemon kept
+   running). Re-run the consistency check.
+
+The honest caveat: the drain only moves members that honor
+`GRACEFUL_SHUTDOWN` (rustbgpd receivers opt in via
+`honor_graceful_shutdown`; support varies across member stacks).
+Members that ignore it still reconverge onto RS2 when the sessions
+close — the drain turns that reconvergence from break-before-make into
+make-before-break for everyone who participates.

--- a/docs/ixp-evaluation.md
+++ b/docs/ixp-evaluation.md
@@ -1,0 +1,30 @@
+# IXP route-server evaluation matrix
+
+One page for an exchange evaluating rustbgpd as a route server: the
+capabilities IXP evaluations actually score, each with its current
+status and a link to the config, cookbook, ADR, or measurement receipt
+that backs it. Statuses are deliberately conservative — an "In
+progress" row says exactly what is missing, and where an incumbent
+currently does better, the row links the comparison rather than
+omitting it. To evaluate against live members with zero blast radius,
+start with the
+[route-server shadow pilot](cookbook/route-server-shadow-pilot.md).
+
+| # | Capability | Status | What exists | Evidence |
+|---|------------|--------|-------------|----------|
+| 1 | Config generation (arouteserver pipeline) | Yes | Keep your `general.yml` / `clients.yml` and refresh cadence: `arouteserver template-context` → in-repo `rs-config-render` → fail-stale render → `--check --strict` validated reload, proven end to end against the pinned official arouteserver image. Upstream arouteserver has no rustbgpd target — the render step is maintained here, not there. | [IXP filter pipeline](cookbook/ixp-filter-pipeline.md) · [`tools/rs-config-render/`](../tools/rs-config-render/README.md) · [ADR-0110](adr/0110-irr-peeringdb-filtering-pipeline.md) |
+| 2 | RFC 7947/7948 route-server semantics | Yes | Byte-level transparent redistribution (verified on the wire against BIRD/GoBGP/FRR), both §2.3.2 path-hiding mitigations (Add-Path and per-client best-path), RFC 7948 §4.8 next-hop ownership rejection. | [Route-server cookbook](cookbook/route-server.md) · [ADR-0101](adr/0101-route-server-profile.md) · [ADR-0107](adr/0107-route-server-next-hop-ownership.md) · M83/M19 in [RECEIPTS.md](RECEIPTS.md) |
+| 3 | BGP communities | Yes | Standard, extended, and large communities in matching and actions across TOML and `.rpol` policy; RFC 7947 §2.3.2 / RFC 8195 control communities (per-target announce / no-announce / prepend, scrubbed on egress, transparency preserved for non-participating sessions). Extended-community control forms are deliberately not implemented. | [RFC notes](RFC_NOTES.md#rfc-7947-232--rfc-8195--route-server-control-communities) · [control-community matrix](cookbook/route-server.md#member-set-control-communities-rfc-7947-232--rfc-8195) |
+| 4 | RPKI: invalid = reject | Yes | RTR client with multi-cache union, RFC 6811 validation with `maxLength` enforced in the Invalid determination, invalid = reject at import in one deny statement; later VRP updates trigger inbound Route Refresh so verdicts track the cache. | [`[rpki]` reference](CONFIGURATION.md#rpki) · reject-at-import lab (M83) in [RECEIPTS.md](RECEIPTS.md) · rendered hygiene chain in the [pipeline](cookbook/ixp-filter-pipeline.md) |
+| 5 | IRR-based filtering | Yes | Per-member IRR prefix/origin sets (bgpq4-expanded, from arouteserver's resolved data model) rendered into trie-backed `.rpol` sets, refreshed on your existing cadence, fail-stale on any implausible or broken IRR answer. The daemon has no native IRRd/bgpq4 client — ingest rides arouteserver's. | [IXP filter pipeline](cookbook/ixp-filter-pipeline.md) · [ADR-0110](adr/0110-irr-peeringdb-filtering-pipeline.md) |
+| 6 | Looking glass incl. filtered routes | Yes | Alice-LG through the birdwatcher adapter: status, peer, and accepted views, a filtered-route view served from the daemon's reject-retention store (with machine-readable reject-reason communities), and a noexport view from a live export dry run. Coverage is IPv4/IPv6 unicast single-table only. | [birdwatcher adapter](../examples/birdwatcher-adapter/README.md) · [Alice-LG wiring](cookbook/ixp-filter-pipeline.md#6-looking-glass-alice-lg-via-the-birdwatcher-adapter) |
+| 7 | Reload at IRR scale | In progress | Published today: a full import+export policy swap under 700 live sessions / 400k routes, with UPDATE-stall and completion measured against BIRD and OpenBGPD on the same host — OpenBGPD currently wins the stall metric, stated plainly in the matrix. A receipt at full IRR-sized member prefix-sets is being produced. | [Reload-stall receipt](perf/reload-stall-2026-07.md) · [IXP matrix, S2](perf/ixp-matrix-2026-07.md#s2--reload-stall-and-completion) |
+| 8 | Paired-RS operations | Yes | Runbook for two independent route servers: why members peer with both, staggered config updates, inter-RS consistency checked with `rbgp diff advertised`, and the maintenance-window drain flow (RFC 8326). | [Paired route servers](cookbook/paired-route-servers.md) |
+| 9 | MANRS documentation | Yes | MANRS IXP Programme Action 1 mapped requirement-by-requirement to validated config fragments and the surfaces that make each control member-verifiable. | [MANRS IXP Action 1](cookbook/manrs-ixp-action1.md) |
+
+Related evaluation material: the broader daemon
+[feature comparison](COMPARISON.md), the
+[reload classification of every config field](reload-matrix.md), the
+[receipt index](RECEIPTS.md) behind every wire-behavior and performance
+claim, and the [migration notes](cookbook/route-server-migration.md)
+for mapping an existing BIRD / OpenBGPD / ARouteServer deployment.


### PR DESCRIPTION
The publishable-now parts of the IXP-evaluator documentation track: a one-page evaluation matrix, the MANRS Action 1 mapping, and the paired-route-server runbook.

## What's in it

**`docs/ixp-evaluation.md`** — one-page evaluation matrix for an IXP route-server evaluator. Nine capability rows (config generation, RFC 7947/7948 semantics, communities, RPKI invalid=reject, IRR filtering, looking glass incl. filtered routes, reload at IRR scale, paired-RS operations, MANRS documentation), each with a status and a link to the config, cookbook, ADR, or measurement receipt behind it. Losses are stated where they exist: the reload row says OpenBGPD currently wins the stall metric and links the matrix; the IRR-scale reload receipt is marked in progress rather than claimed.

**`docs/cookbook/manrs-ixp-action1.md`** — MANRS IXP Programme Action 1 ([MANRS-004.01](https://manrs.org/specifications/MANRS-004/01/), the normative spec) mapped requirement-by-requirement to rustbgpd: RPKI invalid=reject including maxLength, IRR filtering via the render pipeline, bogon/martian hygiene, the RFC 8212 posture (stated plainly as opt-in), per-family prefix limits, and the surfaces that make each control member-verifiable. Also notes the looking-glass coverage of the programme's Action 5.

**`docs/cookbook/paired-route-servers.md`** — operating two independent route servers: why members peer with both, staggered config rollout, inter-RS consistency via a BMP `rib_out_post` capture + `rbgp diff snapshot from-bmp` + `rbgp diff advertised`, and the RFC 8326 maintenance-window drain flow with its honest caveat (only members honoring the community drain early).

Index rows added in `docs/README.md` (how-to + reference tables) and `docs/cookbook/README.md` (recipe + runbook tables).

## Validation

- The complete MANRS example passes `rustbgpd --check --strict` (exit 0); the partial fragments were composed onto that base and also pass (exit 0), including the per-member limits fragment and the paired-RS BMP collector fragment.
- Every relative link and anchor in the three new pages resolves against the tree.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast`, `cargo doc --workspace --no-deps`, `scripts/check-clippy-reasons.py`: all exit 0.
