### PR TITLE
Validate USE_CASES authentication recipes

### DIFF
--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -14,8 +14,8 @@ exist for RFC 7999 discard routes and explicit `[[fib_tables]]` unicast route
 tables.
 
 Note: rustbgpd defaults to a local UDS gRPC listener. The `grpcurl` examples
-below that target `localhost:50051` are paired with config snippets that
-explicitly enable `[global.telemetry.grpc_tcp]`.
+below that target `localhost:50051` require an authenticated TCP listener;
+complete opt-in `[global.telemetry.grpc_tcp]` recipes appear below.
 
 ---
 
@@ -94,37 +94,43 @@ Traffic dropped at line rate
 
 **Example config** ([`examples/ddos-mitigation/config.toml`](../examples/ddos-mitigation/config.toml)):
 
+<!-- use-case-config:ddos-mitigation -->
+
 ```toml
 [global]
 asn = 65500
 router_id = "10.255.0.1"
 listen_port = 179
+ebgp_requires_policy = true
 
 [global.telemetry]
 prometheus_addr = "127.0.0.1:9179"
 log_format = "json"
 
-# Local gRPC over a filesystem-gated Unix socket — the working default under
-# the tier authorization mode.
-[global.telemetry.grpc_uds]
-path = "/var/lib/rustbgpd/grpc.sock"
-# Audit principal for this socket; mapped to a role in [security.grpc.roles].
-principal = "operator"
-
-[security.grpc]
-enforcement = "tier"
-
-[security.grpc.roles]
-operator = "operator"
+# Local automation uses the implicit owner-only UDS and local-operator principal.
 
 # Remote mitigation-platform access over TCP. Under tier a TCP listener needs
 # a bearer token + matching principal (or native mTLS); create the token file
 # first, then uncomment.
+# use-case-remote-tcp:begin
 # [global.telemetry.grpc_tcp]
 # enabled = true
 # address = "127.0.0.1:50051"
 # token_file = "/etc/rustbgpd/grpc-token"
-# principal = "operator"
+# principal = "mitigation-platform"
+# [security.grpc.roles]
+# mitigation-platform = "operator"
+# use-case-remote-tcp:end
+
+[policy]
+import_chain = ["reject-edge-routes"]
+export_chain = ["distribute-mitigation"]
+
+[policy.definitions.reject-edge-routes]
+default_action = "deny"
+
+[policy.definitions.distribute-mitigation]
+default_action = "permit"
 
 # Edge routers that enforce FlowSpec rules
 [[neighbors]]
@@ -278,6 +284,8 @@ selected unicast best routes into explicit non-reserved kernel tables.
 
 **Example config** ([`examples/hosting-provider/config.toml`](../examples/hosting-provider/config.toml)):
 
+<!-- use-case-config:hosting-provider -->
+
 ```toml
 [global]
 asn = 65100
@@ -288,10 +296,18 @@ listen_port = 1179           # non-standard port (edge routers own 179)
 prometheus_addr = "127.0.0.1:9179"
 log_format = "json"
 
-[global.telemetry.grpc_tcp]
-enabled = true
-address = "127.0.0.1:50051"
+# Local provisioning uses the implicit owner-only UDS and local-operator principal.
+
+# Uncomment this complete recipe for authenticated remote provisioning.
+# use-case-remote-tcp:begin
+# [global.telemetry.grpc_tcp]
+# enabled = true
+# address = "127.0.0.1:50051"
 # token_file = "/etc/rustbgpd/grpc-token"
+# principal = "provisioning-system"
+# [security.grpc.roles]
+# provisioning-system = "operator"
+# use-case-remote-tcp:end
 
 # RPKI validation — don't announce prefixes we can't prove we hold
 [rpki]
@@ -386,7 +402,7 @@ grpcurl -plaintext -d '{
 }' localhost:50051 rustbgpd.v1.PolicyService/SetGlobalExportChain
 
 # Stream route changes in real time for the controller
-grpcurl -plaintext localhost:50051 rustbgpd.v1.RibService/WatchRoutes
+grpcurl -plaintext -H "authorization: Bearer $(< /etc/rustbgpd/grpc-token)" localhost:50051 rustbgpd.v1.RibService/WatchRoutes
 ```
 
 ---
@@ -430,19 +446,35 @@ IX peer C  ──┘
 
 **Example config** ([`examples/route-collector/config.toml`](../examples/route-collector/config.toml)):
 
+<!-- use-case-config:route-collector -->
+
 ```toml
 [global]
 asn = 65534
 router_id = "10.255.0.1"
 listen_port = 179
