### PR TITLE
release: prep v0.63.0 — bump workspace, roll CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.63.0] — 2026-08-04
+
 ### Added
 
 - ASPA-invalid policy rejections retain the first proven `NotProviderPlus` hop;
@@ -38,6 +40,74 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   from an older daemon; explicit `--plan-token` Apply fails closed when the
   daemon cannot honor that binding. Existing unary request/response behavior
   remains unchanged.
+
+
+- **Lag-aware `rbgp top` route events.** The optional event panel now uses the
+  typed `WatchEvents` route stream, renders policy source/target/reason and
+  Add-Path ID, and shows exact missed-event counts. Older daemons fall back only
+  when `WatchEvents` is unimplemented and retain an explicit degraded warning.
+
+- **Actionable authorization denials and `rbgp doctor` authz triage.** gRPC
+  PERMISSION_DENIED messages now name the principal, its current role (or
+  that it is unmapped), the required tier, and the exact
+  `[security.grpc.roles]` / listener `max_tier` config change (restart
+  required) that would permit the call; `rbgp` appends a one-line hint
+  pointing at the config surface. `rbgp doctor` gains a `daemon.authz.*`
+  check family: read-RPC reachability with denial as a first-class
+  diagnosed FAIL, the client-side connection identity shape, and the
+  daemon's enforcement mode from the effective config (skipped against
+  daemons that do not expose it).
+
+- **Provenance-bearing commit-confirm authority (LAN-798, ADR-0121).** New
+  confirmed transactions publish an owner-private raw normalized prior, then
+  compact provenance/file-identity metadata, then the config-adjacent locator
+  as the sole pending boot authority. Crash/restart restore verifies and directly
+  adopts that retained accepted snapshot before opening candidate contents or
+  mutating the candidate or backup; launch-target metadata may be inspected
+  while binding the authority. Live abort and timeout instead reuse the same
+  prior object through the ordinary #1370-gated planner and apply path. Abort,
+  timeout, and boot restore durably restore while all three objects remain;
+  confirm, successful rollback, and boot restore become terminal only after
+  locator removal and parent-directory sync. Later exact metadata/raw cleanup
+  is warning-only.
+  Production writes v3 only while retaining frozen v2 locator and locator-free
+  v1 recovery readers without conversion or dual-write. Finish pending state
+  before upgrade or downgrade, and remove format-specific safe residue before
+  starting an older binary; v2 config history separately requires moving the
+  complete history directory aside. Locator absence is authority-free and does
+  not impose pending-storage ownership or mode policy on an ordinary launch
+  path; confirmed writes and any present pending object still require the
+  documented daemon-owned private directory.
+
+- **Config-history provenance schema and rendering.** `ListConfigHistory` and
+  `rbgp config history` now expose an additive config-source digest over the
+  normalized-TOML digest plus the canonical accepted rpol/dataset source roster,
+  together with an explicit provenance status. Successful best-effort history
+  records of newly accepted snapshots use owner-private v2 JSON; legacy and v2
+  rows share one index. Rollback now accepts v2 rows only after one detached
+  load exactly reproduces the recorded TOML, manifest, and source digests;
+  unreadable rows and legacy rows with external declarations fail closed.
+
+- Native `.deb` and `.rpm` packages on every tagged release, for
+  Debian 11+/Ubuntu 22.04+ and RHEL/Rocky/Alma 9+ on amd64 and arm64.
+  The package installs the daemon, `rbgp`, and `rs-config-render` to
+  `/usr/bin`, the hardened systemd unit, man pages and completions,
+  creates the `rustbgpd` service user, and drops a non-overwriting
+  starter config at `/etc/rustbgpd/config.toml` — install, edit the
+  config, `systemctl enable --now rustbgpd`.
+
+- Per-architecture SHA-256 manifests cover each release tarball and its native
+  packages. The install docs select the exact downloaded filename from the
+  manifest, so tarball-only verification does not fail on absent `.deb` or
+  `.rpm` files.
+
+- The container image declares a `HEALTHCHECK` probing `rbgp --json
+  health` over the daemon's local gRPC socket, so `docker ps` and
+  orchestrators report container health without extra wiring.
+
+- The release tarballs now also ship the `birdwatcher-adapter` binary
+  and the systemd unit + kernel-dataplane drop-in under
+  `share/systemd/`.
 
 ### Removed
 
@@ -144,76 +214,6 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ends with a minimal copy-pasteable TOML block fixing that specific
   config, with the operator's own principal strings interpolated.
 
