### PR TITLE
Add announcement-overlap dimension to the IRR reload harness (LAN-892)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- IRR reload harness: announcement-overlap dimension (LAN-892). The
+  scenario generator takes `--overlap-fraction F` (default 0 keeps the
+  historical disjoint output byte-identical): a seeded fraction of base
+  prefixes gains a second announcing member, so `per_client_best` and the
+  grouped update-group control stop being behaviorally identical by
+  construction. The reloadstall harness announces the allocation
+  (`RELOADSTALL_OVERLAP_FILE`), excludes each observer's own announced set
+  from completion, and dumps per-observer final-generation received views
+  (`RELOADSTALL_RECEIVED_VIEW_FILE`). The topology proof derives Loc-RIB,
+  Adj-RIB-In (achieved-overlap), and per-mode Adj-RIB-Out expectations
+  from the scenario manifest, and `verify-receipt.py` gains a
+  `received-view-delta` gate — the observer-side count of (member, prefix)
+  pairs where per-client-best delivered a runner-up path grouped mode
+  suppressed, cross-checked against the manifest allocation — wired into
+  the four-root campaign verifier with red-proofs for overlap-fraction
+  mismatch, manifest/input binding, achieved-overlap drift, grouped-bound
+  violations, and mismatched received-view scenarios.
+
 ### Fixed
 
 - The IRR BMP buffer-receipt sink no longer starves its stop-file check

--- a/bench/scale/irrreload/README.md
+++ b/bench/scale/irrreload/README.md
@@ -41,6 +41,7 @@ policy generations:
 | Announced base table (`TOTAL_PREFIXES`) | 100 | 183,040 (572/member) | 183,040 (572/member) |
 | Per-member IRR filter list (`MIN_LIST`–`MAX_LIST`) | 100 | log-uniform 1,000–40,000 | log-uniform 1,000–40,000 |
 | Per-member change probability (`CHANGED_FRACTION`) | 10% | 10% | 10% |
+| Announcement overlap (`OVERLAP_FRACTION`) | 0 | 0 (canonical) / >0 (LAN-892) | 0 |
 | Seed (`SEED`) | 61 | 61 | 61 |
 | Reload cycles per cell (`RELOADS`) | 1 | 4 | 4 |
 
@@ -57,6 +58,98 @@ The multi-MB configs are **not** committed; they reproduce from the generator
 and pinned inputs. Padding prefixes are /24s from
 30.0.0.0–99.255.255.0 (disjoint from the announced table, the churn range,
 and the bogon list).
+
+## Announcement overlap (LAN-892)
+
+The canonical scenario announces disjoint per-member slices: the Loc-RIB is
+the sum of the per-peer Adj-RIB-Ins and no prefix ever has two candidate
+paths, so `per_client_best` and the grouped control are behaviorally
+identical by construction. `OVERLAP_FRACTION=F` (default 0) makes the
+comparison real: `round(F x TOTAL_PREFIXES)` base prefixes, drawn uniformly
+under a seed-derived RNG stream, each gain exactly ONE second announcing
+member (drawn uniformly from the other members). The second announcer's
+stub announces the prefix, its IRR filter lists admit it in both
+generations, and the allocation is recorded in the scenario manifest
+(`overlap_fraction`, `overlap_pairs`) and in the `overlap.tsv` runtime file
+the harness consumes. `F=0` reproduces the historical generator output
+byte-for-byte (no new files or manifest keys; the seed-61 canonical dataset
+digest is unchanged and pinned in
+`tests/reloadstall_scenario_emitted_check.rs`).
+
+Model limits, stated plainly: every overlapped prefix has exactly two
+announcers (real route servers see heavier tails), the second announcer is
+uniform over members (real overlap concentrates in large transit/CDN
+members), and both paths are equal-preference single-hop routes decided by
+daemon tie-break.
+
+**Topology proof under overlap.** The pre-reload topology gate computes its
+expectations from the manifest allocation instead of assuming disjointness:
+Loc-RIB stays exactly `TOTAL_PREFIXES` (one best route per prefix);
+per-peer Adj-RIB-In must equal that member's announced count (slice +
+second-announcer extras), which also pins the ACHIEVED overlap fraction
+against the manifest (sum of Adj-RIB-Ins = total + overlapped count); in
+`per_client_best` mode each member's Adj-RIB-Out must include the
+runner-up path for every overlapped prefix it announces (only exclusively
+announced prefixes stay suppressed — this is the mode's differentiator and
+is asserted exactly); in grouped mode the winning announcer per overlapped
+prefix is a daemon tie-break, so each member's Adj-RIB-Out is bounded by
+its announced/exclusive counts and the global suppression must total
+exactly one best announcer per prefix. The F=0 case reproduces the
+historical exact assertions verbatim.
+
+**Received-view delta.** The receipt's headline observable for LAN-892 is
+the count of (member, prefix) pairs where per-client-best delivered a
+runner-up path that grouped mode suppressed. It is computed observer-side:
+after the final measured reload, with stub sessions still live, the harness
+dumps each observer's final-generation received view (base prefixes seen
+with the generation marker, BEFORE own-announcement exclusion) to
+`received-view.tsv` (`RELOADSTALL_RECEIVED_VIEW_FILE`), retained in each
+rustbgpd cell's sealed evidence. `verify-receipt.py received-view-delta`
+(and the four-root `campaigns` verifier, per A/B repeat) compares the
+private and grouped cells' views over the same sealed scenario: grouped
+deliveries must be a pointwise subset of per-client-best deliveries, every
+delta pair must be an overlapped prefix observed at one of its announcers,
+and the total must equal the manifest allocation exactly (one suppressed
+best-path announcer per overlapped prefix). Any deviation — mismatched
+scenarios, tampered views, a runner-up that never reached the wire — makes
+the verifier red. No daemon-side gauge is used for this number; the
+Adj-RIB-Out gauges above corroborate it from the daemon side.
+
+**Choosing F.** Public evidence on how much of a route server's table is
+announced by 2+ members is thin. The one published point estimate we found
+is preliminary and single-IXP: an ACM SIGCOMM 2025 poster crawling Alice
+Looking Glass snapshots at 16 major IXPs reports that at one of the largest
+European IXPs roughly 50% of prefixes have alternative paths (Alhamwy,
+Khoulani, Hohlfeld, "POSTER: Crawling Alice Looking Glasses at IXPs to
+Quantify BGP Route Diversity", ACM SIGCOMM 2025 Posters and Demos,
+doi:10.1145/3744969.3748457). The path-hiding mechanism this dimension
+exercises is documented in Richter et al., "Peering at Peerings: On the
+Role of IXP Route Servers" (IMC 2014), which describes route servers
+suppressing alternative paths under a single shared RIB. Because the 50%
+figure is a poster-stage measurement of one IXP (and counts prefixes with
+one or more alternatives, where this model generates exactly one), we do
+not bless a single value: LAN-892 campaigns should run a sensitivity pair —
+`OVERLAP_FRACTION=0.1` (conservative low-diversity bound) and
+`OVERLAP_FRACTION=0.5` (the published large-IXP point estimate). The F>0
+campaigns are the LAN-892 receipt's shape; F=0 remains the canonical
+cross-daemon comparison shape.
+
+```bash
+# LAN-892 overlap campaign (quiet host only), one sensitivity point:
+OVERLAP_FRACTION=0.5 ARTIFACTS_DIR=/tmp/irrreload-ov50-comparison-A bench/scale/irrreload/run-irr-reload.sh
+OVERLAP_FRACTION=0.5 ARTIFACTS_DIR=/tmp/irrreload-ov50-grouped-A bench/scale/irrreload/run-irr-reload.sh rustbgpd-sighup-grouped-control
+OVERLAP_FRACTION=0.5 ARTIFACTS_DIR=/tmp/irrreload-ov50-grouped-B bench/scale/irrreload/run-irr-reload.sh rustbgpd-sighup-grouped-control
+OVERLAP_FRACTION=0.5 ARTIFACTS_DIR=/tmp/irrreload-ov50-comparison-B bench/scale/irrreload/run-irr-reload.sh
+
+python3 bench/scale/irrreload/verify-receipt.py campaigns \
+  --output-dir /tmp/irrreload-ov50-verified \
+  /tmp/irrreload-ov50-comparison-A /tmp/irrreload-ov50-grouped-A \
+  /tmp/irrreload-ov50-grouped-B /tmp/irrreload-ov50-comparison-B
+# verification.json carries received_view_delta; standalone form:
+python3 bench/scale/irrreload/verify-receipt.py received-view-delta \
+  --private-cell /tmp/irrreload-ov50-comparison-A/rustbgpd-sighup \
+  --grouped-cell /tmp/irrreload-ov50-grouped-A/rustbgpd-sighup-grouped-control
+```
 
 ## BMP Loc-RIB dump buffer receipt
 

--- a/bench/scale/irrreload/run-irr-reload.sh
+++ b/bench/scale/irrreload/run-irr-reload.sh
@@ -24,8 +24,14 @@
 #             host lock, two quiet samples per cell, and 300 s cool-downs.
 #
 # Knobs (env): N_MEMBERS TOTAL_PREFIXES MIN_LIST MAX_LIST SEED
-#              CHANGED_FRACTION PORT RELOADS CONTROL_SECS BIRD_THREADS
-#              CELL_TIMEOUT START_TIMEOUT ARTIFACTS_DIR TXN_MAX_CANDIDATE_BYTES
+#              CHANGED_FRACTION OVERLAP_FRACTION PORT RELOADS CONTROL_SECS
+#              BIRD_THREADS CELL_TIMEOUT START_TIMEOUT ARTIFACTS_DIR
+#              TXN_MAX_CANDIDATE_BYTES
+#
+# OVERLAP_FRACTION (default 0) selects the LAN-892 overlap shape: that
+# fraction of base prefixes is announced by a second member, so per-client
+# best and grouped update-group modes stop being behaviorally identical by
+# construction. 0 reproduces the historical disjoint scenario byte-for-byte.
 #
 set -u
 set -o pipefail
@@ -96,6 +102,11 @@ else
 fi
 SEED="${SEED:-61}"
 CHANGED_FRACTION="${CHANGED_FRACTION:-0.1}"
+OVERLAP_FRACTION="${OVERLAP_FRACTION:-0}"
+awk -v f="$OVERLAP_FRACTION" 'BEGIN { exit !(f ~ /^[0-9]+([.][0-9]+)?$/ && f + 0 >= 0 && f + 0 < 1) }' || {
+    echo "OVERLAP_FRACTION must be a decimal in [0, 1)" >&2
+    exit 2
+}
 PORT="${PORT:-1790}"
 # Hard readiness ceiling only; startup is not a reported measurement.
 START_TIMEOUT="${START_TIMEOUT:-600}"
@@ -143,6 +154,7 @@ if [ -n "${DRY_RUN_PROTOCOL:-}" ]; then
     printf 'rustbgpd_grouped_control=path_hiding:false,admit_churn:true,standalone:true\n'
     printf 'competitor_path_hiding=applicable:false,requested:true\n'
     printf 'shape=%s,%s,%s,%s\n' "$N_MEMBERS" "$TOTAL_PREFIXES" "$MIN_LIST" "$MAX_LIST"
+    printf 'overlap_fraction=%s\n' "$OVERLAP_FRACTION"
     printf 'reloads=%s control_secs=%s txn_max_candidate_bytes=%s\n' \
         "$RELOADS" "$CONTROL_SECS" "$TXN_MAX_CANDIDATE_BYTES"
     exit 0
