### PR TITLE
ci(interop): pin the GoBGP v3 fixture

### DIFF
--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -209,6 +209,9 @@ def check(root: Path) -> list[str]:
         f"ENV GOBGP_VERSION={GOBGP_VERSION}",
         'archive="gobgp_${GOBGP_VERSION}_linux_${TARGETARCH}.tar.gz"',
         '*) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;;',
+        'https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/${archive}',
+        'echo "${checksum}  /tmp/${archive}" | sha256sum --check --strict',
+        'tar --extract --gzip --file "/tmp/${archive}" --directory /usr/local/bin gobgp gobgpd',
         'test "$(gobgp --version)" = "gobgp version ${GOBGP_VERSION}"',
         'test "$(gobgpd --version)" = "gobgpd version ${GOBGP_VERSION}"',
     ):

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -30,6 +30,11 @@ BUILDX = (
 BUILD_PUSH = (
     "uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7"
 )
+GOBGP_VERSION = "3.37.0"
+GOBGP_CHECKSUMS = {
+    "amd64": "e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522",
+    "arm64": "0aaa2da6e4dcaaf57e3d0e64eae14946292b0a5894d80ef3b7ebde3bf52beb29",
+}
 
 TRIGGER_HASHES = {
     "ci.yml": "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8",
@@ -196,6 +201,28 @@ def check(root: Path) -> list[str]:
             )
         if f"COPY --from=builder /out/{binary} /usr/local/bin/{binary}" not in dev:
             errors.append(f"Dockerfile: dev does not copy builder /out/{binary}")
+
+    gobgp = (root / "tests" / "interop" / "Dockerfile.gobgp").read_text()
+    for seam in (
+        "FROM debian:bookworm-slim AS gobgp-release",
+        "ARG TARGETARCH",
+        f"ENV GOBGP_VERSION={GOBGP_VERSION}",
+        'archive="gobgp_${GOBGP_VERSION}_linux_${TARGETARCH}.tar.gz"',
+        '*) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;;',
+        'test "$(gobgp --version)" = "gobgp version ${GOBGP_VERSION}"',
+        'test "$(gobgpd --version)" = "gobgpd version ${GOBGP_VERSION}"',
+    ):
+        if seam not in gobgp:
+            errors.append(f"Dockerfile.gobgp: pinned release seam missing: {seam}")
+    if gobgp.count("FROM debian:bookworm-slim") != 2:
+        errors.append("Dockerfile.gobgp: rolling bookworm stage roster drifted")
+    for arch, checksum in GOBGP_CHECKSUMS.items():
+        if f'{arch}) checksum="{checksum}" ;;' not in gobgp:
+            errors.append(f"Dockerfile.gobgp: {arch} checksum drifted")
+    if re.search(r"(?:@latest|releases/(?:latest|download/latest)|GOBGP_VERSION=latest)", gobgp):
+        errors.append("Dockerfile.gobgp: floating GoBGP release is forbidden")
+    if "go install github.com/osrg/gobgp" in gobgp or "FROM golang:" in gobgp:
+        errors.append("Dockerfile.gobgp: source build replaced pinned release archives")
     return errors
 
 

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -24,6 +24,9 @@ class PrimerContractTests(unittest.TestCase):
                 target.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copytree(source, target)
             shutil.copy2(ROOT / "Dockerfile", root / "Dockerfile")
+            gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
+            gobgp.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
             path = root / relative
             text = path.read_text()
             start = 0
@@ -244,6 +247,43 @@ class PrimerContractTests(unittest.TestCase):
                     f"COPY --from=builder /out/{binary} /usr/local/bin/{binary}",
                     "# removed",
                 )
+
+    def test_gobgp_release_archive_contract_is_load_bearing(self):
+        relative = "tests/interop/Dockerfile.gobgp"
+        cases = (
+            ("ENV GOBGP_VERSION=3.37.0", "ENV GOBGP_VERSION=latest"),
+            (
+                'amd64) checksum="e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522" ;;',
+                'amd64) checksum="f20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522" ;;',
+            ),
+            (
+                'arm64) checksum="0aaa2da6e4dcaaf57e3d0e64eae14946292b0a5894d80ef3b7ebde3bf52beb29" ;;',
+                'arm64) checksum="1aaa2da6e4dcaaf57e3d0e64eae14946292b0a5894d80ef3b7ebde3bf52beb29" ;;',
+            ),
+            (
+                '*) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;;',
+                "*) exit 1 ;;",
+            ),
+            (
+                'test "$(gobgp --version)" = "gobgp version ${GOBGP_VERSION}"',
+                "true # removed gobgp assertion",
+            ),
+            (
+                'test "$(gobgpd --version)" = "gobgpd version ${GOBGP_VERSION}"',
+                "true # removed gobgpd assertion",
+            ),
+            (
+                "FROM debian:bookworm-slim AS gobgp-release",
+                "FROM golang:1.23-bookworm AS gobgp-release",
+            ),
+            (
+                "\nFROM debian:bookworm-slim\n",
+                "\nFROM debian:trixie-slim\n",
+            ),
+        )
+        for old, new in cases:
+            with self.subTest(seam=old):
+                self.mutate(relative, old, new)
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -265,6 +265,18 @@ class PrimerContractTests(unittest.TestCase):
                 "*) exit 1 ;;",
             ),
             (
+                'https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/${archive}',
+                "https://example.invalid/${archive}",
+            ),
+            (
+                'echo "${checksum}  /tmp/${archive}" | sha256sum --check --strict',
+                "true # skipped checksum verification",
+            ),
+            (
+                'tar --extract --gzip --file "/tmp/${archive}" --directory /usr/local/bin gobgp gobgpd',
+                'tar --extract --gzip --file "/tmp/${archive}" --directory /usr/local/bin',
+            ),
+            (
                 'test "$(gobgp --version)" = "gobgp version ${GOBGP_VERSION}"',
                 "true # removed gobgp assertion",
             ),

