### PR TITLE
bench: seal IRR reload campaign evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   content-equal sets from separate generations still compare by value.
   (#1346)
 
+- IRR reload campaign receipts now measure first generation output only from
+  marker-qualified non-self base prefixes, fingerprint resumable passes and
+  retained rows to the exact code, binaries, scripts, and campaign inputs, and
+  fail closed on missing or invalid RSS samples instead of accepting stale or
+  incomplete evidence. (LAN-790)
+
 ## [0.62.0] — 2026-07-30
 
 ### Added

--- a/bench/scale/irrreload/README.md
+++ b/bench/scale/irrreload/README.md
@@ -71,6 +71,11 @@ record):
   non-self base-table prefix re-advertised with the new generation marker
   community (`completion_{p50,p95,max}_s`); duplicates never advance the
   window; churn prefixes are excluded by prefix range.
+- **First generation output** —
+  `changed_first_generation_update_{p50,p95,max}_ms` measures reload trigger
+  to the first non-self base prefix carrying the expected generation marker.
+  Unmarked output, stale markers, churn space, duplicates, and the observer's
+  excluded own slice cannot start this clock.
 - **RSS during reload** — `rss_before_mib`/`rss_after_mib` sampled from
   `/proc/<pid>` around each reload for the bare rustbgpd cells, plus the
   full process-tree 5 s-cadence sampler (`bench/scale/matrix/rss-sampler.sh`)
@@ -111,6 +116,24 @@ exit, daemon process-tree RSS > 100 GiB (cell aborted), or cell timeout
 (`CELL_TIMEOUT`). Failed cells keep their artifacts and are published with
 their mechanism, not silently rerun (`status` files make the campaign
 resumable per cell).
+
+Resume status is fingerprint-qualified. The fingerprint covers the exact Git
+commit and dirty-state content, runner/generator/sampler/transaction scripts,
+built daemon/CLI/renderer/harness binaries, Rust/Python/jq/Docker environment,
+selected cells, shape and timing inputs, and the local content IDs behind
+selected container image references. Each cell also retains `scenario.sha256`,
+a relative-path/content-hash roster of the generated config bundle; its digest
+is bound into that cell's provenance and pass status. A pass from any other
+fingerprint or config-bundle digest is discarded and rerun; its old rows cannot
+satisfy the new campaign. Root and per-cell `provenance.json` retain the
+fingerprint without hostnames, usernames, absolute paths, or other host-unique
+identifiers.
+Successful cells may delete their generated scenario only after retaining its
+generator `manifest.json` alongside that provenance.
+
+The RSS sampler is a required instrument: early/nonzero sampler exit or an
+empty/malformed `rss.csv` fails the cell. The runner reaps the sampler after
+the daemon exits and preserves all artifacts on failure.
 
 **Run count**: two full independent campaign runs minimum (fresh daemon
 starts, same cell order) so run-to-run spread is visible — run B into a

--- a/bench/scale/irrreload/run-irr-reload.sh
+++ b/bench/scale/irrreload/run-irr-reload.sh
@@ -27,6 +27,7 @@
 #              CHANGED_FRACTION PORT RELOADS CONTROL_SECS BIRD_THREADS
 #              CELL_TIMEOUT START_TIMEOUT ARTIFACTS_DIR SKIP_PREFLIGHT
 set -u
+set -o pipefail
 
 REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
 RSTALL="$REPO/bench/scale/reloadstall"
