### PR TITLE
Fail Gate8b recovery seams closed

### DIFF
--- a/tests/soak/run-gate8b-mac-churn-soak.sh
+++ b/tests/soak/run-gate8b-mac-churn-soak.sh
@@ -395,12 +395,21 @@ flip_stop_daemon() {
     esac
     docker exec "$container" sh -c \
         "pid=\$(pidof rustbgpd) && [ -n \"\$pid\" ] && kill ${signal} \$pid" \
-        2>/dev/null || true
-    local i
-    for i in $(seq 1 30); do
-        if ! docker exec "$container" pidof rustbgpd >/dev/null 2>&1; then
-            return 0
-        fi
+        2>/dev/null || return
+    local i state
+    for ((i = 0; i < 30; i++)); do
+        state="$(docker exec "$container" sh -c '
+            if pidof rustbgpd >/dev/null 2>&1; then
+                printf running
+            else
+                printf stopped
+            fi
+        ')" || return
+        case "$state" in
+            stopped) return 0 ;;
+            running) ;;
+            *) log "ERROR: $container returned unknown daemon state: $state"; return 1 ;;
+        esac
         sleep 1
     done
     log "WARN: $container rustbgpd did not exit within 30s of ${KILL_MODE} signal"
@@ -410,7 +419,16 @@ flip_stop_daemon() {
 flip_start_daemon() {
     local container="$1" local_ip="$2" remote_ip="$3"
     docker exec "$container" /usr/local/bin/start-rustbgpd-soak-gate8b.sh \
-        "$local_ip" "$remote_ip" "$VNI" || true
+        "$local_ip" "$remote_ip" "$VNI" || return
+}
+
+stop_pe2_daemon() {
+    flip_stop_daemon "$PE2_NAME" || return; PE2_RUNNING=0
+}
+
+start_pe2_daemon() {
+    flip_start_daemon "$PE2_NAME" 10.0.0.2 10.0.0.1 || return
+    wait_established_post_flip "$PE2_NAME" || return; PE2_RUNNING=1
 }
 
 # ---------------------------------------------------------------------------
@@ -862,12 +880,13 @@ while [ "$(date +%s)" -lt "$END_UNIX" ]; do
         if [ "$PE2_RUNNING" = "1" ]; then
             flip_log "stopping PE2 daemon (mode=${KILL_MODE})"
             log "flip: stopping PE2 daemon (mode=${KILL_MODE})"
-            flip_stop_daemon "$PE2_NAME" || true
-            PE2_RUNNING=0
+            if ! stop_pe2_daemon; then
+                log "FATAL: PE2 daemon stop failed"
+                exit 4
+            fi
         else
             flip_log "starting PE2 daemon"
             log "flip: starting PE2 daemon"
-            flip_start_daemon "$PE2_NAME" 10.0.0.2 10.0.0.1
             # Wait for re-establishment so the next sample isn't
             # credited as a nominal steady-state row when the
             # session has actually failed to come back. The fresh
@@ -876,13 +895,15 @@ while [ "$(date +%s)" -lt "$END_UNIX" ]; do
             # once). No cross-restart baseline survives — the
             # counter is in-process — so a `>= 1` gate is the
             # right invariant.
-            wait_established_post_flip "$PE2_NAME" || true
+            if ! start_pe2_daemon; then
+                log "FATAL: PE2 daemon start or session recovery failed"
+                exit 4
+            fi
             # Kernel netns survives a process restart, so the
             # bridge / VXLAN / CE veth / FDB rows are still in
             # place — the churn pool tracking remains accurate.
             # (The old `: >$PE2_POOL` reset was only needed when
             # the container itself was destroyed by `docker stop`.)
-            PE2_RUNNING=1
         fi
         # Post-flip guard: assert the clab veth + 10.0.0.x is
         # still intact. With process-restart this is defense in

--- a/tests/soak/run-gate8b-soak.sh
+++ b/tests/soak/run-gate8b-soak.sh
@@ -47,6 +47,7 @@ SOAK_HOURS="${SOAK_HOURS:-24}"
 SAMPLE_INTERVAL="${SAMPLE_INTERVAL:-60}"          # seconds between CSV rows
 FLIP_INTERVAL_SEC="${FLIP_INTERVAL_SEC:-600}"     # 10-minute DF flips by default
 WARMUP_SEC="${WARMUP_SEC:-120}"                   # discard first 2 min of samples for slope
+BGP_ESTABLISHED_TIMEOUT_SEC="${BGP_ESTABLISHED_TIMEOUT_SEC:-300}"
 PE1_NAME="${PE1_NAME:-clab-gate8b-soak-pe1}"
 PE2_NAME="${PE2_NAME:-clab-gate8b-soak-pe2}"
 CLEANUP="${CLEANUP:-0}"                           # 1 = destroy topology on EXIT
@@ -189,6 +190,24 @@ bridge_flag_state() {
     fi
 }
 
+wait_current_established() {
+    local pe="$1" deadline current
+    deadline=$(($(date +%s) + BGP_ESTABLISHED_TIMEOUT_SEC))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        current="$(prom_extract "$(prom_scrape "$pe")" bgp_peer_session_established)"
+        [ "${current:-0}" = "1" ] && return 0
+        sleep 5
+    done
+    log "ERROR: $pe did not return to Established within ${BGP_ESTABLISHED_TIMEOUT_SEC}s"; return 1
+}
+
+restart_pe2() {
+    docker start "$PE2_NAME" >/dev/null || return
+    docker exec "$PE2_NAME" /usr/local/bin/start-rustbgpd-soak-gate8b.sh 10.0.0.2 10.0.0.1 100 || return
+    wait_current_established "$PE2_NAME" || return
+    PE2_RUNNING=1
+}
+
 # ---------------------------------------------------------------------------
 # Pre-flight
 # ---------------------------------------------------------------------------
@@ -314,19 +333,19 @@ while [ "$(date +%s)" -lt "$END_UNIX" ]; do
         else
             flip_log "starting PE2"
             log "flip: starting PE2"
-            docker start "$PE2_NAME" >/dev/null
             # Re-exec the start script after `docker start` since
             # exec entries from the topology only fire on initial
             # deploy. Without this PE2 wouldn't bring up its bridge
             # / VXLAN on the second start.
-            docker exec "$PE2_NAME" /usr/local/bin/start-rustbgpd-soak-gate8b.sh \
-                10.0.0.2 10.0.0.1 100 || true
+            if ! restart_pe2; then
+                log "FATAL: PE2 restart or session recovery failed"
+                exit 4
+            fi
             # Re-attach the docker-logs tail since `docker start`
             # invalidated the prior tail's underlying stream.
             kill "$PE2_TAIL_PID" 2>/dev/null || true
             docker logs -f "$PE2_NAME" >>"$PE2_LOG" 2>&1 &
             PE2_TAIL_PID=$!
-            PE2_RUNNING=1
         fi
         NEXT_FLIP_UNIX="$((NOW + FLIP_INTERVAL_SEC))"
     fi

--- a/tests/soak/test_intern_churn_analyzers.py
+++ b/tests/soak/test_intern_churn_analyzers.py
@@ -206,6 +206,83 @@ class AnalyzerContracts(unittest.TestCase):
             text=True, capture_output=True, check=False,
         )
 
