### PR TITLE
Add disk-backed commit-confirm authority

### DIFF
--- a/src/config_history.rs
+++ b/src/config_history.rs
@@ -48,8 +48,24 @@ pub struct MixedHistoryEntry {
     row: v2::StoredRow,
 }
 
-pub fn record_accepted(dir: &Path, snapshot: &AcceptedConfigSnapshot) -> io::Result<bool> {
-    v2::record_v2(dir, snapshot.normalized_toml(), stored_manifest(snapshot))
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RecordOutcome {
+    Recorded,
+    Deduplicated,
+    SkippedOversize,
+}
+
+pub fn record_accepted(dir: &Path, snapshot: &AcceptedConfigSnapshot) -> io::Result<RecordOutcome> {
+    if snapshot.normalized_toml().len() > v2::MAX_TOML {
+        return Ok(RecordOutcome::SkippedOversize);
+    }
+    v2::record_v2(dir, snapshot.normalized_toml(), stored_manifest(snapshot)).map(|recorded| {
+        if recorded {
+            RecordOutcome::Recorded
+        } else {
+            RecordOutcome::Deduplicated
+        }
+    })
 }
 
 pub(crate) fn stored_manifest(snapshot: &AcceptedConfigSnapshot) -> v2::Manifest {
@@ -525,6 +541,69 @@ path = "customers.txt"
         assert_eq!(envelope.manifest.datasets.len(), 1);
         assert_eq!(envelope.manifest.datasets[0].name, "customers");
         assert_eq!(envelope.manifest.datasets[0].kind, v2::DatasetKind::Asn);
+    }
+
+    #[test]
+    fn record_outcome_is_explicit_and_oversize_never_mutates_history() {
+        // Destructive proof: routing oversize through `record_v2`, reporting
+        // it as deduplicated, or evicting before the size check changes either
+        // the explicit result or the byte-identical retained roster.
+        let dir = tempfile::tempdir().unwrap();
+        let small_toml = crate::test_support::tier_authorized_uds_test_config(
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+[global.telemetry]
+log_format = "json"
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+"#,
+        );
+        let small = AcceptedConfigSnapshot::from_config_for_test(
+            crate::config::Config::load_toml_with_diagnostics(&small_toml, "small").unwrap(),
+        );
+        assert_eq!(
+            record_accepted(dir.path(), &small).unwrap(),
+            RecordOutcome::Recorded
+        );
+        assert_eq!(
+            record_accepted(dir.path(), &small).unwrap(),
+            RecordOutcome::Deduplicated
+        );
+        let roster = || {
+            let mut entries = fs::read_dir(dir.path())
+                .unwrap()
+                .map(|entry| {
+                    let entry = entry.unwrap();
+                    (entry.file_name(), fs::read(entry.path()).unwrap())
+                })
+                .collect::<Vec<_>>();
+            entries.sort_by(|left, right| left.0.cmp(&right.0));
+            entries
+        };
+        let roster_before = roster();
+
+        let large_toml = small_toml.replacen(
+            "remote_asn = 65002\n",
+            &format!(
+                "remote_asn = 65002\ndescription = {:?}\n",
+                "x".repeat(v2::MAX_TOML + 1)
+            ),
+            1,
+        );
+        let large = AcceptedConfigSnapshot::from_config_for_test(
+            crate::config::Config::load_toml_with_diagnostics(&large_toml, "oversize").unwrap(),
+        );
+        assert!(large.normalized_toml().len() > v2::MAX_TOML);
+        assert_eq!(
+            record_accepted(dir.path(), &large).unwrap(),
+            RecordOutcome::SkippedOversize
+        );
+        let roster_after = roster();
+        assert_eq!(roster_after, roster_before);
     }
 
     /// Red proof: removing any of the three exact equality checks in

--- a/src/config_persister.rs
+++ b/src/config_persister.rs
@@ -311,13 +311,21 @@ impl ConfigPersister {
     /// rather than at each call site.
     fn record_history(&self) {
         self.record_last_persist();
-        if let Some(dir) = self.history_dir()
-            && let Err(error) = crate::config_history::record_accepted(&dir, &self.current)
-        {
-            warn!(
-                error = %error,
-                "failed to record applied config in the config history"
-            );
+        if let Some(dir) = self.history_dir() {
+            match crate::config_history::record_accepted(&dir, &self.current) {
+                Ok(crate::config_history::RecordOutcome::SkippedOversize) => warn!(
+                    bytes = self.current.normalized_toml().len(),
+                    "applied config exceeds the bounded history entry size; history was left unchanged"
+                ),
+                Ok(
+                    crate::config_history::RecordOutcome::Recorded
+                    | crate::config_history::RecordOutcome::Deduplicated,
+                ) => {}
+                Err(error) => warn!(
+                    error = %error,
+                    "failed to record applied config in the config history"
+                ),
+            }
         }
     }
 

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -59,6 +59,7 @@ pub struct ConfigTransactionController {
     accepted_rx: Option<watch::Receiver<Arc<AcceptedConfigSnapshot>>>,
     peer_mgr_internal_tx: Option<mpsc::UnboundedSender<InternalCommand>>,
     confirm_v2_launch: Option<crate::confirm_journal::v2::LaunchIdentity>,
+    confirm_v3_launch: Option<crate::confirm_journal::v3::LaunchIdentity>,
 }
 
 #[derive(Default)]
@@ -81,7 +82,7 @@ struct ConfirmedState {
 #[derive(Clone)]
 struct PendingConfirmedTransaction {
     confirm_id: String,
-    rollback_toml: String,
+    rollback_toml: Option<String>,
     rollback_expected_runtime_snapshot_token: String,
     timeout_seconds: u32,
     deadline: tokio::time::Instant,
@@ -94,13 +95,16 @@ struct PendingConfirmedTransaction {
     /// not repair; the operator resolves it by retrying abort, confirming the
     /// candidate, or restarting (boot revert from the retained journal).
     rollback_failed: Option<proto::ConfigTransactionConfirmationStatus>,
-    /// The exact immutable pre-transaction object encoded in the v2 journal
-    /// and reused by live abort/timeout planning.  `None` is test-only legacy
-    /// v1 coverage.
+    /// The exact immutable pre-transaction object retained by disk-backed
+    /// authority and reused by live abort/timeout planning. `None` is
+    /// test-only legacy v1 coverage.
     prior_snapshot: Option<Arc<AcceptedConfigSnapshot>>,
     /// Pinned locator/journal descriptors retained through the live pending
     /// lifecycle.  The locator is the terminal authority.
     v2_files: Option<Arc<crate::confirm_journal::v2::PendingFiles>>,
+    /// Disk-backed v3 authority. The raw object owns the prior bytes; live
+    /// rollback reuses `prior_snapshot` and retains no duplicate full String.
+    v3_files: Option<Arc<crate::confirm_journal::v3::PendingFiles>>,
 }
 
 #[derive(Clone, Debug)]
@@ -131,6 +135,7 @@ impl ConfigTransactionController {
             accepted_rx: None,
             peer_mgr_internal_tx: None,
             confirm_v2_launch: None,
+            confirm_v3_launch: None,
         }
     }
 
@@ -147,6 +152,7 @@ impl ConfigTransactionController {
             accepted_rx: Some(accepted_rx),
             peer_mgr_internal_tx: None,
             confirm_v2_launch: None,
+            confirm_v3_launch: None,
         }
     }
 
@@ -160,11 +166,21 @@ impl ConfigTransactionController {
     }
 
     #[must_use]
+    #[cfg(test)]
     pub(crate) fn with_confirm_v2_launch(
         mut self,
         launch: crate::confirm_journal::v2::LaunchIdentity,
     ) -> Self {
         self.confirm_v2_launch = Some(launch);
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_confirm_v3_launch(
+        mut self,
+        launch: crate::confirm_journal::v3::LaunchIdentity,
+    ) -> Self {
+        self.confirm_v3_launch = Some(launch);
         self
     }
 
@@ -250,7 +266,7 @@ impl ConfigTransactionController {
                     if request.confirm_timeout_seconds > 0 {
                         validate_confirm_timeout_seconds(request.confirm_timeout_seconds)?;
                     }
-                    if self.confirm_v2_launch.is_none() {
+                    if self.confirm_v2_launch.is_none() && self.confirm_v3_launch.is_none() {
                         self.reject_confirmed_external_sources(&normalized_toml)
                             .await?;
                     }
@@ -311,7 +327,10 @@ impl ConfigTransactionController {
     ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
         let confirmed = parse_confirmed_apply_mode(&request)?;
         if let Some(confirmed) = confirmed {
-            if preloaded.is_none() && self.confirm_v2_launch.is_none() {
+            if preloaded.is_none()
+                && self.confirm_v2_launch.is_none()
+                && self.confirm_v3_launch.is_none()
+            {
                 self.reject_confirmed_external_sources(&request.candidate_toml)
                     .await?;
             }
@@ -531,7 +550,7 @@ impl ConfigTransactionController {
                     // A confirmed gNMI candidate is derived from the live
                     // config. Fence external declarations before that
                     // construction can consult any rpol or dataset path.
-                    if self.confirm_v2_launch.is_none() {
+                    if self.confirm_v2_launch.is_none() && self.confirm_v3_launch.is_none() {
                         self.reject_confirmed_current_external_sources()
                             .await
                             .map_err(apply_error_to_gnmi_set_error)?;
@@ -602,7 +621,7 @@ impl ConfigTransactionController {
         confirmed: Option<ConfirmedApplyMode>,
     ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
         if let Some(confirmed) = confirmed {
-            if self.confirm_v2_launch.is_none() {
+            if self.confirm_v2_launch.is_none() && self.confirm_v3_launch.is_none() {
                 self.reject_confirmed_external_sources(&request.candidate_toml)
                     .await?;
             }
@@ -647,10 +666,12 @@ impl ConfigTransactionController {
             .await
             .map_err(ConfigTransactionApplyError::Unavailable)?;
         let rollback_config = prior_snapshot.config();
-        // The immutable accepted snapshot owns the exact normalized bytes and
-        // source manifest used by both the journal and live rollback.  Never
-        // rerender or reconstruct provenance after this point.
-        let rollback_toml = prior_snapshot.normalized_toml().to_string();
+        // V3 keeps this Arc as the sole live owner of the prior bytes. Frozen
+        // v1/v2 test lanes retain their historical String representation.
+        let rollback_toml = self
+            .confirm_v3_launch
+            .is_none()
+            .then(|| prior_snapshot.normalized_toml().to_string());
 
         // ADR-0113: a confirmed transaction may TIGHTEN an outbound prefix
         // maximum, because its automatic undo only loosens and a loosening is
@@ -680,7 +701,46 @@ impl ConfigTransactionController {
         // inside the confirm window is repaired by the boot-time revert. If
         // the journal cannot be written, refuse the confirmed apply up front
         // (nothing has committed yet) rather than run an unprotected window.
-        let v2_files = if let Some(launch) = &self.confirm_v2_launch {
+        let v3_files = if let Some(launch) = &self.confirm_v3_launch {
+            let pending_dir = self
+                .deps
+                .confirm_journal_path
+                .as_ref()
+                .and_then(|path| path.parent())
+                .ok_or_else(|| {
+                    ConfigTransactionApplyError::Internal(
+                        "refusing confirmed apply: v3 pending storage is unavailable".to_string(),
+                    )
+                })?;
+            match launch.publish(
+                pending_dir,
+                &confirmed.confirm_id,
+                deadline_unix_seconds,
+                &prior_snapshot,
+            ) {
+                Ok(files) => Some(Arc::new(files)),
+                Err(error) => {
+                    if error.authority_retained() {
+                        self.state.lock().await.ambiguous_failure_confirm_id =
+                            Some(confirmed.confirm_id.clone());
+                    }
+                    return Err(ConfigTransactionApplyError::Internal(format!(
+                        "refusing confirmed apply: v3 pending authority publication failed ({:?}); {}",
+                        error.kind(),
+                        if error.authority_retained() {
+                            "locator authority may be durable and config mutations are blocked until restart"
+                        } else {
+                            "the candidate and runtime remain untouched"
+                        }
+                    )));
+                }
+            }
+        } else {
+            None
+        };
+        let v2_files = if v3_files.is_some() {
+            None
+        } else if let Some(launch) = &self.confirm_v2_launch {
             let journal_path = self.deps.confirm_journal_path.as_ref().ok_or_else(|| {
                 ConfigTransactionApplyError::Internal(
                     "refusing confirmed apply: v2 journal storage is unavailable".to_string(),
@@ -707,7 +767,9 @@ impl ConfigTransactionController {
                 &crate::confirm_journal::ConfirmJournal {
                     confirm_id: confirmed.confirm_id.clone(),
                     deadline_unix_seconds,
-                    rollback_toml: rollback_toml.clone(),
+                    rollback_toml: rollback_toml
+                        .clone()
+                        .expect("legacy confirmed apply retains rollback TOML"),
                     rollback_failed: false,
                 },
             )
@@ -756,6 +818,7 @@ impl ConfigTransactionController {
                 // up anyway.
                 self.cleanup_uncommitted_authority(
                     &confirmed.confirm_id,
+                    v3_files.as_deref(),
                     v2_files.as_deref(),
                     "confirmed apply failed",
                 )
@@ -766,6 +829,7 @@ impl ConfigTransactionController {
         if response.status != proto::ConfigTransactionPlanStatus::Committable as i32 {
             self.cleanup_uncommitted_authority(
                 &confirmed.confirm_id,
+                v3_files.as_deref(),
                 v2_files.as_deref(),
                 "confirmed apply did not commit",
             )
@@ -784,8 +848,10 @@ impl ConfigTransactionController {
             committed_sections: response.committed_sections.clone(),
             runtime_snapshot_token: response.runtime_snapshot_token.clone(),
             rollback_failed: None,
-            prior_snapshot: self.confirm_v2_launch.as_ref().map(|_| prior_snapshot),
+            prior_snapshot: (self.confirm_v2_launch.is_some() || self.confirm_v3_launch.is_some())
+                .then_some(prior_snapshot),
             v2_files,
+            v3_files,
         };
         let confirmation = pending_confirmation_proto(
             &pending,
@@ -872,7 +938,17 @@ impl ConfigTransactionController {
         // timer stay armed — a leftover journal would boot-revert a config
         // the operator explicitly confirmed.
         let matched = self.matching_pending(&confirm_id).await?;
-        if let Some(files) = &matched.v2_files {
+        if let Some(files) = &matched.v3_files {
+            let residue_cleanup_failed = files.terminal_cleanup().map_err(|error| {
+                ConfigTransactionApplyError::Internal(format!(
+                    "confirm not recorded: durable v3 locator removal failed ({:?}); the transaction is still pending and will roll back on timeout",
+                    error.kind()
+                ))
+            })?;
+            if residue_cleanup_failed {
+                warn!("confirmed transaction is terminal, but exact v3 residue cleanup failed");
+            }
+        } else if let Some(files) = &matched.v2_files {
             let journal_cleanup_failed = files.terminal_cleanup().map_err(|error| {
                 ConfigTransactionApplyError::Internal(format!(
                     "confirm not recorded: durable v2 locator removal failed ({:?}); the transaction is still pending and will roll back on timeout",
@@ -1438,7 +1514,15 @@ impl ConfigTransactionController {
         pending: &PendingConfirmedTransaction,
     ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
         let request = proto::ApplyConfigTransactionRequest {
-            candidate_toml: pending.rollback_toml.clone(),
+            candidate_toml: pending.prior_snapshot.as_ref().map_or_else(
+                || {
+                    pending
+                        .rollback_toml
+                        .clone()
+                        .expect("legacy pending transaction retains rollback TOML")
+                },
+                |prior| prior.normalized_toml().to_string(),
+            ),
             expected_runtime_snapshot_token: pending
                 .rollback_expected_runtime_snapshot_token
                 .clone(),
@@ -1513,9 +1597,31 @@ impl ConfigTransactionController {
     async fn cleanup_uncommitted_authority(
         &self,
         confirm_id: &str,
+        v3_files: Option<&crate::confirm_journal::v3::PendingFiles>,
         v2_files: Option<&crate::confirm_journal::v2::PendingFiles>,
         context: &'static str,
     ) -> Result<(), ConfigTransactionApplyError> {
+        if let Some(files) = v3_files {
+            return match files.terminal_cleanup() {
+                Ok(residue_cleanup_failed) => {
+                    if residue_cleanup_failed {
+                        warn!(
+                            context,
+                            "v3 locator is durably absent, but exact pending residue cleanup failed"
+                        );
+                    }
+                    Ok(())
+                }
+                Err(error) => {
+                    self.state.lock().await.ambiguous_failure_confirm_id =
+                        Some(confirm_id.to_string());
+                    Err(ConfigTransactionApplyError::Internal(format!(
+                        "v3 commit-confirm operation is nonterminal because durable locator removal failed ({:?}); config mutations remain blocked",
+                        error.kind()
+                    )))
+                }
+            };
+        }
         let Some(files) = v2_files else {
             self.remove_confirm_journal_best_effort(context);
             return Ok(());
@@ -1555,7 +1661,17 @@ impl ConfigTransactionController {
         abort_timer: bool,
     ) -> Result<(), ConfigTransactionApplyError> {
         let matched = self.matching_pending(confirm_id).await?;
-        if let Some(files) = &matched.v2_files {
+        if let Some(files) = &matched.v3_files {
+            let residue_cleanup_failed = files.terminal_cleanup().map_err(|error| {
+                ConfigTransactionApplyError::Internal(format!(
+                    "rollback restored the prior config but remains nonterminal because durable v3 locator removal failed ({:?})",
+                    error.kind()
+                ))
+            })?;
+            if residue_cleanup_failed {
+                warn!("rollback is terminal, but exact v3 residue cleanup failed");
+            }
+        } else if let Some(files) = &matched.v2_files {
             let journal_cleanup_failed = files.terminal_cleanup().map_err(|error| {
                 ConfigTransactionApplyError::Internal(format!(
                     "rollback restored the prior config but remains nonterminal because durable v2 locator removal failed ({:?})",
@@ -1613,7 +1729,14 @@ impl ConfigTransactionController {
             // generic never-confirmed message. Best-effort: the journal
             // (with the proven rollback snapshot) is already on disk, and
             // failing to annotate it must not mask the rollback failure.
-            if let Some(files) = &pending.v2_files {
+            if let Some(files) = &pending.v3_files {
+                if let Err(error) = files.record_rollback_failed() {
+                    warn!(
+                        error_kind = ?error.kind(),
+                        "failed to record rollback failure in the v3 commit-confirm metadata"
+                    );
+                }
+            } else if let Some(files) = &pending.v2_files {
                 if let Err(error) = files.record_rollback_failed() {
                     warn!(
                         error_kind = ?error.kind(),
@@ -1626,7 +1749,10 @@ impl ConfigTransactionController {
                     &crate::confirm_journal::ConfirmJournal {
                         confirm_id: pending.confirm_id.clone(),
                         deadline_unix_seconds: pending.deadline_unix_seconds,
-                        rollback_toml: pending.rollback_toml.clone(),
+                        rollback_toml: pending
+                            .rollback_toml
+                            .clone()
+                            .expect("legacy pending transaction retains rollback TOML"),
                         rollback_failed: true,
                     },
                 )
@@ -5061,7 +5187,151 @@ remote_asn = 65010
             .expect("journal must parse")
     }
 
-    struct V2FibHarness {
+    #[tokio::test]
+    async fn v3_publication_failure_never_enters_peer_or_persister_apply() {
+        // Destructive proof: moving publication below planning/staging makes
+        // one of these receiver assertions observe a command before failure.
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(root.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let state_dir = root.path().join("state");
+        std::fs::create_dir(&state_dir).unwrap();
+        std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let config_path = root.path().join("rustbgpd.toml");
+        let previous = base_toml("");
+        std::fs::write(&config_path, &previous).unwrap();
+        let accepted = Arc::new(AcceptedConfigSnapshot::load(&config_path, None).unwrap());
+        let (_accepted_tx, accepted_rx) = watch::channel(accepted);
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
+        let peer_apply_seen = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let seen = Arc::clone(&peer_apply_seen);
+        let runtime = previous.clone();
+        tokio::spawn(async move {
+            while let Some(command) = peer_rx.recv().await {
+                match command {
+                    PeerManagerCommand::RuntimeConfigSnapshot { reply } => {
+                        let _ =
+                            reply.send(Ok(rustbgpd_api::peer_types::RuntimeConfigSnapshotReply {
+                                toml: runtime.clone(),
+                                rpol_files: Vec::new(),
+                                rpol: rustbgpd_policy::rpol::RpolPolicySet::default(),
+                            }));
+                    }
+                    _ => {
+                        seen.store(true, std::sync::atomic::Ordering::SeqCst);
+                    }
+                }
+            }
+        });
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        let journal = state_dir.join(crate::confirm_journal::JOURNAL_FILE_NAME);
+        let launch = crate::confirm_journal::v3::LaunchIdentity::resolve(&config_path).unwrap();
+
+        // An unsafe fixed-slot occupant blocks publication and is never
+        // removed based on its name alone.
+        std::fs::create_dir(state_dir.join(crate::confirm_journal::v3::RAW_FILE_NAME)).unwrap();
+        let controller = ConfigTransactionController::new_accepted(
+            FibTableControlDeps {
+                confirm_journal_path: Some(journal),
+                ..deps_value(None, peer_tx, Some(config_tx), Vec::new())
+            },
+            BgpMetrics::new(),
+            accepted_rx,
+        )
+        .with_confirm_v3_launch(launch);
+        let error = controller
+            .apply(confirmed_dynamic_request(
+                dynamic_candidate_toml(),
+                "publisher-failure",
+                60,
+            ))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, ConfigTransactionApplyError::Internal(_)));
+        assert!(!peer_apply_seen.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(config_rx.try_recv().is_err());
+        assert_eq!(std::fs::read_to_string(config_path).unwrap(), previous);
+    }
+
+    #[tokio::test]
+    async fn v3_uncertain_locator_publication_arms_controller_mutation_fence() {
+        // Destructive proof: treating the post-rename failure as ordinary
+        // leaves this state unfenced even though boot authority is present.
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(root.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let state_dir = root.path().join("state");
+        std::fs::create_dir(&state_dir).unwrap();
+        std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let config_path = root.path().join("rustbgpd.toml");
+        let previous = base_toml("");
+        std::fs::write(&config_path, &previous).unwrap();
+        let accepted = Arc::new(AcceptedConfigSnapshot::load(&config_path, None).unwrap());
+        let (_accepted_tx, accepted_rx) = watch::channel(accepted);
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
+        let peer_apply_seen = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let seen = Arc::clone(&peer_apply_seen);
+        let runtime = previous.clone();
+        tokio::spawn(async move {
+            while let Some(command) = peer_rx.recv().await {
+                match command {
+                    PeerManagerCommand::RuntimeConfigSnapshot { reply } => {
+                        let _ =
+                            reply.send(Ok(rustbgpd_api::peer_types::RuntimeConfigSnapshotReply {
+                                toml: runtime.clone(),
+                                rpol_files: Vec::new(),
+                                rpol: rustbgpd_policy::rpol::RpolPolicySet::default(),
+                            }));
+                    }
+                    _ => {
+                        seen.store(true, std::sync::atomic::Ordering::SeqCst);
+                    }
+                }
+            }
+        });
+        let (config_tx, mut config_rx) = mpsc::channel(8);
+        let journal = state_dir.join(crate::confirm_journal::JOURNAL_FILE_NAME);
+        let launch = crate::confirm_journal::v3::LaunchIdentity::resolve(&config_path)
+            .unwrap()
+            .fail_locator_directory_sync_for_test();
+        let locator = launch.locator_path();
+        let controller = ConfigTransactionController::new_accepted(
+            FibTableControlDeps {
+                confirm_journal_path: Some(journal),
+                ..deps_value(None, peer_tx, Some(config_tx), Vec::new())
+            },
+            BgpMetrics::new(),
+            accepted_rx,
+        )
+        .with_confirm_v3_launch(launch);
+        assert!(
+            controller
+                .clone()
+                .apply(confirmed_dynamic_request(
+                    dynamic_candidate_toml(),
+                    "uncertain-locator",
+                    60,
+                ))
+                .await
+                .is_err()
+        );
+        assert!(locator.exists());
+        assert_eq!(
+            controller
+                .state
+                .lock()
+                .await
+                .ambiguous_failure_confirm_id
+                .as_deref(),
+            Some("uncertain-locator")
+        );
+        assert!(!peer_apply_seen.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(config_rx.try_recv().is_err());
+    }
+
+    struct DiskBackedFibHarness {
         _root: tempfile::TempDir,
         controller: ConfigTransactionController,
         source: std::path::PathBuf,
@@ -5155,7 +5425,7 @@ remote_asn = 65010
         clippy::too_many_lines,
         reason = "the focused harness keeps one complete external-source FIB transaction fixture"
     )]
-    async fn v2_external_fib_harness(timeout_seconds: u32) -> V2FibHarness {
+    async fn external_fib_harness(timeout_seconds: u32, use_v3: bool) -> DiskBackedFibHarness {
         use std::os::unix::fs::PermissionsExt as _;
 
         let root = tempfile::tempdir().unwrap();
@@ -5277,8 +5547,8 @@ families = ["ipv4_unicast"]
         });
 
         let journal = state_dir.join(crate::confirm_journal::JOURNAL_FILE_NAME);
-        let launch = crate::confirm_journal::v2::LaunchIdentity::resolve(&config_path).unwrap();
-        let locator = launch.locator_path();
+        let v2_launch = crate::confirm_journal::v2::LaunchIdentity::resolve(&config_path).unwrap();
+        let locator = v2_launch.locator_path();
         let controller = ConfigTransactionController::new_accepted(
             FibTableControlDeps {
                 fib_cmd_tx: Some(fib_tx),
@@ -5294,8 +5564,14 @@ families = ["ipv4_unicast"]
             BgpMetrics::new(),
             accepted_rx,
         )
-        .with_preloaded_planner(internal_tx)
-        .with_confirm_v2_launch(launch);
+        .with_preloaded_planner(internal_tx);
+        let controller = if use_v3 {
+            controller.with_confirm_v3_launch(
+                crate::confirm_journal::v3::LaunchIdentity::resolve(&config_path).unwrap(),
+            )
+        } else {
+            controller.with_confirm_v2_launch(v2_launch)
+        };
         let response = controller
             .clone()
             .apply(confirmed_dynamic_request(
@@ -5310,8 +5586,14 @@ families = ["ipv4_unicast"]
             proto::ConfigTransactionPlanStatus::Committable as i32
         );
         assert_eq!(*fib_state.lock().await, vec![replacement]);
+        if use_v3 {
+            let state = controller.state.lock().await;
+            let pending = state.pending.as_ref().unwrap();
+            assert!(pending.rollback_toml.is_none() && pending.prior_snapshot.is_some());
+            assert!(pending.v3_files.is_some() && pending.v2_files.is_none());
+        }
 
-        V2FibHarness {
+        DiskBackedFibHarness {
             _root: root,
             controller,
             source,
@@ -5324,12 +5606,20 @@ families = ["ipv4_unicast"]
     }
 
     #[tokio::test]
+    async fn v3_pending_retains_prior_without_duplicate_toml() {
+        // Destructive proof: restoring the eager `to_string()` allocation
+        // makes the harness assertion observe both full representations.
+        let harness = external_fib_harness(60, true).await;
+        harness.ack_task.abort();
+    }
+
+    #[tokio::test]
     async fn v2_external_fib_abort_reuses_exact_prior_and_is_terminal() {
         // Destructive proof: restoring from rollback TOML instead of the
         // retained Arc rereads the mutated rpol file and fails; dual-writing
         // v1 changes the dispatch prefix; journal-first cleanup leaves the
         // locator present at successful return.
-        let harness = v2_external_fib_harness(60).await;
+        let harness = external_fib_harness(60, false).await;
         assert!(
             std::fs::read(&harness.journal)
                 .unwrap()
@@ -5439,7 +5729,7 @@ families = ["ipv4_unicast"]
         // Destructive proof: removing the preloaded timeout lane or rebuilding
         // provenance from current external bytes leaves the replacement table
         // active and the locator armed after the timer fires.
-        let harness = v2_external_fib_harness(1).await;
+        let harness = external_fib_harness(1, false).await;
         let prior = harness
             .controller
             .state
@@ -5471,7 +5761,7 @@ families = ["ipv4_unicast"]
         // Destructive proof: retaining v1's journal-as-authority rule or
         // clearing in-memory pending state before locator durability leaves
         // the locator present when the RPC reports permanent success.
-        let harness = v2_external_fib_harness(60).await;
+        let harness = external_fib_harness(60, false).await;
         harness
             .controller
             .clone()

--- a/src/confirm_journal.rs
+++ b/src/confirm_journal.rs
@@ -19,6 +19,7 @@
 #![deny(unsafe_code)]
 
 pub(crate) mod v2;
+pub(crate) mod v3;
 
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read as _, Write as _};
@@ -69,9 +70,9 @@ pub struct BootRevert {
 
 /// The operator-facing facts of a boot revert (for the banner, log, metric).
 ///
-/// A `BootRevert` is only produced when the revert fully succeeded — config
-/// restored AND journal consumed. A journal-cleanup failure fails startup
-/// (LAN-219), so there is no "booted anyway" residual state to carry here.
+/// A `BootRevert` is only produced after restore reaches its terminal point:
+/// v1 consumes its journal; v2/v3 durably remove locator authority and report
+/// any later pending-residue cleanup failure as warning-only.
 #[derive(Debug, Clone)]
 pub struct BootRevertNotice {
     pub confirm_id: String,
@@ -81,11 +82,11 @@ pub struct BootRevertNotice {
     /// state the daemon was in before this restart is uncertain (the banner
     /// says so), even though the boot revert itself succeeded.
     pub rollback_failed: bool,
-    /// V2 locator-carried target paths are sensitive and must not be rendered
+    /// V2/v3 locator-carried target paths are sensitive and must not be rendered
     /// by ordinary startup logs or banners.
     pub redact_paths: bool,
-    /// V2 journal cleanup follows the durable terminal locator removal and is
-    /// warning-only.  V1 never reports this state because its cleanup remains
+    /// V2/v3 pending cleanup follows durable terminal locator removal and is
+    /// warning-only. V1 never reports this state because its cleanup remains
     /// part of its legacy terminal operation.
     pub journal_cleanup_failed: bool,
 }

--- a/src/confirm_journal/v3.rs
+++ b/src/confirm_journal/v3.rs
@@ -1,0 +1,1690 @@
+//! Disk-backed v3 commit-confirm authority.
+//!
+//! A config-adjacent locator is the sole boot authority. It names one fixed
+//! metadata object; metadata in turn binds one fixed raw normalized-prior
+//! object by length, digest, device, and inode. Every object is opened relative
+//! to a pinned directory descriptor and publication is raw, metadata, locator.
+
+#![deny(unsafe_code)]
+
+use std::ffi::{OsStr, OsString};
+use std::fs::File;
+use std::io::{self, Read as _, Seek as _, Write as _};
+use std::os::unix::ffi::{OsStrExt as _, OsStringExt as _};
+use std::os::unix::fs::MetadataExt as _;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use crate::config::{AcceptedConfigSnapshot, Config, persisted_config_document};
+use crate::config_history;
+use crate::config_history::v2::{self as history_v2, LosslessPath, Manifest};
+
+const VERSION: u32 = 3;
+const MAX_CONFIRM_ID_CHARS: usize = 128;
+pub(crate) const MAX_RAW_BYTES: usize = 384 * 1024 * 1024;
+const MAX_METADATA_BYTES: usize = 34 * 1024 * 1024;
+const MAX_LOCATOR_BYTES: usize = 512 * 1024;
+const MAX_PATH_BYTES: usize = 64 * 1024;
+const LOCATOR_SUFFIX: &str = ".commit-confirm-locator.json";
+pub(crate) const RAW_FILE_NAME: &str = "commit-confirm-v3-prior.toml";
+pub(crate) const METADATA_FILE_NAME: &str = "commit-confirm-v3-metadata.json";
+
+/// Stable lexical identity captured before the candidate config is opened.
+#[derive(Clone, Debug)]
+pub(crate) struct LaunchIdentity {
+    lexical_config: PathBuf,
+    #[cfg(test)]
+    fail_publish_step: Option<PublishStep>,
+}
+
+impl LaunchIdentity {
+    pub(crate) fn resolve(path: &Path) -> io::Result<Self> {
+        let absolute = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir()?.join(path)
+        };
+        reject_ambiguous_terminal_path(&absolute)?;
+        let lexical_config = normalize_launch_path(&absolute)?;
+        if lexical_config.file_name().is_none() {
+            return Err(invalid("launch config path has no final component"));
+        }
+        Ok(Self {
+            lexical_config,
+            #[cfg(test)]
+            fail_publish_step: None,
+        })
+    }
+
+    pub(crate) fn locator_path(&self) -> PathBuf {
+        let mut bytes = self.lexical_config.as_os_str().as_bytes().to_vec();
+        bytes.extend_from_slice(LOCATOR_SUFFIX.as_bytes());
+        PathBuf::from(OsString::from_vec(bytes))
+    }
+
+    /// Inspect v3 before candidate access. A missing locator or canonical v2
+    /// locator returns `Ok(None)` so the frozen compatibility lane can run.
+    pub(crate) fn boot_revert_check(&self) -> Result<Option<BootRevert>, String> {
+        self.boot_revert_check_io().map_err(|error| {
+            format!(
+                "v3 commit-confirm boot authority is invalid or unavailable ({:?}); inspect the config-adjacent locator and fixed owner-only pending files",
+                error.kind()
+            )
+        })
+    }
+
+    fn boot_revert_check_io(&self) -> io::Result<Option<BootRevert>> {
+        self.boot_revert_check_io_with(|_| Ok(()))
+    }
+
+    fn boot_revert_check_io_with(
+        &self,
+        mut step: impl FnMut(BootStep) -> io::Result<()>,
+    ) -> io::Result<Option<BootRevert>> {
+        let locator = Entry::pin_for_absence(&self.locator_path())?;
+        if !locator.exists()? {
+            return Ok(None);
+        }
+        locator.directory.validate_private()?;
+        let (locator_bytes, locator_identity) = locator.read_bounded(MAX_LOCATOR_BYTES)?;
+        if locator_bytes.starts_with(b"{\"version\":2,") {
+            return Ok(None);
+        }
+        let locator_wire = decode_locator(&locator_bytes)?;
+
+        let metadata_path = path_from_wire(&locator_wire.metadata_path)?;
+        if metadata_path.file_name() != Some(OsStr::new(METADATA_FILE_NAME)) {
+            return Err(invalid("locator metadata path is not the fixed v3 name"));
+        }
+        let pending = Directory::pin(
+            metadata_path
+                .parent()
+                .ok_or_else(|| invalid("fixed v3 metadata path has no parent"))?,
+        )?;
+        let metadata = Entry::fixed(Arc::clone(&pending), METADATA_FILE_NAME);
+        let raw = Entry::fixed(Arc::clone(&pending), RAW_FILE_NAME);
+        if path_from_wire(&locator_wire.metadata_path)? != metadata.absolute_path() {
+            return Err(invalid(
+                "locator does not name the fixed v3 metadata object",
+            ));
+        }
+        let (metadata_bytes, metadata_identity) = metadata.read_bounded(MAX_METADATA_BYTES)?;
+        let metadata_wire = decode_metadata(&metadata_bytes)?;
+        validate_linkage(&locator_wire, &metadata_wire)?;
+        let (raw_bytes, raw_identity) = raw.read_exact_bounded(metadata_wire.raw_length)?;
+        validate_raw(&raw_bytes, raw_identity, &metadata_wire)?;
+
+        let recorded_target = path_from_wire(&locator_wire.config_target)?;
+        verify_launch_target(&self.lexical_config, &recorded_target)?;
+        let target = Entry::pin(&recorded_target)?;
+        let raw_toml = std::str::from_utf8(&raw_bytes).map_err(invalid)?;
+        let accepted = AcceptedConfigSnapshot::load_retained(raw_toml, &recorded_target)
+            .map_err(|_| invalid("journaled prior sources are unavailable or changed"))?;
+        verify_snapshot(&accepted, raw_toml, &metadata_wire)?;
+
+        // Nothing above this point may touch the candidate or backup slot.
+        let backup_name = append_name(&target.name, b".unconfirmed")?;
+        step(BootStep::CandidateSave)?;
+        save_candidate_aside(&target, &backup_name)?;
+        step(BootStep::ConfigRestore)?;
+        target.replace(raw_toml.as_bytes())?;
+
+        step(BootStep::LocatorUnlink)?;
+        locator.remove_matching(locator_identity)?;
+        step(BootStep::LocatorDirectorySync)?;
+        locator.directory.file.sync_all()?;
+        let residue_cleanup_failed = (|| {
+            step(BootStep::MetadataUnlink)?;
+            metadata.remove_matching(metadata_identity)?;
+            step(BootStep::RawUnlink)?;
+            raw.remove_matching(raw_identity)?;
+            step(BootStep::PendingDirectorySync)?;
+            pending.file.sync_all()
+        })()
+        .is_err();
+        Ok(Some(BootRevert {
+            accepted,
+            notice: BootRevertNotice {
+                confirm_id: metadata_wire.confirm_id,
+                rollback_failed: metadata_wire.rollback_failed,
+                residue_cleanup_failed,
+            },
+        }))
+    }
+
+    pub(crate) fn publish(
+        &self,
+        pending_dir: &Path,
+        confirm_id: &str,
+        deadline_unix_seconds: u64,
+        prior: &AcceptedConfigSnapshot,
+    ) -> Result<PendingFiles, PublishError> {
+        self.publish_with(
+            pending_dir,
+            confirm_id,
+            deadline_unix_seconds,
+            prior,
+            |step| {
+                #[cfg(test)]
+                if self.fail_publish_step == Some(step) {
+                    return Err(io::Error::other("injected v3 publication failure"));
+                }
+                #[cfg(not(test))]
+                let _ = step;
+                Ok(())
+            },
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_locator_directory_sync_for_test(mut self) -> Self {
+        self.fail_publish_step = Some(PublishStep::LocatorDirectorySync);
+        self
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one ordered raw-metadata-locator durability transaction"
+    )]
+    fn publish_with(
+        &self,
+        pending_dir: &Path,
+        confirm_id: &str,
+        deadline_unix_seconds: u64,
+        prior: &AcceptedConfigSnapshot,
+        mut step: impl FnMut(PublishStep) -> io::Result<()>,
+    ) -> Result<PendingFiles, PublishError> {
+        let locator = Entry::pin(&self.locator_path()).map_err(PublishError::ordinary)?;
+        if locator.exists().map_err(PublishError::ordinary)? {
+            return Err(PublishError::ordinary(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "commit-confirm locator is already present",
+            )));
+        }
+        validate_confirm_id(confirm_id).map_err(PublishError::ordinary)?;
+        let raw_bytes = prior.normalized_toml().as_bytes();
+        if raw_bytes.len() > MAX_RAW_BYTES {
+            return Err(PublishError::ordinary(limit(
+                "raw normalized prior",
+                MAX_RAW_BYTES,
+            )));
+        }
+        let raw_sha256: [u8; 32] = Sha256::digest(raw_bytes).into();
+        let manifest = config_history::stored_manifest(prior);
+        history_v2::validate_manifest(&manifest).map_err(PublishError::ordinary)?;
+        if manifest.toml_sha256 != raw_sha256
+            || prior.source_sha256() != history_v2::manifest_source_sha256(&manifest)
+        {
+            return Err(PublishError::ordinary(invalid(
+                "accepted prior digest mismatch",
+            )));
+        }
+
+        let pending = Directory::pin(pending_dir).map_err(PublishError::ordinary)?;
+        let raw = Entry::fixed(Arc::clone(&pending), RAW_FILE_NAME);
+        let metadata = Entry::fixed(Arc::clone(&pending), METADATA_FILE_NAME);
+        cleanup_locator_absent_residue_pinned(&pending).map_err(PublishError::ordinary)?;
+        raw.cleanup_stage().map_err(PublishError::ordinary)?;
+        metadata.cleanup_stage().map_err(PublishError::ordinary)?;
+        locator.cleanup_stage().map_err(PublishError::ordinary)?;
+
+        let raw_identity = raw
+            .publish_with(raw_bytes, PublishRole::Raw, &mut step)
+            .map_err(|failure| PublishError::ordinary(failure.error))?;
+        let metadata_wire = Metadata {
+            version: VERSION,
+            confirm_id: confirm_id.to_string(),
+            deadline_unix_seconds,
+            rollback_failed: false,
+            raw_name: LosslessPath(RAW_FILE_NAME.as_bytes().to_vec()),
+            raw_length: raw_bytes.len() as u64,
+            raw_sha256,
+            raw_source_sha256: prior.source_sha256(),
+            raw_device: raw_identity.device,
+            raw_inode: raw_identity.inode,
+            manifest,
+        };
+        let metadata_bytes = match encode_metadata(&metadata_wire) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                cleanup_created(&raw, raw_identity);
+                return Err(PublishError::ordinary(error));
+            }
+        };
+        let metadata_identity =
+            match metadata.publish_with(&metadata_bytes, PublishRole::Metadata, &mut step) {
+                Ok(identity) => identity,
+                Err(failure) => {
+                    cleanup_created(&raw, raw_identity);
+                    return Err(PublishError::ordinary(failure.error));
+                }
+            };
+        let config_target = resolve_launch_target(&self.lexical_config, true)
+            .and_then(|path| Entry::pin(&path).map(|entry| entry.absolute_path()))
+            .map_err(|error| {
+                cleanup_created(&metadata, metadata_identity);
+                cleanup_created(&raw, raw_identity);
+                PublishError::ordinary(error)
+            })?;
+        let locator_wire = Locator {
+            version: VERSION,
+            confirm_id: confirm_id.to_string(),
+            metadata_path: path_to_wire(&metadata.absolute_path()).map_err(|error| {
+                cleanup_created(&metadata, metadata_identity);
+                cleanup_created(&raw, raw_identity);
+                PublishError::ordinary(error)
+            })?,
+            config_target: path_to_wire(&config_target).map_err(|error| {
+                cleanup_created(&metadata, metadata_identity);
+                cleanup_created(&raw, raw_identity);
+                PublishError::ordinary(error)
+            })?,
+            prior_sha256: raw_sha256,
+            prior_source_sha256: prior.source_sha256(),
+        };
+        let locator_bytes = encode_locator(&locator_wire).map_err(|error| {
+            cleanup_created(&metadata, metadata_identity);
+            cleanup_created(&raw, raw_identity);
+            PublishError::ordinary(error)
+        })?;
+        let locator_identity =
+            match locator.publish_with(&locator_bytes, PublishRole::Locator, &mut step) {
+                Ok(identity) => identity,
+                Err(failure) if failure.renamed => {
+                    return Err(PublishError {
+                        error: failure.error,
+                        authority_retained: true,
+                    });
+                }
+                Err(failure) => {
+                    cleanup_created(&metadata, metadata_identity);
+                    cleanup_created(&raw, raw_identity);
+                    return Err(PublishError::ordinary(failure.error));
+                }
+            };
+        Ok(PendingFiles {
+            locator,
+            metadata,
+            raw,
+            state: Mutex::new(PendingState {
+                locator_wire,
+                locator_identity,
+                metadata_wire,
+                metadata_identity,
+                raw_identity,
+                locator_phase: CleanupPhase::Published,
+                metadata_phase: CleanupPhase::Published,
+                raw_phase: CleanupPhase::Published,
+            }),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct PublishError {
+    error: io::Error,
+    authority_retained: bool,
+}
+
+impl PublishError {
+    fn ordinary(error: io::Error) -> Self {
+        Self {
+            error,
+            authority_retained: false,
+        }
+    }
+
+    pub(crate) fn kind(&self) -> io::ErrorKind {
+        self.error.kind()
+    }
+
+    pub(crate) fn authority_retained(&self) -> bool {
+        self.authority_retained
+    }
+}
+
+pub(crate) struct BootRevert {
+    pub(crate) accepted: Arc<AcceptedConfigSnapshot>,
+    pub(crate) notice: BootRevertNotice,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct BootRevertNotice {
+    pub(crate) confirm_id: String,
+    pub(crate) rollback_failed: bool,
+    pub(crate) residue_cleanup_failed: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BootStep {
+    CandidateSave,
+    ConfigRestore,
+    LocatorUnlink,
+    LocatorDirectorySync,
+    MetadataUnlink,
+    RawUnlink,
+    PendingDirectorySync,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PublishRole {
+    Raw,
+    Metadata,
+    Locator,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PublishStep {
+    RawStageSync,
+    RawRename,
+    RawDirectorySync,
+    MetadataStageSync,
+    MetadataRename,
+    MetadataDirectorySync,
+    LocatorStageSync,
+    LocatorRename,
+    LocatorDirectorySync,
+}
+
+impl PublishStep {
+    const fn for_role(role: PublishRole, ordinal: u8) -> Self {
+        match (role, ordinal) {
+            (PublishRole::Raw, 0) => Self::RawStageSync,
+            (PublishRole::Raw, 1) => Self::RawRename,
+            (PublishRole::Raw, 2) => Self::RawDirectorySync,
+            (PublishRole::Metadata, 0) => Self::MetadataStageSync,
+            (PublishRole::Metadata, 1) => Self::MetadataRename,
+            (PublishRole::Metadata, 2) => Self::MetadataDirectorySync,
+            (PublishRole::Locator, 0) => Self::LocatorStageSync,
+            (PublishRole::Locator, 1) => Self::LocatorRename,
+            (PublishRole::Locator, 2) => Self::LocatorDirectorySync,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct PendingFiles {
+    locator: Entry,
+    metadata: Entry,
+    raw: Entry,
+    state: Mutex<PendingState>,
+}
+
+#[derive(Debug)]
+struct PendingState {
+    locator_wire: Locator,
+    locator_identity: FileIdentity,
+    metadata_wire: Metadata,
+    metadata_identity: FileIdentity,
+    raw_identity: FileIdentity,
+    locator_phase: CleanupPhase,
+    metadata_phase: CleanupPhase,
+    raw_phase: CleanupPhase,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CleanupPhase {
+    Published,
+    Unlinked,
+    Synced,
+}
+
+impl PendingFiles {
+    /// Durably remove locator authority first. Fixed residue cleanup after
+    /// that terminal point is warning-only and never re-arms authority.
+    pub(crate) fn terminal_cleanup(&self) -> io::Result<bool> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| invalid("pending cleanup state is unavailable"))?;
+        if state.locator_phase == CleanupPhase::Published {
+            self.locator.verify_locator(&state.locator_wire)?;
+            self.locator.remove_matching(state.locator_identity)?;
+            state.locator_phase = CleanupPhase::Unlinked;
+        }
+        if state.locator_phase == CleanupPhase::Unlinked {
+            self.locator.directory.file.sync_all()?;
+            state.locator_phase = CleanupPhase::Synced;
+        }
+        let residue_result: io::Result<()> = (|| {
+            if state.metadata_phase == CleanupPhase::Published {
+                self.metadata
+                    .verify_metadata(state.metadata_identity, &state.metadata_wire)?;
+                self.metadata.remove_matching(state.metadata_identity)?;
+                state.metadata_phase = CleanupPhase::Unlinked;
+            }
+            if state.raw_phase == CleanupPhase::Published {
+                self.raw
+                    .verify_raw(state.raw_identity, &state.metadata_wire)?;
+                self.raw.remove_matching(state.raw_identity)?;
+                state.raw_phase = CleanupPhase::Unlinked;
+            }
+            if state.metadata_phase == CleanupPhase::Unlinked
+                || state.raw_phase == CleanupPhase::Unlinked
+            {
+                self.metadata.directory.file.sync_all()?;
+                state.metadata_phase = CleanupPhase::Synced;
+                state.raw_phase = CleanupPhase::Synced;
+            }
+            Ok(())
+        })();
+        Ok(residue_result.is_err())
+    }
+
+    /// Replace compact metadata only; locator linkage deliberately excludes
+    /// metadata inode and digest, while the raw identity remains exact.
+    pub(crate) fn record_rollback_failed(&self) -> io::Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| invalid("pending metadata state is unavailable"))?;
+        if state.locator_phase != CleanupPhase::Published
+            || state.metadata_phase != CleanupPhase::Published
+            || state.raw_phase != CleanupPhase::Published
+        {
+            return Err(invalid("pending cleanup has already started"));
+        }
+        self.locator.verify_locator(&state.locator_wire)?;
+        self.metadata
+            .verify_metadata(state.metadata_identity, &state.metadata_wire)?;
+        self.raw
+            .verify_raw(state.raw_identity, &state.metadata_wire)?;
+        let mut updated = state.metadata_wire.clone();
+        updated.rollback_failed = true;
+        let bytes = encode_metadata(&updated)?;
+        let identity = self.metadata.replace(&bytes)?;
+        state.metadata_wire = updated;
+        state.metadata_identity = identity;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Locator {
+    version: u32,
+    confirm_id: String,
+    metadata_path: LosslessPath,
+    config_target: LosslessPath,
+    #[serde(with = "history_digest")]
+    prior_sha256: [u8; 32],
+    #[serde(with = "history_digest")]
+    prior_source_sha256: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Metadata {
+    version: u32,
+    confirm_id: String,
+    deadline_unix_seconds: u64,
+    rollback_failed: bool,
+    raw_name: LosslessPath,
+    raw_length: u64,
+    #[serde(with = "history_digest")]
+    raw_sha256: [u8; 32],
+    #[serde(with = "history_digest")]
+    raw_source_sha256: [u8; 32],
+    raw_device: u64,
+    raw_inode: u64,
+    manifest: Manifest,
+}
+
+fn encode_locator(value: &Locator) -> io::Result<Vec<u8>> {
+    validate_locator(value)?;
+    let mut bytes = serde_json::to_vec(value).map_err(invalid)?;
+    bytes.push(b'\n');
+    enforce_cap("locator", bytes.len(), MAX_LOCATOR_BYTES)?;
+    Ok(bytes)
+}
+
+fn decode_locator(bytes: &[u8]) -> io::Result<Locator> {
+    enforce_cap("locator", bytes.len(), MAX_LOCATOR_BYTES)?;
+    if !bytes.starts_with(b"{\"version\":3,") {
+        return Err(invalid("locator is not canonical v3"));
+    }
+    let value: Locator = serde_json::from_slice(bytes).map_err(invalid)?;
+    validate_locator(&value)?;
+    if encode_locator(&value)? != bytes {
+        return Err(invalid("non-canonical v3 locator"));
+    }
+    Ok(value)
+}
+
+fn validate_locator(value: &Locator) -> io::Result<()> {
+    if value.version != VERSION {
+        return Err(invalid("unsupported locator version"));
+    }
+    validate_confirm_id(&value.confirm_id)?;
+    for path in [&value.metadata_path, &value.config_target] {
+        let decoded = path_from_wire(path)?;
+        if !decoded.is_absolute() || has_parent_dir(&decoded) {
+            return Err(invalid("locator path is not absolute and lexical"));
+        }
+    }
+    Ok(())
+}
+
+fn encode_metadata(value: &Metadata) -> io::Result<Vec<u8>> {
+    validate_metadata(value)?;
+    let mut bytes = serde_json::to_vec(value).map_err(invalid)?;
+    bytes.push(b'\n');
+    enforce_cap("metadata", bytes.len(), MAX_METADATA_BYTES)?;
+    Ok(bytes)
+}
+
+fn decode_metadata(bytes: &[u8]) -> io::Result<Metadata> {
+    enforce_cap("metadata", bytes.len(), MAX_METADATA_BYTES)?;
+    if !bytes.starts_with(b"{\"version\":3,") {
+        return Err(invalid("metadata is not canonical v3"));
+    }
+    let value: Metadata = serde_json::from_slice(bytes).map_err(invalid)?;
+    validate_metadata(&value)?;
+    if encode_metadata(&value)? != bytes {
+        return Err(invalid("non-canonical v3 metadata"));
+    }
+    Ok(value)
+}
+
+fn validate_metadata(value: &Metadata) -> io::Result<()> {
+    if value.version != VERSION {
+        return Err(invalid("unsupported metadata version"));
+    }
+    validate_confirm_id(&value.confirm_id)?;
+    if value.raw_name.0 != RAW_FILE_NAME.as_bytes() {
+        return Err(invalid("metadata does not name the fixed raw object"));
+    }
+    if value.raw_length > MAX_RAW_BYTES as u64 {
+        return Err(limit("raw normalized prior", MAX_RAW_BYTES));
+    }
+    history_v2::validate_manifest(&value.manifest)?;
+    if value.manifest.toml_sha256 != value.raw_sha256
+        || history_v2::manifest_source_sha256(&value.manifest) != value.raw_source_sha256
+    {
+        return Err(invalid("metadata digest linkage mismatch"));
+    }
+    Ok(())
+}
+
+fn validate_linkage(locator: &Locator, metadata: &Metadata) -> io::Result<()> {
+    if locator.confirm_id != metadata.confirm_id
+        || locator.prior_sha256 != metadata.raw_sha256
+        || locator.prior_source_sha256 != metadata.raw_source_sha256
+    {
+        return Err(invalid("locator and metadata linkage mismatch"));
+    }
+    Ok(())
+}
+
+fn validate_raw(bytes: &[u8], identity: FileIdentity, metadata: &Metadata) -> io::Result<()> {
+    if bytes.len() as u64 != metadata.raw_length
+        || identity.device != metadata.raw_device
+        || identity.inode != metadata.raw_inode
+        || <[u8; 32]>::from(Sha256::digest(bytes)) != metadata.raw_sha256
+    {
+        return Err(invalid("raw normalized-prior identity or digest mismatch"));
+    }
+    std::str::from_utf8(bytes).map_err(invalid)?;
+    Ok(())
+}
+
+fn verify_snapshot(
+    snapshot: &AcceptedConfigSnapshot,
+    normalized_toml: &str,
+    metadata: &Metadata,
+) -> io::Result<()> {
+    config_history::verify_retained_snapshot(
+        snapshot,
+        normalized_toml,
+        &metadata.manifest,
+        metadata.raw_source_sha256,
+    )
+    .map_err(invalid)
+}
+
+fn validate_confirm_id(value: &str) -> io::Result<()> {
+    if value.trim().is_empty()
+        || value.chars().count() > MAX_CONFIRM_ID_CHARS
+        || value.chars().any(char::is_control)
+    {
+        return Err(invalid("invalid confirm id"));
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Directory {
+    file: File,
+    real_path: PathBuf,
+}
+
+impl Directory {
+    fn pin(path: &Path) -> io::Result<Arc<Self>> {
+        let directory = Self::pin_unchecked(path)?;
+        directory.validate_private()?;
+        Ok(directory)
+    }
+
+    fn pin_unchecked(path: &Path) -> io::Result<Arc<Self>> {
+        use nix::fcntl::{OFlag, open};
+        use nix::sys::stat::Mode;
+
+        let real_path = std::fs::canonicalize(path)
+            .map_err(|error| io::Error::new(error.kind(), "pending parent unavailable"))?;
+        let fd = open(
+            &real_path,
+            OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_CLOEXEC | OFlag::O_NOFOLLOW,
+            Mode::empty(),
+        )
+        .map_err(errno)?;
+        Ok(Arc::new(Self {
+            file: File::from(fd),
+            real_path,
+        }))
+    }
+
+    fn validate_private(&self) -> io::Result<()> {
+        use nix::unistd::geteuid;
+
+        let metadata = self.file.metadata()?;
+        if !metadata.is_dir()
+            || metadata.uid() != geteuid().as_raw()
+            || metadata.mode() & 0o022 != 0
+        {
+            return Err(invalid("unsafe pending parent owner, type, or mode"));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct FileIdentity {
+    device: u64,
+    inode: u64,
+}
+
+impl FileIdentity {
+    fn from_metadata(metadata: &std::fs::Metadata) -> Self {
+        Self {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Entry {
+    directory: Arc<Directory>,
+    name: OsString,
+}
+
+struct EntryPublishError {
+    error: io::Error,
+    renamed: bool,
+}
+
+impl Entry {
+    fn fixed(directory: Arc<Directory>, name: &str) -> Self {
+        Self {
+            directory,
+            name: OsString::from(name),
+        }
+    }
+
+    fn pin(path: &Path) -> io::Result<Self> {
+        Self::pin_inner(path, true)
+    }
+
+    fn pin_for_absence(path: &Path) -> io::Result<Self> {
+        Self::pin_inner(path, false)
+    }
+
+    fn pin_inner(path: &Path, private: bool) -> io::Result<Self> {
+        let absolute = absolute_path(path)?;
+        let name = absolute
+            .file_name()
+            .ok_or_else(|| invalid("pending file has no final component"))?
+            .to_os_string();
+        let parent = absolute
+            .parent()
+            .ok_or_else(|| invalid("pending file has no parent"))?;
+        let directory = if private {
+            Directory::pin(parent)?
+        } else {
+            Directory::pin_unchecked(parent)?
+        };
+        Ok(Self { directory, name })
+    }
+
+    fn absolute_path(&self) -> PathBuf {
+        self.directory.real_path.join(&self.name)
+    }
+
+    fn stage_name(&self) -> io::Result<OsString> {
+        append_name(&self.name, b".tmp")
+    }
+
+    fn exists(&self) -> io::Result<bool> {
+        use nix::fcntl::AtFlags;
+        use nix::sys::stat::fstatat;
+
+        match fstatat(
+            &self.directory.file,
+            Path::new(&self.name),
+            AtFlags::AT_SYMLINK_NOFOLLOW,
+        ) {
+            Ok(_) => Ok(true),
+            Err(nix::errno::Errno::ENOENT) => Ok(false),
+            Err(error) => Err(errno(error)),
+        }
+    }
+
+    fn open_nofollow(&self) -> io::Result<File> {
+        use nix::fcntl::{OFlag, openat};
+        use nix::sys::stat::Mode;
+
+        openat(
+            &self.directory.file,
+            Path::new(&self.name),
+            OFlag::O_RDONLY | OFlag::O_CLOEXEC | OFlag::O_NOFOLLOW | OFlag::O_NONBLOCK,
+            Mode::empty(),
+        )
+        .map(File::from)
+        .map_err(errno)
+    }
+
+    fn read_bounded(&self, cap: usize) -> io::Result<(Vec<u8>, FileIdentity)> {
+        let mut file = self.open_nofollow()?;
+        let metadata = file.metadata()?;
+        validate_file_metadata(&metadata, cap)?;
+        let identity = FileIdentity::from_metadata(&metadata);
+        Ok((read_opened(&mut file, &metadata, cap)?, identity))
+    }
+
+    fn read_exact_bounded(&self, declared: u64) -> io::Result<(Vec<u8>, FileIdentity)> {
+        if declared > MAX_RAW_BYTES as u64 {
+            return Err(limit("raw normalized prior", MAX_RAW_BYTES));
+        }
+        let mut file = self.open_nofollow()?;
+        let metadata = file.metadata()?;
+        validate_file_metadata(&metadata, MAX_RAW_BYTES)?;
+        if metadata.len() != declared {
+            return Err(invalid("raw normalized-prior declared length mismatch"));
+        }
+        let identity = FileIdentity::from_metadata(&metadata);
+        Ok((read_opened(&mut file, &metadata, MAX_RAW_BYTES)?, identity))
+    }
+
+    fn publish_with(
+        &self,
+        bytes: &[u8],
+        role: PublishRole,
+        step: &mut impl FnMut(PublishStep) -> io::Result<()>,
+    ) -> Result<FileIdentity, EntryPublishError> {
+        use nix::fcntl::{OFlag, RenameFlags, openat, renameat2};
+        use nix::sys::stat::{Mode, fchmod};
+
+        let stage = self.stage_name().map_err(|error| EntryPublishError {
+            error,
+            renamed: false,
+        })?;
+        self.cleanup_stage().map_err(|error| EntryPublishError {
+            error,
+            renamed: false,
+        })?;
+        let stage_entry = Self {
+            directory: Arc::clone(&self.directory),
+            name: stage.clone(),
+        };
+        let fd = openat(
+            &self.directory.file,
+            Path::new(&stage),
+            OFlag::O_WRONLY | OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_CLOEXEC | OFlag::O_NOFOLLOW,
+            Mode::from_bits_truncate(0o600),
+        )
+        .map_err(|error| EntryPublishError {
+            error: errno(error),
+            renamed: false,
+        })?;
+        let mut file = File::from(fd);
+        fchmod(&file, Mode::from_bits_truncate(0o600)).map_err(|error| EntryPublishError {
+            error: errno(error),
+            renamed: false,
+        })?;
+        let identity =
+            FileIdentity::from_metadata(&file.metadata().map_err(|error| EntryPublishError {
+                error,
+                renamed: false,
+            })?);
+        let mut renamed = false;
+        let result = (|| {
+            file.write_all(bytes)?;
+            step(PublishStep::for_role(role, 0))?;
+            file.sync_all()?;
+            drop(file);
+            step(PublishStep::for_role(role, 1))?;
+            renameat2(
+                &self.directory.file,
+                Path::new(&stage),
+                &self.directory.file,
+                Path::new(&self.name),
+                RenameFlags::RENAME_NOREPLACE,
+            )
+            .map_err(errno)?;
+            renamed = true;
+            step(PublishStep::for_role(role, 2))?;
+            self.directory.file.sync_all()
+        })();
+        if let Err(error) = result {
+            let _ = stage_entry.remove_matching(identity);
+            if !(role == PublishRole::Locator && renamed) {
+                let _ = self.remove_matching(identity);
+                let _ = self.directory.file.sync_all();
+            }
+            return Err(EntryPublishError { error, renamed });
+        }
+        Ok(identity)
+    }
+
+    fn replace(&self, bytes: &[u8]) -> io::Result<FileIdentity> {
+        use nix::fcntl::{OFlag, openat, renameat};
+        use nix::sys::stat::{Mode, fchmod};
+
+        let stage = self.stage_name()?;
+        self.cleanup_stage()?;
+        let fd = openat(
+            &self.directory.file,
+            Path::new(&stage),
+            OFlag::O_WRONLY | OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_CLOEXEC | OFlag::O_NOFOLLOW,
+            Mode::from_bits_truncate(0o600),
+        )
+        .map_err(errno)?;
+        let mut file = File::from(fd);
+        fchmod(&file, Mode::from_bits_truncate(0o600)).map_err(errno)?;
+        let identity = FileIdentity::from_metadata(&file.metadata()?);
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        renameat(
+            &self.directory.file,
+            Path::new(&stage),
+            &self.directory.file,
+            Path::new(&self.name),
+        )
+        .map_err(errno)?;
+        self.directory.file.sync_all()?;
+        Ok(identity)
+    }
+
+    fn cleanup_stage(&self) -> io::Result<()> {
+        remove_named_safe(&self.directory.file, &self.stage_name()?)?;
+        self.directory.file.sync_all()
+    }
+
+    fn remove_matching(&self, expected: FileIdentity) -> io::Result<()> {
+        use nix::fcntl::AtFlags;
+        use nix::sys::stat::{SFlag, fstatat};
+        use nix::unistd::{UnlinkatFlags, geteuid, unlinkat};
+
+        let stat = fstatat(
+            &self.directory.file,
+            Path::new(&self.name),
+            AtFlags::AT_SYMLINK_NOFOLLOW,
+        )
+        .map_err(errno)?;
+        if SFlag::from_bits_truncate(stat.st_mode) & SFlag::S_IFMT != SFlag::S_IFREG
+            || stat.st_uid != geteuid().as_raw()
+            || stat.st_mode & 0o7777 != 0o600
+            || stat.st_dev as u64 != expected.device
+            || stat.st_ino as u64 != expected.inode
+        {
+            return Err(invalid("pending file identity changed before cleanup"));
+        }
+        unlinkat(
+            &self.directory.file,
+            Path::new(&self.name),
+            UnlinkatFlags::NoRemoveDir,
+        )
+        .map_err(errno)
+    }
+
+    fn verify_locator(&self, expected: &Locator) -> io::Result<()> {
+        let (bytes, _) = self.read_bounded(MAX_LOCATOR_BYTES)?;
+        if decode_locator(&bytes)? != *expected {
+            return Err(invalid("published locator changed before cleanup"));
+        }
+        Ok(())
+    }
+
+    fn verify_metadata(&self, identity: FileIdentity, expected: &Metadata) -> io::Result<()> {
+        let (bytes, actual) = self.read_bounded(MAX_METADATA_BYTES)?;
+        if actual != identity || decode_metadata(&bytes)? != *expected {
+            return Err(invalid("published metadata changed before cleanup"));
+        }
+        Ok(())
+    }
+
+    fn verify_raw(&self, identity: FileIdentity, metadata: &Metadata) -> io::Result<()> {
+        let (bytes, actual) = self.read_exact_bounded(metadata.raw_length)?;
+        validate_raw(&bytes, actual, metadata)?;
+        if actual != identity {
+            return Err(invalid("published raw object changed before cleanup"));
+        }
+        Ok(())
+    }
+}
+
+fn cleanup_created(entry: &Entry, identity: FileIdentity) {
+    let _ = entry.remove_matching(identity);
+    let _ = entry.directory.file.sync_all();
+}
+
+fn cleanup_locator_absent_residue_pinned(pending: &Arc<Directory>) -> io::Result<()> {
+    let metadata = Entry::fixed(Arc::clone(pending), METADATA_FILE_NAME);
+    let raw = Entry::fixed(Arc::clone(pending), RAW_FILE_NAME);
+    let metadata_read = metadata.read_bounded(MAX_METADATA_BYTES);
+    match metadata_read {
+        Ok((bytes, metadata_identity)) => {
+            let wire = decode_metadata(&bytes)?;
+            let (raw_bytes, raw_identity) = raw.read_exact_bounded(wire.raw_length)?;
+            validate_raw(&raw_bytes, raw_identity, &wire)?;
+            metadata.remove_matching(metadata_identity)?;
+            raw.remove_matching(raw_identity)?;
+            pending.file.sync_all()
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            let (bytes, raw_identity) = match raw.read_bounded(MAX_RAW_BYTES) {
+                Ok(found) => found,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+                Err(error) => return Err(error),
+            };
+            let raw_toml = std::str::from_utf8(&bytes).map_err(invalid)?;
+            let config =
+                Config::load_toml_with_diagnostics(raw_toml, "v3 raw residue").map_err(invalid)?;
+            let normalized = persisted_config_document(&config).map_err(invalid)?;
+            if normalized.as_bytes() != bytes {
+                return Err(invalid("raw residue is not normalized TOML"));
+            }
+            raw.remove_matching(raw_identity)?;
+            pending.file.sync_all()
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn remove_named_safe(directory: &File, name: &OsStr) -> io::Result<()> {
+    use nix::fcntl::AtFlags;
+    use nix::sys::stat::{SFlag, fstatat};
+    use nix::unistd::{UnlinkatFlags, geteuid, unlinkat};
+
+    let stat = match fstatat(directory, Path::new(name), AtFlags::AT_SYMLINK_NOFOLLOW) {
+        Ok(stat) => stat,
+        Err(nix::errno::Errno::ENOENT) => return Ok(()),
+        Err(error) => return Err(errno(error)),
+    };
+    if SFlag::from_bits_truncate(stat.st_mode) & SFlag::S_IFMT != SFlag::S_IFREG
+        || stat.st_uid != geteuid().as_raw()
+        || stat.st_mode & 0o7777 != 0o600
+    {
+        return Err(invalid("unsafe exact pending residue"));
+    }
+    unlinkat(directory, Path::new(name), UnlinkatFlags::NoRemoveDir).map_err(errno)
+}
+
+fn validate_file_metadata(metadata: &std::fs::Metadata, cap: usize) -> io::Result<()> {
+    use nix::unistd::geteuid;
+
+    validate_file_metadata_values(
+        metadata.is_file(),
+        metadata.uid(),
+        metadata.mode(),
+        metadata.len(),
+        cap,
+        geteuid().as_raw(),
+    )
+}
+
+fn validate_file_metadata_values(
+    regular: bool,
+    owner: u32,
+    mode: u32,
+    length: u64,
+    cap: usize,
+    expected_owner: u32,
+) -> io::Result<()> {
+    if !regular || owner != expected_owner || mode & 0o7777 != 0o600 || length > cap as u64 {
+        return Err(invalid("unsafe pending file metadata"));
+    }
+    Ok(())
+}
+
+fn read_opened(file: &mut File, metadata: &std::fs::Metadata, cap: usize) -> io::Result<Vec<u8>> {
+    file.rewind()?;
+    let capacity = usize::try_from(metadata.len())
+        .map_err(|_| invalid("pending file length does not fit this platform"))?;
+    let mut bytes = Vec::with_capacity(capacity);
+    file.take(cap as u64 + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 != metadata.len() || bytes.len() > cap {
+        return Err(invalid("pending file changed while reading"));
+    }
+    Ok(bytes)
+}
+
+fn save_candidate_aside(target: &Entry, backup_name: &OsStr) -> io::Result<()> {
+    use nix::fcntl::AtFlags;
+    use nix::unistd::{UnlinkatFlags, linkat, unlinkat};
+
+    match linkat(
+        &target.directory.file,
+        Path::new(&target.name),
+        &target.directory.file,
+        Path::new(backup_name),
+        AtFlags::empty(),
+    ) {
+        Ok(()) => {
+            unlinkat(
+                &target.directory.file,
+                Path::new(&target.name),
+                UnlinkatFlags::NoRemoveDir,
+            )
+            .map_err(errno)?;
+            target.directory.file.sync_all()
+        }
+        Err(nix::errno::Errno::EEXIST | nix::errno::Errno::ENOENT) => Ok(()),
+        Err(error) => Err(errno(error)),
+    }
+}
+
+fn verify_launch_target(launch: &Path, recorded: &Path) -> io::Result<()> {
+    match resolve_launch_target(launch, false) {
+        Ok(current) if current == recorded => Ok(()),
+        Ok(_) => Err(invalid("launch config target changed")),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn resolve_launch_target(launch: &Path, require_present: bool) -> io::Result<PathBuf> {
+    let parent = launch
+        .parent()
+        .ok_or_else(|| invalid("launch config has no parent"))?;
+    let directory = Directory::pin(parent)?;
+    let name = launch
+        .file_name()
+        .ok_or_else(|| invalid("launch config has no name"))?;
+    match std::fs::canonicalize(launch) {
+        Ok(target) => normalize_absolute(&target),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            use nix::fcntl::{AtFlags, readlinkat};
+            use nix::sys::stat::{SFlag, fstatat};
+
+            match fstatat(
+                &directory.file,
+                Path::new(name),
+                AtFlags::AT_SYMLINK_NOFOLLOW,
+            ) {
+                Ok(stat)
+                    if SFlag::from_bits_truncate(stat.st_mode) & SFlag::S_IFMT
+                        == SFlag::S_IFLNK =>
+                {
+                    let link = readlinkat(&directory.file, Path::new(name)).map_err(errno)?;
+                    let target = if Path::new(&link).is_absolute() {
+                        PathBuf::from(link)
+                    } else {
+                        directory.real_path.join(link)
+                    };
+                    reject_ambiguous_terminal_path(&target)?;
+                    canonicalize_allow_missing(&target)
+                }
+                Ok(_) => Err(invalid("launch config target is not resolvable")),
+                Err(nix::errno::Errno::ENOENT) if !require_present => {
+                    Err(io::Error::from(io::ErrorKind::NotFound))
+                }
+                Err(nix::errno::Errno::ENOENT) => {
+                    Err(invalid("launch config is missing before confirmed apply"))
+                }
+                Err(error) => Err(errno(error)),
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn absolute_path(path: &Path) -> io::Result<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    reject_ambiguous_terminal_path(&absolute)?;
+    normalize_absolute(&absolute)
+}
+
+fn canonicalize_allow_missing(path: &Path) -> io::Result<PathBuf> {
+    let mut probe = path.to_path_buf();
+    let mut missing = Vec::new();
+    loop {
+        match std::fs::canonicalize(&probe) {
+            Ok(mut existing) => {
+                for component in missing.iter().rev() {
+                    existing.push(component);
+                }
+                return normalize_absolute(&existing);
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                missing.push(
+                    probe
+                        .file_name()
+                        .ok_or_else(|| invalid("dangling launch target has no ancestor"))?
+                        .to_os_string(),
+                );
+                if !probe.pop() {
+                    return Err(invalid("dangling launch target escapes root"));
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn reject_ambiguous_terminal_path(path: &Path) -> io::Result<()> {
+    let bytes = path.as_os_str().as_bytes();
+    if bytes.ends_with(b"/") || bytes.ends_with(b"/.") || bytes.ends_with(b"/..") {
+        return Err(invalid("pending path has no unambiguous final component"));
+    }
+    Ok(())
+}
+
+fn normalize_launch_path(path: &Path) -> io::Result<PathBuf> {
+    if has_parent_dir(path) {
+        return Err(invalid("launch config path contains ParentDir"));
+    }
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::Prefix(_) | Component::Normal(_) => {
+                out.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => unreachable!(),
+        }
+    }
+    Ok(out)
+}
+
+fn normalize_absolute(path: &Path) -> io::Result<PathBuf> {
+    if !path.is_absolute() {
+        return Err(invalid("path is not absolute"));
+    }
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::Prefix(_) | Component::Normal(_) => {
+                out.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !out.pop() {
+                    return Err(invalid("path escapes root"));
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn has_parent_dir(path: &Path) -> bool {
+    path.components()
+        .any(|component| component == Component::ParentDir)
+}
+
+fn append_name(name: &OsStr, suffix: &[u8]) -> io::Result<OsString> {
+    let mut bytes = name.as_bytes().to_vec();
+    bytes.extend_from_slice(suffix);
+    if bytes.contains(&0) || bytes.len() > MAX_PATH_BYTES {
+        return Err(invalid("pending basename exceeds its bound"));
+    }
+    Ok(OsString::from_vec(bytes))
+}
+
+fn path_to_wire(path: &Path) -> io::Result<LosslessPath> {
+    let bytes = path.as_os_str().as_bytes();
+    if !path.is_absolute() || bytes.len() > MAX_PATH_BYTES || bytes.contains(&0) {
+        return Err(invalid("pending path is not canonical"));
+    }
+    Ok(LosslessPath(bytes.to_vec()))
+}
+
+fn path_from_wire(path: &LosslessPath) -> io::Result<PathBuf> {
+    if path.0.len() > MAX_PATH_BYTES || path.0.contains(&0) {
+        return Err(invalid("encoded pending path is invalid"));
+    }
+    Ok(PathBuf::from(OsString::from_vec(path.0.clone())))
+}
+
+fn enforce_cap(name: &str, len: usize, cap: usize) -> io::Result<()> {
+    if len > cap {
+        return Err(limit(name, cap));
+    }
+    Ok(())
+}
+
+fn errno(error: nix::errno::Errno) -> io::Error {
+    io::Error::from_raw_os_error(error as i32)
+}
+
+fn invalid(error: impl std::fmt::Display) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, error.to_string())
+}
+
+fn limit(name: &str, bytes: usize) -> io::Error {
+    invalid(format!("{name} exceeds its {bytes}-byte limit"))
+}
+
+mod history_digest {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub(super) fn serialize<S: Serializer>(
+        digest: &[u8; 32],
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&super::history_v2::encode_hex(digest))
+    }
+
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<[u8; 32], D::Error> {
+        let value = String::deserialize(deserializer)?;
+        if value.len() != 64
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err(serde::de::Error::custom(
+                "digest must be 64 lowercase hexadecimal characters",
+            ));
+        }
+        let mut digest = [0u8; 32];
+        for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+            let digit = |byte| {
+                if byte <= b'9' {
+                    byte - b'0'
+                } else {
+                    byte - b'a' + 10
+                }
+            };
+            digest[index] = (digit(pair[0]) << 4) | digit(pair[1]);
+        }
+        Ok(digest)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt as _;
+
+    use super::*;
+    use crate::test_support::tier_authorized_uds_test_config;
+
+    fn private(path: &Path) {
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700)).unwrap();
+    }
+
+    fn config_toml(asn: u32) -> String {
+        tier_authorized_uds_test_config(&format!(
+            r#"
+[global]
+asn = {asn}
+router_id = "192.0.2.1"
+listen_port = 0
+[global.telemetry]
+log_format = "json"
+"#
+        ))
+    }
+
+    struct Fixture {
+        _root: tempfile::TempDir,
+        config: PathBuf,
+        state: PathBuf,
+        raw: PathBuf,
+        metadata: PathBuf,
+        launch: LaunchIdentity,
+        prior: Arc<AcceptedConfigSnapshot>,
+    }
+
+    fn fixture() -> Fixture {
+        let root = tempfile::tempdir().unwrap();
+        private(root.path());
+        let state = root.path().join("state");
+        fs::create_dir(&state).unwrap();
+        private(&state);
+        let config = root.path().join("rustbgpd.toml");
+        let parsed = Config::load_toml_with_diagnostics(&config_toml(64_512), "prior").unwrap();
+        let prior = AcceptedConfigSnapshot::from_config_for_test(parsed);
+        fs::write(&config, prior.normalized_toml()).unwrap();
+        let launch = LaunchIdentity::resolve(&config).unwrap();
+        Fixture {
+            raw: state.join(RAW_FILE_NAME),
+            metadata: state.join(METADATA_FILE_NAME),
+            _root: root,
+            config,
+            state,
+            launch,
+            prior,
+        }
+    }
+
+    #[test]
+    fn all_nine_publication_boundaries_precede_candidate_work() {
+        // Destructive proof: deleting any hook or reordering a layer makes its
+        // named failure unexpectedly succeed or leaves a lower object behind.
+        let steps = [
+            PublishStep::RawStageSync,
+            PublishStep::RawRename,
+            PublishStep::RawDirectorySync,
+            PublishStep::MetadataStageSync,
+            PublishStep::MetadataRename,
+            PublishStep::MetadataDirectorySync,
+            PublishStep::LocatorStageSync,
+            PublishStep::LocatorRename,
+            PublishStep::LocatorDirectorySync,
+        ];
+        for failed in steps {
+            let fixture = fixture();
+            let before = fs::read(&fixture.config).unwrap();
+            let error = fixture
+                .launch
+                .publish_with(&fixture.state, "deploy-1", 9, &fixture.prior, |step| {
+                    if step == failed {
+                        Err(io::Error::other("injected publish boundary"))
+                    } else {
+                        Ok(())
+                    }
+                })
+                .unwrap_err();
+            assert_eq!(fs::read(&fixture.config).unwrap(), before, "{failed:?}");
+            if failed == PublishStep::LocatorDirectorySync {
+                assert!(error.authority_retained());
+                assert!(fixture.launch.locator_path().exists());
+                assert!(fixture.raw.exists() && fixture.metadata.exists());
+            } else {
+                assert!(!error.authority_retained(), "{failed:?}");
+                assert!(!fixture.launch.locator_path().exists(), "{failed:?}");
+                assert!(!fixture.raw.exists(), "{failed:?}");
+                assert!(!fixture.metadata.exists(), "{failed:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn publication_cleanup_never_deletes_a_replacement() {
+        // Destructive proof: name-only cleanup removes `replacement` here.
+        let fixture = fixture();
+        let error = fixture
+            .launch
+            .publish_with(&fixture.state, "deploy-1", 9, &fixture.prior, |step| {
+                if step == PublishStep::RawDirectorySync {
+                    let displaced = fixture.state.join("displaced");
+                    fs::rename(&fixture.raw, &displaced)?;
+                    fs::write(&fixture.raw, b"replacement")?;
+                    fs::set_permissions(&fixture.raw, fs::Permissions::from_mode(0o600))?;
+                    return Err(io::Error::other("inject after replacement"));
+                }
+                Ok(())
+            })
+            .unwrap_err();
+        assert!(!error.authority_retained());
+        assert_eq!(fs::read(&fixture.raw).unwrap(), b"replacement");
+    }
+
+    #[test]
+    fn file_metadata_and_raw_caps_are_exact() {
+        // Destructive proof: changing `>` to `>=`, dropping owner/mode/type,
+        // or lifting the raw cap changes one of these exact boundary verdicts.
+        let owner = nix::unistd::geteuid().as_raw();
+        assert!(
+            validate_file_metadata_values(
+                true,
+                owner,
+                0o100_600,
+                MAX_RAW_BYTES as u64,
+                MAX_RAW_BYTES,
+                owner
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_file_metadata_values(
+                true,
+                owner,
+                0o100_600,
+                MAX_RAW_BYTES as u64 + 1,
+                MAX_RAW_BYTES,
+                owner,
+            )
+            .is_err()
+        );
+        assert!(validate_file_metadata_values(false, owner, 0o100_600, 1, 1, owner).is_err());
+        assert!(validate_file_metadata_values(true, owner + 1, 0o100_600, 1, 1, owner).is_err());
+        assert!(validate_file_metadata_values(true, owner, 0o100_640, 1, 1, owner).is_err());
+    }
+
+    #[test]
+    fn every_corrupt_or_unsafe_layer_fails_before_candidate_access() {
+        // Destructive proof: weakening mode, length, identity, digest, or
+        // linkage validation lets the candidate move into `.unconfirmed`.
+        for mutation in [
+            "raw_mode",
+            "raw_truncate",
+            "raw_growth",
+            "raw_digest",
+            "raw_special",
+            "metadata_identity",
+            "metadata_provenance",
+            "metadata_corrupt",
+            "locator_linkage",
+        ] {
+            let fixture = fixture();
+            fixture
+                .launch
+                .publish(&fixture.state, "deploy-1", 9, &fixture.prior)
+                .unwrap();
+            let candidate = b"unconfirmed candidate";
+            fs::write(&fixture.config, candidate).unwrap();
+            match mutation {
+                "raw_mode" => {
+                    fs::set_permissions(&fixture.raw, fs::Permissions::from_mode(0o640)).unwrap();
+                }
+                "raw_truncate" => {
+                    let bytes = fs::read(&fixture.raw).unwrap();
+                    fs::write(&fixture.raw, &bytes[..bytes.len() - 1]).unwrap();
+                }
+                "raw_growth" => fs::OpenOptions::new()
+                    .append(true)
+                    .open(&fixture.raw)
+                    .unwrap()
+                    .write_all(b"x")
+                    .unwrap(),
+                "raw_digest" => {
+                    let mut bytes = fs::read(&fixture.raw).unwrap();
+                    bytes[0] ^= 1;
+                    fs::write(&fixture.raw, bytes).unwrap();
+                }
+                "raw_special" => {
+                    fs::remove_file(&fixture.raw).unwrap();
+                    fs::create_dir(&fixture.raw).unwrap();
+                }
+                "metadata_identity" => {
+                    let mut wire = decode_metadata(&fs::read(&fixture.metadata).unwrap()).unwrap();
+                    wire.raw_inode = wire.raw_inode.wrapping_add(1);
+                    fs::write(&fixture.metadata, encode_metadata(&wire).unwrap()).unwrap();
+                }
+                "metadata_provenance" => {
+                    let mut wire = decode_metadata(&fs::read(&fixture.metadata).unwrap()).unwrap();
+                    wire.raw_source_sha256[0] ^= 1;
+                    fs::write(&fixture.metadata, serde_json::to_vec(&wire).unwrap()).unwrap();
+                }
+                "metadata_corrupt" => fs::write(&fixture.metadata, b"{\"version\":3,").unwrap(),
+                "locator_linkage" => {
+                    let path = fixture.launch.locator_path();
+                    let mut wire = decode_locator(&fs::read(&path).unwrap()).unwrap();
+                    wire.confirm_id = "other".to_string();
+                    fs::write(path, encode_locator(&wire).unwrap()).unwrap();
+                }
+                _ => unreachable!(),
+            }
+            assert!(fixture.launch.boot_revert_check().is_err(), "{mutation}");
+            assert_eq!(fs::read(&fixture.config).unwrap(), candidate, "{mutation}");
+            assert!(!fixture.config.with_extension("toml.unconfirmed").exists());
+        }
+    }
+
+    #[test]
+    fn rollback_failed_replaces_only_metadata_and_boot_restores() {
+        // Destructive proof: embedding the bit in raw or binding metadata
+        // identity in the locator changes the asserted inode/bytes or fails boot.
+        let fixture = fixture();
+        let files = fixture
+            .launch
+            .publish(&fixture.state, "deploy-1", 9, &fixture.prior)
+            .unwrap();
+        let raw_before = fs::read(&fixture.raw).unwrap();
+        let raw_identity = FileIdentity::from_metadata(&fs::metadata(&fixture.raw).unwrap());
+        let metadata_identity =
+            FileIdentity::from_metadata(&fs::metadata(&fixture.metadata).unwrap());
+        files.record_rollback_failed().unwrap();
+        assert_eq!(fs::read(&fixture.raw).unwrap(), raw_before);
+        assert_eq!(
+            FileIdentity::from_metadata(&fs::metadata(&fixture.raw).unwrap()),
+            raw_identity
+        );
+        assert_ne!(
+            FileIdentity::from_metadata(&fs::metadata(&fixture.metadata).unwrap()),
+            metadata_identity
+        );
+        fs::write(&fixture.config, b"candidate").unwrap();
+        let reverted = fixture.launch.boot_revert_check().unwrap().unwrap();
+        assert!(reverted.notice.rollback_failed);
+        assert_eq!(
+            reverted.accepted.normalized_toml(),
+            fixture.prior.normalized_toml()
+        );
+    }
+
+    #[test]
+    fn restart_states_are_idempotent_and_locator_absence_never_rearms() {
+        // Candidate hard-link/unlink completed, restore not yet started.
+        let save_crash = fixture();
+        save_crash
+            .launch
+            .publish(&save_crash.state, "save-crash", 9, &save_crash.prior)
+            .unwrap();
+        fs::write(&save_crash.config, b"candidate-one").unwrap();
+        assert!(
+            save_crash
+                .launch
+                .boot_revert_check_io_with(|step| {
+                    if step == BootStep::ConfigRestore {
+                        Err(io::Error::other("crash before restore"))
+                    } else {
+                        Ok(())
+                    }
+                })
+                .is_err()
+        );
+        assert!(!save_crash.config.exists());
+        assert!(
+            save_crash
+                .config
+                .with_extension("toml.unconfirmed")
+                .exists()
+        );
+        assert!(save_crash.launch.boot_revert_check().unwrap().is_some());
+        assert!(save_crash.launch.boot_revert_check().unwrap().is_none());
+
+        // Restore landed but locator unlink did not: next boot safely repeats.
+        let restore_crash = fixture();
+        restore_crash
+            .launch
+            .publish(
+                &restore_crash.state,
+                "restore-crash",
+                9,
+                &restore_crash.prior,
+            )
+            .unwrap();
+        fs::write(&restore_crash.config, b"candidate-two").unwrap();
+        assert!(
+            restore_crash
+                .launch
+                .boot_revert_check_io_with(|step| {
+                    if step == BootStep::LocatorUnlink {
+                        Err(io::Error::other("crash before locator unlink"))
+                    } else {
+                        Ok(())
+                    }
+                })
+                .is_err()
+        );
+        assert!(restore_crash.launch.locator_path().exists());
+        assert!(restore_crash.launch.boot_revert_check().unwrap().is_some());
+
+        // Locator unlink landed but its directory sync did not. Both crash
+        // outcomes are safe: if absent, residue is ignored and never re-arms.
+        let unlink_crash = fixture();
+        unlink_crash
+            .launch
+            .publish(&unlink_crash.state, "unlink-crash", 9, &unlink_crash.prior)
+            .unwrap();
+        fs::write(&unlink_crash.config, b"candidate-three").unwrap();
+        assert!(
+            unlink_crash
+                .launch
+                .boot_revert_check_io_with(|step| {
+                    if step == BootStep::LocatorDirectorySync {
+                        Err(io::Error::other("crash after locator unlink"))
+                    } else {
+                        Ok(())
+                    }
+                })
+                .is_err()
+        );
+        assert!(!unlink_crash.launch.locator_path().exists());
+        assert!(unlink_crash.raw.exists() && unlink_crash.metadata.exists());
+        assert!(unlink_crash.launch.boot_revert_check().unwrap().is_none());
+        assert!(unlink_crash.raw.exists() && unlink_crash.metadata.exists());
+    }
+
+    #[test]
+    fn v3_dispatch_preserves_frozen_v1_and_v2_authority() {
+        // V1 bytes remain untouched without a locator.
+        let v1_fixture = fixture();
+        let legacy = v1_fixture
+            .state
+            .join(crate::confirm_journal::JOURNAL_FILE_NAME);
+        fs::write(
+            &legacy,
+            b"{\"confirm_id\":\"v1\",\"deadline_unix_seconds\":9,\"rollback_toml\":\"x\"}",
+        )
+        .unwrap();
+        assert!(v1_fixture.launch.boot_revert_check().unwrap().is_none());
+        assert!(legacy.exists());
+
+        // A canonical v2 locator is handed to the frozen v2 reader unchanged.
+        let v2_fixture = fixture();
+        let v2_journal = v2_fixture
+            .state
+            .join(crate::confirm_journal::JOURNAL_FILE_NAME);
+        let v2 = crate::confirm_journal::v2::LaunchIdentity::resolve(&v2_fixture.config).unwrap();
+        v2.publish(&v2_journal, "v2", 9, &v2_fixture.prior).unwrap();
+        assert!(v2_fixture.launch.boot_revert_check().unwrap().is_none());
+        fs::write(&v2_fixture.config, b"v2 candidate").unwrap();
+        assert!(v2.boot_revert_check().unwrap().is_some());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2519,48 +2519,72 @@ fn main() -> ExitCode {
         process::exit(1);
     }
 
-    // The v2 locator is config-adjacent and must be resolved before a real
+    // The v2/v3 locator is config-adjacent and must be resolved before a real
     // daemon boot opens, sizes, or parses the candidate.  One-shot validation
     // and diff modes remain read-only and therefore do not inspect or consume
     // pending commit-confirm state.
-    let launch_identity = if !check_only && diff_path.is_none() {
-        Some(
-            confirm_journal::v2::LaunchIdentity::resolve(Path::new(&config_path)).unwrap_or_else(
-                |error| {
-                    eprintln!(
-                        "error: invalid launch config identity for commit-confirm authority: {error}"
-                    );
-                    process::exit(1);
-                },
-            ),
-        )
+    let launch_identities = if !check_only && diff_path.is_none() {
+        let v2 = confirm_journal::v2::LaunchIdentity::resolve(Path::new(&config_path))
+            .unwrap_or_else(|error| {
+                eprintln!(
+                    "error: invalid launch config identity for commit-confirm authority: {error}"
+                );
+                process::exit(1);
+            });
+        let v3 = confirm_journal::v3::LaunchIdentity::resolve(Path::new(&config_path))
+            .unwrap_or_else(|error| {
+                eprintln!(
+                    "error: invalid launch config identity for commit-confirm authority: {error}"
+                );
+                process::exit(1);
+            });
+        Some((v2, v3))
     } else {
         None
     };
     let mut boot_revert_notice = None;
-    let mut accepted = if let Some(identity) = &launch_identity {
-        match identity.boot_revert_check() {
+    let mut accepted = if let Some((v2_identity, v3_identity)) = &launch_identities {
+        match v3_identity.boot_revert_check() {
             Ok(Some(revert)) => {
                 boot_revert_notice = Some(confirm_journal::BootRevertNotice {
                     confirm_id: revert.notice.confirm_id,
                     backup_path: PathBuf::new(),
                     rollback_failed: revert.notice.rollback_failed,
                     redact_paths: true,
-                    journal_cleanup_failed: revert.notice.journal_cleanup_failed,
+                    journal_cleanup_failed: revert.notice.residue_cleanup_failed,
                 });
                 revert.accepted
             }
-            Ok(None) => match AcceptedConfigSnapshot::load(Path::new(&config_path), None) {
-                Ok(snapshot) => Arc::new(snapshot),
-                Err(diagnostic) => {
-                    eprintln!("{diagnostic}");
+            Ok(None) => match v2_identity.boot_revert_check() {
+                Ok(Some(revert)) => {
+                    boot_revert_notice = Some(confirm_journal::BootRevertNotice {
+                        confirm_id: revert.notice.confirm_id,
+                        backup_path: PathBuf::new(),
+                        rollback_failed: revert.notice.rollback_failed,
+                        redact_paths: true,
+                        journal_cleanup_failed: revert.notice.journal_cleanup_failed,
+                    });
+                    revert.accepted
+                }
+                Ok(None) => match AcceptedConfigSnapshot::load(Path::new(&config_path), None) {
+                    Ok(snapshot) => Arc::new(snapshot),
+                    Err(diagnostic) => {
+                        eprintln!("{diagnostic}");
+                        process::exit(1);
+                    }
+                },
+                Err(message) => {
+                    eprintln!(
+                        "error: {message}; locator: {}",
+                        v2_identity.locator_path().display()
+                    );
                     process::exit(1);
                 }
             },
             Err(message) => {
                 eprintln!(
                     "error: {message}; locator: {}",
-                    identity.locator_path().display()
+                    v3_identity.locator_path().display()
                 );
                 process::exit(1);
             }
@@ -2702,7 +2726,9 @@ fn main() -> ExitCode {
     let grpc_server_failed = rt.block_on(run(
         accepted,
         boot_revert_notice,
-        launch_identity.expect("daemon boot resolved launch config identity"),
+        launch_identities
+            .expect("daemon boot resolved launch config identity")
+            .1,
         profiler,
     ));
     shutdown_daemon_runtime(rt);
@@ -2923,7 +2949,7 @@ fn resolve_rib_channel_capacity_from(env: Option<&str>) -> usize {
 async fn run<T>(
     accepted: Arc<AcceptedConfigSnapshot>,
     boot_revert_notice: Option<confirm_journal::BootRevertNotice>,
-    launch_identity: confirm_journal::v2::LaunchIdentity,
+    launch_identity: confirm_journal::v3::LaunchIdentity,
     profiler: Option<T>,
 ) -> bool {
     let mut config = accepted.config();
@@ -3212,12 +3238,12 @@ async fn run<T>(
         }
         if notice.journal_cleanup_failed {
             warn!(
-                "commit-confirm boot revert reached durable terminal locator removal, but exact journal residue cleanup failed"
+                "commit-confirm boot revert reached durable terminal locator removal, but exact pending residue cleanup failed"
             );
         }
         // A `BootRevertNotice` exists only after the revert is terminal. V1
-        // still requires journal consumption; v2 becomes terminal at durable
-        // locator absence and reports later journal cleanup as a warning.
+        // still requires journal consumption; v2/v3 become terminal at durable
+        // locator absence and report later pending cleanup as a warning.
         metrics.record_config_transaction_lifecycle("boot_revert", "success");
     }
     let router_id: Ipv4Addr = config.global.router_id.parse().unwrap_or_else(|e| {
@@ -4396,7 +4422,7 @@ async fn run<T>(
                 .clone(),
         )
         .with_preloaded_planner(peer_mgr_internal_tx.clone())
-        .with_confirm_v2_launch(launch_identity);
+        .with_confirm_v3_launch(launch_identity);
     // Process-wide availability gate (LAN-286): BGP-listener bind failure
     // turns readiness red; coordinated shutdown turns readiness red AND
     // stops admitting persisted config mutations and inbound BGP sessions.

--- a/tests/commit_confirm_binary.rs
+++ b/tests/commit_confirm_binary.rs
@@ -4,18 +4,21 @@
 //! default runtime-dir UDS listener, then SIGKILLs the daemon to prove the
 //! boot-time revert journal closes the "confirmed-by-restart" hole:
 //!
-//! - unconfirmed window + SIGKILL → restart follows the config-adjacent v2
+//! - unconfirmed window + SIGKILL → restart follows the config-adjacent v3
 //!   locator, boots the PREVIOUS config, saves the unconfirmed candidate aside,
-//!   consumes both pending files, and prints a path-redacted loud banner;
-//! - confirm + SIGKILL → the new config is retained and no v2 pending files
+//!   consumes the fixed pending files, and prints a path-redacted loud banner;
+//! - confirm + SIGKILL → the new config is retained and no v3 pending files
 //!   remain;
-//! - in-process timeout auto-revert → both v2 pending files are consumed;
+//! - in-process timeout auto-revert → all v3 pending files are consumed;
+//! - an upgrade with v2 authority pending → startup dispatches v2 before
+//!   loading the unconfirmed candidate;
 //! - v2 history survives restart and restores only after source verification
 //!   is available;
 //! - a torn legacy journal with no v2 locator → boot still refuses, naming
 //!   both legacy files.
 
 use std::fs::File;
+use std::os::unix::ffi::OsStrExt as _;
 use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
@@ -24,6 +27,8 @@ use std::time::{Duration, Instant};
 
 const JOURNAL_FILE_NAME: &str = "commit-confirm-journal.json";
 const LOCATOR_SUFFIX: &str = ".commit-confirm-locator.json";
+const V3_RAW_FILE_NAME: &str = "commit-confirm-v3-prior.toml";
+const V3_METADATA_FILE_NAME: &str = "commit-confirm-v3-metadata.json";
 
 struct Daemon {
     child: Child,
@@ -132,6 +137,8 @@ struct Lab {
     config_path: PathBuf,
     candidate_path: PathBuf,
     journal_path: PathBuf,
+    raw_path: PathBuf,
+    metadata_path: PathBuf,
     locator_path: PathBuf,
     grpc_addr: String,
     dir: PathBuf,
@@ -176,7 +183,7 @@ remote_asn = 65010
 /// Set up config + candidate files in `dir` and return the paths.
 fn lab(dir: &Path) -> Lab {
     // Causal destructive-red proof: removing either privacy clamp makes the
-    // real v2 publisher reject the locator or journal parent before candidate
+    // real v3 publisher reject the locator or pending parent before candidate
     // persistence, so every confirmed-apply scenario fails at `apply`.
     std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
         .expect("failed to make config parent owner-only");
@@ -215,21 +222,82 @@ fn lab(dir: &Path) -> Lab {
         config_path,
         candidate_path,
         journal_path: runtime_dir.join(JOURNAL_FILE_NAME),
+        raw_path: runtime_dir.join(V3_RAW_FILE_NAME),
+        metadata_path: runtime_dir.join(V3_METADATA_FILE_NAME),
         locator_path,
         grpc_addr: format!("unix://{}", runtime_dir.join("grpc.sock").display()),
         dir: dir.to_path_buf(),
     }
 }
 
-fn large_candidate_lab(dir: &Path) -> Lab {
+fn large_prior_lab(dir: &Path) -> Lab {
     let lab = lab(dir);
-    let candidate = format!(
-        "{}\n# {}",
-        std::fs::read_to_string(&lab.candidate_path).unwrap(),
-        "x".repeat(8 * 1024 * 1024 + 1)
-    );
+    let mut members = String::new();
+    for index in 1..=320 {
+        use std::fmt::Write as _;
+        writeln!(
+            members,
+            r#"
+[[neighbors]]
+address = "2001:db8::{index:x}"
+remote_asn = 65010
+peer_group = "ix-members"
+description = {:?}
+"#,
+            "member-shape-".repeat(2_700)
+        )
+        .unwrap();
+    }
+    let runtime_dir = lab
+        .journal_path
+        .parent()
+        .expect("journal has runtime parent");
+    let prior = base_toml(runtime_dir, &members);
+    let candidate = base_toml(runtime_dir, &format!("{members}\n{DYNAMIC_NEIGHBOR_EXTRA}"));
+    assert!(prior.len() > 10 * 1024 * 1024);
+    std::fs::write(&lab.config_path, prior).expect("failed to write large normalized prior input");
     std::fs::write(&lab.candidate_path, candidate).expect("failed to write large candidate");
     lab
+}
+
+fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut out, byte| {
+            write!(out, "{byte:02x}").unwrap();
+            out
+        })
+}
+
+fn write_v2_pending_authority(lab: &Lab, envelope: &serde_json::Value, confirm_id: &str) {
+    let prior = envelope["normalized_toml"].as_str().unwrap();
+    let prior_hex = envelope["sha256"].as_str().unwrap();
+    let source_hex = envelope["source_sha256"].as_str().unwrap();
+    let manifest = &envelope["manifest"];
+    assert_eq!(manifest["toml_sha256"], prior_hex);
+    assert_eq!(manifest["rpol_units"].as_array().map(Vec::len), Some(0));
+    assert_eq!(manifest["datasets"].as_array().map(Vec::len), Some(0));
+    let prior_json = serde_json::to_string(prior).unwrap();
+    let journal = format!(
+        "{{\"version\":2,\"confirm_id\":{confirm_id:?},\"deadline_unix_seconds\":9,\"rollback_failed\":false,\"prior\":{{\"sha256\":\"{prior_hex}\",\"source_sha256\":\"{source_hex}\",\"normalized_toml\":{prior_json},\"manifest\":{{\"toml_sha256\":\"{prior_hex}\",\"rpol_units\":[],\"datasets\":[]}}}}}}\n"
+    );
+    let path_wire = |path: &Path| {
+        format!(
+            "{{\"encoding\":\"unix-bytes-hex\",\"value\":\"{}\"}}",
+            hex(path.as_os_str().as_bytes())
+        )
+    };
+    let locator = format!(
+        "{{\"version\":2,\"confirm_id\":{confirm_id:?},\"journal_path\":{},\"config_target\":{},\"prior_sha256\":\"{prior_hex}\",\"prior_source_sha256\":\"{source_hex}\"}}\n",
+        path_wire(&lab.journal_path),
+        path_wire(&lab.config_path),
+    );
+    std::fs::write(&lab.journal_path, journal).unwrap();
+    std::fs::set_permissions(&lab.journal_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    std::fs::write(&lab.locator_path, locator).unwrap();
+    std::fs::set_permissions(&lab.locator_path, std::fs::Permissions::from_mode(0o600)).unwrap();
 }
 
 impl Lab {
@@ -237,6 +305,44 @@ impl Lab {
         let mut daemon = Daemon::spawn(&self.config_path, self.dir.join(stderr_name));
         wait_until_serving(&self.grpc_addr, &mut daemon);
         daemon
+    }
+
+    fn assert_no_v3_authority(&self, context: &str) {
+        assert!(!self.locator_path.exists(), "{context}: locator remains");
+        assert!(!self.raw_path.exists(), "{context}: raw prior remains");
+        assert!(!self.metadata_path.exists(), "{context}: metadata remains");
+    }
+
+    fn apply_plain(&self, candidate: &Path) {
+        let plan = rbgp_json(
+            &self.grpc_addr,
+            &[
+                "--json",
+                "config",
+                "plan",
+                "--from-file",
+                candidate.to_str().unwrap(),
+            ],
+        );
+        let token = plan["runtime_snapshot_token"].as_str().unwrap();
+        let output = rbgp(
+            &self.grpc_addr,
+            &[
+                "--json",
+                "config",
+                "apply",
+                "--from-file",
+                candidate.to_str().unwrap(),
+                "--expected-runtime-snapshot-token",
+                token,
+            ],
+        );
+        assert!(
+            output.status.success(),
+            "plain apply failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     /// Plan + confirmed-apply the dynamic-neighbor candidate; asserts the
@@ -264,7 +370,7 @@ impl Lab {
             .as_str()
             .expect("plan must return a runtime snapshot token");
 
-        let apply = rbgp_json(
+        let apply_output = rbgp(
             &self.grpc_addr,
             &[
                 "--json",
@@ -280,6 +386,21 @@ impl Lab {
                 timeout_seconds,
             ],
         );
+        assert!(
+            apply_output.status.success(),
+            "confirmed apply failed\nstdout:\n{}\nstderr:\n{}\ndaemon logs:\n{}",
+            String::from_utf8_lossy(&apply_output.stdout),
+            String::from_utf8_lossy(&apply_output.stderr),
+            std::fs::read_dir(&self.dir)
+                .unwrap()
+                .filter_map(Result::ok)
+                .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "log"))
+                .filter_map(|entry| std::fs::read_to_string(entry.path()).ok())
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        let apply: serde_json::Value =
+            serde_json::from_slice(&apply_output.stdout).expect("apply output must be JSON");
         assert_eq!(apply["status"], "committable", "apply: {apply}");
         assert_eq!(apply["confirmation"]["status"], "pending", "apply: {apply}");
 
@@ -291,22 +412,24 @@ impl Lab {
             "commit must persist the candidate:\n{on_disk}"
         );
         assert!(
-            self.journal_path.exists(),
-            "confirmed apply must write the v2 revert journal"
+            !self.journal_path.exists(),
+            "v3 must not reuse the legacy path"
         );
         assert!(
             self.locator_path.exists(),
-            "confirmed apply must publish the v2 locator last"
+            "confirmed apply must publish the v3 locator last"
         );
-        let journal = std::fs::read(&self.journal_path).unwrap();
+        let raw = std::fs::read(&self.raw_path).unwrap();
+        let metadata = std::fs::read(&self.metadata_path).unwrap();
         let locator = std::fs::read(&self.locator_path).unwrap();
+        assert!(!raw.is_empty(), "real-binary writer must publish the prior");
         assert!(
-            journal.starts_with(b"{\"version\":2,"),
-            "real-binary writer must emit only the canonical v2 journal"
+            metadata.starts_with(b"{\"version\":3,"),
+            "real-binary writer must emit canonical v3 metadata"
         );
         assert!(
-            locator.starts_with(b"{\"version\":2,"),
-            "real-binary writer must emit the canonical v2 locator"
+            locator.starts_with(b"{\"version\":3,"),
+            "real-binary writer must emit the canonical v3 locator"
         );
     }
 }
@@ -314,7 +437,7 @@ impl Lab {
 #[test]
 fn streamed_confirmed_apply_above_eight_mib_aborts_to_previous_config() {
     let temp = tempfile::tempdir().expect("failed to create temp dir");
-    let lab = large_candidate_lab(temp.path());
+    let lab = large_prior_lab(temp.path());
     // Load-bearing streamed-path proof: this candidate cannot traverse the
     // legacy unary RPC's four-MiB decoder. Reverting either CLI streaming call
     // site makes the confirmed apply fail before commit.
@@ -324,6 +447,13 @@ fn streamed_confirmed_apply_above_eight_mib_aborts_to_previous_config() {
     );
 
     let mut daemon = lab.spawn("daemon.stderr.log");
+    assert_eq!(
+        rbgp_json(&lab.grpc_addr, &["--json", "config", "history"])["entries"]
+            .as_array()
+            .map(Vec::len),
+        Some(0),
+        "oversize boot snapshot must explicitly leave bounded history empty"
+    );
     let human_plan = rbgp(
         &lab.grpc_addr,
         &[
@@ -341,26 +471,77 @@ fn streamed_confirmed_apply_above_eight_mib_aborts_to_previous_config() {
         .expect("streamed plan human output must expose its single-use plan token");
     assert!(!exposed_token.is_empty());
     lab.apply_confirmed("stream-abort", "600");
+    assert!(
+        std::fs::metadata(&lab.raw_path).unwrap().len() > 10 * 1024 * 1024,
+        "real-binary writer must publish a genuinely normalized prior above 10 MiB"
+    );
     let abort = rbgp_json(
         &lab.grpc_addr,
         &["--json", "config", "abort", "stream-abort"],
     );
     assert_eq!(abort["confirmation"]["status"], "aborted", "{abort}");
+    assert_eq!(
+        rbgp_json(&lab.grpc_addr, &["--json", "config", "history"])["entries"]
+            .as_array()
+            .map(Vec::len),
+        Some(0),
+        "oversize candidate and rollback must leave history unchanged"
+    );
     let persisted = std::fs::read_to_string(&lab.config_path).unwrap();
     assert!(
         !persisted.contains("192.0.2.0/24"),
         "abort must restore the pre-transaction config"
     );
-    assert!(
-        !lab.journal_path.exists() && !lab.locator_path.exists(),
-        "abort must consume journal and locator authority"
-    );
+    lab.assert_no_v3_authority("abort must consume v3 authority");
     let ranges = rbgp_json(&lab.grpc_addr, &["--json", "dynamic-neighbor", "list"]);
     assert_eq!(
         ranges.as_array().map(Vec::len),
         Some(0),
         "aborted daemon must run the previous config: {ranges}"
     );
+    daemon.assert_still_running();
+}
+
+#[test]
+fn unsafe_fixed_raw_slot_refuses_before_real_binary_apply() {
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let lab = lab(temp.path());
+    let previous = std::fs::read(&lab.config_path).unwrap();
+    let mut daemon = lab.spawn("daemon.stderr.log");
+    let plan = rbgp_json(
+        &lab.grpc_addr,
+        &[
+            "--json",
+            "config",
+            "plan",
+            "--from-file",
+            lab.candidate_path.to_str().unwrap(),
+        ],
+    );
+    let token = plan["runtime_snapshot_token"].as_str().unwrap();
+    std::fs::create_dir(&lab.raw_path).unwrap();
+    let apply = rbgp(
+        &lab.grpc_addr,
+        &[
+            "--json",
+            "config",
+            "apply",
+            "--from-file",
+            lab.candidate_path.to_str().unwrap(),
+            "--expected-runtime-snapshot-token",
+            token,
+            "--confirm-id",
+            "unsafe-raw",
+            "--confirm-timeout",
+            "60",
+        ],
+    );
+    assert!(!apply.status.success());
+    assert_eq!(std::fs::read(&lab.config_path).unwrap(), previous);
+    assert!(lab.raw_path.is_dir(), "unsafe replacement must survive");
+    assert!(!lab.locator_path.exists() && !lab.metadata_path.exists());
+    let ranges = rbgp_json(&lab.grpc_addr, &["--json", "dynamic-neighbor", "list"]);
+    assert_eq!(ranges.as_array().map(Vec::len), Some(0));
     daemon.assert_still_running();
 }
 
@@ -388,14 +569,7 @@ fn sigkill_in_confirm_window_boots_previous_config_and_saves_candidate_aside() {
         saved_aside.contains("192.0.2.0/24"),
         "saved-aside file must hold the unconfirmed candidate:\n{saved_aside}"
     );
-    assert!(
-        !lab.journal_path.exists(),
-        "boot revert must consume the journal"
-    );
-    assert!(
-        !lab.locator_path.exists(),
-        "boot revert must durably remove locator authority first"
-    );
+    lab.assert_no_v3_authority("boot revert must consume v3 authority");
     let stderr = daemon.stderr();
     assert!(
         stderr.contains("commit-confirm boot revert")
@@ -407,10 +581,12 @@ fn sigkill_in_confirm_window_boots_previous_config_and_saves_candidate_aside() {
         backup_path.to_string_lossy().as_ref(),
         lab.config_path.to_string_lossy().as_ref(),
         lab.journal_path.to_string_lossy().as_ref(),
+        lab.raw_path.to_string_lossy().as_ref(),
+        lab.metadata_path.to_string_lossy().as_ref(),
     ] {
         assert!(
             !stderr.contains(secret),
-            "v2 boot banner must redact persisted path {secret:?}:\n{stderr}"
+            "v3 boot banner must redact persisted path {secret:?}:\n{stderr}"
         );
     }
 
@@ -436,14 +612,7 @@ fn confirm_then_sigkill_retains_new_config_and_leaves_no_journal() {
         &["--json", "config", "confirm", "kill-confirmed"],
     );
     assert_eq!(confirm["confirmation"]["status"], "confirmed", "{confirm}");
-    assert!(
-        !lab.journal_path.exists(),
-        "confirm must consume the revert journal"
-    );
-    assert!(
-        !lab.locator_path.exists(),
-        "confirm must durably remove locator authority"
-    );
+    lab.assert_no_v3_authority("confirm must consume v3 authority");
     daemon.sigkill();
 
     let mut daemon = lab.spawn("second.stderr.log");
@@ -488,19 +657,53 @@ fn in_process_timeout_auto_revert_consumes_journal() {
         thread::sleep(Duration::from_millis(200));
     }
 
-    assert!(
-        !lab.journal_path.exists(),
-        "timeout auto-revert must consume the revert journal"
-    );
-    assert!(
-        !lab.locator_path.exists(),
-        "timeout auto-revert must durably remove locator authority"
-    );
+    lab.assert_no_v3_authority("timeout auto-revert must consume v3 authority");
     let on_disk = std::fs::read_to_string(&lab.config_path).unwrap();
     assert!(
         !on_disk.contains("192.0.2.0/24"),
         "auto-revert must restore the pre-transaction config:\n{on_disk}"
     );
+    daemon.assert_still_running();
+}
+
+#[test]
+fn real_binary_boot_dispatches_v2_authority_before_candidate_load() {
+    // Destructive proof: deleting or reordering main's v3-then-v2 fallback
+    // boots the dynamic-neighbor candidate instead of restoring this prior.
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let lab = lab(temp.path());
+    let daemon = lab.spawn("prior.stderr.log");
+    let effective = rbgp(&lab.grpc_addr, &["config", "effective"]);
+    assert!(effective.status.success());
+    let prior_path = lab.dir.join("normalized-prior.toml");
+    std::fs::write(&prior_path, effective.stdout).unwrap();
+    lab.apply_plain(&lab.candidate_path);
+    lab.apply_plain(&prior_path);
+    let history_dir = lab.journal_path.parent().unwrap().join("config-history");
+    let latest = std::fs::read_dir(&history_dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with("v2-"))
+        .max_by_key(|entry| entry.file_name())
+        .unwrap();
+    let envelope: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(latest.path()).unwrap()).unwrap();
+    daemon.sigkill();
+
+    std::fs::copy(&lab.candidate_path, &lab.config_path).unwrap();
+    write_v2_pending_authority(&lab, &envelope, "upgrade-v2");
+    let mut daemon = lab.spawn("revert.stderr.log");
+    assert!(!lab.locator_path.exists() && !lab.journal_path.exists());
+    assert!(
+        !std::fs::read_to_string(&lab.config_path)
+            .unwrap()
+            .contains("192.0.2.0/24")
+    );
+    let backup = std::fs::read_to_string(lab.dir.join("rustbgpd.toml.unconfirmed")).unwrap();
+    assert!(backup.contains("192.0.2.0/24"));
+    let ranges = rbgp_json(&lab.grpc_addr, &["--json", "dynamic-neighbor", "list"]);
+    assert_eq!(ranges.as_array().map(Vec::len), Some(0));
+    assert!(daemon.stderr().contains("upgrade-v2"));
     daemon.assert_still_running();
 }
 


### PR DESCRIPTION
## Summary

- publish large normalized rollback priors as bounded 0600 raw, metadata, and config-adjacent locator objects with locator-only authority
- keep live commit-confirm state on the accepted snapshot without a duplicate full TOML string, while preserving frozen v1/v2 recovery
- make oversized config-history writes explicitly skip without mutating the retained roster

## Safety model

Raw data and metadata are fully validated before candidate access. Publication is raw then metadata then locator, with file and directory durability at every layer. Confirm, abort, timeout, and boot recovery remove and sync locator authority before best-effort exact-identity residue cleanup. Uncertain post-locator publication arms the existing mutation fence.

## Verification

- cargo fmt --all -- --check
- python3 scripts/check-clippy-reasons.py
- cargo clippy --locked --workspace --all-targets -- -D warnings
- cargo test --locked --workspace
- cargo doc --locked --workspace --no-deps
- 8/8 real-binary commit-confirm scenarios, including a normalized prior above 10 MiB and v2 pending-authority upgrade recovery
- independent crash-consistency and integration reviews: clean

## Load-bearing proofs

- removing a publication durability boundary makes the nine-boundary matrix fail
- restoring the duplicate rollback TOML allocation makes the v3 pending-state test fail
- bypassing the production v2 boot fallback makes the real-binary upgrade test adopt the unconfirmed candidate and leave authority behind
- unsafe fixed-slot, corruption, identity, digest, provenance, and controller non-apply failures each have explicit red assertions