### PR TITLE
fix: reject unsupported gNMI sample intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,9 +90,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - gNMI `updates_only` STREAM/SAMPLE subscriptions now resume sampled data after
   the initial sync instead of remaining silent for the stream's lifetime.
 
-- gNMI STREAM/SAMPLE now schedules every path at its requested clamped interval
+- gNMI STREAM/SAMPLE now schedules every path at its requested interval
   instead of slowing the whole subscription to its longest interval. Co-due
   neighbor paths still share one peer snapshot, and missed periods do not burst.
+
+- gNMI STREAM/SAMPLE now rejects nonzero intervals outside the supported 1s–1h
+  range instead of silently clamping them; zero still selects the 1s floor.
 
 - Graceful Restart and Long-Lived Graceful Restart now retain an iBGP route
   source's route-reflector-client classification for as long as its stale

--- a/crates/api/src/gnmi_dialout.rs
+++ b/crates/api/src/gnmi_dialout.rs
@@ -574,6 +574,33 @@ mod tests {
         );
     }
 
+    #[test]
+    fn build_subscription_list_uses_dial_in_sample_interval_validation() {
+        let paths = [GLOBAL_AS_PATH.to_string()];
+        for interval in [
+            Duration::from_secs(1),
+            Duration::from_secs(10),
+            Duration::from_hours(1),
+        ] {
+            build_subscription_list(&paths, DialoutMode::Sample, interval)
+                .expect("an in-range SAMPLE interval must be accepted");
+        }
+
+        for (interval, raw_nanos) in [
+            (Duration::from_nanos(999_999_999), 999_999_999_u64),
+            (Duration::from_nanos(3_600_000_000_001), 3_600_000_000_001),
+        ] {
+            let err = build_subscription_list(&paths, DialoutMode::Sample, interval).unwrap_err();
+            assert_eq!(
+                err,
+                format!(
+                    "gNMI subscription 1 sample_interval {raw_nanos}ns is outside supported range \
+                     [1000000000ns, 3600000000000ns]"
+                )
+            );
+        }
+    }
+
     // ── zero-key-material pin ─────────────────────────────────────────
 
     #[test]

--- a/crates/api/src/gnmi_service.rs
+++ b/crates/api/src/gnmi_service.rs
@@ -29,7 +29,7 @@ const DEFAULT_PROTOCOL_NAME: &str = "BGP";
 const MAX_SUBSCRIPTIONS: usize = 16;
 const SUBSCRIBE_CHANNEL_DEPTH: usize = 16;
 const MIN_SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
-/// Upper bound on a client-requested `STREAM` `SAMPLE` interval. Clamps absurd
+/// Upper bound on a client-requested `STREAM` `SAMPLE` interval. Rejects absurd
 /// values (a client could otherwise request an interval of centuries) so a
 /// subscription always resamples within a sane bound.
 const MAX_SAMPLE_INTERVAL: Duration = Duration::from_hours(1);
@@ -743,7 +743,7 @@ pub(crate) struct SubscriptionPlan {
     stream_mode: Option<gnmi::SubscriptionMode>,
     paths: Vec<SupportedPath>,
     updates_only: bool,
-    /// Clamped interval for each path in a STREAM plan, in `paths` order.
+    /// Accepted interval for each path in a STREAM/SAMPLE plan, in `paths` order.
     sample_intervals: Vec<Duration>,
     encoding: gnmi::Encoding,
 }
@@ -1047,12 +1047,41 @@ fn parse_subscription_list(list: &gnmi::SubscriptionList) -> Result<Subscription
     let mut paths = Vec::with_capacity(list.subscription.len());
     let mut sample_intervals = Vec::with_capacity(list.subscription.len());
     let mut stream_mode: Option<gnmi::SubscriptionMode> = None;