-### Added
-
-- **Lag-aware `rbgp top` route events.** The optional event panel now uses the
-  typed `WatchEvents` route stream, renders policy source/target/reason and
-  Add-Path ID, and shows exact missed-event counts. Older daemons fall back only
-  when `WatchEvents` is unimplemented and retain an explicit degraded warning.
-
-- **Actionable authorization denials and `rbgp doctor` authz triage.** gRPC
-  PERMISSION_DENIED messages now name the principal, its current role (or
-  that it is unmapped), the required tier, and the exact
-  `[security.grpc.roles]` / listener `max_tier` config change (restart
-  required) that would permit the call; `rbgp` appends a one-line hint
-  pointing at the config surface. `rbgp doctor` gains a `daemon.authz.*`
-  check family: read-RPC reachability with denial as a first-class
-  diagnosed FAIL, the client-side connection identity shape, and the
-  daemon's enforcement mode from the effective config (skipped against
-  daemons that do not expose it).
-
-- **Provenance-bearing commit-confirm authority (LAN-798, ADR-0121).** New
-  confirmed transactions publish an owner-private raw normalized prior, then
-  compact provenance/file-identity metadata, then the config-adjacent locator
-  as the sole pending boot authority. Crash/restart restore verifies and directly
-  adopts that retained accepted snapshot before opening candidate contents or
-  mutating the candidate or backup; launch-target metadata may be inspected
-  while binding the authority. Live abort and timeout instead reuse the same
-  prior object through the ordinary #1370-gated planner and apply path. Abort,
-  timeout, and boot restore durably restore while all three objects remain;
-  confirm, successful rollback, and boot restore become terminal only after
-  locator removal and parent-directory sync. Later exact metadata/raw cleanup
-  is warning-only.
-  Production writes v3 only while retaining frozen v2 locator and locator-free
-  v1 recovery readers without conversion or dual-write. Finish pending state
-  before upgrade or downgrade, and remove format-specific safe residue before
-  starting an older binary; v2 config history separately requires moving the
-  complete history directory aside. Locator absence is authority-free and does
-  not impose pending-storage ownership or mode policy on an ordinary launch
-  path; confirmed writes and any present pending object still require the
-  documented daemon-owned private directory.
-
-- **Config-history provenance schema and rendering.** `ListConfigHistory` and
-  `rbgp config history` now expose an additive config-source digest over the
-  normalized-TOML digest plus the canonical accepted rpol/dataset source roster,
-  together with an explicit provenance status. Successful best-effort history
-  records of newly accepted snapshots use owner-private v2 JSON; legacy and v2
-  rows share one index. Rollback now accepts v2 rows only after one detached
-  load exactly reproduces the recorded TOML, manifest, and source digests;
-  unreadable rows and legacy rows with external declarations fail closed.
-
-- Native `.deb` and `.rpm` packages on every tagged release, for
-  Debian 11+/Ubuntu 22.04+ and RHEL/Rocky/Alma 9+ on amd64 and arm64.
-  The package installs the daemon, `rbgp`, and `rs-config-render` to
-  `/usr/bin`, the hardened systemd unit, man pages and completions,
-  creates the `rustbgpd` service user, and drops a non-overwriting
-  starter config at `/etc/rustbgpd/config.toml` — install, edit the
-  config, `systemctl enable --now rustbgpd`.
-
-- Per-architecture SHA-256 manifests cover each release tarball and its native
-  packages. The install docs select the exact downloaded filename from the
-  manifest, so tarball-only verification does not fail on absent `.deb` or
-  `.rpm` files.
-
-- The container image declares a `HEALTHCHECK` probing `rbgp --json
-  health` over the daemon's local gRPC socket, so `docker ps` and
-  orchestrators report container health without extra wiring.
-
-- The release tarballs now also ship the `birdwatcher-adapter` binary
-  and the systemd unit + kernel-dataplane drop-in under
-  `share/systemd/`.
-
-### Changed
 
 - `rbgp config diff`, `plan`, and `apply` now preflight the fully populated
   protobuf request against tonic's 4,194,304-byte unary-message limit. Oversized
@@ -242,6 +242,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   RHEL/Rocky/Alma 9+; previously they required the newer glibc of the
   CI build host and failed to start on Debian stable and RHEL 9
   derivatives.
+
+- `rustbgpd-wire` 0.16.2: doc-only patch release. The ASPA verification
+  rustdoc now cites `draft-ietf-sidrops-aspa-verification-27`, and the
+  README Supported RFCs table lists RFC 9003 (which obsoletes the
+  previously listed RFC 8203) for administrative shutdown communication.
+  No code or public API change.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "bytes",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "birdwatcher-adapter"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "axum",
  "clap",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "event-bridge"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "clap",
  "rustbgpd-api",
@@ -2817,7 +2817,7 @@ checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rs-config-render"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "clap",
  "serde",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpctl"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "axum",
  "bgpkit-parser",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-api"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bfd"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "bytes",
  "proptest",
@@ -3009,7 +3009,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bmp"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "bytes",
  "rustbgpd-telemetry",
@@ -3021,7 +3021,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-event-history"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "rusqlite",
  "rustbgpd-telemetry",
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "rustbgpd-wire",
  "thiserror 2.0.19",
@@ -3045,7 +3045,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn-linux"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "futures",
  "libc",
@@ -3063,7 +3063,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn-load"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3089,7 +3089,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-mrt"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-policy"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "arc-swap",
  "ariadne",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rib"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "bytes",
  "criterion",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rpki"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "criterion",
  "rustbgpd-wire",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-telemetry"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "prometheus",
  "thiserror 2.0.19",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-transport"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "bytes",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.62.0"
