### PR TITLE
API service consistency batch: bounded actor reads, in-band lag markers, scoped peer labels, explicit gNMI Set guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `WatchRoutes` now signals subscriber lag in-band with a synthetic
+  `ROUTE_EVENT_TYPE_STREAM_LAGGED` marker event (`reason` carries the
+  missed count) instead of silently skipping dropped events, matching the
+  `BGP_EVENT_TYPE_STREAM_LAGGED` contract on `WatchRouteEvents`. The
+  `WatchEvents` policy and dataplane sources gain the same lag marker
+  their route/session/EVPN/BFD siblings already emitted (LAN-898).
+
 - IRR reload harness: announcement-overlap dimension (LAN-892). The
   scenario generator takes `--overlap-fraction F` (default 0 keeps the
   historical disjoint output byte-identical): a seeded fraction of base
@@ -30,6 +37,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   violations, and mismatched received-view scenarios.
 
 ### Fixed
+
+- API service consistency batch (LAN-898): every peer-manager read now
+  carries a 2-second server-side deadline (`DEADLINE_EXCEEDED` instead of
+  hanging `ListPeers`/`GetPeerState`, gNMI Get/Subscribe snapshots, and
+  policy explain reads behind a wedged actor); gNMI `Set` rejects
+  read-only listeners explicitly like every other mutating service;
+  notification and policy events publish the scoped `address%interface`
+  peer label so link-local peers correlate across event streams; and
+  `StreamPlanConfigTransaction` bounds its post-handoff response wait by
+  the total deadline, matching `StreamApplyConfigTransaction`.
 
 - EVPN wire encoding no longer emits silently wrong bytes for invariant
   violations that were only debug-asserted (LAN-896). Release builds

--- a/crates/api/src/actor_read.rs
+++ b/crates/api/src/actor_read.rs
@@ -1,26 +1,44 @@
 //! Shared transport boundary for read-only requests to the state-owning actors.
 
+use std::time::Duration;
+
 use rustbgpd_rib::RibUpdate;
 use tokio::sync::{mpsc, oneshot};
 use tonic::Status;
 
 use crate::peer_types::PeerManagerCommand;
 
+/// Server-side deadline for every peer-manager read. All peer-manager reads
+/// are O(peers) state lookups, so this matches the duration class of the
+/// neighbor service's `RIB_SNAPSHOT_TIMEOUT`: a wedged actor must surface as
+/// `DEADLINE_EXCEEDED` instead of hanging the RPC until client cancel.
+const PEER_MANAGER_READ_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// Send one read-only request to the peer manager and await its reply.
 pub(crate) async fn peer_manager_read<T>(
     tx: &mpsc::Sender<PeerManagerCommand>,
     build: impl FnOnce(oneshot::Sender<T>) -> PeerManagerCommand,
 ) -> Result<T, Status> {
-    let (reply, response) = oneshot::channel();
-    tx.send(build(reply))
-        .await
-        .map_err(|_| Status::unavailable("peer manager unavailable"))?;
-    response
-        .await
-        .map_err(|_| Status::unavailable("peer manager dropped reply"))
+    tokio::time::timeout(PEER_MANAGER_READ_TIMEOUT, async {
+        let (reply, response) = oneshot::channel();
+        tx.send(build(reply))
+            .await
+            .map_err(|_| Status::unavailable("peer manager unavailable"))?;
+        response
+            .await
+            .map_err(|_| Status::unavailable("peer manager dropped reply"))
+    })
+    .await
+    .map_err(|_| Status::deadline_exceeded("peer manager read timed out"))?
 }
 
 /// Send one read-only request to the RIB manager and await its reply.
