### PR TITLE
docs: compatibility-debt inventory and removal schedule (ADR-0122)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1696,6 +1696,19 @@ Cross-cutting cleanups that don't move user-facing capability on their own but
 lower the cost of every future PR. None block a release — grab one when your
 branch is between features.
 
+- [ ] **Compatibility-debt removal schedule (ADR-0122).**
+  [docs/adr/0122-compatibility-debt-inventory.md](docs/adr/0122-compatibility-debt-inventory.md)
+  is the single inventory of retained compat shims under the alpha
+  posture, grouped by surface with per-item removal releases and
+  mechanics. Immediate remove-now items: the two v0.51.0 retired-key
+  migration pointers and the redundant example-config UDS authorization
+  ceremony made unnecessary by #1429. Scheduled: the dead
+  `enforcement = "legacy"` enum variant, the `rbgp rib diff`
+  older-daemon fallbacks, and three superseded proto fields. Two calls
+  are owner-gated there (legacy config-history reader EOL, unary vs
+  streaming Plan/Apply fate); new compat retentions add a row to the
+  ADR in the PR that introduces them.
+
 - [x] **Legacy GR/LLGR RFC gaps in unicast/FlowSpec/EVPN — RESOLVED.**
   The RR families (VPN/BGP-LS/RTC, #636–#638) implement the strict
   semantics; the pre-existing paths had three documented divergences,

--- a/docs/adr/0122-compatibility-debt-inventory.md
+++ b/docs/adr/0122-compatibility-debt-inventory.md
@@ -1,0 +1,105 @@
+# ADR-0122: Compatibility-debt inventory and removal schedule
+
+**Status:** Proposed
+**Date:** 2026-08-03
+
+## Context
+
+rustbgpd is public alpha. The stated posture (README "Config stability" /
+"API stability", `docs/v1-stable-contract.md`) is correctness over
+compatibility: only the machine-pinned v1 RS/RR surface carries a
+compatibility promise; everything else may change between minors with a
+CHANGELOG migration note, and long-lived shims are not wanted. Despite that,
+compatibility code accumulates one PR at a time — dead enum variants kept for
+a schema hash, hidden CLI aliases marked "must never be removed",
+rolling-upgrade fallbacks for daemons that no longer exist in any supported
+deployment.
+
+This ADR is the single inventory of that debt and its removal schedule.
+Nothing is removed by this ADR; each scheduled entry lands as its own PR
+against the release named here. Entries marked **owner decision** need a call
+from the project owner before scheduling.
+
+Not listed, by deliberate judgment: protocol-mandated compatibility (RFC 6793
+AS4 compat attributes, RFC 8277 §2.4 compatibility field, RFC 5925 TCP-AO
+key deprecation flags), rejection of deprecated third-party proto forms (gNMI
+`Path.element` / `Value`), and API semantics that read as compat wording but
+are really deliberate design (`page_size = 0` full snapshot, empty
+`required_families` inheriting partial-intersection behavior, bare integers
+as exact numeric matches). These are not debt.
+
+## Decision
+
+### Lifetime policy for migration aids
+
+Unless an entry says otherwise:
+
+- **Retired-config-key migration pointers** live three minor releases after
+  the key's removal, then are deleted (the plain unknown-field error
+  remains).
+- **CLI/daemon rolling-upgrade fallbacks** support exactly the previous minor
+  release; a fallback whose emitting daemon is two or more minors old is
+  prunable without a new decision.
+- Removal of anything covered by `docs/v1-stable-surface.json` additionally
+  runs the blessed-surface procedure (`scripts/check-v1-stable-surface.py`
+  re-bless) and gets a CHANGELOG **Removed** entry with migration steps.
+
+### Inventory
+
+Classifications: **remove-now** (next docs/cleanup PR, current release
+window), **deprecate → vX** (scheduled removal release), **keep** (retained
+with reason), **owner decision** (genuinely an owner-level call).
+
+#### Config schema surface
+
+| # | Item | What it preserves | Cost of keeping | Classification | Removal mechanics |
+|---|------|-------------------|-----------------|----------------|-------------------|
+| C1 | `GrpcEnforcementConfig::Legacy` enum variant (`src/config/schema.rs:332`). Dead since #1431: validation rejects it outright (`src/config/validation.rs:2672`); the runtime path was removed in v0.63.0 (ADR-0064 status addendum). | v1 config surface still *parses* `enforcement = "legacy"` so the rejection message can carry migration steps; keeps the pinned `GrpcSecurityConfig` schema hash (`docs/v1-stable-surface.json:70`, `docs/rustbgpd.schema.json:1202`). | Dead variant, bespoke error assembly, structural tests policing that no fixture uses it (`src/reload.rs:2830`, `src/config_transaction_control.rs:3273`). | deprecate → v0.65 | Delete variant; add a `retired_key_error`-style pointer for `enforcement = "legacy"` (three-minor lifetime per policy above); re-bless v1 surface + JSON schema; ADR-0064 addendum note; CHANGELOG Removed. |
+| C2 | Retired-key migration pointers in the TOML loader (`retired_key_error`, `src/config/mod.rs:1338`): `[global.telemetry.looking_glass]` and `[[policy.import]]`/`[[policy.export]]`, both removed in v0.51.0. | Actionable migration error instead of a bare serde unknown-field diagnostic. | Two string branches; trivial. | remove-now (v0.63 window) | Both pointers are past the three-minor lifetime (v0.51.0 → v0.62.0). Delete both branches (keep the `retired_key_error` mechanism for C1's pointer); CHANGELOG note. |
+| C3 | `BgpRoleConfig` serde aliases `rs` / `rs-client` (`src/config/schema.rs:1450`). | Common shorthand spellings for RFC 9234 roles in operator configs. | Two attribute lines; zero runtime cost. | keep | Documented spellings, not a migration shim. |
+
+#### CLI surface
+
+| # | Item | What it preserves | Cost of keeping | Classification | Removal mechanics |
+|---|------|-------------------|-----------------|----------------|-------------------|
+| L1 | Hidden `--from-file` compatibility aliases on `config check` / `config diff` / `config apply` (`crates/cli/src/main.rs:419-457`), kept when LAN-329 made file arguments positional. The conventions comment pledges they "must never be removed" (`crates/cli/src/main.rs:40-42`). | Old scripts invoking the pre-LAN-329 flag spelling. | Three hidden args + `candidate_file()` merge helper; near zero. The real debt is the "never" pledge, which contradicts the alpha posture. | owner decision | If removal is approved: delete the hidden args + helper, regenerate checked-in shell completions, CHANGELOG migration note (positional spelling). Either way, reword the conventions comment from "never" to "until the scheduled removal release". |
+| L2 | Visible aliases `--peer` (for `--neighbor`) and `--asn` (for `--remote-asn`) throughout `crates/cli/src/main.rs` (e.g. lines 239, 838). | Both product-language spellings, by design (LAN-329 conventions block). | Zero; clap renders them in help. | keep | Canonical convention, not a shim. |
+| L3 | `rbgp rib diff` older-daemon fallbacks from #1367: single-peer tolerance for daemons that omit `page_version` (`observe_page_version`, `crates/cli/src/commands/diff.rs:1012`) and the MED 0-maps-to-absent fallback for daemons without `med_attr` (`crates/cli/src/commands/diff.rs:1072`, caveat machinery at `diff.rs:76`). | Version-less legacy path: diffing against a ≤v0.62 daemon that predates the fenced advertised-RIB pages. | A fallback state machine, mixed present/absent fail-closed arms, and a caveat surface — the largest single compat structure in the CLI. | deprecate → v0.65 | Fail closed on any response omitting `page_version` (message: upgrade the daemon); delete the single-peer tolerance + `med_attr` fallback + caveat; CHANGELOG note. Rolling-upgrade policy above (N-1) makes v0.65 the earliest release whose N-1 daemon always emits both fields. |
+| L4 | Assorted CLI rolling-upgrade fallbacks for absent additive fields: `neighbor_source_label` "range unavailable" arm (`crates/cli/src/output.rs:246`), max-prefix action absence handling (`crates/cli/src/commands/neighbor.rs:1666-1701`). | `rbgp` from HEAD reading the previous minor's daemon during an upgrade. | Small, individually tested branches. | keep (policy-bounded) | Governed by the N-1 rule: each branch is prunable once its emitting release is two minors old; no per-branch decision needed. |
+
+#### API surface (protobuf / metrics)
+
+| # | Item | What it preserves | Cost of keeping | Classification | Removal mechanics |
+|---|------|-------------------|-----------------|----------------|-------------------|
+| A1 | `AddNeighborRequest.config` legacy carrier — field 1 outside the oneof-shaped pair (`proto/rustbgpd.proto:852`), kept by ADR-0118 when `NeighborCreateIntent` became the presence-aware create path. `rbgp` already sends `intent` (`crates/cli/src/commands/neighbor.rs:1136`). | Pre-ADR-0118 gRPC clients that populate the bare `config` field. | Dual-carrier validation ("exactly one carrier") on every create. | deprecate → v0.65 | Reserve field 1; collapse to `intent` only; `AddNeighbor` is in the pinned NeighborService message graph (`docs/v1-stable-surface.json:142`) → blessed-surface re-bless; CHANGELOG migration (populate `intent`). |
+| A2 | `PathsLimitState.effective_send_max` raw cap (`proto/rustbgpd.proto:482`), superseded by the presence-aware `effective_send_limit`; "preserved for rolling compatibility". | New clients reading pre-`effective_send_limit` daemons; old clients reading the raw field. | One conflated field (0 vs UINT32_MAX sentinel encoding) plus the client-side fallback read. | deprecate → v0.64 | Paths-Limit is Experimental and outside v1 (`docs/v1-stable-contract.md` role matrix), so no bless needed; reserve the field, drop the CLI fallback read, CHANGELOG note. |
+| A3 | `RouteEvent.event_id` back-compat mirror of the envelope event id (`proto/rustbgpd.proto:2815-2825`, `crates/api/src/event_service/cursor.rs:440-443`), kept "for route-only consumers". | Route-only event consumers that never read the `BgpEvent` envelope id. | Duplicate id on every route event; a documented invariant that the two must mirror. | deprecate → v0.65 | RibService/EventService message graphs are pinned (`docs/v1-stable-surface.json:145-146`) → blessed-surface re-bless; reserve the field; CHANGELOG migration (read the envelope id). |
+| A4 | Legacy `bgp_otc_routes_blocked_total{peer,reason}` counter and `otc_routes_blocked` scalar, named "the compatibility surfaces" alongside `OtcRouteBlockedEvent` (`proto/rustbgpd.proto:2740-2745`). | Existing dashboards/alerts on the counter. | One counter family; metrics are the intended observation surface. | keep | Events complement, not replace, the counter; renaming metrics has its own cost (cf. the `bgp_aspa_records` rename cycle in v0.51.0). |
+
+#### Decision-owed (owner)
+
+| # | Item | State | What is owed |
+|---|------|-------|--------------|
+| D1 | Legacy v1 config-history rows, the mixed-format reader (`src/config_history.rs`, `src/config_history/v2.rs`, #1409/#1413), and the v1 commit-confirm boot-revert path. | ADR-0121 §9 keeps legacy rows readable (`LEGACY_TOML_ONLY`, rollback only when no external inputs) and preserves the v1 journal boot revert; LAN-798 (In Progress) is activating commit-confirm v2. No EOL is stated anywhere: legacy *rows* age out via the 20-entry retention, but the legacy reader code and the v1 journal lane live until someone decides. | An EOL release for (a) the legacy row-payload lane in the mixed reader and (b) the locator-absent v1 journal fallback, decided on the LAN-798 thread after v2 activation ships and soaks one release. |
+| D2 | Unary `PlanConfigTransaction` / `ApplyConfigTransaction` (`proto/rustbgpd.proto:115,124`) vs the accepted streaming Plan/Apply direction (LAN-794). | LAN-794's accepted contract keeps unary byte- and behavior-compatible and gives the CLI an `UNIMPLEMENTED`-only bounded unary fallback once streaming ships. Whether unary remains the permanent small-candidate path or becomes a deprecated shim is unstated. | After streaming phase 2 lands: decide whether unary Plan/Apply is (a) kept as the documented small-candidate path or (b) scheduled for removal. Both RPCs are in the pinned ConfigService surface, so (b) is a blessed-surface change. |
+
+#### Internal / examples (remove-now follow-up)
+
+| # | Item | What it preserves | Cost of keeping | Classification | Removal mechanics |
+|---|------|-------------------|-----------------|----------------|-------------------|
+| E1 | Explicit UDS authorization ceremony in all 10 example configs carrying `[global.telemetry.grpc_uds]` + `principal` + `[security.grpc]` + `[security.grpc.roles]` (e.g. `examples/minimal/config.toml:30-42`, `examples/ddos-mitigation/config.toml`; full list: minimal, route-server, ddos-mitigation, manrs-action1, linux-edge-fib, hosting-provider, rr-evpn-fabric, evpn-vtep-leaf, route-collector, docker-compose). | Nothing — since #1429 an owner-only UDS socket (including the implicit default) authorizes clients as `local-operator` with zero config. Valid but verbose. | Every example teaches ~12 lines of unnecessary ceremony as if required; contradicts the #1430 docs that teach the implicit path. | remove-now (v0.63 window, docs-only PR) | Delete the blocks (or reduce to a one-line comment naming the implicit default); keep one example (envoy-mtls or a TCP snippet) demonstrating explicit principals/roles where they buy real scoping; `cargo test --workspace` (example-config fixtures) + docs cross-check. |
+
+## Consequences
+
+- One place answers "why does this still exist and when does it die" for
+  every known shim; new compat retentions should add a row here in the same
+  PR that introduces them.
+- The three-minor / N-1 lifetime policies convert future removals from
+  per-item debates into scheduled cleanups.
+- Two genuinely open calls (D1, D2) and one recorded-pledge conflict (L1)
+  are surfaced for the owner instead of being silently perpetuated.
+- Scheduled removals (C1, A1, A3) touch the blessed v1 surface; each needs
+  the re-bless procedure and a CHANGELOG migration note, which this ADR's
+  mechanics columns pre-write.
+- Until the scheduled release arrives, everything listed keeps working;
+  this ADR changes no behavior.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -130,6 +130,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0119](0119-rfc-8212-secure-default-config-epoch.md) | RFC 8212 secure-default config epoch | Proposed (representation contract and secure-default activation deferred; owner gate required) | 2026-07-29 |
 | [0120](0120-inbound-connection-admission.md) | Inbound connection admission rate limiting | Accepted | 2026-07-30 |
 | [0121](0121-config-history-external-policy-provenance.md) | Config-history external-policy provenance | Accepted — history restore shipped; commit-confirm v2 designed, implementation pending | 2026-08-01 |
+| [0122](0122-compatibility-debt-inventory.md) | Compatibility-debt inventory and removal schedule | Proposed | 2026-08-03 |
 
 ## Template
 


### PR DESCRIPTION
## Summary

LAN-837: one repo-wide inventory of retained compatibility debt under the alpha posture (correctness over compatibility; no long-lived shims), landed as ADR-0122 plus a ROADMAP tech-debt pointer. **Nothing is removed in this PR** — it is the schedule, not the removals; each scheduled entry lands as its own PR against the release named in the table.

## Contents

- `docs/adr/0122-compatibility-debt-inventory.md` — inventory grouped by surface (config schema, CLI, API, decision-owed, examples), each row with what it preserves, cost of keeping, classification, and one-line removal mechanics (including which gates it touches: v1-stable-surface re-bless, CHANGELOG, completions regeneration). Every load-bearing claim carries a file:line reference verified against current main.
- Lifetime policies so future removals are scheduled cleanups, not per-item debates: retired-key migration pointers live three minors; CLI/daemon rolling-upgrade fallbacks support N-1 only.
- Two owner-gated decisions surfaced explicitly: legacy v1 config-history reader/journal EOL (ADR-0121 §9, LAN-798) and the post-streaming fate of unary Plan/Apply (LAN-794). One recorded-pledge conflict flagged: the hidden `--from-file` aliases' "must never be removed" comment vs the alpha posture.
- `docs/adr/README.md` index entry; ROADMAP "Engineering velocity / tech debt" pointer section.

## Classification counts

- remove-now: 2 (v0.51.0 retired-key pointers past their lifetime; redundant example-config UDS authorization ceremony post-#1429, 10 files)
- deprecate with scheduled release: 5 (`GrpcEnforcementConfig::Legacy` variant, `rib diff` older-daemon fallbacks, `AddNeighborRequest.config` legacy carrier, `PathsLimitState.effective_send_max`, `RouteEvent.event_id` mirror)
- keep with reason: 4 (role serde aliases, `--peer`/`--asn` visible aliases, N-1 CLI fallbacks, legacy OTC counter)
- owner decision / decision-owed: 3 (`--from-file` removal, config-history legacy lane EOL, unary vs streaming Plan/Apply)

## Gates

- Docs-only diff: `docs/adr/` + `ROADMAP.md`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` green