### PR TITLE
docs: fence published embedding versions

### DIFF
--- a/.github/workflows/embedding-doc-contract.yml
+++ b/.github/workflows/embedding-doc-contract.yml
@@ -1,0 +1,26 @@
+name: Embedding docs contract
+
+on:
+  push:
+    branches: [main]
+    paths: &paths
+      - docs/EMBEDDING.md
+      - docs/RELEASE_CHECKLIST.md
+      - scripts/check_embedding_versions.py
+      - scripts/test_check_embedding_versions.py
+      - .github/workflows/embedding-doc-contract.yml
+  pull_request:
+    paths: *paths
+
+permissions:
+  contents: read
+
+jobs:
+  embedding-doc-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Check published crate boundary
+        run: |
+          python3 -m unittest -v scripts.test_check_embedding_versions
+          python3 scripts/check_embedding_versions.py

--- a/.github/workflows/embedding-doc-contract.yml
+++ b/.github/workflows/embedding-doc-contract.yml
@@ -22,5 +22,5 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Check published crate boundary
         run: |
-          python3 -m unittest -v scripts.test_check_embedding_versions
+          python3 -m unittest -v scripts/test_check_embedding_versions.py
           python3 scripts/check_embedding_versions.py

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -15,8 +15,8 @@ This document is the contract for embedders: which crate to depend on, what the
 
 | Crate                    | Published? | Depends on (internal)              | Deps (external)            | Stability target | Role for embedders |
 |--------------------------|-----------|-----------------------------------|----------------------------|------------------|--------------------|
-| `rustbgpd-wire`          | **Yes** — crates.io `0.15.0` | none (internal)            | `bytes`, `thiserror`      | **Stable codec** | The one to link. Pure encode/decode. |
-| `rustbgpd-fsm`           | **Yes** — crates.io `0.3.0` | `rustbgpd-wire`            | `thiserror`, `bytes`      | Pure FSM API     | Pure RFC 4271 FSM; no I/O. |
+| `rustbgpd-wire`          | **Yes** — crates.io `0.16.1` | none (internal)            | `bytes`, `thiserror`      | **Stable codec** | The one to link. Pure encode/decode. |
+| `rustbgpd-fsm`           | **Yes** — crates.io `0.3.1` | `rustbgpd-wire`            | `thiserror`, `bytes`      | Pure FSM API     | Pure RFC 4271 FSM; no I/O. |
 | `rustbgpd-rpki`          | No (`publish = false`) | `rustbgpd-wire`            | `tokio`, `tracing`, `smallvec` | Publish next     | VRP table + RTR client. |
 | `rustbgpd-rib`           | No (`publish = false`) | wire, policy, telemetry, rpki     | `prefix-trie`, `ipnet`, ... | Later            | Adj/Loc-RIB; heavier. |
 | `rustbgpd-policy`        | No (`publish = false`) | wire                    | `arc-swap`, `ariadne`, `logos`, `regex`, `sha2`, ... | Later | Import/export policy. |
@@ -118,7 +118,7 @@ in a minor release without a semver-major break. Closed-by-construction sets
 `RpkiValidation`) stay exhaustively matchable on purpose. `crates/wire/README.md`
 carries the full split under "Enum exhaustiveness".
 
-**The prepared 0.16.0 change** is additive at the API level, but **decode
+**The 0.16.0 release** is additive at the API level, but **decode
 acceptance or type classification changed in six places** — bytes that decoded
 under 0.15.0 may now be rejected or typed differently. `crates/wire/README.md`
 carries the itemized list under "0.16.0 compatibility note"; diff exactly that
@@ -143,7 +143,7 @@ This is the "MRT reader / monitor / analyzer" consumer. Links only
 ```toml
 # Cargo.toml
 [dependencies]
-rustbgpd-wire = "0.15.0"
+rustbgpd-wire = "0.16.1"
 bytes = "1"
 ```
 
