### PR TITLE
authz: name the principal and the fix in denials; doctor authz checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Actionable authorization denials and `rbgp doctor` authz triage.** gRPC
+  PERMISSION_DENIED messages now name the principal, its current role (or
+  that it is unmapped), the required tier, and the exact
+  `[security.grpc.roles]` / listener `max_tier` config change (restart
+  required) that would permit the call; `rbgp` appends a one-line hint
+  pointing at the config surface. `rbgp doctor` gains a `daemon.authz.*`
+  check family: read-RPC reachability with denial as a first-class
+  diagnosed FAIL, the client-side connection identity shape, and the
+  daemon's enforcement mode from the effective config (skipped against
+  daemons that do not expose it).
+
 - **Config-history provenance schema and rendering.** `ListConfigHistory` and
   `rbgp config history` now expose an additive config-source digest over the
   normalized-TOML digest plus the canonical accepted rpol/dataset source roster,

--- a/crates/api/src/authz_runtime/decision.rs
+++ b/crates/api/src/authz_runtime/decision.rs
@@ -23,18 +23,40 @@ impl RoleDenial {
         }
     }
 
-    pub(super) fn status(self, tier: AuthTier, path: &str) -> Status {
+    pub(super) fn status(self, principal: &str, tier: AuthTier, path: &str) -> Status {
+        // The principal is the client-supplied identity label (listener
+        // `principal`, mTLS SAN, ...) and is safe to echo; never include
+        // token or certificate material here.
+        let required = minimal_sufficient_role(tier);
         match self {
             Self::PrincipalUnmapped => Status::permission_denied(format!(
-                "principal is not mapped to a gRPC role for {tier} RPC {path}",
-                tier = tier.as_str()
+                "principal \"{principal}\" has no [security.grpc.roles] entry; \
+                 {path} is a {tier} RPC requiring at least role {required} — \
+                 add \"{principal}\" = \"{required}\" under [security.grpc.roles] \
+                 in the daemon config and restart the daemon",
+                tier = tier.as_str(),
+                required = required.as_str()
             )),
             Self::RoleTierDenied { role } => Status::permission_denied(format!(
-                "principal role {role} does not permit {tier} RPC {path}",
+                "principal \"{principal}\" has role {role}; \
+                 {path} is a {tier} RPC requiring at least role {required} — \
+                 raise the role in [security.grpc.roles] \
+                 in the daemon config and restart the daemon",
                 role = role.as_str(),
-                tier = tier.as_str()
+                tier = tier.as_str(),
+                required = required.as_str()
             )),
         }
+    }
+}
+
+/// Smallest role whose ceiling reaches `tier`, used to phrase the
+/// exact fix in denial messages.
+const fn minimal_sufficient_role(tier: AuthTier) -> PrincipalRole {
+    match tier {
+        AuthTier::Read | AuthTier::SensitiveRead => PrincipalRole::Observer,
+        AuthTier::Mutating => PrincipalRole::Automation,
+        AuthTier::OperatorOnly => PrincipalRole::Operator,
     }
 }
 

--- a/crates/api/src/authz_runtime/layer.rs
+++ b/crates/api/src/authz_runtime/layer.rs
@@ -103,7 +103,10 @@ where
             let max_tier = self.context.max_tier.as_str();
             let tier = decision.tier.as_str();
             let response = Status::permission_denied(format!(
-                "listener max_tier {max_tier} does not permit {tier} RPC {path}"
+                "listener max_tier {max_tier} does not permit {tier} RPC {path}; \
+                 this cap is an intentional per-listener ceiling — raise max_tier \
+                 on this listener in the daemon config and restart the daemon, \
+                 or use a listener without the cap"
             ))
             .into_http::<Body>();
             return Box::pin(async move { Ok(response) });
@@ -134,7 +137,9 @@ where
                 denial.result_label(),
                 None,
             );
-            let response = denial.status(decision.tier, &path).into_http::<Body>();
+            let response = denial
+                .status(principal.as_ref(), decision.tier, &path)
+                .into_http::<Body>();
             return Box::pin(async move { Ok(response) });
         }
         let audit_handle = GrpcAuditHandle::default();

--- a/crates/api/src/authz_runtime/tests.rs
+++ b/crates/api/src/authz_runtime/tests.rs
@@ -654,6 +654,118 @@ async fn listener_cap_remains_stricter_than_operator_role() {
     assert!(!text.contains("result=\"role_tier_denied\""));
 }
 
