### PR TITLE
Bound IRR rollback completion wait

### DIFF
--- a/bench/scale/irrreload/README.md
+++ b/bench/scale/irrreload/README.md
@@ -202,9 +202,11 @@ unconditional. Schema-1 transaction evidence conflated those clocks and is
 rejected rather than migrated.
 After the final measurement boundary and before daemon teardown,
 `txn-lifecycle.sh` applies the opposite B generation twice: explicit abort and
-ten-second timeout must report `aborted` and `auto_reverted`, remove all v3
-authority, and restore the exact A disk and effective-runtime hashes. A final
-streamed Plan of A must be tokenless `NOOP`.
+ten-second confirmation timeout must report `aborted` and `auto_reverted`,
+remove all v3 authority, and restore the exact A disk and effective-runtime
+hashes. Expiry of the advertised public deadline starts rollback; terminal
+rollback completion has a separate 600-second ceiling measured from that
+deadline. A final streamed Plan of A must be tokenless `NOOP`.
 
 Because config-history's `SkippedOversize` outcome is internal, the retained
 proof binds the public empty history entries and on-disk history roster before

--- a/bench/scale/irrreload/txn-lifecycle.sh
+++ b/bench/scale/irrreload/txn-lifecycle.sh
@@ -15,6 +15,8 @@ verify="$script_dir/verify-receipt.py"
 locator="$config.commit-confirm-locator.json"
 raw="$runtime_dir/commit-confirm-v3-prior.toml"; metadata="$runtime_dir/commit-confirm-v3-metadata.json"
 legacy="$runtime_dir/commit-confirm-journal.json"; min_raw=$((10 * 1024 * 1024)); max_raw=$((384 * 1024 * 1024)); output="$evidence/lifecycle.json"; mkdir -p "$evidence"
+CONFIRMATION_TIMEOUT_SECONDS=10
+ROLLBACK_COMPLETION_CEILING_SECONDS=600
 die() { echo "txn-lifecycle: $*" >&2; exit 1; }
 sha() { sha256sum -- "$1" | cut -d' ' -f1; }
 runtime_token_valid() { [[ $1 =~ ^kv2:[0-9a-f]{16}:8$ ]]; }
@@ -196,18 +198,23 @@ abort=$(jq -cn --argjson prefix "$abort_prefix" --argjson terminal "$abort_termi
     --argjson warning "$abort_warning" --argjson history_after "$abort_history_after" \
     '$prefix + {terminal:({status:"aborted",status_view_verified:true,restored_exactly:true,history_warning:$warning,
       history_after:$history_after} + $terminal)}') || die "abort receipt failed"
-apply_pending irrreload-timeout 10 || die "timeout pending transaction failed"
+apply_pending irrreload-timeout "$CONFIRMATION_TIMEOUT_SECONDS" || die "timeout pending transaction failed"
 timeout_prefix=$pending_prefix; timeout_runtime=$pending_runtime; timeout_deadline=$pending_deadline
 timeout_warning_before=$(warning_count)
-deadline=$((SECONDS + 60))
+terminal_completion_deadline=$((timeout_deadline + ROLLBACK_COMPLETION_CEILING_SECONDS))
 while :; do
     status_json=$("$rbgp" --addr "$addr" --json config status) || die "timeout status failed"
     outcome=$(printf '%s' "$status_json" | jq -er '.confirmation.status') || die "timeout status malformed"
-    [ "$outcome" = pending ] || break
-    [ "$SECONDS" -lt "$deadline" ] || die "timeout did not auto-revert within 60 seconds"
-    sleep 0.2
+    case "$outcome" in
+        pending)
+            [ "$(date +%s)" -lt "$terminal_completion_deadline" ] ||
+                die "rollback did not complete within ${ROLLBACK_COMPLETION_CEILING_SECONDS} seconds of the public confirmation deadline"
+            sleep 0.2
+            ;;
+        auto_reverted) break ;;
+        *) die "unexpected timeout outcome $outcome" ;;
+    esac
 done
