### PR TITLE
Split workspace tests from the CI core lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,11 +222,6 @@ jobs:
             docs/perf/bgperf-rustbgpd-ehm-wrapper.sh \
             docs/perf/test-event-history-host-fence.sh \
             docs/perf/test-event-history-naming.sh
-      - run: cargo test --workspace
-      - run: cargo doc --workspace --lib --no-deps
-        env:
-          RUSTDOCFLAGS: "-D warnings"
-
       - name: Wire crate README freshness gate
         # Catches the common omission where someone bumps
         # `crates/wire/Cargo.toml` version without revisiting
@@ -258,6 +253,24 @@ jobs:
             fi
             echo "wire bump + README touched — gate passed"
           fi
+
+  core_tests:
+    name: core tests / rustdoc
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+        with:
+          toolchain: stable
+      - uses: ./.github/actions/install-protobuf
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - run: cargo test --workspace
+      - run: cargo doc --workspace --lib --no-deps
+        env:
+          RUSTDOCFLAGS: "-D warnings"
 
   scale_receipts:
     name: scale / receipt checks
@@ -361,17 +374,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: ${{ always() }}
-    needs: [core, scale_receipts]
+    needs: [core, core_tests, scale_receipts]
     env:
       CORE_RESULT: ${{ needs.core.result }}
+      CORE_TESTS_RESULT: ${{ needs.core_tests.result }}
       SCALE_RECEIPTS_RESULT: ${{ needs.scale_receipts.result }}
     steps:
       - name: Aggregate required CI result
         run: |
           set -euo pipefail
           printf 'core=%s\n' "$CORE_RESULT"
+          printf 'core_tests=%s\n' "$CORE_TESTS_RESULT"
           printf 'scale_receipts=%s\n' "$SCALE_RECEIPTS_RESULT"
