### PR TITLE
docs: correct Add-Path update-group claim; flag groups-of-one degradation

### DIFF
--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -127,7 +127,9 @@ import_chain = [
 # Add-Path-capable member: receives up to the eight best export-permitted
 # candidates, subject to configured and negotiated Paths-Limit, and runs
 # its own best-path selection (the preferred path-hiding mitigation).
-# These peers stay update-group-shareable.
+# Like per_client_best, Add-Path send places the member on the per-peer
+# distribution path (the add_path_send fallback reason); update-group
+# sharing applies to members using neither mitigation.
 [[neighbors]]
 address = "198.51.100.2"
 remote_asn = 64501
@@ -324,9 +326,20 @@ Prometheus (`prometheus_addr`, `/metrics`; dashboards in
 |--------|---------------|
 | `bgp_session_state_transitions_total` | flat outside member churn |
 | `sum without (af) (bgp_rpki_vrp_count)` | per-target IPv4 + IPv6 total; non-zero once the RTR cache syncs (`rbgp doctor` warns when configured caches have no visible VRPs) |
-| `bgp_update_group_fallback_peers` | ≥ your `per_client_best` member count (they never group) |
+| `bgp_update_group_fallback_peers` | ≥ your `per_client_best` + Add-Path send member count (both path-hiding mitigations distribute per-peer) |
 | `bgp_rib_outbound_registered_peers` | = established member count |
 | `bgp_policy_generation_loaded_timestamp_seconds` | recent — ages past your render/SIGHUP cadence when the filter pipeline is stuck; see "Policy artifact freshness" in [`OPERATIONS.md`](../OPERATIONS.md) for the alert expressions |
+
+Groups of one are the silent degradation shape: distinct per-member
+export-chain *content* — most commonly per-member literal chains from
+arouteserver-style expansion — puts every member in its own group, at
+full per-peer cost, while `bgp_update_group_fallback_peers` stays 0 and
+`bgp_update_groups` climbs toward the session count. On a fleet whose
+members should share chains, treat `bgp_update_groups` approaching the
+session count as a misconfiguration signal. The fix is one shared
+export chain plus the member-set control communities above for
+per-member steering — they are evaluated at emit time and work inside
+a shared group.
 
 ## Member support: the filtered-route view
 

--- a/examples/route-server/README.md
+++ b/examples/route-server/README.md
@@ -39,8 +39,10 @@ its generic deny, and test both the exception and an unauthorized control.
 - **member-alpha** negotiates **Add-Path send**: it receives up to the eight
   best export-permitted candidates, subject to configured and negotiated
   Paths-Limit, and runs its own best-path selection. Preferred where the
-  member edge supports Add-Path receive — these peers stay
-  update-group-shareable.
+  member edge supports Add-Path receive. Like `per_client_best`, Add-Path
+  send places the member on the per-peer distribution path (the
+  `add_path_send` reason in `rbgp neighbor <addr>`); update-group sharing
+  applies to members using neither mitigation.
 - **member-beta** cannot do Add-Path, so it sets **`per_client_best = true`**
   (requires `route_server_client`): when its export policy denies the best
   path, the route server advertises the best *permitted* candidate instead

--- a/examples/route-server/config.toml
+++ b/examples/route-server/config.toml
@@ -139,7 +139,10 @@ enabled = false
 
 # Add-Path-capable member: sees up to the eight best export-permitted
 # candidates, subject to configured and negotiated Paths-Limit (preferred
-# path-hiding mitigation), and stays update-group-shareable.
+# path-hiding mitigation). Like `per_client_best`, Add-Path send places
+# the member on the per-peer distribution path (the `add_path_send`
+# fallback reason); update-group sharing applies to members using
+# neither mitigation.
 [[neighbors]]
 address = "198.51.100.2"
 remote_asn = 64501


### PR DESCRIPTION
Docs-only. No code changes, no new metrics.

## Correct a false shareability claim

Three route-server docs claimed Add-Path members "stay
update-group-shareable". `add_path_send` is a hard update-group
disqualifier — see the classifier precedence in
`crates/rib/src/update.rs` (`classify_update_group`) and the
`add_path_send` row in the CONFIGURATION.md fallback-reasons table
(ADR-0099 records why per-member path-id correction is unsound). Both
path-hiding mitigations (`per_client_best` and Add-Path send) place
members on the per-peer distribution path; grouping applies to members
using neither. Corrected in:

- `examples/route-server/config.toml` (member-alpha comment)
- `examples/route-server/README.md` (path-hiding section)
- `docs/cookbook/route-server.md` (member-alpha comment)

## Surface silent groups-of-one degradation

In the route-server cookbook Watch section: distinct per-member
export-chain *content* (arouteserver-style per-member literal chains)
produces groups of one — full per-peer cost while
`bgp_update_group_fallback_peers` stays 0 and `bgp_update_groups`
climbs toward the session count. Added guidance to treat
`bgp_update_groups` approaching the session count on a fleet that
should share chains as a misconfiguration signal, with the fix: one
shared chain plus RFC 8195 control communities, which are evaluated at
emit time and work inside a shared group (ADR-0101 Decision 3). The
`bgp_update_group_fallback_peers` healthy-shape row now counts both
mitigations instead of `per_client_best` alone.

Gates: `cargo test --workspace` rc=0 · `git diff --check` rc=0.
