### PR TITLE
Support bounded large effective configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- `rbgp config effective` and `rbgp doctor` now accept a byte-exact effective
+  config document larger than tonic's 4 MiB client default, up to a finite
+  384 MiB of normalized TOML plus its protobuf envelope. The allowance is
+  method-specific; unrelated `ConfigService` RPC clients keep the default
+  decode ceiling. Doctor borrows that document for its checks and probes,
+  then moves the same allocation into the bundle instead of retaining
+  full-document copies.
+
 - The ordinary example configs now rely on the default owner-only gRPC Unix
   socket instead of repeating an explicit principal and role map. Socket
   access and operator authority are unchanged; audit identity changes from

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -33,7 +33,7 @@ rbgp config apply config.toml \
 rbgp config status
 rbgp config confirm deploy-123
 rbgp config abort deploy-123
-rbgp config effective                       # dump running post-defaults config (redacted TOML; -j for JSON)
+rbgp config effective                       # dump running post-defaults config (redacted TOML; -j for JSON; bounded to 384 MiB)
 rbgp config history                         # list applied config transactions
 rbgp config rollback <n>                    # roll back to a prior history entry (1 = previous applied config)
 

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -744,8 +744,7 @@ fn format_unix_utc(unix_seconds: u64) -> String {
 /// redacted server-side. `--json` re-renders the same document as JSON; the
 /// daemon only ships TOML.
 pub async fn effective(connection: Connection, json: bool) -> Result<(), CliError> {
-    let mut client =
-        ConfigServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let mut client = connection.effective_config_client();
     let resp = client
         .get_effective_config(GetEffectiveConfigRequest {})
         .await?

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -20,7 +20,6 @@ use crate::connection::Connection;
 use crate::error::CliError;
 use crate::output::{self, JsonNeighbor};
 use crate::proto::bfd_service_client::BfdServiceClient;
-use crate::proto::config_service_client::ConfigServiceClient;
 use crate::proto::control_service_client::ControlServiceClient;
 use crate::proto::event_service_client::EventServiceClient;
 use crate::proto::global_service_client::GlobalServiceClient;
@@ -164,9 +163,11 @@ impl Reporter {
     }
 }
 
-/// Bundle contents buffered in memory (every section is small and
-/// bounded), then written as one gzipped tarball under a single root
-/// directory so extraction never splatters files into the cwd.
+/// Bundle contents buffered in memory, then written as one gzipped tarball
+/// under a single root directory so extraction never splatters files into
+/// the cwd. Most sections are small; the bounded effective config can be up
+/// to 384 MiB and is moved into the bundle exactly once after its checks and
+/// deployment probes have borrowed it.
 struct Bundle {
     files: Vec<(String, Vec<u8>)>,
 }
@@ -493,6 +494,17 @@ fn parse_state_dir(effective_toml: &str) -> Option<String> {
             .as_str()?
             .to_string(),
     )
+}
+
+fn deploy_config_source<'a>(
+    effective_toml: Option<&'a str>,
+    local_config_source: Option<&'a (String, String)>,
+) -> Option<(&'a str, &'a str)> {
+    effective_toml
+        .map(|toml_text| (toml_text, "effective config"))
+        .or_else(|| {
+            local_config_source.map(|(toml_text, source)| (toml_text.as_str(), source.as_str()))
+        })
 }
 
 fn tcp_ao_configured_targets(effective_toml: &str) -> Vec<String> {
@@ -1698,10 +1710,7 @@ pub(crate) async fn run(
 
             // config/effective.toml: the daemon's own redacted, normalized
             // dump (same RPC as `rbgp config effective`). Never the raw file.
-            let mut config_client = ConfigServiceClient::with_interceptor(
-                connection.channel(),
-                connection.interceptor(),
-            );
+            let mut config_client = connection.effective_config_client();
             match config_client
                 .get_effective_config(GetEffectiveConfigRequest {})
                 .await
@@ -1721,7 +1730,6 @@ pub(crate) async fn run(
                         reporter.record(check.name, check.status, check.detail);
                     }
                     state_dir = parse_state_dir(&toml_text);
-                    bundle.add("config/effective.toml", toml_text.clone().into_bytes());
                     effective_toml = Some(toml_text);
                     sections.insert(
                         "config",
@@ -2073,19 +2081,20 @@ pub(crate) async fn run(
     // otherwise the local config file (the path a local daemon process
     // was started with, else the packaged default). The local file is
     // only parsed for probe targets — it is never copied into the bundle.
-    let config_source: Option<(String, String)> = match &effective_toml {
-        Some(toml_text) => Some((toml_text.clone(), "effective config".to_string())),
-        None => {
-            let path = daemon_limits
-                .first()
-                .and_then(|(pid, _)| proc_cmdline_config_path(*pid))
-                .unwrap_or_else(|| PathBuf::from(DEFAULT_CONFIG_PATH));
-            fs::read_to_string(&path)
-                .ok()
-                .map(|text| (text, path.display().to_string()))
-        }
+    let local_config_source: Option<(String, String)> = if effective_toml.is_none() {
+        let path = daemon_limits
+            .first()
+            .and_then(|(pid, _)| proc_cmdline_config_path(*pid))
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_CONFIG_PATH));
+        fs::read_to_string(&path)
+            .ok()
+            .map(|text| (text, path.display().to_string()))
+    } else {
+        None
     };
-    match &config_source {
+    let config_source =
+        deploy_config_source(effective_toml.as_deref(), local_config_source.as_ref());
+    match config_source {
         Some((toml_text, source)) => {
             let targets = deploy_targets(toml_text);
             if !daemon_reachable && let Some(port) = targets.listen_port {
@@ -2116,6 +2125,12 @@ pub(crate) async fn run(
             );
             sections.insert("probes", "skipped: no config source".to_string());
         }
+    }
+
+    // Checks and probes above only borrow the potentially large document;
+    // transfer its allocation directly into the bundle after the last read.
+    if let Some(toml_text) = effective_toml.take() {
+        bundle.add("config/effective.toml", toml_text.into_bytes());
     }
 
     // ---- config freshness (local daemon processes only) ---------------
@@ -2267,6 +2282,44 @@ mod tests {
     use crate::connection::connect;
     use crate::test_support::spawn_mock_server;
     use tonic::Code;
+
+    /// The effective config can approach 384 MiB. Reintroducing either the
+    /// bundle copy or the probe-source copy adds `toml_text.clone()` to the
+    /// production half and makes this structural allocation fence red.
+    #[test]
+    fn effective_config_is_borrowed_for_probes_then_moved_into_bundle() {
+        let source = include_str!("doctor.rs");
+        let production = source.split("#[cfg(test)]").next().unwrap();
+
+        assert_eq!(production.matches("toml_text.clone()").count(), 0);
+        assert_eq!(production.matches("effective_toml.clone()").count(), 0);
+        assert_eq!(
+            production
+                .matches(
+                    "deploy_config_source(effective_toml.as_deref(), local_config_source.as_ref())"
+                )
+                .count(),
+            1
+        );
+        assert_eq!(production.matches("effective_toml.take()").count(), 1);
+        assert_eq!(production.matches("toml_text.into_bytes()").count(), 1);
+    }
+
+    #[test]
+    fn deploy_probe_config_prefers_effective_and_preserves_local_fallback() {
+        // Removing the local fallback makes the second assertion red;
+        // reversing precedence makes the first assertion red.
+        let local = ("local".to_string(), "/etc/rustbgpd/config.toml".to_string());
+        assert_eq!(
+            deploy_config_source(Some("effective"), Some(&local)),
+            Some(("effective", "effective config"))
+        );
+        assert_eq!(
+            deploy_config_source(None, Some(&local)),
+            Some(("local", "/etc/rustbgpd/config.toml"))
+        );
+        assert_eq!(deploy_config_source(None, None), None);
+    }
 
     /// Load-bearing proof: removing the remote-AdminDown branch makes the
     /// permitted warning red; defaulting absent presence to false makes the

--- a/crates/cli/src/connection.rs
+++ b/crates/cli/src/connection.rs
@@ -18,6 +18,7 @@ use tonic::{Request, Status};
 use tower::service_fn;
 
 use crate::error::CliError;
+use crate::proto::config_service_client::ConfigServiceClient;
 use crate::proto::rib_service_client::RibServiceClient;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -36,6 +37,20 @@ const BEARER_PREFIX: &str = "Bearer ";
 /// `usize::MAX`: a response above the ceiling still fails closed with
 /// `out of range` instead of buffering without bound.
 pub(crate) const LISTING_MAX_DECODE_BYTES: usize = 64 * 1024 * 1024;
+
+/// Decode ceiling for the normalized TOML returned by
+/// `ConfigService.GetEffectiveConfig`.
+///
+/// The document is deliberately a byte-exact full export rather than a
+/// paged surface. Keep the allowance finite and method-specific: 384 MiB of
+/// TOML plus the protobuf string field's one-byte tag and five-byte length
+/// varint at that size. Other `ConfigService` RPCs retain tonic's 4 MiB
+/// client default.
+pub(crate) const EFFECTIVE_CONFIG_MAX_TOML_BYTES: usize = 384 * 1024 * 1024;
+const EFFECTIVE_CONFIG_PROTOBUF_ENVELOPE_BYTES: usize =
+    1 + prost::encoding::encoded_len_varint(EFFECTIVE_CONFIG_MAX_TOML_BYTES as u64);
+pub(crate) const EFFECTIVE_CONFIG_MAX_DECODE_BYTES: usize =
+    EFFECTIVE_CONFIG_MAX_TOML_BYTES + EFFECTIVE_CONFIG_PROTOBUF_ENVELOPE_BYTES;
 
 #[derive(Clone)]
 pub(crate) struct Connection {
@@ -69,6 +84,15 @@ impl Connection {
         self.rib_client_with_decode_limit(LISTING_MAX_DECODE_BYTES)
     }
 
+    /// A `ConfigService` client only for `GetEffectiveConfig`, with room for
+    /// one full bounded normalized-config document. Other config operations
+    /// continue to use the generated client's default decode ceiling.
+    pub(crate) fn effective_config_client(
+        &self,
+    ) -> ConfigServiceClient<InterceptedService<Channel, AuthInterceptor>> {
+        self.config_client_with_decode_limit(EFFECTIVE_CONFIG_MAX_DECODE_BYTES)
+    }
+
     /// Shared constructor core; tests drive it with a small cap to prove
     /// the ceiling is enforced rather than advisory.
     fn rib_client_with_decode_limit(
@@ -76,6 +100,16 @@ impl Connection {
         limit: usize,
     ) -> RibServiceClient<InterceptedService<Channel, AuthInterceptor>> {
         RibServiceClient::with_interceptor(self.channel(), self.interceptor())
+            .max_decoding_message_size(limit)
+    }
+
+    /// Shared constructor core; tests inject a small cap to prove the limit
+    /// is enforced rather than advisory.
+    fn config_client_with_decode_limit(
+        &self,
+        limit: usize,
+    ) -> ConfigServiceClient<InterceptedService<Channel, AuthInterceptor>> {
+        ConfigServiceClient::with_interceptor(self.channel(), self.interceptor())
             .max_decoding_message_size(limit)
     }
 }
@@ -467,6 +501,185 @@ mod tests {
             .await
             .expect_err("server must reject the tokenless client");
         assert_eq!(err.code(), tonic::Code::Unauthenticated, "{err}");
+    }
+
+    fn effective_config_fixture(payload_len: usize) -> String {
+        "#".repeat(payload_len)
+    }
+
+    // Removing the production cap from `effective_config_client` makes this
+    // real >4 MiB loopback response fail with OutOfRange.
+    #[tokio::test]
+    async fn effective_config_client_decodes_response_over_default_ceiling() {
+        let handle = crate::test_support::spawn_mock_server(None).await;
+        let toml = effective_config_fixture(5 * 1024 * 1024);
+        let response = server_proto::GetEffectiveConfigResponse { toml };
+        assert!(
+            response.encoded_len() > 4 * 1024 * 1024,
+            "fixture must exceed tonic's default decode ceiling"
+        );
+        let expected_len = response.toml.len();
+        *handle.state.config_effective_toml.lock().await = Some(response.toml);
+
+        let connection = connect(&handle.addr, None).await.unwrap();
+        let got = connection
+            .effective_config_client()
+            .get_effective_config(crate::proto::GetEffectiveConfigRequest {})
+            .await
+            .expect("bounded effective-config client must decode a >4 MiB document")
+            .into_inner();
+        assert_eq!(got.toml.len(), expected_len);
+    }
+
+    // Replacing the finite cap with an unbounded/default-ignoring constructor
+    // makes this injected 1 KiB ceiling stop rejecting the response.
+    #[tokio::test]
+    async fn effective_config_client_ceiling_is_enforced() {
+        let handle = crate::test_support::spawn_mock_server(None).await;
+        let toml = effective_config_fixture(2048);
+        let response = server_proto::GetEffectiveConfigResponse { toml };
+        assert!(response.encoded_len() > 1024);
+        *handle.state.config_effective_toml.lock().await = Some(response.toml);
+
+        let connection = connect(&handle.addr, None).await.unwrap();
+        let err = connection
+            .config_client_with_decode_limit(1024)
+            .get_effective_config(crate::proto::GetEffectiveConfigRequest {})
+            .await
+            .expect_err("a 1 KiB cap must reject a >1 KiB effective config");
+        assert_eq!(err.code(), tonic::Code::OutOfRange, "{err}");
+    }
+
+    // The method-specific constructor must preserve the ordinary auth
+    // interceptor. Replacing it with an unintercepted client makes the
+    // authenticated request fail; weakening server auth makes the bare
+    // request stop returning Unauthenticated.
+    #[tokio::test]
+    async fn effective_config_client_carries_bearer_token() {
+        let handle = crate::test_support::spawn_mock_server(Some("effective-secret")).await;
+        let dir = tempfile::tempdir().unwrap();
+        let token_path = dir.path().join("token.txt");
+        fs::write(&token_path, "effective-secret\n").unwrap();
+
+        let connection = connect(&handle.addr, Some(token_path.to_str().unwrap()))
+            .await
+            .unwrap();
+        connection
+            .effective_config_client()
+            .get_effective_config(crate::proto::GetEffectiveConfigRequest {})
+            .await
+            .expect("authenticated effective-config call must succeed");
+
+        let bare = connect(&handle.addr, None).await.unwrap();
+        let err = bare
+            .effective_config_client()
+            .get_effective_config(crate::proto::GetEffectiveConfigRequest {})
+            .await
+            .expect_err("server must reject the tokenless client");
+        assert_eq!(err.code(), tonic::Code::Unauthenticated, "{err}");
+    }
+
+    // The cap is 384 MiB of TOML plus exactly the protobuf string-field
+    // envelope at that payload size (one-byte tag + five-byte varint). Any
+    // global/unbounded replacement or omitted envelope makes this red.
+    #[allow(
+        clippy::assertions_on_constants,
+        reason = "constant assertions are mutation fences for the finite protocol budget"
+    )]
+    #[test]
+    fn effective_config_decode_ceiling_has_exact_finite_envelope() {
+        assert_eq!(
+            prost::encoding::encoded_len_varint(EFFECTIVE_CONFIG_MAX_TOML_BYTES as u64),
+            5
+        );
+        assert_eq!(EFFECTIVE_CONFIG_PROTOBUF_ENVELOPE_BYTES, 6);
+        assert_eq!(EFFECTIVE_CONFIG_MAX_DECODE_BYTES, 384 * 1024 * 1024 + 6);
+        assert!(EFFECTIVE_CONFIG_MAX_DECODE_BYTES < usize::MAX);
+
+        let production = include_str!("connection.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .unwrap();
+        let constructors = production
+            .split("pub(crate) fn effective_config_client")
+            .nth(1)
+            .unwrap();
+        assert_eq!(
+            constructors
+                .matches("self.config_client_with_decode_limit(EFFECTIVE_CONFIG_MAX_DECODE_BYTES)")
+                .count(),
+            1,
+            "production helper must consume the finite effective-config cap"
+        );
+        let config_constructor = constructors
+            .split("fn config_client_with_decode_limit")
+            .nth(1)
+            .unwrap();
+        assert_eq!(
+            config_constructor
+                .matches(".max_decoding_message_size(limit)")
+                .count(),
+            1,
+            "ConfigService constructor must enforce its supplied limit"
+        );
+        assert!(!config_constructor.contains("usize::MAX"));
+    }
+
+    fn collect_production_rust_sources(dir: &Path, sources: &mut Vec<(PathBuf, String)>) {
+        for entry in fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                collect_production_rust_sources(&path, sources);
+                continue;
+            }
+            if path.extension().and_then(|ext| ext.to_str()) != Some("rs")
+                || path.file_name().and_then(|name| name.to_str()) == Some("test_support.rs")
+            {
+                continue;
+            }
+            let mut source = fs::read_to_string(&path).unwrap();
+            if let Some(test_module) = source.rfind("#[cfg(test)]\nmod tests {") {
+                source.truncate(test_module);
+            }
+            sources.push((path, source));
+        }
+    }
+
+    // Both and only the full-document consumers anywhere in the CLI source
+    // tree must use the bounded helper. Reverting either command to a raw
+    // generated client, or adding a third production callsite in any file,
+    // changes these counts; test-only modules and test_support.rs are removed.
+    #[test]
+    fn effective_config_surface_inventory_uses_bounded_client() {
+        let mut sources = Vec::new();
+        collect_production_rust_sources(
+            &Path::new(env!("CARGO_MANIFEST_DIR")).join("src"),
+            &mut sources,
+        );
+        let constructors: usize = sources
+            .iter()
+            .map(|(_, source)| source.matches(".effective_config_client()").count())
+            .sum();
+        let calls: usize = sources
+            .iter()
+            .map(|(_, source)| source.matches(".get_effective_config(").count())
+            .sum();
+        assert_eq!(constructors, 2, "inventoried bounded constructor sites");
+        assert_eq!(calls, 2, "inventoried effective-config RPC calls");
+
+        let mut callsite_files: Vec<_> = sources
+            .iter()
+            .filter(|(_, source)| source.contains(".get_effective_config("))
+            .map(|(path, _)| path.strip_prefix(env!("CARGO_MANIFEST_DIR")).unwrap())
+            .collect();
+        callsite_files.sort_unstable();
+        assert_eq!(
+            callsite_files,
+            [
+                Path::new("src/commands/config.rs"),
+                Path::new("src/commands/doctor.rs")
+            ]
+        );
     }
 
     // Inventory fence over the full unary listing surfaces. Every listing

--- a/docs/API.md
+++ b/docs/API.md
@@ -431,8 +431,11 @@ callers submit candidate TOML and receive only redacted diff / plan
 output; `GetEffectiveConfig` is the one deliberate full-document export
 — it returns the effective running config as normalized TOML with
 defaults resolved (selected default-empty policy lists may be omitted) and
-secret material replaced with `<redacted>`
-before it leaves the daemon (`rbgp config effective`).
+secret material replaced with `<redacted>` before it leaves the daemon
+(`rbgp config effective`). The two shipped
+full-document consumers (`rbgp config effective` and `rbgp doctor`) accept
+at most 384 MiB of TOML plus its protobuf envelope; other config RPC clients
+retain tonic's 4 MiB decode default.
 
 | RPC | Description |
 |-----|-------------|

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -134,6 +134,11 @@ rbgp config apply /tmp/new-config.toml \
   --expected-runtime-snapshot-token kv1:...
 ```
 
+`rbgp config effective` downloads this byte-exact full document with a finite
+384 MiB TOML ceiling (plus the protobuf envelope). The same method-specific
+allowance covers the effective-config copy collected by `rbgp doctor`; other
+config RPCs retain the ordinary 4 MiB client decode limit.
+
 `rbgp config plan` and `config apply` stream the candidate in bounded frames;
 they are not limited by tonic's 4,194,304-byte unary-message ceiling. The plan
 receipt includes a single-use `plan_token` bound to the candidate digest,
@@ -1525,7 +1530,7 @@ addresses only, never copied into the bundle.
 ```
 rustbgpd-doctor-<ts>/
 ├── manifest.json            # versions, redaction note, per-section collected/partial/unavailable status, check results
-├── config/effective.toml    # GetEffectiveConfig dump (defaults resolved, selected empty lists omitted, secrets <redacted>)
+├── config/effective.toml    # GetEffectiveConfig dump (resolved defaults, selected empty lists omitted, secrets <redacted>; 384 MiB max)
 ├── peers/bfd.json           # BFD state/diagnostic/strict plus remote-AdminDown bool or null when unknown
 ├── peers/dynamic-neighbors.json # configured acceptance ranges; descriptions scrubbed client-side
 ├── peers/neighbors.json     # per-peer state, counters, flap/slow-peer status


### PR DESCRIPTION
## Summary

- give only the two shipped GetEffectiveConfig consumers a finite 384 MiB TOML plus exact six-byte protobuf response ceiling; all other ConfigService clients keep tonic default limits
- preserve the standard bearer interceptor and source-wide inventory of both production callers
- make rbgp doctor borrow one effective-config allocation through checks and probes, then move it into the bundle instead of retaining three full copies; preserve its readable local-config fallback

## Operating-shape rationale

The measured compacted 320-peer IRR config is 298,877,893 bytes (285.032 MiB), leaving 98.968 MiB below the method-specific ceiling. The former Doctor path retained 896,633,679 payload bytes (855.10 MiB) across three copies at that shape before TOML parsing; this change retains one owned document and moves its allocation into the bundle.

## Load-bearing proofs

- a real 5 MiB loopback response fails under tonic default limits and succeeds through the production helper
- an injected 1 KiB ceiling rejects a larger response; the exact finite constant and protobuf envelope are pinned
- authenticated success plus tokenless rejection goes red if the interceptor is dropped
- a source-wide non-test inventory goes red if either current caller reverts or a third caller appears
- the Doctor allocation fence goes red if either full-document clone returns
- effective-vs-local source selection goes red if precedence or the prior fallback changes

## Verification

- cargo test --locked -p rustbgpctl
- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc --locked --workspace --no-deps
- cargo fmt --all -- --check
- python3 scripts/check-clippy-reasons.py
- git diff --check
- independent adversarial review plus two focused follow-up reviews

Advances LAN-874; final closure waits for the real LAN-832 full-shape lifecycle receipt.