### PR TITLE
Fence runtime deletion of MD5/GTSM-protected neighbors and ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   reload replaces the listener inventory alongside session
   reconciliation.
 
+- **Runtime deletion of an MD5/GTSM-protected neighbor or dynamic range
+  is now refused restart-required** (LAN-910), closing the delete half of
+  the LAN-902 fence set: a runtime delete could not remove the peer's
+  host-scoped (or the range's prefix-scoped) key from the
+  startup/SIGHUP-pinned listener, leaving a stale key installed —
+  fail-closed, but a delete-then-re-add at runtime left the re-added
+  peer's inbound half wedged until SIGHUP. `DeleteNeighbor`,
+  `DeleteDynamicRange`, and `[[neighbors]]` / `[[dynamic_neighbors]]`
+  config transactions that would change the listener's protected
+  inventory now fail with the same restart-required error the create,
+  change, and TCP-AO paths already return; remove the entry from the
+  config file and SIGHUP instead. `DeletePeerGroup` needs no new fence:
+  a group's authentication reaches the listener only through its
+  members, and any member already refuses the delete with
+  `still referenced`.
+
 ### Added
 
 - `WatchRoutes` now signals subscriber lag in-band with a synthetic

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -389,26 +389,6 @@ byte counts.
   dynamic-prefix keys on Linux, including live successor installation,
   selection, and deprecated-key deletion on SIGHUP — see SECURITY.md and
   ADR-0062.)
-- **Runtime neighbor or dynamic-range deletion leaves its inbound MD5
-  key — host-scoped or prefix-scoped — installed on the listener until
-  SIGHUP.** Inbound TCP MD5 is enforced by keys installed on the
-  listening socket, and that inventory is built at startup and replaced
-  only by SIGHUP reload. Deleting an MD5-protected static neighbor — or
-  an MD5-protected dynamic range — through a runtime path (`rbgp`
-  neighbor delete, a config transaction) removes the peer but leaves its
-  host- or prefix-scoped key installed. This is fail-closed, not a
-  bypass: an inbound connection from that address must still sign with
-  the old password, and having signed it matches no configured neighbor
-  or range and is dropped as unconfigured. Nothing reaches the daemon
-  that could not before. The operationally surprising case is
-  delete-then-re-add at runtime: the runtime neighbor-add surface cannot
-  carry `md5_password`, so the re-added peer is plaintext while the
-  listener still demands the old signature, and its inbound half stays
-  wedged with correct-looking config on both ends — the same shape config
-  load rejects for a plaintext neighbor inside an MD5-protected range.
-  SIGHUP after any such change converges the listener. TCP-AO is not
-  affected: protected-owner removal is already refused restart-required.
-  See ADR-0016 and `docs/DESIGN.md`.
 - **Non-negotiated Add-Path NLRI is not detected.** If a peer violates
   negotiation and sends Add-Path-encoded NLRI for a family where Add-Path
   was not negotiated, the wire format is ambiguous — the 4-byte path ID

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -109,7 +109,7 @@ shape itself does not raise the tier.
 | RPC | Tier | Notes |
 |-----|------|-------|
 | `AddNeighbor` | `mutating` | Reversible per-peer. Runtime neighbor creation does not currently accept TCP MD5 or TCP-AO key material over gRPC. |
-| `DeleteNeighbor` | `mutating` | Single-peer scope. |
+| `DeleteNeighbor` | `mutating` | Single-peer scope. Deleting a neighbor that resolves `md5_password` or `ttl_security` is rejected `FAILED_PRECONDITION`, matching TCP-AO: the inbound listener key/TTL inventory is updated only by startup or SIGHUP reload. |
 | `ListNeighbors` | `sensitive_read` | Returns full topology: addresses, ASNs, families, peer-group memberships, route-server flags, counters. No credentials in response. |
 | `GetNeighborState` | `sensitive_read` | Single-peer detail; same shape as `ListNeighbors` element. |
 | `EnableNeighbor` | `mutating` | Single-peer. |
@@ -118,7 +118,7 @@ shape itself does not raise the tier.
 | `RefreshOutbound` | `mutating` | Re-emits one peer's current exportable outbound inventory across its negotiated families. The reply confirms scheduling, not writer drain or remote receipt; full-table use is an O(table) burst and should be serialized. |
 | `ListDynamicNeighbors` | `sensitive_read` | Topology disclosure for the dynamic-prefix accepted peers. |
 | `AddDynamicNeighbor` | `mutating` | Adds an accept-prefix range. Wider than `AddNeighbor` (multi-peer effective), but still per-prefix scope. |
