### PR TITLE
Enforce inbound TCP MD5 and GTSM on the BGP listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Security
+
+- **Inbound TCP MD5 and GTSM were not enforced on the BGP listener**
+  (LAN-902). `md5_password` and `ttl_security` were installed only on
+  active-open (outbound) sockets. The listener accepted unsigned inbound
+  connections for MD5-configured peers, and low-TTL inbound connections
+  for GTSM-configured peers. Dynamic neighbors are passive-only, so an
+  inherited peer-group `md5_password` was accepted in config, reported as
+  configured, and enforced on no socket at any point — a complete silent
+  authentication bypass for the dynamic-peering surface; for static
+  peers the inbound half of every session was unauthenticated even when
+  the outbound half was protected. The listener now installs host-scoped
+  MD5 keys for static neighbors and prefix-scoped keys
+  (`TCP_MD5SIG_EXT`, Linux >= 4.13) for dynamic ranges before
+  `listen()`, and applies strict RFC 5082 `IP_MINTTL` /
+  `IPV6_MINHOPCOUNT` 255 to accepted connections, resolved per peer
+  (exact static match first, then longest dynamic-range match). SIGHUP
+  reload replaces the listener inventory alongside session
+  reconciliation.
+
 ### Added
 
 - `WatchRoutes` now signals subscriber lag in-band with a synthetic
@@ -37,6 +57,30 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   violations, and mismatched received-view scenarios.
 
 ### Changed
+
+- Inbound connections that previously slipped through the unenforced
+  listener are now rejected (LAN-902): an unsigned inbound connection
+  from a peer or dynamic range configured with `md5_password` no longer
+  completes the TCP handshake, and inbound segments arriving with
+  TTL/Hop-Limit below 255 for a `ttl_security` peer are dropped after
+  accept. A peer that was silently interoperating unsigned (or through
+  intermediate hops) against a protected selector will no longer
+  establish — fix that peer's configuration or remove the protection.
+  Conversely, correctly signed inbound connections — previously dropped
+  by the kernel because the listener had no key — now establish.
+  Runtime mutation paths that cannot update the listener now fail
+  loudly instead of pretending: changing `md5_password`/`ttl_security`
+  on an existing peer group via `SetPeerGroup`, changing them on a
+  neighbor via a config transaction, adding a neighbor resolving either
+  via a config transaction, and adding a dynamic range whose peer group
+  carries either via `rbgp`/gRPC are all rejected with
+  restart-required/`FAILED_PRECONDITION` errors directing the change
+  through the config file and SIGHUP reload, which updates the listener
+  atomically with the sessions. A config declaring a plaintext static
+  neighbor (or a plaintext more-specific dynamic range) inside an
+  MD5-protected dynamic range is now rejected at load: the kernel's
+  longest-prefix key match would demand a signature those peers never
+  send.
 
 - GTSM (RFC 5082) now enforces strict TTL/Hop-Limit 255 on receive
   (`IP_MINTTL` / `IPV6_MINHOPCOUNT` raised from 254), matching RFC 5082

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -50,8 +50,9 @@ pub use handle::{
     WarmCheckpointSessionState,
 };
 pub use listener::{
-    AcceptedConnection, BgpListener, ListenerSocketOptions, TcpAoListenerGeneration,
-    TcpAoListenerHandle, TcpAoListenerKey, TcpAoListenerOwnerKind,
+    AcceptedConnection, BgpListener, ListenerSocketOptions, Md5ListenerKey,
+    TcpAoListenerGeneration, TcpAoListenerHandle, TcpAoListenerKey, TcpAoListenerOwnerKind,
+    TtlSecurityListenerPolicy,
 };
 // ADR-0073: import-decision explain types crossing into the api +
 // binary layers (PeerManagerCommand reply, PolicyService mapping).
@@ -62,4 +63,6 @@ pub use session::import_decision_cache::{
 // LAN-472: rejected-route retention types crossing into the api +
 // binary layers (PeerManagerCommand reply, PolicyService mapping).
 pub use session::rejected_routes::{RejectedRouteEntry, RejectedRoutesReply};
-pub use socket_opts::{TcpAoInfoSnapshot, TcpAoKeyState, TcpAoSupport, probe_tcp_ao_support};
+pub use socket_opts::{
+    TcpAoInfoSnapshot, TcpAoKeyState, TcpAoSupport, probe_tcp_ao_support, set_tcp_md5sig,
+};

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -111,11 +111,62 @@ pub enum TcpAoListenerOwnerKind {
     Dynamic,
 }
 
+/// TCP MD5 (RFC 2385) key to install on the inbound listener socket.
+///
+/// Host-length selectors (`/32`, `/128`) key one static neighbor via
+/// `TCP_MD5SIG`; shorter selectors key a dynamic-neighbor range via
+/// `TCP_MD5SIG_EXT` + `TCP_MD5SIG_FLAG_PREFIX`. The kernel resolves
+/// overlapping keys by longest prefix match and copies the matched key onto
+/// each accepted child, so established inbound sessions keep verifying and
+/// signing after listener inventory changes.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Md5ListenerKey {
+    /// Remote network address matched by this key.
+    pub peer: IpAddr,
+    /// Prefix length for the remote network.
+    pub prefix_len: u8,
+    /// MD5 password shared with the covered peers.
+    pub password: crate::config::TransportAuthSecret,
+}
+
+impl std::fmt::Debug for Md5ListenerKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Md5ListenerKey")
+            .field("peer", &self.peer)
+            .field("prefix_len", &self.prefix_len)
+            .field("password", &"<redacted>")
+            .finish()
+    }
+}
+
+/// GTSM (RFC 5082) enforcement selector for inbound accepts.
+///
+/// The listener carries one entry per configured static neighbor and dynamic
+/// range — including `enforce: false` entries — so a static neighbor without
+/// `ttl_security` inside an enforcing dynamic range resolves to its own
+/// policy: exact static match wins, then longest dynamic prefix match.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TtlSecurityListenerPolicy {
+    /// Configuration owner kind for match precedence.
+    pub owner: TcpAoListenerOwnerKind,
+    /// Remote network address matched by this selector.
+    pub peer: IpAddr,
+    /// Prefix length for the remote network.
+    pub prefix_len: u8,
+    /// Whether matched inbound connections require TTL/Hop-Limit 255.
+    pub enforce: bool,
+}
+
 /// Socket options installed before the BGP listener enters `listen(2)`.
 #[derive(Clone, Default)]
 pub struct ListenerSocketOptions {
     /// Static-neighbor TCP-AO MKTs for passive opens.
     pub tcp_ao_keys: Vec<TcpAoListenerKey>,
+    /// TCP MD5 keys for passive opens: host keys for static neighbors,
+    /// prefix keys for dynamic-neighbor ranges.
+    pub md5_keys: Vec<Md5ListenerKey>,
+    /// GTSM selectors applied to accepted children.
+    pub ttl_security: Vec<TtlSecurityListenerPolicy>,
 }
 
 /// BGP inbound listener. Accepts TCP connections and forwards them
@@ -124,6 +175,11 @@ pub struct BgpListener {
     listener: TcpListener,
     accept_tx: mpsc::Sender<AcceptedConnection>,
     tcp_ao_keys: TcpAoListenerKeyIndex,
+    /// TCP MD5 keys currently installed on the listening socket, kept for
+    /// reload-time inventory replacement.
+    md5_keys: Vec<Md5ListenerKey>,
+    /// GTSM selectors applied to accepted children.
+    ttl_security: Vec<TtlSecurityListenerPolicy>,
     /// Latest generation installed in the listener kernel inventory. This may
     /// lead the globally committed generation while sessions are applying.
     tcp_ao_generation: TcpAoRotationGeneration,
@@ -207,6 +263,11 @@ enum TcpAoListenerCommand {
     AcknowledgeGlobalCommit {
         generation: TcpAoRotationGeneration,
         reply: oneshot::Sender<std::io::Result<TcpAoRotationStatus>>,
+    },
+    ReplaceInboundAuth {
+        md5_keys: Vec<Md5ListenerKey>,
+        ttl_security: Vec<TtlSecurityListenerPolicy>,
+        reply: oneshot::Sender<std::io::Result<()>>,
     },
 }
 
@@ -530,6 +591,52 @@ impl TcpAoListenerHandle {
         self.status_rx.borrow().clone()
     }
 
+    /// Replace the listener's TCP MD5 kernel inventory and GTSM selector set
+    /// with the reload-desired state. Established children are unaffected;
+    /// converging replacement semantics make a retry of a partial failure
+    /// safe.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the listener task is unavailable, the control
+    /// deadline expires, or a kernel key install/remove fails (a partial
+    /// application is safe to retry with the identical inventory).
+    pub async fn replace_inbound_auth(
+        &self,
+        md5_keys: Vec<Md5ListenerKey>,
+        ttl_security: Vec<TtlSecurityListenerPolicy>,
+    ) -> std::io::Result<()> {
+        tokio::time::timeout(TCP_AO_ROTATION_CONTROL_TIMEOUT, async {
+            let (reply, response) = oneshot::channel();
+            self.tx
+                .send(TcpAoListenerCommand::ReplaceInboundAuth {
+                    md5_keys,
+                    ttl_security,
+                    reply,
+                })
+                .await
+                .map_err(|_| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::BrokenPipe,
+                        "BGP listener control task exited",
+                    )
+                })?;
+            response.await.map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "BGP listener inbound-auth reply dropped",
+                )
+            })?
+        })
+        .await
+        .map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "BGP listener inbound-auth replacement timed out",
+            )
+        })?
+    }
+
     /// Mark a later global phase (currently established-session apply) failed
     /// after this listener installed but did not globally commit the desired
     /// generation. A retry reuses the same immutable generation.
@@ -769,6 +876,34 @@ impl TcpAoListenerKeyIndex {
     }
 }
 
