### PR TITLE
build(deps): complete prefix-trie 0.10.1 update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2298,9 +2298,9 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be1ea03ff63e842fa707c9cffedc9ff9fa4a0ab540af1a7693d2ff15fa03c65"
+checksum = "6369af434551b9bf8be05ab871ac1263687d6f0c9485e6d781f904f3e06d7d03"
 dependencies = [
  "array-const-fn-init",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ rustc-hash = "2"
 # wait-free load — the Decision 7 purity contract bans lock
 # acquisition on the evaluation path.
 arc-swap = "1"
-prefix-trie = "0.9.2"
+prefix-trie = "0.10.1"
 ipnet = "2.12.0"
 lru = "0.18"
 tikv-jemallocator = { version = "0.7", features = ["profiling", "stats"] }

--- a/bench/scale/rrharness/Cargo.lock
+++ b/bench/scale/rrharness/Cargo.lock
@@ -664,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b81f62da691716444e46e43a913c84b3301ef8a732ad2720306bcbe7320aa4ef"
+checksum = "6369af434551b9bf8be05ab871ac1263687d6f0c9485e6d781f904f3e06d7d03"
 dependencies = [
  "array-const-fn-init",
  "either",

--- a/bench/scale/rrtransport/Cargo.lock
+++ b/bench/scale/rrtransport/Cargo.lock
@@ -479,9 +479,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "prefix-trie"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be1ea03ff63e842fa707c9cffedc9ff9fa4a0ab540af1a7693d2ff15fa03c65"
+checksum = "6369af434551b9bf8be05ab871ac1263687d6f0c9485e6d781f904f3e06d7d03"
 dependencies = [
  "array-const-fn-init",
  "either",


### PR DESCRIPTION
## Summary

- update `prefix-trie` from 0.9.x to 0.10.1
- refresh the two tracked standalone harness lockfiles so every `--locked` gate is reproducible
- preserve the repository policy that leaves the MRT fuzz lockfile untracked

This supersedes the incomplete root-only update in #1344. The production API used by route paging (`PrefixMap::iter_from`) remains available, and the 0.10.1 MSRV (1.81) is below the workspace MSRV.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked`
- MSRV 1.95 workspace/all-targets check
- `cargo audit`
- locked rrharness and rrtransport tests
- rrtransport real smoke: 2 sessions, 100/100 routes each, zero withdrawals, duplicates, or decode failures
- MRT fuzz build against 0.10.1
- RIB ordered-continuation and paged-query tests
- ORR exact/LPM/default-cover/mixed-family tests

## Load-bearing proof

No test code changed. Reverting either standalone lockfile update reproduces the existing `cargo test --manifest-path ... --locked` failure that blocked #1344; with both tracked locks updated, the same gates pass.