### PR TITLE
fix: create receipt runtime directories owner-only

### DIFF
--- a/bench/scale/irrreload/run-irr-reload.sh
+++ b/bench/scale/irrreload/run-irr-reload.sh
@@ -644,8 +644,9 @@ run_cell() {
     local cell=$1
     local cdir="$ART/$cell"
     local run="/tmp/irr-$cell"
-    rm -rf "$run"
-    mkdir -p "$cdir" "$run"
+    rm -rf -- "$run" || return 1
+    mkdir -p "$cdir" || return 1
+    mkdir -m 0700 -- "$run" || return 1
     local daemon_pid="" daemon_start="" container="" reload_cmd="" pid_arg="" topology_mode="" barrier="" final_barrier="" final_acked=false
     local live a b entries generator_cell=$cell
     CELL_SCENARIO_SHA256=""

--- a/tests/reloadstall_scenario_emitted_check.rs
+++ b/tests/reloadstall_scenario_emitted_check.rs
@@ -751,7 +751,8 @@ fn irr_reload_manifest_seals_a_cell_independent_dataset_digest() {
 /// fixture pass; changing the default/control rosters or their explicit mode
 /// flags fails the executed dry-protocol assertions. Removing the pre-trigger
 /// topology call, quiet double-sample, source fence, identity fence, or final
-/// immutable seal fails the corresponding structural assertion below.
+/// immutable seal or owner-only runtime-directory creation fails the
+/// corresponding structural assertion below.
 fn irr_reload_counterbalanced_receipt_protocol_is_load_bearing() {
     let root = env!("CARGO_MANIFEST_DIR");
     let runner = format!("{root}/bench/scale/irrreload/run-irr-reload.sh");
@@ -894,6 +895,21 @@ fn irr_reload_counterbalanced_receipt_protocol_is_load_bearing() {
     assert!(
         script.contains("if [ -z \"$SMOKE\" ]; then\n    if [ -n \"${SKIP_PREFLIGHT:-}\" ]; then"),
         "every full campaign, including rustbgpd-txn, must enter the preflight gate"
+    );
+    let private_runtime = "rm -rf -- \"$run\" || return 1\n    mkdir -p \"$cdir\" || return 1\n    mkdir -m 0700 -- \"$run\" || return 1";
+    let private_runtime_pos = script
+        .find(private_runtime)
+        .expect("runtime directory must be atomically created owner-only");
+    let generation_pos = script
+        .find("gen_scenario rustbgpd")
+        .expect("rustbgpd scenario generation");
+    assert!(
+        private_runtime_pos < generation_pos,
+        "runtime directory must be private before generation and daemon start"
+    );
+    assert!(
+        !script.contains("mkdir -p \"$cdir\" \"$run\""),
+        "caller umask must not control runtime-state directory permissions"
     );
     let load_gate = script
         .split_once("load_gate() {")


### PR DESCRIPTION
## Summary

- create each deterministic IRR receipt runtime directory atomically at mode `0700`
- fail closed if removal or private creation fails
- keep artifact permissions and daemon runtime-state validation unchanged

## Root cause

The first full 320-member transactional campaign on merged main generated its 295,624,985-byte candidate, then failed before measurement. The harness used caller-umask-controlled `mkdir -p`, producing mode `0775`; rustbgpd correctly rejected that directory as runtime-state authority, so commit-confirm and GR marker storage were unavailable.

## Load-bearing proof

The enrolled protocol test requires the exact owner-only creation sequence before scenario generation and daemon start and rejects the old combined `mkdir -p`. Restoring the prior behavior makes the test red with `rc=101` at the private-runtime assertion. Direct probes under `umask 000` and `0777` both produced mode `0700`; a pre-existing final path fails closed.

## Validation

- `bash -n bench/scale/irrreload/run-irr-reload.sh`
- `shellcheck bench/scale/irrreload/run-irr-reload.sh`
- `cargo test --test reloadstall_scenario_emitted_check irr_reload_counterbalanced_receipt_protocol_is_load_bearing -- --exact`
- `python3 bench/scale/irrreload/verify-receipt.py self-test`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
- `git diff --check`
- independent review: clean

The failed campaign root remains immutable and will not be reused. Both receipt roots restart fresh after this lands.

Linear: LAN-870