### PR TITLE
api: normalize unary actor-read outages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Peer- and RIB-manager-backed unary reads in the Neighbor, RIB, Policy, Event,
+  and PeerGroup services now report command-channel closure and dropped replies
+  as `UNAVAILABLE`, while retaining existing deadline and business errors.
+
 - Graceful Restart and Long-Lived Graceful Restart now retain an iBGP route
   source's route-reflector-client classification for as long as its stale
   routes remain eligible for reflection, preventing late joins or LLGR

--- a/crates/api/src/actor_read.rs
+++ b/crates/api/src/actor_read.rs
@@ -1,0 +1,35 @@
+//! Shared transport boundary for unary reads from the state-owning actors.
+
+use rustbgpd_rib::RibUpdate;
+use tokio::sync::{mpsc, oneshot};
+use tonic::Status;
+
+use crate::peer_types::PeerManagerCommand;
+
+/// Send one read command to the peer manager and await its reply.
+pub(crate) async fn peer_manager_read<T>(
+    tx: &mpsc::Sender<PeerManagerCommand>,
+    build: impl FnOnce(oneshot::Sender<T>) -> PeerManagerCommand,
+) -> Result<T, Status> {
+    let (reply, response) = oneshot::channel();
+    tx.send(build(reply))
+        .await
+        .map_err(|_| Status::unavailable("peer manager unavailable"))?;
+    response
+        .await
+        .map_err(|_| Status::unavailable("peer manager dropped reply"))
+}
+
+/// Send one read command to the RIB manager and await its reply.
+pub(crate) async fn rib_manager_read<T>(
+    tx: &mpsc::Sender<RibUpdate>,
+    build: impl FnOnce(oneshot::Sender<T>) -> RibUpdate,
+) -> Result<T, Status> {
+    let (reply, response) = oneshot::channel();
+    tx.send(build(reply))
+        .await
+        .map_err(|_| Status::unavailable("RIB manager unavailable"))?;
+    response
+        .await
+        .map_err(|_| Status::unavailable("RIB manager dropped reply"))
+}

--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -25,6 +25,7 @@ use filters::{
     parse_list_session_events_filter, parse_watch_events_filter,
 };
 
+use crate::actor_read::{peer_manager_read, rib_manager_read};
 use crate::peer_types::{PeerManagerCommand, SessionEvent};
 use crate::proto;
 use crate::rib_service::{BlackholeDiscardSnapshotFn, FibRouteSnapshotFn};
