### PR TITLE
Bound peer-manager mutation requests with a server-side deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   peer label so link-local peers correlate across event streams; and
   `StreamPlanConfigTransaction` bounds its post-handoff response wait by
   the total deadline, matching `StreamApplyConfigTransaction`.
+- Every peer-manager mutation request now carries a 10-minute server-side
+  deadline (LAN-903). The shared mutation helper behind peer-group,
+  policy-definition, and neighbor catalog mutations — plus the neighbor
+  session-control RPCs — awaited the actor reply unbounded; because
+  catalog mutations run on a cancellation-shielded task holding the
+  daemon-wide runtime-config lock, one wedged reply blocked all catalog
+  mutations, SIGHUP reloads, and config transactions until daemon
+  restart. The deadline surfaces as `DEADLINE_EXCEEDED` and releases the
+  lock. It is deliberately mutation-class rather than the 2-second read
+  deadline: one legitimate large-fleet catalog mutation can occupy the
+  actor for ~215 s rebuilding the resolved-policy snapshot
+  (`docs/perf/irr-reload-realistic-mix-2026-08.md`).
 - The BGP listener accept loop classifies `accept(2)` errors instead of
   hot-continuing: resource exhaustion (`EMFILE`/`ENFILE`/`ENOMEM`/
   `ENOBUFS`) backs off progressively (100 ms doubling to 1 s, reset on

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use rustbgpd_transport::RemovePrivateAs;
 use rustbgpd_wire::{Afi, BgpRole, Safi};
-use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio::sync::{Mutex, mpsc};
 use tonic::{Request, Response, Status};
 
 use crate::actor_read::{peer_manager_read, rib_manager_read};
@@ -18,8 +18,8 @@ use crate::peer_types::{
 };
 use crate::proto;
 use crate::server::{
-    AccessMode, ConfigMutationGateFn, check_config_mutation_gate, persist_then_apply,
-    read_only_rejection,
+    AccessMode, ConfigMutationGateFn, check_config_mutation_gate, peer_manager_request,
+    persist_then_apply, read_only_rejection,
 };
 use rustbgpd_rib::{
     EffectiveDistributionMode, NeighborRibSnapshot, NeighborRibSnapshotResponse, RibUpdate,
@@ -322,60 +322,40 @@ async fn add_dynamic_range(
     remote_asn: u32,
     description: Option<String>,
 ) -> Result<(), Status> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(PeerManagerCommand::AddDynamicRange {
-            prefix,
-            peer_group,
-            remote_asn,
-            description,
-            reply: reply_tx,
-        })
-        .await
-        .map_err(|_| Status::internal("peer manager unavailable"))?;
-
-    reply_rx
-        .await
-        .map_err(|_| Status::internal("peer manager dropped reply"))?
-        .map_err(dynamic_range_error_status)
+    peer_manager_request(peer_mgr_tx, |reply| PeerManagerCommand::AddDynamicRange {
+        prefix,
+        peer_group,
+        remote_asn,
+        description,
+        reply,
+    })
+    .await?
+    .map_err(dynamic_range_error_status)
 }
 
 async fn add_static_peer(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     config: PeerManagerNeighborConfig,
 ) -> Result<(), Status> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(PeerManagerCommand::AddPeer {
-            config,
-            sync_config_snapshot: true,
-            reply: reply_tx,
-        })
-        .await
-        .map_err(|_| Status::internal("peer manager unavailable"))?;
-
-    reply_rx
-        .await
-        .map_err(|_| Status::internal("peer manager dropped reply"))?
-        .map_err(peer_lifecycle_error_status)
+    peer_manager_request(peer_mgr_tx, |reply| PeerManagerCommand::AddPeer {
+        config,
+        sync_config_snapshot: true,
+        reply,
+    })
+    .await?
+    .map_err(peer_lifecycle_error_status)
 }
 
 async fn add_presence_aware_peer(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     spec: Box<PresenceAwareNeighborCreate>,
 ) -> Result<(), Status> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(PeerManagerCommand::RuntimeCreatePeer {
-            spec,
-            reply: reply_tx,
-        })
-        .await
-        .map_err(|_| Status::internal("peer manager unavailable"))?;
-    reply_rx
-        .await
-        .map_err(|_| Status::internal("peer manager dropped reply"))?
-        .map_err(peer_lifecycle_error_status)
+    peer_manager_request(peer_mgr_tx, |reply| PeerManagerCommand::RuntimeCreatePeer {
+        spec,
+        reply,
+    })
+    .await?
+    .map_err(peer_lifecycle_error_status)
 }
 
 async fn delete_static_peer(
@@ -383,39 +363,24 @@ async fn delete_static_peer(
     peer: PeerKey,
     sync_config_snapshot: bool,
 ) -> Result<PeerManagerNeighborConfig, Status> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(PeerManagerCommand::DeletePeer {
-            peer,
-            sync_config_snapshot,
-            reply: reply_tx,
-        })
-        .await
-        .map_err(|_| Status::internal("peer manager unavailable"))?;
-
-    reply_rx
-        .await
-        .map_err(|_| Status::internal("peer manager dropped reply"))?
-        .map_err(peer_lifecycle_error_status)
+    peer_manager_request(peer_mgr_tx, |reply| PeerManagerCommand::DeletePeer {
+        peer,
+        sync_config_snapshot,
+        reply,
+    })
+    .await?
+    .map_err(peer_lifecycle_error_status)
 }
 
 async fn delete_dynamic_range(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     prefix: String,
 ) -> Result<RemovedDynamicRange, Status> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(PeerManagerCommand::DeleteDynamicRange {
-            prefix,
-            reply: reply_tx,
-        })
-        .await
-        .map_err(|_| Status::internal("peer manager unavailable"))?;
-
-    reply_rx
-        .await
-        .map_err(|_| Status::internal("peer manager dropped reply"))?
-        .map_err(dynamic_range_error_status)
+    peer_manager_request(peer_mgr_tx, |reply| {
+        PeerManagerCommand::DeleteDynamicRange { prefix, reply }
+    })
+    .await?
+    .map_err(dynamic_range_error_status)
 }
 
 pub(crate) fn family_to_string(afi: Afi, safi: Safi) -> String {
@@ -1453,19 +1418,12 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         let req = request.into_inner();
         let peer = peer_key(&req.address, &req.interface)?;
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::EnablePeer {
-                peer,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(peer_lifecycle_error_status)?;
+        peer_manager_request(&self.peer_mgr_tx, |reply| PeerManagerCommand::EnablePeer {
+            peer,
+            reply,
+        })
+        .await?
+        .map_err(peer_lifecycle_error_status)?;
 
         Ok(Response::new(proto::EnableNeighborResponse {}))
     }
@@ -1488,20 +1446,13 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             parse_families_proto(&req.families)?
         };
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::SoftResetIn {
-                peer,
-                families,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(peer_lifecycle_error_status)?;
+        peer_manager_request(&self.peer_mgr_tx, |reply| PeerManagerCommand::SoftResetIn {
+            peer,
+            families,
+            reply,
+        })
+        .await?
+        .map_err(peer_lifecycle_error_status)?;
 
         Ok(Response::new(proto::SoftResetInResponse {}))
     }
