### PR TITLE
ci(kernel): compile runtime netns tests once

### DIFF
--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -700,7 +700,16 @@ jobs:
       - name: ADR-0059 FDB nexthop group netns tests
         run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh fdb_nhg
 
+      # Compile the rustbgpd test binaries once into the harness's named target
+      # volume. The FIB and BFD selectors below reuse those exact artifacts.
+      - name: Prepare rustbgpd runtime netns test binaries
+        env:
+          RUSTBGPD_COMPILE_ONCE: "1"
+        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh rustbgpd_prepare
+
       - name: ADR-0061 FIB runtime netns test
+        env:
+          RUSTBGPD_COMPILE_ONCE: "1"
         run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh fib_runtime
 
       # This ephemeral hosted invocation denies AF_INET6 to prove the current
@@ -708,6 +717,7 @@ jobs:
       # that open address families can reuse the same opt-in harness profile.
       - name: ADR-0067 BFD runtime netns test (IPv4-only, AF_INET6 absent)
         env:
+          RUSTBGPD_COMPILE_ONCE: "1"
           SECCOMP_PROFILE: crates/evpn-linux/tests/docker/seccomp-deny-af-inet6.json
         run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh bfd_runtime
 

--- a/crates/evpn-linux/tests/docker/run-netns-tests.sh
+++ b/crates/evpn-linux/tests/docker/run-netns-tests.sh
@@ -98,6 +98,7 @@ EXACT_FILTER=1
 # Module-path filter for `-p rustbgpd` daemon netns tests (fib/bfd);
 # empty means the default `netns_*` evpn-linux integration binary.
 RUSTBGPD_TEST_FILTER=""
+RUSTBGPD_PREPARE=0
 case "${1:-all}" in
     spike)      FILTER="bum_filter_spike_validates_kernel_primitive" ;;
     roundtrip)  FILTER="linux_dataplane_set_bum_port_flags_round_trip" ;;
@@ -105,6 +106,7 @@ case "${1:-all}" in
     fdb_nhg)    TEST_BIN="netns_fdb_nhg"; FILTER="" ;;
     fdb_nhg_roundtrip)  TEST_BIN="netns_fdb_nhg"; FILTER="round_trip_install_and_remove_fdb_nhg" ;;
     fdb_nhg_cve)        TEST_BIN="netns_fdb_nhg"; FILTER="cve_guard_blocks_install_when_learning_enabled" ;;
+    rustbgpd_prepare)   FILTER=""; RUSTBGPD_PREPARE=1 ;;
     fib_runtime)        FILTER=""; RUSTBGPD_TEST_FILTER="fib_runtime::tests::netns_general_unicast_fib_" ;;
     bfd_runtime)        FILTER=""; RUSTBGPD_TEST_FILTER="bfd_runtime::tests::netns::" ;;
     bgp_unnumbered)     TEST_BIN="netns_bgp_unnumbered"; FILTER="" ;;
@@ -126,6 +128,20 @@ case "${1:-all}" in
         exit 2
         ;;
 esac
+
+RUSTBGPD_COMPILE_ONCE="${RUSTBGPD_COMPILE_ONCE:-0}"
+if [ "$RUSTBGPD_COMPILE_ONCE" != "0" ] && [ "$RUSTBGPD_COMPILE_ONCE" != "1" ]; then
+    echo "ERROR: RUSTBGPD_COMPILE_ONCE must be 0 or 1" >&2
+    exit 2
+fi
+if [ "$RUSTBGPD_PREPARE" = "1" ] && [ "$RUSTBGPD_COMPILE_ONCE" != "1" ]; then
+    echo "ERROR: rustbgpd_prepare is internal; set RUSTBGPD_COMPILE_ONCE=1" >&2
+    exit 2
+fi
+if [ "$RUSTBGPD_COMPILE_ONCE" = "1" ] && [ "$RUSTBGPD_PREPARE" != "1" ] && [ -z "$RUSTBGPD_TEST_FILTER" ]; then
+    echo "ERROR: RUSTBGPD_COMPILE_ONCE=1 is only valid for rustbgpd_prepare, fib_runtime, or bfd_runtime" >&2
+    exit 2
+fi
 
 SECCOMP_ARGS=()
 if [ -n "${SECCOMP_PROFILE:-}" ]; then
