### PR TITLE
docs: gate release install contract

### DIFF
--- a/.github/workflows/release-install-contract.yml
+++ b/.github/workflows/release-install-contract.yml
@@ -1,0 +1,36 @@
+name: Release install contract
+
+on:
+  pull_request:
+    paths:
+      - docs/deployment.md
+      - docs/QUICKSTART.md
+      - examples/birdwatcher-adapter/README.md
+      - .github/workflows/release.yml
+      - packaging/nfpm.yaml
+      - scripts/check_release_install_contract.py
+      - scripts/test_check_release_install_contract.py
+      - .github/workflows/release-install-contract.yml
+  push:
+    branches: [main]
+    paths:
+      - docs/deployment.md
+      - docs/QUICKSTART.md
+      - examples/birdwatcher-adapter/README.md
+      - .github/workflows/release.yml
+      - packaging/nfpm.yaml
+      - scripts/check_release_install_contract.py
+      - scripts/test_check_release_install_contract.py
+      - .github/workflows/release-install-contract.yml
+permissions:
+  contents: read
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Test release install contract
+        run: python3 scripts/test_check_release_install_contract.py
+      - name: Check repository release install contract
+        run: python3 scripts/check_release_install_contract.py

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -10,6 +10,7 @@ For the fastest no-host setup, use the Docker Compose lab in
 
 Grab the pre-built release tarball — no Rust toolchain, no compile:
 
+<!-- release-install-contract:tarball:start -->
 ```bash
 SUFFIX=linux-amd64   # or linux-arm64
 curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/rustbgpd-${SUFFIX}.tar.gz"
@@ -18,8 +19,24 @@ sha256sum -c "checksums-${SUFFIX}.txt"
 tar -xzf "rustbgpd-${SUFFIX}.tar.gz"
 sudo install -m 0755 rustbgpd rbgp rs-config-render /usr/local/bin/
 
+sudo useradd --system --home-dir /var/lib/rustbgpd \
+  --shell /usr/sbin/nologin rustbgpd 2>/dev/null || true
+sudo install -m 0644 share/systemd/rustbgpd.service \
+  /etc/systemd/system/rustbgpd.service
+sudo install -d -m 0755 /etc/rustbgpd
+rustbgpd --init-config edge --stdout | \
+  sudo tee /etc/rustbgpd/config.toml >/dev/null
+sudo chmod 0640 /etc/rustbgpd/config.toml
+sudo chgrp rustbgpd /etc/rustbgpd/config.toml
+
+# Kernel-dataplane hosts only:
+sudo install -d /etc/systemd/system/rustbgpd.service.d
+sudo install -m 0644 share/systemd/rustbgpd-dataplane.conf \
+  /etc/systemd/system/rustbgpd.service.d/rustbgpd-dataplane.conf
+
 rustbgpd --version && rbgp --version
 ```
+<!-- release-install-contract:tarball:end -->
 
 The third binary, `rs-config-render`, is the
 [IXP route-server config renderer](../tools/rs-config-render/README.md);
@@ -45,7 +62,9 @@ The built binaries are `target/release/rustbgpd` (daemon) and
 
 ## 2. Create a config
 
-Generate a starter config from a built-in profile:
+The tarball systemd install above already generated the production-path
+`edge` profile. For this foreground walkthrough (or a source checkout),
+generate a disposable `lab` profile in the current directory:
 
 ```bash
 # `lab` = minimal single-box setup:
@@ -61,11 +80,13 @@ real config loader before it is printed, and each passes
 `rustbgpd --check --strict` as emitted: `lab` is permit-all in both
 directions, but says so in an explicit chain rather than by omission.
 
-Prefer a checked-in starter file?
+From a source checkout, prefer a checked-in starter file?
 
+<!-- release-install-contract:source-checkout:start -->
 ```bash
 cp examples/minimal/config.toml config.toml
 ```
+<!-- release-install-contract:source-checkout:end -->
 
 For route-server deployments, start from
 [`examples/route-server/config.toml`](../examples/route-server/config.toml) and

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,6 +61,7 @@ The filename is the same on every release; `releases/latest/download/`
 always resolves to the current tag, so this snippet never needs a
 version bump.
 
+<!-- release-install-contract:tarball:start -->
 ```sh
 # Pick the right arch.
 SUFFIX=linux-amd64    # or linux-arm64
@@ -74,7 +75,23 @@ sudo install -m 0644 share/man/man1/rbgp.1 /usr/local/share/man/man1/
 sudo install -m 0644 share/man/man8/rustbgpd.8 /usr/local/share/man/man8/
 sudo install -m 0644 share/completions/rbgp.bash \
   /usr/share/bash-completion/completions/rbgp
