### PR TITLE
bench: instrument per-client-best full resync

### DIFF
--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -12,10 +12,11 @@
 //! the default no-op sink with its concrete EHM sink without widening the
 //! normal public API or duplicating manager-side ring/broadcast work.
 
+use std::cell::Cell;
 use std::collections::{BTreeMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_wire::{Afi, Prefix, Safi};
@@ -30,6 +31,147 @@ use crate::update::{
 };
 
 static POLICY_TRANSITION_RECEIPT_PRINTED: AtomicBool = AtomicBool::new(false);
+static PCB_ENUMERATION_PHASES: AtomicUsize = AtomicUsize::new(0);
+static PCB_ENUMERATED_PREFIXES: AtomicUsize = AtomicUsize::new(0);
+static PCB_STAGING_PHASES: AtomicUsize = AtomicUsize::new(0);
+static PCB_STAGING_PREFIXES: AtomicUsize = AtomicUsize::new(0);
+static PCB_EXACT_PHASES: AtomicUsize = AtomicUsize::new(0);
+static PCB_COMMIT_PHASES: AtomicUsize = AtomicUsize::new(0);
+static PCB_ENQUEUE_PHASES: AtomicUsize = AtomicUsize::new(0);
+static PCB_TOTAL_ENUMERATION_NANOS: AtomicU64 = AtomicU64::new(0);
+static PCB_TOTAL_STAGING_NANOS: AtomicU64 = AtomicU64::new(0);
+static PCB_TOTAL_EXACT_NANOS: AtomicU64 = AtomicU64::new(0);
+static PCB_TOTAL_COMMIT_NANOS: AtomicU64 = AtomicU64::new(0);
+static PCB_TOTAL_ENQUEUE_NANOS: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Copy)]
+struct PerClientBestCandidateBenchAggregate {
+    capture_active: bool,
+    prefix_visits: usize,
+    empty_sets: usize,
+    singleton_sets: usize,
+    multi_sets: usize,
+    heap_backed_collections: usize,
+}
+
+impl PerClientBestCandidateBenchAggregate {
+    const INACTIVE: Self = Self {
+        capture_active: false,
+        prefix_visits: 0,
+        empty_sets: 0,
+        singleton_sets: 0,
+        multi_sets: 0,
+        heap_backed_collections: 0,
+    };
+
+    const fn active() -> Self {
+        Self {
+            capture_active: true,
+            ..Self::INACTIVE
+        }
+    }
+}
+
+thread_local! {
+    static PCB_CANDIDATE_AGGREGATE: Cell<PerClientBestCandidateBenchAggregate> =
+        const { Cell::new(PerClientBestCandidateBenchAggregate::INACTIVE) };
+}
+
+/// Bench-only proof that an authoritative per-client-best policy replacement
+/// traversed the real full-resync selection arm. Durations are deliberately
+/// coarse per-peer totals; no clock is read inside the prefix loop.
+#[derive(Clone, Copy, Debug)]
+pub struct PerClientBestResyncBenchReceipt {
+    pub candidate_prefix_visits: usize,
+    pub empty_candidate_sets: usize,
+    pub singleton_candidate_sets: usize,
+    pub multi_candidate_sets: usize,
+    pub heap_backed_candidate_collections: usize,
+    pub enumeration_phases: usize,
+    pub enumerated_prefixes: usize,
+    pub staging_phases: usize,
+    pub staging_prefixes: usize,
+    pub exact_phases: usize,
+    pub commit_phases: usize,
+    pub enqueue_phases: usize,
+    pub total_enumeration: std::time::Duration,
+    pub total_staging: std::time::Duration,
+    pub total_exact_build_and_encode: std::time::Duration,
+    pub total_private_commit: std::time::Duration,
+    pub total_enqueue: std::time::Duration,
+    pub pending_regroup_baselines: usize,
+    pub pending_extra_withdraw_peers: usize,
+    pub pending_exact_export_withdrawals: usize,
+    pub exact_export_rejection_peers: usize,
+    pub outbound_prefix_limit_peers: usize,
+    pub forced_resync_peers: usize,
+}
+
+fn bench_duration_nanos(duration: std::time::Duration) -> u64 {
+    u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
+}
+
+fn bench_add_duration(total: &AtomicU64, elapsed: std::time::Duration) {
+    let nanos = bench_duration_nanos(elapsed);
+    let _ = total.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_add(nanos))
+    });
+}
+
+pub(in crate::manager) fn bench_record_per_client_best_candidates(
+    cardinality: usize,
+    heap_backed: bool,
+) {
+    PCB_CANDIDATE_AGGREGATE.with(|aggregate| {
+        let mut receipt = aggregate.get();
+        if !receipt.capture_active {
+            return;
+        }
+        receipt.prefix_visits = receipt.prefix_visits.saturating_add(1);
+        match cardinality {
+            0 => receipt.empty_sets = receipt.empty_sets.saturating_add(1),
+            1 => receipt.singleton_sets = receipt.singleton_sets.saturating_add(1),
+            _ => receipt.multi_sets = receipt.multi_sets.saturating_add(1),
+        }
+        if heap_backed {
+            receipt.heap_backed_collections = receipt.heap_backed_collections.saturating_add(1);
+        }
+        aggregate.set(receipt);
+    });
+}
+
+pub(in crate::manager) fn bench_record_per_client_best_enumeration(
+    prefixes: usize,
+    elapsed: std::time::Duration,
+) {
+    PCB_ENUMERATION_PHASES.fetch_add(1, Ordering::Relaxed);
+    PCB_ENUMERATED_PREFIXES.fetch_add(prefixes, Ordering::Relaxed);
+    bench_add_duration(&PCB_TOTAL_ENUMERATION_NANOS, elapsed);
+}
+
+pub(in crate::manager) fn bench_record_per_client_best_staging(
+    prefixes: usize,
+    elapsed: std::time::Duration,
+) {
+    PCB_STAGING_PHASES.fetch_add(1, Ordering::Relaxed);
+    PCB_STAGING_PREFIXES.fetch_add(prefixes, Ordering::Relaxed);
+    bench_add_duration(&PCB_TOTAL_STAGING_NANOS, elapsed);
+}
+
+pub(in crate::manager) fn bench_record_per_client_best_exact(elapsed: std::time::Duration) {
+    PCB_EXACT_PHASES.fetch_add(1, Ordering::Relaxed);
+    bench_add_duration(&PCB_TOTAL_EXACT_NANOS, elapsed);
+}
+
+pub(in crate::manager) fn bench_record_per_client_best_commit(elapsed: std::time::Duration) {
+    PCB_COMMIT_PHASES.fetch_add(1, Ordering::Relaxed);
+    bench_add_duration(&PCB_TOTAL_COMMIT_NANOS, elapsed);
+}
+
+pub(in crate::manager) fn bench_record_per_client_best_enqueue(elapsed: std::time::Duration) {
+    PCB_ENQUEUE_PHASES.fetch_add(1, Ordering::Relaxed);
+    bench_add_duration(&PCB_TOTAL_ENQUEUE_NANOS, elapsed);
+}
 
 /// Instrumentation from the production clean-transition state machine.
 #[derive(Clone, Copy, Debug)]
