### PR TITLE
fix(cli): show ASPA in rejected-route table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `rbgp rib received <peer> --rejected` now shows the retained ASPA
+  validation state beside RPKI in its human-readable table; unavailable
+  validation facts render as `-`, matching the existing RPKI convention.
+
 - gNMI STREAM/ON_CHANGE now fails with `DATA_LOSS` on producer-side
   event-history loss during snapshot, synchronization, or live delivery and on
   live broadcast lag; reconnecting without `updates_only` and consuming a full

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -2285,6 +2285,7 @@ mod tests {
         assert_eq!(r.communities_dropped, 3);
         assert_eq!(r.large_communities_dropped, 0);
         assert_eq!(r.rpki_validation, "invalid");
+        assert_eq!(r.aspa_validation, "unknown");
         assert_eq!(r.rejected_at_unix_ns, 1_000_000_000);
     }
 

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -20,6 +20,7 @@ use crate::proto::{
 use serde::Serialize;
 use serde::ser::{SerializeMap, SerializeSeq, Serializer};
 use std::collections::HashSet;
+use std::io::Write;
 
 /// Parsed route filter options from CLI flags.
 pub struct RouteFilterOpts {
@@ -1891,6 +1892,37 @@ struct JsonRejectedRoutes<'a> {
     rejected_routes: Vec<JsonRejectedRoute<'a>>,
 }
 
+fn rejected_route_cell(value: &str) -> &str {
+    if value.is_empty() { "-" } else { value }
+}
+
+fn write_rejected_routes_table(
+    writer: &mut dyn Write,
+    resp: &ListRejectedRoutesResponse,
+) -> std::io::Result<()> {
+    writeln!(
+        writer,
+        "{:<22} {:<8} {:<18} {:<28} {:<18} {:<10} {:<10} AS Path",
+        "Prefix", "PathId", "Reason", "Detail", "Next Hop", "RPKI", "ASPA"
+    )?;
+    writeln!(writer, "{}", "-".repeat(131))?;
+    for r in &resp.routes {
+        writeln!(
+            writer,
+            "{:<22} {:<8} {:<18} {:<28} {:<18} {:<10} {:<10} {}",
+            format!("{}/{}", r.prefix, r.prefix_length),
+            r.path_id,
+            r.reason,
+            rejected_route_cell(&r.reason_detail),
+            rejected_route_cell(&r.next_hop),
+            rejected_route_cell(&r.rpki_validation),
+            rejected_route_cell(&r.aspa_validation),
+            r.as_path,
+        )?;
+    }
+    Ok(())
+}
+
 fn print_rejected_routes(resp: &ListRejectedRoutesResponse, json: bool) -> Result<(), CliError> {
     if json {
         let rejected_routes = resp
@@ -1930,35 +1962,7 @@ fn print_rejected_routes(resp: &ListRejectedRoutesResponse, json: bool) -> Resul
         println!("No rejected routes retained for {}", resp.peer_address);
         return Ok(());
     }
-    println!(
-        "{:<22} {:<8} {:<18} {:<28} {:<18} {:<10} AS Path",
-        "Prefix", "PathId", "Reason", "Detail", "Next Hop", "RPKI"
-    );
-    println!("{}", "-".repeat(120));
-    for r in &resp.routes {
-        println!(
-            "{:<22} {:<8} {:<18} {:<28} {:<18} {:<10} {}",
-            format!("{}/{}", r.prefix, r.prefix_length),
-            r.path_id,
-            r.reason,
-            if r.reason_detail.is_empty() {
-                "-"
-            } else {
-                &r.reason_detail
-            },
-            if r.next_hop.is_empty() {
-                "-"
-            } else {
-                &r.next_hop
-            },
-            if r.rpki_validation.is_empty() {
-                "-"
-            } else {
-                &r.rpki_validation
-            },
-            r.as_path,
-        );
-    }
+    write_rejected_routes_table(&mut std::io::stdout().lock(), resp)?;
     let shown = resp.routes.len();
     if u32::try_from(shown).unwrap_or(u32::MAX) >= resp.capacity {
         println!(
@@ -2214,6 +2218,42 @@ mod tests {
             received_at_epoch_seconds: 1_750_000_000,
             ..Default::default()
         }
+    }
+
+    /// The two validation columns are independent facts; using the RPKI value
+    /// for both, or omitting ASPA, makes the exact token proof red.
+    #[test]
+    fn rejected_route_table_distinguishes_rpki_and_aspa() {
+        let response = ListRejectedRoutesResponse {
+            routes: vec![
+                crate::proto::RejectedRoute {
+                    prefix: "198.51.100.0".into(),
+                    prefix_length: 24,
+                    reason: "policy_reject".into(),
+                    rpki_validation: "invalid".into(),
+                    aspa_validation: "unknown".into(),
+                    as_path: "65002 65010".into(),
+                    ..Default::default()
+                },
+                crate::proto::RejectedRoute {
+                    prefix: "203.0.113.0".into(),
+                    prefix_length: 24,
+                    reason: "as_path_loop".into(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let mut rendered = Vec::new();
+        write_rejected_routes_table(&mut rendered, &response).unwrap();
+        let rendered = String::from_utf8(rendered).unwrap();
+        let mut lines = rendered.lines();
+        assert!(lines.next().unwrap().contains("RPKI       ASPA"));
+        lines.next();
+        let distinct: Vec<_> = lines.next().unwrap().split_whitespace().collect();
+        assert_eq!(&distinct[5..7], &["invalid", "unknown"]);
+        let unavailable: Vec<_> = lines.next().unwrap().split_whitespace().collect();
+        assert_eq!(&unavailable[5..7], &["-", "-"]);
     }
 
     #[tokio::test]

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -2249,6 +2249,8 @@ mod tests {
                     prefix: "198.51.100.0".into(),
                     prefix_length: 24,
                     reason: "policy_reject".into(),
+                    reason_detail: "missing required community".into(),
+                    next_hop: "192.0.2.1".into(),
                     rpki_validation: "invalid".into(),
                     aspa_validation: "unknown".into(),
                     as_path: "65002 65010".into(),
@@ -2270,10 +2272,12 @@ mod tests {
         let mut lines = rendered.lines();
         assert!(lines.next().unwrap().contains("RPKI       ASPA"));
         lines.next();
-        let distinct: Vec<_> = lines.next().unwrap().split_whitespace().collect();
-        assert_eq!(&distinct[5..7], &["invalid", "unknown"]);
-        let unavailable: Vec<_> = lines.next().unwrap().split_whitespace().collect();
-        assert_eq!(&unavailable[5..7], &["-", "-"]);
+        let distinct = lines.next().unwrap();
+        assert_eq!(distinct[99..109].trim(), "invalid");
+        assert_eq!(distinct[110..120].trim(), "unknown");
+        let unavailable = lines.next().unwrap();
+        assert_eq!(unavailable[99..109].trim(), "-");
+        assert_eq!(unavailable[110..120].trim(), "-");
     }
 
     #[tokio::test]

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -1920,7 +1920,7 @@ fn write_rejected_routes_table(
             r.as_path,
         )?;
     }
-    Ok(())
+    writer.flush()
 }
 
 fn print_rejected_routes(resp: &ListRejectedRoutesResponse, json: bool) -> Result<(), CliError> {
@@ -2221,9 +2221,28 @@ mod tests {
     }
 
     /// The two validation columns are independent facts; using the RPKI value
-    /// for both, or omitting ASPA, makes the exact token proof red.
+    /// for both, omitting ASPA, or skipping the final flush makes the
+    /// corresponding assertion red.
     #[test]
     fn rejected_route_table_distinguishes_rpki_and_aspa() {
+        #[derive(Default)]
+        struct FlushWriter {
+            bytes: Vec<u8>,
+            flushed: bool,
+        }
+
+        impl Write for FlushWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.bytes.extend_from_slice(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                self.flushed = true;
+                Ok(())
+            }
+        }
+
         let response = ListRejectedRoutesResponse {
             routes: vec![
                 crate::proto::RejectedRoute {
@@ -2244,9 +2263,10 @@ mod tests {
             ],
             ..Default::default()
         };
-        let mut rendered = Vec::new();
+        let mut rendered = FlushWriter::default();
         write_rejected_routes_table(&mut rendered, &response).unwrap();
-        let rendered = String::from_utf8(rendered).unwrap();
+        assert!(rendered.flushed);
+        let rendered = String::from_utf8(rendered.bytes).unwrap();
         let mut lines = rendered.lines();
         assert!(lines.next().unwrap().contains("RPKI       ASPA"));
         lines.next();


### PR DESCRIPTION
## Summary

- add the retained ASPA validation state beside RPKI in the human `rbgp rib received <peer> --rejected` table
- render unavailable RPKI and ASPA facts as `-`
- keep JSON, disabled, empty, and capacity-warning behavior unchanged
- flush the writer-backed table so final buffered-write errors surface
- add independent CLI rendering and API-to-proto mapping proofs

## Stack

This is stacked on #1436 so the ASPA correctness and operator-visibility changes can be reviewed in order. The stack-base diff is limited to three files and does not depend on any new proto or retention behavior.

## Load-bearing proofs

- the renderer fixture deliberately uses `RPKI=invalid` and `ASPA=unknown`; removing the ASPA column, swapping the order, or reusing the RPKI value makes the exact row proof red
- a second row proves both unavailable validation facts render as `-`
- blanking the existing API ASPA mapping makes the proto-mapping assertion red
- replacing the final writer flush with a no-op makes the flush-tracking renderer test red

## Verification

- focused CLI renderer test
- focused API mapping test
- package Clippy for CLI and API with warnings denied
- package docs
- `cargo fmt --all -- --check`
- `git diff --check`
- repository pre-commit gates

An independent review found no actionable issues.

