### PR TITLE
Exclude post-generation-start routes from BMP Loc-RIB dump content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- BMP Loc-RIB dumps no longer emit routes admitted after the collector's
+  connection generation started (LAN-885). The dump walk read the live
+  Loc-RIB per chunk, so a route installed mid-dump at a key ahead of the
+  cursor was emitted as dump content — a post-generation-start update on
+  the wire before the dump's End-of-RIB, violating the RFC 9069
+  dump→EoR→live ordering the held-back live buffer exists to guarantee
+  (caught by the IRR-scale BMP buffer receipt). Every dump chunk request
+  now carries the generation-start timestamp and the walk skips routes
+  whose stored install time is newer; those routes reach the collector
+  exclusively via the post-EoR replay of the live buffer. Applies to the
+  unicast and VPN dump phases; live-buffer overflow semantics are
+  unchanged. The buffer-receipt runner also preserves a failed run's raw
+  root (`FAILED-*` under the artifact dir) instead of deleting it, and
+  the receipt sink names the offending prefix, BMP timestamp, and frame
+  position when it detects a boundary breach.
 - Grouped export-policy reloads no longer wedge at IRR scale (LAN-886). The
   update-group classifier rendered each member's whole policy chain into a
   planning-fingerprint string — tens of megabytes per rendering for an

--- a/bench/scale/irrreload/bmp-loc-rib-sink.py
+++ b/bench/scale/irrreload/bmp-loc-rib-sink.py
@@ -254,8 +254,22 @@ class ReceiptState:
     churn_withdrawals: int = 0
     eors: list[tuple[int, int]] = field(default_factory=list)
     post_eor_churn: bool = False
+    frames: int = 0
+
+    def boundary_detail(self, prefix: str, body: bytes) -> str:
+        """Failure context for a dump/live boundary breach: the offending
+        prefix, its per-peer-header BMP timestamp, and where in the dump
+        stream it landed (frame index, EoRs and dump rows seen so far)."""
+        seconds = int.from_bytes(body[34:38], "big")
+        microseconds = int.from_bytes(body[38:42], "big")
+        return (
+            f"prefix={prefix} bmp_timestamp={seconds}.{microseconds:06d}"
+            f" frame_index={self.frames} eors_seen={len(self.eors)}"
+            f" base_rows_seen={len(self.base_seen)}"
+        )
 
     def observe(self, frame: bytes) -> None:
+        self.frames += 1
         msg_type = frame[5]
         body = frame[BMP_HEADER:]
         if msg_type == 4:
@@ -300,7 +314,10 @@ class ReceiptState:
                 if kind == "base":
                     raise ReceiptError(f"base-table withdrawal during dump: {prefix}")
                 if len(self.eors) != len(EXPECTED_EORS):
-                    raise ReceiptError("churn withdrawal appeared before dump End-of-RIB")
+                    raise ReceiptError(
+                        "churn withdrawal appeared before dump End-of-RIB: "
+                        + self.boundary_detail(prefix, body)
+                    )
                 self.churn_withdrawals += 1
                 self.post_eor_churn = True
             for prefix in announced:
@@ -313,7 +330,10 @@ class ReceiptState:
                     self.base_seen.add(index)
                 else:
                     if len(self.eors) != len(EXPECTED_EORS):
-                        raise ReceiptError("churn announcement appeared before dump End-of-RIB")
+                        raise ReceiptError(
+                            "churn announcement appeared before dump End-of-RIB: "
+                            + self.boundary_detail(prefix, body)
+                        )
                     self.churn_announces += 1
                     self.post_eor_churn = True
             return
@@ -569,10 +589,13 @@ def sample_rm(update: bytes, *, peer_type: int = 3) -> bytes:
     return bytes([3]) + struct.pack("!I", BMP_HEADER + len(body)) + bytes([0]) + body
 
 
-def expect_rejected(name: str, action) -> None:
+def expect_rejected(name: str, action, contains: tuple[str, ...] = ()) -> None:
     try:
         action()
-    except ReceiptError:
+    except ReceiptError as error:
+        for fragment in contains:
+            if fragment not in str(error):
+                raise AssertionError(f"{name}: error lacks {fragment!r}: {error}") from error
         print(f"proof:{name}")
         return
     raise AssertionError(f"mutation was accepted: {name}")
