### PR TITLE
feat: activate provenance-bearing commit-confirm v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,26 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   daemon's enforcement mode from the effective config (skipped against
   daemons that do not expose it).
 
+- **Provenance-bearing commit-confirm v2 (LAN-798, ADR-0121).** New confirmed
+  transactions persist the exact accepted prior snapshot—normalized TOML,
+  external-source manifest, and both digests—in a canonical owner-private v2
+  journal, then publish a config-adjacent locator as the sole pending
+  authority before committing the candidate. Crash/restart restore verifies
+  and directly adopts that retained accepted snapshot before opening candidate
+  contents or mutating the candidate or backup; launch-target metadata may be
+  inspected while binding the authority. Live abort and timeout instead reuse
+  the same prior object through the ordinary #1370-gated planner and apply
+  path. Abort, timeout, and boot restore durably restore while both authority
+  files remain, then remove and sync the locator; confirm begins with that
+  durable locator removal. Later exact journal cleanup is warning-only. The
+  locator-free v1 lane remains fail-closed upgrade compatibility, but a live v1
+  transaction must terminate before upgrade and production never converts or
+  dual-writes it. Before downgrade, both the v2 locator and locator-free v2
+  journal residue must be absent; v2 config history separately requires moving
+  the complete history directory aside. Locator absence remains compatible
+  with the packaged root-owned, read-only config directory; confirmed writes
+  still require the documented daemon-owned writable config directory.
+
 - **Config-history provenance schema and rendering.** `ListConfigHistory` and
   `rbgp config history` now expose an additive config-source digest over the
   normalized-TOML digest plus the canonical accepted rpol/dataset source roster,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,9 +104,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   transaction must terminate before upgrade and production never converts or
   dual-writes it. Before downgrade, both the v2 locator and locator-free v2
   journal residue must be absent; v2 config history separately requires moving
-  the complete history directory aside. Locator absence remains compatible
-  with the packaged root-owned, read-only config directory; confirmed writes
-  still require the documented daemon-owned writable config directory.
+  the complete history directory aside. Locator absence is authority-free and
+  does not impose v2 ownership or mode policy on an ordinary launch path;
+  confirmed writes and any present v2 object still require the documented
+  daemon-owned private directory.
 
 - **Config-history provenance schema and rendering.** `ListConfigHistory` and
   `rbgp config history` now expose an additive config-source digest over the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -213,9 +213,20 @@ Levenshtein machinery as the `.rpol` suggestions (LAN-481);
 versions and rollback share the same transaction/validation path, completing
 the check/compare/confirm/rollback workflow for TOML-complete snapshots
 (LAN-483). ADR-0121 provenance recording and mixed legacy/v2 listing are
