### PR TITLE
bench: measure full-scale config transaction lifecycles

### DIFF
--- a/bench/scale/irrreload/README.md
+++ b/bench/scale/irrreload/README.md
@@ -2,9 +2,9 @@
 
 Reload stall + completion under live sessions with a realistic multi-MB
 IRR-generated member policy. The full-shape comparison covers rustbgpd's
-SIGHUP parse-then-swap path versus BIRD 3.3.x and OpenBGPD 9.x. The gRPC
-transactional path is a separate, explicitly smaller receipt because its
-single-message candidate cannot carry the full dataset.
+SIGHUP parse-then-swap path versus BIRD 3.3.x and OpenBGPD 9.x. The streamed
+gRPC transactional path runs the same canonical shape as a separate two-root
+receipt; its rows never enter the cross-daemon comparison.
 
 This directory is the campaign runner and protocol. The instrument is the
 existing `bench/scale/reloadstall` harness — real BGP stub
@@ -29,11 +29,11 @@ policy generations:
 
 ## Shape (a harness parameter, stated exactly)
 
-| Parameter | Smoke (`SMOKE=1`) | Full cross-daemon | Bounded transaction |
+| Parameter | Smoke (`SMOKE=1`) | Full cross-daemon | Full transaction |
 |---|---|---|---|
-| Members (`N_MEMBERS`) | 10 | 320 | 10 |
-| Announced base table (`TOTAL_PREFIXES`) | 100 | 183,040 (572/member) | 5,720 (572/member) |
-| Per-member IRR filter list (`MIN_LIST`–`MAX_LIST`) | 100 | log-uniform 1,000–40,000 | log-uniform 1,000–12,000 |
+| Members (`N_MEMBERS`) | 10 | 320 | 320 |
+| Announced base table (`TOTAL_PREFIXES`) | 100 | 183,040 (572/member) | 183,040 (572/member) |
+| Per-member IRR filter list (`MIN_LIST`–`MAX_LIST`) | 100 | log-uniform 1,000–40,000 | log-uniform 1,000–40,000 |
 | Per-member change probability (`CHANGED_FRACTION`) | 10% | 10% | 10% |
 | Seed (`SEED`) | 61 | 61 | 61 |
 | Reload cycles per cell (`RELOADS`) | 1 | 4 | 4 |
@@ -43,8 +43,7 @@ identical across cells at the same shape (the generator never consults the
 cell when building the dataset). The manifest carries a canonical
 `dataset_sha256`; the full campaign rejects a cell whose digest differs.
 `CHANGED_FRACTION` is a Bernoulli probability, not an exact cohort size: seed
-61 changes 36/320 IRR filter lists at the full shape and 1/10 at the bounded
-transaction shape. Separately, the global A/B export marker changes output
+61 changes 36/320 IRR filter lists at the full shape. Separately, the global A/B export marker changes output
 for all observers, so `peers_changed=320` and the first-generation timing
 percentiles cover 320 observers in the full receipt—not only the 36 members
 whose input lists changed.
@@ -85,7 +84,7 @@ CONFIRM_BENCH_CRON_PAUSED=1 CONFIRM_NO_MAIN_PUSHES=1 ARTIFACTS_DIR=/tmp/bmp-buff
 |---|---|---|
 | `rustbgpd-sighup` | `.rpol` per-member IRR filters rendered by `tools/rs-config-render` (the production IRR pipeline renderer) from a synthetic `arouteserver template-context` document, concatenated into one swapped file | copy generation file over live, `SIGHUP` |
 | `rustbgpd-sighup-grouped-control` | the same `.rpol` policy and canonical dataset, with `per_client_best = false` so all 320 members share one update group | copy generation file over live, `SIGHUP`; standalone diagnostic control only |
-| `rustbgpd-txn` | same dataset as inline `[policy.definitions]` chain-engine statements in a full candidate config TOML | copy candidate, `rbgp config plan` + `config apply` with the plan's snapshot token (`txn-apply.sh`) |
+| `rustbgpd-txn` | same dataset as inline `[policy.definitions]` chain-engine statements in a full candidate config TOML | copy candidate; streamed JSON Plan; explicit streamed Apply with the returned single-use plan token, snapshot token, and commit-confirm; assert pending v3 state, then confirm (`txn-apply.sh`) |
 | `bird` | per-member prefix-set `define`s + import filters in the swapped include file | copy include, `birdc configure` |
 | `openbgpd` | per-member `prefix-set`s + `source-as`/`prefix-set` allow rules in the swapped include file | copy include, `bgpctl reload` |
 
@@ -185,6 +184,25 @@ fingerprint without hostnames, usernames, absolute paths, or other host-unique
 identifiers.
 Successful cells may delete their generated scenario only after retaining its
 generator `manifest.json` alongside that provenance.
+
+The full transaction cell retains only compact lifecycle evidence, never plan
+or runtime token contents and never the multi-MiB candidate or v3 raw snapshot.
+Each of its four measured B/A/B/A reloads proves a streamed committable Plan,
+explicit use of that Plan's UUID-v4 single-use token, pending commit-confirm,
+the canonical config-adjacent v3 locator plus fixed owner-only raw/metadata
+files, full locator→metadata→raw path/digest/device/inode linkage, raw size in
+`(10 MiB, 384 MiB]`, legacy-journal absence, and confirmed terminal cleanup.
+After the final measurement boundary and before daemon teardown,
+`txn-lifecycle.sh` applies the opposite B generation twice: explicit abort and
+ten-second timeout must report `aborted` and `auto_reverted`, remove all v3
+authority, and restore the exact A disk and effective-runtime hashes. A final
+streamed Plan of A must be tokenless `NOOP`.
+
+Because config-history's `SkippedOversize` outcome is internal, the retained
+proof binds the public empty history entries and on-disk history roster before
+and after every persist to the daemon's exact oversize warning (including a
+byte count above 10 MiB). The verifier requires nine such warnings: boot, four
+measured applies, abort apply/restore, and timeout apply/restore.
 Offline verification recomputes the canonical provenance fingerprint, requires
 the exact full-workload knobs and repeat tool/image identities, and re-parses
 `scenario.sha256` against the manifest's safe `runtime_files` roster. Any
@@ -222,7 +240,7 @@ must precede the harness's first wire-measurement trigger. The retained
 `ready`, `ack`, timestamps, config, and raw scrapes are all in the cell's
 checksum chain and are independently re-parsed by the four-root verifier.
 
-**Run count and order**: four fresh artifact roots in fixed A/B/B/A order:
+**Cross-daemon run count and order**: four fresh artifact roots in fixed A/B/B/A order:
 comparison A, grouped-control A, grouped-control B, comparison B. Each cell
 gets a fresh daemon PID/start identity. This counterbalances host drift around
 the diagnostic control without putting the control in the competitor table.
@@ -231,11 +249,20 @@ identities, source/dataset/shape mismatches, non-quiet cells, broken seals, or
 grouped rows in `comparison.csv`; it writes grouped rows only to
 `grouped-control.csv`. The repeats are not statistically independent trials.
 
-**Host-quiet preconditions** (full measured mode enforces): clean `HEAD`
+**Transaction run count and order**: two fresh full-shape roots in strict A/B
+order. `verify-receipt.py transactions` requires the same clean commit,
+dataset, shape, scripts, binaries, and platform, non-overlapping roots, and
+distinct daemon PID/start identities. It independently checks all four cycles,
+abort/timeout restoration, history-warning sequence, exact file roster,
+quiet-host evidence, seals, and the absence of retained token contents.
+
+**Host-quiet preconditions** (every full measured mode enforces): clean `HEAD`
 exactly at `origin/main`, the canonical shape/seed, no `SKIP_PREFLIGHT`, a
 passing `tests/soak/preflight.sh`, and exclusive ownership of the shared host
 lock. Before every cell, two retained 1-minute-load samples at least 30 seconds
-apart must both be below 2.0; cells retain their daemon PID/start identity.
+apart must both be below 2.0, ports 1790 and 9179 must be free, the artifact
+filesystem must have at least 40 GiB available, and `pswpin`/`pswpout` must not
+move between samples; cells retain their daemon PID/start identity.
 Successful roots carry `COMPLETED` plus an exact `SHA256SUMS` roster and become
 read-only. `SMOKE=1` skips the quiet gates because it is not a measurement.
 
@@ -271,16 +298,12 @@ Documented asymmetries (the honesty notes for the eventual receipt):
   `.rpol` route-server representation. Cross-daemon comparisons should use
   the SIGHUP cell; the txn cell answers "what does the transactional seam
   cost for the same semantic change", not engine-vs-engine.
-- **The txn cell is size-capped and separate today.** The candidate travels inside one
-  gRPC message and the daemon's tonic server uses the default ~4 MiB
-  decode limit, and the chain-engine TOML encoding is several times larger
-  than the equivalent `.rpol`. The measured default therefore excludes it.
-  Running `rustbgpd-txn` alone selects the bounded 10-member shape above; the
-  runner rejects any candidate whose encoded apply request (candidate plus
-  the required fixed-shape snapshot token) would exceed 4 MiB before starting
-  the daemon. `txn-apply.sh` rejects an unexpected token shape rather than
-  invalidating that bound. Its rows and artifact root never enter the
-  cross-daemon table.
+- **The txn cell is streamed and separate.** Plan and Apply send bounded chunks
+  and accept a candidate up to 384 MiB, so `rustbgpd-txn` alone now selects the
+  canonical 320-member shape. The runner rejects a measured candidate at or
+  below the 10 MiB history boundary or above the streaming ceiling before
+  starting measurements. The 10-member transaction remains smoke-only. Its
+  rows and artifact roots never enter the cross-daemon table.
 - **Hygiene depth differs slightly.** The rustbgpd SIGHUP cell carries the
   full rendered `rs-hygiene` (including the AS_SET-segment reject term);
   the chain engine and the BIRD/OpenBGPD cells carry the shared core
@@ -320,9 +343,13 @@ python3 bench/scale/irrreload/verify-receipt.py campaigns \
   /tmp/irrreload-comparison-A /tmp/irrreload-grouped-A \
   /tmp/irrreload-grouped-B /tmp/irrreload-comparison-B
 
-# Separate bounded transaction receipt, also repeated into fresh roots:
+# Separate full-shape transaction receipt, repeated into fresh roots:
 ARTIFACTS_DIR=/tmp/irrreload-txn-runA bench/scale/irrreload/run-irr-reload.sh rustbgpd-txn
 ARTIFACTS_DIR=/tmp/irrreload-txn-runB bench/scale/irrreload/run-irr-reload.sh rustbgpd-txn
+
+python3 bench/scale/irrreload/verify-receipt.py transactions \
+  --output-dir /tmp/irrreload-txn-verified \
+  /tmp/irrreload-txn-runA /tmp/irrreload-txn-runB
 ```
 
 The runner builds what it needs (`rustbgpd`, `rbgp`, `rs-config-render`,

--- a/bench/scale/irrreload/run-irr-reload.sh
+++ b/bench/scale/irrreload/run-irr-reload.sh
@@ -8,8 +8,8 @@
 #   rustbgpd-sighup  bare release binary; rs-config-render-derived .rpol
 #                    member policy; SIGHUP parse-then-swap reloads
 #   rustbgpd-txn     bare release binary; same dataset as inline
-#                    [policy.definitions] chains; gRPC `rbgp config
-#                    plan`+`apply` transactional reloads (txn-apply.sh)
+#                    [policy.definitions] chains; streamed Plan + explicit
+#                    plan-token Apply + commit-confirm (txn-apply.sh)
 #   bird             BIRD 3.3.x in docker --network=host; `birdc configure`
 #   openbgpd         OpenBGPD 9.x in docker --network=host; `bgpctl reload`
 #
@@ -36,6 +36,7 @@ HARNESS="$RSTALL/target/release/reloadstall"
 GEN="$RSTALL/gen-irr-scenario.py"
 SAMPLER="$REPO/bench/scale/matrix/rss-sampler.sh"
 TXN_APPLY="$REPO/bench/scale/irrreload/txn-apply.sh"
+TXN_LIFECYCLE="$REPO/bench/scale/irrreload/txn-lifecycle.sh"
 VERIFY="$REPO/bench/scale/irrreload/verify-receipt.py"
 RBGP="$REPO/target/release/rbgp"
 RENDER="$REPO/target/release/rs-config-render"
@@ -81,18 +82,6 @@ if [ -n "$SMOKE" ]; then
     CONTROL_SECS="${CONTROL_SECS:-5}"
     CELL_TIMEOUT="${CELL_TIMEOUT:-900}"
     COOL_DOWN=5
-elif [ "$TXN_ONLY" = true ]; then
-    # The transaction candidate is carried in one tonic request. This
-    # separate representative shape stays below the default 4 MiB decode
-    # ceiling; the runner also checks the exact generated protobuf payload.
-    N_MEMBERS="${N_MEMBERS:-10}"
-    TOTAL_PREFIXES="${TOTAL_PREFIXES:-5720}"
-    MIN_LIST="${MIN_LIST:-1000}"
-    MAX_LIST="${MAX_LIST:-12000}"
-    RELOADS="${RELOADS:-4}"
-    CONTROL_SECS="${CONTROL_SECS:-30}"
-    CELL_TIMEOUT="${CELL_TIMEOUT:-7200}"
-    COOL_DOWN=300
 else
     # The measured shape: 320 members, 572 announced /24s each (the IXP
     # matrix per-member slice), IRR filter lists log-uniform 1k-40k entries.
@@ -117,26 +106,24 @@ cleanup_preflight_log() { [ -z "$PREFLIGHT_LOG" ] || rm -f "$PREFLIGHT_LOG"; }
 trap cleanup_preflight_log EXIT
 RSS_LIMIT_KIB=$((100 * 1024 * 1024)) # abort a cell past 100 GiB (precommitted)
 TOPOLOGY_CAPTURE_TIMEOUT=50
-TONIC_MAX_DECODE_BYTES=4194304
-# candidate_toml plus the fixed snapshot token fits tonic's 4 MiB ceiling.
-TXN_SAFE_CANDIDATE_BYTES=4194275
-TXN_MAX_CANDIDATE_BYTES="${TXN_MAX_CANDIDATE_BYTES:-$TXN_SAFE_CANDIDATE_BYTES}"
+TXN_STREAM_MAX_BYTES=$((384 * 1024 * 1024))
+TXN_MAX_CANDIDATE_BYTES="${TXN_MAX_CANDIDATE_BYTES:-$TXN_STREAM_MAX_BYTES}"
 case $TXN_MAX_CANDIDATE_BYTES in
 '' | *[!0-9]*)
     echo "TXN_MAX_CANDIDATE_BYTES must be an integer" >&2
     exit 2
     ;;
 esac
-if [ "$TXN_MAX_CANDIDATE_BYTES" -gt "$TXN_SAFE_CANDIDATE_BYTES" ]; then
-    echo "TXN_MAX_CANDIDATE_BYTES exceeds the safe apply-request ceiling" >&2
-    echo "maximum: $TXN_SAFE_CANDIDATE_BYTES bytes under tonic's $TONIC_MAX_DECODE_BYTES-byte limit" >&2
+if [ "$TXN_MAX_CANDIDATE_BYTES" -gt "$TXN_STREAM_MAX_BYTES" ]; then
+    echo "TXN_MAX_CANDIDATE_BYTES exceeds the streamed candidate ceiling" >&2
+    echo "maximum: $TXN_STREAM_MAX_BYTES bytes" >&2
     exit 2
 fi
 
 if [ -n "$SMOKE" ]; then
     CAMPAIGN_KIND=smoke
 elif [ "$TXN_ONLY" = true ]; then
-    CAMPAIGN_KIND=transaction-bounded
+    CAMPAIGN_KIND=full-transaction
 elif [ "$GROUPED_ONLY" = true ]; then
     CAMPAIGN_KIND=full-grouped-control
 else
@@ -161,14 +148,14 @@ if [ -n "${DRY_RUN_PROTOCOL:-}" ]; then
     exit 0
 fi
 
-for tool in docker jq python3 cargo curl flock ss sha256sum git awk timeout find sort setsid stdbuf cmp mktemp; do
+for tool in docker jq python3 cargo curl flock ss sha256sum git awk timeout find sort setsid stdbuf cmp mktemp stat df env; do
     command -v "$tool" >/dev/null || {
         echo "missing required tool: $tool" >&2
         exit 1
     }
 done
 
-if [ -z "$SMOKE" ] && [ "$TXN_ONLY" != true ]; then
+if [ -z "$SMOKE" ]; then
     if [ -n "${SKIP_PREFLIGHT:-}" ]; then
         echo "full measured campaigns cannot set SKIP_PREFLIGHT" >&2
         exit 2
@@ -182,7 +169,7 @@ if [ -z "$SMOKE" ] && [ "$TXN_ONLY" != true ]; then
         exit 2
     fi
     if [ "$N_MEMBERS,$TOTAL_PREFIXES,$MIN_LIST,$MAX_LIST,$SEED,$RELOADS,$CHANGED_FRACTION,$PORT,$CONTROL_SECS,$TXN_MAX_CANDIDATE_BYTES,$CELL_TIMEOUT,$START_TIMEOUT,$BIRD_THREADS" != \
-        "320,183040,1000,40000,61,4,0.1,1790,30,4194275,7200,600,8" ]; then
+        "320,183040,1000,40000,61,4,0.1,1790,30,402653184,7200,600,8" ]; then
         echo "full measured campaigns require canonical workload knobs" >&2
         exit 2
     fi
