### PR TITLE
Check BMP sink stop-file every scrape-release iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The IRR BMP buffer-receipt sink no longer starves its stop-file check
+  under continuous post-EoR churn (LAN-889). `wait_for_scrape_release`
+  only consulted the stop-file when the collector socket was idle, so
+  live churn kept the check unreached for the whole ack window; the
+  reloadstall harness's 15 s final-evidence timeout then expired, tore
+  down the sessions, and the sink correctly rejected the resulting base
+  withdrawals — failing a semantically green run. The stop-file is now
+  checked every loop iteration (after at most one pending frame), and
+  the sink self-test pins stop delivery under a saturated socket.
 - BMP Loc-RIB dumps no longer emit routes admitted after the collector's
   connection generation started (LAN-885). The dump walk read the live
   Loc-RIB per chunk, so a route installed mid-dump at a key ahead of the

--- a/bench/scale/irrreload/bmp-loc-rib-sink.py
+++ b/bench/scale/irrreload/bmp-loc-rib-sink.py
@@ -18,6 +18,7 @@ import struct
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from dataclasses import dataclass, field
 
@@ -441,7 +442,14 @@ def wait_for_scrape_release(
     deadline: float,
     captured: int,
 ) -> int:
-    """Keep proving the completed generation is live until the scrape releases it."""
+    """Keep proving the completed generation is live until the scrape releases it.
+
+    The stop-file is checked on every iteration, after at most one frame of
+    pending data: continuous post-EoR churn keeps the socket readable, so a
+    stop check gated on an idle socket would starve for as long as the churn
+    lasts. A failure already queued ahead of the stop (FIN, Termination, a
+    boundary breach) still wins, because the data branch runs first.
+    """
     try:
         while True:
             if time.monotonic() >= deadline:
@@ -451,7 +459,7 @@ def wait_for_scrape_release(
                 if frame is None:
                     raise ReceiptError("complete generation closed before metrics scrape")
                 state.observe(frame)
-            elif stop_file.is_file():
+            if stop_file.is_file():
                 return captured
     except (OSError, ReceiptError):
         generation_open.unlink(missing_ok=True)
@@ -763,6 +771,53 @@ def self_test() -> int:
     prove_pre_scrape_disconnect("complete-fin-before-scrape", None)
     termination = bytes([3]) + struct.pack("!I", BMP_HEADER) + bytes([5])
     prove_pre_scrape_disconnect("termination-before-scrape", termination)
+
+    def prove_stop_under_continuous_churn() -> None:
+        churn_state = primed_state()
+        churn_state.observe(sample_rm(sample_update(announced="20.0.0.0/24")))
+        churn_state.observe(sample_rm(sample_update(announced="20.0.1.0/24")))
+        for family in EXPECTED_EORS:
+            churn_state.observe(sample_rm(sample_update(eor=family)))
+        churn_state.observe(sample_rm(sample_update(announced="172.16.0.0/24")))
+        assert churn_state.complete()
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            stop = root / "stop"
+            open_marker = root / "generation-open"
+            open_marker.write_text("open\n")
+            receiver, sender = socket.socketpair()
+            receiver.settimeout(0.1)
+            churn_frame = sample_rm(sample_update(withdrawn="172.16.0.0/24"))
+            halt = threading.Event()
+
+            def feed() -> None:
+                # Saturate the socket: sendall blocks whenever the buffer
+                # is full, so the receiver never observes an idle socket.
+                while not halt.is_set():
+                    try:
+                        sender.sendall(churn_frame)
+                    except OSError:
+                        return
+
+            feeder = threading.Thread(target=feed, daemon=True)
+            feeder.start()
+            try:
+                time.sleep(0.2)
+                stop.write_text("stop\n")
+                started = time.monotonic()
+                wait_for_scrape_release(
+                    receiver, churn_state, stop, open_marker, time.monotonic() + 5, 0
+                )
+                elapsed = time.monotonic() - started
+                assert elapsed < 1.0, f"stop-file starved under continuous churn: {elapsed:.2f}s"
+            finally:
+                halt.set()
+                receiver.close()
+                sender.close()
+                feeder.join(timeout=1)
+        print("proof:stop-under-continuous-churn")
+
+    prove_stop_under_continuous_churn()
     return 0
 
 


### PR DESCRIPTION
Fixes the BMP buffer-receipt tooling race that failed a semantically green run (LAN-889; evidence in the 2026-08-05 boundary receipt summary).

## Problem

`wait_for_scrape_release` in `bench/scale/irrreload/bmp-loc-rib-sink.py` checked its stop-file only in the `elif` (no-pending-data) branch of a `select(0.05)` loop. Continuous post-EoR churn keeps the collector socket readable, so the stop check was never reached for the entire final-evidence ack window. The reloadstall harness's fixed 15 s `EVIDENCE_TIMEOUT` then expired, the harness exited, its 320 sessions closed, the daemon withdrew the dead peers' routes, and the sink — still holding the generation open — correctly rejected the first base-table withdrawal and exited 1. The daemon's dump/live boundary held throughout; the failure was entirely in the receipt tooling.

## Fix

- The stop-file is now checked on every loop iteration, after at most one pending frame, so a fully saturated socket still observes stop within one frame time (milliseconds at churn rates). A failure already queued ahead of the stop (FIN, Termination, boundary breach) still wins because the data branch runs first — the existing queued-failure seam proofs are unchanged and still pass.
- New self-test leg `proof:stop-under-continuous-churn`: a feeder thread saturates a socketpair with churn withdrawals (blocking `sendall` keeps the buffer full), the stop-file is written mid-stream, and the release must return within 1 s. Red under the previous elif-only logic (times out at the test's 5 s deadline with `timed out waiting for stop`); green with the fix.

## EVIDENCE_TIMEOUT seatbelt

Not taken. The starvation was the sole cause of the ack-window overrun: with per-iteration stop checks the sink acts on stop within milliseconds, well inside the 15 s window, whose remaining role is failing fast when the runner genuinely disappears. Widening it or adding an env knob would only delay that detection and would require editing the reloadstall crate's source-scan pin tests for a knob nothing needs.

## Verification

- `python3 -m py_compile bench/scale/irrreload/bmp-loc-rib-sink.py` — rc=0
- `python3 bench/scale/irrreload/bmp-loc-rib-sink.py --self-test` — rc=0, all 15 proofs, 3 consecutive runs
- Revert-and-run: with the stop check restored to the elif-only form, the new leg fails (`ReceiptError: timed out waiting for stop`, rc=1); restored fix passes
- No shell or Rust files touched; `run-bmp-buffer-receipt.sh` and `bench/scale/reloadstall/` are unchanged