-**shipped**, including exact v2 external-source verification and restore. Provenance is
-audit and verification evidence, not authority to adopt external-policy state;
-#1370 keeps changed external-policy rollback fenced; ~~a bounded
+**shipped**, including exact v2 external-source verification and restore.
+**Shipped (LAN-798):** commit-confirm v2 now journals that same immutable prior
+snapshot behind a config-adjacent locator. Crash boot restore verifies and
+directly adopts the accepted prior snapshot; live abort and timeout reuse the
+same prior object through the normal planner and apply path. Locator removal is
+the durable terminal point. The locator-free v1 lane is fail-closed upgrade
+compatibility: a live v1 transaction must terminate before upgrade, and v2
+never converts or dual-writes it. Downgrade requires both the v2 locator and
+locator-free v2 journal residue to be absent, plus the separate v2-history
+move-aside procedure. Provenance is audit and verification evidence, not
+authority to adopt external-policy state. #1370 fences every full-snapshot
+external-input rollback; its only exceptions remain a true no-op and a targeted
+pure-`[[fib_tables]]` transaction whose external inputs are unchanged;
+~~a bounded
 BIRD/FRR/GoBGP config importer~~ **Shipped (#1015):** structure-only conversion
 with a fail-stop unsupported-directive report and shadow-trial workflow
 (LAN-484).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,9 +59,9 @@ input from the network. It runs under continuous fuzzing in CI.
   external-source identity. The locator is confidential because it carries
   paths and digests. Both are bounded canonical records in daemon-owned regular
   `0600` files; a writer or present v2 object requires a daemon-owned parent
-  that is not group- or world-writable. Locator absence may be established in
-  a non-writable root-owned config parent, preserving the packaged read-only
-  SIGHUP deployment. Reads are descriptor-relative, no-follow, same-FD operations;
+  that is not group- or world-writable. Locator absence carries no authority
+  and therefore adds no v2 ownership or mode requirement to an ordinary
+  launch path. Reads are descriptor-relative, no-follow, same-FD operations;
   unsafe, changed, oversized, or mismatched state fails closed before candidate
   contents are opened and before candidate or backup mutation. Launch-target
   metadata may be inspected to bind the authority. Diagnostics do not expose

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,6 +54,19 @@ input from the network. It runs under continuous fuzzing in CI.
 - **No unbounded allocations.** All channels are bounded. Per-peer
   prefix limits enforced at insertion. UPDATE attribute sizes enforced
   at decode time.
+- **Commit-confirm state is authenticated local authority.** The v2 pending
+  journal is secret-bearing because it contains normalized config and accepted
+  external-source identity. The locator is confidential because it carries
+  paths and digests. Both are bounded canonical records in daemon-owned regular
+  `0600` files; a writer or present v2 object requires a daemon-owned parent
+  that is not group- or world-writable. Locator absence may be established in
+  a non-writable root-owned config parent, preserving the packaged read-only
+  SIGHUP deployment. Reads are descriptor-relative, no-follow, same-FD operations;
+  unsafe, changed, oversized, or mismatched state fails closed before candidate
+  contents are opened and before candidate or backup mutation. Launch-target
+  metadata may be inspected to bind the authority. Diagnostics do not expose
+  locator-carried paths or digests. Durable locator removal, not journal
+  deletion, is the terminal transaction boundary.
 - **No `unsafe` code in shipped paths, with two scoped exceptions.** Every
   workspace crate root carries `#![deny(unsafe_code)]`, so `unsafe` cannot enter
   a crate without a visible, reviewed opt-out. There are two:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3240,11 +3240,27 @@ most 128 characters, and free of control characters; the CLI validates those
 constraints before reading the candidate file or calling the daemon.
 
 The confirm window is durable: the daemon journals the pre-commit config
-snapshot to `<runtime_state_dir>/commit-confirm-journal.json` before the
-candidate commits, and a restart that finds an unconfirmed journal reverts to
-the journaled config at boot, saving the unconfirmed candidate aside as
-`<config>.unconfirmed`. See `docs/OPERATIONS.md` (config transactions) for the
-boot-revert semantics.
+snapshot to `<runtime_state_dir>/commit-confirm-journal.json`, including its
+accepted external-source manifest and digests, then publishes
+`<absolute lexical config path>.commit-confirm-locator.json` before the
+candidate commits. That config-adjacent locator is the sole v2 pending
+authority and is checked before candidate contents are parsed. A restart verifies and
+reuses the exact accepted prior snapshot, restores its recorded config target,
+and saves the unconfirmed candidate as `<recorded-target>.unconfirmed`.
+Confirm and successful rollback become terminal after durable locator removal;
+later exact journal-residue cleanup is warning-only. Files and their parent
+directories must satisfy the storage contract: v2 locator, journal, and staging
+files are daemon-owned regular files with mode `0600`. A writer or present v2
+object requires daemon-owned real parents that are not group- or
+world-writable; locator absence may be established in the packaged root-owned,
+read-only config parent. Before downgrade, both the
+v2 locator and any locator-free v2 journal residue must be absent; v2 config
+history separately requires moving the complete history directory aside. A
+locator-free v1 journal remains a fail-closed compatibility lane, but a live v1
+transaction must terminate before upgrade. Production writes only v2 and never
+converts or dual-writes v1 state.
+See `docs/OPERATIONS.md` (config transactions) for the boot-revert and storage
+semantics.
 
 ```console
 $ rbgp fib-table set edge --table-id 1000 --metric 200 \

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3252,8 +3252,8 @@ later exact journal-residue cleanup is warning-only. Files and their parent
 directories must satisfy the storage contract: v2 locator, journal, and staging
 files are daemon-owned regular files with mode `0600`. A writer or present v2
 object requires daemon-owned real parents that are not group- or
-world-writable; locator absence may be established in the packaged root-owned,
-read-only config parent. Before downgrade, both the
+world-writable. Locator absence carries no authority and does not impose this
+v2 storage policy on an ordinary launch path. Before downgrade, both the
 v2 locator and any locator-free v2 journal residue must be absent; v2 config
 history separately requires moving the complete history directory aside. A
 locator-free v1 journal remains a fail-closed compatibility lane, but a live v1

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -233,10 +233,10 @@ backend.
 
 The lexical config and journal paths are resolved to absolute identities. A
 writer or present v2 object requires daemon-owned real parents that are not
-group- or world-writable. An absent locator may be established under a
-non-writable root-owned config parent, so the packaged SIGHUP-only deployment
-continues to boot; confirmed writes there remain unavailable until the config
-directory is made writable and daemon-owned. Locator, journal, and staging
+group- or world-writable. Locator absence carries no authority and therefore
+does not impose that v2 storage policy on an ordinary launch path; confirmed
+writes remain unavailable until the config directory is private, writable,
+and daemon-owned. Locator, journal, and staging
 files must be regular files owned by the daemon UID with mode `0600`; symlinks
 and special files fail closed. Keep writable state private and on local storage.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -184,19 +184,41 @@ failure, or compound rollback failure) likewise retains the journal and blocks
 all config mutations until a restart boot-reverts.
 
 Commit-confirmed also survives a daemon restart or crash inside the confirm
-window. Before the candidate commits, the daemon journals the pre-commit config
-snapshot to `<runtime_state_dir>/commit-confirm-journal.json` (atomic
-write-tmp+rename+fsync); confirm, abort, and timeout auto-revert consume the
-journal. If the daemon starts and finds an unconfirmed journal, it reverts at
-boot — before adopting the on-disk config, and regardless of how much confirm
-time was left, because the operator's confirming session died with the old
-process (the NETCONF RFC 6241 §8.4 rule: session loss cancels a confirmed
-commit). The unconfirmed candidate config file is saved aside as
-`<config>.unconfirmed` and the boot banner + an ERROR log name the transaction
-and that file; re-plan and re-apply to retry it. A torn or unreadable journal,
-or one whose embedded config no longer parses, refuses boot with a message
-naming both the journal and the config file — delete the journal manually only
-if you are sure the on-disk config is the one you want.
+window. Before the candidate commits, the daemon writes the exact accepted
+pre-commit snapshot to
+`<runtime_state_dir>/commit-confirm-journal.json`, including normalized TOML,
+the external-source manifest, and both digests. It then publishes the sole v2
+pending authority at `<absolute lexical config path>.commit-confirm-locator.json`.
+Both files use write-temp + `fsync` + rename + parent-directory `fsync`, and
+the locator is never published before the journal is durable. A publication
+failure refuses the confirmed apply before candidate persistence.
+
+Startup checks the config-adjacent locator before opening or parsing candidate
+contents. It may inspect launch-target metadata while pinning and binding the
+authority. If the locator is present, the daemon verifies it, the complete
+journal, config-target binding, retained TOML, external sources, and digests,
+then directly adopts that accepted snapshot for boot restore. The revert is
+unconditional, regardless of how much confirm time remained, because the
+operator's confirming session died with the old process (the NETCONF RFC 6241
+§8.4 rule: session loss cancels a confirmed commit). The unconfirmed candidate is saved once as
+`<recorded-target>.unconfirmed`; the loud boot banner names the transaction but
+redacts locator-carried paths and digests. A damaged, unsafe, oversized, or
+mismatched locator/journal refuses boot before candidate contents are opened
+and before candidate or backup mutation.
+
+Abort, timeout, and boot restore durably restore the verified prior config while
+both files remain. They then unlink the locator and `fsync` its parent; only
+that durable locator absence is terminal. Confirm performs no restore and
+starts by unlinking and syncing the locator. Exact journal cleanup follows all
+terminal paths; failure there is a warning and safe residue cannot re-arm the
+transaction. An exact canonical v2 journal found without its locator is
+likewise residue and is removed only after all owner/mode/path checks. Production does
+not scan directories, infer another journal, convert v1, or dual-write. With no
+locator, an existing v1 TOML-only journal is handled by the fail-closed legacy
+boot lane, but a live v1 transaction must terminate before upgrade. Before
+downgrade or starting an older binary, both the v2 locator and locator-free v2
+journal residue must be absent. Separately move the complete v2 config-history
+directory aside before the older binary starts.
 
 The boot-revert save-aside moves the unconfirmed candidate to
 `<config>.unconfirmed` with an atomic hard-link + unlink, so it never clobbers
@@ -208,6 +230,15 @@ intact, rather than risk an unsafe revert. Keep the config and
 `runtime_state_dir` on a local filesystem (the default); this mainly matters
 for containerized deployments that bind-mount the config from an exotic
 backend.
+
+The lexical config and journal paths are resolved to absolute identities. A
+writer or present v2 object requires daemon-owned real parents that are not
+group- or world-writable. An absent locator may be established under a
+non-writable root-owned config parent, so the packaged SIGHUP-only deployment
+continues to boot; confirmed writes there remain unavailable until the config
+directory is made writable and daemon-owned. Locator, journal, and staging
+files must be regular files owned by the daemon UID with mode `0600`; symlinks
+and special files fail closed. Keep writable state private and on local storage.
 
 ### The transactional quartet: check, compare, commit confirmed, rollback
 
@@ -259,8 +290,9 @@ unreadable or mismatched rows fail closed before planning or mutation. An eligib
 row is routed through the **same transaction path as
 `config apply`**: the same plan classification, the same reload-impact and
 update-group annotations, and the same receipts. Confirmed rollback remains
-available only when neither the current nor target config declares external
-inputs; provenance-aware commit-confirm journal support is a later tranche.
+subject to that planner: full-snapshot external-policy adoption is still
+fenced, while an unchanged-external-input pure-`[[fib_tables]]` rollback can
+use the provenance-bearing v2 journal and exact accepted prior snapshot.
 There is no second apply engine —
 a rollback whose entry contains sections the transaction executor cannot
 commit live (for example restart-required `[global]` fields) is rejected

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -257,15 +257,26 @@ daemon down) was the one the mechanism could not revert. That hole is closed:
 
 Proven by real-binary SIGKILL tests in `tests/commit_confirm_binary.rs`:
 SIGKILL mid-window then restart boots the previous config with the candidate
-saved aside; confirm-then-SIGKILL retains the new config with no journal;
-in-process timeout auto-revert consumes the journal; a torn journal refuses
-boot naming both files.
+saved aside; confirm-then-SIGKILL retains the new config with no pending
+authority; in-process timeout auto-revert consumes the pending state; and a
+torn locator-free v1 journal still refuses boot naming both legacy files.
 
-ADR-0121 supersedes only the **designed v2 discovery and provenance contract**:
-v2 pending authority will use an owner-only locator adjacent to the stable
-lexical launch-config path, so boot need not trust the candidate to find its
-revert journal. Its journal carries the immutable prior source manifest and is
-verified before candidate access. That v2 design is implementation-pending.
-The v1 TOML-only journal, candidate-derived `runtime_state_dir` discovery, boot
-revert, and live confirm/abort/timeout behavior described in this amendment
-remain the shipped behavior until that implementation lands.
+ADR-0121 now supersedes the v1 **discovery, payload, and terminal-cleanup
+contract** above. The shipped v2 writer stores the immutable accepted prior
+snapshot, including its external-source manifest and digests, in the
+owner-private runtime-state journal, then publishes an owner-private locator
+adjacent to the stable lexical launch-config path. The locator is the sole v2
+pending authority and is checked before candidate contents are parsed. Boot and live
+rollback verify the same accepted prior snapshot, but the execution paths are
+distinct: boot directly adopts the verified accepted object before opening
+candidate contents or mutating candidate/backup, while live abort and timeout
+reuse it through the ordinary #1370-gated planner and apply path. Launch-target
+metadata may be inspected while binding boot authority. Abort, timeout, and
+boot restore durably restore while both files remain, then remove and sync the
+locator. Confirm starts with that locator removal. Exact journal cleanup after
+the terminal point is warning-only. Production writes only v2. The
+locator-free v1 reader is a fail-closed compatibility lane; a live v1
+transaction must terminate before upgrade and v2 never converts or dual-writes
+it. Before downgrade, both the v2 locator and locator-free v2 journal residue
+must be absent; v2 config history separately requires its complete directory
+to be moved aside.

--- a/docs/adr/0121-config-history-external-policy-provenance.md
+++ b/docs/adr/0121-config-history-external-policy-provenance.md
@@ -417,10 +417,11 @@ The locator, journal, and their stages are regular files owned by the daemon
 uid and mode `0600` from their first byte. For a writer or any present v2
 object, their real parent directories are pinned by descriptor, owned by that
 uid, and neither group- nor world-writable. Establishing locator absence alone
-allows a differently owned parent only when it is neither group- nor
-world-writable; this preserves the packaged root-owned, read-only config
-directory without allowing a v2 writer there. Reads and cleanup are
-descriptor-relative with `O_NOFOLLOW`:
+pins the real parent descriptor but applies no v2 ownership or mode policy:
+absence carries no authority, so ordinary pre-v2 launch paths remain valid.
+Any present locator immediately enters the full private-parent checks, and a
+writer cannot publish there unless the parent meets that contract. Reads and
+cleanup are descriptor-relative with `O_NOFOLLOW`:
 open once, `fstat`, bound, and read through that same descriptor. No check may
 be followed by a path reopen. The lexical config parent and journal parent may
 differ, so each has its own pinned descriptor and durability sync.

--- a/docs/adr/0121-config-history-external-policy-provenance.md
+++ b/docs/adr/0121-config-history-external-policy-provenance.md
@@ -1,7 +1,7 @@
 # ADR-0121: Config-history external-policy provenance
 
-**Status:** Accepted, partially implemented
-**Implementation:** v2 history restore shipped; commit-confirm v2 designed, implementation pending
+**Status:** Accepted, implemented
+**Implementation:** v2 history restore and provenance-bearing commit-confirm v2 shipped
 **Date:** 2026-08-01
 
 ## Context
@@ -414,9 +414,13 @@ lexical `CONFIG_PATH` is unsupported. The two digests must equal the journal's
 embedded prior state before any prior-source load.
 
 The locator, journal, and their stages are regular files owned by the daemon
-uid and mode `0600` from their first byte. Their real parent directories are
-pinned by descriptor, owned by that uid, and neither group- nor
-world-writable. Reads and cleanup are descriptor-relative with `O_NOFOLLOW`:
+uid and mode `0600` from their first byte. For a writer or any present v2
+object, their real parent directories are pinned by descriptor, owned by that
+uid, and neither group- nor world-writable. Establishing locator absence alone
+allows a differently owned parent only when it is neither group- nor
+world-writable; this preserves the packaged root-owned, read-only config
+directory without allowing a v2 writer there. Reads and cleanup are
+descriptor-relative with `O_NOFOLLOW`:
 open once, `fstat`, bound, and read through that same descriptor. No check may
 be followed by a path reopen. The lexical config parent and journal parent may
 differ, so each has its own pinned descriptor and durability sync.
@@ -428,8 +432,9 @@ neither cross-directory staging nor an alternate suffix is recognized.
 #### Writer admissibility and crash order
 
 A confirmed writer may start only while it still owns the stable lexical launch
-identity, both pinned directories pass the checks above, and the final locator
-is absent. Exact owned regular `0600` staging or journal residue may be removed
+identity, the locator, journal, and resolved config-target parents pass the full
+owner-private checks above, and the final locator is absent. Exact owned regular
+`0600` staging or journal residue may be removed
 and its directory synced before proceeding; an unsafe, ambiguous, differently
 owned, non-regular, noncanonical, or unremovable residue refuses the apply.
 Cleanup may touch only the exact journal and locator final basenames and the two
@@ -468,11 +473,13 @@ locator is absent.
 An invalid, unsafe, oversized, mismatched, or unreadable locator occupies the
 `present` rows and fails closed; it never falls back to v1. A valid locator
 whose journal path, `confirm_id`, digests, config target, or journal contents do
-not match also touches neither candidate nor pending files. V1 discovery keeps
-its existing 10 MiB preparse cap and exact format, and a v1 prior containing
-external inputs remains refused. A v2 journal without a locator is never boot
-revert authority. It is either prepublication residue or residue after the
-locator's terminal removal. An exact canonical, owned, regular `0600` journal
+not match does not open candidate contents or mutate candidate, backup, or
+pending files; launch-target metadata may already have been inspected to bind
+authority. V1 discovery keeps its existing 10 MiB preparse cap and exact format,
+and a v1 prior containing external inputs remains refused. A v2 journal without
+a locator is never boot revert authority. It is either prepublication residue
+or residue after the locator's terminal removal. An exact canonical, owned,
+regular `0600` journal
 may be removed and its directory synced before boot proceeds; unsafe,
 malformed, or unremovable residue refuses boot. Locator-absent plus
 journal-present never reconstructs or re-arms pending state.
@@ -511,9 +518,11 @@ redacted path **roles**, never values. No API, log, or normal CLI output renders
 startup diagnostic may name only the deterministic locator path derived from
 the launch argument. Digests and prior source paths are never logged.
 
-Writable downgrade remains unsupported: old binaries do not understand the
-locator or v2 journal. Re-upgrade accepts only the exact states above; it never
-blesses or migrates a residue produced by a downgrade. A live v1 pending
+Writable downgrade remains unsupported until both the locator and locator-free
+v2 journal residue are absent: old binaries do not understand either format.
+This pending-state rule is separate from the v2 history-directory move-aside
+rule below. Re-upgrade accepts only the exact states above; it never blesses or
+migrates a residue produced by a downgrade. A live v1 pending
 transaction must be confirmed, aborted, timed out, or boot-reverted before an
 upgrade. Rewriting it out of band is unsupported; v2 never converts a live v1
 journal and never dual-writes v1 plus v2 pending state.
@@ -553,9 +562,10 @@ candidate. There is no in-place migration or automatic deletion.
   object rather than reparse TOML at each layer.
 - Host paths are retained as sensitive local state, increasing the importance
   of owner-only storage and bounded, non-following reads.
-- V2 commit-confirm boot authority no longer depends on parsing the
-  unconfirmed candidate, but it adds one config-adjacent owner-only locator and
-  makes writable downgrade across that locator unsupported.
+- V2 commit-confirm boot authority no longer depends on parsing unconfirmed
+  candidate contents, but it adds one config-adjacent owner-only locator and
+  makes writable downgrade unsupported until both the locator and locator-free
+  v2 journal residue are absent.
 
 ## Rejected alternatives
 
@@ -673,10 +683,15 @@ identity contract.
 ## Current validation gate
 
 V2 recording, immutable accepted-source capture, mixed listing, additive API
-status/digests, filesystem hardening, and verified v2 history restore are
-shipped with executable destructive proofs. Provenance-bearing commit-confirm
-v2 remains implementation-pending; its locator, journal, state-machine, and
-cleanup proofs above are the implementation gate. Documentation-only design
-changes have no executable red proof.
+status/digests, filesystem hardening, verified v2 history restore, and
+provenance-bearing commit-confirm v2 are shipped with executable destructive
+proofs. The production writer emits only v2 pending state. Locator-free v1
+state remains a fail-closed compatibility lane; a live v1 transaction must
+terminate before upgrade, and v2 never converts or dual-writes it. The
+locator/journal publication order, exact caps and canonical
+encoding, descriptor-relative filesystem checks, six-state boot matrix,
+same-object live rollback, boot-before-candidate restore, terminal locator
+ordering, and post-terminal warning-only residue cleanup remain regression
+gates. Documentation-only design changes have no executable red proof.
 Documentation consistency, source-contract review, link and terminology
 checks, and `git diff --check` remain part of every tranche.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -823,9 +823,9 @@ processes is unsupported even when their configuration files differ.
 
 The lexical config and journal paths are resolved to absolute identities. A
 writer or present v2 object requires daemon-owned real parents that are not
-group- or world-writable. Locator absence may be established in the packaged
-root-owned, read-only config parent, so ordinary SIGHUP-only startup is
-unchanged; confirmed writes still require the documented ownership change.
+group- or world-writable. Locator absence carries no authority and therefore
+adds no v2 ownership or mode requirement to ordinary startup; confirmed writes
+still require the documented ownership change.
 Locator, journal, and exact staging files must be daemon-owned regular files
 with mode `0600`; symlinks and special files fail closed. Do not downgrade or start an
 older binary until both the v2 locator and locator-free v2 journal residue are

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -803,20 +803,36 @@ a field rename, edit the config file by hand.
 
 ### Persistent state on disk
 
-Everything in `runtime_state_dir` (default `/var/lib/rustbgpd`):
+Runtime state lives in `runtime_state_dir` (default `/var/lib/rustbgpd`). One
+commit-confirm v2 authority file instead lives beside the lexical launch config
+so startup can find it before trusting the unconfirmed candidate:
 
 Assign a distinct `runtime_state_dir` to every concurrently running rustbgpd
 daemon. The directory is single-writer runtime state; sharing it between live
 processes is unsupported even when their configuration files differ.
 
-| File | Purpose | Survives restart |
+| Path | Purpose | Survives restart |
 |---|---|---|
 | `gr-restart.toml` | Graceful Restart coordination marker. Written on clean shutdown, read on startup to set the R-bit in OPEN. | Yes |
 | `warm-bundle-v1/` | Optional owner-private shutdown checkpoint (`manifest.json` plus a content-addressed MRT artifact). Published only when `warm_cache_checkpoint_on_shutdown = true`; not restored on startup. | Yes |
-| `commit-confirm-journal.json` | Owner-private pre-transaction config snapshot for crash-safe confirmed commits; consumed by confirm/abort/timeout or boot revert. | Until the transaction is terminal |
+| `<absolute lexical config path>.commit-confirm-locator.json` | Sole v2 pending authority, published only after the journal is durable and checked before candidate contents are parsed. Launch-target metadata may be inspected while binding authority. Durable removal is the terminal point. | Until the transaction is terminal |
+| `<runtime_state_dir>/commit-confirm-journal.json` | Owner-private accepted prior snapshot: normalized TOML, external-source manifest, and digests. Exact residue cleanup after terminal locator removal is warning-only. | Until terminal cleanup; safe residue may remain |
 | `config-history/*` | Last 20 owner-private, secret-bearing legacy TOML and v2 JSON records for `rbgp config history`; newest is index 0. V2 records hash but do not archive external sources and are rollback-eligible only when live sources exactly reproduce recorded provenance. Move this directory aside before downgrading to a version without v2 support. | Yes |
 | `fib-owned.json` | FIB ownership receipt — which kernel routes the daemon installed (ADR-0061). Used to drain orphan installs on next start. | Yes |
 | `grpc.sock` | gRPC UDS endpoint (if `[global.telemetry.grpc_uds]` configured). | Recreated on start |
+
+The lexical config and journal paths are resolved to absolute identities. A
+writer or present v2 object requires daemon-owned real parents that are not
+group- or world-writable. Locator absence may be established in the packaged
+root-owned, read-only config parent, so ordinary SIGHUP-only startup is
+unchanged; confirmed writes still require the documented ownership change.
+Locator, journal, and exact staging files must be daemon-owned regular files
+with mode `0600`; symlinks and special files fail closed. Do not downgrade or start an
+older binary until both the v2 locator and locator-free v2 journal residue are
+absent. Separately move the complete v2 config-history directory aside before
+the older binary starts. Production writes only v2 pending state; locator-free
+v1 journals remain a fail-closed compatibility lane, but a live v1 transaction
+must terminate before upgrade. V2 never converts or dual-writes it.
 
 Routing state is **not restored**. The optional shutdown checkpoint contains
 only eligible post-import-policy Adj-RIB-In views for future use; Loc-RIB,

--- a/src/config_history.rs
+++ b/src/config_history.rs
@@ -52,7 +52,7 @@ pub fn record_accepted(dir: &Path, snapshot: &AcceptedConfigSnapshot) -> io::Res
     v2::record_v2(dir, snapshot.normalized_toml(), stored_manifest(snapshot))
 }
 
-fn stored_manifest(snapshot: &AcceptedConfigSnapshot) -> v2::Manifest {
+pub(crate) fn stored_manifest(snapshot: &AcceptedConfigSnapshot) -> v2::Manifest {
     let manifest = snapshot.source_manifest();
     v2::Manifest {
         toml_sha256: manifest.toml_sha256,

--- a/src/config_history/v2.rs
+++ b/src/config_history/v2.rs
@@ -22,8 +22,8 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 const VERSION: u32 = 2;
-const MAX_ENVELOPE: usize = 32 * 1024 * 1024;
-const MAX_TOML: usize = 10 * 1024 * 1024;
+pub(crate) const MAX_ENVELOPE: usize = 32 * 1024 * 1024;
+pub(crate) const MAX_TOML: usize = 10 * 1024 * 1024;
 const MAX_MANIFEST: usize = 16 * 1024 * 1024;
 const MAX_UNITS: usize = 4096;
 const MAX_MODULES: usize = 64;
@@ -751,7 +751,7 @@ fn validate(envelope: &Envelope) -> io::Result<()> {
     Ok(())
 }
 
-fn validate_manifest(manifest: &Manifest) -> io::Result<()> {
+pub(crate) fn validate_manifest(manifest: &Manifest) -> io::Result<()> {
     if manifest.rpol_units.len() > MAX_UNITS {
         return Err(limit("RPOL units", MAX_UNITS));
     }
@@ -791,7 +791,7 @@ fn validate_manifest(manifest: &Manifest) -> io::Result<()> {
     Ok(())
 }
 
-fn manifest_source_sha256(manifest: &Manifest) -> [u8; 32] {
+pub(crate) fn manifest_source_sha256(manifest: &Manifest) -> [u8; 32] {
     let mut digest = Sha256::new();
     digest.update(SOURCE_DIGEST_DOMAIN);
     frame(&mut digest, &manifest.toml_sha256);

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -58,9 +58,10 @@ pub struct ConfigTransactionController {
     state: Arc<Mutex<ConfirmedState>>,
     accepted_rx: Option<watch::Receiver<Arc<AcceptedConfigSnapshot>>>,
     peer_mgr_internal_tx: Option<mpsc::UnboundedSender<InternalCommand>>,
+    confirm_v2_launch: Option<crate::confirm_journal::v2::LaunchIdentity>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 struct ConfirmedState {
     applying_confirm_id: Option<String>,
     pending: Option<PendingConfirmedTransaction>,
@@ -77,7 +78,7 @@ struct ConfirmedState {
     ambiguous_failure_confirm_id: Option<String>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 struct PendingConfirmedTransaction {
     confirm_id: String,
     rollback_toml: String,
@@ -93,6 +94,13 @@ struct PendingConfirmedTransaction {
     /// not repair; the operator resolves it by retrying abort, confirming the
     /// candidate, or restarting (boot revert from the retained journal).
     rollback_failed: Option<proto::ConfigTransactionConfirmationStatus>,
+    /// The exact immutable pre-transaction object encoded in the v2 journal
+    /// and reused by live abort/timeout planning.  `None` is test-only legacy
+    /// v1 coverage.
+    prior_snapshot: Option<Arc<AcceptedConfigSnapshot>>,
+    /// Pinned locator/journal descriptors retained through the live pending
+    /// lifecycle.  The locator is the terminal authority.
+    v2_files: Option<Arc<crate::confirm_journal::v2::PendingFiles>>,
 }
 
 #[derive(Clone, Debug)]
@@ -122,6 +130,7 @@ impl ConfigTransactionController {
             state: Arc::new(Mutex::new(ConfirmedState::default())),
             accepted_rx: None,
             peer_mgr_internal_tx: None,
+            confirm_v2_launch: None,
         }
     }
 
@@ -137,6 +146,7 @@ impl ConfigTransactionController {
             state: Arc::new(Mutex::new(ConfirmedState::default())),
             accepted_rx: Some(accepted_rx),
             peer_mgr_internal_tx: None,
+            confirm_v2_launch: None,
         }
     }
 
@@ -146,6 +156,15 @@ impl ConfigTransactionController {
         tx: mpsc::UnboundedSender<InternalCommand>,
     ) -> Self {
         self.peer_mgr_internal_tx = Some(tx);
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_confirm_v2_launch(
+        mut self,
+        launch: crate::confirm_journal::v2::LaunchIdentity,
+    ) -> Self {
+        self.confirm_v2_launch = Some(launch);
         self
     }
 
@@ -231,8 +250,10 @@ impl ConfigTransactionController {
                     if request.confirm_timeout_seconds > 0 {
                         validate_confirm_timeout_seconds(request.confirm_timeout_seconds)?;
                     }
-                    self.reject_confirmed_external_sources(&normalized_toml)
-                        .await?;
+                    if self.confirm_v2_launch.is_none() {
+                        self.reject_confirmed_external_sources(&normalized_toml)
+                            .await?;
+                    }
                 }
                 let accepted = self.accepted_rx.as_ref().ok_or_else(|| {
                     ConfigTransactionApplyError::Unavailable(
@@ -290,7 +311,7 @@ impl ConfigTransactionController {
     ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
         let confirmed = parse_confirmed_apply_mode(&request)?;
         if let Some(confirmed) = confirmed {
-            if preloaded.is_none() {
+            if preloaded.is_none() && self.confirm_v2_launch.is_none() {
                 self.reject_confirmed_external_sources(&request.candidate_toml)
                     .await?;
             }
@@ -328,6 +349,25 @@ impl ConfigTransactionController {
         };
         let accepted = accepted_rx.borrow().clone();
         transaction_config_snapshot_accepted(&self.deps.peer_mgr_tx, &accepted).await
+    }
+
+    async fn accepted_prior_snapshot(&self) -> Result<Arc<AcceptedConfigSnapshot>, String> {
+        if let Some(accepted_rx) = &self.accepted_rx {
+            // Bind provenance before awaiting the peer-manager snapshot.  A
+            // concurrent SIGHUP may advance the watch channel while that reply
+            // is in flight; re-borrowing afterwards could otherwise relabel an
+            // older runtime config with a newer external-source manifest.
+            let accepted = accepted_rx.borrow().clone();
+            let runtime =
+                transaction_config_snapshot_accepted(&self.deps.peer_mgr_tx, &accepted).await?;
+            return accepted.derive_config(runtime);
+        }
+        #[cfg(test)]
+        return Ok(AcceptedConfigSnapshot::from_config_for_test(
+            self.accepted_runtime_snapshot().await?,
+        ));
+        #[cfg(not(test))]
+        Err("accepted-config authority unavailable".to_string())
     }
 
     #[must_use]
@@ -491,9 +531,11 @@ impl ConfigTransactionController {
                     // A confirmed gNMI candidate is derived from the live
                     // config. Fence external declarations before that
                     // construction can consult any rpol or dataset path.
-                    self.reject_confirmed_current_external_sources()
-                        .await
-                        .map_err(apply_error_to_gnmi_set_error)?;
+                    if self.confirm_v2_launch.is_none() {
+                        self.reject_confirmed_current_external_sources()
+                            .await
+                            .map_err(apply_error_to_gnmi_set_error)?;
+                    }
                 }
                 None => {
                     self.reject_if_pending("gnmi.gNMI/Set")
@@ -560,8 +602,10 @@ impl ConfigTransactionController {
         confirmed: Option<ConfirmedApplyMode>,
     ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
         if let Some(confirmed) = confirmed {
-            self.reject_confirmed_external_sources(&request.candidate_toml)
-                .await?;
+            if self.confirm_v2_launch.is_none() {
+                self.reject_confirmed_external_sources(&request.candidate_toml)
+                    .await?;
+            }
             self.begin_confirmed_apply(&confirmed.confirm_id).await?;
             let result = self
                 .apply_confirmed_locked(request, confirmed.clone(), None)
@@ -585,6 +629,10 @@ impl ConfigTransactionController {
         }
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "confirmed apply keeps one auditable publication-to-pending-state sequence"
+    )]
     async fn apply_confirmed_locked(
         &self,
         request: proto::ApplyConfigTransactionRequest,
@@ -594,19 +642,15 @@ impl ConfigTransactionController {
             Arc<AcceptedConfigSnapshot>,
         )>,
     ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
-        let rollback_config = self
-            .accepted_runtime_snapshot()
+        let prior_snapshot = self
+            .accepted_prior_snapshot()
             .await
             .map_err(ConfigTransactionApplyError::Unavailable)?;
-        // Rendered as a persisted document, not a bare snapshot: the boot-time
-        // revert writes these bytes straight back over the operator's config
-        // file, so they have to be a file the daemon would have written.
-        let rollback_toml =
-            crate::config::persisted_config_document(&rollback_config).map_err(|error| {
-                ConfigTransactionApplyError::Internal(format!(
-                    "failed to serialize confirmed transaction rollback snapshot: {error}"
-                ))
-            })?;
+        let rollback_config = prior_snapshot.config();
+        // The immutable accepted snapshot owns the exact normalized bytes and
+        // source manifest used by both the journal and live rollback.  Never
+        // rerender or reconstruct provenance after this point.
+        let rollback_toml = prior_snapshot.normalized_toml().to_string();
 
         // ADR-0113: a confirmed transaction may TIGHTEN an outbound prefix
         // maximum, because its automatic undo only loosens and a loosening is
@@ -636,7 +680,28 @@ impl ConfigTransactionController {
         // inside the confirm window is repaired by the boot-time revert. If
         // the journal cannot be written, refuse the confirmed apply up front
         // (nothing has committed yet) rather than run an unprotected window.
-        if let Some(journal_path) = &self.deps.confirm_journal_path {
+        let v2_files = if let Some(launch) = &self.confirm_v2_launch {
+            let journal_path = self.deps.confirm_journal_path.as_ref().ok_or_else(|| {
+                ConfigTransactionApplyError::Internal(
+                    "refusing confirmed apply: v2 journal storage is unavailable".to_string(),
+                )
+            })?;
+            Some(Arc::new(
+                launch
+                    .publish(
+                        journal_path,
+                        &confirmed.confirm_id,
+                        deadline_unix_seconds,
+                        &prior_snapshot,
+                    )
+                    .map_err(|error| {
+                        ConfigTransactionApplyError::Internal(format!(
+                            "refusing confirmed apply: v2 pending authority publication failed ({:?}); inspect owner-only pending storage",
+                            error.kind()
+                        ))
+                    })?,
+            ))
+        } else if let Some(journal_path) = &self.deps.confirm_journal_path {
             crate::confirm_journal::write(
                 journal_path,
                 &crate::confirm_journal::ConfirmJournal {
@@ -652,7 +717,10 @@ impl ConfigTransactionController {
                     journal_path.display()
                 ))
             })?;
-        }
+            None
+        } else {
+            None
+        };
 
         let mut response = match apply_config_transaction_locked_with_preloaded(
             &self.deps, request, preloaded,
@@ -686,12 +754,22 @@ impl ConfigTransactionController {
                 // Provably nothing committed — a stale journal would only
                 // trigger a harmless same-content boot revert, but clean it
                 // up anyway.
-                self.remove_confirm_journal_best_effort("confirmed apply failed");
+                self.cleanup_uncommitted_authority(
+                    &confirmed.confirm_id,
+                    v2_files.as_deref(),
+                    "confirmed apply failed",
+                )
+                .await?;
                 return Err(failure.error);
             }
         };
         if response.status != proto::ConfigTransactionPlanStatus::Committable as i32 {
-            self.remove_confirm_journal_best_effort("confirmed apply did not commit");
+            self.cleanup_uncommitted_authority(
+                &confirmed.confirm_id,
+                v2_files.as_deref(),
+                "confirmed apply did not commit",
+            )
+            .await?;
             return Ok(response);
         }
 
@@ -706,6 +784,8 @@ impl ConfigTransactionController {
             committed_sections: response.committed_sections.clone(),
             runtime_snapshot_token: response.runtime_snapshot_token.clone(),
             rollback_failed: None,
+            prior_snapshot: self.confirm_v2_launch.as_ref().map(|_| prior_snapshot),
+            v2_files,
         };
         let confirmation = pending_confirmation_proto(
             &pending,
@@ -791,8 +871,20 @@ impl ConfigTransactionController {
         // state: if deletion fails the confirm must fail while the fence and
         // timer stay armed — a leftover journal would boot-revert a config
         // the operator explicitly confirmed.
-        let _ = self.matching_pending(&confirm_id).await?;
-        if let Some(journal_path) = &self.deps.confirm_journal_path {
+        let matched = self.matching_pending(&confirm_id).await?;
+        if let Some(files) = &matched.v2_files {
+            let journal_cleanup_failed = files.terminal_cleanup().map_err(|error| {
+                ConfigTransactionApplyError::Internal(format!(
+                    "confirm not recorded: durable v2 locator removal failed ({:?}); the transaction is still pending and will roll back on timeout",
+                    error.kind()
+                ))
+            })?;
+            if journal_cleanup_failed {
+                warn!(
+                    "confirmed transaction is terminal, but exact v2 journal residue cleanup failed"
+                );
+            }
+        } else if let Some(journal_path) = &self.deps.confirm_journal_path {
             crate::confirm_journal::remove(journal_path).map_err(|error| {
                 ConfigTransactionApplyError::Internal(format!(
                     "confirm not recorded: failed to remove the commit-confirm revert journal {}: {error}; \
@@ -851,7 +943,7 @@ impl ConfigTransactionController {
                         "Aborted confirmed config transaction and restored the previous runtime config.",
                         true,
                     )
-                    .await;
+                    .await?;
                 self.metrics
                     .record_config_transaction_lifecycle("abort", "success");
                 Ok(proto::AbortConfigTransactionResponse {
@@ -1258,7 +1350,7 @@ impl ConfigTransactionController {
                         "Confirmed config transaction timed out and was automatically rolled back.",
                         false,
                     )
-                    .await;
+                    .await?;
                     self.metrics
                         .record_config_transaction_lifecycle("auto_revert", "success");
                     info!(confirm_id, "confirmed config transaction auto-reverted");
@@ -1345,23 +1437,36 @@ impl ConfigTransactionController {
         &self,
         pending: &PendingConfirmedTransaction,
     ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
-        let response = apply_config_transaction_locked(
-            &self.deps,
-            proto::ApplyConfigTransactionRequest {
-                candidate_toml: pending.rollback_toml.clone(),
-                expected_runtime_snapshot_token: pending
-                    .rollback_expected_runtime_snapshot_token
-                    .clone(),
-                client_request_id: format!("confirmed-rollback:{}", pending.confirm_id),
-                comment: "confirmed transaction rollback".to_string(),
-                confirm_id: String::new(),
-                confirm_timeout_seconds: 0,
-            },
-        )
-        .await
-        // A failed rollback keeps the transaction pending with the journal
-        // retained regardless of ambiguity, so the flag adds nothing here.
-        .map_err(|failure| failure.error)?;
+        let request = proto::ApplyConfigTransactionRequest {
+            candidate_toml: pending.rollback_toml.clone(),
+            expected_runtime_snapshot_token: pending
+                .rollback_expected_runtime_snapshot_token
+                .clone(),
+            client_request_id: format!("confirmed-rollback:{}", pending.confirm_id),
+            comment: "confirmed transaction rollback".to_string(),
+            confirm_id: String::new(),
+            confirm_timeout_seconds: 0,
+        };
+        let result = if let Some(prior) = &pending.prior_snapshot {
+            let plan = self
+                .plan_preloaded_snapshot(
+                    prior.clone(),
+                    pending.rollback_expected_runtime_snapshot_token.clone(),
+                )
+                .await?;
+            apply_config_transaction_locked_with_preloaded(
+                &self.deps,
+                request,
+                Some((plan, prior.clone())),
+            )
+            .await
+        } else {
+            apply_config_transaction_locked(&self.deps, request).await
+        };
+        let response = result
+            // A failed rollback keeps the transaction pending with the journal
+            // retained regardless of ambiguity, so the flag adds nothing here.
+            .map_err(|failure| failure.error)?;
         // A rollback whose re-apply plan did not commit leaves the
         // aborted/expired candidate running — that is a rollback failure,
         // not a success, and the caller must record AbortFailed /
@@ -1405,6 +1510,37 @@ impl ConfigTransactionController {
         }
     }
 
+    async fn cleanup_uncommitted_authority(
+        &self,
+        confirm_id: &str,
+        v2_files: Option<&crate::confirm_journal::v2::PendingFiles>,
+        context: &'static str,
+    ) -> Result<(), ConfigTransactionApplyError> {
+        let Some(files) = v2_files else {
+            self.remove_confirm_journal_best_effort(context);
+            return Ok(());
+        };
+        match files.terminal_cleanup() {
+            Ok(journal_cleanup_failed) => {
+                if journal_cleanup_failed {
+                    warn!(
+                        context,
+                        "v2 commit-confirm locator is durably absent, but exact journal residue cleanup failed"
+                    );
+                }
+                Ok(())
+            }
+            Err(error) => {
+                let mut state = self.state.lock().await;
+                state.ambiguous_failure_confirm_id = Some(confirm_id.to_string());
+                Err(ConfigTransactionApplyError::Internal(format!(
+                    "v2 commit-confirm operation is nonterminal because durable locator removal failed ({:?}); config mutations remain blocked",
+                    error.kind()
+                )))
+            }
+        }
+    }
+
     /// Consume the pending transaction after a SUCCESSFUL abort/auto-revert
     /// rollback. The rollback re-persisted the pre-transaction config, so the
     /// journal is consumed. A FAILED rollback never reaches here — it keeps
@@ -1417,15 +1553,28 @@ impl ConfigTransactionController {
         runtime_snapshot_token: String,
         human_text: &'static str,
         abort_timer: bool,
-    ) {
-        self.remove_confirm_journal_best_effort("post-rollback cleanup");
+    ) -> Result<(), ConfigTransactionApplyError> {
+        let matched = self.matching_pending(confirm_id).await?;
+        if let Some(files) = &matched.v2_files {
+            let journal_cleanup_failed = files.terminal_cleanup().map_err(|error| {
+                ConfigTransactionApplyError::Internal(format!(
+                    "rollback restored the prior config but remains nonterminal because durable v2 locator removal failed ({:?})",
+                    error.kind()
+                ))
+            })?;
+            if journal_cleanup_failed {
+                warn!("rollback is terminal, but exact v2 journal residue cleanup failed");
+            }
+        } else {
+            self.remove_confirm_journal_best_effort("post-rollback cleanup");
+        }
         let mut state = self.state.lock().await;
         let Some(pending) = state.pending.take() else {
-            return;
+            return Ok(());
         };
         if pending.confirm_id != confirm_id {
             state.pending = Some(pending);
-            return;
+            return Ok(());
         }
         let timer = state.timer.take();
         if abort_timer && let Some(timer) = timer {
@@ -1440,6 +1589,7 @@ impl ConfigTransactionController {
             runtime_snapshot_token,
             human_text: human_text.to_string(),
         });
+        Ok(())
     }
 
     /// LAN-277: record a FAILED abort/auto-revert rollback on the still-pending
@@ -1463,7 +1613,14 @@ impl ConfigTransactionController {
             // generic never-confirmed message. Best-effort: the journal
             // (with the proven rollback snapshot) is already on disk, and
             // failing to annotate it must not mask the rollback failure.
-            if let Some(journal_path) = &self.deps.confirm_journal_path
+            if let Some(files) = &pending.v2_files {
+                if let Err(error) = files.record_rollback_failed() {
+                    warn!(
+                        error_kind = ?error.kind(),
+                        "failed to record rollback failure in the v2 commit-confirm journal"
+                    );
+                }
+            } else if let Some(journal_path) = &self.deps.confirm_journal_path
                 && let Err(error) = crate::confirm_journal::write(
                     journal_path,
                     &crate::confirm_journal::ConfirmJournal {
@@ -3328,7 +3485,12 @@ remote_asn = 65002
         assert_eq!(
             production.matches(".accepted_runtime_snapshot()").count(),
             2,
-            "gNMI Set and confirmed rollback must independently use accepted authority"
+            "gNMI Set construction plus the test-only authority fallback use the accepted helper"
+        );
+        assert_eq!(
+            production.matches(".accepted_prior_snapshot()").count(),
+            1,
+            "confirmed rollback must bind one accepted provenance generation"
         );
         assert!(!production.contains("use crate::reload::runtime_config_snapshot;"));
 
@@ -3439,6 +3601,60 @@ remote_asn = 65002
             assert!(snapshot.policy.rpol.policies.is_empty());
         }
         assert!(Arc::strong_count(&desired_handle) >= 1);
+    }
+
+    #[tokio::test]
+    async fn accepted_prior_snapshot_keeps_one_provenance_generation_across_await() {
+        // Destructive proof: borrowing accepted_rx after the peer-manager await
+        // labels the old runtime config with the replacement source manifest
+        // sent while the reply is in flight, changing source_sha256 below.
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("policy.rpol");
+        let config_path = dir.path().join("rustbgpd.toml");
+        std::fs::write(&source, "policy p { term rest { accept } }\n").unwrap();
+        std::fs::write(
+            &config_path,
+            base_toml(&format!(
+                "[policy]\nrpol_files = [{:?}]\n",
+                source.display().to_string()
+            )),
+        )
+        .unwrap();
+        let prior = Arc::new(AcceptedConfigSnapshot::load(&config_path, None).unwrap());
+        std::fs::write(&source, "policy p { term rest { reject } }\n").unwrap();
+        let replacement = Arc::new(AcceptedConfigSnapshot::load(&config_path, None).unwrap());
+        assert_ne!(prior.source_sha256(), replacement.source_sha256());
+
+        let runtime_toml = prior.normalized_toml().to_string();
+        let runtime_rpol_files = prior.config_ref().policy.rpol_files.clone();
+        let runtime_rpol = prior.config_ref().policy.rpol.clone();
+        let prior_source_sha256 = prior.source_sha256();
+        let replacement_source_sha256 = replacement.source_sha256();
+        let (accepted_tx, accepted_rx) = watch::channel(prior);
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            let Some(PeerManagerCommand::RuntimeConfigSnapshot { reply }) = peer_rx.recv().await
+            else {
+                panic!("accepted prior helper must request the runtime snapshot");
+            };
+            accepted_tx.send(replacement).unwrap();
+            reply
+                .send(Ok(rustbgpd_api::peer_types::RuntimeConfigSnapshotReply {
+                    toml: runtime_toml,
+                    rpol_files: runtime_rpol_files,
+                    rpol: runtime_rpol,
+                }))
+                .unwrap();
+        });
+        let controller = ConfigTransactionController::new_accepted(
+            deps_value(None, peer_tx, None, Vec::new()),
+            BgpMetrics::new(),
+            accepted_rx,
+        );
+
+        let snapshot = controller.accepted_prior_snapshot().await.unwrap();
+        assert_eq!(snapshot.source_sha256(), prior_source_sha256);
+        assert_ne!(snapshot.source_sha256(), replacement_source_sha256);
     }
 
     fn config_transaction_lifecycle_metric(
@@ -4853,6 +5069,431 @@ remote_asn = 65010
     fn read_journal(path: &std::path::Path) -> crate::confirm_journal::ConfirmJournal {
         serde_json::from_str(&std::fs::read_to_string(path).expect("journal must be readable"))
             .expect("journal must parse")
+    }
+
+    struct V2FibHarness {
+        _root: tempfile::TempDir,
+        controller: ConfigTransactionController,
+        source: std::path::PathBuf,
+        journal: std::path::PathBuf,
+        locator: std::path::PathBuf,
+        fib_state: Arc<Mutex<Vec<FibTableConfig>>>,
+        seen_preloaded: Arc<Mutex<Option<Arc<AcceptedConfigSnapshot>>>>,
+        ack_task: tokio::task::JoinHandle<()>,
+    }
+
+    struct V2ExternalFenceHarness {
+        _root: tempfile::TempDir,
+        controller: ConfigTransactionController,
+        current_toml: String,
+        journal: std::path::PathBuf,
+        locator: std::path::PathBuf,
+    }
+
+    fn v2_external_fence_harness(status: RuntimeConfigTransactionStatus) -> V2ExternalFenceHarness {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = tempfile::tempdir().unwrap();
+        let config_dir = root.path().join("config");
+        let state_dir = root.path().join("state");
+        std::fs::create_dir(&config_dir).unwrap();
+        std::fs::create_dir(&state_dir).unwrap();
+        std::fs::set_permissions(&config_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let source = config_dir.join("policy.rpol");
+        std::fs::write(&source, "policy p { term rest { accept } }\n").unwrap();
+        let config_path = config_dir.join("rustbgpd.toml");
+        std::fs::write(
+            &config_path,
+            base_toml(&format!(
+                "[policy]\nrpol_files = [{:?}]\n",
+                source.display().to_string()
+            )),
+        )
+        .unwrap();
+        let accepted = Arc::new(AcceptedConfigSnapshot::load(&config_path, None).unwrap());
+        let current_toml = accepted.normalized_toml().to_string();
+        let runtime_rpol_files = accepted.config_ref().policy.rpol_files.clone();
+        let runtime_rpol = accepted.config_ref().policy.rpol.clone();
+        let (_accepted_tx, accepted_rx) = watch::channel(accepted);
+        let mut plan = plan(status, vec!["[[neighbors]] modify".to_string()]);
+        if status == RuntimeConfigTransactionStatus::Rejected {
+            plan.unsupported_sections = vec!["[policy] external inputs".to_string()];
+        }
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
+        let runtime_toml = current_toml.clone();
+        tokio::spawn(async move {
+            while let Some(command) = peer_rx.recv().await {
+                match command {
+                    PeerManagerCommand::RuntimeConfigSnapshot { reply } => {
+                        let _ =
+                            reply.send(Ok(rustbgpd_api::peer_types::RuntimeConfigSnapshotReply {
+                                toml: runtime_toml.clone(),
+                                rpol_files: runtime_rpol_files.clone(),
+                                rpol: runtime_rpol.clone(),
+                            }));
+                    }
+                    PeerManagerCommand::PlanConfigTransaction { reply, .. } => {
+                        let _ = reply.send(Ok(plan.clone()));
+                    }
+                    _ => panic!("unexpected peer-manager command in v2 external fence harness"),
+                }
+            }
+        });
+        let journal = state_dir.join(crate::confirm_journal::JOURNAL_FILE_NAME);
+        let launch = crate::confirm_journal::v2::LaunchIdentity::resolve(&config_path).unwrap();
+        let locator = launch.locator_path();
+        let controller = ConfigTransactionController::new_accepted(
+            FibTableControlDeps {
+                confirm_journal_path: Some(journal.clone()),
+                ..deps_value(None, peer_tx, None, Vec::new())
+            },
+            BgpMetrics::new(),
+            accepted_rx,
+        )
+        .with_confirm_v2_launch(launch);
+        V2ExternalFenceHarness {
+            _root: root,
+            controller,
+            current_toml,
+            journal,
+            locator,
+        }
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the focused harness keeps one complete external-source FIB transaction fixture"
+    )]
+    async fn v2_external_fib_harness(timeout_seconds: u32) -> V2FibHarness {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = tempfile::tempdir().unwrap();
+        let config_dir = root.path().join("config");
+        let state_dir = root.path().join("state");
+        std::fs::create_dir(&config_dir).unwrap();
+        std::fs::create_dir(&state_dir).unwrap();
+        std::fs::set_permissions(&config_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let source = config_dir.join("policy.rpol");
+        std::fs::write(&source, "policy p { term rest { accept } }\n").unwrap();
+        let source_text = source.display();
+        let previous_toml = base_toml(&format!(
+            r#"
+[policy]
+rpol_files = ["{source_text}"]
+
+[[fib_tables]]
+name = "edge"
+table_id = 1000
+metric = 200
+families = ["ipv4_unicast"]
+"#
+        ));
+        let candidate_toml = base_toml(&format!(
+            r#"
+[policy]
+rpol_files = ["{source_text}"]
+
+[[fib_tables]]
+name = "core"
+table_id = 1001
+metric = 200
+families = ["ipv4_unicast"]
+"#
+        ));
+        let config_path = config_dir.join("rustbgpd.toml");
+        std::fs::write(&config_path, &previous_toml).unwrap();
+        let accepted = Arc::new(AcceptedConfigSnapshot::load(&config_path, None).unwrap());
+        let runtime_rpol_files = accepted.config_ref().policy.rpol_files.clone();
+        let (_accepted_tx, accepted_rx) = watch::channel(accepted);
+
+        let original = table("edge", 1000);
+        let replacement = table("core", 1001);
+        let fib_state = Arc::new(Mutex::new(vec![original.clone()]));
+        let (fib_tx, fib_rx) = mpsc::channel(8);
+        tokio::spawn(fake_fib_actor(fib_rx, fib_state.clone(), None));
+
+        let staged = Arc::new(Mutex::new(vec![snapshot(&original)]));
+        let (peer_tx, mut peer_rx) = mpsc::channel(16);
+        let runtime_toml = previous_toml.clone();
+        tokio::spawn(async move {
+            while let Some(command) = peer_rx.recv().await {
+                match command {
+                    PeerManagerCommand::RuntimeConfigSnapshot { reply } => {
+                        let _ =
+                            reply.send(Ok(rustbgpd_api::peer_types::RuntimeConfigSnapshotReply {
+                                toml: runtime_toml.clone(),
+                                rpol_files: runtime_rpol_files.clone(),
+                                rpol: rustbgpd_policy::rpol::RpolPolicySet::default(),
+                            }));
+                    }
+                    PeerManagerCommand::PlanConfigTransaction { reply, .. } => {
+                        let _ = reply.send(Ok(plan(
+                            RuntimeConfigTransactionStatus::Committable,
+                            vec!["[[fib_tables]]".to_string()],
+                        )));
+                    }
+                    PeerManagerCommand::StageFibTables { tables, reply } => {
+                        *staged.lock().await = tables;
+                        let _ = reply.send(Ok(()));
+                    }
+                    PeerManagerCommand::SetFibTablesSnapshot { tables, reply } => {
+                        *staged.lock().await = tables;
+                        let _ = reply.send(());
+                    }
+                    _ => panic!("unexpected peer-manager command in v2 FIB harness"),
+                }
+            }
+        });
+
+        let seen_preloaded = Arc::new(Mutex::new(None));
+        let seen = seen_preloaded.clone();
+        let (internal_tx, mut internal_rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            while let Some(command) = internal_rx.recv().await {
+                let InternalCommand::PlanAcceptedSnapshot {
+                    snapshot,
+                    expected_runtime_snapshot_token,
+                    reply,
+                } = command
+                else {
+                    panic!("unexpected private command in v2 FIB harness");
+                };
+                *seen.lock().await = Some(snapshot);
+                let mut response = plan(
+                    RuntimeConfigTransactionStatus::Committable,
+                    vec!["[[fib_tables]]".to_string()],
+                );
+                response.runtime_snapshot_token =
+                    expected_runtime_snapshot_token.unwrap_or_else(|| "kv1:new:2".to_string());
+                response.post_commit_runtime_snapshot_token = "kv1:rollback:3".to_string();
+                let _ = reply.send(Ok(response));
+            }
+        });
+
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        let ack_task = tokio::spawn(async move {
+            while let Some(event) = config_rx.recv().await {
+                match event {
+                    ConfigEvent::FibTablesReplaced { ack: Some(ack), .. }
+                    | ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. } => {
+                        ack.accept().await;
+                    }
+                    _ => panic!("unexpected persistence event in v2 FIB harness"),
+                }
+            }
+        });
+
+        let journal = state_dir.join(crate::confirm_journal::JOURNAL_FILE_NAME);
+        let launch = crate::confirm_journal::v2::LaunchIdentity::resolve(&config_path).unwrap();
+        let locator = launch.locator_path();
+        let controller = ConfigTransactionController::new_accepted(
+            FibTableControlDeps {
+                fib_cmd_tx: Some(fib_tx),
+                peer_mgr_tx: peer_tx,
+                rib_tx: None,
+                config_tx: Some(config_tx),
+                lock: Arc::new(Mutex::new(())),
+                config_mutation_gate: None,
+                startup_tables: vec![original],
+                confirm_journal_path: Some(journal.clone()),
+                config_history_dir: None,
+            },
+            BgpMetrics::new(),
+            accepted_rx,
+        )
+        .with_preloaded_planner(internal_tx)
+        .with_confirm_v2_launch(launch);
+        let response = controller
+            .clone()
+            .apply(confirmed_dynamic_request(
+                candidate_toml,
+                "external-fib",
+                timeout_seconds,
+            ))
+            .await
+            .expect("external pure-FIB confirmed apply must remain committable");
+        assert_eq!(
+            response.status,
+            proto::ConfigTransactionPlanStatus::Committable as i32
+        );
+        assert_eq!(*fib_state.lock().await, vec![replacement]);
+
+        V2FibHarness {
+            _root: root,
+            controller,
+            source,
+            journal,
+            locator,
+            fib_state,
+            seen_preloaded,
+            ack_task,
+        }
+    }
+
+    #[tokio::test]
+    async fn v2_external_fib_abort_reuses_exact_prior_and_is_terminal() {
+        // Destructive proof: restoring from rollback TOML instead of the
+        // retained Arc rereads the mutated rpol file and fails; dual-writing
+        // v1 changes the dispatch prefix; journal-first cleanup leaves the
+        // locator present at successful return.
+        let harness = v2_external_fib_harness(60).await;
+        assert!(
+            std::fs::read(&harness.journal)
+                .unwrap()
+                .starts_with(b"{\"version\":2,")
+        );
+        assert!(harness.locator.exists());
+        let prior = harness
+            .controller
+            .state
+            .lock()
+            .await
+            .pending
+            .as_ref()
+            .unwrap()
+            .prior_snapshot
+            .clone()
+            .unwrap();
+        std::fs::write(&harness.source, "policy p { term rest { reject } }\n").unwrap();
+        harness
+            .controller
+            .clone()
+            .abort(proto::AbortConfigTransactionRequest {
+                confirm_id: "external-fib".to_string(),
+            })
+            .await
+            .expect("live abort must reuse verified prior state without source reread");
+        let seen = harness.seen_preloaded.lock().await.clone().unwrap();
+        assert!(Arc::ptr_eq(&prior, &seen));
+        assert_eq!(*harness.fib_state.lock().await, vec![table("edge", 1000)]);
+        assert!(!harness.locator.exists());
+        assert!(!harness.journal.exists());
+        harness.ack_task.abort();
+    }
+
+    #[tokio::test]
+    async fn v2_activation_preserves_native_and_gnmi_full_snapshot_fence() {
+        // Destructive proof: bypassing the ordinary planner after v2 activation
+        // makes either full-snapshot request committable. Publishing after the
+        // verdict or skipping terminal cleanup leaves one of the two authority
+        // files behind after the planner's #1370 rejection.
+        let harness = v2_external_fence_harness(RuntimeConfigTransactionStatus::Rejected);
+        let mut candidate: Config = toml::from_str(&harness.current_toml).unwrap();
+        candidate.neighbors[0].description = Some("must remain fenced".to_string());
+        let response = harness
+            .controller
+            .clone()
+            .apply(confirmed_dynamic_request(
+                toml::to_string_pretty(&candidate).unwrap(),
+                "native-full-snapshot",
+                60,
+            ))
+            .await
+            .expect("#1370 refusal is a rejected plan");
+        assert_eq!(
+            response.status,
+            proto::ConfigTransactionPlanStatus::Rejected as i32
+        );
+        assert!(!harness.locator.exists());
+        assert!(!harness.journal.exists());
+
+        let Err(error) = harness
+            .controller
+            .clone()
+            .apply_gnmi_set(gnmi_set_add_neighbor_confirmed(
+                "10.0.0.3",
+                65003,
+                "gnmi-full-snapshot",
+                60,
+            ))
+            .await
+        else {
+            panic!("confirmed gNMI full-snapshot mutation remains fenced");
+        };
+        assert!(matches!(error, GnmiSetError::FailedPrecondition(_)));
+        assert!(!harness.locator.exists());
+        assert!(!harness.journal.exists());
+    }
+
+    #[tokio::test]
+    async fn v2_activation_preserves_external_true_noop_exception() {
+        // Destructive proof: restoring the pre-v2 declaration fence rejects
+        // this before planning; treating Noop as pending leaves authority or a
+        // confirmation window for a transaction that changed nothing.
+        let harness = v2_external_fence_harness(RuntimeConfigTransactionStatus::Noop);
+        let response = harness
+            .controller
+            .clone()
+            .apply(confirmed_dynamic_request(
+                harness.current_toml.clone(),
+                "external-noop",
+                60,
+            ))
+            .await
+            .expect("true no-op with unchanged external inputs remains allowed");
+        assert_eq!(
+            response.status,
+            proto::ConfigTransactionPlanStatus::Noop as i32
+        );
+        assert!(response.confirmation.is_none());
+        assert!(!harness.locator.exists());
+        assert!(!harness.journal.exists());
+        assert!(harness.controller.state.lock().await.pending.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn v2_external_fib_timeout_reuses_prior_after_source_mutation() {
+        // Destructive proof: removing the preloaded timeout lane or rebuilding
+        // provenance from current external bytes leaves the replacement table
+        // active and the locator armed after the timer fires.
+        let harness = v2_external_fib_harness(1).await;
+        let prior = harness
+            .controller
+            .state
+            .lock()
+            .await
+            .pending
+            .as_ref()
+            .unwrap()
+            .prior_snapshot
+            .clone()
+            .unwrap();
+        std::fs::write(&harness.source, "policy p { term rest { reject } }\n").unwrap();
+        tokio::time::sleep(Duration::from_millis(1_100)).await;
+        let status = harness.controller.status().await.unwrap();
+        assert_eq!(
+            status.confirmation.unwrap().status,
+            proto::ConfigTransactionConfirmationStatus::AutoReverted as i32
+        );
+        let seen = harness.seen_preloaded.lock().await.clone().unwrap();
+        assert!(Arc::ptr_eq(&prior, &seen));
+        assert_eq!(*harness.fib_state.lock().await, vec![table("edge", 1000)]);
+        assert!(!harness.locator.exists());
+        assert!(!harness.journal.exists());
+        harness.ack_task.abort();
+    }
+
+    #[tokio::test]
+    async fn v2_confirm_is_terminal_before_journal_cleanup() {
+        // Destructive proof: retaining v1's journal-as-authority rule or
+        // clearing in-memory pending state before locator durability leaves
+        // the locator present when the RPC reports permanent success.
+        let harness = v2_external_fib_harness(60).await;
+        harness
+            .controller
+            .clone()
+            .confirm(proto::ConfirmConfigTransactionRequest {
+                confirm_id: "external-fib".to_string(),
+            })
+            .await
+            .expect("confirm must durably remove v2 locator authority");
+        assert!(!harness.locator.exists());
+        assert!(!harness.journal.exists());
+        assert_eq!(*harness.fib_state.lock().await, vec![table("core", 1001)]);
+        harness.ack_task.abort();
     }
 
     #[tokio::test]

--- a/src/confirm_journal.rs
+++ b/src/confirm_journal.rs
@@ -18,6 +18,8 @@
 
 #![deny(unsafe_code)]
 
+pub(crate) mod v2;
+
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read as _, Write as _};
 use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
@@ -79,6 +81,13 @@ pub struct BootRevertNotice {
     /// state the daemon was in before this restart is uncertain (the banner
     /// says so), even though the boot revert itself succeeded.
     pub rollback_failed: bool,
+    /// V2 locator-carried target paths are sensitive and must not be rendered
+    /// by ordinary startup logs or banners.
+    pub redact_paths: bool,
+    /// V2 journal cleanup follows the durable terminal locator removal and is
+    /// warning-only.  V1 never reports this state because its cleanup remains
+    /// part of its legacy terminal operation.
+    pub journal_cleanup_failed: bool,
 }
 
 #[must_use]
@@ -125,10 +134,26 @@ pub fn remove(path: &Path) -> io::Result<()> {
 ///   config the operator applies on each restart. The recovery copy at
 ///   `<config_path>.unconfirmed` is preserved; the next boot fails identically
 ///   until the operator removes/fixes the journal.
+#[expect(
+    clippy::too_many_lines,
+    reason = "the legacy v1 boot-revert lane remains intentionally unchanged and linear"
+)]
 pub fn boot_revert_check(
     journal_path: &Path,
     config_path: &Path,
 ) -> Result<Option<BootRevert>, String> {
+    match v2::inspect_locator_absent_journal(journal_path) {
+        Ok(v2::LocatorAbsentJournal::Absent | v2::LocatorAbsentJournal::V2ResidueRemoved) => {
+            return Ok(None);
+        }
+        Ok(v2::LocatorAbsentJournal::LegacyV1) => {}
+        Err(error) => {
+            return Err(format!(
+                "refusing to boot: locator-absent commit-confirm journal state is unsafe or invalid ({:?}: {error}); inspect the owner-only runtime-state journal",
+                error.kind(),
+            ));
+        }
+    }
     // Resolve a symlinked config up front (operators legitimately symlink
     // configs into place): every operation below — save-aside, restore
     // write, refusal messages — then targets the REAL file, so the revert
@@ -248,6 +273,8 @@ pub fn boot_revert_check(
             confirm_id: journal.confirm_id,
             backup_path,
             rollback_failed: journal.rollback_failed,
+            redact_paths: false,
+            journal_cleanup_failed: false,
         },
     }))
 }
@@ -562,6 +589,24 @@ log_format = "json"
         let outcome = boot_revert_check(&journal_path(dir.path()), &config_path).unwrap();
         assert!(outcome.is_none());
         assert_eq!(fs::read_to_string(&config_path).unwrap(), "candidate");
+    }
+
+    #[test]
+    fn boot_check_without_runtime_state_directory_is_normal_boot() {
+        // Destructive proof: pinning the locator-free journal parent before
+        // establishing path absence makes this fresh-install boot fail before
+        // the daemon can create its runtime-state directory.
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rustbgpd.toml");
+        fs::write(&config_path, "candidate").unwrap();
+        let runtime_state_dir = dir.path().join("missing/runtime");
+        let path = journal_path(&runtime_state_dir);
+
+        let outcome = boot_revert_check(&path, &config_path).unwrap();
+
+        assert!(outcome.is_none());
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), "candidate");
+        assert!(!runtime_state_dir.exists());
     }
 
     #[test]

--- a/src/confirm_journal/v2.rs
+++ b/src/confirm_journal/v2.rs
@@ -1,0 +1,2168 @@
+//! ADR-0121 v2 commit-confirm authority.
+//!
+//! The config-adjacent locator is the only v2 boot authority.  Both it and
+//! the provenance-bearing journal are opened, read, published, and removed
+//! relative to pinned private directory descriptors.  Paths retained in the
+//! wire records are deliberately never included in returned errors.
+
+#![deny(unsafe_code)]
+
+use std::ffi::{OsStr, OsString};
+use std::fs::File;
+use std::io::{self, Read as _, Seek as _, Write as _};
+use std::os::unix::ffi::{OsStrExt as _, OsStringExt as _};
+use std::os::unix::fs::MetadataExt as _;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use crate::config::AcceptedConfigSnapshot;
+use crate::config_history;
+use crate::config_history::v2::{self as history_v2, LosslessPath, Manifest};
+
+const VERSION: u32 = 2;
+const MAX_CONFIRM_ID_CHARS: usize = 128;
+const MAX_JOURNAL_BYTES: usize = 34 * 1024 * 1024;
+const MAX_LOCATOR_BYTES: usize = 512 * 1024;
+const MAX_PATH_BYTES: usize = 64 * 1024;
+const LOCATOR_SUFFIX: &str = ".commit-confirm-locator.json";
+
+pub(crate) enum LocatorAbsentJournal {
+    Absent,
+    LegacyV1,
+    V2ResidueRemoved,
+}
+
+/// Dispatch the candidate-derived legacy journal only after locator absence
+/// has already been established.  A canonical v2 object has no authority in
+/// this lane and is removed durably; it is never converted into pending state.
+pub(crate) fn inspect_locator_absent_journal(path: &Path) -> io::Result<LocatorAbsentJournal> {
+    // V1 deliberately retains its historical path/metadata behavior.  This
+    // dispatcher pins only the containing directory, then uses one no-follow
+    // descriptor to classify, validate, read, and (for canonical v2 residue)
+    // remove the same inode.  A non-v2 object is never cleaned here.
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(LocatorAbsentJournal::Absent);
+        }
+        Err(error) => return Err(error),
+    }
+    let entry = Entry::pin_for_legacy_dispatch(path)?;
+    entry.inspect_locator_absent()
+}
+
+/// Stable lexical identity of the launch argument.  It is resolved before a
+/// daemon boot opens the candidate config and is also retained by the live
+/// transaction controller; reloads cannot replace it.
+#[derive(Clone, Debug)]
+pub(crate) struct LaunchIdentity {
+    lexical_config: PathBuf,
+}
+
+impl LaunchIdentity {
+    pub(crate) fn resolve(path: &Path) -> io::Result<Self> {
+        let absolute = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir()?.join(path)
+        };
+        reject_ambiguous_terminal_path(&absolute)?;
+        let lexical_config = normalize_launch_path(&absolute)?;
+        if lexical_config.file_name().is_none() {
+            return Err(invalid("launch config path has no final component"));
+        }
+        Ok(Self { lexical_config })
+    }
+
+    pub(crate) fn locator_path(&self) -> PathBuf {
+        let mut bytes = self.lexical_config.as_os_str().as_bytes().to_vec();
+        bytes.extend_from_slice(LOCATOR_SUFFIX.as_bytes());
+        PathBuf::from(OsString::from_vec(bytes))
+    }
+
+    /// Inspect v2 authority before candidate config access.  `Ok(None)` means
+    /// the locator is absent and the caller may proceed to the legacy lane.
+    pub(crate) fn boot_revert_check(&self) -> Result<Option<BootRevert>, String> {
+        self.boot_revert_check_io().map_err(|error| {
+            format!(
+                "v2 commit-confirm boot authority is invalid or unavailable ({:?}); inspect the config-adjacent locator and owner-only pending files",
+                error.kind()
+            )
+        })
+    }
+
+    fn boot_revert_check_io(&self) -> io::Result<Option<BootRevert>> {
+        self.boot_revert_check_io_with(|_| Ok(()))
+    }
+
+    fn boot_revert_check_io_with(
+        &self,
+        mut step: impl FnMut(BootStep) -> io::Result<()>,
+    ) -> io::Result<Option<BootRevert>> {
+        // The packaged SIGHUP-only deployment intentionally keeps
+        // /etc/rustbgpd root-owned and read-only to the daemon.  Establishing
+        // locator absence there must not make an ordinary boot depend on
+        // daemon ownership.  The parent still cannot admit untrusted writers;
+        // any present locator is subject to the full owner-private contract.
+        let locator = Entry::pin_for_absence(&self.locator_path())?;
+        locator.directory.validate_no_untrusted_writers()?;
+        if !locator.exists()? {
+            return Ok(None);
+        }
+        locator.directory.validate_private()?;
+        let (locator_bytes, locator_identity) =
+            locator.read_bounded_identified(MAX_LOCATOR_BYTES)?;
+        let wire = decode_locator(&locator_bytes)?;
+
+        let journal_path = path_from_wire(&wire.journal_path)?;
+        let journal = Entry::pin(&journal_path)?;
+        if journal.absolute_path_bytes() != journal_path.as_os_str().as_bytes() {
+            return Err(invalid("journal identity is not canonical"));
+        }
+        let (journal_bytes, journal_identity) =
+            journal.read_bounded_identified(MAX_JOURNAL_BYTES)?;
+        let journal_wire = decode_journal(&journal_bytes)?;
+        validate_locator_journal(&wire, &journal_wire, &journal)?;
+
+        let recorded_target = path_from_wire(&wire.config_target)?;
+        verify_launch_target(&self.lexical_config, &recorded_target)?;
+        let target = Entry::pin(&recorded_target)?;
+
+        // Provenance is verified before the candidate, backup slot, locator,
+        // or journal is changed.  This returned Arc is the one boot adopts.
+        let accepted = AcceptedConfigSnapshot::load_retained(
+            &journal_wire.prior.normalized_toml,
+            &recorded_target,
+        )
+        .map_err(|_| invalid("journaled prior sources are unavailable or changed"))?;
+        verify_prior_snapshot(&accepted, &journal_wire.prior)?;
+
+        let backup_name = append_name(&target.name, b".unconfirmed")?;
+        step(BootStep::CandidateSave)?;
+        save_candidate_aside(&target, &backup_name)?;
+        step(BootStep::ConfigRestore)?;
+        target.replace(journal_wire.prior.normalized_toml.as_bytes())?;
+
+        // Durable locator absence is terminal.  Journal cleanup happens only
+        // afterwards and cannot make the completed revert fail or re-arm it.
+        step(BootStep::LocatorUnlink)?;
+        locator.remove_matching(locator_identity)?;
+        step(BootStep::LocatorDirectorySync)?;
+        locator.directory.file.sync_all()?;
+        let journal_cleanup_failed = (|| {
+            step(BootStep::JournalUnlink)?;
+            journal.remove_matching(journal_identity)?;
+            step(BootStep::JournalDirectorySync)?;
+            journal.directory.file.sync_all()
+        })()
+        .is_err();
+        Ok(Some(BootRevert {
+            accepted,
+            notice: BootRevertNotice {
+                confirm_id: journal_wire.confirm_id,
+                rollback_failed: journal_wire.rollback_failed,
+                journal_cleanup_failed,
+            },
+        }))
+    }
+
+    /// Publish a complete v2 pending authority.  Both encodings are completed
+    /// before any stage exists, then journal durability precedes locator
+    /// durability.  The caller may mutate the candidate only after success.
+    pub(crate) fn publish(
+        &self,
+        journal_path: &Path,
+        confirm_id: &str,
+        deadline_unix_seconds: u64,
+        prior: &AcceptedConfigSnapshot,
+    ) -> io::Result<PendingFiles> {
+        self.publish_with(
+            journal_path,
+            confirm_id,
+            deadline_unix_seconds,
+            prior,
+            |_| Ok(()),
+        )
+    }
+
+    fn publish_with(
+        &self,
+        journal_path: &Path,
+        confirm_id: &str,
+        deadline_unix_seconds: u64,
+        prior: &AcceptedConfigSnapshot,
+        mut step: impl FnMut(PublishStep) -> io::Result<()>,
+    ) -> io::Result<PendingFiles> {
+        let locator = Entry::pin(&self.locator_path())?;
+        if locator.exists()? {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "v2 commit-confirm locator is already present",
+            ));
+        }
+        let journal_path = absolute_path(journal_path)?;
+        let journal = Entry::pin(&journal_path)?;
+        let journal_path = journal.absolute_path();
+        let config_target = resolve_launch_target(&self.lexical_config, true)?;
+        // A published transaction must be boot-revertible.  Pin and validate
+        // the resolved target parent now, not for the first time after a crash.
+        let config_target = Entry::pin(&config_target)?.absolute_path();
+        let prior_wire = Prior::from_snapshot(prior);
+        let journal_wire = Journal {
+            version: VERSION,
+            confirm_id: confirm_id.to_string(),
+            deadline_unix_seconds,
+            rollback_failed: false,
+            prior: prior_wire.clone(),
+        };
+        let journal_bytes = encode_journal(&journal_wire)?;
+        let locator_wire = Locator {
+            version: VERSION,
+            confirm_id: confirm_id.to_string(),
+            journal_path: path_to_wire(&journal_path)?,
+            config_target: path_to_wire(&config_target)?,
+            prior_sha256: prior_wire.sha256,
+            prior_source_sha256: prior_wire.source_sha256,
+        };
+        let locator_bytes = encode_locator(&locator_wire)?;
+
+        // Exact safe residue only.  No directory scan or suffix cleanup is
+        // permitted, and an unsafe object obstructs the new apply.
+        locator.cleanup_stage()?;
+        journal.cleanup_stage()?;
+        journal.remove_canonical_v2_residue()?;
+        let journal_identity =
+            journal.publish_with(&journal_bytes, false, PublishRole::Journal, &mut step)?;
+        let locator_identity =
+            match locator.publish_with(&locator_bytes, false, PublishRole::Locator, &mut step) {
+                Ok(identity) => identity,
+                Err(error) => {
+                    let _ =
+                        journal.remove_matching_canonical_journal(journal_identity, &journal_wire);
+                    let _ = journal.directory.file.sync_all();
+                    return Err(error);
+                }
+            };
+        Ok(PendingFiles {
+            locator,
+            journal,
+            state: Mutex::new(PendingState {
+                locator_wire,
+                locator_identity,
+                journal_wire,
+                journal_identity,
+                locator_phase: CleanupPhase::Published,
+                journal_phase: CleanupPhase::Published,
+            }),
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BootStep {
+    CandidateSave,
+    ConfigRestore,
+    LocatorUnlink,
+    LocatorDirectorySync,
+    JournalUnlink,
+    JournalDirectorySync,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PublishRole {
+    Journal,
+    Locator,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PublishStep {
+    JournalStageSync,
+    JournalRename,
+    JournalDirectorySync,
+    LocatorStageSync,
+    LocatorRename,
+    LocatorDirectorySync,
+}
+
+impl PublishStep {
+    const fn for_role(role: PublishRole, ordinal: u8) -> Self {
+        match (role, ordinal) {
+            (PublishRole::Journal, 0) => Self::JournalStageSync,
+            (PublishRole::Journal, 1) => Self::JournalRename,
+            (PublishRole::Journal, 2) => Self::JournalDirectorySync,
+            (PublishRole::Locator, 0) => Self::LocatorStageSync,
+            (PublishRole::Locator, 1) => Self::LocatorRename,
+            (PublishRole::Locator, 2) => Self::LocatorDirectorySync,
+            _ => unreachable!(),
+        }
+    }
+}
+
+pub(crate) struct BootRevert {
+    pub(crate) accepted: Arc<AcceptedConfigSnapshot>,
+    pub(crate) notice: BootRevertNotice,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct BootRevertNotice {
+    pub(crate) confirm_id: String,
+    pub(crate) rollback_failed: bool,
+    pub(crate) journal_cleanup_failed: bool,
+}
+
+/// Descriptor-pinned files for one live pending v2 transaction.
+#[derive(Debug)]
+pub(crate) struct PendingFiles {
+    locator: Entry,
+    journal: Entry,
+    state: Mutex<PendingState>,
+}
+
+#[derive(Debug)]
+struct PendingState {
+    locator_wire: Locator,
+    locator_identity: FileIdentity,
+    journal_wire: Journal,
+    journal_identity: FileIdentity,
+    locator_phase: CleanupPhase,
+    journal_phase: CleanupPhase,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CleanupPhase {
+    Published,
+    Unlinked,
+    Synced,
+}
+
+impl PendingFiles {
+    /// Remove and sync the locator first.  Once this succeeds the candidate is
+    /// permanent (or the revert terminal); journal cleanup is warning-only.
+    pub(crate) fn terminal_cleanup(&self) -> io::Result<bool> {
+        self.terminal_cleanup_with(|_| Ok(()))
+    }
+
+    fn terminal_cleanup_with(
+        &self,
+        mut step: impl FnMut(TerminalStep) -> io::Result<()>,
+    ) -> io::Result<bool> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| invalid("pending cleanup state is unavailable"))?;
+        if state.locator_phase == CleanupPhase::Published {
+            step(TerminalStep::LocatorUnlink)?;
+            self.locator
+                .remove_matching_canonical_locator(state.locator_identity, &state.locator_wire)?;
+            state.locator_phase = CleanupPhase::Unlinked;
+        }
+        if state.locator_phase == CleanupPhase::Unlinked {
+            step(TerminalStep::LocatorDirectorySync)?;
+            self.locator.directory.file.sync_all()?;
+            state.locator_phase = CleanupPhase::Synced;
+        }
+
+        let journal_result: io::Result<()> = (|| {
+            if state.journal_phase == CleanupPhase::Published {
+                step(TerminalStep::JournalUnlink)?;
+                self.journal.remove_matching_canonical_journal(
+                    state.journal_identity,
+                    &state.journal_wire,
+                )?;
+                state.journal_phase = CleanupPhase::Unlinked;
+            }
+            if state.journal_phase == CleanupPhase::Unlinked {
+                step(TerminalStep::JournalDirectorySync)?;
+                self.journal.directory.file.sync_all()?;
+                state.journal_phase = CleanupPhase::Synced;
+            }
+            Ok(())
+        })();
+        Ok(journal_result.is_err())
+    }
+
+    /// Persist the diagnostic rollback-failed bit without changing authority.
+    /// Atomic replacement leaves either the old or new complete journal.
+    pub(crate) fn record_rollback_failed(&self) -> io::Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| invalid("pending journal state is unavailable"))?;
+        if state.locator_phase != CleanupPhase::Published
+            || state.journal_phase != CleanupPhase::Published
+        {
+            return Err(invalid("pending journal cleanup has already started"));
+        }
+        self.journal
+            .verify_matching_canonical_journal(state.journal_identity, &state.journal_wire)?;
+        let mut journal_wire = state.journal_wire.clone();
+        journal_wire.rollback_failed = true;
+        let bytes = encode_journal(&journal_wire)?;
+        let identity = self.journal.publish(&bytes, true)?;
+        state.journal_wire = journal_wire;
+        state.journal_identity = identity;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TerminalStep {
+    LocatorUnlink,
+    LocatorDirectorySync,
+    JournalUnlink,
+    JournalDirectorySync,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Journal {
+    version: u32,
+    confirm_id: String,
+    deadline_unix_seconds: u64,
+    rollback_failed: bool,
+    prior: Prior,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Prior {
+    #[serde(with = "history_digest")]
+    sha256: [u8; 32],
+    #[serde(with = "history_digest")]
+    source_sha256: [u8; 32],
+    normalized_toml: String,
+    manifest: Manifest,
+}
+
+impl Prior {
+    fn from_snapshot(snapshot: &AcceptedConfigSnapshot) -> Self {
+        let manifest = config_history::stored_manifest(snapshot);
+        Self {
+            sha256: manifest.toml_sha256,
+            source_sha256: snapshot.source_sha256(),
+            normalized_toml: snapshot.normalized_toml().to_string(),
+            manifest,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Locator {
+    version: u32,
+    confirm_id: String,
+    journal_path: LosslessPath,
+    config_target: LosslessPath,
+    #[serde(with = "history_digest")]
+    prior_sha256: [u8; 32],
+    #[serde(with = "history_digest")]
+    prior_source_sha256: [u8; 32],
+}
+
+fn encode_journal(journal: &Journal) -> io::Result<Vec<u8>> {
+    validate_journal(journal)?;
+    let mut bytes = serde_json::to_vec(journal).map_err(invalid)?;
+    bytes.push(b'\n');
+    if !bytes.starts_with(b"{\"version\":2,") {
+        return Err(invalid("v2 journal dispatch prefix changed"));
+    }
+    enforce_total_cap("journal", bytes.len(), MAX_JOURNAL_BYTES)?;
+    Ok(bytes)
+}
+
+fn decode_journal(bytes: &[u8]) -> io::Result<Journal> {
+    enforce_total_cap("journal", bytes.len(), MAX_JOURNAL_BYTES)?;
+    if !bytes.starts_with(b"{\"version\":2,") {
+        return Err(invalid("journal is not canonical v2"));
+    }
+    let journal: Journal = serde_json::from_slice(bytes).map_err(invalid)?;
+    validate_journal(&journal)?;
+    if encode_journal(&journal)? != bytes {
+        return Err(invalid("non-canonical v2 journal"));
+    }
+    Ok(journal)
+}
+
+fn validate_journal(journal: &Journal) -> io::Result<()> {
+    if journal.version != VERSION {
+        return Err(invalid("unsupported journal version"));
+    }
+    validate_confirm_id(&journal.confirm_id)?;
+    validate_prior(&journal.prior)
+}
+
+fn validate_prior(prior: &Prior) -> io::Result<()> {
+    if prior.normalized_toml.len() > history_v2::MAX_TOML {
+        return Err(limit("normalized TOML", history_v2::MAX_TOML));
+    }
+    let actual: [u8; 32] = Sha256::digest(prior.normalized_toml.as_bytes()).into();
+    if prior.sha256 != actual || prior.manifest.toml_sha256 != actual {
+        return Err(invalid("prior TOML digest mismatch"));
+    }
+    history_v2::validate_manifest(&prior.manifest)?;
+    if prior.source_sha256 != history_v2::manifest_source_sha256(&prior.manifest) {
+        return Err(invalid("prior source digest mismatch"));
+    }
+    Ok(())
+}
+
+fn verify_prior_snapshot(snapshot: &AcceptedConfigSnapshot, prior: &Prior) -> io::Result<()> {
+    config_history::verify_retained_snapshot(
+        snapshot,
+        &prior.normalized_toml,
+        &prior.manifest,
+        prior.source_sha256,
+    )
+    .map_err(invalid)
+}
+
+fn encode_locator(locator: &Locator) -> io::Result<Vec<u8>> {
+    validate_locator(locator)?;
+    let mut bytes = serde_json::to_vec(locator).map_err(invalid)?;
+    bytes.push(b'\n');
+    enforce_total_cap("locator", bytes.len(), MAX_LOCATOR_BYTES)?;
+    Ok(bytes)
+}
+
+fn decode_locator(bytes: &[u8]) -> io::Result<Locator> {
+    enforce_total_cap("locator", bytes.len(), MAX_LOCATOR_BYTES)?;
+    let locator: Locator = serde_json::from_slice(bytes).map_err(invalid)?;
+    validate_locator(&locator)?;
+    if encode_locator(&locator)? != bytes {
+        return Err(invalid("non-canonical v2 locator"));
+    }
+    Ok(locator)
+}
+
+fn validate_locator(locator: &Locator) -> io::Result<()> {
+    if locator.version != VERSION {
+        return Err(invalid("unsupported locator version"));
+    }
+    validate_confirm_id(&locator.confirm_id)?;
+    for path in [&locator.journal_path, &locator.config_target] {
+        if path.0.len() > MAX_PATH_BYTES {
+            return Err(limit("locator path", MAX_PATH_BYTES));
+        }
+        let decoded = path_from_wire(path)?;
+        if !decoded.is_absolute() || has_parent_dir(&decoded) {
+            return Err(invalid("locator path is not absolute and lexical"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_locator_journal(
+    locator: &Locator,
+    journal: &Journal,
+    journal_entry: &Entry,
+) -> io::Result<()> {
+    if locator.confirm_id != journal.confirm_id
+        || locator.prior_sha256 != journal.prior.sha256
+        || locator.prior_source_sha256 != journal.prior.source_sha256
+        || path_from_wire(&locator.journal_path)?
+            .as_os_str()
+            .as_bytes()
+            != journal_entry.absolute_path_bytes()
+    {
+        return Err(invalid("locator and journal identity mismatch"));
+    }
+    Ok(())
+}
+
+fn validate_confirm_id(value: &str) -> io::Result<()> {
+    if value.trim().is_empty()
+        || value.chars().count() > MAX_CONFIRM_ID_CHARS
+        || value.chars().any(char::is_control)
+    {
+        return Err(invalid("invalid confirm id"));
+    }
+    Ok(())
+}
+
+fn enforce_total_cap(name: &str, len: usize, cap: usize) -> io::Result<()> {
+    if len > cap {
+        return Err(limit(name, cap));
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Directory {
+    file: File,
+    real_path: PathBuf,
+}
+
+impl Directory {
+    fn pin(path: &Path) -> io::Result<Arc<Self>> {
+        let directory = Self::pin_unchecked(path)?;
+        directory.validate_private()?;
+        Ok(directory)
+    }
+
+    /// Pin a directory without applying v2 ownership/mode policy.  This exists
+    /// only to classify locator-free legacy journals without changing the v1
+    /// compatibility lane; any v2 read or cleanup validates the pinned
+    /// descriptor before proceeding.
+    fn pin_unchecked(path: &Path) -> io::Result<Arc<Self>> {
+        use nix::fcntl::{OFlag, open};
+        use nix::sys::stat::Mode;
+
+        let real_path = std::fs::canonicalize(path)
+            .map_err(|error| io::Error::new(error.kind(), "pending parent unavailable"))?;
+        let fd = open(
+            &real_path,
+            OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_CLOEXEC | OFlag::O_NOFOLLOW,
+            Mode::empty(),
+        )
+        .map_err(errno)?;
+        let file = File::from(fd);
+        Ok(Arc::new(Self { file, real_path }))
+    }
+
+    fn validate_private(&self) -> io::Result<()> {
+        use nix::unistd::geteuid;
+
+        let metadata = self.file.metadata()?;
+        validate_directory_metadata_values(
+            metadata.is_dir(),
+            metadata.uid(),
+            metadata.mode(),
+            geteuid().as_raw(),
+            true,
+        )
+    }
+
+    fn validate_no_untrusted_writers(&self) -> io::Result<()> {
+        use nix::unistd::geteuid;
+
+        let metadata = self.file.metadata()?;
+        validate_directory_metadata_values(
+            metadata.is_dir(),
+            metadata.uid(),
+            metadata.mode(),
+            geteuid().as_raw(),
+            false,
+        )
+    }
+}
+
+fn validate_directory_metadata_values(
+    is_dir: bool,
+    owner: u32,
+    mode: u32,
+    expected_owner: u32,
+    require_owner: bool,
+) -> io::Result<()> {
+    if !is_dir || mode & 0o022 != 0 || require_owner && owner != expected_owner {
+        if require_owner {
+            return Err(invalid(format!(
+                "unsafe pending parent owner, type, or mode (dir={}, owner_match={}, mode={:o})",
+                is_dir,
+                owner == expected_owner,
+                mode & 0o7777
+            )));
+        }
+        return Err(invalid(format!(
+            "unsafe pending parent type or mode (dir={}, mode={:o})",
+            is_dir,
+            mode & 0o7777
+        )));
+    }
+    Ok(())
+}
+
+fn validate_pending_metadata(metadata: &std::fs::Metadata, cap: usize) -> io::Result<()> {
+    use nix::unistd::geteuid;
+
+    validate_pending_metadata_values(
+        metadata.is_file(),
+        metadata.uid(),
+        metadata.mode(),
+        metadata.len(),
+        cap,
+        geteuid().as_raw(),
+    )
+}
+
+fn validate_pending_metadata_values(
+    is_file: bool,
+    owner: u32,
+    mode: u32,
+    len: u64,
+    cap: usize,
+    expected_owner: u32,
+) -> io::Result<()> {
+    if !is_file || owner != expected_owner || mode & 0o7777 != 0o600 || len > cap as u64 {
+        return Err(invalid("unsafe pending file metadata"));
+    }
+    Ok(())
+}
+
+fn read_opened_bounded(
+    file: &mut File,
+    metadata: &std::fs::Metadata,
+    cap: usize,
+) -> io::Result<Vec<u8>> {
+    file.rewind()?;
+    let capacity = usize::try_from(metadata.len())
+        .map_err(|_| invalid("pending file length does not fit this platform"))?;
+    let mut bytes = Vec::with_capacity(capacity);
+    file.take(cap as u64 + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 != metadata.len() || bytes.len() > cap {
+        return Err(invalid("pending file changed while reading"));
+    }
+    Ok(bytes)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct FileIdentity {
+    device: u64,
+    inode: u64,
+}
+
+impl FileIdentity {
+    fn from_metadata(metadata: &std::fs::Metadata) -> Self {
+        Self {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Entry {
+    directory: Arc<Directory>,
+    name: OsString,
+}
+
+impl Entry {
+    fn pin(path: &Path) -> io::Result<Self> {
+        let absolute = absolute_path(path)?;
+        let name = absolute
+            .file_name()
+            .ok_or_else(|| invalid("pending file has no final component"))?
+            .to_os_string();
+        let parent = absolute
+            .parent()
+            .ok_or_else(|| invalid("pending file has no parent"))?;
+        Ok(Self {
+            directory: Directory::pin(parent)?,
+            name,
+        })
+    }
+
+    fn pin_for_legacy_dispatch(path: &Path) -> io::Result<Self> {
+        Self::pin_without_owner_check(path)
+    }
+
+    fn pin_for_absence(path: &Path) -> io::Result<Self> {
+        Self::pin_without_owner_check(path)
+    }
+
+    fn pin_without_owner_check(path: &Path) -> io::Result<Self> {
+        let absolute = absolute_path(path)?;
+        let name = absolute
+            .file_name()
+            .ok_or_else(|| invalid("pending file has no final component"))?
+            .to_os_string();
+        let parent = absolute
+            .parent()
+            .ok_or_else(|| invalid("pending file has no parent"))?;
+        Ok(Self {
+            directory: Directory::pin_unchecked(parent)?,
+            name,
+        })
+    }
+
+    fn stage_name(&self) -> io::Result<OsString> {
+        append_name(&self.name, b".tmp")
+    }
+
+    fn absolute_path(&self) -> PathBuf {
+        self.directory.real_path.join(&self.name)
+    }
+
+    fn absolute_path_bytes(&self) -> Vec<u8> {
+        self.absolute_path().as_os_str().as_bytes().to_vec()
+    }
+
+    fn exists(&self) -> io::Result<bool> {
+        use nix::fcntl::AtFlags;
+        use nix::sys::stat::fstatat;
+
+        match fstatat(
+            &self.directory.file,
+            Path::new(&self.name),
+            AtFlags::AT_SYMLINK_NOFOLLOW,
+        ) {
+            Ok(_) => Ok(true),
+            Err(nix::errno::Errno::ENOENT) => Ok(false),
+            Err(error) => Err(errno(error)),
+        }
+    }
+
+    fn read_bounded_identified(&self, cap: usize) -> io::Result<(Vec<u8>, FileIdentity)> {
+        self.read_bounded_identified_with(cap, || Ok(()))
+    }
+
+    fn read_bounded_identified_with(
+        &self,
+        cap: usize,
+        after_check: impl FnOnce() -> io::Result<()>,
+    ) -> io::Result<(Vec<u8>, FileIdentity)> {
+        let mut file = self.open_nofollow()?;
+        let metadata = file.metadata()?;
+        validate_pending_metadata(&metadata, cap)?;
+        let identity = FileIdentity::from_metadata(&metadata);
+        after_check()?;
+        Ok((read_opened_bounded(&mut file, &metadata, cap)?, identity))
+    }
+
+    fn open_nofollow(&self) -> io::Result<File> {
+        use nix::fcntl::{OFlag, openat};
+        use nix::sys::stat::Mode;
+
+        openat(
+            &self.directory.file,
+            Path::new(&self.name),
+            OFlag::O_RDONLY | OFlag::O_CLOEXEC | OFlag::O_NOFOLLOW | OFlag::O_NONBLOCK,
+            Mode::empty(),
+        )
+        .map(File::from)
+        .map_err(errno)
+    }
+
+    fn inspect_locator_absent(&self) -> io::Result<LocatorAbsentJournal> {
+        self.inspect_locator_absent_with(|| Ok(()))
+    }
+
+    fn inspect_locator_absent_with(
+        &self,
+        after_prefix: impl FnOnce() -> io::Result<()>,
+    ) -> io::Result<LocatorAbsentJournal> {
+        use nix::fcntl::AtFlags;
+        use nix::sys::stat::{SFlag, fstatat};
+
+        let stat = match fstatat(
+            &self.directory.file,
+            Path::new(&self.name),
+            AtFlags::AT_SYMLINK_NOFOLLOW,
+        ) {
+            Ok(stat) => stat,
+            Err(nix::errno::Errno::ENOENT) => return Ok(LocatorAbsentJournal::Absent),
+            Err(error) => return Err(errno(error)),
+        };
+        if SFlag::from_bits_truncate(stat.st_mode) & SFlag::S_IFMT != SFlag::S_IFREG {
+            // Preserve the exact v1 lane for symlinks, directories, FIFOs,
+            // sockets, and devices.  Only a regular file can carry v2 residue.
+            return Ok(LocatorAbsentJournal::LegacyV1);
+        }
+
+        let mut file = self.open_nofollow()?;
+        let metadata = file.metadata()?;
+        if !metadata.is_file() {
+            return Err(invalid(
+                "locator-absent journal changed during classification",
+            ));
+        }
+        let identity = FileIdentity::from_metadata(&metadata);
+        let mut prefix = [0u8; 13];
+        let mut prefix_len = 0;
+        while prefix_len < prefix.len() {
+            let read = file.read(&mut prefix[prefix_len..])?;
+            if read == 0 {
+                break;
+            }
+            prefix_len += read;
+        }
+        if prefix_len != prefix.len() || &prefix != b"{\"version\":2," {
+            return Ok(LocatorAbsentJournal::LegacyV1);
+        }
+
+        after_prefix()?;
+        self.directory.validate_private()?;
+        validate_pending_metadata(&metadata, MAX_JOURNAL_BYTES)?;
+        let bytes = read_opened_bounded(&mut file, &metadata, MAX_JOURNAL_BYTES)?;
+        decode_journal(&bytes)?;
+        self.remove_matching(identity)?;
+        self.directory.file.sync_all()?;
+        Ok(LocatorAbsentJournal::V2ResidueRemoved)
+    }
+
+    fn remove_canonical_v2_residue(&self) -> io::Result<()> {
+        let mut file = match self.open_nofollow() {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error),
+        };
+        let metadata = file.metadata()?;
+        validate_pending_metadata(&metadata, MAX_JOURNAL_BYTES)?;
+        let identity = FileIdentity::from_metadata(&metadata);
+        let bytes = read_opened_bounded(&mut file, &metadata, MAX_JOURNAL_BYTES)?;
+        decode_journal(&bytes)?;
+        self.remove_matching(identity)?;
+        self.directory.file.sync_all()
+    }
+
+    fn verify_matching_canonical_journal(
+        &self,
+        expected_identity: FileIdentity,
+        expected: &Journal,
+    ) -> io::Result<()> {
+        let (bytes, identity) = self.read_bounded_identified(MAX_JOURNAL_BYTES)?;
+        if identity != expected_identity || decode_journal(&bytes)? != *expected {
+            return Err(invalid("published journal identity changed before update"));
+        }
+        Ok(())
+    }
+
+    fn remove_matching_canonical_journal(
+        &self,
+        expected_identity: FileIdentity,
+        expected: &Journal,
+    ) -> io::Result<()> {
+        match self.verify_matching_canonical_journal(expected_identity, expected) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error),
+        }
+        match self.remove_matching(expected_identity) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn remove_matching_canonical_locator(
+        &self,
+        expected_identity: FileIdentity,
+        expected: &Locator,
+    ) -> io::Result<()> {
+        let (bytes, _) = match self.read_bounded_identified(MAX_LOCATOR_BYTES) {
+            Ok(found) => found,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error),
+        };
+        if decode_locator(&bytes)? != *expected {
+            return Err(invalid("published locator identity changed before cleanup"));
+        }
+        match self.remove_matching(expected_identity) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn remove_matching(&self, expected: FileIdentity) -> io::Result<()> {
+        use nix::fcntl::AtFlags;
+        use nix::sys::stat::{SFlag, fstatat};
+        use nix::unistd::{UnlinkatFlags, geteuid, unlinkat};
+
+        let stat = fstatat(
+            &self.directory.file,
+            Path::new(&self.name),
+            AtFlags::AT_SYMLINK_NOFOLLOW,
+        )
+        .map_err(errno)?;
+        let regular = SFlag::from_bits_truncate(stat.st_mode) & SFlag::S_IFMT == SFlag::S_IFREG;
+        if !regular
+            || stat.st_uid != geteuid().as_raw()
+            || stat.st_mode & 0o7777 != 0o600
+            || stat.st_dev as u64 != expected.device
+            || stat.st_ino as u64 != expected.inode
+        {
+            return Err(invalid("pending file identity changed before cleanup"));
+        }
+        unlinkat(
+            &self.directory.file,
+            Path::new(&self.name),
+            UnlinkatFlags::NoRemoveDir,
+        )
+        .map_err(errno)
+    }
+
+    fn cleanup_stage(&self) -> io::Result<()> {
+        let stage = self.stage_name()?;
+        remove_named_safe(&self.directory.file, &stage)?;
+        self.directory.file.sync_all()
+    }
+
+    fn publish(&self, bytes: &[u8], replace: bool) -> io::Result<FileIdentity> {
+        self.publish_with(bytes, replace, PublishRole::Journal, &mut |_| Ok(()))
+    }
+
+    fn publish_with(
+        &self,
+        bytes: &[u8],
+        replace: bool,
+        role: PublishRole,
+        step: &mut impl FnMut(PublishStep) -> io::Result<()>,
+    ) -> io::Result<FileIdentity> {
+        use nix::fcntl::{OFlag, RenameFlags, openat, renameat, renameat2};
+        use nix::sys::stat::{Mode, fchmod};
+
+        let stage = self.stage_name()?;
+        self.cleanup_stage()?;
+        let fd = openat(
+            &self.directory.file,
+            Path::new(&stage),
+            OFlag::O_WRONLY | OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_CLOEXEC | OFlag::O_NOFOLLOW,
+            Mode::from_bits_truncate(0o600),
+        )
+        .map_err(errno)?;
+        let mut file = File::from(fd);
+        fchmod(&file, Mode::from_bits_truncate(0o600)).map_err(errno)?;
+        let identity = FileIdentity::from_metadata(&file.metadata()?);
+        let result = (|| {
+            file.write_all(bytes)?;
+            step(PublishStep::for_role(role, 0))?;
+            file.sync_all()?;
+            drop(file);
+            step(PublishStep::for_role(role, 1))?;
+            if replace {
+                renameat(
+                    &self.directory.file,
+                    Path::new(&stage),
+                    &self.directory.file,
+                    Path::new(&self.name),
+                )
+                .map_err(errno)?;
+            } else {
+                renameat2(
+                    &self.directory.file,
+                    Path::new(&stage),
+                    &self.directory.file,
+                    Path::new(&self.name),
+                    RenameFlags::RENAME_NOREPLACE,
+                )
+                .map_err(errno)?;
+            }
+            step(PublishStep::for_role(role, 2))?;
+            self.directory.file.sync_all()
+        })();
+        if result.is_err() {
+            let _ = remove_named_safe(&self.directory.file, &stage);
+            if !replace {
+                let _ = self.remove_matching(identity);
+            }
+            let _ = self.directory.file.sync_all();
+        }
+        result.map(|()| identity)
+    }
+
+    fn replace(&self, bytes: &[u8]) -> io::Result<()> {
+        self.publish(bytes, true).map(|_| ())
+    }
+}
+
+fn remove_named_safe(directory: &File, name: &OsStr) -> io::Result<()> {
+    use nix::fcntl::AtFlags;
+    use nix::sys::stat::{SFlag, fstatat};
+    use nix::unistd::{UnlinkatFlags, geteuid, unlinkat};
+
+    let stat = match fstatat(directory, Path::new(name), AtFlags::AT_SYMLINK_NOFOLLOW) {
+        Ok(stat) => stat,
+        Err(nix::errno::Errno::ENOENT) => return Ok(()),
+        Err(error) => return Err(errno(error)),
+    };
+    let regular = SFlag::from_bits_truncate(stat.st_mode) & SFlag::S_IFMT == SFlag::S_IFREG;
+    if !regular || stat.st_uid != geteuid().as_raw() || stat.st_mode & 0o7777 != 0o600 {
+        return Err(invalid("unsafe exact pending residue"));
+    }
+    unlinkat(directory, Path::new(name), UnlinkatFlags::NoRemoveDir).map_err(errno)
+}
+
+fn save_candidate_aside(target: &Entry, backup_name: &OsStr) -> io::Result<()> {
+    use nix::fcntl::AtFlags;
+    use nix::unistd::{UnlinkatFlags, linkat, unlinkat};
+
+    match linkat(
+        &target.directory.file,
+        Path::new(&target.name),
+        &target.directory.file,
+        Path::new(backup_name),
+        AtFlags::empty(),
+    ) {
+        Ok(()) => {
+            unlinkat(
+                &target.directory.file,
+                Path::new(&target.name),
+                UnlinkatFlags::NoRemoveDir,
+            )
+            .map_err(errno)?;
+            target.directory.file.sync_all()
+        }
+        Err(nix::errno::Errno::EEXIST | nix::errno::Errno::ENOENT) => Ok(()),
+        Err(error) => Err(errno(error)),
+    }
+}
+
+fn verify_launch_target(launch: &Path, recorded: &Path) -> io::Result<()> {
+    match resolve_launch_target(launch, false) {
+        Ok(current) if current == recorded => Ok(()),
+        Ok(_) => Err(invalid("launch config target changed")),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn resolve_launch_target(launch: &Path, require_present: bool) -> io::Result<PathBuf> {
+    let parent = launch
+        .parent()
+        .ok_or_else(|| invalid("launch config has no parent"))?;
+    let directory = Directory::pin(parent)?;
+    let name = launch
+        .file_name()
+        .ok_or_else(|| invalid("launch config has no name"))?;
+    match std::fs::canonicalize(launch) {
+        Ok(target) => Ok(target),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            use nix::fcntl::{AtFlags, readlinkat};
+            use nix::sys::stat::{SFlag, fstatat};
+
+            match fstatat(
+                &directory.file,
+                Path::new(name),
+                AtFlags::AT_SYMLINK_NOFOLLOW,
+            ) {
+                Ok(stat)
+                    if SFlag::from_bits_truncate(stat.st_mode) & SFlag::S_IFMT
+                        == SFlag::S_IFLNK =>
+                {
+                    let link = readlinkat(&directory.file, Path::new(name)).map_err(errno)?;
+                    let target = if Path::new(&link).is_absolute() {
+                        PathBuf::from(link)
+                    } else {
+                        directory.real_path.join(link)
+                    };
+                    reject_ambiguous_terminal_path(&target)?;
+                    canonicalize_allow_missing(&target)
+                }
+                Ok(_) => Err(invalid("launch config target is not resolvable")),
+                Err(nix::errno::Errno::ENOENT) if !require_present => {
+                    Err(io::Error::from(io::ErrorKind::NotFound))
+                }
+                Err(nix::errno::Errno::ENOENT) => {
+                    Err(invalid("launch config is missing before confirmed apply"))
+                }
+                Err(error) => Err(errno(error)),
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn absolute_path(path: &Path) -> io::Result<PathBuf> {
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    reject_ambiguous_terminal_path(&path)?;
+    normalize_absolute(&path)
+}
+
+fn canonicalize_allow_missing(path: &Path) -> io::Result<PathBuf> {
+    let mut probe = path.to_path_buf();
+    let mut missing = Vec::new();
+    loop {
+        match std::fs::canonicalize(&probe) {
+            Ok(mut existing) => {
+                for component in missing.iter().rev() {
+                    existing.push(component);
+                }
+                return normalize_absolute(&existing);
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                let component = probe
+                    .file_name()
+                    .ok_or_else(|| invalid("dangling launch target has no existing ancestor"))?
+                    .to_os_string();
+                missing.push(component);
+                if !probe.pop() {
+                    return Err(invalid("dangling launch target escapes root"));
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn reject_ambiguous_terminal_path(path: &Path) -> io::Result<()> {
+    let bytes = path.as_os_str().as_bytes();
+    if bytes.ends_with(b"/") || bytes.ends_with(b"/.") || bytes.ends_with(b"/..") {
+        return Err(invalid("pending path has no unambiguous final component"));
+    }
+    Ok(())
+}
+
+fn normalize_launch_path(path: &Path) -> io::Result<PathBuf> {
+    if has_parent_dir(path) {
+        return Err(invalid("launch config path contains ParentDir"));
+    }
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::Prefix(_) | Component::Normal(_) => {
+                out.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => unreachable!(),
+        }
+    }
+    Ok(out)
+}
+
+fn normalize_absolute(path: &Path) -> io::Result<PathBuf> {
+    if !path.is_absolute() {
+        return Err(invalid("path is not absolute"));
+    }
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::Prefix(_) | Component::Normal(_) => {
+                out.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !out.pop() {
+                    return Err(invalid("path escapes root"));
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn has_parent_dir(path: &Path) -> bool {
+    path.components()
+        .any(|component| component == Component::ParentDir)
+}
+
+fn append_name(name: &OsStr, suffix: &[u8]) -> io::Result<OsString> {
+    let mut bytes = name.as_bytes().to_vec();
+    bytes.extend_from_slice(suffix);
+    if bytes.contains(&0) || bytes.len() > MAX_PATH_BYTES {
+        return Err(invalid("pending basename exceeds its bound"));
+    }
+    Ok(OsString::from_vec(bytes))
+}
+
+fn path_to_wire(path: &Path) -> io::Result<LosslessPath> {
+    let bytes = path.as_os_str().as_bytes();
+    if !path.is_absolute() || bytes.len() > MAX_PATH_BYTES || bytes.contains(&0) {
+        return Err(invalid("pending path is not canonical"));
+    }
+    Ok(LosslessPath(bytes.to_vec()))
+}
+
+fn path_from_wire(path: &LosslessPath) -> io::Result<PathBuf> {
+    if path.0.len() > MAX_PATH_BYTES || path.0.contains(&0) {
+        return Err(invalid("encoded pending path is invalid"));
+    }
+    Ok(PathBuf::from(OsString::from_vec(path.0.clone())))
+}
+
+fn errno(error: nix::errno::Errno) -> io::Error {
+    io::Error::from_raw_os_error(error as i32)
+}
+
+fn invalid(error: impl std::fmt::Display) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, error.to_string())
+}
+
+fn limit(name: &str, bytes: usize) -> io::Error {
+    invalid(format!("{name} exceeds its {bytes}-byte limit"))
+}
+
+mod history_digest {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub(super) fn serialize<S: Serializer>(
+        digest: &[u8; 32],
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&super::history_v2::encode_hex(digest))
+    }
+
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<[u8; 32], D::Error> {
+        let value = String::deserialize(deserializer)?;
+        if value.len() != 64
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err(serde::de::Error::custom(
+                "digest must be 64 lowercase hexadecimal characters",
+            ));
+        }
+        let mut digest = [0u8; 32];
+        for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+            let digit = |byte| {
+                if byte <= b'9' {
+                    byte - b'0'
+                } else {
+                    byte - b'a' + 10
+                }
+            };
+            digest[index] = (digit(pair[0]) << 4) | digit(pair[1]);
+        }
+        Ok(digest)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt as _;
+
+    use super::*;
+    use crate::test_support::tier_authorized_uds_test_config;
+
+    fn private_dir(parent: &Path, name: &str) -> PathBuf {
+        let path = parent.join(name);
+        fs::create_dir(&path).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+        path
+    }
+
+    fn config_toml(asn: u32) -> String {
+        tier_authorized_uds_test_config(&format!(
+            r#"
+[global]
+asn = {asn}
+router_id = "192.0.2.1"
+listen_port = 179
+[global.telemetry]
+log_format = "json"
+"#
+        ))
+    }
+
+    fn fixture() -> (
+        tempfile::TempDir,
+        PathBuf,
+        PathBuf,
+        LaunchIdentity,
+        Arc<AcceptedConfigSnapshot>,
+    ) {
+        let root = tempfile::tempdir().unwrap();
+        let config_dir = private_dir(root.path(), "config");
+        let journal_dir = private_dir(root.path(), "journal");
+        let config = config_dir.join("rustbgpd.toml");
+        fs::write(&config, config_toml(64_500)).unwrap();
+        fs::set_permissions(&config, fs::Permissions::from_mode(0o600)).unwrap();
+        let prior = Arc::new(AcceptedConfigSnapshot::load(&config, None).unwrap());
+        let launch = LaunchIdentity::resolve(&config).unwrap();
+        let journal = journal_dir.join(super::super::JOURNAL_FILE_NAME);
+        (root, config, journal, launch, prior)
+    }
+
+    fn small_prior() -> Prior {
+        let normalized_toml = "asn = 64512\n".to_string();
+        let sha256 = Sha256::digest(normalized_toml.as_bytes()).into();
+        let manifest = Manifest {
+            toml_sha256: sha256,
+            rpol_units: Vec::new(),
+            datasets: Vec::new(),
+        };
+        Prior {
+            sha256,
+            source_sha256: history_v2::manifest_source_sha256(&manifest),
+            normalized_toml,
+            manifest,
+        }
+    }
+
+    #[test]
+    fn canonical_journal_and_locator_pin_dispatch_and_field_order() {
+        // Destructive proof: reordering a wire-owned field, changing the
+        // dispatch prefix, omitting LF, or accepting pretty JSON makes an
+        // exact byte assertion or canonical decode fail.
+        let prior = small_prior();
+        let journal = Journal {
+            version: 2,
+            confirm_id: "deploy-1".into(),
+            deadline_unix_seconds: 9,
+            rollback_failed: false,
+            prior: prior.clone(),
+        };
+        let bytes = encode_journal(&journal).unwrap();
+        let sha = history_v2::encode_hex(&prior.sha256);
+        let source = history_v2::encode_hex(&prior.source_sha256);
+        assert_eq!(
+            String::from_utf8(bytes.clone()).unwrap(),
+            format!(
+                "{{\"version\":2,\"confirm_id\":\"deploy-1\",\"deadline_unix_seconds\":9,\"rollback_failed\":false,\"prior\":{{\"sha256\":\"{sha}\",\"source_sha256\":\"{source}\",\"normalized_toml\":\"asn = 64512\\n\",\"manifest\":{{\"toml_sha256\":\"{sha}\",\"rpol_units\":[],\"datasets\":[]}}}}}}\n"
+            )
+        );
+        assert_eq!(decode_journal(&bytes).unwrap(), journal);
+        let mut noncanonical = bytes;
+        noncanonical.insert(1, b' ');
+        assert!(decode_journal(&noncanonical).is_err());
+
+        let locator = Locator {
+            version: 2,
+            confirm_id: "deploy-1".into(),
+            journal_path: LosslessPath(b"/state/commit-confirm-journal.json".to_vec()),
+            config_target: LosslessPath(b"/etc/rustbgpd/config.toml".to_vec()),
+            prior_sha256: prior.sha256,
+            prior_source_sha256: prior.source_sha256,
+        };
+        let locator_bytes = encode_locator(&locator).unwrap();
+        let locator_text = String::from_utf8(locator_bytes.clone()).unwrap();
+        assert!(
+            locator_text
+                .starts_with("{\"version\":2,\"confirm_id\":\"deploy-1\",\"journal_path\":")
+        );
+        assert!(locator_text.ends_with(&format!(
+            "\"prior_sha256\":\"{sha}\",\"prior_source_sha256\":\"{source}\"}}\n"
+        )));
+        assert_eq!(decode_locator(&locator_bytes).unwrap(), locator);
+    }
+
+    #[test]
+    fn component_and_total_caps_accept_maximum_and_reject_plus_one() {
+        // Destructive proof: changing either `>` to `>=`, dropping the
+        // confirm/path check, or decoding before the total cap breaks a named
+        // boundary below.
+        let mut prior = small_prior();
+        prior.normalized_toml = "x".repeat(history_v2::MAX_TOML);
+        prior.sha256 = Sha256::digest(prior.normalized_toml.as_bytes()).into();
+        prior.manifest.toml_sha256 = prior.sha256;
+        prior.source_sha256 = history_v2::manifest_source_sha256(&prior.manifest);
+        assert!(validate_prior(&prior).is_ok());
+        prior.normalized_toml.push('x');
+        assert!(validate_prior(&prior).is_err());
+
+        let mut journal = Journal {
+            version: 2,
+            confirm_id: "é".repeat(MAX_CONFIRM_ID_CHARS),
+            deadline_unix_seconds: 0,
+            rollback_failed: false,
+            prior: small_prior(),
+        };
+        assert!(encode_journal(&journal).is_ok());
+        journal.confirm_id.push('é');
+        assert!(encode_journal(&journal).is_err());
+        journal.confirm_id = "   ".to_string();
+        assert!(encode_journal(&journal).is_err());
+        assert!(enforce_total_cap("journal", MAX_JOURNAL_BYTES, MAX_JOURNAL_BYTES).is_ok());
+        let journal_error =
+            enforce_total_cap("journal", MAX_JOURNAL_BYTES + 1, MAX_JOURNAL_BYTES).unwrap_err();
+        assert!(journal_error.to_string().contains("journal exceeds"));
+        assert!(enforce_total_cap("locator", MAX_LOCATOR_BYTES, MAX_LOCATOR_BYTES).is_ok());
+        let locator_error =
+            enforce_total_cap("locator", MAX_LOCATOR_BYTES + 1, MAX_LOCATOR_BYTES).unwrap_err();
+        assert!(locator_error.to_string().contains("locator exceeds"));
+
+        let path = format!("/{}", "x".repeat(MAX_PATH_BYTES - 1));
+        let mut locator = Locator {
+            version: 2,
+            confirm_id: "x".into(),
+            journal_path: LosslessPath(path.into_bytes()),
+            config_target: LosslessPath(b"/c".to_vec()),
+            prior_sha256: [0; 32],
+            prior_source_sha256: [0; 32],
+        };
+        assert!(validate_locator(&locator).is_ok());
+        locator.journal_path.0.push(b'x');
+        assert!(validate_locator(&locator).is_err());
+    }
+
+    #[test]
+    fn publication_is_journal_then_locator_and_every_failure_precedes_candidate_work() {
+        // Destructive proof: swapping publication calls or moving a hook after
+        // its named durability operation changes the exact crash state. Each
+        // injected failure now occurs before that operation, leaves no locator
+        // authority, and never touches config.
+        let expected = [
+            PublishStep::JournalStageSync,
+            PublishStep::JournalRename,
+            PublishStep::JournalDirectorySync,
+            PublishStep::LocatorStageSync,
+            PublishStep::LocatorRename,
+            PublishStep::LocatorDirectorySync,
+        ];
+        let (_root, config, journal, launch, prior) = fixture();
+        let before = fs::read(&config).unwrap();
+        let mut observed = Vec::new();
+        let files = launch
+            .publish_with(&journal, "deploy-1", 9, &prior, |step| {
+                observed.push(step);
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(observed, expected);
+        assert_eq!(fs::read(&config).unwrap(), before);
+        files.terminal_cleanup().unwrap();
+
+        for fail in expected {
+            let (_root, config, journal, launch, prior) = fixture();
+            let before = fs::read(&config).unwrap();
+            let result = launch.publish_with(&journal, "deploy-1", 9, &prior, |step| {
+                if step == fail {
+                    Err(io::Error::other("injected publication failure"))
+                } else {
+                    Ok(())
+                }
+            });
+            assert!(result.is_err(), "{fail:?}");
+            assert_eq!(fs::read(&config).unwrap(), before, "{fail:?}");
+            assert!(!launch.locator_path().exists(), "{fail:?}");
+            assert!(!journal.exists(), "{fail:?}");
+        }
+    }
+
+    #[test]
+    fn publication_failure_preserves_same_name_journal_replacement() {
+        // Destructive proof: cleaning "any canonical v2 residue" after a
+        // locator publication failure deletes this byte-identical replacement.
+        // Cleanup must be bound to the exact inode created by this attempt.
+        let (_root, _config, journal, launch, prior) = fixture();
+        let replacement = journal.with_file_name("replacement-journal");
+        let result = launch.publish_with(&journal, "deploy-1", 9, &prior, |step| {
+            if step == PublishStep::LocatorDirectorySync {
+                let bytes = fs::read(&journal).unwrap();
+                fs::write(&replacement, bytes).unwrap();
+                fs::set_permissions(&replacement, fs::Permissions::from_mode(0o600)).unwrap();
+                fs::rename(&replacement, &journal).unwrap();
+                return Err(io::Error::other("injected locator sync failure"));
+            }
+            Ok(())
+        });
+        assert!(result.is_err());
+        assert!(!launch.locator_path().exists());
+        assert!(journal.exists(), "replacement journal must survive cleanup");
+    }
+
+    #[test]
+    fn writer_removes_only_canonical_v2_final_residue() {
+        // Destructive proof: restoring the old metadata-only final cleanup
+        // erases the byte-exact legacy and garbage occupants asserted below.
+        let (_root, _config, journal, launch, prior) = fixture();
+        super::super::write(
+            &journal,
+            &super::super::ConfirmJournal {
+                confirm_id: "legacy".into(),
+                deadline_unix_seconds: 1,
+                rollback_toml: config_toml(64_499),
+                rollback_failed: false,
+            },
+        )
+        .unwrap();
+        let legacy = fs::read(&journal).unwrap();
+        assert!(launch.publish(&journal, "deploy-1", 9, &prior).is_err());
+        assert_eq!(fs::read(&journal).unwrap(), legacy);
+        assert!(!launch.locator_path().exists());
+
+        fs::write(&journal, b"owner-private garbage").unwrap();
+        fs::set_permissions(&journal, fs::Permissions::from_mode(0o600)).unwrap();
+        let garbage = fs::read(&journal).unwrap();
+        assert!(launch.publish(&journal, "deploy-1", 9, &prior).is_err());
+        assert_eq!(fs::read(&journal).unwrap(), garbage);
+        assert!(!launch.locator_path().exists());
+
+        let canonical_residue = encode_journal(&Journal {
+            version: VERSION,
+            confirm_id: "old-v2".into(),
+            deadline_unix_seconds: 1,
+            rollback_failed: false,
+            prior: Prior::from_snapshot(&prior),
+        })
+        .unwrap();
+        fs::write(&journal, canonical_residue).unwrap();
+        fs::set_permissions(&journal, fs::Permissions::from_mode(0o600)).unwrap();
+        let files = launch
+            .publish(&journal, "deploy-1", 9, &prior)
+            .expect("exact canonical v2 residue is safe only while locator is absent");
+        assert!(launch.locator_path().exists());
+        files.terminal_cleanup().unwrap();
+    }
+
+    #[test]
+    fn matching_v2_boot_verifies_then_restores_and_cleans_terminally() {
+        // Destructive proof: removing journal/locator identity comparison,
+        // prior verification, restore-before-unlink, or either terminal sync
+        // makes this full state transition or the injected sequence fail.
+        let (_root, config, journal, launch, prior) = fixture();
+        let prior_bytes = prior.normalized_toml().as_bytes().to_vec();
+        let files = launch.publish(&journal, "deploy-1", 9, &prior).unwrap();
+        fs::write(&config, b"unconfirmed candidate bytes").unwrap();
+        files.record_rollback_failed().unwrap();
+        drop(files);
+
+        let mut observed = Vec::new();
+        let reverted = launch
+            .boot_revert_check_io_with(|step| {
+                observed.push(step);
+                Ok(())
+            })
+            .unwrap()
+            .expect("locator must authorize the exact journal");
+        assert_eq!(
+            observed,
+            [
+                BootStep::CandidateSave,
+                BootStep::ConfigRestore,
+                BootStep::LocatorUnlink,
+                BootStep::LocatorDirectorySync,
+                BootStep::JournalUnlink,
+                BootStep::JournalDirectorySync,
+            ]
+        );
+        assert_eq!(reverted.notice.confirm_id, "deploy-1");
+        assert!(reverted.notice.rollback_failed);
+        assert_eq!(reverted.accepted.normalized_toml().as_bytes(), prior_bytes);
+        assert_eq!(fs::read(&config).unwrap(), prior_bytes);
+        assert_eq!(
+            fs::read(config.with_file_name("rustbgpd.toml.unconfirmed")).unwrap(),
+            b"unconfirmed candidate bytes"
+        );
+        assert!(!launch.locator_path().exists());
+        assert!(!journal.exists());
+    }
+
+    #[test]
+    fn boot_hooks_fail_before_each_named_operation_and_preserve_authority_order() {
+        // Destructive proof: placing a hook after its operation, deleting the
+        // restore-before-unlink edge, or cleaning the journal before durable
+        // locator absence changes the per-step filesystem state below.
+        let steps = [
+            BootStep::CandidateSave,
+            BootStep::ConfigRestore,
+            BootStep::LocatorUnlink,
+            BootStep::LocatorDirectorySync,
+            BootStep::JournalUnlink,
+            BootStep::JournalDirectorySync,
+        ];
+        for (index, fail) in steps.into_iter().enumerate() {
+            let (_root, config, journal, launch, prior) = fixture();
+            let prior_bytes = prior.normalized_toml().as_bytes().to_vec();
+            let files = launch.publish(&journal, "deploy-1", 9, &prior).unwrap();
+            let candidate = b"candidate";
+            fs::write(&config, candidate).unwrap();
+            drop(files);
+            let mut observed = Vec::new();
+            let result = launch.boot_revert_check_io_with(|step| {
+                observed.push(step);
+                if step == fail {
+                    Err(io::Error::other("injected boot operation failure"))
+                } else {
+                    Ok(())
+                }
+            });
+            assert_eq!(observed, steps[..=index], "{fail:?}");
+
+            if matches!(
+                fail,
+                BootStep::JournalUnlink | BootStep::JournalDirectorySync
+            ) {
+                assert!(
+                    result.unwrap().unwrap().notice.journal_cleanup_failed,
+                    "post-terminal cleanup failure must be warning-only: {fail:?}"
+                );
+            } else {
+                assert!(result.is_err(), "{fail:?}");
+            }
+
+            let backup = config.with_file_name("rustbgpd.toml.unconfirmed");
+            match fail {
+                BootStep::CandidateSave => {
+                    assert_eq!(fs::read(&config).unwrap(), candidate);
+                    assert!(!backup.exists());
+                    assert!(launch.locator_path().exists());
+                }
+                BootStep::ConfigRestore => {
+                    assert!(!config.exists());
+                    assert_eq!(fs::read(&backup).unwrap(), candidate);
+                    assert!(launch.locator_path().exists());
+                }
+                BootStep::LocatorUnlink => {
+                    assert_eq!(fs::read(&config).unwrap(), prior_bytes);
+                    assert!(launch.locator_path().exists());
+                    assert!(journal.exists());
+                }
+                BootStep::LocatorDirectorySync => {
+                    assert_eq!(fs::read(&config).unwrap(), prior_bytes);
+                    assert!(!launch.locator_path().exists());
+                    assert!(journal.exists());
+                }
+                BootStep::JournalUnlink => {
+                    assert!(!launch.locator_path().exists());
+                    assert!(journal.exists());
+                }
+                BootStep::JournalDirectorySync => {
+                    assert!(!launch.locator_path().exists());
+                    assert!(!journal.exists());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn locator_presence_is_fail_closed_and_never_falls_back() {
+        // Destructive proof: treating invalid-present as absent would return
+        // `Ok(None)` and let candidate/v1 discovery proceed.
+        let (_root, config, _journal, launch, _prior) = fixture();
+        let candidate = b"candidate must remain untouched";
+        fs::write(&config, candidate).unwrap();
+        fs::write(launch.locator_path(), b"{}\n").unwrap();
+        fs::set_permissions(launch.locator_path(), fs::Permissions::from_mode(0o600)).unwrap();
+        assert!(launch.boot_revert_check().is_err());
+        assert_eq!(fs::read(&config).unwrap(), candidate);
+        assert!(launch.locator_path().exists());
+    }
+
+    #[test]
+    fn provenance_mismatch_touches_no_candidate_backup_or_pending_state() {
+        // Destructive proof: loading sources after save-aside, clearing the
+        // fence on mismatch, or deleting either pending file changes one of
+        // these byte-exact untouched-state assertions.
+        let root = tempfile::tempdir().unwrap();
+        let config_dir = private_dir(root.path(), "config");
+        let state_dir = private_dir(root.path(), "state");
+        let source = config_dir.join("policy.rpol");
+        fs::write(&source, "policy p { term rest { accept } }\n").unwrap();
+        let config = config_dir.join("rustbgpd.toml");
+        let prior_toml = format!(
+            "{}\n[policy]\nrpol_files = [{:?}]\n",
+            config_toml(64_500),
+            source.display().to_string()
+        );
+        fs::write(&config, prior_toml).unwrap();
+        let prior = Arc::new(AcceptedConfigSnapshot::load(&config, None).unwrap());
+        let launch = LaunchIdentity::resolve(&config).unwrap();
+        let journal = state_dir.join(super::super::JOURNAL_FILE_NAME);
+        let files = launch.publish(&journal, "deploy-1", 9, &prior).unwrap();
+        let candidate = b"unconfirmed candidate must remain untouched";
+        fs::write(&config, candidate).unwrap();
+        fs::write(&source, "policy p { term rest { reject } }\n").unwrap();
+        let journal_before = fs::read(&journal).unwrap();
+        let locator_before = fs::read(launch.locator_path()).unwrap();
+        drop(files);
+
+        assert!(launch.boot_revert_check().is_err());
+        assert_eq!(fs::read(&config).unwrap(), candidate);
+        assert!(!config.with_file_name("rustbgpd.toml.unconfirmed").exists());
+        assert_eq!(fs::read(&journal).unwrap(), journal_before);
+        assert_eq!(fs::read(launch.locator_path()).unwrap(), locator_before);
+    }
+
+    #[test]
+    fn locator_journal_field_mismatch_touches_nothing() {
+        // Destructive proof: deleting locator/journal field comparison lets the
+        // changed confirm id authorize the otherwise-valid journal and mutates
+        // the candidate before the mismatch can be observed.
+        let (_root, config, journal, launch, prior) = fixture();
+        let files = launch.publish(&journal, "deploy-1", 9, &prior).unwrap();
+        let candidate = b"candidate must remain untouched";
+        fs::write(&config, candidate).unwrap();
+        let locator_path = launch.locator_path();
+        let mut locator_wire = decode_locator(&fs::read(&locator_path).unwrap()).unwrap();
+        locator_wire.confirm_id = "different-transaction".to_string();
+        fs::write(&locator_path, encode_locator(&locator_wire).unwrap()).unwrap();
+
+        assert!(launch.boot_revert_check().is_err());
+        assert_eq!(fs::read(&config).unwrap(), candidate);
+        assert!(!config.with_file_name("rustbgpd.toml.unconfirmed").exists());
+        assert!(locator_path.exists());
+        assert!(journal.exists());
+        assert!(files.terminal_cleanup().is_err());
+    }
+
+    #[test]
+    fn all_locator_and_journal_presence_states_dispatch_exactly() {
+        // Destructive proof: absent-locator v2 authorization, lost-journal
+        // tolerance, or v1 acceptance under a locator breaks one of these
+        // explicit state rows.
+        let (_root, config, journal, launch, prior) = fixture();
+        assert!(launch.boot_revert_check().unwrap().is_none());
+
+        // Absent locator + v1 remains delegated to the legacy lane.
+        super::super::write(
+            &journal,
+            &super::super::ConfirmJournal {
+                confirm_id: "legacy".into(),
+                deadline_unix_seconds: 1,
+                rollback_toml: config_toml(64_499),
+                rollback_failed: false,
+            },
+        )
+        .unwrap();
+        assert!(launch.boot_revert_check().unwrap().is_none());
+        assert!(matches!(
+            inspect_locator_absent_journal(&journal).unwrap(),
+            LocatorAbsentJournal::LegacyV1
+        ));
+        fs::remove_file(&journal).unwrap();
+
+        // Present locator + absent journal refuses without touching candidate.
+        let files = launch.publish(&journal, "deploy-1", 9, &prior).unwrap();
+        fs::remove_file(&journal).unwrap();
+        let before = fs::read(&config).unwrap();
+        assert!(launch.boot_revert_check().is_err());
+        assert_eq!(fs::read(&config).unwrap(), before);
+        fs::write(&journal, b"legacy-v1").unwrap();
+        fs::set_permissions(&journal, fs::Permissions::from_mode(0o600)).unwrap();
+        assert!(launch.boot_revert_check().is_err());
+        assert_eq!(fs::read(&config).unwrap(), before);
+        assert!(
+            files.terminal_cleanup().unwrap(),
+            "a replaced journal is warning-only after exact locator removal"
+        );
+        assert_eq!(fs::read(&journal).unwrap(), b"legacy-v1");
+        assert!(!launch.locator_path().exists());
+        fs::remove_file(&journal).unwrap();
+
+        // Absent locator + canonical v2 is residue, never authority.
+        let files = launch.publish(&journal, "deploy-2", 10, &prior).unwrap();
+        fs::remove_file(launch.locator_path()).unwrap();
+        drop(files);
+        assert!(matches!(
+            inspect_locator_absent_journal(&journal).unwrap(),
+            LocatorAbsentJournal::V2ResidueRemoved
+        ));
+        assert!(!journal.exists());
+    }
+
+    #[test]
+    fn locator_absent_dispatch_classifies_reads_and_cleans_one_inode() {
+        // Destructive proof: the former metadata/open/reopen sequence deleted
+        // `replacement` after classifying a different canonical v2 inode.
+        let (_root, _config, journal, launch, prior) = fixture();
+        let files = launch.publish(&journal, "deploy-1", 9, &prior).unwrap();
+        fs::remove_file(launch.locator_path()).unwrap();
+        drop(files);
+
+        let replacement = journal.with_file_name("replacement");
+        fs::write(&replacement, b"legacy replacement must survive").unwrap();
+        fs::set_permissions(&replacement, fs::Permissions::from_mode(0o600)).unwrap();
+        let entry = Entry::pin_for_legacy_dispatch(&journal).unwrap();
+        let result = entry.inspect_locator_absent_with(|| {
+            fs::rename(&replacement, &journal)?;
+            Ok(())
+        });
+        assert!(result.is_err());
+        assert_eq!(
+            fs::read(&journal).unwrap(),
+            b"legacy replacement must survive"
+        );
+
+        // A stable legacy object remains delegated byte-for-byte; dispatch
+        // applies no v2 owner/mode/content cleanup to it.
+        assert!(matches!(
+            inspect_locator_absent_journal(&journal).unwrap(),
+            LocatorAbsentJournal::LegacyV1
+        ));
+        assert_eq!(
+            fs::read(&journal).unwrap(),
+            b"legacy replacement must survive"
+        );
+    }
+
+    #[test]
+    fn symlink_target_binding_detects_retarget_and_restores_dangling_target() {
+        // Destructive proof: recording the lexical leaf rather than the real
+        // target makes the retarget case pass; failing to inspect a dangling
+        // leaf prevents the second revert.
+        let root = tempfile::tempdir().unwrap();
+        let config_dir = private_dir(root.path(), "config");
+        let state_dir = private_dir(root.path(), "state");
+        let target_a = config_dir.join("a.toml");
+        let target_b = config_dir.join("b.toml");
+        fs::write(&target_a, config_toml(64_500)).unwrap();
+        fs::write(&target_b, config_toml(64_501)).unwrap();
+        let link = config_dir.join("config.toml");
+        std::os::unix::fs::symlink("a.toml", &link).unwrap();
+        let launch = LaunchIdentity::resolve(&link).unwrap();
+        let prior = Arc::new(AcceptedConfigSnapshot::load(&link, None).unwrap());
+        let journal = state_dir.join(super::super::JOURNAL_FILE_NAME);
+        let files = launch.publish(&journal, "deploy-1", 9, &prior).unwrap();
+        fs::remove_file(&link).unwrap();
+        std::os::unix::fs::symlink("b.toml", &link).unwrap();
+        assert!(launch.boot_revert_check().is_err());
+        files.terminal_cleanup().unwrap();
+
+        fs::remove_file(&link).unwrap();
+        std::os::unix::fs::symlink("a.toml", &link).unwrap();
+        let files = launch.publish(&journal, "deploy-2", 9, &prior).unwrap();
+        fs::write(&target_a, b"candidate").unwrap();
+        fs::remove_file(&target_a).unwrap();
+        drop(files);
+        assert!(launch.boot_revert_check().unwrap().is_some());
+        assert_eq!(
+            fs::read(&target_a).unwrap(),
+            prior.normalized_toml().as_bytes()
+        );
+        assert_eq!(fs::read(&link).unwrap(), prior.normalized_toml().as_bytes());
+    }
+
+    #[test]
+    fn writer_rejects_unsafe_resolved_target_parent_before_publication() {
+        // Destructive proof: omitting the writer-side target Entry::pin makes
+        // publication succeed even though boot recovery would later reject
+        // this world-writable resolved parent.
+        let root = tempfile::tempdir().unwrap();
+        let config_dir = private_dir(root.path(), "config");
+        let target_dir = private_dir(root.path(), "target");
+        let state_dir = private_dir(root.path(), "state");
+        let target = target_dir.join("real.toml");
+        fs::write(&target, config_toml(64_500)).unwrap();
+        let link = config_dir.join("config.toml");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        let prior = Arc::new(AcceptedConfigSnapshot::load(&link, None).unwrap());
+        let launch = LaunchIdentity::resolve(&link).unwrap();
+        let journal = state_dir.join(super::super::JOURNAL_FILE_NAME);
+        fs::set_permissions(&target_dir, fs::Permissions::from_mode(0o777)).unwrap();
+
+        assert!(launch.publish(&journal, "deploy-1", 9, &prior).is_err());
+        assert!(!launch.locator_path().exists());
+        assert!(!journal.exists());
+    }
+
+    #[test]
+    fn dangling_target_keeps_canonical_identity_through_symlinked_intermediate() {
+        // Destructive proof: replacing `canonicalize_allow_missing` with
+        // lexical normalization makes the dangling target compare as
+        // `config/targets/prior.toml` instead of its recorded real parent.
+        let root = tempfile::tempdir().unwrap();
+        let config_dir = private_dir(root.path(), "config");
+        let real_targets = private_dir(root.path(), "real-targets");
+        let state_dir = private_dir(root.path(), "state");
+        let target = real_targets.join("prior.toml");
+        fs::write(&target, config_toml(64_500)).unwrap();
+        std::os::unix::fs::symlink(&real_targets, config_dir.join("targets")).unwrap();
+        let launch_path = config_dir.join("config.toml");
+        std::os::unix::fs::symlink("targets/prior.toml", &launch_path).unwrap();
+        let launch = LaunchIdentity::resolve(&launch_path).unwrap();
+        let prior = Arc::new(AcceptedConfigSnapshot::load(&launch_path, None).unwrap());
+        let journal = state_dir.join(super::super::JOURNAL_FILE_NAME);
+        let files = launch.publish(&journal, "deploy-1", 9, &prior).unwrap();
+        fs::remove_file(&target).unwrap();
+        drop(files);
+
+        assert!(launch.boot_revert_check().unwrap().is_some());
+        assert_eq!(
+            fs::read(&target).unwrap(),
+            prior.normalized_toml().as_bytes()
+        );
+        assert!(launch_path.is_symlink());
+    }
+
+    #[test]
+    fn descriptor_read_never_reopens_checked_name_and_detects_growth() {
+        // Destructive proof: replacing the checked descriptor with a second
+        // `open(path)` returns `replacement`; dropping the exact-length check
+        // accepts the growth case.
+        let root = tempfile::tempdir().unwrap();
+        let dir = private_dir(root.path(), "private");
+        let path = dir.join("entry");
+        fs::write(&path, b"original").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        let entry = Entry::pin(&path).unwrap();
+        let replacement = dir.join("replacement");
+        fs::write(&replacement, b"replacement").unwrap();
+        fs::set_permissions(&replacement, fs::Permissions::from_mode(0o600)).unwrap();
+        let bytes = entry
+            .read_bounded_identified_with(64, || {
+                fs::rename(&replacement, &path)?;
+                Ok(())
+            })
+            .unwrap()
+            .0;
+        assert_eq!(bytes, b"original");
+        assert_eq!(fs::read(&path).unwrap(), b"replacement");
+
+        fs::write(&path, b"short").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        let entry = Entry::pin(&path).unwrap();
+        assert!(
+            entry
+                .read_bounded_identified_with(64, || {
+                    fs::OpenOptions::new()
+                        .append(true)
+                        .open(&path)?
+                        .write_all(b"-grew")?;
+                    Ok(())
+                })
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn v2_pending_metadata_owner_type_mode_and_size_are_fail_closed() {
+        // Destructive proof: dropping any scalar guard makes its direct row
+        // green; opening without O_NOFOLLOW or checking pathname metadata lets
+        // one of the functional directory/symlink/oversize rows reach decode.
+        use nix::unistd::geteuid;
+
+        let owner = geteuid().as_raw();
+        assert!(validate_pending_metadata_values(true, owner, 0o100_600, 64, 64, owner).is_ok());
+        assert!(
+            validate_pending_metadata_values(true, owner.wrapping_add(1), 0o100_600, 64, 64, owner)
+                .is_err()
+        );
+        assert!(validate_pending_metadata_values(false, owner, 0o040_600, 64, 64, owner).is_err());
+        assert!(validate_pending_metadata_values(true, owner, 0o100_640, 64, 64, owner).is_err());
+        assert!(validate_pending_metadata_values(true, owner, 0o100_600, 65, 64, owner).is_err());
+
+        for occupant in ["directory", "symlink", "oversize"] {
+            let (_root, config, journal, launch, prior) = fixture();
+            let files = launch.publish(&journal, "deploy-1", 9, &prior).unwrap();
+            drop(files);
+            fs::remove_file(&journal).unwrap();
+            match occupant {
+                "directory" => fs::create_dir(&journal).unwrap(),
+                "symlink" => {
+                    let target = journal.with_file_name("symlink-target");
+                    fs::write(&target, b"not authority").unwrap();
+                    std::os::unix::fs::symlink(target, &journal).unwrap();
+                }
+                "oversize" => {
+                    let file = fs::File::create(&journal).unwrap();
+                    file.set_len(MAX_JOURNAL_BYTES as u64 + 1).unwrap();
+                    fs::set_permissions(&journal, fs::Permissions::from_mode(0o600)).unwrap();
+                }
+                _ => unreachable!(),
+            }
+
+            let before = fs::read(&config).unwrap();
+            assert!(launch.boot_revert_check().is_err(), "{occupant}");
+            assert_eq!(fs::read(&config).unwrap(), before, "{occupant}");
+            assert!(launch.locator_path().exists(), "{occupant}");
+        }
+    }
+
+    #[test]
+    fn terminal_cleanup_requires_the_published_inode_even_for_identical_bytes() {
+        // Destructive proof: deleting either identity comparison makes cleanup
+        // unlink a byte-identical replacement that this transaction did not
+        // publish. Locator replacement is nonterminal; journal replacement is
+        // warning-only after locator authority becomes durably absent.
+        let (_root, _config, journal, launch, prior) = fixture();
+        let files = launch.publish(&journal, "deploy-1", 9, &prior).unwrap();
+        let locator = launch.locator_path();
+        let replacement = locator.with_file_name("replacement-locator");
+        fs::write(&replacement, fs::read(&locator).unwrap()).unwrap();
+        fs::set_permissions(&replacement, fs::Permissions::from_mode(0o600)).unwrap();
+        fs::rename(&replacement, &locator).unwrap();
+        assert!(files.terminal_cleanup().is_err());
+        assert!(locator.exists());
+        assert!(journal.exists());
+
+        let (_root, _config, journal, launch, prior) = fixture();
+        let files = launch.publish(&journal, "deploy-2", 10, &prior).unwrap();
+        let replacement = journal.with_file_name("replacement-journal");
+        let expected = fs::read(&journal).unwrap();
+        fs::write(&replacement, &expected).unwrap();
+        fs::set_permissions(&replacement, fs::Permissions::from_mode(0o600)).unwrap();
+        fs::rename(&replacement, &journal).unwrap();
+        assert!(files.record_rollback_failed().is_err());
+        assert!(files.terminal_cleanup().unwrap());
+        assert!(!launch.locator_path().exists());
+        assert_eq!(fs::read(&journal).unwrap(), expected);
+    }
+
+    #[test]
+    fn lexical_parentdir_unsafe_parent_and_unsafe_metadata_refuse() {
+        // Destructive proof: normalizing ParentDir or a terminal `/.`, omitting
+        // parent mode enforcement, requiring daemon ownership merely to prove
+        // locator absence, or accepting journal mode 0640 makes a named
+        // assertion fail.  The owner distinction preserves the packaged
+        // root-owned, read-only config directory while every present v2 object
+        // and writer still require daemon ownership.
+        assert!(LaunchIdentity::resolve(Path::new("/etc/rustbgpd/../config.toml")).is_err());
+        assert!(LaunchIdentity::resolve(Path::new("/etc/rustbgpd/.")).is_err());
+        assert!(validate_directory_metadata_values(true, 0, 0o750, 1000, false).is_ok());
+        assert!(validate_directory_metadata_values(true, 0, 0o750, 1000, true).is_err());
+
+        let (_root, config, journal, launch, prior) = fixture();
+        fs::set_permissions(config.parent().unwrap(), fs::Permissions::from_mode(0o777)).unwrap();
+        assert!(
+            launch.boot_revert_check().is_err(),
+            "locator absence must be established under a pinned safe parent"
+        );
+        assert!(launch.publish(&journal, "deploy-1", 9, &prior).is_err());
+        fs::set_permissions(config.parent().unwrap(), fs::Permissions::from_mode(0o700)).unwrap();
+
+        let files = launch.publish(&journal, "deploy-1", 9, &prior).unwrap();
+        fs::set_permissions(&journal, fs::Permissions::from_mode(0o640)).unwrap();
+        assert!(launch.boot_revert_check().is_err());
+        fs::set_permissions(&journal, fs::Permissions::from_mode(0o600)).unwrap();
+        files.terminal_cleanup().unwrap();
+    }
+
+    #[test]
+    fn absent_locator_preserves_root_owned_read_only_config_parent() {
+        // Destructive proof: pinning the absent locator with the full
+        // daemon-owner check makes this packaged-deployment shape fail for the
+        // unprivileged service UID before candidate loading can begin.
+        let launch =
+            LaunchIdentity::resolve(Path::new("/etc/rustbgpd-v2-absence-proof.toml")).unwrap();
+        assert!(!launch.locator_path().exists());
+        assert!(launch.boot_revert_check().unwrap().is_none());
+    }
+
+    #[test]
+    fn terminal_locator_sync_precedes_warning_only_journal_cleanup() {
+        // Destructive proof: moving journal cleanup before locator sync
+        // changes the exact observation sequence.  A post-terminal journal
+        // failure reports only a warning bit and cannot revive authority.
+        let (_root, _config, journal, launch, prior) = fixture();
+        let files = launch.publish(&journal, "deploy-1", 9, &prior).unwrap();
+        let mut observed = Vec::new();
+        let warning = files
+            .terminal_cleanup_with(|step| {
+                observed.push(step);
+                if step == TerminalStep::JournalUnlink {
+                    Err(io::Error::other("injected post-terminal failure"))
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap();
+        assert!(warning);
+        assert_eq!(
+            observed,
+            [
+                TerminalStep::LocatorUnlink,
+                TerminalStep::LocatorDirectorySync,
+                TerminalStep::JournalUnlink,
+            ]
+        );
+        assert!(!launch.locator_path().exists());
+        // A retry still syncs durable absence and cleanup is harmless.
+        assert!(!files.terminal_cleanup().unwrap());
+
+        // NotFound is terminal only after both parent directories cross their
+        // durability hooks; returning early on either absence drops a sync.
+        let (_root, _config, journal, launch, prior) = fixture();
+        let files = launch.publish(&journal, "deploy-2", 10, &prior).unwrap();
+        fs::remove_file(launch.locator_path()).unwrap();
+        fs::remove_file(&journal).unwrap();
+        let mut observed = Vec::new();
+        assert!(
+            !files
+                .terminal_cleanup_with(|step| {
+                    observed.push(step);
+                    Ok(())
+                })
+                .unwrap()
+        );
+        assert_eq!(
+            observed,
+            [
+                TerminalStep::LocatorUnlink,
+                TerminalStep::LocatorDirectorySync,
+                TerminalStep::JournalUnlink,
+                TerminalStep::JournalDirectorySync,
+            ]
+        );
+    }
+}

--- a/src/confirm_journal/v2.rs
+++ b/src/confirm_journal/v2.rs
@@ -111,17 +111,16 @@ impl LaunchIdentity {
         max_journal_bytes: usize,
         mut step: impl FnMut(BootStep) -> io::Result<()>,
     ) -> io::Result<Option<BootRevert>> {
-        // The packaged SIGHUP-only deployment intentionally keeps
-        // /etc/rustbgpd root-owned and read-only to the daemon.  Establishing
-        // locator absence there must not make an ordinary boot depend on
-        // daemon ownership.  The parent still cannot admit untrusted writers;
-        // any present locator is subject to the full owner-private contract.
+        // Locator absence carries no v2 authority, so it must not impose a
+        // new parent-ownership/mode contract on ordinary pre-v2 launch paths.
+        // Any present locator is subject to the full owner-private contract
+        // below, and every writer applies that contract before publication.
         let locator = Entry::pin_for_absence(&self.locator_path())?;
-        locator.directory.validate_no_untrusted_writers()?;
         if !locator.exists()? {
             return Ok(None);
         }
         locator.directory.validate_private()?;
+        step(BootStep::LocatorParentValidated)?;
         let (locator_bytes, locator_identity) =
             locator.read_bounded_identified(max_locator_bytes)?;
         let wire = decode_locator_with_cap(&locator_bytes, max_locator_bytes)?;
@@ -272,6 +271,7 @@ impl LaunchIdentity {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum BootStep {
+    LocatorParentValidated,
     CandidateSave,
     ConfigRestore,
     LocatorUnlink,
@@ -656,20 +656,6 @@ impl Directory {
             metadata.uid(),
             metadata.mode(),
             geteuid().as_raw(),
-            true,
-        )
-    }
-
-    fn validate_no_untrusted_writers(&self) -> io::Result<()> {
-        use nix::unistd::geteuid;
-
-        let metadata = self.file.metadata()?;
-        validate_directory_metadata_values(
-            metadata.is_dir(),
-            metadata.uid(),
-            metadata.mode(),
-            geteuid().as_raw(),
-            false,
         )
     }
 }
@@ -679,20 +665,12 @@ fn validate_directory_metadata_values(
     owner: u32,
     mode: u32,
     expected_owner: u32,
-    require_owner: bool,
 ) -> io::Result<()> {
-    if !is_dir || mode & 0o022 != 0 || require_owner && owner != expected_owner {
-        if require_owner {
-            return Err(invalid(format!(
-                "unsafe pending parent owner, type, or mode (dir={}, owner_match={}, mode={:o})",
-                is_dir,
-                owner == expected_owner,
-                mode & 0o7777
-            )));
-        }
+    if !is_dir || mode & 0o022 != 0 || owner != expected_owner {
         return Err(invalid(format!(
-            "unsafe pending parent type or mode (dir={}, mode={:o})",
+            "unsafe pending parent owner, type, or mode (dir={}, owner_match={}, mode={:o})",
             is_dir,
+            owner == expected_owner,
             mode & 0o7777
         )));
     }
@@ -1704,6 +1682,7 @@ log_format = "json"
         assert_eq!(
             observed,
             [
+                BootStep::LocatorParentValidated,
                 BootStep::CandidateSave,
                 BootStep::ConfigRestore,
                 BootStep::LocatorUnlink,
@@ -1759,8 +1738,10 @@ log_format = "json"
         let result = launch.boot_revert_check_io_with_limits(
             locator_bytes.len(),
             journal_bytes.len() - 1,
-            |_| {
-                candidate_steps.set(candidate_steps.get() + 1);
+            |step| {
+                if step != BootStep::LocatorParentValidated {
+                    candidate_steps.set(candidate_steps.get() + 1);
+                }
                 Ok(())
             },
         );
@@ -1777,6 +1758,7 @@ log_format = "json"
         // restore-before-unlink edge, or cleaning the journal before durable
         // locator absence changes the per-step filesystem state below.
         let steps = [
+            BootStep::LocatorParentValidated,
             BootStep::CandidateSave,
             BootStep::ConfigRestore,
             BootStep::LocatorUnlink,
@@ -1816,6 +1798,12 @@ log_format = "json"
 
             let backup = config.with_file_name("rustbgpd.toml.unconfirmed");
             match fail {
+                BootStep::LocatorParentValidated => {
+                    assert_eq!(fs::read(&config).unwrap(), candidate);
+                    assert!(!backup.exists());
+                    assert!(launch.locator_path().exists());
+                    assert!(journal.exists());
+                }
                 BootStep::CandidateSave => {
                     assert_eq!(fs::read(&config).unwrap(), candidate);
                     assert!(!backup.exists());
@@ -1890,7 +1878,13 @@ log_format = "json"
         let locator_before = fs::read(launch.locator_path()).unwrap();
         drop(files);
 
-        assert!(launch.boot_revert_check().is_err());
+        let result = launch.boot_revert_check_io_with(|step| {
+            if step == BootStep::LocatorParentValidated {
+                fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o700))?;
+            }
+            Ok(())
+        });
+        assert!(result.is_err());
         assert_eq!(fs::read(&config).unwrap(), candidate);
         assert!(!config.with_file_name("rustbgpd.toml.unconfirmed").exists());
         assert_eq!(fs::read(&journal).unwrap(), journal_before);
@@ -2070,6 +2064,42 @@ log_format = "json"
     }
 
     #[test]
+    fn present_locator_rejects_changed_unsafe_lexical_parent_before_candidate_work() {
+        // Destructive proof: removing the present-locator parent validation
+        // restores the candidate through the distinct still-private target
+        // parent, removes authority, and makes the refusal assertion fail.
+        let root = tempfile::tempdir().unwrap();
+        let config_dir = private_dir(root.path(), "config");
+        let target_dir = private_dir(root.path(), "target");
+        let state_dir = private_dir(root.path(), "state");
+        let target = target_dir.join("real.toml");
+        fs::write(&target, config_toml(64_500)).unwrap();
+        let link = config_dir.join("config.toml");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        let prior = Arc::new(AcceptedConfigSnapshot::load(&link, None).unwrap());
+        let launch = LaunchIdentity::resolve(&link).unwrap();
+        let journal = state_dir.join(super::super::JOURNAL_FILE_NAME);
+        let files = launch.publish(&journal, "deploy-1", 9, &prior).unwrap();
+        let candidate = b"unconfirmed candidate under changed lexical parent";
+        fs::write(&target, candidate).unwrap();
+        fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o777)).unwrap();
+
+        let result = launch.boot_revert_check_io_with(|step| {
+            if step == BootStep::LocatorParentValidated {
+                fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o700))?;
+            }
+            Ok(())
+        });
+        assert!(result.is_err());
+        assert_eq!(fs::read(&target).unwrap(), candidate);
+        assert!(launch.locator_path().exists());
+        assert!(journal.exists());
+
+        fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o700)).unwrap();
+        files.terminal_cleanup().unwrap();
+    }
+
+    #[test]
     fn dangling_target_keeps_canonical_identity_through_symlinked_intermediate() {
         // Destructive proof: replacing `canonicalize_allow_missing` with
         // lexical normalization makes the dangling target compare as
@@ -2213,28 +2243,36 @@ log_format = "json"
     }
 
     #[test]
-    fn lexical_parentdir_unsafe_parent_and_unsafe_metadata_refuse() {
+    fn lexical_parentdir_present_state_and_unsafe_metadata_refuse() {
         // Destructive proof: normalizing ParentDir or a terminal `/.`, omitting
-        // parent mode enforcement, requiring daemon ownership merely to prove
-        // locator absence, or accepting journal mode 0640 makes a named
-        // assertion fail.  The owner distinction preserves the packaged
-        // root-owned, read-only config directory while every present v2 object
-        // and writer still require daemon ownership.
+        // writer parent enforcement, restricting the authority-free
+        // absent-locator lane, or accepting journal mode 0640 makes a named
+        // assertion fail.  Every present v2 object and writer still requires
+        // a daemon-owned private parent.
         assert!(LaunchIdentity::resolve(Path::new("/etc/rustbgpd/../config.toml")).is_err());
         assert!(LaunchIdentity::resolve(Path::new("/etc/rustbgpd/.")).is_err());
-        assert!(validate_directory_metadata_values(true, 0, 0o750, 1000, false).is_ok());
-        assert!(validate_directory_metadata_values(true, 0, 0o750, 1000, true).is_err());
+        assert!(validate_directory_metadata_values(true, 0, 0o750, 1000).is_err());
+        assert!(validate_directory_metadata_values(true, 1000, 0o750, 1000).is_ok());
 
         let (_root, config, journal, launch, prior) = fixture();
         fs::set_permissions(config.parent().unwrap(), fs::Permissions::from_mode(0o777)).unwrap();
         assert!(
-            launch.boot_revert_check().is_err(),
-            "locator absence must be established under a pinned safe parent"
+            launch.boot_revert_check().unwrap().is_none(),
+            "locator absence cannot impose v2 storage policy on the launch path"
         );
         assert!(launch.publish(&journal, "deploy-1", 9, &prior).is_err());
         fs::set_permissions(config.parent().unwrap(), fs::Permissions::from_mode(0o700)).unwrap();
 
         let files = launch.publish(&journal, "deploy-1", 9, &prior).unwrap();
+        let candidate = b"unconfirmed candidate under changed parent";
+        fs::write(&config, candidate).unwrap();
+        fs::set_permissions(config.parent().unwrap(), fs::Permissions::from_mode(0o777)).unwrap();
+        assert!(launch.boot_revert_check().is_err());
+        assert_eq!(fs::read(&config).unwrap(), candidate);
+        assert!(launch.locator_path().exists());
+        assert!(journal.exists());
+        fs::set_permissions(config.parent().unwrap(), fs::Permissions::from_mode(0o700)).unwrap();
+
         fs::set_permissions(&journal, fs::Permissions::from_mode(0o640)).unwrap();
         assert!(launch.boot_revert_check().is_err());
         fs::set_permissions(&journal, fs::Permissions::from_mode(0o600)).unwrap();

--- a/src/confirm_journal/v2.rs
+++ b/src/confirm_journal/v2.rs
@@ -100,6 +100,15 @@ impl LaunchIdentity {
 
     fn boot_revert_check_io_with(
         &self,
+        step: impl FnMut(BootStep) -> io::Result<()>,
+    ) -> io::Result<Option<BootRevert>> {
+        self.boot_revert_check_io_with_limits(MAX_LOCATOR_BYTES, MAX_JOURNAL_BYTES, step)
+    }
+
+    fn boot_revert_check_io_with_limits(
+        &self,
+        max_locator_bytes: usize,
+        max_journal_bytes: usize,
         mut step: impl FnMut(BootStep) -> io::Result<()>,
     ) -> io::Result<Option<BootRevert>> {
         // The packaged SIGHUP-only deployment intentionally keeps
@@ -114,8 +123,8 @@ impl LaunchIdentity {
         }
         locator.directory.validate_private()?;
         let (locator_bytes, locator_identity) =
-            locator.read_bounded_identified(MAX_LOCATOR_BYTES)?;
-        let wire = decode_locator(&locator_bytes)?;
+            locator.read_bounded_identified(max_locator_bytes)?;
+        let wire = decode_locator_with_cap(&locator_bytes, max_locator_bytes)?;
 
         let journal_path = path_from_wire(&wire.journal_path)?;
         let journal = Entry::pin(&journal_path)?;
@@ -123,8 +132,8 @@ impl LaunchIdentity {
             return Err(invalid("journal identity is not canonical"));
         }
         let (journal_bytes, journal_identity) =
-            journal.read_bounded_identified(MAX_JOURNAL_BYTES)?;
-        let journal_wire = decode_journal(&journal_bytes)?;
+            journal.read_bounded_identified(max_journal_bytes)?;
+        let journal_wire = decode_journal_with_cap(&journal_bytes, max_journal_bytes)?;
         validate_locator_journal(&wire, &journal_wire, &journal)?;
 
         let recorded_target = path_from_wire(&wire.config_target)?;
@@ -463,18 +472,26 @@ struct Locator {
 }
 
 fn encode_journal(journal: &Journal) -> io::Result<Vec<u8>> {
+    encode_journal_with_cap(journal, MAX_JOURNAL_BYTES)
+}
+
+fn encode_journal_with_cap(journal: &Journal, max_bytes: usize) -> io::Result<Vec<u8>> {
     validate_journal(journal)?;
     let mut bytes = serde_json::to_vec(journal).map_err(invalid)?;
     bytes.push(b'\n');
     if !bytes.starts_with(b"{\"version\":2,") {
         return Err(invalid("v2 journal dispatch prefix changed"));
     }
-    enforce_total_cap("journal", bytes.len(), MAX_JOURNAL_BYTES)?;
+    enforce_total_cap("journal", bytes.len(), max_bytes)?;
     Ok(bytes)
 }
 
 fn decode_journal(bytes: &[u8]) -> io::Result<Journal> {
-    enforce_total_cap("journal", bytes.len(), MAX_JOURNAL_BYTES)?;
+    decode_journal_with_cap(bytes, MAX_JOURNAL_BYTES)
+}
+
+fn decode_journal_with_cap(bytes: &[u8], max_bytes: usize) -> io::Result<Journal> {
+    enforce_total_cap("journal", bytes.len(), max_bytes)?;
     if !bytes.starts_with(b"{\"version\":2,") {
         return Err(invalid("journal is not canonical v2"));
     }
@@ -520,15 +537,23 @@ fn verify_prior_snapshot(snapshot: &AcceptedConfigSnapshot, prior: &Prior) -> io
 }
 
 fn encode_locator(locator: &Locator) -> io::Result<Vec<u8>> {
+    encode_locator_with_cap(locator, MAX_LOCATOR_BYTES)
+}
+
+fn encode_locator_with_cap(locator: &Locator, max_bytes: usize) -> io::Result<Vec<u8>> {
     validate_locator(locator)?;
     let mut bytes = serde_json::to_vec(locator).map_err(invalid)?;
     bytes.push(b'\n');
-    enforce_total_cap("locator", bytes.len(), MAX_LOCATOR_BYTES)?;
+    enforce_total_cap("locator", bytes.len(), max_bytes)?;
     Ok(bytes)
 }
 
 fn decode_locator(bytes: &[u8]) -> io::Result<Locator> {
-    enforce_total_cap("locator", bytes.len(), MAX_LOCATOR_BYTES)?;
+    decode_locator_with_cap(bytes, MAX_LOCATOR_BYTES)
+}
+
+fn decode_locator_with_cap(bytes: &[u8], max_bytes: usize) -> io::Result<Locator> {
+    enforce_total_cap("locator", bytes.len(), max_bytes)?;
     let locator: Locator = serde_json::from_slice(bytes).map_err(invalid)?;
     validate_locator(&locator)?;
     if encode_locator(&locator)? != bytes {
@@ -1006,6 +1031,10 @@ impl Entry {
 
         let stage = self.stage_name()?;
         self.cleanup_stage()?;
+        let stage_entry = Self {
+            directory: Arc::clone(&self.directory),
+            name: stage.clone(),
+        };
         let fd = openat(
             &self.directory.file,
             Path::new(&stage),
@@ -1044,7 +1073,10 @@ impl Entry {
             self.directory.file.sync_all()
         })();
         if result.is_err() {
-            let _ = remove_named_safe(&self.directory.file, &stage);
+            // A hook or same-uid actor can replace the stage name after this
+            // attempt captured its inode.  Error cleanup may remove only the
+            // inode this publication created, never the replacement.
+            let _ = stage_entry.remove_matching(identity);
             if !replace {
                 let _ = self.remove_matching(identity);
             }
@@ -1427,10 +1459,9 @@ log_format = "json"
     }
 
     #[test]
-    fn component_and_total_caps_accept_maximum_and_reject_plus_one() {
-        // Destructive proof: changing either `>` to `>=`, dropping the
-        // confirm/path check, or decoding before the total cap breaks a named
-        // boundary below.
+    fn component_caps_accept_maximum_and_reject_plus_one() {
+        // Destructive proof: changing either component `>` to `>=` or
+        // dropping the confirm/path check breaks a named boundary below.
         let mut prior = small_prior();
         prior.normalized_toml = "x".repeat(history_v2::MAX_TOML);
         prior.sha256 = Sha256::digest(prior.normalized_toml.as_bytes()).into();
@@ -1452,14 +1483,6 @@ log_format = "json"
         assert!(encode_journal(&journal).is_err());
         journal.confirm_id = "   ".to_string();
         assert!(encode_journal(&journal).is_err());
-        assert!(enforce_total_cap("journal", MAX_JOURNAL_BYTES, MAX_JOURNAL_BYTES).is_ok());
-        let journal_error =
-            enforce_total_cap("journal", MAX_JOURNAL_BYTES + 1, MAX_JOURNAL_BYTES).unwrap_err();
-        assert!(journal_error.to_string().contains("journal exceeds"));
-        assert!(enforce_total_cap("locator", MAX_LOCATOR_BYTES, MAX_LOCATOR_BYTES).is_ok());
-        let locator_error =
-            enforce_total_cap("locator", MAX_LOCATOR_BYTES + 1, MAX_LOCATOR_BYTES).unwrap_err();
-        assert!(locator_error.to_string().contains("locator exceeds"));
 
         let path = format!("/{}", "x".repeat(MAX_PATH_BYTES - 1));
         let mut locator = Locator {
@@ -1473,6 +1496,55 @@ log_format = "json"
         assert!(validate_locator(&locator).is_ok());
         locator.journal_path.0.push(b'x');
         assert!(validate_locator(&locator).is_err());
+    }
+
+    #[test]
+    fn journal_and_locator_codec_total_caps_are_load_bearing() {
+        // Destructive proof: removing the encoder cap makes the N-1 encode
+        // succeed; removing the decoder cap makes the identical canonical
+        // N-byte wire decode successfully under N-1.  These call the same
+        // helpers as the production-constant wrappers above.
+        let prior = small_prior();
+        let journal = Journal {
+            version: VERSION,
+            confirm_id: "deploy-1".into(),
+            deadline_unix_seconds: 9,
+            rollback_failed: false,
+            prior: prior.clone(),
+        };
+        let journal_wire = encode_journal(&journal).unwrap();
+        let journal_max = journal_wire.len();
+        assert_eq!(
+            encode_journal_with_cap(&journal, journal_max).unwrap(),
+            journal_wire
+        );
+        assert_eq!(
+            decode_journal_with_cap(&journal_wire, journal_max).unwrap(),
+            journal
+        );
+        assert!(encode_journal_with_cap(&journal, journal_max - 1).is_err());
+        assert!(decode_journal_with_cap(&journal_wire, journal_max - 1).is_err());
+
+        let locator = Locator {
+            version: VERSION,
+            confirm_id: "deploy-1".into(),
+            journal_path: LosslessPath(b"/state/commit-confirm-journal.json".to_vec()),
+            config_target: LosslessPath(b"/etc/rustbgpd/config.toml".to_vec()),
+            prior_sha256: prior.sha256,
+            prior_source_sha256: prior.source_sha256,
+        };
+        let locator_wire = encode_locator(&locator).unwrap();
+        let locator_max = locator_wire.len();
+        assert_eq!(
+            encode_locator_with_cap(&locator, locator_max).unwrap(),
+            locator_wire
+        );
+        assert_eq!(
+            decode_locator_with_cap(&locator_wire, locator_max).unwrap(),
+            locator
+        );
+        assert!(encode_locator_with_cap(&locator, locator_max - 1).is_err());
+        assert!(decode_locator_with_cap(&locator_wire, locator_max - 1).is_err());
     }
 
     #[test]
@@ -1539,6 +1611,30 @@ log_format = "json"
         assert!(result.is_err());
         assert!(!launch.locator_path().exists());
         assert!(journal.exists(), "replacement journal must survive cleanup");
+    }
+
+    #[test]
+    fn publication_failure_preserves_same_name_stage_replacement() {
+        // Destructive proof: name-only stage cleanup deletes this replacement
+        // after the publisher has captured a different inode.  Error cleanup
+        // must be bound to the exact stage identity created by this attempt.
+        let (_root, _config, journal, launch, prior) = fixture();
+        let stage =
+            journal.with_file_name(append_name(journal.file_name().unwrap(), b".tmp").unwrap());
+        let replacement = b"same-name replacement stage";
+        let result = launch.publish_with(&journal, "deploy-1", 9, &prior, |step| {
+            if step == PublishStep::JournalStageSync {
+                fs::remove_file(&stage).unwrap();
+                fs::write(&stage, replacement).unwrap();
+                fs::set_permissions(&stage, fs::Permissions::from_mode(0o600)).unwrap();
+                return Err(io::Error::other("injected journal stage failure"));
+            }
+            Ok(())
+        });
+        assert!(result.is_err());
+        assert!(!launch.locator_path().exists());
+        assert!(!journal.exists());
+        assert_eq!(fs::read(stage).unwrap(), replacement);
     }
 
     #[test]
@@ -1626,6 +1722,53 @@ log_format = "json"
         );
         assert!(!launch.locator_path().exists());
         assert!(!journal.exists());
+    }
+
+    #[test]
+    fn boot_reader_accepts_exact_journal_cap_and_rejects_plus_one_before_candidate_work() {
+        // Destructive proof: removing the boot reader's journal cap lets the
+        // N-byte journal pass an N-1 limit, increments the candidate-work
+        // hook, and replaces the candidate.  The exact N boundary traverses
+        // the real reader, provenance check, restore, and terminal cleanup.
+        let (_root, config, journal, launch, prior) = fixture();
+        let prior_bytes = prior.normalized_toml().as_bytes().to_vec();
+        let files = launch.publish(&journal, "deploy-1", 9, &prior).unwrap();
+        let locator_bytes = fs::read(launch.locator_path()).unwrap();
+        let journal_bytes = fs::read(&journal).unwrap();
+        fs::write(&config, b"unconfirmed candidate").unwrap();
+        drop(files);
+
+        let reverted = launch
+            .boot_revert_check_io_with_limits(locator_bytes.len(), journal_bytes.len(), |_| Ok(()))
+            .unwrap()
+            .unwrap();
+        assert_eq!(reverted.accepted.normalized_toml().as_bytes(), prior_bytes);
+        assert_eq!(fs::read(&config).unwrap(), prior_bytes);
+        assert!(!launch.locator_path().exists());
+        assert!(!journal.exists());
+
+        let (_root, config, journal, launch, prior) = fixture();
+        let files = launch.publish(&journal, "deploy-2", 9, &prior).unwrap();
+        let locator_bytes = fs::read(launch.locator_path()).unwrap();
+        let journal_bytes = fs::read(&journal).unwrap();
+        let candidate = b"second unconfirmed candidate";
+        fs::write(&config, candidate).unwrap();
+        drop(files);
+        let candidate_steps = std::cell::Cell::new(0usize);
+
+        let result = launch.boot_revert_check_io_with_limits(
+            locator_bytes.len(),
+            journal_bytes.len() - 1,
+            |_| {
+                candidate_steps.set(candidate_steps.get() + 1);
+                Ok(())
+            },
+        );
+        assert!(result.is_err());
+        assert_eq!(candidate_steps.get(), 0);
+        assert_eq!(fs::read(&config).unwrap(), candidate);
+        assert!(launch.locator_path().exists());
+        assert!(journal.exists());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2507,11 +2507,59 @@ fn main() -> ExitCode {
         process::exit(1);
     }
 
-    let mut accepted = match AcceptedConfigSnapshot::load(Path::new(&config_path), None) {
-        Ok(snapshot) => Arc::new(snapshot),
-        Err(diagnostic) => {
-            eprintln!("{diagnostic}");
-            process::exit(1);
+    // The v2 locator is config-adjacent and must be resolved before a real
+    // daemon boot opens, sizes, or parses the candidate.  One-shot validation
+    // and diff modes remain read-only and therefore do not inspect or consume
+    // pending commit-confirm state.
+    let launch_identity = if !check_only && diff_path.is_none() {
+        Some(
+            confirm_journal::v2::LaunchIdentity::resolve(Path::new(&config_path)).unwrap_or_else(
+                |error| {
+                    eprintln!(
+                        "error: invalid launch config identity for commit-confirm authority: {error}"
+                    );
+                    process::exit(1);
+                },
+            ),
+        )
+    } else {
+        None
+    };
+    let mut boot_revert_notice = None;
+    let mut accepted = if let Some(identity) = &launch_identity {
+        match identity.boot_revert_check() {
+            Ok(Some(revert)) => {
+                boot_revert_notice = Some(confirm_journal::BootRevertNotice {
+                    confirm_id: revert.notice.confirm_id,
+                    backup_path: PathBuf::new(),
+                    rollback_failed: revert.notice.rollback_failed,
+                    redact_paths: true,
+                    journal_cleanup_failed: revert.notice.journal_cleanup_failed,
+                });
+                revert.accepted
+            }
+            Ok(None) => match AcceptedConfigSnapshot::load(Path::new(&config_path), None) {
+                Ok(snapshot) => Arc::new(snapshot),
+                Err(diagnostic) => {
+                    eprintln!("{diagnostic}");
+                    process::exit(1);
+                }
+            },
+            Err(message) => {
+                eprintln!(
+                    "error: {message}; locator: {}",
+                    identity.locator_path().display()
+                );
+                process::exit(1);
+            }
+        }
+    } else {
+        match AcceptedConfigSnapshot::load(Path::new(&config_path), None) {
+            Ok(snapshot) => Arc::new(snapshot),
+            Err(diagnostic) => {
+                eprintln!("{diagnostic}");
+                process::exit(1);
+            }
         }
     };
     let mut config = accepted.config();
@@ -2586,28 +2634,30 @@ fn main() -> ExitCode {
     // journal that exists but cannot drive a revert refuses boot (fail
     // closed). Runs only for real daemon startup: --check/--diff returned
     // above and must never mutate config files.
-    let boot_revert_notice = match confirm_journal::boot_revert_check(
-        &confirm_journal::journal_path(&config.runtime_state_dir()),
-        Path::new(&config_path),
-    ) {
-        Ok(None) => None,
-        Ok(Some(revert)) => {
-            drop(revert.config);
-            accepted = match AcceptedConfigSnapshot::load(Path::new(&config_path), None) {
-                Ok(snapshot) => Arc::new(snapshot),
-                Err(diagnostic) => {
-                    eprintln!("{diagnostic}");
-                    process::exit(1);
-                }
-            };
-            config = accepted.config();
-            Some(revert.notice)
-        }
-        Err(message) => {
-            eprintln!("error: {message}");
-            process::exit(1);
-        }
-    };
+    if boot_revert_notice.is_none() {
+        boot_revert_notice = match confirm_journal::boot_revert_check(
+            &confirm_journal::journal_path(&config.runtime_state_dir()),
+            Path::new(&config_path),
+        ) {
+            Ok(None) => None,
+            Ok(Some(revert)) => {
+                drop(revert.config);
+                accepted = match AcceptedConfigSnapshot::load(Path::new(&config_path), None) {
+                    Ok(snapshot) => Arc::new(snapshot),
+                    Err(diagnostic) => {
+                        eprintln!("{diagnostic}");
+                        process::exit(1);
+                    }
+                };
+                config = accepted.config();
+                Some(revert.notice)
+            }
+            Err(message) => {
+                eprintln!("error: {message}");
+                process::exit(1);
+            }
+        };
+    }
 
     let log_directives = config.per_peer_log_directives();
     if let Err(e) = init_logging(&log_directives) {
@@ -2637,7 +2687,12 @@ fn main() -> ExitCode {
         .enable_all()
         .build()
         .unwrap_or_else(|e| fatal_startup_error("failed to create tokio runtime", e));
-    let grpc_server_failed = rt.block_on(run(accepted, boot_revert_notice, profiler));
+    let grpc_server_failed = rt.block_on(run(
+        accepted,
+        boot_revert_notice,
+        launch_identity.expect("daemon boot resolved launch config identity"),
+        profiler,
+    ));
     shutdown_daemon_runtime(rt);
     if grpc_server_failed {
         // The coordinated teardown already ran (NOTIFICATIONs, GR marker,
@@ -2856,6 +2911,7 @@ fn resolve_rib_channel_capacity_from(env: Option<&str>) -> usize {
 async fn run<T>(
     accepted: Arc<AcceptedConfigSnapshot>,
     boot_revert_notice: Option<confirm_journal::BootRevertNotice>,
+    launch_identity: confirm_journal::v2::LaunchIdentity,
     profiler: Option<T>,
 ) -> bool {
     let mut config = accepted.config();
@@ -3106,12 +3162,20 @@ async fn run<T>(
         // Boot-time revert of an unconfirmed commit-confirmed transaction
         // (ADR-0076 Decision 6). Loud on purpose: the operator's last change
         // was undone and its candidate saved aside.
-        error!(
-            confirm_id = %notice.confirm_id,
-            unconfirmed_candidate = %notice.backup_path.display(),
-            rollback_failed = notice.rollback_failed,
-            "commit-confirmed transaction was never confirmed before the last shutdown — reverted to the pre-transaction config at boot; the unconfirmed candidate config was saved aside"
-        );
+        if notice.redact_paths {
+            error!(
+                confirm_id = %notice.confirm_id,
+                rollback_failed = notice.rollback_failed,
+                "commit-confirmed transaction was never confirmed before the last shutdown — verified and reverted to the pre-transaction config at boot; the unconfirmed candidate was saved beside its recorded target"
+            );
+        } else {
+            error!(
+                confirm_id = %notice.confirm_id,
+                unconfirmed_candidate = %notice.backup_path.display(),
+                rollback_failed = notice.rollback_failed,
+                "commit-confirmed transaction was never confirmed before the last shutdown — reverted to the pre-transaction config at boot; the unconfirmed candidate config was saved aside"
+            );
+        }
         eprintln!(
             "!! commit-confirm boot revert: transaction {:?} was never confirmed before the last shutdown.",
             notice.confirm_id
@@ -3124,13 +3188,24 @@ async fn run<T>(
                 "!! A live rollback of this transaction FAILED before the restart, so the pre-restart on-disk state was uncertain."
             );
         }
-        eprintln!(
-            "!! Booted from the pre-transaction config; the unconfirmed candidate was saved to {}.",
-            notice.backup_path.display()
-        );
-        // A `BootRevertNotice` only exists when the revert fully succeeded
-        // (config restored AND journal consumed); a journal-cleanup failure
-        // fails startup upstream (LAN-219), so there is no failure branch here.
+        if notice.redact_paths {
+            eprintln!(
+                "!! Booted from the verified pre-transaction config; the unconfirmed candidate was saved beside its recorded target."
+            );
+        } else {
+            eprintln!(
+                "!! Booted from the pre-transaction config; the unconfirmed candidate was saved to {}.",
+                notice.backup_path.display()
+            );
+        }
+        if notice.journal_cleanup_failed {
+            warn!(
+                "commit-confirm boot revert reached durable terminal locator removal, but exact journal residue cleanup failed"
+            );
+        }
+        // A `BootRevertNotice` exists only after the revert is terminal. V1
+        // still requires journal consumption; v2 becomes terminal at durable
+        // locator absence and reports later journal cleanup as a warning.
         metrics.record_config_transaction_lifecycle("boot_revert", "success");
     }
     let router_id: Ipv4Addr = config.global.router_id.parse().unwrap_or_else(|e| {
@@ -4308,7 +4383,8 @@ async fn run<T>(
                 .expect("daemon config transactions require accepted-config authority")
                 .clone(),
         )
-        .with_preloaded_planner(peer_mgr_internal_tx.clone());
+        .with_preloaded_planner(peer_mgr_internal_tx.clone())
+        .with_confirm_v2_launch(launch_identity);
     // Process-wide availability gate (LAN-286): BGP-listener bind failure
     // turns readiness red; coordinated shutdown turns readiness red AND
     // stops admitting persisted config mutations and inbound BGP sessions.

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -27,6 +27,7 @@
 
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
+use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::thread;
@@ -427,6 +428,8 @@ fn epoch_from_timestamp(s: &str) -> u64 {
 #[test]
 fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_subset() {
     let temp = tempfile::tempdir().expect("create temp dir");
+    std::fs::set_permissions(temp.path(), std::fs::Permissions::from_mode(0o700))
+        .expect("make temp dir private");
     let adapter_port = free_port();
 
     // Spawn the daemon (serves gRPC). Structured logs go to stdout,

--- a/tests/commit_confirm_binary.rs
+++ b/tests/commit_confirm_binary.rs
@@ -4,22 +4,26 @@
 //! default runtime-dir UDS listener, then SIGKILLs the daemon to prove the
 //! boot-time revert journal closes the "confirmed-by-restart" hole:
 //!
-//! - unconfirmed window + SIGKILL → restart boots the PREVIOUS config, saves
-//!   the unconfirmed candidate aside, consumes the journal, and prints the
-//!   loud banner;
-//! - confirm + SIGKILL → the new config is retained and no journal remains;
-//! - in-process timeout auto-revert → the journal is consumed;
+//! - unconfirmed window + SIGKILL → restart follows the config-adjacent v2
+//!   locator, boots the PREVIOUS config, saves the unconfirmed candidate aside,
+//!   consumes both pending files, and prints a path-redacted loud banner;
+//! - confirm + SIGKILL → the new config is retained and no v2 pending files
+//!   remain;
+//! - in-process timeout auto-revert → both v2 pending files are consumed;
 //! - v2 history survives restart and restores only after source verification
 //!   is available;
-//! - torn journal on disk → boot refuses, naming both files.
+//! - a torn legacy journal with no v2 locator → boot still refuses, naming
+//!   both legacy files.
 
 use std::fs::File;
+use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
 const JOURNAL_FILE_NAME: &str = "commit-confirm-journal.json";
+const LOCATOR_SUFFIX: &str = ".commit-confirm-locator.json";
 
 struct Daemon {
     child: Child,
@@ -128,6 +132,7 @@ struct Lab {
     config_path: PathBuf,
     candidate_path: PathBuf,
     journal_path: PathBuf,
+    locator_path: PathBuf,
     grpc_addr: String,
     dir: PathBuf,
 }
@@ -170,9 +175,19 @@ remote_asn = 65010
 
 /// Set up config + candidate files in `dir` and return the paths.
 fn lab(dir: &Path) -> Lab {
+    // Causal destructive-red proof: removing either privacy clamp makes the
+    // real v2 publisher reject the locator or journal parent before candidate
+    // persistence, so every confirmed-apply scenario fails at `apply`.
+    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
+        .expect("failed to make config parent owner-only");
     let runtime_dir = dir.join("runtime");
     std::fs::create_dir_all(&runtime_dir).expect("failed to create runtime dir");
+    std::fs::set_permissions(&runtime_dir, std::fs::Permissions::from_mode(0o700))
+        .expect("failed to make runtime state dir owner-only");
     let config_path = dir.join("rustbgpd.toml");
+    let mut locator_path = config_path.clone().into_os_string();
+    locator_path.push(LOCATOR_SUFFIX);
+    let locator_path = PathBuf::from(locator_path);
     let base = base_toml(&runtime_dir, "");
     let parsed: toml::Value = toml::from_str(&base).expect("base config must parse");
     let principal = "rustbgpd://operator/commit-confirm-test";
@@ -200,6 +215,7 @@ fn lab(dir: &Path) -> Lab {
         config_path,
         candidate_path,
         journal_path: runtime_dir.join(JOURNAL_FILE_NAME),
+        locator_path,
         grpc_addr: format!("unix://{}", runtime_dir.join("grpc.sock").display()),
         dir: dir.to_path_buf(),
     }
@@ -258,7 +274,21 @@ impl Lab {
         );
         assert!(
             self.journal_path.exists(),
-            "confirmed apply must write the revert journal"
+            "confirmed apply must write the v2 revert journal"
+        );
+        assert!(
+            self.locator_path.exists(),
+            "confirmed apply must publish the v2 locator last"
+        );
+        let journal = std::fs::read(&self.journal_path).unwrap();
+        let locator = std::fs::read(&self.locator_path).unwrap();
+        assert!(
+            journal.starts_with(b"{\"version\":2,"),
+            "real-binary writer must emit only the canonical v2 journal"
+        );
+        assert!(
+            locator.starts_with(b"{\"version\":2,"),
+            "real-binary writer must emit the canonical v2 locator"
         );
     }
 }
@@ -291,13 +321,27 @@ fn sigkill_in_confirm_window_boots_previous_config_and_saves_candidate_aside() {
         !lab.journal_path.exists(),
         "boot revert must consume the journal"
     );
+    assert!(
+        !lab.locator_path.exists(),
+        "boot revert must durably remove locator authority first"
+    );
     let stderr = daemon.stderr();
     assert!(
         stderr.contains("commit-confirm boot revert")
             && stderr.contains("kill-window")
-            && stderr.contains("rustbgpd.toml.unconfirmed"),
-        "boot banner must name the transaction and the saved-aside file:\n{stderr}"
+            && stderr.contains("saved beside its recorded target"),
+        "boot banner must name the transaction without exposing paths:\n{stderr}"
     );
+    for secret in [
+        backup_path.to_string_lossy().as_ref(),
+        lab.config_path.to_string_lossy().as_ref(),
+        lab.journal_path.to_string_lossy().as_ref(),
+    ] {
+        assert!(
+            !stderr.contains(secret),
+            "v2 boot banner must redact persisted path {secret:?}:\n{stderr}"
+        );
+    }
 
     // The reverted daemon is running the previous config.
     let ranges = rbgp_json(&lab.grpc_addr, &["--json", "dynamic-neighbor", "list"]);
@@ -324,6 +368,10 @@ fn confirm_then_sigkill_retains_new_config_and_leaves_no_journal() {
     assert!(
         !lab.journal_path.exists(),
         "confirm must consume the revert journal"
+    );
+    assert!(
+        !lab.locator_path.exists(),
+        "confirm must durably remove locator authority"
     );
     daemon.sigkill();
 
@@ -373,6 +421,10 @@ fn in_process_timeout_auto_revert_consumes_journal() {
         !lab.journal_path.exists(),
         "timeout auto-revert must consume the revert journal"
     );
+    assert!(
+        !lab.locator_path.exists(),
+        "timeout auto-revert must durably remove locator authority"
+    );
     let on_disk = std::fs::read_to_string(&lab.config_path).unwrap();
     assert!(
         !on_disk.contains("192.0.2.0/24"),
@@ -385,6 +437,9 @@ fn in_process_timeout_auto_revert_consumes_journal() {
 fn torn_journal_refuses_boot_naming_both_files() {
     let temp = tempfile::tempdir().expect("failed to create temp dir");
     let lab = lab(temp.path());
+    // Causal destructive-red proof for the retained compatibility lane: if
+    // locator absence stops dispatching v1, this truncated legacy journal no
+    // longer produces the exact fail-closed refusal below.
     // Truncated mid-JSON, as a crash during a non-atomic write would leave.
     std::fs::write(&lab.journal_path, "{\"confirm_id\": \"deploy-1\", \"dead")
         .expect("failed to write torn journal");
@@ -531,6 +586,7 @@ fn v2_history_survives_restart_and_restores_after_source_verification() {
         "candidate must still be active before rollback:\n{on_disk}"
     );
     assert!(!lab.journal_path.exists());
+    assert!(!lab.locator_path.exists());
 
     // The retained manifest is verification authority, not adoption authority:
     // changed live external bytes refuse without touching runtime or disk.
@@ -578,5 +634,6 @@ fn v2_history_survives_restart_and_restores_after_source_verification() {
         "restoring a non-newest generation must append an accepted receipt"
     );
     assert!(!lab.journal_path.exists());
+    assert!(!lab.locator_path.exists());
     daemon.assert_still_running();
 }

--- a/tests/evpn_dataplane_rr_only.rs
+++ b/tests/evpn_dataplane_rr_only.rs
@@ -18,6 +18,7 @@
 //! work.
 
 use std::fs::File;
+use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
 use std::thread;
@@ -200,6 +201,8 @@ principal = "rustbgpd://operator/evpn-rr-test"
 #[test]
 fn rr_only_deployment_does_not_spawn_evpn_dataplane_actor() {
     let temp = tempfile::tempdir().expect("failed to create temp dir");
+    std::fs::set_permissions(temp.path(), std::fs::Permissions::from_mode(0o700))
+        .expect("make temp dir private");
     let config_path = write_config(temp.path());
     let grpc_sock = temp.path().join("runtime").join("grpc.sock");
     let grpc_addr = format!("unix://{}", grpc_sock.display());

--- a/tests/evpn_instances_binary.rs
+++ b/tests/evpn_instances_binary.rs
@@ -1,4 +1,5 @@
 use std::fs::File;
+use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
 use std::thread;
@@ -225,6 +226,8 @@ fn removed_adoption_accept_legacy_env_hard_errors_at_boot() {
 #[test]
 fn daemon_binary_surfaces_configured_evpn_instances_through_rbgp() {
     let temp = tempfile::tempdir().expect("failed to create temp dir");
+    std::fs::set_permissions(temp.path(), std::fs::Permissions::from_mode(0o700))
+        .expect("make temp dir private");
     let config_path = write_config(temp.path());
     let grpc_sock = temp.path().join("runtime").join("grpc.sock");
     let grpc_addr = format!("unix://{}", grpc_sock.display());

--- a/tests/grpc_failure_exit_code.rs
+++ b/tests/grpc_failure_exit_code.rs
@@ -8,10 +8,18 @@
 //! failing to bind, and the metrics/readiness listener failing to bind.
 
 use std::net::{TcpListener, TcpStream};
+use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
+
+fn private_tempdir() -> tempfile::TempDir {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    std::fs::set_permissions(temp.path(), std::fs::Permissions::from_mode(0o700))
+        .expect("make temp dir private");
+    temp
+}
 
 struct Daemon {
     child: Child,
@@ -133,7 +141,7 @@ fn free_port() -> u16 {
 
 #[test]
 fn grpc_bind_failure_exits_nonzero() {
-    let temp = tempfile::tempdir().expect("create temp dir");
+    let temp = private_tempdir();
     // Hold the gRPC port so the daemon's listener bind fails with
     // AddrInUse — the gRPC server task exits, which must shut the
     // daemon down with a non-zero exit code.
@@ -153,7 +161,7 @@ fn grpc_bind_failure_exits_nonzero() {
 
 #[test]
 fn metrics_listener_bind_failure_exits_nonzero() {
-    let temp = tempfile::tempdir().expect("create temp dir");
+    let temp = private_tempdir();
     let occupied = TcpListener::bind("127.0.0.1:0").expect("bind occupied metrics port");
     let metrics_port = occupied.local_addr().unwrap().port();
     let config_path =
@@ -183,7 +191,7 @@ fn metrics_listener_bind_failure_exits_nonzero() {
 
 #[test]
 fn bgp_listener_bind_failure_exits_nonzero() {
-    let temp = tempfile::tempdir().expect("create temp dir");
+    let temp = private_tempdir();
     // Hold the BGP listen port with a live listener. SO_REUSEADDR lets a
     // new generation rebind over a closed-but-lingering endpoint, never
     // over an active LISTEN, so this bind genuinely fails — and a daemon
@@ -208,7 +216,7 @@ fn bgp_listener_bind_failure_exits_nonzero() {
 
 #[test]
 fn sigterm_exits_zero() {
-    let temp = tempfile::tempdir().expect("create temp dir");
+    let temp = private_tempdir();
 
     // `free_port()` is bind-then-release, so a parallel workspace test can
     // steal the port before the daemon binds it; the daemon then exits

--- a/tests/quickstart_dynamic_neighbor.rs
+++ b/tests/quickstart_dynamic_neighbor.rs
@@ -5,6 +5,7 @@
 //! itself, and proves runtime apply plus durable persistence.
 
 use std::fs::File;
+use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
 use std::thread;
@@ -249,6 +250,8 @@ fn strict_check(config_path: &Path) -> Output {
 
 fn run_starter(label: &str, source: &str, group_json: &str, commands: &[String]) {
     let temp = tempfile::tempdir().expect("create scenario tempdir");
+    std::fs::set_permissions(temp.path(), std::fs::Permissions::from_mode(0o700))
+        .expect("make temp dir private");
     let runtime_dir = temp.path().join(format!("{label}-runtime"));
     std::fs::create_dir_all(&runtime_dir).expect("create runtime dir");
     let config_path = temp.path().join("config.toml");


### PR DESCRIPTION
## Summary

LAN-798 activates ADR-0121's provenance-bearing commit-confirm v2 contract end to end.

- New confirmed applies persist the exact immutable prior `AcceptedConfigSnapshot`: normalized TOML, the complete external-source manifest, and its source digest. External policy or dataset bytes are verified at recovery time; they are never copied into the journal.
- A config-adjacent locator becomes the authority for an in-flight v2 transaction. The journal and then the locator are durably published before candidate persistence or runtime mutation.
- Boot, abort, and timeout recovery verify locator/journal identity, launch-target identity, and prior provenance before touching the candidate or pending runtime state. The same accepted snapshot generation is retained across the peer-manager await.
- Confirm and successful rollback become terminal when locator absence is durable. Journal cleanup is exact-inode/canonical-content only and warning-only after that terminal point.
- Valid locator-absent v1 journals retain bounded legacy recovery. New transactions write v2 only; there is no dual-write or live conversion lane.

## Safety boundaries

- Locator and journal objects are opened descriptor-relative with no symlink following, bounded reads, same-FD owner/type/mode checks, canonical encoding, and aggregate size caps.
- Present v2 state and all writers require daemon-owned private parents. Locator absence carries no authority and adds no v2 owner/mode policy to an ordinary launch path.
- The resolved config-target parent is pinned before publication, preventing a symlinked launch path from creating a transaction the boot reader would reject.
- Terminal/error cleanup removes only the exact object that was accepted or created; a same-name replacement survives.
- The existing #1370 full-snapshot fencing, native/gNMI behavior, targeted pure-FIB path, and true no-op exception remain intact.
- Persisted paths, digests, and raw filesystem errors remain redacted from ordinary logs and operator output.

## Load-bearing regression proof

Each new or materially changed proof was destructively checked. The mutation named below made the corresponding assertion red, then was restored before the final gates.

<details>
<summary>Codec, storage, and crash-order proofs</summary>

- `canonical_journal_and_locator_pin_dispatch_and_field_order`: changing dispatch/canonical field order or line termination breaks the exact byte assertions.
- `component_caps_accept_maximum_and_reject_plus_one`: changing either component boundary or dropping confirm/path validation admits its named hostile fixture.
- `journal_and_locator_codec_total_caps_are_load_bearing`: removing any one of the four real encoder/decoder cap call sites independently admits its canonical N-byte wire at an N-1 limit.
- `publication_is_journal_then_locator_and_every_failure_precedes_candidate_work`: removing exact cleanup leaves a journal at the injected directory-sync failure; reordering lets a later stage appear before its predecessor.
- `publication_failure_preserves_same_name_journal_replacement`: restoring broad residue cleanup deletes the replacement inode.
- `publication_failure_preserves_same_name_stage_replacement`: restoring name-only error cleanup deletes a same-name temporary-file replacement after the publisher captured a different inode.
- `writer_removes_only_canonical_v2_final_residue`: broadening pre-publication cleanup removes non-canonical or non-v2 residue.
- `matching_v2_boot_verifies_then_restores_and_cleans_terminally`: removing verified restore or terminal cleanup leaves the candidate/authority in the wrong state.
- `boot_reader_accepts_exact_journal_cap_and_rejects_plus_one_before_candidate_work`: bypassing the real boot reader/decode limits lets an N-byte journal cross an N-1 boundary and begin candidate work.
- `boot_hooks_fail_before_each_named_operation_and_preserve_authority_order`: moving or omitting a boot step violates the injected stage/order state.
- `locator_presence_is_fail_closed_and_never_falls_back`: permitting v1 fallback with any locator present accepts the invalid-present fixture.
- `provenance_mismatch_touches_no_candidate_backup_or_pending_state`: moving mutation before verification changes the sentinel files.
- `locator_journal_field_mismatch_touches_nothing`: dropping locator/journal identity equality accepts the mismatched confirm ID.
- `all_locator_and_journal_presence_states_dispatch_exactly`: changing any of the six presence-state dispatch outcomes breaks its matrix cell.
- `locator_absent_dispatch_classifies_reads_and_cleans_one_inode`: broad cleanup or altered locator-absent classification changes the exact inode roster.
- `symlink_target_binding_detects_retarget_and_restores_dangling_target`: dropping launch-target binding accepts a retargeted symlink or fails the recorded dangling target restore.
- `writer_rejects_unsafe_resolved_target_parent_before_publication`: removing resolved-target parent pinning lets publication succeed.
- `dangling_target_keeps_canonical_identity_through_symlinked_intermediate`: lexical rather than canonical target binding changes the recorded identity.
- `descriptor_read_never_reopens_checked_name_and_detects_growth`: reopening by name consumes the swapped file; removing the post-read size check accepts growth.
- `v2_pending_metadata_owner_type_mode_and_size_are_fail_closed`: removing owner/type/mode/oversize checks accepts the corresponding invalid object.
- `terminal_cleanup_requires_the_published_inode_even_for_identical_bytes`: name/bytes-only cleanup deletes the replacement inode.
- `lexical_parentdir_present_state_and_unsafe_metadata_refuse`: restoring parent policy to the authority-free absence branch rejects an ordinary mode-0777 launch path; weakening writer/present-state checks accepts a named hostile fixture.
- `present_locator_rejects_changed_unsafe_lexical_parent_before_candidate_work`: deleting the retained present-locator parent validation lets the hook repair the parent after the missing check and restores the candidate through the distinct target parent.
- `absent_locator_preserves_root_owned_read_only_config_parent`: replacing absence-only pinning with the writer pin rejects the packaged parent.
- `terminal_locator_sync_precedes_warning_only_journal_cleanup`: moving the terminal point or making later journal cleanup fatal changes the injected outcomes.

</details>

<details>
<summary>Runtime, fencing, and real-binary proofs</summary>

- `accepted_prior_snapshot_keeps_one_provenance_generation_across_await`: re-borrowing the watch after the peer-manager reply pairs source B's digest with source A's runtime snapshot.
- `v2_external_fib_abort_reuses_exact_prior_and_is_terminal`: rebuilding/re-reading the prior or leaving authority armed changes the restored Arc/terminal state.
- `v2_activation_preserves_native_and_gnmi_full_snapshot_fence`: deleting the real planner guard lets the native or gNMI full-snapshot case apply.
- `v2_activation_preserves_external_true_noop_exception`: removing the exact no-op exception rejects the unchanged external-policy transaction.
- `v2_external_fib_timeout_reuses_prior_after_source_mutation`: re-reading mutated external bytes changes the timed rollback result.
- `v2_confirm_is_terminal_before_journal_cleanup`: making journal cleanup part of terminal success turns the injected cleanup failure into a failed confirm.
- `boot_check_without_runtime_state_directory_is_normal_boot`: eagerly pinning the missing v2 parent turns ordinary first boot into an error.
- `commit_confirm_binary` scenarios: disabling v2 publication, locator-last ordering, terminal locator removal, path redaction, or locator-absent v1 dispatch breaks the real-daemon assertions.
- The birdwatcher, EVPN, gRPC-exit, and quickstart fixtures now explicitly create private synthetic config parents; reverting those clamps makes startup fail the production parent-safety check before their existing assertions run.

</details>

## Scope

- 20 files, +3,496/-172
- At most 1,726 non-test production Rust additions by a conservative pre-test-module count (cap: 2,200)
- One new production module; no dependency, proto, or public API change

## Gates

- `cargo fmt --all -- --check`
- `python3 scripts/check-clippy-reasons.py`
- `python3 scripts/check-v1-stable-surface.py`
- Focused v2/legacy journal, config-history, transaction-controller, real-binary, birdwatcher, EVPN, gRPC-exit, and quickstart tests
- Real M24 containerlab interoperability receipt: 7 passed, 0 failed with the daemon launched from `/tmp/config.toml`
- Real M43 TCP-AO/BIRD containerlab receipt: 25 passed, 0 failed with the daemon launched from `/tmp/m43-config.toml`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --workspace --no-deps`
- `git diff --check`
