### PR TITLE
docs: align gRPC legacy sunset guidance

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -132,7 +132,8 @@ decisions for every RPC via structured `grpc_authz` logs and
 `[security.grpc].enforcement = "tier"` is enabled, the same runtime layer also
 enforces the authenticated principal's configured role ceiling before the
 handler runs; `"tier"` is the default since v0.24.0, and `"legacy"` is the
-supported opt-out.
+temporary migration mode. In Legacy, configured roles are audit context only
+and the listener's `max_tier` remains the authoritative authorization boundary.
 Forwarded calls emit result-aware labels such as `result="handler_ok"` or
 `result="handler_invalid_argument"` after the handler returns. Rejected calls use
 bounded pre-handler labels: `result="listener_tier_denied"` means the method was
@@ -166,6 +167,12 @@ default). The implicit default UDS listener is safe for local access under
 legacy mode, but tier mode requires an explicit
 `[global.telemetry.grpc_uds]` block with `principal` so requests can be mapped
 to a role.
+Explicit Legacy remains accepted today only for temporary migration; it emits
+a validation warning and fails `rustbgpd --check --strict`. The original
+startup deprecation warning shipped in v0.51.0 on 2026-07-11; validation and
+strict-check enforcement followed in v0.61.0. The two-minor/90-day
+compatibility floor is therefore approximately 2026-10-09. That floor is
+eligibility for a later removal decision, not a promised removal date.
 [`docs/SECURITY.md`](SECURITY.md) covers deployment hardening for this surface,
 and [ADR-0064](adr/0064-grpc-authorization.md) records the tier model itself and
 which of its slices remain open.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -613,12 +613,14 @@ on existing HTTP/2 connections use the new token; already-admitted streaming
 RPCs continue. Invalid or missing material rejects the whole credential reload.
 Changing the path or enabling/disabling token auth remains restart-required.
 
-**ADR-0064 audit principals:** `principal` gives the audit-only
-`grpc_authz` log line a stable operator-controlled identity. On UDS listeners
-it labels the listener identity established by filesystem permissions and/or
-the optional token. On TCP listeners it is accepted only when `token_file` is
-configured and native mTLS is not configured. Native mTLS listeners derive the
-audit principal from the peer certificate in ADR-0064 order: first `rustbgpd:`
+**ADR-0064 principals:** `principal` gives `grpc_authz` records a stable
+operator-controlled identity. Under the default tier enforcement it is also
+the identity looked up in `[security.grpc.roles]`; under legacy enforcement it
+is audit context only. On UDS listeners it labels the listener identity
+established by filesystem permissions and/or the optional token. On TCP
+listeners it is accepted only when `token_file` is configured and native mTLS
+is not configured. Native mTLS listeners derive the audit principal from the
+peer certificate in ADR-0064 order: first `rustbgpd:`
 URI SAN, then email SAN, then Subject CN. If a validated client certificate has
 none of those fields, or if the selected value is too long or contains embedded
 control characters, the request remains allowed in legacy mode and the audit
@@ -629,13 +631,14 @@ principal falls back to `mtls-unresolved`.
 ADR-0064 per-method authorization defaults to `"tier"` since v0.24.0. Tier
 mode enforces `[security.grpc.roles]` for the authenticated principal before
 the handler runs, in addition to listener `max_tier` caps; upgrading without a
-`[security.grpc.roles]` block fails validation at startup. Legacy mode
-(`enforcement = "legacy"`) remains a supported opt-out that preserves the prior
-listener-wide behavior.
+`[security.grpc.roles]` block fails validation at startup. Legacy mode remains
+accepted today only as a temporary migration mode: role mappings are audit
+context only and the listener's `max_tier` is the authoritative authorization
+boundary.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `enforcement` | string | no | `"tier"` | ADR-0064 enforcement mode (default since v0.24.0). `"tier"` enables per-principal role enforcement in addition to listener `max_tier` caps. `"legacy"` is the opt-out that preserves prior listener `access_mode` behavior |
+| `enforcement` | string | no | `"tier"` | ADR-0064 enforcement mode (default since v0.24.0). `"tier"` enables per-principal role enforcement in addition to listener `max_tier` caps. `"legacy"` is the temporary migration mode in which roles are audit-only and the listener cap authorizes calls |
 
 `[security.grpc.roles]` maps an authenticated principal string to one of the
 built-in roles:
@@ -667,6 +670,14 @@ at startup; the error message points at this section and at the
 `enforcement = "legacy"` escape hatch. Already-staged operators see
 no behavior change.
 
+Explicit `enforcement = "legacy"` emits a validation warning, and
+`rustbgpd --check --strict` rejects any config that retains it. The original
+startup deprecation warning shipped in v0.51.0 on 2026-07-11; validation and
+strict-check enforcement followed in v0.61.0. The two-minor/90-day
+compatibility floor is therefore approximately 2026-10-09; reaching that floor
+makes Legacy eligible for a later removal decision, but does not promise
+removal on that date.
+
 The safe migration sequence (run against a pre-upgrade daemon if
 possible):
 
@@ -677,13 +688,15 @@ possible):
 3. For remote TCP, prefer native mTLS so the principal is derived from the
    client certificate; otherwise use `token_file` plus a non-secret
    `principal` label.
-4. Set `enforcement = "legacy"` while staging labels and roles, then run
-   `rustbgpd --check` against the candidate TOML.
+4. Set `enforcement = "legacy"` only while staging labels and roles, then run
+   `rustbgpd --check` against the candidate TOML. This intentionally warns and
+   cannot pass `--check --strict` until the explicit Legacy setting is removed.
 5. Remove the explicit `enforcement = "legacy"` (or change it to
    `"tier"`) and monitor `grpc_authz` logs/metrics for
    `principal_unmapped` and `role_tier_denied`.
-6. If you need to preserve the pre-v0.24.0 behavior indefinitely, set
-   `enforcement = "legacy"` explicitly and keep it there.
+6. If migration cannot finish in one change window, keep explicit Legacy as a
+   documented, time-bounded exception and retain the narrowest practical
+   listener `max_tier` until Tier can be restored.
 
 ```toml
 # The v0.24.0 default — equivalent to omitting [security.grpc]
@@ -698,7 +711,7 @@ enforcement = "tier"
 ```
 
 ```toml
-# Pre-v0.24.0 behavior. Explicit opt-out preserved indefinitely.
+# Temporary migration mode for pre-v0.24.0 behavior; warns under --check.
 [security.grpc]
 enforcement = "legacy"
 ```

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -258,6 +258,8 @@ cargo with the failing `ip netns add` diagnostic.
 ### Token auth smoke
 
 ```bash
+set -euo pipefail
+
 echo "test-token-value" > /tmp/rustbgpd-token
 cat > /tmp/rustbgpd-auth-test.toml <<'EOF'
 [global]
@@ -273,26 +275,48 @@ log_format = "json"
 [global.telemetry.grpc_uds]
 path = "/tmp/rustbgpd-auth/grpc.sock"
 token_file = "/tmp/rustbgpd-token"
+principal = "release-smoke-observer"
 
-# This smoke isolates bearer-token authn; legacy enforcement keeps it
-# independent of tier role config (tier additionally needs grpc_uds.principal
-# plus a matching [security.grpc.roles] entry).
-[security.grpc]
-enforcement = "legacy"
+# Omit explicit enforcement so the smoke exercises the Tier default.
+[security.grpc.roles]
+"release-smoke-observer" = "observer"
 EOF
 
+cleanup_grpc_auth_smoke() {
+  if [ -n "${DAEMON_PID:-}" ]; then
+    kill "$DAEMON_PID" 2>/dev/null || true
+    wait "$DAEMON_PID" 2>/dev/null || true
+  fi
+  rm -rf /tmp/rustbgpd-auth /tmp/rustbgpd-token \
+    /tmp/rustbgpd-auth-test.toml /tmp/rustbgpd-auth-unauthenticated.log \
+    /tmp/rustbgpd-auth-mrt-denied.log
+}
+trap cleanup_grpc_auth_smoke EXIT
+
+./target/release/rustbgpd --check --strict /tmp/rustbgpd-auth-test.toml
 ./target/release/rustbgpd /tmp/rustbgpd-auth-test.toml &
 DAEMON_PID=$!
 sleep 2
 
-# Without token — should fail
-./target/release/rbgp -s unix:///tmp/rustbgpd-auth/grpc.sock health 2>&1 | grep -i "error\|unauthenticated"
+# Without token — must fail authentication.
+if ./target/release/rbgp -s unix:///tmp/rustbgpd-auth/grpc.sock health \
+  >/tmp/rustbgpd-auth-unauthenticated.log 2>&1; then
+  echo "unauthenticated health unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -qi "unauthenticated" /tmp/rustbgpd-auth-unauthenticated.log
 
-# With token — should succeed
+# With token — health is within the observer role and must succeed.
 ./target/release/rbgp -s unix:///tmp/rustbgpd-auth/grpc.sock --token-file /tmp/rustbgpd-token health
 
-kill $DAEMON_PID
-rm -rf /tmp/rustbgpd-auth /tmp/rustbgpd-token /tmp/rustbgpd-auth-test.toml
+# The same authenticated observer must be denied the operator-only MRT trigger.
+if ./target/release/rbgp -s unix:///tmp/rustbgpd-auth/grpc.sock \
+  --token-file /tmp/rustbgpd-token mrt-dump \
+  >/tmp/rustbgpd-auth-mrt-denied.log 2>&1; then
+  echo "observer mrt-dump unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -qi "permission denied" /tmp/rustbgpd-auth-mrt-denied.log
 ```
 
 ### gRPC authorization audit smoke
