### PR TITLE
Complete grouped export-policy transitions without session teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Grouped export-policy reloads no longer wedge at IRR scale (LAN-886). The
+  update-group classifier rendered each member's whole policy chain into a
+  planning-fingerprint string — tens of megabytes per rendering for an
+  IRR-scale member policy — once per member in the fenced Classify and
+  Validate phases, so a 320-member SIGHUP reload fenced the RIB actor for the
+  entire observation window with zero wire output and only completed
+  (`fallback_handoff`) after session teardown closed an outbound channel.
+  Runtime classification now skips the rendering entirely (group identity is
+  the interned chain content); the observational snapshot and planning
+  surfaces keep their chain-content dimension through a cached streaming
+  digest (`PolicyChain::groupability_fingerprint`) instead of the full
+  rendering. Session registration paid the same per-peer rendering cost, so
+  large-fleet convergence drops it too. Additionally, pre-commit transition
+  phases now carry a 60 s aggregate ownership budget (twice the 30 s
+  readiness stall bound): a transition still short of `CommitMembers` at
+  that age hands the cohort to the authoritative per-peer path fail-closed
+  instead of fencing the actor until an invalidation event — previously
+  nothing could trigger the fallback while sessions stayed healthy. Transition phase entries and per-member probe
+  decisions are now logged at debug level.
+
 ## [0.63.0] — 2026-08-04
 
 ### Added

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -1256,6 +1256,12 @@ pub struct PolicyChain {
     /// from zero — stats read as "since this chain instance was
     /// installed".
     hits: OnceLock<Arc<PolicyHitCounters>>,
+    /// Lazily-computed content fingerprint for update-group planning
+    /// identity ([`groupability_fingerprint`](Self::groupability_fingerprint)).
+    /// Derived state like `compiled` (excluded from
+    /// `PartialEq`/`Clone`/`Debug`); fresh on `Clone`, carried by
+    /// [`share`](Self::share).
+    fingerprint: OnceLock<Arc<str>>,
 }
 
 impl Clone for PolicyChain {
@@ -1268,6 +1274,7 @@ impl Clone for PolicyChain {
             policies: self.policies.clone(),
             compiled: OnceLock::new(),
             hits: OnceLock::new(),
+            fingerprint: OnceLock::new(),
         }
     }
 }
@@ -1314,6 +1321,44 @@ pub fn is_rfc8212_reserved_policy_name(name: &str) -> bool {
 }
 
 impl PolicyChain {
+    /// Process-local content fingerprint for update-group planning identity.
+    ///
+    /// Equal for content-equal chains (`PartialEq` on `policies`), and
+    /// computed by streaming the chain's Debug rendering through a hasher —
+    /// never materializing it. That matters at IRR scale, where the rendering
+    /// of one member policy is tens of megabytes: `format!("{chain:?}")` as a
+    /// planning identity took ~1 s per call and, called once per member per
+    /// fenced classification pass, wedged grouped export-policy reloads for
+    /// the whole fleet-observation window (LAN-886). Cached per instance
+    /// like `compiled` (fresh on `Clone`, carried by [`share`](Self::share)).
+    ///
+    /// Identity is process-local diagnostics (live-vs-candidate planning
+    /// comparisons inside one daemon): the 128-bit digest is not stable
+    /// across releases and must not be persisted.
+    #[must_use]
+    pub fn groupability_fingerprint(&self) -> Arc<str> {
+        Arc::clone(self.fingerprint.get_or_init(|| {
+            use std::hash::Hasher as _;
+
+            struct HashWriter(std::collections::hash_map::DefaultHasher);
+            impl fmt::Write for HashWriter {
+                fn write_str(&mut self, fragment: &str) -> fmt::Result {
+                    self.0.write(fragment.as_bytes());
+                    Ok(())
+                }
+            }
+
+            let mut low = HashWriter(std::collections::hash_map::DefaultHasher::new());
+            let mut high = HashWriter(std::collections::hash_map::DefaultHasher::new());
+            high.0.write_u8(1);
+            for writer in [&mut low, &mut high] {
+                // `HashWriter::write_str` is infallible, so this cannot fail.
+                let _ = fmt::write(writer, format_args!("{:?}", self.policies));
+            }
+            Arc::from(format!("{:016x}{:016x}", high.0.finish(), low.0.finish()))
+        }))
+    }
+
     /// Stable origin label for update-group planning diagnostics.
     #[must_use]
     pub fn groupability_provenance(&self) -> &'static str {
@@ -1334,6 +1379,7 @@ impl PolicyChain {
             policies: policies.into_iter().map(NamedPolicy::from).collect(),
             compiled: OnceLock::new(),
             hits: OnceLock::new(),
+            fingerprint: OnceLock::new(),
         }
     }
 
