### PR TITLE
fix: retain RR client role through graceful restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Graceful Restart and Long-Lived Graceful Restart now retain an iBGP route
+  source's route-reflector-client classification for as long as its stale
+  routes remain eligible for reflection, preventing late joins or LLGR
+  promotion from silently suppressing previously reflected routes.
+
 - Config transactions now fail closed when a native apply/rollback or gNMI
   `Set` would adopt a full candidate snapshot while either the running or
   candidate config references external `.rpol` graphs or policy datasets.

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -274,7 +274,10 @@ pub struct RibManager {
     peer_advertised_llgr_families: HashMap<IpAddr, Vec<(Afi, Safi)>>,
     /// Whether each registered outbound peer is eBGP (true) or iBGP (false).
     peer_is_ebgp: HashMap<IpAddr, bool>,
-    /// Whether each registered outbound peer is a route reflector client.
+    /// Whether the active or GR/LLGR-retained peer is a route reflector
+    /// client. Retained across graceful-restart outbound teardown because
+    /// stale iBGP routes still need their source classification; overwritten
+    /// at re-registration and removed by terminal peer teardown.
     peer_is_rr_client: HashMap<IpAddr, bool>,
     /// Local RFC 9234 role for the active outbound registration.
     peer_local_roles: HashMap<IpAddr, Option<BgpRole>>,

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -337,6 +337,7 @@ impl RibManager {
         self.peer_asn.remove(&peer);
         self.peer_group.remove(&peer);
         self.peer_bgp_id.remove(&peer);
+        self.peer_is_rr_client.remove(&peer);
         self.force_outbound_peers.remove(&peer);
         self.clear_peer_refresh_metrics(peer);
     }
@@ -471,8 +472,9 @@ impl RibManager {
     /// graceful-restart teardown paths. Keeping ONE list prevents the two
     /// cleanup sites from drifting — the GR path historically missed maps
     /// added later (the ORF filter/gate leak). Peer-identity maps
-    /// (`peer_asn`/`peer_group`/`peer_bgp_id`) stay out: GR keeps them for
-    /// the returning peer; `PeerDown` removes them at its call site.
+    /// (`peer_asn`/`peer_group`/`peer_bgp_id`) and the retained route-source
+    /// classification (`peer_is_rr_client`) stay out: GR keeps them for stale
+    /// routes and the returning peer; terminal `PeerDown` removes them.
     pub(super) fn clear_outbound_peer_state(&mut self, peer: IpAddr) {
         let was_registered = self.outbound_peers.remove(&peer).is_some();
         self.outbound_session_ids.remove(&peer);
@@ -514,7 +516,6 @@ impl RibManager {
         self.peer_sendable_families.remove(&peer);
         self.peer_advertised_llgr_families.remove(&peer);
         self.peer_is_ebgp.remove(&peer);
-        self.peer_is_rr_client.remove(&peer);
         self.peer_local_roles.remove(&peer);
         self.peer_export_encoders.remove(&peer);
         self.peer_unexportable.remove(&peer);

--- a/crates/rib/src/manager/tests/gr_llgr.rs
+++ b/crates/rib/src/manager/tests/gr_llgr.rs
@@ -1406,6 +1406,225 @@ async fn gr_expiry_sweep_spares_reestablished_peer_awaiting_eor() {
 
 // --- Route Reflector tests ---
 
+fn establish_ibgp_peer(
+    manager: &mut RibManager,
+    peer: IpAddr,
+    session_id: u64,
+    route_reflector_client: bool,
+    negotiated_llgr_families: Vec<(Afi, Safi)>,
+) -> mpsc::Receiver<OutboundRouteUpdate> {
+    let (outbound_tx, outbound_rx) = mpsc::channel(16);
+    manager.handle_update(RibUpdate::PeerUp {
+        per_client_best: false,
+        interpret_rfc1997: true,
+        session_id,
+        peer,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: false,
+        route_reflector_client,
+        orr_vantage: None,
+        add_path_send_families: Vec::new(),
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families,
+    });
+    outbound_rx
+}
+
+fn make_rr_ibgp_route(prefix: Ipv4Prefix, source: Ipv4Addr) -> Route {
+    let mut route = make_route(prefix, source);
+    route.origin_type = crate::route::RouteOrigin::Ibgp;
+    route
+}
+
+async fn drain_unicast_initial_dump(
+    outbound_rx: &mut mpsc::Receiver<OutboundRouteUpdate>,
+) -> Vec<Route> {
+    let mut announced = Vec::new();
+    loop {
+        let update = outbound_rx.recv().await.expect("initial dump stays open");
+        assert!(
+            update.withdraw.is_empty(),
+            "an initial dump must not withdraw unicast routes"
+        );
+        announced.extend(update.announce.iter().cloned());
+        if update.end_of_rib.contains(&(Afi::Ipv4, Safi::Unicast)) {
+            return announced;
+        }
+    }
+}
+
+#[tokio::test]
+async fn grouped_late_join_reflects_gr_retained_rr_client_route() {
+    let (_tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 254));
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+
+    let mut source_rx = establish_ibgp_peer(&mut manager, source, 11, true, Vec::new());
+    drain_eor(&mut source_rx).await;
+    manager.handle_update(RibUpdate::RoutesReceived {
+        session_id: 11,
+        peer: source,
+        announced: vec![make_rr_ibgp_route(prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        withdrawn: Vec::new(),
+        flowspec_announced: Vec::new(),
+        flowspec_withdrawn: Vec::new(),
+        evpn_announced: Vec::new(),
+        evpn_withdrawn: Vec::new(),
+    });
+    drain_route_chunks(&mut manager);
+
+    manager.handle_update(RibUpdate::PeerGracefulRestart {
+        session_id: 11,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_llgr_capable: false,
+        peer_llgr_families: Vec::new(),
+        llgr_stale_time: 0,
+    });
+
+    let mut target_rx = establish_ibgp_peer(&mut manager, target, 21, false, Vec::new());
+    assert!(
+        manager.grouped_member_of(target).is_some(),
+        "late join must exercise the grouped initial-dump path"
+    );
+    let initial = drain_unicast_initial_dump(&mut target_rx).await;
+    assert!(
+        initial
+            .iter()
+            .any(|route| route.prefix == Prefix::V4(prefix) && route.is_stale),
+        "a non-client must receive an RR-client source's GR-retained route before EoR"
+    );
+
+    manager.sweep_gr_stale(source);
+    assert!(
+        !manager.peer_is_rr_client.contains_key(&source),
+        "terminal GR expiry must remove the retained source classification"
+    );
+}
+
+#[tokio::test]
+async fn ungrouped_llgr_promotion_keeps_rr_client_route_advertised() {
+    let (_tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 254));
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    manager.test_force_ungrouped = true;
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let family = (Afi::Ipv4, Safi::Unicast);
+
+    let mut source_rx = establish_ibgp_peer(&mut manager, source, 31, true, vec![family]);
+    drain_eor(&mut source_rx).await;
+    let mut target_rx = establish_ibgp_peer(&mut manager, target, 41, false, vec![family]);
+    drain_eor(&mut target_rx).await;
+    assert!(manager.grouped_member_of(target).is_none());
+
+    manager.handle_update(RibUpdate::RoutesReceived {
+        session_id: 31,
+        peer: source,
+        announced: vec![make_rr_ibgp_route(prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        withdrawn: Vec::new(),
+        flowspec_announced: Vec::new(),
+        flowspec_withdrawn: Vec::new(),
+        evpn_announced: Vec::new(),
+        evpn_withdrawn: Vec::new(),
+    });
+    drain_route_chunks(&mut manager);
+    let initial = target_rx
+        .try_recv()
+        .expect("target receives reflected route");
+    assert!(
+        initial
+            .announce
+            .iter()
+            .any(|route| route.prefix == Prefix::V4(prefix))
+    );
+    assert!(initial.withdraw.is_empty());
+
+    manager.handle_update(RibUpdate::PeerGracefulRestart {
+        session_id: 31,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![family],
+        peer_llgr_capable: true,
+        peer_llgr_families: vec![rustbgpd_wire::LlgrFamily {
+            afi: family.0,
+            safi: family.1,
+            forwarding_preserved: false,
+            stale_time: 600,
+        }],
+        llgr_stale_time: 600,
+    });
+    while let Ok(update) = target_rx.try_recv() {
+        assert!(
+            !update.withdraw.contains(&(Prefix::V4(prefix), 0)),
+            "GR entry must not withdraw the reflected route"
+        );
+    }
+
+    manager.sweep_gr_stale(source);
+    while let Ok(update) = target_rx.try_recv() {
+        assert!(
+            !update.withdraw.contains(&(Prefix::V4(prefix), 0)),
+            "LLGR promotion must not reclassify the retained client route as split-horizon"
+        );
+    }
+    assert!(
+        manager.adj_ribs_out[&target]
+            .get(&Prefix::V4(prefix), 0)
+            .is_some(),
+        "the ungrouped target must retain the reflected prefix after LLGR promotion"
+    );
+    assert_eq!(manager.peer_is_rr_client.get(&source), Some(&true));
+
+    manager.sweep_llgr_stale(source, &[family]);
+    assert!(
+        !manager.peer_is_rr_client.contains_key(&source),
+        "terminal LLGR expiry must remove the retained source classification"
+    );
+}
+
+#[tokio::test]
+async fn rr_client_role_is_overwritten_when_source_reestablishes_as_nonclient() {
+    let (_tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 254));
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+    let mut first_rx = establish_ibgp_peer(&mut manager, source, 51, true, Vec::new());
+    drain_eor(&mut first_rx).await;
+    manager.handle_update(RibUpdate::PeerGracefulRestart {
+        session_id: 51,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_llgr_capable: false,
+        peer_llgr_families: Vec::new(),
+        llgr_stale_time: 0,
+    });
+    assert_eq!(manager.peer_is_rr_client.get(&source), Some(&true));
+
+    let mut replacement_rx = establish_ibgp_peer(&mut manager, source, 52, false, Vec::new());
+    drain_eor(&mut replacement_rx).await;
+    assert_eq!(
+        manager.peer_is_rr_client.get(&source),
+        Some(&false),
+        "new-session registration must overwrite the retained GR role"
+    );
+}
+
 // --- Per-family LLGR lifecycle (LAN-282) + LLGR export coupling (LAN-191) ---
 
 /// Re-establish `peer` through the run loop as an iBGP RR client with the


### PR DESCRIPTION
## Summary

- retain a route source's RR-client classification while its GR or LLGR Adj-RIB-In routes remain eligible for reflection
- remove the classification at terminal peer teardown and keep existing re-registration overwrite semantics
- cover grouped late joins, forced-ungrouped GR-to-LLGR promotion, terminal cleanup, and role changes on re-establishment

## Root cause

Graceful Restart correctly retained stale Adj-RIB-In routes, but shared outbound cleanup deleted their source RR-client classification. RFC 4456 eligibility then treated the missing source as a non-client, so a late or restaged non-client target could silently miss a previously reflected route.

The correction is lifecycle-local: session cleanup retains the source role; terminal teardown removes it. Unknown sources remain fail-closed, and no distribution or GR algorithm changes.

## Verification

- three exact direct-manager GR/LLGR regressions
- cargo fmt --all -- --check
- cargo clippy --locked -p rustbgpd-rib --all-targets -- -D warnings
- cargo test --locked -p rustbgpd-rib: 1036 passed, 2 ignored
- cargo clippy --locked --workspace --all-targets -- -D warnings
- cargo test --locked --workspace
- cargo doc --locked --workspace --no-deps
- git diff --check
- full pre-push fmt, clippy, workspace test, and rustdoc hooks

## Load-bearing proofs

- restoring the old-main cleanup point makes the grouped late join miss the retained stale prefix
- restoring it makes forced-ungrouped LLGR promotion emit a withdrawal
- omitting terminal cleanup leaks the classification after both GR and LLGR expiry
- preventing registration overwrite leaves a re-established non-client classified as an RR client