+    def bash_functions(self, script, names, body):
+        source = (HERE / script).read_text()
+        functions = []
+        for name in names:
+            start = source.index(f"{name}() {{")
+            end = source.index("\n}\n", start) + 3
+            functions.append(source[start:end])
+        return subprocess.run(["bash", "-c", "\n".join([*functions, body])],
+                              text=True, capture_output=True, check=False)
+
+    def test_gate8b_recovery_transitions_fail_closed(self):
+        base = r'''
+PE2_NAME=pe2; PE2_RUNNING=0
+docker() { case "$MODE:$1" in start:start) return 11;; setup:exec) return 12;; esac; }
+wait_current_established() { [ "$MODE" != established ]; }
+restart_pe2; rc=$?; printf '%s' "$PE2_RUNNING"; exit "$rc"
+'''
+        for mode, code, state in (("start", 11, "0"), ("setup", 12, "0"),
+                                  ("established", 1, "0"), ("good", 0, "1")):
+            with self.subTest(runner="base", mode=mode):
+                result = self.bash_functions(
+                    "run-gate8b-soak.sh", ("restart_pe2",), f"MODE={mode}\n{base}"
+                )
+                self.assertEqual((result.returncode, result.stdout), (code, state))
+        wait = r'''
+clock=$(mktemp); echo 0 >"$clock"; BGP_ESTABLISHED_TIMEOUT_SEC=2
+date() { n=$(cat "$clock"); echo "$n"; echo $((n + 1)) >"$clock"; }
+prom_scrape() { :; }; prom_extract() { [ "$MODE" = current ] && echo 1 || echo 0; }
+sleep() { :; }; log() { :; }
+wait_current_established pe2
+'''
+        for mode, code in (("current", 0), ("down", 1)):
+            with self.subTest(runner="base-wait", mode=mode):
+                result = self.bash_functions("run-gate8b-soak.sh", ("wait_current_established",), f"MODE={mode}\n{wait}")
+                self.assertEqual(result.returncode, code)
+        stop = r'''
+KILL_MODE=term; PE2_NAME=pe2; PE2_RUNNING=1
+docker() { case "$MODE:$*" in stop:*kill*) return 1;; transport:*printf\ running*) return 2;; unknown:*printf\ running*) echo unknown;; running:*printf\ running*) echo running;; *:*printf\ running*) echo stopped;; esac; }
+sleep() { :; }; log() { :; }
+stop_pe2_daemon; rc=$?; printf '%s' "$PE2_RUNNING"; exit "$rc"
+'''
+        start = r'''
+VNI=100; PE2_NAME=pe2; PE2_RUNNING=0
+docker() { [ "$MODE" != start ]; }
+wait_established_post_flip() { [ "$MODE" != established ]; }
+start_pe2_daemon; rc=$?; printf '%s' "$PE2_RUNNING"; exit "$rc"
+'''
+        for mode, functions, body, code, state in (
+            ("stop", ("flip_stop_daemon", "stop_pe2_daemon"), stop, 1, "1"),
+            ("transport", ("flip_stop_daemon", "stop_pe2_daemon"), stop, 2, "1"),
+            ("unknown", ("flip_stop_daemon", "stop_pe2_daemon"), stop, 1, "1"),
+            ("running", ("flip_stop_daemon", "stop_pe2_daemon"), stop, 1, "1"),
+            ("good", ("flip_stop_daemon", "stop_pe2_daemon"), stop, 0, "0"),
+            ("start", ("flip_start_daemon", "start_pe2_daemon"), start, 1, "0"),
+            ("established", ("flip_start_daemon", "start_pe2_daemon"), start, 1, "0"),
+            ("good", ("flip_start_daemon", "start_pe2_daemon"), start, 0, "1")):
+            with self.subTest(runner="mac", mode=mode, function=functions[-1]):
+                result = self.bash_functions(
+                    "run-gate8b-mac-churn-soak.sh", functions, f"MODE={mode}\n{body}"
+                )
+                self.assertEqual((result.returncode, result.stdout), (code, state))
+
+    def test_gate8b_recovery_callers_preserve_ordering(self):
+        base = (HERE / "run-gate8b-soak.sh").read_text()
+        restart = base[base.index("restart_pe2() {"):base.index("\n}\n", base.index("restart_pe2() {"))]
+        self.assertIn("if ! restart_pe2; then", base)
+        for before, after in (("docker start", "docker exec"),
+                              ("docker exec", "wait_current_established"),
+                              ("wait_current_established", "PE2_RUNNING=1")):
+            self.assertLess(restart.index(before), restart.index(after))
+        self.assertIn("bgp_peer_session_established", base)
+        mac = (HERE / "run-gate8b-mac-churn-soak.sh").read_text()
+        for call in ("stop_pe2_daemon", "start_pe2_daemon"):
+            self.assertIn(f"if ! {call}; then", mac)
+        self.assertLess(mac.index("flip_stop_daemon \"$PE2_NAME\""), mac.index("PE2_RUNNING=0"))
+        self.assertLess(mac.index("wait_established_post_flip \"$PE2_NAME\""), mac.index("PE2_RUNNING=1"))
+
     def test_gr_runner_requires_complete_ordered_restart(self):
         # The restart kills only bgpd (never the container's PID 1) and
         # supervises the comeback itself when watchfrr abandons the


