### PR TITLE
Fix two EVPN convergence defects: Type 5 NotFound withdraws and unbounded IMET RIB acks

### DIFF
--- a/docs/adr/0102-evpn-origination-acknowledgement.md
+++ b/docs/adr/0102-evpn-origination-acknowledgement.md
@@ -154,7 +154,13 @@ the RIB, tracking emitted-but-unacknowledged operations explicitly.
   future-proofing, and the log/metric trail makes it diagnosable.
 - The actors do one extra map insert/remove per operation and hold a
   clone of each in-flight action — noise next to route construction.
-- Scope: Type 3 (IMET) and SVI publication keep their existing
-  shapes; they are config-derived, re-published on reconfiguration,
-  and were not part of the observed loss class. Extending the tracker
-  to them is mechanical if evidence appears.
+- Scope: SVI publication keeps its existing shape; it is
+  config-derived, re-published on reconfiguration, and was not part
+  of the observed loss class. Extending the tracker to it is
+  mechanical if evidence appears. Type 3 (IMET) routes its
+  inject/withdraw through the bounded `send_and_ack` wait — its
+  converge callers hold the IMET controller mutex across the ack
+  await, so an unbounded wait on a wedged RIB would lock every later
+  EVPN runtime converge out — but keeps its own outcome mapping (an
+  ack timeout reports `RibUnavailable`) rather than adopting the
+  pending-op tracker.

--- a/src/evpn_ack.rs
+++ b/src/evpn_ack.rs
@@ -1,8 +1,12 @@
 //! Acknowledgement-aware EVPN origination toward the RIB (ADR-0102).
 //!
 //! Shared by the local Type 2 MAC/MAC+IP originator
-//! ([`crate::evpn_originator`]) and the Ethernet Segment orchestrator's
-//! Type 1/4 publication ([`crate::evpn_segment`]). Both actors keep a
+//! ([`crate::evpn_originator`]), the Ethernet Segment orchestrator's
+//! Type 1/4 publication ([`crate::evpn_segment`]), and — for the
+//! bounded [`send_and_ack`] wait only, without the pending-op tracker —
+//! the Type 3 IMET controller ([`crate::evpn_imet`]), whose converge
+//! callers hold a mutex across the ack await and therefore must never
+//! wait unboundedly. The two tracker-backed actors keep a
 //! [`PendingRibOps`] tracker: every inject/withdraw sent to the RIB is
 //! recorded as *pending* under `(route identity, generation)` and only
 //! forgotten once the RIB's reply oneshot acknowledges it. A dropped
@@ -48,6 +52,12 @@ pub(crate) const RETRY_BACKOFF_BASE: Duration = Duration::from_secs(1);
 /// failure costs one attempt per 30s per route, not a hot loop.
 pub(crate) const RETRY_BACKOFF_MAX: Duration = Duration::from_secs(30);
 
