### PR TITLE
ci: raise check job timeout to 45 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,12 @@ jobs:
   check:
     runs-on: ubuntu-latest
     # Bound any wedge (e.g. a rustdoc hang) so a stuck step fails fast
-    # instead of running to GitHub's 6-hour default. Cold build + clippy
-    # (--all-targets) + test (--workspace) + doc fits comfortably under this.
-    timeout-minutes: 30
+    # instead of running to GitHub's 6-hour default. Recent green runs
+    # take 24-29 minutes; the previous 30-minute bound sat inside normal
+    # hosted-runner variance and cancelled two healthy runs mid
+    # `cargo test --workspace`, so the ceiling keeps ~1.5x headroom over
+    # the observed green range.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:


### PR DESCRIPTION
Green check runs take 24-29 minutes; the 30-minute ceiling sat inside
normal hosted-runner variance and cancelled two healthy main runs mid
cargo test --workspace. Keep ~1.5x headroom over the observed green
range while still bounding a genuine wedge far below the 6-hour
default.
