### PR TITLE
Harden GTSM, listener accept, L3 retry, and BFD receive paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,39 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   mismatch, manifest/input binding, achieved-overlap drift, grouped-bound
   violations, and mismatched received-view scenarios.
 
+### Changed
+
+- GTSM (RFC 5082) now enforces strict TTL/Hop-Limit 255 on receive
+  (`IP_MINTTL` / `IPV6_MINHOPCOUNT` raised from 254), matching RFC 5082
+  §3.2, FRR/BIRD, and the BFD receive path's exact-255 check. A
+  conformant directly connected peer always emits 255; a session that
+  depended on the previous one-hop-off leniency will no longer
+  establish.
+
 ### Fixed
+
+- The BGP listener accept loop classifies `accept(2)` errors instead of
+  hot-continuing: resource exhaustion (`EMFILE`/`ENFILE`/`ENOMEM`/
+  `ENOBUFS`) backs off progressively (100 ms doubling to 1 s, reset on
+  the next successful accept) instead of spinning the CPU and flooding
+  the log; an unusable listening socket (`EBADF`/`ENOTSOCK`/`EINVAL`/
+  `EOPNOTSUPP`) stops the loop; per-connection failures
+  (`ECONNABORTED`, ...) continue immediately as before.
+
+- EVPN L3 (IP-VRF) reconcile ops now feed the same per-op exponential
+  retry backoff (100 ms → 5 s + jitter, cleared on success) every L2 op
+  class already had. A transiently failing L3 op (e.g. netlink `EBUSY`)
+  used to re-apply on every reconcile wake with zero backoff — and only
+  ever retried when something else woke the actor; it now defers until
+  its backoff elapses and a dedicated retry timer re-fires the pass.
+  Retry entries whose op left the plan (withdrawn or superseded) are
+  pruned across all six schedules so a stale past-due deadline cannot
+  pin the retry timer in the past and busy-loop reconcile passes.
+
+- The BFD receive path discards control packets whose UDP source port
+  falls outside the RFC 5881 §4 range 49152..=65535 —
+  defense-in-depth alongside the exact-TTL check and Your-Discriminator
+  demux that already gate the path.
 
 - EVPN wire encoding no longer emits silently wrong bytes for invariant
   violations that were only debug-asserted (LAN-896). Release builds

--- a/crates/evpn-linux/src/backoff.rs
+++ b/crates/evpn-linux/src/backoff.rs
@@ -144,6 +144,14 @@ impl<K: Ord + Copy> RetrySchedule<K> {
             .collect()
     }
 