@@ -1516,19 +1467,11 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         let req = request.into_inner();
         let peer = peer_key(&req.address, &req.interface)?;
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::RefreshOutbound {
-                peer,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(outbound_refresh_error_status)?;
+        peer_manager_request(&self.peer_mgr_tx, |reply| {
+            PeerManagerCommand::RefreshOutbound { peer, reply }
+        })
+        .await?
+        .map_err(outbound_refresh_error_status)?;
 
         Ok(Response::new(proto::RefreshOutboundResponse {
             scheduled: true,
@@ -1553,20 +1496,13 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             ))
         };
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::DisablePeer {
-                peer,
-                reason,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(peer_lifecycle_error_status)?;
+        peer_manager_request(&self.peer_mgr_tx, |reply| PeerManagerCommand::DisablePeer {
+            peer,
+            reason,
+            reply,
+        })
+        .await?
+        .map_err(peer_lifecycle_error_status)?;
 
         Ok(Response::new(proto::DisableNeighborResponse {}))
     }
@@ -1730,28 +1666,23 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             Some(peer_key(&req.address, &req.interface)?)
         };
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.peer_mgr_tx
-            .send(PeerManagerCommand::SetGracefulShutdown {
+        peer_manager_request(&self.peer_mgr_tx, |reply| {
+            PeerManagerCommand::SetGracefulShutdown {
                 peer,
                 enabled: req.enabled,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("peer manager unavailable"))?;
-
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("peer manager dropped reply"))?
-            .map_err(|e| match e {
-                // PeerNotFound is the operator-typo case — distinguish
-                // from session/RIB dispatch failures so clients can
-                // react appropriately.
-                crate::peer_types::SetGshutError::PeerNotFound(peer) => {
-                    Status::not_found(format!("peer {peer} not found"))
-                }
-                crate::peer_types::SetGshutError::Internal(msg) => Status::internal(msg),
-            })?;
+                reply,
+            }
+        })
+        .await?
+        .map_err(|e| match e {
+            // PeerNotFound is the operator-typo case — distinguish
+            // from session/RIB dispatch failures so clients can
+            // react appropriately.
+            crate::peer_types::SetGshutError::PeerNotFound(peer) => {
+                Status::not_found(format!("peer {peer} not found"))
+            }
+            crate::peer_types::SetGshutError::Internal(msg) => Status::internal(msg),
+        })?;
 
         Ok(Response::new(proto::SetGracefulShutdownResponse {}))
     }
