### PR TITLE
docs: teach the implicit local-operator authz path; fix non-booting snippets

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -20,12 +20,22 @@ grpcurl -plaintext -unix /var/lib/rustbgpd/grpc.sock \
 
 The remaining examples below use
 [grpcurl](https://github.com/fullstorydev/grpcurl) against an explicit local
-TCP listener for readability. Those examples require `grpc_tcp` to be enabled:
+TCP listener for readability. Those examples require `grpc_tcp` to be
+enabled, and under the default tier authorization a TCP listener must
+authenticate — bearer token plus a role-mapped `principal`, or native mTLS:
 
 ```toml
 [global.telemetry.grpc_tcp]
 address = "127.0.0.1:50051"
+token_file = "/etc/rustbgpd/grpc.token"
+principal = "automation.example"
+
+[security.grpc.roles]
+"automation.example" = "operator"
 ```
+
+For readability the examples omit the accompanying
+`-H "authorization: bearer <token>"` metadata header.
 
 The proto definition lives at `proto/rustbgpd.proto`.
 
@@ -163,10 +173,11 @@ Tier enforcement is the default since v0.24.0. When upgrading from an older
 release (or from `enforcement = "legacy"`), stage `[security.grpc.roles]` plus
 explicit listener principals, validate the candidate config with
 `rustbgpd --check`, then move to `enforcement = "tier"` (or rely on the
-default). The implicit default UDS listener is safe for local access under
-legacy mode, but tier mode requires an explicit
-`[global.telemetry.grpc_uds]` block with `principal` so requests can be mapped
-to a role.
+default). The implicit default UDS listener needs no staging: it is
+owner-only, so under tier its clients are authorized as the implicit
+`local-operator` principal at operator tier without a roles entry. Only
+group/world-accessible UDS sockets require an explicit `principal` mapped in
+`[security.grpc.roles]`.
 Explicit Legacy remains accepted today only for temporary migration; it emits
 a validation warning and fails `rustbgpd --check --strict`. The original
 startup deprecation warning shipped in v0.51.0 on 2026-07-11; validation and

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -640,8 +640,10 @@ principal falls back to `mtls-unresolved`.
 
 ADR-0064 per-method authorization defaults to `"tier"` since v0.24.0. Tier
 mode enforces `[security.grpc.roles]` for the authenticated principal before
-the handler runs, in addition to listener `max_tier` caps; upgrading without a
-`[security.grpc.roles]` block fails validation at startup. Legacy mode remains
+the handler runs, in addition to listener `max_tier` caps; a declared
+principal without a matching `[security.grpc.roles]` entry fails validation at
+startup, while owner-only UDS listeners with no principal need no roles block
+at all (implicit `local-operator`). Legacy mode remains
 accepted today only as a temporary migration mode: role mappings are audit
 context only and the listener's `max_tier` is the authoritative authorization
 boundary.
@@ -740,18 +742,28 @@ enforcement = "legacy"
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
 
+# Group-accessible socket (0o660): wider than owner-only, so under tier it
+# requires an explicit principal with a matching role entry below. An
+# owner-only socket (default 0o600) with no principal would instead ride the
+# implicit local-operator identity and need neither.
 [global.telemetry.grpc_uds]
 path = "/var/lib/rustbgpd/grpc.sock"
 mode = 0o660
 access_mode = "read_write"
 principal = "local-admin"
 
+# Under tier a TCP listener must authenticate: bearer token + principal
+# (create the token file first) or native mTLS.
 [global.telemetry.grpc_tcp]
 address = "127.0.0.1:50051"
 access_mode = "read_only"
 max_tier = "sensitive_read"