+
+sudo useradd --system --home-dir /var/lib/rustbgpd \
+  --shell /usr/sbin/nologin rustbgpd 2>/dev/null || true
+sudo install -m 0644 share/systemd/rustbgpd.service \
+  /etc/systemd/system/rustbgpd.service
+sudo install -d -m 0755 /etc/rustbgpd
+rustbgpd --init-config edge --stdout | \
+  sudo tee /etc/rustbgpd/config.toml >/dev/null
+sudo chmod 0640 /etc/rustbgpd/config.toml
+sudo chgrp rustbgpd /etc/rustbgpd/config.toml
+
+# Kernel-dataplane hosts only; control-plane-only hosts omit this drop-in.
+sudo install -d /etc/systemd/system/rustbgpd.service.d
+sudo install -m 0644 share/systemd/rustbgpd-dataplane.conf \
+  /etc/systemd/system/rustbgpd.service.d/rustbgpd-dataplane.conf
 ```
+<!-- release-install-contract:tarball:end -->
 
 The man pages and completions are also generated on demand by the
 binaries themselves (`rbgp man`, `rustbgpd --man`,
@@ -119,7 +136,9 @@ sudo dnf install -y \
   https://github.com/lance0/rustbgpd/releases/download/vX.Y.Z/rustbgpd-X.Y.Z-1.x86_64.rpm
 ```
 
