### PR TITLE
docs(adr): propose shared-group per-client best-path

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -592,6 +592,13 @@ rollback record; the 1,000-peer route-server scale receipt
 is [retained](docs/perf/route-server-1000-2026-07.md). The ARouteServer target
 ships as `tools/rs-config-render`. The current external adapter already serves
 the Birdwatcher-shaped status, peer, accepted-route, and filtered-route subset.
+The open design program on this track is
+[ADR-0126](docs/adr/0126-shared-group-per-client-best.md) (Proposed):
+shared-group per-client best-path, delivering the `per_client_best`
+path-hiding mitigation inside update groups so rendered `path_hiding = true`
+fleets group instead of running fully ungrouped — gated on byte-identical
+per-member views at grouped-class cost per the
+[realistic-mix receipt](docs/perf/irr-reload-realistic-mix-2026-08.md).
 
 **Researched and rejected** (recorded so they aren't re-litigated):
 confederations (RFC 5065 — no demand signal in two years of issues and

--- a/docs/adr/0126-shared-group-per-client-best.md
+++ b/docs/adr/0126-shared-group-per-client-best.md
@@ -76,7 +76,11 @@ peer-context chains, Add-Path send (a negotiated capability outranks the
 fallback per family, ADR-0101 Decision 1), and ORF still disqualify with
 their existing reasons; ORR remains mutually exclusive by validation.
 Non-shareable or non-unicast-only combinations keep today's per-peer
-fallback with an operator-visible reason.
+fallback with an operator-visible reason; when `per_client_best` is
+configured but the key is not unicast-only (VPN/RTC families negotiated),
+that reason is the existing `per_client_best` disqualification string,
+reused unchanged — no new reason surface, the fallback behavior is
+documented instead.
 
 ### 2. Group winner = first permitted candidate in best-path order
 
@@ -113,6 +117,10 @@ captured source attributes, exactly the group table's per-entry payload —
   re-open the Add-Path rank problems of ADR-0099 Decision 5.
 - Not a per-member map: O(members × prefixes) is the shape grouping
   exists to delete.
+- Not a candidate reference re-derived at emit: replay — refresh, join,
+  resync, channel-full drain — must deliver `adv(m)` with zero policy
+  re-evaluation, which requires the post-policy form; the cost is
+  bounded by the lane's O(overlapped prefixes) population.
 
 State is O(overlapped prefixes) — populated only where a distinct-source
 permitted runner-up exists (18,304 / 91,520 entries at the receipt's two
@@ -221,14 +229,24 @@ per-client-best distribution mode; a lane-size gauge
 claim; the received-view-delta verifier is the campaign-level equivalence
 instrument.
 
+Rendered-default timing: `rs-config-render` fleets group immediately at
+ship, conditional on the acceptance gate below — both prongs, not the
+flip alone. The default flips in the release that lands Phase 3 only if
+the received-view-delta verifier proves byte-identical per-member views
+**and** the receipt meets the committed ≥4× sampler RSS-peak reduction.
+If the receipt misses that target, the rendered default holds one
+release behind an opt-out and flips only on a passing receipt.
+
 ## Open decisions
+
+Former open decisions 1 (fallback reason), 3 (rendered-default timing),
+and 4 (lane storage form) are decided and folded into the design above —
+Decisions 1, 9, and 3 respectively. Decisions 2 and 5 remain open calls
+for the owner:
 
 | # | Question | Options | Leaning |
 |---|---|---|---|
-| 1 | Fallback reason when `per_client_best` is set but the key is not unicast-only (VPN/RTC families negotiated) | reuse `per_client_best` / new `per_client_best_families` / reject at validation | reuse `per_client_best` — surface unchanged, documented |
 | 2 | Counter replay for the second permit evaluation | record both evals in group totals / record winner's only | record both; extend the ADR-0098 counter carve-out (oracle compares streams and state, never counters) |
-| 3 | Rendered-default timing: do `rs-config-render` fleets group immediately at ship? | immediate / one release behind an opt-out | immediate — the oracle plus the acceptance receipt are the earn-the-default evidence ADR-0101 Decision 1 asked for |
-| 4 | Lane storage form | full post-policy `Route` shell / candidate reference re-derived at emit | full shell — replay without policy re-evaluation requires the post-policy form; bounded at O(overlapped prefixes) |
 | 5 | ADR-0105 fast-path re-inclusion | never / demand-gated | demand-gated: revisit only with a measured fleet regularly reloading per-client-best cohorts and a receipt |
 
 ## Acceptance gate
@@ -257,6 +275,15 @@ shape, F ∈ {0.1, 0.5}:
 4. **Receipt:** rerun the realistic-mix campaign, gate as above; amend this
    ADR to Accepted with the measured rows; confirm `rs-config-render`
    keeps `path_hiding = true` with grouped output.
+
+Risk concentrates in Phase 2, not Phase 3. The runner-up lane is new
+group-shared mutable state, correctly excluded from the ADR-0105 fast
+path — that path's clean predicate (zero policy-filtered routes on both
+sides) contradicts the mitigation's reason to exist. The dirty-resync
+over-withdraw path and the channel-full `pending_extra_withdraws` seam
+must both handle the lane arms before the classifier flips; defects in
+this design will concentrate at the emit seams, not the classifier
+flip.
 
 ## Non-goals
 

--- a/docs/adr/0126-shared-group-per-client-best.md
+++ b/docs/adr/0126-shared-group-per-client-best.md
@@ -1,0 +1,302 @@
+# ADR-0126: Shared-group per-client best-path — path-hiding mitigation inside update groups
+
+**Status:** Proposed
+**Date:** 2026-08-05
+
+## Context
+
+Both documented RFC 7947 §2.3 path-hiding mitigations — `per_client_best`
+(ADR-0101) and Add-Path send (ADR-0099 Decision 5) — are update-group
+disqualifiers, so no configuration is simultaneously mitigated and grouped.
+`rs-config-render` defaults `path_hiding = true`, so every rendered
+route-server member sets `per_client_best = true` and rendered fleets run
+fully ungrouped. The sealed
+[realistic-mix receipt](../perf/irr-reload-realistic-mix-2026-08.md) prices
+that at the canonical 320-member × 183,040-prefix shape: steady-state reload
+completion p50 87–143 s and sampler RSS peak 10.4–11.3 GiB for per-client
+best, versus 4.5 s and 2.0–2.1 GiB for the (mitigation-less) grouped control
+— while the mitigation delivers exactly the 18,304 (F = 0.1) / 91,520
+(F = 0.5) runner-up pairs the shared-RIB export hides, verified
+byte-for-byte on the wire by the received-view-delta verifier.
+
+The semantic opening: per-client best-path for member `m` is "best
+export-permitted candidate not sourced by `m`". Under a group-shareable
+export chain — content-equal, no peer-context matchers (`GroupKey` already
+guarantees both) — the permit verdict on any candidate is identical for
+every member. The per-member selections therefore collapse to one shared
+computation plus exactly two divergences from today's grouped output:
+
+1. **The member sourcing the staged winner receives the runner-up** — the
+   best permitted candidate from any other source — instead of nothing.
+   One exception per prefix, not per member.
+2. **When the chain denies the Loc-RIB best, all members receive the best
+   permitted candidate.** Today's grouped staging stages nothing
+   (policy-filtered); per-client best walks on. This divergence is
+   group-wide, since verdicts are chain-content-uniform.
+
+This is precisely the optimization RFC 7947 §2.3.2.2 blesses: a global
+Loc-RIB with per-client views "stored as deltas" instead of materialized
+per-client Loc-RIBs (which ADR-0101 Decision 2 rejected permanently).
+
+What the incumbents do, verified against their documentation:
+
+- **BIRD** implements `secondary` on a `sorted` table: export tries each
+  route in preference order until one passes the client's filter. It shares
+  table *memory* (no explicit per-client tables) but still runs each
+  client's export filter per prefix per client; `sorted` is required and is
+  incompatible with `deterministic med`. BIRD 3's threading parallelizes
+  those per-client filter runs across cores without deduplicating them.
+- **OpenBGPD** implements `rde evaluate all`: the RDE evaluates all paths
+  per neighbor. Its early releases shipped the documented bug family of
+  openbgpd-portable issue #21 — a suboptimal path not advertised on
+  startup/reload when the best was filtered, and a stale second-best
+  persisting in `show rib out` after the best was withdrawn until a manual
+  session clear — fixed in OpenBGPD 7.0; arouteserver historically kept the
+  option off for OpenBGPD for this reason while defaulting `path_hiding:
+  True` for BIRD.
+
+Neither shares the export computation or the staged result across clients
+with identical policy: both pay O(clients × candidates) filter evaluation
+for the mitigation. Staging once per group and deriving per-member views —
+mitigation semantics at shared-export cost, with no sorted-table or
+comparator restrictions — is a position neither occupies.
+
+## Decision
+
+### 1. `per_client_best` joins the group key instead of disqualifying
+
+When a `per_client_best` peer's chain is shareable (no
+`requires_peer_context`) and its key is unicast-only
+(`GroupKey::is_unicast_only`), the classifier returns `Groupable` with a
+new `per_client_best: bool` key bit. Mitigated and unmitigated groups must
+never share a table: divergence (2) means a per-client-best group stages
+the first *permitted* candidate where a plain group stages
+Loc-RIB-best-or-nothing. Classifier precedence is unchanged above this arm:
+peer-context chains, Add-Path send (a negotiated capability outranks the
+fallback per family, ADR-0101 Decision 1), and ORF still disqualify with
+their existing reasons; ORR remains mutually exclusive by validation.
+Non-shareable or non-unicast-only combinations keep today's per-peer
+fallback with an operator-visible reason.
+
+### 2. Group winner = first permitted candidate in best-path order
+
+The per-client-best group staging pass replaces "evaluate the Loc-RIB best,
+stage or filter" with the candidate walk `distribute_multipath_prefix`
+already performs for ungrouped per-client-best peers, shared once per
+group: collect candidates via the shared `multipath_candidates` collector
+(minus the per-target split-horizon exclusion, which stays at member emit
+per ADR-0098 Decision 4), sort by `best_path_cmp`, walk in order:
+
+- **winner `w`** = first export-permitted candidate → staged in the group
+  table at `path_id 0` (subsumes divergence 2);
+- **runner-up `r`** = first permitted candidate whose source differs from
+  `w`'s source → staged in the exception lane;
+- early exit once both are found.
+
+At zero overlap the walk terminates after one permit — cost identical to
+today's grouped pass. Each overlapped prefix adds one candidate evaluation.
+No term anywhere scales with member count: the receipt's steady-state
+plateau (per-client-best-only, F-scaling, upstream of the commit fan-out)
+belongs to the per-member candidate-multiplicity class this design removes
+structurally, and no phase of this design reintroduces it.
+
+### 3. The exception lane: a per-prefix runner-up sidecar
+
+The runner-up lives in a per-group sidecar map keyed by prefix — one
+staged post-policy `Route` shell plus next-hop-override residue and
+captured source attributes, exactly the group table's per-entry payload —
+**not** inside the group table and **not** per member:
+
+- Not `path_id 1` entries in the table: every existing query, counter,
+  resync, and replay seam assumes grouped unicast state lives at
+  `path_id 0`; a second in-table rank would leak into all of them and
+  re-open the Add-Path rank problems of ADR-0099 Decision 5.
+- Not a per-member map: O(members × prefixes) is the shape grouping
+  exists to delete.
+
+State is O(overlapped prefixes) — populated only where a distinct-source
+permitted runner-up exists (18,304 / 91,520 entries at the receipt's two
+overlap points, against 183,040 table entries). ADR-0099 Decision 6
+already blessed this shape for ORR: stage top-2, single-best keeps
+`path_id 0` constant.
+
+### 4. Derived views: the advertised-map invariant
+
+No per-member advertised record is added. A member's advertised set is a
+pure function of shared state and member identity:
+
+> **adv(m)** = for each prefix: `w` if `source(w) ≠ m`; else `r` if the
+> lane holds one; else nothing — always at `path_id 0`.
+
+This is the ADR-0099 Decision 2 pattern (a per-member emit-time exception
+that is a function of entry content/source and member identity, never
+per-member history), so it composes with the group-level equality baseline.
+Every cold path derives the same function: join, RFC 2918 refresh, and
+GShut force-refresh replay `adv(m)` family-filtered with zero policy
+re-evaluation (the lane entry carries its post-policy form); dirty resync
+announces `adv(m)` and withdraws `tombstones ∖ adv(m)` (over-withdraw
+remains the safe direction); advertised queries, BMP stat 17, and adj-out
+gauges synthesize from per-source counts with the one-substitution
+adjustment.
+
+### 5. Emit: one new source-flip matrix arm plus a lane delta
+
+`GroupDelta` gains the lane transition (old runner-up, new runner-up)
+alongside the existing `(new, old_source)` pair. The source-flip matrix
+extends:
+
+- `member == source(w_new)`: announce `r` (implicit replace at
+  `path_id 0`) when the lane holds one; withdraw otherwise (today's arm).
+- Lane-only change (runner-up flips or retires, winner unchanged): one
+  member-scoped delta toward `source(w)` only — announce `r'` or withdraw.
+  Equality suppression applies within the lane.
+- All-candidates-gone: the shared withdraw is correct for every member
+  including `source(w)` (its wire held `r` at the same path-id-free slot).
+- Source flip `A → B`: members ≠ A,B ride the shared payload; A gets `w'`;
+  B gets `r'`-or-withdraw. Decidable from the delta alone, as today.
+
+The shared `Arc` payload path (ADR-0098 Decision 6) is unchanged; the
+exceptions set gains at most the winner/runner-up sources per delta.
+Member-scoped emissions lost to a full outbound channel record into
+`pending_extra_withdraws` via the existing
+`member_scoped_withdraws` seam, extended with the lane arms — the
+ADR-0099 channel-full mechanism, not a new one. rs-control communities
+divergence (ADR-0101 Decision 3) applies per member at the same emit
+seams; lane entries carry source attributes so tag transitions extend to
+them.
+
+### 6. The OpenBGPD bug family, as non-goals-to-avoid with mechanisms
+
+- **Stale second-best after best withdrawal** (issue #21): impossible by
+  construction — there is no per-member rib-out record to go stale;
+  `adv(m)` derives from live shared state, every table delta recomputes
+  the lane in the same pass, and resync over-withdraws (RFC 4271 no-op).
+- **Missing suboptimal advertisement on startup/reload** (issue #21):
+  replay and steady-state emission use the single `adv(m)` derivation —
+  there is no second bookkeeping path to diverge.
+- **Churn on content-equal reload**: interned chain-content keying
+  (ADR-0098 Decision 1) makes a content-equal reinstall key-stable;
+  nothing restages, nothing emits. A candidate flip that does not change
+  `w` or `r` emits nothing (equality suppression at both slots).
+
+### 7. Why this does not hit the Add-Path walls
+
+ADR-0099 Decision 5's disqualifiers are per-member *rank sequences* and
+per-member *id history*. Here every member receives at most one route per
+prefix at constant `path_id 0`: no rank assignment, no id holes, no
+renumbering; withdraws are derivable, not recorded. The substitution is a
+pure function of shared state and member identity — the same property that
+admitted the RT filter (Decision 2) and control communities (ADR-0101
+Decision 3). Add-Path send itself stays disqualified; nothing here narrows
+that verdict.
+
+### 8. Generation flips, regroup, and ADR-0105 fencing
+
+A policy reload that changes chain content regroups per-client-best members
+like any grouped member: the destination group's table *and lane* are built
+once per group (one candidate walk per prefix), members diff against
+regroup baselines. Per-client-best groups are **excluded from the ADR-0105
+narrow fast path**: its clean predicate (zero policy-filtered routes on
+both sides) contradicts the mitigation's reason to exist, and ADR-0105's
+"do not broaden" rule stands. They take the ordinary authoritative/regroup
+machinery behind the same fences; the 60-second pre-commit ownership budget
+and fail-closed handoff apply unchanged, and the handoff target — the
+per-peer path — remains a complete correctness fallback (Decision 9's
+oracle guarantees equivalence).
+
+### 9. Migration and observability
+
+Classifier flip lands last (Phase 3): existing per-client-best fleets
+regroup through the ordinary baseline diff, which must be byte-empty on a
+converged fleet (test-pinned) — no session resets. The per-peer path
+remains the correctness oracle: the grouped-vs-forced-ungrouped
+differential suite (`update_groups_oracle.rs`) extends to per-client-best
+fleets with overlapping announcements, asserting identical per-member
+streams across staging, refresh, join, resync, channel-full, and regroup.
+Observability: membership label `group:N` replaces the `per_client_best`
+fallback reason for shareable chains (the reason string remains for
+residual disqualifying combinations); `rbgp neighbor show` still names the
+per-client-best distribution mode; a lane-size gauge
+(`bgp_update_group_runner_up_entries`) exposes the O(overlapped prefixes)
+claim; the received-view-delta verifier is the campaign-level equivalence
+instrument.
+
+## Open decisions
+
+| # | Question | Options | Leaning |
+|---|---|---|---|
+| 1 | Fallback reason when `per_client_best` is set but the key is not unicast-only (VPN/RTC families negotiated) | reuse `per_client_best` / new `per_client_best_families` / reject at validation | reuse `per_client_best` — surface unchanged, documented |
+| 2 | Counter replay for the second permit evaluation | record both evals in group totals / record winner's only | record both; extend the ADR-0098 counter carve-out (oracle compares streams and state, never counters) |
+| 3 | Rendered-default timing: do `rs-config-render` fleets group immediately at ship? | immediate / one release behind an opt-out | immediate — the oracle plus the acceptance receipt are the earn-the-default evidence ADR-0101 Decision 1 asked for |
+| 4 | Lane storage form | full post-policy `Route` shell / candidate reference re-derived at emit | full shell — replay without policy re-evaluation requires the post-policy form; bounded at O(overlapped prefixes) |
+| 5 | ADR-0105 fast-path re-inclusion | never / demand-gated | demand-gated: revisit only with a measured fleet regularly reloading per-client-best cohorts and a receipt |
+
+## Acceptance gate
+
+From the sealed realistic-mix receipt, at the canonical 320 × 183,040
+shape, F ∈ {0.1, 0.5}:
+
+- **Equivalence:** byte-identical per-member received views versus today's
+  ungrouped per-client-best path — every runner-up pair (18,304 / 91,520)
+  delivered, nothing else — proven by the received-view-delta verifier and
+  the extended differential oracle.
+- **Cost:** ≥4× sampler RSS-peak reduction versus the sealed per-client
+  rows (10.4–11.3 GiB), and steady-state reload completion p50 in the
+  grouped-control class (~4.5 s ceiling); the one-extra-evaluation overlap
+  term must not move completion out of that class at F = 0.5.
+
+## Implementation phases
+
+1. **Staging dark:** first-permitted winner walk + runner-up lane in the
+   group pass behind an unchanged classifier; exhaustive lane/source-flip
+   unit matrix.
+2. **Emit seams:** matrix arm, lane deltas, channel-full recording, dirty
+   resync, refresh/join replay, queries/counters, rs-control transitions.
+3. **Classifier flip:** key bit, regroup migration, observability,
+   differential-oracle extension to overlapping per-client-best fleets.
+4. **Receipt:** rerun the realistic-mix campaign, gate as above; amend this
+   ADR to Accepted with the measured rows; confirm `rs-config-render`
+   keeps `path_hiding = true` with grouped output.
+
+## Non-goals
+
+- **Add-Path send grouping** — stays disqualified per ADR-0099 Decision 5
+  ("per-member path-id maps or nothing").
+- **Per-client Loc-RIBs** — rejected permanently (ADR-0101 Decision 2);
+  this design is the RFC 7947 §2.3.2.2 delta formulation instead.
+- **VPN/RTC per-client-best staging** and ORR combinations — out of scope;
+  existing validation and fallbacks stand.
+- **ADR-0105 fast-path broadening** — see open decision 5.
+- **Sorted tables or comparator restrictions** — the BIRD `secondary`
+  constraint set is exactly what the derived-view shape avoids.
+
+## Consequences
+
+If accepted and gated, the rendered route-server default becomes
+simultaneously RFC-7947-mitigated and grouped: grouped-class memory and
+reload completion at the flagship shape without giving up the mitigation,
+with the per-peer path retained wholesale as the correctness oracle and the
+fallback for non-shareable chains. The costs: one more group-key bit, a
+sidecar lane on per-client-best groups, one more matrix arm to keep proven
+by the exhaustive unit matrix and the differential oracle, and a second
+export-policy evaluation per overlapped changed prefix.
+
+## References
+
+- RFC 7947 §2.3 (path hiding; §2.3.2.2 per-client views as deltas over a
+  global Loc-RIB; §2.3.3 Add-Path send-only) —
+  <https://www.rfc-editor.org/rfc/rfc7947>
+- BIRD User's Guide: `secondary` (first filter-accepted route from a
+  `sorted` table; `sorted` incompatible with `deterministic med`) —
+  <https://bird.nic.cz/doc/bird-3.1.2.html>
+- OpenBGPD `rde evaluate all` bug family (fixed in 7.0) —
+  <https://github.com/openbgpd-portable/openbgpd-portable/issues/21>
+- arouteserver path-hiding defaults and per-daemon implementation —
+  <https://arouteserver.readthedocs.io/en/latest/GENERAL.html>
+- CZ.NIC, "BIRD Journey to Threads. Chapter 3½: Route server performance" —
+  <https://en.blog.nic.cz/2022/02/21/bird-journey-to-threads-chapter-3%C2%BD-route-server-performance/>
+- Richter et al., "Peering at Peerings: On the Role of IXP Route Servers",
+  IMC 2014 (the path-hiding mechanism); Alhamwy et al., SIGCOMM 2025
+  Posters (route-diversity point estimate behind the receipt's F values)
+- In-repo: ADR-0098, ADR-0099, ADR-0101, ADR-0105,
+  [realistic-mix receipt](../perf/irr-reload-realistic-mix-2026-08.md)


### PR DESCRIPTION


ADR-0126 (Proposed, 302 lines) designs the path-hiding mitigation inside update groups: one shared staging computation per group with a per-prefix exception lane for the source member's runner-up and group-wide best-permitted selection when the shared chain denies the best. Grounded against BIRD `secondary` (sorted-table constraint), OpenBGPD `rde evaluate all` (the issue #21 second-best bug family named as non-goals with the preventing mechanism for each), RFC 7947 §2.3.2.2, and the sealed realistic-mix receipt whose received-view-delta machinery is the byte-identity acceptance instrument. Gates: workspace tests and diff check green.