### PR TITLE
Add IRR-scale reload-receipt harness (four-cell matrix over reloadstall)

### DIFF
--- a/bench/scale/irrreload/README.md
+++ b/bench/scale/irrreload/README.md
@@ -1,0 +1,171 @@
+# irrreload — IRR-scale reload-receipt matrix
+
+Reload stall + completion under live sessions with a realistic multi-MB
+IRR-generated member policy, for rustbgpd on **both** reload paths (SIGHUP
+parse-then-swap and the gRPC transactional apply) versus BIRD 3.3.x and
+OpenBGPD 9.x.
+
+This directory is the campaign runner and protocol. The instrument is the
+existing `bench/scale/reloadstall` harness, unchanged — real BGP stub
+sessions over loopback TCP, receiver-side timestamps, generation-marker
+completion tracking — driven by `bench/scale/reloadstall/gen-irr-scenario.py`,
+which emits all four cells from one seeded dataset.
+
+## What is being reloaded
+
+The IXP operation this models is the routine IRR filter refresh: the daily
+regeneration of every member's prefix filters from IRR/PeeringDB data,
+pushed into the running route server while sessions stay up. Between the two
+policy generations:
+
+- a parameterized fraction of members (default 10%) get ~1% of their filter
+  list's padding prefixes replaced — content-real, output-neutral (announced
+  prefixes are never touched), forcing a real recompile of multi-thousand-
+  entry prefix sets;
+- the export marker community swaps (`65400:1000` ⇄ `65400:2000`), forcing
+  the full re-advertisement the harness timestamps for completion — the same
+  mechanics as `docs/perf/ixp-matrix-2026-07.md` S2.
+
+## Shape (a harness parameter, stated exactly)
+
+| Parameter | Smoke (`SMOKE=1`) | Measured default |
+|---|---|---|
+| Members (`N_MEMBERS`) | 10 | 320 |
+| Announced base table (`TOTAL_PREFIXES`) | 100 (10 × /24 each) | 183,040 (572 × /24 each) |
+| Per-member IRR filter list (`MIN_LIST`–`MAX_LIST`) | 100 | log-uniform 1,000–40,000 entries |
+| Generation-changed members (`CHANGED_FRACTION`) | 10% | 10% |
+| Seed (`SEED`) | 61 | 61 |
+| Reload cycles per cell (`RELOADS`) | 1 | 4 |
+
+Dataset generation is fully deterministic from the shape + seed and is
+identical across cells (the generator never consults the cell when building
+the dataset). The multi-MB configs are **not** committed; they reproduce
+from the generator alone. Padding prefixes are /24s from
+30.0.0.0–99.255.255.0 (disjoint from the announced table, the churn range,
+and the bogon list).
+
+## Cells and reload mechanisms
+
+| Cell | Policy representation | Reload mechanism |
+|---|---|---|
+| `rustbgpd-sighup` | `.rpol` per-member IRR filters rendered by `tools/rs-config-render` (the production IRR pipeline renderer) from a synthetic `arouteserver template-context` document, concatenated into one swapped file | copy generation file over live, `SIGHUP` |
+| `rustbgpd-txn` | same dataset as inline `[policy.definitions]` chain-engine statements in a full candidate config TOML | copy candidate, `rbgp config plan` + `config apply` with the plan's snapshot token (`txn-apply.sh`) |
+| `bird` | per-member prefix-set `define`s + import filters in the swapped include file | copy include, `birdc configure` |
+| `openbgpd` | per-member `prefix-set`s + `source-as`/`prefix-set` allow rules in the swapped include file | copy include, `bgpctl reload` |
+
+## Measurement definitions (precommitted)
+
+All receiver-side, identical to the IXP matrix instrument; one row per
+reload cycle per cell in `rows.csv` (the harness's `reloadstall_csv`
+record):
+
+- **Reload stall** — per-observer maximum inter-UPDATE gap in the 120 s
+  window after the reload trigger (`*_maxgap_{p50,p95,max}_ms`), against
+  the quiet control-window baseline. Wire-observable: timestamps are taken
+  in the stubs after full wire framing + decode. The trigger timestamp is
+  taken immediately before invoking the reload mechanism, so
+  `birdc`/`bgpctl`/`rbgp` cells include their control-channel round-trip
+  (SIGHUP has none; the txn cell's plan+apply round-trips are deliberately
+  inside the window — they are that path's reload cost).
+- **Completion** — time until an observer holds every expected unique
+  non-self base-table prefix re-advertised with the new generation marker
+  community (`completion_{p50,p95,max}_s`); duplicates never advance the
+  window; churn prefixes are excluded by prefix range.
+- **RSS during reload** — `rss_before_mib`/`rss_after_mib` sampled from
+  `/proc/<pid>` around each reload for the bare rustbgpd cells, plus the
+  full process-tree 5 s-cadence sampler (`bench/scale/matrix/rss-sampler.sh`)
+  for every cell (`rss.csv`; the only RSS instrument for the container
+  cells).
+
+**Acceptance / abort criteria** (a cycle emits no row, the cell fails):
+any stub session down at reload validation, missing generation-marker
+evidence, any daemon UPDATE that fails to decode, a nonzero reload-command
+exit, daemon process-tree RSS > 100 GiB (cell aborted), or cell timeout
+(`CELL_TIMEOUT`). Failed cells keep their artifacts and are published with
+their mechanism, not silently rerun (`status` files make the campaign
+resumable per cell).
+
+**Run count**: two full independent campaign runs minimum (fresh daemon
+starts, same cell order) so run-to-run spread is visible — run B into a
+separate `ARTIFACTS_DIR`.
+
+**Host-quiet preconditions** (measured mode enforces): the campaign starts
+only after `tests/soak/preflight.sh` passes (competing-workload, host-lock,
+disk and mutex checks; `SKIP_PREFLIGHT=1` to override deliberately), plus a
+1-min loadavg < 2.0 gate before each cell and 300 s cool-downs between
+cells. `SMOKE=1` skips all quiet gates because it is a pipeline proof, not
+a measurement.
+
+## Comparability protocol
+
+Mirrors the IXP matrix fairness notes (`docs/perf/ixp-matrix-2026-07.md`):
+
+- **One harness, one instrument** for all cells; same addressing, same
+  churn, same completion semantics.
+- **Same dataset, native idiom per daemon.** Every cell filters the same
+  member/prefix dataset with the same semantic core — per-member
+  (origin-AS ∈ member origin set) ∧ (prefix ∈ member filter list), plus a
+  shared hygiene preamble (AS_PATH length cap 32, bogon reject:
+  10.0.0.0/8, 192.168.0.0/16 — 172.16.0.0/12 deliberately excluded because
+  the harness churn blocks live there) and the generation-marker export
+  tag — expressed in each daemon's native form.
+- **Each daemon reloaded by its operator-documented mechanism** at its
+  documented route-server configuration (BIRD `rs client` + threads knob;
+  OpenBGPD `transparent-as` + `nexthop qualify via default`; rustbgpd
+  `route_server_client` + `per_client_best`).
+
+Documented asymmetries (the honesty notes for the eventual receipt):
+
+- **Reload-semantic asymmetry.** SIGHUP + `.rpol` swap re-parses only the
+  policy files; `birdc configure` and `bgpctl reload` re-parse the entire
+  config; the rustbgpd transactional path parses + diffs + classifies a
+  full candidate config and round-trips plan/apply over gRPC. These are
+  each path's documented reload operation — not the same amount of work.
+- **The two rustbgpd cells use different policy engines.** The
+  transaction seam rejects out-of-band `.rpol` content changes by design
+  (`docs/reload-matrix.md`), so the txn cell carries the dataset as inline
+  chain-engine definitions while the SIGHUP cell uses the production
+  `.rpol` route-server representation. Cross-daemon comparisons should use
+  the SIGHUP cell; the txn cell answers "what does the transactional seam
+  cost for the same semantic change", not engine-vs-engine.
+- **The txn cell is size-capped today.** The candidate travels inside one
+  gRPC message and the daemon's tonic server uses the default ~4 MiB
+  decode limit, and the chain-engine TOML encoding is several times larger
+  than the equivalent `.rpol`. At the measured default shape the candidate
+  far exceeds the cap, so the transactional cell must run at the largest
+  shape that fits (or the daemon must grow a raised/streamed limit first —
+  a finding of this harness, to be stated in the receipt either way).
+- **Hygiene depth differs slightly.** The rustbgpd SIGHUP cell carries the
+  full rendered `rs-hygiene` (including the AS_SET-segment reject term);
+  the chain engine and the BIRD/OpenBGPD cells carry the shared core
+  (path-length + bogons) only. All hygiene is generation-static and
+  constant-size, so it does not contribute to the reload delta being
+  measured.
+- **Bench plumbing edits on the rendered config.** The SIGHUP cell's
+  `config.toml` is rs-config-render output with asserted, session-level
+  patches for the loopback contract (listen port, runtime/UDS paths,
+  `next_hop_ownership` dropped because the stubs use the synthetic
+  10.9.x.y NEXT_HOP; BIRD gets `next hop keep` + glue routes and OpenBGPD
+  `nexthop qualify via default` for the same reason; max-prefix ceilings
+  disabled in the context). Rendered policy files are never edited.
+- **Padding realism ceiling**: filter-list padding entries are all /24s;
+  real IRR lists mix lengths. Constant across daemons and generations.
+
+## Running
+
+```bash
+# Smoke (pipeline proof, any host, ~minutes):
+SMOKE=1 bench/scale/irrreload/run-irr-reload.sh
+
+# Measured campaign (quiet host only — preflight-gated), two runs:
+bench/scale/irrreload/run-irr-reload.sh
+ARTIFACTS_DIR=/tmp/irrreload-artifacts-runB bench/scale/irrreload/run-irr-reload.sh
+```
+
+The runner builds what it needs (`rustbgpd`, `rbgp`, `rs-config-render`,
+the harness), generates each cell's scenario under `/tmp/irr-<cell>` (short
+paths: the gRPC UDS must fit `SUN_LEN`), runs one cell at a time, tears
+down containers/daemons, and appends one row per reload to
+`$ARTIFACTS_DIR/rows.csv`. Exit code 0 requires every requested cell to
+pass and produce at least `RELOADS` rows. Container images: `bird:3.3.1`
+(built from `tests/interop/Dockerfile.bird3`) and `openbgpd/openbgpd:9.1`.

