### PR TITLE
Fail M67 receipt on terminal BGP session loss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,6 +346,7 @@ jobs:
           python3 -m unittest discover \
             -s bench/scale/enhanced-route-refresh -p 'test_*.py'
           python3 -m unittest -v tests/soak/test_intern_churn_analyzers.py
+          python3 -m unittest -v tests/soak/test_m67_link_drain_analyzer.py
           python3 bench/scale/rebaseline/test_classifiers.py
           python3 bench/scale/rebaseline/test_parse_rrharness.py
           python3 bench/scale/rebaseline/test_validate_lan395_criterion.py

--- a/docs/soaks/soak-acceptance-gates.md
+++ b/docs/soaks/soak-acceptance-gates.md
@@ -167,9 +167,10 @@ Gates (analyzer defaults): verdict `pass`; per-node RSS slope
 < 512 MB; measured failover blackout ≤ 30 000 ms and drain release
 ≤ 30 000 ms per cycle (a `-1` unmeasured sentinel fails the cycle —
 a missing prober log can never read as a perfect 0 ms failover);
-cycle count ≥ floor; session transients ≤ 2 samples; docker restart
-counters flat; `pe1_operator_drain` stays 0 (the link stimulus must
-not leak into the operator-drain reason).
+cycle count ≥ floor; session transients ≤ 2 samples and both sessions
+Established in the final CSV row; docker restart counters flat;
+`pe1_operator_drain` stays 0 (the link stimulus must not leak into the
+operator-drain reason).
 
 ### 7. Gate 8b BUM-state — `run-gate8b-soak.sh` (`analyze-gate8b-soak.py`)
 

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -14,12 +14,12 @@ TRIGGER_HASH = "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8
 PERMISSION_HASH = "9691400b3b1036bcdfe724926816dbe71b0aa22ed9b5eb89627e2eeb75079898"
 JOB_HASHES = {
     "core": "81bea34b590cff22f28e437e20dd15ba200d1bfb2424b9158ecdc1c61ac4b2e9",
-    "scale_receipts": "0d6914750718aa18049269ed71ca4de5d85f75ce931701d6af305fb6c2d9844c",
+    "scale_receipts": "71fc9a6a31c39d155ed8da45a326902bc8723ce7472777defea37796175d13fd",
     "check": "afc9629a32cc7c3194ccf0417aaf2623e7a01a8dc95fd0194c2cbfbb29068b57",
     "msrv": "db1ae833d9c8fbbc47dbf2969ac291b90cf413ba9eed2b95dd4cfe34e0a4ba5d",
     "evpn_bum_filter_kernel": "f965e7f95f30772d9d335104dda9e30c53816098bd5f1225a3cadabe7d9a23b3",
 }
-COMMAND_BODY_HASH = "7135e8d910c9a804be659a92ef36d6dfb359668e168990e1d1062744a5609048"
+COMMAND_BODY_HASH = "f2188fe710b2d44b857895000eb9ada9d26a7a2791a1972e2f0bab292a7929d6"
 STEP_NAME = "Check standalone scale harnesses and receipt classifiers"
 CHECKOUT = "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7"
 TOOLCHAIN = (

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -409,7 +409,9 @@ Publish the 24h postmortem only after checking:
 - vtep sessions to both PEs show no sustained non-Established window. The
   sampler records the VTEP's `rbgp neighbor -j` state; isolated CLI/query
   misses are counted in `session_probe_transients`, while a run longer than
-  `--session-transient-samples` fails the gate.
+  `--session-transient-samples` fails the gate. Both sessions must also be
+  Established in the final CSV row; the transient allowance cannot mask a
+  terminal outage.
 - Docker restart counters for vtep/pe1/pe2 stay flat.
 - Every cycle observes pe1 link drain, pe2 DF promotion, AC-gate handover,
   bounded ping blackout, held recovery, pe1 DF restoration, and the CE MAC Type

--- a/tests/soak/analyze-m67-link-drain-soak.py
+++ b/tests/soak/analyze-m67-link-drain-soak.py
@@ -5,7 +5,8 @@ Reads the CSV emitted by run-m67-link-drain-churn-soak.sh and produces a JSON
 verdict for the soak-specific gates:
 
   - no recorded harness failures,
-  - vtep sessions to both PEs have no sustained non-Established window,
+  - vtep sessions to both PEs have no sustained non-Established window and are
+    Established in the final CSV row,
   - container restart counters stay flat,
   - the run observes both drained and recovered phases,
   - pe1/pe2 DF role and link-drain gauges transition through the expected states,
@@ -202,6 +203,12 @@ def main() -> None:
          f"transient samples: pe1={pe1_session_stats[0]} across "
          f"{pe1_session_stats[1]} run(s), pe2={pe2_session_stats[0]} "
          f"across {pe2_session_stats[1]} run(s))")
