### PR TITLE
authz: implicit local-operator for owner-only UDS; one-shot config diagnosis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **Implicit `local-operator` identity for owner-only UDS listeners
+  (ADR-0064 amendment).** Under the default tier enforcement, a UDS
+  listener (implicit or declared) with no `principal` and an owner-only
+  socket mode (no group/world bits, e.g. the default `0o600`) now
+  authorizes its clients as the reserved `local-operator` principal at
+  operator tier — no `[security.grpc.roles]` entry needed. The socket's
+  filesystem permissions are the authentication; a listener-wide UDS
+  principal added no per-client discrimination. Group/world-accessible
+  sockets still require an explicit role-mapped `principal`, the
+  listener `max_tier` cap still applies, `local-operator` is rejected
+  as a declared principal or roles key, and audit records label the
+  implicit path `authn = "uds_owner"`. A zero-config daemon now boots
+  under tier enforcement, and `--init-config lab|edge` no longer emit a
+  `[security.grpc]` block.
+
+- **The implicit UDS listener now survives an explicit TCP listener.**
+  Previously declaring `[global.telemetry.grpc_tcp]` silently dropped
+  the default local socket, breaking local `rbgp` access. The implicit
+  owner-only UDS at `<runtime_state_dir>/grpc.sock` is now enabled
+  whenever `[global.telemetry.grpc_uds]` is not declared; opt out with
+  `[global.telemetry.grpc_uds] enabled = false`. Migration note: a
+  TCP-only config now also binds the local socket — declare the opt-out
+  if that path must not exist.
+
+- **Tier-enforcement config failures are now diagnosed in one shot.**
+  Instead of a sequential ladder surfacing one problem per boot
+  attempt, validation collects every problem (unmapped principals,
+  missing bearer principals, unauthenticated TCP, group-accessible UDS
+  without a principal, mTLS with empty roles) into a single error that
+  ends with a minimal copy-pasteable TOML block fixing that specific
+  config, with the operator's own principal strings interpolated.
+
 ### Added
 
 - **Config-history provenance schema and rendering.** `ListConfigHistory` and

--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -88,6 +88,24 @@ impl PrincipalRole {
     }
 }
 
+/// Reserved implicit principal granted to clients of an owner-only UDS
+/// listener that declares no `principal`. The socket's filesystem
+/// permissions are the authentication; config validation rejects this
+/// name in `[security.grpc.roles]` and listener `principal` fields so
+/// the implicit identity can never be confused with a declared one.
+pub const LOCAL_OPERATOR_PRINCIPAL: &str = "local-operator";
+
+/// True when a UDS socket mode grants no group/world access
+/// (the 0600/0700 class), i.e. only the socket owner can connect.
+#[must_use]
+#[expect(
+    clippy::verbose_bit_mask,
+    reason = "the permission-bit mask is clearer than trailing_zeros() here"
+)]
+pub const fn uds_mode_is_owner_only(mode: u32) -> bool {
+    mode & 0o077 == 0
+}
+
 /// Static authorization metadata for one generated gRPC method path.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct GrpcMethodAuthz {

--- a/crates/api/src/authz_runtime/context.rs
+++ b/crates/api/src/authz_runtime/context.rs
@@ -8,7 +8,7 @@ use tonic::codegen::http;
 use tonic::transport::server::{TcpConnectInfo, TlsConnectInfo};
 use tracing::debug;
 
-use crate::authz::{AuthEnforcement, AuthTier, PrincipalRole};
+use crate::authz::{AuthEnforcement, AuthTier, LOCAL_OPERATOR_PRINCIPAL, PrincipalRole};
 use crate::authz_principal::{PrincipalExtractionError, principal_from_peer_certs};
 use crate::connect_info::RustbgpdTcpConnectInfo;
 use crate::credentials::{CredentialStore, PinnedCredentialGeneration};
@@ -24,6 +24,9 @@ pub enum GrpcAuthnKind {
     BearerToken,
     /// Unix domain socket protected by filesystem permissions.
     Uds,
+    /// Owner-only Unix domain socket whose clients are authorized as
+    /// the implicit `local-operator` principal (ADR-0064 amendment).
+    UdsOwner,
     /// No listener authentication configured.
     None,
 }
@@ -36,6 +39,7 @@ impl GrpcAuthnKind {
             Self::Mtls => "mtls",
             Self::BearerToken => "bearer_token",
             Self::Uds => "uds",
+            Self::UdsOwner => "uds_owner",
             Self::None => "none",
         }
     }