@@ -203,8 +203,8 @@ intentional split (ADR-0002: inherent methods, no I/O in the FSM).
 ```toml
 # Cargo.toml
 [dependencies]
-rustbgpd-wire = "0.15.0"
-rustbgpd-fsm = "0.3.0"
+rustbgpd-wire = "0.16.1"
+rustbgpd-fsm = "0.3.1"
 bytes = "1"
 tokio = { version = "1", features = ["net", "io-util", "time", "rt"] }
 ```
@@ -302,17 +302,19 @@ once that crate is published.
 **Status: `wire` → `fsm` are published; `rpki` is next; `rib`, `bmp`, `mrt`,
 and `policy` are later.**
 
-1. **`rustbgpd-wire` (published as `0.15.0`; `0.16.0` prepared).** This is the
+1. **`rustbgpd-wire` (published as `0.16.1`).** This is the
    foundation — dependent crate versions cannot publish before their wire
    dependency exists on crates.io. `0.15.0` brought `Capability::PathsLimit`
    with its `PathsLimitFamily` entry type (experimental capability code 76),
    the `Ord` implementation on `EvpnRouteKey`, and `#[non_exhaustive]` across
-   the registry-tracking enums. The prepared `0.16.0` is additive at the API
+   the registry-tracking enums. The `0.16.0` release is additive at the API
    level with six binary decode-acceptance changes plus the separate additive
-   Route Distinguisher text-parser change described in §2.3.
+   Route Distinguisher text-parser change described in §2.3. `0.16.1` is a
+   documentation/rustdoc-only release correcting RFC 7606 retained-attribute
+   wording; it has no library-code, public-API, or decode-behavior change.
 
-2. **`rustbgpd-fsm` (published as `0.3.0`; `0.3.1` prepared).** The prepared
-   `0.3.1` keeps the public API backward-compatible: `PeerConfig` gains
+2. **`rustbgpd-fsm` (published as `0.3.1`).** The `0.3.1` release keeps the
+   public API backward-compatible: `PeerConfig` gains
    `min_hold_time` and `required_families`, and `PeerConfig` is
    `#[non_exhaustive]`, so external construction through `PeerConfig::new` is
    unaffected. Negotiation behavior also carries conformance fixes: the last
@@ -405,10 +407,9 @@ To be the de facto Rust BGP codec, the concrete gaps:
 
 ## 7. Published-crate release boundary
 
-`rustbgpd-wire 0.15.0` and `rustbgpd-fsm 0.3.0` are published and are the
-versions the §3 dependency examples name. The next cut prepares
-`rustbgpd-wire 0.16.0` and `rustbgpd-fsm 0.3.1`; the ordering rules that govern
-it, and every publish after it, are:
+`rustbgpd-wire 0.16.1` and `rustbgpd-fsm 0.3.1` are published and are the
+versions the §3 dependency examples name. The ordering rules that govern every
+future publish are:
 
 - Publish `rustbgpd-wire` first, then verify it is registry-visible. Only then
   run the fully verified package/dry-run gate for `rustbgpd-fsm`. Cargo
@@ -416,7 +417,7 @@ it, and every publish after it, are:
   version, so a full FSM package verify cannot resolve before that wire release
   is present in the registry.
 - Keep the dependency examples in §3 pinned to the versions actually available
-  from crates.io — never to a version prepared in-repo but not yet published.
+  from crates.io — never to a version not yet published.
 - Both crates keep their package metadata and README; the README is the rendered
   docs.rs landing page and carries the per-version compatibility notes.
 - Treat any additional crate publish as separate, demand-gated work.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -645,6 +645,9 @@ changed.
 4. Add a `rustbgpd-wire` entry in `CHANGELOG.md`
 5. `cargo publish -p rustbgpd-wire --dry-run`
 6. `cargo publish -p rustbgpd-wire`
