### PR TITLE
docs(adr): propose the v1.0 stability contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -363,6 +363,10 @@ new AFI/SAFI and EVPN dataplane expansion.
   transactions, BMP/MRT/events, and the already-proven RR/controller-feed
   families. Keep its stability, migration, deprecation, and compatibility
   rules current while EVPN VTEP/IRB remains alpha and outside this contract.
+  What tagging v1.0 would mean — the frozen surfaces, the evidence bar, and
+  the post-1.0 deprecation policy — is drafted for decision in
+  [ADR-0125](docs/adr/0125-v1-stability-contract.md) (Proposed), with the
+  open owner calls in its decisions-required table.
 - **Make changed-policy reload the primary performance program.** The corrected
   700-client × 400,400-route mixed run is now measured: shared cohort work cuts
   median completion p50 116.185x and median completion maximum 149.261x, while

--- a/docs/adr/0125-v1-stability-contract.md
+++ b/docs/adr/0125-v1-stability-contract.md
@@ -1,0 +1,223 @@
+# ADR-0125: v1.0 stability contract
+
+**Status:** Proposed (decision draft for the project owner; nothing freezes until Accepted)
+**Date:** 2026-08-04
+
+## Decisions required
+
+Every owner call embedded in this draft, in one place. Each is expanded in
+the section named in the last column.
+
+| # | Decision | Recommended default | Where |
+|---|----------|---------------------|-------|
+| DR1 | Is at least one external pilot's incorporated feedback a hard tagging gate? | Yes — hard gate. Zero pilots exist today; this is the largest gap. | Evidence bar E1 |
+| DR2 | How many archived soak receipts at RS/RR flagship shapes gate the tag? | Two: the SIGHUP file-reload and max-prefix trip/timed-restart scenarios already scheduled into the authorized soak window, archived at multi-day duration. | Evidence bar E2 |
+| DR3 | Does the tag require a comparative IRR-scale reload row against BIRD and OpenBGPD, or is the existing IXP matrix sufficient? | Require one comparative IRR-scale row; the IXP matrix predates the IRR-scale work and the transactional-apply receipt is single-stack. | Evidence bar E3 |
+| DR4 | RFC 8212 secure-by-default: activate per ADR-0119, or record a decision not to flip the default in 1.0? | Resolve either way before tagging; an undecided default is not a stable contract. | Evidence bar E5 |
+| DR5 | ADR-0122 open items: D2 (unary vs streaming Plan/Apply) and L1 (`--from-file` pledge) | Decide D2 after streaming phase 2; reword the L1 "never" pledge to a scheduled-removal statement before the tag. | Evidence bar E4 |
+| DR6 | Are streaming Plan/Apply, `ListConfigHistory`, and `RollbackConfigTransaction` re-blessed into the frozen inventory at 1.0? | Re-bless only surfaces with a release of production use behind them; otherwise they stay outside and are added in a 1.x minor. | Freeze scope |
+| DR7 | Post-1.0 removal floor for inventoried surface | Deprecations announced in 1.x; removal no earlier than 2.0. | Deprecation policy |
+| DR8 | Supported-versions window after 1.0 (SECURITY.md currently says "0.x") | Latest 1.x minor plus the immediately previous minor (N-1), matching the existing migration-support rule. | Deprecation policy |
+
+## Context
+
+rustbgpd is public alpha. The README and `docs/v1-stable-contract.md` already
+carry a deliberately narrow promise: a machine-pinned route-server /
+route-reflector inventory (`docs/v1-stable-surface.json`, enforced by
+`scripts/check-v1-stable-surface.py` and linked Cargo tests) is stable, and
+everything else may change between minors with a CHANGELOG migration note.
+The ROADMAP states that v1.0 is not on a timeline and that its intended
+contract is narrower than the complete daemon surface.
+
+What does not yet exist is a definition of what *tagging v1.0* would mean:
+which surfaces the tag freezes, what evidence must exist before the tag is
+honest, and what compatibility posture replaces the alpha
+correctness-over-compatibility rule afterward. The project's development rule
+is that every claim has a receipt (`docs/RECEIPTS.md`); a 1.0 tag is the
+largest claim the project can make and deserves the same treatment.
+ADR-0122 (compatibility-debt inventory) supplies the removal schedule and
+lifetime policies this contract builds on.
+
+This ADR defines that contract as a decision draft. It changes no behavior,
+freezes nothing, and sets no date.
+
+## Decision
+
+### What v1.0 freezes
+
+v1.0 promotes the existing machine-pinned inventory — not the whole daemon —
+from a narrow v0.x promise to the project's versioned contract. The frozen
+surface at the tag is exactly `docs/v1-stable-surface.json` as of the tagging
+release, comprising:
+
+- **Config schema for the pinned roles.** The stable
+  `route-server-unicast` and `route-reflector-unicast` roles and the four
+  scoped RR-only roles (BGP-LS, L3VPN, labeled-unicast, RT-Constrain), at
+  field granularity: the inventoried stable fields, types, and the pinned
+  effective defaults, under the existing compatibility rules (additive
+  optional siblings allowed; removal, rename, type, default, required-set,
+  or unknown-field-policy changes are breaking).
+- **The blessed RPC sets.** The inventoried GlobalService, ConfigService,
+  NeighborService, PolicyService, PeerGroupService, RibService, EventService,
+  InjectionService, and ControlService methods, pinned by method name,
+  streaming mode, and top-level request/response signature, plus the scoped
+  RR-only RibService set. Additive fields and new RPCs remain allowed;
+  removed field numbers and names stay reserved.
+- **CLI verbs.** The inventoried stable command paths (path and command name
+  only, per the existing scope rule), the versioned machine formats
+  `rbgp-ribdiff/1` and `rbgp-ribsnap/1`, and the test-pinned JSON floors
+  (neighbor detail, update-group comparison, support-bundle manifest v2).
+- **On-disk formats.** The commit-confirm v3 journal, config-history v2 rows
+  (plus the metadata-only v3 rows if ADR-0124 ships first), and the `.rpol`
+  grammar/decision corpus rule. Reading a prior release's on-disk state is
+  governed by the recovery-reader lifetimes in ADR-0122, not by an unbounded
+  any-version promise.
+- **The upgrade-exercise chain.** The contiguous consecutive-release fixture
+  chain must extend to the v1.0 anchor, using the existing milestone-jump
+  annotation if the release numbering jumps.
+
+Explicitly **not** frozen at v1.0 (today's `explicitly_outside_v1` and alpha
+classifications carry forward):
+
+- Streaming config ingress (`StreamPlanConfigTransaction` /
+  `StreamApplyConfigTransaction`), `ListConfigHistory`, and
+  `RollbackConfigTransaction`, until deliberately re-blessed (DR6).
+- The EVPN/VTEP/IRB alpha surfaces, `linux-dataplane`, BFD, gNMI, FlowSpec
+  and EVPN injection, and the experimental Paths-Limit capability.
+- Bench, soak, and harness internals; human-readable CLI output; metrics and
+  events beyond the existing semantic rules (consumers ignore unknown
+  additive fields and series).
+- The daemon remains free to add roles and surfaces in 1.x minors by adding
+  inventory entries; blessing is always an explicit, reviewed act, never an
+  implication of "shipped".
+
+### The evidence bar for tagging
+
+Each criterion states what it is, its honest current state, and whether it is
+an owner decision or already satisfied. The gap list below restates these as
+a backlog.
+
+**E1 — External pilot feedback incorporated (DR1).** At least one external
+shadow or canary deployment, run per the shipped shadow-pilot cookbook, with
+its differences explained and at least one resulting change (or explicit
+no-change finding) recorded. Current state: zero external pilots; the tooling
+(semantic diff engine, `rbgp diff`, incumbent adapters, cookbook) is complete
+and unused in anger. This is the single largest gap between the receipts
+culture and a 1.0 claim: every existing receipt is self-generated.
+
+**E2 — Soak receipts at flagship RS/RR shapes (DR2).** Archived multi-day
+soaks against the precommitted acceptance gates
+(`docs/soaks/soak-acceptance-gates.md`), at route-server / route-reflector
+shapes. Current state: all archived 24 h soaks are EVPN-shaped; the
+precommitted gates name eight guarantees with no soak injection today, of
+which the SIGHUP file-reload and max-prefix trip/timed-restart scenarios are
+scheduled and the rest deferred. Recommended bar: the two scheduled scenarios
+archived green (or published red with fixes), leaving the deferred six as
+post-1.0 work.
+
+**E3 — Comparative reload evidence at IRR scale (DR3).** The IXP receipt
+matrix (700 clients × 400,400 routes vs BIRD 3.3.1 and OpenBGPD 9.1) exists
+and publishes losses alongside wins. The IRR-scale streamed transactional
+apply receipt (320 members × 183,040 routes, 3.2M filter entries) is
+single-stack. Current state: no same-harness row compares rustbgpd's IRR-scale
+reload against the incumbents. Recommended bar: one comparative IRR-scale
+reload/completion row, losses published if that is the result.
+
+**E4 — Compatibility debt executed (DR5).** The ADR-0122 scheduled removals
+land before the tag: the v0.64 items (frozen v1/v2 commit-confirm recovery
+readers, Paths-Limit raw-cap field) and the v0.65 items (legacy enforcement
+enum variant, `rib diff` older-daemon fallbacks, `AddNeighborRequest` legacy
+carrier, `RouteEvent.event_id` mirror). The two open calls — D2
+(unary vs streaming Plan/Apply) and L1 (the `--from-file` "never" pledge) —
+must be resolved, because both sit on the pinned ConfigService/CLI surface
+this contract freezes. Current state: inventory complete, removals scheduled,
+neither open call decided.
+
+**E5 — RFC 8212 posture resolved either way (DR4).** Opt-in enforcement is
+shipped and receipted (ADR-0112, M95); the config-epoch representation that
+makes a default flip safe is specified but not implemented (ADR-0119,
+Proposed). A 1.0 contract must state the default; "undecided" is not a
+default. Either activate per ADR-0119's proofs or record an explicit decision
+that 1.0 ships opt-in.
+
+**E6 — Security and fuzz posture line items.** Current state, largely
+satisfied: the exact fail-closed 17-target fuzz inventory runs in PR CI with
+the nightly libFuzzer campaign; `cargo audit` runs daily; private
+vulnerability reporting is enabled with a stated response timeline. Remaining
+for the tag: SECURITY.md's supported-versions table gains the 1.x row (DR8),
+and release artifacts keep the documented glibc-floor build discipline.
+
+**E7 — Upgrade chain to the anchor.** Already-working machinery: the tagging
+release extends the consecutive-release fixture chain to the v1.0 anchor and
+`scripts/check-v1-stable-surface.py` stays green. Satisfied by the existing
+release process; listed so the tag cannot skip it.
+
+### Post-1.0 deprecation policy
+
+At the tag, the alpha correctness-over-compatibility posture ends **for the
+frozen inventory only**:
+
+- **Frozen surface:** a deprecation is announced in a 1.x minor with a
+  CHANGELOG entry and migration note, remains functional for the rest of 1.x,
+  and is removed no earlier than 2.0 (DR7). This supersedes, for inventoried
+  surface, the current two-minor / 90-day floor. 2.0 is the contract major
+  the existing rules already require for breaking inventory changes.
+- **Non-inventoried surface:** the ADR-0122 lifetime policies continue
+  unchanged — retired-config-key pointers live three minors, rolling-upgrade
+  fallbacks support N-1, and unlisted surfaces may still change between
+  minors with a migration note. 1.0 does not silently widen the promise.
+- **Migration aids:** upgrade support covers the current and immediately
+  previous minor release, as today; SECURITY.md's supported versions align
+  with the same N-1 window (DR8).
+- New compat retentions keep adding rows to the ADR-0122 inventory in the PR
+  that introduces them; that inventory remains the single ledger post-1.0.
+
+### Gap list
+
+The actionable backlog seed: criterion → current state → what closes it.
+
+| Criterion | Current state | Closes the gap |
+|-----------|---------------|----------------|
+| E1 external pilot | Zero pilots; cookbook + tooling shipped, unused externally | One sanitized external shadow run with explained differences and a rollback record; incorporate resulting feedback |
+| E2 RS/RR soaks | Archived soaks are EVPN-shaped; eight precommitted gates uninjected | Run the two scheduled scenarios (SIGHUP reload, max-prefix trip/timed restart) through the authorized soak window; archive receipts |
+| E3 comparative IRR row | IXP matrix predates IRR scale; IRR receipt single-stack | One same-harness IRR-scale reload row vs BIRD and OpenBGPD, losses published |
+| E4 debt schedule | ADR-0122 removals scheduled (v0.64/v0.65), not landed; D2/L1 open | Land scheduled removal PRs; owner decides D2 and L1 |
+| E5 RFC 8212 | Opt-in shipped; ADR-0119 representation unimplemented | Owner decision; if activating, ADR-0119's production-mutation proofs |
+| E6 security posture | Fuzz/audit/reporting in place | SECURITY.md 1.x supported-versions row; keep artifact build floor |
+| E7 upgrade chain | Chain contiguous through the current anchor | Extend to the v1.0 anchor at tag time (existing process) |
+| DR6 re-bless list | Streaming ingress, history/rollback RPCs outside v1 | Deliberate re-bless review for each, or defer to a 1.x minor |
+
+## Consequences
+
+- "What would 1.0 take?" has one answer with an owner-editable decision
+  table, instead of an unstated bar. The gap list is directly convertible to
+  tracked work.
+- The tag stays honest: it cannot happen before the evidence exists, and the
+  evidence requirements are receipts of kinds the project already produces —
+  except E1, which requires a first external party and is therefore not fully
+  under the project's control. That dependency is explicit rather than
+  hidden.
+- Operators get a stated end to alpha-style breaks for the pinned surface and
+  a stated 2.0 removal floor, without the project promising stability for
+  EVPN, dataplane, or streaming surfaces it is still shaping.
+- The existing machinery (surface checker, upgrade-exercise chain, ADR-0122
+  ledger) becomes the enforcement mechanism of the 1.0 contract rather than
+  a parallel system; no new tooling is required to adopt this ADR.
+- Nothing here schedules the tag. Accepting this ADR fixes the meaning and
+  the bar; the timeline remains evidence-driven.
+
+## References
+
+- [`docs/v1-stable-contract.md`](../v1-stable-contract.md) and
+  [`docs/v1-stable-surface.json`](../v1-stable-surface.json), the pinned
+  inventory and compatibility rules
+- [ADR-0122](0122-compatibility-debt-inventory.md), debt inventory, lifetime
+  policies, and the D2/L1 open calls
+- [ADR-0112](0112-rfc-8212-ebgp-requires-policy.md) /
+  [ADR-0119](0119-rfc-8212-secure-default-config-epoch.md), RFC 8212 posture
+- [ADR-0124](0124-bounded-config-history-retention.md), config-history
+  formats
+- [`docs/RECEIPTS.md`](../RECEIPTS.md) and
+  [`docs/soaks/soak-acceptance-gates.md`](../soaks/soak-acceptance-gates.md),
+  the evidence culture this bar is drawn from
+- `SECURITY.md`, supported versions and reporting posture