+ebgp_requires_policy = true
 
 [global.telemetry]
 prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
 
-[global.telemetry.grpc_tcp]
-enabled = true
-address = "0.0.0.0:50051"
+[global.telemetry.grpc_uds]
+path = "/var/lib/rustbgpd/grpc.sock"
+principal = "looking-glass"
+
+[security.grpc.roles]
+looking-glass = "observer"
+
+# Uncomment this complete recipe for an authenticated remote looking glass.
+# Bearer tokens do not encrypt traffic; prefer an mTLS proxy off-box.
+# use-case-remote-tcp:begin
+# [global.telemetry.grpc_tcp]
+# enabled = true
+# address = "0.0.0.0:50051"
+# token_file = "/etc/rustbgpd/grpc-token"
+# principal = "looking-glass"
+# use-case-remote-tcp:end
 
 # RPKI — annotate every route with validation state
 [rpki]
@@ -462,11 +494,16 @@ sys_name = "rustbgpd-collector"
 [[bmp.collectors]]
 address = "10.0.0.100:5000"
 
-# Peers — import everything, export nothing
+# Peers — deliberately import everything and export nothing
 [policy]
+import_chain = ["observe-all"]
 export_chain = ["deny-all"]
 
+[policy.definitions.observe-all]
+default_action = "permit"
+
 [policy.definitions.deny-all]
+default_action = "deny"
 [[policy.definitions.deny-all.statements]]
 action = "deny"
 prefix = "0.0.0.0/0"
@@ -504,11 +541,8 @@ rbgp rib received 10.0.0.1
 # Explain why a route was selected as best
 rbgp rib --prefix 10.0.0.0/24 --explain
 
-# Trigger an on-demand MRT dump
-rbgp mrt-dump
-
 # Stream all route changes (pipe to your analysis tool)