+7. Verify the version is visible in the registry, update the declared current
+   boundary and dependency snippets in `docs/EMBEDDING.md`, then run
+   `python3 scripts/check_embedding_versions.py`.
 
 **Wire crate semver:**
 - **Patch**: bug fixes, stricter validation, docs/test improvements
@@ -673,3 +676,6 @@ do not force an FSM release for every daemon tag.
 4. Add a `rustbgpd-fsm` entry in `CHANGELOG.md`
 5. `cargo publish -p rustbgpd-fsm --dry-run`
 6. `cargo publish -p rustbgpd-fsm`
+7. Verify the version is visible in the registry, update the declared current
+   boundary and dependency snippets in `docs/EMBEDDING.md`, then run
+   `python3 scripts/check_embedding_versions.py`.

--- a/scripts/check_embedding_versions.py
+++ b/scripts/check_embedding_versions.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import re
 import sys
 from pathlib import Path

--- a/scripts/check_embedding_versions.py
+++ b/scripts/check_embedding_versions.py
@@ -1,0 +1,61 @@
+import re
+import sys
+from pathlib import Path
+
+
+PACKAGES = ("wire", "fsm")
+
+
+def section(document: str, start: str, end: str) -> str:
+    rest = document.partition(start)[2].partition("\n")[2]
+    body, marker, _ = rest.partition(end)
+    return body if marker else ""
+
+
+def check(document: str) -> list[str]:
+    errors: list[str] = []
+    boundary = section(document, "## 7. ", "## 8. ").lstrip().split("\n\n", 1)[0]
+    current = re.findall(r"`rustbgpd-(wire|fsm) ([^`]+)`", boundary)
+    versions = dict(current)
+    if len(current) != len(PACKAGES) or set(versions) != set(PACKAGES):
+        return ["current-boundary-version"]
+
+    examples = {
+        "wire": (
+            section(document, "### 3.1 ", "### 3.2 "),
+            section(document, "### 3.3 ", "### 3.4 "),
+        ),
+        "fsm": (section(document, "### 3.3 ", "### 3.4 "),),
+    }
+    for package, bodies in examples.items():
+        assignment = re.compile(rf'^rustbgpd-{package} = "([^"]+)"$', re.MULTILINE)
+        found = [match for body in bodies for match in assignment.findall(body)]
+        if found != [versions[package]] * len(bodies):
+            errors.append(f"{package}-snippet-version")
+
+    publish = re.findall(
+        r"^\d+\. \*\*`rustbgpd-(wire|fsm)` \(published as `([^`]+)`\)\.\*\*",
+        section(document, "## 4. ", "## 5. "),
+        re.MULTILINE,
+    )
+    if len(publish) != len(PACKAGES) or dict(publish) != versions:
+        errors.append("publish-status-version")
+
+    if re.search(r"\bprepared\b", document, re.IGNORECASE):
+        errors.append("forbidden-prepared")
+    return errors
+
+
+def main() -> int:
+    if len(sys.argv) > 2:
+        raise SystemExit(f"usage: {Path(sys.argv[0]).name} [EMBEDDING.md]")
+    default = Path(__file__).resolve().parents[1] / "docs" / "EMBEDDING.md"
+    path = Path(sys.argv[1]) if len(sys.argv) == 2 else default
+    errors = check(path.read_text(encoding="utf-8"))
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+    return int(bool(errors))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_embedding_versions.py
+++ b/scripts/test_check_embedding_versions.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+"""Mutation proofs for the embedding-version documentation contract."""
+
 import subprocess
 import sys
 import tempfile