+    /// Keep only the entries whose key satisfies `keep`. The actor
+    /// prunes entries whose op left the plan (withdrawn / superseded):
+    /// a stale entry's past-due deadline would otherwise pin the
+    /// retry timer in the past and busy-loop reconcile passes.
+    pub fn retain(&mut self, mut keep: impl FnMut(&K) -> bool) {
+        self.entries.retain(|k, _| keep(k));
+    }
+
     /// Number of tracked failed keys (for metrics / diagnostics).
     #[must_use]
     pub fn pending_count(&self) -> usize {

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -66,7 +66,7 @@ use crate::snapshot::{
     vlan_rows_contain,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum L3OpKey {
     Route {
         vrf_id: IpVrfId,
@@ -293,6 +293,13 @@ struct ActorState {
     /// keys so two bridge lifecycle failures cannot suppress each
     /// other or collide with non-FDB report placeholders.
     managed_retry: RetrySchedule<ManagedNetdevOpKey>,
+    /// Retry schedule for Gate 9 L3 (IP-VRF) ops, keyed by
+    /// [`L3OpKey`]. Mirrors the L2 schedules (100 ms → 5 s + jitter,
+    /// cleared on success): without it a transiently failing L3 op
+    /// (e.g. `EBUSY`) re-applied on every reconcile wake with zero
+    /// backoff, hammering netlink and blocking the ADR-0079 reap on
+    /// each pass.
+    l3_retry: RetrySchedule<L3OpKey>,
     /// Per-bridge permanent-failure suppression for managed-netdev
     /// bridge ops. Same fingerprint-equality semantics as the FDB /
     /// BUM maps: changing the desired bridge shape clears the
@@ -529,6 +536,7 @@ impl ActorState {
             nhg_permanent_failures: BTreeMap::new(),
             managed_retry: RetrySchedule::new(),
             managed_permanent_failures: BTreeMap::new(),
+            l3_retry: RetrySchedule::new(),
             pending_deletes: BTreeSet::new(),
             warned_ipv6_fallback: BTreeSet::new(),
             warned_foreign_fdb: BTreeSet::new(),
@@ -621,24 +629,32 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         }
 
         loop {
-            // Compute the next retry deadline across the five retry
+            // Compute the next retry deadline across the six retry
             // schedules — FDB ops keyed by `(VNI, MAC)`, BUM and
             // AC-gate ops keyed by ifindex (separate schedules),
-            // FDB-NHG group-level ops keyed by `AliasGroupKey`, and
+            // FDB-NHG group-level ops keyed by `AliasGroupKey`,
             // managed-netdev ops keyed by `ManagedNetdevOpKey` (LAN-290:
             // previously missing, so a transiently failed managed op
-            // only retried on the next unrelated wake). The earliest
-            // wakes the actor.
+            // only retried on the next unrelated wake), and Gate 9 L3
+            // ops keyed by `L3OpKey`. The earliest wakes the actor.
             let next_fdb = self.state.retry.earliest_due();
             let next_bum = self.state.bum_retry.earliest_due();
             let next_ac_gate = self.state.ac_gate_retry.earliest_due();
             let next_nhg = self.state.nhg_retry.earliest_due();
             let next_managed = self.state.managed_retry.earliest_due();
-            let retry_due = [next_fdb, next_bum, next_ac_gate, next_nhg, next_managed]
-                .into_iter()
-                .flatten()
-                .min()
-                .map(|due_ms| self.state.epoch + Duration::from_millis(due_ms));
+            let next_l3 = self.state.l3_retry.earliest_due();
+            let retry_due = [
+                next_fdb,
+                next_bum,
+                next_ac_gate,
+                next_nhg,
+                next_managed,
+                next_l3,
+            ]
+            .into_iter()
+            .flatten()
+            .min()
+            .map(|due_ms| self.state.epoch + Duration::from_millis(due_ms));
 
             tokio::select! {
                 biased;
@@ -1514,6 +1530,18 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             }
             self.state.last_l3_drop_counts =
                 crate::l3_diff::drop_counts_by_vrf_reason(&l3_plan.drops, intent.ip_vrfs.as_ref());
+            // Prune retry entries whose op left the plan (withdrawn or
+            // superseded) — a stale entry's past-due deadline would
+            // otherwise pin the actor's retry timer in the past and
+            // busy-loop reconcile passes. Pruned against the full plan
+            // (not the guard-gated slice) so a fail-closed pass keeps
+            // its backoff state.
+            let planned_l3_keys: BTreeSet<L3OpKey> =
+                l3_plan.ops.iter().filter_map(l3_op_key).collect();
+            self.state
+                .l3_retry
+                .retain(|key| planned_l3_keys.contains(key));
+            let l3_now_ms = self.state.now_ms();
             // Apply-time fail-stop: an `AddRemoteIpRoute` whose
             // prerequisite `AddL3Neighbor` or `AddL3VxlanFdb` failed
             // earlier in this pass MUST NOT proceed — otherwise the
@@ -1567,7 +1595,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                             // dependent route adds in this pass are
                             // fail-stopped through the prerequisite
                             // sets, and the reap is blocked.
-                            if let Some(key) = l3_key.clone() {
+                            if let Some(key) = l3_key {
                                 if !self.state.warned_foreign_l3.contains(&key) {
                                     self.state.foreign_since_report.replaces_blocked += 1;
                                     tracing::warn!(
@@ -1633,6 +1661,28 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                         "L3",
                     )
                 {
+                    record_l3_prerequisite_failure(
+                        op,
+                        &mut failed_neighbor_keys,
+                        &mut failed_fdb_keys,
+                        &mut failed_l3_group_keys,
+                    );
+                    l3_pass_had_failures = true;
+                    continue;
+                }
+                // Transient retry gating — mirror of the L2 apply path:
+                // skip until the per-op exponential backoff (100 ms →
+                // 5 s + jitter) elapses; the actor's outer `select!`
+                // re-fires on the retry timer. A deferred op fail-stops
+                // its dependents exactly like a failed apply, and the
+                // non-converged pass keeps the ADR-0079 reap blocked.
+                if let Some(key) = l3_key.as_ref()
+                    && let Some(next_due_ms) = self.state.l3_retry.next_due_for(*key)
+                    && next_due_ms > l3_now_ms
+                {
+                    let retry_in_ms =
+                        u32::try_from(next_due_ms.saturating_sub(l3_now_ms)).unwrap_or(u32::MAX);
+                    tracing::trace!(?op, retry_in_ms, "L3 op deferred (backoff not elapsed)");
                     record_l3_prerequisite_failure(
                         op,
                         &mut failed_neighbor_keys,
@@ -1716,6 +1766,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                         );
                         if let Some(key) = l3_key.as_ref() {
                             self.state.l3_permanent_failures.remove(key);
+                            self.state.l3_retry.record_success(*key);
                         }
                         // ADR-0079 claim: a successful add over an
                         // adopted key replaced the crash leftover
@@ -1763,12 +1814,6 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                     }
                     Err(e) => {
                         let class = e.class();
-                        tracing::warn!(
-                            ?class,
-                            error = %e,
-                            ?op,
-                            "L3 op failed; preserving owned state for next reconcile retry"
-                        );
                         l3_pass_had_failures = true;
                         record_l3_prerequisite_failure(
                             op,
@@ -1776,10 +1821,38 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                             &mut failed_fdb_keys,
                             &mut failed_l3_group_keys,
                         );
-                        if class == FailureClass::Permanent
-                            && let Some(key) = l3_key
-                        {
-                            self.state.l3_permanent_failures.insert(key, op.clone());
+                        match class {
+                            FailureClass::Transient | FailureClass::Conflict => {
+                                let retry_in_ms = l3_key.map(|key| {
+                                    let next_due_ms =
+                                        self.state.l3_retry.record_failure(key, l3_now_ms);
+                                    u32::try_from(next_due_ms.saturating_sub(l3_now_ms))
+                                        .unwrap_or(u32::MAX)
+                                });
+                                tracing::warn!(
+                                    ?class,
+                                    ?retry_in_ms,
+                                    error = %e,
+                                    ?op,
+                                    "L3 op failed; preserving owned state, retrying on backoff"
+                                );
+                            }
+                            FailureClass::Permanent => {
+                                if let Some(key) = l3_key {
+                                    // Drop from the transient schedule
+                                    // so we don't double-tick; the
+                                    // fingerprint suppression takes
+                                    // over until the op shape changes.
+                                    self.state.l3_retry.record_success(key);
+                                    self.state.l3_permanent_failures.insert(key, op.clone());
+                                }
+                                tracing::warn!(
+                                    ?class,
+                                    error = %e,
+                                    ?op,
+                                    "L3 op failed permanently; suppressed until op shape changes"
+                                );
+                            }
                         }
                     }
                 }
@@ -1806,6 +1879,10 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             .await;
         } else {
             self.state.last_l3_drop_counts.clear();
+            // No L3 intent — clear any leftover retry entries so a
+            // removed VRF's stale deadlines cannot keep waking the
+            // actor.
+            self.state.l3_retry.retain(|_| false);
         }
 
         let status = build_instance_status(&intent.instances, &probes);
@@ -1853,6 +1930,56 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         let mut applied = Vec::with_capacity(plan.len());
         let mut failed = Vec::new();
         let now_ms = self.state.now_ms();
+
+        // Prune retry entries whose op left the plan (withdrawn or
+        // superseded): a stale entry's past-due deadline would
+        // otherwise pin the actor's retry timer in the past and
+        // busy-loop reconcile passes. Same key-space dispatch as the
+        // gating below.
+        let mut planned_fdb: BTreeSet<(EvpnInstanceId, MacAddress)> = BTreeSet::new();
+        let mut planned_bum: BTreeSet<u32> = BTreeSet::new();
+        let mut planned_ac_gate: BTreeSet<u32> = BTreeSet::new();
+        let mut planned_nhg: BTreeSet<crate::group_state::AliasGroupKey> = BTreeSet::new();
+        let mut planned_managed: BTreeSet<ManagedNetdevOpKey> = BTreeSet::new();
+        for op in &plan.ops {
+            match op {
+                DataplaneOp::SetBumPortFlags { ifindex, .. } => {
+                    planned_bum.insert(*ifindex);
+                }
+                DataplaneOp::SetAcPortState { ifindex, .. } => {
+                    planned_ac_gate.insert(*ifindex);
+                }
+                DataplaneOp::UpdateFdbNhgMembers { group_key, .. } => {
+                    planned_nhg.insert(*group_key);
+                }
+                DataplaneOp::CreateManagedBridge { .. }
+                | DataplaneOp::RemoveManagedBridge { .. }
+                | DataplaneOp::CreateManagedVxlan { .. }
+                | DataplaneOp::RemoveManagedVxlan { .. }
+                | DataplaneOp::CreateManagedSvdVxlan { .. }
+                | DataplaneOp::RemoveManagedSvdVxlan { .. }
+                | DataplaneOp::CreateManagedVrf { .. }
+                | DataplaneOp::RemoveManagedVrf { .. }
+                | DataplaneOp::CreateManagedL3Vxlan { .. }
+                | DataplaneOp::RemoveManagedL3Vxlan { .. }
+                | DataplaneOp::CreateManagedVlanUpper { .. }
+                | DataplaneOp::RemoveManagedVlanUpper { .. } => {
+                    planned_managed.insert(managed_op_key(op).expect("managed op has a key"));
+                }
+                _ => {
+                    planned_fdb.insert((fdb_op_vni(op), fdb_op_mac(op)));
+                }
+            }
+        }
+        self.state.retry.retain(|key| planned_fdb.contains(key));
+        self.state.bum_retry.retain(|key| planned_bum.contains(key));
+        self.state
+            .ac_gate_retry
+            .retain(|key| planned_ac_gate.contains(key));
+        self.state.nhg_retry.retain(|key| planned_nhg.contains(key));
+        self.state
+            .managed_retry
+            .retain(|key| planned_managed.contains(key));
 
         for op in &plan.ops {
             // Permanent-failure suppression — dispatched per op shape

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -3728,6 +3728,67 @@ async fn l3_permanent_route_failure_is_pruned_after_desired_withdraw() {
     h.shutdown().await;
 }
 
+// Gate 9 L3 mirror of `failed_apply_retries_on_backoff_timer`: a
+// transiently failing L3 op must not be re-attempted by wakes inside
+// its backoff window (no netlink hammering), and must retry on the
+// dedicated retry timer once the backoff elapses.
+#[tokio::test(start_paused = true)]
+async fn failed_l3_apply_backs_off_and_retries_on_timer() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_ip_vrf_status(l3_vrf_id(), l3_ready_status());
+    h.handle.set_l3vxlan_ifindex(l3_vrf_id(), L3_IFINDEX);
+
+    let target = DataplaneOp::AddRemoteIpRoute {
+        vrf_id: l3_vrf_id(),
+        prefix: l3_prefix(),
+        table_id: L3_TABLE_ID,
+        l3vxlan_ifindex: L3_IFINDEX,
+        next_hop: ipa("10.0.0.2"),
+        router_mac: l3_router_mac(),
+    };
+    h.handle.inject_failure_io(Some(target));
+
+    let ip_vrfs = l3_ip_vrfs();
+    let prefixes = l3_desired_prefixes(&ip_vrfs);
+    h.intent_tx.send(l3_intent(1, ip_vrfs, prefixes)).unwrap();
+    let _ = wait_for_generation(&mut h, 1).await;
+    assert!(
+        !h.handle.kernel_has_l3_route(L3_TABLE_ID, l3_prefix()),
+        "transient route failure must leave the route uninstalled"
+    );
+    let after_failure = h.handle.apply_count();
+
+    // A wake inside the backoff window (no virtual time has passed)
+    // must NOT re-attempt the failed op.
+    let ip_vrfs = l3_ip_vrfs();
+    let prefixes = l3_desired_prefixes(&ip_vrfs);
+    h.intent_tx.send(l3_intent(2, ip_vrfs, prefixes)).unwrap();
+    let _ = wait_for_generation(&mut h, 2).await;
+    assert_eq!(
+        h.handle.apply_count(),
+        after_failure,
+        "transiently failed L3 op re-attempted with zero backoff"
+    );
+    assert!(!h.handle.kernel_has_l3_route(L3_TABLE_ID, l3_prefix()));
+
+    // The dedicated retry timer re-fires the pass once the backoff
+    // elapses (100 ms ± 25% jitter — allow slack), and the retry
+    // succeeds.
+    tokio::time::advance(Duration::from_millis(200)).await;
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(200)).await;
+    tokio::task::yield_now().await;
+    let _ = h.try_drain_reports().await;
+    assert!(
+        h.handle.kernel_has_l3_route(L3_TABLE_ID, l3_prefix()),
+        "retry timer should have re-run the pass and installed the route; apply_count={}",
+        h.handle.apply_count()
+    );
+    assert!(h.handle.apply_count() > after_failure);
+
+    h.shutdown().await;
+}
+
 #[tokio::test]
 async fn l3_all_active_to_single_cleans_up_l3_nhg_state() {
     let mut h = Harness::spawn(ReconcileActorConfig::for_tests());

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -18,6 +18,39 @@ use tracing::{debug, error, info, warn};
 const DEFAULT_LISTEN_BACKLOG: i32 = 1024;
 const TCP_AO_ROTATION_CONTROL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// First backoff after an accept failure on exhausted resources.
+const ACCEPT_BACKOFF_INITIAL: std::time::Duration = std::time::Duration::from_millis(100);
+/// Backoff cap — the loop keeps probing at this cadence while the
+/// exhaustion persists.
+const ACCEPT_BACKOFF_CAP: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// How the accept loop reacts to one `accept(2)` error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AcceptErrorClass {
+    /// Process/host resource exhaustion (EMFILE, ENFILE, ENOMEM,
+    /// ENOBUFS): the condition outlives one accept call, so retrying
+    /// immediately hot-spins. Back off before the next accept.
+    ResourceExhausted,
+    /// The listening socket is broken (EBADF, ENOTSOCK, EINVAL,
+    /// EOPNOTSUPP): no future accept on this fd can succeed.
+    Fatal,
+    /// Per-connection failure (ECONNABORTED, EINTR, EPROTO, ...):
+    /// the next accept is unaffected — continue immediately.
+    Transient,
+}
+
+fn accept_error_class(err: &std::io::Error) -> AcceptErrorClass {
+    match err.raw_os_error() {
+        Some(libc::EMFILE | libc::ENFILE | libc::ENOMEM | libc::ENOBUFS) => {
+            AcceptErrorClass::ResourceExhausted
+        }
+        Some(libc::EBADF | libc::ENOTSOCK | libc::EINVAL | libc::EOPNOTSUPP) => {
+            AcceptErrorClass::Fatal
+        }
+        _ => AcceptErrorClass::Transient,
+    }
+}
+
 /// An accepted inbound TCP connection.
 pub struct AcceptedConnection {
     /// The raw TCP stream for the accepted connection.
@@ -831,6 +864,7 @@ impl BgpListener {
 
     /// Run the accept loop until the channel is closed.
     pub async fn run(mut self) {
+        let mut accept_backoff = ACCEPT_BACKOFF_INITIAL;
         loop {
             tokio::select! {
                 command = self.rotation_rx.recv() => {
@@ -843,6 +877,7 @@ impl BgpListener {
                 }
                 accepted = self.listener.accept() => match accepted {
                     Ok((stream, peer_addr)) => {
+                        accept_backoff = ACCEPT_BACKOFF_INITIAL;
                         let peer_ip = peer_addr.ip();
                         debug!(%peer_ip, "inbound TCP connection");
                         let tcp_ao_info = match self.inspect_tcp_ao_accept(&stream, peer_ip) {
@@ -863,7 +898,34 @@ impl BgpListener {
                             return;
                         }
                     }
-                    Err(e) => error!(error = %e, "BGP listener accept error"),
+                    Err(e) => match accept_error_class(&e) {
+                        AcceptErrorClass::ResourceExhausted => {
+                            // EMFILE/ENFILE/ENOMEM/ENOBUFS persist until the
+                            // process (or host) sheds load — an immediate
+                            // re-accept would hot-spin the loop and flood the
+                            // log. Progressive backoff, reset on the next
+                            // successful accept.
+                            error!(
+                                error = %e,
+                                backoff_ms = u64::try_from(accept_backoff.as_millis()).unwrap_or(u64::MAX),
+                                "BGP listener accept failed on exhausted resources; backing off"
+                            );
+                            tokio::time::sleep(accept_backoff).await;
+                            accept_backoff = (accept_backoff * 2).min(ACCEPT_BACKOFF_CAP);
+                        }
+                        AcceptErrorClass::Fatal => {
+                            // The listening socket itself is unusable
+                            // (EBADF/ENOTSOCK/EINVAL/EOPNOTSUPP) — accept can
+                            // never succeed again on this fd.
+                            error!(error = %e, "BGP listener socket unusable; accept loop exiting");
+                            return;
+                        }
+                        AcceptErrorClass::Transient => {
+                            // Per-connection failures (ECONNABORTED, EINTR,
+                            // EPROTO, ...) — the next accept is unaffected.
+                            error!(error = %e, "BGP listener accept error");
+                        }
+                    },
                 }
             }
         }
@@ -2371,6 +2433,37 @@ mod tests {
     use crate::config::{TcpAoAlgorithm, TcpAoConfig};
     use std::cell::RefCell;
     use std::net::Ipv4Addr;
+
+    #[test]
+    fn accept_errors_classify_by_errno() {
+        for errno in [libc::EMFILE, libc::ENFILE, libc::ENOMEM, libc::ENOBUFS] {
+            assert_eq!(
+                accept_error_class(&std::io::Error::from_raw_os_error(errno)),
+                AcceptErrorClass::ResourceExhausted,
+                "errno {errno} must back off"
+            );
+        }
+        for errno in [libc::EBADF, libc::ENOTSOCK, libc::EINVAL, libc::EOPNOTSUPP] {
+            assert_eq!(
+                accept_error_class(&std::io::Error::from_raw_os_error(errno)),
+                AcceptErrorClass::Fatal,
+                "errno {errno} must stop the loop"
+            );
+        }
+        for errno in [libc::ECONNABORTED, libc::EINTR, libc::EPROTO] {
+            assert_eq!(
+                accept_error_class(&std::io::Error::from_raw_os_error(errno)),
+                AcceptErrorClass::Transient,
+                "errno {errno} must continue immediately"
+            );
+        }
+        // Errors with no OS errno (e.g. synthesized) never stall or stop
+        // the loop.
+        assert_eq!(
+            accept_error_class(&std::io::Error::other("synthetic")),
+            AcceptErrorClass::Transient
+        );
+    }
 
     fn tcp_ao_config() -> TcpAoKeyring {
         TcpAoConfig {

--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -3109,7 +3109,12 @@ pub fn set_gtsm(socket: &Socket, remote: SocketAddr) -> io::Result<()> {
 )]
 fn set_gtsm_v4(socket: &Socket) -> io::Result<()> {
     const IP_MINTTL: libc::c_int = 21;
-    let min_ttl: libc::c_int = 254;
+    // RFC 5082 §3.2: a directly connected peer's packets arrive with
+    // TTL 255 (the sender's stack cannot emit more, and any forwarding
+    // hop would decrement below it). Strict 255 matches FRR/BIRD and
+    // the BFD receive path's exact-255 check; 254 would accept packets
+    // that crossed one router.
+    let min_ttl: libc::c_int = 255;
 
     let fd = {
         use std::os::unix::io::AsRawFd;
@@ -3146,7 +3151,8 @@ fn set_gtsm_v4(socket: &Socket) -> io::Result<()> {
     reason = "IPv6 GTSM requires raw Linux socket options and socklen_t casts"
 )]
 fn set_gtsm_v6(socket: &Socket) -> io::Result<()> {
-    let min_hops: libc::c_int = 254;
+    // Strict RFC 5082 §3.2 Hop Limit — see the IPv4 twin above.
+    let min_hops: libc::c_int = 255;
     let fd = socket.as_raw_fd();
 
     let ret = unsafe {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -607,7 +607,7 @@ MKTs that are neither Current nor RNext while keeping the owner set, survivor
 order, key definitions, and selected key exact. Protected-owner changes and
 key edits/reordering remain restart-required.
 
-**GTSM (RFC 5082):** Supported in v1 as a configurable option (`ttl_security = true` per neighbor). Sets `IP_TTL` to 255 on outbound and checks inbound TTL >= 254. Simple, effective, and prevents most remote session hijacking.
+**GTSM (RFC 5082):** Supported in v1 as a configurable option (`ttl_security = true` per neighbor). Sets `IP_TTL` to 255 on outbound and requires inbound TTL exactly 255 (strict RFC 5082 §3.2, matching FRR/BIRD). Simple, effective, and prevents most remote session hijacking.
 
 ### Connection Rate Limiting
 

--- a/docs/adr/0016-socket2-for-md5-gtsm.md
+++ b/docs/adr/0016-socket2-for-md5-gtsm.md
@@ -10,7 +10,7 @@ and/or GTSM TTL security (RFC 5082). Both require `setsockopt` calls that must
 happen *before* the TCP connection is established:
 
 - `TCP_MD5SIG` (option 14) — associates an MD5 password with a peer address.
-- `IP_MINTTL` (option 21) — rejects packets with TTL below 254.
+- `IP_MINTTL` (option 21) — rejects packets with TTL below 255 (strict RFC 5082 §3.2).
 
 Tokio's `TcpStream::connect()` creates and connects in one step, providing no
 window to apply socket options.

--- a/src/bfd_runtime.rs
+++ b/src/bfd_runtime.rs
@@ -14,7 +14,8 @@
 //! Design: a single actor task `select!`s over the shared per-AF receive
 //! sockets and a min-deadline timer heap covering every session's transmit and
 //! detection timers. The receive path validates the RFC 5881 TTL/Hop-Limit-255
-//! requirement via `recvmsg` ancillary data, decodes, demultiplexes to the
+//! requirement via `recvmsg` ancillary data and the §4 source-port range
+//! (49152..=65535), decodes, demultiplexes to the
 //! session by Your Discriminator (RFC 5880 §6.8.6; source address only for the
 //! zero-discriminator bootstrap), and executes the resulting
 //! [`rustbgpd_bfd::Action`]s.
@@ -1133,9 +1134,21 @@ mod linux {
         if ttl != Some(255) {
             return Recv::Discard;
         }
-        let Some(src) = msg.address.and_then(socket_ip) else {
+        let Some((src, src_port)) = msg.address.and_then(socket_ip_port) else {
             return Recv::Discard;
         };
+        // RFC 5881 §4: the source port MUST be in 49152..=65535. The
+        // range's upper bound is the u16 ceiling, so only the lower
+        // bound needs checking. Defense-in-depth alongside the
+        // exact-TTL check and discriminator demux.
+        if src_port < BFD_SRC_PORT_MIN {
+            tracing::debug!(
+                %src,
+                src_port,
+                "discarding BFD control packet with out-of-range source port (RFC 5881 §4)"
+            );
+            return Recv::Discard;
+        }
         let n = msg.bytes;
         match ControlPacket::decode(&buf[..n]) {
             Ok(pkt) => Recv::Packet(src, pkt),
@@ -1143,12 +1156,12 @@ mod linux {
         }
     }
 
-    fn socket_ip(addr: nix::sys::socket::SockaddrStorage) -> Option<IpAddr> {
+    fn socket_ip_port(addr: nix::sys::socket::SockaddrStorage) -> Option<(IpAddr, u16)> {
         if let Some(v4) = addr.as_sockaddr_in() {
-            return Some(IpAddr::V4(v4.ip()));
+            return Some((IpAddr::V4(v4.ip()), v4.port()));
         }
         if let Some(v6) = addr.as_sockaddr_in6() {
-            return Some(IpAddr::V6(v6.ip()));
+            return Some((IpAddr::V6(v6.ip()), v6.port()));
         }
         None
     }
@@ -1270,11 +1283,12 @@ mod linux {
     #[cfg(test)]
     mod unit {
         use super::{
-            Deadline, FamilySockets, enable_recv_ttl, kind_key, prepare_runtime_sockets,
-            rx_socket_with,
+            BFD_SRC_PORT_MIN, Deadline, FamilySockets, enable_recv_ttl, kind_key,
+            prepare_runtime_sockets, rx_socket_with,
         };
-        use rustbgpd_bfd::TimerKind;
+        use rustbgpd_bfd::{ControlPacket, Diagnostic, SessionState, TimerKind};
         use std::net::IpAddr;
+        use std::os::fd::AsRawFd;
         use tokio::io::unix::AsyncFd;
         use tokio::time::Instant;
 
@@ -1474,6 +1488,66 @@ mod linux {
             let (pkts, drained) = super::drain_socket(rx.as_raw_fd(), 64);
             assert!(pkts.is_empty());
             assert!(drained, "second turn drains the remainder");
+        }
+
+        fn control_packet(my_discriminator: u32) -> ControlPacket {
+            ControlPacket {
+                diagnostic: Diagnostic::None,
+                state: SessionState::Down,
+                poll: false,
+                final_bit: false,
+                control_plane_independent: false,
+                auth_present: false,
+                demand: false,
+                multipoint: false,
+                detect_mult: 3,
+                my_discriminator,
+                your_discriminator: 0,
+                desired_min_tx_interval: 1_000_000,
+                required_min_rx_interval: 1_000_000,
+                required_min_echo_rx_interval: 0,
+            }
+        }
+
+        /// Bind a loopback UDP sender on the first free port in `range`.
+        fn sender_in(range: std::ops::RangeInclusive<u16>) -> std::net::UdpSocket {
+            for port in range.clone() {
+                if let Ok(s) = std::net::UdpSocket::bind(("127.0.0.1", port)) {
+                    return s;
+                }
+            }
+            panic!("no free sender port in {range:?}");
+        }
+
+        #[test]
+        fn out_of_range_source_port_is_discarded() {
+            // Real RX socket with IP_RECVTTL so the TTL-255 gate passes and
+            // the source-port gate is the discriminating check.
+            let rx = rx_socket_with(false, 0, enable_recv_ttl).expect("rx socket");
+            let rx_port = rx.local_addr().expect("addr").port();
+            let dst = ("127.0.0.1", rx_port);
+
+            // Identical valid packets, distinguished by discriminator; both
+            // senders emit TTL 255. Loopback delivery is synchronous.
+            let bad = sender_in(20000..=20200);
+            assert!(bad.local_addr().expect("addr").port() < BFD_SRC_PORT_MIN);
+            bad.set_ttl(255).expect("ttl");
+            bad.send_to(&control_packet(0xBAD).encode(), dst)
+                .expect("send");
+
+            let good = sender_in(BFD_SRC_PORT_MIN..=BFD_SRC_PORT_MIN + 200);
+            good.set_ttl(255).expect("ttl");
+            good.send_to(&control_packet(0x600D).encode(), dst)
+                .expect("send");
+
+            let (pkts, drained) = super::drain_socket(rx.as_raw_fd(), 8);
+            assert!(drained, "both datagrams fit the budget");
+            let discs: Vec<u32> = pkts.iter().map(|(_, p)| p.my_discriminator).collect();
+            assert_eq!(
+                discs,
+                vec![0x600D],
+                "RFC 5881 §4: only the in-range source port passes"
+            );
         }
     }
 
@@ -2004,6 +2078,21 @@ bfd = {{ profile = "p" }}
             tokio::net::UdpSocket::from_std(s.into()).unwrap()
         }
 
+        /// Transmit socket for the hand-rolled peer, bound to the peer
+        /// address on a port inside the RFC 5881 §4 source-port range —
+        /// the actor's receive path discards control packets from
+        /// out-of-range source ports.
+        fn peer_tx_socket() -> tokio::net::UdpSocket {
+            let s = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)).unwrap();
+            let bound = (49152u16..=65535).any(|port| {
+                let addr: SocketAddr = format!("{PEER_ADDR}:{port}").parse().unwrap();
+                s.bind(&addr.into()).is_ok()
+            });
+            assert!(bound, "no free peer source port in 49152..=65535");
+            s.set_nonblocking(true).unwrap();
+            tokio::net::UdpSocket::from_std(s.into()).unwrap()
+        }
+
         // A control packet from the hand-rolled peer that drives a Down actor
         // to Up: State=Init with a non-zero my/your discriminator pair.
         fn peer_init(your_disc: u32) -> Vec<u8> {
@@ -2029,6 +2118,7 @@ bfd = {{ profile = "p" }}
 
         async fn peer_responder(
             sock: tokio::net::UdpSocket,
+            tx_sock: tokio::net::UdpSocket,
             mode_rx: watch::Receiver<u8>,
             observed_src_port: Arc<AtomicU16>,
             stop: CancellationToken,
@@ -2057,10 +2147,10 @@ bfd = {{ profile = "p" }}
                         }
                         let ttl = if mode == MODE_TTL_BAD { 1 } else { 255 };
                         if ttl != cur_ttl {
-                            sock.set_ttl(ttl).unwrap();
+                            tx_sock.set_ttl(ttl).unwrap();
                             cur_ttl = ttl;
                         }
-                        let _ = sock.send_to(&peer_init(actor_disc), actor).await;
+                        let _ = tx_sock.send_to(&peer_init(actor_disc), actor).await;
                     }
                 }
             }
@@ -2179,6 +2269,7 @@ bfd = {{ profile = "p" }}
             let observed_src_port = Arc::new(AtomicU16::new(0));
             let peer_task = tokio::spawn(peer_responder(
                 peer_socket(),
+                peer_tx_socket(),
                 mode_rx,
                 Arc::clone(&observed_src_port),
                 peer_stop.clone(),


### PR DESCRIPTION
Four transport/dataplane robustness findings from an outside read-only review, each verified against the code before changing anything. One item is a strictness change (GTSM), three are fixes. Gates: fmt, clippy `-D warnings`, `cargo test --workspace`, `cargo doc`, `check-clippy-reasons.py` — all green.

## 1. GTSM accepts TTL 254 — verified, fixed (strict 255)

`set_gtsm_v4`/`set_gtsm_v6` (`crates/transport/src/socket_opts.rs`) set `IP_MINTTL`/`IPV6_MINHOPCOUNT` to 254, accepting a packet that crossed one router. RFC 5082 §3.2 expects exactly 255 from a directly connected peer, and the BFD receive path already enforces exact 255 (`src/bfd_runtime.rs`) — an inconsistent posture between two single-hop guards.

History check before changing: the 254 dates to the original M3 commit (`5ba7a011`), whose comment reads "accept only TTL >= 254, i.e., directly connected" — an off-by-one in the original reasoning, not a recorded interop concession. No ADR, commit, or comment justifies 254; ADR-0016 and DESIGN.md merely describe the implemented value. FRR (`MAXTTL + 1 - hops` = 255 for hops=1) and BIRD both enforce 255. Both families now use 255, with the rationale at the site; ADR-0016, DESIGN.md, and the changelog updated. A peer that relied on the one-hop-off leniency will no longer establish — noted as **Changed** in the changelog.

## 2. Listener accept-loop hot-spins on persistent errno — verified, fixed

`run` (`crates/transport/src/listener.rs`) logged `accept(2)` errors and immediately continued; under fd exhaustion `EMFILE` fires on every iteration — CPU burn plus log flood. Errors are now classified by `accept_error_class`:

- `EMFILE`/`ENFILE`/`ENOMEM`/`ENOBUFS` → progressive async backoff, 100 ms doubling to a 1 s cap, reset on the next successful accept;
- `EBADF`/`ENOTSOCK`/`EINVAL`/`EOPNOTSUPP` → the listening socket is unusable, the loop exits;
- everything else (`ECONNABORTED`, `EINTR`, `EPROTO`, no-errno) → immediate continue, as before.

Test: `accept_errors_classify_by_errno` pins the classification per errno.

## 3. L3 (IP-VRF) reconcile has no retry backoff — verified, fixed

Every L2 op class in `crates/evpn-linux/src/reconcile.rs` feeds a `RetrySchedule` (100 ms → 5 s + jitter) on Transient/Conflict failures; the L3 transient arm only set `l3_pass_had_failures`, so a transiently failing L3 op (netlink `EBUSY`) re-applied on every reconcile wake with zero backoff — and had no dedicated retry timer at all, so with no other wakes it waited for the 60 s periodic dump. Added `RetrySchedule<L3OpKey>` mirroring the L2 pattern: same schedule constants, clear-on-success, permanent failures drop out of the transient schedule, the schedule participates in the actor's retry-timer minimum, and a deferred op fail-stops its dependent route adds and keeps the ADR-0079 reap blocked exactly like a failed apply.

Same-seam hardening found while wiring it: retry entries whose op left the plan (withdrawn or superseded while still failing) are now pruned in all six schedules — a stale entry's past-due deadline would otherwise pin the actor's retry timer in the past and busy-loop reconcile passes.

Test: `failed_l3_apply_backs_off_and_retries_on_timer` (mirrors the L2 `failed_apply_retries_on_backoff_timer`), red-proven against the pre-fix code: it fails there with "transiently failed L3 op re-attempted with zero backoff".

## 4. BFD receive skips RFC 5881 §4 source-port validation — verified, fixed

`recv_one` (`src/bfd_runtime.rs`) validated exact TTL 255 and demuxed by Your Discriminator but ignored the source port already present in the `recvmsg` address. Packets whose UDP source port falls below 49152 are now discarded with a debug log (the range's upper bound is the u16 ceiling, so only the lower bound needs checking) — cheap defense-in-depth in front of the decode. The transmit side already binds inside the range. The netns e2e responder, which replied from source port 3784, now sends from an in-range port via a dedicated tx socket, keeping that test's TTL phases meaningful under the new check.

Test: `out_of_range_source_port_is_discarded` sends the same valid, TTL-255 control packet from an out-of-range and an in-range source port and asserts only the in-range one is delivered.

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test --workspace` — exit 0
- `cargo doc --workspace --no-deps` — exit 0
- `python3 scripts/check-clippy-reasons.py` — exit 0

Changes under `crates/evpn-linux` and `src/bfd_runtime.rs` will trigger the privileged kernel-dataplane CI selectors; the new logic itself is covered by the non-privileged unit/actor tests above.
