### PR TITLE
fix: retain truthful transport failure causes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   manager cannot accept or answer their snapshot request, instead of reporting
   the actor outage as `INTERNAL`.
 
+- Neighbor diagnostics now retain bounded transport root causes for reader and
+  writer failures, outbound saturation, and exact-export invariant teardown;
+  locally generated Cease/8 history records include the same safe cause without
+  exposing raw I/O, panic, route, policy, or shutdown payload text.
+
 - IRR-scale boot and SIGHUP reload no longer recompile the `.rpol` set
   data once per chain resolution: a compiled unit now interns its
   prefix/community/asn sets exactly once and every chain instantiation

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -144,6 +144,49 @@ pub enum SessionNotificationDirection {
     Received,
 }
 
+/// Bounded, secret-free cause for a locally detected session failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionFailureCause {
+    /// TCP reader failed with the named stable I/O error kind.
+    ReaderIo(std::io::ErrorKind),
+    /// TCP writer failed with the named stable I/O error kind.
+    WriterIo(std::io::ErrorKind),
+    /// The writer task panicked.
+    WriterPanicked,
+    /// The writer task was cancelled.
+    WriterCancelled,
+    /// The bounded outbound writer queue saturated.
+    OutboundSaturation,
+    /// A route-bearing envelope omitted its exact export snapshot.
+    ExportSnapshotMissing,
+    /// An exact export snapshot had an incompatible concrete type.
+    ExportSnapshotIncompatible,
+    /// An exact export snapshot belonged to another session.
+    ExportSnapshotWrongOwner,
+    /// Exact export failed after the RIB had committed the update.
+    PostCommitInvariant,
+}
+
+impl std::fmt::Display for SessionFailureCause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ReaderIo(kind) => write!(f, "TCP reader I/O failure ({kind:?})"),
+            Self::WriterIo(kind) => write!(f, "TCP writer I/O failure ({kind:?})"),
+            Self::WriterPanicked => f.write_str("TCP writer task panicked"),
+            Self::WriterCancelled => f.write_str("TCP writer task cancelled"),
+            Self::OutboundSaturation => f.write_str("outbound writer queue saturated"),
+            Self::ExportSnapshotMissing => f.write_str("exact export snapshot missing"),
+            Self::ExportSnapshotIncompatible => {
+                f.write_str("exact export snapshot type incompatible")
+            }
+            Self::ExportSnapshotWrongOwner => {
+                f.write_str("exact export snapshot owned by another session")
+            }
+            Self::PostCommitInvariant => f.write_str("post-commit exact export invariant failed"),
+        }
+    }
+}
+
 /// Metadata-only BGP NOTIFICATION event emitted by a peer session for
 /// operator-facing observability.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -164,6 +207,8 @@ pub struct SessionNotificationEvent {
     pub description: String,
     /// RFC 8203 shutdown communication reason, when present.
     pub shutdown_reason: Option<String>,
+    /// Bounded local failure cause; present only on locally sent Cease/8.
+    pub failure_cause: Option<SessionFailureCause>,
 }
 
 impl SessionIdentity {

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -405,13 +405,18 @@ impl PeerSession {
             peer = %self.peer_label,
             "outbound writer channel saturated — sending Cease/Out-of-Resources and tearing down"
         );
-        self.trigger_outbound_out_of_resources_teardown();
+        self.trigger_outbound_out_of_resources_teardown(
+            crate::handle::SessionFailureCause::OutboundSaturation,
+        );
     }
 
     /// Emit Cease/8, record its bounded cause, and hard-close the writer.
     /// Callers must log their own truthful cause before entering this common
     /// primitive (writer saturation, exact-snapshot invariant breach, etc.).
