### PR TITLE
Fix commit-confirm windows after slow applies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Commit-confirmed transactions now start their public and in-process
+  confirmation deadlines after a successful Apply, preserving the full
+  requested window even when a large candidate takes longer than the timeout
+  to commit. Pre-apply v3 rollback authority remains published before mutation
+  and boot recovery remains unconditional.
+
 - Persisted configuration now sorts all map-valued sections without changing
   their runtime `HashMap` types, making equivalent writes byte- and
   digest-stable regardless of insertion order.

--- a/bench/scale/irrreload/README.md
+++ b/bench/scale/irrreload/README.md
@@ -194,6 +194,12 @@ explicit use of that Plan's UUID-v4 single-use token, pending commit-confirm,
 the canonical config-adjacent v3 locator plus fixed owner-only raw/metadata
 files, full locator→metadata→raw path/digest/device/inode linkage, raw size in
 `(10 MiB, 384 MiB]`, legacy-journal absence, and confirmed terminal cleanup.
+Schema-2 transaction evidence records the authority's informational
+pre-apply deadline separately from the Apply/Status deadline that starts after
+commit, and requires the former to predate the latter. The authority deadline
+need not remain unexpired when a slow Apply returns: boot recovery is
+unconditional. Schema-1 transaction evidence conflated those clocks and is
+rejected rather than migrated.
 After the final measurement boundary and before daemon teardown,
 `txn-lifecycle.sh` applies the opposite B generation twice: explicit abort and
 ten-second timeout must report `aborted` and `auto_reverted`, remove all v3

--- a/bench/scale/irrreload/txn-apply.sh
+++ b/bench/scale/irrreload/txn-apply.sh
@@ -193,7 +193,8 @@ printf '%s' "$status_json" | jq -e --arg id "$confirm_id" --arg runtime "$apply_
       .deadline_unix_seconds == $deadline and .runtime_snapshot_token == $runtime)' >/dev/null ||
     die "pending status view was incoherent"
 pending=$(pending_json "$confirm_id") || die "pending v3/history/process evidence failed"
-[ "$(printf '%s' "$pending" | jq -er '.authority.deadline_unix_seconds')" -eq "$apply_deadline" ] || die "v3 deadline did not match apply"
+authority_deadline=$(printf '%s' "$pending" | jq -er '.authority.deadline_unix_seconds') || die "v3 authority deadline missing"
+[ "$authority_deadline" -lt "$apply_deadline" ] || die "v3 authority deadline did not predate the live deadline"
 warning=$(warning_json "$warning_before") || die "missing oversize-history warning"
 
 confirm_json=$("$rbgp" --addr "$addr" --json config confirm "$confirm_id") || die "confirm failed"
@@ -218,15 +219,16 @@ history_after=$(history_json) || die "cannot capture history after confirm"
 
 row=$(jq -cn --argjson cycle "$cycle" --arg candidate_sha256 "$candidate_sha" \
     --argjson candidate_bytes "$candidate_bytes" --arg candidate_marker "$candidate_marker" --arg confirm_id "$confirm_id" \
+    --argjson apply_deadline "$apply_deadline" \
     --argjson pending "$pending" --argjson terminal "$terminal" \
     --argjson history_before "$history_before" --argjson history_after "$history_after" \
     --argjson warning "$warning" \
-    '{schema:1,cycle:$cycle,candidate:{sha256:$candidate_sha256,bytes:$candidate_bytes,marker:$candidate_marker},
+    '{schema:2,cycle:$cycle,candidate:{sha256:$candidate_sha256,bytes:$candidate_bytes,marker:$candidate_marker},
       plan:{transport:"streamed",status:"committable",plan_token_present:true,
             runtime_snapshot_token_present:true},
       apply:{transport:"streamed",explicit_plan_token:true,status:"committable",
              confirmation_status:"pending",confirm_id:$confirm_id,timeout_seconds:600,
-             deadline_unix_seconds:$pending.authority.deadline_unix_seconds,
+             deadline_unix_seconds:$apply_deadline,
              runtime_token_coherent:true},
       history:{before:$history_before,after:$history_after,outcome:"skipped_oversize",warning:$warning},
       pending:$pending,confirmed:({status:"confirmed",status_view_verified:true} + $terminal)}') || die "cannot encode evidence"