+version = "0.63.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
@@ -33,20 +33,20 @@ categories = ["network-programming"]
 
 [workspace.dependencies]
 # Internal crates
-rustbgpd-wire = { path = "crates/wire", version = "0.16.1" }
-rustbgpd-bfd = { path = "crates/bfd", version = "0.62.0" }
+rustbgpd-wire = { path = "crates/wire", version = "0.16.2" }
+rustbgpd-bfd = { path = "crates/bfd", version = "0.63.0" }
 rustbgpd-fsm = { path = "crates/fsm", version = "0.3.1" }
-rustbgpd-transport = { path = "crates/transport", version = "0.62.0" }
-rustbgpd-rib = { path = "crates/rib", version = "0.62.0" }
-rustbgpd-policy = { path = "crates/policy", version = "0.62.0" }
-rustbgpd-api = { path = "crates/api", version = "0.62.0" }
-rustbgpd-telemetry = { path = "crates/telemetry", version = "0.62.0" }
-rustbgpd-rpki = { path = "crates/rpki", version = "0.62.0" }
-rustbgpd-bmp = { path = "crates/bmp", version = "0.62.0" }
-rustbgpd-mrt = { path = "crates/mrt", version = "0.62.0" }
-rustbgpd-evpn = { path = "crates/evpn", version = "0.62.0" }
-rustbgpd-evpn-linux = { path = "crates/evpn-linux", version = "0.62.0" }
-rustbgpd-event-history = { path = "crates/event-history", version = "0.62.0" }
+rustbgpd-transport = { path = "crates/transport", version = "0.63.0" }
+rustbgpd-rib = { path = "crates/rib", version = "0.63.0" }
+rustbgpd-policy = { path = "crates/policy", version = "0.63.0" }
+rustbgpd-api = { path = "crates/api", version = "0.63.0" }
+rustbgpd-telemetry = { path = "crates/telemetry", version = "0.63.0" }
+rustbgpd-rpki = { path = "crates/rpki", version = "0.63.0" }
+rustbgpd-bmp = { path = "crates/bmp", version = "0.63.0" }
+rustbgpd-mrt = { path = "crates/mrt", version = "0.63.0" }
+rustbgpd-evpn = { path = "crates/evpn", version = "0.63.0" }
+rustbgpd-evpn-linux = { path = "crates/evpn-linux", version = "0.63.0" }
+rustbgpd-event-history = { path = "crates/event-history", version = "0.63.0" }
 
 # External dependencies — pinned across workspace
 bytes = "1"

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ evolving API.**
 | Dimension | Current state |
 |-----------|---------------|
 | **Target use case** | Data-center fabric pilots, IXP route servers, programmable BGP control planes, lab/test environments |
-| **Maturity** | Public alpha (v0.62.0) |
+| **Maturity** | Public alpha (v0.63.0) |
 | **Adopter support** | Reporting channels, compatibility boundaries, and proof limits are documented in [SUPPORT.md](SUPPORT.md). |
 | **Narrow stable contract** | The machine-pinned [route-server / route-reflector v1 contract](docs/v1-stable-contract.md) covers only its inventoried control-plane roles and surfaces; the project and all unlisted features remain alpha. |
 | **Implemented** | Dual-stack BGP/MP-BGP, Add-Path, GR/LLGR, RPKI/RTR, ASPA path verification, FlowSpec, BMP, MRT, BFD, EVPN/VXLAN (alpha), and full gRPC/CLI management. Linux FIB integration is default-off and scoped to RFC 7999 discard routes and configured unicast tables (including ECMP and weighted multipath); broader routing-suite features remain future work. |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1712,9 +1712,10 @@ branch is between features.
   [docs/adr/0122-compatibility-debt-inventory.md](docs/adr/0122-compatibility-debt-inventory.md)
   is the single inventory of retained compat shims under the alpha
   posture, grouped by surface with per-item removal releases and
-  mechanics. Immediate remove-now items: the two v0.51.0 retired-key
+  mechanics. The remove-now items — the two v0.51.0 retired-key
   migration pointers and the redundant example-config UDS authorization
