### PR TITLE
bench: wait for rustbgpd readiness before IRR receipt peers

### DIFF
--- a/bench/scale/irrreload/README.md
+++ b/bench/scale/irrreload/README.md
@@ -135,13 +135,15 @@ measurements — none of them is timed into any reported number; they
 only bound how long the harness waits before declaring a cell broken):
 
 - **Daemon-start readiness**: the runner polls at 1 s cadence until
-  the cell's daemon holds a listener on the BGP port (containers: also
-  until `docker inspect` reports a nonzero daemon PID, retried — a
-  single immediate inspect can race a slow start and record pid=0),
-  with a hard ceiling of `START_TIMEOUT` (default **600 s**). A
-  multi-MB IRR policy parse legitimately takes far longer than a
-  small-config boot; the poll returns as soon as the daemon is ready,
-  so a generous ceiling costs nothing on fast starts.
+  the cell's daemon holds a listener on the BGP port; rustbgpd cells
+  also require a successful `http://127.0.0.1:9179/readyz` after
+  initial peer registration, while BIRD and OpenBGPD remain
+  listener-only (containers: also until `docker inspect` reports a
+  nonzero daemon PID, retried — a single immediate inspect can race a
+  slow start and record pid=0), with a hard ceiling of `START_TIMEOUT`
+  (default **600 s**). A multi-MB IRR policy parse legitimately takes
+  far longer than a small-config boot; the poll returns as soon as the
+  daemon is ready, so a generous ceiling costs nothing on fast starts.
 - **Stub connect**: each stub retries its TCP connect at 500 ms
   cadence for up to **120 s** (`CONNECT_WINDOW` in the reloadstall
   harness) before failing the cell — refused connects while the daemon

--- a/bench/scale/irrreload/run-irr-reload.sh
+++ b/bench/scale/irrreload/run-irr-reload.sh
@@ -629,10 +629,29 @@ wait_ready() {
             return 1
         fi
         if [ "${daemon_pid:-0}" -gt 0 ] && ss -ltnH "sport = :$PORT" | grep -q .; then
-            return 0
+            case $cell in
+            rustbgpd-sighup | rustbgpd-txn | "$GROUPED_CELL")
+                curl -fsS --max-time 2 'http://127.0.0.1:9179/readyz' >/dev/null 2>&1 &&
+                    return 0
+                ;;
+            *)
+                return 0
+                ;;
+            esac
         fi
         if [ "$waited" -ge "$START_TIMEOUT" ]; then
-            echo "cell $cell: no listener on :$PORT after ${START_TIMEOUT}s" >&2
+            case $cell in
+            rustbgpd-sighup | rustbgpd-txn | "$GROUPED_CELL")
+                if [ "${daemon_pid:-0}" -gt 0 ] && ss -ltnH "sport = :$PORT" | grep -q .; then
+                    echo "cell $cell: startup readiness did not complete after ${START_TIMEOUT}s; rustbgpd also requires http://127.0.0.1:9179/readyz" >&2
+                else
+                    echo "cell $cell: no listener on :$PORT after ${START_TIMEOUT}s" >&2
+                fi
+                ;;
+            *)
+                echo "cell $cell: no listener on :$PORT after ${START_TIMEOUT}s" >&2
+                ;;
+            esac
             return 1
         fi
         sleep 1

--- a/tests/reloadstall_scenario_emitted_check.rs
+++ b/tests/reloadstall_scenario_emitted_check.rs
@@ -187,6 +187,93 @@ fn irr_reload_campaign_seals_resume_rows_and_rss_evidence() {
 }
 
 #[test]