--- a/tests/interop/Dockerfile.gobgp
+++ b/tests/interop/Dockerfile.gobgp
@@ -1,7 +1,27 @@
-FROM golang:1.23-bookworm AS builder
+FROM debian:bookworm-slim AS gobgp-release
 
-RUN go install github.com/osrg/gobgp/v3/cmd/gobgpd@latest && \
-    go install github.com/osrg/gobgp/v3/cmd/gobgp@latest
+ARG TARGETARCH
+ENV GOBGP_VERSION=3.37.0
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        amd64) checksum="e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522" ;; \
+        arm64) checksum="0aaa2da6e4dcaaf57e3d0e64eae14946292b0a5894d80ef3b7ebde3bf52beb29" ;; \
+        *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    archive="gobgp_${GOBGP_VERSION}_linux_${TARGETARCH}.tar.gz"; \
+    curl --fail --location --silent --show-error \
+        "https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/${archive}" \
+        --output "/tmp/${archive}"; \
+    echo "${checksum}  /tmp/${archive}" | sha256sum --check --strict; \
+    tar --extract --gzip --file "/tmp/${archive}" --directory /usr/local/bin gobgp gobgpd; \
+    test "$(gobgp --version)" = "gobgp version ${GOBGP_VERSION}"; \
+    test "$(gobgpd --version)" = "gobgpd version ${GOBGP_VERSION}"
 
 FROM debian:bookworm-slim
 
@@ -9,7 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iproute2 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /go/bin/gobgpd /usr/local/bin/gobgpd
-COPY --from=builder /go/bin/gobgp /usr/local/bin/gobgp
+COPY --from=gobgp-release /usr/local/bin/gobgpd /usr/local/bin/gobgpd
+COPY --from=gobgp-release /usr/local/bin/gobgp /usr/local/bin/gobgp
 
 CMD ["sleep", "infinity"]


### PR DESCRIPTION
## Summary

- replace floating `go install ...@latest` inputs with official GoBGP v3.37.0 release archives for linux/amd64 and linux/arm64
- verify the upstream-published SHA-256 before extracting exactly `gobgp` and `gobgpd`
- fail unsupported architectures and assert both runtime versions during the image build
- structurally fence the official versioned URL, checksums, verification pipeline, binary extraction, stage roster, and runtime assertions

## Why

Eight hosted interop/kernel scenarios currently rebuild this fixture. `@latest` happens to resolve to v3.37.0 today, but a future upstream release could change those test inputs without a repository diff. This PR makes the fixture reproducible while preserving the current version and scenarios. It intentionally does not add artifact sharing; the cheaper archive-based build should be measured before that complexity is considered.

Source: [GoBGP v3.37.0 release](https://github.com/osrg/gobgp/releases/tag/v3.37.0).

## Load-bearing regression proofs

- replacing the version with `latest` makes the static contract red
- removing either runtime assertion makes the static contract red
- changing the official release origin, checksum pipeline, or explicit two-binary extraction makes the static contract red
- changing one amd64 checksum digit makes a real no-cache build fail at `sha256sum`
- using the official v3.36.0 archive/checksum while expecting v3.37.0 makes the real build fail at the runtime version assertion
- changing the architecture fallback or rolling two-stage roster makes the contract red

## Verification

- `python3 -m unittest -v scripts/test_check_ci_image_primer_contract.py` (6/6)
- `python3 scripts/check_ci_image_primer_contract.py`
- `python3 -m py_compile scripts/check_ci_image_primer_contract.py scripts/test_check_ci_image_primer_contract.py`
- fresh `docker buildx build --pull --no-cache --platform linux/amd64 --load`
- `gobgp --version` and `gobgpd --version` from the built runtime image: 3.37.0
- upstream checksum asset independently re-read with `gh release download`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `git diff --check origin/main...HEAD`
