### PR TITLE
Terminate cursor streams after producer loss

### DIFF
--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -678,6 +678,48 @@ mod tests {
             .expect("test operation timed out")
     }
 
+    async fn cursor_test_service() -> (
+        tempfile::TempDir,
+        rustbgpd_event_history::EventHistoryManager,
+        EventService,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = rustbgpd_event_history::EventHistoryManager::start(
+            rustbgpd_event_history::EventHistoryConfig {
+                path: dir.path().join("events.db"),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("EHM start");
+        let (rib_tx, _) = spawn_fake_rib();
+        let (peer_tx, _, _) = spawn_fake_peer_manager();
+        let service = EventService::new(rib_tx, peer_tx).with_event_history(Some(manager.handle()));
+        (dir, manager, service)
+    }
+
+    async fn cursor_test_stream(
+        service: &EventService,
+        from_event_id: Option<u64>,
+    ) -> cursor::SubscribeFromEventStream {
+        service
+            .subscribe_from_event(Request::new(proto::SubscribeFromEventRequest {
+                from_event_id,
+                ..Default::default()
+            }))
+            .await
+            .expect("cursor admission")
+            .into_inner()
+    }
+
+    async fn assert_cursor_data_loss(stream: &mut cursor::SubscribeFromEventStream) {
+        let status = within_test_deadline(stream.next())
+            .await
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(status.code(), tonic::Code::DataLoss);
+    }
+
     async fn invoke_watch_event_admission(
         service: &EventService,
         source: WatchEventAdmission,
@@ -2518,6 +2560,42 @@ mod tests {
     }
 
     // ── ADR-0072 PR5 — SubscribeFromEvent handler tests ────────
+
+    #[tokio::test]
+    async fn subscribe_from_event_quiet_stream_fails_on_producer_loss() {
+        // Load-bearing break: removing the producer-loss branch leaves the
+        // quiet stream pending until this test's deadline expires.
+        let (_dir, manager, service) = cursor_test_service().await;
+        let mut stream = cursor_test_stream(&service, None).await;
+
+        manager.state().record_loss();
+        assert_cursor_data_loss(&mut stream).await;
+        assert!(
+            within_test_deadline(stream.next()).await.is_none(),
+            "DATA_LOSS must terminate the admitted cursor"
+        );
+        manager.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn subscribe_from_event_baselines_pre_admission_loss() {
+        // Load-bearing breaks: rejecting a prior loss terminates before the
+        // short quiet-window control; removing live loss detection leaves the
+        // second receive pending until the outer deadline.
+        let (_dir, manager, service) = cursor_test_service().await;
+        manager.state().record_loss();
+        let mut stream = cursor_test_stream(&service, None).await;
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), stream.next())
+                .await
+                .is_err(),
+            "a pre-admission loss must not terminate the new stream"
+        );
+
+        manager.state().record_loss();
+        assert_cursor_data_loss(&mut stream).await;
+        manager.shutdown().await;
+    }
 
     #[tokio::test]
     async fn subscribe_from_event_unavailable_returns_failed_precondition() {

--- a/crates/api/src/event_service/cursor.rs
+++ b/crates/api/src/event_service/cursor.rs
@@ -34,7 +34,7 @@ use rustbgpd_event_history::{
 };
 use rustbgpd_telemetry::BgpMetrics;
 use rustbgpd_wire::Afi;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio_stream::Stream;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::Status;
@@ -456,12 +456,13 @@ fn stamp_durable_ids(event: &mut proto::BgpEvent, durable_event_id: u64) {
 /// `out_rx` in a [`ReceiverStream`] and returns it as the tonic
 /// response. The task exits when the subscriber's output channel
 /// closes (gRPC client disconnect, server drop) or when EHM's
-/// drain task signals end-of-stream.
+/// drain task signals end-of-stream or post-admission producer loss.
 async fn run_drain(
     filter: ProtoFilter,
     cursor: Option<u64>,
     mut committed_rx: mpsc::Receiver<EventSubscriptionItem>,
     out_tx: mpsc::Sender<Result<proto::BgpEvent, Status>>,
+    mut loss_rx: watch::Receiver<u64>,
     metrics: BgpMetrics,
 ) {
     // Forward committed events. Retention-gap detection happens
@@ -470,41 +471,92 @@ async fn run_drain(
     // floor read + first chunk read as one storage op makes the gap
     // signal race-free against retention. Live broadcast lag arrives
     // as `EventSubscriptionItem::Lagged(missed)`.
-    while let Some(item) = committed_rx.recv().await {
-        let committed = match item {
-            EventSubscriptionItem::Event(committed) => committed,
-            EventSubscriptionItem::Lagged(missed) => {
-                let lag = build_live_lag_event(missed);
-                if out_tx.send(Ok(lag)).await.is_err() {
-                    return;
+    loop {
+        let item = tokio::select! {
+            biased;
+            changed = loss_rx.changed() => {
+                if changed.is_ok() {
+                    let _ = out_tx.send(Err(producer_loss_status())).await;
                 }
-                continue;
+                return;
             }
+            item = committed_rx.recv() => {
+                let Some(item) = item else {
+                    return;
+                };
+                item
+            }
+        };
+        let event = match item {
+            EventSubscriptionItem::Event(committed) => {
+                if !filter.matches_committed(&committed) {
+                    continue;
+                }
+                let Some(mut event) = decode_payload_as_bgp_event(&committed, &metrics) else {
+                    continue;
+                };
+                if !filter.matches_event_type(&event) {
+                    continue;
+                }
+                stamp_durable_ids(&mut event, committed.event_id);
+                event
+            }
+            EventSubscriptionItem::Lagged(missed) => build_live_lag_event(missed),
             EventSubscriptionItem::RetentionGap(missed) => {
                 let from = cursor.unwrap_or(0);
                 let oldest_retained = from.saturating_add(missed.saturating_add(1));
-                let lag = build_cursor_gap_event(from, oldest_retained);
                 metrics.record_event_outbox_cursor_gap();
-                if out_tx.send(Ok(lag)).await.is_err() {
-                    return;
-                }
-                continue;
+                build_cursor_gap_event(from, oldest_retained)
             }
         };
-        if !filter.matches_committed(&committed) {
-            continue;
-        }
-        let Some(mut event) = decode_payload_as_bgp_event(&committed, &metrics) else {
-            continue;
-        };
-        if !filter.matches_event_type(&event) {
-            continue;
-        }
-        stamp_durable_ids(&mut event, committed.event_id);
-        if out_tx.send(Ok(event)).await.is_err() {
+        if !send_with_loss(Ok(event), &out_tx, &mut loss_rx).await {
             return;
         }
     }
+}
+
+fn producer_loss_status() -> Status {
+    Status::data_loss(
+        "durable event history lost producer events after cursor admission; reconcile against authoritative state before resuming from the last received event_id",
+    )
+}
+
+async fn send_with_loss(
+    item: Result<proto::BgpEvent, Status>,
+    out_tx: &mpsc::Sender<Result<proto::BgpEvent, Status>>,
+    loss_rx: &mut watch::Receiver<u64>,
+) -> bool {
+    tokio::select! {
+        biased;
+        changed = loss_rx.changed() => {
+            if changed.is_ok() {
+                let _ = out_tx.send(Err(producer_loss_status())).await;
+            }
+            false
+        }
+        permit = out_tx.reserve() => {
+            let Ok(permit) = permit else {
+                return false;
+            };
+            finish_reserved_send(permit, item, loss_rx)
+        }
+    }
+}
+
+fn finish_reserved_send(
+    permit: mpsc::Permit<'_, Result<proto::BgpEvent, Status>>,
+    item: Result<proto::BgpEvent, Status>,
+    loss_rx: &watch::Receiver<u64>,
+) -> bool {
+    let Ok(lost) = loss_rx.has_changed() else {
+        return false;
+    };
+    permit.send(if lost {
+        Err(producer_loss_status())
+    } else {
+        item
+    });
+    !lost
 }
 
 /// Stream type returned by [`subscribe`]. Aliased to keep the
@@ -522,6 +574,14 @@ fn parse_filter_when_available(
         ));
     }
     ProtoFilter::from_request(request)
+}
+
+fn baseline_then_subscribe<T, E>(
+    baseline: impl FnOnce() -> watch::Receiver<u64>,
+    subscribe: impl FnOnce() -> Result<T, E>,
+) -> Result<(T, watch::Receiver<u64>), E> {
+    let loss_rx = baseline();
+    Ok((subscribe()?, loss_rx))
 }
 
 /// Public entry point called by the tonic handler. Performs the
@@ -542,13 +602,22 @@ pub(crate) fn subscribe(
         filter: filter.cursor_subset(),
         output_capacity: OUTPUT_CAPACITY,
     };
-    let subscription = handle
-        .subscribe_from_event(subscribe_req)
-        .map_err(map_ehm_err_to_status)?;
+    let (subscription, loss_rx) = baseline_then_subscribe(
+        || handle.state().subscribe_loss_generation(),
+        || handle.subscribe_from_event(subscribe_req),
+    )
+    .map_err(map_ehm_err_to_status)?;
     let committed_rx = subscription.into_receiver();
 
     let (out_tx, out_rx) = mpsc::channel(OUTPUT_CAPACITY);
-    tokio::spawn(run_drain(filter, cursor, committed_rx, out_tx, metrics));
+    tokio::spawn(run_drain(
+        filter,
+        cursor,
+        committed_rx,
+        out_tx,
+        loss_rx,
+        metrics,
+    ));
 
     Ok(Box::pin(ReceiverStream::new(out_rx)))
 }
@@ -556,6 +625,61 @@ pub(crate) fn subscribe(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn producer_loss_preempts_blocked_cursor_delivery() {
+        // Load-bearing breaks: reversing baseline/admission hides the first loss;
+        // plain send or no reserved-permit recheck emits the pending item below.
+        let (loss_tx, _) = watch::channel(0_u64);
+        let ((), loss_rx) = baseline_then_subscribe(
+            || loss_tx.subscribe(),
+            || {
+                loss_tx.send_modify(|generation| *generation += 1);
+                Ok::<(), ()>(())
+            },
+        )
+        .unwrap();
+        assert!(loss_rx.has_changed().unwrap());
+
+        let filter = ProtoFilter::from_request(&proto::SubscribeFromEventRequest::default())
+            .expect("wildcard filter");
+        let (committed_tx, committed_rx) = mpsc::channel(1);
+        committed_tx
+            .try_send(EventSubscriptionItem::RetentionGap(1))
+            .unwrap();
+        let (out_tx, mut out_rx) = mpsc::channel(1);
+        out_tx.try_send(Ok(proto::BgpEvent::default())).unwrap();
+        let (loss_tx, loss_rx) = watch::channel(0_u64);
+        let mut drain = tokio::spawn(run_drain(
+            filter,
+            Some(0),
+            committed_rx,
+            out_tx,
+            loss_rx,
+            BgpMetrics::new(),
+        ));
+        let blocked = tokio::time::timeout(std::time::Duration::from_millis(50), &mut drain)
+            .await
+            .is_err();
+        assert!(blocked, "cursor delivery must block behind the filler");
+
+        loss_tx.send_modify(|generation| *generation += 1);
+        assert!(out_rx.recv().await.unwrap().is_ok(), "drain the filler");
+        let status = out_rx.recv().await.unwrap().unwrap_err();
+        assert_eq!(status.code(), tonic::Code::DataLoss);
+        drain.await.unwrap();
+        assert!(out_rx.recv().await.is_none(), "DATA_LOSS must terminate");
+
+        // A loss after reserve but before finalization must replace the item.
+        let (out_tx, mut out_rx) = mpsc::channel(1);
+        let permit = out_tx.reserve().await.unwrap();
+        let (loss_tx, loss_rx) = watch::channel(0_u64);
+        loss_tx.send_modify(|generation| *generation += 1);
+        let delivered = finish_reserved_send(permit, Ok(proto::BgpEvent::default()), &loss_rx);
+        assert!(!delivered);
+        let status = out_rx.recv().await.unwrap().unwrap_err();
+        assert_eq!(status.code(), tonic::Code::DataLoss);
+    }
 
     #[test]
     fn from_request_rejects_unknown_category() {

--- a/docs/API.md
+++ b/docs/API.md
@@ -1568,6 +1568,9 @@ enabled. When event history is disabled or unavailable, the RPC returns
 `FAILED_PRECONDITION`; legacy live and `List*Events` RPCs are unaffected.
 That availability result takes precedence over filter validation.
 
+Pre-admission loss is the baseline; later loss wins delivery races and ends with
+`DATA_LOSS`. Cursors cannot replay pre-commit loss, so reconcile state first.
+
 Filters compose AND-wise across category, type, peer, family, and exact prefix.
 Repeated categories are ORed, repeated types are ORed, and the two dimensions
 are ANDed. A request is accepted when any selected category/type pair is real;

--- a/docs/adr/0072-durable-event-history.md
+++ b/docs/adr/0072-durable-event-history.md
@@ -471,6 +471,10 @@ the existing `WatchEvents`, `WatchRoutes`, `WatchRouteEvents`. The
 existing watch RPCs route through EHM internally with the cursor
 absent.
 
+The RPC baselines EHM's loss generation before delivery; later loss wins replay
+or blocked-delivery races and terminates with `DATA_LOSS`. Unlike a retention
+gap, pre-commit loss requires authoritative reconciliation before resuming.
+
 ### Retention — small, hard-capped, two dimensions
 
 Defaults are **deliberately small** so that when an operator enables


### PR DESCRIPTION
## Summary

- baseline the event-history producer-loss generation before cursor admission
- terminate admitted `SubscribeFromEvent` streams with tonic `DATA_LOSS` after any later producer loss
- make loss preempt replay, lag, retention-gap, and blocked output delivery through one guarded send seam
- document the required authoritative-state reconciliation before cursor resume

## Safety boundary

Pre-admission loss establishes the baseline and does not reject a new stream. Retention gaps remain recoverable control frames. This does not add polling, fabricate missed-event counts, change protobuf, or alter legacy live streams.

## Load-bearing proof

- reversing baseline and admission makes the deterministic generation assertion fail
- replacing the guarded send with a plain send leaks the pending frame instead of `DATA_LOSS`
- deleting the post-reserve generation recheck lets the reserved normal item win
- deleting the idle loss arm makes the quiet real-service proof time out
- a pre-admission service control stays quiet, then terminates on the next loss

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- focused event-service and cursor-handoff suites

Independent exact-diff review: MERGE. Scope is four files and 265 lines of churn; the 15-line estimate revision centralizes all cursor delivery behind one guarded seam and makes admission ordering deterministically testable.