### PR TITLE
ci: serialize dev image cache priming

### DIFF
--- a/.github/actions/setup-dataplane-host/action.yml
+++ b/.github/actions/setup-dataplane-host/action.yml
@@ -94,9 +94,6 @@ runs:
         load: true
         tags: rustbgpd:dev
         target: dev
-        cache-from: type=gha
-        # ignore-error: a flaking GHA cache backend ("error writing
-        # layer blob: not_found") must cost the NEXT build its cache
-        # hit, not kill THIS build — the cache is an optimization,
-        # never a correctness input.
-        cache-to: type=gha,mode=max,ignore-error=true
+        # Consumers load locally from the primer's fixed scope but never write
+        # it; a cache miss simply falls back to a normal source build.
+        cache-from: type=gha,scope=rustbgpd-dev

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -41,6 +41,10 @@ on:
       - ".github/workflows/audit.yml"
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Placed above `on:` so the trigger-contract self-check below (which
 # asserts the exact `on:`..`jobs:` region) stays byte-stable.
 permissions:
@@ -62,6 +66,10 @@ jobs:
           bash -n .github/scripts/install-grpcurl.sh
           shellcheck .github/scripts/install-grpcurl.sh
           bash .github/scripts/install-grpcurl.sh --self-test
+      - name: Prove CI image-primer contract
+        run: |
+          python3 -m unittest -v scripts/test_check_ci_image_primer_contract.py
+          python3 scripts/check_ci_image_primer_contract.py
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -140,11 +140,41 @@ on:
       - "**/*.md"
       - "docs/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
+  # Warm one fixed-scope cache per source SHA; jobs still build and load their
+  # own image, falling back to an uncached build if the cache is unavailable.
+  prime_dev_image:
+    name: Prime rustbgpd:dev build cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: rustbgpd-dev-image-${{ github.sha }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - name: Prime rustbgpd:dev build cache
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          load: false
+          tags: rustbgpd:dev
+          target: dev
+          cache-from: type=gha,scope=rustbgpd-dev
+          cache-to: type=gha,scope=rustbgpd-dev,mode=max,ignore-error=true
+
   m1:
+    needs: prime_dev_image
     name: M1 — basic session + UPDATE (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -168,8 +198,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M1 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -179,6 +208,7 @@ jobs:
           script: tests/interop/scripts/test-m1-frr.sh
 
   m13:
+    needs: prime_dev_image
     name: M13 — Policy Engine (FRR 10.3.1, 3-node)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -202,8 +232,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M13 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -213,6 +242,7 @@ jobs:
           script: tests/interop/scripts/test-m13-policy-frr.sh
 
   m80:
+    needs: prime_dev_image
     name: M80 — rpol policy parity (ADR-0096, FRR 10.3.1, 4-node)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -239,8 +269,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M80 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -250,6 +279,7 @@ jobs:
           script: tests/interop/scripts/test-m80-rpol-policy-parity-frr.sh
 
   m15:
+    needs: prime_dev_image
     name: M15 — Route Refresh via gRPC SoftResetIn (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -273,8 +303,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M15 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -284,6 +313,7 @@ jobs:
           script: tests/interop/scripts/test-m15-rr-frr.sh
 
   m10:
+    needs: prime_dev_image
     name: M10 — IPv6 dual-stack / MP-BGP (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -307,8 +337,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M10 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -318,6 +347,7 @@ jobs:
           script: tests/interop/scripts/test-m10-frr-ipv6.sh
 
   m14:
+    needs: prime_dev_image
     name: M14 — Route Reflector (FRR 10.3.1, 3-node iBGP)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -341,8 +371,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M14 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -352,6 +381,7 @@ jobs:
           script: tests/interop/scripts/test-m14-rr-frr.sh
 
   m17:
+    needs: prime_dev_image
     name: M17/M89 — Add-Path + experimental Paths-Limit (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -376,8 +406,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M17 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -394,6 +423,7 @@ jobs:
           script: tests/interop/scripts/test-m89-paths-limit-frr.sh
 
   m73:
+    needs: prime_dev_image
     name: M73/M87 — GoBGP BGP-LS + exact-export/BIRD
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -418,8 +448,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Build gobgp:bgpls
         run: docker build -t gobgp:bgpls -f tests/interop/Dockerfile.gobgp-bgpls tests/interop
@@ -442,6 +471,7 @@ jobs:
           script: tests/interop/scripts/test-m87-exact-export-rejection.sh
 
   m74:
+    needs: prime_dev_image
     name: M74 — VPNv4 route reflection (GoBGP 3.x)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -466,8 +496,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Build gobgp:interop
         run: docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
@@ -480,6 +509,7 @@ jobs:
           script: tests/interop/scripts/test-m74-vpnv4-reflection-gobgp.sh
 
   m75:
+    needs: prime_dev_image
     name: M75 — RT-Constrain VPNv4 filtering (GoBGP 3.x)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -504,8 +534,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Build gobgp:interop
         run: docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
@@ -518,6 +547,7 @@ jobs:
           script: tests/interop/scripts/test-m75-rtc-vpnv4-filter-gobgp.sh
 
   m76:
+    needs: prime_dev_image
     name: M76 — ORR divergent-best (GoBGP 4.6.0)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -542,8 +572,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Build gobgp:bgpls
         run: docker build -t gobgp:bgpls -f tests/interop/Dockerfile.gobgp-bgpls tests/interop
@@ -556,6 +585,7 @@ jobs:
           script: tests/interop/scripts/test-m76-orr-divergent-best-gobgp.sh
 
   m77:
+    needs: prime_dev_image
     name: M77 — GR/LLGR RR-family stale preservation (GoBGP 4.6.0)
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -580,8 +610,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Build gobgp:bgpls
         run: docker build -t gobgp:bgpls -f tests/interop/Dockerfile.gobgp-bgpls tests/interop
@@ -594,6 +623,7 @@ jobs:
           script: tests/interop/scripts/test-m77-gr-llgr-rr-gobgp.sh
 
   m78:
+    needs: prime_dev_image
     name: M78 — Multi-cluster ORR + inter-RR Add-Path (GoBGP 4.6.0)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -618,8 +648,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Build gobgp:bgpls
         run: docker build -t gobgp:bgpls -f tests/interop/Dockerfile.gobgp-bgpls tests/interop
@@ -632,6 +661,7 @@ jobs:
           script: tests/interop/scripts/test-m78-multicluster-orr-gobgp.sh
 
   m79:
+    needs: prime_dev_image
     name: M79 — Labeled-unicast route reflection + GR (GoBGP 4.6.0)
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -656,8 +686,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Build gobgp:bgpls
         run: docker build -t gobgp:bgpls -f tests/interop/Dockerfile.gobgp-bgpls tests/interop
@@ -670,6 +699,7 @@ jobs:
           script: tests/interop/scripts/test-m79-labeled-reflection-gobgp.sh
 
   m22:
+    needs: prime_dev_image
     name: M22 — FlowSpec (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -697,8 +727,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M22 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -708,6 +737,7 @@ jobs:
           script: tests/interop/scripts/test-m22-flowspec-frr.sh
 
   m24:
+    needs: prime_dev_image
     name: M24 — BMP (FRR 10.3.1, Python receiver)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -731,8 +761,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M24 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -742,6 +771,7 @@ jobs:
           script: tests/interop/scripts/test-m24-bmp-frr.sh
 
   m81:
+    needs: prime_dev_image
     name: M81 — BMP trio + BMPv4 receipt (pmacct + gobmp + tshark)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -767,8 +797,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Build gobgp:interop
         run: docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
@@ -787,6 +816,7 @@ jobs:
           script: tests/interop/scripts/test-m81-bmp-trio-gobgp.sh
 
   m82:
+    needs: prime_dev_image
     # Synthetic leg only. The SR Linux vendor leg
     # (m82-evpn-bundle-srlinux.clab.yml) stays local: the NOS image is
     # ~750 MB compressed / 3.2 GB on disk and boots a full chassis sim —
@@ -816,8 +846,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Build gobgp:interop
         run: docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
@@ -830,6 +859,7 @@ jobs:
           script: tests/interop/scripts/test-m82-evpn-bundle-synthetic-gobgp.sh
 
   m83:
+    needs: prime_dev_image
     # Full 3-stack leg in CI: BIRD 2 is a plain apt install on
     # bookworm-slim (deterministic build) and BIRD already runs in
     # hosted CI (M43, kernel-dataplane.yml) without flake history —
@@ -859,8 +889,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Build bird:2-bookworm
         # bird2 + tshark: the member stack that carries the byte-level
@@ -887,6 +916,7 @@ jobs:
           retention-days: 14
 
   m85:
+    needs: prime_dev_image
     name: M85/M93/M95 — RR core, required families, and RFC 8212 presence transitions against BIRD 2
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -912,8 +942,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Build bird:2-bookworm
         run: docker build -t bird:2-bookworm -f tests/interop/Dockerfile.bird tests/interop
@@ -944,6 +973,7 @@ jobs:
           script: tests/interop/scripts/test-m95-rfc8212-presence.sh
 
   m94:
+    needs: prime_dev_image
     name: M94 — RFC 6793 AS4 migration against OLD speakers
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -969,8 +999,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Pull pinned ExaBGP 5.0.9 source
         run: docker pull ghcr.io/exa-networks/exabgp@sha256:5554ac053766e66ca3b99eb6b66e83e32113913729a184dcbaf0cc4abd2f4244
@@ -985,6 +1014,7 @@ jobs:
           script: tests/interop/scripts/test-m94-as4-migration-exabgp.sh
 
   m86:
+    needs: prime_dev_image
     name: M86 — RR core reflection + GR truth against OpenBGPD 9.1 clients
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -1010,8 +1040,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Pull openbgpd/openbgpd:9.1
         # Pinned upstream image from the OpenBGPD portable project; its
@@ -1028,6 +1057,7 @@ jobs:
           script: tests/interop/scripts/test-m86-rr-openbgpd.sh
 
   m25:
+    needs: prime_dev_image
     name: M25 — TCP MD5 + GTSM (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1051,8 +1081,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M25 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -1062,6 +1091,7 @@ jobs:
           script: tests/interop/scripts/test-m25-md5-gtsm-frr.sh
 
   m29:
+    needs: prime_dev_image
     name: M29 — EVPN cap negotiation (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1094,8 +1124,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M29 (deploy + test + destroy with retry)
         # The composite always destroys before each attempt, so an
@@ -1107,6 +1136,7 @@ jobs:
           script: tests/interop/scripts/test-m29-evpn-rr-frr.sh
 
   m30:
+    needs: prime_dev_image
     name: M30 — EVPN Type 2 reflection (FRR 10.3.1, kernel VXLAN)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1134,8 +1164,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M30 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -1145,6 +1174,7 @@ jobs:
           script: tests/interop/scripts/test-m30-evpn-type2-frr.sh
 
   m34:
+    needs: prime_dev_image
     name: M34 — SIGHUP policy soft-reset (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1171,8 +1201,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M34 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -1182,6 +1211,7 @@ jobs:
           script: tests/interop/scripts/test-m34-policy-soft-reset-frr.sh
 
   m35:
+    needs: prime_dev_image
     name: M35 — RFC 8326 Graceful Shutdown (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1208,8 +1238,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M35 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -1219,6 +1248,7 @@ jobs:
           script: tests/interop/scripts/test-m35-graceful-shutdown-frr.sh
 
   m35b:
+    needs: prime_dev_image
     name: M35b — RFC 8326 GShut FlowSpec (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1245,8 +1275,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M35b (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -1256,6 +1285,7 @@ jobs:
           script: tests/interop/scripts/test-m35b-graceful-shutdown-flowspec-frr.sh
 
   m35c:
+    needs: prime_dev_image
     name: M35c — RFC 8326 GShut EVPN (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1281,8 +1311,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M35c (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -1292,6 +1321,7 @@ jobs:
           script: tests/interop/scripts/test-m35c-graceful-shutdown-evpn-frr.sh
 
   m41:
+    needs: prime_dev_image
     name: M41 — RFC 7999 BLACKHOLE (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1319,8 +1349,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M41 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -1330,6 +1359,7 @@ jobs:
           script: tests/interop/scripts/test-m41-blackhole-frr.sh
 
   m44:
+    needs: prime_dev_image
     name: M44 — ADR-0064 gRPC tier authorization (mTLS)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1353,8 +1383,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       # The mTLS PKI fixture must exist before deploy so the topology
       # can bind-mount it into the rustbgpd container. Generated here
@@ -1371,6 +1400,7 @@ jobs:
           script: tests/interop/scripts/test-m44-grpc-tier-authz.sh
 
   m54:
+    needs: prime_dev_image
     name: M54 — ADR-0070 gNMI / OpenConfig over mTLS
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1397,8 +1427,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       # The mTLS PKI fixture must exist before deploy so the topology
       # can bind-mount it into the rustbgpd container.
@@ -1413,6 +1442,7 @@ jobs:
           script: tests/interop/scripts/test-m54-gnmi-openconfig.sh
 
   m55:
+    needs: prime_dev_image
     name: M55 — ADR-0071 BGP Roles + OTC (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1437,8 +1467,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M55 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -1448,6 +1477,7 @@ jobs:
           script: tests/interop/scripts/test-m55-bgp-roles-otc-frr.sh
 
   m56:
+    needs: prime_dev_image
     name: M56 — gNMI Subscribe ON_CHANGE (ADR-0070 deferral resolved)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1474,8 +1504,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       # Reuses the M54 mTLS PKI; same operator cert chain.
       - name: Generate M54 mTLS certs
@@ -1489,6 +1518,7 @@ jobs:
           script: tests/interop/scripts/test-m56-gnmi-onchange-frr.sh
 
   m45:
+    needs: prime_dev_image
     name: M45 — EVPN Type 5 injection (gRPC → FRR)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1512,8 +1542,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M45 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -1523,6 +1552,7 @@ jobs:
           script: tests/interop/scripts/test-m45-evpn-type5-injection.sh
 
   m57:
+    needs: prime_dev_image
     name: M57 — Outbound Route Filtering (RFC 5291/5292, FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1549,8 +1579,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M57 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -1560,6 +1589,7 @@ jobs:
           script: tests/interop/scripts/test-m57-orf-frr.sh
 
   m63:
+    needs: prime_dev_image
     name: M63 — ADR-0078 stalled-RIB hold-timer survival (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -1587,8 +1617,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M63 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test
@@ -1598,6 +1627,7 @@ jobs:
           script: tests/interop/scripts/test-m63-stalled-rib-hold-timer.sh
 
   m64:
+    needs: prime_dev_image
     name: M64 — IPv6-only peering via disable_ipv4_unicast (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1625,8 +1655,7 @@ jobs:
           load: true
           tags: rustbgpd:dev
           target: dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=rustbgpd-dev
 
       - name: Run M64 (deploy + test + destroy with retry)
         uses: ./.github/actions/run-interop-test

--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -30,16 +30,40 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Cancel superseded runs of this workflow for the same ref; hosted jobs are
-  # isolated VMs so there is no shared-daemon reason to serialize anymore.
-  group: kernel-dataplane-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
+  # Warm one fixed-scope cache per source SHA; jobs still build and load their
+  # own image, falling back to an uncached build if the cache is unavailable.
+  prime_dev_image:
+    name: Prime rustbgpd:dev build cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: rustbgpd-dev-image-${{ github.sha }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - name: Prime rustbgpd:dev build cache
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          load: false
+          tags: rustbgpd:dev
+          target: dev
+          cache-from: type=gha,scope=rustbgpd-dev
+          cache-to: type=gha,scope=rustbgpd-dev,mode=max,ignore-error=true
+
   m36:
+    needs: prime_dev_image
     name: M36 — EVPN VTEP receive FDB programming (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -55,6 +79,7 @@ jobs:
           script: tests/interop/scripts/test-m36-evpn-vtep-smoke.sh
 
   m37:
+    needs: prime_dev_image
     name: M37 — EVPN local MAC origination (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -70,6 +95,7 @@ jobs:
           script: tests/interop/scripts/test-m37-evpn-local-origination.sh
 
   m37-ip:
+    needs: prime_dev_image
     name: M37+IP — EVPN local MAC/IP origination (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -85,6 +111,7 @@ jobs:
           script: tests/interop/scripts/test-m37-evpn-mac-ip-origination.sh
 
   m38:
+    needs: prime_dev_image
     name: M38 — EVPN DF election + Type 1/4 origination
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -100,6 +127,7 @@ jobs:
           script: tests/interop/scripts/test-m38-evpn-df-election.sh
 
   m39:
+    needs: prime_dev_image
     name: M39 — EVPN Type 5 symmetric Interface-less IRB (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -116,6 +144,7 @@ jobs:
           script: tests/interop/scripts/test-m39-evpn-type5-symmetric-irb.sh
 
   m39b:
+    needs: prime_dev_image
     name: M39b — EVPN auto-derived Route Targets cross-vendor (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -132,6 +161,7 @@ jobs:
           script: tests/interop/scripts/test-m39b-evpn-auto-rt-frr.sh
 
   m48:
+    needs: prime_dev_image
     name: M48 — EVPN runtime tenant teardown over kernel L3 datapath (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -148,6 +178,7 @@ jobs:
           script: tests/interop/scripts/test-m48-evpn-tenant-teardown-datapath.sh
 
   m60:
+    needs: prime_dev_image
     name: M60 — ADR-0079 EVPN adoption sweep kill-and-restart (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -163,6 +194,7 @@ jobs:
           script: tests/interop/scripts/test-m60-evpn-adoption-sweep.sh
 
   m61:
+    needs: prime_dev_image
     name: M61 — ADR-0079 EVPN L3 adoption sweep kill-and-restart (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -179,6 +211,7 @@ jobs:
           script: tests/interop/scripts/test-m61-evpn-l3-adoption-sweep.sh
 
   m62:
+    needs: prime_dev_image
     name: M62 — ADR-0079 blackhole adoption sweep kill-and-restart (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -194,6 +227,7 @@ jobs:
           script: tests/interop/scripts/test-m62-blackhole-adoption-sweep.sh
 
   m40:
+    needs: prime_dev_image
     name: M40 — ADR-0059 aliasing dataplane ECMP (FRR EVPN-MH 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -209,6 +243,7 @@ jobs:
           script: tests/interop/scripts/test-m40-evpn-aliasing-ecmp-frr.sh
 
   m42:
+    needs: prime_dev_image
     name: M42 — ADR-0061 configured-table unicast FIB runtime (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -224,6 +259,7 @@ jobs:
           script: tests/interop/scripts/test-m42-fib-runtime-frr.sh
 
   m50:
+    needs: prime_dev_image
     name: M50 — ADR-0066 unicast multipath/ECMP FIB install (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -239,6 +275,7 @@ jobs:
           script: tests/interop/scripts/test-m50-fib-ecmp-frr.sh
 
   m52:
+    needs: prime_dev_image
     name: M52 — ADR-0066 multipath-relax (FRR 10.3.1, mixed ASes)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -254,6 +291,7 @@ jobs:
           script: tests/interop/scripts/test-m52-fib-ecmp-relax-frr.sh
 
   m58:
+    needs: prime_dev_image
     name: M58 — ADR-0061 FIB-table runtime CRUD (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -269,6 +307,7 @@ jobs:
           script: tests/interop/scripts/test-m58-fib-table-crud-frr.sh
 
   m53:
+    needs: prime_dev_image
     name: M53 — ADR-0069 BGP unnumbered + scoped FIB (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -284,6 +323,7 @@ jobs:
           script: tests/interop/scripts/test-m53-bgp-unnumbered-frr.sh
 
   m51:
+    needs: prime_dev_image
     name: M51 — ADR-0067 single-hop BFD + RFC 5882 coupling (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -299,6 +339,7 @@ jobs:
           script: tests/interop/scripts/test-m51-bfd-frr.sh
 
   m43:
+    needs: prime_dev_image
     name: M43 — TCP-AO live rotation and crash recovery (BIRD 3.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -429,6 +470,7 @@ jobs:
           script: tests/interop/scripts/test-m43-tcp-ao-bird-crash-restart.sh
 
   m46:
+    needs: prime_dev_image
     name: M46 — EVPN HRW DF election (rustbgpd ×2)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -444,6 +486,7 @@ jobs:
           script: tests/interop/scripts/test-m46-evpn-df-hrw.sh
 
   m47:
+    needs: prime_dev_image
     name: M47 — EVPN runtime tenant teardown (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -459,6 +502,7 @@ jobs:
           script: tests/interop/scripts/test-m47-evpn-tenant-teardown.sh
 
   m49:
+    needs: prime_dev_image
     name: M49 — EVPN preference-DF election (rustbgpd ×2)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -474,6 +518,7 @@ jobs:
           script: tests/interop/scripts/test-m49-evpn-preference-df.sh
 
   m69:
+    needs: prime_dev_image
     name: M69 — EVPN preference-DF election (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -489,6 +534,7 @@ jobs:
           script: tests/interop/scripts/test-m69-evpn-preference-df-frr.sh
 
   m70:
+    needs: prime_dev_image
     name: M70 — ADR-0089 VLAN-aware bridge FDB attribution (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -508,6 +554,7 @@ jobs:
           script: tests/interop/scripts/test-m70-evpn-vlan-aware-bridge-frr.sh
 
   m65:
+    needs: prime_dev_image
     name: M65 — ADR-0083 single-active failover blackout measurement (GoBGP 3.x)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -529,6 +576,7 @@ jobs:
           script: tests/interop/scripts/test-m65-evpn-single-active-failover.sh
 
   m71:
+    needs: prime_dev_image
     name: M71 — RFC 9136 §4.3 ESI overlay-index Type 5 single-active receive (GoBGP 3.x)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -552,6 +600,7 @@ jobs:
           script: tests/interop/scripts/test-m71-evpn-esi-overlay-type5-receive-gobgp.sh
 
   m72:
+    needs: prime_dev_image
     name: M72 — RFC 9136 §4.3 ESI overlay-index Type 5 all-active receive (GoBGP 3.x)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -574,6 +623,7 @@ jobs:
           script: tests/interop/scripts/test-m72-evpn-esi-overlay-type5-all-active-gobgp.sh
 
   m66:
+    needs: prime_dev_image
     name: M66 — ADR-0084 ES drain service handover (rustbgpd ×3)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -592,6 +642,7 @@ jobs:
           script: tests/interop/scripts/test-m66-evpn-es-drain-handover.sh
 
   m67:
+    needs: prime_dev_image
     name: M67 — ADR-0085 link-driven ES drain failover (rustbgpd ×3)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -612,6 +663,7 @@ jobs:
           script: tests/interop/scripts/test-m67-evpn-link-drain-failover.sh
 
   m68:
+    needs: prime_dev_image
     name: M68 — ADR-0087 GW-IP overlay-index Type 5 (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Fail closed when the shared CI image-primer contract drifts."""
+
+from __future__ import annotations
+
+import collections
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+INTEROP = (
+    "m1 m13 m80 m15 m10 m14 m17 m73 m74 m75 m76 m77 m78 m79 m22 "
+    "m24 m81 m82 m83 m85 m94 m86 m25 m29 m30 m34 m35 m35b m35c m41 "
+    "m44 m54 m55 m56 m45 m57 m63 m64"
+).split()
+KERNEL = (
+    "m36 m37 m37-ip m38 m39 m39b m48 m60 m61 m62 m40 m42 m50 m52 "
+    "m58 m53 m51 m43 m46 m47 m49 m69 m70 m65 m71 m72 m66 m67 m68"
+).split()
+WORKFLOWS = ("ci.yml", "audit.yml", "interop.yml", "kernel-dataplane.yml")
+GROUP = "group: ${{ github.workflow }}-${{ github.ref }}"
+PRIMER_GROUP = "group: rustbgpd-dev-image-${{ github.sha }}"
+IMPORT = "cache-from: type=gha,scope=rustbgpd-dev"
+EXPORT = "cache-to: type=gha,scope=rustbgpd-dev,mode=max,ignore-error=true"
+CHECKOUT = "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7"
+BUILDX = (
+    "uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4"
+)
+BUILD_PUSH = (
+    "uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7"
+)
+
+TRIGGER_HASHES = {
+    "ci.yml": "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8",
+    "audit.yml": "1829597143324f5361dfdfece50ddeffd6f7d5934b72198f1837fbdf25339fd3",
+    "interop.yml": "5a02c2699d26443c537ba1560fd1b16c595498e9148b2f99be975ae79b3b9492",
+    "kernel-dataplane.yml": "6a5d9f010df1a4b97bed98beb1e27a7284bdcf3c19befe71263a15a186c73b86",
+}
+PERMISSION_HASHES = {
+    "ci.yml": "ef1c6c32bd7afe22841015d36a48ee18816a0a8eb0e9a1a0af951ce1ff7cd183",
+    "audit.yml": "6f1d70d72bad231d43c575acef6946580e439c879794ed2ea1f4a40340245172",
+    "interop.yml": "6f1d70d72bad231d43c575acef6946580e439c879794ed2ea1f4a40340245172",
+    "kernel-dataplane.yml": "6f1d70d72bad231d43c575acef6946580e439c879794ed2ea1f4a40340245172",
+}
+CALL_HASHES = {
+    "interop.yml": "079176e73f3ca4a329613132ca3863f27400b162091b2d4802e97931001db135",
+    "kernel-dataplane.yml": "decf4a7ba46c4a89f420de248790ef1badbfaba81371ae7c291ad9c9943add03",
+}
+PINS = collections.Counter(
+    {
+        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7": 75,
+        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 1,
+        "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2": 3,
+        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 2,
+        "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4": 42,
+        "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7": 43,
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7": 1,
+        "rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0": 1,
+        "EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1": 1,
+    }
+)
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def _top_block(text: str, key: str) -> str:
+    match = re.search(rf"(?ms)^{re.escape(key)}:\n.*?(?=^[A-Za-z][\w-]*:|\Z)", text)
+    return match.group(0).rstrip() if match else ""
+
+
+def _jobs(text: str) -> dict[str, str]:
+    body = text.split("\njobs:\n", 1)[1] if "\njobs:\n" in text else ""
+    matches = list(re.finditer(r"(?m)^  ([\w-]+):\n", body))
+    return {
+        m.group(1): body[
+            m.end() : matches[i + 1].start() if i + 1 < len(matches) else len(body)
+        ]
+        for i, m in enumerate(matches)
+    }
+
+
+def check(root: Path) -> list[str]:
+    errors: list[str] = []
+    workflow_dir = root / ".github" / "workflows"
+    texts = {name: (workflow_dir / name).read_text() for name in WORKFLOWS}
+    for name, text in texts.items():
+        if GROUP not in _top_block(
+            text, "concurrency"
+        ) or "cancel-in-progress: true" not in _top_block(text, "concurrency"):
+            errors.append(f"{name}: workflow cancellation contract drifted")
+        if _hash(_top_block(text, "on")) != TRIGGER_HASHES[name]:
+            errors.append(f"{name}: triggers drifted")
+        permissions = "\n".join(
+            re.findall(r"(?ms)^permissions:\n.*?(?=^[A-Za-z][\w-]*:|\Z)", text)
+        )
+        if _hash(permissions) != PERMISSION_HASHES[name]:
+            errors.append(f"{name}: permissions drifted")
+
+    for name, roster, setup in (
+        ("interop.yml", INTEROP, False),
+        ("kernel-dataplane.yml", KERNEL, True),
+    ):
+        jobs = _jobs(texts[name])
+        expected = ["prime_dev_image", *roster] + (["netns"] if setup else [])
+        if list(jobs) != expected:
+            errors.append(f"{name}: exact job roster/order drifted")
+        primer = jobs.get("prime_dev_image", "")
+        for seam in (
+            "timeout-minutes: 30",
+            PRIMER_GROUP,
+            "cancel-in-progress: false",
+            CHECKOUT,
+            "ref: ${{ github.sha }}",
+            BUILDX,
+            BUILD_PUSH,
+            "context: .",
+            "load: false",
+            "tags: rustbgpd:dev",
+            "target: dev",
+            IMPORT,
+            EXPORT,
+        ):
+            if seam not in primer:
+                errors.append(f"{name}: primer missing {seam}")
+        if "load: true" in primer:
+            errors.append(f"{name}: primer must export cache, not load an image")
+        for job_name in roster:
+            job = jobs.get(job_name, "")
+            if "needs: prime_dev_image" not in job:
+                errors.append(f"{name}:{job_name}: missing primer dependency")
+            if CHECKOUT not in job:
+                errors.append(f"{name}:{job_name}: pinned checkout drifted")
+            if setup:
+                if "uses: ./.github/actions/setup-dataplane-host" not in job:
+                    errors.append(f"{name}:{job_name}: setup call drifted")
+            else:
+                for seam in (IMPORT, "load: true", "tags: rustbgpd:dev", "target: dev"):
+                    if seam not in job:
+                        errors.append(f"{name}:{job_name}: consumer missing {seam}")
+                if "cache-to:" in job:
+                    errors.append(f"{name}:{job_name}: consumer exports a cache")
+        calls = "\n".join(
+            line.strip()
+            for line in texts[name].splitlines()
+            if re.search(
+                r"(setup-dataplane-host|run-interop-test|label:|topology:|script:)",
+                line,
+            )
+        )
+        if _hash(calls) != CALL_HASHES[name]:
+            errors.append(f"{name}: existing test/setup calls drifted")
+    kernel_jobs = _jobs(texts["kernel-dataplane.yml"])
+    if "needs: prime_dev_image" in kernel_jobs.get("netns", ""):
+        errors.append("kernel-dataplane.yml:netns must remain independent")
+
+    action = (
+        root / ".github" / "actions" / "setup-dataplane-host" / "action.yml"
+    ).read_text()
+    build = action.split("- name: Build rustbgpd:dev", 1)[-1]
+    if BUILDX not in action:
+        errors.append(f"setup-dataplane-host: consumer missing {BUILDX}")
+    for seam in (
+        BUILD_PUSH,
+        "context: .",
+        IMPORT,
+        "load: true",
+        "tags: rustbgpd:dev",
+        "target: dev",
+    ):
+        if seam not in build:
+            errors.append(f"setup-dataplane-host: consumer missing {seam}")
+    if "cache-to:" in build:
+        errors.append("setup-dataplane-host: consumer must not export cache")
+
+    pins = collections.Counter()
+    for text in [*texts.values(), action]:
+        for value in re.findall(r"^\s*(?:- )?uses:\s*(.+)$", text, re.MULTILINE):
+            if not value.strip().startswith("./"):
+                pins[value.strip()] += 1
+    if pins != PINS:
+        errors.append("external action pins/counts drifted")
+
+    dockerfile = (root / "Dockerfile").read_text()
+    builder = dockerfile.split("FROM chef AS builder\n", 1)[-1].split("\nFROM ", 1)[0]
+    dev = dockerfile.split("FROM debian:bookworm-slim AS dev\n", 1)[-1].split(
+        "\nFROM ", 1
+    )[0]
+    binaries = ("rustbgpd", "rbgp", "evpn-tester", "evpn-monitor")
+    for binary in binaries:
+        if f"cp target/ci/{binary} /out/" not in builder:
+            errors.append(
+                f"Dockerfile: builder does not bridge target/ci/{binary} to /out"
+            )
+        if f"COPY --from=builder /out/{binary} /usr/local/bin/{binary}" not in dev:
+            errors.append(f"Dockerfile: dev does not copy builder /out/{binary}")
+    return errors
+
+
+if __name__ == "__main__":
+    failures = check(Path(__file__).resolve().parents[1])
+    if failures:
+        print("CI image-primer contract check failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        raise SystemExit(1)
+    print("CI image-primer contract OK")

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.check_ci_image_primer_contract import check
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class PrimerContractTests(unittest.TestCase):
+    def mutate(self, relative, old, new="", occurrence=0):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            for fixture in (
+                ".github/workflows",
+                ".github/actions/setup-dataplane-host",
+            ):
+                source = ROOT / fixture
+                target = root / fixture
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(source, target)
+            shutil.copy2(ROOT / "Dockerfile", root / "Dockerfile")
+            path = root / relative
+            text = path.read_text()
+            start = 0
+            for _ in range(occurrence + 1):
+                index = text.find(old, start)
+                self.assertNotEqual(
+                    -1, index, f"missing occurrence {occurrence}: {old}"
+                )
+                start = index + len(old)
+            path.write_text(text[:index] + new + text[index + len(old) :])
+            self.assertTrue(check(root), f"mutation stayed green: {relative}: {old}")
+
+    def test_live_contract(self):
+        self.assertEqual([], check(ROOT))
+
+    def test_destructive_workflow_seams(self):
+        cases = (
+            (
+                ".github/workflows/ci.yml",
+                "cancel-in-progress: true",
+                "cancel-in-progress: false",
+            ),
+            (
+                ".github/workflows/ci.yml",
+                "group: ${{ github.workflow }}-${{ github.ref }}",
+                "group: shared",
+            ),
+            (
+                ".github/workflows/audit.yml",
+                "workflow_dispatch: {}",
+                "workflow_dispatch:\n    inputs: {}",
+            ),
+            (
+                ".github/workflows/audit.yml",
+                "permissions:\n  contents: read",
+                "permissions:\n  contents: write",
+            ),
+            (
+                ".github/workflows/interop.yml",
+                "  prime_dev_image:\n",
+                "  renamed_primer:\n",
+            ),
+            (".github/workflows/interop.yml", "  m1:\n", "  removed_m1:\n"),
+            (".github/workflows/interop.yml", "ref: ${{ github.sha }}", "ref: main"),
+            (
+                ".github/workflows/interop.yml",
+                "group: rustbgpd-dev-image-${{ github.sha }}",
+                "group: rustbgpd-dev-image-main",
+            ),
+            (
+                ".github/workflows/interop.yml",
+                "cancel-in-progress: false",
+                "cancel-in-progress: true",
+            ),
+            (".github/workflows/interop.yml", "needs: prime_dev_image", "needs: []"),
+            (
+                ".github/workflows/interop.yml",
+                "cache-from: type=gha,scope=rustbgpd-dev",
+                "cache-from: type=gha",
+            ),
+            (
+                ".github/workflows/interop.yml",
+                "cache-to: type=gha,scope=rustbgpd-dev,mode=max,ignore-error=true",
+                "cache-to: type=gha",
+            ),
+            (".github/workflows/interop.yml", "load: true", "load: false"),
+            (
+                ".github/workflows/interop.yml",
+                "          load: true\n",
+                "          load: true\n          cache-to: type=gha\n",
+            ),
+            (
+                ".github/workflows/interop.yml",
+                "uses: ./.github/actions/run-interop-test",
+                "uses: ./.github/actions/install-containerlab",
+            ),
+            (
+                ".github/workflows/kernel-dataplane.yml",
+                "uses: ./.github/actions/setup-dataplane-host",
+                "uses: ./.github/actions/install-containerlab",
+            ),
+            (
+                ".github/workflows/kernel-dataplane.yml",
+                "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+                "actions/checkout@main",
+            ),
+            (
+                ".github/workflows/kernel-dataplane.yml",
+                "  netns:\n",
+                "  removed-netns:\n",
+            ),
+            (
+                ".github/workflows/kernel-dataplane.yml",
+                "  netns:\n",
+                "  netns:\n    needs: prime_dev_image\n",
+            ),
+        )
+        for relative, old, new in cases:
+            with self.subTest(old=old):
+                self.mutate(relative, old, new)
+
+    def test_both_primers_and_real_consumer_fail_independently(self):
+        for workflow in ("interop.yml", "kernel-dataplane.yml"):
+            relative = f".github/workflows/{workflow}"
+            for old, new in (
+                ("  prime_dev_image:\n", "  removed_primer:\n"),
+                ("timeout-minutes: 30", "timeout-minutes: 29"),
+                ("ref: ${{ github.sha }}", "ref: main"),
+                (
+                    "group: rustbgpd-dev-image-${{ github.sha }}",
+                    "group: rustbgpd-dev-image-main",
+                ),
+                ("cancel-in-progress: false", "cancel-in-progress: true"),
+                ("load: false", "load: true"),
+                ("context: .", "context: elsewhere"),
+                ("tags: rustbgpd:dev", "tags: other:dev"),
+                ("target: dev", "target: release"),
+                ("cache-from: type=gha,scope=rustbgpd-dev", "cache-from: type=gha"),
+                (
+                    "cache-to: type=gha,scope=rustbgpd-dev,mode=max,ignore-error=true",
+                    "cache-to: type=gha",
+                ),
+                (
+                    "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+                    "actions/checkout@main",
+                ),
+                (
+                    "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c",
+                    "docker/setup-buildx-action@main",
+                ),
+                (
+                    "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a",
+                    "docker/build-push-action@main",
+                ),
+            ):
+                with self.subTest(workflow=workflow, seam=old):
+                    self.mutate(relative, old, new)
+
+        for workflow in ("ci.yml", "audit.yml", "interop.yml", "kernel-dataplane.yml"):
+            relative = f".github/workflows/{workflow}"
+            with self.subTest(workflow=workflow, seam="group"):
+                self.mutate(
+                    relative,
+                    "group: ${{ github.workflow }}-${{ github.ref }}",
+                    "group: shared",
+                )
+            with self.subTest(workflow=workflow, seam="cancel"):
+                self.mutate(
+                    relative, "cancel-in-progress: true", "cancel-in-progress: false"
+                )
+
+        interop = ".github/workflows/interop.yml"
+        with self.subTest(workflow=interop, seam="consumer import"):
+            self.mutate(
+                interop,
+                "cache-from: type=gha,scope=rustbgpd-dev",
+                "cache-from: type=gha",
+                occurrence=1,
+            )
+        with self.subTest(workflow=interop, seam="consumer export"):
+            self.mutate(
+                interop,
+                "          load: true\n",
+                "          load: true\n          cache-to: type=gha\n",
+            )
+        with self.subTest(workflow=interop, seam="consumer checkout"):
+            self.mutate(
+                interop,
+                "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+                "actions/checkout@main",
+                occurrence=1,
+            )
+
+        kernel = ".github/workflows/kernel-dataplane.yml"
+        with self.subTest(workflow=kernel, seam="consumer checkout"):
+            self.mutate(
+                kernel,
+                "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+                "actions/checkout@main",
+                occurrence=1,
+            )
+        with self.subTest(workflow=kernel, seam="consumer needs"):
+            self.mutate(kernel, "needs: prime_dev_image", "needs: []")
+
+    def test_destructive_consumer_action_seams(self):
+        relative = ".github/actions/setup-dataplane-host/action.yml"
+        for old, new in (
+            ("cache-from: type=gha,scope=rustbgpd-dev", "cache-from: type=gha"),
+            ("load: true", "load: false"),
+            ("tags: rustbgpd:dev", "tags: other:dev"),
+            ("target: dev", "target: release"),
+            ("context: .", "context: elsewhere"),
+            (
+                "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c",
+                "docker/setup-buildx-action@main",
+            ),
+            (
+                "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a",
+                "docker/build-push-action@main",
+            ),
+            (
+                "cache-from: type=gha,scope=rustbgpd-dev",
+                "cache-from: type=gha,scope=rustbgpd-dev\n        cache-to: type=gha",
+            ),
+        ):
+            with self.subTest(old=old):
+                self.mutate(relative, old, new)
+
+    def test_dockerfile_exact_source_bridge(self):
+        for binary in ("rustbgpd", "rbgp", "evpn-tester", "evpn-monitor"):
+            with self.subTest(binary=binary, side="builder"):
+                self.mutate(
+                    "Dockerfile", f"cp target/ci/{binary} /out/", "true # removed"
+                )
+            with self.subTest(binary=binary, side="dev"):
+                self.mutate(
+                    "Dockerfile",
+                    f"COPY --from=builder /out/{binary} /usr/local/bin/{binary}",
+                    "# removed",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- serialize one exact-SHA `rustbgpd:dev` cache primer across Interop and Kernel Dataplane
- make all 67 image consumers read-only cache users while preserving their exact test rosters
- cancel superseded runs by workflow and ref, including stale rapid main runs
- add a fail-closed structural gate with destructive mutation proofs

## Safety

- primers are pinned, exact-SHA, no-load, and bounded to 30 minutes
- cache export remains an optimization; consumers rebuild from source on a miss
- triggers, permissions, existing timeouts, action pins, Interop jobs, Kernel jobs, and the independent `netns` job are unchanged
- the gate proves the Docker builder copies all four binaries out of cache mounts before the dev image consumes them

## Hosted receipt

Control is PR #1353 at `8449c256`, the immediate base with the same product source and the pre-change workflows.

| Shape | Interop | Kernel | Combined runner-minutes |
| --- | ---: | ---: | ---: |
| Control | 371.93 min / 13m45 wall | 68.32 min / 17m04 wall | 440.25 |
| Candidate, cold scope | 53.32 min / 13m44 wall | 44.85 min / 13m39 wall | 98.17 |
| Candidate, same-head warm | 46.17 min / 4m34 wall | 47.38 min / 7m42 wall | 93.55 |

The cold candidate removes 342.08 runner-minutes, a 77.7% reduction. Across CI, Security audit, Interop, and Kernel, consumption fell from about 472.0 to 129.55 runner-minutes, a 72.6% reduction.

The cold Interop primer compiled once in 9m44; the serialized Kernel primer then hit the same cache in 22 seconds. All 38 Interop consumer image builds completed in 5–17 seconds, 7 seconds median, with the final builder stage reported `CACHED`. On the warm control, primers completed in 26 and 20 seconds and the 38 consumer builds remained 5–20 seconds, 8 seconds median.

Stable-head readiness stayed 24m36 because `CI / check` remains serial. That is expected: this tranche removes duplicate runner work and queue pressure. Splitting its measured 9m24 scale block is the next tranche.

## Validation

- every current-head CI, Security audit, Interop, and Kernel Dataplane check passed
- cold-scope attempt and same-head warm rerun both passed all 38 Interop and 30 Kernel jobs
- `python3 -m unittest -v scripts/test_check_ci_image_primer_contract.py`
- `python3 scripts/check_ci_image_primer_contract.py`
- `bash .github/scripts/install-grpcurl.sh --self-test`
- Ruby YAML parse for all changed workflows and the composite action
- `python3 -m py_compile scripts/check_ci_image_primer_contract.py scripts/test_check_ci_image_primer_contract.py`
- `git diff --check`
- commit and push hooks: fmt, clippy, doc green
- Copilot reviewed all 7 files at the current head and posted no findings

Product docs and CHANGELOG are N/A because daemon and operator behavior do not change.