@@ -271,6 +258,7 @@ CAMPAIGN_PROVENANCE=$(jq -cn \
     --arg generator_sha256 "$(hash_file "$GEN")" \
     --arg sampler_sha256 "$(hash_file "$SAMPLER")" \
     --arg txn_apply_sha256 "$(hash_file "$TXN_APPLY")" \
+    --arg txn_lifecycle_sha256 "$(hash_file "$TXN_LIFECYCLE")" \
     --arg harness_sha256 "$(hash_file "$HARNESS")" \
     --arg daemon_sha256 "$(hash_file "$DAEMON")" \
     --arg cli_sha256 "$(hash_file "$RBGP")" \
@@ -292,7 +280,7 @@ CAMPAIGN_PROVENANCE=$(jq -cn \
     --arg cpu_model "$(awk -F: '/^model name/ { sub(/^[[:space:]]+/, "", $2); print $2; exit }' /proc/cpuinfo)" \
     --arg bird_image "$BIRD_IMAGE" --arg bird_image_id "$BIRD_IMAGE_ID" \
     --arg openbgpd_image "$OPENBGPD_IMAGE" --arg openbgpd_image_id "$OPENBGPD_IMAGE_ID" \
-    '{schema:3,started_at_epoch_ns:$started_at_epoch_ns,git:{commit:$commit,dirty:$dirty,dirty_state_sha256:$dirty_state_sha256,origin_main:$origin_main,head_matches_origin_main:$head_matches_origin_main},scripts:{runner:$run_script_sha256,verifier:$verifier_sha256,generator:$generator_sha256,rss_sampler:$sampler_sha256,txn_apply:$txn_apply_sha256},binaries:{reloadstall:$harness_sha256,rustbgpd:$daemon_sha256,rbgp:$cli_sha256,rs_config_render:$renderer_sha256},environment:{rustc:$rustc,cargo:$cargo,python:$python,jq:$jq,docker:$docker,kernel:$kernel,cpu_model:$cpu_model},inputs:{campaign_kind:$campaign_kind,cells:$cells,smoke:$smoke,n_members:$n_members,total_prefixes:$total_prefixes,min_list:$min_list,max_list:$max_list,seed:$seed,changed_fraction:$changed_fraction,port:$port,reloads:$reloads,control_secs:$control_secs,txn_max_candidate_bytes:$txn_max_candidate_bytes,cell_timeout:$cell_timeout,start_timeout:$start_timeout,bird_threads:$bird_threads,skip_preflight:$skip_preflight,bird_image:$bird_image,bird_image_id:$bird_image_id,openbgpd_image:$openbgpd_image,openbgpd_image_id:$openbgpd_image_id}}') || exit 1
+    '{schema:3,started_at_epoch_ns:$started_at_epoch_ns,git:{commit:$commit,dirty:$dirty,dirty_state_sha256:$dirty_state_sha256,origin_main:$origin_main,head_matches_origin_main:$head_matches_origin_main},scripts:{runner:$run_script_sha256,verifier:$verifier_sha256,generator:$generator_sha256,rss_sampler:$sampler_sha256,txn_apply:$txn_apply_sha256,txn_lifecycle:$txn_lifecycle_sha256},binaries:{reloadstall:$harness_sha256,rustbgpd:$daemon_sha256,rbgp:$cli_sha256,rs_config_render:$renderer_sha256},environment:{rustc:$rustc,cargo:$cargo,python:$python,jq:$jq,docker:$docker,kernel:$kernel,cpu_model:$cpu_model},inputs:{campaign_kind:$campaign_kind,cells:$cells,smoke:$smoke,n_members:$n_members,total_prefixes:$total_prefixes,min_list:$min_list,max_list:$max_list,seed:$seed,changed_fraction:$changed_fraction,port:$port,reloads:$reloads,control_secs:$control_secs,txn_max_candidate_bytes:$txn_max_candidate_bytes,cell_timeout:$cell_timeout,start_timeout:$start_timeout,bird_threads:$bird_threads,skip_preflight:$skip_preflight,bird_image:$bird_image,bird_image_id:$bird_image_id,openbgpd_image:$openbgpd_image,openbgpd_image_id:$openbgpd_image_id}}') || exit 1
 CAMPAIGN_FINGERPRINT=$(printf '%s' "$CAMPAIGN_PROVENANCE" | jq -cS . | sha256sum | cut -d' ' -f1) || exit 1
 SEALED_CAMPAIGN_PROVENANCE=$(printf '%s\n' "$CAMPAIGN_PROVENANCE" | jq -cS \
     --arg fingerprint "$CAMPAIGN_FINGERPRINT" '. + {fingerprint:$fingerprint}') || exit 1
@@ -396,10 +384,15 @@ seal_cell_evidence() {
     local -a evidence_files=(
         daemon.log final-evidence/ready final-evidence/ack manifest.json process.tsv provenance.json reloadstall.log rows.csv rss.csv scenario.sha256
     )
-    if [ -z "$SMOKE" ] && [ "$TXN_ONLY" != true ]; then
+    if [ -z "$SMOKE" ]; then
         evidence_files+=(quiet.tsv)
     fi
     case ${cdir##*/} in
+    rustbgpd-txn)
+        if [ -z "$SMOKE" ]; then
+            evidence_files+=(transactions/cycles.jsonl transactions/lifecycle.json)
+        fi
+        ;;
     rustbgpd-sighup | "$GROUPED_CELL")
         evidence_files+=(config.toml topology.json topology.tsv metrics-1.prom metrics-2.prom metrics-3.prom pre-churn/ready pre-churn/ack)
         ;;
@@ -494,19 +487,36 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 load_gate() {
-    local cell=$1 load sample=1 quiet
+    local cell=$1 load sample=1 quiet pswpin pswpout disk_kib first_pswpin first_pswpout port1790 port9179
     quiet="$ART/$cell/quiet.tsv"
     [ -n "$SMOKE" ] && return 0
-    [ "$TXN_ONLY" = true ] && return 0
     mkdir -p "$ART/$cell"
-    printf 'sample\tepoch_s\tload1\n' >"$quiet"
+    printf 'sample\tepoch_s\tload1\tpswpin\tpswpout\tport1790_free\tport9179_free\tdisk_available_kib\n' >"$quiet"
     while [ "$sample" -le 2 ]; do
         load=$(cut -d' ' -f1 /proc/loadavg)
-        if awk -v l="$load" 'BEGIN { exit !(l < 2.0) }'; then
-            printf '%s\t%s\t%s\n' "$sample" "$(date +%s)" "$load" >>"$quiet"
+        pswpin=$(awk '$1 == "pswpin" {print $2}' /proc/vmstat)
+        pswpout=$(awk '$1 == "pswpout" {print $2}' /proc/vmstat)
+        disk_kib=$(df -Pk "$ART" | awk 'NR == 2 {print $4}')
+        port1790=$(ss -ltnH 'sport = :1790') || { echo "load_gate: cannot inspect port 1790" >&2; exit 1; }
+        port9179=$(ss -ltnH 'sport = :9179') || { echo "load_gate: cannot inspect port 9179" >&2; exit 1; }
+        if awk -v l="$load" 'BEGIN { exit !(l < 2.0) }' &&
+            [ -z "$port1790" ] && [ -z "$port9179" ] &&
+            [ "$disk_kib" -ge $((40 * 1024 * 1024)) ]; then
+            printf '%s\t%s\t%s\t%s\t%s\ttrue\ttrue\t%s\n' \
+                "$sample" "$(date +%s)" "$load" "$pswpin" "$pswpout" "$disk_kib" >>"$quiet"
+            if [ "$sample" -eq 1 ]; then
+                first_pswpin=$pswpin
+                first_pswpout=$pswpout
+            elif [ "$pswpin" != "$first_pswpin" ] || [ "$pswpout" != "$first_pswpout" ]; then
+                echo "load_gate: swap activity observed; restarting quiet samples"
+                printf 'sample\tepoch_s\tload1\tpswpin\tpswpout\tport1790_free\tport9179_free\tdisk_available_kib\n' >"$quiet"
+                sample=1
+                sleep 30
+                continue
+            fi
             sample=$((sample + 1))
         else
-            echo "load_gate: 1-min loadavg $load >= 2.0, waiting 30s"
+            echo "load_gate: waiting for load <2, free ports 1790/9179, and 40 GiB free on ART"
         fi
         [ "$sample" -gt 2 ] || sleep 30
     done
@@ -671,10 +681,13 @@ run_cell() {
         for candidate in "$run/config.toml" "$run/candidate.toml" \
             "$run/gen-a.toml" "$run/gen-b.toml"; do
             candidate_bytes=$(wc -c <"$candidate") || return 1
+            if [ -z "$SMOKE" ] && [ "$candidate_bytes" -le $((10 * 1024 * 1024)) ]; then
+                echo "cell $cell: $(basename "$candidate") is not above the 10 MiB history bound" >&2
+                return 1
+            fi
             if [ "$candidate_bytes" -gt "$TXN_MAX_CANDIDATE_BYTES" ]; then
                 echo "cell $cell: $(basename "$candidate") is ${candidate_bytes} bytes" >&2
-                echo "candidate exceeds the ${TXN_MAX_CANDIDATE_BYTES}-byte tonic request budget" >&2
-                echo "use a smaller separate transaction shape and a fresh ARTIFACTS_DIR" >&2
+                echo "candidate exceeds the ${TXN_MAX_CANDIDATE_BYTES}-byte streamed request budget" >&2
                 return 1
             fi
         done
@@ -684,7 +697,18 @@ run_cell() {
         ACTIVE_DAEMON_PID=$daemon_pid
         live="$run/candidate.toml" a="$run/gen-a.toml" b="$run/gen-b.toml"
         pid_arg=$daemon_pid
-        reload_cmd="$TXN_APPLY $RBGP unix://$run/grpc.sock $run/candidate.toml"
+        if [ -n "$SMOKE" ]; then
+            reload_cmd=$(python3 -c 'import shlex,sys; print(shlex.join(sys.argv[1:]))' \
+                env TXN_SMOKE=1 "$TXN_APPLY" "$RBGP" "unix://$run/grpc.sock" \
+                "$run/candidate.toml" "$run/config.toml" "$run" "$cdir/transactions" \
+                "$daemon_pid" "$cdir/daemon.log") || return 1
+        else
+            mkdir -p "$cdir/transactions" || return 1
+            reload_cmd=$(python3 -c 'import shlex,sys; print(shlex.join(sys.argv[1:]))' \
+                "$TXN_APPLY" "$RBGP" "unix://$run/grpc.sock" "$run/candidate.toml" \
+                "$run/config.toml" "$run" "$cdir/transactions" "$daemon_pid" \
+                "$cdir/daemon.log") || return 1
+        fi
         ;;
     bird)
         gen_scenario bird "$run" --threads "$BIRD_THREADS" \
@@ -795,6 +819,15 @@ run_cell() {
     elif [ -n "$topology_mode" ] && ! bind_first_trigger "$cdir"; then
         echo "cell $cell: first reload trigger was missing or preceded topology proof" >&2
         rc=93
+    fi
+
+    if [ "$cell" = rustbgpd-txn ] && [ -z "$SMOKE" ] && [ "$rc" -eq 0 ]; then
+        if ! "$TXN_LIFECYCLE" "$RBGP" "unix://$run/grpc.sock" "$run/gen-a.toml" \
+            "$run/gen-b.toml" "$run/config.toml" "$run" "$cdir/transactions" \
+            "$daemon_pid" "$cdir/daemon.log"; then
+            echo "cell $cell: abort/timeout lifecycle proof failed" >&2
+            rc=91
+        fi
     fi
 
     if [ -n "$container" ]; then

--- a/bench/scale/irrreload/txn-apply.sh
+++ b/bench/scale/irrreload/txn-apply.sh
@@ -1,41 +1,233 @@
 #!/usr/bin/env bash
-# One gRPC transactional reload: plan the candidate, then apply it with the
-# plan's runtime snapshot token. Used as the reloadstall harness's
-# `reload_cmd` for the rustbgpd-txn cell — the harness copies the next
-# generation over the candidate path first, then invokes this; a nonzero
-# exit fails the reload like a failed SIGHUP.
+# One measured streamed config transaction. The reloadstall harness has already
+# copied the next generation over CANDIDATE before invoking this command.
 #
-# Usage: txn-apply.sh <rbgp-binary> <grpc-addr> <candidate-toml>
+# Usage: txn-apply.sh RBGP ADDR CANDIDATE CONFIG RUNTIME_DIR EVIDENCE_DIR PID DAEMON_LOG
 set -u
+set -o pipefail
 
-if [ $# -ne 3 ]; then
-    echo "usage: txn-apply.sh <rbgp-binary> <grpc-addr> <candidate-toml>" >&2
+if [ $# -ne 8 ]; then
+    echo "usage: txn-apply.sh RBGP ADDR CANDIDATE CONFIG RUNTIME_DIR EVIDENCE_DIR PID DAEMON_LOG" >&2
     exit 2
 fi
 rbgp=$1
 addr=$2
 candidate=$3
+config=$4
+runtime_dir=$5
+evidence=$6
+daemon_pid=$7
+daemon_log=$8
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+verify="$script_dir/verify-receipt.py"
+locator="$config.commit-confirm-locator.json"
+raw="$runtime_dir/commit-confirm-v3-prior.toml"
+metadata="$runtime_dir/commit-confirm-v3-metadata.json"
+legacy="$runtime_dir/commit-confirm-journal.json"
+min_raw=$((10 * 1024 * 1024))
+max_raw=$((384 * 1024 * 1024))
+mkdir -p "$evidence"
+
+die() { echo "txn-apply: $*" >&2; exit 1; }
+sha() { sha256sum -- "$1" | cut -d' ' -f1; }
+runtime_token_valid() { [[ $1 =~ ^kv2:[0-9a-f]{16}:8$ ]]; }
+active_confirm_id=
+cleanup_pending() { [ -z "$active_confirm_id" ] || "$rbgp" --addr "$addr" --json config abort "$active_confirm_id" >/dev/null 2>&1 || true; }
+trap cleanup_pending EXIT
+history_count() {
+    "$rbgp" --addr "$addr" --json config history |
+        jq -er '.entries | select(type == "array") | length'
+}
+history_json() {
+    local entries files history_dir="$runtime_dir/config-history"
+    entries=$("$rbgp" --addr "$addr" --json config history | jq -ecS '.entries') || return 1
+    files=$(
+        if [ -d "$history_dir" ]; then
+            find "$history_dir" -mindepth 1 -maxdepth 1 -type f -printf '%f\n' | sort |
+                while IFS= read -r name; do
+                    jq -cn --arg name "$name" --arg sha256 "$(sha "$history_dir/$name")" \
+                        --argjson bytes "$(wc -c <"$history_dir/$name")" \
+                        '{name:$name,bytes:$bytes,sha256:$sha256}'
+                done
+        fi | jq -scS '.'
+    ) || return 1
+    jq -cn --argjson entries "$entries" --argjson files "$files" '{entries:$entries,files:$files}'
+}
+warning_count() { grep -Fc 'applied config exceeds the bounded history entry size; history was left unchanged' "$daemon_log" 2>/dev/null || true; }
+warning_json() {
+    local before=$1 count line bytes deadline=$((SECONDS + 10))
+    while :; do
+        count=$(warning_count)
+        [ "$count" -gt "$before" ] && break
+        [ "$SECONDS" -lt "$deadline" ] || return 1
+        sleep 0.1
+    done
+    [ "$count" -eq $((before + 1)) ] || return 1
+    line=$(grep -F 'applied config exceeds the bounded history entry size; history was left unchanged' "$daemon_log" | tail -n1) || return 1
+    bytes=$(printf '%s\n' "$line" | jq -er '.fields.bytes | select(type == "number")') || return 1
+    [ "$bytes" -gt "$min_raw" ] || return 1
+    jq -cn --argjson count_before "$before" --argjson count_after "$count" \
+        --argjson bytes "$bytes" '{count_before:$count_before,count_after:$count_after,bytes:$bytes}'
+}
+process_json() {
+    local start vmrss vmhwm
+    start=$(awk '{print $22}' "/proc/$daemon_pid/stat" 2>/dev/null) || return 1
+    vmrss=$(awk '$1 == "VmRSS:" {print $2}' "/proc/$daemon_pid/status") || return 1
+    vmhwm=$(awk '$1 == "VmHWM:" {print $2}' "/proc/$daemon_pid/status") || return 1
+    jq -cn --argjson pid "$daemon_pid" --argjson starttime "$start" \
+        --argjson vmrss_kib "$vmrss" --argjson vmhwm_kib "$vmhwm" \
+        '{pid:$pid,starttime:$starttime,vmrss_kib:$vmrss_kib,vmhwm_kib:$vmhwm_kib}'
+}
+effective_json() {
+    local tmp digest bytes marker
+    tmp=$(mktemp "$runtime_dir/.irr-effective.XXXXXX") || return 1
+    "$rbgp" --addr "$addr" config effective >"$tmp" || { rm -f "$tmp"; return 1; }
+    digest=$(sha "$tmp") || { rm -f "$tmp"; return 1; }
+    bytes=$(wc -c <"$tmp") || { rm -f "$tmp"; return 1; }
+    marker=$("$verify" inspect-generation "$tmp") || { rm -f "$tmp"; return 1; }
+    rm -f "$tmp"
+    jq -cn --arg sha256 "$digest" --argjson bytes "$bytes" --arg marker "$marker" \
+        '{sha256:$sha256,bytes:$bytes,marker:$marker}'
+}
+config_json() {
+    local digest bytes marker
+    digest=$(sha "$config") || return 1
+    bytes=$(wc -c <"$config") || return 1
+    marker=$("$verify" inspect-generation "$config") || return 1
+    jq -cn --arg sha256 "$digest" --argjson bytes "$bytes" --arg marker "$marker" \
+        '{sha256:$sha256,bytes:$bytes,marker:$marker}'
+}
+pending_json() {
+    local confirm_id=$1 authority history process runtime config_state raw_bytes
+    authority=$("$verify" inspect-v3 --locator "$locator" --metadata "$metadata" \
+        --raw "$raw" --config "$config" --confirm-id "$confirm_id") || return 1
+    raw_bytes=$(printf '%s' "$authority" | jq -er '.raw.bytes') || return 1
+    [ "$raw_bytes" -gt "$min_raw" ] && [ "$raw_bytes" -le "$max_raw" ] || return 1
+    [ ! -e "$legacy" ] || return 1
+    history=$(history_count) || return 1
+    [ "$history" -eq 0 ] || return 1
+    process=$(process_json) || return 1
+    runtime=$(effective_json) || return 1
+    config_state=$(config_json) || return 1
+    jq -cn --argjson authority "$authority" --argjson history_entries "$history" \
+        --argjson process "$process" --argjson runtime "$runtime" \
+        --argjson config "$config_state" \
+        '{authority:$authority,legacy_absent:true,
+          history_entries:$history_entries,history_outcome:"skipped_oversize",
+          process:$process,config:$config,runtime:$runtime}'
+}
+terminal_json() {
+    local history process runtime config_state
+    [ ! -e "$locator" ] && [ ! -e "$locator.tmp" ] &&
+        [ ! -e "$raw" ] && [ ! -e "$raw.tmp" ] &&
+        [ ! -e "$metadata" ] && [ ! -e "$metadata.tmp" ] && [ ! -e "$legacy" ] || return 1
+    history=$(history_count) || return 1
+    [ "$history" -eq 0 ] || return 1
+    process=$(process_json) || return 1
+    runtime=$(effective_json) || return 1
+    config_state=$(config_json) || return 1
+    jq -cn --argjson history_entries "$history" --argjson process "$process" \
+        --argjson runtime "$runtime" --argjson config "$config_state" \
+        '{v3_absent:true,legacy_absent:true,history_entries:$history_entries,
+          history_outcome:"skipped_oversize",process:$process,config:$config,runtime:$runtime}'
+}
+
+cycles="$evidence/cycles.jsonl"
+candidate_bytes=$(wc -c <"$candidate") || die "cannot size candidate"
+[ "$candidate_bytes" -le "$max_raw" ] || die "candidate exceeds 384 MiB"
+if [ -z "${TXN_SMOKE:-}" ]; then
+    [ "$candidate_bytes" -gt "$min_raw" ] || die "measured candidate is not above 10 MiB"
+    cycle=$(( $(wc -l <"$cycles" 2>/dev/null || printf 0) + 1 ))
+    if [ "$cycle" -lt 1 ] || [ "$cycle" -gt 4 ]; then
+        die "unexpected measured cycle $cycle"
+    fi
+fi
+candidate_sha=$(sha "$candidate") || die "cannot hash candidate"
+candidate_marker=
+if [ -z "${TXN_SMOKE:-}" ]; then
+    candidate_marker=$("$verify" inspect-generation "$candidate") || die "cannot inspect candidate generation"
+fi
 
 plan_json=$("$rbgp" --addr "$addr" --json config plan "$candidate")
-rc=$?
-if [ "$rc" -eq 0 ]; then
-    # Plan exit 0 = noop candidate: a reload that changes nothing is a
-    # scenario bug, not a measurable reload.
-    echo "txn-apply: candidate is a noop (plan exit 0)" >&2
-    exit 1
+plan_rc=$?
+[ "$plan_rc" -eq 2 ] || die "streamed plan exit $plan_rc, expected committable exit 2"
+[ "$(printf '%s' "$plan_json" | jq -er '.status')" = committable ] || die "plan not committable"
+runtime_token=$(printf '%s' "$plan_json" | jq -er '.runtime_snapshot_token | select(type == "string" and length > 0)') ||
+    die "plan returned no runtime snapshot token"
+runtime_token_valid "$runtime_token" || die "plan runtime snapshot token was not canonical kv2"
+plan_token=$(printf '%s' "$plan_json" | jq -er '.plan_token | select(type == "string" and length > 0)') ||
+    die "streamed plan returned no plan token"
+[[ $plan_token =~ ^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]] ||
+    die "streamed plan token was not UUID-v4"
+if [ -n "${TXN_SMOKE:-}" ]; then
+    apply_json=$("$rbgp" --addr "$addr" --json config apply "$candidate" \
+        --expected-runtime-snapshot-token "$runtime_token" --plan-token "$plan_token") ||
+        die "smoke streamed apply failed"
+    [ "$(printf '%s' "$apply_json" | jq -er '.status')" = committable ] || die "smoke apply not committable"
+    [ "$(printf '%s' "$apply_json" | jq -r '.confirmation')" = null ] || die "smoke apply unexpectedly confirmed"
+    exit 0
 fi
-if [ "$rc" -ne 2 ]; then
-    echo "txn-apply: config plan failed (exit $rc)" >&2
-    exit 1
+history_before=$(history_json) || die "cannot capture history before apply"
+[ "$(printf '%s' "$history_before" | jq -er '.entries | length')" -eq 0 ] || die "history was not empty before apply"
+warning_before=$(warning_count)
+confirm_id="irrreload-measured-$cycle"
+active_confirm_id=$confirm_id
+apply_json=$("$rbgp" --addr "$addr" --json config apply "$candidate" \
+    --expected-runtime-snapshot-token "$runtime_token" --plan-token "$plan_token" \
+    --confirm-id "$confirm_id" --confirm-timeout 600) || die "streamed apply failed"
+[ "$(printf '%s' "$apply_json" | jq -er '.status')" = committable ] || die "apply not committable"
+apply_runtime=$(printf '%s' "$apply_json" | jq -er '.runtime_snapshot_token | select(type == "string")') || die "apply runtime token missing"
+runtime_token_valid "$apply_runtime" || die "apply runtime snapshot token was not canonical kv2"
+apply_deadline=$(printf '%s' "$apply_json" | jq -er --arg id "$confirm_id" --arg runtime "$apply_runtime" \
+    '.confirmation | select(.status == "pending" and .confirm_id == $id and .timeout_seconds == 600 and
+      .deadline_unix_seconds > 0 and .runtime_snapshot_token == $runtime) | .deadline_unix_seconds') ||
+    die "apply confirmation metadata was incoherent"
+now=$(date +%s)
+if [ "$apply_deadline" -le "$now" ] || [ "$apply_deadline" -gt $((now + 605)) ]; then
+    die "apply deadline was outside the requested window"
 fi
-token=$(printf '%s' "$plan_json" | jq -r '.runtime_snapshot_token // empty')
-if [ -z "$token" ]; then
-    echo "txn-apply: plan returned no runtime_snapshot_token" >&2
-    exit 1
-fi
-if [[ ! $token =~ ^kv2:[0-9a-f]{16}:8$ ]]; then
-    echo "txn-apply: plan returned an unexpected runtime_snapshot_token shape" >&2
-    exit 1
-fi
-exec "$rbgp" --addr "$addr" config apply "$candidate" \
-    --expected-runtime-snapshot-token "$token"
+status_json=$("$rbgp" --addr "$addr" --json config status) || die "pending status failed"
+printf '%s' "$status_json" | jq -e --arg id "$confirm_id" --arg runtime "$apply_runtime" \
+    --argjson deadline "$apply_deadline" \
+    '.confirmation | select(.status == "pending" and .confirm_id == $id and .timeout_seconds == 600 and
+      .deadline_unix_seconds == $deadline and .runtime_snapshot_token == $runtime)' >/dev/null ||
+    die "pending status view was incoherent"
+pending=$(pending_json "$confirm_id") || die "pending v3/history/process evidence failed"
+[ "$(printf '%s' "$pending" | jq -er '.authority.deadline_unix_seconds')" -eq "$apply_deadline" ] || die "v3 deadline did not match apply"
+warning=$(warning_json "$warning_before") || die "missing oversize-history warning"
+
+confirm_json=$("$rbgp" --addr "$addr" --json config confirm "$confirm_id") || die "confirm failed"
+printf '%s' "$confirm_json" | jq -e --arg id "$confirm_id" --arg runtime "$apply_runtime" \
+    --argjson deadline "$apply_deadline" \
+    '.confirmation | select(.status == "confirmed" and .confirm_id == $id and .timeout_seconds == 600 and
+      .deadline_unix_seconds == $deadline and .runtime_snapshot_token == $runtime)' >/dev/null ||
+    die "confirm response was incoherent"
+confirmed_status=$("$rbgp" --addr "$addr" --json config status) || die "confirmed status failed"
+printf '%s' "$confirmed_status" | jq -e --arg id "$confirm_id" --arg runtime "$apply_runtime" \
+    --argjson deadline "$apply_deadline" \
+    '.confirmation | select(.status == "confirmed" and .confirm_id == $id and .timeout_seconds == 600 and
+      .deadline_unix_seconds == $deadline and .runtime_snapshot_token == $runtime)' >/dev/null ||
+    die "confirmed status view was incoherent"
+active_confirm_id=
+terminal=$(terminal_json) || die "confirmed cleanup/history/process evidence failed"
+history_after=$(history_json) || die "cannot capture history after confirm"
+[ "$(printf '%s' "$history_before" | jq -cS .)" = "$(printf '%s' "$history_after" | jq -cS .)" ] ||
+    die "bounded history changed across oversize transaction"
+[ "$(printf '%s' "$pending" | jq -r '.process.pid,.process.starttime')" = \
+  "$(printf '%s' "$terminal" | jq -r '.process.pid,.process.starttime')" ] || die "daemon identity changed"
+
+row=$(jq -cn --argjson cycle "$cycle" --arg candidate_sha256 "$candidate_sha" \
+    --argjson candidate_bytes "$candidate_bytes" --arg candidate_marker "$candidate_marker" --arg confirm_id "$confirm_id" \
+    --argjson pending "$pending" --argjson terminal "$terminal" \
+    --argjson history_before "$history_before" --argjson history_after "$history_after" \
+    --argjson warning "$warning" \
+    '{schema:1,cycle:$cycle,candidate:{sha256:$candidate_sha256,bytes:$candidate_bytes,marker:$candidate_marker},
+      plan:{transport:"streamed",status:"committable",plan_token_present:true,
+            runtime_snapshot_token_present:true},
+      apply:{transport:"streamed",explicit_plan_token:true,status:"committable",
+             confirmation_status:"pending",confirm_id:$confirm_id,timeout_seconds:600,
+             deadline_unix_seconds:$pending.authority.deadline_unix_seconds,
+             runtime_token_coherent:true},
+      history:{before:$history_before,after:$history_after,outcome:"skipped_oversize",warning:$warning},
+      pending:$pending,confirmed:({status:"confirmed",status_view_verified:true} + $terminal)}') || die "cannot encode evidence"
+printf '%s\n' "$row" >>"$cycles" || die "cannot retain cycle evidence"