--- a/bench/scale/irrreload/run-irr-reload.sh
+++ b/bench/scale/irrreload/run-irr-reload.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# IRR-scale reload-receipt matrix: sequential policy-reload cells across
+# daemons and, for rustbgpd, across both reload paths. See README.md for the
+# precommitted measurement definitions, fairness protocol, and abort
+# criteria.
+#
+# Cells:
+#   rustbgpd-sighup  bare release binary; rs-config-render-derived .rpol
+#                    member policy; SIGHUP parse-then-swap reloads
+#   rustbgpd-txn     bare release binary; same dataset as inline
+#                    [policy.definitions] chains; gRPC `rbgp config
+#                    plan`+`apply` transactional reloads (txn-apply.sh)
+#   bird             BIRD 3.3.x in docker --network=host; `birdc configure`
+#   openbgpd         OpenBGPD 9.x in docker --network=host; `bgpctl reload`
+#
+# Usage: run-irr-reload.sh [cell ...]
+#        (default: rustbgpd-sighup rustbgpd-txn bird openbgpd)
+#
+# Modes:
+#   SMOKE=1   pipeline proof at a tiny shape (10 members x 100-entry lists,
+#             1 reload/cell, no host-quiet gates). NOT a measurement.
+#   default   the measured shape. Requires a quiet host: runs
+#             tests/soak/preflight.sh first (SKIP_PREFLIGHT=1 to override),
+#             1-min loadavg gate before each cell, 300 s cool-downs.
+#
+# Knobs (env): N_MEMBERS TOTAL_PREFIXES MIN_LIST MAX_LIST SEED
+#              CHANGED_FRACTION PORT RELOADS CONTROL_SECS BIRD_THREADS
+#              CELL_TIMEOUT ARTIFACTS_DIR SKIP_PREFLIGHT
+set -u
+
+REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+RSTALL="$REPO/bench/scale/reloadstall"
+HARNESS="$RSTALL/target/release/reloadstall"
+GEN="$RSTALL/gen-irr-scenario.py"
+SAMPLER="$REPO/bench/scale/matrix/rss-sampler.sh"
+TXN_APPLY="$REPO/bench/scale/irrreload/txn-apply.sh"
+RBGP="$REPO/target/release/rbgp"
+RENDER="$REPO/target/release/rs-config-render"
+DAEMON="$REPO/target/release/rustbgpd"
+
+SMOKE="${SMOKE:-}"
+if [ -n "$SMOKE" ]; then
+    N_MEMBERS="${N_MEMBERS:-10}"
+    TOTAL_PREFIXES="${TOTAL_PREFIXES:-100}"
+    MIN_LIST="${MIN_LIST:-100}"
+    MAX_LIST="${MAX_LIST:-100}"
+    RELOADS="${RELOADS:-1}"
+    CONTROL_SECS="${CONTROL_SECS:-5}"
+    CELL_TIMEOUT="${CELL_TIMEOUT:-900}"
+    COOL_DOWN=5
+else
+    # The measured shape: 320 members, 572 announced /24s each (the IXP
+    # matrix per-member slice), IRR filter lists log-uniform 1k-40k entries.
+    N_MEMBERS="${N_MEMBERS:-320}"
+    TOTAL_PREFIXES="${TOTAL_PREFIXES:-183040}"
+    MIN_LIST="${MIN_LIST:-1000}"
+    MAX_LIST="${MAX_LIST:-40000}"
+    RELOADS="${RELOADS:-4}"
+    CONTROL_SECS="${CONTROL_SECS:-30}"
+    CELL_TIMEOUT="${CELL_TIMEOUT:-7200}"
+    COOL_DOWN=300
+fi
+SEED="${SEED:-61}"
+CHANGED_FRACTION="${CHANGED_FRACTION:-0.1}"
+PORT="${PORT:-1790}"
+BIRD_THREADS="${BIRD_THREADS:-8}"
+ART="${ARTIFACTS_DIR:-/tmp/irrreload-artifacts}"
+RSS_LIMIT_KIB=$((100 * 1024 * 1024)) # abort a cell past 100 GiB (precommitted)
+
+CELLS=("$@")
+[ ${#CELLS[@]} -eq 0 ] && CELLS=(rustbgpd-sighup rustbgpd-txn bird openbgpd)
+
+for tool in docker jq python3 cargo; do
+    command -v "$tool" >/dev/null || {
+        echo "missing required tool: $tool" >&2
+        exit 1
+    }
+done
+
+if [ -z "$SMOKE" ] && [ -z "${SKIP_PREFLIGHT:-}" ]; then
+    echo "=== host-quiet preflight (tests/soak/preflight.sh) ==="
+    "$REPO/tests/soak/preflight.sh" || {
+        echo "preflight failed; fix the host or set SKIP_PREFLIGHT=1" >&2
+        exit 1
+    }
+fi
+
+echo "=== builds ==="
+(cd "$REPO" && cargo build --release -q -p rustbgpd -p rustbgpctl -p rs-config-render) || exit 1
+(cd "$RSTALL" && cargo build --release -q) || exit 1
+for bin in "$HARNESS" "$RBGP" "$RENDER" "$DAEMON"; do
+    [ -x "$bin" ] || {
+        echo "missing binary after build: $bin" >&2
+        exit 1
+    }
+done
+mkdir -p "$ART"
+
+cleanup() {
+    # shellcheck disable=SC2317  # invoked via trap
+    docker rm -f irr-bird irr-obgpd >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+load_gate() {
+    [ -n "$SMOKE" ] && return 0
+    local load
+    while :; do
+        load=$(cut -d' ' -f1 /proc/loadavg)
+        if awk -v l="$load" 'BEGIN { exit !(l < 2.0) }'; then return 0; fi
+        echo "load_gate: 1-min loadavg $load >= 2.0, waiting 30s"
+        sleep 30
+    done
+}
+
+gen_scenario() {
+    local cell=$1 run=$2
+    shift 2
+    python3 "$GEN" "$cell" "$N_MEMBERS" "$TOTAL_PREFIXES" "$run" \
+        --port "$PORT" --seed "$SEED" --min-list "$MIN_LIST" \
+        --max-list "$MAX_LIST" --changed-fraction "$CHANGED_FRACTION" "$@"
+}
+
+# run_cell <cell>: one matrix cell. Nonzero return = cell failed; the
+# campaign continues (matrix convention).
+run_cell() {
+    local cell=$1
+    local cdir="$ART/$cell"
+    # Short run dir: the gRPC UDS path must fit SUN_LEN.
+    local run="/tmp/irr-$cell"
+    rm -rf "$run"
+    mkdir -p "$cdir" "$run"
+
+    local daemon_pid="" container="" reload_cmd="" pid_arg=""
+    local live a b
+    case $cell in
+    rustbgpd-sighup)
+        gen_scenario rustbgpd "$run" --render-bin "$RENDER" || return 1
+        "$DAEMON" "$run/config.toml" >"$cdir/daemon.log" 2>&1 &
+        daemon_pid=$!
+        live="$run/member.rpol" a="$run/gen-a.rpol" b="$run/gen-b.rpol"
+        pid_arg=$daemon_pid # SIGHUP path: harness signals + samples this PID
+        ;;
+    rustbgpd-txn)
+        gen_scenario rustbgpd-txn "$run" || return 1
+        "$DAEMON" "$run/config.toml" >"$cdir/daemon.log" 2>&1 &
+        daemon_pid=$!
+        live="$run/candidate.toml" a="$run/gen-a.toml" b="$run/gen-b.toml"
+        pid_arg=$daemon_pid # RSS from the real PID; reloads via reload_cmd
+        reload_cmd="$TXN_APPLY $RBGP unix://$run/grpc.sock $run/candidate.toml"
+        ;;
+    bird)
+        gen_scenario bird "$run" --threads "$BIRD_THREADS" || return 1
+        container="irr-bird"
+        docker rm -f "$container" >/dev/null 2>&1
+        docker run -d --name "$container" --network=host -v "$run":/etc/bird \
+            bird:3.3.1 bird -f -c /etc/bird/bird.conf >/dev/null || return 1
+        reload_cmd="docker exec $container birdc configure"
+        live="$run/gen.conf" a="$run/gen-a.conf" b="$run/gen-b.conf"
+        pid_arg=0 # the outer sampler owns RSS
+        ;;
+    openbgpd)
+        gen_scenario openbgpd "$run" || return 1
+        container="irr-obgpd"
+        docker rm -f "$container" >/dev/null 2>&1
+        docker run -d --name "$container" --network=host -v "$run":/etc/bgpd \
+            openbgpd/openbgpd:9.1 >/dev/null || return 1
+        reload_cmd="docker exec $container bgpctl reload"
+        live="$run/gen.conf" a="$run/gen-a.conf" b="$run/gen-b.conf"
+        pid_arg=0
+        ;;
+    *)
+        echo "unknown cell: $cell" >&2
+        return 1
+        ;;
+    esac
+
+    sleep 3
+    if [ -n "$container" ]; then
+        daemon_pid=$(docker inspect -f '{{.State.Pid}}' "$container") || daemon_pid=0
+        if [ "$daemon_pid" -le 0 ]; then
+            echo "cell $cell: container died at start" >&2
+            docker logs "$container" >"$cdir/daemon.log" 2>&1
+            docker rm -f "$container" >/dev/null 2>&1
+            return 1
+        fi
+    elif [ ! -d "/proc/$daemon_pid" ]; then
+        echo "cell $cell: daemon died at start (see $cdir/daemon.log)" >&2
+        return 1
+    fi
+
+    "$SAMPLER" "$daemon_pid" "$cdir/rss.csv" 5 &
+    local sampler_pid=$!
+
+    local hargs=("$N_MEMBERS" "$TOTAL_PREFIXES" "$PORT" "$pid_arg"
+        "$live" "$a" "$b" "$RELOADS" "$CONTROL_SECS")
+    # reload_cmd is positional arg 11, so cells using it pass an explicit
+    # all-changed cohort (same completion semantics as the 9-arg form).
+    [ -n "$reload_cmd" ] && hargs+=("$N_MEMBERS" "$reload_cmd")
+
+    # Background so the precommitted RSS abort criterion can kill the cell.
+    timeout "$CELL_TIMEOUT" "$HARNESS" "${hargs[@]}" >"$cdir/reloadstall.log" 2>&1 &
+    local hpid=$!
+    local rc=""
+    while kill -0 "$hpid" 2>/dev/null; do
+        local last_kib
+        last_kib=$(tail -n1 "$cdir/rss.csv" 2>/dev/null | cut -d, -f2)
+        case ${last_kib:-} in
+        '' | *[!0-9]*) ;;
+        *)
+            if [ "$last_kib" -gt "$RSS_LIMIT_KIB" ]; then
+                echo "cell $cell: daemon RSS ${last_kib} KiB > 100 GiB, aborting cell" >&2
+                kill "$hpid" 2>/dev/null
+                rc=99
+            fi
+            ;;
+        esac
+        sleep 5
+    done
+    local hrc
+    wait "$hpid"
+    hrc=$?
+    [ -z "$rc" ] && rc=$hrc
+
+    kill "$sampler_pid" 2>/dev/null
+    if [ -n "$container" ]; then
+        docker logs "$container" >"$cdir/daemon.log" 2>&1
+        docker rm -f "$container" >/dev/null 2>&1
+    else
+        kill "$daemon_pid" 2>/dev/null
+    fi
+    cp "$run/manifest.json" "$cdir/manifest.json" 2>/dev/null
+    if [ "$rc" -eq 0 ]; then
+        grep '^reloadstall_csv,' "$cdir/reloadstall.log" |
+            sed "s/^reloadstall_csv/$cell/" >>"$ART/rows.csv"
+        rm -rf "$run" # scenario reproduces from the generator + manifest
+    fi
+    echo "cell $cell: harness rc=$rc (artifacts: $cdir)"
+    return "$rc"
+}
+
+grep -q '^cell,' "$ART/rows.csv" 2>/dev/null || echo \
+    "cell,reload,peers_total,peers_changed,peers_stable,prefixes,completion_p50_s,completion_p95_s,completion_max_s,changed_maxgap_p50_ms,changed_maxgap_p95_ms,changed_maxgap_max_ms,all_observer_maxgap_p50_ms,all_observer_maxgap_p95_ms,all_observer_maxgap_max_ms,changed_first_update_p50_ms,changed_first_update_p95_ms,changed_first_update_max_ms,rss_before_mib,rss_after_mib,stable_marker_peers,sessions_up,parse_errors" \
+    >"$ART/rows.csv"
+
+overall=0
+for cell in "${CELLS[@]}"; do
+    status_file="$ART/$cell/status"
+    if [ -f "$status_file" ] && grep -qx pass "$status_file"; then
+        echo "cell $cell: already pass, skipping (rm $status_file to rerun)"
+        continue
+    fi
+    load_gate
+    echo "=== cell $cell start $(date -Is) ==="
+    if run_cell "$cell"; then
+        echo pass >"$status_file"
+        echo "=== cell $cell PASS $(date -Is) ==="
+    else
+        echo "fail rc=$? $(date -Is)" >"$status_file"
+        echo "=== cell $cell FAIL ==="
+        overall=1
+    fi
+    echo "cool-down ${COOL_DOWN}s"
+    sleep "$COOL_DOWN"
+done
+
+# Completion gate: every requested cell passed and produced its rows.
+for cell in "${CELLS[@]}"; do
+    grep -qx pass "$ART/$cell/status" 2>/dev/null || overall=1
+    rows=$(grep -c "^$cell," "$ART/rows.csv" 2>/dev/null)
+    if [ "${rows:-0}" -lt "$RELOADS" ]; then
+        echo "cell $cell: expected >= $RELOADS measurement rows, found ${rows:-0}" >&2
+        overall=1
+    fi
+done
+echo "measurement rows: $ART/rows.csv"
+exit "$overall"

