### PR TITLE
feat(cli): make top route events lag-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **Lag-aware `rbgp top` route events.** The optional event panel now uses the
   typed `WatchEvents` route stream, renders policy source/target/reason and
-  Add-Path ID, and shows exact stream-gap counts. Older daemons fall back only
+  Add-Path ID, and shows exact missed-event counts. Older daemons fall back only
   when `WatchEvents` is unimplemented and retain an explicit degraded warning.
 
 - **Actionable authorization denials and `rbgp doctor` authz triage.** gRPC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Lag-aware `rbgp top` route events.** The optional event panel now uses the
+  typed `WatchEvents` route stream, renders policy source/target/reason and
+  Add-Path ID, and shows exact stream-gap counts. Older daemons fall back only
+  when `WatchEvents` is unimplemented and retain an explicit degraded warning.
+
 - **Actionable authorization denials and `rbgp doctor` authz triage.** gRPC
   PERMISSION_DENIED messages now name the principal, its current role (or
   that it is unmapped), the required tier, and the exact

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1583,7 +1583,7 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
   categories; WatchRoutes missed-event signaling if it gains an envelope;
   precomputed dataplane summary counters / watch channels if status-snapshot
   polling becomes expensive; subscription-side indexing or a dedicated event bus
-  if subscriber count / event rate makes post-broadcast filtering expensive; a
+  if subscriber count / event rate makes post-broadcast filtering expensive;
   additional TUI event categories beyond the shipped lag-aware route view.
 - **EVPN adjacent standards.** PBB-EVPN (RFC 7623), RFC 9251 IGMP/MLD proxy
   multicast EVPN routes (types 6/7/8), RFC 9572 BUM segmentation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1584,7 +1584,7 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
   precomputed dataplane summary counters / watch channels if status-snapshot
   polling becomes expensive; subscription-side indexing or a dedicated event bus
   if subscriber count / event rate makes post-broadcast filtering expensive; a
-  TUI live event view.
+  additional TUI event categories beyond the shipped lag-aware route view.
 - **EVPN adjacent standards.** PBB-EVPN (RFC 7623), RFC 9251 IGMP/MLD proxy
   multicast EVPN routes (types 6/7/8), RFC 9572 BUM segmentation
   (types 9/10/11), EVPN optimized ingress replication (RFC 9574),

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -38,11 +38,20 @@ pub(crate) struct MockState {
     pub(crate) list_neighbors_calls: AtomicUsize,
     pub(crate) list_neighbors_failures_remaining: AtomicUsize,
     pub(crate) list_dynamic_neighbors_calls: AtomicUsize,
+    pub(crate) watch_events_calls: AtomicUsize,
+    pub(crate) watch_events_active: AtomicUsize,
+    pub(crate) watch_events_terminations: AtomicUsize,
+    pub(crate) watch_events_clean_end: AtomicBool,
+    pub(crate) watch_events_admission_error: Mutex<Option<(Code, String)>>,
+    pub(crate) watch_events_stream_error: Mutex<Option<(Code, String)>>,
+    pub(crate) watch_events_response: Mutex<Vec<server_proto::BgpEvent>>,
+    pub(crate) last_watch_events: Mutex<Option<server_proto::WatchEventsRequest>>,
     pub(crate) watch_routes_calls: AtomicUsize,
     pub(crate) watch_routes_active: AtomicUsize,
     pub(crate) watch_routes_clean_end: AtomicBool,
     pub(crate) watch_routes_failures_remaining: AtomicUsize,
     pub(crate) watch_routes_terminations: AtomicUsize,
+    pub(crate) watch_routes_response: Mutex<Vec<server_proto::RouteEvent>>,
     pub(crate) list_session_events_calls: AtomicUsize,
     pub(crate) list_policy_events_calls: AtomicUsize,
     pub(crate) config_diff_calls: AtomicUsize,
@@ -1109,17 +1118,47 @@ impl rustbgpd_api::proto::injection_service_server::InjectionService for MockInj
 
 struct MockWatchRoutesStream {
     state: Arc<MockState>,
+    events: std::collections::VecDeque<server_proto::RouteEvent>,
     clean_end: bool,
+}
+
+struct MockWatchEventsStream {
+    state: Arc<MockState>,
+    events: std::collections::VecDeque<Result<server_proto::BgpEvent, Status>>,
+    clean_end: bool,
+}
+
+impl Stream for MockWatchEventsStream {
+    type Item = Result<server_proto::BgpEvent, Status>;
+
+    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.events.pop_front() {
+            Some(event) => Poll::Ready(Some(event)),
+            None if self.clean_end => Poll::Ready(None),
+            None => Poll::Pending,
+        }
+    }
+}
+
+impl Drop for MockWatchEventsStream {
+    fn drop(&mut self) {
+        self.state
+            .watch_events_active
+            .fetch_sub(1, Ordering::SeqCst);
+        self.state
+            .watch_events_terminations
+            .fetch_add(1, Ordering::SeqCst);
+    }
 }
 
 impl Stream for MockWatchRoutesStream {
     type Item = Result<server_proto::RouteEvent, Status>;
 
-    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        if self.clean_end {
-            Poll::Ready(None)
-        } else {
-            Poll::Pending
+    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.events.pop_front() {
+            Some(event) => Poll::Ready(Some(Ok(event))),
+            None if self.clean_end => Poll::Ready(None),
+            None => Poll::Pending,
         }
     }
 }
