### PR TITLE
test(api): pin streaming spool contract constants and unsafe-mode rejection

### DIFF
--- a/crates/api/src/config_service/stream.rs
+++ b/crates/api/src/config_service/stream.rs
@@ -1995,4 +1995,38 @@ mod tests {
         );
         assert!(!has_token(&state, token));
     }
+
+    // The streamed-candidate contract is 384 MiB of TOML spooled in 1 MiB
+    // chunks, with at most 256 live plan tokens that expire after 30 minutes
+    // (docs/API.md; the CLI pins the matching finite decode ceiling in
+    // crates/cli/src/connection.rs). Any widened or unbounded replacement
+    // makes this red.
+    #[test]
+    fn streaming_spool_contract_constants_are_pinned() {
+        assert_eq!(MAX_CANDIDATE_BYTES, 384 * 1024 * 1024);
+        assert_eq!(MAX_CHUNK_BYTES, 1024 * 1024);
+        assert_eq!(MAX_LIVE_PLAN_TOKENS, 256);
+        assert_eq!(PLAN_TOKEN_TTL, Duration::from_mins(30));
+    }
+
+    // create_spool's post-create validation (unsafe streamed config storage)
+    // is defense-in-depth behind O_CREAT|O_EXCL with mode 0600 inside this
+    // already-validated directory; it is unreachable without process-global
+    // umask manipulation or filesystem mocking, so only the directory branch
+    // is exercised here.
+    #[test]
+    fn prepare_rejects_group_visible_spool_directory_and_spools_nothing() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let runtime = TempDir::new().unwrap();
+        let spool = runtime.path().join(SPOOL_DIRECTORY);
+        std::fs::create_dir(&spool).unwrap();
+        std::fs::set_permissions(&spool, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let directory = File::open(runtime.path()).unwrap();
+        let Err(error) = StreamPlanState::prepare(&directory) else {
+            panic!("group-visible spool directory must be rejected");
+        };
+        assert!(error.contains("unsafe type, owner, or mode"), "{error}");
+        assert!(spool_is_anonymous(runtime.path()));
+    }
 }


### PR DESCRIPTION
Test-only change (LAN-884). Adds two tests to the `stream.rs` test module; no production code is touched.

1. `streaming_spool_contract_constants_are_pinned` — pins the streamed-candidate contract documented in docs/API.md and mirrored by the CLI's finite decode-ceiling pin in `crates/cli/src/connection.rs`: `MAX_CANDIDATE_BYTES == 384 * 1024 * 1024`, `MAX_CHUNK_BYTES == 1024 * 1024`, `MAX_LIVE_PLAN_TOKENS == 256`, and the 30-minute `PLAN_TOKEN_TTL`. None of these were pinned elsewhere.
2. `prepare_rejects_group_visible_spool_directory_and_spools_nothing` — pre-creates `stream-plan-v1` with mode 0755 under the runtime-state directory and asserts `StreamPlanState::prepare` fails with the "unsafe type, owner, or mode" error and that the spool directory stays empty (no spool file created).

`create_spool`'s post-create validation branch (`streamed config storage has unsafe type, owner, or mode`) is not covered: the spool file is created via `O_CREAT|O_EXCL` with mode 0600 inside the already-validated 0700 directory, so tripping the check would require process-global umask manipulation (unsafe under the parallel test harness) or filesystem mocking. Noted in a test comment.

## Mutation red-proofs

Both tests were proven load-bearing against temporary mutations (reverted before commit):

**(a) `MAX_CANDIDATE_BYTES` changed 384 MiB -> 512 MiB:**

```
test config_service::stream::tests::streaming_spool_contract_constants_are_pinned ... FAILED
assertion `left == right` failed
  left: 536870912
 right: 402653184
```

**(b) mode check in `prepare_with_limits` weakened (`metadata.mode() & 0o777 != 0o700` clause removed):**

```
test config_service::stream::tests::prepare_rejects_group_visible_spool_directory_and_spools_nothing ... FAILED
panicked: group-visible spool directory must be rejected
```

## Gates (all rc=0)

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p rustbgpd-api`
- `python3 scripts/check-clippy-reasons.py`