--- a/bench/scale/irrreload/txn-lifecycle.sh
+++ b/bench/scale/irrreload/txn-lifecycle.sh
@@ -5,7 +5,6 @@
 # Usage: txn-lifecycle.sh RBGP ADDR CURRENT OPPOSITE CONFIG RUNTIME_DIR EVIDENCE_DIR PID DAEMON_LOG
 set -u
 set -o pipefail
-
 if [ $# -ne 9 ]; then
     echo "usage: txn-lifecycle.sh RBGP ADDR CURRENT OPPOSITE CONFIG RUNTIME_DIR EVIDENCE_DIR PID DAEMON_LOG" >&2
     exit 2
@@ -15,8 +14,7 @@ script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
 verify="$script_dir/verify-receipt.py"
 locator="$config.commit-confirm-locator.json"
 raw="$runtime_dir/commit-confirm-v3-prior.toml"; metadata="$runtime_dir/commit-confirm-v3-metadata.json"
-legacy="$runtime_dir/commit-confirm-journal.json"; min_raw=$((10 * 1024 * 1024)); max_raw=$((384 * 1024 * 1024)); output="$evidence/lifecycle.json"
-
+legacy="$runtime_dir/commit-confirm-journal.json"; min_raw=$((10 * 1024 * 1024)); max_raw=$((384 * 1024 * 1024)); output="$evidence/lifecycle.json"; mkdir -p "$evidence"
 die() { echo "txn-lifecycle: $*" >&2; exit 1; }
 sha() { sha256sum -- "$1" | cut -d' ' -f1; }
 runtime_token_valid() { [[ $1 =~ ^kv2:[0-9a-f]{16}:8$ ]]; }

--- a/bench/scale/irrreload/txn-lifecycle.sh
+++ b/bench/scale/irrreload/txn-lifecycle.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# After the wire harness seals and exits, exercise abort and timeout auto-revert
+# against the same still-running rustbgpd process.
+#
+# Usage: txn-lifecycle.sh RBGP ADDR CURRENT OPPOSITE CONFIG RUNTIME_DIR EVIDENCE_DIR PID DAEMON_LOG
+set -u
+set -o pipefail
+
+if [ $# -ne 9 ]; then
+    echo "usage: txn-lifecycle.sh RBGP ADDR CURRENT OPPOSITE CONFIG RUNTIME_DIR EVIDENCE_DIR PID DAEMON_LOG" >&2
+    exit 2
+fi
+rbgp=$1; addr=$2; current=$3; opposite=$4; config=$5; runtime_dir=$6; evidence=$7; daemon_pid=$8; daemon_log=$9
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+verify="$script_dir/verify-receipt.py"
+locator="$config.commit-confirm-locator.json"
+raw="$runtime_dir/commit-confirm-v3-prior.toml"; metadata="$runtime_dir/commit-confirm-v3-metadata.json"
+legacy="$runtime_dir/commit-confirm-journal.json"; min_raw=$((10 * 1024 * 1024)); max_raw=$((384 * 1024 * 1024)); output="$evidence/lifecycle.json"
+
+die() { echo "txn-lifecycle: $*" >&2; exit 1; }
+sha() { sha256sum -- "$1" | cut -d' ' -f1; }
+runtime_token_valid() { [[ $1 =~ ^kv2:[0-9a-f]{16}:8$ ]]; }
+active_confirm_id=; cleanup_pending() {
+    if [ -n "$active_confirm_id" ]; then
+        "$rbgp" --addr "$addr" --json config abort "$active_confirm_id" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup_pending EXIT
+history_count() { "$rbgp" --addr "$addr" --json config history | jq -er '.entries | select(type == "array") | length'; }
+history_json() {
+    local entries files history_dir="$runtime_dir/config-history"
+    entries=$("$rbgp" --addr "$addr" --json config history | jq -ecS '.entries') || return 1
+    files=$(
+        if [ -d "$history_dir" ]; then
+            find "$history_dir" -mindepth 1 -maxdepth 1 -type f -printf '%f\n' | sort |
+                while IFS= read -r name; do
+                    jq -cn --arg name "$name" --arg sha256 "$(sha "$history_dir/$name")" \
+                        --argjson bytes "$(wc -c <"$history_dir/$name")" \
+                        '{name:$name,bytes:$bytes,sha256:$sha256}'
+                done
+        fi | jq -scS '.'
+    ) || return 1
+    jq -cn --argjson entries "$entries" --argjson files "$files" '{entries:$entries,files:$files}'
+}
+warning_count() { grep -Fc 'applied config exceeds the bounded history entry size; history was left unchanged' "$daemon_log" 2>/dev/null || true; }
+warning_json() {
+    local before=$1 count line bytes deadline=$((SECONDS + 10))
+    while :; do
+        count=$(warning_count); [ "$count" -gt "$before" ] && break
+        [ "$SECONDS" -lt "$deadline" ] || return 1; sleep 0.1
+    done
+    [ "$count" -eq $((before + 1)) ] || return 1
+    line=$(grep -F 'applied config exceeds the bounded history entry size; history was left unchanged' "$daemon_log" | tail -n1) || return 1
+    bytes=$(printf '%s\n' "$line" | jq -er '.fields.bytes | select(type == "number")') || return 1
+    [ "$bytes" -gt "$min_raw" ] || return 1
+    jq -cn --argjson count_before "$before" --argjson count_after "$count" --argjson bytes "$bytes" \
+        '{count_before:$count_before,count_after:$count_after,bytes:$bytes}'
+}
+process_json() {
+    local start vmrss vmhwm
+    start=$(awk '{print $22}' "/proc/$daemon_pid/stat" 2>/dev/null) || return 1
+    vmrss=$(awk '$1 == "VmRSS:" {print $2}' "/proc/$daemon_pid/status") || return 1
+    vmhwm=$(awk '$1 == "VmHWM:" {print $2}' "/proc/$daemon_pid/status") || return 1
+    jq -cn --argjson pid "$daemon_pid" --argjson starttime "$start" \
+        --argjson vmrss_kib "$vmrss" --argjson vmhwm_kib "$vmhwm" \
+        '{pid:$pid,starttime:$starttime,vmrss_kib:$vmrss_kib,vmhwm_kib:$vmhwm_kib}'
+}
+content_json() {
+    local path=$1 digest bytes marker
+    digest=$(sha "$path") || return 1; bytes=$(wc -c <"$path") || return 1
+    marker=$("$verify" inspect-generation "$path") || return 1
+    jq -cn --arg sha256 "$digest" --argjson bytes "$bytes" --arg marker "$marker" \
+        '{sha256:$sha256,bytes:$bytes,marker:$marker}'
+}
+effective_json() {
+    local tmp result
+    tmp=$(mktemp "$runtime_dir/.irr-effective.XXXXXX") || return 1
+    "$rbgp" --addr "$addr" config effective >"$tmp" || { rm -f "$tmp"; return 1; }
+    result=$(content_json "$tmp") || { rm -f "$tmp"; return 1; }
+    rm -f "$tmp"; printf '%s\n' "$result"
+}
+state_json() {
+    local history process runtime disk
+    history=$(history_count) || return 1; [ "$history" -eq 0 ] || return 1
+    process=$(process_json) || return 1; runtime=$(effective_json) || return 1
+    disk=$(content_json "$config") || return 1
+    jq -cn --argjson history_entries "$history" --argjson process "$process" \
+        --argjson runtime "$runtime" --argjson disk "$disk" \
+        '{history_entries:$history_entries,history_outcome:"skipped_oversize",
+          process:$process,config:$disk,runtime:$runtime}'
+}
+pending_json() {
+    local confirm_id=$1 authority history process runtime disk raw_bytes
+    authority=$("$verify" inspect-v3 --locator "$locator" --metadata "$metadata" \
+        --raw "$raw" --config "$config" --confirm-id "$confirm_id") || return 1
+    raw_bytes=$(printf '%s' "$authority" | jq -er '.raw.bytes') || return 1
+    [ "$raw_bytes" -gt "$min_raw" ] && [ "$raw_bytes" -le "$max_raw" ] || return 1
+    [ ! -e "$legacy" ] || return 1
+    history=$(history_count) || return 1; [ "$history" -eq 0 ] || return 1
+    process=$(process_json) || return 1; runtime=$(effective_json) || return 1
+    disk=$(content_json "$config") || return 1
+    jq -cn --argjson authority "$authority" --argjson history_entries "$history" \
+        --argjson process "$process" --argjson runtime "$runtime" --argjson disk "$disk" \
+        '{authority:$authority,legacy_absent:true,
+          history_entries:$history_entries,history_outcome:"skipped_oversize",
+          process:$process,config:$disk,runtime:$runtime}'
+}
+terminal_json() {
+    local state
+    [ ! -e "$locator" ] && [ ! -e "$locator.tmp" ] &&
+        [ ! -e "$raw" ] && [ ! -e "$raw.tmp" ] &&
+        [ ! -e "$metadata" ] && [ ! -e "$metadata.tmp" ] && [ ! -e "$legacy" ] || return 1
+    state=$(state_json) || return 1
+    jq -cn --argjson state "$state" '{v3_absent:true,legacy_absent:true} + $state'
+}
+apply_pending() {
+    local id=$1 timeout=$2 plan_json plan_rc runtime_token plan_token apply_json apply_runtime status_json pending history_before warning_before warning now
+    history_before=$(history_json) || return 1
+    [ "$(printf '%s' "$history_before" | jq -er '.entries | length')" -eq 0 ] || return 1
+    warning_before=$(warning_count)
+    plan_json=$("$rbgp" --addr "$addr" --json config plan "$opposite"); plan_rc=$?
+    [ "$plan_rc" -eq 2 ] || return 1
+    [ "$(printf '%s' "$plan_json" | jq -er '.status')" = committable ] || return 1
+    runtime_token=$(printf '%s' "$plan_json" | jq -er '.runtime_snapshot_token | select(length > 0)') || return 1
+    runtime_token_valid "$runtime_token" || return 1
+    plan_token=$(printf '%s' "$plan_json" | jq -er '.plan_token | select(length > 0)') || return 1
+    [[ $plan_token =~ ^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]] || return 1
+    active_confirm_id=$id
+    apply_json=$("$rbgp" --addr "$addr" --json config apply "$opposite" \
+        --expected-runtime-snapshot-token "$runtime_token" --plan-token "$plan_token" \
+        --confirm-id "$id" --confirm-timeout "$timeout") || return 1
+    [ "$(printf '%s' "$apply_json" | jq -er '.status')" = committable ] || return 1
+    apply_runtime=$(printf '%s' "$apply_json" | jq -er '.runtime_snapshot_token | select(type == "string")') || return 1
+    runtime_token_valid "$apply_runtime" || return 1
+    pending_deadline=$(printf '%s' "$apply_json" | jq -er --arg id "$id" --arg runtime "$apply_runtime" \
+        --argjson timeout "$timeout" \
+        '.confirmation | select(.status == "pending" and .confirm_id == $id and .timeout_seconds == $timeout and
+          .deadline_unix_seconds > 0 and .runtime_snapshot_token == $runtime) | .deadline_unix_seconds') || return 1
+    now=$(date +%s)
+    if [ "$pending_deadline" -le "$now" ] || [ "$pending_deadline" -gt $((now + timeout + 5)) ]; then
+        return 1
+    fi
+    status_json=$("$rbgp" --addr "$addr" --json config status) || return 1
+    printf '%s' "$status_json" | jq -e --arg id "$id" --arg runtime "$apply_runtime" \
+        --argjson timeout "$timeout" --argjson deadline "$pending_deadline" \
+        '.confirmation | select(.status == "pending" and .confirm_id == $id and .timeout_seconds == $timeout and
+          .deadline_unix_seconds == $deadline and .runtime_snapshot_token == $runtime)' >/dev/null || return 1
+    pending=$(pending_json "$id") || return 1
+    [ "$(printf '%s' "$pending" | jq -er '.authority.deadline_unix_seconds')" -eq "$pending_deadline" ] || return 1
+    warning=$(warning_json "$warning_before") || return 1
+    pending_runtime=$apply_runtime
+    pending_prefix=$(jq -cn --arg id "$id" --argjson timeout_seconds "$timeout" \
+        --argjson deadline_unix_seconds "$pending_deadline" --argjson pending "$pending" \
+        --argjson history_before "$history_before" --argjson warning "$warning" \
+        '{candidate_role:"opposite",plan:{transport:"streamed",status:"committable",
+          plan_token_present:true,runtime_snapshot_token_present:true},
+          apply:{transport:"streamed",explicit_plan_token:true,status:"committable",
+          confirmation_status:"pending",confirm_id:$id,timeout_seconds:$timeout_seconds,
+          deadline_unix_seconds:$deadline_unix_seconds,runtime_token_coherent:true},
+          history_before:$history_before,apply_history_warning:$warning,pending:$pending}'
+    ) || return 1
+}
+[ ! -e "$output" ] || die "lifecycle evidence already exists"
+[ "$(wc -l <"$evidence/cycles.jsonl" 2>/dev/null)" -eq 4 ] || die "four measured cycles are required"
+current_state=$(state_json) || die "cannot capture restored-current baseline"
+current_input=$(content_json "$current") || die "cannot capture current candidate"
+opposite_input=$(content_json "$opposite") || die "cannot capture opposite candidate"
+[ "$(printf '%s' "$current_input" | jq -r .sha256)" != "$(printf '%s' "$opposite_input" | jq -r .sha256)" ] ||
+    die "current and opposite generations are identical"
+apply_pending irrreload-abort 600 || die "abort pending transaction failed"
+abort_prefix=$pending_prefix; abort_runtime=$pending_runtime; abort_deadline=$pending_deadline
+abort_warning_before=$(warning_count)
+abort_json=$("$rbgp" --addr "$addr" --json config abort irrreload-abort) || die "abort RPC failed"
+abort_rollback_runtime=$(printf '%s' "$abort_json" | jq -er '.confirmation.runtime_snapshot_token | select(type == "string")') || die "abort runtime token missing"
+runtime_token_valid "$abort_rollback_runtime" || die "abort runtime token was not canonical kv2"
+[ "$abort_rollback_runtime" != "$abort_runtime" ] || die "abort did not rotate the runtime token"
+printf '%s' "$abort_json" | jq -e --arg runtime "$abort_rollback_runtime" --argjson deadline "$abort_deadline" \
+    'select(.runtime_snapshot_token == $runtime) | .confirmation |
+      select(.status == "aborted" and .confirm_id == "irrreload-abort" and
+      .timeout_seconds == 600 and .deadline_unix_seconds == $deadline and .runtime_snapshot_token == $runtime)' >/dev/null ||
+    die "abort response was incoherent"
+abort_status=$("$rbgp" --addr "$addr" --json config status) || die "abort terminal status failed"
+printf '%s' "$abort_status" | jq -e --arg runtime "$abort_rollback_runtime" --argjson deadline "$abort_deadline" \
+    '.confirmation | select(.status == "aborted" and .confirm_id == "irrreload-abort" and
+      .timeout_seconds == 600 and .deadline_unix_seconds == $deadline and .runtime_snapshot_token == $runtime)' >/dev/null ||
+    die "abort terminal status view was incoherent"
+active_confirm_id=
+abort_terminal=$(terminal_json) || die "abort cleanup evidence failed"
+abort_warning=$(warning_json "$abort_warning_before") || die "missing abort restore history warning"
+abort_history_after=$(history_json) || die "cannot capture history after abort"
+[ "$(printf '%s' "$abort_prefix" | jq -cS '.history_before')" = "$(printf '%s' "$abort_history_after" | jq -cS .)" ] ||
+    die "bounded history changed across abort"
+[ "$(printf '%s' "$abort_terminal" | jq -cS '.config,.runtime,.process.pid,.process.starttime')" = \
+  "$(printf '%s' "$current_state" | jq -cS '.config,.runtime,.process.pid,.process.starttime')" ] ||
+    die "abort did not exactly restore disk/runtime/process identity"
+abort=$(jq -cn --argjson prefix "$abort_prefix" --argjson terminal "$abort_terminal" \
+    --argjson warning "$abort_warning" --argjson history_after "$abort_history_after" \
+    '$prefix + {terminal:({status:"aborted",status_view_verified:true,restored_exactly:true,history_warning:$warning,
+      history_after:$history_after} + $terminal)}') || die "abort receipt failed"
+apply_pending irrreload-timeout 10 || die "timeout pending transaction failed"
+timeout_prefix=$pending_prefix; timeout_runtime=$pending_runtime; timeout_deadline=$pending_deadline
+timeout_warning_before=$(warning_count)
+deadline=$((SECONDS + 60))
+while :; do
+    status_json=$("$rbgp" --addr "$addr" --json config status) || die "timeout status failed"
+    outcome=$(printf '%s' "$status_json" | jq -er '.confirmation.status') || die "timeout status malformed"
+    [ "$outcome" = pending ] || break
+    [ "$SECONDS" -lt "$deadline" ] || die "timeout did not auto-revert within 60 seconds"
+    sleep 0.2
+done
+[ "$outcome" = auto_reverted ] || die "unexpected timeout outcome $outcome"
+timeout_rollback_runtime=$(printf '%s' "$status_json" | jq -er '.confirmation.runtime_snapshot_token | select(type == "string")') || die "timeout runtime token missing"
+runtime_token_valid "$timeout_rollback_runtime" || die "timeout runtime token was not canonical kv2"
+[ "$timeout_rollback_runtime" != "$timeout_runtime" ] || die "timeout did not rotate the runtime token"
+printf '%s' "$status_json" | jq -e --arg runtime "$timeout_rollback_runtime" --argjson deadline "$timeout_deadline" \
+    '.confirmation | select(.status == "auto_reverted" and .confirm_id == "irrreload-timeout" and
+      .timeout_seconds == 10 and .deadline_unix_seconds == $deadline and .runtime_snapshot_token == $runtime)' >/dev/null ||
+    die "timeout terminal status view was incoherent"
+active_confirm_id=
+timeout_terminal=$(terminal_json) || die "timeout cleanup evidence failed"
+timeout_warning=$(warning_json "$timeout_warning_before") || die "missing timeout restore history warning"
+timeout_history_after=$(history_json) || die "cannot capture history after timeout"
+[ "$(printf '%s' "$timeout_prefix" | jq -cS '.history_before')" = "$(printf '%s' "$timeout_history_after" | jq -cS .)" ] ||
+    die "bounded history changed across timeout"
+[ "$(printf '%s' "$timeout_terminal" | jq -cS '.config,.runtime,.process.pid,.process.starttime')" = \
+  "$(printf '%s' "$current_state" | jq -cS '.config,.runtime,.process.pid,.process.starttime')" ] ||
+    die "timeout did not exactly restore disk/runtime/process identity"
+timeout=$(jq -cn --argjson prefix "$timeout_prefix" --argjson terminal "$timeout_terminal" \
+    --argjson warning "$timeout_warning" --argjson history_after "$timeout_history_after" \
+    '$prefix + {terminal:({status:"auto_reverted",status_view_verified:true,restored_exactly:true,history_warning:$warning,
+      history_after:$history_after} + $terminal)}') || die "timeout receipt failed"
+noop_json=$("$rbgp" --addr "$addr" --json config plan "$current"); noop_rc=$?
+[ "$noop_rc" -eq 0 ] || die "restored-current plan exit $noop_rc, expected NOOP exit 0"
+[ "$(printf '%s' "$noop_json" | jq -er '.status')" = noop ] || die "restored-current plan not NOOP"
+[ "$(printf '%s' "$noop_json" | jq -r '.plan_token')" = null ] || die "NOOP unexpectedly returned a plan token"
+final_state=$(state_json) || die "cannot capture final restored state"
+[ "$(printf '%s' "$final_state" | jq -cS '.config,.runtime,.process.pid,.process.starttime')" = \
+  "$(printf '%s' "$current_state" | jq -cS '.config,.runtime,.process.pid,.process.starttime')" ] ||
+    die "final state differs from restored-current baseline"
+tmp="$output.tmp"
+jq -n --argjson baseline "$current_state" --argjson current "$current_input" \
+    --argjson opposite "$opposite_input" --argjson abort "$abort" --argjson timeout "$timeout" \
+    --argjson final_state "$final_state" \
+    '{schema:1,generations:{current:$current,opposite:$opposite},baseline:$baseline,
+      abort:$abort,timeout:$timeout,restored_current_plan:{transport:"streamed",status:"noop",
+      plan_token_present:false},final_state:$final_state}' >"$tmp" || die "cannot encode lifecycle evidence"
+mv "$tmp" "$output" || die "cannot publish lifecycle evidence"

