### PR TITLE
docs: verify the embedding crate map

### DIFF
--- a/.github/workflows/embedding-doc-contract.yml
+++ b/.github/workflows/embedding-doc-contract.yml
@@ -6,7 +6,11 @@ on:
     paths: &paths
       - docs/EMBEDDING.md
       - docs/RELEASE_CHECKLIST.md
+      - Cargo.toml
+      - '**/Cargo.toml'
+      - scripts/check_embedding_crate_map.py
       - scripts/check_embedding_versions.py
+      - scripts/test_check_embedding_crate_map.py
       - scripts/test_check_embedding_versions.py
       - .github/workflows/embedding-doc-contract.yml
   pull_request:
@@ -24,3 +28,7 @@ jobs:
         run: |
           python3 -m unittest -v scripts/test_check_embedding_versions.py
           python3 scripts/check_embedding_versions.py
+      - name: Check embedding crate map
+        run: |
+          python3 -m unittest -v scripts/test_check_embedding_crate_map.py
+          python3 scripts/check_embedding_crate_map.py

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -13,34 +13,44 @@ This document is the contract for embedders: which crate to depend on, what the
 
 ## 1. Crate map and publish status
 
-| Crate                    | Published? | Depends on (internal)              | Deps (external)            | Stability target | Role for embedders |
-|--------------------------|-----------|-----------------------------------|----------------------------|------------------|--------------------|
-| `rustbgpd-wire`          | **Yes** — crates.io `0.16.1` | none (internal)            | `bytes`, `thiserror`      | **Stable codec** | The one to link. Pure encode/decode. |
-| `rustbgpd-fsm`           | **Yes** — crates.io `0.3.1` | `rustbgpd-wire`            | `thiserror`, `bytes`      | Pure FSM API     | Pure RFC 4271 FSM; no I/O. |
-| `rustbgpd-rpki`          | No (`publish = false`) | `rustbgpd-wire`            | `tokio`, `tracing`, `smallvec` | Publish next     | VRP table + RTR client. |
-| `rustbgpd-rib`           | No (`publish = false`) | wire, policy, telemetry, rpki     | `prefix-trie`, `ipnet`, ... | Later            | Adj/Loc-RIB; heavier. |
-| `rustbgpd-policy`        | No (`publish = false`) | wire                    | `arc-swap`, `ariadne`, `logos`, `regex`, `sha2`, ... | Later | Import/export policy. |
-| `rustbgpd-transport`     | No (`publish = false`) | wire, fsm, rib, rpki, policy, telemetry, bmp | `tokio`, `socket2`, ... | Later (daemon-tier) | Async session runtime. |
-| `rustbgpd-api`           | No (`publish = false`) | (codegen)                | `tonic`, `prost`           | Never as a lib   | gRPC server types. External clients generate from the proto instead — see §3.4. |
-| `rustbgpd-bmp`           | No (`publish = false`) | telemetry                | `tokio`                    | After rib        | RFC 7854 BMP export. |
-| `rustbgpd-mrt`           | No (`publish = false`) | wire, rib                | `flate2`, `chrono`         | After rib        | RFC 6396 dump export. |
-| `rustbgpd-evpn`          | No (`publish = false`) | wire                     | `thiserror`, `tracing`     | Daemon-tier      | EVPN origination. |
-| `rustbgpd-evpn-linux`    | No (`publish = false`) | (internal)                | `rtnetlink`, `nix`         | Never (Linux-specific) | Kernel dataplane. |
-| `rustbgpd` (daemon bin)  | No (`publish = false`) | all                            | —                          | N/A              | The daemon. Not a library. |
+<!-- BEGIN EMBEDDING CRATE MAP -->
+| Package | Cargo publish | Internal normal/build path dependencies | Role |
+|---------|---------------|-----------------------------------------|------|
+| `birdwatcher-adapter` | Disabled | `rustbgpd-api` | Birdwatcher-compatible REST adapter backed by the daemon gRPC API. |
+| `event-bridge` | Disabled | `rustbgpd-api` | Reference durable-event collector bridge. |
+| `rs-config-render` | Disabled | None | Route-server configuration rendering tool. |
+| `rustbgpctl` | Disabled | `rustbgpd-policy`, `rustbgpd-wire` | Thin gRPC management CLI and support library. |
+| `rustbgpd` | Disabled | `rustbgpd-api`, `rustbgpd-bfd`, `rustbgpd-bmp`, `rustbgpd-event-history`, `rustbgpd-evpn`, `rustbgpd-evpn-linux`, `rustbgpd-fsm`, `rustbgpd-mrt`, `rustbgpd-policy`, `rustbgpd-rib`, `rustbgpd-rpki`, `rustbgpd-telemetry`, `rustbgpd-transport`, `rustbgpd-wire` | Daemon binary and internal assembly library. |
+| `rustbgpd-api` | Disabled | `rustbgpd-event-history`, `rustbgpd-evpn`, `rustbgpd-fsm`, `rustbgpd-policy`, `rustbgpd-rib`, `rustbgpd-telemetry`, `rustbgpd-transport`, `rustbgpd-wire` | gRPC server, generated bindings, and service types. |
+| `rustbgpd-bfd` | Disabled | None | Pure BFD packet codec and session state machine. |
+| `rustbgpd-bmp` | Disabled | `rustbgpd-telemetry`, `rustbgpd-wire` | RFC 7854 BMP export. |
+| `rustbgpd-event-history` | Disabled | `rustbgpd-telemetry` | Durable local event outbox. |
+| `rustbgpd-evpn` | Disabled | `rustbgpd-wire` | EVPN VTEP domain model. |
+| `rustbgpd-evpn-linux` | Disabled | `rustbgpd-evpn` | Linux netlink EVPN dataplane reconciler. |
+| `rustbgpd-evpn-load` | Disabled | `rustbgpd-wire` | EVPN route-reflector benchmark load generator. |
+| `rustbgpd-fsm` | Enabled | `rustbgpd-wire` | Pure RFC 4271 FSM; no I/O. |
+| `rustbgpd-mrt` | Disabled | `rustbgpd-rib`, `rustbgpd-wire` | RFC 6396 MRT dump export. |
+| `rustbgpd-policy` | Disabled | `rustbgpd-wire` | Import/export policy engine. |
+| `rustbgpd-rib` | Disabled | `rustbgpd-bmp`, `rustbgpd-policy`, `rustbgpd-rpki`, `rustbgpd-telemetry`, `rustbgpd-wire` | Adj-RIB and Loc-RIB best-path data structures. |
+| `rustbgpd-rpki` | Disabled | `rustbgpd-wire` | VRP table, RTR client, and origin validation. |
+| `rustbgpd-telemetry` | Disabled | None | Prometheus metrics and structured tracing. |
+| `rustbgpd-transport` | Disabled | `rustbgpd-bmp`, `rustbgpd-fsm`, `rustbgpd-policy`, `rustbgpd-rib`, `rustbgpd-rpki`, `rustbgpd-telemetry`, `rustbgpd-wire` | Async TCP session runtime. |
+| `rustbgpd-wire` | Enabled | None | Pure BGP message encode/decode. |
+<!-- END EMBEDDING CRATE MAP -->
 
