### PR TITLE
fix(aspa): enforce edge-ingress applicability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   route-collector example keeps its explicit observer boundary, Docker Compose
   keeps authenticated TCP, and the three commented TCP recipes now include a
   complete token, principal, and role mapping.
+- **ASPA applicability now follows draft -27 at the session boundary.** The
+  first-AS check now covers roleless eBGP and RFC 6793 OLD peers after AS_PATH
+  reconstruction while preserving the transparent-IX `rs-client` exception.
+  IPv4/IPv6-unicast routes learned over iBGP now remain ASPA `Unknown` before
+  import policy and across cache revalidation, matching rustbgpd's
+  edge-ingress policy. Existing iBGP routes can consequently change from a
+  computed Valid/Invalid ranking to Unknown after upgrade.
 
 - **Implicit `local-operator` identity for owner-only UDS listeners
   (ADR-0064 amendment).** Under the default tier enforcement, a UDS

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -806,8 +806,9 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
   equal-cost sibling index for wide full-table multipath; platform-diversity
   interop for weighted multipath.
 - **ASPA verification — test hardening.** Role-aware upstream/downstream
-  verification now ships with the draft-v25 first-AS precondition, §6.2
-  IPv4/IPv6-unicast family gate, best-path preference, and
+  verification now ships with the draft-v27 first-AS precondition for
+  roleless and RFC 6793 OLD eBGP peers, the transparent-IX exception, §6.2
+  IPv4/IPv6-unicast edge-ingress/iBGP-Unknown gate, best-path preference, and
   `match_aspa_validation` import/export policy. Direct policy-match unit coverage
   now pins all ASPA verdicts plus combined RPKI+ASPA predicates. A compact
   offline subset of the NIST-BRIO ASPA demo corpus (b7.1.2) is imported as

--- a/crates/rib/src/manager/helpers.rs
+++ b/crates/rib/src/manager/helpers.rs
@@ -271,9 +271,9 @@ pub(super) fn validate_route_rpki(route: &crate::route::Route, table: &VrpTable)
 /// Validate a route's `AS_PATH` against the ASPA table.
 ///
 /// Runs the same role-aware ASPA verification that was used at import time.
-/// Returns `Unknown` if no `AS_PATH` is present.
+/// Returns `Unknown` for iBGP routes or if no `AS_PATH` is present.
 ///
-/// Per `draft-ietf-sidrops-aspa-verification-26` §6.2, ASPA applies only
+/// Per `draft-ietf-sidrops-aspa-verification-27` §6.2, ASPA applies only
 /// to IPv4/IPv6 unicast. This helper is invoked from unicast-RIB contexts
 /// only (distribution and graceful-restart revalidation of unicast
 /// routes), so the §6.2 precondition is satisfied by construction. If
