### PR TITLE
bench: harden the IRR reload comparison receipt

### DIFF
--- a/bench/scale/irrreload/README.md
+++ b/bench/scale/irrreload/README.md
@@ -58,6 +58,7 @@ and the bogon list).
 | Cell | Policy representation | Reload mechanism |
 |---|---|---|
 | `rustbgpd-sighup` | `.rpol` per-member IRR filters rendered by `tools/rs-config-render` (the production IRR pipeline renderer) from a synthetic `arouteserver template-context` document, concatenated into one swapped file | copy generation file over live, `SIGHUP` |
+| `rustbgpd-sighup-grouped-control` | the same `.rpol` policy and canonical dataset, with `per_client_best = false` so all 320 members share one update group | copy generation file over live, `SIGHUP`; standalone diagnostic control only |
 | `rustbgpd-txn` | same dataset as inline `[policy.definitions]` chain-engine statements in a full candidate config TOML | copy candidate, `rbgp config plan` + `config apply` with the plan's snapshot token (`txn-apply.sh`) |
 | `bird` | per-member prefix-set `define`s + import filters in the swapped include file | copy include, `birdc configure` |
 | `openbgpd` | per-member `prefix-set`s + `source-as`/`prefix-set` allow rules in the swapped include file | copy include, `bgpctl reload` |
@@ -158,22 +159,59 @@ fingerprint without hostnames, usernames, absolute paths, or other host-unique
 identifiers.
 Successful cells may delete their generated scenario only after retaining its
 generator `manifest.json` alongside that provenance.
+Offline verification recomputes the canonical provenance fingerprint, requires
+the exact full-workload knobs and repeat tool/image identities, and re-parses
+`scenario.sha256` against the manifest's safe `runtime_files` roster. Any
+symlink in a retained receipt is invalid.
 
 The RSS sampler is a required instrument: early/nonzero sampler exit or an
 empty/malformed `rss.csv` fails the cell. The runner reaps the sampler after
 the daemon exits and preserves all artifacts on failure.
 
-**Run count**: two fixed-order fresh-process campaign repeats minimum (fresh
-daemon starts, same cell order) so run-to-run spread is visible — run B into
-a separate `ARTIFACTS_DIR`. These are repeats, not statistically independent
-or counterbalanced trials.
+For the two rustbgpd cells, the runner opts into the reloadstall harness's
+`RELOADSTALL_PRE_CHURN_EVIDENCE_DIR` boundary. After base convergence and
+before starting churn, the harness publishes `ready` and waits at most 60
+seconds for a regular `ack`; absent means the historical harness path is
+unchanged. The runner retries transiently unsettled evidence for at most 50
+seconds, and atomically publishes `ack` only after accepting three production
+Prometheus scrapes at least one second apart. Invalid evidence is never
+acknowledged, so the cell fails closed with the boundary and attempt retained.
 
-**Host-quiet preconditions** (measured mode enforces): the campaign starts
-only after `tests/soak/preflight.sh` passes (competing-workload, host-lock,
-disk and mutex checks; `SKIP_PREFLIGHT=1` to override deliberately), plus a
-1-min loadavg < 2.0 gate before each cell and 300 s cool-downs between
-cells. `SMOKE=1` skips all quiet gates because it is a pipeline proof, not
-a measurement.
+Every cell also opts into `RELOADSTALL_EVIDENCE_DIR`. After the final measured
+rows are emitted, the harness keeps its stub sessions live and publishes
+`ready`. Before atomically publishing `ack`, the runner verifies that the
+daemon PID/start identity still matches the cell and records `process.tsv`.
+The retained final `ready`/`ack` pair therefore binds process identity to the
+measurement end rather than to a post-exit state with the stubs already gone.
+Missing or mismatched evidence is never acknowledged and fails the cell.
+
+At the full shape, the scrapes must show no Add-Path config, all 320 sessions
+established, empty outbound queues, Loc-RIB exactly 183,040, exact per-peer Adj-RIB-In and
+Adj-RIB-Out family rosters/counts, and a stable exact update-group topology.
+The comparison cell requires 320 `per_client_best` peers, zero groups, 320
+fallback peers, and every peer's group gauge at `-1`. The grouped control
+requires no `per_client_best` peers, exactly one 320-member group, zero
+fallback peers, and one shared nonnegative group ID. The last accepted scrape
+must precede the harness's first wire-measurement trigger. The retained
+`ready`, `ack`, timestamps, config, and raw scrapes are all in the cell's
+checksum chain and are independently re-parsed by the four-root verifier.
+
+**Run count and order**: four fresh artifact roots in fixed A/B/B/A order:
+comparison A, grouped-control A, grouped-control B, comparison B. Each cell
+gets a fresh daemon PID/start identity. This counterbalances host drift around
+the diagnostic control without putting the control in the competitor table.
+`verify-receipt.py campaigns` rejects reordered roots, reused process
+identities, source/dataset/shape mismatches, non-quiet cells, broken seals, or
+grouped rows in `comparison.csv`; it writes grouped rows only to
+`grouped-control.csv`. The repeats are not statistically independent trials.
+
+**Host-quiet preconditions** (full measured mode enforces): clean `HEAD`
+exactly at `origin/main`, the canonical shape/seed, no `SKIP_PREFLIGHT`, a
+passing `tests/soak/preflight.sh`, and exclusive ownership of the shared host
+lock. Before every cell, two retained 1-minute-load samples at least 30 seconds
+apart must both be below 2.0; cells retain their daemon PID/start identity.
+Successful roots carry `COMPLETED` plus an exact `SHA256SUMS` roster and become
+read-only. `SMOKE=1` skips the quiet gates because it is not a measurement.
 
 ## Comparability protocol
 
@@ -232,6 +270,12 @@ Documented asymmetries (the honesty notes for the eventual receipt):
   disabled in the context). Rendered policy files are never edited.
 - **Padding realism ceiling**: filter-list padding entries are all /24s;
   real IRR lists mix lengths. Constant across daemons and generations.
+- **Path-hiding control is not another competitor.** The comparison's
+  rustbgpd config explicitly uses `--path-hiding true --admit-churn true`.
+  The standalone grouped control uses `false/true`. BIRD and OpenBGPD retain
+  the same canonical dataset and churn admission, but path hiding is recorded
+  as non-applicable in their manifests. Grouped-control rows diagnose the
+  update-group fanout seam and never enter comparison or recommendation text.
 
 ## Running
 
@@ -239,9 +283,16 @@ Documented asymmetries (the honesty notes for the eventual receipt):
 # Smoke (pipeline proof, any host, ~minutes):
 SMOKE=1 bench/scale/irrreload/run-irr-reload.sh
 
-# Measured campaign (quiet host only — preflight-gated), two runs:
-ARTIFACTS_DIR=/tmp/irrreload-full-runA bench/scale/irrreload/run-irr-reload.sh
-ARTIFACTS_DIR=/tmp/irrreload-full-runB bench/scale/irrreload/run-irr-reload.sh
+# Full campaign (quiet host only), exact A/B/B/A order and fresh roots:
+ARTIFACTS_DIR=/tmp/irrreload-comparison-A bench/scale/irrreload/run-irr-reload.sh
+ARTIFACTS_DIR=/tmp/irrreload-grouped-A bench/scale/irrreload/run-irr-reload.sh rustbgpd-sighup-grouped-control
+ARTIFACTS_DIR=/tmp/irrreload-grouped-B bench/scale/irrreload/run-irr-reload.sh rustbgpd-sighup-grouped-control
+ARTIFACTS_DIR=/tmp/irrreload-comparison-B bench/scale/irrreload/run-irr-reload.sh
+
+python3 bench/scale/irrreload/verify-receipt.py campaigns \
+  --output-dir /tmp/irrreload-verified \
+  /tmp/irrreload-comparison-A /tmp/irrreload-grouped-A \
+  /tmp/irrreload-grouped-B /tmp/irrreload-comparison-B
 
 # Separate bounded transaction receipt, also repeated into fresh roots:
 ARTIFACTS_DIR=/tmp/irrreload-txn-runA bench/scale/irrreload/run-irr-reload.sh rustbgpd-txn

--- a/bench/scale/irrreload/run-irr-reload.sh
+++ b/bench/scale/irrreload/run-irr-reload.sh
@@ -20,14 +20,13 @@
 # Modes:
 #   SMOKE=1   pipeline proof at a tiny shape (10 members x 100-entry lists,
 #             1 reload/cell, no host-quiet gates). NOT a measurement.
-#   default   the measured shape. Requires a quiet host: runs
-#             tests/soak/preflight.sh first (SKIP_PREFLIGHT=1 to override),
-#             1-min loadavg gate before each cell, 300 s cool-downs.
+#   default   the measured shape. Requires clean origin/main, preflight +
+#             host lock, two quiet samples per cell, and 300 s cool-downs.
 #
 # Knobs (env): N_MEMBERS TOTAL_PREFIXES MIN_LIST MAX_LIST SEED
 #              CHANGED_FRACTION PORT RELOADS CONTROL_SECS BIRD_THREADS
-#              CELL_TIMEOUT START_TIMEOUT ARTIFACTS_DIR SKIP_PREFLIGHT
-#              TXN_MAX_CANDIDATE_BYTES
+#              CELL_TIMEOUT START_TIMEOUT ARTIFACTS_DIR TXN_MAX_CANDIDATE_BYTES
+#
 set -u
 set -o pipefail
 
@@ -37,11 +36,13 @@ HARNESS="$RSTALL/target/release/reloadstall"
 GEN="$RSTALL/gen-irr-scenario.py"
 SAMPLER="$REPO/bench/scale/matrix/rss-sampler.sh"
 TXN_APPLY="$REPO/bench/scale/irrreload/txn-apply.sh"
+VERIFY="$REPO/bench/scale/irrreload/verify-receipt.py"
 RBGP="$REPO/target/release/rbgp"
 RENDER="$REPO/target/release/rs-config-render"
 DAEMON="$REPO/target/release/rustbgpd"
 
 SMOKE="${SMOKE:-}"
