### PR TITLE
Document commit-confirm v3 authority contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,26 +144,26 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   daemon's enforcement mode from the effective config (skipped against
   daemons that do not expose it).
 
-- **Provenance-bearing commit-confirm v2 (LAN-798, ADR-0121).** New confirmed
-  transactions persist the exact accepted prior snapshot—normalized TOML,
-  external-source manifest, and both digests—in a canonical owner-private v2
-  journal, then publish a config-adjacent locator as the sole pending
-  authority before committing the candidate. Crash/restart restore verifies
-  and directly adopts that retained accepted snapshot before opening candidate
-  contents or mutating the candidate or backup; launch-target metadata may be
-  inspected while binding the authority. Live abort and timeout instead reuse
-  the same prior object through the ordinary #1370-gated planner and apply
-  path. Abort, timeout, and boot restore durably restore while both authority
-  files remain, then remove and sync the locator; confirm begins with that
-  durable locator removal. Later exact journal cleanup is warning-only. The
-  locator-free v1 lane remains fail-closed upgrade compatibility, but a live v1
-  transaction must terminate before upgrade and production never converts or
-  dual-writes it. Before downgrade, both the v2 locator and locator-free v2
-  journal residue must be absent; v2 config history separately requires moving
-  the complete history directory aside. Locator absence is authority-free and
-  does not impose v2 ownership or mode policy on an ordinary launch path;
-  confirmed writes and any present v2 object still require the documented
-  daemon-owned private directory.
+- **Provenance-bearing commit-confirm authority (LAN-798, ADR-0121).** New
+  confirmed transactions publish an owner-private raw normalized prior, then
+  compact provenance/file-identity metadata, then the config-adjacent locator
+  as the sole pending boot authority. Crash/restart restore verifies and directly
+  adopts that retained accepted snapshot before opening candidate contents or
+  mutating the candidate or backup; launch-target metadata may be inspected
+  while binding the authority. Live abort and timeout instead reuse the same
+  prior object through the ordinary #1370-gated planner and apply path. Abort,
+  timeout, and boot restore durably restore while all three objects remain;
+  confirm, successful rollback, and boot restore become terminal only after
+  locator removal and parent-directory sync. Later exact metadata/raw cleanup
+  is warning-only.
+  Production writes v3 only while retaining frozen v2 locator and locator-free
+  v1 recovery readers without conversion or dual-write. Finish pending state
+  before upgrade or downgrade, and remove format-specific safe residue before
+  starting an older binary; v2 config history separately requires moving the
+  complete history directory aside. Locator absence is authority-free and does
+  not impose pending-storage ownership or mode policy on an ordinary launch
+  path; confirmed writes and any present pending object still require the
+  documented daemon-owned private directory.
 
 - **Config-history provenance schema and rendering.** `ListConfigHistory` and
   `rbgp config history` now expose an additive config-source digest over the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,19 +54,22 @@ input from the network. It runs under continuous fuzzing in CI.
 - **No unbounded allocations.** All channels are bounded. Per-peer
   prefix limits enforced at insertion. UPDATE attribute sizes enforced
   at decode time.
-- **Commit-confirm state is authenticated local authority.** The v2 pending
-  journal is secret-bearing because it contains normalized config and accepted
-  external-source identity. The locator is confidential because it carries
-  paths and digests. Both are bounded canonical records in daemon-owned regular
-  `0600` files; a writer or present v2 object requires a daemon-owned parent
-  that is not group- or world-writable. Locator absence carries no authority
-  and therefore adds no v2 ownership or mode requirement to an ordinary
-  launch path. Reads are descriptor-relative, no-follow, same-FD operations;
-  unsafe, changed, oversized, or mismatched state fails closed before candidate
-  contents are opened and before candidate or backup mutation. Launch-target
-  metadata may be inspected to bind the authority. Diagnostics do not expose
-  locator-carried paths or digests. Durable locator removal, not journal
-  deletion, is the terminal transaction boundary.
+- **Commit-confirm state is authenticated local authority.** Production writes
+  v3 in durability order: secret-bearing normalized configuration at
+  `<runtime_state_dir>/commit-confirm-v3-prior.toml`, confidential provenance
+  and file-identity metadata at `commit-confirm-v3-metadata.json`, then the
+  confidential config-adjacent `commit-confirm-locator.json`. Metadata and the
+  locator contain paths and digests, not raw TOML; the locator is the sole boot
+  authority. All are bounded daemon-owned regular `0600` files, and a writer or
+  present pending object requires daemon-owned real parents that are not group-
+  or world-writable. Reads are descriptor-relative, no-follow, same-FD
+  operations; unsafe, changed, oversized, or mismatched state fails closed
+  before candidate contents are opened or candidate/backup mutation. Durable
+  locator unlink plus parent `fsync` is terminal; only later verified exact
+  metadata/raw cleanup and pending-directory `fsync` can fail warning-only.
+  Locator absence carries no v2/v3 authority; locator-free v1 remains boot
+  authority. Startup retains the v2 locator and locator-free v1 readers
+  without converting or dual-writing either format.
 - **No `unsafe` code in shipped paths, with two scoped exceptions.** Every
   workspace crate root carries `#![deny(unsafe_code)]`, so `unsafe` cannot enter
   a crate without a visible, reviewed opt-out. There are two:

--- a/docs/API.md
+++ b/docs/API.md
@@ -573,12 +573,23 @@ confirmation, other persisted runtime config mutators fail with
 `confirm_id` to make the change permanent, or `AbortConfigTransaction` to roll
 back immediately. If the timer expires first, the daemon re-applies the
 pre-commit runtime snapshot through the same transaction executor and persists
-the rollback. The confirm window is durable. Before commit, the daemon journals the
-pre-commit config to `<runtime_state_dir>/commit-confirm-journal.json`; a
-restart that finds an unconfirmed journal reverts at boot before adopting the
-on-disk config, saves the unconfirmed candidate as `<config>.unconfirmed`, and
-fails closed on torn, unusable, or unremovable journal state. `GetConfigTransactionStatus`
-reports the current pending transaction or the last terminal lifecycle result.
+the rollback. The confirm window is durable. Before commit, the v3 writer
+publishes the exact accepted normalized prior to
+`<runtime_state_dir>/commit-confirm-v3-prior.toml`, its provenance and
+file-identity metadata to `commit-confirm-v3-metadata.json`, then the sole boot
+authority to `<absolute lexical config path>.commit-confirm-locator.json`.
+Startup checks that locator before candidate contents and verifies the complete
+chain before restoring; unsafe, torn, or mismatched state fails closed.
+Confirm and successful rollback become terminal only after locator unlink and
+parent-directory `fsync`. Subsequent verified exact metadata/raw cleanup and
+pending-directory `fsync` are warning-only; locator-free residue cannot re-arm
+the transaction.
+Production writes v3; the v2 locator and locator-free v1 formats are frozen
+compatibility readers without conversion or dual-write. Finish a live v1/v2
+transaction before upgrade. Before downgrade, finish or abort v3 rather than
+deleting a live locator; only after terminal cleanup verify v3 and v2 pending
+state is absent. `GetConfigTransactionStatus` reports the pending transaction
+or last terminal lifecycle result.
 A failed abort/auto-revert rollback is not terminal: the transaction stays
 pending with an `ABORT_FAILED`/`AUTO_REVERT_FAILED` status and the mutation
 fence stays closed until the abort is retried successfully, the candidate is

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3256,26 +3256,31 @@ confirmed apply returns `FAILED_PRECONDITION` with the actual and limit byte
 counts before publishing authority or mutating peer, persisted, or runtime
 state. Apply without `--confirm-id`, or reduce the canonical config size.
 
