### PR TITLE
Pin GitHub Actions by version tag instead of commit SHA

### DIFF
--- a/.github/actions/install-containerlab/action.yml
+++ b/.github/actions/install-containerlab/action.yml
@@ -21,7 +21,7 @@ runs:
     # naturally invalidates the cache and re-downloads.
     - name: Restore containerlab ${{ inputs.version }} .deb from cache
       id: clab-deb
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@v4
       with:
         path: ~/.cache/containerlab/containerlab_${{ inputs.version }}_linux_amd64.deb
         key: containerlab-deb-${{ inputs.version }}

--- a/.github/actions/setup-dataplane-host/action.yml
+++ b/.github/actions/setup-dataplane-host/action.yml
@@ -84,11 +84,11 @@ runs:
 
     - name: Set up Docker Buildx
       if: ${{ inputs.build-image == 'true' }}
-      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      uses: docker/setup-buildx-action@v4
 
     - name: Build rustbgpd:dev
       if: ${{ inputs.build-image == 'true' }}
-      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+      uses: docker/build-push-action@v7
       with:
         context: .
         load: true

--- a/.github/workflows/alert-rules.yml
+++ b/.github/workflows/alert-rules.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - name: Check Grafana dashboard
         run: python3 scripts/check-grafana-dashboard.py
       - name: Install promtool (pinned)

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -65,14 +65,14 @@ jobs:
       contents: read
       checks: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       # rustsec/audit-check is the canonical action; it caches the
       # advisory DB and posts findings as PR review comments.
       # Pinned to a release tag rather than `@v2` floating so the
       # action contents are reproducible.
       - name: Run cargo audit
-        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -83,12 +83,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       # EmbarkStudios' official action; installs a pinned cargo-deny
       # and runs the four checks against deny.toml. Pinned to a
       # release tag for reproducibility, matching the audit job.
       - name: Run cargo deny
-        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+        uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check advisories bans licenses sources

--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           fetch-depth: 0 # full history + tags for `git describe` and the A/B worktrees
 
-      - uses: dtolnay/rust-toolchain@master # stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
 
         with:
 

--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -61,17 +61,17 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history + tags for `git describe` and the A/B worktrees
 
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: dtolnay/rust-toolchain@master # stable
 
         with:
 
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@v2
         with:
           key: bench-nightly-${{ inputs.package || 'rustbgpd-rib' }}-${{ inputs.bench || 'rib_ops' }}
 
@@ -168,7 +168,7 @@ jobs:
 
       - name: Upload Criterion artifacts
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@v7
         with:
           name: criterion-bench-nightly
           path: target/bench-compare/

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -86,17 +86,17 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: dtolnay/rust-toolchain@master # stable
 
         with:
 
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@v2
         with:
           key: bench-${{ inputs.package }}-${{ inputs.bench }}
 
@@ -150,7 +150,7 @@ jobs:
 
       - name: Upload Criterion artifacts
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@v7
         with:
           name: criterion-bench-compare
           path: target/bench-compare/

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@master # stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
 
         with:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     # hosted receipts establish a safe tighter bound.
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
         with:
           # Need history so the wire-readme freshness gate can diff
           # against the previous commit / PR base.
@@ -73,12 +73,12 @@ jobs:
         run: |
           python3 -m unittest -v scripts/test_check_ci_scale_split_contract.py
           python3 scripts/check_ci_scale_split_contract.py
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: dtolnay/rust-toolchain@master # stable
         with:
           toolchain: stable
           components: rustfmt, clippy
       - uses: ./.github/actions/install-protobuf
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@v2
       - name: Prove exact fail-closed fuzz target inventory
         run: |
           python3 -m unittest -v scripts/test_check_fuzz_target_inventory.py
@@ -259,14 +259,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: dtolnay/rust-toolchain@master # stable
         with:
           toolchain: stable
       - uses: ./.github/actions/install-protobuf
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
       - run: cargo doc --workspace --lib --no-deps
         env:
@@ -277,17 +277,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
         with:
           # test-rrharness-driver resolves a retained pin commit and creates a
           # detached worktree at that exact revision.
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: dtolnay/rust-toolchain@master # stable
         with:
           toolchain: stable
           components: rustfmt, clippy
       - uses: ./.github/actions/install-protobuf
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@v2
       - name: Install receipt-tool dependencies
         run: |
           sudo apt-get update
