### PR TITLE
bench: measure attribute intern hashing cost

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1414,11 +1414,15 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
     per-(vantage, key) ORR groups — cut (win bounded by
     peers-per-vantage, second staged-table dimension), un-defer trigger:
     an operator running many peers per vantage.
-  - Adj-RIB-In attribute interning: explore storing a stable fingerprint beside
-    interned `Arc<Vec<PathAttribute>>` sets to avoid hashing every attribute on
-    each insert, with full equality fallback. Gate on `adj_rib_in_insert`,
-    `bulk_initial_load`, and churn benches across typical, rich, and
-    many-unique attribute sets; do not regress the memory win from interning.
+  - Adj-RIB-In attribute-intern hashing: **measured NO-GO**
+    ([August 2026 receipt](docs/perf/attr-intern-hashing-2026-08.md)). The
+    rich/shared intern, insert, and bulk rows were stable, but their required
+    isolated hash-only numerator exceeded the 3% same-SHA range cap (19.71%),
+    and rich/shared churn exceeded its 5% cap (5.04%); no stable fingerprint
+    prototype or production gain is authorized. Reopen only with a cleaner
+    isolated attribution and repeat the full typical/rich/unique insert,
+    bulk-load, and churn measurement matrix. Only a measurement GO may proceed
+    to a prototype's collision and memory gates.
   - General FIB runtime: investigate prefix-dirty reconcile so a single prefix
     change does not necessarily trigger full RIB query + full kernel dump +
     full projection. Design-gated because drift recovery, ECMP siblings,

--- a/crates/rib/benches/rib_ops.rs
+++ b/crates/rib/benches/rib_ops.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use std::time::Instant;
@@ -12,17 +14,33 @@ use rustbgpd_rib::best_path::best_path_cmp;
 use rustbgpd_rib::loc_rib::LocRib;
 use rustbgpd_rib::route::{Route, RouteOrigin};
 use rustbgpd_wire::{
-    AsPath, AsPathSegment, Ipv4Prefix, Origin, PathAttribute, Prefix, RpkiValidation,
+    AsPath, AsPathSegment, ExtendedCommunity, Ipv4Prefix, LargeCommunity, Origin, PathAttribute,
+    Prefix, RpkiValidation,
 };
+use rustc_hash::FxHasher;
 
 fn generate_prefixes(count: usize) -> Vec<Prefix> {
-    (0..count)
+    const PREFIXES_PER_BLOCK: usize = 1 << 16;
+    const BLOCKS: usize = 256 - 10;
+    assert!(
+        count <= PREFIXES_PER_BLOCK * BLOCKS,
+        "benchmark prefix space exhausted"
+    );
+    let prefixes: Vec<_> = (0..count)
         .map(|i| {
+            let block =
+                u8::try_from(i / PREFIXES_PER_BLOCK).expect("benchmark prefix block fits u8");
             let b1 = ((i >> 8) & 0xFF) as u8;
             let b2 = (i & 0xFF) as u8;
-            Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, b1, b2, 0), 24))
+            Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10 + block, b1, b2, 0), 24))
         })
-        .collect()
+        .collect();
+    assert_eq!(
+        prefixes.iter().copied().collect::<HashSet<_>>().len(),
+        count,
+        "benchmark prefixes must remain unique beyond 65,536"
+    );
+    prefixes
 }
 
 fn typical_attributes(peer_idx: u32) -> Vec<PathAttribute> {
@@ -41,14 +59,348 @@ fn typical_attributes(peer_idx: u32) -> Vec<PathAttribute> {
     ]
 }
 