+/// Resolve whether GTSM is enforced for one inbound peer address, matching
+/// accept-time neighbor resolution: an exact static selector wins, otherwise
+/// the longest covering dynamic selector, otherwise no enforcement.
+fn resolve_ttl_security(policies: &[TtlSecurityListenerPolicy], addr: IpAddr) -> bool {
+    let covers = |policy: &TtlSecurityListenerPolicy| match (policy.peer, addr) {
+        (IpAddr::V4(network), IpAddr::V4(addr)) if policy.prefix_len <= 32 => {
+            mask_v4(network.into(), policy.prefix_len) == mask_v4(addr.into(), policy.prefix_len)
+        }
+        (IpAddr::V6(network), IpAddr::V6(addr)) if policy.prefix_len <= 128 => {
+            mask_v6(network.into(), policy.prefix_len) == mask_v6(addr.into(), policy.prefix_len)
+        }
+        _ => false,
+    };
+    let host_len = if addr.is_ipv4() { 32 } else { 128 };
+    let static_exact = policies.iter().find(|policy| {
+        policy.owner == TcpAoListenerOwnerKind::Static
+            && policy.prefix_len == host_len
+            && covers(policy)
+    });
+    let dynamic_longest = policies
+        .iter()
+        .filter(|policy| policy.owner == TcpAoListenerOwnerKind::Dynamic && covers(policy))
+        .max_by_key(|policy| policy.prefix_len);
+    static_exact
+        .or(dynamic_longest)
+        .is_some_and(|policy| policy.enforce)
+}
+
 fn mask_v4(addr: u32, prefix_len: u8) -> u32 {
     if prefix_len == 0 {
         0
@@ -823,6 +958,12 @@ impl BgpListener {
             addr = %bound_addr,
             requested_addr = %addr,
             tcp_ao_keys,
+            md5_keys = options.md5_keys.len(),
+            ttl_security_selectors = options
+                .ttl_security
+                .iter()
+                .filter(|policy| policy.enforce)
+                .count(),
             "BGP listener bound"
         );
         let (rotation_tx, rotation_rx) = mpsc::channel(4);
@@ -831,6 +972,8 @@ impl BgpListener {
             listener,
             accept_tx,
             tcp_ao_keys: TcpAoListenerKeyIndex::new(options.tcp_ao_keys),
+            md5_keys: options.md5_keys,
+            ttl_security: options.ttl_security,
             tcp_ao_generation: TcpAoRotationGeneration::STARTUP,
             previous_tcp_ao_generation: None,
             tcp_ao_committed_generation: TcpAoRotationGeneration::STARTUP,
@@ -880,6 +1023,22 @@ impl BgpListener {
                         accept_backoff = ACCEPT_BACKOFF_INITIAL;
                         let peer_ip = peer_addr.ip();
                         debug!(%peer_ip, "inbound TCP connection");
+                        // GTSM before any byte of this connection is handed
+                        // to the peer manager. The shared listener socket
+                        // cannot carry per-peer IP_MINTTL, so the accepted
+                        // child gets it here; segments the kernel queued
+                        // between the handshake and this setsockopt are not
+                        // re-filtered, but every later segment (including any
+                        // KEEPALIVE required to reach Established) is.
+                        if resolve_ttl_security(&self.ttl_security, peer_ip)
+                            && let Err(err) = crate::socket_opts::set_gtsm(
+                                &socket2::SockRef::from(&stream),
+                                peer_addr,
+                            )
+                        {
+                            warn!(peer = %peer_ip, error = %err, "rejecting inbound connection: GTSM TTL policy could not be installed");
+                            continue;
+                        }
                         let tcp_ao_info = match self.inspect_tcp_ao_accept(&stream, peer_ip) {
                             Ok(info) => info,
                             Err(err) => {
@@ -960,6 +1119,13 @@ impl BgpListener {
                 reply,
             } => {
                 let _ = reply.send(self.mark_awaiting_peer_generation(generation, detail));
+            }
+            TcpAoListenerCommand::ReplaceInboundAuth {
+                md5_keys,
+                ttl_security,
+                reply,
+            } => {
+                let _ = reply.send(self.replace_inbound_auth(md5_keys, ttl_security));
             }
             TcpAoListenerCommand::MarkDependentFailure {
                 generation,
@@ -1671,6 +1837,26 @@ impl BgpListener {
         Ok(status)
     }
 
+    /// Replace the listener MD5 kernel inventory and the GTSM selector set
+    /// with the reload-desired state. MD5 password changes are inherently
+    /// session-disruptive (both ends must move together), so unlike TCP-AO
+    /// rotation this is a plain converging replacement: adds are kernel
+    /// replaces and a retried partial application converges.
+    fn replace_inbound_auth(
+        &mut self,
+        md5_keys: Vec<Md5ListenerKey>,
+        ttl_security: Vec<TtlSecurityListenerPolicy>,
+    ) -> std::io::Result<()> {
+        apply_md5_inventory(
+            &socket2::SockRef::from(&self.listener),
+            &self.md5_keys,
+            &md5_keys,
+        )?;
+        self.md5_keys = md5_keys;
+        self.ttl_security = ttl_security;
+        Ok(())
+    }
+
     fn inspect_tcp_ao_accept(
         &self,
         stream: &TcpStream,
@@ -2195,6 +2381,7 @@ fn plan_add_only_listener_generation<'a>(
 
     let desired_options = ListenerSocketOptions {
         tcp_ao_keys: desired.to_vec(),
+        ..ListenerSocketOptions::default()
     };
     validate_listener_tcp_ao_capacity(&desired_options)?;
     let mut additions = Vec::new();
@@ -2363,11 +2550,87 @@ where
             debug!(peer = %key.peer, send_id = config.send_id, "TCP-AO listener key configured");
         }
     }
+    for key in &options.md5_keys {
+        // Like the MKTs above, these are peer/prefix-scoped: an inbound peer
+        // covered by a key must sign (unsigned segments are dropped in the
+        // kernel before the handshake completes), while uncovered peers on
+        // the shared listener are unaffected. The kernel copies the matched
+        // key onto each accepted child, so established sessions keep
+        // verifying and signing without per-accept work here.
+        install_listener_md5_key(&socket, key)?;
+        debug!(peer = %key.peer, prefix_len = key.prefix_len, "TCP MD5 listener key configured");
+    }
     socket.listen(DEFAULT_LISTEN_BACKLOG)?;
     socket.set_nonblocking(true)?;
 
     let std_listener: std::net::TcpListener = socket.into();
     TcpListener::from_std(std_listener)
+}
+
+/// Install one listener MD5 key: host-length selectors through `TCP_MD5SIG`,
+/// range selectors through `TCP_MD5SIG_EXT` prefix keying. Reinstalling an
+/// existing selector replaces its password.
+fn install_listener_md5_key(socket: &Socket, key: &Md5ListenerKey) -> std::io::Result<()> {
+    let host_len = if key.peer.is_ipv4() { 32 } else { 128 };
+    let result = if key.prefix_len >= host_len {
+        crate::socket_opts::set_tcp_md5sig(
+            socket,
+            SocketAddr::new(key.peer, 0),
+            key.password.as_ref(),
+        )
+    } else {
+        crate::socket_opts::set_tcp_md5sig_prefix(
+            socket,
+            key.peer,
+            key.prefix_len,
+            key.password.as_ref(),
+        )
+    };
+    result.map_err(|err| {
+        std::io::Error::new(
+            err.kind(),
+            format!(
+                "failed to install listener TCP MD5 key for {}/{}: {err}",
+                key.peer, key.prefix_len
+            ),
+        )
+    })
+}
+
+/// Converge the listening socket's kernel MD5 inventory from `current` to
+/// `desired`: install new or re-passworded selectors (kernel add is a
+/// replace), then delete selectors no longer present. Deleting a key does not
+/// affect established children, which own kernel copies of the key they were
+/// accepted under.
+fn apply_md5_inventory(
+    socket: &Socket,
+    current: &[Md5ListenerKey],
+    desired: &[Md5ListenerKey],
+) -> std::io::Result<()> {
+    for key in desired {
+        if !current.contains(key) {
+            install_listener_md5_key(socket, key)?;
+        }
+    }
+    for key in current {
+        let selector_retained = desired
+            .iter()
+            .any(|kept| kept.peer == key.peer && kept.prefix_len == key.prefix_len);
+        if !selector_retained {
+            crate::socket_opts::remove_tcp_md5sig(socket, key.peer, key.prefix_len).map_err(
+                |err| {
+                    std::io::Error::new(
+                        err.kind(),
+                        format!(
+                            "failed to remove listener TCP MD5 key for {}/{}: {err}",
+                            key.peer, key.prefix_len
+                        ),
+                    )
+                },
+            )?;
+        }
+    }
+    Ok(())
 }
 
 fn validate_listener_tcp_ao_capacity(options: &ListenerSocketOptions) -> std::io::Result<()> {
@@ -2556,7 +2819,10 @@ mod tests {
                 }
             })
             .collect();
-        ListenerSocketOptions { tcp_ao_keys }
+        ListenerSocketOptions {
+            tcp_ao_keys,
+            ..ListenerSocketOptions::default()
+        }
     }
 
     #[test]
@@ -3720,6 +3986,7 @@ mod tests {
                 prefix_len: 32,
                 config: TcpAoKeyring(vec![tcp_ao_config().0.remove(0), second]),
             }],
+            ..ListenerSocketOptions::default()
         };
 
         let listener = bind_socket2_listener_with(
@@ -3775,6 +4042,7 @@ mod tests {
                 prefix_len: 32,
                 config: TcpAoKeyring(vec![tcp_ao_config().0.remove(0), second]),
             }],
+            ..ListenerSocketOptions::default()
         };
 
         let err = bind_socket2_listener_with(
@@ -3862,6 +4130,7 @@ mod tests {
             accept_tx,
             ListenerSocketOptions {
                 tcp_ao_keys: vec![owner.clone()],
+                ..ListenerSocketOptions::default()
             },
         )
         .await
@@ -4056,6 +4325,7 @@ mod tests {
                         config: static_config.clone(),
                     },
                 ],
+                ..ListenerSocketOptions::default()
             },
         )
         .await

--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -62,20 +62,32 @@ impl Drop for TcpMd5Sig {
     }
 }
 
-/// Set TCP MD5 signature on a socket for a specific peer.
-///
-/// This implements RFC 2385 by calling `setsockopt(TCP_MD5SIG)` on Linux.
-/// The password is associated with a specific peer address.
+/// `setsockopt` names from `include/uapi/linux/tcp.h`. `TCP_MD5SIG` keys one
+/// exact peer address; `TCP_MD5SIG_EXT` (Linux >= 4.13) honors `tcpm_flags` /
+/// `tcpm_prefixlen`, which is the only kernel form that can key a whole
+/// dynamic-neighbor prefix on a listening socket.
+#[cfg(target_os = "linux")]
+const TCP_MD5SIG: libc::c_int = 14;
+#[cfg(target_os = "linux")]
+const TCP_MD5SIG_EXT: libc::c_int = 32;
+#[cfg(target_os = "linux")]
+const TCP_MD5SIG_FLAG_PREFIX: u8 = 0x1;
+
+/// One `setsockopt(TCP_MD5SIG[_EXT])` call. An empty `key` deletes the
+/// matching kernel MD5 key (that is the kernel's own deletion encoding).
 #[cfg(target_os = "linux")]
 #[allow(
     unsafe_code,
     clippy::cast_possible_truncation,
     reason = "Linux socket option ABI requires raw libc structs and socklen_t casts"
 )]
