### PR TITLE
feat: expose BMP Loc-RIB dump buffer pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12199,6 +12199,12 @@ stable track (Tokio's policy) — gated in PR-CI so it doesn't drift.
   healthy. Operators can now alert on BMP loss without a log scraper.
   Closes the [BMP drop/replay counters](KNOWN_ISSUES.md) gap.
 
+- **BMP Loc-RIB live-buffer gauges.** Per-collector current depth and
+  generation high-water mark now expose pressure behind bootstrap and table
+  dumps, including the overflowing row before the existing 8192-row bound
+  closes the incomplete generation. This is instrumentation only; a separate
+  live-scale measurement will determine whether the fixed bound needs resizing.
+
 ### Fixed
 
 - **Per-peer outbound writer task; eliminates `GetHealth` wedge under

--- a/crates/bmp/src/manager.rs
+++ b/crates/bmp/src/manager.rs
@@ -132,6 +132,18 @@ impl CollectorPhase {
             }
         }
     }
+
+    const fn loc_rib_peer_up(&self) -> bool {
+        match self {
+            Self::BootstrapPending {
+                loc_rib_peer_up, ..
+            }
+            | Self::Active {
+                loc_rib_peer_up, ..
+            } => *loc_rib_peer_up,
+            Self::Disconnected => false,
+        }
+    }
 }
 
 struct Collector {
@@ -454,7 +466,12 @@ impl BmpManager {
             match &mut self.collectors[idx].phase {
                 CollectorPhase::Disconnected => {}
                 CollectorPhase::BootstrapPending { loc_rib_buffer, .. } => {
-                    if buffer_loc_rib_message(loc_rib_buffer, msg) {
+                    let overflow = buffer_loc_rib_message(loc_rib_buffer, msg);
+                    self.metrics.observe_bmp_loc_rib_dump_live_buffer(
+                        &addr.to_string(),
+                        loc_rib_buffer.len(),
+                    );
+                    if overflow {
                         overflowed.push(idx);
                     }
                 }
@@ -462,10 +479,15 @@ impl BmpManager {
                     generation, sender, ..
                 } => {
                     if let Some(dump) = self.active_dumps.get_mut(&idx) {
-                        if *generation == dump.generation
-                            && buffer_loc_rib_message(&mut dump.buffered, msg)
-                        {
-                            overflowed.push(idx);
+                        if *generation == dump.generation {
+                            let overflow = buffer_loc_rib_message(&mut dump.buffered, msg);
+                            self.metrics.observe_bmp_loc_rib_dump_live_buffer(
+                                &addr.to_string(),
+                                dump.buffered.len(),
+                            );
+                            if overflow {
+                                overflowed.push(idx);
+                            }
                         }
                     } else if let Err(e) = sender.try_send(msg) {
                         let reason = trysend_reason(&e);
@@ -511,6 +533,8 @@ impl BmpManager {
                 "live_buffer_full",
                 u64::try_from(discarded).unwrap_or(u64::MAX),
             );
+            self.metrics
+                .clear_bmp_loc_rib_dump_live_buffer(&self.collectors[idx].addr.to_string());
             warn!(collector = %self.collectors[idx].addr, discarded, "live Loc-RIB buffer exceeded its bound; closing incomplete BMP generation");
         }
         for task in &tasks {
@@ -635,6 +659,10 @@ impl BmpManager {
                 // Dropping the last sender for every active generation lets
                 // clients drain Peer Down before emitting Termination.
                 for collector in &mut self.collectors {
+                    if collector.phase.loc_rib_peer_up() {
+                        self.metrics
+                            .clear_bmp_loc_rib_dump_live_buffer(&collector.addr.to_string());
+                    }
                     collector.phase = CollectorPhase::Disconnected;
                 }
                 true
@@ -648,6 +676,10 @@ impl BmpManager {
     async fn fence_and_abort_dumps(&mut self) {
         for collector in &self.collectors {
             collector.generation.fetch_add(1, Ordering::SeqCst);
+            if collector.phase.loc_rib_peer_up() {
+                self.metrics
+                    .clear_bmp_loc_rib_dump_live_buffer(&collector.addr.to_string());
+            }
         }
         let tasks: Vec<_> = self
             .active_dumps
@@ -705,6 +737,9 @@ impl BmpManager {
                 .map(|(_, encoded)| encoded[collector.version.idx()].clone()),
         );
         let loc_rib_peer_up = collector.filter.loc_rib && self.loc_rib.is_some();
+        if loc_rib_peer_up {
+            self.metrics.reset_bmp_loc_rib_dump_live_buffer(&addr_label);
+        }
         if let Some(cfg) = self.loc_rib.as_ref().filter(|_| loc_rib_peer_up) {
             messages.push(codec::encode_loc_rib_peer_up(
                 cfg,
@@ -798,6 +833,10 @@ impl BmpManager {
         self.cancel_dump(collector_id);
         let collector = &mut self.collectors[collector_id];
         if collector.phase.generation() == Some(generation) {
+            if collector.filter.loc_rib && self.loc_rib.is_some() {
+                self.metrics
+                    .clear_bmp_loc_rib_dump_live_buffer(&collector.addr.to_string());
+            }
             collector.generation.fetch_add(1, Ordering::SeqCst);
             collector.phase = CollectorPhase::Disconnected;
         }
@@ -824,6 +863,7 @@ impl BmpManager {
             return;
         };
         let addr_label = collector.addr.to_string();
+        self.metrics.clear_bmp_loc_rib_dump_live_buffer(&addr_label);
         if let DumpOutcome::Failed(failure) = done.outcome {
             self.loc_rib_suppressed.insert(done.collector_id);
             self.metrics.record_bmp_collector_drop(
@@ -962,6 +1002,15 @@ impl BmpManager {
                     "BMP collector channel full or closed, dropping message"
                 );
             }
+        }
+    }
+}
+
+impl Drop for BmpManager {
+    fn drop(&mut self) {
+        for collector in &self.collectors {
+            self.metrics
+                .reap_bmp_loc_rib_dump_live_buffer(&collector.addr.to_string());
         }
     }
 }
@@ -1679,6 +1728,160 @@ mod tests {
                 })
             })
             .map_or(0, |m| m.counter.value() as u64)
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "test gauges use small exact integer values"
+    )]
+    fn gauge_value(metrics: &BgpMetrics, name: &str, collector: SocketAddr) -> i64 {
+        metrics
+            .registry()
+            .gather()
+            .into_iter()
+            .find(|f| f.name() == name)
+            .and_then(|mut f| {
+                f.take_metric().into_iter().find(|m| {
+                    m.label
+                        .iter()
+                        .any(|l| l.name() == "collector" && l.value() == collector.to_string())
+                })
+            })
+            .map_or(0, |m| m.gauge.value() as i64)
+    }
+
+    fn gauge_series_exists(metrics: &BgpMetrics, name: &str, collector: SocketAddr) -> bool {
+        metrics.registry().gather().into_iter().any(|f| {
+            f.name() == name
+                && f.metric.iter().any(|m| {
+                    m.label
+                        .iter()
+                        .any(|l| l.name() == "collector" && l.value() == collector.to_string())
+                })
+        })
+    }
+
+    fn assert_live_buffer_gauges(
+        metrics: &BgpMetrics,
+        collector: SocketAddr,
+        depth: i64,
+        hwm: i64,
+    ) {
+        assert_eq!(
+            gauge_value(metrics, "bmp_loc_rib_dump_live_buffer_depth", collector),
+            depth
+        );
+        assert_eq!(
+            gauge_value(
+                metrics,
+                "bmp_loc_rib_dump_live_buffer_high_watermark",
+                collector
+            ),
+            hwm
+        );
+    }
+
+    #[tokio::test]
+    async fn loc_rib_live_buffer_metrics_follow_generation_storage_lifecycle() {
+        let (_event_tx, event_rx) = mpsc::channel(1);
+        let (_control_tx, control_rx) = mpsc::channel(1);
+        let (dump_tx, _dump_rx) = mpsc::channel(1);
+        let metrics = BgpMetrics::new();
+        let addr = collector_addr(0);
+        let mut manager = BmpManager::new(
+            event_rx,
+            control_rx,
+            vec![(addr, loc_rib_filter(), BmpVersion::V3)],
+            metrics.clone(),
+        )
+        .with_loc_rib(loc_rib_config(), dump_tx);
+        let (bad_sender, _bad_receiver) = mpsc::channel(1);
+        let (bad_bootstrap, _bad_bootstrap_rx) = tokio::sync::oneshot::channel();
+        manager.handle_collector_connected(0, collector_addr(1), bad_sender, bad_bootstrap);
+        assert!(!gauge_series_exists(
+            &metrics,
+            "bmp_loc_rib_dump_live_buffer_depth",
+            addr
+        ));
+        let (sender, _receiver) = mpsc::channel(4);
+        let (bootstrap_tx, bootstrap_rx) = tokio::sync::oneshot::channel();
+        manager.handle_collector_connected(0, addr, sender, bootstrap_tx);
+        let generation = bootstrap_rx.await.unwrap().generation;
+        assert_live_buffer_gauges(&metrics, addr, 0, 0);
+
+        manager
+            .handle_loc_rib_event(&BmpEvent::LocRibStats { per_family: vec![] })
+            .await;
+        assert_live_buffer_gauges(&metrics, addr, 1, 1);
+        manager.handle_bootstrap_complete(0, generation);
+        assert_eq!(
+            gauge_value(&metrics, "bmp_loc_rib_dump_live_buffer_depth", addr),
+            1
+        );
+        manager.handle_collector_disconnected(0, addr, generation + 1);
+        assert_eq!(
+            gauge_value(&metrics, "bmp_loc_rib_dump_live_buffer_depth", addr),
+            1
+        );
+
+        manager.handle_dump_done(&DumpDone {
+            collector_id: 0,
+            generation,
+            outcome: DumpOutcome::Complete,
+        });
+        assert_live_buffer_gauges(&metrics, addr, 0, 1);
+    }
+
+    #[test]
+    fn manager_drop_reaps_only_its_exact_collector_series() {
+        let metrics = BgpMetrics::new();
+        let addr0 = collector_addr(0);
+        let addr1 = collector_addr(1);
+        metrics.reset_bmp_loc_rib_dump_live_buffer(&addr0.to_string());
+        metrics.reset_bmp_loc_rib_dump_live_buffer(&addr1.to_string());
+        metrics.observe_bmp_loc_rib_dump_live_buffer(&addr0.to_string(), 3);
+        metrics.observe_bmp_loc_rib_dump_live_buffer(&addr1.to_string(), 5);
+        let (_event_tx, event_rx) = mpsc::channel(1);
+        let (_control_tx, control_rx) = mpsc::channel(1);
+        let manager = BmpManager::new(
+            event_rx,
+            control_rx,
+            vec![(addr0, loc_rib_filter(), BmpVersion::V3)],
+            metrics.clone(),
+        );
+
+        drop(manager);
+
+        for name in [
+            "bmp_loc_rib_dump_live_buffer_depth",
+            "bmp_loc_rib_dump_live_buffer_high_watermark",
+        ] {
+            assert!(!gauge_series_exists(&metrics, name, addr0));
+            assert!(gauge_series_exists(&metrics, name, addr1));
+        }
+        assert_eq!(
+            gauge_value(&metrics, "bmp_loc_rib_dump_live_buffer_depth", addr1),
+            5
+        );
+    }
+
+    #[test]
+    fn manager_drop_does_not_materialize_never_connected_series() {
+        let metrics = BgpMetrics::new();
+        let addr = collector_addr(0);
+        let (_event_tx, event_rx) = mpsc::channel(1);
+        let (_control_tx, control_rx) = mpsc::channel(1);
+        drop(BmpManager::new(
+            event_rx,
+            control_rx,
+            vec![(addr, loc_rib_filter(), BmpVersion::V3)],
+            metrics.clone(),
+        ));
+        assert!(!gauge_series_exists(
+            &metrics,
+            "bmp_loc_rib_dump_live_buffer_depth",
+            addr
+        ));
     }
 
     /// Collector channel saturates during regular fan-out → manager
@@ -2605,6 +2808,7 @@ mod tests {
             ),
             1
         );
+        assert_live_buffer_gauges(&metrics, collector_addr(0), 0, 1);
         event_tx
             .send(BmpEvent::LocRibRouteMonitoring {
                 update_pdu: Bytes::from_static(&[0xCF; 23]),
@@ -2629,6 +2833,7 @@ mod tests {
 
         let (bootstrap2, mut c_rx2) =
             connect_collector(&control_tx, 0, collector_addr(0), 16).await;
+        assert_live_buffer_gauges(&metrics, collector_addr(0), 0, 0);
         complete_bootstrap(&control_tx, 0, bootstrap2.generation).await;
         let request = dump_rx.recv().await.unwrap();
         request
@@ -2850,6 +3055,8 @@ mod tests {
             ),
             (LOC_RIB_DUMP_LIVE_BUFFER_CAP + 1) as u64
         );
+        assert_live_buffer_gauges(&metrics, collector_addr(0), 0, 8193);
+        assert_eq!(LOC_RIB_DUMP_LIVE_BUFFER_CAP, 8192);
     }
 
     /// Production mutations: awaiting one task before fencing collector 1

--- a/crates/bmp/src/manager.rs
+++ b/crates/bmp/src/manager.rs
@@ -148,6 +148,7 @@ impl CollectorPhase {
 
 struct Collector {
     addr: SocketAddr,
+    addr_label: String,
     filter: BmpMonitorFilter,
     version: BmpVersion,
     phase: CollectorPhase,
@@ -205,6 +206,7 @@ impl BmpManager {
                 .into_iter()
                 .map(|(addr, filter, version)| Collector {
                     addr,
+                    addr_label: addr.to_string(),
                     filter,
                     version,
                     phase: CollectorPhase::Disconnected,
@@ -238,6 +240,7 @@ impl BmpManager {
                     let loc_rib_peer_up = filter.loc_rib;
                     Collector {
                         addr,
+                        addr_label: addr.to_string(),
                         filter,
                         version,
                         phase: CollectorPhase::Active {
@@ -462,15 +465,15 @@ impl BmpManager {
             let msg = memo[version.idx()]
                 .get_or_insert_with(|| encode(version))
                 .clone();
-            let addr = self.collectors[idx].addr;
-            match &mut self.collectors[idx].phase {
+            let collector = &mut self.collectors[idx];
+            let addr = collector.addr;
+            let addr_label = collector.addr_label.as_str();
+            match &mut collector.phase {
                 CollectorPhase::Disconnected => {}
                 CollectorPhase::BootstrapPending { loc_rib_buffer, .. } => {
                     let overflow = buffer_loc_rib_message(loc_rib_buffer, msg);
-                    self.metrics.observe_bmp_loc_rib_dump_live_buffer(
-                        &addr.to_string(),
-                        loc_rib_buffer.len(),
-                    );
+                    self.metrics
+                        .observe_bmp_loc_rib_dump_live_buffer(addr_label, loc_rib_buffer.len());
                     if overflow {
                         overflowed.push(idx);
                     }
@@ -482,7 +485,7 @@ impl BmpManager {
                         if *generation == dump.generation {
                             let overflow = buffer_loc_rib_message(&mut dump.buffered, msg);
                             self.metrics.observe_bmp_loc_rib_dump_live_buffer(
-                                &addr.to_string(),
+                                addr_label,
                                 dump.buffered.len(),
                             );
                             if overflow {
@@ -491,12 +494,8 @@ impl BmpManager {
                         }
                     } else if let Err(e) = sender.try_send(msg) {
                         let reason = trysend_reason(&e);
-                        self.metrics.record_bmp_collector_drop(
-                            &addr.to_string(),
-                            "fan_out",
-                            reason,
-                            1,
-                        );
+                        self.metrics
+                            .record_bmp_collector_drop(addr_label, "fan_out", reason, 1);
                         warn!(collector = %addr, error = %e, "BMP collector channel full or closed, dropping message");
                     }
                 }

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -395,6 +395,8 @@ pub struct BgpMetrics {
     bmp_collector_drops: IntCounterVec,
     bmp_replay_attempts: IntCounterVec,
     bmp_control_event_drops: IntCounterVec,
+    bmp_loc_rib_dump_live_buffer_depth: IntGaugeVec,
+    bmp_loc_rib_dump_live_buffer_high_watermark: IntGaugeVec,
 
     // ── Event history outbox (ADR-0072) ───────────────────────
     event_outbox_committed: IntCounterVec,
@@ -1817,6 +1819,23 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        let bmp_loc_rib_dump_live_buffer_depth = IntGaugeVec::new(
+            Opts::new(
+                "bmp_loc_rib_dump_live_buffer_depth",
+                "Current live Loc-RIB rows buffered behind collector bootstrap or dump",
+            ),
+            &["collector"],
+        )
+        .expect("valid metric definition");
+        let bmp_loc_rib_dump_live_buffer_high_watermark = IntGaugeVec::new(
+            Opts::new(
+                "bmp_loc_rib_dump_live_buffer_high_watermark",
+                "Highest live Loc-RIB buffer depth observed in the current collector generation",
+            ),
+            &["collector"],
+        )
+        .expect("valid metric definition");
+
         // ── Event history outbox (ADR-0072) ─────────────────────
         let event_outbox_committed = IntCounterVec::new(
             Opts::new(
@@ -2344,6 +2363,14 @@ impl BgpMetrics {
             .register(Box::new(bmp_control_event_drops.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(bmp_loc_rib_dump_live_buffer_depth.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(
+                bmp_loc_rib_dump_live_buffer_high_watermark.clone(),
+            ))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(event_outbox_committed.clone()))
             .expect("metric not already registered");
         registry
@@ -2530,6 +2557,8 @@ impl BgpMetrics {
             bmp_collector_drops,
             bmp_replay_attempts,
             bmp_control_event_drops,
+            bmp_loc_rib_dump_live_buffer_depth,
+            bmp_loc_rib_dump_live_buffer_high_watermark,
             event_outbox_committed,
             event_outbox_dropped,
             event_outbox_queue_depth,
@@ -4310,6 +4339,48 @@ impl BgpMetrics {
             .inc();
     }
 
+    /// Reset live-buffer gauges for a newly validated collector generation.
+    pub fn reset_bmp_loc_rib_dump_live_buffer(&self, collector: &str) {
+        self.bmp_loc_rib_dump_live_buffer_depth
+            .with_label_values(&[collector])
+            .set(0);
+        self.bmp_loc_rib_dump_live_buffer_high_watermark
+            .with_label_values(&[collector])
+            .set(0);
+    }
+
+    /// Observe a live-buffer depth, updating both current and generation HWM.
+    pub fn observe_bmp_loc_rib_dump_live_buffer(&self, collector: &str, depth: usize) {
+        let value = i64::try_from(depth).unwrap_or(i64::MAX);
+        self.bmp_loc_rib_dump_live_buffer_depth
+            .with_label_values(&[collector])
+            .set(value);
+        let high = self
+            .bmp_loc_rib_dump_live_buffer_high_watermark
+            .with_label_values(&[collector]);
+        if value > high.get() {
+            high.set(value);
+        }
+    }
+
+    /// Clear only the current live-buffer depth after storage is discarded.
+    pub fn clear_bmp_loc_rib_dump_live_buffer(&self, collector: &str) {
+        self.bmp_loc_rib_dump_live_buffer_depth
+            .with_label_values(&[collector])
+            .set(0);
+    }
+
+    /// Remove the exact collector's live-buffer series.
+    pub fn reap_bmp_loc_rib_dump_live_buffer(&self, collector: &str) {
+        let labels = &[collector];
+        let _ = self
+            .bmp_loc_rib_dump_live_buffer_depth
+            .remove_label_values(labels);
+        let _ = self
+            .bmp_loc_rib_dump_live_buffer_high_watermark
+            .remove_label_values(labels);
+    }
+
     // ── Event history outbox (ADR-0072) ─────────────────────────
 
     /// Record a successful durable commit. Called by EHM after each
@@ -5920,6 +5991,58 @@ mod tests {
             .with_label_values(&["10.0.0.2", "channel_closed"])
             .get();
         assert_eq!(closed, 1);
+    }
+
+    #[test]
+    fn bmp_live_buffer_gauges_reset_observe_clear_and_reap_exact_series() {
+        let m = BgpMetrics::new();
+        let first = "127.0.0.1:11000";
+        let sibling = "127.0.0.1:11001";
+        for collector in [first, sibling] {
+            m.reset_bmp_loc_rib_dump_live_buffer(collector);
+        }
+        m.observe_bmp_loc_rib_dump_live_buffer(first, 1);
+        m.observe_bmp_loc_rib_dump_live_buffer(first, 3);
+        m.observe_bmp_loc_rib_dump_live_buffer(first, 2);
+        m.observe_bmp_loc_rib_dump_live_buffer(sibling, 7);
+        assert_eq!(
+            m.bmp_loc_rib_dump_live_buffer_depth
+                .with_label_values(&[first])
+                .get(),
+            2
+        );
+        assert_eq!(
+            m.bmp_loc_rib_dump_live_buffer_high_watermark
+                .with_label_values(&[first])
+                .get(),
+            3
+        );
+
+        m.clear_bmp_loc_rib_dump_live_buffer(first);
+        assert_eq!(
+            m.bmp_loc_rib_dump_live_buffer_depth
+                .with_label_values(&[first])
+                .get(),
+            0
+        );
+        assert_eq!(
+            m.bmp_loc_rib_dump_live_buffer_high_watermark
+                .with_label_values(&[first])
+                .get(),
+            3
+        );
+        m.reset_bmp_loc_rib_dump_live_buffer(first);
+        assert_eq!(
+            m.bmp_loc_rib_dump_live_buffer_high_watermark
+                .with_label_values(&[first])
+                .get(),
+            0
+        );
+
+        m.reap_bmp_loc_rib_dump_live_buffer(first);
+        let text = gather_text(&m);
+        assert!(!text.contains("collector=\"127.0.0.1:11000\""));
+        assert!(text.contains("collector=\"127.0.0.1:11001\""));
     }
 
     #[test]

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1141,6 +1141,14 @@ event-history rings, bounded stream broadcasts, subscriber gauges, and lag
 counters. Keep accepted clients on a management network and use separate
 listeners when monitoring, automation, and operators need different ceilings.
 
+For BMP Loc-RIB collectors,
+`bmp_loc_rib_dump_live_buffer_depth{collector}` reports live rows currently
+held behind bootstrap or a table dump, while
+`bmp_loc_rib_dump_live_buffer_high_watermark{collector}` retains that
+connection generation's peak. The label is the configured `SocketAddr`
+including port. Current depth returns to zero when storage is released; the
+high-water mark resets only after the next validated connection.
+
 The RPCs that deserve the most attention are:
 
 | Class | Examples | Guardrail |

--- a/docs/cookbook/monitoring-feed.md
+++ b/docs/cookbook/monitoring-feed.md
@@ -115,6 +115,13 @@ live RouteMonitoring deltas. From the daemon side the collector
 connection state is visible in the logs (`log_format = "json"`) and
 the BMP metrics below.
 
+During a Loc-RIB bootstrap or dump, watch
+`bmp_loc_rib_dump_live_buffer_depth{collector}` for the current queued live
+rows and `bmp_loc_rib_dump_live_buffer_high_watermark{collector}` for the
+connection generation's peak. The `collector` value is the configured socket
+address including port. A high-water mark near the fixed 8192-row bound means
+the collector or dump path needs investigation before the next burst.
+
 **Event replay (the bridge contract):** live tail plus durable replay
 from a cursor. `--from-event-id 0` replays everything retained, then
 tails; your bridge persists the last `event_id` it processed and


### PR DESCRIPTION
## Summary

- add per-collector current-depth and latest-generation high-water gauges for live Loc-RIB rows held behind BMP bootstrap/table dumps
- observe the real 8,193rd row before the existing fail-closed 8,192-row overflow discard
- preserve high-water evidence across completion, failure, overflow, disconnect, and shutdown while reaping exact series when the manager is removed
- cache the stable collector metric label once so per-row buffering does not allocate a new `String`
- document the metric labels and operator interpretation without changing the fixed buffer bound

## Correctness

- metric series are created/reset only after a validated Loc-RIB collector connection
- bootstrap and active-dump append paths update the same current/HWM pair; the bootstrap-to-dump handoff does not reset it
- invalid address/index, stale generation/dump, non-Loc-RIB, disconnected, and suppressed paths do not create or mutate the gauges
- storage release clears only current depth; HWM resets only on the next validated generation
- the cached `collector` label is the configured immutable `SocketAddr` string including port
- no cap, buffering, dump, reconnect, disconnect, End-of-RIB, configuration, schema, or label-cardinality behavior changes

## Load-bearing proof

Each new seam was destructively mutated and restored:

1. removing generation reset fails the reconnect/reset receipt
2. removing append observation fails the bootstrap/current/HWM receipt
3. removing storage-release clearing fails the completion/failure/overflow depth receipts
4. removing exact-series reaping fails the manager-drop receipt while sibling preservation remains asserted
5. moving overflow observation after discard loses the asserted 8,193 high-water mark

The overflow test also pins the production cap literal at 8,192.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- focused telemetry: 88/88
- focused BMP: 83/83
- independent initial and review-delta judgments: GO

Final scope: five approved files; conservative cap accounting is production 145/150 churn, tests 210/220, docs/changelog 21/35, total +363/-13 = 376/405.
