### PR TITLE
test: reserve refused doctor probe ports

### DIFF
--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -2928,11 +2928,9 @@ paths = ["x"]
     async fn reachability_probe_distinguishes_listener_from_cli_vantage() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let live = listener.local_addr().unwrap();
-        // A port that was just bound and released: connecting is refused.
-        let dead = {
-            let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-            l.local_addr().unwrap()
-        };
+        let dead_socket = tokio::net::TcpSocket::new_v4().unwrap();
+        dead_socket.bind("127.0.0.1:0".parse().unwrap()).unwrap();
+        let dead = dead_socket.local_addr().unwrap();
         let targets = DeployTargets {
             listen_port: Some(dead.port()),
             rpki_caches: vec![live.to_string()],
@@ -3977,10 +3975,9 @@ paths = ["x"]
     async fn doctor_remote_daemon_dependency_probes_are_cli_vantage_warnings() {
         let live = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let live_port = live.local_addr().unwrap().port();
-        let dead = {
-            let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-            l.local_addr().unwrap()
-        };
+        let dead_socket = tokio::net::TcpSocket::new_v4().unwrap();
+        dead_socket.bind("127.0.0.1:0".parse().unwrap()).unwrap();
+        let dead = dead_socket.local_addr().unwrap();
 
         let server = spawn_mock_server(None).await;
         let state_dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- reserve each intentionally unreachable doctor-test port with a bound, non-listening TCP socket
- prevent another concurrent test or mock server from reusing the released ephemeral port
- leave production reachability probes, timeout behavior, and status semantics unchanged

## Root cause

Main CI run 30663353028 observed an unreachable RPKI target as reachable. Both affected fixtures previously bound `127.0.0.1:0`, recorded the address, and dropped the listener before the probe ran. Under concurrency, another listener could acquire that address, so the production probe correctly returned `ok`.

## Verification

- both affected exact tests pass
- complete doctor module passes: 51/51
- stress receipt: 20,000 exact executions at parallelism 64, split evenly across both tests, zero failures
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`

## Load-bearing proof

Each retained socket was independently changed into a listening socket. The first test failed its expected refused-probe status (`Ok` versus `Fail`); the remote-daemon test failed its expected warning status (`ok` versus `warn`). Both mutations were restored before the final stress and workspace gates.