@@ -217,21 +233,33 @@ DOCKER_ARGS=(
 # netnses and re-exec into them; running them in parallel inside
 # the same container risks them clobbering each other on the
 # `/proc/$$/ns` namespace inheritance the inner re-exec depends on.
-if [ -n "$RUSTBGPD_TEST_FILTER" ]; then
+if [ "$RUSTBGPD_PREPARE" = "1" ]; then
     # The rustbgpd binary's gRPC types are generated from
     # `proto/rustbgpd.proto` by `rustbgpd-api`'s build script into that crate's
     # OUT_DIR. The persistent `$TARGET_CACHE_VOL` can retain a stale generated
     # module when the proto changes but cargo's incremental fingerprint does not
     # re-run the build script (the proto lives outside the crate dir), which
     # surfaces as "struct FibRouteStatus has no field named ..." compile errors.
-    # Force a regeneration of just that crate before building so the cached
-    # volume can't ship a stale proto. Cheap: only `rustbgpd-api` is rebuilt.
-    # Single-quote the filter inside the `sh -c` program so it reaches
-    # `cargo test` verbatim even if it ever gains whitespace / shell
-    # metacharacters (today it is a plain module path).
+    # Force a regeneration of just that crate before compiling the rustbgpd
+    # test binaries once. The FIB and BFD selectors below reuse those prepared
+    # artifacts through the same named target volume.
     TEST_ARGS=(
-        sh -c "cargo clean -p rustbgpd-api && cargo test -p rustbgpd '${RUSTBGPD_TEST_FILTER}' -- --test-threads=1 --nocapture"
+        sh -c "cargo clean -p rustbgpd-api && cargo test -p rustbgpd --no-run"
     )
+elif [ -n "$RUSTBGPD_TEST_FILTER" ]; then
+    if [ "$RUSTBGPD_COMPILE_ONCE" = "1" ]; then
+        TEST_ARGS=(
+            cargo test -p rustbgpd "$RUSTBGPD_TEST_FILTER"
+            --
+            --test-threads=1 --nocapture
+        )
+    else
+        # Preserve conservative standalone behavior: regenerate the external
+        # proto and compile before running either filtered runtime selector.
+        TEST_ARGS=(
+            sh -c "cargo clean -p rustbgpd-api && cargo test -p rustbgpd '${RUSTBGPD_TEST_FILTER}' -- --test-threads=1 --nocapture"
+        )
+    fi
 else
     TEST_ARGS=(
         cargo test -p rustbgpd-evpn-linux --test "$TEST_BIN"

--- a/docs/perf/kernel-dataplane-compile-once-2026-08.md
+++ b/docs/perf/kernel-dataplane-compile-once-2026-08.md
@@ -1,0 +1,45 @@
+# Kernel dataplane compile-once receipt — 2026-08
+
+Status: measurement in progress. Local correctness is green; there is no hosted performance claim yet.
+
+## Boundary and candidate
+
+The predeclared five-run control median is 422 seconds for the complete privileged
+netns job. Within that boundary, FIB took 273 seconds and the redundant BFD
+compile took 51 seconds; these observations are not acceptance evidence.
+
+The candidate adds one internal `rustbgpd_prepare` selector immediately before
+FIB. It runs the only
+`cargo clean -p rustbgpd-api && cargo test -p rustbgpd --no-run`, using the
+existing named target volume. Opted-in FIB and BFD then execute against those
+artifacts; standalone calls retain their conservative clean-build. BFD retains
+the AF_INET6-denying seccomp profile.
+
+Public selector semantics, job/call rosters, container `--rm`, capabilities, AppArmor, cargo and target-volume identity/lifetime, and other selectors remain unchanged.
+
+## Local correctness
+
+A clean local proof used a fresh, uniquely named target volume, then removed it. The BFD
+invocation used the workflow's AF_INET6-denying seccomp profile:
+
+Prepare passed in 96 seconds and built the test binaries with `--no-run`; FIB passed 4 tests in 1 second (Cargo: 0.17 seconds); BFD passed its test in 2
+seconds (Cargo: 0.16 seconds).
+
+These local wall times prove artifact reuse only. Host, image, cache, and runner
+conditions differ from GitHub-hosted controls, so they are not a performance
+comparison.
+
+The structural checker also rejects prepare removal/reordering, missing or misused compile-once opt-in, any second clean/compile, FIB/BFD filter drift, target-volume drift, removal of
+container cleanup or privileges, AF_INET6 seccomp drift, and selector-roster
+changes. Its destructive mutation suite executes each of those red paths.
+
+## Hosted acceptance
+
+Two GitHub-hosted attempts are required. Each must keep BFD at or below 15
+seconds and the total netns job at or below 390 seconds. The candidate must
+improve the five-control median by at least 8% or 35 seconds, keep all selectors
+green, and show no more than 5% aggregate workflow-compute regression. A seed,
+retry after unrelated runner failure, or local result cannot satisfy the gate.
+
+Until both hosted attempts and aggregate-compute accounting pass, the verdict
+remains measurement in progress.

--- a/docs/perf/kernel-dataplane-compile-once-2026-08.md
+++ b/docs/perf/kernel-dataplane-compile-once-2026-08.md
@@ -4,9 +4,9 @@ Status: measurement in progress. Local correctness is green; there is no hosted 
 
 ## Boundary and candidate
 
-The predeclared five-run control median is 422 seconds for the complete privileged
-netns job. Within that boundary, FIB took 273 seconds and the redundant BFD
-compile took 51 seconds; these observations are not acceptance evidence.
+The predeclared controls were run/job `30806738909/91663744751`, `30815271882/91691417967`, `30823070482/91717624804`,
+`30833928077/91754355578`, and `30781164612/91585922738`: 409/412/422/424/427 seconds (median 422).
+Within that cohort, FIB's median was 273 seconds and redundant BFD's was 51 seconds.
 
 The candidate adds one internal `rustbgpd_prepare` selector immediately before
 FIB. It runs the only
@@ -35,11 +35,11 @@ changes. Its destructive mutation suite executes each of those red paths.
 
 ## Hosted acceptance
 
-Two GitHub-hosted attempts are required. Each must keep BFD at or below 15
-seconds and the total netns job at or below 390 seconds. The candidate must
-improve the five-control median by at least 8% or 35 seconds, keep all selectors
-green, and show no more than 5% aggregate workflow-compute regression. A seed,
-retry after unrelated runner failure, or local result cannot satisfy the gate.
+Two hosted attempts must each keep BFD <=15 seconds and netns <=390 seconds, save at least 35 seconds against the 422-second median, and keep every selector green.
+For each attempt, `C(run)` is the sum of raw `completed_at - started_at` seconds across the identical 31-job Kernel Dataplane roster; queue time is excluded.
+Both attempts must keep `C(run) <= 2912`, or 105% of the 2774-second control-aggregate median; the verdict uses the slower candidate aggregate.
+Any failed, cancelled, missing-timestamp, runner-failure, or roster-mismatched attempt is invalid; jobs are never spliced across attempts.
+A seed, retry after unrelated runner failure, or local result cannot satisfy the gate.
 
 Until both hosted attempts and aggregate-compute accounting pass, the verdict
 remains measurement in progress.

--- a/docs/perf/kernel-dataplane-compile-once-2026-08.md
+++ b/docs/perf/kernel-dataplane-compile-once-2026-08.md
@@ -1,6 +1,6 @@
 # Kernel dataplane compile-once receipt — 2026-08
 
-Status: measurement in progress. Local correctness is green; there is no hosted performance claim yet.
+Status: NO-GO. Local correctness is green, but the predeclared two-attempt aggregate gate did not pass.
 
 ## Boundary and candidate
 
@@ -41,5 +41,5 @@ Both attempts must keep `C(run) <= 2912`, or 105% of the 2774-second control-agg
 Any failed, cancelled, missing-timestamp, runner-failure, or roster-mismatched attempt is invalid; jobs are never spliced across attempts.
 A seed, retry after unrelated runner failure, or local result cannot satisfy the gate.
 
-Until both hosted attempts and aggregate-compute accounting pass, the verdict
-remains measurement in progress.
+Run/job `30849663483/91806407214` passed at 355 seconds (FIB 1, BFD 3; `C=2758`); `30849975385/91807352207` passed at 354 seconds (FIB 1, BFD 3) but `C=3016` exceeded 2912.
+The affected lane saved 67–68 seconds twice, but the full-workflow attempts disagreed under the frozen guard. The candidate is closed without a performance claim or merge.

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -35,6 +35,15 @@ GOBGP_CHECKSUMS = {
     "amd64": "e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522",
     "arm64": "0aaa2da6e4dcaaf57e3d0e64eae14946292b0a5894d80ef3b7ebde3bf52beb29",
 }
+NETNS_SELECTOR_HASH = "0278940b2953d00c57398b3545141144afb4f0e7673b20cffe2599521c37b9ff"
+NETNS_COMPILE_ONCE_HASH = "384d95c6b7449ba345be55aea4ed890c78958467f4140abf327e80be39309d76"
+NETNS_WORKFLOW_SELECTORS = tuple(
+    "fdb_nhg rustbgpd_prepare fib_runtime bfd_runtime dataplane_vlan_fdb "
+    "macip_vlan_attribution svd_fdb_vni managed_bridge managed_vxlan "
+    "managed_svd_vxlan managed_vlan_upper managed_ready l3_multipath "
+    "managed_ip_vrf_ready l3_all_active_writer".split()
+)
+NETNS_SECCOMP_HASH = "2c2fc7d46458574b4fe2d820cb82697b3ff9e4a31083de518bdb2993b0ed9fcb"
 
 TRIGGER_HASHES = {
     "ci.yml": "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8",
@@ -158,8 +167,114 @@ def check(root: Path) -> list[str]:
         if _hash(calls) != CALL_HASHES[name]:
             errors.append(f"{name}: existing test/setup calls drifted")
     kernel_jobs = _jobs(texts["kernel-dataplane.yml"])
-    if "needs: prime_dev_image" in kernel_jobs.get("netns", ""):
+    netns_job = kernel_jobs.get("netns", "")
+    if "needs: prime_dev_image" in netns_job:
         errors.append("kernel-dataplane.yml:netns must remain independent")
+
+    runner = (
+        root / "crates" / "evpn-linux" / "tests" / "docker" / "run-netns-tests.sh"
+    ).read_text()
+    selector_body = runner.split('case "${1:-all}" in', 1)[-1].split("\nesac", 1)[0]
+    if _hash(selector_body) != NETNS_SELECTOR_HASH:
+        errors.append("run-netns-tests.sh: selector semantics drifted")
+
+    validation_marker = 'RUSTBGPD_COMPILE_ONCE="${RUSTBGPD_COMPILE_ONCE:-0}"'
+    validation = validation_marker + runner.split(validation_marker, 1)[-1].split(
+        "\n\nSECCOMP_ARGS=()", 1
+    )[0]
+    if _hash(validation) != NETNS_COMPILE_ONCE_HASH:
+        errors.append("run-netns-tests.sh: compile-once validation drifted")
+
+    workflow_selectors = tuple(
+        re.findall(
+            r"run: bash crates/evpn-linux/tests/docker/run-netns-tests\.sh ([\w-]+)",
+            netns_job,
+        )
+    )
+    if workflow_selectors != NETNS_WORKFLOW_SELECTORS:
+        errors.append("kernel-dataplane.yml:netns selector calls/order drifted")
+
+    prepare = (
+        'sh -c "cargo clean -p rustbgpd-api && ' 'cargo test -p rustbgpd --no-run"'
+    )
+    runtime = 'cargo test -p rustbgpd "$RUSTBGPD_TEST_FILTER"'
+    standalone = (
+        'sh -c "cargo clean -p rustbgpd-api && cargo test -p rustbgpd '
+        "'${RUSTBGPD_TEST_FILTER}' -- --test-threads=1 --nocapture\""
+    )
+    if runner.count(prepare) != 1:
+        errors.append("run-netns-tests.sh: rustbgpd prepare command drifted")
+    if runner.count(standalone) != 1:
+        errors.append("run-netns-tests.sh: standalone FIB/BFD clean-build drifted")
+    if runner.count("cargo clean -p rustbgpd-api") != 2:
+        errors.append("run-netns-tests.sh: rustbgpd-api clean roster drifted")
+    if runner.count("cargo test -p rustbgpd --no-run") != 1:
+        errors.append("run-netns-tests.sh: rustbgpd must be compiled exactly once")
+    if runner.count(runtime) != 1:
+        errors.append("run-netns-tests.sh: FIB/BFD prepared-artifact reuse drifted")
+
+    docker_args = runner.split("\nDOCKER_ARGS=(\n", 1)[-1].split("\n)\n", 1)[0]
+    effective_docker_args = tuple(
+        line.strip()
+        for line in docker_args.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    )
+    expected_docker_args = (
+        "--rm",
+        "--cap-add=NET_ADMIN",
+        "--cap-add=SYS_ADMIN",
+        "--security-opt apparmor=unconfined",
+        '"${SECCOMP_ARGS[@]}"',
+        "-e EVPN_LINUX_NETNS=1",
+        "-e RUST_BACKTRACE=1",
+        "-e CARGO_TERM_COLOR=always",
+        '-v "${REPO_ROOT}:/work"',
+        '-v "${CARGO_CACHE_VOL}:/usr/local/cargo/registry"',
+        '-v "${TARGET_CACHE_VOL}:/work/target"',
+        "-w /work",
+    )
+    if effective_docker_args != expected_docker_args:
+        errors.append(
+            "run-netns-tests.sh: container cleanup/privileges/volumes drifted"
+        )
+    for seam in (
+        "RUSTBGPD_PREPARE=0",
+        'RUSTBGPD_COMPILE_ONCE="${RUSTBGPD_COMPILE_ONCE:-0}"',
+        'if [ "$RUSTBGPD_PREPARE" = "1" ]; then',
+        'elif [ -n "$RUSTBGPD_TEST_FILTER" ]; then',
+        'CARGO_CACHE_VOL="${CARGO_CACHE_VOL:-rustbgpd-netns-tests-cargo}"',
+        'TARGET_CACHE_VOL="${TARGET_CACHE_VOL:-rustbgpd-netns-tests-target}"',
+        'SECCOMP_ARGS+=("--security-opt=seccomp=$SECCOMP_PROFILE_RESOLVED")',
+    ):
+        if runner.count(seam) != 1:
+            errors.append(f"run-netns-tests.sh: harness seam drifted: {seam}")
+    if "TARGET_CACHE_VOL:" in netns_job or "docker volume rm" in netns_job:
+        errors.append("kernel-dataplane.yml:netns named target-volume lifetime drifted")
+
+    seccomp_path = "crates/evpn-linux/tests/docker/seccomp-deny-af-inet6.json"
+    compile_once = 'RUSTBGPD_COMPILE_ONCE: "1"'
+    for step_name in (
+        "Prepare rustbgpd runtime netns test binaries",
+        "ADR-0061 FIB runtime netns test",
+        "ADR-0067 BFD runtime netns test",
+    ):
+        step = netns_job.split(f"- name: {step_name}", 1)[-1].split(
+            "\n      - name:", 1
+        )[0]
+        if compile_once not in step:
+            errors.append(f"kernel-dataplane.yml:netns {step_name} opt-in drifted")
+    if netns_job.count(compile_once) != 3:
+        errors.append("kernel-dataplane.yml:netns compile-once opt-in roster drifted")
+    bfd_step = netns_job.split("- name: ADR-0067 BFD runtime", 1)[-1].split(
+        "\n      - name:", 1
+    )[0]
+    if (
+        netns_job.count(f"SECCOMP_PROFILE: {seccomp_path}") != 1
+        or f"SECCOMP_PROFILE: {seccomp_path}" not in bfd_step
+    ):
+        errors.append("kernel-dataplane.yml:netns BFD seccomp profile drifted")
+    if _hash((root / seccomp_path).read_text()) != NETNS_SECCOMP_HASH:
+        errors.append("seccomp-deny-af-inet6.json: AF_INET6 denial drifted")
 
     action = (
         root / ".github" / "actions" / "setup-dataplane-host" / "action.yml"

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -37,6 +37,7 @@ GOBGP_CHECKSUMS = {
 }
 NETNS_SELECTOR_HASH = "0278940b2953d00c57398b3545141144afb4f0e7673b20cffe2599521c37b9ff"
 NETNS_COMPILE_ONCE_HASH = "384d95c6b7449ba345be55aea4ed890c78958467f4140abf327e80be39309d76"
+NETNS_EXECUTION_HASH = "f7279b3aeb46ec8a4594f942b977251c3c094b06e32b681a906158989f6da1fd"
 NETNS_WORKFLOW_SELECTORS = tuple(
     "fdb_nhg rustbgpd_prepare fib_runtime bfd_runtime dataplane_vlan_fdb "
     "macip_vlan_attribution svd_fdb_vni managed_bridge managed_vxlan "
@@ -184,6 +185,10 @@ def check(root: Path) -> list[str]:
     )[0]
     if _hash(validation) != NETNS_COMPILE_ONCE_HASH:
         errors.append("run-netns-tests.sh: compile-once validation drifted")
+    execution_marker = "# `--test-threads=1`:"
+    execution = execution_marker + runner.split(execution_marker, 1)[-1]
+    if _hash(execution) != NETNS_EXECUTION_HASH:
+        errors.append("run-netns-tests.sh: command selection/execution drifted")
 
     workflow_selectors = tuple(
         re.findall(
@@ -208,8 +213,6 @@ def check(root: Path) -> list[str]:
         errors.append("run-netns-tests.sh: standalone FIB/BFD clean-build drifted")
     if runner.count("cargo clean -p rustbgpd-api") != 2:
         errors.append("run-netns-tests.sh: rustbgpd-api clean roster drifted")
-    if runner.count("cargo test -p rustbgpd --no-run") != 1:
-        errors.append("run-netns-tests.sh: rustbgpd must be compiled exactly once")
     if runner.count(runtime) != 1:
         errors.append("run-netns-tests.sh: FIB/BFD prepared-artifact reuse drifted")
 

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -278,6 +278,12 @@ class PrimerContractTests(unittest.TestCase):
                 reuse,
                 standalone,
             ),
+            (
+                "an alternate second compile is inserted",
+                runner,
+                'exec docker run "${DOCKER_ARGS[@]}" "$IMAGE_TAG" "${TEST_ARGS[@]}"',
+                'docker run "${DOCKER_ARGS[@]}" "$IMAGE_TAG" cargo test --package rustbgpd --no-run\nexec docker run "${DOCKER_ARGS[@]}" "$IMAGE_TAG" "${TEST_ARGS[@]}"',
+            ),
             ("standalone FIB/BFD skip the conservative clean", runner, standalone, reuse),
             (
                 "FIB selects the wrong tests",

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -18,6 +18,7 @@ class PrimerContractTests(unittest.TestCase):
             for fixture in (
                 ".github/workflows",
                 ".github/actions/setup-dataplane-host",
+                "crates/evpn-linux/tests/docker",
             ):
                 source = ROOT / fixture
                 target = root / fixture
@@ -233,6 +234,89 @@ class PrimerContractTests(unittest.TestCase):
             ),
         ):
             with self.subTest(old=old):
+                self.mutate(relative, old, new)
+
+    def test_netns_compile_once_contract_is_load_bearing(self):
+        workflow = ".github/workflows/kernel-dataplane.yml"
+        runner = "crates/evpn-linux/tests/docker/run-netns-tests.sh"
+        seccomp = "crates/evpn-linux/tests/docker/seccomp-deny-af-inet6.json"
+        reuse = 'cargo test -p rustbgpd "$RUSTBGPD_TEST_FILTER"'
+        standalone = 'sh -c "cargo clean -p rustbgpd-api && cargo test -p rustbgpd \'${RUSTBGPD_TEST_FILTER}\' -- --test-threads=1 --nocapture"'
+        prepare_then_fib = """\
+      - name: Prepare rustbgpd runtime netns test binaries
+        env:
+          RUSTBGPD_COMPILE_ONCE: "1"
+        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh rustbgpd_prepare
+
+      - name: ADR-0061 FIB runtime netns test
+        env:
+          RUSTBGPD_COMPILE_ONCE: "1"
+        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh fib_runtime
+"""
+        fib_then_prepare = """\
+      - name: ADR-0061 FIB runtime netns test
+        env:
+          RUSTBGPD_COMPILE_ONCE: "1"
+        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh fib_runtime
+
+      - name: Prepare rustbgpd runtime netns test binaries
+        env:
+          RUSTBGPD_COMPILE_ONCE: "1"
+        run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh rustbgpd_prepare
+"""
+        cases = (
+            ("prepare runs after FIB", workflow, prepare_then_fib, fib_then_prepare),
+            (
+                "prepare is omitted",
+                workflow,
+                "run-netns-tests.sh rustbgpd_prepare",
+                "run-netns-tests.sh fib_runtime",
+            ),
+            (
+                "FIB/BFD clean and compile a second time",
+                runner,
+                reuse,
+                standalone,
+            ),
+            ("standalone FIB/BFD skip the conservative clean", runner, standalone, reuse),
+            (
+                "FIB selects the wrong tests",
+                runner,
+                "fib_runtime::tests::netns_general_unicast_fib_",
+                "fib_runtime::tests::wrong_",
+            ),
+            (
+                "BFD selects the wrong tests",
+                runner,
+                "bfd_runtime::tests::netns::",
+                "bfd_runtime::tests::wrong::",
+            ),
+            (
+                "compile-once opt-in is removed",
+                workflow,
+                'RUSTBGPD_COMPILE_ONCE: "1"',
+                'RUSTBGPD_COMPILE_ONCE: "0"',
+            ),
+            ("prepare becomes callable without opt-in", runner, 'if [ "$RUSTBGPD_PREPARE" = "1" ] && [ "$RUSTBGPD_COMPILE_ONCE" != "1" ]; then', "if false; then"),
+            ("compile-once becomes valid on unrelated selectors", runner, 'if [ "$RUSTBGPD_COMPILE_ONCE" = "1" ] && [ "$RUSTBGPD_PREPARE" != "1" ] && [ -z "$RUSTBGPD_TEST_FILTER" ]; then', "if false; then"),
+            ("target volume identity changes", runner, "rustbgpd-netns-tests-target", "rustbgpd-netns-tests-target-prepare"),
+            ("container cleanup is removed", runner, "    --rm\n", ""),
+            ("NET_ADMIN privilege is removed", runner, "    --cap-add=NET_ADMIN\n", ""),
+            (
+                "BFD no longer denies AF_INET6",
+                seccomp,
+                '"value": 10',
+                '"value": 2',
+            ),
+            (
+                "the public selector roster changes",
+                runner,
+                "    managed_ready)",
+                "    removed_managed_ready)",
+            ),
+        )
+        for breakage, relative, old, new in cases:
+            with self.subTest(breakage=breakage):
                 self.mutate(relative, old, new)
 
     def test_dockerfile_exact_source_bridge(self):


### PR DESCRIPTION
## Verdict: NO-GO

The compile-once mechanism is locally correct and the affected lane improved repeatably, but the candidate did not pass its frozen full-workflow acceptance gate and is not being merged.

## Hosted evidence

- pinned controls: 409/412/422/424/427 seconds; median 422
- run `30849663483`, netns job `91806407214`: 355 seconds; prepare 264, FIB 1, BFD 3; all 31 workflow jobs passed; aggregate compute 2,758 seconds
- run `30849975385`, netns job `91807352207`: 354 seconds; prepare 266, FIB 1, BFD 3; all 31 workflow jobs passed; aggregate compute 3,016 seconds
- frozen aggregate ceiling: 2,912 seconds per attempt

The affected lane saved 67–68 seconds in both attempts and neither FIB nor BFD recompiled the prepared target. However, the second full-workflow aggregate exceeded the ceiling, so the two-attempt verdict is a non-result under the predeclared rule.

## Review and verification

Self-review preserved conservative standalone FIB/BFD proto regeneration. Independent review then found and fixed two proof defects before the final attempts: an alternate spelling could insert a second compile without tripping the checker, and the receipt did not pin the control run/job IDs or aggregate formula. The repaired checker freezes the complete command-selection/execution block and its destructive suite inserts an alternate second command to prove the gate goes red. Copilot reviewed the repaired code head with no comments.

Local verification passed the full workspace fmt, Clippy, tests, warning-denied library docs, Python contract suite, live checker, Python compilation, Bash syntax, ShellCheck, workflow YAML parse, and diff check. The final receipt is in `docs/perf/kernel-dataplane-compile-once-2026-08.md` on this branch.