@@ -267,7 +279,8 @@ CAMPAIGN_PROVENANCE=$(jq -cn \
     --arg smoke "$SMOKE" --arg n_members "$N_MEMBERS" \
     --arg total_prefixes "$TOTAL_PREFIXES" --arg min_list "$MIN_LIST" \
     --arg max_list "$MAX_LIST" --arg seed "$SEED" \
-    --arg changed_fraction "$CHANGED_FRACTION" --arg port "$PORT" \
+    --arg changed_fraction "$CHANGED_FRACTION" \
+    --arg overlap_fraction "$OVERLAP_FRACTION" --arg port "$PORT" \
     --arg reloads "$RELOADS" --arg control_secs "$CONTROL_SECS" \
     --arg campaign_kind "$CAMPAIGN_KIND" \
     --arg txn_max_candidate_bytes "$TXN_MAX_CANDIDATE_BYTES" \
@@ -280,7 +293,7 @@ CAMPAIGN_PROVENANCE=$(jq -cn \
     --arg cpu_model "$(awk -F: '/^model name/ { sub(/^[[:space:]]+/, "", $2); print $2; exit }' /proc/cpuinfo)" \
     --arg bird_image "$BIRD_IMAGE" --arg bird_image_id "$BIRD_IMAGE_ID" \
     --arg openbgpd_image "$OPENBGPD_IMAGE" --arg openbgpd_image_id "$OPENBGPD_IMAGE_ID" \
-    '{schema:3,started_at_epoch_ns:$started_at_epoch_ns,git:{commit:$commit,dirty:$dirty,dirty_state_sha256:$dirty_state_sha256,origin_main:$origin_main,head_matches_origin_main:$head_matches_origin_main},scripts:{runner:$run_script_sha256,verifier:$verifier_sha256,generator:$generator_sha256,rss_sampler:$sampler_sha256,txn_apply:$txn_apply_sha256,txn_lifecycle:$txn_lifecycle_sha256},binaries:{reloadstall:$harness_sha256,rustbgpd:$daemon_sha256,rbgp:$cli_sha256,rs_config_render:$renderer_sha256},environment:{rustc:$rustc,cargo:$cargo,python:$python,jq:$jq,docker:$docker,kernel:$kernel,cpu_model:$cpu_model},inputs:{campaign_kind:$campaign_kind,cells:$cells,smoke:$smoke,n_members:$n_members,total_prefixes:$total_prefixes,min_list:$min_list,max_list:$max_list,seed:$seed,changed_fraction:$changed_fraction,port:$port,reloads:$reloads,control_secs:$control_secs,txn_max_candidate_bytes:$txn_max_candidate_bytes,cell_timeout:$cell_timeout,start_timeout:$start_timeout,bird_threads:$bird_threads,skip_preflight:$skip_preflight,bird_image:$bird_image,bird_image_id:$bird_image_id,openbgpd_image:$openbgpd_image,openbgpd_image_id:$openbgpd_image_id}}') || exit 1
+    '{schema:3,started_at_epoch_ns:$started_at_epoch_ns,git:{commit:$commit,dirty:$dirty,dirty_state_sha256:$dirty_state_sha256,origin_main:$origin_main,head_matches_origin_main:$head_matches_origin_main},scripts:{runner:$run_script_sha256,verifier:$verifier_sha256,generator:$generator_sha256,rss_sampler:$sampler_sha256,txn_apply:$txn_apply_sha256,txn_lifecycle:$txn_lifecycle_sha256},binaries:{reloadstall:$harness_sha256,rustbgpd:$daemon_sha256,rbgp:$cli_sha256,rs_config_render:$renderer_sha256},environment:{rustc:$rustc,cargo:$cargo,python:$python,jq:$jq,docker:$docker,kernel:$kernel,cpu_model:$cpu_model},inputs:{campaign_kind:$campaign_kind,cells:$cells,smoke:$smoke,n_members:$n_members,total_prefixes:$total_prefixes,min_list:$min_list,max_list:$max_list,seed:$seed,changed_fraction:$changed_fraction,overlap_fraction:$overlap_fraction,port:$port,reloads:$reloads,control_secs:$control_secs,txn_max_candidate_bytes:$txn_max_candidate_bytes,cell_timeout:$cell_timeout,start_timeout:$start_timeout,bird_threads:$bird_threads,skip_preflight:$skip_preflight,bird_image:$bird_image,bird_image_id:$bird_image_id,openbgpd_image:$openbgpd_image,openbgpd_image_id:$openbgpd_image_id}}') || exit 1
 CAMPAIGN_FINGERPRINT=$(printf '%s' "$CAMPAIGN_PROVENANCE" | jq -cS . | sha256sum | cut -d' ' -f1) || exit 1
 SEALED_CAMPAIGN_PROVENANCE=$(printf '%s\n' "$CAMPAIGN_PROVENANCE" | jq -cS \
     --arg fingerprint "$CAMPAIGN_FINGERPRINT" '. + {fingerprint:$fingerprint}') || exit 1
@@ -394,7 +407,7 @@ seal_cell_evidence() {
         fi
         ;;
     rustbgpd-sighup | "$GROUPED_CELL")
-        evidence_files+=(config.toml topology.json topology.tsv metrics-1.prom metrics-2.prom metrics-3.prom pre-churn/ready pre-churn/ack)
+        evidence_files+=(config.toml topology.json topology.tsv metrics-1.prom metrics-2.prom metrics-3.prom pre-churn/ready pre-churn/ack received-view.tsv)
         ;;
     esac
     : >"$cdir/evidence.sha256.tmp"