-    pub(super) fn trigger_outbound_out_of_resources_teardown(&mut self) {
+    pub(super) fn trigger_outbound_out_of_resources_teardown(
+        &mut self,
+        cause: crate::handle::SessionFailureCause,
+    ) {
         // `handle_tcp_disconnect` clears the priority sender on the first
         // trigger. A second failure can already be in the synchronous caller
         // stack; do not emit another notification event/counter for a writer
@@ -419,12 +424,14 @@ impl PeerSession {
         if self.writer_priority_tx.is_none() {
             return;
         }
+        self.pending_outbound_teardown_cause = Some(cause);
         let notif = rustbgpd_wire::NotificationMessage::new(
             NotificationCode::Cease,
             cease_subcode::OUT_OF_RESOURCES,
             bytes::Bytes::new(),
         );
         self.record_notification_cause(SessionNotificationDirection::Sent, &notif);
+        self.last_error = cause.to_string();
         // Classify the upcoming BMP Peer Down truthfully: reason 1
         // (local system sent NOTIFICATION) carrying the Cease/8 PDU,
         // instead of the reason-4 "remote closed" default.

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -161,7 +161,7 @@ pub(crate) struct PeerSession {
     ///   retained** so the run-loop's writer-exit `select!` arm can
     ///   observe the writer task exiting — cleanly after draining its
     ///   priority queue on ordinary closes, or with
-    ///   `WriterExit::TornDown` after the saturation hard close (bulk
+    ///   `WriterExit::TornDown` after a local hard close (bulk
     ///   backlog discarded, `Cease/8` flushed best-effort). The arm body
     ///   clears `writer_join = None` after `JoinHandle::await` resolves
     ///   exactly once — polling a completed `JoinHandle` again panics.
@@ -177,7 +177,7 @@ pub(crate) struct PeerSession {
     writer_bulk_tx: Option<mpsc::Sender<Bytes>>,
     /// Unbounded priority channel handed to the writer task. Carries
     /// OPEN, KEEPALIVE, NOTIFICATION, operator ROUTE-REFRESH commands,
-    /// and the `Cease/8` we emit on bulk saturation.
+    /// and the `Cease/8` we emit on a local Out-of-Resources teardown.
     writer_priority_tx: Option<mpsc::UnboundedSender<Bytes>>,
     /// KEEPALIVE cadence control for the writer task (ADR-0078). The
     /// session sends `Some(interval)` when the FSM starts the keepalive
@@ -393,6 +393,8 @@ pub(crate) struct PeerSession {
     flap_count: u64,
     established_at: Option<Instant>,
     last_error: String,
+    /// Root cause of an in-flight local Cease/8 teardown.
+    pending_outbound_teardown_cause: Option<crate::handle::SessionFailureCause>,
     /// Latest query-time TCP-AO inspection for the currently owned stream.
     tcp_ao_info: Option<crate::TcpAoInfoSnapshot>,
     /// Secret-free configured MKT identity/rollover metadata. This survives
@@ -1148,6 +1150,7 @@ impl PeerSession {
             flap_count: 0,
             established_at: None,
             last_error: String::new(),
+            pending_outbound_teardown_cause: None,
             tcp_ao_info: None,
             tcp_ao_key_metadata,
             tcp_ao_protected,
@@ -1316,6 +1319,7 @@ impl PeerSession {
             flap_count: 0,
             established_at: None,
             last_error: String::new(),
+            pending_outbound_teardown_cause: None,
             tcp_ao_info,
             tcp_ao_key_metadata,
             tcp_ao_protected,
@@ -1562,6 +1566,11 @@ impl PeerSession {
             )
             .to_string(),
             shutdown_reason,
+            failure_cause: (direction == SessionNotificationDirection::Sent
+                && notification.code == NotificationCode::Cease
+                && notification.subcode == cease_subcode::OUT_OF_RESOURCES)
+                .then_some(self.pending_outbound_teardown_cause)
+                .flatten(),
         };
 
         if let Err(e) = tx.try_send(event) {
@@ -1599,6 +1608,11 @@ impl PeerSession {
         &mut self,
         join_result: Result<Result<(), writer::WriterExit>, tokio::task::JoinError>,
     ) {
+        // A local Cease/8 cause owns the diagnostic until the writer exit
+        // resulting from that teardown is observed. Taking the latch here
+        // preserves the cause through this match while allowing a later,
+        // independent connection failure to become visible.
+        let pending_outbound_cause = self.pending_outbound_teardown_cause.take();
         match join_result {
             Ok(Ok(())) => {
                 debug!(peer = %self.peer_label, "writer task exited cleanly");
@@ -1610,10 +1624,12 @@ impl PeerSession {
                 self.last_down_reason = Some(PeerDownReason::LocalNoNotification(
                     SEND_HOLD_TIMER_EXPIRES_FSM_EVENT,
                 ));
-                self.last_error = format!(
-                    "send hold timer expired after {}s (RFC 9687)",
-                    limit.as_secs()
-                );
+                if pending_outbound_cause.is_none() {
+                    self.last_error = format!(
+                        "send hold timer expired after {}s (RFC 9687)",
+                        limit.as_secs()
+                    );
+                }
                 self.emit_notification_event(
                     SessionNotificationDirection::Sent,
                     &NotificationMessage {
@@ -1629,22 +1645,53 @@ impl PeerSession {
                 );
             }
             Ok(Err(writer::WriterExit::TornDown)) => {
-                // Saturation teardown: the writer discarded the bulk
-                // backlog, put the Cease/8 on the wire best-effort, and
-                // hard-closed. Fall through so the FSM sees
+                // Local hard teardown: the writer discarded the bulk backlog,
+                // put the Cease/8 on the wire best-effort, and hard-closed.
+                // Fall through so the FSM sees
                 // `TcpConnectionFails` and the RIB gets its
                 // PeerDown/deregistration from this run-loop path.
-                debug!(peer = %self.peer_label, "writer task hard-closed by saturation teardown");
+                debug!(peer = %self.peer_label, "writer task completed local hard teardown");
             }
             Ok(Err(writer::WriterExit::Io(e))) => {
-                debug!(peer = %self.peer_label, error = %e, "writer task TCP error");
+                let cause = crate::handle::SessionFailureCause::WriterIo(e.kind());
+                debug!(peer = %self.peer_label, cause = %cause, "writer task TCP error");
+                if pending_outbound_cause.is_none() {
+                    self.last_error = cause.to_string();
+                }
             }
             Err(e) => {
-                warn!(peer = %self.peer_label, error = %e, "writer task panicked");
+                let cause = if e.is_cancelled() {
+                    crate::handle::SessionFailureCause::WriterCancelled
+                } else {
+                    crate::handle::SessionFailureCause::WriterPanicked
+                };
+                warn!(peer = %self.peer_label, cause = %cause, "writer task ended unexpectedly");
+                if pending_outbound_cause.is_none() {
+                    self.last_error = cause.to_string();
+                }
             }
         }
         self.handle_tcp_disconnect();
         self.drive_fsm(Event::TcpConnectionFails).await;
+    }
+
+    async fn handle_tcp_read_result(&mut self, result: std::io::Result<usize>) {
+        match result {
+            Ok(0) => {
+                self.handle_tcp_disconnect();
+                self.drive_fsm(Event::TcpConnectionFails).await;
+            }
+            Ok(_n) => self.process_read_buffer().await,
+            Err(e) => {
+                let cause = crate::handle::SessionFailureCause::ReaderIo(e.kind());
+                debug!(peer = %self.peer_label, cause = %cause, "TCP read error");
+                if self.pending_outbound_teardown_cause.is_none() {
+                    self.last_error = cause.to_string();
+                }
+                self.handle_tcp_disconnect();
+                self.drive_fsm(Event::TcpConnectionFails).await;
+            }
+        }
     }
 
     pub(super) fn record_otc_routes_blocked(
@@ -1720,18 +1767,7 @@ impl PeerSession {
             tokio::select! {
                 // TCP read — only when connected and past the Idle bootstrap
                 result = read_tcp(read_half, &mut read_buf.buf), if read_active => {
-                    match result {
-                        Ok(0) => {
-                            self.handle_tcp_disconnect();
-                            self.drive_fsm(Event::TcpConnectionFails).await;
-                        }
-                        Ok(_n) => self.process_read_buffer().await,
-                        Err(e) => {
-                            debug!(peer = %self.peer_label, error = %e, "TCP read error");
-                            self.handle_tcp_disconnect();
-                            self.drive_fsm(Event::TcpConnectionFails).await;
-                        }
-                    }
+                    self.handle_tcp_read_result(result).await;
                 }
 
                 // External command

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -144,7 +144,9 @@ impl PeerSession {
                     peer = %self.peer_label,
                     "RIB route-bearing envelope omitted its exact export snapshot — sending Cease/Out-of-Resources and tearing down"
                 );
-                self.trigger_outbound_out_of_resources_teardown();
+                self.trigger_outbound_out_of_resources_teardown(
+                    crate::handle::SessionFailureCause::ExportSnapshotMissing,
+                );
                 return;
             }
         };
@@ -153,7 +155,9 @@ impl PeerSession {
                 peer = %self.peer_label,
                 "RIB outbound envelope carries an exact export snapshot from the wrong encoder — sending Cease/Out-of-Resources and tearing down"
             );
-            self.trigger_outbound_out_of_resources_teardown();
+            self.trigger_outbound_out_of_resources_teardown(
+                crate::handle::SessionFailureCause::ExportSnapshotIncompatible,
+            );
             return;
         };
         if rustbgpd_rib::ExactExportSnapshot::owner_id(export)
@@ -163,7 +167,9 @@ impl PeerSession {
                 peer = %self.peer_label,
                 "RIB outbound envelope carries an exact export snapshot owned by another session — sending Cease/Out-of-Resources and tearing down"
             );
-            self.trigger_outbound_out_of_resources_teardown();
+            self.trigger_outbound_out_of_resources_teardown(
+                crate::handle::SessionFailureCause::ExportSnapshotWrongOwner,
+            );
             return;
         }
         for route in &update.otc_blocked {
@@ -396,7 +402,9 @@ impl PeerSession {
                             %error,
                             "IPv4 Extended Next Hop route failed exact export preparation after RIB commit — sending Cease/Out-of-Resources and tearing down"
                         );
-                        self.trigger_outbound_out_of_resources_teardown();
+                        self.trigger_outbound_out_of_resources_teardown(
+                            crate::handle::SessionFailureCause::PostCommitInvariant,
+                        );
                         return;
                     }
                 };
@@ -533,7 +541,9 @@ impl PeerSession {
                         %error,
                         "IPv6 route failed exact export preparation after RIB commit — sending Cease/Out-of-Resources and tearing down"
                     );
-                    self.trigger_outbound_out_of_resources_teardown();
+                    self.trigger_outbound_out_of_resources_teardown(
+                        crate::handle::SessionFailureCause::PostCommitInvariant,
+                    );
                     return;
                 }
             };
@@ -1166,7 +1176,9 @@ impl PeerSession {
                         max = max_len,
                         "single IPv4 {kind} entry exceeds maximum message length — tearing down the session so Adj-RIB-Out is rebuilt on reconnect"
                     );
-                    self.trigger_outbound_out_of_resources_teardown();
+                    self.trigger_outbound_out_of_resources_teardown(
+                        crate::handle::SessionFailureCause::PostCommitInvariant,
+                    );
                     return false;
                 }
                 chunk_size = (chunk_size / 2).max(1);
@@ -1253,7 +1265,9 @@ impl PeerSession {
                         "single {family} {kind} cannot be encoded — tearing down the session so Adj-RIB-Out is rebuilt on reconnect"
                     ),
                 }
-                self.trigger_outbound_out_of_resources_teardown();
+                self.trigger_outbound_out_of_resources_teardown(
+                    crate::handle::SessionFailureCause::PostCommitInvariant,
+                );
                 return false;
             }
             let message = candidate.expect("successful MP build checked above");
@@ -1332,7 +1346,9 @@ impl PeerSession {
                         max = max_len,
                         "single EVPN route exceeds maximum message length — tearing down the session so Adj-RIB-Out is rebuilt on reconnect"
                     );
-                    self.trigger_outbound_out_of_resources_teardown();
+                    self.trigger_outbound_out_of_resources_teardown(
+                        crate::handle::SessionFailureCause::PostCommitInvariant,
+                    );
                     return false;
                 }
                 chunk_size = (chunk_size / 2).max(1);
@@ -1375,7 +1391,9 @@ impl PeerSession {
                         max = max_len,
                         "single EVPN withdrawal exceeds maximum message length — tearing down the session so Adj-RIB-Out is rebuilt on reconnect"
                     );
-                    self.trigger_outbound_out_of_resources_teardown();
+                    self.trigger_outbound_out_of_resources_teardown(
+                        crate::handle::SessionFailureCause::PostCommitInvariant,
+                    );
                     return false;
                 }
                 chunk_size = (chunk_size / 2).max(1);
@@ -1426,7 +1444,9 @@ impl PeerSession {
                         max = max_len,
                         "single BGP-LS route exceeds maximum message length — sending Cease/Out-of-Resources and tearing down"
                     );
-                    self.trigger_outbound_out_of_resources_teardown();
+                    self.trigger_outbound_out_of_resources_teardown(
+                        crate::handle::SessionFailureCause::PostCommitInvariant,
+                    );
                     return false;
                 }
                 chunk_size = (chunk_size / 2).max(1);
@@ -1469,7 +1489,9 @@ impl PeerSession {
                         max = max_len,
                         "single BGP-LS withdrawal exceeds maximum message length — sending Cease/Out-of-Resources and tearing down"
                     );
-                    self.trigger_outbound_out_of_resources_teardown();
+                    self.trigger_outbound_out_of_resources_teardown(
+                        crate::handle::SessionFailureCause::PostCommitInvariant,
+                    );
                     return false;
                 }
                 chunk_size = (chunk_size / 2).max(1);
