### PR TITLE
Fail gNMI ON_CHANGE closed on event history loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- gNMI STREAM/ON_CHANGE now fails with `DATA_LOSS` on producer-side
+  event-history loss during snapshot, synchronization, or live delivery and on
+  live broadcast lag; reconnecting without `updates_only` and consuming a full
+  initial snapshot establishes a fresh recoverable baseline.
+
 - Coordinated shutdown drains event history under one five-second deadline and
   latches abandoned work; submitted-append timeouts remain unknown, not drops.
 

--- a/crates/api/src/event_history_sinks.rs
+++ b/crates/api/src/event_history_sinks.rs
@@ -99,7 +99,7 @@ impl EhmRibSink {
                 self.metrics
                     .record_event_outbox_drop(category.as_str(), "queue_full");
                 self.metrics.mark_event_outbox_degraded();
-                self.state.flip_degraded();
+                self.state.record_loss();
                 warn!(
                     category = category.as_str(),
                     "event outbox producer queue full; dropping event"
@@ -385,7 +385,7 @@ pub fn record_source_lag(
 ) {
     metrics.record_event_outbox_drops_by(category, "source_lagged", missed);
     metrics.mark_event_outbox_degraded();
-    handle.state().flip_degraded();
+    handle.state().record_loss();
 }
 
 /// Try-send convenience for producers that already have a built
@@ -401,7 +401,7 @@ pub fn try_send_envelope(
         Err(TrySendError::Full(_)) => {
             metrics.record_event_outbox_drop(category.as_str(), "queue_full");
             metrics.mark_event_outbox_degraded();
-            handle.state().flip_degraded();
+            handle.state().record_loss();
             warn!(
                 category = category.as_str(),
                 "event outbox producer queue full; dropping event"
@@ -709,11 +709,45 @@ mod tests {
         manager.shutdown().await;
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn direct_queue_full_advances_loss_generation() {
+        // Load-bearing break: removing `record_loss` from
+        // `try_send_envelope`'s Full branch leaves both generation assertions red.
+        // The current-thread runtime prevents the actor from draining between sends.
+        let dir = tempfile::tempdir().unwrap();
+        let metrics = BgpMetrics::new();
+        let mut config = small_ehm_config(&dir, &metrics);
+        config.queue_capacity = 1;
+        let manager = EventHistoryManager::start(config).await.expect("EHM start");
+        let handle = manager.handle();
+        let mut losses = handle.state().subscribe_loss_generation();
+
+        try_send_envelope(
+            &handle,
+            &metrics,
+            route_event_envelope(sample_route_event(RouteEventType::Added, 0), 0),
+        );
+        assert!(!losses.has_changed().unwrap());
+        assert_eq!(drop_counter(&metrics, "route", "queue_full"), 0);
+
+        try_send_envelope(
+            &handle,
+            &metrics,
+            route_event_envelope(sample_route_event(RouteEventType::Added, 1), 0),
+        );
+        assert!(losses.has_changed().unwrap());
+        assert_eq!(*losses.borrow_and_update(), 1);
+        assert_eq!(drop_counter(&metrics, "route", "queue_full"), 1);
+
+        manager.shutdown().await;
+    }
+
     /// Queue-full pin: a full snapshot channel drops with the same
     /// counters and degraded flips the direct EHM enqueue had.
     #[test]
     fn snapshot_queue_full_drops_and_degrades() {
         let state = Arc::new(EhmState::default());
+        let mut losses = state.subscribe_loss_generation();
         let metrics = BgpMetrics::new();
         let (snapshot_tx, _snapshot_rx) = mpsc::channel(1);
         let sink = EhmRibSink {
@@ -724,15 +758,23 @@ mod tests {
 
         sink.publish_route_event(&sample_route_event(RouteEventType::Added, 0));
         assert!(!state.degraded(), "accepted publish must not degrade");
+        assert!(!losses.has_changed().unwrap());
         assert_eq!(drop_counter(&metrics, "route", "queue_full"), 0);
 
         sink.publish_route_event(&sample_route_event(RouteEventType::Added, 1));
         assert!(state.degraded(), "queue-full drop must flip EHM state");
+        assert!(losses.has_changed().unwrap());
+        assert_eq!(*losses.borrow_and_update(), 1);
         assert!(
             metrics.event_outbox_degraded(),
             "queue-full drop must flip the Prometheus gauge"
         );
         assert_eq!(drop_counter(&metrics, "route", "queue_full"), 1);
+
+        sink.publish_route_event(&sample_route_event(RouteEventType::Added, 2));
+        assert!(losses.has_changed().unwrap());
+        assert_eq!(*losses.borrow_and_update(), 2);
+        assert_eq!(drop_counter(&metrics, "route", "queue_full"), 2);
     }
 
     /// Closed pin: a closed snapshot channel (teardown) records the
@@ -741,6 +783,7 @@ mod tests {
     #[test]
     fn snapshot_channel_closed_records_drop_without_degraded() {
         let state = Arc::new(EhmState::default());
+        let losses = state.subscribe_loss_generation();
         let metrics = BgpMetrics::new();
         let (snapshot_tx, snapshot_rx) = mpsc::channel(1);
         drop(snapshot_rx);
@@ -752,6 +795,7 @@ mod tests {
 
         sink.publish_evpn_event(&sample_evpn_event());
         assert!(!state.degraded(), "closed drop must not flip EHM state");
+        assert!(!losses.has_changed().unwrap());
         assert!(
             !metrics.event_outbox_degraded(),
             "closed drop must not flip the Prometheus gauge"
@@ -770,6 +814,7 @@ mod tests {
             .await
             .expect("EHM start");
         let handle = manager.handle();
+        let losses = handle.state().subscribe_loss_generation();
         let mut committed_rx = handle.subscribe_live();
         let (sink, stage) = make_rib_event_sink(handle.clone(), metrics.clone());
 
@@ -792,16 +837,24 @@ mod tests {
             !handle.state().degraded(),
             "late publish after stage shutdown must not degrade"
         );
+        assert!(!losses.has_changed().unwrap());
 
         manager.shutdown().await;
         assert_eq!(handle.state().latest_event_id(), 16);
+        try_send_envelope(
+            &handle,
+            &metrics,
+            route_event_envelope(sample_route_event(RouteEventType::Added, 100), 0),
+        );
+        assert_eq!(drop_counter(&metrics, "route", "closed"), 2);
+        assert!(!losses.has_changed().unwrap());
     }
 
     #[tokio::test]
     async fn record_source_lag_flips_metric_and_in_process_state() {
         // Regression for the dual-signal bug the PR #291 second
         // review pass caught: `mark_event_outbox_degraded()` was
-        // called but `handle.state().flip_degraded()` was not, so
+        // called but `handle.state().record_loss()` was not, so
         // any health probe reading the in-process EHM state would
         // see `degraded() == false` even after a real source lag.
         let dir = tempfile::tempdir().unwrap();
@@ -822,6 +875,7 @@ mod tests {
         .await
         .expect("EHM start");
         let handle = manager.handle();
+        let mut losses = handle.state().subscribe_loss_generation();
         let metrics = BgpMetrics::new();
 
         // Baseline: nothing is degraded, no drops recorded.
@@ -844,10 +898,17 @@ mod tests {
             handle.state().degraded(),
             "EHM in-process state must flip on source_lagged drop"
         );
+        assert!(losses.has_changed().unwrap());
+        assert_eq!(*losses.borrow_and_update(), 1);
         assert!(
             metrics.event_outbox_degraded(),
             "Prometheus degraded gauge must flip on source_lagged drop"
         );
+
+        record_source_lag(&handle, &metrics, "dataplane", 3);
+        assert!(losses.has_changed().unwrap());
+        assert_eq!(*losses.borrow_and_update(), 2);
+        assert_eq!(drop_counter(&metrics, "dataplane", "source_lagged"), 10);
 
         manager.shutdown().await;
     }

--- a/crates/api/src/gnmi_service.rs
+++ b/crates/api/src/gnmi_service.rs
@@ -172,6 +172,38 @@ async fn forward_responses(
     true
 }
 
+async fn send_on_change_response(
+    response: Result<gnmi::SubscribeResponse, Status>,
+    tx: &tokio::sync::mpsc::Sender<Result<gnmi::SubscribeResponse, Status>>,
+    loss_rx: &mut tokio::sync::watch::Receiver<u64>,
+) -> bool {
+    tokio::select! {
+        biased;
+        changed = loss_rx.changed() => {
+            if changed.is_ok() {
+                let _ = tx.send(Err(on_change_loss_status())).await;
+            }
+            false
+        }
+        permit = tx.reserve() => {
+            let Ok(permit) = permit else {
+                return false;
+            };
+            match loss_rx.has_changed() {
+                Ok(true) => {
+                    permit.send(Err(on_change_loss_status()));
+                    false
+                }
+                Ok(false) => {
+                    permit.send(response);
+                    true
+                }
+                Err(_) => false,
+            }
+        }
+    }
+}
+
 impl GnmiService {
     /// Create a gNMI service backed by the daemon's peer manager.
     #[must_use]
@@ -649,8 +681,9 @@ impl GnmiService {
     /// fresh subscription starts a fresh initial snapshot. The
     /// disconnect window is intentionally NOT replayed — collectors
     /// that need historical replay use `SubscribeFromEvent` directly.
-    /// On broadcast `Lagged`, the stream closes with `DataLoss` so
-    /// the collector reconnects and resyncs from a fresh snapshot.
+    /// Broadcast lag or producer-side loss closes with `DataLoss` so the
+    /// collector reconnects without `updates_only` and resyncs from a full
+    /// initial snapshot.
     #[allow(
         clippy::too_many_lines,
         reason = "presence-aware live events and heartbeat reconciliation share one select loop"
@@ -684,11 +717,9 @@ impl GnmiService {
             return;
         }
 
-        // Subscribe to the live broadcast BEFORE the initial snapshot.
-        // Any transition that lands between snapshot capture and
-        // attach would otherwise be silently lost; the broadcast
-        // attach happens first, then the snapshot dedup-overrides
-        // anything stale the broadcast might also carry.
+        // Subscribe to loss and live events before the initial snapshot. The watch
+        // baselines prior loss; the next loss or transition must wake this stream.
+        let mut loss_rx = handle.state().subscribe_loss_generation();
         let mut broadcast_rx = handle.subscribe_live();
 
         // Initial snapshot — one Update per configured peer (including
@@ -697,14 +728,33 @@ impl GnmiService {
         // sync_response still flushes downstream.
         let started_updates_only = plan.updates_only;
         let mut presence = HashMap::new();
-        if !self
-            .forward_on_change_snapshot(&plan, &tx, &mut presence)
-            .await
-        {
-            return;
+        tokio::select! {
+            biased;
+            changed = loss_rx.changed() => {
+                if changed.is_ok() {
+                    let _ = tx.send(Err(on_change_loss_status())).await;
+                }
+                return;
+            }
+            completed = self.forward_on_change_snapshot(&plan, &tx, &mut presence) => {
+                if !completed {
+                    return;
+                }
+            }
         }
-        if tx.send(Ok(sync_response())).await.is_err() {
-            return;
+        tokio::select! {
+            biased;
+            changed = loss_rx.changed() => {
+                if changed.is_ok() {
+                    let _ = tx.send(Err(on_change_loss_status())).await;
+                }
+                return;
+            }
+            sent = tx.send(Ok(sync_response())) => {
+                if sent.is_err() {
+                    return;
+                }
+            }
         }
         plan.updates_only = false;
 
@@ -747,7 +797,7 @@ impl GnmiService {
                                     }
                                     None => continue,
                                 };
-                                if tx.send(Ok(response)).await.is_err() {
+                                if !send_on_change_response(Ok(response), &tx, &mut loss_rx).await {
                                     return;
                                 }
                                 if is_update {
@@ -765,13 +815,13 @@ impl GnmiService {
                     Err(RecvError::Lagged(missed)) => {
                         // Per the contract, ON_CHANGE does not paper
                         // over gaps. Close with DataLoss so the
-                        // collector reconnects and gets a fresh
-                        // initial snapshot. SubscribeFromEvent is the
-                        // RPC for historical replay.
+                        // collector reconnects without updates_only and
+                        // gets a full initial snapshot. SubscribeFromEvent
+                        // is the RPC for historical replay.
                         let _ = tx
                             .send(Err(Status::data_loss(format!(
                                 "gNMI ON_CHANGE broadcast lagged by {missed} events; \
-                                 reconnect to resync from a fresh snapshot"
+                                 reconnect without updates_only to resync from a full initial snapshot"
                             ))))
                             .await;
                         return;
@@ -788,7 +838,7 @@ impl GnmiService {
                     let mut responses = match rendered {
                         Ok(responses) => responses,
                         Err(error) => {
-                            let _ = tx.send(Err(error)).await;
+                            let _ = send_on_change_response(Err(error), &tx, &mut loss_rx).await;
                             return;
                         }
                     };
@@ -805,8 +855,10 @@ impl GnmiService {
                         let paths = removed.iter().map(|(_, path)| path.clone()).collect();
                         responses.push(update_response(Vec::new(), paths));
                     }
-                    if !forward_responses(Ok(responses), &tx).await {
-                        return;
+                    for response in responses {
+                        if !send_on_change_response(Ok(response), &tx, &mut loss_rx).await {
+                            return;
+                        }
                     }
                     presence.extend(refreshed);
                     for (identity, _) in removed {
@@ -832,6 +884,12 @@ impl GnmiService {
                         &plan,
                         heartbeat_due.clone(),
                     ));
+                },
+                changed = loss_rx.changed() => {
+                    if changed.is_ok() {
+                        let _ = tx.send(Err(on_change_loss_status())).await;
+                    }
+                    return;
                 },
                 () = tx.closed() => return,
             }
@@ -2330,6 +2388,12 @@ fn sync_response() -> gnmi::SubscribeResponse {
         response: Some(gnmi::subscribe_response::Response::SyncResponse(true)),
         extension: Vec::new(),
     }
+}
+
+fn on_change_loss_status() -> Status {
+    Status::data_loss(
+        "gNMI ON_CHANGE event history lost producer events; reconnect without updates_only to resync from a full initial snapshot",
+    )
 }
 
 fn now_nanos() -> i64 {
@@ -4899,6 +4963,23 @@ mod tests {
         }
     }
 
+    async fn next_on_change(
+        rx: &mut tokio::sync::mpsc::Receiver<Result<gnmi::SubscribeResponse, Status>>,
+    ) -> Result<gnmi::SubscribeResponse, Status> {
+        tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("ON_CHANGE response timed out")
+            .expect("ON_CHANGE stream closed without status")
+    }
+
+    fn assert_on_change_loss(error: &Status) {
+        assert_eq!(error.code(), tonic::Code::DataLoss);
+        assert_eq!(
+            error.message(),
+            "gNMI ON_CHANGE event history lost producer events; reconnect without updates_only to resync from a full initial snapshot"
+        );
+    }
+
     #[test]
     fn path_parser_accepts_wildcard_neighbor_address() {
         // Regression: gnmic and most OpenConfig collectors emit
@@ -5191,6 +5272,169 @@ mod tests {
 
         drop(stream);
         drop(harness);
+        manager.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn on_change_baselines_prior_loss_and_fails_on_the_next_loss() {
+        // Load-bearing breaks: rejecting the degraded baseline suppresses the
+        // snapshot; removing the live loss arm leaves the final receive pending.
+        let (service, manager) = ehm_service(vec![test_peer("10.0.0.2".parse().unwrap())]).await;
+        let state = manager.state();
+        state.record_loss();
+        let prior_loss = state.subscribe_loss_generation();
+        assert_eq!(*prior_loss.borrow(), 1);
+        assert!(!prior_loss.has_changed().unwrap());
+        let plan = parse_subscription_list(&stream_on_change_list(
+            neighbor_session_state_wildcard_path(),
+        ))
+        .unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(SUBSCRIBE_CHANNEL_DEPTH);
+        let task = tokio::spawn(service.run_on_change(plan, tx));
+
+        assert!(matches!(
+            next_on_change(&mut rx).await.unwrap().response,
+            Some(gnmi::subscribe_response::Response::Update(_))
+        ));
+        assert!(matches!(
+            next_on_change(&mut rx).await.unwrap().response,
+            Some(gnmi::subscribe_response::Response::SyncResponse(true))
+        ));
+        state.record_loss();
+        assert_on_change_loss(&next_on_change(&mut rx).await.unwrap_err());
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("ON_CHANGE stream did not terminate after producer loss")
+            .unwrap();
+        manager.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn on_change_loss_preempts_a_blocked_initial_snapshot() {
+        // Load-bearing break: subscribing after or not racing the snapshot lets
+        // the two-second guard expire without a terminal status.
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let snapshot_entered = Arc::clone(&entered);
+        let snapshot_release = Arc::clone(&release);
+        let manager = event_history_manager().await;
+        let state = manager.state();
+        let service = GnmiService::with_peer_snapshot(65001, "192.0.2.1", move || {
+            let entered = Arc::clone(&snapshot_entered);
+            let release = Arc::clone(&snapshot_release);
+            async move {
+                entered.notify_one();
+                release.notified().await;
+                Ok(vec![test_peer("10.0.0.2".parse().unwrap())])
+            }
+        })
+        .with_event_history(Some(manager.handle()));
+        let plan = parse_subscription_list(&stream_on_change_list(
+            neighbor_session_state_wildcard_path(),
+        ))
+        .unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(SUBSCRIBE_CHANNEL_DEPTH);
+        let task = tokio::spawn(service.run_on_change(plan, tx));
+        tokio::time::timeout(Duration::from_secs(2), entered.notified())
+            .await
+            .expect("initial snapshot did not start");
+
+        state.record_loss();
+        assert_on_change_loss(&next_on_change(&mut rx).await.unwrap_err());
+        release.notify_waiters();
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("ON_CHANGE stream did not terminate after snapshot loss")
+            .unwrap();
+        manager.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn on_change_loss_preempts_a_blocked_updates_only_sync() {
+        // Load-bearing break: removing the sync race emits sync_response after
+        // the filler drains instead of the terminal DATA_LOSS status.
+        let (service, manager) = ehm_service(Vec::new()).await;
+        let state = manager.state();
+        let mut list = stream_on_change_list(neighbor_session_state_wildcard_path());
+        list.updates_only = true;
+        let plan = parse_subscription_list(&list).unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        tx.try_send(Ok(sync_response())).unwrap();
+        let mut run = Box::pin(service.run_on_change(plan, tx));
+        std::future::poll_fn(|cx| {
+            assert!(std::future::Future::poll(run.as_mut(), cx).is_pending());
+            std::task::Poll::Ready(())
+        })
+        .await;
+
+        state.record_loss();
+        assert!(matches!(
+            next_on_change(&mut rx).await.unwrap().response,
+            Some(gnmi::subscribe_response::Response::SyncResponse(true))
+        ));
+        let task = tokio::spawn(run);
+        assert_on_change_loss(&next_on_change(&mut rx).await.unwrap_err());
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("ON_CHANGE stream did not terminate after blocked sync loss")
+            .unwrap();
+        manager.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn on_change_loss_preempts_a_blocked_live_delivery() {
+        // Load-bearing break: replacing the loss-aware send with a plain
+        // `tx.send` delivers the committed IDLE update before DATA_LOSS.
+        use crate::peer_types::SessionLifecycleEventType::Lost;
+
+        let (service, manager) = ehm_service(Vec::new()).await;
+        let state = manager.state();
+        let mut list = stream_on_change_list(neighbor_session_state_wildcard_path());
+        list.updates_only = true;
+        let plan = parse_subscription_list(&list).unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let filler_tx = tx.clone();
+        let mut run = Box::pin(service.run_on_change(plan, tx));
+        std::future::poll_fn(|cx| {
+            assert!(std::future::Future::poll(run.as_mut(), cx).is_pending());
+            std::task::Poll::Ready(())
+        })
+        .await;
+        assert!(matches!(
+            next_on_change(&mut rx).await.unwrap().response,
+            Some(gnmi::subscribe_response::Response::SyncResponse(true))
+        ));
+
+        manager
+            .handle()
+            .sender()
+            .try_send(session_envelope(Lost, Some(SessionState::Idle)))
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while state.latest_event_id() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("session event was not committed");
+        filler_tx.try_send(Ok(sync_response())).unwrap();
+        std::future::poll_fn(|cx| {
+            assert!(std::future::Future::poll(run.as_mut(), cx).is_pending());
+            std::task::Poll::Ready(())
+        })
+        .await;
+
+        state.record_loss();
+        assert!(matches!(
+            next_on_change(&mut rx).await.unwrap().response,
+            Some(gnmi::subscribe_response::Response::SyncResponse(true))
+        ));
+        let task = tokio::spawn(run);
+        assert_on_change_loss(&next_on_change(&mut rx).await.unwrap_err());
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("ON_CHANGE stream did not terminate after blocked live loss")
+            .unwrap();
         manager.shutdown().await;
     }
 

--- a/crates/event-history/src/lib.rs
+++ b/crates/event-history/src/lib.rs
@@ -663,6 +663,9 @@ pub struct EhmState {
     /// when EHM enters pass-through. Never auto-clears in v1 — the
     /// operator restarts to clear.
     degraded: AtomicBool,
+    /// Process-local wake boundary for irreversible event loss. Unlike
+    /// `degraded`, every detected loss advances this generation.
+    loss_generation: watch::Sender<u64>,
     /// True when EHM is in pass-through (no persistence, broadcasts
     /// only). Set when the allocator anchor is unrecoverable AND a
     /// prior stale file exists.
@@ -685,13 +688,21 @@ impl EhmState {
         self.pass_through.load(Ordering::Acquire)
     }
 
-    /// Flip the degraded flag to `true`. Public so out-of-crate
-    /// producers (the EHM-backed RIB sink, the BFD bridge, etc.) can
-    /// signal that they had to drop an event before it reached the
-    /// outbox. Idempotent: re-flipping a true flag is a no-op. Never
-    /// auto-clears in v1; operator restarts to clear.
-    pub fn flip_degraded(&self) {
+    /// Record an irreversible event loss. Public so out-of-crate producers
+    /// (the EHM-backed RIB sink, the BFD bridge, etc.) can signal loss before
+    /// it reaches the outbox. The degraded latch never auto-clears, while the
+    /// process-local generation advances on every call to wake live consumers.
+    pub fn record_loss(&self) {
         self.degraded.store(true, Ordering::Release);
+        self.loss_generation
+            .send_modify(|generation| *generation = generation.wrapping_add(1));
+    }
+
+    /// Subscribe to losses detected after this call. Earlier generations are
+    /// considered seen, allowing a fresh snapshot to establish a new baseline.
+    #[must_use]
+    pub fn subscribe_loss_generation(&self) -> watch::Receiver<u64> {
+        self.loss_generation.subscribe()
     }
 }
 
@@ -723,7 +734,7 @@ impl EventHistoryManager {
                     "event outbox cannot recover allocator anchor; entering pass-through mode"
                 );
                 state.pass_through.store(true, Ordering::Release);
-                state.flip_degraded();
+                state.record_loss();
                 // The crate-level API returns PassThrough here; the daemon
                 // wiring decides whether to create a live-only manager for
                 // required=false.
@@ -733,7 +744,7 @@ impl EventHistoryManager {
         };
 
         if init.had_quarantine {
-            state.flip_degraded();
+            state.record_loss();
             if let Some(metrics) = &config.metrics {
                 metrics.mark_event_outbox_degraded();
             }
@@ -975,7 +986,7 @@ fn record_shutdown_loss(
     if !progress.loss_recorded.swap(true, Ordering::AcqRel) {
         #[cfg(test)]
         progress.loss_latches.fetch_add(1, Ordering::AcqRel);
-        state.flip_degraded();
+        state.record_loss();
         if let Some(metrics) = metrics {
             metrics.mark_event_outbox_degraded();
         }
@@ -1269,7 +1280,7 @@ async fn run_actor(
                 Ok(Err(e)) => {
                     error!(error = %e, "batch commit failed; events dropped");
                     record_commit_failure_metrics(config.metrics.as_ref(), &shared);
-                    state.flip_degraded();
+                    state.record_loss();
                 }
                 Err(_) => {
                     let queued =
@@ -1335,6 +1346,33 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(1), store.test_wait_for_send(op))
             .await
             .expect("storage request backstop elapsed");
+    }
+
+    #[tokio::test]
+    async fn append_error_advances_loss_generation() {
+        // Load-bearing break: replacing `record_loss` in the actor's append-error
+        // branch with only the degraded latch exceeds the generation backstop.
+        let dir = tempfile::tempdir().unwrap();
+        let manager = EventHistoryManager::start(test_config(dir.path().join("events.db"), 1))
+            .await
+            .unwrap();
+        let state = manager.state();
+        let mut losses = state.subscribe_loss_generation();
+
+        manager.storage.shutdown().await;
+        manager
+            .sender()
+            .try_send(event(Category::Route, 1))
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), losses.changed())
+            .await
+            .expect("append-error loss generation backstop elapsed")
+            .unwrap();
+        assert_eq!(*losses.borrow_and_update(), 1);
+        assert!(state.degraded());
+        assert_eq!(state.latest_event_id(), 0);
+
+        manager.shutdown().await;
     }
 
     #[tokio::test]
@@ -1424,6 +1462,7 @@ mod tests {
         let mut manager = EventHistoryManager::start(config).await.unwrap();
         let store = manager.storage.clone();
         let state = manager.state();
+        let mut losses = state.subscribe_loss_generation();
         let progress = Arc::clone(&manager.shutdown_progress);
         store.test_pause_after_send(Append);
         manager
@@ -1467,8 +1506,11 @@ mod tests {
         assert!(has_label("reason", "shutdown_timeout"));
         assert_eq!(dropped.get_counter().value(), 1.0);
         assert_eq!(progress.loss_latches.load(Ordering::Acquire), 1);
+        assert!(losses.has_changed().unwrap());
+        assert_eq!(*losses.borrow_and_update(), 1);
         record_shutdown_loss(&state, &progress, Some(&metrics));
         assert_eq!(progress.loss_latches.load(Ordering::Acquire), 1);
+        assert!(!losses.has_changed().unwrap());
         assert_eq!(store.test_append_calls(), 1);
         manager.shutdown().await;
     }

--- a/docs/GNMI.md
+++ b/docs/GNMI.md
@@ -270,10 +270,13 @@ accepted.
   `UNIMPLEMENTED` with a message naming the supported leaf. The
   counter leaves (`messages/*`) and the `enabled` leaf stay
   SAMPLE/POLL-only in v1.
-- **Lag.** When the EHM broadcast receiver falls behind, the stream
-  closes with `DATA_LOSS` so the collector reconnects and resyncs
-  from a fresh initial snapshot. `Subscribe ON_CHANGE` does not
-  paper over gaps.
+- **Loss.** Broadcast lag or a later producer-side EHM loss closes the stream
+  with `DATA_LOSS`, including during the initial snapshot or `sync_response`.
+  To repair the gap, reconnect without `updates_only` and consume a full initial
+  snapshot. A fresh subscription baselines prior loss; it is not permanently
+  poisoned by the process-lifetime degraded latch.
+  The producer signal is service-wide, so loss in any event category closes
+  every ON_CHANGE stream rather than risking a silently incomplete view.
 - **Mixed-mode subscriptions.** A `SubscriptionList` that mixes
   `SAMPLE` and `ON_CHANGE` subscriptions is rejected with
   `UNIMPLEMENTED` — the v1 dispatch picks one mode per stream.

--- a/docs/adr/0070-gnmi-openconfig-telemetry.md
+++ b/docs/adr/0070-gnmi-openconfig-telemetry.md
@@ -174,9 +174,13 @@ the spec makes it the fallback when a client omits the encoding.
     Reconnect semantics: gNMI carries no cursor on reconnect, so each
     fresh subscription gets a fresh initial snapshot — the disconnect
     window is NOT replayed. Collectors that need historical replay
-    use `SubscribeFromEvent` directly. On broadcast `Lagged` the
-    stream closes with `DataLoss` so the collector reconnects and
-    resyncs. Counter leaves (`messages/*`) and the `enabled` leaf
+    use `SubscribeFromEvent` directly. The handler subscribes to EHM's
+    process-local loss generation before baseline work. Broadcast `Lagged` or
+    any later producer loss during snapshot, sync, or live delivery closes with
+    `DataLoss`; recovery requires reconnecting without `updates_only` and
+    consuming a full initial snapshot. A new subscription baselines prior loss.
+    The loss generation is service-wide and coalescing, not a missed-event count.
+    Counter leaves (`messages/*`) and the `enabled` leaf
     remain SAMPLE/POLL-only — counters need a separate event source,
     and `enabled` is not on the lifecycle-event payload today.
 

--- a/docs/adr/0072-durable-event-history.md
+++ b/docs/adr/0072-durable-event-history.md
@@ -763,9 +763,14 @@ reference bridge at `examples/event-bridge/`:
   `Category::Session`), decodes each `CommittedEvent`'s
   prost-encoded `BgpEvent` payload, and emits one OpenConfig leaf
   Update per transition. `FailedPrecondition` when EHM is disabled.
-  Reconnect = fresh initial snapshot (no replay); broadcast `Lagged`
-  closes with `DataLoss` so the collector reconnects. The gNMI
-  Subscribe surface stays at the `SensitiveRead` authz tier
+  Reconnect = fresh initial snapshot (no replay). A process-local watched loss
+  generation advances on every irreversible producer loss, including repeated
+  loss after the degraded latch is set. gNMI subscribes before its baseline and
+  closes with `DataLoss` on later producer loss or broadcast `Lagged`; recovery
+  reconnects without `updates_only` and consumes a full initial snapshot.
+  Normal shutdown `Closed` paths do not advance the generation. It is
+  service-wide, coalescing, and intentionally not an exact missed-event count.
+  The gNMI Subscribe surface stays at the `SensitiveRead` authz tier
   regardless of internal EHM backing — the external contract is
   still gNMI Subscribe. See [ADR-0070](0070-gnmi-openconfig-telemetry.md)
   for the v1 scope contract.


### PR DESCRIPTION
## Summary

- retain a process-local loss generation for every genuine event-history producer loss, including repeated loss after degradation is latched
- subscribe before the ON_CHANGE baseline and terminate snapshot, sync, live, and heartbeat delivery with `DATA_LOSS` on later loss
- make backpressured live and heartbeat sends loss-aware so an ordinary post-gap update cannot escape before the terminal status
- document the service-wide, coalescing signal and the required recovery: reconnect without `updates_only` and consume a full initial snapshot

Normal closed-channel teardown remains neutral and fresh subscriptions baseline earlier loss instead of inheriting a permanently poisoned process state.

## Load-bearing proofs

Sixteen restored destructive mutations made the relevant tests red. They cover retained generation with no receiver, repeated queue-full and source-lag loss, direct queue saturation, a real append failure, normal closed-channel neutrality, one-shot shutdown loss, snapshot/sync/live terminal preemption, exact status text, and a committed live event blocked behind a full output channel. Reverting that final send to plain `tx.send` delivers the stale IDLE update first and fails the regression.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- event-history package, API sink, and all ten ON_CHANGE focused tests
- two independent exact-diff semantic reviews

Scope: 7 files, +410/-46, exactly 110 non-test Rust additions.