### PR TITLE
fix: skip abandoned read snapshots

### DIFF
--- a/crates/rib/src/manager/queries.rs
+++ b/crates/rib/src/manager/queries.rs
@@ -40,6 +40,18 @@ pub(super) fn send_mrt_snapshot(
         warn!("MRT snapshot query caller dropped before receiving response");
     }
 }
+
+fn send_neighbor_rib_snapshot(
+    reply: tokio::sync::oneshot::Sender<NeighborRibSnapshotResponse>,
+    build: impl FnOnce() -> NeighborRibSnapshotResponse,
+) {
+    if reply.is_closed() {
+        debug!("neighbor RIB snapshot query canceled before materialization");
+        return;
+    }
+    let _ = reply.send(build());
+}
+
 /// Synthesized messages per RFC 9069 Loc-RIB dump chunk — the
 /// per-request allocation bound of the resumable dump (the final chunk
 /// additionally carries one End-of-RIB marker per streamed family).
@@ -1637,26 +1649,28 @@ impl RibManager {
         comparison: Option<(IpAddr, IpAddr)>,
         reply: tokio::sync::oneshot::Sender<NeighborRibSnapshotResponse>,
     ) {
-        let snapshots = peers
-            .into_iter()
-            .map(|peer| NeighborRibSnapshot {
-                peer,
-                advertised_count: self
-                    .grouped_advertised_count(peer)
-                    .unwrap_or_else(|| self.adj_ribs_out.get(&peer).map_or(0, AdjRibOut::len)),
-                policy_stats: self
-                    .export_policy_stats
-                    .get(&peer)
-                    .copied()
-                    .unwrap_or_default(),
-                outbound: self.peer_outbound_state(peer),
-            })
-            .collect();
-        let comparison = comparison
-            .map(|(primary, comparison)| self.update_group_comparison(primary, comparison));
-        let _ = reply.send(NeighborRibSnapshotResponse {
-            snapshots,
-            comparison,
+        send_neighbor_rib_snapshot(reply, || {
+            let snapshots = peers
+                .into_iter()
+                .map(|peer| NeighborRibSnapshot {
+                    peer,
+                    advertised_count: self
+                        .grouped_advertised_count(peer)
+                        .unwrap_or_else(|| self.adj_ribs_out.get(&peer).map_or(0, AdjRibOut::len)),
+                    policy_stats: self
+                        .export_policy_stats
+                        .get(&peer)
+                        .copied()
+                        .unwrap_or_default(),
+                    outbound: self.peer_outbound_state(peer),
+                })
+                .collect();
+            let comparison = comparison
+                .map(|(primary, comparison)| self.update_group_comparison(primary, comparison));
+            NeighborRibSnapshotResponse {
+                snapshots,
+                comparison,
+            }
         });
     }
     /// Snapshot the live per-term hit counters of installed export
@@ -2007,5 +2021,17 @@ impl RibManager {
             routes,
             evpn_routes,
         })
+    }
+}
+
+#[cfg(test)]
+mod cancellation_tests {
+    use super::*;
+
+    #[test]
+    fn canceled_neighbor_rib_snapshot_does_not_invoke_builder() {
+        let (reply, receiver) = tokio::sync::oneshot::channel();
+        drop(receiver);
+        send_neighbor_rib_snapshot(reply, || panic!("canceled query materialized"));
     }
 }

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -34,7 +34,10 @@ use std::net::IpAddr;
 use std::sync::Arc;
 
 use rustbgpd_policy::{NextHopAction, PolicyAction, PolicyChain, PolicyEvaluation};
-use rustbgpd_wire::{Afi, BgpRole, LargeCommunity, PathAttribute, Prefix, Safi};
+use rustbgpd_wire::{
+    Afi, BgpRole, ExtendedCommunity, LargeCommunity, PathAttribute, Prefix, Safi, VpnAddressFamily,
+    VpnRouteKey,
+};
 use rustc_hash::FxHashMap;
 use tracing::{debug, info, warn};
 
@@ -47,7 +50,17 @@ use crate::update::{
     UpdateGroupComparisonDifference, UpdateGroupComparisonMembership, UpdateGroupComparisonVerdict,
     UpdateGroupPeerComparison, UpdateGroupPeerSnapshot, UpdateGroupSnapshot, classify_update_group,
 };