-Only `rustbgpd-wire` and `rustbgpd-fsm` are on crates.io. Every other crate in
-the workspace carries `publish = false` and cannot be named as a dependency by
-a project outside this repository — including `rustbgpd-api`. A consumer that
-needs the daemon's gRPC surface generates a client from the proto (§3.4).
+All Cargo workspace packages are listed. Internal dependencies include normal and build dependencies, including target-specific dependencies; dev dependencies are excluded.
 
-**Publish order and why:** the dependency DAG drives the order: `fsm` depends
-only on `wire`; `rpki` depends only on `wire`; `rib` depends on
-`wire + policy + telemetry + rpki`. Publishing in this order means each
-published crate has only *already-published* (or external) dependencies, which
-is a hard crates.io requirement. `fsm` shipped before `rpki` because it is the
-smaller, purer, and more broadly useful building block — a test harness or a
-minimal speaker needs the fsm but not the RPKI table. `rpki` is the next
-candidate. See §4 for the full rationale.
+Only `rustbgpd-wire` and `rustbgpd-fsm` are registry-published releases from
+this workspace. `Disabled` means this repository's package manifest sets
+`publish = false`; it makes no claim about unrelated registry packages with a
+similar name. These workspace packages can still be consumed through git or
+path dependencies, including from outside this repository. A consumer that
+needs the daemon's gRPC surface can instead generate a client from the proto
+(§3.4).
+
+This map records the current workspace topology, not a publication sequence.
+Notably, `rustbgpd-rib` depends on `rustbgpd-bmp`; §4 discusses future
+publication candidates and the gates that would apply.
 
 ---
 

