### PR TITLE
docs: enforce origin authorization in MANRS example

### DIFF
--- a/docs/cookbook/manrs-ixp-action1.md
+++ b/docs/cookbook/manrs-ixp-action1.md
@@ -161,77 +161,37 @@ Action 1 filtering is only credible if members can see it working:
   import ladder and names the statement that rejected it — the
   support-ticket workflow is in [explain.md](../explain.md).
 
-## Complete example
+## Copyable example
 
-A minimal self-contained Action 1 shape — RPKI invalid = reject,
-inline stand-ins for rendered IRR sets, hygiene ordering, RFC 8212 on,
-per-family limits. In production the member prefix statements and
-ceilings come from the pipeline render; the checked-in
-[`examples/route-server/`](../../examples/route-server/) starter adds
-the `.rpol` hygiene chain, RPKI-valid preference, dual-stack members,
-and Add-Path / per-client-best path-hiding mitigation.
+The checked-in [`examples/manrs-action1/`](../../examples/manrs-action1/)
+is the minimal complete example. Its
+[`config.toml`](../../examples/manrs-action1/config.toml) keeps RPKI-invalid
+rejection ahead of the member filter, references the `.rpol` file through
+`rpol_files`, enables the RFC 8212 posture, and declares transparent export
+explicitly while retaining a per-family prefix limit.
 
-```toml
-[global]
-asn = 64500
-router_id = "192.0.2.1"
-listen_port = 179
-ebgp_requires_policy = true
+The member authorization is deliberately conjunctive. Both the resolved
+AS-SET and prefix-set must match; the tail rejects everything else:
 
-[global.telemetry]
-log_format = "json"
+```rpol
+asn-set member-a-origins { 64501 }
+prefix-set member-a-prefixes { 203.0.113.0/24 }
 
-[global.telemetry.grpc_uds]
-path = "/var/lib/rustbgpd/grpc.sock"
-principal = "operator"
-
-[security.grpc]
-enforcement = "tier"
-
-[security.grpc.roles]
-operator = "operator"
-
-[rpki]
-[[rpki.cache_servers]]
-address = "127.0.0.1:3323"
-
-[policy.definitions.reject-rpki-invalid]
-[[policy.definitions.reject-rpki-invalid.statements]]
-match_rpki_validation = "invalid"
-action = "deny"
-
-# Stand-in for a rendered per-member IRR set: permit only what the
-# member's AS-SET resolves to, deny the rest.
-[policy.definitions.member-a-irr]
-default_action = "deny"
-[[policy.definitions.member-a-irr.statements]]
-prefix = "203.0.113.0/24"
-action = "permit"
-
-# Transparent export is a declared decision (RFC 7947), not an omission.
-[policy.definitions.rs-transparent-export]
-default_action = "permit"
-
-[policy]
-export_chain = ["rs-transparent-export"]
-
-[[neighbors]]
-address = "192.0.2.10"
-remote_asn = 64501
-description = "member-a"
-route_server_client = true
-role = "route_server"
-families = ["ipv4_unicast"]
-max_prefixes_ipv4 = 10000
-max_prefix_restart_seconds = 900
-import_policy_chain = ["reject-rpki-invalid", "member-a-irr"]
+policy member-a-irr {
+    term accept-authorized {
+        if route.origin-as in member-a-origins && route.prefix in member-a-prefixes { accept }
+    }
+    term reject-unauthorized { reject }
+}
 ```
 
-Validate before anything touches the wire — this exact configuration
-exits 0:
+The adjacent in-language fixtures prove the authorized route is accepted,
+the same prefix with the wrong origin is rejected, and the registered origin
+cannot announce a different prefix. Validate the copy before deployment:
 
 ```bash