-    for subscription in &list.subscription {
+    for (index, subscription) in list.subscription.iter().enumerate() {
         let path = subscription
             .path
             .as_ref()
             .ok_or_else(|| Status::invalid_argument("subscription path is required"))?;
         let full_path = combine_paths(list.prefix.as_ref(), path)?;
+        let this_mode = gnmi::SubscriptionMode::try_from(subscription.mode).map_err(|_| {
+            Status::invalid_argument(format!("unknown subscription mode {}", subscription.mode))
+        })?;
+        if mode == gnmi::subscription_list::Mode::Stream {
+            let raw_nanos = subscription.sample_interval;
+            if this_mode == gnmi::SubscriptionMode::TargetDefined && raw_nanos != 0 {
+                return Err(Status::invalid_argument(format!(
+                    "gNMI subscription {} TARGET_DEFINED sample_interval {raw_nanos}ns must be zero",
+                    index + 1
+                )));
+            }
+            let requested = if this_mode == gnmi::SubscriptionMode::Sample && raw_nanos != 0 {
+                let requested = Duration::from_nanos(raw_nanos);
+                if !(MIN_SAMPLE_INTERVAL..=MAX_SAMPLE_INTERVAL).contains(&requested) {
+                    return Err(Status::invalid_argument(format!(
+                        "gNMI subscription {} sample_interval {raw_nanos}ns is outside supported \
+                         range [{}ns, {}ns]",
+                        index + 1,
+                        MIN_SAMPLE_INTERVAL.as_nanos(),
+                        MAX_SAMPLE_INTERVAL.as_nanos()
+                    )));
+                }
+                requested
+            } else {
+                MIN_SAMPLE_INTERVAL
+            };
+            sample_intervals.push(requested);
+        }
+
         // Validate the mode against the fully-joined path so the
         // ON_CHANGE leaf check still works when the subscription
         // splits prefix and tail across `list.prefix` + `path`.
@@ -1060,20 +1089,10 @@ fn parse_subscription_list(list: &gnmi::SubscriptionList) -> Result<Subscription
         paths.push(parse_supported_path(&full_path)?);
 
         if mode == gnmi::subscription_list::Mode::Stream {
-            // Honor the client's requested interval, clamped to
-            // [MIN_SAMPLE_INTERVAL, MAX_SAMPLE_INTERVAL] (a missing/zero interval
-            // defaults to the floor; an absurd value is capped).
-            let requested = Duration::from_nanos(subscription.sample_interval)
-                .clamp(MIN_SAMPLE_INTERVAL, MAX_SAMPLE_INTERVAL);
-            sample_intervals.push(requested);
-
             // Reject mixed STREAM modes within one SubscriptionList:
             // the v1 dispatch picks SAMPLE *or* ON_CHANGE for the
             // whole task, not per-path. Two same-mode subscriptions
             // are fine.
-            let this_mode = gnmi::SubscriptionMode::try_from(subscription.mode).map_err(|_| {
-                Status::invalid_argument(format!("unknown subscription mode {}", subscription.mode))
-            })?;
             match stream_mode {
                 None => stream_mode = Some(this_mode),
                 Some(existing) if existing == this_mode => {}
@@ -2980,6 +2999,19 @@ mod tests {
         .unwrap_err();
         assert_eq!(target_defined.code(), tonic::Code::Unimplemented);
 
+        let mut target_defined_nonzero = subscription_list(
+            gnmi::subscription_list::Mode::Stream,
+            gnmi::SubscriptionMode::TargetDefined,
+            path.clone(),
+        );
+        target_defined_nonzero.subscription[0].sample_interval = 1_000_000_000;
+        let err = parse_subscription_list(&target_defined_nonzero).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert_eq!(
+            err.message(),
+            "gNMI subscription 1 TARGET_DEFINED sample_interval 1000000000ns must be zero"
+        );
+
         let mut too_many = subscription_list(
             gnmi::subscription_list::Mode::Once,
             gnmi::SubscriptionMode::TargetDefined,
@@ -3057,66 +3089,31 @@ mod tests {
     }
 
     #[test]
-    fn stream_sample_interval_honors_request_above_floor() {
-        // A 5s request is kept as-is (it is already above the 1s floor).
-        let plan = parse_subscription_list(&stream_sample_list(5_000_000_000)).unwrap();
-        assert_eq!(plan.sample_intervals, vec![Duration::from_secs(5)]);
+    fn stream_sample_intervals_accept_zero_and_supported_range() {
+        for (raw_nanos, expected) in [
+            (0, MIN_SAMPLE_INTERVAL),
+            (1_000_000_000, Duration::from_secs(1)),
+            (5_000_000_000, Duration::from_secs(5)),
+            (3_600_000_000_000, MAX_SAMPLE_INTERVAL),
+        ] {
+            let plan = parse_subscription_list(&stream_sample_list(raw_nanos)).unwrap();
+            assert_eq!(plan.sample_intervals, vec![expected]);
+        }
     }
 
     #[test]
-    fn stream_sample_interval_raises_sub_floor_request_to_floor() {
-        // A 1ms request is raised up to the 1s floor.
-        let plan = parse_subscription_list(&stream_sample_list(1_000_000)).unwrap();
-        assert_eq!(plan.sample_intervals, vec![MIN_SAMPLE_INTERVAL]);
-    }
-
-    #[test]
-    fn stream_sample_interval_defaults_zero_to_floor() {
-        // A missing/zero interval defaults to the floor.
-        let plan = parse_subscription_list(&stream_sample_list(0)).unwrap();
-        assert_eq!(plan.sample_intervals, vec![MIN_SAMPLE_INTERVAL]);
-    }
-
-    #[test]
-    fn stream_sample_interval_caps_absurd_request_to_ceiling() {
-        // An absurd interval (u64::MAX ns ≈ centuries) is capped to the ceiling.
-        let plan = parse_subscription_list(&stream_sample_list(u64::MAX)).unwrap();
-        assert_eq!(plan.sample_intervals, vec![MAX_SAMPLE_INTERVAL]);
-    }
-
-    #[test]
-    fn stream_sample_intervals_are_clamped_per_subscription() {
-        let path = mounted_path(&[pe("bgp"), pe("global"), pe("state")]);
-        let subscription = |nanos| gnmi::Subscription {
-            path: Some(path.clone()),
-            mode: gnmi::SubscriptionMode::Sample as i32,
-            sample_interval: nanos,
-            suppress_redundant: false,
-            heartbeat_interval: 0,
-        };
-        let list = gnmi::SubscriptionList {
-            prefix: None,
-            subscription: vec![
-                subscription(0),             // -> floor (1s)
-                subscription(2_000_000_000), // -> 2s
-                subscription(1_000_000),     // -> floor (1s)
-            ],
-            qos: None,
-            mode: gnmi::subscription_list::Mode::Stream as i32,
-            allow_aggregation: false,
-            use_models: Vec::new(),
-            encoding: gnmi::Encoding::JsonIetf as i32,
-            updates_only: false,
-        };
-        let plan = parse_subscription_list(&list).unwrap();
-        assert_eq!(
-            plan.sample_intervals,
-            vec![
-                MIN_SAMPLE_INTERVAL,
-                Duration::from_secs(2),
-                MIN_SAMPLE_INTERVAL
-            ]
-        );
+    fn stream_sample_intervals_reject_nonzero_outside_supported_range() {
+        for raw_nanos in [1, 999_999_999, 3_600_000_000_001, u64::MAX] {
+            let err = parse_subscription_list(&stream_sample_list(raw_nanos)).unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+            assert_eq!(
+                err.message(),
+                format!(
+                    "gNMI subscription 1 sample_interval {raw_nanos}ns is outside supported range \
+                     [1000000000ns, 3600000000000ns]"
+                )
+            );
+        }
     }
 
     // --- Subscribe RPC-level harness ---------------------------------------
@@ -3658,6 +3655,40 @@ mod tests {
             vec![Some(fast_path), Some(slow_path)]
         );
         assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn tcp_subscribe_rejects_invalid_second_interval_before_snapshot() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let snapshot_calls = Arc::clone(&calls);
+        let service = GnmiService::with_peer_snapshot(65001, "192.0.2.1", move || {
+            snapshot_calls.fetch_add(1, Ordering::SeqCst);
+            async move { Ok(Vec::new()) }
+        });
+        let (mut list, _, _) = two_interval_neighbor_sample_list();
+        list.subscription[1].sample_interval = 999_999_999;
+        let mut harness = serve(service).await;
+        let status = match harness
+            .client
+            .subscribe(tokio_stream::iter(vec![subscribe_msg(list)]))
+            .await
+        {
+            Err(status) => status,
+            Ok(response) => response
+                .into_inner()
+                .message()
+                .await
+                .expect_err("invalid second interval must precede Update or sync_response"),
+        };
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert_eq!(
+            status.message(),
+            "gNMI subscription 2 sample_interval 999999999ns is outside supported range \
+             [1000000000ns, 3600000000000ns]"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2920,7 +2920,7 @@ tls_key_file = "/etc/rustbgpd/client.key"    # required with tls_cert_file
 | `address` | string | yes | -- | Collector `host:port` (DNS names allowed; bracket IPv6 literals) |
 | `paths` | array | yes | -- | OpenConfig gNMI paths in xpath form — the same path surface the dial-in Subscribe server supports (see `docs/GNMI.md`) |
 | `mode` | string | no | `"sample"` | `"sample"` (periodic resample) or `"on_change"` (event-driven; v1 covers the `session-state` leaf and requires `[event_history].enabled = true`) |
-| `sample_interval` | u64 | no | 10 | Seconds between samples in SAMPLE mode, clamped to [1s, 1h] like dial-in |
+| `sample_interval` | u64 | no | 10 | Seconds between samples in SAMPLE mode; values from 1 through 3600 are retained, while zero and values above 3600 are rejected |
 | `backoff_initial` | u64 | no | 1 | First reconnect delay in seconds; doubles per consecutive failure |
 | `backoff_max` | u64 | no | 30 | Reconnect delay cap in seconds |
 | `tls_ca_file` | string | no | -- | CA bundle (PEM path) verifying the collector's server certificate; setting it enables TLS |

--- a/docs/GNMI.md
+++ b/docs/GNMI.md
@@ -455,11 +455,11 @@ gnmic \
   --path "$OC_BGP/global/state/router-id"
 ```
 
-The requested `--sample-interval` is clamped to `[1s, 1h]`: a sub-second
-or zero/missing interval is raised to the 1-second floor, and anything
-above one hour is capped at the 1-hour ceiling. Multiple SAMPLE paths in one
-subscription retain their own clamped intervals; co-due neighbor paths share
-one peer snapshot, and delayed ticks skip missed periods without catch-up bursts.
+For STREAM/SAMPLE, a zero/missing `--sample-interval` uses the 1-second floor.
+Nonzero intervals from 1 second through 1 hour are retained exactly; sub-second
+or above-1-hour requests fail with `INVALID_ARGUMENT`. Multiple SAMPLE paths in
+one subscription retain their own accepted intervals; co-due neighbor paths
+share one peer snapshot, and delayed ticks skip missed periods without bursts.
 
 ## Troubleshooting
 

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -1145,7 +1145,7 @@
           }
         },
         "sample_interval": {
-          "description": "SAMPLE resample interval in seconds. Default 10; clamped to\n[1s, 1h] like a dial-in subscription's requested interval.",
+          "description": "SAMPLE resample interval in seconds. Default 10; values from 1\nthrough 3600 are retained, while zero and values above 3600 are rejected.",
           "type": "integer",
           "format": "uint64",
           "default": 10,

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -471,8 +471,8 @@ pub struct GnmiDialoutTarget {
     /// and requires `[event_history].enabled = true`).
     #[serde(default)]
     pub mode: GnmiDialoutModeConfig,
-    /// SAMPLE resample interval in seconds. Default 10; clamped to
-    /// [1s, 1h] like a dial-in subscription's requested interval.
+    /// SAMPLE resample interval in seconds. Default 10; values from 1
+    /// through 3600 are retained, while zero and values above 3600 are rejected.
     #[serde(default = "default_gnmi_dialout_sample_interval")]
     pub sample_interval: u64,
     /// First reconnect delay in seconds after a connection failure;


### PR DESCRIPTION
## Summary

- reject explicit STREAM/SAMPLE intervals outside the supported 1s–1h range with `INVALID_ARGUMENT` instead of silently clamping them
- preserve zero as the 1s target default and reject explicit `TARGET_DEFINED` intervals before the existing unsupported-mode response
- route dial-out subscriptions through the same interval validation and align operator docs plus the generated config schema

This follows the OpenConfig gNMI requirement that an unsupported explicitly requested SAMPLE interval close the stream with `INVALID_ARGUMENT`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --all-features`
- `python3 scripts/check-v1-stable-surface.py`
- `cargo test --workspace config_json_schema_committed_copy_is_fresh`

## Load-bearing proof

Temporarily restoring the former `Duration::clamp` logic makes all three new rejection seams fail: the parser boundary matrix, the real TCP invalid-second-subscription test (including its zero-snapshot assertion), and the dial-out validation matrix. Restoring strict validation makes them green.

Closes LAN-811