-# token_file = "/etc/rustbgpd/grpc.token"
-# principal = "observer-readonly"
+token_file = "/etc/rustbgpd/grpc.token"
+principal = "observer-readonly"
+
+[security.grpc.roles]
+"local-admin" = "operator"
+"observer-readonly" = "observer"
 ```
 
 ---

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -233,6 +233,14 @@ The boot config file (TOML) provides initial state. At startup, the daemon loads
 
 ### Minimal Config Example
 
+A bare config boots. No gRPC listener or `[security.grpc]` section is needed
+for local operation: the daemon synthesizes an owner-only Unix socket at
+`<runtime_state_dir>/grpc.sock`, and under the default tier authorization its
+clients are authorized as the implicit `local-operator` principal — the
+socket's filesystem permissions are the authentication. Declaring listeners,
+principals, and roles only becomes necessary for remote (TCP) or
+group-accessible access; see `docs/CONFIGURATION.md` under `[security.grpc]`.
+
 ```toml
 [global]
 asn = 65001
@@ -242,6 +250,18 @@ listen_port = 179
 [global.telemetry]
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
+
+# Explicit, labeled permit-all. An eBGP neighbor with no policy is not a
+# smaller config, it is an unfiltered one.
+[policy.definitions.permit-all-import]
+default_action = "permit"
+
+[policy.definitions.permit-all-export]
+default_action = "permit"
+
+[policy]
+import_chain = ["permit-all-import"]
+export_chain = ["permit-all-export"]
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -255,10 +275,6 @@ address = "10.0.0.3"
 remote_asn = 65001
 description = "ibgp-reflector"
 hold_time = 90
-
-[[neighbors.policy]]
-import = "allow-all"
-export = "deny-all"
 ```
 
 ### Graceful Shutdown

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -109,7 +109,12 @@ rustbgpd config.toml
 ## 4. Verify
 
 The minimal example uses `/tmp/rustbgpd` as its runtime state directory, so point
-the CLI at that socket:
+the CLI at that socket. gRPC access and authorization need no configuration
+here: the local socket is owner-only, so its clients are authorized as the
+implicit `local-operator` principal — even a config with no gRPC or
+`[security.grpc]` section at all gets this listener by default. Remote (TCP)
+or named access needs explicit principals and roles; see
+[CONFIGURATION.md](CONFIGURATION.md#securitygrpc).
 
 <!-- rbgp-cli-conformance -->
 ```bash

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -453,9 +453,16 @@ the roadmap:
   deprecation warning shipped in v0.51.0 on 2026-07-11; validation and
   strict-check enforcement followed in v0.61.0. The two-minor/90-day floor is
   therefore approximately 2026-10-09. That is only eligibility for a later
-  removal decision, not a promised removal date. Configs that rely on the
-  implicit UDS listener must declare `[global.telemetry.grpc_uds]` with a
-  `principal` to run under tier enforcement.
+  removal decision, not a promised removal date. Under tier enforcement, an
+  owner-only UDS socket (no group/world mode bits, e.g. the default `0o600`)
+  with no `principal` — including the implicit default listener — authorizes
+  its clients as the reserved implicit `local-operator` principal at operator
+  tier: the socket's filesystem permissions are the authentication, so no
+  `[security.grpc.roles]` entry is needed. Group- or world-accessible UDS
+  sockets still require an explicit `principal` plus a matching role entry,
+  and `local-operator` is reserved (rejected in roles and listener
+  `principal` fields, like `mtls-unresolved`). Audit records label the
+  implicit path distinctly (`authn = "uds_owner"`).
 - Per-principal request-rate and stream-count budgets are not implemented in
   the daemon. Use listener tier caps, role enforcement, management-network
   controls, client deadlines, and the documented `grpc_authz` / stream metrics

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -104,11 +104,27 @@ listen_port = 179
 prometheus_addr = "127.0.0.1:9179"
 log_format = "json"
 
