### PR TITLE
Refresh effective-config shell completions

### DIFF
--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -3716,7 +3716,7 @@ _rbgp__subcmd__config_commands() {
 'status:Show pending or last confirmed-transaction lifecycle state' \
 'history:List retained config-history rows (newest first)' \
 'rollback:Roll back to an eligible config snapshot (Junos \`rollback N\`)' \
-'effective:Dump the daemon'\''s effective running config (defaults materialized)' \
+'effective:Dump the daemon'\''s effective running config (defaults resolved)' \
 'import:Import a BIRD 2 / FRR / GoBGP config into a rustbgpd config.toml' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
@@ -3758,7 +3758,7 @@ _rbgp__subcmd__config__subcmd__help_commands() {
 'status:Show pending or last confirmed-transaction lifecycle state' \
 'history:List retained config-history rows (newest first)' \
 'rollback:Roll back to an eligible config snapshot (Junos \`rollback N\`)' \
-'effective:Dump the daemon'\''s effective running config (defaults materialized)' \
+'effective:Dump the daemon'\''s effective running config (defaults resolved)' \
 'import:Import a BIRD 2 / FRR / GoBGP config into a rustbgpd config.toml' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
@@ -4513,7 +4513,7 @@ _rbgp__subcmd__help__subcmd__config_commands() {
 'status:Show pending or last confirmed-transaction lifecycle state' \
 'history:List retained config-history rows (newest first)' \
 'rollback:Roll back to an eligible config snapshot (Junos \`rollback N\`)' \
-'effective:Dump the daemon'\''s effective running config (defaults materialized)' \
+'effective:Dump the daemon'\''s effective running config (defaults resolved)' \
 'import:Import a BIRD 2 / FRR / GoBGP config into a rustbgpd config.toml' \
     )
     _describe -t commands 'rbgp help config commands' commands "$@"

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -76,7 +76,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_su
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -f -a "status" -d 'Show pending or last confirmed-transaction lifecycle state'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -f -a "history" -d 'List retained config-history rows (newest first)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -f -a "rollback" -d 'Roll back to an eligible config snapshot (Junos `rollback N`)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -f -a "effective" -d 'Dump the daemon\'s effective running config (defaults materialized)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -f -a "effective" -d 'Dump the daemon\'s effective running config (defaults resolved)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -f -a "import" -d 'Import a BIRD 2 / FRR / GoBGP config into a rustbgpd config.toml'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -l from-file -d 'Hidden compatibility alias for the positional `CANDIDATE`' -r
@@ -156,7 +156,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "status" -d 'Show pending or last confirmed-transaction lifecycle state'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "history" -d 'List retained config-history rows (newest first)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "rollback" -d 'Roll back to an eligible config snapshot (Junos `rollback N`)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "effective" -d 'Dump the daemon\'s effective running config (defaults materialized)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "effective" -d 'Dump the daemon\'s effective running config (defaults resolved)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "import" -d 'Import a BIRD 2 / FRR / GoBGP config into a rustbgpd config.toml'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset refresh-out help" -l compare -d 'Compare this peer\'s live update-group membership with another configured peer without exposing internal group identifiers' -r
@@ -1146,7 +1146,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "status" -d 'Show pending or last confirmed-transaction lifecycle state'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "history" -d 'List retained config-history rows (newest first)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "rollback" -d 'Roll back to an eligible config snapshot (Junos `rollback N`)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "effective" -d 'Dump the daemon\'s effective running config (defaults materialized)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "effective" -d 'Dump the daemon\'s effective running config (defaults resolved)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "import" -d 'Import a BIRD 2 / FRR / GoBGP config into a rustbgpd config.toml'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor" -f -a "add" -d 'Add a new neighbor'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor" -f -a "delete" -d 'Delete this neighbor'


### PR DESCRIPTION
## Summary

Regenerate the checked-in Zsh and Fish completion artifacts after the effective-config help text changed from defaults materialized to defaults resolved. Bash output is byte-identical and correctly remains unchanged.

## Verification

- cargo test --locked -p rustbgpctl checked_in_completions_match_current_cli
- cargo test --locked -p rustbgpctl
- cargo fmt --all -- --check
- git diff --check
- independent generated-artifact review

The byte-for-byte completion freshness test goes red if either generated file is reverted.

Closes LAN-876.