### PR TITLE
Capture the VPN query handler duration before sending the actor reply

### DIFF
--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2385,13 +2385,21 @@ impl RibManager {
                     self.loc_rib.iter_vpn().cloned().collect();
                 #[cfg(feature = "bench-internals")]
                 let (rows, capacity) = (routes.len(), routes.capacity());
+                // The handler duration must be captured BEFORE the reply is
+                // sent: once the reply lands, the service task can finish the
+                // whole RPC while this thread is preempted, and a
+                // capture-after-send handler time can exceed the caller's
+                // wall-clock measurement (the vpn_query bench subtracts the
+                // two and relies on strict nesting).
+                #[cfg(feature = "bench-internals")]
+                let handler_ns = u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
                 let _ = reply.send(routes);
                 #[cfg(feature = "bench-internals")]
                 if let Some(receipts) = &self.vpn_query_bench_receipts {
                     self.vpn_query_bench_dispatches =
                         self.vpn_query_bench_dispatches.saturating_add(1);
                     let _ = receipts.try_send((
-                        u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX),
+                        handler_ns,
                         rows,
                         capacity,
                         self.vpn_query_bench_dispatches,


### PR DESCRIPTION
## What broke

The `scale / receipt checks` job fails intermittently on main at 871ae0a1 in `bench/tests/test-vpn-query-receipt.sh`:

```
thread 'main' panicked at crates/api/benches/vpn_query.rs:323:14:
service_method_ns underflowed actor_handler_ns
```

The bench computes `post_actor_ns = service_method_ns.checked_sub(actor_ns)`, where `service_method_ns` is the bench's wall-clock measurement around the whole `list_vpn_routes` call and `actor_ns` is the RIB actor's self-reported handler duration.

## Why

This is a src-side instrumentation race in the bench-internals receipt, not a bench arithmetic problem and not a regression from #1485 (`list_vpn_routes` uses `rib_manager_read`, which #1485 left unbounded; the whole path is byte-identical before and after that merge).

In the `RibUpdate::QueryVpnRoutes` arm (`crates/rib/src/manager/mod.rs`), `started.elapsed()` was captured after `reply.send(routes)`. Once the reply lands, the service task can complete the entire RPC — filter, convert, return — while the actor thread sits preempted between the send and the elapsed capture, so the reported `actor_handler_ns` includes that scheduling gap and can exceed the caller's wall-clock measurement. CI pins the bench to a single CPU with `taskset -c`, which makes exactly this interleaving routine. The ordering dates to #1256; recent merges only changed the timing lottery.

The receipt verifier in `test-vpn-query-receipt.sh` independently asserts `service_method_ns >= actor_handler_ns` on the emitted JSON, so a bench-side `saturating_sub` would only have moved the failure into the shell verifier. The invariant itself is correct and must hold; the capture point was wrong.

## Fix

Capture the handler duration before sending the reply. The measured actor interval is then strictly nested inside the caller's measurement on the same monotonic clock, so the subtraction is valid deterministically. One measurement moved plus a comment; the bench's `checked_sub().expect(...)` stays as the pin on the restored invariant. `vpn_query_allocation` shares the same source file and the same actor receipt, so both bench targets are covered by this single change.

## Evidence

- Pre-fix: panic reproduced in 159 iterations of `vpn_query_timing smoke U`, pinned to one core with a competing spinner on the same core.
- Post-fix: 300/300 iterations pass under the same contention.
- `bash bench/tests/test-vpn-query-receipt.sh` (the failing CI step's bench gate, both timing and allocation targets) exits 0.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps`, `python3 scripts/check-clippy-reasons.py`, `cargo check -p rustbgpd-rib --features bench-internals --benches` all exit 0.