+/// Red proof: removing the rustbgpd `/readyz` request, moving it before the
+/// BGP-listener gate, or restoring the listener-only early return makes the
+/// source contract or executable failure fixture turn red. BIRD remains gated
+/// only by its BGP listener.
+fn irr_reload_rustbgpd_startup_requires_readyz_after_bgp_listener() {
+    let runner = std::fs::read_to_string(format!(
+        "{}/bench/scale/irrreload/run-irr-reload.sh",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .expect("read IRR reload runner");
+    let wait_ready = runner
+        .split_once("wait_ready() {")
+        .and_then(|(_, rest)| rest.split_once("run_cell() {"))
+        .map(|(body, _)| format!("wait_ready() {{{body}"))
+        .expect("wait_ready function body");
+    let bgp_listener = wait_ready
+        .find("ss -ltnH \"sport = :$PORT\" | grep -q .; then")
+        .expect("BGP listener gate");
+    let rustbgpd_cells = wait_ready
+        .find("rustbgpd-sighup | rustbgpd-txn | \"$GROUPED_CELL\")")
+        .expect("rustbgpd cell branch");
+    let readyz = wait_ready
+        .find("curl -fsS --max-time 2 'http://127.0.0.1:9179/readyz' >/dev/null 2>&1 &&")
+        .expect("rustbgpd readiness gate");
+    assert!(
+        bgp_listener < rustbgpd_cells && rustbgpd_cells < readyz,
+        "rustbgpd must pass BGP and /readyz gates before startup succeeds"
+    );
+
+    let fixture_dir = tempfile::tempdir().expect("fixture directory");
+    let run_fixture = |cell: &str, readyz_rc: u8, ss_rc: u8| {
+        std::process::Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                r#"{wait_ready}
+ss() {{ [ "$SS_RC" -eq 0 ] && printf 'LISTEN\n'; }}
+curl() {{ return "$READYZ_RC"; }}
+container=
+daemon_pid=$$
+PORT=1790
+START_TIMEOUT=0
+GROUPED_CELL=rustbgpd-sighup-grouped-control
+wait_ready "$CELL" "$CDIR"
+"#
+            ))
+            .env("CELL", cell)
+            .env("CDIR", fixture_dir.path())
+            .env("READYZ_RC", readyz_rc.to_string())
+            .env("SS_RC", ss_rc.to_string())
+            .output()
+            .expect("run readiness fixture")
+    };
+
+    let rustbgpd_blocked = run_fixture("rustbgpd-txn", 22, 0);
+    let blocked_stderr = String::from_utf8_lossy(&rustbgpd_blocked.stderr);
+    assert!(
+        !rustbgpd_blocked.status.success(),
+        "rustbgpd passed with /readyz failing\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&rustbgpd_blocked.stdout),
+        blocked_stderr
+    );
+    assert!(
+        blocked_stderr.contains("startup readiness did not complete after 0s; rustbgpd also requires http://127.0.0.1:9179/readyz"),
+        "rustbgpd readiness timeout was misleading: {blocked_stderr}"
+    );
+    let rustbgpd_no_listener = run_fixture("rustbgpd-txn", 0, 1);
+    let no_listener_stderr = String::from_utf8_lossy(&rustbgpd_no_listener.stderr);
+    assert!(!rustbgpd_no_listener.status.success());
+    assert_eq!(
+        no_listener_stderr.trim(),
+        "cell rustbgpd-txn: no listener on :1790 after 0s"
+    );
+    assert!(!no_listener_stderr.contains("/readyz"));
+
+    let rustbgpd_ready = run_fixture("rustbgpd-txn", 0, 0);
+    assert!(
+        rustbgpd_ready.status.success(),
+        "rustbgpd did not become ready"
+    );
+    let bird_ready = run_fixture("bird", 22, 0);
+    assert!(
+        bird_ready.status.success(),
+        "BIRD startup unexpectedly required /readyz"
+    );
+}
+
+#[test]
 /// Red proof: removing or moving the empty-sample guard after the CSV append
 /// makes this fail, restoring the teardown race's bogus terminal `0,0` row.
 fn rss_sampler_drops_empty_teardown_samples_before_append() {


### PR DESCRIPTION
## Summary

- require both the BGP listener and the daemon readiness endpoint before starting peers in rustbgpd IRR receipt cells
- preserve listener-only startup for BIRD and OpenBGPD
- align the precommitted campaign protocol with the executable gate

## Root cause

A canonical 320-member run started reloadstall as soon as the BGP socket bound. rustbgpd intentionally binds that socket before installing its initial peer roster, so 14 configured peers connected during the partial-roster window and were reset as unknown. The readiness endpoint is deliberately activated only after initial peer registration; the harness now honors that boundary.

## Load-bearing proof

The focused fixture supplies a live PID and a positive BGP listener probe, then proves that:

- rustbgpd startup remains blocked while the readiness endpoint fails
- rustbgpd startup succeeds when the endpoint succeeds
- BIRD remains unaffected by a failing rustbgpd readiness endpoint
- the readiness check stays after the BGP-listener condition

Restoring the listener-only return makes the focused test fail.

## Verification

- `bash -n bench/scale/irrreload/run-irr-reload.sh`
- `shellcheck bench/scale/irrreload/run-irr-reload.sh`
- `cargo test --test reloadstall_scenario_emitted_check` (14/14)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
- `git diff --check`