### PR TITLE
fix: cancel abandoned snapshot work

### DIFF
--- a/crates/rib/src/manager/queries.rs
+++ b/crates/rib/src/manager/queries.rs
@@ -21,7 +21,8 @@ use crate::update::{
     BestPathCandidate, ExactExportKey, ExplainAdvertisedRoute, ExplainAdvertisedRouteError,
     ExplainBestPath, MrtPeerEntry, MrtSnapshotData, NeighborPolicyStats, NeighborRibSnapshot,
     NeighborRibSnapshotResponse, RoutePage, RoutePageError, RoutePageVersion, RouteQueryFilter,
-    RouteQueryKey, RouteQueryScope, WarmMrtSnapshotBudget, WarmMrtSnapshotView, route_query_key,
+    RouteQueryKey, RouteQueryScope, UpdateGroupPeerComparison, WarmMrtSnapshotBudget,
+    WarmMrtSnapshotView, route_query_key,
 };
 
 pub(super) fn send_mrt_snapshot(
@@ -41,15 +42,51 @@ pub(super) fn send_mrt_snapshot(
     }
 }
 
+fn materialize_neighbor_rib_snapshot(
+    peers: Vec<IpAddr>,
+    comparison: Option<(IpAddr, IpAddr)>,
+    mut is_canceled: impl FnMut() -> bool,
+    mut build_row: impl FnMut(IpAddr) -> NeighborRibSnapshot,
+    build_comparison: impl FnOnce(IpAddr, IpAddr) -> UpdateGroupPeerComparison,
+) -> Option<NeighborRibSnapshotResponse> {
+    let mut snapshots = Vec::with_capacity(peers.len());
+    for peer in peers {
+        if is_canceled() {
+            return None;
+        }
+        snapshots.push(build_row(peer));
+    }
+    if is_canceled() {
+        return None;
+    }
+    let comparison = comparison.map(|(primary, comparison)| build_comparison(primary, comparison));
+    if is_canceled() {
+        return None;
+    }
+    Some(NeighborRibSnapshotResponse {
+        snapshots,
+        comparison,
+    })
+}
+
 fn send_neighbor_rib_snapshot(
     reply: tokio::sync::oneshot::Sender<NeighborRibSnapshotResponse>,
-    build: impl FnOnce() -> NeighborRibSnapshotResponse,
+    peers: Vec<IpAddr>,
+    comparison: Option<(IpAddr, IpAddr)>,
+    build_row: impl FnMut(IpAddr) -> NeighborRibSnapshot,
+    build_comparison: impl FnOnce(IpAddr, IpAddr) -> UpdateGroupPeerComparison,
 ) {
-    if reply.is_closed() {
-        debug!("neighbor RIB snapshot query canceled before materialization");
+    let Some(snapshot) = materialize_neighbor_rib_snapshot(
+        peers,
+        comparison,
+        || reply.is_closed(),
+        build_row,
+        build_comparison,
+    ) else {
+        debug!("neighbor RIB snapshot query canceled during materialization");
         return;
-    }
-    let _ = reply.send(build());
+    };
+    let _ = reply.send(snapshot);
 }
 
 /// Synthesized messages per RFC 9069 Loc-RIB dump chunk — the
@@ -1649,29 +1686,24 @@ impl RibManager {
         comparison: Option<(IpAddr, IpAddr)>,
         reply: tokio::sync::oneshot::Sender<NeighborRibSnapshotResponse>,
     ) {
-        send_neighbor_rib_snapshot(reply, || {
-            let snapshots = peers
-                .into_iter()
-                .map(|peer| NeighborRibSnapshot {
-                    peer,
-                    advertised_count: self
-                        .grouped_advertised_count(peer)
-                        .unwrap_or_else(|| self.adj_ribs_out.get(&peer).map_or(0, AdjRibOut::len)),
-                    policy_stats: self
-                        .export_policy_stats
-                        .get(&peer)
-                        .copied()
-                        .unwrap_or_default(),
-                    outbound: self.peer_outbound_state(peer),
-                })
-                .collect();
-            let comparison = comparison
-                .map(|(primary, comparison)| self.update_group_comparison(primary, comparison));
-            NeighborRibSnapshotResponse {
-                snapshots,
-                comparison,
-            }
-        });
+        send_neighbor_rib_snapshot(
+            reply,
+            peers,
+            comparison,
+            |peer| NeighborRibSnapshot {
+                peer,
+                advertised_count: self
+                    .grouped_advertised_count(peer)
+                    .unwrap_or_else(|| self.adj_ribs_out.get(&peer).map_or(0, AdjRibOut::len)),
+                policy_stats: self
+                    .export_policy_stats
+                    .get(&peer)
+                    .copied()
+                    .unwrap_or_default(),
+                outbound: self.peer_outbound_state(peer),
+            },
+            |primary, comparison| self.update_group_comparison(primary, comparison),
+        );
     }
     /// Snapshot the live per-term hit counters of installed export
     /// chains (ADR-0096 Decision 3.3): one entry per peer with an
