### PR TITLE
bench: add IRR memory attribution harness

### DIFF
--- a/bench/scale/irrreload/run-memory-attribution.sh
+++ b/bench/scale/irrreload/run-memory-attribution.sh
@@ -1,0 +1,551 @@
+#!/usr/bin/env bash
+# Fresh-process IRR route-server memory attribution: private/grouped/grouped/private.
+set -euo pipefail
+
+REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+GEN=${GENERATOR:-$REPO/bench/scale/reloadstall/gen-irr-scenario.py}
+CLASSIFIER=$REPO/bench/scale/rebaseline/classify_dhat.py
+PROTOCOL=(private grouped grouped private)
+PATH_HIDING=(true false false true)
+RSS_LIMIT_KIB=$((100 * 1024 * 1024))
+START_TIMEOUT=${START_TIMEOUT:-60}
+SETTLE_TIMEOUT=${SETTLE_TIMEOUT:-10}
+LEG_TIMEOUT=${LEG_TIMEOUT:-600}
+PORT=${PORT:-1790}
+METRICS_PORT=${METRICS_PORT:-9179}
+
+die() { echo "$*" >&2; exit 1; }
+uint() { [[ $1 =~ ^[0-9]+$ ]]; }
+hash_file() { sha256sum -- "$1" | awk '{print $1}'; }
+monotonic() { awk '{print $1}' /proc/uptime; }
+validate_protocol() {
+    [[ $# == 4 && $1 == private && $2 == grouped && $3 == grouped && $4 == private ]]
+}
+
+validate_scrapes() {
+    python3 - "$@" <<'PY'
+import math, pathlib, re, sys
+mode, peers_text, total_text, allocator_text, config, *paths = sys.argv[1:]
+peers, total, allocator = int(peers_text), int(total_text), allocator_text == "true"
+if len(paths) != 3:
+    raise SystemExit("exactly three consecutive scrapes are required")
+metric_name = re.compile(r'[A-Za-z_:][A-Za-z0-9_:]*')
+label_name = re.compile(r'[A-Za-z_][A-Za-z0-9_]*')
+float_value = re.compile(r'(?:[-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][-+]?[0-9]+)?|NaN|[+-]Inf)')
+int64_timestamp = re.compile(r'[+-]?[0-9]+')
+watched = ("bgp_rib_", "bgp_peer_", "bgp_update_group", "jemalloc_")
+def quoted(text, pos):
+    if pos >= len(text) or text[pos] != '"': raise ValueError("expected quoted string")
+    chars, pos = [], pos + 1
+    while pos < len(text):
+        char, pos = text[pos], pos + 1
+        if char == '"': return ''.join(chars), pos
+        if char == '\\':
+            if pos >= len(text) or text[pos] not in '\\"n': raise ValueError("malformed escape")
+            chars.append({'\\': '\\', '"': '"', 'n': '\n'}[text[pos]]); pos += 1
+        elif char in '\r\n': raise ValueError("unescaped line break")
+        else: chars.append(char)
+    raise ValueError("unterminated quoted string")
+def parse_sample(text):
+    match = metric_name.match(text)
+    if not match: return None
+    name, pos, labels = match.group(), match.end(), {}
+    if pos < len(text) and text[pos] == '{':
+        pos += 1
+        while True:
+            while pos < len(text) and text[pos] in ' \t': pos += 1
+            if pos < len(text) and text[pos] == '}': pos += 1; break
+            if pos < len(text) and text[pos] == '"': key, pos = quoted(text, pos)
+            else:
+                match = label_name.match(text, pos)
+                if not match: raise ValueError("malformed label name")
+                key, pos = match.group(), match.end()
+            while pos < len(text) and text[pos] in ' \t': pos += 1
+            if pos >= len(text) or text[pos] != '=': raise ValueError("missing label equals")
+            pos += 1
+            while pos < len(text) and text[pos] in ' \t': pos += 1
+            value, pos = quoted(text, pos)
+            if key in labels: raise ValueError(f"duplicate label: {key!r}")
+            labels[key] = value
+            while pos < len(text) and text[pos] in ' \t': pos += 1
+            if pos < len(text) and text[pos] == '}': pos += 1; break
+            if pos >= len(text) or text[pos] != ',': raise ValueError("malformed label separator")
+            pos += 1
+    if pos >= len(text) or text[pos] not in ' \t': raise ValueError("missing value separator")
+    tokens = text[pos:].split()
+    if len(tokens) not in (1, 2) or not float_value.fullmatch(tokens[0]): raise ValueError("malformed sample value")
+    if len(tokens) == 2:
+        if not int64_timestamp.fullmatch(tokens[1]): raise ValueError("malformed timestamp")
+        if not -(1 << 63) <= int(tokens[1]) < (1 << 63): raise ValueError("timestamp outside int64")
+    return name, labels, float(tokens[0])
+def parse(path):
+    result, identities = {}, set()
+    for line in pathlib.Path(path).read_text().splitlines():
+        text = line.strip()
+        if not text or text.startswith('#'): continue
+        try: parsed = parse_sample(text)
+        except ValueError:
+            if text.startswith(watched): raise
+            continue
+        if parsed is None: continue
+        name, labels, value = parsed
+        identity = (name, tuple(sorted(labels.items())))
+        if identity in identities: raise ValueError(f"duplicate metric sample: {identity}")
+        identities.add(identity); result.setdefault(name, []).append((labels, value))
+    return result
+scrapes = [parse(path) for path in paths]
+def rows(data, name, count=None):
+    found = data.get(name, [])
+    if count is not None and len(found) != count:
+        raise ValueError(f"{name}: expected {count} samples, got {len(found)}")
+    if any(not math.isfinite(value) for _, value in found):
+        raise ValueError(f"{name}: non-finite sample")
+    return found
+def singleton(data, name):
+    labels, value = rows(data, name, 1)[0]
+    if labels: raise ValueError(f"{name}: unexpected labels {labels}")
+    return value
+def one(data, name, expected):
+    value = singleton(data, name)
+    if value != expected: raise ValueError(f"{name}: expected {expected}, got {value:g}")
+def peer_rows(data, name, extra=()):
+    found = rows(data, name, peers)
+    identities = [labels.get("peer") for labels, _ in found]
+    expected = {"peer", *extra}
+    if None in identities or len(set(identities)) != peers or any(set(labels) != expected for labels, _ in found):
+        raise ValueError(f"{name}: missing/duplicate peer or unexpected labels")
+    return found
+def family_rows(data, name, identities, families):
+    found = rows(data, name, peers * len(families)); expected = {(peer, family) for peer in identities for family in families}
+    actual = {(labels.get("peer"), labels.get("afi_safi")) for labels, _ in found}
+    if actual != expected or any(set(labels) != {"peer", "afi_safi"} for labels, _ in found):
+        raise ValueError(f"{name}: family/peer roster mismatch")
+    return {(labels["peer"], labels["afi_safi"]): value for labels, value in found}
+text = pathlib.Path(config).read_text()
+if "[neighbors.add_path]" in text:
+    raise ValueError("memory legs require Add-Path disabled")
+expected_best = peers if mode == "private" else 0
+if text.count("per_client_best = true") != expected_best:
+    raise ValueError(f"{mode}: per_client_best mapping is not exact")
+for data in scrapes:
+    one(data, "bgp_rib_outbound_registered_peers", peers)
+    one(data, "bgp_rib_ingest_channel_depth", 0)
+    one(data, "bgp_rib_policy_transition_in_progress", 0)
+    sessions = peer_rows(data, "bgp_peer_session_established", ("interface",)); peer_ids = {labels["peer"] for labels, _ in sessions}
+    if [value for _, value in sessions] != [1.0] * peers:
+        raise ValueError("not every expected session is established")
+    queues = peer_rows(data, "bgp_peer_outbound_queue_depth")
+    if {labels["peer"] for labels, _ in queues} != peer_ids or [value for _, value in queues] != [0.0] * peers:
+        raise ValueError("every outbound queue must be zero")
+    loc = rows(data, "bgp_rib_loc_prefixes", 1)
+    if loc[0] != ({"afi_safi": "all"}, float(total)): raise ValueError("Loc-RIB aggregate mismatch")
+    adj_in = family_rows(data, "bgp_rib_prefixes", peer_ids, ("all", "flowspec"))
+    if any(adj_in[(peer, "all")] != total // peers or adj_in[(peer, "flowspec")] != 0 for peer in peer_ids):
+        raise ValueError("Adj-RIB-In aggregate/non-all roster mismatch")
+    expected_out = total - total // peers
+    out_families = ("all", "bgpls", "evpn", "flowspec", "labeled", "rtc", "vpn")
+    adj_out = family_rows(data, "bgp_rib_adj_out_prefixes", peer_ids, out_families)
+    if any(adj_out[(peer, family)] != (expected_out if family == "all" else 0) for peer in peer_ids for family in out_families):
+        raise ValueError("Adj-RIB-Out aggregate/non-all roster mismatch")
+    peer_groups = peer_rows(data, "bgp_peer_update_group")
+    if {labels["peer"] for labels, _ in peer_groups} != peer_ids: raise ValueError("group peer roster mismatch")
+    if mode == "private":
+        one(data, "bgp_update_groups", 0); one(data, "bgp_update_group_fallback_peers", peers)
+        if rows(data, "bgp_update_group_members") or any(value != -1 for _, value in peer_groups):
+            raise ValueError("private leg must have no groups and all peer group gauges -1")
+    else:
+        one(data, "bgp_update_groups", 1); one(data, "bgp_update_group_fallback_peers", 0)
+        members = rows(data, "bgp_update_group_members", 1)
+        if set(members[0][0]) != {"group"}: raise ValueError("group member labels invalid")
+        group = members[0][0].get("group")
+        ids = {value for _, value in peer_groups}
+        group_id = next(iter(ids)) if len(ids) == 1 else math.nan
+        if members[0][1] != peers or not math.isfinite(group_id) or group_id < 0 or group_id != int(group_id) or group != str(int(group_id)):
+            raise ValueError("grouped leg must have exactly one complete shared nonnegative group")
+    if allocator:
+        names = ("jemalloc_allocated_bytes", "jemalloc_active_bytes",
+                 "jemalloc_resident_bytes", "jemalloc_mapped_bytes")
+        values = [singleton(data, name) for name in names]
+        if any(value <= 0 or value != int(value) for value in values):
+            raise ValueError("allocator gauges must be unique positive numeric samples")
+        if values[0] > values[1]: raise ValueError("jemalloc allocated exceeds active")
+stable = lambda data: sorted(
+    (name, tuple(sorted(labels.items())), value)
+    for name, found in data.items()
+    if name.startswith("bgp_rib_") and name.endswith("_prefixes")
+       or name in {"bgp_update_groups", "bgp_update_group_members",
+                   "bgp_update_group_fallback_peers", "bgp_peer_update_group"}
+    for labels, value in found)
+if not stable(scrapes[0]) or stable(scrapes[0]) != stable(scrapes[1]) or stable(scrapes[1]) != stable(scrapes[2]):
+    raise SystemExit("route/group gauges were not stable for three consecutive scrapes")
+PY
+}
+
+validate_evidence() {
+    python3 - "$@" <<'PY'
+import datetime, math, pathlib, re, sys
+root, expected_pid, expected_start = pathlib.Path(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3])
+required = ["timestamps.tsv", "metrics-1.prom", "metrics-2.prom", "metrics-3.prom",
+            "root.status", "root.smaps_rollup", "roster-before.tsv", "roster-after.tsv"]
+for name in required:
+    path = root / name
+    if not path.is_file() or path.stat().st_size == 0: raise SystemExit(f"partial evidence: {name}")
+timestamps = [line.split('\t') for line in (root/"timestamps.tsv").read_text().splitlines()]
+if timestamps[0] != ["phase", "monotonic", "utc"] or [row[0] for row in timestamps[1:]] != ["start","scrape1","scrape2","scrape3","capture_end"] or any(len(row) != 3 for row in timestamps):
+    raise SystemExit("measurement timestamps do not contain exactly one accepted capture")
+mono = [float(row[1]) for row in timestamps[1:]]
+utc = [datetime.datetime.strptime(row[2], "%Y-%m-%dT%H:%M:%SZ") for row in timestamps[1:]]
+if not all(math.isfinite(value) for value in mono) or not all(left < right for left, right in zip(mono, mono[1:])) or mono[2]-mono[1] < 1 or mono[3]-mono[2] < 1 or any(left > right for left, right in zip(utc, utc[1:])):
+    raise SystemExit("measurement timestamps are invalid, unordered, or under 1s scrape cadence")
+for name, field in [("root.status", "VmRSS"), ("root.smaps_rollup", "Rss")]:
+    if not re.search(rf"^{field}:\s+[1-9][0-9]*\s+kB$", (root/name).read_text(), re.M):
+        raise SystemExit(f"{name}: missing numeric {field}")
+def roster(name):
+    lines = (root/name).read_text().splitlines()
+    if lines[0] != "pid\tppid\tstarttime\trss_kib\ttree_rss_kib": raise SystemExit("bad roster header")
+    rows = [line.split('\t') for line in lines[1:]]
+    if not rows or any(len(row) != 5 or not all(value.isdigit() for value in row) for row in rows):
+        raise SystemExit("partial PID/RSS/tree roster")
+    parsed = {int(row[0]): tuple(map(int, row[1:])) for row in rows}
+    if len(parsed) != len(rows) or expected_pid not in parsed or parsed[expected_pid][1] != expected_start:
+        raise SystemExit("duplicate or missing root PID/starttime")
+    if len({row[4] for row in rows}) != 1 or any(int(row[3]) <= 0 for row in rows) or int(rows[0][4]) != sum(int(row[3]) for row in rows):
+        raise SystemExit("invalid per-PID or tree RSS")
+    for pid, (ppid, _, _, _) in parsed.items():
+        seen = set()
+        while pid != expected_pid:
+            if pid in seen or pid not in parsed: raise SystemExit("disconnected/cyclic process tree")
+            seen.add(pid); pid = parsed[pid][0]
+    return {(pid, values[1]) for pid, values in parsed.items()}
+if roster("roster-before.tsv") != roster("roster-after.tsv"):
+    raise SystemExit("PID liveness/identity changed during evidence capture")
+PY
+}
+
+capture_roster() {
+    python3 - "$1" "$2" <<'PY'
+import pathlib, re, sys
+root, output = int(sys.argv[1]), pathlib.Path(sys.argv[2])
+rows = {}
+for path in pathlib.Path('/proc').glob('[0-9]*/stat'):
+    try:
+        text = path.read_text(); pid = int(path.parent.name); tail = text[text.rfind(')')+2:].split()
+        status = path.with_name('status').read_text()
+        rss = int(re.search(r'^VmRSS:\s+([0-9]+)\s+kB$', status, re.M).group(1))
+        rows[pid] = (int(tail[1]), int(tail[19]), rss)
+    except (OSError, AttributeError, ValueError): pass
+if root not in rows: raise SystemExit("root process disappeared")
+selected = {root}
+while True:
+    added = {pid for pid, (ppid, _, _) in rows.items() if ppid in selected} - selected
+    if not added: break
+    selected |= added
+tree = sum(rows[pid][2] for pid in selected)
+with output.open('w') as stream:
+    stream.write('pid\tppid\tstarttime\trss_kib\ttree_rss_kib\n')
+    for pid in sorted(selected):
+        ppid, start, rss = rows[pid]; stream.write(f'{pid}\t{ppid}\t{start}\t{rss}\t{tree}\n')
+PY
+}
+
+terminate_group() {
+    local pid=${1:-} attempt
+    [[ -n $pid ]] || return 0
+    kill -TERM -- "-$pid" 2>/dev/null || true
+    for ((attempt=0; attempt<100; attempt++)); do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
+    kill -KILL -- "-$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+}
+
+validate_dhat() {
+    local raw=$1 out=$2 injected=${3:-}
+    mkdir -p "$out"
+    if [[ -n $injected ]]; then
+        python3 "$CLASSIFIER" "$raw" --output "$out/classified.tsv" --derivative "$out/raw-derivative.tsv" || return
+        cp "$injected" "$out/derivative.tsv"
+    else
+        python3 "$CLASSIFIER" "$raw" --output "$out/classified.tsv" --derivative "$out/derivative.tsv" || return
+    fi
+    python3 "$CLASSIFIER" --from-derivative "$out/derivative.tsv" --output "$out/reclassified.tsv" || return
+    cmp -s "$out/classified.tsv" "$out/reclassified.tsv" || return 1
+    awk -F '\t' '$1=="TOTAL" {ok=($2 ~ /^[0-9]+$/ && $2>0)} END{exit !ok}' "$out/classified.tsv"
+}
+
+expect_reject() {
+    local name=$1; shift
+    if "$@" >/dev/null 2>&1; then echo "red-proof $name unexpectedly accepted" >&2; return 1; fi
+    echo "red-proof $name=pass"
+}
+
+self_test() (
+    local tmp fixture=$REPO/bench/scale/rebaseline/fixtures/dhat.json
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    validate_protocol "${PROTOCOL[@]}" || return
+    expect_reject leg-reordered validate_protocol private grouped private grouped
+    expect_reject leg-omitted validate_protocol private grouped grouped
+    python3 - "$GEN" "$tmp" <<'PY'
+import importlib.util, json, pathlib, subprocess, sys
+gen, root = sys.argv[1], pathlib.Path(sys.argv[2]); spec = importlib.util.spec_from_file_location("gen", gen)
+module = importlib.util.module_from_spec(spec); spec.loader.exec_module(module)
+assert module.context_doc([], "a", True, False)["cfg"] == module.context_doc([], "a", False, False)["cfg"] | {"path_hiding": True}
+assert module.context_doc([], "a", False, False)["cfg"]["path_hiding"] is False
+assert module.context_doc([], "a", True, False)["cfg"]["add_path"] is False
+for value in ("true", "false"):
+    out = root/value
+    subprocess.run([sys.executable, gen, "bird", "8", "8", str(out), "--min-list", "1", "--max-list", "1", "--path-hiding", value], check=True, stdout=subprocess.DEVNULL)
+first, second = [json.loads((root/value/"manifest.json").read_text()) for value in ("true", "false")]
+assert first["path_hiding"] is None and second["path_hiding"] is None
+assert first["path_hiding_requested"] is True and second["path_hiding_requested"] is False
+assert first["path_hiding_applicable"] is False and second["path_hiding_applicable"] is False
+assert first["dataset_sha256"] == second["dataset_sha256"]
+out = root/"no-churn"
+subprocess.run([sys.executable, gen, "bird", "8", "8", str(out), "--min-list", "1", "--max-list", "1", "--admit-churn", "false"], check=True, stdout=subprocess.DEVNULL)
+third = json.loads((out/"manifest.json").read_text())
+assert third["admit_churn"] is False and third["dataset_sha256"] == first["dataset_sha256"]
+PY
+    echo "red-proof path-hiding-mapping-and-hash=pass"
+    python3 - "$tmp" <<'PY'
+import pathlib, sys
+root=pathlib.Path(sys.argv[1])
+def metrics(mode, bad=None, step=0):
+    lines=["bgp_rib_outbound_registered_peers 2e0 -3982045", "bgp_rib_ingest_channel_depth 0",
+           "bgp_rib_policy_transition_in_progress 0", f"bgp_rib_loc_prefixes{{afi_safi=\"all\"}} {'NaN' if bad=='nonfinite' else 7 if bad=='wrong-routes' else 8}"]
+    for n in range(2):
+        peer = "p0" if bad=="duplicate-peer" and n==1 else f"p{n}"
+        queue_labels = f'peer="{peer}"'
+        if bad=="duplicate-label" and n==0: queue_labels += f',peer="{peer}"'
+        if bad in ("malformed-label","malformed-escape") and n==0: queue_labels = f"peer={peer}" if bad=="malformed-label" else rf'peer="{peer}\q"'
+        if bad=="unexpected-label" and n==0: queue_labels += ',extra="x"'
+        if bad=="missing-label" and n==0: queue_labels = 'extra="x"'
+        lines += [rf'bgp_peer_session_established{{interface="ether\\net\n\"quoted\"",peer="p{n}"}} 1e0 +123',
+                  f'bgp_peer_outbound_queue_depth{{{queue_labels}}} {1 if bad=="queue" and n==1 else 0}']
+        lines += [f'bgp_rib_prefixes{{afi_safi="{family}",peer="p{n}"}} {4 if family=="all" else int(bad=="family" and n==1)}' for family in ("all","flowspec")]
+        lines += [f'bgp_rib_adj_out_prefixes{{afi_safi="{family}",peer="p{n}"}} {4 if family=="all" else int(bad=="adj-out-family" and n==1 and family=="vpn")}' for family in ("all","bgpls","evpn","flowspec","labeled","rtc","vpn")]
+    if mode=="private":
+        lines += ["bgp_update_groups 0", "bgp_update_group_fallback_peers 2"]
+        lines += [f'bgp_peer_update_group{{peer="p{n}"}} -1' for n in range(2)]
+    else:
+        lines += [f"bgp_update_groups {2 if bad=='group' else 1}", "bgp_update_group_fallback_peers 0",
+                  'bgp_update_group_members{group="7"} 2']
+        lines += [f'bgp_peer_update_group{{peer="p{n}"}} {7.5 if bad=="fractional-group" else 7}' for n in range(2)]
+    alloc=[1000,1000,1400,1600]
+    if bad!="missing-allocator":
+        lines += [f"{name} {value}" for name,value in zip(("jemalloc_allocated_bytes","jemalloc_active_bytes","jemalloc_resident_bytes","jemalloc_mapped_bytes"),alloc)]
+    if bad=="allocator-conflation": lines += ["jemalloc_allocated_bytes 999"]
+    if bad=="unstable" and step==2: lines[3]=lines[3].replace(" 8", " 9")
+    return "\n".join(lines)+"\n"
+for case,mode,bad in [("good-private","private",None),("good-grouped","grouped",None),
+                      ("bad-group","grouped","group"),("bad-queue","private","queue"),
+                      ("wrong-routes","private","wrong-routes"),("nonfinite","private","nonfinite"),("bad-family","private","family"),("bad-adj-out-family","private","adj-out-family"),
+                      ("duplicate-label","private","duplicate-label"),("malformed-label","private","malformed-label"),("malformed-escape","private","malformed-escape"),
+                      ("unexpected-label","private","unexpected-label"),("missing-label","private","missing-label"),
+                      ("duplicate-peer","private","duplicate-peer"),
+                      ("fractional-group","grouped","fractional-group"),("bad-allocator","private","allocator-conflation"),
+                      ("missing-allocator","private","missing-allocator"),
+                      ("unstable","private","unstable")]:
+    d=root/case; d.mkdir(); (d/"config.toml").write_text(("per_client_best = true\n"*2) if mode=="private" else "")
+    for step in range(3): (d/f"metrics-{step+1}.prom").write_text(metrics(mode,bad,step))
+e=root/"evidence"; e.mkdir()
+for name,text in [("timestamps.tsv","phase\tmonotonic\tutc\nstart\t0\t2026-01-01T00:00:00Z\nscrape1\t1\t2026-01-01T00:00:01Z\nscrape2\t2\t2026-01-01T00:00:02Z\nscrape3\t3\t2026-01-01T00:00:03Z\ncapture_end\t4\t2026-01-01T00:00:04Z\n"),
+                  ("root.status","VmRSS:\t10 kB\n"),("root.smaps_rollup","Rss:\t10 kB\n")]: (e/name).write_text(text)
+for step in range(3): (e/f"metrics-{step+1}.prom").write_text(metrics("private"))
+roster="pid\tppid\tstarttime\trss_kib\ttree_rss_kib\n10\t1\t100\t10\t10\n"
+(e/"roster-before.tsv").write_text(roster); (e/"roster-after.tsv").write_text(roster)
+PY
+    local d
+    for d in good-private good-grouped; do validate_scrapes "${d#good-}" 2 8 true "$tmp/$d/config.toml" "$tmp/$d"/metrics-{1,2,3}.prom; done; echo "positive-proof prometheus-syntax=pass"
+    expect_reject group-enforcement validate_scrapes grouped 2 8 true "$tmp/bad-group/config.toml" "$tmp/bad-group"/metrics-{1,2,3}.prom
+    expect_reject queue-enforcement validate_scrapes private 2 8 true "$tmp/bad-queue/config.toml" "$tmp/bad-queue"/metrics-{1,2,3}.prom
+    expect_reject route-count-enforcement validate_scrapes private 2 8 true "$tmp/wrong-routes/config.toml" "$tmp/wrong-routes"/metrics-{1,2,3}.prom
+    expect_reject metric-parser-nonfinite validate_scrapes private 2 8 true "$tmp/nonfinite/config.toml" "$tmp/nonfinite"/metrics-{1,2,3}.prom
+    expect_reject route-family-enforcement validate_scrapes private 2 8 true "$tmp/bad-family/config.toml" "$tmp/bad-family"/metrics-{1,2,3}.prom
+    expect_reject adj-out-family-enforcement validate_scrapes private 2 8 true "$tmp/bad-adj-out-family/config.toml" "$tmp/bad-adj-out-family"/metrics-{1,2,3}.prom
+    for d in duplicate-label malformed-label malformed-escape unexpected-label missing-label duplicate-peer; do expect_reject "metric-parser-$d" validate_scrapes private 2 8 true "$tmp/$d/config.toml" "$tmp/$d"/metrics-{1,2,3}.prom; done
+    expect_reject fractional-group validate_scrapes grouped 2 8 true "$tmp/fractional-group/config.toml" "$tmp/fractional-group"/metrics-{1,2,3}.prom
+    expect_reject three-scrape-stability validate_scrapes private 2 8 true "$tmp/unstable/config.toml" "$tmp/unstable"/metrics-{1,2,3}.prom
+    expect_reject allocator-conflation validate_scrapes private 2 8 true "$tmp/bad-allocator/config.toml" "$tmp/bad-allocator"/metrics-{1,2,3}.prom
+    expect_reject allocator-omission validate_scrapes private 2 8 true "$tmp/missing-allocator/config.toml" "$tmp/missing-allocator"/metrics-{1,2,3}.prom
+    validate_evidence "$tmp/evidence" 10 100
+    cp -a "$tmp/evidence" "$tmp/pid-reuse"; sed -i 's/\t100\t/\t101\t/' "$tmp/pid-reuse/roster-after.tsv"
+    expect_reject pid-reuse validate_evidence "$tmp/pid-reuse" 10 100
+    cp -a "$tmp/evidence" "$tmp/proc-missing"; rm "$tmp/proc-missing/root.smaps_rollup"
+    expect_reject proc-omission validate_evidence "$tmp/proc-missing" 10 100
+    cp -a "$tmp/evidence" "$tmp/tree-missing"; sed -i 's/\t10$//' "$tmp/tree-missing/roster-after.tsv"
+    expect_reject tree-rss-omission validate_evidence "$tmp/tree-missing" 10 100
+    cp -a "$tmp/evidence" "$tmp/retry-timestamps"; sed -i '3p' "$tmp/retry-timestamps/timestamps.tsv"; expect_reject timestamp-retry-accumulation validate_evidence "$tmp/retry-timestamps" 10 100
+    cp -a "$tmp/evidence" "$tmp/short-cadence"; sed -i 's/scrape2\t2/scrape2\t1.5/' "$tmp/short-cadence/timestamps.tsv"; expect_reject timestamp-cadence validate_evidence "$tmp/short-cadence" 10 100
+    cp -a "$tmp/evidence" "$tmp/reversed-time"; sed -i 's/capture_end\t4/capture_end\t2.5/' "$tmp/reversed-time/timestamps.tsv"; expect_reject timestamp-order-reversal validate_evidence "$tmp/reversed-time" 10 100
+    cp -a "$tmp/evidence" "$tmp/root-omitted"; sed -i '2,$d' "$tmp/root-omitted"/roster-{before,after}.tsv; expect_reject roster-root-omission validate_evidence "$tmp/root-omitted" 10 100
+    cp -a "$tmp/evidence" "$tmp/root-replaced"; sed -i 's/^10\t/11\t/' "$tmp/root-replaced"/roster-{before,after}.tsv; expect_reject roster-root-replacement validate_evidence "$tmp/root-replaced" 10 100
+    cp -a "$tmp/evidence" "$tmp/duplicate-roster"; duplicate=$(tail -n1 "$tmp/duplicate-roster/roster-before.tsv"); printf '%s\n' "$duplicate" >>"$tmp/duplicate-roster/roster-before.tsv"; expect_reject roster-duplicate validate_evidence "$tmp/duplicate-roster" 10 100
+    cp -a "$tmp/evidence" "$tmp/bad-tree"; sed -i 's/\t10$/\t11/' "$tmp/bad-tree/roster-before.tsv"; expect_reject roster-tree-sum validate_evidence "$tmp/bad-tree" 10 100
+    cp -a "$tmp/evidence" "$tmp/disconnected"; printf '11\t99\t101\t10\t20\n' >>"$tmp/disconnected/roster-before.tsv"; sed -i 's/\t10$/\t20/' "$tmp/disconnected/roster-before.tsv"; expect_reject roster-disconnected validate_evidence "$tmp/disconnected" 10 100
+    validate_dhat "$fixture" "$tmp/dhat-good"
+    jq '.pps |= map(.gb=0)' "$fixture" >"$tmp/dhat-zero.json"
+    expect_reject dhat-zero-live validate_dhat "$tmp/dhat-zero.json" "$tmp/dhat-zero"
+    jq '.pps[0].gb=1 | .pps[0].fs=[]' "$fixture" >"$tmp/dhat-unsymbolized.json"
+    expect_reject dhat-unsymbolized validate_dhat "$tmp/dhat-unsymbolized.json" "$tmp/dhat-unsymbolized"
+    jq '.pps |= map(if .gb > 0 then .gb += 1 else . end)' "$fixture" >"$tmp/dhat-mismatch.json"
+    python3 "$CLASSIFIER" "$tmp/dhat-mismatch.json" --output "$tmp/dhat-mismatch.tsv" --derivative "$tmp/dhat-bad.tsv"
+    expect_reject dhat-raw-derivative-mismatch validate_dhat "$fixture" "$tmp/dhat-mismatch-check" "$tmp/dhat-bad.tsv"
+    for rejection in metrics-port-fixed:METRICS_PORT:9180 port-positive:PORT:0 port-range:PORT:65536 timeout-numeric:START_TIMEOUT:no timeout-positive:START_TIMEOUT:0 start-timeout-cap:START_TIMEOUT:121 settle-timeout-cap:SETTLE_TIMEOUT:11 leg-timeout-cap:LEG_TIMEOUT:901; do
+        IFS=: read -r proof knob invalid <<<"$rejection"
+        if env SELF_TEST= MODE=smoke DRY_RUN_PROTOCOL=1 "$knob=$invalid" bash "$0" >/dev/null 2>&1; then die "red fixture accepted: $proof"; fi; printf 'red-proof %s=pass\n' "$proof"
+    done
+    echo "SELF_TEST pass"
+)
+
+if [[ ${SELF_TEST:-0} == 1 ]]; then self_test; exit; fi
+
+case ${MODE:-} in
+smoke) N_MEMBERS=${N_MEMBERS:-8}; TOTAL_PREFIXES=${TOTAL_PREFIXES:-800}; MIN_LIST=${MIN_LIST:-100}; MAX_LIST=${MAX_LIST:-100}
+       ((N_MEMBERS <= 16 && TOTAL_PREFIXES <= 1600 && MAX_LIST <= 200)) || die "smoke shape exceeds bounded ceiling" ;;
+dhat)  N_MEMBERS=${N_MEMBERS:-8}; TOTAL_PREFIXES=${TOTAL_PREFIXES:-800}; MIN_LIST=${MIN_LIST:-100}; MAX_LIST=${MAX_LIST:-100}
+       ((N_MEMBERS <= 16 && TOTAL_PREFIXES <= 1600 && MAX_LIST <= 200)) || die "DHAT shape exceeds bounded ceiling" ;;
+full)  [[ ${FULL_SHAPE:-0} == 1 ]] || die "MODE=full requires FULL_SHAPE=1"
+       N_MEMBERS=${N_MEMBERS:-320}; TOTAL_PREFIXES=${TOTAL_PREFIXES:-183040}; MIN_LIST=${MIN_LIST:-1000}; MAX_LIST=${MAX_LIST:-40000}
+       [[ $N_MEMBERS == 320 && $TOTAL_PREFIXES == 183040 && $MIN_LIST == 1000 && $MAX_LIST == 40000 ]] || die "full mode requires canonical shape 320,183040,1000,40000" ;;
+*) echo "set MODE=smoke, MODE=dhat, or MODE=full FULL_SHAPE=1" >&2; exit 2 ;;
+esac
+if ! uint "$N_MEMBERS" || ! uint "$TOTAL_PREFIXES" || ! uint "$MIN_LIST" || ! uint "$MAX_LIST"; then
+    die "shape values must be integers"
+fi
+for value in "$PORT" "$METRICS_PORT" "$START_TIMEOUT" "$SETTLE_TIMEOUT" "$LEG_TIMEOUT"; do if ! uint "$value" || ((value <= 0)); then die "ports/timeouts must be positive integers"; fi; done
+if ((PORT > 65535)) || [[ $METRICS_PORT != 9179 ]]; then die "daemon port must fit u16 and metrics port is fixed at 9179"; fi
+((N_MEMBERS >= 8 && TOTAL_PREFIXES % N_MEMBERS == 0 && MIN_LIST >= 1 && MIN_LIST <= MAX_LIST)) || die "shape violates generator contract"
+((SETTLE_TIMEOUT <= 10)) || die "settle timeout exceeds reloadstall's bounded evidence handshake"
+[[ $MODE == full ]] || ((START_TIMEOUT <= 120 && SETTLE_TIMEOUT <= 10 && LEG_TIMEOUT <= 900)) || die "bounded mode timeout ceiling exceeded"
+validate_protocol "${PROTOCOL[@]}" || die "protocol order invalid"
+if [[ ${DRY_RUN_PROTOCOL:-0} == 1 ]]; then
+    printf 'mode=%s\nprotocol=%s\npath_hiding=%s\nadmit_churn=false\nshape=%s,%s,%s,%s\nports=%s,9179\ntimeouts=%s,%s,%s\nrss_abort_gib=100\n' \
+        "$MODE" "$(IFS=,; echo "${PROTOCOL[*]}")" "$(IFS=,; echo "${PATH_HIDING[*]}")" \
+        "$N_MEMBERS" "$TOTAL_PREFIXES" "$MIN_LIST" "$MAX_LIST" "$PORT" "$START_TIMEOUT" "$SETTLE_TIMEOUT" "$LEG_TIMEOUT"
+    exit
+fi
+
+[[ -n ${ARTIFACT_ROOT:-} && ! -e $ARTIFACT_ROOT ]] || die "ARTIFACT_ROOT must name a fresh path"
+for tool in cargo curl flock git jq python3 setsid sha256sum ss timeout; do command -v "$tool" >/dev/null || die "missing tool: $tool"; done
+mkdir -p "$(dirname "$ARTIFACT_ROOT")"
+umask 077; mkdir "$ARTIFACT_ROOT"; ART=$(cd "$ARTIFACT_ROOT" && pwd)
+if [[ $MODE == full ]]; then "$REPO/tests/soak/preflight.sh" >"$ART/full-preflight.log" 2>&1 || exit 75; fi
+LOCK=${RUSTBGPD_HOST_LOCK:-$HOME/.local/state/rustbgpd-host.lock}; mkdir -p "$(dirname "$LOCK")"; exec {LOCK_FD}>"$LOCK"
+flock -n "$LOCK_FD" || exit 75
+COMMIT=$(git -C "$REPO" rev-parse HEAD)
+dirty_hash() {
+    (cd "$REPO" && {
+        git status --porcelain=v1 -z
+        git diff --binary HEAD --
+        git ls-files --others --exclude-standard -z | while IFS= read -r -d '' path; do
+            printf 'untracked %s\0' "$path"; sha256sum -- "$path"
+        done
+    }) | sha256sum | awk '{print $1}'
+}
+DIRTY_STATE_SHA256=$(dirty_hash)
+printf 'phase\tmonotonic\tutc\tload1\tmem_available_kib\tports_free\n' >"$ART/preflight.tsv"
+ports_free=true; ss -H -ltn | awk -v a=":$PORT" -v b=":$METRICS_PORT" '$4~a"$"||$4~b"$"{found=1} END{exit found?0:1}' && ports_free=false
+printf 'prebuild\t%s\t%s\t%s\t%s\t%s\n' "$(monotonic)" "$(date -u +%FT%TZ)" "$(awk '{print $1}' /proc/loadavg)" \
+    "$(awk '$1=="MemAvailable:"{print $2}' /proc/meminfo)" "$ports_free" >>"$ART/preflight.tsv"
+[[ $ports_free == true ]] || die "benchmark ports are in use"
+PROFILE=release; BUILD_FEATURES=(); [[ $MODE != dhat ]] || { PROFILE=release-prof; BUILD_FEATURES=(--features dhat-heap); }
+(cd "$REPO" && cargo build --locked --profile "$PROFILE" -p rustbgpd -p rs-config-render "${BUILD_FEATURES[@]}") >"$ART/build.log" 2>&1
+(cd "$REPO" && cargo build --locked --release --manifest-path bench/scale/reloadstall/Cargo.toml) >>"$ART/build.log" 2>&1
+DAEMON=$REPO/target/$PROFILE/rustbgpd; RENDER=$REPO/target/$PROFILE/rs-config-render
+HARNESS=$REPO/bench/scale/reloadstall/target/release/reloadstall
+for binary in "$DAEMON" "$RENDER" "$HARNESS"; do [[ -x $binary ]] || die "missing binary: $binary"; done
+printf 'script %s\ngenerator %s\nclassifier %s\ndaemon %s\nrenderer %s\nharness %s\n' \
+    "$(hash_file "${BASH_SOURCE[0]}")" "$(hash_file "$GEN")" "$(hash_file "$CLASSIFIER")" \
+    "$(hash_file "$DAEMON")" "$(hash_file "$RENDER")" "$(hash_file "$HARNESS")" >"$ART/hashes.txt"
+{ rustc -vV; cargo -V; python3 --version; jq --version; } >"$ART/tools.txt" 2>&1
+printf '%q ' "$0" "$@" >"$ART/argv.txt"; printf '\n' >>"$ART/argv.txt"
+
+ACTIVE_DAEMON='' ACTIVE_HARNESS='' ACTIVE_GUARD='' RUN_DIR=''
+cleanup() { local rc=$?; trap - EXIT; terminate_group "$ACTIVE_HARNESS"; terminate_group "$ACTIVE_DAEMON"; [[ -z $ACTIVE_GUARD ]] || kill "$ACTIVE_GUARD" 2>/dev/null || true; [[ -z $RUN_DIR ]] || rm -rf "$RUN_DIR"; exit "$rc"; }
+trap cleanup EXIT; trap 'exit 130' INT; trap 'exit 143' TERM
+
+rss_guard() {
+    local root=$1 start=$2 harness=$3 out=$4 rss
+    printf 'monotonic\tutc\ttree_rss_kib\n' >"$out"
+    while kill -0 "$root" 2>/dev/null && kill -0 "$harness" 2>/dev/null; do
+        [[ $(awk '{print $22}' "/proc/$root/stat" 2>/dev/null) == "$start" ]] || { touch "$out.identity-abort"; break; }
+        rss=$(ps -eo pid=,ppid=,rss= | awk -v root="$root" '{p[$1]=$2;r[$1]=$3} END{for(i in p){x=i;while(x in p&&x!=root&&p[x]!=x)x=p[x];if(x==root)s+=r[i]}print s+0}')
+        printf '%s\t%s\t%s\n' "$(monotonic)" "$(date -u +%FT%TZ)" "$rss" >>"$out"
+        if ((rss > RSS_LIMIT_KIB)); then touch "$out.rss-abort"; kill -TERM -- "-$harness" "-$root" 2>/dev/null || true; break; fi
+        sleep 1
+    done
+}
+
+DATASET=''
+run_leg() {
+    local number=$1 mode=$2 hiding=$3 label ldir start deadline accepted=0 hrc allocator=true
+    label=$(printf '%02d-%s' "$number" "$mode"); ldir=$ART/$label; mkdir "$ldir"
+    RUN_DIR=$(mktemp -d "/tmp/lan789-${number}.XXXXXX")
+    python3 "$GEN" rustbgpd "$N_MEMBERS" "$TOTAL_PREFIXES" "$RUN_DIR" --render-bin "$RENDER" \
+        --port "$PORT" --seed 61 --min-list "$MIN_LIST" --max-list "$MAX_LIST" --path-hiding "$hiding" \
+        --admit-churn false >"$ldir/generator.log"
+    cp "$RUN_DIR/manifest.json" "$ldir/manifest.json"
+    [[ $(jq -r .path_hiding "$RUN_DIR/manifest.json") == "$hiding" ]] || die "$label path-hiding manifest mismatch"
+    [[ $(jq -r .admit_churn "$RUN_DIR/manifest.json") == false ]] || die "$label churn policy mismatch"
+    local digest; digest=$(jq -er .dataset_sha256 "$RUN_DIR/manifest.json")
+    [[ -z $DATASET || $DATASET == "$digest" ]] || die "private/grouped dataset digests differ"
+    DATASET=$digest
+    (cd "$RUN_DIR" && jq -r '.runtime_files[]' manifest.json | while read -r path; do sha256sum "$path"; done) >"$ldir/scenario.sha256"
+    "$DAEMON" --check "$RUN_DIR/config.toml" >"$ldir/daemon-check.log" 2>&1
+    (cd "$ldir" && exec setsid "$DAEMON" "$RUN_DIR/config.toml") >"$ldir/daemon.log" 2>&1 & ACTIVE_DAEMON=$!
+    start=$(awk '{print $22}' "/proc/$ACTIVE_DAEMON/stat"); deadline=$((SECONDS + START_TIMEOUT))
+    until curl -fsS --max-time 1 "http://127.0.0.1:$METRICS_PORT/readyz" >/dev/null 2>&1; do
+        kill -0 "$ACTIVE_DAEMON" 2>/dev/null || die "$label daemon exited"; ((SECONDS < deadline)) || die "$label startup timeout"; sleep 1
+    done
+    mkdir "$RUN_DIR/final-evidence"
+    setsid timeout -k 10 "${LEG_TIMEOUT}s" env RELOADSTALL_EVIDENCE_DIR="$RUN_DIR/final-evidence" \
+        "$HARNESS" "$N_MEMBERS" "$TOTAL_PREFIXES" "$PORT" "$ACTIVE_DAEMON" "$RUN_DIR/member.rpol" \
+        "$RUN_DIR/gen-a.rpol" "$RUN_DIR/gen-b.rpol" 0 3 "$N_MEMBERS" >"$ldir/reloadstall.log" 2>&1 & ACTIVE_HARNESS=$!
+    rss_guard "$ACTIVE_DAEMON" "$start" "$ACTIVE_HARNESS" "$ldir/rss.tsv" & ACTIVE_GUARD=$!
+    deadline=$((SECONDS + LEG_TIMEOUT))
+    until [[ -e $RUN_DIR/final-evidence/ready ]]; do
+        kill -0 "$ACTIVE_HARNESS" 2>/dev/null || die "$label harness exited before evidence"; ((SECONDS < deadline)) || die "$label evidence timeout"; sleep 1
+    done
+    [[ $MODE == dhat ]] && allocator=false
+    deadline=$((SECONDS + SETTLE_TIMEOUT))
+    while ((SECONDS < deadline)); do
+        rm -f "$ldir"/metrics-{1,2,3}.prom; printf 'phase\tmonotonic\tutc\nstart\t%s\t%s\n' "$(monotonic)" "$(date -u +%FT%TZ)" >"$ldir/timestamps.tsv"
+        for sample in 1 2 3; do
+            curl -fsS --max-time 2 "http://127.0.0.1:$METRICS_PORT/metrics" >"$ldir/metrics-$sample.prom" || break
+            printf 'scrape%s\t%s\t%s\n' "$sample" "$(monotonic)" "$(date -u +%FT%TZ)" >>"$ldir/timestamps.tsv"
+            ((sample == 3)) || sleep 1
+        done
+        if validate_scrapes "$mode" "$N_MEMBERS" "$TOTAL_PREFIXES" "$allocator" "$RUN_DIR/config.toml" "$ldir"/metrics-{1,2,3}.prom 2>"$ldir/settle.error"; then accepted=1; break; fi
+        sleep 1
+    done
+    ((accepted == 1)) || { cat "$ldir/settle.error" >&2; die "$label did not quiesce"; }
+    capture_roster "$ACTIVE_DAEMON" "$ldir/roster-before.tsv"
+    cp "/proc/$ACTIVE_DAEMON/status" "$ldir/root.status"; cp "/proc/$ACTIVE_DAEMON/smaps_rollup" "$ldir/root.smaps_rollup"
+    capture_roster "$ACTIVE_DAEMON" "$ldir/roster-after.tsv"
+    printf 'capture_end\t%s\t%s\n' "$(monotonic)" "$(date -u +%FT%TZ)" >>"$ldir/timestamps.tsv"
+    validate_evidence "$ldir" "$ACTIVE_DAEMON" "$start"
+    touch "$RUN_DIR/final-evidence/ack"
+    set +e; wait "$ACTIVE_HARNESS"; hrc=$?; set -e; ACTIVE_HARNESS=''
+    [[ -z $ACTIVE_GUARD ]] || { wait "$ACTIVE_GUARD" || true; ACTIVE_GUARD=''; }
+    ((hrc == 0)) || die "$label harness failed ($hrc)"
+    [[ ! -e $ldir/rss.tsv.rss-abort && ! -e $ldir/rss.tsv.identity-abort ]] || die "$label RSS/identity guard aborted"
+    [[ $(awk '{print $22}' "/proc/$ACTIVE_DAEMON/stat" 2>/dev/null) == "$start" ]] || die "$label root PID identity changed"
+    terminate_group "$ACTIVE_DAEMON"; ACTIVE_DAEMON=''
+    if [[ $MODE == dhat ]]; then [[ -s $ldir/dhat-heap.json ]] || die "$label missing graceful DHAT JSON"; validate_dhat "$ldir/dhat-heap.json" "$ldir/dhat"; fi
+    (cd "$ldir" && find . -type f ! -name evidence.sha256 -print0 | sort -z | xargs -0 sha256sum) >"$ldir/evidence.sha256"
+    jq -n --argjson leg "$number" --arg mode "$mode" --argjson path_hiding "$hiding" --arg dataset "$digest" \
+        --arg scenario "$(hash_file "$ldir/scenario.sha256")" --arg evidence "$(hash_file "$ldir/evidence.sha256")" \
+        '{status:"pass",leg:$leg,mode:$mode,path_hiding:$path_hiding,add_path:false,admit_churn:false,dataset_sha256:$dataset,scenario_roster_sha256:$scenario,evidence_roster_sha256:$evidence}' >"$ldir/status.json"
+    rm -rf "$RUN_DIR"; RUN_DIR=''
+}
+
+for index in "${!PROTOCOL[@]}"; do run_leg "$((index+1))" "${PROTOCOL[index]}" "${PATH_HIDING[index]}"; done
+[[ $(git -C "$REPO" rev-parse HEAD) == "$COMMIT" && $(dirty_hash) == "$DIRTY_STATE_SHA256" ]] || die "source identity changed during campaign"
+jq -n --arg commit "$COMMIT" --arg dirty_state_sha256 "$DIRTY_STATE_SHA256" --arg mode "$MODE" \
+    --arg dataset_sha256 "$DATASET" --argjson members "$N_MEMBERS" --argjson total_prefixes "$TOTAL_PREFIXES" \
+    --argjson min_list "$MIN_LIST" --argjson max_list "$MAX_LIST" --argjson start_timeout "$START_TIMEOUT" \
+    --argjson settle_timeout "$SETTLE_TIMEOUT" --argjson leg_timeout "$LEG_TIMEOUT" --argjson daemon_port "$PORT" --argjson metrics_port "$METRICS_PORT" \
+    --argjson legs "$(jq -s '.' "$ART"/*/status.json)" \
+    '{commit:$commit,dirty_state_sha256:$dirty_state_sha256,mode:$mode,protocol:["private","grouped","grouped","private"],path_hiding:[true,false,false,true],add_path:false,admit_churn:false,ports:{daemon:$daemon_port,metrics:$metrics_port},shape:{members:$members,total_prefixes:$total_prefixes,min_list:$min_list,max_list:$max_list},timeouts_seconds:{start:$start_timeout,settle:$settle_timeout,leg:$leg_timeout},rss_abort_gib:100,dataset_sha256:$dataset_sha256,preflight:"pass",legs:$legs}' >"$ART/manifest.json"
+(cd "$ART" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum) >"$ART/SHA256SUMS"
+chmod -R a-w "$ART"; trap - EXIT
+echo "memory attribution artifact sealed read-only: $ART"

