### PR TITLE
Add bounded ASPA invalid-hop diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- ASPA-invalid policy rejections retain the first proven `NotProviderPlus` hop;
+  cache refresh emits one bounded top-eight summary without changing routing.
+
 - Outside-v1 `StreamPlanConfigTransaction` and `StreamApplyConfigTransaction`
   gRPC ingress for
   large config candidates. It requires an authenticated listener, accepts

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -1138,7 +1138,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         let routes = reply
             .entries
             .into_iter()
-            .map(|(key, entry)| {
+            .map(|(key, mut entry)| {
                 let (prefix, prefix_length) = match key.prefix {
                     Prefix::V4(p) => (p.addr.to_string(), u32::from(p.len)),
                     Prefix::V6(p) => (p.addr.to_string(), u32::from(p.len)),
@@ -1154,7 +1154,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
                     path_id: key.path_id,
                     afi_safi,
                     reason: entry.reason.as_str().to_string(),
-                    reason_detail: entry.rendered_reason_detail(),
+                    reason_detail: entry.take_rendered_reason_detail(),
                     next_hop: entry.next_hop.map(|nh| nh.to_string()).unwrap_or_default(),
                     as_path: entry.as_path,
                     communities: entry.communities,

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -1154,7 +1154,7 @@ impl proto::policy_service_server::PolicyService for PolicyService {
                     path_id: key.path_id,
                     afi_safi,
                     reason: entry.reason.as_str().to_string(),
-                    reason_detail: entry.detail.unwrap_or_default(),
+                    reason_detail: entry.rendered_reason_detail(),
                     next_hop: entry.next_hop.map(|nh| nh.to_string()).unwrap_or_default(),
                     as_path: entry.as_path,
                     communities: entry.communities,
@@ -2250,7 +2250,7 @@ mod tests {
             )),
             path_id: 0,
         };
-        let entry = RejectedRouteEntry {
+        let mut entry = RejectedRouteEntry {
             reason: ImportRejectReason::PolicyReject,
             detail: Some("member-import".to_string()),
             next_hop: Some(std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 2))),
@@ -2261,8 +2261,10 @@ mod tests {
             large_communities_dropped: 0,
             rpki: rustbgpd_wire::RpkiValidation::Invalid,
             aspa: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_invalid_hop: None,
             rejected_at: std::time::UNIX_EPOCH + Duration::from_secs(1),
         };
+        entry.set_aspa_invalid_hop(65010, 65002);
         let resp = list_rejected_routes_response(Some(RejectedRoutesReply {
             enabled: true,
             capacity: 1024,
@@ -2278,7 +2280,10 @@ mod tests {
         assert_eq!(r.prefix_length, 24);
         assert_eq!(r.afi_safi, proto::AddressFamily::Ipv4Unicast as i32);
         assert_eq!(r.reason, "policy_reject");
-        assert_eq!(r.reason_detail, "member-import");
+        assert_eq!(
+            r.reason_detail,
+            "member-import | aspa_not_provider customer=65010 provider=65002"
+        );
         assert_eq!(r.next_hop, "10.0.0.2");
         assert_eq!(r.as_path, "65002 65010");
         assert_eq!(r.communities, vec![999]);

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -7,7 +7,10 @@ use rustbgpd_wire::{Afi, EvpnRouteKey, Prefix, Safi};
 use tracing::info;
 
 use super::RibManager;
-use super::helpers::{LlgrPeerConfig, gauge_val, validate_route_aspa, validate_route_rpki};
+use super::helpers::{
+    AspaInvalidHopSummary, LlgrPeerConfig, gauge_val, validate_route_aspa_detailed,
+    validate_route_rpki,
+};
 use crate::route::{BgpLsFamily, BgpLsRouteKey};
 
 impl RibManager {
@@ -338,35 +341,46 @@ impl RibManager {
     }
 
     pub(super) fn handle_aspa_cache_update(&mut self, table: Arc<rustbgpd_rpki::AspaTable>) {
-        info!(
-            records = table.len(),
-            "ASPA cache update — re-validating routes"
-        );
         self.aspa_table = Some(table);
         let Some(table) = self.aspa_table.as_ref() else {
             return;
         };
-        self.metrics.set_aspa_records(gauge_val(table.len()));
+        let records = table.len();
+        self.metrics.set_aspa_records(gauge_val(records));
 
         let mut affected = HashSet::new();
+        let mut routes_scanned = 0_u64;
+        let mut changed_routes = 0_u64;
+        let mut invalid_hops = AspaInvalidHopSummary::default();
         for rib in self.ribs.values_mut() {
             for route in rib.iter_mut() {
-                let new_state = validate_route_aspa(route, table);
-                if route.aspa_state != new_state {
-                    route.aspa_state = new_state;
+                routes_scanned += 1;
+                let result = validate_route_aspa_detailed(route, table);
+                if let Some(hop) = result.invalid_hop {
+                    invalid_hops.observe(hop);
+                }
+                if route.aspa_state != result.state {
+                    route.aspa_state = result.state;
+                    changed_routes += 1;
                     affected.insert(route.prefix);
                 }
             }
         }
 
         if !affected.is_empty() {
-            info!(
-                changed = affected.len(),
-                "ASPA re-validation changed routes"
-            );
             let changed = self.recompute_best(&affected);
             self.distribute_changes(&changed, &affected);
         }
+        info!(
+            records,
+            routes_scanned,
+            changed_routes,
+            affected_prefixes = affected.len(),
+            invalid_hop_routes = invalid_hops.routes,
+            suppressed_routes = invalid_hops.suppressed_routes,
+            invalid_hops = %invalid_hops.render(),
+            "ASPA cache update re-validation complete"
+        );
     }
 
     /// Sweep stale routes for a peer whose GR timer has expired.

--- a/crates/rib/src/manager/helpers.rs
+++ b/crates/rib/src/manager/helpers.rs
@@ -1,9 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
+use std::fmt::Write;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
 use rustbgpd_policy::RouteFamily;
-use rustbgpd_rpki::{AspaTable, VrpTable};
+use rustbgpd_rpki::{AspaInvalidHop, AspaTable, AspaVerificationResult, VrpTable};
 use rustbgpd_wire::{
     Afi, AspaValidation, LlgrFamily, Prefix, RpkiValidation, Safi, VpnAddressFamily, VpnRouteKey,
 };
@@ -284,12 +285,73 @@ pub(super) fn validate_route_aspa(
     route: &crate::route::Route,
     table: &AspaTable,
 ) -> AspaValidation {
+    validate_route_aspa_detailed(route, table).state
+}
+
+pub(super) fn validate_route_aspa_detailed(
+    route: &crate::route::Route,
+    table: &AspaTable,
+) -> AspaVerificationResult {
     if !route.is_ebgp() {
-        return AspaValidation::Unknown;
+        return AspaVerificationResult {
+            state: AspaValidation::Unknown,
+            invalid_hop: None,
+        };
     }
     match route.as_path() {
-        Some(path) => rustbgpd_rpki::aspa_verify::verify(path, table, route.aspa_context),
-        None => AspaValidation::Unknown,
+        Some(path) => rustbgpd_rpki::aspa_verify::verify_detailed(path, table, route.aspa_context),
+        None => AspaVerificationResult {
+            state: AspaValidation::Unknown,
+            invalid_hop: None,
+        },
+    }
+}
+
+const MAX_ASPA_INVALID_HOPS: usize = 8;
+
+#[derive(Default)]
+pub(super) struct AspaInvalidHopSummary {
+    pairs: BTreeMap<AspaInvalidHop, u64>,
+    pub(super) routes: u64,
+    pub(super) suppressed_routes: u64,
+}
+
+impl AspaInvalidHopSummary {
+    pub(super) fn observe(&mut self, hop: AspaInvalidHop) {
+        self.routes += 1;
+        if let Some(count) = self.pairs.get_mut(&hop) {
+            *count += 1;
+            return;
+        }
+        if self.pairs.len() < MAX_ASPA_INVALID_HOPS {
+            self.pairs.insert(hop, 1);
+            return;
+        }
+        let Some((&largest, _)) = self.pairs.last_key_value() else {
+            return;
+        };
+        if hop < largest {
+            self.suppressed_routes += self.pairs.remove(&largest).unwrap_or(0);
+            self.pairs.insert(hop, 1);
+        } else {
+            self.suppressed_routes += 1;
+        }
+    }
+
+    pub(super) fn render(&self) -> String {
+        let mut rendered = String::new();
+        for (index, (hop, count)) in self.pairs.iter().enumerate() {
+            if index != 0 {
+                rendered.push_str(", ");
+            }
+            let _ = write!(
+                rendered,
+                "{}>{}:{count}",
+                hop.customer_asn, hop.provider_asn
+            );
+        }
+        debug_assert!(rendered.len() <= 512);
+        rendered
     }
 }
 

--- a/crates/rib/src/manager/tests/rpki.rs
+++ b/crates/rib/src/manager/tests/rpki.rs
@@ -1,4 +1,141 @@
 use super::*;
+use crate::manager::helpers::AspaInvalidHopSummary;
+
+/// Red proof: retention, eviction/admission accounting, or counts/order break exact output.
+#[test]
+fn aspa_invalid_hop_summary_keeps_smallest_pairs_and_exact_suppression() {
+    let mut summary = AspaInvalidHopSummary::default();
+    for customer_asn in 2..=9 {
+        summary.observe(rustbgpd_rpki::AspaInvalidHop {
+            customer_asn,
+            provider_asn: customer_asn + 100,
+        });
+    }
+    for _ in 0..2 {
+        summary.observe(rustbgpd_rpki::AspaInvalidHop {
+            customer_asn: 9,
+            provider_asn: 109,
+        });
+    }
+    summary.observe(rustbgpd_rpki::AspaInvalidHop {
+        customer_asn: 1,
+        provider_asn: 101,
+    });
+    for _ in 0..2 {
+        summary.observe(rustbgpd_rpki::AspaInvalidHop {
+            customer_asn: 10,
+            provider_asn: 110,
+        });
+        summary.observe(rustbgpd_rpki::AspaInvalidHop {
+            customer_asn: 1,
+            provider_asn: 101,
+        });
+    }
+    assert_eq!(summary.routes, 15);
+    assert_eq!(summary.suppressed_routes, 5);
+    let rendered = summary.render();
+    assert_eq!(
+        rendered,
+        "1>101:3, 2>102:1, 3>103:1, 4>104:1, 5>105:1, 6>106:1, 7>107:1, 8>108:1"
+    );
+    assert!(rendered.len() <= 512);
+}
+
+/// Red proof: deleting/splitting the event or skipping unchanged Invalid breaks exact fields.
+#[test]
+fn aspa_cache_update_emits_one_bounded_completion_event() {
+    use std::collections::BTreeMap;
+    use std::sync::{Arc as StdArc, Mutex};
+
+    use rustbgpd_rpki::{AspaRecord, AspaTable};
+    use tracing::field::{Field, Visit};
+    use tracing::span::{Attributes, Id, Record};
+    use tracing::{Event, Metadata, Subscriber};
+
+    #[derive(Default)]
+    struct Fields(BTreeMap<String, String>);
+    impl Visit for Fields {
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.0.insert(field.name().to_string(), value.to_string());
+        }
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            self.0
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+    }
+
+    struct Capture(StdArc<Mutex<Vec<Fields>>>);
+    impl Subscriber for Capture {
+        fn enabled(&self, _: &Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+        fn record(&self, _: &Id, _: &Record<'_>) {}
+        fn record_follows_from(&self, _: &Id, _: &Id) {}
+        fn event(&self, event: &Event<'_>) {
+            let mut fields = Fields::default();
+            event.record(&mut fields);
+            self.0.lock().unwrap().push(fields);
+        }
+        fn enter(&self, _: &Id) {}
+        fn exit(&self, _: &Id) {}
+    }
+
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(1, 0, 0, 8));
+    let mut first = make_route_with_as_path(
+        Ipv4Prefix::new(Ipv4Addr::new(10, 0, 1, 0), 24),
+        Ipv4Addr::new(1, 0, 0, 8),
+        vec![65002, 65003],
+    );
+    first.aspa_state = rustbgpd_wire::AspaValidation::Valid;
+    let mut unchanged = make_route_with_as_path(
+        Ipv4Prefix::new(Ipv4Addr::new(10, 0, 2, 0), 24),
+        Ipv4Addr::new(1, 0, 0, 8),
+        vec![65004, 65005],
+    );
+    unchanged.aspa_state = rustbgpd_wire::AspaValidation::Invalid;
+    let mut rib = crate::adj_rib_in::AdjRibIn::new(peer);
+    rib.insert(first);
+    rib.insert(unchanged);
+    manager.ribs.insert(peer, rib);
+
+    let captured = StdArc::new(Mutex::new(Vec::new()));
+    let table = Arc::new(AspaTable::new(vec![
+        AspaRecord {
+            customer_asn: 65003,
+            provider_asns: vec![99],
+        },
+        AspaRecord {
+            customer_asn: 65005,
+            provider_asns: vec![99],
+        },
+    ]));
+    tracing::subscriber::with_default(Capture(StdArc::clone(&captured)), || {
+        manager.handle_aspa_cache_update(table);
+    });
+
+    let events = captured.lock().unwrap();
+    assert_eq!(events.len(), 1);
+    let fields = &events[0].0;
+    for (name, value) in [
+        ("records", "2"),
+        ("routes_scanned", "2"),
+        ("changed_routes", "1"),
+        ("affected_prefixes", "1"),
+        ("invalid_hop_routes", "2"),
+        ("suppressed_routes", "0"),
+    ] {
+        assert_eq!(fields.get(name).map(String::as_str), Some(value), "{name}");
+    }
+    assert_eq!(
+        fields.get("invalid_hops").map(String::as_str),
+        Some("65003>65002:1, 65005>65004:1")
+    );
+}
 
 #[test]
 fn validate_route_rpki_valid() {

--- a/crates/rpki/src/aspa_verify.rs
+++ b/crates/rpki/src/aspa_verify.rs
@@ -7,6 +7,39 @@ use rustbgpd_wire::{AsPath, AsPathSegment, AspaValidation, AspaValidationContext
 
 use crate::aspa::{AspaTable, ProviderAuth};
 
+/// Proven customer/provider pair that made an ASPA path invalid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AspaInvalidHop {
+    pub customer_asn: u32,
+    pub provider_asn: u32,
+}
+
+/// ASPA verdict plus the first proven `NotProviderPlus` hop, when one exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AspaVerificationResult {
+    pub state: AspaValidation,
+    pub invalid_hop: Option<AspaInvalidHop>,
+}
+
+impl AspaVerificationResult {
+    pub(crate) const fn state(state: AspaValidation) -> Self {
+        Self {
+            state,
+            invalid_hop: None,
+        }
+    }
+
+    const fn invalid(customer_asn: u32, provider_asn: u32) -> Self {
+        Self {
+            state: AspaValidation::Invalid,
+            invalid_hop: Some(AspaInvalidHop {
+                customer_asn,
+                provider_asn,
+            }),
+        }
+    }
+}
+
 /// Compress an `AS_PATH` into a flat list of ASNs with consecutive duplicates
 /// removed (`AS_PATH` preload compression per the ASPA verification spec).
 ///
@@ -61,9 +94,22 @@ fn leftmost_as_matches_neighbor(hops: &[u32], neighbor_asn: Option<u32>) -> bool
 /// from a provider and downstream verification is applied.
 #[must_use]
 pub fn verify(path: &AsPath, table: &AspaTable, context: AspaValidationContext) -> AspaValidation {
+    verify_detailed(path, table, context).state
+}
+
+/// Verify an `AS_PATH`, retaining the first `NotProviderPlus` hop. Invalid
+/// structural/precondition outcomes deliberately carry no pair.
+#[must_use]
+pub fn verify_detailed(
+    path: &AsPath,
+    table: &AspaTable,
+    context: AspaValidationContext,
+) -> AspaVerificationResult {
     match direction_for_role(context.local_role) {
-        VerificationDirection::Upstream => verify_upstream_with_context(path, table, context),
-        VerificationDirection::Downstream => verify_downstream(path, table, context),
+        VerificationDirection::Upstream => {
+            verify_upstream_with_context_detailed(path, table, context)
+        }
+        VerificationDirection::Downstream => verify_downstream_detailed(path, table, context),
     }
 }
 
@@ -107,32 +153,32 @@ pub fn verify(path: &AsPath, table: &AspaTable, context: AspaValidationContext) 
 /// that introduces a non-zero `max_down_ramp`) fires the corpus test.
 #[must_use]
 pub fn verify_upstream(path: &AsPath, table: &AspaTable) -> AspaValidation {
-    verify_upstream_with_context(path, table, AspaValidationContext::default())
+    verify_upstream_with_context_detailed(path, table, AspaValidationContext::default()).state
 }
 
-fn verify_upstream_with_context(
+fn verify_upstream_with_context_detailed(
     path: &AsPath,
     table: &AspaTable,
     context: AspaValidationContext,
-) -> AspaValidation {
+) -> AspaVerificationResult {
     let Some(compressed) = compress_as_path(path) else {
-        return AspaValidation::Invalid; // AS_SET present
+        return AspaVerificationResult::state(AspaValidation::Invalid); // AS_SET present
     };
 
     // Empty AS_PATH is Invalid per spec step 1.
     if compressed.is_empty() {
-        return AspaValidation::Invalid;
+        return AspaVerificationResult::state(AspaValidation::Invalid);
     }
 
     if !context.first_as_check_exempt
         && !leftmost_as_matches_neighbor(&compressed, context.neighbor_asn)
     {
-        return AspaValidation::Invalid;
+        return AspaVerificationResult::state(AspaValidation::Invalid);
     }
 
     // Single-hop path: only origin AS, no pairs to verify → Valid.
     if compressed.len() == 1 {
-        return AspaValidation::Valid;
+        return AspaVerificationResult::state(AspaValidation::Valid);
     }
 
     // Walk from origin (last element) toward neighbor (first element).
@@ -152,7 +198,7 @@ fn verify_upstream_with_context(
             }
             ProviderAuth::NotProviderPlus => {
                 // Proven non-provider relationship — path is invalid.
-                return AspaValidation::Invalid;
+                return AspaVerificationResult::invalid(customer, provider);
             }
             ProviderAuth::NoAttestation => {
                 // Cannot verify this hop — mark as incomplete.
@@ -162,23 +208,23 @@ fn verify_upstream_with_context(
     }
 
     if has_no_attestation {
-        AspaValidation::Unknown
+        AspaVerificationResult::state(AspaValidation::Unknown)
     } else {
-        AspaValidation::Valid
+        AspaVerificationResult::state(AspaValidation::Valid)
     }
 }
 
-fn verify_downstream(
+fn verify_downstream_detailed(
     path: &AsPath,
     table: &AspaTable,
     context: AspaValidationContext,
-) -> AspaValidation {
+) -> AspaVerificationResult {
     let Some(compressed) = compress_as_path(path) else {
-        return AspaValidation::Invalid; // AS_SET present
+        return AspaVerificationResult::state(AspaValidation::Invalid); // AS_SET present
     };
 
     if compressed.is_empty() {
-        return AspaValidation::Invalid;
+        return AspaVerificationResult::state(AspaValidation::Invalid);
     }
 
     // Downstream verification always enforces the leftmost-AS precondition:
@@ -187,26 +233,32 @@ fn verify_downstream(
     // exemption never applies downstream — an RS-client uses upstream
     // verification. `direction_for_role` is the single source of that mapping.
     if !leftmost_as_matches_neighbor(&compressed, context.neighbor_asn) {
-        return AspaValidation::Invalid;
+        return AspaVerificationResult::state(AspaValidation::Invalid);
     }
 
     if compressed.len() == 1 {
-        return AspaValidation::Valid;
+        return AspaVerificationResult::state(AspaValidation::Valid);
     }
 
     let origin_to_neighbor: Vec<u32> = compressed.iter().rev().copied().collect();
     let n = origin_to_neighbor.len();
-    let max_up = ramp_up_bound(&origin_to_neighbor, table, BoundMode::Max);
-    let min_up = ramp_up_bound(&origin_to_neighbor, table, BoundMode::Min);
+    let (max_up, invalid_hop) = ramp_up_bound(&origin_to_neighbor, table, BoundMode::Max);
+    let (min_up, _) = ramp_up_bound(&origin_to_neighbor, table, BoundMode::Min);
     let max_down = ramp_down_bound(&origin_to_neighbor, table, BoundMode::Max);
     let min_down = ramp_down_bound(&origin_to_neighbor, table, BoundMode::Min);
 
     if max_up + max_down < n {
-        AspaValidation::Invalid
+        AspaVerificationResult {
+            state: AspaValidation::Invalid,
+            // The downstream Invalid inequality guarantees that the max-up
+            // walk encountered `NotProviderPlus`; there is no max-down
+            // fallback because it would report a different traversal.
+            invalid_hop,
+        }
     } else if min_up + min_down < n {
-        AspaValidation::Unknown
+        AspaVerificationResult::state(AspaValidation::Unknown)
     } else {
-        AspaValidation::Valid
+        AspaVerificationResult::state(AspaValidation::Valid)
     }
 }
 
@@ -216,16 +268,27 @@ enum BoundMode {
     Min,
 }
 
-fn ramp_up_bound(origin_to_neighbor: &[u32], table: &AspaTable, mode: BoundMode) -> usize {
+fn ramp_up_bound(
+    origin_to_neighbor: &[u32],
+    table: &AspaTable,
+    mode: BoundMode,
+) -> (usize, Option<AspaInvalidHop>) {
     let n = origin_to_neighbor.len();
     for i in 0..n.saturating_sub(1) {
         let customer = origin_to_neighbor[i];
         let provider = origin_to_neighbor[i + 1];
-        if stops_ramp(table.authorized(customer, provider), mode) {
-            return i + 1;
+        let auth = table.authorized(customer, provider);
+        if stops_ramp(auth, mode) {
+            return (
+                i + 1,
+                (auth == ProviderAuth::NotProviderPlus).then_some(AspaInvalidHop {
+                    customer_asn: customer,
+                    provider_asn: provider,
+                }),
+            );
         }
     }
-    n
+    (n, None)
 }
 
 fn ramp_down_bound(origin_to_neighbor: &[u32], table: &AspaTable, mode: BoundMode) -> usize {
@@ -276,6 +339,47 @@ mod tests {
             neighbor_asn: Some(neighbor_asn),
             local_role,
             first_as_check_exempt: matches!(local_role, Some(BgpRole::RouteServerClient)),
+        }
+    }
+
+    /// Red proof: choosing the last/swapped hop or attaching one to any other
+    /// outcome breaks an exact pair/no-pair assertion.
+    #[test]
+    fn detailed_result_reports_only_first_not_provider_hop() {
+        let all_bad = make_table(vec![(1, vec![99]), (2, vec![99]), (3, vec![99])]);
+        let path = make_path(&[3, 2, 1]);
+        let expected = Some(AspaInvalidHop {
+            customer_asn: 1,
+            provider_asn: 2,
+        });
+        assert_eq!(
+            verify_detailed(&path, &all_bad, context(None, 3)),
+            AspaVerificationResult {
+                state: AspaValidation::Invalid,
+                invalid_hop: expected,
+            }
+        );
+        assert_eq!(
+            verify_detailed(&path, &all_bad, context(Some(BgpRole::Customer), 3)),
+            AspaVerificationResult {
+                state: AspaValidation::Invalid,
+                invalid_hop: expected,
+            }
+        );
+
+        let empty = make_table(vec![]);
+        let valid = make_table(vec![(1, vec![2])]);
+        let as_set = AsPath {
+            segments: vec![AsPathSegment::AsSet(vec![2, 1])],
+        };
+        for result in [
+            verify_detailed(&make_path(&[2, 1]), &valid, context(None, 2)),
+            verify_detailed(&make_path(&[2, 1]), &empty, context(None, 2)),
+            verify_detailed(&as_set, &empty, context(None, 2)),
+            verify_detailed(&make_path(&[]), &empty, context(None, 2)),
+            verify_detailed(&make_path(&[2, 1]), &empty, context(None, 9)),
+        ] {
+            assert_eq!(result.invalid_hop, None, "state={:?}", result.state);
         }
     }
 
@@ -529,6 +633,16 @@ mod tests {
             ),
             expected,
             "neighbor={neighbor_asn} role={local_role:?} path={as_path:?}"
+        );
+        assert_eq!(
+            verify_detailed(
+                &make_path(as_path),
+                table,
+                context(local_role, neighbor_asn)
+            )
+            .state,
+            expected,
+            "detailed neighbor={neighbor_asn} role={local_role:?} path={as_path:?}"
         );
     }
 
@@ -933,12 +1047,14 @@ mod tests {
                     let table = build_table_from_states(hops, states);
                     let path = make_path(hops);
                     let prod = verify_upstream(&path, &table);
+                    let detailed = verify_detailed(&path, &table, AspaValidationContext::default());
                     let refr = verify_upstream_bounds_v25(&path, &table);
                     assert_eq!(
                         prod, refr,
                         "divergence: hops={hops:?} states={states:?} \
                          prod={prod:?} ref={refr:?}"
                     );
+                    assert_eq!(detailed.state, prod, "detailed verdict drifted");
                     cases_checked += 1;
                 }
             }

--- a/crates/rpki/src/lib.rs
+++ b/crates/rpki/src/lib.rs
@@ -58,6 +58,7 @@ pub mod vrp_manager;
 use std::sync::Arc;
 
 pub use aspa::{AspaRecord, AspaTable};
+pub use aspa_verify::{AspaInvalidHop, AspaVerificationResult};
 pub use rtr_client::{RtrClient, RtrClientConfig, VrpUpdate};
 pub use vrp::{VrpEntry, VrpTable};
 pub use vrp_manager::{AspaTableUpdate, RpkiTableUpdate, VrpManager};
@@ -111,14 +112,25 @@ impl ValidationSnapshot {
         family: (rustbgpd_wire::Afi, rustbgpd_wire::Safi),
         context: rustbgpd_wire::AspaValidationContext,
     ) -> rustbgpd_wire::AspaValidation {
+        self.validate_aspa_detailed(as_path, family, context).state
+    }
+
+    /// Detailed form of [`Self::validate_aspa`] for bounded diagnostics.
+    #[must_use]
+    pub fn validate_aspa_detailed(
+        &self,
+        as_path: Option<&rustbgpd_wire::AsPath>,
+        family: (rustbgpd_wire::Afi, rustbgpd_wire::Safi),
+        context: rustbgpd_wire::AspaValidationContext,
+    ) -> AspaVerificationResult {
         use rustbgpd_wire::{Afi, AspaValidation, Safi};
         // §6.2 family gate.
         if !matches!(family, (Afi::Ipv4 | Afi::Ipv6, Safi::Unicast)) {
-            return AspaValidation::Unknown;
+            return AspaVerificationResult::state(AspaValidation::Unknown);
         }
         match (&self.aspa_table, as_path) {
-            (Some(table), Some(path)) => aspa_verify::verify(path, table, context),
-            _ => AspaValidation::Unknown,
+            (Some(table), Some(path)) => aspa_verify::verify_detailed(path, table, context),
+            _ => AspaVerificationResult::state(AspaValidation::Unknown),
         }
     }
 }

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -652,6 +652,7 @@ impl PeerSession {
             large_communities_dropped: 0,
             rpki: rustbgpd_wire::RpkiValidation::NotFound,
             aspa: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_invalid_hop: None,
             rejected_at: SystemTime::now(),
         };
         // Bound before the caller clones it across every rejected
@@ -684,6 +685,7 @@ impl PeerSession {
             large_communities_dropped: 0,
             rpki: rustbgpd_wire::RpkiValidation::NotFound,
             aspa: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_invalid_hop: None,
             rejected_at: SystemTime::now(),
         };
         prototype.enforce_bounds();
@@ -1774,15 +1776,21 @@ impl PeerSession {
         // to import policy and stores Unknown for every iBGP unicast route.
         let validate_aspa = |family| {
             if !is_ebgp {
-                return rustbgpd_wire::AspaValidation::Unknown;
+                return rustbgpd_rpki::AspaVerificationResult {
+                    state: rustbgpd_wire::AspaValidation::Unknown,
+                    invalid_hop: None,
+                };
             }
-            validation
-                .as_ref()
-                .map_or(rustbgpd_wire::AspaValidation::Unknown, |v| {
-                    v.validate_aspa(parsed_as_path, family, aspa_context)
-                })
+            validation.as_ref().map_or(
+                rustbgpd_rpki::AspaVerificationResult {
+                    state: rustbgpd_wire::AspaValidation::Unknown,
+                    invalid_hop: None,
+                },
+                |v| v.validate_aspa_detailed(parsed_as_path, family, aspa_context),
+            )
         };
-        let body_aspa_state = validate_aspa((Afi::Ipv4, Safi::Unicast));
+        let body_aspa = validate_aspa((Afi::Ipv4, Safi::Unicast));
+        let body_aspa_state = body_aspa.state;
         let unnumbered_ipv4_body_forbidden = self.is_scoped_link_local_peer();
         if unnumbered_ipv4_body_forbidden
             && (!parsed.announced.is_empty() || !parsed.withdrawn.is_empty())
@@ -1907,6 +1915,7 @@ impl PeerSession {
                             reject_entry.next_hop = Some(body_next_hop);
                             reject_entry.rpki = rpki_state;
                             reject_entry.aspa = body_aspa_state;
+                            reject_entry.aspa_invalid_hop = body_aspa.invalid_hop;
                             rejected_retained.push((prefix, entry.path_id, reject_entry));
                         }
                         denied_unicast.push((prefix, entry.path_id));
@@ -2007,7 +2016,8 @@ impl PeerSession {
                     // anything outside IPv4/IPv6 unicast — so FlowSpec and
                     // EVPN announcements below propagate `Unknown` even when
                     // an ASPA table is loaded, without any extra branching.
-                    let mp_aspa_state = validate_aspa(family);
+                    let mp_aspa = validate_aspa(family);
+                    let mp_aspa_state = mp_aspa.state;
                     if mp.safi == Safi::FlowSpec {
                         // FlowSpec announced routes — no next-hop (NH len = 0)
                         for rule in &mp.flowspec_announced {
@@ -2550,6 +2560,7 @@ impl PeerSession {
                                 reject_entry.next_hop = Some(mp.next_hop);
                                 reject_entry.rpki = mp_rpki_state;
                                 reject_entry.aspa = mp_aspa_state;
+                                reject_entry.aspa_invalid_hop = mp_aspa.invalid_hop;
                                 rejected_retained.push((entry.prefix, entry.path_id, reject_entry));
                             }
                             denied_unicast.push((entry.prefix, entry.path_id));

--- a/crates/transport/src/session/rejected_routes.rs
+++ b/crates/transport/src/session/rejected_routes.rs
@@ -156,21 +156,23 @@ impl RejectedRouteEntry {
     }
 
     #[must_use]
-    pub fn rendered_reason_detail(&self) -> String {
+    pub fn take_rendered_reason_detail(&mut self) -> String {
+        let detail = self.detail.take();
         let Some(hop) = self.aspa_invalid_hop else {
-            return self.detail.clone().unwrap_or_default();
+            return detail.unwrap_or_default();
         };
         let suffix = format!(
             "aspa_not_provider customer={} provider={}",
             hop.customer_asn, hop.provider_asn
         );
-        let Some(detail) = self.detail.as_deref() else {
+        let Some(mut detail) = detail else {
             return suffix;
         };
-        let mut prefix = detail.to_owned();
         let prefix_budget = MAX_RENDERED_REASON_DETAIL_BYTES - suffix.len() - 3;
-        truncate_marked(&mut prefix, prefix_budget);
-        format!("{prefix} | {suffix}")
+        truncate_marked(&mut detail, prefix_budget);
+        detail.push_str(" | ");
+        detail.push_str(&suffix);
+        detail
     }
 
     /// Enforce the per-entry byte bound: truncate the string fields
@@ -367,19 +369,21 @@ mod tests {
         assert_eq!(snap[0].1.reason, ImportRejectReason::PolicyReject);
     }
 
-    /// Red proof: omitting the suffix/prefix or its cap breaks exact assertions;
-    /// the no-hop detail must remain byte-identical.
+    /// Red proof: suffix/prefix/cap and no-hop bytes are exact; detail must move, not clone.
     #[test]
     fn reason_detail_appends_bounded_aspa_hop_suffix() {
         let mut rejected = entry(ImportRejectReason::PolicyReject);
         rejected.detail = Some("member-import".to_owned());
-        assert_eq!(rejected.rendered_reason_detail(), "member-import");
-        rejected.aspa_invalid_hop = Some(AspaInvalidHop {
-            customer_asn: u32::MAX,
-            provider_asn: u32::MAX,
-        });
+        assert_eq!(rejected.take_rendered_reason_detail(), "member-import");
+        assert_eq!(rejected.detail, None);
+        rejected.set_aspa_invalid_hop(u32::MAX, u32::MAX);
+        rejected.detail = Some(String::new());
+        assert_eq!(
+            rejected.take_rendered_reason_detail(),
+            " | aspa_not_provider customer=4294967295 provider=4294967295"
+        );
         rejected.detail = Some("p".repeat(500));
-        let rendered = rejected.rendered_reason_detail();
+        let rendered = rejected.take_rendered_reason_detail();
         assert!(rendered.len() <= MAX_RENDERED_REASON_DETAIL_BYTES);
         assert!(rendered.starts_with('p'));
         assert!(rendered.contains(" | aspa_not_provider customer=4294967295 provider=4294967295"));

--- a/crates/transport/src/session/rejected_routes.rs
+++ b/crates/transport/src/session/rejected_routes.rs
@@ -51,6 +51,7 @@ use std::num::NonZeroUsize;
 use std::time::SystemTime;
 
 use lru::LruCache;
+use rustbgpd_rpki::AspaInvalidHop;
 use rustbgpd_telemetry::reason_labels::ImportRejectReason;
 use rustbgpd_wire::{AspaValidation, LargeCommunity, RpkiValidation};
 
@@ -71,6 +72,9 @@ pub const MAX_RETAINED_AS_PATH_BYTES: usize = 96;
 /// Byte cap on a retained entry's `detail` string, marker included.
 /// Policy names and gate sub-reason tokens fit comfortably.
 pub const MAX_RETAINED_DETAIL_BYTES: usize = 64;
+
+/// Wire/API bound after appending an ASPA hop to `reason_detail`.
+pub const MAX_RENDERED_REASON_DETAIL_BYTES: usize = 128;
 
 /// Cap on retained standard communities; the excess is counted in
 /// [`RejectedRouteEntry::communities_dropped`].
@@ -137,11 +141,38 @@ pub struct RejectedRouteEntry {
     pub rpki: RpkiValidation,
     /// ASPA path-verification state at rejection time.
     pub aspa: AspaValidation,
+    /// First proven ASPA `NotProviderPlus` hop at rejection time.
+    pub aspa_invalid_hop: Option<AspaInvalidHop>,
     /// Wall-clock time of the rejection.
     pub rejected_at: SystemTime,
 }
 
 impl RejectedRouteEntry {
+    pub fn set_aspa_invalid_hop(&mut self, customer_asn: u32, provider_asn: u32) {
+        self.aspa_invalid_hop = Some(AspaInvalidHop {
+            customer_asn,
+            provider_asn,
+        });
+    }
+
+    #[must_use]
+    pub fn rendered_reason_detail(&self) -> String {
+        let Some(hop) = self.aspa_invalid_hop else {
+            return self.detail.clone().unwrap_or_default();
+        };
+        let suffix = format!(
+            "aspa_not_provider customer={} provider={}",
+            hop.customer_asn, hop.provider_asn
+        );
+        let Some(detail) = self.detail.as_deref() else {
+            return suffix;
+        };
+        let mut prefix = detail.to_owned();
+        let prefix_budget = MAX_RENDERED_REASON_DETAIL_BYTES - suffix.len() - 3;
+        truncate_marked(&mut prefix, prefix_budget);
+        format!("{prefix} | {suffix}")
+    }
+
     /// Enforce the per-entry byte bound: truncate the string fields
     /// (marker appended) and cap the community vectors, recording the
     /// dropped counts. `RejectedRouteStore::insert` applies this to
@@ -321,6 +352,7 @@ mod tests {
             large_communities_dropped: 0,
             rpki: RpkiValidation::NotFound,
             aspa: AspaValidation::Unknown,
+            aspa_invalid_hop: None,
             rejected_at: SystemTime::UNIX_EPOCH,
         }
     }
@@ -333,6 +365,24 @@ mod tests {
         assert_eq!(snap.len(), 1);
         assert_eq!(snap[0].0, key(1));
         assert_eq!(snap[0].1.reason, ImportRejectReason::PolicyReject);
+    }
+
+    /// Red proof: omitting the suffix/prefix or its cap breaks exact assertions;
+    /// the no-hop detail must remain byte-identical.
+    #[test]
+    fn reason_detail_appends_bounded_aspa_hop_suffix() {
+        let mut rejected = entry(ImportRejectReason::PolicyReject);
+        rejected.detail = Some("member-import".to_owned());
+        assert_eq!(rejected.rendered_reason_detail(), "member-import");
+        rejected.aspa_invalid_hop = Some(AspaInvalidHop {
+            customer_asn: u32::MAX,
+            provider_asn: u32::MAX,
+        });
+        rejected.detail = Some("p".repeat(500));
+        let rendered = rejected.rendered_reason_detail();
+        assert!(rendered.len() <= MAX_RENDERED_REASON_DETAIL_BYTES);
+        assert!(rendered.starts_with('p'));
+        assert!(rendered.contains(" | aspa_not_provider customer=4294967295 provider=4294967295"));
     }
 
     #[test]

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -14063,7 +14063,7 @@ async fn import_policy_filters_aspa_invalid_with_snapshot() {
     };
     let (_watch_tx, watch_rx) = watch::channel(snapshot);
     // Import policy: deny ASPA-invalid routes
-    let deny_invalid = PolicyChain::new(vec![Policy {
+    let mut deny_invalid = PolicyChain::new(vec![Policy {
         entries: vec![PolicyStatement {
             prefix: None,
             ge: None,
@@ -14087,6 +14087,7 @@ async fn import_policy_filters_aspa_invalid_with_snapshot() {
         }],
         default_action: PolicyAction::Permit,
     }]);
+    deny_invalid.policies[0].name = Some("member-import".to_owned());
     let mut session = PeerSession::new(
         config,
         metrics,
@@ -14178,6 +14179,19 @@ async fn import_policy_filters_aspa_invalid_with_snapshot() {
         }
         _ => panic!("unexpected RibUpdate variant"),
     }
+    // Load-bearing pair propagation proof: dropping the detailed verifier
+    // result at ingress, swapping pair order, or losing policy attribution
+    // makes these exact assertions fail.
+    let retained = session.rejected_routes.snapshot();
+    assert_eq!(retained.len(), 1);
+    assert_eq!(retained[0].1.detail.as_deref(), Some("member-import"));
+    assert_eq!(
+        retained[0].1.aspa_invalid_hop,
+        Some(rustbgpd_rpki::AspaInvalidHop {
+            customer_asn: 65004,
+            provider_asn: 65002,
+        })
+    );
 }
 /// Regression: when an inbound UPDATE is discarded due to RFC 4456
 /// loop detection (our cluster-id present in `CLUSTER_LIST`), any EVPN


### PR DESCRIPTION
## Summary\n\n- expose the first RFC ASPA Invalid customer/provider hop through existing bounded rejected-route detail\n- aggregate refresh diagnostics into one deterministic top-eight completion event with exact total and suppressed counts\n- preserve route verdicts, policy behavior, refresh semantics, protobufs, configuration, and metric cardinality\n\n## Correctness\n\nThe retained rejection entry stays below its existing 512-byte budget. Detail remains capped at 128 bytes; aggregate output is capped at 512 bytes. The summary counts Invalid routes even when the validation state remains unchanged, keeps the lexicographically smallest eight distinct pairs, and accounts exactly for evicted and never-admitted routes.\n\nLoad-bearing proofs were run by reverting each guarded behavior. The focused tests failed for swapped customer/provider direction, a fabricated structural hop, dropped ingress propagation, lost named-policy attribution, altered suffix rendering, old API mapping, changed-only aggregation, count-one eviction accounting, and missing never-admitted suppression.\n\n## Verification\n\n- cargo fmt --all -- --check\n- cargo clippy --workspace --all-targets --all-features -- -D warnings\n- cargo test --workspace\n- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps\n- git diff --check\n\nTwo independent final reviews returned CLEAN and GO on the exact committed diff.