-The confirm window is durable: the daemon journals the pre-commit config
-snapshot to `<runtime_state_dir>/commit-confirm-journal.json`, including its
-accepted external-source manifest and digests, then publishes
-`<absolute lexical config path>.commit-confirm-locator.json` before the
-candidate commits. That config-adjacent locator is the sole v2 pending
-authority and is checked before candidate contents are parsed. A restart verifies and
-reuses the exact accepted prior snapshot, restores its recorded config target,
-and saves the unconfirmed candidate as `<recorded-target>.unconfirmed`.
-Confirm and successful rollback become terminal after durable locator removal;
-later exact journal-residue cleanup is warning-only. Files and their parent
-directories must satisfy the storage contract: v2 locator, journal, and staging
-files are daemon-owned regular files with mode `0600`. A writer or present v2
-object requires daemon-owned real parents that are not group- or
-world-writable. Locator absence carries no authority and does not impose this
-v2 storage policy on an ordinary launch path. Before downgrade, both the
-v2 locator and any locator-free v2 journal residue must be absent; v2 config
-history separately requires moving the complete history directory aside. A
-locator-free v1 journal remains a fail-closed compatibility lane, but a live v1
-transaction must terminate before upgrade. Production writes only v2 and never
-converts or dual-writes v1 state.
+The confirm window is durable: before the candidate commits, the v3 writer
+publishes `<runtime_state_dir>/commit-confirm-v3-prior.toml`, then
+`<runtime_state_dir>/commit-confirm-v3-metadata.json`, then
+`<absolute lexical config path>.commit-confirm-locator.json`. The raw prior is
+the exact accepted normalized TOML. Metadata binds its provenance, digests,
+length, device, and inode; the config-adjacent locator is the sole pending boot
+authority. A restart checks that locator before candidate contents, verifies
+the complete chain, restores the recorded target, and saves the unconfirmed
+candidate as `<recorded-target>.unconfirmed`.
+
+Confirm and successful rollback become terminal after locator removal and its
+parent-directory `fsync`; later metadata/raw removal and pending-directory
+`fsync` are warning-only. All pending and staging files are daemon-owned regular
+files with mode `0600`, and a writer or present pending object requires
+daemon-owned real parents that are not group- or world-writable. Locator
+absence carries no authority and does not impose this storage policy on an
+ordinary launch path.
+
+Production writes v3 only. Startup retains the frozen v2 locator reader and the
+locator-free v1 fail-closed reader without conversion or dual-write. Finish or
+abort a live v1/v2 transaction before upgrade. Before downgrade, finish or
+abort v3, then ensure the locator and both fixed v3 residue files are absent;
+also ensure any v2 locator or locator-free v2 journal residue is absent. V2
+config history separately requires moving the complete history directory
+aside.
 See `docs/OPERATIONS.md` (config transactions) for the boot-revert and storage
 semantics.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -184,8 +184,12 @@ While a confirmed transaction is applying or awaiting confirmation, SIGHUP
 reload is ignored and every persisted runtime config mutator (FIB-table and
 dynamic-neighbor CRUD, neighbor lifecycle, a further `config apply`) is rejected
 with `FAILED_PRECONDITION`, so a pending timeout rollback cannot be overwritten
-by a later ad hoc change. The fence clears once the transaction is confirmed,
-aborted, or auto-reverted.
+by a later ad hoc change. The fence clears only after the transaction is
+terminal, including durable locator removal and parent-directory sync. If that
+authority removal fails after a confirm or otherwise successful rollback, the
+operation remains nonterminal and config mutations stay blocked; failure only
+in the later exact metadata/raw cleanup or pending-directory `fsync` is
+warning-only.
 
 `rbgp config status` reports the lifecycle outcome: `pending` (timer running),
 `confirmed`, `aborted`, `auto_reverted` (timer expired and the pre-commit
@@ -201,41 +205,52 @@ failure, or compound rollback failure) likewise retains the journal and blocks
 all config mutations until a restart boot-reverts.
 
 Commit-confirmed also survives a daemon restart or crash inside the confirm
-window. Before the candidate commits, the daemon writes the exact accepted
-pre-commit snapshot to
-`<runtime_state_dir>/commit-confirm-journal.json`, including normalized TOML,
-the external-source manifest, and both digests. It then publishes the sole v2
-pending authority at `<absolute lexical config path>.commit-confirm-locator.json`.
-Both files use write-temp + `fsync` + rename + parent-directory `fsync`, and
-the locator is never published before the journal is durable. A publication
-failure refuses the confirmed apply before candidate persistence.
+window. Before the candidate commits, the v3 writer publishes three objects in
+order: the exact accepted normalized TOML at
+`<runtime_state_dir>/commit-confirm-v3-prior.toml`, provenance and fixed-file
+identity metadata at
+`<runtime_state_dir>/commit-confirm-v3-metadata.json`, then the sole pending
+boot authority at
+`<absolute lexical config path>.commit-confirm-locator.json`. Each object uses
+write-temp + `fsync` + rename + parent-directory `fsync`; raw prior durability
+precedes metadata durability, and both precede the locator. A publication
+failure refuses the confirmed apply before candidate persistence unless the
+locator rename may already be durable, in which case mutations stay fenced
+until restart.
 
 Startup checks the config-adjacent locator before opening or parsing candidate
 contents. It may inspect launch-target metadata while pinning and binding the
 authority. If the locator is present, the daemon verifies it, the complete
