### PR TITLE
Keep the per-client-best fanout bench on the per-peer fallback

### DIFF
--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -344,8 +344,13 @@ impl RibManager {
     }
 
     /// Register synthetic eBGP route-server clients on the production
-    /// per-client-best fallback. The explicit seam keeps the grouping
-    /// disqualifier visible instead of adding a positional flag to callers.
+    /// per-client-best per-peer fallback. Since the ADR-0126 Phase 3
+    /// classifier flip a unicast-only per-client-best peer GROUPS, so the
+    /// fallback these fixtures promise requires a non-unicast-only session:
+    /// each peer also negotiates VPNv4 (no VPN routes exist in any fixture,
+    /// so the wire stays pure IPv4-unicast). The explicit seam keeps the
+    /// grouping disqualifier visible instead of adding a positional flag to
+    /// callers.
     #[must_use]
     pub fn bench_register_per_client_best_route_server_peers<F>(
         &mut self,
@@ -445,6 +450,17 @@ impl RibManager {
             let (tx, mut rx) = mpsc::channel(channel_capacity);
             self.pending_peer_export_encoders
                 .insert((peer, session_id), make_exact_export_encoder(peer_asn));
+            // ADR-0126 Decision 1: a unicast-only per-client-best session
+            // classifies Groupable, so a per-client-best fixture peer must
+            // negotiate a non-unicast-only family to stay on the per-peer
+            // fallback these fixtures measure. No fixture seeds VPN routes,
+            // so the negotiated-but-empty family never reaches an envelope,
+            // a receipt counter, or a family gauge.
+            let sendable_families = if per_client_best {
+                vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv4, Safi::MplsVpn)]
+            } else {
+                vec![(Afi::Ipv4, Safi::Unicast)]
+            };
             self.handle_peer_up(
                 peer,
                 session_id,
@@ -452,7 +468,7 @@ impl RibManager {
                 Ipv4Addr::new(192, 0, 2, 1), // shared bgp-id (irrelevant to fanout cost)
                 tx,
                 export_policy.cloned(),
-                vec![(Afi::Ipv4, Safi::Unicast)],
+                sendable_families,
                 is_ebgp,
                 is_rr_client,
                 None, // no ORR vantage

--- a/crates/transport/benches/fanout.rs
+++ b/crates/transport/benches/fanout.rs
@@ -57,13 +57,15 @@
 //! makes no performance claim.
 //!
 //! `per_client_best_full_resync` covers the authoritative private fallback at
-//! 4,096 IPv4 routes and 8/64 eBGP route-server clients. Routes are sourced
-//! round-robin from that same fleet, so every resync proves both self-source
-//! exclusion and the singleton per-target candidate arm. Setup output is
-//! drained before one export-policy replacement per peer is timed; selection,
-//! exact-encoder, private commit, enqueue, inventory, and residue receipts are
-//! checked afterward. This is instrumentation only and makes no performance
-//! claim.
+//! 4,096 IPv4 routes and 8/64 eBGP route-server clients. Since the ADR-0126
+//! Phase 3 classifier flip that fallback requires a non-unicast-only session,
+//! so each fixture peer also negotiates VPNv4 (route-free — the wire stays
+//! pure IPv4-unicast). Routes are sourced round-robin from that same fleet, so
+//! every resync proves both self-source exclusion and the singleton per-target
+//! candidate arm. Setup output is drained before one export-policy replacement
+//! per peer is timed; selection, exact-encoder, private commit, enqueue,
+//! inventory, and residue receipts are checked afterward. This is
+//! instrumentation only and makes no performance claim.
 //!
 //! Gated behind `bench-internals`; run with:
 //!   cargo bench -p rustbgpd-transport --features bench-internals --bench fanout


### PR DESCRIPTION
Fixes the post-merge bench-smoke red on main after #1512 (the ADR-0126 Phase 3 classifier flip): `cargo test -p rustbgpd-transport --bench fanout` panicked at the `per_client_best_full_resync` setup receipt (`fanout.rs:780`, `update_groups == 0`).

## Why it broke

The bench's route-server fixture — `per_client_best`, a shareable community export chain, IPv4-unicast-only sessions — is exactly the shape the flip moved from the per-peer fallback into a shared update group. Post-flip the fixture regrouped, so every private-fallback receipt pin (zero groups, `ungrouped_peers == peers`, private route counts, per-peer resync phase counts) went stale. `cargo test --workspace` does not execute criterion bench bodies, which is why #1512's test-suite sweep missed it.

## Old vs new contract

The instrument's purpose is unchanged: `per_client_best_full_resync` measures the authoritative **private per-peer fallback** resync (per-client-best selection walk, exact encode, private commit, enqueue) at 4,096 routes across 8/64 clients. Post-flip that fallback is the residual production path for per-client-best peers with a non-unicast-only session (VPNv4/VPNv6/RTC negotiated), under the unchanged `per_client_best` reason.

- **Old fixture:** per-client-best peers on IPv4-unicast-only sessions — pre-flip these disqualified from grouping, so the private path ran.
- **New fixture:** `bench_register_per_client_best_route_server_peers` registers each peer with VPNv4 also negotiated (route-free), the same non-unicast-only shape the flip's own residual-fallback test pins. The peers stay legitimately ungrouped and every receipt assertion holds as written — no assertion changed.

The negotiated-but-empty VPNv4 family is inert on the measured path: the family-gauge mask derives from committed payload (stays `0x01`), the resync enumerates an empty VPN table into an empty key set with no extra phases, and no envelope carries VPN content — the bench times the identical private resync work it timed before the flip.

## Sibling sweep

Replicated CI's `bench/smoke-benches.sh` locally: all nine criterion targets pass (`rustbgpd-api/event_history_producer`, `rustbgpd/fib_projection`, `rustbgpd-policy/explain_snapshot`, `rustbgpd-policy/policy_eval`, `rustbgpd-rib/rib_ops`, `rustbgpd-rpki/validate`, `rustbgpd-transport/fanout`, `rustbgpd-transport/inbound_attrs`, `rustbgpd-wire/codec`); the four standalone harnesses are excluded by the script as in CI. The helper is the only per-client-best bench registration seam, and no other bench target pins pre-flip classification.

No CHANGELOG entry: bench fixture only, no production behavior change.
