### PR TITLE
Make MRT scratch campaign self-verifying

### DIFF
--- a/bench/run-mrt-attribute-scratch-campaign.py
+++ b/bench/run-mrt-attribute-scratch-campaign.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Build and run the frozen MRT scratch A/B under one host fence."""
+import argparse, datetime, fcntl, hashlib, importlib.util, json, os, pathlib, shutil, subprocess, tempfile, time
+HERE = pathlib.Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location("scratch_verify", HERE / "verify-mrt-attribute-scratch-campaign.py")
+VERIFY = importlib.util.module_from_spec(SPEC); SPEC.loader.exec_module(VERIFY)
+def run(argv, check=True, **kwargs): return subprocess.run(argv, check=check, **kwargs)
+def output(argv): return subprocess.check_output(argv, text=True).strip()
+def sha(path): return hashlib.sha256(path.read_bytes()).hexdigest()
+def dump(path, value): path.write_text(json.dumps(value, sort_keys=True, indent=2) + "\n")
+def open_lock(path): return os.fdopen(os.open(path,os.O_RDWR|os.O_CREAT|os.O_CLOEXEC|os.O_NOFOLLOW,0o600),"r+")
+def cleanup(repo,temp,trees,remove=run):
+    ok=True
+    for tree in trees: ok &= remove(["git","-C",str(repo),"worktree","remove","--force",str(tree)],check=False).returncode == 0
+    if ok: shutil.rmtree(temp)
+    else: raise RuntimeError(f"worktree cleanup failed; retained recovery state in {temp}")
+def governor(cpu):
+    path = pathlib.Path(f"/sys/devices/system/cpu/cpu{cpu}/cpufreq/scaling_governor")
+    return path.read_text().strip()
+def wait_idle(cpu, log, phase):
+    deadline = time.monotonic() + 300
+    while True:
+        load = float(pathlib.Path("/proc/loadavg").read_text().split()[0]); gov = governor(cpu)
+        competitors=sorted(name for name in output(["ps","-eo","comm="]).splitlines() if name.strip() in {"cargo","rustc","perf","rustbgpd"} or name.strip().startswith(("snapshot_alloc","rrharness","reloadstall")))
+        record = {"phase":phase,"utc":datetime.datetime.now(datetime.timezone.utc).isoformat(),"load_1m":load,"governor":gov,"competitors":competitors,"status":"pass" if load < 2 and gov == "performance" and not competitors else "wait"}
+        with log.open("a") as stream: stream.write(json.dumps(record,sort_keys=True,separators=(",",":"))+"\n")
+        if record["status"] == "pass": return
+        if time.monotonic() >= deadline: raise RuntimeError(f"host preflight timed out for {phase}")
+        time.sleep(1)
+def build(repo, tree, variant, mode, target, commands):
+    command = next(row for row in commands if row.get("kind") == "build" and row["variant"] == variant and row["mode"] == mode)
+    env = os.environ.copy(); env["CARGO_TARGET_DIR"] = str(target)
+    run(command["argv"], cwd=tree, env=env)
+    binaries = [p for p in (target/"release"/"deps").glob("snapshot_allocation-*") if p.is_file() and os.access(p,os.X_OK)]
+    if len(binaries) != 1: raise RuntimeError(f"expected one {variant} {mode} binary, found {len(binaries)}")
+    destination = repo/"binaries"/f"{variant}-{mode}"; shutil.copy2(binaries[0],destination)
+def seal(root):
+    rows=[]
+    for path in sorted(p for p in root.rglob("*") if p.is_file() and p != root/"SHA256SUMS"):
+        rows.append(f"{sha(path)}  {path.relative_to(root)}\n")
+    (root/"SHA256SUMS").write_text("".join(rows))
+def main():
+    parser=argparse.ArgumentParser(); parser.add_argument("output",type=pathlib.Path); parser.add_argument("--repo",type=pathlib.Path,default=HERE.parent)
+    args=parser.parse_args(); cpu_count=os.cpu_count()
+    if type(cpu_count) is not int or cpu_count <= 0: raise RuntimeError("os.cpu_count() must return a positive integer")
+    repo=args.repo.resolve(); root=args.output.absolute()
+    if root.exists(): raise SystemExit(f"refusing existing output: {root}")
+    for script in (HERE/"run-mrt-attribute-scratch-campaign.py",HERE/"verify-mrt-attribute-scratch-campaign.py"):
+        run(["git","-C",str(repo),"ls-files","--error-unmatch",str(script.relative_to(repo))],stdout=subprocess.DEVNULL)
+        run(["git","-C",str(repo),"diff","--quiet","--",str(script.relative_to(repo))])
+        run(["git","-C",str(repo),"diff","--cached","--quiet","--",str(script.relative_to(repo))])
+    lock_path=pathlib.Path(os.environ.get("RUSTBGPD_HOST_LOCK",pathlib.Path.home()/".local/state/rustbgpd-host.lock")); lock_path.parent.mkdir(parents=True,exist_ok=True)
+    lock=open_lock(lock_path)
+    try: fcntl.flock(lock,fcntl.LOCK_EX|fcntl.LOCK_NB)
+    except BlockingIOError: raise SystemExit("shared rustbgpd host lock is busy")
+    root.mkdir(); (root/"raw").mkdir(); (root/"binaries").mkdir(); (root/"source").mkdir()
+    shutil.copy2(HERE/"run-mrt-attribute-scratch-campaign.py",root/"source"/"runner-mrt-attribute-scratch-campaign.py")
+    shutil.copy2(HERE/"verify-mrt-attribute-scratch-campaign.py",root/"source"/"verifier-mrt-attribute-scratch-campaign.py")
+    commands=VERIFY.expected_commands(); temp=pathlib.Path(tempfile.mkdtemp(prefix="mrt-scratch-")); trees={}
+    try:
+        for variant, commit in (("control",VERIFY.CONTROL),("candidate",VERIFY.CANDIDATE)):
+            tree=temp/variant; run(["git","-C",str(repo),"worktree","add","--detach",str(tree),commit]); trees[variant]=tree
+        for variant in ("control","candidate"):
+            for mode in ("timing","diagnostic"): build(root,trees[variant],variant,mode,temp/f"target-{variant}-{mode}",commands)
+        binaries={variant:{mode:sha(root/"binaries"/f"{variant}-{mode}") for mode in ("timing","diagnostic")} for variant in ("control","candidate")}
+        dump(root/"manifest.json",{"schema":1,"control_commit":VERIFY.CONTROL,"candidate_commit":VERIFY.CANDIDATE,"control_tree":VERIFY.TREES["control"],"candidate_tree":VERIFY.TREES["candidate"],"instrument_sha256":VERIFY.INSTRUMENT,"runner_sha256":sha(root/"source"/"runner-mrt-attribute-scratch-campaign.py"),"verifier_sha256":sha(root/"source"/"verifier-mrt-attribute-scratch-campaign.py"),"binaries":binaries})
+        cpu_model=next(line.split(":",1)[1].strip() for line in pathlib.Path("/proc/cpuinfo").read_text().splitlines() if line.startswith("model name"))
+        dump(root/"provenance.json",{"rustc":output(["rustc","-Vv"]),"cargo":output(["cargo","-V"]),"kernel":output(["uname","-srmo"]),"cpu_model":cpu_model,"cpu_count":cpu_count,"governor":governor(0),"affinity":"0","taskset":output(["taskset","--version"])})
+        with (root/"commands.jsonl").open("w") as stream:
+            for row in commands: stream.write(json.dumps({k:v for k,v in row.items() if k != "binary_sha256"},sort_keys=True,separators=(",",":"))+"\n")
+        for command in commands:
+            if command["kind"] == "build": continue
+            variant,shape,mode=command["variant"],command["shape"],command["mode"]
+            if command["kind"] == "abba": name=f"b{command['block']}-s{command['slot']}-{shape}.{mode}.jsonl"
+            else: name=f"same-{shape}-{command['side']}.timing.jsonl"
+            target=root/"raw"/name; wait_idle(0,root/"preflight.jsonl",name)
+            argv=command["argv"][:3]+[str(root/"binaries"/f"{variant}-{mode}")]+command["argv"][4:-1]+[str(target)]
+            run(argv)
+        VERIFY.verify(root,repo,write=True,check_seal=False); seal(root); VERIFY.verify(root,repo)
+    finally:
+        cleanup(repo,temp,trees.values())
+    print(json.dumps({"classification":"go","bundle":str(root)},sort_keys=True))
+if __name__ == "__main__": main()

--- a/bench/tests/test_verify_mrt_attribute_scratch_campaign.py
+++ b/bench/tests/test_verify_mrt_attribute_scratch_campaign.py
@@ -1,0 +1,163 @@
+import hashlib, importlib.util, json, os, pathlib, shutil, subprocess, tempfile, types, unittest, unittest.mock
+REPO = pathlib.Path(__file__).parents[2]
+SCRIPT = REPO / "bench/verify-mrt-attribute-scratch-campaign.py"
+SPEC = importlib.util.spec_from_file_location("scratch_verify", SCRIPT)
+VERIFY = importlib.util.module_from_spec(SPEC); SPEC.loader.exec_module(VERIFY)
+RUN_SPEC = importlib.util.spec_from_file_location("scratch_runner", REPO / "bench/run-mrt-attribute-scratch-campaign.py")
+RUNNER = importlib.util.module_from_spec(RUN_SPEC); RUN_SPEC.loader.exec_module(RUNNER)
+def write_json(path, value): path.write_text(json.dumps(value, sort_keys=True, indent=2)+"\n")
+def write_rows(path, rows): path.write_text("".join(json.dumps(r,sort_keys=True,separators=(",",":"))+"\n" for r in rows))
+def digest(path): return hashlib.sha256(path.read_bytes()).hexdigest()
+def seal(root):
+    (root/"SHA256SUMS").write_text("".join(f"{digest(p)}  {p.relative_to(root)}\n" for p in sorted(root.rglob("*")) if p.is_file() and p != root/"SHA256SUMS"))
+def raw_row(variant, shape, mode, index, elapsed, calls, capacity):
+    paths,prefixes,sources=VERIFY.SHAPES[shape]; hexes=("1" if shape=="ixp-700" else "2")*64
+    row={"schema_version":3,"variant":"candidate","scratch_variant":variant,"commit":VERIFY.CONTROL if variant=="control" else VERIFY.CANDIDATE,"mode":mode,"shape":shape,"smoke":False,"warmup_count":2,"sample_index":index,"path_count":paths,"prefix_count":prefixes,"source_count":sources,"output_len_bytes":paths*80,"output_capacity_bytes":paths*80,"decoded_entry_count":paths,"elapsed_ns":elapsed,"raw_sha256":hexes,"semantic_sha256":("3" if shape=="ixp-700" else "4")*64,"allocator":None,"growth":None,"growth_path_assertion":None}
+    if mode=="diagnostic":
+        row.update(elapsed_ns=None,allocator={name:(calls if name=="alloc_calls" else 0) for name in VERIFY.ALLOC},
+                   growth={"top_level_unbounded_capacity_misses":1},growth_path_assertion="bounded-growth-observed",
+                   attribute_scratch={"eligible_opportunities":paths*6,"reuse_count":paths*6 if variant=="candidate" else 0,
+                                      "retained_capacity_bytes":capacity if variant=="candidate" else 0})
+    return row
+def fixture(root, candidate_ns=90, same_right=100, candidate_calls=70, capacity=4096, control_ns=100, same_left=100, finalize=True):
+    for name in ("raw","binaries","source"): (root/name).mkdir(parents=True)
+    shutil.copy2(REPO/"bench/run-mrt-attribute-scratch-campaign.py",root/"source/runner-mrt-attribute-scratch-campaign.py")
+    shutil.copy2(SCRIPT,root/"source/verifier-mrt-attribute-scratch-campaign.py")
+    binaries={}
+    for variant in ("control","candidate"):
+        binaries[variant]={}
+        for mode in ("timing","diagnostic"):
+            path=root/"binaries"/f"{variant}-{mode}"; path.write_bytes(f"{variant}-{mode}".encode()); binaries[variant][mode]=digest(path)
+    write_json(root/"manifest.json",{"schema":1,"control_commit":VERIFY.CONTROL,"candidate_commit":VERIFY.CANDIDATE,"control_tree":VERIFY.TREES["control"],"candidate_tree":VERIFY.TREES["candidate"],"instrument_sha256":VERIFY.INSTRUMENT,"runner_sha256":digest(root/"source/runner-mrt-attribute-scratch-campaign.py"),"verifier_sha256":digest(root/"source/verifier-mrt-attribute-scratch-campaign.py"),"binaries":binaries})
+    write_json(root/"provenance.json",{"rustc":"rustc","cargo":"cargo","kernel":"Linux","cpu_model":"cpu","cpu_count":64,"governor":"performance","affinity":"0","taskset":"taskset"})
+    commands=VERIFY.expected_commands(); write_rows(root/"commands.jsonl",commands)
+    phases=[]
+    for c in commands:
+        if c["kind"]=="build": continue
+        phase=(f"b{c['block']}-s{c['slot']}-{c['shape']}.{c['mode']}.jsonl" if c["kind"]=="abba" else f"same-{c['shape']}-{c['side']}.timing.jsonl")
+        phases.append({"phase":phase,"utc":"2026-08-03T00:00:00+00:00","load_1m":0.1,"governor":"performance","competitors":[],"status":"pass"})
+    write_rows(root/"preflight.jsonl",phases)
+    for block in range(1,5):
+        for slot,variant in enumerate(VERIFY.ORDER,1):
+            for shape in VERIFY.SHAPES:
+                stem=root/"raw"/f"b{block}-s{slot}-{shape}"
+                ns=candidate_ns if variant=="candidate" else control_ns; calls=candidate_calls if variant=="candidate" else 100
+                write_rows(stem.with_suffix(".timing.jsonl"),[raw_row(variant,shape,"timing",i,ns,calls,capacity) for i in range(1,8)])
+                write_rows(stem.with_suffix(".diagnostic.jsonl"),[raw_row(variant,shape,"diagnostic",1,None,calls,capacity)])
+    for shape in VERIFY.SHAPES:
+        for side,ns in (("left",same_left),("right",same_right)):
+            write_rows(root/"raw"/f"same-{shape}-{side}.timing.jsonl",[raw_row("control",shape,"timing",i,ns,100,0) for i in range(1,8)])
+    if finalize: write_rows(root/"canonical.jsonl",VERIFY.derive(root)); seal(root)
+def edit_json(path, change):
+    value=json.loads(path.read_text()); change(value); write_json(path,value)
+def edit_rows(path, change):
+    rows=[json.loads(line) for line in path.read_text().splitlines()]; change(rows); write_rows(path,rows)
+class CampaignContract(unittest.TestCase):
+    def make(self, **kwargs):
+        tmp=tempfile.TemporaryDirectory(); root=pathlib.Path(tmp.name); fixture(root,**kwargs); return tmp,root
+    def test_valid_and_drift_adjusted_equality(self):
+        for kwargs in ({},{"candidate_ns":91,"same_right":96}):
+            with self.subTest(kwargs=kwargs):
+                tmp,root=self.make(**kwargs); self.addCleanup(tmp.cleanup)
+                self.assertEqual(VERIFY.verify(root,REPO)["classification"],"go")
+    def test_runner_plan_is_four_builds_sixty_four_abba_and_four_same_sha(self):
+        kinds=[row["kind"] for row in VERIFY.expected_commands()]
+        self.assertEqual((VERIFY.CONTROL,VERIFY.CANDIDATE),("a1cab917d49541d2137e54f9b2b2128e3c3f6715","0c98597b2e831423390c050ba3db2571f3e97b53")); self.assertEqual(VERIFY.ORDER,("control","candidate","candidate","control")); self.assertEqual(VERIFY.SHAPES,{"ixp-700":(400400,400400,700),"dual-full-feed":(800800,400400,2)})
+        self.assertEqual(VERIFY.TREES,{"control":"2b1039dfdf0cd3526e5c1d0778a30c4bc978530a","candidate":"a6b2a7aee3ff2dfcef98fb2d8096e42244c846ae"}); self.assertEqual(VERIFY.INSTRUMENT,"860327fc1cb629235b13f29903fd9ca75438e72a0c7859c3411f13bfe35a1f30")
+        self.assertEqual((kinds.count("build"),kinds.count("abba"),kinds.count("same-sha")),(4,64,4))
+        self.assertEqual(VERIFY.expected_commands()[4]["argv"],["taskset","-c","0","control-timing","timing","--candidate","--scratch-variant","control","--shape","ixp-700","--commit","a1cab917d49541d2137e54f9b2b2128e3c3f6715","--output","b1-s1-ixp-700.timing.jsonl"])
+        self.assertEqual(VERIFY.expected_commands()[-1]["argv"],["taskset","-c","0","control-timing","timing","--candidate","--scratch-variant","control","--shape","dual-full-feed","--commit","a1cab917d49541d2137e54f9b2b2128e3c3f6715","--output","same-dual-full-feed-right.timing.jsonl"])
+    def test_lock_and_cleanup_fail_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root=pathlib.Path(directory); lock=root/"lock"; lock.write_text("held"); handle=RUNNER.open_lock(lock); handle.close(); self.assertEqual(lock.read_text(),"held")
+            link=root/"link"; link.symlink_to(lock); self.assertRaises(OSError,RUNNER.open_lock,link)
+            stale=root/"stale"; stale.mkdir(); failed=lambda *args,**kwargs:types.SimpleNamespace(returncode=1)
+            with self.assertRaises(RuntimeError): RUNNER.cleanup(REPO,stale,[stale/"tree"],failed)
+            self.assertTrue(stale.exists())
+    def test_runner_rejects_invalid_cpu_count_before_output_work(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root=pathlib.Path(directory)
+            for value in (None,True,0,-1):
+                with self.subTest(value=value),unittest.mock.patch.object(RUNNER.os,"cpu_count",return_value=value),unittest.mock.patch("sys.argv",["runner",str(root)]),self.assertRaisesRegex(RuntimeError,"positive integer"): RUNNER.main()
+            with unittest.mock.patch.object(RUNNER.os,"cpu_count",return_value=64),unittest.mock.patch("sys.argv",["runner",str(root)]),self.assertRaisesRegex(SystemExit,"refusing existing output"): RUNNER.main()
+    def test_exact_threshold_rejects_fraction_below_boundary(self):
+        tmp=tempfile.TemporaryDirectory(); self.addCleanup(tmp.cleanup); root=pathlib.Path(tmp.name)
+        fixture(root,candidate_ns=909999993,control_ns=999999992,same_left=1000000007,same_right=960000007,finalize=False)
+        with self.assertRaises(VERIFY.Invalid): VERIFY.derive(root)
+    def rejected(self, mutate, rederive=False, exact=False):
+        tmp,root=self.make(); self.addCleanup(tmp.cleanup); mutate(root); seal(root)
+        if rederive:
+            try: write_rows(root/"canonical.jsonl",VERIFY.derive(root)); seal(root)
+            except (VERIFY.Invalid,KeyError,ValueError): pass
+        expected=VERIFY.Invalid if exact else (VERIFY.Invalid,KeyError,ValueError,json.JSONDecodeError)
+        with self.assertRaises(expected): VERIFY.verify(root,REPO)
+    def test_checksum_mutation_is_rejected(self):
+        for mode in ("reorder","duplicate","nested"):
+            tmp,root=self.make(); self.addCleanup(tmp.cleanup); lines=(root/"SHA256SUMS").read_text().splitlines()
+            if mode=="nested": (root/"raw/SHA256SUMS").write_text("nested authority name\n")
+            else: (root/"SHA256SUMS").write_text("\n".join((list(reversed(lines)) if mode=="reorder" else lines+[lines[0]]))+"\n")
+            with self.subTest(mode=mode),self.assertRaises(VERIFY.Invalid): VERIFY.verify(root,REPO)
+            if mode=="nested":
+                for sealer in (seal,RUNNER.seal): sealer(root); self.assertIn("raw/SHA256SUMS",(root/"SHA256SUMS").read_text()); self.assertEqual(VERIFY.verify(root,REPO)["classification"],"go")
+        tmp,root=self.make(); self.addCleanup(tmp.cleanup); link=root.parent/f"{root.name}-link"; link.symlink_to(root,target_is_directory=True)
+        self.addCleanup(link.unlink)
+        with self.assertRaises(VERIFY.Invalid): VERIFY.verify(link,REPO)
+        result=subprocess.run(["python3",str(SCRIPT),str(link),"--repo",str(REPO)],capture_output=True,text=True)
+        self.assertEqual(result.returncode,2); self.assertIn("bundle root symlink",result.stderr)
+    def test_load_bearing_mutations(self):
+        def both(root,suffix,change):
+            for slot in (2,3): edit_rows(root/"raw"/f"b1-s{slot}-ixp-700.{suffix}.jsonl",change)
+        def identity(root, stem):
+            for suffix in ("timing","diagnostic") if stem.startswith("b") else ("timing",): edit_rows(root/"raw"/f"{stem}.{suffix}.jsonl",lambda rows:[row.update(raw_sha256="9"*64,semantic_sha256="8"*64) for row in rows])
+        def binary_alias(root):
+            target=root/"binaries/candidate-timing"; target.write_bytes((root/"binaries/control-timing").read_bytes())
+            edit_json(root/"manifest.json",lambda value:value["binaries"]["candidate"].update(timing=digest(target)))
+        def cv_witness(root):
+            for slot,values in ((1,[9000000000]*7),(2,[6790711581,7491474890,7491474890,7491474890,7491474890,7491474890,8192238199]),(3,[7491474890]*7),(4,[9000000000]*7)): edit_rows(root/"raw"/f"b1-s{slot}-ixp-700.timing.jsonl",lambda rows,values=values:[row.update(elapsed_ns=value) for row,value in zip(rows,values)])
+        mutations={
+          "reorder":lambda r: (r/"canonical.jsonl").write_text("\n".join(reversed((r/"canonical.jsonl").read_text().splitlines()))+"\n"),
+          "raw-edit":lambda r: edit_rows(r/"raw/b1-s1-ixp-700.timing.jsonl",lambda x:x[0].update(elapsed_ns=101)),
+          "raw-opaque-edit":lambda r: edit_rows(r/"raw/b1-s1-ixp-700.timing.jsonl",lambda x:x[0].update(output_capacity_bytes=x[0]["output_capacity_bytes"]+1)),
+          "tree":lambda r:edit_json(r/"manifest.json",lambda x:x.update(control_tree="0"*40)),
+          "source-commit":lambda r:edit_rows(r/"raw/b1-s1-ixp-700.timing.jsonl",lambda x:x[0].update(commit="0"*40)),
+          "raw-schema-float":lambda r:edit_rows(r/"raw/b1-s1-ixp-700.timing.jsonl",lambda x:x[0].update(schema_version=3.0)),
+          "binary-hash":lambda r:edit_json(r/"manifest.json",lambda x:x["binaries"]["control"].update(timing="0"*64)),
+          "missing-cell":lambda r:(r/"raw/b1-s1-ixp-700.timing.jsonl").unlink(),
+          "instrument":lambda r:edit_json(r/"manifest.json",lambda x:x.update(instrument_sha256="0"*64)),
+          "manifest-schema-bool":lambda r:edit_json(r/"manifest.json",lambda x:x.update(schema=True)),
+          "provenance-cpu-bool":lambda r:edit_json(r/"provenance.json",lambda x:x.update(cpu_count=True)),
+          "runner":lambda r:(r/"source/runner-mrt-attribute-scratch-campaign.py").write_text("changed\n"),
+          "verifier":lambda r:(r/"source/verifier-mrt-attribute-scratch-campaign.py").write_text("changed\n"),
+          "command":lambda r:write_rows(r/"commands.jsonl",list(reversed(VERIFY.expected_commands()))),
+          "preflight":lambda r:edit_rows(r/"preflight.jsonl",lambda x:x[0].update(status="wait")),
+          "cv":cv_witness,
+          "allocation":lambda r:both(r,"diagnostic",lambda x:x[0]["allocator"].update(alloc_calls=81)),
+          "timing":lambda r:both(r,"timing",lambda x:[v.update(elapsed_ns=96) for v in x]),
+          "same-sha":lambda r:edit_rows(r/"raw/same-ixp-700-right.timing.jsonl",lambda x:[v.update(elapsed_ns=95) for v in x]),
+          "reuse":lambda r:edit_rows(r/"raw/b1-s2-ixp-700.diagnostic.jsonl",lambda x:x[0]["attribute_scratch"].update(reuse_count=0)),
+          "opportunities":lambda r:edit_rows(r/"raw/b1-s2-ixp-700.diagnostic.jsonl",lambda x:x[0]["attribute_scratch"].update(eligible_opportunities=1)),
+          "cap-zero":lambda r:edit_rows(r/"raw/b1-s2-ixp-700.diagnostic.jsonl",lambda x:x[0]["attribute_scratch"].update(retained_capacity_bytes=0)),
+          "cap-large":lambda r:edit_rows(r/"raw/b1-s2-ixp-700.diagnostic.jsonl",lambda x:x[0]["attribute_scratch"].update(retained_capacity_bytes=131073)),
+          "cap-bool":lambda r:edit_rows(r/"raw/b1-s2-ixp-700.diagnostic.jsonl",lambda x:x[0]["attribute_scratch"].update(retained_capacity_bytes=True)),
+          "growth":lambda r:edit_rows(r/"raw/b1-s2-ixp-700.diagnostic.jsonl",lambda x:x[0]["growth"].update(top_level_unbounded_capacity_misses=0)),
+          "growth-large":lambda r:edit_rows(r/"raw/b1-s2-ixp-700.diagnostic.jsonl",lambda x:x[0]["growth"].update(top_level_unbounded_capacity_misses=65)),
+          "growth-bool":lambda r:edit_rows(r/"raw/b1-s2-ixp-700.diagnostic.jsonl",lambda x:x[0]["growth"].update(top_level_unbounded_capacity_misses=True)),
+          "abba-identity":lambda r:identity(r,"b1-s2-ixp-700"),
+          "same-sha-identity":lambda r:identity(r,"same-ixp-700-right"),
+          "binary-alias":binary_alias,
+          "manifest-object":lambda r:write_json(r/"manifest.json",[]),
+          "binaries-object":lambda r:edit_json(r/"manifest.json",lambda x:x.update(binaries=[{}])),
+          "binary-mode-map":lambda r:edit_json(r/"manifest.json",lambda x:x["binaries"].update(control=["timing","diagnostic"])),
+          "provenance-object":lambda r:write_json(r/"provenance.json",["rustc","cargo","kernel","cpu_model","cpu_count","governor","affinity","taskset"]),
+          "preflight-row-object":lambda r:edit_rows(r/"preflight.jsonl",lambda x:x.__setitem__(0,["phase","utc","load_1m","governor","competitors","status"])),
+          "preflight-phase-object":lambda r:edit_rows(r/"preflight.jsonl",lambda x:x[0].update(phase=[])),
+          "growth-object":lambda r:edit_rows(r/"raw/b1-s2-ixp-700.diagnostic.jsonl",lambda x:x[0].update(growth=None)),
+          "scratch-object":lambda r:edit_rows(r/"raw/b1-s2-ixp-700.diagnostic.jsonl",lambda x:x[0].update(attribute_scratch=None)),
+          "sealed-symlink":lambda r:((r/"manifest.json").rename(r/"manifest.real"),(r/"manifest.json").symlink_to("manifest.real")),
+          "special-node":lambda r:os.mkfifo(r/"raw/unsealed.fifo"),
+        }
+        gate_mutations={"source-commit","raw-schema-float","cv","allocation","timing","same-sha","reuse","opportunities","cap-zero","cap-large","cap-bool","growth","growth-large","growth-bool","abba-identity","same-sha-identity"}
+        exact_mutations={"manifest-object","binaries-object","binary-mode-map","provenance-object","preflight-row-object","preflight-phase-object","growth-object","scratch-object","sealed-symlink","special-node"}
+        for name,mutate in mutations.items():
+            with self.subTest(name=name): self.rejected(mutate,name in gate_mutations,name in exact_mutations)
+if __name__ == "__main__": unittest.main()

--- a/bench/verify-mrt-attribute-scratch-campaign.py
+++ b/bench/verify-mrt-attribute-scratch-campaign.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Derive and fail closed on the frozen MRT attribute-scratch campaign."""
+import argparse, hashlib, json, pathlib, re, statistics, subprocess
+CONTROL = "a1cab917d49541d2137e54f9b2b2128e3c3f6715"
+CANDIDATE = "0c98597b2e831423390c050ba3db2571f3e97b53"
+TREES = {"control": "2b1039dfdf0cd3526e5c1d0778a30c4bc978530a",
+         "candidate": "a6b2a7aee3ff2dfcef98fb2d8096e42244c846ae"}
+INSTRUMENT = "860327fc1cb629235b13f29903fd9ca75438e72a0c7859c3411f13bfe35a1f30"
+ORDER = ("control", "candidate", "candidate", "control")
+SHAPES = {"ixp-700": (400400, 400400, 700), "dual-full-feed": (800800, 400400, 2)}
+BASE = set("schema_version variant scratch_variant commit mode shape smoke warmup_count sample_index path_count prefix_count source_count output_len_bytes output_capacity_bytes decoded_entry_count elapsed_ns raw_sha256 semantic_sha256 allocator growth growth_path_assertion".split())
+HEX64 = re.compile(r"[0-9a-f]{64}\Z")
+ALLOC = set("alloc_calls alloc_zeroed_calls realloc_calls dealloc_calls requested_bytes baseline_live_requested_bytes final_live_requested_bytes peak_live_requested_bytes peak_live_delta_bytes peak_live_overhead_bytes".split())
+class Invalid(ValueError): pass
+def need(ok, message):
+    if not ok: raise Invalid(message)
+def sha(path): return hashlib.sha256(path.read_bytes()).hexdigest()
+def read_json(path): return json.loads(path.read_text())
+def read_rows(path): return [json.loads(x) for x in path.read_text().splitlines() if x]
+def median(rows): return statistics.median(row["elapsed_ns"] for row in rows)
+def cv_within_limit(rows):
+    values = [row["elapsed_ns"] for row in rows]
+    n=len(values); total=sum(values); d2=sum((n*value-total)**2 for value in values)
+    return 400*d2 <= n*total*total
+def expected_commands():
+    rows = []
+    for variant in ("control","candidate"):
+        for mode in ("timing","diagnostic"):
+            argv=["cargo","build","--locked","--profile","bench","-p","rustbgpd-mrt","--bench","snapshot_allocation"]
+            if mode=="diagnostic": argv += ["--features","snapshot-allocation-diagnostics"]
+            rows.append({"kind":"build","variant":variant,"mode":mode,"argv":argv})
+    for block in range(1, 5):
+        for slot, variant in enumerate(ORDER, 1):
+            for shape in SHAPES:
+                for mode in ("timing", "diagnostic"):
+                    name=f"b{block}-s{slot}-{shape}.{mode}.jsonl"
+                    rows.append({"kind":"abba", "block":block, "slot":slot,
+                                 "variant":variant, "shape":shape, "mode":mode,
+                                 "argv":["taskset","-c","0",f"{variant}-{mode}",mode,"--candidate","--scratch-variant",variant,"--shape",shape,"--commit",CONTROL if variant=="control" else CANDIDATE,"--output",name]})
+    for shape in SHAPES:
+        for side in ("left", "right"):
+            name=f"same-{shape}-{side}.timing.jsonl"
+            rows.append({"kind":"same-sha", "side":side, "variant":"control",
+                         "shape":shape, "mode":"timing","argv":["taskset","-c","0","control-timing","timing","--candidate","--scratch-variant","control","--shape",shape,"--commit",CONTROL,"--output",name]})
+    return rows
+def check_raw(rows, variant, shape, mode):
+    expected = BASE | ({"attribute_scratch"} if mode == "diagnostic" else set())
+    need(len(rows) == (7 if mode == "timing" else 1), "raw sample count")
+    paths, prefixes, sources = SHAPES[shape]
+    commit = CONTROL if variant == "control" else CANDIDATE
+    for index, row in enumerate(rows, 1):
+        need(type(row) is dict and set(row) == expected, "closed raw schema")
+        need(type(row["schema_version"]) is int and row["schema_version"] == 3 and row["variant"] == "candidate"
+             and row["scratch_variant"] == variant and row["commit"] == commit,
+             "raw source/variant identity")
+        need(row["mode"] == mode and row["shape"] == shape and row["smoke"] is False
+             and row["warmup_count"] == 2 and row["sample_index"] == index,
+             "raw mode/order identity")
+        need(all(type(row[name]) is int for name in ("warmup_count","sample_index","path_count","prefix_count","source_count","output_len_bytes","output_capacity_bytes","decoded_entry_count"))
+             and row["output_capacity_bytes"] >= row["output_len_bytes"], "raw numeric contract")
+        need((row["path_count"], row["prefix_count"], row["source_count"],
+              row["decoded_entry_count"]) == (paths, prefixes, sources, paths)
+             and row["output_len_bytes"] > 0, "fleet/count identity")
+        need(isinstance(row["raw_sha256"], str) and HEX64.fullmatch(row["raw_sha256"])
+             and isinstance(row["semantic_sha256"], str)
+             and HEX64.fullmatch(row["semantic_sha256"]), "digest shape")
+        if mode == "timing":
+            need(type(row["elapsed_ns"]) is int and row["elapsed_ns"] > 0
+                 and row["allocator"] is None and row["growth"] is None
+                 and row["growth_path_assertion"] is None, "timing-mode contract")
+        else:
+            scratch, alloc, growth = row["attribute_scratch"], row["allocator"], row["growth"]
+            need(row["elapsed_ns"] is None and isinstance(alloc, dict) and set(alloc) == ALLOC
+                 and all(type(value) is int and value >= 0 for value in alloc.values())
+                 and type(growth) is dict and set(growth) == {"top_level_unbounded_capacity_misses"}
+                 and type(growth["top_level_unbounded_capacity_misses"]) is int
+                 and 1 <= growth["top_level_unbounded_capacity_misses"] <= 64
+                 and type(scratch) is dict and set(scratch) == {"eligible_opportunities","reuse_count","retained_capacity_bytes"}
+                 and all(type(scratch[name]) is int for name in scratch)
+                 and row["growth_path_assertion"] == "bounded-growth-observed",
+                 "diagnostic-mode contract")
+            need(scratch["eligible_opportunities"] == paths * 6, "opportunity count")
+            if variant == "control": need(scratch["reuse_count"] == 0 and scratch["retained_capacity_bytes"] == 0, "control scratch contract")
+            else: need(scratch["reuse_count"] == paths * 6 and 1 <= scratch["retained_capacity_bytes"] <= 131072, "candidate scratch contract")
+            need(sum(alloc[k] for k in ("alloc_calls","alloc_zeroed_calls","realloc_calls")) > 0, "allocator signal")
+    if mode == "timing": need(cv_within_limit(rows), "timing CV")
+def derive(root):
+    canonical, cells = [], {}; identities={shape:set() for shape in SHAPES}
+    for block in range(1, 5):
+        for slot, variant in enumerate(ORDER, 1):
+            for shape in SHAPES:
+                stem = root / "raw" / f"b{block}-s{slot}-{shape}"
+                timing_path, diagnostic_path = stem.with_suffix(".timing.jsonl"), stem.with_suffix(".diagnostic.jsonl")
+                timing, diagnostic = read_rows(timing_path), read_rows(diagnostic_path)
+                check_raw(timing, variant, shape, "timing"); check_raw(diagnostic, variant, shape, "diagnostic")
+                all_rows, d = timing + diagnostic, diagnostic[0]
+                need(len({(r["raw_sha256"],r["semantic_sha256"],r["output_len_bytes"],r["decoded_entry_count"]) for r in all_rows}) == 1, "raw/semantic/count mismatch")
+                identities[shape].update((r["raw_sha256"],r["semantic_sha256"],r["output_len_bytes"],r["decoded_entry_count"],r["path_count"],r["prefix_count"],r["source_count"]) for r in all_rows)
+                alloc = sum(d["allocator"][k] for k in ("alloc_calls","alloc_zeroed_calls","realloc_calls"))
+                row = {"schema":2,"block":block,"slot":slot,"scratch_variant":variant,
+                       "shape":shape,"source_commit":d["commit"],"source_tree":TREES[variant],
+                       "timing_ns":[r["elapsed_ns"] for r in timing],"allocator_calls":alloc,
+                       "eligible_opportunities":d["attribute_scratch"]["eligible_opportunities"],
+                       "scratch_reuses":d["attribute_scratch"]["reuse_count"],
+                       "retained_scratch_capacity_bytes":d["attribute_scratch"]["retained_capacity_bytes"],
+                       "output_len_bytes":d["output_len_bytes"],"decoded_entry_count":d["decoded_entry_count"],
+                       "prefix_count":d["prefix_count"],"source_count":d["source_count"],
+                       "raw_sha256":d["raw_sha256"],"semantic_sha256":d["semantic_sha256"],
+                       "timing_jsonl_sha256":sha(timing_path),"diagnostic_jsonl_sha256":sha(diagnostic_path)}
+                canonical.append(row); cells[block,slot,shape] = row
+    same, same_hashes = {}, {}
+    for shape in SHAPES:
+        sides = []
+        for side in ("left","right"):
+            path=root / "raw" / f"same-{shape}-{side}.timing.jsonl"; rows = read_rows(path)
+            same_hashes[shape,side]=sha(path)
+            check_raw(rows, "control", shape, "timing"); sides.append(median(rows))
+            identities[shape].update((r["raw_sha256"],r["semantic_sha256"],r["output_len_bytes"],r["decoded_entry_count"],r["path_count"],r["prefix_count"],r["source_count"]) for r in rows)
+        favorable=max(0,sides[0]-sides[1]); need(favorable*100 < sides[0]*5, "same-SHA favorable drift")
+        same[shape] = favorable,sides[0]
+    need(all(len(values)==1 for values in identities.values()), "cross-cell encoded identity drift")
+    for row in canonical:
+        row["same_sha_left_jsonl_sha256"]=same_hashes[row["shape"],"left"]
+        row["same_sha_right_jsonl_sha256"]=same_hashes[row["shape"],"right"]
+    for block in range(1,5):
+        for shape in SHAPES:
+            controls = [cells[block,s,shape] for s in (1,4)]; candidates = [cells[block,s,shape] for s in (2,3)]
+            need(sum(r["allocator_calls"] for r in candidates) * 100 <= sum(r["allocator_calls"] for r in controls) * 80, "allocation reduction")
+            cm = sum(statistics.median(r["timing_ns"]) for r in controls); bm = sum(statistics.median(r["timing_ns"]) for r in candidates)
+            favorable,left= same[shape]
+            need(((cm-bm)*100-5*cm)*left >= favorable*100*cm, "drift-adjusted timing threshold")
+    return canonical
+def verify(root, repo, write=False, check_seal=True):
+    need(not root.is_symlink(), "bundle root symlink"); entries=tuple(root.rglob("*")); need(all(not path.is_symlink() for path in entries), "bundle symlink"); need(all(path.is_file() or path.is_dir() for path in entries), "bundle special entry")
+    files=tuple(path for path in entries if path.is_file())
+    manifest = read_json(root / "manifest.json")
+    need(type(manifest) is dict, "manifest object")
+    need(type(manifest.get("schema")) is int, "manifest schema type")
+    need(manifest == {"schema":1,"control_commit":CONTROL,"candidate_commit":CANDIDATE,
+         "control_tree":TREES["control"],"candidate_tree":TREES["candidate"],
+         "instrument_sha256":INSTRUMENT,"runner_sha256":manifest.get("runner_sha256"),
+         "verifier_sha256":manifest.get("verifier_sha256"),"binaries":manifest.get("binaries")}, "closed manifest")
+    need(type(manifest["binaries"]) is dict and set(manifest["binaries"]) == {"control","candidate"}
+         and all(type(manifest["binaries"][v]) is dict and set(manifest["binaries"][v]) == {"timing","diagnostic"} for v in manifest["binaries"]), "binary manifest schema")
+    binary_digests=[manifest["binaries"][variant][mode] for variant in ("control","candidate") for mode in ("timing","diagnostic")]
+    need(all(isinstance(value,str) and HEX64.fullmatch(value) for value in binary_digests) and len(set(binary_digests))==4, "four distinct binary identities")
+    for variant, commit in (("control",CONTROL),("candidate",CANDIDATE)):
+        commit_object = subprocess.check_output(["git","-C",str(repo),"cat-file","commit",commit])
+        rehashed = subprocess.check_output(["git","-C",str(repo),"hash-object","-t","commit","--stdin"],input=commit_object).decode().strip()
+        need(rehashed == commit, "source commit rehash")
+        tree = subprocess.check_output(["git","-C",str(repo),"rev-parse",f"{commit}^{{tree}}"], text=True).strip()
+        need(tree == TREES[variant] == manifest[f"{variant}_tree"], "source tree rehash")
+        source = subprocess.check_output(["git","-C",str(repo),"show",f"{commit}:crates/mrt/benches/snapshot_allocation.rs"])
+        need(hashlib.sha256(source).hexdigest() == INSTRUMENT, "committed instrument drift")
+        for mode in ("timing","diagnostic"):
+            need(sha(root/"binaries"/f"{variant}-{mode}") == manifest["binaries"][variant][mode], "binary rehash")
+    for name, current_name in (("runner","run-mrt-attribute-scratch-campaign.py"),("verifier","verify-mrt-attribute-scratch-campaign.py")):
+        retained = root/"source"/f"{name}-mrt-attribute-scratch-campaign.py"
+        current = repo/"bench"/current_name
+        need(sha(retained) == sha(current) == manifest[f"{name}_sha256"], "runner/verifier drift")
+    provenance = read_json(root/"provenance.json")
+    need(type(provenance) is dict and set(provenance) == {"rustc","cargo","kernel","cpu_model","cpu_count","governor","affinity","taskset"}
+         and type(provenance["cpu_count"]) is int and provenance["cpu_count"] > 0
+         and all(isinstance(provenance[name],str) and provenance[name] for name in ("rustc","cargo","kernel","cpu_model","governor","affinity","taskset"))
+         and provenance["governor"] == "performance" and provenance["affinity"] == "0", "provenance contract")
+    commands = read_rows(root/"commands.jsonl"); need(commands == expected_commands(), "command/order contract")
+    preflight=read_rows(root/"preflight.jsonl")
+    allowed={f"b{b}-s{s}-{shape}.{mode}.jsonl" for b in range(1,5) for s in range(1,5) for shape in SHAPES for mode in ("timing","diagnostic")}
+    allowed|={f"same-{shape}-{side}.timing.jsonl" for shape in SHAPES for side in ("left","right")}
+    phase_order=[(f"b{c['block']}-s{c['slot']}-{c['shape']}.{c['mode']}.jsonl" if c["kind"]=="abba" else f"same-{c['shape']}-{c['side']}.timing.jsonl") for c in commands if c["kind"]!="build"]
+    cursor=0
+    for row in preflight:
+        need(type(row) is dict and set(row)=={"phase","utc","load_1m","governor","competitors","status"} and isinstance(row["phase"],str) and row["phase"] in allowed
+             and isinstance(row["utc"],str) and row["utc"].endswith("+00:00")
+             and type(row["load_1m"]) in (int,float) and row["load_1m"] >= 0
+             and isinstance(row["governor"],str) and isinstance(row["competitors"],list)
+             and all(isinstance(name,str) and re.fullmatch(r"[A-Za-z0-9_.-]+",name) for name in row["competitors"])
+             and row["status"] in ("wait","pass") and cursor < len(phase_order)
+             and row["phase"]==phase_order[cursor], "preflight contract")
+        if row["status"]=="pass":
+            need(row["load_1m"] < 2 and row["governor"]=="performance" and row["competitors"]==[], "passing preflight contract"); cursor+=1
+    need(cursor == len(phase_order), "preflight phase roster")
+    expected_raw = {f"b{b}-s{s}-{shape}.{mode}.jsonl" for b in range(1,5) for s in range(1,5) for shape in SHAPES for mode in ("timing","diagnostic")}
+    expected_raw |= {f"same-{shape}-{side}.timing.jsonl" for shape in SHAPES for side in ("left","right")}
+    need({p.name for p in (root/"raw").glob("*.jsonl")} == expected_raw, "raw cell roster")
+    canonical = "".join(json.dumps(r,sort_keys=True,separators=(",",":"))+"\n" for r in derive(root))
+    target = root/"canonical.jsonl"
+    if write: target.write_text(canonical)
+    else: need(target.read_text() == canonical, "canonical derivation drift")
+    if check_seal:
+        sealed=sorted((path for path in files if path != root/"SHA256SUMS"),key=lambda path:path.relative_to(root).as_posix())
+        expected="".join(f"{sha(path)}  {path.relative_to(root)}\n" for path in sealed)
+        need((root/"SHA256SUMS").read_text()==expected, "canonical checksum roster")
+    return {"classification":"go","rows":32,"blocks":4}
+def main():
+    parser=argparse.ArgumentParser(); parser.add_argument("bundle",type=pathlib.Path); parser.add_argument("--repo",type=pathlib.Path,default=pathlib.Path.cwd()); parser.add_argument("--write",action="store_true")
+    args=parser.parse_args()
+    try: print(json.dumps(verify(args.bundle.absolute(),args.repo.resolve(),args.write,not args.write),sort_keys=True))
+    except (OSError,ValueError,json.JSONDecodeError,subprocess.CalledProcessError) as error: parser.error(str(error))
+if __name__ == "__main__": main()


### PR DESCRIPTION
## Summary

- add a tracked runner for the frozen MRT attribute-scratch A/B with four builds, four ABBA blocks across both fleet shapes, and separate same-SHA controls
- retain raw rows and mechanically derive a sealed 32-row receipt with source, tree, instrument, runner, verifier, binary, command, preflight, and host provenance checks
- fail closed on semantic drift, noisy cells, insufficient timing or allocation improvement, scratch-contract drift, receipt mutation, unsafe host locking, and incomplete cleanup

This is harness-only. It deliberately does not run the exclusive-host campaign or make a performance claim.

## Verification

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v bench/tests/test_verify_mrt_attribute_scratch_campaign.py`
- Python compilation and both executable help paths
- repository commit and push hooks
- independent completion and semantic reviews of the exact 3-file, 449-line tree

## Load-bearing proofs

The mutation suite is mechanically re-derived and resealed where applicable. It goes red for cell reordering, raw-row edits, forged source/tree/instrument/binary identities, missing cells, cross-cell semantic drift, binary aliasing, CV above 5 percent, same-SHA drift at 5 percent, timing or allocation shortfall, invalid scratch reuse/capacity/growth values, non-canonical checksums, unsafe lock behavior, and cleanup failures.

Linear: LAN-863