### PR TITLE
Make persisted config map order deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Persisted configuration now sorts all map-valued sections without changing
+  their runtime `HashMap` types, making equivalent writes byte- and
+  digest-stable regardless of insertion order.
+
 - `rbgp config effective` and `rbgp doctor` now accept a byte-exact effective
   config document larger than tonic's 4 MiB client default, up to a finite
   384 MiB of normalized TOML plus its protobuf envelope. The allowance is

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2377,6 +2377,8 @@ pub const PERSISTED_CONFIG_HEADER: &str = "\
 
 /// The exact document the daemon writes for `config`:
 /// [`PERSISTED_CONFIG_HEADER`] followed by the canonical TOML rendering.
+/// Persisted `HashMap` fields borrow and sort their entries during serde
+/// output, so equivalent runtime maps produce byte-identical documents.
 ///
 /// Every durable config write and every applied-config history entry goes
 /// through here, so a new persist call site cannot omit the header.

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6,6 +6,7 @@ use std::num::NonZeroU32;
 use std::path::PathBuf;
 
 use schemars::{JsonSchema, Schema, SchemaGenerator};
+use serde::ser::SerializeMap as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use rustbgpd_wire::BgpRole;
@@ -18,6 +19,37 @@ pub(super) const DEFAULT_HOLD_TIME: u16 = rustbgpd_fsm::DEFAULT_HOLD_TIME;
 pub(super) const DEFAULT_DYNAMIC_NEIGHBOR_LIMIT: u32 = 100;
 pub(super) const DEFAULT_CONNECT_RETRY_SECS: u32 = 5;
 pub(super) const BGP_PORT: u16 = 179;