-use rustbgpd_wire::{ExtendedCommunity, VpnAddressFamily, VpnRouteKey};
+
+fn send_update_group_snapshot(
+    reply: tokio::sync::oneshot::Sender<UpdateGroupSnapshot>,
+    build: impl FnOnce() -> UpdateGroupSnapshot,
+) {
+    if reply.is_closed() {
+        debug!("update-group snapshot query canceled before materialization");
+        return;
+    }
+    let _ = reply.send(build());
+}
 
 /// A configured policy name retained by shared staging. `Arc` keeps a
 /// group-wide per-route verdict from rebuilding the same owned label at every
@@ -3225,35 +3238,37 @@ impl RibManager {
         &self,
         reply: tokio::sync::oneshot::Sender<UpdateGroupSnapshot>,
     ) {
-        let mut peers = self
-            .update_groups
-            .members
-            .iter()
-            .map(|(&peer, membership)| {
-                let chain = self.export_policy_for(peer);
-                let orf_negotiated = self
-                    .live_sessions
-                    .get(&peer)
-                    .and_then(|sessions| sessions.last())
-                    .is_some_and(|record| !record.negotiated_orf_recv.is_empty());
-                let input = self.update_group_classifier_input(
-                    peer,
-                    chain,
-                    orf_negotiated || self.peer_orf_filters.contains_key(&peer),
-                );
-                UpdateGroupPeerSnapshot {
-                    peer,
-                    classification: classify_update_group(input.clone()),
-                    input,
-                    runtime_membership: membership.label(),
-                }
-            })
-            .collect::<Vec<_>>();
-        peers.sort_by_key(|row| match row.peer {
-            IpAddr::V4(addr) => (0, addr.octets().to_vec()),
-            IpAddr::V6(addr) => (1, addr.octets().to_vec()),
+        send_update_group_snapshot(reply, || {
+            let mut peers = self
+                .update_groups
+                .members
+                .iter()
+                .map(|(&peer, membership)| {
+                    let chain = self.export_policy_for(peer);
+                    let orf_negotiated = self
+                        .live_sessions
+                        .get(&peer)
+                        .and_then(|sessions| sessions.last())
+                        .is_some_and(|record| !record.negotiated_orf_recv.is_empty());
+                    let input = self.update_group_classifier_input(
+                        peer,
+                        chain,
+                        orf_negotiated || self.peer_orf_filters.contains_key(&peer),
+                    );
+                    UpdateGroupPeerSnapshot {
+                        peer,
+                        classification: classify_update_group(input.clone()),
+                        input,
+                        runtime_membership: membership.label(),
+                    }
+                })
+                .collect::<Vec<_>>();
+            peers.sort_by_key(|row| match row.peer {
+                IpAddr::V4(addr) => (0, addr.octets().to_vec()),
+                IpAddr::V6(addr) => (1, addr.octets().to_vec()),
+            });
+            UpdateGroupSnapshot { peers }
         });
-        let _ = reply.send(UpdateGroupSnapshot { peers });
     }
 
     pub(super) fn handle_query_update_group_comparison(
@@ -3512,6 +3527,13 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn canceled_update_group_snapshot_does_not_invoke_builder() {
+        let (reply, receiver) = tokio::sync::oneshot::channel::<UpdateGroupSnapshot>();
+        drop(receiver);
+        send_update_group_snapshot(reply, || panic!("canceled query materialized"));
+    }
     use crate::test_support::make_route;
 
     fn comparison_key() -> GroupKey {

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -875,6 +875,9 @@ impl PeerManager {
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::ListPeers { reply } => {
+                            if reply.is_closed() {
+                                continue;
+                            }
                             let infos = self.list_peers().await;
                             let _ = reply.send(infos);
                         }
@@ -911,12 +914,18 @@ impl PeerManager {
                         PeerManagerCommand::PlanConfigTransaction {
                             candidate_toml,
                             expected_runtime_snapshot_token,
-                            reply,
+                            mut reply,
                         } => {
-                            let result = self.plan_config_transaction(
+                            let planning = self.plan_config_transaction(
                                 &candidate_toml,
                                 expected_runtime_snapshot_token.as_deref(),
-                            ).await;
+                            );
+                            tokio::pin!(planning);
+                            let result = tokio::select! {
+                                biased;
+                                () = reply.closed() => continue,
+                                result = &mut planning => result,
+                            };
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::StageConfigSnapshot {

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -154,6 +154,134 @@ fn test_peer_manager() -> PeerManager {
 }
 
 #[tokio::test]
+async fn canceled_ordinary_list_peers_skips_session_queries() {
+    let (tx, rx) = mpsc::channel(8);
+    let (rib_tx, _rib_rx) = mpsc::channel(8);
+    let mut manager = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    let peer: IpAddr = "192.0.2.1".parse().unwrap();
+    let counters = Arc::new(FakePeerCounters::default());
+    insert_test_managed_peer(
+        &mut manager,
+        peer,
+        fake_peer_handle(peer, SessionState::Established, None, counters.clone()),
+        false,
+    );
+    let stale_peer: IpAddr = "192.0.2.2".parse().unwrap();
+    let (stale_commands, stale_receiver) = mpsc::channel(1);
+    let stale_task = tokio::spawn(async move {
+        drop(stale_receiver);
+        Ok::<(), rustbgpd_transport::TransportError>(())
+    });
+    insert_test_managed_peer(
+        &mut manager,
+        stale_peer,
+        PeerHandle::from_parts(stale_commands, stale_task),
+        false,
+    );
+    let actor = tokio::spawn(manager.run());
+    tokio::task::yield_now().await;
+
+    let (reply, receiver) = oneshot::channel();
+    drop(receiver);
+    tx.send(PeerManagerCommand::ListPeers { reply })
+        .await
+        .unwrap();
+
+    let (reply, receiver) = oneshot::channel();
+    tx.send(PeerManagerCommand::ListPeers { reply })
+        .await
+        .unwrap();
+    let peers = receiver.await.unwrap();
+    assert_eq!(peers.len(), 2);
+    assert!(
+        peers.iter().any(|row| row.address == peer && !row.stale),
+        "live row remains fresh"
+    );
+    assert!(
+        peers
+            .iter()
+            .any(|row| row.address == stale_peer && row.stale),
+        "unanswered row keeps the existing stale fallback"
+    );
+    assert_eq!(counters.query_state.load(Ordering::SeqCst), 1);
+
+    tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    actor.await.unwrap();
+}
+
+#[tokio::test]
+async fn canceled_plan_drops_rib_snapshot_and_actor_answers_later_command() {
+    let config = load_test_config(
+        r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+"#,
+    );
+    let candidate = toml::to_string_pretty(&config).unwrap();
+    let (tx, rx) = mpsc::channel(8);
+    let (rib_tx, mut rib_rx) = mpsc::channel(8);
+    let manager = PeerManager::new_with_config(
+        rx,
+        mpsc::unbounded_channel().1,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+        None,
+        config,
+    );
+    let actor = tokio::spawn(manager.run());
+
+    let (plan_reply, plan_receiver) = oneshot::channel();
+    tx.send(PeerManagerCommand::PlanConfigTransaction {
+        candidate_toml: candidate,
+        expected_runtime_snapshot_token: None,
+        reply: plan_reply,
+    })
+    .await
+    .unwrap();
+    let RibUpdate::QueryUpdateGroupSnapshot { mut reply } = rib_rx.recv().await.unwrap() else {
+        panic!("plan did not request its RIB snapshot");
+    };
+    drop(plan_receiver);
+    tokio::time::timeout(Duration::from_secs(1), reply.closed())
+        .await
+        .expect("abandoned plan kept its RIB snapshot receiver alive");
+
+    let (policies_reply, policies_receiver) = oneshot::channel();
+    tx.send(PeerManagerCommand::ListPolicies {
+        reply: policies_reply,
+    })
+    .await
+    .unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(1), policies_receiver)
+        .await
+        .expect("actor remained blocked on the abandoned RIB snapshot")
+        .unwrap();
+
+    tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    actor.await.unwrap();
+}
+
+#[tokio::test]
 async fn stale_live_snapshot_is_rejected_before_candidate_validation() {
     let config = load_test_config(
         r#"


### PR DESCRIPTION
## Summary

- skip ordinary peer-list fanout when the caller has already abandoned the response
- cancel only the read-only config-planning future when its caller disconnects, releasing any in-flight RIB snapshot request
- defer update-group and neighbor RIB snapshot materialization until their response receiver is known to be open
- preserve live request semantics, snapshot coherence, stale-token ordering, and every mutation/rollback path

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- focused cancellation regressions and both affected library suites
- independent architecture review of the final diff

## Load-bearing proofs

- removing the `ListPeers` receiver guard admits a second session-state query and fails the exact-count assertion
- removing plan cancellation retains the RIB snapshot receiver past the one-second deadline and blocks the actor
- removing either RIB snapshot guard invokes its panic builder after the response receiver is dropped

## Documentation

No documentation or changelog change: successful API responses, defaults, and operator-visible behavior are unchanged.
