### PR TITLE
fix: tolerate rrtransport child exit races

### DIFF
--- a/bench/scale/rrtransport/run-receipt.sh
+++ b/bench/scale/rrtransport/run-receipt.sh
@@ -128,7 +128,7 @@ classify_child_exe() {
 
 child_identity() {
   local process=$1 stat_line stat_fields
-  stat_line=$(<"/proc/$process/stat") 2>/dev/null || return 1
+  stat_line=$(command cat -- "/proc/$process/stat" 2>/dev/null) || return 1
   stat_line=${stat_line##*) }
   read -r -a stat_fields <<<"$stat_line"
   (( ${#stat_fields[@]} >= 20 )) || return 1
@@ -728,6 +728,15 @@ case ${1:-} in
   --classify-child-exe)
     [[ $# == 4 ]] || exit 2
     classify_child_exe "$2" "$3" "$4"
+    exit
+    ;;
+  --child-identity-fixture)
+    [[ $# == 2 ]] || exit 2
+    if child_identity "$2"; then
+      printf 'present\t%s\n' "$identity_starttime"
+    else
+      echo absent
+    fi
     exit
     ;;
   --sample-direct-rss-observations)

--- a/bench/tests/test-rrtransport-receipt.sh
+++ b/bench/tests/test-rrtransport-receipt.sh
@@ -206,6 +206,15 @@ expect_red changed-hash mutate -c 'import pathlib,sys;(pathlib.Path(sys.argv[1])
 [[ $("$runner" --classify-child-exe /expected /expected Z) == exited ]]
 [[ $("$runner" --classify-child-exe /expected /expected absent) == retry_expected_absent ]]
 
+# Exercise the real /proc reader after a process has exited. This goes red if
+# child_identity reverts to Bash's fatal optimized $(<file) reader; scripted
+# observation tests cannot catch shell-level failures while opening procfs.
+sleep 0.01 &
+exited_pid=$!
+wait "$exited_pid"
+[[ ! -e /proc/$exited_pid ]]
+[[ $("$runner" --child-identity-fixture "$exited_pid") == absent ]]
+
 direct_fixture() {
   local name=$1 expected=$2 expected_status=$3 actual status=0 stderr; shift 3
   stderr=$tmp/$name.stderr


### PR DESCRIPTION
## Summary

- treat a child disappearing between PID observation and `/proc/<pid>/stat` as an ordinary terminal race
- preserve live PID/start-time identity checks and parser failures
- exercise the real procfs seam after reaping an exited child

## Root cause

Bash optimized `$(<file)` redirection exits the script under `set -e` when procfs disappears, before the intended `|| return 1` fallback can run. A guarded `command cat` returns through the existing absence path.

## Load-bearing proof

The new fixture fails on the prior reader with `/proc/<pid>/stat: No such file or directory`; restoring that reader makes the focused test red. The fixed fixture returned `absent` in 100/100 repetitions.

## Validation

- `bash -n bench/scale/rrtransport/run-receipt.sh`
- `shellcheck bench/scale/rrtransport/run-receipt.sh bench/tests/test-rrtransport-receipt.sh`
- `bash bench/tests/test-rrtransport-receipt.sh`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`
- independent review: clean

Linear: LAN-869