--- a/bench/scale/reloadstall/gen-irr-scenario.py
+++ b/bench/scale/reloadstall/gen-irr-scenario.py
@@ -33,7 +33,10 @@ Cells:
 
 The dataset is derived only from (n_members, total_prefixes, seed, list
 bounds, changed fraction) — never from the cell — so all four cells filter
-the SAME member/prefix data. Generation B replaces the first `delta` padding
+the SAME member/prefix data. Path-hiding and churn-admission are recorded
+emission modes, not canonical member-dataset inputs; disabling churn admission
+removes the harness's 172.16-23.x blocks from emitted policies only. Generation
+B replaces the first `delta` padding
 prefixes of each changed member's list with fresh ones (content-real,
 output-neutral: announced and churn prefixes are never touched) and swaps the
 export marker community 65400:1000 -> 65400:2000, which forces the full
@@ -48,7 +51,7 @@ Usage:
     gen-irr-scenario.py <cell> <n_members> <total_prefixes> <out_dir>
         [--port 1790] [--seed 61] [--min-list 1000] [--max-list 40000]
         [--changed-fraction 0.1] [--render-bin PATH] [--threads 8]
-        [--conf-dir DIR]
+        [--conf-dir DIR] [--path-hiding true|false] [--admit-churn true|false]
 
 Emits into <out_dir> (per cell):
   rustbgpd      config.toml, member.rpol (live, = gen-a), gen-a.rpol,