@@ -284,6 +284,9 @@ pub(super) fn validate_route_aspa(
     route: &crate::route::Route,
     table: &AspaTable,
 ) -> AspaValidation {
+    if !route.is_ebgp() {
+        return AspaValidation::Unknown;
+    }
     match route.as_path() {
         Some(path) => rustbgpd_rpki::aspa_verify::verify(path, table, route.aspa_context),
         None => AspaValidation::Unknown,

--- a/crates/rib/src/manager/tests/rpki.rs
+++ b/crates/rib/src/manager/tests/rpki.rs
@@ -410,6 +410,84 @@ async fn rpki_no_table_all_not_found() {
     handle.await.unwrap();
 }
 
+/// Load-bearing RIB replay proof: removing the `!route.is_ebgp()` guard makes
+/// insertion evaluate Valid and the cache update evaluate Invalid, so both
+/// exact Unknown assertions fail.
+#[tokio::test]
+async fn ibgp_aspa_stays_unknown_on_insert_and_cache_revalidation() {
+    use rustbgpd_rpki::{AspaRecord, AspaTable};
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let peer = IpAddr::V4(Ipv4Addr::new(1, 0, 0, 5));
+    let valid_table = Arc::new(AspaTable::new(vec![AspaRecord {
+        customer_asn: 65003,
+        provider_asns: vec![65002],
+    }]));
+    tx.send(RibUpdate::AspaTableUpdate { table: valid_table })
+        .await
+        .unwrap();
+
+    let mut route = make_route_with_as_path(
+        Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24),
+        Ipv4Addr::new(1, 0, 0, 5),
+        vec![65002, 65003],
+    );
+    route.origin_type = crate::route::RouteOrigin::Ibgp;
+    route.aspa_context = rustbgpd_wire::AspaValidationContext {
+        neighbor_asn: Some(65002),
+        local_role: None,
+        first_as_check_exempt: false,
+    };
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![route],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let query = async |tx: &mpsc::Sender<RibUpdate>| {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(RibUpdate::QueryReceivedRoutes {
+            peer: Some(peer),
+            reply: reply_tx,
+        })
+        .await
+        .unwrap();
+        reply_rx.await.unwrap()
+    };
+    let inserted = query(&tx).await;
+    assert_eq!(
+        inserted[0].aspa_state,
+        rustbgpd_wire::AspaValidation::Unknown
+    );
+
+    let invalid_table = Arc::new(AspaTable::new(vec![AspaRecord {
+        customer_asn: 65003,
+        provider_asns: vec![65099],
+    }]));
+    tx.send(RibUpdate::AspaTableUpdate {
+        table: invalid_table,
+    })
+    .await
+    .unwrap();
+    let revalidated = query(&tx).await;
+    assert_eq!(
+        revalidated[0].aspa_state,
+        rustbgpd_wire::AspaValidation::Unknown
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 #[tokio::test]
 async fn aspa_cache_update_revalidates_with_stored_downstream_context() {
     use rustbgpd_rpki::{AspaRecord, AspaTable};

--- a/crates/rpki/src/aspa_verify.rs
+++ b/crates/rpki/src/aspa_verify.rs
@@ -53,7 +53,7 @@ fn leftmost_as_matches_neighbor(hops: &[u32], neighbor_asn: Option<u32>) -> bool
 }
 
 /// Verify an `AS_PATH` using the role-aware ASPA procedures from
-/// `draft-ietf-sidrops-aspa-verification-26` §5.4 and §5.5.
+/// `draft-ietf-sidrops-aspa-verification-27` §5.4 and §5.5.
 ///
 /// With no configured role, this preserves rustbgpd's legacy upstream-only
 /// behavior. When the local role is [`BgpRole::Customer`], routes are treated
@@ -67,7 +67,7 @@ pub fn verify(path: &AsPath, table: &AspaTable, context: AspaValidationContext) 
 }
 
 /// Verify an `AS_PATH` using upstream ASPA verification per
-/// `draft-ietf-sidrops-aspa-verification-26` §5.4.
+/// `draft-ietf-sidrops-aspa-verification-27` §5.4.
 ///
 /// The compressed path is indexed as `hop[0]` = neighbor AS (closest),
 /// `hop[N-1]` = origin AS (farthest). The algorithm walks from origin

--- a/crates/rpki/src/aspa_verify.rs
+++ b/crates/rpki/src/aspa_verify.rs
@@ -55,9 +55,10 @@ fn leftmost_as_matches_neighbor(hops: &[u32], neighbor_asn: Option<u32>) -> bool
 /// Verify an `AS_PATH` using the role-aware ASPA procedures from
 /// `draft-ietf-sidrops-aspa-verification-27` §5.4 and §5.5.
 ///
-/// With no configured role, this preserves rustbgpd's legacy upstream-only
-/// behavior. When the local role is [`BgpRole::Customer`], routes are treated
-/// as received from a provider and downstream verification is applied.
+/// With no configured role, rustbgpd uses upstream verification; the session
+/// boundary independently enforces the current draft's first-AS precondition.
+/// When the local role is [`BgpRole::Customer`], routes are treated as received
+/// from a provider and downstream verification is applied.
 #[must_use]
 pub fn verify(path: &AsPath, table: &AspaTable, context: AspaValidationContext) -> AspaValidation {
     match direction_for_role(context.local_role) {

--- a/crates/rpki/src/lib.rs
+++ b/crates/rpki/src/lib.rs
@@ -94,7 +94,7 @@ impl ValidationSnapshot {
 
     /// Validate a route's `AS_PATH` against the ASPA table.
     ///
-    /// Per `draft-ietf-sidrops-aspa-verification-26` §6.2, ASPA
+    /// Per `draft-ietf-sidrops-aspa-verification-27` §6.2, ASPA
     /// verification is applied only to `{AFI 1 (IPv4), SAFI 1 (Unicast)}`
     /// and `{AFI 2 (IPv6), SAFI 1 (Unicast)}`. For any other family this
     /// returns `Unknown` immediately without consulting the table — the

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -771,7 +771,8 @@ impl PeerSession {
                     .map_or(self.config.peer.remote_asn, |n| n.peer_asn),
             ),
             local_role,
-            first_as_check_exempt: matches!(local_role, Some(BgpRole::RouteServerClient)),
+            first_as_check_exempt: self.config.route_server_client
+                || matches!(local_role, Some(BgpRole::RouteServerClient)),
         }
     }
     /// Return the received and negotiated ASNs when an IPv4/IPv6-unicast

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -765,28 +765,25 @@ impl PeerSession {
     pub(super) fn aspa_validation_context(&self) -> AspaValidationContext {
         let local_role = self.config.peer.local_role;
         AspaValidationContext {
-            neighbor_asn: local_role.map(|_| {
+            neighbor_asn: Some(
                 self.negotiated
                     .as_ref()
-                    .map_or(self.config.peer.remote_asn, |n| n.peer_asn)
-            }),
+                    .map_or(self.config.peer.remote_asn, |n| n.peer_asn),
+            ),
             local_role,
             first_as_check_exempt: matches!(local_role, Some(BgpRole::RouteServerClient)),
         }
     }
     /// Return the received and negotiated ASNs when an IPv4/IPv6-unicast
-    /// UPDATE between role-aware, four-octet-AS-capable eBGP speakers fails
-    /// the ASPA first-AS precondition. Roleless sessions keep their
-    /// compatibility behavior, and an RS-client remains exempt for a
-    /// transparent route server / IX.
+    /// UPDATE from an eBGP peer fails the ASPA first-AS precondition. An
+    /// RS-client remains exempt for a transparent route server / IX.
     pub(super) fn aspa_first_as_mismatch(
         &self,
-        four_octet_as: bool,
         is_ebgp: bool,
         has_unicast_announcements: bool,
         attrs: &[PathAttribute],
     ) -> Option<(Option<u32>, u32)> {
-        if !four_octet_as || !is_ebgp || !has_unicast_announcements {
+        if !is_ebgp || !has_unicast_announcements {
             return None;
         }
         let context = self.aspa_validation_context();
@@ -1383,10 +1380,11 @@ impl PeerSession {
             self.metrics
                 .record_update_malformed(&self.peer_label, malformed_disposition_label(applied));
         }
-        // draft-ietf-sidrops-aspa-verification-26 §5: between role-aware,
-        // four-octet-AS-capable eBGP speakers, an AS_PATH whose most recently
-        // added AS is not the negotiated neighbor AS is semantically invalid
-        // and SHALL use RFC 7606 treat-as-withdraw. Section 6.2 scopes ASPA
+        // draft-ietf-sidrops-aspa-verification-27 §5: an AS_PATH whose most
+        // recently added AS is not the negotiated eBGP neighbor AS is
+        // semantically invalid and SHALL use RFC 7606 treat-as-withdraw. For
+        // an RFC 6793 OLD peer, `parse_revised` has already reconstructed the
+        // effective path before this check. Section 6.2 scopes ASPA
         // verification to IPv4/IPv6 unicast. Apply this before policy/ASPA
         // state so the disposition cannot depend on an operator policy or
         // cache snapshot.
@@ -1400,12 +1398,9 @@ impl PeerSession {
                             && !mp.announced.is_empty()
                 )
             });
-        if let Some((received_first_as, neighbor_asn)) = self.aspa_first_as_mismatch(
-            four_octet_as,
-            is_ebgp,
-            has_unicast_announcements,
-            &parsed.attributes,
-        ) {
+        if let Some((received_first_as, neighbor_asn)) =
+            self.aspa_first_as_mismatch(is_ebgp, has_unicast_announcements, &parsed.attributes)
+        {
             warn!(
                 peer = %self.peer_label,
                 received_first_as = ?received_first_as,
@@ -1763,22 +1758,30 @@ impl PeerSession {
         // Compute ASPA state once per UPDATE for the IPv4-unicast body NLRI
         // surface. Other families compute their own state inside the
         // MP_REACH_NLRI handling below — draft-ietf-sidrops-aspa-
-        // verification-25 §6.2 limits verification to IPv4/IPv6 unicast,
+        // verification-27 §6.2 limits verification to IPv4/IPv6 unicast,
         // and `ValidationSnapshot::validate_aspa` returns `Unknown` for
         // every other family.
         //
-        // draft v25 §5.4 step 2 also requires the most-recent AS in `AS_PATH`
+        // draft v27 §5.4 step 2 also requires the most-recent AS in `AS_PATH`
         // to equal the negotiated neighbor ASN, with a transparent-route-
-        // server-client exception. That leftmost-AS precondition is enforced
-        // here whenever a local BGP Role is configured (the role-aware
-        // context carries the neighbor ASN and the RS-client exemption); the
-        // roleless case keeps the legacy behavior and skips it.
+        // server-client exception. The context always carries the neighbor
+        // ASN; a configured role selects verification direction, not whether
+        // the first-AS precondition applies.
         let aspa_context = self.aspa_validation_context();
-        let body_aspa_state = validation
-            .as_ref()
-            .map_or(rustbgpd_wire::AspaValidation::Unknown, |v| {
-                v.validate_aspa(parsed_as_path, (Afi::Ipv4, Safi::Unicast), aspa_context)
-            });
+        // ASPA is an edge-ingress signal. Draft -27 §6.2 says applying it to
+        // iBGP is NOT RECOMMENDED, so rustbgpd deliberately presents Unknown
+        // to import policy and stores Unknown for every iBGP unicast route.
+        let validate_aspa = |family| {
+            if !is_ebgp {
+                return rustbgpd_wire::AspaValidation::Unknown;
+            }
+            validation
+                .as_ref()
+                .map_or(rustbgpd_wire::AspaValidation::Unknown, |v| {
+                    v.validate_aspa(parsed_as_path, family, aspa_context)
+                })
+        };
+        let body_aspa_state = validate_aspa((Afi::Ipv4, Safi::Unicast));
         let unnumbered_ipv4_body_forbidden = self.is_scoped_link_local_peer();
         if unnumbered_ipv4_body_forbidden
             && (!parsed.announced.is_empty() || !parsed.withdrawn.is_empty())
@@ -1998,16 +2001,12 @@ impl PeerSession {
                         );
                         continue;
                     }
-                    // ASPA state for this MP_REACH family. Per draft v25 §6.2,
+                    // ASPA state for this MP_REACH family. Per draft v27 §6.2,
                     // `ValidationSnapshot::validate_aspa` returns `Unknown` for
                     // anything outside IPv4/IPv6 unicast — so FlowSpec and
                     // EVPN announcements below propagate `Unknown` even when
                     // an ASPA table is loaded, without any extra branching.
-                    let mp_aspa_state = validation
-                        .as_ref()
-                        .map_or(rustbgpd_wire::AspaValidation::Unknown, |v| {
-                            v.validate_aspa(parsed_as_path, family, aspa_context)
-                        });
+                    let mp_aspa_state = validate_aspa(family);
                     if mp.safi == Safi::FlowSpec {
                         // FlowSpec announced routes — no next-hop (NH len = 0)
                         for rule in &mp.flowspec_announced {

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1266,13 +1266,15 @@ async fn aspa_first_as_mismatch_enforced_without_configured_role() {
 async fn aspa_first_as_mismatch_enforced_for_old_peer() {
     assert_aspa_first_as_mismatch_withdraws_replacement(false).await;
 }
-/// Load-bearing transparent-IX control: removing the RS-client exemption (or
-/// applying the first-AS check to every eBGP session) makes this mismatched
-/// route disappear instead of being announced.
+/// Load-bearing transparent-IX control: removing the legacy
+/// `route_server_client` exemption (or applying the first-AS check to every
+/// eBGP session) makes this mismatched route disappear instead of being
+/// announced. This is the configuration seam used by existing route-server
+/// deployments that do not also negotiate an RFC 9234 role.
 #[tokio::test]
-async fn aspa_first_as_mismatch_exempts_route_server_client() {
+async fn aspa_first_as_mismatch_exempts_legacy_route_server_client() {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
-    session.config.peer.local_role = Some(BgpRole::RouteServerClient);
+    session.config.route_server_client = true;
     install_test_negotiated_session(&mut session, negotiated_session(65002, false));
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
 

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1179,16 +1179,18 @@ fn aspa_validation_context_uses_negotiated_asn_and_local_role() {
     );
     assert!(context.first_as_check_exempt);
 }
+/// Load-bearing context proof: restoring the configured-role condition makes
+/// the roleless neighbor ASN `None`, failing the exact negotiated-ASN assertion.
 #[test]
-fn aspa_validation_context_preserves_roleless_legacy_behavior() {
+fn aspa_validation_context_carries_neighbor_asn_without_a_role() {
     let mut session = make_test_session(65001, 65002);
     session.negotiated = Some(negotiated_session(65099, false));
     let context = session.aspa_validation_context();
-    assert_eq!(context.neighbor_asn, None);
+    assert_eq!(context.neighbor_asn, Some(65099));
     assert_eq!(context.local_role, None);
     assert!(!context.first_as_check_exempt);
 }
-fn aspa_first_as_update(prefix: Ipv4Prefix, first_asn: u32) -> UpdateMessage {
+fn aspa_first_as_update(prefix: Ipv4Prefix, first_asn: u32, four_octet_as: bool) -> UpdateMessage {
     UpdateMessage::build(
         &[Ipv4NlriEntry { path_id: 0, prefix }],
         &[],
@@ -1199,26 +1201,24 @@ fn aspa_first_as_update(prefix: Ipv4Prefix, first_asn: u32) -> UpdateMessage {
             }),
             PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
         ],
-        true,
+        four_octet_as,
         false,
         Ipv4UnicastMode::Body,
     )
 }
-/// Load-bearing proof: deleting the role-aware first-AS branch in
-/// `process_update` leaves the second announcement installed, so the exact
-/// withdrawal and known-prefix assertions fail.
-#[tokio::test]
-async fn aspa_first_as_mismatch_withdraws_replacement_and_keeps_session_established() {
+async fn assert_aspa_first_as_mismatch_withdraws_replacement(four_octet_as: bool) {
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
-    session.config.peer.local_role = Some(BgpRole::Peer);
     let (client, _server) = connected_stream_pair().await;
     session.test_install_stream(client);
     establish_test_session(&mut session, 65002).await;
     while rib_rx.try_recv().is_ok() {}
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.four_octet_as = four_octet_as;
+    install_test_negotiated_session(&mut session, negotiated);
 
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
     session
-        .process_update(aspa_first_as_update(prefix, 65002))
+        .process_update(aspa_first_as_update(prefix, 65002, four_octet_as))
         .await;
     let RibUpdate::RoutesReceived { announced, .. } = rib_rx
         .try_recv()
@@ -1230,7 +1230,7 @@ async fn aspa_first_as_mismatch_withdraws_replacement_and_keeps_session_establis
     assert_eq!(session.known_prefix_count(), 1);
 
     session
-        .process_update(aspa_first_as_update(prefix, 65003))
+        .process_update(aspa_first_as_update(prefix, 65003, four_octet_as))
         .await;
     let RibUpdate::RoutesReceived {
         announced,
@@ -1252,6 +1252,20 @@ async fn aspa_first_as_mismatch_withdraws_replacement_and_keeps_session_establis
     );
     assert_single_malformed_disposition(&session, "treat_as_withdraw");
 }
+/// Load-bearing roleless-peer proof: restoring the configured-role gate leaves
+/// the mismatched replacement installed, failing the exact withdrawal and
+/// known-prefix assertions in the shared exercise.
+#[tokio::test]
+async fn aspa_first_as_mismatch_enforced_without_configured_role() {
+    assert_aspa_first_as_mismatch_withdraws_replacement(true).await;
+}
+/// Load-bearing RFC 6793 OLD-peer proof: restoring the negotiated
+/// four-octet-AS gate leaves the mismatched two-octet path installed, failing
+/// the exact withdrawal and known-prefix assertions in the shared exercise.
+#[tokio::test]
+async fn aspa_first_as_mismatch_enforced_for_old_peer() {
+    assert_aspa_first_as_mismatch_withdraws_replacement(false).await;
+}
 /// Load-bearing transparent-IX control: removing the RS-client exemption (or
 /// applying the first-AS check to every eBGP session) makes this mismatched
 /// route disappear instead of being announced.
@@ -1263,7 +1277,7 @@ async fn aspa_first_as_mismatch_exempts_route_server_client() {
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
 
     session
-        .process_update(aspa_first_as_update(prefix, 65003))
+        .process_update(aspa_first_as_update(prefix, 65003, true))
         .await;
     let RibUpdate::RoutesReceived {
         announced,
@@ -1279,28 +1293,19 @@ async fn aspa_first_as_mismatch_exempts_route_server_client() {
     assert!(withdrawn.is_empty());
     assert_eq!(session.known_prefix_count(), 1);
 }
-/// Load-bearing compatibility controls: removing either the eBGP or
-/// configured-role guard makes its corresponding mismatched path return a
-/// violation.
+/// Load-bearing scope controls: removing either the eBGP or unicast-family
+/// guard makes its corresponding mismatched path return a violation.
 #[test]
-fn aspa_first_as_mismatch_preserves_roleless_and_ibgp_compatibility() {
+fn aspa_first_as_mismatch_preserves_ibgp_and_family_scope() {
     let attrs = [PathAttribute::AsPath(AsPath {
         segments: vec![AsPathSegment::AsSequence(vec![65003])],
     })];
-
-    let mut roleless_ebgp = make_test_session(65001, 65002);
-    install_test_negotiated_session(&mut roleless_ebgp, negotiated_session(65002, false));
-    assert_eq!(
-        roleless_ebgp.aspa_first_as_mismatch(true, true, true, &attrs),
-        None,
-        "roleless eBGP keeps legacy first-AS behavior"
-    );
 
     let mut internal_role_session = make_test_session(65001, 65001);
     internal_role_session.config.peer.local_role = Some(BgpRole::Peer);
     install_test_negotiated_session(&mut internal_role_session, negotiated_session(65001, false));
     assert_eq!(
-        internal_role_session.aspa_first_as_mismatch(true, false, true, &attrs),
+        internal_role_session.aspa_first_as_mismatch(false, true, &attrs),
         None,
         "the ASPA first-AS precondition is not applied to iBGP"
     );
@@ -1309,19 +1314,14 @@ fn aspa_first_as_mismatch_preserves_roleless_and_ibgp_compatibility() {
     external_role_session.config.peer.local_role = Some(BgpRole::Peer);
     install_test_negotiated_session(&mut external_role_session, negotiated_session(65002, false));
     assert_eq!(
-        external_role_session.aspa_first_as_mismatch(false, true, true, &attrs),
-        None,
-        "the draft check requires four-octet-AS capability"
-    );
-    assert_eq!(
-        external_role_session.aspa_first_as_mismatch(true, true, false, &attrs),
+        external_role_session.aspa_first_as_mismatch(true, false, &attrs),
         None,
         "the draft check is scoped to IPv4/IPv6 unicast announcements"
     );
 
     let empty_path = [PathAttribute::AsPath(AsPath { segments: vec![] })];
     assert_eq!(
-        external_role_session.aspa_first_as_mismatch(true, true, true, &empty_path),
+        external_role_session.aspa_first_as_mismatch(true, true, &empty_path),
         Some((None, 65002)),
         "an AS_PATH with no ordered first AS fails the neighbor-AS check"
     );
@@ -1332,7 +1332,7 @@ fn aspa_first_as_mismatch_preserves_roleless_and_ibgp_compatibility() {
         ],
     })];
     assert_eq!(
-        external_role_session.aspa_first_as_mismatch(true, true, true, &split_sequence),
+        external_role_session.aspa_first_as_mismatch(true, true, &split_sequence),
         Some((Some(65003), 65002)),
         "the first ordered ASN may be in a later AS_SEQUENCE"
     );
@@ -1343,7 +1343,7 @@ fn aspa_first_as_mismatch_preserves_roleless_and_ibgp_compatibility() {
         ],
     })];
     assert_eq!(
-        external_role_session.aspa_first_as_mismatch(true, true, true, &with_as_set),
+        external_role_session.aspa_first_as_mismatch(true, true, &with_as_set),
         None,
         "AS_SET disposition remains outside the neighbor-AS gate"
     );
@@ -13928,6 +13928,103 @@ async fn import_policy_filters_rpki_invalid_with_snapshot() {
         assert_eq!(entry.rpki, rustbgpd_wire::RpkiValidation::Invalid);
     }
 }
+/// Load-bearing edge-ingress proof: removing the transport iBGP gate makes
+/// both the IPv4 body and IPv6 `MP_REACH` paths evaluate `Invalid` at import
+/// policy, so the permit-Unknown policy drops them and this exact two-route
+/// assertion fails.
+#[tokio::test]
+async fn ibgp_import_policy_sees_unknown_aspa_for_ipv4_and_ipv6() {
+    use rustbgpd_rpki::{AspaTable, ValidationSnapshot};
+    use tokio::sync::watch;
+
+    let mut peer_config = PeerConfig::new(65001, 65001, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)];
+    let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    let (_cmd_tx, cmd_rx) = mpsc::channel(8);
+    let (rib_tx, mut rib_rx) = mpsc::channel(64);
+    let snapshot = ValidationSnapshot {
+        vrp_table: None,
+        aspa_table: Some(Arc::new(AspaTable::new(vec![]))),
+    };
+    let (_watch_tx, watch_rx) = watch::channel(snapshot);
+    let mut permit_unknown_statement = retention_statement(None, PolicyAction::Permit);
+    permit_unknown_statement.match_aspa_validation = Some(rustbgpd_wire::AspaValidation::Unknown);
+    let permit_unknown = PolicyChain::new(vec![Policy {
+        entries: vec![permit_unknown_statement],
+        default_action: PolicyAction::Deny,
+    }]);
+    let mut session = PeerSession::new(
+        config,
+        BgpMetrics::new(),
+        cmd_rx,
+        rib_tx,
+        Some(permit_unknown),
+        None,
+        None,
+        None,
+        Some(watch_rx),
+        false,
+    );
+    let mut negotiated = negotiated_session(65001, false);
+    negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)];
+    install_test_negotiated_session(&mut session, negotiated);
+
+    let v4 = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let v6 = Ipv6Prefix::new("2001:db8::".parse().unwrap(), 32);
+    let attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            // No local-AS loop, but the leftmost AS does not match the iBGP
+            // neighbor ASN; applying eBGP ASPA semantics would be Invalid.
+            segments: vec![AsPathSegment::AsSequence(vec![65002, 65003])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+        PathAttribute::MpReachNlri(rustbgpd_wire::MpReachNlri {
+            afi: Afi::Ipv6,
+            safi: Safi::Unicast,
+            next_hop: IpAddr::V6("2001:db8::1".parse().unwrap()),
+            link_local_next_hop: None,
+            announced: vec![rustbgpd_wire::NlriEntry {
+                path_id: 0,
+                prefix: Prefix::V6(v6),
+            }],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            labeled_announced: vec![],
+            vpn_announced: vec![],
+            rtc_announced: vec![],
+        }),
+    ];
+    session
+        .process_update(UpdateMessage::build(
+            &[Ipv4NlriEntry {
+                path_id: 0,
+                prefix: v4,
+            }],
+            &[],
+            &attrs,
+            true,
+            false,
+            Ipv4UnicastMode::Body,
+        ))
+        .await;
+
+    let RibUpdate::RoutesReceived { announced, .. } =
+        rib_rx.try_recv().expect("both iBGP routes reach the RIB")
+    else {
+        panic!("expected RoutesReceived");
+    };
+    assert_eq!(announced.len(), 2);
+    assert!(announced.iter().any(|route| route.prefix == Prefix::V4(v4)));
+    assert!(announced.iter().any(|route| route.prefix == Prefix::V6(v6)));
+    assert!(
+        announced
+            .iter()
+            .all(|route| route.aspa_state == rustbgpd_wire::AspaValidation::Unknown)
+    );
+}
+
 /// Verify that import policy `match_aspa_validation = "invalid"` + `action = "deny"`
 /// drops ASPA-invalid routes when a `ValidationSnapshot` with an ASPA table is provided.
 #[tokio::test]

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -194,14 +194,14 @@ pub enum AspaValidation {
 /// Session context needed to choose and replay ASPA path verification.
 ///
 /// ASPA verification is role-aware in
-/// `draft-ietf-sidrops-aspa-verification-26`: routes received from a
+/// `draft-ietf-sidrops-aspa-verification-27`: routes received from a
 /// provider use downstream verification, while customer/peer/route-server
 /// shapes use upstream verification. Stored routes keep this compact context
 /// so RTR cache updates can revalidate them with the same relationship
 /// semantics used at import time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct AspaValidationContext {
-    /// Neighbor ASN used for the draft v25 leftmost-AS precondition.
+    /// Neighbor ASN used for the current draft's first-AS precondition.
     pub neighbor_asn: Option<u32>,
     /// Locally configured BGP Role for this eBGP session.
     pub local_role: Option<BgpRole>,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2510,10 +2510,11 @@ same entry are ANDed.
 
 ASPA verification is an IPv4/IPv6-unicast edge-ingress signal. eBGP routes
 are verified even when no BGP Role is configured; a Role selects verification
-direction, while `rs-client` retains the transparent-IX first-AS exception.
-RFC 6793 OLD peers are checked after AS_PATH reconstruction. Routes learned
-over iBGP always present `aspa = "unknown"` to import policy and keep that
-state across ASPA cache revalidation, following
+direction. Transparent sessions retain the first-AS exception when configured
+with either `route_server_client = true` or the local `rs-client` Role. RFC 6793
+OLD peers are checked after AS_PATH reconstruction. Routes learned over iBGP
+always present `aspa = "unknown"` to import policy and keep that state across
+ASPA cache revalidation, following
 `draft-ietf-sidrops-aspa-verification-27` §6.2's recommendation against
 internal-session verification.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2508,6 +2508,15 @@ same entry are ANDed.
 `match_med_ge`, `match_med_le`, `match_next_hop`, or
 `match_rpki_validation` / `match_aspa_validation` is required.
 
+ASPA verification is an IPv4/IPv6-unicast edge-ingress signal. eBGP routes
+are verified even when no BGP Role is configured; a Role selects verification
+direction, while `rs-client` retains the transparent-IX first-AS exception.
+RFC 6793 OLD peers are checked after AS_PATH reconstruction. Routes learned
+over iBGP always present `aspa = "unknown"` to import policy and keep that
+state across ASPA cache revalidation, following
+`draft-ietf-sidrops-aspa-verification-27` §6.2's recommendation against
+internal-session verification.
+
 ### Route modifications (set actions)
 
 These fields modify matching routes. Only valid with `action = "permit"`.

--- a/docs/adr/0049-aspa-verification.md
+++ b/docs/adr/0049-aspa-verification.md
@@ -62,7 +62,7 @@ multiple CAs may issue ASPAs for the same customer.
 ### Role-aware verification
 
 ASPA verification is selected from the configured BGP Role (RFC 9234), matching
-draft-ietf-sidrops-aspa-verification-25 §6.3:
+draft-ietf-sidrops-aspa-verification-27 §6.3:
 
 - local role `customer` (routes received from a provider) uses downstream
   verification (§5.5);
@@ -75,7 +75,7 @@ can revalidate with the same direction used at import time.
 
 ### Verification algorithm
 
-Per draft-ietf-sidrops-aspa-verification:
+Per draft-ietf-sidrops-aspa-verification-27:
 
 1. Compress AS_PATH: flatten segments, remove consecutive duplicates
 2. Empty AS_PATH -> Invalid (per spec step 1)
@@ -191,6 +191,8 @@ ASPA table changes. Set on ingress and updated on ASPA table changes.
   ASPA is only available when the cache supports RTR v2
 - No new ASPA-specific config is needed — it uses the same RTR cache servers
   as RPKI ROV and the existing BGP Roles configuration to select direction
+- iBGP routes deliberately carry `Unknown`: ASPA is an edge-ingress signal,
+  and draft -27 §6.2 says its use on internal sessions is NOT RECOMMENDED
 
 ## Amendments
 
@@ -250,3 +252,25 @@ subset of the NIST-BRIO ASPA demo corpus (b7.1.2) now pins upstream and
 downstream Valid / Invalid / Unknown verifier outcomes, including the documented
 ASPA-Valid forged-origin / forged-segment limitations. Keep expanding focused
 `match_aspa_validation` policy coverage as demand warrants.
+
+### 2026-08-03 — Edge-ingress applicability and RFC 6793 peers
+
+The implementation is aligned with
+`draft-ietf-sidrops-aspa-verification-27` on three applicability boundaries:
+
+- The §5 neighbor-AS check applies to eligible eBGP unicast routes even when no
+  BGP Role is configured. Roles select upstream versus downstream verification;
+  they are not a prerequisite for the neighbor-AS check. A local
+  `rs-client` remains exempt for a transparent IX as required by §5.
+- A peer that did not negotiate the four-octet-AS capability is not exempt.
+  rustbgpd is the RFC 6793 NEW speaker and applies the check to the effective
+  AS_PATH after `AS_PATH` / `AS4_PATH` reconstruction.
+- IPv4/IPv6-unicast routes learned over iBGP are assigned `Unknown` before
+  import policy. Initial insertion and later ASPA-cache revalidation preserve
+  that state. This is rustbgpd's edge-ingress policy based on draft -27 §6.2's
+  NOT RECOMMENDED language, not a protocol MUST.
+
+The first two corrections can newly treat a roleless or RFC 6793 OLD-peer
+eBGP UPDATE with a mismatched first AS as withdraw. The iBGP correction can
+change prior ASPA-derived best-path rankings by replacing computed Valid or
+Invalid states with Unknown; no best-path algorithm or retention rule changed.

--- a/docs/adr/0049-aspa-verification.md
+++ b/docs/adr/0049-aspa-verification.md
@@ -261,8 +261,9 @@ The implementation is aligned with
 - The §5 neighbor-AS check applies to eligible eBGP unicast routes even when no
   BGP Role is configured. Roleless sessions continue to use upstream
   verification; configured roles select upstream versus downstream verification
-  and are not a prerequisite for the neighbor-AS check. A local
-  `rs-client` remains exempt for a transparent IX as required by §5.
+  and are not a prerequisite for the neighbor-AS check. Transparent sessions
+  remain exempt when identified by either the existing
+  `route_server_client = true` knob or a local `rs-client` Role.
 - A peer that did not negotiate the four-octet-AS capability is not exempt.
   rustbgpd is the RFC 6793 NEW speaker and applies the check to the effective
   AS_PATH after `AS_PATH` / `AS4_PATH` reconstruction.

--- a/docs/adr/0049-aspa-verification.md
+++ b/docs/adr/0049-aspa-verification.md
@@ -259,8 +259,9 @@ The implementation is aligned with
 `draft-ietf-sidrops-aspa-verification-27` on three applicability boundaries:
 
 - The §5 neighbor-AS check applies to eligible eBGP unicast routes even when no
-  BGP Role is configured. Roles select upstream versus downstream verification;
-  they are not a prerequisite for the neighbor-AS check. A local
+  BGP Role is configured. Roleless sessions continue to use upstream
+  verification; configured roles select upstream versus downstream verification
+  and are not a prerequisite for the neighbor-AS check. A local
   `rs-client` remains exempt for a transparent IX as required by §5.
 - A peer that did not negotiate the four-octet-AS capability is not exempt.
   rustbgpd is the RFC 6793 NEW speaker and applies the check to the effective


### PR DESCRIPTION
## Summary

- enforce the ASPA first-AS precondition for roleless eBGP sessions and RFC 6793 OLD peers after effective `AS_PATH` reconstruction
- preserve transparent-IX behavior for both the existing `route_server_client = true` knob and the RFC 9234 `rs-client` role
- keep IPv4/IPv6-unicast routes learned over iBGP at ASPA `Unknown` before import policy and across RIB cache revalidation
- update the active operator and design documentation to draft -27

## Standards and operator impact

This aligns the session boundary with [draft-ietf-sidrops-aspa-verification-27](https://www.ietf.org/archive/id/draft-ietf-sidrops-aspa-verification-27.html) §§5 and 6.2 and uses the reconstructed path defined by [RFC 6793](https://www.rfc-editor.org/rfc/rfc6793.html).

Transparent route-server sessions remain exempt from the first-AS precondition when configured through either supported route-server signal. A roleless non-route-server eBGP or RFC 6793 OLD-peer UPDATE with a mismatched first AS is now handled as treat-as-withdraw. Existing iBGP routes can change from a computed ASPA Valid/Invalid ranking to Unknown after upgrade; no best-path, retention, API, or schema contract changes.

## Load-bearing regression proofs

Each new regression was destructively checked:

- restoring the configured-role gate makes the roleless negotiated-ASN assertion fail
- restoring the negotiated four-octet-AS gate leaves an OLD-peer mismatch installed instead of withdrawn
- removing the transport iBGP gate causes the IPv4/IPv6 permit-Unknown import-policy test to lose both routes
- removing the RIB iBGP guard changes insertion and cache revalidation away from exact Unknown
- removing the RFC 9234 `rs-client` exemption drops its transparent-IX route
- removing the legacy `route_server_client` exemption makes the focused test fail because no announcement reaches the RIB

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- focused first-AS, iBGP import-policy, and RIB insertion/cache-revalidation tests
- local M94 RFC 6793 OLD-speaker receipt: 13/13 passed, including exact AS4 projection, reconstructed loop rejection, withdrawal, and both sessions remaining Established
- `git diff --check origin/main...HEAD`