@@ -2032,6 +2064,120 @@ mod cancellation_tests {
     fn canceled_neighbor_rib_snapshot_does_not_invoke_builder() {
         let (reply, receiver) = tokio::sync::oneshot::channel();
         drop(receiver);
-        send_neighbor_rib_snapshot(reply, || panic!("canceled query materialized"));
+        send_neighbor_rib_snapshot(
+            reply,
+            vec!["192.0.2.1".parse().unwrap()],
+            None,
+            |_| panic!("canceled query materialized"),
+            |_, _| panic!("canceled query compared"),
+        );
+    }
+
+    /// Load-bearing mid-materialization cancellation proof: removing the
+    /// per-row closure check visits K+1 and continues building an
+    /// undeliverable response; removing the pre-comparison check invokes the
+    /// comparison after the Kth row cancels the request.
+    #[test]
+    fn canceled_neighbor_rib_snapshot_stops_at_exact_row_boundary() {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        const PEERS: usize = 32;
+        const CLOSE_AFTER: usize = 7;
+        let canceled = Rc::new(std::cell::Cell::new(false));
+        let visited = Rc::new(RefCell::new(Vec::new()));
+        let peers: Vec<IpAddr> = (1..=PEERS)
+            .map(|octet| IpAddr::V4(Ipv4Addr::new(192, 0, 2, u8::try_from(octet).unwrap())))
+            .collect();
+
+        let response = materialize_neighbor_rib_snapshot(
+            peers.clone(),
+            Some((peers[0], peers[1])),
+            {
+                let canceled = Rc::clone(&canceled);
+                move || canceled.get()
+            },
+            {
+                let canceled = Rc::clone(&canceled);
+                let visited = Rc::clone(&visited);
+                move |peer| {
+                    visited.borrow_mut().push(peer);
+                    if visited.borrow().len() == CLOSE_AFTER {
+                        canceled.set(true);
+                    }
+                    NeighborRibSnapshot {
+                        peer,
+                        advertised_count: 0,
+                        policy_stats: NeighborPolicyStats::default(),
+                        outbound: crate::update::PeerOutboundState {
+                            update_group: String::new(),
+                            effective_distribution_mode:
+                                crate::update::EffectiveDistributionMode::Unknown,
+                            selection_deferral: Vec::new(),
+                            outbound_prefix_limits: Vec::new(),
+                        },
+                    }
+                }
+            },
+            |_, _| panic!("comparison must not be built after cancellation"),
+        );
+
+        assert!(response.is_none(), "canceled snapshot is never publishable");
+        assert_eq!(&*visited.borrow(), &peers[..CLOSE_AFTER]);
+    }
+
+    /// Load-bearing pre-comparison fence: removing the check immediately
+    /// after the final row invokes comparison construction for a request that
+    /// was canceled while that row was materialized.
+    #[test]
+    fn canceled_neighbor_rib_snapshot_skips_comparison_after_last_row() {
+        let canceled = std::cell::Cell::new(false);
+        let response = materialize_neighbor_rib_snapshot(
+            vec!["192.0.2.1".parse().unwrap()],
+            Some(("192.0.2.1".parse().unwrap(), "192.0.2.2".parse().unwrap())),
+            || canceled.get(),
+            |peer| {
+                canceled.set(true);
+                NeighborRibSnapshot {
+                    peer,
+                    advertised_count: 0,
+                    policy_stats: NeighborPolicyStats::default(),
+                    outbound: crate::update::PeerOutboundState {
+                        update_group: String::new(),
+                        effective_distribution_mode:
+                            crate::update::EffectiveDistributionMode::Unknown,
+                        selection_deferral: Vec::new(),
+                        outbound_prefix_limits: Vec::new(),
+                    },
+                }
+            },
+            |_, _| panic!("comparison must not be built after the final row canceled"),
+        );
+        assert!(response.is_none());
+    }
+
+    /// Load-bearing final fence: removing the post-comparison cancellation
+    /// check returns `Some`, which makes the caller enter its send path after
+    /// the request was canceled during comparison construction.
+    #[test]
+    fn canceled_neighbor_rib_snapshot_skips_send_after_comparison() {
+        let canceled = std::cell::Cell::new(false);
+        let response = materialize_neighbor_rib_snapshot(
+            Vec::new(),
+            Some(("192.0.2.1".parse().unwrap(), "192.0.2.2".parse().unwrap())),
+            || canceled.get(),
+            |_| unreachable!("no rows requested"),
+            |_, _| {
+                canceled.set(true);
+                UpdateGroupPeerComparison {
+                    primary_update_group: String::new(),
+                    verdict: crate::update::UpdateGroupComparisonVerdict::Unknown,
+                    primary_membership: crate::update::UpdateGroupComparisonMembership::Unknown,
+                    comparison_membership: crate::update::UpdateGroupComparisonMembership::Unknown,
+                    differences: Vec::new(),
+                }
+            },
+        );
+        assert!(response.is_none(), "send path must remain unreachable");
     }
 }

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -508,11 +508,7 @@ impl PeerManager {
     async fn handle_readiness_query(&self, query: PeerManagerReadinessQuery) {
         match query {
             PeerManagerReadinessQuery::ListPeers { reply } => {
-                if reply.is_closed() {
-                    return;
-                }
-                let infos = self.list_peers().await;
-                let _ = reply.send(infos);
+                self.answer_list_peers(reply).await;
             }
         }
     }
@@ -875,15 +871,10 @@ impl PeerManager {
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::ListPeers { reply } => {
-                            if reply.is_closed() {
-                                continue;
-                            }
-                            let infos = self.list_peers().await;
-                            let _ = reply.send(infos);
+                            self.answer_list_peers(reply).await;
                         }
                         PeerManagerCommand::QueryWarmCheckpointCapture { reply } => {
-                            let capture = self.query_warm_checkpoint_capture().await;
-                            let _ = reply.send(capture);
+                            self.answer_warm_checkpoint_capture(reply).await;
                         }
                         PeerManagerCommand::SubscribeSessionEvents { reply } => {
                             let _ = reply.send(self.session_events_tx.subscribe());

--- a/src/peer_manager/snapshot.rs
+++ b/src/peer_manager/snapshot.rs
@@ -9,6 +9,7 @@ use rustbgpd_bmp::{BmpEvent, BmpPeerInfo, BmpPeerType};
 use rustbgpd_fsm::SessionState;
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_transport::{PeerHandle, PeerSessionState};
+use tokio_util::task::AbortOnDropHandle;
 use tracing::warn;
 
 use crate::config::{RFC8212_MISSING_EXPORT_POLICY, RFC8212_MISSING_IMPORT_POLICY};
@@ -214,15 +215,14 @@ fn effective_remote_asn(managed: &ManagedPeer, session_state: Option<&PeerSessio
 async fn collect_session_states(
     peers: &HashMap<PeerKey, ManagedPeer>,
 ) -> HashMap<PeerKey, Option<PeerSessionState>> {
-    let mut tasks: Vec<tokio::task::JoinHandle<(PeerKey, Option<PeerSessionState>)>> =
-        Vec::with_capacity(peers.len());
+    let mut tasks = Vec::with_capacity(peers.len());
     for (peer, managed) in peers {
         let peer = peer.clone();
         let commands = managed.handle.commands_sender();
-        tasks.push(tokio::spawn(async move {
+        tasks.push(AbortOnDropHandle::new(tokio::spawn(async move {
             let state = PeerHandle::query_state_with(commands, PEER_QUERY_TIMEOUT).await;
             (peer, state)
-        }));
+        })));
     }
 
     let mut out = HashMap::with_capacity(tasks.len());
@@ -349,12 +349,12 @@ impl PeerManager {
             let peer = peer.clone();
             let session_id = managed.session_id;
             let commands = managed.handle.commands_sender();
-            tasks.push(tokio::spawn(async move {
+            tasks.push(AbortOnDropHandle::new(tokio::spawn(async move {
                 let state =
                     PeerHandle::query_warm_checkpoint_state_with(commands, PEER_QUERY_TIMEOUT)
                         .await;
                 (peer, session_id, canonical_import_policy, state)
-            }));
+            })));
         }
 
         let mut sessions = Vec::with_capacity(tasks.len());
@@ -469,6 +469,45 @@ impl PeerManager {
             infos.push(info);
         }
         infos
+    }
+
+    /// Answer an operator/readiness peer snapshot only when its caller still
+    /// owns the response. Dropping the response mid-fan-out drops
+    /// `list_peers`; its abort-on-drop query drivers then release any bounded
+    /// session-command slots they were waiting to acquire. A query already
+    /// admitted to a session may still be observed, but no orphaned driver
+    /// remains behind the canceled aggregate read.
+    pub(super) async fn answer_list_peers(
+        &self,
+        mut reply: tokio::sync::oneshot::Sender<Vec<PeerInfo>>,
+    ) {
+        if reply.is_closed() {
+            return;
+        }
+        let infos = tokio::select! {
+            biased;
+            () = reply.closed() => return,
+            infos = self.list_peers() => infos,
+        };
+        let _ = reply.send(infos);
+    }
+
+    /// Complete-only warm-checkpoint reply fence. Cancellation drops the
+    /// capture future and therefore every abort-on-drop per-session driver;
+    /// successful callers still receive one all-or-nothing, sorted capture.
+    pub(super) async fn answer_warm_checkpoint_capture(
+        &self,
+        mut reply: tokio::sync::oneshot::Sender<Result<WarmCheckpointCapture, String>>,
+    ) {
+        if reply.is_closed() {
+            return;
+        }
+        let capture = tokio::select! {
+            biased;
+            () = reply.closed() => return,
+            capture = self.query_warm_checkpoint_capture() => capture,
+        };
+        let _ = reply.send(capture);
     }
 
     fn bmp_peer_info(

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -153,6 +153,377 @@ fn test_peer_manager() -> PeerManager {
     )
 }
 
+fn blocked_snapshot_query_handle(
+    peer: IpAddr,
+    release: oneshot::Receiver<()>,
+    observed: mpsc::UnboundedSender<&'static str>,
+) -> PeerHandle {
+    use rustbgpd_transport::PeerCommand;
+
+    let (commands, mut receiver) = mpsc::channel(1);
+    commands
+        .try_send(PeerCommand::Start)
+        .expect("pre-fill the session command channel");
+    let task = tokio::spawn(async move {
+        let _ = release.await;
+        assert!(matches!(receiver.recv().await, Some(PeerCommand::Start)));
+        while let Some(command) = receiver.recv().await {
+            match command {
+                PeerCommand::QueryState { reply } => {
+                    let _ = observed.send("state");
+                    let _ = reply.send(policy_test_peer_state(peer, SessionState::Established));
+                }
+                PeerCommand::QueryWarmCheckpointState { reply } => {
+                    let _ = observed.send("warm");
+                    let _ = reply.send(eligible_warm_checkpoint_state());
+                }
+                PeerCommand::Shutdown | PeerCommand::Stop { .. } | PeerCommand::CollisionDump => {
+                    break;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    PeerHandle::from_parts(commands, task)
+}
+
+async fn assert_canceled_list_peers_releases_driver(use_readiness_lane: bool) {
+    use rustbgpd_api::peer_types::PeerManagerReadinessQuery;
+
+    let (tx, rx) = mpsc::channel(1);
+    let (readiness_tx, readiness_rx) = mpsc::channel(1);
+    let (rib_tx, _rib_rx) = mpsc::channel(8);
+    let mut manager = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    )
+    .with_readiness_queries(readiness_rx);
+    let peer: IpAddr = "192.0.2.1".parse().unwrap();
+    let (release, release_rx) = oneshot::channel();
+    let (observed, mut observations) = mpsc::unbounded_channel();
+    insert_test_managed_peer(
+        &mut manager,
+        peer,
+        blocked_snapshot_query_handle(peer, release_rx, observed),
+        false,
+    );
+    let actor = tokio::spawn(manager.run());
+
+    let (canceled_reply, canceled_response) = oneshot::channel();
+    if use_readiness_lane {
+        readiness_tx
+            .send(PeerManagerReadinessQuery::ListPeers {
+                reply: canceled_reply,
+            })
+            .await
+            .unwrap();
+    } else {
+        tx.send(PeerManagerCommand::ListPeers {
+            reply: canceled_reply,
+        })
+        .await
+        .unwrap();
+    }
+    // The bounded peer-manager/readiness channel accepting another item proves
+    // the actor consumed the snapshot request. Its one session query is then
+    // synchronously spawned and parked behind the deliberately full channel.
+    while if use_readiness_lane {
+        readiness_tx.capacity() == 0
+    } else {
+        tx.capacity() == 0
+    } {
+        tokio::task::yield_now().await;
+    }
+    tokio::task::yield_now().await;
+
+    let later_tx = tx.clone();
+    let later_command = tokio::spawn(async move { subscribe_session_events(&later_tx).await });
+    tokio::task::yield_now().await;
+    assert!(
+        !later_command.is_finished(),
+        "later manager command waits behind the live snapshot"
+    );
+    drop(canceled_response);
+    for _ in 0..10 {
+        tokio::task::yield_now().await;
+        if later_command.is_finished() {
+            break;
+        }
+    }
+    assert!(
+        later_command.is_finished(),
+        "canceling the snapshot releases the manager without advancing time"
+    );
+    drop(later_command.await.unwrap());
+
+    release.send(()).unwrap();
+    for _ in 0..5 {
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        observations.try_recv().is_err(),
+        "the canceled driver must not admit a late QueryState"
+    );
+
+    let (reply, response) = oneshot::channel();
+    if use_readiness_lane {
+        readiness_tx
+            .send(PeerManagerReadinessQuery::ListPeers { reply })
+            .await
+            .unwrap();
+    } else {
+        tx.send(PeerManagerCommand::ListPeers { reply })
+            .await
+            .unwrap();
+    }
+    let peers = response.await.unwrap();
+    assert_eq!(peers.len(), 1);
+    assert_eq!(observations.recv().await, Some("state"));
+    assert!(observations.try_recv().is_err());
+
+    tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    actor.await.unwrap();
+}
+
+/// Load-bearing ordinary-lane proof: detaching the spawned `QueryState` driver
+/// leaves it queued after aggregate cancellation, so freeing the slot observes
+/// a late first query and the exact-one assertion fails.
+#[tokio::test(start_paused = true)]
+async fn canceled_ordinary_list_peers_aborts_blocked_session_driver() {
+    assert_canceled_list_peers_releases_driver(false).await;
+}
+
+/// Load-bearing readiness-lane proof: bypassing the shared complete-only
+/// answer path or detaching its driver admits a late `QueryState` after the
+/// health caller is gone.
+#[tokio::test(start_paused = true)]
+async fn canceled_readiness_list_peers_aborts_blocked_session_driver() {
+    assert_canceled_list_peers_releases_driver(true).await;
+}
+
+/// Load-bearing warm-capture proof: detaching `QueryWarmCheckpointState` leaves
+/// it queued after cancellation, so freeing the slot observes a late warm
+/// query before the next all-or-nothing capture.
+#[tokio::test(start_paused = true)]
+async fn canceled_warm_checkpoint_aborts_blocked_session_driver() {
+    let (tx, rx) = mpsc::channel(1);
+    let (rib_tx, _rib_rx) = mpsc::channel(8);
+    let mut manager = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    let peer: IpAddr = "192.0.2.1".parse().unwrap();
+    let (release, release_rx) = oneshot::channel();
+    let (observed, mut observations) = mpsc::unbounded_channel();
+    insert_test_managed_peer(
+        &mut manager,
+        peer,
+        blocked_snapshot_query_handle(peer, release_rx, observed),
+        false,
+    );
+    let actor = tokio::spawn(manager.run());
+
+    let (reply, response) = oneshot::channel();
+    tx.send(PeerManagerCommand::QueryWarmCheckpointCapture { reply })
+        .await
+        .unwrap();
+    while tx.capacity() == 0 {
+        tokio::task::yield_now().await;
+    }
+    tokio::task::yield_now().await;
+    let later_tx = tx.clone();
+    let later_command = tokio::spawn(async move { subscribe_session_events(&later_tx).await });
+    tokio::task::yield_now().await;
+    assert!(!later_command.is_finished());
+    drop(response);
+    for _ in 0..10 {
+        tokio::task::yield_now().await;
+        if later_command.is_finished() {
+            break;
+        }
+    }
+    assert!(later_command.is_finished());
+    drop(later_command.await.unwrap());
+
+    release.send(()).unwrap();
+    for _ in 0..5 {
+        tokio::task::yield_now().await;
+    }
+    assert!(observations.try_recv().is_err());
+
+    let (reply, response) = oneshot::channel();
+    tx.send(PeerManagerCommand::QueryWarmCheckpointCapture { reply })
+        .await
+        .unwrap();
+    let capture = response.await.unwrap().unwrap();
+    assert_eq!(capture.sessions.len(), 1);
+    assert_eq!(observations.recv().await, Some("warm"));
+    assert!(observations.try_recv().is_err());
+
+    tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    actor.await.unwrap();
+}
+
+enum HeldSnapshotReply {
+    State(IpAddr, oneshot::Sender<PeerSessionState>),
+    Warm(IpAddr, oneshot::Sender<WarmCheckpointSessionState>),
+}
+
+impl HeldSnapshotReply {
+    fn peer(&self) -> IpAddr {
+        match self {
+            Self::State(peer, _) | Self::Warm(peer, _) => *peer,
+        }
+    }
+
+    fn is_closed(&self) -> bool {
+        match self {
+            Self::State(_, reply) => reply.is_closed(),
+            Self::Warm(_, reply) => reply.is_closed(),
+        }
+    }
+}
+
+fn held_snapshot_query_handle(
+    peer: IpAddr,
+    warm: bool,
+    admitted: mpsc::UnboundedSender<HeldSnapshotReply>,
+) -> PeerHandle {
+    use rustbgpd_transport::PeerCommand;
+
+    let (commands, mut receiver) = mpsc::channel(1);
+    let task = tokio::spawn(async move {
+        while let Some(command) = receiver.recv().await {
+            match command {
+                PeerCommand::QueryState { reply } if !warm => {
+                    let _ = admitted.send(HeldSnapshotReply::State(peer, reply));
+                    break;
+                }
+                PeerCommand::QueryWarmCheckpointState { reply } if warm => {
+                    let _ = admitted.send(HeldSnapshotReply::Warm(peer, reply));
+                    break;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    PeerHandle::from_parts(commands, task)
+}
+
+fn blocked_cohort_query_handle(
+    release: oneshot::Receiver<()>,
+    settled: mpsc::UnboundedSender<bool>,
+) -> PeerHandle {
+    use rustbgpd_transport::PeerCommand;
+
+    let (commands, mut receiver) = mpsc::channel(1);
+    commands
+        .try_send(PeerCommand::Start)
+        .expect("pre-fill cohort command channel");
+    let task = tokio::spawn(async move {
+        let _ = release.await;
+        assert!(matches!(receiver.recv().await, Some(PeerCommand::Start)));
+        let admitted = receiver.recv().await.is_some_and(|command| {
+            matches!(
+                command,
+                PeerCommand::QueryState { .. } | PeerCommand::QueryWarmCheckpointState { .. }
+            )
+        });
+        let _ = settled.send(admitted);
+        Ok(())
+    });
+    PeerHandle::from_parts(commands, task)
+}
+
+async fn assert_canceled_snapshot_cohort_aborts_every_driver(warm: bool) {
+    const PEERS: usize = 32;
+    const ADMITTED: usize = 7;
+
+    let mut manager = test_peer_manager();
+    let (admitted, mut admitted_rx) = mpsc::unbounded_channel();
+    let (settled, mut settled_rx) = mpsc::unbounded_channel();
+    let mut releases = Vec::new();
+    for index in 1..=PEERS {
+        let peer = IpAddr::V4(Ipv4Addr::new(198, 51, 100, u8::try_from(index).unwrap()));
+        let handle = if index <= ADMITTED {
+            held_snapshot_query_handle(peer, warm, admitted.clone())
+        } else {
+            let (release, release_rx) = oneshot::channel();
+            releases.push(release);
+            blocked_cohort_query_handle(release_rx, settled.clone())
+        };
+        insert_test_managed_peer(&mut manager, peer, handle, false);
+    }
+    drop(admitted);
+    drop(settled);
+
+    let collector = tokio::spawn(async move {
+        if warm {
+            let _ = manager.query_warm_checkpoint_capture().await;
+        } else {
+            let _ = manager.list_peers().await;
+        }
+    });
+    let mut admitted_replies = Vec::with_capacity(ADMITTED);
+    for _ in 0..ADMITTED {
+        admitted_replies.push(admitted_rx.recv().await.unwrap());
+    }
+    let admitted_peers: BTreeSet<_> = admitted_replies
+        .iter()
+        .map(HeldSnapshotReply::peer)
+        .collect();
+    assert_eq!(admitted_peers.len(), ADMITTED);
+
+    collector.abort();
+    assert!(collector.await.unwrap_err().is_cancelled());
+    assert!(
+        admitted_replies.iter().all(HeldSnapshotReply::is_closed),
+        "every admitted session reply receiver closes synchronously"
+    );
+
+    for release in releases {
+        release.send(()).unwrap();
+    }
+    for _ in ADMITTED..PEERS {
+        assert_eq!(
+            settled_rx.recv().await,
+            Some(false),
+            "a driver waiting for a remaining session slot must not be admitted"
+        );
+    }
+    assert!(settled_rx.try_recv().is_err());
+}
+
+/// Load-bearing high-cardinality `QueryState` proof: plain `JoinHandles` detach
+/// when the collector is canceled, so all 25 blocked drivers become admitted
+/// after their slots are freed and the exact-empty assertion fails.
+#[tokio::test(start_paused = true)]
+async fn canceled_list_peers_cohort_aborts_admitted_and_blocked_drivers() {
+    assert_canceled_snapshot_cohort_aborts_every_driver(false).await;
+}
+
+/// Load-bearing high-cardinality warm proof: plain `JoinHandles` detach when the
+/// capture is canceled, so blocked `QueryWarmCheckpointState` drivers enter the
+/// session channels and admitted reply senders stay open.
+#[tokio::test(start_paused = true)]
+async fn canceled_warm_checkpoint_cohort_aborts_admitted_and_blocked_drivers() {
+    assert_canceled_snapshot_cohort_aborts_every_driver(true).await;
+}
+
 #[tokio::test]
 async fn canceled_ordinary_list_peers_skips_session_queries() {
     let (tx, rx) = mpsc::channel(8);


### PR DESCRIPTION
## Summary

- give per-session peer and warm-checkpoint query drivers abort-on-drop ownership
- race ordinary, readiness, and warm aggregate reads against caller closure and publish only complete results
- stop neighbor RIB materialization between rows and before comparison or final publication when its reply is abandoned

## Verification

- cargo fmt --all -- --check
- python3 scripts/check-clippy-reasons.py
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --lib --no-deps
- cargo check -p rustbgpd --no-default-features --all-targets
- focused RIB, daemon, warm-checkpoint, and API aggregate-snapshot preservation tests

## Load-bearing regression proofs

- replacing either abort-on-drop wrapper with a plain task handle leaves all seven admitted session reply senders open
- bypassing any ordinary, readiness, or warm reply fence leaves a later peer-manager command blocked
- removing the between-row RIB fence builds all 32 rows instead of stopping at row 7
- removing either comparison or final-publication fence makes the canceled response constructible

No documentation change is needed because successful API, checkpoint, configuration, and output semantics are unchanged.