@@ -552,6 +565,7 @@ capture_topology() {
             [ "$sample" -eq 3 ] || sleep 1
         done
         if python3 "$VERIFY" topology --mode "$mode" --peers "$N_MEMBERS" --total "$TOTAL_PREFIXES" \
+            --manifest "$run/manifest.json" \
             --config "$cdir/config.toml" --timestamps "$cdir/topology.tsv" \
             --output "$cdir/topology.json" "$cdir"/metrics-{1,2,3}.prom 2>"$cdir/topology.error"; then
             rm -f "$cdir/topology.error"
@@ -608,7 +622,8 @@ gen_scenario() {
     shift 2
     python3 "$GEN" "$cell" "$N_MEMBERS" "$TOTAL_PREFIXES" "$run" \
         --port "$PORT" --seed "$SEED" --min-list "$MIN_LIST" \
-        --max-list "$MAX_LIST" --changed-fraction "$CHANGED_FRACTION" "$@"
+        --max-list "$MAX_LIST" --changed-fraction "$CHANGED_FRACTION" \
+        --overlap-fraction "$OVERLAP_FRACTION" "$@"
 }
 
 wait_ready() {
@@ -772,14 +787,19 @@ run_cell() {
     # Background so the precommitted RSS abort criterion can kill the cell.
     final_barrier="$run/final-evidence"
     [ ! -e "$final_barrier" ] || return 1
+    local -a henv=(RELOADSTALL_EVIDENCE_DIR="$final_barrier")
+    # The generator emits overlap.tsv only at OVERLAP_FRACTION > 0; every
+    # cell's stubs must announce the same second-announcer allocation.
+    [ ! -f "$run/overlap.tsv" ] || henv+=(RELOADSTALL_OVERLAP_FILE="$run/overlap.tsv")
     if [ -n "$topology_mode" ]; then
         barrier="$run/pre-churn-evidence"
         [ ! -e "$barrier" ] || return 1
-        setsid env RELOADSTALL_PRE_CHURN_EVIDENCE_DIR="$barrier" \
-            RELOADSTALL_EVIDENCE_DIR="$final_barrier" \
+        henv+=(RELOADSTALL_PRE_CHURN_EVIDENCE_DIR="$barrier"
+            RELOADSTALL_RECEIVED_VIEW_FILE="$cdir/received-view.tsv")
+        setsid env "${henv[@]}" \
             timeout "$CELL_TIMEOUT" stdbuf -oL -eL "$HARNESS" "${hargs[@]}" >"$cdir/reloadstall.log" 2>&1 &
     else
-        setsid env RELOADSTALL_EVIDENCE_DIR="$final_barrier" \
+        setsid env "${henv[@]}" \
             timeout "$CELL_TIMEOUT" stdbuf -oL -eL "$HARNESS" "${hargs[@]}" >"$cdir/reloadstall.log" 2>&1 &
     fi
     local hpid=$!

--- a/bench/scale/irrreload/verify-receipt.py
+++ b/bench/scale/irrreload/verify-receipt.py
@@ -206,6 +206,47 @@ def family_rows(data, name: str, peers: set[str], families: tuple[str, ...]):
     return {(labels["peer"], labels["afi_safi"]): value for labels, value in found}
 
 
+def member_addr(member: int) -> str:
+    """The harness stub source address for member index `member`."""
+    return f"127.1.{member // 200}.{member % 200 + 1}"
+
+
+def load_overlap(manifest_path: Path | None, peers: int, total: int):
+    """Read and validate the manifest's LAN-892 overlap allocation.
+
+    Returns (fraction, pairs) where pairs is [(prefix_index, second_member)].
+    An absent manifest or absent overlap keys is the historical disjoint
+    shape (F=0). The declared fraction must reproduce the allocation size
+    exactly, every pair must be in range with a second announcer distinct
+    from the slice owner, and prefixes may gain at most one second announcer.
+    """
+    manifest = read_json(manifest_path) if manifest_path is not None else {}
+    fraction = manifest.get("overlap_fraction", 0.0)
+    pairs = manifest.get("overlap_pairs", [])
+    per_peer = total // peers
+    if isinstance(fraction, bool) or not isinstance(fraction, (int, float)) or not 0 <= fraction < 1:
+        fail("manifest overlap_fraction is out of range")
+    if not isinstance(pairs, list) or (fraction == 0) != (pairs == []):
+        fail("manifest overlap_fraction and overlap_pairs disagree")
+    if len(pairs) != round(fraction * total):
+        fail("manifest overlap allocation does not match its declared fraction")
+    seen = set()
+    validated = []
+    for pair in pairs:
+        if (
+            not isinstance(pair, list)
+            or len(pair) != 2
+            or any(isinstance(value, bool) or not isinstance(value, int) for value in pair)
+        ):
+            fail("malformed overlap pair")
+        idx, second = pair
+        if not 0 <= idx < total or not 0 <= second < peers or idx // per_peer == second or idx in seen:
+            fail("invalid overlap pair (range, own-slice second announcer, or duplicate)")
+        seen.add(idx)
+        validated.append((idx, second))
+    return fraction, validated
+
+
 def validate_topology(
     mode: str,
     peers: int,
@@ -214,9 +255,16 @@ def validate_topology(
     timestamps: Path,
     metric_paths: list[Path],
     output: Path,
+    manifest: Path | None = None,
 ) -> None:
     if mode not in ("private", "grouped") or len(metric_paths) != 3:
         fail("topology requires private/grouped mode and exactly three scrapes")
+    overlap_fraction, overlap_pairs = load_overlap(manifest, peers, total)
+    announced_extra = [0] * peers
+    own_overlapped = [0] * peers
+    for idx, second in overlap_pairs:
+        announced_extra[second] += 1
+        own_overlapped[idx // (total // peers)] += 1
     config_text = config.read_text()
     if "[neighbors.add_path]" in config_text:
         fail("topology proof requires Add-Path disabled")
@@ -272,21 +320,65 @@ def validate_topology(
             fail("Loc-RIB aggregate mismatch")
         per_peer = total // peers
         adj_in = family_rows(data, "bgp_rib_prefixes", identities, ("all", "flowspec"))
-        if any(
-            adj_in[(peer, family)] != (per_peer if family == "all" else 0)
-            for peer in identities
-            for family in ("all", "flowspec")
-        ):
+        if any(adj_in[(peer, "flowspec")] != 0 for peer in identities):
             fail("Adj-RIB-In aggregate/non-all roster mismatch")
         out_families = ("all", "bgpls", "evpn", "flowspec", "labeled", "rtc", "vpn")
         adj_out = family_rows(data, "bgp_rib_adj_out_prefixes", identities, out_families)
-        expected_out = total - per_peer
         if any(
-            adj_out[(peer, family)] != (expected_out if family == "all" else 0)
+            adj_out[(peer, family)] != 0
             for peer in identities
             for family in out_families
+            if family != "all"
         ):
             fail("Adj-RIB-Out aggregate/non-all roster mismatch")
+        if not overlap_pairs:
+            # Disjoint announcements: the historical exact expectations.
+            if any(adj_in[(peer, "all")] != per_peer for peer in identities):
+                fail("Adj-RIB-In aggregate/non-all roster mismatch")
+            if any(adj_out[(peer, "all")] != total - per_peer for peer in identities):
+                fail("Adj-RIB-Out aggregate/non-all roster mismatch")
+        else:
+            # Overlap shape: per-member expectations from the manifest
+            # allocation, keyed by the deterministic stub addressing.
+            member_of = {member_addr(member): member for member in range(peers)}
+            if set(member_of) != identities:
+                fail("overlap topology requires the harness stub peer roster")
+            for peer in identities:
+                member = member_of[peer]
+                if adj_in[(peer, "all")] != per_peer + announced_extra[member]:
+                    fail("Adj-RIB-In does not reflect the manifest overlap allocation")
+            if mode == "private":
+                # Per-client best must deliver the runner-up path for every
+                # overlapped prefix the observer itself announces: only
+                # exclusively-announced prefixes stay suppressed.
+                if any(
+                    adj_out[(peer, "all")]
+                    != total - (per_peer - own_overlapped[member_of[peer]])
+                    for peer in identities
+                ):
+                    fail("per-client-best Adj-RIB-Out must deliver runner-up paths")
+            else:
+                # One shared group: each prefix is suppressed exactly at its
+                # best-path announcer. Which announcer wins an overlapped
+                # prefix is a daemon tie-break, so bound per member and pin
+                # the exact global suppression count.
+                suppressed = 0
+                for peer in identities:
+                    member = member_of[peer]
+                    value = adj_out[(peer, "all")]
+                    lower = total - (per_peer + announced_extra[member])
+                    upper = total - (per_peer - own_overlapped[member])
+                    if not lower <= value <= upper:
+                        fail("grouped Adj-RIB-Out outside announcer bounds")
+                    suppressed += total - value
+                if suppressed != total:
+                    fail("grouped suppression must total one best announcer per prefix")
+        achieved = sum(adj_in[(peer, "all")] for peer in identities) - total
+        if achieved != len(overlap_pairs):
+            fail(
+                f"achieved overlap ({achieved} second paths) does not match "
+                f"the manifest allocation ({len(overlap_pairs)})"
+            )
         if mode == "private":
             one(data, "bgp_update_groups", 0)
             one(data, "bgp_update_group_fallback_peers", peers)
@@ -331,11 +423,97 @@ def validate_topology(
                 "peers": peers,
                 "scrape_epoch_ns": epoch_ns,
                 "group_id": group_id,
+                "overlap_fraction": overlap_fraction,
+                "overlap_pairs": len(overlap_pairs),
             },
             sort_keys=True,
         )
         + "\n"
     )
+
+
+def read_received_view(path: Path, peers: int, total: int) -> list[set[int]]:
+    """Parse the harness's final-generation received-view dump.
+
+    Returns each observer's MISSING base-prefix set (complement of what it
+    observed with the final generation marker, before own-announcement
+    exclusion).
+    """
+    lines = path.read_text().splitlines()
+    if not lines or lines[0] != f"received_view_v1\ttotal={total}\tpeers={peers}":
+        fail(f"{path}: received-view header mismatch")
+    if len(lines) != peers + 1:
+        fail(f"{path}: received-view observer roster mismatch")
+    missing = []
+    for expected_observer, line in enumerate(lines[1:]):
+        parts = line.split("\t")
+        if len(parts) != 3 or parts[0] != str(expected_observer):
+            fail(f"{path}: malformed received-view row")
+        try:
+            indices = [int(value) for value in parts[2].split(",")] if parts[2] else []
+        except ValueError:
+            fail(f"{path}: non-integer received-view index")
+        if (
+            parts[1] != str(len(indices))
+            or any(not 0 <= value < total for value in indices)
+            or sorted(set(indices)) != indices
+        ):
+            fail(f"{path}: received-view indices invalid")
+        missing.append(set(indices))
+    return missing
+
+
+def received_view_delta(private_cell: Path, grouped_cell: Path) -> dict:
+    """Observer-side per-client-best vs grouped received-view delta.
+
+    Counts (member, prefix) pairs where per-client-best delivered a runner-up
+    path that grouped mode suppressed, from the two cells' retained
+    received-view dumps over the SAME scenario. Every delta pair must be an
+    overlapped prefix observed at one of its announcers, grouped deliveries
+    must be a pointwise subset of per-client-best deliveries, and the total
+    must equal the manifest allocation (exactly one suppressed announcer —
+    the best-path one — per overlapped prefix).
+    """
+    manifests = [read_json(cell / "manifest.json") for cell in (private_cell, grouped_cell)]
+    shared = (
+        "dataset_sha256",
+        "n_members",
+        "total_prefixes",
+        "seed",
+        "overlap_fraction",
+        "overlap_pairs",
+    )
+    if any(manifests[0].get(key) != manifests[1].get(key) for key in shared):
+        fail("received-view delta cells do not share one scenario")
+    if manifests[0].get("path_hiding") is not True or manifests[1].get("path_hiding") is not False:
+        fail("received-view delta requires one private cell and one grouped cell")
+    peers, total = manifests[0].get("n_members"), manifests[0].get("total_prefixes")
+    if not isinstance(peers, int) or not isinstance(total, int) or peers <= 0 or total <= 0:
+        fail("received-view delta manifests lack a valid shape")
+    fraction, pairs = load_overlap(private_cell / "manifest.json", peers, total)
+    per_peer = total // peers
+    announcers = {idx: {idx // per_peer, second} for idx, second in pairs}
+    private_missing = read_received_view(private_cell / "received-view.tsv", peers, total)
+    grouped_missing = read_received_view(grouped_cell / "received-view.tsv", peers, total)
+    delta = 0
+    for member in range(peers):
+        if not private_missing[member] <= grouped_missing[member]:
+            fail("grouped mode delivered a prefix per-client-best did not")
+        for idx in grouped_missing[member] - private_missing[member]:
+            if member not in announcers.get(idx, ()):
+                fail("received-view delta pair is outside the overlap allocation")
+            delta += 1
+    if delta != len(pairs):
+        fail(
+            f"received-view delta ({delta}) does not equal the overlap "
+            f"allocation ({len(pairs)})"
+        )
+    return {
+        "status": "pass",
+        "overlap_fraction": fraction,
+        "overlap_pairs": len(pairs),
+        "suppressed_runner_up_pairs": delta,
+    }
 
 
 def sha256(path: Path) -> str:
@@ -1172,11 +1350,22 @@ def validate_root(root: Path, kind: str):
         "cells",
         "bird_image_id",
         "openbgpd_image_id",
+        "overlap_fraction",
     }
     if set(inputs) != expected_input_keys or any(
         inputs.get(key) != value for key, value in CANONICAL_FULL_INPUTS.items()
     ):
         fail(f"{root}: full workload inputs are not exact and canonical")
+    # The overlap fraction is a legitimate campaign dimension (LAN-892), not
+    # a canonical constant: require a well-formed value and bind every cell
+    # manifest to it below. Cross-root equality rides the inputs identity.
+    inputs_overlap = inputs.get("overlap_fraction")
+    if (
+        not isinstance(inputs_overlap, str)
+        or not re.fullmatch(r"[0-9]+([.][0-9]+)?", inputs_overlap)
+        or not 0 <= float(inputs_overlap) < 1
+    ):
+        fail(f"{root}: overlap_fraction input is not a decimal in [0, 1)")
     selected_image = re.compile(r"sha256:[0-9a-f]{64}")
     expected_image_id = selected_image.fullmatch if kind == "comparison" else None
     if (
@@ -1256,6 +1445,9 @@ def validate_root(root: Path, kind: str):
         )
         if manifest.get("dataset_sha256") != dataset or manifest.get("admit_churn") is not True:
             fail(f"{root}: {cell} manifest dataset/churn mismatch")
+        if manifest.get("overlap_fraction", 0.0) != float(inputs_overlap):
+            fail(f"{root}: {cell} manifest overlap does not match campaign inputs")
+        load_overlap(cdir / "manifest.json", 320, 183040)
         manifest_shape = tuple(
             int(manifest.get(name, -1))
             for name in ("n_members", "total_prefixes", "min_list", "max_list", "seed")
@@ -1285,6 +1477,7 @@ def validate_root(root: Path, kind: str):
                 marker_path = cdir / "pre-churn" / marker
                 if marker_path.is_symlink() or not marker_path.is_file() or marker_path.read_text() != f"{marker}\n":
                     fail(f"{root}: {cell} pre-churn {marker} is not an exact regular marker")
+            read_received_view(cdir / "received-view.tsv", 320, 183040)
             topology = read_json(cdir / "topology.json")
             expected_mode = "private" if cell == "rustbgpd-sighup" else "grouped"
             with tempfile.NamedTemporaryFile() as revalidated:
@@ -1296,11 +1489,12 @@ def validate_root(root: Path, kind: str):
                     cdir / "topology.tsv",
                     [cdir / f"metrics-{sample}.prom" for sample in range(1, 4)],
                     Path(revalidated.name),
+                    cdir / "manifest.json",
                 )
                 raw_topology = read_json(Path(revalidated.name))
             scrapes = topology.get("scrape_epoch_ns", [])
             if (
-                any(topology.get(key) != raw_topology.get(key) for key in ("status", "mode", "peers", "scrape_epoch_ns", "group_id"))
+                any(topology.get(key) != raw_topology.get(key) for key in ("status", "mode", "peers", "scrape_epoch_ns", "group_id", "overlap_fraction", "overlap_pairs"))
                 or topology.get("status") != "pass"
                 or topology.get("mode") != expected_mode
                 or topology.get("peers") != 320
@@ -1401,6 +1595,20 @@ def validate_campaigns(roots: list[Path], output_dir: Path) -> None:
     identities = [identity for entry in campaigns for identity in entry["identities"]]
     if len(identities) != len(set(identities)):
         fail("daemon PID/start identity was reused across campaign cells")
+    # Received-view delta (LAN-892): per repeat, the observer-side count of
+    # (member, prefix) pairs where per-client-best delivered a runner-up path
+    # that the grouped control suppressed, over the shared scenario.
+    deltas = {
+        label: received_view_delta(
+            comparison_root / "rustbgpd-sighup", grouped_root / GROUPED_CELL
+        )
+        for label, comparison_root, grouped_root in (
+            ("A", roots[0], roots[1]),
+            ("B", roots[3], roots[2]),
+        )
+    }
+    if deltas["A"] != deltas["B"]:
+        fail("A/B repeats disagree on the received-view delta")
     output_dir.mkdir(parents=True, exist_ok=False)
     write_combined(
         output_dir / "comparison.csv", (campaigns[0], campaigns[3]), COMPARISON_CELLS
@@ -1417,6 +1625,7 @@ def validate_campaigns(roots: list[Path], output_dir: Path) -> None:
                 "dataset_sha256": campaigns[0]["dataset"],
                 "comparison_rows": len(campaigns[0]["rows"]) + len(campaigns[3]["rows"]),
                 "grouped_control_rows": len(campaigns[1]["rows"]) + len(campaigns[2]["rows"]),
+                "received_view_delta": deltas["A"],
             },
             sort_keys=True,
         )
@@ -1558,6 +1767,7 @@ def make_fixture(root: Path, kind: str, started: int, identity_seed: int) -> Non
         "environment": {key: "fixture" for key in ("rustc", "cargo", "python", "jq", "docker", "kernel", "cpu_model")},
         "inputs": {
             **CANONICAL_FULL_INPUTS,
+            "overlap_fraction": "0",
             "campaign_kind": {"comparison": "full-cross-daemon", "grouped": "full-grouped-control", "transaction": "full-transaction"}[kind],
             "cells": ",".join(cells),
             "bird_image_id": image_id if kind == "comparison" else "not-selected",
@@ -1620,7 +1830,12 @@ def make_fixture(root: Path, kind: str, started: int, identity_seed: int) -> Non
         if cell in ("rustbgpd-sighup", GROUPED_CELL):
             topology_mode = "private" if cell == "rustbgpd-sighup" else "grouped"
             group_id = None if topology_mode == "private" else 7
-            (cdir / "topology.json").write_text(json.dumps({"status": "pass", "mode": topology_mode, "peers": 320, "scrape_epoch_ns": [1_000_000_000, 2_000_000_000, 3_000_000_000], "group_id": group_id, "first_reload_wall_us": 4_000_000}))
+            (cdir / "topology.json").write_text(json.dumps({"status": "pass", "mode": topology_mode, "peers": 320, "scrape_epoch_ns": [1_000_000_000, 2_000_000_000, 3_000_000_000], "group_id": group_id, "first_reload_wall_us": 4_000_000, "overlap_fraction": 0.0, "overlap_pairs": 0}))
+            received_rows = [f"received_view_v1\ttotal=183040\tpeers=320"]
+            for observer in range(320):
+                own = ",".join(str(index) for index in range(observer * 572, (observer + 1) * 572))
+                received_rows.append(f"{observer}\t572\t{own}")
+            (cdir / "received-view.tsv").write_text("\n".join(received_rows) + "\n")
             (cdir / "config.toml").write_text("per_client_best = true\n" * (320 if cell == "rustbgpd-sighup" else 0))
             (cdir / "topology.tsv").write_text("phase\tepoch_ns\nscrape1\t1000000000\nscrape2\t2000000000\nscrape3\t3000000000\n")
             metrics = ["bgp_rib_outbound_registered_peers 320", "bgp_rib_ingest_channel_depth 0", "bgp_rib_policy_transition_in_progress 0", 'bgp_rib_loc_prefixes{afi_safi="all"} 183040']
@@ -1940,6 +2155,154 @@ def self_test() -> None:
         wrong_count = topology_dir / "wrong-count.toml"
         wrong_count.write_text("per_client_best = true\n")
         topology_rejected("config-count", "none", wrong_count)
+
+        # --- Overlap topology (LAN-892): 2 members x 4 prefixes, prefix 0
+        # gains member 1 as second announcer (fraction 1/8). ---
+        overlap_dir = base / "overlap"
+        overlap_dir.mkdir()
+        addr = [member_addr(member) for member in range(2)]
+
+        def overlap_manifest(name, fraction=0.125, pairs=((0, 1),)):
+            path = overlap_dir / f"{name}.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "overlap_fraction": fraction,
+                        "overlap_pairs": [list(pair) for pair in pairs],
+                    }
+                )
+            )
+            return path
+
+        def overlap_metric_text(mode, adj_in, adj_out):
+            lines = [
+                "bgp_rib_outbound_registered_peers 2",
+                "bgp_rib_ingest_channel_depth 0",
+                "bgp_rib_policy_transition_in_progress 0",
+                'bgp_rib_loc_prefixes{afi_safi="all"} 8',
+            ]
+            for member, peer in enumerate(addr):
+                lines += [
+                    f'bgp_peer_session_established{{interface="eth0",peer="{peer}"}} 1',
+                    f'bgp_session_established_total{{peer="{peer}"}} 1',
+                    f'bgp_peer_outbound_queue_depth{{peer="{peer}"}} 0',
+                    f'bgp_rib_prefixes{{afi_safi="all",peer="{peer}"}} {adj_in[member]}',
+                    f'bgp_rib_prefixes{{afi_safi="flowspec",peer="{peer}"}} 0',
+                ]
+                lines += [
+                    f'bgp_rib_adj_out_prefixes{{afi_safi="{family}",peer="{peer}"}} '
+                    f'{adj_out[member] if family == "all" else 0}'
+                    for family in ("all", "bgpls", "evpn", "flowspec", "labeled", "rtc", "vpn")
+                ]
+            if mode == "private":
+                lines += ["bgp_update_groups 0", "bgp_update_group_fallback_peers 2"]
+                lines += [f'bgp_peer_update_group{{peer="{peer}"}} -1' for peer in addr]
+            else:
+                lines += [
+                    "bgp_update_groups 1",
+                    "bgp_update_group_fallback_peers 0",
+                    'bgp_update_group_members{group="7"} 2',
+                ]
+                lines += [f'bgp_peer_update_group{{peer="{peer}"}} 7' for peer in addr]
+            return "\n".join(lines) + "\n"
+
+        def overlap_topology(name, mode, adj_in, adj_out, manifest_path):
+            config = overlap_dir / f"{name}.toml"
+            config.write_text("per_client_best = true\n" * (2 if mode == "private" else 0))
+            paths = []
+            for sample in range(1, 4):
+                path = overlap_dir / f"{name}-{sample}.prom"
+                path.write_text(overlap_metric_text(mode, adj_in, adj_out))
+                paths.append(path)
+            validate_topology(
+                mode, 2, 8, config, timestamps, paths, overlap_dir / f"{name}.json", manifest_path
+            )
+
+        good_overlap = overlap_manifest("good")
+        # Private: runner-up delivery leaves only exclusive announcements
+        # suppressed. Grouped: member 0 wins the overlapped prefix.
+        overlap_topology("private-green", "private", (4, 5), (5, 4), good_overlap)
+        overlap_topology("grouped-green", "grouped", (4, 5), (4, 4), good_overlap)
+
+        def overlap_rejected(name, mode, adj_in, adj_out, manifest_path):
+            try:
+                overlap_topology(f"bad-{name}", mode, adj_in, adj_out, manifest_path)
+            except InvalidReceipt:
+                proofs[name] = True
+                return
+            fail(f"red overlap fixture unexpectedly accepted: {name}")
+
+        overlap_rejected(
+            "overlap-fraction-mismatch", "private", (4, 5), (5, 4),
+            overlap_manifest("fraction-mismatch", fraction=0.25),
+        )
+        overlap_rejected(
+            "overlap-pair-own-slice", "private", (4, 5), (5, 4),
+            overlap_manifest("own-slice", pairs=((0, 0),)),
+        )
+        overlap_rejected("overlap-achieved", "private", (4, 4), (5, 4), good_overlap)
+        overlap_rejected("overlap-private-runner-up", "private", (4, 5), (4, 4), good_overlap)
+        overlap_rejected("overlap-grouped-bounds", "grouped", (4, 5), (4, 5), good_overlap)
+        overlap_rejected("overlap-grouped-sum", "grouped", (4, 5), (5, 4), good_overlap)
+
+        # --- Received-view delta (LAN-892) over the same tiny shape. ---
+        def delta_cell(name, path_hiding, missing, dataset="d" * 64):
+            cell = base / f"delta-{name}"
+            cell.mkdir()
+            (cell / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "dataset_sha256": dataset,
+                        "n_members": 2,
+                        "total_prefixes": 8,
+                        "seed": 61,
+                        "path_hiding": path_hiding,
+                        "overlap_fraction": 0.125,
+                        "overlap_pairs": [[0, 1]],
+                    }
+                )
+            )
+            rows = ["received_view_v1\ttotal=8\tpeers=2"]
+            for observer, indices in enumerate(missing):
+                joined = ",".join(str(index) for index in sorted(indices))
+                rows.append(f"{observer}\t{len(indices)}\t{joined}")
+            (cell / "received-view.tsv").write_text("\n".join(rows) + "\n")
+            return cell
+
+        private_view = delta_cell("private", True, [{1, 2, 3}, {4, 5, 6, 7}])
+        grouped_view = delta_cell("grouped", False, [{0, 1, 2, 3}, {4, 5, 6, 7}])
+        result = received_view_delta(private_view, grouped_view)
+        if result["suppressed_runner_up_pairs"] != 1 or result["status"] != "pass":
+            fail("received-view delta green fixture did not pass")
+
+        def delta_rejected(name, private_cell, grouped_cell):
+            try:
+                received_view_delta(private_cell, grouped_cell)
+            except InvalidReceipt:
+                proofs[name] = True
+                return
+            fail(f"red received-view fixture unexpectedly accepted: {name}")
+
+        delta_rejected(
+            "received-view-scenario",
+            private_view,
+            delta_cell("other-dataset", False, [{0, 1, 2, 3}, {4, 5, 6, 7}], dataset="e" * 64),
+        )
+        delta_rejected(
+            "received-view-subset",
+            delta_cell("private-undelivered", True, [{0, 1, 2, 3}, {4, 5, 6, 7}]),
+            delta_cell("grouped-over", False, [{1, 2, 3}, {4, 5, 6, 7}]),
+        )
+        delta_rejected(
+            "received-view-delta-count",
+            delta_cell("private-count", True, [{1, 2, 3}, {4, 5, 6, 7}]),
+            delta_cell("grouped-count", False, [{1, 2, 3}, {4, 5, 6, 7}]),
+        )
+        delta_rejected(
+            "received-view-outside-allocation",
+            delta_cell("private-outside", True, [{1, 2, 3}, {4, 5, 6, 7}]),
+            delta_cell("grouped-outside", False, [{1, 2, 3}, {1, 4, 5, 6, 7}]),
+        )
         names = ("comparison-a", "grouped-a", "grouped-b", "comparison-b")
         kinds = ("comparison", "grouped", "grouped", "comparison")
         roots = [base / name for name in names]
@@ -2149,6 +2512,18 @@ def self_test() -> None:
             alter_json(manifest_path, lambda data: data["runtime_files"].append("extra.conf"))
             rebind_scenario_manifest(cdir)
         rejected("scenario-roster", break_scenario_roster)
+        def break_overlap_input_binding(root):
+            # Internally valid manifest overlap (1 pair at the canonical
+            # total) while the campaign inputs still declare overlap 0.
+            cdir = root / "bird"
+            alter_json(
+                cdir / "manifest.json",
+                lambda data: data.update(
+                    {"overlap_fraction": 1 / 183040, "overlap_pairs": [[0, 1]]}
+                ),
+            )
+            rebind_scenario_manifest(cdir)
+        rejected("overlap-input-binding", break_overlap_input_binding)
         def break_scenario_duplicate(root):
             cdir = root / "bird"
             alter_json(cdir / "manifest.json", lambda data: data["runtime_files"].append("bird.conf"))
@@ -2297,6 +2672,12 @@ def self_test() -> None:
         grouped_pair_drift("cross-role-source-identity", "binaries", "rbgp", "a" * 64)
         expected = {"default-roster", "mixed-roster", "mode-flags", "topology-mutation", "barrier-marker", "final-barrier-marker", "live-topology-gauge", "route-gauge", "route-family", "one-scrape-drift", "add-path", "config-count", "dirty-commit", "origin-only", "head-matches-false", "mismatched-commit", "commit-malformed", "scripts-null", "scripts-empty-map", "binary-malformed", "fingerprint-recompute", "canonical-changed-fraction", "canonical-control-secs", "canonical-bird-threads", "repeat-image-identity", "cell-root-provenance", "nonoverlap-order", "quiet-spacing", "preflight-raw", "cell-status", "cell-provenance", "evidence-roster", "scenario-roster", "scenario-duplicate", "scenario-unsafe-path", "scenario-retained-config", "cell-root-rows", "reload-log-rows", "percentile-order", "percentile-positive", "first-generation-bound", "observer-gap-bound", "row-invariants", "rss-raw", "seal-checksum", "exact-root-roster", "symlink-anywhere", "writable-root", "grouped-output-isolation", "output-exact-roster", "output-audit-call", "ordering", "reused-identity", "cross-role-environment", "cross-role-source-identity"}
         expected |= {"current-down", "reestablished", "flapped", "counter-malformed", "establishment-roster", "flap-roster", "row-session-loss"}
+        expected |= set(
+            """overlap-fraction-mismatch overlap-pair-own-slice overlap-achieved
+            overlap-private-runner-up overlap-grouped-bounds overlap-grouped-sum
+            overlap-input-binding received-view-scenario received-view-subset
+            received-view-delta-count received-view-outside-allocation""".split()
+        )
         expected |= set("""v3-inspector-linkage v3-inspector-mode v3-inspector-target v3-inspector-canonical v3-inspector-field-order v3-inspector-nested-order v3-inspector-raw-utf8 transaction-cycle-roster transaction-plan-token transaction-confirm transaction-v3-pending transaction-v3-linkage transaction-apply-deadline-missing transaction-apply-deadline-bool transaction-v3-deadline-missing transaction-v3-deadline-bool transaction-v3-deadline-stale transaction-v3-deadline-swapped transaction-v3-deadline-tamper transaction-schema-v1 transaction-lifecycle-schema-v1 transaction-v3-cleanup transaction-history transaction-abort transaction-timeout transaction-noop transaction-opposite
 transaction-token-leak transaction-warning-log transaction-warning-binding transaction-applied-generation transaction-scenario-generation transaction-cross-root-generation transaction-port-gate transaction-disk-gate transaction-swap-gate transaction-fallback-shape
 transaction-mixed-binary transaction-process-reuse transaction-file-tamper transaction-extra-file""".split())
@@ -2318,7 +2699,16 @@ def main() -> int:
     topology.add_argument("--config", type=Path, required=True)
     topology.add_argument("--timestamps", type=Path, required=True)
     topology.add_argument("--output", type=Path, required=True)
+    topology.add_argument(
+        "--manifest",
+        type=Path,
+        help="scenario manifest carrying the overlap allocation (absent = disjoint)",
+    )
     topology.add_argument("metrics", nargs=3, type=Path)
+    delta_parser = subparsers.add_parser("received-view-delta")
+    delta_parser.add_argument("--private-cell", required=True, type=Path)
+    delta_parser.add_argument("--grouped-cell", required=True, type=Path)
+    delta_parser.add_argument("--output", type=Path)
     campaigns = subparsers.add_parser("campaigns")
     campaigns.add_argument("--output-dir", required=True, type=Path)
     campaigns.add_argument("roots", nargs=4, type=Path)
@@ -2337,7 +2727,12 @@ def main() -> int:
     args = parser.parse_args()
     try:
         if args.command == "topology":
-            validate_topology(args.mode, args.peers, args.total, args.config, args.timestamps, args.metrics, args.output)
+            validate_topology(args.mode, args.peers, args.total, args.config, args.timestamps, args.metrics, args.output, args.manifest)
+        elif args.command == "received-view-delta":
+            result = received_view_delta(args.private_cell, args.grouped_cell)
+            if args.output is not None:
+                args.output.write_text(json.dumps(result, sort_keys=True) + "\n")
+            print(json.dumps(result, sort_keys=True))
         elif args.command == "campaigns":
             validate_campaigns(args.roots, args.output_dir)
         elif args.command == "transactions":

--- a/bench/scale/reloadstall/gen-irr-scenario.py
+++ b/bench/scale/reloadstall/gen-irr-scenario.py
@@ -50,8 +50,16 @@ live at 172.16-23.x and must propagate for the inter-UPDATE gap baseline.
 Usage:
     gen-irr-scenario.py <cell> <n_members> <total_prefixes> <out_dir>
         [--port 1790] [--seed 61] [--min-list 1000] [--max-list 40000]
-        [--changed-fraction 0.1] [--render-bin PATH] [--threads 8]
-        [--conf-dir DIR] [--path-hiding true|false] [--admit-churn true|false]
+        [--changed-fraction 0.1] [--overlap-fraction 0.0] [--render-bin PATH]
+        [--threads 8] [--conf-dir DIR] [--path-hiding true|false]
+        [--admit-churn true|false]
+
+With --overlap-fraction F > 0, round(F * total_prefixes) base prefixes gain a
+second announcing member (drawn uniformly, seed-deterministic); the second
+announcer's filter lists admit them, an overlap.tsv runtime file carries the
+allocation for the harness stubs, and the manifest records
+overlap_fraction/overlap_pairs. F=0 output is byte-identical to the
+pre-overlap generator (no new files or manifest keys).
 
 Emits into <out_dir> (per cell):
   rustbgpd      config.toml, member.rpol (live, = gen-a), gen-a.rpol,
@@ -117,6 +125,9 @@ class Member:
         self.addr = addr
         self.list_a = list_a
         self.list_b = list_b
+        # Global base-table indices this member announces IN ADDITION to its
+        # own contiguous slice (the --overlap-fraction second-announcer role).
+        self.announced_extra = []
 
     def prefixes(self, gen: str) -> list[str]:
         return self.list_a if gen == "a" else self.list_b
@@ -156,6 +167,52 @@ def build_dataset(args) -> list[Member]:
     return members
 
 
+def apply_overlap(args, members: list[Member]) -> list[tuple[int, int]]:
+    """Overlap model (LAN-892): a fraction F of the announced base table is
+    announced by exactly TWO members instead of one.
+
+    round(F * total_prefixes) distinct base prefixes are drawn uniformly;
+    each gains ONE second announcer drawn uniformly from the other members.
+    The second announcer's filter lists admit the prefix in both generations
+    (announced prefixes are never generation-churned). The draw uses a
+    seed-derived RNG stream separate from build_dataset's, so F=0 leaves the
+    generator's output byte-identical to the pre-overlap generator and any
+    F>0 allocation is deterministic under the seed.
+    """
+    count = round(args.overlap_fraction * args.total_prefixes)
+    if count == 0:
+        return []
+    per_peer = args.total_prefixes // args.n_members
+    rng = random.Random(f"irr-overlap-{args.seed}")
+    pairs = []
+    extras: dict[int, list[str]] = {}
+    for idx in sorted(rng.sample(range(args.total_prefixes), count)):
+        owner = idx // per_peer
+        second = rng.randrange(args.n_members - 1)
+        if second >= owner:
+            second += 1
+        pairs.append((idx, second))
+        members[second].announced_extra.append(idx)
+        extras.setdefault(second, []).append(base_prefix(idx))
+    for member_idx, prefixes in extras.items():
+        member = members[member_idx]
+        # list_b may alias list_a for unchanged members; capture that before
+        # rebinding so the extras land exactly once in each generation.
+        aliased = member.list_b is member.list_a
+        member.list_a = member.list_a + prefixes
+        member.list_b = member.list_a if aliased else member.list_b + prefixes
+    return pairs
+
+
+def write_overlap_file(out: pathlib.Path, pairs: list[tuple[int, int]]) -> list[str]:
+    """Emit the harness's second-announcer allocation (member<TAB>prefix idx)."""
+    if not pairs:
+        return []
+    lines = [f"{second}\t{idx}" for idx, second in pairs]
+    (out / "overlap.tsv").write_text("\n".join(lines) + "\n")
+    return ["overlap.tsv"]
+
+
 def check_sun_len(rundir: pathlib.Path) -> str:
     """gRPC UDS path must fit sun_path (~108 bytes); fail early like siblings."""
     sock = f"{rundir}/grpc.sock"
@@ -175,10 +232,17 @@ def canonical_member_record(member: Member) -> bytes:
         "list_a": member.list_a,
         "list_b": member.list_b,
     }