+/// `NoAck` reason for a reply oneshot the RIB dropped without
+/// answering. A const (rather than an inline literal) so
+/// [`crate::evpn_imet`] can pattern-match it when mapping ack
+/// outcomes onto its caller-visible outcome enums.
+pub(crate) const NOACK_REPLY_DROPPED: &str = "reply dropped";
+
 /// Outcome of one inject/withdraw attempt against the RIB.
 #[derive(Debug)]
 pub(crate) enum RibAckOutcome {
@@ -82,7 +92,7 @@ pub(crate) async fn send_and_ack(
     match tokio::time::timeout(RIB_ACK_TIMEOUT, reply_rx).await {
         Ok(Ok(Ok(()))) => RibAckOutcome::Acked,
         Ok(Ok(Err(e))) => RibAckOutcome::Rejected(e),
-        Ok(Err(_)) => RibAckOutcome::NoAck("reply dropped"),
+        Ok(Err(_)) => RibAckOutcome::NoAck(NOACK_REPLY_DROPPED),
         Err(_) => RibAckOutcome::NoAck("ack timeout"),
     }
 }

--- a/src/evpn_imet.rs
+++ b/src/evpn_imet.rs
@@ -59,6 +59,8 @@ use rustbgpd_wire::{
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
+use crate::evpn_ack::{NOACK_REPLY_DROPPED, RibAckOutcome, send_and_ack};
+
 /// Result of asking the IMET controller to originate one VNI.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ImetOriginateOutcome {
@@ -72,7 +74,11 @@ pub enum ImetOriginateOutcome {
         /// Existing Type 3 route key.
         key: EvpnRouteKey,
     },
-    /// The RIB command channel closed before the inject could be sent.
+    /// The RIB command channel closed before the inject could be sent,
+    /// or the RIB failed to acknowledge it within the ADR-0102
+    /// [`crate::evpn_ack::RIB_ACK_TIMEOUT`]. The route is not tracked;
+    /// converge callers report a failure and may retry (the inject is
+    /// idempotent per key).
     RibUnavailable {
         /// Type 3 route key that would have been injected.
         key: EvpnRouteKey,
@@ -102,7 +108,10 @@ pub enum ImetWithdrawOutcome {
         /// Requested VNI.
         vni: EvpnInstanceId,
     },
-    /// The RIB command channel closed before the withdraw could be sent.
+    /// The RIB command channel closed before the withdraw could be sent,
+    /// or the RIB failed to acknowledge it within the ADR-0102
+    /// [`crate::evpn_ack::RIB_ACK_TIMEOUT`]. The key stays tracked so a
+    /// later converge retries the withdraw.
     RibUnavailable {
         /// Type 3 route key that would have been withdrawn.
         key: EvpnRouteKey,
@@ -234,31 +243,29 @@ async fn inject_imet_route(
     rib_tx: &mpsc::Sender<RibUpdate>,
 ) -> ImetOriginateOutcome {
     let key = route.key();
-    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-    if rib_tx
-        .send(RibUpdate::InjectEvpn {
-            route,
-            reply: reply_tx,
-        })
-        .await
-        .is_err()
-    {
-        warn!(?key, "RIB channel closed; cannot originate IMET");
-        return ImetOriginateOutcome::RibUnavailable { key };
-    }
-
-    match reply_rx.await {
-        Ok(Ok(())) => {
+    // ADR-0102 `send_and_ack` bounds the wait: converge callers hold the
+    // daemon's IMET controller mutex across this await, so an unbounded
+    // wait on a wedged RIB would hold that mutex forever and lock every
+    // later EVPN runtime converge out until restart.
+    match send_and_ack(rib_tx, |reply| RibUpdate::InjectEvpn { route, reply }).await {
+        RibAckOutcome::Acked => {
             debug!(?key, vni = vni.as_u32(), "originated Type 3 IMET");
             ImetOriginateOutcome::Originated { key }
         }
-        Ok(Err(e)) => {
+        RibAckOutcome::Rejected(e) => {
             warn!(?key, vni = vni.as_u32(), error = %e, "RIB rejected IMET inject");
             ImetOriginateOutcome::Rejected { key }
         }
-        Err(_) => {
+        RibAckOutcome::NoAck(NOACK_REPLY_DROPPED) => {
             warn!(?key, vni = vni.as_u32(), "RIB IMET inject reply dropped");
             ImetOriginateOutcome::ReplyDropped { key }
+        }
+        // Channel closed or ack timeout: the RIB is unavailable as far as
+        // this converge is concerned — report a real failure rather than
+        // claiming success against a wedged RIB.
+        RibAckOutcome::NoAck(reason) => {
+            warn!(?key, vni = vni.as_u32(), reason, "cannot originate IMET");
+            ImetOriginateOutcome::RibUnavailable { key }
         }
     }
 }
@@ -267,20 +274,10 @@ async fn withdraw_imet_key(
     key: EvpnRouteKey,
     rib_tx: &mpsc::Sender<RibUpdate>,
 ) -> ImetWithdrawOutcome {
-    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-    if rib_tx
-        .send(RibUpdate::WithdrawEvpn {
-            key,
-            reply: reply_tx,
-        })
-        .await
-        .is_err()
-    {
-        warn!(?key, "RIB channel closed; cannot withdraw IMET");
-        return ImetWithdrawOutcome::RibUnavailable { key };
-    }
-    match reply_rx.await {
-        Ok(Ok(())) => {
+    // Bounded for the same converge-holds-the-mutex reason as
+    // [`inject_imet_route`].
+    match send_and_ack(rib_tx, |reply| RibUpdate::WithdrawEvpn { key, reply }).await {
+        RibAckOutcome::Acked => {
             debug!(?key, "withdrew Type 3 IMET");
             ImetWithdrawOutcome::Withdrawn { key }
         }
@@ -291,7 +288,7 @@ async fn withdraw_imet_key(
         // the RIB doesn't hold makes the VNI permanently un-deletable and
         // un-redefinable: re-origination short-circuits on AlreadyOriginated
         // and every later delete/redefine converge rejects until restart.
-        Ok(Err(rustbgpd_rib::RibCommandError::NotFound(message))) => {
+        RibAckOutcome::Rejected(rustbgpd_rib::RibCommandError::NotFound(message)) => {
             warn!(
                 ?key,
                 %message,
@@ -299,13 +296,17 @@ async fn withdraw_imet_key(
             );
             ImetWithdrawOutcome::Withdrawn { key }
         }
-        Ok(Err(e)) => {
+        RibAckOutcome::Rejected(e) => {
             debug!(?key, error = %e, "RIB IMET withdraw declined");
             ImetWithdrawOutcome::Rejected { key }
         }
-        Err(_) => {
+        RibAckOutcome::NoAck(NOACK_REPLY_DROPPED) => {
             warn!(?key, "RIB IMET withdraw reply dropped");
             ImetWithdrawOutcome::ReplyDropped { key }
+        }
+        RibAckOutcome::NoAck(reason) => {
+            warn!(?key, reason, "cannot withdraw IMET");
+            ImetWithdrawOutcome::RibUnavailable { key }
         }
     }
 }
@@ -738,6 +739,104 @@ mod tests {
         );
         drop(rib_tx);
         responder.await.unwrap();
+    }
+
+    /// Regression: converge paths (`converge_l2vni_add` / `_swap` /
+    /// `_redefine` / `_delete`) hold the daemon's IMET controller mutex
+    /// across the RIB ack await. A wedged RIB — command received, reply
+    /// neither sent nor dropped — previously parked that await forever,
+    /// holding the mutex and locking every later EVPN runtime converge out
+    /// until restart. The ADR-0102 `send_and_ack` timeout bounds the await;
+    /// the timeout maps to `RibUnavailable` so the converge reports a real
+    /// failure instead of claiming success.
+    #[tokio::test(start_paused = true)]
+    async fn stalled_rib_originate_releases_controller_lock_at_ack_timeout() {
+        let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(8);
+        let controller = Arc::new(tokio::sync::Mutex::new(EvpnImetController::new()));
+
+        // First converge: lock the controller across the originate await,
+        // exactly like converge_l2vni_add does.
+        let converge = {
+            let controller = controller.clone();
+            let rib_tx = rib_tx.clone();
+            tokio::spawn(async move {
+                controller
+                    .lock()
+                    .await
+                    .originate_instance(local_instance(100), &rib_tx)
+                    .await
+            })
+        };
+
+        // Wedged RIB: receive the inject but never answer — keep the reply
+        // sender alive (dropping it would signal "reply dropped" instead).
+        let parked_reply = match rib_rx.recv().await.expect("inject reaches the RIB") {
+            RibUpdate::InjectEvpn { reply, .. } => reply,
+            _other => panic!("expected InjectEvpn"),
+        };
+
+        // Second converge attempt: must acquire the lock once the ack
+        // timeout releases the first holder.
+        let second = tokio::time::timeout(
+            crate::evpn_ack::RIB_ACK_TIMEOUT + std::time::Duration::from_secs(1),
+            controller.lock(),
+        )
+        .await;
+        assert!(
+            second.is_ok(),
+            "a stalled RIB must not hold the IMET controller lock past the ack timeout"
+        );
+        drop(second);
+
+        let outcome = converge.await.unwrap();
+        assert!(
+            matches!(outcome, ImetOriginateOutcome::RibUnavailable { .. }),
+            "ack timeout must surface as a converge failure, got {outcome:?}"
+        );
+        assert!(
+            controller.lock().await.is_empty(),
+            "an unacknowledged originate must not be tracked"
+        );
+        drop(parked_reply);
+    }
+
+    /// Same wedged-RIB bound for the withdraw path: the ack timeout maps to
+    /// `RibUnavailable` and the key stays tracked so a later converge can
+    /// retry the withdraw.
+    #[tokio::test(start_paused = true)]
+    async fn stalled_rib_withdraw_times_out_as_rib_unavailable() {
+        let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(8);
+        let mut controller = EvpnImetController::new();
+
+        let (outcome, ()) = tokio::join!(
+            controller.originate_instance(local_instance(100), &rib_tx),
+            async {
+                if let Some(RibUpdate::InjectEvpn { reply, .. }) = rib_rx.recv().await {
+                    let _ = reply.send(Ok(()));
+                }
+            }
+        );
+        let ImetOriginateOutcome::Originated { key } = outcome else {
+            panic!("expected originate, got {outcome:?}");
+        };
+
+        let (outcome, _parked_reply) =
+            tokio::join!(controller.withdraw_instance(vni(100), &rib_tx), async {
+                match rib_rx.recv().await.expect("withdraw reaches the RIB") {
+                    RibUpdate::WithdrawEvpn { reply, .. } => reply,
+                    _other => panic!("expected WithdrawEvpn"),
+                }
+            });
+        assert_eq!(
+            outcome,
+            ImetWithdrawOutcome::RibUnavailable { key },
+            "withdraw ack timeout must report RibUnavailable, not hang"
+        );
+        assert_eq!(
+            controller.originated_key(vni(100)),
+            Some(key),
+            "an unacknowledged withdraw must keep the key tracked for retry"
+        );
     }
 
     #[tokio::test]

--- a/src/evpn_l3_originator.rs
+++ b/src/evpn_l3_originator.rs
@@ -67,8 +67,8 @@ use rustbgpd_evpn::{
     EvpnIpPrefixValue, IpVrf, IpVrfDataplaneStatus, IpVrfId, IpVrfTable, LocalIpRouteObservation,
     RouteSource,
 };
-use rustbgpd_rib::RibUpdate;
 use rustbgpd_rib::route::{EvpnRibRoute, RouteOrigin};
+use rustbgpd_rib::{RibCommandError, RibUpdate};
 use rustbgpd_telemetry::BgpMetrics;
 use rustbgpd_wire::EvpnRouteKey;
 use tokio::sync::{mpsc, oneshot, watch};
@@ -699,10 +699,12 @@ async fn inject_one(
 }
 
 /// Issue a `WithdrawEvpn` over the RIB channel and wait for the
-/// acknowledgement. Returns `true` only when the RIB replied
-/// `Ok(())`. Callers must keep the entry in their in-memory
-/// `originated` map when this returns `false` so the next reconcile
-/// pass retries.
+/// acknowledgement. Returns `true` when the RIB replied `Ok(())` —
+/// or `NotFound`, which means the route is already absent (exactly
+/// the state the withdraw wanted, e.g. after a prior withdraw whose
+/// oneshot reply was dropped). Callers must keep the entry in their
+/// in-memory `originated` map when this returns `false` so the next
+/// reconcile pass retries.
 async fn withdraw_one(
     rib_tx: &mpsc::Sender<RibUpdate>,
     vrf_id: IpVrfId,
@@ -723,6 +725,24 @@ async fn withdraw_one(
     }
     match reply_rx.await {
         Ok(Ok(())) => {
+            counts.dec(vrf_id);
+            true
+        }
+        // The RIB doesn't hold this key: the route is already gone
+        // (e.g. a prior withdraw whose oneshot reply was dropped).
+        // Converge to RIB reality — untrack and decrement — instead of
+        // treating it as a failure: a `false` here keeps the entry in
+        // `originated` and every later reconcile retries the withdraw,
+        // gets `NotFound`, and fails forever. In the key-change branch
+        // of `originate_one` that also blocks re-origination of the
+        // new key, so the VRF's Type 5 route never updates. Mirrors
+        // the Type 2 (`rib_write`) and IMET NotFound handling.
+        Ok(Err(RibCommandError::NotFound(message))) => {
+            warn!(
+                %message,
+                vrf_id = ?vrf_id,
+                "L3 originator: withdraw target already absent — treating as withdrawn"
+            );
             counts.dec(vrf_id);
             true
         }
@@ -974,6 +994,17 @@ mod tests {
     enum ReplyMode {
         Ok,
         Reject,
+        NotFound,
+    }
+
+    impl ReplyMode {
+        fn response(self) -> Result<(), RibCommandError> {
+            match self {
+                ReplyMode::Ok => Ok(()),
+                ReplyMode::Reject => Err(RibCommandError::internal("test rejection")),
+                ReplyMode::NotFound => Err(RibCommandError::not_found("EVPN route key not found")),
+            }
+        }
     }
 
     /// Spawn a RIB-channel responder that records every Inject /
@@ -994,19 +1025,11 @@ mod tests {
                     RibUpdate::InjectEvpn { route, reply } => {
                         let key = route.key();
                         calls.push(RibCall::Inject(key));
-                        let response = match mode.inject {
-                            ReplyMode::Ok => Ok(()),
-                            ReplyMode::Reject => Err(RibCommandError::internal("test rejection")),
-                        };
-                        let _ = reply.send(response);
+                        let _ = reply.send(mode.inject.response());
                     }
                     RibUpdate::WithdrawEvpn { key, reply } => {
                         calls.push(RibCall::Withdraw(key));
-                        let response = match mode.withdraw {
-                            ReplyMode::Ok => Ok(()),
-                            ReplyMode::Reject => Err(RibCommandError::internal("test rejection")),
-                        };
-                        let _ = reply.send(response);
+                        let _ = reply.send(mode.withdraw.response());
                     }
                     _other => {
                         calls.push(RibCall::Other);
@@ -1676,6 +1699,127 @@ mod tests {
                 .iter()
                 .filter(|c| matches!(c, RibCall::Withdraw(_)))
                 .all(|c| matches!(c, RibCall::Withdraw(k) if *k == predicted)),
+        );
+    }
+
+    /// Regression: a withdraw the RIB answers with `NotFound` must converge
+    /// the originator to RIB reality — untrack the entry and decrement the
+    /// per-VRF count exactly once — instead of treating it as a failure.
+    /// The RIB doesn't hold the key when the route is already gone (e.g. a
+    /// prior withdraw whose oneshot reply was dropped); keeping the entry
+    /// meant every later reconcile retried the withdraw, got `NotFound`,
+    /// and returned false forever. Mirrors the IMET regression
+    /// `controller_untracks_key_when_withdraw_not_found`.
+    #[tokio::test]
+    async fn withdraw_not_found_untracks_entry_and_decrements_count_once() {
+        let v = vrf(100, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+        let predicted = predicted_key(&v, observation(100, [10, 1, 0, 0], 24).prefix);
+        let mut h = Harness::with_responder_mode(
+            vec![v],
+            RibResponderMode {
+                inject: ReplyMode::Ok,
+                withdraw: ReplyMode::NotFound,
+            },
+        );
+
+        h.status_tx.send_replace(vec![ready_status(100)]);
+        let mut obs_map = HashMap::new();
+        obs_map.insert(
+            IpVrfId::new(100).unwrap(),
+            vec![observation(100, [10, 1, 0, 0], 24)],
+        );
+        h.obs_tx.send_replace(Arc::new(obs_map));
+        let originated = Harness::drive_one(BTreeMap::new(), &mut h.cfg).await;
+        assert_eq!(originated.len(), 1);
+        assert_eq!(h.cfg.originated_counts.count(IpVrfId::new(100).unwrap()), 1);
+
+        // Observation disappears; the RIB answers the withdraw `NotFound`
+        // (the route is already gone). Absence is the withdraw's goal.
+        let mut empty_map = HashMap::new();
+        empty_map.insert(IpVrfId::new(100).unwrap(), vec![]);
+        h.obs_tx.send_replace(Arc::new(empty_map));
+        let originated = Harness::drive_one(originated, &mut h.cfg).await;
+        assert!(
+            originated.is_empty(),
+            "NotFound withdraw must untrack the entry, not retry forever"
+        );
+        assert_eq!(
+            h.cfg.originated_counts.count(IpVrfId::new(100).unwrap()),
+            0,
+            "NotFound withdraw must decrement the per-VRF count"
+        );
+
+        // A further pass must not retry the withdraw or touch the count.
+        let originated = Harness::drive_one(originated, &mut h.cfg).await;
+        assert!(originated.is_empty());
+        assert_eq!(
+            h.cfg.originated_counts.count(IpVrfId::new(100).unwrap()),
+            0,
+            "the count must be decremented exactly once"
+        );
+        let calls = h.collect_calls().await;
+        assert_eq!(
+            calls,
+            vec![RibCall::Inject(predicted), RibCall::Withdraw(predicted)],
+            "exactly one withdraw — no NotFound retry loop"
+        );
+    }
+
+    /// Regression for the key-change branch of `originate_one`: when the
+    /// stale key's withdraw answers `NotFound`, the originator must still
+    /// re-originate the NEW key. Treating `NotFound` as a failure blocked
+    /// the re-injection forever, so the VRF's Type 5 route never updated.
+    #[tokio::test]
+    async fn redefine_withdraw_not_found_reinjects_new_key() {
+        let old = vrf(100, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+        let new = redefined_vrf(100, 999, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+        let prefix = observation(100, [10, 1, 0, 0], 24).prefix;
+        let old_key = predicted_key(&old, prefix);
+        let new_key = predicted_key(&new, prefix);
+        let mut h = Harness::with_responder_mode(
+            vec![old],
+            RibResponderMode {
+                inject: ReplyMode::Ok,
+                withdraw: ReplyMode::NotFound,
+            },
+        );
+
+        h.status_tx.send_replace(vec![ready_status(100)]);
+        let mut obs_map = HashMap::new();
+        obs_map.insert(
+            IpVrfId::new(100).unwrap(),
+            vec![observation(100, [10, 1, 0, 0], 24)],
+        );
+        h.obs_tx.send_replace(Arc::new(obs_map));
+        let originated = Harness::drive_one(BTreeMap::new(), &mut h.cfg).await;
+
+        // Redefine the VRF (new RD → new key). The stale key's withdraw
+        // answers NotFound; the new key must still be injected.
+        let mut redefined = IpVrfTable::new();
+        redefined.insert(new).unwrap();
+        h.cfg.ip_vrfs = Arc::new(redefined);
+        let originated = Harness::drive_one(originated, &mut h.cfg).await;
+
+        assert_eq!(
+            originated
+                .get(&(IpVrfId::new(100).unwrap(), prefix))
+                .map(|e| e.key),
+            Some(new_key),
+            "NotFound on the stale key must not block re-origination of the new key"
+        );
+        assert_eq!(
+            h.cfg.originated_counts.count(IpVrfId::new(100).unwrap()),
+            1,
+            "one dec for the absent stale key, one inc for the new inject"
+        );
+        let calls = h.collect_calls().await;
+        assert_eq!(
+            calls,
+            vec![
+                RibCall::Inject(old_key),
+                RibCall::Withdraw(old_key),
+                RibCall::Inject(new_key),
+            ]
         );
     }
 


### PR DESCRIPTION
Two EVPN convergence robustness defects, both in the "the RIB's reply never confirms what actually happened" class.

## 1. Type 5 originator: `NotFound` withdraw replies retried forever

**Problem.** `withdraw_one` in `src/evpn_l3_originator.rs` treated every RIB error reply as a transient failure. A withdraw the RIB applied but whose oneshot reply was dropped left the entry stuck in `originated`: every later reconcile retried the withdraw, got `RibCommandError::NotFound`, and returned false forever. In the key-change branch of `originate_one` this also blocked re-origination of the new key, so a redefined IP-VRF's Type 5 route never updated; `drain_all` leaked the per-VRF originated count the same way. The Type 2 originator (`evpn_originator::rib_write`) and the IMET controller both already converge on `NotFound`.

**Fix.** Handle `NotFound` in `withdraw_one` — the single path all four withdraw sites (reconcile phase 1, the key-change branch, `drain_changed_ip_vrfs`, `drain_all`) route through. Absence is the withdraw's goal: untrack the entry and decrement the per-VRF count exactly once.

**Evidence.** New regression tests, both red before the fix:

- `withdraw_not_found_untracks_entry_and_decrements_count_once` — failed with `NotFound withdraw must untrack the entry, not retry forever`.
- `redefine_withdraw_not_found_reinjects_new_key` — failed with `NotFound on the stale key must not block re-origination of the new key` (entry pinned to the old-RD key, new key never injected).

## 2. IMET: unbounded RIB awaits held under the controller mutex

**Problem.** `inject_imet_route` / `withdraw_imet_key` in `src/evpn_imet.rs` awaited the RIB reply oneshot with no bound, and every EVPN runtime converge path (`converge_l2vni_add`/`_swap`/`_redefine`/`_delete`, `rollback_imet_redefine`) holds the daemon's `imet_controller` mutex across that await. A wedged RIB actor — command received, reply never sent — held the mutex forever and locked every subsequent EVPN runtime converge out until restart. The ADR-0102 `send_and_ack` helper bounds exactly this pattern and was already used by the Type 2 originator and the ES orchestrator; IMET was never migrated.

**Fix.** Route both IMET operations through `send_and_ack` (`RIB_ACK_TIMEOUT` = 5 s). An ack timeout or closed channel maps to `RibUnavailable`, so the converge reports a real failure instead of claiming success: an unacknowledged originate stays untracked (the inject is idempotent per key on converge retry) and an unacknowledged withdraw keeps its key tracked for retry. A dropped reply keeps its existing `ReplyDropped` semantics via the shared `NOACK_REPLY_DROPPED` reason. The ADR-0102 scope note is updated to match.

**Evidence.** New regression tests, both red before the fix:

- `stalled_rib_originate_releases_controller_lock_at_ack_timeout` — mirrors the converger's lock-across-await pattern; failed with `a stalled RIB must not hold the IMET controller lock past the ack timeout`.
- `stalled_rib_withdraw_times_out_as_rib_unavailable` — hung indefinitely before the fix (no timer to fire); now resolves as `RibUnavailable` with the key still tracked.

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test --workspace` — exit 0 (96/96 targets)
- `cargo doc --workspace --no-deps` — exit 0
- `python3 scripts/check-clippy-reasons.py` — exit 0