--- a/bench/scale/irrreload/txn-lifecycle.sh
+++ b/bench/scale/irrreload/txn-lifecycle.sh
@@ -112,7 +112,7 @@ terminal_json() {
     jq -cn --argjson state "$state" '{v3_absent:true,legacy_absent:true} + $state'
 }
 apply_pending() {
-    local id=$1 timeout=$2 plan_json plan_rc runtime_token plan_token apply_json apply_runtime status_json pending history_before warning_before warning now
+    local id=$1 timeout=$2 plan_json plan_rc runtime_token plan_token apply_json apply_runtime status_json pending history_before warning_before warning now authority_deadline
     history_before=$(history_json) || return 1
     [ "$(printf '%s' "$history_before" | jq -er '.entries | length')" -eq 0 ] || return 1
     warning_before=$(warning_count)
@@ -144,7 +144,8 @@ apply_pending() {
         '.confirmation | select(.status == "pending" and .confirm_id == $id and .timeout_seconds == $timeout and
           .deadline_unix_seconds == $deadline and .runtime_snapshot_token == $runtime)' >/dev/null || return 1
     pending=$(pending_json "$id") || return 1
-    [ "$(printf '%s' "$pending" | jq -er '.authority.deadline_unix_seconds')" -eq "$pending_deadline" ] || return 1
+    authority_deadline=$(printf '%s' "$pending" | jq -er '.authority.deadline_unix_seconds') || return 1
+    [ "$authority_deadline" -lt "$pending_deadline" ] || return 1
     warning=$(warning_json "$warning_before") || return 1
     pending_runtime=$apply_runtime
     pending_prefix=$(jq -cn --arg id "$id" --argjson timeout_seconds "$timeout" \
@@ -239,7 +240,7 @@ tmp="$output.tmp"
 jq -n --argjson baseline "$current_state" --argjson current "$current_input" \
     --argjson opposite "$opposite_input" --argjson abort "$abort" --argjson timeout "$timeout" \
     --argjson final_state "$final_state" \
-    '{schema:1,generations:{current:$current,opposite:$opposite},baseline:$baseline,
+    '{schema:2,generations:{current:$current,opposite:$opposite},baseline:$baseline,
       abort:$abort,timeout:$timeout,restored_current_plan:{transport:"streamed",status:"noop",
       plan_token_present:false},final_state:$final_state}' >"$tmp" || die "cannot encode lifecycle evidence"
 mv "$tmp" "$output" || die "cannot publish lifecycle evidence"

--- a/bench/scale/irrreload/verify-receipt.py
+++ b/bench/scale/irrreload/verify-receipt.py
@@ -791,7 +791,8 @@ def validate_file_identity(value, expected_name: str, context: str) -> None:
         fail(f"{context}: invalid v3 file identity")
 
 
-def validate_authority(value, confirm_id: str, deadline: int, context: str) -> None:
+def validate_authority(value, confirm_id: str, context: str) -> int:
+    deadline = value.get("deadline_unix_seconds") if isinstance(value, dict) else None
     if (
         set(value or {})
         != {
@@ -807,7 +808,8 @@ def validate_authority(value, confirm_id: str, deadline: int, context: str) -> N
         or value.get("schema") != 1
         or value.get("version") != 3
         or value.get("confirm_id") != confirm_id
-        or value.get("deadline_unix_seconds") != deadline
+        or type(deadline) is not int
+        or deadline <= 0
         or value.get("linkage_verified") is not True
     ):
         fail(f"{context}: v3 authority linkage receipt is invalid")
@@ -816,6 +818,7 @@ def validate_authority(value, confirm_id: str, deadline: int, context: str) -> N
     validate_file_identity(value["raw"], "commit-confirm-v3-prior.toml", context)
     if not 10 * 1024 * 1024 < value["raw"]["bytes"] <= 384 * 1024 * 1024:
         fail(f"{context}: v3 raw snapshot is outside (10 MiB, 384 MiB]")
+    return deadline
 
 
 def validate_state(
@@ -840,7 +843,9 @@ def validate_state(
     validate_content(value["config"], context)
     validate_content(value["runtime"], context)
     if pending:
-        validate_authority(value["authority"], confirm_id, deadline, context)
+        authority_deadline = validate_authority(value["authority"], confirm_id, context)
+        if authority_deadline >= deadline:
+            fail(f"{context}: v3 authority deadline did not predate the live deadline")
 
 
 def validate_plan_apply(prefix, confirm_id: str, timeout: int, context: str) -> int:
@@ -853,7 +858,7 @@ def validate_plan_apply(prefix, confirm_id: str, timeout: int, context: str) -> 
         "plan_token_present": True,
         "runtime_snapshot_token_present": True,
         }
-        or not isinstance(deadline, int)
+        or type(deadline) is not int
         or deadline <= 0
         or apply
         != {
@@ -894,7 +899,7 @@ def validate_transaction_evidence(
     actual_ids = []
     for number, cycle in enumerate(cycles, 1):
         reject_transaction_tokens(cycle)
-        if set(cycle) != {"schema", "cycle", "candidate", "plan", "apply", "history", "pending", "confirmed"} or cycle.get("schema") != 1 or cycle.get("cycle") != number:
+        if set(cycle) != {"schema", "cycle", "candidate", "plan", "apply", "history", "pending", "confirmed"} or cycle.get("schema") != 2 or cycle.get("cycle") != number:
             fail(f"{cdir}: transaction cycle roster/order is invalid")
         validate_content(cycle["candidate"], f"cycle {number} candidate")
         if not 10 * 1024 * 1024 < cycle["candidate"]["bytes"] <= 384 * 1024 * 1024:
@@ -976,7 +981,7 @@ def validate_transaction_evidence(
 
     lifecycle = read_json(cdir / "transactions/lifecycle.json")
     reject_transaction_tokens(lifecycle)
-    if set(lifecycle or {}) != {"schema", "generations", "baseline", "abort", "timeout", "restored_current_plan", "final_state"} or lifecycle.get("schema") != 1:
+    if set(lifecycle or {}) != {"schema", "generations", "baseline", "abort", "timeout", "restored_current_plan", "final_state"} or lifecycle.get("schema") != 2:
         fail(f"{cdir}: lifecycle roster is invalid")
     generations = lifecycle.get("generations", {})
     if set(generations) != {"current", "opposite"}:
@@ -1477,7 +1482,7 @@ def make_transaction_evidence(cdir: Path, pid: int) -> None:
                 "process": process, "config": content(digest), "runtime": content(digest)}
 
     def pending(digest, confirm_id, deadline, inode):
-        return {"authority": authority(confirm_id, deadline, inode),
+        return {"authority": authority(confirm_id, deadline - 1, inode),
                 "legacy_absent": True, **base_state(digest)}
 
     def terminal(digest):
@@ -1493,7 +1498,7 @@ def make_transaction_evidence(cdir: Path, pid: int) -> None:
         deadline = 1_000 + number
         cycles.append(
             {
-                "schema": 1,
+                "schema": 2,
                 "cycle": number,
                 "candidate": content(digest),
                 "plan": {"transport": "streamed", "status": "committable", "plan_token_present": True, "runtime_snapshot_token_present": True},
@@ -1521,7 +1526,7 @@ def make_transaction_evidence(cdir: Path, pid: int) -> None:
                 "history_after": history, **terminal("a")}}
 
     lifecycle = {
-        "schema": 1,
+        "schema": 2,
         "generations": {"current": content("a"), "opposite": content("b")},
         "baseline": base_state("a"),
         "abort": phase("abort", 600, 5, 6, 200),
@@ -2012,12 +2017,26 @@ def self_test() -> None:
                     swap_state_markers(state)
             mutate_lifecycle(root, swap_lifecycle)
 
+        def swap_cycle_deadlines(row):
+            public = row["apply"]["deadline_unix_seconds"]
+            authority = row["pending"]["authority"]["deadline_unix_seconds"]
+            row["apply"]["deadline_unix_seconds"] = authority
+            row["pending"]["authority"]["deadline_unix_seconds"] = public
+
         txn_rejected("transaction-cycle-roster", lambda root: mutate_cycle(root, 0, lambda row: row.update({"cycle": 2})))
         txn_rejected("transaction-plan-token", lambda root: mutate_cycle(root, 0, lambda row: row["apply"].update({"explicit_plan_token": False})))
         txn_rejected("transaction-confirm", lambda root: mutate_cycle(root, 0, lambda row: row["confirmed"].update({"status": "pending"})))
         txn_rejected("transaction-v3-pending", lambda root: mutate_cycle(root, 0, lambda row: row["pending"]["authority"]["raw"].update({"bytes": 1024})))
         txn_rejected("transaction-v3-linkage", lambda root: mutate_cycle(root, 0, lambda row: row["pending"]["authority"].update({"linkage_verified": False})))
-        txn_rejected("transaction-v3-deadline", lambda root: mutate_cycle(root, 0, lambda row: row["pending"]["authority"].update({"deadline_unix_seconds": 9999})))
+        txn_rejected("transaction-apply-deadline-missing", lambda root: mutate_cycle(root, 0, lambda row: row["apply"].pop("deadline_unix_seconds")))
+        txn_rejected("transaction-apply-deadline-bool", lambda root: mutate_cycle(root, 0, lambda row: row["apply"].update({"deadline_unix_seconds": True})))
+        txn_rejected("transaction-v3-deadline-missing", lambda root: mutate_cycle(root, 0, lambda row: row["pending"]["authority"].pop("deadline_unix_seconds")))
+        txn_rejected("transaction-v3-deadline-bool", lambda root: mutate_cycle(root, 0, lambda row: row["pending"]["authority"].update({"deadline_unix_seconds": True})))
+        txn_rejected("transaction-v3-deadline-stale", lambda root: mutate_cycle(root, 0, lambda row: row["pending"]["authority"].update({"deadline_unix_seconds": row["apply"]["deadline_unix_seconds"]})))
+        txn_rejected("transaction-v3-deadline-swapped", lambda root: mutate_cycle(root, 0, swap_cycle_deadlines))
+        txn_rejected("transaction-v3-deadline-tamper", lambda root: mutate_cycle(root, 0, lambda row: row["pending"]["authority"].update({"deadline_unix_seconds": 9999})))
+        txn_rejected("transaction-schema-v1", lambda root: mutate_cycle(root, 0, lambda row: row.update({"schema": 1})))
+        txn_rejected("transaction-lifecycle-schema-v1", lambda root: mutate_lifecycle(root, lambda value: value.update({"schema": 1})))
         txn_rejected("transaction-v3-cleanup", lambda root: mutate_cycle(root, 0, lambda row: row["confirmed"].update({"v3_absent": False})))
         txn_rejected("transaction-history", lambda root: mutate_cycle(root, 0, lambda row: row["history"]["after"]["entries"].append({"index": 0})))
         txn_rejected("transaction-abort", lambda root: mutate_lifecycle(root, lambda value: value["abort"]["terminal"].update({"status": "confirmed"})))
@@ -2278,7 +2297,7 @@ def self_test() -> None:
         grouped_pair_drift("cross-role-source-identity", "binaries", "rbgp", "a" * 64)
         expected = {"default-roster", "mixed-roster", "mode-flags", "topology-mutation", "barrier-marker", "final-barrier-marker", "live-topology-gauge", "route-gauge", "route-family", "one-scrape-drift", "add-path", "config-count", "dirty-commit", "origin-only", "head-matches-false", "mismatched-commit", "commit-malformed", "scripts-null", "scripts-empty-map", "binary-malformed", "fingerprint-recompute", "canonical-changed-fraction", "canonical-control-secs", "canonical-bird-threads", "repeat-image-identity", "cell-root-provenance", "nonoverlap-order", "quiet-spacing", "preflight-raw", "cell-status", "cell-provenance", "evidence-roster", "scenario-roster", "scenario-duplicate", "scenario-unsafe-path", "scenario-retained-config", "cell-root-rows", "reload-log-rows", "percentile-order", "percentile-positive", "first-generation-bound", "observer-gap-bound", "row-invariants", "rss-raw", "seal-checksum", "exact-root-roster", "symlink-anywhere", "writable-root", "grouped-output-isolation", "output-exact-roster", "output-audit-call", "ordering", "reused-identity", "cross-role-environment", "cross-role-source-identity"}
         expected |= {"current-down", "reestablished", "flapped", "counter-malformed", "establishment-roster", "flap-roster", "row-session-loss"}
-        expected |= set("""v3-inspector-linkage v3-inspector-mode v3-inspector-target v3-inspector-canonical v3-inspector-field-order v3-inspector-nested-order v3-inspector-raw-utf8 transaction-cycle-roster transaction-plan-token transaction-confirm transaction-v3-pending transaction-v3-linkage transaction-v3-deadline transaction-v3-cleanup transaction-history transaction-abort transaction-timeout transaction-noop transaction-opposite
+        expected |= set("""v3-inspector-linkage v3-inspector-mode v3-inspector-target v3-inspector-canonical v3-inspector-field-order v3-inspector-nested-order v3-inspector-raw-utf8 transaction-cycle-roster transaction-plan-token transaction-confirm transaction-v3-pending transaction-v3-linkage transaction-apply-deadline-missing transaction-apply-deadline-bool transaction-v3-deadline-missing transaction-v3-deadline-bool transaction-v3-deadline-stale transaction-v3-deadline-swapped transaction-v3-deadline-tamper transaction-schema-v1 transaction-lifecycle-schema-v1 transaction-v3-cleanup transaction-history transaction-abort transaction-timeout transaction-noop transaction-opposite
 transaction-token-leak transaction-warning-log transaction-warning-binding transaction-applied-generation transaction-scenario-generation transaction-cross-root-generation transaction-port-gate transaction-disk-gate transaction-swap-gate transaction-fallback-shape
 transaction-mixed-binary transaction-process-reuse transaction-file-tamper transaction-extra-file""".split())
         missing = expected - proofs.keys()

--- a/docs/API.md
+++ b/docs/API.md
@@ -608,7 +608,7 @@ runtime mutation. Ordinary unconfirmed Apply remains available.
 | `status` | `ConfigTransactionConfirmationStatus` | Lifecycle state (see below). |
 | `confirm_id` | string | The operator-supplied handle for the transaction. |
 | `timeout_seconds` | uint32 | Effective confirm timeout applied (echoed). |
-| `deadline_unix_seconds` | uint64 | Absolute auto-revert deadline; `0` when not pending. |
+| `deadline_unix_seconds` | uint64 | Absolute live auto-revert deadline, minted after Apply commits and retained in the last terminal lifecycle record. Pre-commit durable authority carries a separate informational deadline derived at publication because boot recovery is unconditional. |
 | `committed_sections` | repeated string | Sections the confirmed apply committed. |
 | `runtime_snapshot_token` | string | Post-commit token for the pending change. |
 | `human_text` | string | Redacted human-readable summary. |

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -172,7 +172,13 @@ rbgp config abort deploy-20260605-1
 
 Confirm handles must be non-empty, at most 128 characters, and free of control
 characters. `--confirm-timeout` requires `--confirm-id`; the daemon default is
-600 seconds and the maximum accepted timeout is 86400 seconds.
+600 seconds and the maximum accepted timeout is 86400 seconds. The full window
+starts after Apply commits, so a large candidate does not consume its own
+confirmation time while it is still applying. Durable rollback authority is
+published first; its stored deadline is derived at that pre-apply publication
+and may already be past when a slow Apply returns, while `config status`
+reports the live post-commit deadline. Boot recovery ignores the authority
+deadline and reverts unconditionally.
 
 The v3 commit-confirm journal caps the current accepted normalized config it
 must retain as rollback authority at 384 MiB. If that prior exceeds the cap,

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -224,8 +224,9 @@ daemon down) was the one the mechanism could not revert. That hole is closed:
 
 - **Journal at commit.** Before the confirmed candidate commits, the daemon
   atomically persists (write temp file, fsync, rename, fsync directory) a
-  revert journal — `confirm_id`, deadline, and the full pre-commit config TOML
-  snapshot — to `<runtime_state_dir>/commit-confirm-journal.json`. If the
+  revert journal — `confirm_id`, an informational pre-apply deadline, and the
+  full pre-commit config TOML snapshot — to
+  `<runtime_state_dir>/commit-confirm-journal.json`. If the
   journal cannot be written, the confirmed apply is refused up front; a
   confirm window never runs unprotected. Confirm deletes the journal (and the
   confirm fails, keeping the fence and timer armed, if deletion fails — a
@@ -233,6 +234,12 @@ daemon down) was the one the mechanism could not revert. That hole is closed:
   Abort and timeout auto-revert delete it after a successful rollback; a
   FAILED rollback deliberately retains it so the next boot repairs what the
   running process could not.
+- **Start the live window after commit.** The public Unix deadline and the
+  in-process monotonic timer are minted together only after a committable Apply
+  succeeds, so validation, persistence, and runtime fan-out do not consume the
+  operator's requested confirmation window. The already-published journal is
+  not rewritten: its deadline is publication metadata, and boot recovery below
+  is unconditional.
 - **Boot-time revert, unconditionally.** Before adopting the on-disk config,
   startup checks for the journal. If an unconfirmed journal exists, the daemon
   boots from the journal's pre-transaction config, restores it to the config
@@ -261,9 +268,9 @@ saved aside; confirm-then-SIGKILL retains the new config with no pending
 authority; in-process timeout auto-revert consumes the pending state; and a
 torn locator-free v1 journal still refuses boot naming both legacy files.
 
-ADR-0121 now supersedes the v1 **discovery, payload, and terminal-cleanup
-contract** above. The shipped v2 writer stores the immutable accepted prior
-snapshot, including its external-source manifest and digests, in the
+ADR-0121 subsequently superseded the v1 **discovery, payload, and
+terminal-cleanup contract** above. Its v2 writer stores the immutable accepted
+prior snapshot, including its external-source manifest and digests, in the
 owner-private runtime-state journal, then publishes an owner-private locator
 adjacent to the stable lexical launch-config path. The locator is the sole v2
 pending authority and is checked before candidate contents are parsed. Boot and live
@@ -274,9 +281,15 @@ reuse it through the ordinary #1370-gated planner and apply path. Launch-target
 metadata may be inspected while binding boot authority. Abort, timeout, and
 boot restore durably restore while both files remain, then remove and sync the
 locator. Confirm starts with that locator removal. Exact journal cleanup after
-the terminal point is warning-only. Production writes only v2. The
+the terminal point is warning-only. That amendment wrote only v2. The
 locator-free v1 reader is a fail-closed compatibility lane; a live v1
 transaction must terminate before upgrade and v2 never converts or dual-writes
 it. Before downgrade, both the v2 locator and locator-free v2 journal residue
 must be absent; v2 config history separately requires its complete directory
 to be moved aside.
+
+The later disk-backed v3 implementation supersedes only v2's pending-authority
+storage. Production writes v3 raw prior, compact metadata, and a config-adjacent
+locator; v1 and v2 remain frozen recovery readers. The live confirmation-window
+and unconditional boot-revert decisions above apply unchanged across all three
+storage formats.

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -700,7 +700,7 @@ impl ConfigTransactionController {
         }
 
         let timeout = Duration::from_secs(u64::from(confirmed.timeout_seconds));
-        let deadline_unix_seconds = SystemTime::now()
+        let authority_deadline_unix_seconds = SystemTime::now()
             .checked_add(timeout)
             .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
             .map_or(0, |duration| duration.as_secs());
@@ -724,7 +724,7 @@ impl ConfigTransactionController {
             match launch.publish(
                 pending_dir,
                 &confirmed.confirm_id,
-                deadline_unix_seconds,
+                authority_deadline_unix_seconds,
                 &prior_snapshot,
             ) {
                 Ok(files) => Some(Arc::new(files)),
@@ -760,7 +760,7 @@ impl ConfigTransactionController {
                     .publish(
                         journal_path,
                         &confirmed.confirm_id,
-                        deadline_unix_seconds,
+                        authority_deadline_unix_seconds,
                         &prior_snapshot,
                     )
                     .map_err(|error| {
@@ -775,7 +775,7 @@ impl ConfigTransactionController {
                 journal_path,
                 &crate::confirm_journal::ConfirmJournal {
                     confirm_id: confirmed.confirm_id.clone(),
-                    deadline_unix_seconds,
+                    deadline_unix_seconds: authority_deadline_unix_seconds,
                     rollback_toml: rollback_toml
                         .clone()
                         .expect("legacy confirmed apply retains rollback TOML"),
@@ -846,7 +846,14 @@ impl ConfigTransactionController {
             return Ok(response);
         }
 
+        // The durable authority must predate mutation, but its timestamp is
+        // informational: boot recovery is unconditional. Start the live and
+        // public confirmation window only after the candidate has committed.
         let deadline = tokio::time::Instant::now() + timeout;
+        let deadline_unix_seconds = SystemTime::now()
+            .checked_add(timeout)
+            .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+            .map_or(0, |duration| duration.as_secs());
         let pending = PendingConfirmedTransaction {
             confirm_id: confirmed.confirm_id.clone(),
             rollback_toml,
@@ -5430,8 +5437,12 @@ remote_asn = 65010
         source: std::path::PathBuf,
         journal: std::path::PathBuf,
         locator: std::path::PathBuf,
+        raw: std::path::PathBuf,
+        metadata: std::path::PathBuf,
         fib_state: Arc<Mutex<Vec<FibTableConfig>>>,
         seen_preloaded: Arc<Mutex<Option<Arc<AcceptedConfigSnapshot>>>>,
+        first_ack_released_at: Arc<Mutex<Option<tokio::time::Instant>>>,
+        confirmation: proto::ConfigTransactionConfirmation,
         ack_task: tokio::task::JoinHandle<()>,
     }
 
@@ -5518,7 +5529,11 @@ remote_asn = 65010
         clippy::too_many_lines,
         reason = "the focused harness keeps one complete external-source FIB transaction fixture"
     )]
-    async fn external_fib_harness(timeout_seconds: u32, use_v3: bool) -> DiskBackedFibHarness {
+    async fn external_fib_harness(
+        timeout_seconds: u32,
+        use_v3: bool,
+        first_ack_delay: Option<Duration>,
+    ) -> DiskBackedFibHarness {
         use std::os::unix::fs::PermissionsExt as _;
 
         let root = tempfile::tempdir().unwrap();
@@ -5627,19 +5642,9 @@ families = ["ipv4_unicast"]
         });
 
         let (config_tx, mut config_rx) = mpsc::channel(8);
-        let ack_task = tokio::spawn(async move {
-            while let Some(event) = config_rx.recv().await {
-                match event {
-                    ConfigEvent::FibTablesReplaced { ack: Some(ack), .. }
-                    | ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. } => {
-                        ack.accept().await;
-                    }
-                    _ => panic!("unexpected persistence event in v2 FIB harness"),
-                }
-            }
-        });
-
         let journal = state_dir.join(crate::confirm_journal::JOURNAL_FILE_NAME);
+        let raw = state_dir.join(crate::confirm_journal::v3::RAW_FILE_NAME);
+        let metadata = state_dir.join(crate::confirm_journal::v3::METADATA_FILE_NAME);
         let v2_launch = crate::confirm_journal::v2::LaunchIdentity::resolve(&config_path).unwrap();
         let locator = v2_launch.locator_path();
         let controller = ConfigTransactionController::new_accepted(
@@ -5665,6 +5670,43 @@ families = ["ipv4_unicast"]
         } else {
             controller.with_confirm_v2_launch(v2_launch)
         };
+        let ack_controller = controller.clone();
+        let ack_locator = locator.clone();
+        let ack_raw = raw.clone();
+        let ack_metadata = metadata.clone();
+        let first_ack_released_at = Arc::new(Mutex::new(None));
+        let ack_released_at = Arc::clone(&first_ack_released_at);
+        let ack_task = tokio::spawn(async move {
+            let mut first_ack_delay = first_ack_delay;
+            while let Some(event) = config_rx.recv().await {
+                match event {
+                    ConfigEvent::FibTablesReplaced { ack: Some(ack), .. }
+                    | ConfigEvent::ConfigTransactionCommitted { ack: Some(ack), .. } => {
+                        if let Some(delay) = first_ack_delay.take() {
+                            let state = ack_controller.state.lock().await;
+                            assert_eq!(state.applying_confirm_id.as_deref(), Some("external-fib"));
+                            assert!(state.pending.is_none());
+                            drop(state);
+                            assert!(
+                                ack_locator.exists() && ack_raw.exists() && ack_metadata.exists()
+                            );
+                            tokio::time::sleep(delay).await;
+                            let authority: serde_json::Value =
+                                serde_json::from_slice(&std::fs::read(&ack_metadata).unwrap())
+                                    .unwrap();
+                            let now = SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .unwrap()
+                                .as_secs();
+                            assert!(authority["deadline_unix_seconds"].as_u64().unwrap() <= now);
+                            *ack_released_at.lock().await = Some(tokio::time::Instant::now());
+                        }
+                        ack.accept().await;
+                    }
+                    _ => panic!("unexpected persistence event in v2 FIB harness"),
+                }
+            }
+        });
         let response = controller
             .clone()
             .apply(confirmed_dynamic_request(
@@ -5678,6 +5720,7 @@ families = ["ipv4_unicast"]
             response.status,
             proto::ConfigTransactionPlanStatus::Committable as i32
         );
+        let confirmation = response.confirmation.unwrap();
         assert_eq!(*fib_state.lock().await, vec![replacement]);
         if use_v3 {
             let state = controller.state.lock().await;
@@ -5692,8 +5735,12 @@ families = ["ipv4_unicast"]
             source,
             journal,
             locator,
+            raw,
+            metadata,
             fib_state,
             seen_preloaded,
+            first_ack_released_at,
+            confirmation,
             ack_task,
         }
     }
@@ -5702,7 +5749,88 @@ families = ["ipv4_unicast"]
     async fn v3_pending_retains_prior_without_duplicate_toml() {
         // Destructive proof: restoring the eager `to_string()` allocation
         // makes the harness assertion observe both full representations.
-        let harness = external_fib_harness(60, true).await;
+        let harness = external_fib_harness(60, true, None).await;
+        harness.ack_task.abort();
+    }
+
+    #[tokio::test]
+    async fn slow_v3_apply_starts_full_confirmation_window_after_commit() {
+        // Destructive proofs: the delayed-ack harness asserts authority exists
+        // while Apply is unfinished; moving the public wall deadline before
+        // the ack collapses the distinct authority/public values, and moving
+        // the live monotonic deadline before the ack violates its exact lower
+        // bound. Dropping the timer fails the bounded terminal wait. Rebuilding
+        // the prior from mutated source bytes breaks the Arc and FIB assertions.
+        let harness = external_fib_harness(1, true, Some(Duration::from_millis(1_100))).await;
+        let authority: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&harness.metadata).unwrap()).unwrap();
+        let authority_deadline = authority["deadline_unix_seconds"].as_u64().unwrap();
+        assert!(harness.confirmation.deadline_unix_seconds > authority_deadline);
+        let ack_released_at = harness.first_ack_released_at.lock().await.unwrap();
+        assert!(
+            harness
+                .controller
+                .state
+                .lock()
+                .await
+                .pending
+                .as_ref()
+                .unwrap()
+                .deadline
+                >= ack_released_at + Duration::from_secs(1)
+        );
+        assert_eq!(
+            harness
+                .controller
+                .status()
+                .await
+                .unwrap()
+                .confirmation
+                .unwrap()
+                .deadline_unix_seconds,
+            harness.confirmation.deadline_unix_seconds
+        );
+        let prior = harness
+            .controller
+            .state
+            .lock()
+            .await
+            .pending
+            .as_ref()
+            .unwrap()
+            .prior_snapshot
+            .clone()
+            .unwrap();
+        std::fs::write(&harness.source, "policy p { term rest { reject } }\n").unwrap();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let status = harness
+                    .controller
+                    .status()
+                    .await
+                    .unwrap()
+                    .confirmation
+                    .unwrap();
+                if status.status == proto::ConfigTransactionConfirmationStatus::AutoReverted as i32
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("post-commit timer must auto-revert");
+        assert!(Arc::ptr_eq(
+            &prior,
+            harness.seen_preloaded.lock().await.as_ref().unwrap()
+        ));
+        assert_eq!(*harness.fib_state.lock().await, vec![table("edge", 1000)]);
+        assert!(
+            !harness.locator.exists()
+                && !harness.metadata.exists()
+                && !harness.raw.exists()
+                && !harness.journal.exists()
+        );
         harness.ack_task.abort();
     }
 
@@ -5712,7 +5840,7 @@ families = ["ipv4_unicast"]
         // retained Arc rereads the mutated rpol file and fails; dual-writing
         // v1 changes the dispatch prefix; journal-first cleanup leaves the
         // locator present at successful return.
-        let harness = external_fib_harness(60, false).await;
+        let harness = external_fib_harness(60, false, None).await;
         assert!(
             std::fs::read(&harness.journal)
                 .unwrap()
@@ -5822,7 +5950,7 @@ families = ["ipv4_unicast"]
         // Destructive proof: removing the preloaded timeout lane or rebuilding
         // provenance from current external bytes leaves the replacement table
         // active and the locator armed after the timer fires.
-        let harness = external_fib_harness(1, false).await;
+        let harness = external_fib_harness(1, false, None).await;
         let prior = harness
             .controller
             .state
@@ -5854,7 +5982,7 @@ families = ["ipv4_unicast"]
         // Destructive proof: retaining v1's journal-as-authority rule or
         // clearing in-memory pending state before locator durability leaves
         // the locator present when the RPC reports permanent success.
-        let harness = external_fib_harness(60, false).await;
+        let harness = external_fib_harness(60, false, None).await;
         harness
             .controller
             .clone()


### PR DESCRIPTION
## Summary

- start the live confirmation window only after a committable apply succeeds
- preserve the pre-apply v1/v2/v3 rollback authority without rewriting durable metadata
- separate durable authority and public deadlines in the IRR transaction receipt

## Why

A slow apply could consume the entire confirmation interval before the API returned. The durable rollback authority must still exist before mutation, but the operator-facing and monotonic live confirmation windows should begin only after the apply is successfully committed.

This keeps recovery fail-closed while ensuring callers receive the full requested confirmation interval.

## Verification

- cargo fmt --all -- --check
- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
- cargo test --locked --workspace
- RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --no-deps
- focused delayed-ack v3 lifecycle regression
- IRR receipt verifier self-test
- ShellCheck for both transaction runners
- stable-surface and Clippy-reason gates

## Load-bearing proofs

- Reusing the pre-apply wall deadline as the public deadline fails the strict receipt ordering proof.
- Starting the live timer before the delayed persistence acknowledgement fails the exact monotonic lower-bound assertion.
- Removing pre-apply v3 authority publication fails before the successful apply can complete.
- Missing, equal, swapped, boolean, or tampered receipt deadlines each make the verifier self-test red.

The failed full-scale root remains preserved. Fresh campaign roots will be generated after this fix lands.

Standards context: [RFC 6241 section 8.4](https://www.rfc-editor.org/rfc/rfc6241.html#section-8.4) and [OpenConfig commit-confirmed guidance](https://openconfig.net/docs/guides/commit-confirmed/).
