### PR TITLE
bmp: fail closed on Loc-RIB dump overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- A Loc-RIB live buffer that outgrows its 8,192-row bound during BMP bootstrap
+  now closes only that collector's incomplete TCP generation and reconnects
+  from a fresh dump. It no longer drops one delta while allowing the same
+  session's End-of-RIB to certify an incomplete view.
+
 - `ListFibTables` now reports FIB reconciler command-channel closure or a
   dropped `GetTables` reply as retryable `UNAVAILABLE`; mutation-path actor
   faults remain `INTERNAL`.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -209,9 +209,11 @@ byte counts.
   admission, reply, or delivery fails before its terminal EoRs,
   buffered live Loc-RIB rows are discarded and that view stays
   suppressed until the next reconnect rather than being released as
-  an incomplete snapshot. For a route reflector the
-  post-policy Loc-RIB is the view most dump consumers actually want. Rib-out
-  dump synthesis was
+  an incomplete snapshot. The same fail-closed reconnect occurs if more than
+  8,192 live rows accumulate during bootstrap or the dump; TCP EOF invalidates
+  the incomplete BMP session before a new generation starts fresh. For a route
+  reflector the post-policy Loc-RIB is the view most dump consumers actually
+  want. Rib-out dump synthesis was
   evaluated and deliberately deferred: `AdjRibOut` stores post-policy
   routes *before* transport stamping, so a synthesized dump would miss
   the session-side attribute rewrites (`ORIGINATOR_ID`/`CLUSTER_LIST`

--- a/crates/bmp/src/client.rs
+++ b/crates/bmp/src/client.rs
@@ -6,7 +6,6 @@
 
 use std::time::Duration;
 
-#[cfg(test)]
 use bytes::Bytes;
 use rustbgpd_telemetry::BgpMetrics;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
@@ -44,6 +43,34 @@ pub struct BmpClient {
 }
 
 impl BmpClient {
+    fn generation_closed<T>(rx: &mpsc::Receiver<T>, stop: &watch::Receiver<bool>) -> bool {
+        rx.is_closed() && !reconnect_shutdown_requested(stop)
+    }
+
+    async fn close_generation_and_retry(
+        &self,
+        receiver: mpsc::Receiver<Bytes>,
+        mut stream: TcpStream,
+        generation: u64,
+        shutdown: &mut watch::Receiver<bool>,
+        backoff: &mut Duration,
+        max_backoff: Duration,
+    ) -> bool {
+        self.notify_disconnected(
+            self.config.collector_id,
+            self.config.collector_addr,
+            generation,
+        );
+        drop(receiver);
+        if reconnect_shutdown_requested(shutdown) {
+            self.send_termination(&mut stream).await;
+            return true;
+        }
+        drop(stream);
+        wait_post_connect_retry(shutdown, backoff, max_backoff).await;
+        reconnect_shutdown_requested(shutdown)
+    }
+
     fn notify_disconnected(
         &self,
         collector_id: usize,
@@ -159,33 +186,13 @@ impl BmpClient {
         PostConnectWriteOutcome::Sent
     }
 
-    async fn send_live_or_retry<W>(
-        &self,
-        stream: &mut W,
-        message: &[u8],
-        generation: u64,
-        shutdown: &mut watch::Receiver<bool>,
-        backoff: &mut Duration,
-        max_backoff: Duration,
-    ) -> PostConnectWriteOutcome
+    async fn send_live_or_retry<W>(&self, stream: &mut W, message: &[u8]) -> PostConnectWriteOutcome
     where
         W: AsyncWrite + Unpin,
     {
         if let Err(error) = Self::write_all_with_timeout(stream, message).await {
             warn!(collector = %self.config.collector_addr, %error, "BMP write failed, reconnecting");
-            self.notify_disconnected(
-                self.config.collector_id,
-                self.config.collector_addr,
-                generation,
-            );
-            return if self
-                .wait_post_connect_retry_or_terminate(stream, shutdown, backoff, max_backoff)
-                .await
-            {
-                PostConnectWriteOutcome::Shutdown
-            } else {
-                PostConnectWriteOutcome::Retry
-            };
+            return PostConnectWriteOutcome::Retry;
         }
         PostConnectWriteOutcome::Sent
     }
@@ -211,9 +218,10 @@ impl BmpClient {
 
     /// Stop retrying a disconnected collector when daemon shutdown begins.
     ///
-    /// The signal interrupts connection and bootstrap retries. Once a
-    /// generation is live, the client waits for the manager to close its
-    /// sender, drains the accepted queue, and sends Termination last.
+    /// The signal interrupts connection and bootstrap retries. Once shutdown
+    /// is signaled, a live client drains the manager-accepted queue and sends
+    /// Termination last; ordinary generation closure discards its invalidated
+    /// queue and reconnects.
     #[must_use]
     pub fn with_reconnect_shutdown(mut self, shutdown: watch::Receiver<bool>) -> Self {
         self.reconnect_shutdown = Some(shutdown);
@@ -241,7 +249,7 @@ impl BmpClient {
             .take()
             .unwrap_or(fallback_shutdown_rx);
 
-        loop {
+        'reconnect: loop {
             let Some(mut stream) = connect_with_reconnect_shutdown(
                 addr,
                 max_backoff,
@@ -367,19 +375,47 @@ impl BmpClient {
                     continue;
                 }
             };
-            let mut bootstrap_failed = false;
             for message in bootstrap.messages {
+                if Self::generation_closed(&rx, &reconnect_shutdown) {
+                    if self
+                        .close_generation_and_retry(
+                            rx,
+                            stream,
+                            bootstrap.generation,
+                            &mut reconnect_shutdown,
+                            &mut post_connect_backoff,
+                            max_backoff,
+                        )
+                        .await
+                    {
+                        return;
+                    }
+                    continue 'reconnect;
+                }
                 if let Err(e) = Self::write_all_with_timeout(&mut stream, &message).await {
                     warn!(collector = %addr, error = %e, "failed to write BMP bootstrap");
-                    bootstrap_failed = true;
-                    break;
+                    if self
+                        .close_generation_and_retry(
+                            rx,
+                            stream,
+                            bootstrap.generation,
+                            &mut reconnect_shutdown,
+                            &mut post_connect_backoff,
+                            max_backoff,
+                        )
+                        .await
+                    {
+                        return;
+                    }
+                    continue 'reconnect;
                 }
             }
-            if bootstrap_failed {
-                self.notify_disconnected(id, addr, bootstrap.generation);
+            if Self::generation_closed(&rx, &reconnect_shutdown) {
                 if self
-                    .wait_post_connect_retry_or_terminate(
-                        &mut stream,
+                    .close_generation_and_retry(
+                        rx,
+                        stream,
+                        bootstrap.generation,
                         &mut reconnect_shutdown,
                         &mut post_connect_backoff,
                         max_backoff,
@@ -410,10 +446,11 @@ impl BmpClient {
                         "collector_bootstrap_complete",
                         "channel_closed",
                     );
-                    self.notify_disconnected(id, addr, bootstrap.generation);
                     if self
-                        .wait_post_connect_retry_or_terminate(
-                            &mut stream,
+                        .close_generation_and_retry(
+                            rx,
+                            stream,
+                            bootstrap.generation,
                             &mut reconnect_shutdown,
                             &mut post_connect_backoff,
                             max_backoff,
@@ -430,10 +467,11 @@ impl BmpClient {
                         "collector_bootstrap_complete",
                         "channel_timeout",
                     );
-                    self.notify_disconnected(id, addr, bootstrap.generation);
                     if self
-                        .wait_post_connect_retry_or_terminate(
-                            &mut stream,
+                        .close_generation_and_retry(
+                            rx,
+                            stream,
+                            bootstrap.generation,
                             &mut reconnect_shutdown,
                             &mut post_connect_backoff,
                             max_backoff,
@@ -456,35 +494,56 @@ impl BmpClient {
                         info!(collector = %addr, "BMP client shutting down");
                         return;
                     }
-                    self.notify_disconnected(id, addr, bootstrap.generation);
                     if self
-                        .wait_post_connect_retry_or_terminate(
-                            &mut stream,
+                        .close_generation_and_retry(
+                            rx,
+                            stream,
+                            bootstrap.generation,
                             &mut reconnect_shutdown,
                             &mut post_connect_backoff,
                             max_backoff,
                         )
                         .await
                     {
-                        info!(collector = %addr, "BMP client shutting down");
                         return;
                     }
-                    break;
+                    continue 'reconnect;
                 };
+                if Self::generation_closed(&rx, &reconnect_shutdown) {
+                    if self
+                        .close_generation_and_retry(
+                            rx,
+                            stream,
+                            bootstrap.generation,
+                            &mut reconnect_shutdown,
+                            &mut post_connect_backoff,
+                            max_backoff,
+                        )
+                        .await
+                    {
+                        return;
+                    }
+                    continue 'reconnect;
+                }
 
-                match self
-                    .send_live_or_retry(
-                        &mut stream,
-                        &msg,
-                        bootstrap.generation,
-                        &mut reconnect_shutdown,
-                        &mut post_connect_backoff,
-                        max_backoff,
-                    )
-                    .await
-                {
+                match self.send_live_or_retry(&mut stream, &msg).await {
                     PostConnectWriteOutcome::Sent => {}
-                    PostConnectWriteOutcome::Retry => break,
+                    PostConnectWriteOutcome::Retry => {
+                        if self
+                            .close_generation_and_retry(
+                                rx,
+                                stream,
+                                bootstrap.generation,
+                                &mut reconnect_shutdown,
+                                &mut post_connect_backoff,
+                                max_backoff,
+                            )
+                            .await
+                        {
+                            return;
+                        }
+                        continue 'reconnect;
+                    }
                     PostConnectWriteOutcome::Shutdown => return,
                 }
             }
@@ -852,6 +911,204 @@ mod tests {
         handle.abort();
     }
 
+    /// Production mutation: retaining `stream` while awaiting retry makes EOF
+    /// miss the sub-backoff deadline; treating the close as shutdown emits a
+    /// Termination instead of an empty tail.
+    #[tokio::test]
+    async fn empty_generation_close_drops_tcp_before_reconnect_backoff() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (control_tx, mut control_rx) = mpsc::channel(8);
+        let client = BmpClient::new(
+            BmpClientConfig {
+                collector_id: 7,
+                collector_addr: addr,
+                reconnect_interval: 30,
+                version: BmpVersion::V3,
+            },
+            "rustbgpd".to_string(),
+            "test".to_string(),
+            control_tx,
+            BgpMetrics::new(),
+        );
+        let handle = tokio::spawn(client.run());
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let initiation = codec::encode_initiation("rustbgpd", "test", BmpVersion::V3);
+        let mut observed = vec![0; initiation.len()];
+        stream.read_exact(&mut observed).await.unwrap();
+        let BmpControlEvent::CollectorConnected {
+            sender, bootstrap, ..
+        } = control_rx.recv().await.unwrap()
+        else {
+            panic!("expected connected");
+        };
+        bootstrap
+            .send(crate::types::BmpCollectorBootstrap {
+                generation: 11,
+                messages: vec![],
+            })
+            .unwrap();
+        assert!(matches!(
+            control_rx.recv().await,
+            Some(BmpControlEvent::CollectorBootstrapComplete { generation: 11, .. })
+        ));
+        drop(sender);
+
+        let mut tail = Vec::new();
+        tokio::time::timeout(Duration::from_millis(500), stream.read_to_end(&mut tail))
+            .await
+            .expect("TCP remained open into one-second retry backoff")
+            .unwrap();
+        assert!(tail.is_empty(), "ordinary close emitted Termination");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .is_err(),
+            "client reconnected before the one-second backoff"
+        );
+        assert!(matches!(
+            control_rx.recv().await,
+            Some(BmpControlEvent::CollectorDisconnected { generation: 11, .. })
+        ));
+        handle.abort();
+    }
+
+    /// Production mutation: deleting the post-`recv(Some)` close check writes
+    /// the queued EoR-shaped sentinel. Holding the socket across retry misses
+    /// the EOF deadline. The full control channel deterministically parks the
+    /// client after its final bootstrap check until the sender is closed.
+    #[tokio::test]
+    async fn closed_generation_never_starts_prequeued_live_message() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (control_tx, mut control_rx) = mpsc::channel(1);
+        let control_fill = control_tx.clone();
+        let client = BmpClient::new(
+            BmpClientConfig {
+                collector_id: 7,
+                collector_addr: addr,
+                reconnect_interval: 30,
+                version: BmpVersion::V3,
+            },
+            "rustbgpd".to_string(),
+            "test".to_string(),
+            control_tx,
+            BgpMetrics::new(),
+        );
+        let handle = tokio::spawn(client.run());
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let initiation = codec::encode_initiation("rustbgpd", "test", BmpVersion::V3);
+        let mut observed = vec![0; initiation.len()];
+        stream.read_exact(&mut observed).await.unwrap();
+        let BmpControlEvent::CollectorConnected {
+            sender, bootstrap, ..
+        } = control_rx.recv().await.unwrap()
+        else {
+            panic!("expected connected");
+        };
+        sender
+            .send(Bytes::from_static(&[3, 0, 0, 0, 6, 0]))
+            .await
+            .unwrap();
+        control_fill.send(BmpControlEvent::Shutdown).await.unwrap();
+        bootstrap
+            .send(crate::types::BmpCollectorBootstrap {
+                generation: 12,
+                messages: vec![],
+            })
+            .unwrap();
+        tokio::task::yield_now().await;
+        drop(sender);
+        assert!(matches!(
+            control_rx.recv().await,
+            Some(BmpControlEvent::Shutdown)
+        ));
+        assert!(matches!(
+            control_rx.recv().await,
+            Some(BmpControlEvent::CollectorBootstrapComplete { generation: 12, .. })
+        ));
+
+        let mut tail = Vec::new();
+        tokio::time::timeout(Duration::from_millis(500), stream.read_to_end(&mut tail))
+            .await
+            .expect("TCP remained open into one-second retry backoff")
+            .unwrap();
+        assert!(tail.is_empty(), "closed queue sentinel reached TCP");
+        handle.abort();
+    }
+
+    /// Production mutations: removing the per-bootstrap check, the final
+    /// pre-completion check, or the post-recv check changes the exact count;
+    /// moving any check after its write violates the source-order assertions.
+    #[test]
+    fn generation_close_checks_guard_every_write_seam() {
+        let source = include_str!("client.rs")
+            .split("#[cfg(test)]\nmod tests")
+            .next()
+            .unwrap();
+        let loop_start = source.find("for message in bootstrap.messages").unwrap();
+        let first_check = source[loop_start..]
+            .find("Self::generation_closed(&rx")
+            .unwrap()
+            + loop_start;
+        let bootstrap_write = source[first_check..]
+            .find("Self::write_all_with_timeout")
+            .unwrap()
+            + first_check;
+        let final_check = source[bootstrap_write..]
+            .find("Self::generation_closed(&rx")
+            .unwrap()
+            + bootstrap_write;
+        let completion = source[final_check..]
+            .find("CollectorBootstrapComplete")
+            .unwrap()
+            + final_check;
+        let receive = source[completion..].find("rx.recv().await").unwrap() + completion;
+        let live_check = source[receive..]
+            .find("Self::generation_closed(&rx")
+            .unwrap()
+            + receive;
+        let live_write = source[live_check..].find("send_live_or_retry").unwrap() + live_check;
+        let retry = source[live_write..]
+            .find("PostConnectWriteOutcome::Retry =>")
+            .unwrap()
+            + live_write;
+        let retry_close = source[retry..].find("close_generation_and_retry").unwrap() + retry;
+        assert!(loop_start < first_check && first_check < bootstrap_write);
+        assert!(bootstrap_write < final_check && final_check < completion);
+        assert!(receive < live_check && live_check < live_write);
+        assert!(live_write < retry && retry < retry_close);
+        let completion_failures = &source[completion..receive];
+        assert_eq!(
+            completion_failures
+                .matches("close_generation_and_retry")
+                .count(),
+            2
+        );
+        assert_eq!(source.matches("Self::generation_closed(&rx").count(), 3);
+    }
+
+    /// Semantic half of the structural bootstrap proof: closing after the
+    /// first direct write makes the same predicate stop before message two.
+    /// Making `generation_closed` ignore `Receiver::is_closed` turns it red.
+    #[test]
+    fn bootstrap_close_after_message_one_excludes_message_two() {
+        let (sender, receiver) = mpsc::channel::<Bytes>(1);
+        let (_shutdown_tx, shutdown) = watch::channel(false);
+        let mut sender = Some(sender);
+        let mut written = Vec::new();
+        for message in [b"one".as_slice(), b"two".as_slice()] {
+            if BmpClient::generation_closed(&receiver, &shutdown) {
+                break;
+            }
+            written.push(message);
+            if written.len() == 1 {
+                drop(sender.take());
+            }
+        }
+        assert_eq!(written, [b"one".as_slice()]);
+    }
+
     /// Load-bearing call-site proof: removing the bounded retry from the
     /// Initiation failure handler makes this task finish before one second.
     /// The injected writer makes the real Initiation write path fail without
@@ -901,12 +1158,12 @@ mod tests {
         );
     }
 
-    /// Load-bearing call-site proof: removing the bounded retry from the live
-    /// write failure handler makes this task finish before one second. The
-    /// injected writer avoids relying on TCP reset timing.
-    #[tokio::test(start_paused = true)]
-    async fn live_write_failure_waits_before_reconnect() {
-        let (control_tx, mut control_rx) = mpsc::channel(1);
+    /// Load-bearing proof: reporting a failed write as sent makes this red.
+    /// The generation owner—not the borrowed writer helper—owns TCP close and
+    /// retry, so it can discard the socket before awaiting backoff.
+    #[tokio::test]
+    async fn live_write_failure_returns_retry_to_generation_owner() {
+        let (control_tx, _control_rx) = mpsc::channel(1);
         let client = BmpClient::new(
             BmpClientConfig {
                 collector_id: 7,
@@ -919,39 +1176,11 @@ mod tests {
             control_tx,
             BgpMetrics::new(),
         );
-        let (_shutdown_tx, mut shutdown_rx) = watch::channel(false);
-        let task = tokio::spawn(async move {
-            let mut writer = BrokenWriter;
-            let mut backoff = Duration::from_secs(1);
-            let outcome = client
-                .send_live_or_retry(
-                    &mut writer,
-                    b"live",
-                    42,
-                    &mut shutdown_rx,
-                    &mut backoff,
-                    Duration::from_secs(4),
-                )
-                .await;
-            (outcome, backoff)
-        });
-
-        tokio::task::yield_now().await;
-        assert!(
-            !task.is_finished(),
-            "live write failure skipped retry delay"
-        );
-        tokio::time::advance(Duration::from_millis(999)).await;
-        assert!(!task.is_finished(), "live retry fired too early");
-        tokio::time::advance(Duration::from_millis(1)).await;
+        let mut writer = BrokenWriter;
         assert_eq!(
-            task.await.unwrap(),
-            (PostConnectWriteOutcome::Retry, Duration::from_secs(2))
+            client.send_live_or_retry(&mut writer, b"live").await,
+            PostConnectWriteOutcome::Retry
         );
-        assert!(matches!(
-            control_rx.recv().await,
-            Some(BmpControlEvent::CollectorDisconnected { generation: 42, .. })
-        ));
     }
 
     /// Load-bearing proof: draining the live receiver before writing the
@@ -991,7 +1220,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        match ev {
+        let generation_sender = match ev {
             BmpControlEvent::CollectorConnected {
                 collector_id,
                 collector_addr,
@@ -1007,9 +1236,10 @@ mod tests {
                         messages: vec![bootstrap_message.clone()],
                     })
                     .unwrap();
+                sender
             }
             other => panic!("expected CollectorConnected, got {other:?}"),
-        }
+        };
 
         assert!(matches!(
             control_rx.recv().await,
@@ -1023,13 +1253,15 @@ mod tests {
         let mut expected = bootstrap_message.to_vec();
         expected.extend_from_slice(&live_message);
         assert_eq!(ordered, expected);
+        drop(generation_sender);
 
         handle.abort();
     }
 
-    /// Load-bearing proof: removing the completion send timeout hangs this
-    /// test; entering the live loop after the timeout writes the queued live
-    /// sentinel and makes the empty-wire assertion red.
+    /// Load-bearing proof: removing the completion timeout hangs this test;
+    /// retaining TCP across its retry misses the EOF deadline; entering the
+    /// live loop writes the queued sentinel. The sender closes only after the
+    /// client is parked in the full completion-send channel.
     #[tokio::test]
     async fn bootstrap_completion_timeout_never_enters_live_stream() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1075,14 +1307,18 @@ mod tests {
                 messages: vec![],
             })
             .unwrap();
+        tokio::task::yield_now().await;
+        drop(sender);
 
         tokio::time::sleep(CONTROL_TIMEOUT + Duration::from_millis(100)).await;
-        let mut sentinel = [0_u8; 1];
+        let mut tail = Vec::new();
+        tokio::time::timeout(Duration::from_millis(100), stream.read_to_end(&mut tail))
+            .await
+            .expect("completion timeout retained TCP into reconnect backoff")
+            .unwrap();
         assert!(
-            tokio::time::timeout(Duration::from_millis(100), stream.read_exact(&mut sentinel))
-                .await
-                .is_err(),
-            "live queue drained after BootstrapComplete timed out"
+            tail.is_empty(),
+            "live queue drained after completion timeout"
         );
         let drops = metrics
             .registry()

--- a/crates/bmp/src/manager.rs
+++ b/crates/bmp/src/manager.rs
@@ -38,10 +38,9 @@ const LOC_RIB_DUMP_REPLY_TIMEOUT: std::time::Duration = std::time::Duration::fro
 /// reconnect triggers a fresh one).
 const LOC_RIB_DUMP_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-/// Bound on live Loc-RIB messages held back per collector while its
-/// initial table dump streams. Overflow drops the newest message
-/// (counted on `bmp_collector_drops_total`) — the same lossy posture as
-/// a full collector channel; the collector's next reconnect resyncs.
+/// Maximum live Loc-RIB rows held behind bootstrap or an in-flight dump.
+/// Exceeding the cap fails that collector generation closed rather than
+/// certifying a snapshot that omitted live deltas.
 const LOC_RIB_DUMP_LIVE_BUFFER_CAP: usize = 8192;
 
 /// One in-flight Loc-RIB dump for a collector connection generation.
@@ -291,7 +290,7 @@ impl BmpManager {
             tokio::select! {
                 maybe_event = self.event_rx.recv(), if events_open => {
                     if let Some(event) = maybe_event {
-                        self.handle_event(&event);
+                        self.handle_event(&event).await;
                     } else {
                         events_open = false;
                         debug!("BMP event channel closed");
@@ -395,7 +394,11 @@ impl BmpManager {
     /// flushed after the dump's End-of-RIB ([`Self::handle_dump_done`]),
     /// so the collector-facing order is always dump rows (point-in-time
     /// snapshot) → `EoR` → live deltas from that point.
-    fn handle_loc_rib_event(&mut self, event: &BmpEvent) {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "encoding, fan-out, and fail-closed fencing form one actor transaction"
+    )]
+    async fn handle_loc_rib_event(&mut self, event: &BmpEvent) {
         let Some(cfg) = self.loc_rib.clone() else {
             return;
         };
@@ -438,6 +441,7 @@ impl BmpManager {
             _ => unreachable!("guarded above"),
         };
         let mut memo: [Option<Bytes>; 2] = [None, None];
+        let mut overflowed = Vec::new();
         for idx in 0..self.collectors.len() {
             if !self.collectors[idx].filter.loc_rib || self.loc_rib_suppressed.contains(&idx) {
                 continue;
@@ -450,14 +454,18 @@ impl BmpManager {
             match &mut self.collectors[idx].phase {
                 CollectorPhase::Disconnected => {}
                 CollectorPhase::BootstrapPending { loc_rib_buffer, .. } => {
-                    buffer_loc_rib_message(&self.metrics, addr, loc_rib_buffer, msg);
+                    if buffer_loc_rib_message(loc_rib_buffer, msg) {
+                        overflowed.push(idx);
+                    }
                 }
                 CollectorPhase::Active {
                     generation, sender, ..
                 } => {
                     if let Some(dump) = self.active_dumps.get_mut(&idx) {
-                        if *generation == dump.generation {
-                            buffer_loc_rib_message(&self.metrics, addr, &mut dump.buffered, msg);
+                        if *generation == dump.generation
+                            && buffer_loc_rib_message(&mut dump.buffered, msg)
+                        {
+                            overflowed.push(idx);
                         }
                     } else if let Err(e) = sender.try_send(msg) {
                         let reason = trysend_reason(&e);
@@ -472,12 +480,51 @@ impl BmpManager {
                 }
             }
         }
+        if overflowed.is_empty() {
+            return;
+        }
+
+        // Fence every affected generation before awaiting any forwarder. TCP
+        // EOF invalidates all rows already observed for that BMP session.
+        let mut tasks = Vec::new();
+        for idx in overflowed {
+            self.collectors[idx]
+                .generation
+                .fetch_add(1, Ordering::SeqCst);
+            let phase = std::mem::replace(
+                &mut self.collectors[idx].phase,
+                CollectorPhase::Disconnected,
+            );
+            let discarded = match phase {
+                CollectorPhase::BootstrapPending { loc_rib_buffer, .. } => loc_rib_buffer.len(),
+                CollectorPhase::Active { .. } => {
+                    let dump = self.active_dumps.remove(&idx).unwrap();
+                    let len = dump.buffered.len();
+                    tasks.push(dump.task);
+                    len
+                }
+                CollectorPhase::Disconnected => unreachable!("validated connected phase"),
+            };
+            self.metrics.record_bmp_collector_drop(
+                &self.collectors[idx].addr.to_string(),
+                "loc_rib_dump",
+                "live_buffer_full",
+                u64::try_from(discarded).unwrap_or(u64::MAX),
+            );
+            warn!(collector = %self.collectors[idx].addr, discarded, "live Loc-RIB buffer exceeded its bound; closing incomplete BMP generation");
+        }
+        for task in &tasks {
+            task.abort();
+        }
+        for task in tasks {
+            let _ = task.await;
+        }
     }
 
-    fn handle_event(&mut self, event: &BmpEvent) {
+    async fn handle_event(&mut self, event: &BmpEvent) {
         match event {
             BmpEvent::LocRibRouteMonitoring { .. } | BmpEvent::LocRibStats { .. } => {
-                self.handle_loc_rib_event(event);
+                self.handle_loc_rib_event(event).await;
             }
             BmpEvent::PeerUp { peer_info, .. } => {
                 // Encode both versions eagerly: the cache must be able
@@ -548,7 +595,7 @@ impl BmpManager {
                 // event already accepted before fencing generations so its
                 // wire message precedes the terminal Loc-RIB Peer Down.
                 while let Ok(event) = self.event_rx.try_recv() {
-                    self.handle_event(&event);
+                    self.handle_event(&event).await;
                 }
                 self.fence_and_abort_dumps().await;
                 // RFC 9069 §5.3: emit Peer Down only on a generation whose
@@ -1043,18 +1090,9 @@ async fn stream_loc_rib_dump(f: DumpForwarder) -> Option<DumpOutcome> {
     }
 }
 
-fn buffer_loc_rib_message(
-    metrics: &BgpMetrics,
-    addr: SocketAddr,
-    buffer: &mut Vec<Bytes>,
-    message: Bytes,
-) {
-    if buffer.len() < LOC_RIB_DUMP_LIVE_BUFFER_CAP {
-        buffer.push(message);
-    } else {
-        metrics.record_bmp_collector_drop(&addr.to_string(), "loc_rib_dump", "live_buffer_full", 1);
-        warn!(collector = %addr, "live Loc-RIB buffer full before initial dump completion, dropping message");
-    }
+fn buffer_loc_rib_message(buffer: &mut Vec<Bytes>, message: Bytes) -> bool {
+    buffer.push(message);
+    buffer.len() > LOC_RIB_DUMP_LIVE_BUFFER_CAP
 }
 
 /// Classify a `tokio::sync::mpsc::error::TrySendError` into the
@@ -2762,6 +2800,236 @@ mod tests {
             collector_rx.recv().await.is_none(),
             "detached dump retained the generation sender"
         );
+    }
+
+    /// Production mutation: restoring the `len < CAP` drop-newest branch
+    /// leaves the generation connected and records one drop instead of all
+    /// CAP+1 rows invalidated by the now-incomplete TCP session.
+    #[tokio::test]
+    async fn bootstrap_live_buffer_overflow_closes_generation_and_counts_all_rows() {
+        let (_event_tx, event_rx) = mpsc::channel(1);
+        let (_control_tx, control_rx) = mpsc::channel(1);
+        let (dump_tx, _dump_rx) = mpsc::channel(1);
+        let metrics = BgpMetrics::new();
+        let mut manager = BmpManager::new(
+            event_rx,
+            control_rx,
+            vec![(collector_addr(0), loc_rib_filter(), BmpVersion::V3)],
+            metrics.clone(),
+        )
+        .with_loc_rib(loc_rib_config(), dump_tx);
+        let (sender, mut receiver) = mpsc::channel(1);
+        manager.collectors[0].generation.store(7, Ordering::SeqCst);
+        manager.collectors[0].phase = CollectorPhase::BootstrapPending {
+            generation: 7,
+            sender,
+            loc_rib_peer_up: true,
+            loc_rib_buffer: vec![Bytes::new(); LOC_RIB_DUMP_LIVE_BUFFER_CAP],
+        };
+        assert_eq!(manager.collectors[0].phase.generation(), Some(7));
+        assert!(!receiver.is_closed(), "CAP rows keep the generation live");
+
+        manager
+            .handle_event(&BmpEvent::LocRibStats { per_family: vec![] })
+            .await;
+
+        assert!(matches!(
+            manager.collectors[0].phase,
+            CollectorPhase::Disconnected
+        ));
+        assert!(receiver.recv().await.is_none(), "CAP+1 closes the sender");
+        assert_eq!(
+            metric_value_with_labels(
+                &metrics,
+                "bmp_collector_drops_total",
+                &[
+                    ("collector", &collector_addr(0).to_string()),
+                    ("phase", "loc_rib_dump"),
+                    ("reason", "live_buffer_full"),
+                ],
+            ),
+            (LOC_RIB_DUMP_LIVE_BUFFER_CAP + 1) as u64
+        );
+    }
+
+    /// Production mutations: awaiting one task before fencing collector 1
+    /// makes the first sentinel report false; omitting abort-or-await leaves a
+    /// sentinel/reply live; fencing all collectors closes the unaffected third.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one fixture proves fencing, cancellation, accounting, and isolation"
+    )]
+    #[tokio::test]
+    async fn active_dump_overflow_fences_all_then_awaits_with_isolation() {
+        struct FenceSentinel {
+            other: Arc<AtomicU64>,
+            result: Option<tokio::sync::oneshot::Sender<bool>>,
+        }
+        impl Drop for FenceSentinel {
+            fn drop(&mut self) {
+                let _ = self
+                    .result
+                    .take()
+                    .unwrap()
+                    .send(self.other.load(Ordering::SeqCst) != 9);
+            }
+        }
+
+        let (_event_tx, event_rx) = mpsc::channel(1);
+        let (_control_tx, control_rx) = mpsc::channel(1);
+        let (dump_tx, _dump_rx) = mpsc::channel(1);
+        let metrics = BgpMetrics::new();
+        let mut manager = BmpManager::new(
+            event_rx,
+            control_rx,
+            (0..3)
+                .map(|id| (collector_addr(id), loc_rib_filter(), BmpVersion::V3))
+                .collect(),
+            metrics.clone(),
+        )
+        .with_loc_rib(loc_rib_config(), dump_tx);
+        let mut receivers = Vec::new();
+        let mut task_senders = Vec::new();
+        for collector in &mut manager.collectors {
+            let (sender, receiver) = mpsc::channel(1);
+            task_senders.push(sender.clone());
+            collector.generation.store(9, Ordering::SeqCst);
+            collector.phase = CollectorPhase::Active {
+                generation: 9,
+                sender,
+                loc_rib_peer_up: true,
+            };
+            receivers.push(receiver);
+        }
+        let other = Arc::clone(&manager.collectors[1].generation);
+        let (fenced_tx, fenced_rx) = tokio::sync::oneshot::channel();
+        let held0 = task_senders.remove(0);
+        let task0 = tokio::spawn(async move {
+            let _held = held0;
+            let _sentinel = FenceSentinel {
+                other,
+                result: Some(fenced_tx),
+            };
+            std::future::pending::<()>().await;
+        });
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel::<()>();
+        let held1 = task_senders.remove(0);
+        let task1 = tokio::spawn(async move {
+            let _held = held1;
+            let _ = reply_rx.await;
+        });
+        tokio::task::yield_now().await;
+        manager.active_dumps.insert(
+            0,
+            ActiveDump {
+                generation: 9,
+                task: task0,
+                buffered: vec![Bytes::new(); LOC_RIB_DUMP_LIVE_BUFFER_CAP],
+            },
+        );
+        manager.active_dumps.insert(
+            1,
+            ActiveDump {
+                generation: 9,
+                task: task1,
+                buffered: vec![Bytes::new(); LOC_RIB_DUMP_LIVE_BUFFER_CAP],
+            },
+        );
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            manager.handle_event(&BmpEvent::LocRibStats { per_family: vec![] }),
+        )
+        .await
+        .expect("overflow handler did not abort and await every dump");
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), fenced_rx)
+                .await
+                .expect("cancellation sentinel was not dropped")
+                .unwrap(),
+            "all generations fence before await"
+        );
+        assert!(reply_tx.is_closed(), "dump reply closed before resume");
+        assert!(!manager.active_dumps.contains_key(&0));
+        assert!(!manager.active_dumps.contains_key(&1));
+        assert!(matches!(
+            manager.collectors[0].phase,
+            CollectorPhase::Disconnected
+        ));
+        assert!(matches!(
+            manager.collectors[1].phase,
+            CollectorPhase::Disconnected
+        ));
+        assert_eq!(manager.collectors[2].phase.generation(), Some(9));
+        for receiver in &mut receivers[..2] {
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_secs(1), receiver.recv())
+                    .await
+                    .expect("affected generation sender remained live")
+                    .is_none()
+            );
+        }
+        assert_eq!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), receivers[2].recv())
+                .await
+                .expect("unaffected collector stopped receiving")
+                .unwrap()[5],
+            1,
+            "third stays live"
+        );
+        for id in 0..2 {
+            assert_eq!(
+                metric_value_with_labels(
+                    &metrics,
+                    "bmp_collector_drops_total",
+                    &[
+                        ("collector", &collector_addr(id).to_string()),
+                        ("reason", "live_buffer_full"),
+                    ],
+                ),
+                (LOC_RIB_DUMP_LIVE_BUFFER_CAP + 1) as u64
+            );
+        }
+    }
+
+    /// Production mutation: omitting the `ActiveDump` generation comparison
+    /// lets an overflow left by generation 4 fence its generation 5 replacement.
+    #[tokio::test]
+    async fn stale_active_dump_overflow_cannot_fence_replacement() {
+        let (_event_tx, event_rx) = mpsc::channel(1);
+        let (_control_tx, control_rx) = mpsc::channel(1);
+        let (dump_tx, _dump_rx) = mpsc::channel(1);
+        let mut manager = BmpManager::new(
+            event_rx,
+            control_rx,
+            vec![(collector_addr(0), loc_rib_filter(), BmpVersion::V3)],
+            BgpMetrics::new(),
+        )
+        .with_loc_rib(loc_rib_config(), dump_tx);
+        let (sender, receiver) = mpsc::channel(1);
+        manager.collectors[0].generation.store(5, Ordering::SeqCst);
+        manager.collectors[0].phase = CollectorPhase::Active {
+            generation: 5,
+            sender,
+            loc_rib_peer_up: true,
+        };
+        manager.active_dumps.insert(
+            0,
+            ActiveDump {
+                generation: 4,
+                task: tokio::spawn(std::future::pending()),
+                buffered: vec![Bytes::new(); LOC_RIB_DUMP_LIVE_BUFFER_CAP],
+            },
+        );
+
+        manager
+            .handle_event(&BmpEvent::LocRibStats { per_family: vec![] })
+            .await;
+
+        assert_eq!(manager.collectors[0].phase.generation(), Some(5));
+        assert!(!receiver.is_closed(), "replacement remains connected");
+        manager.active_dumps.remove(&0).unwrap().task.abort();
     }
 
     #[tokio::test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2867,7 +2867,10 @@ and collector delivery are independently bounded. A failure before the
 RIB-owned terminal End-of-RIB closure increments
 `bmp_collector_drops_total{phase="loc_rib_dump"}`, discards buffered live
 Loc-RIB rows, and suppresses that view until the next reconnect rather than
-releasing an incomplete snapshot.
+releasing an incomplete snapshot. More than 8,192 live rows buffered behind
+bootstrap or an in-flight dump closes only that collector's TCP generation;
+the reconnect starts a fresh cursor-less dump, so an End-of-RIB cannot certify
+a view with a dropped live delta.
 
 All Loc-RIB messages — including the emulated peer's Peer Up/Down and stats
 — go only to collectors that monitor `loc_rib`.

--- a/docs/adr/0097-bmp-monitoring.md
+++ b/docs/adr/0097-bmp-monitoring.md
@@ -110,7 +110,13 @@ This ADR records the decisions of that arc as shipped.
    carrying the synthesized End-of-RIB closure completes the dump; any earlier
    failure discards buffered Loc-RIB deltas and suppresses that view until the
    next generation. Ordinary Adj-RIB views remain live-only and continue under
-   the existing bounded fan-out policy.
+   the existing bounded fan-out policy. The held live delta buffer is bounded
+   at 8,192 rows. Reaching row 8,193 fences that collector generation, aborts
+   and awaits its dump forwarder, and closes TCP before the capped reconnect
+   delay; a fresh generation starts cursor-less. RFC 7854's TCP-session
+   lifetime is the validity boundary, so any rows already streamed on the
+   incomplete generation are invalidated rather than followed by a misleading
+   End-of-RIB. Coordinated daemon shutdown remains the distinct draining path.
 
 3. **Rib-out table dumps were rejected.** AdjRibOut stores routes
    *pre*-transport-stamping — ORIGINATOR_ID/CLUSTER_LIST, GShut, and


### PR DESCRIPTION
## Summary

- fence only the affected BMP collector generation when its held Loc-RIB live buffer reaches 8,193 rows
- abort and await every affected dump after all generation fences are published, then reconnect from a fresh cursor-less dump
- stop starting queued or bootstrap PDUs after ordinary generation closure and close TCP before reconnect backoff
- preserve coordinated shutdown draining and Termination ordering

## Correctness contract

TCP session closure invalidates any partial BMP view and any EoR raced by an already-started write. The implementation does not promise zero bytes after an in-flight write; it guarantees that no new PDU starts after closure is observed and that an incomplete generation cannot remain valid. Existing metric labels are unchanged and the counter records all 8,193 held rows discarded by the failed generation.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --no-deps`
- rustbgpd-bmp: 80/80 tests
- independent attack review and final exact-diff review: approved

## Load-bearing proofs

The regression suite was forced red and restored for each guarded break: disabling the overflow transition; omitting dump abort; removing stale-generation matching; retaining TCP through reconnect backoff; starting a queued EoR-shaped PDU after closure; removing either bootstrap write guard; ignoring receiver closure; retaining TCP across BootstrapComplete timeout; treating a failed live write as sent; and bypassing the Retry-to-owner-close path. Existing shutdown payload/Termination and Loc-RIB Peer Down tests are negative controls.