@@ -643,6 +666,17 @@ def self_test() -> int:
     expect_rejected(
         "dump-before-live-order",
         lambda: before_eor.observe(sample_rm(sample_update(announced="172.16.0.0/24"))),
+        contains=(
+            "prefix=172.16.0.0/24",
+            "bmp_timestamp=0.000000",
+            "frame_index=5",
+            "eors_seen=0",
+        ),
+    )
+    expect_rejected(
+        "churn-withdrawal-before-eor",
+        lambda: primed_state().observe(sample_rm(sample_update(withdrawn="172.16.0.0/24"))),
+        contains=("prefix=172.16.0.0/24", "bmp_timestamp=", "frame_index="),
     )
     oversized = bytes([3]) + struct.pack("!I", MAX_FRAME_BYTES + 1) + bytes([0])
     expect_rejected("frame-bound", lambda: validated_frame_length(oversized))

--- a/bench/scale/irrreload/run-bmp-buffer-receipt.sh
+++ b/bench/scale/irrreload/run-bmp-buffer-receipt.sh
@@ -66,10 +66,23 @@ terminate_group() {
     [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null || kill -TERM -- "-$pid" 2>/dev/null || true
 }
 cleanup() {
+    local rc=$?
     terminate_group "$ACTIVE_SINK"
     terminate_group "$ACTIVE_HARNESS"
     terminate_group "$ACTIVE_DAEMON"
-    [ -z "$ACTIVE_TMP" ] || rm -rf "$ACTIVE_TMP"
+    if [ -n "$ACTIVE_TMP" ]; then
+        if [ "$rc" -eq 0 ]; then
+            rm -rf "$ACTIVE_TMP"
+        else
+            # A red run keeps its raw root (sink capture, generated
+            # scenario, partial sink state, pre-churn evidence) inside
+            # the artifact dir instead of losing it to cleanup.
+            local keep
+            keep="$ART/FAILED-$(basename "$ACTIVE_TMP")"
+            mv -- "$ACTIVE_TMP" "$keep" 2>/dev/null ||
+                echo "failed to preserve red run root $ACTIVE_TMP" >&2
+        fi
+    fi
 }
 trap cleanup EXIT
 trap 'exit 130' INT

--- a/crates/bmp/src/manager.rs
+++ b/crates/bmp/src/manager.rs
@@ -108,6 +108,11 @@ enum CollectorPhase {
         /// before the client confirms it reached TCP. They must follow the
         /// initial dump's terminal End-of-RIB, never precede it.
         loc_rib_buffer: Vec<Bytes>,
+        /// When this generation began holding live deltas back. Carried
+        /// on every dump chunk request so the RIB walk excludes routes
+        /// installed after it — those must arrive only via the post-EoR
+        /// replay of the buffer (LAN-885).
+        started_at: std::time::SystemTime,
     },
     Active {
         generation: u64,
@@ -752,6 +757,7 @@ impl BmpManager {
             sender,
             loc_rib_peer_up,
             loc_rib_buffer: Vec::new(),
+            started_at: std::time::SystemTime::now(),
         };
         self.loc_rib_suppressed.remove(&collector_id);
         info!(
@@ -783,19 +789,20 @@ impl BmpManager {
             return;
         };
         let old_phase = std::mem::replace(&mut collector.phase, CollectorPhase::Disconnected);
-        let loc_rib_buffer = match old_phase {
+        let (loc_rib_buffer, started_at) = match old_phase {
             CollectorPhase::BootstrapPending {
                 generation: current,
                 sender,
                 loc_rib_peer_up,
                 loc_rib_buffer,
+                started_at,
             } if current == generation => {
                 collector.phase = CollectorPhase::Active {
                     generation,
                     sender,
                     loc_rib_peer_up,
                 };
-                loc_rib_buffer
+                (loc_rib_buffer, started_at)
             }
             other => {
                 collector.phase = other;
@@ -807,7 +814,7 @@ impl BmpManager {
             collector_id,
             generation, "BMP collector bootstrap completed"
         );
-        self.start_loc_rib_dump(collector_id, generation, loc_rib_buffer);
+        self.start_loc_rib_dump(collector_id, generation, loc_rib_buffer, started_at);
     }
 
     fn handle_collector_disconnected(
@@ -917,7 +924,13 @@ impl BmpManager {
     /// fenced by the collector's connection generation so a reconnect
     /// mid-dump can never leak stale dump rows into the new
     /// connection's stream (LAN-289).
-    fn start_loc_rib_dump(&mut self, collector_id: usize, generation: u64, buffered: Vec<Bytes>) {
+    fn start_loc_rib_dump(
+        &mut self,
+        collector_id: usize,
+        generation: u64,
+        buffered: Vec<Bytes>,
+        started_at: std::time::SystemTime,
+    ) {
         let Some(ref cfg) = self.loc_rib else {
             return;
         };
@@ -950,6 +963,7 @@ impl BmpManager {
                 addr_label,
                 generation: generation_fence,
                 dump_generation: generation,
+                started_at,
             },
             self.dump_done_tx.clone(),
             collector_id,
@@ -1028,6 +1042,10 @@ struct DumpForwarder {
     /// The generation this dump was started for; the forwarder aborts
     /// as soon as the live value moves past it.
     dump_generation: u64,
+    /// When the generation began holding live Loc-RIB deltas back;
+    /// carried on every chunk request so the RIB walk never emits a
+    /// route installed after it as dump content (LAN-885).
+    started_at: std::time::SystemTime,
 }
 
 impl DumpForwarder {
@@ -1083,7 +1101,11 @@ async fn stream_loc_rib_dump(f: DumpForwarder) -> Option<DumpOutcome> {
         let (reply, chunk_rx) = tokio::sync::oneshot::channel();
         match tokio::time::timeout(
             LOC_RIB_DUMP_REQUEST_TIMEOUT,
-            f.dump_tx.send(BmpDumpRequest { cursor, reply }),
+            f.dump_tx.send(BmpDumpRequest {
+                cursor,
+                started_at: f.started_at,
+                reply,
+            }),
         )
         .await
         {
@@ -1230,6 +1252,7 @@ mod tests {
             addr_label: collector_addr(0).to_string(),
             generation: Arc::new(AtomicU64::new(1)),
             dump_generation: 1,
+            started_at: std::time::SystemTime::now(),
         }
     }
 
@@ -2114,6 +2137,7 @@ mod tests {
         dump_tx
             .try_send(BmpDumpRequest {
                 cursor: None,
+                started_at: std::time::SystemTime::now(),
                 reply,
             })
             .unwrap();
@@ -3029,6 +3053,7 @@ mod tests {
             sender,
             loc_rib_peer_up: true,
             loc_rib_buffer: vec![Bytes::new(); LOC_RIB_DUMP_LIVE_BUFFER_CAP],
+            started_at: std::time::SystemTime::now(),
         };
         assert_eq!(manager.collectors[0].phase.generation(), Some(7));
         assert!(!receiver.is_closed(), "CAP rows keep the generation live");

--- a/crates/bmp/src/types.rs
+++ b/crates/bmp/src/types.rs
@@ -124,10 +124,12 @@ impl BmpLocRibConfig {
 /// position, it stays valid across route insertions and removals
 /// between chunks: each chunk is "the smallest keys strictly greater
 /// than the cursor", so a surviving route is emitted exactly once and
-/// mutations land on the live stream. The BMP manager holds a
-/// collector's live Loc-RIB messages back until the dump's End-of-RIB,
-/// so on the wire the deltas always follow the snapshot rows they
-/// supersede (dump → `EoR` → live; no dump-vs-live reordering).
+/// mutations land on the live stream — routes installed after the
+/// request's `started_at` are excluded from dump content (LAN-885).
+/// The BMP manager holds a collector's live Loc-RIB messages back
+/// until the dump's End-of-RIB, so on the wire the deltas always
+/// follow the snapshot rows they supersede (dump → `EoR` → live; no
+/// dump-vs-live reordering).
 #[derive(Debug, Clone, Copy)]
 pub enum BmpDumpCursor {
     /// Resuming the unicast Loc-RIB walk after this prefix.
@@ -150,6 +152,14 @@ pub enum BmpDumpCursor {
 pub struct BmpDumpRequest {
     /// Resume position; `None` starts a fresh dump.
     pub cursor: Option<BmpDumpCursor>,
+    /// When this collector's connection generation began — the instant
+    /// the BMP manager started holding back live Loc-RIB deltas for
+    /// post-End-of-RIB replay. The dump walk emits only routes
+    /// installed at or before this instant; anything newer reaches the
+    /// collector exclusively via the held-back live replay, so no
+    /// post-generation-start update can precede the dump's End-of-RIB
+    /// on the wire (LAN-885).
+    pub started_at: SystemTime,
     /// Reply channel for this chunk.
     pub reply: oneshot::Sender<BmpDumpChunk>,
 }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2429,8 +2429,12 @@ impl RibManager {
             } => {
                 self.handle_query_warm_mrt_snapshot(&views, &budget, reply);
             }
-            RibUpdate::QueryBmpLocRibDump { cursor, reply } => {
-                self.handle_query_bmp_loc_rib_dump(cursor, reply);
+            RibUpdate::QueryBmpLocRibDump {
+                cursor,
+                started_at,
+                reply,
+            } => {
+                self.handle_query_bmp_loc_rib_dump(cursor, started_at, reply);
             }
             RibUpdate::QueryBmpLocRibStats { reply } => {
                 self.handle_query_bmp_loc_rib_stats(reply);

--- a/crates/rib/src/manager/queries.rs
+++ b/crates/rib/src/manager/queries.rs
@@ -271,10 +271,11 @@ impl RibManager {
     /// one pass over the unordered Loc-RIB map. That makes the cursor
     /// robust to mutations between chunks — a route that survives the
     /// dump is emitted exactly once, a removed route simply stops
-    /// matching, and an insertion behind the cursor reaches the
-    /// collector via the live stream (which the BMP manager holds back
-    /// until the dump's End-of-RIB, so deltas always follow the
-    /// snapshot rows on the wire). A phase yielding fewer than `N`
+    /// matching, and any route installed after `started_at` (behind
+    /// *or ahead of* the cursor) reaches the collector only via the
+    /// live stream, which the BMP manager holds back until the dump's
+    /// End-of-RIB — so no post-generation-start update can precede the
+    /// `EoR` on the wire (LAN-885). A phase yielding fewer than `N`
     /// keys is exhausted:
     /// unicast hands over to VPN, VPN closes the dump with one
     /// End-of-RIB per streamed family (dump→EoR→live ordering).
@@ -285,6 +286,7 @@ impl RibManager {
     pub(super) fn handle_query_bmp_loc_rib_dump(
         &self,
         cursor: Option<rustbgpd_bmp::BmpDumpCursor>,
+        started_at: std::time::SystemTime,
         reply: tokio::sync::oneshot::Sender<rustbgpd_bmp::BmpDumpChunk>,
     ) {
         use crate::bmp_sync;
@@ -319,6 +321,18 @@ impl RibManager {
                     else {
                         continue;
                     };
+                    // LAN-885: the walk reads the live table, so a route
+                    // admitted after the collector's generation began must
+                    // not become dump content — its held-back live delta
+                    // replays after End-of-RIB instead. Emitting it here
+                    // would leak a post-generation-start update across the
+                    // dump/live boundary. (Stored wall-clock install times:
+                    // a backward clock step mid-dump could readmit such a
+                    // route — accepted; a monotonic install sequence is the
+                    // upgrade path.)
+                    if installed_at > started_at {
+                        continue;
+                    }
                     if let Some(pdu) = bmp_sync::synthesize_unicast_announce(route) {
                         let status = bmp_sync::loc_rib_path_status(
                             route.is_stale || route.is_llgr_stale,
@@ -343,6 +357,11 @@ impl RibManager {
                     else {
                         continue;
                     };
+                    // LAN-885: same post-generation-start exclusion as the
+                    // unicast phase above.
+                    if installed_at > started_at {
+                        continue;
+                    }
                     if let Some(pdu) = bmp_sync::synthesize_vpn_announce(route) {
                         let status = bmp_sync::loc_rib_path_status(
                             route.is_stale || route.is_llgr_stale,

--- a/crates/rib/src/manager/tests/bmp.rs
+++ b/crates/rib/src/manager/tests/bmp.rs
@@ -54,6 +54,7 @@ fn assert_no_event(bmp_rx: &mut mpsc::Receiver<BmpEvent>) {
 async fn drive_loc_rib_dump_from(
     tx: &mpsc::Sender<RibUpdate>,
     mut cursor: Option<BmpDumpCursor>,
+    started_at: SystemTime,
 ) -> (
     Vec<(bytes::Bytes, SystemTime, Option<BmpPathStatus>)>,
     usize,
@@ -62,9 +63,13 @@ async fn drive_loc_rib_dump_from(
     let mut requests = 0usize;
     loop {
         let (reply, chunk_rx) = oneshot::channel();
-        tx.send(RibUpdate::QueryBmpLocRibDump { cursor, reply })
-            .await
-            .unwrap();
+        tx.send(RibUpdate::QueryBmpLocRibDump {
+            cursor,
+            started_at,
+            reply,
+        })
+        .await
+        .unwrap();
         let chunk = tokio::time::timeout(Duration::from_secs(2), chunk_rx)
             .await
             .expect("dump chunk within timeout")
@@ -356,7 +361,7 @@ async fn query_bmp_loc_rib_dump_streams_routes_then_eor_per_family() {
     tokio::time::sleep(Duration::from_millis(1200)).await;
 
     let dump_started = SystemTime::now();
-    let (messages, requests) = drive_loc_rib_dump_from(&tx, None).await;
+    let (messages, requests) = drive_loc_rib_dump_from(&tx, None, dump_started).await;
     // Two resumable requests: the unicast phase, then the VPN phase
     // closing with the End-of-RIB markers.
     assert_eq!(requests, 2, "unicast chunk, then VPN + EoR chunk");
@@ -470,7 +475,7 @@ async fn dump_timestamps_equal_stored_install_time() {
     // could not accidentally pass.
     tokio::time::sleep(Duration::from_millis(50)).await;
 
-    let (messages, _) = drive_loc_rib_dump_from(&tx, None).await;
+    let (messages, _) = drive_loc_rib_dump_from(&tx, None, SystemTime::now()).await;
     let (route_msgs, _) = messages.split_at(2);
     for (pdu, timestamp, _) in route_msgs {
         let parsed = decode_pdu(pdu);
@@ -531,7 +536,17 @@ async fn loc_rib_dump_chunks_stream_complete_table() {
     .await
     .unwrap();
 
-    let (messages, requests) = drive_loc_rib_dump_from(&tx, None).await;
+    // Barrier: a serviced stats query proves the actor has applied the
+    // install batch before the generation-start stamp is taken.
+    let (barrier_reply, barrier_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryBmpLocRibStats {
+        reply: barrier_reply,
+    })
+    .await
+    .unwrap();
+    barrier_rx.await.unwrap();
+
+    let (messages, requests) = drive_loc_rib_dump_from(&tx, None, SystemTime::now()).await;
     // Three bounded unicast chunks (256 + 256 + 88), then the VPN
     // phase closing the dump with the four EoR markers.
     assert_eq!(requests, 4, "dump streams across multiple chunk requests");
@@ -557,11 +572,11 @@ async fn loc_rib_dump_chunks_stream_complete_table() {
 /// Live RIB commands interleave between dump chunk requests, and the
 /// key-based cursor is robust to mutations mid-dump: a stats query
 /// fired between chunks is serviced before the dump resumes, a route
-/// inserted behind the cursor stays off the dump (the live stream
-/// covers it — the accepted race), a route inserted ahead of the
-/// cursor is picked up, and a not-yet-dumped route withdrawn between
-/// chunks never appears. The dump still completes with the
-/// End-of-RIB set.
+/// inserted mid-dump stays off the dump whether its key sorts behind
+/// or ahead of the cursor (post-`started_at` installs are live-stream
+/// territory, held back until End-of-RIB — LAN-885), and a
+/// not-yet-dumped route withdrawn between chunks never appears. The
+/// dump still completes with the End-of-RIB set.
 #[expect(
     clippy::too_many_lines,
     reason = "one mid-dump mutation walk: chunk, mutate, live query, resume, membership asserts"
@@ -604,11 +619,24 @@ async fn loc_rib_dump_interleaves_live_commands_between_chunks() {
     .await
     .unwrap();
 
+    // Barrier: a serviced stats query proves the actor has applied the
+    // install batch, so the routes' stored install times all precede
+    // the generation-start stamp taken next.
+    let (barrier_reply, barrier_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryBmpLocRibStats {
+        reply: barrier_reply,
+    })
+    .await
+    .unwrap();
+    barrier_rx.await.unwrap();
+
     // First chunk by hand (the forwarder's opening request): exactly
     // the chunk-size smallest prefixes, with a resume cursor.
+    let dump_started = SystemTime::now();
     let (reply, chunk_rx) = oneshot::channel();
     tx.send(RibUpdate::QueryBmpLocRibDump {
         cursor: None,
+        started_at: dump_started,
         reply,
     })
     .await
@@ -620,9 +648,10 @@ async fn loc_rib_dump_interleaves_live_commands_between_chunks() {
     assert_eq!(first.messages.len(), BMP_DUMP_CHUNK_SIZE);
     let cursor = first.next.expect("table larger than one chunk");
 
-    // Mutate the table between chunk requests: one prefix sorting
-    // before the cursor (dump must skip it), one after (dump must pick
-    // it up), and withdraw a not-yet-dumped prefix.
+    // Mutate the table between chunk requests: one post-start prefix
+    // sorting before the cursor and one after (the dump must skip
+    // both — they belong to the held-back live stream), and withdraw
+    // a not-yet-dumped prefix.
     let low = Ipv4Prefix::new(Ipv4Addr::new(1, 0, 0, 0), 24);
     let high = Ipv4Prefix::new(Ipv4Addr::new(240, 0, 0, 0), 24);
     let withdrawn_mid = prefixes[BMP_DUMP_CHUNK_SIZE + 10];
@@ -664,7 +693,7 @@ async fn loc_rib_dump_interleaves_live_commands_between_chunks() {
     );
 
     // Resume the dump to completion from the first chunk's cursor.
-    let (rest, _) = drive_loc_rib_dump_from(&tx, Some(cursor)).await;
+    let (rest, _) = drive_loc_rib_dump_from(&tx, Some(cursor), dump_started).await;
     let mut messages = first.messages;
     messages.extend(rest);
 
@@ -673,19 +702,161 @@ async fn loc_rib_dump_interleaves_live_commands_between_chunks() {
         .iter()
         .copied()
         .filter(|&p| p != withdrawn_mid)
-        .chain(std::iter::once(high))
         .collect();
     expected.sort_unstable();
     let mut sorted = dumped.clone();
     sorted.sort_unstable();
     assert_eq!(
         sorted, expected,
-        "surviving + ahead-of-cursor routes exactly once; behind-cursor \
-         insert and mid-dump withdrawal absent"
+        "surviving pre-start routes exactly once; post-start inserts \
+         and the mid-dump withdrawal absent"
     );
     assert!(
-        !dumped.contains(&low),
-        "insertion behind the cursor is live-stream territory, not dump"
+        !dumped.contains(&low) && !dumped.contains(&high),
+        "post-start insertion is live-stream territory regardless of \
+         which side of the cursor its key sorts on (LAN-885)"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// LAN-885 dump/live boundary: a Loc-RIB mutation admitted after the
+/// collector's generation started must never be emitted as dump
+/// content, even when its key sorts ahead of the cursor — the BMP
+/// manager holds its live delta back for post-End-of-RIB replay, and
+/// the walker emitting it would put a post-generation-start update on
+/// the wire before the dump's `EoR` (the red 2026-08-04 IRR receipt).
+/// Covers a fresh insert, an attribute replace of a not-yet-dumped
+/// route (install-time refresh), and a post-start VPN install.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one boundary walk: install, stamp, chunk, post-start churn, resume, membership asserts"
+)]
+#[tokio::test]
+async fn loc_rib_dump_excludes_routes_admitted_after_dump_start() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer = Ipv4Addr::new(10, 0, 0, 1);
+    let total = BMP_DUMP_CHUNK_SIZE + 8;
+    let prefixes: Vec<Ipv4Prefix> = (0..total)
+        .map(|i| {
+            Ipv4Prefix::new(
+                Ipv4Addr::new(
+                    10,
+                    u8::try_from(i / 256).unwrap(),
+                    u8::try_from(i % 256).unwrap(),
+                    0,
+                ),
+                24,
+            )
+        })
+        .collect();
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(peer),
+        session_id: 0,
+        announced: prefixes
+            .iter()
+            .map(|&p| make_route_with_lp(p, peer, 100))
+            .collect(),
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    // Barrier: a serviced stats query proves the actor has applied the
+    // install batch, so the routes' stored install times all precede
+    // the generation-start stamp taken next.
+    let (barrier_reply, barrier_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryBmpLocRibStats {
+        reply: barrier_reply,
+    })
+    .await
+    .unwrap();
+    barrier_rx.await.unwrap();
+
+    // Generation start: the instant the BMP manager begins holding
+    // live deltas back. Everything installed above precedes it.
+    let dump_started = SystemTime::now();
+    let (reply, chunk_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryBmpLocRibDump {
+        cursor: None,
+        started_at: dump_started,
+        reply,
+    })
+    .await
+    .unwrap();
+    let first = tokio::time::timeout(Duration::from_secs(2), chunk_rx)
+        .await
+        .expect("first chunk within timeout")
+        .expect("RIB manager replies");
+    let cursor = first.next.expect("table larger than one chunk");
+
+    // Post-start churn, all sorting ahead of the cursor: a fresh
+    // prefix, a replace (changed local-pref refreshes the stored
+    // install time) of a route the dump has not reached yet, and a
+    // fresh VPN route ahead of the (not yet started) VPN phase.
+    let fresh = Ipv4Prefix::new(Ipv4Addr::new(240, 0, 0, 0), 24);
+    let replaced = prefixes[BMP_DUMP_CHUNK_SIZE + 4];
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(peer),
+        session_id: 0,
+        announced: vec![
+            make_route_with_lp(fresh, peer, 100),
+            make_route_with_lp(replaced, peer, 200),
+        ],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        peer: IpAddr::V4(peer),
+        session_id: 0,
+        announced: vec![make_vpn_rib_route(peer, 42, 1042, 100)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let (rest, _) = drive_loc_rib_dump_from(&tx, Some(cursor), dump_started).await;
+    let mut messages = first.messages;
+    messages.extend(rest);
+
+    let dumped = dumped_unicast_prefixes(&messages);
+    assert!(
+        !dumped.contains(&fresh),
+        "post-start insert ahead of the cursor leaked into dump content"
+    );
+    assert!(
+        !dumped.contains(&replaced),
+        "post-start replace of a not-yet-dumped route leaked its new \
+         state into dump content (the held-back live delta covers it)"
+    );
+    let mut expected: Vec<Ipv4Prefix> = prefixes
+        .iter()
+        .copied()
+        .filter(|&p| p != replaced)
+        .collect();
+    expected.sort_unstable();
+    let mut sorted = dumped.clone();
+    sorted.sort_unstable();
+    assert_eq!(sorted, expected, "pre-start routes dumped exactly once");
+    // No VPN announce made it either: dump rows + the four EoR markers
+    // account for every message.
+    assert_eq!(
+        messages.len(),
+        expected.len() + 4,
+        "post-start VPN install leaked into dump content"
     );
 
     drop(tx);

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -2209,6 +2209,12 @@ pub enum RibUpdate {
         /// Resume position from the previous chunk's reply; `None`
         /// starts a fresh dump.
         cursor: Option<rustbgpd_bmp::BmpDumpCursor>,
+        /// When the collector's connection generation began holding
+        /// live Loc-RIB deltas back. Routes installed after this
+        /// instant are excluded from dump content — they reach the
+        /// collector only via the post-End-of-RIB live replay
+        /// (LAN-885).
+        started_at: std::time::SystemTime,
         /// Reply channel for this chunk (from the BMP manager's
         /// `BmpDumpRequest`).
         reply: oneshot::Sender<rustbgpd_bmp::BmpDumpChunk>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3411,6 +3411,7 @@ async fn run<T>(
                     if dump_rib_tx
                         .send(RibUpdate::QueryBmpLocRibDump {
                             cursor: request.cursor,
+                            started_at: request.started_at,
                             reply: request.reply,
                         })
                         .await


### PR DESCRIPTION
Fixes the BMP Loc-RIB dump/live boundary violation caught by the red 2026-08-04 IRR-scale buffer receipt (LAN-885): a canonical churn-roster announcement reached the collector 3.4 s into dump generation 1, before the dump's End-of-RIB markers.

## Mechanism verdict: (2) snapshot-less dump walk

The walker, not the live path, leaked the update.

- `RibManager::handle_query_bmp_loc_rib_dump` (`crates/rib/src/manager/queries.rs`) selects each chunk as "the N smallest keys strictly greater than the cursor" **from the live Loc-RIB** (`smallest_keys_after(self.loc_rib.iter()...)`). A route installed after generation start whose key sorts ahead of the cursor is picked up and emitted as dump content. Its own doc comment only claimed the safe half ("an insertion behind the cursor reaches the collector via the live stream") — insertions ahead of the cursor were dumped, and the prior test `loc_rib_dump_interleaves_live_commands_between_chunks` pinned exactly that leaking behavior ("a route inserted ahead of the cursor is picked up").
- Mechanism (1) — a live-path leak — is ruled out by inspection: `BmpManager::handle_loc_rib_event` (`crates/bmp/src/manager.rs`) buffers live Loc-RIB messages in `BootstrapPending::loc_rib_buffer` from the instant of `CollectorConnected` and in `ActiveDump::buffered` while the dump runs; the `BootstrapPending → Active + active_dumps` transition is synchronous inside `handle_bootstrap_complete`, and `handle_dump_done` flushes the buffer onto the same per-connection channel the forwarder already enqueued the EoR markers on, so the flush cannot overtake them. The client writes the bootstrap frames before draining the connection channel (`crates/bmp/src/client.rs`).
- In the red run, churn began only after the sink accepted (~0.5 s after generation start at 19:48:14.877Z), so every churn install postdates generation start; the walker emitting one ahead of the cursor is sufficient and consistent with the sealed `daemon.log`/`sink.log` correlation.

## Fix

The BMP manager stamps `started_at` when it begins holding live deltas back (collector connect) and carries it on every `BmpDumpRequest`; the walk skips any route whose stored install time (LAN-193 wall-clock stamps, refreshed on replace) is newer, in both the unicast and VPN phases. Such routes reach the collector exactly once — via the post-EoR replay of the held-back buffer. The 8,192-entry live-buffer overflow semantics are untouched (overflow still fails the generation closed). Residual, noted in the walk: install times are wall clock, so a backward clock step mid-dump could readmit a post-start route; a monotonic install sequence is the upgrade path.

## Red proof (bounded repro; no full-scale rerun needed)

The mechanism does not require scale — it needs only a dump spanning more than one chunk with an install ahead of the cursor between chunk requests. With the two walker guards disabled (`if false && installed_at > started_at`), the new and reshaped tests fail exactly as the receipt did:

```
---- manager::tests::bmp::loc_rib_dump_excludes_routes_admitted_after_dump_start stdout ----
panicked at crates/rib/src/manager/tests/bmp.rs:832:5:
post-start insert ahead of the cursor leaked into dump content

---- manager::tests::bmp::loc_rib_dump_interleaves_live_commands_between_chunks stdout ----
panicked at crates/rib/src/manager/tests/bmp.rs:709:5:
assertion `left == right` failed: surviving pre-start routes exactly once; post-start inserts and the mid-dump withdrawal absent
  ... left contains Ipv4Prefix { addr: 240.0.0.0, len: 24 }  <- the post-start insert, emitted as dump content

test result: FAILED. 1 passed; 2 failed
```

With the guards restored, the suite is green (10/10 in `manager::tests::bmp`, 1049/1049 in the rib lib suite).

## Seam findings

- **Adj-RIB-In / Adj-RIB-Out views**: no table dump exists for these views — collector bootstrap replays Peer Ups only, with no End-of-RIB boundary to violate. No equivalent hole.
- **Per-peer bootstrap ordering**: live route-monitoring messages enqueued during `BootstrapPending` ride the per-connection channel, which the client drains only after writing the bootstrap frames — ordering holds.
- **Collectors connecting mid-dump**: per-collector generation, buffer, and dump task (`active_dumps` keyed by collector index); each new connection stamps its own `started_at`. Independent.
- **Loc-RIB stats reports**: buffered in the same live buffer during a dump; replay after EoR. No boundary issue.
- **Overflow path**: `buffer_loc_rib_message` cap and the fail-closed generation teardown are byte-identical.

## Evidence-loss fixes (first commit)

- `run-bmp-buffer-receipt.sh`: the EXIT trap deleted `$ACTIVE_TMP` even on failure, losing the raw frame capture the receipt needed to distinguish the two candidate mechanisms. Red runs now move the root to `FAILED-<run>` inside the artifact dir.
- `bmp-loc-rib-sink.py`: the boundary `ReceiptError`s now carry the offending prefix, its per-peer-header BMP timestamp, the frame index, and the dump position (EoRs and dump rows seen); the self-test pins the detail fields.

## Gates (all rc=0)

| Gate | rc |
|---|---|
| `cargo fmt --all --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace` | 0 |
| `cargo doc --workspace --no-deps` | 0 |
| `python3 scripts/check-clippy-reasons.py` | 0 |
| `cargo test -p rustbgpd-bmp` | 0 |
| `cargo test -p rustbgpd-rib --lib` (x5, flake check) | 0 |
| `bash -n` + `shellcheck` on the runner | 0 |
| sink `--self-test` (all proofs incl. new detail assertions) | 0 |
| runner `DRY_RUN_PROTOCOL=1` smoke | 0 |
