### PR TITLE
EVPN wire encode hardening: fail hard where debug-only assertions silently emitted wrong wire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- EVPN wire encoding no longer emits silently wrong bytes for invariant
+  violations that were only debug-asserted (LAN-896). Release builds
+  used to encode a Type 5 route with a gateway/prefix family mismatch
+  by substituting UNSPECIFIED in the prefix family (round-tripping as a
+  different, undetectably corrupted route), pin an EAD-per-ES ethernet
+  tag to MAX_ET regardless of the struct field (silently rewriting a
+  key field), encode an EAD-per-EVI carrying MAX_ET verbatim (decoding
+  back as EAD-per-ES — an identity flip), and synthesize a zero-ESI
+  Type 4 fallback that the decoder itself rejects as malformed. The
+  first three are now hard encode errors — **breaking**:
+  `rustbgpd-wire`'s `encode_evpn_nlri` now returns
+  `Result<(), EncodeError>` — and the Type 4 fallback is skipped with a
+  warning instead of emitted.
+
 - The IRR BMP buffer-receipt sink no longer starves its stop-file check
   under continuous post-EoR churn (LAN-889). `wait_for_scrape_release`
   only consulted the stop-file when the collector socket was idle, so

--- a/crates/mrt/src/codec.rs
+++ b/crates/mrt/src/codec.rs
@@ -696,7 +696,7 @@ fn encode_evpn_rib_generic(
         buf.extend_from_slice(&(Afi::L2Vpn as u16).to_be_bytes())?;
         buf.push(Safi::Evpn as u8)?;
         let mut nlri = Vec::new();
-        encode_evpn_nlri(std::slice::from_ref(&route.route), &mut nlri);
+        encode_evpn_nlri(std::slice::from_ref(&route.route), &mut nlri)?;
         buf.extend_from_slice(&nlri)?;
         buf.extend_from_slice(&1u16.to_be_bytes())?;
         encode_evpn_route_rib_entry(buf, route, peer_index, originated_time)?;
@@ -2429,7 +2429,7 @@ mod tests {
         // same EvpnRoute — proves the record header carries the canonical
         // EVPN NLRI TLV (route_type + length + body).
         let mut expected_nlri = Vec::new();
-        encode_evpn_nlri(std::slice::from_ref(&route.route), &mut expected_nlri);
+        encode_evpn_nlri(std::slice::from_ref(&route.route), &mut expected_nlri).unwrap();
         let nlri_start = 7; // after seq(4) + afi(2) + safi(1)
         let nlri_end = nlri_start + expected_nlri.len();
         assert_eq!(
@@ -2465,7 +2465,7 @@ mod tests {
         assert_eq!(u16::from_be_bytes([payload[4], payload[5]]), 25);
         assert_eq!(payload[6], 70);
         let mut expected_nlri = Vec::new();
-        encode_evpn_nlri(std::slice::from_ref(&route.route), &mut expected_nlri);
+        encode_evpn_nlri(std::slice::from_ref(&route.route), &mut expected_nlri).unwrap();
         assert_eq!(
             &payload[7..7 + expected_nlri.len()],
             expected_nlri.as_slice()

--- a/crates/wire/fuzz/fuzz_targets/decode_evpn.rs
+++ b/crates/wire/fuzz/fuzz_targets/decode_evpn.rs
@@ -8,7 +8,7 @@ fuzz_target!(|data: &[u8]| {
         // Successful decode must round-trip through encode back into valid bytes
         // that decode identically.
         let mut buf = Vec::new();
-        encode_evpn_nlri(&routes, &mut buf);
+        encode_evpn_nlri(&routes, &mut buf).expect("decoded routes must re-encode");
         let redecoded = decode_evpn_nlri(&buf).expect("round-trip decode");
         assert_eq!(routes, redecoded, "evpn round-trip mismatch");
     }

--- a/crates/wire/fuzz/fuzz_targets/encode_evpn.rs
+++ b/crates/wire/fuzz/fuzz_targets/encode_evpn.rs
@@ -201,9 +201,9 @@ fuzz_target!(|data: &[u8]| {
         return;
     }
     let mut buf = Vec::new();
-    encode_evpn_nlri(&routes, &mut buf);
+    encode_evpn_nlri(&routes, &mut buf).expect("constructed routes must encode");
     let decoded = decode_evpn_nlri(&buf).expect("constructed routes must decode");
     let mut buf2 = Vec::new();
-    encode_evpn_nlri(&decoded, &mut buf2);
+    encode_evpn_nlri(&decoded, &mut buf2).expect("decoded routes must re-encode");
     assert_eq!(buf, buf2, "encode is not a function");
 });

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -2772,7 +2772,7 @@ fn encode_mp_reach_nlri(
             }
         }
         buf.push(0); // Reserved
-        crate::evpn::encode_evpn_nlri(&mp.evpn_announced, buf);
+        crate::evpn::encode_evpn_nlri(&mp.evpn_announced, buf)?;
         return Ok(());
     }
     if mp.afi == Afi::BgpLs && matches!(mp.safi, Safi::BgpLs | Safi::BgpLsVpn) {
@@ -2894,7 +2894,7 @@ fn encode_mp_unreach_nlri(
     }
     // EVPN: encode EVPN NLRI routes
     if mp.afi == Afi::L2Vpn && mp.safi == Safi::Evpn {
-        crate::evpn::encode_evpn_nlri(&mp.evpn_withdrawn, buf);
+        crate::evpn::encode_evpn_nlri(&mp.evpn_withdrawn, buf)?;
         return Ok(());
     }
     if mp.afi == Afi::BgpLs && matches!(mp.safi, Safi::BgpLs | Safi::BgpLsVpn) {

--- a/crates/wire/src/evpn.rs
+++ b/crates/wire/src/evpn.rs
@@ -1196,9 +1196,11 @@ fn encode_type5_body(r: &EvpnIpPrefixRoute, out: &mut Vec<u8>) -> Result<(), Enc
 /// # Errors
 ///
 /// Returns [`EncodeError::ValueOutOfRange`] if a route violates a wire
-/// invariant the decoder discriminates on (currently: a Type 5 gateway
-/// whose address family differs from its prefix). `buf` may hold a
-/// partial encoding after an error and must be discarded.
+/// invariant the decoder discriminates on: a Type 5 gateway whose
+/// address family differs from its prefix, an EAD-per-ES route whose
+/// ethernet tag is not `MAX_ET`, or an EAD-per-EVI route whose ethernet
+/// tag is `MAX_ET`. `buf` may hold a partial encoding after an error
+/// and must be discarded.
 pub fn encode_evpn_nlri(routes: &[EvpnRoute], buf: &mut Vec<u8>) -> Result<(), EncodeError> {
     for route in routes {
         let route_type = route.route_type();
@@ -1209,21 +1211,25 @@ pub fn encode_evpn_nlri(routes: &[EvpnRoute], buf: &mut Vec<u8>) -> Result<(), E
         match route {
             EvpnRoute::EadPerEs(r) => {
                 // RFC 7432 §7.1: EAD-per-ES carries MAX_ET in the Ethernet
-                // Tag field; the decoder uses that to discriminate from
-                // EAD-per-EVI. Force MAX_ET on the wire regardless of the
-                // struct field so a buggy upstream cannot silently flip
-                // the route's identity.
-                debug_assert!(
-                    r.ethernet_tag.is_max_et(),
-                    "EVPN EAD-per-ES must carry MAX_ET ethernet tag"
-                );
-                encode_type1_body(r.rd, r.esi, EthernetTagId::MAX_ET, r.label, buf);
+                // Tag field; the decoder uses that value to discriminate
+                // from EAD-per-EVI. Encoding any other tag (or pinning it
+                // silently, as release builds used to) would let a buggy
+                // upstream flip the route's identity — hard error instead.
+                if !r.ethernet_tag.is_max_et() {
+                    return Err(EncodeError::ValueOutOfRange {
+                        field: "EVPN EAD-per-ES ethernet tag",
+                        value: format!("{} (must be MAX_ET)", r.ethernet_tag),
+                    });
+                }
+                encode_type1_body(r.rd, r.esi, r.ethernet_tag, r.label, buf);
             }
             EvpnRoute::EadPerEvi(r) => {
-                debug_assert!(
-                    !r.ethernet_tag.is_max_et(),
-                    "EVPN EAD-per-EVI must not carry MAX_ET ethernet tag"
-                );
+                if r.ethernet_tag.is_max_et() {
+                    return Err(EncodeError::ValueOutOfRange {
+                        field: "EVPN EAD-per-EVI ethernet tag",
+                        value: "MAX_ET (reserved for EAD-per-ES)".to_string(),
+                    });
+                }
                 encode_type1_body(r.rd, r.esi, r.ethernet_tag, r.label, buf);
             }
             EvpnRoute::MacIp(r) => encode_type2_body(r, buf),
@@ -1648,9 +1654,7 @@ mod tests {
     }
 
     /// Regression: an EAD-per-ES route round-trips encode → decode back
-    /// to `EadPerEs`, never silently becoming `EadPerEvi`. The encoder
-    /// pins the ethernet tag to `MAX_ET` (the per-ES discriminator
-    /// per RFC 7432 §7.1) regardless of what the struct field holds.
+    /// to `EadPerEs`, never silently becoming `EadPerEvi`.
     #[test]
     fn ead_per_es_encode_round_trips_to_per_es() {
         let r = EvpnRoute::EadPerEs(EvpnEadPerEs {
@@ -1664,6 +1668,49 @@ mod tests {
         let decoded = decode_evpn_nlri(&buf).unwrap();
         assert_eq!(decoded.len(), 1);
         assert!(matches!(decoded[0], EvpnRoute::EadPerEs(_)));
+    }
+
+    /// Regression: an EAD-per-ES route with a non-`MAX_ET` ethernet tag
+    /// is a hard encode error. Release builds previously pinned the tag
+    /// to `MAX_ET` on the wire regardless of the struct field, so a
+    /// route keyed on tag 7 round-tripped keyed on `MAX_ET` — a lossy
+    /// silent rewrite of a key field.
+    #[test]
+    fn ead_per_es_encode_rejects_non_max_et_tag() {
+        let r = EvpnRoute::EadPerEs(EvpnEadPerEs {
+            rd: sample_rd(),
+            esi: sample_esi(),
+            ethernet_tag: EthernetTagId(7),
+            label: MplsLabel::new(500),
+        });
+        let mut buf = Vec::new();
+        let err = encode_evpn_nlri(&[r], &mut buf).unwrap_err();
+        assert!(
+            matches!(err, EncodeError::ValueOutOfRange { field, .. }
+                if field == "EVPN EAD-per-ES ethernet tag"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// Regression: an EAD-per-EVI route carrying `MAX_ET` is a hard
+    /// encode error. `MAX_ET` is the per-ES discriminator (RFC 7432
+    /// §7.1), so release builds previously encoded such a route as wire
+    /// bytes that decode back as `EadPerEs` — a silent identity flip.
+    #[test]
+    fn ead_per_evi_encode_rejects_max_et_tag() {
+        let r = EvpnRoute::EadPerEvi(EvpnEadPerEvi {
+            rd: sample_rd(),
+            esi: sample_esi(),
+            ethernet_tag: EthernetTagId::MAX_ET,
+            label: MplsLabel::new(500),
+        });
+        let mut buf = Vec::new();
+        let err = encode_evpn_nlri(&[r], &mut buf).unwrap_err();
+        assert!(
+            matches!(err, EncodeError::ValueOutOfRange { field, .. }
+                if field == "EVPN EAD-per-EVI ethernet tag"),
+            "unexpected error: {err}"
+        );
     }
 
     /// Regression: a Type 5 gateway whose family differs from the prefix

--- a/crates/wire/src/evpn.rs
+++ b/crates/wire/src/evpn.rs
@@ -21,7 +21,7 @@
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use crate::error::DecodeError;
+use crate::error::{DecodeError, EncodeError};
 use crate::nlri::{Ipv4Prefix, Ipv6Prefix};
 
 // ---------------------------------------------------------------------------
@@ -1160,47 +1160,46 @@ fn encode_type4_body(r: &EvpnEs, out: &mut Vec<u8>) {
     encode_ip_addr(r.originator_ip, out);
 }
 
-fn encode_type5_body(r: &EvpnIpPrefixRoute, out: &mut Vec<u8>) {
+fn encode_type5_body(r: &EvpnIpPrefixRoute, out: &mut Vec<u8>) -> Result<(), EncodeError> {
     // RFC 9136 §3 requires the GW IP to be the same family as the IP
-    // prefix. A debug assertion catches programmer bugs immediately;
-    // release builds fall back to UNSPECIFIED in the prefix family
-    // rather than silently truncating/scrambling the wrong-family
-    // address bytes.
-    debug_assert!(
-        matches!(
-            (&r.prefix, &r.gateway),
-            (EvpnIpPrefixValue::V4(_), IpAddr::V4(_)) | (EvpnIpPrefixValue::V6(_), IpAddr::V6(_))
-        ),
-        "EVPN Type 5: gateway family must match prefix family"
-    );
+    // prefix. `decode_type5` infers the family from the payload length
+    // alone, so any fallback encoding (e.g. UNSPECIFIED in the prefix
+    // family) would round-trip as a silently different route with no
+    // way to detect the corruption — refuse to encode instead.
     out.extend_from_slice(&r.rd.0);
     out.extend_from_slice(&r.esi.0);
     out.extend_from_slice(&r.ethernet_tag.0.to_be_bytes());
-    match r.prefix {
-        EvpnIpPrefixValue::V4(p) => {
+    match (r.prefix, r.gateway) {
+        (EvpnIpPrefixValue::V4(p), IpAddr::V4(gw)) => {
             out.push(p.len);
             out.extend_from_slice(&p.addr.octets());
-            if let IpAddr::V4(gw) = r.gateway {
-                out.extend_from_slice(&gw.octets());
-            } else {
-                out.extend_from_slice(&Ipv4Addr::UNSPECIFIED.octets());
-            }
+            out.extend_from_slice(&gw.octets());
         }
-        EvpnIpPrefixValue::V6(p) => {
+        (EvpnIpPrefixValue::V6(p), IpAddr::V6(gw)) => {
             out.push(p.len);
             out.extend_from_slice(&p.addr.octets());
-            if let IpAddr::V6(gw) = r.gateway {
-                out.extend_from_slice(&gw.octets());
-            } else {
-                out.extend_from_slice(&Ipv6Addr::UNSPECIFIED.octets());
-            }
+            out.extend_from_slice(&gw.octets());
+        }
+        (prefix, gateway) => {
+            return Err(EncodeError::ValueOutOfRange {
+                field: "EVPN Type 5 gateway",
+                value: format!("{gateway} (family must match prefix {prefix})"),
+            });
         }
     }
     encode_mpls_label(r.label, out);
+    Ok(())
 }
 
 /// Encode a list of EVPN NLRI entries to wire bytes.
-pub fn encode_evpn_nlri(routes: &[EvpnRoute], buf: &mut Vec<u8>) {
+///
+/// # Errors
+///
+/// Returns [`EncodeError::ValueOutOfRange`] if a route violates a wire
+/// invariant the decoder discriminates on (currently: a Type 5 gateway
+/// whose address family differs from its prefix). `buf` may hold a
+/// partial encoding after an error and must be discarded.
+pub fn encode_evpn_nlri(routes: &[EvpnRoute], buf: &mut Vec<u8>) -> Result<(), EncodeError> {
     for route in routes {
         let route_type = route.route_type();
         let len_placeholder = buf.len();
@@ -1230,7 +1229,7 @@ pub fn encode_evpn_nlri(routes: &[EvpnRoute], buf: &mut Vec<u8>) {
             EvpnRoute::MacIp(r) => encode_type2_body(r, buf),
             EvpnRoute::Imet(r) => encode_type3_body(r, buf),
             EvpnRoute::Es(r) => encode_type4_body(r, buf),
-            EvpnRoute::IpPrefix(r) => encode_type5_body(r, buf),
+            EvpnRoute::IpPrefix(r) => encode_type5_body(r, buf)?,
         }
         let body_len = buf.len() - body_start;
         debug_assert!(
@@ -1245,6 +1244,7 @@ pub fn encode_evpn_nlri(routes: &[EvpnRoute], buf: &mut Vec<u8>) {
             buf[len_placeholder + 1] = body_len as u8;
         }
     }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -1266,7 +1266,7 @@ mod tests {
 
     fn roundtrip(routes: &[EvpnRoute]) {
         let mut buf = Vec::new();
-        encode_evpn_nlri(routes, &mut buf);
+        encode_evpn_nlri(routes, &mut buf).expect("encode should succeed");
         let decoded = decode_evpn_nlri(&buf).expect("decode should succeed");
         assert_eq!(routes, decoded.as_slice(), "round-trip mismatch");
     }
@@ -1576,10 +1576,10 @@ mod tests {
             originator_ip: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)),
         });
         let mut buf = Vec::new();
-        encode_evpn_nlri(std::slice::from_ref(&imet), &mut buf);
+        encode_evpn_nlri(std::slice::from_ref(&imet), &mut buf).unwrap();
         // Append an unknown route type (99) with a 4-byte payload.
         buf.extend_from_slice(&[99u8, 4, 0xAA, 0xBB, 0xCC, 0xDD]);
-        encode_evpn_nlri(std::slice::from_ref(&imet2), &mut buf);
+        encode_evpn_nlri(std::slice::from_ref(&imet2), &mut buf).unwrap();
 
         let decoded = decode_evpn_nlri(&buf).unwrap();
         assert_eq!(decoded.len(), 2, "unknown type should be skipped");
@@ -1660,20 +1660,21 @@ mod tests {
             label: MplsLabel::new(7),
         });
         let mut buf = Vec::new();
-        encode_evpn_nlri(std::slice::from_ref(&r), &mut buf);
+        encode_evpn_nlri(std::slice::from_ref(&r), &mut buf).unwrap();
         let decoded = decode_evpn_nlri(&buf).unwrap();
         assert_eq!(decoded.len(), 1);
         assert!(matches!(decoded[0], EvpnRoute::EadPerEs(_)));
     }
 
-    /// Regression: gateway-family mismatch on Type 5 trips the
-    /// `debug_assert!` so encoder bugs surface in tests/CI rather than
-    /// silently corrupting the wire payload. Cargo runs unit tests with
-    /// debug assertions on, so this test is `#[should_panic]`.
+    /// Regression: a Type 5 gateway whose family differs from the prefix
+    /// is a hard encode error in every build profile. Release builds
+    /// previously fell back to UNSPECIFIED in the prefix family, which
+    /// round-tripped as `{prefix: V4, gateway: V4(0.0.0.0)}` — an
+    /// undetectably different route (`decode_type5` infers family from
+    /// payload length alone).
     #[test]
-    #[should_panic(expected = "gateway family must match prefix family")]
-    fn type5_encode_panics_on_family_mismatch_in_debug() {
-        let r = EvpnRoute::IpPrefix(EvpnIpPrefixRoute {
+    fn type5_encode_rejects_family_mismatch() {
+        let v4_prefix_v6_gw = EvpnRoute::IpPrefix(EvpnIpPrefixRoute {
             rd: sample_rd(),
             esi: EthernetSegmentIdentifier::ZERO,
             ethernet_tag: EthernetTagId(0),
@@ -1681,7 +1682,22 @@ mod tests {
             gateway: IpAddr::V6(Ipv6Addr::LOCALHOST),
             label: MplsLabel::new(100),
         });
-        let mut buf = Vec::new();
-        encode_evpn_nlri(&[r], &mut buf);
+        let v6_prefix_v4_gw = EvpnRoute::IpPrefix(EvpnIpPrefixRoute {
+            rd: sample_rd(),
+            esi: EthernetSegmentIdentifier::ZERO,
+            ethernet_tag: EthernetTagId(0),
+            prefix: EvpnIpPrefixValue::V6(Ipv6Prefix::new(Ipv6Addr::LOCALHOST, 128)),
+            gateway: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            label: MplsLabel::new(100),
+        });
+        for route in [v4_prefix_v6_gw, v6_prefix_v4_gw] {
+            let mut buf = Vec::new();
+            let err = encode_evpn_nlri(std::slice::from_ref(&route), &mut buf).unwrap_err();
+            assert!(
+                matches!(err, EncodeError::ValueOutOfRange { field, .. }
+                    if field == "EVPN Type 5 gateway"),
+                "unexpected error: {err}"
+            );
+        }
     }
 }

--- a/src/evpn_segment.rs
+++ b/src/evpn_segment.rs
@@ -1524,7 +1524,7 @@ async fn attempt_es_action(
                 );
                 return;
             };
-            let route = build_es_route(
+            let Some(route) = build_es_route(
                 ctx.inst,
                 &key,
                 ctx.esi_label,
@@ -1532,7 +1532,13 @@ async fn attempt_es_action(
                 ctx.df_preference,
                 ctx.df_dont_preempt,
                 ctx.redundancy_mode,
-            );
+            ) else {
+                // Wrong key shape is a programming bug (already logged at
+                // warn by the builder) — retrying cannot fix it, so drop
+                // the pending op instead of deferring it forever.
+                pending.forget(key, generation);
+                return;
+            };
             match send_and_ack(&runtime.rib_tx, |reply| RibUpdate::InjectEvpn {
                 route,
                 reply,
@@ -1657,6 +1663,12 @@ async fn retry_pending_rib_ops(
 /// - **Type 1 EAD-per-EVI**: no extra extcomms (the per-EVI label
 ///   lives in the route's MPLS label field; aliasing extcomms are
 ///   Gate 8b territory).
+///
+/// Returns `None` for key shapes this builder does not originate
+/// (anything other than Type 4 ES / EAD-per-ES / EAD-per-EVI): the old
+/// fallback synthesized a zero-ESI Type 4 route that the wire decoder
+/// itself rejects as malformed, so a fired fallback emitted
+/// undecodable bytes.
 fn build_es_route(
     instance: &EvpnInstance,
     key: &EvpnRouteKey,
@@ -1665,7 +1677,7 @@ fn build_es_route(
     df_preference: u32,
     df_dont_preempt: bool,
     redundancy_mode: RedundancyMode,
-) -> EvpnRibRoute {
+) -> Option<EvpnRibRoute> {
     let (route, key_specific_extcomms): (EvpnRoute, Vec<rustbgpd_wire::ExtendedCommunity>) =
         match key {
             EvpnRouteKey::Es {
@@ -1735,22 +1747,15 @@ fn build_es_route(
                 Vec::new(),
             ),
             // Other key shapes shouldn't reach this builder — Type 1/4
-            // originators only emit the three above.
+            // originators only emit the three above. A zero-ESI Type 4
+            // fallback is not an option: the decoder rejects it as
+            // malformed, so it would put undecodable bytes on the wire.
             other => {
                 warn!(
                     ?other,
-                    "EVPN segment: unexpected key shape passed to ES route builder"
+                    "EVPN segment: unexpected key shape passed to ES route builder; skipping"
                 );
-                // Synthesize a degenerate Type 4 to avoid panicking in
-                // production; callers will see the warn-level log.
-                (
-                    EvpnRoute::Es(EvpnEs {
-                        rd: instance.rd,
-                        esi: EthernetSegmentIdentifier::ZERO,
-                        originator_ip: instance.local_vtep_ip,
-                    }),
-                    Vec::new(),
-                )
+                return None;
             }
         };
 
@@ -1769,7 +1774,7 @@ fn build_es_route(
         PathAttribute::ExtendedCommunities(ext_communities),
     ];
 
-    EvpnRibRoute {
+    Some(EvpnRibRoute {
         route,
         next_hop: instance.local_vtep_ip,
         link_local_next_hop: None,
@@ -1780,7 +1785,7 @@ fn build_es_route(
         peer_router_id: std::net::Ipv4Addr::UNSPECIFIED,
         is_stale: false,
         is_llgr_stale: false,
-    }
+    })
 }
 
 fn next_hop_path_attribute(vtep_ip: IpAddr) -> PathAttribute {
@@ -1983,7 +1988,8 @@ mod tests {
             32_768,
             false,
             RedundancyMode::AllActive,
-        );
+        )
+        .expect("ES route builder accepts Type 1/4 keys");
         assert!(matches!(route.route, EvpnRoute::Es(_)));
         // Must carry: Origin, AsPath, NextHop, ExtendedCommunities.
         assert!(
@@ -2012,6 +2018,31 @@ mod tests {
         );
     }
 
+    /// Regression: a key shape the Type 1/4 originators never emit is
+    /// skipped, not "handled" by synthesizing a fallback route. The old
+    /// fallback built a zero-ESI Type 4 that the wire decoder itself
+    /// rejects ("EVPN Type 4 ES route with all-zero ESI"), so a fired
+    /// fallback put undecodable bytes on the wire.
+    #[test]
+    fn build_es_route_skips_unexpected_key_shape() {
+        let inst = instance(100);
+        let key = EvpnRouteKey::Imet {
+            rd: rd(65000, 100),
+            ethernet_tag: EthernetTagId(0),
+            originator_ip: ipa("10.0.0.1"),
+        };
+        let route = build_es_route(
+            &inst,
+            &key,
+            MplsLabel::new(123),
+            DfAlgorithm::DefaultModulo,
+            32_768,
+            false,
+            RedundancyMode::AllActive,
+        );
+        assert!(route.is_none(), "unexpected key shape must be skipped");
+    }
+
     #[test]
     fn build_ead_per_es_route_uses_max_et() {
         let inst = instance(100);
@@ -2028,7 +2059,8 @@ mod tests {
             32_768,
             false,
             RedundancyMode::AllActive,
-        );
+        )
+        .expect("ES route builder accepts Type 1/4 keys");
         match route.route {
             EvpnRoute::EadPerEs(r) => {
                 assert_eq!(r.ethernet_tag, EthernetTagId::MAX_ET);
@@ -2056,7 +2088,8 @@ mod tests {
             32_768,
             false,
             RedundancyMode::AllActive,
-        );
+        )
+        .expect("ES route builder accepts Type 1/4 keys");
         match route.route {
             EvpnRoute::EadPerEvi(r) => {
                 assert_eq!(r.ethernet_tag.0, 0);
@@ -2117,7 +2150,8 @@ mod tests {
             32_768,
             false,
             RedundancyMode::AllActive,
-        );
+        )
+        .expect("ES route builder accepts Type 1/4 keys");
         let extcomms = route
             .attributes
             .iter()
@@ -2151,7 +2185,8 @@ mod tests {
             32_768,
             false,
             RedundancyMode::AllActive,
-        );
+        )
+        .expect("ES route builder accepts Type 1/4 keys");
         let extcomms = route
             .attributes
             .iter()
@@ -2190,7 +2225,8 @@ mod tests {
             500,
             false,
             RedundancyMode::AllActive,
-        );
+        )
+        .expect("ES route builder accepts Type 1/4 keys");
         let extcomms = route
             .attributes
             .iter()
@@ -2228,7 +2264,8 @@ mod tests {
             500,
             true, // df_dont_preempt
             RedundancyMode::AllActive,
-        );
+        )
+        .expect("ES route builder accepts Type 1/4 keys");
         let df = route
             .attributes
             .iter()
@@ -2266,7 +2303,8 @@ mod tests {
             42,
             true, // df_dont_preempt
             RedundancyMode::AllActive,
-        );
+        )
+        .expect("ES route builder accepts Type 1/4 keys");
         let df = route
             .attributes
             .iter()
@@ -2308,7 +2346,8 @@ mod tests {
             32_768,
             false,
             RedundancyMode::AllActive,
-        );
+        )
+        .expect("ES route builder accepts Type 1/4 keys");
         let extcomms = route
             .attributes
             .iter()
@@ -2432,7 +2471,8 @@ mod tests {
             32_768,
             false,
             RedundancyMode::AllActive,
-        );
+        )
+        .expect("ES route builder accepts Type 1/4 keys");
         let extcomms = route
             .attributes
             .iter()
@@ -2477,7 +2517,8 @@ mod tests {
             32_768,
             false,
             RedundancyMode::SingleActive,
-        );
+        )
+        .expect("ES route builder accepts Type 1/4 keys");
         let extcomms = route
             .attributes
             .iter()
@@ -2511,7 +2552,8 @@ mod tests {
             32_768,
             false,
             RedundancyMode::AllActive,
-        );
+        )
+        .expect("ES route builder accepts Type 1/4 keys");
         let extcomms = route
             .attributes
             .iter()


### PR DESCRIPTION
Three same-class EVPN encode defects where a `debug_assert!` guarded a wire invariant, so release builds silently emitted wrong bytes instead of failing. Each was first reproduced with a red test run under `--release` (debug assertions compiled out) to observe the shipped behavior, then fixed to a hard error/skip.

## 1. Type 5 gateway/prefix family mismatch (`crates/wire/src/evpn.rs`)

`encode_type5_body` fell back to encoding the gateway as UNSPECIFIED in the prefix family. Because `decode_type5` infers the address family from payload length alone, the corruption is undetectable on the receiving side.

Red observation (release): `{prefix: 10.0.0.0/8, gateway: ::1}` encoded and round-tripped as `{prefix: 10.0.0.0/8, gateway: 0.0.0.0}`.

Fix: `encode_evpn_nlri` is now fallible and returns `EncodeError::ValueOutOfRange` for the mismatch. The former `#[should_panic]` debug-assert test is replaced by `type5_encode_rejects_family_mismatch`, which asserts the `Err` in both directions (V4 prefix/V6 gateway and V6 prefix/V4 gateway) and holds in every build profile.

Callers: the MP_REACH/MP_UNREACH attribute encoders and the MRT `RIB_GENERIC` encoder already return `Result` and now propagate via `?` (MRT's `EncodeError` already has `#[from]` for the wire error); fuzz targets `expect` on shapes they construct as valid. No new `unwrap` on any daemon path.

## 2. EAD ethernet-tag invariants (`crates/wire/src/evpn.rs`)

RFC 7432 §7.1 discriminates EAD-per-ES from EAD-per-EVI by the Ethernet Tag (`MAX_ET` vs anything else). Release builds pinned EAD-per-ES to `MAX_ET` regardless of the struct field, and encoded an EAD-per-EVI carrying `MAX_ET` verbatim.

Red observations (release):
- `EadPerEs` constructed with tag 7 round-tripped with tag `MAX_ET` — a key field silently rewritten.
- `EadPerEvi` constructed with `MAX_ET` round-tripped as `EadPerEs` — a route identity flip.

Fix: chose promoting both assertions to runtime `Err` over dropping the `ethernet_tag` field from `EvpnEadPerEs`. The field removal would fan out through `EvpnRouteKey` and six crates while covering only the per-ES half of the hazard (a per-EVI struct carrying `MAX_ET` still flips identity on the wire); the runtime check rides the fallible encode path from item 1, covers both directions, and adds no further API change. Tests: `ead_per_es_encode_rejects_non_max_et_tag`, `ead_per_evi_encode_rejects_max_et_tag`.

## 3. Zero-ESI Type 4 fallback (`src/evpn_segment.rs`)

`build_es_route`'s wrong-key fallback synthesized a zero-ESI Type 4 route to avoid panicking, but the decoder rejects all-zero-ESI Type 4 as malformed — a fired fallback emitted undecodable wire.

Red observation: encoding the fallback route and decoding it back fails with `UPDATE: EVPN Type 4 ES route with all-zero ESI (RFC 7432 §7.4)`.

Fix: `build_es_route` returns `Option<EvpnRibRoute>`; the unexpected-key arm logs the offending key at warn level and returns `None`. The inject path drops the pending operation (`forget`, matching the missing-build-context path) rather than deferring it, since a wrong key shape is a programming bug retrying cannot fix. Test: `build_es_route_skips_unexpected_key_shape`.

## Breaking API surface (`rustbgpd-wire`, published)

`pub fn encode_evpn_nlri(&[EvpnRoute], &mut Vec<u8>)` now returns `Result<(), EncodeError>`. No types changed shape. Semver-major for the next `rustbgpd-wire` publish; the version is intentionally not bumped here.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps`, `scripts/check-clippy-reasons.py`, and `cargo +nightly fuzz build` in `crates/wire/fuzz` all exit 0.
