### PR TITLE
tests: require terminal BGP health in M33 soak

### DIFF
--- a/docs/soaks/soak-acceptance-gates.md
+++ b/docs/soaks/soak-acceptance-gates.md
@@ -141,8 +141,9 @@ values; window floors follow the same 0.9× rule as above.
 50 k EVPN Type 2 routes + continuous tester churn. Gates: RSS slope
 < 1.0 MB/h fail / < 0.5 clean; peak RSS < 512 MB; session-flap delta
 == 0 (flap/drop counters in `samples.csv`); outbound route-drop delta
-== 0; zero gRPC health failures; healthy at end; restart detection via
-counter monotonicity (`bgp_messages_sent_total`). Abort: two
+== 0; zero gRPC health failures; exactly three valid peer-session gauges
+and all Established in the final sample; restart detection via counter
+monotonicity (`bgp_messages_sent_total`). Abort: two
 consecutive gRPC health-check failures.
 
 ### 5. M37 local-origination MAC churn — `run-m37-local-origination-churn-soak.sh`

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -94,7 +94,7 @@ Each run creates `tests/soak/runs/<UTC-timestamp>/` containing:
 
 | File | Content |
 |------|---------|
-| `samples.csv` | One row per sample interval (timestamp, uptime, RSS, CPU, gRPC health, EVPN RIB sizes, flap/drop/message counters) |
+| `samples.csv` | One row per sample interval (timestamp, uptime, RSS, CPU, gRPC health, three-session BGP health, EVPN RIB sizes, flap/drop/message counters) |
 | `soak.log` | Mirrored stdout/stderr from the runner |
 | `monitor.json` | Final report from the synthetic observer peer |
 | `monitor.log` | Tracing logs from the observer peer |
@@ -113,7 +113,8 @@ The runner exits non-zero if the analyzer fails any gate.
 | Session flap delta | `== 0` |
 | Outbound route drop delta | `== 0` |
 | gRPC health failures | `0` across all samples |
-| Daemon unhealthy at end (last 3 samples) | false |
+| BGP sessions established at end | Final sample is `1` only when exactly three valid peer gauges are present and all are established |
+| Daemon unavailable in all final 3 samples (gRPC failed or RSS missing) | false |
 | Process restart detected (counter monotonicity) | false |
 
 Verdicts: `clean` (slope < 0.5 MB/h and all gates pass), `pass` (gates pass

--- a/tests/soak/analyze-soak.py
+++ b/tests/soak/analyze-soak.py
@@ -13,6 +13,7 @@ Gates (defaults, all CLI-overridable):
   - session flap delta                    == 0
   - outbound route drop delta             == 0
   - gRPC health failures                  == 0
+  - all three BGP sessions established in final sample
   - daemon unhealthy in final 3 samples   false
   - process restart detected              false (counter monotonicity)
 
@@ -164,6 +165,7 @@ def main() -> int:
         "uptime_sec",
         "mem_mb",
         "grpc_ok",
+        "bgp_sessions_established",
         "session_flaps_total",
         "outbound_drops_total",
         "msgs_sent_total",
@@ -228,6 +230,17 @@ def main() -> int:
     # gRPC health rollup.
     grpc_failures = sum(1 for r in rows if r.get("grpc_ok") == "0")
 
+    terminal_sessions = rows[-1].get("bgp_sessions_established")
+    terminal_sessions_healthy = terminal_sessions == "1"
+    if terminal_sessions_healthy:
+        terminal_sessions_reason = "all 3 BGP sessions established"
+    elif terminal_sessions == "0":
+        terminal_sessions_reason = "one or more of 3 BGP sessions not established"
+    else:
+        terminal_sessions_reason = (
+            f"terminal BGP session evidence unavailable or invalid: {terminal_sessions!r}"
+        )
+
     # Daemon unhealthy at end: last 3 samples with grpc_ok==0 OR mem_mb==NaN.
     tail = rows[-3:]
     daemon_unhealthy_at_end = len(tail) >= 1 and all(
@@ -255,6 +268,8 @@ def main() -> int:
         fails.append(f"{drop_delta} outbound route drop(s) during soak")
     if grpc_failures > 0:
         fails.append(f"gRPC health failed on {grpc_failures}/{total_samples} samples")
+    if not terminal_sessions_healthy:
+        fails.append(terminal_sessions_reason)
     if daemon_unhealthy_at_end:
         fails.append("daemon unhealthy in final 3 samples (likely crashed)")
     if restart_detected:
@@ -271,6 +286,7 @@ def main() -> int:
         and flap_delta == 0
         and drop_delta == 0
         and grpc_failures == 0
+        and terminal_sessions_healthy
         and not daemon_unhealthy_at_end
         and not restart_detected
     ):
@@ -324,6 +340,11 @@ def main() -> int:
             "recv_delta": msgs_recv_last - msgs_recv_first,
         },
         "grpc_health_failures": grpc_failures,