+    # Emitted only when the member is a second announcer, so the F=0 canonical
+    # stream (and its pinned seed-61 digest) is byte-identical to the
+    # pre-overlap generator.
+    if member.announced_extra:
+        record["announced_extra"] = member.announced_extra
     return json.dumps(record, sort_keys=True, separators=(",", ":")).encode() + b"\n"
 
 
-def write_manifest(out: pathlib.Path, args, members, files: list[str]) -> None:
+def write_manifest(
+    out: pathlib.Path, args, members, files: list[str], overlap: list[tuple[int, int]]
+) -> None:
     dataset_digest = hashlib.sha256()
     for member in members:
         dataset_digest.update(canonical_member_record(member))
@@ -207,6 +271,10 @@ def write_manifest(out: pathlib.Path, args, members, files: list[str]) -> None:
         "runtime_files": files,
         "file_bytes": {f: (out / f).stat().st_size for f in files},
     }
+    if overlap:
+        # Keys are absent at F=0 so the default manifest stays byte-identical.
+        manifest["overlap_fraction"] = args.overlap_fraction
+        manifest["overlap_pairs"] = [list(pair) for pair in overlap]
     (out / "manifest.json").write_text(json.dumps(manifest, indent=1) + "\n")
 
 
@@ -769,6 +837,13 @@ def main() -> None:
     parser.add_argument("--min-list", type=int, default=1000)
     parser.add_argument("--max-list", type=int, default=40000)
     parser.add_argument("--changed-fraction", type=float, default=0.1)