@@ -1764,6 +1695,7 @@ mod tests {
     use prost::Message;
     use proto::neighbor_service_server::NeighborService as _;
     use tokio::sync::mpsc::error::TryRecvError;
+    use tokio::sync::oneshot;
 
     fn make_service() -> NeighborService {
         let (tx, _rx) = mpsc::channel(16);

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -8,7 +8,7 @@ use rustbgpd_transport::{
     SessionQueryOutcome,
 };
 use rustbgpd_wire::{Afi, Ipv4Prefix, Ipv6Prefix, Prefix, Safi};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 use tonic::{Request, Response, Status};
 
 use crate::actor_read::{peer_manager_read, rib_manager_read};
@@ -18,8 +18,8 @@ use crate::peer_types::{
 use crate::policy_helpers::{proto_statement_to_input, validate_policy_action};
 use crate::proto;
 use crate::server::{
-    AccessMode, ConfigMutationGateFn, apply_catalog_mutation, catalog_mutation_error_to_status,
-    peer_manager_request, persist_then_apply, read_only_rejection, run_shielded_catalog_mutation,
+    AccessMode, ConfigMutationGateFn, apply_catalog_mutation, peer_manager_request,
+    persist_then_apply, read_only_rejection, run_shielded_catalog_mutation,
 };
 use std::sync::Arc;
 
@@ -375,37 +375,23 @@ async fn set_policy_definition(
     name: String,
     definition: NamedPolicyDefinition,
 ) -> Result<(), Status> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(PeerManagerCommand::SetPolicy {
-            name,
-            definition,
-            reply: reply_tx,
-        })
-        .await
-        .map_err(|_| Status::internal("peer manager unavailable"))?;
-    reply_rx
-        .await
-        .map_err(|_| Status::internal("peer manager dropped reply"))?
-        .map_err(|error| catalog_mutation_error_to_status(&error))
+    apply_catalog_mutation(peer_mgr_tx, |reply| PeerManagerCommand::SetPolicy {
+        name,
+        definition,
+        reply,
+    })
+    .await
 }
 
 async fn delete_policy_definition(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     name: String,
 ) -> Result<(), Status> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(PeerManagerCommand::DeletePolicy {
-            name,
-            reply: reply_tx,
-        })
-        .await
-        .map_err(|_| Status::internal("peer manager unavailable"))?;
-    reply_rx
-        .await
-        .map_err(|_| Status::internal("peer manager dropped reply"))?
-        .map_err(|error| catalog_mutation_error_to_status(&error))
+    apply_catalog_mutation(peer_mgr_tx, |reply| PeerManagerCommand::DeletePolicy {
+        name,
+        reply,
+    })
+    .await
 }
 
 /// Reject a chain mutation for a neighbor that is not configured, without
@@ -1644,6 +1630,7 @@ mod tests {
     use crate::peer_types::{CatalogMutationError, PolicyAsPathPrependConfig};
     use crate::proto::policy_service_server::PolicyService as PolicyServiceRpc;
     use tokio::sync::mpsc::error::TryRecvError;
+    use tokio::sync::oneshot;
 
     fn sample_proto_definition() -> proto::PolicyDefinition {
         proto::PolicyDefinition {

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -577,20 +577,49 @@ where
         .map_err(|_| Status::internal(format!("{operation} task did not complete")))?
 }
 
+/// Server-side deadline for every peer-manager mutation request.
+///
+/// Reads share a 2 s bound (`actor_read::PEER_MANAGER_READ_TIMEOUT`)
+/// because they are O(peers) state lookups; mutations are a different
+/// duration class. A single catalog mutation can legitimately rebuild the
+/// resolved-policy snapshot for every live peer, and the published
+/// large-fleet receipt (`docs/perf/irr-reload-realistic-mix-2026-08.md`:
+/// 640 clients, per-client-best, F = 0.5) stamps that class of actor
+/// occupancy at ~70 s plus a 133–145 s commit fan-out — roughly 215 s
+/// daemon-side for one legitimate pass. 600 s keeps ~3x headroom over
+/// that worst receipt while still converting a wedged actor into
+/// `DEADLINE_EXCEEDED`. That bound matters doubly here: the mutation
+/// callers run inside `run_shielded_catalog_mutation`, whose detached
+/// task holds the daemon-wide runtime-config lock and outlives client
+/// cancellation, so an unbounded await wedges every catalog mutation,
+/// SIGHUP reload, and config transaction until daemon restart.
+const PEER_MANAGER_MUTATION_TIMEOUT: Duration = Duration::from_mins(10);
+
 /// Send a peer-manager command built around a oneshot reply channel and
-/// await the reply.
+/// await the reply, bounded by [`PEER_MANAGER_MUTATION_TIMEOUT`].
+///
+/// # Errors
+///
+/// Returns `DEADLINE_EXCEEDED` when the deadline expires. The command may
+/// still be applied by the actor afterwards — like any RPC deadline, the
+/// outcome is unknown — but the error propagates out of the shielded body,
+/// so the runtime-config lock guard drops instead of being held forever.
 pub(crate) async fn peer_manager_request<R>(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     build_command: impl FnOnce(oneshot::Sender<R>) -> PeerManagerCommand,
 ) -> Result<R, Status> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(build_command(reply_tx))
-        .await
-        .map_err(|_| Status::internal("peer manager unavailable"))?;
-    reply_rx
-        .await
-        .map_err(|_| Status::internal("peer manager dropped reply"))
+    tokio::time::timeout(PEER_MANAGER_MUTATION_TIMEOUT, async {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        peer_mgr_tx
+            .send(build_command(reply_tx))
+            .await
+            .map_err(|_| Status::internal("peer manager unavailable"))?;
+        reply_rx
+            .await
+            .map_err(|_| Status::internal("peer manager dropped reply"))
+    })
+    .await
+    .map_err(|_| Status::deadline_exceeded("peer manager mutation timed out"))?
 }
 
 /// Send a catalog mutation command to the peer manager and map its
@@ -2229,5 +2258,80 @@ mod tests {
         );
         assert_eq!(context.authn(), GrpcAuthnKind::Uds);
         assert_eq!(context.principal(), "uds:/run/rustbgpd/grpc.sock");
+    }
+
+    /// Load-bearing: without a server-side deadline inside
+    /// `peer_manager_request`, a wedged peer-manager actor leaves the
+    /// request pending forever and the outer test guard expires instead
+    /// of observing the production `DeadlineExceeded` status. Mirrors
+    /// `actor_read::tests::stalled_peer_manager_read_returns_deadline_exceeded`
+    /// for the mutation backbone.
+    #[tokio::test(start_paused = true)]
+    async fn stalled_peer_manager_request_returns_deadline_exceeded() {
+        let (tx, rx) = mpsc::channel(1);
+        let result = tokio::time::timeout(
+            Duration::from_hours(1),
+            peer_manager_request(&tx, |reply| PeerManagerCommand::ListPeers { reply }),
+        )
+        .await
+        .expect("peer-manager request must be bounded server-side");
+        assert_eq!(result.unwrap_err().code(), tonic::Code::DeadlineExceeded);
+        // Held so the command is accepted but never answered.
+        drop(rx);
+    }
+
+    /// The timeout must propagate out of the shielded body so the
+    /// detached task finishes and drops the runtime-config lock guard.
+    /// A timeout that leaked the lock would leave the second mutation
+    /// parked on `lock().await` until this test's own guard expires.
+    #[tokio::test(start_paused = true)]
+    async fn catalog_mutation_after_peer_manager_timeout_acquires_lock() {
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        let (tx, mut rx) = mpsc::channel(2);
+        let responder = tokio::spawn(async move {
+            // First mutation: accept the command but never answer it, so
+            // the shielded body can only finish via the server-side
+            // deadline. Holding the command keeps its reply sender alive.
+            let wedged = rx.recv().await.expect("first command");
+            // Second mutation: answer promptly.
+            match rx.recv().await.expect("second command") {
+                PeerManagerCommand::DeletePeerGroup { reply, .. } => {
+                    let _ = reply.send(Ok(()));
+                }
+                _ => panic!("unexpected command"),
+            }
+            drop(wedged);
+        });
+
+        let wedged_tx = tx.clone();
+        let first = tokio::time::timeout(
+            Duration::from_hours(1),
+            run_shielded_catalog_mutation(lock.clone(), None, "test.wedged", move || async move {
+                apply_catalog_mutation(&wedged_tx, |reply| PeerManagerCommand::DeletePeerGroup {
+                    name: "wedged".into(),
+                    reply,
+                })
+                .await
+            }),
+        )
+        .await
+        .expect("catalog mutation must be bounded server-side");
+        assert_eq!(first.unwrap_err().code(), tonic::Code::DeadlineExceeded);
+
+        let healthy_tx = tx.clone();
+        let second = tokio::time::timeout(
+            Duration::from_secs(5),
+            run_shielded_catalog_mutation(lock, None, "test.healthy", move || async move {
+                apply_catalog_mutation(&healthy_tx, |reply| PeerManagerCommand::DeletePeerGroup {
+                    name: "healthy".into(),
+                    reply,
+                })
+                .await
+            }),
+        )
+        .await
+        .expect("timed-out mutation must release the runtime-config lock");
+        second.expect("second mutation must succeed after the first times out");
+        responder.await.expect("responder task");
     }
 }