--- a/docs/adr/0125-v1-stability-contract.md
+++ b/docs/adr/0125-v1-stability-contract.md
@@ -1,11 +1,11 @@
 # ADR-0125: v1.0 stability contract
 
-**Status:** Proposed (decision draft for the project owner; nothing freezes until Accepted)
+**Status:** Proposed (nothing freezes until Accepted)
 **Date:** 2026-08-04
 
 ## Decisions required
 
-Every owner call embedded in this draft, in one place. Each is expanded in
+Every open decision in this proposal, in one place. Each is expanded in
 the section named in the last column.
 
 | # | Decision | Recommended default | Where |
@@ -94,7 +94,7 @@ classifications carry forward):
 ### The evidence bar for tagging
 
 Each criterion states what it is, its honest current state, and whether it is
-an owner decision or already satisfied. The gap list below restates these as
+an open decision or already satisfied. The gap list below restates these as
 a backlog.
 
 **E1 — External pilot feedback incorporated (DR1).** At least one external
@@ -181,15 +181,15 @@ The actionable backlog seed: criterion → current state → what closes it.
 | E1 external pilot | Zero pilots; cookbook + tooling shipped, unused externally | One sanitized external shadow run with explained differences and a rollback record; incorporate resulting feedback |
 | E2 RS/RR soaks | Archived soaks are EVPN-shaped; eight precommitted gates uninjected | Run the two scheduled scenarios (SIGHUP reload, max-prefix trip/timed restart) through the authorized soak window; archive receipts |
 | E3 comparative IRR row | IXP matrix predates IRR scale; IRR receipt single-stack | One same-harness IRR-scale reload row vs BIRD and OpenBGPD, losses published |