+GROUPED_CELL=rustbgpd-sighup-grouped-control
 CELLS=("$@")
 if [ ${#CELLS[@]} -eq 0 ]; then
     if [ -n "$SMOKE" ]; then
@@ -49,6 +50,15 @@ if [ ${#CELLS[@]} -eq 0 ]; then
     else
         CELLS=(rustbgpd-sighup bird openbgpd)
     fi
+fi
+
+GROUPED_ONLY=false
+if [[ " ${CELLS[*]} " == *" $GROUPED_CELL "* ]]; then
+    if [ ${#CELLS[@]} -ne 1 ]; then
+        echo "$GROUPED_CELL is a standalone control, never a comparison-table cell" >&2
+        exit 2
+    fi
+    GROUPED_ONLY=true
 fi
 
 TXN_ONLY=false
@@ -98,20 +108,17 @@ fi
 SEED="${SEED:-61}"
 CHANGED_FRACTION="${CHANGED_FRACTION:-0.1}"
 PORT="${PORT:-1790}"
-# Daemon-start readiness ceiling (seconds). Parsing a multi-MB IRR
-# policy takes far longer than a small-config boot, so readiness is
-# polled (1 s cadence, until the BGP listener is up) instead of a
-# fixed sleep; this is only the hard ceiling. A harness parameter, not
-# a measurement — see README "Startup and readiness windows".
+# Hard readiness ceiling only; startup is not a reported measurement.
 START_TIMEOUT="${START_TIMEOUT:-600}"
 BIRD_THREADS="${BIRD_THREADS:-8}"
 ART="${ARTIFACTS_DIR:-/tmp/irrreload-artifacts}"
+PREFLIGHT_LOG=""
+cleanup_preflight_log() { [ -z "$PREFLIGHT_LOG" ] || rm -f "$PREFLIGHT_LOG"; }
+trap cleanup_preflight_log EXIT
 RSS_LIMIT_KIB=$((100 * 1024 * 1024)) # abort a cell past 100 GiB (precommitted)
+TOPOLOGY_CAPTURE_TIMEOUT=50
 TONIC_MAX_DECODE_BYTES=4194304
-# Apply carries candidate_toml (field 1) plus the required 22-byte
-# runtime-snapshot token (field 2). At this candidate size, protobuf uses
-# one-byte tags/field-2 length and a four-byte field-1 length:
-# 4_194_275 + 5 + 24 = tonic's 4 MiB decoded-message ceiling exactly.
+# candidate_toml plus the fixed snapshot token fits tonic's 4 MiB ceiling.
 TXN_SAFE_CANDIDATE_BYTES=4194275
 TXN_MAX_CANDIDATE_BYTES="${TXN_MAX_CANDIDATE_BYTES:-$TXN_SAFE_CANDIDATE_BYTES}"
 case $TXN_MAX_CANDIDATE_BYTES in
@@ -130,32 +137,72 @@ if [ -n "$SMOKE" ]; then
     CAMPAIGN_KIND=smoke
 elif [ "$TXN_ONLY" = true ]; then
     CAMPAIGN_KIND=transaction-bounded
+elif [ "$GROUPED_ONLY" = true ]; then
+    CAMPAIGN_KIND=full-grouped-control
 else
     CAMPAIGN_KIND=full-cross-daemon
 fi
 
+if [[ " ${CELLS[*]} " == *" rustbgpd-sighup "* || "$GROUPED_ONLY" = true ]] &&
+    [ "$CONTROL_SECS" -lt 4 ]; then
+    echo "rustbgpd SIGHUP cells need CONTROL_SECS >= 4 for pre-reload topology proof" >&2
+    exit 2
+fi
+
 if [ -n "${DRY_RUN_PROTOCOL:-}" ]; then
     printf 'cells=%s\n' "$(IFS=,; echo "${CELLS[*]}")"
+    printf 'campaign_kind=%s\n' "$CAMPAIGN_KIND"
+    printf 'rustbgpd_private=path_hiding:true,admit_churn:true\n'
+    printf 'rustbgpd_grouped_control=path_hiding:false,admit_churn:true,standalone:true\n'
+    printf 'competitor_path_hiding=applicable:false,requested:true\n'
     printf 'shape=%s,%s,%s,%s\n' "$N_MEMBERS" "$TOTAL_PREFIXES" "$MIN_LIST" "$MAX_LIST"
     printf 'reloads=%s control_secs=%s txn_max_candidate_bytes=%s\n' \
         "$RELOADS" "$CONTROL_SECS" "$TXN_MAX_CANDIDATE_BYTES"
     exit 0
 fi
 
-for tool in docker jq python3 cargo ss sha256sum git awk timeout find sort setsid cmp mktemp; do
+for tool in docker jq python3 cargo curl flock ss sha256sum git awk timeout find sort setsid stdbuf cmp mktemp; do
     command -v "$tool" >/dev/null || {
         echo "missing required tool: $tool" >&2
         exit 1
     }
 done
 
-if [ -z "$SMOKE" ] && [ -z "${SKIP_PREFLIGHT:-}" ]; then
+if [ -z "$SMOKE" ] && [ "$TXN_ONLY" != true ]; then
+    if [ -n "${SKIP_PREFLIGHT:-}" ]; then
+        echo "full measured campaigns cannot set SKIP_PREFLIGHT" >&2
+        exit 2
+    fi
+    git -C "$REPO" fetch --quiet origin main || exit 1
+    HEAD_COMMIT=$(git -C "$REPO" rev-parse HEAD) || exit 1
+    ORIGIN_MAIN=$(git -C "$REPO" rev-parse origin/main) || exit 1
+    if [ "$HEAD_COMMIT" != "$ORIGIN_MAIN" ] ||
+        [ -n "$(git -C "$REPO" status --porcelain=v1)" ]; then
+        echo "full measured campaigns require a clean HEAD exactly at origin/main" >&2
+        exit 2
+    fi
+    if [ "$N_MEMBERS,$TOTAL_PREFIXES,$MIN_LIST,$MAX_LIST,$SEED,$RELOADS,$CHANGED_FRACTION,$PORT,$CONTROL_SECS,$TXN_MAX_CANDIDATE_BYTES,$CELL_TIMEOUT,$START_TIMEOUT,$BIRD_THREADS" != \
+        "320,183040,1000,40000,61,4,0.1,1790,30,4194275,7200,600,8" ]; then
+        echo "full measured campaigns require canonical workload knobs" >&2
+        exit 2
+    fi
     echo "=== host-quiet preflight (tests/soak/preflight.sh) ==="
-    "$REPO/tests/soak/preflight.sh" || {
-        echo "preflight failed; fix the host or set SKIP_PREFLIGHT=1" >&2
+    PREFLIGHT_LOG=$(mktemp /tmp/irrreload-preflight.XXXXXX) || exit 1
+    "$REPO/tests/soak/preflight.sh" >"$PREFLIGHT_LOG" 2>&1 || {
+        cat "$PREFLIGHT_LOG" >&2
+        rm -f "$PREFLIGHT_LOG"
+        echo "preflight failed; fix the named host condition" >&2
         exit 1
     }
 fi
+
+HOST_LOCK="${RUSTBGPD_HOST_LOCK:-$HOME/.local/state/rustbgpd-host.lock}"
+mkdir -p "$(dirname "$HOST_LOCK")"
+exec {HOST_LOCK_FD}>"$HOST_LOCK"
+flock -n "$HOST_LOCK_FD" || {
+    echo "host benchmark lock is held: $HOST_LOCK" >&2
+    exit 75
+}
 
 echo "=== builds ==="
 (cd "$REPO" && cargo build --release -q -p rustbgpd -p rustbgpctl -p rs-config-render) || exit 1
@@ -167,6 +214,10 @@ for bin in "$HARNESS" "$RBGP" "$RENDER" "$DAEMON"; do
     }
 done
 mkdir -p "$ART"
+if [ -e "$ART/COMPLETED" ] || [ -e "$ART/SHA256SUMS" ]; then
+    echo "completed artifact roots are immutable; choose a fresh ARTIFACTS_DIR" >&2
+    exit 2
+fi
 hash_file() {
     local output
     output=$(sha256sum -- "$1") || return 1
@@ -189,15 +240,14 @@ image_id_for_cells() {
 BIRD_IMAGE_ID=$(image_id_for_cells bird "$BIRD_IMAGE") || exit 1
 OPENBGPD_IMAGE_ID=$(image_id_for_cells openbgpd "$OPENBGPD_IMAGE") || exit 1
 DOCKER_VERSION=$(docker --version)
-if [[ " ${CELLS[*]} " == *" bird "* || " ${CELLS[*]} " == *" openbgpd "* ]]; then
-    DOCKER_VERSION=$(docker version --format '{{.Client.Version}}/{{.Server.Version}}') || exit 1
-fi
 
-# Seal resumability and retained evidence to the exact code, tools, and
-# campaign inputs. All paths stay repository-relative and no host identity is
-# recorded. A dirty checkout is represented by its byte-exact tracked diff
-# plus content hashes for untracked files.
 COMMIT=$(git -C "$REPO" rev-parse HEAD) || exit 1
+# Full provenance binds source, tools, binaries, images, and campaign inputs;
+# dirty smoke runs include tracked diffs and untracked content hashes.
+ORIGIN_MAIN=$(git -C "$REPO" rev-parse origin/main 2>/dev/null || printf unavailable)
+HEAD_MATCHES_ORIGIN_MAIN=false
+[ "$COMMIT" = "$ORIGIN_MAIN" ] && HEAD_MATCHES_ORIGIN_MAIN=true
+CAMPAIGN_STARTED_EPOCH_NS=$(date +%s%N)
 DIRTY=false
 [ -z "$(git -C "$REPO" status --porcelain=v1)" ] || DIRTY=true
 DIRTY_STATE_SHA256=$(
@@ -214,7 +264,10 @@ DIRTY_STATE_SHA256=$(printf '%s' "$DIRTY_STATE_SHA256" | sha256sum | cut -d' ' -
 CAMPAIGN_PROVENANCE=$(jq -cn \
     --arg commit "$COMMIT" --argjson dirty "$DIRTY" \
     --arg dirty_state_sha256 "$DIRTY_STATE_SHA256" \
+    --arg origin_main "$ORIGIN_MAIN" --argjson head_matches_origin_main "$HEAD_MATCHES_ORIGIN_MAIN" \
+    --argjson started_at_epoch_ns "$CAMPAIGN_STARTED_EPOCH_NS" \
     --arg run_script_sha256 "$(hash_file "$REPO/bench/scale/irrreload/run-irr-reload.sh")" \
+    --arg verifier_sha256 "$(hash_file "$VERIFY")" \
     --arg generator_sha256 "$(hash_file "$GEN")" \
     --arg sampler_sha256 "$(hash_file "$SAMPLER")" \
     --arg txn_apply_sha256 "$(hash_file "$TXN_APPLY")" \
@@ -239,8 +292,8 @@ CAMPAIGN_PROVENANCE=$(jq -cn \
     --arg cpu_model "$(awk -F: '/^model name/ { sub(/^[[:space:]]+/, "", $2); print $2; exit }' /proc/cpuinfo)" \
     --arg bird_image "$BIRD_IMAGE" --arg bird_image_id "$BIRD_IMAGE_ID" \
     --arg openbgpd_image "$OPENBGPD_IMAGE" --arg openbgpd_image_id "$OPENBGPD_IMAGE_ID" \
-    '{schema:2,git:{commit:$commit,dirty:$dirty,dirty_state_sha256:$dirty_state_sha256},scripts:{runner:$run_script_sha256,generator:$generator_sha256,rss_sampler:$sampler_sha256,txn_apply:$txn_apply_sha256},binaries:{reloadstall:$harness_sha256,rustbgpd:$daemon_sha256,rbgp:$cli_sha256,rs_config_render:$renderer_sha256},environment:{rustc:$rustc,cargo:$cargo,python:$python,jq:$jq,docker:$docker,kernel:$kernel,cpu_model:$cpu_model},inputs:{campaign_kind:$campaign_kind,cells:$cells,smoke:$smoke,n_members:$n_members,total_prefixes:$total_prefixes,min_list:$min_list,max_list:$max_list,seed:$seed,changed_fraction:$changed_fraction,port:$port,reloads:$reloads,control_secs:$control_secs,txn_max_candidate_bytes:$txn_max_candidate_bytes,cell_timeout:$cell_timeout,start_timeout:$start_timeout,bird_threads:$bird_threads,skip_preflight:$skip_preflight,bird_image:$bird_image,bird_image_id:$bird_image_id,openbgpd_image:$openbgpd_image,openbgpd_image_id:$openbgpd_image_id}}') || exit 1
-CAMPAIGN_FINGERPRINT=$(printf '%s' "$CAMPAIGN_PROVENANCE" | sha256sum | cut -d' ' -f1) || exit 1
+    '{schema:3,started_at_epoch_ns:$started_at_epoch_ns,git:{commit:$commit,dirty:$dirty,dirty_state_sha256:$dirty_state_sha256,origin_main:$origin_main,head_matches_origin_main:$head_matches_origin_main},scripts:{runner:$run_script_sha256,verifier:$verifier_sha256,generator:$generator_sha256,rss_sampler:$sampler_sha256,txn_apply:$txn_apply_sha256},binaries:{reloadstall:$harness_sha256,rustbgpd:$daemon_sha256,rbgp:$cli_sha256,rs_config_render:$renderer_sha256},environment:{rustc:$rustc,cargo:$cargo,python:$python,jq:$jq,docker:$docker,kernel:$kernel,cpu_model:$cpu_model},inputs:{campaign_kind:$campaign_kind,cells:$cells,smoke:$smoke,n_members:$n_members,total_prefixes:$total_prefixes,min_list:$min_list,max_list:$max_list,seed:$seed,changed_fraction:$changed_fraction,port:$port,reloads:$reloads,control_secs:$control_secs,txn_max_candidate_bytes:$txn_max_candidate_bytes,cell_timeout:$cell_timeout,start_timeout:$start_timeout,bird_threads:$bird_threads,skip_preflight:$skip_preflight,bird_image:$bird_image,bird_image_id:$bird_image_id,openbgpd_image:$openbgpd_image,openbgpd_image_id:$openbgpd_image_id}}') || exit 1
+CAMPAIGN_FINGERPRINT=$(printf '%s' "$CAMPAIGN_PROVENANCE" | jq -cS . | sha256sum | cut -d' ' -f1) || exit 1
 SEALED_CAMPAIGN_PROVENANCE=$(printf '%s\n' "$CAMPAIGN_PROVENANCE" | jq -cS \
     --arg fingerprint "$CAMPAIGN_FINGERPRINT" '. + {fingerprint:$fingerprint}') || exit 1
 ARTIFACT_ROOT_EXISTING=false
@@ -268,6 +321,10 @@ elif [ -n "$(find "$ART" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
     exit 2
 else
     printf '%s\n' "$SEALED_CAMPAIGN_PROVENANCE" >"$ART/provenance.json" || exit 1
+fi
+if [ -n "$PREFLIGHT_LOG" ]; then
+    mv "$PREFLIGHT_LOG" "$ART/preflight.log" || exit 1
+    PREFLIGHT_LOG=""
 fi
 ROWS_HEADER="cell,reload,peers_total,peers_changed,peers_stable,prefixes,completion_p50_s,completion_p95_s,completion_max_s,changed_maxgap_p50_ms,changed_maxgap_p95_ms,changed_maxgap_max_ms,all_observer_maxgap_p50_ms,all_observer_maxgap_p95_ms,all_observer_maxgap_max_ms,changed_first_generation_update_p50_ms,changed_first_generation_update_p95_ms,changed_first_generation_update_max_ms,rss_before_mib,rss_after_mib,stable_marker_peers,sessions_up,parse_errors"
 if [ -f "$ART/rows.csv" ] && [ "$(head -n1 "$ART/rows.csv")" != "$ROWS_HEADER" ]; then
@@ -337,8 +394,16 @@ validate_cell_rows() {
 seal_cell_evidence() {
     local cdir=$1 path digest
     local -a evidence_files=(
-        daemon.log manifest.json provenance.json reloadstall.log rows.csv rss.csv scenario.sha256
+        daemon.log final-evidence/ready final-evidence/ack manifest.json process.tsv provenance.json reloadstall.log rows.csv rss.csv scenario.sha256
     )
+    if [ -z "$SMOKE" ] && [ "$TXN_ONLY" != true ]; then
+        evidence_files+=(quiet.tsv)
+    fi
+    case ${cdir##*/} in
+    rustbgpd-sighup | "$GROUPED_CELL")
+        evidence_files+=(config.toml topology.json topology.tsv metrics-1.prom metrics-2.prom metrics-3.prom pre-churn/ready pre-churn/ack)
+        ;;
+    esac
     : >"$cdir/evidence.sha256.tmp"
     for path in "${evidence_files[@]}"; do
         [ -f "$cdir/$path" ] || {
@@ -421,6 +486,7 @@ cleanup_active_processes() {
 cleanup() {
     # shellcheck disable=SC2317  # invoked via trap
     cleanup_active_processes
+    cleanup_preflight_log
     docker rm -f irr-bird irr-obgpd >/dev/null 2>&1
 }
 trap cleanup EXIT
@@ -428,16 +494,105 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 load_gate() {
+    local cell=$1 load sample=1 quiet
+    quiet="$ART/$cell/quiet.tsv"
     [ -n "$SMOKE" ] && return 0
-    local load
-    while :; do
+    [ "$TXN_ONLY" = true ] && return 0
+    mkdir -p "$ART/$cell"
+    printf 'sample\tepoch_s\tload1\n' >"$quiet"
+    while [ "$sample" -le 2 ]; do
         load=$(cut -d' ' -f1 /proc/loadavg)
-        if awk -v l="$load" 'BEGIN { exit !(l < 2.0) }'; then return 0; fi
-        echo "load_gate: 1-min loadavg $load >= 2.0, waiting 30s"
-        sleep 30
+        if awk -v l="$load" 'BEGIN { exit !(l < 2.0) }'; then
+            printf '%s\t%s\t%s\n' "$sample" "$(date +%s)" "$load" >>"$quiet"
+            sample=$((sample + 1))
+        else
+            echo "load_gate: 1-min loadavg $load >= 2.0, waiting 30s"
+        fi
+        [ "$sample" -gt 2 ] || sleep 30
     done
 }
 
+capture_topology() {
+    local mode=$1 cdir=$2 run=$3 hpid=$4 barrier=$5 deadline sample entries
+    deadline=$((SECONDS + CELL_TIMEOUT))
+    while [ ! -e "$barrier/ready" ]; do
+        kill -0 "$hpid" 2>/dev/null || {
+            echo "topology: harness exited before pre-churn boundary" >&2
+            return 1
+        }
+        [ "$SECONDS" -lt "$deadline" ] || {
+            echo "topology: pre-churn boundary timed out" >&2
+            return 1
+        }
+        sleep 0.2
+    done
+    entries=$(find "$barrier" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)
+    if [ "$entries" != ready ] || [ ! -f "$barrier/ready" ] || [ -L "$barrier/ready" ]; then
+        echo "topology: pre-churn boundary is stale or non-regular" >&2
+        return 1
+    fi
+    cp "$run/config.toml" "$cdir/config.toml" || return 1
+    deadline=$((SECONDS + TOPOLOGY_CAPTURE_TIMEOUT))
+    while [ "$SECONDS" -lt "$deadline" ] && kill -0 "$hpid" 2>/dev/null; do
+        rm -f "$cdir/topology.json" "$cdir"/metrics-{1,2,3}.prom
+        printf 'phase\tepoch_ns\n' >"$cdir/topology.tsv"
+        for sample in 1 2 3; do
+            curl -fsS --max-time 2 'http://127.0.0.1:9179/metrics' >"$cdir/metrics-$sample.prom" || break
+            printf 'scrape%s\t%s\n' "$sample" "$(date +%s%N)" >>"$cdir/topology.tsv"
+            [ "$sample" -eq 3 ] || sleep 1
+        done
+        if python3 "$VERIFY" topology --mode "$mode" --peers "$N_MEMBERS" --total "$TOTAL_PREFIXES" \
+            --config "$cdir/config.toml" --timestamps "$cdir/topology.tsv" \
+            --output "$cdir/topology.json" "$cdir"/metrics-{1,2,3}.prom 2>"$cdir/topology.error"; then
+            rm -f "$cdir/topology.error"
+            ack_pre_churn "$barrier" true "$cdir" && return 0
+            return 1
+        fi
+        sleep 0.2
+    done
+    cat "$cdir/topology.error" >&2 2>/dev/null || true
+    echo "topology: invalid pre-churn evidence; acknowledgement withheld" >&2
+    return 1
+}
+ack_pre_churn() {
+    local barrier=$1 evidence_valid=$2 cdir=$3 tmp
+    tmp="$barrier/ack.tmp"
+    [ "$evidence_valid" = true ] || return 1
+    [ -f "$barrier/ready" ] && [ ! -L "$barrier/ready" ] && [ ! -e "$barrier/ack" ] || return 1
+    printf 'ack\n' >"$tmp" || return 1
+    mv -T "$tmp" "$barrier/ack" || return 1
+    [ -f "$barrier/ack" ] && [ ! -L "$barrier/ack" ] || return 1
+    mkdir -p "$cdir/pre-churn" || return 1
+    cp "$barrier/ready" "$barrier/ack" "$cdir/pre-churn/" || return 1
+}
+ack_final_evidence() {
+    local barrier=$1 cdir=$2 daemon_pid=$3 daemon_start=$4 after tmp
+    [ -f "$barrier/ready" ] && [ ! -L "$barrier/ready" ] && [ ! -e "$barrier/ack" ] || return 1
+    after=$(awk '{print $22}' "/proc/$daemon_pid/stat" 2>/dev/null) || return 1
+    [ "$after" = "$daemon_start" ] || return 1
+    printf 'pid\tstarttime_before\tstarttime_after\n%s\t%s\t%s\n' \
+        "$daemon_pid" "$daemon_start" "$after" >"$cdir/process.tsv" || return 1
+    tmp="$barrier/ack.tmp"
+    printf 'ack\n' >"$tmp" || return 1
+    mv -T "$tmp" "$barrier/ack" || return 1
+    [ -f "$barrier/ack" ] && [ ! -L "$barrier/ack" ] || return 1
+    mkdir -p "$cdir/final-evidence" || return 1
+    cp "$barrier/ready" "$barrier/ack" "$cdir/final-evidence/" || return 1
+}
+bind_first_trigger() {
+    local cdir=$1 trigger
+    trigger=$(sed -n 's/^reload 1 .*wall_us=\([0-9][0-9]*\).*/\1/p' "$cdir/reloadstall.log" | head -n1)
+    case $trigger in '' | *[!0-9]*) return 1 ;; esac
+    python3 - "$cdir/topology.json" "$trigger" <<'PY'
+import json, pathlib, sys
+path, trigger = pathlib.Path(sys.argv[1]), int(sys.argv[2])
+data = json.loads(path.read_text())
+if data["scrape_epoch_ns"][-1] // 1000 >= trigger:
+    raise SystemExit("topology proof did not precede the first reload trigger")
+data["first_reload_wall_us"] = trigger
+path.write_text(json.dumps(data, sort_keys=True) + "\n")
+PY
+}
 gen_scenario() {
     local cell=$1 run=$2
     shift 2
@@ -446,14 +601,6 @@ gen_scenario() {
         --max-list "$MAX_LIST" --changed-fraction "$CHANGED_FRACTION" "$@"
 }
 
-# wait_ready <cell> <cdir>: poll (1 s cadence, ceiling START_TIMEOUT)
-# until the cell's daemon listens on $PORT — large-config parses take
-# far longer than the fixed 3 s the small-config harness assumed. For
-# container cells this also captures daemon_pid via docker inspect,
-# retried until nonzero: a single immediate inspect used to race a
-# slow-starting container and record pid=0. Fails fast if the daemon
-# process/container dies first. Uses/sets the caller's daemon_pid and
-# container.
 wait_ready() {
     local cell=$1 cdir=$2 waited=0
     while :; do
@@ -483,33 +630,43 @@ wait_ready() {
     done
 }
 
-# run_cell <cell>: one matrix cell. Nonzero return = cell failed; the
-# campaign continues (matrix convention).
 run_cell() {
     local cell=$1
     local cdir="$ART/$cell"
-    # Short run dir: the gRPC UDS path must fit SUN_LEN.
     local run="/tmp/irr-$cell"
     rm -rf "$run"
     mkdir -p "$cdir" "$run"
-
-    local daemon_pid="" container="" reload_cmd="" pid_arg=""
-    local live a b
+    local daemon_pid="" daemon_start="" container="" reload_cmd="" pid_arg="" topology_mode="" barrier="" final_barrier="" final_acked=false
+    local live a b entries generator_cell=$cell
     CELL_SCENARIO_SHA256=""
     CELL_DATASET_SHA256=""
     CELL_EVIDENCE_SHA256=""
     case $cell in
     rustbgpd-sighup)
-        gen_scenario rustbgpd "$run" --render-bin "$RENDER" || return 1
+        gen_scenario rustbgpd "$run" --render-bin "$RENDER" \
+            --path-hiding true --admit-churn true || return 1
         seal_scenario "$run" "$cdir" || return 1
         setsid "$DAEMON" "$run/config.toml" >"$cdir/daemon.log" 2>&1 &
         daemon_pid=$!
         ACTIVE_DAEMON_PID=$daemon_pid
         live="$run/member.rpol" a="$run/gen-a.rpol" b="$run/gen-b.rpol"
-        pid_arg=$daemon_pid # SIGHUP path: harness signals + samples this PID
+        pid_arg=$daemon_pid
+        topology_mode=private
+        ;;
+    "$GROUPED_CELL")
+        generator_cell=rustbgpd
+        gen_scenario "$generator_cell" "$run" --render-bin "$RENDER" \
+            --path-hiding false --admit-churn true || return 1
+        seal_scenario "$run" "$cdir" || return 1
+        setsid "$DAEMON" "$run/config.toml" >"$cdir/daemon.log" 2>&1 &
+        daemon_pid=$!
+        ACTIVE_DAEMON_PID=$daemon_pid
+        live="$run/member.rpol" a="$run/gen-a.rpol" b="$run/gen-b.rpol"
+        pid_arg=$daemon_pid
+        topology_mode=grouped
         ;;
     rustbgpd-txn)
-        gen_scenario rustbgpd-txn "$run" || return 1
+        gen_scenario rustbgpd-txn "$run" --path-hiding true --admit-churn true || return 1
         local candidate candidate_bytes
         for candidate in "$run/config.toml" "$run/candidate.toml" \
             "$run/gen-a.toml" "$run/gen-b.toml"; do
@@ -526,11 +683,12 @@ run_cell() {
         daemon_pid=$!
         ACTIVE_DAEMON_PID=$daemon_pid
         live="$run/candidate.toml" a="$run/gen-a.toml" b="$run/gen-b.toml"
-        pid_arg=$daemon_pid # RSS from the real PID; reloads via reload_cmd
+        pid_arg=$daemon_pid
         reload_cmd="$TXN_APPLY $RBGP unix://$run/grpc.sock $run/candidate.toml"
         ;;
     bird)
-        gen_scenario bird "$run" --threads "$BIRD_THREADS" || return 1
+        gen_scenario bird "$run" --threads "$BIRD_THREADS" \
+            --path-hiding true --admit-churn true || return 1
         seal_scenario "$run" "$cdir" || return 1
         container="irr-bird"
         docker rm -f "$container" >/dev/null 2>&1
@@ -541,7 +699,7 @@ run_cell() {
         pid_arg=0 # the outer sampler owns RSS
         ;;
     openbgpd)
-        gen_scenario openbgpd "$run" || return 1
+        gen_scenario openbgpd "$run" --path-hiding true --admit-churn true || return 1
         seal_scenario "$run" "$cdir" || return 1
         container="irr-obgpd"
         docker rm -f "$container" >/dev/null 2>&1
@@ -558,23 +716,53 @@ run_cell() {
     esac
 
     wait_ready "$cell" "$cdir" || return 1
+    daemon_start=$(awk '{print $22}' "/proc/$daemon_pid/stat" 2>/dev/null) || return 1
+    case $daemon_start in '' | *[!0-9]*) return 1 ;; esac
 
     setsid "$SAMPLER" "$daemon_pid" "$cdir/rss.csv" 5 &
     local sampler_pid=$!
     ACTIVE_SAMPLER_PID=$sampler_pid
-
     local hargs=("$N_MEMBERS" "$TOTAL_PREFIXES" "$PORT" "$pid_arg"
         "$live" "$a" "$b" "$RELOADS" "$CONTROL_SECS")
-    # reload_cmd is positional arg 11, so cells using it pass an explicit
-    # all-changed cohort (same completion semantics as the 9-arg form).
     [ -n "$reload_cmd" ] && hargs+=("$N_MEMBERS" "$reload_cmd")
-
     # Background so the precommitted RSS abort criterion can kill the cell.
-    setsid timeout "$CELL_TIMEOUT" "$HARNESS" "${hargs[@]}" >"$cdir/reloadstall.log" 2>&1 &
+    final_barrier="$run/final-evidence"
+    [ ! -e "$final_barrier" ] || return 1
+    if [ -n "$topology_mode" ]; then
+        barrier="$run/pre-churn-evidence"
+        [ ! -e "$barrier" ] || return 1
+        setsid env RELOADSTALL_PRE_CHURN_EVIDENCE_DIR="$barrier" \
+            RELOADSTALL_EVIDENCE_DIR="$final_barrier" \
+            timeout "$CELL_TIMEOUT" stdbuf -oL -eL "$HARNESS" "${hargs[@]}" >"$cdir/reloadstall.log" 2>&1 &
+    else
+        setsid env RELOADSTALL_EVIDENCE_DIR="$final_barrier" \
+            timeout "$CELL_TIMEOUT" stdbuf -oL -eL "$HARNESS" "${hargs[@]}" >"$cdir/reloadstall.log" 2>&1 &
+    fi
     local hpid=$!
     ACTIVE_HARNESS_PID=$hpid
     local rc=""
+    if [ -n "$topology_mode" ] && ! capture_topology "$topology_mode" "$cdir" "$run" "$hpid" "$barrier"; then
+        terminate_process_group "$hpid"
+        rc=93
+    fi
     while kill -0 "$hpid" 2>/dev/null; do
+        if [ "$final_acked" != true ] && [ "$(awk '{print $22}' "/proc/$daemon_pid/stat" 2>/dev/null)" != "$daemon_start" ]; then
+            echo "cell $cell: daemon PID/start identity changed" >&2
+            terminate_process_group "$hpid"
+            rc=94
+            break
+        fi
+        if [ "$final_acked" != true ] && [ -e "$final_barrier/ready" ]; then
+            entries=$(find "$final_barrier" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)
+            if [ "$entries" != ready ] || ! ack_final_evidence \
+                "$final_barrier" "$cdir" "$daemon_pid" "$daemon_start"; then
+                echo "cell $cell: final evidence identity/boundary validation failed" >&2
+                terminate_process_group "$hpid"
+                rc=92
+                break
+            fi
+            final_acked=true
+        fi
         if ! kill -0 "$sampler_pid" 2>/dev/null; then
             echo "cell $cell: RSS sampler exited before harness completion" >&2
             terminate_process_group "$hpid"
@@ -601,6 +789,13 @@ run_cell() {
     hrc=$?
     ACTIVE_HARNESS_PID=""
     [ -z "$rc" ] && rc=$hrc
+    if [ "$final_acked" != true ]; then
+        echo "cell $cell: harness exited without a final evidence boundary" >&2
+        rc=92
+    elif [ -n "$topology_mode" ] && ! bind_first_trigger "$cdir"; then
+        echo "cell $cell: first reload trigger was missing or preceded topology proof" >&2
+        rc=93
+    fi
 
     if [ -n "$container" ]; then
         docker logs "$container" >"$cdir/daemon.log" 2>&1
@@ -707,7 +902,7 @@ for cell in "${CELLS[@]}"; do
         overall=1
         continue
     fi
-    load_gate
+    load_gate "$cell"
     echo "=== cell $cell start $(date -Is) ==="
     CELL_SCENARIO_SHA256=""
     CELL_DATASET_SHA256=""
@@ -739,4 +934,14 @@ for cell in "${CELLS[@]}"; do
     fi
 done
 echo "measurement rows: $ART/rows.csv"
+if [ "$overall" -eq 0 ]; then
+    jq -n --arg fingerprint "$CAMPAIGN_FINGERPRINT" --argjson completed_at_epoch_ns "$(date +%s%N)" \
+        --arg cells "$(IFS=,; echo "${CELLS[*]}")" \
+        '{status:"pass",fingerprint:$fingerprint,completed_at_epoch_ns:$completed_at_epoch_ns,cells:$cells}' \
+        >"$ART/COMPLETED" || exit 1
+    (cd "$ART" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum) \
+        >"$ART/SHA256SUMS" || exit 1
+    chmod -R a-w "$ART" || exit 1
+    echo "sealed read-only artifact root: $ART"
+fi
 exit "$overall"

--- a/bench/scale/irrreload/verify-receipt.py
+++ b/bench/scale/irrreload/verify-receipt.py
@@ -1,0 +1,1406 @@
+#!/usr/bin/env python3
+"""Validate IRR reload topology evidence and counterbalanced receipts."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import stat
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+COMPARISON_CELLS = ("rustbgpd-sighup", "bird", "openbgpd")
+GROUPED_CELL = "rustbgpd-sighup-grouped-control"
+CANONICAL_SHAPE = (320, 183040, 1000, 40000, 61)
+CANONICAL_FULL_INPUTS = {
+    "smoke": "",
+    "n_members": "320",
+    "total_prefixes": "183040",
+    "min_list": "1000",
+    "max_list": "40000",
+    "seed": "61",
+    "changed_fraction": "0.1",
+    "port": "1790",
+    "reloads": "4",
+    "control_secs": "30",
+    "txn_max_candidate_bytes": "4194275",
+    "cell_timeout": "7200",
+    "start_timeout": "600",
+    "bird_threads": "8",
+    "skip_preflight": "",
+    "bird_image": "bird:3.3.1",
+    "openbgpd_image": "openbgpd/openbgpd:9.1",
+}
+ROWS_HEADER = (
+    "cell,reload,peers_total,peers_changed,peers_stable,prefixes,"
+    "completion_p50_s,completion_p95_s,completion_max_s,"
+    "changed_maxgap_p50_ms,changed_maxgap_p95_ms,changed_maxgap_max_ms,"
+    "all_observer_maxgap_p50_ms,all_observer_maxgap_p95_ms,"
+    "all_observer_maxgap_max_ms,changed_first_generation_update_p50_ms,"
+    "changed_first_generation_update_p95_ms,changed_first_generation_update_max_ms,"
+    "rss_before_mib,rss_after_mib,stable_marker_peers,sessions_up,parse_errors"
+)
+METRIC_NAME = re.compile(r"[A-Za-z_:][A-Za-z0-9_:]*")
+LABEL_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+FLOAT_VALUE = re.compile(
+    r"(?:[-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][-+]?[0-9]+)?|NaN|[+-]Inf)"
+)
+INT64_TIMESTAMP = re.compile(r"[+-]?[0-9]+")
+WATCHED = ("bgp_rib_", "bgp_peer_", "bgp_update_group")
+
+
+class InvalidReceipt(ValueError):
+    pass
+
+
+def fail(message: str) -> None:
+    raise InvalidReceipt(message)
+
+
+def quoted(text: str, position: int) -> tuple[str, int]:
+    if position >= len(text) or text[position] != '"':
+        fail("expected quoted string")
+    chars: list[str] = []
+    position += 1
+    while position < len(text):
+        char = text[position]
+        position += 1
+        if char == '"':
+            return "".join(chars), position
+        if char == "\\":
+            if position >= len(text) or text[position] not in '\\"n':
+                fail("malformed label escape")
+            chars.append({"\\": "\\", '"': '"', "n": "\n"}[text[position]])
+            position += 1
+        elif char in "\r\n":
+            fail("unescaped line break")
+        else:
+            chars.append(char)
+    fail("unterminated quoted string")
+
+
+def parse_sample(text: str):
+    match = METRIC_NAME.match(text)
+    if not match:
+        return None
+    name, position, labels = match.group(), match.end(), {}
+    if position < len(text) and text[position] == "{":
+        position += 1
+        while True:
+            while position < len(text) and text[position] in " \t":
+                position += 1
+            if position < len(text) and text[position] == "}":
+                position += 1
+                break
+            if position < len(text) and text[position] == '"':
+                key, position = quoted(text, position)
+            else:
+                match = LABEL_NAME.match(text, position)
+                if not match:
+                    fail("malformed label name")
+                key, position = match.group(), match.end()
+            while position < len(text) and text[position] in " \t":
+                position += 1
+            if position >= len(text) or text[position] != "=":
+                fail("missing label equals")
+            position += 1
+            while position < len(text) and text[position] in " \t":
+                position += 1
+            value, position = quoted(text, position)
+            if key in labels:
+                fail(f"duplicate label {key!r}")
+            labels[key] = value
+            while position < len(text) and text[position] in " \t":
+                position += 1
+            if position < len(text) and text[position] == "}":
+                position += 1
+                break
+            if position >= len(text) or text[position] != ",":
+                fail("malformed label separator")
+            position += 1
+    if position >= len(text) or text[position] not in " \t":
+        fail("missing sample value separator")
+    tokens = text[position:].split()
+    if len(tokens) not in (1, 2) or not FLOAT_VALUE.fullmatch(tokens[0]):
+        fail("malformed sample value")
+    if len(tokens) == 2:
+        if not INT64_TIMESTAMP.fullmatch(tokens[1]):
+            fail("malformed sample timestamp")
+        timestamp = int(tokens[1])
+        if not -(1 << 63) <= timestamp < (1 << 63):
+            fail("sample timestamp outside int64")
+    return name, labels, float(tokens[0])
+
+
+def parse_metrics(path: Path) -> dict[str, list[tuple[dict[str, str], float]]]:
+    result: dict[str, list[tuple[dict[str, str], float]]] = {}
+    identities = set()
+    for line in path.read_text().splitlines():
+        text = line.strip()
+        if not text or text.startswith("#"):
+            continue
+        try:
+            parsed = parse_sample(text)
+        except InvalidReceipt:
+            if text.startswith(WATCHED):
+                raise
+            continue
+        if parsed is None:
+            continue
+        name, labels, value = parsed
+        identity = (name, tuple(sorted(labels.items())))
+        if identity in identities:
+            fail(f"duplicate metric sample {identity}")
+        identities.add(identity)
+        result.setdefault(name, []).append((labels, value))
+    return result
+
+
+def rows(data, name: str, count: int | None = None):
+    found = data.get(name, [])
+    if count is not None and len(found) != count:
+        fail(f"{name}: expected {count} samples, got {len(found)}")
+    if any(not math.isfinite(value) for _, value in found):
+        fail(f"{name}: non-finite sample")
+    return found
+
+
+def one(data, name: str, expected: int) -> None:
+    found = rows(data, name, 1)
+    labels, value = found[0]
+    if labels or value != expected:
+        fail(f"{name}: expected unlabelled {expected}, got {found[0]}")
+
+
+def peer_rows(data, name: str, peers: int, extra=()):
+    found = rows(data, name, peers)
+    expected_labels = {"peer", *extra}
+    identities = [labels.get("peer") for labels, _ in found]
+    if (
+        None in identities
+        or len(set(identities)) != peers
+        or any(set(labels) != expected_labels for labels, _ in found)
+    ):
+        fail(f"{name}: missing/duplicate peer or unexpected labels")
+    return found
+
+
+def family_rows(data, name: str, peers: set[str], families: tuple[str, ...]):
+    found = rows(data, name, len(peers) * len(families))
+    expected = {(peer, family) for peer in peers for family in families}
+    actual = {(labels.get("peer"), labels.get("afi_safi")) for labels, _ in found}
+    if actual != expected or any(set(labels) != {"peer", "afi_safi"} for labels, _ in found):
+        fail(f"{name}: family/peer roster mismatch")
+    return {(labels["peer"], labels["afi_safi"]): value for labels, value in found}
+
+
+def validate_topology(
+    mode: str,
+    peers: int,
+    total: int,
+    config: Path,
+    timestamps: Path,
+    metric_paths: list[Path],
+    output: Path,
+) -> None:
+    if mode not in ("private", "grouped") or len(metric_paths) != 3:
+        fail("topology requires private/grouped mode and exactly three scrapes")
+    config_text = config.read_text()
+    if "[neighbors.add_path]" in config_text:
+        fail("topology proof requires Add-Path disabled")
+    expected_best = peers if mode == "private" else 0
+    if config_text.count("per_client_best = true") != expected_best:
+        fail(f"{mode}: per_client_best mapping is not exact")
+    timestamp_rows = list(csv.DictReader(timestamps.open(), delimiter="\t"))
+    if [row.get("phase") for row in timestamp_rows] != ["scrape1", "scrape2", "scrape3"]:
+        fail("topology timestamps must contain exactly three scrapes")
+    epoch_ns = [int(row["epoch_ns"]) for row in timestamp_rows]
+    if epoch_ns[1] - epoch_ns[0] < 1_000_000_000 or epoch_ns[2] - epoch_ns[1] < 1_000_000_000:
+        fail("topology scrapes must be at least one second apart")
+    scrapes = [parse_metrics(path) for path in metric_paths]
+    stable = []
+    peer_roster = None
+    group_id = None
+    for data in scrapes:
+        one(data, "bgp_rib_outbound_registered_peers", peers)
+        one(data, "bgp_rib_ingest_channel_depth", 0)
+        one(data, "bgp_rib_policy_transition_in_progress", 0)
+        sessions = peer_rows(data, "bgp_peer_session_established", peers, ("interface",))
+        if any(value != 1 for _, value in sessions):
+            fail("not every expected session is established")
+        identities = {labels["peer"] for labels, _ in sessions}
+        queues = peer_rows(data, "bgp_peer_outbound_queue_depth", peers)
+        if {labels["peer"] for labels, _ in queues} != identities or any(
+            value != 0 for _, value in queues
+        ):
+            fail("every expected outbound queue must be empty")
+        groups = peer_rows(data, "bgp_peer_update_group", peers)
+        if {labels["peer"] for labels, _ in groups} != identities:
+            fail("group peer roster mismatch")
+        if peer_roster is None:
+            peer_roster = identities
+        elif peer_roster != identities:
+            fail("peer roster changed between topology scrapes")
+        loc = rows(data, "bgp_rib_loc_prefixes", 1)
+        if loc != [({"afi_safi": "all"}, float(total))]:
+            fail("Loc-RIB aggregate mismatch")
+        per_peer = total // peers
+        adj_in = family_rows(data, "bgp_rib_prefixes", identities, ("all", "flowspec"))
+        if any(
+            adj_in[(peer, family)] != (per_peer if family == "all" else 0)
+            for peer in identities
+            for family in ("all", "flowspec")
+        ):
+            fail("Adj-RIB-In aggregate/non-all roster mismatch")
+        out_families = ("all", "bgpls", "evpn", "flowspec", "labeled", "rtc", "vpn")
+        adj_out = family_rows(data, "bgp_rib_adj_out_prefixes", identities, out_families)
+        expected_out = total - per_peer
+        if any(
+            adj_out[(peer, family)] != (expected_out if family == "all" else 0)
+            for peer in identities
+            for family in out_families
+        ):
+            fail("Adj-RIB-Out aggregate/non-all roster mismatch")
+        if mode == "private":
+            one(data, "bgp_update_groups", 0)
+            one(data, "bgp_update_group_fallback_peers", peers)
+            if rows(data, "bgp_update_group_members") or any(value != -1 for _, value in groups):
+                fail("private topology must have no group and every peer at group -1")
+            group_snapshot = (0, peers, tuple(sorted((labels["peer"], value) for labels, value in groups)))
+        else:
+            one(data, "bgp_update_groups", 1)
+            one(data, "bgp_update_group_fallback_peers", 0)
+            members = rows(data, "bgp_update_group_members", 1)
+            labels, member_count = members[0]
+            ids = {value for _, value in groups}
+            candidate = next(iter(ids)) if len(ids) == 1 else math.nan
+            if (
+                set(labels) != {"group"}
+                or member_count != peers
+                or not math.isfinite(candidate)
+                or candidate < 0
+                or candidate != int(candidate)
+                or labels["group"] != str(int(candidate))
+            ):
+                fail("grouped topology must have one complete nonnegative group")
+            if group_id is None:
+                group_id = int(candidate)
+            group_snapshot = (1, 0, int(candidate), tuple(sorted((labels["peer"], value) for labels, value in groups)))
+        route_snapshot = tuple(
+            sorted(
+                (name, tuple(sorted(labels.items())), value)
+                for name, found in data.items()
+                if name in {"bgp_rib_loc_prefixes", "bgp_rib_prefixes", "bgp_rib_adj_out_prefixes"}
+                for labels, value in found
+            )
+        )
+        stable.append((group_snapshot, route_snapshot))
+    if not stable[0] == stable[1] == stable[2]:
+        fail("topology was not stable across three scrapes")
+    output.write_text(
+        json.dumps(
+            {
+                "status": "pass",
+                "mode": mode,
+                "peers": peers,
+                "scrape_epoch_ns": epoch_ns,
+                "group_id": group_id,
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def provenance_fingerprint(provenance: dict) -> str:
+    unsigned = dict(provenance)
+    unsigned.pop("fingerprint", None)
+    canonical = json.dumps(
+        unsigned, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+    return hashlib.sha256((canonical + "\n").encode()).hexdigest()
+
+
+def reject_symlinks(root: Path) -> None:
+    if root.is_symlink() or any(path.is_symlink() for path in root.rglob("*")):
+        fail(f"{root}: receipt contains a symlink")
+
+
+def validate_seal(root: Path) -> None:
+    completed = root / "COMPLETED"
+    roster = root / "SHA256SUMS"
+    if not completed.is_file() or not roster.is_file():
+        fail(f"{root}: incomplete root (COMPLETED/SHA256SUMS missing)")
+    expected = {}
+    for line in roster.read_text().splitlines():
+        match = re.fullmatch(r"([0-9a-f]{64})  (.+)", line)
+        if not match or match.group(2).startswith("/") or ".." in Path(match.group(2)).parts:
+            fail(f"{root}: malformed checksum roster")
+        relative = match.group(2).removeprefix("./")
+        if not relative or relative in expected:
+            fail(f"{root}: duplicate checksum path")
+        expected[relative] = match.group(1)
+    actual = {
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*")
+        if path.is_file() and path.name != "SHA256SUMS"
+    }
+    if actual != set(expected):
+        fail(f"{root}: checksum roster does not exactly cover retained files")
+    for relative, digest in expected.items():
+        if sha256(root / relative) != digest:
+            fail(f"{root}: checksum mismatch for {relative}")
+    for path in [root, *root.rglob("*")]:
+        if path.stat().st_mode & (stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH):
+            fail(f"{root}: writable retained path {path.relative_to(root) if path != root else '.'}")
+
+
+def read_json(path: Path):
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        fail(f"{path}: invalid JSON: {error}")
+
+
+def validate_quiet(path: Path) -> None:
+    data = list(csv.DictReader(path.open(), delimiter="\t"))
+    if [row.get("sample") for row in data] != ["1", "2"]:
+        fail(f"{path}: quiet gate needs exactly two samples")
+    epochs = [int(row["epoch_s"]) for row in data]
+    loads = [float(row["load1"]) for row in data]
+    if epochs[1] - epochs[0] < 30 or any(not math.isfinite(load) or load >= 2.0 for load in loads):
+        fail(f"{path}: quiet samples are too close or not below load 2")
+
+
+def validate_process(path: Path) -> tuple[int, int]:
+    data = list(csv.DictReader(path.open(), delimiter="\t"))
+    if len(data) != 1:
+        fail(f"{path}: expected one process identity")
+    row = data[0]
+    pid, before, after = int(row["pid"]), int(row["starttime_before"]), int(row["starttime_after"])
+    if pid <= 0 or before <= 0 or before != after:
+        fail(f"{path}: missing, reused, or changed process identity")
+    return pid, before
+
+
+def read_rows(path: Path, expected_cells: tuple[str, ...]) -> list[list[str]]:
+    with path.open(newline="") as stream:
+        reader = csv.reader(stream)
+        header = next(reader, None)
+        data = list(reader)
+    if header != ROWS_HEADER.split(","):
+        fail(f"{path}: unexpected row header")
+    if len(data) != 4 * len(expected_cells):
+        fail(f"{path}: expected four rows per cell")
+    for cell in expected_cells:
+        found = [row for row in data if row and row[0] == cell]
+        if len(found) != 4 or [row[1] for row in found] != ["1", "2", "3", "4"]:
+            fail(f"{path}: {cell} does not have reload rows 1..4")
+    if {row[0] for row in data if row} != set(expected_cells):
+        fail(f"{path}: unexpected/missing cells")
+    if any(len(row) != 23 for row in data):
+        fail(f"{path}: malformed measurement row width")
+    return data
+
+
+def validate_preflight(path: Path) -> None:
+    text = path.read_text()
+    lines = text.splitlines()
+    if "[preflight] READY — all pre-flight checks passed" not in lines or any(
+        "FAIL:" in line for line in lines
+    ):
+        fail(f"{path}: preflight did not finish READY without failures")
+    for phrase in ("bench-nightly cron is paused", "no pushes to main"):
+        if not any(phrase in line and "confirmed" in line for line in lines):
+            fail(f"{path}: missing manual confirmation for {phrase}")
+
+
+def parse_digest_roster(path: Path, expected_paths: set[str]) -> dict[str, str]:
+    entries = {}
+    for line in path.read_text().splitlines():
+        match = re.fullmatch(r"([0-9a-f]{64})  (?:\./)?(.+)", line)
+        if not match or match.group(2).startswith("/") or ".." in Path(match.group(2)).parts:
+            fail(f"{path}: malformed digest roster")
+        if match.group(2) in entries:
+            fail(f"{path}: duplicate digest path")
+        entries[match.group(2)] = match.group(1)
+    if set(entries) != expected_paths:
+        fail(f"{path}: digest roster does not exactly cover expected paths")
+    return entries
+
+
+def validate_digest_roster(path: Path, base: Path, expected_paths: set[str]) -> str:
+    entries = parse_digest_roster(path, expected_paths)
+    for relative, digest in entries.items():
+        if sha256(base / relative) != digest:
+            fail(f"{path}: checksum mismatch for {relative}")
+    return sha256(path)
+
+
+def validate_scenario_roster(cdir: Path, manifest: dict) -> str:
+    runtime_files = manifest.get("runtime_files")
+    if not isinstance(runtime_files, list) or not runtime_files:
+        fail(f"{cdir}: manifest runtime_files is not a nonempty roster")
+    if any(
+        not isinstance(relative, str)
+        or not relative
+        or Path(relative).name != relative
+        or ".." in relative
+        or relative == "manifest.json"
+        for relative in runtime_files
+    ) or len(set(runtime_files)) != len(runtime_files):
+        fail(f"{cdir}: manifest runtime_files contains an unsafe or duplicate path")
+    expected = {*runtime_files, "manifest.json"}
+    entries = parse_digest_roster(cdir / "scenario.sha256", expected)
+    for relative, digest in entries.items():
+        retained = cdir / relative
+        if retained.exists() and (not retained.is_file() or sha256(retained) != digest):
+            fail(f"{cdir}: retained scenario input mismatch for {relative}")
+    if sha256(cdir / "manifest.json") != entries["manifest.json"]:
+        fail(f"{cdir}: scenario roster does not bind retained manifest.json")
+    return sha256(cdir / "scenario.sha256")
+
+
+def validate_measurement_rows(rows_data: list[list[str]], cell: str, peers: int, total: int) -> None:
+    for row in rows_data:
+        if row[0] != cell:
+            fail(f"{cell}: row escaped its cell roster")
+        try:
+            integers = [int(row[index]) for index in (1, 2, 3, 4, 5, 20, 21, 22)]
+            floats = [float(row[index]) for index in range(6, 20)]
+        except ValueError:
+            fail(f"{cell}: nonnumeric measurement field")
+        if any(value < 0 or not math.isfinite(value) for value in floats):
+            fail(f"{cell}: negative/non-finite measurement")
+        for offset in (0, 3, 6, 9):
+            p50, p95, maximum = floats[offset : offset + 3]
+            if not p50 <= p95 <= maximum:
+                fail(f"{cell}: percentile triplet is not monotonic")
+        if floats[0] <= 0 or floats[9] <= 0:
+            fail(f"{cell}: completion/first-generation latency must be positive")
+        if any(
+            first_generation > completion * 1000
+            for completion, first_generation in zip(
+                floats[0:3], floats[9:12], strict=True
+            )
+        ):
+            fail(f"{cell}: first-generation latency exceeds completion latency")
+        if any(
+            all_observer < changed_observer
+            for changed_observer, all_observer in zip(
+                floats[3:6], floats[6:9], strict=True
+            )
+        ):
+            fail(f"{cell}: all-observer max-gap is below changed-observer max-gap")
+        reload_no, peers_total, peers_changed, peers_stable, prefixes, stable_marker, sessions, parse_errors = integers
+        if (
+            reload_no not in range(1, 5)
+            or peers_total != peers
+            or peers_changed != peers
+            or peers_stable != 0
+            or prefixes != total
+            or stable_marker != 0
+            or sessions != peers
+            or parse_errors != 0
+        ):
+            fail(f"{cell}: canonical row invariants failed")
+
+
+def validate_rss(path: Path) -> None:
+    data = list(csv.reader(path.open()))
+    if not data or data[0] != ["epoch_s", "total_rss_kib", "pids"] or len(data) < 2:
+        fail(f"{path}: RSS evidence is missing or malformed")
+    for row in data[1:]:
+        if len(row) != 3 or any(not value.isdigit() or int(value) <= 0 for value in row):
+            fail(f"{path}: RSS sample is not a positive integer triple")
+
+
+def validate_cell_chain(
+    root: Path,
+    cell: str,
+    root_provenance: dict,
+    scenario_digest: str,
+    dataset: str,
+    root_rows: list[list[str]],
+    peers: int,
+    total: int,
+) -> None:
+    cdir = root / cell
+    fingerprint = root_provenance["fingerprint"]
+    cell_rows = list(csv.reader((cdir / "rows.csv").open()))
+    expected_rows = [row for row in root_rows if row[0] == cell]
+    if cell_rows != expected_rows:
+        fail(f"{cdir}: cell rows do not equal their root rows")
+    validate_measurement_rows(cell_rows, cell, peers, total)
+    logged = []
+    for line in (cdir / "reloadstall.log").read_text().splitlines():
+        if line.startswith("reloadstall_csv,"):
+            logged.append([cell, *line.split(",")[1:]])
+    if logged != cell_rows:
+        fail(f"{cdir}: retained rows do not re-extract from reloadstall.log")
+    validate_rss(cdir / "rss.csv")
+    cell_provenance = read_json(cdir / "provenance.json")
+    scenario = cell_provenance.pop("scenario", {})
+    if (
+        cell_provenance != root_provenance
+        or scenario.get("manifest_sha256") != scenario_digest
+        or scenario.get("dataset_sha256") != dataset
+    ):
+        fail(f"{cdir}: cell provenance/scenario chain is broken")
+    retained = {
+        path.relative_to(cdir).as_posix()
+        for path in cdir.rglob("*")
+        if path.is_file() and path.name not in {"evidence.sha256", "status"}
+    }
+    evidence_digest = validate_digest_roster(cdir / "evidence.sha256", cdir, retained)
+    status = (cdir / "status").read_text().split()
+    if status != ["pass", fingerprint, scenario_digest, dataset, evidence_digest]:
+        fail(f"{cdir}: pass status does not bind the full evidence chain")
+
+
+def validate_root(root: Path, kind: str):
+    reject_symlinks(root)
+    validate_seal(root)
+    validate_preflight(root / "preflight.log")
+    provenance = read_json(root / "provenance.json")
+    inputs, git = provenance.get("inputs", {}), provenance.get("git", {})
+    expected_cells = COMPARISON_CELLS if kind == "comparison" else (GROUPED_CELL,)
+    expected_kind = "full-cross-daemon" if kind == "comparison" else "full-grouped-control"
+    scripts = provenance.get("scripts")
+    binaries = provenance.get("binaries")
+    environment = provenance.get("environment")
+    top_entries = {path.name for path in root.iterdir()}
+    expected_entries = {
+        "COMPLETED",
+        "SHA256SUMS",
+        "dataset.sha256",
+        "preflight.log",
+        "provenance.json",
+        "rows.csv",
+        *expected_cells,
+    }
+    if top_entries != expected_entries:
+        fail(f"{root}: artifact-root roster is not exact")
+    if inputs.get("cells") != ",".join(expected_cells):
+        fail(f"{root}: wrong {kind} cell roster")
+    if inputs.get("campaign_kind") != expected_kind:
+        fail(f"{root}: wrong campaign kind for {kind} role")
+    fingerprint = provenance.get("fingerprint")
+    if (
+        set(provenance)
+        != {
+            "schema",
+            "started_at_epoch_ns",
+            "git",
+            "scripts",
+            "binaries",
+            "environment",
+            "inputs",
+            "fingerprint",
+        }
+        or provenance.get("schema") != 3
+        or not isinstance(provenance.get("started_at_epoch_ns"), int)
+        or provenance.get("started_at_epoch_ns", -1) <= 0
+        or not isinstance(fingerprint, str)
+        or not re.fullmatch(r"[0-9a-f]{64}", fingerprint)
+        or provenance_fingerprint(provenance) != fingerprint
+        or not isinstance(scripts, dict)
+        or set(scripts) != {"runner", "verifier", "generator", "rss_sampler", "txn_apply"}
+        or not all(isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value) for value in scripts.values())
+        or not isinstance(binaries, dict)
+        or set(binaries) != {"reloadstall", "rustbgpd", "rbgp", "rs_config_render"}
+        or not all(isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value) for value in binaries.values())
+        or not isinstance(environment, dict)
+        or set(environment)
+        != {"rustc", "cargo", "python", "jq", "docker", "kernel", "cpu_model"}
+        or not all(isinstance(value, str) and value for value in environment.values())
+    ):
+        fail(f"{root}: schema/tool/source provenance is incomplete")
+    expected_input_keys = {
+        *CANONICAL_FULL_INPUTS,
+        "campaign_kind",
+        "cells",
+        "bird_image_id",
+        "openbgpd_image_id",
+    }
+    if set(inputs) != expected_input_keys or any(
+        inputs.get(key) != value for key, value in CANONICAL_FULL_INPUTS.items()
+    ):
+        fail(f"{root}: full workload inputs are not exact and canonical")
+    selected_image = re.compile(r"sha256:[0-9a-f]{64}")
+    expected_image_id = selected_image.fullmatch if kind == "comparison" else None
+    if (
+        kind == "comparison"
+        and not all(
+            isinstance(inputs.get(key), str) and expected_image_id(inputs[key])
+            for key in ("bird_image_id", "openbgpd_image_id")
+        )
+    ) or (
+        kind == "grouped"
+        and any(
+            inputs.get(key) != "not-selected"
+            for key in ("bird_image_id", "openbgpd_image_id")
+        )
+    ):
+        fail(f"{root}: container image identities do not match the campaign role")
+    actual_shape = tuple(int(inputs.get(name, -1)) for name in ("n_members", "total_prefixes", "min_list", "max_list", "seed"))
+    if actual_shape != CANONICAL_SHAPE or int(inputs.get("reloads", -1)) != 4:
+        fail(f"{root}: noncanonical full shape/seed/reload count")
+    commit = git.get("commit")
+    if (
+        not isinstance(commit, str)
+        or not re.fullmatch(r"[0-9a-f]{40}", commit)
+        or not isinstance(git.get("origin_main"), str)
+        or not re.fullmatch(r"[0-9a-f]{40}", git.get("origin_main"))
+        or git.get("dirty") is not False
+        or git.get("origin_main") != commit
+        or git.get("head_matches_origin_main") is not True
+        or not re.fullmatch(r"[0-9a-f]{64}", git.get("dirty_state_sha256", ""))
+        or set(git)
+        != {
+            "commit",
+            "dirty",
+            "dirty_state_sha256",
+            "origin_main",
+            "head_matches_origin_main",
+        }
+    ):
+        fail(f"{root}: full source/preflight contract not proven")
+    dataset = (root / "dataset.sha256").read_text().strip()
+    if not re.fullmatch(r"[0-9a-f]{64}", dataset):
+        fail(f"{root}: invalid canonical dataset digest")
+    rows_data = read_rows(root / "rows.csv", expected_cells)
+    completed = read_json(root / "COMPLETED")
+    if (
+        completed.get("status") != "pass"
+        or completed.get("fingerprint") != fingerprint
+        or completed.get("cells") != ",".join(expected_cells)
+        or not isinstance(completed.get("completed_at_epoch_ns"), int)
+        or completed.get("completed_at_epoch_ns", -1) <= provenance["started_at_epoch_ns"]
+    ):
+        fail(f"{root}: COMPLETED does not bind status/cells/fingerprint/time")
+    identities = []
+    for cell in expected_cells:
+        cdir = root / cell
+        validate_quiet(cdir / "quiet.tsv")
+        identities.append(validate_process(cdir / "process.tsv"))
+        for marker in ("ready", "ack"):
+            marker_path = cdir / "final-evidence" / marker
+            if marker_path.is_symlink() or not marker_path.is_file() or marker_path.read_text() != f"{marker}\n":
+                fail(f"{root}: {cell} final-evidence {marker} is not an exact regular marker")
+        manifest = read_json(cdir / "manifest.json")
+        scenario_digest = validate_scenario_roster(cdir, manifest)
+        validate_cell_chain(
+            root,
+            cell,
+            provenance,
+            scenario_digest,
+            dataset,
+            rows_data,
+            320,
+            183040,
+        )
+        if manifest.get("dataset_sha256") != dataset or manifest.get("admit_churn") is not True:
+            fail(f"{root}: {cell} manifest dataset/churn mismatch")
+        manifest_shape = tuple(
+            int(manifest.get(name, -1))
+            for name in ("n_members", "total_prefixes", "min_list", "max_list", "seed")
+        )
+        if manifest_shape != CANONICAL_SHAPE:
+            fail(f"{root}: {cell} manifest does not describe the canonical dataset")
+        if cell == "rustbgpd-sighup":
+            if manifest.get("path_hiding") is not True or manifest.get("path_hiding_applicable") is not True:
+                fail(f"{root}: private rustbgpd path-hiding mode not explicit")
+        elif cell == GROUPED_CELL:
+            if manifest.get("path_hiding") is not False or manifest.get("path_hiding_applicable") is not True:
+                fail(f"{root}: grouped rustbgpd path-hiding mode not explicit")
+        elif not (
+            manifest.get("path_hiding") is None
+            and manifest.get("path_hiding_applicable") is False
+            and manifest.get("path_hiding_requested") is True
+        ):
+            fail(f"{root}: competitor path-hiding applicability is misstated")
+        if cell in ("rustbgpd-sighup", GROUPED_CELL):
+            for marker in ("ready", "ack"):
+                marker_path = cdir / "pre-churn" / marker
+                if marker_path.is_symlink() or not marker_path.is_file() or marker_path.read_text() != f"{marker}\n":
+                    fail(f"{root}: {cell} pre-churn {marker} is not an exact regular marker")
+            topology = read_json(cdir / "topology.json")
+            expected_mode = "private" if cell == "rustbgpd-sighup" else "grouped"
+            with tempfile.NamedTemporaryFile() as revalidated:
+                validate_topology(
+                    expected_mode,
+                    320,
+                    183040,
+                    cdir / "config.toml",
+                    cdir / "topology.tsv",
+                    [cdir / f"metrics-{sample}.prom" for sample in range(1, 4)],
+                    Path(revalidated.name),
+                )
+                raw_topology = read_json(Path(revalidated.name))
+            scrapes = topology.get("scrape_epoch_ns", [])
+            if (
+                any(topology.get(key) != raw_topology.get(key) for key in ("status", "mode", "peers", "scrape_epoch_ns", "group_id"))
+                or topology.get("status") != "pass"
+                or topology.get("mode") != expected_mode
+                or topology.get("peers") != 320
+                or len(scrapes) != 3
+                or any(right - left < 1_000_000_000 for left, right in zip(scrapes, scrapes[1:]))
+                or scrapes[-1] // 1000 >= int(topology.get("first_reload_wall_us", -1))
+            ):
+                fail(f"{root}: {cell} pre-reload topology proof is invalid")
+    return {
+        "root": root,
+        "kind": kind,
+        "commit": commit,
+        "dataset": dataset,
+        "shape": actual_shape,
+        "started": int(provenance.get("started_at_epoch_ns", -1)),
+        "completed": int(completed.get("completed_at_epoch_ns", -1)),
+        "git": git,
+        "scripts": scripts,
+        "binaries": binaries,
+        "environment": environment,
+        "inputs": inputs,
+        "identities": identities,
+        "rows": rows_data,
+    }
+
+
+def audit_combined(path: Path, expected_cells: tuple[str, ...]) -> None:
+    with path.open(newline="") as stream:
+        reader = csv.reader(stream)
+        header = next(reader, None)
+        data = list(reader)
+    if header != ["repeat", *ROWS_HEADER.split(",")]:
+        fail(f"{path}: combined output header mismatch")
+    if len(data) != 8 * len(expected_cells):
+        fail(f"{path}: combined output row count mismatch")
+    for repeat in ("A", "B"):
+        repeat_rows = [row for row in data if row and row[0] == repeat]
+        if len(repeat_rows) != 4 * len(expected_cells) or {
+            row[1] for row in repeat_rows
+        } != set(expected_cells):
+            fail(f"{path}: {repeat} cell roster/count mismatch")
+        for cell in expected_cells:
+            if [row[2] for row in repeat_rows if row[1] == cell] != ["1", "2", "3", "4"]:
+                fail(f"{path}: {repeat}/{cell} reload roster mismatch")
+    if {row[0] for row in data if row} != {"A", "B"}:
+        fail(f"{path}: repeat labels must be exactly A/B")
+
+
+def write_combined(path: Path, campaigns, expected_cells: tuple[str, ...]) -> None:
+    if len(campaigns) != 2 or any(
+        {row[0] for row in campaign["rows"]} != set(expected_cells)
+        or len(campaign["rows"]) != 4 * len(expected_cells)
+        for campaign in campaigns
+    ):
+        fail(f"{path}: writer input escaped expected cell roster")
+    with path.open("w", newline="") as stream:
+        writer = csv.writer(stream, lineterminator="\n")
+        writer.writerow(["repeat", *ROWS_HEADER.split(",")])
+        for repeat, campaign in zip(("A", "B"), campaigns, strict=True):
+            for row in campaign["rows"]:
+                writer.writerow([repeat, *row])
+    audit_combined(path, expected_cells)
+
+
+def validate_campaigns(roots: list[Path], output_dir: Path) -> None:
+    if len(roots) != 4:
+        fail("expected four roots in comparison-A/grouped-A/grouped-B/comparison-B order")
+    campaigns = [
+        validate_root(roots[0], "comparison"),
+        validate_root(roots[1], "grouped"),
+        validate_root(roots[2], "grouped"),
+        validate_root(roots[3], "comparison"),
+    ]
+    if len({(entry["commit"], entry["shape"], entry["dataset"]) for entry in campaigns}) != 1:
+        fail("four roots do not share commit, canonical shape/seed, and dataset digest")
+    starts = [entry["started"] for entry in campaigns]
+    if any(value <= 0 for value in starts) or starts != sorted(starts) or len(set(starts)) != 4:
+        fail("roots are not in strict A/B/B/A execution order")
+    if any(
+        campaigns[index]["completed"] >= campaigns[index + 1]["started"]
+        for index in range(3)
+    ):
+        fail("campaign roots overlap or do not finish before the next root starts")
+    source_identity = ("git", "scripts", "binaries", "environment")
+    if any(
+        tuple(campaign[key] for key in source_identity)
+        != tuple(campaigns[0][key] for key in source_identity)
+        for campaign in campaigns[1:]
+    ):
+        fail("four roots do not share exact source, tool, and platform identities")
+    repeat_identity = ("git", "scripts", "binaries", "environment", "inputs")
+    for left, right in ((campaigns[0], campaigns[3]), (campaigns[1], campaigns[2])):
+        if tuple(left[key] for key in repeat_identity) != tuple(
+            right[key] for key in repeat_identity
+        ):
+            fail("A/B repeats do not share exact protocol, tool, and image identities")
+    identities = [identity for entry in campaigns for identity in entry["identities"]]
+    if len(identities) != len(set(identities)):
+        fail("daemon PID/start identity was reused across campaign cells")
+    output_dir.mkdir(parents=True, exist_ok=False)
+    write_combined(
+        output_dir / "comparison.csv", (campaigns[0], campaigns[3]), COMPARISON_CELLS
+    )
+    write_combined(
+        output_dir / "grouped-control.csv", (campaigns[1], campaigns[2]), (GROUPED_CELL,)
+    )
+    (output_dir / "verification.json").write_text(
+        json.dumps(
+            {
+                "status": "pass",
+                "order": ["comparison-A", "grouped-A", "grouped-B", "comparison-B"],
+                "commit": campaigns[0]["commit"],
+                "dataset_sha256": campaigns[0]["dataset"],
+                "comparison_rows": len(campaigns[0]["rows"]) + len(campaigns[3]["rows"]),
+                "grouped_control_rows": len(campaigns[1]["rows"]) + len(campaigns[2]["rows"]),
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
+def make_fixture(root: Path, kind: str, started: int, identity_seed: int) -> None:
+    cells = COMPARISON_CELLS if kind == "comparison" else (GROUPED_CELL,)
+    root.mkdir()
+    dataset = "a" * 64
+    (root / "dataset.sha256").write_text(dataset + "\n")
+    image_id = "sha256:" + "a" * 64
+    provenance = {
+        "schema": 3,
+        "started_at_epoch_ns": started,
+        "git": {"commit": "c" * 40, "dirty": False, "dirty_state_sha256": "d" * 64, "origin_main": "c" * 40, "head_matches_origin_main": True},
+        "scripts": {"runner": "1" * 64, "verifier": "2" * 64, "generator": "3" * 64, "rss_sampler": "4" * 64, "txn_apply": "5" * 64},
+        "binaries": {"reloadstall": "6" * 64, "rustbgpd": "7" * 64, "rbgp": "8" * 64, "rs_config_render": "9" * 64},
+        "environment": {key: "fixture" for key in ("rustc", "cargo", "python", "jq", "docker", "kernel", "cpu_model")},
+        "inputs": {
+            **CANONICAL_FULL_INPUTS,
+            "campaign_kind": "full-cross-daemon" if kind == "comparison" else "full-grouped-control",
+            "cells": ",".join(cells),
+            "bird_image_id": image_id if kind == "comparison" else "not-selected",
+            "openbgpd_image_id": image_id if kind == "comparison" else "not-selected",
+        },
+    }
+    provenance["fingerprint"] = provenance_fingerprint(provenance)
+    fingerprint = provenance["fingerprint"]
+    (root / "provenance.json").write_text(json.dumps(provenance))
+    (root / "preflight.log").write_text(
+        "  ok: bench-nightly cron is paused for the soak window (confirmed via fixture)\n"
+        "  ok: no pushes to main during the soak window (confirmed via fixture)\n"
+        "[preflight] READY — all pre-flight checks passed\n"
+    )
+    root_rows = []
+    with (root / "rows.csv").open("w") as stream:
+        stream.write(ROWS_HEADER + "\n")
+        for cell in cells:
+            for reload_no in range(1, 5):
+                row = [cell, str(reload_no), "320", "320", "0", "183040", *(["1"] * 14), "0", "320", "0"]
+                root_rows.append(row)
+                stream.write(",".join(row) + "\n")
+    for offset, cell in enumerate(cells):
+        cdir = root / cell
+        cdir.mkdir()
+        (cdir / "quiet.tsv").write_text("sample\tepoch_s\tload1\n1\t1\t0.5\n2\t31\t0.5\n")
+        pid = identity_seed + offset
+        (cdir / "process.tsv").write_text(f"pid\tstarttime_before\tstarttime_after\n{pid}\t{pid + 100}\t{pid + 100}\n")
+        if cell == "rustbgpd-sighup":
+            mode = {"path_hiding": True, "path_hiding_applicable": True, "path_hiding_requested": True}
+        elif cell == GROUPED_CELL:
+            mode = {"path_hiding": False, "path_hiding_applicable": True, "path_hiding_requested": False}
+        else:
+            mode = {"path_hiding": None, "path_hiding_applicable": False, "path_hiding_requested": True}
+        runtime_files = {
+            "rustbgpd-sighup": ["config.toml", "member.rpol", "gen-a.rpol", "gen-b.rpol"],
+            GROUPED_CELL: ["config.toml", "member.rpol", "gen-a.rpol", "gen-b.rpol"],
+            "bird": ["bird.conf", "gen.conf", "gen-a.conf", "gen-b.conf"],
+            "openbgpd": ["bgpd.conf", "gen.conf", "gen-a.conf", "gen-b.conf"],
+        }[cell]
+        manifest = {"dataset_sha256": dataset, "admit_churn": True, "n_members": 320, "total_prefixes": 183040, "min_list": 1000, "max_list": 40000, "seed": 61, "runtime_files": runtime_files, **mode}
+        (cdir / "manifest.json").write_text(json.dumps(manifest))
+        cell_rows = [row for row in root_rows if row[0] == cell]
+        (cdir / "rows.csv").write_text("".join(",".join(row) + "\n" for row in cell_rows))
+        (cdir / "reloadstall.log").write_text(
+            "".join("reloadstall_csv," + ",".join(row[1:]) + "\n" for row in cell_rows)
+        )
+        (cdir / "daemon.log").write_text("fixture daemon log\n")
+        (cdir / "rss.csv").write_text("epoch_s,total_rss_kib,pids\n1,1024,1\n")
+        final_boundary = cdir / "final-evidence"
+        final_boundary.mkdir()
+        (final_boundary / "ready").write_text("ready\n")
+        (final_boundary / "ack").write_text("ack\n")
+        if cell in ("rustbgpd-sighup", GROUPED_CELL):
+            topology_mode = "private" if cell == "rustbgpd-sighup" else "grouped"
+            group_id = None if topology_mode == "private" else 7
+            (cdir / "topology.json").write_text(json.dumps({"status": "pass", "mode": topology_mode, "peers": 320, "scrape_epoch_ns": [1_000_000_000, 2_000_000_000, 3_000_000_000], "group_id": group_id, "first_reload_wall_us": 4_000_000}))
+            (cdir / "config.toml").write_text("per_client_best = true\n" * (320 if cell == "rustbgpd-sighup" else 0))
+            (cdir / "topology.tsv").write_text("phase\tepoch_ns\nscrape1\t1000000000\nscrape2\t2000000000\nscrape3\t3000000000\n")
+            metrics = ["bgp_rib_outbound_registered_peers 320", "bgp_rib_ingest_channel_depth 0", "bgp_rib_policy_transition_in_progress 0", 'bgp_rib_loc_prefixes{afi_safi="all"} 183040']
+            for peer in range(320):
+                metrics += [f'bgp_peer_session_established{{interface="eth0",peer="p{peer}"}} 1', f'bgp_peer_outbound_queue_depth{{peer="p{peer}"}} 0']
+                metrics += [f'bgp_rib_prefixes{{afi_safi="{family}",peer="p{peer}"}} {572 if family == "all" else 0}' for family in ("all", "flowspec")]
+                metrics += [f'bgp_rib_adj_out_prefixes{{afi_safi="{family}",peer="p{peer}"}} {182468 if family == "all" else 0}' for family in ("all", "bgpls", "evpn", "flowspec", "labeled", "rtc", "vpn")]
+            if topology_mode == "private":
+                metrics += ["bgp_update_groups 0", "bgp_update_group_fallback_peers 320"]
+                metrics += [f'bgp_peer_update_group{{peer="p{peer}"}} -1' for peer in range(320)]
+            else:
+                metrics += ["bgp_update_groups 1", "bgp_update_group_fallback_peers 0", 'bgp_update_group_members{group="7"} 320']
+                metrics += [f'bgp_peer_update_group{{peer="p{peer}"}} 7' for peer in range(320)]
+            for sample in range(1, 4):
+                (cdir / f"metrics-{sample}.prom").write_text("\n".join(metrics) + "\n")
+            boundary = cdir / "pre-churn"
+            boundary.mkdir()
+            (boundary / "ready").write_text("ready\n")
+            (boundary / "ack").write_text("ack\n")
+        scenario_lines = []
+        for relative in [*runtime_files, "manifest.json"]:
+            retained_input = cdir / relative
+            digest = sha256(retained_input) if retained_input.is_file() else "0" * 64
+            scenario_lines.append(f"{digest}  ./{relative}")
+        (cdir / "scenario.sha256").write_text("\n".join(sorted(scenario_lines)) + "\n")
+        cell_provenance = json.loads(json.dumps(provenance))
+        cell_provenance["scenario"] = {
+            "manifest_sha256": sha256(cdir / "scenario.sha256"),
+            "dataset_sha256": dataset,
+        }
+        (cdir / "provenance.json").write_text(json.dumps(cell_provenance))
+        retained = {
+            path.relative_to(cdir).as_posix()
+            for path in cdir.rglob("*")
+            if path.is_file()
+        }
+        lines = [f"{sha256(cdir / relative)}  {relative}" for relative in sorted(retained)]
+        (cdir / "evidence.sha256").write_text("\n".join(lines) + "\n")
+        evidence_digest = sha256(cdir / "evidence.sha256")
+        scenario_digest = sha256(cdir / "scenario.sha256")
+        (cdir / "status").write_text(
+            f"pass {fingerprint} {scenario_digest} {dataset} {evidence_digest}\n"
+        )
+    (root / "COMPLETED").write_text(json.dumps({"status": "pass", "fingerprint": fingerprint, "completed_at_epoch_ns": started + 5, "cells": ",".join(cells)}))
+    reseal(root)
+    freeze(root)
+
+
+def thaw(root: Path) -> None:
+    for path in [root, *root.rglob("*")]:
+        path.chmod(path.stat().st_mode | stat.S_IWUSR)
+
+
+def freeze(root: Path) -> None:
+    for path in sorted([root, *root.rglob("*")], key=lambda item: len(item.parts), reverse=True):
+        path.chmod(path.stat().st_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
+
+
+def reseal(root: Path) -> None:
+    roster = root / "SHA256SUMS"
+    if roster.exists():
+        roster.unlink()
+    lines = []
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        lines.append(f"{sha256(path)}  {path.relative_to(root).as_posix()}")
+    roster.write_text("\n".join(lines) + "\n")
+
+
+def reseal_cell_evidence(root: Path) -> None:
+    for roster in root.rglob("evidence.sha256"):
+        cdir = roster.parent
+        status = cdir / "status"
+        retained = {
+            path.relative_to(cdir).as_posix()
+            for path in cdir.rglob("*")
+            if path.is_file() and path.name not in {"evidence.sha256", "status"}
+        }
+        roster.write_text(
+            "\n".join(
+                f"{sha256(cdir / relative)}  {relative}" for relative in sorted(retained)
+            )
+            + "\n"
+        )
+        prior = status.read_text().split()
+        status.write_text(
+            f"pass {prior[1]} {sha256(cdir / 'scenario.sha256')} {prior[3]} {sha256(roster)}\n"
+        )
+
+
+def rebind_provenance(root: Path) -> None:
+    provenance_path = root / "provenance.json"
+    provenance = read_json(provenance_path)
+    provenance["fingerprint"] = provenance_fingerprint(provenance)
+    provenance_path.write_text(json.dumps(provenance))
+    for cell in (*COMPARISON_CELLS, GROUPED_CELL):
+        cell_path = root / cell / "provenance.json"
+        if not cell_path.is_file():
+            continue
+        cell_provenance = read_json(cell_path)
+        scenario = cell_provenance["scenario"]
+        cell_path.write_text(json.dumps({**provenance, "scenario": scenario}))
+        status_path = cell_path.parent / "status"
+        status = status_path.read_text().split()
+        status[1] = provenance["fingerprint"]
+        status_path.write_text(" ".join(status) + "\n")
+    completed_path = root / "COMPLETED"
+    completed = read_json(completed_path)
+    completed["fingerprint"] = provenance["fingerprint"]
+    completed_path.write_text(json.dumps(completed))
+
+
+def self_test() -> None:
+    proofs = {}
+    with tempfile.TemporaryDirectory() as directory:
+        base = Path(directory)
+        topology_dir = base / "topology"
+        topology_dir.mkdir()
+        timestamps = topology_dir / "timestamps.tsv"
+        timestamps.write_text(
+            "phase\tepoch_ns\n"
+            "scrape1\t1000000000\n"
+            "scrape2\t2000000000\n"
+            "scrape3\t3000000000\n"
+        )
+
+        def metric_text(mode: str, bad: str | None = None) -> str:
+            lines = [
+                "bgp_rib_outbound_registered_peers 2",
+                "bgp_rib_ingest_channel_depth 0",
+                "bgp_rib_policy_transition_in_progress 0",
+                f'bgp_rib_loc_prefixes{{afi_safi="all"}} {7 if bad == "route-gauge" else 8}',
+            ]
+            for peer in ("p0", "p1"):
+                lines += [
+                    f'bgp_peer_session_established{{interface="eth0",peer="{peer}"}} 1',
+                    f'bgp_peer_outbound_queue_depth{{peer="{peer}"}} 0',
+                ]
+                lines += [
+                    f'bgp_rib_prefixes{{afi_safi="{family}",peer="{peer}"}} '
+                    f'{4 if family == "all" else int(bad == "route-family" and peer == "p1")}'
+                    for family in ("all", "flowspec")
+                ]
+                lines += [
+                    f'bgp_rib_adj_out_prefixes{{afi_safi="{family}",peer="{peer}"}} '
+                    f'{4 if family == "all" else 0}'
+                    for family in ("all", "bgpls", "evpn", "flowspec", "labeled", "rtc", "vpn")
+                ]
+            if mode == "private":
+                lines += ["bgp_update_groups 0", "bgp_update_group_fallback_peers 2"]
+                lines += [f'bgp_peer_update_group{{peer="p{index}"}} -1' for index in range(2)]
+            else:
+                group = 8 if bad == "drift" else 7
+                lines += [f"bgp_update_groups {2 if bad == 'group' else 1}", "bgp_update_group_fallback_peers 0", f'bgp_update_group_members{{group="{group}"}} 2']
+                lines += [f'bgp_peer_update_group{{peer="p{index}"}} {group}' for index in range(2)]
+            return "\n".join(lines) + "\n"
+
+        for mode in ("private", "grouped"):
+            config = topology_dir / f"{mode}.toml"
+            config.write_text("per_client_best = true\n" * (2 if mode == "private" else 0))
+            paths = []
+            for sample in range(1, 4):
+                path = topology_dir / f"{mode}-{sample}.prom"
+                path.write_text(metric_text(mode))
+                paths.append(path)
+            validate_topology(mode, 2, 8, config, timestamps, paths, topology_dir / f"{mode}.json")
+        def topology_rejected(name: str, bad: str, config: Path | None = None):
+            paths = []
+            for sample in range(1, 4):
+                path = topology_dir / f"{name}-{sample}.prom"
+                effective_bad = bad if bad != "drift" or sample == 3 else None
+                path.write_text(metric_text("grouped", effective_bad))
+                paths.append(path)
+            try:
+                validate_topology("grouped", 2, 8, config or topology_dir / "grouped.toml", timestamps, paths, topology_dir / f"{name}.json")
+            except InvalidReceipt:
+                proofs[name] = True
+
+        topology_rejected("live-topology-gauge", "group")
+        topology_rejected("route-gauge", "route-gauge")
+        topology_rejected("route-family", "route-family")
+        topology_rejected("one-scrape-drift", "drift")
+        add_path = topology_dir / "add-path.toml"
+        add_path.write_text("[neighbors.add_path]\nsend = true\n")
+        topology_rejected("add-path", "none", add_path)
+        wrong_count = topology_dir / "wrong-count.toml"
+        wrong_count.write_text("per_client_best = true\n")
+        topology_rejected("config-count", "none", wrong_count)
+        names = ("comparison-a", "grouped-a", "grouped-b", "comparison-b")
+        kinds = ("comparison", "grouped", "grouped", "comparison")
+        roots = [base / name for name in names]
+        for index, (root, kind) in enumerate(zip(roots, kinds, strict=True)):
+            make_fixture(root, kind, 10 + index * 10, 1000 + index * 10)
+        good_output = base / "good-output"
+        validate_campaigns(roots, good_output)
+        audit_combined(good_output / "comparison.csv", COMPARISON_CELLS)
+        audit_combined(good_output / "grouped-control.csv", (GROUPED_CELL,))
+
+        def rejected(
+            name, mutate, reseal_after=True, freeze_after=True, cell_reseal=True
+        ):
+            copied = base / f"bad-{name}"
+            shutil.copytree(base / "comparison-a", copied)
+            thaw(copied)
+            mutate(copied)
+            if reseal_after:
+                if cell_reseal:
+                    reseal_cell_evidence(copied)
+                reseal(copied)
+            if freeze_after:
+                freeze(copied)
+            bad_roots = [copied, roots[1], roots[2], roots[3]]
+            try:
+                validate_campaigns(bad_roots, base / f"output-{name}")
+            except InvalidReceipt:
+                proofs[name] = True
+                return
+            fail(f"red fixture unexpectedly accepted: {name}")
+
+        def alter_json(path, function):
+            data = read_json(path); function(data); path.write_text(json.dumps(data))
+        rejected("default-roster", lambda root: alter_json(root / "provenance.json", lambda data: data["inputs"].update({"cells": "bird"})))
+        rejected("mixed-roster", lambda root: alter_json(root / "provenance.json", lambda data: data["inputs"].update({"cells": f"{','.join(COMPARISON_CELLS)},{GROUPED_CELL}"})))
+        rejected("mode-flags", lambda root: alter_json(root / "rustbgpd-sighup/manifest.json", lambda data: data.update({"path_hiding": False})))
+        rejected("topology-mutation", lambda root: alter_json(root / "rustbgpd-sighup/topology.json", lambda data: data.update({"first_reload_wall_us": 2_000_000})))
+        rejected("barrier-marker", lambda root: (root / "rustbgpd-sighup/pre-churn/ack").write_text("stale\n"))
+        rejected("final-barrier-marker", lambda root: (root / "bird/final-evidence/ack").write_text("stale\n"))
+        rejected("dirty-commit", lambda root: alter_json(root / "provenance.json", lambda data: data["git"].update({"dirty": True})))
+        rejected("origin-only", lambda root: alter_json(root / "provenance.json", lambda data: data["git"].update({"origin_main": "e" * 40})))
+        rejected("head-matches-false", lambda root: alter_json(root / "provenance.json", lambda data: data["git"].update({"head_matches_origin_main": False})))
+        rejected("mismatched-commit", lambda root: alter_json(root / "provenance.json", lambda data: data["git"].update({"commit": "d" * 40, "origin_main": "d" * 40})))
+        rejected("commit-malformed", lambda root: alter_json(root / "provenance.json", lambda data: data["git"].update({"commit": "C" * 40, "origin_main": "C" * 40})))
+        rejected("scripts-null", lambda root: alter_json(root / "provenance.json", lambda data: data.update({"scripts": None})))
+        rejected("scripts-empty-map", lambda root: alter_json(root / "provenance.json", lambda data: data.update({"scripts": {}})))
+        rejected("binary-malformed", lambda root: alter_json(root / "provenance.json", lambda data: data["binaries"].update({"rbgp": "not-a-digest"})))
+        rejected("fingerprint-recompute", lambda root: alter_json(root / "provenance.json", lambda data: data["environment"].update({"docker": "changed"})))
+        def change_input_and_rebind(root, key, value):
+            alter_json(root / "provenance.json", lambda data: data["inputs"].update({key: value}))
+            rebind_provenance(root)
+        rejected("canonical-changed-fraction", lambda root: change_input_and_rebind(root, "changed_fraction", "0.2"))
+        rejected("canonical-control-secs", lambda root: change_input_and_rebind(root, "control_secs", "31"))
+        rejected("canonical-bird-threads", lambda root: change_input_and_rebind(root, "bird_threads", "7"))
+        rejected("repeat-image-identity", lambda root: change_input_and_rebind(root, "bird_image_id", "sha256:" + "b" * 64))
+        rejected("cell-root-provenance", lambda root: alter_json(root / "bird/provenance.json", lambda data: data["environment"].update({"docker": "cell-only"})))
+        def overlap_next_root(root):
+            alter_json(root / "COMPLETED", lambda data: data.update({"completed_at_epoch_ns": 20}))
+        rejected("nonoverlap-order", overlap_next_root)
+        rejected("quiet-spacing", lambda root: (root / "bird/quiet.tsv").write_text("sample\tepoch_s\tload1\n1\t1\t0.5\n2\t2\t0.5\n"))
+        rejected("preflight-raw", lambda root: (root / "preflight.log").write_text("FAIL: fixture\n"))
+        rejected("cell-status", lambda root: (root / "bird/status").write_text("fail stale\n"), cell_reseal=False)
+        rejected("cell-provenance", lambda root: alter_json(root / "bird/provenance.json", lambda data: data["scenario"].update({"dataset_sha256": "b" * 64})))
+        def break_evidence_roster(root):
+            roster = root / "bird/evidence.sha256"
+            roster.write_text("\n".join(roster.read_text().splitlines()[1:]) + "\n")
+            status = root / "bird/status"
+            fields = status.read_text().split()
+            fields[4] = sha256(roster)
+            status.write_text(" ".join(fields) + "\n")
+        rejected("evidence-roster", break_evidence_roster, cell_reseal=False)
+        def rebind_scenario_manifest(cdir):
+            manifest_path = cdir / "manifest.json"
+            scenario_path = cdir / "scenario.sha256"
+            lines = [
+                f"{sha256(manifest_path)}  ./manifest.json"
+                if line.endswith("  ./manifest.json")
+                else line
+                for line in scenario_path.read_text().splitlines()
+            ]
+            scenario_path.write_text("\n".join(lines) + "\n")
+            alter_json(
+                cdir / "provenance.json",
+                lambda data: data["scenario"].update(
+                    {"manifest_sha256": sha256(scenario_path)}
+                ),
+            )
+        def break_scenario_roster(root):
+            cdir = root / "bird"
+            manifest_path = cdir / "manifest.json"
+            alter_json(manifest_path, lambda data: data["runtime_files"].append("extra.conf"))
+            rebind_scenario_manifest(cdir)
+        rejected("scenario-roster", break_scenario_roster)
+        def break_scenario_duplicate(root):
+            cdir = root / "bird"
+            alter_json(cdir / "manifest.json", lambda data: data["runtime_files"].append("bird.conf"))
+            rebind_scenario_manifest(cdir)
+        rejected("scenario-duplicate", break_scenario_duplicate)
+        def break_scenario_unsafe(root):
+            cdir = root / "bird"
+            alter_json(cdir / "manifest.json", lambda data: data["runtime_files"].__setitem__(0, "../bird.conf"))
+            scenario_path = cdir / "scenario.sha256"
+            lines = [
+                line.replace("  ./bird.conf", "  ./../bird.conf")
+                if line.endswith("  ./bird.conf")
+                else line
+                for line in scenario_path.read_text().splitlines()
+            ]
+            scenario_path.write_text("\n".join(lines) + "\n")
+            rebind_scenario_manifest(cdir)
+        rejected("scenario-unsafe-path", break_scenario_unsafe)
+        rejected("scenario-retained-config", lambda root: (root / "rustbgpd-sighup/config.toml").write_text((root / "rustbgpd-sighup/config.toml").read_text() + "# drift\n"))
+        rejected("cell-root-rows", lambda root: (root / "bird/rows.csv").write_text((root / "bird/rows.csv").read_text().replace(",1,1,1,", ",2,1,1,", 1)))
+        rejected("reload-log-rows", lambda root: (root / "bird/reloadstall.log").write_text("reloadstall_csv,missing\n"))
+        def break_percentile(root, start, values):
+            root_rows_path = root / "rows.csv"
+            with root_rows_path.open(newline="") as stream:
+                all_rows = list(csv.reader(stream))
+            header, data = all_rows[0], all_rows[1:]
+            target = next(row for row in data if row[0] == "bird")
+            target[start : start + 3] = values
+            with root_rows_path.open("w", newline="") as stream:
+                writer = csv.writer(stream, lineterminator="\n")
+                writer.writerow(header)
+                writer.writerows(data)
+            bird_rows = [row for row in data if row[0] == "bird"]
+            with (root / "bird/rows.csv").open("w", newline="") as stream:
+                csv.writer(stream, lineterminator="\n").writerows(bird_rows)
+            (root / "bird/reloadstall.log").write_text(
+                "".join(
+                    "reloadstall_csv," + ",".join(row[1:]) + "\n"
+                    for row in bird_rows
+                )
+            )
+        rejected("percentile-order", lambda root: break_percentile(root, 6, ["3", "2", "1"]))
+        rejected("percentile-positive", lambda root: break_percentile(root, 15, ["0", "1", "2"]))
+        rejected("first-generation-bound", lambda root: break_percentile(root, 15, ["1001", "1001", "1001"]))
+        rejected("observer-gap-bound", lambda root: break_percentile(root, 9, ["2", "2", "2"]))
+        def break_row_invariant(root):
+            for relative in ("rows.csv", "bird/rows.csv", "bird/reloadstall.log"):
+                path = root / relative
+                path.write_text(path.read_text().replace(",320,320,0,183040,", ",320,319,0,183040,", 1))
+        rejected("row-invariants", break_row_invariant)
+        rejected("rss-raw", lambda root: (root / "bird/rss.csv").write_text("epoch_s,total_rss_kib,pids\n1,0,1\n"))
+        def break_top_checksum_only(root):
+            daemon_log = root / "bird/daemon.log"
+            daemon_log.write_text(daemon_log.read_text() + "semantically harmless line\n")
+            reseal_cell_evidence(root)
+        rejected("seal-checksum", break_top_checksum_only, reseal_after=False)
+        rejected("exact-root-roster", lambda root: (root / "unexpected.txt").write_text("unexpected\n"))
+        def replace_with_symlink(root):
+            daemon_log = root / "bird/daemon.log"
+            daemon_log.unlink()
+            daemon_log.symlink_to("../preflight.log")
+        rejected("symlink-anywhere", replace_with_symlink)
+        rejected("writable-root", lambda root: None, freeze_after=False)
+        comparison_campaigns = [validate_root(roots[0], "comparison"), validate_root(roots[3], "comparison")]
+        escaped = [
+            {**campaign, "rows": [row.copy() for row in campaign["rows"]]}
+            for campaign in comparison_campaigns
+        ]
+        escaped[0]["rows"][0][0] = GROUPED_CELL
+        original_audit = globals()["audit_combined"]
+        globals()["audit_combined"] = lambda _path, _cells: None
+        try:
+            write_combined(base / "escaped-comparison.csv", escaped, COMPARISON_CELLS)
+        except InvalidReceipt:
+            proofs["grouped-output-isolation"] = True
+        finally:
+            globals()["audit_combined"] = original_audit
+        corrupted_output = base / "corrupt-comparison.csv"
+        shutil.copyfile(good_output / "comparison.csv", corrupted_output)
+        corrupted_output.write_text(corrupted_output.read_text().replace("A,", "C,", 1))
+        try:
+            audit_combined(corrupted_output, COMPARISON_CELLS)
+        except InvalidReceipt:
+            proofs["output-exact-roster"] = True
+        class AuditCalled(Exception):
+            pass
+        def audit_sentinel(_path, _cells):
+            raise AuditCalled
+        globals()["audit_combined"] = audit_sentinel
+        try:
+            write_combined(base / "audit-call.csv", comparison_campaigns, COMPARISON_CELLS)
+        except AuditCalled:
+            proofs["output-audit-call"] = True
+        finally:
+            globals()["audit_combined"] = original_audit
+        # Separate roots cover ordering and cross-root identity reuse.
+        reordered = [roots[0], roots[2], roots[1], roots[3]]
+        try:
+            validate_campaigns(reordered, base / "output-ordering")
+        except InvalidReceipt:
+            proofs["ordering"] = True
+        reused = base / "reused"
+        shutil.copytree(roots[1], reused); thaw(reused)
+        shutil.copyfile(roots[2] / "rustbgpd-sighup-grouped-control/process.tsv", reused / "rustbgpd-sighup-grouped-control/process.tsv")
+        reseal_cell_evidence(reused); reseal(reused); freeze(reused)
+        try:
+            validate_campaigns([roots[0], reused, roots[2], roots[3]], base / "output-reused")
+        except InvalidReceipt:
+            proofs["reused-identity"] = True
+        def grouped_pair_drift(name, section, key, value):
+            changed = []
+            for suffix, source in zip(("a", "b"), roots[1:3], strict=True):
+                copied = base / f"bad-{name}-{suffix}"
+                shutil.copytree(source, copied)
+                thaw(copied)
+                alter_json(
+                    copied / "provenance.json",
+                    lambda data: data[section].update({key: value}),
+                )
+                rebind_provenance(copied)
+                reseal_cell_evidence(copied)
+                reseal(copied)
+                freeze(copied)
+                changed.append(copied)
+            try:
+                validate_campaigns(
+                    [roots[0], *changed, roots[3]], base / f"output-{name}"
+                )
+            except InvalidReceipt:
+                proofs[name] = True
+        grouped_pair_drift("cross-role-environment", "environment", "cpu_model", "other-platform")
+        grouped_pair_drift("cross-role-source-identity", "binaries", "rbgp", "a" * 64)
+        expected = {"default-roster", "mixed-roster", "mode-flags", "topology-mutation", "barrier-marker", "final-barrier-marker", "live-topology-gauge", "route-gauge", "route-family", "one-scrape-drift", "add-path", "config-count", "dirty-commit", "origin-only", "head-matches-false", "mismatched-commit", "commit-malformed", "scripts-null", "scripts-empty-map", "binary-malformed", "fingerprint-recompute", "canonical-changed-fraction", "canonical-control-secs", "canonical-bird-threads", "repeat-image-identity", "cell-root-provenance", "nonoverlap-order", "quiet-spacing", "preflight-raw", "cell-status", "cell-provenance", "evidence-roster", "scenario-roster", "scenario-duplicate", "scenario-unsafe-path", "scenario-retained-config", "cell-root-rows", "reload-log-rows", "percentile-order", "percentile-positive", "first-generation-bound", "observer-gap-bound", "row-invariants", "rss-raw", "seal-checksum", "exact-root-roster", "symlink-anywhere", "writable-root", "grouped-output-isolation", "output-exact-roster", "output-audit-call", "ordering", "reused-identity", "cross-role-environment", "cross-role-source-identity"}
+        missing = expected - proofs.keys()
+        if missing:
+            fail(f"self-test proofs did not reject: {sorted(missing)}")
+        for name in sorted(expected):
+            print(f"red-proof {name}=pass")
+        print("SELF_TEST pass")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    topology = subparsers.add_parser("topology")
+    topology.add_argument("--mode", choices=("private", "grouped"), required=True)
+    topology.add_argument("--peers", type=int, required=True)
+    topology.add_argument("--total", type=int, required=True)
+    topology.add_argument("--config", type=Path, required=True)
+    topology.add_argument("--timestamps", type=Path, required=True)
+    topology.add_argument("--output", type=Path, required=True)
+    topology.add_argument("metrics", nargs=3, type=Path)
+    campaigns = subparsers.add_parser("campaigns")
+    campaigns.add_argument("--output-dir", required=True, type=Path)
+    campaigns.add_argument("roots", nargs=4, type=Path)
+    subparsers.add_parser("self-test")
+    args = parser.parse_args()
+    try:
+        if args.command == "topology":
+            validate_topology(args.mode, args.peers, args.total, args.config, args.timestamps, args.metrics, args.output)
+        elif args.command == "campaigns":
+            validate_campaigns(args.roots, args.output_dir)
+        else:
+            self_test()
+    except (InvalidReceipt, OSError, KeyError, TypeError, ValueError) as error:
+        print(f"receipt invalid: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/scale/matrix/rss-sampler.sh
+++ b/bench/scale/matrix/rss-sampler.sh
@@ -42,6 +42,12 @@ while [ -d "/proc/$root" ]; do
             n=$((n + 1))
         fi
     done
+    # The root can exit after the loop's /proc liveness check but before its
+    # status is read. Do not turn that teardown race into a bogus zero sample.
+    if [ "$n" -eq 0 ] || [ "$total" -eq 0 ]; then
+        sleep "$interval"
+        continue
+    fi
     echo "$(date +%s),$total,$n" >>"$out"
     sleep "$interval"
 done

--- a/bench/scale/reloadstall/src/main.rs
+++ b/bench/scale/reloadstall/src/main.rs
@@ -88,6 +88,7 @@ const CONNECT_WINDOW: Duration = Duration::from_secs(120);
 const FLAP_ROUNDS: u32 = 3;
 const FLAP_RECONNECT_SECS: u64 = 10;
 const EVIDENCE_TIMEOUT: Duration = Duration::from_secs(15);
+const PRE_CHURN_EVIDENCE_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// What the shared per-observer bitmap is armed to track (flapstorm mode).
 const FLAP_OFF: u32 = 0;
@@ -934,6 +935,52 @@ async fn await_evidence_capture(evidence_dir: &Path, timeout: Duration) -> std::
     Ok(())
 }
 
+async fn await_pre_churn_evidence_capture(
+    evidence_dir: &Path,
+    timeout: Duration,
+) -> std::io::Result<()> {
+    std::fs::create_dir_all(evidence_dir)?;
+    if std::fs::read_dir(evidence_dir)?.next().is_some() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            "pre-churn evidence directory is not empty",
+        ));
+    }
+    std::fs::write(evidence_dir.join("ready"), b"ready\n")?;
+    if !std::fs::symlink_metadata(evidence_dir.join("ready"))?
+        .file_type()
+        .is_file()
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "pre-churn ready marker is not a regular file",
+        ));
+    }
+    let deadline = Instant::now() + timeout;
+    loop {
+        match std::fs::symlink_metadata(evidence_dir.join("ack")) {
+            Ok(metadata) if metadata.file_type().is_file() => return Ok(()),
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        if Instant::now() >= deadline {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!(
+                    "pre-churn evidence acknowledgement not received within {}s",
+                    timeout.as_secs()
+                ),
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+fn final_evidence_allowed(_reloads: u32, flapstorm: Option<u32>) -> bool {
+    flapstorm.is_none()
+}
+
 #[allow(clippy::too_many_lines)]
 fn main() {
     let mut a: Vec<String> = std::env::args().collect();
@@ -974,6 +1021,8 @@ fn main() {
     let changed_peers: u32 = a.get(10).map_or(n_peers, |value| value.parse().unwrap());
     let reload_cmd: Option<String> = a.get(11).cloned();
     let evidence_dir = std::env::var_os("RELOADSTALL_EVIDENCE_DIR").map(PathBuf::from);
+    let pre_churn_evidence_dir =
+        std::env::var_os("RELOADSTALL_PRE_CHURN_EVIDENCE_DIR").map(PathBuf::from);
     assert!(n_peers >= CHURNERS, "n_peers must be at least {CHURNERS}");
     assert!(
         (1..=n_peers).contains(&changed_peers),
@@ -984,8 +1033,8 @@ fn main() {
         "daemon_pid 0 (outer RSS sampler) requires reload_cmd or --flapstorm"
     );
     assert!(
-        evidence_dir.is_none() || (reloads == 0 && flapstorm.is_none()),
-        "RELOADSTALL_EVIDENCE_DIR is only valid for zero-reload measurements"
+        evidence_dir.is_none() || final_evidence_allowed(reloads, flapstorm),
+        "RELOADSTALL_EVIDENCE_DIR is not valid for flapstorm measurements"
     );
     if let Some(k) = flapstorm {
         assert!(
@@ -1113,6 +1162,15 @@ fn main() {
             ctx.t0.elapsed().as_secs_f64(),
             rss_mib(pid)
         );
+
+        if let Some(evidence_dir) = pre_churn_evidence_dir.as_deref() {
+            if let Err(error) =
+                await_pre_churn_evidence_capture(evidence_dir, PRE_CHURN_EVIDENCE_TIMEOUT).await
+            {
+                eprintln!("FAIL: pre-churn evidence handshake failed: {error}");
+                std::process::exit(1);
+            }
+        }
 
         // --- Start churn: last CHURNERS stubs flap a dedicated block. ---
         for c in 0..CHURNERS {
@@ -1472,18 +1530,17 @@ mod tests {
     #[tokio::test]
     async fn evidence_handshake_keeps_boundary_until_ack() {
         let directory = evidence_test_dir("ack");
-        let writer_dir = directory.clone();
-        let ack_writer = tokio::spawn(async move {
-            while !writer_dir.join("ready").is_file() {
-                tokio::time::sleep(Duration::from_millis(1)).await;
-            }
-            std::fs::write(writer_dir.join("ack"), b"ack\n").unwrap();
+        let waiter_dir = directory.clone();
+        let waiter = tokio::spawn(async move {
+            await_evidence_capture(&waiter_dir, Duration::from_secs(1)).await
         });
-
-        await_evidence_capture(&directory, Duration::from_secs(1))
-            .await
-            .unwrap();
-        ack_writer.await.unwrap();
+        while !directory.join("ready").is_file() {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(!waiter.is_finished(), "barrier advanced before regular ack");
+        std::fs::write(directory.join("ack"), b"ack\n").unwrap();
+        waiter.await.unwrap().unwrap();
         assert!(directory.join("ready").is_file());
         std::fs::remove_dir_all(directory).unwrap();
     }
@@ -1491,7 +1548,7 @@ mod tests {
     #[tokio::test]
     async fn evidence_handshake_timeout_fails_closed() {
         let directory = evidence_test_dir("timeout");
-        let error = await_evidence_capture(&directory, Duration::from_millis(10))
+        let error = await_pre_churn_evidence_capture(&directory, Duration::from_millis(10))
             .await
             .unwrap_err();
 
@@ -1507,13 +1564,62 @@ mod tests {
             std::fs::create_dir_all(&directory).unwrap();
             std::fs::write(directory.join(marker), b"stale\n").unwrap();
 
-            let error = await_evidence_capture(&directory, Duration::from_millis(10))
+            let error =
+                await_pre_churn_evidence_capture(&directory, Duration::from_millis(10))
                 .await
                 .unwrap_err();
 
             assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
             std::fs::remove_dir_all(directory).unwrap();
         }
+    }
+
+    #[tokio::test]
+    async fn evidence_handshake_rejects_non_regular_ack() {
+        let directory = evidence_test_dir("ack-directory");
+        let writer_dir = directory.clone();
+        let writer = tokio::spawn(async move {
+            while !writer_dir.join("ready").is_file() {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            std::fs::create_dir(writer_dir.join("ack")).unwrap();
+        });
+        let error = await_pre_churn_evidence_capture(&directory, Duration::from_millis(25))
+            .await
+            .unwrap_err();
+        writer.await.unwrap();
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn pre_churn_evidence_barrier_is_ordered_before_churn() {
+        let source = include_str!("main.rs");
+        let converged = source.find("\"converged (>=").unwrap();
+        let barrier = source
+            .find("await_pre_churn_evidence_capture(evidence_dir, PRE_CHURN_EVIDENCE_TIMEOUT)")
+            .unwrap();
+        let churn = source.find("// --- Start churn:").unwrap();
+        assert!(converged < barrier && barrier < churn);
+        let opt_in = ["RELOADSTALL_PRE_", "CHURN_EVIDENCE_DIR"].concat();
+        assert_eq!(
+            source.matches(&opt_in).count(),
+            1,
+            "removing opt-in or making the barrier unconditional changes behavior"
+        );
+    }
+
+    #[test]
+    fn final_evidence_accepts_reloads_but_rejects_flapstorm() {
+        assert!(final_evidence_allowed(4, None));
+        assert!(final_evidence_allowed(0, None));
+        assert!(!final_evidence_allowed(0, Some(1)));
+        assert!(!final_evidence_allowed(4, Some(1)));
+    }
+
+    #[test]
+    fn pre_churn_evidence_timeout_is_exactly_sixty_seconds() {
+        assert_eq!(PRE_CHURN_EVIDENCE_TIMEOUT, Duration::from_secs(60));
     }
 
     #[test]

--- a/bench/scale/reloadstall/src/main.rs
+++ b/bench/scale/reloadstall/src/main.rs
@@ -1564,8 +1564,7 @@ mod tests {
             std::fs::create_dir_all(&directory).unwrap();
             std::fs::write(directory.join(marker), b"stale\n").unwrap();
 
-            let error =
-                await_pre_churn_evidence_capture(&directory, Duration::from_millis(10))
+            let error = await_pre_churn_evidence_capture(&directory, Duration::from_millis(10))
                 .await
                 .unwrap_err();
 

--- a/tests/reloadstall_scenario_emitted_check.rs
+++ b/tests/reloadstall_scenario_emitted_check.rs
@@ -187,6 +187,27 @@ fn irr_reload_campaign_seals_resume_rows_and_rss_evidence() {
     assert!(terminate.contains("wait \"$pid\""));
 }
 
+#[test]
+/// Red proof: removing or moving the empty-sample guard after the CSV append
+/// makes this fail, restoring the teardown race's bogus terminal `0,0` row.
+fn rss_sampler_drops_empty_teardown_samples_before_append() {
+    let sampler = std::fs::read_to_string(format!(
+        "{}/bench/scale/matrix/rss-sampler.sh",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .expect("read RSS sampler");
+    let guard = sampler
+        .find("if [ \"$n\" -eq 0 ] || [ \"$total\" -eq 0 ]; then")
+        .expect("empty RSS sample guard");
+    let append = sampler
+        .find("echo \"$(date +%s),$total,$n\" >>\"$out\"")
+        .expect("RSS sample append");
+    assert!(
+        guard < append,
+        "empty samples must be rejected before append"
+    );
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 /// Red proof: removing the process-group KILL escalation leaves the TERM-
@@ -740,6 +761,248 @@ fn irr_reload_manifest_seals_a_cell_independent_dataset_digest() {
     )
     .expect("parse manifest");
     assert_ne!(manifest["dataset_sha256"], digests[0]);
+}
+
+#[test]
+/// Red proofs: removing a semantic verifier check makes its named corrupt
+/// fixture pass; changing the default/control rosters or their explicit mode
+/// flags fails the executed dry-protocol assertions. Removing the pre-trigger
+/// topology call, quiet double-sample, source fence, identity fence, or final
+/// immutable seal fails the corresponding structural assertion below.
+fn irr_reload_counterbalanced_receipt_protocol_is_load_bearing() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let runner = format!("{root}/bench/scale/irrreload/run-irr-reload.sh");
+    let verifier = format!("{root}/bench/scale/irrreload/verify-receipt.py");
+
+    let self_test = std::process::Command::new("python3")
+        .args([&verifier, "self-test"])
+        .output()
+        .expect("run receipt verifier self-test");
+    assert!(
+        self_test.status.success(),
+        "verifier self-test failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&self_test.stdout),
+        String::from_utf8_lossy(&self_test.stderr)
+    );
+    let stdout = String::from_utf8(self_test.stdout).expect("self-test UTF-8");
+    for proof in [
+        "default-roster",
+        "mixed-roster",
+        "mode-flags",
+        "live-topology-gauge",
+        "route-gauge",
+        "route-family",
+        "one-scrape-drift",
+        "add-path",
+        "config-count",
+        "topology-mutation",
+        "barrier-marker",
+        "final-barrier-marker",
+        "ordering",
+        "dirty-commit",
+        "origin-only",
+        "head-matches-false",
+        "mismatched-commit",
+        "commit-malformed",
+        "scripts-null",
+        "scripts-empty-map",
+        "binary-malformed",
+        "fingerprint-recompute",
+        "canonical-changed-fraction",
+        "canonical-control-secs",
+        "canonical-bird-threads",
+        "repeat-image-identity",
+        "cell-root-provenance",
+        "nonoverlap-order",
+        "reused-identity",
+        "quiet-spacing",
+        "preflight-raw",
+        "cell-status",
+        "cell-provenance",
+        "evidence-roster",
+        "scenario-roster",
+        "scenario-duplicate",
+        "scenario-unsafe-path",
+        "scenario-retained-config",
+        "cell-root-rows",
+        "reload-log-rows",
+        "row-invariants",
+        "rss-raw",
+        "seal-checksum",
+        "exact-root-roster",
+        "symlink-anywhere",
+        "writable-root",
+        "grouped-output-isolation",
+        "output-exact-roster",
+        "output-audit-call",
+    ] {
+        assert!(
+            stdout.contains(&format!("red-proof {proof}=pass")),
+            "{proof}"
+        );
+    }
+
+    let dry = |cells: &[&str]| {
+        std::process::Command::new("bash")
+            .arg(&runner)
+            .args(cells)
+            .env("DRY_RUN_PROTOCOL", "1")
+            .env_remove("SMOKE")
+            .output()
+            .expect("run dry protocol")
+    };
+    let comparison = dry(&[]);
+    assert!(comparison.status.success());
+    let comparison = String::from_utf8(comparison.stdout).expect("comparison UTF-8");
+    assert!(comparison.contains("cells=rustbgpd-sighup,bird,openbgpd\n"));
+    assert!(comparison.contains("campaign_kind=full-cross-daemon\n"));
+    assert!(comparison.contains("rustbgpd_private=path_hiding:true,admit_churn:true\n"));
+    assert!(comparison.contains("competitor_path_hiding=applicable:false,requested:true\n"));
+    assert!(comparison.contains("shape=320,183040,1000,40000\n"));
+
+    let grouped = dry(&["rustbgpd-sighup-grouped-control"]);
+    assert!(grouped.status.success());
+    let grouped = String::from_utf8(grouped.stdout).expect("grouped UTF-8");
+    assert!(grouped.contains("cells=rustbgpd-sighup-grouped-control\n"));
+    assert!(grouped.contains("campaign_kind=full-grouped-control\n"));
+    assert!(
+        grouped.contains(
+            "rustbgpd_grouped_control=path_hiding:false,admit_churn:true,standalone:true\n"
+        )
+    );
+    let mixed = dry(&["rustbgpd-sighup", "rustbgpd-sighup-grouped-control"]);
+    assert!(
+        !mixed.status.success(),
+        "grouped control entered comparison roster"
+    );
+
+    let script = std::fs::read_to_string(&runner).expect("read runner");
+    assert!(
+        script.lines().count() <= 950,
+        "runner parsing belongs in Python"
+    );
+    for guard in [
+        "RELOADSTALL_PRE_CHURN_EVIDENCE_DIR=\"$barrier\"",
+        "RELOADSTALL_EVIDENCE_DIR=\"$final_barrier\"",
+        "jq -cS . | sha256sum",
+        "320,183040,1000,40000,61,4,0.1,1790,30,4194275,7200,600,8",
+        "capture_topology \"$topology_mode\" \"$cdir\" \"$run\" \"$hpid\" \"$barrier\"",
+        "ack_pre_churn \"$barrier\" true \"$cdir\"",
+        "--peers \"$N_MEMBERS\" --total \"$TOTAL_PREFIXES\"",
+        "TOPOLOGY_CAPTURE_TIMEOUT=50",
+        "deadline=$((SECONDS + TOPOLOGY_CAPTURE_TIMEOUT))",
+        "rm -f \"$cdir/topology.json\" \"$cdir\"/metrics-{1,2,3}.prom",
+        "bind_first_trigger \"$cdir\"",
+        "full measured campaigns require a clean HEAD exactly at origin/main",
+        "printf 'sample\\tepoch_s\\tload1\\n'",
+        "[ \"$sample\" -gt 2 ] || sleep 30",
+        "daemon PID/start identity changed",
+        "find . -type f ! -name SHA256SUMS",
+        "chmod -R a-w \"$ART\"",
+    ] {
+        assert!(script.contains(guard), "missing protocol guard: {guard}");
+    }
+}
+
+#[test]
+/// Red proof: moving the atomic `ack` publish before the `/proc` starttime
+/// comparison or process.tsv capture fails the source-order assertions;
+/// removing the mismatch guard makes the wrong-start invocation create ack.
+fn irr_reload_final_evidence_captures_identity_before_ack() {
+    let runner = std::fs::read_to_string(format!(
+        "{}/bench/scale/irrreload/run-irr-reload.sh",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .expect("read runner");
+    let body = runner
+        .split_once("ack_final_evidence() {")
+        .and_then(|(_, rest)| rest.split_once("bind_first_trigger() {"))
+        .map(|(body, _)| format!("ack_final_evidence() {{{body}"))
+        .expect("final evidence helper");
+    let identity = body.find("after=$(awk").expect("identity read");
+    let process = body.find("process.tsv").expect("process receipt");
+    let ack = body
+        .find("mv -T \"$tmp\" \"$barrier/ack\"")
+        .expect("atomic ack");
+    assert!(identity < process && process < ack);
+
+    let temp = tempfile::tempdir().unwrap();
+    let barrier = temp.path().join("barrier");
+    let evidence = temp.path().join("evidence");
+    std::fs::create_dir(&barrier).unwrap();
+    std::fs::write(barrier.join("ready"), "ready\n").unwrap();
+    let pid = std::process::id().to_string();
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).unwrap();
+    let start = stat
+        .split_whitespace()
+        .nth(21)
+        .unwrap()
+        .parse::<u64>()
+        .unwrap();
+    let invalid = std::process::Command::new("bash")
+        .args([
+            "-c",
+            &format!("{body}\nack_final_evidence \"$BARRIER\" \"$EVIDENCE\" \"$PID\" \"$START\""),
+        ])
+        .env("BARRIER", &barrier)
+        .env("EVIDENCE", &evidence)
+        .env("PID", &pid)
+        .env("START", (start + 1).to_string())
+        .status()
+        .unwrap();
+    assert!(!invalid.success());
+    assert!(!barrier.join("ack").exists());
+}
+
+#[test]
+/// Red proof: removing the evidence-valid guard creates `ack` for the false
+/// invocation and fails this test; replacing the atomic regular-file publish
+/// with a non-file marker fails the positive half.
+fn irr_reload_invalid_topology_never_acknowledges_pre_churn_barrier() {
+    let runner = std::fs::read_to_string(format!(
+        "{}/bench/scale/irrreload/run-irr-reload.sh",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .expect("read runner");
+    let body = runner
+        .split_once("ack_pre_churn() {")
+        .and_then(|(_, rest)| rest.split_once("bind_first_trigger() {"))
+        .map(|(body, _)| format!("ack_pre_churn() {{{body}"))
+        .expect("ack helper");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let barrier = temp.path().join("barrier");
+    let evidence = temp.path().join("evidence");
+    std::fs::create_dir(&barrier).unwrap();
+    std::fs::write(barrier.join("ready"), "ready\n").unwrap();
+
+    let invalid = std::process::Command::new("bash")
+        .args([
+            "-c",
+            &format!("{body}\nack_pre_churn \"$BARRIER\" false \"$EVIDENCE\""),
+        ])
+        .env("BARRIER", &barrier)
+        .env("EVIDENCE", &evidence)
+        .status()
+        .expect("run invalid acknowledgement");
+    assert!(!invalid.success());
+    assert!(!barrier.join("ack").exists());
+
+    let valid = std::process::Command::new("bash")
+        .args([
+            "-c",
+            &format!("{body}\nack_pre_churn \"$BARRIER\" true \"$EVIDENCE\""),
+        ])
+        .env("BARRIER", &barrier)
+        .env("EVIDENCE", &evidence)
+        .status()
+        .expect("run valid acknowledgement");
+    assert!(valid.success());
+    let metadata = std::fs::symlink_metadata(barrier.join("ack")).unwrap();
+    assert!(metadata.file_type().is_file() && !metadata.file_type().is_symlink());
+    assert_eq!(
+        std::fs::read_to_string(evidence.join("pre-churn/ack")).unwrap(),
+        "ack\n"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- keep the cross-daemon fairness roster unchanged while adding a standalone rustbgpd grouped-control cell on the identical IRR dataset
- bind live pre-churn topology and final process identity with bounded, fail-closed ready/ack boundaries
- add an offline A/B/B/A verifier for canonical workload, source/platform identity, immutable evidence, exact route/group topology, and semantically valid measurement rows
- prevent the shared RSS sampler from recording a bogus terminal zero sample when its root exits during collection

This is the harness-only tranche. It does not publish performance results or change daemon production behavior. Full measurement remains blocked until this lands and the campaign runs from the clean merged commit.

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps
- verifier self-test: 55 destructive red proofs
- default smoke: rustbgpd SIGHUP, bounded transaction, BIRD, and OpenBGPD all passed
- standalone grouped-control smoke passed
- prior zero-reload memory-attribution smoke passed unchanged

## Load-bearing proofs

Each new fence has a mutation that rebinds lower checksums/provenance where needed and still fails at the intended guard. These cover roster/mode drift, source and platform drift, overlapping or reused processes, topology drift, scenario/evidence tampering, symlinks, malformed rows, impossible percentile relationships, and output cross-contamination. Reverting the RSS teardown guard makes its structural regression fail.