-# Enable TCP listener for mitigation platform to reach gRPC
-[global.telemetry.grpc_tcp]
-enabled = true
-address = "127.0.0.1:50051"
+# Local gRPC over a filesystem-gated Unix socket — the working default under
+# the tier authorization mode.
+[global.telemetry.grpc_uds]
+path = "/var/lib/rustbgpd/grpc.sock"
+# Audit principal for this socket; mapped to a role in [security.grpc.roles].
+principal = "operator"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+operator = "operator"
+
+# Remote mitigation-platform access over TCP. Under tier a TCP listener needs
+# a bearer token + matching principal (or native mTLS); create the token file
+# first, then uncomment.
+# [global.telemetry.grpc_tcp]
+# enabled = true
+# address = "127.0.0.1:50051"
 # token_file = "/etc/rustbgpd/grpc-token"
+# principal = "operator"
 
 # Edge routers that enforce FlowSpec rules
 [[neighbors]]
@@ -140,7 +156,7 @@ grpcurl -plaintext -d '{
   "actions": {
     "traffic_rate_bytes": 1250000
   }
-}' localhost:50051 rustbgpd.v1.InjectionService/AddFlowSpec
+}' -unix /var/lib/rustbgpd/grpc.sock rustbgpd.v1.InjectionService/AddFlowSpec
 ```
 
 ```bash
@@ -149,14 +165,14 @@ grpcurl -plaintext -d '{
   "prefix": "203.0.113.10/32",
   "next_hop": "192.0.2.1",
   "communities": ["65535:666"]
-}' localhost:50051 rustbgpd.v1.InjectionService/AddPath
+}' -unix /var/lib/rustbgpd/grpc.sock rustbgpd.v1.InjectionService/AddPath
 ```
 
 ```bash
 # Withdraw when the attack subsides
 grpcurl -plaintext -d '{
   "prefix": "203.0.113.10/32"