-| E4 debt schedule | ADR-0122 removals scheduled (v0.64/v0.65), not landed; D2/L1 open | Land scheduled removal PRs; owner decides D2 and L1 |
-| E5 RFC 8212 | Opt-in shipped; ADR-0119 representation unimplemented | Owner decision; if activating, ADR-0119's production-mutation proofs |
+| E4 debt schedule | ADR-0122 removals scheduled (v0.64/v0.65), not landed; D2/L1 open | Land scheduled removal PRs; decide D2 and L1 |
+| E5 RFC 8212 | Opt-in shipped; ADR-0119 representation unimplemented | Open decision; if activating, ADR-0119's production-mutation proofs |
 | E6 security posture | Fuzz/audit/reporting in place | SECURITY.md 1.x supported-versions row; keep artifact build floor |
 | E7 upgrade chain | Chain contiguous through the current anchor | Extend to the v1.0 anchor at tag time (existing process) |
 | DR6 re-bless list | Streaming ingress, history/rollback RPCs outside v1 | Deliberate re-bless review for each, or defer to a 1.x minor |
 
 ## Consequences
 
-- "What would 1.0 take?" has one answer with an owner-editable decision
+- "What would 1.0 take?" has one answer with an explicit decision
   table, instead of an unstated bar. The gap list is directly convertible to
   tracked work.
 - The tag stays honest: it cannot happen before the evidence exists, and the

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -133,6 +133,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0122](0122-compatibility-debt-inventory.md) | Compatibility-debt inventory and removal schedule | Proposed | 2026-08-03 |
 | [0123](0123-aspa-v27-mitigation-and-retention.md) | ASPA draft-v27 mitigation requires lossless retention | Proposed (behavior activation NO-GO until retention gates pass) | 2026-08-03 |
 | [0124](0124-bounded-config-history-retention.md) | Bounded config-history retention for oversized snapshots | Proposed (owner decisions recorded; implementation pending) | 2026-08-04 |