--- a/scripts/check_embedding_crate_map.py
+++ b/scripts/check_embedding_crate_map.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Check that the embedding crate map matches locked, offline Cargo metadata."""
+
+import json
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCUMENT = ROOT / "docs" / "EMBEDDING.md"
+COMMAND = (
+    "cargo",
+    "metadata",
+    "--locked",
+    "--offline",
+    "--format-version",
+    "1",
+    "--no-deps",
+)
+BEGIN = "<!-- BEGIN EMBEDDING CRATE MAP -->"
+END = "<!-- END EMBEDDING CRATE MAP -->"
+SCOPE = (
+    "All Cargo workspace packages are listed. Internal dependencies include "
+    "normal and build dependencies, including target-specific dependencies; "
+    "dev dependencies are excluded."
+)
+
+
+def cargo_metadata(root: Path = ROOT) -> dict:
+    result = subprocess.run(COMMAND, cwd=root, capture_output=True, text=True)
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip() or "cargo metadata failed")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(f"invalid cargo metadata JSON: {error}") from error
+
+
+def expected_rows(metadata: dict) -> dict[str, tuple[str, tuple[str, ...]]]:
+    members = set(metadata["workspace_members"])
+    packages = [package for package in metadata["packages"] if package["id"] in members]
+    names = {package["name"] for package in packages}
+    rows = {}
+    for package in packages:
+        dependencies = sorted(
+            {
+                dependency["name"]
+                for dependency in package["dependencies"]
+                if dependency.get("kind") in (None, "build")
+                and dependency.get("path") is not None
+                and dependency["name"] in names
+            }
+        )
+        publish = "Disabled" if package.get("publish") == [] else "Enabled"
+        rows[package["name"]] = (publish, tuple(dependencies))
+    return rows
+
+
+def table_rows(document: str) -> list[tuple[str, str, str]]:
+    if document.count(BEGIN) != 1 or document.count(END) != 1:
+        raise ValueError("crate-map markers must each appear exactly once")
+    _, _, rest = document.partition(BEGIN)
+    body, _, _ = rest.partition(END)
+    rows = []
+    for line in body.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) != 4 or cells[0] == "Package" or set(cells[0]) <= {"-"}:
+            continue
+        name = (
+            cells[0][1:-1]
+            if cells[0].startswith("`") and cells[0].endswith("`")
+            else cells[0]
+        )
+        rows.append((name, cells[1], cells[2]))
+    return rows
+
+
+def diagnostic(kind: str, detail: str) -> str:
+    return f"EMBEDDING_CRATE_MAP_{kind}: {detail}"
+
+
+def check(document: str, metadata: dict) -> list[str]:
+    errors = []
+    if document.count(f"{END}\n\n{SCOPE}\n") != 1:
+        errors.append(diagnostic("SCOPE", "checked-scope sentence differs"))
+    try:
+        rows = table_rows(document)
+        expected = expected_rows(metadata)
+    except ValueError as error:
+        return errors + [diagnostic("SCOPE", str(error))]
+    except (KeyError, TypeError) as error:
+        return errors + [diagnostic("METADATA", str(error))]
+
+    counts = Counter(name for name, _, _ in rows)
+    actual = set(counts)
+    for name in sorted(set(expected) - actual):
+        errors.append(diagnostic("MISSING", name))
+    for name in sorted(actual - set(expected)):
+        errors.append(diagnostic("EXTRA", name))
+    for name in sorted(name for name, count in counts.items() if count != 1):
+        errors.append(diagnostic("DUPLICATE", name))
+
+    by_name = {name: (publish, dependencies) for name, publish, dependencies in rows}
+    for name in sorted(set(expected) & actual):
+        if counts[name] != 1:
+            continue
+        publish, dependencies = by_name[name]
+        expected_publish, expected_dependencies = expected[name]
+        if publish != expected_publish:
+            errors.append(
+                diagnostic(
+                    "PUBLISH",
+                    f"{name} documented={publish} metadata={expected_publish}",
+                )
+            )
+        rendered = (
+            "None"
+            if not expected_dependencies
+            else ", ".join(f"`{dependency}`" for dependency in expected_dependencies)
+        )
+        if dependencies != rendered:
+            errors.append(
+                diagnostic(
+                    "DEPS",
+                    f"{name} documented=[{dependencies}] metadata=[{rendered}]",
+                )
+            )
+    return errors
+
+
+def main() -> int:
+    if len(sys.argv) > 2:
+        raise SystemExit(f"usage: {Path(sys.argv[0]).name} [EMBEDDING.md]")
+    path = Path(sys.argv[1]) if len(sys.argv) == 2 else DOCUMENT
+    try:
+        errors = check(path.read_text(encoding="utf-8"), cargo_metadata())
+    except (OSError, RuntimeError) as error:
+        errors = [diagnostic("METADATA", str(error))]
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+    return int(bool(errors))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_embedding_crate_map.py
+++ b/scripts/check_embedding_crate_map.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Check that the embedding crate map matches locked, offline Cargo metadata."""
 