-rustbgpd --check --strict manrs-action1.toml
+rustbgpd --check --strict examples/manrs-action1/config.toml
+rbgp policy check examples/manrs-action1/member-a-irr.rpol
 ```
 
 ## Publishing your policy

--- a/examples/manrs-action1/config.toml
+++ b/examples/manrs-action1/config.toml
@@ -1,0 +1,48 @@
+# Minimal MANRS IXP Action 1 route-server example.
+
+[global]
+asn = 64500
+router_id = "192.0.2.1"
+listen_port = 179
+ebgp_requires_policy = true
+
+[global.telemetry]
+log_format = "json"
+
+[global.telemetry.grpc_uds]
+path = "/var/lib/rustbgpd/grpc.sock"
+principal = "operator"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+operator = "operator"
+
+[rpki]
+[[rpki.cache_servers]]
+address = "127.0.0.1:3323"
+
+[policy.definitions.reject-rpki-invalid]
+[[policy.definitions.reject-rpki-invalid.statements]]
+match_rpki_validation = "invalid"
+action = "deny"
+
+# Transparent route-server export is explicit, not permit-by-omission.
+[policy.definitions.rs-transparent-export]
+default_action = "permit"
+
+[policy]
+rpol_files = ["member-a-irr.rpol"]
+
+[[neighbors]]
+address = "192.0.2.10"
+remote_asn = 64501
+description = "member-a"
+route_server_client = true
+role = "route_server"
+families = ["ipv4_unicast"]
+max_prefixes_ipv4 = 10000
+max_prefix_restart_seconds = 900
+import_policy_chain = ["reject-rpki-invalid", "member-a-irr"]
+export_policy_chain = ["rs-transparent-export"]

--- a/examples/manrs-action1/member-a-irr.rpol
+++ b/examples/manrs-action1/member-a-irr.rpol
@@ -1,0 +1,25 @@
+# Minimal resolved IRR authorization for member AS64501.
+asn-set member-a-origins { 64501 }
+prefix-set member-a-prefixes { 203.0.113.0/24 }
+
+policy member-a-irr {
+    term accept-authorized {
+        if route.origin-as in member-a-origins && route.prefix in member-a-prefixes { accept }
+    }
+    term reject-unauthorized { reject }
+}
+
+test authorized-origin-and-prefix-is-accepted {
+    route { prefix 203.0.113.0/24; as-path "64501" }
+    expect member-a-irr == accept
+}
+
+test registered-prefix-with-wrong-origin-is-rejected {
+    route { prefix 203.0.113.0/24; as-path "64502" }
+    expect member-a-irr == reject
+}
+
+test registered-origin-with-other-prefix-is-rejected {
+    route { prefix 198.51.100.0/24; as-path "64501" }
+    expect member-a-irr == reject
+}

--- a/tests/manrs_action1_example.rs
+++ b/tests/manrs_action1_example.rs
@@ -1,0 +1,61 @@
+//! The copyable MANRS Action 1 example stays daemon-valid and its embedded
+//! policy tests run through the real `rbgp policy check` command.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn repo_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn run_rbgp(args: &[&str]) -> Output {
+    let sibling = Path::new(env!("CARGO_BIN_EXE_rustbgpd"))
+        .parent()
+        .expect("rustbgpd binary has a parent")
+        .join("rbgp");
+    if sibling.is_file() {
+        return Command::new(sibling)
+            .args(args)
+            .current_dir(repo_root())
+            .output()
+            .expect("run rbgp");
+    }
+
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
+    Command::new(cargo)
+        .args(["run", "--quiet", "-p", "rustbgpctl", "--bin", "rbgp", "--"])
+        .args(args)
+        .current_dir(repo_root())
+        .output()
+        .expect("run rbgp through cargo")
+}
+
+fn example(path: &str) -> PathBuf {
+    repo_root().join("examples/manrs-action1").join(path)
+}
+
+#[test]
+fn manrs_action1_example_passes_strict_config_and_policy_checks() {
+    let config = example("config.toml");
+    let config_output = Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
+        .args(["--check", "--strict"])
+        .arg(&config)
+        .output()
+        .expect("run rustbgpd --check --strict");
+    assert!(
+        config_output.status.success(),
+        "strict config check failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&config_output.stdout),
+        String::from_utf8_lossy(&config_output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&config_output.stdout).contains("config OK"));
+
+    let policy = example("member-a-irr.rpol");
+    let policy_output = run_rbgp(&["policy", "check", policy.to_str().expect("UTF-8 path")]);
+    assert!(
+        policy_output.status.success(),
+        "policy check failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&policy_output.stdout),
+        String::from_utf8_lossy(&policy_output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

- replace the cookbook’s inline prefix-only IRR stand-in with a checked-in, copyable MANRS Action 1 example
- require both the registered origin AS and exact registered prefix before accepting a member route
- permanently run the real strict config checker and real policy-test backend against the example

## Correctness boundary

MANRS permits IRR and/or RPKI filtering generally. This PR does not claim the previous overall posture was categorically noncompliant; it fixes the narrower mismatch between the cookbook’s stated rendered IRR prefix/origin model and the policy it actually executed.

The production renderer already emits the same conjunction:

```rpol
route.origin-as in member-a-origins &&
route.prefix in member-a-prefixes
```

The example retains RPKI-invalid rejection, explicit RFC 8212 import/export policy, transparent route-server export, and the previous per-family prefix limit/restart window. Runtime and API behavior do not change, so CHANGELOG and ROADMAP are N/A.

## Load-bearing proof

Removing only `route.origin-as in member-a-origins &&` makes the real `rbgp policy check` exit 2: the same registered prefix from AS64502 changes from the required `reject` verdict to `accept`. Restoring the conjunct returns all three fixtures to green.

## Validation

- `target/debug/rustbgpd --check --strict examples/manrs-action1/config.toml` (`config OK`)
- `target/debug/rbgp policy check examples/manrs-action1/member-a-irr.rpol` (3 passed, 0 failed)
- `cargo test --locked --test manrs_action1_example`
- `cargo test --locked --test starter_configs_check_strict`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
- commit/push hooks green