### PR TITLE
Fix low-severity defect batch (LAN-906)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   mismatch, manifest/input binding, achieved-overlap drift, grouped-bound
   violations, and mismatched received-view scenarios.
 
+- `bmp_loc_rib_source_drops_total{event, reason}`: RFC 9069 Loc-RIB
+  events (route monitoring, periodic stats) dropped at the
+  RIB/PeerManager→BmpManager channel. This path previously only warned;
+  `bmp_source_drops_total` covers only the PeerSession→BmpManager path.
+
 ### Changed
 
 - GTSM (RFC 5082) now enforces strict TTL/Hop-Limit 255 on receive
@@ -47,6 +52,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Low-severity defect batch (LAN-906): a staged config write no longer
+  leaks its secret-bearing temp file when the publishing rename or
+  directory fsync fails (`StagedWrite` now removes the temp file on every
+  non-publishing path); `bmp_collector_drops_total` counts the held-back
+  live Loc-RIB messages discarded by a failed dump alongside the dump
+  stream itself instead of undercounting by up to the buffer size;
+  deleting a peer group referenced only by a `[[dynamic_neighbors]]`
+  range is now refused with `StillReferenced` instead of silently
+  orphaning the range; and collector-labeled BMP counter series
+  (`bmp_collector_drops_total`, `bmp_replay_attempts_total`,
+  `bmp_control_event_drops_total`) are reaped on BMP manager teardown
+  like the live-buffer gauges already were.
 - API service consistency batch (LAN-898): every peer-manager read now
   carries a 2-second server-side deadline (`DEADLINE_EXCEEDED` instead of
   hanging `ListPeers`/`GetPeerState`, gNMI Get/Subscribe snapshots, and

--- a/crates/bmp/src/manager.rs
+++ b/crates/bmp/src/manager.rs
@@ -905,11 +905,14 @@ impl BmpManager {
         self.metrics.clear_bmp_loc_rib_dump_live_buffer(&addr_label);
         if let DumpOutcome::Failed(failure) = done.outcome {
             self.loc_rib_suppressed.insert(done.collector_id);
+            // The discarded held-back live messages are real drops too:
+            // count them alongside what the failure itself lost.
+            let buffered_dropped = u64::try_from(dump.buffered.len()).unwrap_or(u64::MAX);
             self.metrics.record_bmp_collector_drop(
                 &addr_label,
                 "loc_rib_dump",
                 failure.reason(),
-                failure.dropped(),
+                failure.dropped().saturating_add(buffered_dropped),
             );
             warn!(
                 collector = %collector.addr,
@@ -1057,8 +1060,9 @@ impl BmpManager {
 impl Drop for BmpManager {
     fn drop(&mut self) {
         for collector in &self.collectors {
-            self.metrics
-                .reap_bmp_loc_rib_dump_live_buffer(&collector.addr.to_string());
+            let addr_label = collector.addr.to_string();
+            self.metrics.reap_bmp_loc_rib_dump_live_buffer(&addr_label);
+            self.metrics.reap_bmp_collector_series(&addr_label);
         }
     }
 }
@@ -1877,7 +1881,7 @@ mod tests {
             .map_or(0, |m| m.gauge.value() as i64)
     }
 
-    fn gauge_series_exists(metrics: &BgpMetrics, name: &str, collector: SocketAddr) -> bool {
+    fn collector_series_exists(metrics: &BgpMetrics, name: &str, collector: SocketAddr) -> bool {
         metrics.registry().gather().into_iter().any(|f| {
             f.name() == name
                 && f.metric.iter().any(|m| {
@@ -1925,7 +1929,7 @@ mod tests {
         let (bad_sender, _bad_receiver) = mpsc::channel(1);
         let (bad_bootstrap, _bad_bootstrap_rx) = tokio::sync::oneshot::channel();
         manager.handle_collector_connected(0, collector_addr(1), bad_sender, bad_bootstrap);
-        assert!(!gauge_series_exists(
+        assert!(!collector_series_exists(
             &metrics,
             "bmp_loc_rib_dump_live_buffer_depth",
             addr
@@ -1968,6 +1972,12 @@ mod tests {
         metrics.reset_bmp_loc_rib_dump_live_buffer(&addr1.to_string());
         metrics.observe_bmp_loc_rib_dump_live_buffer(&addr0.to_string(), 3);
         metrics.observe_bmp_loc_rib_dump_live_buffer(&addr1.to_string(), 5);
+        for addr in [addr0, addr1] {
+            let label = addr.to_string();
+            metrics.record_bmp_collector_drop(&label, "fan_out", "channel_full", 1);
+            metrics.record_bmp_replay_attempt(&label);
+            metrics.record_bmp_control_event_drop(&label, "collector_connected", "channel_full");
+        }
         let (_event_tx, event_rx) = mpsc::channel(1);
         let (_control_tx, control_rx) = mpsc::channel(1);
         let manager = BmpManager::new(
@@ -1982,9 +1992,12 @@ mod tests {
         for name in [
             "bmp_loc_rib_dump_live_buffer_depth",
             "bmp_loc_rib_dump_live_buffer_high_watermark",
+            "bmp_collector_drops_total",
+            "bmp_replay_attempts_total",
+            "bmp_control_event_drops_total",
         ] {
-            assert!(!gauge_series_exists(&metrics, name, addr0));
-            assert!(gauge_series_exists(&metrics, name, addr1));
+            assert!(!collector_series_exists(&metrics, name, addr0), "{name}");
+            assert!(collector_series_exists(&metrics, name, addr1), "{name}");
         }
         assert_eq!(
             gauge_value(&metrics, "bmp_loc_rib_dump_live_buffer_depth", addr1),
@@ -2004,7 +2017,7 @@ mod tests {
             vec![(addr, loc_rib_filter(), BmpVersion::V3)],
             metrics.clone(),
         ));
-        assert!(!gauge_series_exists(
+        assert!(!collector_series_exists(
             &metrics,
             "bmp_loc_rib_dump_live_buffer_depth",
             addr
@@ -2917,25 +2930,21 @@ mod tests {
             .unwrap();
         wait_until_received(&event_tx, 16).await;
         drop(request.reply);
-        for _ in 0..40 {
-            if metric_value_with_labels(
-                &metrics,
-                "bmp_collector_drops_total",
-                &[("phase", "loc_rib_dump"), ("reason", "reply_closed")],
-            ) == 1
-            {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
-        assert_eq!(
+        // One dropped dump stream plus one discarded held-back live message.
+        let dump_drops = || {
             metric_value_with_labels(
                 &metrics,
                 "bmp_collector_drops_total",
                 &[("phase", "loc_rib_dump"), ("reason", "reply_closed")],
-            ),
-            1
-        );
+            )
+        };
+        for _ in 0..40 {
+            if dump_drops() == 2 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(dump_drops(), 2);
         assert_live_buffer_gauges(&metrics, collector_addr(0), 0, 1);
         event_tx
             .send(BmpEvent::LocRibRouteMonitoring {

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1290,6 +1290,12 @@ impl RibManager {
             timestamp,
             path_status,
         }) {
+            let reason = match e {
+                tokio::sync::mpsc::error::TrySendError::Full(_) => "channel_full",
+                tokio::sync::mpsc::error::TrySendError::Closed(_) => "channel_closed",
+            };
+            self.metrics
+                .record_bmp_loc_rib_source_drop("route_monitoring", reason);
             warn!(error = %e, "BMP event channel full or closed, dropping Loc-RIB route monitoring");
         }
     }

--- a/crates/rpki/src/rtr_client.rs
+++ b/crates/rpki/src/rtr_client.rs
@@ -788,6 +788,11 @@ impl RtrClient {
             // are only collected once it is set.
             let mut pending_session: Option<u16> = None;
             let mut records: usize = 0;
+            // PDUs are split by flag bit; wire order within the transaction
+            // is discarded. Safe against a correct cache, which sends net
+            // deltas per serial (RFC 8210) — the VRP manager applies all
+            // withdrawals before all announcements, so an "announce X then
+            // withdraw X" pair in one serial would resolve to X present.
             let mut announced = Vec::new();
             let mut withdrawn = Vec::new();
             let mut aspa_announced: Vec<AspaRecord> = Vec::new();

--- a/crates/rpki/src/vrp_manager.rs
+++ b/crates/rpki/src/vrp_manager.rs
@@ -127,7 +127,13 @@ impl VrpManager {
                     aspa_withdrawn = aspa_withdrawn.len(),
                     "incremental update from cache"
                 );
-                // VRP incremental
+                // VRP incremental. Withdrawals apply before announcements —
+                // wire order within the serial was already discarded by the
+                // RTR client's flag-bit split. This assumes the cache sends
+                // net deltas per serial (RFC 8210 semantics); a pathological
+                // "announce X then withdraw X" in one serial would leave X
+                // present. Robustness-only: correct caches never send both
+                // sides for one record in one serial.
                 let table = self.server_tables.entry(server).or_default();
                 for w in &withdrawn {
                     table.remove(w);

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -185,8 +185,11 @@ thread_local! {
 /// **Adding a `peer`-labeled Vec metric?** Add it to the reap list in
 /// [`Self::reap_peer_series`] too, so the series are removed when the
 /// peer is deleted. Families without a `peer` label are process-global
-/// (or keyed by another identity such as VNI, VRF, or BMP collector)
-/// and are intentionally not reaped.
+/// (or keyed by another identity such as VNI or VRF) and are
+/// intentionally not reaped — except `collector`-labeled BMP families,
+/// which [`Self::reap_bmp_collector_series`] and
+/// [`Self::reap_bmp_loc_rib_dump_live_buffer`] remove on BMP manager
+/// teardown.
 #[derive(Debug, Clone)]
 pub struct BgpMetrics {
     registry: Registry,
@@ -392,6 +395,7 @@ pub struct BgpMetrics {
 
     // ── BMP exporter ───────────────────────────────────────────
     bmp_source_drops: IntCounterVec,
+    bmp_loc_rib_source_drops: IntCounterVec,
     bmp_collector_drops: IntCounterVec,
     bmp_replay_attempts: IntCounterVec,
     bmp_control_event_drops: IntCounterVec,
@@ -1792,6 +1796,15 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        let bmp_loc_rib_source_drops = IntCounterVec::new(
+            Opts::new(
+                "bmp_loc_rib_source_drops_total",
+                "RFC 9069 Loc-RIB events dropped at the RIB/PeerManager→BmpManager channel, by event (route_monitoring, stats) and bounded reason (channel_full, channel_closed)",
+            ),
+            &["event", "reason"],
+        )
+        .expect("valid metric definition");
+
         let bmp_collector_drops = IntCounterVec::new(
             Opts::new(
                 "bmp_collector_drops_total",
@@ -2354,6 +2367,9 @@ impl BgpMetrics {
             .register(Box::new(bmp_source_drops.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(bmp_loc_rib_source_drops.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(bmp_collector_drops.clone()))
             .expect("metric not already registered");
         registry
@@ -2554,6 +2570,7 @@ impl BgpMetrics {
             evpn_foreign_nhid_range_conflicts,
             evpn_runtime_decomposed_fail_stops,
             bmp_source_drops,
+            bmp_loc_rib_source_drops,
             bmp_collector_drops,
             bmp_replay_attempts,
             bmp_control_event_drops,
@@ -2697,19 +2714,27 @@ impl BgpMetrics {
         let _ = self.peer_session_established.remove_label_values(labels);
     }
 
-    /// Remove every series of one Vec metric whose `peer` label equals
-    /// `peer`.
+    fn reap_peer_series_from_vec<T: prometheus::core::MetricVecBuilder>(
+        vec: &prometheus::core::MetricVec<T>,
+        peer: &str,
+    ) {
+        Self::reap_label_series_from_vec(vec, "peer", peer);
+    }
+
+    /// Remove every series of one Vec metric whose `label` label equals
+    /// `value`.
     ///
     /// The prometheus crate has no wildcard removal —
     /// `remove_label_values` needs the exact, complete label-value
     /// tuple in the declared label order. So: collect the family proto,
-    /// select the metrics whose `peer` label matches, rebuild each full
+    /// select the metrics whose `label` label matches, rebuild each full
     /// tuple in the order of the family's declared `variable_labels`
     /// (the proto sorts label pairs by name, which may differ), and
     /// remove them one by one.
-    fn reap_peer_series_from_vec<T: prometheus::core::MetricVecBuilder>(
+    fn reap_label_series_from_vec<T: prometheus::core::MetricVecBuilder>(
         vec: &prometheus::core::MetricVec<T>,
-        peer: &str,
+        label: &str,
+        value: &str,
     ) {
         use prometheus::core::Collector;
 
@@ -2722,7 +2747,7 @@ impl BgpMetrics {
                 let labels = metric.get_label();
                 if !labels
                     .iter()
-                    .any(|label| label.name() == "peer" && label.value() == peer)
+                    .any(|pair| pair.name() == label && pair.value() == value)
                 {
                     continue;
                 }
@@ -4306,6 +4331,16 @@ impl BgpMetrics {
             .inc();
     }
 
+    /// Record an RFC 9069 Loc-RIB event dropped at the
+    /// RIB/PeerManager→BmpManager channel. `event` is `route_monitoring`
+    /// or `stats`; `reason` is `channel_full` or `channel_closed`. Both
+    /// label sets are bounded, so this family needs no reaping.
+    pub fn record_bmp_loc_rib_source_drop(&self, event: &str, reason: &str) {
+        self.bmp_loc_rib_source_drops
+            .with_label_values(&[event, reason])
+            .inc();
+    }
+
     /// Record `count` BMP messages dropped at the BmpManager→BmpClient
     /// channel. `count = 1` for fan-out drops; replay aborts pass the
     /// remaining cached-PeerUp count so an early break still surfaces
@@ -4379,6 +4414,18 @@ impl BgpMetrics {
         let _ = self
             .bmp_loc_rib_dump_live_buffer_high_watermark
             .remove_label_values(labels);
+    }
+
+    /// Remove every collector-labeled BMP counter series for `collector`.
+    ///
+    /// Counterpart of [`Self::reap_bmp_loc_rib_dump_live_buffer`] for the
+    /// counter families, called from the same collector-teardown site
+    /// (`BmpManager`'s `Drop`) so a collector that leaves the config does
+    /// not keep its series alive in a long-lived registry.
+    pub fn reap_bmp_collector_series(&self, collector: &str) {
+        Self::reap_label_series_from_vec(&self.bmp_collector_drops, "collector", collector);
+        Self::reap_label_series_from_vec(&self.bmp_replay_attempts, "collector", collector);
+        Self::reap_label_series_from_vec(&self.bmp_control_event_drops, "collector", collector);
     }
 
     // ── Event history outbox (ADR-0072) ─────────────────────────
@@ -6043,6 +6090,27 @@ mod tests {
         let text = gather_text(&m);
         assert!(!text.contains("collector=\"127.0.0.1:11000\""));
         assert!(text.contains("collector=\"127.0.0.1:11001\""));
+    }
+
+    #[test]
+    fn bmp_loc_rib_source_drop_counter() {
+        let m = BgpMetrics::new();
+        m.record_bmp_loc_rib_source_drop("route_monitoring", "channel_full");
+        m.record_bmp_loc_rib_source_drop("route_monitoring", "channel_full");
+        m.record_bmp_loc_rib_source_drop("stats", "channel_closed");
+
+        assert_eq!(
+            m.bmp_loc_rib_source_drops
+                .with_label_values(&["route_monitoring", "channel_full"])
+                .get(),
+            2
+        );
+        assert_eq!(
+            m.bmp_loc_rib_source_drops
+                .with_label_values(&["stats", "channel_closed"])
+                .get(),
+            1
+        );
     }
 
     #[test]

--- a/src/confirm_journal.rs
+++ b/src/confirm_journal.rs
@@ -436,15 +436,37 @@ pub(crate) struct StagedWrite {
 
 impl StagedWrite {
     /// Publish the staged bytes: rename into place and fsync the directory.
-    pub(crate) fn commit(self) -> io::Result<()> {
-        commit_staged(&self.tmp, &self.target)
-            .map_err(|error| name_write_failure(&self.target, &error))
+    pub(crate) fn commit(mut self) -> io::Result<()> {
+        let result = commit_staged(&self.tmp, &self.target)
+            .map_err(|error| name_write_failure(&self.target, &error));
+        if result.is_ok() {
+            // The rename consumed the temp file. Clear the path so `Drop`
+            // cannot remove a live file a later stage re-creates under the
+            // same name.
+            self.tmp = PathBuf::new();
+        }
+        result
     }
 
-    /// Drop the staged bytes. Best effort: a leftover temp file is harmless
-    /// (the next stage truncates it) and there is nothing useful to report.
+    /// Drop the staged bytes without publishing them; [`Drop`] removes the
+    /// temp file.
     pub(crate) fn discard(self) {
-        let _ = fs::remove_file(&self.tmp);
+        drop(self);
+    }
+}
+
+/// Best-effort removal of the temp file on every path that does not publish
+/// it — an explicit [`StagedWrite::discard`], a failed [`StagedWrite::commit`]
+/// (including an `fsync_dir` failure after the rename, where removing the
+/// already-renamed-away temp path is a harmless no-op), or a caller error
+/// path dropping the stage. The payload embeds config snapshots that may
+/// carry TCP-MD5/TCP-AO secrets, so an unpublished temp file must not
+/// outlive its stage.
+impl Drop for StagedWrite {
+    fn drop(&mut self) {
+        if !self.tmp.as_os_str().is_empty() {
+            let _ = fs::remove_file(&self.tmp);
+        }
     }
 }
 
@@ -755,6 +777,51 @@ log_format = "json"
         write_atomic(&path, b"secret2").unwrap();
         assert_eq!(fs::metadata(&path).unwrap().mode() & 0o777, 0o600);
         assert_eq!(fs::read_to_string(&path).unwrap(), "secret2");
+    }
+
+    #[test]
+    fn staged_write_commit_publishes_and_leaves_no_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("rustbgpd.toml");
+
+        stage_atomic(&target, b"secret").unwrap().commit().unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "secret");
+        assert!(!dir.path().join("rustbgpd.toml.tmp").exists());
+    }
+
+    #[test]
+    fn staged_write_failed_commit_removes_the_temp_file() {
+        // Force the publishing rename to fail by making the destination a
+        // directory: `rename(2)` of a file over a directory is EISDIR.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("rustbgpd.toml");
+        fs::create_dir(&target).unwrap();
+        let tmp = dir.path().join("rustbgpd.toml.tmp");
+
+        let staged = stage_atomic(&target, b"secret").unwrap();
+        assert!(tmp.exists());
+        staged.commit().unwrap_err();
+
+        assert!(
+            !tmp.exists(),
+            "a failed commit must not leak the secret-bearing temp file"
+        );
+        assert!(target.is_dir(), "the destination must be left untouched");
+    }
+
+    #[test]
+    fn dropped_staged_write_removes_the_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("rustbgpd.toml");
+        let tmp = dir.path().join("rustbgpd.toml.tmp");
+
+        let staged = stage_atomic(&target, b"secret").unwrap();
+        assert!(tmp.exists());
+        drop(staged);
+
+        assert!(!tmp.exists());
+        assert!(!target.exists());
     }
 
     #[test]

--- a/src/peer_manager/snapshot.rs
+++ b/src/peer_manager/snapshot.rs
@@ -573,6 +573,11 @@ impl PeerManager {
             return;
         };
         if let Err(e) = bmp_tx.try_send(BmpEvent::LocRibStats { per_family }) {
+            let reason = match e {
+                tokio::sync::mpsc::error::TrySendError::Full(_) => "channel_full",
+                tokio::sync::mpsc::error::TrySendError::Closed(_) => "channel_closed",
+            };
+            self.metrics.record_bmp_loc_rib_source_drop("stats", reason);
             warn!(
                 error = %e,
                 "BMP event channel full or closed, dropping periodic Loc-RIB stats report"

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -388,6 +388,11 @@ pub fn peer_group_references(config: &Config, name: &str) -> Vec<String> {
             refs.push(format!("neighbor {}", neighbor.address));
         }
     }
+    for range in &config.dynamic_neighbors {
+        if range.peer_group == name {
+            refs.push(format!("dynamic_neighbors {}", range.prefix));
+        }
+    }
     for (set_name, set) in &config.policy.neighbor_sets {
         if set.peer_groups.iter().any(|group| group == name) {
             refs.push(format!("neighbor_set {set_name}"));
@@ -1008,6 +1013,27 @@ remote_asn = 65002
 
         let refs = peer_group_references(&config, "fabric");
         assert_eq!(refs, vec!["fib_table edge"]);
+    }
+
+    #[test]
+    fn peer_group_references_include_dynamic_neighbor_ranges() {
+        // A group referenced only by a [[dynamic_neighbors]] range must
+        // still count as referenced: DeletePeerGroup / SIGHUP refuse the
+        // delete iff this list is non-empty, and deleting it would drop
+        // every future dynamic peer from the range at accept time.
+        let mut config = minimal_config();
+        config
+            .dynamic_neighbors
+            .push(crate::config::DynamicNeighborConfig {
+                prefix: "192.0.2.0/24".to_string(),
+                peer_group: "fabric".to_string(),
+                remote_asn: 0,
+                description: None,
+                tcp_ao: None,
+            });
+
+        let refs = peer_group_references(&config, "fabric");
+        assert_eq!(refs, vec!["dynamic_neighbors 192.0.2.0/24"]);
     }
 
     #[test]


### PR DESCRIPTION
Six low-severity defects, each verified against the code before fixing.

**1. StagedWrite temp-file leak — fixed.** `commit()` consumed `self`, so a failing rename or directory fsync left the 0o600 temp file (full config, including TCP-MD5/TCP-AO secrets) on disk; `write_atomic` and the config persister's staged-commit path inherited the leak. `StagedWrite` now removes the temp file in `Drop` on every non-publishing path; `commit()` clears the path on success so `Drop` can never remove a file a later stage re-creates under the same name. Tests: `staged_write_commit_publishes_and_leaves_no_temp_file`, `staged_write_failed_commit_removes_the_temp_file` (EISDIR-forced rename failure), `dropped_staged_write_removes_the_temp_file`.

**2. BMP dump-failure drop undercount — fixed.** `handle_dump_done` recorded only `failure.dropped()` while discarding `dump.buffered` (up to 8,192 held-back live messages) with a warn. The metric now adds `dump.buffered.len()`. The test encoding the undercount was `failed_dump_suppresses_loc_rib_until_reconnect_but_not_ordinary_views`: it buffers one live message behind the failing dump and asserted `bmp_collector_drops_total == 1`; it now asserts 2.

**3. RIB→BmpManager Loc-RIB drops unmetered — fixed.** New `bmp_loc_rib_source_drops_total{event, reason}` (events `route_monitoring`, `stats`; reasons `channel_full`, `channel_closed`), recorded at `emit_bmp_loc_rib` in the RIB manager and `emit_loc_rib_bmp_stats` in the peer manager. Both label sets are bounded, so the family needs no reaping. Test: `bmp_loc_rib_source_drop_counter`.

**4. `peer_group_references` omitted `dynamic_neighbors` — fixed.** A group referenced only by a `[[dynamic_neighbors]]` range could be deleted (gRPC `DeletePeerGroup` or SIGHUP) with no `StillReferenced`, silently dropping every future dynamic peer from the range at accept time. The reference walk now includes dynamic ranges; refusal follows from the existing non-empty-references check in `apply_peer_group_change`. Test: `peer_group_references_include_dynamic_neighbor_ranges` (red before the fix — the walk returned no references).

**5. RTR incremental PDU ordering — documented, not restructured.** The claim is real: the client splits PDUs by flag bit and the VRP manager applies all withdrawals before all announcements, so "announce X then withdraw X" within one serial resolves to X present. A correct cache sends net deltas per serial (RFC 8210), making this robustness-only; carrying wire order would reshape `VrpUpdate::Incremental` across the crate boundary and its tests to defend against a cache bug the protocol forbids. Comments added at both sites naming the assumption and its ceiling.

**6. Collector-labeled BMP counters never reaped — fixed.** `[bmp]` is restart-required, so the only in-process collector-removal site is `BmpManager`'s `Drop`, which already reaped the live-buffer gauges. New `reap_bmp_collector_series` removes the `bmp_collector_drops`, `bmp_replay_attempts`, and `bmp_control_event_drops` series (via the generalized label-matching reap helper) and is called from that same `Drop`. Test: `manager_drop_reaps_only_its_exact_collector_series` extended to cover the three counter families.

Gates (all exit 0): `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps`, `scripts/check-clippy-reasons.py`, `cargo check -p rustbgpd-rib --features bench-internals --benches`.