-  ceremony made unnecessary by #1429. Scheduled: the dead
+  ceremony made unnecessary by #1429 — landed in v0.63.0 (#1435).
+  Remaining scheduled: the dead
   `enforcement = "legacy"` enum variant, the `rbgp rib diff`
   older-daemon fallbacks, and three superseded proto fields. Two calls
   are owner-gated there (legacy config-history reader EOL, unary vs

--- a/bench/scale/config-persistence/Cargo.lock
+++ b/bench/scale/config-persistence/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "bytes",
  "thiserror",

--- a/bench/scale/enhanced-route-refresh/Cargo.lock
+++ b/bench/scale/enhanced-route-refresh/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "bytes",
  "thiserror",

--- a/bench/scale/outbound-prefix-limit-scale/Cargo.lock
+++ b/bench/scale/outbound-prefix-limit-scale/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "bytes",
  "thiserror",

--- a/bench/scale/outbound-prefix-limits/Cargo.lock
+++ b/bench/scale/outbound-prefix-limits/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "bytes",
  "thiserror",

--- a/bench/scale/reloadstall/Cargo.lock
+++ b/bench/scale/reloadstall/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "bytes",
  "thiserror",

--- a/bench/scale/rrharness/Cargo.lock
+++ b/bench/scale/rrharness/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bmp"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "bytes",
  "rustbgpd-telemetry",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-policy"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "arc-swap",
  "ariadne",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rib"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "bytes",
  "ipnet",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rpki"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "rustbgpd-wire",
  "smallvec",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-telemetry"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "prometheus",
  "thiserror 2.0.18",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-transport"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "bytes",
  "libc",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "bytes",
  "thiserror 2.0.18",

--- a/bench/scale/rrtransport/Cargo.lock
+++ b/bench/scale/rrtransport/Cargo.lock
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-bmp"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "bytes",
  "rustbgpd-telemetry",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-evpn-load"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-policy"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "arc-swap",
  "ariadne",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rib"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "bytes",
  "ipnet",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-rpki"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "rustbgpd-wire",
  "smallvec",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-telemetry"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "prometheus",
  "thiserror 2.0.19",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-transport"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "bytes",
  "libc",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "bytes",
  "thiserror 2.0.19",

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbgpd-wire"
-version = "0.16.1"
+version = "0.16.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -46,7 +46,6 @@ analyzers, test harnesses, MRT readers, etc.
 | 7999 | `BLACKHOLE` well-known community (`0xFFFF_029A`, rendered as `65535:666`) |
 | 8092 | Large communities (3× u32) |
 | 8097 | Origin Validation State Extended Community (type 0x43): `ORIGIN_VALIDATION_{VALID,NOT_FOUND,INVALID}` `ExtendedCommunity` constants with `OV_*` textual rendering. Codec only — RPKI-to-community stamping lives in the daemon |
-| 8203 | Admin shutdown communication |
 | 8277 | IPv4/IPv6 labeled-unicast NLRI codec (SAFI 4): label-stack + prefix encode/decode, Add-Path and withdraw forms. Inert codec substrate |
 | 8326 | `GRACEFUL_SHUTDOWN` well-known community (`0xFFFF_0000`) |
 | 8365 | EVPN over VXLAN encapsulation |
@@ -55,6 +54,7 @@ analyzers, test harnesses, MRT readers, etc.
 | 8654 | Extended messages (up to 65535 bytes). `encode_message_with_limit()` and the per-message `encode_with_limit()` helpers (on `NotificationMessage` / `RouteRefreshMessage`) encode against a caller-supplied size ceiling; the default `encode()` keeps the 4096-byte base limit |
 | 8950 | Extended next hop (IPv4 NLRI over IPv6 NH); optional acceptance of a link-local-primary `MP_REACH_NLRI` next-hop for unnumbered peers via `UpdateValidationOptions` |
 | 8955/8956 | FlowSpec: 13 component types, numeric/bitmask operators; §6.1-compliant `NEXT_HOP` validation (the irrelevant-next-hop case is accepted, not rejected); `FlowSpecRule::validate_encoded_len` rejects rules above the 12-bit `MAX_FLOWSPEC_NLRI_RULE_LEN` (4095 bytes) before they reach the wire |
+| 9003 | Administrative Shutdown Communication (obsoletes RFC 8203) |
 | 9012 | BGP Encapsulation extended community (§4.1) — VXLAN sub-type used by EVPN encap |
 | 9072 | Extended Optional Parameters Length for BGP OPEN: classic encoding through 255 optional-parameter octets, extended aggregate and per-parameter lengths above that boundary, and permissive extended-format receive at smaller lengths |
 | 9135 | EVPN integrated routing for IRB |

--- a/docs/v1-stable-contract.md
+++ b/docs/v1-stable-contract.md
@@ -165,7 +165,9 @@ archived under `tests/fixtures/v1-stable/v0.60.0/`; the v0.61.0 release records
 it as the accepted consecutive v0.60.0-to-v0.61.0 exercise and proves it with
 the current parser. The v0.61.0 route-server example continues the chain under
 `tests/fixtures/v1-stable/v0.61.0/` as the accepted consecutive
-v0.61.0-to-v0.62.0 exercise, proven the same way.
+v0.61.0-to-v0.62.0 exercise, proven the same way. The v0.62.0 route-server
+example continues the chain under `tests/fixtures/v1-stable/v0.62.0/` as the
+accepted consecutive v0.62.0-to-v0.63.0 exercise, proven the same way.
 
 ## Release gate
 

--- a/docs/v1-stable-surface.json
+++ b/docs/v1-stable-surface.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "contract": "rustbgpd-rs-rr-v1",
-  "baseline_release": "v0.62.0",
+  "baseline_release": "v0.63.0",
   "scope": "Narrow route-server and route-reflector product contract; unlisted surfaces are not stable by implication.",
   "roles": [
     {
@@ -326,6 +326,20 @@
       "semantic_toml_sha256": "450d3b3e844bb42d4dfe0974efbfafa5f2098e3c15547a94bb7fe70b7ad82704",
       "validation_source": "src/config/tests.rs",
       "validation_test": "config::tests::v1_stable_v0_61_route_server_fixture_parses",
+      "result": "accepted_without_config_migration"
+    },
+    {
+      "from_release": "v0.62.0",
+      "to_release": "v0.63.0",
+      "fixture_directory": "tests/fixtures/v1-stable/v0.62.0/route-server",
+      "source_directory": "examples/route-server",
+      "files": [
+        {"path": "config.toml", "sha256": "68dca9fe44f67b4d58b1f15f3ddb2233d074f5a510f0117b15535a7d944f49df"},
+        {"path": "hygiene.rpol", "sha256": "9035313c7813273a64856780be66d790f25cafcb8a7f04e44ada16efb083e515"}
+      ],
+      "semantic_toml_sha256": "450d3b3e844bb42d4dfe0974efbfafa5f2098e3c15547a94bb7fe70b7ad82704",
+      "validation_source": "src/config/tests.rs",
+      "validation_test": "config::tests::v1_stable_v0_62_route_server_fixture_parses",
       "result": "accepted_without_config_migration"
     }
   ]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -966,6 +966,27 @@ fn v1_stable_v0_61_route_server_fixture_parses() {
         .unwrap_or_else(|err| panic!("v0.61.0 route-server config no longer validates: {err}"));
 }
 
+#[test]
+fn v1_stable_v0_62_route_server_fixture_parses() {
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/v1-stable/v0.62.0/route-server");
+    let config_path = fixture.join("config.toml");
+    let source = fs::read_to_string(&config_path).unwrap_or_else(|err| {
+        panic!(
+            "failed to read immutable v0.62.0 route-server fixture {}: {err}",
+            config_path.display()
+        );
+    });
+    let mut config: Config = toml::from_str(&source)
+        .unwrap_or_else(|err| panic!("v0.62.0 route-server config no longer parses: {err}"));
+    config
+        .load_rpol_files(Some(&fixture))
+        .unwrap_or_else(|err| panic!("v0.62.0 route-server rpol no longer loads: {err}"));
+    config
+        .validate()
+        .unwrap_or_else(|err| panic!("v0.62.0 route-server config no longer validates: {err}"));
+}
+
 const V1_EFFECTIVE_DEFAULTS_TOML: &str = r#"
 [global]
 asn = 65001

--- a/tests/fixtures/v1-stable/v0.62.0/route-server/config.toml
+++ b/tests/fixtures/v1-stable/v0.62.0/route-server/config.toml
@@ -1,0 +1,175 @@
+# IXP route server configuration
+#
+# rustbgpd as an IX route server with two members. Every member gets:
+# - transparent route-server mode (preserve original NEXT_HOP, no AS prepend)
+# - local BGP role "route_server" (RFC 9234: OTC attached on egress,
+#   role capability negotiated when the member also sets its role)
+# - dual-stack (IPv4 + IPv6 unicast)
+# - RPKI origin validation (drop invalid, prefer valid) and import
+#   hygiene (reject AS_SET, ASPA-invalid, and a dated dual-stack
+#   special-purpose prefix snapshot — see hygiene.rpol)
+#
+# Path-hiding mitigation (RFC 7947 §2.3.2), both flavors:
+# - member-alpha negotiates Add-Path send: it sees up to the eight best
+#   export-permitted candidates, subject to configured and negotiated
+#   Paths-Limit, and runs its own selection (the preferred mitigation);
+# - member-beta cannot do Add-Path, so it opts into per_client_best:
+#   when its export policy denies the best path, the route server
+#   advertises the best *permitted* candidate instead of hiding the
+#   prefix (the BIRD-`secondary` equivalent).
+#
+# Add more [[neighbors]] blocks for additional IXP members, or manage
+# them dynamically via gRPC at runtime.
+
+[global]
+asn = 65500
+router_id = "198.51.100.1"
+listen_port = 179
+# RFC 8212: a member session with no explicit policy carries nothing in
+# that direction. The export chain below is deliberately permit-all, and
+# this knob is what keeps that a decision: delete the chain and members
+# stop receiving routes, loudly, instead of inheriting the same permit-all
+# by omission. Startup-only — SIGHUP keeps the running value, so changing
+# it takes a daemon restart.
+ebgp_requires_policy = true
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+# For remote management, prefer an mTLS proxy (see examples/envoy-mtls/).
+# Uncomment below only for trusted management networks:
+# [global.telemetry.grpc_tcp]
+# address = "127.0.0.1:50051"
+
+[global.telemetry.grpc_uds]
+path = "/var/lib/rustbgpd/grpc.sock"
+# Audit principal for this local socket (UDS access is gated by file perms);
+# mapped to a role in [security.grpc.roles] below.
+principal = "operator"
+
+[security.grpc]
+# Per-principal gRPC authorization (ADR-0064; default since v0.24.0).
+# Roles: observer (sensitive_read) | automation (mutating) | operator (operator_only)
+enforcement = "tier"
+
+[security.grpc.roles]
+operator = "operator"
+
+# --- RPKI origin validation ---
+
+[rpki]
+[[rpki.cache_servers]]
+address = "127.0.0.1:3323"       # Routinator, rpki-client, etc.
+
+# --- Named policy definitions ---
+
+[policy.definitions.reject-rpki-invalid]
+[[policy.definitions.reject-rpki-invalid.statements]]
+match_rpki_validation = "invalid"
+action = "deny"
+
+[policy.definitions.reject-long-prefixes]
+default_action = "permit"
+[[policy.definitions.reject-long-prefixes.statements]]
+prefix = "0.0.0.0/0"
+ge = 25
+le = 32
+action = "deny"
+[[policy.definitions.reject-long-prefixes.statements]]
+prefix = "::/0"
+ge = 49
+le = 128
+action = "deny"
+
+[policy.definitions.prefer-rpki-valid]
+[[policy.definitions.prefer-rpki-valid.statements]]
+match_rpki_validation = "valid"
+action = "permit"
+set_local_pref = 200
+[[policy.definitions.prefer-rpki-valid.statements]]
+match_rpki_validation = "not_found"
+action = "permit"
+set_local_pref = 100
+
+# --- Export policy: permit-all, on purpose ---
+#
+# An IX route server is transparent by design (RFC 7947): it hands each
+# member what that member's own filters selected, without imposing the
+# route server's opinion on top. So permit-all is the correct export
+# posture here — but it is *declared*, not inherited. A route server that
+# is permit-all because nobody wrote an export chain behaves identically
+# on the wire; only this chain, and this comment, record that it was a
+# choice rather than an omission.
+#
+# Per-member filtering (a member that wants a subset, or a bilateral
+# arrangement) belongs in that neighbor's `export_policy_chain`, which
+# overrides this globally applied one. member-beta's `per_client_best`
+# below is what makes such a per-member denial advertise the best
+# permitted candidate rather than hide the prefix.
+[policy.definitions.rs-transparent-export]
+default_action = "permit"
+
+[policy]
+# ixp-hygiene and reject-special-purpose live in hygiene.rpol; rpol and
+# TOML policies share one namespace and compose in one ordered chain.
+rpol_files = ["hygiene.rpol"]
+import_chain = [
+    "reject-rpki-invalid",
+    "ixp-hygiene",
+    "reject-special-purpose",
+    "reject-long-prefixes",
+    "prefer-rpki-valid",
+]
+export_chain = ["rs-transparent-export"]
+
+# Import-decision explain, off — stated rather than inherited, because on
+# a route server it is the memory decision that matters most. The cache is
+# per session, so its cost is multiplied by member count, and 4096 entries
+# cannot retain a member's full table anyway: a query for an arbitrary
+# prefix would be a coin-flip against an evicted answer. On a 1000-member
+# fleet whose members each announce more than 4096 prefixes, an enabled
+# cache at the default size saturates in the low gigabytes.
+#
+# For the member-facing "why is my route filtered?" question, prefer
+# `[policy.reject_retention]` (on by default) and
+# `rbgp rib received <member> --rejected` — it enumerates rejections with
+# reasons and does not need the prefix known in advance.
+#
+# Turn this on deliberately, with `cache_size` raised toward the member's
+# retained-prefix count, while you are diagnosing — not as a standing cost.
+[policy.explain]
+enabled = false
+
+# --- IXP member peers ---
+
+# Add-Path-capable member: sees up to the eight best export-permitted
+# candidates, subject to configured and negotiated Paths-Limit (preferred
+# path-hiding mitigation), and stays update-group-shareable.
+[[neighbors]]
+address = "198.51.100.2"
+remote_asn = 64501
+description = "member-alpha"
+hold_time = 90
+families = ["ipv4_unicast", "ipv6_unicast"]
+route_server_client = true
+role = "route_server"
+max_prefixes = 50000
+
+[neighbors.add_path]
+send = true
+send_max = 8
+
+# Member without Add-Path: per_client_best advertises the best
+# export-policy-permitted candidate when the overall best is denied
+# (RFC 7947 §2.3.2 per-client best-path). Requires route_server_client.
+[[neighbors]]
+address = "198.51.100.3"
+remote_asn = 64502
+description = "member-beta"
+hold_time = 90
+families = ["ipv4_unicast", "ipv6_unicast"]
+route_server_client = true
+per_client_best = true
+role = "route_server"
+max_prefixes = 50000

--- a/tests/fixtures/v1-stable/v0.62.0/route-server/hygiene.rpol
+++ b/tests/fixtures/v1-stable/v0.62.0/route-server/hygiene.rpol
@@ -1,0 +1,166 @@
+# IXP import hygiene (rpol policy language, ADR-0096).
+#
+# Referenced from config.toml via `[policy] rpol_files` and the import
+# chain; edits hot-apply via SIGHUP. Run the in-language tests below
+# with `rbgp policy check hygiene.rpol`.
+
+# Dated starter snapshot of the IANA IPv4 and IPv6 Special-Purpose Address
+# Registries (both updated 2025-10-09; reviewed here 2026-07-15). The reject
+# set contains the two default routes plus active rows whose "Globally
+# Reachable" value is False. It is deliberately not a complete bogon feed:
+# terminated rows, unallocated space, multicast, and True/N/A rows outside a
+# rejected parent are omitted. Active True/N/A children of a rejected parent
+# must stay in this first set so the policy accepts them before the broad deny.
+prefix-set special-purpose-parent-exceptions {
+    192.0.0.9/32,
+    192.0.0.10/32,
+    2001::/32 le 128,
+    2001:1::1/128,
+    2001:1::2/128,
+    2001:1::3/128,
+    2001:3::/32 le 128,
+    2001:4:112::/48 le 128,
+    2001:20::/28 le 128,
+    2001:30::/28 le 128,
+}
+
+prefix-set non-global-special-purpose {
+    0.0.0.0/0,
+    0.0.0.0/8 le 32,
+    10.0.0.0/8 le 32,
+    100.64.0.0/10 le 32,
+    127.0.0.0/8 le 32,
+    169.254.0.0/16 le 32,
+    172.16.0.0/12 le 32,
+    192.0.0.0/24 le 32,
+    192.0.2.0/24 le 32,
+    192.88.99.2/32,
+    192.168.0.0/16 le 32,
+    198.18.0.0/15 le 32,
+    198.51.100.0/24 le 32,
+    203.0.113.0/24 le 32,
+    240.0.0.0/4 le 32,
+    ::/0,
+    ::/128,
+    ::1/128,
+    ::ffff:0:0/96 le 128,
+    64:ff9b:1::/48 le 128,
+    100::/64 le 128,
+    100:0:0:1::/64 le 128,
+    2001::/23 le 128,
+    2001:db8::/32 le 128,
+    3fff::/20 le 128,
+    5f00::/16 le 128,
+    fc00::/7 le 128,
+    fe80::/10 le 128,
+}
+
+policy reject-special-purpose {
+    term preserve-active-parent-exception {
+        if route.prefix in special-purpose-parent-exceptions { accept }
+    }
+    term reject-non-global { if route.prefix in non-global-special-purpose { reject } }
+}
+
+policy ixp-hygiene {
+    # Reject routes carrying an AS_SET (deprecated by RFC 9774; common
+    # IXP hygiene, arouteserver rejects them too). AS_PATHs render
+    # AS_SETs in braces — "65001 {65002 65003}" — so a literal `{`
+    # (escaped for the regex) matches any AS_SET segment.
+    term reject-as-set { if route.as-path matches "\\{" { reject } }
+    # Reject ASPA-invalid AS paths (draft-ietf-sidrops-aspa-verification).
+    # Inert (state = unknown) until ASPA objects are loaded from the
+    # RPKI cache; activates automatically once they are.
+    term reject-aspa-invalid { if route.aspa == invalid { reject } }
+    # Tag the RPKI origin-validation outcome as an RFC 8097 extended
+    # community (non-transitive opaque, type 0x43) so route-server
+    # clients can act on it without running their own validator.
+    # OV_INVALID never reaches clients here — the TOML import chain
+    # drops rpki-invalid routes — but tagging is harmless and keeps
+    # the terms uniform if that drop is ever relaxed.
+    term tag-ov-valid { if route.rpki == valid { add ext-community OV_VALID } }
+    term tag-ov-not-found { if route.rpki == not-found { add ext-community OV_NOT_FOUND } }
+    term tag-ov-invalid { if route.rpki == invalid { add ext-community OV_INVALID } }
+}
+
+test as-set-is-rejected {
+    route { prefix 203.0.113.0/24; as-path "64501 {64502 64503}" }
+    expect ixp-hygiene == reject
+}
+
+test aspa-invalid-is-rejected {
+    route { prefix 203.0.113.0/24; as-path "64501"; aspa invalid }
+    expect ixp-hygiene == reject
+}
+
+test clean-route-falls-through {
+    route { prefix 203.0.113.0/24; as-path "64501 64510" }
+    expect ixp-hygiene == accept
+}
+
+test rpki-valid-is-tagged-ov-valid {
+    route { prefix 203.0.113.0/24; as-path "64501"; rpki valid }
+    expect ixp-hygiene == accept with ext-community OV_VALID
+}
+
+test rpki-not-found-is-tagged-ov-not-found {
+    route { prefix 203.0.113.0/24; as-path "64501" }
+    expect ixp-hygiene == accept with ext-community OV_NOT_FOUND
+}
+
+test rpki-invalid-is-tagged-ov-invalid {
+    route { prefix 203.0.113.0/24; as-path "64501"; rpki invalid }
+    expect ixp-hygiene == accept with ext-community OV_INVALID
+}
+
+test ipv4-default-is-rejected {
+    route { prefix 0.0.0.0/0 }
+    expect reject-special-purpose == reject
+}
+
+test ipv6-default-is-rejected {
+    route { prefix ::/0 }
+    expect reject-special-purpose == reject
+}
+
+test shared-address-more-specific-is-rejected {
+    route { prefix 100.65.0.0/24 }
+    expect reject-special-purpose == reject
+}
+
+test unique-local-more-specific-is-rejected {
+    route { prefix fd00:1::/48 }
+    expect reject-special-purpose == reject
+}
+
+test pcp-parent-exception-is-preserved {
+    route { prefix 192.0.0.9/32 }
+    expect reject-special-purpose == accept
+}
+
+test teredo-parent-exception-is-preserved {
+    route { prefix 2001:0:1234::/48 }
+    expect reject-special-purpose == accept
+}
+
+test as112-parent-exception-is-preserved {
+    route { prefix 2001:4:112::/48 }
+    expect reject-special-purpose == accept
+}
+
+test ordinary-global-ipv4-falls-through {
+    route { prefix 8.8.8.0/24 }
+    expect reject-special-purpose == accept
+}
+
+test ordinary-global-ipv6-falls-through {
+    route { prefix 2001:4860::/32 }
+    expect reject-special-purpose == accept
+}
+
+# This policy only classifies the dated special-purpose snapshot. The later
+# reject-long-prefixes chain member remains responsible for prefix-length caps.
+test too-long-parent-exception-falls-through {
+    route { prefix 2001:4:112::1/128 }
+    expect reject-special-purpose == accept
+}


### PR DESCRIPTION
Release prep for v0.63.0.

## Headline items in this release

- **Authorization UX + legacy retirement** — implicit `local-operator`
  identity for owner-only UDS listeners (bare configs boot `--strict`-clean
  with zero authz config), one-shot tier-config diagnosis, denials that name
  the principal/role/fix, `rbgp doctor` authz checks; `security.grpc.enforcement
  = "legacy"` no longer boots (breaking; migration notes in the CHANGELOG).
- **IRR-scale streaming transactional config** — `StreamPlanConfigTransaction`
  / `StreamApplyConfigTransaction` gRPC ingress for large candidates (1 MiB
  chunks, 384 MiB ceiling, SHA-256 framing), `rbgp config plan/apply` stream
  by default, disk-backed commit-confirm v3 authority with post-apply deadline
  semantics.
- **ASPA applicability + diagnostics** — edge-ingress applicability
  enforcement, bounded invalid-hop (`NotProviderPlus`) diagnostics, ASPA shown
  in the rejected-route table.
- **IRR reload performance fix** — set-table interning in `RpolFile`
  (`--check` 5m21s → 1.1s on the 65 MB IRR file; SIGHUP reload completes
  instead of DNF).
- **glibc-floor packaging fix** — release binaries now build against
  glibc 2.31 and run on Debian 11+ / Ubuntu 22.04+ / RHEL 9 derivatives.
- **OS packages** — per-arch `.deb`/`.rpm` artifacts with man pages,
  completions, and the systemd unit.

## Prep contents

- CHANGELOG: `[Unreleased]` rolled to `[0.63.0] — 2026-08-04` (heading matches
  the release workflow's `## [X.Y.Z]` extraction); duplicate subsection
  headings from the cycle merged content-preserving; fresh `[Unreleased]`
  seeded.
- Workspace `0.62.0` → `0.63.0` plus every internal `rustbgpd-*` pin; wire pin
  → `0.16.2`.
- `rustbgpd-wire` 0.16.2 in its own commit: doc-only patch — ASPA rustdoc now
  cites draft-ietf-sidrops-aspa-verification-27; README RFC table corrects
  RFC 8203 → RFC 9003 (obsoleted).
- v1 stable surface: `baseline_release` → v0.63.0; consecutive
  v0.62.0 → v0.63.0 upgrade exercise appended with the byte-identical v0.62.0
  route-server fixture archived from the tag plus a current-parser proof test.
- Workspace lockfile and all seven standalone harness lockfiles refreshed and
  `--locked`-tested.
- README Maturity row → v0.63.0; ROADMAP ADR-0122 remove-now items marked
  landed (#1435).
- Shell completions regenerated from the built binary (no drift).

## Gates

| Gate | rc |
|------|----|
| cargo fmt --all -- --check | 0 |
| cargo clippy --workspace --all-targets -- -D warnings | 0 |
| cargo test --workspace | 0 (96 suites ok) |
| cargo doc --workspace --no-deps (deny warnings) | 0 |
| cargo build --workspace --release | 0 |
| cargo audit | 0 (no advisories) |
| scripts/check-clippy-reasons.py | 0 |
| scripts/check-v1-stable-surface.py | 0 (OK) |
| cargo test -p rustbgpd-api authz | 0 (43 passed) |
| cargo publish -p rustbgpd-wire --dry-run | 0 (aborted at dry-run upload) |
| 7× standalone harness cargo test --locked | 0 each |

New-this-cycle gRPC methods and their tiers (unchanged, reported per the
release checklist): `ConfigService/StreamPlanConfigTransaction` =
`sensitive_read`; `ConfigService/StreamApplyConfigTransaction` =
`operator_only`.

Tagging follows the release walk in docs/RELEASE_CHECKLIST.md after merge.
