### PR TITLE
Fail soak analyzers on terminal BGP session loss

### DIFF
--- a/docs/soaks/soak-acceptance-gates.md
+++ b/docs/soaks/soak-acceptance-gates.md
@@ -92,7 +92,7 @@ intern GC. Analyzer: `analyze-soak-gr-restart.py`.
 | Peak RSS | < 512 MB | CSV `rss_mb` max | Same. |
 | Restart cycles completed | ≥ 0.8 × (duration ÷ `RESTART_INTERVAL_SEC`) | CSV `restart_cycles` max | Incremented by the harness on every completed cycle. Analyzer floor is ≥ 1; the window floor (chosen here) rejects a run that silently stalled mid-window. 0.8× rather than 1.0× because per-cycle work (GR polling + re-establish, ~15–45 s) rides on top of the interval — a 72 h run at the 300 s default must show ≥ 691 cycles. |
 | GR evidence ordered | positive `gr_active`+`stale` observed, then both clear, every cycle | `bgp_gr_active_peers`, `bgp_gr_stale_routes` → CSV columns | Set by GR entry on peer death; cleared by EoR + stale-clear. Harness fails closed mid-run if either phase is not observed within 30 s. |
-| Session recovered at end | Established in final samples | FRR `show bgp neighbors` → CSV `bgp_established` | Every restart flips it 1→0→1. |
+| Session recovered at end | Final CSV `bgp_established` == 1 | FRR `show bgp neighbors` → CSV `bgp_established` | Every restart flips it 1→0→1. |
 | Re-establish latency | ≤ 60 s after peer returns | harness `wait_established 60` (fail-closed), `cycles.log` | Checked every cycle. |
 | Zero crash | no daemon restart | `bgp_messages_sent_total` monotone across samples (abort criterion) | Counter advances with every keepalive/update. |
 
@@ -111,7 +111,7 @@ Analyzer: `analyze-soak-hot-reload.py`.
 | Apply cycles completed | ≥ 0.9 × (duration ÷ `APPLY_INTERVAL_SEC`) | CSV `apply_cycles` | Window floor, same stall rationale as scenario 1; 0.9× (tighter than scenario 1) because an apply cycle is seconds of work against a 120 s interval. |
 | Session-flap budget | flap delta == 0 across the whole run | `rbgp neighbor -j` `flap_count` → CSV `flap_count` (backed by `bgp_session_flaps_total`) | Sampled every interval; a live-apply that bounces the session moves it immediately. |
 | Session uptime | nondecreasing | CSV `uptime_seconds` | Resets on any reconnect — catches a flap that lands between flap-count samples. |
-| Session established at end | yes | CSV `bgp_established` | Scraped from FRR every sample. |
+| Session established at end | Final CSV `bgp_established` == 1 | CSV `bgp_established` | Scraped from FRR every sample. |
 
 ### 3. Inject-churn (gRPC route injection) — `run-soak-inject-churn.sh`
 
@@ -127,7 +127,7 @@ Injection: sustained `InjectionService` AddPath/DeletePath churn
 | Churn cycles completed | ≥ 0.5 × ((duration − warmup) ÷ `CHURN_INTERVAL_SEC`) | CSV `churn_cycles` | Window floor. 0.5× of nominal because each batch is 2 × `CHURN_BATCH` sequential `docker exec` RPCs whose wall time rides on top of the 5 s interval; the receipt must state the achieved cadence. At defaults a 72 h run must show ≥ 25 908 cycles. |
 | Final consumer convergence | FRR route count == live target, exactly, within 30 s of churn end | FRR `show bgp ipv4 unicast` → CSV `frr_route_count` vs `live_target` | The consumer count tracks every add/delete batch; an off-by-anything at terminal means a lost announce or withdraw. |
 | Session-flap budget | flap delta == 0 | CSV `flap_count` / `uptime_seconds` (as scenario 2) | Sampled every interval. |
-| Session established at end | yes | CSV `bgp_established` | Every sample. |
+| Session established at end | Final CSV `bgp_established` == 1 | CSV `bgp_established` | Every sample. |
 | Injection RPC failures | 0 (fail-closed) | harness exit path + `churn.log` | Every `rbgp rib` call is checked; a failed RPC aborts the run. |
 
 ## Additional shipped scenarios