--- a/scripts/test_check_embedding_versions.py
+++ b/scripts/test_check_embedding_versions.py
@@ -1,0 +1,83 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER = ROOT / "scripts" / "check_embedding_versions.py"
+DOCUMENT = (ROOT / "docs" / "EMBEDDING.md").read_text(encoding="utf-8")
+
+
+class EmbeddingVersionContractTests(unittest.TestCase):
+    def run_checker(self, document: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "EMBEDDING.md"
+            path.write_text(document, encoding="utf-8")
+            return subprocess.run(
+                [sys.executable, str(CHECKER), str(path)],
+                capture_output=True,
+                text=True,
+            )
+
+    def assert_fails(self, document: str, diagnostic: str) -> None:
+        result = self.run_checker(document)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(diagnostic, result.stdout + result.stderr)
+
+    def replace_nth(self, old: str, new: str, occurrence: int = 0) -> str:
+        start = -1
+        for _ in range(occurrence + 1):
+            start = DOCUMENT.find(old, start + 1)
+        self.assertGreaterEqual(start, 0)
+        return DOCUMENT[:start] + new + DOCUMENT[start + len(old) :]
+
+    def test_each_wire_snippet_is_guarded(self) -> None:
+        """Red if either wire dependency example drifts to 0.15.0."""
+        old = 'rustbgpd-wire = "0.16.1"'
+        for occurrence in (0, 1):
+            with self.subTest(occurrence=occurrence):
+                self.assert_fails(
+                    self.replace_nth(old, 'rustbgpd-wire = "0.15.0"', occurrence),
+                    "wire-snippet-version",
+                )
+
+    def test_fsm_snippet_is_guarded(self) -> None:
+        """Red if the FSM dependency example drifts to 0.3.0."""
+        self.assert_fails(
+            self.replace_nth('rustbgpd-fsm = "0.3.1"', 'rustbgpd-fsm = "0.3.0"'),
+            "fsm-snippet-version",
+        )
+
+    def test_publish_statuses_are_guarded(self) -> None:
+        """Red if either numbered publish heading names an old version."""
+        mutations = (("wire", "0.16.1", "0.16.0"), ("fsm", "0.3.1", "0.3.0"))
+        for package, current, old in mutations:
+            with self.subTest(package=package):
+                self.assert_fails(
+                    self.replace_nth(
+                        f"(published as `{current}`)", f"(published as `{old}`)"
+                    ),
+                    "publish-status-version",
+                )
+
+    def test_current_boundary_is_guarded(self) -> None:
+        """Red if §7 loses either authoritative current-version slot."""
+        self.assert_fails(
+            self.replace_nth("`rustbgpd-fsm 0.3.1`", "rustbgpd-fsm 0.3.1"),
+            "current-boundary-version",
+        )
+
+    def test_prepared_language_is_forbidden(self) -> None:
+        """Red if a published release is again described as prepared."""
+        self.assert_fails(
+            self.replace_nth(
+                "**The 0.16.0 release**", "**The prepared 0.16.0 release**"
+            ),
+            "forbidden-prepared",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- update the embedder guide to the published `rustbgpd-wire 0.16.1` and `rustbgpd-fsm 0.3.1` boundary
- add a path-scoped contract that keeps the dependency examples and publish statuses aligned with the authoritative boundary
- require post-publish registry verification and guide updates in the release checklist

## Contract

Section 7 is the sole source of the current published pair. The checker deliberately does not inspect the crate map in section 1, so the package-inventory contract can evolve independently.

The workflow is Markdown-path scoped, uses only the Python standard library, performs no registry access, and pins checkout to an exact v7 SHA. Registry visibility remains an explicit human release step.

## Load-bearing proofs

Each mutation test names the production break that makes it red:

- removing either current-version slot from section 7 fails boundary extraction
- reverting either wire dependency snippet fails `wire-snippet-version`
- reverting the FSM dependency snippet fails `fsm-snippet-version`
- reverting either numbered publish status fails `publish-status-version`
- restoring `prepared` language fails `forbidden-prepared`

The checked-in document is then run through the same checker separately.

## Verification

- `python3 scripts/check_embedding_versions.py`
- `python3 -m unittest -v scripts.test_check_embedding_versions`
- `black --check scripts/check_embedding_versions.py scripts/test_check_embedding_versions.py`
- workflow YAML safe-load
- live `cargo info` for wire 0.16.1 and FSM 0.3.1
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