@@ -76,7 +77,7 @@ RSS_LIMIT_KIB=$((100 * 1024 * 1024)) # abort a cell past 100 GiB (precommitted)
 CELLS=("$@")
 [ ${#CELLS[@]} -eq 0 ] && CELLS=(rustbgpd-sighup rustbgpd-txn bird openbgpd)
 
-for tool in docker jq python3 cargo ss; do
+for tool in docker jq python3 cargo ss sha256sum git awk timeout find sort; do
     command -v "$tool" >/dev/null || {
         echo "missing required tool: $tool" >&2
         exit 1
@@ -101,6 +102,113 @@ for bin in "$HARNESS" "$RBGP" "$RENDER" "$DAEMON"; do
     }
 done
 mkdir -p "$ART"
+PRIOR_FINGERPRINT=$(jq -r '.fingerprint // empty' "$ART/provenance.json" 2>/dev/null)
+hash_file() {
+    local output
+    output=$(sha256sum -- "$1") || return 1
+    printf '%s\n' "${output%% *}"
+}
+
+BIRD_IMAGE="bird:3.3.1"
+OPENBGPD_IMAGE="openbgpd/openbgpd:9.1"
+image_id_for_cells() {
+    local cell=$1 image=$2
+    if [[ " ${CELLS[*]} " != *" $cell "* ]]; then
+        printf 'not-selected'
+        return
+    fi
+    docker image inspect --format '{{.Id}}' "$image" 2>/dev/null || {
+        docker pull "$image" >/dev/null || return 1
+        docker image inspect --format '{{.Id}}' "$image"
+    }
+}
+BIRD_IMAGE_ID=$(image_id_for_cells bird "$BIRD_IMAGE") || exit 1
+OPENBGPD_IMAGE_ID=$(image_id_for_cells openbgpd "$OPENBGPD_IMAGE") || exit 1
+DOCKER_VERSION=$(docker --version)
+if [[ " ${CELLS[*]} " == *" bird "* || " ${CELLS[*]} " == *" openbgpd "* ]]; then
+    DOCKER_VERSION=$(docker version --format '{{.Client.Version}}/{{.Server.Version}}') || exit 1
+fi
+
+# Seal resumability and retained evidence to the exact code, tools, and
+# campaign inputs. All paths stay repository-relative and no host identity is
+# recorded. A dirty checkout is represented by its byte-exact tracked diff
+# plus content hashes for untracked files.
+COMMIT=$(git -C "$REPO" rev-parse HEAD) || exit 1
+DIRTY=false
+[ -z "$(git -C "$REPO" status --porcelain=v1)" ] || DIRTY=true
+DIRTY_STATE_SHA256=$(
+    cd "$REPO" || exit 1
+    git status --porcelain=v1
+    git diff --binary HEAD --
+    git ls-files --others --exclude-standard -z |
+        while IFS= read -r -d '' path; do
+            printf 'untracked %s ' "$path"
+            hash_file "$path"
+        done
+) || exit 1
+DIRTY_STATE_SHA256=$(printf '%s' "$DIRTY_STATE_SHA256" | sha256sum | cut -d' ' -f1) || exit 1
+CAMPAIGN_PROVENANCE=$(jq -cn \
+    --arg commit "$COMMIT" --argjson dirty "$DIRTY" \
+    --arg dirty_state_sha256 "$DIRTY_STATE_SHA256" \
+    --arg run_script_sha256 "$(hash_file "$REPO/bench/scale/irrreload/run-irr-reload.sh")" \
+    --arg generator_sha256 "$(hash_file "$GEN")" \
+    --arg sampler_sha256 "$(hash_file "$SAMPLER")" \
+    --arg txn_apply_sha256 "$(hash_file "$TXN_APPLY")" \
+    --arg harness_sha256 "$(hash_file "$HARNESS")" \
+    --arg daemon_sha256 "$(hash_file "$DAEMON")" \
+    --arg cli_sha256 "$(hash_file "$RBGP")" \
+    --arg renderer_sha256 "$(hash_file "$RENDER")" \
+    --arg cells "$(IFS=,; echo "${CELLS[*]}")" \
+    --arg smoke "$SMOKE" --arg n_members "$N_MEMBERS" \
+    --arg total_prefixes "$TOTAL_PREFIXES" --arg min_list "$MIN_LIST" \
+    --arg max_list "$MAX_LIST" --arg seed "$SEED" \
+    --arg changed_fraction "$CHANGED_FRACTION" --arg port "$PORT" \
+    --arg reloads "$RELOADS" --arg control_secs "$CONTROL_SECS" \
+    --arg cell_timeout "$CELL_TIMEOUT" --arg start_timeout "$START_TIMEOUT" \
+    --arg bird_threads "$BIRD_THREADS" --arg skip_preflight "${SKIP_PREFLIGHT:-}" \
+    --arg rustc "$(rustc -Vv)" --arg cargo "$(cargo -V)" \
+    --arg python "$(python3 --version 2>&1)" --arg jq "$(jq --version)" \
+    --arg docker "$DOCKER_VERSION" \
+    --arg kernel "$(uname -srm)" \
+    --arg cpu_model "$(awk -F: '/^model name/ { sub(/^[[:space:]]+/, "", $2); print $2; exit }' /proc/cpuinfo)" \
+    --arg bird_image "$BIRD_IMAGE" --arg bird_image_id "$BIRD_IMAGE_ID" \
+    --arg openbgpd_image "$OPENBGPD_IMAGE" --arg openbgpd_image_id "$OPENBGPD_IMAGE_ID" \
+    '{schema:1,git:{commit:$commit,dirty:$dirty,dirty_state_sha256:$dirty_state_sha256},scripts:{runner:$run_script_sha256,generator:$generator_sha256,rss_sampler:$sampler_sha256,txn_apply:$txn_apply_sha256},binaries:{reloadstall:$harness_sha256,rustbgpd:$daemon_sha256,rbgp:$cli_sha256,rs_config_render:$renderer_sha256},environment:{rustc:$rustc,cargo:$cargo,python:$python,jq:$jq,docker:$docker,kernel:$kernel,cpu_model:$cpu_model},inputs:{cells:$cells,smoke:$smoke,n_members:$n_members,total_prefixes:$total_prefixes,min_list:$min_list,max_list:$max_list,seed:$seed,changed_fraction:$changed_fraction,port:$port,reloads:$reloads,control_secs:$control_secs,cell_timeout:$cell_timeout,start_timeout:$start_timeout,bird_threads:$bird_threads,skip_preflight:$skip_preflight,bird_image:$bird_image,bird_image_id:$bird_image_id,openbgpd_image:$openbgpd_image,openbgpd_image_id:$openbgpd_image_id}}') || exit 1
+CAMPAIGN_FINGERPRINT=$(printf '%s' "$CAMPAIGN_PROVENANCE" | sha256sum | cut -d' ' -f1) || exit 1
+printf '%s\n' "$CAMPAIGN_PROVENANCE" | jq --arg fingerprint "$CAMPAIGN_FINGERPRINT" \
+    '. + {fingerprint:$fingerprint}' >"$ART/provenance.json" || exit 1
+ROWS_HEADER="cell,reload,peers_total,peers_changed,peers_stable,prefixes,completion_p50_s,completion_p95_s,completion_max_s,changed_maxgap_p50_ms,changed_maxgap_p95_ms,changed_maxgap_max_ms,all_observer_maxgap_p50_ms,all_observer_maxgap_p95_ms,all_observer_maxgap_max_ms,changed_first_generation_update_p50_ms,changed_first_generation_update_p95_ms,changed_first_generation_update_max_ms,rss_before_mib,rss_after_mib,stable_marker_peers,sessions_up,parse_errors"
+if [ "$PRIOR_FINGERPRINT" != "$CAMPAIGN_FINGERPRINT" ] ||
+    [ "$(head -n1 "$ART/rows.csv" 2>/dev/null)" != "$ROWS_HEADER" ]; then
+    printf '%s\n' "$ROWS_HEADER" >"$ART/rows.csv"
+fi
+
+cell_receipt_matches() {
+    local cdir=$1 scenario_sha actual_sha
+    scenario_sha=$(jq -er --arg fingerprint "$CAMPAIGN_FINGERPRINT" \
+        'select(.fingerprint == $fingerprint) | .scenario.manifest_sha256' \
+        "$cdir/provenance.json" 2>/dev/null) || return 1
+    [ -n "$scenario_sha" ] || return 1
+    actual_sha=$(hash_file "$cdir/scenario.sha256" 2>/dev/null) || return 1
+    [ "$actual_sha" = "$scenario_sha" ] || return 1
+    grep -qx "pass $CAMPAIGN_FINGERPRINT $scenario_sha" "$cdir/status" 2>/dev/null
+}
+
+seal_scenario() {
+    local run=$1 cdir=$2
+    (
+        cd "$run" || exit 1
+        find . -type f -print0 | sort -z |
+            while IFS= read -r -d '' path; do
+                digest=$(hash_file "$path") || exit 1
+                printf '%s  %s\n' "$digest" "$path"
+            done
+    ) >"$cdir/scenario.sha256" || return 1
+    CELL_SCENARIO_SHA256=$(hash_file "$cdir/scenario.sha256") || return 1
+    jq --arg scenario_sha "$CELL_SCENARIO_SHA256" \
+        '. + {scenario:{manifest_sha256:$scenario_sha}}' \
+        "$ART/provenance.json" >"$cdir/provenance.json"
+}
 
 cleanup() {
     # shellcheck disable=SC2317  # invoked via trap
@@ -176,9 +284,11 @@ run_cell() {
 
     local daemon_pid="" container="" reload_cmd="" pid_arg=""
     local live a b
+    CELL_SCENARIO_SHA256=""
     case $cell in
     rustbgpd-sighup)
         gen_scenario rustbgpd "$run" --render-bin "$RENDER" || return 1
+        seal_scenario "$run" "$cdir" || return 1
         "$DAEMON" "$run/config.toml" >"$cdir/daemon.log" 2>&1 &
         daemon_pid=$!
         live="$run/member.rpol" a="$run/gen-a.rpol" b="$run/gen-b.rpol"
@@ -186,6 +296,7 @@ run_cell() {
         ;;
     rustbgpd-txn)
         gen_scenario rustbgpd-txn "$run" || return 1
+        seal_scenario "$run" "$cdir" || return 1
         "$DAEMON" "$run/config.toml" >"$cdir/daemon.log" 2>&1 &
         daemon_pid=$!
         live="$run/candidate.toml" a="$run/gen-a.toml" b="$run/gen-b.toml"
@@ -194,20 +305,22 @@ run_cell() {
         ;;
     bird)
         gen_scenario bird "$run" --threads "$BIRD_THREADS" || return 1
+        seal_scenario "$run" "$cdir" || return 1
         container="irr-bird"
         docker rm -f "$container" >/dev/null 2>&1
         docker run -d --name "$container" --network=host -v "$run":/etc/bird \
-            bird:3.3.1 bird -f -c /etc/bird/bird.conf >/dev/null || return 1
+            "$BIRD_IMAGE_ID" bird -f -c /etc/bird/bird.conf >/dev/null || return 1
         reload_cmd="docker exec $container birdc configure"
         live="$run/gen.conf" a="$run/gen-a.conf" b="$run/gen-b.conf"
         pid_arg=0 # the outer sampler owns RSS
         ;;
     openbgpd)
         gen_scenario openbgpd "$run" || return 1
+        seal_scenario "$run" "$cdir" || return 1
         container="irr-obgpd"
         docker rm -f "$container" >/dev/null 2>&1
         docker run -d --name "$container" --network=host -v "$run":/etc/bgpd \
-            openbgpd/openbgpd:9.1 >/dev/null || return 1
+            "$OPENBGPD_IMAGE_ID" >/dev/null || return 1
         reload_cmd="docker exec $container bgpctl reload"
         live="$run/gen.conf" a="$run/gen-a.conf" b="$run/gen-b.conf"
         pid_arg=0
@@ -234,6 +347,12 @@ run_cell() {
     local hpid=$!
     local rc=""
     while kill -0 "$hpid" 2>/dev/null; do
+        if ! kill -0 "$sampler_pid" 2>/dev/null; then
+            echo "cell $cell: RSS sampler exited before harness completion" >&2
+            kill "$hpid" 2>/dev/null
+            rc=98
+            break
+        fi
         local last_kib
         last_kib=$(tail -n1 "$cdir/rss.csv" 2>/dev/null | cut -d, -f2)
         case ${last_kib:-} in
@@ -253,41 +372,70 @@ run_cell() {
     hrc=$?
     [ -z "$rc" ] && rc=$hrc
 
-    kill "$sampler_pid" 2>/dev/null
     if [ -n "$container" ]; then
         docker logs "$container" >"$cdir/daemon.log" 2>&1
         docker rm -f "$container" >/dev/null 2>&1
     else
         kill "$daemon_pid" 2>/dev/null
+        wait "$daemon_pid" 2>/dev/null
     fi
-    cp "$run/manifest.json" "$cdir/manifest.json" 2>/dev/null
+    local sampler_rc=0
+    wait "$sampler_pid" || sampler_rc=$?
+    if [ "$sampler_rc" -ne 0 ]; then
+        echo "cell $cell: RSS sampler failed rc=$sampler_rc" >&2
+        rc=98
+    elif ! awk -F, 'NR == 1 { if ($0 != "epoch_s,total_rss_kib,pids") bad=1; next } NF != 3 || $1 !~ /^[0-9]+$/ || $2 !~ /^[1-9][0-9]*$/ || $3 !~ /^[1-9][0-9]*$/ { bad=1 } NR > 1 { rows++ } END { exit (bad || rows == 0) }' "$cdir/rss.csv"; then
+        echo "cell $cell: RSS sampler produced empty or invalid data" >&2
+        rc=98
+    fi
+    if ! cp "$run/manifest.json" "$cdir/manifest.json" ||
+        [ "$(hash_file "$cdir/scenario.sha256" 2>/dev/null)" != "$CELL_SCENARIO_SHA256" ]; then
+        echo "cell $cell: required manifest/provenance retention failed" >&2
+        rc=97
+    fi
     if [ "$rc" -eq 0 ]; then
+        local rows_tmp="$cdir/rows.csv.tmp"
         grep '^reloadstall_csv,' "$cdir/reloadstall.log" |
-            sed "s/^reloadstall_csv/$cell/" >>"$ART/rows.csv"
-        rm -rf "$run" # scenario reproduces from the generator + manifest
+            sed "s/^reloadstall_csv/$cell/" >"$rows_tmp"
+        if ! awk -F, -v cell="$cell" -v expected="$RELOADS" \
+            'NF != 23 || $1 != cell || $2 != sprintf("%d", NR) { bad=1 } END { exit (bad || NR != expected) }' \
+            "$rows_tmp"; then
+            echo "cell $cell: invalid, missing, or duplicate measurement rows" >&2
+            rm -f "$rows_tmp"
+            rc=96
+        else
+            if ! sed -n '1,$p' "$rows_tmp" >>"$ART/rows.csv"; then
+                echo "cell $cell: failed to retain measurement rows" >&2
+                rc=96
+            else
+                rm -f "$rows_tmp"
+                rm -rf "$run" # reproduces from the generator + manifest
+            fi
+        fi
     fi
     echo "cell $cell: harness rc=$rc (artifacts: $cdir)"
     return "$rc"
 }
 
-grep -q '^cell,' "$ART/rows.csv" 2>/dev/null || echo \
-    "cell,reload,peers_total,peers_changed,peers_stable,prefixes,completion_p50_s,completion_p95_s,completion_max_s,changed_maxgap_p50_ms,changed_maxgap_p95_ms,changed_maxgap_max_ms,all_observer_maxgap_p50_ms,all_observer_maxgap_p95_ms,all_observer_maxgap_max_ms,changed_first_update_p50_ms,changed_first_update_p95_ms,changed_first_update_max_ms,rss_before_mib,rss_after_mib,stable_marker_peers,sessions_up,parse_errors" \
-    >"$ART/rows.csv"
-
 overall=0
 for cell in "${CELLS[@]}"; do
     status_file="$ART/$cell/status"
-    if [ -f "$status_file" ] && grep -qx pass "$status_file"; then
-        echo "cell $cell: already pass, skipping (rm $status_file to rerun)"
+    existing_rows=$(grep -c "^$cell," "$ART/rows.csv" 2>/dev/null)
+    if cell_receipt_matches "$ART/$cell" &&
+        [ "${existing_rows:-0}" -eq "$RELOADS" ]; then
+        echo "cell $cell: matching fingerprint already passed, skipping"
         continue
     fi
+    # Rows from another fingerprint can never satisfy this campaign.
+    awk -F, -v cell="$cell" 'NR == 1 || $1 != cell' "$ART/rows.csv" >"$ART/rows.csv.tmp" &&
+        mv "$ART/rows.csv.tmp" "$ART/rows.csv"
     load_gate
     echo "=== cell $cell start $(date -Is) ==="
     if run_cell "$cell"; then
-        echo pass >"$status_file"
+        echo "pass $CAMPAIGN_FINGERPRINT $CELL_SCENARIO_SHA256" >"$status_file"
         echo "=== cell $cell PASS $(date -Is) ==="
     else
-        echo "fail rc=$? $(date -Is)" >"$status_file"
+        echo "fail $CAMPAIGN_FINGERPRINT ${CELL_SCENARIO_SHA256:-unavailable} rc=$?" >"$status_file"
         echo "=== cell $cell FAIL ==="
         overall=1
     fi
@@ -297,10 +445,10 @@ done
 
 # Completion gate: every requested cell passed and produced its rows.
 for cell in "${CELLS[@]}"; do
-    grep -qx pass "$ART/$cell/status" 2>/dev/null || overall=1
+    cell_receipt_matches "$ART/$cell" || overall=1
     rows=$(grep -c "^$cell," "$ART/rows.csv" 2>/dev/null)
-    if [ "${rows:-0}" -lt "$RELOADS" ]; then
-        echo "cell $cell: expected >= $RELOADS measurement rows, found ${rows:-0}" >&2
+    if [ "${rows:-0}" -ne "$RELOADS" ]; then
+        echo "cell $cell: expected exactly $RELOADS measurement rows, found ${rows:-0}" >&2
         overall=1
     fi
 done

--- a/bench/scale/reloadstall/src/main.rs
+++ b/bench/scale/reloadstall/src/main.rs
@@ -142,6 +142,7 @@ struct GenerationProgress {
     excluded_start: usize,
     excluded_end: usize,
     completed_at_us: Option<u64>,
+    first_marker_base_at_us: Option<u64>,
 }
 
 impl GenerationProgress {
@@ -154,6 +155,7 @@ impl GenerationProgress {
         self.excluded_start = usize::try_from(excluded_start).unwrap();
         self.excluded_end = usize::try_from(excluded_start + excluded_len).unwrap();
         self.completed_at_us = None;
+        self.first_marker_base_at_us = None;
     }
 
     fn observe(&mut self, prefix_index: usize, t_us: u64) {
@@ -167,6 +169,9 @@ impl GenerationProgress {
         };
         if *slot & bit != 0 {
             return;
+        }
+        if self.first_marker_base_at_us.is_none() {
+            self.first_marker_base_at_us = Some(t_us);
         }
         *slot |= bit;
         self.unique += 1;
@@ -240,7 +245,7 @@ fn observe_generation(
     progress: &mut GenerationProgress,
     expected_community: u32,
     communities: &[u32],
-    announced: &[Ipv4Prefix],
+    announced: impl IntoIterator<Item = Ipv4Prefix>,
     total_prefixes: u32,
     t_us: u64,
 ) {
@@ -248,7 +253,7 @@ fn observe_generation(
         return;
     }
     for prefix in announced {
-        if let Some(index) = base_prefix_index(*prefix, total_prefixes) {
+        if let Some(index) = base_prefix_index(prefix, total_prefixes) {
             progress.observe(index, t_us);
         }
     }
@@ -545,16 +550,17 @@ async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<Stub, String> {
                             }
 
                             let expected = ob.expected_community.load(Ordering::Acquire);
-                            if base > 0 && expected != 0 && communities.contains(&expected) {
+                            if base > 0 && expected != 0 {
                                 let mut generation = ob.generation.lock().unwrap();
                                 if ob.expected_community.load(Ordering::Acquire) == expected {
-                                    for e in &parsed.announced {
-                                        if let Some(index) =
-                                            base_prefix_index(e.prefix, total_prefixes)
-                                        {
-                                            generation.observe(index, t_us);
-                                        }
-                                    }
+                                    observe_generation(
+                                        &mut generation,
+                                        expected,
+                                        communities,
+                                        parsed.announced.iter().map(|entry| entry.prefix),
+                                        total_prefixes,
+                                        t_us,
+                                    );
                                 }
                             }
                         }
@@ -1166,8 +1172,8 @@ fn main() {
              completion_p50_s,completion_p95_s,completion_max_s,\
              changed_maxgap_p50_ms,changed_maxgap_p95_ms,changed_maxgap_max_ms,\
              all_observer_maxgap_p50_ms,all_observer_maxgap_p95_ms,\
-             all_observer_maxgap_max_ms,changed_first_update_p50_ms,\
-             changed_first_update_p95_ms,changed_first_update_max_ms,\
+             all_observer_maxgap_max_ms,changed_first_generation_update_p50_ms,\
+             changed_first_generation_update_p95_ms,changed_first_generation_update_max_ms,\
              rss_before_mib,rss_after_mib,stable_marker_peers,sessions_up,parse_errors"
         );
 
@@ -1194,11 +1200,16 @@ fn main() {
                     u32::try_from(i).unwrap() * per_peer,
                     per_peer,
                 );
+            }
+            // The tracker stays disarmed until its trigger timestamp exists,
+            // so a delayed UPDATE from an older A/B generation cannot become
+            // pre-trigger evidence (or underflow the duration below).
+            let t_hup = now_us(&ctx);
+            for observer in ctx.obs.iter().take(changed_peers as usize) {
                 observer
                     .expected_community
                     .store(expected_community, Ordering::Release);
             }
-            let t_hup = now_us(&ctx);
             let expected_stable = usize::try_from(n_peers - changed_peers).unwrap();
             if let Some(cmd) = &reload_cmd {
                 // Matrix cells (BIRD/OpenBGPD) reload via a command, e.g.
@@ -1341,10 +1352,14 @@ fn main() {
                 if let Some(tc) = completion_us(&ctx, i) {
                     comp_s.push((tc - t_hup) as f64 / 1e6);
                     gaps.push(max_gap_ms(&ctx, i, t_hup, tc, false));
-                    // Leading stall: SIGHUP -> first UPDATE of any kind.
-                    let ev = ctx.obs[i].events.lock().unwrap();
-                    if let Some(e) = ev.iter().find(|e| e.t_us >= t_hup) {
-                        firsts.push((e.t_us - t_hup) as f64 / 1000.0);
+                    // Leading generation stall: trigger -> first base-prefix
+                    // UPDATE carrying the expected generation marker.
+                    let generation = ctx.obs[i].generation.lock().unwrap();
+                    if let Some(first) = generation.first_marker_base_at_us {
+                        let elapsed = first
+                            .checked_sub(t_hup)
+                            .expect("generation evidence predates reload trigger");
+                        firsts.push(elapsed as f64 / 1000.0);
                     }
                 }
             }
@@ -1357,7 +1372,10 @@ fn main() {
                 &format!("reload {r} all_observer_maxgap_ms"),
                 all_observer_gaps,
             );
-            let first_update = stats_line(&format!("reload {r} first_update_ms"), firsts);
+            let first_generation_update = stats_line(
+                &format!("reload {r} changed_first_generation_update_ms"),
+                firsts,
+            );
             let rss_after = rss_mib(pid);
             println!(
                 "reload {r} rss_mib before={rss_before} after={} comms_sample={:?}",
@@ -1399,9 +1417,9 @@ fn main() {
                 all_gap.p50,
                 all_gap.p95,
                 all_gap.max,
-                first_update.p50,
-                first_update.p95,
-                first_update.max,
+                first_generation_update.p50,
+                first_generation_update.p95,
+                first_generation_update.max,
             );
             // Quiesce between reloads.
             tokio::time::sleep(Duration::from_secs(20)).await;
@@ -1530,25 +1548,57 @@ mod tests {
 
         observe_generation(
             &mut progress,
+            0,
+            &[COMMUNITY_GEN_B],
+            announced.iter().copied(),
+            128,
+            5,
+        );
+        assert_eq!(
+            progress.first_marker_base_at_us, None,
+            "generation evidence must stay empty while the tracker is disarmed"
+        );
+
+        observe_generation(
+            &mut progress,
             COMMUNITY_GEN_B,
             &[COMMUNITY_GEN_A],
-            &announced,
+            announced.iter().copied(),
             128,
             10,
         );
         assert_eq!(progress.unique, 0);
         assert_eq!(progress.completed_at_us, None);
+        assert_eq!(progress.first_marker_base_at_us, None);
+
+        // Churn carrying the expected marker is not base-generation output.
+        observe_generation(
+            &mut progress,
+            COMMUNITY_GEN_B,
+            &[COMMUNITY_GEN_B],
+            std::iter::once(churn_prefix(0, 0)),
+            128,
+            15,
+        );
+        assert_eq!(progress.first_marker_base_at_us, None);
 
         observe_generation(
             &mut progress,
             COMMUNITY_GEN_B,
             &[COMMUNITY_GEN_B],
-            &announced,
+            announced.iter().copied(),
             128,
             20,
         );
         assert_eq!(progress.unique, 1);
         assert_eq!(progress.completed_at_us, Some(20));
+        assert_eq!(progress.first_marker_base_at_us, Some(20));
+
+        progress.reset(128, 1, 100, 27);
+        assert_eq!(
+            progress.first_marker_base_at_us, None,
+            "a new generation must not inherit first-output evidence"
+        );
     }
 
     #[test]
@@ -1556,11 +1606,17 @@ mod tests {
         let mut progress = GenerationProgress::default();
         progress.reset(4, 3, 2, 1);
 
+        progress.observe(2, 5);
+        assert_eq!(progress.first_marker_base_at_us, None);
         progress.observe(0, 10);
         progress.observe(1, 20);
-        progress.observe(2, 30);
         assert_eq!(progress.unique, 2, "own prefix must not advance completion");
         assert_eq!(progress.completed_at_us, None);
+        assert_eq!(
+            progress.first_marker_base_at_us,
+            Some(10),
+            "excluded own-slice output must not set or replace accepted evidence"
+        );
 
         progress.observe(3, 40);
         assert_eq!(progress.unique, 3);

--- a/tests/reloadstall_scenario_emitted_check.rs
+++ b/tests/reloadstall_scenario_emitted_check.rs
@@ -85,3 +85,64 @@ fn emitted_1000_peer_scenario_is_all_ebgp_and_daemon_valid() {
         String::from_utf8_lossy(&checked.stderr)
     );
 }
+
+#[test]
+/// Red proof: replacing the fingerprint-qualified status match with the old
+/// bare `pass` match, or removing the sampler wait/data gate, makes this fail.
+/// The column assertion likewise fails if the ambiguous historical label is
+/// restored in future output.
+fn irr_reload_campaign_seals_resume_rows_and_rss_evidence() {
+    let runner = std::fs::read_to_string(format!(
+        "{}/bench/scale/irrreload/run-irr-reload.sh",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .expect("read IRR reload runner");
+
+    for required in [
+        "pass $CAMPAIGN_FINGERPRINT",
+        "provenance.json",
+        "DIRTY_STATE_SHA256",
+        "bird_image_id",
+        "openbgpd_image_id",
+        "scenario.sha256",
+        "cell_receipt_matches",
+        "[ \"$actual_sha\" = \"$scenario_sha\" ] || return 1",
+        "pass $CAMPAIGN_FINGERPRINT $scenario_sha",
+        "pass $CAMPAIGN_FINGERPRINT $CELL_SCENARIO_SHA256",
+        "wait \"$sampler_pid\"",
+        "RSS sampler produced empty or invalid data",
+        "changed_first_generation_update_p50_ms",
+        "changed_first_generation_update_p95_ms",
+        "changed_first_generation_update_max_ms",
+        "[ \"$PRIOR_FINGERPRINT\" != \"$CAMPAIGN_FINGERPRINT\" ]",
+        "[ \"$(head -n1 \"$ART/rows.csv\" 2>/dev/null)\" != \"$ROWS_HEADER\" ]",
+        "required manifest/provenance retention failed",
+        "rc=97",
+        "NF != 23 || $1 != cell || $2 != sprintf(\"%d\", NR)",
+        "NR != expected",
+        "invalid, missing, or duplicate measurement rows",
+        "failed to retain measurement rows",
+        "rc=96",
+        "[ \"${existing_rows:-0}\" -eq \"$RELOADS\" ]",
+        "[ \"${rows:-0}\" -ne \"$RELOADS\" ]",
+    ] {
+        assert!(
+            runner.contains(required),
+            "missing receipt seal: {required}"
+        );
+    }
+    assert!(
+        !runner.contains("changed_first_update_p50_ms"),
+        "future rows must not reuse the ambiguous historical column name"
+    );
+    let retention_gate = runner
+        .find("required manifest/provenance retention failed")
+        .expect("retention failure gate");
+    let scenario_delete = runner
+        .rfind("rm -rf \"$run\"")
+        .expect("successful scenario deletion");
+    assert!(
+        retention_gate < scenario_delete,
+        "retention must fail closed before successful scenario deletion"
+    );
+}


### PR DESCRIPTION
## Summary

- measure first output only when a non-self base prefix carries the expected policy-generation marker
- disarm/reset before taking the trigger timestamp, then arm, so delayed output from an older A/B cycle cannot become pre-trigger evidence
- bind resumable status and retained rows to the exact commit, dirty content, scripts, binaries, actual generated config-bundle hashes, inputs, toolchain, and selected container image IDs
- fail closed on pre-trigger evidence, config-roster mismatch, an early or invalid RSS sampler, missing manifest/provenance, malformed or duplicate rows, and row-retention failure
- document the new metric and reproducibility contract

This corrects the prior 13.6 ms label: that value was the first UPDATE of any kind after SIGHUP, not proven new-generation re-advertisement.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
- reloadstall unit suite, shell syntax, and ShellCheck
- four-cell smoke repeated on the final receipt contract: SIGHUP, transactional apply, BIRD, and OpenBGPD; all 10/10 sessions, zero parse errors, exactly one sealed row per cell, and a retained per-cell config hash roster
- same-fingerprint resume skipped all four cells; changed-input resume changed the fingerprint, reran the cell, and replaced old rows

## Load-bearing proofs

- `generation_progress_rejects_stale_policy_markers`: removing the expected-marker membership check makes the stale-marker assertion fail.
- `irr_reload_campaign_seals_resume_rows_and_rss_evidence`: removing the sampler reap or the generated-config digest comparison makes the receipt-seal assertion fail.

Depends on the interning-contract hardening merged in #1349.