+from __future__ import annotations
+
 import json
 import subprocess
 import sys
@@ -10,15 +12,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 DOCUMENT = ROOT / "docs" / "EMBEDDING.md"
-COMMAND = (
-    "cargo",
-    "metadata",
-    "--locked",
-    "--offline",
-    "--format-version",
-    "1",
-    "--no-deps",
-)
+COMMAND = "cargo metadata --locked --offline --format-version 1 --no-deps".split()
 BEGIN = "<!-- BEGIN EMBEDDING CRATE MAP -->"
 END = "<!-- END EMBEDDING CRATE MAP -->"
 SCOPE = (

--- a/scripts/test_check_embedding_crate_map.py
+++ b/scripts/test_check_embedding_crate_map.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Mutation proofs for the embedding crate-map documentation contract."""
+
+import copy
+import unittest
+from pathlib import Path
+
+from scripts import check_embedding_crate_map as checker
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCUMENT = (ROOT / "docs" / "EMBEDDING.md").read_text(encoding="utf-8")
+
+
+class EmbeddingCrateMapTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.metadata = checker.cargo_metadata()
+
+    def assert_red(self, document: str, diagnostic: str, metadata=None) -> None:
+        errors = checker.check(document, metadata or self.metadata)
+        self.assertTrue(any(error.startswith(diagnostic) for error in errors), errors)
+
+    @staticmethod
+    def row(package: str) -> str:
+        return next(
+            line
+            for line in DOCUMENT.splitlines()
+            if line.startswith(f"| `{package}` |")
+        )
+
+    def test_added_rib_edge_is_guarded(self) -> None:
+        """Red if the RIB row invents an internal FSM dependency edge."""
+        old = "`rustbgpd-bmp`, `rustbgpd-policy`"
+        changed = "`rustbgpd-bmp`, `rustbgpd-fsm`, `rustbgpd-policy`"
+        self.assert_red(DOCUMENT.replace(old, changed, 1), "EMBEDDING_CRATE_MAP_DEPS")
+
+    def test_removed_rib_edge_is_guarded(self) -> None:
+        """Red if the RIB row drops its real internal BMP dependency edge."""
+        self.assert_red(
+            DOCUMENT.replace(
+                "`rustbgpd-bmp`, `rustbgpd-policy`", "`rustbgpd-policy`", 1
+            ),
+            "EMBEDDING_CRATE_MAP_DEPS",
+        )
+
+    def test_deleted_bfd_row_is_guarded(self) -> None:
+        """Red if the BFD workspace package row is deleted from the map."""
+        self.assert_red(
+            DOCUMENT.replace(self.row("rustbgpd-bfd") + "\n", "", 1),
+            "EMBEDDING_CRATE_MAP_MISSING",
+        )
+
+    def test_new_workspace_package_is_guarded(self) -> None:
+        """Red if metadata gains a workspace package without a documentation row."""
+        metadata = copy.deepcopy(self.metadata)
+        package = {
+            "id": "path+file:///synthetic#rustbgpd-new@0.1.0",
+            "name": "rustbgpd-new",
+            "publish": [],
+            "dependencies": [],
+        }
+        metadata["packages"].append(package)
+        metadata["workspace_members"].append(package["id"])
+        self.assert_red(DOCUMENT, "EMBEDDING_CRATE_MAP_MISSING", metadata)
+
+    def test_extra_document_row_is_guarded(self) -> None:
+        """Red if the map claims a package outside the Cargo workspace."""
+        row = "| `rustbgpd-ghost` | Disabled | None | Not a package. |\n"
+        changed = DOCUMENT.replace(checker.END, row + checker.END, 1)
+        self.assert_red(changed, "EMBEDDING_CRATE_MAP_EXTRA")
+
+    def test_scope_sentence_is_guarded(self) -> None:
+        """Red if scope or either marker's exact cardinality drifts."""
+        start, end = DOCUMENT.index(checker.BEGIN), DOCUMENT.index(checker.END)
+        fenced = DOCUMENT[start : end + len(checker.END)]
+        suffixes = (checker.BEGIN, checker.END, fenced)
+        changes = [DOCUMENT.replace(checker.SCOPE, "Drifted.", 1)]
+        changes.extend(DOCUMENT + suffix for suffix in suffixes)
+        for changed in changes:
+            self.assert_red(changed, "EMBEDDING_CRATE_MAP_SCOPE")
+
+    def test_dependency_kind_scope_is_load_bearing(self) -> None:
+        """Red if build/target edges are dropped or dev edges are included."""
+        for kind, target in (("build", None), (None, 'cfg(target_os = "linux")')):
+            metadata = copy.deepcopy(self.metadata)
+            rib = next(p for p in metadata["packages"] if p["name"] == "rustbgpd-rib")
+            edge = next(d for d in rib["dependencies"] if d["name"] == "rustbgpd-bmp")
+            edge["kind"], edge["target"] = kind, target
+            self.assertEqual(checker.check(DOCUMENT, metadata), [])
+        metadata = copy.deepcopy(self.metadata)
+        bfd = next(p for p in metadata["packages"] if p["name"] == "rustbgpd-bfd")
+        edge = {
+            "name": "rustbgpd-wire",
+            "kind": "dev",
+            "path": "/synthetic/wire",
+        }
+        bfd["dependencies"].append(edge)
+        self.assertEqual(checker.check(DOCUMENT, metadata), [])
+
+    def test_fsm_publish_flag_is_guarded(self) -> None:
+        """Red if the published FSM package is marked Cargo-publish Disabled."""
+        changed = DOCUMENT.replace(
+            self.row("rustbgpd-fsm"),
+            self.row("rustbgpd-fsm").replace("Enabled", "Disabled"),
+            1,
+        )
+        self.assert_red(changed, "EMBEDDING_CRATE_MAP_PUBLISH")
+
+    def test_duplicate_row_is_guarded(self) -> None:
+        """Red if any workspace package appears twice in the map."""
+        row = self.row("rustbgpd-bfd")
+        changed = DOCUMENT.replace(row, row + "\n" + row, 1)
+        self.assert_red(changed, "EMBEDDING_CRATE_MAP_DUPLICATE")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace the partial embedding crate list with the exact 20-package Cargo workspace map
- derive publishability and internal normal/build path dependencies from locked offline Cargo metadata
- add a path-scoped documentation contract and mutation proofs for roster, edges, publish flags, scope, and marker cardinality

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked --offline -- -D warnings`
- `cargo test --workspace --all-features --locked --offline` (1,812 workspace tests)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps --locked --offline`
- both embedding contract checkers and 14 mutation tests
- independent adversarial review: GO

## Load-bearing proofs

Each mutation test names the production/documentation break that makes it red: adding or removing a real dependency edge, deleting or inventing a package, adding a package in Cargo metadata, changing the FSM publish flag, duplicating rows or fences, drifting the checked scope, dropping build/target-specific edges, or admitting dev-only edges. The live checker also runs separately against the current document and locked metadata.