@@ -516,21 +517,17 @@ impl proto::event_service_server::EventService for EventService {
         request: Request<proto::ListEvpnEventsRequest>,
     ) -> Result<Response<proto::ListEvpnEventsResponse>, Status> {
         let filter = parse_list_evpn_events_filter(&request.into_inner())?;
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::QueryEvpnRouteEventHistory {
+        let events = rib_manager_read(&self.rib_tx, |reply| {
+            RibUpdate::QueryEvpnRouteEventHistory {
                 peer: filter.peer,
                 route_type: filter.route_type,
                 rd: filter.rd,
                 event_types: filter.event_types,
                 limit: filter.limit,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-        let events = reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+                reply,
+            }
+        })
+        .await?;
         Ok(Response::new(proto::ListEvpnEventsResponse {
             events: events.into_iter().map(evpn_event_to_bgp_event).collect(),
         }))
@@ -541,19 +538,15 @@ impl proto::event_service_server::EventService for EventService {
         request: Request<proto::ListSessionEventsRequest>,
     ) -> Result<Response<proto::ListSessionEventsResponse>, Status> {
         let filter = parse_list_session_events_filter(&request.into_inner())?;
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::QuerySessionEventHistory {
+        let events = peer_manager_read(&self.peer_mgr_tx, |reply| {
+            PeerManagerCommand::QuerySessionEventHistory {
                 peer: filter.peer,
                 event_types: filter.event_types,
                 limit: filter.limit,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        let events = reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?;
+                reply,
+            }
+        })
+        .await?;
         Ok(Response::new(proto::ListSessionEventsResponse {
             events: events
                 .into_iter()
@@ -567,18 +560,14 @@ impl proto::event_service_server::EventService for EventService {
         request: Request<proto::ListPolicyEventsRequest>,
     ) -> Result<Response<proto::ListPolicyEventsResponse>, Status> {
         let filter = parse_list_policy_events_filter(&request.into_inner())?;
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::QueryPolicyEventHistory {
+        let events = peer_manager_read(&self.peer_mgr_tx, |reply| {
+            PeerManagerCommand::QueryPolicyEventHistory {
                 peer: filter.peer,
                 limit: filter.limit,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        let events = reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?;
+                reply,
+            }
+        })
+        .await?;
         Ok(Response::new(proto::ListPolicyEventsResponse {
             events: events.into_iter().map(policy_event_to_bgp_event).collect(),
         }))
@@ -645,6 +634,88 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use tokio::sync::broadcast;
     use tokio_stream::StreamExt;
+
+    #[derive(Clone, Copy, Debug)]
+    enum ListEventRead {
+        Evpn,
+        Session,
+        Policy,
+    }
+
+    const LIST_EVENT_READS: [ListEventRead; 3] = [
+        ListEventRead::Evpn,
+        ListEventRead::Session,
+        ListEventRead::Policy,
+    ];
+
+    async fn invoke_list_event_read(
+        service: &EventService,
+        rpc: ListEventRead,
+    ) -> Result<(), Status> {
+        match rpc {
+            ListEventRead::Evpn => service
+                .list_evpn_events(Request::new(proto::ListEvpnEventsRequest::default()))
+                .await
+                .map(|_| ()),
+            ListEventRead::Session => service
+                .list_session_events(Request::new(proto::ListSessionEventsRequest::default()))
+                .await
+                .map(|_| ()),
+            ListEventRead::Policy => service
+                .list_policy_events(Request::new(proto::ListPolicyEventsRequest::default()))
+                .await
+                .map(|_| ()),
+        }
+    }
+
+    /// Load-bearing: restoring an included list RPC's actor-send mapping to
+    /// `INTERNAL` makes its row red. No watch/subscription RPC is included.
+    #[tokio::test]
+    async fn list_event_read_send_failures_are_unavailable() {
+        for rpc in LIST_EVENT_READS {
+            let (rib_tx, rib_rx) = tokio::sync::mpsc::channel(1);
+            let (peer_tx, peer_rx) = tokio::sync::mpsc::channel(1);
+            match rpc {
+                ListEventRead::Evpn => drop(rib_rx),
+                ListEventRead::Session | ListEventRead::Policy => drop(peer_rx),
+            }
+            let service = EventService::new(rib_tx, peer_tx);
+            let error = invoke_list_event_read(&service, rpc).await.unwrap_err();
+            assert_eq!(error.code(), tonic::Code::Unavailable, "{rpc:?}");
+            let expected = match rpc {
+                ListEventRead::Evpn => "RIB manager unavailable",
+                ListEventRead::Session | ListEventRead::Policy => "peer manager unavailable",
+            };
+            assert_eq!(error.message(), expected, "{rpc:?}");
+        }
+    }
+
+    /// Load-bearing: restoring an included list RPC's reply-await mapping to
+    /// `INTERNAL` makes its accepted-then-dropped row red.
+    #[tokio::test]
+    async fn list_event_read_reply_drops_are_unavailable() {
+        for rpc in LIST_EVENT_READS {
+            let (rib_tx, mut rib_rx) = tokio::sync::mpsc::channel(1);
+            let (peer_tx, mut peer_rx) = tokio::sync::mpsc::channel(1);
+            let actor = match rpc {
+                ListEventRead::Evpn => tokio::spawn(async move {
+                    drop(rib_rx.recv().await.expect("EVPN history read"));
+                }),
+                ListEventRead::Session | ListEventRead::Policy => tokio::spawn(async move {
+                    drop(peer_rx.recv().await.expect("peer event-history read"));
+                }),
+            };
+            let service = EventService::new(rib_tx, peer_tx);
+            let error = invoke_list_event_read(&service, rpc).await.unwrap_err();
+            actor.await.unwrap();
+            assert_eq!(error.code(), tonic::Code::Unavailable, "{rpc:?}");
+            let expected = match rpc {
+                ListEventRead::Evpn => "RIB manager dropped reply",
+                ListEventRead::Session | ListEventRead::Policy => "peer manager dropped reply",
+            };
+            assert_eq!(error.message(), expected, "{rpc:?}");
+        }
+    }
 
     #[tokio::test]
     async fn route_event_bridge_emits_bgp_event() {

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -9,6 +9,7 @@
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
 
+mod actor_read;
 mod audit;
 pub mod authz;
 pub mod authz_principal;

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -10,6 +10,7 @@ use rustbgpd_wire::{Afi, BgpRole, Safi};
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tonic::{Request, Response, Status};
 
+use crate::actor_read::{peer_manager_read, rib_manager_read};
 use crate::peer_types::{
     ConfigEvent, DynamicRangeError, NeighborCreateAddPath, NeighborCreateSpec,
     OutboundRefreshError, PeerInfo, PeerKey, PeerLifecycleError, PeerManagerCommand,
@@ -52,20 +53,6 @@ fn validate_update_group_comparison_scope(
     } else {
         Ok(())
     }
-}
-
-async fn peer_manager_read<T>(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    command: impl FnOnce(oneshot::Sender<T>) -> PeerManagerCommand,
-) -> Result<T, Status> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(command(reply_tx))
-        .await
-        .map_err(|_| Status::unavailable("peer manager unavailable"))?;
-    reply_rx
-        .await
-        .map_err(|_| Status::unavailable("peer manager dropped reply"))
 }
 
 /// Parse a list of family strings from the gRPC proto into `(Afi, Safi)` pairs.
@@ -204,20 +191,14 @@ async fn query_neighbor_rib_snapshots(
     peers: Vec<IpAddr>,
     comparison: Option<(IpAddr, IpAddr)>,
 ) -> Result<NeighborRibSnapshotResponse, Status> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tokio::time::timeout(RIB_SNAPSHOT_TIMEOUT, async {
-        rib_tx
-            .send(RibUpdate::QueryNeighborRibSnapshots {
-                peers,
-                comparison,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))
-    })
+    tokio::time::timeout(
+        RIB_SNAPSHOT_TIMEOUT,
+        rib_manager_read(rib_tx, |reply| RibUpdate::QueryNeighborRibSnapshots {
+            peers,
+            comparison,
+            reply,
+        }),
+    )
     .await
     .map_err(|_| Status::deadline_exceeded("RIB snapshot query timed out"))?
 }
@@ -1936,6 +1917,99 @@ mod tests {
         assert_eq!(error.code(), tonic::Code::Unavailable);
         assert_eq!(error.message(), "peer manager dropped reply");
         assert!(matches!(rib_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[derive(Clone, Copy)]
+    enum NeighborRibReadRpc {
+        ListNeighbors,
+        GetNeighborState,
+    }
+
+    async fn invoke_neighbor_rib_read(
+        svc: &NeighborService,
+        rpc: NeighborRibReadRpc,
+    ) -> Result<(), Status> {
+        match rpc {
+            NeighborRibReadRpc::ListNeighbors => svc
+                .list_neighbors(Request::new(proto::ListNeighborsRequest {}))
+                .await
+                .map(|_| ()),
+            NeighborRibReadRpc::GetNeighborState => svc
+                .get_neighbor_state(Request::new(proto::GetNeighborStateRequest {
+                    address: "192.0.2.1".into(),
+                    ..Default::default()
+                }))
+                .await
+                .map(|_| ()),
+        }
+    }
+
+    fn neighbor_rib_read_service(
+        rpc: NeighborRibReadRpc,
+        rib_tx: mpsc::Sender<RibUpdate>,
+    ) -> (NeighborService, tokio::task::JoinHandle<()>) {
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        let actor = tokio::spawn(async move {
+            match (rpc, peer_rx.recv().await.expect("peer read command")) {
+                (NeighborRibReadRpc::ListNeighbors, PeerManagerCommand::ListPeers { reply }) => {
+                    reply
+                        .send(vec![peer_info("192.0.2.1".parse().unwrap())])
+                        .unwrap();
+                }
+                (
+                    NeighborRibReadRpc::GetNeighborState,
+                    PeerManagerCommand::GetPeerState { reply, .. },
+                ) => {
+                    reply
+                        .send(Some(peer_info("192.0.2.1".parse().unwrap())))
+                        .unwrap();
+                }
+                _ => panic!("unexpected peer read command"),
+            }
+        });
+        (
+            NeighborService::new(65001, AccessMode::ReadWrite, peer_tx, rib_tx, None),
+            actor,
+        )
+    }
+
+    /// Load-bearing: restoring either RIB send mapping to `INTERNAL` makes
+    /// both rows red after their peer-manager stage succeeds.
+    #[tokio::test]
+    async fn neighbor_rib_read_send_failures_are_unavailable() {
+        for rpc in [
+            NeighborRibReadRpc::ListNeighbors,
+            NeighborRibReadRpc::GetNeighborState,
+        ] {
+            let (rib_tx, rib_rx) = mpsc::channel(1);
+            drop(rib_rx);
+            let (svc, peer) = neighbor_rib_read_service(rpc, rib_tx);
+            let error = invoke_neighbor_rib_read(&svc, rpc).await.unwrap_err();
+            peer.await.unwrap();
+            assert_eq!(error.code(), tonic::Code::Unavailable);
+            assert_eq!(error.message(), "RIB manager unavailable");
+        }
+    }
+
+    /// Load-bearing: restoring either RIB reply-await mapping to `INTERNAL`
+    /// makes both accepted-then-dropped rows red.
+    #[tokio::test]
+    async fn neighbor_rib_read_reply_drops_are_unavailable() {
+        for rpc in [
+            NeighborRibReadRpc::ListNeighbors,
+            NeighborRibReadRpc::GetNeighborState,
+        ] {
+            let (rib_tx, mut rib_rx) = mpsc::channel(1);
+            let (svc, peer) = neighbor_rib_read_service(rpc, rib_tx);
+            let rib = tokio::spawn(async move {
+                drop(rib_rx.recv().await.expect("RIB read command"));
+            });
+            let error = invoke_neighbor_rib_read(&svc, rpc).await.unwrap_err();
+            peer.await.unwrap();
+            rib.await.unwrap();
+            assert_eq!(error.code(), tonic::Code::Unavailable);
+            assert_eq!(error.message(), "RIB manager dropped reply");
+        }
     }
 
     fn intent_request(

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -3,9 +3,10 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 use tonic::{Request, Response, Status};
 
+use crate::actor_read::peer_manager_read;
 use crate::audit::{set_peer_group_summary, set_request_summary};
 use crate::neighbor_service::{
     family_to_string, parse_families_proto, parse_remove_private_as_proto,
@@ -341,14 +342,10 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
         &self,
         _request: Request<proto::ListPeerGroupsRequest>,
     ) -> Result<Response<proto::ListPeerGroupsResponse>, Status> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::ListPeerGroups { reply: reply_tx })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        let peer_groups = reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?;
+        let peer_groups = peer_manager_read(&self.peer_mgr_tx, |reply| {
+            PeerManagerCommand::ListPeerGroups { reply }
+        })
+        .await?;
         Ok(Response::new(proto::ListPeerGroupsResponse {
             peer_groups: peer_groups
                 .into_iter()
@@ -368,18 +365,14 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
         if req.name.trim().is_empty() {
             return Err(Status::invalid_argument("name is required"));
         }
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::GetPeerGroup {
+        let definition = peer_manager_read(&self.peer_mgr_tx, |reply| {
+            PeerManagerCommand::GetPeerGroup {
                 name: req.name.clone(),
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        let definition = reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .ok_or_else(|| Status::not_found("peer group not found"))?;
+                reply,
+            }
+        })
+        .await?
+        .ok_or_else(|| Status::not_found("peer group not found"))?;
         Ok(Response::new(proto::GetPeerGroupResponse {
             name: req.name,
             definition: Some(input_definition_to_proto(&definition)),
@@ -613,6 +606,102 @@ mod tests {
             route_server_client: Some(true),
             ..Default::default()
         }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum PeerGroupRead {
+        List,
+        Get,
+    }
+
+    const PEER_GROUP_READS: [PeerGroupRead; 2] = [PeerGroupRead::List, PeerGroupRead::Get];
+
+    async fn invoke_peer_group_read(
+        service: &PeerGroupService,
+        rpc: PeerGroupRead,
+    ) -> Result<(), Status> {
+        match rpc {
+            PeerGroupRead::List => PeerGroupServiceRpc::list_peer_groups(
+                service,
+                Request::new(proto::ListPeerGroupsRequest {}),
+            )
+            .await
+            .map(|_| ()),
+            PeerGroupRead::Get => PeerGroupServiceRpc::get_peer_group(
+                service,
+                Request::new(proto::GetPeerGroupRequest {
+                    name: "rs-clients".into(),
+                }),
+            )
+            .await
+            .map(|_| ()),
+        }
+    }
+
+    /// Load-bearing: restoring either unary peer-group send mapping to
+    /// `INTERNAL` makes its row red.
+    #[tokio::test]
+    async fn peer_group_read_send_failures_are_unavailable() {
+        for rpc in PEER_GROUP_READS {
+            let (peer_tx, peer_rx) = mpsc::channel(1);
+            drop(peer_rx);
+            let service = PeerGroupService::new(AccessMode::ReadOnly, peer_tx, None, None);
+            let error = invoke_peer_group_read(&service, rpc).await.unwrap_err();
+            assert_eq!(error.code(), tonic::Code::Unavailable, "{rpc:?}");
+            assert_eq!(error.message(), "peer manager unavailable", "{rpc:?}");
+        }
+    }
+
+    /// Load-bearing: restoring either unary peer-group reply-await mapping to
+    /// `INTERNAL` makes its accepted-then-dropped row red.
+    #[tokio::test]
+    async fn peer_group_read_reply_drops_are_unavailable() {
+        for rpc in PEER_GROUP_READS {
+            let (peer_tx, mut peer_rx) = mpsc::channel(1);
+            let actor = tokio::spawn(async move {
+                drop(peer_rx.recv().await.expect("peer-group read command"));
+            });
+            let service = PeerGroupService::new(AccessMode::ReadOnly, peer_tx, None, None);
+            let error = invoke_peer_group_read(&service, rpc).await.unwrap_err();
+            actor.await.unwrap();
+            assert_eq!(error.code(), tonic::Code::Unavailable, "{rpc:?}");
+            assert_eq!(error.message(), "peer manager dropped reply", "{rpc:?}");
+        }
+    }
+
+    /// Negative controls: validation happens before actor admission, while an
+    /// accepted missing-resource reply remains `NOT_FOUND` rather than actor
+    /// unavailability.
+    #[tokio::test]
+    async fn peer_group_read_preserves_invalid_and_not_found() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        let service = PeerGroupService::new(AccessMode::ReadOnly, peer_tx, None, None);
+        let invalid = PeerGroupServiceRpc::get_peer_group(
+            &service,
+            Request::new(proto::GetPeerGroupRequest { name: " ".into() }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(invalid.code(), tonic::Code::InvalidArgument);
+        assert!(matches!(peer_rx.try_recv(), Err(TryRecvError::Empty)));
+
+        let call = tokio::spawn(async move {
+            PeerGroupServiceRpc::get_peer_group(
+                &service,
+                Request::new(proto::GetPeerGroupRequest {
+                    name: "missing".into(),
+                }),
+            )
+            .await
+        });
+        let PeerManagerCommand::GetPeerGroup { reply, .. } =
+            peer_rx.recv().await.expect("missing peer-group lookup")
+        else {
+            panic!("expected peer-group lookup");
+        };
+        reply.send(None).unwrap();
+        let missing = call.await.unwrap().unwrap_err();
+        assert_eq!(missing.code(), tonic::Code::NotFound);
     }
 
     #[test]

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -11,6 +11,7 @@ use rustbgpd_wire::{Afi, Ipv4Prefix, Ipv6Prefix, Prefix, Safi};
 use tokio::sync::{mpsc, oneshot};
 use tonic::{Request, Response, Status};
 
+use crate::actor_read::{peer_manager_read, rib_manager_read};
 use crate::peer_types::{
     ConfigEvent, NamedPolicyDefinition, PeerManagerCommand, PolicyStatementDefinition,
 };
@@ -28,27 +29,18 @@ const POLICY_STATS_AGGREGATE_TIMEOUT: Duration = Duration::from_millis(500);
 /// Run one policy-stats backend send and reply within the RPC's shared
 /// absolute deadline. A saturated bounded channel is part of the same budget
 /// as the reply wait; no sequential stage receives a fresh timeout.
-async fn policy_stats_request<C, T>(
-    tx: &mpsc::Sender<C>,
+async fn policy_stats_request<T>(
     deadline: tokio::time::Instant,
-    build_command: impl FnOnce(oneshot::Sender<T>) -> C,
-    unavailable: &'static str,
-    dropped_reply: &'static str,
+    request: impl std::future::Future<Output = Result<T, Status>>,
 ) -> Result<T, Status> {
     if deadline <= tokio::time::Instant::now() {
         return Err(Status::deadline_exceeded(
             "policy stats aggregate deadline exceeded",
         ));
     }
-    tokio::time::timeout_at(deadline, async {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        tx.send(build_command(reply_tx))
-            .await
-            .map_err(|_| Status::internal(unavailable))?;
-        reply_rx.await.map_err(|_| Status::internal(dropped_reply))
-    })
-    .await
-    .map_err(|_| Status::deadline_exceeded("policy stats aggregate deadline exceeded"))?
+    tokio::time::timeout_at(deadline, request)
+        .await
+        .map_err(|_| Status::deadline_exceeded("policy stats aggregate deadline exceeded"))?
 }
 
 /// Map the v1-supported `AddressFamily` proto values to `(Afi, Safi)`.
@@ -444,11 +436,11 @@ async fn require_managed_peer_address(
     deadline: tokio::time::Instant,
 ) -> Result<(), Status> {
     policy_stats_request(
-        peer_mgr_tx,
         deadline,
-        |reply| PeerManagerCommand::HasPeerAddress { address, reply },
-        "peer manager unavailable",
-        "peer manager dropped reply",
+        peer_manager_read(peer_mgr_tx, |reply| PeerManagerCommand::HasPeerAddress {
+            address,
+            reply,
+        }),
     )
     .await?
     .then_some(())
@@ -461,14 +453,10 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         &self,
         _request: Request<proto::ListPoliciesRequest>,
     ) -> Result<Response<proto::ListPoliciesResponse>, Status> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::ListPolicies { reply: reply_tx })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        let policies = reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?;
+        let policies = peer_manager_read(&self.peer_mgr_tx, |reply| {
+            PeerManagerCommand::ListPolicies { reply }
+        })
+        .await?;
         Ok(Response::new(proto::ListPoliciesResponse {
             policies: policies
                 .into_iter()
@@ -488,17 +476,12 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         if req.name.trim().is_empty() {
             return Err(Status::invalid_argument("name is required"));
         }
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::GetPolicy {
+        let definition =
+            peer_manager_read(&self.peer_mgr_tx, |reply| PeerManagerCommand::GetPolicy {
                 name: req.name.clone(),
-                reply: reply_tx,
+                reply,
             })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        let definition = reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
+            .await?
             .ok_or_else(|| Status::not_found("policy not found"))?;
         Ok(Response::new(proto::GetPolicyResponse {
             name: req.name,
@@ -581,14 +564,10 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         &self,
         _request: Request<proto::ListNeighborSetsRequest>,
     ) -> Result<Response<proto::ListNeighborSetsResponse>, Status> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::ListNeighborSets { reply: reply_tx })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        let neighbor_sets = reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?;
+        let neighbor_sets = peer_manager_read(&self.peer_mgr_tx, |reply| {
+            PeerManagerCommand::ListNeighborSets { reply }
+        })
+        .await?;
         Ok(Response::new(proto::ListNeighborSetsResponse {
             neighbor_sets: neighbor_sets
                 .into_iter()
@@ -612,18 +591,14 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         if req.name.trim().is_empty() {
             return Err(Status::invalid_argument("name is required"));
         }
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::GetNeighborSet {
+        let definition = peer_manager_read(&self.peer_mgr_tx, |reply| {
+            PeerManagerCommand::GetNeighborSet {
                 name: req.name.clone(),
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        let definition = reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .ok_or_else(|| Status::not_found("neighbor set not found"))?;
+                reply,
+            }
+        })
+        .await?
+        .ok_or_else(|| Status::not_found("neighbor set not found"))?;
         Ok(Response::new(proto::GetNeighborSetResponse {
             name: req.name,
             definition: Some(proto::NeighborSetDefinition {
@@ -724,14 +699,10 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         &self,
         _request: Request<proto::GetGlobalPolicyChainsRequest>,
     ) -> Result<Response<proto::GlobalPolicyChains>, Status> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::GetGlobalPolicyChains { reply: reply_tx })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        let chains = reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?;
+        let chains = peer_manager_read(&self.peer_mgr_tx, |reply| {
+            PeerManagerCommand::GetGlobalPolicyChains { reply }
+        })
+        .await?;
         Ok(Response::new(proto::GlobalPolicyChains {
             import_policy_names: chains.import_policy_names,
             export_policy_names: chains.export_policy_names,
@@ -867,18 +838,11 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .address
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::GetNeighborPolicyChains {
-                address,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        let chains = reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .ok_or_else(|| Status::not_found("neighbor not found"))?;
+        let chains = peer_manager_read(&self.peer_mgr_tx, |reply| {
+            PeerManagerCommand::GetNeighborPolicyChains { address, reply }
+        })
+        .await?
+        .ok_or_else(|| Status::not_found("neighbor not found"))?;
         Ok(Response::new(proto::NeighborPolicyChains {
             address: req.address,
             import_policy_names: chains.import_policy_names,
@@ -1056,21 +1020,17 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         let (afi, safi) = explain_afi_safi(req.afi_safi)?;
         let prefix = explain_prefix(afi, &req.prefix, req.prefix_length)?;
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::ExplainImportPolicy {
+        let reply = peer_manager_read(&self.peer_mgr_tx, |reply| {
+            PeerManagerCommand::ExplainImportPolicy {
                 address,
                 afi,
                 safi,
                 prefix,
                 path_id: req.path_id,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        let reply = reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?;
+                reply,
+            }
+        })
+        .await?;
         let reply: Option<ImportExplainReply> = match reply {
             SessionQueryOutcome::Reply(reply) => Some(reply),
             SessionQueryOutcome::SessionGone => None,
@@ -1152,17 +1112,10 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid peer_address: {e}")))?;
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::ListRejectedRoutes {
-                address,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        let reply = reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?;
+        let reply = peer_manager_read(&self.peer_mgr_tx, |reply| {
+            PeerManagerCommand::ListRejectedRoutes { address, reply }
+        })
+        .await?;
         let reply: Option<RejectedRoutesReply> = match reply {
             SessionQueryOutcome::Reply(reply) => Some(reply),
             SessionQueryOutcome::SessionGone => None,
@@ -1322,33 +1275,25 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         let rib_tx = self.rib_tx.as_ref().ok_or_else(|| {
             Status::failed_precondition("route snapshot runtime unavailable on this listener")
         })?;
-        let (reply_tx, reply_rx) = oneshot::channel();
-        let query = if import {
-            RibUpdate::QueryReceivedRoutes {
-                peer: peer_filter,
-                reply: reply_tx,
+        let routes = rib_manager_read(rib_tx, |reply| {
+            if import {
+                RibUpdate::QueryReceivedRoutes {
+                    peer: peer_filter,
+                    reply,
+                }
+            } else {
+                RibUpdate::QueryBestRoutes { reply }
             }
-        } else {
-            RibUpdate::QueryBestRoutes { reply: reply_tx }
-        };
-        rib_tx
-            .send(query)
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-        let routes = reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+        })
+        .await?;
 
         // Peer context (ASN / peer-group) so guards on peer.* fields
         // see real values.
-        let (peers_tx, peers_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::ListPeers { reply: peers_tx })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-        let peer_context: std::collections::HashMap<IpAddr, (u32, Option<String>)> = peers_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
+        let peer_context: std::collections::HashMap<IpAddr, (u32, Option<String>)> =
+            peer_manager_read(&self.peer_mgr_tx, |reply| PeerManagerCommand::ListPeers {
+                reply,
+            })
+            .await?
             .into_iter()
             .map(|info| (info.address, (info.remote_asn, info.peer_group)))
             .collect();
@@ -1420,11 +1365,11 @@ impl proto::policy_service_server::PolicyService for PolicyService {
                 Status::failed_precondition("policy stats runtime unavailable on this listener")
             })?;
             let chains = policy_stats_request(
-                rib_tx,
                 deadline,
-                |reply| RibUpdate::QueryExportPolicyTermHits { peer, reply },
-                "RIB manager unavailable",
-                "RIB manager dropped reply",
+                rib_manager_read(rib_tx, |reply| RibUpdate::QueryExportPolicyTermHits {
+                    peer,
+                    reply,
+                }),
             )
             .await?;
             out.extend(chains.into_iter().map(|chain| {
@@ -1445,15 +1390,14 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         }
         if want_import {
             let chains = policy_stats_request(
-                &self.peer_mgr_tx,
                 deadline,
-                |reply| PeerManagerCommand::QueryImportPolicyTermHits {
-                    peer,
-                    deadline,
-                    reply,
-                },
-                "peer manager unavailable",
-                "peer manager dropped reply",
+                peer_manager_read(&self.peer_mgr_tx, |reply| {
+                    PeerManagerCommand::QueryImportPolicyTermHits {
+                        peer,
+                        deadline,
+                        reply,
+                    }
+                }),
             )
             .await?;
             let chains = match chains {
@@ -1488,11 +1432,10 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         // operator-visible half of "failed refresh keeps the prior
         // snapshot" (name, kind, generation, records, last error).
         let datasets = policy_stats_request(
-            &self.peer_mgr_tx,
             deadline,
-            |reply| PeerManagerCommand::QueryPolicyDatasets { reply },
-            "peer manager unavailable",
-            "peer manager dropped reply",
+            peer_manager_read(&self.peer_mgr_tx, |reply| {
+                PeerManagerCommand::QueryPolicyDatasets { reply }
+            }),
         )
         .await?
         .into_iter()
@@ -1712,6 +1655,351 @@ mod tests {
                 ..Default::default()
             }],
         }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum PolicyRead {
+        ListPolicies,
+        GetPolicy,
+        ListNeighborSets,
+        GetNeighborSet,
+        GetGlobalPolicyChains,
+        GetNeighborPolicyChains,
+        ExplainImportPolicy,
+        ListRejectedRoutes,
+        TestPolicy,
+        GetPolicyStats,
+    }
+
+    const POLICY_READS: [PolicyRead; 10] = [
+        PolicyRead::ListPolicies,
+        PolicyRead::GetPolicy,
+        PolicyRead::ListNeighborSets,
+        PolicyRead::GetNeighborSet,
+        PolicyRead::GetGlobalPolicyChains,
+        PolicyRead::GetNeighborPolicyChains,
+        PolicyRead::ExplainImportPolicy,
+        PolicyRead::ListRejectedRoutes,
+        PolicyRead::TestPolicy,
+        PolicyRead::GetPolicyStats,
+    ];
+
+    impl PolicyRead {
+        const fn rib_first(self) -> bool {
+            matches!(self, Self::TestPolicy | Self::GetPolicyStats)
+        }
+    }
+
+    fn test_policy_request() -> proto::TestPolicyRequest {
+        proto::TestPolicyRequest {
+            rpol_source: TEST_RPOL.to_string(),
+            policy: "customer-in(200)".to_string(),
+            direction: "import".to_string(),
+            peer: String::new(),
+            afi_safi: proto::AddressFamily::Unspecified as i32,
+            limit: 0,
+            show_changes: 0,
+        }
+    }
+
+    fn policy_stats_rpc_request(
+        peer_address: &str,
+        direction: &str,
+    ) -> proto::GetPolicyStatsRequest {
+        proto::GetPolicyStatsRequest {
+            peer_address: peer_address.to_string(),
+            direction: direction.to_string(),
+        }
+    }
+
+    async fn invoke_policy_read(service: &PolicyService, rpc: PolicyRead) -> Result<(), Status> {
+        match rpc {
+            PolicyRead::ListPolicies => PolicyServiceRpc::list_policies(
+                service,
+                Request::new(proto::ListPoliciesRequest {}),
+            )
+            .await
+            .map(|_| ()),
+            PolicyRead::GetPolicy => PolicyServiceRpc::get_policy(
+                service,
+                Request::new(proto::GetPolicyRequest { name: "p".into() }),
+            )
+            .await
+            .map(|_| ()),
+            PolicyRead::ListNeighborSets => PolicyServiceRpc::list_neighbor_sets(
+                service,
+                Request::new(proto::ListNeighborSetsRequest {}),
+            )
+            .await
+            .map(|_| ()),
+            PolicyRead::GetNeighborSet => PolicyServiceRpc::get_neighbor_set(
+                service,
+                Request::new(proto::GetNeighborSetRequest { name: "s".into() }),
+            )
+            .await
+            .map(|_| ()),
+            PolicyRead::GetGlobalPolicyChains => PolicyServiceRpc::get_global_policy_chains(
+                service,
+                Request::new(proto::GetGlobalPolicyChainsRequest {}),
+            )
+            .await
+            .map(|_| ()),
+            PolicyRead::GetNeighborPolicyChains => PolicyServiceRpc::get_neighbor_policy_chains(
+                service,
+                Request::new(proto::GetNeighborPolicyChainsRequest {
+                    address: "192.0.2.1".into(),
+                }),
+            )
+            .await
+            .map(|_| ()),
+            PolicyRead::ExplainImportPolicy => {
+                PolicyServiceRpc::explain_import_policy(service, Request::new(explain_request()))
+                    .await
+                    .map(|_| ())
+            }
+            PolicyRead::ListRejectedRoutes => PolicyServiceRpc::list_rejected_routes(
+                service,
+                Request::new(proto::ListRejectedRoutesRequest {
+                    peer_address: "192.0.2.1".into(),
+                }),
+            )
+            .await
+            .map(|_| ()),
+            PolicyRead::TestPolicy => {
+                PolicyServiceRpc::test_policy(service, Request::new(test_policy_request()))
+                    .await
+                    .map(|_| ())
+            }
+            PolicyRead::GetPolicyStats => PolicyServiceRpc::get_policy_stats(
+                service,
+                Request::new(policy_stats_rpc_request("", "export")),
+            )
+            .await
+            .map(|_| ()),
+        }
+    }
+
+    /// Load-bearing: restoring any included RPC's first actor-send mapping to
+    /// `INTERNAL` makes its row red. The two multi-stage RPCs start at the RIB.
+    #[tokio::test]
+    async fn policy_read_send_failures_are_unavailable() {
+        for rpc in POLICY_READS {
+            let (peer_tx, peer_rx) = mpsc::channel(1);
+            let (rib_tx, rib_rx) = mpsc::channel(1);
+            let service = PolicyService::new(AccessMode::ReadOnly, peer_tx, None, None)
+                .with_rib_query(rib_tx);
+            let expected = if rpc.rib_first() {
+                drop(rib_rx);
+                let _peer_rx = peer_rx;
+                "RIB manager unavailable"
+            } else {
+                drop(peer_rx);
+                let _rib_rx = rib_rx;
+                "peer manager unavailable"
+            };
+            let error = invoke_policy_read(&service, rpc).await.unwrap_err();
+            assert_eq!(error.code(), tonic::Code::Unavailable, "{rpc:?}");
+            assert_eq!(error.message(), expected, "{rpc:?}");
+        }
+    }
+
+    /// Load-bearing: restoring any included RPC's first reply-await mapping to
+    /// `INTERNAL` makes its accepted-then-dropped row red.
+    #[tokio::test]
+    async fn policy_read_reply_drops_are_unavailable() {
+        for rpc in POLICY_READS {
+            let (peer_tx, mut peer_rx) = mpsc::channel(1);
+            let (rib_tx, mut rib_rx) = mpsc::channel(1);
+            let service = PolicyService::new(AccessMode::ReadOnly, peer_tx, None, None)
+                .with_rib_query(rib_tx);
+            let (actor, expected) = if rpc.rib_first() {
+                (
+                    tokio::spawn(async move {
+                        drop(rib_rx.recv().await.expect("policy RIB read"));
+                    }),
+                    "RIB manager dropped reply",
+                )
+            } else {
+                (
+                    tokio::spawn(async move {
+                        drop(peer_rx.recv().await.expect("policy peer read"));
+                    }),
+                    "peer manager dropped reply",
+                )
+            };
+            let error = invoke_policy_read(&service, rpc).await.unwrap_err();
+            actor.await.unwrap();
+            assert_eq!(error.code(), tonic::Code::Unavailable, "{rpc:?}");
+            assert_eq!(error.message(), expected, "{rpc:?}");
+        }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum PolicyReadExtraStage {
+        TestPolicyPeerContext,
+        PolicyStatsPeerValidation,
+        PolicyStatsImport,
+        PolicyStatsDatasets,
+    }
+
+    const POLICY_READ_EXTRA_STAGES: [PolicyReadExtraStage; 4] = [
+        PolicyReadExtraStage::TestPolicyPeerContext,
+        PolicyReadExtraStage::PolicyStatsPeerValidation,
+        PolicyReadExtraStage::PolicyStatsImport,
+        PolicyReadExtraStage::PolicyStatsDatasets,
+    ];
+
+    async fn invoke_policy_extra_stage(
+        service: &PolicyService,
+        stage: PolicyReadExtraStage,
+    ) -> Result<(), Status> {
+        match stage {
+            PolicyReadExtraStage::TestPolicyPeerContext => {
+                PolicyServiceRpc::test_policy(service, Request::new(test_policy_request()))
+                    .await
+                    .map(|_| ())
+            }
+            PolicyReadExtraStage::PolicyStatsPeerValidation => PolicyServiceRpc::get_policy_stats(
+                service,
+                Request::new(policy_stats_rpc_request("192.0.2.1", "export")),
+            )
+            .await
+            .map(|_| ()),
+            PolicyReadExtraStage::PolicyStatsImport => PolicyServiceRpc::get_policy_stats(
+                service,
+                Request::new(policy_stats_rpc_request("", "import")),
+            )
+            .await
+            .map(|_| ()),
+            PolicyReadExtraStage::PolicyStatsDatasets => PolicyServiceRpc::get_policy_stats(
+                service,
+                Request::new(policy_stats_rpc_request("", "export")),
+            )
+            .await
+            .map(|_| ()),
+        }
+    }
+
+    async fn answer_policy_stage_rib(mut rib_rx: mpsc::Receiver<rustbgpd_rib::RibUpdate>) {
+        let Some(update) = rib_rx.recv().await else {
+            return;
+        };
+        match update {
+            rustbgpd_rib::RibUpdate::QueryReceivedRoutes { reply, .. }
+            | rustbgpd_rib::RibUpdate::QueryBestRoutes { reply } => {
+                let _ = reply.send(Vec::new());
+            }
+            rustbgpd_rib::RibUpdate::QueryExportPolicyTermHits { reply, .. } => {
+                let _ = reply.send(Vec::new());
+            }
+            _ => panic!("unexpected policy-stage RIB query"),
+        }
+    }
+
+    /// Load-bearing: bypassing the shared peer helper at any post-RIB or
+    /// stats-only peer stage makes that stage's send-closed row red.
+    #[tokio::test]
+    async fn policy_extra_stage_send_failures_are_unavailable() {
+        for stage in POLICY_READ_EXTRA_STAGES {
+            let (peer_tx, peer_rx) = mpsc::channel(1);
+            drop(peer_rx);
+            let (rib_tx, rib_rx) = mpsc::channel(1);
+            let rib = tokio::spawn(answer_policy_stage_rib(rib_rx));
+            let service = PolicyService::new(AccessMode::ReadOnly, peer_tx, None, None)
+                .with_rib_query(rib_tx);
+            let error = invoke_policy_extra_stage(&service, stage)
+                .await
+                .unwrap_err();
+            drop(service);
+            rib.await.unwrap();
+            assert_eq!(error.code(), tonic::Code::Unavailable, "{stage:?}");
+            assert_eq!(error.message(), "peer manager unavailable", "{stage:?}");
+        }
+    }
+
+    /// Load-bearing: bypassing the shared peer helper at any post-RIB or
+    /// stats-only peer stage makes that accepted/dropped row red.
+    #[tokio::test]
+    async fn policy_extra_stage_reply_drops_are_unavailable() {
+        for stage in POLICY_READ_EXTRA_STAGES {
+            let (peer_tx, mut peer_rx) = mpsc::channel(1);
+            let peer = tokio::spawn(async move {
+                drop(peer_rx.recv().await.expect("policy-stage peer read"));
+            });
+            let (rib_tx, rib_rx) = mpsc::channel(1);
+            let rib = tokio::spawn(answer_policy_stage_rib(rib_rx));
+            let service = PolicyService::new(AccessMode::ReadOnly, peer_tx, None, None)
+                .with_rib_query(rib_tx);
+            let error = invoke_policy_extra_stage(&service, stage)
+                .await
+                .unwrap_err();
+            drop(service);
+            peer.await.unwrap();
+            rib.await.unwrap();
+            assert_eq!(error.code(), tonic::Code::Unavailable, "{stage:?}");
+            assert_eq!(error.message(), "peer manager dropped reply", "{stage:?}");
+        }
+    }
+
+    /// Negative control: request validation still precedes actor I/O, while
+    /// successfully delivered typed `None` replies retain `NOT_FOUND`.
+    #[tokio::test]
+    async fn policy_reads_preserve_invalid_and_not_found() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(3);
+        let service = PolicyService::new(AccessMode::ReadOnly, peer_tx, None, None);
+
+        let invalid = PolicyServiceRpc::get_policy(
+            &service,
+            Request::new(proto::GetPolicyRequest {
+                name: String::new(),
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(invalid.code(), tonic::Code::InvalidArgument);
+        assert!(matches!(peer_rx.try_recv(), Err(TryRecvError::Empty)));
+
+        let actor = tokio::spawn(async move {
+            for _ in 0..3 {
+                match peer_rx.recv().await.expect("policy read") {
+                    PeerManagerCommand::GetPolicy { reply, .. } => {
+                        let _ = reply.send(None);
+                    }
+                    PeerManagerCommand::GetNeighborSet { reply, .. } => {
+                        let _ = reply.send(None);
+                    }
+                    PeerManagerCommand::GetNeighborPolicyChains { reply, .. } => {
+                        let _ = reply.send(None);
+                    }
+                    _ => panic!("unexpected policy read"),
+                }
+            }
+        });
+
+        let policy = PolicyServiceRpc::get_policy(
+            &service,
+            Request::new(proto::GetPolicyRequest { name: "p".into() }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(policy.code(), tonic::Code::NotFound);
+        let neighbor_set = PolicyServiceRpc::get_neighbor_set(
+            &service,
+            Request::new(proto::GetNeighborSetRequest { name: "s".into() }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(neighbor_set.code(), tonic::Code::NotFound);
+        let chains = PolicyServiceRpc::get_neighbor_policy_chains(
+            &service,
+            Request::new(proto::GetNeighborPolicyChainsRequest {
+                address: "192.0.2.1".into(),
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(chains.code(), tonic::Code::NotFound);
+        actor.await.unwrap();
     }
 
     #[test]
@@ -3173,18 +3461,11 @@ policy customer-in(peer_lp: u32) {
     /// leaking backend closure as INTERNAL.
     #[tokio::test(start_paused = true)]
     async fn policy_stats_expired_deadline_precedes_immediately_closed_backend() {
-        let (tx, rx) = mpsc::channel::<u8>(1);
-        drop(rx);
-
-        let error = policy_stats_request::<u8, ()>(
-            &tx,
-            tokio::time::Instant::now(),
-            |_reply| 1,
-            "backend unavailable",
-            "backend dropped reply",
-        )
-        .await
-        .expect_err("already-expired request must fail");
+        let closed_backend =
+            std::future::ready(Err::<(), _>(Status::unavailable("backend unavailable")));
+        let error = policy_stats_request(tokio::time::Instant::now(), closed_backend)
+            .await
+            .expect_err("already-expired request must fail");
 
         assert_eq!(error.code(), tonic::Code::DeadlineExceeded);
     }

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -12,6 +12,7 @@ use tokio_stream::{Stream, StreamExt, wrappers::BroadcastStream};
 use tonic::{Request, Response, Status};
 use tracing::debug;
 
+use crate::actor_read::rib_manager_read;
 use crate::event_service::{route_event_to_bgp_event, stream_lag_bgp_event};
 use crate::proto;
 use rustbgpd_rib::{
@@ -229,25 +230,11 @@ impl RibService {
     }
 
     async fn query_orr_topology(&self) -> Result<OrrTopologySnapshot, Status> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::QueryOrrTopology { reply: reply_tx })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))
+        rib_manager_read(&self.rib_tx, |reply| RibUpdate::QueryOrrTopology { reply }).await
     }
 
     async fn query_orr_status(&self) -> Result<OrrStatusSnapshot, Status> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::QueryOrrStatus { reply: reply_tx })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))
+        rib_manager_read(&self.rib_tx, |reply| RibUpdate::QueryOrrStatus { reply }).await
     }
 
     /// One bounded, resumable page from the RIB task. Filtering and
@@ -262,30 +249,23 @@ impl RibService {
         expected_version: Option<RoutePageVersion>,
         page_size: usize,
     ) -> Result<RoutePage, Status> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::QueryRoutesPage {
-                scope,
-                filter,
-                after,
-                expected_version,
-                page_size,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))?
-            .map_err(|error| match error {
-                RoutePageError::Invalidated => Status::aborted(
-                    "route table changed during pagination; restart with an empty page_token",
-                ),
-                RoutePageError::GenerationExhausted => Status::unavailable(
-                    "route pagination unavailable because its process-local generation is exhausted",
-                ),
-            })
+        rib_manager_read(&self.rib_tx, |reply| RibUpdate::QueryRoutesPage {
+            scope,
+            filter,
+            after,
+            expected_version,
+            page_size,
+            reply,
+        })
+        .await?
+        .map_err(|error| match error {
+            RoutePageError::Invalidated => Status::aborted(
+                "route table changed during pagination; restart with an empty page_token",
+            ),
+            RoutePageError::GenerationExhausted => Status::unavailable(
+                "route pagination unavailable because its process-local generation is exhausted",
+            ),
+        })
     }
 
     async fn query_explain_advertised_route(
@@ -296,23 +276,16 @@ impl RibService {
         labeled: bool,
         source: Option<RouteSourceIdentity>,
     ) -> Result<ExplainAdvertisedRoute, Status> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::ExplainAdvertisedRoute {
-                peer,
-                prefix,
-                rd,
-                labeled,
-                source,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))?
-            .map_err(explain_advertised_error_status)
+        rib_manager_read(&self.rib_tx, |reply| RibUpdate::ExplainAdvertisedRoute {
+            peer,
+            prefix,
+            rd,
+            labeled,
+            source,
+            reply,
+        })
+        .await?
+        .map_err(explain_advertised_error_status)
     }
 
     async fn query_explain_best_path(
@@ -320,19 +293,12 @@ impl RibService {
         prefix: Prefix,
         peer: Option<IpAddr>,
     ) -> Result<Option<ExplainBestPath>, Status> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::ExplainBestPath {
-                prefix,
-                peer,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))
+        rib_manager_read(&self.rib_tx, |reply| RibUpdate::ExplainBestPath {
+            prefix,
+            peer,
+            reply,
+        })
+        .await
     }
 }
 
@@ -1603,21 +1569,14 @@ impl proto::rib_service_server::RibService for RibService {
             )
         };
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::QueryRouteEventHistory {
-                peer,
-                afi,
-                prefix,
-                limit: req.limit as usize,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-
-        let events = reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+        let events = rib_manager_read(&self.rib_tx, |reply| RibUpdate::QueryRouteEventHistory {
+            peer,
+            afi,
+            prefix,
+            limit: req.limit as usize,
+            reply,
+        })
+        .await?;
         Ok(Response::new(proto::ListRouteEventsResponse {
             events: events.into_iter().map(route_event_to_proto).collect(),
         }))
@@ -1734,15 +1693,10 @@ impl proto::rib_service_server::RibService for RibService {
         let req = request.into_inner();
         validate_flowspec_afi_safi(req.afi_safi)?;
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::QueryFlowSpecRoutes { reply: reply_tx })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-
-        let all_routes = reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+        let all_routes = rib_manager_read(&self.rib_tx, |reply| RibUpdate::QueryFlowSpecRoutes {
+            reply,
+        })
+        .await?;
 
         // Filter by AFI if requested
         let filtered: Vec<&FlowSpecRoute> = all_routes
@@ -1793,15 +1747,8 @@ impl proto::rib_service_server::RibService for RibService {
             )
         };
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::QueryEvpnRoutes { reply: reply_tx })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-
-        let all_routes = reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+        let all_routes =
+            rib_manager_read(&self.rib_tx, |reply| RibUpdate::QueryEvpnRoutes { reply }).await?;
 
         let type_filter = req.route_type_filter;
 
@@ -1855,15 +1802,8 @@ impl proto::rib_service_server::RibService for RibService {
         }
         let peer_filter = parse_optional_peer_filter(&req.peer_filter)?;
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::QueryBgpLsRoutes { reply: reply_tx })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-
-        let all_routes = reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+        let all_routes =
+            rib_manager_read(&self.rib_tx, |reply| RibUpdate::QueryBgpLsRoutes { reply }).await?;
 
         let family_filter = req.afi_safi;
         let type_filter = req.nlri_type_filter;
@@ -1906,15 +1846,8 @@ impl proto::rib_service_server::RibService for RibService {
             )));
         }
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::QueryVpnRoutes { reply: reply_tx })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-
-        let all_routes = reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+        let all_routes =
+            rib_manager_read(&self.rib_tx, |reply| RibUpdate::QueryVpnRoutes { reply }).await?;
 
         #[cfg(feature = "bench-internals")]
         let post_actor_started = Instant::now();
@@ -1962,15 +1895,10 @@ impl proto::rib_service_server::RibService for RibService {
             )));
         }
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::QueryLabeledRoutes { reply: reply_tx })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-
-        let all_routes = reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+        let all_routes = rib_manager_read(&self.rib_tx, |reply| RibUpdate::QueryLabeledRoutes {
+            reply,
+        })
+        .await?;
 
         let family_filter = req.afi_safi;
         let routes = all_routes
@@ -1997,15 +1925,8 @@ impl proto::rib_service_server::RibService for RibService {
         let req = request.into_inner();
         let peer_filter = parse_optional_peer_filter(&req.peer_filter)?;
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::QueryRtcRoutes { reply: reply_tx })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-
-        let all_routes = reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+        let all_routes =
+            rib_manager_read(&self.rib_tx, |reply| RibUpdate::QueryRtcRoutes { reply }).await?;
 
         let routes = all_routes
             .iter()
@@ -2795,6 +2716,149 @@ mod tests {
     fn make_service() -> RibService {
         let (tx, _rx) = mpsc::channel(16);
         RibService::new(tx)
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum UnaryRibRead {
+        ListReceivedRoutes,
+        ListBestRoutes,
+        ListAdvertisedRoutes,
+        ExplainAdvertisedRoute,
+        ExplainBestPath,
+        ListRouteEvents,
+        ListFlowSpecRoutes,
+        ListEvpnRoutes,
+        ListBgpLsRoutes,
+        ListVpnRoutes,
+        ListLabeledRoutes,
+        ListRtcRoutes,
+        ListTopologyNodes,
+        ListTopologyLinks,
+        ListOrrStatus,
+    }
+
+    const UNARY_RIB_READS: [UnaryRibRead; 15] = [
+        UnaryRibRead::ListReceivedRoutes,
+        UnaryRibRead::ListBestRoutes,
+        UnaryRibRead::ListAdvertisedRoutes,
+        UnaryRibRead::ExplainAdvertisedRoute,
+        UnaryRibRead::ExplainBestPath,
+        UnaryRibRead::ListRouteEvents,
+        UnaryRibRead::ListFlowSpecRoutes,
+        UnaryRibRead::ListEvpnRoutes,
+        UnaryRibRead::ListBgpLsRoutes,
+        UnaryRibRead::ListVpnRoutes,
+        UnaryRibRead::ListLabeledRoutes,
+        UnaryRibRead::ListRtcRoutes,
+        UnaryRibRead::ListTopologyNodes,
+        UnaryRibRead::ListTopologyLinks,
+        UnaryRibRead::ListOrrStatus,
+    ];
+
+    async fn invoke_unary_rib_read(svc: &RibService, rpc: UnaryRibRead) -> Result<(), Status> {
+        match rpc {
+            UnaryRibRead::ListReceivedRoutes => svc
+                .list_received_routes(Request::new(list_routes_request()))
+                .await
+                .map(|_| ()),
+            UnaryRibRead::ListBestRoutes => svc
+                .list_best_routes(Request::new(list_routes_request()))
+                .await
+                .map(|_| ()),
+            UnaryRibRead::ListAdvertisedRoutes => svc
+                .list_advertised_routes(Request::new(proto::ListRoutesRequest {
+                    neighbor_address: "192.0.2.1".into(),
+                    ..list_routes_request()
+                }))
+                .await
+                .map(|_| ()),
+            UnaryRibRead::ExplainAdvertisedRoute => svc
+                .explain_advertised_route(Request::new(proto::ExplainAdvertisedRouteRequest {
+                    peer_address: "192.0.2.1".into(),
+                    prefix: "203.0.113.0".into(),
+                    prefix_length: 24,
+                    ..Default::default()
+                }))
+                .await
+                .map(|_| ()),
+            UnaryRibRead::ExplainBestPath => svc
+                .explain_best_path(Request::new(explain_best_path_request()))
+                .await
+                .map(|_| ()),
+            UnaryRibRead::ListRouteEvents => svc
+                .list_route_events(Request::new(proto::ListRouteEventsRequest::default()))
+                .await
+                .map(|_| ()),
+            UnaryRibRead::ListFlowSpecRoutes => svc
+                .list_flow_spec_routes(Request::new(proto::ListFlowSpecRequest::default()))
+                .await
+                .map(|_| ()),
+            UnaryRibRead::ListEvpnRoutes => svc
+                .list_evpn_routes(Request::new(proto::ListEvpnRequest::default()))
+                .await
+                .map(|_| ()),
+            UnaryRibRead::ListBgpLsRoutes => svc
+                .list_bgp_ls_routes(Request::new(proto::ListBgpLsRequest::default()))
+                .await
+                .map(|_| ()),
+            UnaryRibRead::ListVpnRoutes => svc
+                .list_vpn_routes(Request::new(proto::ListVpnRoutesRequest::default()))
+                .await
+                .map(|_| ()),
+            UnaryRibRead::ListLabeledRoutes => svc
+                .list_labeled_routes(Request::new(proto::ListLabeledRoutesRequest::default()))
+                .await
+                .map(|_| ()),
+            UnaryRibRead::ListRtcRoutes => svc
+                .list_rtc_routes(Request::new(proto::ListRtcRoutesRequest::default()))
+                .await
+                .map(|_| ()),
+            UnaryRibRead::ListTopologyNodes => svc
+                .list_topology_nodes(Request::new(proto::ListTopologyNodesRequest {}))
+                .await
+                .map(|_| ()),
+            UnaryRibRead::ListTopologyLinks => svc
+                .list_topology_links(Request::new(proto::ListTopologyLinksRequest {}))
+                .await
+                .map(|_| ()),
+            UnaryRibRead::ListOrrStatus => svc
+                .list_orr_status(Request::new(proto::ListOrrStatusRequest {}))
+                .await
+                .map(|_| ()),
+        }
+    }
+
+    /// Load-bearing: restoring any included unary RIB send mapping to
+    /// `INTERNAL` makes its row red. Stream subscription RPCs are absent.
+    #[tokio::test]
+    async fn unary_rib_read_send_failures_are_unavailable() {
+        for rpc in UNARY_RIB_READS {
+            let (tx, rx) = mpsc::channel(1);
+            drop(rx);
+            let error = invoke_unary_rib_read(&RibService::new(tx), rpc)
+                .await
+                .unwrap_err();
+            assert_eq!(error.code(), tonic::Code::Unavailable, "{rpc:?}");
+            assert_eq!(error.message(), "RIB manager unavailable", "{rpc:?}");
+        }
+    }
+
+    /// Load-bearing: restoring any included unary RIB reply-await mapping to
+    /// `INTERNAL` makes its accepted-then-dropped row red.
+    #[tokio::test]
+    async fn unary_rib_read_reply_drops_are_unavailable() {
+        for rpc in UNARY_RIB_READS {
+            let (tx, mut rx) = mpsc::channel(1);
+            let actor = tokio::spawn(async move {
+                drop(rx.recv().await.expect("unary RIB read command"));
+            });
+            let error = invoke_unary_rib_read(&RibService::new(tx), rpc)
+                .await
+                .unwrap_err();
+            actor.await.unwrap();
+            assert_eq!(error.code(), tonic::Code::Unavailable, "{rpc:?}");
+            assert_eq!(error.message(), "RIB manager dropped reply", "{rpc:?}");
+        }
     }
 
     fn bgpls_test_routes(peer: IpAddr) -> Vec<BgpLsRibRoute> {


### PR DESCRIPTION
## Summary

- map peer-manager and RIB-manager command-channel closure and dropped replies to actor-specific `UNAVAILABLE` statuses
- apply the shared mapping to 33 bounded unary read RPCs across Neighbor, RIB, Policy, Event, and PeerGroup services
- preserve existing deadlines, malformed-snapshot failures, page invalidation, not-found results, typed session outcomes, and mutation semantics

## Scope

This intentionally excludes streams, watches, subscriptions, gNMI, direct snapshots, every mutation/control/persistence path, and the separately owned `ListFibTables` FIB-reconciler hook.

## Verification

- 80 endpoint/stage transport rows cover send-closed and accepted-command/dropped-reply failures
- destructive proofs make the peer send, peer dropped-reply, RIB send, RIB dropped-reply, `TestPolicy`, `GetPolicyStats`, and expired-deadline precedence cases go red when their guarded mapping is removed or changed
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked -p rustbgpd-api` (535 passed)
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked -p rustbgpd-api --no-deps`
- full commit and push hooks, including workspace tests and docs
- independent attack review and final exact-patch review
