### PR TITLE
Stop polling a closed peer-manager private lane

### DIFF
--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -293,7 +293,7 @@ pub struct PeerManager {
     /// commands remain on `rx` and therefore stay ordered behind a policy
     /// transaction until it either commits or rolls back.
     readiness_rx: Option<mpsc::Receiver<PeerManagerReadinessQuery>>,
-    internal_rx: mpsc::UnboundedReceiver<InternalCommand>,
+    internal_rx: Option<mpsc::UnboundedReceiver<InternalCommand>>,
     local_asn: u32,
     router_id: Ipv4Addr,
     /// Local cluster ID for route reflection (RFC 4456). `None` when not an RR.
@@ -557,6 +557,20 @@ impl PeerManager {
         }
     }
 
+    async fn receive_internal_command(
+        internal_rx: &mut Option<mpsc::UnboundedReceiver<InternalCommand>>,
+    ) -> Option<InternalCommand> {
+        let command = match internal_rx.as_mut() {
+            Some(rx) => rx.recv().await,
+            None => std::future::pending().await,
+        };
+        if command.is_none() {
+            *internal_rx = None;
+            debug!("peer manager internal command channel closed");
+        }
+        command
+    }
+
     #[expect(
         clippy::too_many_arguments,
         reason = "configured peer construction keeps all explicit lifecycle dependencies visible"
@@ -598,7 +612,7 @@ impl PeerManager {
             session_index: HashMap::new(),
             rx,
             readiness_rx: None,
-            internal_rx,
+            internal_rx: Some(internal_rx),
             local_asn,
             router_id,
             cluster_id,
@@ -1511,7 +1525,7 @@ impl PeerManager {
                         }
                     }
                 }
-                internal = self.internal_rx.recv() => {
+                internal = Self::receive_internal_command(&mut self.internal_rx) => {
                     match internal {
                         Some(InternalCommand::ReplaceConfigSnapshot { config, ack }) => {
                             self.current_config = *config;

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -153,6 +153,68 @@ fn test_peer_manager() -> PeerManager {
     )
 }
 
+#[tokio::test]
+async fn closed_internal_command_lane_disables_after_first_poll() {
+    // Load-bearing: removing the close-to-disabled transition leaves the
+    // receiver present and makes every later receive immediately ready.
+    let (internal_tx, internal_rx) = mpsc::unbounded_channel();
+    drop(internal_tx);
+    let mut internal_rx = Some(internal_rx);
+
+    assert!(
+        PeerManager::receive_internal_command(&mut internal_rx)
+            .await
+            .is_none()
+    );
+    assert!(internal_rx.is_none());
+
+    let mut second = Box::pin(PeerManager::receive_internal_command(&mut internal_rx));
+    assert!(matches!(
+        futures::poll!(second.as_mut()),
+        std::task::Poll::Pending
+    ));
+}
+
+#[tokio::test]
+async fn closed_internal_command_lane_keeps_public_actor_live() {
+    // Load-bearing: treating private-lane closure as actor shutdown makes the
+    // initial poll Ready and prevents the bounded public command round-trip.
+    let (tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let manager = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    let mut actor = Box::pin(manager.run());
+    assert!(matches!(
+        futures::poll!(actor.as_mut()),
+        std::task::Poll::Pending
+    ));
+    let handle = tokio::spawn(actor);
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::ListDynamicRanges { reply: reply_tx })
+        .await
+        .unwrap();
+    let ranges = tokio::time::timeout(Duration::from_secs(1), reply_rx)
+        .await
+        .expect("public command stalled after the private lane closed")
+        .unwrap();
+    assert!(ranges.is_empty());
+
+    tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(1), handle)
+        .await
+        .expect("peer manager did not shut down")
+        .unwrap();
+}
+
 fn blocked_snapshot_query_handle(
     peer: IpAddr,
     release: oneshot::Receiver<()>,


### PR DESCRIPTION
## Summary

- disable only the peer manager private-command receive arm after its sender closes
- park the disabled arm instead of busy-spinning or terminating the actor
- prove public commands and explicit shutdown remain live after private-lane closure

## Validation

- peer-manager serial suite: 342/342
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps
- destructive proof: removing the disable transition fails the closed-lane state assertion immediately
- destructive proof: returning the actor on private-lane closure fails the actor-liveness assertion immediately

This restores an internal actor-liveness invariant; no public API, configuration, or documented behavior changes.