-pub fn set_tcp_md5sig(socket: &Socket, peer: SocketAddr, password: &str) -> io::Result<()> {
+fn tcp_md5sig_setsockopt(
+    socket: &Socket,
+    peer: SocketAddr,
+    prefix_len: Option<u8>,
+    key_bytes: &[u8],
+) -> io::Result<()> {
     use std::mem;
-
-    const TCP_MD5SIG: libc::c_int = 14;
 
     let peer_sa: socket2::SockAddr = peer.into();
     let mut sig = TcpMd5Sig::zeroed();
@@ -88,7 +100,6 @@ pub fn set_tcp_md5sig(socket: &Socket, peer: SocketAddr, password: &str) -> io::
         std::ptr::copy_nonoverlapping(sa_bytes, dst, sa_len);
     }
 
-    let key_bytes = password.as_bytes();
     if key_bytes.len() > TCP_MD5SIG_MAXKEYLEN {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -99,13 +110,21 @@ pub fn set_tcp_md5sig(socket: &Socket, peer: SocketAddr, password: &str) -> io::
     sig.tcpm_keylen = key_bytes.len() as u16;
     sig.tcpm_key[..key_bytes.len()].copy_from_slice(key_bytes);
 
+    let optname = if let Some(prefix_len) = prefix_len {
+        sig.tcpm_flags = TCP_MD5SIG_FLAG_PREFIX;
+        sig.tcpm_prefixlen = prefix_len;
+        TCP_MD5SIG_EXT
+    } else {
+        TCP_MD5SIG
+    };
+
     let fd = socket.as_raw_fd();
 
     let ret = unsafe {
         libc::setsockopt(
             fd,
             libc::IPPROTO_TCP,
-            TCP_MD5SIG,
+            optname,
             (&raw const sig).cast(),
             // Safe: size_of TcpMd5Sig is well under u32::MAX
             mem::size_of::<TcpMd5Sig>() as libc::socklen_t,
@@ -119,9 +138,93 @@ pub fn set_tcp_md5sig(socket: &Socket, peer: SocketAddr, password: &str) -> io::
     }
 }
 
+/// Set TCP MD5 signature on a socket for a specific peer.
+///
+/// This implements RFC 2385 by calling `setsockopt(TCP_MD5SIG)` on Linux.
+/// The password is associated with a specific peer address.
+///
+/// # Errors
+///
+/// Returns the kernel `setsockopt` error, or `InvalidInput` when the
+/// password exceeds the 80-byte kernel key limit.
+#[cfg(target_os = "linux")]
+pub fn set_tcp_md5sig(socket: &Socket, peer: SocketAddr, password: &str) -> io::Result<()> {
+    tcp_md5sig_setsockopt(socket, peer, None, password.as_bytes())
+}
+
+/// Set a prefix-scoped TCP MD5 key (RFC 2385) covering every peer inside
+/// `peer/prefix_len`, via `setsockopt(TCP_MD5SIG_EXT)` with
+/// `TCP_MD5SIG_FLAG_PREFIX` (Linux >= 4.13). This is the listener-side form
+/// used for dynamic-neighbor ranges: the kernel resolves overlapping keys by
+/// longest prefix match, so an exact host key still wins over a range key.
+///
+/// # Errors
+///
+/// Returns the kernel `setsockopt` error (`ENOPROTOOPT` on kernels without
+/// `TCP_MD5SIG_EXT`), or `InvalidInput` for an oversized password.
+#[cfg(target_os = "linux")]
+pub fn set_tcp_md5sig_prefix(
+    socket: &Socket,
+    peer: IpAddr,
+    prefix_len: u8,
+    password: &str,
+) -> io::Result<()> {
+    tcp_md5sig_setsockopt(
+        socket,
+        SocketAddr::new(peer, 0),
+        Some(prefix_len),
+        password.as_bytes(),
+    )
+}
+
+/// Remove the TCP MD5 key for `peer/prefix_len` from a socket. Host-length
+/// selectors (`/32`, `/128`) delete through plain `TCP_MD5SIG`, matching how
+/// they were installed. `ENOENT` (no such key) is treated as success so a
+/// retried inventory replacement converges.
+///
+/// # Errors
+///
+/// Returns any kernel `setsockopt` error other than `ENOENT`.
+#[cfg(target_os = "linux")]
+pub fn remove_tcp_md5sig(socket: &Socket, peer: IpAddr, prefix_len: u8) -> io::Result<()> {
+    let host_len = if peer.is_ipv4() { 32 } else { 128 };
+    let prefix = (prefix_len < host_len).then_some(prefix_len);
+    match tcp_md5sig_setsockopt(socket, SocketAddr::new(peer, 0), prefix, &[]) {
+        Err(err) if err.raw_os_error() == Some(libc::ENOENT) => Ok(()),
+        result => result,
+    }
+}
+
 /// Stub for non-Linux platforms.
 #[cfg(not(target_os = "linux"))]
 pub fn set_tcp_md5sig(_socket: &Socket, _peer: SocketAddr, _password: &str) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "TCP MD5 authentication is only supported on Linux",
+    ))
+}
+
+/// Stub for non-Linux platforms.
+#[cfg(not(target_os = "linux"))]
+pub fn set_tcp_md5sig_prefix(
+    _socket: &Socket,
+    _peer: std::net::IpAddr,
+    _prefix_len: u8,
+    _password: &str,
+) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "TCP MD5 authentication is only supported on Linux",
+    ))
+}
+
+/// Stub for non-Linux platforms.
+#[cfg(not(target_os = "linux"))]
+pub fn remove_tcp_md5sig(
+    _socket: &Socket,
+    _peer: std::net::IpAddr,
+    _prefix_len: u8,
+) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "TCP MD5 authentication is only supported on Linux",