@@ -407,12 +407,12 @@ jobs:
     # file alongside `Cargo.toml` and `Dockerfile`.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master # 1.95
         with:
           toolchain: "1.95"
       - uses: ./.github/actions/install-protobuf
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@v2
         with:
           # Distinct cache key from the `check` job so MSRV builds don't
           # share artifacts compiled by stable rustc.
@@ -445,15 +445,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       # Pre-build the harness image with GHA cache so the warm path
       # (no Dockerfile change) skips the `apt-get install` rebuild.
       - name: Build netns-test harness image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: crates/evpn-linux/tests/docker/Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           python3 -m unittest -v scripts/test_check_ci_scale_split_contract.py
           python3 scripts/check_ci_scale_split_contract.py
-      - uses: dtolnay/rust-toolchain@master # stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable
           components: rustfmt, clippy
@@ -262,7 +262,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@master # stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable
       - uses: ./.github/actions/install-protobuf
@@ -282,7 +282,7 @@ jobs:
           # test-rrharness-driver resolves a retained pin commit and creates a
           # detached worktree at that exact revision.
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@master # stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable
           components: rustfmt, clippy
@@ -408,7 +408,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@master # 1.95
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95
         with:
           toolchain: "1.95"
       - uses: ./.github/actions/install-protobuf

--- a/.github/workflows/clusterfuzzlite.yml
+++ b/.github/workflows/clusterfuzzlite.yml
@@ -17,19 +17,19 @@ jobs:
     # all 17 targets plus the observed 14-minute ASan build.
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - name: Prove exact fail-closed fuzz target inventory
         run: |
           python3 -m unittest -v scripts/test_check_fuzz_target_inventory.py
           python3 scripts/check_fuzz_target_inventory.py
       - name: Build address-sanitized fuzzers
-        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
         with:
           language: rust
           sanitizer: address
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run code-change fuzzing
-        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 300

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -20,7 +20,7 @@ jobs:
     # for this release — no image may be published from it.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - name: Assert tag matches workspace version
         run: |
           set -euo pipefail
@@ -39,12 +39,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master # stable
         with:
           toolchain: stable
       - uses: ./.github/actions/install-protobuf
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
 
   build-and-push:
@@ -55,10 +55,10 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -66,7 +66,7 @@ jobs:
 
       - name: Extract version from tag
         id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -77,7 +77,7 @@ jobs:
         # Build (without pushing) into the local image store so artifact
         # content can be asserted before anything reaches the registry.
         # The push step below reuses these layers.
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -90,7 +90,7 @@ jobs:
             'test -f /LICENSE-MIT && test -f /LICENSE-APACHE'
 
       - name: Build and push
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@master # stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable
       - uses: ./.github/actions/install-protobuf

--- a/.github/workflows/embedding-doc-contract.yml
+++ b/.github/workflows/embedding-doc-contract.yml
@@ -23,7 +23,7 @@ jobs:
   embedding-doc-contract:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - name: Check published crate boundary
         run: |
           python3 -m unittest -v scripts/test_check_embedding_versions.py

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -12,7 +12,7 @@ jobs:
   fuzz:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       # fuzz/rust-nightly.txt holds the single reviewed nightly, shared with
       # the OSS-Fuzz and ClusterFuzzLite images. A floating `nightly` lets an
       # upstream compiler regression take the campaign down with no change on
@@ -34,7 +34,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.nightly.outputs.toolchain }}
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@v2
       - run: cargo install cargo-fuzz --locked
       # Every target in each fuzz crate, 2 minutes apiece. Seed corpora are
       # tracked under fuzz/seeds/<target>/ (fuzz/corpus/ is gitignored, so a
