### PR TITLE
Decompose the policy reload snapshot span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Structured phase timing for the SIGHUP policy-reload path (LAN-888). A
+  config load now logs one `config source loaded` line with `toml_parse_ms`,
+  `rpol_load_ms`, `dataset_bind_ms`, and `validate_ms` alongside the total
+  `elapsed_ms`; the once-per-file rpol set-table intern logs
+  `interned rpol set tables built` with `elapsed_ms` at the moment it fires;
+  and an rpol registry swap logs `resolved live peer policy chains` with
+  `elapsed_ms` for the per-peer chain re-resolution before the snapshot
+  apply fan-out. Together with the existing partitioned-snapshot and RIB
+  export-policy transition lines, the daemon log alone attributes where a
+  reload spends its time. Measurement only — no behavior change.
+
 - ASPA-invalid policy rejections retain the first proven `NotProviderPlus` hop;
   cache refresh emits one bounded top-eight summary without changing routing.
 

--- a/crates/policy/src/rpol/mod.rs
+++ b/crates/policy/src/rpol/mod.rs
@@ -142,8 +142,19 @@ impl RpolFile {
 
     /// The unit's interned set tables, built on first use.
     fn tables(&self) -> &lower::SetTables {
-        self.tables
-            .get_or_init(|| lower::SetTables::build(&self.file))
+        self.tables.get_or_init(|| {
+            // LAN-888: this build is the expensive interning step at IRR
+            // scale, and *when* it fires (config load vs first chain
+            // resolve) is exactly what reload attribution needs — one
+            // timestamped line per `RpolFile` lifetime, self-locating.
+            let started = std::time::Instant::now();
+            let tables = lower::SetTables::build(&self.file);
+            tracing::info!(
+                elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+                "interned rpol set tables built"
+            );
+            tables
+        })
     }
 
     /// The main file's source text.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -102,6 +102,11 @@ impl StagedDatasetCommit {
     }
 }
 