@@ -84,6 +87,7 @@ PADDING_SPACE = 70 * 65536
 # 172.16.0.0/12 is deliberately absent (churn range, see module docstring).
 BOGONS_V4 = ["10.0.0.0/8", "192.168.0.0/16"]
 MAX_AS_PATH_LEN = 32
+CHURN_PREFIX_STEMS = tuple(f"172.{16 + churner}." for churner in range(CHURNERS))
 
 
 def stub_addr(i: int) -> str:
@@ -120,6 +124,13 @@ class Member:
     @property
     def changed(self) -> bool:
         return self.list_a != self.list_b
+
+
+def policy_prefixes(member: Member, gen: str, admit_churn: bool) -> list[str]:
+    prefixes = member.prefixes(gen)
+    if admit_churn:
+        return prefixes
+    return [prefix for prefix in prefixes if not prefix.startswith(CHURN_PREFIX_STEMS)]
 
 
 def build_dataset(args) -> list[Member]:
@@ -171,6 +182,7 @@ def write_manifest(out: pathlib.Path, args, members, files: list[str]) -> None:
     dataset_digest = hashlib.sha256()
     for member in members:
         dataset_digest.update(canonical_member_record(member))
+    path_hiding_applicable = args.cell in ("rustbgpd", "rustbgpd-txn")
     manifest = {
         "cell": args.cell,
         "n_members": args.n_members,
@@ -179,9 +191,15 @@ def write_manifest(out: pathlib.Path, args, members, files: list[str]) -> None:
         "min_list": args.min_list,
         "max_list": args.max_list,
         "changed_fraction": args.changed_fraction,
+        "path_hiding": args.path_hiding if path_hiding_applicable else None,
+        "path_hiding_requested": args.path_hiding,
+        "path_hiding_applicable": path_hiding_applicable,
+        "admit_churn": args.admit_churn,
         "dataset_sha256": dataset_digest.hexdigest(),
-        "list_sizes": [len(m.list_a) for m in members],
-        "total_filter_entries": sum(len(m.list_a) for m in members),
+        "list_sizes": [len(policy_prefixes(m, "a", args.admit_churn)) for m in members],
+        "total_filter_entries": sum(
+            len(policy_prefixes(m, "a", args.admit_churn)) for m in members
+        ),
         "changed_members": [m.idx for m in members if m.changed],
         "runtime_files": files,
         "file_bytes": {f: (out / f).stat().st_size for f in files},
@@ -192,7 +210,9 @@ def write_manifest(out: pathlib.Path, args, members, files: list[str]) -> None:
 # --- rustbgpd (SIGHUP) cell -------------------------------------------------
 
 
-def context_doc(members: list[Member], gen: str) -> dict:
+def context_doc(
+    members: list[Member], gen: str, path_hiding: bool, admit_churn: bool
+) -> dict:
     """Synthetic `arouteserver template-context` single-document form.
 
     Modeled on tools/rs-config-render/tests/fixtures/context-small.yml (the
@@ -215,7 +235,7 @@ def context_doc(members: list[Member], gen: str) -> dict:
                     "length": int(p.split("/")[1]),
                     "exact": True,
                 }
-                for p in m.prefixes(gen)
+                for p in policy_prefixes(m, gen, admit_churn)
             ],
         }
         clients.append(
@@ -256,7 +276,7 @@ def context_doc(members: list[Member], gen: str) -> dict:
             "rs_as": RS_ASN,
             "router_id": "10.0.0.1",
             "prepend_rs_as": False,
-            "path_hiding": True,
+            "path_hiding": path_hiding,
             "passive": True,
             "gtsm": False,
             "multihop": None,
@@ -396,7 +416,9 @@ def emit_rustbgpd(args, members: list[Member], out: pathlib.Path) -> list[str]:
     check_sun_len(rundir)
     for gen in ("a", "b"):
         ctx = out / f"context-{gen}.json"
-        ctx.write_text(json.dumps(context_doc(members, gen)))
+        ctx.write_text(
+            json.dumps(context_doc(members, gen, args.path_hiding, args.admit_churn))
+        )
         render_dir = out / f"render-{gen}"
         subprocess.run(
             [
@@ -494,7 +516,7 @@ def txn_config(args, members: list[Member], gen: str, rundir: pathlib.Path) -> s
             f"[policy.definitions.m{m.idx}-prefixes]",
             'default_action = "deny"',
         ]
-        for p in m.prefixes(gen):
+        for p in policy_prefixes(m, gen, args.admit_churn):
             lines += [
                 f"[[policy.definitions.m{m.idx}-prefixes.statements]]",
                 'action = "permit"',
@@ -507,7 +529,7 @@ def txn_config(args, members: list[Member], gen: str, rundir: pathlib.Path) -> s
             f'address = "{m.addr}"',
             f"remote_asn = {m.asn}",
             "route_server_client = true",
-            "per_client_best = true",
+            *(["per_client_best = true"] if args.path_hiding else []),
             'families = ["ipv4_unicast"]',
             "hold_time = 180",
             f'import_policy_chain = ["irr-hygiene", "m{m.idx}-origin", "m{m.idx}-prefixes"]',
@@ -530,7 +552,7 @@ def emit_txn(args, members: list[Member], out: pathlib.Path) -> list[str]:
 # --- BIRD cell ---------------------------------------------------------------
 
 
-def bird_gen_conf(members: list[Member], gen: str) -> str:
+def bird_gen_conf(members: list[Member], gen: str, admit_churn: bool) -> str:
     out = [
         "# IRR reload-matrix policy generation - generated by gen-irr-scenario.py.",
         "# Swapped over gen.conf, then `birdc configure`. One prefix-set define +",
@@ -547,7 +569,7 @@ def bird_gen_conf(members: list[Member], gen: str) -> str:
         "",
     ]
     for m in members:
-        prefixes = m.prefixes(gen)
+        prefixes = policy_prefixes(m, gen, admit_churn)
         out.append(f"define M{m.idx}_PFX = [")
         for k in range(0, len(prefixes), 8):
             row = ", ".join(prefixes[k : k + 8])
@@ -569,7 +591,9 @@ def bird_gen_conf(members: list[Member], gen: str) -> str:
 def emit_bird(args, members: list[Member], out: pathlib.Path) -> list[str]:
     conf_dir = args.conf_dir or "/etc/bird"
     for gen in ("a", "b"):
-        (out / f"gen-{gen}.conf").write_text(bird_gen_conf(members, gen))
+        (out / f"gen-{gen}.conf").write_text(
+            bird_gen_conf(members, gen, args.admit_churn)
+        )
     (out / "gen.conf").write_text((out / "gen-a.conf").read_text())
     config = [
         "# IRR reload-matrix BIRD route server - generated by gen-irr-scenario.py.",
@@ -622,7 +646,7 @@ def emit_bird(args, members: list[Member], out: pathlib.Path) -> list[str]:
 # --- OpenBGPD cell -----------------------------------------------------------
 
 
-def obgpd_gen_conf(members: list[Member], gen: str) -> str:
+def obgpd_gen_conf(members: list[Member], gen: str, admit_churn: bool) -> str:
     out = [
         "# IRR reload-matrix policy generation - generated by gen-irr-scenario.py.",
         "# Swapped over gen.conf, then `bgpctl reload`. Prefix-sets first, then",
@@ -632,7 +656,7 @@ def obgpd_gen_conf(members: list[Member], gen: str) -> str:
         "",
     ]
     for m in members:
-        prefixes = m.prefixes(gen)
+        prefixes = policy_prefixes(m, gen, admit_churn)
         out.append(f"prefix-set ps{m.idx} {{")
         for k in range(0, len(prefixes), 8):
             out.append("\t" + " ".join(prefixes[k : k + 8]))
@@ -656,7 +680,9 @@ def obgpd_gen_conf(members: list[Member], gen: str) -> str:
 def emit_obgpd(args, members: list[Member], out: pathlib.Path) -> list[str]:
     conf_dir = args.conf_dir or "/etc/bgpd"
     for gen in ("a", "b"):
-        (out / f"gen-{gen}.conf").write_text(obgpd_gen_conf(members, gen))
+        (out / f"gen-{gen}.conf").write_text(
+            obgpd_gen_conf(members, gen, args.admit_churn)
+        )
     (out / "gen.conf").write_text((out / "gen-a.conf").read_text())
     config = [
         "# IRR reload-matrix OpenBGPD route server - generated by gen-irr-scenario.py.",
@@ -719,11 +745,25 @@ def main() -> None:
     parser.add_argument("--threads", type=int, default=8, help="BIRD threads knob")
     parser.add_argument("--conf-dir", help="config dir as seen by the running daemon")
     parser.add_argument(
+        "--path-hiding",
+        choices=("true", "false"),
+        default="true",
+        help="render per-client best-path mitigation (default: true)",
+    )
+    parser.add_argument(
+        "--admit-churn",
+        choices=("true", "false"),
+        default="true",
+        help="include harness churn blocks in emitted import policies (default: true)",
+    )
+    parser.add_argument(
         "--canonical-dataset-out",
         type=pathlib.Path,
         help="test/debug output: stream the exact cell-independent digest input",
     )
     args = parser.parse_args()
+    args.path_hiding = args.path_hiding == "true"
+    args.admit_churn = args.admit_churn == "true"
 
     if args.n_members < CHURNERS:
         sys.exit(f"n_members must be >= {CHURNERS} (harness churner contract)")
@@ -740,7 +780,7 @@ def main() -> None:
                 canonical.write(canonical_member_record(member))
     files = EMITTERS[args.cell](args, members, args.out_dir)
     write_manifest(args.out_dir, args, members, files)
-    total_entries = sum(len(m.list_a) for m in members)
+    total_entries = sum(len(policy_prefixes(m, "a", args.admit_churn)) for m in members)
     swapped = files[1]  # the live swap file in every cell's roster
     print(
         f"wrote {args.out_dir.resolve()} cell={args.cell} members={args.n_members} "

--- a/tests/reloadstall_scenario_emitted_check.rs
+++ b/tests/reloadstall_scenario_emitted_check.rs
@@ -661,6 +661,15 @@ fn irr_reload_manifest_seals_a_cell_independent_dataset_digest() {
             &std::fs::read(dir.path().join("manifest.json")).expect("read manifest"),
         )
         .expect("parse manifest");
+        let applicable = matches!(cell, "rustbgpd" | "rustbgpd-txn");
+        assert_eq!(manifest["path_hiding_applicable"], applicable);
+        assert_eq!(manifest["path_hiding_requested"], true);
+        let expected_path_hiding = serde_json::json!(applicable.then_some(true));
+        assert_eq!(manifest["path_hiding"], expected_path_hiding);
+        assert_eq!(
+            manifest["admit_churn"], true,
+            "default digest path admits churn"
+        );
         digests.push(
             manifest["dataset_sha256"]
                 .as_str()
@@ -731,4 +740,232 @@ fn irr_reload_manifest_seals_a_cell_independent_dataset_digest() {
     )
     .expect("parse manifest");
     assert_ne!(manifest["dataset_sha256"], digests[0]);
+}
+
+#[test]
+/// Red proof: reversing or omitting the path-hiding value changes the emitted
+/// context/config assertions; adding it to the canonical record changes the
+/// byte-for-byte canonical stream and dataset digest comparison.
+fn irr_memory_path_hiding_is_explicit_but_not_dataset_identity() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let generator = format!("{root}/bench/scale/reloadstall/gen-irr-scenario.py");
+    let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from(root).join("target"));
+    let renderer = target_dir.join("debug/rs-config-render");
+    assert!(
+        renderer.is_file(),
+        "build rs-config-render before this test"
+    );
+
+    let mut observations = Vec::new();
+    for (path_hiding, admit_churn) in [("true", "false"), ("false", "false"), ("true", "true")] {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let canonical = dir.path().join("canonical.jsonl");
+        let output = std::process::Command::new("python3")
+            .args([&generator, "rustbgpd", "8", "80"])
+            .arg(dir.path())
+            .args([
+                "--render-bin",
+                renderer.to_str().expect("renderer path"),
+                "--min-list",
+                "10",
+                "--max-list",
+                "10",
+                "--path-hiding",
+                path_hiding,
+                "--admit-churn",
+                admit_churn,
+                "--canonical-dataset-out",
+            ])
+            .arg(&canonical)
+            .output()
+            .expect("run generator");
+        assert!(
+            output.status.success(),
+            "generator failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let manifest: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(dir.path().join("manifest.json")).expect("manifest"),
+        )
+        .expect("manifest JSON");
+        let context: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(dir.path().join("context-a.json")).expect("context"),
+        )
+        .expect("context JSON");
+        let config = std::fs::read_to_string(dir.path().join("config.toml")).expect("config");
+        let expected = path_hiding == "true";
+        let expected_churn = admit_churn == "true";
+        let stdout = String::from_utf8(output.stdout).expect("generator stdout");
+        let effective_entries = if expected_churn { 208 } else { 80 };
+        assert!(stdout.contains(&format!("filter_entries={effective_entries}")));
+        assert_eq!(manifest["path_hiding"], expected);
+        assert_eq!(manifest["admit_churn"], expected_churn);
+        assert_eq!(context["cfg"]["path_hiding"], expected);
+        assert_eq!(context["cfg"]["add_path"], false);
+        assert_eq!(
+            config.matches("per_client_best = true").count(),
+            if expected { 8 } else { 0 }
+        );
+        assert!(!config.contains("[neighbors.add_path]"));
+        let policy = std::fs::read_to_string(dir.path().join("member.rpol")).expect("policy");
+        assert!(
+            policy.contains("20.0.0.0/24"),
+            "base prefix must remain admitted"
+        );
+        if expected_churn {
+            assert!(policy.contains("\n    172.16.0.0/24"));
+            assert_eq!(manifest["total_filter_entries"], 208);
+            assert!(
+                manifest["list_sizes"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .all(|size| size == 26)
+            );
+        } else {
+            assert!(
+                !policy.contains("\n    172."),
+                "all churn blocks must be rejected"
+            );
+            assert_eq!(manifest["total_filter_entries"], 80);
+            assert!(
+                manifest["list_sizes"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .all(|size| size == 10)
+            );
+        }
+        observations.push((
+            manifest["dataset_sha256"].as_str().unwrap().to_owned(),
+            std::fs::read(canonical).expect("canonical dataset"),
+        ));
+    }
+    assert!(observations.windows(2).all(|pair| pair[0] == pair[1]));
+}
+
+#[test]
+/// Fixture-backed red proofs execute the same semantic validators as a real
+/// run. Each corrupt fixture must be rejected independently; token presence
+/// alone cannot make this test pass.
+fn irr_memory_protocol_self_test_exercises_semantic_rejections() {
+    let runner = format!(
+        "{}/bench/scale/irrreload/run-memory-attribution.sh",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let output = std::process::Command::new("bash")
+        .arg(&runner)
+        .env("SELF_TEST", "1")
+        .env_remove("MODE")
+        .output()
+        .expect("run memory attribution self-test");
+    assert!(
+        output.status.success(),
+        "self-test failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 self-test output");
+    for proof in [
+        "leg-reordered",
+        "leg-omitted",
+        "path-hiding-mapping-and-hash",
+        "group-enforcement",
+        "queue-enforcement",
+        "route-count-enforcement",
+        "route-family-enforcement",
+        "adj-out-family-enforcement",
+        "metric-parser-duplicate-label",
+        "metric-parser-malformed-label",
+        "metric-parser-malformed-escape",
+        "metric-parser-nonfinite",
+        "metric-parser-unexpected-label",
+        "metric-parser-missing-label",
+        "metric-parser-duplicate-peer",
+        "fractional-group",
+        "three-scrape-stability",
+        "allocator-conflation",
+        "allocator-omission",
+        "pid-reuse",
+        "proc-omission",
+        "tree-rss-omission",
+        "timestamp-retry-accumulation",
+        "timestamp-cadence",
+        "timestamp-order-reversal",
+        "roster-duplicate",
+        "roster-root-omission",
+        "roster-root-replacement",
+        "roster-tree-sum",
+        "roster-disconnected",
+        "dhat-zero-live",
+        "dhat-unsymbolized",
+        "dhat-raw-derivative-mismatch",
+        "metrics-port-fixed",
+        "port-positive",
+        "port-range",
+        "timeout-numeric",
+        "timeout-positive",
+        "start-timeout-cap",
+        "settle-timeout-cap",
+        "leg-timeout-cap",
+    ] {
+        assert!(
+            stdout.contains(&format!("red-proof {proof}=pass")),
+            "{proof}"
+        );
+    }
+    assert!(stdout.contains("positive-proof prometheus-syntax=pass"));
+    assert!(stdout.contains("SELF_TEST pass"));
+
+    let failed_tmp = tempfile::tempdir().expect("failed self-test TMPDIR");
+    let failed = std::process::Command::new("bash")
+        .arg(&runner)
+        .env("SELF_TEST", "1")
+        .env("GENERATOR", failed_tmp.path().join("missing-generator.py"))
+        .env("TMPDIR", failed_tmp.path())
+        .output()
+        .expect("run deliberately failed self-test");
+    assert!(!failed.status.success());
+    assert_eq!(
+        std::fs::read_dir(failed_tmp.path())
+            .expect("read failed self-test TMPDIR")
+            .count(),
+        0,
+        "removing the self-test EXIT trap leaves its generated tempdir behind"
+    );
+
+    let implicit = std::process::Command::new("bash")
+        .arg(&runner)
+        .env_remove("MODE")
+        .output()
+        .expect("run implicit mode");
+    assert_eq!(implicit.status.code(), Some(2));
+
+    let full_without_opt_in = std::process::Command::new("bash")
+        .arg(&runner)
+        .env("MODE", "full")
+        .env("DRY_RUN_PROTOCOL", "1")
+        .env_remove("FULL_SHAPE")
+        .output()
+        .expect("run gated full mode");
+    assert!(!full_without_opt_in.status.success());
+
+    for mode in ["smoke", "dhat"] {
+        let dry = std::process::Command::new("bash")
+            .arg(&runner)
+            .env("MODE", mode)
+            .env("DRY_RUN_PROTOCOL", "1")
+            .output()
+            .expect("run bounded dry protocol");
+        assert!(dry.status.success(), "{mode} dry protocol");
+        let text = String::from_utf8(dry.stdout).expect("dry protocol UTF-8");
+        assert!(text.contains("protocol=private,grouped,grouped,private"));
+        assert!(text.contains("path_hiding=true,false,false,true"));
+        assert!(text.contains("admit_churn=false"));
+        assert!(text.contains("ports=1790,9179"));
+        assert!(text.contains("rss_abort_gib=100"));
+    }
 }


### PR DESCRIPTION
## Summary

- add an explicit private/grouped/grouped/private fresh-process memory-attribution protocol for the IRR route-server shape
- make path-hiding and churn admission explicit generator emission modes while keeping the canonical member dataset identity stable
- fail closed on production route/group/allocator metrics, process identity, timestamp cadence, RSS bounds, partial evidence, and source drift
- seal successful evidence with checksums and read-only permissions

This is benchmark instrumentation only. It changes no daemon behavior and makes no performance claim. The DHAT and canonical 320-member campaigns remain deferred until this harness lands.

## Load-bearing proof

The integration test invokes the same validators used by a real run. Named destructive fixtures go red if the guarded logic is removed, including:

- private/grouped protocol order and path-hiding emission
- exact aggregate and eager-family route rosters
- complete update-group membership and integral group IDs
- Prometheus label/sample identity, valid escaping, and non-finite evidence rejection
- allocator singleton/ordering checks
- accepted timestamp cadence/order and retry replacement
- expected root PID/starttime, connected process roster, and exact tree RSS sum
- fixed metrics port, bounded timeouts, RSS abort, and DHAT classifier integrity

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- `bash -n` and `shellcheck` on the runner
- runner `SELF_TEST=1` with every named red proof
- fresh bounded real-daemon smoke: 8 peers / 800 routes, private/grouped/grouped/private, 8/8 sessions in every leg
- smoke artifact checksum, exact source-state hash, read-only permission, and process/listener cleanup audits

Linear: LAN-789