-| `DeleteDynamicNeighbor` | `mutating` | Removes a prefix range; stops future accepts only — established dynamic peers keep running and drain when they next return to Idle. |
+| `DeleteDynamicNeighbor` | `mutating` | Removes a prefix range; stops future accepts only — established dynamic peers keep running and drain when they next return to Idle. Deleting a range whose peer group carries `md5_password` or `ttl_security` is rejected `FAILED_PRECONDITION`, matching TCP-AO: the inbound listener key/TTL inventory is updated only by startup or SIGHUP reload. |
 | `SetGracefulShutdown` | `operator_only` | Network-wide when `address` is empty; listed here because the proto puts it in `NeighborService`. |
 
 ### PolicyService (22 RPCs)

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -2196,7 +2196,13 @@ async fn commit_apply_family_inner(
             .await
         }
         ApplyFamily::DynamicNeighbors => {
-            commit_candidate_snapshot_locked(&deps.peer_mgr_tx, config_tx, candidate_toml).await?;
+            commit_dynamic_neighbors_locked(
+                &deps.peer_mgr_tx,
+                config_tx,
+                candidate_toml,
+                &candidate,
+            )
+            .await?;
             Ok(committable_response(
                 post_commit_runtime_snapshot_token,
                 vec![DYNAMIC_SECTION.to_string()],
@@ -2405,6 +2411,55 @@ async fn commit_candidate_snapshot_locked(
 ) -> Result<(), ApplyFailure> {
     let permit = reserve_persist_permit(config_tx).await?;
     let previous_toml = stage_config_snapshot(peer_mgr_tx, candidate_toml.clone()).await?;
+    if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
+        return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_toml, failure).await);
+    }
+    // LAN-277 window (a): the candidate is durable on disk from here on — a
+    // finalization failure must not be reported as a clean no-commit failure.
+    commit_config_snapshot_stage(peer_mgr_tx)
+        .await
+        .map_err(ApplyFailure::ambiguous)?;
+    Ok(())
+}
+
+/// `[[dynamic_neighbors]]` commits replace the range set through the staged
+/// config snapshot without going through the peer manager's per-range
+/// add/delete surface, so the listener fences in `add_dynamic_range` /
+/// `delete_dynamic_range` never run for them. Refuse here instead when the
+/// transaction would change the startup/SIGHUP-pinned listener MD5/GTSM
+/// range inventory (remove or add a protected range, or reassign one across
+/// a protection boundary).
+async fn commit_dynamic_neighbors_locked(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    config_tx: &mpsc::Sender<ConfigEvent>,
+    candidate_toml: String,
+    candidate: &Config,
+) -> Result<(), ApplyFailure> {
+    let permit = reserve_persist_permit(config_tx).await?;
+    let previous_toml = stage_config_snapshot(peer_mgr_tx, candidate_toml.clone()).await?;
+    let previous = match Config::load_toml_with_diagnostics(
+        &previous_toml,
+        "previous runtime config transaction snapshot",
+    ) {
+        Ok(previous) => previous,
+        Err(error) => {
+            let error = ConfigTransactionApplyError::Internal(error);
+            return Err(
+                rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error.into()).await,
+            );
+        }
+    };
+    if dynamic_range_listener_auth_inventory(&previous)
+        != dynamic_range_listener_auth_inventory(candidate)
+    {
+        let error = peer_lifecycle_error_to_apply_error(PeerLifecycleError::RestartRequired(
+            "[[dynamic_neighbors]] transaction changes a range protected by md5_password or \
+             ttl_security; inbound listener enforcement is updated only by startup or SIGHUP \
+             reload — apply this change through the config file and SIGHUP"
+                .to_string(),
+        ));
+        return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error.into()).await);
+    }
     if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
         return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_toml, failure).await);
     }
@@ -3063,6 +3118,25 @@ async fn rollback_peer_reshape_and_snapshot(
     }
 }
 