--- a/bench/scale/irrreload/verify-receipt.py
+++ b/bench/scale/irrreload/verify-receipt.py
@@ -538,7 +538,7 @@ def validate_quiet(path: Path) -> None:
         or len({(row.get("pswpin"), row.get("pswpout")) for row in data}) != 1
         or any(not row.get("pswpin", "").isdigit() or not row.get("pswpout", "").isdigit() for row in data)
     ):
-        fail(f"{path}: quiet samples are too close or not below load 2")
+        fail(f"{path}: quiet samples fail spacing, load, port, disk, or swap gates")
 
 
 def validate_process(path: Path) -> tuple[int, int]:

--- a/bench/scale/irrreload/verify-receipt.py
+++ b/bench/scale/irrreload/verify-receipt.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import argparse
+import codecs
 import csv
 import hashlib
 import json
 import math
+import mmap
 import os
 import re
 import shutil
@@ -20,6 +22,7 @@ from pathlib import Path
 
 COMPARISON_CELLS = ("rustbgpd-sighup", "bird", "openbgpd")
 GROUPED_CELL = "rustbgpd-sighup-grouped-control"
+TRANSACTION_CELL = "rustbgpd-txn"
 CANONICAL_SHAPE = (320, 183040, 1000, 40000, 61)
 CANONICAL_FULL_INPUTS = {
     "smoke": "",
@@ -32,7 +35,7 @@ CANONICAL_FULL_INPUTS = {
     "port": "1790",
     "reloads": "4",
     "control_secs": "30",
-    "txn_max_candidate_bytes": "4194275",
+    "txn_max_candidate_bytes": "402653184",
     "cell_timeout": "7200",
     "start_timeout": "600",
     "bird_threads": "8",
@@ -393,13 +396,148 @@ def read_json(path: Path):
         fail(f"{path}: invalid JSON: {error}")
 
 
+def decode_lossless_path(value, context: str) -> bytes:
+    if (
+        not isinstance(value, dict)
+        or list(value) != ["encoding", "value"]
+        or value.get("encoding") != "unix-bytes-hex"
+        or not isinstance(value.get("value"), str)
+        or len(value["value"]) % 2 or not re.fullmatch(r"[0-9a-f]*", value["value"])
+    ):
+        fail(f"{context}: invalid lossless path")
+    return bytes.fromhex(value["value"])
+
+
+def inline_manifest_source_sha256(manifest: dict, raw_sha: str) -> str:
+    if manifest != {"toml_sha256": raw_sha, "rpol_units": [], "datasets": []}:
+        fail("transaction v3 manifest is not the exact inline-policy shape")
+    digest = hashlib.sha256(b"rustbgpd.config-source.v2\0")
+    for value in (bytes.fromhex(raw_sha), (0).to_bytes(8, "big"), (0).to_bytes(8, "big")):
+        digest.update(len(value).to_bytes(8, "big"))
+        digest.update(value)
+    return digest.hexdigest()
+
+
+def canonical_json(path: Path, cap: int, context: str) -> tuple[dict, bytes]:
+    raw = path.read_bytes()
+    if not raw or len(raw) > cap:
+        fail(f"{context}: file is empty or exceeds its cap")
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as error:
+        fail(f"{context}: invalid JSON: {error}")
+    encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode() + b"\n"
+    if encoded != raw or not raw.startswith(b'{"version":3,'):
+        fail(f"{context}: JSON is not canonical v3")
+    return value, raw
+
+
+def secure_file_identity(path: Path, cap: int, context: str) -> dict:
+    if path.is_symlink():
+        fail(f"{context}: symlink is forbidden")
+    metadata = path.stat()
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_IMODE(metadata.st_mode) != 0o600
+        or metadata.st_uid != os.geteuid()
+        or metadata.st_size <= 0
+        or metadata.st_size > cap
+    ):
+        fail(f"{context}: type, owner, mode, or size is invalid")
+    return {"name": path.name, "device": metadata.st_dev, "inode": metadata.st_ino,
+            "bytes": metadata.st_size, "sha256": sha256(path), "mode": "0600",
+            "owner_current_uid": True}
+
+
+def require_utf8(path: Path, context: str) -> None:
+    decoder = codecs.getincrementaldecoder("utf-8")("strict")
+    try:
+        with path.open("rb") as stream:
+            while chunk := stream.read(1024 * 1024):
+                decoder.decode(chunk)
+        decoder.decode(b"", final=True)
+    except UnicodeDecodeError:
+        fail(f"{context}: content is not UTF-8")
+
+
+def inspect_v3(locator_path: Path, metadata_path: Path, raw_path: Path, config_path: Path, confirm_id: str) -> dict:
+    locator_identity = secure_file_identity(locator_path, 512 * 1024, "v3 locator")
+    metadata_identity = secure_file_identity(metadata_path, 34 * 1024 * 1024, "v3 metadata")
+    raw_identity = secure_file_identity(raw_path, 384 * 1024 * 1024, "v3 raw")
+    locator, _ = canonical_json(locator_path, 512 * 1024, "v3 locator")
+    metadata, _ = canonical_json(metadata_path, 34 * 1024 * 1024, "v3 metadata")
+    locator_fields = ("version", "confirm_id", "metadata_path", "config_target",
+                      "prior_sha256", "prior_source_sha256")
+    metadata_fields = ("version", "confirm_id", "deadline_unix_seconds", "rollback_failed",
+                       "raw_name", "raw_length", "raw_sha256", "raw_source_sha256",
+                       "raw_device", "raw_inode", "manifest")
+    if tuple(locator or {}) != locator_fields or type(locator.get("version")) is not int or locator["version"] != 3 or locator.get("confirm_id") != confirm_id:
+        fail("v3 locator schema or confirmation id is invalid")
+    if tuple(metadata or {}) != metadata_fields or type(metadata.get("version")) is not int or metadata["version"] != 3 or metadata.get("confirm_id") != confirm_id:
+        fail("v3 metadata schema or confirmation id is invalid")
+    if tuple(metadata.get("manifest") or {}) != ("toml_sha256", "rpol_units", "datasets"):
+        fail("v3 metadata manifest field order is invalid")
+    expected_metadata = os.fsencode(str(metadata_path.resolve(strict=True)))
+    expected_config = os.fsencode(str(config_path.resolve(strict=True)))
+    if decode_lossless_path(locator["metadata_path"], "v3 metadata path") != expected_metadata:
+        fail("v3 locator does not name the expected metadata path")
+    if decode_lossless_path(locator["config_target"], "v3 config target") != expected_config:
+        fail("v3 locator does not name the expected config target")
+    if decode_lossless_path(metadata["raw_name"], "v3 raw name") != b"commit-confirm-v3-prior.toml":
+        fail("v3 metadata does not name the fixed raw object")
+    require_utf8(raw_path, "v3 raw")
+    raw_sha = raw_identity["sha256"]
+    source_sha = inline_manifest_source_sha256(metadata["manifest"], raw_sha)
+    if (
+        metadata.get("rollback_failed") is not False
+        or type(metadata.get("deadline_unix_seconds")) is not int
+        or metadata["deadline_unix_seconds"] <= 0
+        or any(type(metadata.get(field)) is not int for field in ("raw_length", "raw_device", "raw_inode"))
+        or metadata.get("raw_length") != raw_identity["bytes"]
+        or metadata.get("raw_device") != raw_identity["device"]
+        or metadata.get("raw_inode") != raw_identity["inode"]
+        or metadata.get("raw_sha256") != raw_sha
+        or metadata.get("raw_source_sha256") != source_sha
+        or metadata["manifest"].get("toml_sha256") != raw_sha
+        or locator.get("prior_sha256") != raw_sha
+        or locator.get("prior_source_sha256") != source_sha
+    ):
+        fail("v3 locator, metadata, manifest, and raw object are not linked")
+    return {
+        "schema": 1,
+        "version": 3,
+        "confirm_id": confirm_id,
+        "deadline_unix_seconds": metadata["deadline_unix_seconds"],
+        "linkage_verified": True,
+        "locator": locator_identity,
+        "metadata": metadata_identity,
+        "raw": raw_identity,
+    }
+
+
+def generation_marker(path: Path) -> str:
+    pattern = re.compile(rb'set_community_add\s*=\s*\[\s*"65400:(1000|2000)"\s*,?\s*\]')
+    with path.open("rb") as stream, mmap.mmap(stream.fileno(), 0, access=mmap.ACCESS_READ) as data:
+        markers = pattern.findall(data)
+    if len(markers) != 1:
+        fail(f"{path}: transaction generation marker is not exact A or B")
+    return "65400:" + markers[0].decode()
+
+
 def validate_quiet(path: Path) -> None:
     data = list(csv.DictReader(path.open(), delimiter="\t"))
     if [row.get("sample") for row in data] != ["1", "2"]:
         fail(f"{path}: quiet gate needs exactly two samples")
     epochs = [int(row["epoch_s"]) for row in data]
     loads = [float(row["load1"]) for row in data]
-    if epochs[1] - epochs[0] < 30 or any(not math.isfinite(load) or load >= 2.0 for load in loads):
+    if (
+        epochs[1] - epochs[0] < 30
+        or any(not math.isfinite(load) or load >= 2.0 for load in loads)
+        or any(row.get("port1790_free") != "true" or row.get("port9179_free") != "true" for row in data)
+        or any(int(row.get("disk_available_kib", "0")) < 40 * 1024 * 1024 for row in data)
+        or len({(row.get("pswpin"), row.get("pswpout")) for row in data}) != 1
+        or any(not row.get("pswpin", "").isdigit() or not row.get("pswpout", "").isdigit() for row in data)
+    ):
         fail(f"{path}: quiet samples are too close or not below load 2")
 
 
@@ -589,14 +727,390 @@ def validate_cell_chain(
         fail(f"{cdir}: pass status does not bind the full evidence chain")
 
 
+def reject_transaction_tokens(value, path="receipt") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in {"plan_token", "runtime_snapshot_token"}:
+                fail(f"{path}: token contents were retained")
+            reject_transaction_tokens(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            reject_transaction_tokens(child, f"{path}[{index}]")
+    elif isinstance(value, str) and (
+        re.fullmatch(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}", value)
+        or value.startswith(("kv1:", "kv2:"))
+    ):
+        fail(f"{path}: token-shaped string was retained")
+
+
+def validate_content(value, context: str) -> None:
+    if set(value or {}) != {"sha256", "bytes", "marker"} or not re.fullmatch(
+        r"[0-9a-f]{64}", value.get("sha256", "")
+    ) or not isinstance(value.get("bytes"), int) or value["bytes"] <= 0 or value.get(
+        "marker"
+    ) not in {"65400:1000", "65400:2000"}:
+        fail(f"{context}: invalid content identity")
+
+
+def validate_process_json(value, expected: tuple[int, int], context: str) -> None:
+    if (
+        set(value or {}) != {"pid", "starttime", "vmrss_kib", "vmhwm_kib"}
+        or (value.get("pid"), value.get("starttime")) != expected
+        or not all(isinstance(value.get(key), int) and value[key] > 0 for key in value)
+        or value["vmhwm_kib"] < value["vmrss_kib"]
+    ):
+        fail(f"{context}: daemon process/RSS identity is invalid")
+
+
+def validate_history(value, context: str) -> None:
+    if set(value or {}) != {"entries", "files"} or value.get("entries") != [] or value.get("files") != []:
+        fail(f"{context}: oversize history was not exactly empty")
+
+
+def validate_warning(value, context: str) -> tuple[int, int]:
+    if (
+        set(value or {}) != {"count_before", "count_after", "bytes"}
+        or not all(isinstance(value.get(key), int) for key in value)
+        or value["count_after"] != value["count_before"] + 1
+        or value["bytes"] <= 10 * 1024 * 1024
+    ):
+        fail(f"{context}: SkippedOversize warning evidence is invalid")
+    return value["count_before"], value["count_after"]
+
+
+def validate_file_identity(value, expected_name: str, context: str) -> None:
+    if (
+        set(value or {})
+        != {"name", "device", "inode", "bytes", "sha256", "mode", "owner_current_uid"}
+        or value.get("name") != expected_name
+        or not re.fullmatch(r"[0-9a-f]{64}", value.get("sha256", ""))
+        or not all(isinstance(value.get(key), int) and value[key] > 0 for key in ("device", "inode", "bytes"))
+        or value.get("mode") != "0600"
+        or value.get("owner_current_uid") is not True
+    ):
+        fail(f"{context}: invalid v3 file identity")
+
+
+def validate_authority(value, confirm_id: str, deadline: int, context: str) -> None:
+    if (
+        set(value or {})
+        != {
+            "schema",
+            "version",
+            "confirm_id",
+            "deadline_unix_seconds",
+            "linkage_verified",
+            "locator",
+            "metadata",
+            "raw",
+        }
+        or value.get("schema") != 1
+        or value.get("version") != 3
+        or value.get("confirm_id") != confirm_id
+        or value.get("deadline_unix_seconds") != deadline
+        or value.get("linkage_verified") is not True
+    ):
+        fail(f"{context}: v3 authority linkage receipt is invalid")
+    validate_file_identity(value["locator"], "config.toml.commit-confirm-locator.json", context)
+    validate_file_identity(value["metadata"], "commit-confirm-v3-metadata.json", context)
+    validate_file_identity(value["raw"], "commit-confirm-v3-prior.toml", context)
+    if not 10 * 1024 * 1024 < value["raw"]["bytes"] <= 384 * 1024 * 1024:
+        fail(f"{context}: v3 raw snapshot is outside (10 MiB, 384 MiB]")
+
+
+def validate_state(
+    value,
+    expected_process: tuple[int, int],
+    pending: bool,
+    context: str,
+    confirm_id: str = "",
+    deadline: int = 0,
+) -> None:
+    common = {"legacy_absent", "history_entries", "history_outcome", "process", "config", "runtime"}
+    expected_keys = common | ({"authority"} if pending else {"v3_absent"})
+    if (
+        set(value or {}) != expected_keys
+        or value.get("legacy_absent") is not True
+        or value.get("history_entries") != 0
+        or value.get("history_outcome") != "skipped_oversize"
+        or (not pending and value.get("v3_absent") is not True)
+    ):
+        fail(f"{context}: lifecycle state shape/outcome is invalid")
+    validate_process_json(value["process"], expected_process, context)
+    validate_content(value["config"], context)
+    validate_content(value["runtime"], context)
+    if pending:
+        validate_authority(value["authority"], confirm_id, deadline, context)
+
+
+def validate_plan_apply(prefix, confirm_id: str, timeout: int, context: str) -> int:
+    plan, apply = prefix.get("plan", {}), prefix.get("apply", {})
+    deadline = apply.get("deadline_unix_seconds")
+    if (
+        plan != {
+        "transport": "streamed",
+        "status": "committable",
+        "plan_token_present": True,
+        "runtime_snapshot_token_present": True,
+        }
+        or not isinstance(deadline, int)
+        or deadline <= 0
+        or apply
+        != {
+            "transport": "streamed",
+            "explicit_plan_token": True,
+            "status": "committable",
+            "confirmation_status": "pending",
+            "confirm_id": confirm_id,
+            "timeout_seconds": timeout,
+            "deadline_unix_seconds": deadline,
+            "runtime_token_coherent": True,
+        }
+    ):
+        fail(f"{context}: streamed explicit-token confirmed apply contract is invalid")
+    return deadline
+
+
+def validate_transaction_evidence(
+    cdir: Path, identity: tuple[int, int], scenario_entries: dict[str, str]
+) -> dict:
+    expected_files = {
+        "daemon.log", "evidence.sha256", "final-evidence/ack", "final-evidence/ready",
+        "manifest.json", "process.tsv", "provenance.json", "quiet.tsv", "reloadstall.log",
+        "rows.csv", "rss.csv", "scenario.sha256", "status", "transactions/cycles.jsonl",
+        "transactions/lifecycle.json",
+    }
+    actual_files = {path.relative_to(cdir).as_posix() for path in cdir.rglob("*") if path.is_file()}
+    if actual_files != expected_files:
+        fail(f"{cdir}: transaction cell roster is not exact")
+    try:
+        cycles = [json.loads(line) for line in (cdir / "transactions/cycles.jsonl").read_text().splitlines()]
+    except json.JSONDecodeError as error:
+        fail(f"{cdir}: invalid transaction cycle JSONL: {error}")
+    if len(cycles) != 4:
+        fail(f"{cdir}: expected exactly four transaction cycles")
+    warning_edges = []
+    candidate_ids = []
+    actual_ids = []
+    for number, cycle in enumerate(cycles, 1):
+        reject_transaction_tokens(cycle)
+        if set(cycle) != {"schema", "cycle", "candidate", "plan", "apply", "history", "pending", "confirmed"} or cycle.get("schema") != 1 or cycle.get("cycle") != number:
+            fail(f"{cdir}: transaction cycle roster/order is invalid")
+        validate_content(cycle["candidate"], f"cycle {number} candidate")
+        if not 10 * 1024 * 1024 < cycle["candidate"]["bytes"] <= 384 * 1024 * 1024:
+            fail(f"{cdir}: transaction candidate is outside streamed bounds")
+        candidate_ids.append(
+            (
+                cycle["candidate"]["sha256"],
+                cycle["candidate"]["bytes"],
+                cycle["candidate"]["marker"],
+            )
+        )
+        confirm_id = f"irrreload-measured-{number}"
+        deadline = validate_plan_apply(cycle, confirm_id, 600, f"cycle {number}")
+        history = cycle.get("history", {})
+        if set(history) != {"before", "after", "outcome", "warning"} or history.get("outcome") != "skipped_oversize":
+            fail(f"{cdir}: cycle {number} history receipt is invalid")
+        validate_history(history["before"], f"cycle {number} history before")
+        validate_history(history["after"], f"cycle {number} history after")
+        if history["before"] != history["after"]:
+            fail(f"{cdir}: cycle {number} changed bounded history")
+        warning_edges.append(validate_warning(history["warning"], f"cycle {number}"))
+        validate_state(
+            cycle["pending"],
+            identity,
+            True,
+            f"cycle {number} pending",
+            confirm_id,
+            deadline,
+        )
+        confirmed = cycle["confirmed"]
+        if confirmed.get("status") != "confirmed" or confirmed.get("status_view_verified") is not True:
+            fail(f"{cdir}: cycle {number} was not confirmed")
+        validate_state(
+            {
+                key: value
+                for key, value in confirmed.items()
+                if key not in {"status", "status_view_verified"}
+            },
+            identity,
+            False,
+            f"cycle {number} confirmed",
+        )
+        for field in ("config", "runtime"):
+            if cycle["pending"][field] != confirmed[field]:
+                fail(f"{cdir}: confirm changed {field} identity")
+        expected_marker = "65400:2000" if number % 2 else "65400:1000"
+        if cycle["candidate"]["marker"] != expected_marker or any(
+            confirmed[field]["marker"] != expected_marker
+            for field in ("config", "runtime")
+        ):
+            fail(f"{cdir}: cycle {number} did not apply its sealed generation marker")
+        actual_ids.append(
+            (
+                (
+                    confirmed["config"]["sha256"],
+                    confirmed["config"]["bytes"],
+                    confirmed["config"]["marker"],
+                ),
+                (
+                    confirmed["runtime"]["sha256"],
+                    confirmed["runtime"]["bytes"],
+                    confirmed["runtime"]["marker"],
+                ),
+            )
+        )
+    if not (candidate_ids[0] == candidate_ids[2] and candidate_ids[1] == candidate_ids[3] and candidate_ids[0] != candidate_ids[1]):
+        fail(f"{cdir}: measured candidates do not alternate B/A/B/A")
+    if (
+        candidate_ids[0][0] != scenario_entries.get("gen-b.toml")
+        or candidate_ids[1][0] != scenario_entries.get("gen-a.toml")
+    ):
+        fail(f"{cdir}: measured candidates are not bound to sealed gen-a/gen-b inputs")
+    if not (
+        actual_ids[0] == actual_ids[2]
+        and actual_ids[1] == actual_ids[3]
+        and actual_ids[0] != actual_ids[1]
+    ):
+        fail(f"{cdir}: persisted config/runtime did not alternate B/A/B/A")
+
+    lifecycle = read_json(cdir / "transactions/lifecycle.json")
+    reject_transaction_tokens(lifecycle)
+    if set(lifecycle or {}) != {"schema", "generations", "baseline", "abort", "timeout", "restored_current_plan", "final_state"} or lifecycle.get("schema") != 1:
+        fail(f"{cdir}: lifecycle roster is invalid")
+    generations = lifecycle.get("generations", {})
+    if set(generations) != {"current", "opposite"}:
+        fail(f"{cdir}: lifecycle generation roster is invalid")
+    validate_content(generations["current"], "current generation")
+    validate_content(generations["opposite"], "opposite generation")
+    if (
+        (
+            generations["current"]["sha256"],
+            generations["current"]["bytes"],
+            generations["current"]["marker"],
+        )
+        != candidate_ids[3]
+        or (
+            generations["opposite"]["sha256"],
+            generations["opposite"]["bytes"],
+            generations["opposite"]["marker"],
+        )
+        != candidate_ids[2]
+    ):
+        fail(f"{cdir}: lifecycle did not use final A/opposite B generations")
+    baseline = lifecycle["baseline"]
+    final_state = lifecycle["final_state"]
+    for state, label in ((baseline, "baseline"), (final_state, "final")):
+        if set(state or {}) != {"history_entries", "history_outcome", "process", "config", "runtime"} or state.get("history_entries") != 0 or state.get("history_outcome") != "skipped_oversize":
+            fail(f"{cdir}: {label} restored state is invalid")
+        validate_process_json(state["process"], identity, label)
+        validate_content(state["config"], label); validate_content(state["runtime"], label)
+    if any(baseline[field] != final_state[field] for field in ("config", "runtime")):
+        fail(f"{cdir}: final disk/runtime state was not restored exactly")
+    if any(
+        (baseline[field]["sha256"], baseline[field]["bytes"], baseline[field]["marker"])
+        != actual_ids[3][index]
+        for index, field in enumerate(("config", "runtime"))
+    ):
+        fail(f"{cdir}: lifecycle baseline is not measured generation A")
+    prior_after = warning_edges[-1][1]
+    for name, terminal_status in (("abort", "aborted"), ("timeout", "auto_reverted")):
+        phase = lifecycle.get(name, {})
+        expected_id = f"irrreload-{name}"
+        required = {"candidate_role", "plan", "apply", "history_before", "apply_history_warning", "pending", "terminal"}
+        if set(phase or {}) != required or phase.get("candidate_role") != "opposite":
+            fail(f"{cdir}: {name} lifecycle roster is invalid")
+        deadline = validate_plan_apply(phase, expected_id, 600 if name == "abort" else 10, name)
+        validate_history(phase["history_before"], f"{name} history before")
+        apply_edge = validate_warning(phase["apply_history_warning"], f"{name} apply")
+        validate_state(
+            phase["pending"], identity, True, f"{name} pending", expected_id, deadline
+        )
+        terminal = phase["terminal"]
+        extra = {
+            "status",
+            "status_view_verified",
+            "restored_exactly",
+            "history_warning",
+            "history_after",
+        }
+        if (
+            not extra.issubset(terminal)
+            or terminal.get("status") != terminal_status
+            or terminal.get("status_view_verified") is not True
+            or terminal.get("restored_exactly") is not True
+        ):
+            fail(f"{cdir}: {name} terminal outcome is invalid")
+        validate_state({key: value for key, value in terminal.items() if key not in extra}, identity, False, f"{name} terminal")
+        validate_history(terminal["history_after"], f"{name} history after")
+        if terminal["history_after"] != phase["history_before"]:
+            fail(f"{cdir}: {name} changed bounded history")
+        terminal_edge = validate_warning(terminal["history_warning"], f"{name} restore")
+        if apply_edge[0] != prior_after or terminal_edge[0] != apply_edge[1]:
+            fail(f"{cdir}: {name} history warning sequence is discontinuous")
+        prior_after = terminal_edge[1]
+        for field in ("config", "runtime"):
+            if terminal[field] != baseline[field]:
+                fail(f"{cdir}: {name} did not restore {field} exactly")
+        for index, field in enumerate(("config", "runtime")):
+            pending_identity = (
+                phase["pending"][field]["sha256"],
+                phase["pending"][field]["bytes"],
+                phase["pending"][field]["marker"],
+            )
+            if pending_identity != actual_ids[2][index]:
+                fail(f"{cdir}: {name} pending state is not measured generation B")
+    if any(right[0] != left[1] for left, right in zip(warning_edges, warning_edges[1:])) or warning_edges[0][0] != 1 or prior_after != 9:
+        fail(f"{cdir}: oversize warning count is not exact across nine persists")
+    if lifecycle.get("restored_current_plan") != {"transport": "streamed", "status": "noop", "plan_token_present": False}:
+        fail(f"{cdir}: restored-current streamed Plan was not tokenless NOOP")
+    warning_lines = [
+        line for line in (cdir / "daemon.log").read_text().splitlines()
+        if "applied config exceeds the bounded history entry size; history was left unchanged" in line
+    ]
+    if len(warning_lines) != 9:
+        fail(f"{cdir}: daemon log does not contain exactly nine oversize history warnings")
+    try:
+        warning_bytes = [json.loads(line)["fields"]["bytes"] for line in warning_lines]
+    except (json.JSONDecodeError, KeyError, TypeError):
+        fail(f"{cdir}: daemon oversize warning lines are malformed")
+    if any(not isinstance(size, int) or size <= 10 * 1024 * 1024 for size in warning_bytes):
+        fail(f"{cdir}: daemon oversize warning byte counts are invalid")
+    compact_warning_bytes = [cycle["history"]["warning"]["bytes"] for cycle in cycles]
+    for name in ("abort", "timeout"):
+        compact_warning_bytes.extend(
+            (
+                lifecycle[name]["apply_history_warning"]["bytes"],
+                lifecycle[name]["terminal"]["history_warning"]["bytes"],
+            )
+        )
+    if compact_warning_bytes != warning_bytes[1:]:
+        fail(f"{cdir}: compact history-warning evidence is not bound to daemon log order")
+    return {
+        "inputs": {"a": candidate_ids[1], "b": candidate_ids[0]},
+        "actual": {
+            "a": {"config": actual_ids[1][0], "runtime": actual_ids[1][1]},
+            "b": {"config": actual_ids[0][0], "runtime": actual_ids[0][1]},
+        },
+    }
+
+
 def validate_root(root: Path, kind: str):
     reject_symlinks(root)
     validate_seal(root)
     validate_preflight(root / "preflight.log")
     provenance = read_json(root / "provenance.json")
     inputs, git = provenance.get("inputs", {}), provenance.get("git", {})
-    expected_cells = COMPARISON_CELLS if kind == "comparison" else (GROUPED_CELL,)
-    expected_kind = "full-cross-daemon" if kind == "comparison" else "full-grouped-control"
+    expected_cells = {
+        "comparison": COMPARISON_CELLS,
+        "grouped": (GROUPED_CELL,),
+        "transaction": (TRANSACTION_CELL,),
+    }[kind]
+    expected_kind = {
+        "comparison": "full-cross-daemon",
+        "grouped": "full-grouped-control",
+        "transaction": "full-transaction",
+    }[kind]
     scripts = provenance.get("scripts")
     binaries = provenance.get("binaries")
     environment = provenance.get("environment")
@@ -636,7 +1150,7 @@ def validate_root(root: Path, kind: str):
         or not re.fullmatch(r"[0-9a-f]{64}", fingerprint)
         or provenance_fingerprint(provenance) != fingerprint
         or not isinstance(scripts, dict)
-        or set(scripts) != {"runner", "verifier", "generator", "rss_sampler", "txn_apply"}
+        or set(scripts) != {"runner", "verifier", "generator", "rss_sampler", "txn_apply", "txn_lifecycle"}
         or not all(isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value) for value in scripts.values())
         or not isinstance(binaries, dict)
         or set(binaries) != {"reloadstall", "rustbgpd", "rbgp", "rs_config_render"}
@@ -667,7 +1181,7 @@ def validate_root(root: Path, kind: str):
             for key in ("bird_image_id", "openbgpd_image_id")
         )
     ) or (
-        kind == "grouped"
+        kind != "comparison"
         and any(
             inputs.get(key) != "not-selected"
             for key in ("bird_image_id", "openbgpd_image_id")
@@ -711,6 +1225,7 @@ def validate_root(root: Path, kind: str):
     ):
         fail(f"{root}: COMPLETED does not bind status/cells/fingerprint/time")
     identities = []
+    transaction_evidence = None
     for cell in expected_cells:
         cdir = root / cell
         validate_quiet(cdir / "quiet.tsv")
@@ -721,6 +1236,9 @@ def validate_root(root: Path, kind: str):
                 fail(f"{root}: {cell} final-evidence {marker} is not an exact regular marker")
         manifest = read_json(cdir / "manifest.json")
         scenario_digest = validate_scenario_roster(cdir, manifest)
+        scenario_entries = parse_digest_roster(
+            cdir / "scenario.sha256", {*manifest["runtime_files"], "manifest.json"}
+        )
         validate_cell_chain(
             root,
             cell,
@@ -745,6 +1263,12 @@ def validate_root(root: Path, kind: str):
         elif cell == GROUPED_CELL:
             if manifest.get("path_hiding") is not False or manifest.get("path_hiding_applicable") is not True:
                 fail(f"{root}: grouped rustbgpd path-hiding mode not explicit")
+        elif cell == TRANSACTION_CELL:
+            if manifest.get("path_hiding") is not True or manifest.get("path_hiding_applicable") is not True:
+                fail(f"{root}: transaction path-hiding mode not explicit")
+            transaction_evidence = validate_transaction_evidence(
+                cdir, identities[-1], scenario_entries
+            )
         elif not (
             manifest.get("path_hiding") is None
             and manifest.get("path_hiding_applicable") is False
@@ -795,6 +1319,7 @@ def validate_root(root: Path, kind: str):
         "inputs": inputs,
         "identities": identities,
         "rows": rows_data,
+        "transaction_evidence": transaction_evidence,
     }
 
 
@@ -894,8 +1419,127 @@ def validate_campaigns(roots: list[Path], output_dir: Path) -> None:
     )
 
 
+def validate_transactions(roots: list[Path], output_dir: Path) -> None:
+    if len(roots) != 2:
+        fail("expected exactly two transaction roots in A/B order")
+    campaigns = [validate_root(root, "transaction") for root in roots]
+    if len({(entry["commit"], entry["shape"], entry["dataset"]) for entry in campaigns}) != 1:
+        fail("transaction roots do not share commit, canonical shape/seed, and dataset")
+    if campaigns[0]["completed"] >= campaigns[1]["started"]:
+        fail("transaction roots overlap or are not in A/B order")
+    shared = ("git", "scripts", "binaries", "environment", "inputs")
+    if any(campaigns[0][key] != campaigns[1][key] for key in shared):
+        fail("transaction roots do not share exact source, tool, platform, and inputs")
+    if campaigns[0]["transaction_evidence"] != campaigns[1]["transaction_evidence"]:
+        fail("transaction roots do not share exact A/B input and applied-state identities")
+    identities = [identity for campaign in campaigns for identity in campaign["identities"]]
+    if len(identities) != len(set(identities)):
+        fail("daemon PID/start identity was reused across transaction roots")
+    output_dir.mkdir(parents=True, exist_ok=False)
+    write_combined(output_dir / "transactions.csv", campaigns, (TRANSACTION_CELL,))
+    (output_dir / "verification.json").write_text(
+        json.dumps(
+            {
+                "status": "pass",
+                "order": ["transaction-A", "transaction-B"],
+                "commit": campaigns[0]["commit"],
+                "dataset_sha256": campaigns[0]["dataset"],
+                "transaction_rows": sum(len(campaign["rows"]) for campaign in campaigns),
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
+def make_transaction_evidence(cdir: Path, pid: int) -> None:
+    size = 11 * 1024 * 1024
+    history = {"entries": [], "files": []}
+    process = {"pid": pid, "starttime": pid + 100, "vmrss_kib": 1024, "vmhwm_kib": 2048}
+
+    def content(digest):
+        return {"sha256": digest * 64, "bytes": size,
+                "marker": "65400:1000" if digest == "a" else "65400:2000"}
+
+    def file_identity(name, digest, inode, bytes_count):
+        return {"name": name, "device": 1, "inode": inode, "bytes": bytes_count,
+                "sha256": digest * 64, "mode": "0600", "owner_current_uid": True}
+
+    def authority(confirm_id, deadline, inode):
+        return {"schema": 1, "version": 3, "confirm_id": confirm_id,
+            "deadline_unix_seconds": deadline, "linkage_verified": True,
+            "locator": file_identity("config.toml.commit-confirm-locator.json", "c", inode, 100),
+            "raw": file_identity("commit-confirm-v3-prior.toml", "d", inode + 1, size),
+            "metadata": file_identity("commit-confirm-v3-metadata.json", "e", inode + 2, 200)}
+
+    def base_state(digest):
+        return {"history_entries": 0, "history_outcome": "skipped_oversize",
+                "process": process, "config": content(digest), "runtime": content(digest)}
+
+    def pending(digest, confirm_id, deadline, inode):
+        return {"authority": authority(confirm_id, deadline, inode),
+                "legacy_absent": True, **base_state(digest)}
+
+    def terminal(digest):
+        return {"v3_absent": True, "legacy_absent": True, **base_state(digest)}
+
+    def warning(before):
+        return {"count_before": before, "count_after": before + 1, "bytes": size}
+
+    cycles = []
+    for number in range(1, 5):
+        digest = "b" if number % 2 else "a"
+        confirm_id = f"irrreload-measured-{number}"
+        deadline = 1_000 + number
+        cycles.append(
+            {
+                "schema": 1,
+                "cycle": number,
+                "candidate": content(digest),
+                "plan": {"transport": "streamed", "status": "committable", "plan_token_present": True, "runtime_snapshot_token_present": True},
+                "apply": {"transport": "streamed", "explicit_plan_token": True, "status": "committable", "confirmation_status": "pending", "confirm_id": confirm_id, "timeout_seconds": 600, "deadline_unix_seconds": deadline, "runtime_token_coherent": True},
+                "history": {"before": history, "after": history, "outcome": "skipped_oversize", "warning": warning(number)},
+                "pending": pending(digest, confirm_id, deadline, 100 + number * 10),
+                "confirmed": {"status": "confirmed", "status_view_verified": True, **terminal(digest)},
+            }
+        )
+    txn_dir = cdir / "transactions"
+    txn_dir.mkdir()
+    (txn_dir / "cycles.jsonl").write_text("".join(json.dumps(cycle) + "\n" for cycle in cycles))
+
+    def phase(name, timeout, apply_before, restore_before, inode):
+        confirm_id = f"irrreload-{name}"
+        deadline = 2_000 + inode
+        return {"candidate_role": "opposite",
+            "plan": {"transport": "streamed", "status": "committable", "plan_token_present": True, "runtime_snapshot_token_present": True},
+            "apply": {"transport": "streamed", "explicit_plan_token": True, "status": "committable", "confirmation_status": "pending", "confirm_id": confirm_id, "timeout_seconds": timeout, "deadline_unix_seconds": deadline, "runtime_token_coherent": True},
+            "history_before": history, "apply_history_warning": warning(apply_before),
+            "pending": pending("b", confirm_id, deadline, inode),
+            "terminal": {"status": "aborted" if name == "abort" else "auto_reverted",
+                "status_view_verified": True, "restored_exactly": True,
+                "history_warning": warning(restore_before),
+                "history_after": history, **terminal("a")}}
+
+    lifecycle = {
+        "schema": 1,
+        "generations": {"current": content("a"), "opposite": content("b")},
+        "baseline": base_state("a"),
+        "abort": phase("abort", 600, 5, 6, 200),
+        "timeout": phase("timeout", 10, 7, 8, 300),
+        "restored_current_plan": {"transport": "streamed", "status": "noop", "plan_token_present": False},
+        "final_state": base_state("a"),
+    }
+    (txn_dir / "lifecycle.json").write_text(json.dumps(lifecycle) + "\n")
+    warning_line = json.dumps({"fields": {"message": "applied config exceeds the bounded history entry size; history was left unchanged", "bytes": size}})
+    (cdir / "daemon.log").write_text((warning_line + "\n") * 9)
+
+
 def make_fixture(root: Path, kind: str, started: int, identity_seed: int) -> None:
-    cells = COMPARISON_CELLS if kind == "comparison" else (GROUPED_CELL,)
+    cells = {
+        "comparison": COMPARISON_CELLS,
+        "grouped": (GROUPED_CELL,),
+        "transaction": (TRANSACTION_CELL,),
+    }[kind]
     root.mkdir()
     dataset = "a" * 64
     (root / "dataset.sha256").write_text(dataset + "\n")
@@ -904,12 +1548,12 @@ def make_fixture(root: Path, kind: str, started: int, identity_seed: int) -> Non
         "schema": 3,
         "started_at_epoch_ns": started,
         "git": {"commit": "c" * 40, "dirty": False, "dirty_state_sha256": "d" * 64, "origin_main": "c" * 40, "head_matches_origin_main": True},
-        "scripts": {"runner": "1" * 64, "verifier": "2" * 64, "generator": "3" * 64, "rss_sampler": "4" * 64, "txn_apply": "5" * 64},
+        "scripts": {"runner": "1" * 64, "verifier": "2" * 64, "generator": "3" * 64, "rss_sampler": "4" * 64, "txn_apply": "5" * 64, "txn_lifecycle": "a" * 64},
         "binaries": {"reloadstall": "6" * 64, "rustbgpd": "7" * 64, "rbgp": "8" * 64, "rs_config_render": "9" * 64},
         "environment": {key: "fixture" for key in ("rustc", "cargo", "python", "jq", "docker", "kernel", "cpu_model")},
         "inputs": {
             **CANONICAL_FULL_INPUTS,
-            "campaign_kind": "full-cross-daemon" if kind == "comparison" else "full-grouped-control",
+            "campaign_kind": {"comparison": "full-cross-daemon", "grouped": "full-grouped-control", "transaction": "full-transaction"}[kind],
             "cells": ",".join(cells),
             "bird_image_id": image_id if kind == "comparison" else "not-selected",
             "openbgpd_image_id": image_id if kind == "comparison" else "not-selected",
@@ -934,18 +1578,24 @@ def make_fixture(root: Path, kind: str, started: int, identity_seed: int) -> Non
     for offset, cell in enumerate(cells):
         cdir = root / cell
         cdir.mkdir()
-        (cdir / "quiet.tsv").write_text("sample\tepoch_s\tload1\n1\t1\t0.5\n2\t31\t0.5\n")
+        (cdir / "quiet.tsv").write_text(
+            "sample\tepoch_s\tload1\tpswpin\tpswpout\tport1790_free\tport9179_free\tdisk_available_kib\n"
+            "1\t1\t0.5\t0\t0\ttrue\ttrue\t41943040\n2\t31\t0.5\t0\t0\ttrue\ttrue\t41943040\n"
+        )
         pid = identity_seed + offset
         (cdir / "process.tsv").write_text(f"pid\tstarttime_before\tstarttime_after\n{pid}\t{pid + 100}\t{pid + 100}\n")
         if cell == "rustbgpd-sighup":
             mode = {"path_hiding": True, "path_hiding_applicable": True, "path_hiding_requested": True}
         elif cell == GROUPED_CELL:
             mode = {"path_hiding": False, "path_hiding_applicable": True, "path_hiding_requested": False}
+        elif cell == TRANSACTION_CELL:
+            mode = {"path_hiding": True, "path_hiding_applicable": True, "path_hiding_requested": True}
         else:
             mode = {"path_hiding": None, "path_hiding_applicable": False, "path_hiding_requested": True}
         runtime_files = {
             "rustbgpd-sighup": ["config.toml", "member.rpol", "gen-a.rpol", "gen-b.rpol"],
             GROUPED_CELL: ["config.toml", "member.rpol", "gen-a.rpol", "gen-b.rpol"],
+            TRANSACTION_CELL: ["config.toml", "candidate.toml", "gen-a.toml", "gen-b.toml"],
             "bird": ["bird.conf", "gen.conf", "gen-a.conf", "gen-b.conf"],
             "openbgpd": ["bgpd.conf", "gen.conf", "gen-a.conf", "gen-b.conf"],
         }[cell]
@@ -986,10 +1636,17 @@ def make_fixture(root: Path, kind: str, started: int, identity_seed: int) -> Non
             boundary.mkdir()
             (boundary / "ready").write_text("ready\n")
             (boundary / "ack").write_text("ack\n")
+        elif cell == TRANSACTION_CELL:
+            make_transaction_evidence(cdir, pid)
         scenario_lines = []
         for relative in [*runtime_files, "manifest.json"]:
             retained_input = cdir / relative
-            digest = sha256(retained_input) if retained_input.is_file() else "0" * 64
+            if cell == TRANSACTION_CELL and relative == "gen-a.toml":
+                digest = "a" * 64
+            elif cell == TRANSACTION_CELL and relative == "gen-b.toml":
+                digest = "b" * 64
+            else:
+                digest = sha256(retained_input) if retained_input.is_file() else "0" * 64
             scenario_lines.append(f"{digest}  ./{relative}")
         (cdir / "scenario.sha256").write_text("\n".join(sorted(scenario_lines)) + "\n")
         cell_provenance = json.loads(json.dumps(provenance))
@@ -1061,7 +1718,7 @@ def rebind_provenance(root: Path) -> None:
     provenance = read_json(provenance_path)
     provenance["fingerprint"] = provenance_fingerprint(provenance)
     provenance_path.write_text(json.dumps(provenance))
-    for cell in (*COMPARISON_CELLS, GROUPED_CELL):
+    for cell in (*COMPARISON_CELLS, GROUPED_CELL, TRANSACTION_CELL):
         cell_path = root / cell / "provenance.json"
         if not cell_path.is_file():
             continue
@@ -1082,6 +1739,106 @@ def self_test() -> None:
     proofs = {}
     with tempfile.TemporaryDirectory() as directory:
         base = Path(directory)
+
+        v3_dir = base / "v3"
+        v3_dir.mkdir(mode=0o700)
+        v3_config, v3_raw = v3_dir / "config.toml", v3_dir / "commit-confirm-v3-prior.toml"
+        v3_metadata = v3_dir / "commit-confirm-v3-metadata.json"; v3_locator = v3_dir / "config.toml.commit-confirm-locator.json"
+        v3_config.write_text("candidate\n")
+        v3_raw.write_text("prior\n")
+        v3_raw.chmod(0o600)
+        raw_stat = v3_raw.stat()
+        raw_sha = sha256(v3_raw)
+        manifest = {"toml_sha256": raw_sha, "rpol_units": [], "datasets": []}
+        source_sha = inline_manifest_source_sha256(manifest, raw_sha)
+
+        def wire_path(path: Path) -> dict:
+            return {"encoding": "unix-bytes-hex", "value": os.fsencode(str(path.resolve(strict=True))).hex()}
+
+        def write_canonical(path: Path, value: dict) -> None:
+            path.write_bytes(json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode() + b"\n")
+            path.chmod(0o600)
+
+        metadata_value = {
+            "version": 3, "confirm_id": "fixture-confirm", "deadline_unix_seconds": 1234,
+            "rollback_failed": False,
+            "raw_name": {"encoding": "unix-bytes-hex", "value": b"commit-confirm-v3-prior.toml".hex()},
+            "raw_length": raw_stat.st_size, "raw_sha256": raw_sha, "raw_source_sha256": source_sha,
+            "raw_device": raw_stat.st_dev, "raw_inode": raw_stat.st_ino, "manifest": manifest,
+        }
+        write_canonical(v3_metadata, metadata_value)
+        locator_value = {"version": 3, "confirm_id": "fixture-confirm",
+                         "metadata_path": wire_path(v3_metadata), "config_target": wire_path(v3_config),
+                         "prior_sha256": raw_sha, "prior_source_sha256": source_sha}
+        write_canonical(v3_locator, locator_value)
+        inspect_v3(v3_locator, v3_metadata, v3_raw, v3_config, "fixture-confirm")
+
+        def inspect_rejected(name: str, mutate) -> None:
+            copied = base / f"bad-{name}"
+            shutil.copytree(v3_dir, copied)
+            copied_raw, copied_metadata = copied / v3_raw.name, copied / v3_metadata.name
+            copied_locator, copied_config = copied / v3_locator.name, copied / v3_config.name
+            copied_stat = copied_raw.stat()
+            copied_metadata_value = read_json(copied_metadata)
+            copied_metadata_value.update(raw_device=copied_stat.st_dev, raw_inode=copied_stat.st_ino)
+            write_canonical(copied_metadata, copied_metadata_value)
+            copied_locator_value = read_json(copied_locator)
+            copied_locator_value.update(metadata_path=wire_path(copied_metadata), config_target=wire_path(copied_config))
+            write_canonical(copied_locator, copied_locator_value)
+            mutate(copied)
+            try:
+                inspect_v3(copied_locator, copied_metadata, copied_raw, copied_config, "fixture-confirm")
+            except InvalidReceipt:
+                proofs[name] = True
+                return
+            fail(f"red v3 inspector fixture unexpectedly accepted: {name}")
+
+        def corrupt_metadata(copied: Path) -> None:
+            value = read_json(copied / v3_metadata.name)
+            value["raw_sha256"] = "f" * 64
+            write_canonical(copied / v3_metadata.name, value)
+
+        def corrupt_target(copied: Path) -> None:
+            value = read_json(copied / v3_locator.name)
+            value["config_target"] = {"encoding": "unix-bytes-hex", "value": b"/wrong/config.toml".hex()}
+            write_canonical(copied / v3_locator.name, value)
+
+        def corrupt_order(copied: Path) -> None:
+            value = read_json(copied / v3_locator.name)
+            write_canonical(copied / v3_locator.name, {
+                "version": value["version"], "metadata_path": value["metadata_path"],
+                "confirm_id": value["confirm_id"], "config_target": value["config_target"],
+                "prior_sha256": value["prior_sha256"], "prior_source_sha256": value["prior_source_sha256"],
+            })
+
+        def corrupt_nested_order(copied: Path) -> None:
+            value = read_json(copied / v3_locator.name); wire = value["metadata_path"]
+            value["metadata_path"] = {"value": wire["value"], "encoding": wire["encoding"]}
+            write_canonical(copied / v3_locator.name, value)
+
+        def corrupt_raw_utf8(copied: Path) -> None:
+            raw_path = copied / v3_raw.name; raw_path.write_bytes(b"prior\xff\n"); raw_path.chmod(0o600)
+            raw_stat = raw_path.stat(); raw_sha = sha256(raw_path)
+            metadata_path = copied / v3_metadata.name; value = read_json(metadata_path)
+            value.update(raw_length=raw_stat.st_size, raw_sha256=raw_sha, raw_device=raw_stat.st_dev, raw_inode=raw_stat.st_ino)
+            value["manifest"]["toml_sha256"] = raw_sha
+            value["raw_source_sha256"] = inline_manifest_source_sha256(value["manifest"], raw_sha)
+            write_canonical(metadata_path, value)
+            locator_path = copied / v3_locator.name; locator = read_json(locator_path)
+            locator.update(prior_sha256=raw_sha, prior_source_sha256=value["raw_source_sha256"])
+            write_canonical(locator_path, locator)
+
+        inspect_rejected("v3-inspector-linkage", corrupt_metadata)
+        inspect_rejected("v3-inspector-mode", lambda copied: (copied / v3_raw.name).chmod(0o644))
+        inspect_rejected("v3-inspector-target", corrupt_target)
+        inspect_rejected("v3-inspector-field-order", corrupt_order)
+        inspect_rejected("v3-inspector-nested-order", corrupt_nested_order)
+        inspect_rejected("v3-inspector-raw-utf8", corrupt_raw_utf8)
+        inspect_rejected(
+            "v3-inspector-canonical",
+            lambda copied: (copied / v3_locator.name).write_text(json.dumps(read_json(copied / v3_locator.name), indent=2) + "\n"),
+        )
+
         topology_dir = base / "topology"
         topology_dir.mkdir()
         timestamps = topology_dir / "timestamps.tsv"
@@ -1187,6 +1944,108 @@ def self_test() -> None:
         validate_campaigns(roots, good_output)
         audit_combined(good_output / "comparison.csv", COMPARISON_CELLS)
         audit_combined(good_output / "grouped-control.csv", (GROUPED_CELL,))
+        txn_roots = [base / "transaction-a", base / "transaction-b"]
+        make_fixture(txn_roots[0], "transaction", 100, 2000)
+        make_fixture(txn_roots[1], "transaction", 110, 3000)
+        transaction_output = base / "transaction-output"
+        validate_transactions(txn_roots, transaction_output)
+        audit_combined(transaction_output / "transactions.csv", (TRANSACTION_CELL,))
+
+        def mutate_cycle(root, index, function):
+            path = root / TRANSACTION_CELL / "transactions/cycles.jsonl"
+            rows = [json.loads(line) for line in path.read_text().splitlines()]
+            function(rows[index])
+            path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+
+        def mutate_lifecycle(root, function):
+            path = root / TRANSACTION_CELL / "transactions/lifecycle.json"
+            value = read_json(path); function(value); path.write_text(json.dumps(value) + "\n")
+
+        def txn_alter_json(path, function):
+            value = read_json(path); function(value); path.write_text(json.dumps(value) + "\n")
+
+        def txn_rejected(name, mutate, root_index=0, cell_reseal=True):
+            copied = base / f"bad-txn-{name}"
+            shutil.copytree(txn_roots[root_index], copied); thaw(copied); mutate(copied)
+            if cell_reseal:
+                reseal_cell_evidence(copied)
+            reseal(copied); freeze(copied)
+            pair = txn_roots.copy(); pair[root_index] = copied
+            try:
+                validate_transactions(pair, base / f"txn-output-{name}")
+            except InvalidReceipt:
+                proofs[name] = True
+                return
+            fail(f"red transaction fixture unexpectedly accepted: {name}")
+
+        def txn_pair_rejected(name, mutate):
+            pair = []
+            for index, root in enumerate(txn_roots):
+                copied = base / f"bad-txn-{name}-{index}"
+                shutil.copytree(root, copied); thaw(copied); mutate(copied)
+                reseal_cell_evidence(copied); reseal(copied); freeze(copied); pair.append(copied)
+            try:
+                validate_transactions(pair, base / f"txn-output-{name}")
+            except InvalidReceipt:
+                proofs[name] = True; return
+            fail(f"red transaction pair unexpectedly accepted: {name}")
+
+        def mutate_candidate_b(root, digest, bind_scenario=False):
+            mutate_cycle(root, 0, lambda row: row["candidate"].update({"sha256": digest}))
+            mutate_cycle(root, 2, lambda row: row["candidate"].update({"sha256": digest}))
+            mutate_lifecycle(root, lambda value: value["generations"]["opposite"].update({"sha256": digest}))
+            if bind_scenario:
+                cdir = root / TRANSACTION_CELL; scenario = cdir / "scenario.sha256"
+                scenario.write_text(scenario.read_text().replace("b" * 64 + "  ./gen-b.toml", digest + "  ./gen-b.toml"))
+                txn_alter_json(cdir / "provenance.json", lambda value: value["scenario"].update({"manifest_sha256": sha256(scenario)}))
+
+        def swap_state_markers(state):
+            for field in ("config", "runtime"):
+                marker = state[field]["marker"]
+                state[field]["marker"] = "65400:1000" if marker == "65400:2000" else "65400:2000"
+
+        def swap_applied_markers(root):
+            for index in range(4):
+                mutate_cycle(root, index, lambda row: (swap_state_markers(row["pending"]), swap_state_markers(row["confirmed"])))
+            def swap_lifecycle(value):
+                for state in (value["baseline"], value["final_state"], value["abort"]["pending"], value["abort"]["terminal"], value["timeout"]["pending"], value["timeout"]["terminal"]):
+                    swap_state_markers(state)
+            mutate_lifecycle(root, swap_lifecycle)
+
+        txn_rejected("transaction-cycle-roster", lambda root: mutate_cycle(root, 0, lambda row: row.update({"cycle": 2})))
+        txn_rejected("transaction-plan-token", lambda root: mutate_cycle(root, 0, lambda row: row["apply"].update({"explicit_plan_token": False})))
+        txn_rejected("transaction-confirm", lambda root: mutate_cycle(root, 0, lambda row: row["confirmed"].update({"status": "pending"})))
+        txn_rejected("transaction-v3-pending", lambda root: mutate_cycle(root, 0, lambda row: row["pending"]["authority"]["raw"].update({"bytes": 1024})))
+        txn_rejected("transaction-v3-linkage", lambda root: mutate_cycle(root, 0, lambda row: row["pending"]["authority"].update({"linkage_verified": False})))
+        txn_rejected("transaction-v3-deadline", lambda root: mutate_cycle(root, 0, lambda row: row["pending"]["authority"].update({"deadline_unix_seconds": 9999})))
+        txn_rejected("transaction-v3-cleanup", lambda root: mutate_cycle(root, 0, lambda row: row["confirmed"].update({"v3_absent": False})))
+        txn_rejected("transaction-history", lambda root: mutate_cycle(root, 0, lambda row: row["history"]["after"]["entries"].append({"index": 0})))
+        txn_rejected("transaction-abort", lambda root: mutate_lifecycle(root, lambda value: value["abort"]["terminal"].update({"status": "confirmed"})))
+        txn_rejected("transaction-timeout", lambda root: mutate_lifecycle(root, lambda value: value["timeout"]["terminal"].update({"status": "auto_revert_failed"})))
+        txn_rejected("transaction-noop", lambda root: mutate_lifecycle(root, lambda value: value["restored_current_plan"].update({"status": "committable"})))
+        txn_rejected("transaction-opposite", lambda root: mutate_lifecycle(root, lambda value: value["generations"].update({"opposite": value["generations"]["current"]})))
+        txn_rejected("transaction-token-leak", lambda root: mutate_cycle(root, 0, lambda row: row.update({"plan_token": "00000000-0000-4000-8000-000000000000"})))
+        txn_rejected("transaction-warning-log", lambda root: (root / TRANSACTION_CELL / "daemon.log").write_text("missing warning\n"))
+        txn_rejected("transaction-warning-binding", lambda root: mutate_cycle(root, 0, lambda row: row["history"]["warning"].update({"bytes": 12 * 1024 * 1024})))
+        txn_pair_rejected("transaction-applied-generation", swap_applied_markers)
+        txn_pair_rejected("transaction-scenario-generation", lambda root: mutate_candidate_b(root, "f" * 64))
+        txn_rejected("transaction-cross-root-generation", lambda root: mutate_candidate_b(root, "f" * 64, True), root_index=1)
+        txn_rejected("transaction-port-gate", lambda root: (root / TRANSACTION_CELL / "quiet.tsv").write_text((root / TRANSACTION_CELL / "quiet.tsv").read_text().replace("true\ttrue", "false\ttrue", 1)))
+        txn_rejected("transaction-disk-gate", lambda root: (root / TRANSACTION_CELL / "quiet.tsv").write_text((root / TRANSACTION_CELL / "quiet.tsv").read_text().replace("41943040", "41943039", 1)))
+        txn_rejected("transaction-swap-gate", lambda root: (root / TRANSACTION_CELL / "quiet.tsv").write_text((root / TRANSACTION_CELL / "quiet.tsv").read_text().replace("2\t31\t0.5\t0\t0", "2\t31\t0.5\t1\t0")))
+        txn_rejected("transaction-fallback-shape", lambda root: (txn_alter_json(root / "provenance.json", lambda value: value["inputs"].update({"n_members": "10"})), rebind_provenance(root)))
+        txn_rejected("transaction-mixed-binary", lambda root: (txn_alter_json(root / "provenance.json", lambda value: value["binaries"].update({"rbgp": "f" * 64})), rebind_provenance(root)), root_index=1)
+
+        def reuse_transaction_process(root):
+            source = txn_roots[0] / TRANSACTION_CELL / "process.tsv"
+            shutil.copyfile(source, root / TRANSACTION_CELL / "process.tsv")
+            old, new = 3000, 2000
+            for relative in ("transactions/cycles.jsonl", "transactions/lifecycle.json"):
+                path = root / TRANSACTION_CELL / relative
+                path.write_text(path.read_text().replace(f'"pid": {old}', f'"pid": {new}').replace(f'"starttime": {old + 100}', f'"starttime": {new + 100}'))
+        txn_rejected("transaction-process-reuse", reuse_transaction_process, root_index=1)
+        txn_rejected("transaction-file-tamper", lambda root: (root / TRANSACTION_CELL / "transactions/cycles.jsonl").write_text("tampered\n"), cell_reseal=False)
+        txn_rejected("transaction-extra-file", lambda root: (root / TRANSACTION_CELL / "unexpected.txt").write_text("unexpected\n"))
 
         def rejected(
             name, mutate, reseal_after=True, freeze_after=True, cell_reseal=True
@@ -1419,6 +2278,9 @@ def self_test() -> None:
         grouped_pair_drift("cross-role-source-identity", "binaries", "rbgp", "a" * 64)
         expected = {"default-roster", "mixed-roster", "mode-flags", "topology-mutation", "barrier-marker", "final-barrier-marker", "live-topology-gauge", "route-gauge", "route-family", "one-scrape-drift", "add-path", "config-count", "dirty-commit", "origin-only", "head-matches-false", "mismatched-commit", "commit-malformed", "scripts-null", "scripts-empty-map", "binary-malformed", "fingerprint-recompute", "canonical-changed-fraction", "canonical-control-secs", "canonical-bird-threads", "repeat-image-identity", "cell-root-provenance", "nonoverlap-order", "quiet-spacing", "preflight-raw", "cell-status", "cell-provenance", "evidence-roster", "scenario-roster", "scenario-duplicate", "scenario-unsafe-path", "scenario-retained-config", "cell-root-rows", "reload-log-rows", "percentile-order", "percentile-positive", "first-generation-bound", "observer-gap-bound", "row-invariants", "rss-raw", "seal-checksum", "exact-root-roster", "symlink-anywhere", "writable-root", "grouped-output-isolation", "output-exact-roster", "output-audit-call", "ordering", "reused-identity", "cross-role-environment", "cross-role-source-identity"}
         expected |= {"current-down", "reestablished", "flapped", "counter-malformed", "establishment-roster", "flap-roster", "row-session-loss"}
+        expected |= set("""v3-inspector-linkage v3-inspector-mode v3-inspector-target v3-inspector-canonical v3-inspector-field-order v3-inspector-nested-order v3-inspector-raw-utf8 transaction-cycle-roster transaction-plan-token transaction-confirm transaction-v3-pending transaction-v3-linkage transaction-v3-deadline transaction-v3-cleanup transaction-history transaction-abort transaction-timeout transaction-noop transaction-opposite
+transaction-token-leak transaction-warning-log transaction-warning-binding transaction-applied-generation transaction-scenario-generation transaction-cross-root-generation transaction-port-gate transaction-disk-gate transaction-swap-gate transaction-fallback-shape
+transaction-mixed-binary transaction-process-reuse transaction-file-tamper transaction-extra-file""".split())
         missing = expected - proofs.keys()
         if missing:
             fail(f"self-test proofs did not reject: {sorted(missing)}")
@@ -1441,6 +2303,17 @@ def main() -> int:
     campaigns = subparsers.add_parser("campaigns")
     campaigns.add_argument("--output-dir", required=True, type=Path)
     campaigns.add_argument("roots", nargs=4, type=Path)
+    transactions = subparsers.add_parser("transactions")
+    transactions.add_argument("--output-dir", required=True, type=Path)
+    transactions.add_argument("roots", nargs=2, type=Path)
+    inspect = subparsers.add_parser("inspect-v3")
+    inspect.add_argument("--locator", required=True, type=Path)
+    inspect.add_argument("--metadata", required=True, type=Path)
+    inspect.add_argument("--raw", required=True, type=Path)
+    inspect.add_argument("--config", required=True, type=Path)
+    inspect.add_argument("--confirm-id", required=True)
+    marker = subparsers.add_parser("inspect-generation")
+    marker.add_argument("config", type=Path)
     subparsers.add_parser("self-test")
     args = parser.parse_args()
     try:
@@ -1448,6 +2321,24 @@ def main() -> int:
             validate_topology(args.mode, args.peers, args.total, args.config, args.timestamps, args.metrics, args.output)
         elif args.command == "campaigns":
             validate_campaigns(args.roots, args.output_dir)
+        elif args.command == "transactions":
+            validate_transactions(args.roots, args.output_dir)
+        elif args.command == "inspect-v3":
+            print(
+                json.dumps(
+                    inspect_v3(
+                        args.locator,
+                        args.metadata,
+                        args.raw,
+                        args.config,
+                        args.confirm_id,
+                    ),
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+            )
+        elif args.command == "inspect-generation":
+            print(generation_marker(args.config))
         else:
             self_test()
     except (InvalidReceipt, OSError, KeyError, TypeError, ValueError) as error:

--- a/tests/commit_confirm_binary.rs
+++ b/tests/commit_confirm_binary.rs
@@ -38,9 +38,12 @@ struct Daemon {
 impl Daemon {
     fn spawn(config_path: &Path, stderr_path: PathBuf) -> Self {
         let stderr = File::create(&stderr_path).expect("failed to create daemon stderr log");
+        let stdout = stderr
+            .try_clone()
+            .expect("failed to clone daemon audit log handle");
         let child = Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
             .arg(config_path)
-            .stdout(Stdio::null())
+            .stdout(Stdio::from(stdout))
             .stderr(Stdio::from(stderr))
             .spawn()
             .expect("failed to spawn rustbgpd binary");
@@ -65,6 +68,14 @@ impl Daemon {
                 self.stderr_path.display()
             )
         })
+    }
+
+    fn grpc_audit_method_count(&self, method: &str) -> usize {
+        self.stderr()
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .filter(|event| event["fields"]["method"].as_str() == Some(method))
+            .count()
     }
 
     /// SIGKILL — no shutdown coordination, simulating a crash inside the
@@ -347,7 +358,8 @@ impl Lab {
 
     /// Plan + confirmed-apply the dynamic-neighbor candidate; asserts the
     /// transaction commits and enters the pending confirm window.
-    fn apply_confirmed(&self, confirm_id: &str, timeout_seconds: &str) {
+    fn apply_confirmed(&self, daemon: &Daemon, confirm_id: &str, timeout_seconds: &str) {
+        let plan_audits_before = daemon.grpc_audit_method_count("StreamPlanConfigTransaction");
         let plan = rbgp_json(
             &self.grpc_addr,
             &[
@@ -366,6 +378,11 @@ impl Lab {
             !plan_token.is_empty(),
             "streamed plan token must not be empty"
         );
+        assert_eq!(
+            daemon.grpc_audit_method_count("StreamPlanConfigTransaction"),
+            plan_audits_before + 1,
+            "the reviewed streamed Plan must emit exactly one production audit event"
+        );
         let token = plan["runtime_snapshot_token"]
             .as_str()
             .expect("plan must return a runtime snapshot token");
@@ -380,6 +397,8 @@ impl Lab {
                 self.candidate_path.to_str().unwrap(),
                 "--expected-runtime-snapshot-token",
                 token,
+                "--plan-token",
+                plan_token,
                 "--confirm-id",
                 confirm_id,
                 "--confirm-timeout",
@@ -403,6 +422,11 @@ impl Lab {
             serde_json::from_slice(&apply_output.stdout).expect("apply output must be JSON");
         assert_eq!(apply["status"], "committable", "apply: {apply}");
         assert_eq!(apply["confirmation"]["status"], "pending", "apply: {apply}");
+        assert_eq!(
+            daemon.grpc_audit_method_count("StreamPlanConfigTransaction"),
+            plan_audits_before + 1,
+            "explicit Apply must consume the reviewed Plan token without an implicit second Plan"
+        );
 
         // Commit persisted the (unconfirmed) candidate to the config file and
         // journaled the revert state.
@@ -470,7 +494,7 @@ fn streamed_confirmed_apply_above_eight_mib_aborts_to_previous_config() {
         .find_map(|line| line.strip_prefix("plan_token: "))
         .expect("streamed plan human output must expose its single-use plan token");
     assert!(!exposed_token.is_empty());
-    lab.apply_confirmed("stream-abort", "600");
+    lab.apply_confirmed(&daemon, "stream-abort", "600");
     assert!(
         std::fs::metadata(&lab.raw_path).unwrap().len() > 10 * 1024 * 1024,
         "real-binary writer must publish a genuinely normalized prior above 10 MiB"
@@ -551,7 +575,7 @@ fn sigkill_in_confirm_window_boots_previous_config_and_saves_candidate_aside() {
     let lab = lab(temp.path());
 
     let daemon = lab.spawn("first.stderr.log");
-    lab.apply_confirmed("kill-window", "600");
+    lab.apply_confirmed(&daemon, "kill-window", "600");
     daemon.sigkill();
 
     // Restart: boot must revert BEFORE adopting the on-disk (unconfirmed)
@@ -606,7 +630,7 @@ fn confirm_then_sigkill_retains_new_config_and_leaves_no_journal() {
     let lab = lab(temp.path());
 
     let daemon = lab.spawn("first.stderr.log");
-    lab.apply_confirmed("kill-confirmed", "600");
+    lab.apply_confirmed(&daemon, "kill-confirmed", "600");
     let confirm = rbgp_json(
         &lab.grpc_addr,
         &["--json", "config", "confirm", "kill-confirmed"],
@@ -637,7 +661,7 @@ fn in_process_timeout_auto_revert_consumes_journal() {
     let lab = lab(temp.path());
 
     let mut daemon = lab.spawn("daemon.stderr.log");
-    lab.apply_confirmed("timeout-revert", "2");
+    lab.apply_confirmed(&daemon, "timeout-revert", "2");
 
     // Poll for the auto-revert (2s timer + rollback work).
     let deadline = Instant::now() + Duration::from_secs(30);

--- a/tests/reloadstall_scenario_emitted_check.rs
+++ b/tests/reloadstall_scenario_emitted_check.rs
@@ -24,7 +24,6 @@ fn emitted_1000_peer_scenario_is_all_ebgp_and_daemon_valid() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-
     let config_path = dir.path().join("config.toml");
     let config_text = std::fs::read_to_string(&config_path).expect("read config");
     let config: toml::Value = toml::from_str(&config_text).expect("parse generated TOML");
@@ -132,7 +131,7 @@ fn irr_reload_campaign_seals_resume_rows_and_rss_evidence() {
         "rustbgpd-txn must use a separate measured campaign",
         "TXN_MAX_CANDIDATE_BYTES",
         "if [ \"$candidate_bytes\" -gt \"$TXN_MAX_CANDIDATE_BYTES\" ]; then",
-        "candidate exceeds the ${TXN_MAX_CANDIDATE_BYTES}-byte tonic request budget",
+        "candidate exceeds the ${TXN_MAX_CANDIDATE_BYTES}-byte streamed request budget",
         "cleanup_active_processes",
         "terminate_process_group \"$pid\"",
         "ACTIVE_HARNESS_PID",
@@ -470,17 +469,19 @@ fn run_irr_protocol(args: &[&str], smoke: bool) -> String {
 }
 
 #[test]
-/// Red proof: restoring the measured four-cell default makes the first
-/// assertion fail; removing the separate bounded transaction preset makes
-/// the second fail. The smoke assertion keeps all four plumbing paths gated.
-fn irr_reload_protocol_separates_full_scale_from_bounded_transaction() {
+/// Red proof: shrinking the measured transaction path or admitting it into the
+/// cross-daemon table fails these exact protocol assertions. Smoke retains the
+/// explicit ten-member plumbing proof.
+fn irr_reload_protocol_separates_full_transaction_from_smoke() {
     let measured = run_irr_protocol(&[], false);
     assert!(measured.contains("cells=rustbgpd-sighup,bird,openbgpd\n"));
     assert!(measured.contains("shape=320,183040,1000,40000\n"));
 
     let transaction = run_irr_protocol(&["rustbgpd-txn"], false);
     assert!(transaction.contains("cells=rustbgpd-txn\n"));
-    assert!(transaction.contains("shape=10,5720,1000,12000\n"));
+    assert!(transaction.contains("campaign_kind=full-transaction\n"));
+    assert!(transaction.contains("shape=320,183040,1000,40000\n"));
+    assert!(transaction.contains("txn_max_candidate_bytes=402653184\n"));
 
     let smoke = run_irr_protocol(&[], true);
     assert!(smoke.contains("cells=rustbgpd-sighup,rustbgpd-txn,bird,openbgpd\n"));
@@ -505,99 +506,81 @@ fn irr_reload_protocol_separates_full_scale_from_bounded_transaction() {
 }
 
 #[test]
-/// Red proof: increasing the bounded preset beyond tonic's default message
-/// ceiling fails the real Plan/Apply protobuf encoded-size assertions;
-/// selecting a seed/shape with no real IRR-list delta fails the changed-member
-/// assertion.
-fn irr_reload_bounded_transaction_preset_fits_tonic_request() {
-    use prost::Message;
-    use rustbgpd_api::proto::{ApplyConfigTransactionRequest, PlanConfigTransactionRequest};
-
+/// A fake CLI accepts Apply only when txn-apply passes the exact UUID returned
+/// by Plan. Presence-only checks or an automatically replanned Apply turn red.
+fn irr_reload_transaction_helper_uses_exact_streamed_plan_token() {
+    use std::os::unix::fs::PermissionsExt as _;
     let root = env!("CARGO_MANIFEST_DIR");
-    let generator = format!("{root}/bench/scale/reloadstall/gen-irr-scenario.py");
-    let protocol = run_irr_protocol(&["rustbgpd-txn"], false);
-    let shape = protocol
-        .lines()
-        .find_map(|line| line.strip_prefix("shape="))
-        .expect("resolved transaction shape")
-        .split(',')
-        .collect::<Vec<_>>();
-    assert_eq!(shape.len(), 4);
-    let candidate_budget = protocol
-        .split_whitespace()
-        .find_map(|field| field.strip_prefix("txn_max_candidate_bytes="))
-        .expect("resolved transaction message budget")
-        .parse::<u64>()
-        .expect("numeric transaction message budget");
+    let helper = format!("{root}/bench/scale/irrreload/txn-apply.sh");
     let dir = tempfile::tempdir().expect("tempdir");
-    let output = std::process::Command::new("python3")
-        .args([&generator, "rustbgpd-txn", shape[0], shape[1]])
-        .arg(dir.path())
-        .args([
-            "--port",
-            "1790",
-            "--seed",
-            "61",
-            "--min-list",
-            shape[2],
-            "--max-list",
-            shape[3],
-            "--changed-fraction",
-            "0.1",
-        ])
-        .output()
-        .expect("generate bounded transaction scenario");
-    assert!(output.status.success());
-    let manifest: serde_json::Value = serde_json::from_slice(
-        &std::fs::read(dir.path().join("manifest.json")).expect("read manifest"),
+    let fake = dir.path().join("rbgp");
+    std::fs::write(
+        &fake,
+        r#"#!/usr/bin/env bash
+set -u
+if [[ " $* " == *" config plan "* ]]; then
+  printf '%s\n' '{"status":"committable","runtime_snapshot_token":"kv2:0123456789abcdef:8","plan_token":"12345678-1234-4123-8123-123456789abc"}'
+  exit 2
+fi
+if [[ " $* " == *" config apply "* ]]; then
+  exact=false
+  while [ $# -gt 0 ]; do
+    if [ "$1" = --plan-token ] && [ "${2:-}" = 12345678-1234-4123-8123-123456789abc ]; then exact=true; fi
+    shift
+  done
+  [ "$exact" = true ] || exit 9
+  printf '%s\n' '{"status":"committable","confirmation":null}'
+  exit 0
+fi
+exit 8
+"#,
     )
-    .expect("parse manifest");
-    assert_eq!(manifest["changed_members"].as_array().unwrap().len(), 1);
-    const TONIC_DECODE_LIMIT: usize = 4 * 1024 * 1024;
-    const SNAPSHOT_TOKEN: &str = "kv2:0123456789abcdef:8";
-    assert_eq!(SNAPSHOT_TOKEN.len(), 22);
-    for candidate in ["config.toml", "candidate.toml", "gen-a.toml", "gen-b.toml"] {
-        let bytes = manifest["file_bytes"][candidate]
-            .as_u64()
-            .expect("candidate byte count");
-        assert!(bytes <= candidate_budget, "{candidate}: {bytes}");
-        let candidate_toml = "x".repeat(bytes as usize);
-        let plan = PlanConfigTransactionRequest {
-            candidate_toml: candidate_toml.clone(),
-            expected_runtime_snapshot_token: String::new(),
-        };
-        let apply = ApplyConfigTransactionRequest {
-            candidate_toml,
-            expected_runtime_snapshot_token: SNAPSHOT_TOKEN.to_owned(),
-            client_request_id: String::new(),
-            comment: String::new(),
-            confirm_id: String::new(),
-            confirm_timeout_seconds: 0,
-        };
+    .expect("write fake rbgp");
+    let mut permissions = std::fs::metadata(&fake).unwrap().permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&fake, permissions).unwrap();
+    let candidate = dir.path().join("candidate.toml");
+    std::fs::write(
+        &candidate,
+        "[global]\nasn = 65000\nrouter_id = \"192.0.2.1\"\n",
+    )
+    .unwrap();
+    let config = dir.path().join("config.toml");
+    let evidence = dir.path().join("evidence");
+    let daemon_log = dir.path().join("daemon.log");
+    let pid = std::process::id().to_string();
+    let output = std::process::Command::new("bash")
+        .arg(&helper)
+        .args([
+            fake.as_os_str(),
+            std::ffi::OsStr::new("unix:///tmp/fake.sock"),
+            candidate.as_os_str(),
+            config.as_os_str(),
+            dir.path().as_os_str(),
+            evidence.as_os_str(),
+            std::ffi::OsStr::new(&pid),
+            daemon_log.as_os_str(),
+        ])
+        .env("TXN_SMOKE", "1")
+        .output()
+        .expect("run transaction helper");
+    assert!(
+        output.status.success(),
+        "helper failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let helper_source = std::fs::read_to_string(&helper).expect("read transaction helper");
+    for guard in [
+        "trap cleanup_pending EXIT",
+        "active_confirm_id=$confirm_id",
+        "active_confirm_id=\nterminal=",
+    ] {
         assert!(
-            plan.encoded_len() <= TONIC_DECODE_LIMIT,
-            "{candidate}: plan"
-        );
-        assert!(
-            apply.encoded_len() <= TONIC_DECODE_LIMIT,
-            "{candidate}: apply"
+            helper_source.contains(guard),
+            "missing pending cleanup guard: {guard}"
         );
     }
-    let at_budget = "x".repeat(candidate_budget as usize);
-    let exact_apply = ApplyConfigTransactionRequest {
-        candidate_toml: at_budget,
-        expected_runtime_snapshot_token: SNAPSHOT_TOKEN.to_owned(),
-        client_request_id: String::new(),
-        comment: String::new(),
-        confirm_id: String::new(),
-        confirm_timeout_seconds: 0,
-    };
-    assert_eq!(exact_apply.encoded_len(), TONIC_DECODE_LIMIT);
-    let over_limit = ApplyConfigTransactionRequest {
-        candidate_toml: "x".repeat(candidate_budget as usize + 1),
-        ..exact_apply
-    };
-    assert_eq!(over_limit.encoded_len(), TONIC_DECODE_LIMIT + 1);
 
     let runner = format!("{root}/bench/scale/irrreload/run-irr-reload.sh");
     let rejected = std::process::Command::new("bash")
@@ -606,14 +589,14 @@ fn irr_reload_bounded_transaction_preset_fits_tonic_request() {
         .env("DRY_RUN_PROTOCOL", "1")
         .env(
             "TXN_MAX_CANDIDATE_BYTES",
-            (candidate_budget + 1).to_string(),
+            (384_u64 * 1024 * 1024 + 1).to_string(),
         )
         .output()
         .expect("run over-limit protocol");
     assert_eq!(rejected.status.code(), Some(2));
     assert!(
         String::from_utf8_lossy(&rejected.stderr)
-            .contains("TXN_MAX_CANDIDATE_BYTES exceeds the safe apply-request ceiling")
+            .contains("TXN_MAX_CANDIDATE_BYTES exceeds the streamed candidate ceiling")
     );
 }
 
@@ -878,14 +861,14 @@ fn irr_reload_counterbalanced_receipt_protocol_is_load_bearing() {
 
     let script = std::fs::read_to_string(&runner).expect("read runner");
     assert!(
-        script.lines().count() <= 950,
+        script.lines().count() <= 1_050,
         "runner parsing belongs in Python"
     );
     for guard in [
         "RELOADSTALL_PRE_CHURN_EVIDENCE_DIR=\"$barrier\"",
         "RELOADSTALL_EVIDENCE_DIR=\"$final_barrier\"",
         "jq -cS . | sha256sum",
-        "320,183040,1000,40000,61,4,0.1,1790,30,4194275,7200,600,8",
+        "320,183040,1000,40000,61,4,0.1,1790,30,402653184,7200,600,8",
         "capture_topology \"$topology_mode\" \"$cdir\" \"$run\" \"$hpid\" \"$barrier\"",
         "ack_pre_churn \"$barrier\" true \"$cdir\"",
         "--peers \"$N_MEMBERS\" --total \"$TOTAL_PREFIXES\"",
@@ -894,14 +877,33 @@ fn irr_reload_counterbalanced_receipt_protocol_is_load_bearing() {
         "rm -f \"$cdir/topology.json\" \"$cdir\"/metrics-{1,2,3}.prom",
         "bind_first_trigger \"$cdir\"",
         "full measured campaigns require a clean HEAD exactly at origin/main",
-        "printf 'sample\\tepoch_s\\tload1\\n'",
+        "printf 'sample\\tepoch_s\\tload1\\tpswpin\\tpswpout",
         "[ \"$sample\" -gt 2 ] || sleep 30",
         "daemon PID/start identity changed",
+        "transactions/cycles.jsonl transactions/lifecycle.json",
+        "txn-lifecycle.sh",
+        "shlex.join(sys.argv[1:])",
+        "env TXN_SMOKE=1",
+        "pswpin\\tpswpout\\tport1790_free\\tport9179_free\\tdisk_available_kib",
+        "[ \"$disk_kib\" -ge $((40 * 1024 * 1024)) ]",
         "find . -type f ! -name SHA256SUMS",
         "chmod -R a-w \"$ART\"",
     ] {
         assert!(script.contains(guard), "missing protocol guard: {guard}");
     }
+    assert!(
+        script.contains("if [ -z \"$SMOKE\" ]; then\n    if [ -n \"${SKIP_PREFLIGHT:-}\" ]; then"),
+        "every full campaign, including rustbgpd-txn, must enter the preflight gate"
+    );
+    let load_gate = script
+        .split_once("load_gate() {")
+        .and_then(|(_, rest)| rest.split_once("capture_topology() {"))
+        .map(|(body, _)| body)
+        .expect("load_gate body must remain structurally inspectable");
+    assert!(
+        !load_gate.contains("TXN_ONLY"),
+        "full transaction campaigns must not bypass quiet-host sampling"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- promote the IRR transaction lane from the ten-member smoke shape to the canonical 320-member, 183,040-prefix scale shape
- use streamed Plan plus explicit-token Apply for four confirmed B/A/B/A cycles, then exercise abort and timeout auto-revert against the same daemon
- bind retained evidence to v3 journal authority, sealed candidate generations, disk and runtime state, history warnings, process identity, and exact two-root reproducibility
- retain the ten-member lane as the fast smoke path

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
- `cargo test --test commit_confirm_binary --no-fail-fast`
- `cargo test --test reloadstall_scenario_emitted_check --no-fail-fast`
- `shellcheck bench/scale/irrreload/run-irr-reload.sh bench/scale/irrreload/txn-apply.sh bench/scale/irrreload/txn-lifecycle.sh`
- `python3 bench/scale/irrreload/verify-receipt.py self-test`

The transaction verifier includes destructive fixtures for v3 authority, sealed scenario binding, applied-state generation binding, warning order, preflight gates, exact retained rosters, and cross-root identity. Removing each guarded check makes its named fixture pass and the self-test fail.