+    gate("sessions_established_at_end",
+         rows[-1].get("pe1_session_established") == "1"
+         and rows[-1].get("pe2_session_established") == "1",
+         "final CSV vtep neighbor states "
+         f"(pe1={rows[-1].get('pe1_session_established')}, "
+         f"pe2={rows[-1].get('pe2_session_established')})")
     gate("restart_counts_flat",
          is_flat(rows, "pe1_restart_count")
          and is_flat(rows, "pe2_restart_count")

--- a/tests/soak/test_m67_link_drain_analyzer.py
+++ b/tests/soak/test_m67_link_drain_analyzer.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Fail-closed contracts for the M67 link-drain soak analyzer."""
+
+import csv
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+HERE = Path(__file__).parent
+FIELDS = [
+    "elapsed_sec", "cycle", "phase", "pe1_rss_mb", "pe2_rss_mb",
+    "vtep_rss_mb", "pe1_session_established", "pe2_session_established",
+    "pe1_restart_count", "pe2_restart_count", "vtep_restart_count",
+    "pe1_link_drain", "pe1_operator_drain", "pe2_df", "pe2_nondf",
+    "blackout_ms", "release_ms", "failures",
+]
+BASE_ROWS = [
+    {
+        "elapsed_sec": "0", "cycle": "0", "phase": "drained",
+        "pe1_rss_mb": "10", "pe2_rss_mb": "10", "vtep_rss_mb": "10",
+        "pe1_restart_count": "0", "pe2_restart_count": "0",
+        "vtep_restart_count": "0", "pe1_link_drain": "1",
+        "pe1_operator_drain": "0", "pe2_df": "1", "pe2_nondf": "0",
+        "blackout_ms": "100", "release_ms": "", "failures": "0",
+    },
+    {
+        "elapsed_sec": "10", "cycle": "1", "phase": "recovered",
+        "pe1_rss_mb": "10", "pe2_rss_mb": "10", "vtep_rss_mb": "10",
+        "pe1_restart_count": "0", "pe2_restart_count": "0",
+        "vtep_restart_count": "0", "pe1_link_drain": "0",
+        "pe1_operator_drain": "0", "pe2_df": "0", "pe2_nondf": "1",
+        "blackout_ms": "", "release_ms": "100", "failures": "0",
+    },
+    {
+        "elapsed_sec": "20", "cycle": "1", "phase": "idle",
+        "pe1_rss_mb": "10", "pe2_rss_mb": "10", "vtep_rss_mb": "10",
+        "pe1_restart_count": "0", "pe2_restart_count": "0",
+        "vtep_restart_count": "0", "pe1_link_drain": "0",
+        "pe1_operator_drain": "0", "pe2_df": "0", "pe2_nondf": "1",
+        "blackout_ms": "", "release_ms": "", "failures": "0",
+    },
+]
+
+
+def run_analyzer(pe1_states, pe2_states):
+    rows = [dict(row) for row in BASE_ROWS]
+    for row, pe1, pe2 in zip(rows, pe1_states, pe2_states):
+        row["pe1_session_established"] = pe1
+        row["pe2_session_established"] = pe2
+    with tempfile.TemporaryDirectory() as tmp:
+        samples = Path(tmp) / "samples.csv"
+        with samples.open("w", newline="") as stream:
+            writer = csv.DictWriter(stream, fieldnames=FIELDS)
+            writer.writeheader()
+            writer.writerows(rows)
+        result = subprocess.run(
+            ["python3", str(HERE / "analyze-m67-link-drain-soak.py"),
+             str(samples)],
+            text=True, capture_output=True, check=False,
+        )
+    return result, json.loads(result.stdout)
+
+
+class M67AnalyzerContracts(unittest.TestCase):
+    # Destructive proof: deleting the terminal gate makes both terminal-down
+    # cases return 0; deleting either peer clause breaks its matching case.
+    def test_terminal_sessions_must_both_be_established(self):
+        cases = (
+            ("recovered", ["0", "0", "1"], ["0", "0", "1"], True),
+            ("pe1_terminal_down", ["1", "0", "0"], ["1", "1", "1"], False),
+            ("pe2_terminal_down", ["1", "1", "1"], ["1", "0", "0"], False),
+        )
+        for scenario, pe1_states, pe2_states, expected_pass in cases:
+            with self.subTest(scenario=scenario):
+                result, payload = run_analyzer(pe1_states, pe2_states)
+                gates = {gate["name"]: gate for gate in payload["gates"]}
+                self.assertEqual(result.returncode, 0 if expected_pass else 1,
+                                 result.stderr)
+                self.assertTrue(gates["sessions_stayed_established"]["pass"])
+                if expected_pass:
+                    self.assertTrue(all(gate["pass"] for gate in gates.values()), payload)
+                else:
+                    self.assertFalse(gates["sessions_established_at_end"]["pass"])
+                    self.assertTrue(all(
+                        gate["pass"] for name, gate in gates.items()
+                        if name != "sessions_established_at_end"
+                    ), payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- require both M67 VTEP-to-PE sessions to be Established in the final CSV row
- preserve the existing allowance for up to two consecutive transient sampler misses
- add and CI-enroll a dedicated regression that isolates PE1 and PE2 terminal loss
- refresh the scale-job structural fence for the intentional CI enrollment
- document the difference between tolerated interior transients and forbidden terminal outage

## Load-bearing proof

The table-driven regression saturates the existing transient allowance and proves the boundary:

- both peers `0,0,1` pass with every gate green
- PE1 `1,0,0` with PE2 healthy fails only `sessions_established_at_end`
- PE2 `1,0,0` with PE1 healthy fails only `sessions_established_at_end`

Deleting the combined terminal gate makes both outage cases false-green. Removing only the PE1 or PE2 clause makes that peer's matching case false-green. Each mutation was applied independently and restored before final verification.

## Verification

- `python3 -m unittest -v tests/soak/test_m67_link_drain_analyzer.py`
- `python3 -m unittest -v tests/soak/test_intern_churn_analyzers.py`
- `python3 -m unittest -v scripts/test_check_ci_scale_split_contract.py`
- `python3 scripts/check_ci_scale_split_contract.py`
- committed 4,800-row M67 receipt reanalysis at `--min-cycles 960`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- independent exact-diff review: MERGE

This is the M67 child slice of the broader soak/scale reconnect audit. Gate8b and scale-validator proof gaps remain tracked independently.
