### PR TITLE
Tolerate terminal races in rrtransport RSS sampling

### DIFF
--- a/bench/scale/rrtransport/run-receipt.sh
+++ b/bench/scale/rrtransport/run-receipt.sh
@@ -30,27 +30,62 @@ classify_rss() {
   fi
 }
 
-observe_direct_rss() {
-  local status_file=$1 status state rss
+read_direct_rss_observation() {
+  local process=$1 status
+  direct_start_before=absent
+  direct_state=absent
+  direct_rss=absent
+  direct_start_after=absent
+  if child_identity "$process"; then direct_start_before=$identity_starttime; fi
+  status=$(command cat -- "/proc/$process/status" 2>/dev/null || true)
+  direct_state=$(awk '$1=="State:" {print substr($2,1,1)}' <<<"$status")
+  [[ -n $direct_state ]] || direct_state=absent
+  direct_rss=$(awk '/VmRSS:/ {print $2}' <<<"$status")
+  [[ $direct_rss =~ ^[0-9]+$ ]] || direct_rss=absent
+  if child_identity "$process"; then direct_start_after=$identity_starttime; fi
+}
+
+read_scripted_direct_rss_observation() {
+  local _process=$1 snapshot
+  snapshot=${scripted_direct_observations[$scripted_direct_index]}
+  (( scripted_direct_index += 1 ))
+  IFS=, read -r direct_start_before direct_state direct_rss direct_start_after <<<"$snapshot"
+}
+
+resolve_direct_rss() {
+  local process=$1 expected_start=$2 attempt
   direct_rss_action=reject
   direct_rss_kib=0
-  if ! status=$(command cat -- "$status_file" 2>/dev/null); then
-    direct_rss_action=exited
-    return
-  fi
-  state=$(awk '$1=="State:" {print substr($2,1,1)}' <<<"$status")
-  rss=$(awk '/VmRSS:/ {print $2}' <<<"$status")
-  if [[ $state == X || $state == Z ]]; then
-    direct_rss_action=exited
-  elif [[ -n $state && $rss =~ ^[0-9]+$ ]]; then
-    direct_rss_action=sample
-    direct_rss_kib=$rss
-  fi
+  for attempt in 1 2 3; do
+    "$direct_rss_observation_reader" "$process"
+    if [[ $direct_start_before == absent && $direct_start_after == absent ]]; then
+      direct_rss_action=exited
+      return
+    fi
+    if [[ $direct_start_before == "$expected_start" && $direct_start_after == absent ]]; then
+      direct_rss_action=exited
+      return
+    fi
+    if [[ $direct_start_before != "$expected_start" ||
+      $direct_start_after != "$expected_start" ]]; then
+      return
+    fi
+    if [[ $direct_state == X || $direct_state == Z ]]; then
+      direct_rss_action=exited
+      return
+    fi
+    if [[ $direct_rss =~ ^[0-9]+$ ]]; then
+      direct_rss_action=sample
+      direct_rss_kib=$direct_rss
+      return
+    fi
+    (( attempt < 3 )) && sleep 0.01
+  done
 }
 
 sample_direct_rss() {
-  local status_file=$1 output=$2
-  observe_direct_rss "$status_file"
+  local process=$1 expected_start=$2 output=$3
+  resolve_direct_rss "$process" "$expected_start"
   case $direct_rss_action in
     exited) ;;
     sample)
@@ -280,6 +315,7 @@ validate_tiny_gate_identity() {
     $start_before == "$start_after" && $pgrp_before == "$supervisor" &&
     $pgrp_after == "$supervisor" ]] || return 1
   tiny_validated_rss=$rss