-          if [[ "$CORE_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]; then
+          if [[ "$CORE_RESULT" != "success" || "$CORE_TESTS_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]; then
             exit 1
           fi
 

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -49,9 +49,9 @@ CALL_HASHES = {
 }
 PINS = collections.Counter(
     {
-        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7": 76,
-        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 2,
-        "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2": 4,
+        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7": 77,
+        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 3,
+        "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2": 5,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 2,
         "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4": 42,
         "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7": 43,

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail closed when the CI scale/receipt split contract drifts."""
+"""Fail closed when the CI core/scale split contract drifts."""
 
 from __future__ import annotations
 
@@ -9,13 +9,21 @@ import re
 import sys
 from pathlib import Path
 
-ROSTER = ["core", "scale_receipts", "check", "msrv", "evpn_bum_filter_kernel"]
+ROSTER = [
+    "core",
+    "core_tests",
+    "scale_receipts",
+    "check",
+    "msrv",
+    "evpn_bum_filter_kernel",
+]
 TRIGGER_HASH = "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8"
 PERMISSION_HASH = "9691400b3b1036bcdfe724926816dbe71b0aa22ed9b5eb89627e2eeb75079898"
 JOB_HASHES = {
-    "core": "81bea34b590cff22f28e437e20dd15ba200d1bfb2424b9158ecdc1c61ac4b2e9",
+    "core": "91977c62f11648ed94441920df8c21d7a86eb07130b5f57fca8c970eec450edd",
+    "core_tests": "2e5d0d9268a7af2503d76c094a1305501ec861812091cec43b18eaf99ba89a09",
     "scale_receipts": "91d5396ba46147fd7a489b49cbc6207f8588f350df3308c92f236f3936dbcf4f",
-    "check": "afc9629a32cc7c3194ccf0417aaf2623e7a01a8dc95fd0194c2cbfbb29068b57",
+    "check": "cfc655ca80392ab0699390b461e5e8e9b41410cc724201aafe75ae6da7d83213",
     "msrv": "db1ae833d9c8fbbc47dbf2969ac291b90cf413ba9eed2b95dd4cfe34e0a4ba5d",
     "evpn_bum_filter_kernel": "f965e7f95f30772d9d335104dda9e30c53816098bd5f1225a3cadabe7d9a23b3",
 }
@@ -28,9 +36,9 @@ TOOLCHAIN = (
 RUST_CACHE = "uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2"
 PINS = collections.Counter(
     {
-        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7": 4,
-        "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2": 3,
-        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 2,
+        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7": 5,
+        "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2": 4,
+        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 3,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 1,
         "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4": 1,
         "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7": 1,
@@ -82,6 +90,30 @@ def check(root: Path) -> list[str]:
         if _hash(jobs.get(name, "")) != expected:
             errors.append(f"{name} job body drifted")
 
+    core_tests = jobs.get("core_tests", "")
+    for seam in (
+        "name: core tests / rustdoc",
+        "runs-on: ubuntu-latest",
+        "timeout-minutes: 30",
+        CHECKOUT,
+        "fetch-depth: 0",
+        TOOLCHAIN,
+        "toolchain: stable",
+        "uses: ./.github/actions/install-protobuf",
+        RUST_CACHE,
+        "- run: cargo test --workspace",
+        "- run: cargo doc --workspace --lib --no-deps",
+        'RUSTDOCFLAGS: "-D warnings"',
+    ):
+        if seam not in core_tests:
+            errors.append(f"core_tests missing {seam}")
+    for command in (
+        "- run: cargo test --workspace",
+        "- run: cargo doc --workspace --lib --no-deps",
+    ):
+        if text.count(command) != 1 or command in jobs.get("core", ""):
+            errors.append(f"{command} must exist only in core_tests")
+
     if text.count(f"- name: {STEP_NAME}") != 1:
         errors.append("extracted scale/receipt step must appear exactly once")
     scale = jobs.get("scale_receipts", "")
@@ -114,12 +146,14 @@ def check(root: Path) -> list[str]:
         "runs-on: ubuntu-latest",
         "timeout-minutes: 5",
         "if: ${{ always() }}",
-        "needs: [core, scale_receipts]",
+        "needs: [core, core_tests, scale_receipts]",
         "CORE_RESULT: ${{ needs.core.result }}",
+        "CORE_TESTS_RESULT: ${{ needs.core_tests.result }}",
         "SCALE_RECEIPTS_RESULT: ${{ needs.scale_receipts.result }}",
         "printf 'core=%s\\n' \"$CORE_RESULT\"",
+        "printf 'core_tests=%s\\n' \"$CORE_TESTS_RESULT\"",
         "printf 'scale_receipts=%s\\n' \"$SCALE_RECEIPTS_RESULT\"",
-        '[[ "$CORE_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]',
+        '[[ "$CORE_RESULT" != "success" || "$CORE_TESTS_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]',
     ):
         if seam not in aggregate:
             errors.append(f"aggregate check missing {seam}")

--- a/scripts/test_check_ci_scale_split_contract.py
+++ b/scripts/test_check_ci_scale_split_contract.py
@@ -38,11 +38,13 @@ class ScaleSplitContractTests(unittest.TestCase):
     def test_destructive_roster_and_preserved_bodies(self) -> None:
         cases = (
             ("  core:\n", "  renamed_core:\n"),
+            ("  core_tests:\n", "  renamed_core_tests:\n"),
             ("  scale_receipts:\n", "  renamed_scale:\n"),
             ("  check:\n", "  renamed_check:\n"),
             ("  msrv:\n", "  renamed_msrv:\n"),
             ("  evpn_bum_filter_kernel:\n", "  renamed_evpn:\n"),
             ("timeout-minutes: 45", "timeout-minutes: 44"),
+            ("Wire crate README freshness gate", "changed final core step"),
             ("key: msrv-1.95", "key: msrv-drift"),
             ("IMAGE_TAG: rustbgpd-netns-tests:latest", "IMAGE_TAG: drift"),
             ("branches: [main]", "branches: [other]"),
@@ -71,9 +73,9 @@ class ScaleSplitContractTests(unittest.TestCase):
         cases = (
             ("name: scale / receipt checks", "name: changed"),
             ("timeout-minutes: 30", "timeout-minutes: 29"),
-            ("fetch-depth: 0", "fetch-depth: 1", 1),
+            ("fetch-depth: 0", "fetch-depth: 1", 2),
             ("components: rustfmt, clippy", "components: rustfmt"),
-            ("uses: ./.github/actions/install-protobuf", "uses: ./changed", 1),
+            ("uses: ./.github/actions/install-protobuf", "uses: ./changed", 2),
             ("sudo apt-get install -y ripgrep", "sudo apt-get install -y grep"),
             (
                 "cargo fmt --manifest-path bench/scale/rrharness/Cargo.toml -- --check",
@@ -91,27 +93,70 @@ class ScaleSplitContractTests(unittest.TestCase):
             with self.subTest(seam=old):
                 self.mutate(old, new, occurrence[0] if occurrence else 0)
         for pin, occurrence in (
-            ("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", 1),
-            ("dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c", 1),
-            ("Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32", 1),
+            ("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", 2),
+            ("dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c", 2),
+            ("Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32", 2),
         ):
             with self.subTest(pin=pin):
                 self.mutate(pin, "changed@main", occurrence)
+
+    def test_destructive_core_tests_extraction_and_setup(self) -> None:
+        cases = (
+            ("name: core tests / rustdoc", "name: changed"),
+            ("timeout-minutes: 30", "timeout-minutes: 29"),
+            ("fetch-depth: 0", "fetch-depth: 1", 1),
+            ("uses: ./.github/actions/install-protobuf", "uses: ./changed", 1),
+            ("- run: cargo test --workspace", "- run: true"),
+            ("- run: cargo doc --workspace --lib --no-deps", "- run: true"),
+            ('RUSTDOCFLAGS: "-D warnings"', 'RUSTDOCFLAGS: ""'),
+        )
+        for case in cases:
+            old, new, *occurrence = case
+            with self.subTest(seam=old):
+                self.mutate(old, new, occurrence[0] if occurrence else 0)
+        for pin in (
+            "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+            "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c",
+            "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32",
+        ):
+            with self.subTest(pin=pin):
+                self.mutate(pin, "changed@main", 1)
+        self.mutate(
+            "      - name: Wire crate README freshness gate",
+            "      - run: cargo test --workspace\n"
+            "      - run: cargo doc --workspace --lib --no-deps\n"
+            "        env:\n"
+            '          RUSTDOCFLAGS: "-D warnings"\n'
+            "      - name: Wire crate README freshness gate",
+        )
 
     def test_destructive_aggregate_seams(self) -> None:
         cases = (
             ("name: check", "name: changed"),
             ("timeout-minutes: 5", "timeout-minutes: 6"),
             ("if: ${{ always() }}", "if: ${{ success() }}"),
-            ("needs: [core, scale_receipts]", "needs: [core]"),
+            (
+                "needs: [core, core_tests, scale_receipts]",
+                "needs: [core_tests, scale_receipts]",
+            ),
+            (
+                "needs: [core, core_tests, scale_receipts]",
+                "needs: [core, scale_receipts]",
+            ),
+            ("needs: [core, core_tests, scale_receipts]", "needs: [core, core_tests]"),
             ("CORE_RESULT: ${{ needs.core.result }}", "CORE_RESULT: success"),
+            (
+                "CORE_TESTS_RESULT: ${{ needs.core_tests.result }}",
+                "CORE_TESTS_RESULT: success",
+            ),
             (
                 "SCALE_RECEIPTS_RESULT: ${{ needs.scale_receipts.result }}",
                 "SCALE_RECEIPTS_RESULT: success",
             ),
             ("printf 'core=%s\\n' \"$CORE_RESULT\"", "true"),
+            ("printf 'core_tests=%s\\n' \"$CORE_TESTS_RESULT\"", "true"),
             (
-                '[[ "$CORE_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]',
+                '[[ "$CORE_RESULT" != "success" || "$CORE_TESTS_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]',
                 "[[ false ]]",
             ),
         )
@@ -124,26 +169,32 @@ class ScaleSplitContractTests(unittest.TestCase):
         shell = aggregate_shell(_jobs(workflow)["check"])
         self.assertTrue(shell)
 
-        def run(core=None, scale=None):
+        def run(core=None, core_tests=None, scale=None):
             env = os.environ.copy()
             env.pop("CORE_RESULT", None)
+            env.pop("CORE_TESTS_RESULT", None)
             env.pop("SCALE_RECEIPTS_RESULT", None)
             if core is not None:
                 env["CORE_RESULT"] = core
+            if core_tests is not None:
+                env["CORE_TESTS_RESULT"] = core_tests
             if scale is not None:
                 env["SCALE_RECEIPTS_RESULT"] = scale
             return subprocess.run(
                 ["bash", "-c", shell], env=env, capture_output=True, text=True
             )
 
-        self.assertEqual(0, run("success", "success").returncode)
+        self.assertEqual(0, run("success", "success", "success").returncode)
         for bad in ("failure", "cancelled", "skipped", ""):
             with self.subTest(child="core", result=bad):
-                self.assertNotEqual(0, run(bad, "success").returncode)
+                self.assertNotEqual(0, run(bad, "success", "success").returncode)
+            with self.subTest(child="core_tests", result=bad):
+                self.assertNotEqual(0, run("success", bad, "success").returncode)
             with self.subTest(child="scale_receipts", result=bad):
-                self.assertNotEqual(0, run("success", bad).returncode)
-        self.assertNotEqual(0, run(None, "success").returncode)
-        self.assertNotEqual(0, run("success", None).returncode)
+                self.assertNotEqual(0, run("success", "success", bad).returncode)
+        self.assertNotEqual(0, run(None, "success", "success").returncode)
+        self.assertNotEqual(0, run("success", None, "success").returncode)
+        self.assertNotEqual(0, run("success", "success", None).returncode)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- move the existing workspace-test and warning-denied rustdoc commands byte-for-byte into one parallel core_tests lane
- preserve every other core, scale, MSRV, kernel, trigger, permission, environment, and action-pin contract
- extend the stable aggregate to require exact success from core, core_tests, and scale receipts

## Baseline and merge gate

Five exact main controls put core at 13:25–16:17, median 15:40, with required-check readiness about 15:56.

This is a measured experiment. After the cold exact-head run, rerun the same workflow without another push. Merge only if the warm required check is ready within 12:00 or improves at least 25%, split-local runner time is at most 21:09, and the whole workflow is at most 39:33. A miss is HOLD/revert, not a prompt for cache redesign or more jobs.

## Validation

- 11 live and destructive contract tests
- both CI contract checkers
- Ruby workflow parse, Python compilation, Black, and diff-check
- workspace fmt, clippy, tests, and warning-denied docs via hooks
- independent final Judge GO

## Load-bearing proof

Destructive mutations cover job roster/order and hashes; test/doc deletion, drift, duplication, and warning weakening; full-history checkout, toolchain, protobuf, cache pins, and timeout; every aggregate dependency/result/log/predicate seam; failure, cancellation, skip, empty, and missing results for each child; and all retained trigger, permission, scale, MSRV, kernel, and action-pin contracts.