### PR TITLE
Require Gate8b terminal session recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,6 +346,7 @@ jobs:
           python3 -m unittest discover \
             -s bench/scale/enhanced-route-refresh -p 'test_*.py'
           python3 -m unittest -v tests/soak/test_intern_churn_analyzers.py
+          python3 -m unittest -v tests/soak/test_gate8b_recovery_contract.py
           python3 -m unittest -v tests/soak/test_m67_link_drain_analyzer.py
           python3 bench/scale/rebaseline/test_classifiers.py
           python3 bench/scale/rebaseline/test_parse_rrharness.py

--- a/docs/soaks/soak-acceptance-gates.md
+++ b/docs/soaks/soak-acceptance-gates.md
@@ -174,17 +174,21 @@ operator-drain reason).
 
 ### 7. Gate 8b BUM-state — `run-gate8b-soak.sh` (`analyze-gate8b-soak.py`)
 
-DF flips via in-container daemon process restart (SIGTERM; opt-in
-SIGKILL via `KILL_MODE=kill`). Gates: per-PE RSS slope < 1.5 MB/h;
+DF flips via PE2 container stop/start, including setup-script replay, current
+session recovery, and log-tail reattachment. Gates: per-PE RSS slope < 1.5 MB/h;
 peak RSS < 512 MB; DF transition counters (`evpn_df_role_changes_total`)
 monotone — a reset means an unplanned daemon restart; ≥ 1 full flip
-cycle (window floor 0.9× applies); `verify_topology_link` passes before
-and after every flip (fail-loud exit 4 — the tripwire for the
-veth-destroyed false positive documented in the README).
+cycle (window floor 0.9× applies); the single terminal row has
+`pe2_running = 1` and both `pe*_session_established = 1`.
 
 ### 8. Gate 8b MAC-churn — `run-gate8b-mac-churn-soak.sh`
 
 Scenario 7 plus sustained FDB churn and RFC 7432 §15.1 mobility moves.
