### PR TITLE
fix: fence external policy config transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Config transactions now fail closed when a native apply/rollback or gNMI
+  `Set` would adopt a full candidate snapshot while either the running or
+  candidate config references external `.rpol` graphs or policy datasets.
+  Those file bytes are outside the transaction token and staging boundary;
+  deploy TOML and external files together, then use SIGHUP. External-input
+  no-ops and targeted `[[fib_tables]]` transactions with unchanged policy
+  inputs remain available. Config diffs now expose dataset binding/path
+  changes, and `.rpol` diffs also cover roots and graph-budget settings.
+
 - Config history now counts TOML `[policy.definitions.*]` tables correctly and
   describes index 0 as the newest recorded normalized TOML snapshot instead of
   implying it must be the running or persisted config; operator docs now state

--- a/docs/API.md
+++ b/docs/API.md
@@ -467,6 +467,16 @@ at a time. Cross-family candidates, mixed policy/session effective impacts,
 and other valid-but-unsupported sections return `REJECTED` without mutation
 until their section executor lands.
 
+Native apply and rollback reject any supported family that would stage and
+adopt the full candidate snapshot when either side references external
+`.rpol` main/import files or `[policy.datasets]` snapshots. Those bytes are not
+covered by the transaction token and cannot be rolled back atomically with the
+TOML. Deploy the TOML, `.rpol` graph, and dataset snapshots together, then send
+SIGHUP. A true no-op remains `NOOP`; a pure `[[fib_tables]]` transaction with
+unchanged external inputs remains committable because that executor substitutes
+only the targeted table set rather than adopting the full candidate config.
+`diff_json.reload_applied.datasets_changed` reports dataset binding/path edits.
+
 ```bash
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   -d @ localhost:50051 rustbgpd.v1.ConfigService/DiffRuntimeConfig <<'JSON'

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2289,11 +2289,15 @@ import_policy_chain = ["customer-in(200)", "bogon-filter", "toml-defined"]
   for materially changed import chains — same mechanism as
   `[policy.definitions]` edits). `rbgp config diff` reports the change
   under the policy section.
-- **Scope notes:** config *transactions* fail closed on `.rpol`
-  content: the files live outside the candidate TOML, so a candidate
-  whose `rpol_files` list changed is rejected as unsupported — apply
-  `.rpol` changes via SIGHUP. gNMI Set likewise edits only the TOML
-  surface, not `.rpol` file content. `rbgp policy explain` statement
+- **Scope notes:** config transactions fail closed while either the running or
+  candidate config references external `.rpol` graphs or policy datasets if
+  the selected executor would adopt the full candidate snapshot. The files
+  live outside the candidate TOML, transaction token, and rollback payload.
+  This applies to native apply/rollback and gNMI Set. Deploy TOML, `.rpol`
+  graphs, and datasets together, then use SIGHUP. True no-ops and pure
+  `[[fib_tables]]` transactions with unchanged external inputs remain
+  available because the FIB executor substitutes only its targeted table set.
+  `rbgp policy explain` statement
   traces cover `.rpol` chain members at term granularity, and
   `rbgp policy stats` reads the installed chains' live per-term hit
   counters (see [`rpol-language.md`](rpol-language.md)).
@@ -3133,6 +3137,12 @@ impacted Established peer must have negotiated Route Refresh or the transaction
 is rejected and rolled back. Dynamic-range peer-group reassignments and mixed
 policy/session effective-impact candidates remain rejected until dedicated
 executors exist.
+When either the running or candidate config references external `.rpol` graphs
+or `[policy.datasets]` snapshots, every full-candidate transaction family is
+also rejected: the external bytes are not staged, tokened, or rollback-safe.
+Use coordinated file deployment plus SIGHUP. A no-op remains a no-op, and a
+pure `[[fib_tables]]` edit with unchanged external inputs remains committable
+because it does not adopt the rest of the candidate snapshot.
 Like SIGHUP and FIB CRUD, FIB transaction apply requires the FIB reconciler to
 already be running: a daemon that started with no `[[fib_tables]]` still needs a
 restart to enable the subsystem.

--- a/docs/GNMI.md
+++ b/docs/GNMI.md
@@ -98,6 +98,12 @@ Transaction and validation behavior:
 - supported changes translate the live runtime config snapshot into candidate
   TOML and call the ADR-0076 transaction controller. There is no parallel commit
   path.
+- If either the running or generated candidate references external `.rpol`
+  graphs or `[policy.datasets]` snapshots, a supported non-noop Set is rejected
+  before mutation: those bytes are outside the transaction token and rollback
+  boundary. A true no-op remains a no-op. Deploy the TOML and external files
+  together and use SIGHUP. (The native transaction API's targeted pure-
+  `[[fib_tables]]` exception is not a gNMI Set surface.)
 - unsupported config leaves, including `enabled`, `local-as`, auth, timers,
   transport, BFD, AFI-SAFI, policy, route-reflector/client,
   route-server-client, and Add-Path settings, return `UNIMPLEMENTED`.
@@ -150,6 +156,9 @@ Transaction and validation behavior:
   place, and live dynamic sessions accepted by an affected range are
   gracefully reset after persist to re-accept under the committed config
   (ADR-0086).
+- The external-policy-input fence above applies even when the requested
+  peer-group leaf itself is unrelated to policy; the executor would otherwise
+  adopt the whole generated candidate snapshot.
 - If a candidate peer-group edit would affect a dynamic-neighbor range in a
   way that the transaction model cannot safely reshape (for example a range
   peer-group reassignment, or mixed policy/session impact), the transaction

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -250,6 +250,14 @@ external inputs can make the restored policy differ or make rollback fail.
 Keep the operator-authored TOML, `.rpol` graph, and datasets under version
 control or another coordinated deployment system.
 
+Do not use native config apply/rollback or gNMI Set for a full-candidate change
+while either side references `.rpol` or `[policy.datasets]` files. Those bytes
+are outside the transaction token and rollback payload, so the planner rejects
+the change without mutation. Deploy the TOML and external inputs together and
+send SIGHUP instead. External-input no-ops still return `NOOP`; a pure
+`[[fib_tables]]` transaction with unchanged external inputs remains safe and
+committable because it stages only the FIB table set.
+
 For a static-neighbor edit, change the neighbor in the candidate file (for
 example `hold_time`, `max_prefixes`, policy-chain refs, or ORF receive), run
 `config plan`, then apply with the returned token. The transaction reconfigures
@@ -276,6 +284,10 @@ rollback, and live dynamic sessions accepted by an affected
 re-accept under the committed config on reconnect (ADR-0086). Mixed-family
 candidates, dynamic-range peer-group reassignments, mixed policy/session
 effective impact, and unsupported sections are rejected without mutation.
+The same rejection applies to every full-candidate family while the running or
+candidate config references external `.rpol` graphs or policy datasets; use a
+coordinated file deployment plus SIGHUP. Pure `[[fib_tables]]` edits with those
+inputs unchanged remain the targeted exception.
 
 Output is grouped into two actionable sections plus a per-neighbor
 effective-impact view:

--- a/docs/adr/0096-policy-language.md
+++ b/docs/adr/0096-policy-language.md
@@ -194,7 +194,7 @@ query machinery — no session impact, `SensitiveRead` authz. In-language
 standalone), so operators unit-test policies in CI before ever touching
 the daemon.
 
-## Decision 7 — Apply semantics ride ADR-0076 unchanged
+## Decision 7 — Apply semantics ride ADR-0076, with an external-input fence
 
 Compile at plan time (sub-ms; compile failure = plan failure, nothing
 applied). The planner's impact set comes from IR structural diff
@@ -202,6 +202,15 @@ applied). The planner's impact set comes from IR structural diff
 per-session atomic, commit-confirmed compatible, no FRR-style
 reject-window. Set-data-only changes (a prefix added to a set) diff as
 data, refreshing only peers whose policies reference that set.
+
+Compatibility correction: native config apply/rollback and gNMI Set cannot
+atomically stage or restore `.rpol` main/import files or policy-dataset
+snapshots. While either the running or candidate config references those
+inputs, the v1 planner rejects every executor family that would adopt the full
+candidate snapshot. Operators deploy TOML and external inputs together and use
+SIGHUP. True no-ops remain no-ops; pure `[[fib_tables]]` transactions with
+unchanged external inputs remain committable because that targeted executor
+does not adopt the full candidate config.
 
 ## Deferred (explicitly, with re-entry conditions)
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1245,6 +1245,8 @@ const TRANSACTION_POLICY_NEIGHBOR_SETS_SECTION: &str = "[policy] neighbor_sets";
 const TRANSACTION_POLICY_GLOBAL_CHAINS_SECTION: &str = "[policy] global chains";
 const TRANSACTION_POLICY_LIVE_IMPACT_SECTION: &str = "[policy] live impact";
 const TRANSACTION_SESSION_RESHAPE_SECTION: &str = "effective neighbor session reshape";
+const TRANSACTION_EXTERNAL_POLICY_INPUTS_SECTION: &str =
+    "[policy] external inputs (rpol_files / datasets; deploy files and apply via SIGHUP reload)";
 
 /// Detect removed config keys in a TOML document that failed typed
 /// deserialization and return a migration error naming the
@@ -1700,6 +1702,10 @@ pub struct PeerGroupDiff {
 
 /// Differences between two policy configurations.
 #[derive(Debug, serde::Serialize)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "diff flags intentionally mirror independently reportable policy surfaces"
+)]
 pub struct PolicyDiff {
     pub definitions_added: Vec<String>,
     pub definitions_removed: Vec<String>,
@@ -1709,11 +1715,22 @@ pub struct PolicyDiff {
     pub neighbor_sets_changed: Vec<String>,
     pub import_chain_changed: bool,
     pub export_chain_changed: bool,
-    /// The `[policy] rpol_files` list or any referenced `.rpol` file's
-    /// compiled content changed (ADR-0096). Reload-applied: chains
-    /// referencing rpol policies re-resolve and hot-swap through the
-    /// same live-policy path as `[policy.definitions]` edits.
+    /// The `[policy] rpol_files` / `rpol_roots` / `rpol_max_graph_bytes`
+    /// settings or any referenced `.rpol` file's compiled graph changed
+    /// (ADR-0096). Reload-applied: chains referencing rpol policies
+    /// re-resolve and hot-swap through the same live-policy path as
+    /// `[policy.definitions]` edits.
     pub rpol_changed: bool,
+    /// A `[policy.datasets.<name>]` binding or path changed. Dataset
+    /// contents live outside TOML; this flag describes only the binding
+    /// surface visible in a config diff.
+    pub datasets_changed: bool,
+    /// Internal transaction-planning fence: either side of this diff
+    /// references `.rpol` or dataset files. Kept out of serialized diff
+    /// output; the public JSON surface exposes only actual changes.
+    #[serde(skip)]
+    #[doc(hidden)]
+    pub external_inputs_present: bool,
 }
 
 impl PolicyDiff {
@@ -1727,6 +1744,7 @@ impl PolicyDiff {
             || self.import_chain_changed
             || self.export_chain_changed
             || self.rpol_changed
+            || self.datasets_changed
     }
 }
 
@@ -2040,6 +2058,7 @@ impl ConfigDiff {
             || self.policy.import_chain_changed
             || self.policy.export_chain_changed
             || self.policy.rpol_changed
+            || self.policy.datasets_changed
             || self.honor_graceful_shutdown_changed
             || self.honor_blackhole_changed
             || self.dynamic_neighbors_reload_applied_changed
@@ -2647,13 +2666,22 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
             .push("mixed transaction families".to_string());
     }
     if diff.policy.rpol_changed {
-        // No v1 transaction executor owns the .rpol file catalog — the
-        // files live outside the candidate TOML, so a transaction
-        // cannot atomically stage their content. Apply .rpol changes
-        // via SIGHUP reload (which re-reads and hot-swaps them).
-        class
-            .unsupported_sections
-            .push("[policy] rpol_files (apply .rpol changes via SIGHUP reload)".to_string());
+        push_transaction_external_policy_inputs_reason(&mut class);
+    }
+    if diff.policy.datasets_changed {
+        push_transaction_external_policy_inputs_reason(&mut class);
+    }
+    if diff.policy.external_inputs_present
+        && transaction_stages_full_candidate_snapshot(&class.supported_sections)
+    {
+        // Every v1 executor except the targeted FIB path adopts the full
+        // candidate snapshot. External policy bytes are neither staged nor
+        // covered by the optimistic token, so accepting that snapshot could
+        // make an unrelated neighbor/catalog mutation silently adopt policy
+        // content that was never part of the transaction. A true no-op has no
+        // supported family and remains a no-op; pure FIB substitutes only the
+        // table set and is therefore safe with unchanged external inputs.
+        push_transaction_external_policy_inputs_reason(&mut class);
     }
     if diff.honor_graceful_shutdown_changed {
         class
@@ -2851,6 +2879,26 @@ fn transaction_sections_are_one_family(sections: &[String]) -> bool {
         <= 1
 }
 
+fn transaction_stages_full_candidate_snapshot(sections: &[String]) -> bool {
+    sections
+        .iter()
+        .any(|section| section != TRANSACTION_FIB_SECTION)
+}
+
+fn push_transaction_external_policy_inputs_reason(
+    class: &mut ConfigTransactionSectionClassification,
+) {
+    if !class
+        .unsupported_sections
+        .iter()
+        .any(|section| section == TRANSACTION_EXTERNAL_POLICY_INPUTS_SECTION)
+    {
+        class
+            .unsupported_sections
+            .push(TRANSACTION_EXTERNAL_POLICY_INPUTS_SECTION.to_string());
+    }
+}
+
 /// JSON schema shared by `rustbgpd --diff --json` and the live runtime
 /// config-diff API. The schema mirrors the human diff buckets:
 /// reload-applied, restart-required, and informational.
@@ -2880,6 +2928,7 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
             "import_chain_changed": diff.policy.import_chain_changed,
             "export_chain_changed": diff.policy.export_chain_changed,
             "rpol_changed": diff.policy.rpol_changed,
+            "datasets_changed": diff.policy.datasets_changed,
             "honor_graceful_shutdown_changed": diff.honor_graceful_shutdown_changed,
             "honor_blackhole_changed": diff.honor_blackhole_changed,
             "dynamic_neighbors_changed": diff.dynamic_neighbors_reload_applied_changed,
@@ -2976,7 +3025,8 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
         || !p.neighbor_sets_changed.is_empty()
         || p.import_chain_changed
         || p.export_chain_changed
-        || p.rpol_changed;
+        || p.rpol_changed
+        || p.datasets_changed;
 
     if diff.has_reload_applied_changes() {
         let _ = writeln!(out, "{}\n", style.reload_header);
@@ -3050,7 +3100,14 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
             if p.rpol_changed {
                 let _ = writeln!(
                     out,
-                    "    {} rpol_files / .rpol content",
+                    "    {} rpol_files / rpol_roots / rpol_max_graph_bytes / .rpol graph",
+                    style.change_marker
+                );
+            }
+            if p.datasets_changed {
+                let _ = writeln!(
+                    out,
+                    "    {} policy dataset bindings / paths",
                     style.change_marker
                 );
             }
@@ -5001,7 +5058,15 @@ pub fn diff_policy(old: &PolicyConfig, new: &PolicyConfig) -> PolicyDiff {
         neighbor_sets_changed,
         import_chain_changed: old.import_chain != new.import_chain,
         export_chain_changed: old.export_chain != new.export_chain,
-        rpol_changed: old.rpol_files != new.rpol_files || old.rpol != new.rpol,
+        rpol_changed: old.rpol_files != new.rpol_files
+            || old.rpol_roots != new.rpol_roots
+            || old.rpol_max_graph_bytes != new.rpol_max_graph_bytes
+            || old.rpol != new.rpol,
+        datasets_changed: old.datasets != new.datasets,
+        external_inputs_present: !old.rpol_files.is_empty()
+            || !new.rpol_files.is_empty()
+            || !old.datasets.is_empty()
+            || !new.datasets.is_empty(),
     }
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -16440,6 +16440,119 @@ fn rpol_edit_classifies_policy_chain_impact_for_referencing_peers_only() {
     assert!(diff.effective_neighbor_impact.is_empty(), "{diff:?}");
 }
 
+#[test]
+fn full_snapshot_transaction_with_rpol_inputs_is_rejected() {
+    let dir = rpol_config_dir(RPOL_SOURCE, r#""customer-in(200)""#);
+    let current = load_dir(&dir).expect("config with rpol input loads");
+    let mut candidate = load_dir(&dir).expect("candidate independently reloads rpol input");
+    candidate.neighbors[1].description = Some("changed by transaction".to_string());
+
+    let diff = diff_config(&current, &candidate);
+    assert!(!diff.policy.rpol_changed, "external inputs are unchanged");
+    let class = classify_config_transaction_v1(&diff);
+
+    assert_eq!(class.supported_sections, vec!["[[neighbors]] modify"]);
+    assert_eq!(
+        class.unsupported_sections,
+        vec![TRANSACTION_EXTERNAL_POLICY_INPUTS_SECTION]
+    );
+    assert!(!class.is_committable());
+}
+
+#[test]
+fn rpol_resolution_settings_change_is_unsupported() {
+    let dir = rpol_config_dir(RPOL_SOURCE, r#""customer-in(200)""#);
+    let current = load_dir(&dir).expect("config with rpol input loads");
+
+    let mut roots_candidate = current.clone();
+    roots_candidate
+        .policy
+        .rpol_roots
+        .push(dir.path().join("policies").display().to_string());
+    let roots_diff = diff_config(&current, &roots_candidate);
+    assert!(roots_diff.policy.rpol_changed);
+    assert_eq!(
+        classify_config_transaction_v1(&roots_diff).unsupported_sections,
+        vec![TRANSACTION_EXTERNAL_POLICY_INPUTS_SECTION]
+    );
+
+    let mut budget_candidate = current.clone();
+    budget_candidate.policy.rpol_max_graph_bytes /= 2;
+    let budget_diff = diff_config(&current, &budget_candidate);
+    assert!(budget_diff.policy.rpol_changed);
+    assert_eq!(
+        classify_config_transaction_v1(&budget_diff).unsupported_sections,
+        vec![TRANSACTION_EXTERNAL_POLICY_INPUTS_SECTION]
+    );
+    let json = config_diff_json_value(&budget_diff);
+    assert_eq!(json["reload_applied"]["rpol_changed"], true);
+    let text = format_config_diff(&budget_diff);
+    assert!(text.contains("rpol_max_graph_bytes"), "{text}");
+}
+
+#[test]
+fn targeted_fib_transaction_with_unchanged_external_inputs_remains_committable() {
+    let dir = rpol_config_dir(RPOL_SOURCE, r#""customer-in(200)""#);
+    let mut current = load_dir(&dir).expect("config with rpol input loads");
+    current.fib_tables.push(FibTableConfig {
+        name: "edge".to_string(),
+        table_id: 1000,
+        metric: 200,
+        families: vec!["ipv4_unicast".to_string()],
+        allowed_peer_groups: Vec::new(),
+        allowed_neighbors: Vec::new(),
+        max_routes: None,
+        maximum_paths: None,
+        maximum_paths_ebgp: None,
+        maximum_paths_ibgp: None,
+    });
+    let mut candidate = current.clone();
+    candidate.fib_tables[0].metric = 201;
+
+    let diff = diff_config(&current, &candidate);
+    let class = classify_config_transaction_v1(&diff);
+
+    assert_eq!(class.supported_sections, vec!["[[fib_tables]]"]);
+    assert!(class.unsupported_sections.is_empty(), "{class:?}");
+    assert!(class.is_committable(), "{class:?}");
+
+    let mut budget_candidate = candidate.clone();
+    budget_candidate.policy.rpol_max_graph_bytes /= 2;
+    let mixed_budget = classify_config_transaction_v1(&diff_config(&current, &budget_candidate));
+    assert_eq!(mixed_budget.supported_sections, vec!["[[fib_tables]]"]);
+    assert_eq!(
+        mixed_budget.unsupported_sections,
+        vec![TRANSACTION_EXTERNAL_POLICY_INPUTS_SECTION]
+    );
+    assert!(!mixed_budget.is_committable());
+
+    let mut roots_candidate = candidate;
+    roots_candidate
+        .policy
+        .rpol_roots
+        .push(dir.path().join("policies").display().to_string());
+    let mixed_roots = classify_config_transaction_v1(&diff_config(&current, &roots_candidate));
+    assert_eq!(mixed_roots.supported_sections, vec!["[[fib_tables]]"]);
+    assert_eq!(
+        mixed_roots.unsupported_sections,
+        vec![TRANSACTION_EXTERNAL_POLICY_INPUTS_SECTION]
+    );
+    assert!(!mixed_roots.is_committable());
+}
+
+#[test]
+fn external_input_noop_remains_noop() {
+    let dir = rpol_config_dir(RPOL_SOURCE, r#""customer-in(200)""#);
+    let current = load_dir(&dir).expect("config with rpol input loads");
+    let candidate = load_dir(&dir).expect("candidate independently reloads rpol input");
+
+    let diff = diff_config(&current, &candidate);
+    let class = classify_config_transaction_v1(&diff);
+
+    assert!(class.is_noop(), "{class:?}");
+    assert!(class.unsupported_sections.is_empty(), "{class:?}");
+}
+
 // ── RFC 9687 send hold timer config ─────────────────────────────
 
 #[test]
@@ -17012,6 +17125,128 @@ fn staged_dataset_reload_defers_live_handle_mutation_until_commit() {
     assert!(live.status().last_error.is_some());
     assert_eq!(live.pin().generation, 2);
     assert_eq!(live.pin().data.records(), 2);
+}
+
+#[test]
+fn dataset_path_change_is_visible_and_transaction_unsupported() {
+    let dir = dataset_config_dir("64500\n");
+    let current = load_dir(&dir).expect("config with dataset input loads");
+    let mut candidate = current.clone();
+    candidate
+        .policy
+        .datasets
+        .get_mut("customers")
+        .expect("binding")
+        .path
+        .push_str(".next");
+
+    let diff = diff_config(&current, &candidate);
+    let class = classify_config_transaction_v1(&diff);
+
+    assert!(diff.policy.datasets_changed);
+    assert!(diff.has_reload_applied_changes());
+    assert_eq!(
+        config_diff_json_value(&diff)["reload_applied"]["datasets_changed"],
+        true
+    );
+    let text = format_config_diff(&diff);
+    assert!(text.contains("policy dataset bindings / paths"), "{text}");
+    assert_eq!(
+        class.unsupported_sections,
+        vec![TRANSACTION_EXTERNAL_POLICY_INPUTS_SECTION]
+    );
+    assert!(!class.is_committable());
+
+    let mut fib_current = current;
+    fib_current.fib_tables.push(FibTableConfig {
+        name: "edge".to_string(),
+        table_id: 1000,
+        metric: 200,
+        families: vec!["ipv4_unicast".to_string()],
+        allowed_peer_groups: Vec::new(),
+        allowed_neighbors: Vec::new(),
+        max_routes: None,
+        maximum_paths: None,
+        maximum_paths_ebgp: None,
+        maximum_paths_ibgp: None,
+    });
+    let mut mixed_candidate = fib_current.clone();
+    mixed_candidate.fib_tables[0].metric = 201;
+    mixed_candidate
+        .policy
+        .datasets
+        .get_mut("customers")
+        .expect("binding")
+        .path
+        .push_str(".next");
+    let mixed = classify_config_transaction_v1(&diff_config(&fib_current, &mixed_candidate));
+    assert_eq!(mixed.supported_sections, vec!["[[fib_tables]]"]);
+    assert_eq!(
+        mixed.unsupported_sections,
+        vec![TRANSACTION_EXTERNAL_POLICY_INPUTS_SECTION]
+    );
+    assert!(!mixed.is_committable());
+}
+
+#[test]
+fn full_snapshot_transaction_with_dataset_inputs_is_rejected_without_handle_mutation() {
+    let dir = dataset_config_dir("64500\n");
+    let current = load_dir(&dir).expect("config with dataset input loads");
+    let live = std::sync::Arc::clone(
+        current
+            .policy
+            .dataset_bindings
+            .get("customers")
+            .expect("live binding"),
+    );
+    let generation = live.pin().generation;
+    let mut candidate = load_dir(&dir).expect("candidate independently reloads dataset input");
+    let candidate_binding = std::sync::Arc::clone(
+        candidate
+            .policy
+            .dataset_bindings
+            .get("customers")
+            .expect("candidate binding"),
+    );
+    candidate.neighbors[0].description = Some("changed by transaction".to_string());
+
+    let diff = diff_config(&current, &candidate);
+    let class = classify_config_transaction_v1(&diff);
+
+    assert!(!diff.policy.datasets_changed, "binding is unchanged");
+    assert_eq!(class.supported_sections, vec!["[[neighbors]] modify"]);
+    assert_eq!(
+        class.unsupported_sections,
+        vec![TRANSACTION_EXTERNAL_POLICY_INPUTS_SECTION]
+    );
+    assert!(!class.is_committable());
+    assert!(!std::sync::Arc::ptr_eq(&live, &candidate_binding));
+    assert_eq!(live.pin().generation, generation);
+}
+
+#[test]
+fn only_fib_transactions_avoid_full_candidate_snapshot_staging() {
+    assert!(!transaction_stages_full_candidate_snapshot(&[
+        TRANSACTION_FIB_SECTION.to_string(),
+    ]));
+
+    for section in [
+        TRANSACTION_DYNAMIC_SECTION,
+        TRANSACTION_NEIGHBOR_ADD_SECTION,
+        TRANSACTION_NEIGHBOR_DELETE_SECTION,
+        TRANSACTION_NEIGHBOR_MODIFY_SECTION,
+        TRANSACTION_PEER_GROUP_CATALOG_SECTION,
+        TRANSACTION_POLICY_DEFINITIONS_SECTION,
+        TRANSACTION_POLICY_NEIGHBOR_SETS_SECTION,
+        TRANSACTION_POLICY_GLOBAL_CHAINS_SECTION,
+        TRANSACTION_POLICY_LIVE_IMPACT_SECTION,
+        TRANSACTION_SESSION_RESHAPE_SECTION,
+    ] {
+        assert!(
+            transaction_stages_full_candidate_snapshot(&[section.to_string()]),
+            "{section} must stay behind the external-input fence"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -4106,9 +4106,10 @@ peer_group = "{group}"
             ),
             staged.clone(),
         ));
+        let (config_tx, mut config_rx) = mpsc::channel(1);
 
         let response = apply_config_transaction(
-            deps(None, peer_tx, None, Vec::new()),
+            deps(None, peer_tx, Some(config_tx), Vec::new()),
             proto::ApplyConfigTransactionRequest {
                 candidate_toml: base_toml(
                     r#"
@@ -4135,6 +4136,11 @@ peer_group = "ix-members"
         );
         assert!(response.committed_sections.is_empty());
         assert!(staged.lock().await.is_empty());
+        assert!(matches!(
+            config_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty
+                | tokio::sync::mpsc::error::TryRecvError::Disconnected)
+        ));
     }
 
     #[tokio::test]
@@ -4583,7 +4589,12 @@ remote_asn = 65010
     async fn rejected_confirmed_apply_leaves_no_journal() {
         let dir = tempfile::tempdir().unwrap();
         let journal_path = dir.path().join("commit-confirm-journal.json");
-        let snapshot_toml = Arc::new(Mutex::new(base_toml("")));
+        let history_dir = dir.path().join("history");
+        std::fs::create_dir(&history_dir).unwrap();
+        let history_sentinel = history_dir.join("existing.json");
+        std::fs::write(&history_sentinel, "retained history").unwrap();
+        let original_snapshot = base_toml("");
+        let snapshot_toml = Arc::new(Mutex::new(original_snapshot.clone()));
         let peers = Arc::new(Mutex::new(Vec::new()));
         let (peer_tx, peer_rx) = mpsc::channel(8);
         tokio::spawn(fake_snapshot_peer_manager(
@@ -4592,15 +4603,11 @@ remote_asn = 65010
             snapshot_toml.clone(),
             peers,
         ));
-        let (config_tx, config_rx) = mpsc::channel(8);
-        let ack_task = tokio::spawn(ack_config_transaction_commits(config_rx));
-        let controller = ConfigTransactionController::new(
-            FibTableControlDeps {
-                confirm_journal_path: Some(journal_path.clone()),
-                ..deps_value(None, peer_tx, Some(config_tx), Vec::new())
-            },
-            BgpMetrics::new(),
-        );
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        let mut deps = deps_value(None, peer_tx, Some(config_tx), Vec::new());
+        deps.confirm_journal_path = Some(journal_path.clone());
+        deps.config_history_dir = Some(history_dir.clone());
+        let controller = ConfigTransactionController::new(deps, BgpMetrics::new());
 
         let response = controller
             .clone()
@@ -4619,7 +4626,16 @@ remote_asn = 65010
             !journal_path.exists(),
             "a rejected confirmed apply must not leave a journal behind"
         );
-        ack_task.abort();
+        assert_eq!(*snapshot_toml.lock().await, original_snapshot);
+        assert_eq!(
+            std::fs::read_to_string(&history_sentinel).unwrap(),
+            "retained history"
+        );
+        assert_eq!(std::fs::read_dir(&history_dir).unwrap().count(), 1);
+        assert!(matches!(
+            config_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
     }
 
     /// Shared body for the LAN-277 ambiguous-completion apply tests: run one

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -807,6 +807,267 @@ remote_asn = 65002
     responder.await.unwrap();
 }
 
+#[tokio::test]
+async fn transaction_plan_rejects_full_snapshot_family_with_external_policy_inputs() {
+    let dir = tempfile::tempdir().unwrap();
+    let rpol_path = dir.path().join("edge.rpol");
+    let dataset_path = dir.path().join("customers.list");
+    std::fs::write(
+        &rpol_path,
+        r"
+dataset asn-set customers
+
+policy edge-in {
+    term customer { if route.origin-as in customers { accept } }
+    term rest { reject }
+}
+",
+    )
+    .unwrap();
+    std::fs::write(&dataset_path, "64500\n").unwrap();
+    let config = load_test_config(&format!(
+        r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[policy]
+rpol_files = [{rpol_path:?}]
+
+[policy.datasets.customers]
+path = {dataset_path:?}
+
+[[neighbors]]
+address = "192.0.2.1"
+remote_asn = 65002
+description = "before"
+import_policy_chain = ["edge-in"]
+"#,
+        rpol_path = rpol_path.display().to_string(),
+        dataset_path = dataset_path.display().to_string()
+    ));
+    let live_dataset = std::sync::Arc::clone(
+        config
+            .policy
+            .dataset_bindings
+            .get("customers")
+            .expect("live dataset binding"),
+    );
+    let live_status = live_dataset.status();
+    std::fs::write(&dataset_path, "64500\n64999\n").unwrap();
+    let mut candidate = config.clone();
+    candidate.neighbors[0].description = Some("after".to_string());
+    let candidate = toml::to_string_pretty(&candidate).unwrap();
+    let (_tx, rx) = mpsc::channel(4);
+    let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (rib_tx, mut rib_rx) = mpsc::channel(4);
+    let mgr = PeerManager::new_with_config(
+        rx,
+        internal_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+        None,
+        config,
+    );
+    let responder = tokio::spawn(async move {
+        let Some(RibUpdate::QueryUpdateGroupSnapshot { reply }) = rib_rx.recv().await else {
+            panic!("plan snapshot query missing");
+        };
+        reply
+            .send(rustbgpd_rib::UpdateGroupSnapshot::default())
+            .unwrap();
+    });
+
+    let plan = mgr.plan_config_transaction(&candidate, None).await.unwrap();
+
+    assert_eq!(
+        plan.status,
+        rustbgpd_api::peer_types::RuntimeConfigTransactionStatus::Rejected
+    );
+    assert_eq!(plan.supported_sections, vec!["[[neighbors]] modify"]);
+    assert_eq!(plan.unsupported_sections.len(), 1);
+    assert!(plan.unsupported_sections[0].contains("external inputs"));
+    assert_eq!(
+        mgr.current_config.neighbors[0].description.as_deref(),
+        Some("before")
+    );
+    assert_eq!(live_dataset.status(), live_status);
+    assert_eq!(live_dataset.pin().data.records(), 1);
+    responder.await.unwrap();
+}
+
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "keeps the external dataset, real peer snapshot, and both planner verdicts in one load-bearing scenario"
+)]
+async fn independent_external_reparse_noop_and_pure_fib_have_zero_update_group_impact() {
+    let dir = tempfile::tempdir().unwrap();
+    let rpol_path = dir.path().join("catalog.rpol");
+    let dataset_path = dir.path().join("customers.list");
+    std::fs::write(
+        &rpol_path,
+        r"
+dataset asn-set customers
+
+policy dataset-export {
+    term customer { if route.origin-as in customers { accept } }
+    term rest { reject }
+}
+",
+    )
+    .unwrap();
+    std::fs::write(&dataset_path, "64500\n").unwrap();
+    let mut current = load_test_config(&format!(
+        r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[policy]
+rpol_files = [{rpol_path:?}]
+
+[policy.datasets.customers]
+path = {dataset_path:?}
+
+[[neighbors]]
+address = "192.0.2.1"
+remote_asn = 65002
+export_policy_chain = ["dataset-export"]
+"#,
+        rpol_path = rpol_path.display().to_string(),
+        dataset_path = dataset_path.display().to_string()
+    ));
+    current.fib_tables.push(crate::config::FibTableConfig {
+        name: "edge".to_string(),
+        table_id: 1000,
+        metric: 200,
+        families: vec!["ipv4_unicast".to_string()],
+        allowed_peer_groups: Vec::new(),
+        allowed_neighbors: Vec::new(),
+        max_routes: None,
+        maximum_paths: None,
+        maximum_paths_ebgp: None,
+        maximum_paths_ibgp: None,
+    });
+    let noop_candidate = toml::to_string_pretty(&current).unwrap();
+    let mut fib_candidate = current.clone();
+    fib_candidate.fib_tables[0].metric = 201;
+    let fib_candidate = toml::to_string_pretty(&fib_candidate).unwrap();
+    let resolved = current.resolved_neighbors().unwrap();
+    let neighbor = &resolved[0];
+    let policy = neighbor
+        .export_policy
+        .as_ref()
+        .expect("export chain resolved");
+    assert!(policy.references_dataset("customers"));
+    let live_input = rustbgpd_rib::UpdateGroupClassifierInput {
+        policy_fingerprint: Some(format!("{policy:?}")),
+        policy_provenance: Some(policy.groupability_provenance().to_string()),
+        policy_requires_peer_context: policy.requires_peer_context(),
+        target_is_ebgp: true,
+        target_is_rr_client: neighbor.transport_config.route_reflector_client,
+        target_local_role: neighbor
+            .transport_config
+            .peer
+            .local_role
+            .map(rustbgpd_wire::BgpRole::to_u8),
+        sendable_families: vec![(1, 1)],
+        llgr_families: Vec::new(),
+        add_path_send: false,
+        per_client_best: neighbor.transport_config.per_client_best,
+        interpret_rfc1997: neighbor.transport_config.interpret_rfc1997,
+        orr_vantage: neighbor.transport_config.orr_vantage,
+        orf_installed: false,
+    };
+    let live_classification = rustbgpd_rib::classify_update_group(live_input.clone());
+    let (_tx, rx) = mpsc::channel(4);
+    let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (rib_tx, mut rib_rx) = mpsc::channel(4);
+    let mgr = PeerManager::new_with_config(
+        rx,
+        internal_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+        None,
+        current,
+    );
+    let responder = tokio::spawn(async move {
+        for _ in 0..2 {
+            let Some(RibUpdate::QueryUpdateGroupSnapshot { reply }) = rib_rx.recv().await else {
+                panic!("plan snapshot query missing");
+            };
+            reply
+                .send(rustbgpd_rib::UpdateGroupSnapshot {
+                    peers: vec![rustbgpd_rib::UpdateGroupPeerSnapshot {
+                        peer: "192.0.2.1".parse().unwrap(),
+                        input: live_input.clone(),
+                        classification: live_classification.clone(),
+                        runtime_membership: "group:0".to_string(),
+                    }],
+                })
+                .unwrap();
+        }
+    });
+
+    let noop = mgr
+        .plan_config_transaction(&noop_candidate, None)
+        .await
+        .unwrap();
+    let fib = mgr
+        .plan_config_transaction(&fib_candidate, None)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        noop.status,
+        rustbgpd_api::peer_types::RuntimeConfigTransactionStatus::Noop
+    );
+    assert!(noop.supported_sections.is_empty());
+    assert!(noop.unsupported_sections.is_empty());
+    assert_eq!(noop.update_group_impact.entries.len(), 1);
+    assert_eq!(noop.update_group_impact.entries[0].transition, "no_op");
+    assert!(!noop.update_group_impact.entries[0].local_resync);
+    assert_eq!(noop.update_group_impact.rollup.affected_peers, 0);
+    assert_eq!(noop.update_group_impact.rollup.affected_families, 0);
+    assert_eq!(noop.update_group_impact.rollup.local_resyncs, 0);
+    assert_eq!(noop.update_group_impact.rollup.no_op, 1);
+    assert_eq!(
+        fib.status,
+        rustbgpd_api::peer_types::RuntimeConfigTransactionStatus::Committable
+    );
+    assert_eq!(fib.supported_sections, vec!["[[fib_tables]]"]);
+    assert!(fib.unsupported_sections.is_empty());
+    assert_eq!(fib.update_group_impact.entries.len(), 1);
+    assert_eq!(fib.update_group_impact.entries[0].transition, "no_op");
+    assert!(!fib.update_group_impact.entries[0].local_resync);
+    assert_eq!(fib.update_group_impact.rollup.affected_peers, 0);
+    assert_eq!(fib.update_group_impact.rollup.affected_families, 0);
+    assert_eq!(fib.update_group_impact.rollup.local_resyncs, 0);
+    assert_eq!(fib.update_group_impact.rollup.no_op, 1);
+    responder.await.unwrap();
+}
+
 async fn query_session_event_history(
     mgr: &PeerManager,
     peer: Option<IpAddr>,


### PR DESCRIPTION
## Summary

- reject native and gNMI config transactions that would adopt a full candidate snapshot while the running or candidate config references external rpol or dataset inputs
- expose dataset binding/path changes and expand rpol diff coverage to roots, graph limits, and compiled graph changes
- preserve genuine no-op plans and pure targeted FIB transactions, and document coordinated file deployment plus SIGHUP

## Correctness boundary

External policy bytes are outside the transaction token, staging payload, and rollback payload. All current non-FIB executors adopt the full candidate snapshot, so they now fail closed before runtime, persistence, history, journal, or event mutation. The FIB executor remains safe because it substitutes only the accepted table set.

No protobuf, history format, SIGHUP behavior, dataset-handle model, or production transaction-control flow changes.

## Verification

- cargo fmt --all -- --check
- cargo build --locked -p rs-config-render --bin rs-config-render
- cargo test --locked -p rustbgpd
- cargo clippy --locked -p rustbgpd --all-targets -- -D warnings
- cargo doc --locked -p rustbgpd --no-deps
- python3 scripts/check-v1-stable-surface.py
- git diff --check
- full pre-push fmt, clippy, workspace test, and rustdoc hooks

## Load-bearing proofs

- removing the external-input fence makes rpol, dataset, and real peer-manager rejection tests fail
- omitting dataset paths, rpol roots, or graph-budget fields makes visibility and mixed-FIB rejection tests fail
- fencing no-ops or pure FIB, or exempting a non-FIB family, fails the preservation/family matrix
- pointer-sensitive policy reparsing turns a real dataset-backed peer row into regroup/resync instead of no-op
- planning-time dataset mutation changes live handle status/data/generation assertions
- continuing after rejection mutates snapshot, event, history, or journal assertions; routing FIB through full-snapshot persistence trips the existing strict dispatch fake