### PR TITLE
Backpressure the BMP post-dump Loc-RIB flush instead of dropping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The post-dump flush of held-back live Loc-RIB messages no longer drops
+  on a full collector channel (LAN-894). The flush `try_send`-ed the
+  entire held-back buffer (bounded at 8,192 messages) into the
+  per-collector outbound channel (capacity 4,096) in one synchronous
+  burst, so any held-back count above the channel's free space — already
+  partially consumed by concurrent churn fan-out — was silently dropped,
+  and the now-full channel made concurrent live fan-out sends drop too: a
+  collector that had just received a complete dump missed live updates.
+  The flush now runs as a per-collector task that awaits channel capacity,
+  pacing delivery at the collector's TCP drain rate while live events keep
+  buffering behind it in arrival order; the dump→EoR→live ordering, the
+  live-buffer overflow closure for a collector persistently slower than
+  churn, and a per-message send timeout for a dead collector all remain.
+  Other collectors and the churn path are never blocked by one
+  collector's flush.
 - The IRR BMP buffer-receipt sink no longer starves its stop-file check
   under continuous post-EoR churn (LAN-889). `wait_for_scrape_release`
   only consulted the stop-file when the collector socket was idle, so

--- a/bench/scale/irrreload/run-bmp-buffer-receipt.sh
+++ b/bench/scale/irrreload/run-bmp-buffer-receipt.sh
@@ -61,9 +61,19 @@ cargo build --release -p rustbgpd --bin rustbgpd -p rs-config-render --bin rs-co
 cargo build --release --manifest-path bench/scale/reloadstall/Cargo.toml --locked
 
 ACTIVE_DAEMON="" ACTIVE_HARNESS="" ACTIVE_SINK="" ACTIVE_TMP=""
