### PR TITLE
bench: make IRR reload receipts replay-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,9 @@ jobs:
             --locked --all-targets -- -D warnings
           cargo clippy --manifest-path bench/scale/outbound-prefix-limit-scale/Cargo.toml \
             --locked --all-targets -- -D warnings
+          # The IRR manifest contract exercises the production rustbgpd
+          # renderer, so make that prerequisite explicit on a clean runner.
+          cargo build -p rs-config-render
           cargo test --test reloadstall_scenario_emitted_check
           bash -n bench/compare-criterion.sh
           shellcheck bench/smoke-benches.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   fail closed on missing or invalid RSS samples instead of accepting stale or
   incomplete evidence. (LAN-790)
 
+- The measured IRR reload campaign now keeps its 320-member comparison to the
+  three mechanisms that can carry the same full dataset; the tonic-bounded
+  transaction path runs as a separately labeled 10-member receipt. Campaign
+  roots refuse to overwrite failed, interrupted, mismatched, or inconsistent
+  evidence, and each native cell is sealed to one canonical dataset digest and
+  its exact runtime inputs rather than timestamped renderer receipts.
+
 ## [0.62.0] — 2026-07-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,6 +2919,7 @@ dependencies = [
  "nix 0.31.3",
  "owo-colors",
  "prometheus",
+ "prost",
  "rs-config-render",
  "rtnetlink",
  "rustbgpctl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,6 +195,7 @@ rs-config-render = { path = "tools/rs-config-render" }
 # The importer gate (tests/config_import_emitted_check.rs) translates the
 # CLI's BIRD/FRR/GoBGP fixtures and proves the output passes `--check`.
 rustbgpctl = { path = "crates/cli" }
+prost.workspace = true
 serde_yaml.workspace = true
 tempfile.workspace = true
 tower.workspace = true

--- a/bench/scale/irrreload/README.md
+++ b/bench/scale/irrreload/README.md
@@ -1,15 +1,16 @@
 # irrreload — IRR-scale reload-receipt matrix
 
 Reload stall + completion under live sessions with a realistic multi-MB
-IRR-generated member policy, for rustbgpd on **both** reload paths (SIGHUP
-parse-then-swap and the gRPC transactional apply) versus BIRD 3.3.x and
-OpenBGPD 9.x.
+IRR-generated member policy. The full-shape comparison covers rustbgpd's
+SIGHUP parse-then-swap path versus BIRD 3.3.x and OpenBGPD 9.x. The gRPC
+transactional path is a separate, explicitly smaller receipt because its
+single-message candidate cannot carry the full dataset.
 
 This directory is the campaign runner and protocol. The instrument is the
-existing `bench/scale/reloadstall` harness, unchanged — real BGP stub
+existing `bench/scale/reloadstall` harness — real BGP stub
 sessions over loopback TCP, receiver-side timestamps, generation-marker
 completion tracking — driven by `bench/scale/reloadstall/gen-irr-scenario.py`,
-which emits all four cells from one seeded dataset.
+which can emit every native representation from one seeded dataset.
 
 ## What is being reloaded
 
@@ -28,19 +29,27 @@ policy generations:
 
 ## Shape (a harness parameter, stated exactly)
 
-| Parameter | Smoke (`SMOKE=1`) | Measured default |
-|---|---|---|
-| Members (`N_MEMBERS`) | 10 | 320 |
-| Announced base table (`TOTAL_PREFIXES`) | 100 (10 × /24 each) | 183,040 (572 × /24 each) |
-| Per-member IRR filter list (`MIN_LIST`–`MAX_LIST`) | 100 | log-uniform 1,000–40,000 entries |
-| Generation-changed members (`CHANGED_FRACTION`) | 10% | 10% |
-| Seed (`SEED`) | 61 | 61 |
-| Reload cycles per cell (`RELOADS`) | 1 | 4 |
+| Parameter | Smoke (`SMOKE=1`) | Full cross-daemon | Bounded transaction |
+|---|---|---|---|
+| Members (`N_MEMBERS`) | 10 | 320 | 10 |
+| Announced base table (`TOTAL_PREFIXES`) | 100 | 183,040 (572/member) | 5,720 (572/member) |
+| Per-member IRR filter list (`MIN_LIST`–`MAX_LIST`) | 100 | log-uniform 1,000–40,000 | log-uniform 1,000–12,000 |
+| Per-member change probability (`CHANGED_FRACTION`) | 10% | 10% | 10% |
+| Seed (`SEED`) | 61 | 61 | 61 |
+| Reload cycles per cell (`RELOADS`) | 1 | 4 | 4 |
 
 Dataset generation is fully deterministic from the shape + seed and is
-identical across cells (the generator never consults the cell when building
-the dataset). The multi-MB configs are **not** committed; they reproduce
-from the generator alone. Padding prefixes are /24s from
+identical across cells at the same shape (the generator never consults the
+cell when building the dataset). The manifest carries a canonical
+`dataset_sha256`; the full campaign rejects a cell whose digest differs.
+`CHANGED_FRACTION` is a Bernoulli probability, not an exact cohort size: seed
+61 changes 36/320 IRR filter lists at the full shape and 1/10 at the bounded
+transaction shape. Separately, the global A/B export marker changes output
+for all observers, so `peers_changed=320` and the first-generation timing
+percentiles cover 320 observers in the full receipt—not only the 36 members
+whose input lists changed.
+The multi-MB configs are **not** committed; they reproduce from the generator
+and pinned inputs. Padding prefixes are /24s from
 30.0.0.0–99.255.255.0 (disjoint from the announced table, the churn range,
 and the bogon list).
 
@@ -82,6 +91,19 @@ record):
   for every cell (`rss.csv`; the only RSS instrument for the container
   cells).
 
+Cross-daemon RSS comparisons use only the outer sampler, never the row-level
+VmRSS fields (which are zero for container cells). For each reload, the
+precommitted control statistic is the median `total_rss_kib` sample whose
+integer epoch is in `[floor(trigger)-CONTROL_SECS, floor(trigger))`; the reload
+statistic is the maximum sample in
+`[floor(trigger), ceil(trigger+completion_max_s)]`. The trigger comes from the
+logged `wall_us` and completion from that reload's emitted row. A missing
+sample in either window invalidates the RSS comparison. The sampler sums RSS
+across a process tree, so shared mappings can be double-counted; it prefers
+`smaps_rollup` for readable processes and can fall back to VmRSS for
+root-owned container processes. Close absolute differences are therefore not
+treated as exact allocator comparisons.
+
 **Startup and readiness windows** (harness parameters, not
 measurements — none of them is timed into any reported number; they
 only bound how long the harness waits before declaring a cell broken):
@@ -113,19 +135,25 @@ only bound how long the harness waits before declaring a cell broken):
 any stub session down at reload validation, missing generation-marker
 evidence, any daemon UPDATE that fails to decode, a nonzero reload-command
 exit, daemon process-tree RSS > 100 GiB (cell aborted), or cell timeout
-(`CELL_TIMEOUT`). Failed cells keep their artifacts and are published with
-their mechanism, not silently rerun (`status` files make the campaign
-resumable per cell).
+(`CELL_TIMEOUT`). Artifact roots are immutable: a failed/interrupted cell,
+an inconsistent row set, or a different campaign fingerprint is never
+overwritten. Preserve it and choose a fresh `ARTIFACTS_DIR`; matching passed
+cells alone are resumable/skippable. Each passed cell seals its exact rows,
+RSS samples, daemon and harness logs, manifest, provenance, and scenario roster;
+resume revalidates that evidence and the root-row copy before skipping. A
+missing or malformed root seal aborts the whole invocation before another cell
+can append evidence.
 
 Resume status is fingerprint-qualified. The fingerprint covers the exact Git
 commit and dirty-state content, runner/generator/sampler/transaction scripts,
 built daemon/CLI/renderer/harness binaries, Rust/Python/jq/Docker environment,
 selected cells, shape and timing inputs, and the local content IDs behind
 selected container image references. Each cell also retains `scenario.sha256`,
-a relative-path/content-hash roster of the generated config bundle; its digest
-is bound into that cell's provenance and pass status. A pass from any other
-fingerprint or config-bundle digest is discarded and rerun; its old rows cannot
-satisfy the new campaign. Root and per-cell `provenance.json` retain the
+a relative-path/content-hash roster of the manifest and exact daemon runtime
+inputs (not timestamped renderer receipts); its digest and the common dataset
+digest are bound into that cell's provenance and pass status. A pass from any
+other fingerprint or input digest cannot satisfy the new campaign. Root and
+per-cell `provenance.json` retain the
 fingerprint without hostnames, usernames, absolute paths, or other host-unique
 identifiers.
 Successful cells may delete their generated scenario only after retaining its
@@ -135,9 +163,10 @@ The RSS sampler is a required instrument: early/nonzero sampler exit or an
 empty/malformed `rss.csv` fails the cell. The runner reaps the sampler after
 the daemon exits and preserves all artifacts on failure.
 