+    parser.add_argument(
+        "--overlap-fraction",
+        type=float,
+        default=0.0,
+        help="fraction of base prefixes announced by a second member "
+        "(default 0 = disjoint announcements, byte-identical legacy output)",
+    )
     parser.add_argument("--render-bin", help="rs-config-render binary (rustbgpd cell)")
     parser.add_argument("--threads", type=int, default=8, help="BIRD threads knob")
     parser.add_argument("--conf-dir", help="config dir as seen by the running daemon")
@@ -805,15 +880,21 @@ def main() -> None:
         sys.exit("total_prefixes must divide evenly by n_members (harness contract)")
     if not 1 <= args.min_list <= args.max_list:
         sys.exit("need 1 <= min_list <= max_list")
+    if not 0.0 <= args.overlap_fraction < 1.0:
+        sys.exit("need 0 <= overlap_fraction < 1")
+    if args.overlap_fraction > 0 and args.n_members < 2:
+        sys.exit("overlap needs at least two members")
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
     members = build_dataset(args)
+    overlap = apply_overlap(args, members)
     if args.canonical_dataset_out is not None:
         with args.canonical_dataset_out.open("wb") as canonical:
             for member in members:
                 canonical.write(canonical_member_record(member))
     files = EMITTERS[args.cell](args, members, args.out_dir)