+| [0125](0125-v1-stability-contract.md) | v1.0 stability contract | Proposed (decision draft for the project owner; nothing freezes until Accepted) | 2026-08-04 |
 
 ## Template
 


### PR DESCRIPTION
## Summary

ADR-0125 (**Proposed**) defines what tagging v1.0 would mean:

- **Freeze scope**: exactly the machine-pinned `docs/v1-stable-surface.json` inventory at the tagging release — config schema for the RS/RR roles, the blessed nine-service RPC sets, the inventoried CLI verbs and machine formats, the commit-confirm v3 / config-history v2 on-disk formats, and the upgrade-exercise chain. Streaming ingress, history/rollback RPCs, EVPN/VTEP alpha, dataplane, and bench/harness internals stay explicitly outside.
- **Evidence bar** (E1–E7): each criterion with its honest current state.
- **Post-1.0 deprecation policy**: deprecate in 1.x, remove no earlier than 2.0 for inventoried surface; ADR-0122 lifetime policies continue unchanged for everything else.
- **Gap list**: the actionable backlog seed.

One ROADMAP line points at the draft from the stabilization section.

## Decisions required (collected at the top of the ADR)

| # | Decision | Recommended default |
|---|----------|---------------------|
| DR1 | Is one external pilot's incorporated feedback a hard tagging gate? | Yes — zero pilots today; largest gap |
| DR2 | How many archived RS/RR-shape soak receipts gate the tag? | The two already-scheduled scenarios (SIGHUP reload, max-prefix trip/timed restart), multi-day |
| DR3 | Comparative IRR-scale reload row vs BIRD/OpenBGPD required, or is the IXP matrix enough? | Require one comparative IRR-scale row |
| DR4 | RFC 8212 secure-by-default: activate per ADR-0119 or record an explicit opt-in-for-1.0 decision | Resolve either way before tagging |
| DR5 | ADR-0122 open items D2 (unary vs streaming Plan/Apply) and L1 (`--from-file` pledge) | Decide D2 after streaming phase 2; reword L1's "never" before the tag |
| DR6 | Re-bless streaming Plan/Apply, `ListConfigHistory`, `RollbackConfigTransaction` at 1.0? | Only surfaces with a release of production use; otherwise add in a 1.x minor |
| DR7 | Post-1.0 removal floor for inventoried surface | Deprecate in 1.x, remove no earlier than 2.0 |
| DR8 | Supported-versions window after 1.0 | Latest 1.x minor + previous (N-1) |

## Gates

- `cargo test --workspace`: rc 0 (96 suites, 0 failures)
- `python3 scripts/check-v1-stable-surface.py`: rc 0 (surface file unchanged)
- `git diff --check`: rc 0
- pre-push `cargo doc`: passed