-journal, config-target binding, retained TOML, external sources, and digests,
+metadata and raw prior, config-target binding, retained TOML, external sources,
+file identity, and digests,
 then directly adopts that accepted snapshot for boot restore. The revert is
 unconditional, regardless of how much confirm time remained, because the
 operator's confirming session died with the old process (the NETCONF RFC 6241
-§8.4 rule: session loss cancels a confirmed commit). The unconfirmed candidate is saved once as
-`<recorded-target>.unconfirmed`; the loud boot banner names the transaction but
-redacts locator-carried paths and digests. A damaged, unsafe, oversized, or
-mismatched locator/journal refuses boot before candidate contents are opened
-and before candidate or backup mutation.
+§8.4 rule: session loss cancels a confirmed commit). The unconfirmed candidate
+is saved once as `<recorded-target>.unconfirmed`; the loud boot banner names
+the transaction but redacts locator-carried paths and digests. A damaged,
+unsafe, oversized, or
+mismatched locator, metadata, or raw prior refuses boot before candidate
+contents are opened and before candidate or backup mutation.
 
-Abort, timeout, and boot restore durably restore the verified prior config while
-both files remain. They then unlink the locator and `fsync` its parent; only
-that durable locator absence is terminal. Confirm performs no restore and
-starts by unlinking and syncing the locator. Exact journal cleanup follows all
-terminal paths; failure there is a warning and safe residue cannot re-arm the
-transaction. An exact canonical v2 journal found without its locator is
-likewise residue and is removed only after all owner/mode/path checks. Production does
-not scan directories, infer another journal, convert v1, or dual-write. With no
-locator, an existing v1 TOML-only journal is handled by the fail-closed legacy
-boot lane, but a live v1 transaction must terminate before upgrade. Before
-downgrade or starting an older binary, both the v2 locator and locator-free v2
-journal residue must be absent. Separately move the complete v2 config-history
-directory aside before the older binary starts.
+Abort, timeout, and boot restore durably restore the verified prior config
+while all three objects remain. They then unlink the locator and `fsync` its
+parent; only that durable locator absence is terminal. Confirm performs no
+restore and starts by unlinking and syncing the locator. Exact metadata
+removal, raw-prior removal, and pending-directory `fsync` follow all terminal
+paths; failure there is a warning and locator-free residue cannot re-arm the
+transaction. A later confirmed apply removes only verified residue at those
+two fixed v3 names.
+
+Production writes v3 only. Startup checks v3 first, delegates a canonical v2
+locator unchanged to the frozen v2 recovery reader, then retains the
+locator-free v1 fail-closed reader; it does not convert or dual-write either
+legacy format. A live v1 or v2 transaction must terminate before upgrade.
+Before downgrade or starting an older binary, finish or abort any pending v3
+transaction; do not remove its locator by hand. After it is terminal, ensure
+the locator and both fixed v3 residue files are absent. Also ensure the frozen
+v2 locator and locator-free v2 journal residue are absent, and separately move
+the complete v2 config-history directory aside before the older binary starts.
 
 The boot-revert save-aside moves the unconfirmed candidate to
 `<config>.unconfirmed` with an atomic hard-link + unlink, so it never clobbers
@@ -248,14 +263,15 @@ intact, rather than risk an unsafe revert. Keep the config and
 for containerized deployments that bind-mount the config from an exotic
 backend.
 
-The lexical config and journal paths are resolved to absolute identities. A
-writer or present v2 object requires daemon-owned real parents that are not
-group- or world-writable. Locator absence carries no authority and therefore
-does not impose that v2 storage policy on an ordinary launch path; confirmed
-writes remain unavailable until the config directory is private, writable,
-and daemon-owned. Locator, journal, and staging
+The lexical config, metadata, and raw-prior paths are resolved to absolute
+identities. A writer or present pending object requires daemon-owned real
+parents that are not group- or world-writable. Locator absence carries no
+authority and therefore does not impose that storage policy on an ordinary
+launch path; confirmed writes remain unavailable until the config directory is
+private, writable, and daemon-owned. Locator, metadata, raw-prior, and staging
 files must be regular files owned by the daemon UID with mode `0600`; symlinks
-and special files fail closed. Keep writable state private and on local storage.
+and special files fail closed. Keep writable state private and on local
+storage.
 
 ### The transactional quartet: check, compare, commit confirmed, rollback
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -343,18 +343,26 @@ deadline expires.
 
 ## Recorded config history confidentiality
 