@@ -1344,6 +1390,7 @@ impl PolicyChain {
             policies,
             compiled: OnceLock::new(),
             hits: OnceLock::new(),
+            fingerprint: OnceLock::new(),
         }
     }
 
@@ -1383,6 +1430,11 @@ impl PolicyChain {
                 .map(Arc::clone)
                 .map_or_else(OnceLock::new, OnceLock::from),
             hits: OnceLock::from(hits),
+            fingerprint: self
+                .fingerprint
+                .get()
+                .map(Arc::clone)
+                .map_or_else(OnceLock::new, OnceLock::from),
         }
     }
 

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -318,7 +318,7 @@ enum CleanPolicyTransitionPhase {
         cursor: usize,
         probe_cache: SharedUnicastProbeCache,
         prepared: Vec<PreparedCleanPolicyTransitionPeer>,
-        active_probe: Option<CleanPolicyTransitionProbe>,
+        active_probe: Option<Box<CleanPolicyTransitionProbe>>,
         full_probe_count: usize,
     },
     Validate {
@@ -1232,6 +1232,27 @@ impl RibManager {
             .phase
             .take()
             .expect("pending clean transition always owns one phase");
+        // Fail closed while sessions are healthy (LAN-886): every other
+        // pre-commit fallback trigger is an invalidation event (session or
+        // channel loss, table drift), so without a time budget a
+        // slow-but-healthy transition fences the actor — and therefore all
+        // wire output — until teardown finally invalidates it. Pre-commit
+        // phases mutate nothing externally visible, so handing the cohort to
+        // the authoritative per-peer path here is safe; `CommitMembers` is
+        // exempt because its first batch may already be on a member's wire.
+        if !matches!(phase, CleanPolicyTransitionPhase::CommitMembers { .. })
+            && pending.elapsed() >= super::MAX_PRECOMMIT_POLICY_TRANSITION_OWNERSHIP
+        {
+            warn!(
+                member_count = pending.member_count(),
+                elapsed_ms = u64::try_from(pending.elapsed().as_millis()).unwrap_or(u64::MAX),
+                "clean export-policy transition exceeded its pre-commit ownership budget; \
+                 handing the cohort to the authoritative per-peer path"
+            );
+            // Dropping the phase releases any reserved outbound permits.
+            drop(phase);
+            return CleanPolicyTransitionAdvance::Fallback(pending);
+        }
         match phase {
             CleanPolicyTransitionPhase::Classify {
                 mut cursor,
@@ -1327,6 +1348,13 @@ impl RibManager {
                                 // exactly like one it created itself.
                                 pending.created_destination = Some(destination);
                             }
+                            debug!(
+                                destination,
+                                maintained = true,
+                                elapsed_ms = u64::try_from(pending.elapsed().as_millis())
+                                    .unwrap_or(u64::MAX),
+                                "clean policy transition entering BuildInventory"
+                            );
                             pending.phase = Some(CleanPolicyTransitionPhase::BuildInventory {
                                 source,
                                 destination,
@@ -1381,6 +1409,13 @@ impl RibManager {
                         memo,
                     });
                 } else {
+                    debug!(
+                        destination,
+                        maintained = false,
+                        elapsed_ms =
+                            u64::try_from(pending.elapsed().as_millis()).unwrap_or(u64::MAX),
+                        "clean policy transition entering BuildInventory"
+                    );
                     pending.phase = Some(CleanPolicyTransitionPhase::BuildInventory {
                         source,
                         destination,
@@ -1461,10 +1496,17 @@ impl RibManager {
                         inventory,
                     });
                 } else {
+                    let inventory = inventory.finish();
+                    debug!(
+                        announce_len = inventory.announce.len(),
+                        elapsed_ms =
+                            u64::try_from(pending.elapsed().as_millis()).unwrap_or(u64::MAX),
+                        "clean policy transition entering ProbeAndPrepare"
+                    );
                     pending.phase = Some(CleanPolicyTransitionPhase::ProbeAndPrepare {
                         source,
                         destination,
-                        inventory: inventory.finish(),
+                        inventory,
                         cursor: 0,
                         probe_cache: SharedUnicastProbeCache::default(),
                         prepared: Vec::with_capacity(pending.replacements.len()),
@@ -1582,12 +1624,22 @@ impl RibManager {
                             if snapshot.owner_id() != encoder.owner_id() {
                                 return CleanPolicyTransitionAdvance::Fallback(pending);
                             }
-                            if let Some(maximum) = probe_cache.reuse_grouped_exact_export_maximum(
+                            let reuse = probe_cache.reuse_grouped_exact_export_maximum(
                                 destination,
                                 &inventory.announce,
                                 &inventory.next_hop_override,
                                 snapshot.as_ref(),
-                            ) {
+                            );
+                            debug!(
+                                %peer,
+                                reused = reuse.is_some(),
+                                cursor,
+                                full_probe_count,
+                                elapsed_ms =
+                                    u64::try_from(pending.elapsed().as_millis()).unwrap_or(u64::MAX),
+                                "clean policy transition member probe decision"
+                            );
+                            if let Some(maximum) = reuse {
                                 if maximum.is_err() {
                                     return CleanPolicyTransitionAdvance::Fallback(pending);
                                 }
@@ -1601,7 +1653,7 @@ impl RibManager {
                                 });
                                 cursor += 1;
                             } else {
-                                active_probe = Some(CleanPolicyTransitionProbe {
+                                active_probe = Some(Box::new(CleanPolicyTransitionProbe {
                                     peer,
                                     session_id,
                                     export_policy,
@@ -1610,7 +1662,7 @@ impl RibManager {
                                     permit,
                                     cursor: 0,
                                     encoded_lengths: Vec::with_capacity(inventory.announce.len()),
-                                });
+                                }));
                             }
                         }
                     }
@@ -1623,6 +1675,12 @@ impl RibManager {
                 }
 
                 if cursor == pending.replacements.len() && active_probe.is_none() {
+                    debug!(
+                        full_probe_count,
+                        elapsed_ms =
+                            u64::try_from(pending.elapsed().as_millis()).unwrap_or(u64::MAX),
+                        "clean policy transition entering Validate"
+                    );
                     pending.phase = Some(CleanPolicyTransitionPhase::Validate {
                         source,
                         destination,
@@ -1680,6 +1738,10 @@ impl RibManager {
                 if !all_current {
                     return CleanPolicyTransitionAdvance::Fallback(pending);
                 }
+                debug!(
+                    elapsed_ms = u64::try_from(pending.elapsed().as_millis()).unwrap_or(u64::MAX),
+                    "clean policy transition entering CommitMembers"
+                );
                 pending.phase = Some(CleanPolicyTransitionPhase::CommitMembers {
                     source,
                     destination,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -624,7 +624,20 @@ const SLOW_POLICY_TRANSITION: std::time::Duration = std::time::Duration::from_se
 
 /// Readiness stays live during bounded transition progress, but fails closed
 /// once ownership is far beyond any legitimate transition receipt.
-const MAX_HEALTHY_POLICY_TRANSITION_AGE: std::time::Duration = std::time::Duration::from_secs(30);
+pub(in crate::manager) const MAX_HEALTHY_POLICY_TRANSITION_AGE: std::time::Duration =
+    std::time::Duration::from_secs(30);
+
+/// Aggregate pre-commit ownership budget for one clean policy transition:
+/// still short of `CommitMembers` at this age, the transition hands the
+/// cohort to the authoritative per-peer path fail-closed (LAN-886 — before
+/// this budget existed, every pre-commit fallback trigger was an
+/// invalidation event, so a slow-but-healthy transition fenced the actor
+/// and all wire output until session teardown finally closed an outbound
+/// channel). Twice the readiness bound by construction: the stalled
+/// readiness verdict at [`MAX_HEALTHY_POLICY_TRANSITION_AGE`] is the early
+/// warning, this handoff is the remedy.
+pub(in crate::manager) const MAX_PRECOMMIT_POLICY_TRANSITION_OWNERSHIP: std::time::Duration =
+    MAX_HEALTHY_POLICY_TRANSITION_AGE.saturating_mul(2);
 
 /// Registration material for one live transport session of a peer
 /// address, captured at `PeerUp`. Held in `RibManager::live_sessions` so

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -4597,6 +4597,177 @@ async fn commit_flush_never_falls_back_after_first_emission() {
     assert_eq!(manager.grouped_member_of(peers[9]), Some(destination));
 }
 
+/// The observational snapshot surface keeps its chain-content dimension
+/// (planning comparisons diff live rows against candidate rows on it),
+/// while runtime classification skips the rendering entirely (LAN-886).
+/// The digest must agree across distinct instances of content-equal
+/// chains and differ across different chain content.
+#[tokio::test]
+async fn snapshot_rows_carry_content_stable_policy_fingerprints() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let shared = community_chain(0xFDE8_2114);
+    let distinct = community_chain(0xFDE8_2115);
+    let chains = [shared.clone(), shared.clone(), distinct.clone()];
+    let mut peers = Vec::new();
+    for (index, chain) in chains.into_iter().enumerate() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 44, 0, u8::try_from(index + 1).unwrap()));
+        peers.push(peer);
+        let (outbound_tx, _outbound_rx) = mpsc::channel(8);
+        manager.handle_update(RibUpdate::PeerUp {
+            peer,
+            session_id: 0,
+            peer_asn: 65_000,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            outbound_tx,
+            export_policy: Some(chain),
+            sendable_families: ipv4_sendable(),
+            is_ebgp: false,
+            route_reflector_client: true,
+            orr_vantage: None,
+            per_client_best: false,
+            interpret_rfc1997: true,
+            add_path_send_families: vec![],
+            add_path_send_max: 0,
+            negotiated_orf_recv: vec![],
+            negotiated_llgr_families: vec![],
+        });
+    }
+    let (reply, response) = oneshot::channel();
+    manager.handle_query_update_group_snapshot(reply);
+    let snapshot = response.await.unwrap();
+    let fingerprint_of = |peer: IpAddr| {
+        snapshot
+            .peers
+            .iter()
+            .find(|row| row.peer == peer)
+            .expect("snapshot row per registered peer")
+            .input
+            .policy_fingerprint
+            .clone()
+            .expect("snapshot rows carry the planning fingerprint")
+    };
+    assert_eq!(
+        fingerprint_of(peers[0]),
+        fingerprint_of(peers[1]),
+        "content-equal chain instances share one planning fingerprint"
+    );
+    assert_ne!(
+        fingerprint_of(peers[0]),
+        fingerprint_of(peers[2]),
+        "different chain content yields a different planning fingerprint"
+    );
+}
+
+/// LAN-886: a transition whose PRE-COMMIT phases outlive the ownership
+/// budget must hand the cohort back fail-closed while every session is
+/// still healthy. Before the budget existed, every pre-commit fallback
+/// trigger was an invalidation event (session/channel loss, table drift),
+/// so a slow-but-healthy transition fenced the actor — and all wire
+/// output — until session teardown finally invalidated it: the grouped
+/// IRR-scale reload wedged for the entire 600 s observation window and
+/// completed `fallback_handoff` one second AFTER teardown. On the
+/// pre-budget logic this test fails at the poll below with `continue`.
+#[tokio::test(start_paused = true)]
+async fn healthy_transition_past_precommit_budget_hands_off_fail_closed() {
+    use crate::manager::distribution::CleanPolicyTransitionAdvance;
+    const MEMBER_COUNT: usize = 4;
+    const ROUTE_COUNT: usize = 3;
+    let (mut manager, peers, mut receivers) =
+        direct_clean_transition_manager(MEMBER_COUNT, ROUTE_COUNT, None);
+    let next_policy = community_chain(0xFDE8_2112);
+    let mut response = start_clean_transition(&mut manager, &peers, &next_policy);
+    let source = manager.grouped_member_of(peers[0]).expect("grouped");
+
+    // Healthy pre-commit progress first: classification completes.
+    let (kind, outcome) = step_parked_transition(&mut manager);
+    assert_eq!((kind, outcome), ("bounded", "continue"));
+
+    // The fenced pre-commit work outlives the ownership budget (paused
+    // time models the LAN-886 shape, where per-member classification cost
+    // stretched the phases past any healthy observation window).
+    tokio::time::advance(super::super::MAX_PRECOMMIT_POLICY_TRANSITION_OWNERSHIP).await;
+
+    let pending = manager
+        .pending_clean_policy_transition
+        .take()
+        .expect("transition still owned");
+    match manager.advance_clean_policy_transition(pending) {
+        CleanPolicyTransitionAdvance::Fallback(mut failed) => {
+            failed
+                .discard_uncommitted_transition(&mut manager)
+                .expect("fallback cleanup succeeds");
+            // Mirror the run loop's fallback arm: the caller receives the
+            // authoritative per-peer handoff.
+            let reply = failed.take_reply().expect("fallback owns the caller reply");
+            reply
+                .send(Ok(
+                    crate::update::ExportPolicyCohortOutcome::RequiresAuthoritativePerPeerApply,
+                ))
+                .expect("caller awaits the handoff");
+        }
+        CleanPolicyTransitionAdvance::Continue(_) => {
+            panic!("healthy transition past its pre-commit budget must hand off, not continue")
+        }
+        CleanPolicyTransitionAdvance::Committed(_) => {
+            panic!("healthy transition past its pre-commit budget must hand off, not commit")
+        }
+    }
+    assert_eq!(
+        response.try_recv().unwrap(),
+        Ok(crate::update::ExportPolicyCohortOutcome::RequiresAuthoritativePerPeerApply)
+    );
+    // Fail-closed: nothing externally visible happened — no envelope
+    // reached any member and every membership is unchanged.
+    for receiver in &mut receivers {
+        assert!(receiver.try_recv().is_err());
+    }
+    for &peer in &peers {
+        assert_eq!(manager.grouped_member_of(peer), Some(source));
+    }
+}
+
+/// The pre-commit budget must never abort `CommitMembers`: once the first
+/// batch has emitted, an over-budget transition still runs to `Committed`
+/// (an envelope may already be on a member's wire — the phase-level
+/// invariant of ADR-0105 §3.6).
+#[tokio::test(start_paused = true)]
+async fn over_budget_commit_flush_still_completes() {
+    const MEMBER_COUNT: usize = 2 * super::super::COMMIT_MEMBERS_PER_POLL + 1;
+    const ROUTE_COUNT: usize = 2;
+    let (mut manager, peers, _receivers) =
+        direct_clean_transition_manager(MEMBER_COUNT, ROUTE_COUNT, None);
+    let next_policy = community_chain(0xFDE8_2113);
+    let mut response = start_clean_transition(&mut manager, &peers, &next_policy);
+
+    // Drive to the first parked commit poll (first batch already emitted).
+    loop {
+        let (kind, outcome) = step_parked_transition(&mut manager);
+        assert_eq!(outcome, "continue", "{kind} poll must park mid-transition");
+        if kind == "commit" {
+            break;
+        }
+    }
+    tokio::time::advance(super::super::MAX_PRECOMMIT_POLICY_TRANSITION_OWNERSHIP).await;
+    loop {
+        let (kind, outcome) = step_parked_transition(&mut manager);
+        assert_eq!(kind, "commit");
+        match outcome {
+            "committed" => break,
+            "continue" => {}
+            other => panic!("over-budget commit flush must complete, not {other}"),
+        }
+    }
+    assert_eq!(
+        response.try_recv().unwrap(),
+        Ok(crate::update::ExportPolicyCohortOutcome::Committed)
+    );
+    let destination = manager.grouped_member_of(peers[0]).expect("grouped");
+    for &peer in &peers {
+        assert_eq!(manager.grouped_member_of(peer), Some(destination));
+    }
+}
+
 /// Fence integrity across the batched flush: a primary route update and a
 /// second cohort enqueued behind an owned transition are processed only
 /// after its terminal commit, in order — every member observes

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -3084,6 +3084,7 @@ impl RibManager {
             peer,
             chain,
             orf_negotiated || self.peer_orf_filters.contains_key(&peer),
+            false,
         );
         let fingerprint = match classify_update_group(input) {
             UpdateGroupClassification::PolicyPeerContext => {
@@ -3232,11 +3233,22 @@ impl RibManager {
         self.refresh_group_residue_gauge();
     }
 
+    /// Build the classifier input for one peer.
+    ///
+    /// `with_policy_fingerprint` gates the O(chain-size) planning-identity
+    /// digest: runtime classification (registration, policy edits, the
+    /// fenced clean-transition phases) passes `false` because runtime group
+    /// identity is the interned chain content, not the fingerprint — at IRR
+    /// scale rendering the fingerprint per member wedged grouped reloads for
+    /// the whole observation window (LAN-886). The observational snapshot
+    /// surface passes `true` so live-vs-candidate planning comparisons keep
+    /// their chain-content dimension.
     fn update_group_classifier_input(
         &self,
         peer: IpAddr,
         chain: Option<&PolicyChain>,
         orf_installed: bool,
+        with_policy_fingerprint: bool,
     ) -> UpdateGroupClassifierInput {
         let sendable = self.peer_sendable_families.get(&peer);
         let mut sendable_families = sendable
@@ -3256,7 +3268,9 @@ impl RibManager {
         llgr_families.sort_unstable();
         llgr_families.dedup();
         UpdateGroupClassifierInput {
-            policy_fingerprint: chain.map(|value| format!("{value:?}")),
+            policy_fingerprint: with_policy_fingerprint
+                .then(|| chain.map(|value| value.groupability_fingerprint().to_string()))
+                .flatten(),
             policy_provenance: chain.map(|value| value.groupability_provenance().to_string()),
             policy_requires_peer_context: chain.is_some_and(PolicyChain::requires_peer_context),
             target_is_ebgp: self.peer_is_ebgp.get(&peer).copied().unwrap_or(false),
@@ -3309,6 +3323,7 @@ impl RibManager {
                     peer,
                     chain,
                     orf_negotiated || self.peer_orf_filters.contains_key(&peer),
+                    true,
                 );
                 UpdateGroupPeerSnapshot {
                     peer,

--- a/docs/adr/0105-grouped-export-policy-transition.md
+++ b/docs/adr/0105-grouped-export-policy-transition.md
@@ -2,6 +2,18 @@
 
 **Status:** Accepted
 **Date:** 2026-07-14
+**Amended:** 2026-08-04 (LAN-886) — pre-commit phases carry a 60-second
+aggregate ownership budget (twice the 30-second readiness stall bound): a
+transition still short of `CommitMembers` at that age hands the cohort to
+the authoritative per-peer path fail-closed, because every other pre-commit
+fallback trigger is an invalidation event and a slow-but-healthy transition
+otherwise fences the actor indefinitely. The stalled readiness verdict is
+the early warning; this handoff is the remedy. `CommitMembers` remains
+exempt (first emission bars fallback). The same incident removed the per-member policy
+fingerprint rendering from runtime classification: group identity is the
+interned chain content, and the rendering — O(chain size) per member, tens
+of megabytes at IRR scale — was consumed only by the observational
+snapshot/planning surfaces, which now use a cached streaming digest.
 
 ## Context
 

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1039,7 +1039,7 @@ export_policy_chain = ["dataset-export"]
         .expect("export chain resolved");
     assert!(policy.references_dataset("customers"));
     let live_input = rustbgpd_rib::UpdateGroupClassifierInput {
-        policy_fingerprint: Some(format!("{policy:?}")),
+        policy_fingerprint: Some(policy.groupability_fingerprint().to_string()),
         policy_provenance: Some(policy.groupability_provenance().to_string()),
         policy_requires_peer_context: policy.requires_peer_context(),
         target_is_ebgp: true,

--- a/src/peer_manager/update_group_plan.rs
+++ b/src/peer_manager/update_group_plan.rs
@@ -55,7 +55,10 @@ fn candidate_input(
 ) -> UpdateGroupClassifierInput {
     let policy = candidate.export_policy.as_ref();
     UpdateGroupClassifierInput {
-        policy_fingerprint: policy.map(|chain| format!("{chain:?}")),
+        // Same planning-identity digest the RIB snapshot rows carry —
+        // live-vs-candidate comparisons only match when both sides render
+        // chain content through `groupability_fingerprint` (LAN-886).
+        policy_fingerprint: policy.map(|chain| chain.groupability_fingerprint().to_string()),
         policy_provenance: policy.map(|chain| chain.groupability_provenance().to_string()),
         policy_requires_peer_context: policy.is_some_and(PolicyChain::requires_peer_context),
         target_is_ebgp: candidate.transport_config.peer.remote_asn != local_asn,


### PR DESCRIPTION
Fixes the LAN-886 grouped export-policy reload wedge from the 2026-08-04
quiet-window campaign (`ef958c10`, grouped-A root: 0/320 observers for the
whole 600 s window, `fallback_handoff` at `elapsed_ms=598378` — one second
after session teardown).

## Causal chain

1. SIGHUP → policy snapshot resolves (1.3 s, healthy) → the peer manager
   selects all 320 members as one export-only cohort → the RIB accepts
   `ReplacePeerExportPolicies` and the clean-transition fence takes the
   actor (ADR-0105: all mutations and general queries queue; emission
   starts only in `CommitMembers`).
2. `Classify` calls `clean_policy_transition_destination` per member, which
   builds an `UpdateGroupClassifierInput` whose `policy_fingerprint` was
   `format!("{chain:?}")` — a Debug rendering of the member's entire policy
   chain. The IRR member policy renders to ~65 MB (3.2 M set entries):
   ~0.9 s and a 65 MB allocation per member, ~300 s for 320 members.
3. `Validate` repeats the identical per-member call (session revalidation),
   in a single unbounded actor poll — another ~300 s. Total ≈ 600 s of
   fenced CPU with zero wire output, and the rendered string is then
   discarded: runtime group identity is the interned chain content
   (`GroupKey.chain`), never the string.
4. Every pre-commit fallback trigger was an invalidation event (session or
   channel loss, encoder owner mismatch, table drift, rs-control tag). No
   time-based trigger existed, so the designed fallback could effectively
   never fire while sessions were healthy. Harness teardown at 600 s closed
   the outbound channels; the next per-member step hit a dead session →
   `Fallback` → `completed outcome=fallback_handoff` one second later.
   Exactly the sealed daemon.log timeline.
5. Per-client mode is unaffected because members are
   `GroupMembership::PerClientBest`: the first membership lookup in
   `Classify` returns non-`Grouped` before any classifier input is built →
   fallback at `elapsed_ms=0` (the sealed comparison-A log shows exactly
   that, 4×) → the authoritative per-peer path, which works.

Instrumented reproduction on this branch (320 members × 18,240 routes,
lists 200–1000 — same mechanism, smaller chain): entering BuildInventory at
13,948 ms (Classify), ProbeAndPrepare 13,957→13,961 ms (one full probe walk,
319 cohort reuses — probe sharing is not the problem), Validate
13,961→28,658 ms (single poll), committed 28,659 ms. The identical run at
10×1k commits in 16 ms. Scaling the per-member rendering to the 65 MB
campaign chain reproduces the ~600 s wedge arithmetically (640 renderings ×
~0.9 s).

## Fix

- Runtime classification no longer renders the fingerprint at all
  (`update_group_classifier_input(.., with_policy_fingerprint: false)`).
  This covers the fenced `Classify`/`Validate` phases and every other
  runtime classification (PeerUp registration, regroup, slow-peer
  recompute) — session registration paid the same per-peer rendering cost,
  so large-fleet convergence sheds it too.
- The observational surfaces (update-group snapshot query, config-plan
  candidate side) keep their chain-content dimension through
  `PolicyChain::groupability_fingerprint()`: a 128-bit streaming digest of
  the same rendering (never materialized), `OnceLock`-cached per instance,
  carried by `share()`, fresh on `Clone`. Both sides of the live-vs-candidate
  planning comparison use the same digest, so plan diffs keep matching.
- Pre-commit transition phases now carry a 60 s aggregate ownership budget
  (`MAX_PRECOMMIT_POLICY_TRANSITION_OWNERSHIP`, twice the 30 s readiness
  stall bound — the stalled readiness verdict is the early warning, the
  handoff is the remedy): a transition still short of `CommitMembers` at
  that age hands the
  cohort to the authoritative per-peer path fail-closed — permits released,
  unowned destination discarded, nothing externally visible mutated —
  instead of fencing the actor until an invalidation event. `CommitMembers`
  is exempt (first emission bars fallback, per the ADR-0105 §3.6 invariant).
- Transition phase entries and per-member probe decisions now log at debug
  level (the sealed log had a single WARN in 598 s).

ADR-0105 amended accordingly.

## Red proof

`healthy_transition_past_precommit_budget_hands_off_fail_closed`
(paused-time, deterministic): healthy grouped transition, advance past the
ownership budget, next poll must hand off fail-closed with
`RequiresAuthoritativePerPeerApply`, no envelope delivered, memberships
unchanged. With the budget check reverted (pre-fix logic):

```
thread '...healthy_transition_past_precommit_budget_hands_off_fail_closed' panicked:
healthy transition past its pre-commit budget must hand off, not continue
test result: FAILED. 0 passed; 1 failed
```

Restored: passes. `over_budget_commit_flush_still_completes` pins the
CommitMembers exemption; `snapshot_rows_carry_content_stable_policy_fingerprints`
pins the observational digest contract (equal content ⇒ equal digest across
instances; different content ⇒ different digest).

## Live verification (grouped control cell, this branch)

320 members × 18,240 prefixes, `per_client_best=false`, SIGHUP reload:

| binary | transition | cell verdict |
|---|---|---|
| pre-fix (instrumented base) | committed at 28,659 ms (Classify 13.9 s + Validate 14.7 s) | — |
| with fix | committed at **17 ms** | PASS rc=0 — completion p50 0.576 s, 320/320 observers, first re-adv p50 529 ms, 0 parse errors |

And at the exact failed-campaign shape (320 members × 183,040 prefixes,
3,218,965 filter-list entries, 65 MB member.rpol, grouped, SIGHUP gen-b
swap; freshly generated scenario, same generator/contract as the sealed
grouped-A root):

- transition: `completed outcome=committed member_count=320 elapsed_ms=160`
  (Classify+staging 1 ms, inventory 119 ms, probe 32 ms with one full walk +
  319 cohort reuses, Validate 2 ms, commit 7 ms) — the sealed campaign run
  wedged here for 598,378 ms and never emitted.
- harness: PASS rc=0 — completion p50 1.75 s / max 1.82 s, 320/320
  observers, unique 182,468/182,468, first re-adv p50 1.62 s, 0 parse
  errors. (The sealed per-client comparison cell completed the same
  reload in ~230 s p50; the sealed grouped cell completed never.)
- whole cell, boot → converged → reload → sealed: 70 s wall. PeerUp
  registration classification paid the same per-member rendering, so
  initial convergence at this shape drops from ~400 s to well under a
  minute as a side effect.

## Seam expansion

- PeerUp/regroup/slow-peer classification: same defect, same call path —
  covered by the same fix (fingerprint no longer rendered at runtime).
- Update-group snapshot query (`QueryUpdateGroupSnapshot`, used by config
  transaction plans and `rbgp` planning): rendered the same string per
  registered peer inside the actor — now the cached digest.
- Ordinary grouped emission (`SharedGroupEncode`/probe cohort reuse) is NOT
  affected: the repro shows one full probe walk + 319 reuses working as
  designed.
- `DestinationPrestage` (unfenced pre-staging) is a different mechanism:
  best-effort, advances only when no mutation traffic is queued, and the
  campaign log shows it completing in ~1.3 s. Its peer-manager await is
  unbounded, but starvation requires saturating back-to-back mutations and
  does not fence the actor; left as-is, noted here deliberately.
- Other transition-like waits (GR/LLGR/refresh timers, member join/leave
  replay) do not share the fallback-only-on-invalidation pattern.

## Gates

| gate | rc |
|---|---|
| cargo fmt --all -- --check | 0 |
| cargo clippy --workspace --all-targets -- -D warnings | 0 |
| cargo test --workspace | 0 |
| cargo doc | 0 |
| python3 scripts/check-clippy-reasons.py | 0 |
| cargo check -p rustbgpd-rib --features bench-internals --benches | 0 |