+///
+/// Unlike [`peer_manager_read`], this is deliberately unbounded here: RIB
+/// reads can be legitimately slow at large table sizes, so a single fixed
+/// deadline does not fit every caller. Callers that need a bound wrap this
+/// in `tokio::time::timeout` (see the neighbor service's
+/// `RIB_SNAPSHOT_TIMEOUT`).
 pub(crate) async fn rib_manager_read<T>(
     tx: &mpsc::Sender<RibUpdate>,
     build: impl FnOnce(oneshot::Sender<T>) -> RibUpdate,
@@ -32,4 +50,29 @@ pub(crate) async fn rib_manager_read<T>(
     response
         .await
         .map_err(|_| Status::unavailable("RIB manager dropped reply"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::peer_types::PeerManagerCommand;
+    use std::time::Duration;
+
+    /// Load-bearing: without a server-side deadline inside
+    /// `peer_manager_read`, a wedged peer-manager actor leaves the request
+    /// pending forever and the outer test guard expires instead of observing
+    /// the production `DeadlineExceeded` status.
+    #[tokio::test(start_paused = true)]
+    async fn stalled_peer_manager_read_returns_deadline_exceeded() {
+        let (tx, rx) = mpsc::channel(1);
+        let result = tokio::time::timeout(
+            Duration::from_secs(30),
+            peer_manager_read(&tx, |reply| PeerManagerCommand::ListPeers { reply }),
+        )
+        .await
+        .expect("peer-manager read must be bounded server-side");
+        assert_eq!(result.unwrap_err().code(), tonic::Code::DeadlineExceeded);
+        // Held so the command is accepted but never answered.
+        drop(rx);
+    }
 }

--- a/crates/api/src/config_service/stream.rs
+++ b/crates/api/src/config_service/stream.rs
@@ -469,8 +469,13 @@ pub(super) async fn stream_plan_config_transaction(
         audit,
         response_tx,
     ));
-    response_rx
+    // Outer bound for parity with StreamApplyConfigTransaction: the detached
+    // task's async work is deadline-limited internally, but token issuance
+    // runs outside that window and a wedged/never-scheduled task must not
+    // hang the RPC past the total deadline.
+    timeout_at(deadline, response_rx)
         .await
+        .map_err(|_| Status::deadline_exceeded("streamed config plan exceeded total deadline"))?
         .map_err(|_| Status::internal("streamed config planner task did not complete"))?
         .map(Response::new)
 }
@@ -1834,6 +1839,33 @@ mod tests {
             .send(Ok(sample_plan(RuntimeConfigTransactionStatus::Committable)))
             .unwrap();
         task.await.unwrap();
+        assert!(state.tokens.lock().unwrap().is_empty());
+    }
+
+    /// After handoff the plan RPC is bounded by the total deadline — a wedged
+    /// planner surfaces `DEADLINE_EXCEEDED` to the client instead of hanging
+    /// (parity with `StreamApplyConfigTransaction`'s response deadline).
+    #[tokio::test(start_paused = true)]
+    async fn plan_response_is_bounded_by_total_deadline_after_handoff() {
+        let runtime = TempDir::new().unwrap();
+        let state = state_at(runtime.path(), StreamLimits::default());
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        let listener = spawn_listener(Arc::clone(&state), peer_tx, true).await;
+        let mut client = listener.client.clone();
+        let request = tokio::spawn(async move {
+            client
+                .stream_plan_config_transaction(futures::stream::iter(frames(b"stalled", None)))
+                .await
+        });
+        let PeerManagerCommand::PlanConfigTransaction { reply, .. } = peer_rx.recv().await.unwrap()
+        else {
+            panic!("unexpected peer-manager command");
+        };
+        tokio::time::advance(Duration::from_secs(30 * 60 + 1)).await;
+        let error = request.await.unwrap().unwrap_err();
+        assert_eq!(error.code(), tonic::Code::DeadlineExceeded);
+        assert!(error.message().contains("total deadline"));
+        drop(reply);
         assert!(state.tokens.lock().unwrap().is_empty());
     }
 

--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -316,9 +316,12 @@ impl proto::event_service_server::EventService for EventService {
                             );
                             debug!(
                                 missed,
-                                "WatchEvents policy subscriber lagged, skipping missed events"
+                                "WatchEvents policy subscriber lagged, emitting missed-event signal"
                             );
-                            None
+                            Some(Ok(stream_lag_bgp_event(
+                                proto::EventCategory::Policy,
+                                missed,
+                            )))
                         }
                         Ok(event) => {
                             let _subscriber_guard = &policy_subscriber_guard;
@@ -356,9 +359,12 @@ impl proto::event_service_server::EventService for EventService {
                             );
                             debug!(
                                 missed,
-                                "WatchEvents dataplane subscriber lagged, skipping missed events"
+                                "WatchEvents dataplane subscriber lagged, emitting missed-event signal"
                             );
-                            None
+                            Some(Ok(stream_lag_bgp_event(
+                                proto::EventCategory::Dataplane,
+                                missed,
+                            )))
                         }
                         Ok(event) => {
                             let _subscriber_guard = &dataplane_subscriber_guard;
@@ -2418,6 +2424,63 @@ mod tests {
             panic!("expected stream lag payload");
         };
         assert_eq!(lag.source_category, proto::EventCategory::Session as i32);
+        assert!(lag.missed_count > 0);
+    }
+
+    /// Cross-stream correlation: notification and policy events must render
+    /// the same scoped `address%interface` peer label lifecycle events use.
+    #[test]
+    fn notification_and_policy_events_render_scoped_peer_label() {
+        let peer: IpAddr = "fe80::1".parse().unwrap();
+        let SessionEvent::Notification(mut notification) =
+            notification_event(peer, SessionNotificationEventType::Sent)
+        else {
+            unreachable!()
+        };
+        notification.peer_label = Some("fe80::1%eth0".to_string());
+        let event = session_event_to_bgp_event(SessionEvent::Notification(notification));
+        assert_eq!(event.peer_address, "fe80::1%eth0");
+        let Some(proto::bgp_event::Payload::Notification(payload)) = event.payload else {
+            panic!("expected notification payload");
+        };
+        assert_eq!(payload.peer_address, "fe80::1%eth0");
+
+        let mut policy = policy_event(Some(peer));
+        policy.peer_label = Some("fe80::1%eth0".to_string());
+        let event = policy_event_to_bgp_event(policy);
+        assert_eq!(event.peer_address, "fe80::1%eth0");
+        let Some(proto::bgp_event::Payload::Policy(payload)) = event.payload else {
+            panic!("expected policy payload");
+        };
+        assert_eq!(payload.peer_address, "fe80::1%eth0");
+    }
+
+    #[tokio::test]
+    async fn policy_lag_emits_missed_event_signal() {
+        let (rib_tx, _) = spawn_fake_rib();
+        let (peer_tx, _, policy_events_tx) = spawn_fake_peer_manager();
+        let service = EventService::new(rib_tx, peer_tx);
+        let response = service
+            .watch_events(Request::new(proto::WatchEventsRequest {
+                categories: vec![proto::EventCategory::Policy as i32],
+                ..Default::default()
+            }))
+            .await
+            .unwrap();
+        let mut stream = response.into_inner();
+
+        for _ in 0..32 {
+            policy_events_tx.send(policy_event(None)).unwrap();
+        }
+
+        let event = stream.next().await.unwrap().unwrap();
+        assert_eq!(event.category, proto::EventCategory::Policy as i32);
+        assert_eq!(event.event_type, proto::BgpEventType::StreamLagged as i32);
+        assert_eq!(event.severity, proto::EventSeverity::Warning as i32);
+        let Some(proto::bgp_event::Payload::StreamLag(lag)) = event.payload else {
+            panic!("expected stream lag payload");
+        };
+        assert_eq!(lag.source_category, proto::EventCategory::Policy as i32);
         assert!(lag.missed_count > 0);
     }
 