### PR DESCRIPTION
## Summary

- require the container-restart runner to complete startup and observe the current session Established before marking PE2 running
- require the process-restart runner to observe stop, start, and fresh re-establishment success before changing its harness state
- distinguish an observed stopped daemon from Docker transport failure or unknown probe output

The runners keep their existing restart models and deliberate PE2-down phases. This patch does not change the CSV schema, analyzer, topology, timing bounds, or daemon behavior.

## Load-bearing regression proof

The focused contract test extracts and executes the production shell functions with injected failures. Independently restoring each former fail-open seam makes only its matching case red:

- container start, setup, and current-Established failures
- process stop signal, stop-probe transport, unknown, running, and stopped states
- process daemon start and post-restart establishment failures
- premature running-state assignments in either runner

Successful recovery remains green, and the existing analyzer contract suite stays green.

## Verification

- `python3 -m unittest -v tests/soak/test_intern_churn_analyzers.py`
- `python3 -m py_compile tests/soak/test_intern_churn_analyzers.py`
- `bash -n tests/soak/run-gate8b-soak.sh tests/soak/run-gate8b-mac-churn-soak.sh`
- `shellcheck -x -e SC1091,SC2034 tests/soak/run-gate8b-soak.sh tests/soak/run-gate8b-mac-churn-soak.sh`
- `python3 scripts/check_ci_scale_split_contract.py`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- independent exact-diff review: MERGE