@@ -1370,9 +1409,34 @@ impl rustbgpd_api::proto::event_service_server::EventService for MockEventServic
 
     async fn watch_events(
         &self,
-        _request: Request<server_proto::WatchEventsRequest>,
+        request: Request<server_proto::WatchEventsRequest>,
     ) -> Result<Response<Self::WatchEventsStream>, Status> {
-        Err(Status::unimplemented("not used in CLI tests"))
+        self.state.watch_events_calls.fetch_add(1, Ordering::SeqCst);
+        *self.state.last_watch_events.lock().await = Some(request.into_inner());
+        if let Some((code, message)) = self.state.watch_events_admission_error.lock().await.clone()
+        {
+            return Err(Status::new(code, message));
+        }
+
+        let mut events = self
+            .state
+            .watch_events_response
+            .lock()
+            .await
+            .drain(..)
+            .map(Ok)
+            .collect::<std::collections::VecDeque<_>>();
+        if let Some((code, message)) = self.state.watch_events_stream_error.lock().await.take() {
+            events.push_back(Err(Status::new(code, message)));
+        }
+        self.state
+            .watch_events_active
+            .fetch_add(1, Ordering::SeqCst);
+        Ok(Response::new(Box::pin(MockWatchEventsStream {
+            state: Arc::clone(&self.state),
+            events,
+            clean_end: self.state.watch_events_clean_end.load(Ordering::SeqCst),
+        })))
     }
 
     async fn subscribe_from_event(
@@ -1830,8 +1894,16 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         self.state
             .watch_routes_active
             .fetch_add(1, Ordering::SeqCst);
+        let events = self
+            .state
+            .watch_routes_response
+            .lock()
+            .await
+            .drain(..)
+            .collect();
         Ok(Response::new(Box::pin(MockWatchRoutesStream {
             state: Arc::clone(&self.state),
+            events,
             clean_end: self.state.watch_routes_clean_end.load(Ordering::SeqCst),
         })))
     }

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -5,7 +5,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::widgets::TableState;
 
 use crate::proto::{GlobalState, HealthResponse, NeighborState};
-use crate::tui::data::{DataSnapshot, Freshness, RouteEventEntry};
+use crate::tui::data::{DataSnapshot, Freshness, RouteEventEntry, RouteEventUpdate};
 
 const MAX_EVENTS: usize = 100;
 
@@ -85,6 +85,7 @@ pub struct App {
     pub dynamic_range_count: Option<usize>,
     pub dynamic_ranges_freshness: Option<Freshness>,
     pub route_events: VecDeque<RouteEventEntry>,
+    pub route_event_stream_status: Option<String>,
     pub rpki_vrp_count: Option<u64>,
     pub metrics_freshness: Option<Freshness>,
 
@@ -120,6 +121,7 @@ impl App {
             dynamic_range_count: None,
             dynamic_ranges_freshness: None,
             route_events: VecDeque::new(),
+            route_event_stream_status: None,
             rpki_vrp_count: None,
             metrics_freshness: None,
             prev_counters: HashMap::new(),
@@ -348,10 +350,17 @@ impl App {
         self.peer_table_state.select(Some(selected_idx));
     }
 
-    pub fn on_route_event(&mut self, event: RouteEventEntry) {
-        self.route_events.push_front(event);
-        if self.route_events.len() > MAX_EVENTS {
-            self.route_events.pop_back();
+    pub fn on_route_event(&mut self, update: RouteEventUpdate) {
+        match update {
+            RouteEventUpdate::Event(event) => {
+                self.route_events.push_front(event);
+                if self.route_events.len() > MAX_EVENTS {
+                    self.route_events.pop_back();
+                }
+            }
+            RouteEventUpdate::StreamStatus(status) => {
+                self.route_event_stream_status = status;
+            }
         }
     }
 
@@ -517,6 +526,34 @@ mod tests {
         ]));
 
         assert_eq!(app.view, View::PeerDetail("198.51.100.1".into()));
+    }
+
+    /// Red proof: storing compatibility state in the bounded event deque (or
+    /// clearing it while evicting rows) loses the warning after 101 events.
+    #[test]
+    fn degraded_stream_warning_survives_event_deque_eviction() {
+        let mut app = App::new();
+        let warning = "DEGRADED: WatchEvents unsupported; using legacy WatchRoutes; missed-event counts unavailable";
+        app.on_route_event(RouteEventUpdate::StreamStatus(Some(warning.into())));
+        for index in 0..=MAX_EVENTS {
+            app.on_route_event(RouteEventUpdate::Event(RouteEventEntry {
+                kind: crate::tui::data::RouteEventKind::Route,
+                timestamp: index.to_string(),
+                event_type: "added".into(),
+                prefix: "203.0.113.0/24".into(),
+                peer_address: "192.0.2.1".into(),
+                previous_peer_address: String::new(),
+                target_peer_address: String::new(),
+                reason: String::new(),
+                path_id: 0,
+                missed_count: 0,
+            }));
+        }
+
+        assert_eq!(app.route_events.len(), MAX_EVENTS);
+        assert_eq!(app.route_event_stream_status.as_deref(), Some(warning));
+        app.on_route_event(RouteEventUpdate::StreamStatus(None));
+        assert!(app.route_event_stream_status.is_none());
     }
 
     #[test]

--- a/crates/cli/src/tui/data.rs
+++ b/crates/cli/src/tui/data.rs
@@ -7,12 +7,14 @@ use tokio::time::Instant;
 use crate::commands::control::rpki_vrp_count_sum;
 use crate::connection::Connection;
 use crate::proto::control_service_client::ControlServiceClient;
+use crate::proto::event_service_client::EventServiceClient;
 use crate::proto::global_service_client::GlobalServiceClient;
 use crate::proto::neighbor_service_client::NeighborServiceClient;
 use crate::proto::rib_service_client::RibServiceClient;
 use crate::proto::{
-    GetGlobalRequest, GlobalState, HealthRequest, HealthResponse, ListDynamicNeighborsRequest,
-    ListNeighborsRequest, MetricsRequest, NeighborState, WatchRoutesRequest,
+    BgpEvent, BgpEventType, EventCategory, GetGlobalRequest, GlobalState, HealthRequest,
+    HealthResponse, ListDynamicNeighborsRequest, ListNeighborsRequest, MetricsRequest,
+    NeighborState, RouteEvent, RouteEventType, WatchEventsRequest, WatchRoutesRequest, bgp_event,
 };
 
 pub struct DataSnapshot {
@@ -37,11 +39,26 @@ pub enum Freshness {
 }
 
 pub struct RouteEventEntry {
+    pub kind: RouteEventKind,
     pub timestamp: String,
     pub event_type: String,
     pub prefix: String,
     pub peer_address: String,
+    pub previous_peer_address: String,
+    pub target_peer_address: String,
+    pub reason: String,
     pub path_id: u32,
+    pub missed_count: u64,
+}
+
+pub enum RouteEventKind {
+    Route,
+    StreamLag,
+}
+
+pub enum RouteEventUpdate {
+    Event(RouteEventEntry),
+    StreamStatus(Option<String>),
 }
 
 pub(super) struct FetcherHandle(JoinHandle<()>, JoinHandle<()>);
@@ -53,11 +70,23 @@ impl Drop for FetcherHandle {
     }
 }
 
-fn format_event_type(t: i32) -> &'static str {
+fn format_event_type(t: BgpEventType) -> &'static str {
     match t {
-        1 => "added",
-        2 => "withdrawn",
-        3 => "best_changed",
+        BgpEventType::RouteAdded => "added",
+        BgpEventType::RouteWithdrawn => "withdrawn",
+        BgpEventType::RouteBestChanged => "best_changed",
+        BgpEventType::RoutePolicyFiltered => "policy_filtered",
+        BgpEventType::StreamLagged => "stream_lagged",
+        _ => "unknown",
+    }
+}
+
+fn format_legacy_event_type(t: i32) -> &'static str {
+    match RouteEventType::try_from(t) {
+        Ok(RouteEventType::Added) => "added",
+        Ok(RouteEventType::Withdrawn) => "withdrawn",
+        Ok(RouteEventType::BestChanged) => "best_changed",
+        Ok(RouteEventType::PolicyFiltered) => "policy_filtered",
         _ => "unknown",
     }
 }