@@ -311,6 +335,10 @@ confirm both audit surfaces move:
 # Metrics should expose bounded-label decision counters, with no method path or
 # principal labels:
 curl -fsS http://127.0.0.1:19179/metrics | grep bgp_grpc_authz_decisions_total
+
+# Cleanup only after the audit smoke has consumed the running daemon.
+cleanup_grpc_auth_smoke
+trap - EXIT
 ```
 
 For external audit prep, verify the published inventory is still fenced to the

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -66,8 +66,9 @@ Preferred posture:
   client certificate (`rustbgpd:` URI SAN, then email SAN, then Subject CN);
   unsafe or overlong cert values fall back to `mtls-unresolved` rather than
   entering structured logs verbatim.
-  In legacy mode these roles are audit context only; in tier mode they
-  authorize or deny calls by method tier.
+  In the temporary Legacy migration mode these roles are audit context only
+  and listener `max_tier` is authoritative; in Tier mode they authorize or
+  deny calls by method tier.
 - Listener `max_tier` caps are enforced now and should be used to bound remote
   TCP listeners to the smallest required method tier. `access_mode =
   "read_only"` remains a compatibility ceiling equivalent to
@@ -446,7 +447,13 @@ the roadmap:
 - Authorization defaults to per-principal tier enforcement
   (`security.grpc.enforcement = "tier"`, default since v0.24.0) layered on
   listener `access_mode` (`read_only` vs `read_write`) and `max_tier` caps.
-  `enforcement = "legacy"` remains a supported opt-out. Configs that rely on the
+  `enforcement = "legacy"` remains accepted today only as a temporary
+  migration mode: roles are audit-only, the listener cap authorizes calls,
+  validation warns, and `--check --strict` fails. The original startup
+  deprecation warning shipped in v0.51.0 on 2026-07-11; validation and
+  strict-check enforcement followed in v0.61.0. The two-minor/90-day floor is
+  therefore approximately 2026-10-09. That is only eligibility for a later
+  removal decision, not a promised removal date. Configs that rely on the
   implicit UDS listener must declare `[global.telemetry.grpc_uds]` with a
   `principal` to run under tier enforcement.
 - Per-principal request-rate and stream-count budgets are not implemented in

--- a/docs/adr/0064-threat-model.md
+++ b/docs/adr/0064-threat-model.md
@@ -22,9 +22,10 @@ credential reaches the entire read-write surface.
 
 ## Scope and assumptions
 
-- `security.grpc.enforcement = "tier"` is the default. `legacy` remains an
-  explicit compatibility opt-out and deliberately does not get the principal
-  role check; listener caps still apply.
+- `security.grpc.enforcement = "tier"` is the default since v0.24.0. `legacy`
+  remains accepted today only as a temporary migration mode and deliberately
+  does not get the principal role check: roles are audit context only and the
+  listener's `max_tier` is authoritative.
 - The daemon is deployed on a management network. Network reachability,
   certificate issuance, bearer-token distribution, UDS permissions, and log
   collection are operator responsibilities outside this process.
@@ -122,7 +123,7 @@ flowchart LR
 | TM-005 | Authorization or credential material changes while accepted calls, streams, or TLS connections remain live. | Listener shape, auth mode, principal, roles, and access settings are restart-required and remain pinned to the startup generation. SIGHUP rotates bearer and mTLS material at unchanged paths; new bearer RPCs use the new token generation and new TLS connections use the new certificate generation. | Admitted streams continue, and an existing mTLS connection remains accepted and can make further calls. **Medium**: immediate role revocation requires restart; immediate mTLS revocation also requires ending existing connections. Client deadlines can bound cooperative streams but are not forced revocation. |
 | TM-006 | An unauthenticated network-reachable caller floods bearer requests, TLS connections, or malformed paths, consuming request processing and audit/log capacity. | Invalid bearer requests fail authentication; mTLS handshakes have concurrency and time bounds; unknown paths are `operator_only`. | There is no general connection or request rate limiter, and bearer failures still emit `grpc_authz` records. **Medium** when a listener is broadly reachable; keep it on a restricted management network and enforce upstream connection/request limits. |
 | TM-007 | A new RPC or generated route evades a low-risk classification and is exposed through a less restrictive listener. | The static matrix is checked against both protobuf inputs and the JSON/Markdown exports; unknown paths fail closed as `operator_only`. | Classification correctness still depends on review of a new method's semantics. **Low**: the structural fence makes omission fail closed, but a wrongly chosen known tier remains a review risk. |
-| TM-008 | An operator enables the supported `legacy` compatibility mode and assumes configured roles still constrain calls. Any authenticated identity can instead use every method permitted by that listener's `max_tier`. | `legacy` is an explicit non-default opt-out; validation and `--check` warn about the weaker posture; listener caps and authentication remain enforced. | Role mappings are audit context only in this mode. **Medium**: activation is deliberate, but a broad listener can give one accepted credential the full capped surface. Keep `legacy` time-bounded for migration and set a deliberately narrow `max_tier`. |
+| TM-008 | An operator enables the temporary `legacy` migration mode and assumes configured roles still constrain calls. Any authenticated identity can instead use every method permitted by that listener's `max_tier`. | Legacy is explicit and non-default; validation warns, `--check --strict` fails, and listener caps and authentication remain enforced. | Role mappings are audit context only in this mode. **Medium**: activation is deliberate, but a broad listener can give one accepted credential the full capped surface. Keep Legacy time-bounded for migration and set a deliberately narrow `max_tier`. The original startup warning shipped in v0.51.0 on 2026-07-11; validation and strict-check enforcement followed in v0.61.0. The approximately 2026-10-09 two-minor/90-day floor creates only eligibility for a later removal decision, not a promised date. |
 
 ## Operational mitigations and detection
 
@@ -131,7 +132,7 @@ flowchart LR
   actions.
 - Treat `[security.grpc.roles]`, listener `principal`, mTLS client issuance,
   bearer-token files, and UDS permissions as privileged configuration. Do not
-  use `legacy` except as a documented migration exception.
+  use Legacy except as a documented, time-bounded migration exception.
 - Collect and protect `grpc_authz` structured records; alert on
   `listener_tier_denied`, `principal_unmapped`, `role_tier_denied`,
   both `authn_failed` and `handler_unauthenticated` authentication failures,
@@ -175,6 +176,8 @@ red-proof is **N/A**. The factual baseline was checked directly against:
 
 The key review rule is therefore explicit: under the default `tier` mode, a
 valid accepted management-plane identity can use only the method tiers granted
-by both its role and listener. Under the supported `legacy` opt-out, the
+by both its role and listener. Under the temporary Legacy migration mode, the
 listener ceiling is the authorization boundary and role mappings are audit
-context only. Neither baseline assumes an audit-only listener-cap layer.
+context only; explicit Legacy warns and fails `--check --strict`. Neither
+baseline assumes an audit-only listener-cap layer. These current-status notes
+do not alter ADR-0064's historical decision record.

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -29,9 +29,14 @@ this inventory before the handler runs, and applies two checks in order:
    reaches `mutating`, `operator` reaches `operator_only`. A principal
    with no role entry is denied (`principal_unmapped`); a principal whose
    role sits below the method tier is denied (`role_tier_denied`).
-   `enforcement = "legacy"` remains a supported opt-out in which roles
-   are audit context only and the listener ceiling is the sole tier
-   check.
+   `enforcement = "legacy"` remains accepted today only as a temporary
+   migration mode in which roles are audit context only and the listener
+   ceiling is the authoritative tier check. Explicit Legacy warns during
+   validation and fails `rustbgpd --check --strict`. The original startup
+   deprecation warning shipped in v0.51.0 on 2026-07-11; validation and
+   strict-check enforcement followed in v0.61.0. The resulting two-minor/90-day
+   floor is approximately 2026-10-09 and establishes only eligibility for a
+   later removal decision, not a promised removal date.
 
 Principals come from the listener's authenticated identity: native mTLS
 listeners derive them from the validated client certificate (`rustbgpd:`
@@ -303,7 +308,11 @@ specific method if the model warrants it.
    legacy-permissive but can opt into per-tier enforcement) so the
    cut-over is not a breaking change for everyone on the same
    release. That opt-in path shipped as slice-5a, and the production
-   default flipped to `tier` in v0.24.0 (legacy is now the opt-out).
+   default flipped to `tier` in v0.24.0 (Legacy remains accepted today only as
+   the temporary migration mode).
+   Current status: Legacy is retained only as the temporary, warning-bearing
+   migration mode described above; this historical migration decision does not
+   promise that the compatibility mode remains indefinitely.
 7. **Audit logging.** The runtime now emits tier-decision logs and the
    low-cardinality `bgp_grpc_authz_decisions_total` metric for every RPC;
    listener `max_tier` denials use the bounded


### PR DESCRIPTION
## Summary

- align the API, configuration, security, threat-model, and method-inventory docs with the shipped Tier default and temporary Legacy migration contract
- distinguish the v0.51.0 startup deprecation warning from the v0.61.0 validation and strict-check enforcement, using the canonical approximately 2026-10-09 eligibility floor without promising removal
- make the release checklist exercise the default Tier mode with an authenticated observer, an operator-only denial, audit metrics, and cleanup after the dependent checks

## Verification

- `cargo test -p rustbgpd-api authz --no-fail-fast` (38 passed)
- `cargo test -p rustbgpd --test check_strict --no-fail-fast` (11 passed)
- `cargo test -p rustbgpd grpc_security --no-fail-fast` (13 passed)
- `python3 scripts/check-v1-stable-surface.py`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- `cargo doc --workspace --no-deps`
- release Tier smoke: strict config accepted; unauthenticated health denied; authenticated observer health accepted; observer MRT trigger denied; expected authn/authz metrics observed before cleanup

## Load-bearing proof

Each checklist dependency was removed or inverted in isolation:

- explicit Legacy makes strict preflight fail
- removing the listener principal makes strict preflight fail
- removing the observer role makes strict preflight fail
- removing the client token makes authenticated health fail
- removing the server token makes unauthenticated health unexpectedly succeed
- granting operator makes the MRT request reach the handler instead of returning the required authorization denial

The final diff is six documentation files and 136 gross lines.