### PR TITLE
Lower peer.address/asn/group != to a dedicated NeighborNe node

### DIFF
--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -244,6 +244,30 @@ impl NeighborSetMatch {
             || peer_asn.is_some_and(|asn| self.remote_asns.contains(&asn))
             || peer_group.is_some_and(|group| self.peer_groups.iter().any(|name| name == group))
     }
+
+    /// The `!=` mirror of [`matches`](Self::matches): every populated
+    /// dimension's peer field must be present and miss the set —
+    /// `!=` mirrors `==`, so an absent field satisfies neither
+    /// (LAN-209 class, LAN-895). Like `matches`, an empty set never
+    /// matches.
+    #[must_use]
+    pub fn matches_ne(
+        &self,
+        peer_address: Option<IpAddr>,
+        peer_asn: Option<u32>,
+        peer_group: Option<&str>,
+    ) -> bool {
+        if self.addresses.is_empty() && self.remote_asns.is_empty() && self.peer_groups.is_empty() {
+            return false;
+        }
+        (self.addresses.is_empty()
+            || peer_address.is_some_and(|addr| !self.addresses.contains(&addr)))
+            && (self.remote_asns.is_empty()
+                || peer_asn.is_some_and(|asn| !self.remote_asns.contains(&asn)))
+            && (self.peer_groups.is_empty()
+                || peer_group
+                    .is_some_and(|group| !self.peer_groups.iter().any(|name| name == group)))
+    }
 }
 
 /// What to do with the next-hop attribute.

--- a/crates/policy/src/engine/explain.rs
+++ b/crates/policy/src/engine/explain.rs
@@ -824,6 +824,12 @@ fn binding(expr: &MatchExpr) -> u8 {
         {
             0
         }
+        // A multi-member `Ne` set renders as an internal `&&`.
+        MatchExpr::NeighborNe(set)
+            if set.addresses.len() + set.remote_asns.len() + set.peer_groups.len() > 1 =>
+        {
+            1
+        }
         MatchExpr::And(_) => 1,
         _ => 2,
     }
@@ -937,6 +943,24 @@ fn render_prec(expr: &MatchExpr, tables: &CompiledChain, min_binding: u8) -> Str
                 "false".to_string()
             } else {
                 parts.join(" || ")
+            }
+        }
+        MatchExpr::NeighborNe(set) => {
+            let mut parts: Vec<String> = Vec::new();
+            for addr in &set.addresses {
+                parts.push(format!("peer.address != {addr}"));
+            }
+            for asn in &set.remote_asns {
+                parts.push(format!("peer.asn != {asn}"));
+            }
+            for group in &set.peer_groups {
+                parts.push(format!("peer.group != {group:?}"));
+            }
+            if parts.is_empty() {
+                // An empty neighbor set never matches.
+                "false".to_string()
+            } else {
+                parts.join(" && ")
             }
         }
         MatchExpr::RouteTypeIs(route_type) => {

--- a/crates/policy/src/engine/tests/guard_render.rs
+++ b/crates/policy/src/engine/tests/guard_render.rs
@@ -132,6 +132,27 @@ fn every_node_type_renders_its_golden_form() {
             "peer.group == \"edge\"",
         ),
         (
+            MatchExpr::NeighborNe(Box::new(NeighborSetMatch {
+                addresses: vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))],
+                ..NeighborSetMatch::default()
+            })),
+            "peer.address != 10.0.0.2",
+        ),
+        (
+            MatchExpr::NeighborNe(Box::new(NeighborSetMatch {
+                remote_asns: vec![65001],
+                ..NeighborSetMatch::default()
+            })),
+            "peer.asn != 65001",
+        ),
+        (
+            MatchExpr::NeighborNe(Box::new(NeighborSetMatch {
+                peer_groups: vec!["edge".to_string()],
+                ..NeighborSetMatch::default()
+            })),
+            "peer.group != \"edge\"",
+        ),
+        (
             MatchExpr::RouteTypeIs(RouteType::Internal),
             "route.route-type == internal",
         ),