### PR DESCRIPTION
## Problem

`peer_manager_request` (crates/api/src/server.rs) — the shared helper behind every catalog mutation (peer groups via `apply_catalog_mutation`, policy definitions, neighbor CRUD) — awaited its oneshot reply with no timeout; its only error paths were channel-closed and reply-dropped. Its callers run inside `run_shielded_catalog_mutation`, whose detached task holds the daemon-wide runtime-config lock and, by design (ADR-0080 cancellation shield), outlives client cancellation. One wedged peer-manager reply therefore blocked all catalog mutations, SIGHUP reloads, FIB-table and neighbor CRUD, and config transactions until daemon restart — not merely until client cancel.

#1485 bounded the sibling read helper (`peer_manager_read`, 2 s → `DEADLINE_EXCEEDED`) but left the mutation backbone unbounded.

## Fix

Wrap `peer_manager_request` in a `PEER_MANAGER_MUTATION_TIMEOUT` of **10 minutes**, mapped to `DEADLINE_EXCEEDED`. The error propagates out of the shielded body, so the detached task finishes and the runtime-config lock guard drops instead of being held forever.

**Why 10 minutes and not the 2 s read class:** a single legitimate catalog mutation can rebuild the resolved-policy snapshot for every live peer. The published large-fleet receipt (`docs/perf/irr-reload-realistic-mix-2026-08.md`: 640 clients, per-client-best, F = 0.5) stamps that class of actor occupancy at ~70 s plus a 133–145 s commit fan-out — roughly 215 s daemon-side for one legitimate pass. Ten minutes keeps ~3x headroom over that worst receipt, so the deadline cannot false-trip a mutation that shape already proved legitimate, while a genuinely wedged actor still surfaces as an error that releases the lock. A false trip is worse than slow detection here: the command is already in flight, so `DEADLINE_EXCEEDED` means outcome-unknown (documented on the helper), like any RPC deadline.