+COMPLETED_RUNS=()
 terminate_group() {
     local pid=${1:-}
     [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null || kill -TERM -- "-$pid" 2>/dev/null || true
+}
+# A red run keeps its raw root (sink capture, generated scenario,
+# partial sink state, pre-churn evidence) inside the artifact dir
+# instead of losing it to cleanup.
+preserve_run_root() {
+    local run=$1 keep
+    keep="$ART/FAILED-$(basename "$run")"
+    mv -- "$run" "$keep" 2>/dev/null ||
+        echo "failed to preserve red run root $run" >&2
 }
 cleanup() {
     local rc=$?
@@ -74,14 +84,17 @@ cleanup() {
         if [ "$rc" -eq 0 ]; then
             rm -rf "$ACTIVE_TMP"
         else
-            # A red run keeps its raw root (sink capture, generated
-            # scenario, partial sink state, pre-churn evidence) inside
-            # the artifact dir instead of losing it to cleanup.
-            local keep
-            keep="$ART/FAILED-$(basename "$ACTIVE_TMP")"
-            mv -- "$ACTIVE_TMP" "$keep" 2>/dev/null ||
-                echo "failed to preserve red run root $ACTIVE_TMP" >&2
+            preserve_run_root "$ACTIVE_TMP"
         fi
+    fi
+    # Raw roots of completed runs are retained until cross-run
+    # verification passes; a failure after run_once (e.g. the verifier
+    # rejecting the pair) preserves them like any other red run.
+    if [ "$rc" -ne 0 ]; then
+        local run
+        for run in "${COMPLETED_RUNS[@]}"; do
+            [ ! -e "$run" ] || preserve_run_root "$run"
+        done
     fi
 }
 trap cleanup EXIT
@@ -191,7 +204,7 @@ run_once() {
     terminate_group "$daemon_pid"
     wait "$daemon_pid" || true
     ACTIVE_DAEMON=""
-    rm -rf "$run"
+    COMPLETED_RUNS+=("$run")
     ACTIVE_TMP=""
 }
 
@@ -200,9 +213,21 @@ jq -n --arg commit "$HEAD" \
     >"$ART/provenance.json"
 run_once a
 run_once b
-python3 "$VERIFY" verify --allow-unsealed "$ART" >"$ART/verification.json"
+# Capture the verifier's stderr and drop the partial stdout redirect on
+# failure so a red verification never leaves an empty verification.json
+# behind as if it were a result.
+if ! python3 "$VERIFY" verify --allow-unsealed "$ART" \
+    >"$ART/verification.json" 2>"$ART/verification.stderr"; then
+    rm -f "$ART/verification.json"
+    echo "cross-run verification failed:" >&2
+    cat "$ART/verification.stderr" >&2
+    exit 1
+fi
+rm -f "$ART/verification.stderr"
 printf 'pass\n' >"$ART/COMPLETED"
 (cd "$ART" && find . -type f ! -name SHA256SUMS -printf '%P\0' | sort -z | xargs -0 sha256sum) >"$ART/SHA256SUMS"
 chmod -R a-w "$ART"
 python3 "$VERIFY" verify "$ART" >/dev/null
+rm -rf -- "${COMPLETED_RUNS[@]}"
+COMPLETED_RUNS=()
 echo "sealed BMP buffer receipt: $ART"

--- a/crates/bmp/src/manager.rs
+++ b/crates/bmp/src/manager.rs
@@ -43,11 +43,13 @@ const LOC_RIB_DUMP_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from
 /// certifying a snapshot that omitted live deltas.
 const LOC_RIB_DUMP_LIVE_BUFFER_CAP: usize = 8192;
 
-/// One in-flight Loc-RIB dump for a collector connection generation.
+/// One in-flight Loc-RIB dump — or a post-dump flush round of its
+/// held-back live messages — for a collector connection generation.
 struct ActiveDump {
     /// Connection generation the dump was started for.
     generation: u64,
-    /// The forwarder task, aborted when the connection is superseded.
+    /// The forwarder or flush task, aborted when the connection is
+    /// superseded.
     task: tokio::task::JoinHandle<()>,
     /// Live Loc-RIB messages held back while the dump streams, flushed
     /// in arrival order after the dump's End-of-RIB so the collector
@@ -81,6 +83,12 @@ enum DumpFailure {
     ReplyClosed,
     ChannelTimeout,
     ChannelClosed,
+    /// The post-dump flush of held-back live messages stalled past
+    /// [`LOC_RIB_DUMP_SEND_TIMEOUT`] with this many messages undelivered.
+    FlushTimeout(u64),
+    /// The collector channel closed mid-flush with this many messages
+    /// undelivered.
+    FlushClosed(u64),
 }
 
 impl DumpFailure {
@@ -92,6 +100,18 @@ impl DumpFailure {
             Self::ReplyClosed => "reply_closed",
             Self::ChannelTimeout => "channel_timeout",
             Self::ChannelClosed => "channel_closed",
+            Self::FlushTimeout(_) => "flush_timeout",
+            Self::FlushClosed(_) => "flush_closed",
+        }
+    }
+
+    /// Messages irrecoverably lost by the failure itself. Dump failures
+    /// count as one dropped stream; a flush failure knows exactly how
+    /// many held-back live messages it left undelivered.
+    const fn dropped(self) -> u64 {
+        match self {
+            Self::FlushTimeout(n) | Self::FlushClosed(n) => n,
+            _ => 1,
         }
     }
 }
@@ -186,7 +206,9 @@ pub struct BmpManager {
     /// generation starts clean and heals the suppression.
     loc_rib_suppressed: std::collections::HashSet<usize>,
     /// In-flight Loc-RIB dump (plus its held-back live messages) per
-    /// collector index. Present from dump spawn until its [`DumpDone`].
+    /// collector index. Present from dump spawn until the dump and
+    /// every follow-up flush round report [`DumpDone`] with nothing
+    /// left held back.
     active_dumps: std::collections::HashMap<usize, ActiveDump>,
     /// Cloned into each spawned dump forwarder; completions come back
     /// on `dump_done_rx` in the manager loop.
@@ -851,6 +873,17 @@ impl BmpManager {
     /// Apply a generation-current dump outcome. Only a complete terminal
     /// RIB chunk flushes buffered deltas. Failure discards them and
     /// suppresses this Loc-RIB view until a later connection generation.
+    ///
+    /// The flush runs as a follow-up task registered in
+    /// [`Self::active_dumps`]: the held-back buffer (up to
+    /// [`LOC_RIB_DUMP_LIVE_BUFFER_CAP`] messages) can exceed the
+    /// collector channel's free capacity, so delivery must await
+    /// capacity at the collector's drain rate ([`flush_held_loc_rib`])
+    /// instead of dropping whatever the burst could not fit. While a
+    /// round flushes, live events keep buffering behind it; each round's
+    /// completion arrives back here and flushes what accumulated
+    /// meanwhile, and the collector goes live once a round completes
+    /// with nothing held.
     fn handle_dump_done(&mut self, done: &DumpDone) {
         match self.active_dumps.get(&done.collector_id) {
             Some(dump) if dump.generation == done.generation => {}
@@ -876,39 +909,41 @@ impl BmpManager {
                 &addr_label,
                 "loc_rib_dump",
                 failure.reason(),
-                1,
+                failure.dropped(),
             );
             warn!(
                 collector = %collector.addr,
                 generation = done.generation,
                 reason = failure.reason(),
                 buffered_dropped = dump.buffered.len(),
-                "Loc-RIB dump failed before End-of-RIB; suppressing this view until reconnect"
+                "Loc-RIB dump or post-dump flush failed; suppressing this view until reconnect"
             );
             return;
         }
-
-        let total = dump.buffered.len();
-        for (idx, msg) in dump.buffered.into_iter().enumerate() {
-            if let Err(e) = tx.try_send(msg) {
-                let reason = trysend_reason(&e);
-                let remaining = u64::try_from(total - idx).unwrap_or(u64::MAX);
-                self.metrics.record_bmp_collector_drop(
-                    &addr_label,
-                    "loc_rib_dump",
-                    reason,
-                    remaining,
-                );
-                warn!(
-                    collector = %collector.addr,
-                    error = %e,
-                    skipped = remaining,
-                    "BMP collector channel full or closed flushing post-dump live \
-                     Loc-RIB messages; remaining messages dropped"
-                );
-                break;
-            }
+        if dump.buffered.is_empty() {
+            return;
         }
+
+        let flush = FlushForwarder {
+            collector_tx: tx.clone(),
+            addr_label,
+            generation: Arc::clone(&collector.generation),
+            dump_generation: done.generation,
+        };
+        let task = tokio::spawn(flush_held_loc_rib(
+            flush,
+            dump.buffered,
+            self.dump_done_tx.clone(),
+            done.collector_id,
+        ));
+        self.active_dumps.insert(
+            done.collector_id,
+            ActiveDump {
+                generation: done.generation,
+                task,
+                buffered: Vec::new(),
+            },
+        );
     }
 
     /// RFC 9069 table sync for a (re)connected collector that monitors
@@ -1158,6 +1193,76 @@ async fn stream_loc_rib_dump(f: DumpForwarder) -> Option<DumpOutcome> {
             return Some(DumpOutcome::Complete);
         }
     }
+}
+
+/// Everything one post-dump flush task needs, mirroring
+/// [`DumpForwarder`] for the flush leg.
+struct FlushForwarder {
+    collector_tx: mpsc::Sender<Bytes>,
+    addr_label: String,
+    /// Live connection generation shared with the manager; same fencing
+    /// contract as [`DumpForwarder::generation`].
+    generation: Arc<AtomicU64>,
+    dump_generation: u64,
+}
+
+impl FlushForwarder {
+    fn superseded(&self) -> bool {
+        self.generation.load(Ordering::SeqCst) != self.dump_generation
+    }
+}
+
+/// Deliver one completed dump's held-back live Loc-RIB messages,
+/// awaiting collector-channel capacity instead of dropping: the source
+/// is bounded (at most [`LOC_RIB_DUMP_LIVE_BUFFER_CAP`] messages) and
+/// the writer drains to a TCP socket, so a healthy collector always
+/// absorbs the burst even when it briefly outpaces the writer.
+/// [`LOC_RIB_DUMP_SEND_TIMEOUT`] per message remains the last resort
+/// for a genuinely dead or stalled collector, and the generation fence
+/// stops the task the moment the connection is superseded.
+///
+/// Runs as the collector's registered dump task so one collector's
+/// flush never blocks the manager loop, other collectors, or the churn
+/// fan-out path.
+async fn flush_held_loc_rib(
+    f: FlushForwarder,
+    buffered: Vec<Bytes>,
+    done_tx: mpsc::Sender<DumpDone>,
+    collector_id: usize,
+) {
+    let total = buffered.len();
+    let mut outcome = DumpOutcome::Complete;
+    for (idx, msg) in buffered.into_iter().enumerate() {
+        if f.superseded() {
+            return;
+        }
+        let remaining = u64::try_from(total - idx).unwrap_or(u64::MAX);
+        let failure =
+            match tokio::time::timeout(LOC_RIB_DUMP_SEND_TIMEOUT, f.collector_tx.send(msg)).await {
+                Ok(Ok(())) => continue,
+                Ok(Err(_)) => DumpFailure::FlushClosed(remaining),
+                Err(_) => DumpFailure::FlushTimeout(remaining),
+            };
+        if f.superseded() {
+            return;
+        }
+        warn!(
+            collector = %f.addr_label,
+            reason = failure.reason(),
+            skipped = remaining,
+            "BMP collector stalled or closed flushing post-dump live Loc-RIB \
+             messages; remaining messages dropped"
+        );
+        outcome = DumpOutcome::Failed(failure);
+        break;
+    }
+    let _ = done_tx
+        .send(DumpDone {
+            collector_id,
+            generation: f.dump_generation,
+            outcome,
+        })
+        .await;
 }
 
 fn buffer_loc_rib_message(buffer: &mut Vec<Bytes>, message: Bytes) -> bool {
@@ -3261,6 +3366,98 @@ mod tests {
         assert_eq!(manager.collectors[0].phase.generation(), Some(5));
         assert!(!receiver.is_closed(), "replacement remains connected");
         manager.active_dumps.remove(&0).unwrap().task.abort();
+    }
+
+    /// Load-bearing proof that the post-dump flush awaits collector-channel
+    /// capacity: the held-back buffer exceeds the channel and churn keeps
+    /// arriving while nothing drains, so a `try_send` flush cannot deliver.
+    /// Every message must arrive, held-back before churn, with zero drops.
+    #[tokio::test]
+    async fn post_dump_flush_with_concurrent_churn_delivers_everything() {
+        const HELD: usize = 64;
+        const CHURN: usize = 64;
+        // Far smaller than HELD so the flush burst can never fit at once.
+        const CHANNEL: usize = 8;
+
+        let (event_tx, event_rx) = mpsc::channel(CHURN);
+        let (control_tx, control_rx) = mpsc::channel(1);
+        let (dump_tx, _dump_rx) = mpsc::channel(1);
+        let (collector_tx, mut collector_rx) = mpsc::channel::<Bytes>(CHANNEL);
+        let metrics = BgpMetrics::new();
+        let addr = collector_addr(0);
+        let mut manager = BmpManager::new_connected_for_test(
+            event_rx,
+            control_rx,
+            vec![(addr, collector_tx, loc_rib_filter(), BmpVersion::V3)],
+            metrics.clone(),
+        )
+        .with_loc_rib(loc_rib_config(), dump_tx);
+        manager.active_dumps.insert(
+            0,
+            ActiveDump {
+                generation: 1,
+                task: tokio::spawn(async {}),
+                buffered: vec![Bytes::from_static(b"held"); HELD],
+            },
+        );
+        let done_tx = manager.dump_done_tx.clone();
+        let handle = tokio::spawn(manager.run());
+
+        done_tx
+            .send(DumpDone {
+                collector_id: 0,
+                generation: 1,
+                outcome: DumpOutcome::Complete,
+            })
+            .await
+            .unwrap();
+        // Concurrent churn: accepted by the manager while the flush is
+        // still blocked on the full channel (nothing drains yet).
+        for _ in 0..CHURN {
+            event_tx
+                .send(BmpEvent::LocRibStats { per_family: vec![] })
+                .await
+                .unwrap();
+        }
+        wait_until_received(&event_tx, CHURN).await;
+
+        let drops = |phase: &str| {
+            metric_value_with_labels(
+                &metrics,
+                "bmp_collector_drops_total",
+                &[("collector", &addr.to_string()), ("phase", phase)],
+            )
+        };
+        let total = HELD + CHURN;
+        let mut held_seen = 0_usize;
+        let mut churn_seen = 0_usize;
+        for _ in 0..total {
+            let Ok(Some(msg)) =
+                tokio::time::timeout(std::time::Duration::from_secs(10), collector_rx.recv()).await
+            else {
+                panic!(
+                    "delivery stalled after {} of {total} messages \
+                     (drops: loc_rib_dump={}, fan_out={})",
+                    held_seen + churn_seen,
+                    drops("loc_rib_dump"),
+                    drops("fan_out"),
+                )
+            };
+            if msg == Bytes::from_static(b"held") {
+                assert_eq!(churn_seen, 0, "held-back message delivered after churn");
+                held_seen += 1;
+            } else {
+                churn_seen += 1;
+            }
+        }
+        assert_eq!(held_seen, HELD);
+        assert_eq!(churn_seen, CHURN);
+        assert_eq!(drops("loc_rib_dump"), 0);
+        assert_eq!(drops("fan_out"), 0);
+
+        drop(event_tx);
+        drop(control_tx);
+        handle.await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

A collector that had just received a complete RFC 9069 Loc-RIB dump could silently miss live updates. Observed at collector connect + 4 s: `BMP collector channel full or closed flushing post-dump live Loc-RIB messages; remaining messages dropped (skipped: 230)` plus 144 individual fan-out drop warns (`bgp_collector_drops_total{loc_rib_dump,channel_full}=230`, `{fan_out,channel_full}=144`), while the held-back live buffer never overflowed (high-watermark ~2,912 of 8,192). An identical run was clean — a nondeterministic race, not a capacity ceiling.

## Channel-design adjudication

The per-collector outbound channel (BMP manager → per-connection TCP writer) is a bounded mpsc with `COLLECTOR_CHANNEL_CAPACITY = 4096` (`crates/bmp/src/client.rs`). While a Loc-RIB dump streams, live Loc-RIB events for that collector are held back in the dump's buffer, bounded by `LOC_RIB_DUMP_LIVE_BUFFER_CAP = 8192` (`crates/bmp/src/manager.rs`). On dump completion, `handle_dump_done` flushed that entire held-back buffer into the channel in one synchronous `try_send` loop.

The burst therefore races the writer's TCP drain against up to 8,192 enqueues delivered at memcpy speed — the buffer bound is 2x the channel capacity, so a large flush cannot fit even into an empty channel, and under churn the channel is already partially occupied by concurrent fan-out. Whatever the burst could not fit was dropped (`loc_rib_dump/channel_full`), and the channel it left full then made concurrent live fan-out `try_send`s drop too (`fan_out/channel_full` — the 144 collateral drops). The dump streaming path itself already paces per-message with a send timeout; only the post-dump flush lacked backpressure.

## Fix

The flush now runs as a per-collector task registered as the collector's active dump entry. It `send().await`s each message, pacing delivery at the collector's TCP drain rate, while live events arriving meanwhile keep buffering behind it in arrival order. Each completed round reports back through the existing `DumpDone` path and flushes what accumulated during the previous round; the collector goes fully live once a round completes with nothing held back.

Invariants preserved:

- dump rows → End-of-RIB → live deltas ordering, per collector;
- one collector's flush never blocks the manager loop, other collectors, or the churn fan-out path;
- the live-buffer cap still fails the generation closed for a collector persistently slower than churn (the flush rounds converge or trip that cap);
- drops remain only as a last resort: a per-message `LOC_RIB_DUMP_SEND_TIMEOUT` (30 s) for a genuinely dead or stalled collector, reported as new `flush_timeout`/`flush_closed` reasons carrying the exact undelivered remainder, with the existing view-suppression-until-reconnect semantics;
- the connection-generation fence stops a flush the moment the collector reconnects or drops.

## Red evidence

New test `post_dump_flush_with_concurrent_churn_delivers_everything`: 64 held-back messages, 64 concurrent churn events, an 8-slot collector channel that nothing drains until every event has been accepted by the manager — then everything must arrive, held-back before churn, with zero drops. Under the previous flush logic this test fails with 120 of 128 messages dropped:

```
delivery stalled after 8 of 128 messages (drops: loc_rib_dump=57, fan_out=63)
```

— the same two-sided signature as the production incident: the try_send flush drops the burst remainder, then the full channel drops the concurrent churn.

## Receipt-runner hardening (separate commit)

Two evidence-loss seams in `bench/scale/irrreload/run-bmp-buffer-receipt.sh`:

- the cross-run verification step redirected only the verifier's stdout, so a verifier failure left an empty `verification.json` behind and its stderr diagnostics unretained — stderr is now captured, surfaced on failure, and the partial stdout artifact removed;
- per-run raw roots were deleted as soon as `run_once` succeeded even though cross-run verification can still fail afterwards — completed raw roots are now retained until the sealed receipt verifies, and preserved under the artifact dir (`FAILED-*`) when a later step fails.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps`, `scripts/check-clippy-reasons.py` — all exit 0.