@@ -123,6 +265,7 @@ impl RibManager {
             channel_capacity,
             |_| 64_512,
             false,
+            false,
             is_rr_client,
             |_| make_exact_export_encoder(),
         )
@@ -195,6 +338,33 @@ impl RibManager {
             |index| remote_asns[index],
             true,
             false,
+            false,
+            make_exact_export_encoder,
+        )
+    }
+
+    /// Register synthetic eBGP route-server clients on the production
+    /// per-client-best fallback. The explicit seam keeps the grouping
+    /// disqualifier visible instead of adding a positional flag to callers.
+    #[must_use]
+    pub fn bench_register_per_client_best_route_server_peers<F>(
+        &mut self,
+        remote_asns: &[u32],
+        export_policy: Option<&PolicyChain>,
+        channel_capacity: usize,
+        make_exact_export_encoder: F,
+    ) -> Vec<mpsc::Receiver<OutboundRouteUpdate>>
+    where
+        F: FnMut(u32) -> Arc<dyn ExactExportEncoder>,
+    {
+        self.bench_register_peers_with_profile(
+            remote_asns.len(),
+            export_policy,
+            channel_capacity,
+            |index| remote_asns[index],
+            true,
+            true,
+            false,
             make_exact_export_encoder,
         )
     }
@@ -256,6 +426,7 @@ impl RibManager {
         channel_capacity: usize,
         mut peer_asn: P,
         is_ebgp: bool,
+        per_client_best: bool,
         is_rr_client: bool,
         mut make_exact_export_encoder: F,
     ) -> Vec<mpsc::Receiver<OutboundRouteUpdate>>
