### PR TITLE
Low-severity sweep from the outside review: doctor freshness, FIB cancel persist, VRP withdraw cost, v1 journal note

### DIFF
--- a/crates/rpki/src/vrp_manager.rs
+++ b/crates/rpki/src/vrp_manager.rs
@@ -5,7 +5,7 @@
 //! snapshots. When either table changes, sends the updated snapshot to the
 //! RIB manager.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -32,8 +32,9 @@ pub struct AspaTableUpdate {
 
 /// Merges VRP and ASPA data from multiple RTR cache servers.
 pub struct VrpManager {
-    /// Per-server VRP entry sets.
-    server_tables: HashMap<SocketAddr, Vec<VrpEntry>>,
+    /// Per-server VRP entry sets. A set (not a list) so an incremental
+    /// withdraw is O(withdrawn) instead of O(withdrawn × table size).
+    server_tables: HashMap<SocketAddr, HashSet<VrpEntry>>,
     /// Per-server ASPA state, keyed by customer ASN.
     ///
     /// Keyed (not a record list) because 8210bis ASPA PDUs carry the
@@ -99,7 +100,8 @@ impl VrpManager {
                     aspa = aspa_records.len(),
                     "full table from cache"
                 );
-                self.server_tables.insert(server, entries);
+                self.server_tables
+                    .insert(server, entries.into_iter().collect());
                 // Later PDUs for the same customer ASN replace earlier
                 // ones within a full table (8210bis replacement semantics).
                 self.server_aspa_tables.insert(
@@ -128,7 +130,7 @@ impl VrpManager {
                 // VRP incremental
                 let table = self.server_tables.entry(server).or_default();
                 for w in &withdrawn {
-                    table.retain(|e| e != w);
+                    table.remove(w);
                 }
                 table.extend(announced);
 
@@ -155,6 +157,12 @@ impl VrpManager {
         self.rebuild_and_distribute_aspa().await;
     }
 
+    // Full rebuild (clone + sort of every entry) on every update, even a
+    // one-entry incremental. Fine at real-world shapes: RTR serial-notify
+    // deltas are tiny next to the ~600k-VRP global table, and rebuilds are
+    // O(total log total) on a single manager task off the hot path.
+    // ponytail: revisit with per-family incremental table maintenance only if
+    // caches ever stream high-rate deltas.
     async fn rebuild_and_distribute_vrp(&mut self) {
         let merged: Vec<VrpEntry> = self
             .server_tables

--- a/src/confirm_journal.rs
+++ b/src/confirm_journal.rs
@@ -283,6 +283,11 @@ pub fn boot_revert_check(
 /// Read the journal with a hard byte cap (LAN-221). Even if `metadata().len()`
 /// under-reports (a lying special file slipped past `is_file`, or the file grew
 /// after the size guard), never buffer more than the sanity cap.
+///
+/// Unlike the v2/v3 readers, this legacy lane does not re-verify the bytes
+/// read against the file's metadata length (changed-while-reading guard) —
+/// defense-in-depth only, deliberately not backported: the whole v1 recovery
+/// lane is scheduled for removal in v0.64 (ADR-0122 D1).
 fn read_journal_bounded(path: &Path) -> io::Result<String> {
     let mut reader = File::open(path)?.take(MAX_JOURNAL_BYTES + 1);
     let mut buf = String::new();

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -381,11 +381,19 @@ async fn run_loop<F>(
                             persist_owned_state(&config, &owned);
                             let _ = reply.send(Ok(()));
                         } else {
-                            // Revert and re-persist under the previous signature so
-                            // any still-owned routes stay adoptable on restart and
-                            // keep getting retried by the periodic reconcile.
+                            // Revert. A pre-plan bail (`!reached_apply`) never
+                            // touched `owned` and never persisted, so the on-disk
+                            // state is already correct — rewriting it would only
+                            // persist under a signature the reconcile never acted
+                            // on. The orphan case DID mutate owned state (and the
+                            // reconcile persisted it under the NEW signature), so
+                            // re-persist under the reverted signature to keep
+                            // still-owned routes adoptable on restart and retried
+                            // by the periodic reconcile.
                             config.tables = previous;
-                            persist_owned_state(&config, &owned);
+                            if reached_apply {
+                                persist_owned_state(&config, &owned);
+                            }
                             let _ = reply.send(Err(if reached_apply {
                                 "FIB table change left owned routes outside the new \
                                  set (a withdraw failed); reverted to keep them owned"
@@ -3409,6 +3417,52 @@ mod tests {
 
         assert!(statuses.is_empty());
         assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn replace_tables_pre_apply_bail_does_not_rewrite_owned_state() {
+        // A ReplaceTables whose reconcile bails before the apply phase (kernel
+        // dump failure here) leaves `owned` untouched, so the cancel path must
+        // not rewrite the owned-state file: persisting would stamp a signature
+        // the reconcile never acted on.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fib-owned.json");
+        let mut config = config();
+        config.owned_state_path = Some(path.clone());
+        let (rib_tx, _query_count, _events_tx) = rib_with_events(Vec::new());
+        let (status_tx, _status_rx) = watch::channel(Vec::new());
+        let (event_tx, _) = broadcast::channel(16);
+        let shutdown = CancellationToken::new();
+        let handle = spawn_with_fib(
+            config,
+            rib_tx.clone(),
+            rib_tx,
+            FakeFib {
+                fail_dump: Some("netlink unavailable".to_string()),
+                ..FakeFib::default()
+            },
+            metrics(),
+            status_tx,
+            event_tx,
+            shutdown.clone(),
+        );
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        handle
+            .command_sender()
+            .send(FibRuntimeCommand::ReplaceTables {
+                tables: vec![table("edge2", 1001, 200, &["ipv4_unicast"])],
+                reply: reply_tx,
+            })
+            .await
+            .unwrap();
+        let result = reply_rx.await.unwrap();
+        assert!(result.is_err(), "pre-apply bail must reject the swap");
+        assert!(
+            !path.exists(),
+            "pre-apply bail must not rewrite the owned-state file"
+        );
+        handle.shutdown().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
Resolves the four low-severity items from the outside read-only review. Each claim was verified against the current code before choosing a resolution.

## 1. Doctor `config_freshness_check` false-positive after SIGHUP — no change (claim stale)

The reviewed claim (config mtime compared against daemon start time) no longer describes the code. Since #1156, `config_freshness_check` compares against the daemon's own `config-last-persist` marker (`crates/cli/src/commands/doctor.rs`, `config_freshness_reference`). The marker is recorded by the persister's `record_last_persist` at every point the daemon's view of the file becomes current — boot, every durable write, and the SIGHUP snapshot refresh (`RefreshSnapshotNoPersist` → `record_current_history`, `src/config_persister.rs`) — so a SIGHUP-applied edit clears the warning without a restart. Process start is only the fallback for a daemon that wrote no marker, and that degraded mode is already documented at both the reader and the writer.

## 2. FIB `ReplaceTables` cancel-path persist — fixed

`src/fib_runtime.rs`: `reconcile_once_with_events` returns `false` only on a pre-plan bail (shutdown, RIB/peer-group query failure, kernel dump failure), and every owned-state mutation happens after that point in `apply_plan` — so when `reached_apply == false`, `owned` is untouched and nothing was persisted under the new signature. The cancel path now skips `persist_owned_state` in that case instead of rewriting the file under a table set the reconcile never acted on. The orphaned-withdraw revert keeps its persist: there the reconcile did mutate owned state (and persisted it under the new signature), and the re-persist under the reverted signature is what keeps still-owned routes adoptable on restart. Rolling back the owned mutations instead was rejected as unsafe — owned state mirrors what is actually in the kernel.

Test: `replace_tables_pre_apply_bail_does_not_rewrite_owned_state` drives a spawned actor's `ReplaceTables` into a kernel-dump failure and asserts the command is rejected and the owned-state file is not written. Verified red against the previous unconditional persist.

## 3. VRP incremental withdraw cost — fixed (index) + documented (rebuild)

`crates/rpki/src/vrp_manager.rs`: per-server tables are now `HashSet<VrpEntry>` (the type already derives `Hash`/`Eq`), so an incremental withdraw is O(withdrawn) instead of O(withdrawn × table_size); merged-table semantics are unchanged since `VrpTable::new` sorts and dedups regardless of source order. The full rebuild per update is retained and now carries a comment stating the shape at which it matters: RTR serial-notify deltas are tiny next to the ~600k-VRP global table, and the rebuild runs on a single manager task off the hot path. Existing incremental-withdraw tests pin the behavior.

## 4. Legacy v1 confirm-journal read — deferred to removal

`src/confirm_journal.rs` `read_journal_bounded`: the missing check is v2/v3's bytes-read-vs-metadata-length (changed-while-reading) guard — defense-in-depth only. ADR-0122 D1 records the v1 recovery lane's EOL as v0.64 ("delete the v1 recovery lane" in the v0.64 removal PR) and the removal has not slipped. A doc comment at the site now records why the guard is deliberately not backported and references the scheduled removal.

## Verification

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test --workspace` — exit 0
- `cargo doc --workspace --no-deps` — exit 0
- `python3 scripts/check-clippy-reasons.py` — exit 0
- `cargo check -p rustbgpd-rpki` from `crates/rpki` (standalone) — exit 0