-**Run count**: two full independent campaign runs minimum (fresh daemon
-starts, same cell order) so run-to-run spread is visible — run B into a
-separate `ARTIFACTS_DIR`.
+**Run count**: two fixed-order fresh-process campaign repeats minimum (fresh
+daemon starts, same cell order) so run-to-run spread is visible — run B into
+a separate `ARTIFACTS_DIR`. These are repeats, not statistically independent
+or counterbalanced trials.
 
 **Host-quiet preconditions** (measured mode enforces): the campaign starts
 only after `tests/soak/preflight.sh` passes (competing-workload, host-lock,
@@ -150,7 +179,7 @@ a measurement.
 
 Mirrors the IXP matrix fairness notes (`docs/perf/ixp-matrix-2026-07.md`):
 
-- **One harness, one instrument** for all cells; same addressing, same
+- **One harness, one instrument** for the three full-shape cells; same addressing, same
   churn, same completion semantics.
 - **Same dataset, native idiom per daemon.** Every cell filters the same
   member/prefix dataset with the same semantic core — per-member
@@ -178,13 +207,16 @@ Documented asymmetries (the honesty notes for the eventual receipt):
   `.rpol` route-server representation. Cross-daemon comparisons should use
   the SIGHUP cell; the txn cell answers "what does the transactional seam
   cost for the same semantic change", not engine-vs-engine.
-- **The txn cell is size-capped today.** The candidate travels inside one
+- **The txn cell is size-capped and separate today.** The candidate travels inside one
   gRPC message and the daemon's tonic server uses the default ~4 MiB
   decode limit, and the chain-engine TOML encoding is several times larger
-  than the equivalent `.rpol`. At the measured default shape the candidate
-  far exceeds the cap, so the transactional cell must run at the largest
-  shape that fits (or the daemon must grow a raised/streamed limit first —
-  a finding of this harness, to be stated in the receipt either way).
+  than the equivalent `.rpol`. The measured default therefore excludes it.
+  Running `rustbgpd-txn` alone selects the bounded 10-member shape above; the
+  runner rejects any candidate whose encoded apply request (candidate plus
+  the required fixed-shape snapshot token) would exceed 4 MiB before starting
+  the daemon. `txn-apply.sh` rejects an unexpected token shape rather than
+  invalidating that bound. Its rows and artifact root never enter the
+  cross-daemon table.
 - **Hygiene depth differs slightly.** The rustbgpd SIGHUP cell carries the
   full rendered `rs-hygiene` (including the AS_SET-segment reject term);
   the chain engine and the BIRD/OpenBGPD cells carry the shared core
@@ -208,14 +240,19 @@ Documented asymmetries (the honesty notes for the eventual receipt):
 SMOKE=1 bench/scale/irrreload/run-irr-reload.sh
 
 # Measured campaign (quiet host only — preflight-gated), two runs:
-bench/scale/irrreload/run-irr-reload.sh
-ARTIFACTS_DIR=/tmp/irrreload-artifacts-runB bench/scale/irrreload/run-irr-reload.sh
+ARTIFACTS_DIR=/tmp/irrreload-full-runA bench/scale/irrreload/run-irr-reload.sh
+ARTIFACTS_DIR=/tmp/irrreload-full-runB bench/scale/irrreload/run-irr-reload.sh
+
+# Separate bounded transaction receipt, also repeated into fresh roots:
+ARTIFACTS_DIR=/tmp/irrreload-txn-runA bench/scale/irrreload/run-irr-reload.sh rustbgpd-txn
+ARTIFACTS_DIR=/tmp/irrreload-txn-runB bench/scale/irrreload/run-irr-reload.sh rustbgpd-txn
 ```
 
 The runner builds what it needs (`rustbgpd`, `rbgp`, `rs-config-render`,
 the harness), generates each cell's scenario under `/tmp/irr-<cell>` (short
 paths: the gRPC UDS must fit `SUN_LEN`), runs one cell at a time, tears
 down containers/daemons, and appends one row per reload to
-`$ARTIFACTS_DIR/rows.csv`. Exit code 0 requires every requested cell to
-pass and produce at least `RELOADS` rows. Container images: `bird:3.3.1`
+`$ARTIFACTS_DIR/rows.csv`. At the full default, exit code 0 requires the
+three comparable cells to pass and produce exactly `RELOADS` rows apiece.
+Container images: `bird:3.3.1`
 (built from `tests/interop/Dockerfile.bird3`) and `openbgpd/openbgpd:9.1`.

--- a/bench/scale/irrreload/run-irr-reload.sh
+++ b/bench/scale/irrreload/run-irr-reload.sh
@@ -14,7 +14,8 @@
 #   openbgpd         OpenBGPD 9.x in docker --network=host; `bgpctl reload`
 #
 # Usage: run-irr-reload.sh [cell ...]
-#        (default: rustbgpd-sighup rustbgpd-txn bird openbgpd)
+#        (measured default: rustbgpd-sighup bird openbgpd)
+#        (smoke default: all four cells)
 #
 # Modes:
 #   SMOKE=1   pipeline proof at a tiny shape (10 members x 100-entry lists,
@@ -26,6 +27,7 @@
 # Knobs (env): N_MEMBERS TOTAL_PREFIXES MIN_LIST MAX_LIST SEED
 #              CHANGED_FRACTION PORT RELOADS CONTROL_SECS BIRD_THREADS
 #              CELL_TIMEOUT START_TIMEOUT ARTIFACTS_DIR SKIP_PREFLIGHT
+#              TXN_MAX_CANDIDATE_BYTES
 set -u
 set -o pipefail
 
@@ -40,6 +42,26 @@ RENDER="$REPO/target/release/rs-config-render"
 DAEMON="$REPO/target/release/rustbgpd"
 
 SMOKE="${SMOKE:-}"
+CELLS=("$@")
+if [ ${#CELLS[@]} -eq 0 ]; then
+    if [ -n "$SMOKE" ]; then
+        CELLS=(rustbgpd-sighup rustbgpd-txn bird openbgpd)
+    else
+        CELLS=(rustbgpd-sighup bird openbgpd)
+    fi
+fi
+
+TXN_ONLY=false
+if [ ${#CELLS[@]} -eq 1 ] && [ "${CELLS[0]}" = rustbgpd-txn ]; then
+    TXN_ONLY=true
+fi
+if [ -z "$SMOKE" ] && [[ " ${CELLS[*]} " == *" rustbgpd-txn "* ]] &&
+    [ "$TXN_ONLY" != true ]; then
+    echo "rustbgpd-txn must use a separate measured campaign and ARTIFACTS_DIR" >&2
+    echo "run this full-shape comparison without it, then run rustbgpd-txn alone" >&2
+    exit 2
+fi
+
 if [ -n "$SMOKE" ]; then
     N_MEMBERS="${N_MEMBERS:-10}"
     TOTAL_PREFIXES="${TOTAL_PREFIXES:-100}"
@@ -49,6 +71,18 @@ if [ -n "$SMOKE" ]; then
     CONTROL_SECS="${CONTROL_SECS:-5}"
     CELL_TIMEOUT="${CELL_TIMEOUT:-900}"
     COOL_DOWN=5
+elif [ "$TXN_ONLY" = true ]; then
+    # The transaction candidate is carried in one tonic request. This
+    # separate representative shape stays below the default 4 MiB decode
+    # ceiling; the runner also checks the exact generated protobuf payload.
+    N_MEMBERS="${N_MEMBERS:-10}"
+    TOTAL_PREFIXES="${TOTAL_PREFIXES:-5720}"
+    MIN_LIST="${MIN_LIST:-1000}"
+    MAX_LIST="${MAX_LIST:-12000}"
+    RELOADS="${RELOADS:-4}"
+    CONTROL_SECS="${CONTROL_SECS:-30}"
+    CELL_TIMEOUT="${CELL_TIMEOUT:-7200}"
+    COOL_DOWN=300
 else
     # The measured shape: 320 members, 572 announced /24s each (the IXP
     # matrix per-member slice), IRR filter lists log-uniform 1k-40k entries.
@@ -73,11 +107,42 @@ START_TIMEOUT="${START_TIMEOUT:-600}"
 BIRD_THREADS="${BIRD_THREADS:-8}"
 ART="${ARTIFACTS_DIR:-/tmp/irrreload-artifacts}"
 RSS_LIMIT_KIB=$((100 * 1024 * 1024)) # abort a cell past 100 GiB (precommitted)
+TONIC_MAX_DECODE_BYTES=4194304
+# Apply carries candidate_toml (field 1) plus the required 22-byte
+# runtime-snapshot token (field 2). At this candidate size, protobuf uses
+# one-byte tags/field-2 length and a four-byte field-1 length:
+# 4_194_275 + 5 + 24 = tonic's 4 MiB decoded-message ceiling exactly.
+TXN_SAFE_CANDIDATE_BYTES=4194275
+TXN_MAX_CANDIDATE_BYTES="${TXN_MAX_CANDIDATE_BYTES:-$TXN_SAFE_CANDIDATE_BYTES}"
+case $TXN_MAX_CANDIDATE_BYTES in
+'' | *[!0-9]*)
+    echo "TXN_MAX_CANDIDATE_BYTES must be an integer" >&2
+    exit 2
+    ;;
+esac
+if [ "$TXN_MAX_CANDIDATE_BYTES" -gt "$TXN_SAFE_CANDIDATE_BYTES" ]; then
+    echo "TXN_MAX_CANDIDATE_BYTES exceeds the safe apply-request ceiling" >&2
+    echo "maximum: $TXN_SAFE_CANDIDATE_BYTES bytes under tonic's $TONIC_MAX_DECODE_BYTES-byte limit" >&2
+    exit 2
+fi
 
-CELLS=("$@")
-[ ${#CELLS[@]} -eq 0 ] && CELLS=(rustbgpd-sighup rustbgpd-txn bird openbgpd)
+if [ -n "$SMOKE" ]; then
+    CAMPAIGN_KIND=smoke
+elif [ "$TXN_ONLY" = true ]; then
+    CAMPAIGN_KIND=transaction-bounded
+else
+    CAMPAIGN_KIND=full-cross-daemon
+fi
 
-for tool in docker jq python3 cargo ss sha256sum git awk timeout find sort; do
+if [ -n "${DRY_RUN_PROTOCOL:-}" ]; then
+    printf 'cells=%s\n' "$(IFS=,; echo "${CELLS[*]}")"
+    printf 'shape=%s,%s,%s,%s\n' "$N_MEMBERS" "$TOTAL_PREFIXES" "$MIN_LIST" "$MAX_LIST"
+    printf 'reloads=%s control_secs=%s txn_max_candidate_bytes=%s\n' \
+        "$RELOADS" "$CONTROL_SECS" "$TXN_MAX_CANDIDATE_BYTES"
+    exit 0
+fi
+
+for tool in docker jq python3 cargo ss sha256sum git awk timeout find sort setsid cmp mktemp; do
     command -v "$tool" >/dev/null || {
         echo "missing required tool: $tool" >&2
         exit 1
@@ -102,7 +167,6 @@ for bin in "$HARNESS" "$RBGP" "$RENDER" "$DAEMON"; do
     }
 done
 mkdir -p "$ART"
-PRIOR_FINGERPRINT=$(jq -r '.fingerprint // empty' "$ART/provenance.json" 2>/dev/null)
 hash_file() {
     local output
     output=$(sha256sum -- "$1") || return 1
@@ -164,6 +228,8 @@ CAMPAIGN_PROVENANCE=$(jq -cn \
     --arg max_list "$MAX_LIST" --arg seed "$SEED" \
     --arg changed_fraction "$CHANGED_FRACTION" --arg port "$PORT" \
     --arg reloads "$RELOADS" --arg control_secs "$CONTROL_SECS" \
+    --arg campaign_kind "$CAMPAIGN_KIND" \
+    --arg txn_max_candidate_bytes "$TXN_MAX_CANDIDATE_BYTES" \
     --arg cell_timeout "$CELL_TIMEOUT" --arg start_timeout "$START_TIMEOUT" \
     --arg bird_threads "$BIRD_THREADS" --arg skip_preflight "${SKIP_PREFLIGHT:-}" \
     --arg rustc "$(rustc -Vv)" --arg cargo "$(cargo -V)" \
@@ -173,48 +239,193 @@ CAMPAIGN_PROVENANCE=$(jq -cn \
     --arg cpu_model "$(awk -F: '/^model name/ { sub(/^[[:space:]]+/, "", $2); print $2; exit }' /proc/cpuinfo)" \
     --arg bird_image "$BIRD_IMAGE" --arg bird_image_id "$BIRD_IMAGE_ID" \
     --arg openbgpd_image "$OPENBGPD_IMAGE" --arg openbgpd_image_id "$OPENBGPD_IMAGE_ID" \
-    '{schema:1,git:{commit:$commit,dirty:$dirty,dirty_state_sha256:$dirty_state_sha256},scripts:{runner:$run_script_sha256,generator:$generator_sha256,rss_sampler:$sampler_sha256,txn_apply:$txn_apply_sha256},binaries:{reloadstall:$harness_sha256,rustbgpd:$daemon_sha256,rbgp:$cli_sha256,rs_config_render:$renderer_sha256},environment:{rustc:$rustc,cargo:$cargo,python:$python,jq:$jq,docker:$docker,kernel:$kernel,cpu_model:$cpu_model},inputs:{cells:$cells,smoke:$smoke,n_members:$n_members,total_prefixes:$total_prefixes,min_list:$min_list,max_list:$max_list,seed:$seed,changed_fraction:$changed_fraction,port:$port,reloads:$reloads,control_secs:$control_secs,cell_timeout:$cell_timeout,start_timeout:$start_timeout,bird_threads:$bird_threads,skip_preflight:$skip_preflight,bird_image:$bird_image,bird_image_id:$bird_image_id,openbgpd_image:$openbgpd_image,openbgpd_image_id:$openbgpd_image_id}}') || exit 1
+    '{schema:2,git:{commit:$commit,dirty:$dirty,dirty_state_sha256:$dirty_state_sha256},scripts:{runner:$run_script_sha256,generator:$generator_sha256,rss_sampler:$sampler_sha256,txn_apply:$txn_apply_sha256},binaries:{reloadstall:$harness_sha256,rustbgpd:$daemon_sha256,rbgp:$cli_sha256,rs_config_render:$renderer_sha256},environment:{rustc:$rustc,cargo:$cargo,python:$python,jq:$jq,docker:$docker,kernel:$kernel,cpu_model:$cpu_model},inputs:{campaign_kind:$campaign_kind,cells:$cells,smoke:$smoke,n_members:$n_members,total_prefixes:$total_prefixes,min_list:$min_list,max_list:$max_list,seed:$seed,changed_fraction:$changed_fraction,port:$port,reloads:$reloads,control_secs:$control_secs,txn_max_candidate_bytes:$txn_max_candidate_bytes,cell_timeout:$cell_timeout,start_timeout:$start_timeout,bird_threads:$bird_threads,skip_preflight:$skip_preflight,bird_image:$bird_image,bird_image_id:$bird_image_id,openbgpd_image:$openbgpd_image,openbgpd_image_id:$openbgpd_image_id}}') || exit 1
 CAMPAIGN_FINGERPRINT=$(printf '%s' "$CAMPAIGN_PROVENANCE" | sha256sum | cut -d' ' -f1) || exit 1
-printf '%s\n' "$CAMPAIGN_PROVENANCE" | jq --arg fingerprint "$CAMPAIGN_FINGERPRINT" \
-    '. + {fingerprint:$fingerprint}' >"$ART/provenance.json" || exit 1
+SEALED_CAMPAIGN_PROVENANCE=$(printf '%s\n' "$CAMPAIGN_PROVENANCE" | jq -cS \
+    --arg fingerprint "$CAMPAIGN_FINGERPRINT" '. + {fingerprint:$fingerprint}') || exit 1
+ARTIFACT_ROOT_EXISTING=false
+if [ -e "$ART/provenance.json" ]; then
+    ARTIFACT_ROOT_EXISTING=true
+    PRIOR_FINGERPRINT=$(jq -er '.fingerprint | select(type == "string" and length > 0)' \
+        "$ART/provenance.json" 2>/dev/null) || {
+        echo "artifact root has malformed provenance; refusing to overwrite it" >&2
+        echo "choose a fresh ARTIFACTS_DIR" >&2
+        exit 2
+    }
+    PRIOR_PROVENANCE=$(jq -cS . "$ART/provenance.json" 2>/dev/null) || {
+        echo "artifact root has malformed provenance; refusing to overwrite it" >&2
+        echo "choose a fresh ARTIFACTS_DIR" >&2
+        exit 2
+    }
+    if [ "$PRIOR_PROVENANCE" != "$SEALED_CAMPAIGN_PROVENANCE" ]; then
+        echo "artifact root belongs to campaign $PRIOR_FINGERPRINT" >&2
+        echo "refusing to overwrite or repair its provenance; choose a fresh ARTIFACTS_DIR" >&2
+        exit 2
+    fi
+elif [ -n "$(find "$ART" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+    echo "non-empty artifact root has no provenance; refusing to overwrite it" >&2
+    echo "choose a fresh ARTIFACTS_DIR" >&2
+    exit 2
+else
+    printf '%s\n' "$SEALED_CAMPAIGN_PROVENANCE" >"$ART/provenance.json" || exit 1
+fi
 ROWS_HEADER="cell,reload,peers_total,peers_changed,peers_stable,prefixes,completion_p50_s,completion_p95_s,completion_max_s,changed_maxgap_p50_ms,changed_maxgap_p95_ms,changed_maxgap_max_ms,all_observer_maxgap_p50_ms,all_observer_maxgap_p95_ms,all_observer_maxgap_max_ms,changed_first_generation_update_p50_ms,changed_first_generation_update_p95_ms,changed_first_generation_update_max_ms,rss_before_mib,rss_after_mib,stable_marker_peers,sessions_up,parse_errors"
-if [ "$PRIOR_FINGERPRINT" != "$CAMPAIGN_FINGERPRINT" ] ||
-    [ "$(head -n1 "$ART/rows.csv" 2>/dev/null)" != "$ROWS_HEADER" ]; then
+if [ -f "$ART/rows.csv" ] && [ "$(head -n1 "$ART/rows.csv")" != "$ROWS_HEADER" ]; then
+    echo "artifact root has an incompatible rows.csv; choose a fresh ARTIFACTS_DIR" >&2
+    exit 2
+fi
+if [ "$ARTIFACT_ROOT_EXISTING" = true ] && [ ! -f "$ART/rows.csv" ]; then
+    echo "existing artifact root has no rows.csv; refusing to repair it" >&2
+    echo "choose a fresh ARTIFACTS_DIR" >&2
+    exit 2
+fi
+if [ "$ARTIFACT_ROOT_EXISTING" = false ]; then
     printf '%s\n' "$ROWS_HEADER" >"$ART/rows.csv"
 fi
 
 cell_receipt_matches() {
-    local cdir=$1 scenario_sha actual_sha
+    local cdir=$1 cell scenario_sha dataset_sha evidence_sha actual_sha rows_tmp
+    cell=${cdir##*/}
     scenario_sha=$(jq -er --arg fingerprint "$CAMPAIGN_FINGERPRINT" \
         'select(.fingerprint == $fingerprint) | .scenario.manifest_sha256' \
         "$cdir/provenance.json" 2>/dev/null) || return 1
+    dataset_sha=$(jq -er --arg fingerprint "$CAMPAIGN_FINGERPRINT" \
+        'select(.fingerprint == $fingerprint) | .scenario.dataset_sha256' \
+        "$cdir/provenance.json" 2>/dev/null) || return 1
     [ -n "$scenario_sha" ] || return 1
+    [ -n "$dataset_sha" ] || return 1
     actual_sha=$(hash_file "$cdir/scenario.sha256" 2>/dev/null) || return 1
     [ "$actual_sha" = "$scenario_sha" ] || return 1
-    grep -qx "pass $CAMPAIGN_FINGERPRINT $scenario_sha" "$cdir/status" 2>/dev/null
+    [ "$(cat "$ART/dataset.sha256" 2>/dev/null)" = "$dataset_sha" ] || return 1
+    evidence_sha=$(awk -v fingerprint="$CAMPAIGN_FINGERPRINT" \
+        -v scenario="$scenario_sha" -v dataset="$dataset_sha" \
+        '$1 == "pass" && $2 == fingerprint && $3 == scenario && $4 == dataset && NF == 5 { print $5 }' \
+        "$cdir/status" 2>/dev/null) || return 1
+    [ -n "$evidence_sha" ] || return 1
+    actual_sha=$(hash_file "$cdir/evidence.sha256" 2>/dev/null) || return 1
+    [ "$actual_sha" = "$evidence_sha" ] || return 1
+    (cd "$cdir" && sha256sum --check --strict --status evidence.sha256) || return 1
+    validate_cell_rows "$cdir/rows.csv" "$cell" || return 1
+    rows_tmp=$(mktemp "/tmp/irrreload-$cell-rows.XXXXXX") || return 1
+    grep "^$cell," "$ART/rows.csv" >"$rows_tmp" || {
+        rm -f "$rows_tmp"
+        return 1
+    }
+    cmp -s "$cdir/rows.csv" "$rows_tmp"
+    local rc=$?
+    rm -f "$rows_tmp"
+    return "$rc"
+}
+
+validate_cell_rows() {
+    local rows=$1 cell=$2
+    awk -F, -v cell="$cell" -v expected="$RELOADS" '
+        function uint(v) { return v ~ /^[0-9]+$/ }
+        function number(v) { return v ~ /^[0-9]+([.][0-9]+)?$/ }
+        NF != 23 || $1 != cell || $2 != sprintf("%d", NR) { bad=1; next }
+        !uint($3) || !uint($4) || !uint($5) || !uint($6) { bad=1 }
+        !number($7) || !number($8) || !number($9) { bad=1 }
+        !number($10) || !number($11) || !number($12) { bad=1 }
+        !number($13) || !number($14) || !number($15) { bad=1 }
+        !number($16) || !number($17) || !number($18) { bad=1 }
+        !number($19) || !number($20) { bad=1 }
+        !uint($21) || !uint($22) || !uint($23) { bad=1 }
+        END { exit (bad || NR != expected) }
+    ' "$rows"
+}
+
+seal_cell_evidence() {
+    local cdir=$1 path digest
+    local -a evidence_files=(
+        daemon.log manifest.json provenance.json reloadstall.log rows.csv rss.csv scenario.sha256
+    )
+    : >"$cdir/evidence.sha256.tmp"
+    for path in "${evidence_files[@]}"; do
+        [ -f "$cdir/$path" ] || {
+            echo "missing retained cell evidence: $path" >&2
+            rm -f "$cdir/evidence.sha256.tmp"
+            return 1
+        }
+        digest=$(hash_file "$cdir/$path") || return 1
+        printf '%s  %s\n' "$digest" "$path" >>"$cdir/evidence.sha256.tmp" || return 1
+    done
+    mv "$cdir/evidence.sha256.tmp" "$cdir/evidence.sha256" || return 1
+    CELL_EVIDENCE_SHA256=$(hash_file "$cdir/evidence.sha256") || return 1
 }
 
 seal_scenario() {
-    local run=$1 cdir=$2
-    (
-        cd "$run" || exit 1
-        find . -type f -print0 | sort -z |
-            while IFS= read -r -d '' path; do
-                digest=$(hash_file "$path") || exit 1
-                printf '%s  %s\n' "$digest" "$path"
-            done
-    ) >"$cdir/scenario.sha256" || return 1
+    local run=$1 cdir=$2 path digest
+    local -a runtime_files=()
+    mapfile -t runtime_files < <(
+        jq -er '.runtime_files | select(type == "array" and length > 0)[]' \
+            "$run/manifest.json"
+    ) || return 1
+    [ ${#runtime_files[@]} -gt 0 ] || return 1
+    : >"$cdir/scenario.sha256"
+    for path in "${runtime_files[@]}" manifest.json; do
+        case $path in
+        '' | /* | */* | *..*)
+            echo "invalid runtime input path in manifest: $path" >&2
+            return 1
+            ;;
+        esac
+        [ -f "$run/$path" ] || {
+            echo "runtime input missing: $path" >&2
+            return 1
+        }
+        digest=$(hash_file "$run/$path") || return 1
+        printf '%s  ./%s\n' "$digest" "$path" >>"$cdir/scenario.sha256" || return 1
+    done
+    sort -o "$cdir/scenario.sha256" "$cdir/scenario.sha256" || return 1
     CELL_SCENARIO_SHA256=$(hash_file "$cdir/scenario.sha256") || return 1
+    CELL_DATASET_SHA256=$(jq -er '.dataset_sha256' "$run/manifest.json") || return 1
+    if [ -f "$ART/dataset.sha256" ]; then
+        if [ "$(cat "$ART/dataset.sha256")" != "$CELL_DATASET_SHA256" ]; then
+            echo "cell dataset digest differs from the campaign dataset" >&2
+            return 1
+        fi
+    else
+        printf '%s\n' "$CELL_DATASET_SHA256" >"$ART/dataset.sha256" || return 1
+    fi
     jq --arg scenario_sha "$CELL_SCENARIO_SHA256" \
-        '. + {scenario:{manifest_sha256:$scenario_sha}}' \
+        --arg dataset_sha "$CELL_DATASET_SHA256" \
+        '. + {scenario:{manifest_sha256:$scenario_sha,dataset_sha256:$dataset_sha}}' \
         "$ART/provenance.json" >"$cdir/provenance.json"
 }
 
+ACTIVE_DAEMON_PID=""
+ACTIVE_HARNESS_PID=""
+ACTIVE_SAMPLER_PID=""
+terminate_process_group() {
+    # shellcheck disable=SC2317  # invoked directly and via trap
+    local pid=$1 attempt
+    [ -n "$pid" ] || return 0
+    kill -TERM -- "-$pid" 2>/dev/null || true
+    for ((attempt = 0; attempt < 20; attempt++)); do
+        kill -0 -- "-$pid" 2>/dev/null || break
+        sleep 0.1
+    done
+    kill -KILL -- "-$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+}
+cleanup_active_processes() {
+    # shellcheck disable=SC2317  # invoked directly and via trap
+    local pid
+    for pid in "$ACTIVE_HARNESS_PID" "$ACTIVE_SAMPLER_PID" "$ACTIVE_DAEMON_PID"; do
+        terminate_process_group "$pid"
+    done
+    ACTIVE_HARNESS_PID=""
+    ACTIVE_SAMPLER_PID=""
+    ACTIVE_DAEMON_PID=""
+}
 cleanup() {
     # shellcheck disable=SC2317  # invoked via trap
+    cleanup_active_processes
     docker rm -f irr-bird irr-obgpd >/dev/null 2>&1
 }
 trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 load_gate() {
     [ -n "$SMOKE" ] && return 0
@@ -285,20 +496,35 @@ run_cell() {
     local daemon_pid="" container="" reload_cmd="" pid_arg=""
     local live a b
     CELL_SCENARIO_SHA256=""
+    CELL_DATASET_SHA256=""
+    CELL_EVIDENCE_SHA256=""
     case $cell in
     rustbgpd-sighup)
         gen_scenario rustbgpd "$run" --render-bin "$RENDER" || return 1
         seal_scenario "$run" "$cdir" || return 1
-        "$DAEMON" "$run/config.toml" >"$cdir/daemon.log" 2>&1 &
+        setsid "$DAEMON" "$run/config.toml" >"$cdir/daemon.log" 2>&1 &
         daemon_pid=$!
+        ACTIVE_DAEMON_PID=$daemon_pid
         live="$run/member.rpol" a="$run/gen-a.rpol" b="$run/gen-b.rpol"
         pid_arg=$daemon_pid # SIGHUP path: harness signals + samples this PID
         ;;
     rustbgpd-txn)
         gen_scenario rustbgpd-txn "$run" || return 1
+        local candidate candidate_bytes
+        for candidate in "$run/config.toml" "$run/candidate.toml" \
+            "$run/gen-a.toml" "$run/gen-b.toml"; do
+            candidate_bytes=$(wc -c <"$candidate") || return 1
+            if [ "$candidate_bytes" -gt "$TXN_MAX_CANDIDATE_BYTES" ]; then
+                echo "cell $cell: $(basename "$candidate") is ${candidate_bytes} bytes" >&2
+                echo "candidate exceeds the ${TXN_MAX_CANDIDATE_BYTES}-byte tonic request budget" >&2
+                echo "use a smaller separate transaction shape and a fresh ARTIFACTS_DIR" >&2
+                return 1
+            fi
+        done
         seal_scenario "$run" "$cdir" || return 1
-        "$DAEMON" "$run/config.toml" >"$cdir/daemon.log" 2>&1 &
+        setsid "$DAEMON" "$run/config.toml" >"$cdir/daemon.log" 2>&1 &
         daemon_pid=$!
+        ACTIVE_DAEMON_PID=$daemon_pid
         live="$run/candidate.toml" a="$run/gen-a.toml" b="$run/gen-b.toml"
         pid_arg=$daemon_pid # RSS from the real PID; reloads via reload_cmd
         reload_cmd="$TXN_APPLY $RBGP unix://$run/grpc.sock $run/candidate.toml"
@@ -333,8 +559,9 @@ run_cell() {
 
     wait_ready "$cell" "$cdir" || return 1
 
-    "$SAMPLER" "$daemon_pid" "$cdir/rss.csv" 5 &
+    setsid "$SAMPLER" "$daemon_pid" "$cdir/rss.csv" 5 &
     local sampler_pid=$!
+    ACTIVE_SAMPLER_PID=$sampler_pid
 
     local hargs=("$N_MEMBERS" "$TOTAL_PREFIXES" "$PORT" "$pid_arg"
         "$live" "$a" "$b" "$RELOADS" "$CONTROL_SECS")
@@ -343,13 +570,14 @@ run_cell() {
     [ -n "$reload_cmd" ] && hargs+=("$N_MEMBERS" "$reload_cmd")
 
     # Background so the precommitted RSS abort criterion can kill the cell.
-    timeout "$CELL_TIMEOUT" "$HARNESS" "${hargs[@]}" >"$cdir/reloadstall.log" 2>&1 &
+    setsid timeout "$CELL_TIMEOUT" "$HARNESS" "${hargs[@]}" >"$cdir/reloadstall.log" 2>&1 &
     local hpid=$!
+    ACTIVE_HARNESS_PID=$hpid
     local rc=""
     while kill -0 "$hpid" 2>/dev/null; do
         if ! kill -0 "$sampler_pid" 2>/dev/null; then
             echo "cell $cell: RSS sampler exited before harness completion" >&2
-            kill "$hpid" 2>/dev/null
+            terminate_process_group "$hpid"
             rc=98
             break
         fi
@@ -360,8 +588,9 @@ run_cell() {
         *)
             if [ "$last_kib" -gt "$RSS_LIMIT_KIB" ]; then
                 echo "cell $cell: daemon RSS ${last_kib} KiB > 100 GiB, aborting cell" >&2
-                kill "$hpid" 2>/dev/null
+                terminate_process_group "$hpid"
                 rc=99
+                break
             fi
             ;;
         esac
@@ -370,17 +599,19 @@ run_cell() {
     local hrc
     wait "$hpid"
     hrc=$?
+    ACTIVE_HARNESS_PID=""
     [ -z "$rc" ] && rc=$hrc
 
     if [ -n "$container" ]; then
         docker logs "$container" >"$cdir/daemon.log" 2>&1
         docker rm -f "$container" >/dev/null 2>&1
     else
-        kill "$daemon_pid" 2>/dev/null
-        wait "$daemon_pid" 2>/dev/null
+        terminate_process_group "$daemon_pid"
+        ACTIVE_DAEMON_PID=""
     fi
     local sampler_rc=0
     wait "$sampler_pid" || sampler_rc=$?
+    ACTIVE_SAMPLER_PID=""
     if [ "$sampler_rc" -ne 0 ]; then
         echo "cell $cell: RSS sampler failed rc=$sampler_rc" >&2
         rc=98
@@ -397,18 +628,19 @@ run_cell() {
         local rows_tmp="$cdir/rows.csv.tmp"
         grep '^reloadstall_csv,' "$cdir/reloadstall.log" |
             sed "s/^reloadstall_csv/$cell/" >"$rows_tmp"
-        if ! awk -F, -v cell="$cell" -v expected="$RELOADS" \
-            'NF != 23 || $1 != cell || $2 != sprintf("%d", NR) { bad=1 } END { exit (bad || NR != expected) }' \
-            "$rows_tmp"; then
+        if ! validate_cell_rows "$rows_tmp" "$cell"; then
             echo "cell $cell: invalid, missing, or duplicate measurement rows" >&2
             rm -f "$rows_tmp"
             rc=96
         else
-            if ! sed -n '1,$p' "$rows_tmp" >>"$ART/rows.csv"; then
+            if ! mv "$rows_tmp" "$cdir/rows.csv" ||
+                ! sed -n '1,$p' "$cdir/rows.csv" >>"$ART/rows.csv"; then
                 echo "cell $cell: failed to retain measurement rows" >&2
                 rc=96
+            elif ! seal_cell_evidence "$cdir"; then
+                echo "cell $cell: failed to seal retained evidence" >&2
+                rc=95
             else
-                rm -f "$rows_tmp"
                 rm -rf "$run" # reproduces from the generator + manifest
             fi
         fi
@@ -416,6 +648,49 @@ run_cell() {
     echo "cell $cell: harness rc=$rc (artifacts: $cdir)"
     return "$rc"
 }
+
+if [ "$ARTIFACT_ROOT_EXISTING" = true ]; then
+    allowed_cells=",$(IFS=,; echo "${CELLS[*]}"),"
+    if ! awk -F, -v allowed="$allowed_cells" '
+        NR == 1 { next }
+        index(allowed, "," $1 ",") == 0 { exit 1 }
+    ' "$ART/rows.csv"; then
+        echo "artifact root has measurement rows outside the selected cell roster" >&2
+        echo "choose a fresh ARTIFACTS_DIR" >&2
+        exit 2
+    fi
+    while IFS= read -r entry; do
+        name=${entry##*/}
+        case $name in
+        provenance.json | rows.csv | dataset.sha256) ;;
+        *)
+            if [[ " ${CELLS[*]} " != *" $name "* ]]; then
+                echo "artifact root has unexpected entry: $name" >&2
+                echo "choose a fresh ARTIFACTS_DIR" >&2
+                exit 2
+            fi
+            ;;
+        esac
+    done < <(find "$ART" -mindepth 1 -maxdepth 1 -print)
+    any_existing_cell=false
+    for cell in "${CELLS[@]}"; do
+        existing_rows=$(grep -c "^$cell," "$ART/rows.csv" 2>/dev/null)
+        if [ -e "$ART/$cell" ] || [ "${existing_rows:-0}" -ne 0 ]; then
+            any_existing_cell=true
+            if ! cell_receipt_matches "$ART/$cell" ||
+                [ "${existing_rows:-0}" -ne "$RELOADS" ]; then
+                echo "cell $cell: existing evidence is inconsistent and immutable" >&2
+                echo "choose a fresh ARTIFACTS_DIR" >&2
+                exit 2
+            fi
+        fi
+    done
+    if [ "$any_existing_cell" = false ] && [ -e "$ART/dataset.sha256" ]; then
+        echo "artifact root has an unowned dataset digest; refusing to repair it" >&2
+        echo "choose a fresh ARTIFACTS_DIR" >&2
+        exit 2
+    fi
+fi
 
 overall=0
 for cell in "${CELLS[@]}"; do
@@ -426,16 +701,27 @@ for cell in "${CELLS[@]}"; do
         echo "cell $cell: matching fingerprint already passed, skipping"
         continue
     fi
-    # Rows from another fingerprint can never satisfy this campaign.
-    awk -F, -v cell="$cell" 'NR == 1 || $1 != cell' "$ART/rows.csv" >"$ART/rows.csv.tmp" &&
-        mv "$ART/rows.csv.tmp" "$ART/rows.csv"
+    if [ -e "$ART/$cell" ] || [ "${existing_rows:-0}" -ne 0 ]; then
+        echo "cell $cell: existing failed, interrupted, or inconsistent evidence is immutable" >&2
+        echo "refusing to overwrite it; choose a fresh ARTIFACTS_DIR" >&2
+        overall=1
+        continue
+    fi
     load_gate
     echo "=== cell $cell start $(date -Is) ==="
+    CELL_SCENARIO_SHA256=""
+    CELL_DATASET_SHA256=""
+    CELL_EVIDENCE_SHA256=""
     if run_cell "$cell"; then
-        echo "pass $CAMPAIGN_FINGERPRINT $CELL_SCENARIO_SHA256" >"$status_file"
+        echo "pass $CAMPAIGN_FINGERPRINT $CELL_SCENARIO_SHA256 $CELL_DATASET_SHA256 $CELL_EVIDENCE_SHA256" \
+            >"$status_file"
         echo "=== cell $cell PASS $(date -Is) ==="
     else
-        echo "fail $CAMPAIGN_FINGERPRINT ${CELL_SCENARIO_SHA256:-unavailable} rc=$?" >"$status_file"
+        rc=$?
+        cleanup
+        mkdir -p "$ART/$cell"
+        echo "fail $CAMPAIGN_FINGERPRINT ${CELL_SCENARIO_SHA256:-unavailable} ${CELL_DATASET_SHA256:-unavailable} ${CELL_EVIDENCE_SHA256:-unavailable} rc=$rc" \
+            >"$status_file"
         echo "=== cell $cell FAIL ==="
         overall=1
     fi

--- a/bench/scale/irrreload/txn-apply.sh
+++ b/bench/scale/irrreload/txn-apply.sh
@@ -33,5 +33,9 @@ if [ -z "$token" ]; then
     echo "txn-apply: plan returned no runtime_snapshot_token" >&2
     exit 1
 fi
+if [[ ! $token =~ ^kv2:[0-9a-f]{16}:8$ ]]; then
+    echo "txn-apply: plan returned an unexpected runtime_snapshot_token shape" >&2
+    exit 1
+fi
 exec "$rbgp" --addr "$addr" config apply "$candidate" \
     --expected-runtime-snapshot-token "$token"

--- a/bench/scale/reloadstall/gen-irr-scenario.py
+++ b/bench/scale/reloadstall/gen-irr-scenario.py
@@ -57,11 +57,13 @@ Emits into <out_dir> (per cell):
                 gen-a.toml, gen-b.toml
   bird          bird.conf, gen.conf (live, = gen-a), gen-a.conf, gen-b.conf
   openbgpd      bgpd.conf, gen.conf (live, = gen-a), gen-a.conf, gen-b.conf
-plus manifest.json (shape, seed, per-member list sizes, changed members,
-emitted byte sizes) in every cell.
+plus manifest.json (shape, seed, canonical cell-independent dataset digest,
+runtime-input roster, per-member list sizes, changed members, emitted byte
+sizes) in every cell.
 """
 
 import argparse
+import hashlib
 import json
 import math
 import pathlib
@@ -154,7 +156,21 @@ def check_sun_len(rundir: pathlib.Path) -> str:
     return sock
 
 
+def canonical_member_record(member: Member) -> bytes:
+    record = {
+        "idx": member.idx,
+        "asn": member.asn,
+        "addr": member.addr,
+        "list_a": member.list_a,
+        "list_b": member.list_b,
+    }
+    return json.dumps(record, sort_keys=True, separators=(",", ":")).encode() + b"\n"
+
+
 def write_manifest(out: pathlib.Path, args, members, files: list[str]) -> None:
+    dataset_digest = hashlib.sha256()
+    for member in members:
+        dataset_digest.update(canonical_member_record(member))
     manifest = {
         "cell": args.cell,
         "n_members": args.n_members,
@@ -163,9 +179,11 @@ def write_manifest(out: pathlib.Path, args, members, files: list[str]) -> None:
         "min_list": args.min_list,
         "max_list": args.max_list,
         "changed_fraction": args.changed_fraction,
+        "dataset_sha256": dataset_digest.hexdigest(),
         "list_sizes": [len(m.list_a) for m in members],
         "total_filter_entries": sum(len(m.list_a) for m in members),
         "changed_members": [m.idx for m in members if m.changed],
+        "runtime_files": files,
         "file_bytes": {f: (out / f).stat().st_size for f in files},
     }
     (out / "manifest.json").write_text(json.dumps(manifest, indent=1) + "\n")
@@ -700,6 +718,11 @@ def main() -> None:
     parser.add_argument("--render-bin", help="rs-config-render binary (rustbgpd cell)")
     parser.add_argument("--threads", type=int, default=8, help="BIRD threads knob")
     parser.add_argument("--conf-dir", help="config dir as seen by the running daemon")
+    parser.add_argument(
+        "--canonical-dataset-out",
+        type=pathlib.Path,
+        help="test/debug output: stream the exact cell-independent digest input",
+    )
     args = parser.parse_args()
 
     if args.n_members < CHURNERS:
@@ -711,6 +734,10 @@ def main() -> None:
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
     members = build_dataset(args)
+    if args.canonical_dataset_out is not None:
+        with args.canonical_dataset_out.open("wb") as canonical:
+            for member in members:
+                canonical.write(canonical_member_record(member))
     files = EMITTERS[args.cell](args, members, args.out_dir)
     write_manifest(args.out_dir, args, members, files)
     total_entries = sum(len(m.list_a) for m in members)

--- a/tests/reloadstall_scenario_emitted_check.rs
+++ b/tests/reloadstall_scenario_emitted_check.rs
@@ -105,17 +105,43 @@ fn irr_reload_campaign_seals_resume_rows_and_rss_evidence() {
         "bird_image_id",
         "openbgpd_image_id",
         "scenario.sha256",
+        "dataset.sha256",
+        "dataset_sha256",
+        ".runtime_files | select(type == \"array\" and length > 0)[]",
         "cell_receipt_matches",
         "[ \"$actual_sha\" = \"$scenario_sha\" ] || return 1",
-        "pass $CAMPAIGN_FINGERPRINT $scenario_sha",
-        "pass $CAMPAIGN_FINGERPRINT $CELL_SCENARIO_SHA256",
+        "evidence.sha256",
+        "sha256sum --check --strict --status evidence.sha256",
+        "cmp -s \"$cdir/rows.csv\" \"$rows_tmp\"",
+        "validate_cell_rows \"$cdir/rows.csv\" \"$cell\"",
+        "pass $CAMPAIGN_FINGERPRINT $CELL_SCENARIO_SHA256 $CELL_DATASET_SHA256 $CELL_EVIDENCE_SHA256",
         "wait \"$sampler_pid\"",
         "RSS sampler produced empty or invalid data",
         "changed_first_generation_update_p50_ms",
         "changed_first_generation_update_p95_ms",
         "changed_first_generation_update_max_ms",
-        "[ \"$PRIOR_FINGERPRINT\" != \"$CAMPAIGN_FINGERPRINT\" ]",
-        "[ \"$(head -n1 \"$ART/rows.csv\" 2>/dev/null)\" != \"$ROWS_HEADER\" ]",
+        "artifact root belongs to campaign",
+        "existing failed, interrupted, or inconsistent evidence is immutable",
+        "choose a fresh ARTIFACTS_DIR",
+        "artifact root has malformed provenance; refusing to overwrite it",
+        "non-empty artifact root has no provenance; refusing to overwrite it",
+        "refusing to overwrite or repair its provenance",
+        "if [ \"$PRIOR_PROVENANCE\" != \"$SEALED_CAMPAIGN_PROVENANCE\" ]; then",
+        "if [ -e \"$ART/$cell\" ] || [ \"${existing_rows:-0}\" -ne 0 ]; then",
+        "CELLS=(rustbgpd-sighup bird openbgpd)",
+        "rustbgpd-txn must use a separate measured campaign",
+        "TXN_MAX_CANDIDATE_BYTES",
+        "if [ \"$candidate_bytes\" -gt \"$TXN_MAX_CANDIDATE_BYTES\" ]; then",
+        "candidate exceeds the ${TXN_MAX_CANDIDATE_BYTES}-byte tonic request budget",
+        "cleanup_active_processes",
+        "terminate_process_group \"$pid\"",
+        "ACTIVE_HARNESS_PID",
+        "ACTIVE_SAMPLER_PID",
+        "ACTIVE_DAEMON_PID",
+        "kill -TERM -- \"-$pid\"",
+        "kill -KILL -- \"-$pid\"",
+        "trap 'exit 130' INT",
+        "trap 'exit 143' TERM",
         "required manifest/provenance retention failed",
         "rc=97",
         "NF != 23 || $1 != cell || $2 != sprintf(\"%d\", NR)",
@@ -145,4 +171,564 @@ fn irr_reload_campaign_seals_resume_rows_and_rss_evidence() {
         retention_gate < scenario_delete,
         "retention must fail closed before successful scenario deletion"
     );
+    let cleanup = runner
+        .split_once("cleanup() {")
+        .and_then(|(_, rest)| rest.split_once("trap cleanup EXIT"))
+        .map(|(body, _)| body)
+        .expect("cleanup function body");
+    assert!(cleanup.contains("cleanup_active_processes"));
+    let terminate = runner
+        .split_once("terminate_process_group() {")
+        .and_then(|(_, rest)| rest.split_once("cleanup_active_processes() {"))
+        .map(|(body, _)| body)
+        .expect("bounded process-group terminator");
+    assert!(terminate.contains("kill -TERM -- \"-$pid\""));
+    assert!(terminate.contains("kill -KILL -- \"-$pid\""));
+    assert!(terminate.contains("wait \"$pid\""));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+/// Red proof: removing the process-group KILL escalation leaves the TERM-
+/// ignoring child alive after the helper returns and fails the bounded liveness
+/// assertion. The external timeout and cleanup guard turn that regression into
+/// a bounded failure rather than a hung test or leaked process.
+fn irr_reload_process_group_cleanup_kills_a_stubborn_child() {
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::Stdio;
+
+    struct ProcessGroupGuard {
+        child: std::process::Child,
+        pgid: String,
+    }
+
+    impl Drop for ProcessGroupGuard {
+        fn drop(&mut self) {
+            let _ = std::process::Command::new("kill")
+                .args(["-KILL", "--", &self.pgid])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+
+    let runner = std::fs::read_to_string(format!(
+        "{}/bench/scale/irrreload/run-irr-reload.sh",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .expect("read IRR reload runner");
+    let terminate = runner
+        .split_once("terminate_process_group() {")
+        .and_then(|(_, rest)| rest.split_once("cleanup_active_processes() {"))
+        .map(|(body, _)| format!("terminate_process_group() {{{body}"))
+        .expect("bounded process-group terminator");
+
+    let ready_dir = tempfile::tempdir().expect("readiness directory");
+    let ready_path = ready_dir.path().join("ready");
+    let child = std::process::Command::new("setsid")
+        .args([
+            "bash",
+            "-c",
+            "trap '' TERM; : >\"$1\"; while :; do sleep 1; done",
+            "stubborn-child",
+        ])
+        .arg(&ready_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("start stubborn process group");
+    let pid = child.id();
+    let pgid = format!("-{pid}");
+    let mut stubborn = ProcessGroupGuard { child, pgid };
+    let ready = (0..100).any(|_| {
+        if ready_path.is_file() {
+            true
+        } else {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            false
+        }
+    });
+    assert!(ready, "stubborn child did not become ready");
+
+    let cleanup = std::process::Command::new("timeout")
+        .args(["--signal=KILL", "5s", "bash", "-c"])
+        .arg(format!("{terminate}\nterminate_process_group {pid}"))
+        .status()
+        .expect("run process-group cleanup");
+    assert!(cleanup.success(), "cleanup helper failed");
+
+    let status = (0..20)
+        .find_map(|_| {
+            let status = stubborn.child.try_wait().expect("inspect stubborn process");
+            if status.is_none() {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            status
+        })
+        .expect("stubborn process survived process-group cleanup");
+    assert_eq!(status.signal(), Some(9), "stubborn group must reach KILL");
+    let gone = (0..20).any(|_| {
+        let alive = std::process::Command::new("kill")
+            .args(["-0", "--", &stubborn.pgid])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("probe process-group liveness")
+            .success();
+        if alive {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            false
+        } else {
+            true
+        }
+    });
+    assert!(gone, "stubborn process group survived cleanup");
+}
+
+fn sha256_hex(bytes: impl AsRef<[u8]>) -> String {
+    use sha2::{Digest, Sha256};
+
+    Sha256::digest(bytes.as_ref())
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[test]
+/// Red proof: removing the retained-evidence digest check accepts the RSS
+/// mutation; removing the exact global/cell row comparison accepts the global
+/// row mutation; removing numeric row validation accepts the coherently
+/// re-sealed malformed row.
+fn irr_reload_resume_rejects_mutated_or_malformed_evidence() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let runner = std::fs::read_to_string(format!("{root}/bench/scale/irrreload/run-irr-reload.sh"))
+        .expect("read runner");
+    let receipt_functions = runner
+        .split_once("cell_receipt_matches() {")
+        .and_then(|(_, rest)| rest.split_once("seal_scenario() {"))
+        .map(|(body, _)| format!("cell_receipt_matches() {{{body}"))
+        .expect("receipt functions");
+
+    let art = tempfile::tempdir().expect("artifact root");
+    let cdir = art.path().join("bird");
+    std::fs::create_dir(&cdir).expect("cell dir");
+    std::fs::write(art.path().join("dataset.sha256"), "dataset\n").expect("dataset seal");
+    let scenario = "012345  ./manifest.json\n";
+    std::fs::write(cdir.join("scenario.sha256"), scenario).expect("scenario roster");
+    let scenario_sha = sha256_hex(scenario);
+    let provenance = serde_json::json!({
+        "fingerprint": "campaign",
+        "scenario": {
+            "manifest_sha256": scenario_sha,
+            "dataset_sha256": "dataset"
+        }
+    });
+    std::fs::write(
+        cdir.join("provenance.json"),
+        serde_json::to_vec(&provenance).expect("provenance JSON"),
+    )
+    .expect("provenance");
+    let good_row =
+        "bird,1,10,1,9,100,1.0,1.1,1.2,2.0,2.1,2.2,3.0,3.1,3.2,4.0,4.1,4.2,100.0,101.0,10,10,0\n";
+    let header = "cell,reload,peers_total,peers_changed,peers_stable,prefixes,completion_p50_s,completion_p95_s,completion_max_s,changed_maxgap_p50_ms,changed_maxgap_p95_ms,changed_maxgap_max_ms,all_observer_maxgap_p50_ms,all_observer_maxgap_p95_ms,all_observer_maxgap_max_ms,changed_first_generation_update_p50_ms,changed_first_generation_update_p95_ms,changed_first_generation_update_max_ms,rss_before_mib,rss_after_mib,stable_marker_peers,sessions_up,parse_errors\n";
+    for (name, contents) in [
+        ("daemon.log", "daemon\n"),
+        ("manifest.json", "{}\n"),
+        ("reloadstall.log", "receipt\n"),
+        ("rows.csv", good_row),
+        ("rss.csv", "epoch_s,total_rss_kib,pids\n1,100,1\n"),
+    ] {
+        std::fs::write(cdir.join(name), contents).expect("cell evidence");
+    }
+    std::fs::write(art.path().join("rows.csv"), format!("{header}{good_row}"))
+        .expect("campaign rows");
+
+    let seal = |cdir: &std::path::Path| {
+        let files = [
+            "daemon.log",
+            "manifest.json",
+            "provenance.json",
+            "reloadstall.log",
+            "rows.csv",
+            "rss.csv",
+            "scenario.sha256",
+        ];
+        let mut roster = String::new();
+        for name in files {
+            let bytes = std::fs::read(cdir.join(name)).expect("read evidence");
+            roster.push_str(&format!("{}  {name}\n", sha256_hex(bytes)));
+        }
+        std::fs::write(cdir.join("evidence.sha256"), &roster).expect("evidence roster");
+        let evidence_sha = sha256_hex(roster);
+        std::fs::write(
+            cdir.join("status"),
+            format!("pass campaign {scenario_sha} dataset {evidence_sha}\n"),
+        )
+        .expect("status");
+    };
+    seal(&cdir);
+
+    let verify = || {
+        std::process::Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "set -u\nART='{}'\nRELOADS=1\nCAMPAIGN_FINGERPRINT=campaign\nhash_file() {{ sha256sum -- \"$1\" | cut -d' ' -f1; }}\n{}\ncell_receipt_matches \"$ART/bird\"",
+                art.path().display(),
+                receipt_functions
+            ))
+            .status()
+            .expect("run receipt verifier")
+            .success()
+    };
+
+    assert!(verify(), "sealed receipt must resume");
+    std::fs::write(
+        art.path().join("rows.csv"),
+        format!("{header}{}", good_row.replace("1.0", "9.0")),
+    )
+    .expect("mutate root row");
+    assert!(!verify(), "changed global row must invalidate resume");
+    std::fs::write(art.path().join("rows.csv"), format!("{header}{good_row}"))
+        .expect("restore root row");
+    std::fs::write(
+        cdir.join("rss.csv"),
+        "epoch_s,total_rss_kib,pids\n1,999,1\n",
+    )
+    .expect("mutate RSS evidence");
+    assert!(!verify(), "changed raw evidence must invalidate resume");
+
+    let malformed_row = good_row.replacen("1.0", "oops", 1);
+    std::fs::write(
+        cdir.join("rss.csv"),
+        "epoch_s,total_rss_kib,pids\n1,100,1\n",
+    )
+    .expect("restore RSS evidence");
+    std::fs::write(cdir.join("rows.csv"), &malformed_row).expect("malformed cell row");
+    std::fs::write(
+        art.path().join("rows.csv"),
+        format!("{header}{malformed_row}"),
+    )
+    .expect("malformed root row");
+    seal(&cdir);
+    assert!(!verify(), "malformed numeric row must invalidate resume");
+}
+
+fn run_irr_protocol(args: &[&str], smoke: bool) -> String {
+    let runner = format!(
+        "{}/bench/scale/irrreload/run-irr-reload.sh",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let mut command = std::process::Command::new("bash");
+    command.arg(runner).args(args).env("DRY_RUN_PROTOCOL", "1");
+    for knob in [
+        "N_MEMBERS",
+        "TOTAL_PREFIXES",
+        "MIN_LIST",
+        "MAX_LIST",
+        "RELOADS",
+        "CONTROL_SECS",
+        "TXN_MAX_CANDIDATE_BYTES",
+    ] {
+        command.env_remove(knob);
+    }
+    if smoke {
+        command.env("SMOKE", "1");
+    } else {
+        command.env_remove("SMOKE");
+    }
+    let output = command.output().expect("run IRR protocol resolver");
+    assert!(
+        output.status.success(),
+        "protocol resolver failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("protocol output is UTF-8")
+}
+
+#[test]
+/// Red proof: restoring the measured four-cell default makes the first
+/// assertion fail; removing the separate bounded transaction preset makes
+/// the second fail. The smoke assertion keeps all four plumbing paths gated.
+fn irr_reload_protocol_separates_full_scale_from_bounded_transaction() {
+    let measured = run_irr_protocol(&[], false);
+    assert!(measured.contains("cells=rustbgpd-sighup,bird,openbgpd\n"));
+    assert!(measured.contains("shape=320,183040,1000,40000\n"));
+
+    let transaction = run_irr_protocol(&["rustbgpd-txn"], false);
+    assert!(transaction.contains("cells=rustbgpd-txn\n"));
+    assert!(transaction.contains("shape=10,5720,1000,12000\n"));
+
+    let smoke = run_irr_protocol(&[], true);
+    assert!(smoke.contains("cells=rustbgpd-sighup,rustbgpd-txn,bird,openbgpd\n"));
+    assert!(smoke.contains("shape=10,100,100,100\n"));
+
+    let runner = format!(
+        "{}/bench/scale/irrreload/run-irr-reload.sh",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let mixed = std::process::Command::new("bash")
+        .arg(runner)
+        .args(["rustbgpd-sighup", "rustbgpd-txn"])
+        .env("DRY_RUN_PROTOCOL", "1")
+        .env_remove("SMOKE")
+        .output()
+        .expect("run invalid mixed protocol");
+    assert_eq!(mixed.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&mixed.stderr)
+            .contains("rustbgpd-txn must use a separate measured campaign")
+    );
+}
+
+#[test]
+/// Red proof: increasing the bounded preset beyond tonic's default message
+/// ceiling fails the real Plan/Apply protobuf encoded-size assertions;
+/// selecting a seed/shape with no real IRR-list delta fails the changed-member
+/// assertion.
+fn irr_reload_bounded_transaction_preset_fits_tonic_request() {
+    use prost::Message;
+    use rustbgpd_api::proto::{ApplyConfigTransactionRequest, PlanConfigTransactionRequest};
+
+    let root = env!("CARGO_MANIFEST_DIR");
+    let generator = format!("{root}/bench/scale/reloadstall/gen-irr-scenario.py");
+    let protocol = run_irr_protocol(&["rustbgpd-txn"], false);
+    let shape = protocol
+        .lines()
+        .find_map(|line| line.strip_prefix("shape="))
+        .expect("resolved transaction shape")
+        .split(',')
+        .collect::<Vec<_>>();
+    assert_eq!(shape.len(), 4);
+    let candidate_budget = protocol
+        .split_whitespace()
+        .find_map(|field| field.strip_prefix("txn_max_candidate_bytes="))
+        .expect("resolved transaction message budget")
+        .parse::<u64>()
+        .expect("numeric transaction message budget");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let output = std::process::Command::new("python3")
+        .args([&generator, "rustbgpd-txn", shape[0], shape[1]])
+        .arg(dir.path())
+        .args([
+            "--port",
+            "1790",
+            "--seed",
+            "61",
+            "--min-list",
+            shape[2],
+            "--max-list",
+            shape[3],
+            "--changed-fraction",
+            "0.1",
+        ])
+        .output()
+        .expect("generate bounded transaction scenario");
+    assert!(output.status.success());
+    let manifest: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(dir.path().join("manifest.json")).expect("read manifest"),
+    )
+    .expect("parse manifest");
+    assert_eq!(manifest["changed_members"].as_array().unwrap().len(), 1);
+    const TONIC_DECODE_LIMIT: usize = 4 * 1024 * 1024;
+    const SNAPSHOT_TOKEN: &str = "kv2:0123456789abcdef:8";
+    assert_eq!(SNAPSHOT_TOKEN.len(), 22);
+    for candidate in ["config.toml", "candidate.toml", "gen-a.toml", "gen-b.toml"] {
+        let bytes = manifest["file_bytes"][candidate]
+            .as_u64()
+            .expect("candidate byte count");
+        assert!(bytes <= candidate_budget, "{candidate}: {bytes}");
+        let candidate_toml = "x".repeat(bytes as usize);
+        let plan = PlanConfigTransactionRequest {
+            candidate_toml: candidate_toml.clone(),
+            expected_runtime_snapshot_token: String::new(),
+        };
+        let apply = ApplyConfigTransactionRequest {
+            candidate_toml,
+            expected_runtime_snapshot_token: SNAPSHOT_TOKEN.to_owned(),
+            client_request_id: String::new(),
+            comment: String::new(),
+            confirm_id: String::new(),
+            confirm_timeout_seconds: 0,
+        };
+        assert!(
+            plan.encoded_len() <= TONIC_DECODE_LIMIT,
+            "{candidate}: plan"
+        );
+        assert!(
+            apply.encoded_len() <= TONIC_DECODE_LIMIT,
+            "{candidate}: apply"
+        );
+    }
+    let at_budget = "x".repeat(candidate_budget as usize);
+    let exact_apply = ApplyConfigTransactionRequest {
+        candidate_toml: at_budget,
+        expected_runtime_snapshot_token: SNAPSHOT_TOKEN.to_owned(),
+        client_request_id: String::new(),
+        comment: String::new(),
+        confirm_id: String::new(),
+        confirm_timeout_seconds: 0,
+    };
+    assert_eq!(exact_apply.encoded_len(), TONIC_DECODE_LIMIT);
+    let over_limit = ApplyConfigTransactionRequest {
+        candidate_toml: "x".repeat(candidate_budget as usize + 1),
+        ..exact_apply
+    };
+    assert_eq!(over_limit.encoded_len(), TONIC_DECODE_LIMIT + 1);
+
+    let runner = format!("{root}/bench/scale/irrreload/run-irr-reload.sh");
+    let rejected = std::process::Command::new("bash")
+        .arg(runner)
+        .arg("rustbgpd-txn")
+        .env("DRY_RUN_PROTOCOL", "1")
+        .env(
+            "TXN_MAX_CANDIDATE_BYTES",
+            (candidate_budget + 1).to_string(),
+        )
+        .output()
+        .expect("run over-limit protocol");
+    assert_eq!(rejected.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&rejected.stderr)
+            .contains("TXN_MAX_CANDIDATE_BYTES exceeds the safe apply-request ceiling")
+    );
+}
+
+#[test]
+/// Red proof: including the cell name or native rendering in the canonical
+/// dataset digest makes the four-cell equality fail. Omitting or changing any
+/// canonical record field fails the independently pinned seed-61 digest; a
+/// seed-insensitive digest fails the changed-seed assertion.
+fn irr_reload_manifest_seals_a_cell_independent_dataset_digest() {
+    use sha2::{Digest, Sha256};
+
+    let root = env!("CARGO_MANIFEST_DIR");
+    let generator = format!("{root}/bench/scale/reloadstall/gen-irr-scenario.py");
+    let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from(root).join("target"));
+    let renderer = target_dir.join("debug/rs-config-render");
+    assert!(
+        renderer.is_file(),
+        "missing renderer at {}",
+        renderer.display()
+    );
+    let mut digests = Vec::new();
+    for (cell, expected_roster) in [
+        (
+            "rustbgpd",
+            &["config.toml", "member.rpol", "gen-a.rpol", "gen-b.rpol"][..],
+        ),
+        (
+            "rustbgpd-txn",
+            &["config.toml", "candidate.toml", "gen-a.toml", "gen-b.toml"][..],
+        ),
+        (
+            "bird",
+            &["bird.conf", "gen.conf", "gen-a.conf", "gen-b.conf"][..],
+        ),
+        (
+            "openbgpd",
+            &["bgpd.conf", "gen.conf", "gen-a.conf", "gen-b.conf"][..],
+        ),
+    ] {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let canonical = dir.path().join("canonical-dataset.jsonl");
+        let mut command = std::process::Command::new("python3");
+        command
+            .args([&generator, cell, "10", "100"])
+            .arg(dir.path())
+            .args([
+                "--port",
+                "1790",
+                "--seed",
+                "61",
+                "--min-list",
+                "100",
+                "--max-list",
+                "100",
+                "--canonical-dataset-out",
+            ])
+            .arg(&canonical);
+        if cell == "rustbgpd" {
+            command.arg("--render-bin").arg(&renderer);
+        }
+        let output = command.output().expect("run IRR generator");
+        assert!(output.status.success(), "generator failed for {cell}");
+        let manifest: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(dir.path().join("manifest.json")).expect("read manifest"),
+        )
+        .expect("parse manifest");
+        digests.push(
+            manifest["dataset_sha256"]
+                .as_str()
+                .expect("dataset digest")
+                .to_owned(),
+        );
+        let roster = manifest["runtime_files"]
+            .as_array()
+            .expect("runtime file roster")
+            .iter()
+            .map(|value| value.as_str().expect("runtime path"))
+            .collect::<Vec<_>>();
+        assert_eq!(roster, expected_roster, "{cell} runtime roster");
+        let canonical_digest =
+            Sha256::digest(std::fs::read(&canonical).expect("read canonical dataset"))
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect::<String>();
+        assert_eq!(manifest["dataset_sha256"], canonical_digest);
+        assert_eq!(
+            canonical_digest, "708688117bf8909ab9b5a631171ae8d4343f38ce813f9ff67e219c2af31df65b",
+            "seed-61 canonical dataset contract changed for {cell}"
+        );
+
+        let records = std::fs::read_to_string(&canonical)
+            .expect("read canonical records")
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("record JSON"))
+            .collect::<Vec<_>>();
+        assert_eq!(records.len(), 10);
+        let first = records[0].as_object().expect("member record object");
+        assert_eq!(
+            first.keys().map(String::as_str).collect::<Vec<_>>(),
+            ["addr", "asn", "idx", "list_a", "list_b"]
+        );
+        assert_eq!(first["idx"], 0);
+        assert_eq!(first["asn"], 64_512);
+        assert_eq!(first["addr"], "127.1.0.1");
+        let list_a = first["list_a"].as_array().expect("list_a");
+        let list_b = first["list_b"].as_array().expect("list_b");
+        assert_eq!(list_a.len(), 100);
+        assert_eq!(list_b, list_a);
+        assert_eq!(list_a[0], "20.0.0.0/24");
+        assert_eq!(list_a[9], "20.0.9.0/24");
+        assert_eq!(list_a[99], "88.30.166.0/24");
+    }
+    assert!(digests.windows(2).all(|pair| pair[0] == pair[1]));
+
+    let changed = tempfile::tempdir().expect("tempdir");
+    let output = std::process::Command::new("python3")
+        .args([&generator, "bird", "10", "100"])
+        .arg(changed.path())
+        .args([
+            "--port",
+            "1790",
+            "--seed",
+            "62",
+            "--min-list",
+            "100",
+            "--max-list",
+            "100",
+        ])
+        .output()
+        .expect("run changed-seed IRR generator");
+    assert!(output.status.success());
+    let manifest: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(changed.path().join("manifest.json")).expect("read manifest"),
+    )
+    .expect("parse manifest");
+    assert_ne!(manifest["dataset_sha256"], digests[0]);
 }


### PR DESCRIPTION
## What changed

- keep the 320-member comparison to the three reload mechanisms that can carry the same full dataset, with the tonic-bounded transaction path labeled and run separately at 10 members
- enforce the exact 4 MiB encoded Apply request ceiling using the generated Prost type and fail closed if the runtime token shape changes
- make campaign provenance immutable and reject incomplete, failed, mismatched, or inconsistent artifact roots before any cell appends data
- bind each passed cell to the canonical dataset, exact runtime inputs, numeric rows, RSS samples, logs, provenance, and an evidence digest
- start daemon, sampler, and harness in isolated process groups with bounded TERM-to-KILL cleanup
- document fixed-order repeat semantics, RSS methodology, fleet shapes, and comparison limits

## Why

The prior campaign could mix a transaction cell that cannot carry the full dataset into the measured comparison, repair or reuse incomplete artifact roots, and accept retained rows whose underlying evidence had changed. Those behaviors could turn a failed or incomparable run into a publishable-looking receipt.

This changes the measurement contract only. It makes no new performance claim.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `shellcheck bench/scale/irrreload/run-irr-reload.sh bench/scale/irrreload/txn-apply.sh`
- `bash -n bench/scale/irrreload/run-irr-reload.sh bench/scale/irrreload/txn-apply.sh`
- four-cell smoke: every cell completed with 10/10 sessions and zero parse errors
- live SIGINT receipt: exit 130, no campaign process groups or comparison containers left behind

## Load-bearing proofs

- restoring the old all-four measured default fails the protocol-separation test
- restoring the old raw candidate bound fails the real Prost encoded-length assertion at 4,194,328 bytes
- making the dataset digest cell-dependent fails four-cell equality; deleting a canonical record field fails the independently pinned digest
- removing the evidence digest check, global/cell row equality, or numeric row validation makes the mutation test accept corrupted evidence and fail
- removing the process-group KILL escalation makes the live stubborn-child test fail in a bounded interval; its cleanup guard leaves no child behind