-    write_manifest(args.out_dir, args, members, files)
+    files += write_overlap_file(args.out_dir, overlap)
+    write_manifest(args.out_dir, args, members, files, overlap)
     total_entries = sum(len(policy_prefixes(m, "a", args.admit_churn)) for m in members)
     swapped = files[1]  # the live swap file in every cell's roster
     print(

--- a/bench/scale/reloadstall/src/main.rs
+++ b/bench/scale/reloadstall/src/main.rs
@@ -23,6 +23,17 @@
 //!   <daemon_pid>; a nonzero exit fails the run like a failed SIGHUP.
 //! - `daemon_pid` 0: skip in-harness RSS sampling (an outer sampler owns
 //!   it; RSS columns report 0). Requires `reload_cmd` or `--flapstorm`.
+//! - `RELOADSTALL_OVERLAP_FILE` (env, reload mode only): a generator-emitted
+//!   `member<TAB>global prefix index` allocation of overlap second
+//!   announcers (LAN-892). Listed stubs additionally announce those base
+//!   prefixes; completion targets exclude each observer's own announced set
+//!   (slice + extras), which both update-group modes are guaranteed to
+//!   deliver.
+//! - `RELOADSTALL_RECEIVED_VIEW_FILE` (env, reload mode with
+//!   RELOADSTALL_EVIDENCE_DIR): before the final evidence boundary, dump
+//!   each observer's final-generation received view (base prefixes seen
+//!   with the marker, BEFORE own-announcement exclusion) so the verifier
+//!   can compute the per-client-best vs grouped received-view delta.
 //! - `--flapstorm K` (anywhere in argv): alternative mode replacing the
 //!   reload loop. After convergence + the control window, close the first
 //!   K stub sockets simultaneously, timestamp every survivor's receipt of
@@ -138,10 +149,19 @@ struct Stub {
 #[derive(Default)]
 struct GenerationProgress {
     seen: Vec<u64>,
+    /// Every base prefix observed with the active generation marker BEFORE
+    /// own-announcement exclusion — the LAN-892 received view. With overlap,
+    /// per-client-best delivers runner-up paths for prefixes the observer
+    /// itself announces; those are excluded from completion but must still be
+    /// evidenced for the received-view delta.
+    received: Vec<u64>,
     unique: u64,
     target: u64,
     excluded_start: usize,
     excluded_end: usize,
+    /// Sorted extra own-announced indices (overlap second-announcer role),
+    /// excluded from completion alongside the contiguous own slice.
+    excluded_extra: Vec<usize>,
     completed_at_us: Option<u64>,
     first_marker_base_at_us: Option<u64>,
 }
@@ -151,16 +171,34 @@ impl GenerationProgress {
         self.seen.clear();
         self.seen
             .resize(usize::try_from(total_prefixes).unwrap().div_ceil(64), 0);
+        self.received.clear();
+        self.received.resize(self.seen.len(), 0);
         self.unique = 0;
         self.target = target;
         self.excluded_start = usize::try_from(excluded_start).unwrap();
         self.excluded_end = usize::try_from(excluded_start + excluded_len).unwrap();
+        self.excluded_extra.clear();
         self.completed_at_us = None;
         self.first_marker_base_at_us = None;
     }
 
+    /// Exclude the observer's extra own-announced prefixes (overlap second-
+    /// announcer role) from completion, shrinking the target to match. Call
+    /// after `reset`; the generator guarantees these are outside the
+    /// contiguous own slice.
+    fn exclude_extra(&mut self, extra: &[u32]) {
+        self.excluded_extra = extra.iter().map(|&idx| idx as usize).collect();
+        self.excluded_extra.sort_unstable();
+        self.target = self.target.saturating_sub(extra.len() as u64);
+    }
+
     fn observe(&mut self, prefix_index: usize, t_us: u64) {
-        if (self.excluded_start..self.excluded_end).contains(&prefix_index) {
+        if let Some(slot) = self.received.get_mut(prefix_index / 64) {
+            *slot |= 1u64 << (prefix_index % 64);
+        }
+        if (self.excluded_start..self.excluded_end).contains(&prefix_index)
+            || self.excluded_extra.binary_search(&prefix_index).is_ok()
+        {
             return;
         }
         let word = prefix_index / 64;
@@ -188,6 +226,10 @@ struct Ctx {
     per_peer: u32,
     daemon: SocketAddr,
     obs: Vec<Obs>,
+    /// Per-stub extra announced base indices beyond the contiguous own slice
+    /// (`RELOADSTALL_OVERLAP_FILE`, the LAN-892 overlap dimension). Empty
+    /// vectors when overlap is off — the historical disjoint shape.
+    extras: Vec<Vec<u32>>,
     /// Daemon UPDATEs the stub failed to decode — a daemon defect that
     /// invalidates the run (see the reader and the exit check in `main`).
     parse_errors: AtomicU64,
@@ -336,6 +378,92 @@ fn withdraw_msg(prefixes: &[Ipv4Prefix]) -> Message {
 fn own_slice(ctx: &Ctx, i: u32) -> Vec<Ipv4Prefix> {
     let lo = i * ctx.per_peer;
     (lo..lo + ctx.per_peer).map(base_prefix).collect()
+}
+
+/// Everything stub `i` announces: its own slice plus its overlap
+/// second-announcer prefixes (LAN-892; empty extras reproduce the
+/// historical disjoint announcements exactly).
+fn announced_prefixes(ctx: &Ctx, i: u32) -> Vec<Ipv4Prefix> {
+    let mut prefixes = own_slice(ctx, i);
+    prefixes.extend(ctx.extras[i as usize].iter().copied().map(base_prefix));
+    prefixes
+}
+
+/// Parse the generator's overlap allocation (`member<TAB>global prefix index`
+/// per line): the extra base prefixes each stub announces beyond its own
+/// slice. Rejects out-of-range members and prefixes, own-slice entries
+/// (already announced), and duplicates.
+fn parse_overlap_file(
+    text: &str,
+    n_peers: u32,
+    total: u32,
+    per_peer: u32,
+) -> Result<Vec<Vec<u32>>, String> {
+    let mut extras = vec![Vec::new(); n_peers as usize];
+    for (index, line) in text.lines().enumerate() {
+        let number = index + 1;
+        let (member, idx) = line
+            .split_once('\t')
+            .ok_or(format!("overlap line {number}: missing tab separator"))?;
+        let member: u32 = member
+            .parse()
+            .map_err(|_| format!("overlap line {number}: invalid member index"))?;
+        let idx: u32 = idx
+            .parse()
+            .map_err(|_| format!("overlap line {number}: invalid prefix index"))?;
+        if member >= n_peers {
+            return Err(format!(
+                "overlap line {number}: member {member} out of range"
+            ));
+        }
+        if idx >= total {
+            return Err(format!(
+                "overlap line {number}: prefix index {idx} out of range"
+            ));
+        }
+        if idx / per_peer == member {
+            return Err(format!(
+                "overlap line {number}: prefix {idx} is in member {member}'s own slice"
+            ));
+        }
+        let list: &mut Vec<u32> = &mut extras[member as usize];
+        if list.contains(&idx) {
+            return Err(format!(
+                "overlap line {number}: duplicate ({member}, {idx})"
+            ));
+        }
+        list.push(idx);
+    }
+    for list in &mut extras {
+        list.sort_unstable();
+    }
+    Ok(extras)
+}
+
+/// Dump every observer's LAN-892 received view (final-generation base
+/// prefixes seen, before own-announcement exclusion) as
+/// `observer<TAB>missing_count<TAB>comma-joined missing indices`.
+fn write_received_view(ctx: &Ctx, path: &Path) -> std::io::Result<()> {
+    let total = usize::try_from(ctx.n_peers * ctx.per_peer).unwrap();
+    let mut out = format!(
+        "received_view_v1\ttotal={}\tpeers={}\n",
+        ctx.n_peers * ctx.per_peer,
+        ctx.n_peers
+    );
+    for (i, observer) in ctx.obs.iter().enumerate() {
+        let generation = observer.generation.lock().unwrap();
+        let missing: Vec<String> = (0..total)
+            .filter(|&idx| {
+                generation
+                    .received
+                    .get(idx / 64)
+                    .is_none_or(|slot| slot & (1u64 << (idx % 64)) == 0)
+            })
+            .map(|idx| idx.to_string())
+            .collect();
+        out.push_str(&format!("{i}\t{}\t{}\n", missing.len(), missing.join(",")));
+    }
+    std::fs::write(path, out)
 }
 
 async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<Stub, String> {
@@ -606,7 +734,7 @@ async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<Stub, String> {
                         let tx = tx_for_reader.clone();
                         let rc = Arc::clone(&rctx);
                         tokio::spawn(async move {
-                            let slice = own_slice(&rc, i);
+                            let slice = announced_prefixes(&rc, i);
                             for m in announce_msgs(i, &slice) {
                                 if tx.send(m).await.is_err() {
                                     break;
@@ -841,7 +969,7 @@ async fn run_flapstorm(ctx: &Arc<Ctx>, stubs: &mut [Stub], k: u32, pid: i32) {
         let t_reann = now_us(ctx);
         println!("flap {round} reannounce wall_us={}", wall_us());
         for i in 0..k {
-            let slice = own_slice(ctx, i);
+            let slice = announced_prefixes(ctx, i);
             for m in announce_msgs(i, &slice) {
                 if stubs[i as usize].tx.send(m).await.is_err() {
                     eprintln!("flap {round} re-announce send failed for stub {i}");
@@ -1082,6 +1210,8 @@ fn main() {
     let evidence_dir = std::env::var_os("RELOADSTALL_EVIDENCE_DIR").map(PathBuf::from);
     let pre_churn_evidence_dir =
         std::env::var_os("RELOADSTALL_PRE_CHURN_EVIDENCE_DIR").map(PathBuf::from);
+    let overlap_file = std::env::var_os("RELOADSTALL_OVERLAP_FILE").map(PathBuf::from);
+    let received_view_file = std::env::var_os("RELOADSTALL_RECEIVED_VIEW_FILE").map(PathBuf::from);
     assert!(n_peers >= CHURNERS, "n_peers must be at least {CHURNERS}");
     assert!(
         (1..=n_peers).contains(&changed_peers),
@@ -1116,6 +1246,42 @@ fn main() {
     }
     let per_peer = total / n_peers;
     assert_eq!(total % n_peers, 0, "total must divide evenly");
+    // Overlap and the received-view dump are reload-mode instruments only:
+    // flapstorm and convergence-only completion accounting assumes the
+    // historical disjoint announcements.
+    assert!(
+        overlap_file.is_none() || (reloads > 0 && flapstorm.is_none() && !convergence_only),
+        "RELOADSTALL_OVERLAP_FILE requires the reload mode (reloads > 0)"
+    );
+    assert!(
+        received_view_file.is_none()
+            || (reloads > 0
+                && flapstorm.is_none()
+                && !convergence_only
+                && changed_peers == n_peers
+                && evidence_dir.is_some()),
+        "RELOADSTALL_RECEIVED_VIEW_FILE requires the all-changed reload mode \
+         with RELOADSTALL_EVIDENCE_DIR (the dump precedes the final boundary)"
+    );
+    let extras = match overlap_file.as_deref() {
+        Some(path) => {
+            let text = std::fs::read_to_string(path).unwrap_or_else(|error| {
+                eprintln!(
+                    "cannot read RELOADSTALL_OVERLAP_FILE {}: {error}",
+                    path.display()
+                );
+                std::process::exit(2);
+            });
+            parse_overlap_file(&text, n_peers, total, per_peer).unwrap_or_else(|error| {
+                eprintln!(
+                    "invalid RELOADSTALL_OVERLAP_FILE {}: {error}",
+                    path.display()
+                );
+                std::process::exit(2);
+            })
+        }
+        None => vec![Vec::new(); n_peers as usize],
+    };
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(24)
@@ -1141,6 +1307,7 @@ fn main() {
                     flap_mode: AtomicU32::new(FLAP_OFF),
                 })
                 .collect(),
+            extras,
             parse_errors: AtomicU64::new(0),
         });
         println!(
@@ -1175,19 +1342,29 @@ fn main() {
         );
 
         let expected = u64::from(total - per_peer);
+        // Per-observer completion target: overlap second announcers also
+        // exclude their extra announced prefixes (a member never depends on
+        // receiving what it announces; grouped mode may legitimately
+        // suppress those toward the best-path announcer).
+        let targets: Vec<u64> = ctx
+            .extras
+            .iter()
+            .map(|extra| expected - extra.len() as u64)
+            .collect();
         let exact_initial = convergence_only || needs_first_exact_bitmap(reloads, flapstorm); // FIRST_EXACT_ARM:
         if exact_initial {
             for (i, observer) in ctx.obs.iter().enumerate() {
                 let own_start = u32::try_from(i).unwrap() * per_peer;
                 let mut generation = observer.generation.lock().unwrap();
                 generation.reset(total, expected, own_start, per_peer);
+                generation.exclude_extra(&ctx.extras[i]);
                 let mode = &observer.flap_mode;
                 mode.store(FLAP_TRACK_ANNOUNCES, Ordering::Release);
             }
         }
         // --- Announce base table (FIRST_EXACT_SEND). ---
         for i in 0..n_peers {
-            let slice = own_slice(&ctx, i);
+            let slice = announced_prefixes(&ctx, i);
             for m in announce_msgs(i, &slice) {
                 stubs[i as usize].tx.send(m).await.unwrap();
             }
@@ -1208,7 +1385,11 @@ fn main() {
                     }
                 })
                 .collect();
-            if *counts.iter().min().unwrap() >= expected {
+            if counts
+                .iter()
+                .zip(&targets)
+                .all(|(count, target)| count >= target)
+            {
                 break counts;
             }
             let sum: u64 = counts.iter().sum();
@@ -1227,7 +1408,7 @@ fn main() {
                 let below: Vec<(usize, u64)> = counts
                     .iter()
                     .enumerate()
-                    .filter(|&(_, &c)| c < expected)
+                    .filter(|&(i, &c)| c < targets[i])
                     .map(|(i, &c)| (i, c))
                     .collect();
                 eprintln!(
@@ -1257,7 +1438,11 @@ fn main() {
                 } else {
                     "reload"
                 },
-                unique.iter().filter(|&&count| count >= expected).count(),
+                unique
+                    .iter()
+                    .zip(&targets)
+                    .filter(|(count, target)| count >= target)
+                    .count(),
                 unique.iter().min().unwrap(),
                 unique.iter().max().unwrap()
             );
@@ -1394,12 +1579,9 @@ fn main() {
                 .enumerate()
             {
                 observer.expected_community.store(0, Ordering::Release);
-                observer.generation.lock().unwrap().reset(
-                    total,
-                    expected,
-                    u32::try_from(i).unwrap() * per_peer,
-                    per_peer,
-                );
+                let mut generation = observer.generation.lock().unwrap();
+                generation.reset(total, expected, u32::try_from(i).unwrap() * per_peer, per_peer);
+                generation.exclude_extra(&ctx.extras[i]);
             }
             // The tracker stays disarmed until its trigger timestamp exists,
             // so a delayed UPDATE from an older A/B generation cannot become
@@ -1648,6 +1830,12 @@ fn main() {
             std::process::exit(1);
         }
         println!("final sessions_up {up}/{n_peers} parse_errors={parse_errors}");
+        if let Some(path) = received_view_file.as_deref() {
+            if let Err(error) = write_received_view(&ctx, path) {
+                eprintln!("FAIL: received-view dump failed: {error}");
+                std::process::exit(1);
+            }
+        }
         if let Err(error) = await_evidence_capture(evidence_dir, EVIDENCE_TIMEOUT).await {
             eprintln!("FAIL: final evidence handshake failed: {error}");
             std::process::exit(1);
@@ -1986,6 +2174,53 @@ mod tests {
         assert!(!stable_marker_is_fresh(99, 100));
         assert!(stable_marker_is_fresh(100, 100));
         assert!(stable_marker_is_fresh(101, 100));
+    }
+
+    #[test]
+    fn overlap_file_parses_and_rejects_malformed_allocations() {
+        let extras = parse_overlap_file("1\t0\n0\t7\n1\t5\n", 4, 8, 2).unwrap();
+        assert_eq!(extras, vec![vec![7], vec![0, 5], vec![], vec![]]);
+        assert!(parse_overlap_file("", 4, 8, 2)
+            .unwrap()
+            .iter()
+            .all(Vec::is_empty));
+        for (bad, why) in [
+            ("1 0", "missing tab"),
+            ("x\t0", "member parse"),
+            ("1\tx", "index parse"),
+            ("4\t0", "member out of range"),
+            ("1\t8", "prefix out of range"),
+            ("1\t3", "own-slice prefix"),
+            ("1\t0\n1\t0", "duplicate"),
+        ] {
+            assert!(parse_overlap_file(bad, 4, 8, 2).is_err(), "{why}");
+        }
+    }
+
+    #[test]
+    fn received_view_records_before_exclusion_and_extras_shrink_target() {
+        let mut progress = GenerationProgress::default();
+        progress.reset(8, 6, 2, 2); // observer 1 of 4, per_peer 2
+        progress.exclude_extra(&[5]);
+        assert_eq!(progress.target, 5);
+
+        progress.observe(2, 10); // own slice: excluded from completion
+        progress.observe(5, 20); // overlap extra: excluded from completion
+        assert_eq!(progress.unique, 0);
+        for idx in [0, 1, 4, 6, 7] {
+            progress.observe(idx, 30);
+        }
+        assert_eq!(progress.unique, 5);
+        assert_eq!(progress.completed_at_us, Some(30));
+        // The received view keeps every delivered prefix, including the
+        // excluded own announcements (the per-client-best runner-up path).
+        let received: Vec<usize> = (0..8)
+            .filter(|idx| progress.received[idx / 64] & (1 << (idx % 64)) != 0)
+            .collect();
+        assert_eq!(received, vec![0, 1, 2, 4, 5, 6, 7]);
+        progress.reset(8, 6, 2, 2);
+        assert!(progress.excluded_extra.is_empty(), "reset clears extras");
+        assert!(progress.received.iter().all(|&slot| slot == 0));
     }
 
     #[test]

--- a/tests/reloadstall_scenario_emitted_check.rs
+++ b/tests/reloadstall_scenario_emitted_check.rs
@@ -933,6 +933,17 @@ fn irr_reload_counterbalanced_receipt_protocol_is_load_bearing() {
         "grouped-output-isolation",
         "output-exact-roster",
         "output-audit-call",
+        "overlap-fraction-mismatch",
+        "overlap-pair-own-slice",
+        "overlap-achieved",
+        "overlap-private-runner-up",
+        "overlap-grouped-bounds",
+        "overlap-grouped-sum",
+        "overlap-input-binding",
+        "received-view-scenario",
+        "received-view-subset",
+        "received-view-delta-count",
+        "received-view-outside-allocation",
     ] {
         assert!(
             stdout.contains(&format!("red-proof {proof}=pass")),
@@ -957,6 +968,31 @@ fn irr_reload_counterbalanced_receipt_protocol_is_load_bearing() {
     assert!(comparison.contains("rustbgpd_private=path_hiding:true,admit_churn:true\n"));
     assert!(comparison.contains("competitor_path_hiding=applicable:false,requested:true\n"));
     assert!(comparison.contains("shape=320,183040,1000,40000\n"));
+    assert!(comparison.contains("overlap_fraction=0\n"));
+    let overlap = std::process::Command::new("bash")
+        .arg(&runner)
+        .env("DRY_RUN_PROTOCOL", "1")
+        .env("OVERLAP_FRACTION", "0.3")
+        .env_remove("SMOKE")
+        .output()
+        .expect("run overlap dry protocol");
+    assert!(overlap.status.success());
+    assert!(
+        String::from_utf8(overlap.stdout)
+            .expect("overlap UTF-8")
+            .contains("overlap_fraction=0.3\n")
+    );
+    let bad_overlap = std::process::Command::new("bash")
+        .arg(&runner)
+        .env("DRY_RUN_PROTOCOL", "1")
+        .env("OVERLAP_FRACTION", "1.5")
+        .env_remove("SMOKE")
+        .output()
+        .expect("run rejected overlap dry protocol");
+    assert!(
+        !bad_overlap.status.success(),
+        "overlap fraction outside [0, 1) must be rejected"
+    );
 
     let grouped = dry(&["rustbgpd-sighup-grouped-control"]);
     assert!(grouped.status.success());
@@ -987,6 +1023,10 @@ fn irr_reload_counterbalanced_receipt_protocol_is_load_bearing() {
         "capture_topology \"$topology_mode\" \"$cdir\" \"$run\" \"$hpid\" \"$barrier\"",
         "ack_pre_churn \"$barrier\" true \"$cdir\"",
         "--peers \"$N_MEMBERS\" --total \"$TOTAL_PREFIXES\"",
+        "--manifest \"$run/manifest.json\"",
+        "RELOADSTALL_OVERLAP_FILE=\"$run/overlap.tsv\"",
+        "RELOADSTALL_RECEIVED_VIEW_FILE=\"$cdir/received-view.tsv\"",
+        "--overlap-fraction \"$OVERLAP_FRACTION\"",
         "TOPOLOGY_CAPTURE_TIMEOUT=50",
         "deadline=$((SECONDS + TOPOLOGY_CAPTURE_TIMEOUT))",
         "rm -f \"$cdir/topology.json\" \"$cdir\"/metrics-{1,2,3}.prom",
@@ -1335,6 +1375,109 @@ fn irr_memory_path_hiding_is_explicit_but_not_dataset_identity() {
         ));
     }
     assert!(observations.windows(2).all(|pair| pair[0] == pair[1]));
+}
+
+#[test]
+/// Red proof: reverting the overlap allocation to the RNG stream used by
+/// build_dataset (or leaking overlap keys/files at F=0) fails the byte-level
+/// default assertions here or the pinned seed-61 dataset digest above; a
+/// nondeterministic draw fails the repeat-equality assertion; dropping the
+/// second announcer's filter-list admission or the manifest allocation fails
+/// the emission assertions.
+fn irr_overlap_dimension_is_deterministic_and_absent_at_default() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let generator = format!("{root}/bench/scale/reloadstall/gen-irr-scenario.py");
+    let run = |dir: &std::path::Path, overlap: &[&str]| {
+        let output = std::process::Command::new("python3")
+            .args([&generator, "bird", "8", "96"])
+            .arg(dir)
+            .args(["--min-list", "20", "--max-list", "20"])
+            .args(overlap)
+            .output()
+            .expect("run IRR generator");
+        assert!(
+            output.status.success(),
+            "generator failed\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    let read_manifest = |dir: &std::path::Path| -> serde_json::Value {
+        serde_json::from_slice(&std::fs::read(dir.join("manifest.json")).expect("manifest"))
+            .expect("manifest JSON")
+    };
+
+    let default_dir = tempfile::tempdir().expect("tempdir");
+    run(default_dir.path(), &[]);
+    let default_manifest = read_manifest(default_dir.path());
+    assert!(default_manifest.get("overlap_fraction").is_none());
+    assert!(default_manifest.get("overlap_pairs").is_none());
+    assert!(
+        !default_dir.path().join("overlap.tsv").exists(),
+        "F=0 must not emit an overlap allocation file"
+    );
+
+    let overlap_dirs = [
+        tempfile::tempdir().expect("tempdir"),
+        tempfile::tempdir().expect("tempdir"),
+    ];
+    for dir in &overlap_dirs {
+        run(dir.path(), &["--overlap-fraction", "0.25"]);
+    }
+    assert_eq!(
+        std::fs::read(overlap_dirs[0].path().join("manifest.json")).expect("manifest bytes"),
+        std::fs::read(overlap_dirs[1].path().join("manifest.json")).expect("manifest bytes"),
+        "overlap allocation must be deterministic under the seed"
+    );
+    let manifest = read_manifest(overlap_dirs[0].path());
+    assert_eq!(manifest["overlap_fraction"], 0.25);
+    let pairs = manifest["overlap_pairs"].as_array().expect("overlap pairs");
+    assert_eq!(pairs.len(), 24, "round(0.25 * 96) overlapped prefixes");
+    assert_ne!(
+        manifest["dataset_sha256"], default_manifest["dataset_sha256"],
+        "overlap must change the canonical dataset identity"
+    );
+    let roster: Vec<&str> = manifest["runtime_files"]
+        .as_array()
+        .expect("runtime roster")
+        .iter()
+        .map(|value| value.as_str().expect("runtime path"))
+        .collect();
+    assert!(roster.contains(&"overlap.tsv"));
+    let per_peer = 96 / 8;
+    let overlap_tsv =
+        std::fs::read_to_string(overlap_dirs[0].path().join("overlap.tsv")).expect("overlap.tsv");
+    let mut allocations = Vec::new();
+    for line in overlap_tsv.lines() {
+        let (member, idx) = line.split_once('\t').expect("member\tprefix line");
+        let member: u64 = member.parse().expect("member index");
+        let idx: u64 = idx.parse().expect("prefix index");
+        assert!(member < 8 && idx < 96 && idx / per_peer != member);
+        allocations.push((idx, member));
+    }
+    let manifest_pairs: Vec<(u64, u64)> = pairs
+        .iter()
+        .map(|pair| {
+            let pair = pair.as_array().expect("pair");
+            (
+                pair[0].as_u64().expect("prefix index"),
+                pair[1].as_u64().expect("second announcer"),
+            )
+        })
+        .collect();
+    assert_eq!(allocations, manifest_pairs);
+    let gen_a = std::fs::read_to_string(overlap_dirs[0].path().join("gen-a.conf")).expect("gen-a");
+    for (idx, _) in &manifest_pairs {
+        let prefix = format!(
+            "{}.{}.{}.0/24",
+            20 + (idx >> 16),
+            (idx >> 8) & 0xff,
+            idx & 0xff
+        );
+        assert!(
+            gen_a.matches(prefix.as_str()).count() >= 2,
+            "second announcer's filter list must admit {prefix}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Why

The IRR reload campaign's canonical scenario announces disjoint per-member slices: the Loc-RIB equals the sum of the per-peer Adj-RIB-Ins and no prefix ever has two candidate paths, so `per_client_best` and the grouped update-group control are behaviorally identical by construction. LAN-892 needs the harness to measure the two modes at a shape where they actually differ. This PR adds that dimension; the sealed campaign itself runs later in a quiet window.

## Generator: `--overlap-fraction F` (default 0)

`round(F x TOTAL_PREFIXES)` base prefixes, drawn uniformly under a seed-derived RNG stream (`irr-overlap-<seed>`, separate from `build_dataset`'s stream), each gain exactly ONE second announcing member drawn uniformly from the other members. The second announcer's filter lists admit the prefix in both generations, the allocation is sealed in the manifest (`overlap_fraction`, `overlap_pairs`) and emitted as an `overlap.tsv` runtime file (in `runtime_files`, so it enters `scenario.sha256` and the evidence chain), and the canonical member records gain `announced_extra` only when non-empty — so the dataset digest identifies the allocation while F=0 output stays byte-identical.

**F=0 byte-identity proof:** generated every cell with the origin/main generator and this one at the same shape and diffed the outputs: `bird`, `openbgpd` byte-identical via `diff -r`; `rustbgpd-txn` and rendered `rustbgpd` identical for every runtime file and manifest (modulo the embedded run-directory path, which differs only because two output directories were compared). Independently, the pinned seed-61 canonical dataset digest (`708688…f65b` in `tests/reloadstall_scenario_emitted_check.rs`) is unchanged and enforced in CI for all four cells. F=0 emits no new files and no new manifest keys. F=0.3 output is deterministic across runs (byte-equal manifests, asserted in the new emitted-check test).

## Harness (reloadstall)

- `RELOADSTALL_OVERLAP_FILE` (reload mode only): validated `member<TAB>prefix` allocation; listed stubs announce the extras in the base announce and in ROUTE_REFRESH replays.
- Completion targets exclude each observer's own announced set (slice + extras) — a member never depends on receiving what it announces, which both update-group modes can legitimately suppress. F=0 reduces to the historical uniform target.
- `RELOADSTALL_RECEIVED_VIEW_FILE`: a per-observer received bitmap records marker-carrying base deliveries BEFORE own-announcement exclusion; the final-generation view is dumped (as per-observer missing sets) before the final evidence boundary, with stub sessions still live.
- The frozen positional CLI is unchanged; both extensions are env-gated and rejected outside the all-changed reload mode (flapstorm/convergence-only assert them off).

## Topology proof generalization

`validate_topology` now derives expectations from the scenario manifest (new `--manifest` flag; retained `manifest.json` at re-validation):

- Loc-RIB stays exactly `TOTAL_PREFIXES` (one best route per prefix — `loc_rib.len()` counts unique prefixes).
- Per-peer Adj-RIB-In must equal each member's announced count, keyed by the deterministic stub addressing; the sum pins the ACHIEVED overlap against the manifest allocation.
- Private mode: per-peer Adj-RIB-Out must equal `total - exclusive(m)` — per-client-best must deliver the runner-up path for every overlapped prefix the observer announces. Asserted exactly.
- Grouped mode: the winning announcer per overlapped prefix is a daemon tie-break, so per-peer Adj-RIB-Out is bounded by the member's announced/exclusive counts and the global suppression must total exactly one best announcer per prefix.
- F=0 reproduces the historical exact assertions verbatim (existing fixtures and the F=0 smoke pass unchanged).

## Received-view delta (the campaign's LAN-892 observable)

Chosen design: **observer-side comparison of per-member received views between the two modes' cells over the same sealed scenario, computed by the verifier from harness-retained evidence** — no daemon code, no reliance on the daemon's own gauges for its differentiator (the Adj-RIB-Out gauges corroborate from the daemon side). `verify-receipt.py received-view-delta` (and `campaigns`, per A/B repeat with repeat-agreement required) checks: same scenario identity, grouped deliveries a pointwise subset of per-client-best deliveries, every delta pair an overlapped prefix at one of its announcers, and the total equal to the manifest allocation (exactly one suppressed best-path announcer per overlapped prefix).

## Runner

`OVERLAP_FRACTION` env knob (validated decimal in `[0,1)`), wired through generation, provenance inputs (verifier requires input/manifest binding; cross-root equality rides the inputs identity), harness environment, topology capture, and the sealed evidence roster (`received-view.tsv` for the two rustbgpd cells). Grouped-control rows remain confined to `grouped-control.csv` by the existing verifier rule (`grouped-output-isolation` red-proof still green).

## Red-proofs

Self-test grew from 103 to 114 red-proofs, all green (`verify-receipt.py self-test`; enforced by the emitted-check test). New: `overlap-fraction-mismatch`, `overlap-pair-own-slice`, `overlap-achieved`, `overlap-private-runner-up`, `overlap-grouped-bounds`, `overlap-grouped-sum`, `overlap-input-binding`, `received-view-scenario`, `received-view-subset`, `received-view-delta-count`, `received-view-outside-allocation`.

Live apply-red-restore transcripts against the sealed F=0.3 smoke artifacts:

```
=== green baseline: topology revalidation (private, retained artifacts) ===
green rc=0
=== RED 1: overlap-fraction mismatch (manifest fraction 0.5, allocation unchanged) ===
receipt invalid: manifest overlap allocation does not match its declared fraction
red rc=1 (expected 1)
=== RED 2: manifest allocation tampering (drop one overlap pair) ===
receipt invalid: Adj-RIB-In does not reflect the manifest overlap allocation
red rc=1 (expected 1)
=== green baseline: received-view delta ===
{"overlap_fraction": 0.3, "overlap_pairs": 29, "status": "pass", "suppressed_runner_up_pairs": 29}
green rc=0
=== RED 3: received-view computation fed mismatched scenarios ===
receipt invalid: received-view delta cells do not share one scenario
red rc=1 (expected 1)
=== RED 4: tampered received view (grouped view claims a runner-up delivery) ===
receipt invalid: grouped mode delivered a prefix per-client-best did not
red rc=1 (expected 1)
=== restore: originals untouched; re-run green ===
{"overlap_fraction": 0.3, "overlap_pairs": 29, "status": "pass", "suppressed_runner_up_pairs": 29}
restored green rc=0
```

## Smokes (run to green)

- **F=0 regression** (`SMOKE=1 N_MEMBERS=8 TOTAL_PREFIXES=96`, all four cells): rc=0, root sealed; the private cell's received view shows each observer missing exactly its own 12-prefix slice; topology proof passes with `overlap_pairs: 0`.
- **F=0.3, both modes** (`OVERLAP_FRACTION=0.3`, same shape): `rustbgpd-sighup` rc=0 and `rustbgpd-sighup-grouped-control` rc=0, each passing its manifest-derived topology proof end-to-end against the live daemon (29 achieved second paths; private Adj-RIB-Out delivers runner-ups exactly; grouped suppression totals one best announcer per prefix). Cross-cell received-view delta: `suppressed_runner_up_pairs = 29 = overlap_pairs`.

## Choosing F (sources in the README)

Public evidence is thin; the one published point estimate is preliminary and single-IXP: Alhamwy, Khoulani, Hohlfeld, "POSTER: Crawling Alice Looking Glasses at IXPs to Quantify BGP Route Diversity" (ACM SIGCOMM 2025 Posters and Demos, doi:10.1145/3744969.3748457) reports ~50% of prefixes with alternative paths at one of the largest European IXPs; the path-hiding mechanism is documented in Richter et al., "Peering at Peerings" (IMC 2014). The README therefore recommends a sensitivity pair rather than one blessed value: `OVERLAP_FRACTION=0.1` (conservative low-diversity bound) and `0.5` (the published point estimate), and states that F>0 campaigns are the LAN-892 receipt's shape.

## Gates (all rc=0)

`python3 -m py_compile` (generator + verifier) · `verify-receipt.py self-test` (114 red-proofs) · `bash -n` + `shellcheck` on `run-irr-reload.sh` · `cargo fmt --check` / `cargo clippy --workspace --all-targets` / `cargo test --workspace` · `cargo test --manifest-path bench/scale/reloadstall/Cargo.toml --locked` (19 tests) · `cargo doc --no-deps` · `scripts/check-clippy-reasons.py` · both smokes above.