@@ -1533,7 +1555,9 @@ impl PeerSession {
                         max = max_len,
                         "single VPN route exceeds maximum message length — sending Cease/Out-of-Resources and tearing down"
                     );
-                    self.trigger_outbound_out_of_resources_teardown();
+                    self.trigger_outbound_out_of_resources_teardown(
+                        crate::handle::SessionFailureCause::PostCommitInvariant,
+                    );
                     return false;
                 }
                 chunk_size = (chunk_size / 2).max(1);
@@ -1577,7 +1601,9 @@ impl PeerSession {
                         max = max_len,
                         "single VPN withdrawal exceeds maximum message length — sending Cease/Out-of-Resources and tearing down"
                     );
-                    self.trigger_outbound_out_of_resources_teardown();
+                    self.trigger_outbound_out_of_resources_teardown(
+                        crate::handle::SessionFailureCause::PostCommitInvariant,
+                    );
                     return false;
                 }
                 chunk_size = (chunk_size / 2).max(1);
@@ -1635,7 +1661,9 @@ impl PeerSession {
                         max = max_len,
                         "single labeled route exceeds maximum message length — sending Cease/Out-of-Resources and tearing down"
                     );
-                    self.trigger_outbound_out_of_resources_teardown();
+                    self.trigger_outbound_out_of_resources_teardown(
+                        crate::handle::SessionFailureCause::PostCommitInvariant,
+                    );
                     return false;
                 }
                 chunk_size = (chunk_size / 2).max(1);
