### PR TITLE
Stage per-client-best groups from the widened all-affected set

### DIFF
--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -3734,8 +3734,11 @@ impl RibManager {
         // changed prefix), committed to the group tables. The per-peer
         // loop below emits the deltas per member via the source-flip
         // matrix; disqualified peers take the per-peer staging path
-        // exactly as before.
-        let group_stage = self.stage_update_groups(&best_changed, &mut export_memo);
+        // exactly as before. Plain groups stage `best_changed`;
+        // per-client-best groups stage the widened all-affected union
+        // (their winner walk reads the candidate list, not the Loc-RIB
+        // best).
+        let group_stage = self.stage_update_groups(&best_changed, &all_affected, &mut export_memo);
         let mut shared_unicast_probe_cache = SharedUnicastProbeCache::default();
         // LAN-474 emit-time filter: whether a group's pass carries any
         // control-tagged announce delta, memoized per (group, rs_asn) —
@@ -3772,12 +3775,17 @@ impl RibManager {
             // A grouped force-only resync intentionally re-announces the
             // current group table and ignores pass tombstones/deltas. Its
             // setters synchronously run an empty distribution pass, so it
-            // cannot meet a genuine best-change pass. A failed force send is
+            // cannot meet a genuine change pass — an all-affected-only
+            // pass included, since that stages real deltas for
+            // per-client-best groups. A failed force send is
             // also dirty and is valid here: dirty assembly includes the
             // tombstones needed to heal subsequent churn.
             debug_assert!(
-                member_of.is_none() || !is_force || is_dirty || best_changed.is_empty(),
-                "a grouped force-only resync cannot share a nonempty best-change pass"
+                member_of.is_none()
+                    || !is_force
+                    || is_dirty
+                    || (best_changed.is_empty() && all_affected.is_empty()),
+                "a grouped force-only resync cannot share a nonempty distribution pass"
             );
             let resync = is_dirty || is_force;
             #[cfg(feature = "bench-internals")]
@@ -3826,11 +3834,26 @@ impl RibManager {
                 }
                 all.retain(|prefix| !self.selection_deferred(prefix_family(prefix)));
                 Cow::Owned(all)
-            } else if member_of.is_some() {
+            } else if let Some(gid) = member_of {
                 // Grouped peers have no ORR / Add-Path extras (both are
-                // grouping disqualifiers): the group deltas cover
-                // exactly the best-changed set.
-                Cow::Borrowed(&best_changed)
+                // grouping disqualifiers). A plain group's deltas cover
+                // exactly the best-changed set; a per-client-best group
+                // stages from the widened all-affected set (its winner
+                // walk reads the candidate list, not the Loc-RIB best),
+                // so its members' pass scope — the empty-pass gate and
+                // the filtered-inventory and OTC reconciliations —
+                // widens the same way.
+                let group_per_client_best = self
+                    .group_ribs
+                    .get(&gid)
+                    .is_some_and(|group| group.per_client_best);
+                if group_per_client_best && !all_affected.is_empty() {
+                    let mut prefixes = best_changed.clone();
+                    prefixes.extend(all_affected.iter().copied());
+                    Cow::Owned(prefixes)
+                } else {
+                    Cow::Borrowed(&best_changed)
+                }
             } else {
                 // An RFC 9107 ORR peer selects from the per-target
                 // candidate set, not the Loc-RIB best — a candidate

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -2213,18 +2213,39 @@ impl RibManager {
     /// the per-peer loop emits them per member via the source-flip
     /// matrix. `memo` is the pass-scoped export memo shared with the
     /// ungrouped fallback staging.
+    ///
+    /// A plain group stages exactly `best_changed`: its input is
+    /// Loc-RIB-best-or-nothing, so the narrow set is complete. A
+    /// per-client-best group's winner walk reads the candidate list,
+    /// not the Loc-RIB best — a candidate change can flip the winner
+    /// or the lane while the best stands — so it stages the widened
+    /// `best_changed ∪ all_affected` set, mirroring the ungrouped
+    /// per-client-best enumeration. The union is built once, and only
+    /// when such a group exists; winner-equality and lane suppression
+    /// make the widened pass a no-op wherever neither slot moved.
     pub(in crate::manager) fn stage_update_groups(
         &mut self,
         best_changed: &HashSet<Prefix>,
+        all_affected: &HashSet<Prefix>,
         memo: &mut super::distribution::ExportMemo,
     ) -> HashMap<usize, GroupStageOutput> {
         let mut staged = HashMap::new();
-        if best_changed.is_empty() || self.group_ribs.is_empty() {
+        if self.group_ribs.is_empty() || (best_changed.is_empty() && all_affected.is_empty()) {
             return staged;
         }
+        let widened: Option<HashSet<Prefix>> = (!all_affected.is_empty()
+            && self.group_ribs.values().any(|group| group.per_client_best))
+        .then(|| best_changed.union(all_affected).copied().collect());
         let gids: Vec<usize> = self.group_ribs.keys().copied().collect();
         for gid in gids {
-            let mut out = self.stage_group_prefixes(gid, best_changed, memo);
+            let prefixes = match (&widened, self.group_ribs.get(&gid)) {
+                (Some(widened), Some(group)) if group.per_client_best => widened,
+                _ => best_changed,
+            };
+            if prefixes.is_empty() {
+                continue;
+            }
+            let mut out = self.stage_group_prefixes(gid, prefixes, memo);
             // Built here (the fanout path) and not inside the staging
             // pass: `join_group`'s table-build pass discards its output.
             out.build_shared_emit();
@@ -8433,5 +8454,211 @@ mod tests {
         group.apply_delta(&withdraw_delta(k1, Some(MEMBER)));
         assert_eq!(group.advertised_count_for(OTHER1), 1);
         assert_eq!(group.table.len(), 1);
+    }
+
+    // --- ADR-0126 staging trigger: per-client-best groups stage from
+    // --- the widened all-affected set, plain groups from
+    // --- `best_changed` exactly.
+
+    const OTHER3: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 9, 0, 4));
+
+    /// Plain sibling of [`per_client_best_group`] with a caller-chosen
+    /// export chain — the staging-trigger control group.
+    fn plain_group_with_chain(chain: Option<PolicyChain>) -> GroupRibOut {
+        GroupRibOut::new(
+            chain,
+            false,
+            false,
+            true,
+            None,
+            vec![(Afi::Ipv4, Safi::Unicast)],
+            vec![],
+            false,
+            0,
+        )
+    }
+
+    /// A candidate change that leaves the Loc-RIB best untouched
+    /// (`best_changed` empty, the prefix carried by `all_affected`
+    /// alone) must still restage a per-client-best group: the walk's
+    /// input is the candidate list, not the Loc-RIB best. The chain
+    /// denies the Loc-RIB best, so the advertised winner is the
+    /// second-ranked candidate — withdrawing IT moves the wire while
+    /// the best stands.
+    #[test]
+    fn pcb_group_restages_from_all_affected_without_best_change() {
+        let mut m = staging_manager();
+        let p = prefix(1);
+        let mut rx = register_pcb_member(
+            &mut m,
+            MEMBER,
+            per_client_best_group(Some(deny_sources_chain(&[OTHER1]))),
+        );
+        seed(&mut m, cand(p, OTHER1, 300)); // Loc-RIB best, chain-denied
+        seed(&mut m, cand(p, OTHER2, 200)); // advertised winner
+        seed(&mut m, cand(p, OTHER3, 100));
+        let changed = m.recompute_best(&HashSet::from([p]));
+        m.distribute_changes(&changed, &HashSet::from([p]));
+        let (announced, _) = folded_outbound(&mut rx);
+        assert_eq!(
+            announced[&p].0, OTHER2,
+            "precondition: the winner is the second-ranked candidate"
+        );
+
+        // Withdraw the WINNER's candidate — not the Loc-RIB best, so
+        // selection reports no best change.
+        unseed(&mut m, OTHER2, p);
+        let changed = m.recompute_best(&HashSet::from([p]));
+        assert!(
+            changed.is_empty(),
+            "precondition: the Loc-RIB best is unmoved"
+        );
+        m.distribute_changes(&changed, &HashSet::from([p]));
+        let group = m.group_ribs.get(&PCB_GID).unwrap();
+        assert_eq!(
+            group.table.get(&p, 0).map(|r| r.peer),
+            Some(OTHER3),
+            "the widened pass restages the next permitted candidate"
+        );
+        let (announced, withdrawn) = folded_outbound(&mut rx);
+        assert_eq!(
+            announced.get(&p).map(|(source, _)| *source),
+            Some(OTHER3),
+            "the member receives the new winner"
+        );
+        assert!(withdrawn.is_empty());
+    }
+
+    /// The staging-trigger control: a plain group with the same
+    /// candidates and chain stages Loc-RIB-best-or-nothing, so the
+    /// same candidate withdrawal correctly restages nothing.
+    #[test]
+    fn plain_group_denied_best_does_not_restage_on_candidate_withdrawal() {
+        let mut m = staging_manager();
+        let p = prefix(1);
+        let mut rx = register_pcb_member(
+            &mut m,
+            MEMBER,
+            plain_group_with_chain(Some(deny_sources_chain(&[OTHER1]))),
+        );
+        seed(&mut m, cand(p, OTHER1, 300));
+        seed(&mut m, cand(p, OTHER2, 200));
+        seed(&mut m, cand(p, OTHER3, 100));
+        let changed = m.recompute_best(&HashSet::from([p]));
+        m.distribute_changes(&changed, &HashSet::from([p]));
+
+        unseed(&mut m, OTHER2, p);
+        let changed = m.recompute_best(&HashSet::from([p]));
+        assert!(changed.is_empty());
+        m.distribute_changes(&changed, &HashSet::from([p]));
+        let group = m.group_ribs.get(&PCB_GID).unwrap();
+        assert!(
+            group.table.get(&p, 0).is_none(),
+            "the denied Loc-RIB best stages nothing for a plain group"
+        );
+        let (announced, withdrawn) = folded_outbound(&mut rx);
+        assert!(announced.is_empty() && withdrawn.is_empty());
+    }
+
+    /// The lane-stale shape from the `OpenBGPD` issue-#21 family: the
+    /// permitted winner IS the (unmoved) Loc-RIB best and the
+    /// runner-up candidate is withdrawn — `best_changed` stays empty.
+    /// The widened pass retires the lane and withdraws the substituted
+    /// slot from `source(w)`; staging only `best_changed` would leave
+    /// the lane stale and the withdrawn route on that member's wire.
+    #[test]
+    fn pcb_lane_retires_when_runner_up_withdrawn_without_best_change() {
+        let mut m = staging_manager();
+        let p = prefix(1);
+        let mut rx = register_pcb_member(&mut m, OTHER1, per_client_best_group(None));
+        seed(&mut m, cand(p, OTHER1, 300)); // winner = Loc-RIB best, member-sourced
+        seed(&mut m, cand(p, OTHER2, 200)); // runner-up
+        let changed = m.recompute_best(&HashSet::from([p]));
+        m.distribute_changes(&changed, &HashSet::from([p]));
+        let (announced, _) = folded_outbound(&mut rx);
+        assert_eq!(
+            announced[&p].0, OTHER2,
+            "precondition: source(w) holds the lane substitution"
+        );
+        assert_eq!(lane_source(&m, p), Some(OTHER2));
+
+        unseed(&mut m, OTHER2, p);
+        let changed = m.recompute_best(&HashSet::from([p]));
+        assert!(
+            changed.is_empty(),
+            "precondition: the Loc-RIB best is unmoved"
+        );
+        m.distribute_changes(&changed, &HashSet::from([p]));
+        assert_eq!(
+            lane_source(&m, p),
+            None,
+            "the widened pass retires the lane"
+        );
+        let (announced, withdrawn) = folded_outbound(&mut rx);
+        assert!(announced.is_empty());
+        assert_eq!(
+            withdrawn,
+            vec![(p, 0)],
+            "the substituted slot is withdrawn from source(w)"
+        );
+    }
+
+    /// Cost guard for the widened pass (ADR-0126 Decision 2 pricing):
+    /// a candidate change below both slots restages the prefix through
+    /// the walk, but winner-equality and lane suppression make it a
+    /// no-op — zero deltas, zero lane transitions.
+    #[test]
+    fn pcb_widened_pass_with_unchanged_winner_and_lane_is_noop() {
+        let mut m = staging_manager();
+        let p = prefix(1);
+        seed(&mut m, cand(p, OTHER1, 300));
+        seed(&mut m, cand(p, OTHER2, 200));
+        seed(&mut m, cand(p, OTHER3, 100));
+        m.group_ribs.insert(PCB_GID, per_client_best_group(None));
+        let _ = stage_pcb(&mut m, &[p]);
+
+        // The third-ranked candidate churns — below the winner AND the
+        // lane; the prefix arrives via `all_affected` alone.
+        unseed(&mut m, OTHER3, p);
+        let mut memo = super::super::distribution::ExportMemo::default();
+        let staged = m.stage_update_groups(&HashSet::new(), &HashSet::from([p]), &mut memo);
+        let out = staged.get(&PCB_GID).expect("per-client-best group staged");
+        assert!(out.deltas.is_empty(), "unchanged winner stays suppressed");
+        assert!(
+            out.lane_deltas.is_empty(),
+            "unchanged lane stays suppressed"
+        );
+        assert_eq!(lane_source(&m, p), Some(OTHER2));
+    }
+
+    /// Plain groups keep the exact `best_changed` staging input: an
+    /// all-affected-only pass stages no plain group at all (the
+    /// widened set is never even built without a per-client-best
+    /// group), and a mixed pass never leaks all-affected extras into a
+    /// plain group's staging.
+    #[test]
+    fn plain_group_staging_keeps_best_changed_exactly() {
+        const PLAIN_GID: usize = 92;
+        let mut m = staging_manager();
+        let (p, q) = (prefix(1), prefix(2));
+        seed(&mut m, cand(p, OTHER1, 300));
+        seed(&mut m, cand(q, OTHER2, 300));
+        let _ = m.recompute_best(&HashSet::from([p, q]));
+        m.group_ribs.insert(PLAIN_GID, empty_group());
+        let mut memo = super::super::distribution::ExportMemo::default();
+        let staged = m.stage_update_groups(&HashSet::new(), &HashSet::from([p]), &mut memo);
+        assert!(
+            staged.is_empty(),
+            "an all-affected-only pass stages no plain group"
+        );
+        let staged = m.stage_update_groups(&HashSet::from([p]), &HashSet::from([p, q]), &mut memo);
+        let out = staged
+            .get(&PLAIN_GID)
+            .expect("plain group staged over best_changed");
+        assert_eq!(out.deltas.len(), 1);
+        assert_eq!(
+            out.deltas[0].prefix, p,
+            "all-affected extras never reach a plain group"
+        );
     }
 }

--- a/docs/adr/0126-shared-group-per-client-best.md
+++ b/docs/adr/0126-shared-group-per-client-best.md
@@ -104,6 +104,20 @@ plateau (per-client-best-only, F-scaling, upstream of the commit fan-out)
 belongs to the per-member candidate-multiplicity class this design removes
 structurally, and no phase of this design reintroduces it.
 
+**Staging trigger:** the pass hands per-client-best groups the same
+widened changed-prefix set the ungrouped per-client-best path enumerates
+— every prefix with any candidate change, not only Loc-RIB best flips —
+because the walk's input is the candidate list, not the Loc-RIB best. A
+candidate withdrawal or re-rank can flip the winner or retire the
+runner-up while the Loc-RIB best stands (the chain may deny that best
+outright); staging only best-flip prefixes would leave the lane stale —
+the issue-#21 class Decision 6 rules out. Plain groups keep the exact
+best-changed set: their staging input is Loc-RIB-best-or-nothing, so the
+narrow set is complete for them, and the widened set is not built at all
+when no per-client-best group exists. Winner-equality and lane
+suppression make the widened pass a no-op wherever neither slot moved,
+which is what keeps the per-candidate-change pricing above intact.
+
 **Counter recording:** every evaluation the walk performs enters the
 group's eval accumulator — the winner's permit, the runner-up's permit,
 and every candidate denied ahead of either. This is not a two-eval


### PR DESCRIPTION
## Defect

`stage_update_groups` was driven by the pass's `best_changed` set. A per-client-best group's winner walk (ADR-0126 Decision 2) reads the candidate list, not the Loc-RIB best: a candidate change can flip the filtered winner — or retire the runner-up lane — while the Loc-RIB best stands, most plainly when the export chain denies that best and the advertised winner is a lower-ranked candidate. Such a pass arrives with `best_changed` empty and the prefix carried by `all_affected` alone, so the group never restaged: the winner walk did not run, Decision 6's "every table delta recomputes the lane in the same pass" was vacuous for these prefixes, and the lane went stale — the OpenBGPD issue-#21 class the ADR rules out. The ungrouped per-client-best path already widens its enumeration for exactly this reason; the grouped path did not.

Dark today (no production configuration creates a per-client-best group), silently wrong at the Phase 3 classifier flip.

## Fix

- `stage_update_groups` takes both sets. Per-client-best groups stage from the widened `best_changed ∪ all_affected` union; plain groups keep the exact `best_changed` set — their staging input is Loc-RIB-best-or-nothing, so the narrow set is complete for them and their staging is unchanged. The union is built once per pass and only when a per-client-best group exists, so today's production shape pays nothing.
- The grouped members' per-pass prefix scope (`effective_prefixes`) widens the same way for members of per-client-best groups: the empty-pass gate and the filtered-inventory/OTC reconciliations share that scope with the group-side `record_policy_filtered`/`record_otc_blocked` calls, which now record over the widened set.
- Cost: staging a widened prefix whose winner and lane are both unchanged is a no-op by construction — winner-equality suppression against the group table plus lane suppression against the prior lane entry produce zero deltas and zero lane transitions. The widened set only ever contains prefixes with at least one candidate change, so the cost stays within ADR-0126 Decision 2's per-candidate-change pricing (test-pinned).

## Assertion contract changes

- The grouped enumeration arm's documented invariant changes from "the group deltas cover exactly the best-changed set" (all groups) to per-mode: plain groups' deltas cover exactly `best_changed`; per-client-best groups' deltas may originate from any all-affected prefix, and their members' pass scope widens to match.
- The grouped force-only-resync `debug_assert` tightens from "cannot share a nonempty best-change pass" to "cannot share a nonempty distribution pass" (`best_changed` and `all_affected` both empty): an all-affected-only pass now stages real deltas for per-client-best groups, so `best_changed` emptiness no longer proves the pass staged nothing. Both force setters synchronously run an empty pass, so the tightened form holds by the same argument as the old one.

## Audit: consumers of the staged output and `⊆ best_changed` assumptions

- Delta emission (`emit_group_deltas_for_member`, lane/rs-transition emitters, shared-emit build, `has_tagged_route`): delta-driven, no `best_changed` coupling — safe.
- `policy_filtered_for_member` + `update_policy_filtered_routes_for_prefixes`: scope-coupled to the staging set; fixed by widening `effective_prefixes` for per-client-best members.
- `reconcile_peer_otc_blocked` / `record_otc_blocked` / `otc_blocked_for_member`: same scope coupling, same fix. The per-client-best staging arm does not yet populate OTC (the one unlanded Phase 2 seam); when it lands it inherits the widened scope automatically because it flows through the same staged-prefix argument.
- `apply_group_policy_counters` (`stage.evals`): aggregate integer adds, no prefix scoping; re-evaluating widened prefixes matches the ungrouped path, which also re-evaluates them — safe.
- Empty-pass gate (`effective_prefixes.is_empty() → continue`): previously skipped member emission entirely on all-affected-only passes; covered by the widened scope.
- Channel-full tombstone/`member_scoped_withdraws` recording and dirty-resync enumeration (group table + tombstones + regroup baselines + extra-withdraw residue): derive from committed group state, not the pass sets — safe.
- Grouped force-only-resync `debug_assert`: proxy broken by the widening; tightened as above.
- `join_group` and the ADR-0105 transition-chunk builders call `stage_group_prefixes` with full Loc-RIB enumerations: complete for per-client-best (every prefix with any candidate has a Loc-RIB entry) — safe; per-client-best groups are excluded from the ADR-0105 fast path regardless (Decision 8).

## Tests

- `pcb_group_restages_from_all_affected_without_best_change`: chain denies the Loc-RIB best, winner is the second-ranked candidate; withdrawing the winner's candidate (best unmoved, `best_changed` empty) restages the group to the next permitted candidate and the member receives it.
- `plain_group_denied_best_does_not_restage_on_candidate_withdrawal`: the same inputs against a plain group correctly stage and emit nothing.
- `pcb_lane_retires_when_runner_up_withdrawn_without_best_change`: permitted winner is the unmoved best; withdrawing the runner-up retires the lane and withdraws the substituted slot from `source(w)`. Red-checked: both per-client-best tests fail against the pre-fix code (stale winner, stale lane); the plain control passes pre-fix.
- `pcb_widened_pass_with_unchanged_winner_and_lane_is_noop`: cost guard — churn below both slots produces zero deltas and zero lane transitions.
- `plain_group_staging_keeps_best_changed_exactly`: an all-affected-only pass stages no plain group; a mixed pass never leaks all-affected extras into a plain group.

Existing tests unmodified. ADR-0126 Decision 2 gains a staging-trigger paragraph naming the widened set and why the walk requires it.