### PR TITLE
refactor: remove obsolete PeerManager compatibility carriers

### DIFF
--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -12,10 +12,9 @@ use tonic::{Request, Response, Status};
 
 use crate::actor_read::{peer_manager_read, rib_manager_read};
 use crate::peer_types::{
-    ConfigEvent, DynamicRangeError, NeighborCreateAddPath, NeighborCreateSpec,
-    OutboundRefreshError, PeerInfo, PeerKey, PeerLifecycleError, PeerManagerCommand,
-    PeerManagerNeighborConfig, PresenceAwareNeighborCreate, RemovedDynamicRange,
-    Rfc8212PolicyStatus,
+    ConfigEvent, DynamicRangeError, NeighborCreateAddPath, OutboundRefreshError, PeerInfo, PeerKey,
+    PeerLifecycleError, PeerManagerCommand, PeerManagerNeighborConfig, PresenceAwareNeighborCreate,
+    RemovedDynamicRange, Rfc8212PolicyStatus,
 };
 use crate::proto;
 use crate::server::{
@@ -363,7 +362,7 @@ async fn add_static_peer(
 
 async fn add_presence_aware_peer(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    spec: NeighborCreateSpec,
+    spec: Box<PresenceAwareNeighborCreate>,
 ) -> Result<(), Status> {
     let (reply_tx, reply_rx) = oneshot::channel();
     peer_mgr_tx
@@ -502,7 +501,7 @@ const CREATE_ADD_PATH_PATHS: [&str; 4] = [
 )]
 fn parse_presence_aware_create(
     intent: proto::NeighborCreateIntent,
-) -> Result<NeighborCreateSpec, Status> {
+) -> Result<Box<PresenceAwareNeighborCreate>, Status> {
     let config = intent
         .config
         .ok_or_else(|| Status::invalid_argument("intent.config is required"))?;
@@ -643,34 +642,32 @@ fn parse_presence_aware_create(
         })
     };
 
-    Ok(NeighborCreateSpec::PresenceAware(Box::new(
-        PresenceAwareNeighborCreate {
-            address,
-            interface,
-            remote_asn: config.remote_asn,
-            description: (!config.description.trim().is_empty()).then_some(config.description),
-            peer_group: (!config.peer_group.trim().is_empty()).then_some(config.peer_group),
-            hold_time,
-            min_hold_time,
-            send_hold_time: config.send_hold_time,
-            max_prefixes: (config.max_prefixes > 0).then_some(config.max_prefixes),
-            max_prefix_restart_seconds: config.max_prefix_restart_seconds,
-            remove_private_as,
-            local_role,
-            families,
-            required_families,
-            route_server_client: selected
-                .contains("route_server_client")
-                .then_some(config.route_server_client),
-            per_client_best: selected
-                .contains("per_client_best")
-                .then_some(config.per_client_best),
-            strict_role: selected
-                .contains("strict_role")
-                .then_some(config.strict_role),
-            add_path,
-        },
-    )))
+    Ok(Box::new(PresenceAwareNeighborCreate {
+        address,
+        interface,
+        remote_asn: config.remote_asn,
+        description: (!config.description.trim().is_empty()).then_some(config.description),
+        peer_group: (!config.peer_group.trim().is_empty()).then_some(config.peer_group),
+        hold_time,
+        min_hold_time,
+        send_hold_time: config.send_hold_time,
+        max_prefixes: (config.max_prefixes > 0).then_some(config.max_prefixes),
+        max_prefix_restart_seconds: config.max_prefix_restart_seconds,
+        remove_private_as,
+        local_role,
+        families,
+        required_families,
+        route_server_client: selected
+            .contains("route_server_client")
+            .then_some(config.route_server_client),
+        per_client_best: selected
+            .contains("per_client_best")
+            .then_some(config.per_client_best),
+        strict_role: selected
+            .contains("strict_role")
+            .then_some(config.strict_role),
+        add_path,
+    }))
 }
 
 #[expect(
@@ -2190,10 +2187,7 @@ mod tests {
         )
         .intent
         .unwrap();