@@ -1685,7 +1713,9 @@ impl PeerSession {
                         max = max_len,
                         "single labeled withdrawal exceeds maximum message length — sending Cease/Out-of-Resources and tearing down"
                     );
-                    self.trigger_outbound_out_of_resources_teardown();
+                    self.trigger_outbound_out_of_resources_teardown(
+                        crate::handle::SessionFailureCause::PostCommitInvariant,
+                    );
                     return false;
                 }
                 chunk_size = (chunk_size / 2).max(1);
@@ -1736,7 +1766,9 @@ impl PeerSession {
                         max = max_len,
                         "single RTC route exceeds maximum message length — sending Cease/Out-of-Resources and tearing down"
                     );
-                    self.trigger_outbound_out_of_resources_teardown();
+                    self.trigger_outbound_out_of_resources_teardown(
+                        crate::handle::SessionFailureCause::PostCommitInvariant,
+                    );
                     return false;
                 }
                 chunk_size = (chunk_size / 2).max(1);
@@ -1780,7 +1812,9 @@ impl PeerSession {
                         max = max_len,
                         "single RTC withdrawal exceeds maximum message length — sending Cease/Out-of-Resources and tearing down"
                     );
-                    self.trigger_outbound_out_of_resources_teardown();
+                    self.trigger_outbound_out_of_resources_teardown(
+                        crate::handle::SessionFailureCause::PostCommitInvariant,
+                    );
                     return false;
                 }
                 chunk_size = (chunk_size / 2).max(1);
@@ -2005,6 +2039,14 @@ mod tests {
             };
             assert_eq!(notification.code, NotificationCode::Cease);
             assert_eq!(notification.subcode, cease_subcode::OUT_OF_RESOURCES);
+            assert_eq!(
+                session.pending_outbound_teardown_cause,
+                Some(crate::handle::SessionFailureCause::PostCommitInvariant)
+            );
+            assert_eq!(
+                session.last_error,
+                crate::handle::SessionFailureCause::PostCommitInvariant.to_string()
+            );
 
             let join = session
                 .writer_join

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -3054,6 +3054,7 @@ async fn received_notification_events_report_direct_and_hard_reset_shutdown_reas
         assert_eq!(event.code, NotificationCode::Cease.as_u8());
         assert_eq!(event.subcode, expected_subcode);
         assert_eq!(event.shutdown_reason.as_deref(), Some(reason));
