### PR TITLE
ci: parallelize scale and receipt checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,13 @@ on:
       - "**/*.md"
 
 jobs:
-  check:
+  core:
     runs-on: ubuntu-latest
     # Bound any wedge (e.g. a rustdoc hang) so a stuck step fails fast
-    # instead of running to GitHub's 6-hour default. Recent green runs
-    # now reach the mid-30-minute range; the previous 30-minute bound sat
-    # inside normal hosted-runner variance and cancelled two healthy runs
-    # mid `cargo test --workspace`. Keep the 45-minute ceiling above that
-    # observed green range.
+    # instead of running to GitHub's 6-hour default. The last serial run
+    # took 24m32; extracting the 9m10 scale/receipt block should leave this
+    # lane near 15 minutes. Keep the inherited 45-minute ceiling until
+    # hosted receipts establish a safe tighter bound.
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -70,6 +69,10 @@ jobs:
         run: |
           python3 -m unittest -v scripts/test_check_ci_image_primer_contract.py
           python3 scripts/check_ci_image_primer_contract.py
+      - name: Prove CI scale split contract
+        run: |
+          python3 -m unittest -v scripts/test_check_ci_scale_split_contract.py
+          python3 scripts/check_ci_scale_split_contract.py
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable
@@ -148,81 +151,6 @@ jobs:
       # deny(unsafe_code) lint posture — it is only armed when neither
       # allocator feature is on, so the default build no longer checks it.
       - run: cargo check -p rustbgpd --no-default-features --all-targets
-      - name: Check standalone scale harnesses and receipt classifiers
-        run: |
-          set -euo pipefail
-          cargo fmt --manifest-path bench/scale/rrharness/Cargo.toml -- --check
-          cargo fmt --manifest-path bench/scale/rrtransport/Cargo.toml -- --check
-          cargo fmt --manifest-path bench/scale/reloadstall/Cargo.toml -- --check
-          cargo fmt --manifest-path bench/scale/outbound-prefix-limits/Cargo.toml -- --check
-          cargo fmt --manifest-path bench/scale/config-persistence/Cargo.toml -- --check
-          cargo fmt --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml -- --check
-          cargo fmt --manifest-path bench/scale/outbound-prefix-limit-scale/Cargo.toml -- --check
-          cargo test --manifest-path bench/scale/rrharness/Cargo.toml --locked
-          cargo test --manifest-path bench/scale/rrtransport/Cargo.toml --locked
-          cargo test --manifest-path bench/scale/reloadstall/Cargo.toml --locked
-          cargo test --manifest-path bench/scale/outbound-prefix-limits/Cargo.toml --locked
-          cargo test --manifest-path bench/scale/config-persistence/Cargo.toml --locked
-          cargo test --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml --locked
-          cargo test --manifest-path bench/scale/outbound-prefix-limit-scale/Cargo.toml --locked
-          cargo clippy --manifest-path bench/scale/outbound-prefix-limits/Cargo.toml \
-            --locked --all-targets -- -D warnings
-          cargo clippy --manifest-path bench/scale/rrtransport/Cargo.toml \
-            --locked --all-targets -- -D warnings
-          cargo run --manifest-path bench/scale/rrtransport/Cargo.toml --locked -- smoke
-          rrtransport_receipt=$(mktemp -d)
-          bench/scale/rrtransport/run-receipt.sh --real-smoke "$rrtransport_receipt"
-          bash bench/tests/test-rrtransport-receipt.sh
-          cargo clippy --manifest-path bench/scale/config-persistence/Cargo.toml \
-            --locked --all-targets -- -D warnings
-          cargo clippy --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml \
-            --locked --all-targets -- -D warnings
-          cargo clippy --manifest-path bench/scale/outbound-prefix-limit-scale/Cargo.toml \
-            --locked --all-targets -- -D warnings
-          # The IRR manifest contract exercises the production rustbgpd
-          # renderer, so make that prerequisite explicit on a clean runner.
-          cargo build -p rs-config-render
-          cargo test --test reloadstall_scenario_emitted_check
-          bash -n bench/compare-criterion.sh
-          shellcheck bench/smoke-benches.sh
-          bash -n bench/scale/route-server-1000/run-receipt.sh
-          bash -n bench/scale/outbound-prefix-limits/run-receipt.sh
-          bash -n bench/scale/config-persistence/run-receipt.sh
-          bash -n bench/scale/enhanced-route-refresh/run-receipt.sh
-          bash -n bench/scale/outbound-prefix-limit-scale/run-receipt.sh
-          bash -n bench/scale/rrtransport/run-receipt.sh
-          bash -n bench/tests/test-rrtransport-receipt.sh
-          bash -n bench/tests/test-route-server-1000-receipt.sh
-          bash -n bench/tests/test-vpn-query-receipt.sh
-          bash -n bench/tests/test-vpn-query-campaign.sh
-          bash -n bench/run-vpn-query-campaign.sh
-          shellcheck bench/scale/route-server-1000/run-receipt.sh \
-            bench/scale/outbound-prefix-limits/run-receipt.sh \
-            bench/scale/config-persistence/run-receipt.sh \
-            bench/scale/enhanced-route-refresh/run-receipt.sh \
-            bench/scale/outbound-prefix-limit-scale/run-receipt.sh \
-            bench/scale/rrtransport/run-receipt.sh \
-            bench/tests/test-rrtransport-receipt.sh \
-            bench/tests/test-route-server-1000-receipt.sh
-          shellcheck bench/tests/test-vpn-query-receipt.sh
-          shellcheck bench/tests/test-vpn-query-campaign.sh \
-            bench/run-vpn-query-campaign.sh
-          bash bench/tests/test-route-server-1000-receipt.sh
-          bash bench/tests/test-vpn-query-receipt.sh
-          bash bench/tests/test-vpn-query-campaign.sh
-          bash -n bench/scale/compare-rrharness.sh
-          bash bench/tests/test-rrharness-driver.sh
-          python3 -m unittest discover \
-            -s bench/scale/enhanced-route-refresh -p 'test_*.py'
-          python3 -m unittest -v tests/soak/test_intern_churn_analyzers.py
-          python3 bench/scale/rebaseline/test_classifiers.py
-          python3 bench/scale/rebaseline/test_parse_rrharness.py
-          python3 bench/scale/rebaseline/test_validate_lan395_criterion.py
-          python3 bench/tests/test_verify_mrt_growth_campaign.py
-          (
-            cd docs/perf/artifacts/enhanced-route-refresh-2026-07
-            sha256sum -c SHA256SUMS
-          )
       - name: Verify committed RIB rebaseline receipt
         run: |
           set -euo pipefail
