### PR TITLE
Make accepted config snapshots authoritative

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,6 +4,7 @@ pub mod profiles;
 mod resolution;
 mod schema;
 mod source_provenance;
+pub(crate) use source_provenance::AcceptedConfigSnapshot;
 mod validation;
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -385,7 +386,7 @@ impl Config {
 
     #[expect(
         clippy::too_many_lines,
-        reason = "the dormant provenance handoff preserves the existing linear load state machine"
+        reason = "active provenance capture preserves the existing linear load state machine"
     )]
     fn bind_datasets_capturing(
         &mut self,
@@ -606,6 +607,7 @@ impl Config {
     /// mutating their shared handles. Call [`Self::prepare_staged_datasets`]
     /// after every no-side-effect reload preflight has passed, then commit the
     /// returned plan at the ordered dataset reconciliation step.
+    #[cfg(test)]
     pub(crate) fn load_with_diagnostics_and_staged_datasets(
         path: &str,
         prior_datasets: &rustbgpd_policy::datasets::DatasetBindings,

--- a/src/config/source_provenance.rs
+++ b/src/config/source_provenance.rs
@@ -1,8 +1,8 @@
-//! Dormant accepted-config same-read source identity (ADR-0121 tranche 1).
+//! Accepted-config ownership and same-read source identity (ADR-0121).
 
 #![allow(
     dead_code,
-    reason = "ADR-0121 tranche 1 deliberately lands a dormant loader handoff"
+    reason = "accepted ownership is active while digest and v2 exposure remain private"
 )]
 
 use std::path::{Path, PathBuf};
@@ -177,7 +177,7 @@ fn lossless_path_bytes(path: &Path) -> (&'static [u8], Vec<u8>) {
     (b"windows-wide-be", bytes)
 }
 
-struct AcceptedConfigSnapshot {
+pub(crate) struct AcceptedConfigSnapshot {
     config: Arc<Config>,
     normalized_toml: Arc<str>,
     manifest: SourceManifest,
@@ -186,13 +186,35 @@ struct AcceptedConfigSnapshot {
 }
 
 impl AcceptedConfigSnapshot {
-    fn load(path: &Path, prior: Option<&Self>) -> Result<Self, String> {
+    pub(crate) fn load(path: &Path, prior: Option<&Self>) -> Result<Self, String> {
         Self::load_with_hook(path, prior, || {})
+    }
+
+    pub(crate) fn load_for_reload(
+        path: &Path,
+        prior: &Self,
+        live_bindings: &rustbgpd_policy::datasets::DatasetBindings,
+    ) -> Result<Self, String> {
+        Self::load_captured(path, Some(prior), Some(live_bindings), || {})
     }
 
     fn load_with_hook(
         path: &Path,
         prior: Option<&Self>,
+        after_capture: impl FnOnce(),
+    ) -> Result<Self, String> {
+        Self::load_captured(
+            path,
+            prior,
+            prior.map(|snapshot| &snapshot.config.policy.dataset_bindings),
+            after_capture,
+        )
+    }
+
+    fn load_captured(
+        path: &Path,
+        prior: Option<&Self>,
+        live_bindings: Option<&rustbgpd_policy::datasets::DatasetBindings>,
         after_capture: impl FnOnce(),
     ) -> Result<Self, String> {
         let bytes = std::fs::read(path)
@@ -205,7 +227,7 @@ impl AcceptedConfigSnapshot {
             &content,
             &path.display().to_string(),
             base_dir.as_deref(),
-            prior.map(|snapshot| &snapshot.config.policy.dataset_bindings),
+            live_bindings,
             DatasetBindMode::Stage,
             Some(&mut capture),
             prior.map(|snapshot| &snapshot.manifest),
@@ -229,10 +251,138 @@ impl AcceptedConfigSnapshot {
         })
     }
 
-    fn config(&self) -> Config {
+    pub(crate) fn derive_config(&self, mut config: Config) -> Result<Arc<Self>, String> {
+        self.require_same_external_roster(&config)?;
+        config.policy.dataset_bindings = config.policy.dataset_bindings.detached_clone();
+        let normalized_toml: Arc<str> = persisted_config_document(&config)
+            .map_err(|error| format!("failed to normalize accepted config: {error}"))?
+            .into();
+        let sha256 = Sha256::digest(normalized_toml.as_bytes()).into();
+        let mut manifest = self.manifest.clone();
+        manifest.toml_sha256 = sha256;
+        let source_sha256 = manifest.source_sha256();
+        Ok(Arc::new(Self {
+            config: Arc::new(config),
+            normalized_toml,
+            manifest,
+            sha256,
+            source_sha256,
+        }))
+    }
+
+    pub(crate) fn derive_toml_without_sources(
+        &self,
+        content: &str,
+        source_name: &str,
+    ) -> Result<Arc<Self>, String> {
+        let mut config: Config =
+            toml::from_str(content).map_err(|error| format!("invalid {source_name}: {error}"))?;
+        self.require_same_external_roster(&config)?;
+        config.file_path.clone_from(&self.config.file_path);
+        config.policy.rpol.clone_from(&self.config.policy.rpol);
+        config.policy.dataset_bindings = self.config.policy.dataset_bindings.detached_clone();
+        config.policy.dataset_events = self.config.policy.dataset_events.clone();
+        config
+            .validate()
+            .map_err(|error| format!("invalid {source_name}: {error}"))?;
+        self.derive_config(config)
+    }
+
+    pub(crate) fn runtime_config_without_sources(
+        &self,
+        content: &str,
+        rpol_files: &[String],
+        rpol: rustbgpd_policy::rpol::RpolPolicySet,
+        live_bindings: &rustbgpd_policy::datasets::DatasetBindings,
+    ) -> Result<Config, String> {
+        let mut config: Config = toml::from_str(content)
+            .map_err(|error| format!("invalid runtime config snapshot: {error}"))?;
+        if config.policy.rpol_files != rpol_files {
+            return Err(
+                "runtime config snapshot rpol roster disagrees with live registry".to_string(),
+            );
+        }
+        config.file_path.clone_from(&self.config.file_path);
+        config.policy.rpol = rpol;
+        config.policy.dataset_bindings = live_bindings.clone();
+        config
+            .validate()
+            .map_err(|error| format!("invalid runtime config snapshot: {error}"))?;
+        Ok(config)
+    }
+
+    /// Reconstruct a config document for transaction editing or rollback
+    /// serialization without attaching any accepted or live external data.
+    ///
+    /// A partial SIGHUP may leave runtime generation A beside accepted desired
+    /// generation B. Transaction construction needs A's document shape, but
+    /// must not validate it against B's detached datasets or expose those
+    /// bindings to policy planning. The eventual transaction executor reloads
+    /// and validates the candidate at its existing accepted-input boundary.
+    pub(crate) fn transaction_config_without_sources(
+        &self,
+        content: &str,
+        rpol_files: &[String],
+    ) -> Result<Config, String> {
+        let mut config: Config = toml::from_str(content)
+            .map_err(|error| format!("invalid runtime config document: {error}"))?;
+        if config.policy.rpol_files != rpol_files {
+            return Err(
+                "runtime config document rpol roster disagrees with live registry".to_string(),
+            );
+        }
+        config.file_path.clone_from(&self.config.file_path);
+        Ok(config)
+    }
+
+    fn require_same_external_roster(&self, config: &Config) -> Result<(), String> {
+        if config.policy.rpol_files != self.config.policy.rpol_files
+            || config.policy.rpol_roots != self.config.policy.rpol_roots
+            || config.policy.rpol_max_graph_bytes != self.config.policy.rpol_max_graph_bytes
+            || config.policy.datasets != self.config.policy.datasets
+        {
+            return Err(
+                "runtime config mutation cannot change external policy-source inventory; edit the config file and use SIGHUP"
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_config_for_test(config: Config) -> Arc<Self> {
+        let normalized_toml: Arc<str> = persisted_config_document(&config).unwrap().into();
+        let sha256 = Sha256::digest(normalized_toml.as_bytes()).into();
+        let manifest = SourceCapture::default().finish(sha256);
+        Arc::new(Self {
+            config: Arc::new(config),
+            normalized_toml,
+            source_sha256: manifest.source_sha256(),
+            manifest,
+            sha256,
+        })
+    }
+
+    pub(crate) fn config(&self) -> Config {
         let mut config = (*self.config).clone();
         config.policy.dataset_bindings = config.policy.dataset_bindings.detached_clone();
         config
+    }
+
+    pub(crate) fn config_ref(&self) -> &Config {
+        &self.config
+    }
+
+    pub(crate) fn normalized_toml(&self) -> &str {
+        &self.normalized_toml
+    }
+}
+
+impl std::ops::Deref for AcceptedConfigSnapshot {
+    type Target = Config;
+
+    fn deref(&self) -> &Self::Target {
+        self.config_ref()
     }
 }
 
@@ -307,6 +457,102 @@ path = "customers.txt"
             .iter()
             .map(|module| module.path.file_name().unwrap().to_str().unwrap())
             .collect()
+    }
+
+    #[test]
+    fn source_free_derivation_retains_roster_and_rejects_inventory_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let snapshot = AcceptedConfigSnapshot::load(&fixture(dir.path()), None).unwrap();
+        fs::remove_file(dir.path().join("policy.rpol")).unwrap();
+        fs::remove_file(dir.path().join("lib.rpol")).unwrap();
+        fs::remove_file(dir.path().join("a-child.rpol")).unwrap();
+        fs::remove_file(dir.path().join("a-unit.rpol")).unwrap();
+        fs::remove_file(dir.path().join("customers.txt")).unwrap();
+
+        let mut fib_only = snapshot.config();
+        fib_only.fib_tables.push(super::super::FibTableConfig {
+            name: "edge".to_string(),
+            table_id: 100,
+            metric: 100,
+            families: super::super::default_fib_families(),
+            allowed_peer_groups: Vec::new(),
+            allowed_neighbors: Vec::new(),
+            max_routes: None,
+            maximum_paths: None,
+            maximum_paths_ebgp: None,
+            maximum_paths_ibgp: None,
+        });
+        let derived = snapshot
+            .derive_config(fib_only)
+            .expect("post-capture derivation must not reread deleted sources");
+        assert_eq!(derived.manifest.rpol_units, snapshot.manifest.rpol_units);
+        assert_eq!(derived.manifest.datasets, snapshot.manifest.datasets);
+
+        let live_bindings = snapshot.policy.dataset_bindings.detached_clone();
+        let live_dataset = Arc::clone(live_bindings.get("customers").unwrap());
+        let supplied_rpol = snapshot.policy.rpol.clone();
+        let supplied_file = Arc::clone(&supplied_rpol.policies["outbound"].file);
+        let runtime = snapshot
+            .runtime_config_without_sources(
+                snapshot.normalized_toml(),
+                &snapshot.policy.rpol_files,
+                supplied_rpol,
+                &live_bindings,
+            )
+            .expect("runtime reconstruction must not reread deleted external sources");
+        assert!(Arc::ptr_eq(
+            runtime.policy.dataset_bindings.get("customers").unwrap(),
+            &live_dataset
+        ));
+        assert!(Arc::ptr_eq(
+            &runtime.policy.rpol.policies["outbound"].file,
+            &supplied_file
+        ));
+
+        let mut changed_roster = snapshot.config();
+        changed_roster
+            .policy
+            .rpol_files
+            .push("/new/source.rpol".to_string());
+        assert!(
+            snapshot.derive_config(changed_roster).is_err(),
+            "a source-free mutation must not relabel changed external inventory"
+        );
+    }
+
+    #[test]
+    fn partial_reload_runtime_roster_stays_distinct_from_accepted_desired() {
+        let dir = tempfile::tempdir().unwrap();
+        let desired = AcceptedConfigSnapshot::load(&fixture(dir.path()), None).unwrap();
+        fs::remove_file(dir.path().join("policy.rpol")).unwrap();
+        fs::remove_file(dir.path().join("lib.rpol")).unwrap();
+        fs::remove_file(dir.path().join("a-child.rpol")).unwrap();
+        fs::remove_file(dir.path().join("a-unit.rpol")).unwrap();
+        fs::remove_file(dir.path().join("customers.txt")).unwrap();
+
+        let runtime_toml = tier_authorized_uds_test_config(
+            r#"
+[global]
+asn = 65000
+router_id = "192.0.2.1"
+listen_port = 179
+[global.telemetry]
+log_format = "json"
+"#,
+        );
+        let runtime = desired
+            .runtime_config_without_sources(
+                &runtime_toml,
+                &[],
+                rustbgpd_policy::rpol::RpolPolicySet::default(),
+                &rustbgpd_policy::datasets::DatasetBindings::default(),
+            )
+            .expect("runtime A must reconstruct independently of desired roster B");
+
+        assert!(runtime.policy.rpol_files.is_empty());
+        assert!(runtime.policy.datasets.is_empty());
+        assert_eq!(desired.policy.rpol_files.len(), 2);
+        assert_eq!(desired.policy.datasets.len(), 1);
     }
 
     #[test]

--- a/src/config_persister.rs
+++ b/src/config_persister.rs
@@ -8,11 +8,14 @@
 
 use std::net::IpAddr;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use tokio::sync::{mpsc, oneshot};
 use tracing::{error, info, warn};
 
-use crate::config::{Config, Neighbor, persisted_config_document};
+#[cfg(test)]
+use crate::config::Config;
+use crate::config::{AcceptedConfigSnapshot, Neighbor};
 
 /// File under `runtime_state_dir` recording the config file's mtime as of the
 /// daemon's last read or write of it.
@@ -29,17 +32,23 @@ pub enum ConfigMutation {
     AddNeighbor(Box<Neighbor>),
     DeleteNeighbor(IpAddr),
     /// Replace the entire config snapshot and persist it to disk.
-    ReplaceConfig(Box<Config>),
+    ReplaceConfig(Arc<AcceptedConfigSnapshot>),
     /// Replace the entire config snapshot, persist it to disk, then acknowledge
     /// the result to a caller that must not proceed until the write has settled.
-    ReplaceConfigAck(Box<Config>, oneshot::Sender<Result<(), String>>),
+    ReplaceConfigAck(
+        Arc<AcceptedConfigSnapshot>,
+        oneshot::Sender<Result<(), String>>,
+    ),
     /// Durably stage a replacement snapshot without publishing it, then
     /// acknowledge whether the write can land. Every persistence failure an
     /// operator actually hits (unwritable directory, read-only mount, full
     /// filesystem) surfaces here, before the caller mutates any runtime state.
     ///
     /// Exactly one stage may be outstanding; a second replaces the first.
-    StageConfigAck(Box<Config>, oneshot::Sender<Result<(), String>>),
+    StageConfigAck(
+        Arc<AcceptedConfigSnapshot>,
+        oneshot::Sender<Result<(), String>>,
+    ),
     /// Publish the staged snapshot: rename it into place and adopt it.
     CommitStagedConfig(oneshot::Sender<Result<(), String>>),
     /// Drop the staged snapshot. The caller's runtime change did not land, so
@@ -52,27 +61,30 @@ pub enum ConfigMutation {
     /// snapshot, but future gRPC mutations must still apply on top of
     /// the operator's desired file rather than writing the pinned
     /// runtime snapshot back to disk.
-    RefreshSnapshotNoPersist(Box<Config>),
+    RefreshSnapshotNoPersist(Arc<AcceptedConfigSnapshot>),
 }
 
 /// Listens for config mutations and persists them atomically.
 pub struct ConfigPersister {
     rx: mpsc::Receiver<ConfigMutation>,
     config_path: PathBuf,
-    current: Config,
+    current: Arc<AcceptedConfigSnapshot>,
     /// `runtime_state_dir`, the home of the applied-config history
     /// (`config_history`) and the last-persist marker. `None` disables both
     /// (unit tests, embedders without a state dir).
     state_dir: Option<PathBuf>,
     /// Durably written but unpublished snapshot, awaiting commit or discard.
-    staged: Option<(crate::confirm_journal::StagedWrite, Config, String)>,
+    staged: Option<(
+        crate::confirm_journal::StagedWrite,
+        Arc<AcceptedConfigSnapshot>,
+    )>,
 }
 
 impl ConfigPersister {
-    pub fn new(
+    pub fn new_accepted(
         rx: mpsc::Receiver<ConfigMutation>,
         config_path: PathBuf,
-        current: Config,
+        current: Arc<AcceptedConfigSnapshot>,
         state_dir: Option<PathBuf>,
     ) -> Self {
         Self {
@@ -82,6 +94,21 @@ impl ConfigPersister {
             state_dir,
             staged: None,
         }
+    }
+
+    #[cfg(test)]
+    pub fn new(
+        rx: mpsc::Receiver<ConfigMutation>,
+        config_path: PathBuf,
+        current: Config,
+        state_dir: Option<PathBuf>,
+    ) -> Self {
+        Self::new_accepted(
+            rx,
+            config_path,
+            AcceptedConfigSnapshot::from_config_for_test(current),
+            state_dir,
+        )
     }
 
     pub async fn run(mut self) {
@@ -96,9 +123,9 @@ impl ConfigPersister {
             match mutation {
                 ConfigMutation::ReplaceConfigAck(new_config, ack) => {
                     self.discard_staged();
-                    let previous = self.current.clone();
+                    let previous = Arc::clone(&self.current);
                     info!("replacing persister config snapshot and persisting it");
-                    self.current = *new_config;
+                    self.current = new_config;
                     let result = self.persist().map_err(|e| e.to_string());
                     if let Err(e) = &result {
                         self.current = previous;
@@ -112,7 +139,7 @@ impl ConfigPersister {
                     continue;
                 }
                 ConfigMutation::StageConfigAck(new_config, ack) => {
-                    let _ = ack.send(self.stage(*new_config).map_err(|e| e.to_string()));
+                    let _ = ack.send(self.stage(new_config).map_err(|e| e.to_string()));
                     continue;
                 }
                 ConfigMutation::CommitStagedConfig(ack) => {
@@ -144,23 +171,25 @@ impl ConfigPersister {
     /// it. A failure here is the whole point of the two-phase handshake: the
     /// caller learns the write cannot land while its runtime state is still
     /// untouched.
-    fn stage(&mut self, new_config: Config) -> std::io::Result<()> {
+    fn stage(&mut self, new_config: Arc<AcceptedConfigSnapshot>) -> std::io::Result<()> {
         // A superseded stage is discarded, never published: its caller either
         // failed its apply or is gone.
         self.discard_staged();
-        let toml_str = persisted_config_document(&new_config).map_err(std::io::Error::other)?;
-        let staged = crate::confirm_journal::stage_atomic(&self.config_path, toml_str.as_bytes())?;
+        let staged = crate::confirm_journal::stage_atomic(
+            &self.config_path,
+            new_config.normalized_toml().as_bytes(),
+        )?;
         info!(
             path = %self.config_path.display(),
             "staged config write, awaiting commit"
         );
-        self.staged = Some((staged, new_config, toml_str));
+        self.staged = Some((staged, new_config));
         Ok(())
     }
 
     /// Publish the staged candidate and adopt it as the persister snapshot.
     fn commit_staged(&mut self) -> Result<(), String> {
-        let Some((staged, config, toml_str)) = self.staged.take() else {
+        let Some((staged, config)) = self.staged.take() else {
             return Err("no staged config write to commit".to_string());
         };
         if let Err(error) = staged.commit() {
@@ -172,7 +201,7 @@ impl ConfigPersister {
             return Err(error.to_string());
         }
         self.current = config;
-        self.record_history(&toml_str);
+        self.record_current_history();
         Ok(())
     }
 
@@ -206,32 +235,42 @@ impl ConfigPersister {
                     );
                 } else {
                     info!(address = %neighbor.address, "persisting added neighbor");
-                    self.current.neighbors.push(*neighbor);
+                    let mut config = self.current.config();
+                    config.neighbors.push(*neighbor);
+                    self.current = self
+                        .current
+                        .derive_config(config)
+                        .expect("validated config remains serializable");
                 }
                 true
             }
             ConfigMutation::DeleteNeighbor(address) => {
                 let addr_str = address.to_string();
-                let before = self.current.neighbors.len();
-                self.current.neighbors.retain(|n| n.address != addr_str);
-                if self.current.neighbors.len() < before {
+                let mut config = self.current.config();
+                let before = config.neighbors.len();
+                config.neighbors.retain(|n| n.address != addr_str);
+                if config.neighbors.len() < before {
                     info!(%address, "persisting deleted neighbor");
                 }
+                self.current = self
+                    .current
+                    .derive_config(config)
+                    .expect("validated config remains serializable");
                 true
             }
             ConfigMutation::ReplaceConfig(new_config) => {
                 info!("replacing persister config snapshot and persisting it");
-                self.current = *new_config;
+                self.current = new_config;
                 true
             }
             ConfigMutation::ReplaceConfigAck(new_config, _) => {
                 info!("replacing persister config snapshot and persisting it");
-                self.current = *new_config;
+                self.current = new_config;
                 true
             }
             ConfigMutation::RefreshSnapshotNoPersist(new_config) => {
                 info!("refreshing persister config snapshot without writing to disk");
-                self.current = *new_config;
+                self.current = new_config;
                 // The operator already persisted and successfully reloaded
                 // this desired config. Record the validated snapshot without
                 // writing it back: otherwise history index 0 still names the
@@ -243,16 +282,17 @@ impl ConfigPersister {
     }
 
     fn persist(&self) -> std::io::Result<()> {
-        let toml_str = persisted_config_document(&self.current).map_err(std::io::Error::other)?;
-
         // Durable atomic write: temp file → fsync → rename → fsync parent dir.
         // Reuses the commit-confirm journal's proven primitive so a crash in the
         // settle window can never leave a torn/zero-length config (LAN-206).
-        crate::confirm_journal::write_atomic(&self.config_path, toml_str.as_bytes())?;
+        crate::confirm_journal::write_atomic(
+            &self.config_path,
+            self.current.normalized_toml().as_bytes(),
+        )?;
         // Every durable config write funnels through this method, so recording
         // here gives the applied-config history exactly one choke point:
         // transaction commits, gRPC CRUD mutations, and boot all land in it.
-        self.record_history(&toml_str);
+        self.record_history(self.current.normalized_toml());
         Ok(())
     }
 
@@ -321,19 +361,14 @@ impl ConfigPersister {
     }
 
     fn record_current_history(&self) {
-        match persisted_config_document(&self.current) {
-            Ok(toml_str) => self.record_history(&toml_str),
-            Err(error) => warn!(
-                error = %error,
-                "failed to serialize the applied config for config history"
-            ),
-        }
+        self.record_history(self.current.normalized_toml());
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::persisted_config_document;
 
     fn minimal_config() -> Config {
         let toml_str = r#"
@@ -616,11 +651,8 @@ remote_asn = 65002
 
         let mut refreshed = minimal_config();
         refreshed.neighbors.push(test_neighbor("10.0.0.2", 65002));
-        assert!(
-            !persister.apply(ConfigMutation::RefreshSnapshotNoPersist(Box::new(
-                refreshed.clone()
-            ),))
-        );
+        let refreshed_snapshot = persister.current.derive_config(refreshed.clone()).unwrap();
+        assert!(!persister.apply(ConfigMutation::RefreshSnapshotNoPersist(refreshed_snapshot)));
 
         let entries = crate::config_history::list(&history).unwrap();
         assert_eq!(entries.len(), 2);
@@ -642,9 +674,9 @@ remote_asn = 65002
         let persister = ConfigPersister::new(rx, path.clone(), config, None);
         let handle = tokio::spawn(persister.run());
 
-        tx.send(ConfigMutation::RefreshSnapshotNoPersist(Box::new(
-            refreshed,
-        )))
+        tx.send(ConfigMutation::RefreshSnapshotNoPersist(
+            AcceptedConfigSnapshot::from_config_for_test(refreshed),
+        ))
         .await
         .unwrap();
         tx.send(ConfigMutation::AddNeighbor(Box::new(test_neighbor(
@@ -759,9 +791,11 @@ log_format = "json"
         let (tx, rx) = mpsc::channel(16);
         let persister = ConfigPersister::new(rx, path.clone(), reloaded.clone(), None);
         let handle = tokio::spawn(persister.run());
-        tx.send(ConfigMutation::ReplaceConfig(Box::new(reloaded)))
-            .await
-            .unwrap();
+        tx.send(ConfigMutation::ReplaceConfig(
+            AcceptedConfigSnapshot::from_config_for_test(reloaded),
+        ))
+        .await
+        .unwrap();
         drop(tx);
         handle.await.unwrap();
         let second = std::fs::read_to_string(&path).unwrap();

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -8,7 +8,7 @@ use std::fmt::Write as _;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio::sync::{Mutex, mpsc, oneshot, watch};
 
 use rustbgpd_api::peer_types::{
     ConfigEvent, ConfigPersistAck, DynamicPeerBounceOutcome, DynamicRangeTarget, PeerKey,
@@ -24,12 +24,15 @@ use rustbgpd_api::server::{
 use rustbgpd_telemetry::BgpMetrics;
 use tracing::{error, info, warn};
 
-use crate::config::{Config, EffectiveNeighborImpactKind, Neighbor, diff_config, diff_neighbors};
+use crate::config::{
+    AcceptedConfigSnapshot, Config, EffectiveNeighborImpactKind, Neighbor, diff_config,
+    diff_neighbors,
+};
 use crate::fib_table_control::{
     FibTableControlDeps, commit_fib_tables_locked, runtime_unavailable_error,
 };
 use crate::gnmi_set_bridge;
-use crate::reload::runtime_config_snapshot;
+use crate::reload::transaction_config_snapshot_accepted;
 
 const PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
 const DEFAULT_CONFIRM_TIMEOUT_SECONDS: u32 = 600;
@@ -52,6 +55,7 @@ pub struct ConfigTransactionController {
     deps: Arc<FibTableControlDeps>,
     metrics: BgpMetrics,
     state: Arc<Mutex<ConfirmedState>>,
+    accepted_rx: Option<watch::Receiver<Arc<AcceptedConfigSnapshot>>>,
 }
 
 #[derive(Debug, Default)]
@@ -107,13 +111,40 @@ struct ConfirmedApplyMode {
 }
 
 impl ConfigTransactionController {
+    #[cfg(test)]
     #[must_use]
     pub fn new(deps: FibTableControlDeps, metrics: BgpMetrics) -> Self {
         Self {
             deps: Arc::new(deps),
             metrics,
             state: Arc::new(Mutex::new(ConfirmedState::default())),
+            accepted_rx: None,
         }
+    }
+
+    #[must_use]
+    pub(crate) fn new_accepted(
+        deps: FibTableControlDeps,
+        metrics: BgpMetrics,
+        accepted_rx: watch::Receiver<Arc<AcceptedConfigSnapshot>>,
+    ) -> Self {
+        Self {
+            deps: Arc::new(deps),
+            metrics,
+            state: Arc::new(Mutex::new(ConfirmedState::default())),
+            accepted_rx: Some(accepted_rx),
+        }
+    }
+
+    async fn accepted_runtime_snapshot(&self) -> Result<Config, String> {
+        let Some(accepted_rx) = &self.accepted_rx else {
+            #[cfg(test)]
+            return crate::reload::runtime_config_snapshot(&self.deps.peer_mgr_tx).await;
+            #[cfg(not(test))]
+            return Err("accepted-config authority unavailable".to_string());
+        };
+        let accepted = accepted_rx.borrow().clone();
+        transaction_config_snapshot_accepted(&self.deps.peer_mgr_tx, &accepted).await
     }
 
     #[must_use]
@@ -276,7 +307,8 @@ impl ConfigTransactionController {
                         .map_err(apply_error_to_gnmi_set_error)?;
                 }
             }
-            let current = runtime_config_snapshot(&self.deps.peer_mgr_tx)
+            let current = self
+                .accepted_runtime_snapshot()
                 .await
                 .map_err(GnmiSetError::Unavailable)?;
             let candidate = gnmi_set_bridge::apply_transaction_to_config(current, &transaction)?;
@@ -362,7 +394,8 @@ impl ConfigTransactionController {
         request: proto::ApplyConfigTransactionRequest,
         confirmed: ConfirmedApplyMode,
     ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
-        let rollback_config = runtime_config_snapshot(&self.deps.peer_mgr_tx)
+        let rollback_config = self
+            .accepted_runtime_snapshot()
             .await
             .map_err(ConfigTransactionApplyError::Unavailable)?;
         // Rendered as a persisted document, not a bare snapshot: the boot-time
@@ -2986,6 +3019,126 @@ remote_asn = 65002
 {extra}
 "#
         ))
+    }
+
+    #[test]
+    fn production_snapshot_callers_are_fenced_to_the_accepted_helper() {
+        let source = include_str!("config_transaction_control.rs");
+        let production = source.split("#[cfg(test)]\nmod tests {").next().unwrap();
+        assert_eq!(
+            production.matches(".accepted_runtime_snapshot()").count(),
+            2,
+            "gNMI Set and confirmed rollback must independently use accepted authority"
+        );
+        assert!(!production.contains("use crate::reload::runtime_config_snapshot;"));
+
+        let reload = include_str!("reload.rs");
+        let legacy = reload
+            .find("pub(crate) async fn runtime_config_snapshot(")
+            .unwrap();
+        assert!(reload[..legacy].ends_with("#[cfg(test)]\n"));
+    }
+
+    #[tokio::test]
+    async fn accepted_runtime_snapshot_keeps_split_runtime_external_state_document_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime_rpol = dir.path().join("runtime.rpol");
+        let runtime_dataset = dir.path().join("runtime-customers.txt");
+        let desired_rpol = dir.path().join("desired.rpol");
+        let desired_dataset = dir.path().join("desired-customers.txt");
+        for path in [
+            &runtime_rpol,
+            &runtime_dataset,
+            &desired_rpol,
+            &desired_dataset,
+        ] {
+            std::fs::write(path, "captured then deleted\n").unwrap();
+        }
+
+        let mut runtime = Config::load_toml_with_diagnostics(&base_toml(""), "runtime").unwrap();
+        runtime.policy.rpol_files = vec![runtime_rpol.display().to_string()];
+        runtime.policy.import_chain = vec!["runtime-in".to_string()];
+        runtime.policy.datasets.insert(
+            "runtime-customers".to_string(),
+            crate::config::DatasetFileConfig {
+                path: runtime_dataset.display().to_string(),
+            },
+        );
+
+        let mut desired = Config::load_toml_with_diagnostics(&base_toml(""), "desired").unwrap();
+        desired.policy.rpol_files = vec![desired_rpol.display().to_string()];
+        desired.policy.import_chain = vec!["desired-in".to_string()];
+        desired.policy.datasets.insert(
+            "desired-customers".to_string(),
+            crate::config::DatasetFileConfig {
+                path: desired_dataset.display().to_string(),
+            },
+        );
+        let desired_handle = Arc::new(rustbgpd_policy::datasets::DatasetHandle::new(
+            "desired-customers",
+            rustbgpd_policy::datasets::DatasetKind::Asn,
+            rustbgpd_policy::datasets::DatasetData::Asn(rustbgpd_policy::sets::AsnSet::new([
+                64500,
+            ])),
+        ));
+        desired
+            .policy
+            .dataset_bindings
+            .insert(Arc::clone(&desired_handle));
+        let desired = AcceptedConfigSnapshot::from_config_for_test(desired);
+        let (_accepted_tx, accepted_rx) = watch::channel(desired);
+
+        let runtime_toml = crate::config::persisted_config_document(&runtime).unwrap();
+        let runtime_rpol_files = runtime.policy.rpol_files.clone();
+        for path in [runtime_rpol, runtime_dataset, desired_rpol, desired_dataset] {
+            std::fs::remove_file(path).unwrap();
+        }
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            for _ in 0..2 {
+                let Some(PeerManagerCommand::RuntimeConfigSnapshot { reply }) =
+                    peer_rx.recv().await
+                else {
+                    panic!("accepted snapshot helper must request the PM runtime TOML");
+                };
+                reply
+                    .send(Ok(rustbgpd_api::peer_types::RuntimeConfigSnapshotReply {
+                        toml: runtime_toml.clone(),
+                        rpol_files: runtime_rpol_files.clone(),
+                        rpol: rustbgpd_policy::rpol::RpolPolicySet::default(),
+                    }))
+                    .unwrap();
+            }
+        });
+        let controller = ConfigTransactionController::new_accepted(
+            deps_value(None, peer_tx, None, Vec::new()),
+            BgpMetrics::new(),
+            accepted_rx,
+        );
+
+        let gnmi_construction = controller.accepted_runtime_snapshot().await.unwrap();
+        let confirmed_rollback = controller.accepted_runtime_snapshot().await.unwrap();
+        for snapshot in [&gnmi_construction, &confirmed_rollback] {
+            assert_eq!(snapshot.policy.import_chain, ["runtime-in"]);
+            assert!(snapshot.policy.datasets.contains_key("runtime-customers"));
+            assert!(!snapshot.policy.datasets.contains_key("desired-customers"));
+            assert!(
+                snapshot
+                    .policy
+                    .dataset_bindings
+                    .get("runtime-customers")
+                    .is_none()
+            );
+            assert!(
+                snapshot
+                    .policy
+                    .dataset_bindings
+                    .get("desired-customers")
+                    .is_none()
+            );
+            assert!(snapshot.policy.rpol.policies.is_empty());
+        }
+        assert!(Arc::strong_count(&desired_handle) >= 1);
     }
 
     fn config_transaction_lifecycle_metric(

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,13 +79,14 @@ use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
 use crate::config::{
-    Config, GrpcAccessMode, GrpcEnforcementConfig, GrpcListener, GrpcMaxTier, GrpcRoleConfig,
-    UnpolicedEbgpBoundary,
+    AcceptedConfigSnapshot, Config, GrpcAccessMode, GrpcEnforcementConfig, GrpcListener,
+    GrpcMaxTier, GrpcRoleConfig, UnpolicedEbgpBoundary,
 };
 use crate::config_persister::{ConfigMutation, ConfigPersister};
 use crate::peer_manager::PeerManager;
 use crate::reload::{
-    apply_reload_outcome, reload_config_with_tcp_ao, run_config_bridge, runtime_config_snapshot,
+    apply_reload_outcome, reload_config_with_tcp_ao, run_config_bridge_accepted,
+    runtime_config_snapshot_accepted,
 };
 use rustbgpd_api::health_probe::DaemonGate;
 use rustbgpd_api::peer_types::{
@@ -2518,13 +2519,14 @@ fn main() -> ExitCode {
         process::exit(1);
     }
 
-    let mut config = match Config::load_with_diagnostics(&config_path) {
-        Ok(c) => c,
+    let mut accepted = match AcceptedConfigSnapshot::load(Path::new(&config_path), None) {
+        Ok(snapshot) => Arc::new(snapshot),
         Err(diagnostic) => {
             eprintln!("{diagnostic}");
             process::exit(1);
         }
     };
+    let mut config = accepted.config();
 
     if check_only {
         // The summary line is the only thing some operators read. When
@@ -2602,7 +2604,15 @@ fn main() -> ExitCode {
     ) {
         Ok(None) => None,
         Ok(Some(revert)) => {
-            config = *revert.config;
+            drop(revert.config);
+            accepted = match AcceptedConfigSnapshot::load(Path::new(&config_path), None) {
+                Ok(snapshot) => Arc::new(snapshot),
+                Err(diagnostic) => {
+                    eprintln!("{diagnostic}");
+                    process::exit(1);
+                }
+            };
+            config = accepted.config();
             Some(revert.notice)
         }
         Err(message) => {
@@ -2639,7 +2649,7 @@ fn main() -> ExitCode {
         .enable_all()
         .build()
         .unwrap_or_else(|e| fatal_startup_error("failed to create tokio runtime", e));
-    let grpc_server_failed = rt.block_on(run(config, boot_revert_notice, profiler));
+    let grpc_server_failed = rt.block_on(run(accepted, boot_revert_notice, profiler));
     shutdown_daemon_runtime(rt);
     if grpc_server_failed {
         // The coordinated teardown already ran (NOTIFICATIONs, GR marker,
@@ -2856,10 +2866,11 @@ fn resolve_rib_channel_capacity_from(env: Option<&str>) -> usize {
 /// unexpectedly (a component failure — the process must exit non-zero),
 /// `false` for operator-initiated shutdowns (signals, Shutdown RPC).
 async fn run<T>(
-    mut config: Config,
+    accepted: Arc<AcceptedConfigSnapshot>,
     boot_revert_notice: Option<confirm_journal::BootRevertNotice>,
     profiler: Option<T>,
 ) -> bool {
+    let mut config = accepted.config();
     // Snapshot the gRPC listener config as it was at process start.
     // The live TCP/UDS listeners bind once and are not rebuilt on
     // SIGHUP; this snapshot is what they're actually serving. Reload
@@ -3552,26 +3563,28 @@ async fn run<T>(
     // what's on disk. Otherwise the next gRPC mutation would apply
     // to a stale pre-reload snapshot and overwrite the persisted
     // file with `stale_pre_reload + one_mutation`.
-    let (config_event_tx, bridge_replace_tx) = if let Some(ref path) = config.file_path {
+    let (config_event_tx, bridge_replace_tx, accepted_rx) = if let Some(ref path) = config.file_path
+    {
         let (event_tx, event_rx) = mpsc::channel::<rustbgpd_api::peer_types::ConfigEvent>(64);
         let (mutation_tx, mutation_rx) = mpsc::channel::<ConfigMutation>(64);
-        let (bridge_replace_tx, bridge_replace_rx) = mpsc::unbounded_channel::<Box<Config>>();
-        let persister = ConfigPersister::new(
+        let (bridge_replace_tx, bridge_replace_rx) = mpsc::unbounded_channel();
+        let (accepted_tx, accepted_rx) = watch::channel(Arc::clone(&accepted));
+        let persister = ConfigPersister::new_accepted(
             mutation_rx,
             path.clone(),
-            config.clone(),
+            Arc::clone(&accepted),
             Some(config.runtime_state_dir()),
         );
         tokio::spawn(persister.run());
-        tokio::spawn(run_config_bridge(
+        tokio::spawn(run_config_bridge_accepted(
             event_rx,
             bridge_replace_rx,
             mutation_tx,
-            config.clone(),
+            accepted_tx,
         ));
-        (Some(event_tx), Some(bridge_replace_tx))
+        (Some(event_tx), Some(bridge_replace_tx), Some(accepted_rx))
     } else {
-        (None, None)
+        (None, None, None)
     };
 
     // Shutdown channels:
@@ -4282,7 +4295,7 @@ async fn run<T>(
     // accepted runtime changes.
     let runtime_config_lock = std::sync::Arc::new(tokio::sync::Mutex::new(()));
     let config_transaction_controller =
-        config_transaction_control::ConfigTransactionController::new(
+        config_transaction_control::ConfigTransactionController::new_accepted(
             fib_table_control::FibTableControlDeps {
                 fib_cmd_tx: fib_cmd_tx.clone(),
                 peer_mgr_tx: peer_mgr_tx.clone(),
@@ -4302,6 +4315,10 @@ async fn run<T>(
                 config_history_dir: Some(config_history::history_dir(&config.runtime_state_dir())),
             },
             metrics.clone(),
+            accepted_rx
+                .as_ref()
+                .expect("daemon config transactions require accepted-config authority")
+                .clone(),
         );
     // Process-wide availability gate (LAN-286): BGP-listener bind failure
     // turns readiness red; coordinated shutdown turns readiness red AND
@@ -4809,6 +4826,8 @@ async fn run<T>(
                 let reload_metrics = metrics.clone();
                 let tcp_ao_listener = tcp_ao_listener_handle.clone();
                 let limits_rib_tx = rib_tx.clone();
+                let accepted_rx = accepted_rx.clone();
+                let live_bindings = config.policy.dataset_bindings.clone();
                 reload_in_flight = Some(tokio::spawn(async move {
                     let _runtime_config_guard = runtime_config_lock.lock().await;
                     if let Err(error) = config_transaction_controller
@@ -4833,7 +4852,18 @@ async fn run<T>(
                             }
                         }
                     }
-                    let snapshot = match runtime_config_snapshot(&pm_tx).await {
+                    let Some(accepted_rx) = accepted_rx else {
+                        error!("SIGHUP reload has no accepted-config authority");
+                        return None;
+                    };
+                    let prior_accepted = accepted_rx.borrow().clone();
+                    let snapshot = match runtime_config_snapshot_accepted(
+                        &pm_tx,
+                        &prior_accepted,
+                        &live_bindings,
+                    )
+                    .await
+                    {
                         Ok(snapshot) => snapshot,
                         Err(error) => {
                             error!(
@@ -4852,15 +4882,25 @@ async fn run<T>(
                     // though the operator's file still holds it. A candidate
                     // that will not parse is left for the reload itself to
                     // report.
-                    if let Ok(candidate) = config::Config::load_with_diagnostics(&path)
-                        && let Err(error) =
-                            reload::apply_outbound_prefix_limits(&limits_rib_tx, &candidate).await
+                    let desired = match AcceptedConfigSnapshot::load_for_reload(
+                        Path::new(&path),
+                        &prior_accepted,
+                        &live_bindings,
+                    ) {
+                        Ok(snapshot) => Arc::new(snapshot),
+                        Err(diagnostic) => {
+                            error!("{diagnostic}");
+                            return None;
+                        }
+                    };
+                    if let Err(error) =
+                        reload::apply_outbound_prefix_limits(&limits_rib_tx, &desired).await
                     {
                         error!(error = %error, "SIGHUP reload rejected");
                         return None;
                     }
                     let reloaded = reload_config_with_tcp_ao(
-                        &path,
+                        desired,
                         &snapshot,
                         live_tcp.as_ref(),
                         live_uds.as_ref(),

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -8,13 +8,14 @@ use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::net::IpAddr;
 use std::ops::Deref;
+use std::sync::Arc;
 
 use rustbgpd_api::peer_types::{
     CatalogMutationError, ConfigEvent, ConfigPersistAck, ConfigPersistError, FibTableSnapshot,
     PeerManagerCommand, PeerManagerNeighborConfig,
 };
 use rustbgpd_policy::PolicyChain;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, watch};
 use tracing::{error, info, warn};
 
 use rustbgpd_transport::{
@@ -23,7 +24,7 @@ use rustbgpd_transport::{
     TcpAoRotationStatus,
 };
 
-use crate::config::{self, Config};
+use crate::config::{self, AcceptedConfigSnapshot, Config};
 use crate::config_persister::ConfigMutation;
 use crate::evpn_runtime_converger::EvpnRuntimeReloadApply;
 use crate::fib_runtime::FibRuntimeCommand;
@@ -594,11 +595,11 @@ fn copy_tcp_ao_runtime_fields(target: &mut Config, source: &Config) {
 #[derive(Clone)]
 pub(crate) struct ReloadedConfig {
     runtime: Config,
-    desired: Config,
+    desired: Arc<AcceptedConfigSnapshot>,
 }
 
 impl ReloadedConfig {
-    fn new(runtime: Config, desired: Config) -> Self {
+    fn new(runtime: Config, desired: Arc<AcceptedConfigSnapshot>) -> Self {
         Self { runtime, desired }
     }
 }
@@ -665,6 +666,7 @@ async fn send_catalog_pm_step(
 /// this helper, so any transaction that acquired the same lock first has
 /// already staged its accepted snapshot. That makes the returned config the
 /// correct live baseline for reload diffing.
+#[cfg(test)]
 pub(crate) async fn runtime_config_snapshot(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
 ) -> Result<Config, String> {
@@ -677,14 +679,49 @@ pub(crate) async fn runtime_config_snapshot(
         .await
         .map_err(|e| format!("peer manager dropped runtime snapshot reply: {e}"))??;
     let mut config = Config::load_toml_with_diagnostics(&snapshot.toml, "runtime config snapshot")?;
-    // Overlay the LIVE compiled `.rpol` registry (ADR-0096): loading
-    // the TOML recompiled the `.rpol` files from disk, which would
-    // mask exactly the disk edits a reload diff must detect (both
-    // sides would see the new content). The registry the daemon is
-    // actually running is the one the snapshot reply carries.
     config.policy.rpol_files = snapshot.rpol_files;
     config.policy.rpol = snapshot.rpol;
     Ok(config)
+}
+
+/// Reconstruct the SIGHUP runtime baseline without rereading external sources.
+pub(crate) async fn runtime_config_snapshot_accepted(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    accepted: &AcceptedConfigSnapshot,
+    live_bindings: &rustbgpd_policy::datasets::DatasetBindings,
+) -> Result<Config, String> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::RuntimeConfigSnapshot { reply: reply_tx })
+        .await
+        .map_err(|e| format!("send to peer manager failed: {e}"))?;
+    let snapshot = reply_rx
+        .await
+        .map_err(|e| format!("peer manager dropped runtime snapshot reply: {e}"))??;
+    accepted.runtime_config_without_sources(
+        &snapshot.toml,
+        &snapshot.rpol_files,
+        snapshot.rpol,
+        live_bindings,
+    )
+}
+
+/// Reconstruct the transaction-editing document without external-source reads
+/// or policy resolution. Unlike the SIGHUP baseline above, this value is only
+/// serialized or edited before the executor performs its normal validation.
+pub(crate) async fn transaction_config_snapshot_accepted(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    accepted: &AcceptedConfigSnapshot,
+) -> Result<Config, String> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::RuntimeConfigSnapshot { reply: reply_tx })
+        .await
+        .map_err(|e| format!("send to peer manager failed: {e}"))?;
+    let snapshot = reply_rx
+        .await
+        .map_err(|e| format!("peer manager dropped runtime snapshot reply: {e}"))??;
+    accepted.transaction_config_without_sources(&snapshot.toml, &snapshot.rpol_files)
 }
 
 fn fib_table_snapshots(tables: &[config::FibTableConfig]) -> Vec<FibTableSnapshot> {
@@ -777,7 +814,7 @@ async fn persister_round_trip(rx: oneshot::Receiver<Result<(), String>>) -> Resu
 /// the staged write — or drops it, discarding the stage.
 async fn persist_acknowledged(
     mutation_tx: &mpsc::Sender<ConfigMutation>,
-    candidate: Config,
+    candidate: Arc<AcceptedConfigSnapshot>,
     ack: ConfigPersistAck,
 ) -> AckedPersistOutcome {
     let ConfigPersistAck { staged, commit } = ack;
@@ -786,10 +823,7 @@ async fn persist_acknowledged(
         // asked for one durable write with one acknowledgement.
         let (persist_ack_tx, persist_ack_rx) = oneshot::channel();
         if mutation_tx
-            .send(ConfigMutation::ReplaceConfigAck(
-                Box::new(candidate),
-                persist_ack_tx,
-            ))
+            .send(ConfigMutation::ReplaceConfigAck(candidate, persist_ack_tx))
             .await
             .is_err()
         {
@@ -810,10 +844,7 @@ async fn persist_acknowledged(
 
     let (stage_ack_tx, stage_ack_rx) = oneshot::channel();
     if mutation_tx
-        .send(ConfigMutation::StageConfigAck(
-            Box::new(candidate),
-            stage_ack_tx,
-        ))
+        .send(ConfigMutation::StageConfigAck(candidate, stage_ack_tx))
         .await
         .is_err()
     {
@@ -882,13 +913,18 @@ async fn persist_acknowledged(
 /// task's tolerance) terminates the bridge — the persister task is
 /// dead, the daemon is shutting down, and there's nothing useful
 /// left to do here.
-pub(crate) async fn run_config_bridge(
+pub(crate) struct AcceptedBridgeReplacement {
+    snapshot: Arc<AcceptedConfigSnapshot>,
+    adopted: oneshot::Sender<()>,
+}
+
+pub(crate) async fn run_config_bridge_accepted(
     mut event_rx: mpsc::Receiver<rustbgpd_api::peer_types::ConfigEvent>,
-    mut bridge_replace_rx: mpsc::UnboundedReceiver<Box<Config>>,
+    mut bridge_replace_rx: mpsc::UnboundedReceiver<AcceptedBridgeReplacement>,
     mutation_tx: mpsc::Sender<ConfigMutation>,
-    initial: Config,
+    accepted_tx: watch::Sender<Arc<AcceptedConfigSnapshot>>,
 ) {
-    let mut current_config = initial;
+    let mut current = accepted_tx.borrow().clone();
     let mut event_rx_open = true;
     let mut bridge_replace_rx_open = true;
     loop {
@@ -900,17 +936,20 @@ pub(crate) async fn run_config_bridge(
             biased;
             replace = bridge_replace_rx.recv(), if bridge_replace_rx_open => {
                 match replace {
-                    Some(new_snapshot) => {
-                        current_config = *new_snapshot;
+                    Some(replacement) => {
+                        let new_snapshot = replacement.snapshot;
                         if mutation_tx
-                            .send(ConfigMutation::RefreshSnapshotNoPersist(Box::new(
-                                current_config.clone(),
+                            .send(ConfigMutation::RefreshSnapshotNoPersist(Arc::clone(
+                                &new_snapshot,
                             )))
                             .await
                             .is_err()
                         {
                             break;
                         }
+                        current = new_snapshot;
+                        accepted_tx.send_replace(Arc::clone(&current));
+                        let _ = replacement.adopted.send(());
                     }
                     None => bridge_replace_rx_open = false,
                 }
@@ -927,15 +966,17 @@ pub(crate) async fn run_config_bridge(
                             ..
                         } = &event
                         {
-                            Config::load_toml_with_diagnostics(
+                            current.derive_toml_without_sources(
                                 candidate_toml,
                                 "committed config transaction",
                             )
-                            .map_err(|error| CatalogMutationError::invalid(error.clone()))
+                            .map_err(CatalogMutationError::invalid)
                         } else {
-                            let mut candidate = current_config.clone();
+                            let mut candidate = current.config();
                             match apply_config_event(&mut candidate, &event) {
-                                Ok(()) => Ok(candidate),
+                                Ok(()) => current
+                                    .derive_config(candidate)
+                                    .map_err(CatalogMutationError::invalid),
                                 // Staging now runs before the caller's runtime
                                 // change, so this is where a bad request is
                                 // caught. Carry the same typed error the
@@ -957,20 +998,24 @@ pub(crate) async fn run_config_bridge(
                             }
                         };
                         if let Some(ack) = event_ack {
-                            match persist_acknowledged(&mutation_tx, candidate.clone(), ack).await {
-                                AckedPersistOutcome::Applied => current_config = candidate,
+                            match persist_acknowledged(&mutation_tx, Arc::clone(&candidate), ack).await {
+                                AckedPersistOutcome::Applied => {
+                                    current = candidate;
+                                    accepted_tx.send_replace(Arc::clone(&current));
+                                }
                                 AckedPersistOutcome::Rejected => {}
                                 AckedPersistOutcome::PersisterLost => break,
                             }
                         } else {
-                            current_config = candidate;
                             if mutation_tx
-                                .send(ConfigMutation::ReplaceConfig(Box::new(current_config.clone())))
+                                .send(ConfigMutation::ReplaceConfig(Arc::clone(&candidate)))
                                 .await
                                 .is_err()
                             {
                                 break;
                             }
+                            current = candidate;
+                            accepted_tx.send_replace(Arc::clone(&current));
                         }
                     }
                     None => event_rx_open = false,
@@ -978,6 +1023,36 @@ pub(crate) async fn run_config_bridge(
             }
         }
     }
+}
+
+#[cfg(test)]
+pub(crate) async fn run_config_bridge(
+    event_rx: mpsc::Receiver<rustbgpd_api::peer_types::ConfigEvent>,
+    bridge_replace_rx: mpsc::UnboundedReceiver<Box<Config>>,
+    mutation_tx: mpsc::Sender<ConfigMutation>,
+    initial: Config,
+) {
+    let initial = AcceptedConfigSnapshot::from_config_for_test(initial);
+    let (accepted_tx, _accepted_rx) = watch::channel(Arc::clone(&initial));
+    let (replace_tx, accepted_replace_rx) = mpsc::unbounded_channel();
+    tokio::spawn(async move {
+        let mut bridge_replace_rx = bridge_replace_rx;
+        while let Some(config) = bridge_replace_rx.recv().await {
+            let (adopted, _adopted_rx) = oneshot::channel();
+            if replace_tx
+                .send(AcceptedBridgeReplacement {
+                    snapshot: initial
+                        .derive_config(*config)
+                        .expect("test config serializes"),
+                    adopted,
+                })
+                .is_err()
+            {
+                break;
+            }
+        }
+    });
+    run_config_bridge_accepted(event_rx, accepted_replace_rx, mutation_tx, accepted_tx).await;
 }
 
 /// Forward a freshly reloaded config to the peer manager and the
@@ -1007,12 +1082,12 @@ pub(crate) async fn run_config_bridge(
 /// caller's — leaving it explicit at the call site keeps the SIGHUP
 /// retry semantics readable.
 ///
-/// Async only because the SIGHUP-arm caller awaits in the same
-/// position; both internal sends are unbounded and never block.
+/// This remains async because it waits for both the peer-manager snapshot
+/// assignment and the bridge's accepted-snapshot adoption acknowledgements.
 pub(crate) async fn apply_reload_outcome(
     reloaded: ReloadedConfig,
     peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
-    bridge_replace_tx: Option<&mpsc::UnboundedSender<Box<Config>>>,
+    bridge_replace_tx: Option<&mpsc::UnboundedSender<AcceptedBridgeReplacement>>,
 ) -> Result<Config, &'static str> {
     // Acknowledge the snapshot so the caller (holding the FIB coordinator lock)
     // doesn't release the lock until the peer manager has actually assigned
@@ -1032,10 +1107,18 @@ pub(crate) async fn apply_reload_outcome(
     if ack_rx.await.is_err() {
         return Err("peer_mgr_snapshot");
     }
-    if let Some(tx) = bridge_replace_tx
-        && tx.send(Box::new(reloaded.desired.clone())).is_err()
-    {
-        return Err("config_bridge");
+    if let Some(tx) = bridge_replace_tx {
+        let (adopted, adopted_rx) = oneshot::channel();
+        if tx
+            .send(AcceptedBridgeReplacement {
+                snapshot: Arc::clone(&reloaded.desired),
+                adopted,
+            })
+            .is_err()
+            || adopted_rx.await.is_err()
+        {
+            return Err("config_bridge");
+        }
     }
 
     // Per-peer `log_level` is a LIVE field (reload matrix): re-apply the
@@ -1161,8 +1244,17 @@ pub(crate) async fn reload_config(
     let config_path = std::path::Path::new(config_path);
     let source = std::fs::read_to_string(config_path).unwrap();
     write_tier_test_config(config_path, &source);
+    let prior = AcceptedConfigSnapshot::from_config_for_test(current.clone());
+    let desired = Arc::new(
+        AcceptedConfigSnapshot::load_for_reload(
+            config_path,
+            &prior,
+            &current.policy.dataset_bindings,
+        )
+        .ok()?,
+    );
     reload_config_with_tcp_ao(
-        config_path.to_str().unwrap(),
+        desired,
         current,
         live_grpc_tcp,
         live_grpc_uds,
@@ -1180,7 +1272,7 @@ pub(crate) async fn reload_config(
     reason = "reload threads live subsystem handles, ordered reconciliation, and failure aggregation through one transaction coordinator"
 )]
 pub(crate) async fn reload_config_with_tcp_ao(
-    config_path: &str,
+    desired_snapshot: Arc<AcceptedConfigSnapshot>,
     current: &Config,
     live_grpc_tcp: Option<&config::GrpcTcpListenerConfig>,
     live_grpc_uds: Option<&config::GrpcUdsListenerConfig>,
@@ -1194,16 +1286,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
     // Shared live handles are committed only after the complete no-side-effect
     // preflight below, so a rejected authentication-boundary reload cannot
     // leak new policy data into running chains.
-    let mut desired_config = match Config::load_with_diagnostics_and_staged_datasets(
-        config_path,
-        &current.policy.dataset_bindings,
-    ) {
-        Ok(c) => c,
-        Err(diagnostic) => {
-            error!("{diagnostic}");
-            return None;
-        }
-    };
+    let mut desired_config = desired_snapshot.config();
     let mut new_config = desired_config.clone();
 
     let honor_graceful_shutdown_changed =
@@ -1637,7 +1720,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
         } else {
             info!("config reloaded — no neighbor / policy / peer-group changes detected");
         }
-        return Some(ReloadedConfig::new(new_config, desired_config));
+        return Some(ReloadedConfig::new(new_config, desired_snapshot));
     }
 
     if explain_changed {
@@ -1736,7 +1819,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
         {
             return halt_partial(
                 working_config,
-                &desired_config,
+                &desired_snapshot,
                 ReloadStepFailure {
                     bucket: "policy.explain.sync",
                     target: "[policy.explain]".to_string(),
@@ -1796,7 +1879,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             Err(error) => {
                 return halt_partial(
                     working_config,
-                    &desired_config,
+                    &desired_snapshot,
                     ReloadStepFailure {
                         bucket: "policy.rpol.sync",
                         target: "[policy] rpol_files".to_string(),
@@ -1864,7 +1947,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
         else {
             return halt_partial(
                 working_config,
-                &desired_config,
+                &desired_snapshot,
                 ReloadStepFailure {
                     bucket,
                     target: name.clone(),
@@ -1891,7 +1974,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 if let Err(error) = apply_config_event(&mut working_config, &event) {
                     return halt_partial(
                         working_config,
-                        &desired_config,
+                        &desired_snapshot,
                         ReloadStepFailure {
                             bucket,
                             target: name.clone(),
@@ -1906,7 +1989,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             Err(error) => {
                 return halt_partial(
                     working_config,
-                    &desired_config,
+                    &desired_snapshot,
                     ReloadStepFailure {
                         bucket,
                         target: name.clone(),
@@ -1931,7 +2014,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
         let Some(definition) = policy_admin::named_policy_from_config(&new_config, name) else {
             return halt_partial(
                 working_config,
-                &desired_config,
+                &desired_snapshot,
                 ReloadStepFailure {
                     bucket,
                     target: name.clone(),
@@ -1958,7 +2041,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 if let Err(error) = apply_config_event(&mut working_config, &event) {
                     return halt_partial(
                         working_config,
-                        &desired_config,
+                        &desired_snapshot,
                         ReloadStepFailure {
                             bucket,
                             target: name.clone(),
@@ -1973,7 +2056,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             Err(error) => {
                 return halt_partial(
                     working_config,
-                    &desired_config,
+                    &desired_snapshot,
                     ReloadStepFailure {
                         bucket,
                         target: name.clone(),
@@ -1998,7 +2081,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
         let Some(definition) = policy_admin::named_peer_group_from_config(&new_config, name) else {
             return halt_partial(
                 working_config,
-                &desired_config,
+                &desired_snapshot,
                 ReloadStepFailure {
                     bucket,
                     target: name.clone(),
@@ -2025,7 +2108,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 if let Err(error) = apply_config_event(&mut working_config, &event) {
                     return halt_partial(
                         working_config,
-                        &desired_config,
+                        &desired_snapshot,
                         ReloadStepFailure {
                             bucket,
                             target: name.clone(),
@@ -2040,7 +2123,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             Err(error) => {
                 return halt_partial(
                     working_config,
-                    &desired_config,
+                    &desired_snapshot,
                     ReloadStepFailure {
                         bucket,
                         target: name.clone(),
@@ -2082,7 +2165,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 if let Err(error) = apply_config_event(&mut working_config, &event) {
                     return halt_partial(
                         working_config,
-                        &desired_config,
+                        &desired_snapshot,
                         ReloadStepFailure {
                             bucket: "global_chain.import",
                             target: String::new(),
@@ -2097,7 +2180,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             Err(error) => {
                 return halt_partial(
                     working_config,
-                    &desired_config,
+                    &desired_snapshot,
                     ReloadStepFailure {
                         bucket: "global_chain.import",
                         target: String::new(),
@@ -2136,7 +2219,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 if let Err(error) = apply_config_event(&mut working_config, &event) {
                     return halt_partial(
                         working_config,
-                        &desired_config,
+                        &desired_snapshot,
                         ReloadStepFailure {
                             bucket: "global_chain.export",
                             target: String::new(),
@@ -2151,7 +2234,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             Err(error) => {
                 return halt_partial(
                     working_config,
-                    &desired_config,
+                    &desired_snapshot,
                     ReloadStepFailure {
                         bucket: "global_chain.export",
                         target: String::new(),
@@ -2222,7 +2305,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             Err(e) => {
                 return halt_partial(
                     working_config,
-                    &desired_config,
+                    &desired_snapshot,
                     ReloadStepFailure {
                         bucket: "neighbors.resolve",
                         target: "new_config.resolved_neighbors".to_string(),
@@ -2284,7 +2367,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             {
                 return halt_partial(
                     working_config,
-                    &desired_config,
+                    &desired_snapshot,
                     ReloadStepFailure {
                         bucket: "neighbors.hot_update",
                         target: n.address.clone(),
@@ -2317,7 +2400,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             {
                 return halt_partial(
                     working_config,
-                    &desired_config,
+                    &desired_snapshot,
                     ReloadStepFailure {
                         bucket: "neighbors.reconcile",
                         target: String::new(),
@@ -2366,7 +2449,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                      reloading again. Earlier reload steps (policy / peer-group / chain \
                      edits) DID land at the manager and remain in effect."
                     );
-                    return Some(ReloadedConfig::new(working_config, desired_config));
+                    return Some(ReloadedConfig::new(working_config, desired_snapshot));
                 }
                 Err(e) => {
                     error!(
@@ -2377,7 +2460,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                          steps (policy / peer-group / chain edits) DID land at the manager \
                          and remain in effect."
                     );
-                    return Some(ReloadedConfig::new(working_config, desired_config));
+                    return Some(ReloadedConfig::new(working_config, desired_snapshot));
                 }
             }
         }
@@ -2476,7 +2559,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                                 working_config.fib_tables.clone_from(&new_config.fib_tables);
                                 return halt_partial(
                                     working_config,
-                                    &desired_config,
+                                    &desired_snapshot,
                                     ReloadStepFailure {
                                         bucket: "fib_tables.snapshot",
                                         target: "[[fib_tables]]".to_string(),
@@ -2552,7 +2635,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 if let Err(error) = apply_config_event(&mut working_config, &event) {
                     return halt_partial(
                         working_config,
-                        &desired_config,
+                        &desired_snapshot,
                         ReloadStepFailure {
                             bucket: "peer_group.delete",
                             target: name.clone(),
@@ -2567,7 +2650,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             Err(error) => {
                 return halt_partial(
                     working_config,
-                    &desired_config,
+                    &desired_snapshot,
                     ReloadStepFailure {
                         bucket: "peer_group.delete",
                         target: name.clone(),
@@ -2593,7 +2676,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 if let Err(error) = apply_config_event(&mut working_config, &event) {
                     return halt_partial(
                         working_config,
-                        &desired_config,
+                        &desired_snapshot,
                         ReloadStepFailure {
                             bucket: "policy.delete",
                             target: name.clone(),
@@ -2608,7 +2691,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             Err(error) => {
                 return halt_partial(
                     working_config,
-                    &desired_config,
+                    &desired_snapshot,
                     ReloadStepFailure {
                         bucket: "policy.delete",
                         target: name.clone(),
@@ -2634,7 +2717,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 if let Err(error) = apply_config_event(&mut working_config, &event) {
                     return halt_partial(
                         working_config,
-                        &desired_config,
+                        &desired_snapshot,
                         ReloadStepFailure {
                             bucket: "neighbor_set.delete",
                             target: name.clone(),
@@ -2649,7 +2732,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             Err(error) => {
                 return halt_partial(
                     working_config,
-                    &desired_config,
+                    &desired_snapshot,
                     ReloadStepFailure {
                         bucket: "neighbor_set.delete",
                         target: name.clone(),
@@ -2675,7 +2758,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
     // failure is surfaced rather than logged-and-forgotten.
 
     info!("config reload complete");
-    Some(ReloadedConfig::new(working_config, desired_config))
+    Some(ReloadedConfig::new(working_config, desired_snapshot))
 }
 
 /// Halt a SIGHUP reload at the first failed step. Logs the failure
@@ -2696,7 +2779,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
 )]
 fn halt_partial(
     working_config: Config,
-    desired_config: &Config,
+    desired_config: &Arc<AcceptedConfigSnapshot>,
     failure: ReloadStepFailure,
 ) -> Option<ReloadedConfig> {
     error!(
@@ -2705,7 +2788,10 @@ fn halt_partial(
         error = %failure.error,
         "config reload halted at this step — runtime state matches the in-memory snapshot returned by reload (partial). Re-edit TOML and reload again to converge."
     );
-    Some(ReloadedConfig::new(working_config, desired_config.clone()))
+    Some(ReloadedConfig::new(
+        working_config,
+        Arc::clone(desired_config),
+    ))
 }
 
 #[cfg(test)]
@@ -7189,7 +7275,7 @@ peer_group = "secure"
     async fn apply_reload_outcome_bridge_failure_after_peer_mgr_snapshot() {
         let (peer_mgr_internal_tx, mut peer_mgr_internal_rx) =
             mpsc::unbounded_channel::<InternalCommand>();
-        let (bridge_tx, bridge_rx) = mpsc::unbounded_channel::<Box<Config>>();
+        let (bridge_tx, bridge_rx) = mpsc::unbounded_channel::<AcceptedBridgeReplacement>();
         // Drop the bridge rx so the helper's send fails immediately
         // with a closed-channel error.
         drop(bridge_rx);
@@ -7215,7 +7301,10 @@ peer_group = "secure"
         });
 
         let result = apply_reload_outcome(
-            ReloadedConfig::new(cfg.clone(), cfg.clone()),
+            ReloadedConfig::new(
+                cfg.clone(),
+                AcceptedConfigSnapshot::from_config_for_test(cfg.clone()),
+            ),
             &peer_mgr_internal_tx,
             Some(&bridge_tx),
         )
@@ -7231,6 +7320,41 @@ peer_group = "secure"
             expected_asn,
             "peer manager must receive the snapshot before the bridge send is attempted"
         );
+    }
+
+    #[tokio::test]
+    async fn apply_reload_outcome_waits_for_bridge_adoption() {
+        let cfg = Config::load_toml_with_diagnostics(baseline_toml(), "adoption test").unwrap();
+        let desired = AcceptedConfigSnapshot::from_config_for_test(cfg.clone());
+        let (peer_tx, mut peer_rx) = mpsc::unbounded_channel::<InternalCommand>();
+        let (bridge_tx, mut bridge_rx) = mpsc::unbounded_channel::<AcceptedBridgeReplacement>();
+        let apply_peer_tx = peer_tx.clone();
+        let apply_bridge_tx = bridge_tx.clone();
+        let apply_desired = Arc::clone(&desired);
+        let apply = tokio::spawn(async move {
+            apply_reload_outcome(
+                ReloadedConfig::new(cfg, apply_desired),
+                &apply_peer_tx,
+                Some(&apply_bridge_tx),
+            )
+            .await
+        });
+
+        let Some(InternalCommand::ReplaceConfigSnapshot { ack: Some(ack), .. }) =
+            peer_rx.recv().await
+        else {
+            panic!("reload outcome must request peer-manager adoption");
+        };
+        ack.send(()).unwrap();
+        let replacement = bridge_rx.recv().await.unwrap();
+        assert!(Arc::ptr_eq(&replacement.snapshot, &desired));
+        tokio::task::yield_now().await;
+        assert!(
+            !apply.is_finished(),
+            "reload must retain its coordinator barrier until bridge adoption"
+        );
+        replacement.adopted.send(()).unwrap();
+        assert!(apply.await.unwrap().is_ok());
     }
 
     /// Bridge-disabled mode (no persister, so no bridge) must succeed: the
@@ -7258,7 +7382,10 @@ peer_group = "secure"
         });
 
         let advanced = apply_reload_outcome(
-            ReloadedConfig::new(cfg.clone(), cfg.clone()),
+            ReloadedConfig::new(
+                cfg.clone(),
+                AcceptedConfigSnapshot::from_config_for_test(cfg.clone()),
+            ),
             &peer_mgr_internal_tx,
             None,
         )
@@ -7307,13 +7434,27 @@ peer_group = "secure"
         );
 
         let (event_tx, event_rx) = mpsc::channel::<ConfigEvent>(8);
-        let (replace_tx, replace_rx) = mpsc::unbounded_channel::<Box<Config>>();
+        let (replace_tx, replace_rx) = mpsc::unbounded_channel::<AcceptedBridgeReplacement>();
         let (mutation_tx, mut mutation_rx) = mpsc::channel::<ConfigMutation>(8);
+        let initial = AcceptedConfigSnapshot::from_config_for_test(stale);
+        let (accepted_tx, _accepted_rx) = watch::channel(initial);
 
-        let bridge = tokio::spawn(run_config_bridge(event_rx, replace_rx, mutation_tx, stale));
+        let bridge = tokio::spawn(run_config_bridge_accepted(
+            event_rx,
+            replace_rx,
+            mutation_tx,
+            accepted_tx,
+        ));
 
         // Push the SIGHUP-style replacement first.
-        replace_tx.send(Box::new(reloaded.clone())).unwrap();
+        let (adopted, adopted_rx) = oneshot::channel();
+        replace_tx
+            .send(AcceptedBridgeReplacement {
+                snapshot: AcceptedConfigSnapshot::from_config_for_test(reloaded.clone()),
+                adopted,
+            })
+            .unwrap();
+        adopted_rx.await.unwrap();
         // Then a gRPC mutation that adds a policy definition. If the
         // bridge missed the swap, this would compute against `stale`
         // and the resulting ReplaceConfig wouldn't carry the new
@@ -7439,6 +7580,84 @@ peer_group = "secure"
         timeout(Duration::from_secs(1), bridge)
             .await
             .expect("bridge should exit after both inputs close")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn config_bridge_watch_publishes_only_the_successfully_persisted_arc() {
+        use rustbgpd_api::peer_types::{ConfigEvent, FibTableSnapshot};
+        use tokio::time::{Duration, timeout};
+
+        let path = unique_temp_path("bridge-accepted-watch");
+        std::fs::write(&path, baseline_toml()).unwrap();
+        let initial = Arc::new(AcceptedConfigSnapshot::load(&path, None).unwrap());
+        std::fs::remove_file(&path).ok();
+        let (event_tx, event_rx) = mpsc::channel(4);
+        let (replace_tx, replace_rx) = mpsc::unbounded_channel();
+        let (mutation_tx, mut mutation_rx) = mpsc::channel(4);
+        let (accepted_tx, mut accepted_rx) = watch::channel(Arc::clone(&initial));
+        let bridge = tokio::spawn(run_config_bridge_accepted(
+            event_rx,
+            replace_rx,
+            mutation_tx,
+            accepted_tx,
+        ));
+
+        let event = |name: &str, ack| ConfigEvent::FibTablesReplaced {
+            tables: vec![FibTableSnapshot {
+                name: name.to_string(),
+                table_id: 100,
+                metric: 200,
+                families: vec!["ipv4_unicast".to_string()],
+                allowed_peer_groups: Vec::new(),
+                allowed_neighbors: Vec::new(),
+                max_routes: None,
+                maximum_paths: None,
+                maximum_paths_ebgp: None,
+                maximum_paths_ibgp: None,
+            }],
+            ack: Some(ConfigPersistAck::immediate(ack)),
+        };
+
+        let (ack_tx, ack_rx) = oneshot::channel();
+        event_tx.send(event("accepted", ack_tx)).await.unwrap();
+        let ConfigMutation::ReplaceConfigAck(candidate, persist_ack) =
+            mutation_rx.recv().await.unwrap()
+        else {
+            panic!("acknowledged event must carry its accepted Arc");
+        };
+        assert!(Arc::ptr_eq(&accepted_rx.borrow(), &initial));
+        persist_ack.send(Ok(())).unwrap();
+        assert!(ack_rx.await.unwrap().is_ok());
+        timeout(Duration::from_secs(1), accepted_rx.changed())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(Arc::ptr_eq(&accepted_rx.borrow(), &candidate));
+
+        let (failed_ack_tx, failed_ack_rx) = oneshot::channel();
+        event_tx
+            .send(event("rejected", failed_ack_tx))
+            .await
+            .unwrap();
+        let ConfigMutation::ReplaceConfigAck(rejected, failed_persist_ack) =
+            mutation_rx.recv().await.unwrap()
+        else {
+            panic!("second acknowledged event must carry its accepted Arc");
+        };
+        assert!(!Arc::ptr_eq(&candidate, &rejected));
+        failed_persist_ack
+            .send(Err("injected".to_string()))
+            .unwrap();
+        assert!(failed_ack_rx.await.unwrap().is_err());
+        assert!(Arc::ptr_eq(&accepted_rx.borrow(), &candidate));
+        assert!(!accepted_rx.has_changed().unwrap());
+
+        drop(replace_tx);
+        drop(event_tx);
+        timeout(Duration::from_secs(1), bridge)
+            .await
+            .unwrap()
             .unwrap();
     }
 
@@ -7913,18 +8132,26 @@ remote_asn = 65002
         let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
         let live_grpc_tcp = initial.global.telemetry.grpc_tcp.clone();
         let live_grpc_uds = initial.global.telemetry.grpc_uds.clone();
+        let initial_accepted = AcceptedConfigSnapshot::from_config_for_test(initial.clone());
 
         let (event_tx, event_rx) = mpsc::channel::<ConfigEvent>(8);
-        let (replace_tx, replace_rx) = mpsc::unbounded_channel::<Box<Config>>();
+        let (replace_tx, replace_rx) = mpsc::unbounded_channel::<AcceptedBridgeReplacement>();
         let (mutation_tx, mutation_rx) = mpsc::channel::<ConfigMutation>(8);
         let persister = tokio::spawn(
-            ConfigPersister::new(mutation_rx, path.clone(), initial.clone(), None).run(),
+            ConfigPersister::new_accepted(
+                mutation_rx,
+                path.clone(),
+                Arc::clone(&initial_accepted),
+                None,
+            )
+            .run(),
         );
-        let bridge = tokio::spawn(run_config_bridge(
+        let (accepted_tx, _accepted_rx) = watch::channel(initial_accepted);
+        let bridge = tokio::spawn(run_config_bridge_accepted(
             event_rx,
             replace_rx,
             mutation_tx,
-            initial.clone(),
+            accepted_tx,
         ));
 
         std::fs::write(&path, new_toml).unwrap();


### PR DESCRIPTION
## Summary

- carry one accepted config snapshot, normalized TOML document, and captured external-source identity through boot, SIGHUP, bridge adoption, and persistence
- keep partially applied runtime state distinct from accepted desired state so a later SIGHUP can retry convergence
- reconstruct gNMI and confirmed-rollback transaction documents without rereading or attaching external policy data
- wait for both peer-manager and config-bridge adoption before releasing the runtime-config coordinator

## Safety

- public config events, v1 history storage/listing/rollback, journals, and acknowledgement behavior are unchanged
- legacy source-rereading helpers and constructors are test-only
- accepted external-source inventory cannot be relabeled by a source-free runtime mutation

## Load-bearing proofs

Each guarded break was applied locally and made its focused proof fail before restoration:

- restoring desired/runtime roster equality breaks partial-reload retry
- removing the bridge adoption wait releases the coordinator early
- restoring the external-aware runtime loader rereads deleted source files
- restoring a controller caller to the legacy loader fails the production build fence
- removing the accepted external-roster guard permits source inventory relabeling
- attaching accepted desired bindings to a split runtime fails transaction reconstruction during policy validation

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked`
- `git diff --check`