+
+#[cfg(test)]
+pub(super) static PERSISTENCE_PROBE_DIRECT_MAPS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+fn serialize_sorted_hash_map<K, V, S>(map: &HashMap<K, V>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    K: Ord + Serialize,
+    V: Serialize,
+    S: Serializer,
+{
+    #[cfg(test)]
+    if matches!(
+        std::env::var("RUSTBGPD_PERSISTENCE_PROBE_ARM").as_deref(),
+        Ok("direct")
+    ) {
+        PERSISTENCE_PROBE_DIRECT_MAPS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let mut map_out = serializer.serialize_map(Some(map.len()))?;
+        for (key, value) in map {
+            map_out.serialize_entry(key, value)?;
+        }
+        return map_out.end();
+    }
+    let mut entries: Vec<_> = map.iter().collect();
+    entries.sort_unstable_by_key(|(key, _)| *key);
+    let mut map_out = serializer.serialize_map(Some(entries.len()))?;
+    for (key, value) in entries {
+        map_out.serialize_entry(key, value)?;
+    }
+    map_out.end()
+}
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -33,7 +65,7 @@ pub struct Config {
     #[serde(default)]
     pub neighbors: Vec<Neighbor>,
     /// Named peer groups providing inherited defaults for neighbors.
-    #[serde(default)]
+    #[serde(default, serialize_with = "serialize_sorted_hash_map")]
     pub peer_groups: HashMap<String, PeerGroupConfig>,
     /// Routing policy: inline statements, named definitions, chains,
     /// and `.rpol` files.
@@ -315,7 +347,7 @@ pub struct GrpcSecurityConfig {
     #[serde(default)]
     pub enforcement: GrpcEnforcementConfig,
     /// Per-principal role assignments (principal name -> role).
-    #[serde(default)]
+    #[serde(default, serialize_with = "serialize_sorted_hash_map")]
     pub roles: HashMap<String, GrpcRoleConfig>,
 }
 
@@ -1543,10 +1575,10 @@ fn default_bfd_multiplier() -> u32 {
 #[serde(deny_unknown_fields)]
 pub struct PolicyConfig {
     /// Named policy definitions, reusable across neighbors and directions.
-    #[serde(default)]
+    #[serde(default, serialize_with = "serialize_sorted_hash_map")]
     pub definitions: HashMap<String, NamedPolicyConfig>,
     /// Named neighbor-set definitions for policy matching.
-    #[serde(default)]
+    #[serde(default, serialize_with = "serialize_sorted_hash_map")]
     pub neighbor_sets: HashMap<String, NeighborSetConfig>,
     /// Global import policy chain (references named definitions).
     #[serde(default)]
@@ -1612,7 +1644,7 @@ pub struct PolicyConfig {
     /// entry and every entry needs a declaration — both directions are
     /// load errors. Relative paths resolve against the config file's
     /// directory and are rewritten absolute at load, like `rpol_files`.
-    #[serde(default)]
+    #[serde(default, serialize_with = "serialize_sorted_hash_map")]
     pub datasets: HashMap<String, DatasetFileConfig>,
     /// Live dataset handles (name → shared handle), populated at load,
     /// not serialized. `PartialEq` is handle identity: a SIGHUP reload

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -13093,6 +13093,30 @@ fn run_persistence_probe_child(arm: &str, receipt: &Path) {
 }
 
 #[cfg(target_os = "linux")]
+fn assert_persistence_probe_receipts(direct: &[u128], sorted: &[u128]) {
+    const MIB: usize = 1024 * 1024;
+
+    assert_eq!(direct[0], sorted[0]);
+    assert!(direct[4] >= direct[0] / 2);
+    assert!(sorted[4] >= sorted[0] / 2);
+    let allowance = ((direct[4] * 5) / 100).max((64 * MIB) as u128);
+    assert!(sorted[4] <= direct[4] + allowance);
+    assert!(sorted[1] <= direct[1] * 115 / 100 + 250_000_000);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn persistence_probe_comparison_rejects_vacuous_sorted_hwm() {
+    // Load-bearing: replacing the two per-arm growth assertions with `||`
+    // makes the zero-growth sorted receipt pass and this test fail.
+    let direct = [342_422_054, 2_500_000_000, 0, 0, 1_740_000_000];
+    let sorted = [342_422_054, 2_500_000_000, 0, 0, 0];
+    assert!(
+        std::panic::catch_unwind(|| assert_persistence_probe_receipts(&direct, &sorted)).is_err()
+    );
+}
+
+#[cfg(target_os = "linux")]
 #[test]
 #[ignore = "release-only fresh-process 3.2M-statement persistence A/B"]
 #[allow(
@@ -13104,7 +13128,6 @@ fn persisted_config_release_scale_probe() {
 
     const ARM: &str = "RUSTBGPD_PERSISTENCE_PROBE_ARM";
     const RECEIPT: &str = "RUSTBGPD_PERSISTENCE_PROBE_RECEIPT";
-    const MIB: usize = 1024 * 1024;
     assert!(!cfg!(debug_assertions), "run with --release");
     if let (Ok(arm), Ok(receipt)) = (std::env::var(ARM), std::env::var(RECEIPT)) {
         run_persistence_probe_child(&arm, Path::new(&receipt));
@@ -13138,11 +13161,7 @@ fn persisted_config_release_scale_probe() {
     };
     let direct = read(direct_file.path());
     let sorted = read(sorted_file.path());
-    assert_eq!(direct[0], sorted[0]);
-    assert!(direct[4] >= direct[0] / 2 || sorted[4] >= sorted[0] / 2);
-    let allowance = ((direct[4] * 5) / 100).max((64 * MIB) as u128);
-    assert!(sorted[4] <= direct[4] + allowance);
-    assert!(sorted[1] <= direct[1] * 115 / 100 + 250_000_000);
+    assert_persistence_probe_receipts(&direct, &sorted);
 }
 
 /// The maintenance header belongs to files the daemon writes, and nowhere

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -12913,6 +12913,238 @@ fn runtime_snapshot_token_is_stable_and_changes_with_config() {
     assert!(token_a.starts_with("kv1:"));
 }
 
+fn persistence_order_fixture(reverse: bool, bulk_statement_count: usize) -> Config {
+    let source = format!(
+        "{}\n[policy.definitions.seed]\n[[policy.definitions.seed.statements]]\n\
+         action = \"permit\"\nprefix = \"2001:db8:1234:5678::/64\"\nge = 64\n",
+        valid_toml()
+    );
+    let mut config = parse_schema_only(&source).unwrap();
+    let statement = config
+        .policy
+        .definitions
+        .remove("seed")
+        .unwrap()
+        .statements
+        .remove(0);
+    let mut names = ["alpha", "beta", "gamma", "zeta"];
+    if reverse {
+        names.reverse();
+    }
+    for name in names {
+        let hold_time = match name {
+            "alpha" => 30,
+            "beta" => 45,
+            "gamma" => 60,
+            "zeta" => 90,
+            _ => unreachable!(),
+        };
+        config.peer_groups.insert(
+            name.to_string(),
+            PeerGroupConfig {
+                hold_time: Some(hold_time),
+                ..PeerGroupConfig::default()
+            },
+        );
+        let role = match name {
+            "alpha" => GrpcRoleConfig::Observer,
+            "beta" | "gamma" => GrpcRoleConfig::Automation,
+            "zeta" => GrpcRoleConfig::Operator,
+            _ => unreachable!(),
+        };
+        config.security.grpc.roles.insert(name.to_string(), role);
+        let mut statements = if name == "zeta" {
+            vec![statement.clone(); bulk_statement_count]
+        } else {
+            Vec::new()
+        };
+        if statements.len() == 2 {
+            statements[1].action = "deny".to_string();
+            statements[1].prefix = Some("198.51.100.0/24".to_string());
+            statements[1].ge = Some(24);
+        }
+        config.policy.definitions.insert(
+            name.to_string(),
+            NamedPolicyConfig {
+                default_action: "permit".to_string(),
+                statements,
+            },
+        );
+        config.policy.neighbor_sets.insert(
+            name.to_string(),
+            NeighborSetConfig {
+                addresses: vec![format!("192.0.2.{hold_time}")],
+                ..NeighborSetConfig::default()
+            },
+        );
+        config.policy.datasets.insert(
+            name.to_string(),
+            DatasetFileConfig {
+                path: format!("/var/lib/rustbgpd/{name}.set"),
+            },
+        );
+    }
+    config
+}
+
+fn reverse_insertion_persistence_pair() -> (Config, Config) {
+    for _ in 0..128 {
+        let left = persistence_order_fixture(false, 2);
+        let right = persistence_order_fixture(true, 2);
+        let all_raw_orders_differ = left.peer_groups.keys().collect::<Vec<_>>()
+            != right.peer_groups.keys().collect::<Vec<_>>()
+            && left.security.grpc.roles.keys().collect::<Vec<_>>()
+                != right.security.grpc.roles.keys().collect::<Vec<_>>()
+            && left.policy.definitions.keys().collect::<Vec<_>>()
+                != right.policy.definitions.keys().collect::<Vec<_>>()
+            && left.policy.neighbor_sets.keys().collect::<Vec<_>>()
+                != right.policy.neighbor_sets.keys().collect::<Vec<_>>()
+            && left.policy.datasets.keys().collect::<Vec<_>>()
+                != right.policy.datasets.keys().collect::<Vec<_>>();
+        if all_raw_orders_differ {
+            return (left, right);
+        }
+    }
+    panic!("failed to construct distinct raw HashMap iteration orders");
+}
+
+#[test]
+fn persisted_config_sorts_every_hash_map_and_round_trips_to_a_fixpoint() {
+    use sha2::{Digest as _, Sha256};
+
+    // Load-bearing: every pair has reverse insertion and provably distinct raw
+    // iteration order. Removing any serialize_with link makes the bytes differ.
+    let (left, right) = reverse_insertion_persistence_pair();
+    let left_document = persisted_config_document(&left).unwrap();
+    let right_document = persisted_config_document(&right).unwrap();
+    assert_eq!(left_document, right_document);
+    assert_eq!(
+        Sha256::digest(left_document.as_bytes()),
+        Sha256::digest(right_document.as_bytes())
+    );
+
+    let reloaded: Config = toml::from_str(&left_document).unwrap();
+    assert_eq!(persisted_config_document(&reloaded).unwrap(), left_document);
+    let statements = &reloaded.policy.definitions["zeta"].statements;
+    assert_eq!(statements[0].action, "permit");
+    assert_eq!(statements[1].action, "deny");
+}
+
+#[cfg(target_os = "linux")]
+fn linux_vm_hwm_bytes() -> usize {
+    fs::read_to_string("/proc/self/status")
+        .unwrap()
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")?
+                .split_whitespace()
+                .next()?
+                .parse::<usize>()
+                .ok()
+        })
+        .unwrap()
+        * 1024
+}
+
+#[cfg(target_os = "linux")]
+fn persistence_probe_fixture() -> Config {
+    let mut config = persistence_order_fixture(false, 1);
+    let statement = config.policy.definitions["zeta"].statements[0].clone();
+    config.policy.definitions.clear();
+    for member in 0..320 {
+        config.policy.definitions.insert(
+            format!("member-{member:03}"),
+            NamedPolicyConfig {
+                default_action: "permit".to_string(),
+                statements: vec![statement.clone(); 10_000],
+            },
+        );
+    }
+    config
+}
+
+#[cfg(target_os = "linux")]
+fn run_persistence_probe_child(arm: &str, receipt: &Path) {
+    use std::time::Instant;
+
+    let config = persistence_probe_fixture();
+    let baseline = linux_vm_hwm_bytes();
+    let started = Instant::now();
+    assert!(matches!(arm, "direct" | "sorted"));
+    let rendered = persisted_config_document(&config).unwrap();
+    let elapsed = started.elapsed().as_nanos();
+    let direct_maps =
+        super::schema::PERSISTENCE_PROBE_DIRECT_MAPS.swap(0, std::sync::atomic::Ordering::Relaxed);
+    assert_eq!(direct_maps == 0, arm == "sorted");
+    let peak = linux_vm_hwm_bytes();
+    let growth = peak.saturating_sub(baseline);
+    let bytes = rendered.len();
+    let round_tripped: Config = toml::from_str(&rendered).unwrap();
+    drop(rendered);
+    assert_eq!(round_tripped, config);
+    fs::write(
+        receipt,
+        format!("{bytes},{elapsed},{baseline},{peak},{growth}"),
+    )
+    .unwrap();
+    eprintln!(
+        "arm={arm} bytes={bytes} elapsed_ns={elapsed} baseline={baseline} peak={peak} growth={growth}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+#[ignore = "release-only fresh-process 3.2M-statement persistence A/B"]
+#[allow(
+    clippy::assertions_on_constants,
+    reason = "the ignored scale probe must reject accidental debug-profile runs"
+)]
+fn persisted_config_release_scale_probe() {
+    use std::process::Command;
+
+    const ARM: &str = "RUSTBGPD_PERSISTENCE_PROBE_ARM";
+    const RECEIPT: &str = "RUSTBGPD_PERSISTENCE_PROBE_RECEIPT";
+    const MIB: usize = 1024 * 1024;
+    assert!(!cfg!(debug_assertions), "run with --release");
+    if let (Ok(arm), Ok(receipt)) = (std::env::var(ARM), std::env::var(RECEIPT)) {
+        run_persistence_probe_child(&arm, Path::new(&receipt));
+        return;
+    }
+    let executable = std::env::current_exe().unwrap();
+    let direct_file = NamedTempFile::new().unwrap();
+    let sorted_file = NamedTempFile::new().unwrap();
+    for (arm, receipt) in [("direct", &direct_file), ("sorted", &sorted_file)] {
+        assert!(
+            Command::new(&executable)
+                .args([
+                    "config::tests::persisted_config_release_scale_probe",
+                    "--ignored",
+                    "--exact",
+                    "--nocapture"
+                ])
+                .env(ARM, arm)
+                .env(RECEIPT, receipt.path())
+                .status()
+                .unwrap()
+                .success()
+        );
+    }
+    let read = |path: &Path| -> Vec<u128> {
+        fs::read_to_string(path)
+            .unwrap()
+            .split(',')
+            .map(|value| value.parse().unwrap())
+            .collect()
+    };
+    let direct = read(direct_file.path());
+    let sorted = read(sorted_file.path());
+    assert_eq!(direct[0], sorted[0]);
+    assert!(direct[4] >= direct[0] / 2 || sorted[4] >= sorted[0] / 2);
+    let allowance = ((direct[4] * 5) / 100).max((64 * MIB) as u128);
+    assert!(sorted[4] <= direct[4] + allowance);
+    assert!(sorted[1] <= direct[1] * 115 / 100 + 250_000_000);
+}
+
 /// The maintenance header belongs to files the daemon writes, and nowhere
 /// else. Two neighbouring canonical renderings sit right next to the persist
 /// path and must stay clean of it: the commit-confirm snapshot token and the


### PR DESCRIPTION
## Summary

Equivalent runtime configurations could serialize to different bytes because five persisted `HashMap` fields followed randomized iteration order. That stopped LAN-832's exact rollback proof even though the restored configuration was semantically identical.

This change adds borrowed, sorted serialization for exactly:

- `Config.peer_groups`
- `GrpcSecurityConfig.roles`
- `PolicyConfig.definitions`
- `PolicyConfig.neighbor_sets`
- `PolicyConfig.datasets`

Runtime types, TOML shape, omission behavior, schema, and vector/statement ordering are unchanged.

## Verification

The regression fixture constructs all five maps with reverse insertion order and confirms:

- raw iteration order differs for every map;
- persisted bytes and SHA-256 digests are identical;
- the document round-trips to an identical `Config`;
- reserialization reaches a byte-exact fixpoint;
- policy statement order is preserved.

As a destructive red proof, each of the five `serialize_with` links was removed individually. Every removal made the regression fail; restoring all five returned it to green.

A release-profile, fresh-process A/B exercised the real `persisted_config_document` path with 320 definitions x 10,000 statements, or 3.2 million statements. A test-only counter proved the direct arm bypassed sorting while the sorted arm used the production path:

| Arm | Output bytes | Elapsed | Baseline HWM | Peak HWM | Growth |
| --- | ---: | ---: | ---: | ---: | ---: |
| Direct | 342,422,054 | 2.478 s | 1,349,025,792 | 3,092,049,920 | 1,743,024,128 |
| Sorted | 342,422,054 | 2.549 s | 1,348,800,512 | 3,092,373,504 | 1,743,572,992 |

Both arms round-tripped the full document to their original `Config`. A synthetic receipt test injects zero sorted-arm growth and proves the per-arm non-vacuity check goes red; replacing the two checks with the former `direct || sorted` predicate makes that test fail. The original absolute-memory proposal was rejected: most peak memory comes from the existing TOML serializer's per-statement table representation and final document copies, not sorting these five small maps. That broader amplification is tracked separately in LAN-878 rather than expanding this correctness fix.

Local gates passed:

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --workspace --no-deps`
- `python3 scripts/check-clippy-reasons.py`
- `python3 scripts/check-v1-stable-surface.py`
- the ignored release A/B above

Self-review covered the single commit, full branch diff, persistence compatibility, omission/vector-order risks, and operator-facing release note. No roadmap change is needed because this fixes the persistence contract rather than changing roadmap scope.

Fixes LAN-877.
