### PR TITLE
authz: retire legacy gRPC enforcement; tier is mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING: `security.grpc.enforcement = "legacy"` no longer boots.** The
+  pre-v0.24.0 gRPC authorization mode — roles recorded as audit context but
+  never enforced, listener `max_tier` as the only ceiling — is removed as a
+  functioning mode. The value still parses (the v1 config surface keeps the
+  enum variant, now deprecated) but validation rejects it at boot, `--check`,
+  and SIGHUP/transaction reload with a one-shot message carrying the
+  migration steps. The runtime legacy path, its startup advisory, and the
+  `enforcement` audit-log label are gone; ADR-0064 per-principal role
+  ceilings are now enforced unconditionally.
+
+  Migration: if your only management surface is a local socket (`rbgp` over
+  UDS, including the implicit default at `<runtime_state_dir>/grpc.sock`),
+  delete the whole `[security.grpc]` block — the owner-only socket authorizes
+  its clients as the implicit `local-operator` identity. A listener with a
+  declared `principal` keeps working with three lines:
+
+  ```toml
+  [security.grpc]
+  enforcement = "tier"
+
+  [security.grpc.roles]
+  "<your-principal>" = "operator"
+  ```
+
+  Supersession note: docs previously projected a two-minor/90-day floor
+  (≈2026-10-09) as the earliest *eligibility* for this removal. The cut lands
+  earlier as an explicit owner decision under the project's pre-1.0 alpha
+  stability posture, taken once the implicit `local-operator` identity
+  (below) removed the migration burden for local-only deployments.
+
 ### Changed
 
 - **Implicit `local-operator` identity for owner-only UDS listeners

--- a/bench/scale/enhanced-route-refresh/gen-scenario.py
+++ b/bench/scale/enhanced-route-refresh/gen-scenario.py
@@ -36,9 +36,6 @@ prometheus_addr = "127.0.0.1:{metrics_port}"
 [global.telemetry.grpc_uds]
 path = "{socket}"
 
-[security.grpc]
-enforcement = "legacy"
-
 [[neighbors]]
 address = "127.1.0.1"
 remote_asn = 64512

--- a/bench/scale/reloadstall/gen-irr-scenario.py
+++ b/bench/scale/reloadstall/gen-irr-scenario.py
@@ -357,11 +357,9 @@ def bench_telemetry_block(rundir: pathlib.Path) -> str:
         'prometheus_addr = "127.0.0.1:9179"\n'
         "\n"
         "[global.telemetry.grpc_uds]\n"
+        "# Owner-only socket: clients authorize as the implicit\n"
+        "# local-operator, so no [security.grpc] block is needed.\n"
         f'path = "{rundir}/grpc.sock"\n'
-        "\n"
-        "[security.grpc]\n"
-        "# Loopback benchmark: UDS access is gated by file perms.\n"
-        'enforcement = "legacy"\n'
         "\n"
     )
 

--- a/bench/scale/reloadstall/gen-scenario.py
+++ b/bench/scale/reloadstall/gen-scenario.py
@@ -153,12 +153,9 @@ config = [
     'prometheus_addr = "127.0.0.1:9179"',
     "",
     "[global.telemetry.grpc_uds]",
-    f'path = "{rundir}/grpc.sock"',  # the `rbgp health` control-query probe dials this
-    "",
-    "[security.grpc]",
-    # Loopback benchmark: UDS access is gated by file perms; legacy mode lets
-    # the control-query probe dial without a per-method role map.
-    'enforcement = "legacy"',
+    # The `rbgp health` control-query probe dials this owner-only socket and
+    # authorizes as the implicit local-operator — no [security.grpc] needed.
+    f'path = "{rundir}/grpc.sock"',
     "",
     "[policy]",
     'rpol_files = ["member.rpol"]',

--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -3,8 +3,10 @@
 //! ADR-0064 uses this table as the code-level source of truth for
 //! method risk tiers. Runtime authorization enforces listener-level
 //! `AccessMode` checks in `server.rs`, per-listener `max_tier`
-//! ceilings in `authz_runtime`, and per-principal role ceilings under
-//! ADR-0064 `enforcement = "tier"`, the default since v0.24.0.
+//! ceilings in `authz_runtime`, and ADR-0064 per-principal role
+//! ceilings — unconditionally: the pre-v0.24.0 "legacy" mode that
+//! skipped role ceilings was removed, and config validation rejects
+//! `enforcement = "legacy"` outright.
 
 /// Authorization tier assigned to one gRPC method.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -28,29 +30,6 @@ impl AuthTier {
             Self::SensitiveRead => "sensitive_read",
             Self::Mutating => "mutating",
             Self::OperatorOnly => "operator_only",
-        }
-    }
-}
-
-/// Runtime gRPC authorization enforcement mode.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub enum AuthEnforcement {
-    /// Preserve legacy listener-wide behavior. Listener `max_tier`
-    /// caps still apply, but principal roles do not authorize calls.
-    #[default]
-    Legacy,
-    /// Enforce per-principal role ceilings in addition to listener
-    /// `max_tier` caps.
-    Tier,
-}
-
-impl AuthEnforcement {
-    /// Stable lower-case label used by logs and tests.
-    #[must_use]
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Legacy => "legacy",
-            Self::Tier => "tier",
         }
     }
 }

--- a/crates/api/src/authz_runtime/context.rs
+++ b/crates/api/src/authz_runtime/context.rs
@@ -8,7 +8,7 @@ use tonic::codegen::http;
 use tonic::transport::server::{TcpConnectInfo, TlsConnectInfo};
 use tracing::debug;
 
-use crate::authz::{AuthEnforcement, AuthTier, LOCAL_OPERATOR_PRINCIPAL, PrincipalRole};
+use crate::authz::{AuthTier, LOCAL_OPERATOR_PRINCIPAL, PrincipalRole};
 use crate::authz_principal::{PrincipalExtractionError, principal_from_peer_certs};
 use crate::connect_info::RustbgpdTcpConnectInfo;
 use crate::credentials::{CredentialStore, PinnedCredentialGeneration};