+/// Saturating whole-millisecond elapsed time for structured log fields.
+fn elapsed_ms(started: std::time::Instant) -> u64 {
+    u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
 impl Config {
     fn peer_group_for_neighbor(
         &self,
@@ -161,6 +166,7 @@ impl Config {
         mut capture: Option<&mut source_provenance::SourceCapture>,
         prior_manifest: Option<&source_provenance::SourceManifest>,
     ) -> Result<Self, String> {
+        let load_started = std::time::Instant::now();
         let mut config: Config = match toml::from_str(content) {
             Ok(c) => c,
             Err(e) => {
@@ -175,11 +181,13 @@ impl Config {
                     .unwrap_or_else(|| format!("error: {error}")));
             }
         };
+        let toml_parse_ms = elapsed_ms(load_started);
         // Compile referenced .rpol files before validation: chain
         // references resolve against the combined TOML + rpol policy
         // namespace, and rpol compile diagnostics (already
         // ariadne-rendered against the .rpol source) are config load
         // errors in their own right.
+        let phase_started = std::time::Instant::now();
         let rpol_result = match capture.as_deref_mut() {
             Some(capture) => config.load_rpol_files_capturing(base_dir, Some(capture)),
             None => config.load_rpol_files(base_dir),
@@ -191,12 +199,14 @@ impl Config {
                     .unwrap_or_else(|| format!("error: {other}")),
             });
         }
+        let rpol_load_ms = elapsed_ms(phase_started);
         // Bind dataset declarations to their snapshot files (LAN-305)
         // before validation: chain references probe datasets, so the
         // resolver needs the handles. With `prior_datasets` (the
         // SIGHUP reload path) existing handles are reused — content
         // swaps happen inside them and a failed refresh keeps the
         // prior snapshot instead of failing the load.
+        let phase_started = std::time::Instant::now();
         let dataset_result = match capture {
             Some(capture) => config.bind_datasets_capturing(
                 base_dir,
@@ -210,10 +220,26 @@ impl Config {
         if let Err(error) = dataset_result {
             return Err(format!("error: {error}"));
         }
+        let dataset_bind_ms = elapsed_ms(phase_started);
+        let phase_started = std::time::Instant::now();
         if let Err(error) = config.validate() {
             return Err(diagnostic::render_diagnostic(content, source_name, &error)
                 .unwrap_or_else(|| format!("error: {error}")));
         }
+        let validate_ms = elapsed_ms(phase_started);
+        // LAN-888: phase-attributed load timing so the daemon log alone
+        // answers where a slow config load (notably an IRR-scale SIGHUP
+        // reload) spends its time. One Instant pair per phase — no
+        // per-entry work.
+        tracing::info!(
+            source = source_name,
+            elapsed_ms = elapsed_ms(load_started),
+            toml_parse_ms,
+            rpol_load_ms,
+            dataset_bind_ms,
+            validate_ms,
+            "config source loaded"
+        );
         // Canonicalize static neighbor address spellings. Reload diffs and
         // runtime lookups compare the config string against
         // `IpAddr::to_string()`, so a representation-only respelling

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -16264,6 +16264,80 @@ fn rpol_files_load_resolve_and_evaluate_in_chains() {
     assert_eq!(eval.matched_policy.as_deref(), Some("bogon-filter"));
 }
 
+/// LAN-888: a config load emits one phase-attributed timing line
+/// (`config source loaded` with `toml_parse_ms` / `rpol_load_ms` /
+/// `dataset_bind_ms` / `validate_ms` nested inside `elapsed_ms`), and the
+/// once-per-`RpolFile` set-table intern stamps its own line — so a SIGHUP
+/// reload's daemon log attributes where load time went with no harness.
+#[test]
+fn config_load_emits_phase_timing_fields() {
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    struct Sink(Arc<Mutex<Vec<u8>>>);
+    impl Write for Sink {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let sink = Sink(Arc::new(Mutex::new(Vec::new())));
+    let writer_sink = sink.clone();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(move || writer_sink.clone())
+        .finish();
+
+    let dir = rpol_config_dir(RPOL_SOURCE, r#""customer-in(200)", "bogon-filter""#);
+    tracing::subscriber::with_default(subscriber, || {
+        // Sibling tests reach these callsites with no subscriber installed,
+        // which caches `Interest::never()` process-wide, and a scoped
+        // subscriber does not invalidate that cache. Warm the callsites, then
+        // re-register them against this subscriber; a callsite is registered
+        // once, so the measured load below cannot lose the race afterwards.
+        drop(load_dir(&dir).expect("config with rpol files loads"));
+        tracing::callsite::rebuild_interest_cache();
+        sink.0.lock().unwrap().clear();
+
+        let config = load_dir(&dir).expect("config with rpol files loads");
+        // Chain resolution reaches the once-per-file set-table intern
+        // regardless of whether validation already built it.
+        config
+            .effective_policy_chains_for_neighbor(&config.neighbors[0])
+            .expect("chains resolve");
+    });
+
+    let output = String::from_utf8(sink.0.lock().unwrap().clone()).expect("utf8 log output");
+    let loaded = output
+        .lines()
+        .find(|line| line.contains("config source loaded"))
+        .unwrap_or_else(|| panic!("config load emits its timing line; captured: {output}"));
+    let json: serde_json::Value = serde_json::from_str(loaded).expect("structured log line");
+    let fields = &json["fields"];
+    let phase = |name: &str| {
+        fields[name]
+            .as_u64()
+            .unwrap_or_else(|| panic!("{name} must be a u64 field on: {loaded}"))
+    };
+    assert!(
+        phase("toml_parse_ms")
+            + phase("rpol_load_ms")
+            + phase("dataset_bind_ms")
+            + phase("validate_ms")
+            <= phase("elapsed_ms"),
+        "phase timings must nest inside the total: {loaded}"
+    );
+    assert!(
+        output.contains("interned rpol set tables built"),
+        "set-table intern build must stamp its own timing line"
+    );
+}
+
 /// The real startup roster resolves neighbors through bounded set-interning
 /// chunks. Common `.rpol` set content within one chunk must share its backing
 /// index, distinct content must not alias, and allocation identity must remain

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -2448,6 +2448,7 @@ impl PeerManager {
         // touched. A mid-fanout apply failure attempts to restore already-updated
         // peers to their captured priors; a compound rollback failure is surfaced
         // and may leave the existing per-peer retry intent armed.
+        let resolve_started = Instant::now();
         let mut targets: Vec<ResolvedPeerPolicy> = Vec::new();
         for peer_key in peers {
             let Some(managed) = self.peers.get(&peer_key) else {
@@ -2503,6 +2504,14 @@ impl PeerManager {
                 export_policy,
             });
         }
+        // LAN-888: the resolve loop above is where per-peer chain
+        // lowering/monomorphization happens on an rpol registry swap —
+        // stamp it separately from the apply fan-out that follows.
+        info!(
+            peers = targets.len(),
+            elapsed_ms = u64::try_from(resolve_started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "resolved live peer policy chains"
+        );
         let applied = self
             .apply_resolved_policy_snapshot(targets)
             .await


### PR DESCRIPTION
## Why

At the IRR shape, the SIGHUP path up to `partitioned resolved policy
snapshot` costs 1.27 s on the first reload but ~15.3 s on reloads 2–4
(four-root reload comparison, `comparison-A/rustbgpd-sighup`). The daemon
log has no intermediate marks between `SIGHUP received, reloading
configuration` and the snapshot line, so the cost cannot be attributed
without attaching a profiler to a reload campaign. This is measurement
plumbing only — no fix, no behavior change.

## What

Phase-attributed `elapsed_ms` fields, in the same structured style as the
existing `partitioned resolved policy snapshot` and `RIB export-policy
transition completed` lines:

- `config source loaded` (`src/config/mod.rs`) — total `elapsed_ms` with
  `toml_parse_ms`, `rpol_load_ms`, `dataset_bind_ms`, and `validate_ms`
  nested inside it. `rpol_load_ms` covers the `.rpol` read, import-graph
  resolution, parse, and typecheck for every referenced file.
- `interned rpol set tables built` (`crates/policy/src/rpol/mod.rs`) — the
  once-per-compilation-unit `OnceLock` set-table build. Logged inside the
  `get_or_init` closure so the line's timestamp also answers *when* the
  interning fires (config load vs. first chain resolve), which is the
  half of the question a duration alone would not settle.
- `resolved live peer policy chains` (`src/peer_manager/policy.rs`) — the
  per-peer chain resolution/lowering loop on an rpol registry swap,
  stamped separately from the snapshot apply fan-out that follows it.

One `Instant` pair per phase; nothing runs per set entry or per prefix.

## Phases and anchors

| Phase | Anchor |
| --- | --- |
| (a) config file parse | `src/config/mod.rs:184` (`toml_parse_ms`) |
| (b) rpol file parse | `src/config/mod.rs:202` (`rpol_load_ms`) |
| (c) set-table intern/build | `crates/policy/src/rpol/mod.rs:144` |
| (d) chain resolution/lowering | `src/peer_manager/policy.rs:2507` |
| (e) snapshot partition | already instrumented — `src/peer_manager/policy.rs:506` / `:544` |

Two adjacent phases came along for free and are logged because they sit
inside the same measured window: dataset binding (`dataset_bind_ms`) and
config validation (`validate_ms`).

## Gap

Phase (e) is reported as it already was. The existing `partitioned
resolved policy snapshot` line opens the window and `committed
partitioned resolved policy snapshot` closes it with `elapsed_ms`, but
the partition path has three early returns to the wholly authoritative
apply (duplicate targets, cohort < 2, and the defensive cohort fallback)
that leave through a different exit with no timing line. Giving those
exits a shared stamp means restructuring the function's returns, which is
outside a measurement-only change; the four-cell campaign shape reaches
the instrumented cohort path.

## Tests

`config_load_emits_phase_timing_fields` (`src/config/tests.rs`) captures
JSON-formatted tracing output over a real `.rpol`-referencing config load
and asserts the fields are present, `u64`, and that the phase timings sum
to no more than the total — no absolute thresholds, so nothing here can
flake on a loaded box. The test warms the callsites and rebuilds the
tracing interest cache inside its subscriber scope: sibling tests in the
same binary reach these callsites with no subscriber installed, which
caches `Interest::never()` process-wide, and a scoped subscriber does not
invalidate that cache on its own.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -D
warnings`, `cargo test --workspace`, `cargo doc`,
`scripts/check-clippy-reasons.py`, and `cargo +nightly fuzz build` in
`crates/policy/fuzz` all pass.
