### PR TITLE
policy: restore public rpol set-store sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   content-equal sets from separate generations still compare by value.
   (#1346)
 
+- The public `RpolFile` compiler again interns literal sets through its
+  caller-owned `SetStore`, preserving sharing across separately parsed files.
+  The daemon selects the whole-file table cache explicitly for roster fan-out,
+  retaining the IRR-scale reload fix without silently changing the public
+  compiler contract.
+
 - IRR reload campaign receipts now measure first generation output only from
   marker-qualified non-self base prefixes, fingerprint resumable passes and
   retained rows to the exact code, binaries, scripts, and campaign inputs, and

--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -324,11 +324,10 @@ impl SetTables {
 impl<'a> Lowerer<'a> {
     /// Build the chain tables over `file`, interning its sets through
     /// the caller-owned store.
-    /// Callers holding an [`RpolFile`](super::RpolFile) should go
-    /// through its cached tables instead (via
-    /// [`Self::from_tables`]) — this entry is for one-shot compiles
-    /// that own no file handle and may share content with other
-    /// one-shot compiles using the same store.
+    /// One-shot compiles and the general [`RpolFile`](super::RpolFile)
+    /// API use this path so separately parsed sources can share content
+    /// through the same store. High-fanout callers deliberately use
+    /// [`Self::from_tables`] and the file-owned cache instead.
     pub(super) fn new(file: &'a SourceFile, store: &mut SetStore) -> Self {
         Self::from_tables(file, &SetTables::build_with_store(file, store))
     }

--- a/crates/policy/src/rpol/mod.rs
+++ b/crates/policy/src/rpol/mod.rs
@@ -74,13 +74,13 @@ pub struct RpolFile {
     modules: Vec<ModuleSource>,
     /// The merged compilation unit (imports dissolved).
     file: ast::SourceFile,
-    /// Lazily-built interned set tables, shared by every chain
-    /// compiled from this unit. Interning is the expensive part of
-    /// lowering (IRR-scale files carry millions of prefix-set
-    /// entries), and per-chain re-interning also gave every chain its
-    /// own copy of the set data — one build here means per-neighbor
-    /// chain resolution costs an `Arc` clone and all chains share one
-    /// copy (LAN-788).
+    /// Lazily-built interned set tables for high-fanout compilation.
+    /// Interning is the expensive part of lowering (IRR-scale files
+    /// carry millions of prefix-set entries), and per-chain re-interning
+    /// gave every daemon neighbor its own copy of the set data. The
+    /// roster resolver explicitly uses this cache; the general public
+    /// compiler keeps interning through its caller's `SetStore` so
+    /// separately parsed files can still share content.
     tables: std::sync::OnceLock<lower::SetTables>,
 }
 
@@ -247,9 +247,10 @@ impl RpolFile {
     }
 
     /// [`Self::compile_policy`] with explicit dataset bindings
-    /// (LAN-305): the daemon's chain resolver passes the config-built
-    /// registry bindings; referenced-but-unbound (or kind-mismatched)
-    /// datasets yield `Err` naming them.
+    /// (LAN-305): referenced-but-unbound (or kind-mismatched) datasets yield
+    /// `Err` naming them. Literal sets are interned through
+    /// `store`, preserving content sharing with other sources compiled through
+    /// that same caller-owned store.
     ///
     /// # Panics
     ///
@@ -263,13 +264,53 @@ impl RpolFile {
         store: &mut SetStore,
         datasets: &DatasetBindings,
     ) -> Option<Result<CompiledChain, MissingDatasets>> {
+        self.compile_policy_bound_impl(name, args, store, datasets, false)
+    }
+
+    /// High-fanout variant of [`Self::compile_policy_bound`] for a caller that
+    /// deliberately wants this file's once-built literal-set tables. The
+    /// caller store still interns parameter-dependent regexes, but literal
+    /// prefix/community/ASN sets come from the file cache instead of being
+    /// re-canonicalized for every chain.
+    ///
+    /// Most callers should use [`Self::compile_policy_bound`], which preserves
+    /// the [`SetStore`] contract across separately parsed files. The daemon's
+    /// roster resolver uses this variant because one `RpolFile` fans out to
+    /// hundreds of peer chains at IRR scale.
+    ///
+    /// # Panics
+    ///
+    /// If `args.len()` does not match the policy's declared parameter count.
+    #[must_use]
+    pub fn compile_policy_bound_cached_tables(
+        &self,
+        name: &str,
+        args: &[u32],
+        store: &mut SetStore,
+        datasets: &DatasetBindings,
+    ) -> Option<Result<CompiledChain, MissingDatasets>> {
+        self.compile_policy_bound_impl(name, args, store, datasets, true)
+    }
+
+    fn compile_policy_bound_impl(
+        &self,
+        name: &str,
+        args: &[u32],
+        store: &mut SetStore,
+        datasets: &DatasetBindings,
+        cached_tables: bool,
+    ) -> Option<Result<CompiledChain, MissingDatasets>> {
         let def = self.file.policies.iter().find(|p| p.name.node == name)?;
         assert_eq!(
             def.params.len(),
             args.len(),
             "rpol chain reference arity is checked at config resolve"
         );
-        let mut lowerer = lower::Lowerer::from_tables(&self.file, self.tables());
+        let mut lowerer = if cached_tables {
+            lower::Lowerer::from_tables(&self.file, self.tables())
+        } else {
+            lower::Lowerer::new(&self.file, store)
+        };
         let chain = lowerer.instantiate_chain(name, args, store, datasets);
         let missing = lowerer.take_missing_datasets();
         Some(if missing.is_empty() {

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -11,7 +11,7 @@ use crate::engine::{PolicyAction, RouteContext, RouteModifications};
 use crate::ir::{Cmp, MatchExpr, PolicySource, SetId, TermAction};
 use crate::sets::SetStore;
 
-use super::{TestReport, check_rpol, compile_rpol, run_rpol_tests};
+use super::{RpolFile, TestReport, check_rpol, compile_rpol, run_rpol_tests};
 
 const ADR_EXAMPLE: &str = r"
 prefix-set customers { 10.10.0.0/16 ge 24 le 28, 192.0.2.0/24 }
@@ -103,6 +103,52 @@ fn one_shot_compiles_share_literal_sets_through_caller_store() {
     let mut store = SetStore::new();
     let first = compile_rpol(&source("first"), &mut store).expect("first source compiles");
     let second = compile_rpol(&source("second"), &mut store).expect("second source compiles");
+
+    assert!(Arc::ptr_eq(&first.prefix_sets[0], &second.prefix_sets[0]));
+    assert!(Arc::ptr_eq(
+        &first.community_sets[0],
+        &second.community_sets[0]
+    ));
+    assert!(Arc::ptr_eq(&first.asn_sets[0], &second.asn_sets[0]));
+}
+
+/// `RpolFile::compile_policy{_bound}` retains the caller-owned `SetStore`
+/// contract even after each file's high-fanout cache has been initialized.
+///
+/// Red proof: routing either public compile back through `self.tables()` makes
+/// all three pointer-identity assertions red because the two files own separate
+/// private tables.
+#[test]
+fn rpol_file_compiles_share_literal_sets_through_caller_store() {
+    let source = |policy: &str| {
+        format!(
+            "prefix-set prefixes {{ 192.0.2.0/24 }}\n\
+             community-set communities {{ 65000:100 }}\n\
+             asn-set asns {{ 64512 }}\n\
+             policy {policy} {{ term allow {{ accept }} }}"
+        )
+    };
+    let first_file = RpolFile::parse(&source("first")).expect("first source parses");
+    let second_file = RpolFile::parse(&source("second")).expect("second source parses");
+
+    // Initialize both private tables first: caller-store sharing must not rely
+    // on this public compile happening to win each OnceLock race.
+    assert_eq!(first_file.run_tests().total, 0);
+    assert_eq!(second_file.run_tests().total, 0);
+
+    let mut store = SetStore::new();
+    let first = first_file
+        .compile_policy("first", &[], &mut store)
+        .expect("first policy compiles");
+    let second = second_file
+        .compile_policy_bound(
+            "second",
+            &[],
+            &mut store,
+            &crate::datasets::DatasetBindings::new(),
+        )
+        .expect("second policy exists")
+        .expect("second policy binds");
 
     assert!(Arc::ptr_eq(&first.prefix_sets[0], &second.prefix_sets[0]));
     assert!(Arc::ptr_eq(

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -456,7 +456,7 @@ fn resolve_rpol_chain_ref(
     }
     let mut compiled = entry
         .file
-        .compile_policy_bound(base, &args, store, datasets)
+        .compile_policy_bound_cached_tables(base, &args, store, datasets)
         .expect("registry entry names a policy defined in its file")
         .map_err(|missing| ConfigError::InvalidPolicyEntry {
             // Unreachable through `Config::load` (bind_datasets runs


### PR DESCRIPTION
## Problem

#1346 correctly made daemon roster resolution share one file-owned set table, but it also changed the public `RpolFile::compile_policy{_bound}` contract: callers passing one `SetStore` no longer shared identical literal sets across separately parsed files. That was an unintended public API regression.

## Fix

- Keep the public compiler on the caller-owned `SetStore` path.
- Add an explicit cached-table entry point for high-fanout callers.
- Make the daemon roster resolver the sole production caller of that fast path.
- Document the two ownership contracts separately.

The IRR-scale fix remains intact: daemon resolution still builds each file's millions of set entries once. General library callers again get the sharing semantics their `SetStore` argument promises.

## Load-bearing proof

`rpol_file_compiles_share_literal_sets_through_caller_store` initializes two files' private caches, compiles one policy through each public API with the same caller store, and requires pointer identity for prefix, community, and ASN sets. Routing the public compiler back through the file cache makes the test fail on the first identity assertion.

## Gates

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