+        "terminal_session_health": {
+            "healthy": terminal_sessions_healthy,
+            "value": terminal_sessions,
+            "reason": terminal_sessions_reason,
+        },
         "daemon_unhealthy_at_end": daemon_unhealthy_at_end,
         "restart_detected": restart_detected,
         "thresholds": {

--- a/tests/soak/run-m33-soak.sh
+++ b/tests/soak/run-m33-soak.sh
@@ -156,14 +156,14 @@ parse_mem_to_mb() {
 # ---------------------------------------------------------------------------
 # Prometheus metric extraction — one curl + awk per sample.
 # Returns a single space-delimited line:
-#   rib_loc_evpn  adj_out_evpn_total  flaps_total  drops_total  msgs_sent  msgs_recv
+#   rib_loc_evpn  adj_out_evpn_total  flaps_total  drops_total  msgs_sent  msgs_recv  sessions_ok
 # Any field that fails to parse yields "NaN" (gauges) or "0" (counters).
 # ---------------------------------------------------------------------------
 
 sample_metrics() {
     local body
     body=$(curl -s --max-time 5 "http://${RR_IP}:9179/metrics" 2>/dev/null) || {
-        echo "NaN NaN NaN NaN NaN NaN"
+        echo "NaN NaN NaN NaN NaN NaN NaN"
         return
     }
     awk '
@@ -173,14 +173,23 @@ sample_metrics() {
         /^bgp_outbound_route_drops_total\{/                                 { drops   += $2 }
         /^bgp_messages_sent_total\{/                                        { sent    += $2 }
         /^bgp_messages_received_total\{/                                    { recv    += $2 }
+        /^bgp_peer_session_established\{/ {
+            sessions++
+            if ($2 !~ /^([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?$/ \
+                    || ($2 + 0) < 0 || ($2 + 0) > 1 \
+                    || ($2 + 0) != int($2 + 0)) sessions_invalid=1
+            established += $2
+        }
         END {
-            printf "%s %s %s %s %s %s\n",
+            sessions_ok = (sessions != 3 || sessions_invalid) ? "NaN" \
+                : (established == 3 ? "1" : "0")
+            printf "%s %s %s %s %s %s %s\n",
                 (rib_loc==""?"NaN":rib_loc),
                 (adj_out==""?"NaN":adj_out),
                 (flaps==""?0:flaps),
                 (drops==""?0:drops),
                 (sent==""?0:sent),
-                (recv==""?0:recv)
+                (recv==""?0:recv), sessions_ok
         }
     ' <<<"$body"
 }
@@ -295,7 +304,7 @@ done
 log "[stage 4] starting sampler — ${SAMPLE_INTERVAL}s cadence"
 
 # Header on first write.
-echo "timestamp,uptime_sec,mem_mb,cpu_pct,grpc_ok,rib_loc_evpn,adj_out_evpn_total,session_flaps_total,outbound_drops_total,msgs_sent_total,msgs_recv_total" > "$CSV"
+echo "timestamp,uptime_sec,mem_mb,cpu_pct,grpc_ok,rib_loc_evpn,adj_out_evpn_total,session_flaps_total,outbound_drops_total,msgs_sent_total,msgs_recv_total,bgp_sessions_established" > "$CSV"
 
 SOAK_START=$(date +%s)
 SAMPLER_RUN_FLAG="$RUN_DIR/.sampler-running"
@@ -333,12 +342,13 @@ touch "$SAMPLER_RUN_FLAG"
             grpc_ok=1
         fi
 
-        read -r rib_loc adj_out flaps drops sent recv <<<"$(sample_metrics)"
+        read -r rib_loc adj_out flaps drops sent recv sessions_ok <<<"$(sample_metrics)"
 
-        printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+        printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
             "$ts" "$uptime" "${mem_mb:-NaN}" "${cpu_pct:-NaN}" "$grpc_ok" \
             "${rib_loc:-NaN}" "${adj_out:-NaN}" \
             "${flaps:-0}" "${drops:-0}" "${sent:-0}" "${recv:-0}" \
+            "${sessions_ok:-NaN}" \
             >> "$CSV"
 
         sleep "$SAMPLE_INTERVAL"

--- a/tests/soak/test_analyze_soak.py
+++ b/tests/soak/test_analyze_soak.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Load-bearing terminal-health contracts for the M33 soak analyzer."""
+
+import csv
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+HERE = Path(__file__).parent
+FIELDS = [
+    "uptime_sec", "mem_mb", "grpc_ok", "session_flaps_total",
+    "outbound_drops_total", "msgs_sent_total", "msgs_recv_total",
+    "bgp_sessions_established",
+]
+
+
+def run_analyzer(states, *, terminal=None, omit_header=False):
+    rows = []
+    for index, state in enumerate(states):
+        rows.append({
+            "uptime_sec": str(index * 3600), "mem_mb": "10",
+            "grpc_ok": "1", "session_flaps_total": "0",
+            "outbound_drops_total": "0", "msgs_sent_total": str(index + 1),
+            "msgs_recv_total": str(index + 1),
+            "bgp_sessions_established": state,
+        })
+    if terminal is not None:
+        rows[-1]["bgp_sessions_established"] = terminal
+    fields = [f for f in FIELDS if not (omit_header and f == "bgp_sessions_established")]
+    with tempfile.TemporaryDirectory() as tmp:
+        samples = Path(tmp) / "samples.csv"
+        with samples.open("w", newline="") as stream:
+            writer = csv.DictWriter(stream, fieldnames=fields, extrasaction="ignore")
+            writer.writeheader()
+            writer.writerows(rows)
+        result = subprocess.run(
+            ["python3", str(HERE / "analyze-soak.py"), str(samples),
+             "--warmup-sec", "0"],
+            text=True, capture_output=True, check=False,
+        )
+    payload = json.loads(result.stdout) if result.stdout else None
+    return result, payload
+
+
+def run_runner_session_classifier(values):
+    runner = (HERE / "run-m33-soak.sh").read_text()
+    marker = "    awk '\n"
+    start = runner.index(marker) + len(marker)
+    end = runner.index("\n    ' <<<\"$body\"", start)
+    metrics = "\n".join(
+        f'bgp_peer_session_established{{interface="",peer="192.0.2.{index}"}} {value}'
+        for index, value in enumerate(values, 1)
+    )
+    result = subprocess.run(
+        ["awk", runner[start:end]],
+        input=metrics,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout.split()[-1]
+
+
+class M33AnalyzerContracts(unittest.TestCase):
+    # Destructive proof: replacing final-row equality with a tail-any predicate
+    # makes terminal_down, NaN, blank, and malformed evidence return zero.
+    def test_terminal_sample_alone_declares_session_health(self):
+        cases = (
+            ("recovered", ["0", "1", "1"], 0),
+            ("terminal_down", ["1", "1", "0"], 1),
+            ("missing_evidence", ["1", "1", "NaN"], 1),
+            ("blank_evidence", ["1", "1", ""], 1),
+            ("malformed_evidence", ["1", "1", "wat"], 1),
+        )
+        for name, states, expected in cases:
+            with self.subTest(name=name):
+                result, payload = run_analyzer(states)
+                self.assertEqual(result.returncode, expected, result.stderr)
+                health = payload["terminal_session_health"]
+                self.assertEqual(health["healthy"], expected == 0)
+                self.assertTrue(health["reason"])
+
+    def test_missing_session_health_header_is_input_error(self):
+        result, _ = run_analyzer(["1", "1", "1"], omit_header=True)
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("bgp_sessions_established", result.stderr)
+
+    # Destructive proof: changing the production series cardinality, binary
+    # validation, or all-established comparison breaks at least one case.
+    def test_runner_classifies_exact_three_binary_session_gauges(self):
+        cases = (
+            ("all_up", ["1", "1", "1"], "1"),
+            ("one_down", ["1", "0", "1"], "0"),
+            ("missing", ["1", "1"], "NaN"),
+            ("extra", ["1", "1", "1", "1"], "NaN"),
+            ("malformed", ["1", "wat", "1"], "NaN"),
+            ("non_binary", ["1", "2", "1"], "NaN"),
+            ("non_finite", ["1", "+Inf", "1"], "NaN"),
+        )
+        for name, values, expected in cases:
+            with self.subTest(name=name):
+                self.assertEqual(run_runner_session_classifier(values), expected)
+
+    # Destructive proof: removing the scrape, header, sampler assignment, or
+    # analyzer requirement breaks one of these independent bindings.
+    def test_runner_and_analyzer_bind_terminal_session_evidence(self):
+        runner = (HERE / "run-m33-soak.sh").read_text()
+        analyzer = (HERE / "analyze-soak.py").read_text()
+        self.assertIn('/^bgp_peer_session_established\\{/', runner)
+        self.assertIn("sessions != 3", runner)
+        self.assertIn("bgp_sessions_established\" > \"$CSV\"", runner)
+        self.assertIn("read -r rib_loc adj_out flaps drops sent recv sessions_ok", runner)
+        self.assertIn('"bgp_sessions_established",', analyzer)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- record current BGP session health in every M33 soak sample
- fail closed unless the terminal sample proves exactly three valid peer-session gauges are all Established
- execute both the production AWK classifier and analyzer against recovered, terminal-down, missing, extra, malformed, non-binary, and non-finite evidence
- align the M33 runner and acceptance-gate documentation

## Root cause

The original report blamed the three-sample daemon-health tail, but any gRPC failure already fails the analyzer. The actual blind spot was that M33 recorded no current BGP session state, so all three sessions could be down while gRPC remained healthy and the analyzer still passed.

## Validation

- python3 -m unittest discover -s tests/soak -p 'test_*.py' (22 tests)
- python3 -m py_compile tests/soak/analyze-soak.py tests/soak/test_analyze_soak.py
- bash -n tests/soak/run-m33-soak.sh
- shellcheck --severity=error tests/soak/run-m33-soak.sh
- cargo fmt --all -- --check
- git diff --check
- pre-commit and pre-push repository hooks

## Load-bearing proofs

Replacing terminal equality with the prior tail-any shape makes the terminal-down, missing, blank, and malformed cases fail their test because the analyzer incorrectly exits zero. Relaxing the production classifier's exact-three cardinality makes the extra-series case fail. Removing the runner scrape/header/row plumbing or analyzer-required column also makes the structural binding test fail.