+/// The listener's dynamic-range inbound-auth inventory derived from a
+/// config: effective prefix → (MD5 password, GTSM) for every range whose
+/// peer group carries either. The listener installs these at startup/SIGHUP
+/// only, so runtime commits must leave this set unchanged.
+fn dynamic_range_listener_auth_inventory(
+    config: &Config,
+) -> std::collections::BTreeSet<((std::net::IpAddr, u8), Option<String>, bool)> {
+    config
+        .dynamic_neighbors
+        .iter()
+        .filter_map(|range| {
+            let key = crate::config::effective_prefix_str(&range.prefix)?;
+            let group = config.peer_groups.get(&range.peer_group)?;
+            let gtsm = group.ttl_security == Some(true);
+            (group.md5_password.is_some() || gtsm).then(|| (key, group.md5_password.clone(), gtsm))
+        })
+        .collect()
+}
+
 /// A neighbor added at runtime cannot get its inbound MD5 key or GTSM
 /// selector onto the BGP listener (startup/SIGHUP-pinned); admitting it
 /// would leave its inbound half silently unauthenticated.
@@ -3660,6 +3734,75 @@ remote_asn = 65002
             .find("pub(crate) async fn runtime_config_snapshot(")
             .unwrap();
         assert!(reload[..legacy].ends_with("#[cfg(test)]\n"));
+    }
+
+    /// LAN-910: the `[[dynamic_neighbors]]` executor commits by snapshot
+    /// replacement, so this inventory comparison is its only listener fence —
+    /// `delete_dynamic_range`'s per-range fence never runs for transactions.
+    #[test]
+    fn dynamic_range_listener_auth_inventory_flags_protected_range_changes() {
+        const MD5_RANGE: &str = r#"
+[[dynamic_neighbors]]
+prefix = "10.9.0.0/24"
+peer_group = "md5-members"
+"#;
+        const GTSM_RANGE: &str = r#"
+[[dynamic_neighbors]]
+prefix = "10.10.0.0/24"
+peer_group = "gtsm-members"
+"#;
+        const PLAIN_RANGE: &str = r#"
+[[dynamic_neighbors]]
+prefix = "10.8.0.0/24"
+peer_group = "plain"
+"#;
+        let load = |ranges: &str| {
+            Config::load_toml_with_diagnostics(
+                &format!(
+                    r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[peer_groups.md5-members]
+md5_password = "secret"
+
+[peer_groups.gtsm-members]
+ttl_security = true
+
+[peer_groups.plain]
+{ranges}
+"#
+                ),
+                "inventory test config",
+            )
+            .expect("inventory test config must parse")
+        };
+        let full = load(&format!("{MD5_RANGE}{GTSM_RANGE}{PLAIN_RANGE}"));
+        let no_plain = load(&format!("{MD5_RANGE}{GTSM_RANGE}"));
+        let no_md5 = load(&format!("{GTSM_RANGE}{PLAIN_RANGE}"));
+        let no_gtsm = load(&format!("{MD5_RANGE}{PLAIN_RANGE}"));
+
+        assert_eq!(
+            dynamic_range_listener_auth_inventory(&full),
+            dynamic_range_listener_auth_inventory(&no_plain),
+            "removing an unprotected range must not change the listener inventory"
+        );
+        assert_ne!(
+            dynamic_range_listener_auth_inventory(&full),
+            dynamic_range_listener_auth_inventory(&no_md5),
+            "removing an MD5-protected range must change the listener inventory"
+        );
+        assert_ne!(
+            dynamic_range_listener_auth_inventory(&full),
+            dynamic_range_listener_auth_inventory(&no_gtsm),
+            "removing a GTSM-protected range must change the listener inventory"
+        );
     }
 
     #[tokio::test]

--- a/src/peer_manager/dynamic.rs
+++ b/src/peer_manager/dynamic.rs
@@ -314,6 +314,28 @@ impl PeerManager {
                 key.0, key.1
             )));
         }
+        // The range's inherited MD5 prefix key and GTSM selector live on the
+        // BGP listener, which only startup and SIGHUP reload can update — a
+        // runtime delete would leave the stale prefix key installed
+        // (fail-closed, but a delete-then-re-add wedges the re-added range's
+        // inbound half until SIGHUP).
+        if self.current_config.dynamic_neighbors.iter().any(|range| {
+            crate::config::effective_prefix_str(&range.prefix) == Some(key)
+                && self
+                    .current_config
+                    .peer_groups
+                    .get(&range.peer_group)
+                    .is_some_and(|group| {
+                        group.md5_password.is_some() || group.ttl_security == Some(true)
+                    })
+        }) {
+            return Err(DynamicRangeError::Invalid(format!(
+                "dynamic range {}/{} inherits md5_password or ttl_security; inbound listener \
+                 enforcement is updated only by startup or SIGHUP reload — remove it through \
+                 the config file and SIGHUP",
+                key.0, key.1
+            )));
+        }
 
         // Snapshot the config entry being removed (owned) before mutating, so
         // rollback can restore the exact range. dynamic_ranges and

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -761,6 +761,31 @@ impl PeerManager {
         Ok(())
     }
 