@@ -329,6 +257,116 @@ jobs:
               exit 1
             fi
             echo "wire bump + README touched — gate passed"
+          fi
+
+  scale_receipts:
+    name: scale / receipt checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+      - uses: ./.github/actions/install-protobuf
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Install receipt-tool dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
+      - name: Check standalone scale harnesses and receipt classifiers
+        run: |
+          set -euo pipefail
+          cargo fmt --manifest-path bench/scale/rrharness/Cargo.toml -- --check
+          cargo fmt --manifest-path bench/scale/rrtransport/Cargo.toml -- --check
+          cargo fmt --manifest-path bench/scale/reloadstall/Cargo.toml -- --check
+          cargo fmt --manifest-path bench/scale/outbound-prefix-limits/Cargo.toml -- --check
+          cargo fmt --manifest-path bench/scale/config-persistence/Cargo.toml -- --check
+          cargo fmt --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml -- --check
+          cargo fmt --manifest-path bench/scale/outbound-prefix-limit-scale/Cargo.toml -- --check
+          cargo test --manifest-path bench/scale/rrharness/Cargo.toml --locked
+          cargo test --manifest-path bench/scale/rrtransport/Cargo.toml --locked
+          cargo test --manifest-path bench/scale/reloadstall/Cargo.toml --locked
+          cargo test --manifest-path bench/scale/outbound-prefix-limits/Cargo.toml --locked
+          cargo test --manifest-path bench/scale/config-persistence/Cargo.toml --locked
+          cargo test --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml --locked
+          cargo test --manifest-path bench/scale/outbound-prefix-limit-scale/Cargo.toml --locked
+          cargo clippy --manifest-path bench/scale/outbound-prefix-limits/Cargo.toml \
+            --locked --all-targets -- -D warnings
+          cargo clippy --manifest-path bench/scale/rrtransport/Cargo.toml \
+            --locked --all-targets -- -D warnings
+          cargo run --manifest-path bench/scale/rrtransport/Cargo.toml --locked -- smoke
+          rrtransport_receipt=$(mktemp -d)
+          bench/scale/rrtransport/run-receipt.sh --real-smoke "$rrtransport_receipt"
+          bash bench/tests/test-rrtransport-receipt.sh
+          cargo clippy --manifest-path bench/scale/config-persistence/Cargo.toml \
+            --locked --all-targets -- -D warnings
+          cargo clippy --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml \
+            --locked --all-targets -- -D warnings
+          cargo clippy --manifest-path bench/scale/outbound-prefix-limit-scale/Cargo.toml \
+            --locked --all-targets -- -D warnings
+          # The IRR manifest contract exercises the production rustbgpd
+          # renderer, so make that prerequisite explicit on a clean runner.
+          cargo build -p rs-config-render
+          cargo test --test reloadstall_scenario_emitted_check
+          bash -n bench/compare-criterion.sh
+          shellcheck bench/smoke-benches.sh
+          bash -n bench/scale/route-server-1000/run-receipt.sh
+          bash -n bench/scale/outbound-prefix-limits/run-receipt.sh
+          bash -n bench/scale/config-persistence/run-receipt.sh
+          bash -n bench/scale/enhanced-route-refresh/run-receipt.sh
+          bash -n bench/scale/outbound-prefix-limit-scale/run-receipt.sh
+          bash -n bench/scale/rrtransport/run-receipt.sh
+          bash -n bench/tests/test-rrtransport-receipt.sh
+          bash -n bench/tests/test-route-server-1000-receipt.sh
+          bash -n bench/tests/test-vpn-query-receipt.sh
+          bash -n bench/tests/test-vpn-query-campaign.sh
+          bash -n bench/run-vpn-query-campaign.sh
+          shellcheck bench/scale/route-server-1000/run-receipt.sh \
+            bench/scale/outbound-prefix-limits/run-receipt.sh \
+            bench/scale/config-persistence/run-receipt.sh \
+            bench/scale/enhanced-route-refresh/run-receipt.sh \
+            bench/scale/outbound-prefix-limit-scale/run-receipt.sh \
+            bench/scale/rrtransport/run-receipt.sh \
+            bench/tests/test-rrtransport-receipt.sh \
+            bench/tests/test-route-server-1000-receipt.sh
+          shellcheck bench/tests/test-vpn-query-receipt.sh
+          shellcheck bench/tests/test-vpn-query-campaign.sh \
+            bench/run-vpn-query-campaign.sh
+          bash bench/tests/test-route-server-1000-receipt.sh
+          bash bench/tests/test-vpn-query-receipt.sh
+          bash bench/tests/test-vpn-query-campaign.sh
+          bash -n bench/scale/compare-rrharness.sh
+          bash bench/tests/test-rrharness-driver.sh
+          python3 -m unittest discover \
+            -s bench/scale/enhanced-route-refresh -p 'test_*.py'
+          python3 -m unittest -v tests/soak/test_intern_churn_analyzers.py
+          python3 bench/scale/rebaseline/test_classifiers.py
+          python3 bench/scale/rebaseline/test_parse_rrharness.py
+          python3 bench/scale/rebaseline/test_validate_lan395_criterion.py
+          python3 bench/tests/test_verify_mrt_growth_campaign.py
+          (
+            cd docs/perf/artifacts/enhanced-route-refresh-2026-07
+            sha256sum -c SHA256SUMS
+          )
+  check:
+    name: check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ always() }}
+    needs: [core, scale_receipts]
+    env:
+      CORE_RESULT: ${{ needs.core.result }}
+      SCALE_RECEIPTS_RESULT: ${{ needs.scale_receipts.result }}
+    steps:
+      - name: Aggregate required CI result
+        run: |
+          set -euo pipefail
+          printf 'core=%s\n' "$CORE_RESULT"
+          printf 'scale_receipts=%s\n' "$SCALE_RECEIPTS_RESULT"
+          if [[ "$CORE_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]; then
+            exit 1
           fi
 
   msrv:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # test-rrharness-driver resolves a retained pin commit and creates a
+          # detached worktree at that exact revision.
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -49,9 +49,9 @@ CALL_HASHES = {
 }
 PINS = collections.Counter(
     {
-        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7": 75,
-        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 1,
-        "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2": 3,
+        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7": 76,
+        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 2,
+        "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2": 4,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 2,
         "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4": 42,
         "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7": 43,

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -14,7 +14,7 @@ TRIGGER_HASH = "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8
 PERMISSION_HASH = "9691400b3b1036bcdfe724926816dbe71b0aa22ed9b5eb89627e2eeb75079898"
 JOB_HASHES = {
     "core": "81bea34b590cff22f28e437e20dd15ba200d1bfb2424b9158ecdc1c61ac4b2e9",
-    "scale_receipts": "003631994e4a9d995e580ca5b974ef4316d1e020ff66fb954133a6b6cfc339c7",
+    "scale_receipts": "0d6914750718aa18049269ed71ca4de5d85f75ce931701d6af305fb6c2d9844c",
     "check": "afc9629a32cc7c3194ccf0417aaf2623e7a01a8dc95fd0194c2cbfbb29068b57",
     "msrv": "db1ae833d9c8fbbc47dbf2969ac291b90cf413ba9eed2b95dd4cfe34e0a4ba5d",
     "evpn_bum_filter_kernel": "f965e7f95f30772d9d335104dda9e30c53816098bd5f1225a3cadabe7d9a23b3",
@@ -96,6 +96,7 @@ def check(root: Path) -> list[str]:
         "runs-on: ubuntu-latest",
         "timeout-minutes: 30",
         CHECKOUT,
+        "fetch-depth: 0",
         TOOLCHAIN,
         "toolchain: stable",
         "components: rustfmt, clippy",

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Fail closed when the CI scale/receipt split contract drifts."""
+
+from __future__ import annotations
+
+import collections
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+ROSTER = ["core", "scale_receipts", "check", "msrv", "evpn_bum_filter_kernel"]
+TRIGGER_HASH = "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8"
+PERMISSION_HASH = "9691400b3b1036bcdfe724926816dbe71b0aa22ed9b5eb89627e2eeb75079898"
+JOB_HASHES = {
+    "core": "81bea34b590cff22f28e437e20dd15ba200d1bfb2424b9158ecdc1c61ac4b2e9",
+    "scale_receipts": "003631994e4a9d995e580ca5b974ef4316d1e020ff66fb954133a6b6cfc339c7",
+    "check": "afc9629a32cc7c3194ccf0417aaf2623e7a01a8dc95fd0194c2cbfbb29068b57",
+    "msrv": "db1ae833d9c8fbbc47dbf2969ac291b90cf413ba9eed2b95dd4cfe34e0a4ba5d",
+    "evpn_bum_filter_kernel": "f965e7f95f30772d9d335104dda9e30c53816098bd5f1225a3cadabe7d9a23b3",
+}
+COMMAND_BODY_HASH = "7135e8d910c9a804be659a92ef36d6dfb359668e168990e1d1062744a5609048"
+STEP_NAME = "Check standalone scale harnesses and receipt classifiers"
+CHECKOUT = "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7"
+TOOLCHAIN = (
+    "uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable"
+)
+RUST_CACHE = "uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2"
+PINS = collections.Counter(
+    {
+        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7": 4,
+        "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2": 3,
+        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 2,
+        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 1,
+        "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4": 1,
+        "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7": 1,
+    }
+)
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def _top_block(text: str, key: str) -> str:
+    match = re.search(rf"(?ms)^{re.escape(key)}:\n.*?(?=^[A-Za-z][\w-]*:|\Z)", text)
+    return match.group(0).rstrip() if match else ""
+
+
+def _jobs(text: str) -> dict[str, str]:
+    body = text.split("\njobs:\n", 1)[1] if "\njobs:\n" in text else ""
+    matches = list(re.finditer(r"(?m)^  ([\w-]+):\n", body))
+    return {
+        match.group(1): body[
+            match.end() : (
+                matches[index + 1].start() if index + 1 < len(matches) else len(body)
+            )
+        ]
+        for index, match in enumerate(matches)
+    }
+
+
+def aggregate_shell(job: str) -> str:
+    match = re.search(
+        r"(?ms)^      - name: Aggregate required CI result\n        run: \|\n(.*?)(?=^      - |\Z)",
+        job,
+    )
+    return "" if match is None else re.sub(r"(?m)^          ", "", match.group(1))
+
+
+def check(root: Path) -> list[str]:
+    errors: list[str] = []
+    text = (root / ".github" / "workflows" / "ci.yml").read_text()
+    jobs = _jobs(text)
+    if list(jobs) != ROSTER:
+        errors.append("exact CI job roster/order drifted")
+    if _hash(_top_block(text, "on")) != TRIGGER_HASH:
+        errors.append("CI triggers drifted")
+    if _hash(_top_block(text, "permissions")) != PERMISSION_HASH:
+        errors.append("CI permissions drifted")
+    for name, expected in JOB_HASHES.items():
+        if _hash(jobs.get(name, "")) != expected:
+            errors.append(f"{name} job body drifted")
+
+    if text.count(f"- name: {STEP_NAME}") != 1:
+        errors.append("extracted scale/receipt step must appear exactly once")
+    scale = jobs.get("scale_receipts", "")
+    command_match = re.search(
+        rf"(?ms)^      - name: {re.escape(STEP_NAME)}\n        run: \|\n(.*?)(?=^      - |\Z)",
+        scale,
+    )
+    if command_match is None or _hash(command_match.group(1)) != COMMAND_BODY_HASH:
+        errors.append("extracted command body/order drifted")
+    for seam in (
+        "name: scale / receipt checks",
+        "runs-on: ubuntu-latest",
+        "timeout-minutes: 30",
+        CHECKOUT,
+        TOOLCHAIN,
+        "toolchain: stable",
+        "components: rustfmt, clippy",
+        "uses: ./.github/actions/install-protobuf",
+        RUST_CACHE,
+        "sudo apt-get update",
+        "sudo apt-get install -y ripgrep",
+    ):
+        if seam not in scale:
+            errors.append(f"scale_receipts missing {seam}")
+
+    aggregate = jobs.get("check", "")
+    for seam in (
+        "name: check",
+        "runs-on: ubuntu-latest",
+        "timeout-minutes: 5",
+        "if: ${{ always() }}",
+        "needs: [core, scale_receipts]",
+        "CORE_RESULT: ${{ needs.core.result }}",
+        "SCALE_RECEIPTS_RESULT: ${{ needs.scale_receipts.result }}",
+        "printf 'core=%s\\n' \"$CORE_RESULT\"",
+        "printf 'scale_receipts=%s\\n' \"$SCALE_RECEIPTS_RESULT\"",
+        '[[ "$CORE_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]',
+    ):
+        if seam not in aggregate:
+            errors.append(f"aggregate check missing {seam}")
+    if "actions/checkout@" in aggregate:
+        errors.append("aggregate check must not checkout source")
+    if not aggregate_shell(aggregate):
+        errors.append("aggregate check shell missing")
+
+    pins = collections.Counter(
+        value.strip()
+        for value in re.findall(r"^\s*(?:- )?uses:\s*(.+)$", text, re.MULTILINE)
+        if not value.strip().startswith("./")
+    )
+    if pins != PINS:
+        errors.append("CI external action pins/counts drifted")
+    return errors
+
+
+if __name__ == "__main__":
+    failures = check(Path(__file__).resolve().parents[1])
+    if failures:
+        print("CI scale split contract check failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        raise SystemExit(1)
+    print("CI scale split contract OK")

--- a/scripts/test_check_ci_scale_split_contract.py
+++ b/scripts/test_check_ci_scale_split_contract.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.check_ci_scale_split_contract import _jobs, aggregate_shell, check
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ".github/workflows/ci.yml"
+
+
+class ScaleSplitContractTests(unittest.TestCase):
+    def mutate(self, old: str, new: str = "", occurrence: int = 0) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            target = root / WORKFLOW
+            target.parent.mkdir(parents=True)
+            shutil.copy2(ROOT / WORKFLOW, target)
+            text = target.read_text()
+            start = 0
+            for _ in range(occurrence + 1):
+                index = text.find(old, start)
+                self.assertNotEqual(
+                    -1, index, f"missing occurrence {occurrence}: {old}"
+                )
+                start = index + len(old)
+            target.write_text(text[:index] + new + text[index + len(old) :])
+            self.assertTrue(check(root), f"mutation stayed green: {old}")
+
+    def test_live_contract(self) -> None:
+        self.assertEqual([], check(ROOT))
+
+    def test_destructive_roster_and_preserved_bodies(self) -> None:
+        cases = (
+            ("  core:\n", "  renamed_core:\n"),
+            ("  scale_receipts:\n", "  renamed_scale:\n"),
+            ("  check:\n", "  renamed_check:\n"),
+            ("  msrv:\n", "  renamed_msrv:\n"),
+            ("  evpn_bum_filter_kernel:\n", "  renamed_evpn:\n"),
+            ("timeout-minutes: 45", "timeout-minutes: 44"),
+            ("key: msrv-1.95", "key: msrv-drift"),
+            ("IMAGE_TAG: rustbgpd-netns-tests:latest", "IMAGE_TAG: drift"),
+            ("branches: [main]", "branches: [other]"),
+            ("permissions:\n  contents: read", "permissions:\n  contents: write"),
+        )
+        for old, new in cases:
+            with self.subTest(seam=old):
+                self.mutate(old, new)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            target = root / WORKFLOW
+            target.parent.mkdir(parents=True)
+            shutil.copy2(ROOT / WORKFLOW, target)
+            text = target.read_text()
+            core_start = text.index("  core:\n")
+            scale_start = text.index("  scale_receipts:\n")
+            check_start = text.index("  check:\n", scale_start)
+            core = text[core_start:scale_start]
+            scale = text[scale_start:check_start]
+            target.write_text(text[:core_start] + scale + core + text[check_start:])
+            self.assertTrue(check(root), "job-order mutation stayed green")
+
+    def test_destructive_extracted_step_and_setup(self) -> None:
+        step_name = "- name: Check standalone scale harnesses and receipt classifiers"
+        cases = (
+            ("name: scale / receipt checks", "name: changed"),
+            ("timeout-minutes: 30", "timeout-minutes: 29"),
+            ("components: rustfmt, clippy", "components: rustfmt"),
+            ("uses: ./.github/actions/install-protobuf", "uses: ./changed", 1),
+            ("sudo apt-get install -y ripgrep", "sudo apt-get install -y grep"),
+            (
+                "cargo fmt --manifest-path bench/scale/rrharness/Cargo.toml -- --check",
+                "true",
+            ),
+            (
+                "cargo test --manifest-path bench/scale/rrtransport/Cargo.toml --locked",
+                "true",
+            ),
+            ("python3 bench/tests/test_verify_mrt_growth_campaign.py", "true"),
+            (step_name, f"{step_name}\n      {step_name}"),
+        )
+        for case in cases:
+            old, new, *occurrence = case
+            with self.subTest(seam=old):
+                self.mutate(old, new, occurrence[0] if occurrence else 0)
+        for pin, occurrence in (
+            ("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", 1),
+            ("dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c", 1),
+            ("Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32", 1),
+        ):
+            with self.subTest(pin=pin):
+                self.mutate(pin, "changed@main", occurrence)
+
+    def test_destructive_aggregate_seams(self) -> None:
+        cases = (
+            ("name: check", "name: changed"),
+            ("timeout-minutes: 5", "timeout-minutes: 6"),
+            ("if: ${{ always() }}", "if: ${{ success() }}"),
+            ("needs: [core, scale_receipts]", "needs: [core]"),
+            ("CORE_RESULT: ${{ needs.core.result }}", "CORE_RESULT: success"),
+            (
+                "SCALE_RECEIPTS_RESULT: ${{ needs.scale_receipts.result }}",
+                "SCALE_RECEIPTS_RESULT: success",
+            ),
+            ("printf 'core=%s\\n' \"$CORE_RESULT\"", "true"),
+            (
+                '[[ "$CORE_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]',
+                "[[ false ]]",
+            ),
+        )
+        for old, new in cases:
+            with self.subTest(seam=old):
+                self.mutate(old, new)
+
+    def test_aggregate_shell_truth_table(self) -> None:
+        workflow = (ROOT / WORKFLOW).read_text()
+        shell = aggregate_shell(_jobs(workflow)["check"])
+        self.assertTrue(shell)
+
+        def run(core=None, scale=None):
+            env = os.environ.copy()
+            env.pop("CORE_RESULT", None)
+            env.pop("SCALE_RECEIPTS_RESULT", None)
+            if core is not None:
+                env["CORE_RESULT"] = core
+            if scale is not None:
+                env["SCALE_RECEIPTS_RESULT"] = scale
+            return subprocess.run(
+                ["bash", "-c", shell], env=env, capture_output=True, text=True
+            )
+
+        self.assertEqual(0, run("success", "success").returncode)
+        for bad in ("failure", "cancelled", "skipped", ""):
+            with self.subTest(child="core", result=bad):
+                self.assertNotEqual(0, run(bad, "success").returncode)
+            with self.subTest(child="scale_receipts", result=bad):
+                self.assertNotEqual(0, run("success", bad).returncode)
+        self.assertNotEqual(0, run(None, "success").returncode)
+        self.assertNotEqual(0, run("success", None).returncode)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_ci_scale_split_contract.py
+++ b/scripts/test_check_ci_scale_split_contract.py
@@ -71,6 +71,7 @@ class ScaleSplitContractTests(unittest.TestCase):
         cases = (
             ("name: scale / receipt checks", "name: changed"),
             ("timeout-minutes: 30", "timeout-minutes: 29"),
+            ("fetch-depth: 0", "fetch-depth: 1", 1),
             ("components: rustfmt, clippy", "components: rustfmt"),
             ("uses: ./.github/actions/install-protobuf", "uses: ./changed", 1),
             ("sudo apt-get install -y ripgrep", "sudo apt-get install -y grep"),


### PR DESCRIPTION
## Summary

- extract the measured standalone scale/receipt block into one parallel job without changing its command body
- preserve the existing `CI / check` status context as a fail-closed aggregate over the core and scale lanes
- add destructive structural proofs for the job graph, complete command inventory, preserved core lanes, action pins, checkout history, and aggregate truth table

## Safety

- the original scale/receipt command body is byte-identical and appears exactly once
- the original check body is byte-identical as `core` after removing only the extracted block, adding the contract proof, and correcting its timing comment
- the scale lane checks out complete history because its retained RR harness calls `git log`
- MSRV and EVPN kernel jobs, triggers, permissions, existing gate bodies, and product code are unchanged
- the aggregate uses `always()` and fails unless both child results are exactly `success`; failure, cancelled, skipped, empty, and missing results are exercised destructively

## Measured impact

Immediate-base control (`963bfe9e`): stable `CI / check` readiness was 24m32s; total CI runner time was 27m54s.

Exact-head `41047131` receipts:

| attempt | stable readiness | core | scale / receipts | total runner time |
| --- | ---: | ---: | ---: | ---: |
| first, both new job caches cold | 21m10s | 21m01s | 17m58s | 42m25s |
| same-head warm control | **13m12s** | 12m55s | 10m52s | **27m09s** |

The representative warm path cuts required-check readiness by 11m20s (46.2%) while slightly reducing total runner time by 45s. The first attempt discloses the one-time cost of priming two newly named job-scoped Rust caches; it remains green and preserves the full gate inventory. The aggregate itself took 3s on the warm run and did not become eligible until both child jobs succeeded.

## Validation

- `python3 -m unittest -v scripts/test_check_ci_scale_split_contract.py`
- `python3 scripts/check_ci_scale_split_contract.py`
- `python3 -m unittest -v scripts/test_check_ci_image_primer_contract.py`
- `python3 scripts/check_ci_image_primer_contract.py`
- Black and Python byte-compilation for the three checker files
- Ruby YAML parse for `.github/workflows/ci.yml`
- independent base/current partition byte-stability proof
- exact-head hosted CI initial attempt and same-head rerun
- all exact-head Interop and Kernel Dataplane checks green
- `git diff --check`
- commit/push hooks: fmt, clippy, test where applicable, and rustdoc green

Product docs, ROADMAP, and CHANGELOG are N/A because coverage and daemon/operator behavior do not change.