--- a/crates/transport/tests/listener.rs
+++ b/crates/transport/tests/listener.rs
@@ -4,6 +4,328 @@ use rustbgpd_transport::BgpListener;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 
+#[cfg(target_os = "linux")]
+mod inbound_auth {
+    use std::io::Write;
+    use std::net::{IpAddr, SocketAddr};
+    use std::time::Duration;
+
+    use rustbgpd_transport::{
+        AcceptedConnection, BgpListener, ListenerSocketOptions, Md5ListenerKey,
+        TcpAoListenerOwnerKind, TtlSecurityListenerPolicy, set_tcp_md5sig,
+    };
+    use tokio::io::AsyncReadExt;
+    use tokio::sync::mpsc;
+
+    const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+    const ACCEPT_TIMEOUT: Duration = Duration::from_secs(2);
+    const READ_TIMEOUT: Duration = Duration::from_secs(1);
+
+    async fn bind_listener(
+        options: ListenerSocketOptions,
+    ) -> (SocketAddr, mpsc::Receiver<AcceptedConnection>) {
+        let (accept_tx, accept_rx) = mpsc::channel(4);
+        let listener =
+            BgpListener::bind_with_options("127.0.0.1:0".parse().unwrap(), accept_tx, options)
+                .await
+                .expect("listener bind with inbound auth options");
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(listener.run());
+        (addr, accept_rx)
+    }
+
+    /// Blocking loopback client. `md5_password` signs every segment for the
+    /// server address; `source` binds an explicit 127/8 source address; `ttl`
+    /// overrides the outgoing IPv4 TTL.
+    fn connect_client(
+        server: SocketAddr,
+        source: Option<IpAddr>,
+        md5_password: Option<&str>,
+        ttl: Option<u32>,
+    ) -> std::io::Result<std::net::TcpStream> {
+        let socket = socket2::Socket::new(
+            socket2::Domain::IPV4,
+            socket2::Type::STREAM,
+            Some(socket2::Protocol::TCP),
+        )?;
+        if let Some(password) = md5_password {
+            set_tcp_md5sig(&socket, server, password)?;
+        }
+        if let Some(ttl) = ttl {
+            socket.set_ttl_v4(ttl)?;
+        }
+        if let Some(source) = source {
+            socket.bind(&SocketAddr::new(source, 0).into())?;
+        }
+        socket.connect_timeout(&server.into(), CONNECT_TIMEOUT)?;
+        Ok(socket.into())
+    }
+
+    async fn spawn_connect(
+        server: SocketAddr,
+        source: Option<IpAddr>,
+        md5_password: Option<String>,
+        ttl: Option<u32>,
+    ) -> std::io::Result<std::net::TcpStream> {
+        tokio::task::spawn_blocking(move || {
+            connect_client(server, source, md5_password.as_deref(), ttl)
+        })
+        .await
+        .expect("client connect task")
+    }
+
+    async fn expect_accept(rx: &mut mpsc::Receiver<AcceptedConnection>) -> AcceptedConnection {
+        tokio::time::timeout(ACCEPT_TIMEOUT, rx.recv())
+            .await
+            .expect("listener did not accept connection")
+            .expect("accept channel closed")
+    }
+
+    /// Write from the blocking client and expect the bytes to arrive on the
+    /// accepted stream.
+    async fn expect_data_flows(mut client: std::net::TcpStream, mut accepted: AcceptedConnection) {
+        tokio::task::spawn_blocking(move || {
+            client.write_all(b"ping").expect("client write");
+            // Keep the client socket open until the server has read.
+            std::thread::sleep(Duration::from_millis(500));
+        });
+        let mut buf = [0u8; 4];
+        tokio::time::timeout(READ_TIMEOUT, accepted.stream.read_exact(&mut buf))
+            .await
+            .expect("inbound data did not arrive on the accepted connection")
+            .expect("read accepted stream");
+        assert_eq!(&buf, b"ping");
+    }
+
+    /// Write from the blocking client and expect the accepted stream to see
+    /// nothing: the kernel must drop the client's segments.
+    async fn expect_data_blocked(
+        mut client: std::net::TcpStream,
+        mut accepted: AcceptedConnection,
+    ) {
+        tokio::task::spawn_blocking(move || {
+            let _ = client.write_all(b"ping");
+            std::thread::sleep(Duration::from_millis(1500));
+        });
+        let mut buf = [0u8; 4];
+        let read = tokio::time::timeout(READ_TIMEOUT, accepted.stream.read_exact(&mut buf)).await;
+        assert!(
+            read.is_err(),
+            "inbound data from a GTSM-violating peer reached the accepted connection"
+        );
+    }
+
+    fn md5_options(peer: IpAddr, prefix_len: u8, password: &str) -> ListenerSocketOptions {
+        ListenerSocketOptions {
+            md5_keys: vec![Md5ListenerKey {
+                peer,
+                prefix_len,
+                password: password.into(),
+            }],
+            ..ListenerSocketOptions::default()
+        }
+    }
+
+    /// A static neighbor's configured MD5 password must be enforced on the
+    /// inbound half: an unsigned connection may not even complete the
+    /// handshake, while a correctly signed one establishes and carries data
+    /// (proving the accepted child inherited the key).
+    #[tokio::test]
+    async fn md5_host_key_rejects_unsigned_static_inbound() {
+        let password = "lan902-static-secret";
+        let (addr, mut accept_rx) =
+            bind_listener(md5_options("127.0.0.1".parse().unwrap(), 32, password)).await;
+
+        let unsigned = spawn_connect(addr, None, None, None).await;
+        assert!(
+            unsigned.is_err(),
+            "unsigned inbound connection completed against an MD5-protected static neighbor"
+        );
+
+        let signed = spawn_connect(addr, None, Some(password.to_string()), None)
+            .await
+            .expect("signed inbound connection");
+        let accepted = expect_accept(&mut accept_rx).await;
+        assert!(accepted.tcp_ao_info.is_none());
+        expect_data_flows(signed, accepted).await;
+    }
+
+    /// A dynamic-neighbor range's MD5 password must be enforced for every
+    /// address in the range via a prefix-scoped kernel key (TCP_MD5SIG_EXT):
+    /// unsigned members are rejected, signed members establish.
+    #[tokio::test]
+    async fn md5_prefix_key_rejects_unsigned_dynamic_inbound() {
+        let password = "lan902-dynamic-secret";
+        let (addr, mut accept_rx) =
+            bind_listener(md5_options("127.0.0.0".parse().unwrap(), 8, password)).await;
+
+        let unsigned = spawn_connect(addr, Some("127.0.0.2".parse().unwrap()), None, None).await;
+        assert!(
+            unsigned.is_err(),
+            "unsigned inbound connection completed against an MD5-protected dynamic range"
+        );
+
+        let signed = spawn_connect(
+            addr,
+            Some("127.0.0.3".parse().unwrap()),
+            Some(password.to_string()),
+            None,
+        )
+        .await
+        .expect("signed inbound connection from dynamic range");
+        let accepted = expect_accept(&mut accept_rx).await;
+        assert_eq!(
+            accepted.peer_addr.ip(),
+            "127.0.0.3".parse::<IpAddr>().unwrap()
+        );
+        expect_data_flows(signed, accepted).await;
+    }
+
+    /// Peer-scoped listener keys must not affect uncovered peers on the
+    /// shared listener: a peer outside every configured selector stays
+    /// plaintext.
+    #[tokio::test]
+    async fn md5_keys_leave_uncovered_peers_plaintext() {
+        let (addr, mut accept_rx) = bind_listener(md5_options(
+            "127.0.0.9".parse().unwrap(),
+            32,
+            "covered-only",
+        ))
+        .await;
+
+        let plaintext = spawn_connect(addr, None, None, None)
+            .await
+            .expect("uncovered plaintext inbound connection");
+        let accepted = expect_accept(&mut accept_rx).await;
+        expect_data_flows(plaintext, accepted).await;
+    }
+
+    /// GTSM for a static neighbor: after accept, segments arriving with a
+    /// TTL below 255 must be dropped in the kernel, while a compliant
+    /// TTL-255 sender's data arrives.
+    #[tokio::test]
+    async fn ttl_security_rejects_low_ttl_static_inbound() {
+        let options = ListenerSocketOptions {
+            ttl_security: vec![TtlSecurityListenerPolicy {
+                owner: TcpAoListenerOwnerKind::Static,
+                peer: "127.0.0.1".parse().unwrap(),
+                prefix_len: 32,
+                enforce: true,
+            }],
+            ..ListenerSocketOptions::default()
+        };
+        let (addr, mut accept_rx) = bind_listener(options).await;
+
+        // Default loopback TTL (64) violates strict RFC 5082 §3.2.
+        let low_ttl = spawn_connect(addr, None, None, None)
+            .await
+            .expect("TCP handshake for low-TTL client");
+        let accepted = expect_accept(&mut accept_rx).await;
+        expect_data_blocked(low_ttl, accepted).await;
+
+        let compliant = spawn_connect(addr, None, None, Some(255))
+            .await
+            .expect("TCP handshake for TTL-255 client");
+        let accepted = expect_accept(&mut accept_rx).await;
+        expect_data_flows(compliant, accepted).await;
+    }
+
+    /// GTSM for a dynamic range, with a static exception inside it: the
+    /// range member is enforced, the static neighbor resolves to its own
+    /// non-enforcing policy.
+    #[tokio::test]
+    async fn ttl_security_dynamic_range_with_static_exception() {
+        let options = ListenerSocketOptions {
+            ttl_security: vec![
+                TtlSecurityListenerPolicy {
+                    owner: TcpAoListenerOwnerKind::Dynamic,
+                    peer: "127.0.0.0".parse().unwrap(),
+                    prefix_len: 8,
+                    enforce: true,
+                },
+                TtlSecurityListenerPolicy {
+                    owner: TcpAoListenerOwnerKind::Static,
+                    peer: "127.0.0.1".parse().unwrap(),
+                    prefix_len: 32,
+                    enforce: false,
+                },
+            ],
+            ..ListenerSocketOptions::default()
+        };
+        let (addr, mut accept_rx) = bind_listener(options).await;
+
+        let range_member = spawn_connect(addr, Some("127.0.0.7".parse().unwrap()), None, None)
+            .await
+            .expect("TCP handshake for dynamic-range client");
+        let accepted = expect_accept(&mut accept_rx).await;
+        expect_data_blocked(range_member, accepted).await;
+
+        let static_exception = spawn_connect(addr, None, None, None)
+            .await
+            .expect("TCP handshake for static-exception client");
+        let accepted = expect_accept(&mut accept_rx).await;
+        expect_data_flows(static_exception, accepted).await;
+    }
+
+    /// Reload-time inventory replacement: a password change takes effect on
+    /// the live listener (old rejected, new accepted), and removing the key
+    /// returns the selector to plaintext.
+    #[tokio::test]
+    async fn replace_inbound_auth_swaps_and_removes_md5_keys() {
+        let peer: IpAddr = "127.0.0.1".parse().unwrap();
+        let (accept_tx, mut accept_rx) = mpsc::channel(4);
+        let listener = BgpListener::bind_with_options(
+            "127.0.0.1:0".parse().unwrap(),
+            accept_tx,
+            md5_options(peer, 32, "old-secret"),
+        )
+        .await
+        .expect("listener bind with initial MD5 key");
+        let addr = listener.local_addr().unwrap();
+        let control = listener.tcp_ao_rotation_handle();
+        tokio::spawn(listener.run());
+
+        let signed_old = spawn_connect(addr, None, Some("old-secret".to_string()), None)
+            .await
+            .expect("inbound signed with the initial password");
+        let accepted = expect_accept(&mut accept_rx).await;
+        expect_data_flows(signed_old, accepted).await;
+
+        control
+            .replace_inbound_auth(
+                vec![Md5ListenerKey {
+                    peer,
+                    prefix_len: 32,
+                    password: "new-secret".into(),
+                }],
+                Vec::new(),
+            )
+            .await
+            .expect("replace listener MD5 inventory");
+
+        let stale = spawn_connect(addr, None, Some("old-secret".to_string()), None).await;
+        assert!(
+            stale.is_err(),
+            "old password still accepted after inventory replacement"
+        );
+        let signed_new = spawn_connect(addr, None, Some("new-secret".to_string()), None)
+            .await
+            .expect("inbound signed with the replaced password");
+        let accepted = expect_accept(&mut accept_rx).await;
+        expect_data_flows(signed_new, accepted).await;
+
+        control
+            .replace_inbound_auth(Vec::new(), Vec::new())
+            .await
+            .expect("remove listener MD5 inventory");
+        let plaintext = spawn_connect(addr, None, None, None)
+            .await
+            .expect("plaintext inbound after key removal");
+        let accepted = expect_accept(&mut accept_rx).await;
+        expect_data_flows(plaintext, accepted).await;
+    }
+}
+
 #[tokio::test]
 async fn socket2_backed_listener_accepts_tcp_connections() {
     let (accept_tx, mut accept_rx) = mpsc::channel(4);

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -590,7 +590,7 @@ This section defines the security stance for rustbgpd. Not all items are v1 impl
 
 **Supported platforms (v1): Linux (x86_64, aarch64).** TCP MD5, GTSM via `IP_TTL`, and certain socket options are Linux-specific. macOS and BSD may work for development builds but are not tested or supported targets. This is stated explicitly to prevent bug reports about platform-specific socket behavior.
 
-**TCP MD5 (RFC 2385):** Supported in v1. This is table stakes for any BGP daemon deployed in production — most peers will require it. Implemented via `setsockopt(TCP_MD5SIG)` on the listener and per-peer outbound sockets. Linux only.
+**TCP MD5 (RFC 2385):** Supported in v1. This is table stakes for any BGP daemon deployed in production — most peers will require it. Active-open sockets install the password via `setsockopt(TCP_MD5SIG)` before `connect()`. The passive BGP listener installs host-scoped keys for static neighbors (`TCP_MD5SIG`) and prefix-scoped keys for dynamic-neighbor ranges (`TCP_MD5SIG_EXT` with `TCP_MD5SIG_FLAG_PREFIX`, Linux ≥ 4.13) before `listen()`; the kernel resolves overlapping keys by longest prefix match, rejects unsigned segments from covered peers during the handshake, and copies the matched key onto each accepted child. SIGHUP reload replaces the listener key inventory; a changed password is inherently session-disruptive. Linux only.
 
 **TCP-AO (RFC 5925):** Staged via ADR-0062. Static-neighbor and direct
 dynamic-prefix `tcp_ao` TOML accepts ordered keyrings on Linux:
@@ -607,7 +607,7 @@ MKTs that are neither Current nor RNext while keeping the owner set, survivor
 order, key definitions, and selected key exact. Protected-owner changes and
 key edits/reordering remain restart-required.
 
-**GTSM (RFC 5082):** Supported in v1 as a configurable option (`ttl_security = true` per neighbor). Sets `IP_TTL` to 255 on outbound and requires inbound TTL exactly 255 (strict RFC 5082 §3.2, matching FRR/BIRD). Simple, effective, and prevents most remote session hijacking.
+**GTSM (RFC 5082):** Supported in v1 as a configurable option (`ttl_security = true` per neighbor or peer group). Sets TTL/Hop-Limit 255 on outbound and requires inbound TTL exactly 255 (strict RFC 5082 §3.2, matching FRR/BIRD) via `IP_MINTTL` / `IPV6_MINHOPCOUNT`. Active-open sockets are configured before `connect()`; inbound connections are configured on the accepted socket at accept time, resolved per peer (exact static neighbor first, then longest dynamic-range match), since the shared listener socket cannot carry per-peer TTL policy — handshake segments therefore precede the filter, but every later segment, including any KEEPALIVE required to reach Established, is enforced. Simple, effective, and prevents most remote session hijacking.
 
 ### Connection Rate Limiting
 

--- a/docs/adr/0016-socket2-for-md5-gtsm.md
+++ b/docs/adr/0016-socket2-for-md5-gtsm.md
@@ -2,6 +2,16 @@
 
 **Status:** Accepted
 **Date:** 2026-02-27
+**Update (2026-08):** the decision below covered only the active-open
+(outbound) socket; the inbound half was unenforced until LAN-902. The passive
+BGP listener now installs host-scoped MD5 keys for static neighbors
+(`TCP_MD5SIG`) and prefix-scoped keys for dynamic-neighbor ranges
+(`TCP_MD5SIG_EXT` + `TCP_MD5SIG_FLAG_PREFIX`, Linux ≥ 4.13) before
+`listen()` — the kernel rejects unsigned handshakes from covered peers and
+copies the matched key onto accepted children. GTSM is applied per peer on
+each accepted socket at accept time (`IP_MINTTL` / `IPV6_MINHOPCOUNT`),
+resolved exact-static-first then longest dynamic-range match, because the
+shared listener socket cannot carry per-peer TTL policy.
 
 ## Context
 

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -154,7 +154,7 @@ shape itself does not raise the tier.
 |-----|------|-------|
 | `ListPeerGroups` | `sensitive_read` | Exposes group templates including inherited policy chain names; `md5_password` is redacted from read responses and represented by `has_md5_password`. |
 | `GetPeerGroup` | `sensitive_read` | Single-group; `md5_password` is redacted from read responses and represented by `has_md5_password`. |
-| `SetPeerGroup` | `operator_only` | Edits propagate to every neighbor inheriting the group — blast radius is N peers, not one. This is also the current gRPC-visible credential ingress for `md5_password`. |
+| `SetPeerGroup` | `operator_only` | Edits propagate to every neighbor inheriting the group — blast radius is N peers, not one. `md5_password` may be set when creating a group, but changing `md5_password` or `ttl_security` on an existing group is rejected `FAILED_PRECONDITION`: the inbound listener key/TTL inventory is updated only by startup or SIGHUP reload. |
 | `DeletePeerGroup` | `operator_only` | Same propagation; will fail if any neighbor still references the group. |
 | `SetNeighborPeerGroup` | `mutating` | Single-neighbor reassignment. |
 | `ClearNeighborPeerGroup` | `mutating` | Single-neighbor. |
@@ -293,7 +293,9 @@ specific method if the model warrants it.
    reject at handshake, not pretend to filter per-event.
 5. **Credential ingress is narrow but not `AddNeighbor`.** The
    gRPC-visible credential-bearing field today is
-   `PeerGroupDefinition.md5_password` through `SetPeerGroup`; static
+   `PeerGroupDefinition.md5_password` through `SetPeerGroup` (group
+   creation only — changing it on an existing group is rejected because
+   the inbound listener key inventory is startup/SIGHUP-pinned); static
    neighbor TCP-AO is TOML/runtime-only and is not exposed through
    gRPC. Read paths never echo secret material back:
    `ListPeerGroups` and `GetPeerGroup` redact `md5_password` instead

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -8794,6 +8794,90 @@ remote_asn = 65002
 }
 
 #[test]