-        let NeighborCreateSpec::PresenceAware(raw) = parse_presence_aware_create(intent).unwrap()
-        else {
-            panic!("presence-aware parser returned legacy")
-        };
+        let raw = parse_presence_aware_create(intent).unwrap();
         assert_eq!(raw.families, Some(vec![(Afi::Ipv6, Safi::Unicast)]));
         assert_eq!(
             raw.required_families,
@@ -4368,6 +4362,12 @@ mod tests {
             ConfigEvent::PresenceAwareNeighborAdded { spec, ack } => (spec, ack.unwrap()),
             _ => panic!("expected PresenceAwareNeighborAdded"),
         };
+        assert_eq!(persisted.peer_group.as_deref(), Some("ix-members"));
+        assert_eq!(persisted.description, None);
+        assert_eq!(persisted.hold_time, None);
+        assert_eq!(persisted.families, None);
+        assert_eq!(persisted.route_server_client, None);
+        assert_eq!(persisted.add_path, None);
         assert!(
             matches!(peer_mgr_rx.try_recv(), Err(TryRecvError::Empty)),
             "the actor command must wait for the persistence stage acknowledgement"
@@ -4376,14 +4376,7 @@ mod tests {
 
         match peer_mgr_rx.recv().await.unwrap() {
             PeerManagerCommand::RuntimeCreatePeer { spec, reply } => {
-                let (
-                    NeighborCreateSpec::PresenceAware(persisted),
-                    NeighborCreateSpec::PresenceAware(applied),
-                ) = (persisted, spec)
-                else {
-                    panic!("both ownership boundaries must carry raw presence-aware intent")
-                };
-                assert_eq!(applied, persisted);
+                assert_eq!(spec, persisted);
                 assert!(
                     tokio::time::timeout(Duration::from_millis(20), &mut call)
                         .await

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -650,8 +650,8 @@ pub enum PeerManagerCommand {
     },
     /// Create a runtime peer from a presence-preserving raw specification.
     RuntimeCreatePeer {
-        /// Raw create intent; the actor rejects non-presence-aware variants.
-        spec: NeighborCreateSpec,
+        /// Boxed raw create intent resolved only inside the actor.
+        spec: Box<PresenceAwareNeighborCreate>,
         /// Reply channel for success/failure.
         reply: oneshot::Sender<Result<(), PeerLifecycleError>>,
     },
@@ -1682,15 +1682,6 @@ pub struct PresenceAwareNeighborCreate {
     pub add_path: Option<NeighborCreateAddPath>,
 }
 
-/// Internal compatibility discriminator for runtime neighbor creation.
-#[derive(Clone)]
-pub enum NeighborCreateSpec {
-    /// Existing resolved legacy payload.
-    Legacy(Box<PeerManagerNeighborConfig>),
-    /// Raw presence-aware payload.
-    PresenceAware(Box<PresenceAwareNeighborCreate>),
-}
-
 /// Configuration for adding a peer dynamically.
 #[derive(Clone)]
 #[expect(
@@ -1960,8 +1951,8 @@ pub enum ConfigEvent {
     /// A presence-aware neighbor create whose raw intent must reach disk and
     /// the peer-manager actor unchanged.
     PresenceAwareNeighborAdded {
-        /// Compatibility-discriminated create specification.
-        spec: NeighborCreateSpec,
+        /// Boxed raw create intent, preserved without default materialization.
+        spec: Box<PresenceAwareNeighborCreate>,
         /// Optional two-phase persistence acknowledgement.
         ack: Option<ConfigPersistAck>,
     },

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -246,23 +246,6 @@ impl Default for SessionIdentity {
 /// [`SessionLifecycleNotification`] instead.
 #[derive(Debug)]
 pub enum SessionNotification {
-    /// BGP FSM state changed.
-    ///
-    /// Kept for compatibility with tests and external users of the transport
-    /// crate. New peer sessions publish state changes over the bounded
-    /// [`SessionLifecycleNotification`] channel when one is configured.
-    StateChanged {
-        /// Peer-manager scoped session generation.
-        session_id: u64,
-        /// Role the session had when spawned.
-        role: SessionRole,
-        /// IP address of the remote peer.
-        peer_addr: IpAddr,
-        /// Previous FSM state.
-        old: SessionState,
-        /// New FSM state.
-        new: SessionState,
-    },
     /// Session received a valid OPEN and transitioned to `OpenConfirm`.
     OpenReceived {
         /// Peer-manager scoped session generation.

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -308,16 +308,11 @@ impl PeerSession {
                         new.as_str(),
                     );
 
-                    // Publish operator-facing lifecycle state changes over
-                    // one channel per session so PeerManager can preserve
-                    // per-session order. Existing callers that do not opt
-                    // into the lifecycle channel keep the legacy StateChanged
-                    // notification behavior on the lossless path.
-                    if self.session_lifecycle_tx.is_some() {
-                        self.try_send_lifecycle_state_changed(old, new);
-                    } else {
-                        self.send_lossless_state_changed(old, new);
-                    }
+                    // Publish operator-facing lifecycle state changes over one
+                    // bounded channel per session so PeerManager can preserve
+                    // per-session order. Constructors without that optional
+                    // channel intentionally emit no lifecycle notification.
+                    self.try_send_lifecycle_state_changed(old, new);
 
                     // Notify PeerManager for lossless collision detection.
                     // Read from the FSM's negotiated (set at OpenConfirm),
@@ -793,24 +788,6 @@ impl PeerSession {
         }
 
         follow_up
-    }
-
-    fn send_lossless_state_changed(&self, old: SessionState, new: SessionState) {
-        if let Some(ref notify_tx) = self.session_notify_tx
-            && let Err(e) = notify_tx.send(SessionNotification::StateChanged {
-                session_id: self.session_identity.id,
-                role: self.session_identity.role,
-                peer_addr: self.peer_ip,
-                old,
-                new,
-            })
-        {
-            warn!(
-                peer = %self.peer_label,
-                error = %e,
-                "failed to send StateChanged notification"
-            );
-        }
     }
 
     fn try_send_lifecycle_state_changed(&self, old: SessionState, new: SessionState) {

--- a/crates/transport/tests/session_lifecycle.rs
+++ b/crates/transport/tests/session_lifecycle.rs
@@ -654,7 +654,7 @@ async fn state_changed_uses_bounded_lifecycle_channel() {
 }
 
 #[tokio::test]
-async fn legacy_identity_constructor_preserves_state_changed_notifications() {
+async fn constructor_without_lifecycle_sender_keeps_state_changes_off_lossless_lane() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let metrics = BgpMetrics::new();
@@ -676,18 +676,24 @@ async fn legacy_identity_constructor_preserves_state_changed_notifications() {
     );
     handle.start().await.unwrap();
 
-    let (_peer_stream, _) = listener.accept().await.unwrap();
-    let notification = tokio::time::timeout(Duration::from_secs(5), notify_rx.recv())
+    let (mut peer_stream, _) = listener.accept().await.unwrap();
+    let mut buf = BytesMut::with_capacity(4096);
+    let message = tokio::time::timeout(
+        Duration::from_secs(5),
+        read_bgp_message(&mut peer_stream, &mut buf),
+    )
+    .await
+    .expect("real FSM should send OPEN within timeout");
+    assert!(matches!(message, Message::Open(_)));
+    let state = handle
+        .query_state_timeout(Duration::from_secs(1))
         .await
-        .expect("legacy StateChanged notification should arrive")
-        .expect("notification channel should stay open");
+        .expect("real FSM should answer after reaching OpenSent");
+    assert_eq!(state.fsm_state, SessionState::OpenSent);
 
     assert!(
-        matches!(
-            notification,
-            SessionNotification::StateChanged { session_id: 7, .. }
-        ),
-        "legacy constructor must keep StateChanged on the notification channel"
+        notify_rx.try_recv().is_err(),
+        "a constructor without a lifecycle sender must not copy state changes onto the lossless lane"
     );
 
     handle.shutdown().await.unwrap().unwrap();
@@ -813,16 +819,10 @@ async fn open_confirm_sends_session_notification() {
     // The OpenReceived notification should arrive before Established (no
     // KEEPALIVE sent yet). Ordinary StateChanged events use the bounded
     // lifecycle channel rather than this lossless collision channel.
-    let notification = loop {
-        let notification = tokio::time::timeout(Duration::from_secs(5), notify_rx.recv())
-            .await
-            .expect("should receive notification within timeout")
-            .expect("channel should not be closed");
-        if matches!(notification, SessionNotification::StateChanged { .. }) {
-            continue;
-        }
-        break notification;
-    };
+    let notification = tokio::time::timeout(Duration::from_secs(5), notify_rx.recv())
+        .await
+        .expect("should receive notification within timeout")
+        .expect("channel should not be closed");
 
     match notification {
         SessionNotification::OpenReceived {
@@ -887,16 +887,10 @@ async fn query_state_returns_router_id_at_open_confirm() {
     // Wait for the OpenReceived notification to confirm we're in OpenConfirm.
     // Ordinary StateChanged events use the bounded lifecycle channel rather
     // than this lossless collision channel.
-    let notification = loop {
-        let notification = tokio::time::timeout(Duration::from_secs(5), notify_rx.recv())
-            .await
-            .expect("should receive notification within timeout")
-            .expect("channel should not be closed");
-        if matches!(notification, SessionNotification::StateChanged { .. }) {
-            continue;
-        }
-        break notification;
-    };
+    let notification = tokio::time::timeout(Duration::from_secs(5), notify_rx.recv())
+        .await
+        .expect("should receive notification within timeout")
+        .expect("channel should not be closed");
     assert!(matches!(
         notification,
         SessionNotification::OpenReceived { .. }

--- a/docs/adr/0118-presence-preserving-runtime-neighbor-create.md
+++ b/docs/adr/0118-presence-preserving-runtime-neighbor-create.md
@@ -195,22 +195,21 @@ and must be visible in CLI/API documentation when implementation ships.
 
 ### Raw carrier and ownership
 
-An internal discriminated carrier preserves the compatibility split:
+A direct boxed raw carrier preserves presence until actor resolution:
 
 ```text
-NeighborCreateSpec
-├── Legacy(PeerManagerNeighborConfig)
-└── PresenceAware(NeighborCreateIntent)
+Box<PresenceAwareNeighborCreate>
 ```
 
 The presence-aware form uses option/list/block shapes that map losslessly to a
 raw config `Neighbor`; it is not a partially resolved transport config. The
-same `NeighborCreateSpec` crosses both ownership boundaries:
+same boxed raw carrier crosses both ownership boundaries:
 
-1. `ConfigEvent::NeighborAdded` carries it to the config bridge.
+1. `ConfigEvent::PresenceAwareNeighborAdded` carries it to the config bridge.
 2. The bridge applies it to a cloned raw `Config`, runs `Config::validate`,
    and stages the exact candidate TOML.
-3. The PeerManager add command carries the same spec to the actor.
+3. `PeerManagerCommand::RuntimeCreatePeer` carries the same raw value to the
+   actor.
 4. PeerManager applies it to its actor-owned `current_config`, selects the raw
    neighbor, and invokes the existing resolver before spawning the session.
 5. Only after runtime apply succeeds does the already-staged config publish.
@@ -219,10 +218,9 @@ The existing stage-then-apply-then-commit and cancellation-shielding behavior
 does not change. A persistence, validation, or runtime failure creates neither
 a durable neighbor nor a live peer.
 
-The legacy form continues through today's conversion without reinterpretation.
-Internal startup, reconfigure, delete rollback, and tests that already carry a
-resolved `PeerManagerNeighborConfig` remain legacy unless a separate design
-explicitly moves them.
+Legacy `AddNeighbor`, startup, reconfigure, and delete rollback continue through
+their existing resolved `PeerManagerNeighborConfig` paths without entering this
+presence-aware carrier.
 
 ### Validation ordering
 

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeSet;
 
 use rustbgpd_api::peer_types::{
-    ConfigEvent, DynamicPeerBounceOutcome, DynamicRangeTarget, NeighborCreateSpec,
-    OutboundRefreshError, PeerKey, PeerLifecycleError, PeerManagerNeighborConfig,
+    ConfigEvent, DynamicPeerBounceOutcome, DynamicRangeTarget, OutboundRefreshError, PeerKey,
+    PeerLifecycleError, PeerManagerNeighborConfig, PresenceAwareNeighborCreate,
     SessionLifecycleEventType, SetGshutError,
 };
 use rustbgpd_rib::{RibCommandError, RibUpdate};
@@ -487,14 +487,9 @@ impl PeerManager {
 
     pub(super) async fn runtime_create_peer(
         &mut self,
-        spec: NeighborCreateSpec,
+        spec: Box<PresenceAwareNeighborCreate>,
     ) -> Result<(), PeerLifecycleError> {
-        let NeighborCreateSpec::PresenceAware(raw) = &spec else {
-            return Err(PeerLifecycleError::Invalid(
-                "runtime create requires a presence-aware neighbor spec".to_string(),
-            ));
-        };
-        let peer = PeerKey::new(raw.address, raw.interface.clone());
+        let peer = PeerKey::new(spec.address, spec.interface.clone());
         if self.peers.contains_key(&peer) {
             return Err(PeerLifecycleError::AlreadyExists(peer));
         }

--- a/src/peer_manager/notifications.rs
+++ b/src/peer_manager/notifications.rs
@@ -96,15 +96,6 @@ impl PeerManager {
     )]
     pub(super) async fn handle_session_notification(&mut self, notification: SessionNotification) {
         match notification {
-            SessionNotification::StateChanged {
-                session_id,
-                role,
-                peer_addr,
-                old,
-                new,
-            } => {
-                self.handle_state_changed_notification(session_id, role, peer_addr, None, old, new);
-            }
             SessionNotification::OpenReceived {
                 session_id,
                 role,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -17691,18 +17691,10 @@ async fn simultaneous_active_open_runs_inbound_candidate_before_primary_idle() {
     )
     .await;
 
-    let notification = loop {
-        let notification =
-            tokio::time::timeout(Duration::from_secs(2), mgr.session_notify_rx.recv())
-                .await
-                .expect("candidate should notify OpenReceived")
-                .expect("notification channel should stay open");
-        if matches!(notification, SessionNotification::StateChanged { .. }) {
-            mgr.handle_session_notification(notification).await;
-            continue;
-        }
-        break notification;
-    };
+    let notification = tokio::time::timeout(Duration::from_secs(2), mgr.session_notify_rx.recv())
+        .await
+        .expect("candidate should notify OpenReceived")
+        .expect("notification channel should stay open");
     match &notification {
         SessionNotification::OpenReceived {
             role,
@@ -17715,7 +17707,6 @@ async fn simultaneous_active_open_runs_inbound_candidate_before_primary_idle() {
             assert_eq!(*peer_asn, 65002);
         }
         other @ (SessionNotification::BackToIdle { .. }
-        | SessionNotification::StateChanged { .. }
         | SessionNotification::MaxPrefixExceeded { .. }) => {
             panic!("expected OpenReceived from candidate, got {other:?}");
         }
@@ -21706,7 +21697,7 @@ async fn presence_create_rejections_leave_no_disk_history_or_live_half_state() {
 }
 
 #[test]
-fn presence_create_policy_event_keeps_the_legacy_neighbor_sentinel() {
+fn presence_create_policy_event_keeps_the_neighbor_sentinel() {
     let raw = rustbgpd_api::peer_types::PresenceAwareNeighborCreate {
         address: "10.0.0.9".parse().unwrap(),
         interface: None,
@@ -21728,7 +21719,7 @@ fn presence_create_policy_event_keeps_the_legacy_neighbor_sentinel() {
         add_path: None,
     };
     let event = ConfigEvent::PresenceAwareNeighborAdded {
-        spec: rustbgpd_api::peer_types::NeighborCreateSpec::PresenceAware(Box::new(raw)),
+        spec: Box::new(raw),
         ack: None,
     };
     assert_eq!(

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -5,8 +5,8 @@ use std::net::IpAddr;
 use rustbgpd_api::peer_types::{
     AddPathDefinition, CatalogMutationError, ConfigEvent, FibTableSnapshot,
     NamedNeighborSetSnapshot, NamedPeerGroupSnapshot, NamedPolicyDefinition, NamedPolicySnapshot,
-    NeighborCreateSpec, NeighborSetDefinition, PeerGroupDefinition, PolicyAsPathPrependConfig,
-    PolicyChainAssignment, PolicyStatementDefinition, PresenceAwareNeighborCreate,
+    NeighborSetDefinition, PeerGroupDefinition, PolicyAsPathPrependConfig, PolicyChainAssignment,
+    PolicyStatementDefinition, PresenceAwareNeighborCreate,
 };
 
 use crate::config::{
@@ -438,20 +438,6 @@ pub(crate) fn catalog_config_error(error: ConfigError) -> CatalogMutationError {
     }
 }
 
-fn presence_aware_neighbor(spec: &NeighborCreateSpec) -> Result<Neighbor, ConfigError> {
-    let NeighborCreateSpec::PresenceAware(raw) = spec else {
-        let NeighborCreateSpec::Legacy(config) = spec else {
-            unreachable!()
-        };
-        return Err(ConfigError::InvalidNeighborConfig {
-            address: config.address.to_string(),
-            field: "runtime_create".to_string(),
-            reason: "presence-aware event requires a presence-aware spec".to_string(),
-        });
-    };
-    Ok(raw_neighbor(raw))
-}
-
 fn raw_neighbor(raw: &PresenceAwareNeighborCreate) -> Neighbor {
     let family_name = |(afi, safi): &(rustbgpd_wire::Afi, rustbgpd_wire::Safi)| match (afi, safi) {
         (rustbgpd_wire::Afi::Ipv4, rustbgpd_wire::Safi::Unicast) => "ipv4_unicast".to_string(),
@@ -656,7 +642,7 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
             }
         }
         ConfigEvent::PresenceAwareNeighborAdded { spec, .. } => {
-            let neighbor = presence_aware_neighbor(spec)?;
+            let neighbor = raw_neighbor(spec);
             if !config.neighbors.iter().any(|configured| {
                 configured.address == neighbor.address && configured.interface == neighbor.interface
             }) {


### PR DESCRIPTION
## Summary

- remove the obsolete lossless FSM StateChanged fallback while retaining the bounded lifecycle path and lossless collision/latch notifications
- replace the unused NeighborCreateSpec discriminator with the direct boxed presence-aware carrier across parsing, persistence, and actor ownership
- update ADR-0118 to describe the shipped single-carrier model

## Why

Every production PeerManager session already supplies the bounded lifecycle channel, and no current path constructs the legacy runtime-neighbor variant. Removing both internal compatibility branches tightens ownership boundaries without changing protobuf, configuration, stable-v1, persistence, or operator behavior.

## Verification

- cargo test -p rustbgpd-transport --test session_lifecycle --no-fail-fast
- cargo test -p rustbgpd-api neighbor_service --no-fail-fast
- cargo test -p rustbgpd presence_create --no-fail-fast
- cargo test --workspace --no-fail-fast
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo doc --workspace --no-deps
- python3 scripts/check-v1-stable-surface.py
- pre-push fmt/clippy/test/doc hooks

## Load-bearing proof

- restoring the lossless StateChanged fallback makes the real-FSM constructor-without-lifecycle test fail on a non-empty lossless lane
- suppressing bounded lifecycle emission makes the positive lifecycle test time out
- materializing default families during parsing fails the raw persistence-boundary assertion
- materializing defaults between persistence and actor dispatch fails exact carrier equality
- structural scan finds neither removed compatibility symbol