-}' localhost:50051 rustbgpd.v1.InjectionService/DeletePath
+}' -unix /var/lib/rustbgpd/grpc.sock rustbgpd.v1.InjectionService/DeletePath
 ```
 
 **Monitoring:** Prometheus metrics track FlowSpec rule counts per peer. BMP

--- a/docs/cookbook/evpn-fabric-rr.md
+++ b/docs/cookbook/evpn-fabric-rr.md
@@ -34,15 +34,10 @@ cluster_id = "10.0.0.100"
 prometheus_addr = "127.0.0.1:9179"
 log_format = "json"
 
+# Owner-only local socket (default mode 0600): clients are authorized as the
+# implicit "local-operator" principal — no [security.grpc] block needed.
 [global.telemetry.grpc_uds]
 path = "/var/lib/rustbgpd/grpc.sock"
-principal = "operator"
-
-[security.grpc]
-enforcement = "tier"
-
-[security.grpc.roles]
-operator = "operator"
 
 # All VTEPs are iBGP RR clients on the l2vpn_evpn family. Empty
 # [[evpn_instances]] (none configured) selects pure RR mode: no local

--- a/docs/cookbook/l3vpn-route-reflector.md
+++ b/docs/cookbook/l3vpn-route-reflector.md
@@ -39,15 +39,10 @@ cluster_id = "10.0.0.1"
 prometheus_addr = "127.0.0.1:9179"
 log_format = "json"
 
+# Owner-only local socket (default mode 0600): clients are authorized as the
+# implicit "local-operator" principal — no [security.grpc] block needed.
 [global.telemetry.grpc_uds]
 path = "/var/lib/rustbgpd/grpc.sock"
-principal = "operator"
-
-[security.grpc]
-enforcement = "tier"
-
-[security.grpc.roles]
-operator = "operator"
 
 # PE clients: VPN families plus "rtc" (RFC 4684, AFI 1 / SAFI 132).
 # Each PE advertises its RT membership as RTC NLRIs; the RR filters

--- a/docs/cookbook/monitoring-feed.md
+++ b/docs/cookbook/monitoring-feed.md
@@ -33,15 +33,10 @@ cluster_id = "10.255.0.1"
 prometheus_addr = "127.0.0.1:9179"
 log_format = "json"
 
+# Owner-only local socket (default mode 0600): clients are authorized as the
+# implicit "local-operator" principal — no [security.grpc] block needed.
 [global.telemetry.grpc_uds]
 path = "/var/lib/rustbgpd/grpc.sock"
-principal = "operator"
-
-[security.grpc]
-enforcement = "tier"
-
-[security.grpc.roles]
-operator = "operator"
 
 # Durable event outbox (ADR-0072): restart-safe replay cursor for
 # SubscribeFromEvent. Opt-in — it costs memory/CPU at scale, which is

--- a/docs/cookbook/policy-quickstart.md
+++ b/docs/cookbook/policy-quickstart.md
@@ -134,15 +134,10 @@ listen_port = 179
 prometheus_addr = "127.0.0.1:9179"
 log_format = "json"
 
+# Owner-only local socket (default mode 0600): clients are authorized as the
+# implicit "local-operator" principal — no [security.grpc] block needed.
 [global.telemetry.grpc_uds]
 path = "/var/lib/rustbgpd/grpc.sock"
-principal = "operator"
-
-[security.grpc]
-enforcement = "tier"
-
-[security.grpc.roles]
-operator = "operator"
 
 [policy]
 rpol_files = ["policies/edge.rpol"]   # relative to this config file

--- a/docs/cookbook/route-reflector.md
+++ b/docs/cookbook/route-reflector.md
@@ -33,15 +33,10 @@ dynamic_neighbor_limit = 1024  # cap for the auto-accept range below
 prometheus_addr = "127.0.0.1:9179"
 log_format = "json"
 
+# Owner-only local socket (default mode 0600): clients are authorized as the
+# implicit "local-operator" principal — no [security.grpc] block needed.
 [global.telemetry.grpc_uds]
 path = "/var/lib/rustbgpd/grpc.sock"
-principal = "operator"
-
-[security.grpc]
-enforcement = "tier"
-
-[security.grpc.roles]
-operator = "operator"
 
 # One template for the whole client fleet. Uniform clients group
 # automatically (ADR-0098) — there is no update-group knob.

--- a/docs/cookbook/route-server-shadow-pilot.md
+++ b/docs/cookbook/route-server-shadow-pilot.md
@@ -110,15 +110,10 @@ ebgp_requires_policy = true
 prometheus_addr = "127.0.0.1:9179"
 log_format = "json"
 
+# Owner-only local socket (default mode 0600): clients are authorized as the
+# implicit "local-operator" principal — no [security.grpc] block needed.
 [global.telemetry.grpc_uds]
 path = "/var/lib/rustbgpd/grpc.sock"
-principal = "operator"
-
-[security.grpc]
-enforcement = "tier"
-
-[security.grpc.roles]
-operator = "operator"
 
 # --- RPKI origin validation (your intended production feed) ---
 

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -69,15 +69,10 @@ listen_port = 179
 prometheus_addr = "127.0.0.1:9179"
 log_format = "json"
 
+# Owner-only local socket (default mode 0600): clients are authorized as the
+# implicit "local-operator" principal — no [security.grpc] block needed.
 [global.telemetry.grpc_uds]
 path = "/var/lib/rustbgpd/grpc.sock"
-principal = "operator"
-
-[security.grpc]
-enforcement = "tier"
-
-[security.grpc.roles]
-operator = "operator"
 
 # --- RPKI origin validation ---
 [rpki]

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -41,9 +41,12 @@ this inventory before the handler runs, and applies two checks in order:
 Principals come from the listener's authenticated identity: native mTLS
 listeners derive them from the validated client certificate (`rustbgpd:`
 URI SAN, then email SAN, then Subject CN), while bearer-token and UDS
-listeners carry an explicit configured `principal` label. Under tier
-enforcement, startup validation rejects a listener that offers neither
-rather than falling back open.
+listeners carry an explicit configured `principal` label — except that an
+owner-only UDS listener (no group/world mode bits) with no `principal` is
+authorized as the reserved implicit `local-operator` principal at operator
+tier (`authn = "uds_owner"`). Under tier enforcement, startup validation
+rejects any other listener that offers no principal source rather than
+falling back open.
 
 The tier assigned to each RPC below is therefore load-bearing: it is the
 floor a caller's role must reach and the value a listener cap is compared


### PR DESCRIPTION
Docs sweep for the shipped authz-UX semantics (#1429 implicit `local-operator` for owner-only UDS + one-shot tier diagnosis; #1428 actionable denials + `rbgp doctor` authz checks). Docs-only; zero source changes.

## What changed

- **docs/DESIGN.md** — the "Minimal Config Example" was non-booting (`[[neighbors.policy]]` with `import`/`export` keys is not real config syntax). Replaced with labeled permit-all chains; new prose states the zero-config truth: a bare config boots, the implicit owner-only UDS socket authorizes as `local-operator`, no security block needed for local operation. Snippet passes `--check --strict`.
- **docs/USE_CASES.md** — the DDoS example showed an unauthenticated `grpc_tcp` listener, which tier enforcement rejects at config load. Aligned with the tier-correct `examples/ddos-mitigation/config.toml` (UDS + mapped principal, TCP commented with the token prerequisite) and moved the grpcurl workflow to the `-unix` socket form.
- **docs/SECURITY.md** — the current-gaps bullet still said configs relying on the implicit UDS listener must declare a principal. Rewritten for the implicit rule: owner-only mode implies implicit `local-operator` at operator tier; group/world-accessible modes require an explicit principal + role; `local-operator` is reserved; `authn = "uds_owner"` audit labeling.
- **docs/QUICKSTART.md** — a few sentences at the Verify step: local socket access needs zero authz config; CONFIGURATION.md link for remote/named access.
- **Cookbooks (7)** — `monitoring-feed`, `route-server`, `l3vpn-route-reflector`, `policy-quickstart`, `route-reflector`, `evpn-fabric-rr`, `route-server-shadow-pilot` all carried the same 8-line local-only authz block that is now ceremony. Replaced with the owner-only socket plus a one-line implicit-rule note. The other six cookbooks configure no gRPC listener and needed nothing.
- **docs/CONFIGURATION.md** — two leftovers post-#1429: the `[security.grpc]` intro still claimed any tier config fails without a roles block, and the mixed-listener example was invalid under the default tier (0o660 UDS principal with no role mapping, unauthenticated TCP). Both corrected; the example now doubles as the group-accessible-vs-owner-only teaching case.
- **docs/API.md** — the grpcurl TCP prerequisite snippet was rejected under tier (no token/mTLS); now shows token + mapped principal and notes the omitted `authorization: bearer` header. The migration paragraph no longer requires declaring the implicit UDS listener with a principal.
- **docs/grpc-method-inventory.md** — the principal-source paragraph now carves out the owner-only implicit identity (`authn = "uds_owner"`) instead of claiming validation rejects every principal-less listener.

## Snippet validation

Each changed TOML snippet was extracted verbatim and run through a freshly built `rustbgpd --check`:

| Snippet | Mode | Result |
|---|---|---|
| DESIGN.md minimal config | `--check --strict` | pass |
| USE_CASES.md DDoS config | `--check` | pass (abridged excerpt; only the expected eBGP-no-policy warning blocks strict) |
| CONFIGURATION.md mixed-listener example | `--check --strict` | pass (fragment scaffolded with `[global]`; token path pointed at a fixture file) |
| API.md grpc_tcp prerequisite | `--check --strict` | pass (same scaffolding) |
| cookbook monitoring-feed, l3vpn-route-reflector, policy-quickstart, route-reflector, evpn-fabric-rr, route-server-shadow-pilot | `--check --strict` | pass |
| cookbook route-server | `--check` | pass (abridged excerpt; expected eBGP-no-policy warning only) |

`git diff --check` clean; diff touches `docs/` only.