@@ -51,6 +55,10 @@ pub struct GrpcAuthAuditContext {
     principal: String,
     pub(super) enforcement: AuthEnforcement,
     roles: Arc<BTreeMap<String, PrincipalRole>>,
+    // Role granted to the reserved `local-operator` principal on an
+    // owner-only UDS listener without consulting the roles map — the
+    // socket's filesystem permissions are the authentication.
+    implicit_role: Option<PrincipalRole>,
     resolve_mtls_principal: bool,
     expected_bearer_header: Option<BearerAuthSecret>,
     dynamic_bearer: Option<(CredentialStore, usize)>,
@@ -74,6 +82,7 @@ impl GrpcAuthAuditContext {
             principal: principal.into(),
             enforcement: AuthEnforcement::Legacy,
             roles: Arc::new(BTreeMap::new()),
+            implicit_role: None,
             resolve_mtls_principal: false,
             expected_bearer_header: None,
             dynamic_bearer: None,
@@ -89,6 +98,15 @@ impl GrpcAuthAuditContext {
     ) -> Self {
         self.enforcement = enforcement;
         self.roles = roles;
+        self
+    }
+
+    /// Authorize the reserved `local-operator` principal at operator
+    /// tier without a `[security.grpc.roles]` entry. Only owner-only
+    /// UDS listeners with no declared principal get this.
+    #[must_use]
+    pub fn with_implicit_local_operator(mut self) -> Self {
+        self.implicit_role = Some(PrincipalRole::Operator);
         self
     }
 
@@ -159,7 +177,7 @@ impl GrpcAuthAuditContext {
         if self.enforcement != AuthEnforcement::Tier {
             return None;
         }
-        let Some(role) = self.roles.get(principal).copied() else {
+        let Some(role) = self.resolve_role(principal) else {
             return Some(RoleDenial::PrincipalUnmapped);
         };
         if tier > role.max_tier() {
@@ -172,9 +190,18 @@ impl GrpcAuthAuditContext {
         if self.enforcement != AuthEnforcement::Tier {
             return "legacy";
         }
-        self.roles
-            .get(principal)
-            .map_or("unmapped", |role| role.as_str())
+        self.resolve_role(principal)
+            .map_or("unmapped", PrincipalRole::as_str)
+    }
+
+    fn resolve_role(&self, principal: &str) -> Option<PrincipalRole> {
+        // Validation rejects `local-operator` in the roles map, so the
+        // implicit fallback can never shadow a declared entry.
+        self.roles.get(principal).copied().or_else(|| {
+            (principal == LOCAL_OPERATOR_PRINCIPAL)
+                .then_some(self.implicit_role)
+                .flatten()
+        })
     }
 
     pub(crate) fn principal_for_extensions<'a>(

--- a/crates/api/src/authz_runtime/tests.rs
+++ b/crates/api/src/authz_runtime/tests.rs
@@ -23,7 +23,7 @@ use tower::{Layer, Service};
 
 use super::*;
 use crate::audit::{GrpcAuditHandle, GrpcRequestSummary};
-use crate::authz::{AuthEnforcement, AuthTier, PrincipalRole};
+use crate::authz::{AuthEnforcement, AuthTier, LOCAL_OPERATOR_PRINCIPAL, PrincipalRole};
 use crate::connect_info::{RustbgpdTcpConnectInfo, RustbgpdTcpStream};
 use crate::test_support::metrics_text as gather_text;
 
@@ -591,6 +591,66 @@ async fn tier_enforcement_denies_unmapped_principal() {
 
     let text = gather_text(&metrics);
     assert!(text.contains("result=\"principal_unmapped\""));
+}
+
+#[tokio::test]
+async fn tier_enforcement_authorizes_implicit_local_operator_with_empty_roles() {
+    // Owner-only UDS listener with no declared principal: the implicit
+    // `local-operator` identity is operator-tier without any
+    // [security.grpc.roles] entry. Red proof: removing the implicit
+    // resolution denies this as principal_unmapped.
+    let metrics = BgpMetrics::new();
+    let context = GrpcAuthAuditContext::new(
+        "unix:///run/rustbgpd/grpc.sock",
+        "read_write",
+        AuthTier::OperatorOnly,
+        GrpcAuthnKind::UdsOwner,
+        LOCAL_OPERATOR_PRINCIPAL,
+    )
+    .with_role_enforcement(AuthEnforcement::Tier, roles(&[]))
+    .with_implicit_local_operator();
+    let layer = GrpcAuthzLayer::new(context, metrics.clone());
+    let mut service = layer.layer(EchoService);
+    let request = Request::builder()
+        .uri("/rustbgpd.v1.ControlService/Shutdown")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = service.call(request).await.unwrap();
+    assert_eq!(response.status(), http::StatusCode::OK);
+
+    let text = gather_text(&metrics);
+    assert!(text.contains("result=\"handler_ok\""));
+    assert!(text.contains("authn=\"uds_owner\""));
+}
+
+#[tokio::test]
+async fn tier_enforcement_still_caps_implicit_local_operator_by_listener_tier() {
+    // The listener max_tier ceiling applies to the implicit identity
+    // exactly as it does to declared principals.
+    let metrics = BgpMetrics::new();
+    let context = GrpcAuthAuditContext::new(
+        "unix:///run/rustbgpd/grpc.sock",
+        "read_write",
+        AuthTier::SensitiveRead,
+        GrpcAuthnKind::UdsOwner,
+        LOCAL_OPERATOR_PRINCIPAL,
+    )
+    .with_role_enforcement(AuthEnforcement::Tier, roles(&[]))
+    .with_implicit_local_operator();
+    let layer = GrpcAuthzLayer::new(context, metrics.clone());
+    let mut service = layer.layer(EchoService);
+    let request = Request::builder()
+        .uri("/rustbgpd.v1.ControlService/Shutdown")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = service.call(request).await.unwrap();
+    let status = tonic::Status::from_header_map(response.headers()).unwrap();
+    assert_eq!(status.code(), tonic::Code::PermissionDenied);
+
+    let text = gather_text(&metrics);
+    assert!(text.contains("result=\"listener_tier_denied\""));
 }
 
 #[tokio::test]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -20,7 +20,9 @@ use tonic::transport::Server;
 use tonic::{Request, Status};
 use tracing::{error, info, warn};
 
-use crate::authz::{AuthEnforcement, AuthTier, PrincipalRole};
+use crate::authz::{
+    AuthEnforcement, AuthTier, LOCAL_OPERATOR_PRINCIPAL, PrincipalRole, uds_mode_is_owner_only,
+};
 use crate::authz_runtime::{GrpcAuthAuditContext, GrpcAuthnKind, GrpcAuthzLayer};
 use crate::bfd_service::BfdService;
 use crate::config_service::ConfigService;
@@ -786,6 +788,7 @@ fn tcp_audit_context(
 
 fn uds_audit_context(
     path: &Path,
+    mode: u32,
     access_mode: AccessMode,
     max_tier: AuthTier,
     role_config: RuntimeAuthzConfig,
@@ -793,7 +796,7 @@ fn uds_audit_context(
     configured_principal: Option<&str>,
 ) -> GrpcAuthAuditContext {
     let auth_enabled = auth_token.is_some();
-    let (authn, principal) = if let Some(principal) = configured_principal {
+    let (authn, principal, implicit_operator) = if let Some(principal) = configured_principal {
         (
             if auth_enabled {
                 GrpcAuthnKind::BearerToken
@@ -801,13 +804,27 @@ fn uds_audit_context(
                 GrpcAuthnKind::Uds
             },
             principal.to_string(),
+            false,
+        )
+    } else if uds_mode_is_owner_only(mode) {
+        // ADR-0064 amendment: the owner-only socket mode is the
+        // authentication, so clients are authorized as the implicit
+        // `local-operator` operator identity without a roles entry.
+        (
+            GrpcAuthnKind::UdsOwner,
+            LOCAL_OPERATOR_PRINCIPAL.to_string(),
+            true,
         )
     } else if auth_enabled {
-        (GrpcAuthnKind::BearerToken, "bearer-token".to_string())
+        (
+            GrpcAuthnKind::BearerToken,
+            "bearer-token".to_string(),
+            false,
+        )
     } else {
-        (GrpcAuthnKind::Uds, format!("uds:{}", path.display()))
+        (GrpcAuthnKind::Uds, format!("uds:{}", path.display()), false)
     };
-    GrpcAuthAuditContext::new(
+    let context = GrpcAuthAuditContext::new(
         format!("unix://{}", path.display()),
         access_mode.as_str(),
         max_tier,
@@ -815,7 +832,12 @@ fn uds_audit_context(
         principal,
     )
     .with_role_enforcement(role_config.enforcement, role_config.roles)
-    .with_bearer_token(auth_token)
+    .with_bearer_token(auth_token);
+    if implicit_operator {
+        context.with_implicit_local_operator()
+    } else {
+        context
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1500,6 +1522,7 @@ async fn run_uds_listener(
         .is_some();
     let audit_context = uds_audit_context(
         &path,
+        mode,
         access_mode,
         max_tier,
         RuntimeAuthzConfig { enforcement, roles },
@@ -2017,6 +2040,7 @@ mod tests {
     fn uds_audit_context_uses_configured_principal() {
         let context = uds_audit_context(
             Path::new("/run/rustbgpd/grpc.sock"),
+            0o600,
             AccessMode::ReadWrite,
             AuthTier::SensitiveRead,
             tier_authz("local-admin"),
@@ -2026,5 +2050,47 @@ mod tests {
         assert_eq!(context.authn(), GrpcAuthnKind::Uds);
         assert_eq!(context.principal(), "local-admin");
         assert_eq!(context.max_tier(), AuthTier::SensitiveRead);
+    }
+
+    #[test]
+    fn uds_audit_context_owner_only_socket_resolves_implicit_local_operator() {
+        // Red proof: dropping the implicit-identity resolution turns the
+        // principal back into the unmapped `uds:<path>` placeholder and
+        // fails these assertions (and the zero-config boot smoke).
+        let context = uds_audit_context(
+            Path::new("/run/rustbgpd/grpc.sock"),
+            0o600,
+            AccessMode::ReadWrite,
+            AuthTier::OperatorOnly,
+            RuntimeAuthzConfig {
+                enforcement: AuthEnforcement::Tier,
+                roles: Arc::new(BTreeMap::new()),
+            },
+            None,
+            None,
+        );
+        assert_eq!(context.authn(), GrpcAuthnKind::UdsOwner);
+        assert_eq!(context.principal(), LOCAL_OPERATOR_PRINCIPAL);
+    }
+
+    #[test]
+    fn uds_audit_context_group_accessible_socket_stays_unmapped() {
+        // Red proof: widening the owner-only check to accept group
+        // bits (e.g. 0o660) makes this listener resolve the implicit
+        // identity and fails this test.
+        let context = uds_audit_context(
+            Path::new("/run/rustbgpd/grpc.sock"),
+            0o660,
+            AccessMode::ReadWrite,
+            AuthTier::OperatorOnly,
+            RuntimeAuthzConfig {
+                enforcement: AuthEnforcement::Tier,
+                roles: Arc::new(BTreeMap::new()),
+            },
+            None,
+            None,
+        );
+        assert_eq!(context.authn(), GrpcAuthnKind::Uds);
+        assert_eq!(context.principal(), "uds:/run/rustbgpd/grpc.sock");
     }
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -535,9 +535,19 @@ gRPC listeners are configured with optional subtables:
 
 ### `[global.telemetry.grpc_uds]`
 
-Preferred local-only gRPC transport. If neither `grpc_uds` nor `grpc_tcp` is
-configured, rustbgpd enables this listener by default at
-`<runtime_state_dir>/grpc.sock`.
+Preferred local-only gRPC transport. Unless this table is declared explicitly
+(including `enabled = false` as an opt-out), rustbgpd enables this listener by
+default at `<runtime_state_dir>/grpc.sock` — also alongside an explicit
+`grpc_tcp` listener, so local `rbgp` access keeps working when TCP is added.
+
+An owner-only socket (no group/world mode bits, e.g. the default `0o600`) with
+no `principal` authorizes its clients as the implicit, reserved
+`local-operator` principal at operator tier — the socket's filesystem
+permissions are the authentication, so no `[security.grpc.roles]` entry is
+needed. A greenfield config therefore needs no security block at all for
+local operation. Group/world-accessible modes still require an explicit
+`principal` plus a matching role entry, and `local-operator` itself is
+reserved (rejected in roles and listener `principal` fields).
 
 | Field        | Type   | Required | Default | Description |
 |--------------|--------|----------|---------|-------------|
@@ -651,24 +661,32 @@ built-in roles:
 
 When `enforcement = "tier"` is configured:
 
-- `[security.grpc.roles]` must contain at least one principal mapping.
 - Bearer-token TCP listeners must set both `token_file` and an explicit
   `principal`; the token value itself is never used as an identity. That
   principal must have a matching `[security.grpc.roles]` entry.
-- UDS listeners must set an explicit `principal`; filesystem permissions
-  authenticate access but do not identify the client role. That principal must
-  have a matching `[security.grpc.roles]` entry.
+- Owner-only UDS listeners (no group/world mode bits) with no `principal`
+  authorize as the implicit `local-operator` principal at operator tier — no
+  roles entry needed. Group/world-accessible UDS listeners must set an
+  explicit `principal` with a matching `[security.grpc.roles]` entry.
 - Native mTLS TCP listeners derive the principal from the verified client
-  certificate and do not set `grpc_tcp.principal`.
+  certificate and do not set `grpc_tcp.principal`; the roles table must map
+  each expected certificate principal.
 - Unauthenticated TCP listeners are rejected at config load.
 - Requests from principals absent from `[security.grpc.roles]` fail closed with
   `PERMISSION_DENIED`.
 
-**Default changed to `tier` in v0.24.0.** Upgrading an existing
-deployment without staging the migration first will fail validation
-at startup; the error message points at this section and at the
-`enforcement = "legacy"` escape hatch. Already-staged operators see
-no behavior change.
+A config that fails these rules is rejected with a single error listing every
+detected problem, ending with a minimal copy-pasteable TOML block that fixes
+that specific config.
+
+**Default changed to `tier` in v0.24.0.** Upgrading a deployment that
+uses TCP listeners, group/world-accessible UDS sockets, or declared
+principals without staging the migration first will fail validation at
+startup; the error lists every problem, ends with a paste-ready fix,
+and points at the `enforcement = "legacy"` escape hatch. Deployments
+that only use an owner-only UDS socket (including the implicit default)
+boot without any staging via the implicit `local-operator` identity.
+Already-staged operators see no behavior change.
 
 Explicit `enforcement = "legacy"` emits a validation warning, and
 `rustbgpd --check --strict` rejects any config that retains it. The original
@@ -682,9 +700,10 @@ The safe migration sequence (run against a pre-upgrade daemon if
 possible):
 
 1. Add `[security.grpc.roles]` entries for every expected gRPC principal.
-2. Set an explicit `principal` on each UDS listener and each bearer-token TCP
-   listener. The implicit default UDS listener has no principal identity, so
-   tier-ready configs must declare `[global.telemetry.grpc_uds]` explicitly.
+2. Set an explicit `principal` on each bearer-token TCP listener and each
+   group/world-accessible UDS listener. Owner-only UDS listeners (including
+   the implicit default listener) need nothing: their clients are authorized
+   as the implicit `local-operator` principal.
 3. For remote TCP, prefer native mTLS so the principal is derived from the
    client certificate; otherwise use `token_file` plus a non-secret
    `principal` label.
@@ -4050,8 +4069,8 @@ starting:
 | `grpc_*.token_file` must exist, be readable, and contain a non-empty token when configured | `invalid gRPC config` |
 | `grpc_*.principal` must not be empty when configured | `invalid gRPC config` |
 | `grpc_tcp.principal` requires `grpc_tcp.token_file` and is rejected on mTLS listeners because mTLS principals are derived from client certificates | `invalid gRPC config` |
-| `security.grpc.enforcement = "tier"` requires at least one role mapping and every enabled listener must have mTLS or an explicit principal | `invalid gRPC config` |
-| `[security.grpc.roles]` principal keys must not be empty; role values must be `observer`, `automation`, or `operator` | `invalid gRPC config` / TOML parse error |
+| `security.grpc.enforcement = "tier"` requires every enabled listener to have mTLS, an explicit role-mapped principal, or an owner-only UDS mode (implicit `local-operator`); all problems are reported in one error with a paste-ready fix | `invalid gRPC config` |
+| `[security.grpc.roles]` principal keys must not be empty and must not use the reserved `mtls-unresolved` / `local-operator` names; role values must be `observer`, `automation`, or `operator` | `invalid gRPC config` / TOML parse error |
 | If `grpc_tcp`/`grpc_uds` tables are present, at least one listener must be enabled | `invalid gRPC config` |
 | `hold_time` must be 0 (disabled) or >= 3 seconds | `invalid hold_time` |
 | `min_hold_time` must be 3..=65535 and no greater than a non-zero effective `hold_time` | `invalid min_hold_time` |

--- a/docs/adr/0064-grpc-authorization.md
+++ b/docs/adr/0064-grpc-authorization.md
@@ -1,6 +1,6 @@
 # ADR-0064: gRPC per-method authorization
 
-**Status:** Accepted
+**Status:** Accepted (amended 2026-08-03: implicit `local-operator` for owner-only UDS, §4)
 **Date:** 2026-05-18
 
 ## Context
@@ -157,13 +157,43 @@ principal source:
 - Bearer-token listeners must configure an explicit token principal
   label before tier enforcement can be enabled, because the token value
   itself is not a stable audit identity.
-- UDS listeners must configure an explicit listener principal or rely
-  only on `max_tier`; filesystem permissions authenticate the client
-  but do not identify a per-client role.
+- UDS listeners may configure an explicit listener principal;
+  filesystem permissions authenticate the client but do not identify a
+  per-client role.
 
 If tier enforcement is enabled on a listener without either mTLS
 principal extraction or an explicit non-mTLS principal, startup rejects
-the configuration instead of falling back open.
+the configuration instead of falling back open — with one amended
+exception for owner-only UDS listeners:
+
+**Amendment (2026-08-03): implicit `local-operator` for owner-only
+UDS.** A UDS listener (implicit or declared) with no `principal` and an
+owner-only socket mode (`mode & 0o077 == 0`, the 0600/0700 class) is
+authorized as the reserved principal `local-operator` at the `operator`
+role ceiling, without a `[security.grpc.roles]` entry. Rationale: the
+socket's filesystem permissions *are* the authentication, and because a
+UDS principal is listener-wide, a roles entry adds zero per-client
+discrimination there — it was pure ceremony blocking zero-config local
+operation. Rules:
+
+- Group/world-accessible modes keep the explicit-principal requirement;
+  wider modes buy real scoping, so they keep the ceremony.
+- A declared `principal` behaves exactly as before (must be mapped in
+  `[security.grpc.roles]`).
+- The listener `max_tier` cap applies to the implicit identity
+  unchanged.
+- `local-operator` is reserved: declaring it in
+  `[security.grpc.roles]` or as a listener `principal` is rejected at
+  config load (like `mtls-unresolved`), so the implicit identity can
+  never be confused with a declared one.
+- Audit records label the implicit path distinctly
+  (`authn = "uds_owner"`, principal `local-operator`).
+
+Per-uid identities via `SO_PEERCRED` were considered and deferred: they
+would give multi-user sockets real per-client roles, but owner-only
+sockets — the only mode the implicit grant covers — have exactly one
+authorized uid by construction, so peer-cred lookup adds surface
+without adding discrimination there.
 
 Roles are configured per-principal in `[security.grpc.roles]`:
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -693,23 +693,14 @@ impl Config {
 
     /// Resolve the configured gRPC listeners.
     ///
-    /// If neither TCP nor UDS is configured explicitly, a secure local-only UDS
-    /// listener is enabled at `<runtime_state_dir>/grpc.sock`.
+    /// Unless `[global.telemetry.grpc_uds]` is declared explicitly (which
+    /// includes `enabled = false` as an opt-out), a secure local-only UDS
+    /// listener is enabled at `<runtime_state_dir>/grpc.sock` — including
+    /// alongside an explicit TCP listener.
     pub fn grpc_listeners(&self) -> Vec<GrpcListener> {
         let telemetry = &self.global.telemetry;
         let tcp = telemetry.grpc_tcp.as_ref().filter(|cfg| cfg.enabled);
         let uds = telemetry.grpc_uds.as_ref().filter(|cfg| cfg.enabled);
-
-        if tcp.is_none() && uds.is_none() {
-            return vec![GrpcListener::Uds {
-                path: self.default_grpc_uds_path(),
-                mode: 0o600,
-                access_mode: GrpcAccessMode::ReadWrite,
-                max_tier: GrpcMaxTier::OperatorOnly,
-                token_file: None,
-                principal: None,
-            }];
-        }
 
         let mut listeners = Vec::new();
         if let Some(cfg) = tcp {
@@ -761,6 +752,17 @@ impl Config {
                 max_tier: effective_grpc_max_tier(access_mode, cfg.max_tier),
                 token_file: cfg.token_file.as_ref().map(PathBuf::from),
                 principal: cfg.principal.clone(),
+            });
+        } else if telemetry.grpc_uds.is_none() {
+            // Implicit owner-only local socket; its clients authorize as
+            // the implicit `local-operator` identity (ADR-0064 amendment).
+            listeners.push(GrpcListener::Uds {
+                path: self.default_grpc_uds_path(),
+                mode: 0o600,
+                access_mode: GrpcAccessMode::ReadWrite,
+                max_tier: GrpcMaxTier::OperatorOnly,
+                token_file: None,
+                principal: None,
             });
         }
         listeners

--- a/src/config/profiles.rs
+++ b/src/config/profiles.rs
@@ -27,10 +27,12 @@ pub fn profile_toml(name: &str) -> Option<&'static str> {
 
 /// `lab` — a minimal single-box setup for experimenting locally: one
 /// eBGP neighbor, gRPC over a local Unix socket, runtime state under
-/// `/tmp`. Local gRPC access is authenticated by Unix-socket filesystem
-/// permissions and authorized through a stable operator principal. Its
-/// permit-all policy is written out and labeled rather than left to
-/// omission, so `--check --strict` is clean and the posture is a choice.
+/// `/tmp`. Local gRPC access rides the owner-only socket: filesystem
+/// permissions authenticate, and the socket owner is authorized as the
+/// implicit `local-operator` principal, so no explicit security block
+/// is needed. Its permit-all policy is written out and labeled rather
+/// than left to omission, so `--check --strict` is clean and the
+/// posture is a choice.
 const LAB: &str = r#"# rustbgpd "lab" profile — a minimal local setup for experimenting on
 # one machine. Edit the ASNs and addresses for your topology, then:
 #   rustbgpd config-lab.toml          # (after saving this output)
@@ -54,23 +56,16 @@ ebgp_requires_policy = true
 prometheus_addr = "127.0.0.1:9179"
 log_format = "json"
 
-# Local control socket for rbgp. Filesystem permissions authenticate access to
-# the socket; the stable principal below drives authorization and audit logs.
-# When adapting this profile, change the example path and principal label for
-# your deployment, and keep the matching role key below in sync.
+# Local control socket for rbgp. The socket is owner-only (mode 0600), so
+# filesystem permissions authenticate access and the socket owner is
+# authorized as the implicit "local-operator" principal at operator tier —
+# no [security.grpc] block needed for local operation. To add remote or
+# named access (more principals, TCP, mTLS), see docs/CONFIGURATION.md
+# under [security.grpc].
 [global.telemetry.grpc_uds]
 enabled = true
 path = "/tmp/rustbgpd/grpc.sock"
 mode = 0o600
-principal = "operator"
-
-[security.grpc]
-# Per-principal authorization. The UDS principal is not a credential: socket
-# filesystem permissions authenticate access, and this role grants its ceiling.
-enforcement = "tier"
-
-[security.grpc.roles]
-operator = "operator"
 
 # ==========================================================================
 # DELIBERATE LAB POSTURE: PERMIT ALL, BOTH DIRECTIONS. NOT FOR PRODUCTION.
@@ -139,23 +134,16 @@ ebgp_requires_policy = true
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
 
-# Local control socket for rbgp. Filesystem permissions authenticate access to
-# the socket; the stable principal below drives authorization and audit logs.
-# When adapting this profile, change the example path and principal label for
-# your deployment, and keep the matching role key below in sync.
+# Local control socket for rbgp. The socket is owner-only (mode 0600), so
+# filesystem permissions authenticate access and the socket owner is
+# authorized as the implicit "local-operator" principal at operator tier —
+# no [security.grpc] block needed for local operation. To add remote or
+# named access (more principals, TCP, mTLS), see docs/CONFIGURATION.md
+# under [security.grpc].
 [global.telemetry.grpc_uds]
 enabled = true
 path = "/var/lib/rustbgpd/grpc.sock"
 mode = 0o600
-principal = "operator"
-
-[security.grpc]
-# Per-principal authorization. The UDS principal is not a credential: socket
-# filesystem permissions authenticate access, and this role grants its ceiling.
-enforcement = "tier"
-
-[security.grpc.roles]
-operator = "operator"
 
 # Named import policy: permit by default, but drop the IPv4 default
 # route from upstream. Add more statements (RPKI, AS_PATH, communities)
@@ -206,7 +194,7 @@ hold_time = 90
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{Config, GrpcEnforcementConfig, GrpcRoleConfig};
+    use crate::config::{Config, GrpcEnforcementConfig};
 
     #[test]
     fn every_profile_validates() {
@@ -221,11 +209,14 @@ mod tests {
     }
 
     #[test]
-    fn every_profile_has_an_explicit_tier_authorized_uds_operator() {
-        // Load-bearing bootstrap contract: restoring legacy enforcement,
-        // removing the UDS principal or its matching role, downgrading that
-        // role, or disabling the only listener makes this test or the strict
-        // config load fail instead of shipping an unsafe or unusable profile.
+    fn every_profile_relies_on_the_implicit_local_operator_uds() {
+        // Load-bearing bootstrap contract: profiles validate clean under
+        // the default tier enforcement with NO explicit security block —
+        // the owner-only UDS grants the implicit `local-operator`
+        // identity. Restoring legacy enforcement, widening the socket
+        // mode, adding a principal back, or dropping the explanatory
+        // comment makes this test fail instead of shipping ceremony (or
+        // an unexplained implicit grant) to new operators.
         for name in PROFILE_NAMES {
             let toml = profile_toml(name).expect("listed profile must resolve");
             let config = Config::load_toml_with_diagnostics(toml, name)
@@ -235,6 +226,10 @@ mod tests {
                 config.security.grpc.enforcement,
                 GrpcEnforcementConfig::Tier,
                 "--init-config {name} must use tier gRPC enforcement"
+            );
+            assert!(
+                config.security.grpc.roles.is_empty(),
+                "--init-config {name} must not need a [security.grpc.roles] block"
             );
 
             let uds = config
@@ -247,17 +242,18 @@ mod tests {
                 uds.enabled,
                 "--init-config {name} must enable its declared grpc_uds listener"
             );
-            let principal = uds.principal.as_deref().unwrap_or_else(|| {
-                panic!("--init-config {name} grpc_uds must declare a stable principal")
-            });
             assert_eq!(
-                principal, "operator",
-                "--init-config {name} must preserve its stable UDS audit principal"
+                uds.principal, None,
+                "--init-config {name} grpc_uds must rely on the implicit identity"
             );
             assert_eq!(
-                config.security.grpc.roles.get(principal),
-                Some(&GrpcRoleConfig::Operator),
-                "--init-config {name} grpc_uds principal must map to the operator role"
+                uds.mode & 0o077,
+                0,
+                "--init-config {name} grpc_uds must stay owner-only for the implicit grant"
+            );
+            assert!(
+                toml.contains("local-operator"),
+                "--init-config {name} must explain the implicit local-operator rule"
             );
         }
     }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1723,6 +1723,8 @@ fn grpc_listeners_default_to_uds() {
 
 #[test]
 fn grpc_tcp_listener_parses_when_enabled() {
+    // An explicit TCP listener no longer suppresses the implicit local
+    // UDS listener; it rides alongside.
     let toml_str = format!(
         "{}\n[global.telemetry.grpc_tcp]\naddress = \"127.0.0.1:50051\"\n",
         valid_toml()
@@ -1730,15 +1732,43 @@ fn grpc_tcp_listener_parses_when_enabled() {
     let config = parse_schema_only(&toml_str).unwrap();
     assert_eq!(
         config.grpc_listeners(),
-        vec![GrpcListener::Tcp {
-            addr: "127.0.0.1:50051".parse().unwrap(),
-            access_mode: GrpcAccessMode::ReadWrite,
-            max_tier: GrpcMaxTier::OperatorOnly,
-            token_file: None,
-            principal: None,
-            tls: None,
-        }]
+        vec![
+            GrpcListener::Tcp {
+                addr: "127.0.0.1:50051".parse().unwrap(),
+                access_mode: GrpcAccessMode::ReadWrite,
+                max_tier: GrpcMaxTier::OperatorOnly,
+                token_file: None,
+                principal: None,
+                tls: None,
+            },
+            implicit_uds_listener(&config),
+        ]
     );
+}
+
+/// The implicit owner-only UDS listener synthesized whenever
+/// `[global.telemetry.grpc_uds]` is not declared.
+fn implicit_uds_listener(config: &Config) -> GrpcListener {
+    GrpcListener::Uds {
+        path: config.default_grpc_uds_path(),
+        mode: 0o600,
+        access_mode: GrpcAccessMode::ReadWrite,
+        max_tier: GrpcMaxTier::OperatorOnly,
+        token_file: None,
+        principal: None,
+    }
+}
+
+#[test]
+fn grpc_explicit_uds_opt_out_disables_the_implicit_listener() {
+    let toml_str = format!(
+        "{}\n[global.telemetry.grpc_tcp]\naddress = \"127.0.0.1:50051\"\n\n[global.telemetry.grpc_uds]\nenabled = false\n",
+        valid_toml()
+    );
+    let config = parse_schema_only(&toml_str).unwrap();
+    let listeners = config.grpc_listeners();
+    assert_eq!(listeners.len(), 1);
+    assert!(matches!(listeners[0], GrpcListener::Tcp { .. }));
 }
 
 #[test]
@@ -1750,14 +1780,17 @@ fn grpc_listener_access_mode_parses() {
     let config = parse_schema_only(&toml_str).unwrap();
     assert_eq!(
         config.grpc_listeners(),
-        vec![GrpcListener::Tcp {
-            addr: "127.0.0.1:50051".parse().unwrap(),
-            access_mode: GrpcAccessMode::ReadOnly,
-            max_tier: GrpcMaxTier::SensitiveRead,
-            token_file: None,
-            principal: None,
-            tls: None,
-        }]
+        vec![
+            GrpcListener::Tcp {
+                addr: "127.0.0.1:50051".parse().unwrap(),
+                access_mode: GrpcAccessMode::ReadOnly,
+                max_tier: GrpcMaxTier::SensitiveRead,
+                token_file: None,
+                principal: None,
+                tls: None,
+            },
+            implicit_uds_listener(&config),
+        ]
     );
 }
 
@@ -1770,14 +1803,17 @@ fn grpc_listener_max_tier_parses() {
     let config = parse_schema_only(&toml_str).unwrap();
     assert_eq!(
         config.grpc_listeners(),
-        vec![GrpcListener::Tcp {
-            addr: "127.0.0.1:50051".parse().unwrap(),
-            access_mode: GrpcAccessMode::ReadWrite,
-            max_tier: GrpcMaxTier::Mutating,
-            token_file: None,
-            principal: None,
-            tls: None,
-        }]
+        vec![
+            GrpcListener::Tcp {
+                addr: "127.0.0.1:50051".parse().unwrap(),
+                access_mode: GrpcAccessMode::ReadWrite,
+                max_tier: GrpcMaxTier::Mutating,
+                token_file: None,
+                principal: None,
+                tls: None,
+            },
+            implicit_uds_listener(&config),
+        ]
     );
 }
 
@@ -1790,14 +1826,17 @@ fn grpc_listener_access_mode_read_only_caps_max_tier() {
     let config = parse_schema_only(&toml_str).unwrap();
     assert_eq!(
         config.grpc_listeners(),
-        vec![GrpcListener::Tcp {
-            addr: "127.0.0.1:50051".parse().unwrap(),
-            access_mode: GrpcAccessMode::ReadOnly,
-            max_tier: GrpcMaxTier::SensitiveRead,
-            token_file: None,
-            principal: None,
-            tls: None,
-        }]
+        vec![
+            GrpcListener::Tcp {
+                addr: "127.0.0.1:50051".parse().unwrap(),
+                access_mode: GrpcAccessMode::ReadOnly,
+                max_tier: GrpcMaxTier::SensitiveRead,
+                token_file: None,
+                principal: None,
+                tls: None,
+            },
+            implicit_uds_listener(&config),
+        ]
     );
 }
 
@@ -1881,10 +1920,9 @@ fn explicit_legacy_grpc_enforcement_loads_roles_and_warns() {
 fn grpc_security_default_is_tier_since_v0_24() {
     // Pinned by the v0.24.0 ADR-0064 slice 4b default flip. If this
     // regresses to Legacy without a deliberate schema change, the
-    // production security posture has silently rolled back. Builds
-    // a minimal tier-ready config (no [security.grpc] block — relies
-    // entirely on the default — plus one role + grpc_uds with
-    // matching principal) so validation passes.
+    // production security posture has silently rolled back. The
+    // owner-only UDS listener needs no principal or roles: the
+    // implicit `local-operator` identity authorizes it under tier.
     let toml_str = r#"
 [global]
 asn = 65001
@@ -1897,10 +1935,6 @@ log_format = "json"
 
 [global.telemetry.grpc_uds]
 path = "/tmp/rustbgpd-default-tier-test.sock"
-principal = "local-operator"
-
-[security.grpc.roles]
-"local-operator" = "operator"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -1920,13 +1954,12 @@ hold_time = 90
 }
 
 #[test]
-fn grpc_security_empty_config_fails_tier_validation_with_legacy_hint() {
-    // After the v0.24.0 default flip, an operator who upgrades
-    // without staging [security.grpc.roles] should see a clean
-    // validation failure whose error message points at the
-    // migration checklist AND the legacy escape hatch. Uses a TOML
-    // without any [security.grpc] block to exercise the bare-upgrade
-    // path.
+fn grpc_security_zero_config_boots_under_tier_with_implicit_local_operator() {
+    // Red proof for the implicit local-operator rule: a config with no
+    // [security.grpc] block and no declared listener is valid under the
+    // default tier enforcement — the implicit owner-only UDS listener
+    // authorizes the socket owner as `local-operator`. Removing the
+    // implicit rule (or the implicit listener) fails this test.
     let toml_str = r#"
 [global]
 asn = 65001
@@ -1943,18 +1976,10 @@ remote_asn = 65002
 description = "peer-1"
 hold_time = 90
 "#;
-    // Strict parsing leaves the raw config untouched so this test sees the
-    // v0.24.0 production-default Tier validation path.
-    let result = parse_strict(toml_str);
-    let err = result.expect_err("default-tier mode with no roles must fail validation");
-    let msg = format!("{err}");
-    assert!(
-        msg.contains("v0.24.0 default"),
-        "validation error should call out the v0.24.0 default flip: {msg}"
-    );
-    assert!(
-        msg.contains("enforcement = \\\"legacy\\\"") || msg.contains("enforcement = \"legacy\""),
-        "validation error should mention the legacy escape hatch: {msg}"
+    let config = parse_strict(toml_str).expect("zero-config boot must validate under tier");
+    assert_eq!(
+        config.grpc_listeners(),
+        vec![implicit_uds_listener(&config)]
     );
 }
 
@@ -2008,7 +2033,11 @@ fn grpc_security_reserved_unresolved_mtls_role_rejected() {
 }
 
 #[test]
-fn grpc_security_tier_requires_roles() {
+fn grpc_security_tier_diagnoses_uds_principal_missing_from_roles() {
+    // WP1 one-shot diagnosis: a declared UDS principal with no roles
+    // entry gets one error ending in a paste-ready fix built from the
+    // operator's own principal string. Red proof: dropping the paste
+    // block from the message fails this test.
     let toml_str = format!(
         "{}\n[security.grpc]\nenforcement = \"tier\"\n\n[global.telemetry.grpc_uds]\npath = \"/tmp/rustbgpd-test.sock\"\nprincipal = \"local-admin\"\n",
         valid_toml_no_grpc_security()
@@ -2018,31 +2047,51 @@ fn grpc_security_tier_requires_roles() {
         panic!("expected InvalidGrpcConfig");
     };
     assert!(
-        reason.contains("requires at least one"),
+        reason.contains("grpc_uds.principal \"local-admin\" has no"),
         "got unexpected reason: {reason}"
+    );
+    assert!(
+        reason.contains("add this to fix it:")
+            && reason.contains("[security.grpc.roles]")
+            && reason.contains("\"local-admin\" = \"operator\""),
+        "error must end with a paste-ready fix: {reason}"
+    );
+    assert!(
+        reason.contains("enforcement = \"legacy\""),
+        "error must mention the legacy escape hatch: {reason}"
     );
 }
 
 #[test]
-fn grpc_security_tier_rejects_implicit_uds_without_principal() {
+fn grpc_security_tier_accepts_implicit_uds_via_local_operator() {
+    // Tier enforcement with roles staged but no declared listener:
+    // the implicit owner-only UDS authorizes as `local-operator`.
     let toml_str = format!(
         "{}\n[security.grpc]\nenforcement = \"tier\"\n\n[security.grpc.roles]\n\"local-admin\" = \"operator\"\n",
         valid_toml_no_grpc_security()
     );
-    let err = parse_strict(&toml_str).unwrap_err();
-    let ConfigError::InvalidGrpcConfig { reason } = err else {
-        panic!("expected InvalidGrpcConfig");
-    };
-    assert!(
-        reason.contains("implicit UDS listener"),
-        "got unexpected reason: {reason}"
-    );
+    parse_strict(&toml_str).expect("implicit UDS must validate under tier");
 }
 
 #[test]
-fn grpc_security_tier_rejects_uds_without_principal() {
+fn grpc_security_tier_accepts_owner_only_uds_without_principal() {
+    // A declared UDS listener with the default owner-only mode and no
+    // principal relies on the implicit `local-operator` identity.
     let toml_str = format!(
-        "{}\n[security.grpc]\nenforcement = \"tier\"\n\n[security.grpc.roles]\n\"local-admin\" = \"operator\"\n\n[global.telemetry.grpc_uds]\npath = \"/tmp/rustbgpd-test.sock\"\n",
+        "{}\n[security.grpc]\nenforcement = \"tier\"\n\n[global.telemetry.grpc_uds]\npath = \"/tmp/rustbgpd-test.sock\"\n",
+        valid_toml_no_grpc_security()
+    );
+    parse_strict(&toml_str).expect("owner-only UDS without principal must validate under tier");
+}
+
+#[test]
+fn grpc_security_tier_rejects_group_accessible_uds_without_principal() {
+    // Red proof for the owner-only gate: widening the implicit rule to
+    // accept group-accessible modes (e.g. 0o660) makes this config
+    // valid and fails this test. Group/world access buys real scoping,
+    // so it keeps the explicit principal ceremony.
+    let toml_str = format!(
+        "{}\n[security.grpc]\nenforcement = \"tier\"\n\n[global.telemetry.grpc_uds]\npath = \"/tmp/rustbgpd-test.sock\"\nmode = 0o660\n",
         valid_toml_no_grpc_security()
     );
     let err = parse_strict(&toml_str).unwrap_err();
@@ -2050,13 +2099,19 @@ fn grpc_security_tier_rejects_uds_without_principal() {
         panic!("expected InvalidGrpcConfig");
     };
     assert!(
-        reason.contains("requires grpc_uds.principal"),
+        reason.contains("group/world-accessible (mode 0o660)") && reason.contains("local-operator"),
         "got unexpected reason: {reason}"
+    );
+    assert!(
+        reason.contains("add this to fix it:")
+            && reason.contains("principal = \"local-admin\"")
+            && reason.contains("\"local-admin\" = \"operator\""),
+        "error must end with a paste-ready fix: {reason}"
     );
 }
 
 #[test]
-fn grpc_security_tier_rejects_bearer_tcp_without_principal() {
+fn grpc_security_tier_diagnoses_bearer_tcp_without_principal() {
     let token_file = NamedTempFile::new().unwrap();
     fs::write(token_file.path(), "secret").unwrap();
     let toml_str = format!(
@@ -2069,13 +2124,19 @@ fn grpc_security_tier_rejects_bearer_tcp_without_principal() {
         panic!("expected InvalidGrpcConfig");
     };
     assert!(
-        reason.contains("requires grpc_tcp.principal"),
+        reason.contains("bearer-token TCP listener has no grpc_tcp.principal"),
         "got unexpected reason: {reason}"
+    );
+    assert!(
+        reason.contains("add this to fix it:")
+            && reason.contains("[global.telemetry.grpc_tcp]")
+            && reason.contains("principal = \"automation\""),
+        "error must end with a paste-ready fix: {reason}"
     );
 }
 
 #[test]
-fn grpc_security_tier_rejects_non_mtls_principal_absent_from_roles() {
+fn grpc_security_tier_diagnoses_non_mtls_principal_absent_from_roles() {
     let token_file = NamedTempFile::new().unwrap();
     fs::write(token_file.path(), "secret").unwrap();
     let toml_str = format!(
@@ -2088,13 +2149,18 @@ fn grpc_security_tier_rejects_non_mtls_principal_absent_from_roles() {
         panic!("expected InvalidGrpcConfig");
     };
     assert!(
-        reason.contains("to be present in [security.grpc.roles]"),
+        reason.contains("grpc_tcp.principal \"automation.example\" has no"),
         "got unexpected reason: {reason}"
+    );
+    assert!(
+        reason.contains("add this to fix it:")
+            && reason.contains("\"automation.example\" = \"operator\""),
+        "error must interpolate the operator's own principal into the fix: {reason}"
     );
 }
 
 #[test]
-fn grpc_security_tier_rejects_unauthenticated_tcp() {
+fn grpc_security_tier_diagnoses_unauthenticated_tcp() {
     let toml_str = format!(
         "{}\n[security.grpc]\nenforcement = \"tier\"\n\n[security.grpc.roles]\n\"automation.example\" = \"automation\"\n\n[global.telemetry.grpc_tcp]\naddress = \"127.0.0.1:50051\"\n",
         valid_toml_no_grpc_security()
@@ -2104,7 +2170,63 @@ fn grpc_security_tier_rejects_unauthenticated_tcp() {
         panic!("expected InvalidGrpcConfig");
     };
     assert!(
-        reason.contains("rejects unauthenticated TCP"),
+        reason.contains("TCP listener is unauthenticated"),
+        "got unexpected reason: {reason}"
+    );
+    assert!(
+        reason.contains("add this to fix it:") && reason.contains("token_file = "),
+        "error must end with a paste-ready fix: {reason}"
+    );
+}
+
+#[test]
+fn grpc_security_tier_reports_all_problems_in_one_error() {
+    // The whole point of the one-shot diagnosis: two independent
+    // problems surface in one numbered error, not one per boot attempt.
+    let toml_str = format!(
+        "{}\n[security.grpc]\nenforcement = \"tier\"\n\n[global.telemetry.grpc_tcp]\naddress = \"127.0.0.1:50051\"\n\n[global.telemetry.grpc_uds]\npath = \"/tmp/rustbgpd-test.sock\"\nmode = 0o660\n",
+        valid_toml_no_grpc_security()
+    );
+    let err = parse_strict(&toml_str).unwrap_err();
+    let ConfigError::InvalidGrpcConfig { reason } = err else {
+        panic!("expected InvalidGrpcConfig");
+    };
+    assert!(
+        reason.contains("2 problem(s)") && reason.contains("  1. ") && reason.contains("  2. "),
+        "both problems must appear in one error: {reason}"
+    );
+}
+
+#[test]
+fn grpc_security_reserved_local_operator_role_rejected() {
+    // Red proof: dropping the reserved-name rejection lets an operator
+    // map "local-operator" in roles and fails this test.
+    let toml_str = format!(
+        "{}\n[security.grpc.roles]\n\"local-operator\" = \"observer\"\n",
+        valid_toml()
+    );
+    let err = parse_strict(&toml_str).unwrap_err();
+    let ConfigError::InvalidGrpcConfig { reason } = err else {
+        panic!("expected InvalidGrpcConfig");
+    };
+    assert!(
+        reason.contains("reserved principal") && reason.contains("local-operator"),
+        "got unexpected reason: {reason}"
+    );
+}
+
+#[test]
+fn grpc_listener_reserved_local_operator_principal_rejected() {
+    let toml_str = format!(
+        "{}\n[global.telemetry.grpc_uds]\npath = \"/tmp/rustbgpd-test.sock\"\nprincipal = \"local-operator\"\n",
+        valid_toml()
+    );
+    let err = parse_strict(&toml_str).unwrap_err();
+    let ConfigError::InvalidGrpcConfig { reason } = err else {
+        panic!("expected InvalidGrpcConfig");
+    };
+    assert!(
+        reason.contains("reserved principal") && reason.contains("grpc_uds.principal"),
         "got unexpected reason: {reason}"
     );
 }
@@ -2162,14 +2284,17 @@ fn grpc_tcp_bearer_principal_parses() {
     let config = parse_schema_only(&toml_str).unwrap();
     assert_eq!(
         config.grpc_listeners(),
-        vec![GrpcListener::Tcp {
-            addr: "127.0.0.1:50051".parse().unwrap(),
-            access_mode: GrpcAccessMode::ReadWrite,
-            max_tier: GrpcMaxTier::OperatorOnly,
-            token_file: Some(token_file.path().to_path_buf()),
-            principal: Some("automation.example".to_string()),
-            tls: None,
-        }]
+        vec![
+            GrpcListener::Tcp {
+                addr: "127.0.0.1:50051".parse().unwrap(),
+                access_mode: GrpcAccessMode::ReadWrite,
+                max_tier: GrpcMaxTier::OperatorOnly,
+                token_file: Some(token_file.path().to_path_buf()),
+                principal: Some("automation.example".to_string()),
+                tls: None,
+            },
+            implicit_uds_listener(&config),
+        ]
     );
 }
 
@@ -2193,14 +2318,17 @@ fn grpc_security_tier_accepts_bearer_tcp_with_principal_role() {
     );
     assert_eq!(
         config.grpc_listeners(),
-        vec![GrpcListener::Tcp {
-            addr: "127.0.0.1:50051".parse().unwrap(),
-            access_mode: GrpcAccessMode::ReadWrite,
-            max_tier: GrpcMaxTier::Mutating,
-            token_file: Some(token_file.path().to_path_buf()),
-            principal: Some("automation.example".to_string()),
-            tls: None,
-        }]
+        vec![
+            GrpcListener::Tcp {
+                addr: "127.0.0.1:50051".parse().unwrap(),
+                access_mode: GrpcAccessMode::ReadWrite,
+                max_tier: GrpcMaxTier::Mutating,
+                token_file: Some(token_file.path().to_path_buf()),
+                principal: Some("automation.example".to_string()),
+                tls: None,
+            },
+            implicit_uds_listener(&config),
+        ]
     );
 }
 
@@ -2304,7 +2432,7 @@ fn grpc_tls_full_config_accepted() {
     );
     let config = parse_strict(&toml_str).unwrap();
     let listeners = config.grpc_listeners();
-    assert_eq!(listeners.len(), 1);
+    assert_eq!(listeners.len(), 2, "TCP plus the implicit UDS listener");
     let GrpcListener::Tcp { tls, .. } = &listeners[0] else {
         panic!("expected Tcp listener");
     };
@@ -16755,16 +16883,26 @@ fn assert_raw_default_tier_rejected(error: &str) {
     );
 }
 
+/// A raw config that fails default-Tier validation: a declared UDS
+/// principal with no `[security.grpc.roles]` entry. Proves the
+/// production loaders run Tier validation with no test-only bypass.
+fn raw_tier_invalid_toml() -> String {
+    format!(
+        "{}\n[global.telemetry.grpc_uds]\npath = \"/tmp/rustbgpd-test.sock\"\nprincipal = \"local-admin\"\n",
+        valid_toml()
+    )
+}
+
 #[test]
 fn production_text_loader_preserves_default_tier_validation() {
-    let error = Config::load_toml_with_diagnostics(valid_toml(), "raw-text.toml")
-        .expect_err("raw text without gRPC authorization must fail closed");
+    let error = Config::load_toml_with_diagnostics(&raw_tier_invalid_toml(), "raw-text.toml")
+        .expect_err("raw text with an unmapped principal must fail closed");
     assert_raw_default_tier_rejected(&error);
 }
 
 fn raw_default_tier_config_file() -> NamedTempFile {
     let file = NamedTempFile::new().expect("temp config");
-    fs::write(file.path(), valid_toml()).expect("write raw config");
+    fs::write(file.path(), raw_tier_invalid_toml()).expect("write raw config");
     file
 }
 

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -1,7 +1,9 @@
 use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::Path;
 
+use rustbgpd_api::authz::{LOCAL_OPERATOR_PRINCIPAL, uds_mode_is_owner_only};
 use rustbgpd_transport::TCP_AO_MAX_INSPECT_KEYS;
 
 use super::parse::{
@@ -2668,101 +2670,178 @@ fn validate_grpc_security(security: &SecurityConfig) -> Result<(), ConfigError> 
                     .to_string(),
             });
         }
+        if principal == LOCAL_OPERATOR_PRINCIPAL {
+            return Err(ConfigError::InvalidGrpcConfig {
+                reason: format!(
+                    "security.grpc.roles must not map reserved principal \
+                     {LOCAL_OPERATOR_PRINCIPAL:?}; it is granted implicitly \
+                     to clients of an owner-only UDS listener"
+                ),
+            });
+        }
     }
     Ok(())
 }
 
+/// One-shot tier-enforcement diagnosis: collect every problem in a
+/// single pass, then emit one error that ends with a copy-pasteable
+/// minimal TOML fix, instead of surfacing one rung per boot attempt.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one linear diagnosis pass per listener kind plus message assembly"
+)]
 fn validate_grpc_tier_enforcement(config: &Config) -> Result<(), ConfigError> {
     if config.security.grpc.enforcement != GrpcEnforcementConfig::Tier {
         return Ok(());
     }
-    if config.security.grpc.roles.is_empty() {
-        return Err(ConfigError::InvalidGrpcConfig {
-            reason: "security.grpc.enforcement = \"tier\" (the v0.24.0 \
-                     default) requires at least one [security.grpc.roles] \
-                     entry — see docs/CONFIGURATION.md for the migration \
-                     checklist, or opt back into legacy with \
-                     `security.grpc.enforcement = \"legacy\"`"
-                .to_string(),
-        });
-    }
-
     let telemetry = &config.global.telemetry;
     let tcp = telemetry.grpc_tcp.as_ref().filter(|cfg| cfg.enabled);
     let uds = telemetry.grpc_uds.as_ref().filter(|cfg| cfg.enabled);
-    if tcp.is_none() && uds.is_none() {
-        return Err(ConfigError::InvalidGrpcConfig {
-            reason: "security.grpc.enforcement = \"tier\" (the v0.24.0 \
-                     default) requires an explicit gRPC listener with mTLS \
-                     or a configured principal; the implicit UDS listener \
-                     has no role identity. Configure \
-                     [global.telemetry.grpc_uds] with `principal`, or opt \
-                     back into legacy with \
-                     `security.grpc.enforcement = \"legacy\"`"
-                .to_string(),
-        });
-    }
+    let roles = &config.security.grpc.roles;
+
+    let mut problems: Vec<String> = Vec::new();
+    // Fix lines the operator adds inside an existing listener table.
+    let mut listener_fixes: Vec<String> = Vec::new();
+    // Pre-formatted `"principal" = "role"` lines for the fix block's
+    // [security.grpc.roles] table.
+    let mut role_fixes: Vec<String> = Vec::new();
 
     if let Some(cfg) = tcp {
         let mtls_enabled = cfg.tls_cert_file.is_some()
             && cfg.tls_key_file.is_some()
             && cfg.tls_client_ca_file.is_some();
-        if !mtls_enabled && cfg.principal.is_none() {
-            if cfg.token_file.is_some() {
-                return Err(ConfigError::InvalidGrpcConfig {
-                    reason: "security.grpc.enforcement = \"tier\" requires \
-                             grpc_tcp.principal for bearer-token TCP listeners"
+        if mtls_enabled {
+            if roles.is_empty() {
+                problems.push(
+                    "the mTLS TCP listener derives a per-client principal from \
+                     each client certificate, but [security.grpc.roles] is \
+                     empty, so every client would be denied as \
+                     principal_unmapped"
                         .to_string(),
-                });
+                );
+                role_fixes.push(
+                    "# one entry per client certificate principal \
+                     (rustbgpd: URI SAN, then email SAN, then Subject CN):\n\
+                     \"rustbgpd://operator/alice\" = \"operator\""
+                        .to_string(),
+                );
             }
-            return Err(ConfigError::InvalidGrpcConfig {
-                reason: "security.grpc.enforcement = \"tier\" rejects \
-                         unauthenticated TCP listeners; configure native mTLS \
-                         or grpc_tcp.token_file plus grpc_tcp.principal"
+        } else if let Some(principal) = cfg.principal.as_deref() {
+            if !roles.contains_key(principal) {
+                problems.push(format!(
+                    "grpc_tcp.principal {principal:?} has no \
+                     [security.grpc.roles] entry"
+                ));
+                role_fixes.push(format!("{principal:?} = \"operator\""));
+            }
+        } else if cfg.token_file.is_some() {
+            problems.push(
+                "the bearer-token TCP listener has no grpc_tcp.principal, so \
+                 its clients have no role identity"
                     .to_string(),
-            });
-        }
-        if let Some(principal) = cfg.principal.as_deref() {
-            validate_grpc_role_principal(config, principal, "grpc_tcp.principal")?;
+            );
+            listener_fixes.push(
+                "# add to your [global.telemetry.grpc_tcp] table:\n\
+                 principal = \"automation\""
+                    .to_string(),
+            );
+            role_fixes.push("\"automation\" = \"automation\"".to_string());
+        } else {
+            problems.push(
+                "the TCP listener is unauthenticated; tier enforcement \
+                 requires native mTLS (tls_cert_file + tls_key_file + \
+                 tls_client_ca_file) or grpc_tcp.token_file plus \
+                 grpc_tcp.principal"
+                    .to_string(),
+            );
+            listener_fixes.push(
+                "# add to your [global.telemetry.grpc_tcp] table:\n\
+                 token_file = \"/etc/rustbgpd/grpc.token\"\n\
+                 principal = \"automation\""
+                    .to_string(),
+            );
+            role_fixes.push("\"automation\" = \"automation\"".to_string());
         }
     }
 
     if let Some(cfg) = uds {
-        let Some(principal) = cfg.principal.as_deref() else {
-            return Err(ConfigError::InvalidGrpcConfig {
-                reason: "security.grpc.enforcement = \"tier\" requires \
-                         grpc_uds.principal for UDS listeners"
+        if let Some(principal) = cfg.principal.as_deref() {
+            if !roles.contains_key(principal) {
+                problems.push(format!(
+                    "grpc_uds.principal {principal:?} has no \
+                     [security.grpc.roles] entry"
+                ));
+                role_fixes.push(format!("{principal:?} = \"operator\""));
+            }
+        } else if !uds_mode_is_owner_only(cfg.mode) {
+            problems.push(format!(
+                "the UDS listener is group/world-accessible (mode 0o{:o}) \
+                 with no grpc_uds.principal; only an owner-only socket (no \
+                 group/world mode bits, e.g. mode = 0o600) gets the implicit \
+                 {LOCAL_OPERATOR_PRINCIPAL:?} identity",
+                cfg.mode
+            ));
+            listener_fixes.push(
+                "# add to your [global.telemetry.grpc_uds] table \
+                 (or set mode = 0o600 to keep it owner-only):\n\
+                 principal = \"local-admin\""
                     .to_string(),
-            });
-        };
-        validate_grpc_role_principal(config, principal, "grpc_uds.principal")?;
+            );
+            role_fixes.push("\"local-admin\" = \"operator\"".to_string());
+        }
+        // Owner-only UDS with no declared principal authorizes as the
+        // implicit `local-operator` identity — nothing to require. The
+        // same rule covers the implicit default listener.
     }
-    Ok(())
-}
 
-fn validate_grpc_role_principal(
-    config: &Config,
-    principal: &str,
-    field_name: &str,
-) -> Result<(), ConfigError> {
-    if config.security.grpc.roles.contains_key(principal) {
+    if problems.is_empty() {
         return Ok(());
     }
-    Err(ConfigError::InvalidGrpcConfig {
-        reason: format!(
-            "security.grpc.enforcement = \"tier\" requires {field_name} \
-             principal {principal:?} to be present in [security.grpc.roles]"
-        ),
-    })
+
+    role_fixes.dedup();
+    let mut reason = format!(
+        "security.grpc.enforcement = \"tier\" (the v0.24.0 default) found \
+         {} problem(s) with this config:\n",
+        problems.len()
+    );
+    for (idx, problem) in problems.iter().enumerate() {
+        let _ = writeln!(reason, "  {}. {problem}", idx + 1);
+    }
+    reason.push_str("add this to fix it:\n");
+    for fix in &listener_fixes {
+        reason.push_str(fix);
+        reason.push('\n');
+    }
+    if !role_fixes.is_empty() {
+        reason.push_str("[security.grpc.roles]\n");
+        for fix in &role_fixes {
+            reason.push_str(fix);
+            reason.push('\n');
+        }
+    }
+    reason.push_str(
+        "or opt back into legacy with security.grpc.enforcement = \"legacy\" \
+         (migration checklist: docs/CONFIGURATION.md, [security.grpc])",
+    );
+    Err(ConfigError::InvalidGrpcConfig { reason })
 }
 
 fn validate_grpc_principal(principal: Option<&str>, field_name: &str) -> Result<(), ConfigError> {
-    if let Some(principal) = principal
-        && principal.trim().is_empty()
-    {
-        return Err(ConfigError::InvalidGrpcConfig {
-            reason: format!("{field_name} must not be empty"),
-        });
+    if let Some(principal) = principal {
+        if principal.trim().is_empty() {
+            return Err(ConfigError::InvalidGrpcConfig {
+                reason: format!("{field_name} must not be empty"),
+            });
+        }
+        if principal == LOCAL_OPERATOR_PRINCIPAL {
+            return Err(ConfigError::InvalidGrpcConfig {
+                reason: format!(
+                    "{field_name} must not use reserved principal \
+                     {LOCAL_OPERATOR_PRINCIPAL:?}; it is granted implicitly \
+                     to clients of an owner-only UDS listener"
+                ),
+            });
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## Problem

Tier enforcement (the v0.24.0 default) required every UDS listener to declare a `principal` mapped in `[security.grpc.roles]` — including the implicit local socket, which made a zero-config boot impossible and forced an 8-line authz block into the starter profiles. The requirement bought nothing on UDS: the principal is listener-wide, so the roles entry added no per-client discrimination — the socket's filesystem permissions were already the entire authentication story. Two adjacent paper cuts: declaring `grpc_tcp` silently dropped the implicit local socket (breaking `rbgp`), and a config that failed tier validation surfaced its problems one error per boot attempt.

## Fix

- **Implicit `local-operator` (ADR-0064 amendment).** A UDS listener (implicit or declared) with no `principal` and an owner-only mode (`mode & 0o077 == 0`) authorizes its clients as the reserved `local-operator` principal at operator tier, with no roles entry. The identity is resolved when building the listener's auth context — never inserted into the operator's roles map. Audit records label the path distinctly (`authn = "uds_owner"`, `principal = "local-operator"`, `role = "operator"`). Group/world-accessible modes keep the explicit-principal requirement; the listener `max_tier` cap applies unchanged; `local-operator` is reserved (rejected in roles and listener `principal` fields, like `mtls-unresolved`).
- **Implicit UDS survives explicit TCP.** The implicit owner-only UDS at `<runtime_state_dir>/grpc.sock` is synthesized whenever `[global.telemetry.grpc_uds]` is not declared; `enabled = false` opts out. Behavior change with migration note in CHANGELOG (additive convenience; TCP-only configs now also bind the local socket unless opted out).
- **One-shot config diagnosis.** Remaining tier failures (unmapped principals, bearer TCP without principal, unauthenticated TCP, group-accessible UDS without principal, mTLS with empty roles) are collected in a single pass into one error: a numbered problem list ending with a minimal copy-pasteable TOML block built from the config's own principal strings, plus the legacy escape hatch.
- **Profiles.** `--init-config lab|edge` drop `[security.grpc]`/roles/principal and explain the implicit rule in the emitted comment; the contract test pins the new invariant (validates clean under tier with no security block, owner-only mode, comment names `local-operator`).
- **Docs.** ADR-0064 §4 amended (decision-record style; `SO_PEERCRED` per-uid identities considered and deferred), `docs/CONFIGURATION.md` UDS/security sections and migration checklist updated, CHANGELOG entries under [Unreleased]. `docs/reload-matrix.md` untouched (roles stay restart-pinned).

## Security rationale

Owner-only socket permissions are a real authentication boundary: exactly one uid can connect, enforced by the kernel. Granting that uid operator tier matches what the roles table would have expressed anyway, minus the ceremony. The rule deliberately stops at owner-only: a group/world-accessible socket admits multiple identities, so per-client scoping (explicit principal + role) keeps its value and its requirement. The reserved-name rejection makes the implicit identity unforgeable via config.

## Red proofs (in test code)

- Widening the owner-only gate to accept `0o660` fails `grpc_security_tier_rejects_group_accessible_uds_without_principal` and `uds_audit_context_group_accessible_socket_stays_unmapped`.
- Removing the implicit-identity resolution fails `grpc_security_zero_config_boots_under_tier_with_implicit_local_operator`, `uds_audit_context_owner_only_socket_resolves_implicit_local_operator`, and `tier_enforcement_authorizes_implicit_local_operator_with_empty_roles`.
- Removing the reserved-name rejection fails `grpc_security_reserved_local_operator_role_rejected` / `grpc_listener_reserved_local_operator_principal_rejected`.
- Dropping the paste block from the one-shot error fails the `grpc_security_tier_diagnoses_*` tests.

## Verification

| Gate | Result |
|------|--------|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace` | 0 |
| `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` | 0 |
| `python3 scripts/check-clippy-reasons.py` | 0 |
| `python3 scripts/check-v1-stable-surface.py` | 0 |
| `cargo test -p rustbgpd-api authz` | 0 (40 passed) |
| Live smoke: bare config (asn/router_id/neighbor, no security block) `--check --strict` | exit 0 |
| Live smoke: release daemon + `rbgp health` / `rbgp neighbor` over UDS, no token | healthy; audit log shows `authn="uds_owner" principal="local-operator" role="operator" result="handler_ok"` |
| Live smoke: `mode = 0o660` + no principal at `--check` | refused with the one-shot message + paste block |

No `[security.grpc]` or listener schema fields added/renamed/removed — semantics only; the config schema dump is unchanged.