+fn rich_attributes(peer_idx: u32) -> Vec<PathAttribute> {
+    let mut attrs = typical_attributes(peer_idx);
+    attrs.push(PathAttribute::Communities(
+        (0..32).map(|i| (65_000_u32 << 16) | i).collect(),
+    ));
+    attrs.push(PathAttribute::ExtendedCommunities(
+        (0..24)
+            .map(|i| ExtendedCommunity::new(0x0002_FDE8_0000_0000 | i))
+            .collect(),
+    ));
+    attrs.push(PathAttribute::LargeCommunities(
+        (0..16)
+            .map(|i| LargeCommunity::new(65_000, 100 + i, 200 + i))
+            .collect(),
+    ));
+    attrs.push(PathAttribute::OriginatorId(Ipv4Addr::new(192, 0, 2, 1)));
+    attrs.push(PathAttribute::ClusterList(
+        (0..16)
+            .map(|i| Ipv4Addr::new(198, 51, 100, i + 1))
+            .collect(),
+    ));
+    attrs.push(PathAttribute::OnlyToCustomer(65_000));
+    attrs
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AttrProfile {
+    Typical,
+    Rich,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AttrAllocation {
+    SharedArc,
+    IndependentEqual,
+    ManyUnique,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct AttrCase {
+    label: &'static str,
+    count: usize,
+    profile: AttrProfile,
+    allocation: AttrAllocation,
+}
+
+const fn attr_case(
+    label: &'static str,
+    count: usize,
+    profile: AttrProfile,
+    allocation: AttrAllocation,
+) -> AttrCase {
+    AttrCase {
+        label,
+        count,
+        profile,
+        allocation,
+    }
+}
+
+const ATTR_CASES: [AttrCase; 7] = [
+    attr_case(
+        "typical_shared_arc",
+        10_000,
+        AttrProfile::Typical,
+        AttrAllocation::SharedArc,
+    ),
+    attr_case(
+        "typical_independent_equal",
+        10_000,
+        AttrProfile::Typical,
+        AttrAllocation::IndependentEqual,
+    ),
+    attr_case(
+        "rich_shared_arc",
+        10_000,
+        AttrProfile::Rich,
+        AttrAllocation::SharedArc,
+    ),
+    attr_case(
+        "rich_independent_equal",
+        10_000,
+        AttrProfile::Rich,
+        AttrAllocation::IndependentEqual,
+    ),
+    attr_case(
+        "many_unique",
+        10_000,
+        AttrProfile::Typical,
+        AttrAllocation::ManyUnique,
+    ),
+    attr_case(
+        "typical_shared_arc",
+        100_000,
+        AttrProfile::Typical,
+        AttrAllocation::SharedArc,
+    ),
+    attr_case(
+        "typical_independent_equal",
+        100_000,
+        AttrProfile::Typical,
+        AttrAllocation::IndependentEqual,
+    ),
+];
+
+fn base_attributes(profile: AttrProfile) -> Vec<PathAttribute> {
+    match profile {
+        AttrProfile::Typical => typical_attributes(1),
+        AttrProfile::Rich => rich_attributes(1),
+    }
+}
+
+fn unique_attributes(index: usize) -> Vec<PathAttribute> {
+    let mut attrs = typical_attributes(1);
+    let med = attrs
+        .iter_mut()
+        .find_map(|attr| match attr {
+            PathAttribute::Med(value) => Some(value),
+            _ => None,
+        })
+        .expect("typical benchmark attributes contain MED");
+    *med = u32::try_from(index).expect("benchmark unique index fits u32");
+    attrs
+}
+
+fn build_attribute_arcs(case: AttrCase, count: usize) -> Vec<Arc<Vec<PathAttribute>>> {
+    match case.allocation {
+        AttrAllocation::SharedArc => {
+            let attrs = Arc::new(base_attributes(case.profile));
+            vec![attrs; count]
+        }
+        AttrAllocation::IndependentEqual => {
+            let attrs = base_attributes(case.profile);
+            (0..count).map(|_| Arc::new(attrs.clone())).collect()
+        }
+        AttrAllocation::ManyUnique => (0..count)
+            .map(|index| Arc::new(unique_attributes(index)))
+            .collect(),
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct HashObservation {
+    digest: u64,
+    writes: u64,
+    bytes: u64,
+}
+
+#[derive(Default)]
+struct CountingHasher {
+    inner: FxHasher,
+    writes: u64,
+    bytes: u64,
+}
+
+macro_rules! forward_counted_write {
+    ($method:ident, $ty:ty) => {
+        fn $method(&mut self, value: $ty) {
+            self.writes += 1;
+            self.bytes += std::mem::size_of::<$ty>() as u64;
+            self.inner.$method(value);
+        }
+    };
+}
+
+impl Hasher for CountingHasher {
+    fn finish(&self) -> u64 {
+        self.inner.finish()
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.writes += 1;
+        self.bytes += bytes.len() as u64;
+        self.inner.write(bytes);
+    }
+
+    forward_counted_write!(write_u8, u8);
+    forward_counted_write!(write_u16, u16);
+    forward_counted_write!(write_u32, u32);
+    forward_counted_write!(write_u64, u64);
+    forward_counted_write!(write_u128, u128);
+    forward_counted_write!(write_usize, usize);
+    forward_counted_write!(write_i8, i8);
+    forward_counted_write!(write_i16, i16);
+    forward_counted_write!(write_i32, i32);
+    forward_counted_write!(write_i64, i64);
+    forward_counted_write!(write_i128, i128);
+    forward_counted_write!(write_isize, isize);
+}
+
+fn observe_hash(attrs: &[PathAttribute]) -> HashObservation {
+    let mut hasher = CountingHasher::default();
+    attrs.hash(&mut hasher);
+    HashObservation {
+        digest: hasher.finish(),
+        writes: hasher.writes,
+        bytes: hasher.bytes,
+    }
+}
+
+fn hash_with_production_hasher(attrs: &[PathAttribute]) -> u64 {
+    let mut hasher = FxHasher::default();
+    attrs.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn validate_attr_case(case: AttrCase) {
+    let mut attrs = build_attribute_arcs(case, case.count);
+    let input_pointers = attrs
+        .iter()
+        .map(|attrs| Arc::as_ptr(attrs) as usize)
+        .collect::<HashSet<_>>()
+        .len();
+    let input_contents = attrs.iter().map(Arc::as_ref).collect::<HashSet<_>>().len();
+
+    match case.allocation {
+        AttrAllocation::SharedArc => {
+            assert_eq!(input_pointers, 1, "shared case must reuse one Arc");
+            assert_eq!(input_contents, 1, "shared case must have equal content");
+        }
+        AttrAllocation::IndependentEqual => {
+            assert_eq!(input_pointers, case.count, "equal case must start unshared");
+            assert_eq!(input_contents, 1, "equal case must have equal content");
+        }
+        AttrAllocation::ManyUnique => {
+            assert_eq!(
+                input_pointers, case.count,
+                "unique case must start unshared"
+            );
+            assert_eq!(
+                input_contents, case.count,
+                "unique content must not collapse"
+            );
+        }
+    }
+
+    let mut table = AttrInternTable::new();
+    for value in &mut attrs {
+        table.intern(value);
+    }
+    let output_pointers = attrs
+        .iter()
+        .map(|attrs| Arc::as_ptr(attrs) as usize)
+        .collect::<HashSet<_>>()
+        .len();
+    let expected = if case.allocation == AttrAllocation::ManyUnique {
+        case.count
+    } else {
+        1
+    };
+    assert_eq!(
+        table.len(),
+        expected,
+        "intern table length must match content"
+    );
+    assert_eq!(
+        output_pointers, expected,
+        "interned pointer roster must match table"
+    );
+}
+
+fn validate_attr_hash_measurement() {
+    let typical_shared = build_attribute_arcs(ATTR_CASES[0], 1);
+    let typical_equal = build_attribute_arcs(ATTR_CASES[1], 1);
+    let rich_shared = build_attribute_arcs(ATTR_CASES[2], 1);
+    let rich_equal = build_attribute_arcs(ATTR_CASES[3], 1);
+
+    let typical_shared_hash = observe_hash(&typical_shared[0]);
+    let typical_equal_hash = observe_hash(&typical_equal[0]);
+    let rich_shared_hash = observe_hash(&rich_shared[0]);
+    let rich_equal_hash = observe_hash(&rich_equal[0]);
+
+    assert!(
+        typical_shared_hash.writes > 0 && typical_shared_hash.bytes > 0,
+        "attrs.hash must perform counted work"
+    );
+    assert_eq!(
+        typical_shared_hash, typical_equal_hash,
+        "shared and independently allocated equal typical attrs must hash identically"
+    );
+    assert_eq!(
+        rich_shared_hash, rich_equal_hash,
+        "shared and independently allocated equal rich attrs must hash identically"
+    );
+    assert_eq!(
+        typical_shared_hash.digest,
+        hash_with_production_hasher(&typical_shared[0]),
+        "counting and timed hash helpers must agree for typical attrs"
+    );
+    assert_eq!(
+        rich_shared_hash.digest,
+        hash_with_production_hasher(&rich_shared[0]),
+        "counting and timed hash helpers must agree for rich attrs"
+    );
+    assert!(
+        rich_shared_hash.writes > typical_shared_hash.writes,
+        "rich attrs must perform more hash writes"
+    );
+    assert!(
+        rich_shared_hash.bytes > typical_shared_hash.bytes,
+        "rich attrs must hash more bytes"
+    );
+    assert_ne!(
+        hash_with_production_hasher(&unique_attributes(1)),
+        hash_with_production_hasher(&unique_attributes(2)),
+        "distinct attribute content must produce distinct fixture digests"
+    );
+
+    for case in ATTR_CASES {
+        validate_attr_case(case);
+    }
+    let prefixes = generate_prefixes(100_000);
+    assert_eq!(
+        prefixes[0],
+        Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24))
+    );
+    assert_eq!(
+        prefixes[65_535],
+        Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 255, 255, 0), 24))
+    );
+    assert_eq!(
+        prefixes[65_536],
+        Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(11, 0, 0, 0), 24))
+    );
+}
+
 fn make_route(prefix: Prefix, peer_idx: u32) -> Route {
+    make_route_with_attributes(prefix, peer_idx, Arc::new(typical_attributes(peer_idx)))
+}
+
+fn make_route_with_attributes(
+    prefix: Prefix,
+    peer_idx: u32,
+    attributes: Arc<Vec<PathAttribute>>,
+) -> Route {
     Route {
         prefix,
         next_hop: IpAddr::V4(Ipv4Addr::new(10, 0, peer_idx as u8, 1)),
         link_local_next_hop: None,
         next_hop_scope: None,
         peer: IpAddr::V4(Ipv4Addr::new(10, 0, peer_idx as u8, 1)),
-        attributes: Arc::new(typical_attributes(peer_idx)),
+        attributes,
         received_at: Instant::now(),
         origin_type: RouteOrigin::Ebgp,
         peer_router_id: Ipv4Addr::new(10, 0, peer_idx as u8, 1),
@@ -90,6 +442,226 @@ fn export_ctx(prefix: Prefix, aspath_str: &str) -> RouteContext<'_> {
         local_pref: None,
         med: None,
     }
+}
+
+fn bench_attr_intern_hashing(c: &mut Criterion) {
+    // This is deliberately outside every timed loop. Deleting the real
+    // `attrs.hash(&mut hasher)` call makes the executable fail here before it
+    // can publish Criterion numbers.
+    validate_attr_hash_measurement();
+
+    let mut hash_group = c.benchmark_group("attr_hash_only");
+    hash_group.sample_size(10);
+    for case in ATTR_CASES {
+        let attrs = build_attribute_arcs(case, case.count);
+        hash_group.bench_with_input(
+            BenchmarkId::new(case.label, case.count),
+            &attrs,
+            |b, attrs| {
+                b.iter(|| {
+                    let mut folded = 0_u64;
+                    for (index, attrs) in attrs.iter().enumerate() {
+                        let digest = hash_with_production_hasher(std::hint::black_box(attrs));
+                        folded = folded.rotate_left(1) ^ digest ^ index as u64;
+                    }
+                    std::hint::black_box(folded)
+                });
+            },
+        );
+    }
+    hash_group.finish();
+
+    let mut intern_group = c.benchmark_group("attr_intern");
+    intern_group.sample_size(10);
+    for case in ATTR_CASES {
+        let attrs = build_attribute_arcs(case, case.count);
+        intern_group.bench_with_input(
+            BenchmarkId::new(case.label, case.count),
+            &attrs,
+            |b, attrs| {
+                b.iter_batched(
+                    || (attrs.clone(), AttrInternTable::new()),
+                    |(mut attrs, mut table)| {
+                        for value in &mut attrs {
+                            table.intern(value);
+                        }
+                        std::hint::black_box((attrs, table))
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    intern_group.finish();
+}
+
+fn case_routes(case: AttrCase, peer_idx: u32) -> (Vec<Prefix>, Vec<Route>) {
+    let prefixes = generate_prefixes(case.count);
+    let attrs = build_attribute_arcs(case, case.count);
+    let routes = prefixes
+        .iter()
+        .zip(attrs)
+        .map(|(prefix, attrs)| make_route_with_attributes(*prefix, peer_idx, attrs))
+        .collect();
+    (prefixes, routes)
+}
+
+fn bench_attr_hashing_adj_rib_in_insert(c: &mut Criterion) {
+    let mut group = c.benchmark_group("attr_hashing_adj_rib_in_insert");
+    group.sample_size(10);
+    for case in ATTR_CASES {
+        let (_, routes) = case_routes(case, 1);
+        group.bench_with_input(
+            BenchmarkId::new(case.label, case.count),
+            &routes,
+            |b, routes| {
+                b.iter_batched(
+                    || {
+                        (
+                            AdjRibIn::with_capacity(
+                                IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+                                routes.len(),
+                                0,
+                            ),
+                            AttrInternTable::new(),
+                        )
+                    },
+                    |(mut rib, mut intern)| {
+                        for route in routes {
+                            let mut route = route.clone();
+                            intern.intern(&mut route.attributes);
+                            rib.insert(route);
+                        }
+                        std::hint::black_box((rib, intern))
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_attr_hashing_bulk_initial_load(c: &mut Criterion) {
+    let mut group = c.benchmark_group("attr_hashing_bulk_initial_load");
+    group.sample_size(10);
+    for case in ATTR_CASES {
+        let (prefixes, routes) = case_routes(case, 1);
+        group.bench_with_input(
+            BenchmarkId::new(case.label, case.count),
+            &(&prefixes, &routes),
+            |b, (prefixes, routes)| {
+                b.iter_batched(
+                    || {
+                        (
+                            AdjRibIn::with_capacity(
+                                IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+                                routes.len(),
+                                0,
+                            ),
+                            LocRib::with_capacity(routes.len()),
+                            AdjRibOut::with_capacity(
+                                IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+                                routes.len(),
+                            ),
+                            AttrInternTable::new(),
+                        )
+                    },
+                    |(mut rib, mut loc, mut out, mut intern)| {
+                        for route in *routes {
+                            let mut route = route.clone();
+                            intern.intern(&mut route.attributes);
+                            rib.insert(route);
+                        }
+                        for prefix in *prefixes {
+                            if loc.recompute(*prefix, rib.iter_prefix(prefix))
+                                && let Some(best) = loc.get(prefix)
+                            {
+                                out.insert(best.clone());
+                            }
+                        }
+                        std::hint::black_box((rib, loc, out, intern))
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_attr_hashing_route_churn(c: &mut Criterion) {
+    let mut group = c.benchmark_group("attr_hashing_route_churn");
+    group.sample_size(10);
+    for case in ATTR_CASES {
+        let churn_count = case.count / 10;
+        let prefixes = generate_prefixes(case.count);
+        let attrs = build_attribute_arcs(case, case.count + churn_count);
+        let base_routes: Vec<_> = prefixes
+            .iter()
+            .zip(attrs[..case.count].iter().cloned())
+            .map(|(prefix, attrs)| make_route_with_attributes(*prefix, 1, attrs))
+            .collect();
+        let churn_routes: Vec<_> = prefixes[..churn_count]
+            .iter()
+            .zip(attrs[case.count..].iter().cloned())
+            .map(|(prefix, attrs)| make_route_with_attributes(*prefix, 2, attrs))
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new(case.label, case.count),
+            &(&prefixes, &base_routes, &churn_routes),
+            |b, (prefixes, base_routes, churn_routes)| {
+                b.iter_batched(
+                    || {
+                        let mut rib = AdjRibIn::with_capacity(
+                            IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+                            base_routes.len(),
+                            0,
+                        );
+                        let rib2 = AdjRibIn::with_capacity(
+                            IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+                            churn_routes.len(),
+                            0,
+                        );
+                        let mut loc = LocRib::with_capacity(base_routes.len());
+                        let mut intern = AttrInternTable::new();
+                        for route in *base_routes {
+                            let mut route = route.clone();
+                            intern.intern(&mut route.attributes);
+                            rib.insert(route);
+                        }
+                        for prefix in *prefixes {
+                            loc.recompute(*prefix, rib.iter_prefix(prefix));
+                        }
+                        (rib, rib2, loc, intern)
+                    },
+                    |(rib, mut rib2, mut loc, mut intern)| {
+                        for route in *churn_routes {
+                            let mut route = route.clone();
+                            intern.intern(&mut route.attributes);
+                            rib2.insert(route);
+                        }
+                        for prefix in &prefixes[..churn_count] {
+                            let candidates =
+                                rib.iter_prefix(prefix).chain(rib2.iter_prefix(prefix));
+                            loc.recompute(*prefix, candidates);
+                        }
+                        for prefix in &prefixes[..churn_count] {
+                            rib2.withdraw(prefix, 0);
+                        }
+                        for prefix in &prefixes[..churn_count] {
+                            loc.recompute(*prefix, rib.iter_prefix(prefix));
+                        }
+                        intern.gc();
+                        std::hint::black_box((rib, rib2, loc, intern))
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    group.finish();
 }
 
 fn bench_best_path_cmp(c: &mut Criterion) {
@@ -416,6 +988,10 @@ fn bench_export_policy_eval(c: &mut Criterion) {
 
 criterion_group!(
     benches,
+    bench_attr_intern_hashing,
+    bench_attr_hashing_adj_rib_in_insert,
+    bench_attr_hashing_bulk_initial_load,
+    bench_attr_hashing_route_churn,
     bench_best_path_cmp,
     bench_adj_rib_in_insert,
     bench_loc_rib_recompute,

--- a/docs/perf/artifacts/attr-intern-hashing-2026-08.csv
+++ b/docs/perf/artifacts/attr-intern-hashing-2026-08.csv
@@ -1,0 +1,181 @@
+record_type,attempt,order,group,case,count,median_ns,criterion_stddev_ns,attempt_mean_ns,between_attempt_stddev_ns,range_pct,cv_pct,limit_pct,retained,hash_scale,diagnostic_pct,required_pct,two_x_noise_pct,decision,note
+attempt,A1,1,attr_hash_only,many_unique,10000,295178.475,44019.057,,,,,,,,,,,,
+attempt,B1,2,attr_hash_only,many_unique,10000,196823.960,760.950,,,,,,,,,,,,
+attempt,B2,3,attr_hash_only,many_unique,10000,150100.050,484.569,,,,,,,,,,,,
+attempt,A2,4,attr_hash_only,many_unique,10000,195576.158,58.154,,,,,,,,,,,,
+attempt,A1,1,attr_hash_only,rich_independent_equal,10000,1598296.694,65701.604,,,,,,,,,,,,
+attempt,B1,2,attr_hash_only,rich_independent_equal,10000,1447382.735,47212.042,,,,,,,,,,,,
+attempt,B2,3,attr_hash_only,rich_independent_equal,10000,1409300.318,13322.558,,,,,,,,,,,,
+attempt,A2,4,attr_hash_only,rich_independent_equal,10000,1349905.671,11173.118,,,,,,,,,,,,
+attempt,A1,1,attr_hash_only,rich_shared_arc,10000,1011869.345,41293.529,,,,,,,,,,,,
+attempt,B1,2,attr_hash_only,rich_shared_arc,10000,839276.420,2482.701,,,,,,,,,,,,
+attempt,B2,3,attr_hash_only,rich_shared_arc,10000,838090.640,971.547,,,,,,,,,,,,
+attempt,A2,4,attr_hash_only,rich_shared_arc,10000,838203.434,775.156,,,,,,,,,,,,
+attempt,A1,1,attr_hash_only,typical_independent_equal,10000,294883.460,44203.270,,,,,,,,,,,,
+attempt,B1,2,attr_hash_only,typical_independent_equal,10000,196159.401,334.388,,,,,,,,,,,,
+attempt,B2,3,attr_hash_only,typical_independent_equal,10000,151660.620,362.396,,,,,,,,,,,,
+attempt,A2,4,attr_hash_only,typical_independent_equal,10000,195772.155,554.350,,,,,,,,,,,,
+attempt,A1,1,attr_hash_only,typical_independent_equal,100000,10095505.236,1254617.202,,,,,,,,,,,,
+attempt,B1,2,attr_hash_only,typical_independent_equal,100000,9285207.514,28435.968,,,,,,,,,,,,
+attempt,B2,3,attr_hash_only,typical_independent_equal,100000,6134199.556,15311.599,,,,,,,,,,,,
+attempt,A2,4,attr_hash_only,typical_independent_equal,100000,9378648.354,29149.356,,,,,,,,,,,,
+attempt,A1,1,attr_hash_only,typical_shared_arc,10000,216527.263,36499.320,,,,,,,,,,,,
+attempt,B1,2,attr_hash_only,typical_shared_arc,10000,101293.120,532.756,,,,,,,,,,,,
+attempt,B2,3,attr_hash_only,typical_shared_arc,10000,99294.905,415.492,,,,,,,,,,,,
+attempt,A2,4,attr_hash_only,typical_shared_arc,10000,102276.606,316.142,,,,,,,,,,,,
+attempt,A1,1,attr_hash_only,typical_shared_arc,100000,2166838.028,374604.648,,,,,,,,,,,,
+attempt,B1,2,attr_hash_only,typical_shared_arc,100000,977776.951,4314.115,,,,,,,,,,,,
+attempt,B2,3,attr_hash_only,typical_shared_arc,100000,991255.654,5805.811,,,,,,,,,,,,
+attempt,A2,4,attr_hash_only,typical_shared_arc,100000,991570.853,6860.216,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_adj_rib_in_insert,many_unique,10000,1032903.808,1442.014,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_adj_rib_in_insert,many_unique,10000,1030896.286,9763.786,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_adj_rib_in_insert,many_unique,10000,1027008.602,3229.397,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_adj_rib_in_insert,many_unique,10000,1023634.786,2750.406,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_adj_rib_in_insert,rich_independent_equal,10000,1963570.574,8768.267,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_adj_rib_in_insert,rich_independent_equal,10000,1963116.224,11379.590,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_adj_rib_in_insert,rich_independent_equal,10000,1939353.114,11155.497,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_adj_rib_in_insert,rich_independent_equal,10000,1958979.228,28420.152,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_adj_rib_in_insert,rich_shared_arc,10000,1192198.586,6351.959,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_adj_rib_in_insert,rich_shared_arc,10000,1190795.881,4580.053,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_adj_rib_in_insert,rich_shared_arc,10000,1193852.617,13225.035,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_adj_rib_in_insert,rich_shared_arc,10000,1192752.307,1207.015,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_adj_rib_in_insert,typical_independent_equal,10000,630176.972,5857.115,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_adj_rib_in_insert,typical_independent_equal,10000,621666.962,2014.062,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_adj_rib_in_insert,typical_independent_equal,10000,625049.706,2110.626,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_adj_rib_in_insert,typical_independent_equal,10000,625635.056,1312.188,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_adj_rib_in_insert,typical_independent_equal,100000,13997525.661,314682.688,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_adj_rib_in_insert,typical_independent_equal,100000,14466274.028,184871.754,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_adj_rib_in_insert,typical_independent_equal,100000,14170206.867,177869.172,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_adj_rib_in_insert,typical_independent_equal,100000,11644790.812,166229.317,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_adj_rib_in_insert,typical_shared_arc,10000,437610.087,2747.306,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_adj_rib_in_insert,typical_shared_arc,10000,437138.195,1778.347,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_adj_rib_in_insert,typical_shared_arc,10000,439861.907,3719.879,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_adj_rib_in_insert,typical_shared_arc,10000,435485.002,388.233,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_adj_rib_in_insert,typical_shared_arc,100000,4502312.362,38820.839,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_adj_rib_in_insert,typical_shared_arc,100000,4381731.194,7846.618,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_adj_rib_in_insert,typical_shared_arc,100000,4394677.924,2863.026,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_adj_rib_in_insert,typical_shared_arc,100000,4392806.931,7906.101,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_bulk_initial_load,many_unique,10000,2084870.337,13206.632,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_bulk_initial_load,many_unique,10000,2089859.872,50749.107,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_bulk_initial_load,many_unique,10000,2087553.850,2532.332,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_bulk_initial_load,many_unique,10000,2096380.587,8632.854,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_bulk_initial_load,rich_independent_equal,10000,3355627.432,38397.108,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_bulk_initial_load,rich_independent_equal,10000,3294408.077,66348.251,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_bulk_initial_load,rich_independent_equal,10000,3322367.108,16925.375,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_bulk_initial_load,rich_independent_equal,10000,3258547.810,85335.706,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_bulk_initial_load,rich_shared_arc,10000,2225377.768,10957.648,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_bulk_initial_load,rich_shared_arc,10000,2216933.479,3387.482,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_bulk_initial_load,rich_shared_arc,10000,2207961.094,6116.609,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_bulk_initial_load,rich_shared_arc,10000,2223067.093,6195.098,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_bulk_initial_load,typical_independent_equal,10000,1661162.160,3317.334,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_bulk_initial_load,typical_independent_equal,10000,1651546.093,7557.170,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_bulk_initial_load,typical_independent_equal,10000,1646924.038,4363.378,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_bulk_initial_load,typical_independent_equal,10000,1659501.381,3357.684,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_bulk_initial_load,typical_independent_equal,100000,54116654.750,772465.475,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_bulk_initial_load,typical_independent_equal,100000,53170727.500,554982.664,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_bulk_initial_load,typical_independent_equal,100000,52596572.188,436533.125,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_bulk_initial_load,typical_independent_equal,100000,54726141.444,423161.779,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_bulk_initial_load,typical_shared_arc,10000,1464691.467,25787.305,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_bulk_initial_load,typical_shared_arc,10000,1463313.717,6778.833,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_bulk_initial_load,typical_shared_arc,10000,1463140.905,8251.984,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_bulk_initial_load,typical_shared_arc,10000,1470889.664,3541.243,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_bulk_initial_load,typical_shared_arc,100000,23536409.486,185968.819,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_bulk_initial_load,typical_shared_arc,100000,23127813.350,193180.668,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_bulk_initial_load,typical_shared_arc,100000,23956002.738,149405.030,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_bulk_initial_load,typical_shared_arc,100000,23331105.759,61838.555,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_route_churn,many_unique,10000,313246.954,735.691,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_route_churn,many_unique,10000,311032.793,2637.144,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_route_churn,many_unique,10000,312086.037,3191.102,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_route_churn,many_unique,10000,326865.169,3047.673,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_route_churn,rich_independent_equal,10000,455478.636,13109.850,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_route_churn,rich_independent_equal,10000,459866.932,1297.731,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_route_churn,rich_independent_equal,10000,460099.639,1758.676,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_route_churn,rich_independent_equal,10000,462144.222,1760.357,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_route_churn,rich_shared_arc,10000,352653.251,864.783,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_route_churn,rich_shared_arc,10000,352764.135,2094.199,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_route_churn,rich_shared_arc,10000,353693.315,3129.710,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_route_churn,rich_shared_arc,10000,370661.145,657.687,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_route_churn,typical_independent_equal,10000,285677.288,679.545,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_route_churn,typical_independent_equal,10000,285842.708,783.854,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_route_churn,typical_independent_equal,10000,286425.155,525.303,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_route_churn,typical_independent_equal,10000,301075.205,3078.195,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_route_churn,typical_independent_equal,100000,4185908.325,49578.011,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_route_churn,typical_independent_equal,100000,4080169.450,56471.790,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_route_churn,typical_independent_equal,100000,3979160.785,36587.003,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_route_churn,typical_independent_equal,100000,4590868.021,146671.998,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_route_churn,typical_shared_arc,10000,266275.192,495.669,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_route_churn,typical_shared_arc,10000,264876.689,228.882,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_route_churn,typical_shared_arc,10000,266351.679,742.395,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_route_churn,typical_shared_arc,10000,280736.505,317.802,,,,,,,,,,,,
+attempt,A1,1,attr_hashing_route_churn,typical_shared_arc,100000,3185860.656,38201.756,,,,,,,,,,,,
+attempt,B1,2,attr_hashing_route_churn,typical_shared_arc,100000,3193207.208,64652.467,,,,,,,,,,,,
+attempt,B2,3,attr_hashing_route_churn,typical_shared_arc,100000,3135517.661,6950.600,,,,,,,,,,,,
+attempt,A2,4,attr_hashing_route_churn,typical_shared_arc,100000,3364485.062,21274.254,,,,,,,,,,,,
+attempt,A1,1,attr_intern,many_unique,10000,682154.622,12544.994,,,,,,,,,,,,
+attempt,B1,2,attr_intern,many_unique,10000,663513.272,2363.474,,,,,,,,,,,,
+attempt,B2,3,attr_intern,many_unique,10000,660732.369,6792.364,,,,,,,,,,,,
+attempt,A2,4,attr_intern,many_unique,10000,663455.061,431.363,,,,,,,,,,,,
+attempt,A1,1,attr_intern,rich_independent_equal,10000,1443507.602,8136.168,,,,,,,,,,,,
+attempt,B1,2,attr_intern,rich_independent_equal,10000,1455098.861,5292.154,,,,,,,,,,,,
+attempt,B2,3,attr_intern,rich_independent_equal,10000,1437808.403,15633.327,,,,,,,,,,,,
+attempt,A2,4,attr_intern,rich_independent_equal,10000,1466061.954,8048.774,,,,,,,,,,,,
+attempt,A1,1,attr_intern,rich_shared_arc,10000,911921.456,2648.336,,,,,,,,,,,,
+attempt,B1,2,attr_intern,rich_shared_arc,10000,912325.162,711.743,,,,,,,,,,,,
+attempt,B2,3,attr_intern,rich_shared_arc,10000,912318.044,4905.647,,,,,,,,,,,,
+attempt,A2,4,attr_intern,rich_shared_arc,10000,912913.107,3117.085,,,,,,,,,,,,
+attempt,A1,1,attr_intern,typical_independent_equal,10000,262808.586,2968.224,,,,,,,,,,,,
+attempt,B1,2,attr_intern,typical_independent_equal,10000,281018.372,1256.221,,,,,,,,,,,,
+attempt,B2,3,attr_intern,typical_independent_equal,10000,260297.710,2977.849,,,,,,,,,,,,
+attempt,A2,4,attr_intern,typical_independent_equal,10000,280759.909,1232.630,,,,,,,,,,,,
+attempt,A1,1,attr_intern,typical_independent_equal,100000,4898583.845,239866.760,,,,,,,,,,,,
+attempt,B1,2,attr_intern,typical_independent_equal,100000,4381146.004,136495.930,,,,,,,,,,,,
+attempt,B2,3,attr_intern,typical_independent_equal,100000,5131708.726,141677.106,,,,,,,,,,,,
+attempt,A2,4,attr_intern,typical_independent_equal,100000,4495065.422,77110.962,,,,,,,,,,,,
+attempt,A1,1,attr_intern,typical_shared_arc,10000,114180.703,566.684,,,,,,,,,,,,
+attempt,B1,2,attr_intern,typical_shared_arc,10000,113672.189,611.613,,,,,,,,,,,,
+attempt,B2,3,attr_intern,typical_shared_arc,10000,113795.475,376.477,,,,,,,,,,,,
+attempt,A2,4,attr_intern,typical_shared_arc,10000,114393.505,1367.130,,,,,,,,,,,,
+attempt,A1,1,attr_intern,typical_shared_arc,100000,1137718.100,17776.841,,,,,,,,,,,,
+attempt,B1,2,attr_intern,typical_shared_arc,100000,1165086.222,2627.811,,,,,,,,,,,,
+attempt,B2,3,attr_intern,typical_shared_arc,100000,1142607.780,2509.233,,,,,,,,,,,,
+attempt,A2,4,attr_intern,typical_shared_arc,100000,1169372.285,8115.474,,,,,,,,,,,,
+summary,,,attr_hash_only,many_unique,10000,,,209419.661,61165.580,69.276,29.207,3,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_hash_only,rich_independent_equal,10000,,,1451221.355,105937.295,17.116,7.300,3,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_hash_only,rich_shared_arc,10000,,,881859.960,86674.571,19.706,9.829,3,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_hash_only,typical_independent_equal,10000,,,209618.909,60558.781,68.325,28.890,3,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_hash_only,typical_independent_equal,100000,,,8723390.165,1763671.342,45.410,20.218,3,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_hash_only,typical_shared_arc,10000,,,129847.974,57799.507,90.284,44.513,3,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_hash_only,typical_shared_arc,100000,,,1281860.371,590020.137,92.761,46.028,3,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_hashing_adj_rib_in_insert,many_unique,10000,,,1028610.870,4122.342,0.901,0.401,5,true,,,,,,retained for interpretation
+summary,,,attr_hashing_adj_rib_in_insert,rich_independent_equal,10000,,,1956254.785,11455.554,1.238,0.586,5,true,,,,,,retained for interpretation
+summary,,,attr_hashing_adj_rib_in_insert,rich_shared_arc,10000,,,1192399.848,1271.217,0.256,0.107,5,true,,,,,,retained for interpretation
+summary,,,attr_hashing_adj_rib_in_insert,typical_independent_equal,10000,,,625632.174,3498.446,1.360,0.559,5,true,,,,,,retained for interpretation
+summary,,,attr_hashing_adj_rib_in_insert,typical_independent_equal,100000,,,13569699.342,1297788.332,20.793,9.564,5,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_hashing_adj_rib_in_insert,typical_shared_arc,10000,,,437523.798,1805.508,1.000,0.413,5,true,,,,,,retained for interpretation
+summary,,,attr_hashing_adj_rib_in_insert,typical_shared_arc,100000,,,4417882.103,56576.070,2.729,1.281,5,true,,,,,,retained for interpretation
+summary,,,attr_hashing_bulk_initial_load,many_unique,10000,,,2089666.162,4918.768,0.551,0.235,5,true,,,,,,retained for interpretation
+summary,,,attr_hashing_bulk_initial_load,rich_independent_equal,10000,,,3307737.607,41250.334,2.935,1.247,5,true,,,,,,retained for interpretation
+summary,,,attr_hashing_bulk_initial_load,rich_shared_arc,10000,,,2218334.858,7779.792,0.785,0.351,5,true,,,,,,retained for interpretation
+summary,,,attr_hashing_bulk_initial_load,typical_independent_equal,10000,,,1654783.418,6713.113,0.860,0.406,5,true,,,,,,retained for interpretation
+summary,,,attr_hashing_bulk_initial_load,typical_independent_equal,100000,,,53652523.970,951355.851,3.969,1.773,5,true,,,,,,retained for interpretation
+summary,,,attr_hashing_bulk_initial_load,typical_shared_arc,10000,,,1465508.938,3653.630,0.529,0.249,5,true,,,,,,retained for interpretation
+summary,,,attr_hashing_bulk_initial_load,typical_shared_arc,100000,,,23487832.833,353892.712,3.526,1.507,5,true,,,,,,retained for interpretation
+summary,,,attr_hashing_route_churn,many_unique,10000,,,315807.738,7426.878,5.013,2.352,5,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_hashing_route_churn,rich_independent_equal,10000,,,459397.357,2805.669,1.451,0.611,5,true,,,,,,retained for interpretation
+summary,,,attr_hashing_route_churn,rich_shared_arc,10000,,,357442.961,8824.454,5.038,2.469,5,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_hashing_route_churn,typical_independent_equal,10000,,,289755.089,7553.557,5.314,2.607,5,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_hashing_route_churn,typical_independent_equal,100000,,,4209026.645,268191.339,14.533,6.372,5,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_hashing_route_churn,typical_shared_arc,10000,,,269560.016,7481.777,5.884,2.776,5,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_hashing_route_churn,typical_shared_arc,100000,,,3219767.647,99827.069,7.111,3.100,5,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_intern,many_unique,10000,,,667463.831,9879.425,3.210,1.480,3,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_intern,rich_independent_equal,10000,,,1450619.205,12559.689,1.948,0.866,3,true,,,,,,retained for interpretation
+summary,,,attr_intern,rich_shared_arc,10000,,,912369.442,408.601,0.109,0.045,3,true,,,,,,retained for interpretation
+summary,,,attr_intern,typical_independent_equal,10000,,,271221.145,11211.099,7.640,4.134,3,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_intern,typical_independent_equal,100000,,,4726625.999,349589.399,15.879,7.396,3,false,,,,,,discarded from interpretation: same-SHA noise bound exceeded
+summary,,,attr_intern,typical_shared_arc,10000,,,114010.468,334.839,0.633,0.294,3,true,,,,,,retained for interpretation
+summary,,,attr_intern,typical_shared_arc,100000,,,1153696.097,15850.604,2.744,1.374,3,true,,,,,,retained for interpretation
+derived,,,attr_intern,rich_shared_arc,10000,,,,,,,,false,1.0,96.656,20,6,NOT_EVALUATED,hash-only divided by isolated intern; source hash-only row failed the 3% control bound
+derived,,,attr_hashing_adj_rib_in_insert,rich_shared_arc,10000,,,,,,,,false,1.0,73.957,5,10,NOT_EVALUATED,hash-only divided by full insert; source hash-only row failed the 3% control bound
+derived,,,attr_hashing_bulk_initial_load,rich_shared_arc,10000,,,,,,,,false,1.0,39.753,5,10,NOT_EVALUATED,hash-only divided by bulk load; source hash-only row failed the 3% control bound
+derived,,,attr_hashing_route_churn,rich_shared_arc,10000,,,,,,,,false,0.1,24.671,5,10,NOT_EVALUATED,one tenth of hash-only because churn interns 1000 of 10000 routes; source hash-only row failed the 3% control bound
+decision,,,all,rich_shared_arc,10000,,,,,,,,false,,,,,NO-GO,isolated rich shared hash-only range exceeded 3% and rich shared churn range exceeded 5%; no actionable attribution or prototype authorization

--- a/docs/perf/attr-intern-hashing-2026-08.md
+++ b/docs/perf/attr-intern-hashing-2026-08.md
@@ -1,0 +1,263 @@
+# Attribute-intern hashing attribution (August 2026)
+
+## Verdict
+
+**Measured NO-GO.** The experiment does not authorize a fingerprint cache or
+any other production optimization.
+
+The rich/shared-`Arc` intern, insert, and bulk rows were stable, but the
+required isolated hash-only row was not: its four same-SHA medians spanned
+**19.71%**, over the predeclared **3%** isolated-control limit. Rich/shared
+churn also spanned **5.04%**, over its 5% limit. Because every attribution
+ratio uses the rejected hash row as its numerator, none is actionable. The raw
+values remain in the artifact for audit, but are explicitly marked
+`NOT_EVALUATED`.
+
+This is a measurement receipt, not a performance claim. It changes no
+production code and measures no production speedup.
+
+## Question and decision rule
+
+The roadmap asks whether repeatedly hashing an already-shared
+`Arc<Vec<PathAttribute>>` is expensive enough to justify prototyping a stable
+fingerprint with full-equality fallback. This experiment required all of the
+following before a later prototype could be recommended:
+
+1. the isolated rich/shared hash-only time is at least 20% of isolated intern
+   time;
+2. its conservative ceiling is at least 5% in Adj-RIB-In insertion, bulk
+   initial load, and route churn;
+3. each signal is more than twice its control noise; and
+4. every input row is retained by the same-SHA controls: at most 3% range for
+   isolated rows, at most 5% for end-to-end rows, and at most 5% coefficient
+   of variation for either class.
+
+Failure of any requirement is a NO-GO. There is no rounding exception.
+
+## Harness
+
+The benchmark-local additions to `crates/rib/benches/rib_ops.rs` cover this
+matrix:
+
+| Attribute shape | Allocation shape | 10k | 100k |
+|---|---|---:|---:|
+| Typical | one shared `Arc` | yes | yes |
+| Typical | independently allocated, content-equal `Arc`s | yes | yes |
+| Rich | one shared `Arc` | yes | no |
+| Rich | independently allocated, content-equal `Arc`s | yes | no |
+| Typical | many unique values | yes | no |
+
+Every matrix row runs through isolated `attr_hash_only`, isolated
+`attr_intern`, Adj-RIB-In insertion, bulk initial load, and route churn. Churn
+starts with the stated route count and times announcements plus withdrawals
+for 10% of it, matching the existing 10k-base/1k-churn shape.
+
+The typical vector is the existing five-attribute benchmark vector: ORIGIN,
+AS_PATH, NEXT_HOP, LOCAL_PREF, and MED. The rich vector adds 32 communities,
+24 extended communities, 16 large communities, an originator ID, a 16-entry
+cluster list, and OTC. The many-unique row varies MED without changing the
+attribute roster.
+
+### Prefix correction while preserving prefix length
+
+The old generator repeated prefixes above 65,536. The corrected generator
+preserves indices 0 through 65,535 exactly as the historical
+`10.b1.b2.0/24` sequence. Each later 65,536-prefix block advances only the
+first octet, preserving the historical `/24` prefix-length shape. A full
+`HashSet` uniqueness assertion runs outside timed regions. The preflight pins
+indices 0, 65,535, and 65,536 to `10.0.0.0/24`, `10.255.255.0/24`, and
+`11.0.0.0/24`. Thus the 100k and existing 500k benches are unique without
+converting unrelated historical `/24` rows to `/32`. It does not claim the
+new later blocks have the same topology as the old duplicated fixtures.
+
+### Attribution and structural assertions
+
+A benchmark-local `CountingHasher` wraps the production `FxHasher` and feeds
+the real `attrs.hash(&mut hasher)` implementation. Before Criterion measures
+anything, the preflight asserts:
+
+- nonzero hash writes and bytes;
+- identical digest and work for shared versus independently allocated equal
+  typical attributes;
+- the same equality for rich attributes;
+- equality between the counting digest and the actual timed helper's digest
+  for both typical and rich attributes;
+- distinct digests for two fixtures with distinct MED values;
+- strictly more writes and bytes for rich than typical attributes;
+- one input pointer for shared rows and one pointer per input for independent
+  rows;
+- one content value and one final intern-table entry for equal rows; and
+- no content, pointer, or table-length collapse for the many-unique row.
+
+The timed hash-only arm uses a plain production `FxHasher`; the counting
+wrapper is assertion-only and therefore does not inflate the timed numerator.
+That arm constructs one hasher per attribute vector and folds each digest with
+its loop index so the compiler cannot discard the work. The fold makes the
+result a conservative hash ceiling rather than a pure instruction-level hash
+cost. The intern arm calls the real `AttrInternTable::intern`.
+
+### Load-bearing red proofs
+
+Two destructive mutations were applied independently. First, the timed
+`hash_with_production_hasher` helper's `attrs.hash(&mut hasher)` call was
+replaced with a non-hashing `black_box`. This command failed before emitting a
+Criterion measurement:
+
+```text
+cargo bench -p rustbgpd-rib --bench rib_ops -- \
+  'attr_hash_only/typical_shared_arc/10000' \
+  --warm-up-time 0.1 --measurement-time 0.1 --sample-size 10 --noplot
+```
+
+The timed-helper failure was:
+
+```text
+counting and timed hash helpers must agree for typical attrs
+left: 8849704318604773807
+right: 0
+```
+
+Second, the generator was reverted to the old constant first octet, while
+retaining the 100k input. The same command failed before sampling:
+
+```text
+benchmark prefixes must remain unique beyond 65,536
+left: 65536
+right: 100000
+```
+
+Restoring each guarded line made the preflight pass. These are the production
+breaks that make the measurement gate red; behavioral interning assertions
+alone would remain green after either attribution-fixture defect.
+
+## Host and provenance
+
+The retained controls ran on one physical CPU of this host:
+
+- AMD Ryzen Threadripper 7970X, 32 cores / 64 threads, one NUMA node;
+- 128 MiB L3, 32 MiB L2;
+- Linux 6.17.0-35-generic, x86_64;
+- CPU 15 via `taskset -c 15`;
+- `amd-pstate-epp`, `performance` governor;
+- rustc 1.97.0 (`2d8144b7880597b6e6d3dfd63a9a9efae3f533d3`);
+- cargo 1.97.0 (`c980f4866`); and
+- Criterion 0.8.2.
+
+Source and binary identity:
+
+| Item | SHA-256 |
+|---|---|
+| Measurement base before the docs-only rebase | `8b5a28a6a9a713ae23a5b7b4c38fbee8f166cee2` |
+| Settled base after the docs-only rebase | `b05c29fa17e41a60124d22780a0c53984d339466` |
+| `Cargo.lock` | `d20b5fde3bf984ba4da5225f3a41a94b043672f2b6844d0777d3f8fe76593e18` |
+| `rib_ops.rs` after the harness change | `14dc9042e8db8f54d2cb8c596e696fb7f4723e127bbd18feac56d3a6009bdd38` |
+| `git diff -- crates/rib/benches/rib_ops.rs` | `81af68db313f5bf1b4c2c90083253ac9e8d9693894c2bef5c871ad67ffc9d0b6` |
+| Release benchmark binary | `60e8d1e2ca14489b4ef049e6431151b03ffed73b0227ef2a3c533bb512a73b5e` |
+
+The base update contained only `ROADMAP.md`, the ADR index, and ADR-0121. The
+benchmark source hash, benchmark diff hash, and binary hash were
+identical before and after that update. No measurement was rerun or re-labeled
+across a code change.
+
+## Commands and control order
+
+The final controls used the restored timed hash helper and prefix-preserving
+generator. The earlier `/32` experiment and both campaigns run before the
+timed-helper/boundary attack-review fixes were discarded in full. None of
+their rows appear in the checked-in CSV.
+
+The exact final command template was:
+
+```text
+flock -n /tmp/rustbgpd-perf.lock taskset -c 15 \
+  cargo bench -p rustbgpd-rib --bench rib_ops -- attr_ \
+  --save-baseline <baseline> --warm-up-time 1 --measurement-time 2 \
+  --sample-size 10 --noplot --quiet
+```
+
+The baselines were run counterbalanced on the same source and binary:
+
+| Order | Baseline | Rich/shared hash estimate timestamp (local) |
+|---:|---|---|
+| 1 | `attrhash3_a1` | 2026-08-01 07:23:41 -0400 |
+| 2 | `attrhash3_b1` | 2026-08-01 07:26:00 -0400 |
+| 3 | `attrhash3_b2` | 2026-08-01 07:28:12 -0400 |
+| 4 | `attrhash3_a2` | 2026-08-01 07:30:32 -0400 |
+
+`A` and `B` are deliberately identical same-SHA controls, not candidate and
+baseline implementations. For each row, the receipt uses Criterion's median
+point estimate from each attempt, then computes the mean, sample standard
+deviation, range divided by mean, and coefficient of variation across those
+four medians.
+
+## Result
+
+The decision shape was rich attributes sharing one `Arc`, representing the RR
+or route-server case that a pointer/fingerprint shortcut would target.
+
+| Row | Mean of medians | Range | CV | Limit | Retained |
+|---|---:|---:|---:|---:|---|
+| Hash only | 0.882 ms | 19.71% | 9.83% | 3% | **No** |
+| Intern | 0.912 ms | 0.11% | 0.05% | 3% | Yes |
+| Adj-RIB-In insert | 1.192 ms | 0.26% | 0.11% | 5% | Yes |
+| Bulk initial load | 2.218 ms | 0.79% | 0.35% | 5% | Yes |
+| Route churn | 0.357 ms | 5.04% | 2.47% | 5% | **No** |
+
+The four hash-only medians were 1.012, 0.839, 0.838, and 0.838 ms. The first
+attempt is not removed as an outlier: the retention rule is intentionally
+attempt-level and bounded, so the 19.71% span invalidates the row.
+
+For completeness, dividing the discarded hash numerator by the stable rows
+would produce diagnostic values of 96.7% of isolated intern, 74.0% of insert,
+39.8% of bulk load, and 24.7% of churn after scaling hash work to the 1k churn
+announcements. These are recorded as `NOT_EVALUATED`, not evidence. Quoting
+them as a likely gain would confuse a ceiling with a measured optimization and
+would ignore the failed control.
+
+The 100k rows do not rescue the experiment. Typical/shared hash-only missed
+the 3% isolated bound despite its intern row passing, while
+typical/independently-equal missed multiple control bounds. The CSV retains
+every attempt and marks each rejected summary explicitly.
+
+## Artifact
+
+[`artifacts/attr-intern-hashing-2026-08.csv`](artifacts/attr-intern-hashing-2026-08.csv)
+contains:
+
+- 140 raw attempt rows: four attempts for all 35 benchmark rows;
+- Criterion's within-attempt standard deviation beside each raw median;
+- 35 across-attempt summaries with range, CV, limit, and retention decision;
+- four non-actionable diagnostic ratios with their required and two-noise
+  thresholds; and
+- the final `NO-GO` row.
+
+No raw row was deleted because it was inconvenient. Superseded campaigns used
+a different generator or preflight binary and are excluded as different
+experiments, not filtered statistically.
+
+## Why retain a NO-GO harness
+
+The harness earns its maintenance cost in three bounded ways. It fixes the
+pre-existing duplicate-prefix defect in the established 100k/500k RIB benches;
+it leaves the exact matrix needed to repeat the roadmap question instead of
+reconstructing a subtly different experiment; and its preflight makes hash,
+pointer, content, table-length, and prefix-boundary drift fail before numbers
+can publish. It is not on a per-commit CI path and adds no production code.
+
+An earns-its-keep pass collapsed the repetitive case construction before the
+final campaign. The three pipeline bodies remain explicit because they define
+different timed boundaries; abstracting them after measurement would change
+source and binary identity, invalidate all four controls, and make the receipt
+harder to audit. Retaining the measured form is lower complexity than another
+unmotivated rerun.
+
+## Next step
+
+Do not implement the fingerprint optimization from this receipt. If profiles
+continue to identify attribute hashing, rerun the isolated rich/shared row
+with a measurement method that can hold its same-SHA range below 3%—for
+example, longer measurement windows and an explicitly recorded frequency
+trace—then repeat the entire gate. A later prototype still requires a real
+production A/B and full equality fallback. Only after the full measurement
+matrix produces a GO should that prototype proceed to collision and memory
+gates.


### PR DESCRIPTION
## Summary

- add a retained Criterion matrix that distinguishes shared, independently allocated equal, rich, and many-unique attribute sets
- repair the pre-existing benchmark prefix fixture so inputs above 65,536 remain unique while retaining the historical `/24` prefix-length shape
- publish all four corrected same-SHA controls and the resulting measured NO-GO

## Result

The required rich/shared hash-only control was not stable enough to authorize an optimization:

| Row | Mean of medians | Range | Limit | Retained |
|---|---:|---:|---:|---|
| hash only | 0.882 ms | 19.71% | 3% | no |
| intern | 0.912 ms | 0.11% | 3% | yes |
| Adj-RIB-In insert | 1.192 ms | 0.26% | 5% | yes |
| bulk initial load | 2.218 ms | 0.79% | 5% | yes |
| route churn | 0.357 ms | 5.04% | 5% | no |

All four derived ratios are retained as `NOT_EVALUATED`. This PR changes no production code, claims no speedup, and does not authorize a fingerprint cache or other production optimization.

The checked-in CSV contains 140 attempt rows, 35 summaries, four non-actionable diagnostics, and one NO-GO decision. Every raw median was independently matched to Criterion's retained estimate.

## Load-bearing proofs

- replacing the timed FxHasher helper's real `attrs.hash` call makes preflight fail on digest disagreement before Criterion samples
- restoring the old constant-first-octet prefix generator makes the 100,000-route preflight fail at 65,536 unique prefixes before sampling
- exact boundary assertions pin indices 0, 65,535, and 65,536 to `10.0.0.0/24`, `10.255.255.0/24`, and `11.0.0.0/24`

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- focused RIB bench clippy, 1,040 RIB tests, benchmark registration/preflight, CSV math, raw Criterion row, checksum, link, typo, exact-scope, and diff checks
- two independent reviews of the exact frozen patch
