### PR TITLE
Skip the outbound prefix-limit RIB preflight when maxima are unchanged

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5017,8 +5017,12 @@ async fn run<T>(
                             return None;
                         }
                     };
-                    if let Err(error) =
-                        reload::apply_outbound_prefix_limits(&limits_rib_tx, &desired).await
+                    if let Err(error) = reload::apply_outbound_prefix_limits_if_changed(
+                        &limits_rib_tx,
+                        &snapshot,
+                        desired.config_ref(),
+                    )
+                    .await
                     {
                         error!(error = %error, "SIGHUP reload rejected");
                         return None;

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -1134,6 +1134,9 @@ impl PeerManager {
                             let _ = reply.send(());
                         }
                         PeerManagerCommand::SyncRpolPolicies { rpol_files, rpol, dataset_bindings, reply } => {
+                            // LAN-888: receipt stamp — the gap back to the
+                            // reload flow's dispatch log is FIFO queue wait.
+                            info!("rpol policy sync command received");
                             let result = self.sync_rpol_policies(rpol_files, rpol, dataset_bindings).await;
                             let _ = reply.send(result);
                         }

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -2408,7 +2408,15 @@ impl PeerManager {
         rpol: rustbgpd_policy::rpol::RpolPolicySet,
         dataset_bindings: rustbgpd_policy::datasets::DatasetBindings,
     ) -> Result<(), CatalogMutationError> {
+        // LAN-888: the manager-side config snapshot clone carries the full
+        // prior rpol registry — stamp it so the receipt→resolve gap can't
+        // hide it.
+        let clone_started = Instant::now();
         let mut next_config = self.current_config.clone();
+        info!(
+            elapsed_ms = u64::try_from(clone_started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "rpol sync config snapshot cloned"
+        );
         next_config.policy.rpol_files = rpol_files;
         next_config.policy.rpol = rpol;
         // LAN-305: the new registry's `dataset` declarations resolve

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -9,6 +9,7 @@ use std::fmt::Display;
 use std::net::IpAddr;
 use std::ops::Deref;
 use std::sync::Arc;
+use std::time::Instant;
 
 use rustbgpd_api::peer_types::{
     CatalogMutationError, ConfigEvent, ConfigPersistAck, ConfigPersistError, FibTableSnapshot,
@@ -112,6 +113,30 @@ pub(crate) async fn apply_outbound_prefix_limits(
             Err(error)
         }
     }
+}
+
+/// SIGHUP wrapper around [`apply_outbound_prefix_limits`]: skip the RIB
+/// round-trips entirely when the desired maxima equal the live ones.
+///
+/// LAN-888: the preflight is two awaited sends through the RIB manager's
+/// update channel, FIFO behind any in-flight redistribution backlog — on
+/// repeat IRR-scale reloads in per-client-best mode that queue wait
+/// dominated the whole SIGHUP→snapshot window (~78 s of a ~79 s reload).
+/// The ADR-0113 check only ever rejects a *lowering* below current
+/// advertised usage, so an unchanged limit set cannot be rejected and the
+/// preflight is a no-op by construction; activation would re-install the
+/// identical set. The common rpol-content-only reload therefore never
+/// touches the RIB here.
+pub(crate) async fn apply_outbound_prefix_limits_if_changed(
+    rib_tx: &mpsc::Sender<rustbgpd_rib::RibUpdate>,
+    live: &Config,
+    desired: &Config,
+) -> Result<(), String> {
+    if live.outbound_prefix_limits() == desired.outbound_prefix_limits() {
+        info!("outbound prefix maxima unchanged; skipping RIB preflight");
+        return Ok(());
+    }
+    apply_outbound_prefix_limits(rib_tx, desired).await
 }
 
 /// Build a `PeerManagerNeighborConfig` from transport config components.
@@ -1838,12 +1863,24 @@ pub(crate) async fn reload_config_with_tcp_ao(
     // materially changed ones, so an rpol-content-only reload is fully
     // applied by this single step.
     if policy_diff.rpol_changed {
+        // LAN-888: stamp the registry-clone cost and the dispatch moment.
+        // The gap between this line and the peer manager's receipt log is
+        // pure command-channel queue wait — the only piece of the
+        // SIGHUP→snapshot window no other span can see.
+        let clone_started = Instant::now();
+        let rpol_files = new_config.policy.rpol_files.clone();
+        let rpol = new_config.policy.rpol.clone();
+        let dataset_bindings = new_config.policy.dataset_bindings.clone();
+        info!(
+            clone_ms = u64::try_from(clone_started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "rpol policy sync dispatched"
+        );
         let (ack_tx, ack_rx) = oneshot::channel();
         let send_failed = peer_mgr_tx
             .send(PeerManagerCommand::SyncRpolPolicies {
-                rpol_files: new_config.policy.rpol_files.clone(),
-                rpol: new_config.policy.rpol.clone(),
-                dataset_bindings: new_config.policy.dataset_bindings.clone(),
+                rpol_files,
+                rpol,
+                dataset_bindings,
                 reply: ack_tx,
             })
             .await
@@ -5213,6 +5250,34 @@ hold_time = 90
     ) -> (Option<ReloadedConfig>, Vec<String>) {
         let (mut outcomes, tags) = drive_reloads(initial_toml, new_toml, 1).await;
         (outcomes.pop().unwrap(), tags)
+    }
+
+    /// LAN-888: a reload whose outbound prefix maxima equal the live
+    /// ones must not touch the RIB at all — the closed channel here
+    /// fails any attempted round-trip. A changed maximum must reach
+    /// for the RIB and surface its unavailability.
+    #[tokio::test]
+    async fn unchanged_outbound_prefix_limits_skip_the_rib_preflight() {
+        let (rib_tx, rib_rx) = mpsc::channel::<rustbgpd_rib::RibUpdate>(1);
+        drop(rib_rx);
+        let live =
+            Config::load_toml_with_diagnostics(baseline_toml(), "limits-preflight-live").unwrap();
+        let desired_same =
+            Config::load_toml_with_diagnostics(baseline_toml(), "limits-preflight-same").unwrap();
+        apply_outbound_prefix_limits_if_changed(&rib_tx, &live, &desired_same)
+            .await
+            .expect("unchanged maxima must skip the RIB preflight entirely");
+
+        let raised = baseline_toml().replace(
+            "hold_time = 90",
+            "hold_time = 90\nmax_prefixes_out_ipv4 = 100",
+        );
+        let desired_raised =
+            Config::load_toml_with_diagnostics(&raised, "limits-preflight-raised").unwrap();
+        let error = apply_outbound_prefix_limits_if_changed(&rib_tx, &live, &desired_raised)
+            .await
+            .expect_err("changed maxima must attempt the RIB preflight");
+        assert!(error.contains("RIB manager unavailable"), "{error}");
     }
 
     /// ADR-0096: an rpol-content-only reload sends `SyncRpolPolicies`


### PR DESCRIPTION
## Problem

Repeat IRR-scale SIGHUP reloads in per-client-best mode plateaued at tens of seconds (F-scaling: ~15 s disjoint, ~29 s at 10% overlap, ~70 s at 50% overlap) while reload 1 completed in ~1.3 s, with every instrumented phase — parse, intern, dataset bind, validate, chain re-resolution — flat across reloads. The plateau lived in a fully silent stretch between `config source loaded` and the rpol sync dispatch.

## Attribution

New spans (dispatch stamp with registry-clone cost, peer-manager receipt stamp, manager-side config clone stamp) bracket the stretch. A bounded 2-reload diagnostic at the measured shape (320 members, 183k prefixes, 50% overlap, per-client best-path) attributes reload 2's entire 77.8 s to the code between config load and dispatch — with queue wait to the peer manager at 3 ms and both config clones at ~0 ms. The only awaited work in that stretch is the outbound prefix-limit preflight: two sequential round-trips (`PrepareOutboundPrefixLimits` + `ApplyOutboundPrefixLimits`) through the RIB manager's update channel, FIFO behind the redistribution backlog the previous reload's route refresh left in flight. Reload 1 has no backlog, so it never paid this; grouped update-group fleets drain their single shared stream quickly, so they never paid it either — matching the observed mode and overlap fingerprints exactly.

## Fix

The preflight only ever rejects a *lowering* below current advertised usage, and activation installs the config's limit set. When the desired maxima equal the live ones, rejection is impossible and activation would re-install the identical set — the preflight is a no-op by construction. The SIGHUP path now compares the two `OutboundPrefixLimitConfig` views and skips both round-trips when equal, so an rpol-content-only reload never touches the RIB before the policy sync. A reload that actually changes a maximum still runs the full ADR-0113 preflight (and still pays the queue wait — that is the check working as designed).

With the fix, the same diagnostic shape's reload 2 runs config-load→snapshot in ~0.3 s (from ~78.5 s); reload 1 is unchanged.

## Tests

`unchanged_outbound_prefix_limits_skip_the_rib_preflight`: with a closed RIB channel, equal maxima must succeed without any RIB round-trip; a raised maximum must reach for the RIB and surface its unavailability.