+    /// Runtime (RPC / config-transaction) entry to [`Self::delete_peer`].
+    /// The peer's inbound MD5 key and GTSM selector live on the BGP listener,
+    /// which only startup and SIGHUP reload can update — a runtime delete
+    /// would leave the stale host key installed (fail-closed, but a
+    /// delete-then-re-add wedges the re-added peer's inbound half until
+    /// SIGHUP). SIGHUP reconcile removals use [`Self::delete_peer`] directly:
+    /// the reload coordinator replaces the listener inventory in the same
+    /// coordinated apply.
+    pub(super) async fn delete_peer_runtime(
+        &mut self,
+        peer: PeerKey,
+        sync_config_snapshot: bool,
+    ) -> Result<PeerManagerNeighborConfig, PeerLifecycleError> {
+        if self.peers.get(&peer).is_some_and(|managed| {
+            managed.transport_config.md5_password.is_some() || managed.transport_config.ttl_security
+        }) {
+            return Err(PeerLifecycleError::RestartRequired(format!(
+                "peer {peer} resolves md5_password or ttl_security; inbound listener \
+                 enforcement is updated only by startup or SIGHUP reload — remove this \
+                 neighbor through the config file and SIGHUP"
+            )));
+        }
+        self.delete_peer(peer, sync_config_snapshot).await
+    }
+
     pub(super) async fn delete_peer(
         &mut self,
         peer: PeerKey,

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -881,7 +881,7 @@ impl PeerManager {
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::DeletePeer { peer, sync_config_snapshot, reply } => {
-                            let result = self.delete_peer(peer, sync_config_snapshot).await;
+                            let result = self.delete_peer_runtime(peer, sync_config_snapshot).await;
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::ReconfigurePeer { config, reply } => {

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1550,6 +1550,184 @@ fn add_dynamic_range_rejects_overlap_with_md5_protected_range() {
     );
 }
 
+/// LAN-910: the delete counterpart of the runtime-create fence. A protected
+/// peer's inbound MD5 key / GTSM selector live on the startup/SIGHUP-pinned
+/// listener; a runtime delete would leave the stale key installed and wedge
+/// a delete-then-re-add. (`delete_peer_removes` keeps proving the unprotected
+/// runtime delete path clean.)
+#[tokio::test]
+async fn delete_peer_rejects_listener_enforced_auth() {
+    let (tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    let handle = tokio::spawn(mgr.run());
+
+    let mut md5_config = make_config(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 65002);
+    md5_config.md5_password = Some("secret".to_string().into());
+    let mut gtsm_config = make_config(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)), 65003);
+    gtsm_config.ttl_security = true;
+
+    for config in [md5_config, gtsm_config] {
+        let addr = config.address;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(PeerManagerCommand::AddPeer {
+            config,
+            sync_config_snapshot: false,
+            reply: reply_tx,
+        })
+        .await
+        .unwrap();
+        assert!(reply_rx.await.unwrap().is_ok());
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(PeerManagerCommand::DeletePeer {
+            peer: key(addr),
+            sync_config_snapshot: false,
+            reply: reply_tx,
+        })
+        .await
+        .unwrap();
+        match reply_rx.await.unwrap() {
+            Ok(_) => panic!("runtime delete of a listener-protected peer must be refused"),
+            Err(err) => assert!(
+                matches!(
+                    &err,
+                    rustbgpd_api::peer_types::PeerLifecycleError::RestartRequired(reason)
+                        if reason.contains("startup or SIGHUP reload")
+                ),
+                "{err}"
+            ),
+        }
+    }
+
+    let (list_tx, list_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::ListPeers { reply: list_tx })
+        .await
+        .unwrap();
+    assert_eq!(
+        list_rx.await.unwrap().len(),
+        2,
+        "refused deletes must leave the peers configured"
+    );
+
+    tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    handle.await.unwrap();
+}
+
+/// LAN-910: the delete counterpart of the runtime range-add fence. The
+/// protected range models a startup-configured one (the add fence refuses to
+/// create it at runtime). (`delete_dynamic_range_removes_and_stops_future_match`
+/// keeps proving the unprotected runtime range delete clean.)
+#[test]
+fn delete_dynamic_range_rejects_listener_enforced_group_auth() {
+    let mut mgr = dynamic_test_manager();
+    for (name, group, prefix) in [
+        (
+            "md5-members",
+            crate::config::PeerGroupConfig {
+                md5_password: Some("secret".to_string()),
+                ..Default::default()
+            },
+            "10.9.0.0/24",
+        ),
+        (
+            "gtsm-members",
+            crate::config::PeerGroupConfig {
+                ttl_security: Some(true),
+                ..Default::default()
+            },
+            "10.10.0.0/24",
+        ),
+    ] {
+        mgr.current_config
+            .peer_groups
+            .insert(name.to_string(), group);
+        mgr.current_config
+            .dynamic_neighbors
+            .push(crate::config::DynamicNeighborConfig {
+                prefix: prefix.to_string(),
+                peer_group: name.to_string(),
+                remote_asn: 0,
+                description: None,
+                tcp_ao: None,
+            });
+        mgr.dynamic_ranges = PeerManager::parse_dynamic_ranges(&mgr.current_config);
+        let err = mgr
+            .delete_dynamic_range(prefix)
+            .expect_err("runtime delete of a listener-protected range must be refused");
+        assert!(
+            matches!(
+                &err,
+                rustbgpd_api::peer_types::DynamicRangeError::Invalid(reason)
+                    if reason.contains("startup or SIGHUP reload")
+            ),
+            "{err}"
+        );
+        assert!(
+            mgr.current_config
+                .dynamic_neighbors
+                .iter()
+                .any(|range| range.prefix == prefix),
+            "refused delete must keep the range configured"
+        );
+    }
+}
+
+/// LAN-910 Gap B verdict: `DeletePeerGroup` needs no `md5_password` /
+/// `ttl_security` fence
+/// of its own. A group's authentication reaches the listener only through
+/// its members (static host keys, dynamic-range prefix keys), and any such
+/// member already blocks the delete with `StillReferenced` — including
+/// `[[dynamic_neighbors]]` ranges since LAN-906. An unreferenced group
+/// contributes nothing to the listener inventory, so deleting it is safe.
+#[tokio::test]
+async fn delete_peer_group_referenced_by_md5_dynamic_range_is_refused() {
+    let mut mgr = dynamic_test_manager();
+    mgr.current_config.peer_groups.insert(
+        "md5-members".to_string(),
+        crate::config::PeerGroupConfig {
+            md5_password: Some("secret".to_string()),
+            ..Default::default()
+        },
+    );
+    mgr.current_config
+        .dynamic_neighbors
+        .push(crate::config::DynamicNeighborConfig {
+            prefix: "10.9.0.0/24".to_string(),
+            peer_group: "md5-members".to_string(),
+            remote_asn: 0,
+            description: None,
+            tcp_ao: None,
+        });
+    let err = mgr
+        .apply_peer_group_change(
+            rustbgpd_api::peer_types::ConfigEvent::DeletePeerGroup {
+                name: "md5-members".to_string(),
+                ack: None,
+            },
+            Vec::new(),
+        )
+        .await
+        .expect_err("deleting a group still referenced by a dynamic range must be refused");
+    assert!(
+        matches!(&err, CatalogMutationError::StillReferenced { .. }),
+        "{err:?}"
+    );
+    assert!(
+        mgr.current_config.peer_groups.contains_key("md5-members"),
+        "refused delete must keep the group"
+    );
+}
+
 fn test_tcp_ao() -> crate::config::TcpAoConfig {
     crate::config::TcpAoConfig {
         key: "secret".to_string(),


### PR DESCRIPTION
#1495 fenced runtime creates, changes, reshapes, dynamic-range adds, and `SetPeerGroup` as restart-required when they resolve `md5_password` / `ttl_security`, but the delete paths only refused TCP-AO. Deleting a protected neighbor or range at runtime removed the peer while its host- or prefix-scoped key stayed installed on the startup/SIGHUP-pinned listener. The residue is fail-closed, but delete-then-re-add at runtime wedged the re-added peer's inbound half with correct-looking config on both ends.

## Per-gap verdict

**Gap A — `delete_peer_checked` (static neighbors): confirmed and fenced.** The sole `RestartRequired` arm was TCP-AO. Both runtime routes (`DeleteNeighbor` RPC and the config-transaction removed loop) reach it through `PeerManagerCommand::DeletePeer`; SIGHUP reconcile reaches the same `delete_peer` wrapper but legitimately pairs removals with a listener inventory replacement, so the fence cannot live inside `delete_peer_checked` itself. A new `delete_peer_runtime` wrapper fences the `DeletePeer` command dispatch — the shared choke point for both runtime routes — refusing restart-required when the managed peer's transport config resolves `md5_password` or `ttl_security`, with the same error shape as the existing create/reshape fences. Red pre-fix: `delete_peer_rejects_listener_enforced_auth` failed with `runtime delete of a listener-protected peer must be refused` (the delete succeeded).

**Gap B — `DeletePeerGroup`: already covered, no fence added.** On current main `peer_group_references` includes static neighbors, `[[dynamic_neighbors]]` ranges (since #1492), neighbor sets, and FIB-table allow lists, so a group with any member that could place its authentication on the listener is refused `StillReferenced` before the MD5 question arises. A group's `md5_password` / `ttl_security` reaches the listener inventory only through resolved static members and dynamic ranges (`md5_listener_key_for_neighbor` / `_for_dynamic_range`, `ttl_security_listener_policy_*`); an unreferenced group contributes nothing, so deleting it is harmless. An unconditional MD5 fence there would also break SIGHUP reload, which deletes groups through the same catalog arm after removing their members. `delete_peer_group_referenced_by_md5_dynamic_range_is_refused` passed pre-fix, documenting the covering mechanism.

**Gap C — `delete_dynamic_range`: confirmed and fenced.** Only the TCP-AO startup-pinned arm existed; `DeleteDynamicNeighbor` on an MD5- or GTSM-protected range left the `TCP_MD5SIG_EXT` prefix key (and accept-time TTL selector) installed. The delete now refuses restart-required when the range's peer group carries either knob, mirroring the TCP-AO arm. Red pre-fix: `delete_dynamic_range_rejects_listener_enforced_group_auth` failed with `runtime delete of a listener-protected range must be refused: DynamicNeighborConfig { prefix: "10.9.0.0/24", ... }` (the delete succeeded and returned the removed range).

**Gap C′ — `[[dynamic_neighbors]]` config transactions (found expanding the seam): fenced.** The `ApplyFamily::DynamicNeighbors` executor commits by staged snapshot replacement (`StageConfigSnapshot` rebuilds `dynamic_ranges` wholesale), so neither the `delete_dynamic_range` fence above nor #1495's `add_dynamic_range` fence ever runs for it — a transaction could remove or add a protected range unnoticed. `commit_dynamic_neighbors_locked` now compares the previous and candidate protected-range inventories (effective prefix, MD5 password, GTSM) after staging and rolls back with the same restart-required error on any difference, covering removal, addition, and reassignment through the transaction surface. `dynamic_range_listener_auth_inventory_flags_protected_range_changes` covers the comparison.

## KNOWN_ISSUES decision

The entry added by #1497 ("Runtime neighbor or dynamic-range deletion leaves its inbound MD5 key … installed on the listener until SIGHUP") is **deleted**, not narrowed. Every supported runtime route that could strand a key is now refused restart-required (RPC neighbor delete, transaction neighbor removal, RPC range delete, transaction range removal) or already refused `StillReferenced` (group delete), and SIGHUP reload replaces the listener inventory by design. The entry described only the deletion residue; that shape is no longer reachable, so there is no residual left to narrow it to.

## Operator-visible change

Deleting an MD5- or GTSM-protected neighbor or dynamic range at runtime now returns `FAILED_PRECONDITION` (restart required), matching the existing TCP-AO behavior and the #1495 create/change fences; remove the entry from the config file and SIGHUP instead. Unprotected deletes are unchanged. `docs/grpc-method-inventory.md` rows for `DeleteNeighbor` and `DeleteDynamicNeighbor` note the refusal.

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test --workspace` — exit 0
- `cargo doc --workspace --no-deps` — exit 0
- `python3 scripts/check-clippy-reasons.py` — exit 0
- `cargo test -p rustbgpd-api authz` — exit 0 (43 passed)