+fn md5_dynamic_range_rejects_plaintext_static_neighbor_inside_prefix() {
+    let err = parse(&dynamic_tcp_ao_toml(
+        r#"
+[peer_groups.md5-members]
+md5_password = "range-secret"
+
+[[dynamic_neighbors]]
+prefix = "10.0.0.0/24"
+peer_group = "md5-members"
+
+[[neighbors]]
+address = "10.0.0.42"
+remote_asn = 65002
+"#,
+    ))
+    .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("has no md5_password: the kernel's prefix key would require a signature"),
+        "unexpected error: {err}"
+    );
+
+    // The same shape with a password on the inside neighbor is accepted: the
+    // kernel resolves the host key by longest prefix match.
+    parse(&dynamic_tcp_ao_toml(
+        r#"
+[peer_groups.md5-members]
+md5_password = "range-secret"
+
+[[dynamic_neighbors]]
+prefix = "10.0.0.0/24"
+peer_group = "md5-members"
+
+[[neighbors]]
+address = "10.0.0.42"
+remote_asn = 65002
+md5_password = "host-secret"
+"#,
+    ))
+    .unwrap();
+}
+
+#[test]
+fn md5_dynamic_range_rejects_nested_plaintext_dynamic_range() {
+    let err = parse(&dynamic_tcp_ao_toml(
+        r#"
+[peer_groups.md5-members]
+md5_password = "range-secret"
+
+[[dynamic_neighbors]]
+prefix = "10.0.0.0/16"
+peer_group = "md5-members"
+
+[[dynamic_neighbors]]
+prefix = "10.0.7.0/24"
+peer_group = "ix-members"
+"#,
+    ))
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("nests inside MD5-protected"),
+        "unexpected error: {err}"
+    );
+
+    // The inverse nesting is consistent: the more specific MD5 range wins
+    // both the accept-time group match and the kernel key lookup.
+    parse(&dynamic_tcp_ao_toml(
+        r#"
+[peer_groups.md5-members]
+md5_password = "range-secret"
+
+[[dynamic_neighbors]]
+prefix = "10.0.0.0/16"
+peer_group = "ix-members"
+
+[[dynamic_neighbors]]
+prefix = "10.0.7.0/24"
+peer_group = "md5-members"
+"#,
+    ))
+    .unwrap();
+}
+
+#[test]
 fn overlapping_tcp_ao_owners_require_directionally_disjoint_ids() {
     let allowed = dynamic_tcp_ao_toml(
         r#"

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -1232,6 +1232,82 @@ impl Config {
             }
         }
 
+        // Inbound MD5 for a dynamic range is enforced with a prefix-scoped
+        // kernel key on the shared listener, and the kernel resolves
+        // overlapping keys by longest prefix match. Any address whose
+        // accept-time configuration resolves to "no MD5" but whose kernel
+        // key lookup resolves to a range key would be silently forced to
+        // sign — its legitimate unsigned connection dropped with no
+        // counterpart socket ever knowing why. Reject those shapes at load.
+        for (i, dn) in self.dynamic_neighbors.iter().enumerate() {
+            if dn.tcp_ao.is_some() {
+                continue;
+            }
+            let range_has_md5 = self
+                .peer_groups
+                .get(&dn.peer_group)
+                .is_some_and(|group| group.md5_password.is_some());
+            if !range_has_md5 {
+                continue;
+            }
+            for neighbor in &self.neighbors {
+                let Ok(address) = neighbor.address.parse::<IpAddr>() else {
+                    continue;
+                };
+                let host_prefix = (address, if address.is_ipv4() { 32 } else { 128 });
+                if !dynamic_prefixes_intersect(parsed_dynamic_prefixes[i], host_prefix)
+                    || neighbor.tcp_ao.is_some()
+                {
+                    continue;
+                }
+                let neighbor_has_md5 = neighbor.md5_password.is_some()
+                    || neighbor
+                        .peer_group
+                        .as_deref()
+                        .and_then(|name| self.peer_groups.get(name))
+                        .is_some_and(|group| group.md5_password.is_some());
+                if !neighbor_has_md5 {
+                    return Err(ConfigError::InvalidDynamicNeighbor {
+                        reason: format!(
+                            "dynamic_neighbors[{i}] {:?} requires MD5 via peer_group {:?}, but \
+                             static neighbor {:?} inside the range has no md5_password: the \
+                             kernel's prefix key would require a signature this neighbor never \
+                             sends. Give the neighbor an md5_password or move it outside the \
+                             range",
+                            dn.prefix, dn.peer_group, neighbor.address
+                        ),
+                    });
+                }
+            }
+            for (j, other) in self.dynamic_neighbors.iter().enumerate() {
+                if i == j
+                    || !dynamic_prefixes_intersect(
+                        parsed_dynamic_prefixes[i],
+                        parsed_dynamic_prefixes[j],
+                    )
+                {
+                    continue;
+                }
+                let other_has_md5 = other.tcp_ao.is_none()
+                    && self
+                        .peer_groups
+                        .get(&other.peer_group)
+                        .is_some_and(|group| group.md5_password.is_some());
+                if !other_has_md5 && parsed_dynamic_prefixes[j].1 >= parsed_dynamic_prefixes[i].1 {
+                    return Err(ConfigError::InvalidDynamicNeighbor {
+                        reason: format!(
+                            "dynamic_neighbors[{j}] {:?} has no MD5 but nests inside \
+                             MD5-protected dynamic_neighbors[{i}] {:?}: members of the inner \
+                             range would resolve to a plaintext peer group while the kernel's \
+                             prefix key requires a signature. Protect the inner range or make \
+                             the ranges disjoint",
+                            other.prefix, dn.prefix
+                        ),
+                    });
+                }
+            }
+        }
+
         validate_tcp_ao_listener_capacity(self, &parsed_dynamic_prefixes)?;
 
         // Validate dynamic_neighbor_limit range

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -2416,6 +2416,10 @@ async fn commit_candidate_snapshot_locked(
     Ok(())
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "one linear add/change/remove apply pass whose every failure arm threads the same rollback pair"
+)]
 async fn commit_static_neighbors_locked(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     config_tx: &mpsc::Sender<ConfigEvent>,
@@ -2469,6 +2473,15 @@ async fn commit_static_neighbors_locked(
         }
     };
     for config in added {
+        if let Some(error) = runtime_added_neighbor_inbound_auth_error(&config) {
+            return Err(rollback_static_and_snapshot(
+                peer_mgr_tx,
+                applied,
+                previous_toml,
+                error.into(),
+            )
+            .await);
+        }
         if let Err(error) = add_static_peer(peer_mgr_tx, config.clone()).await {
             return Err(rollback_static_and_snapshot(
                 peer_mgr_tx,
@@ -3050,6 +3063,22 @@ async fn rollback_peer_reshape_and_snapshot(
     }
 }
 
+/// A neighbor added at runtime cannot get its inbound MD5 key or GTSM
+/// selector onto the BGP listener (startup/SIGHUP-pinned); admitting it
+/// would leave its inbound half silently unauthenticated.
+fn runtime_added_neighbor_inbound_auth_error(
+    config: &PeerManagerNeighborConfig,
+) -> Option<ConfigTransactionApplyError> {
+    (config.md5_password.is_some() || config.ttl_security).then(|| {
+        peer_lifecycle_error_to_apply_error(PeerLifecycleError::RestartRequired(format!(
+            "added neighbor {} resolves md5_password or ttl_security; inbound listener \
+             enforcement is updated only by startup or SIGHUP reload — add this \
+             neighbor through the config file and SIGHUP",
+            config.address
+        )))
+    })
+}
+
 fn resolve_static_neighbors(
     candidate: &Config,
     neighbors: &[Neighbor],
@@ -3565,7 +3594,7 @@ mod tests {
         let module_sources = [
             ("confirm_journal.rs", include_str!("confirm_journal.rs"), 2),
             ("gnmi_set_bridge.rs", include_str!("gnmi_set_bridge.rs"), 2),
-            ("main.rs", include_str!("main.rs"), 2),
+            ("main.rs", include_str!("main.rs"), 4),
             ("policy_admin.rs", include_str!("policy_admin.rs"), 3),
         ];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,8 +69,9 @@ use rustbgpd_mrt::{
 use rustbgpd_rib::{RibManager, RibUpdate, WarmMrtSnapshotBudget, WarmMrtSnapshotView};
 use rustbgpd_telemetry::{BgpMetrics, init_logging};
 use rustbgpd_transport::{
-    BgpListener, ListenerSocketOptions, TcpAoAlgorithm, TcpAoConfig as TransportTcpAoConfig,
-    TcpAoKeyring, TcpAoListenerKey, TcpAoListenerOwnerKind,
+    BgpListener, ListenerSocketOptions, Md5ListenerKey, TcpAoAlgorithm,
+    TcpAoConfig as TransportTcpAoConfig, TcpAoKeyring, TcpAoListenerKey, TcpAoListenerOwnerKind,
+    TtlSecurityListenerPolicy,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
@@ -1836,6 +1837,88 @@ fn tcp_ao_listener_key_for_dynamic_range(
                 })
                 .collect(),
         ),
+    })
+}
+
+/// Inbound TCP MD5 listener key for a static neighbor: the resolved
+/// (peer-group-inherited) password, keyed to the exact host address.
+fn md5_listener_key_for_neighbor(
+    listen_addr: SocketAddr,
+    neighbor: &config::ResolvedNeighbor,
+) -> Option<Md5ListenerKey> {
+    let password = neighbor.transport_config.md5_password.as_ref()?;
+    let peer = neighbor.transport_config.remote_addr.ip();
+    if listen_addr.is_ipv4() != peer.is_ipv4() {
+        return None;
+    }
+    Some(Md5ListenerKey {
+        peer,
+        prefix_len: if peer.is_ipv4() { 32 } else { 128 },
+        password: password.clone(),
+    })
+}
+
+/// Inbound TCP MD5 listener key for a dynamic range: the referenced peer
+/// group's password, keyed to the whole prefix. Dynamic members are
+/// passive-only, so the listener key is the only socket this password can
+/// ever reach.
+fn md5_listener_key_for_dynamic_range(
+    listen_addr: SocketAddr,
+    range: &config::DynamicNeighborConfig,
+    peer_groups: &std::collections::HashMap<String, config::PeerGroupConfig>,
+) -> Option<Md5ListenerKey> {
+    // A range with direct TCP-AO never inherits group authentication
+    // (validated at config load).
+    if range.tcp_ao.is_some() {
+        return None;
+    }
+    let password = peer_groups.get(&range.peer_group)?.md5_password.as_ref()?;
+    let (peer, prefix_len) = config::effective_prefix_str(&range.prefix)?;
+    if listen_addr.is_ipv4() != peer.is_ipv4() {
+        return None;
+    }
+    Some(Md5ListenerKey {
+        peer,
+        prefix_len,
+        password: password.as_str().into(),
+    })
+}
+
+/// GTSM selector for a static neighbor. Entries are emitted for every
+/// neighbor — including `enforce: false` — so a non-GTSM static neighbor
+/// inside an enforcing dynamic range keeps its own policy at accept time.
+fn ttl_security_listener_policy_for_neighbor(
+    listen_addr: SocketAddr,
+    neighbor: &config::ResolvedNeighbor,
+) -> Option<TtlSecurityListenerPolicy> {
+    let peer = neighbor.transport_config.remote_addr.ip();
+    if listen_addr.is_ipv4() != peer.is_ipv4() {
+        return None;
+    }
+    Some(TtlSecurityListenerPolicy {
+        owner: TcpAoListenerOwnerKind::Static,
+        peer,
+        prefix_len: if peer.is_ipv4() { 32 } else { 128 },
+        enforce: neighbor.transport_config.ttl_security,
+    })
+}
+
+/// GTSM selector for a dynamic range, resolved from its peer group.
+fn ttl_security_listener_policy_for_dynamic_range(
+    listen_addr: SocketAddr,
+    range: &config::DynamicNeighborConfig,
+    peer_groups: &std::collections::HashMap<String, config::PeerGroupConfig>,
+) -> Option<TtlSecurityListenerPolicy> {
+    let group = peer_groups.get(&range.peer_group)?;
+    let (peer, prefix_len) = config::effective_prefix_str(&range.prefix)?;
+    if listen_addr.is_ipv4() != peer.is_ipv4() {
+        return None;
+    }
+    Some(TtlSecurityListenerPolicy {
+        owner: TcpAoListenerOwnerKind::Dynamic,
+        peer,
+        prefix_len,
+        enforce: group.ttl_security.unwrap_or(false),
     })
 }
 
@@ -4671,6 +4754,24 @@ async fn run<T>(
                     .filter_map(|range| tcp_ao_listener_key_for_dynamic_range(listen_addr, range)),
             )
             .collect(),
+        md5_keys: peer_configs
+            .iter()
+            .filter_map(|neighbor| md5_listener_key_for_neighbor(listen_addr, neighbor))
+            .chain(config.dynamic_neighbors.iter().filter_map(|range| {
+                md5_listener_key_for_dynamic_range(listen_addr, range, &config.peer_groups)
+            }))
+            .collect(),
+        ttl_security: peer_configs
+            .iter()
+            .filter_map(|neighbor| ttl_security_listener_policy_for_neighbor(listen_addr, neighbor))
+            .chain(config.dynamic_neighbors.iter().filter_map(|range| {
+                ttl_security_listener_policy_for_dynamic_range(
+                    listen_addr,
+                    range,
+                    &config.peer_groups,
+                )
+            }))
+            .collect(),
     };
 
     let (accept_tx, mut accept_rx) = mpsc::channel::<rustbgpd_transport::AcceptedConnection>(64);
@@ -7015,6 +7116,119 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
             (v6.peer.to_string(), v6.prefix_len),
             ("2001:db8::".to_string(), 48)
         );