-`<runtime_state_dir>/config-history/` (legacy TOML plus v2 JSON) and a pending
-`commit-confirm-journal.json` contain normalized TOML configuration snapshots.
-That can include TCP-MD5 passwords, TCP-AO keys, API credentials, and other
-secrets; the redacted `rbgp config history` summary does not make the files
-themselves safe to publish. Files are owner-only (`0600`) in an owner-private
-directory (`0700`). Normal history output never exposes paths, filenames, or
-raw filesystem errors. V2 hashes external-source identity but does not archive
-source bytes, so rollback requires one detached load to reproduce the recorded
+`<runtime_state_dir>/config-history/` (legacy TOML plus v2 JSON), the fixed v3
+raw prior, and frozen v1/v2 `commit-confirm-journal.json` contain normalized
+TOML. They can
+include TCP-MD5 passwords, TCP-AO keys, API credentials, and other secrets;
+redacted history/status output does not make these files safe to publish. The
+fixed `commit-confirm-v3-metadata.json` and config-adjacent
+`commit-confirm-locator.json` contain no raw TOML but remain confidential
+because they carry paths, digests, provenance, and file identities. All pending
+files are owner-only (`0600`) under the documented private-parent policy.
+
+Production publishes raw prior, then metadata, then the locator as sole boot
+authority. Durable locator unlink and parent `fsync` is terminal; only later
+verified exact metadata/raw cleanup and pending-directory `fsync` are
+warning-only. Frozen v2-locator and
+locator-free v1 readers remain for compatibility and never receive new writes.
+V2 config-history semantics are unchanged: external-source identity is hashed,
+not archived, so rollback requires one detached load to reproduce the recorded
 TOML, manifest, and source digest exactly. Unreadable rows and legacy rows with
-external declarations fail closed. Keep `runtime_state_dir` on owner-controlled
-local storage and protect backups as secret-bearing configuration, not as
-ordinary operational telemetry.
+external declarations fail closed. Keep `runtime_state_dir` and backups on
+owner-controlled local storage as secret-bearing configuration, not telemetry.
 
 `ListConfigHistory` exposes explicit provenance status without inferring trust
 from a readable file or filename digest. Its additive config-source digest is

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -803,9 +803,9 @@ a field rename, edit the config file by hand.
 
 ### Persistent state on disk
 
-Runtime state lives in `runtime_state_dir` (default `/var/lib/rustbgpd`). One
-commit-confirm v2 authority file instead lives beside the lexical launch config
-so startup can find it before trusting the unconfirmed candidate:
+Runtime state lives in `runtime_state_dir` (default `/var/lib/rustbgpd`). The
+v3 commit-confirm locator instead lives beside the lexical launch config so
+startup finds the sole pending authority before trusting candidate contents:
 
 Assign a distinct `runtime_state_dir` to every concurrently running rustbgpd
 daemon. The directory is single-writer runtime state; sharing it between live
@@ -815,24 +815,28 @@ processes is unsupported even when their configuration files differ.
 |---|---|---|
 | `gr-restart.toml` | Graceful Restart coordination marker. Written on clean shutdown, read on startup to set the R-bit in OPEN. | Yes |
 | `warm-bundle-v1/` | Optional owner-private shutdown checkpoint (`manifest.json` plus a content-addressed MRT artifact). Published only when `warm_cache_checkpoint_on_shutdown = true`; not restored on startup. | Yes |
