### PR TITLE
ci(release): add dispatchable dry-run mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,20 @@ name: Release Binaries
 on:
   push:
     tags: ["v*"]
+  # Dry-run dispatch: exercise every job (version gate, tests, both
+  # matrix builds, packaging, assertions, checksums, artifact upload)
+  # without publishing anything. Workflow edits otherwise meet their
+  # first execution on a live tag push, costing tag delete/recreate
+  # cycles when they fail. The publish step is guarded on the push
+  # event itself, so a dispatch run can never create a release
+  # regardless of the input value.
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build and verify everything; publish nothing"
+        type: boolean
+        required: true
+        default: true
 
 # Read-only default; the `release` job alone escalates to the
 # contents scope needed to create the release.
@@ -21,8 +35,12 @@ jobs:
       - name: Assert tag matches workspace version
         run: |
           set -euo pipefail
-          tag_version="${GITHUB_REF_NAME#v}"
           manifest_version="$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml","rb"))["workspace"]["package"]["version"])')"
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "dry-run dispatch: no tag ref exists, skipping the tag/version equality check; workspace version is ${manifest_version}"
+            exit 0
+          fi
+          tag_version="${GITHUB_REF_NAME#v}"
           if [ "$tag_version" != "$manifest_version" ]; then
             echo "::error file=Cargo.toml::tag ${GITHUB_REF_NAME} does not match [workspace.package] version ${manifest_version}; refusing to publish"
             exit 1
@@ -211,7 +229,14 @@ jobs:
           echo "0660ca602b2d2d2ae4781a06c692b3eeb9d437ffea05b831d76e41f4a3188783  /tmp/nfpm.tgz" | sha256sum -c
           tar -C /tmp -xzf /tmp/nfpm.tgz nfpm
           deb_arch=${{ matrix.suffix == 'linux-amd64' && 'amd64' || 'arm64' }}
-          scripts/build-packages.sh staging "$deb_arch" "${GITHUB_REF_NAME#v}" dist /tmp/nfpm
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            # No tag ref in a dry run; package as the workspace version.
+            # (sed, not python3/tomllib: bullseye's python3 is 3.9.)
+            version="$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -n1)"
+          else
+            version="${GITHUB_REF_NAME#v}"
+          fi
+          scripts/build-packages.sh staging "$deb_arch" "$version" dist /tmp/nfpm
 
       - name: Compute per-arch checksums
         run: |
@@ -258,7 +283,13 @@ jobs:
         # list boundaries) so the release page renders cleanly.
         run: |
           set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            # No tag ref in a dry run; extract the workspace version's
+            # section so the CHANGELOG gate is exercised too.
+            version="$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml","rb"))["workspace"]["package"]["version"])')"
+          else
+            version="${GITHUB_REF_NAME#v}"
+          fi
           awk -v v="$version" '
             $0 ~ "^## \\[" v "\\]" { in_section=1; print; next }
             in_section && /^## \[/ { exit }
@@ -274,6 +305,11 @@ jobs:
           cat release-notes.md
 
       - name: Create GitHub Release
+        # The only externally visible step in the workflow. Guarded on
+        # the push event itself (not the dry_run input) so a dispatch
+        # run can never publish: without a tag ref, action-gh-release
+        # would otherwise act on the branch ref.
+        if: github.event_name == 'push'
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           body_path: release-notes.md

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -617,6 +617,11 @@ docker run --rm --entrypoint rbgp rustbgpd:dev --help
 6. **Annotated** tag (lightweight tags break the release-history convention
    here): `git tag -a vX.Y.Z -m "vX.Y.Z — <one-line headline>"`
 7. Push: `git push origin main && git push origin vX.Y.Z`
+   - If this cycle touched `.github/workflows/release.yml`, run the
+     dispatch dry-run to green **before pushing the tag** (after the
+     workflow change is on `main`): `gh workflow run release.yml -f
+     dry_run=true` — workflow edits otherwise meet their first
+     execution on the live tag.
 8. Verify CI passes on the tag (build matrix x86_64 + aarch64, doc, GHCR
    push, release.yml binary build + GitHub Release creation). Both
    publication workflows are fail-closed: `release.yml` and


### PR DESCRIPTION
## Why

The v0.63.0 tag push failed twice on `release.yml` defects that only manifest at execution time:

1. Container jobs default `run` steps to dash, which rejects `set -o pipefail` (fixed by the `defaults.run.shell: bash` block).
2. `apt-get install --no-install-recommends` dropped `libc6-dev-arm64-cross`, breaking every C dependency in the aarch64 leg (fixed in 39ebf370's parent chain).

Both fixes only met their first execution on a live tag, because tag push is the workflow's only trigger — each failure cost a tag delete/recreate cycle. This PR makes the workflow dry-runnable via `workflow_dispatch` so future workflow edits can be executed to green before the tag exists.

## What runs in a dry run

Everything except publication: `verify-tag-version`, `test`, both matrix `build` legs (cross toolchain, protoc pin, jemalloc release build, tarball packaging, content assertions, nfpm `.deb`/`.rpm`, per-arch checksums, workflow-artifact upload), and the `release` job's artifact download + CHANGELOG section extraction. The only step skipped is **Create GitHub Release**, guarded with:

```yaml
if: github.event_name == 'push'
```

The guard is on the push event itself rather than the `dry_run` input: on a dispatch there is no tag ref, so `action-gh-release` would act on the branch ref — a dispatch run can therefore never publish regardless of the input value. The `dry_run` input (required, default `true`) exists as an explicit statement of intent on the dispatch form.

## Dispatch-mode version source

`verify-tag-version` still reads the workspace version, then skips only the tag-equality assertion with an explicit log line (`dry-run dispatch: no tag ref exists, skipping the tag/version equality check`). The tag-push path is byte-for-byte the same fail-closed comparison as before. This is the smallest honest design: there is no tag to compare against in dispatch mode, and inventing one (e.g. requiring a version input) would test the input, not the release.

The two other tag-derived values resolve to the workspace version in dispatch mode:

- `.deb`/`.rpm` package version (via `sed` on `Cargo.toml` — the bullseye container's python3 is 3.9, no `tomllib`)
- CHANGELOG section extraction in the `release` job (via `tomllib` on ubuntu-latest, same idiom as `verify-tag-version`), so the changelog gate is exercised too

## Limitations and post-merge activation

A dispatch run needs the workflow on the default branch, so this cannot be fully executed before merge. Validation done here: `python3 yaml.safe_load` on the file, `git diff --check` (both clean); `actionlint` is not installed on this machine.

After merge, activate with:

```
gh workflow run release.yml -f dry_run=true
```

Green looks like: all five jobs succeed (`verify-tag-version` logs the dry-run skip line, both `build` legs upload `binaries-linux-{amd64,arm64}` workflow artifacts containing the tarball, packages, schema, and checksums), the `release` job prints the extracted `0.63.x` CHANGELOG notes, and **Create GitHub Release shows as skipped** — and no release or tag appears on the repo.

`docs/RELEASE_CHECKLIST.md` step 7 now requires this dry-run to green before pushing the tag in any cycle that touched `release.yml`.