+    }
+
+    #[test]
+    fn md5_listener_key_covers_resolved_static_password_and_group_dynamic_range() {
+        let config = load_config_from_toml(
+            "listener-md5-inventory",
+            &tier_authorized_uds_test_config(
+                r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[peer_groups.members]
+md5_password = "group-secret"
+ttl_security = true
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+peer_group = "members"
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "members"
+"#,
+            ),
+        );
+        let listen_addr = config.listen_addr();
+        let neighbor = config.resolved_neighbors().unwrap().pop().unwrap();
+
+        // Static: password inherited from the peer group, keyed host-length.
+        let static_key = md5_listener_key_for_neighbor(listen_addr, &neighbor).unwrap();
+        assert_eq!(static_key.peer.to_string(), "10.0.0.2");
+        assert_eq!(static_key.prefix_len, 32);
+
+        // Dynamic: the group's password becomes a prefix-scoped listener key
+        // even though dynamic members never active-open.
+        let dynamic_key = md5_listener_key_for_dynamic_range(
+            listen_addr,
+            &config.dynamic_neighbors[0],
+            &config.peer_groups,
+        )
+        .unwrap();
+        assert_eq!(dynamic_key.peer.to_string(), "192.0.2.0");
+        assert_eq!(dynamic_key.prefix_len, 24);
+
+        // GTSM selectors resolve from the same sources.
+        let static_ttl = ttl_security_listener_policy_for_neighbor(listen_addr, &neighbor).unwrap();
+        assert_eq!(static_ttl.owner, TcpAoListenerOwnerKind::Static);
+        assert!(static_ttl.enforce);
+        let dynamic_ttl = ttl_security_listener_policy_for_dynamic_range(
+            listen_addr,
+            &config.dynamic_neighbors[0],
+            &config.peer_groups,
+        )
+        .unwrap();
+        assert_eq!(dynamic_ttl.owner, TcpAoListenerOwnerKind::Dynamic);
+        assert_eq!(dynamic_ttl.prefix_len, 24);
+        assert!(dynamic_ttl.enforce);
+    }
+
+    #[test]
+    fn md5_listener_key_skips_family_mismatch_and_unprotected_entries() {
+        let config = load_config_from_toml(
+            "listener-md5-skips",
+            &tier_authorized_uds_test_config(
+                r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[peer_groups.plain]
+hold_time = 90
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+peer_group = "plain"
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "plain"
+"#,
+            ),
+        );
+        let listen_addr = config.listen_addr();
+        let neighbor = config.resolved_neighbors().unwrap().pop().unwrap();
+
+        assert!(md5_listener_key_for_neighbor(listen_addr, &neighbor).is_none());
+        assert!(
+            md5_listener_key_for_dynamic_range(
+                listen_addr,
+                &config.dynamic_neighbors[0],
+                &config.peer_groups
+            )
+            .is_none()
+        );
+        // Unprotected entries still emit non-enforcing GTSM selectors so a
+        // static exception inside an enforcing range resolves correctly.
+        let static_ttl = ttl_security_listener_policy_for_neighbor(listen_addr, &neighbor).unwrap();
+        assert!(!static_ttl.enforce);
+        // Family mismatch: a v6 listener never carries v4 keys.
+        let v6_listener: SocketAddr = "[::]:179".parse().unwrap();
+        assert!(md5_listener_key_for_neighbor(v6_listener, &neighbor).is_none());
+        assert!(ttl_security_listener_policy_for_neighbor(v6_listener, &neighbor).is_none());
     }
 
     #[test]

--- a/src/peer_manager/dynamic.rs
+++ b/src/peer_manager/dynamic.rs
@@ -201,6 +201,18 @@ impl PeerManager {
                  dynamic neighbors (static neighbors only in v1 — see ADR-0067)"
             )));
         }
