### PR TITLE
Initialize the transaction cycle ledger before the first-cycle read

### DIFF
--- a/bench/scale/irrreload/txn-apply.sh
+++ b/bench/scale/irrreload/txn-apply.sh
@@ -137,6 +137,7 @@ candidate_bytes=$(wc -c <"$candidate") || die "cannot size candidate"
 [ "$candidate_bytes" -le "$max_raw" ] || die "candidate exceeds 384 MiB"
 if [ -z "${TXN_SMOKE:-}" ]; then
     [ "$candidate_bytes" -gt "$min_raw" ] || die "measured candidate is not above 10 MiB"
+    [ -e "$cycles" ] || : >"$cycles"
     cycle=$(( $(wc -l <"$cycles" 2>/dev/null || printf 0) + 1 ))
     if [ "$cycle" -lt 1 ] || [ "$cycle" -gt 4 ]; then
         die "unexpected measured cycle $cycle"


### PR DESCRIPTION
During a full-shape IRR transaction run the harness logged:

```
txn-apply.sh: line 140: .../transactions/cycles.jsonl: No such file or directory
```

The first measured cycle computes its cycle number from the line count of `transactions/cycles.jsonl`, which no cycle has created yet. The `|| printf 0` fallback kept the numbering correct, but redirections apply left to right: the failed `<"$cycles"` open is reported before `2>/dev/null` takes effect, so the diagnostic escaped to the run log on every first cycle.

Fix: create the ledger empty when absent, immediately before the read. Recorded ledger content and cycle numbering are unchanged — cycle 1 still reads an empty ledger and appends identical JSONL rows, and neither `verify-receipt.py` nor `txn-lifecycle.sh` distinguishes an absent ledger from an empty one (both only require four rows post-run).

Verified with an extracted reproducer of the exact expression (the non-smoke path needs a live daemon, so the expression was exercised standalone): before the fix the empty-dir case emits the spurious diagnostic with `cycle=1`; after, no diagnostic, still `cycle=1`; a 2-row ledger yields `cycle=3` and unchanged content in both shapes. `bash -n` and `shellcheck` both exit 0 on the script.