### PR TITLE
Close receipt session continuity proofs

### DIFF
--- a/bench/scale/enhanced-route-refresh/test_validate_phase.py
+++ b/bench/scale/enhanced-route-refresh/test_validate_phase.py
@@ -14,7 +14,7 @@ def line(name, value, **labels):
     return f"{name}{suffix} {value}\n"
 
 
-def metrics(rib, active, stale, begin, eorr, timeout):
+def metrics(rib, active, stale, begin, eorr, timeout, *, current=1, established=1, flaps=0):
     text = ""
     text += line(
         "bgp_rib_prefixes",
@@ -43,10 +43,17 @@ def metrics(rib, active, stale, begin, eorr, timeout):
     )
     text += line(
         "bgp_session_established_total",
-        1,
+        established,
         peer=validate_phase.PEER,
     )
-    text += line("bgp_session_flaps_total", 0, peer=validate_phase.PEER)
+    text += line(
+        "bgp_peer_session_established",
+        current,
+        peer=validate_phase.PEER,
+        interface="",
+    )
+    if flaps is not None:
+        text += line("bgp_session_flaps_total", flaps, peer=validate_phase.PEER)
     for operation, count in (
         ("begin", begin),
         ("eorr", eorr),
@@ -88,6 +95,24 @@ class PhaseValidatorTests(unittest.TestCase):
             )
             summary = validate_phase.validate(phase, candidate, baseline)
             self.assertEqual(summary["phase"], phase)
+
+    def test_later_phase_requires_current_uninterrupted_session(self):
+        baseline = self.parse(metrics(100_000, 0, 0, 7, 11, 13))
+        candidate = dict(rib=100_000, active=0, stale=0, begin=9, eorr=12, timeout=13)
+        summary = validate_phase.validate(
+            "restored", self.parse(metrics(**candidate, flaps=None)), baseline
+        )
+        self.assertEqual(summary["session_established"], 1)
+        for name, change, metric in (
+            ("current-down", {"current": 0}, "bgp_peer_session_established"),
+            ("reestablished", {"established": 2}, "bgp_session_established_total"),
+            ("flapped", {"flaps": 1}, "bgp_session_flaps_total"),
+        ):
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(AssertionError, metric):
+                    validate_phase.validate(
+                        "restored", self.parse(metrics(**candidate, **change)), baseline
+                    )
 
     def test_missing_eorr_sweep_is_red(self):
         baseline = self.parse(metrics(100_000, 0, 0, 0, 0, 0))

--- a/bench/scale/enhanced-route-refresh/validate_phase.py
+++ b/bench/scale/enhanced-route-refresh/validate_phase.py
@@ -106,6 +106,12 @@ def validate(phase, metrics, baseline):
     require(metrics, "bgp_session_established_total", {"peer": PEER}, 1)
     require(
         metrics,
+        "bgp_peer_session_established",
+        {"interface": "", "peer": PEER},
+        1,
+    )
+    require(
+        metrics,
         "bgp_session_flaps_total",
         {"peer": PEER},
         0,
@@ -152,6 +158,7 @@ def validate(phase, metrics, baseline):
         "refresh_stale": stale,
         "max_prefix_usage": rib,
         "session_established_total": 1,
+        "session_established": 1,
         "session_flaps_total": 0,
         "actor_begin_count": expected_counts["begin"],
         "actor_eorr_count": expected_counts["eorr"],

--- a/bench/tests/test-rrtransport-receipt.sh
+++ b/bench/tests/test-rrtransport-receipt.sh
@@ -152,6 +152,9 @@ expect_red nlri-count mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/
 expect_red corrupt-prefix mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"per-peer.tsv";s=p.read_text();p.write_text(s.replace("7c50a897bc4a4e51","0000000000000000",1))'
 expect_red staged-is-wire mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"phase.json";d=json.loads(p.read_text());d["wire_ms"]=2;p.write_text(json.dumps(d))'
 expect_red group-key mutate -c 'import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/"phase.json";d=json.loads(p.read_text());d["groups"]=2;p.write_text(json.dumps(d))'
+for field in sessions established_before established_after; do
+  expect_red "phase-$field" mutate -c "import json,pathlib,sys;p=pathlib.Path(sys.argv[1])/'phase.json';d=json.loads(p.read_text());d['$field']=999;p.write_text(json.dumps(d))"
+done
 expect_red sessions-999 mutate -c 'import pathlib,sys;p=pathlib.Path(sys.argv[1])/"per-peer.tsv";p.write_text("\n".join(p.read_text().splitlines()[:-1])+"\n")'
 for field in withdrawals duplicates outside decode_failures; do
   expect_red "$field" mutate -c "import pathlib,sys;p=pathlib.Path(sys.argv[1])/'per-peer.tsv';s=p.read_text();h=s.splitlines()[0].split('\\t').index('$field');r=s.splitlines();x=r[1].split('\\t');x[h]='1';r[1]='\\t'.join(x);p.write_text('\\n'.join(r)+'\\n')"


### PR DESCRIPTION
## Summary

- require the enhanced-route-refresh receipt to prove the peer is currently Established, has entered Established exactly once, and has not flapped
- retain absent-as-zero semantics for the optional zero-flap metric and expose current state in the phase summary
- add isolated rrtransport phase-field proofs for session fleet size and both pre/post establishment gates while keeping fleet-cardinality deletion separate

## Verification

- four enhanced-route-refresh validator tests
- full rrtransport receipt harness
- Python compile, `bash -n`, ShellCheck, and diff check
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

## Load-bearing proof

Removing the current-state, establishment-total, or flap guard makes only its matching negative false-green. Disabling absent-as-zero fails the omitted-zero positive fixture. The three rrtransport phase mutations are isolated from the existing per-peer row-deletion proof.