@@ -111,7 +111,7 @@ jobs:
           done
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@v7
         with:
           name: fuzz-crashes
           path: |

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -158,13 +158,13 @@ jobs:
       group: rustbgpd-dev-image-${{ github.sha }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
       - name: Prime rustbgpd:dev build cache
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: false
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -189,10 +189,10 @@ jobs:
           bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -213,7 +213,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -223,10 +223,10 @@ jobs:
           bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -260,10 +260,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -284,7 +284,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -294,10 +294,10 @@ jobs:
           bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -318,7 +318,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -328,10 +328,10 @@ jobs:
           bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -352,7 +352,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -362,10 +362,10 @@ jobs:
           bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -386,7 +386,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -397,10 +397,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -428,7 +428,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -439,10 +439,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -476,7 +476,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -487,10 +487,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -514,7 +514,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -525,10 +525,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -552,7 +552,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -563,10 +563,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -590,7 +590,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -601,10 +601,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -628,7 +628,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -639,10 +639,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -666,7 +666,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -677,10 +677,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -704,7 +704,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -718,10 +718,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -742,7 +742,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -752,10 +752,10 @@ jobs:
           bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -776,7 +776,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -788,10 +788,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -826,7 +826,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -837,10 +837,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -868,7 +868,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -880,10 +880,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -908,7 +908,7 @@ jobs:
 
       - name: Upload M83 failed-attempt evidence
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@v7
         with:
           name: m83-failed-attempts-${{ github.run_attempt }}
           path: ${{ runner.temp }}/m83-failure-artifacts
@@ -921,7 +921,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -933,10 +933,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -978,7 +978,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -990,10 +990,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1019,7 +1019,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -1031,10 +1031,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1062,7 +1062,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -1072,10 +1072,10 @@ jobs:
           bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1096,7 +1096,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       # containerlab and grpcurl are installed locally to the runner;
       # both are cheap (single Go binaries). Pinned versions to keep the
@@ -1115,10 +1115,10 @@ jobs:
       # cache hits. The cargo registry / target dir gets reused via the
       # GitHub Actions cache backend (type=gha).
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1141,7 +1141,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -1155,10 +1155,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1179,7 +1179,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -1192,10 +1192,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1216,7 +1216,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -1229,10 +1229,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1253,7 +1253,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -1266,10 +1266,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1290,7 +1290,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -1302,10 +1302,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1326,7 +1326,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -1340,10 +1340,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1364,7 +1364,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -1374,10 +1374,10 @@ jobs:
           bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1405,7 +1405,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -1418,10 +1418,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1447,7 +1447,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -1458,10 +1458,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1482,7 +1482,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -1495,10 +1495,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1523,7 +1523,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -1533,10 +1533,10 @@ jobs:
           bash .github/scripts/install-grpcurl.sh
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1557,7 +1557,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -1570,10 +1570,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1594,7 +1594,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -1608,10 +1608,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -1632,7 +1632,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
@@ -1646,10 +1646,10 @@ jobs:
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Build rustbgpd:dev
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true

--- a/.github/workflows/ixp-compat.yml
+++ b/.github/workflows/ixp-compat.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - name: Verify the pinned upstream contract
         run: tests/compat/ixp-manager-birdseye/run.sh

--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -47,13 +47,13 @@ jobs:
       group: rustbgpd-dev-image-${{ github.sha }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
       - name: Prime rustbgpd:dev build cache
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: false
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M36 (deploy + test + destroy with retry)
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M37 (deploy + test + destroy with retry)
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M37+IP (deploy + test + destroy with retry)
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M38 (deploy + test + destroy with retry)
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M39 (deploy + test + destroy with retry)
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M39b (deploy + test + destroy with retry)
@@ -166,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M48 (deploy + test + destroy with retry)
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M60 (deploy + test + destroy with retry)
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M61 (deploy + test + destroy with retry)
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M62 (deploy + test + destroy with retry)
@@ -232,7 +232,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M40 (deploy + test + destroy with retry)
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M42 (deploy + test + destroy with retry)
@@ -264,7 +264,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M50 (deploy + test + destroy with retry)
@@ -280,7 +280,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M52 (deploy + test + destroy with retry)
@@ -296,7 +296,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M58 (deploy + test + destroy with retry)
@@ -312,7 +312,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M53 (deploy + test + destroy with retry)
@@ -328,7 +328,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M51 (deploy + test + destroy with retry)
@@ -344,7 +344,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
 
@@ -377,13 +377,13 @@ jobs:
 
       - name: Install Rust 1.95 for the direct GET_KEYS receipt
         if: steps.tcp_ao.outputs.supported == 'true'
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95
+        uses: dtolnay/rust-toolchain@master # 1.95
         with:
           toolchain: "1.95"
 
       - name: Cache direct GET_KEYS receipt build
         if: steps.tcp_ao.outputs.supported == 'true'
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@v2
         with:
           shared-key: m43-tcp-ao-get-keys
 
@@ -444,7 +444,7 @@ jobs:
       # image's cache separate from rustbgpd:dev's.
       - name: Build BIRD 3.3.1 TCP-AO image
         if: steps.tcp_ao.outputs.supported == 'true'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: tests/interop
           file: tests/interop/Dockerfile.bird3
@@ -475,7 +475,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M46 (deploy + test + destroy with retry)
@@ -491,7 +491,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M47 (deploy + test + destroy with retry)
@@ -507,7 +507,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M49 (deploy + test + destroy with retry)
@@ -523,7 +523,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       - name: Run M69 (deploy + test + destroy with retry)
@@ -539,7 +539,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       # Cross-vendor proof for ADR-0089's v1 Linux topology: rustbgpd owns
@@ -559,7 +559,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       # The segment PEs run GoBGP (the failure injection needs the RFC 7432
@@ -581,7 +581,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       # rustbgpd is the receive-side DUT; GoBGP is the route source. GoBGP
@@ -605,7 +605,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       # rustbgpd is the receive-side DUT; two GoBGP PEs are route
@@ -628,7 +628,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       # All three BGP speakers are rustbgpd — the origination-side
@@ -647,7 +647,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       # The M66 sibling with the production trigger: an attachment-
@@ -668,7 +668,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-dataplane-host
         id: dataplane
       # Cross-vendor consume-side proof for native GW-IP overlay-index
@@ -688,7 +688,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       # The Docker netns harness builds its own image and runs the privileged
       # tests inside `docker run --cap-add=NET_ADMIN --cap-add=SYS_ADMIN`, so the

--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -377,7 +377,7 @@ jobs:
 
       - name: Install Rust 1.95 for the direct GET_KEYS receipt
         if: steps.tcp_ao.outputs.supported == 'true'
-        uses: dtolnay/rust-toolchain@master # 1.95
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95
         with:
           toolchain: "1.95"
 

--- a/.github/workflows/privileged-interop.yml
+++ b/.github/workflows/privileged-interop.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install protoc + jq
         run: |

--- a/.github/workflows/release-install-contract.yml
+++ b/.github/workflows/release-install-contract.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - name: Test release install contract
         run: python3 scripts/test_check_release_install_contract.py
       - name: Check repository release install contract

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@master # stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable
       - uses: ./.github/actions/install-protobuf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     # for this release — nothing may be built or published from it.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - name: Assert tag matches workspace version
         run: |
           set -euo pipefail
@@ -54,12 +54,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master # stable
         with:
           toolchain: stable
       - uses: ./.github/actions/install-protobuf
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
 
   build:
@@ -90,7 +90,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Install cross-compilation target and tools
         if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -247,7 +247,7 @@ jobs:
           cat checksums-${{ matrix.suffix }}.txt
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@v7
         with:
           name: binaries-${{ matrix.suffix }}
           path: dist/
@@ -260,10 +260,10 @@ jobs:
     permissions:
       contents: write  # create the GitHub release
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true
@@ -310,7 +310,7 @@ jobs:
         # run can never publish: without a tag ref, action-gh-release
         # would otherwise act on the branch ref.
         if: github.event_name == 'push'
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
+        uses: softprops/action-gh-release@v3
         with:
           body_path: release-notes.md
           files: artifacts/*

--- a/.github/workflows/update-group-fault.yml
+++ b/.github/workflows/update-group-fault.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@master # stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/update-group-fault.yml
+++ b/.github/workflows/update-group-fault.yml
@@ -20,11 +20,11 @@ jobs:
     # leaving time for build, the full sweep, log upload, and failure restore.
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master # stable
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@v2
         with:
           key: update-group-fault
       - name: Verify exact ignored corpus test exists
@@ -93,7 +93,7 @@ jobs:
           echo "status=$result_status" >>"$GITHUB_OUTPUT"
       - name: Upload failing corpus log
         if: steps.corpus.outputs.status != '0'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@v7
         with:
           name: update-group-fault-${{ github.run_id }}
           path: update-group-fault.log

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -51,9 +51,9 @@ CALL_HASHES = {
 PINS = collections.Counter(
     {
         "actions/checkout@v7": 77,
-        "dtolnay/rust-toolchain@master # stable": 3,
+        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 3,
         "Swatinem/rust-cache@v2": 5,
-        "dtolnay/rust-toolchain@master # 1.95": 2,
+        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 2,
         "docker/setup-buildx-action@v4": 42,
         "docker/build-push-action@v7": 43,
         "actions/upload-artifact@v7": 1,

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -23,13 +23,9 @@ GROUP = "group: ${{ github.workflow }}-${{ github.ref }}"
 PRIMER_GROUP = "group: rustbgpd-dev-image-${{ github.sha }}"
 IMPORT = "cache-from: type=gha,scope=rustbgpd-dev"
 EXPORT = "cache-to: type=gha,scope=rustbgpd-dev,mode=max,ignore-error=true"
-CHECKOUT = "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7"
-BUILDX = (
-    "uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4"
-)
-BUILD_PUSH = (
-    "uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7"
-)
+CHECKOUT = "uses: actions/checkout@v7"
+BUILDX = "uses: docker/setup-buildx-action@v4"
+BUILD_PUSH = "uses: docker/build-push-action@v7"
 GOBGP_VERSION = "3.37.0"
 GOBGP_CHECKSUMS = {
     "amd64": "e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522",
@@ -54,15 +50,15 @@ CALL_HASHES = {
 }
 PINS = collections.Counter(
     {
-        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7": 77,
-        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 3,
-        "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2": 5,
-        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 2,
-        "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4": 42,
-        "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7": 43,
-        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7": 1,
-        "rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0": 1,
-        "EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1": 1,
+        "actions/checkout@v7": 77,
+        "dtolnay/rust-toolchain@master # stable": 3,
+        "Swatinem/rust-cache@v2": 5,
+        "dtolnay/rust-toolchain@master # 1.95": 2,
+        "docker/setup-buildx-action@v4": 42,
+        "docker/build-push-action@v7": 43,
+        "actions/upload-artifact@v7": 1,
+        "rustsec/audit-check@v2.0.0": 1,
+        "EmbarkStudios/cargo-deny-action@v2": 1,
     }
 )
 

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -20,28 +20,26 @@ ROSTER = [
 TRIGGER_HASH = "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8"
 PERMISSION_HASH = "9691400b3b1036bcdfe724926816dbe71b0aa22ed9b5eb89627e2eeb75079898"
 JOB_HASHES = {
-    "core": "91977c62f11648ed94441920df8c21d7a86eb07130b5f57fca8c970eec450edd",
-    "core_tests": "2e5d0d9268a7af2503d76c094a1305501ec861812091cec43b18eaf99ba89a09",
-    "scale_receipts": "91d5396ba46147fd7a489b49cbc6207f8588f350df3308c92f236f3936dbcf4f",
+    "core": "a4c0f059a81cc7f6161b27ee557a444d8ece31554461a25cb7ed425e6e348da5",
+    "core_tests": "249218c607b87f02e827acb81ca2c26d2a16eebc0aa5c4b0780d539aee17ba65",
+    "scale_receipts": "de016d9c60dc02710cd3a2d87b3d1da4d12cc077055974220b07a50f0835b27b",
     "check": "cfc655ca80392ab0699390b461e5e8e9b41410cc724201aafe75ae6da7d83213",
-    "msrv": "db1ae833d9c8fbbc47dbf2969ac291b90cf413ba9eed2b95dd4cfe34e0a4ba5d",
-    "evpn_bum_filter_kernel": "f965e7f95f30772d9d335104dda9e30c53816098bd5f1225a3cadabe7d9a23b3",
+    "msrv": "886fcc40c19b18d4c7bde52d8b735b153d0c091e0a8e1c865bcd6651daf0b7b5",
+    "evpn_bum_filter_kernel": "d427ed2c650d619d926cad0a4cbb6b558dd013ace9b18ba48757be529420863a",
 }
 COMMAND_BODY_HASH = "9e3c949873c8c0872a1a5403b69300c3a5306025af3cf893782ff1d60a1a2b2f"
 STEP_NAME = "Check standalone scale harnesses and receipt classifiers"
-CHECKOUT = "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7"
-TOOLCHAIN = (
-    "uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable"
-)
-RUST_CACHE = "uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2"
+CHECKOUT = "uses: actions/checkout@v7"
+TOOLCHAIN = "uses: dtolnay/rust-toolchain@master # stable"
+RUST_CACHE = "uses: Swatinem/rust-cache@v2"
 PINS = collections.Counter(
     {
-        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7": 5,
-        "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2": 4,
-        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 3,
-        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 1,
-        "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4": 1,
-        "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7": 1,
+        "actions/checkout@v7": 5,
+        "Swatinem/rust-cache@v2": 4,
+        "dtolnay/rust-toolchain@master # stable": 3,
+        "dtolnay/rust-toolchain@master # 1.95": 1,
+        "docker/setup-buildx-action@v4": 1,
+        "docker/build-push-action@v7": 1,
     }
 )
 

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -20,24 +20,26 @@ ROSTER = [
 TRIGGER_HASH = "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8"
 PERMISSION_HASH = "9691400b3b1036bcdfe724926816dbe71b0aa22ed9b5eb89627e2eeb75079898"
 JOB_HASHES = {
-    "core": "a4c0f059a81cc7f6161b27ee557a444d8ece31554461a25cb7ed425e6e348da5",
-    "core_tests": "249218c607b87f02e827acb81ca2c26d2a16eebc0aa5c4b0780d539aee17ba65",
-    "scale_receipts": "de016d9c60dc02710cd3a2d87b3d1da4d12cc077055974220b07a50f0835b27b",
+    "core": "4eb93b493beb95530d53b696901b0d4ee03c880fd3499fece71ec133e39d621b",
+    "core_tests": "a600b370f7ad23208c65872684eba87f037b245d6074336626ca4175deca1e2f",
+    "scale_receipts": "2fef431828f2dc4dd879a10774752be598082a91435356771a5f61a3caaf9bd5",
     "check": "cfc655ca80392ab0699390b461e5e8e9b41410cc724201aafe75ae6da7d83213",
-    "msrv": "886fcc40c19b18d4c7bde52d8b735b153d0c091e0a8e1c865bcd6651daf0b7b5",
+    "msrv": "273de02a6a1e67e17913b50023326214261b8f4d6399f8f8867188e7e3d2acb9",
     "evpn_bum_filter_kernel": "d427ed2c650d619d926cad0a4cbb6b558dd013ace9b18ba48757be529420863a",
 }
 COMMAND_BODY_HASH = "9e3c949873c8c0872a1a5403b69300c3a5306025af3cf893782ff1d60a1a2b2f"
 STEP_NAME = "Check standalone scale harnesses and receipt classifiers"
 CHECKOUT = "uses: actions/checkout@v7"
-TOOLCHAIN = "uses: dtolnay/rust-toolchain@master # stable"
+TOOLCHAIN = (
+    "uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable"
+)
 RUST_CACHE = "uses: Swatinem/rust-cache@v2"
 PINS = collections.Counter(
     {
         "actions/checkout@v7": 5,
         "Swatinem/rust-cache@v2": 4,
-        "dtolnay/rust-toolchain@master # stable": 3,
-        "dtolnay/rust-toolchain@master # 1.95": 1,
+        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 3,
+        "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 1,
         "docker/setup-buildx-action@v4": 1,
         "docker/build-push-action@v7": 1,
     }

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -110,7 +110,7 @@ class PrimerContractTests(unittest.TestCase):
             ),
             (
                 ".github/workflows/kernel-dataplane.yml",
-                "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+                "actions/checkout@v7",
                 "actions/checkout@main",
             ),
             (
@@ -150,15 +150,15 @@ class PrimerContractTests(unittest.TestCase):
                     "cache-to: type=gha",
                 ),
                 (
-                    "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+                    "actions/checkout@v7",
                     "actions/checkout@main",
                 ),
                 (
-                    "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c",
+                    "docker/setup-buildx-action@v4",
                     "docker/setup-buildx-action@main",
                 ),
                 (
-                    "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a",
+                    "docker/build-push-action@v7",
                     "docker/build-push-action@main",
                 ),
             ):
@@ -195,7 +195,7 @@ class PrimerContractTests(unittest.TestCase):
         with self.subTest(workflow=interop, seam="consumer checkout"):
             self.mutate(
                 interop,
-                "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+                "actions/checkout@v7",
                 "actions/checkout@main",
                 occurrence=1,
             )
@@ -204,7 +204,7 @@ class PrimerContractTests(unittest.TestCase):
         with self.subTest(workflow=kernel, seam="consumer checkout"):
             self.mutate(
                 kernel,
-                "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+                "actions/checkout@v7",
                 "actions/checkout@main",
                 occurrence=1,
             )
@@ -220,11 +220,11 @@ class PrimerContractTests(unittest.TestCase):
             ("target: dev", "target: release"),
             ("context: .", "context: elsewhere"),
             (
-                "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c",
+                "docker/setup-buildx-action@v4",
                 "docker/setup-buildx-action@main",
             ),
             (
-                "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a",
+                "docker/build-push-action@v7",
                 "docker/build-push-action@main",
             ),
             (

--- a/scripts/test_check_ci_scale_split_contract.py
+++ b/scripts/test_check_ci_scale_split_contract.py
@@ -94,7 +94,7 @@ class ScaleSplitContractTests(unittest.TestCase):
                 self.mutate(old, new, occurrence[0] if occurrence else 0)
         for pin, occurrence in (
             ("actions/checkout@v7", 2),
-            ("dtolnay/rust-toolchain@master", 2),
+            ("dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c", 2),
             ("Swatinem/rust-cache@v2", 2),
         ):
             with self.subTest(pin=pin):
@@ -116,7 +116,7 @@ class ScaleSplitContractTests(unittest.TestCase):
                 self.mutate(old, new, occurrence[0] if occurrence else 0)
         for pin in (
             "actions/checkout@v7",
-            "dtolnay/rust-toolchain@master",
+            "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c",
             "Swatinem/rust-cache@v2",
         ):
             with self.subTest(pin=pin):

--- a/scripts/test_check_ci_scale_split_contract.py
+++ b/scripts/test_check_ci_scale_split_contract.py
@@ -93,9 +93,9 @@ class ScaleSplitContractTests(unittest.TestCase):
             with self.subTest(seam=old):
                 self.mutate(old, new, occurrence[0] if occurrence else 0)
         for pin, occurrence in (
-            ("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", 2),
-            ("dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c", 2),
-            ("Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32", 2),
+            ("actions/checkout@v7", 2),
+            ("dtolnay/rust-toolchain@master", 2),
+            ("Swatinem/rust-cache@v2", 2),
         ):
             with self.subTest(pin=pin):
                 self.mutate(pin, "changed@main", occurrence)
@@ -115,9 +115,9 @@ class ScaleSplitContractTests(unittest.TestCase):
             with self.subTest(seam=old):
                 self.mutate(old, new, occurrence[0] if occurrence else 0)
         for pin in (
-            "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
-            "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c",
-            "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32",
+            "actions/checkout@v7",
+            "dtolnay/rust-toolchain@master",
+            "Swatinem/rust-cache@v2",
         ):
             with self.subTest(pin=pin):
                 self.mutate(pin, "changed@main", 1)


### PR DESCRIPTION
## What changed

The 14 actions whose pinned SHA maps cleanly to a published version tag now pin
by tag across `.github/workflows/*.yml` and the composite actions in
`.github/actions/*/action.yml` — 207 `uses:` references. For 12 of the 14 the
major-version tag points at the **exact commit that was previously pinned**, so
what CI executes is byte-identical; the two forward moves are called out below.

Every SHA carried a trailing `# vN` comment naming its tag. Each SHA was
re-resolved against the upstream tag API rather than trusting the comment; the
tag now lives in the ref and the redundant comment is dropped.

`dtolnay/rust-toolchain` is deliberately **not** converted and keeps its
immutable SHA pin — see below.

## Convention

The moving major-version tag where the action publishes one, and the exact
release tag where it does not (`rustsec/audit-check` publishes no major tag, so
it pins `v2.0.0`). This matches the tag names the trailing comments already
tracked.

## SHA to tag mapping

| Action | Old SHA | Exact tag at that SHA | New pin | Uses |
| --- | --- | --- | --- | --- |
| `actions/checkout` | `3d3c42e5aac5ba805825da76410c181273ba90b1` | v7.0.1 | `v7` | 94 |
| `docker/build-push-action` | `53b7df96c91f9c12dcc8a07bcb9ccacbed38856a` | v7.3.0 | `v7` | 45 |
| `docker/setup-buildx-action` | `bb05f3f5519dd87d3ba754cc423b652a5edd6d2c` | v4.2.0 | `v4` | 42 |
| `Swatinem/rust-cache` | `e18b497796c12c097a38f9edb9d0641fb99eee32` | *(untagged)* | `v2` | 11 |
| `actions/upload-artifact` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | v7.0.1 | `v7` | 6 |
| `softprops/action-gh-release` | `3d0d9888cb7fd7b750713d6e236d1fcb99157228` | v3.0.2 | `v3` | 1 |
| `rustsec/audit-check` | `69366f33c96575abad1ee0dba8212993eecbe998` | v2.0.0 | `v2.0.0` | 1 |
| `google/clusterfuzzlite/actions/run_fuzzers` | `884713a6c30a92e5e8544c39945cd7cb630abcd1` | v1 | `v1` | 1 |
| `google/clusterfuzzlite/actions/build_fuzzers` | `884713a6c30a92e5e8544c39945cd7cb630abcd1` | v1 | `v1` | 1 |
| `EmbarkStudios/cargo-deny-action` | `3c6349835b2b7b196a839186cb8b78e02f7b5f25` | v2.1.1 | `v2` | 1 |
| `docker/metadata-action` | `dc802804100637a589fabce1cb79ff13a1411302` | v6.2.0 | `v6` | 1 |
| `docker/login-action` | `dbcb813823bdd20940b903addbd779551569679f` | v4.6.0 | `v4` | 1 |
| `actions/download-artifact` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` | v8.0.1 | `v8` | 1 |
| `actions/cache` | `0057852bfaa89a56745cba8c7296529d2fc39830` | v4.3.0 | `v4` | 1 |
| `dtolnay/rust-toolchain` | `2c7215f132e9ebf062739d9130488b56d53c060c` | *(no version tags)* | **unchanged (SHA kept)** | 10 |

## Version changes within a tag line

**`Swatinem/rust-cache`** — the pinned SHA was not a tagged release. It is the
commit immediately after the `v2.9.0` tag (2026-03-12, ten hours after the
tag), a strict ancestor of the current `v2`. Moving to `v2` therefore advances
it from an untagged post-v2.9.0 commit to **v2.9.2** — a forward move within
the v2 line, not a downgrade.

All other converted actions' tags resolve to the exact previously pinned
commit today; they will float forward as upstream re-points the major tag,
which is the point of the change.

## dtolnay/rust-toolchain: deliberately not converted

This action publishes no per-release version tag, and no existing ref
reproduces the pinned behavior:

- Its only tag, `v1`, is **eleven commits behind** the pinned SHA and predates
  `RUSTUP_PERMIT_COPY_RENAME: 1` (the cross-device-copy fix, upstream #177),
  so tag-pinning would be a behavior regression, not a pin-format change.
- Its channel branches (`@stable`, `@1.95`) drop the `toolchain` key from
  `inputs:` and hardcode the version, which would break the `msrv` job's
  `toolchain: "1.95"` input contract.
- `@master` is a mutable branch ref, which is not an acceptable pin on
  self-hosted runners.

The immutable SHA pin stays, with its `# stable` / `# 1.95` channel comments
intact. All ten usages are byte-identical to their previous form. The
pre-existing bare `dtolnay/rust-toolchain@master` in `fuzz.yml` (toolchain
supplied from the reviewed `fuzz/rust-nightly.txt` pin) is also unchanged.

## Toolchain and MSRV

Unchanged. Toolchain selection is carried by the explicit `toolchain:` input
at every call site, including the `msrv` job's `toolchain: "1.95"`.

## Contract checkers

`scripts/check_ci_image_primer_contract.py` and
`scripts/check_ci_scale_split_contract.py` assert on these pin strings
literally, and the latter hashes the `ci.yml` job bodies containing them; their
unit tests mutate the pin literals to prove the checkers fail closed. All are
updated in lockstep: the tag-converted pins move to tag form, the
rust-toolchain assertions keep the SHA form, and the job-body hashes are
re-derived. Every pin count and every other hashed seam is preserved; the one
job body containing no converted pin (`check`) keeps its original hash as a
control.

## Dependabot

Dependabot will now propose readable tag bumps for the 14 tag-pinned actions
(`actions/checkout` from v7 to v8) instead of SHA-to-SHA diffs. It continues to
propose SHA bumps for `dtolnay/rust-toolchain`, and does not track the local
`./.github/actions/*` refs.

## Gates

| Gate | Exit |
| --- | --- |
| `grep -rhoE "uses: [^ ]+@[0-9a-f]{40}" .github/` → exactly the 10 rust-toolchain pins | 0 |
| YAML parse, all 20 workflow + composite action files | 0 |
| `python3 scripts/check_ci_image_primer_contract.py` | 0 |
| `python3 scripts/check_ci_scale_split_contract.py` | 0 |
| `python3 -m unittest scripts/test_check_ci_image_primer_contract.py` | 0 |
| `python3 -m unittest scripts/test_check_ci_scale_split_contract.py` | 0 |
| `python3 scripts/check_fuzz_toolchain_pin.py` | 0 |
| `cargo fmt --all -- --check` | 0 |
| `python3 scripts/check-clippy-reasons.py` | 0 |

No actionlint or yamllint configuration exists in the repository, so YAML
validation used `yaml.safe_load` over every touched file.
