### PR TITLE
Enforce per-client-best group OTC egress at the pre-commit backstop

### DIFF
--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -735,7 +735,10 @@ pub(super) fn no_export_export_suppressed(
 /// RFC 9234 §5 egress rule for IPv4/IPv6 unicast: a route that already
 /// carries OTC must not be propagated toward a Provider, Peer, or Route
 /// Server. The local role names our side of those relationships.
-fn otc_egress_blocked(route: &crate::route::Route, local_role: Option<BgpRole>) -> bool {
+pub(in crate::manager) fn otc_egress_blocked(
+    route: &crate::route::Route,
+    local_role: Option<BgpRole>,
+) -> bool {
     matches!(
         local_role,
         Some(BgpRole::Customer | BgpRole::Peer | BgpRole::RouteServerClient)
@@ -1194,7 +1197,17 @@ impl RibManager {
                 .all(|family| !self.selection_deferred(*family))
         });
         let current_session = self.outbound_session_ids.get(&peer).copied();
+        // Members of a per-client-best group are excluded from the ADR-0105
+        // narrow fast path outright: its clean predicate (zero
+        // policy-filtered routes on both sides) contradicts the
+        // mitigation's reason to exist. Re-inclusion is demand-gated
+        // (ADR-0126 Decision 8).
+        let not_per_client_best_group = self
+            .grouped_member_of(peer)
+            .and_then(|gid| self.group_ribs.get(&gid))
+            .is_none_or(|group| !group.per_client_best);
         only_unicast
+            && not_per_client_best_group
             && no_private_family_state
             && no_selection_gate
             && self.outbound_peers.contains_key(&peer)
@@ -2193,14 +2206,23 @@ impl RibManager {
         // RFC 9234 egress enforcement for every concrete-peer selection
         // shape. Single-best group staging applies the same gate before its
         // shared table commit; this central pass covers private single-best,
-        // ORR, Add-Path, and per-client-best without duplicating their tails.
+        // ORR, Add-Path, and per-client-best without duplicating their tails
+        // — including per-client-best GROUP members, whose winner walk
+        // stages the first permitted candidate regardless of OTC and defers
+        // egress enforcement here (ADR-0126 Decision 5), matching the
+        // ungrouped per-client-best path.
         if announce
             .iter()
             .any(|route| otc_egress_blocked(route, local_role))
         {
+            let per_client_best_member = self
+                .grouped_member_of(peer)
+                .and_then(|gid| self.group_ribs.get(&gid))
+                .is_some_and(|group| group.per_client_best);
             debug_assert!(
-                grouped_unicast_count.is_none(),
-                "group staging must reject OTC before its shared table commit"
+                grouped_unicast_count.is_none() || per_client_best_member,
+                "single-best group staging must reject OTC before its shared table commit; \
+                 per-client-best groups defer to this backstop by design"
             );
             debug_assert_eq!(announce.len(), next_hop_override.len());
             let mut permitted = Vec::with_capacity(announce.len());
@@ -2214,11 +2236,28 @@ impl RibManager {
                 .zip(next_hop_override.iter().cloned())
             {
                 if otc_egress_blocked(&route, local_role) {
-                    if self
-                        .adj_ribs_out
-                        .get(&peer)
-                        .and_then(|rib_out| rib_out.get(&route.prefix, route.path_id))
-                        .is_some()
+                    // A per-client-best group member's prior wire view is
+                    // group-derived (no per-peer unicast Adj-RIB-Out), so
+                    // the previously-advertised gate below cannot see it. A
+                    // NEWLY blocked identity — one still pending its
+                    // diagnostic, reconciled from the group residue before
+                    // this send at every seam — may be replacing a
+                    // delivered clean advertisement: convert it to a
+                    // withdraw once. Over-withdraw is the safe direction
+                    // (RFC 4271 no-op when nothing was delivered); a steady
+                    // blocked identity replays silently on refresh/join,
+                    // matching the ungrouped path's Adj-RIB-Out-gated
+                    // silence.
+                    let group_wire_may_hold = per_client_best_member
+                        && self.pending_otc_blocked.get(&peer).is_some_and(|pending| {
+                            pending.contains_key(&(route.prefix, route.path_id))
+                        });
+                    if (group_wire_may_hold
+                        || self
+                            .adj_ribs_out
+                            .get(&peer)
+                            .and_then(|rib_out| rib_out.get(&route.prefix, route.path_id))
+                            .is_some())
                         && withdrawn_keys.insert((route.prefix, route.path_id))
                     {
                         withdraw.push((route.prefix, route.path_id));
@@ -4233,6 +4272,14 @@ impl RibManager {
                         .extend(group.policy_filtered_for_member(peer, &effective_prefixes));
                     group_otc_blocked = if resync {
                         group.otc_blocked_for_member(peer, None)
+                    } else if group.per_client_best {
+                        // The staging pass just refreshed the residue for
+                        // exactly its staged prefixes, and the residue
+                        // derivation substitutes the lane runner-up toward
+                        // `source(w)` — the per-member outcome of the
+                        // pre-commit backstop (ADR-0126), which the flat
+                        // pass vector below cannot express.
+                        group.otc_blocked_for_member(peer, Some(&effective_prefixes))
                     } else {
                         group_stage
                             .get(&gid)

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -1669,9 +1669,17 @@ impl RibManager {
     /// `rs_control` and ORR are absent by construction: control
     /// communities diverge per TARGET (enforced at the member-emit
     /// seams, like today's group staging), and ORR peers cannot be
-    /// per-client-best (validation-enforced). OTC egress and rs-tag
-    /// transitions for per-client-best groups land with the ADR-0126
-    /// Phase 2 emit seams.
+    /// per-client-best (validation-enforced). RFC 9234 OTC egress is
+    /// deliberately NOT gated in this walk: per-client-best groups
+    /// enforce OTC at the central pre-commit backstop
+    /// (`try_send_and_commit_outbound_update_with_group_prior_and_otc_scope`),
+    /// matching the ungrouped per-client-best path — the in-walk gate
+    /// in [`Self::distribute_single_best_prefix`] serves single-best
+    /// staging only. A blocked winner stays staged and is RECORDED
+    /// into `otc_blocked` for the group's residue; a blocked
+    /// runner-up needs no recording — the residue derivation
+    /// (`GroupRibOut::otc_blocked_for_member`) reads it from the lane
+    /// entry itself.
     #[expect(
         clippy::too_many_arguments,
         clippy::too_many_lines,
@@ -1686,6 +1694,7 @@ impl RibManager {
         group_is_ebgp: bool,
         interpret_rfc1997: bool,
         group_is_rr_client: bool,
+        group_local_role: Option<rustbgpd_wire::BgpRole>,
         cluster_id: Option<Ipv4Addr>,
         sendable: Option<&Vec<(Afi, Safi)>>,
         llgr: Option<&Vec<(Afi, Safi)>>,
@@ -1696,6 +1705,7 @@ impl RibManager {
         withdraw: &mut Vec<(Prefix, u32)>,
         nh_override_flags: &mut Vec<Option<rustbgpd_policy::NextHopAction>>,
         policy_filtered: &mut Vec<(PolicyFilteredRouteKey, Option<PolicyLabel>)>,
+        otc_blocked: &mut Vec<crate::route::Route>,
     ) -> PerClientBestPrefixStage {
         use crate::best_path::best_path_cmp;
 
@@ -1801,6 +1811,19 @@ impl RibManager {
             winner_source = Some(candidate.peer);
             stage.winner_label = label;
             stage.winner_source_attrs = capture_source_attrs(candidate);
+            // RFC 9234 record-not-act (ADR-0126): a blocked winner
+            // stays staged — the pre-commit backstop strips it from
+            // every member emission — but its blocked identity must
+            // land in the group residue so per-member diagnostics and
+            // the replay reconciliations see the backstop's outcome.
+            // `group_local_role` is group-uniform (snapshot on
+            // `GroupRibOut`), so this one verdict covers every member.
+            // Recorded even when the announce below is
+            // equality-suppressed: the caller's `record_otc_blocked`
+            // refreshes this prefix's residue every pass.
+            if super::otc_egress_blocked(&modified, group_local_role) {
+                otc_blocked.push(modified.clone());
+            }
             let changed = rib_out
                 .get(prefix, 0)
                 .is_none_or(|existing| !routes_equal(existing, &modified));

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -1448,14 +1448,40 @@ impl GroupRibOut {
         member: IpAddr,
         prefixes: Option<&HashSet<Prefix>>,
     ) -> Vec<Route> {
-        self.otc_blocked
+        let mut blocked: Vec<Route> = self
+            .otc_blocked
             .values()
             .filter(|route| {
                 route.peer != member
                     && prefixes.is_none_or(|prefixes| prefixes.contains(&route.prefix))
             })
             .cloned()
-            .collect()
+            .collect();
+        // ADR-0126: the member sourcing a staged winner receives the
+        // lane runner-up instead (adv(m)), so ITS blocked entry at that
+        // slot is the runner-up when that carries OTC — derived from
+        // the lane here rather than stored (both slots share the
+        // `(prefix, 0)` residue key). `local_role` is group-uniform
+        // (snapshot on this group), so one verdict covers every member;
+        // the own-source filter above already withholds the winner from
+        // `source(w)`. Together the two terms reproduce the pre-commit
+        // backstop's per-member outcome, blocked(adv(m)), exactly.
+        if self.per_client_best {
+            blocked.extend(
+                self.runner_up
+                    .iter()
+                    .filter(|(prefix, entry)| {
+                        entry.winner_source == member
+                            && prefixes.is_none_or(|prefixes| prefixes.contains(prefix))
+                            && super::distribution::otc_egress_blocked(
+                                &entry.route,
+                                self.local_role,
+                            )
+                    })
+                    .map(|(_, entry)| entry.route.clone()),
+            );
+        }
+        blocked
     }
 
     fn count_slot(prefix: &Prefix) -> usize {
@@ -1927,7 +1953,13 @@ impl RibManager {
         destination: usize,
     ) -> Option<Vec<(Prefix, u32)>> {
         let clean = |group: &GroupRibOut| {
-            group.dirty_members.is_empty()
+            // Per-client-best groups are excluded from the ADR-0105 narrow
+            // fast path outright — its clean predicate (zero
+            // policy-filtered routes on both sides) contradicts the
+            // mitigation's reason to exist. Re-inclusion is demand-gated
+            // (ADR-0126 Decision 8).
+            !group.per_client_best
+                && group.dirty_members.is_empty()
                 && group.tombstones.is_empty()
                 && group.vpn_tombstones.is_empty()
                 && group.table.vpn_len() == 0
@@ -2304,6 +2336,7 @@ impl RibManager {
                         group.is_ebgp,
                         group.interpret_rfc1997,
                         group.is_rr_client,
+                        group.local_role,
                         self.cluster_id,
                         Some(&group.sendable),
                         Some(&group.llgr),
@@ -2314,6 +2347,7 @@ impl RibManager {
                         &mut withdraw,
                         &mut nh_flags,
                         &mut labeled_filtered,
+                        &mut out.otc_blocked,
                     );
                     // The winner announce (at most one — the walk
                     // stages a single `path_id 0` winner), captured
@@ -3787,6 +3821,20 @@ impl RibManager {
             return None;
         };
         let source = *source;
+        // A per-client-best source group never takes the ADR-0105 fast
+        // path — nor its unfenced destination prestage, whose only
+        // preflight is this function. Checked on the source cell: the
+        // ADR-0126 Phase 3 `per_client_best` key bit keeps source and
+        // destination in agreement, and `begin_policy_transition_group`
+        // only ever creates plain destination cells. Re-inclusion is
+        // demand-gated (ADR-0126 Decision 8).
+        if self
+            .group_ribs
+            .get(&source)
+            .is_some_and(|group| group.per_client_best)
+        {
+            return None;
+        }
         let GroupMembership::Grouped(destination) =
             self.compute_update_group_membership_for_policy(peer, policy)
         else {
@@ -8660,5 +8708,503 @@ mod tests {
             out.deltas[0].prefix, p,
             "all-affected extras never reach a plain group"
         );
+    }
+
+    // --- ADR-0126 Decision 5: RFC 9234 OTC egress for per-client-best
+    // --- groups is enforced at the central pre-commit backstop — the
+    // --- walk records blocked staged output, never acts on it.
+
+    fn with_otc_attr(mut route: Route) -> Route {
+        let mut attrs = (*route.attributes).clone();
+        attrs.push(PathAttribute::OnlyToCustomer(64_496));
+        route.attributes = Arc::new(attrs);
+        route
+    }
+
+    /// [`per_client_best_group`] under a role RFC 9234 blocks OTC
+    /// egress for. `local_role` is group-uniform (in the group key), so
+    /// the snapshot is the walk's only role input.
+    fn per_client_best_customer_group() -> GroupRibOut {
+        let mut group = per_client_best_group(None);
+        group.local_role = Some(BgpRole::Customer);
+        group
+    }
+
+    /// Register `member` on the UNGROUPED per-client-best path — the
+    /// grouped path's correctness oracle — with the staging knobs of
+    /// [`per_client_best_group`] (iBGP RR client) so both sides run
+    /// the same export gates.
+    fn register_ungrouped_pcb_peer(
+        m: &mut RibManager,
+        member: IpAddr,
+    ) -> tokio::sync::mpsc::Receiver<crate::update::OutboundRouteUpdate> {
+        let (outbound_tx, mut outbound_rx) = tokio::sync::mpsc::channel(8);
+        m.handle_update(crate::update::RibUpdate::PeerUp {
+            peer: member,
+            session_id: 0,
+            peer_asn: TARGET_ASN,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            outbound_tx,
+            export_policy: None,
+            sendable_families: vec![(Afi::Ipv4, Safi::Unicast)],
+            is_ebgp: false,
+            route_reflector_client: true,
+            orr_vantage: None,
+            per_client_best: true,
+            interpret_rfc1997: true,
+            add_path_send_families: vec![],
+            add_path_send_max: 0,
+            negotiated_orf_recv: vec![],
+            negotiated_llgr_families: vec![],
+        });
+        while outbound_rx.try_recv().is_ok() {}
+        outbound_rx
+    }
+
+    /// Feed inbound routes through the REAL chunked distribution pass.
+    fn receive_routes(m: &mut RibManager, source: IpAddr, announced: Vec<Route>) {
+        m.handle_update(crate::update::RibUpdate::RoutesReceived {
+            peer: source,
+            session_id: 0,
+            announced,
+            withdrawn: vec![],
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![],
+            evpn_withdrawn: vec![],
+        });
+        while m.process_next_route_chunk() {}
+    }
+
+    /// Every queued envelope folded to the wire-relevant fields.
+    #[derive(Debug, PartialEq, Default)]
+    struct DrainedWire {
+        announced: Vec<(Prefix, IpAddr)>,
+        withdrawn: Vec<(Prefix, u32)>,
+        otc_blocked: Vec<(Prefix, IpAddr)>,
+    }
+
+    fn drain_wire(
+        rx: &mut tokio::sync::mpsc::Receiver<crate::update::OutboundRouteUpdate>,
+    ) -> DrainedWire {
+        let mut wire = DrainedWire::default();
+        while let Ok(update) = rx.try_recv() {
+            wire.announced
+                .extend(update.announce.iter().map(|r| (r.prefix, r.peer)));
+            wire.withdrawn.extend(update.withdraw.iter().copied());
+            wire.otc_blocked
+                .extend(update.otc_blocked.iter().map(|r| (r.prefix, r.peer)));
+        }
+        wire
+    }
+
+    /// No in-walk gate (ADR-0126 Decision 5): a blocked winner stays
+    /// staged in the table and the pass RECORDS it — into the pass
+    /// output and, committed, the persistent residue — including on a
+    /// later equality-suppressed restage. `source(w)` never sees its
+    /// own winner in the residue derivation.
+    #[test]
+    fn pcb_otc_blocked_winner_stays_staged_and_residue_recorded() {
+        let mut m = staging_manager();
+        let p = prefix(1);
+        seed(&mut m, with_otc_attr(cand(p, OTHER1, 300)));
+        seed(&mut m, cand(p, OTHER2, 200));
+        m.group_ribs
+            .insert(PCB_GID, per_client_best_customer_group());
+
+        let out = stage_pcb(&mut m, &[p]);
+
+        assert_eq!(out.deltas.len(), 1);
+        assert!(
+            out.deltas[0].new.is_some(),
+            "blocked winner is staged, not withdrawn"
+        );
+        let group = m.group_ribs.get(&PCB_GID).unwrap();
+        let staged = group
+            .table
+            .get(&p, 0)
+            .expect("blocked winner stays in the table");
+        assert_eq!(staged.peer, OTHER1);
+        assert!(
+            staged
+                .attributes
+                .iter()
+                .any(|attr| matches!(attr, PathAttribute::OnlyToCustomer(_))),
+            "the staged form keeps the OTC attribute"
+        );
+        assert_eq!(lane_source(&m, p), Some(OTHER2));
+        assert_eq!(out.otc_blocked.len(), 1);
+        assert_eq!(out.otc_blocked[0].peer, OTHER1);
+        let blocked = group.otc_blocked_for_member(MEMBER, None);
+        assert_eq!(
+            blocked.iter().map(|r| r.peer).collect::<Vec<_>>(),
+            vec![OTHER1],
+            "non-source members see the blocked winner"
+        );
+        assert!(
+            group.otc_blocked_for_member(OTHER1, None).is_empty(),
+            "source(w) receives the clean runner-up — nothing blocked for it"
+        );
+
+        // Equality-suppressed restage: no delta, residue re-recorded.
+        let out = stage_pcb(&mut m, &[p]);
+        assert!(out.deltas.is_empty());
+        assert_eq!(out.otc_blocked.len(), 1);
+        let group = m.group_ribs.get(&PCB_GID).unwrap();
+        assert_eq!(group.otc_blocked_for_member(MEMBER, None).len(), 1);
+    }
+
+    /// A blocked runner-up is DERIVED from the lane at consumption
+    /// (both slots share the `(prefix, 0)` residue key, so it is never
+    /// stored): only `source(w)` — whose adv(m) is the runner-up —
+    /// sees it, prefix scoping applies, and with BOTH slots blocked
+    /// each member sees exactly blocked(adv(m)).
+    #[test]
+    fn pcb_otc_blocked_runner_up_derived_toward_winner_source() {
+        let mut m = staging_manager();
+        let p = prefix(1);
+        seed(&mut m, cand(p, OTHER1, 300));
+        seed(&mut m, with_otc_attr(cand(p, OTHER2, 200)));
+        m.group_ribs
+            .insert(PCB_GID, per_client_best_customer_group());
+
+        let out = stage_pcb(&mut m, &[p]);
+
+        assert!(out.otc_blocked.is_empty(), "a clean winner records nothing");
+        let group = m.group_ribs.get(&PCB_GID).unwrap();
+        assert!(
+            group.otc_blocked_for_member(MEMBER, None).is_empty(),
+            "non-source members receive the clean winner"
+        );
+        assert_eq!(
+            group
+                .otc_blocked_for_member(OTHER1, None)
+                .iter()
+                .map(|r| r.peer)
+                .collect::<Vec<_>>(),
+            vec![OTHER2],
+            "source(w)'s derived view is the blocked runner-up"
+        );
+        assert!(
+            group
+                .otc_blocked_for_member(OTHER1, Some(&HashSet::from([prefix(2)])))
+                .is_empty(),
+            "prefix scoping applies to the lane term"
+        );
+
+        // Both slots blocked: winner rides the residue map, runner-up
+        // the lane — per member exactly blocked(adv(m)).
+        seed(&mut m, with_otc_attr(cand(p, OTHER1, 300)));
+        let out = stage_pcb(&mut m, &[p]);
+        assert_eq!(out.otc_blocked.len(), 1);
+        let group = m.group_ribs.get(&PCB_GID).unwrap();
+        assert_eq!(
+            group
+                .otc_blocked_for_member(MEMBER, None)
+                .iter()
+                .map(|r| r.peer)
+                .collect::<Vec<_>>(),
+            vec![OTHER1]
+        );
+        assert_eq!(
+            group
+                .otc_blocked_for_member(OTHER1, None)
+                .iter()
+                .map(|r| r.peer)
+                .collect::<Vec<_>>(),
+            vec![OTHER2]
+        );
+    }
+
+    /// Backstop parity through the REAL commit path: a delivered clean
+    /// winner replaced by an OTC-carrying one is stripped at the
+    /// pre-commit backstop and converted to exactly the withdraw the
+    /// ungrouped per-client-best path emits for identical inputs —
+    /// while the group table keeps the blocked winner — and the
+    /// refresh/join replays of the steady blocked state are silent on
+    /// both sides.
+    #[test]
+    fn pcb_otc_transition_emission_matches_ungrouped_per_client_best() {
+        let p = prefix(1);
+        let run = |grouped: bool| -> Vec<DrainedWire> {
+            let mut m = staging_manager();
+            let mut rx = if grouped {
+                register_pcb_member(&mut m, MEMBER, per_client_best_customer_group())
+            } else {
+                register_ungrouped_pcb_peer(&mut m, MEMBER)
+            };
+            m.peer_local_roles.insert(MEMBER, Some(BgpRole::Customer));
+            let mut passes = Vec::new();
+            receive_routes(&mut m, OTHER1, vec![cand(p, OTHER1, 300)]);
+            passes.push(drain_wire(&mut rx));
+            receive_routes(&mut m, OTHER1, vec![with_otc_attr(cand(p, OTHER1, 300))]);
+            passes.push(drain_wire(&mut rx));
+            m.send_route_refresh_response(MEMBER, Afi::Ipv4, Safi::Unicast);
+            passes.push(drain_wire(&mut rx));
+            m.send_initial_table(MEMBER);
+            passes.push(drain_wire(&mut rx));
+            if grouped {
+                let group = m.group_ribs.get(&PCB_GID).unwrap();
+                assert_eq!(
+                    group.table.get(&p, 0).map(|r| r.peer),
+                    Some(OTHER1),
+                    "the blocked winner stays staged behind the stripped emissions"
+                );
+            }
+            passes
+        };
+        let grouped = run(true);
+        let ungrouped = run(false);
+        assert_eq!(grouped, ungrouped, "grouped-vs-ungrouped wire divergence");
+        assert_eq!(grouped[0].announced, vec![(p, OTHER1)]);
+        assert!(grouped[0].withdrawn.is_empty() && grouped[0].otc_blocked.is_empty());
+        assert_eq!(
+            grouped[1],
+            DrainedWire {
+                announced: vec![],
+                withdrawn: vec![(p, 0)],
+                otc_blocked: vec![(p, OTHER1)],
+            },
+            "the blocked replacement converts to a withdraw plus its diagnostic"
+        );
+        assert_eq!(
+            grouped[2],
+            DrainedWire::default(),
+            "a steady blocked identity replays silently on refresh"
+        );
+        assert_eq!(
+            grouped[3],
+            DrainedWire::default(),
+            "a same-session join replay of the steady blocked state stays silent"
+        );
+    }
+
+    /// The one deliberate deviation from the ungrouped path, pinned: a
+    /// NEWLY blocked identity that was never delivered. The ungrouped
+    /// path's Adj-RIB-Out gate keeps it silent; a group member's prior
+    /// wire view is group-derived, so the backstop emits one defensive
+    /// withdraw (an RFC 4271 no-op — over-withdraw is the safe
+    /// direction) alongside the diagnostic. Steady-state replays are
+    /// silent on both sides afterwards.
+    #[test]
+    fn pcb_otc_fresh_blocked_prefix_emits_one_defensive_withdraw() {
+        let p = prefix(1);
+        let run = |grouped: bool| -> (DrainedWire, DrainedWire) {
+            let mut m = staging_manager();
+            let mut rx = if grouped {
+                register_pcb_member(&mut m, MEMBER, per_client_best_customer_group())
+            } else {
+                register_ungrouped_pcb_peer(&mut m, MEMBER)
+            };
+            m.peer_local_roles.insert(MEMBER, Some(BgpRole::Customer));
+            receive_routes(&mut m, OTHER1, vec![with_otc_attr(cand(p, OTHER1, 300))]);
+            let pass = drain_wire(&mut rx);
+            m.send_route_refresh_response(MEMBER, Afi::Ipv4, Safi::Unicast);
+            (pass, drain_wire(&mut rx))
+        };
+        let (grouped_pass, grouped_refresh) = run(true);
+        let (ungrouped_pass, ungrouped_refresh) = run(false);
+        assert_eq!(
+            grouped_pass,
+            DrainedWire {
+                announced: vec![],
+                withdrawn: vec![(p, 0)],
+                otc_blocked: vec![(p, OTHER1)],
+            },
+            "grouped: one defensive withdraw beside the diagnostic"
+        );
+        assert_eq!(
+            ungrouped_pass,
+            DrainedWire {
+                announced: vec![],
+                withdrawn: vec![],
+                otc_blocked: vec![(p, OTHER1)],
+            },
+            "ungrouped: the Adj-RIB-Out gate keeps the fresh case silent"
+        );
+        assert_eq!(grouped_refresh, DrainedWire::default());
+        assert_eq!(ungrouped_refresh, DrainedWire::default());
+    }
+
+    /// Lane variant through the real path: a blocked runner-up
+    /// substituting toward `source(w)` is stripped/suppressed exactly
+    /// like the ungrouped outcome (which stages the same route as the
+    /// member's first non-own permitted candidate) — modulo the pinned
+    /// defensive withdraw on the fresh edge — and its diagnostic is
+    /// the LANE route.
+    #[test]
+    fn pcb_otc_blocked_lane_substitution_matches_ungrouped_toward_winner_source() {
+        let p = prefix(1);
+        let run = |grouped: bool| -> (DrainedWire, DrainedWire) {
+            let mut m = staging_manager();
+            let mut rx = if grouped {
+                register_pcb_member(&mut m, MEMBER, per_client_best_customer_group())
+            } else {
+                register_ungrouped_pcb_peer(&mut m, MEMBER)
+            };
+            m.peer_local_roles.insert(MEMBER, Some(BgpRole::Customer));
+            // The member sources the winner; its derived view is the
+            // runner-up. The winner pass's emission toward the member
+            // is not under test — drained and discarded.
+            receive_routes(&mut m, MEMBER, vec![cand(p, MEMBER, 300)]);
+            let _ = drain_wire(&mut rx);
+            receive_routes(&mut m, OTHER2, vec![with_otc_attr(cand(p, OTHER2, 200))]);
+            let pass = drain_wire(&mut rx);
+            m.send_route_refresh_response(MEMBER, Afi::Ipv4, Safi::Unicast);
+            (pass, drain_wire(&mut rx))
+        };
+        let (grouped_pass, grouped_refresh) = run(true);
+        let (ungrouped_pass, ungrouped_refresh) = run(false);
+        assert!(grouped_pass.announced.is_empty() && ungrouped_pass.announced.is_empty());
+        assert_eq!(
+            grouped_pass.otc_blocked,
+            vec![(p, OTHER2)],
+            "the diagnostic is the LANE route toward source(w)"
+        );
+        assert_eq!(ungrouped_pass.otc_blocked, vec![(p, OTHER2)]);
+        assert_eq!(
+            grouped_pass.withdrawn,
+            vec![(p, 0)],
+            "fresh blocked edge: the pinned defensive withdraw"
+        );
+        assert!(ungrouped_pass.withdrawn.is_empty());
+        assert_eq!(grouped_refresh, DrainedWire::default());
+        assert_eq!(ungrouped_refresh, DrainedWire::default());
+    }
+
+    /// A SINGLE-BEST group reaching the backstop with an OTC-blocked
+    /// announce is still a bug — its in-walk gate must reject before
+    /// the shared table commit; only per-client-best groups defer to
+    /// the backstop.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "single-best group staging must reject OTC")]
+    fn single_best_group_otc_at_backstop_trips_debug_assert() {
+        let mut m = staging_manager();
+        let (outbound_tx, _outbound_rx) = tokio::sync::mpsc::channel(8);
+        m.outbound_peers.insert(MEMBER, outbound_tx);
+        m.peer_export_encoders
+            .insert(MEMBER, super::super::permissive_test_exact_export_encoder());
+        m.peer_local_roles.insert(MEMBER, Some(BgpRole::Customer));
+        m.update_groups
+            .members
+            .insert(MEMBER, GroupMembership::Grouped(PCB_GID));
+        m.group_ribs.insert(PCB_GID, empty_group());
+        let announce: Arc<[Route]> = vec![with_otc_attr(route(prefix(1), OTHER1))].into();
+        let nh: Arc<[Option<NextHopAction>]> = vec![None].into();
+        let _ = m.try_send_and_commit_outbound_update(
+            MEMBER,
+            nh,
+            announce,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+    }
+
+    /// The per-client-best counterpart of the assert test: the same
+    /// backstop entry does NOT panic — the blocked announce strips,
+    /// the pending-gated conversion emits its withdraw, and the
+    /// diagnostic delivers (clearing the pending edge).
+    #[test]
+    fn per_client_best_group_otc_at_backstop_strips_with_pending_gated_withdraw() {
+        let mut m = staging_manager();
+        let (outbound_tx, mut outbound_rx) = tokio::sync::mpsc::channel(8);
+        m.outbound_peers.insert(MEMBER, outbound_tx);
+        m.peer_export_encoders
+            .insert(MEMBER, super::super::permissive_test_exact_export_encoder());
+        m.peer_local_roles.insert(MEMBER, Some(BgpRole::Customer));
+        m.update_groups
+            .members
+            .insert(MEMBER, GroupMembership::Grouped(PCB_GID));
+        m.group_ribs
+            .insert(PCB_GID, per_client_best_customer_group());
+        let blocked = with_otc_attr(route(prefix(1), OTHER1));
+        m.pending_otc_blocked
+            .entry(MEMBER)
+            .or_default()
+            .insert((prefix(1), 0), blocked.clone());
+        let announce: Arc<[Route]> = vec![blocked].into();
+        let nh: Arc<[Option<NextHopAction>]> = vec![None].into();
+        assert!(m.try_send_and_commit_outbound_update(
+            MEMBER,
+            nh,
+            announce,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        ));
+        let update = outbound_rx.try_recv().unwrap();
+        assert!(
+            update.announce.is_empty(),
+            "the blocked announce is stripped"
+        );
+        assert_eq!(
+            update.withdraw,
+            vec![(prefix(1), 0)],
+            "a pending (newly blocked) identity converts to a withdraw"
+        );
+        assert_eq!(update.otc_blocked.len(), 1);
+        assert!(
+            !m.pending_otc_blocked.contains_key(&MEMBER),
+            "the delivered diagnostic retires the pending edge"
+        );
+    }
+
+    /// ADR-0105 exclusion (ADR-0126 Decision 8): a per-client-best
+    /// group on EITHER side rejects the clean-transition inventory
+    /// even when every other clean term holds; plain groups with the
+    /// same tables stay eligible.
+    #[test]
+    fn per_client_best_groups_are_excluded_from_clean_transition_inventory() {
+        let mut m = staging_manager();
+        let build = |per_client_best: bool| {
+            let mut group = if per_client_best {
+                per_client_best_group(None)
+            } else {
+                empty_group()
+            };
+            group.apply_delta(&announce_delta(prefix(1), OTHER1, None));
+            group
+        };
+        m.group_ribs.insert(1, build(false));
+        m.group_ribs.insert(2, build(false));
+        m.group_ribs.insert(3, build(true));
+        m.group_ribs.insert(4, build(true));
+        assert!(
+            m.begin_clean_policy_transition_inventory(1, 2).is_some(),
+            "plain groups stay eligible"
+        );
+        for (source, destination) in [(3, 4), (3, 2), (1, 4)] {
+            assert!(
+                m.begin_clean_policy_transition_inventory(source, destination)
+                    .is_none(),
+                "a per-client-best side must reject the fast path ({source} -> {destination})"
+            );
+        }
     }
 }

--- a/docs/adr/0126-shared-group-per-client-best.md
+++ b/docs/adr/0126-shared-group-per-client-best.md
@@ -230,6 +230,22 @@ divergence (ADR-0101 Decision 3) applies per member at the same emit
 seams; lane entries carry source attributes so tag transitions extend to
 them.
 
+RFC 9234 OTC egress for per-client-best groups is enforced at the
+central pre-commit backstop, matching the ungrouped per-client-best
+path's semantics: the winner walk stages the first permitted candidate
+regardless of OTC, and every member emission — steady-state, refresh,
+join, and resync alike — passes through the backstop, which strips a
+blocked route and converts it to a withdraw where a delivered
+advertisement may be replaced (over-withdraw remains the safe
+direction). The in-walk gate serves single-best staging only. A blocked
+winner therefore stays in the group table and a blocked runner-up stays
+in the lane; the group's OTC residue derivation covers both — the
+recorded winner for non-source members, the lane entry toward
+`source(w)` — so per-member diagnostics and the replay reconciliations
+see exactly the backstop's outcome. The differential-oracle comparison
+is post-backstop on both sides, so byte-identity holds with OTC-blocked
+routes invisible to both.
+
 ### 6. The OpenBGPD bug family, as non-goals-to-avoid with mechanisms
 
 - **Stale second-best after best withdrawal** (issue #21): impossible by


### PR DESCRIPTION
Closes out the ADR-0126 Phase 2 seams: the RFC 9234 OTC enforcement decision for per-client-best groups, plus the ADR-0105 clean-transition exclusion Decision 8 promised.

## OTC egress: backstop parity (ADR-0126 Decision 5)

OTC is a post-policy egress gate, not part of chain evaluation. The per-client-best winner walk deliberately has **no in-walk OTC gate** — it stages the first export-permitted candidate regardless of OTC, exactly like the ungrouped per-client-best path, and every member emission is enforced at the central pre-commit backstop (`try_send_and_commit_outbound_update_with_group_prior_and_otc_scope`). The in-walk gate in `distribute_single_best_prefix` serves single-best staging only.

- **Record, not act:** the walk records a blocked staged winner into the group's OTC residue (re-recorded on equality-suppressed restages; the group's snapshot `local_role` is group-uniform, so one verdict covers every member). A blocked runner-up is never stored — both slots share the `(prefix, 0)` residue key — it is derived from the lane entry inside `otc_blocked_for_member`, whose two terms (own-source-filtered winner + lane entry toward `source(w)`) reproduce the backstop's per-member outcome, blocked(adv(m)), exactly. The steady-state fanout's non-resync arm now reads that derivation for per-client-best groups instead of the flat pass vector.
- **Assertion relaxed precisely:** the backstop `debug_assert` keys on the member group's `per_client_best` flag, not on "grouped" — a single-best group reaching the backstop with an OTC-blocked route still trips it.
- **Withdraw conversion:** a grouped member's prior wire view is group-derived (no per-peer unicast Adj-RIB-Out), so the previously-advertised gate cannot see it. A NEWLY blocked identity — one still pending its diagnostic, reconciled from the group residue before every send — converts to one withdraw; a steady blocked identity replays silently on refresh/join, matching the ungrouped path's Adj-RIB-Out-gated silence.

**Per-seam call-path evidence** (every replay seam's unicast announces flow through the backstop; no seam needs residue-side suppression):

| Seam | Assembly | Backstop entry |
|---|---|---|
| Steady-state fanout | shared payload / member matrix + lane arms (`distribution/mod.rs` ~4230-4300) | `distribution/mod.rs` ~4950 (`..._with_group_prior_and_otc_scope`) |
| RFC 2918 refresh replay | adv(m) walk (`route_refresh.rs` ~1028-1064) | `route_refresh.rs` ~1320 |
| Join / initial dump | adv(m) walk (`peer_lifecycle.rs` ~1235-1265) | `peer_lifecycle.rs` ~1800 |
| Dirty/force resync | `assemble_group_resync` (`update_groups.rs` ~2760) | same fanout call as above (resync arm) |
| Channel-full lane residue | `pending_extra_withdraws` (withdraw-only; OTC never blocks withdraws) | resync enumeration, same call |

**One pinned deviation:** a newly blocked identity that was never delivered emits one defensive withdraw on the grouped side (RFC 4271 no-op; over-withdraw is the design's safe direction) where the ungrouped path's Adj-RIB-Out gate stays silent — the member's prior wire state is not knowable per peer without the per-member bookkeeping this design exists to delete. Pinned by test. The blocked winner also remains in the group table, so table-derived counts include it; the differential-oracle comparison is post-backstop on both sides, so wire byte-identity holds with OTC-blocked routes invisible to both (recorded in the ADR).

## ADR-0105 exclusion (ADR-0126 Decision 8)

`per_client_best` terms added at all three decision points, each citing the demand-gated re-inclusion trigger:

- `clean_policy_transition_peer_ready` (member eligibility, `distribution/mod.rs`)
- `begin_clean_policy_transition_inventory` clean closure (inventory side, both groups)
- `clean_policy_transition_destination` (preflight — the only guard on the unfenced destination prestage entry `begin_destination_prestage`, which the two predicates above never see)

`begin_policy_transition_group` already hardcodes a plain destination cell with the Decision 8 citation; the preflight exclusion now makes that provably correct. Fast-path entries audited: `advance_clean_policy_transition` (both phases) and `begin_destination_prestage` — all route through the amended predicates.

## ADR amendment

Decision 5 gains the settled OTC paragraph: backstop enforcement matching the ungrouped path, in-walk gate scoped to single-best staging, post-backstop oracle comparison.

## Tests

- Staging: blocked winner stays staged + recorded (incl. equality-suppressed restage); blocked runner-up derived toward `source(w)` only, prefix-scoped, both-slots-blocked = blocked(adv(m)) per member.
- Real commit path, grouped-vs-ungrouped wire comparison: clean-to-blocked transition (withdraw + diagnostic, identical), steady-state refresh and same-session join silence (identical), fresh-blocked deviation (pinned on both sides), lane-substitution variant toward `source(w)`.
- Backstop assert: single-best group + OTC trips it (`#[should_panic]`, `cfg(debug_assertions)`); per-client-best counterpart strips with the pending-gated withdraw and retires the pending edge.
- ADR-0105: per-client-best group on either side rejects the clean-transition inventory; plain groups unaffected; all existing ADR-0105/oracle/per-client-best tests pass unmodified.

Gates: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps`, `check-clippy-reasons.py`, `cargo check -p rustbgpd-rib --features bench-internals --benches` — all exit 0.