@@ -69,6 +98,8 @@ fn parse_vrp_count(prometheus_text: &str) -> Option<u64> {
 const METRICS_POLL_INTERVAL: Duration = Duration::from_secs(60);
 const DYNAMIC_RANGES_POLL_INTERVAL: Duration = Duration::from_secs(60);
 const ROUTE_STREAM_RECONNECT_BACKOFF: Duration = Duration::from_secs(2);
+const LEGACY_ROUTE_STREAM_WARNING: &str =
+    "DEGRADED: WatchEvents unsupported; using legacy WatchRoutes; missed-event counts unavailable";
 
 struct FetcherState {
     global: Option<GlobalState>,
@@ -102,7 +133,7 @@ pub(super) fn spawn_fetcher(
     connection: Connection,
     interval: Duration,
     data_tx: mpsc::Sender<DataSnapshot>,
-    event_tx: mpsc::Sender<RouteEventEntry>,
+    event_tx: mpsc::Sender<RouteEventUpdate>,
     event_watch: watch::Receiver<bool>,
 ) -> FetcherHandle {
     let route_fetcher = tokio::spawn(route_event_loop(connection.clone(), event_tx, event_watch));
@@ -242,7 +273,7 @@ async fn poll_once(connection: &Connection, state: &mut FetcherState) -> DataSna
 
 async fn route_event_loop(
     connection: Connection,
-    event_tx: mpsc::Sender<RouteEventEntry>,
+    event_tx: mpsc::Sender<RouteEventUpdate>,
     mut enabled: watch::Receiver<bool>,
 ) {
     loop {
@@ -253,7 +284,7 @@ async fn route_event_loop(
         }
 
         let completed = tokio::select! {
-            _ = stream_routes(&connection, &event_tx) => true,
+            _ = stream_route_events(&connection, &event_tx) => true,
             changed = enabled.changed() => {
                 if changed.is_err() {
                     return;
@@ -276,9 +307,131 @@ async fn route_event_loop(
     }
 }
 
+enum PrimaryStreamOutcome {
+    Unsupported,
+    Finished(Result<(), tonic::Status>),
+}
+
+async fn stream_route_events(connection: &Connection, event_tx: &mpsc::Sender<RouteEventUpdate>) {
+    match stream_events(connection, event_tx).await {
+        PrimaryStreamOutcome::Unsupported => {
+            if send_stream_status(event_tx, LEGACY_ROUTE_STREAM_WARNING.to_string()).await
+                && let Err(error) = stream_routes(connection, event_tx).await
+            {
+                let status = format!(
+                    "{LEGACY_ROUTE_STREAM_WARNING}; legacy stream error: {}; retrying",
+                    error.message()
+                );
+                send_stream_status(event_tx, status).await;
+            }
+        }
+        PrimaryStreamOutcome::Finished(Err(error)) => {
+            let status = format!("route event stream error: {}; retrying", error.message());
+            send_stream_status(event_tx, status).await;
+        }
+        PrimaryStreamOutcome::Finished(Ok(())) => {}
+    }
+}
+
+async fn send_stream_status(event_tx: &mpsc::Sender<RouteEventUpdate>, status: String) -> bool {
+    event_tx
+        .send(RouteEventUpdate::StreamStatus(Some(status)))
+        .await
+        .is_ok()
+}
+
+async fn stream_events(
+    connection: &Connection,
+    event_tx: &mpsc::Sender<RouteEventUpdate>,
+) -> PrimaryStreamOutcome {
+    let mut client =
+        EventServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let mut stream = match client
+        .watch_events(WatchEventsRequest {
+            categories: vec![EventCategory::Route as i32],
+            ..Default::default()
+        })
+        .await
+    {
+        Ok(response) => response.into_inner(),
+        Err(error) if error.code() == tonic::Code::Unimplemented => {
+            return PrimaryStreamOutcome::Unsupported;
+        }
+        Err(error) => return PrimaryStreamOutcome::Finished(Err(error)),
+    };
+    if event_tx
+        .send(RouteEventUpdate::StreamStatus(None))
+        .await
+        .is_err()
+    {
+        return PrimaryStreamOutcome::Finished(Ok(()));
+    }
+
+    loop {
+        match stream.message().await {
+            Ok(Some(event)) => {
+                if let Some(entry) = route_event_entry(event)
+                    && event_tx.send(RouteEventUpdate::Event(entry)).await.is_err()
+                {
+                    return PrimaryStreamOutcome::Finished(Ok(()));
+                }
+            }
+            Ok(None) => return PrimaryStreamOutcome::Finished(Ok(())),
+            Err(error) => return PrimaryStreamOutcome::Finished(Err(error)),
+        }
+    }
+}
+
+fn route_event_entry(event: BgpEvent) -> Option<RouteEventEntry> {
+    let event_type = BgpEventType::try_from(event.event_type).ok()?;
+    match event.payload? {
+        bgp_event::Payload::Route(route)
+            if matches!(
+                event_type,
+                BgpEventType::RouteAdded
+                    | BgpEventType::RouteWithdrawn
+                    | BgpEventType::RouteBestChanged
+                    | BgpEventType::RoutePolicyFiltered
+            ) =>
+        {
+            Some(route_entry(format_event_type(event_type), route))
+        }
+        bgp_event::Payload::StreamLag(lag) if event_type == BgpEventType::StreamLagged => {
+            Some(RouteEventEntry {
+                kind: RouteEventKind::StreamLag,
+                timestamp: event.timestamp,
+                event_type: format_event_type(event_type).to_string(),
+                prefix: String::new(),
+                peer_address: String::new(),
+                previous_peer_address: String::new(),
+                target_peer_address: String::new(),
+                reason: lag.reason,
+                path_id: 0,
+                missed_count: lag.missed_count,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn route_entry(event_type: &str, event: RouteEvent) -> RouteEventEntry {
+    RouteEventEntry {
+        kind: RouteEventKind::Route,
+        timestamp: event.timestamp,
+        event_type: event_type.to_string(),
+        prefix: format!("{}/{}", event.prefix, event.prefix_length),
+        peer_address: event.peer_address,
+        previous_peer_address: event.previous_peer_address,
+        target_peer_address: event.target_peer_address,
+        reason: event.reason,
+        path_id: event.path_id,
+        missed_count: 0,
+    }
+}
+
 async fn stream_routes(
     connection: &Connection,
-    event_tx: &mpsc::Sender<RouteEventEntry>,
+    event_tx: &mpsc::Sender<RouteEventUpdate>,
 ) -> Result<(), tonic::Status> {
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
@@ -291,14 +444,12 @@ async fn stream_routes(
         .into_inner();
 
     while let Some(event) = stream.message().await? {
-        let entry = RouteEventEntry {
-            timestamp: event.timestamp,
-            event_type: format_event_type(event.event_type).to_string(),
-            prefix: format!("{}/{}", event.prefix, event.prefix_length),
-            peer_address: event.peer_address,
-            path_id: event.path_id,
-        };
-        if event_tx.send(entry).await.is_err() {
+        let event_type = format_legacy_event_type(event.event_type);
+        if event_tx
+            .send(RouteEventUpdate::Event(route_entry(event_type, event)))
+            .await
+            .is_err()
+        {
             break;
         }
     }
@@ -329,6 +480,56 @@ mod tests {
         }
     }
 
+    fn policy_event(summary: &str) -> rustbgpd_api::proto::BgpEvent {
+        rustbgpd_api::proto::BgpEvent {
+            timestamp: "2026-08-03T12:00:00Z".into(),
+            category: EventCategory::Route as i32,
+            event_type: BgpEventType::RoutePolicyFiltered as i32,
+            summary: summary.into(),
+            payload: Some(rustbgpd_api::proto::bgp_event::Payload::Route(
+                rustbgpd_api::proto::RouteEvent {
+                    event_type: RouteEventType::PolicyFiltered as i32,
+                    prefix: "203.0.113.0".into(),
+                    prefix_length: 24,
+                    peer_address: "192.0.2.1".into(),
+                    previous_peer_address: "192.0.2.2".into(),
+                    target_peer_address: "192.0.2.3".into(),
+                    timestamp: "2026-08-03T12:00:00Z".into(),
+                    path_id: 77,
+                    reason: "policy_denied".into(),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        }
+    }
+
+    fn lag_event(summary: &str) -> rustbgpd_api::proto::BgpEvent {
+        rustbgpd_api::proto::BgpEvent {
+            timestamp: "2026-08-03T12:00:01Z".into(),
+            category: EventCategory::Route as i32,
+            event_type: BgpEventType::StreamLagged as i32,
+            summary: summary.into(),
+            payload: Some(rustbgpd_api::proto::bgp_event::Payload::StreamLag(
+                rustbgpd_api::proto::StreamLagEvent {
+                    source_category: EventCategory::Route as i32,
+                    missed_count: 7,
+                    reason: "receiver_lagged".into(),
+                },
+            )),
+            ..Default::default()
+        }
+    }
+
+    async fn next_event(event_rx: &mut mpsc::Receiver<RouteEventUpdate>) -> RouteEventEntry {
+        loop {
+            match event_rx.recv().await.unwrap() {
+                RouteEventUpdate::Event(event) => return event,
+                RouteEventUpdate::StreamStatus(_) => {}
+            }
+        }
+    }
+
     fn dynamic_range_calls(server: &crate::test_support::MockServerHandle) -> usize {
         server
             .state
@@ -337,9 +538,13 @@ mod tests {
     }
 
     async fn assert_route_reconnect_backoff(server: &crate::test_support::MockServerHandle) {
+        *server.state.watch_events_admission_error.lock().await = Some((
+            tonic::Code::Unimplemented,
+            "WatchEvents unavailable on this daemon".into(),
+        ));
         let connection = connect(&server.addr, None).await.unwrap();
         let (enabled_tx, enabled_rx) = watch::channel(true);
-        let (event_tx, _event_rx) = mpsc::channel(1);
+        let (event_tx, _event_rx) = mpsc::channel(8);
         let task = tokio::spawn(route_event_loop(connection, event_tx, enabled_rx));
 
         wait_for(|| server.state.watch_routes_calls.load(Ordering::SeqCst) == 1).await;
@@ -354,9 +559,11 @@ mod tests {
         settle_tasks().await;
         tokio::time::advance(ROUTE_STREAM_RECONNECT_BACKOFF - Duration::from_millis(1)).await;
         tokio::task::yield_now().await;
+        assert_eq!(server.state.watch_events_calls.load(Ordering::SeqCst), 1);
         assert_eq!(server.state.watch_routes_calls.load(Ordering::SeqCst), 1);
 
         tokio::time::advance(Duration::from_millis(1)).await;
+        wait_for(|| server.state.watch_events_calls.load(Ordering::SeqCst) == 2).await;
         wait_for(|| server.state.watch_routes_calls.load(Ordering::SeqCst) == 2).await;
 
         drop(enabled_tx);
@@ -609,7 +816,8 @@ mod tests {
         assert_eq!(server.state.metrics_calls.load(Ordering::SeqCst), 2);
     }
 
-    /// Red proof: the old detached watcher starts early and survives final drop.
+    /// Red proof: starting the primary stream while disabled or failing to
+    /// cancel its response changes the zero/active assertions.
     #[tokio::test]
     async fn route_stream_is_opt_in_and_cancellable() {
         let server = spawn_mock_server(None).await;
@@ -627,20 +835,222 @@ mod tests {
 
         data_rx.recv().await.unwrap();
         settle_tasks().await;
-        assert_eq!(server.state.watch_routes_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(server.state.watch_events_calls.load(Ordering::SeqCst), 0);
 
         enabled_tx.send(true).unwrap();
-        wait_for(|| server.state.watch_routes_calls.load(Ordering::SeqCst) == 1).await;
-        wait_for(|| server.state.watch_routes_active.load(Ordering::SeqCst) == 1).await;
+        wait_for(|| server.state.watch_events_calls.load(Ordering::SeqCst) == 1).await;
+        wait_for(|| server.state.watch_events_active.load(Ordering::SeqCst) == 1).await;
 
         enabled_tx.send(false).unwrap();
-        wait_for(|| server.state.watch_routes_active.load(Ordering::SeqCst) == 0).await;
-        assert_eq!(server.state.watch_routes_calls.load(Ordering::SeqCst), 1);
+        wait_for(|| server.state.watch_events_active.load(Ordering::SeqCst) == 0).await;
+        assert_eq!(server.state.watch_events_calls.load(Ordering::SeqCst), 1);
 
         enabled_tx.send(true).unwrap();
-        wait_for(|| server.state.watch_routes_active.load(Ordering::SeqCst) == 1).await;
+        wait_for(|| server.state.watch_events_active.load(Ordering::SeqCst) == 1).await;
         drop(task);
+        wait_for(|| server.state.watch_events_active.load(Ordering::SeqCst) == 0).await;
+    }
+
+    /// Red proof: detaching the fallback stream from the visibility select
+    /// leaves its active counter nonzero after hide and handle drop.
+    #[tokio::test]
+    async fn legacy_fallback_is_cancellable() {
+        let server = spawn_mock_server(None).await;
+        *server.state.watch_events_admission_error.lock().await =
+            Some((tonic::Code::Unimplemented, "old daemon".into()));
+        let connection = connect(&server.addr, None).await.unwrap();
+        let (enabled_tx, enabled_rx) = watch::channel(true);
+        let (event_tx, _event_rx) = mpsc::channel(4);
+        let task = tokio::spawn(route_event_loop(connection, event_tx, enabled_rx));
+
+        wait_for(|| server.state.watch_routes_active.load(Ordering::SeqCst) == 1).await;
+        enabled_tx.send(false).unwrap();
         wait_for(|| server.state.watch_routes_active.load(Ordering::SeqCst) == 0).await;
+        enabled_tx.send(true).unwrap();
+        wait_for(|| server.state.watch_routes_active.load(Ordering::SeqCst) == 1).await;
+        task.abort();
+        let _ = task.await;
+        wait_for(|| server.state.watch_routes_active.load(Ordering::SeqCst) == 0).await;
+    }
+
+    /// Red proof: broadening fallback beyond admission UNIMPLEMENTED makes the
+    /// PermissionDenied and Unavailable rows call legacy WatchRoutes.
+    #[tokio::test]
+    async fn only_admission_unimplemented_enters_legacy_stream() {
+        for (code, expected_legacy_calls) in [
+            (tonic::Code::Unimplemented, 1),
+            (tonic::Code::PermissionDenied, 0),
+            (tonic::Code::Unavailable, 0),
+        ] {
+            let server = spawn_mock_server(None).await;
+            *server.state.watch_events_admission_error.lock().await =
+                Some((code, "primary admission rejected".into()));
+            let connection = connect(&server.addr, None).await.unwrap();
+            let (_enabled_tx, enabled_rx) = watch::channel(true);
+            let (event_tx, mut event_rx) = mpsc::channel(4);
+            let task = tokio::spawn(route_event_loop(connection, event_tx, enabled_rx));
+
+            wait_for(|| server.state.watch_events_calls.load(Ordering::SeqCst) == 1).await;
+            settle_tasks().await;
+            assert_eq!(
+                server.state.watch_routes_calls.load(Ordering::SeqCst),
+                expected_legacy_calls,
+                "admission status {code:?}"
+            );
+            let RouteEventUpdate::StreamStatus(Some(status)) = event_rx.recv().await.unwrap()
+            else {
+                panic!("stream admission must publish visible status");
+            };
+            if code == tonic::Code::Unimplemented {
+                assert_eq!(
+                    status,
+                    "DEGRADED: WatchEvents unsupported; using legacy WatchRoutes; missed-event counts unavailable"
+                );
+            }
+            task.abort();
+            let _ = task.await;
+        }
+    }
+
+    /// Red proof: switching the primary RPC back to WatchRoutes, accepting a
+    /// non-route event type by numeric coincidence, or reading lag from the
+    /// conflicting summary breaks these assertions.
+    #[tokio::test]
+    async fn primary_stream_preserves_policy_context_and_exact_lag_count() {
+        let server = spawn_mock_server(None).await;
+        let mut non_route = policy_event("must be ignored");
+        non_route.event_type = BgpEventType::SessionEstablished as i32;
+        *server.state.watch_events_response.lock().await = vec![
+            non_route,
+            policy_event("misleading policy summary"),
+            lag_event("missed 999 events"),
+        ];
+        let connection = connect(&server.addr, None).await.unwrap();
+        let (_enabled_tx, enabled_rx) = watch::channel(true);
+        let (event_tx, mut event_rx) = mpsc::channel(8);
+        let task = tokio::spawn(route_event_loop(connection, event_tx, enabled_rx));
+
+        let policy = next_event(&mut event_rx).await;
+        let lag = next_event(&mut event_rx).await;
+        assert_eq!(server.state.watch_events_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(server.state.watch_routes_calls.load(Ordering::SeqCst), 0);
+        let request = server.state.last_watch_events.lock().await.clone().unwrap();
+        assert_eq!(request.categories, vec![EventCategory::Route as i32]);
+        assert!(request.event_types.is_empty());
+        assert_eq!(policy.event_type, "policy_filtered");
+        assert_eq!(policy.peer_address, "192.0.2.1");
+        assert_eq!(policy.previous_peer_address, "192.0.2.2");
+        assert_eq!(policy.target_peer_address, "192.0.2.3");
+        assert_eq!(policy.reason, "policy_denied");
+        assert_eq!(policy.path_id, 77);
+        assert_eq!(lag.event_type, "stream_lagged");
+        assert_eq!(lag.missed_count, 7);
+        assert_eq!(lag.reason, "receiver_lagged");
+        task.abort();
+        let _ = task.await;
+    }
+
+    /// Red proof: bypassing the typed legacy mapper drops one or more policy
+    /// source/previous/target/reason/path fields from the fallback result.
+    #[tokio::test]
+    async fn legacy_fallback_preserves_policy_context_through_mock_grpc() {
+        let server = spawn_mock_server(None).await;
+        *server.state.watch_events_admission_error.lock().await =
+            Some((tonic::Code::Unimplemented, "old daemon".into()));
+        let route = match policy_event("legacy policy summary").payload.unwrap() {
+            rustbgpd_api::proto::bgp_event::Payload::Route(route) => route,
+            _ => unreachable!(),
+        };
+        *server.state.watch_routes_response.lock().await = vec![route];
+        let connection = connect(&server.addr, None).await.unwrap();
+        let (_enabled_tx, enabled_rx) = watch::channel(true);
+        let (event_tx, mut event_rx) = mpsc::channel(4);
+        let task = tokio::spawn(route_event_loop(connection, event_tx, enabled_rx));
+
+        let policy = next_event(&mut event_rx).await;
+        assert_eq!(policy.event_type, "policy_filtered");
+        assert_eq!(policy.peer_address, "192.0.2.1");
+        assert_eq!(policy.previous_peer_address, "192.0.2.2");
+        assert_eq!(policy.target_peer_address, "192.0.2.3");
+        assert_eq!(policy.reason, "policy_denied");
+        assert_eq!(policy.path_id, 77);
+        task.abort();
+        let _ = task.await;
+    }
+
+    /// Red proof: decoding the legacy enum as BgpEventType makes the invalid
+    /// legacy value inherit an unrelated BGP-event label.
+    #[test]
+    fn legacy_route_event_type_has_an_independent_mapping() {
+        assert_eq!(
+            format_legacy_event_type(RouteEventType::PolicyFiltered as i32),
+            "policy_filtered"
+        );
+        assert_eq!(
+            format_legacy_event_type(BgpEventType::SessionEstablished as i32),
+            "unknown"
+        );
+    }
+
+    /// Red proof: treating a post-admission UNIMPLEMENTED as legacy support
+    /// increments WatchRoutes instead of surfacing the primary error.
+    #[tokio::test(start_paused = true)]
+    async fn post_admission_unimplemented_never_falls_back() {
+        let server = spawn_mock_server(None).await;
+        *server.state.watch_events_stream_error.lock().await =
+            Some((tonic::Code::Unimplemented, "stream item failed".into()));
+        let connection = connect(&server.addr, None).await.unwrap();
+        let (_enabled_tx, enabled_rx) = watch::channel(true);
+        let (event_tx, mut event_rx) = mpsc::channel(4);
+        let task = tokio::spawn(route_event_loop(connection, event_tx, enabled_rx));
+
+        let mut visible_error = None;
+        while visible_error.is_none() {
+            if let RouteEventUpdate::StreamStatus(status) = event_rx.recv().await.unwrap() {
+                visible_error = status;
+            }
+        }
+        assert!(visible_error.unwrap().contains("stream item failed"));
+        assert_eq!(server.state.watch_routes_calls.load(Ordering::SeqCst), 0);
+        tokio::time::advance(ROUTE_STREAM_RECONNECT_BACKOFF - Duration::from_millis(1)).await;
+        assert_eq!(server.state.watch_events_calls.load(Ordering::SeqCst), 1);
+        tokio::time::advance(Duration::from_millis(1)).await;
+        wait_for(|| server.state.watch_events_calls.load(Ordering::SeqCst) == 2).await;
+        task.abort();
+        let _ = task.await;
+    }
+
+    /// Red proof: removing the clean-end delay increments the second-call
+    /// assertion before its exact two-second deadline.
+    #[tokio::test(start_paused = true)]
+    async fn primary_clean_end_reprobes_primary_after_backoff() {
+        let server = spawn_mock_server(None).await;
+        server
+            .state
+            .watch_events_clean_end
+            .store(true, Ordering::SeqCst);
+        let connection = connect(&server.addr, None).await.unwrap();
+        let (_enabled_tx, enabled_rx) = watch::channel(true);
+        let (event_tx, _event_rx) = mpsc::channel(4);
+        let task = tokio::spawn(route_event_loop(connection, event_tx, enabled_rx));
+
+        wait_for(|| server.state.watch_events_calls.load(Ordering::SeqCst) == 1).await;
+        wait_for(|| {
+            server
+                .state
+                .watch_events_terminations
+                .load(Ordering::SeqCst)
+                == 1
+        })
+        .await;
+        settle_tasks().await;
+        tokio::time::advance(ROUTE_STREAM_RECONNECT_BACKOFF - Duration::from_millis(1)).await;
+        assert_eq!(server.state.watch_events_calls.load(Ordering::SeqCst), 1);
+        tokio::time::advance(Duration::from_millis(1)).await;
+        wait_for(|| server.state.watch_events_calls.load(Ordering::SeqCst) == 2).await;
+        assert_eq!(server.state.watch_routes_calls.load(Ordering::SeqCst), 0);
+        task.abort();
+        let _ = task.await;
     }
 
     /// Red proof: removing the clean-end delay reconnects before the deadline.

--- a/crates/cli/src/tui/data.rs
+++ b/crates/cli/src/tui/data.rs
@@ -823,7 +823,7 @@ mod tests {
         let server = spawn_mock_server(None).await;
         let connection = connect(&server.addr, None).await.unwrap();
         let (enabled_tx, enabled_rx) = watch::channel(false);
-        let (event_tx, _event_rx) = mpsc::channel(1);
+        let (event_tx, mut event_rx) = mpsc::channel(1);
         let (data_tx, mut data_rx) = mpsc::channel(1);
         let task = spawn_fetcher(
             connection,
@@ -840,6 +840,10 @@ mod tests {
         enabled_tx.send(true).unwrap();
         wait_for(|| server.state.watch_events_calls.load(Ordering::SeqCst) == 1).await;
         wait_for(|| server.state.watch_events_active.load(Ordering::SeqCst) == 1).await;
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(1), event_rx.recv()).await,
+            Ok(Some(RouteEventUpdate::StreamStatus(None)))
+        ));
 
         enabled_tx.send(false).unwrap();
         wait_for(|| server.state.watch_events_active.load(Ordering::SeqCst) == 0).await;
@@ -847,6 +851,10 @@ mod tests {
 
         enabled_tx.send(true).unwrap();
         wait_for(|| server.state.watch_events_active.load(Ordering::SeqCst) == 1).await;
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(1), event_rx.recv()).await,
+            Ok(Some(RouteEventUpdate::StreamStatus(None)))
+        ));
         drop(task);
         wait_for(|| server.state.watch_events_active.load(Ordering::SeqCst) == 0).await;
     }

--- a/crates/cli/src/tui/ui.rs
+++ b/crates/cli/src/tui/ui.rs
@@ -10,7 +10,7 @@ use crate::commands::neighbor::{
 };
 use crate::output::{format_duration, format_state_with_stale, neighbor_source_label};
 use crate::tui::app::{App, SortColumn, View, neighbor_key};
-use crate::tui::data::Freshness;
+use crate::tui::data::{Freshness, RouteEventEntry, RouteEventKind};
 use crate::tui::theme::Theme;
 
 pub fn draw(f: &mut Frame, app: &mut App, theme: &Theme) {
@@ -275,35 +275,59 @@ fn draw_events(f: &mut Frame, app: &App, area: Rect, theme: &Theme) {
     let inner = block.inner(area);
     f.render_widget(block, area);
 
-    let max_lines = inner.height as usize;
-    let lines: Vec<Line> = app
-        .route_events
-        .iter()
-        .take(max_lines)
-        .map(|e| {
-            let color = theme.event_color(&e.event_type);
-            let path_id = if e.path_id > 0 {
-                format!(" path_id={}", e.path_id)
-            } else {
-                String::new()
-            };
-            Line::from(vec![
-                Span::styled(
-                    format!("[{}] ", e.timestamp),
-                    Style::default().fg(theme.text_dim),
-                ),
-                Span::styled(format!("{:<10}", e.event_type), Style::default().fg(color)),
-                Span::styled(format!("{:<20}", e.prefix), Style::default().fg(theme.text)),
-                Span::styled(
-                    format!("from {}{}", e.peer_address, path_id),
-                    Style::default().fg(theme.text_dim),
-                ),
-            ])
-        })
-        .collect();
+    let mut lines = Vec::new();
+    if let Some(status) = &app.route_event_stream_status {
+        lines.push(Line::styled(
+            format!("warning: {status}"),
+            Style::default().fg(theme.error),
+        ));
+    }
+    lines.extend(
+        app.route_events
+            .iter()
+            .take((inner.height as usize).saturating_sub(lines.len()))
+            .map(|e| {
+                let color = theme.event_color(&e.event_type);
+                Line::from(vec![
+                    Span::styled(
+                        format!("[{}] ", e.timestamp),
+                        Style::default().fg(theme.text_dim),
+                    ),
+                    Span::styled(format!("{:<10}", e.event_type), Style::default().fg(color)),
+                    Span::styled(format!("{:<20}", e.prefix), Style::default().fg(theme.text)),
+                    Span::styled(route_event_context(e), Style::default().fg(theme.text_dim)),
+                ])
+            }),
+    );
 
     let paragraph = Paragraph::new(lines);
     f.render_widget(paragraph, inner);
+}
+
+fn route_event_context(event: &RouteEventEntry) -> String {
+    if matches!(&event.kind, RouteEventKind::StreamLag) {
+        let reason = if event.reason.is_empty() {
+            String::new()
+        } else {
+            format!(" reason={}", event.reason)
+        };
+        return format!("missed={}{}", event.missed_count, reason);
+    }
+
+    let mut fields = vec![format!("from {}", event.peer_address)];
+    if !event.previous_peer_address.is_empty() {
+        fields.push(format!("previous={}", event.previous_peer_address));
+    }
+    if !event.target_peer_address.is_empty() {
+        fields.push(format!("to={}", event.target_peer_address));
+    }
+    if !event.reason.is_empty() {
+        fields.push(format!("reason={}", event.reason));
+    }
+    if event.path_id > 0 {
+        fields.push(format!("path_id={}", event.path_id));
+    }
+    fields.join(" ")
 }
 
 fn draw_footer(f: &mut Frame, app: &App, area: Rect, theme: &Theme) {
@@ -714,6 +738,63 @@ mod tests {
         assert_eq!(format_number(1000), "1,000");
         assert_eq!(format_number(12345), "12,345");
         assert_eq!(format_number(1234567), "1,234,567");
+    }
+
+    /// Red proof: restoring the source-only event row or storing the degraded
+    /// warning in the bounded route rows removes these strings from the real
+    /// rendered event panel.
+    #[test]
+    fn event_panel_test_backend_renders_context_lag_and_degraded_status() {
+        let mut app = App::new();
+        app.show_events = true;
+        app.on_data(snapshot(Vec::new(), Freshness::Fresh));
+        app.on_route_event(crate::tui::data::RouteEventUpdate::StreamStatus(Some(
+            "DEGRADED: WatchEvents unsupported; using legacy WatchRoutes; missed-event counts unavailable".into(),
+        )));
+        let lag = |missed_count| RouteEventEntry {
+            kind: RouteEventKind::StreamLag,
+            timestamp: "12:00:01".into(),
+            event_type: "stream_lagged".into(),
+            prefix: String::new(),
+            peer_address: String::new(),
+            previous_peer_address: String::new(),
+            target_peer_address: String::new(),
+            reason: "receiver_lagged".into(),
+            path_id: 0,
+            missed_count,
+        };
+        app.on_route_event(crate::tui::data::RouteEventUpdate::Event(lag(7)));
+        app.on_route_event(crate::tui::data::RouteEventUpdate::Event(lag(0)));
+        app.on_route_event(crate::tui::data::RouteEventUpdate::Event(RouteEventEntry {
+            kind: RouteEventKind::Route,
+            timestamp: "12:00:00".into(),
+            event_type: "policy_filtered".into(),
+            prefix: "203.0.113.0/24".into(),
+            peer_address: "192.0.2.1".into(),
+            previous_peer_address: "192.0.2.2".into(),
+            target_peer_address: "192.0.2.3".into(),
+            reason: "policy_denied".into(),
+            path_id: 77,
+            missed_count: 0,
+        }));
+        let mut terminal = Terminal::new(TestBackend::new(180, 18)).unwrap();
+        terminal
+            .draw(|frame| draw(frame, &mut app, &Theme::default()))
+            .unwrap();
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+
+        assert!(rendered.contains("DEGRADED: WatchEvents unsupported"));
+        assert!(rendered.contains(
+            "from 192.0.2.1 previous=192.0.2.2 to=192.0.2.3 reason=policy_denied path_id=77"
+        ));
+        assert!(rendered.contains("missed=7 reason=receiver_lagged"));
+        assert!(rendered.contains("missed=0 reason=receiver_lagged"));
     }
 
     fn snapshot(neighbors: Vec<NeighborState>, freshness: Freshness) -> DataSnapshot {

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1901,7 +1901,13 @@ rbgp top -i 5     # 5s poll interval
 
 Shows sessions, prefix counts, message rates, RPKI VRP counts, and
 streaming route events in a terminal UI. The route-event subscription is
-opened only while the events panel is visible (`e`). Global identity is retried
+opened only while the events panel is visible (`e`).
+The panel uses the lag-aware `WatchEvents` route stream, including exact missed
+counts and policy-filter source/target/reason/Add-Path context. With an older
+daemon that rejects `WatchEvents` as unimplemented, it uses legacy
+`WatchRoutes` and keeps a `DEGRADED` warning visible because that stream cannot
+report missed events. Other admission and stream errors do not downgrade.
+Global identity is retried
 on each normal poll until the first successful fetch, then cached; the
 Prometheus metrics scrape runs on a separate 60-second cadence. Before either
 optional source succeeds, the status line reports `global unavailable` or


### PR DESCRIPTION
## Summary\n- switch the optional rbgp top route-event panel to the typed WatchEvents route stream\n- render policy source, previous/target peer, reason, Add-Path ID, and exact stream-lag counts\n- fall back to legacy WatchRoutes only when admission returns UNIMPLEMENTED, with a persistent degraded warning\n\n## Compatibility and safety\n- route streaming remains opt-in and is cancelled whenever the event panel is hidden\n- permission, availability, and post-admission stream errors stay visible and never trigger a silent downgrade\n- UI history remains bounded to 100 rows; compatibility state is stored separately so eviction cannot hide degraded mode\n\n## Verification\n- cargo fmt --all -- --check\n- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings\n- cargo test --locked --workspace --no-fail-fast\n- RUSTDOCFLAGS=-D warnings cargo doc --locked --workspace --no-deps\n- python3 scripts/check-clippy-reasons.py\n- python3 scripts/check-v1-stable-surface.py\n- independent diff review: no actionable findings\n\n## Load-bearing proofs\n- removing the route category filter fails the primary request assertion\n- replacing the exact lag count with zero fails the typed lag test\n- detaching fallback from the visibility select fails the cancellation test\n- restoring source-only rendering fails the Ratatui backend assertion\n- clearing compatibility state on row eviction fails the 101-event retention test