+This runner flips only the in-container daemon process (SIGTERM; opt-in SIGKILL)
+so the netns and FDB survive, and retains its before/after
+`verify_topology_link` tripwire. Its terminal recovery must restore the current
+sessions and preserve that topology; cumulative establishment counters are
+diagnostic only.
 Analyzer coverage is scenario 7's (`analyze-gate8b-soak.py`); the
 MAC-churn-specific gates are precommitted here and read from
 `samples.csv`: `evpn_local_origination_errors_total` == 0 (CSV

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -14,12 +14,12 @@ TRIGGER_HASH = "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8
 PERMISSION_HASH = "9691400b3b1036bcdfe724926816dbe71b0aa22ed9b5eb89627e2eeb75079898"
 JOB_HASHES = {
     "core": "81bea34b590cff22f28e437e20dd15ba200d1bfb2424b9158ecdc1c61ac4b2e9",
-    "scale_receipts": "71fc9a6a31c39d155ed8da45a326902bc8723ce7472777defea37796175d13fd",
+    "scale_receipts": "91d5396ba46147fd7a489b49cbc6207f8588f350df3308c92f236f3936dbcf4f",
     "check": "afc9629a32cc7c3194ccf0417aaf2623e7a01a8dc95fd0194c2cbfbb29068b57",
     "msrv": "db1ae833d9c8fbbc47dbf2969ac291b90cf413ba9eed2b95dd4cfe34e0a4ba5d",
     "evpn_bum_filter_kernel": "f965e7f95f30772d9d335104dda9e30c53816098bd5f1225a3cadabe7d9a23b3",
 }
-COMMAND_BODY_HASH = "f2188fe710b2d44b857895000eb9ada9d26a7a2791a1972e2f0bab292a7929d6"
+COMMAND_BODY_HASH = "9e3c949873c8c0872a1a5403b69300c3a5306025af3cf893782ff1d60a1a2b2f"
 STEP_NAME = "Check standalone scale harnesses and receipt classifiers"
 CHECKOUT = "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7"
 TOOLCHAIN = (

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -448,6 +448,11 @@ the BUM-suppression rtnetlink path is exercised on every flip.
 - iBGP L2VPN/EVPN session between PE1 (10.0.0.1) and PE2
   (10.0.0.2).
 
+This base runner deliberately exercises **container restart** (`docker stop` /
+`docker start`), reruns the container setup script, waits for the current BGP
+session gauge, and reattaches its log tail. The MAC-churn runner below uses a
+daemon-process restart instead because its kernel FDB and netns must survive.
+
 ## Run
 
 ```bash
@@ -476,8 +481,14 @@ pe1_rss_mb, pe2_rss_mb,
 pe1_df_role, pe2_df_role,
 pe1_df_changes, pe2_df_changes,
 pe1_bum_flags, pe2_bum_flags,    # df / nondf / mixed / unreachable
-pe2_running                       # 1 / 0 driven by harness
+pe2_running,                      # 1 / 0 driven by harness
+pe1_session_established, pe2_session_established  # current-session gauges
 ```
+
+The current-gauge columns are an intentional schema boundary and sit directly
+after `pe2_running`. At duration expiry the runner recovers PE2 if the final
+flip left it down, then always appends exactly one terminal evidence row. A
+failed recovery leaves that row in the receipt and makes the runner fail.
 
 Plus per-PE daemon logs streamed to `pe1.log` / `pe2.log` and
 flip events recorded in `flips.log` so post-mortem of any anomaly
@@ -502,7 +513,8 @@ python3 tests/soak/analyze-gate8b-soak.py \
 
 Gates: per-PE memory slope < 1.5 MB/h, peak RSS < 512 MB, DF
 transition counters monotone (no daemon restart inside the
-window), at least one full flip cycle observed.
+window), at least one full flip cycle observed, and the terminal row reports
+`pe2_running = 1` with both current-session gauges equal to 1.
 
 ## When to run Gate 8b soak
 
@@ -628,7 +640,8 @@ pe1_df_role, pe2_df_role,
 pe1_df_changes, pe2_df_changes,
 pe1_bum_flags, pe2_bum_flags,
 pe2_running,
-pe1_established_seen, pe2_established_seen,         # sum of bgp_session_established_total — per-sample observability after the pre-churn gate
+pe1_session_established, pe2_session_established,   # current bgp_peer_session_established gauges
+pe1_established_seen, pe2_established_seen,         # cumulative diagnostic only; cannot prove current recovery
 pe1_pool_size, pe2_pool_size,                       # harness-tracked
 pe1_fdb_total, pe2_fdb_total,                       # kernel `bridge fdb show | wc -l`
 pe1_fdb_extern_learn, pe2_fdb_extern_learn,         # daemon-programmed remote rows
@@ -643,6 +656,13 @@ pe1_drift_orphans_cleaned, pe2_drift_orphans_cleaned,
 pe1_drift_disabled, pe2_drift_disabled,             # ADR-0059 drift counters
 churn_adds_total, churn_dels_total, churn_moves_total
 ```
+
+The two current-gauge columns immediately after `pe2_running` are a deliberate
+schema boundary. Every row derives both current and cumulative session values
+from the same single scrape per PE. At expiry this process-restart runner
+recovers PE2, rechecks current establishment and topology preservation, and
+appends exactly one terminal row; cumulative counters never substitute for the
+current-state evidence.
 
 Plus per-PE daemon logs (`pe1.log` / `pe2.log`), flip events
 (`flips.log`), churn batches (`churn.log`), and live pool state

--- a/tests/soak/analyze-gate8b-soak.py
+++ b/tests/soak/analyze-gate8b-soak.py
@@ -82,7 +82,18 @@ def main():
 
     try:
         with open(args.samples_csv) as f:
-            rows = list(csv.DictReader(f))
+            reader = csv.DictReader(f)
+            required = {
+                "elapsed_sec", "pe1_rss_mb", "pe2_rss_mb",
+                "pe1_df_changes", "pe2_df_changes", "pe1_bum_flags",
+                "pe2_running", "pe1_session_established",
+                "pe2_session_established",
+            }
+            missing = required - set(reader.fieldnames or ())
+            if missing:
+                print(f"ERROR: missing required columns: {sorted(missing)}", file=sys.stderr)
+                sys.exit(2)
+            rows = list(reader)
     except OSError as e:
         print(f"ERROR: cannot read {args.samples_csv}: {e}", file=sys.stderr)
         sys.exit(2)
@@ -158,6 +169,9 @@ def main():
     pe1_flag_states = {r["pe1_bum_flags"] for r in rows if r["pe1_bum_flags"]}
     pe2_running_samples = sum(1 for r in rows if r["pe2_running"] == "1")
     pe2_stopped_samples = sum(1 for r in rows if r["pe2_running"] == "0")
+    terminal = rows[-1]
+    terminal_pe1_current = safe_float(terminal["pe1_session_established"])
+    terminal_pe2_current = safe_float(terminal["pe2_session_established"])
 
     gates = []
 
@@ -181,6 +195,14 @@ def main():
     gate("ran_through_at_least_one_full_flip_cycle",
          pe2_running_samples > 0 and pe2_stopped_samples > 0,
          f"pe2 running={pe2_running_samples} stopped={pe2_stopped_samples}")
+    gate(
+        "terminal_sessions_recovered",
+        terminal["pe2_running"] == "1"
+        and terminal_pe1_current == 1
+        and terminal_pe2_current == 1,
+        f"pe2_running={terminal['pe2_running']!r} "
+        f"current=({terminal_pe1_current!r}, {terminal_pe2_current!r})",
+    )
 
     verdict_pass = all(g["pass"] for g in gates)
     out = {

--- a/tests/soak/gate8b-terminal-recovery.sh
+++ b/tests/soak/gate8b-terminal-recovery.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Recover PE2 when needed, then append exactly one terminal evidence row.
+# The sample callback still runs after a failed recovery so the receipt records
+# the failure state before the runner returns nonzero.
+gate8b_terminal_recovery() {
+    local pe2_running="$1" recover_callback="$2" sample_callback="$3" recovery_rc=0
+    if [ "$pe2_running" != "1" ]; then
+        "$recover_callback" || recovery_rc=$?
+    fi
+    "$sample_callback" || return
+    return "$recovery_rc"
+}

--- a/tests/soak/run-gate8b-mac-churn-soak.sh
+++ b/tests/soak/run-gate8b-mac-churn-soak.sh
@@ -143,6 +143,8 @@ exec > >(tee -a "$SOAK_LOG") 2>&1
 # shellcheck source=./host-lock.sh
 source "$SOAK_SCRIPT_DIR/host-lock.sh"
 acquire_rustbgpd_host_lock
+# shellcheck source=./gate8b-terminal-recovery.sh
+source "$SOAK_SCRIPT_DIR/gate8b-terminal-recovery.sh"
 
 # ---------------------------------------------------------------------------
 # Helpers (shared shape with run-gate8b-soak.sh)
@@ -262,14 +264,8 @@ nh_count() {
     docker exec "$container" sh -c 'ip nexthop show 2>/dev/null | wc -l' 2>/dev/null || echo ""
 }
 
-# Sum every `bgp_session_established_total{...}` row this PE exports.
-# Each successful entry into the Established FSM state increments
-# the counter by 1 (see `rustbgpd_telemetry::metrics`), so > 0 means
-# the BGP session has been up at least once. Returns 0 if the scrape
-# is empty or the metric is absent.
-pe_established_total() {
-    local container="$1" prom
-    prom="$(prom_scrape "$container")"
+prom_established_total() {
+    local prom="$1"
     [ -z "$prom" ] && { echo 0; return; }
     printf '%s' "$prom" | awk '
         $0 ~ /^bgp_session_established_total\{/ { sum += $NF }
@@ -277,8 +273,21 @@ pe_established_total() {
     '
 }
 
-# Refuse to start churn until both PEs have reached Established at
-# least once. The OPEN-collision-race recovery time on simultaneous
+prom_established_current() {
+    local prom="$1"
+    [ -z "$prom" ] && { echo 0; return; }
+    printf '%s' "$prom" | awk '
+        $0 ~ /^bgp_peer_session_established\{/ { sum += $NF }
+        END { print sum + 0 }
+    '
+}
+
+pe_established_current() {
+    prom_established_current "$(prom_scrape "$1")"
+}
+
+# Refuse to start churn until both PEs are currently Established.
+# The OPEN-collision-race recovery time on simultaneous
 # clab deploy can exceed the fixed warmup window; gating here keeps
 # the validation honest — without it the soak can pass with
 # `extern_learn = 0` and miss the entire remote-Type-2 receive path.
@@ -288,10 +297,10 @@ wait_established() {
     log "waiting up to ${timeout_sec}s for both PEs to reach BGP Established"
     while [ "$(date +%s)" -lt "$deadline" ]; do
         local p1 p2
-        p1="$(pe_established_total "$PE1_NAME")"
-        p2="$(pe_established_total "$PE2_NAME")"
+        p1="$(pe_established_current "$PE1_NAME")"
+        p2="$(pe_established_current "$PE2_NAME")"
         if [ "${p1:-0}" -ge 1 ] && [ "${p2:-0}" -ge 1 ]; then
-            log "BGP Established gate passed (pe1_established_total=${p1} pe2_established_total=${p2})"
+            log "BGP Established gate passed (pe1_current=${p1} pe2_current=${p2})"
             return 0
         fi
         sleep 5
@@ -351,14 +360,10 @@ verify_topology_link() {
     return "$ok"
 }
 
-# Wait for a freshly restarted PE's daemon to reach Established at
-# least once. `bgp_session_established_total` is an in-process
-# counter — it resets to 0 every time the daemon process restarts,
-# so `>= 1` post-restart is the right "the new process actually
-# peered" gate. (A pre-flip baseline would be meaningless because
-# the counter doesn't survive the restart.) During the bind window
+# Wait for a freshly restarted PE's daemon to be currently Established.
+# During the bind window
 # right after the new daemon launches, `curl` to :9179 returns
-# "connection refused" and `pe_established_total` falls back to 0,
+# "connection refused" and `pe_established_current` falls back to 0,
 # which simply keeps the poll loop running until the listener is
 # up and the OPEN exchange completes.
 wait_established_post_flip() {
@@ -367,9 +372,9 @@ wait_established_post_flip() {
     local deadline=$(($(date +%s) + timeout_sec))
     while [ "$(date +%s)" -lt "$deadline" ]; do
         local cur
-        cur="$(pe_established_total "$pe")"
+        cur="$(pe_established_current "$pe")"
         if [ "${cur:-0}" -ge 1 ]; then
-            log "post-flip re-established: $pe established_total=$cur"
+            log "post-flip re-established: $pe current=$cur"
             return 0
         fi
         sleep 5
@@ -668,6 +673,47 @@ churn_loop() {
     done
 }
 
+recover_terminal_pe2() {
+    start_pe2_daemon || return
+    verify_topology_link || return
+}
+
+sample_row() {
+    local NOW="${1:-$(date +%s)}" ELAPSED PE1_PROM PE2_PROM
+    local PE1_RSS PE2_RSS PE1_DF PE2_DF PE1_DF_CHANGES PE2_DF_CHANGES
+    local PE1_FLAGS PE2_FLAGS PE1_CURRENT PE2_CURRENT PE1_ESTAB PE2_ESTAB
+    local PE1_POOL_N PE2_POOL_N PE1_FDB_TOTAL PE2_FDB_TOTAL PE1_FDB_EXT PE2_FDB_EXT
+    local PE1_NH PE2_NH PE1_ORIGS PE2_ORIGS PE1_ORIG_ERR PE2_ORIG_ERR
+    local PE1_OBS_DROPS PE2_OBS_DROPS PE1_DUP_MOVES PE2_DUP_MOVES
+    local PE1_REPAIRED PE2_REPAIRED PE1_REPLACED PE2_REPLACED
+    local PE1_ORPHANS PE2_ORPHANS PE1_DDISABLED PE2_DDISABLED
+    ELAPSED="${2:-$((NOW - START_UNIX))}"
+    PE1_PROM="$(prom_scrape "$PE1_NAME")"; PE2_PROM="$(prom_scrape "$PE2_NAME")"
+    PE1_RSS="$(container_rss_mb "$PE1_NAME" || echo "")"; PE2_RSS="$(container_rss_mb "$PE2_NAME" || echo "")"
+    PE1_DF="$(prom_extract "$PE1_PROM" evpn_df_role 'role="df"')"; PE2_DF="$(prom_extract "$PE2_PROM" evpn_df_role 'role="df"')"
+    PE1_DF_CHANGES="$(prom_extract "$PE1_PROM" evpn_df_role_changes_total)"; PE2_DF_CHANGES="$(prom_extract "$PE2_PROM" evpn_df_role_changes_total)"
+    PE1_FLAGS="$(bridge_flag_state "$PE1_NAME")"; PE2_FLAGS="$(bridge_flag_state "$PE2_NAME" 2>/dev/null || echo unreachable)"
+    PE1_CURRENT="$(prom_established_current "$PE1_PROM")"; PE2_CURRENT="$(prom_established_current "$PE2_PROM")"
+    PE1_ESTAB="$(prom_established_total "$PE1_PROM")"; PE2_ESTAB="$(prom_established_total "$PE2_PROM")"
+    PE1_POOL_N="$(pool_size 1)"; PE2_POOL_N="$(pool_size 2)"
+    PE1_FDB_TOTAL="$(fdb_total_count "$PE1_NAME")"; PE2_FDB_TOTAL="$(fdb_total_count "$PE2_NAME")"
+    PE1_FDB_EXT="$(fdb_extern_learn_count "$PE1_NAME")"; PE2_FDB_EXT="$(fdb_extern_learn_count "$PE2_NAME")"
+    PE1_NH="$(nh_count "$PE1_NAME")"; PE2_NH="$(nh_count "$PE2_NAME")"
+    PE1_ORIGS="$(prom_extract "$PE1_PROM" evpn_local_originations_total)"; PE2_ORIGS="$(prom_extract "$PE2_PROM" evpn_local_originations_total)"
+    PE1_ORIG_ERR="$(prom_extract "$PE1_PROM" evpn_local_origination_errors_total)"; PE2_ORIG_ERR="$(prom_extract "$PE2_PROM" evpn_local_origination_errors_total)"
+    PE1_OBS_DROPS="$(prom_extract "$PE1_PROM" evpn_local_observations_dropped_total)"; PE2_OBS_DROPS="$(prom_extract "$PE2_PROM" evpn_local_observations_dropped_total)"
+    PE1_DUP_MOVES="$(prom_extract "$PE1_PROM" evpn_duplicate_mac_moves_total)"; PE2_DUP_MOVES="$(prom_extract "$PE2_PROM" evpn_duplicate_mac_moves_total)"
+    PE1_REPAIRED="$(prom_extract "$PE1_PROM" evpn_fdb_nhg_drift_members_repaired_total)"; PE2_REPAIRED="$(prom_extract "$PE2_PROM" evpn_fdb_nhg_drift_members_repaired_total)"
+    PE1_REPLACED="$(prom_extract "$PE1_PROM" evpn_fdb_nhg_drift_groups_replaced_total)"; PE2_REPLACED="$(prom_extract "$PE2_PROM" evpn_fdb_nhg_drift_groups_replaced_total)"
+    PE1_ORPHANS="$(prom_extract "$PE1_PROM" evpn_fdb_nhg_orphans_cleaned_total)"; PE2_ORPHANS="$(prom_extract "$PE2_PROM" evpn_fdb_nhg_orphans_cleaned_total)"
+    PE1_DDISABLED="$(prom_extract "$PE1_PROM" evpn_fdb_nhg_drift_disabled_total)"; PE2_DDISABLED="$(prom_extract "$PE2_PROM" evpn_fdb_nhg_drift_disabled_total)"
+    {
+        printf '%s' "$NOW"
+        printf ',%s' "$ELAPSED" "${PE1_RSS:-NaN}" "${PE2_RSS:-NaN}" "${PE1_DF:-NaN}" "${PE2_DF:-NaN}" "${PE1_DF_CHANGES:-NaN}" "${PE2_DF_CHANGES:-NaN}" "${PE1_FLAGS:-unknown}" "${PE2_FLAGS:-unknown}" "$PE2_RUNNING" "${PE1_CURRENT:-NaN}" "${PE2_CURRENT:-NaN}" "${PE1_ESTAB:-NaN}" "${PE2_ESTAB:-NaN}" "$PE1_POOL_N" "$PE2_POOL_N" "${PE1_FDB_TOTAL:-NaN}" "${PE2_FDB_TOTAL:-NaN}" "${PE1_FDB_EXT:-NaN}" "${PE2_FDB_EXT:-NaN}" "${PE1_NH:-NaN}" "${PE2_NH:-NaN}" "${PE1_ORIGS:-NaN}" "${PE2_ORIGS:-NaN}" "${PE1_ORIG_ERR:-NaN}" "${PE2_ORIG_ERR:-NaN}" "${PE1_OBS_DROPS:-NaN}" "${PE2_OBS_DROPS:-NaN}" "${PE1_DUP_MOVES:-NaN}" "${PE2_DUP_MOVES:-NaN}" "${PE1_REPAIRED:-NaN}" "${PE2_REPAIRED:-NaN}" "${PE1_REPLACED:-NaN}" "${PE2_REPLACED:-NaN}" "${PE1_ORPHANS:-NaN}" "${PE2_ORPHANS:-NaN}" "${PE1_DDISABLED:-NaN}" "${PE2_DDISABLED:-NaN}" "$(< "$CHURN_ADDS_FILE")" "$(< "$CHURN_DELS_FILE")" "$(< "$CHURN_MOVES_FILE")"
+        printf '\n'
+    } >>"$SAMPLES_CSV"
+}
+
 # ---------------------------------------------------------------------------
 # Pre-flight
 # ---------------------------------------------------------------------------
@@ -748,7 +794,7 @@ trap cleanup EXIT INT TERM
 # ---------------------------------------------------------------------------
 
 cat >"$SAMPLES_CSV" <<'EOF'
-ts_unix,elapsed_sec,pe1_rss_mb,pe2_rss_mb,pe1_df_role,pe2_df_role,pe1_df_changes,pe2_df_changes,pe1_bum_flags,pe2_bum_flags,pe2_running,pe1_established_seen,pe2_established_seen,pe1_pool_size,pe2_pool_size,pe1_fdb_total,pe2_fdb_total,pe1_fdb_extern_learn,pe2_fdb_extern_learn,pe1_nh_count,pe2_nh_count,pe1_local_origs,pe2_local_origs,pe1_local_orig_errors,pe2_local_orig_errors,pe1_local_obs_drops,pe2_local_obs_drops,pe1_dup_mac_moves,pe2_dup_mac_moves,pe1_drift_members_repaired,pe2_drift_members_repaired,pe1_drift_groups_replaced,pe2_drift_groups_replaced,pe1_drift_orphans_cleaned,pe2_drift_orphans_cleaned,pe1_drift_disabled,pe2_drift_disabled,churn_adds_total,churn_dels_total,churn_moves_total
+ts_unix,elapsed_sec,pe1_rss_mb,pe2_rss_mb,pe1_df_role,pe2_df_role,pe1_df_changes,pe2_df_changes,pe1_bum_flags,pe2_bum_flags,pe2_running,pe1_session_established,pe2_session_established,pe1_established_seen,pe2_established_seen,pe1_pool_size,pe2_pool_size,pe1_fdb_total,pe2_fdb_total,pe1_fdb_extern_learn,pe2_fdb_extern_learn,pe1_nh_count,pe2_nh_count,pe1_local_origs,pe2_local_origs,pe1_local_orig_errors,pe2_local_orig_errors,pe1_local_obs_drops,pe2_local_obs_drops,pe1_dup_mac_moves,pe2_dup_mac_moves,pe1_drift_members_repaired,pe2_drift_members_repaired,pe1_drift_groups_replaced,pe2_drift_groups_replaced,pe1_drift_orphans_cleaned,pe2_drift_orphans_cleaned,pe1_drift_disabled,pe2_drift_disabled,churn_adds_total,churn_dels_total,churn_moves_total
 EOF
 
 # ---------------------------------------------------------------------------
@@ -799,74 +845,7 @@ while [ "$(date +%s)" -lt "$END_UNIX" ]; do
     NOW="$(date +%s)"
     ELAPSED="$((NOW - START_UNIX))"
 
-    # Scrape per-PE.
-    PE1_PROM="$(prom_scrape "$PE1_NAME")"
-    PE2_PROM="$(prom_scrape "$PE2_NAME")"
-
-    PE1_RSS="$(container_rss_mb "$PE1_NAME" || echo "")"
-    PE2_RSS="$(container_rss_mb "$PE2_NAME" || echo "")"
-
-    PE1_DF="$(prom_extract "$PE1_PROM" evpn_df_role 'role="df"')"
-    PE2_DF="$(prom_extract "$PE2_PROM" evpn_df_role 'role="df"')"
-    PE1_DF_CHANGES="$(prom_extract "$PE1_PROM" evpn_df_role_changes_total)"
-    PE2_DF_CHANGES="$(prom_extract "$PE2_PROM" evpn_df_role_changes_total)"
-
-    PE1_FLAGS="$(bridge_flag_state "$PE1_NAME")"
-    PE2_FLAGS="$(bridge_flag_state "$PE2_NAME" 2>/dev/null || echo unreachable)"
-
-    PE1_ESTAB="$(pe_established_total "$PE1_NAME")"
-    PE2_ESTAB="$(pe_established_total "$PE2_NAME")"
-
-    PE1_POOL_N="$(pool_size 1)"
-    PE2_POOL_N="$(pool_size 2)"
-
-    PE1_FDB_TOTAL="$(fdb_total_count "$PE1_NAME")"
-    PE2_FDB_TOTAL="$(fdb_total_count "$PE2_NAME")"
-    PE1_FDB_EXT="$(fdb_extern_learn_count "$PE1_NAME")"
-    PE2_FDB_EXT="$(fdb_extern_learn_count "$PE2_NAME")"
-    PE1_NH="$(nh_count "$PE1_NAME")"
-    PE2_NH="$(nh_count "$PE2_NAME")"
-
-    PE1_ORIGS="$(prom_extract "$PE1_PROM" evpn_local_originations_total)"
-    PE2_ORIGS="$(prom_extract "$PE2_PROM" evpn_local_originations_total)"
-    PE1_ORIG_ERR="$(prom_extract "$PE1_PROM" evpn_local_origination_errors_total)"
-    PE2_ORIG_ERR="$(prom_extract "$PE2_PROM" evpn_local_origination_errors_total)"
-    PE1_OBS_DROPS="$(prom_extract "$PE1_PROM" evpn_local_observations_dropped_total)"
-    PE2_OBS_DROPS="$(prom_extract "$PE2_PROM" evpn_local_observations_dropped_total)"
-    PE1_DUP_MOVES="$(prom_extract "$PE1_PROM" evpn_duplicate_mac_moves_total)"
-    PE2_DUP_MOVES="$(prom_extract "$PE2_PROM" evpn_duplicate_mac_moves_total)"
-
-    PE1_REPAIRED="$(prom_extract "$PE1_PROM" evpn_fdb_nhg_drift_members_repaired_total)"
-    PE2_REPAIRED="$(prom_extract "$PE2_PROM" evpn_fdb_nhg_drift_members_repaired_total)"
-    PE1_REPLACED="$(prom_extract "$PE1_PROM" evpn_fdb_nhg_drift_groups_replaced_total)"
-    PE2_REPLACED="$(prom_extract "$PE2_PROM" evpn_fdb_nhg_drift_groups_replaced_total)"
-    PE1_ORPHANS="$(prom_extract "$PE1_PROM" evpn_fdb_nhg_orphans_cleaned_total)"
-    PE2_ORPHANS="$(prom_extract "$PE2_PROM" evpn_fdb_nhg_orphans_cleaned_total)"
-    PE1_DDISABLED="$(prom_extract "$PE1_PROM" evpn_fdb_nhg_drift_disabled_total)"
-    PE2_DDISABLED="$(prom_extract "$PE2_PROM" evpn_fdb_nhg_drift_disabled_total)"
-
-    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
-        "$NOW" "$ELAPSED" \
-        "${PE1_RSS:-NaN}" "${PE2_RSS:-NaN}" \
-        "${PE1_DF:-NaN}" "${PE2_DF:-NaN}" \
-        "${PE1_DF_CHANGES:-NaN}" "${PE2_DF_CHANGES:-NaN}" \
-        "${PE1_FLAGS:-unknown}" "${PE2_FLAGS:-unknown}" \
-        "$PE2_RUNNING" \
-        "${PE1_ESTAB:-NaN}" "${PE2_ESTAB:-NaN}" \
-        "$PE1_POOL_N" "$PE2_POOL_N" \
-        "${PE1_FDB_TOTAL:-NaN}" "${PE2_FDB_TOTAL:-NaN}" \
-        "${PE1_FDB_EXT:-NaN}" "${PE2_FDB_EXT:-NaN}" \
-        "${PE1_NH:-NaN}" "${PE2_NH:-NaN}" \
-        "${PE1_ORIGS:-NaN}" "${PE2_ORIGS:-NaN}" \
-        "${PE1_ORIG_ERR:-NaN}" "${PE2_ORIG_ERR:-NaN}" \
-        "${PE1_OBS_DROPS:-NaN}" "${PE2_OBS_DROPS:-NaN}" \
-        "${PE1_DUP_MOVES:-NaN}" "${PE2_DUP_MOVES:-NaN}" \
-        "${PE1_REPAIRED:-NaN}" "${PE2_REPAIRED:-NaN}" \
-        "${PE1_REPLACED:-NaN}" "${PE2_REPLACED:-NaN}" \
-        "${PE1_ORPHANS:-NaN}" "${PE2_ORPHANS:-NaN}" \
-        "${PE1_DDISABLED:-NaN}" "${PE2_DDISABLED:-NaN}" \
-        "$(< "$CHURN_ADDS_FILE")" "$(< "$CHURN_DELS_FILE")" "$(< "$CHURN_MOVES_FILE")" \
-        >>"$SAMPLES_CSV"
+    sample_row "$NOW" "$ELAPSED"
 
     # Flip PE2 if it's time.
     if [ "$NOW" -ge "$NEXT_FLIP_UNIX" ]; then
@@ -889,12 +868,9 @@ while [ "$(date +%s)" -lt "$END_UNIX" ]; do
             log "flip: starting PE2 daemon"
             # Wait for re-establishment so the next sample isn't
             # credited as a nominal steady-state row when the
-            # session has actually failed to come back. The fresh
-            # daemon's counter starts at 0; we just need it to hit
-            # 1 (i.e., the new process has reached Established
-            # once). No cross-restart baseline survives — the
-            # counter is in-process — so a `>= 1` gate is the
-            # right invariant.
+            # session has actually failed to come back. The current
+            # gauge must reach 1; a cumulative counter cannot prove
+            # that the restarted session is still Established.
             if ! start_pe2_daemon; then
                 log "FATAL: PE2 daemon start or session recovery failed"
                 exit 4
@@ -921,6 +897,11 @@ while [ "$(date +%s)" -lt "$END_UNIX" ]; do
 
     sleep "$SAMPLE_INTERVAL"
 done
+
+if ! gate8b_terminal_recovery "$PE2_RUNNING" recover_terminal_pe2 sample_row; then
+    log "FATAL: terminal PE2 recovery failed; final evidence row retained"
+    exit 4
+fi
 
 log "soak loop completed; final samples in $SAMPLES_CSV"
 log "totals: adds=$(< "$CHURN_ADDS_FILE") dels=$(< "$CHURN_DELS_FILE") moves=$(< "$CHURN_MOVES_FILE")"

--- a/tests/soak/run-gate8b-soak.sh
+++ b/tests/soak/run-gate8b-soak.sh
@@ -75,6 +75,8 @@ exec > >(tee -a "$SOAK_LOG") 2>&1
 # shellcheck source=./host-lock.sh
 source "$SOAK_SCRIPT_DIR/host-lock.sh"
 acquire_rustbgpd_host_lock
+# shellcheck source=./gate8b-terminal-recovery.sh
+source "$SOAK_SCRIPT_DIR/gate8b-terminal-recovery.sh"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -208,6 +210,38 @@ restart_pe2() {
     PE2_RUNNING=1
 }
 
+reattach_pe2_log() {
+    kill "$PE2_TAIL_PID" 2>/dev/null || true
+    docker logs -f "$PE2_NAME" >>"$PE2_LOG" 2>&1 &
+    PE2_TAIL_PID=$!
+}
+
+recover_terminal_pe2() {
+    restart_pe2 || return
+    reattach_pe2_log
+}
+
+sample_row() {
+    local now="${1:-$(date +%s)}" elapsed pe1_prom pe2_prom
+    elapsed="${2:-$((now - START_UNIX))}"
+    pe1_prom="$(prom_scrape "$PE1_NAME")"
+    pe2_prom="$(prom_scrape "$PE2_NAME")"
+    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+        "$now" "$elapsed" \
+        "$(container_rss_mb "$PE1_NAME" || echo NaN)" \
+        "$(container_rss_mb "$PE2_NAME" || echo NaN)" \
+        "$(prom_extract "$pe1_prom" evpn_df_role 'role="df"' || echo NaN)" \
+        "$(prom_extract "$pe2_prom" evpn_df_role 'role="df"' || echo NaN)" \
+        "$(prom_extract "$pe1_prom" evpn_df_role_changes_total || echo NaN)" \
+        "$(prom_extract "$pe2_prom" evpn_df_role_changes_total || echo NaN)" \
+        "$(bridge_flag_state "$PE1_NAME")" \
+        "$(bridge_flag_state "$PE2_NAME" 2>/dev/null || echo unreachable)" \
+        "$PE2_RUNNING" \
+        "$(prom_extract "$pe1_prom" bgp_peer_session_established || echo NaN)" \
+        "$(prom_extract "$pe2_prom" bgp_peer_session_established || echo NaN)" \
+        >>"$SAMPLES_CSV"
+}
+
 # ---------------------------------------------------------------------------
 # Pre-flight
 # ---------------------------------------------------------------------------
@@ -276,7 +310,7 @@ trap cleanup EXIT INT TERM
 # ---------------------------------------------------------------------------
 
 cat >"$SAMPLES_CSV" <<'EOF'
-ts_unix,elapsed_sec,pe1_rss_mb,pe2_rss_mb,pe1_df_role,pe2_df_role,pe1_df_changes,pe2_df_changes,pe1_bum_flags,pe2_bum_flags,pe2_running
+ts_unix,elapsed_sec,pe1_rss_mb,pe2_rss_mb,pe1_df_role,pe2_df_role,pe1_df_changes,pe2_df_changes,pe1_bum_flags,pe2_bum_flags,pe2_running,pe1_session_established,pe2_session_established
 EOF
 
 # ---------------------------------------------------------------------------
@@ -301,27 +335,7 @@ while [ "$(date +%s)" -lt "$END_UNIX" ]; do
     NOW="$(date +%s)"
     ELAPSED="$((NOW - START_UNIX))"
 
-    # Sample.
-    PE1_PROM="$(prom_scrape "$PE1_NAME")"
-    PE2_PROM="$(prom_scrape "$PE2_NAME")"
-    PE1_RSS="$(container_rss_mb "$PE1_NAME" || echo "")"
-    PE2_RSS="$(container_rss_mb "$PE2_NAME" || echo "")"
-
-    PE1_DF="$(prom_extract "$PE1_PROM" evpn_df_role 'role="df"')"
-    PE2_DF="$(prom_extract "$PE2_PROM" evpn_df_role 'role="df"')"
-    PE1_DF_CHANGES="$(prom_extract "$PE1_PROM" evpn_df_role_changes_total)"
-    PE2_DF_CHANGES="$(prom_extract "$PE2_PROM" evpn_df_role_changes_total)"
-
-    PE1_FLAGS="$(bridge_flag_state "$PE1_NAME")"
-    PE2_FLAGS="$(bridge_flag_state "$PE2_NAME" 2>/dev/null || echo unreachable)"
-
-    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
-        "$NOW" "$ELAPSED" \
-        "${PE1_RSS:-NaN}" "${PE2_RSS:-NaN}" \
-        "${PE1_DF:-NaN}" "${PE2_DF:-NaN}" \
-        "${PE1_DF_CHANGES:-NaN}" "${PE2_DF_CHANGES:-NaN}" \
-        "${PE1_FLAGS:-unknown}" "${PE2_FLAGS:-unknown}" \
-        "$PE2_RUNNING" >>"$SAMPLES_CSV"
+    sample_row "$NOW" "$ELAPSED"
 
     # Flip PE2 if it's time.
     if [ "$NOW" -ge "$NEXT_FLIP_UNIX" ]; then
@@ -343,14 +357,17 @@ while [ "$(date +%s)" -lt "$END_UNIX" ]; do
             fi
             # Re-attach the docker-logs tail since `docker start`
             # invalidated the prior tail's underlying stream.
-            kill "$PE2_TAIL_PID" 2>/dev/null || true
-            docker logs -f "$PE2_NAME" >>"$PE2_LOG" 2>&1 &
-            PE2_TAIL_PID=$!
+            reattach_pe2_log
         fi
         NEXT_FLIP_UNIX="$((NOW + FLIP_INTERVAL_SEC))"
     fi
 
     sleep "$SAMPLE_INTERVAL"
 done
+
+if ! gate8b_terminal_recovery "$PE2_RUNNING" recover_terminal_pe2 sample_row; then
+    log "FATAL: terminal PE2 recovery failed; final evidence row retained"
+    exit 4
+fi
 
 log "soak loop completed; final samples in $SAMPLES_CSV"

--- a/tests/soak/test_gate8b_recovery_contract.py
+++ b/tests/soak/test_gate8b_recovery_contract.py
@@ -110,7 +110,10 @@ rc=$?; cat "$events"; exit "$rc"
         ):
             with self.subTest(mode=mode):
                 result = subprocess.run(
-                    ["bash", "-c", f"source {helper}\nMODE={mode} INITIAL={initial}\n{body}"],
+                    [
+                        "bash", "-c", f'source "$1"\nMODE={mode} INITIAL={initial}\n{body}',
+                        "gate8b-recovery-test", str(helper),
+                    ],
                     text=True, capture_output=True, check=False,
                 )
                 self.assertEqual(result.returncode, code)

--- a/tests/soak/test_gate8b_recovery_contract.py
+++ b/tests/soak/test_gate8b_recovery_contract.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Load-bearing contracts for Gate 8b terminal recovery evidence."""
+
+import csv
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+HERE = Path(__file__).parent
+FIELDS = [
+    "elapsed_sec", "pe1_rss_mb", "pe2_rss_mb", "pe1_df_changes",
+    "pe2_df_changes", "pe1_bum_flags", "pe2_running",
+    "pe1_session_established", "pe2_session_established",
+    "pe1_established_seen", "pe2_established_seen",
+]
+
+
+def healthy_rows():
+    rows = []
+    for elapsed, running in enumerate(("1", "0", "0", "1", "1", "1")):
+        rows.append({
+            "elapsed_sec": str(elapsed * 3600),
+            "pe1_rss_mb": "10", "pe2_rss_mb": "10",
+            "pe1_df_changes": str(elapsed), "pe2_df_changes": str(elapsed),
+            "pe1_bum_flags": "df", "pe2_running": running,
+            "pe1_session_established": "1",
+            "pe2_session_established": running,
+            "pe1_established_seen": "9", "pe2_established_seen": "9",
+        })
+    return rows
+
+
+def run_analyzer(fields, rows):
+    with tempfile.TemporaryDirectory() as tmp:
+        samples = Path(tmp) / "samples.csv"
+        with samples.open("w", newline="") as stream:
+            writer = csv.DictWriter(stream, fieldnames=fields, extrasaction="ignore")
+            writer.writeheader()
+            writer.writerows(rows)
+        result = subprocess.run(
+            ["python3", str(HERE / "analyze-gate8b-soak.py"), str(samples)],
+            text=True, capture_output=True, check=False,
+        )
+        report = json.loads(result.stdout) if result.stdout else None
+        return result, report
+
+
+class Gate8bRecoveryContract(unittest.TestCase):
+    def test_terminal_recovery_gate_passes_with_deliberate_down_rows(self):
+        result, report = run_analyzer(FIELDS, healthy_rows())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        terminal = next(g for g in report["gates"]
+                        if g["name"] == "terminal_sessions_recovered")
+        self.assertTrue(terminal["pass"])
+
+    def test_terminal_clauses_fail_independently(self):
+        cases = (
+            ("pe2_running", "0"),
+            ("pe1_session_established", "0"),
+            ("pe1_session_established", "NaN"),
+            ("pe1_session_established", ""),
+            ("pe1_session_established", None),
+            ("pe2_session_established", "0"),
+            ("pe2_session_established", "NaN"),
+            ("pe2_session_established", ""),
+            ("pe2_session_established", None),
+        )
+        for field, value in cases:
+            with self.subTest(field=field, value=value):
+                rows = healthy_rows()
+                if value is None:
+                    rows[-1].pop(field)
+                else:
+                    rows[-1][field] = value
+                rows[-1]["pe1_established_seen"] = "99"
+                rows[-1]["pe2_established_seen"] = "99"
+                result, report = run_analyzer(FIELDS, rows)
+                self.assertEqual(result.returncode, 1)
+                failed = [g for g in report["gates"] if not g["pass"]]
+                self.assertEqual([g["name"] for g in failed],
+                                 ["terminal_sessions_recovered"])
+                self.assertIn("current=", failed[0]["detail"])
+
+    def test_missing_current_headers_are_input_errors(self):
+        for field in ("pe1_session_established", "pe2_session_established"):
+            with self.subTest(field=field):
+                fields = [name for name in FIELDS if name != field]
+                result, report = run_analyzer(fields, healthy_rows())
+                self.assertEqual(result.returncode, 2)
+                self.assertIsNone(report)
+                self.assertIn(field, result.stderr)
+
+    def test_shared_helper_orders_recovery_before_one_evidence_row(self):
+        helper = HERE / "gate8b-terminal-recovery.sh"
+        body = r'''
+events=$(mktemp); PE2_RUNNING=$INITIAL
+recover() { echo recover >>"$events"; [ "$MODE" != fail ] || return 7; PE2_RUNNING=1; }
+sample() { echo "sample:$PE2_RUNNING" >>"$events"; [ "$MODE" != sample-fail ] || return 8; }
+gate8b_terminal_recovery "$PE2_RUNNING" recover sample
+rc=$?; cat "$events"; exit "$rc"
+'''
+        for mode, initial, code, events in (
+            ("up", "1", 0, ["sample:1"]),
+            ("recover", "0", 0, ["recover", "sample:1"]),
+            ("fail", "0", 7, ["recover", "sample:0"]),
+            ("sample-fail", "1", 8, ["sample:1"]),
+        ):
+            with self.subTest(mode=mode):
+                result = subprocess.run(
+                    ["bash", "-c", f"source {helper}\nMODE={mode} INITIAL={initial}\n{body}"],
+                    text=True, capture_output=True, check=False,
+                )
+                self.assertEqual(result.returncode, code)
+                self.assertEqual(result.stdout.splitlines(), events)
+
+    def test_runners_bind_terminal_helper_and_current_state(self):
+        base = (HERE / "run-gate8b-soak.sh").read_text()
+        mac = (HERE / "run-gate8b-mac-churn-soak.sh").read_text()
+        columns = "pe2_running,pe1_session_established,pe2_session_established"
+        for source in (base, mac):
+            self.assertIn(columns, source)
+            self.assertEqual(source.count("gate8b_terminal_recovery \"$PE2_RUNNING\""), 1)
+            self.assertLess(source.rindex("done\n"), source.index("gate8b_terminal_recovery \"$PE2_RUNNING\""))
+            sample = source[source.index("sample_row() {"):source.index("\n}\n", source.index("sample_row() {"))]
+            self.assertEqual(sample.count('prom_scrape "$PE1_NAME"'), 1)
+            self.assertEqual(sample.count('prom_scrape "$PE2_NAME"'), 1)
+        self.assertIn("restart_pe2 || return", base)
+        self.assertIn("reattach_pe2_log", base)
+        self.assertIn("start_pe2_daemon || return", mac)
+        self.assertIn("verify_topology_link || return", mac)
+        self.assertIn('prom_established_total "$PE1_PROM"', mac)
+        self.assertNotIn("pe_established_total", mac)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- recover PE2 at duration expiry using each Gate8b runner's existing restart model, then append exactly one terminal evidence row
- record authoritative current-session gauges for both peers and fail the analyzer closed unless both are established in the terminal row
- retain cumulative establishment counters as diagnostics only, document the schema boundary, and enroll the focused contract tests in CI
- refresh the two structurally fenced scale-receipt digests for the newly enrolled command

## Verification

- 17 focused Gate8b tests
- 5 CI structural-contract tests plus live checker
- Python compile, `bash -n`, ShellCheck, and diff check
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (1,815 daemon tests; full workspace green after an unrelated ephemeral `AddrInUse` retry)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

## Load-bearing proof

The focused mutations independently make the contract red when each current-session clause, required header, recovery-before-sample ordering, failed-recovery evidence row, sample-error propagation, single-sample property, or CI enrollment guard is removed. Deliberate interior PE2-down rows remain valid; only the terminal row must prove recovery.