@@ -284,8 +455,8 @@ impl RibManager {
                 vec![(Afi::Ipv4, Safi::Unicast)],
                 is_ebgp,
                 is_rr_client,
-                None,       // no ORR vantage
-                false,      // no per-client best (RS mode)
+                None, // no ORR vantage
+                per_client_best,
                 true,       // interpret RFC 1997 (production default)
                 Vec::new(), // no Add-Path send
                 0,
@@ -477,6 +648,70 @@ impl RibManager {
     /// fanout pass.
     pub fn bench_reset_adj_rib_out_fanout_receipt(&mut self) {
         self.adj_rib_out_commit_stats = super::AdjRibOutCommitStats::default();
+    }
+
+    /// Reset the feature-gated per-client-best full-resync instrumentation.
+    pub fn bench_reset_per_client_best_resync_receipt(&mut self) {
+        PCB_CANDIDATE_AGGREGATE.set(PerClientBestCandidateBenchAggregate::active());
+        for counter in [
+            &PCB_ENUMERATION_PHASES,
+            &PCB_ENUMERATED_PREFIXES,
+            &PCB_STAGING_PHASES,
+            &PCB_STAGING_PREFIXES,
+            &PCB_EXACT_PHASES,
+            &PCB_COMMIT_PHASES,
+            &PCB_ENQUEUE_PHASES,
+        ] {
+            counter.store(0, Ordering::Relaxed);
+        }
+        for total in [
+            &PCB_TOTAL_ENUMERATION_NANOS,
+            &PCB_TOTAL_STAGING_NANOS,
+            &PCB_TOTAL_EXACT_NANOS,
+            &PCB_TOTAL_COMMIT_NANOS,
+            &PCB_TOTAL_ENQUEUE_NANOS,
+        ] {
+            total.store(0, Ordering::Relaxed);
+        }
+    }
+
+    /// Capture the most recent per-client-best full-resync phase and residue
+    /// proof. The returned non-`Eq` receipt deliberately carries durations.
+    #[must_use]
+    pub fn bench_per_client_best_resync_receipt(&self) -> PerClientBestResyncBenchReceipt {
+        let candidates = PCB_CANDIDATE_AGGREGATE.get();
+        PCB_CANDIDATE_AGGREGATE.set(PerClientBestCandidateBenchAggregate {
+            capture_active: false,
+            ..candidates
+        });
+        let load = |counter: &AtomicUsize| counter.load(Ordering::Relaxed);
+        let duration =
+            |total: &AtomicU64| std::time::Duration::from_nanos(total.load(Ordering::Relaxed));
+        PerClientBestResyncBenchReceipt {
+            candidate_prefix_visits: candidates.prefix_visits,
+            empty_candidate_sets: candidates.empty_sets,
+            singleton_candidate_sets: candidates.singleton_sets,
+            multi_candidate_sets: candidates.multi_sets,
+            heap_backed_candidate_collections: candidates.heap_backed_collections,
+            enumeration_phases: load(&PCB_ENUMERATION_PHASES),
+            enumerated_prefixes: load(&PCB_ENUMERATED_PREFIXES),
+            staging_phases: load(&PCB_STAGING_PHASES),
+            staging_prefixes: load(&PCB_STAGING_PREFIXES),
+            exact_phases: load(&PCB_EXACT_PHASES),
+            commit_phases: load(&PCB_COMMIT_PHASES),
+            enqueue_phases: load(&PCB_ENQUEUE_PHASES),
+            total_enumeration: duration(&PCB_TOTAL_ENUMERATION_NANOS),
+            total_staging: duration(&PCB_TOTAL_STAGING_NANOS),
+            total_exact_build_and_encode: duration(&PCB_TOTAL_EXACT_NANOS),
+            total_private_commit: duration(&PCB_TOTAL_COMMIT_NANOS),
+            total_enqueue: duration(&PCB_TOTAL_ENQUEUE_NANOS),
+            pending_regroup_baselines: self.pending_regroup_baseline.len(),
+            pending_extra_withdraw_peers: self.pending_extra_withdraws.len(),
+            pending_exact_export_withdrawals: self.pending_exact_export_withdrawals.len(),
+            exact_export_rejection_peers: self.peer_unexportable.len(),
+            outbound_prefix_limit_peers: self.outbound_prefix_limits.len(),
+            forced_resync_peers: self.force_outbound_peers.len(),
+        }
     }
 
     /// Capture production-path and current metric evidence after one measured

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -2031,6 +2031,9 @@ impl RibManager {
         mut shared_unicast_precommit: Option<SharedUnicastPrecommit<'_>>,
         otc_reconcile_prefixes: Option<&HashSet<Prefix>>,
     ) -> bool {
+        #[cfg(feature = "bench-internals")]
+        let bench_per_client_best_resync = self.peer_per_client_best.contains(&peer)
+            && (self.dirty_peers.contains(&peer) || self.force_outbound_peers.contains(&peer));
         let gated = announce
             .iter()
             .any(|route| self.selection_deferred(prefix_family(&route.prefix)))
@@ -2091,7 +2094,6 @@ impl RibManager {
         let Ok(permit) = tx.try_reserve() else {
             return false;
         };
-
         // Validate the trust boundary before consuming any durable pending
         // state (OTC diagnostics or the rejected-route overlay). A failed
         // precommit leaves those structures intact for the retry.
@@ -2219,6 +2221,8 @@ impl RibManager {
         {
             use crate::update::{ExactExportCandidate, ExactExportKey};
 
+            #[cfg(feature = "bench-internals")]
+            let bench_exact_started = bench_per_client_best_resync.then(std::time::Instant::now);
             debug_assert_eq!(announce.len(), next_hop_override.len());
             let family_lengths = [
                 announce.len(),
@@ -2317,6 +2321,10 @@ impl RibManager {
                 }
                 results
             };
+            #[cfg(feature = "bench-internals")]
+            if let Some(started) = bench_exact_started {
+                super::bench_support::bench_record_per_client_best_exact(started.elapsed());
+            }
             #[cfg(any(test, feature = "bench-internals"))]
             {
                 self.adj_rib_out_commit_stats
@@ -2506,7 +2514,6 @@ impl RibManager {
         {
             self.peer_unexportable.remove(&peer);
         }
-
         // Recompute grouped projections after the sparse overlay mutation;
         // these counts drive both metrics and query/BMP truth.
         let grouped_unicast_count = self.grouped_advertised_count(peer);
@@ -2560,6 +2567,8 @@ impl RibManager {
             | (u8::from(vpn_changed) << 4)
             | (u8::from(labeled_changed) << 5)
             | (u8::from(rtc_changed) << 6);
+        #[cfg(feature = "bench-internals")]
+        let bench_commit_started = bench_per_client_best_resync.then(std::time::Instant::now);
         if has_committed_route_payload {
             #[cfg(any(test, feature = "bench-internals"))]
             {
@@ -2679,6 +2688,10 @@ impl RibManager {
                 );
             }
         }
+        #[cfg(feature = "bench-internals")]
+        if let Some(started) = bench_commit_started {
+            super::bench_support::bench_record_per_client_best_commit(started.elapsed());
+        }
 
         // ADR-0113 capacity gauges publish the committed admitted truth, so
         // they refresh here rather than at the enforcement seam above, which
@@ -2698,6 +2711,8 @@ impl RibManager {
                 self.pending_otc_blocked.remove(&peer);
             }
         }
+        #[cfg(feature = "bench-internals")]
+        let bench_enqueue_started = bench_per_client_best_resync.then(std::time::Instant::now);
         enqueue_outbound_update(
             permit,
             OutboundRouteUpdate {
@@ -2725,6 +2740,10 @@ impl RibManager {
                 shared_group_encode: None,
             },
         );
+        #[cfg(feature = "bench-internals")]
+        if let Some(started) = bench_enqueue_started {
+            super::bench_support::bench_record_per_client_best_enqueue(started.elapsed());
+        }
         #[cfg(any(test, feature = "bench-internals"))]
         if has_committed_route_payload {
             self.adj_rib_out_commit_stats.successful_enqueues = self
@@ -3699,6 +3718,11 @@ impl RibManager {
                 "a grouped force-only resync cannot share a nonempty best-change pass"
             );
             let resync = is_dirty || is_force;
+            #[cfg(feature = "bench-internals")]
+            let bench_per_client_best_resync = resync && self.peer_per_client_best.contains(&peer);
+            #[cfg(feature = "bench-internals")]
+            let bench_enumeration_started =
+                bench_per_client_best_resync.then(std::time::Instant::now);
             let effective_prefixes: Cow<'_, HashSet<Prefix>> = if resync {
                 let mut all: HashSet<Prefix> = self.loc_rib.iter().map(|r| r.prefix).collect();
                 if let Some(gid) = member_of {
@@ -3940,6 +3964,13 @@ impl RibManager {
             } else {
                 HashSet::new()
             };
+            #[cfg(feature = "bench-internals")]
+            if let Some(started) = bench_enumeration_started {
+                super::bench_support::bench_record_per_client_best_enumeration(
+                    effective_prefixes.len(),
+                    started.elapsed(),
+                );
+            }
 
             if effective_prefixes.is_empty()
                 && effective_flowspec_rules.is_empty()
@@ -3977,6 +4008,8 @@ impl RibManager {
                 continue;
             }
 
+            #[cfg(feature = "bench-internals")]
+            let bench_staging_started = bench_per_client_best_resync.then(std::time::Instant::now);
             let mut announce = Vec::new();
             let mut withdraw = Vec::new();
             let mut nh_override_flags: Vec<Option<rustbgpd_policy::NextHopAction>> = Vec::new();
@@ -4576,6 +4609,13 @@ impl RibManager {
                 );
             }
 
+            #[cfg(feature = "bench-internals")]
+            if let Some(started) = bench_staging_started {
+                super::bench_support::bench_record_per_client_best_staging(
+                    effective_prefixes.len(),
+                    started.elapsed(),
+                );
+            }
             // The outbound payload: the group-shared Arc for a covered
             // member, otherwise this peer's own staged vectors. A shared
             // member never stages per-peer unicast (grouped + in-sync),

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -1490,6 +1490,13 @@ impl RibManager {
             llgr,
         )
         .collect();
+        #[cfg(feature = "bench-internals")]
+        if stage_path_id_zero {
+            super::super::bench_support::bench_record_per_client_best_candidates(
+                candidates.len(),
+                candidates.capacity() > 0,
+            );
+        }
 
         // Sort by best-path preference (best first). A target bound to a
         // resolved ORR vantage ranks by the vantage's interior cost to

--- a/crates/transport/benches/fanout.rs
+++ b/crates/transport/benches/fanout.rs
@@ -56,6 +56,15 @@
 //! enqueues one exact withdrawal-only envelope per member. This instrument also
 //! makes no performance claim.
 //!
+//! `per_client_best_full_resync` covers the authoritative private fallback at
+//! 4,096 IPv4 routes and 8/64 eBGP route-server clients. Routes are sourced
+//! round-robin from that same fleet, so every resync proves both self-source
+//! exclusion and the singleton per-target candidate arm. Setup output is
+//! drained before one export-policy replacement per peer is timed; selection,
+//! exact-encoder, private commit, enqueue, inventory, and residue receipts are
+//! checked afterward. This is instrumentation only and makes no performance
+//! claim.
+//!
 //! Gated behind `bench-internals`; run with:
 //!   cargo bench -p rustbgpd-transport --features bench-internals --bench fanout
 //!
@@ -99,6 +108,12 @@ const ADJ_RIB_OUT_GAUGE_PEER_COUNTS: [usize; 5] = [1, 8, 64, 256, 1_000];
 const GROUPED_WITHDRAWAL_PEER_COUNTS: [usize; 4] = [8, 64, 256, 1_000];
 /// Route-server fleets for grouped export-policy denial staging.
 const GROUPED_POLICY_DENIAL_PEER_COUNTS: [usize; 3] = [8, 64, 256];
+/// Fleet sizes for the private per-client-best full-table resync instrument.
+const PER_CLIENT_BEST_RESYNC_PEER_COUNTS: [usize; 2] = [8, 64];
+/// Fixed Loc-RIB inventory for private per-client-best full-table resync.
+const PER_CLIENT_BEST_RESYNC_ROUTES: usize = 4_096;
+const PER_CLIENT_BEST_COMMUNITY_A: u32 = (65_000 << 16) | 100;
+const PER_CLIENT_BEST_COMMUNITY_B: u32 = (65_000 << 16) | 200;
 /// Loc-RIB sizes for the late RR-client initial-table join instrument.
 const INITIAL_TABLE_JOIN_ROUTE_COUNTS: [usize; 2] = [4_096, 65_536];
 /// Candidate-set sizes for Add-Path top-N export staging.
@@ -662,6 +677,239 @@ fn assert_real_transport_snapshot(update: &OutboundRouteUpdate) {
         usize::from(rustbgpd_wire::MAX_MESSAGE_LEN),
         "the benchmark fleet must use classic-message session profiles"
     );
+}
+
+struct PerClientBestResyncState {
+    manager: RibManager,
+    receivers: Vec<mpsc::Receiver<OutboundRouteUpdate>>,
+    expected_inventories: Vec<HashSet<(Prefix, u32)>>,
+    current_community: u32,
+}
+
+fn per_client_best_resync_routes(peers: usize) -> Vec<Route> {
+    assert_eq!(PER_CLIENT_BEST_RESYNC_ROUTES % peers, 0);
+    policy_regroup_routes(PER_CLIENT_BEST_RESYNC_ROUTES)
+        .into_iter()
+        .enumerate()
+        .map(|(index, mut route)| {
+            let source = RibManager::bench_peer_address(index % peers);
+            route.peer = source;
+            route.peer_router_id = match source {
+                IpAddr::V4(address) => address,
+                IpAddr::V6(_) => unreachable!("benchmark peer addresses are IPv4"),
+            };
+            route
+        })
+        .collect()
+}
+
+fn route_has_community(route: &Route, community: u32) -> bool {
+    route.attributes.iter().any(|attribute| {
+        matches!(attribute, PathAttribute::Communities(values) if values.contains(&community))
+    })
+}
+
+fn drain_per_client_best_resync_envelopes(
+    receiver: &mut mpsc::Receiver<OutboundRouteUpdate>,
+    target: IpAddr,
+    expected: &HashSet<(Prefix, u32)>,
+    expected_community: u32,
+    expected_envelopes: usize,
+) {
+    let mut actual = HashSet::with_capacity(expected.len());
+    for _ in 0..expected_envelopes {
+        let update = receiver
+            .try_recv()
+            .expect("each private full-resync phase must enqueue its route inventory");
+        assert_unicast_only_envelope(&update);
+        assert_real_transport_snapshot(&update);
+        assert!(update.announce_source_exclusion.is_none());
+        assert!(update.withdraw.is_empty());
+        assert_eq!(update.announce.len(), update.next_hop_override.len());
+        assert!(update.next_hop_override.iter().all(Option::is_none));
+        for route in update.announce.iter() {
+            assert_ne!(route.peer, target, "self-sourced routes must stay excluded");
+            assert_eq!(route.path_id, 0, "per-client best is single-path output");
+            assert!(
+                route_has_community(route, expected_community),
+                "the policy replacement must remain wire-visible"
+            );
+            assert!(
+                actual.insert((route.prefix, route.path_id)),
+                "a private inventory must not repeat an NLRI identity"
+            );
+        }
+    }
+    assert_eq!(actual, *expected);
+    assert!(
+        matches!(receiver.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+        "the live channel must be empty after the expected private envelope(s)"
+    );
+}
+
+fn build_per_client_best_resync(peers: usize) -> PerClientBestResyncState {
+    let (_tx, rx) = mpsc::channel::<RibUpdate>(16);
+    let (_qtx, qrx) = mpsc::channel::<RibUpdate>(16);
+    let mut manager = RibManager::new(rx, qrx, None, None, BgpMetrics::new());
+    let remote_asns = route_server_remote_asns(peers, true);
+    let old_policy = community_export_chain(PER_CLIENT_BEST_COMMUNITY_A);
+    let mut receivers = manager.bench_register_per_client_best_route_server_peers(
+        &remote_asns,
+        Some(&old_policy),
+        peers + 1,
+        fanout_bench_route_server_export_encoder,
+    );
+    let routes = per_client_best_resync_routes(peers);
+    let expected_inventories = (0..peers)
+        .map(|index| {
+            let target = RibManager::bench_peer_address(index);
+            routes
+                .iter()
+                .filter(|route| route.peer != target)
+                .map(|route| (route.prefix, route.path_id))
+                .collect::<HashSet<_>>()
+        })
+        .collect::<Vec<_>>();
+    manager.bench_seed_loc_rib(routes);
+
+    let expected_per_peer = PER_CLIENT_BEST_RESYNC_ROUTES
+        - PER_CLIENT_BEST_RESYNC_ROUTES
+            .checked_div(peers)
+            .expect("nonzero fleet");
+    let setup_receipt = manager.bench_adj_rib_out_fanout_receipt();
+    assert_eq!(setup_receipt.update_groups, 0);
+    assert_eq!(setup_receipt.grouped_peers, 0);
+    assert_eq!(setup_receipt.ungrouped_peers, peers);
+    assert_eq!(setup_receipt.dirty_peers, 0);
+    assert_eq!(setup_receipt.grouped_unicast_routes, 0);
+    assert_eq!(
+        setup_receipt.private_unicast_routes,
+        expected_per_peer * peers
+    );
+    for (index, receiver) in receivers.iter_mut().enumerate() {
+        assert_eq!(expected_inventories[index].len(), expected_per_peer);
+        drain_per_client_best_resync_envelopes(
+            receiver,
+            RibManager::bench_peer_address(index),
+            &expected_inventories[index],
+            PER_CLIENT_BEST_COMMUNITY_A,
+            peers - 1,
+        );
+    }
+    manager.bench_reset_adj_rib_out_fanout_receipt();
+    manager.bench_reset_per_client_best_resync_receipt();
+    PerClientBestResyncState {
+        manager,
+        receivers,
+        expected_inventories,
+        current_community: PER_CLIENT_BEST_COMMUNITY_A,
+    }
+}
+
+fn assert_per_client_best_resync_receipts(state: &mut PerClientBestResyncState, peers: usize) {
+    let expected_per_peer = PER_CLIENT_BEST_RESYNC_ROUTES - PER_CLIENT_BEST_RESYNC_ROUTES / peers;
+    let expected_private = expected_per_peer * peers;
+    let fanout = state.manager.bench_adj_rib_out_fanout_receipt();
+    assert_eq!(fanout.update_groups, 0);
+    assert_eq!(fanout.grouped_peers, 0);
+    assert_eq!(fanout.ungrouped_peers, peers);
+    assert_eq!(fanout.dirty_peers, 0);
+    assert_eq!(fanout.grouped_unicast_routes, 0);
+    assert_eq!(fanout.private_unicast_routes, expected_private);
+    assert_eq!(fanout.routes_received_dispatches, 0);
+    assert_eq!(fanout.routes_received_withdrawals, 0);
+    assert_eq!(fanout.exact_probe_batches, peers);
+    assert_eq!(fanout.exact_probe_candidates, expected_private);
+    assert_eq!(fanout.exact_probe_nonzero_encoded_lengths, expected_private);
+    assert_eq!(fanout.exact_probe_cache_reuses, 0);
+    assert_eq!(fanout.successful_commits, peers);
+    assert_eq!(fanout.successful_enqueues, peers);
+    assert_eq!(fanout.family_gauge_writes, peers);
+    assert_eq!(fanout.last_family_gauge_write_mask, 0x01);
+    assert_eq!(fanout.private_extra_prefix_scans, 0);
+    assert_eq!(fanout.first_peer_family_values[0], expected_per_peer as i64);
+
+    let policy = state.manager.bench_policy_transition_receipt();
+    assert_eq!(policy.plan_builds, 0);
+    assert_eq!(policy.full_exact_probes, 0);
+    assert_eq!(policy.route_shell_materializations, 0);
+    assert_eq!(policy.actor_polls, 0);
+    assert_eq!(policy.authoritative_peer_applies, peers);
+
+    let pcb = state.manager.bench_per_client_best_resync_receipt();
+    let prefix_visits = PER_CLIENT_BEST_RESYNC_ROUTES * peers;
+    assert_eq!(pcb.candidate_prefix_visits, prefix_visits);
+    assert_eq!(pcb.empty_candidate_sets, PER_CLIENT_BEST_RESYNC_ROUTES);
+    assert_eq!(pcb.singleton_candidate_sets, expected_private);
+    assert_eq!(pcb.multi_candidate_sets, 0);
+    assert_eq!(pcb.heap_backed_candidate_collections, expected_private);
+    assert_eq!(pcb.enumeration_phases, peers);
+    assert_eq!(pcb.enumerated_prefixes, prefix_visits);
+    assert_eq!(pcb.staging_phases, peers);
+    assert_eq!(pcb.staging_prefixes, prefix_visits);
+    assert_eq!(pcb.exact_phases, peers);
+    assert_eq!(pcb.commit_phases, peers);
+    assert_eq!(pcb.enqueue_phases, peers);
+    assert_eq!(pcb.pending_regroup_baselines, 0);
+    assert_eq!(pcb.pending_extra_withdraw_peers, 0);
+    assert_eq!(pcb.pending_exact_export_withdrawals, 0);
+    assert_eq!(pcb.exact_export_rejection_peers, 0);
+    assert_eq!(pcb.outbound_prefix_limit_peers, 0);
+    assert_eq!(pcb.forced_resync_peers, 0);
+    assert!(!pcb.total_enumeration.is_zero());
+    assert!(!pcb.total_staging.is_zero());
+    assert!(!pcb.total_exact_build_and_encode.is_zero());
+    assert!(!pcb.total_private_commit.is_zero());
+    assert!(!pcb.total_enqueue.is_zero());
+
+    for (index, receiver) in state.receivers.iter_mut().enumerate() {
+        drain_per_client_best_resync_envelopes(
+            receiver,
+            RibManager::bench_peer_address(index),
+            &state.expected_inventories[index],
+            state.current_community,
+            1,
+        );
+    }
+}
+
+fn bench_per_client_best_full_resync(c: &mut Criterion) {
+    let mut group = c.benchmark_group("per_client_best_full_resync");
+    group.sample_size(10);
+    for &peers in &PER_CLIENT_BEST_RESYNC_PEER_COUNTS {
+        group.bench_with_input(
+            BenchmarkId::new(
+                "ipv4_routes",
+                format!("{PER_CLIENT_BEST_RESYNC_ROUTES}/{peers}"),
+            ),
+            &peers,
+            |bench, &peers| {
+                let mut state = build_per_client_best_resync(peers);
+                bench.iter_custom(|iterations| {
+                    let mut accumulated = Duration::ZERO;
+                    for _ in 0..iterations {
+                        state.current_community =
+                            if state.current_community == PER_CLIENT_BEST_COMMUNITY_A {
+                                PER_CLIENT_BEST_COMMUNITY_B
+                            } else {
+                                PER_CLIENT_BEST_COMMUNITY_A
+                            };
+                        let next_policy = community_export_chain(state.current_community);
+                        state.manager.bench_reset_adj_rib_out_fanout_receipt();
+                        state.manager.bench_reset_per_client_best_resync_receipt();
+                        let started = Instant::now();
+                        state
+                            .manager
+                            .bench_replace_export_policy_per_peer(peers, &next_policy);
+                        accumulated += started.elapsed();
+                        assert_per_client_best_resync_receipts(&mut state, peers);
+                    }
+                    accumulated
+                });
+            },
+        );
+    }
+    group.finish();
 }
 
 fn drain_one_route_bearing_envelope_per_peer(
@@ -1946,6 +2194,7 @@ criterion_group!(
     benches,
     bench_fanout,
     bench_private_single_best_fanout,
+    bench_per_client_best_full_resync,
     bench_ixp_exact_export_fanout,
     bench_adj_rib_out_family_gauge,
     bench_grouped_withdrawal_fanout,


### PR DESCRIPTION
## Summary

- add a real-encoder per-client-best full-resync benchmark at 4,096 routes across 8 and 64 route-server members
- prove the private fallback workload with exact candidate, Adj-RIB-Out, encoder, channel, and residue receipts
- expose capture-scoped candidate cardinalities and five coarse bench-only phase totals without changing production behavior

## Measurement boundary

This PR adds instrumentation only. It makes no performance claim and does not change the candidate container. Candidate accounting is thread-local and active only between benchmark reset and receipt capture; the hot loop performs no global atomic RMWs.

## Load-bearing proof

Removing the collector hook makes the 8-peer fixture fail at `candidate_prefix_visits`: observed 0, expected 32,768. Restoring it makes both the 8- and 64-peer optimized fixtures pass. The receipt also fails if the fleet groups, uses a stub encoder, includes self-sourced routes, omits a commit/enqueue, leaves dirty state, or produces extra/closed-channel output.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo clippy -p rustbgpd-rib -p rustbgpd-transport --bench fanout --all-features -- -D warnings`
- `cargo test -p rustbgpd-rib -p rustbgpd-transport --all-features`
- `cargo bench -p rustbgpd-transport --features bench-internals --bench fanout --no-run`
- `cargo bench -p rustbgpd-transport --features bench-internals --bench fanout -- per_client_best_full_resync --test`
- `git diff --check`

Closes LAN-793