@@ -158,6 +179,7 @@ fn every_node_type_renders_its_golden_form() {
         (MatchExpr::Or(vec![]), "false"),
         // An empty neighbor set never matches.
         (MatchExpr::NeighborIn(Box::default()), "false"),
+        (MatchExpr::NeighborNe(Box::default()), "false"),
     ];
     for (expr, expected) in cases {
         assert_eq!(render_expr(&expr, &tables), expected, "node {expr:?}");

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -1513,6 +1513,10 @@ impl CompiledChain {
             MatchExpr::NeighborIn(set) => {
                 set.matches(ctx.peer_address, ctx.peer_asn, ctx.peer_group)
             }
+            // `!=` mirrors `==`: an absent peer field matches neither.
+            MatchExpr::NeighborNe(set) => {
+                set.matches_ne(ctx.peer_address, ctx.peer_asn, ctx.peer_group)
+            }
             MatchExpr::RouteTypeIs(route_type) => ctx.route_type == Some(*route_type),
             // `!=` mirrors `==`: an absent route-type matches neither.
             MatchExpr::RouteTypeNe(route_type) => ctx.route_type.is_some_and(|t| t != *route_type),

--- a/crates/policy/src/ir.rs
+++ b/crates/policy/src/ir.rs
@@ -455,6 +455,8 @@ pub struct ValueCmpNode {
 ///   siblings (`RouteTypeNe` / `EvpnRouteTypeNe` / `NextHopNe`) never
 ///   match when the corresponding context field is `None` (`!=` mirrors
 ///   `==`: an absent attribute satisfies neither).
+/// - `NeighborIn` and its `Ne` sibling `NeighborNe` likewise never
+///   match when the compared peer field is absent (LAN-895).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MatchExpr {
     /// Always matches (an unconditional term).
@@ -538,6 +540,15 @@ pub enum MatchExpr {
     /// `MatchExpr`'s size — And-children are walked as a contiguous
     /// `Vec`, so small nodes are cache locality.
     NeighborIn(Box<NeighborSetMatch>),
+    /// The evaluation peer is known and matches **no** set member.
+    /// Unlike `Not(NeighborIn(_))`, this never matches when the
+    /// compared peer field is absent (an ungrouped peer has no
+    /// `peer.group`; explain dry-runs may carry no peer at all) —
+    /// `!=` mirrors `==`, so an absent field satisfies neither
+    /// (LAN-895). Reads peer identity, so like
+    /// [`NeighborIn`](Self::NeighborIn) it counts toward
+    /// [`CompiledChain::requires_peer_context`].
+    NeighborNe(Box<NeighborSetMatch>),
     /// The route's source class equals this type.
     RouteTypeIs(RouteType),
     /// The route's source class differs from this type. Unlike
@@ -673,7 +684,7 @@ impl MatchExpr {
                 DatasetProbe::Community => 3,
                 _ => 1,
             },
-            MatchExpr::NeighborIn(_) => 2,
+            MatchExpr::NeighborIn(_) | MatchExpr::NeighborNe(_) => 2,
             MatchExpr::CommunityContains(_) | MatchExpr::CommunityInSet(_) => 3,
             MatchExpr::AsPathMatches(_) => 4,
             MatchExpr::Not(inner) => inner.cost_class(),
@@ -962,7 +973,8 @@ impl CompiledChain {
     }
 
     /// Whether evaluating this chain depends on the evaluation peer's
-    /// identity (any [`MatchExpr::NeighborIn`] node — peer address,
+    /// identity (any [`MatchExpr::NeighborIn`] /
+    /// [`MatchExpr::NeighborNe`] node — peer address,
     /// ASN, or peer-group matching — a strict-next-hop
     /// [`MatchExpr::NextHopEqPeer`] / [`MatchExpr::NextHopNePeer`]
     /// node, a [`MatchExpr::PeerAsInSet`] membership probe, a
@@ -982,6 +994,7 @@ impl CompiledChain {
     pub fn requires_peer_context(&self) -> bool {
         self.any_guard_node(&|expr| match expr {
             MatchExpr::NeighborIn(_)
+            | MatchExpr::NeighborNe(_)
             | MatchExpr::NextHopEqPeer
             | MatchExpr::NextHopNePeer
             | MatchExpr::PeerAsInSet(_)

--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -1009,6 +1009,13 @@ fn lower_cmp(
                 MatchExpr::EvpnRouteTypeIs(evpn_type)
             }
         }
+        // `negate_if` (i.e. `Not(Eq)`) is safe for rpki/aspa ONLY
+        // because their context fields are non-optional total enums —
+        // "absent" is an explicit value (`NotFound` / `Unknown`), so
+        // `Not` is a true complement. Fields whose context value is an
+        // `Option` (peer.*, next-hop, prefix, …) must lower `!=` to a
+        // dedicated Ne node instead: `Not` matches on absence (LAN-209,
+        // LAN-895).
         Field::Rpki => {
             let node = MatchExpr::RpkiIs(match rhs_ident(rhs) {
                 "valid" => rustbgpd_wire::RpkiValidation::Valid,
@@ -1075,32 +1082,49 @@ fn lower_cmp(
             }
             _ => unreachable!("typechecked: next-hop compares an IP or peer.address"),
         },
+        // `!=` gets a dedicated Ne node rather than `Not(Eq)` (LAN-895):
+        // an absent peer field (peer.group on an ungrouped peer;
+        // peer-less explain dry-runs) must match neither `==` nor `!=`
+        // (LAN-209 class), and `Not(NeighborIn)` would wrongly match
+        // when it is absent.
         Field::PeerAddress => {
             let Rhs::Ip(addr, _) = rhs else {
                 unreachable!("typechecked: peer.address compares an IP")
             };
-            let node = MatchExpr::NeighborIn(Box::new(NeighborSetMatch {
+            let set = Box::new(NeighborSetMatch {
                 addresses: vec![*addr],
                 ..NeighborSetMatch::default()
-            }));
-            negate_if(op == CmpOp::Ne, node)
+            });
+            if op == CmpOp::Ne {
+                MatchExpr::NeighborNe(set)
+            } else {
+                MatchExpr::NeighborIn(set)
+            }
         }
         Field::PeerAsn => {
-            let node = MatchExpr::NeighborIn(Box::new(NeighborSetMatch {
+            let set = Box::new(NeighborSetMatch {
                 remote_asns: vec![rhs_u32(rhs, env)],
                 ..NeighborSetMatch::default()
-            }));
-            negate_if(op == CmpOp::Ne, node)
+            });
+            if op == CmpOp::Ne {
+                MatchExpr::NeighborNe(set)
+            } else {
+                MatchExpr::NeighborIn(set)
+            }
         }
         Field::PeerGroup => {
             let Rhs::Str(group) = rhs else {
                 unreachable!("typechecked: peer.group compares a string")
             };
-            let node = MatchExpr::NeighborIn(Box::new(NeighborSetMatch {
+            let set = Box::new(NeighborSetMatch {
                 peer_groups: vec![group.node.clone()],
                 ..NeighborSetMatch::default()
-            }));
-            negate_if(op == CmpOp::Ne, node)
+            });
+            if op == CmpOp::Ne {
+                MatchExpr::NeighborNe(set)
+            } else {
+                MatchExpr::NeighborIn(set)
+            }
         }
         // `!=` gets a dedicated Ne node rather than `Not(Eq)`: a
         // prefixless route (BGP-LS / RTC NLRIs) must match neither `==`

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -1419,6 +1419,9 @@ fn absent_route_attribute_matches_neither_eq_nor_ne() {
         ("route.route-type", "external"),
         ("route.evpn-route-type", "3"),
         ("route.family", "evpn"),
+        ("peer.address", "192.0.2.1"),
+        ("peer.asn", "65010"),
+        ("peer.group", "\"leaf\""),
     ];
     let absent = absent_ctx();
     for (field, literal) in fields {
@@ -1525,6 +1528,125 @@ fn route_type_ne_absent_does_not_match() {
         PolicyAction::Permit,
         "absent route-type must not match `!= external`"
     );
+}
+
+#[test]
+fn peer_address_ne_absent_does_not_match() {
+    // A route evaluated without peer identity must match neither `==`
+    // nor `!=` — `Not(NeighborIn)` used to match when the peer address
+    // was absent (LAN-895).
+    let chain = reject_if("peer.address != 192.0.2.1");
+    assert_eq!(
+        chain.policies[0].terms[0].guard,
+        MatchExpr::NeighborNe(Box::new(crate::engine::NeighborSetMatch {
+            addresses: vec!["192.0.2.1".parse().unwrap()],
+            ..Default::default()
+        }))
+    );
+    let base = absent_ctx();
+    // Present and differing → matches → reject.
+    let differing = RouteContext {
+        peer_address: Some("198.51.100.7".parse().unwrap()),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&differing).action, PolicyAction::Deny);
+    // Present and equal → no match → accept.
+    let equal = RouteContext {
+        peer_address: Some("192.0.2.1".parse().unwrap()),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&equal).action, PolicyAction::Permit);
+    // Absent → must NOT match → accept (this was the bug).
+    assert_eq!(
+        chain.evaluate(&base).action,
+        PolicyAction::Permit,
+        "absent peer address must not match `peer.address != 192.0.2.1`"
+    );
+}
+
+#[test]
+fn peer_asn_ne_absent_does_not_match() {
+    // An unknown peer ASN must match neither `==` nor `!=` —
+    // `Not(NeighborIn)` used to match when it was absent (LAN-895).
+    let chain = reject_if("peer.asn != 65010");
+    assert_eq!(
+        chain.policies[0].terms[0].guard,
+        MatchExpr::NeighborNe(Box::new(crate::engine::NeighborSetMatch {
+            remote_asns: vec![65010],
+            ..Default::default()
+        }))
+    );
+    let base = absent_ctx();
+    // Present and differing → matches → reject.
+    let differing = RouteContext {
+        peer_asn: Some(65020),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&differing).action, PolicyAction::Deny);
+    // Present and equal → no match → accept.
+    let equal = RouteContext {
+        peer_asn: Some(65010),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&equal).action, PolicyAction::Permit);
+    // Absent → must NOT match → accept (this was the bug).
+    assert_eq!(
+        chain.evaluate(&base).action,
+        PolicyAction::Permit,
+        "absent peer ASN must not match `peer.asn != 65010`"
+    );
+}
+
+#[test]
+fn peer_group_ne_absent_does_not_match() {
+    // An ungrouped peer (peer_group None — the routine live case) must
+    // match neither `==` nor `!=` — `Not(NeighborIn)` used to match
+    // every ungrouped peer (LAN-895).
+    let chain = reject_if(r#"peer.group != "leaf""#);
+    assert_eq!(
+        chain.policies[0].terms[0].guard,
+        MatchExpr::NeighborNe(Box::new(crate::engine::NeighborSetMatch {
+            peer_groups: vec!["leaf".to_string()],
+            ..Default::default()
+        }))
+    );
+    let base = absent_ctx();
+    // Present and differing → matches → reject.
+    let differing = RouteContext {
+        peer_group: Some("spine"),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&differing).action, PolicyAction::Deny);
+    // Present and equal → no match → accept.
+    let equal = RouteContext {
+        peer_group: Some("leaf"),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&equal).action, PolicyAction::Permit);
+    // Absent → must NOT match → accept (this was the bug).
+    assert_eq!(
+        chain.evaluate(&base).action,
+        PolicyAction::Permit,
+        "ungrouped peer must not match `peer.group != \"leaf\"`"
+    );
+}
+
+#[test]
+fn peer_ne_still_requires_peer_context() {
+    // The dedicated Ne node reads peer identity exactly like
+    // `NeighborIn`, so it must keep disqualifying peers from
+    // update-group sharing.
+    for guard in [
+        "peer.address != 192.0.2.1",
+        "peer.asn != 65010",
+        r#"peer.group != "leaf""#,
+    ] {
+        let chain = reject_if(guard);
+        assert!(
+            chain.requires_peer_context(),
+            "`{guard}` must require peer context"
+        );
+    }
 }
 
 // ── asn-sets and origin-as predicates (LAN-249) ────────────────────


### PR DESCRIPTION
## Problem

`peer.address != x`, `peer.asn != n`, and `peer.group != "g"` lowered via `negate_if` to `Not(NeighborIn(set))`. `NeighborIn` returns false when the compared peer field is absent, so the negation matched every route with absent peer context. `peer.group` is routinely `None` for ungrouped peers, and explain dry-runs may carry no peer identity at all — a `peer.group != "g"` guard therefore matched every ungrouped peer.

Every other absence-bearing field (`route.prefix`, `route.next-hop`, `route.route-type`, `route.evpn-route-type`, `route.family`) already lowers `!=` to a dedicated `*Ne` node for exactly this reason (LAN-209 class).

## Fix

- New `MatchExpr::NeighborNe(Box<NeighborSetMatch>)`: matches only when every populated set dimension's peer field is present and misses the set (`!=` mirrors `==`: an absent field satisfies neither). An empty set never matches, mirroring `NeighborIn`.
- The three peer fields' `CmpOp::Ne` lowering now emits `NeighborNe` instead of `Not(NeighborIn)`.
- `NeighborNe` counts toward `requires_peer_context`, so update-group disqualification is unchanged (covered by a test).
- Policy explain renders the node (`peer.address != 10.0.0.2 && …`, joined with `&&`; multi-member sets bind at `And` precedence).
- The remaining `negate_if` sites (`route.rpki` / `route.aspa`) are safe: their context fields are non-optional total enums (`NotFound` / `Unknown` are explicit values), so `Not` is a true complement — now documented with a constraint comment at the lowering site. The `Not(And(Ge,Le))` scalar-`!=` helper serves only `local-pref`/`med` (RFC 4271 implicit defaults) and `as-path.len` (always defined), which are likewise total.

## Tests

- Per-field absence tests: `peer_address_ne_absent_does_not_match`, `peer_asn_ne_absent_does_not_match`, `peer_group_ne_absent_does_not_match` (present-and-differing matches, present-and-equal does not, absent does not — the last failed against the old lowering).
- The three peer fields join the LAN-209 `absent_route_attribute_matches_neither_eq_nor_ne` table so a regression to `Not(Eq)` trips it.
- `peer_ne_still_requires_peer_context` pins update-group disqualification.
- Guard-render cases for all three `NeighborNe` forms plus the empty set.