-grpcurl -plaintext localhost:50051 rustbgpd.v1.RibService/WatchRoutes
+grpcurl -plaintext -H "authorization: Bearer $(< /etc/rustbgpd/grpc-token)" localhost:50051 rustbgpd.v1.RibService/WatchRoutes
 ```
 
 ---

--- a/tests/starter_configs_check_strict.rs
+++ b/tests/starter_configs_check_strict.rs
@@ -20,6 +20,9 @@ use std::process::Command;
 /// The repo's public test-only bearer token, substituted for a starter's
 /// `token_file` when that path only exists inside a container.
 const TOKEN_FIXTURE: &str = "tests/fixtures/grpc-test-only-operator.token";
+const TCP_BEGIN: &str = "# use-case-remote-tcp:begin";
+const TCP_END: &str = "# use-case-remote-tcp:end";
+const TOKEN_PLACEHOLDER: &str = "/etc/rustbgpd/grpc-token";
 
 fn repo_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -101,6 +104,34 @@ fn assert_clean(label: &str, code: Option<i32>, stdout: &str, stderr: &str) {
     );
 }
 
+fn assert_once(source: &str, marker: &str) {
+    assert_eq!(source.matches(marker).count(), 1, "marker drift: {marker}");
+}
+fn has_line(source: &str, expected: &str) -> bool {
+    source.lines().any(|line| line == expected)
+}
+fn anchored_toml_fence<'a>(document: &'a str, marker: &str) -> &'a str {
+    assert_once(document, marker);
+    let tail = document.split_once(marker).expect("unique marker").1;
+    let fence = tail
+        .strip_prefix("\n\n```toml\n")
+        .unwrap_or_else(|| panic!("{marker} no longer directly anchors a TOML fence"));
+    fence
+        .split_once("\n```")
+        .unwrap_or_else(|| panic!("unterminated fence after {marker}"))
+        .0
+}
+
+fn enable_remote_tcp(source: &str, token_literal: &str) -> String {
+    assert_once(source, TCP_BEGIN);
+    assert_once(source, TCP_END);
+    assert_once(source, TOKEN_PLACEHOLDER);
+    let (before, tail) = source.split_once(TCP_BEGIN).expect("TCP begin marker");
+    let (recipe, after) = tail.split_once(TCP_END).expect("TCP end marker");
+    format!("{before}{}{after}", recipe.replace("\n# ", "\n"))
+        .replace(&format!("\"{TOKEN_PLACEHOLDER}\""), token_literal)
+}
+
 #[test]
 fn every_init_config_profile_passes_check_strict() {
     let profiles = profile_names();
@@ -167,6 +198,87 @@ fn every_example_config_passes_check_strict() {
         let (code, stdout, stderr) = run(&["--check", "--strict", path]);
         assert_clean(&config.display().to_string(), code, &stdout, &stderr);
     }
+}
+
+#[test]
+fn use_case_config_fences_pass_base_and_authenticated_tcp_check_strict() {
+    let document =
+        fs::read_to_string(repo_root().join("docs/USE_CASES.md")).expect("read use-case guide");
+    assert_eq!(document.matches("<!-- use-case-config:").count(), 3);
+    let bearer_header = r#"-H "authorization: Bearer $(< /etc/rustbgpd/grpc-token)""#;
+    assert_eq!(document.matches(bearer_header).count(), 2);
+    let cases = [
+        ("ddos-mitigation", "mitigation-platform", "operator"),
+        ("hosting-provider", "provisioning-system", "operator"),
+        ("route-collector", "looking-glass", "observer"),
+    ];
+    let dir = tempfile::tempdir().expect("tempdir");
+    let token = dir.path().join("use-case.token");
+    fs::copy(repo_root().join(TOKEN_FIXTURE), &token).expect("copy token fixture");
+    let token_literal = toml::Value::String(token.display().to_string()).to_string();
+    let mut checks = 0;
+    for (name, tcp_principal, tcp_role) in cases {
+        let marker = format!("<!-- use-case-config:{name} -->");
+        let fence = anchored_toml_fence(&document, &marker);
+        assert!(!has_line(fence, "[global.telemetry.grpc_tcp]"));
+        if name == "route-collector" {
+            assert!(has_line(fence, "principal = \"looking-glass\""));
+            assert!(has_line(fence, "looking-glass = \"observer\""));
+        } else {
+            assert!(!has_line(fence, "[global.telemetry.grpc_uds]"));
+            assert!(!has_line(fence, "[security.grpc.roles]"));
+        }
+        let cfg: toml::Value = toml::from_str(fence).expect("fence is TOML");
+        let policy = match name {
+            "ddos-mitigation" => Some((
+                "reject-edge-routes",
+                "distribute-mitigation",
+                "deny",
+                "permit",
+            )),
+            "route-collector" => Some(("observe-all", "deny-all", "permit", "deny")),
+            _ => None,
+        };
+        if let Some((import, export, ia, ea)) = policy {
+            assert_eq!(cfg["global"]["ebgp_requires_policy"].as_bool(), Some(true));
+            for (key, expected) in [("import_chain", import), ("export_chain", export)] {
+                let chain = cfg["policy"][key].as_array().expect("policy chain array");
+                assert_eq!(chain.len(), 1);
+                assert_eq!(chain[0].as_str(), Some(expected));
+            }
+            assert_eq!(
+                cfg["policy"]["definitions"][import]["default_action"].as_str(),
+                Some(ia)
+            );
+            assert_eq!(
+                cfg["policy"]["definitions"][export]["default_action"].as_str(),
+                Some(ea)
+            );
+        }
+        let tcp_source = enable_remote_tcp(fence, &token_literal);
+        assert!(has_line(&tcp_source, "[global.telemetry.grpc_tcp]"));
+        assert!(has_line(
+            &tcp_source,
+            &format!("token_file = {token_literal}")
+        ));
+        assert!(has_line(
+            &tcp_source,
+            &format!("principal = \"{tcp_principal}\"")
+        ));
+        assert!(has_line(
+            &tcp_source,
+            &format!("{tcp_principal} = \"{tcp_role}\"")
+        ));
+        for (variant, source) in [("base", fence), ("tcp", tcp_source.as_str())] {
+            let path = dir.path().join(format!("{name}-{variant}.toml"));
+            fs::write(&path, source).expect("write extracted fence");
+            let (code, stdout, stderr) =
+                run(&["--check", "--strict", path.to_str().expect("UTF-8")]);
+            checks += 1;
+            assert_clean(&format!("{name} {variant}"), code, &stdout, &stderr);
+        }
+    }
+    assert_eq!(checks, 6, "receipt must execute exactly six strict checks");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- make the three active `USE_CASES` gRPC config fences valid in their local/default form
- include complete authenticated remote TCP recipes with the authorization tier required by each documented workflow
- execute all three base and TCP variants through the real strict config checker

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --locked --test starter_configs_check_strict -- --nocapture`
- independent completion reviews: clean

## Load-bearing proof
- anchor/recipe drift and incorrect local UDS or observer boundaries fail structural assertions
- missing token, principal, matching role, required-policy flag, chain, or default action makes its owning cell red
- exactly three documented fences and six real strict-check executions are required

Linear: LAN-860