--- a/bench/scale/irrreload/txn-apply.sh
+++ b/bench/scale/irrreload/txn-apply.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# One gRPC transactional reload: plan the candidate, then apply it with the
+# plan's runtime snapshot token. Used as the reloadstall harness's
+# `reload_cmd` for the rustbgpd-txn cell — the harness copies the next
+# generation over the candidate path first, then invokes this; a nonzero
+# exit fails the reload like a failed SIGHUP.
+#
+# Usage: txn-apply.sh <rbgp-binary> <grpc-addr> <candidate-toml>
+set -u
+
+if [ $# -ne 3 ]; then
+    echo "usage: txn-apply.sh <rbgp-binary> <grpc-addr> <candidate-toml>" >&2
+    exit 2
+fi
+rbgp=$1
+addr=$2
+candidate=$3
+
+plan_json=$("$rbgp" --addr "$addr" --json config plan "$candidate")
+rc=$?
+if [ "$rc" -eq 0 ]; then
+    # Plan exit 0 = noop candidate: a reload that changes nothing is a
+    # scenario bug, not a measurable reload.
+    echo "txn-apply: candidate is a noop (plan exit 0)" >&2
+    exit 1
+fi
+if [ "$rc" -ne 2 ]; then
+    echo "txn-apply: config plan failed (exit $rc)" >&2
+    exit 1
+fi
+token=$(printf '%s' "$plan_json" | jq -r '.runtime_snapshot_token // empty')
+if [ -z "$token" ]; then
+    echo "txn-apply: plan returned no runtime_snapshot_token" >&2
+    exit 1
+fi
+exec "$rbgp" --addr "$addr" config apply "$candidate" \
+    --expected-runtime-snapshot-token "$token"

--- a/bench/scale/reloadstall/gen-irr-scenario.py
+++ b/bench/scale/reloadstall/gen-irr-scenario.py
@@ -1,0 +1,727 @@
+#!/usr/bin/env python3
+"""Generate the IRR-scale reload scenario for one cell of the IRR reload matrix.
+
+Same harness (`src/main.rs`), same addressing contract as the sibling
+generators (stub `i` binds 127.1.(i//200).(i%200+1), ASN 64512+i, announces
+/24 slices of the 20.0.0.0-base table, last 8 stubs churn 172.16+c.j.0/24
+blocks), but the policy being reloaded is an IRR-scale member policy: every
+member carries an IRR-style filter list (its announced slice + its churn
+block + deterministic padding prefixes drawn from 30.0.0.0-99.255.255.0),
+sized log-uniformly between --min-list and --max-list entries. The whole
+generation-varying policy lives in ONE file per daemon, so the harness's
+frozen copy-then-reload contract drives every cell unchanged.
+
+Cells:
+  rustbgpd      SIGHUP parse-then-swap cell. The member policy is rendered by
+                `rs-config-render` (the production IRR pipeline renderer) from
+                a synthetic `arouteserver template-context` document built
+                from the dataset; the rendered rs-hygiene + per-client .rpol
+                files are concatenated (plus the generation marker export
+                policy) into gen-a.rpol/gen-b.rpol and the rendered
+                config.toml is patched for the loopback bench contract (see
+                patch_rendered_config for the exact, asserted edits).
+  rustbgpd-txn  gRPC transactional cell. The config-transaction seam rejects
+                out-of-band .rpol content changes by design, so this cell
+                expresses the same dataset as inline [policy.definitions]
+                chain-engine statements; the swapped artifact is a full
+                candidate config TOML, applied via `rbgp config plan/apply`.
+  bird          BIRD 3.3.x route server; per-member prefix-set defines +
+                import filters in the swapped include file, `birdc configure`.
+  openbgpd      OpenBGPD 9.x route server; per-member prefix-sets +
+                source-as/prefix-set allow rules in the swapped include file,
+                `bgpctl reload`.
+
+The dataset is derived only from (n_members, total_prefixes, seed, list
+bounds, changed fraction) — never from the cell — so all four cells filter
+the SAME member/prefix data. Generation B replaces the first `delta` padding
+prefixes of each changed member's list with fresh ones (content-real,
+output-neutral: announced and churn prefixes are never touched) and swaps the
+export marker community 65400:1000 -> 65400:2000, which forces the full
+re-advertisement the harness timestamps for completion. Marker admin 65400 is
+deliberately not the route-server ASN (65500): RS-administered standard
+communities are RFC 7947 control forms scrubbed from the wire toward members.
+
+Bogon hygiene deliberately omits 172.16.0.0/12: the harness's churn blocks
+live at 172.16-23.x and must propagate for the inter-UPDATE gap baseline.
+
+Usage:
+    gen-irr-scenario.py <cell> <n_members> <total_prefixes> <out_dir>
+        [--port 1790] [--seed 61] [--min-list 1000] [--max-list 40000]
+        [--changed-fraction 0.1] [--render-bin PATH] [--threads 8]
+        [--conf-dir DIR]
+
+Emits into <out_dir> (per cell):
+  rustbgpd      config.toml, member.rpol (live, = gen-a), gen-a.rpol,
+                gen-b.rpol, render-{a,b}/ (rs-config-render output + receipt)
+  rustbgpd-txn  config.toml (boot, = gen-a), candidate.toml (live swap file),
+                gen-a.toml, gen-b.toml
+  bird          bird.conf, gen.conf (live, = gen-a), gen-a.conf, gen-b.conf
+  openbgpd      bgpd.conf, gen.conf (live, = gen-a), gen-a.conf, gen-b.conf
+plus manifest.json (shape, seed, per-member list sizes, changed members,
+emitted byte sizes) in every cell.
+"""
+
+import argparse
+import json
+import math
+import pathlib
+import random
+import subprocess
+import sys
+
+CHURNERS = 8
+CHURN_BLOCK = 16
+RS_ASN = 65500  # matches gen-bird/gen-obgpd; not in the stub ASN range
+MARKER_ADMIN = 65400
+MARKER = {"a": 1000, "b": 2000}  # must match src/main.rs COMMUNITY_GEN_A/B
+# Padding prefixes are /24s drawn from 30.0.0.0-99.255.255.0: disjoint from
+# the announced base table (20.x-26.x at supported shapes), the churn blocks
+# (172.16-23.x) and the bogon list below.
+PADDING_FIRST_OCTET = 30
+PADDING_SPACE = 70 * 65536
+# 172.16.0.0/12 is deliberately absent (churn range, see module docstring).
+BOGONS_V4 = ["10.0.0.0/8", "192.168.0.0/16"]
+MAX_AS_PATH_LEN = 32
+
+
+def stub_addr(i: int) -> str:
+    return f"127.1.{i // 200}.{i % 200 + 1}"
+
+
+def stub_asn(i: int) -> int:
+    return 64512 + i
+
+
+def base_prefix(idx: int) -> str:
+    return f"{20 + (idx >> 16)}.{(idx >> 8) & 0xFF}.{idx & 0xFF}.0/24"
+
+
+def padding_prefix(idx: int) -> str:
+    return f"{PADDING_FIRST_OCTET + (idx >> 16)}.{(idx >> 8) & 0xFF}.{idx & 0xFF}.0/24"
+
+
+def churn_prefixes(churner: int) -> list[str]:
+    return [f"172.{16 + churner}.{j}.0/24" for j in range(CHURN_BLOCK)]
+
+
+class Member:
+    def __init__(self, idx, asn, addr, list_a, list_b):
+        self.idx = idx
+        self.asn = asn
+        self.addr = addr
+        self.list_a = list_a
+        self.list_b = list_b
+
+    def prefixes(self, gen: str) -> list[str]:
+        return self.list_a if gen == "a" else self.list_b
+
+    @property
+    def changed(self) -> bool:
+        return self.list_a != self.list_b
+
+
+def build_dataset(args) -> list[Member]:
+    """Seeded dataset; identical for every cell (never consult args.cell)."""
+    n, total = args.n_members, args.total_prefixes
+    per_peer = total // n
+    rng = random.Random(args.seed)
+    members = []
+    for i in range(n):
+        target = round(
+            math.exp(rng.uniform(math.log(args.min_list), math.log(args.max_list)))
+        )
+        fixed = [base_prefix(idx) for idx in range(i * per_peer, (i + 1) * per_peer)]
+        if i >= n - CHURNERS:
+            fixed += churn_prefixes(i - (n - CHURNERS))
+        need = max(0, target - len(fixed))
+        changed = rng.random() < args.changed_fraction and need > 0
+        delta = max(1, need // 100) if changed else 0
+        pool = [padding_prefix(p) for p in rng.sample(range(PADDING_SPACE), need + delta)]
+        list_a = fixed + pool[:need]
+        list_b = fixed + pool[delta : need + delta] if delta else list_a
+        members.append(Member(i, stub_asn(i), stub_addr(i), list_a, list_b))
+    return members
+
+
+def check_sun_len(rundir: pathlib.Path) -> str:
+    """gRPC UDS path must fit sun_path (~108 bytes); fail early like siblings."""
+    sock = f"{rundir}/grpc.sock"
+    if len(sock.encode()) > 100:
+        sys.exit(
+            f"grpc.sock path too long for SUN_LEN ({len(sock)} bytes): {sock}\n"
+            f"pass a shorter <out_dir> (e.g. /tmp/irr-rs)."
+        )
+    return sock
+
+
+def write_manifest(out: pathlib.Path, args, members, files: list[str]) -> None:
+    manifest = {
+        "cell": args.cell,
+        "n_members": args.n_members,
+        "total_prefixes": args.total_prefixes,
+        "seed": args.seed,
+        "min_list": args.min_list,
+        "max_list": args.max_list,
+        "changed_fraction": args.changed_fraction,
+        "list_sizes": [len(m.list_a) for m in members],
+        "total_filter_entries": sum(len(m.list_a) for m in members),
+        "changed_members": [m.idx for m in members if m.changed],
+        "file_bytes": {f: (out / f).stat().st_size for f in files},
+    }
+    (out / "manifest.json").write_text(json.dumps(manifest, indent=1) + "\n")
+
+
+# --- rustbgpd (SIGHUP) cell -------------------------------------------------
+
+
+def context_doc(members: list[Member], gen: str) -> dict:
+    """Synthetic `arouteserver template-context` single-document form.
+
+    Modeled on tools/rs-config-render/tests/fixtures/context-small.yml (the
+    top-level keys are pinned by the renderer's shape fingerprint). JSON is
+    valid YAML, so the document is emitted with json.dumps. Knob intents:
+    reject_invalid_as_in_as_path=false (stub ASNs are RFC 6996 private —
+    the hygiene private-ASN term would reject every route), RPKI disabled
+    (no RTR cache in the bench), max_prefix absent (no ceilings: announced
+    slices are tiny and ceilings are not what this harness measures).
+    """
+    asns, irrdb, clients = {}, {}, []
+    for m in members:
+        bundle = f"AS{m.asn}_bundle"
+        asns[f"AS{m.asn}"] = {"as_sets": [f"AS-IRRBENCH-M{m.idx}"]}
+        irrdb[bundle] = {
+            "asns": [m.asn],
+            "prefixes": [
+                {
+                    "prefix": p.split("/")[0],
+                    "length": int(p.split("/")[1]),
+                    "exact": True,
+                }
+                for p in m.prefixes(gen)
+            ],
+        }
+        clients.append(
+            {
+                "id": f"AS{m.asn}_1",
+                "asn": m.asn,
+                "ip": m.addr,
+                "description": f"member-{m.idx}",
+                "cfg": {
+                    "rfc8950": False,
+                    "blackhole_filtering": {"announce_to_client": True},
+                    "filtering": {"irrdb": {"as_set_bundle_ids": [bundle]}},
+                },
+            }
+        )
+    return {
+        "ip_ver": None,
+        "list_ip_vers": [4, 6],
+        "live_tests": False,
+        "rtt_based_functions_are_used": False,
+        "perform_graceful_shutdown": False,
+        "any_reject_cause_map_community_set": False,
+        "asn3216_map": {},
+        "arin_whois_records": {},
+        "registrobr_whois_records": {},
+        "rpki_roas": {},
+        "reject_reasons": {"1": "Invalid AS_PATH length", "2": "Prefix is bogon"},
+        "never_via_route_servers_asns": [],
+        "bogons": [
+            {
+                "prefix": p.split("/")[0],
+                "length": int(p.split("/")[1]),
+                "comment": "bench bogon (172.16/12 omitted: harness churn range)",
+            }
+            for p in BOGONS_V4
+        ],
+        "cfg": {
+            "rs_as": RS_ASN,
+            "router_id": "10.0.0.1",
+            "prepend_rs_as": False,
+            "path_hiding": True,
+            "passive": True,
+            "gtsm": False,
+            "multihop": None,
+            "add_path": False,
+            "rfc8950": False,
+            "graceful_shutdown": {"enabled": True, "local_pref": 0},
+            "blackhole_filtering": {
+                "policy_ipv4": None,
+                "policy_ipv6": None,
+                "announce_to_client": True,
+            },
+            "rtt_thresholds": None,
+            "communities": {
+                "blackholing": {"std": None, "lrg": None, "ext": None},
+                "do_not_announce_to_any": {
+                    "std": f"0:{RS_ASN}",
+                    "lrg": None,
+                    "ext": None,
+                },
+                "do_not_announce_to_peers_with_rtt_lower_than": {
+                    "std": None,
+                    "lrg": None,
+                    "ext": None,
+                },
+            },
+            "filtering": {
+                "next_hop": {"policy": "strict"},
+                "ipv4_pref_len": {"min": 8, "max": 24},
+                "ipv6_pref_len": {"min": 12, "max": 48},
+                "global_black_list_pref": [
+                    {"prefix": "192.0.2.0", "length": 24, "comment": "out-of-table"}
+                ],
+                "max_as_path_len": MAX_AS_PATH_LEN,
+                "reject_invalid_as_in_as_path": False,
+                "transit_free": {"action": "reject", "asns": [174, 3356]},
+                "irrdb": {
+                    "enforce_origin_in_as_set": True,
+                    "enforce_prefix_in_as_set": True,
+                    "allow_longer_prefixes": False,
+                    "tag_as_set": True,
+                },
+                "rpki_bgp_origin_validation": {"enabled": False, "reject_invalid": False},
+                "max_prefix": {
+                    "action": None,
+                    "count_rejected_routes": False,
+                    "peering_db": {"enabled": False},
+                    "restart_after": None,
+                    "general_limit_ipv4": 0,
+                    "general_limit_ipv6": 0,
+                },
+                "reject_policy": {"policy": "reject"},
+            },
+        },
+        "asns": asns,
+        "clients": clients,
+        "irrdb_info": irrdb,
+    }
+
+
+def marker_policy_rpol(gen: str) -> str:
+    return (
+        "\n# Generation marker export policy — appended by gen-irr-scenario.py.\n"
+        "# The harness samples this community off decoded UPDATEs to timestamp\n"
+        "# reload completion (same mechanics as the IXP receipt matrix).\n"
+        "policy irr-member-out {\n"
+        f"    term tag {{ add community {MARKER_ADMIN}:{MARKER[gen]}; accept }}\n"
+        "}\n"
+    )
+
+
+def bench_telemetry_block(rundir: pathlib.Path) -> str:
+    return (
+        "[global.telemetry]\n"
+        'log_format = "json"\n'
+        'prometheus_addr = "127.0.0.1:9179"\n'
+        "\n"
+        "[global.telemetry.grpc_uds]\n"
+        f'path = "{rundir}/grpc.sock"\n'
+        "\n"
+        "[security.grpc]\n"
+        "# Loopback benchmark: UDS access is gated by file perms.\n"
+        'enforcement = "legacy"\n'
+        "\n"
+    )
+
+
+def patch_rendered_config(text: str, n: int, port: int, rundir: pathlib.Path) -> str:
+    """Adapt rs-config-render output to the loopback bench contract.
+
+    Every edit is asserted so renderer-output drift fails loudly instead of
+    producing a silently different scenario. Policy content (the rendered
+    .rpol files) is never touched here — only session/telemetry plumbing:
+      - listen_port + runtime_state_dir for the bench port and run dir;
+      - the telemetry/security block (bench UDS path, prometheus, legacy);
+      - next_hop_ownership dropped (the harness's synthetic 10.9.x.y
+        NEXT_HOP is not the peer address; BIRD/OpenBGPD cells get the
+        equivalent accommodation: `next hop keep` glue / `nexthop qualify
+        via default`) — replaced by the sibling generators' hold_time;
+      - rpol_files collapsed to the single swapped file; export chain
+        pointed at the generation marker policy.
+    """
+
+    def replace_once(haystack: str, old: str, new: str) -> str:
+        assert haystack.count(old) == 1, f"expected exactly one {old!r} in rendered config"
+        return haystack.replace(old, new)
+
+    text = replace_once(
+        text,
+        "listen_port = 179\n",
+        f"listen_port = {port}\nruntime_state_dir = \"{rundir}\"\n",
+    )
+    tele = text.index("[global.telemetry]")
+    export_anchor = text.index("# --- Export policy")
+    assert tele < export_anchor
+    text = text[:tele] + bench_telemetry_block(rundir) + text[export_anchor:]
+
+    count = text.count('next_hop_ownership = "strict_peer"\n')
+    assert count == n, f"expected {n} next_hop_ownership lines, found {count}"
+    text = text.replace('next_hop_ownership = "strict_peer"\n', "hold_time = 180\n")
+
+    files_start = text.index("rpol_files = [")
+    files_end = text.index("]", files_start) + 1
+    text = text[:files_start] + 'rpol_files = ["member.rpol"' + text[files_end - 1 :]
+    text = replace_once(
+        text,
+        'export_chain = ["rs-transparent-export"]\n',
+        'export_chain = ["irr-member-out"]\n',
+    )
+    assert "max_prefixes" not in text, "unexpected max-prefix ceilings in bench render"
+    return text
+
+
+def emit_rustbgpd(args, members: list[Member], out: pathlib.Path) -> list[str]:
+    if not args.render_bin:
+        sys.exit("cell rustbgpd requires --render-bin (path to rs-config-render)")
+    rundir = out.resolve()
+    check_sun_len(rundir)
+    for gen in ("a", "b"):
+        ctx = out / f"context-{gen}.json"
+        ctx.write_text(json.dumps(context_doc(members, gen)))
+        render_dir = out / f"render-{gen}"
+        subprocess.run(
+            [
+                args.render_bin,
+                "--context",
+                str(ctx),
+                "--out-dir",
+                str(render_dir),
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+        rendered_config = (render_dir / "config.toml").read_text()
+        # Concatenate the rendered policy files in the order config.toml
+        # references them, then append the generation marker policy.
+        parts = []
+        for line in rendered_config.splitlines():
+            line = line.strip()
+            if line.startswith('"policy/') and line.endswith('",'):
+                parts.append((render_dir / line.strip('",')).read_text())
+        assert len(parts) == len(members) + 1, "rendered rpol roster mismatch"
+        (out / f"gen-{gen}.rpol").write_text("".join(parts) + marker_policy_rpol(gen))
+        if gen == "a":
+            (out / "config.toml").write_text(
+                patch_rendered_config(rendered_config, len(members), args.port, rundir)
+            )
+    (out / "member.rpol").write_text((out / "gen-a.rpol").read_text())
+    return ["config.toml", "member.rpol", "gen-a.rpol", "gen-b.rpol"]
+
+
+# --- rustbgpd-txn (gRPC transactional) cell ---------------------------------
+
+
+def txn_config(args, members: list[Member], gen: str, rundir: pathlib.Path) -> str:
+    """Full candidate config: the same dataset as [policy.definitions] chains.
+
+    The transaction seam refuses out-of-band .rpol content changes by
+    design (docs/reload-matrix.md), so this cell carries the policy in the
+    inline chain engine: per member an origin definition (AS_PATH origin
+    anchor) and a prefix-list definition (one exact-match statement per
+    filter entry), plus a shared hygiene definition (path-length cap +
+    bogons; the AS_SET-segment regex term of rs-hygiene has no inline
+    equivalent — documented in the harness README) and the generation
+    marker export definition.
+    """
+    lines = [
+        "# IRR reload-matrix transactional candidate — generated by",
+        f"# gen-irr-scenario.py (generation {gen}).",
+        "",
+        "[global]",
+        f"asn = {RS_ASN}",
+        'router_id = "10.0.0.1"',
+        f"listen_port = {args.port}",
+        f'runtime_state_dir = "{rundir}"',
+        "",
+        bench_telemetry_block(rundir).rstrip(),
+        "",
+        "[policy]",
+        'export_chain = ["irr-member-out"]',
+        "",
+        "[policy.definitions.irr-hygiene]",
+        'default_action = "permit"',
+        "[[policy.definitions.irr-hygiene.statements]]",
+        'action = "deny"',
+        f"match_as_path_length_ge = {MAX_AS_PATH_LEN + 1}",
+    ]
+    for bogon in BOGONS_V4:
+        lines += [
+            "[[policy.definitions.irr-hygiene.statements]]",
+            'action = "deny"',
+            f'prefix = "{bogon}"',
+            f"ge = {bogon.split('/')[1]}",
+            "le = 32",
+        ]
+    lines += [
+        "",
+        "[policy.definitions.irr-member-out]",
+        'default_action = "permit"',
+        "[[policy.definitions.irr-member-out.statements]]",
+        'action = "permit"',
+        'prefix = "0.0.0.0/0"',
+        "ge = 0",
+        "le = 32",
+        f'set_community_add = ["{MARKER_ADMIN}:{MARKER[gen]}"]',
+        "",
+    ]
+    for m in members:
+        lines += [
+            f"[policy.definitions.m{m.idx}-origin]",
+            'default_action = "deny"',
+            f"[[policy.definitions.m{m.idx}-origin.statements]]",
+            'action = "permit"',
+            f'match_as_path = "_{m.asn}$"',
+            "",
+            f"[policy.definitions.m{m.idx}-prefixes]",
+            'default_action = "deny"',
+        ]
+        for p in m.prefixes(gen):
+            lines += [
+                f"[[policy.definitions.m{m.idx}-prefixes.statements]]",
+                'action = "permit"',
+                f'prefix = "{p}"',
+            ]
+        lines.append("")
+    for m in members:
+        lines += [
+            "[[neighbors]]",
+            f'address = "{m.addr}"',
+            f"remote_asn = {m.asn}",
+            "route_server_client = true",
+            "per_client_best = true",
+            'families = ["ipv4_unicast"]',
+            "hold_time = 180",
+            f'import_policy_chain = ["irr-hygiene", "m{m.idx}-origin", "m{m.idx}-prefixes"]',
+            "",
+        ]
+    return "\n".join(lines)
+
+
+def emit_txn(args, members: list[Member], out: pathlib.Path) -> list[str]:
+    rundir = out.resolve()
+    check_sun_len(rundir)
+    for gen in ("a", "b"):
+        (out / f"gen-{gen}.toml").write_text(txn_config(args, members, gen, rundir))
+    boot = (out / "gen-a.toml").read_text()
+    (out / "config.toml").write_text(boot)
+    (out / "candidate.toml").write_text(boot)
+    return ["config.toml", "candidate.toml", "gen-a.toml", "gen-b.toml"]
+
+
+# --- BIRD cell ---------------------------------------------------------------
+
+
+def bird_gen_conf(members: list[Member], gen: str) -> str:
+    out = [
+        "# IRR reload-matrix policy generation - generated by gen-irr-scenario.py.",
+        "# Swapped over gen.conf, then `birdc configure`. One prefix-set define +",
+        "# one import filter per member; the export filter tags the generation",
+        "# marker community the harness tracks for completion.",
+        "# 172.16/12 is absent from the bogons: harness churn range.",
+        "",
+        "define IRR_BOGONS = [ " + ", ".join(f"{b}+" for b in BOGONS_V4) + " ];",
+        "",
+        "filter member_out {",
+        f"    bgp_community.add(({MARKER_ADMIN},{MARKER[gen]}));",
+        "    accept;",
+        "}",
+        "",
+    ]
+    for m in members:
+        prefixes = m.prefixes(gen)
+        out.append(f"define M{m.idx}_PFX = [")
+        for k in range(0, len(prefixes), 8):
+            row = ", ".join(prefixes[k : k + 8])
+            out.append(f"    {row}{',' if k + 8 < len(prefixes) else ''}")
+        out += [
+            "];",
+            f"filter member_in_{m.idx} {{",
+            f"    if bgp_path.len > {MAX_AS_PATH_LEN} then reject;",
+            "    if net ~ IRR_BOGONS then reject;",
+            f"    if bgp_path.last != {m.asn} then reject;",
+            f"    if ! (net ~ M{m.idx}_PFX) then reject;",
+            "    accept;",
+            "}",
+            "",
+        ]
+    return "\n".join(out)
+
+
+def emit_bird(args, members: list[Member], out: pathlib.Path) -> list[str]:
+    conf_dir = args.conf_dir or "/etc/bird"
+    for gen in ("a", "b"):
+        (out / f"gen-{gen}.conf").write_text(bird_gen_conf(members, gen))
+    (out / "gen.conf").write_text((out / "gen-a.conf").read_text())
+    config = [
+        "# IRR reload-matrix BIRD route server - generated by gen-irr-scenario.py.",
+        "# Run: docker run -d --network=host -v <out_dir>:/etc/bird bird:3.3.1 \\",
+        "#          bird -f -c /etc/bird/bird.conf",
+        "# Reload: overwrite gen.conf, then `birdc configure`.",
+        "",
+        'router id 10.0.0.1;',
+        f"threads {args.threads};",
+        "log stderr all;",
+        "",
+        "protocol device { scan time 10; }",
+        "",
+        "# NEXT_HOP glue (same as gen-bird-scenario.py): the stubs' synthetic",
+        "# 10.9.x.y next hops resolve through device routes over lo.",
+        "protocol static nh_glue {",
+        "    ipv4;",
+        '    route 10.9.0.0/16 via "lo";',
+        '    route 127.1.0.0/16 via "lo";',
+        "}",
+        "",
+        f'include "{conf_dir}/gen.conf";',
+        "",
+        "template bgp rs_member {",
+        f"    local 127.0.0.1 port {args.port} as {RS_ASN};",
+        "    rs client;",
+        "    passive;",
+        "    multihop;",
+        "    hold time 180;",
+        "}",
+        "",
+    ]
+    for m in members:
+        config += [
+            f"protocol bgp peer{m.idx} from rs_member {{",
+            f"    neighbor {m.addr} as {m.asn};",
+            "    ipv4 {",
+            f"        import filter member_in_{m.idx};",
+            "        export filter member_out;",
+            "        next hop keep;",
+            "        gateway recursive;",
+            "    };",
+            "}",
+        ]
+    config.append("")
+    (out / "bird.conf").write_text("\n".join(config))
+    return ["bird.conf", "gen.conf", "gen-a.conf", "gen-b.conf"]
+
+
+# --- OpenBGPD cell -----------------------------------------------------------
+
+
+def obgpd_gen_conf(members: list[Member], gen: str) -> str:
+    out = [
+        "# IRR reload-matrix policy generation - generated by gen-irr-scenario.py.",
+        "# Swapped over gen.conf, then `bgpctl reload`. Prefix-sets first, then",
+        "# the import ruleset (last matching rule wins; hygiene denies are",
+        "# quick). The trailing match tags the generation marker community.",
+        "# 172.16/12 is absent from the bogons: harness churn range.",
+        "",
+    ]
+    for m in members:
+        prefixes = m.prefixes(gen)
+        out.append(f"prefix-set ps{m.idx} {{")
+        for k in range(0, len(prefixes), 8):
+            out.append("\t" + " ".join(prefixes[k : k + 8]))
+        out.append("}")
+    out += [
+        "",
+        "deny from any",
+        f"deny quick from any max-as-len {MAX_AS_PATH_LEN}",
+    ]
+    out += [f"deny quick from any prefix {b} or-longer" for b in BOGONS_V4]
+    out += [
+        f"allow from {m.addr} source-as {m.asn} prefix-set ps{m.idx}" for m in members
+    ]
+    out += [
+        f"match to any set community {MARKER_ADMIN}:{MARKER[gen]}",
+        "",
+    ]
+    return "\n".join(out)
+
+
+def emit_obgpd(args, members: list[Member], out: pathlib.Path) -> list[str]:
+    conf_dir = args.conf_dir or "/etc/bgpd"
+    for gen in ("a", "b"):
+        (out / f"gen-{gen}.conf").write_text(obgpd_gen_conf(members, gen))
+    (out / "gen.conf").write_text((out / "gen-a.conf").read_text())
+    config = [
+        "# IRR reload-matrix OpenBGPD route server - generated by gen-irr-scenario.py.",
+        "# Run: docker run -d --network=host -v <out_dir>:/etc/bgpd openbgpd/openbgpd:9.1",
+        "# Reload: overwrite gen.conf, then `bgpctl reload`.",
+        "",
+        f"AS {RS_ASN}",
+        "router-id 10.0.0.1",
+        "fib-update no",
+        "transparent-as yes",
+        f"listen on 127.0.0.1 port {args.port}",
+        "",
+        "# Synthetic 10.9.x.y next hops qualify via the host's default route",
+        "# (same as gen-obgpd-scenario.py; the host MUST have a default route).",
+        "nexthop qualify via default",
+        "",
+    ]
+    for m in members:
+        config += [
+            f"neighbor {m.addr} {{",
+            f'\tdescr "member{m.idx}"',
+            f"\tremote-as {m.asn}",
+            "\tpassive",
+            "\tholdtime 180",
+            "\tannounce IPv4 unicast",
+            "}",
+        ]
+    config += [
+        "",
+        "allow to any set nexthop no-modify",
+        f'include "{conf_dir}/gen.conf"',
+        "",
+    ]
+    (out / "bgpd.conf").write_text("\n".join(config))
+    return ["bgpd.conf", "gen.conf", "gen-a.conf", "gen-b.conf"]
+
+
+EMITTERS = {
+    "rustbgpd": emit_rustbgpd,
+    "rustbgpd-txn": emit_txn,
+    "bird": emit_bird,
+    "openbgpd": emit_obgpd,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("cell", choices=sorted(EMITTERS))
+    parser.add_argument("n_members", type=int)
+    parser.add_argument("total_prefixes", type=int)
+    parser.add_argument("out_dir", type=pathlib.Path)
+    parser.add_argument("--port", type=int, default=1790)
+    parser.add_argument("--seed", type=int, default=61)
+    parser.add_argument("--min-list", type=int, default=1000)
+    parser.add_argument("--max-list", type=int, default=40000)
+    parser.add_argument("--changed-fraction", type=float, default=0.1)
+    parser.add_argument("--render-bin", help="rs-config-render binary (rustbgpd cell)")
+    parser.add_argument("--threads", type=int, default=8, help="BIRD threads knob")
+    parser.add_argument("--conf-dir", help="config dir as seen by the running daemon")
+    args = parser.parse_args()
+
+    if args.n_members < CHURNERS:
+        sys.exit(f"n_members must be >= {CHURNERS} (harness churner contract)")
+    if args.total_prefixes % args.n_members:
+        sys.exit("total_prefixes must divide evenly by n_members (harness contract)")
+    if not 1 <= args.min_list <= args.max_list:
+        sys.exit("need 1 <= min_list <= max_list")
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    members = build_dataset(args)
+    files = EMITTERS[args.cell](args, members, args.out_dir)
+    write_manifest(args.out_dir, args, members, files)
+    total_entries = sum(len(m.list_a) for m in members)
+    swapped = files[1]  # the live swap file in every cell's roster
+    print(
+        f"wrote {args.out_dir.resolve()} cell={args.cell} members={args.n_members} "
+        f"filter_entries={total_entries} changed_members="
+        f"{sum(1 for m in members if m.changed)} "
+        f"swapped_file={swapped} ({(args.out_dir / swapped).stat().st_size} bytes)"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Builds the IRR-scale reload-receipt harness: reload stall + convergence under live sessions with a realistic multi-MB IRR-generated member policy, for rustbgpd on **both** reload paths (SIGHUP parse-then-swap and gRPC transactional apply) versus BIRD 3.3.x and OpenBGPD 9.1. This PR is the harness, configs, and comparability protocol, smoked at a tiny shape; **the measured campaign runs separately on a quiet host** (preflight-gated) and is not part of this change.

## Design

The instrument is the existing `bench/scale/reloadstall` harness, **unchanged** — its frozen copy-one-file-then-reload contract drives every cell, because each cell keeps the entire generation-varying policy in one swapped file. New pieces:

- `bench/scale/reloadstall/gen-irr-scenario.py` — one seeded generator, four cell emitters, one dataset (derived only from shape + seed, never from the cell). Default measured shape, stated as parameters: **320 members, filter lists log-uniform 1,000–40,000 entries (seed 61: min 1,009 / median 5,198 / max 38,867; 3,218,965 entries total), 572 announced /24s per member, 10% of members get ~1% of their padding prefixes replaced between generations** (content-real, output-neutral), plus the generation marker-community swap (`65400:1000` ⇄ `65400:2000`) that forces the full re-advertisement the harness timestamps. Multi-MB configs are never committed; everything reproduces from the generator.
- `bench/scale/irrreload/run-irr-reload.sh` — sequential cell runner modeled on `bench/scale/matrix/run-matrix.sh`: resumable per-cell status files, RSS-abort guard, load gate + cool-downs, exit-code-gated row production, container/daemon teardown.
- `bench/scale/irrreload/txn-apply.sh` — one transactional reload: `rbgp config plan --json` → snapshot token → `rbgp config apply`.
- `bench/scale/irrreload/README.md` — precommitted measurement definitions (wire-observable stall, marker completion, RSS), abort criteria, minimum run count (2 independent campaign runs), host-quiet preconditions (`tests/soak/preflight.sh` gated), and the full comparability protocol.

Cells:

| Cell | Policy representation | Reload |
|---|---|---|
| rustbgpd-sighup | `.rpol` rendered by `tools/rs-config-render` from a synthetic `arouteserver template-context` built from the dataset (production IRR pipeline shape: rs-hygiene + per-client origin/prefix sets), concatenated into one swapped file | SIGHUP |
| rustbgpd-txn | same dataset as inline `[policy.definitions]` chains in a full candidate config | `rbgp config plan` + `apply` |
| bird | per-member prefix-set defines + import filters in the swapped include | `birdc configure` |
| openbgpd | per-member `prefix-set`s + `source-as` allow rules in the swapped include | `bgpctl reload` |

## Fairness protocol

Mirrors the IXP matrix (`docs/perf/ixp-matrix-2026-07.md`): one harness and one instrument for all cells; the same member/prefix dataset expressed in each daemon's native idiom with the same semantic core (origin ∈ member origin set ∧ prefix ∈ member filter list, shared hygiene preamble, marker export tag); each daemon reloaded by its operator-documented mechanism at its documented route-server configuration. Documented asymmetries (README):

- reload-semantic asymmetry across the four mechanisms (policy-file reparse vs full-config reparse vs candidate parse+diff+classify over gRPC);
- the two rustbgpd cells use different policy engines — the transaction seam refuses out-of-band `.rpol` content changes by design, so cross-daemon comparisons use the SIGHUP cell and the txn cell answers "what does the transactional seam cost for the same semantic change";
- the txn candidate is size-capped by the tonic default ~4 MiB decode limit: at the default measured shape the chain-engine candidate is ~296 MB, so the transactional cell must run at the largest shape that fits (or the daemon must grow a raised/streamed limit first) — a finding this harness precommits for the receipt either way;
- hygiene depth differs slightly per representation (generation-static and constant-size, so outside the measured reload delta);
- bench plumbing on the rendered config is limited to asserted, session-level patches (listen/UDS/telemetry, `next_hop_ownership` dropped for the synthetic-NEXT_HOP loopback contract, mirroring BIRD's `next hop keep` glue and OpenBGPD's `nexthop qualify via default`); rendered policy files are never edited;
- bogon hygiene deliberately omits 172.16.0.0/12 — the harness churn blocks live there and must propagate.

## Smoke (pipeline proof, not a measurement)

`SMOKE=1 bench/scale/irrreload/run-irr-reload.sh` — 10 members × 100-entry lists, one reload per cell; all four cells PASS, runner exit 0, containers torn down. Rows produced end to end (`rows.csv`):

```
cell,reload,peers_total,peers_changed,peers_stable,prefixes,completion_p50_s,completion_p95_s,completion_max_s,changed_maxgap_p50_ms,changed_maxgap_p95_ms,changed_maxgap_max_ms,all_observer_maxgap_p50_ms,all_observer_maxgap_p95_ms,all_observer_maxgap_max_ms,changed_first_update_p50_ms,changed_first_update_p95_ms,changed_first_update_max_ms,rss_before_mib,rss_after_mib,stable_marker_peers,sessions_up,parse_errors
rustbgpd-sighup,1,10,10,0,100,0.018172,0.054246,0.054246,13.493,40.783,40.783,24.769,40.783,40.783,13.487,38.229,38.229,37,39,0,10,0
rustbgpd-txn,1,10,10,0,100,0.049610,0.089376,0.089376,42.828,48.164,48.164,42.828,48.164,48.164,42.828,48.164,48.164,41,57,0,10,0
bird,1,10,10,0,100,0.052127,0.093759,0.093759,40.616,41.780,41.780,40.616,41.780,41.780,16.008,30.961,30.961,0,0,0,10,0
openbgpd,1,10,10,0,100,0.050121,0.050138,0.050138,22.348,38.840,38.840,22.348,38.840,38.840,0.993,17.485,17.485,0,0,0,10,0
```

Generated size at the default measured shape (generated locally to size it, not committed): rustbgpd `.rpol` 65.1 MB, BIRD include 53.6 MB, OpenBGPD include 49.2 MB, transactional TOML candidate 295.6 MB.

## Measured campaign (later, quiet host)

```bash
bench/scale/irrreload/run-irr-reload.sh                                              # run A
ARTIFACTS_DIR=/tmp/irrreload-artifacts-runB bench/scale/irrreload/run-irr-reload.sh  # run B
```

Measured mode refuses to start until `tests/soak/preflight.sh` passes; smoke mode never gates and never measures.