--- a/tests/soak/analyze-soak-gr-restart.py
+++ b/tests/soak/analyze-soak-gr-restart.py
@@ -11,7 +11,7 @@ JSON verdict against the soak-specific gates:
   - peak RSS < 512 MB
   - at least one restart cycle recorded
   - positive GR-active and stale-route evidence followed by both clearing
-  - BGP established observed in the final 3 samples (session recovered)
+  - BGP established in the final CSV sample (session recovered)
 
 Stdlib only. Exit code 0 on pass, 1 on any gate failure, 2 on
 harness/input error.
@@ -97,9 +97,7 @@ def analyze(rows: list[dict[str, str]]) -> dict:
 
     peak_rss = max((r for _, r in rss), default=float("nan"))
 
-    # Last 3 samples established?
-    tail = established_final[-3:] if established_final else []
-    final_established = tail.count("1") > 0 if tail else False
+    final_established = bool(established_final) and established_final[-1] == "1"
 
     gates = {
         "intern_slope_per_hour": {

--- a/tests/soak/analyze-soak-hot-reload.py
+++ b/tests/soak/analyze-soak-hot-reload.py
@@ -7,7 +7,7 @@ verdict against the soak-specific gates:
   - RSS slope (steady state, MB/hour) < 1.0
   - intern table size (bgp_rib_attr_intern_global_size) slope per hour < 1.0
   - peak RSS < 512 MB
-  - session established in final 3 samples (no flap from live-apply)
+  - session established in the final CSV sample (no flap from live-apply)
   - at least one successful apply, zero failures, and exact apply accounting
   - unchanged flap count and nondecreasing session uptime
 
@@ -106,8 +106,7 @@ def analyze(rows: list[dict[str, str]]) -> dict:
     )
     peak_rss = max((r for _, r in rss_pts), default=float("nan"))
 
-    tail = established_final[-3:] if established_final else []
-    final_established = tail.count("1") > 0 if tail else False
+    final_established = bool(established_final) and established_final[-1] == "1"
 
     total_applies = final_ok + final_fail
     gates = {

--- a/tests/soak/analyze-soak-inject-churn.py
+++ b/tests/soak/analyze-soak-inject-churn.py
@@ -7,7 +7,7 @@ verdict against the soak-specific gates:
   - RSS slope (steady state, MB/hour) < 1.0
   - intern table size (bgp_rib_attr_intern_global_size) slope per hour < 1.0
   - peak RSS < 512 MB
-  - session established in final 3 samples (no flap)
+  - session established in the final CSV sample (no flap)
   - at least one churn cycle recorded
   - final consumer route count exactly matches the live target
   - unchanged flap count and nondecreasing session uptime
@@ -95,8 +95,7 @@ def analyze(rows: list[dict[str, str]]) -> dict:
     )
     peak_rss = max((r for _, r in rss_pts), default=float("nan"))
 
-    tail = established_final[-3:] if established_final else []
-    final_established = tail.count("1") > 0 if tail else False
+    final_established = bool(established_final) and established_final[-1] == "1"
 
     gates = {
         "intern_slope_per_hour": {

--- a/tests/soak/test_intern_churn_analyzers.py
+++ b/tests/soak/test_intern_churn_analyzers.py
@@ -99,6 +99,78 @@ class AnalyzerContracts(unittest.TestCase):
             run_analyzer("analyze-soak-inject-churn.py", fields, rows).returncode, 1
         )
 
+    # Destructive proof: restoring tail.count("1") > 0 makes the terminal-down
+    # cases return 0 instead of 1.
+    def test_terminal_established_requires_final_sample_up(self):
+        cases = [
+            (
+                "analyze-soak-gr-restart.py",
+                [*BASE, "elapsed_sec", "gr_active_peers", "gr_stale_routes",
+                 "restart_cycles"],
+                [
+                    {**BASE, "elapsed_sec": "0", "gr_active_peers": "0",
+                     "gr_stale_routes": "0", "restart_cycles": "0"},
+                    {**BASE, "elapsed_sec": "3600", "gr_active_peers": "1",
+                     "gr_stale_routes": "2", "restart_cycles": "0"},
+                    {**BASE, "elapsed_sec": "7200", "gr_active_peers": "0",
+                     "gr_stale_routes": "0", "restart_cycles": "1"},
+                ],
+            ),
+            (
+                "analyze-soak-hot-reload.py",
+                [*BASE, "elapsed_sec", "apply_cycles", "apply_ok", "apply_fail",
+                 "flap_count", "uptime_seconds"],
+                [
+                    {**BASE, "elapsed_sec": "0", "apply_cycles": "0", "apply_ok": "0",
+                     "apply_fail": "0", "flap_count": "3", "uptime_seconds": "10"},
+                    {**BASE, "elapsed_sec": "3600", "apply_cycles": "1", "apply_ok": "1",
+                     "apply_fail": "0", "flap_count": "3", "uptime_seconds": "3610"},
+                    {**BASE, "elapsed_sec": "7200", "apply_cycles": "1", "apply_ok": "1",
+                     "apply_fail": "0", "flap_count": "3", "uptime_seconds": "7210"},
+                ],
+            ),
+            (
+                "analyze-soak-inject-churn.py",
+                [*BASE, "elapsed_sec", "live_target", "frr_route_count",
+                 "churn_cycles", "add_total", "del_total", "flap_count",
+                 "uptime_seconds"],
+                [
+                    {**BASE, "elapsed_sec": "0", "live_target": "1024",
+                     "frr_route_count": "0", "churn_cycles": "0", "add_total": "1024",
+                     "del_total": "0", "flap_count": "0", "uptime_seconds": "10"},
+                    {**BASE, "elapsed_sec": "3600", "live_target": "1024",
+                     "frr_route_count": "1024", "churn_cycles": "1", "add_total": "1049",
+                     "del_total": "25", "flap_count": "0", "uptime_seconds": "3610"},
+                    {**BASE, "elapsed_sec": "7200", "live_target": "1024",
+                     "frr_route_count": "1024", "churn_cycles": "1", "add_total": "1049",
+                     "del_total": "25", "flap_count": "0", "uptime_seconds": "7210"},
+                ],
+            ),
+        ]
+        scenarios = (
+            ("three_up", ["1", "1", "1"], True),
+            ("recovered", ["0", "1", "1"], True),
+            ("two_up", ["1", "1"], True),
+            ("down_for_two", ["1", "0", "0"], False),
+            ("terminal_down", ["1", "1", "0"], False),
+        )
+        for analyzer, fields, valid_rows in cases:
+            for scenario, states, expected_pass in scenarios:
+                with self.subTest(analyzer=analyzer, scenario=scenario):
+                    rows = [dict(row) for row in valid_rows[-len(states):]]
+                    for row, state in zip(rows, states):
+                        row["bgp_established"] = state
+                    result = run_analyzer(analyzer, fields, rows)
+                    payload = json.loads(result.stdout)
+                    target = payload["gates"]["final_session_established"]
+                    self.assertEqual(result.returncode, 0 if expected_pass else 1,
+                                     result.stderr)
+                    self.assertEqual(target["pass"], expected_pass)
+                    self.assertTrue(all(
+                        gate["pass"] for name, gate in payload["gates"].items()
+                        if expected_pass or name != "final_session_established"
+                    ), payload)
+
     def test_missing_or_malformed_required_evidence_is_input_error(self):
         cases = [
             ("analyze-soak-gr-restart.py", "gr_stale_routes",


### PR DESCRIPTION
## Summary

- make the GR-restart, hot-reload, and injection-churn analyzers require the explicit terminal CSV sample to be Established
- keep recovered transient and short valid evidence accepted; whole-run flap/uptime and ordered-GR gates remain independent
- document the exact terminal-row contract in each analyzer and the soak acceptance table
- add one table-driven regression covering positive and terminal-down tails across all three analyzers

## Load-bearing proof

For each analyzer, restoring the prior `tail.count("1") > 0` predicate makes both terminal-down cases (`1,0,0` and `1,1,0`) return success, so the focused regression goes red. The production predicate was reverted independently in all three files and restored after each failure.

The test also proves the intended boundary:

- `1,1,1`, `0,1,1`, and two-row `1,1` pass
- `1,0,0` and `1,1,0` fail
- every non-target gate remains green in each negative case

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `python3 -m unittest -v tests/soak/test_intern_churn_analyzers.py`
- independent exact-diff review: MERGE

This is the primary-analyzer slice of LAN-816. The audit's separate M67, Gate8b, and scale-validator proof gaps remain tracked independently.