+  tiny_validated_starttime=$start_after
 }
 
 await_tiny_startup_gate() {
@@ -577,7 +613,7 @@ stop_reap_fixture() {
 
 check_seam() {
   local script=$1 outer verify_call verify_body checksums_call checksums_body
-  local direct_rss_call direct_rss_exit
+  local direct_rss_call direct_rss_exit direct_rss_resolver
   outer="timeout -k 10 1200 \"\$scr"
   outer+="ipt\" --campaign-inner \"\$output\""
   verify_call="full_ver"
@@ -588,12 +624,15 @@ check_seam() {
   checksums_call+="sums \"\$receipt\""
   checksums_body="sha256sum -c SHA"
   checksums_body+="256SUMS --strict"
-  direct_rss_call="sample_direct_rss \"/proc/\$pid/status\" \"\$receipt\""
+  direct_rss_call="sample_direct_rss \"\$pid\" \"\$tiny_validated_starttime\" \"\$receipt\""
   direct_rss_exit="[[ \$direct_rss_action != exited ]] || break"
+  direct_rss_resolver='resolve_direct_'
+  direct_rss_resolver+="rss \"\$process\" \"\$expected_start\""
   if ! grep -Fq "$outer" "$script" || ! grep -Fq "$verify_call" "$script" ||
     ! grep -Fq "$verify_body" "$script" || ! grep -Fq "$checksums_call" "$script" ||
     ! grep -Fq "$checksums_body" "$script" || ! grep -Fq "$direct_rss_call" "$script" ||
-    ! grep -Fq "$direct_rss_exit" "$script"; then
+    ! grep -Fq "$direct_rss_exit" "$script" ||
+    ! grep -Fq "$direct_rss_resolver" "$script"; then
     echo "runner lacks production verifier/checksum/RSS seam" >&2
     return 1
   fi
@@ -691,21 +730,18 @@ case ${1:-} in
     classify_child_exe "$2" "$3" "$4"
     exit
     ;;
-  --observe-direct-rss)
-    [[ $# == 2 ]] || exit 2
-    observe_direct_rss "$2"
-    printf '%s\t%s\n' "$direct_rss_action" "$direct_rss_kib"
-    exit
-    ;;
-  --sample-direct-rss-fixture)
-    [[ $# == 3 ]] || exit 2
-    receipt=$3
+  --sample-direct-rss-observations)
+    (( $# >= 4 )) || exit 2
+    receipt=$2; sample_status=0
     mkdir -p "$receipt"
     printf 'checkpoint\trss_kib\n' >"$receipt/rss.tsv"
     max_rss=0
-    sample_direct_rss "$2" "$receipt"
+    scripted_direct_observations=("${@:4}")
+    scripted_direct_index=0
+    direct_rss_observation_reader=read_scripted_direct_rss_observation
+    sample_direct_rss 4242 "$3" "$receipt" || sample_status=$?
     printf '%s\t%s\t%s\n' "$direct_rss_action" "$direct_rss_kib" "$max_rss"
-    exit
+    exit "$sample_status"
     ;;
   --resolve-child-observations)
     (( $# >= 4 )) || exit 2
@@ -766,8 +802,9 @@ case ${1:-} in
       report_tiny_startup_failure "$receipt" || true
       exit 1
     fi
+    direct_rss_observation_reader=read_direct_rss_observation
     while kill -0 "$pid" 2>/dev/null; do
-      sample_direct_rss "/proc/$pid/status" "$receipt" || exit 1
+      sample_direct_rss "$pid" "$tiny_validated_starttime" "$receipt" || exit 1
       [[ $direct_rss_action != exited ]] || break
       sleep 0.05
     done

--- a/bench/tests/test-rrtransport-receipt.sh
+++ b/bench/tests/test-rrtransport-receipt.sh
@@ -206,33 +206,47 @@ expect_red changed-hash mutate -c 'import pathlib,sys;(pathlib.Path(sys.argv[1])
 [[ $("$runner" --classify-child-exe /expected /expected Z) == exited ]]
 [[ $("$runner" --classify-child-exe /expected /expected absent) == retry_expected_absent ]]
 
-printf 'Name:\trrtiny\nState:\tR (running)\nVmRSS:\t1234 kB\n' >"$tmp/live.status"
-printf 'Name:\trrtiny\nState:\tZ (zombie)\n' >"$tmp/zombie.status"
-printf 'Name:\trrtiny\nState:\tR (running)\n' >"$tmp/missing-rss.status"
-printf 'Name:\trrtiny\nVmRSS:\t1234 kB\n' >"$tmp/missing-state.status"
-printf 'Name:\trrtiny\nState:\tR (running)\nVmRSS:\t2097153 kB\n' >"$tmp/over-limit.status"
-[[ $("$runner" --observe-direct-rss "$tmp/live.status") == $'sample\t1234' ]]
-[[ $("$runner" --observe-direct-rss "$tmp/zombie.status") == $'exited\t0' ]]
-[[ $("$runner" --observe-direct-rss "$tmp/missing-rss.status") == $'reject\t0' ]]
-[[ $("$runner" --observe-direct-rss "$tmp/missing-state.status") == $'reject\t0' ]]
-[[ $("$runner" --observe-direct-rss "$tmp/absent.status") == $'exited\t0' ]]
-[[ $("$runner" --sample-direct-rss-fixture "$tmp/live.status" "$tmp/live-rss") == \
-  $'sample\t1234\t1234' ]]
-[[ $(<"$tmp/live-rss/rss.tsv") == \
+direct_fixture() {
+  local name=$1 expected=$2 expected_status=$3 actual status=0 stderr; shift 3
+  stderr=$tmp/$name.stderr
+  actual=$("$runner" --sample-direct-rss-observations "$tmp/$name" 11 "$@" \
+    2>"$stderr") || status=$?
+  [[ $actual == "$expected" && $status == "$expected_status" ]]
+  if (( expected_status == 0 )); then
+    [[ ! -s $stderr ]]
+  else
+    [[ $(<"$stderr") == "tiny sampler observed live process without numeric VmRSS" ]]
+  fi
+}
+direct_fixture exit-after-miss $'exited\t0\t0' 0 \
+  11,R,absent,11 11,Z,absent,11
+[[ $(<"$tmp/exit-after-miss/rss.tsv") == $'checkpoint\trss_kib' ]]
+direct_fixture exit-during-bracket $'exited\t0\t0' 0 \
+  11,R,absent,absent
+[[ $(<"$tmp/exit-during-bracket/rss.tsv") == $'checkpoint\trss_kib' ]]
+direct_fixture sample-after-miss $'sample\t1234\t1234' 0 \
+  11,R,absent,11 11,R,1234,11
+[[ $(<"$tmp/sample-after-miss/rss.tsv") == \
   $'checkpoint\trss_kib\nprocess_tree_target_rss_sample\t1234' ]]
-[[ $("$runner" --sample-direct-rss-fixture "$tmp/zombie.status" "$tmp/zombie-rss") == \
-  $'exited\t0\t0' ]]
-[[ $(<"$tmp/zombie-rss/rss.tsv") == $'checkpoint\trss_kib' ]]
-if "$runner" --sample-direct-rss-fixture "$tmp/missing-rss.status" "$tmp/missing-rss" \
-  2>"$tmp/missing-rss.stderr"; then
-  echo "live process without VmRSS was accepted" >&2
-  exit 1
-fi
-[[ $(<"$tmp/missing-rss/rss.tsv") == $'checkpoint\trss_kib' ]]
-grep -Fxq "tiny sampler observed live process without numeric VmRSS" \
-  "$tmp/missing-rss.stderr"
-if "$runner" --sample-direct-rss-fixture "$tmp/over-limit.status" "$tmp/over-limit" \
-  >"$tmp/over-limit.stdout" 2>"$tmp/over-limit.stderr"; then
+direct_fixture sample-after-missing-state $'sample\t1234\t1234' 0 \
+  11,absent,absent,11 11,R,1234,11
+[[ $(<"$tmp/sample-after-missing-state/rss.tsv") == \
+  $'checkpoint\trss_kib\nprocess_tree_target_rss_sample\t1234' ]]
+direct_fixture persistent-miss $'reject\t0\t0' 1 \
+  11,R,absent,11 11,S,absent,11 11,D,absent,11
+[[ $(<"$tmp/persistent-miss/rss.tsv") == $'checkpoint\trss_kib' ]]
+direct_fixture persistent-missing-state $'reject\t0\t0' 1 \
+  11,absent,absent,11 11,absent,absent,11 11,absent,absent,11
+[[ $(<"$tmp/persistent-missing-state/rss.tsv") == $'checkpoint\trss_kib' ]]
+direct_fixture reused-pid $'reject\t0\t0' 1 \
+  11,R,absent,11 12,R,1234,12
+[[ $(<"$tmp/reused-pid/rss.tsv") == $'checkpoint\trss_kib' ]]
+direct_fixture foreign-then-absent $'reject\t0\t0' 1 12,R,absent,absent
+direct_fixture absent-then-expected $'reject\t0\t0' 1 absent,R,absent,11
+direct_fixture incoherent-bracket $'reject\t0\t0' 1 11,R,absent,12
+if "$runner" --sample-direct-rss-observations "$tmp/over-limit" 11 \
+  11,R,absent,11 11,R,2097153,11 >"$tmp/over-limit.stdout" \
+  2>"$tmp/over-limit.stderr"; then
   echo "production direct sampler bypassed the RSS ceiling" >&2
   exit 1
 fi
@@ -378,7 +392,8 @@ for seam in \
   "python3 \"\$verifier\" \"\$receipt\" --full | tee \"\$receipt/verifier.txt\"" \
   "full_checksums \"\$receipt\"" \
   "sha256sum -c SHA256SUMS --strict" \
-  "sample_direct_rss \"/proc/\$pid/status\" \"\$receipt\"" \
+  "sample_direct_rss \"\$pid\" \"\$tiny_validated_starttime\" \"\$receipt\"" \
+  "resolve_direct_rss \"\$process\" \"\$expected_start\"" \
   "[[ \$direct_rss_action != exited ]] || break"; do
   cp "$runner" "$tmp/runner"
   grep -Fv "$seam" "$tmp/runner" >"$tmp/mutated"


### PR DESCRIPTION
## Summary

- pin direct RSS observations to the startup-validated process starttime
- retry bounded live observations with missing VmRSS or an unparseable state without fabricating samples
- reject persistent malformed observations and PID replacement while preserving the 2 GiB ceiling
- turn expected rejection diagnostics into asserted fixture evidence instead of CI noise

## Validation

- bash bench/tests/test-rrtransport-receipt.sh
- shellcheck --severity=error bench/scale/rrtransport/run-receipt.sh bench/tests/test-rrtransport-receipt.sh
- git diff --check
- workspace fmt, clippy, tests, and warning-denied docs via hooks
- real procfs smoke

## Load-bearing proof

Each guarded break was applied and restored. Reducing the retry cap to one rejects transient recovery; accepting the third miss blesses persistent malformed input; removing cached identity accepts PID reuse; bypassing classify_rss accepts an over-limit sample; removing the production resolver call breaks the seam gate; removing expected-to-absent terminal handling rejects a normal exit race; treating missing State as terminal loses a later valid sample; accepting persistent missing State as exit blesses malformed live input; removing diagnostic capture makes the expected-failure fixture red.