--- a/crates/api/src/event_service/convert.rs
+++ b/crates/api/src/event_service/convert.rs
@@ -230,7 +230,10 @@ fn session_lifecycle_event_to_bgp_event(event: SessionLifecycleEvent) -> proto::
 
 fn session_notification_event_to_bgp_event(event: SessionNotificationEvent) -> proto::BgpEvent {
     let event_type = session_notification_event_type_to_bgp_event_type(event.event_type);
-    let peer_address = event.peer.to_string();
+    let peer_address = event
+        .peer_label
+        .clone()
+        .unwrap_or_else(|| event.peer.to_string());
     let direction = match event.event_type {
         SessionNotificationEventType::Sent => "sent",
         SessionNotificationEventType::Received => "received",
@@ -265,17 +268,20 @@ fn session_notification_event_to_bgp_event(event: SessionNotificationEvent) -> p
     }
 }
 
+#[must_use]
 pub fn policy_event_to_bgp_event(event: PolicyEvent) -> proto::BgpEvent {
     let PolicyEvent {
         operation,
         target_type,
         target,
         peer,
+        peer_label,
         affected_peer_count,
         timestamp,
         reason,
     } = event;
-    let peer_address = peer.map_or_else(String::new, |peer| peer.to_string());
+    let peer_address =
+        peer_label.unwrap_or_else(|| peer.map_or_else(String::new, |peer| peer.to_string()));
     let policy = proto::PolicyEvent {
         event_type: proto::BgpEventType::PolicyChanged as i32,
         operation: operation.to_string(),

--- a/crates/api/src/gnmi_dialout.rs
+++ b/crates/api/src/gnmi_dialout.rs
@@ -691,7 +691,12 @@ mod tests {
 
     fn test_service() -> GnmiService {
         let (peer_tx, _session_events, _policy_events) = spawn_fake_peer_manager();
-        GnmiService::new(65000, "192.0.2.1".to_string(), peer_tx)
+        GnmiService::new(
+            65000,
+            "192.0.2.1".to_string(),
+            crate::server::AccessMode::ReadWrite,
+            peer_tx,
+        )
     }
 
     fn test_target(name: &str, addr: SocketAddr) -> DialoutTarget {
@@ -880,7 +885,12 @@ mod tests {
                 }
             }
         });
-        let service = GnmiService::new(65000, "192.0.2.1".to_string(), peer_tx);
+        let service = GnmiService::new(
+            65000,
+            "192.0.2.1".to_string(),
+            crate::server::AccessMode::ReadWrite,
+            peer_tx,
+        );
 
         // Global + neighbor paths: the snapshot both carries a real leaf
         // update and requires the (failable) peer snapshot.

--- a/crates/api/src/gnmi_service.rs
+++ b/crates/api/src/gnmi_service.rs
@@ -21,7 +21,10 @@ use crate::gnmi;
 use crate::gnmi_ext;
 use crate::peer_types::{PeerInfo, PeerManagerCommand};
 use crate::proto;
-use crate::server::{GnmiSetCommitAction, GnmiSetFn, GnmiSetOperation, GnmiSetTransaction};
+use crate::server::{
+    AccessMode, GnmiSetCommitAction, GnmiSetFn, GnmiSetOperation, GnmiSetTransaction,
+    read_only_rejection,
+};
 
 const GNMI_VERSION: &str = "0.10.0";
 const DEFAULT_NETWORK_INSTANCE: &str = "DEFAULT";
@@ -135,6 +138,9 @@ fn render_heartbeat_snapshot<'a>(
 pub struct GnmiService {
     asn: u32,
     router_id: String,
+    /// Listener access mode. `Set` is guarded explicitly like every other
+    /// mutating service, in addition to the authz tier cap on `gnmi.gNMI/Set`.
+    access_mode: AccessMode,
     peer_snapshot: PeerSnapshotFn,
     /// Bounds concurrent `Subscribe` streams; a permit is held for the lifetime
     /// of each open stream.
@@ -210,9 +216,10 @@ impl GnmiService {
     pub fn new(
         asn: u32,
         router_id: String,
+        access_mode: AccessMode,
         peer_mgr_tx: tokio::sync::mpsc::Sender<PeerManagerCommand>,
     ) -> Self {
-        Self::with_peer_snapshot(asn, router_id, move || {
+        let mut service = Self::with_peer_snapshot(asn, router_id, move || {
             let peer_mgr_tx = peer_mgr_tx.clone();
             Box::pin(async move {
                 peer_manager_read(&peer_mgr_tx, |reply| PeerManagerCommand::ListPeers {
@@ -220,7 +227,9 @@ impl GnmiService {
                 })
                 .await
             })
-        })
+        });
+        service.access_mode = access_mode;
+        service
     }
 
     fn with_peer_snapshot<F, Fut>(asn: u32, router_id: impl Into<String>, peer_snapshot: F) -> Self
@@ -231,6 +240,7 @@ impl GnmiService {
         Self {
             asn,
             router_id: router_id.into(),
+            access_mode: AccessMode::ReadWrite,
             peer_snapshot: Arc::new(move || Box::pin(peer_snapshot())),
             subscribe_slots: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_SUBSCRIPTIONS)),
             event_history: None,
@@ -333,6 +343,12 @@ impl GnmiService {
         }
     }
 
+    /// Subscription variant of [`Self::render_query`]: an absent neighbor
+    /// yields an empty snapshot instead of `NOT_FOUND`. Intentional
+    /// divergence from Get — a subscription may be opened before the peer
+    /// comes up (or across a peer's removal and re-add) and must keep
+    /// streaming once it appears, while a one-shot Get for a neighbor that
+    /// does not exist is an addressing error.
     fn render_subscription_query(
         &self,
         query: &SupportedPath,
@@ -1387,6 +1403,10 @@ fn normalize_set_path(
     Ok(full_path)
 }
 
+/// Build the all-success per-op `UpdateResult` list from the normalized
+/// request. Sound only because the Set bridge is atomic: on any failure the
+/// RPC errors and this response is discarded, so these results are never sent
+/// for a partially applied transaction.
 fn set_response_from_operations(operations: &[GnmiSetOperation]) -> gnmi::SetResponse {
     gnmi::SetResponse {
         prefix: None,
@@ -1962,6 +1982,9 @@ fn render_global_updates(
     }
 }
 
+/// Get-path neighbor rendering: an absent neighbor is `NOT_FOUND`. Subscribe
+/// intentionally diverges (empty snapshot, keeps streaming) — see
+/// `GnmiService::render_subscription_query` for the rationale.
 fn render_neighbor_updates(
     peers: &[PeerInfo],
     local_as: u32,
@@ -2429,10 +2452,19 @@ impl gnmi::g_nmi_server::GNmi for GnmiService {
         request: Request<gnmi::SetRequest>,
     ) -> Result<Response<gnmi::SetResponse>, Status> {
         set_request_summary(&request, gnmi_set_summary(request.get_ref()));
+        if let Some(status) = read_only_rejection(self.access_mode) {
+            return Err(status);
+        }
         let Some(set_handler) = &self.set_handler else {
             return Err(Status::unimplemented("gNMI Set is not supported"));
         };
         let transaction = normalize_set_request(request.into_inner())?;
+        // The bridge applies the whole request as one candidate config through
+        // the transaction controller, so Set is all-or-nothing (as the gNMI
+        // spec requires): a failed transaction surfaces as a gRPC error and no
+        // SetResponse is returned. Per-op results built from the request are
+        // therefore only ever sent when every operation was applied — partial
+        // apply is unrepresentable by construction, not misreported.
         let mut response = set_response_from_operations(&transaction.operations);
         let outcome = set_handler(transaction)
             .await
@@ -3155,6 +3187,30 @@ mod tests {
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
         assert!(err.message().contains("unsupported gNMI Set origin"));
+    }
+
+    /// Read-only listeners must reject Set explicitly (like every other
+    /// mutating service), independent of the authz tier cap on
+    /// `gnmi.gNMI/Set`.
+    #[tokio::test]
+    async fn set_on_read_only_listener_is_rejected_before_hook() {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+            panic!("read-only listeners must reject Set before invoking the hook");
+        });
+        let mut service = test_service(Vec::new()).with_set_handler(Some(hook));
+        service.access_mode = crate::server::AccessMode::ReadOnly;
+        let err = service
+            .set(Request::new(gnmi::SetRequest {
+                prefix: None,
+                delete: vec![relative_path(&["network-instances"])],
+                replace: Vec::new(),
+                update: Vec::new(),
+                extension: Vec::new(),
+                union_replace: Vec::new(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
     }
 
     #[tokio::test]
@@ -4054,8 +4110,13 @@ mod tests {
         let (peer_tx, peer_rx) = tokio::sync::mpsc::channel(1);
         drop(peer_rx);
         let manager = event_history_manager().await;
-        let service = GnmiService::new(65001, "192.0.2.1".to_string(), peer_tx)
-            .with_event_history(Some(manager.handle()));
+        let service = GnmiService::new(
+            65001,
+            "192.0.2.1".to_string(),
+            crate::server::AccessMode::ReadWrite,
+            peer_tx,
+        )
+        .with_event_history(Some(manager.handle()));
         assert_peer_snapshot_outage(service, "peer manager unavailable").await;
         manager.shutdown().await;
     }
@@ -4075,8 +4136,13 @@ mod tests {
             }
         });
         let manager = event_history_manager().await;
-        let service = GnmiService::new(65001, "192.0.2.1".to_string(), peer_tx)
-            .with_event_history(Some(manager.handle()));
+        let service = GnmiService::new(
+            65001,
+            "192.0.2.1".to_string(),
+            crate::server::AccessMode::ReadWrite,
+            peer_tx,
+        )
+        .with_event_history(Some(manager.handle()));
         assert_peer_snapshot_outage(service, "peer manager dropped reply").await;
         tokio::time::timeout(Duration::from_secs(2), actor)
             .await
@@ -4792,7 +4858,13 @@ mod tests {
         // Load-bearing break: clearing `updates_only` for ONCE emits data and
         // queues ListPeers instead of ending immediately after sync.
         let (peer_tx, mut peer_rx) = tokio::sync::mpsc::channel(1);
-        let mut harness = serve(GnmiService::new(65001, "192.0.2.1".into(), peer_tx)).await;
+        let mut harness = serve(GnmiService::new(
+            65001,
+            "192.0.2.1".into(),
+            crate::server::AccessMode::ReadWrite,
+            peer_tx,
+        ))
+        .await;
         let mut list = subscription_list(
             gnmi::subscription_list::Mode::Once,
             gnmi::SubscriptionMode::TargetDefined,
@@ -4823,7 +4895,13 @@ mod tests {
         // Load-bearing break: clearing `updates_only` in POLL emits data and
         // queues ListPeers during the initial phase or either explicit poll.
         let (peer_tx, mut peer_rx) = tokio::sync::mpsc::channel(1);
-        let mut harness = serve(GnmiService::new(65001, "192.0.2.1".into(), peer_tx)).await;
+        let mut harness = serve(GnmiService::new(
+            65001,
+            "192.0.2.1".into(),
+            crate::server::AccessMode::ReadWrite,
+            peer_tx,
+        ))
+        .await;
         let mut list = subscription_list(
             gnmi::subscription_list::Mode::Poll,
             gnmi::SubscriptionMode::TargetDefined,
@@ -4880,7 +4958,13 @@ mod tests {
                 }
             }
         });
-        let mut harness = serve(GnmiService::new(65001, "192.0.2.1".into(), peer_tx)).await;
+        let mut harness = serve(GnmiService::new(
+            65001,
+            "192.0.2.1".into(),
+            crate::server::AccessMode::ReadWrite,
+            peer_tx,
+        ))
+        .await;
         let mut list = subscription_list(
             gnmi::subscription_list::Mode::Stream,
             gnmi::SubscriptionMode::Sample,

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -156,6 +156,9 @@ pub struct SessionNotificationEvent {
     pub event_type: SessionNotificationEventType,
     /// Peer address associated with the event.
     pub peer: IpAddr,
+    /// Operator-facing peer label. Scoped IPv6 link-local peers render as
+    /// `address%interface`, matching lifecycle events so streams correlate.
+    pub peer_label: Option<String>,
     /// Unix epoch seconds, string-shaped to match `RouteEvent`.
     pub timestamp: String,
     /// BGP NOTIFICATION error code.
@@ -184,6 +187,10 @@ pub struct PolicyEvent {
     pub target: String,
     /// Peer address when this mutation is scoped to one peer.
     pub peer: Option<IpAddr>,
+    /// Operator-facing peer label for `peer`. Scoped IPv6 link-local peers
+    /// render as `address%interface`, matching lifecycle events so streams
+    /// correlate.
+    pub peer_label: Option<String>,
     /// Number of currently managed peers the runtime mutation touched.
     pub affected_peer_count: usize,
     /// Unix epoch seconds, string-shaped to match `RouteEvent`.

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -1285,6 +1285,19 @@ pub(crate) fn route_event_to_proto(event: rustbgpd_rib::RouteEvent) -> proto::Ro
     }
 }
 
+/// Synthetic in-band lag marker for `WatchRoutes`, mirroring the
+/// `BGP_EVENT_TYPE_STREAM_LAGGED` contract on the `BgpEvent` streams: a
+/// subscriber that fell behind the broadcast buffer sees the gap instead of a
+/// silent skip. Prefix/peer fields stay empty; `reason` carries the count.
+fn stream_lag_route_event(missed: u64) -> proto::RouteEvent {
+    proto::RouteEvent {
+        event_type: proto::RouteEventType::StreamLagged.into(),
+        timestamp: rustbgpd_rib::event::unix_timestamp_now(),
+        reason: format!("route event stream lagged; missed {missed} event(s)"),
+        ..Default::default()
+    }
+}
+
 fn route_event_matches_watch_filter(
     event: &rustbgpd_rib::RouteEvent,
     afi_safi_filter: i32,
@@ -1618,9 +1631,9 @@ impl proto::rib_service_server::RibService for RibService {
                 metrics.record_event_stream_lagged("watch_routes", "route", missed);
                 debug!(
                     missed,
-                    "WatchRoutes subscriber lagged, skipping missed events"
+                    "WatchRoutes subscriber lagged, emitting missed-event signal"
                 );
-                None
+                Some(Ok(stream_lag_route_event(missed)))
             }
         });
 
@@ -3934,7 +3947,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn watch_routes_lagged_subscriber_increments_metric() {
+    async fn watch_routes_lagged_subscriber_emits_marker_and_increments_metric() {
         let metrics = BgpMetrics::new();
         let (svc, events_tx) = make_watch_routes_service(metrics.clone());
 
@@ -3952,6 +3965,18 @@ mod tests {
                 ))
                 .unwrap();
         }
+
+        // The gap must be visible in-band: first item is the lag marker, then
+        // the surviving events resume.
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.event_type, proto::RouteEventType::StreamLagged as i32);
+        assert!(event.prefix.is_empty());
+        assert!(event.peer_address.is_empty());
+        assert_eq!(event.reason, "route event stream lagged; missed 4 event(s)");
 
         let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
             .await

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -1532,7 +1532,7 @@ async fn run_tcp_listener(
     ));
     if tls_enabled {
         routes.add_service(GNmiServer::with_interceptor(
-            GnmiService::new(asn, router_id.clone(), peer_mgr_tx.clone())
+            GnmiService::new(asn, router_id.clone(), access_mode, peer_mgr_tx.clone())
                 .with_set_handler(gnmi_set.clone())
                 .with_event_history(event_history.clone()),
             interceptor.clone(),
@@ -1755,7 +1755,7 @@ async fn run_uds_listener(
         interceptor.clone(),
     ));
     routes.add_service(GNmiServer::with_interceptor(
-        GnmiService::new(asn, router_id, peer_mgr_tx.clone())
+        GnmiService::new(asn, router_id, access_mode, peer_mgr_tx.clone())
             .with_set_handler(gnmi_set)
             .with_event_history(event_history.clone()),
         interceptor,

--- a/crates/api/src/test_support.rs
+++ b/crates/api/src/test_support.rs
@@ -405,6 +405,7 @@ pub(crate) fn notification_event(
     SessionEvent::Notification(SessionNotificationEvent {
         event_type,
         peer,
+        peer_label: None,
         timestamp: "789".to_string(),
         code: 6,
         subcode: 7,
@@ -423,6 +424,7 @@ pub(crate) fn policy_event(peer: Option<IpAddr>) -> PolicyEvent {
         target_type: "policy",
         target: "audit-policy".to_string(),
         peer,
+        peer_label: None,
         affected_peer_count: 2,
         timestamp: "789".to_string(),
         reason: "policy set policy audit-policy".to_string(),

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -1807,6 +1807,10 @@ service RibService {
   rpc DeleteFibTable(DeleteFibTableRequest) returns (ListFibTablesResponse);
   rpc ListFibTables(ListFibTablesRequest) returns (ListFibTablesResponse);
   rpc ListRouteEvents(ListRouteEventsRequest) returns (ListRouteEventsResponse);
+  // Streams live route events. When a subscriber falls behind the broadcast
+  // buffer, dropped events are signalled in-band with a
+  // ROUTE_EVENT_TYPE_STREAM_LAGGED marker event (same contract as
+  // WatchRouteEvents' BGP_EVENT_TYPE_STREAM_LAGGED).
   rpc WatchRoutes(WatchRoutesRequest) returns (stream RouteEvent);
   rpc WatchRouteEvents(WatchRoutesRequest) returns (stream BgpEvent);
   rpc ListFlowSpecRoutes(ListFlowSpecRequest) returns (ListFlowSpecResponse);
@@ -2438,6 +2442,11 @@ enum RouteEventType {
   ROUTE_EVENT_TYPE_WITHDRAWN = 2;
   ROUTE_EVENT_TYPE_BEST_CHANGED = 3;
   ROUTE_EVENT_TYPE_POLICY_FILTERED = 4;
+  // Synthetic in-band marker on WatchRoutes: the subscriber lagged behind the
+  // broadcast buffer and events were dropped. `reason` carries the missed
+  // count; prefix/peer fields are empty. Collectors that require a gapless
+  // view must resynchronize (e.g. ListRoutes) when they observe this marker.
+  ROUTE_EVENT_TYPE_STREAM_LAGGED = 5;
 }
 
 message RouteEvent {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4862,6 +4862,8 @@ async fn run<T>(
         rustbgpd_api::gnmi_dialout::GnmiService::new(
             config.global.asn,
             config.global.router_id.clone(),
+            // Dial-out only renders Subscribe snapshots; it never serves Set.
+            rustbgpd_api::server::AccessMode::ReadOnly,
             peer_mgr_tx.clone(),
         )
         .with_event_history(event_history_handle.clone()),

--- a/src/peer_manager/events.rs
+++ b/src/peer_manager/events.rs
@@ -190,12 +190,17 @@ impl PeerManager {
         if target_type == "neighbor" {
             return;
         }
+        // Scoped label so link-local peers correlate with lifecycle events.
+        let peer_label = peer
+            .and_then(|address| self.unique_peer_key_for_address(address))
+            .map(|key| key.label());
         let reason = format!("policy {operation} {target_type} {target}");
         self.publish_policy_event(PolicyEvent {
             operation,
             target_type,
             target,
             peer,
+            peer_label,
             affected_peer_count,
             timestamp: Self::session_event_timestamp(),
             reason,
@@ -288,9 +293,17 @@ impl PeerManager {
             TransportNotificationDirection::Sent => "sent",
             TransportNotificationDirection::Received => "received",
         };
+        // Scoped label so link-local peers correlate with lifecycle events.
+        let peer_label = self
+            .peer_key_for_session(event.session_id)
+            .or_else(|| self.unique_peer_key_for_address(event.peer_addr))
+            .map(|key| key.label());
+        let rendered_peer = peer_label
+            .clone()
+            .unwrap_or_else(|| event.peer_addr.to_string());
         let mut reason = format!(
-            "BGP NOTIFICATION {direction} for peer {}: {}/{} ({})",
-            event.peer_addr, event.code, event.subcode, event.description
+            "BGP NOTIFICATION {direction} for peer {rendered_peer}: {}/{} ({})",
+            event.code, event.subcode, event.description
         );
         if let Some(cause) = event.failure_cause {
             use std::fmt::Write as _;
@@ -299,6 +312,7 @@ impl PeerManager {
         self.publish_session_event(SessionEvent::Notification(SessionNotificationEvent {
             event_type,
             peer: event.peer_addr,
+            peer_label,
             timestamp: Self::session_event_timestamp(),
             code: event.code,
             subcode: event.subcode,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1185,6 +1185,7 @@ fn test_policy_event(target: &str, peer: Option<IpAddr>) -> PolicyEvent {
         target_type: "policy",
         target: target.to_string(),
         peer,
+        peer_label: None,
         affected_peer_count: usize::from(peer.is_some()),
         timestamp: "1".to_string(),
         reason: format!("policy set policy {target}"),
@@ -7745,6 +7746,86 @@ async fn notification_event_reason_includes_bounded_failure_cause() {
     assert_eq!(event.subcode, 8);
     assert_eq!(event.description, "Out of Resources");
     assert_eq!(event.shutdown_reason, None);
+}
+
+/// Cross-stream correlation: notification events for interface-scoped
+/// (link-local) peers must carry the same scoped peer label that lifecycle
+/// events publish, not the bare address.
+#[tokio::test]
+async fn notification_event_uses_scoped_peer_label_for_interface_scoped_peer() {
+    let mut mgr = test_peer_manager();
+    let addr: IpAddr = "fe80::2".parse().unwrap();
+    insert_test_scoped_managed_peer(
+        &mut mgr,
+        addr,
+        "eth0",
+        10,
+        7,
+        fake_peer_handle(
+            addr,
+            SessionState::Established,
+            None,
+            Arc::new(FakePeerCounters::default()),
+        ),
+    );
+    let mut events = mgr.session_events_tx.subscribe();
+    mgr.publish_notification_event(rustbgpd_transport::SessionNotificationEvent {
+        session_id: 7,
+        peer_addr: addr,
+        role: rustbgpd_transport::SessionRole::Primary,
+        direction: rustbgpd_transport::SessionNotificationDirection::Received,
+        code: rustbgpd_wire::notification::NotificationCode::Cease.as_u8(),
+        subcode: rustbgpd_wire::notification::cease_subcode::ADMINISTRATIVE_RESET,
+        description: "Administrative Reset".to_string(),
+        shutdown_reason: None,
+        failure_cause: None,
+    });
+
+    let rustbgpd_api::peer_types::SessionEvent::Notification(event) = events.try_recv().unwrap()
+    else {
+        panic!("expected notification event");
+    };
+    assert!(
+        event.reason.contains("fe80::2%eth0"),
+        "notification reason must use the scoped peer label, got: {}",
+        event.reason
+    );
+    assert_eq!(event.peer_label.as_deref(), Some("fe80::2%eth0"));
+    assert_eq!(event.peer, addr);
+}
+
+/// Policy events scoped to an interface-scoped peer carry the scoped label so
+/// they correlate with the lifecycle stream.
+#[tokio::test]
+async fn policy_event_uses_scoped_peer_label_for_interface_scoped_peer() {
+    let mut mgr = test_peer_manager();
+    let addr: IpAddr = "fe80::2".parse().unwrap();
+    insert_test_scoped_managed_peer(
+        &mut mgr,
+        addr,
+        "eth0",
+        10,
+        7,
+        fake_peer_handle(
+            addr,
+            SessionState::Established,
+            None,
+            Arc::new(FakePeerCounters::default()),
+        ),
+    );
+    let mut events = mgr.policy_events_tx.subscribe();
+    mgr.publish_policy_config_event(
+        &ConfigEvent::SetNeighborImportChain {
+            address: addr,
+            policy_names: Vec::new(),
+            ack: None,
+        },
+        1,
+    );
+
+    let event = events.try_recv().unwrap();
+    assert_eq!(event.peer, Some(addr));
+    assert_eq!(event.peer_label.as_deref(), Some("fe80::2%eth0"));
 }
 
 /// Successful configured-peer installs publish their current admin event only


### PR DESCRIPTION
API service consistency batch (LAN-898): six findings from an external read-only review of `crates/api`, each verified against the code before acting. Four fixed, one fixed-for-parity, two documented as intentional.

## 1. Unbounded peer-manager reads — fixed

`peer_manager_read` awaited the actor reply with no deadline, so `ListPeers`/`GetPeerState`, gNMI Get/Subscribe peer snapshots, `ExplainImportPolicy`, and event-stream subscriptions hung behind a wedged actor until client cancel, while the neighbor service's RIB read was already bounded by `RIB_SNAPSHOT_TIMEOUT` (2 s). The shared helper now wraps send+reply in a 2-second timeout mapped to `DEADLINE_EXCEEDED`, bounding every caller at once. `rib_manager_read` deliberately stays unbounded at the helper (large-table RIB queries have no single fitting deadline; bounded callers wrap it), now documented on the function.

Test: `actor_read::tests::stalled_peer_manager_read_returns_deadline_exceeded` (written first, confirmed hanging past the outer guard pre-fix).

## 2. WatchRoutes swallowed broadcast lag — fixed

Confirmed: same broadcast source as `WatchRouteEvents`, but the `Lagged` arm returned `None` — the lag metric moved while the stream showed nothing. The proto can represent it additively: new `ROUTE_EVENT_TYPE_STREAM_LAGGED` enum value plus a synthetic marker `RouteEvent` carrying the missed count in `reason`, mirroring the `BGP_EVENT_TYPE_STREAM_LAGGED` contract. Expanding the finding across its seam: the `WatchEvents` policy and dataplane-aggregate arms had the same silent skip while their route/session/EVPN/BFD siblings emitted `stream_lag_bgp_event`; they now emit the marker too.

Tests: `watch_routes_lagged_subscriber_emits_marker_and_increments_metric`, `policy_lag_emits_missed_event_signal` (both written first, red against the swallow).

## 3. gNMI Set per-op results built from the request — intentional, documented

Verified what the bridge actually does: the whole `SetRequest` is applied as one candidate config through the ADR-0076 transaction controller (`apply_transaction_to_config` → single `ApplyConfigTransaction`), so Set is all-or-nothing — exactly what the gNMI spec requires of `Set`. On any failure the RPC returns a gRPC error and the pre-built response is discarded, so the all-success `UpdateResult` list is only ever sent when every operation applied; partial apply is unrepresentable by construction, not misreported. Documented on `set()` and `set_response_from_operations`. The failure path was already pinned by `set_hook_error_maps_to_grpc_status`; no per-op error plumbing invented.

## 4. gNMI Set lacked an explicit read-only guard — fixed

Confirmed: every other mutating service calls `read_only_rejection` in-service; Set relied on the authz layer's `sensitive_read` ceiling for `access_mode = "read_only"` listeners. `GnmiService` now carries the listener access mode and `set()` rejects read-only listeners explicitly with `PERMISSION_DENIED` before touching the handler. The dial-out handle, which only renders Subscribe snapshots, is constructed read-only. The `gnmi.gNMI/Set` → `operator_only` tier pin already exists in the authz tests and is unchanged; no methods added or removed, so `docs/grpc-method-inventory.md` needs no regeneration.

Test: `set_on_read_only_listener_is_rejected_before_hook`.

## 5. peer_address scoping split across event streams — fixed

Confirmed: lifecycle events rendered the scoped `address%interface` label while notification and policy events used bare `to_string()`, breaking cross-stream correlation for link-local peers. Both event types gain `peer_label`; the peer manager resolves it from the session's peer key (falling back to a unique address match) for notifications and from the targeted neighbor's key for policy events, and the converters (plus the notification reason string) prefer it with the same bare-address fallback lifecycle events use.

Tests: `notification_event_uses_scoped_peer_label_for_interface_scoped_peer` (written first, red on the bare address), `policy_event_uses_scoped_peer_label_for_interface_scoped_peer`, `notification_and_policy_events_render_scoped_peer_label`.

## 6. stream_plan_config_transaction missing the outer timeout_at — fixed for parity

Verified with a caveat: the detached planner wraps its async work (peer-manager send + reply) in `timeout_at(deadline, ...)` internally, so the reachable async paths already surfaced `DEADLINE_EXCEEDED` and a pre-fix failing test was not induceable without artificial injection. However, plan-token issuance runs outside that inner window (a blocking mutex), and a wedged or never-scheduled task would hang the RPC — the hole `StreamApplyConfigTransaction` already closes with its outer `timeout_at`. Wrapped for parity with matching error mapping.

Test: `plan_response_is_bounded_by_total_deadline_after_handoff` pins the post-handoff deadline behavior under a paused clock.

## 7. gNMI Get errors on absent neighbor, Subscribe returns empty — intentional, documented

Confirmed intentional (subscribe-before-up: a subscription opened before the peer exists, or across removal/re-add, must keep streaming once it appears; a one-shot Get for a missing neighbor is an addressing error). Documented at both sites: `render_neighbor_updates` (Get path) and `GnmiService::render_subscription_query` (Subscribe path), each pointing at the other.

## Gates

- `cargo fmt --all -- --check` — 0
- `cargo clippy --workspace --all-targets -- -D warnings` — 0
- `cargo test --workspace` — 0
- `cargo doc --workspace --no-deps` — 0
- `python3 scripts/check-clippy-reasons.py` — 0
- `cargo test -p rustbgpd-api authz` — 0 (43 passed; tier matrix unchanged)

Proto change is additive (new enum value + comments); codegen regenerated cleanly in-build.
