### PR TITLE
api: normalize watch admission outages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `WatchRoutes`, `WatchRouteEvents`, and the route, session, policy, and EVPN
+  admissions for `WatchEvents` now report actor command-channel closure and
+  dropped replies as `UNAVAILABLE`, with stable actor-specific messages. Live
+  stream closure and lag behavior after admission are unchanged.
+
 - A Loc-RIB live buffer that outgrows its 8,192-row bound during BMP bootstrap
   now closes only that collector's incomplete TCP generation and reconnects
   from a fresh dump. It no longer drops one delta while allowing the same

--- a/crates/api/src/actor_read.rs
+++ b/crates/api/src/actor_read.rs
@@ -1,4 +1,4 @@
-//! Shared transport boundary for unary reads from the state-owning actors.
+//! Shared transport boundary for read-only requests to the state-owning actors.
 
 use rustbgpd_rib::RibUpdate;
 use tokio::sync::{mpsc, oneshot};
@@ -6,7 +6,7 @@ use tonic::Status;
 
 use crate::peer_types::PeerManagerCommand;
 
-/// Send one read command to the peer manager and await its reply.
+/// Send one read-only request to the peer manager and await its reply.
 pub(crate) async fn peer_manager_read<T>(
     tx: &mpsc::Sender<PeerManagerCommand>,
     build: impl FnOnce(oneshot::Sender<T>) -> PeerManagerCommand,
@@ -20,7 +20,7 @@ pub(crate) async fn peer_manager_read<T>(
         .map_err(|_| Status::unavailable("peer manager dropped reply"))
 }
 
-/// Send one read command to the RIB manager and await its reply.
+/// Send one read-only request to the RIB manager and await its reply.
 pub(crate) async fn rib_manager_read<T>(
     tx: &mpsc::Sender<RibUpdate>,
     build: impl FnOnce(oneshot::Sender<T>) -> RibUpdate,

--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -3,7 +3,7 @@
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
-use tokio::sync::{broadcast, oneshot};
+use tokio::sync::broadcast;
 use tokio_stream::Stream;
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
@@ -213,14 +213,10 @@ impl proto::event_service_server::EventService for EventService {
 
         let route_stream: Pin<Box<dyn Stream<Item = Result<proto::BgpEvent, Status>> + Send>> =
             if filter.wants_route_events() {
-                let (reply_tx, reply_rx) = oneshot::channel();
-                self.rib_tx
-                    .send(RibUpdate::SubscribeRouteEvents { reply: reply_tx })
-                    .await
-                    .map_err(|_| Status::internal("RIB manager unavailable"))?;
-                let broadcast_rx = reply_rx
-                    .await
-                    .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+                let broadcast_rx = rib_manager_read(&self.rib_tx, |reply| {
+                    RibUpdate::SubscribeRouteEvents { reply }
+                })
+                .await?;
                 let route_filter = filter.clone();
                 let route_metrics = self.metrics.clone();
                 let route_subscriber_guard =
@@ -259,14 +255,10 @@ impl proto::event_service_server::EventService for EventService {
 
         let session_stream: Pin<Box<dyn Stream<Item = Result<proto::BgpEvent, Status>> + Send>> =
             if filter.wants_session_events() {
-                let (reply_tx, reply_rx) = oneshot::channel();
-                self.peer_mgr_tx
-                    .send(PeerManagerCommand::SubscribeSessionEvents { reply: reply_tx })
-                    .await
-                    .map_err(|_| Status::internal("peer manager unavailable"))?;
-                let broadcast_rx = reply_rx
-                    .await
-                    .map_err(|_| Status::internal("peer manager dropped reply"))?;
+                let broadcast_rx = peer_manager_read(&self.peer_mgr_tx, |reply| {
+                    PeerManagerCommand::SubscribeSessionEvents { reply }
+                })
+                .await?;
                 let session_filter = filter.clone();
                 let session_metrics = self.metrics.clone();
                 let session_subscriber_guard =
@@ -305,14 +297,10 @@ impl proto::event_service_server::EventService for EventService {
 
         let policy_stream: Pin<Box<dyn Stream<Item = Result<proto::BgpEvent, Status>> + Send>> =
             if filter.wants_policy_events() {
-                let (reply_tx, reply_rx) = oneshot::channel();
-                self.peer_mgr_tx
-                    .send(PeerManagerCommand::SubscribePolicyEvents { reply: reply_tx })
-                    .await
-                    .map_err(|_| Status::internal("peer manager unavailable"))?;
-                let broadcast_rx = reply_rx
-                    .await
-                    .map_err(|_| Status::internal("peer manager dropped reply"))?;
+                let broadcast_rx = peer_manager_read(&self.peer_mgr_tx, |reply| {
+                    PeerManagerCommand::SubscribePolicyEvents { reply }
+                })
+                .await?;
                 let policy_filter = filter.clone();
                 let policy_metrics = self.metrics.clone();
                 let policy_subscriber_guard =
@@ -426,14 +414,10 @@ impl proto::event_service_server::EventService for EventService {
 
         let evpn_stream: Pin<Box<dyn Stream<Item = Result<proto::BgpEvent, Status>> + Send>> =
             if filter.wants_evpn_events() {
-                let (reply_tx, reply_rx) = oneshot::channel();
-                self.rib_tx
-                    .send(RibUpdate::SubscribeEvpnRouteEvents { reply: reply_tx })
-                    .await
-                    .map_err(|_| Status::internal("RIB manager unavailable"))?;
-                let broadcast_rx = reply_rx
-                    .await
-                    .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+                let broadcast_rx = rib_manager_read(&self.rib_tx, |reply| {
+                    RibUpdate::SubscribeEvpnRouteEvents { reply }
+                })
+                .await?;
                 let evpn_filter = filter.clone();
                 let evpn_metrics = self.metrics.clone();
                 let evpn_subscriber_guard =
@@ -648,6 +632,78 @@ mod tests {
         ListEventRead::Policy,
     ];
 
+    #[derive(Clone, Copy, Debug)]
+    enum WatchEventAdmission {
+        Route,
+        Session,
+        Policy,
+        Evpn,
+    }
+
+    impl WatchEventAdmission {
+        fn category(self) -> proto::EventCategory {
+            match self {
+                Self::Route => proto::EventCategory::Route,
+                Self::Session => proto::EventCategory::Session,
+                Self::Policy => proto::EventCategory::Policy,
+                Self::Evpn => proto::EventCategory::Evpn,
+            }
+        }
+
+        fn manager(self) -> &'static str {
+            match self {
+                Self::Route | Self::Evpn => "RIB",
+                Self::Session | Self::Policy => "peer",
+            }
+        }
+    }
+
+    const WATCH_EVENT_ADMISSIONS: [WatchEventAdmission; 4] = [
+        WatchEventAdmission::Route,
+        WatchEventAdmission::Session,
+        WatchEventAdmission::Policy,
+        WatchEventAdmission::Evpn,
+    ];
+
+    fn watch_event_request(source: WatchEventAdmission) -> proto::WatchEventsRequest {
+        proto::WatchEventsRequest {
+            categories: vec![source.category() as i32],
+            ..Default::default()
+        }
+    }
+
+    async fn within_test_deadline<T>(future: impl std::future::Future<Output = T>) -> T {
+        tokio::time::timeout(std::time::Duration::from_secs(1), future)
+            .await
+            .expect("test operation timed out")
+    }
+
+    async fn invoke_watch_event_admission(
+        service: &EventService,
+        source: WatchEventAdmission,
+    ) -> Result<(), Status> {
+        within_test_deadline(service.watch_events(Request::new(watch_event_request(source))))
+            .await
+            .map(|_| ())
+    }
+
+    fn event_service_with_metrics(
+        rib_tx: tokio::sync::mpsc::Sender<RibUpdate>,
+        peer_tx: tokio::sync::mpsc::Sender<PeerManagerCommand>,
+        metrics: &BgpMetrics,
+    ) -> EventService {
+        EventService::with_dataplane_snapshots_broadcaster_and_metrics(
+            rib_tx,
+            peer_tx,
+            Arc::new(Vec::new),
+            Arc::new(Vec::new),
+            dataplane_event_broadcaster(),
+            None,
+            None,
+            metrics.clone(),
+        )
+    }
+
     async fn invoke_list_event_read(
         service: &EventService,
         rpc: ListEventRead,
@@ -714,6 +770,188 @@ mod tests {
                 ListEventRead::Session | ListEventRead::Policy => "peer manager dropped reply",
             };
             assert_eq!(error.message(), expected, "{rpc:?}");
+        }
+    }
+
+    /// Load-bearing: restoring any included `WatchEvents` actor-send mapping to
+    /// `INTERNAL` makes its isolated actual-handler row red.
+    #[tokio::test]
+    async fn watch_event_admission_send_failures_are_unavailable() {
+        for source in WATCH_EVENT_ADMISSIONS {
+            let (rib_tx, rib_rx) = tokio::sync::mpsc::channel(1);
+            let (peer_tx, peer_rx) = tokio::sync::mpsc::channel(1);
+            match source {
+                WatchEventAdmission::Route | WatchEventAdmission::Evpn => drop(rib_rx),
+                WatchEventAdmission::Session | WatchEventAdmission::Policy => drop(peer_rx),
+            }
+            let service = EventService::new(rib_tx, peer_tx);
+            let error = invoke_watch_event_admission(&service, source)
+                .await
+                .unwrap_err();
+            assert_eq!(error.code(), tonic::Code::Unavailable, "{source:?}");
+            assert_eq!(
+                error.message(),
+                format!("{} manager unavailable", source.manager()),
+                "{source:?}"
+            );
+        }
+    }
+
+    /// Load-bearing: restoring any included `WatchEvents` reply-await mapping to
+    /// `INTERNAL` makes its accepted-then-dropped actual-handler row red.
+    #[tokio::test]
+    async fn watch_event_admission_reply_drops_are_unavailable() {
+        for source in WATCH_EVENT_ADMISSIONS {
+            let (rib_tx, mut rib_rx) = tokio::sync::mpsc::channel(1);
+            let (peer_tx, mut peer_rx) = tokio::sync::mpsc::channel(1);
+            let actor = match source {
+                WatchEventAdmission::Route | WatchEventAdmission::Evpn => {
+                    tokio::spawn(async move {
+                        drop(rib_rx.recv().await.expect("RIB watch admission"));
+                    })
+                }
+                WatchEventAdmission::Session | WatchEventAdmission::Policy => {
+                    tokio::spawn(async move {
+                        drop(peer_rx.recv().await.expect("peer watch admission"));
+                    })
+                }
+            };
+            let service = EventService::new(rib_tx, peer_tx);
+            let error = invoke_watch_event_admission(&service, source)
+                .await
+                .unwrap_err();
+            within_test_deadline(actor).await.unwrap();
+            assert_eq!(error.code(), tonic::Code::Unavailable, "{source:?}");
+            assert_eq!(
+                error.message(),
+                format!("{} manager dropped reply", source.manager()),
+                "{source:?}"
+            );
+        }
+    }
+
+    /// Load-bearing: leaking the route receiver or its subscriber guard across
+    /// a later session-admission error makes the zero-count assertion red;
+    /// restoring the session send mapping to `INTERNAL` makes the status red.
+    #[tokio::test]
+    async fn watch_events_releases_route_admission_when_session_send_fails() {
+        let (rib_tx, mut rib_rx) = tokio::sync::mpsc::channel(1);
+        let (peer_tx, peer_rx) = tokio::sync::mpsc::channel(1);
+        let (route_events_tx, _) = broadcast::channel(1);
+        let route_events_for_actor = route_events_tx.clone();
+        let rib_actor = tokio::spawn(async move {
+            match rib_rx.recv().await.expect("route watch admission") {
+                RibUpdate::SubscribeRouteEvents { reply } => {
+                    let _ = reply.send(route_events_for_actor.subscribe());
+                }
+                _ => panic!("expected route watch admission"),
+            }
+        });
+        drop(peer_rx);
+
+        let metrics = BgpMetrics::new();
+        let service = event_service_with_metrics(rib_tx, peer_tx, &metrics);
+        let Err(error) = within_test_deadline(service.watch_events(Request::new(
+            proto::WatchEventsRequest {
+                categories: vec![
+                    proto::EventCategory::Route as i32,
+                    proto::EventCategory::Session as i32,
+                ],
+                ..Default::default()
+            },
+        )))
+        .await
+        else {
+            panic!("session admission must fail");
+        };
+        within_test_deadline(rib_actor).await.unwrap();
+
+        assert_eq!(error.code(), tonic::Code::Unavailable);
+        assert_eq!(error.message(), "peer manager unavailable");
+        assert_eq!(route_events_tx.receiver_count(), 0);
+        assert!(
+            gather_text(&metrics).contains(
+                "bgp_event_stream_subscribers{service=\"watch_events\",source=\"route\"} 0"
+            )
+        );
+    }
+
+    /// Load-bearing: leaking any earlier receiver or subscriber guard across
+    /// the later EVPN reply drop makes its zero-count assertion red; restoring
+    /// the EVPN reply mapping to `INTERNAL` makes the status red.
+    #[tokio::test]
+    async fn watch_events_releases_earlier_admissions_when_evpn_reply_drops() {
+        let (rib_tx, mut rib_rx) = tokio::sync::mpsc::channel(2);
+        let (peer_tx, mut peer_rx) = tokio::sync::mpsc::channel(2);
+        let (route_events_tx, _) = broadcast::channel(1);
+        let (session_events_tx, _) = broadcast::channel(1);
+        let (policy_events_tx, _) = broadcast::channel(1);
+
+        let route_events_for_actor = route_events_tx.clone();
+        let rib_actor = tokio::spawn(async move {
+            match rib_rx.recv().await.expect("route watch admission") {
+                RibUpdate::SubscribeRouteEvents { reply } => {
+                    let _ = reply.send(route_events_for_actor.subscribe());
+                }
+                _ => panic!("expected route watch admission"),
+            }
+            match rib_rx.recv().await.expect("EVPN watch admission") {
+                RibUpdate::SubscribeEvpnRouteEvents { reply } => drop(reply),
+                _ => panic!("expected EVPN watch admission"),
+            }
+        });
+
+        let session_events_for_actor = session_events_tx.clone();
+        let policy_events_for_actor = policy_events_tx.clone();
+        let peer_actor = tokio::spawn(async move {
+            match peer_rx.recv().await.expect("session watch admission") {
+                PeerManagerCommand::SubscribeSessionEvents { reply } => {
+                    let _ = reply.send(session_events_for_actor.subscribe());
+                }
+                _ => panic!("expected session watch admission"),
+            }
+            match peer_rx.recv().await.expect("policy watch admission") {
+                PeerManagerCommand::SubscribePolicyEvents { reply } => {
+                    let _ = reply.send(policy_events_for_actor.subscribe());
+                }
+                _ => panic!("expected policy watch admission"),
+            }
+        });
+
+        let metrics = BgpMetrics::new();
+        let service = event_service_with_metrics(rib_tx, peer_tx, &metrics);
+        let Err(error) = within_test_deadline(service.watch_events(Request::new(
+            proto::WatchEventsRequest {
+                categories: vec![
+                    proto::EventCategory::Route as i32,
+                    proto::EventCategory::Session as i32,
+                    proto::EventCategory::Policy as i32,
+                    proto::EventCategory::Evpn as i32,
+                ],
+                ..Default::default()
+            },
+        )))
+        .await
+        else {
+            panic!("EVPN admission must fail");
+        };
+        within_test_deadline(rib_actor).await.unwrap();
+        within_test_deadline(peer_actor).await.unwrap();
+
+        assert_eq!(error.code(), tonic::Code::Unavailable);
+        assert_eq!(error.message(), "RIB manager dropped reply");
+        for (source, receivers) in [
+            ("route", route_events_tx.receiver_count()),
+            ("session", session_events_tx.receiver_count()),
+            ("policy", policy_events_tx.receiver_count()),
+        ] {
+            assert_eq!(receivers, 0, "{source} receiver leaked");
+            assert!(
+                gather_text(&metrics).contains(&format!(
+                    "bgp_event_stream_subscribers{{service=\"watch_events\",source=\"{source}\"}} 0"
+                )),
+                "{source} subscriber gauge did not return to zero"
+            );
         }
     }
 

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 use std::time::Instant;
 
 use sha2::{Digest, Sha256};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tokio_stream::{Stream, StreamExt, wrappers::BroadcastStream};
 use tonic::{Request, Response, Status};
@@ -1600,16 +1600,10 @@ impl proto::rib_service_server::RibService for RibService {
             )
         };
 
-        // Subscribe to route events from the RIB manager
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::SubscribeRouteEvents { reply: reply_tx })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-
-        let broadcast_rx = reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+        let broadcast_rx = rib_manager_read(&self.rib_tx, |reply| {
+            RibUpdate::SubscribeRouteEvents { reply }
+        })
+        .await?;
 
         let metrics = self.metrics.clone();
         let subscriber_guard = metrics.event_stream_subscriber_guard("watch_routes", "route");
@@ -1651,15 +1645,10 @@ impl proto::rib_service_server::RibService for RibService {
             )
         };
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::SubscribeRouteEvents { reply: reply_tx })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-
-        let broadcast_rx = reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+        let broadcast_rx = rib_manager_read(&self.rib_tx, |reply| {
+            RibUpdate::SubscribeRouteEvents { reply }
+        })
+        .await?;
 
         let metrics = self.metrics.clone();
         let subscriber_guard = metrics.event_stream_subscriber_guard("watch_route_events", "route");
@@ -2755,6 +2744,38 @@ mod tests {
         UnaryRibRead::ListOrrStatus,
     ];
 
+    #[derive(Clone, Copy, Debug)]
+    enum RibWatchAdmission {
+        WatchRoutes,
+        WatchRouteEvents,
+    }
+
+    const RIB_WATCH_ADMISSIONS: [RibWatchAdmission; 2] = [
+        RibWatchAdmission::WatchRoutes,
+        RibWatchAdmission::WatchRouteEvents,
+    ];
+
+    async fn invoke_rib_watch_admission(
+        service: &RibService,
+        rpc: RibWatchAdmission,
+    ) -> Result<(), Status> {
+        let request = proto::WatchRoutesRequest::default();
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            match rpc {
+                RibWatchAdmission::WatchRoutes => service
+                    .watch_routes(Request::new(request))
+                    .await
+                    .map(|_| ()),
+                RibWatchAdmission::WatchRouteEvents => service
+                    .watch_route_events(Request::new(request))
+                    .await
+                    .map(|_| ()),
+            }
+        })
+        .await
+        .expect("RIB watch admission timed out")
+    }
+
     async fn invoke_unary_rib_read(svc: &RibService, rpc: UnaryRibRead) -> Result<(), Status> {
         match rpc {
             UnaryRibRead::ListReceivedRoutes => svc
@@ -2856,6 +2877,42 @@ mod tests {
                 .await
                 .unwrap_err();
             actor.await.unwrap();
+            assert_eq!(error.code(), tonic::Code::Unavailable, "{rpc:?}");
+            assert_eq!(error.message(), "RIB manager dropped reply", "{rpc:?}");
+        }
+    }
+
+    /// Load-bearing: restoring either watch admission's actor-send mapping to
+    /// `INTERNAL` makes its actual-handler row red.
+    #[tokio::test]
+    async fn rib_watch_admission_send_failures_are_unavailable() {
+        for rpc in RIB_WATCH_ADMISSIONS {
+            let (tx, rx) = mpsc::channel(1);
+            drop(rx);
+            let error = invoke_rib_watch_admission(&RibService::new(tx), rpc)
+                .await
+                .unwrap_err();
+            assert_eq!(error.code(), tonic::Code::Unavailable, "{rpc:?}");
+            assert_eq!(error.message(), "RIB manager unavailable", "{rpc:?}");
+        }
+    }
+
+    /// Load-bearing: restoring either watch admission's reply-await mapping to
+    /// `INTERNAL` makes its accepted-then-dropped actual-handler row red.
+    #[tokio::test]
+    async fn rib_watch_admission_reply_drops_are_unavailable() {
+        for rpc in RIB_WATCH_ADMISSIONS {
+            let (tx, mut rx) = mpsc::channel(1);
+            let actor = tokio::spawn(async move {
+                drop(rx.recv().await.expect("RIB watch admission"));
+            });
+            let error = invoke_rib_watch_admission(&RibService::new(tx), rpc)
+                .await
+                .unwrap_err();
+            tokio::time::timeout(std::time::Duration::from_secs(1), actor)
+                .await
+                .expect("RIB actor join timed out")
+                .unwrap();
             assert_eq!(error.code(), tonic::Code::Unavailable, "{rpc:?}");
             assert_eq!(error.message(), "RIB manager dropped reply", "{rpc:?}");
         }


### PR DESCRIPTION
## Summary

- normalize pre-stream actor admission failures for route and event watches to stable `UNAVAILABLE` statuses
- reuse the shared read-only actor boundary without changing post-admission closure or lag semantics
- add actual-handler matrices for both actor failure modes and cleanup receipts for partially admitted multi-source watches

## Load-bearing proof

- restoring the previous `INTERNAL` mappings makes both the RIB and event admission matrices fail on exact status
- retaining an earlier admitted stream or subscriber guard makes the cleanup receipts fail with a live receiver and nonzero gauge
- every handler call and actor join in the new failure harness is bounded at one second

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- independent attack review of the frozen patch