+        // Inbound MD5 and GTSM for dynamic ranges are enforced on the BGP
+        // listener (prefix MD5 key, accept-time TTL selector), which only
+        // the startup bind and SIGHUP reload paths can update. Accepting
+        // this range here would report the group's authentication as
+        // configured while enforcing it on no socket.
+        if group.md5_password.is_some() || group.ttl_security == Some(true) {
+            return Err(DynamicRangeError::Invalid(format!(
+                "peer_group {peer_group:?} sets md5_password or ttl_security, which are \
+                 enforced on the startup-pinned BGP listener and cannot be installed at \
+                 runtime; restart rustbgpd with an updated configuration"
+            )));
+        }
 
         let key = crate::config::effective_prefix(addr, prefix_len);
         if self.current_config.dynamic_neighbors.iter().any(|range| {
@@ -211,6 +223,23 @@ impl PeerManager {
         }) {
             return Err(DynamicRangeError::Invalid(format!(
                 "dynamic range {}/{} overlaps a startup-pinned TCP-AO range; restart \
+                 rustbgpd with an updated configuration instead",
+                key.0, key.1
+            )));
+        }
+        if self.current_config.dynamic_neighbors.iter().any(|range| {
+            range.tcp_ao.is_none()
+                && self
+                    .current_config
+                    .peer_groups
+                    .get(&range.peer_group)
+                    .is_some_and(|existing| existing.md5_password.is_some())
+                && crate::config::effective_prefix_str(&range.prefix).is_some_and(|protected| {
+                    crate::config::dynamic_prefixes_intersect(key, protected)
+                })
+        }) {
+            return Err(DynamicRangeError::Invalid(format!(
+                "dynamic range {}/{} overlaps a startup-pinned MD5-protected range; restart \
                  rustbgpd with an updated configuration instead",
                 key.0, key.1
             )));

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -515,6 +515,16 @@ impl PeerManager {
             .resolve_neighbor(neighbor)
             .map_err(|error| PeerLifecycleError::Invalid(error.to_string()))?;
         let config = Self::peer_manager_config_from_resolved(resolved, false);
+        // Inbound MD5/GTSM enforcement lives on the BGP listener, which only
+        // startup and SIGHUP reload can update — a runtime-created neighbor
+        // resolving to either would have an unprotected inbound half.
+        if config.md5_password.is_some() || config.ttl_security {
+            return Err(PeerLifecycleError::RestartRequired(format!(
+                "peer {peer} resolves md5_password or ttl_security; inbound listener \
+                 enforcement is updated only by startup or SIGHUP reload — add this neighbor \
+                 through the config file and SIGHUP"
+            )));
+        }
 
         let previous_config = std::mem::replace(&mut self.current_config, next_config);
         match self.add_peer(config, false).await {
@@ -771,6 +781,29 @@ impl PeerManager {
         self.delete_peer_checked(peer, false, next_tcp_ao, false)
             .await
             .map(|_| ())
+    }
+
+    /// Runtime (config-transaction) entry to [`Self::reconfigure_peer`].
+    /// Unlike SIGHUP reload — which replaces the listener MD5/GTSM inventory
+    /// in the same coordinated apply — runtime paths cannot update the BGP
+    /// listener, so a change to either field must fail loudly instead of
+    /// leaving the listener enforcing the old inventory.
+    pub(super) async fn reconfigure_peer_runtime(
+        &mut self,
+        config: PeerManagerNeighborConfig,
+    ) -> Result<PeerManagerNeighborConfig, PeerLifecycleError> {
+        let peer = PeerKey::new(config.address, config.interface.clone());
+        if let Some(managed) = self.peers.get(&peer)
+            && (managed.transport_config.md5_password != config.md5_password
+                || managed.transport_config.ttl_security != config.ttl_security)
+        {
+            return Err(PeerLifecycleError::RestartRequired(format!(
+                "peer {peer} changes md5_password or ttl_security; inbound listener \
+                 enforcement is updated only by startup or SIGHUP reload — apply this change \
+                 through the config file and SIGHUP"
+            )));
+        }
+        self.reconfigure_peer(config).await
     }
 
     pub(super) async fn reconfigure_peer(
@@ -1069,6 +1102,20 @@ impl PeerManager {
             if managed.transport_config.tcp_ao != target.tcp_ao {
                 return Err(PeerLifecycleError::RestartRequired(format!(
                     "peer reshape target {peer} changes tcp_ao; TCP-AO changes require a daemon restart"
+                )));
+            }
+            // Inbound MD5 keys and GTSM selectors live on the BGP listener,
+            // which only startup and the SIGHUP reload coordinator can
+            // update. A runtime reshape that changed them would leave the
+            // listener enforcing the old inventory (stale password accepted
+            // inbound, new password rejected).
+            if managed.transport_config.md5_password != target.md5_password
+                || managed.transport_config.ttl_security != target.ttl_security
+            {
+                return Err(PeerLifecycleError::RestartRequired(format!(
+                    "peer reshape target {peer} changes md5_password or ttl_security; inbound \
+                     listener enforcement is updated only by startup or SIGHUP reload — apply \
+                     this change through the config file and SIGHUP"
                 )));
             }
             // Defense in depth: the transaction executor already gates dynamic

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -885,7 +885,7 @@ impl PeerManager {
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::ReconfigurePeer { config, reply } => {
-                            let result = self.reconfigure_peer(config).await;
+                            let result = self.reconfigure_peer_runtime(config).await;
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::ListPeers { reply } => {

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -2890,6 +2890,25 @@ impl PeerManager {
             return Ok(());
         }
 
+        // Inbound MD5 keys and GTSM selectors derived from a peer group
+        // (static members' host keys, dynamic ranges' prefix keys and TTL
+        // selectors) live on the BGP listener, which only startup and the
+        // SIGHUP reload coordinator can update. Changing them on an existing
+        // group here would leave the listener enforcing the old inventory —
+        // including accepting the old password inbound.
+        if let ConfigEvent::SetPeerGroup { name, .. } = &event
+            && let Some(old_group) = self.current_config.peer_groups.get(name)
+            && let Some(new_group) = next_config.peer_groups.get(name)
+            && (old_group.md5_password != new_group.md5_password
+                || old_group.ttl_security != new_group.ttl_security)
+        {
+            return Err(CatalogMutationError::RestartRequired(format!(
+                "peer group {name:?} changes md5_password or ttl_security; inbound listener \
+                 enforcement is updated only by startup or SIGHUP reload — apply this change \
+                 through the config file and SIGHUP"
+            )));
+        }
+
         // Partition the group edit's changed fields by `ConfigFieldImpact`
         // the way `diff_neighbors` already does for neighbor edits: when
         // every changed field is reload-matrix `live`, the members'

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1427,6 +1427,129 @@ fn add_dynamic_range_rejects_unknown_peer_group() {
     );
 }
 
+#[test]
+fn add_dynamic_range_rejects_listener_enforced_group_auth() {
+    let mut mgr = dynamic_test_manager();
+    // Listener MD5/GTSM inventories are startup/reload-pinned; a runtime
+    // range referencing a group with either knob would report authentication
+    // as configured while enforcing it on no socket.
+    for (name, group) in [
+        (
+            "md5-members",
+            crate::config::PeerGroupConfig {
+                md5_password: Some("secret".to_string()),
+                ..Default::default()
+            },
+        ),
+        (
+            "gtsm-members",
+            crate::config::PeerGroupConfig {
+                ttl_security: Some(true),
+                ..Default::default()
+            },
+        ),
+    ] {
+        mgr.current_config
+            .peer_groups
+            .insert(name.to_string(), group);
+        let err = mgr
+            .add_dynamic_range("10.9.0.0/24".into(), name.into(), 0, None)
+            .expect_err("listener-enforced group auth must be rejected at runtime");
+        assert!(
+            matches!(
+                &err,
+                rustbgpd_api::peer_types::DynamicRangeError::Invalid(reason)
+                    if reason.contains("startup-pinned BGP listener")
+            ),
+            "{err}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn runtime_create_peer_rejects_listener_enforced_group_auth() {
+    let mut mgr = dynamic_test_manager();
+    mgr.current_config.peer_groups.insert(
+        "gtsm-members".to_string(),
+        crate::config::PeerGroupConfig {
+            ttl_security: Some(true),
+            ..Default::default()
+        },
+    );
+    let err = mgr
+        .runtime_create_peer(Box::new(
+            rustbgpd_api::peer_types::PresenceAwareNeighborCreate {
+                address: "10.0.0.9".parse().unwrap(),
+                interface: None,
+                remote_asn: 65009,
+                description: None,
+                peer_group: Some("gtsm-members".to_string()),
+                hold_time: None,
+                min_hold_time: None,
+                send_hold_time: None,
+                max_prefixes: None,
+                max_prefix_restart_seconds: None,
+                remove_private_as: None,
+                local_role: None,
+                families: None,
+                required_families: None,
+                route_server_client: None,
+                per_client_best: None,
+                strict_role: None,
+                add_path: None,
+            },
+        ))
+        .await
+        .expect_err("runtime create resolving listener-enforced auth must be rejected");
+    assert!(
+        matches!(
+            &err,
+            rustbgpd_api::peer_types::PeerLifecycleError::RestartRequired(reason)
+                if reason.contains("startup or SIGHUP reload")
+        ),
+        "{err}"
+    );
+    assert!(
+        !mgr.current_config
+            .neighbors
+            .iter()
+            .any(|neighbor| neighbor.address == "10.0.0.9"),
+        "rejected create must not advance the config snapshot"
+    );
+}
+
+#[test]
+fn add_dynamic_range_rejects_overlap_with_md5_protected_range() {
+    let mut mgr = dynamic_test_manager();
+    mgr.current_config.peer_groups.insert(
+        "md5-members".to_string(),
+        crate::config::PeerGroupConfig {
+            md5_password: Some("secret".to_string()),
+            ..Default::default()
+        },
+    );
+    mgr.current_config
+        .dynamic_neighbors
+        .push(crate::config::DynamicNeighborConfig {
+            prefix: "10.8.0.0/16".to_string(),
+            peer_group: "md5-members".to_string(),
+            remote_asn: 0,
+            description: None,
+            tcp_ao: None,
+        });
+    let err = mgr
+        .add_dynamic_range("10.8.4.0/24".into(), "ix-members".into(), 0, None)
+        .expect_err("overlap with an MD5-protected startup range must be rejected");
+    assert!(
+        matches!(
+            &err,
+            rustbgpd_api::peer_types::DynamicRangeError::Invalid(reason)
+                if reason.contains("startup-pinned MD5-protected range")
+        ),
+        "{err}"
+    );
+}
+
 fn test_tcp_ao() -> crate::config::TcpAoConfig {
     crate::config::TcpAoConfig {
         key: "secret".to_string(),
@@ -21268,10 +21391,6 @@ impl PersistenceRig {
     /// Not `async`: everything here is either synchronous or a `tokio::spawn`,
     /// which only needs the caller's runtime, so the rig is fully wired the
     /// moment this returns.
-    #[expect(
-        clippy::too_many_lines,
-        reason = "the integration rig setup is intentionally centralized"
-    )]
     fn start() -> Self {
         let dir = tempfile::tempdir().expect("temp config dir");
         let config_path = dir.path().join("config.toml");
@@ -21291,7 +21410,6 @@ log_format = "json"
 families = ["ipv4_unicast", "ipv6_unicast"]
 route_server_client = true
 per_client_best = true
-ttl_security = true
 graceful_restart = false
 role = "route_server"
 strict_role = true
@@ -21665,13 +21783,17 @@ async fn presence_create_preserves_raw_inheritance_over_disk_actor_and_reload() 
         assert!(raw.families.is_empty());
         assert_eq!(raw.route_server_client, None);
         assert_eq!(raw.per_client_best, None);
+        // `ttl_security` (and `md5_password`) are deliberately absent from
+        // the fixture group: a presence-create resolving either is rejected
+        // at runtime because inbound listener enforcement is
+        // startup/SIGHUP-pinned (covered by
+        // `runtime_create_peer_rejects_listener_enforced_group_auth`).
         assert_eq!(raw.ttl_security, None);
         assert_eq!(raw.graceful_restart, None);
         assert_eq!(raw.role, None);
         assert_eq!(raw.strict_role, None);
         assert_eq!(raw.add_path, None);
         let effective = snapshot.resolve_neighbor(raw).unwrap();
-        assert!(effective.transport_config.ttl_security);
         assert!(!effective.transport_config.peer.graceful_restart);
 
         let raw = snapshot

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -346,6 +346,45 @@ fn config_keyring_is_deletion(
             .all(|(index, key)| survivors.contains(&index) || key.deprecated)
 }
 
+/// Complete listener inbound-auth inventory (TCP MD5 keys + GTSM selectors)
+/// for one config snapshot, built from the same per-neighbor / per-range
+/// builders the startup bind path uses.
+fn listener_inbound_auth_inventory(
+    config: &Config,
+) -> Result<
+    (
+        Vec<rustbgpd_transport::Md5ListenerKey>,
+        Vec<rustbgpd_transport::TtlSecurityListenerPolicy>,
+    ),
+    String,
+> {
+    let listen_addr = config.listen_addr();
+    let resolved = config
+        .resolved_neighbors()
+        .map_err(|error| error.to_string())?;
+    let md5_keys = resolved
+        .iter()
+        .filter_map(|neighbor| crate::md5_listener_key_for_neighbor(listen_addr, neighbor))
+        .chain(config.dynamic_neighbors.iter().filter_map(|range| {
+            crate::md5_listener_key_for_dynamic_range(listen_addr, range, &config.peer_groups)
+        }))
+        .collect();
+    let ttl_security = resolved
+        .iter()
+        .filter_map(|neighbor| {
+            crate::ttl_security_listener_policy_for_neighbor(listen_addr, neighbor)
+        })
+        .chain(config.dynamic_neighbors.iter().filter_map(|range| {
+            crate::ttl_security_listener_policy_for_dynamic_range(
+                listen_addr,
+                range,
+                &config.peer_groups,
+            )
+        }))
+        .collect();
+    Ok((md5_keys, ttl_security))
+}
+
 #[expect(
     clippy::too_many_lines,
     reason = "the compiler must validate static and dynamic owner inventories together before issuing one immutable generation plan"
@@ -1563,6 +1602,41 @@ pub(crate) async fn reload_config_with_tcp_ao(
             operation = ?plan.operation,
             "TCP-AO generation applied to listener and established sessions"
         );
+    }
+
+    // Listener inbound MD5/GTSM inventory follows the same config → listener
+    // flow as the TCP-AO keys above, but as a plain converging replacement:
+    // an MD5 password change is inherently session-disruptive, so there is no
+    // multi-generation rotation to preserve. The listener is updated before
+    // sessions reconcile so a bounced peer's inbound reconnect already meets
+    // the new inventory.
+    if let Some(listener) = tcp_ao_listener {
+        let current_inventory = match listener_inbound_auth_inventory(current) {
+            Ok(inventory) => inventory,
+            Err(error) => {
+                error!(%error, "failed to compute the live listener inbound-auth inventory");
+                return None;
+            }
+        };
+        let desired_inventory = match listener_inbound_auth_inventory(&new_config) {
+            Ok(inventory) => inventory,
+            Err(error) => {
+                error!(%error, "failed to compute the desired listener inbound-auth inventory");
+                return None;
+            }
+        };
+        if current_inventory != desired_inventory {
+            let (md5_keys, ttl_security) = desired_inventory;
+            if let Err(error) = listener.replace_inbound_auth(md5_keys, ttl_security).await {
+                error!(
+                    error = %error,
+                    "listener inbound MD5/GTSM inventory replacement failed; \
+                     refusing reload (retrying the identical reload converges)"
+                );
+                return None;
+            }
+            info!("listener inbound MD5/GTSM inventory replaced");
+        }
     }
 
     let dataset_commit = desired_config.prepare_staged_datasets(&current.policy.dataset_bindings);
@@ -2869,7 +2943,7 @@ mod tests {
             (concat!("explicit_tier", "_test_toml("), 3),
             (concat!("write_tier", "_test_config("), 12),
             (concat!("load_tier", "_test_config("), 29),
-            (concat!("load_tier", "_test_toml("), 6),
+            (concat!("load_tier", "_test_toml("), 8),
             (concat!("tier_authorized_uds", "_test_config("), 2),
             (concat!("assert_tier_authorized", "_test_config("), 17),
         ];
@@ -6393,6 +6467,60 @@ hold_time = 90
         assert_eq!(
             desired.0.iter().map(|key| key.send_id).collect::<Vec<_>>(),
             [2, 1]
+        );
+    }
+
+    #[test]
+    fn listener_inbound_auth_inventory_tracks_md5_and_gtsm_changes() {
+        let base = |group_auth: &str| {
+            format!(
+                r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+[global.telemetry]
+log_format = "json"
+[peer_groups.members]
+{group_auth}
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+md5_password = "static-secret"
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "members"
+"#
+            )
+        };
+        let current = load_tier_test_toml(&base("md5_password = \"old\""), "inbound-auth-old");
+        let desired = load_tier_test_toml(
+            &base("md5_password = \"new\"\nttl_security = true"),
+            "inbound-auth-new",
+        );
+
+        let current_inventory = listener_inbound_auth_inventory(&current).unwrap();
+        // Identical config → identical inventory: no spurious replacement.
+        assert_eq!(
+            current_inventory,
+            listener_inbound_auth_inventory(&current).unwrap()
+        );
+        let desired_inventory = listener_inbound_auth_inventory(&desired).unwrap();
+        assert_ne!(current_inventory, desired_inventory);
+
+        // The desired inventory carries the static host key, the group's
+        // range prefix key, and the enforcing range GTSM selector.
+        let (md5_keys, ttl_security) = desired_inventory;
+        let selectors: Vec<(String, u8)> = md5_keys
+            .iter()
+            .map(|key| (key.peer.to_string(), key.prefix_len))
+            .collect();
+        assert!(selectors.contains(&("10.0.0.2".to_string(), 32)));
+        assert!(selectors.contains(&("192.0.2.0".to_string(), 24)));
+        assert!(
+            ttl_security
+                .iter()
+                .any(|policy| policy.enforce && policy.prefix_len == 24)
         );
     }
 


### PR DESCRIPTION
## Summary

`md5_password` and `ttl_security` were installed only on active-open (outbound) sockets. The BGP listener installed neither: it accepted unsigned inbound connections for MD5-configured peers and low-TTL inbound connections for GTSM-configured peers.

**Dynamic neighbors are passive-only and never active-open**, so an inherited peer-group `md5_password` was accepted in config, reported as configured, and installed on no socket at any point — a complete silent authentication bypass for the whole dynamic-peering surface. For static peers, the inbound half of every session was unauthenticated even when the outbound half was protected. GTSM was likewise unenforced for anything reaching the listener. Conversely, a correctly configured peer's *signed* inbound SYN was dropped by the kernel (MD5 option present, no key on the socket), so protected inbound sessions could only establish through the local active open.

## Changes

- `ListenerSocketOptions` carries `md5_keys` and `ttl_security` selectors alongside `tcp_ao_keys`, built from the same config → listener flow.
- The listener installs host-scoped MD5 keys for static neighbors (`TCP_MD5SIG`) and prefix-scoped keys for dynamic-neighbor ranges (`TCP_MD5SIG_EXT` + `TCP_MD5SIG_FLAG_PREFIX`, Linux >= 4.13) before `listen(2)`. The kernel resolves overlapping keys by longest prefix match, rejects unsigned handshakes from covered peers, and copies the matched key onto accepted children, so established sessions keep verifying and signing without per-accept work.
- GTSM is applied per peer on each accepted socket at accept time (`IP_MINTTL` / `IPV6_MINHOPCOUNT` 255, plus outbound TTL 255), resolved exact-static-first then longest dynamic-range match — the shared listener socket cannot carry per-peer TTL policy. Segments queued between the handshake and accept precede the filter; every later segment, including any KEEPALIVE required to reach Established, is enforced.
- SIGHUP reload replaces the listener MD5/GTSM inventory through the existing listener control channel before session reconciliation. Unlike TCP-AO rotation there is no multi-generation machinery: an MD5 password change is inherently session-disruptive, so the replacement is a plain converging add/replace/delete whose retry is safe.
- Runtime mutation paths that cannot update the startup/SIGHUP-pinned listener now fail loudly (restart-required / `FAILED_PRECONDITION`) instead of leaving a stale or missing inventory: `SetPeerGroup` changes to `md5_password`/`ttl_security` on an existing group, config-transaction neighbor changes or adds resolving either, presence-aware creates resolving either, and dynamic-range adds whose peer group carries either (plus adds overlapping an MD5-protected startup range).
- Config load rejects a plaintext static neighbor — or a nested more-specific plaintext dynamic range — inside an MD5-protected dynamic range: the kernel's longest-prefix key lookup would demand a signature those peers never send, wedging them undiagnosably.

## Operator-visible behavior change

- Unsigned inbound connections from peers or ranges configured with `md5_password` no longer complete the TCP handshake; correctly signed inbound connections (previously dropped) now establish.
- Inbound segments below TTL/Hop-Limit 255 for `ttl_security` peers are dropped after accept; a peer that was silently interoperating unsigned or through intermediate hops will no longer establish.
- The runtime mutation rejections above direct those changes through the config file and SIGHUP reload, which updates the listener atomically with the sessions.

## Docs

- `docs/DESIGN.md` claimed MD5 was "implemented via setsockopt(TCP_MD5SIG) on the listener" — untrue until this change; the MD5 and GTSM paragraphs now describe the actual mechanism, including the accept-time GTSM semantics.
- ADR-0016 carries an update note: the original decision covered only the active-open socket.
- `docs/grpc-method-inventory.md` reflects the `SetPeerGroup` credential-ingress restriction.

## Tests

Real-kernel loopback tests in `crates/transport/tests/listener.rs` (no privileges required; Linux-gated): unsigned/signed inbound against a static host key and a dynamic-range prefix key, uncovered-peer isolation on the shared listener, low-TTL rejection for static and dynamic-range peers including the static-exception-inside-enforcing-range shape, and live inventory replacement (old password rejected, new accepted, removal returns to plaintext). All four enforcement tests were verified failing against the unenforced listener behavior before the fix. Additional unit coverage: listener option builders, reload inventory planning, config-load rejection shapes, and every runtime-mutation rejection.