### PR TITLE
test: isolate Birdwatcher smoke from GR recovery

### DIFF
--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -257,21 +257,35 @@ principal = "rustbgpd://observer/birdwatcher-test"
 address = "192.0.2.10"
 remote_asn = 65010
 description = "smoke peer"
+graceful_restart = false
 
 [[neighbors]]
 address = "127.0.0.1"
 remote_asn = 65020
 description = "live peer"
+graceful_restart = false
 
 [[neighbors]]
 address = "127.0.0.2"
 remote_asn = 65030
 description = "receiver peer"
+graceful_restart = false
 "#,
         runtime_dir = runtime_dir.display(),
         token_path = token_path.display()
     );
     let parsed: toml::Value = toml::from_str(&config).expect("test config must parse");
+    let graceful_restart = parsed["neighbors"]
+        .as_array()
+        .expect("neighbors must be an array")
+        .iter()
+        .map(|neighbor| {
+            neighbor
+                .get("graceful_restart")
+                .and_then(toml::Value::as_bool)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(graceful_restart, vec![Some(false); 3]);
     let principal = "rustbgpd://observer/birdwatcher-test";
     assert_eq!(
         parsed["security"]["grpc"]["enforcement"].as_str(),


### PR DESCRIPTION
## Summary

- explicitly disable Graceful Restart for all three peers in the Birdwatcher adapter smoke fixture
- assert the parsed fixture contains exactly three explicit `false` values
- prevent a failed first daemon bind attempt from carrying a shutdown GR marker into the retry and withholding Loc-RIB selection for the unrelated 60-second adapter receipt

## Root cause and scope

The hosted failure was retry-state contamination, not a production noexport race. The first daemon attempt exited before listening, coordinated shutdown persisted a GR marker, and the retry reused the same runtime-state directory. Because the fixture implicitly enabled 120-second GR but establishes only the announcer before its assertion, `ListBestRoutes` stayed empty through the receipt deadline.

This one-file, +14/-0 change isolates a smoke test that does not exercise GR. It does not change production GR defaults, selection deferral, retry behavior, endpoints, runtime-state layout, or timeouts. Product docs and CHANGELOG are N/A.

## Load-bearing proof

Each of the three assignments was removed independently. Every mutation failed immediately at the parsed-config assertion with the corresponding `None` slot, before daemon startup. All three mutations were restored.

## Validation

- complete focused Birdwatcher adapter smoke test
- focused test pinned to one permitted CPU
- eight concurrent focused copies with separate logs; all exited zero
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
- commit/push hooks green