### PR TITLE
policy: intern rpol set tables once per compiled unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- IRR-scale boot and SIGHUP reload no longer recompile the `.rpol` set
+  data once per chain resolution: a compiled unit now interns its
+  prefix/community/asn sets exactly once and every chain instantiation
+  (per-neighbor import/export resolution, validation, reload sweeps)
+  shares those `Arc`s. At a 320-member route-server shape with 3.2M
+  prefix-set entries, config validation drops from over five minutes to
+  about one second, boot and reload stop pinning runtime workers long
+  enough to expire hold timers, and resident memory stops scaling with
+  the neighbor count (previously one full copy of the set data per
+  resolved neighbor). `PrefixSet` equality gained a same-allocation
+  fast path, so policy diffs on shared sets are O(1) instead of a full
+  member-list comparison per peer.
+
 - Editing `slow_peer_threshold_pct`, `slow_peer_duration`, or
   `slow_peer_isolation` on a static `[[neighbors]]` entry was silently ignored
   by SIGHUP reload: the change took effect only at the next natural session

--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -253,15 +253,88 @@ pub(super) struct Lowerer<'a> {
     missing_datasets: Vec<String>,
 }
 
+/// The interned set data of one source file: every defined
+/// prefix/community/asn set, indexed in definition order. Building
+/// this is the expensive part of lowering — at IRR scale a file
+/// carries millions of prefix-set entries — so `RpolFile` builds it
+/// once and every chain instantiation reuses the `Arc`s instead of
+/// re-interning through a fresh store (LAN-788: per-neighbor chain
+/// resolution re-interned the full file, turning a ~1 s compile into
+/// minutes and one shared set copy into one copy per neighbor).
+#[derive(Debug)]
+pub(super) struct SetTables {
+    prefix: Vec<Arc<PrefixSet>>,
+    community: Vec<Arc<CommunitySet>>,
+    asn: Vec<Arc<AsnSet>>,
+}
+
+impl SetTables {
+    /// Intern every set defined in `file`. A local store preserves
+    /// intra-file deduplication (two identically-valued sets share one
+    /// `Arc`). Must only be called on a typechecked AST.
+    pub(super) fn build(file: &SourceFile) -> Self {
+        let mut store = SetStore::new();
+        let prefix_sets = file
+            .prefix_sets
+            .iter()
+            .map(|def| {
+                let entries: Vec<PrefixSetEntry> = def
+                    .entries
+                    .iter()
+                    .map(|entry| PrefixSetEntry {
+                        prefix: entry.prefix,
+                        ge: entry.ge,
+                        le: entry.le,
+                    })
+                    .collect();
+                store.prefix_set(&entries)
+            })
+            .collect();
+        let community_sets = file
+            .community_sets
+            .iter()
+            .map(|def| {
+                let criteria: Vec<CommunityMatch> =
+                    def.entries.iter().map(|lit| lit.node.to_match()).collect();
+                store.community_set(&criteria)
+            })
+            .collect();
+        let asn_sets = file
+            .asn_sets
+            .iter()
+            .map(|def| {
+                let asns: Vec<u32> = def.entries.iter().map(|asn| asn.node).collect();
+                store.asn_set(&asns)
+            })
+            .collect();
+        Self {
+            prefix: prefix_sets,
+            community: community_sets,
+            asn: asn_sets,
+        }
+    }
+}
+
 impl<'a> Lowerer<'a> {
-    /// Intern every defined set through `store` and build the chain
-    /// tables. Must only be called on a typechecked AST.
-    pub(super) fn new(file: &'a SourceFile, store: &mut SetStore) -> Self {
+    /// Build the chain tables over `file`, interning its sets fresh.
+    /// Callers holding an [`RpolFile`](super::RpolFile) should go
+    /// through its cached tables instead (via
+    /// [`Self::from_tables`]) — this entry is for one-shot compiles
+    /// that own no file handle.
+    pub(super) fn new(file: &'a SourceFile) -> Self {
+        Self::from_tables(file, &SetTables::build(file))
+    }
+
+    /// Build the chain tables over `file` from pre-interned set
+    /// tables: the set `Arc`s are cloned, so every chain built from
+    /// the same tables shares one copy of each set's data. Must only
+    /// be called with tables built from this same `file`.
+    pub(super) fn from_tables(file: &'a SourceFile, tables: &SetTables) -> Self {
         let mut lowerer = Self {
             file,
-            prefix_sets: Vec::new(),
-            community_sets: Vec::new(),
-            asn_sets: Vec::new(),
+            prefix_sets: tables.prefix.clone(),
+            community_sets: tables.community.clone(),
+            asn_sets: tables.asn.clone(),
             as_path_regexes: Vec::new(),
             prefix_set_names: Vec::new(),
             community_set_names: Vec::new(),
@@ -275,43 +348,25 @@ impl<'a> Lowerer<'a> {
             bindings: DatasetBindings::new(),
             missing_datasets: Vec::new(),
         };
-        for def in &file.prefix_sets {
-            let entries: Vec<PrefixSetEntry> = def
-                .entries
-                .iter()
-                .map(|entry| PrefixSetEntry {
-                    prefix: entry.prefix,
-                    ge: entry.ge,
-                    le: entry.le,
-                })
-                .collect();
-            let set = store.prefix_set(&entries);
-            let id = SetId(u32::try_from(lowerer.prefix_sets.len()).expect("fits u32"));
-            lowerer.prefix_sets.push(set);
+        for (index, def) in file.prefix_sets.iter().enumerate() {
+            let id = SetId(u32::try_from(index).expect("fits u32"));
             lowerer.prefix_set_names.push(Some(def.name.node.clone()));
             lowerer.prefix_set_ids.insert(def.name.node.clone(), id);
         }
-        for def in &file.community_sets {
-            let criteria: Vec<CommunityMatch> =
-                def.entries.iter().map(|lit| lit.node.to_match()).collect();
-            let set = store.community_set(&criteria);
-            let id = SetId(u32::try_from(lowerer.community_sets.len()).expect("fits u32"));
-            lowerer.community_sets.push(set);
+        for (index, def) in file.community_sets.iter().enumerate() {
+            let id = SetId(u32::try_from(index).expect("fits u32"));
             lowerer
                 .community_set_names
                 .push(Some(def.name.node.clone()));
             lowerer.community_set_ids.insert(def.name.node.clone(), id);
         }
-        for def in &file.asn_sets {
-            let asns: Vec<u32> = def.entries.iter().map(|asn| asn.node).collect();
-            let set = store.asn_set(&asns);
-            let id = SetId(u32::try_from(lowerer.asn_sets.len()).expect("fits u32"));
-            lowerer.asn_sets.push(set);
+        for (index, def) in file.asn_sets.iter().enumerate() {
+            let id = SetId(u32::try_from(index).expect("fits u32"));
             lowerer.asn_set_names.push(Some(def.name.node.clone()));
             lowerer.asn_set_ids.insert(def.name.node.clone(), id);
         }
         // Regexes are interned lazily at each use site (they can be
-        // parameter-dependent via `contains <param>`); `store` is
+        // parameter-dependent via `contains <param>`); the store is
         // borrowed per call instead of held in `self` because test-run
         // instantiation happens after the main chain is built.
         lowerer

--- a/crates/policy/src/rpol/mod.rs
+++ b/crates/policy/src/rpol/mod.rs
@@ -74,6 +74,14 @@ pub struct RpolFile {
     modules: Vec<ModuleSource>,
     /// The merged compilation unit (imports dissolved).
     file: ast::SourceFile,
+    /// Lazily-built interned set tables, shared by every chain
+    /// compiled from this unit. Interning is the expensive part of
+    /// lowering (IRR-scale files carry millions of prefix-set
+    /// entries), and per-chain re-interning also gave every chain its
+    /// own copy of the set data — one build here means per-neighbor
+    /// chain resolution costs an `Arc` clone and all chains share one
+    /// copy (LAN-788).
+    tables: std::sync::OnceLock<lower::SetTables>,
 }
 
 impl RpolFile {
@@ -90,6 +98,7 @@ impl RpolFile {
         Ok(Self {
             modules: vec![ModuleSource::inline(source)],
             file,
+            tables: std::sync::OnceLock::new(),
         })
     }
 
@@ -123,7 +132,14 @@ impl RpolFile {
         Ok(Self {
             modules: graph.modules,
             file: graph.merged,
+            tables: std::sync::OnceLock::new(),
         })
+    }
+
+    /// The unit's interned set tables, built on first use.
+    fn tables(&self) -> &lower::SetTables {
+        self.tables
+            .get_or_init(|| lower::SetTables::build(&self.file))
     }
 
     /// The main file's source text.
@@ -163,7 +179,7 @@ impl RpolFile {
     #[must_use]
     pub fn run_tests(&self) -> TestReport {
         let mut store = SetStore::new();
-        let mut lowerer = lower::Lowerer::new(&self.file, &mut store);
+        let mut lowerer = lower::Lowerer::from_tables(&self.file, self.tables());
         testing::run_tests(&self.file.tests, &mut lowerer, &mut store)
     }
 
@@ -176,7 +192,7 @@ impl RpolFile {
     #[must_use]
     pub fn run_tests_with_coverage(&self) -> (TestReport, CoverageReport) {
         let mut store = SetStore::new();
-        let mut lowerer = lower::Lowerer::new(&self.file, &mut store);
+        let mut lowerer = lower::Lowerer::from_tables(&self.file, self.tables());
         let mut accum = coverage::CoverageAccum::new(&self.file);
         let report = testing::run_tests_recording(
             &self.file.tests,
@@ -253,7 +269,7 @@ impl RpolFile {
             args.len(),
             "rpol chain reference arity is checked at config resolve"
         );
-        let mut lowerer = lower::Lowerer::new(&self.file, store);
+        let mut lowerer = lower::Lowerer::from_tables(&self.file, self.tables());
         let chain = lowerer.instantiate_chain(name, args, store, datasets);
         let missing = lowerer.take_missing_datasets();
         Some(if missing.is_empty() {
@@ -356,7 +372,7 @@ impl Eq for RpolPolicySet {}
 pub fn compile_rpol(source: &str, store: &mut SetStore) -> Result<CompiledChain, Diagnostics> {
     let (file, diags) = front(source)?;
     debug_assert!(diags.is_empty());
-    let mut lowerer = lower::Lowerer::new(&file, store);
+    let mut lowerer = lower::Lowerer::new(&file);
     let chain = lowerer.zero_param_chain(store, &DatasetBindings::new());
     // Inline compilation has no config to bind datasets from
     // (LAN-305): a zero-parameter policy probing one is an error here,
@@ -390,7 +406,7 @@ pub fn compile_rpol(source: &str, store: &mut SetStore) -> Result<CompiledChain,
 pub fn run_rpol_tests(source: &str) -> Result<TestReport, Diagnostics> {
     let (file, _) = front(source)?;
     let mut store = SetStore::new();
-    let mut lowerer = lower::Lowerer::new(&file, &mut store);
+    let mut lowerer = lower::Lowerer::new(&file);
     Ok(testing::run_tests(&file.tests, &mut lowerer, &mut store))
 }
 

--- a/crates/policy/src/sets.rs
+++ b/crates/policy/src/sets.rs
@@ -222,6 +222,14 @@ impl PrefixSet {
 
 impl PartialEq for PrefixSet {
     fn eq(&self, other: &Self) -> bool {
+        // Same allocation ⇒ equal without touching the member list —
+        // chains built from one file share their sets via `Arc`
+        // (LAN-788), and IRR-scale sets carry millions of entries, so
+        // policy diffs would otherwise pay a full-set comparison per
+        // peer.
+        if std::ptr::eq(self, other) {
+            return true;
+        }
         // The index is derived deterministically from the canonical
         // member list, so members alone are the identity.
         self.entries == other.entries

--- a/src/config/resolution.rs
+++ b/src/config/resolution.rs
@@ -25,8 +25,12 @@ use super::{
     PeerGroupConfig, RFC8212_MISSING_EXPORT_POLICY, RFC8212_MISSING_IMPORT_POLICY,
 };
 
-/// Bound canonical policy-set key retention while still sharing common sets
-/// across the dominant contiguous roster shape.
+/// Bound the resolution store's canonical policy-set key retention while
+/// still sharing common sets across the dominant contiguous roster shape.
+/// Scope note: `.rpol` set data no longer flows through this store — the
+/// compiled unit interns it once and every chain shares those `Arc`s
+/// regardless of chunk (LAN-788) — so this bounds only TOML-defined set
+/// and regex retention during a resolution sweep.
 const RESOLVED_NEIGHBOR_SET_STORE_CHUNK_SIZE: usize = 32;
 
 impl Config {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -15868,17 +15868,20 @@ import_policy_chain = ["distinct-import"]
     );
 }
 
-/// Set sharing is bounded to contiguous roster chunks without changing
-/// neighbor order.
+/// Every resolved neighbor shares one canonical copy of an rpol set's
+/// data, without changing neighbor order: the compiled unit interns
+/// its sets once and every chain instantiation clones the `Arc`s
+/// (LAN-788 — per-chunk re-interning gave 320 IRR-scale peers ten
+/// independent multi-million-entry copies).
 ///
 /// Red proofs:
-/// - restoring one store per neighbor makes the within-chunk identity and
+/// - restoring per-chain interning (`Lowerer::new` re-interning
+///   through the caller's store) makes the identity and
 ///   canonical-copy-count assertions red;
-/// - restoring one unbounded store makes the boundary identity and
-///   canonical-copy-count assertions red;
-/// - reordering chunk output makes the address-order assertion red.
+/// - reordering resolution output makes the address-order assertion
+///   red.
 #[test]
-fn resolved_neighbor_set_sharing_is_chunk_bounded_and_ordered() {
+fn resolved_neighbor_set_sharing_is_global_and_ordered() {
     let source = r"
 prefix-set shared { 10.0.0.0/8 le 32, 192.0.2.0/24 }
 policy shared-import {
@@ -15937,7 +15940,7 @@ import_policy_chain = ["shared-import"]
         &set(&resolved[0]),
         &set(&resolved[31])
     ));
-    assert!(!std::sync::Arc::ptr_eq(
+    assert!(std::sync::Arc::ptr_eq(
         &set(&resolved[31]),
         &set(&resolved[32])
     ));
@@ -15947,8 +15950,8 @@ import_policy_chain = ["shared-import"]
         .collect();
     assert_eq!(
         canonical_copies.len(),
-        3,
-        "65 peers must retain one canonical set per 32-neighbor chunk"
+        1,
+        "all 65 peers must share one canonical copy of the set data"
     );
     let actual_order: Vec<_> = resolved
         .iter()


### PR DESCRIPTION
## Problem

At an IRR-scale route-server shape (320 members, 3.2M prefix-set entries, 65MB `.rpol` source — the `bench/scale/irrreload` measured default), SIGHUP reload never completed: after "reloading configuration" the daemon went silent, and at exactly +600s all 320 established sessions dropped on hold-timer expiry. Boot to listener took 4.7 minutes and `--check` alone took 5m21s, while `rbgp policy check` on the same file finishes in 1 second.

The offline checker compiles the unit once; the daemon compiled it hundreds of times. Every chain resolution — per-neighbor import/export resolution, each of validation's per-neighbor/per-group/global chain probes, and the reload path's repeated sweeps — constructed a `Lowerer` that re-interned every set defined in the file through a fresh `SetStore`: an O(n log n) canonicalization over all 3.2M entries plus a fresh copy of every set, per call, inline on runtime workers. Resident memory scaled with the neighbor count (one full copy of the set data per resolved neighbor), and policy diffs compared full multi-million-entry member lists per peer because no two chains ever shared an allocation.

## Fix

- `RpolFile` builds its interned set tables once (`OnceLock`); every `Lowerer` construction clones the `Arc`s, so chain instantiation is an AST walk over the (small) policy bodies and all chains compiled from one unit share one copy of the set data.
- `PrefixSet` equality gains a same-allocation fast path, so policy diffs on shared sets are O(1) instead of a full member-list comparison.
- The resolution-store sharing test now pins global sharing (one canonical copy across the roster) in place of the retired 32-neighbor chunk bound, whose red-proof asserted the exact behavior this removes.

## Measured (irrreload harness shape, same host, before → after)

| Probe | Before | After |
|---|---|---|
| `rustbgpd --check` on the cell config | 5m21s | **1.1s** |
| Clean process start → 320 sessions established | ~283s | **~1.38s** |
| SIGHUP reload | DNF >15min, 320/320 sessions lost | **completes, 320/320 sessions up** |
| Generation-qualified first output after SIGHUP | none observed | **not validly measured in this receipt** |
| Settled RSS at converged base table | ~12.0 GiB | 9.3 GiB |

The earlier 0.3-second value was harness start → sessions established after the daemon was already listening, not clean-process boot. The earlier 13.6 ms value sampled unrelated ongoing churn rather than generation-qualified output and is invalid; LAN-790 hardens the receipt against that mistake.

One corrected diagnostic run later observed generation-qualified completion p50 227.95s (p95 431.57s, max 453.91s) for 183,040 prefixes × 320 peers. That run is diagnostic rather than publishable campaign evidence. The residual is structurally consistent with `per_client_best` disqualifying update groups and forcing 320 private Adj-RIB-Out/fan-out paths; LAN-782 tracks the controlled cross-daemon receipt and grouped control, while LAN-789 tracks heap attribution for the 9.3 GiB settled RSS.

## Gates

fmt, clippy `-D warnings`, `cargo doc`, `cargo test --workspace` (1789 passed), `check-clippy-reasons`, policy-crate `cargo +nightly fuzz build`, and a diagnostic full `bench/scale/irrreload` `rustbgpd-sighup` cell (PASS, artifacts retained under `/tmp`). LAN-790 subsequently hardened the campaign protocol before any result is published.