+// The three denial messages are an operator-facing contract: each must
+// name the principal in play and the smallest sufficient fix. Dropping
+// the fix clause (the "add ... and restart" / "raise ..." tail) from
+// any message turns the matching assertion red.
+
+#[tokio::test]
+async fn unmapped_denial_names_principal_and_roles_entry_fix() {
+    let metrics = BgpMetrics::new();
+    let context = GrpcAuthAuditContext::new(
+        "unix:///run/rustbgpd/grpc.sock",
+        "read_write",
+        AuthTier::OperatorOnly,
+        GrpcAuthnKind::Uds,
+        "ci-bot",
+    )
+    .with_role_enforcement(AuthEnforcement::Tier, roles(&[]));
+    let layer = GrpcAuthzLayer::new(context, metrics);
+    let mut service = layer.layer(EchoService);
+    let request = Request::builder()
+        .uri("/rustbgpd.v1.ConfigService/DiffRuntimeConfig")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = service.call(request).await.unwrap();
+    let status = tonic::Status::from_header_map(response.headers()).unwrap();
+    assert_eq!(status.code(), tonic::Code::PermissionDenied);
+    let message = status.message();
+    assert!(
+        message.contains("principal \"ci-bot\" has no [security.grpc.roles] entry"),
+        "message must name the unmapped principal: {message}"
+    );
+    assert!(
+        message.contains(
+            "add \"ci-bot\" = \"observer\" under [security.grpc.roles] \
+             in the daemon config and restart the daemon"
+        ),
+        "message must carry the smallest sufficient fix: {message}"
+    );
+}
+
+#[tokio::test]
+async fn role_tier_denial_names_principal_current_and_required_role() {
+    let metrics = BgpMetrics::new();
+    let context = tier_test_context(
+        "tcp://127.0.0.1:50051",
+        "read_write",
+        AuthTier::OperatorOnly,
+        GrpcAuthnKind::BearerToken,
+        "ci-bot",
+        PrincipalRole::Observer,
+    );
+    let layer = GrpcAuthzLayer::new(context, metrics);
+    let mut service = layer.layer(EchoService);
+    let request = Request::builder()
+        .uri("/rustbgpd.v1.NeighborService/AddNeighbor")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = service.call(request).await.unwrap();
+    let status = tonic::Status::from_header_map(response.headers()).unwrap();
+    assert_eq!(status.code(), tonic::Code::PermissionDenied);
+    let message = status.message();
+    assert!(
+        message.contains("principal \"ci-bot\" has role observer"),
+        "message must name the principal and its current role: {message}"
+    );
+    assert!(
+        message.contains(
+            "is a mutating RPC requiring at least role automation — \
+             raise the role in [security.grpc.roles] \
+             in the daemon config and restart the daemon"
+        ),
+        "message must carry the smallest sufficient fix: {message}"
+    );
+}
+
+#[tokio::test]
+async fn listener_cap_denial_names_cap_and_listener_fix() {
+    let metrics = BgpMetrics::new();
+    let context = tier_test_context(
+        "tcp://127.0.0.1:50051",
+        "read_write",
+        AuthTier::SensitiveRead,
+        GrpcAuthnKind::BearerToken,
+        "ci-bot",
+        PrincipalRole::Operator,
+    );
+    let layer = GrpcAuthzLayer::new(context, metrics);
+    let mut service = layer.layer(EchoService);
+    let request = Request::builder()
+        .uri("/rustbgpd.v1.NeighborService/AddNeighbor")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = service.call(request).await.unwrap();
+    let status = tonic::Status::from_header_map(response.headers()).unwrap();
+    assert_eq!(status.code(), tonic::Code::PermissionDenied);
+    let message = status.message();
+    assert!(
+        message.contains("listener max_tier sensitive_read does not permit mutating RPC"),
+        "message must name the listener cap: {message}"
+    );
+    assert!(
+        message.contains(
+            "this cap is an intentional per-listener ceiling — raise max_tier \
+             on this listener in the daemon config and restart the daemon, \
+             or use a listener without the cap"
+        ),
+        "message must carry the smallest sufficient fix: {message}"
+    );
+}
+
 #[test]
 fn audit_context_debug_redacts_bearer_secret() {
     let context = GrpcAuthAuditContext::new(

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -1466,6 +1466,103 @@ fn config_freshness_check(
     }
 }
 
+/// `daemon.authz.reachable`: the `GetHealth` probe outcome viewed through
+/// an authorization lens. `GetHealth` is the least-privileged RPC doctor
+/// issues (`sensitive_read`, within every role's ceiling), so a
+/// PERMISSION_DENIED there means this connection's identity cannot use the
+/// gRPC surface at all, and the check surfaces the daemon's actionable
+/// denial message as a first-class FAIL instead of a generic RPC error.
+/// Transport/handler failures stay owned by `daemon.healthy` (skip).
+fn authz_reachable_check(health_error: Option<&tonic::Status>) -> Option<Check> {
+    let name = "daemon.authz.reachable".to_string();
+    match health_error {
+        None => Some(Check {
+            name,
+            status: CheckStatus::Ok,
+            detail: "GetHealth (sensitive_read) permitted on this connection".to_string(),
+        }),
+        Some(status) if status.code() == tonic::Code::PermissionDenied => Some(Check {
+            name,
+            status: CheckStatus::Fail,
+            detail: format!(
+                "daemon denied GetHealth (sensitive_read): {}",
+                status.message()
+            ),
+        }),
+        Some(status) if status.code() == tonic::Code::Unauthenticated => Some(Check {
+            name,
+            status: CheckStatus::Fail,
+            detail: format!(
+                "daemon rejected this connection's credentials on GetHealth: {}",
+                status.message()
+            ),
+        }),
+        Some(_) => None,
+    }
+}
+
+/// `daemon.authz.identity`: what this connection looks like from the
+/// client side. The daemon does not expose the resolved principal/role
+/// over any RPC, so the check reports the transport and credential shape
+/// it can prove locally and says so honestly; the daemon's `grpc_authz`
+/// log records the authoritative per-request mapping.
+fn authz_identity_check(daemon_address: &str, token_file_configured: bool) -> Check {
+    let transport = if daemon_address.starts_with("unix://") {
+        "a unix socket"
+    } else if token_file_configured {
+        "TCP with a bearer token"
+    } else {
+        "TCP without a bearer token"
+    };
+    Check {
+        name: "daemon.authz.identity".to_string(),
+        status: CheckStatus::Ok,
+        detail: format!(
+            "connected via {transport}; the daemon assigns the principal from its listener \
+             config and does not expose the resolved principal/role over RPC — its \
+             grpc_authz log records the authoritative mapping"
+        ),
+    }
+}
+
+/// `daemon.authz.enforcement`: enforcement mode as already exposed by the
+/// daemon's own redacted effective-config dump. An older daemon whose dump
+/// lacks `[security.grpc]` yields `None` (check skipped), never a FAIL.
+fn authz_enforcement_check(effective_toml: &str) -> Option<Check> {
+    let value: toml::Value = toml::from_str(effective_toml).ok()?;
+    let grpc = value.get("security")?.get("grpc")?;
+    let enforcement = grpc.get("enforcement")?.as_str()?;
+    let mapped_roles = grpc
+        .get("roles")
+        .and_then(toml::Value::as_table)
+        .map_or(0, toml::map::Map::len);
+    let (status, detail) = match enforcement {
+        "tier" => (
+            CheckStatus::Ok,
+            format!(
+                "per-principal tier enforcement is active \
+                 ({mapped_roles} principal(s) mapped in [security.grpc.roles])"
+            ),
+        ),
+        "legacy" => (
+            CheckStatus::Warn,
+            "enforcement = \"legacy\": principal roles are audit-only and the listener \
+             max_tier authorizes calls; migrate to enforcement = \"tier\" \
+             (see docs/CONFIGURATION.md)"
+                .to_string(),
+        ),
+        other => (
+            CheckStatus::Warn,
+            format!("unrecognized [security.grpc] enforcement mode \"{other}\""),
+        ),
+    };
+    Some(Check {
+        name: "daemon.authz.enforcement".to_string(),
+        status,
+        detail,
+    })
+}
+
 pub(crate) async fn run(
     connection: Result<Connection, CliError>,
     opts: &DoctorOptions<'_>,
@@ -1511,8 +1608,16 @@ pub(crate) async fn run(
                 connection.interceptor(),
             );
 
-            // system/health.json + the healthy check.
-            match control.get_health(HealthRequest {}).await {
+            // system/health.json + the healthy check. The same probe outcome
+            // feeds the daemon.authz.* triage: a PERMISSION_DENIED here is an
+            // authorization finding, not a health one.
+            let health_result = control.get_health(HealthRequest {}).await;
+            if let Some(check) = authz_reachable_check(health_result.as_ref().err()) {
+                reporter.record(check.name, check.status, check.detail);
+            }
+            let identity = authz_identity_check(opts.daemon_address, opts.token_file_configured);
+            reporter.record(identity.name, identity.status, identity.detail);
+            match health_result {
                 Ok(resp) => {
                     let health = resp.into_inner();
                     if !health.daemon_version.is_empty() {
@@ -1610,6 +1715,9 @@ pub(crate) async fn run(
                         !deploy_targets(&toml_text).rpki_caches.is_empty(),
                         metrics_text.as_deref(),
                     ) {
+                        reporter.record(check.name, check.status, check.detail);
+                    }
+                    if let Some(check) = authz_enforcement_check(&toml_text) {
                         reporter.record(check.name, check.status, check.detail);
                     }
                     state_dir = parse_state_dir(&toml_text);
@@ -2799,6 +2907,65 @@ tcp_ao = { key = "<redacted>", send_id = 1, recv_id = 2, algorithm = "hmac(sha25
         assert_eq!(parse_state_dir(toml), Some("/tmp/x".to_string()));
         assert_eq!(parse_state_dir("[global]\nasn = 65000\n"), None);
         assert_eq!(parse_state_dir("not toml ["), None);
+    }
+
+    #[test]
+    fn authz_reachable_maps_denial_to_fail_with_server_message() {
+        let ok = authz_reachable_check(None).unwrap();
+        assert_eq!(ok.name, "daemon.authz.reachable");
+        assert_eq!(ok.status, CheckStatus::Ok);
+
+        let denied = tonic::Status::permission_denied(
+            "principal \"ci-bot\" has no [security.grpc.roles] entry",
+        );
+        let check = authz_reachable_check(Some(&denied)).unwrap();
+        assert_eq!(check.status, CheckStatus::Fail);
+        assert!(check.detail.contains("principal \"ci-bot\""));
+
+        let unauthenticated = tonic::Status::unauthenticated("invalid bearer token");
+        let check = authz_reachable_check(Some(&unauthenticated)).unwrap();
+        assert_eq!(check.status, CheckStatus::Fail);
+        assert!(check.detail.contains("invalid bearer token"));
+
+        // Transport/handler failures are daemon.healthy's finding.
+        assert!(authz_reachable_check(Some(&tonic::Status::internal("boom"))).is_none());
+    }
+
+    #[test]
+    fn authz_identity_reports_transport_and_names_the_limitation() {
+        let uds = authz_identity_check("unix:///run/rustbgpd/grpc.sock", false);
+        assert_eq!(uds.name, "daemon.authz.identity");
+        assert_eq!(uds.status, CheckStatus::Ok);
+        assert!(uds.detail.contains("unix socket"));
+        assert!(
+            uds.detail
+                .contains("not expose the resolved principal/role")
+        );
+
+        let tcp_token = authz_identity_check("127.0.0.1:50051", true);
+        assert!(tcp_token.detail.contains("TCP with a bearer token"));
+
+        let tcp_plain = authz_identity_check("127.0.0.1:50051", false);
+        assert!(tcp_plain.detail.contains("TCP without a bearer token"));
+    }
+
+    #[test]
+    fn authz_enforcement_reads_effective_config_and_skips_when_absent() {
+        let tier = "[security.grpc]\nenforcement = \"tier\"\n\
+                    [security.grpc.roles]\nadmin = \"operator\"\n";
+        let check = authz_enforcement_check(tier).unwrap();
+        assert_eq!(check.name, "daemon.authz.enforcement");
+        assert_eq!(check.status, CheckStatus::Ok);
+        assert!(check.detail.contains("1 principal(s) mapped"));
+
+        let legacy = "[security.grpc]\nenforcement = \"legacy\"\n";
+        let check = authz_enforcement_check(legacy).unwrap();
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.detail.contains("audit-only"));
+
+        // Older daemons without the section in the dump: skip, never FAIL.
+        assert!(authz_enforcement_check("[global]\nasn = 65000\n").is_none());
+        assert!(authz_enforcement_check("not toml [").is_none());
     }
 
     #[test]

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -53,7 +53,17 @@ impl From<tonic::Status> for CliError {
             tonic::Code::NotFound => "not found",
             tonic::Code::InvalidArgument => "invalid argument",
             tonic::Code::FailedPrecondition => "precondition failed",
-            tonic::Code::PermissionDenied => "permission denied",
+            // Authorization denials carry the daemon's actionable message
+            // (principal, role, and the exact config fix); the hint adds
+            // only where that surface lives and how changes take effect.
+            tonic::Code::PermissionDenied => {
+                return CliError::Rpc(format!(
+                    "permission denied: {}\n  \
+                     hint: gRPC authorization is [security.grpc] daemon config; changes need a \
+                     daemon restart, not a reload — see docs/CONFIGURATION.md",
+                    s.message()
+                ));
+            }
             tonic::Code::Unauthenticated => "unauthenticated",
             tonic::Code::AlreadyExists => "already exists",
             tonic::Code::ResourceExhausted => "resource exhausted",
@@ -147,11 +157,13 @@ mod tests {
     }
 
     #[test]
-    fn permission_denied_gets_short_prefix() {
+    fn permission_denied_keeps_server_message_and_adds_config_hint() {
         let err = CliError::from(Status::permission_denied("token lacks write scope"));
         assert_eq!(
             err.to_string(),
-            "permission denied: token lacks write scope"
+            "permission denied: token lacks write scope\n  \
+             hint: gRPC authorization is [security.grpc] daemon config; changes need a \
+             daemon restart, not a reload — see docs/CONFIGURATION.md"
         );
     }
 


### PR DESCRIPTION
## Summary

Part of the authz-UX program (LAN-850, WP4): a denied operator should learn who they are to the daemon, why the call was denied, and the exact config change that fixes it — without reading source.

### Daemon-side denial messages (`crates/api/src/authz_runtime/`)
All three PERMISSION_DENIED messages now name the principal, its current role (or that it is unmapped), the required tier, and the smallest sufficient fix, noting restart-only semantics:

- unmapped: `principal "ci-bot" has no [security.grpc.roles] entry; <path> is a <tier> RPC requiring at least role <role> — add "ci-bot" = "<role>" under [security.grpc.roles] in the daemon config and restart the daemon`
- insufficient role: `principal "ci-bot" has role observer; <path> is a mutating RPC requiring at least role automation — raise the role in [security.grpc.roles] in the daemon config and restart the daemon`
- listener cap: `listener max_tier <cap> does not permit <tier> RPC <path>; this cap is an intentional per-listener ceiling — raise max_tier on this listener in the daemon config and restart the daemon, or use a listener without the cap`

The principal label is client-supplied identity and safe to echo; no token or certificate material enters any message. Denial semantics are unchanged — same requests denied, same codes, same audit result labels and metrics; message content only.

### `rbgp` hint line (`crates/cli/src/error.rs`)
Every PERMISSION_DENIED renders the server message plus one hint line pointing at the `[security.grpc]` config surface, restart (not reload) semantics, and `docs/CONFIGURATION.md`.

### `rbgp doctor` authz check family (`crates/cli/src/commands/doctor.rs`)
- `daemon.authz.reachable` — the GetHealth probe through an authorization lens: PERMISSION_DENIED is a first-class FAIL carrying the daemon's actionable message (credential rejection diagnosed too); transport/handler failures stay owned by `daemon.healthy`.
- `daemon.authz.identity` — transport and credential shape provable client-side, honestly labeled: the resolved principal/role is not exposed over RPC and this PR adds no proto surface.
- `daemon.authz.enforcement` — enforcement mode and mapped-role count read from the daemon's own redacted effective-config dump; skipped (not FAIL) against daemons whose dump lacks the section.

## Testing

- Three new tests pin principal + fix text per message; mutation-verified red (dropping any fix clause fails the matching assertion). Doctor helpers unit-tested including the degrade-to-skip paths.
- Gates all exit 0: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`, `scripts/check-clippy-reasons.py`, `cargo test -p rustbgpd-api authz`.
- Live smoke against a release build (tier config, observer-role bearer principal `ci-bot`): mutating RPC returns the new role-tier denial plus the CLI hint; `rbgp doctor` shows the three `daemon.authz.*` checks green, and against a `max_tier = "read"` listener reports the denial as an actionable FAIL.