+        assert_eq!(event.failure_cause, None);
     }
 }
 
@@ -3155,6 +3156,7 @@ async fn locally_sent_notification_events_report_direct_and_hard_reset_shutdown_
         assert_eq!(event.code, NotificationCode::Cease.as_u8());
         assert_eq!(event.subcode, expected_subcode);
         assert_eq!(event.shutdown_reason.as_deref(), Some(reason));
+        assert_eq!(event.failure_cause, None);
     }
 }
 
@@ -3191,6 +3193,7 @@ async fn stop_command_sends_and_reports_exact_shutdown_communication() {
         event.shutdown_reason.as_deref(),
         Some("planned maintenance")
     );
+    assert_eq!(event.failure_cause, None);
     let notification = read_until_notification(&mut server).await;
     assert_eq!(notification.code, NotificationCode::Cease);
     assert_eq!(notification.subcode, cease_subcode::ADMINISTRATIVE_SHUTDOWN);
@@ -7019,19 +7022,31 @@ impl rustbgpd_rib::ExactExportSnapshot for ForeignExactExportSnapshot {
 async fn route_bearing_envelope_without_own_session_snapshot_fails_closed() {
     use rustbgpd_wire::notification::{NotificationCode, cease_subcode};
 
+    type SnapshotFailureCase = (
+        &'static str,
+        Option<Arc<dyn rustbgpd_rib::ExactExportSnapshot>>,
+        crate::handle::SessionFailureCause,
+    );
+
     let (other_session, _other_rib_rx) = make_test_session_with_rib(65001, 65002);
-    let cases: Vec<(&str, Option<Arc<dyn rustbgpd_rib::ExactExportSnapshot>>)> = vec![
-        ("missing", None),
+    let cases: Vec<SnapshotFailureCase> = vec![
+        (
+            "missing",
+            None,
+            crate::handle::SessionFailureCause::ExportSnapshotMissing,
+        ),
         (
             "foreign concrete type",
             Some(Arc::new(ForeignExactExportSnapshot)),
+            crate::handle::SessionFailureCause::ExportSnapshotIncompatible,
         ),
         (
             "same concrete type from another session",
             Some(other_session.publish_export_profile()),
+            crate::handle::SessionFailureCause::ExportSnapshotWrongOwner,
         ),
     ];
-    for (name, snapshot) in cases {
+    for (name, snapshot, cause) in cases {
         let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
         let (client, mut server) = connected_stream_pair().await;
         session.test_install_stream(client);
@@ -7047,12 +7062,182 @@ async fn route_bearing_envelope_without_own_session_snapshot_fails_closed() {
         };
         assert_eq!(notification.code, NotificationCode::Cease);
         assert_eq!(notification.subcode, cease_subcode::OUT_OF_RESOURCES);
+        assert_eq!(
+            session.pending_outbound_teardown_cause,
+            Some(cause),
+            "{name}"
+        );
+        assert_eq!(session.last_error, cause.to_string(), "{name}");
         assert!(session.read_half.is_none(), "{name}: read half must close");
         assert!(
             session.writer_bulk_tx.is_none(),
             "{name}: bulk sender must close"
         );
     }
+}
+
+/// Load-bearing: storing raw I/O text leaks the sentinel, dropping the read
+/// cause loses the bounded value, and treating clean EOF as an error replaces
+/// the seeded diagnostic.
+#[tokio::test]
+async fn tcp_reader_error_is_bounded_but_clean_eof_is_not_an_error() {
+    let (mut failed, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (event_tx, mut event_rx) = mpsc::channel(1);
+    failed.session_event_tx = Some(event_tx);
+    failed.last_error = "prior".to_string();
+    failed
+        .handle_tcp_read_result(Err(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "secret reader detail",
+        )))
+        .await;
+    assert_eq!(
+        failed.last_error,
+        "TCP reader I/O failure (ConnectionReset)"
+    );
+    assert!(!failed.last_error.contains("secret"));
+    assert!(matches!(
+        event_rx.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+
+    let (mut eof, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    eof.last_error = "prior".to_string();
+    eof.handle_tcp_read_result(Ok(0)).await;
+    assert_eq!(eof.last_error, "prior");
+}
+
+/// Load-bearing: raw writer or `JoinError` rendering leaks either sentinel;
+/// collapsing panic and cancellation or changing a clean exit replaces one of
+/// the exact bounded/seeded assertions.
+#[tokio::test]
+async fn writer_io_and_join_failure_are_bounded() {
+    let (mut io_session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (event_tx, mut event_rx) = mpsc::channel(1);
+    io_session.session_event_tx = Some(event_tx);
+    io_session
+        .handle_writer_exit(Ok(Err(super::writer::WriterExit::Io(std::io::Error::new(
+            std::io::ErrorKind::BrokenPipe,
+            "secret writer detail",
+        )))))
+        .await;
+    assert_eq!(io_session.last_error, "TCP writer I/O failure (BrokenPipe)");
+    assert!(!io_session.last_error.contains("secret"));
+    assert!(matches!(
+        event_rx.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+
+    let join = tokio::spawn(async { panic!("secret panic detail") }).await;
+    let (mut panic_session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    panic_session.handle_writer_exit(join.map(|_| Ok(()))).await;
+    assert_eq!(panic_session.last_error, "TCP writer task panicked");
+    assert!(!panic_session.last_error.contains("secret"));
+
+    let cancelled = tokio::spawn(std::future::pending::<()>());
+    cancelled.abort();
+    let cancelled = cancelled.await;
+    let (mut cancelled_session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    cancelled_session
+        .handle_writer_exit(cancelled.map(|()| Ok(())))
+        .await;
+    assert_eq!(cancelled_session.last_error, "TCP writer task cancelled");
+
+    let (mut clean, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    clean.last_error = "prior actionable failure".to_string();
+    clean.handle_writer_exit(Ok(Ok(()))).await;
+    assert_eq!(clean.last_error, "prior actionable failure");
+}
+
+/// Load-bearing: removing the pending-cause guards lets consequential writer
+/// or reader I/O replace the exact-export cause; never clearing the latch keeps
+/// the final independent read failure from becoming visible.
+#[tokio::test]
+async fn outbound_root_cause_survives_writer_exit() {
+    let cause = crate::handle::SessionFailureCause::PostCommitInvariant;
+    for exit in [
+        super::writer::WriterExit::TornDown,
+        super::writer::WriterExit::Io(std::io::Error::new(
+            std::io::ErrorKind::BrokenPipe,
+            "secondary writer detail",
+        )),
+    ] {
+        let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+        session.pending_outbound_teardown_cause = Some(cause);
+        session.last_error = cause.to_string();
+        session.handle_writer_exit(Ok(Err(exit))).await;
+        assert_eq!(session.last_error, cause.to_string());
+        assert!(session.pending_outbound_teardown_cause.is_none());
+    }
+
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    session.pending_outbound_teardown_cause = Some(cause);
+    session.last_error = cause.to_string();
+    session
+        .handle_tcp_read_result(Err(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "consequential reader detail",
+        )))
+        .await;
+    assert_eq!(session.last_error, cause.to_string());
+    assert_eq!(session.pending_outbound_teardown_cause, Some(cause));
+    session
+        .handle_writer_exit(Ok(Err(super::writer::WriterExit::TornDown)))
+        .await;
+    assert!(session.pending_outbound_teardown_cause.is_none());
+    session
+        .handle_tcp_read_result(Err(std::io::Error::new(
+            std::io::ErrorKind::ConnectionAborted,
+            "later independent reader detail",
+        )))
+        .await;
+    assert_eq!(
+        session.last_error,
+        "TCP reader I/O failure (ConnectionAborted)"
+    );
+}
+
+/// Load-bearing: omitting a cause, classifying a snapshot breach as generic
+/// post-commit failure, or labeling any exact-export site as saturation changes
+/// one of these production-source inventory counts.
+#[test]
+fn outbound_out_of_resources_sites_have_specific_cause_inventory() {
+    let source = include_str!("outbound.rs");
+    let production = source
+        .split_once("\n#[cfg(test)]\nmod tests")
+        .expect("outbound module keeps production before tests")
+        .0;
+    assert_eq!(
+        production
+            .matches("trigger_outbound_out_of_resources_teardown(")
+            .count(),
+        17
+    );
+    assert_eq!(
+        production
+            .matches("SessionFailureCause::ExportSnapshotMissing")
+            .count(),
+        1
+    );
+    assert_eq!(
+        production
+            .matches("SessionFailureCause::ExportSnapshotIncompatible")
+            .count(),
+        1
+    );
+    assert_eq!(
+        production
+            .matches("SessionFailureCause::ExportSnapshotWrongOwner")
+            .count(),
+        1
+    );
+    assert_eq!(
+        production
+            .matches("SessionFailureCause::PostCommitInvariant")
+            .count(),
+        14
+    );
+    assert!(!production.contains("SessionFailureCause::OutboundSaturation"));
 }
 /// Without the negotiated Route Refresh capability the request is
 /// skipped (warned, not sent) — the rest of the update still goes out.
@@ -15178,10 +15363,7 @@ async fn outbound_saturation_teardown_emits_cease_out_of_resources() {
         session.notifications_sent, 1,
         "a duplicate saturation trigger must not invent another sent notification"
     );
-    assert_eq!(
-        session.last_error,
-        "sent NOTIFICATION 6/8 (Out of Resources)"
-    );
+    assert_eq!(session.last_error, "outbound writer queue saturated");
     let prometheus_count = counter_value(
         &session.metrics,
         "bgp_notifications_sent_total",
@@ -15195,6 +15377,10 @@ async fn outbound_saturation_teardown_emits_cease_out_of_resources() {
     assert_eq!(event.direction, SessionNotificationDirection::Sent);
     assert_eq!(event.code, NotificationCode::Cease.as_u8());
     assert_eq!(event.subcode, cease_subcode::OUT_OF_RESOURCES);
+    assert_eq!(
+        event.failure_cause,
+        Some(crate::handle::SessionFailureCause::OutboundSaturation)
+    );
     assert!(
         matches!(event_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
         "duplicate trigger must not publish another sent-notification event"

--- a/crates/transport/src/session/writer.rs
+++ b/crates/transport/src/session/writer.rs
@@ -24,19 +24,18 @@
 //! KEEPALIVE frame on each deadline. This is FRR's dedicated
 //! keepalive-thread invariant in our two-task shape.
 //!
-//! Saturation policy lives in the session task, not here:
-//! `bulk_tx.try_send` failing with `Full` means the peer hasn't drained
-//! 4096 BGP messages, the session emits a `Cease/8` (Out of Resources,
-//! RFC 4486 §4 subcode 8) through `priority_tx`, signals `teardown_tx`,
-//! and drops the senders. The teardown signal makes this task **discard
+//! Local Out-of-Resources policy lives in the session task, not here.
+//! Queue saturation and exact-export invariant failures emit a `Cease/8`
+//! (Out of Resources, RFC 4486 §4 subcode 8) through `priority_tx`, signal
+//! `teardown_tx`, and drop the senders. The teardown signal makes this task **discard
 //! the queued bulk backlog instead of draining it** — the Cease must be
-//! the final frame the peer sees, and flushing a saturated queue would
+//! the final frame the peer sees, and flushing a queued backlog would
 //! delay the close indefinitely — flush the already-enqueued priority
 //! frames best-effort within [`TEARDOWN_LINGER`], and exit with
 //! [`WriterExit::TornDown`] so the session's writer-exit arm drives
 //! `TcpConnectionFails` + FSM/RIB cleanup exactly like a real TCP
 //! failure. Wiring lives in
-//! `PeerSession::trigger_outbound_saturation_teardown`; this module
+//! `PeerSession::trigger_outbound_out_of_resources_teardown`; this module
 //! owns the discard/flush/close mechanics.
 //!
 //! # Bulk write coalescing (LAN-332)
@@ -49,7 +48,7 @@
 //! contiguous buffer and issues a single `write_all + flush` — the
 //! same shape as FRR's packed subgroup streams. Only bulk frames
 //! coalesce: priority frames (OPEN, KEEPALIVE, NOTIFICATION, Cease)
-//! always write alone, so the saturation-teardown guarantee that the
+//! always write alone, so the hard-teardown guarantee that the
 //! `Cease/8` is the final frame on the wire cannot be violated by a
 //! batch that pulled the Cease and then appended bulk behind it, and
 //! biased priority preemption keeps single-frame granularity on the
@@ -103,7 +102,7 @@ pub(super) enum WriterExit {
         /// The configured `SendHoldTime` that elapsed.
         limit: Duration,
     },
-    /// Session-requested hard close (outbound saturation `Cease/8`):
+    /// Session-requested hard close after a local `Cease/8`:
     /// the queued bulk backlog was discarded — never drained — the
     /// Cease was flushed best-effort within [`TEARDOWN_LINGER`], and
     /// the socket closed. The session's writer-exit arm maps this to
@@ -114,7 +113,7 @@ pub(super) enum WriterExit {
 /// Best-effort bound on teardown writes: how long the writer will wait
 /// for an in-flight frame to reach a frame boundary and for the Cease
 /// NOTIFICATION to reach the wire before hard-closing anyway. A
-/// saturated TCP window may never accept the Cease; the close must not
+/// blocked TCP window may never accept the Cease; the close must not
 /// wait on it.
 const TEARDOWN_LINGER: Duration = Duration::from_secs(2);
 
@@ -180,7 +179,7 @@ pub(super) struct WriterHandle {
     /// retimes the writer-owned periodic KEEPALIVE, `None` stops it.
     /// Dropping the sender also stops it.
     pub(super) keepalive_tx: watch::Sender<Option<Duration>>,
-    /// Hard-teardown signal (saturation `Cease/8`): sending `true`
+    /// Hard-teardown signal (local `Cease/8`): sending `true`
     /// makes the writer discard the bulk backlog, flush pending
     /// priority frames within [`TEARDOWN_LINGER`], and exit with
     /// [`WriterExit::TornDown`]. Racing an in-flight write is part of
@@ -254,7 +253,7 @@ struct WriterTask {
 
 /// Resolve once the session has signalled hard teardown. Pends forever
 /// otherwise — including when the sender is dropped *without*
-/// signalling, which is the ordinary (non-saturation) close path and
+/// signalling, which is the ordinary (non-hard-teardown) close path and
 /// must keep the writer's drain-then-exit semantics.
 async fn teardown_requested(rx: &mut watch::Receiver<bool>) {
     while !*rx.borrow_and_update() {
@@ -285,7 +284,7 @@ impl WriterTask {
         let mut cadence: Option<Duration> = *self.keepalive_rx.borrow();
         let mut next_keepalive = cadence.map(|interval| tokio::time::Instant::now() + interval);
         loop {
-            // Hard teardown (saturation Cease/8): discard the bulk
+            // Hard teardown (local Cease/8): discard the bulk
             // backlog, flush the pending priority frames best-effort,
             // close. Checked at the top of every iteration so no bulk
             // frame can slip out between the signal and the close.
@@ -300,7 +299,7 @@ impl WriterTask {
                 return Ok(());
             }
             // `biased` keeps NOTIFICATIONs and KEEPALIVEs from starving
-            // behind a backlog of UPDATEs, and ensures the saturation
+            // behind a backlog of UPDATEs, and ensures the teardown
             // `Cease/8` reaches the wire before any further bulk work.
             // The bool marks bulk-arm frames as coalescible; priority
             // and cadence frames always write alone (module docs,
@@ -435,7 +434,7 @@ impl WriterTask {
             }
         };
         result.map_err(|e| {
-            warn!(error = %e, "writer: write/flush failed");
+            warn!(error_kind = ?e.kind(), "writer: write/flush failed");
             WriterExit::Io(e)
         })
     }
@@ -443,7 +442,7 @@ impl WriterTask {
     /// Session-requested hard close: drop the queued bulk backlog on
     /// the floor — the `Cease/8` already enqueued on the priority
     /// channel must be the FINAL frame the peer sees, and draining a
-    /// saturated queue could take unbounded time — then flush the
+    /// queued backlog could take unbounded time — then flush the
     /// pending priority frames best-effort within [`TEARDOWN_LINGER`]
     /// and exit. Returning drops the write half, which closes the
     /// socket without draining.
@@ -459,12 +458,12 @@ impl WriterTask {
             };
             match tokio::time::timeout_at(deadline, write).await {
                 Ok(Ok(())) => {}
-                // Best-effort: a saturated TCP window may never accept
+                // Best-effort: a blocked TCP window may never accept
                 // the Cease. Do not delay the close for it.
                 Ok(Err(_)) | Err(_) => break,
             }
         }
-        debug!(peer = %self.peer_label, "writer: hard close after saturation teardown");
+        debug!(peer = %self.peer_label, "writer: session-requested hard close complete");
         Err(WriterExit::TornDown)
     }
 }

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2191,6 +2191,13 @@ warning log. Cease/8 still tears down the session if transport encounters an
 impossible single-route message or a missing/mismatched encoder snapshot; that
 is defense in depth, not the normal rejection path.
 
+Neighbor `last_error` and session notification history retain the bounded local
+cause of that defense-in-depth teardown, outbound queue saturation, and TCP
+reader/writer failures. These diagnostics deliberately exclude raw operating-
+system errors, task panic payloads, routes, attributes, policy data, and
+shutdown communication text. A locally sent Cease/8 retains the category while
+its canonical BGP description and wire payload remain unchanged.
+
 An RFC 9107 ORR peer's explain ranks the per-vantage candidate set the
 ORR export uses (with per-candidate cost output). When filtered or ignored
 topology inputs are present, the stable

--- a/src/peer_manager/events.rs
+++ b/src/peer_manager/events.rs
@@ -272,10 +272,14 @@ impl PeerManager {
             TransportNotificationDirection::Sent => "sent",
             TransportNotificationDirection::Received => "received",
         };
-        let reason = format!(
+        let mut reason = format!(
             "BGP NOTIFICATION {direction} for peer {}: {}/{} ({})",
             event.peer_addr, event.code, event.subcode, event.description
         );
+        if let Some(cause) = event.failure_cause {
+            use std::fmt::Write as _;
+            let _ = write!(reason, "; transport failure: {cause}");
+        }
         self.publish_session_event(SessionEvent::Notification(SessionNotificationEvent {
             event_type,
             peer: event.peer_addr,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -6981,6 +6981,40 @@ async fn session_event_history_records_events_without_subscriber() {
     assert_eq!(events[0].event_type, SessionLifecycleEventType::PeerEnabled);
 }
 
+/// Load-bearing: omitting the bounded cause from notification-history
+/// projection removes the exact suffix while changing the canonical BGP
+/// description or shutdown reason breaks the remaining field assertions.
+#[tokio::test]
+async fn notification_event_reason_includes_bounded_failure_cause() {
+    let mut mgr = test_peer_manager();
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut events = mgr.session_events_tx.subscribe();
+    mgr.publish_notification_event(rustbgpd_transport::SessionNotificationEvent {
+        session_id: 1,
+        peer_addr: addr,
+        role: rustbgpd_transport::SessionRole::Primary,
+        direction: rustbgpd_transport::SessionNotificationDirection::Sent,
+        code: rustbgpd_wire::notification::NotificationCode::Cease.as_u8(),
+        subcode: rustbgpd_wire::notification::cease_subcode::OUT_OF_RESOURCES,
+        description: "Out of Resources".to_string(),
+        shutdown_reason: None,
+        failure_cause: Some(rustbgpd_transport::handle::SessionFailureCause::OutboundSaturation),
+    });
+
+    let rustbgpd_api::peer_types::SessionEvent::Notification(event) = events.try_recv().unwrap()
+    else {
+        panic!("expected notification event");
+    };
+    assert_eq!(
+        event.reason,
+        "BGP NOTIFICATION sent for peer 10.0.0.2: 6/8 (Out of Resources); transport failure: outbound writer queue saturated"
+    );
+    assert_eq!(event.code, 6);
+    assert_eq!(event.subcode, 8);
+    assert_eq!(event.description, "Out of Resources");
+    assert_eq!(event.shutdown_reason, None);
+}
+
 /// Successful configured-peer installs publish their current admin event only
 /// after installation; failed duplicate adds must not fabricate one.
 #[tokio::test]


### PR DESCRIPTION
## Summary

- retain a bounded root-cause classification for TCP reader/writer failures, outbound saturation, and exact-export fail-closed teardown
- expose that safe cause in neighbor diagnostics and locally generated Cease/8 notification history without changing BGP wire bytes, BMP reason, counters, retry, or FSM behavior
- replace saturation-only teardown wording with truthful generic hard-teardown wording

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --no-deps --all-features`
- independent scope and correctness review: GO

## Load-bearing regression proofs

Each new boundary was mutated locally and shown to go red: raw reader/writer rendering exposed sentinels; removing cause precedence or latch release broke lifecycle assertions; dropping event projection broke history coverage; misclassifying snapshot, saturation, and EVPN sites broke their exact-cause tests; and attaching causes to administrative Cease events broke negative controls.