-The package installs the three binaries to `/usr/bin`, the hardened
+<!-- release-install-contract:native-package:start -->
+The package installs the three binaries (`rustbgpd`, `rbgp`, and
+`rs-config-render`) to `/usr/bin`, the hardened
 systemd unit (see [systemd](#systemd) below — same unit, `ExecStart`
 pointed at `/usr/bin`), man pages and shell completions, and creates
 the `rustbgpd` system user (imperatively at install time, plus a
@@ -127,6 +146,7 @@ declarative `sysusers.d` file). A starter config lands at
 `/etc/rustbgpd/config.toml` (mode `0640 root:rustbgpd`, never
 overwritten on upgrade) — the [minimal profile](../examples/minimal/config.toml)
 with its state paths set to `/var/lib/rustbgpd`. Then:
+<!-- release-install-contract:native-package:end -->
 
 ```sh
 sudo $EDITOR /etc/rustbgpd/config.toml   # set ASN, router_id, neighbors
@@ -278,8 +298,10 @@ Notes on the sandbox:
 
 The [Debian/RPM packages](#debian--rpm-packages) perform all of the
 below on install (unit at `/lib/systemd/system`, `ExecStart` at
-`/usr/bin`). For a tarball or source install:
+`/usr/bin`). The tarball commands above use its `share/systemd/` tree.
+The following paths are only for a source checkout:
 
+<!-- release-install-contract:source-checkout:start -->
 ```sh
 sudo useradd --system --home-dir /var/lib/rustbgpd \
   --shell /usr/sbin/nologin rustbgpd
@@ -292,6 +314,7 @@ $EDITOR /etc/rustbgpd/config.toml    # set ASN, router_id, neighbors
 sudo systemctl daemon-reload
 sudo systemctl enable --now rustbgpd
 ```
+<!-- release-install-contract:source-checkout:end -->
 
 ### Kernel dataplane: opt-in privilege drop-in
 

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -14,10 +14,14 @@ complete: IPv4/IPv6 unicast single-table only (no VPN/EVPN views, no
 Rationale: the daemon's durable API identity is **gRPC + `rbgp`**.
 Partial compatibility with someone else's REST API inside daemon core
 is a permanent source of misunderstanding, so the birdwatcher surface
-lives here as a maintained adapter instead. It is a workspace member
-but not part of the default `cargo build`, release tarballs, or
-container images; it builds with `--workspace` or an explicit
-`-p birdwatcher-adapter`.
+lives here as a maintained adapter instead.
+
+<!-- release-install-contract:birdwatcher-boundary:start -->
+The `birdwatcher-adapter` binary is included in release tarballs. It is
+excluded from the default `cargo build`, native `.deb`/`.rpm` packages, and
+container images; build it from a source checkout with `--workspace` or an
+explicit `-p birdwatcher-adapter`.
+<!-- release-install-contract:birdwatcher-boundary:end -->
 
 ## Build + run
 

--- a/scripts/check_release_install_contract.py
+++ b/scripts/check_release_install_contract.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Fail closed when release payloads and copyable install docs diverge."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def marked(text: str, name: str, label: str) -> str:
+    start = f"<!-- release-install-contract:{name}:start -->"
+    end = f"<!-- release-install-contract:{name}:end -->"
+    if text.count(start) != 1 or text.count(end) != 1:
+        raise ValueError(f"{label}: expected one {name} marker pair")
+    body = text.split(start, 1)[1].split(end, 1)[0]
+    if not body.strip():
+        raise ValueError(f"{label}: empty {name} region")
+    return body
+
+
+def workflow_step(text: str, name: str) -> str:
+    match = re.search(
+        rf"(?ms)^      - name: {re.escape(name)}\n(.*?)(?=^      - name: |^  [a-zA-Z0-9_-]+:|\Z)",
+        text,
+    )
+    if not match:
+        raise ValueError(f"release.yml: missing step {name!r}")
+    return match.group(1)
+
+
+def require(errors: list[str], label: str, text: str, tokens: tuple[str, ...]) -> None:
+    for token in tokens:
+        if token not in text:
+            errors.append(f"{label}: missing {token!r}")
+
+
+def check(root: Path) -> list[str]:
+    errors: list[str] = []
+    read = lambda path: (root / path).read_text(encoding="utf-8")
+    try:
+        release = read(".github/workflows/release.yml")
+        package = workflow_step(release, "Package binaries")
+        assertion = workflow_step(
+            release,
+            "Assert tarball has nonempty binaries, licenses, man pages, and completions",
+        )
+        require(
+            errors,
+            "release package step",
+            package,
+            (
+                "target/${{ matrix.target }}/release/birdwatcher-adapter",
+                "examples/systemd/rustbgpd.service",
+                "examples/systemd/rustbgpd-dataplane.conf",
+                "staging/share/systemd/",
+                "rustbgpd rbgp rs-config-render birdwatcher-adapter",
+            ),
+        )
+        require(
+            errors,
+            "release assertion step",
+            assertion,
+            (
+                "birdwatcher-adapter",
+                "share/systemd/rustbgpd.service",
+                "share/systemd/rustbgpd-dataplane.conf",
+            ),
+        )
+
+        nfpm = read("packaging/nfpm.yaml")
+        native_bins = set(re.findall(r"(?m)^\s+dst: (/usr/bin/[^\s]+)\s*$", nfpm))
+        expected = {"/usr/bin/rustbgpd", "/usr/bin/rbgp", "/usr/bin/rs-config-render"}
+        if native_bins != expected:
+            errors.append(f"packaging/nfpm.yaml: /usr/bin payload {sorted(native_bins)!r}")
+
+        for path in ("docs/deployment.md", "docs/QUICKSTART.md"):
+            doc = read(path)
+            tarball = marked(doc, "tarball", path)
+            require(
+                errors,
+                f"{path} tarball region",
+                tarball,
+                (
+                    "share/systemd/rustbgpd.service",
+                    "share/systemd/rustbgpd-dataplane.conf",
+                    "rustbgpd --init-config edge --stdout",
+                ),
+            )
+            if "examples/systemd/" in tarball:
+                errors.append(f"{path}: tarball region uses source-checkout systemd paths")
+
+        deployment = read("docs/deployment.md")
+        native = marked(deployment, "native-package", "docs/deployment.md")
+        sentence = re.search(r"installs the three binaries \((.*?)\) to `/usr/bin`", " ".join(native.split()))
+        documented = re.findall(r"`([^`]+)`", sentence.group(1)) if sentence else []
+        if documented != ["rustbgpd", "rbgp", "rs-config-render"]:
+            errors.append(f"docs/deployment.md: documented native binaries {documented!r}")
+        source = marked(deployment, "source-checkout", "docs/deployment.md")
+        require(
+            errors,
+            "docs/deployment.md source-checkout region",
+            source,
+            ("examples/systemd/rustbgpd.service", "examples/minimal/config.toml"),
+        )
+
+        adapter = marked(
+            read("examples/birdwatcher-adapter/README.md"),
+            "birdwatcher-boundary",
+            "birdwatcher README",
+        )
+        require(
+            errors,
+            "birdwatcher README boundary",
+            adapter,
+            (
+                "included in release tarballs",
+                "excluded from the default `cargo build`",
+                "native `.deb`/`.rpm` packages",
+                "container images",
+            ),
+        )
+    except (OSError, ValueError) as error:
+        errors.append(str(error))
+    return errors
+
+
+def main() -> int:
+    errors = check(Path(__file__).resolve().parents[1])
+    if errors:
+        print("release install contract failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print("release install contract OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_release_install_contract.py
+++ b/scripts/test_check_release_install_contract.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import check_release_install_contract as contract
+ROOT = Path(__file__).resolve().parents[1]
+INPUTS = (
+    ".github/workflows/release.yml",
+    "packaging/nfpm.yaml",
+    "docs/deployment.md",
+    "docs/QUICKSTART.md",
+    "examples/birdwatcher-adapter/README.md",
+)
+
+class ReleaseInstallContractTest(unittest.TestCase):
+    def fixture(self) -> Path:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        root = Path(temp.name)
+        for relative in INPUTS:
+            target = root / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(ROOT / relative, target)
+        return root
+
+    def mutate(self, root: Path, relative: str, old: str, new: str) -> list[str]:
+        path = root / relative
+        text = path.read_text()
+        self.assertIn(old, text)
+        path.write_text(text.replace(old, new))
+        return contract.check(root)
+
+    def test_repository_contract(self) -> None:
+        self.assertEqual(contract.check(ROOT), [])
+
+    def test_wrong_examples_unit_path_fails(self) -> None:
+        errors = self.mutate(
+            self.fixture(),
+            "docs/deployment.md",
+            "share/systemd/rustbgpd.service",
+            "examples/systemd/rustbgpd.service",
+        )
+        self.assertTrue(any("tarball region" in error for error in errors), errors)
+
+    def test_removed_release_assertion_unit_fails(self) -> None:
+        root = self.fixture()
+        path = root / ".github/workflows/release.yml"
+        text = path.read_text()
+        marker = "      - name: Assert tarball has nonempty binaries, licenses, man pages, and completions"
+        before, after = text.split(marker, 1)
+        after = after.replace("share/systemd/rustbgpd.service", "share/systemd/removed.service", 1)
+        path.write_text(before + marker + after)
+        errors = contract.check(root)
+        self.assertTrue(any("release assertion step" in error for error in errors), errors)
+
+    def test_reverted_birdwatcher_boundary_fails(self) -> None:
+        errors = self.mutate(
+            self.fixture(),
+            "examples/birdwatcher-adapter/README.md",
+            "included in release tarballs",
+            "not part of release tarballs",
+        )
+        self.assertTrue(any("birdwatcher" in error for error in errors), errors)
+
+    def test_adapter_in_native_inventory_fails(self) -> None:
+        root = self.fixture()
+        path = root / "packaging/nfpm.yaml"
+        path.write_text(
+            path.read_text()
+            + "\n  - src: synthetic/birdwatcher-adapter\n"
+            + "    dst: /usr/bin/birdwatcher-adapter\n"
+        )
+        errors = contract.check(root)
+        self.assertTrue(any("/usr/bin payload" in error for error in errors), errors)
+
+    def test_fourth_documented_native_binary_fails(self) -> None:
+        errors = self.mutate(
+            self.fixture(), "docs/deployment.md", "`rs-config-render`) to", "`rs-config-render`, `extra`) to"
+        )
+        self.assertTrue(any("documented native binaries" in error for error in errors), errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make tarball install commands use the systemd files actually shipped under `share/systemd/`
- generate the production starter config with `rustbgpd --init-config edge --stdout` and visibly distinguish source-checkout-only example paths
- correct the Birdwatcher adapter availability matrix while preserving the intentional three-binary native-package boundary
- add a stdlib-only structural checker and focused five-minute workflow for Markdown-only and packaging-contract changes

## Root cause

The release workflow stages the systemd unit under `share/systemd/` and does not ship the repository `examples/` tree. The deployment guide nevertheless told extracted-tarball users to copy `examples/systemd/rustbgpd.service` and `examples/minimal/config.toml`, so a clean tarball installation stopped on missing files. The adapter README also still claimed `birdwatcher-adapter` was absent from tarballs.

This PR changes documentation and the contract gate only. Release assembly, native packages, containers, Cargo, production behavior, CHANGELOG, and ROADMAP are unchanged. Native packages remain exactly `rustbgpd`, `rbgp`, and `rs-config-render`; the adapter remains tarball-only.

## Load-bearing proofs

The checker test suite independently makes each of these drifts red:

- change the tarball unit path back to `examples/systemd/...`
- remove the unit from the release archive assertion
- revert the Birdwatcher tarball/native/container boundary
- add the adapter to the nFPM binary inventory
- add a fourth binary to the documented native-package list

## Validation

- `python3 -m unittest -v scripts/test_check_release_install_contract.py` (6 passed)
- `python3 scripts/test_check_release_install_contract.py` (6 passed)
- `python3 scripts/check_release_install_contract.py`
- `cargo test --locked --test starter_configs_check_strict every_init_config_profile_passes_check_strict -- --exact`
- workflow YAML parse
- `cargo fmt --all -- --check`
- `git diff --check`

Exact patch: six files, +320/-8. Independent final audit approved commit `3c481113`.