-| `<absolute lexical config path>.commit-confirm-locator.json` | Sole v2 pending authority, published only after the journal is durable and checked before candidate contents are parsed. Launch-target metadata may be inspected while binding authority. Durable removal is the terminal point. | Until the transaction is terminal |
-| `<runtime_state_dir>/commit-confirm-journal.json` | Owner-private accepted prior snapshot: normalized TOML, external-source manifest, and digests. Exact residue cleanup after terminal locator removal is warning-only. | Until terminal cleanup; safe residue may remain |
+| `<runtime_state_dir>/commit-confirm-journal.json` | Frozen locator-free v1 authority and v2 compatibility journal; secret-bearing normalized TOML. Production does not write it. | Until legacy recovery or verified residue cleanup |
+| `<runtime_state_dir>/commit-confirm-v3-prior.toml` | Fixed v3 raw accepted prior; secret-bearing normalized TOML. Published first. | Until terminal cleanup; safe residue may remain |
+| `<runtime_state_dir>/commit-confirm-v3-metadata.json` | Fixed confidential provenance, digest, and file-identity metadata; no raw TOML. Published after the raw prior. | Until terminal cleanup; safe residue may remain |
+| `<absolute lexical config path>.commit-confirm-locator.json` | Confidential paths/digests and sole v3 pending boot authority; no raw TOML. Published last and checked before candidate contents. | Until durable unlink and parent sync make the transaction terminal |
 | `config-history/*` | Last 20 owner-private, secret-bearing legacy TOML and v2 JSON records for `rbgp config history`; newest is index 0. V2 records hash but do not archive external sources and are rollback-eligible only when live sources exactly reproduce recorded provenance. Move this directory aside before downgrading to a version without v2 support. | Yes |
 | `fib-owned.json` | FIB ownership receipt — which kernel routes the daemon installed (ADR-0061). Used to drain orphan installs on next start. | Yes |
 | `grpc.sock` | gRPC UDS endpoint (if `[global.telemetry.grpc_uds]` configured). | Recreated on start |
 
-The lexical config and journal paths are resolved to absolute identities. A
-writer or present v2 object requires daemon-owned real parents that are not
-group- or world-writable. Locator absence carries no authority and therefore
-adds no v2 ownership or mode requirement to ordinary startup; confirmed writes
-still require the documented ownership change.
-Locator, journal, and exact staging files must be daemon-owned regular files
-with mode `0600`; symlinks and special files fail closed. Do not downgrade or start an
-older binary until both the v2 locator and locator-free v2 journal residue are
-absent. Separately move the complete v2 config-history directory aside before
-the older binary starts. Production writes only v2 pending state; locator-free
-v1 journals remain a fail-closed compatibility lane, but a live v1 transaction
-must terminate before upgrade. V2 never converts or dual-writes it.
+The lexical config, metadata, and raw-prior paths resolve to absolute
+identities. A writer or present pending object requires daemon-owned real
+parents that are not group- or world-writable; locator absence carries no
+authority or ordinary-startup storage requirement. Pending and staging files
+must be daemon-owned regular files with mode `0600`; symlinks and special files
+fail closed. Locator unlink plus parent `fsync` is terminal; only subsequent
+verified metadata/raw cleanup and pending-directory `fsync` are warning-only.
+
+Production writes v3. The v2 locator and locator-free v1 lanes are frozen
+compatibility readers without conversion or dual-write. Finish or abort live
+v1/v2 state before upgrade. Before downgrade, finish or abort v3 and never
+delete its live locator manually; after it is terminal, verify the locator and
+both fixed v3 files are absent. Also verify v2 locator/journal residue is absent
+and move the complete v2 config-history directory aside for an older binary.
 
 Routing state is **not restored**. The optional shutdown checkpoint contains
 only eligible post-import-policy Adj-RIB-In views for future use; Loc-RIB,


### PR DESCRIPTION
## Summary

- replace the stale live-v2 commit-confirm description with the as-built v3 raw-prior -> metadata -> config-adjacent locator publication order
- document the locator as the sole v3 boot authority and durable locator unlink plus parent-directory fsync as the terminal boundary, while preserving locator-free v1 recovery authority
- distinguish warning-only exact residue cleanup from failures that keep the transaction nonterminal and mutations fenced
- inventory the secret-bearing v3 and frozen legacy files across operator, deployment, API, and security guidance while preserving valid v2 config-history and frozen v1/v2 recovery-reader wording

## Review-driven scope

The initial three-file correction exposed four still-current security, API, and deployment passages that contradicted the shipped writer. The final change keeps the correction cohesive and bounded at exactly seven files and 295 changed lines; no behavior, API, format, cap, or compatibility reader changed.

## Verification

- cargo test --locked -p rustbgpctl curated_documentation_commands_parse_with_the_real_cli
- cargo test --locked --test commit_confirm_binary (8/8)
- cargo test --locked --test grpc_service_count_docs
- cargo fmt --all -- --check
- RUSTDOCFLAGS='-D warnings' cargo doc --locked --workspace --no-deps
- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
- focused stale production-v2 wording audit
- git diff --check

Load-bearing red proof: N/A for this documentation-only contract correction. Every storage, authority, cleanup, compatibility, and downgrade statement was traced to the production v3 writer, transaction controller, startup dispatch, and frozen legacy readers.

Resolves LAN-875 when merged.