-[ "$outcome" = auto_reverted ] || die "unexpected timeout outcome $outcome"
 timeout_rollback_runtime=$(printf '%s' "$status_json" | jq -er '.confirmation.runtime_snapshot_token | select(type == "string")') || die "timeout runtime token missing"
 runtime_token_valid "$timeout_rollback_runtime" || die "timeout runtime token was not canonical kv2"
 [ "$timeout_rollback_runtime" != "$timeout_runtime" ] || die "timeout did not rotate the runtime token"

--- a/tests/reloadstall_scenario_emitted_check.rs
+++ b/tests/reloadstall_scenario_emitted_check.rs
@@ -688,6 +688,33 @@ exit 8
 }
 
 #[test]
+/// Red proof: restoring the old 60-second wait or reusing the confirmation
+/// timeout as the rollback-completion bound fails these distinct contracts.
+fn irr_reload_transaction_lifecycle_separates_confirmation_and_rollback_bounds() {
+    let lifecycle = std::fs::read_to_string(format!(
+        "{}/bench/scale/irrreload/txn-lifecycle.sh",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .expect("read transaction lifecycle helper");
+
+    for required in [
+        "CONFIRMATION_TIMEOUT_SECONDS=10",
+        "ROLLBACK_COMPLETION_CEILING_SECONDS=600",
+        "apply_pending irrreload-timeout \"$CONFIRMATION_TIMEOUT_SECONDS\"",
+        "terminal_completion_deadline=$((timeout_deadline + ROLLBACK_COMPLETION_CEILING_SECONDS))",
+        "pending)",
+        "auto_reverted) break",
+        "*) die \"unexpected timeout outcome $outcome\"",
+    ] {
+        assert!(
+            lifecycle.contains(required),
+            "missing timeout bound contract: {required}"
+        );
+    }
+    assert!(!lifecycle.contains("SECONDS + 60"));
+}
+
+#[test]
 /// Red proof: including the cell name or native rendering in the canonical
 /// dataset digest makes the four-cell equality fail. Omitting or changing any
 /// canonical record field fails the independently pinned seed-61 digest; a


### PR DESCRIPTION
## Problem

The IRR-scale transaction-lifecycle harness rejected a legitimate run: after the 10-second confirmation window expired, the terminal-state poll gave rollback only 60 seconds, but a full reverse apply of the 295 MiB opposite-generation transaction legitimately took ~73 seconds. The harness reported a false red on a correct auto-revert.

The 60-second wait also conflated two distinct contracts: how long the daemon holds a pending transaction open for confirmation, and how long a rollback is allowed to take once the deadline expires.

## Change

Two separately named bounds in `bench/scale/irrreload/txn-lifecycle.sh`:

- `CONFIRMATION_TIMEOUT_SECONDS=10` — the confirmation deadline passed to `config apply`, unchanged.
- `ROLLBACK_COMPLETION_CEILING_SECONDS=600` — a new ceiling on terminal rollback completion, measured from the advertised public deadline (`deadline_unix_seconds` from the apply response) rather than from an arbitrary local stopwatch.

While waiting, the poll only tolerates `pending`; `auto_reverted` terminates the wait successfully, and any other confirmation status fails immediately instead of being waited out.

`tests/reloadstall_scenario_emitted_check.rs` gains a focused check pinning both named bounds, the deadline arithmetic, the fail-fast case arms, and the absence of the old 60-second wait. The harness README now documents both clocks.

## Verification

All in this branch's worktree, exit-code judged:

- `cargo fmt --all -- --check` — rc=0
- `cargo clippy --workspace --all-targets -- -D warnings` — rc=0
- `cargo test --workspace` — rc=0
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` — rc=0
- `python3 scripts/check-clippy-reasons.py` — rc=0
- `bash -n bench/scale/irrreload/txn-lifecycle.sh` — rc=0
- `shellcheck bench/scale/irrreload/txn-lifecycle.sh` — rc=0, no findings

Refs LAN-832.