### PR TITLE
chore: simplify release verification

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,8 +8,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
-# Read-only default; `build-and-push` alone escalates to the scopes
-# image publication + provenance attestation need.
+# Read-only default; `build-and-push` alone adds package publication.
 permissions:
   contents: read
 
@@ -54,8 +53,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write      # OIDC identity for provenance attestation
-      attestations: write  # store the provenance attestation
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -93,21 +90,9 @@ jobs:
             'test -f /LICENSE-MIT && test -f /LICENSE-APACHE'
 
       - name: Build and push
-        id: push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Attest build provenance for the image
-        # SLSA build provenance for the pushed image digest, stored in
-        # the GHCR registry so `gh attestation verify
-        # oci://ghcr.io/...` works — see docs/deployment.md
-        # "Verifying release artifacts".
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,8 @@ on:
   push:
     tags: ["v*"]
 
-# Read-only default; the `release` job alone escalates to the scopes
-# release publication needs (contents to create the release, id-token +
-# attestations for build provenance).
+# Read-only default; the `release` job alone escalates to the
+# contents scope needed to create the release.
 permissions:
   contents: read
 
@@ -223,9 +222,7 @@ jobs:
     needs: [verify-tag-version, test, build]
     runs-on: ubuntu-latest
     permissions:
-      contents: write      # create the GitHub release
-      id-token: write      # OIDC identity for provenance attestation
-      attestations: write  # store the provenance attestation
+      contents: write  # create the GitHub release
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -234,48 +231,6 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
-
-      - name: Generate CycloneDX SBOM
-        # One SBOM per release, from the workspace Cargo.lock — the
-        # dependency set is identical across both arch tarballs and the
-        # deb/rpm packages, so a single arch-independent document
-        # covers all of them. The `rustbgpd-wire` / `rustbgpd-fsm`
-        # crates published separately on crates.io appear here as
-        # workspace components; their own crates.io releases carry no
-        # separate SBOM. Published under the stable asset name
-        # `rustbgpd.cdx.json` (works with releases/latest/download/).
-        run: |
-          set -euo pipefail
-          curl -sSfL -o /tmp/syft.tgz \
-            https://github.com/anchore/syft/releases/download/v1.50.0/syft_1.50.0_linux_amd64.tar.gz
-          echo "bf7b29ff57f06da30918266a0e1c2885a8f99784798d1bdb1628886aa015d788  /tmp/syft.tgz" | sha256sum -c
-          tar -C /tmp -xzf /tmp/syft.tgz syft
-          /tmp/syft scan dir:. --select-catalogers rust \
-            -o cyclonedx-json=artifacts/rustbgpd.cdx.json
-          # Fail closed on a degenerate SBOM (catalogers drifting,
-          # lockfile not picked up).
-          python3 - <<'EOF'
-          import json, sys
-          doc = json.load(open("artifacts/rustbgpd.cdx.json"))
-          names = {c["name"] for c in doc.get("components", [])}
-          missing = {"rustbgpd", "rustbgpd-wire", "rustbgpd-fsm"} - names
-          if missing or len(names) < 100:
-              sys.exit(f"SBOM implausible: {len(names)} components, missing {missing}")
-          print(f"SBOM OK: {len(names)} components")
-          EOF
-
-      - name: Attest build provenance for release artifacts
-        # SLSA build provenance for every downloadable build product:
-        # both arch tarballs, all deb/rpm packages, and the SBOM.
-        # Operators verify with `gh attestation verify` — see
-        # docs/deployment.md "Verifying release artifacts".
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
-        with:
-          subject-path: |
-            artifacts/*.tar.gz
-            artifacts/*.deb
-            artifacts/*.rpm
-            artifacts/rustbgpd.cdx.json
 
       - name: Extract CHANGELOG section for this tag
         # Pull the matching `## [X.Y.Z]` block out of CHANGELOG.md so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,14 +28,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   starter config at `/etc/rustbgpd/config.toml` — install, edit the
   config, `systemctl enable --now rustbgpd`.
 
-- Release supply-chain verification: every release asset (tarballs,
-  packages, SBOM) and the GHCR image digest now carry GitHub
-  build-provenance attestations — `gh attestation verify <asset>
-  --repo lance0/rustbgpd` proves an artifact came out of this
-  repository's release workflow at the tagged commit. Each release
-  also publishes a CycloneDX SBOM of the full dependency graph as
-  `rustbgpd.cdx.json`. See "Verifying release artifacts" in
-  `docs/deployment.md`.
+- Per-architecture SHA-256 manifests cover each release tarball and its native
+  packages. The install docs select the exact downloaded filename from the
+  manifest, so tarball-only verification does not fail on absent `.deb` or
+  `.rpm` files.
 
 - The container image declares a `HEALTHCHECK` probing `rbgp --json
   health` over the daemon's local gRPC socket, so `docker ps` and

--- a/README.md
+++ b/README.md
@@ -222,10 +222,11 @@ Every tagged release ships static-named per-arch tarballs, so
 
 ```bash
 SUFFIX=linux-amd64   # or linux-arm64
-curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/rustbgpd-${SUFFIX}.tar.gz"
+TARBALL="rustbgpd-${SUFFIX}.tar.gz"
+curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/${TARBALL}"
 curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/checksums-${SUFFIX}.txt"
-sha256sum -c "checksums-${SUFFIX}.txt"
-tar -xzf "rustbgpd-${SUFFIX}.tar.gz"
+awk -v file="$TARBALL" '$2 == file || $2 == "./" file { print }' "checksums-${SUFFIX}.txt" | sha256sum -c -
+tar -xzf "$TARBALL"
 sudo install -m 0755 rustbgpd rbgp rs-config-render /usr/local/bin/
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -106,17 +106,17 @@ in CI and fails when the inventory drifts from the reviewed list.
 
 ### Notes for Integrators
 
-Manufacturers integrating rustbgpd who need to document upstream
-open-source handling (for example under the EU Cyber Resilience Act) can
-point at:
+Integrators documenting rustbgpd's upstream open-source handling can point at:
 
 - This coordinated disclosure policy, including the response timelines
   above.
 - Private vulnerability intake via GitHub private vulnerability
   reporting, enabled on the repository.
 - CVE assignment for qualifying vulnerabilities via the GHSA flow.
-- Machine-readable dependency inventory: from v0.63 onward, release
-  artifacts include an SBOM.
+- Exact dependency inventory in the committed `Cargo.lock` for every tagged
+  source tree.
+- MIT or Apache-2.0 licensing; software and release artifacts are provided
+  as-is under those licenses.
 
 ### Authentication (v1)
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -13,10 +13,11 @@ Grab the pre-built release tarball — no Rust toolchain, no compile:
 <!-- release-install-contract:tarball:start -->
 ```bash
 SUFFIX=linux-amd64   # or linux-arm64
-curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/rustbgpd-${SUFFIX}.tar.gz"
+TARBALL="rustbgpd-${SUFFIX}.tar.gz"
+curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/${TARBALL}"
 curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/checksums-${SUFFIX}.txt"
-sha256sum -c "checksums-${SUFFIX}.txt"
-tar -xzf "rustbgpd-${SUFFIX}.tar.gz"
+awk -v file="$TARBALL" '$2 == file || $2 == "./" file { print }' "checksums-${SUFFIX}.txt" | sha256sum -c -
+tar -xzf "$TARBALL"
 sudo install -m 0755 rustbgpd rbgp rs-config-render /usr/local/bin/
 
 sudo useradd --system --home-dir /var/lib/rustbgpd \

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -611,8 +611,8 @@ docker run --rm --entrypoint rbgp rustbgpd:dev --help
     [GitHub Releases](https://github.com/lance0/rustbgpd/releases) — each
     tag should publish version-less `rustbgpd-linux-amd64.tar.gz` and
     `rustbgpd-linux-arm64.tar.gz`, per-arch `.deb`/`.rpm` packages, the
-    `rustbgpd.cdx.json` SBOM, plus per-arch `checksums-<arch>.txt`
-    (covering tarball + packages).
+    standalone config schema, plus per-arch `checksums-<arch>.txt`
+    (covering the tarball and packages).
     Each tarball contains `rustbgpd`, `rbgp`, `rs-config-render`,
     `birdwatcher-adapter`, `LICENSE-MIT`, and `LICENSE-APACHE` plus the
     systemd unit under `share/systemd/` (presence is asserted by the
@@ -620,10 +620,14 @@ docker run --rm --entrypoint rbgp rustbgpd:dev --help
     The version-less filenames are what powers the static
     `releases/latest/download/` URLs in `docs/deployment.md`; if the
     filenames drift, deployment.md silently breaks for new operators.
-    Spot-check provenance on one asset and the image:
-    `gh attestation verify rustbgpd-linux-amd64.tar.gz --repo lance0/rustbgpd`
-    and `gh attestation verify oci://ghcr.io/lance0/rustbgpd:X.Y.Z --repo
-    lance0/rustbgpd`.
+    Download one tarball and its checksum manifest, then spot-check only that
+    file:
+
+    ```sh
+    awk -v file=rustbgpd-linux-amd64.tar.gz '$2 == file || $2 == "./" file { print }' \
+      checksums-linux-amd64.txt | sha256sum -c -
+    ```
+
 11. **Verify GitHub release notes**: check that the release created by CI has
     accurate notes. The `release` workflow extracts the matching
     `## [X.Y.Z]` block out of `CHANGELOG.md` via awk and fails the tag build

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -69,6 +69,10 @@ TARBALL=rustbgpd-${SUFFIX}.tar.gz
 
 curl -fL -o "$TARBALL" \
   "https://github.com/lance0/rustbgpd/releases/latest/download/${TARBALL}"
+curl -fLO \
+  "https://github.com/lance0/rustbgpd/releases/latest/download/checksums-${SUFFIX}.txt"
+awk -v file="$TARBALL" '$2 == file || $2 == "./" file { print }' \
+  "checksums-${SUFFIX}.txt" | sha256sum -c -
 tar -xzf "$TARBALL"
 sudo install -m 0755 rustbgpd rbgp rs-config-render /usr/local/bin/
 sudo install -m 0644 share/man/man1/rbgp.1 /usr/local/share/man/man1/
@@ -165,40 +169,25 @@ mutation.
 
 ### Verifying release artifacts
 
-Every release asset — both tarballs, all `.deb`/`.rpm` packages, and
-the SBOM — carries a GitHub build-provenance attestation ([SLSA
-provenance](https://slsa.dev/) signed via GitHub OIDC), created by the
-release workflow at tag time. Verify with the `gh` CLI (≥ 2.49)
-before installing:
+Each architecture has a `checksums-<arch>.txt` manifest covering its
+tarball and native packages. Select the exact downloaded filename before
+passing the row to `sha256sum`; checking the whole manifest fails when the
+other package formats have not also been downloaded:
 
 ```sh
-gh attestation verify rustbgpd-linux-amd64.tar.gz --repo lance0/rustbgpd
-gh attestation verify rustbgpd_X.Y.Z_amd64.deb --repo lance0/rustbgpd
+SUFFIX=linux-amd64
+ARTIFACT=rustbgpd-linux-amd64.tar.gz
+curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/${ARTIFACT}"
+curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/checksums-${SUFFIX}.txt"
+awk -v file="$ARTIFACT" '$2 == file || $2 == "./" file { print }' \
+  "checksums-${SUFFIX}.txt" | sha256sum -c -
 ```
 
-The container image is attested by digest, with the attestation pushed
-to GHCR alongside the image:
-
-```sh
-gh attestation verify oci://ghcr.io/lance0/rustbgpd:latest --repo lance0/rustbgpd
-```
-
-A successful verification proves the artifact was built by this
-repository's release workflow from the tagged commit — not rebuilt or
-modified by anyone else, including a compromised release-asset upload.
-
-A CycloneDX SBOM covering the full workspace dependency graph is
-published with each release under the stable asset name
-`rustbgpd.cdx.json` (one per release; the dependency set is identical
-across architectures and package formats):
-
-```sh
-curl -fLO https://github.com/lance0/rustbgpd/releases/latest/download/rustbgpd.cdx.json
-```
-
-The separately published crates.io libraries (`rustbgpd-wire`,
-`rustbgpd-fsm`) appear in that SBOM as workspace components; their
-crates.io releases do not carry their own SBOM documents.
+This detects a download that differs from the manifest published with the
+GitHub release; it does not independently authenticate GitHub. The committed
+`Cargo.lock` is the exact Rust dependency inventory for a tagged source tree.
+Release binaries and containers are provided under the repository's license
+terms and warranty disclaimers.
 
 ### From source
 


### PR DESCRIPTION
## Summary

- remove the unshipped CycloneDX SBOM and GitHub provenance-attestation ceremony from release and container workflows
- retain per-architecture checksums, least-privilege workflow permissions, pinned actions, tests, audit, deny, licensing, and disclosure controls
- fix tarball-only checksum examples by selecting the exact downloaded artifact instead of checking absent package files

## Why

The project does not need to promise and maintain compliance-shaped release ceremony that has not shipped. The existing copied checksum command also fails once a manifest contains the tarball plus native packages and the operator downloaded only the tarball.

## Verification

- `python3 -m unittest -v scripts/test_check_release_install_contract.py`
- `python3 scripts/check_release_install_contract.py`
- parsed both edited workflows with PyYAML
- exercised exact-artifact checksum selection for success, missing-row failure, and tampered-payload failure
- pre-push hooks: `cargo doc --workspace --no-deps`

## Load-bearing proof

No production checker was changed. The checksum selector was exercised against three counterexamples: the documented command succeeds for the selected tarball, fails when that filename is absent from the manifest, and fails when the selected payload is modified.