@@ -53,7 +53,6 @@ pub struct GrpcAuthAuditContext {
     pub(super) max_tier: AuthTier,
     pub(super) authn: GrpcAuthnKind,
     principal: String,
-    pub(super) enforcement: AuthEnforcement,
     roles: Arc<BTreeMap<String, PrincipalRole>>,
     // Role granted to the reserved `local-operator` principal on an
     // owner-only UDS listener without consulting the roles map — the
@@ -80,7 +79,6 @@ impl GrpcAuthAuditContext {
             max_tier,
             authn,
             principal: principal.into(),
-            enforcement: AuthEnforcement::Legacy,
             roles: Arc::new(BTreeMap::new()),
             implicit_role: None,
             resolve_mtls_principal: false,
@@ -89,14 +87,11 @@ impl GrpcAuthAuditContext {
         }
     }
 
-    /// Attach the global ADR-0064 enforcement mode and principal-role map.
+    /// Attach the global ADR-0064 principal-role map. Role ceilings are
+    /// enforced unconditionally — the removed "legacy" mode was the only
+    /// way to skip them.
     #[must_use]
-    pub fn with_role_enforcement(
-        mut self,
-        enforcement: AuthEnforcement,
-        roles: Arc<BTreeMap<String, PrincipalRole>>,
-    ) -> Self {
-        self.enforcement = enforcement;
+    pub fn with_roles(mut self, roles: Arc<BTreeMap<String, PrincipalRole>>) -> Self {
         self.roles = roles;
         self
     }
@@ -174,9 +169,6 @@ impl GrpcAuthAuditContext {
     }
 
     pub(super) fn role_denial(&self, principal: &str, tier: AuthTier) -> Option<RoleDenial> {
-        if self.enforcement != AuthEnforcement::Tier {
-            return None;
-        }
         let Some(role) = self.resolve_role(principal) else {
             return Some(RoleDenial::PrincipalUnmapped);
         };
@@ -187,9 +179,6 @@ impl GrpcAuthAuditContext {
     }
 
     pub(super) fn role_label(&self, principal: &str) -> &'static str {
-        if self.enforcement != AuthEnforcement::Tier {
-            return "legacy";
-        }
         self.resolve_role(principal)
             .map_or("unmapped", PrincipalRole::as_str)
     }

--- a/crates/api/src/authz_runtime/decision.rs
+++ b/crates/api/src/authz_runtime/decision.rs
@@ -122,7 +122,6 @@ pub(super) fn record_audit_decision(
     let access_mode = context.access_mode;
     let max_tier = context.max_tier.as_str();
     let authn = context.authn.as_str();
-    let enforcement = context.enforcement.as_str();
     let role = context.role_label(principal);
     let request_summary = request_summary.map_or("", GrpcRequestSummary::as_str);
 
@@ -139,7 +138,6 @@ pub(super) fn record_audit_decision(
             access_mode,
             max_tier,
             authn,
-            enforcement,
             role,
             principal,
             request_summary,
@@ -158,7 +156,6 @@ pub(super) fn record_audit_decision(
             access_mode,
             max_tier,
             authn,
-            enforcement,
             role,
             principal,
             request_summary,

--- a/crates/api/src/authz_runtime/tests.rs
+++ b/crates/api/src/authz_runtime/tests.rs
@@ -23,7 +23,7 @@ use tower::{Layer, Service};
 
 use super::*;
 use crate::audit::{GrpcAuditHandle, GrpcRequestSummary};
-use crate::authz::{AuthEnforcement, AuthTier, LOCAL_OPERATOR_PRINCIPAL, PrincipalRole};
+use crate::authz::{AuthTier, LOCAL_OPERATOR_PRINCIPAL, PrincipalRole};
 use crate::connect_info::{RustbgpdTcpConnectInfo, RustbgpdTcpStream};
 use crate::test_support::metrics_text as gather_text;
 
@@ -104,7 +104,7 @@ fn tier_test_context(
     role: PrincipalRole,
 ) -> GrpcAuthAuditContext {
     GrpcAuthAuditContext::new(listener, access_mode, max_tier, authn, principal)
-        .with_role_enforcement(AuthEnforcement::Tier, roles(&[(principal, role)]))
+        .with_roles(roles(&[(principal, role)]))
 }
 
 fn private_key(key: &KeyPair) -> PrivateKeyDer<'static> {
@@ -459,10 +459,7 @@ async fn tier_enforcement_allows_observer_sensitive_read() {
         GrpcAuthnKind::BearerToken,
         "observer.example",
     )
-    .with_role_enforcement(
-        AuthEnforcement::Tier,
-        roles(&[("observer.example", PrincipalRole::Observer)]),
-    )
+    .with_roles(roles(&[("observer.example", PrincipalRole::Observer)]))
     .with_bearer_token(Some("secret"));
     let layer = GrpcAuthzLayer::new(context, metrics.clone());
     let mut service = layer.layer(EchoService);
@@ -520,10 +517,7 @@ async fn tier_enforcement_denies_operator_only_for_automation() {
         GrpcAuthnKind::Uds,
         "automation.example",
     )
-    .with_role_enforcement(
-        AuthEnforcement::Tier,
-        roles(&[("automation.example", PrincipalRole::Automation)]),
-    );
+    .with_roles(roles(&[("automation.example", PrincipalRole::Automation)]));
     let layer = GrpcAuthzLayer::new(context, metrics.clone());
     let mut service = layer.layer(EchoService);
     let request = Request::builder()
@@ -549,10 +543,7 @@ async fn tier_enforcement_allows_operator_only_for_operator() {
         GrpcAuthnKind::Uds,
         "operator.example",
     )
-    .with_role_enforcement(
-        AuthEnforcement::Tier,
-        roles(&[("operator.example", PrincipalRole::Operator)]),
-    );
+    .with_roles(roles(&[("operator.example", PrincipalRole::Operator)]));
     let layer = GrpcAuthzLayer::new(context, metrics.clone());
     let mut service = layer.layer(EchoService);
     let request = Request::builder()
@@ -577,7 +568,7 @@ async fn tier_enforcement_denies_unmapped_principal() {
         GrpcAuthnKind::Uds,
         "unmapped.example",
     )
-    .with_role_enforcement(AuthEnforcement::Tier, roles(&[]));
+    .with_roles(roles(&[]));
     let layer = GrpcAuthzLayer::new(context, metrics.clone());
     let mut service = layer.layer(EchoService);
     let request = Request::builder()
@@ -607,7 +598,7 @@ async fn tier_enforcement_authorizes_implicit_local_operator_with_empty_roles() 
         GrpcAuthnKind::UdsOwner,
         LOCAL_OPERATOR_PRINCIPAL,
     )
-    .with_role_enforcement(AuthEnforcement::Tier, roles(&[]))
+    .with_roles(roles(&[]))
     .with_implicit_local_operator();
     let layer = GrpcAuthzLayer::new(context, metrics.clone());
     let mut service = layer.layer(EchoService);
@@ -636,7 +627,7 @@ async fn tier_enforcement_still_caps_implicit_local_operator_by_listener_tier() 
         GrpcAuthnKind::UdsOwner,
         LOCAL_OPERATOR_PRINCIPAL,
     )
-    .with_role_enforcement(AuthEnforcement::Tier, roles(&[]))
+    .with_roles(roles(&[]))
     .with_implicit_local_operator();
     let layer = GrpcAuthzLayer::new(context, metrics.clone());
     let mut service = layer.layer(EchoService);
@@ -663,10 +654,7 @@ async fn tier_enforcement_authenticates_bearer_before_role_denial() {
         GrpcAuthnKind::BearerToken,
         "observer.example",
     )
-    .with_role_enforcement(
-        AuthEnforcement::Tier,
-        roles(&[("observer.example", PrincipalRole::Observer)]),
-    )
+    .with_roles(roles(&[("observer.example", PrincipalRole::Observer)]))
     .with_bearer_token(Some("secret"));
     let layer = GrpcAuthzLayer::new(context, metrics.clone());
     let mut service = layer.layer(EchoService);
@@ -694,10 +682,7 @@ async fn listener_cap_remains_stricter_than_operator_role() {
         GrpcAuthnKind::Uds,
         "operator.example",
     )
-    .with_role_enforcement(
-        AuthEnforcement::Tier,
-        roles(&[("operator.example", PrincipalRole::Operator)]),
-    );
+    .with_roles(roles(&[("operator.example", PrincipalRole::Operator)]));
     let layer = GrpcAuthzLayer::new(context, metrics.clone());
     let mut service = layer.layer(EchoService);
     let request = Request::builder()
@@ -729,7 +714,7 @@ async fn unmapped_denial_names_principal_and_roles_entry_fix() {
         GrpcAuthnKind::Uds,
         "ci-bot",
     )
-    .with_role_enforcement(AuthEnforcement::Tier, roles(&[]));
+    .with_roles(roles(&[]));
     let layer = GrpcAuthzLayer::new(context, metrics);
     let mut service = layer.layer(EchoService);
     let request = Request::builder()

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -20,9 +20,7 @@ use tonic::transport::Server;
 use tonic::{Request, Status};
 use tracing::{error, info, warn};
 
-use crate::authz::{
-    AuthEnforcement, AuthTier, LOCAL_OPERATOR_PRINCIPAL, PrincipalRole, uds_mode_is_owner_only,
-};
+use crate::authz::{AuthTier, LOCAL_OPERATOR_PRINCIPAL, PrincipalRole, uds_mode_is_owner_only};
 use crate::authz_runtime::{GrpcAuthAuditContext, GrpcAuthnKind, GrpcAuthzLayer};
 use crate::bfd_service::BfdService;
 use crate::config_service::ConfigService;
@@ -691,9 +689,8 @@ pub struct ListenerConfig {
     pub access_mode: AccessMode,
     /// Effective ADR-0064 listener method-tier ceiling.
     pub max_tier: AuthTier,
-    /// ADR-0064 principal-role enforcement mode.
-    pub enforcement: AuthEnforcement,
-    /// Global principal-to-role map used when `enforcement = tier`.
+    /// Global ADR-0064 principal-to-role map; role ceilings are
+    /// enforced unconditionally.
     pub roles: Arc<BTreeMap<String, PrincipalRole>>,
     pub credential_store: CredentialStore,
     pub credential_index: usize,
@@ -742,17 +739,11 @@ pub enum ListenerEndpoint {
     Uds { path: PathBuf, mode: u32 },
 }
 
-#[derive(Clone)]
-struct RuntimeAuthzConfig {
-    enforcement: AuthEnforcement,
-    roles: Arc<BTreeMap<String, PrincipalRole>>,
-}
-
 fn tcp_audit_context(
     addr: SocketAddr,
     access_mode: AccessMode,
     max_tier: AuthTier,
-    role_config: RuntimeAuthzConfig,
+    roles: Arc<BTreeMap<String, PrincipalRole>>,
     bearer_enabled: bool,
     tls_enabled: bool,
     configured_principal: Option<&str>,
@@ -778,7 +769,7 @@ fn tcp_audit_context(
         authn,
         principal,
     )
-    .with_role_enforcement(role_config.enforcement, role_config.roles);
+    .with_roles(roles);
     if tls_enabled {
         context.with_mtls_peer_principal()
     } else {
@@ -791,7 +782,7 @@ fn uds_audit_context(
     mode: u32,
     access_mode: AccessMode,
     max_tier: AuthTier,
-    role_config: RuntimeAuthzConfig,
+    roles: Arc<BTreeMap<String, PrincipalRole>>,
     auth_token: Option<&str>,
     configured_principal: Option<&str>,
 ) -> GrpcAuthAuditContext {
@@ -831,7 +822,7 @@ fn uds_audit_context(
         authn,
         principal,
     )
-    .with_role_enforcement(role_config.enforcement, role_config.roles)
+    .with_roles(roles)
     .with_bearer_token(auth_token);
     if implicit_operator {
         context.with_implicit_local_operator()
@@ -1063,7 +1054,6 @@ async fn run_listener(
         endpoint,
         access_mode,
         max_tier,
-        enforcement,
         roles,
         credential_store,
         credential_index,
@@ -1076,7 +1066,6 @@ async fn run_listener(
                 addr,
                 access_mode,
                 max_tier,
-                enforcement,
                 roles,
                 credential_store,
                 credential_index,
@@ -1136,7 +1125,6 @@ async fn run_listener(
                 mode,
                 access_mode,
                 max_tier,
-                enforcement,
                 roles,
                 credential_store,
                 credential_index,
@@ -1202,7 +1190,6 @@ async fn run_tcp_listener(
     addr: SocketAddr,
     access_mode: AccessMode,
     max_tier: AuthTier,
-    enforcement: AuthEnforcement,
     roles: Arc<BTreeMap<String, PrincipalRole>>,
     credential_store: CredentialStore,
     credential_index: usize,
@@ -1274,7 +1261,7 @@ async fn run_tcp_listener(
         bound_addr,
         access_mode,
         max_tier,
-        RuntimeAuthzConfig { enforcement, roles },
+        roles,
         auth_enabled,
         tls_enabled,
         principal.as_deref(),
@@ -1462,7 +1449,6 @@ async fn run_uds_listener(
     mode: u32,
     access_mode: AccessMode,
     max_tier: AuthTier,
-    enforcement: AuthEnforcement,
     roles: Arc<BTreeMap<String, PrincipalRole>>,
     credential_store: CredentialStore,
     credential_index: usize,
@@ -1525,7 +1511,7 @@ async fn run_uds_listener(
         mode,
         access_mode,
         max_tier,
-        RuntimeAuthzConfig { enforcement, roles },
+        roles,
         None,
         principal.as_deref(),
     );
@@ -1747,24 +1733,22 @@ mod tests {
     use crate::proto::{EventCategory, WatchEventsRequest};
     use crate::test_support::{session_event, spawn_fake_peer_manager, spawn_fake_rib};
 
-    fn tier_authz(principal: &str) -> RuntimeAuthzConfig {
-        RuntimeAuthzConfig {
-            enforcement: AuthEnforcement::Tier,
-            roles: Arc::new(BTreeMap::from([(
-                principal.to_string(),
-                PrincipalRole::Operator,
-            )])),
-        }
+    fn tier_authz(principal: &str) -> Arc<BTreeMap<String, PrincipalRole>> {
+        Arc::new(BTreeMap::from([(
+            principal.to_string(),
+            PrincipalRole::Operator,
+        )]))
     }
 
-    /// Mutation proof: restoring the old Legacy test builder or dropping its
-    /// principal mapping makes one of these exact assertions red.
+    /// Tier enforcement is unconditional: `AuthEnforcement` no longer
+    /// exists, so a legacy allow-all context cannot be constructed at the
+    /// type level. This pins the builder's principal mapping — dropping it
+    /// makes the assertion red.
     #[test]
     fn test_authz_builder_uses_tier_operator_role() {
-        let config = tier_authz("rustbgpd://operator/api-test");
-        assert_eq!(config.enforcement, AuthEnforcement::Tier);
+        let roles = tier_authz("rustbgpd://operator/api-test");
         assert_eq!(
-            config.roles.get("rustbgpd://operator/api-test"),
+            roles.get("rustbgpd://operator/api-test"),
             Some(&PrincipalRole::Operator)
         );
     }
@@ -2062,10 +2046,7 @@ mod tests {
             0o600,
             AccessMode::ReadWrite,
             AuthTier::OperatorOnly,
-            RuntimeAuthzConfig {
-                enforcement: AuthEnforcement::Tier,
-                roles: Arc::new(BTreeMap::new()),
-            },
+            Arc::new(BTreeMap::new()),
             None,
             None,
         );
@@ -2083,10 +2064,7 @@ mod tests {
             0o660,
             AccessMode::ReadWrite,
             AuthTier::OperatorOnly,
-            RuntimeAuthzConfig {
-                enforcement: AuthEnforcement::Tier,
-                roles: Arc::new(BTreeMap::new()),
-            },
+            Arc::new(BTreeMap::new()),
             None,
             None,
         );

--- a/docs/API.md
+++ b/docs/API.md
@@ -138,12 +138,12 @@ machine-readable export for auditors and generated clients; the Rust `authz`
 tests verify it against the source-of-truth matrix. The runtime records tier
 decisions for every RPC via structured `grpc_authz` logs and
 `bgp_grpc_authz_decisions_total{tier,result,authn,access_mode}`. Listener
-`max_tier` caps are enforced in all modes. When
-`[security.grpc].enforcement = "tier"` is enabled, the same runtime layer also
-enforces the authenticated principal's configured role ceiling before the
-handler runs; `"tier"` is the default since v0.24.0, and `"legacy"` is the
-temporary migration mode. In Legacy, configured roles are audit context only
-and the listener's `max_tier` remains the authoritative authorization boundary.
+`max_tier` caps are always enforced. The same runtime layer also enforces the
+authenticated principal's configured role ceiling before the handler runs —
+unconditionally: `"tier"` has been the default since v0.24.0 and is the only
+mode since v0.63.0. The former `"legacy"` migration mode (roles recorded as
+audit context but never enforced) was removed; a config that still sets it is
+rejected at boot, `--check`, and reload with a migration message.
 Forwarded calls emit result-aware labels such as `result="handler_ok"` or
 `result="handler_invalid_argument"` after the handler returns. Rejected calls use
 bounded pre-handler labels: `result="listener_tier_denied"` means the method was
@@ -158,32 +158,36 @@ logs; `DiffRuntimeConfigRequest.candidate_toml`,
 `ApplyConfigTransactionRequest.candidate_toml` are always summarized as
 redacted metadata, transaction apply comments are not logged verbatim, and
 `SetPeerGroup` logs MD5 state without the MD5 value.
-Operators can now predeclare `[security.grpc.roles]` and set explicit
-listener `principal` labels for bearer-token TCP and UDS listeners. In legacy
-mode those labels improve audit identity only; in tier mode they are the
-principal strings looked up in `[security.grpc.roles]`.
+Operators declare `[security.grpc.roles]` and set explicit listener
+`principal` labels for bearer-token TCP and UDS listeners; those labels are
+the principal strings looked up in `[security.grpc.roles]`.
 Native mTLS listeners derive the audit principal from the client certificate
 using ADR-0064 precedence: `rustbgpd:` URI SAN, then email SAN, then Subject
-CN. A validated cert without those fields falls back to `mtls-unresolved` while
-legacy mode remains active. Extracted principal values must fit the bounded
+CN. Extracted principal values must fit the bounded
 audit label form and must not contain embedded control characters; unsupported
-values also fall back to `mtls-unresolved`.
+values fall back to `mtls-unresolved`, which cannot be mapped in
+`[security.grpc.roles]` and is therefore denied.
 
-Tier enforcement is the default since v0.24.0. When upgrading from an older
-release (or from `enforcement = "legacy"`), stage `[security.grpc.roles]` plus
-explicit listener principals, validate the candidate config with
-`rustbgpd --check`, then move to `enforcement = "tier"` (or rely on the
-default). The implicit default UDS listener needs no staging: it is
-owner-only, so under tier its clients are authorized as the implicit
-`local-operator` principal at operator tier without a roles entry. Only
-group/world-accessible UDS sockets require an explicit `principal` mapped in
-`[security.grpc.roles]`.
-Explicit Legacy remains accepted today only for temporary migration; it emits
-a validation warning and fails `rustbgpd --check --strict`. The original
-startup deprecation warning shipped in v0.51.0 on 2026-07-11; validation and
-strict-check enforcement followed in v0.61.0. The two-minor/90-day
-compatibility floor is therefore approximately 2026-10-09. That floor is
-eligibility for a later removal decision, not a promised removal date.
+Tier enforcement is the default since v0.24.0 and mandatory since v0.63.0.
+When upgrading from an older release, stage `[security.grpc.roles]` plus
+explicit listener principals and validate the candidate config with
+`rustbgpd --check`. The implicit default UDS listener needs no staging: it is
+owner-only, so its clients are authorized as the implicit
+`local-operator` principal at operator tier without a roles entry — a config
+whose only management surface is a local socket needs no `[security.grpc]`
+block at all. Only group/world-accessible UDS sockets require an explicit
+`principal` mapped in `[security.grpc.roles]`.
+`enforcement = "legacy"` was removed in v0.63.0 and is rejected at
+validation. Earlier editions of this document projected a two-minor/90-day
+compatibility floor (approximately 2026-10-09) as the earliest *eligibility*
+for removal; that guidance is superseded. The removal landed earlier as an
+explicit owner decision under the project's pre-1.0 alpha stability posture
+(see `README`/`ROADMAP` on version stability), taken once the implicit
+`local-operator` identity removed the migration burden for local-only
+deployments: for them the migration is deleting the `[security.grpc]` block.
+A stuck operator keeps a named-principal setup working with three lines —
+`enforcement = "tier"` plus a `[security.grpc.roles]` entry mapping the
+listener's `principal`; the rejection message carries the exact paste block.
 [`docs/SECURITY.md`](SECURITY.md) covers deployment hardening for this surface,
 and [ADR-0064](adr/0064-grpc-authorization.md) records the tier model itself and
 which of its slices remain open.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -624,33 +624,33 @@ RPCs continue. Invalid or missing material rejects the whole credential reload.
 Changing the path or enabling/disabling token auth remains restart-required.
 
 **ADR-0064 principals:** `principal` gives `grpc_authz` records a stable
-operator-controlled identity. Under the default tier enforcement it is also
-the identity looked up in `[security.grpc.roles]`; under legacy enforcement it
-is audit context only. On UDS listeners it labels the listener identity
+operator-controlled identity, and it is
+the identity looked up in `[security.grpc.roles]`. On UDS listeners it labels the listener identity
 established by filesystem permissions and/or the optional token. On TCP
 listeners it is accepted only when `token_file` is configured and native mTLS
 is not configured. Native mTLS listeners derive the audit principal from the
 peer certificate in ADR-0064 order: first `rustbgpd:`
 URI SAN, then email SAN, then Subject CN. If a validated client certificate has
 none of those fields, or if the selected value is too long or contains embedded
-control characters, the request remains allowed in legacy mode and the audit
-principal falls back to `mtls-unresolved`.
+control characters, the audit
+principal falls back to `mtls-unresolved`, which cannot be mapped in
+`[security.grpc.roles]` and is therefore denied.
 
 ### `[security.grpc]`
 
-ADR-0064 per-method authorization defaults to `"tier"` since v0.24.0. Tier
+ADR-0064 per-method authorization is `"tier"` — the default since v0.24.0
+and the only mode since v0.63.0. Tier
 mode enforces `[security.grpc.roles]` for the authenticated principal before
 the handler runs, in addition to listener `max_tier` caps; a declared
 principal without a matching `[security.grpc.roles]` entry fails validation at
 startup, while owner-only UDS listeners with no principal need no roles block
-at all (implicit `local-operator`). Legacy mode remains
-accepted today only as a temporary migration mode: role mappings are audit
-context only and the listener's `max_tier` is the authoritative authorization
-boundary.
+at all (implicit `local-operator`). The former `"legacy"` migration mode was
+removed in v0.63.0: the value still parses but is rejected at boot,
+`--check`, and reload with a message carrying the migration steps.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `enforcement` | string | no | `"tier"` | ADR-0064 enforcement mode (default since v0.24.0). `"tier"` enables per-principal role enforcement in addition to listener `max_tier` caps. `"legacy"` is the temporary migration mode in which roles are audit-only and the listener cap authorizes calls |
+| `enforcement` | string | no | `"tier"` | ADR-0064 enforcement mode. `"tier"` (default since v0.24.0, the only mode since v0.63.0) enforces per-principal role ceilings in addition to listener `max_tier` caps. `"legacy"` was removed in v0.63.0 and is rejected at validation |
 
 `[security.grpc.roles]` maps an authenticated principal string to one of the
 built-in roles:
@@ -684,19 +684,22 @@ that specific config.
 **Default changed to `tier` in v0.24.0.** Upgrading a deployment that
 uses TCP listeners, group/world-accessible UDS sockets, or declared
 principals without staging the migration first will fail validation at
-startup; the error lists every problem, ends with a paste-ready fix,
-and points at the `enforcement = "legacy"` escape hatch. Deployments
+startup; the error lists every problem and ends with a paste-ready
+fix. Deployments
 that only use an owner-only UDS socket (including the implicit default)
 boot without any staging via the implicit `local-operator` identity.
 Already-staged operators see no behavior change.
 
-Explicit `enforcement = "legacy"` emits a validation warning, and
-`rustbgpd --check --strict` rejects any config that retains it. The original
-startup deprecation warning shipped in v0.51.0 on 2026-07-11; validation and
-strict-check enforcement followed in v0.61.0. The two-minor/90-day
-compatibility floor is therefore approximately 2026-10-09; reaching that floor
-makes Legacy eligible for a later removal decision, but does not promise
-removal on that date.
+**`enforcement = "legacy"` was removed in v0.63.0** and is rejected at boot,
+`--check`, and reload. Earlier editions of this document projected a
+two-minor/90-day floor (≈2026-10-09) as the earliest *eligibility* for
+removal; that guidance is superseded — the removal landed earlier as an
+explicit owner decision under the project's pre-1.0 alpha stability posture,
+once the implicit `local-operator` identity removed the migration burden for
+local-only deployments. If an upgrade hits the rejection: local-only configs
+delete the whole `[security.grpc]` block; named-principal setups keep the
+three-line tier config shown in the rejection message (`enforcement =
+"tier"` plus a `[security.grpc.roles]` entry for the listener principal).
 
 The safe migration sequence (run against a pre-upgrade daemon if
 possible):
@@ -709,15 +712,11 @@ possible):
 3. For remote TCP, prefer native mTLS so the principal is derived from the
    client certificate; otherwise use `token_file` plus a non-secret
    `principal` label.
-4. Set `enforcement = "legacy"` only while staging labels and roles, then run
-   `rustbgpd --check` against the candidate TOML. This intentionally warns and
-   cannot pass `--check --strict` until the explicit Legacy setting is removed.
-5. Remove the explicit `enforcement = "legacy"` (or change it to
-   `"tier"`) and monitor `grpc_authz` logs/metrics for
+4. Run `rustbgpd --check` against the candidate TOML; a config that fails
+   the tier rules is rejected with a single error listing every problem and
+   a paste-ready fix.
+5. Deploy and monitor `grpc_authz` logs/metrics for
    `principal_unmapped` and `role_tier_denied`.
-6. If migration cannot finish in one change window, keep explicit Legacy as a
-   documented, time-bounded exception and retain the narrowest practical
-   listener `max_tier` until Tier can be restored.
 
 ```toml
 # The v0.24.0 default — equivalent to omitting [security.grpc]
@@ -729,12 +728,6 @@ enforcement = "tier"
 "observer-readonly" = "observer"
 "automation.example" = "automation"
 "operator.example" = "operator"
-```
-
-```toml
-# Temporary migration mode for pre-v0.24.0 behavior; warns under --check.
-[security.grpc]
-enforcement = "legacy"
 ```
 
 ```toml

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -66,9 +66,9 @@ Preferred posture:
   client certificate (`rustbgpd:` URI SAN, then email SAN, then Subject CN);
   unsafe or overlong cert values fall back to `mtls-unresolved` rather than
   entering structured logs verbatim.
-  In the temporary Legacy migration mode these roles are audit context only
-  and listener `max_tier` is authoritative; in Tier mode they authorize or
-  deny calls by method tier.
+  Roles authorize or deny calls by method tier unconditionally: the former
+  Legacy migration mode (roles as audit context only) was removed in v0.63.0
+  and its config value is rejected at validation.
 - Listener `max_tier` caps are enforced now and should be used to bound remote
   TCP listeners to the smallest required method tier. `access_mode =
   "read_only"` remains a compatibility ceiling equivalent to
@@ -444,16 +444,19 @@ the roadmap:
 
 ## Current gaps
 
-- Authorization defaults to per-principal tier enforcement
-  (`security.grpc.enforcement = "tier"`, default since v0.24.0) layered on
-  listener `access_mode` (`read_only` vs `read_write`) and `max_tier` caps.
-  `enforcement = "legacy"` remains accepted today only as a temporary
-  migration mode: roles are audit-only, the listener cap authorizes calls,
-  validation warns, and `--check --strict` fails. The original startup
-  deprecation warning shipped in v0.51.0 on 2026-07-11; validation and
-  strict-check enforcement followed in v0.61.0. The two-minor/90-day floor is
-  therefore approximately 2026-10-09. That is only eligibility for a later
-  removal decision, not a promised removal date. Under tier enforcement, an
+- Authorization is per-principal tier enforcement
+  (`security.grpc.enforcement = "tier"`, default since v0.24.0, mandatory
+  since v0.63.0) layered on listener `access_mode` (`read_only` vs
+  `read_write`) and `max_tier` caps.
+  `enforcement = "legacy"` was removed in v0.63.0: validation rejects it at
+  boot, `--check`, and reload. Earlier editions of this document stated a
+  two-minor/90-day floor (≈2026-10-09) as removal *eligibility*; that
+  guidance is superseded — the removal landed earlier as an explicit owner
+  decision under the pre-1.0 alpha stability posture, once the implicit
+  `local-operator` identity reduced the migration for local-only deployments
+  to deleting the `[security.grpc]` block (named-principal setups keep a
+  three-line tier config; the rejection message carries the paste block).
+  Under tier enforcement, an
   owner-only UDS socket (no group/world mode bits, e.g. the default `0o600`)
   with no `principal` — including the implicit default listener — authorizes
   its clients as the reserved implicit `local-operator` principal at operator

--- a/docs/adr/0064-grpc-authorization.md
+++ b/docs/adr/0064-grpc-authorization.md
@@ -1,6 +1,6 @@
 # ADR-0064: gRPC per-method authorization
 
-**Status:** Accepted (amended 2026-08-03: implicit `local-operator` for owner-only UDS, §4)
+**Status:** Accepted (amended 2026-08-03: implicit `local-operator` for owner-only UDS, §4; addendum 2026-08-03: legacy mode removed, see "Status addendum" below)
 **Date:** 2026-05-18
 
 ## Context
@@ -447,3 +447,21 @@ proto credential markers remain deferred.
 | 5. Enforcement + default flip | Done in v0.24.0: opt-in `tier` role enforcement (slice 5a) + migration prep + default flip from `legacy` to `tier` (slice 5b, closes #164) |
 | 6. Audit log hardening | Partial: result-aware records + explicit credential masking table + operations guidance for audit retention and resource guardrails |
 | 7. External-review prep | Partial: current enforced-system threat model; external sign-off and auditor packet remain |
+
+## Status addendum (2026-08-03): legacy mode removed in v0.63.0
+
+The `enforcement = "legacy"` migration mode described above completed its
+purpose and was removed as a functioning mode in v0.63.0. The value still
+parses (the v1 config surface keeps the enum variant) but validation rejects
+it at boot, `--check`, and reload with a one-shot migration message; the
+runtime no longer carries the roles-as-audit-context-only path, so tier role
+ceilings are enforced unconditionally.
+
+Earlier sunset language in this repository projected a two-minor/90-day floor
+(≈2026-10-09) as the earliest *eligibility* for removal. The removal landed
+before that date as an explicit owner decision under the project's pre-1.0
+alpha stability posture, taken once the implicit `local-operator` identity
+(§4 amendment) reduced the migration for local-only deployments to deleting
+the `[security.grpc]` block entirely. Named-principal deployments keep a
+three-line tier config; the rejection message carries the exact paste block.
+References to `legacy` elsewhere in this ADR are historical design record.

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -22,21 +22,20 @@ this inventory before the handler runs, and applies two checks in order:
    `sensitive_read` ceiling and the stricter of the two wins, so the
    binary access mode is a compatibility ceiling layered over the tier
    model rather than the mechanism behind it.
-2. **Principal role.** With `[security.grpc].enforcement = "tier"` — the
-   default since v0.24.0 — the call's authenticated principal is looked
+2. **Principal role.** The call's authenticated principal is looked
    up in `[security.grpc.roles]` and the role's ceiling must reach the
    method's tier: `observer` reaches `sensitive_read`, `automation`
    reaches `mutating`, `operator` reaches `operator_only`. A principal
    with no role entry is denied (`principal_unmapped`); a principal whose
    role sits below the method tier is denied (`role_tier_denied`).
-   `enforcement = "legacy"` remains accepted today only as a temporary
-   migration mode in which roles are audit context only and the listener
-   ceiling is the authoritative tier check. Explicit Legacy warns during
-   validation and fails `rustbgpd --check --strict`. The original startup
-   deprecation warning shipped in v0.51.0 on 2026-07-11; validation and
-   strict-check enforcement followed in v0.61.0. The resulting two-minor/90-day
-   floor is approximately 2026-10-09 and establishes only eligibility for a
-   later removal decision, not a promised removal date.
+   This check is unconditional: `"tier"` has been the default since
+   v0.24.0 and is the only mode since v0.63.0, when
+   `enforcement = "legacy"` (roles as audit context only) was removed and
+   became a validation rejection. Earlier editions of this document stated
+   a two-minor/90-day floor (≈2026-10-09) as removal *eligibility*; that
+   guidance is superseded by the explicit owner decision to remove the mode
+   under the pre-1.0 alpha stability posture — see `docs/API.md` for the
+   supersession note and migration guidance.
 
 Principals come from the listener's authenticated identity: native mTLS
 listeners derive them from the validated client certificate (`rustbgpd:`
@@ -311,11 +310,9 @@ specific method if the model warrants it.
    legacy-permissive but can opt into per-tier enforcement) so the
    cut-over is not a breaking change for everyone on the same
    release. That opt-in path shipped as slice-5a, and the production
-   default flipped to `tier` in v0.24.0 (Legacy remains accepted today only as
-   the temporary migration mode).
-   Current status: Legacy is retained only as the temporary, warning-bearing
-   migration mode described above; this historical migration decision does not
-   promise that the compatibility mode remains indefinitely.
+   default flipped to `tier` in v0.24.0.
+   Current status: the Legacy migration mode completed its purpose and was
+   removed in v0.63.0; the config value is rejected at validation.
 7. **Audit logging.** The runtime now emits tier-decision logs and the
    low-cardinality `bgp_grpc_authz_decisions_total` metric for every RPC;
    listener `max_tier` denials use the bounded

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -1197,12 +1197,12 @@
     "GrpcEnforcementConfig": {
       "oneOf": [
         {
-          "description": "Preserve pre-v0.24.0 role authorization behavior. Listener\n`max_tier` caps still apply in this mode, but per-principal\nrole ceilings are not enforced. Operators who need this\nbehavior after v0.24.0 must set `enforcement = \"legacy\"`\nexplicitly.",
+          "description": "Deprecated: the pre-v0.24.0 mode that skipped per-principal\nrole ceilings was removed in v0.63.0. The value still parses\n(the v1 config surface keeps the variant) but validation\nrejects it at boot, `--check`, and reload with the migration\nsteps. Local-only deployments can delete the whole\n`[security.grpc]` block instead — an owner-only UDS socket\nauthorizes its clients as the implicit `local-operator`.",
           "type": "string",
           "const": "legacy"
         },
         {
-          "description": "Enforce per-principal role ceilings in addition to listener\n`max_tier` caps. **Default since v0.24.0** after the\nmigration window documented in `docs/CONFIGURATION.md`.\nExisting deployments that do not configure\n`[security.grpc.roles]` will fail validation at startup with\na message pointing at the migration checklist; operators who\nhave not staged their config can opt back into `legacy`\nexplicitly.",
+          "description": "Enforce per-principal role ceilings in addition to listener\n`max_tier` caps. **Default since v0.24.0** and the only mode\nsince v0.63.0. Deployments whose listeners have no role\nidentity fail validation at startup with a message pointing\nat the migration checklist in `docs/CONFIGURATION.md`.",
           "type": "string",
           "const": "tier"
         }
@@ -1229,7 +1229,7 @@
       "type": "object",
       "properties": {
         "enforcement": {
-          "description": "Role-enforcement mode: `\"legacy\"` or `\"tier\"`.",
+          "description": "Role-enforcement mode. `\"tier\"` (the default) is the only mode\nthat boots; `\"legacy\"` still parses but is rejected at\nvalidation since v0.63.0.",
           "$ref": "#/$defs/GrpcEnforcementConfig",
           "default": "tier"
         },

--- a/scripts/fixtures/release-notes/edge-cases.expected.md
+++ b/scripts/fixtures/release-notes/edge-cases.expected.md
@@ -14,7 +14,7 @@ A configuration example that must stay byte-for-byte verbatim inside the fence, 
 
 ```toml
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
 roles = { admin = "spki-sha256:..." }
 ```
 

--- a/scripts/fixtures/release-notes/edge-cases.in.md
+++ b/scripts/fixtures/release-notes/edge-cases.in.md
@@ -20,7 +20,7 @@ fence, even though some lines are short:
 
 ```toml
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
 roles = { admin = "spki-sha256:..." }
 ```
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -309,7 +309,9 @@ pub struct SecurityConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(deny_unknown_fields)]
 pub struct GrpcSecurityConfig {
-    /// Role-enforcement mode: `"legacy"` or `"tier"`.
+    /// Role-enforcement mode. `"tier"` (the default) is the only mode
+    /// that boots; `"legacy"` still parses but is rejected at
+    /// validation since v0.63.0.
     #[serde(default)]
     pub enforcement: GrpcEnforcementConfig,
     /// Per-principal role assignments (principal name -> role).
@@ -320,20 +322,19 @@ pub struct GrpcSecurityConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum GrpcEnforcementConfig {
-    /// Preserve pre-v0.24.0 role authorization behavior. Listener
-    /// `max_tier` caps still apply in this mode, but per-principal
-    /// role ceilings are not enforced. Operators who need this
-    /// behavior after v0.24.0 must set `enforcement = "legacy"`
-    /// explicitly.
+    /// Deprecated: the pre-v0.24.0 mode that skipped per-principal
+    /// role ceilings was removed in v0.63.0. The value still parses
+    /// (the v1 config surface keeps the variant) but validation
+    /// rejects it at boot, `--check`, and reload with the migration
+    /// steps. Local-only deployments can delete the whole
+    /// `[security.grpc]` block instead — an owner-only UDS socket
+    /// authorizes its clients as the implicit `local-operator`.
     Legacy,
     /// Enforce per-principal role ceilings in addition to listener
-    /// `max_tier` caps. **Default since v0.24.0** after the
-    /// migration window documented in `docs/CONFIGURATION.md`.
-    /// Existing deployments that do not configure
-    /// `[security.grpc.roles]` will fail validation at startup with
-    /// a message pointing at the migration checklist; operators who
-    /// have not staged their config can opt back into `legacy`
-    /// explicitly.
+    /// `max_tier` caps. **Default since v0.24.0** and the only mode
+    /// since v0.63.0. Deployments whose listeners have no role
+    /// identity fail validation at startup with a message pointing
+    /// at the migration checklist in `docs/CONFIGURATION.md`.
     #[default]
     Tier,
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1861,58 +1861,36 @@ fn grpc_listener_max_tier_can_be_stricter_than_access_mode() {
 }
 
 #[test]
-fn explicit_legacy_grpc_enforcement_loads_roles_and_warns() {
-    // After the v0.24.0 default flip, operators who want the prior
-    // pre-enforcement posture must set `enforcement = "legacy"`
-    // explicitly. This test pins that the explicit opt-out still
-    // parses cleanly alongside a populated roles map (operators
-    // staging roles ahead of flipping enforcement to "tier").
+fn explicit_legacy_grpc_enforcement_is_rejected() {
+    // v0.63.0 removed the legacy runtime path outright: the value still
+    // parses (the v1 surface keeps the variant) but validation rejects it
+    // on every load path — boot, `--check`, and reload all route through
+    // here. Restoring the old acceptance makes this red.
     let toml_str = format!(
-        "{}\n[security.grpc]\nenforcement = \"legacy\"\n\n[security.grpc.roles]\n\"observer-readonly\" = \"observer\"\n\"automation.example\" = \"automation\"\n\"operator.example\" = \"operator\"\n",
+        "{}\n[security.grpc]\nenforcement = \"legacy\"\n\n[security.grpc.roles]\n\"operator.example\" = \"operator\"\n",
         valid_toml_no_grpc_security()
     );
-    let config = Config::load_toml_with_diagnostics(&toml_str, "legacy compatibility").unwrap();
-    assert_eq!(
-        config.security.grpc.enforcement,
-        GrpcEnforcementConfig::Legacy
-    );
-    assert_eq!(
-        config.security.grpc.roles["observer-readonly"],
-        GrpcRoleConfig::Observer
-    );
-    assert_eq!(
-        config.security.grpc.roles["automation.example"],
-        GrpcRoleConfig::Automation
-    );
-    assert_eq!(
-        config.security.grpc.roles["operator.example"],
-        GrpcRoleConfig::Operator
-    );
-    let advisory = config
-        .advisories()
-        .into_iter()
-        .find(|a| a.headline.contains("security.grpc.enforcement"))
-        .expect("legacy enforcement must raise an advisory");
-    let text = advisory.one_line();
+    let err = Config::load_toml_with_diagnostics(&toml_str, "legacy removal")
+        .expect_err("legacy enforcement must fail validation");
     assert!(
-        text.contains("mandatory in a future release"),
-        "advisory must name the sunset: {text}"
+        err.contains("security.grpc.enforcement = \"legacy\" was removed in v0.63.0"),
+        "rejection must name the removal decision: {err}"
     );
-    // Condition, consequence, action — an advisory that only restates the
-    // setting leaves the operator with nothing to do about it.
+    // Local-only operators get the zero-config exit: the implicit
+    // local-operator identity covers owner-only UDS clients.
     assert!(
-        text.contains("max_tier cap"),
-        "advisory must name the consequence: {text}"
+        err.contains("delete the whole [security.grpc] block") && err.contains("local-operator"),
+        "rejection must give the delete-the-block guidance: {err}"
+    );
+    // Named-principal setups get the paste block for the tier config to keep.
+    assert!(
+        err.contains("[security.grpc]\nenforcement = \"tier\"")
+            && err.contains("[security.grpc.roles]\n\"<your-principal>\" = \"operator\""),
+        "rejection must carry the copy-pasteable tier fix: {err}"
     );
     assert!(
-        text.contains("enforcement = \"tier\"")
-            && text.contains("[security.grpc.roles]")
-            && text.contains("principal"),
-        "advisory must give the migration action: {text}"
-    );
-    assert!(
-        text.contains("docs/adr/0064-grpc-authorization.md"),
-        "advisory must cite the migration reference: {text}"
+        err.contains("docs/CONFIGURATION.md") && err.contains("docs/adr/0064"),
+        "rejection must cite the migration references: {err}"
     );
 }
 
@@ -2056,9 +2034,15 @@ fn grpc_security_tier_diagnoses_uds_principal_missing_from_roles() {
             && reason.contains("\"local-admin\" = \"operator\""),
         "error must end with a paste-ready fix: {reason}"
     );
+    // v0.63.0 removed the legacy escape hatch; the fix must not
+    // resurrect it.
     assert!(
-        reason.contains("enforcement = \"legacy\""),
-        "error must mention the legacy escape hatch: {reason}"
+        !reason.contains("enforcement = \"legacy\""),
+        "error must not offer the removed legacy mode: {reason}"
+    );
+    assert!(
+        reason.contains("docs/CONFIGURATION.md"),
+        "error must point at the migration checklist: {reason}"
     );
 }
 
@@ -16859,7 +16843,7 @@ fn retired_looking_glass_fails_load_with_migration_error() {
     );
 }
 
-// ── Legacy gRPC enforcement sunset warning ───────────────────────────
+// ── Tier gRPC enforcement (legacy mode removed in v0.63.0) ───────────
 
 #[test]
 fn tier_grpc_enforcement_does_not_warn() {
@@ -16941,7 +16925,7 @@ fn config_loader_has_no_test_only_legacy_bypass() {
         "production loader source must not contain a test-only auth seam"
     );
     // The loader itself never branches on Legacy: the only production code
-    // that selects it is the operator-facing advisory in `validation.rs`.
+    // that selects it is the v0.63.0 removal rejection in `validation.rs`.
     assert_eq!(
         source.matches("GrpcEnforcementConfig::Legacy").count(),
         0,
@@ -16957,7 +16941,7 @@ fn config_loader_has_no_test_only_legacy_bypass() {
             .matches("GrpcEnforcementConfig::Legacy")
             .count(),
         1,
-        "only the compatibility advisory may select Legacy"
+        "only the removal rejection may select Legacy"
     );
 }
 

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -1339,33 +1339,6 @@ impl Config {
             });
         }
 
-        // Pre-ADR-0064 gRPC authorization. Tier enforcement has been the
-        // default since v0.24.0 and becomes mandatory, so an operator still
-        // pinned to `legacy` is carrying both an open management surface and
-        // a config that a future release will reject.
-        if matches!(
-            self.security.grpc.enforcement,
-            GrpcEnforcementConfig::Legacy
-        ) {
-            advisories.push(ConfigAdvisory {
-                headline: "security.grpc.enforcement = \"legacy\" disables per-method tier \
-                           authorization.",
-                detail: "Every authenticated client of a read_write listener may call every\n\
-                         method up to that listener's max_tier cap, including the\n\
-                         operator_only methods that reconfigure the daemon; the\n\
-                         [security.grpc.roles] entries are recorded as audit context and deny\n\
-                         nothing. Tier enforcement is the default since v0.24.0 and becomes\n\
-                         mandatory in a future release, which will reject this config.\n\
-                         \n\
-                         To migrate: give every listener a role identity — mTLS listeners\n\
-                         derive it from the client certificate, bearer-token TCP and UDS\n\
-                         listeners need an explicit `principal` — map each principal in\n\
-                         [security.grpc.roles] to observer, automation, or operator, then set\n\
-                         security.grpc.enforcement = \"tier\". See\n\
-                         docs/adr/0064-grpc-authorization.md and docs/SECURITY.md.",
-            });
-        }
-
         advisories
     }
 }
@@ -2691,8 +2664,34 @@ fn validate_grpc_security(security: &SecurityConfig) -> Result<(), ConfigError> 
     reason = "one linear diagnosis pass per listener kind plus message assembly"
 )]
 fn validate_grpc_tier_enforcement(config: &Config) -> Result<(), ConfigError> {
-    if config.security.grpc.enforcement != GrpcEnforcementConfig::Tier {
-        return Ok(());
+    // `enforcement = "legacy"` is rejected outright: the runtime path it
+    // selected (role ceilings recorded but never enforced) was removed in
+    // v0.63.0 as an explicit owner decision under the pre-1.0 stability
+    // posture, ahead of the sunset window docs/API.md once projected. The
+    // enum variant survives only so the v1 config surface stays parseable.
+    if config.security.grpc.enforcement == GrpcEnforcementConfig::Legacy {
+        return Err(ConfigError::InvalidGrpcConfig {
+            reason: "security.grpc.enforcement = \"legacy\" was removed in v0.63.0 and no \
+                     longer boots:\n  \
+                     1. legacy mode recorded [security.grpc.roles] as audit context but \
+                     enforced nothing; that runtime path no longer exists, so there is \
+                     nothing to opt back into\n  \
+                     2. if your clients are local (rbgp over a UDS socket, including the \
+                     implicit default at <runtime_state_dir>/grpc.sock), tier enforcement \
+                     needs no configuration at all — the owner-only socket authorizes them \
+                     as the implicit \"local-operator\": simply delete the whole \
+                     [security.grpc] block\n  \
+                     3. a listener with a declared principal keeps working under tier with \
+                     a role entry; keep this instead:\n\
+                     [security.grpc]\n\
+                     enforcement = \"tier\"\n\
+                     \n\
+                     [security.grpc.roles]\n\
+                     \"<your-principal>\" = \"operator\"\n\
+                     (migration: docs/CONFIGURATION.md [security.grpc]; removal decision: \
+                     docs/adr/0064-grpc-authorization.md)"
+                .to_string(),
+        });
     }
     let telemetry = &config.global.telemetry;
     let tcp = telemetry.grpc_tcp.as_ref().filter(|cfg| cfg.enabled);
@@ -2819,10 +2818,7 @@ fn validate_grpc_tier_enforcement(config: &Config) -> Result<(), ConfigError> {
             reason.push('\n');
         }
     }
-    reason.push_str(
-        "or opt back into legacy with security.grpc.enforcement = \"legacy\" \
-         (migration checklist: docs/CONFIGURATION.md, [security.grpc])",
-    );
+    reason.push_str("(migration checklist: docs/CONFIGURATION.md, [security.grpc])");
     Err(ConfigError::InvalidGrpcConfig { reason })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,8 +79,8 @@ use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
 use crate::config::{
-    AcceptedConfigSnapshot, Config, GrpcAccessMode, GrpcEnforcementConfig, GrpcListener,
-    GrpcMaxTier, GrpcRoleConfig, UnpolicedEbgpBoundary,
+    AcceptedConfigSnapshot, Config, GrpcAccessMode, GrpcListener, GrpcMaxTier, GrpcRoleConfig,
+    UnpolicedEbgpBoundary,
 };
 use crate::config_persister::{ConfigMutation, ConfigPersister};
 use crate::peer_manager::PeerManager;
@@ -1041,15 +1041,6 @@ fn spawn_bfd_event_bridge(
     })
 }
 
-const fn grpc_enforcement_to_auth_enforcement(
-    value: GrpcEnforcementConfig,
-) -> rustbgpd_api::authz::AuthEnforcement {
-    match value {
-        GrpcEnforcementConfig::Legacy => rustbgpd_api::authz::AuthEnforcement::Legacy,
-        GrpcEnforcementConfig::Tier => rustbgpd_api::authz::AuthEnforcement::Tier,
-    }
-}
-
 const fn grpc_role_to_principal_role(value: GrpcRoleConfig) -> rustbgpd_api::authz::PrincipalRole {
     match value {
         GrpcRoleConfig::Observer => rustbgpd_api::authz::PrincipalRole::Observer,
@@ -1475,7 +1466,6 @@ fn marker_fail_if(selected: MarkerFaultPoint, current: MarkerFaultPoint) -> std:
 
 fn resolve_grpc_listeners(config: &Config) -> Result<Vec<GrpcListenerConfig>, String> {
     use rustbgpd_api::credentials::{CredentialSource, CredentialStore, TlsSource};
-    let enforcement = grpc_enforcement_to_auth_enforcement(config.security.grpc.enforcement);
     let roles = Arc::new(grpc_principal_roles(config));
     let declared = config.grpc_listeners();
     let sources = declared
@@ -1515,7 +1505,6 @@ fn resolve_grpc_listeners(config: &Config) -> Result<Vec<GrpcListenerConfig>, St
                     endpoint: ListenerEndpoint::Tcp(addr),
                     access_mode: access_mode.into(),
                     max_tier: grpc_max_tier_to_auth_tier(max_tier),
-                    enforcement,
                     roles: Arc::clone(&roles),
                     credential_store: credential_store.clone(),
                     credential_index,
@@ -1533,7 +1522,6 @@ fn resolve_grpc_listeners(config: &Config) -> Result<Vec<GrpcListenerConfig>, St
                 endpoint: ListenerEndpoint::Uds { path, mode },
                 access_mode: access_mode.into(),
                 max_tier: grpc_max_tier_to_auth_tier(max_tier),
-                enforcement,
                 roles: Arc::clone(&roles),
                 credential_store: credential_store.clone(),
                 credential_index,

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -448,20 +448,14 @@ impl PeerManager {
                 },
                 // PeerManager::new constructs an in-memory baseline
                 // Config before the operator's TOML is applied. The
-                // schema default is `enforcement = "tier"` after the
-                // v0.24.0 flip, but a defaulted Config has no
-                // [security.grpc.roles], which would fail
-                // post-apply validation in `apply_config_event`.
-                // Use the explicit legacy posture here so the
-                // baseline is internally consistent; the real
-                // config arrives via reload / config-bridge with
-                // its own [security.grpc] block.
-                security: crate::config::SecurityConfig {
-                    grpc: crate::config::GrpcSecurityConfig {
-                        enforcement: crate::config::GrpcEnforcementConfig::Legacy,
-                        roles: std::collections::HashMap::new(),
-                    },
-                },
+                // tier default with no listeners and no roles is valid
+                // since the implicit local-operator amendment (the
+                // implicit owner-only UDS listener needs no
+                // [security.grpc.roles]), so the baseline can carry
+                // the plain schema default; the real config arrives
+                // via reload / config-bridge with its own
+                // [security.grpc] block.
+                security: crate::config::SecurityConfig::default(),
                 neighbors: Vec::new(),
                 peer_groups: HashMap::new(),
                 policy: crate::config::PolicyConfig::default(),

--- a/tests/chaos/chaos-flap-storm.sh
+++ b/tests/chaos/chaos-flap-storm.sh
@@ -36,6 +36,7 @@ REPORT="$RUN_DIR/report.json"
 
 # Reuse interop test-lib for resolve_grpc_addr / grpc_health
 TOPO="$CHAOS_TOPO"
+INTEROP_TEST_OPERATOR_AUTH=1
 # shellcheck source=../interop/scripts/test-lib.sh
 source "$SCRIPT_DIR/../interop/scripts/test-lib.sh"
 resolve_grpc_addr
@@ -64,7 +65,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     cycles=$((cycles + 1))
 
     # Disable
-    if ! grpcurl -plaintext -import-path . -proto "$PROTO" \
+    if ! grpcurl_call \
         -d "{\"address\":\"$PEER_TARGET\"}" \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/DisableNeighbor \
         >>"$DRIVER_LOG" 2>&1; then
@@ -81,7 +82,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
 
     # Re-enable
-    if ! grpcurl -plaintext -import-path . -proto "$PROTO" \
+    if ! grpcurl_call \
         -d "{\"address\":\"$PEER_TARGET\"}" \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/EnableNeighbor \
         >>"$DRIVER_LOG" 2>&1; then
@@ -90,7 +91,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
 
     # Wait briefly for re-Establish; check state.
     sleep "$CHAOS_INTERVAL_SEC"
-    state=$(grpcurl -plaintext -import-path . -proto "$PROTO" \
+    state=$(grpcurl_call \
         -d "{\"address\":\"$PEER_TARGET\"}" \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>/dev/null \
         | jq -r '.state // empty')
@@ -133,7 +134,7 @@ fi
 log "[chaos-flap-storm] post-storm: waiting up to 30s for $PEER_TARGET to re-Establish"
 post_storm_established=0
 for _ in $(seq 1 30); do
-    state=$(grpcurl -plaintext -import-path . -proto "$PROTO" \
+    state=$(grpcurl_call \
         -d "{\"address\":\"$PEER_TARGET\"}" \
         "$GRPC_ADDR" rustbgpd.v1.NeighborService/GetNeighborState 2>/dev/null \
         | jq -r '.state // empty')

--- a/tests/chaos/chaos-grpc-churn.sh
+++ b/tests/chaos/chaos-grpc-churn.sh
@@ -34,8 +34,13 @@ PROBE_LOG="$RUN_DIR/probe.log"
 REPORT="$RUN_DIR/report.json"
 
 TOPO="$CHAOS_TOPO"
+INTEROP_TEST_OPERATOR_AUTH=1
 # shellcheck source=../interop/scripts/test-lib.sh
 source "$SCRIPT_DIR/../interop/scripts/test-lib.sh"
+# Arrays cannot be exported to the xargs subshells running shot(), so
+# the shared bearer header travels as a plain string.
+IFS= read -r _CHAOS_TOKEN < "$INTEROP_TEST_OPERATOR_TOKEN_FILE"
+GRPC_AUTH_HEADER="authorization: Bearer $_CHAOS_TOKEN"
 resolve_grpc_addr
 
 log "[chaos-grpc-churn] duration=${CHAOS_DURATION_SEC}s parallelism=$CHAOS_PARALLELISM"
@@ -53,18 +58,21 @@ shot() {
     case $op in
         0)
             grpcurl -plaintext -import-path . -proto "$PROTO" \
+                -H "$GRPC_AUTH_HEADER" \
                 -d "{\"config\":{\"address\":\"$ip\",\"remote_asn\":65999,\"families\":[\"ipv4_unicast\"]}}" \
                 "$GRPC_ADDR" rustbgpd.v1.NeighborService/AddNeighbor 2>&1 \
                 | head -1 >>"$DRIVER_LOG"
             ;;
         1)
             grpcurl -plaintext -import-path . -proto "$PROTO" \
+                -H "$GRPC_AUTH_HEADER" \
                 -d "{\"address\":\"$ip\"}" \
                 "$GRPC_ADDR" rustbgpd.v1.NeighborService/DeleteNeighbor 2>&1 \
                 | head -1 >>"$DRIVER_LOG"
             ;;
         2)
             grpcurl -plaintext -import-path . -proto "$PROTO" \
+                -H "$GRPC_AUTH_HEADER" \
                 -d "{\"address\":\"$ip\"}" \
                 "$GRPC_ADDR" rustbgpd.v1.NeighborService/SoftResetIn 2>&1 \
                 | head -1 >>"$DRIVER_LOG"
@@ -72,7 +80,7 @@ shot() {
     esac
 }
 export -f shot
-export GRPC_ADDR PROTO DRIVER_LOG
+export GRPC_ADDR PROTO DRIVER_LOG GRPC_AUTH_HEADER
 
 # Probe daemon health every 2 s in the background.
 probe_pid=

--- a/tests/check_strict.rs
+++ b/tests/check_strict.rs
@@ -111,10 +111,10 @@ route_reflector_client = true
 orr_vantage = "192.0.2.7"
 "#;
 
-/// The pre-ADR-0064 gRPC authorization mode. A genuine risk in the
-/// operator's own config, so `--check` reports it and `--strict` fails on
-/// it; iBGP and no ORR vantage, so it is the only warning.
-const LEGACY_GRPC_WARNS: &str = r#"
+/// The pre-ADR-0064 gRPC authorization mode, removed in v0.63.0: the
+/// config no longer loads at all, so `--check` fails with the migration
+/// message rather than warning.
+const LEGACY_GRPC_REJECTED: &str = r#"
 [global]
 asn = 65001
 router_id = "10.0.0.1"
@@ -132,11 +132,11 @@ address = "10.0.0.2"
 remote_asn = 65001
 "#;
 
-/// Three distinct warning kinds at once: an unpoliced eBGP neighbor, an
-/// unresolvable ORR vantage, and legacy gRPC enforcement. The count is what
-/// `--strict` gates on, so a fix that surfaced each warning without summing
-/// them into one total would still report the wrong number here.
-const THREE_KINDS: &str = r#"
+/// Two distinct warning kinds at once: an unpoliced eBGP neighbor and an
+/// unresolvable ORR vantage. The count is what `--strict` gates on, so a
+/// fix that surfaced each warning without summing them into one total
+/// would still report the wrong number here.
+const TWO_KINDS: &str = r#"
 [global]
 asn = 65001
 router_id = "10.0.0.1"
@@ -145,9 +145,6 @@ runtime_state_dir = "/tmp/rustbgpd-check-strict"
 
 [global.telemetry]
 log_format = "json"
-
-[security.grpc]
-enforcement = "legacy"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -321,54 +318,42 @@ fn check_strict_fails_on_a_validation_origin_warning() {
     );
 }
 
-/// Legacy gRPC enforcement is a risk in the operator's own config, not an
-/// unfinished feature of the release, so `--check` reports it and it must
-/// state the migration action rather than only the state.
+/// Legacy gRPC enforcement was removed in v0.63.0: `--check` (strict or
+/// not) fails at load with the one-shot migration message. Restoring the
+/// old validation acceptance makes this red.
 #[test]
-fn check_reports_legacy_grpc_enforcement() {
-    let (code, stdout, stderr) = run(LEGACY_GRPC_WARNS, &["--check"]);
-    assert_eq!(code, Some(0), "stdout:\n{stdout}\nstderr:\n{stderr}");
-    assert!(
-        stdout.contains("config VALID, 1 WARNING — NOT a clean check"),
-        "summary line did not count the legacy-enforcement warning:\n{stdout}"
-    );
-    assert!(
-        stderr.contains("security.grpc.enforcement = \"legacy\""),
-        "warning did not name the condition:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("max_tier cap"),
-        "warning did not name the consequence:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("To migrate:")
-            && stderr.contains("[security.grpc.roles]")
-            && stderr.contains("security.grpc.enforcement = \"tier\""),
-        "warning did not give the migration action:\n{stderr}"
-    );
-}
-
-#[test]
-fn check_strict_fails_on_legacy_grpc_enforcement() {
-    let (code, stdout, stderr) = run(LEGACY_GRPC_WARNS, &["--check", "--strict"]);
-    assert_eq!(code, Some(1), "stdout:\n{stdout}\nstderr:\n{stderr}");
+fn check_rejects_legacy_grpc_enforcement() {
+    for args in [&["--check"][..], &["--check", "--strict"][..]] {
+        let (code, stdout, stderr) = run(LEGACY_GRPC_REJECTED, args);
+        assert_eq!(code, Some(1), "stdout:\n{stdout}\nstderr:\n{stderr}");
+        assert!(
+            stderr.contains("security.grpc.enforcement = \"legacy\" was removed in v0.63.0"),
+            "rejection did not name the removal:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("delete the whole [security.grpc] block"),
+            "rejection did not give the delete-the-block guidance:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("enforcement = \"tier\"")
+                && stderr.contains("[security.grpc.roles]")
+                && stderr.contains("\"<your-principal>\" = \"operator\""),
+            "rejection did not carry the paste block:\n{stderr}"
+        );
+    }
 }
 
 /// The aggregate. `--strict` gates on the total, so every kind has to be
 /// summed into the one count — the case a per-warning fix gets wrong.
 #[test]
 fn check_counts_every_warning_kind_together() {
-    let (code, stdout, stderr) = run(THREE_KINDS, &["--check"]);
+    let (code, stdout, stderr) = run(TWO_KINDS, &["--check"]);
     assert_eq!(code, Some(0), "stdout:\n{stdout}\nstderr:\n{stderr}");
     assert!(
-        stdout.contains("config VALID, 3 WARNINGS — NOT a clean check"),
-        "the three warning kinds were not summed into one total:\n{stdout}"
+        stdout.contains("config VALID, 2 WARNINGS — NOT a clean check"),
+        "the two warning kinds were not summed into one total:\n{stdout}"
     );
-    for expected in [
-        "eBGP neighbor",
-        "orr_vantage",
-        "security.grpc.enforcement = \"legacy\"",
-    ] {
+    for expected in ["eBGP neighbor", "orr_vantage"] {
         assert!(
             stderr.contains(expected),
             "{expected:?} missing from the framed warnings:\n{stderr}"
@@ -376,11 +361,11 @@ fn check_counts_every_warning_kind_together() {
     }
     assert_eq!(
         stderr.matches("WARNING:").count(),
-        3,
+        2,
         "each kind gets its own framed block:\n{stderr}"
     );
 
-    let (code, _, _) = run(THREE_KINDS, &["--check", "--strict"]);
+    let (code, _, _) = run(TWO_KINDS, &["--check", "--strict"]);
     assert_eq!(code, Some(1), "strict must fail the same config");
 }
 

--- a/tests/interop/configs/rustbgpd-frr-badopen.toml
+++ b/tests/interop/configs/rustbgpd-frr-badopen.toml
@@ -14,7 +14,3 @@ address = "10.0.0.2"
 remote_asn = 65099
 description = "frr-badopen"
 hold_time = 90
-
-# Legacy: no gRPC listener is configured here, so tier roles would govern nothing.
-[security.grpc]
-enforcement = "legacy"

--- a/tests/interop/configs/rustbgpd-m33-scale.toml
+++ b/tests/interop/configs/rustbgpd-m33-scale.toml
@@ -13,6 +13,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.1.1.2"
@@ -38,6 +40,8 @@ hold_time = 180
 families = ["l2vpn_evpn"]
 route_reflector_client = true
 
-# Legacy: the M33 driver and soak read the RIB over plaintext grpcurl, presenting no credential.
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m37-originator.toml
+++ b/tests/interop/configs/rustbgpd-m37-originator.toml
@@ -8,8 +8,9 @@ listen_port = 179
 log_format = "json"
 prometheus_addr = "0.0.0.0:9179"
 
-[global.telemetry.grpc_tcp]
-address = "0.0.0.0:50051"
+# No gRPC listener: M37 asserts via FRR's RIB, kernel bridge fdb, and
+# Prometheus. The implicit owner-only UDS listener satisfies default tier
+# enforcement with the implicit local-operator identity.
 
 # Single EVPN instance bound to br100 / vxlan100 — the start script
 # pre-creates the bridge + VXLAN port + a non-VXLAN bridge port
@@ -29,7 +30,3 @@ remote_asn = 65000
 description = "consumer-frr"
 hold_time = 30
 families = ["l2vpn_evpn"]
-
-# Legacy: M37 asserts via FRR's RIB, kernel bridge fdb, and Prometheus — never this gRPC listener.
-[security.grpc]
-enforcement = "legacy"

--- a/tests/interop/configs/rustbgpd-m39-pe1.toml
+++ b/tests/interop/configs/rustbgpd-m39-pe1.toml
@@ -31,6 +31,8 @@ log_format = "json"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -53,6 +55,8 @@ vrf_device = "vrf1"
 l3vxlan_device = "l3vxlan100"
 table_id = 100
 
-# Legacy: the M39 driver reads the RIB over plaintext grpcurl; the Gate 9 soak reuses this config.
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-m67-vtep.toml
+++ b/tests/interop/configs/rustbgpd-m67-vtep.toml
@@ -17,6 +17,8 @@ prometheus_addr = "0.0.0.0:9179"
 
 [global.telemetry.grpc_tcp]
 address = "0.0.0.0:50051"
+token_file = "/run/rustbgpd/grpc-test-only-operator.token"
+principal = "rustbgpd://operator/test-only"
 
 # Single EVPN instance bound to br100 / vxlan100 — the start script
 # pre-creates the topology in this container's netns. The single-active
@@ -45,6 +47,8 @@ hold_time = 30
 families = ["l2vpn_evpn"]
 route_reflector_client = true
 
-# Legacy: M67 mounts its operator token on pe1/pe2 only; driver and soak read this vtep via plain rbgp.
 [security.grpc]
-enforcement = "legacy"
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/test-only" = "operator"

--- a/tests/interop/configs/rustbgpd-soak-gr-restart.toml
+++ b/tests/interop/configs/rustbgpd-soak-gr-restart.toml
@@ -11,8 +11,8 @@ listen_port = 179
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
 
-[global.telemetry.grpc_tcp]
-address = "0.0.0.0:50051"
+# No gRPC listener: this soak observes via Prometheus and FRR only. The
+# implicit owner-only UDS listener satisfies default tier enforcement.
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -23,7 +23,3 @@ graceful_restart = true
 gr_restart_time = 15
 gr_stale_routes_time = 20
 llgr_stale_time = 60
-
-# Legacy: the GR-restart soak observes via Prometheus and FRR only, with no gRPC client or token.
-[security.grpc]
-enforcement = "legacy"

--- a/tests/interop/configs/rustbgpd-soak-hot-reload.toml
+++ b/tests/interop/configs/rustbgpd-soak-hot-reload.toml
@@ -12,15 +12,11 @@ listen_port = 179
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
 
-[global.telemetry.grpc_tcp]
-address = "0.0.0.0:50051"
+# No gRPC listener: the soak's rbgp calls run inside the container and
+# use the implicit owner-only UDS socket (local-operator identity).
 
 [[neighbors]]
 address = "10.0.0.2"
 remote_asn = 65002
 description = "frr-soak-hot-reload-cycle-0"
 hold_time = 90
-
-# Legacy: the soak's generated candidates pin this same block, and its rbgp calls carry no token.
-[security.grpc]
-enforcement = "legacy"

--- a/tests/interop/configs/rustbgpd-soak-inject-churn.toml
+++ b/tests/interop/configs/rustbgpd-soak-inject-churn.toml
@@ -10,15 +10,11 @@ listen_port = 179
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
 
-[global.telemetry.grpc_tcp]
-address = "0.0.0.0:50051"
+# No gRPC listener: the soak's rbgp rib add/delete calls run inside the
+# container and use the implicit owner-only UDS socket (local-operator).
 
 [[neighbors]]
 address = "10.0.0.2"
 remote_asn = 65002
 description = "frr-soak-inject"
 hold_time = 90
-
-# Legacy: the churn soak drives rbgp rib add/delete over the plaintext listener with no token.
-[security.grpc]
-enforcement = "legacy"

--- a/tests/interop/m33-evpn-scale.clab.yml
+++ b/tests/interop/m33-evpn-scale.clab.yml
@@ -38,6 +38,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m33-scale.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.1.1.1/30 dev eth1

--- a/tests/interop/m39-evpn-type5-symmetric-irb.clab.yml
+++ b/tests/interop/m39-evpn-type5-symmetric-irb.clab.yml
@@ -54,6 +54,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m39-pe1.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-m39-pe1.sh:/usr/local/bin/start-rustbgpd-m39-pe1.sh:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:

--- a/tests/interop/m67-evpn-link-drain-failover.clab.yml
+++ b/tests/interop/m67-evpn-link-drain-failover.clab.yml
@@ -89,6 +89,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m67-vtep.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ./scripts/start-rustbgpd-vtep.sh:/usr/local/bin/start-rustbgpd-vtep.sh:ro
       exec:
         - sh -c "echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6"
@@ -117,6 +118,7 @@ topology:
         - bridge fdb append 00:00:00:00:00:00 dev vxlan100 dst 10.0.2.2 self permanent
       env:
         RUST_LOG: info,rustbgpd_evpn_linux=debug,rustbgpd::evpn_dataplane=debug
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     pe1:
       kind: linux

--- a/tests/interop/scripts/test-m33-evpn-scale.sh
+++ b/tests/interop/scripts/test-m33-evpn-scale.sh
@@ -38,6 +38,7 @@
 
 TOPO="m33-evpn-scale"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTEROP_TEST_OPERATOR_AUTH=1
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 
@@ -58,7 +59,7 @@ TESTER_LINGER=240
 
 grpc_list_evpn() {
     # 50k EVPN routes blow past grpcurl's default 4 MiB message size.
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -max-msg-sz 134217728 \
         -d '{}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListEvpnRoutes 2>/dev/null || true
@@ -230,7 +231,7 @@ else
 fi
 
 log "[check] tester peers stayed Established without mid-run flaps"
-neighbors_json=$(grpcurl -plaintext -import-path . -proto "$PROTO" \
+neighbors_json=$(grpcurl_call \
     "$GRPC_ADDR" rustbgpd.v1.NeighborService/ListNeighbors 2>/dev/null)
 # `jq` is mandatory — the prior awk parser was fragile to JSON layout
 # changes and could miscount under proto3 default-field elision.

--- a/tests/interop/scripts/test-m39-evpn-type5-symmetric-irb.sh
+++ b/tests/interop/scripts/test-m39-evpn-type5-symmetric-irb.sh
@@ -45,6 +45,7 @@ PE2="clab-${TOPO}-pe2"
 RUSTBGPD="$PE1"
 export RUSTBGPD
 
+INTEROP_TEST_OPERATOR_AUTH=1
 # shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 
@@ -81,7 +82,7 @@ PE1_ROUTER_MAC="02:00:00:00:01:01"
 # ---------------------------------------------------------------------------
 
 grpc_list_evpn() {
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{}' \
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListEvpnRoutes 2>/dev/null
 }
@@ -179,7 +180,7 @@ wait_pe1_installed_count() {
     local attempts=$((timeout / 2))
     for _ in $(seq 1 "$attempts"); do
         local got
-        got=$(grpcurl -plaintext -import-path . -proto "$PROTO" \
+        got=$(grpcurl_call \
             -d '{"name":"vrf1"}' \
             "$GRPC_ADDR" rustbgpd.v1.EvpnService/GetIpVrf 2>/dev/null \
             | jq -r '.installedRoutesCount // 0')
@@ -279,7 +280,7 @@ if wait_pe1_installed_count 1 30; then
     ok "installed_routes_count=1 on vrf1"
 else
     fail "installed_routes_count did not reach 1 within 30s"
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"name":"vrf1"}' \
         "$GRPC_ADDR" rustbgpd.v1.EvpnService/GetIpVrf >&2 || true
 fi
@@ -385,7 +386,7 @@ if wait_pe1_installed_count 0 30; then
     ok "installed_routes_count converged to 0 on vrf1"
 else
     fail "installed_routes_count never reached 0"
-    grpcurl -plaintext -import-path . -proto "$PROTO" \
+    grpcurl_call \
         -d '{"name":"vrf1"}' \
         "$GRPC_ADDR" rustbgpd.v1.EvpnService/GetIpVrf >&2 || true
 fi

--- a/tests/interop/scripts/test-m67-evpn-link-drain-failover.sh
+++ b/tests/interop/scripts/test-m67-evpn-link-drain-failover.sh
@@ -83,6 +83,7 @@ TOPO="m67-evpn-link-drain-failover"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RUSTBGPD="clab-${TOPO}-vtep"
 export RUSTBGPD
+INTEROP_TEST_OPERATOR_AUTH=1
 # shellcheck source=tests/interop/scripts/test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 

--- a/tests/interop_tier_auth_dataplane.rs
+++ b/tests/interop_tier_auth_dataplane.rs
@@ -12,19 +12,14 @@ const TOKEN_BIND: &str =
     "../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro";
 const CI_PRINCIPAL: &str = "rustbgpd://operator/ci";
 
-// In-range configs pinned to `enforcement = "legacy"`. Each records its reason
-// at its own `[security.grpc]` block, and the equality allowlist in
-// interop_tier_auth_rr.rs owns the legacy inventory. Excluded here because the
-// identity assertions below describe a listener that enforces tier ceilings,
-// which these deliberately do not:
+// In-range configs whose only management surface is an owner-only UDS
+// socket (the implicit default listener): no `[security.grpc]` block and no
+// TCP listener at all, so the token/principal assertions below have nothing
+// to describe. Tier enforcement still governs them — their clients authorize
+// as the implicit `local-operator` (the shape that let LAN-547 retire the
+// legacy allowlist):
 //   m37-originator — asserted via FRR's RIB, kernel bridge fdb, and Prometheus
-//   m39-pe1 — plaintext grpcurl driver; the Gate 9 soak reuses the config
-//   m67-vtep — M67 mounts its operator token on pe1/pe2 only
-const LEGACY_EXCEPTIONS: &[&str] = &[
-    "rustbgpd-m37-originator.toml",
-    "rustbgpd-m39-pe1.toml",
-    "rustbgpd-m67-vtep.toml",
-];
+const IMPLICIT_LOCAL_OPERATOR_EXCEPTIONS: &[&str] = &["rustbgpd-m37-originator.toml"];
 
 // In-range configs that DO enforce tier, but authenticate with a lab-owned
 // credential rather than the shared test-only operator identity, so the
@@ -51,7 +46,7 @@ fn in_scope(name: &str) -> bool {
     let digits: String = suffix.chars().take_while(char::is_ascii_digit).collect();
     name.ends_with(".toml")
         && digits.parse::<u8>().is_ok_and(|n| (36..=69).contains(&n))
-        && !LEGACY_EXCEPTIONS.contains(&name)
+        && !IMPLICIT_LOCAL_OPERATOR_EXCEPTIONS.contains(&name)
         && !LAB_CREDENTIAL_EXCEPTIONS.contains(&name)
 }
 
@@ -105,7 +100,7 @@ fn active_dataplane_interop_is_tier_authenticated_end_to_end() {
         );
         configs.insert(name.to_owned());
     }
-    assert_eq!(configs.len(), 37, "classify the changed config inventory");
+    assert_eq!(configs.len(), 39, "classify the changed config inventory");
 
     let mut topologies = BTreeSet::new();
     let mut mounted = BTreeSet::new();
@@ -148,7 +143,7 @@ fn active_dataplane_interop_is_tier_authenticated_end_to_end() {
         unmounted,
         BTreeSet::from(["rustbgpd-m47-teardown.toml".into()])
     );
-    assert_eq!(topologies.len(), 29, "topology inventory changed");
+    assert_eq!(topologies.len(), 31, "topology inventory changed");
 
     let standalone = [
         "m38-evpn-df-election",
@@ -195,9 +190,9 @@ fn active_dataplane_interop_is_tier_authenticated_end_to_end() {
 }
 
 /// Both exception lists are proven, not merely trusted: a stale entry naming a
-/// renamed or deleted config, a legacy pin that silently moved to tier, or a
-/// lab config that adopted the shared identity and should rejoin the scoped
-/// assertions each make this red.
+/// renamed or deleted config, an implicit-local-operator config that grew a
+/// declared security surface, or a lab config that adopted the shared identity
+/// and should rejoin the scoped assertions each make this red.
 #[test]
 fn auth_exceptions_still_match_their_declared_category() {
     let config_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/interop/configs");
@@ -214,12 +209,18 @@ fn auth_exceptions_still_match_their_declared_category() {
             .map(str::to_owned)
     };
 
-    for name in LEGACY_EXCEPTIONS {
+    for name in IMPLICIT_LOCAL_OPERATOR_EXCEPTIONS {
         let source = read(name);
-        assert_eq!(
-            enforcement(name, &source).as_deref(),
-            Some("legacy"),
-            "{name} is listed as a legacy exception but no longer pins legacy"
+        let value: toml::Value =
+            toml::from_str(&source).unwrap_or_else(|error| panic!("{name}: {error}"));
+        assert!(
+            value.get("security").is_none(),
+            "{name} is listed as implicit-local-operator but declares [security]"
+        );
+        assert!(
+            value["global"]["telemetry"].get("grpc_tcp").is_none(),
+            "{name} is listed as implicit-local-operator but declares a TCP \
+             listener, which tier validation would reject unauthenticated"
         );
     }
 

--- a/tests/interop_tier_auth_rr.rs
+++ b/tests/interop_tier_auth_rr.rs
@@ -62,32 +62,6 @@ const TOPOLOGIES: &[&str] = &[
     "m92-gobgp-v47-rs-differential",
     "m93-required-families-bird",
 ];
-// Configs deliberately held on `enforcement = "legacy"`. Each states its own
-// reason at its `[security.grpc]` block; the tags below are the short form.
-// Adding an entry means recording the reason in the config too.
-const LEGACY_ALLOWLIST: &[&str] = &[
-    // no gRPC listener to govern
-    "tests/interop/configs/rustbgpd-frr-badopen.toml",
-    // driver and soak call grpcurl directly, uncredentialed
-    "tests/interop/configs/rustbgpd-m33-scale.toml",
-    // asserted through FRR, bridge fdb, and Prometheus
-    "tests/interop/configs/rustbgpd-m37-originator.toml",
-    // plaintext grpcurl driver; shared with the Gate 9 soak
-    "tests/interop/configs/rustbgpd-m39-pe1.toml",
-    // operator token on pe1/pe2 only; vtep read over plain rbgp
-    "tests/interop/configs/rustbgpd-m67-vtep.toml",
-    // soak observes via Prometheus and FRR, no gRPC client
-    "tests/interop/configs/rustbgpd-soak-gr-restart.toml",
-    // soak's generated candidates pin the same legacy block
-    "tests/interop/configs/rustbgpd-soak-hot-reload.toml",
-    // soak drives rbgp rib add/delete without a token
-    "tests/interop/configs/rustbgpd-soak-inject-churn.toml",
-    // Gate 8b soaks observe via Prometheus only
-    "tests/soak/configs/rustbgpd-soak-gate8b-pe1.toml",
-    // Gate 8b soaks observe via Prometheus only
-    "tests/soak/configs/rustbgpd-soak-gate8b-pe2.toml",
-];
-
 fn is_rr_slice(name: &str) -> bool {
     let Some(suffix) = name.strip_prefix("rustbgpd-m") else {
         return false;
@@ -97,16 +71,6 @@ fn is_rr_slice(name: &str) -> bool {
         && digits
             .parse::<u8>()
             .is_ok_and(|n| (70..=93).contains(&n) && n != 90)
-}
-
-fn has_legacy_enforcement(source: &str) -> bool {
-    let value: toml::Value = toml::from_str(source).expect("config must be valid TOML");
-    value
-        .get("security")
-        .and_then(|security| security.get("grpc"))
-        .and_then(|grpc| grpc.get("enforcement"))
-        .and_then(toml::Value::as_str)
-        == Some("legacy")
 }
 
 /// Reverting tier auth, a node bind/env, or driver helper wiring makes this
@@ -259,47 +223,53 @@ fn rr_and_route_server_interop_is_tier_authenticated_end_to_end() {
     assert_eq!(drivers.len(), 23, "driver inventory changed");
 }
 
-/// Adding an unowned legacy config or removing a stale allowlist entry makes
-/// this red: equality deliberately fences both sides of the inventory.
+/// v0.63.0 retired `enforcement = "legacy"` (validation rejects it), so no
+/// live config, config generator, or lab fixture may still pin it. This
+/// replaces the LAN-546 legacy allowlist: the allowlist existed only to
+/// tolerate legacy, and its former entries are all migrated. Scanned:
+/// every text file under tests/, bench/, and scripts/, except
+/// - `.rs` sources (the rejection tests carry the literal on purpose),
+/// - `artifacts-*` directories (byte-exact captures of past bench runs),
+/// - `runs` directories (local soak/chaos run outputs, untracked).
+///
+/// Both TOML quote styles are matched so a single-quoted pin cannot slip
+/// past the gate.
 #[test]
-fn legacy_auth_inventory_is_exactly_the_owned_exceptions() {
+fn no_config_producer_still_pins_legacy_enforcement() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let mut live = BTreeSet::new();
-    for relative_dir in ["tests/interop/configs", "tests/soak/configs"] {
-        for entry in fs::read_dir(root.join(relative_dir)).unwrap() {
-            let file = entry.unwrap().path();
-            if file.extension().and_then(|ext| ext.to_str()) != Some("toml") {
+    let mut stack: Vec<_> = ["tests", "bench", "scripts"]
+        .iter()
+        .map(|dir| root.join(dir))
+        .collect();
+    let mut offenders = Vec::new();
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir).unwrap() {
+            let path = entry.unwrap().path();
+            let name = path.file_name().unwrap().to_str().unwrap();
+            if path.is_dir() {
+                if !name.starts_with("artifacts-") && name != "runs" && name != "target" {
+                    stack.push(path);
+                }
                 continue;
             }
-            if has_legacy_enforcement(&fs::read_to_string(&file).expect("config readable")) {
-                live.insert(
-                    file.strip_prefix(root)
-                        .unwrap()
-                        .to_str()
-                        .unwrap()
-                        .to_owned(),
-                );
+            if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+                continue;
+            }
+            let Ok(source) = fs::read_to_string(&path) else {
+                continue; // binary fixture
+            };
+            if source.contains("enforcement = \"legacy\"")
+                || source.contains("enforcement = 'legacy'")
+            {
+                offenders.push(path.strip_prefix(root).unwrap().display().to_string());
             }
         }
     }
+    offenders.sort();
     assert_eq!(
-        live,
-        LEGACY_ALLOWLIST
-            .iter()
-            .map(|path| (*path).to_owned())
-            .collect()
+        offenders,
+        Vec::<String>::new(),
+        "enforcement = \"legacy\" was removed in v0.63.0; migrate these to \
+         tier (or delete their [security.grpc] block for owner-only UDS)"
     );
-}
-
-/// Replacing semantic TOML inspection with a text search makes this red: the
-/// legacy value uses equivalent single-quote syntax and the tier value names
-/// legacy only in a comment.
-#[test]
-fn legacy_inventory_classification_is_semantic() {
-    assert!(has_legacy_enforcement(
-        "[security.grpc]\nenforcement = 'legacy'\n"
-    ));
-    assert!(!has_legacy_enforcement(
-        "[security.grpc]\nenforcement = 'tier' # enforcement = \"legacy\"\n"
-    ));
 }

--- a/tests/interop_tier_auth_rr.rs
+++ b/tests/interop_tier_auth_rr.rs
@@ -227,42 +227,45 @@ fn rr_and_route_server_interop_is_tier_authenticated_end_to_end() {
 /// live config, config generator, or lab fixture may still pin it. This
 /// replaces the LAN-546 legacy allowlist: the allowlist existed only to
 /// tolerate legacy, and its former entries are all migrated. Scanned:
-/// every text file under tests/, bench/, and scripts/, except
+/// every git-tracked text file under tests/, bench/, and scripts/,
+/// except
 /// - `.rs` sources (the rejection tests carry the literal on purpose),
-/// - `artifacts-*` directories (byte-exact captures of past bench runs),
-/// - `runs` directories (local soak/chaos run outputs, untracked).
+/// - `artifacts-*` directories (byte-exact captures of past bench runs).
+///
+/// Only tracked files are scanned (`git ls-files`): untracked local run
+/// outputs — old campaign artifacts, soak scratch — are not config
+/// producers and must not flake this gate on a dev box.
 ///
 /// Both TOML quote styles are matched so a single-quoted pin cannot slip
 /// past the gate.
 #[test]
 fn no_config_producer_still_pins_legacy_enforcement() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let mut stack: Vec<_> = ["tests", "bench", "scripts"]
-        .iter()
-        .map(|dir| root.join(dir))
-        .collect();
+    let tracked = std::process::Command::new("git")
+        .args(["ls-files", "-z", "--", "tests", "bench", "scripts"])
+        .current_dir(root)
+        .output()
+        .expect("git ls-files enumerates the tracked scan set");
+    assert!(tracked.status.success(), "git ls-files failed");
     let mut offenders = Vec::new();
-    while let Some(dir) = stack.pop() {
-        for entry in fs::read_dir(&dir).unwrap() {
-            let path = entry.unwrap().path();
-            let name = path.file_name().unwrap().to_str().unwrap();
-            if path.is_dir() {
-                if !name.starts_with("artifacts-") && name != "runs" && name != "target" {
-                    stack.push(path);
-                }
-                continue;
-            }
-            if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
-                continue;
-            }
-            let Ok(source) = fs::read_to_string(&path) else {
-                continue; // binary fixture
-            };
-            if source.contains("enforcement = \"legacy\"")
-                || source.contains("enforcement = 'legacy'")
-            {
-                offenders.push(path.strip_prefix(root).unwrap().display().to_string());
-            }
+    for rel in String::from_utf8(tracked.stdout)
+        .expect("tracked paths are UTF-8")
+        .split('\0')
+        .filter(|rel| !rel.is_empty())
+    {
+        let path = root.join(rel);
+        if rel.split('/').any(|part| part.starts_with("artifacts-")) {
+            continue;
+        }
+        if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+            continue;
+        }
+        let Ok(source) = fs::read_to_string(&path) else {
+            continue; // binary fixture
+        };
+        if source.contains("enforcement = \"legacy\"") || source.contains("enforcement = 'legacy'")
+        {
+            offenders.push(rel.to_string());
         }
     }
     offenders.sort();

--- a/tests/soak/configs/rustbgpd-soak-gate8b-pe1.toml
+++ b/tests/soak/configs/rustbgpd-soak-gate8b-pe1.toml
@@ -21,8 +21,8 @@ listen_port = 179
 log_format = "json"
 prometheus_addr = "0.0.0.0:9179"
 
-[global.telemetry.grpc_tcp]
-address = "0.0.0.0:50051"
+# No gRPC listener: the Gate 8b soaks observe via Prometheus only. The
+# implicit owner-only UDS listener satisfies default tier enforcement.
 
 [[evpn_instances]]
 vni = 100
@@ -45,7 +45,3 @@ remote_asn = 65000
 description = "pe2"
 hold_time = 30
 families = ["l2vpn_evpn"]
-
-# Legacy: the Gate 8b soaks observe via Prometheus only; no gRPC client or operator token is wired.
-[security.grpc]
-enforcement = "legacy"

--- a/tests/soak/configs/rustbgpd-soak-gate8b-pe2.toml
+++ b/tests/soak/configs/rustbgpd-soak-gate8b-pe2.toml
@@ -17,8 +17,8 @@ listen_port = 179
 log_format = "json"
 prometheus_addr = "0.0.0.0:9179"
 
-[global.telemetry.grpc_tcp]
-address = "0.0.0.0:50051"
+# No gRPC listener: the Gate 8b soaks observe via Prometheus only. The
+# implicit owner-only UDS listener satisfies default tier enforcement.
 
 [[evpn_instances]]
 vni = 100
@@ -41,7 +41,3 @@ remote_asn = 65000
 description = "pe1"
 hold_time = 30
 families = ["l2vpn_evpn"]
-
-# Legacy: the Gate 8b soaks observe via Prometheus only; no gRPC client or operator token is wired.
-[security.grpc]
-enforcement = "legacy"

--- a/tests/soak/gate9-slice6-soak.clab.yml
+++ b/tests/soak/gate9-slice6-soak.clab.yml
@@ -32,6 +32,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ../interop/configs/rustbgpd-m39-pe1.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ../interop/scripts/start-rustbgpd-m39-pe1.sh:/usr/local/bin/start-rustbgpd-m39-pe1.sh:ro
         - ../interop/scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:

--- a/tests/soak/m67-link-drain-soak.clab.yml
+++ b/tests/soak/m67-link-drain-soak.clab.yml
@@ -89,6 +89,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ../interop/configs/rustbgpd-m67-vtep.toml:/etc/rustbgpd/config.toml:ro
+        - ../fixtures/grpc-test-only-operator.token:/run/rustbgpd/grpc-test-only-operator.token:ro
         - ../interop/scripts/start-rustbgpd-vtep.sh:/usr/local/bin/start-rustbgpd-vtep.sh:ro
       exec:
         - sh -c "echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6"
@@ -117,6 +118,7 @@ topology:
         - bridge fdb append 00:00:00:00:00:00 dev vxlan100 dst 10.0.2.2 self permanent
       env:
         RUST_LOG: info,rustbgpd_evpn_linux=debug,rustbgpd::evpn_dataplane=debug
+        RUSTBGPD_TOKEN_FILE: /run/rustbgpd/grpc-test-only-operator.token
 
     pe1:
       kind: linux

--- a/tests/soak/run-m33-soak.sh
+++ b/tests/soak/run-m33-soak.sh
@@ -41,8 +41,13 @@ INTEROP_SCRIPT_DIR="$(cd "$SOAK_SCRIPT_DIR/../interop/scripts" && pwd)"
 # `containerlab destroy` to find the right topology file.
 SCRIPT_DIR="$INTEROP_SCRIPT_DIR"
 
+INTEROP_TEST_OPERATOR_AUTH=1
 # shellcheck source=../interop/scripts/test-lib.sh
 source "$INTEROP_SCRIPT_DIR/test-lib.sh"
+# The inlined grpcurl probes below run under `timeout` where test-lib
+# functions are invisible, so carry the shared bearer header as a string.
+IFS= read -r _SOAK_TOKEN < "$INTEROP_TEST_OPERATOR_TOKEN_FILE"
+GRPC_AUTH_HEADER="authorization: Bearer $_SOAK_TOKEN"
 
 # ---------------------------------------------------------------------------
 # Config (env-overridable)
@@ -337,7 +342,7 @@ touch "$SAMPLER_RUN_FLAG"
         # plus an outer `timeout` ceiling.
         grpc_ok=0
         if timeout 10 grpcurl -plaintext -connect-timeout 5 -import-path . \
-            -proto "$PROTO" "$GRPC_ADDR" \
+            -proto "$PROTO" -H "$GRPC_AUTH_HEADER" "$GRPC_ADDR" \
             rustbgpd.v1.ControlService/GetHealth >/dev/null 2>&1; then
             grpc_ok=1
         fi
@@ -378,7 +383,7 @@ while true; do
     # should be detected as a failure, not block here for hours.
     if [ $(( now - last_health_log )) -ge "$HEALTH_CHECK_INTERVAL" ]; then
         if timeout 10 grpcurl -plaintext -connect-timeout 5 -import-path . \
-            -proto "$PROTO" "$GRPC_ADDR" \
+            -proto "$PROTO" -H "$GRPC_AUTH_HEADER" "$GRPC_ADDR" \
             rustbgpd.v1.ControlService/GetHealth >/dev/null 2>&1; then
             consecutive_health_fails=0
             elapsed_h=$(awk -v s=$((now - SOAK_START)) 'BEGIN { printf "%.2f", s/3600.0 }')

--- a/tests/soak/run-soak-hot-reload.sh
+++ b/tests/soak/run-soak-hot-reload.sh
@@ -41,7 +41,9 @@ RUSTBGPD="${RUSTBGPD:-clab-${TOPO}-rustbgpd}"
 FRR="${FRR:-clab-${TOPO}-frr}"
 RUSTBGPD_IP="${RUSTBGPD_IP:-10.0.0.1}"
 FRR_IP="${FRR_IP:-10.0.0.2}"
-GRPC_ADDR="${GRPC_ADDR:-http://127.0.0.1:50051}"
+# Default UDS socket: owner-only, so the in-container rbgp calls
+# authorize as the implicit local-operator under tier enforcement.
+GRPC_ADDR="${GRPC_ADDR:-unix:///var/lib/rustbgpd/grpc.sock}"
 
 RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
 RUN_DIR="${RUN_DIR_OVERRIDE:-$SOAK_SCRIPT_DIR/runs/soak-hot-reload-$RUN_ID}"
@@ -179,17 +181,11 @@ listen_port = 179
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
 
-[global.telemetry.grpc_tcp]
-address = "0.0.0.0:50051"
-
 [[neighbors]]
 address = "10.0.0.2"
 remote_asn = 65002
 description = "frr-soak-hot-reload-cycle-${cycle}"
 hold_time = 90
-
-[security.grpc]
-enforcement = "legacy"
 EOF
 }
 

--- a/tests/soak/run-soak-inject-churn.sh
+++ b/tests/soak/run-soak-inject-churn.sh
@@ -44,7 +44,9 @@ RUSTBGPD="${RUSTBGPD:-clab-${TOPO}-rustbgpd}"
 FRR="${FRR:-clab-${TOPO}-frr}"
 RUSTBGPD_IP="${RUSTBGPD_IP:-10.0.0.1}"
 FRR_IP="${FRR_IP:-10.0.0.2}"
-GRPC_ADDR="${GRPC_ADDR:-http://127.0.0.1:50051}"
+# Default UDS socket: owner-only, so the in-container rbgp calls
+# authorize as the implicit local-operator under tier enforcement.
+GRPC_ADDR="${GRPC_ADDR:-unix:///var/lib/rustbgpd/grpc.sock}"
 NEXTHOP="${NEXTHOP:-10.0.0.1}"
 
 RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"


### PR DESCRIPTION
## What

Retires `security.grpc.enforcement = "legacy"` as a functioning mode (LAN-547). The value still parses — the v1 config surface keeps the `GrpcEnforcementConfig::Legacy` variant, now doc-deprecated (removal of the dead variant tracked in the compat-debt inventory, LAN-837) — but validation rejects it at boot, `--check`, and reload with a one-shot diagnosis in the #1429 style: numbered facts plus a copy-pasteable fix.

```
error: invalid gRPC config: security.grpc.enforcement = "legacy" was removed in v0.63.0 and no longer boots:
  1. legacy mode recorded [security.grpc.roles] as audit context but enforced nothing; ...
  2. if your clients are local (rbgp over a UDS socket, ...) ... simply delete the whole [security.grpc] block
  3. a listener with a declared principal keeps working under tier with a role entry; keep this instead:
[security.grpc]
enforcement = "tier"

[security.grpc.roles]
"<your-principal>" = "operator"
```

The runtime legacy path is deleted outright: `AuthEnforcement` is gone from `rustbgpd-api`, role ceilings are enforced unconditionally (a legacy allow-all context can no longer be constructed at the type level), the constant `enforcement` audit-log label is dropped, and the startup advisory / `--check` warning plumbing for legacy is removed — `--check` now fails with exit 1 instead of warning. `[security.grpc]` reload edits stay restart-pinned; a reload delivering a legacy config hits the same loader rejection.

## Why

Owner decision recorded on LAN-547: one-release clean cut, correctness-over-compat, under the project's pre-1.0 alpha stability posture. The implicit `local-operator` identity (#1429) removed the migration burden for local-only deployments — for them the migration is literally deleting the legacy line (or the whole block).

**Supersession note:** docs previously projected a two-minor/90-day floor (≈2026-10-09) as the earliest *eligibility* for this removal. Every passage that stated that floor (`docs/API.md`, `docs/SECURITY.md`, `docs/CONFIGURATION.md`, `docs/grpc-method-inventory.md`) now states the supersession explicitly rather than being silently rewritten; ADR-0064 gains a short status addendum.

## Migration

- Local-only management (rbgp over UDS, including the implicit default socket): delete the `[security.grpc]` block. Owner-only sockets authorize as the implicit `local-operator`.
- Named-principal listeners: keep `enforcement = "tier"` plus a `[security.grpc.roles]` entry for the listener principal (the rejection message carries the exact paste block).

Every in-repo config producer is migrated with the removal:

- Dropped `[security.grpc]` + unused plaintext TCP listener (implicit owner-only UDS now serves them): `rustbgpd-frr-badopen`, `rustbgpd-m37-originator`, `rustbgpd-soak-gr-restart`, `rustbgpd-soak-hot-reload`, `rustbgpd-soak-inject-churn`, `rustbgpd-soak-gate8b-pe1/pe2`; the hot-reload/inject-churn soak drivers now dial the default UDS socket, and the hot-reload candidate template loses the legacy block.
- Adopted the shared test-only tier identity (token bind + `[security.grpc.roles]`, drivers send the bearer credential): `rustbgpd-m33-scale` (+ chaos-flap-storm, chaos-grpc-churn, run-m33-soak), `rustbgpd-m39-pe1` (+ gate9 soak topology), `rustbgpd-m67-vtep` (vtep node now mirrors the M66 token env).
- Bench generators (`enhanced-route-refresh`, `reloadstall` x2) drop the legacy block — their owner-only UDS probes ride the implicit identity.
- The LAN-546 legacy allowlists (`LEGACY_EXCEPTIONS` / `LEGACY_ALLOWLIST` and the semantic classifier) are deleted; a new repo-wide test gate asserts no config producer under `tests/`, `bench/`, or `scripts/` pins legacy (recorded `artifacts-*` captures and `.rs` rejection fixtures exempt). Mutation-proven red/green.

## Proofs

- `--check` on a legacy config exits 1 with the new message (release-build smoke + `tests/check_strict.rs`); the same config with the block deleted passes `--check --strict`.
- Restoring the legacy validation acceptance flips the rejection test red (mutation-tested).
- Planting a legacy config flips the repo-wide gate red (mutation-tested).
- Gates: fmt, clippy `-D warnings`, `cargo test --workspace`, `RUSTDOCFLAGS='-D warnings' cargo doc`, `check-clippy-reasons.py`, `check-v1-stable-surface.py` (no schema fields change; `docs/rustbgpd.schema.json` re-blessed for doc-comment text), `cargo test -p rustbgpd-api authz` — all exit 0.

Recorded artifacts (`docs/perf/artifacts/**`, `bench/scale/matrix/artifacts-*/**`) are byte-exact captures of past runs and are deliberately not rewritten.