## Same-shape sweep

Routed the remaining unbounded peer-manager reply awaits in `crates/api` through the now-bounded helpers (net deletion; error codes and messages for the existing channel-closed/reply-dropped paths unchanged):

- `policy_service.rs`: `set_policy_definition` / `delete_policy_definition` → `apply_catalog_mutation`.
- `neighbor_service.rs`: the five catalog-mutation helpers (`add_dynamic_range`, `add_static_peer`, `add_presence_aware_peer`, `delete_static_peer`, `delete_dynamic_range`, all under the same runtime-config-lock shields) and the `EnableNeighbor`/`DisableNeighbor`/`SoftResetIn`/`RefreshOutbound`/`SetGracefulShutdown` handlers → `peer_manager_request`.

Left as-is, different classes: `rib_manager_read` (deliberately unbounded at the shared helper, documented; bounded callers wrap it), the injection service's RIB awaits, the config-bridge oneshots in `config_service.rs`, the MRT trigger await in `control_service.rs`, and the health-probe lanes.

## Tests

- `stalled_peer_manager_request_returns_deadline_exceeded` — mirrors the read-side deadline test for the mutation backbone; fails pre-fix with the outer guard expiring instead of the production status.
- `catalog_mutation_after_peer_manager_timeout_acquires_lock` — a wedged first mutation returns `DEADLINE_EXCEEDED` and a second mutation then acquires the runtime-config lock and succeeds, proving the timeout releases the shield rather than leaking the lock. Both use tokio's paused clock (0 s wall time).

Gates: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (×2), `cargo doc --workspace --no-deps`, `check-clippy-reasons.py`, `cargo test -p rustbgpd-api authz` — all green.

Fixes LAN-903.