### PR TITLE
Batch the authoritative export-policy handoff into one shared RIB transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,27 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The authoritative per-peer export-policy handoff no longer costs one
+  full-table resync per member. When the optimized clean transition
+  declines a reload cohort — per-client-best groups always decline it
+  (ADR-0126 Decision 8) — the peer manager handed each member to the RIB
+  one command at a time, and each command drained as an O(table)
+  clone-walk, probe, and encode: a 320-member per-client-best SIGHUP
+  reload at the canonical IRR shape spent 99.8% of its 140–148 s
+  completing 320 serial full-table resyncs while the equivalent grouped
+  reload committed in ~3 s. The handoff is now ONE batched RIB command:
+  a source group whose batched members all move to one fresh chain-only
+  destination builds the destination table once, derives one
+  equality-suppressed old→new wire delta (O(actual policy diff), shared
+  `Arc` payload, encode-once fanout with per-member split-horizon
+  exclusion), and delivers each winner-source member its runner-up lane
+  substitution as a member-scoped supplement; every other batch shape
+  degrades member-by-member to the existing regroup baseline machinery,
+  drained by one trailing distribution pass instead of one pass per
+  member. Policy and membership state commit atomically within the one
+  actor call; a member whose emission cannot be prepared (closed or full
+  channel, encoder churn, exact-export rejection) is marked dirty and
+  healed by the ordinary resync from the committed state.
 - Non-unicast route listings no longer stall the RIB actor with a
   full-table copy the API then discards (LAN-905). `ListEvpnRoutes`,
   `ListBgpLsRoutes`, `ListVpnRoutes`, `ListLabeledRoutes`,

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -2950,6 +2950,553 @@ impl RibManager {
             Some(PendingCleanPolicyTransition::new(replacements, Some(reply)));
     }
 
+    pub(super) fn handle_replace_peer_export_policies_authoritatively(
+        &mut self,
+        replacements: Vec<PeerExportPolicyReplacement>,
+        reply: tokio::sync::oneshot::Sender<Result<(), RibCommandError>>,
+    ) {
+        let _ = reply.send(self.apply_export_policy_replacements_synchronously(replacements));
+    }
+
+    /// Apply a batch of authoritative export-policy replacements in one
+    /// actor call with ONE trailing distribution pass — the batched form
+    /// of [`Self::replace_peer_export_policy_synchronously`] the
+    /// clean-transition fallback hands whole cohorts to (per-client-best
+    /// groups always land here per ADR-0126 Decision 8).
+    ///
+    /// A source group whose batched movers all target one fresh
+    /// destination differing only in chain content takes the shared
+    /// transition ([`Self::apply_batched_group_transition`]): the
+    /// destination table is built once, the old→new wire delta is
+    /// derived once from the source group's shared view plus the
+    /// ADR-0126 Decision 4 per-member exceptions (split horizon via
+    /// `announce_source_exclusion`, lane substitutions as member-scoped
+    /// supplements), and the announce payload is encode-once shared
+    /// across the cohort. Everything else — partial-group moves,
+    /// already-owned destinations, ungrouped members, non-unicast
+    /// profiles, rs-tagged or OTC-bearing deltas — takes the ordinary
+    /// per-member regroup machinery (baseline snapshot + dirty resync),
+    /// drained together by the single trailing pass.
+    ///
+    /// State commits entirely within this call: after validation there
+    /// is no partial-state failure mode. Replacements naming peers no
+    /// longer registered are skipped (serial-loop parity); a member
+    /// whose emission cannot be prepared is marked dirty and healed by
+    /// the ordinary resync from the committed state.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the batch keeps validation, cohort selection, and the single \
+                  distribution pass in one auditable transaction body"
+    )]
+    pub(in crate::manager) fn apply_export_policy_replacements_synchronously(
+        &mut self,
+        replacements: Vec<PeerExportPolicyReplacement>,
+    ) -> Result<(), RibCommandError> {
+        if self.pending_clean_policy_transition.is_some() {
+            return Err(RibCommandError::internal(
+                "internal RIB sequencing error: policy transition already in progress",
+            ));
+        }
+        let started = std::time::Instant::now();
+        let n_replacements = replacements.len();
+        // Duplicate targets: the cohort math below assumes one
+        // replacement per peer. Apply duplicates in caller order through
+        // the single-peer seam instead — last-writer-wins, exactly the
+        // serial loop's shape (a departed peer is skipped identically).
+        let mut seen: HashSet<IpAddr> = HashSet::new();
+        if replacements
+            .iter()
+            .any(|replacement| !seen.insert(replacement.peer))
+        {
+            for replacement in replacements {
+                match self.replace_peer_export_policy_synchronously(
+                    replacement.peer,
+                    replacement.export_policy,
+                ) {
+                    Ok(()) | Err(RibCommandError::NotFound(_)) => {}
+                    Err(error) => return Err(error),
+                }
+            }
+            return Ok(());
+        }
+        // A still-running destination preparation cannot be trusted
+        // mid-walk (same guard as the cohort transition command).
+        if let Some(prestage) = self.pending_destination_prestage.take() {
+            self.discard_uncommitted_policy_transition_group(prestage.destination);
+        }
+
+        let mut present: Vec<PeerExportPolicyReplacement> = Vec::with_capacity(replacements.len());
+        let mut n_skipped_unregistered = 0_usize;
+        for replacement in replacements {
+            if self.outbound_peers.contains_key(&replacement.peer) {
+                present.push(replacement);
+            } else {
+                info!(
+                    peer = %replacement.peer,
+                    "authoritative export-policy batch skipped a peer no longer registered in the RIB; a reconnect will install the desired policy"
+                );
+                n_skipped_unregistered += 1;
+            }
+        }
+
+        // Previous memberships, captured before any mutation.
+        let previous: Vec<Option<usize>> = present
+            .iter()
+            .map(|replacement| self.grouped_member_of(replacement.peer))
+            .collect();
+        // Install the new chains (content-equal INSTANCE guard — see
+        // `replace_peer_export_policy_synchronously` for the ADR-0096
+        // term-hit rationale), then classify each member's destination.
+        for replacement in &present {
+            if self.peer_export_policies.get(&replacement.peer) != Some(&replacement.export_policy)
+            {
+                self.peer_export_policies
+                    .insert(replacement.peer, replacement.export_policy.clone());
+            }
+        }
+        let destinations: Vec<Option<usize>> = present
+            .iter()
+            .map(
+                |replacement| match self.compute_update_group_membership(replacement.peer) {
+                    super::update_groups::GroupMembership::Grouped(gid) => Some(gid),
+                    _ => None,
+                },
+            )
+            .collect();
+
+        // Candidate cohorts: batched movers of one source group whose
+        // destinations agree. A source group with mixed or ungrouped
+        // destinations degrades wholesale to the per-member machinery.
+        let mut cohorts: Vec<(usize, usize, Vec<IpAddr>)> = Vec::new();
+        let mut residual: Vec<IpAddr> = Vec::new();
+        {
+            let mut by_source: HashMap<usize, Option<(usize, Vec<IpAddr>)>> = HashMap::new();
+            for (index, replacement) in present.iter().enumerate() {
+                match (previous[index], destinations[index]) {
+                    (Some(source), Some(destination)) if source != destination => {
+                        match by_source
+                            .entry(source)
+                            .or_insert_with(|| Some((destination, Vec::new())))
+                        {
+                            Some((expected, members)) if *expected == destination => {
+                                members.push(replacement.peer);
+                            }
+                            entry => *entry = None,
+                        }
+                    }
+                    _ => residual.push(replacement.peer),
+                }
+            }
+            // Deterministic cohort order (source gid) so two source
+            // groups converging on one destination resolve stably: the
+            // first claims the fresh destination, the second degrades.
+            let mut sources: Vec<usize> = by_source.keys().copied().collect();
+            sources.sort_unstable();
+            for source in sources {
+                match by_source.remove(&source).flatten() {
+                    Some((destination, members)) => {
+                        cohorts.push((source, destination, members));
+                    }
+                    None => {
+                        // Mixed destinations under one source group: every
+                        // one of its batched movers takes the per-member
+                        // path.
+                        for (index, replacement) in present.iter().enumerate() {
+                            if previous[index] == Some(source)
+                                && destinations[index]
+                                    .is_some_and(|destination| Some(destination) != previous[index])
+                            {
+                                residual.push(replacement.peer);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut n_shared_members = 0_usize;
+        let mut n_destination_groups = 0_usize;
+        for (source, destination, members) in cohorts {
+            if self.apply_batched_group_transition(source, destination, &members) {
+                n_shared_members += members.len();
+                n_destination_groups += 1;
+            } else {
+                residual.extend(members);
+            }
+        }
+
+        // Per-member fallback: the ordinary regroup lifecycle (baseline
+        // snapshot + dirty), drained by the one pass below — the exact
+        // body of the single-peer seam, minus its per-call pass.
+        let n_fallback_members = residual.len();
+        for peer in residual {
+            let before = self.grouped_member_of(peer);
+            self.recompute_update_group(peer);
+            let key_stable = before.is_some() && before == self.grouped_member_of(peer);
+            if !key_stable {
+                self.mark_outbound_dirty(peer);
+            }
+        }
+
+        // Group tables and memberships moved above without a staging
+        // pass; advertised-query continuations must not survive that.
+        self.advance_advertised_pages();
+        // ONE distribution pass: drains every fallback/dirty member and
+        // owns the global retry opportunity, exactly like the single-peer
+        // seam's per-call pass.
+        self.distribute_changes(&HashSet::new(), &HashSet::new());
+        #[cfg(any(test, feature = "bench-internals"))]
+        {
+            self.policy_transition_stats.batched_authoritative_batches = self
+                .policy_transition_stats
+                .batched_authoritative_batches
+                .saturating_add(1);
+            self.policy_transition_stats
+                .batched_authoritative_shared_members = self
+                .policy_transition_stats
+                .batched_authoritative_shared_members
+                .saturating_add(n_shared_members);
+            self.policy_transition_stats
+                .batched_authoritative_fallback_members = self
+                .policy_transition_stats
+                .batched_authoritative_fallback_members
+                .saturating_add(n_fallback_members);
+        }
+        info!(
+            outcome = "batched_authoritative",
+            n_replacements,
+            n_destination_groups,
+            n_shared_members,
+            n_fallback_members,
+            n_skipped_unregistered,
+            elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "authoritative export-policy batch applied"
+        );
+        Ok(())
+    }
+
+    /// Commit one qualifying cohort through the shared batched
+    /// transition: build the destination table once, derive the shared
+    /// old→new delta plus ADR-0126 per-member exceptions once, move the
+    /// memberships, and enqueue the encode-once shared payload per
+    /// member. Returns `false` (nothing externally visible mutated
+    /// beyond an unowned staged destination the per-member fallback then
+    /// adopts) when the cohort does not qualify.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the cohort commit keeps its gates, membership moves, and \
+                  per-member emissions in one auditable body"
+    )]
+    fn apply_batched_group_transition(
+        &mut self,
+        source: usize,
+        destination: usize,
+        members: &[IpAddr],
+    ) -> bool {
+        // The shared delta covers unicast-only, chain-only moves — the
+        // same narrow shape as the clean transition, with the
+        // authoritative per-member path as the complete fallback for
+        // everything else.
+        if !self.batched_transition_keys_qualify(source, destination) {
+            return false;
+        }
+        // The destination must be memberless: an owned destination's
+        // members must see nothing, which is the regroup baseline diff's
+        // job, not this transition's.
+        if self
+            .group_ribs
+            .get(&destination)
+            .is_some_and(|group| !group.members.is_empty())
+        {
+            return false;
+        }
+        // Consume the completed-prestage record exactly like the clean
+        // transition's Classify phase: a match hands the staged table to
+        // this transition, a mismatch discards the never-adopted group.
+        if let Some(prepared) = self.prepared_destination.take()
+            && prepared != destination
+        {
+            self.discard_uncommitted_policy_transition_group(prepared);
+        }
+        let Some(&exemplar) = members.first() else {
+            return false;
+        };
+        // Build (or adopt) the destination table — the join-time build
+        // pass, run once for the whole cohort.
+        self.ensure_group_table(destination, exemplar);
+        let inventory = {
+            let (Some(source_group), Some(destination_group)) = (
+                self.group_ribs.get(&source),
+                self.group_ribs.get(&destination),
+            ) else {
+                return false;
+            };
+            // RFC 9234 OTC enforcement rides inside the inventory build:
+            // a blocked route in the emitted delta, or blocked-winner
+            // residue on either side, degrades the cohort to the
+            // per-member path, whose seams run the pre-commit backstop
+            // (ADR-0126 Decision 5). A role-bearing route-server fleet
+            // with no OTC-attributed routes — the rendered default —
+            // shares normally.
+            let mut rs_asns: Vec<u32> = members
+                .iter()
+                .filter_map(|member| self.peer_rs_control.get(member).copied())
+                .collect();
+            rs_asns.sort_unstable();
+            rs_asns.dedup();
+            let Some(inventory) =
+                Self::batched_transition_inventory(source_group, destination_group, &rs_asns)
+            else {
+                return false;
+            };
+            inventory
+        };
+
+        // Everything below commits: no fallible step touches shared
+        // state before this point.
+        let source_tombstones: Vec<(Prefix, u32)> = self
+            .group_ribs
+            .get(&source)
+            .map(|group| group.tombstones.iter().copied().collect())
+            .unwrap_or_default();
+        // A member whose wire lags its table (dirty, or carrying regroup
+        // residue) cannot take the shared delta — its resync owns the
+        // heal. It still moves with the cohort, carrying the source
+        // group's tombstones as extra (over-)withdraws (the regroup
+        // dirty-leaver rule).
+        let lagging: HashSet<IpAddr> = members
+            .iter()
+            .copied()
+            .filter(|member| {
+                self.dirty_peers.contains(member)
+                    || self.pending_regroup_baseline.contains_key(member)
+                    || self.pending_extra_withdraws.contains_key(member)
+            })
+            .collect();
+        for &peer in members {
+            if lagging.contains(&peer) && !source_tombstones.is_empty() {
+                let extras = self.pending_extra_withdraws.entry(peer).or_default();
+                extras.unicast.extend(source_tombstones.iter().copied());
+            }
+            self.commit_clean_policy_transition_member(peer, source, destination);
+            if lagging.contains(&peer) {
+                // Re-flag into the destination's dirty set (the leave
+                // above dropped the source-side flag).
+                self.mark_outbound_dirty(peer);
+            }
+        }
+
+        // The prefix scope of the per-member policy-denial restamp: every
+        // prefix whose verdict this transition may have moved.
+        let mut filtered_scope: HashSet<Prefix> =
+            self.loc_rib.iter().map(|route| route.prefix).collect();
+        if let Some(group) = self.group_ribs.get(&destination) {
+            filtered_scope.extend(group.table.iter().map(|route| route.prefix));
+        }
+        filtered_scope.extend(source_tombstones.iter().map(|(prefix, _)| *prefix));
+        filtered_scope.extend(inventory.withdraw.iter().map(|(prefix, _)| *prefix));
+
+        let shared_encode = (!inventory.announce.is_empty())
+            .then(|| Arc::new(crate::update::SharedGroupEncode::default()));
+        let mut probe_cache = SharedUnicastProbeCache::default();
+        for &peer in members {
+            if lagging.contains(&peer) {
+                continue;
+            }
+            if let Err(reason) = self.emit_batched_member_envelopes(
+                peer,
+                destination,
+                &inventory,
+                shared_encode.as_ref(),
+                &mut probe_cache,
+            ) {
+                debug!(
+                    %peer,
+                    reason,
+                    "batched authoritative transition member emission degraded to dirty resync"
+                );
+                self.mark_outbound_dirty(peer);
+                continue;
+            }
+            self.apply_batched_transition_counters(peer, &inventory);
+            let current: HashSet<PolicyFilteredRouteKey> = self
+                .group_ribs
+                .get(&destination)
+                .map(|group| {
+                    group
+                        .policy_filtered_for_member(peer, &filtered_scope)
+                        .collect()
+                })
+                .unwrap_or_default();
+            self.update_policy_filtered_routes_for_prefixes(peer, &filtered_scope, &current);
+            let advertised = self.grouped_advertised_count(peer).unwrap_or(0);
+            self.metrics
+                .set_adj_rib_out_prefixes(&peer.to_string(), "all", gauge_val(advertised));
+        }
+        self.finish_clean_policy_transition_commit();
+        info!(
+            source_group = source,
+            destination_group = destination,
+            members = members.len(),
+            announced = inventory.announce.len(),
+            withdrawn = inventory.withdraw.len(),
+            supplemented = inventory.supplements.len(),
+            "applied batched authoritative export-policy transition"
+        );
+        true
+    }
+
+    /// Prepare and enqueue one clean cohort member's wire delta: the
+    /// shared announce payload (split horizon via
+    /// `announce_source_exclusion`, encode-once via the shared cell)
+    /// plus, when needed, one member-scoped envelope carrying the shared
+    /// withdraws and the member's ADR-0126 lane corrections. Probes
+    /// everything against the member's exact-export snapshot before
+    /// reserving or sending anything; any failure leaves the member's
+    /// wire untouched for the dirty resync.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "probe, reserve, and send stay in one body so the \
+                  nothing-sent-on-failure ordering is auditable"
+    )]
+    fn emit_batched_member_envelopes(
+        &mut self,
+        peer: IpAddr,
+        destination: usize,
+        inventory: &super::update_groups::BatchedTransitionInventory,
+        shared_encode: Option<&Arc<crate::update::SharedGroupEncode>>,
+        probe_cache: &mut SharedUnicastProbeCache,
+    ) -> Result<(), &'static str> {
+        let Some(sender) = self.outbound_peers.get(&peer).cloned() else {
+            return Err("peer no longer registered");
+        };
+        if sender.is_closed() {
+            return Err("outbound channel closed");
+        }
+        let Some(encoder) = self.peer_export_encoders.get(&peer) else {
+            return Err("no exact-export encoder");
+        };
+        let snapshot = encoder.snapshot();
+        if snapshot.owner_id() != encoder.owner_id() {
+            return Err("exact-export encoder churned");
+        }
+        let supplement = inventory.supplements.get(&peer);
+        let supplement_announce = supplement.map_or(0, |entry| entry.announce.len());
+        let supplement_withdraw: Vec<(Prefix, u32)> = inventory
+            .withdraw
+            .iter()
+            .copied()
+            .chain(
+                supplement
+                    .into_iter()
+                    .flat_map(|entry| entry.withdraw.iter().copied()),
+            )
+            .collect();
+        // Probe the shared payload: the first member's full batch probe
+        // seeds the cohort cache; every compatible member afterwards
+        // proves only the largest encoded message against its own
+        // ceiling (the clean transition's reuse shape).
+        if !inventory.announce.is_empty() {
+            let reused = probe_cache.reuse_grouped_exact_export_maximum(
+                destination,
+                &inventory.announce,
+                &inventory.next_hop_override,
+                snapshot.as_ref(),
+            );
+            match reused {
+                Some(Ok(_)) => {}
+                Some(Err(_)) => return Err("shared payload exceeds the member's message ceiling"),
+                None => {
+                    let candidates: Vec<crate::update::ExactExportCandidate<'_>> = inventory
+                        .announce
+                        .iter()
+                        .zip(inventory.next_hop_override.iter())
+                        .map(
+                            |(route, next_hop)| crate::update::ExactExportCandidate::Unicast {
+                                route,
+                                next_hop_override: next_hop.as_ref(),
+                            },
+                        )
+                        .collect();
+                    let (results, cardinality_correct) =
+                        probe_exact_export_announcements(peer, snapshot.as_ref(), &candidates);
+                    if !cardinality_correct || results.iter().any(Result::is_err) {
+                        return Err("shared payload exact-export probe rejected");
+                    }
+                    let encoded_lengths = results
+                        .iter()
+                        .filter_map(|result| result.as_ref().ok().map(|result| result.encoded_len))
+                        .collect();
+                    probe_cache.store(
+                        destination,
+                        Arc::clone(&inventory.announce),
+                        Arc::clone(&inventory.next_hop_override),
+                        Arc::clone(&snapshot),
+                        encoded_lengths,
+                    );
+                }
+            }
+        }
+        // Probe the member-scoped lane substitutions.
+        if let Some(entry) = supplement {
+            for (route, next_hop) in &entry.announce {
+                if snapshot
+                    .probe_announcement(crate::update::ExactExportCandidate::Unicast {
+                        route,
+                        next_hop_override: next_hop.as_ref(),
+                    })
+                    .is_err()
+                {
+                    return Err("lane supplement exact-export probe rejected");
+                }
+            }
+        }
+        // Reserve every needed permit before sending anything, so a full
+        // channel degrades the member cleanly instead of half-emitting.
+        let shared_permit = if inventory.announce.is_empty() {
+            None
+        } else {
+            match sender.clone().try_reserve_owned() {
+                Ok(permit) => Some(permit),
+                Err(_) => return Err("outbound channel full"),
+            }
+        };
+        let supplement_permit = if supplement_announce == 0 && supplement_withdraw.is_empty() {
+            None
+        } else {
+            match sender.clone().try_reserve_owned() {
+                Ok(permit) => Some(permit),
+                Err(_) => return Err("outbound channel full"),
+            }
+        };
+        if let Some(permit) = shared_permit {
+            permit.send(OutboundRouteUpdate {
+                exact_export_snapshot: Some(Arc::clone(&snapshot)),
+                announce_source_exclusion: Some(peer),
+                announce: Arc::clone(&inventory.announce),
+                next_hop_override: Arc::clone(&inventory.next_hop_override),
+                shared_group_encode: shared_encode.map(Arc::clone),
+                ..OutboundRouteUpdate::default()
+            });
+        }
+        if let Some(permit) = supplement_permit {
+            let (announce, next_hop_override): (
+                Vec<crate::route::Route>,
+                Vec<Option<rustbgpd_policy::NextHopAction>>,
+            ) = supplement
+                .map(|entry| entry.announce.iter().cloned().unzip())
+                .unwrap_or_default();
+            permit.send(OutboundRouteUpdate {
+                exact_export_snapshot: Some(snapshot),
+                announce: announce.into(),
+                next_hop_override: next_hop_override.into(),
+                withdraw: supplement_withdraw,
+                ..OutboundRouteUpdate::default()
+            });
+        }
+        Ok(())
+    }
+
     /// Begin the unfenced staging of a prospective clean-transition
     /// destination group ([`crate::update::RibUpdate::PrepareExportPolicyDestination`]).
     /// The reply is held until [`Self::advance_destination_prestage`]

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -62,6 +62,13 @@ struct PolicyTransitionStats {
     max_prefix_snapshot_poll: std::time::Duration,
     max_finalize_poll: std::time::Duration,
     max_commit_poll: std::time::Duration,
+    /// Batched authoritative applies
+    /// (`RibUpdate::ReplacePeerExportPoliciesAuthoritatively`) and how
+    /// their members split between the shared cohort transition and the
+    /// per-member fallback — the one-pass receipt for tests.
+    batched_authoritative_batches: usize,
+    batched_authoritative_shared_members: usize,
+    batched_authoritative_fallback_members: usize,
     #[cfg(feature = "bench-internals")]
     authoritative_peer_applies: usize,
     #[cfg(feature = "bench-internals")]
@@ -1442,6 +1449,7 @@ impl RibManager {
             // so advancing here at acceptance covers the whole transaction.
             RibUpdate::ReplacePeerExportPolicy { .. }
             | RibUpdate::ReplacePeerExportPolicies { .. }
+            | RibUpdate::ReplacePeerExportPoliciesAuthoritatively { .. }
             | RibUpdate::ApplyOutboundPrefixLimits { .. }
             | RibUpdate::RefreshPeerOutbound { .. } => self.advance_advertised_pages(),
             RibUpdate::PeerUp { .. }
@@ -2241,6 +2249,10 @@ impl RibManager {
                 replacements,
                 reply,
             } => self.handle_replace_peer_export_policies(replacements, reply),
+            RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
+                replacements,
+                reply,
+            } => self.handle_replace_peer_export_policies_authoritatively(replacements, reply),
             RibUpdate::PrepareExportPolicyDestination {
                 peer,
                 export_policy,

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -6169,3 +6169,471 @@ async fn converged_per_client_best_fleet_regroups_byte_empty() {
     drop(tx);
     handle.await.unwrap();
 }
+
+// --- batched authoritative export-policy apply
+// (`RibUpdate::ReplacePeerExportPoliciesAuthoritatively`) ---
+
+/// Register one per-client-best route-server member directly on the
+/// manager, with an exact-export encoder (the batched shared payload is
+/// probe-gated like the clean transition's).
+fn register_direct_pcb_peer(
+    manager: &mut RibManager,
+    peer: IpAddr,
+    export_policy: Option<PolicyChain>,
+    encoder: Arc<dyn crate::update::ExactExportEncoder>,
+) -> mpsc::Receiver<OutboundRouteUpdate> {
+    manager.handle_update(RibUpdate::SetPeerExportEncoder {
+        peer,
+        session_id: 0,
+        encoder,
+    });
+    // The rendered route-server default carries an RFC 9234 role on
+    // every member; the batched transition must share regardless (a
+    // RouteServer-role fleet with no OTC-attributed routes never blocks).
+    manager.handle_update(RibUpdate::SetPeerExportContext {
+        peer,
+        session_id: 0,
+        local_role: Some(rustbgpd_wire::BgpRole::RouteServer),
+    });
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(32);
+    manager.handle_update(RibUpdate::PeerUp {
+        peer,
+        session_id: 0,
+        peer_asn: 65_100,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx,
+        export_policy,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        per_client_best: true,
+        interpret_rfc1997: true,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    });
+    // Drain the initial dump (route replay for a late joiner) up to and
+    // including its End-of-RIB marker.
+    let mut saw_eor = false;
+    while let Ok(update) = outbound_rx.try_recv() {
+        if update.end_of_rib == ipv4_sendable() {
+            saw_eor = true;
+            break;
+        }
+    }
+    assert!(saw_eor, "initial dump must deliver the IPv4-unicast EoR");
+    outbound_rx
+}
+
+struct BatchedPcbFleet {
+    manager: RibManager,
+    members: Vec<IpAddr>,
+    receivers: Vec<mpsc::Receiver<OutboundRouteUpdate>>,
+    shared_prefix: Ipv4Prefix,
+    probes: Arc<AtomicUsize>,
+    reuses: Arc<AtomicUsize>,
+}
+
+/// Four grouped per-client-best members, each announcing an own /24;
+/// members 0 and 1 both announce `shared_prefix`, so the group's
+/// exception lane holds one runner-up. Setup envelopes are drained.
+fn batched_pcb_fleet(export_policy: Option<&PolicyChain>) -> BatchedPcbFleet {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let probes = Arc::new(AtomicUsize::new(0));
+    let reuses = Arc::new(AtomicUsize::new(0));
+    let members: Vec<IpAddr> = (1..=4)
+        .map(|host| IpAddr::V4(Ipv4Addr::new(10, 40, 0, host)))
+        .collect();
+    let mut receivers = Vec::new();
+    for (index, &peer) in members.iter().enumerate() {
+        receivers.push(register_direct_pcb_peer(
+            &mut manager,
+            peer,
+            export_policy.cloned(),
+            Arc::new(CohortExactEncoder {
+                owner: u64::try_from(index + 1).unwrap(),
+                profile: 23,
+                max_len: 4_096,
+                generation: AtomicUsize::new(0),
+                advance_generation: false,
+                probes: Arc::clone(&probes),
+                reuses: Arc::clone(&reuses),
+            }),
+        ));
+    }
+    for (index, &peer) in members.iter().enumerate() {
+        let IpAddr::V4(source) = peer else {
+            unreachable!()
+        };
+        let index = u8::try_from(index).unwrap();
+        distribute_direct_route(
+            &mut manager,
+            source,
+            Ipv4Prefix::new(Ipv4Addr::new(203, 0, 110 + index, 0), 24),
+        );
+    }
+    let shared_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 199, 0), 24);
+    for &peer in &members[..2] {
+        let IpAddr::V4(source) = peer else {
+            unreachable!()
+        };
+        distribute_direct_route(&mut manager, source, shared_prefix);
+    }
+    for receiver in &mut receivers {
+        while receiver.try_recv().is_ok() {}
+    }
+    BatchedPcbFleet {
+        manager,
+        members,
+        receivers,
+        shared_prefix,
+        probes,
+        reuses,
+    }
+}
+
+fn batch_replacements(
+    members: &[IpAddr],
+    export_policy: &PolicyChain,
+) -> Vec<crate::update::PeerExportPolicyReplacement> {
+    members
+        .iter()
+        .map(|&peer| crate::update::PeerExportPolicyReplacement {
+            peer,
+            export_policy: Some(export_policy.clone()),
+        })
+        .collect()
+}
+
+/// The canonical batched cohort: every member of one per-client-best
+/// group moves to a fresh chain in ONE command with ZERO per-member
+/// resync passes — the shared payload is one `Arc` and one encode cell
+/// across the cohort, split horizon rides `announce_source_exclusion`,
+/// and the winner's source receives its lane substitution as a
+/// member-scoped supplement.
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one scenario pins topology, payload sharing, supplements, counters, and pass count together"
+)]
+fn batched_authoritative_pcb_cohort_commits_in_one_shared_transition() {
+    let old_policy = community_chain(0xFDE8_0001);
+    let next_policy = community_chain(0xFDE8_0002);
+    let mut fleet = batched_pcb_fleet(Some(&old_policy));
+    let source_gid = fleet.manager.grouped_member_of(fleet.members[0]).unwrap();
+    let permitted_before: Vec<u64> = fleet
+        .members
+        .iter()
+        .map(|peer| {
+            fleet
+                .manager
+                .export_policy_stats
+                .get(peer)
+                .map_or(0, |stats| stats.export_policy_routes_permitted)
+        })
+        .collect();
+    let passes_before = fleet.manager.adj_rib_out_commit_stats.metrics_handle_clones;
+    let probes_before = fleet.probes.load(Ordering::Relaxed);
+    let reuses_before = fleet.reuses.load(Ordering::Relaxed);
+
+    let (reply, mut response) = oneshot::channel();
+    fleet
+        .manager
+        .handle_update(RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
+            replacements: batch_replacements(&fleet.members, &next_policy),
+            reply,
+        });
+    assert_eq!(response.try_recv().unwrap(), Ok(()));
+
+    // One batch, every member on the shared transition, no fallback —
+    // and ZERO distribution passes: the wire delta was derived and
+    // enqueued inside the batch, so nothing was left dirty to resync.
+    let stats = fleet.manager.policy_transition_stats;
+    assert_eq!(stats.batched_authoritative_batches, 1);
+    assert_eq!(stats.batched_authoritative_shared_members, 4);
+    assert_eq!(stats.batched_authoritative_fallback_members, 0);
+    assert_eq!(
+        fleet.manager.adj_rib_out_commit_stats.metrics_handle_clones, passes_before,
+        "the batched transition must not fall back to per-member resync passes"
+    );
+
+    // Final topology: one destination group holding all four members,
+    // per-client-best, with the shared prefix's lane intact.
+    let destination_gid = fleet.manager.grouped_member_of(fleet.members[0]).unwrap();
+    assert_ne!(source_gid, destination_gid);
+    assert_eq!(
+        fleet.manager.group_ribs.len(),
+        1,
+        "source group must be dropped"
+    );
+    let group = &fleet.manager.group_ribs[&destination_gid];
+    assert!(group.per_client_best);
+    assert_eq!(group.members.len(), 4);
+    assert_eq!(group.table.len(), 5);
+    let winner = group
+        .table
+        .get(&Prefix::V4(fleet.shared_prefix), 0)
+        .unwrap()
+        .peer;
+    assert_eq!(group.lane_counts.get(&winner), Some(&[1, 0]));
+    for peer in &fleet.members {
+        assert_eq!(
+            fleet.manager.grouped_member_of(*peer),
+            Some(destination_gid)
+        );
+        assert!(!fleet.manager.dirty_peers.contains(peer));
+    }
+
+    // Wire shape: one shared envelope per member — the SAME announce Arc
+    // and encode cell, split horizon via the exclusion — plus exactly
+    // one lane supplement toward the winner's source.
+    let mut shared_announces = Vec::new();
+    let mut shared_cells = Vec::new();
+    for (index, receiver) in fleet.receivers.iter_mut().enumerate() {
+        let member = fleet.members[index];
+        let shared = receiver.try_recv().unwrap();
+        assert_eq!(shared.announce_source_exclusion, Some(member));
+        assert_eq!(
+            shared.announce.len(),
+            5,
+            "marker-style change re-announces every slot"
+        );
+        assert!(shared.withdraw.is_empty());
+        assert!(
+            shared
+                .announce
+                .iter()
+                .all(|route| route.attributes.iter().any(|attribute| {
+                    matches!(attribute, PathAttribute::Communities(values) if values.contains(&0xFDE8_0002))
+                })),
+            "shared payload must carry the destination chain's output"
+        );
+        shared_cells.push(shared.shared_group_encode.clone().unwrap());
+        shared_announces.push(shared.announce.clone());
+        if member == winner {
+            let supplement = receiver.try_recv().unwrap();
+            assert_eq!(supplement.announce_source_exclusion, None);
+            assert_eq!(supplement.announce.len(), 1);
+            assert_eq!(
+                supplement.announce[0].prefix,
+                Prefix::V4(fleet.shared_prefix)
+            );
+            assert_ne!(
+                supplement.announce[0].peer, winner,
+                "the lane substitutes the runner-up"
+            );
+            assert!(supplement.withdraw.is_empty());
+        }
+        assert!(
+            receiver.try_recv().is_err(),
+            "no further envelopes: the batch emits at most shared + supplement"
+        );
+    }
+    assert!(
+        shared_announces
+            .iter()
+            .all(|announce| Arc::ptr_eq(announce, &shared_announces[0])),
+        "one announce payload shared across the cohort"
+    );
+    assert!(
+        shared_cells
+            .iter()
+            .all(|cell| Arc::ptr_eq(cell, &shared_cells[0])),
+        "one encode cell shared across the cohort"
+    );
+
+    // Exact-export cost shape: ONE full probe of the shared payload (5
+    // candidates) plus the winner's one-route supplement probe; every
+    // other member proves only the reused maximum.
+    assert_eq!(fleet.probes.load(Ordering::Relaxed) - probes_before, 6);
+    assert_eq!(fleet.reuses.load(Ordering::Relaxed) - reuses_before, 3);
+
+    // Counter replay parity with the join-time fold: every member's
+    // adv(m) is 4 slots (3 other own-prefixes + the shared slot — the
+    // winner substituting its lane entry), replayed as permits.
+    for (index, peer) in fleet.members.iter().enumerate() {
+        let permitted = fleet
+            .manager
+            .export_policy_stats
+            .get(peer)
+            .map_or(0, |stats| stats.export_policy_routes_permitted);
+        assert_eq!(
+            permitted - permitted_before[index],
+            4,
+            "member {peer} replays totals − own + lane"
+        );
+    }
+}
+
+/// The batched wire delta is O(actual policy diff), not O(table): a
+/// chain change touching one prefix announces exactly that slot (and
+/// its lane substitution toward the winner's source) — every unchanged
+/// slot is equality-suppressed out of the shared payload.
+#[test]
+fn batched_authoritative_apply_announces_only_changed_slots() {
+    let mut fleet = batched_pcb_fleet(None);
+    let shared_prefix = fleet.shared_prefix;
+    let mut statement = deny_statement(shared_prefix);
+    statement.action = PolicyAction::Permit;
+    statement.modifications.communities_add.push(0xFDE8_0002);
+    let next_policy = PolicyChain::new(vec![Policy {
+        entries: vec![statement],
+        default_action: PolicyAction::Permit,
+    }]);
+    let passes_before = fleet.manager.adj_rib_out_commit_stats.metrics_handle_clones;
+
+    let (reply, mut response) = oneshot::channel();
+    fleet
+        .manager
+        .handle_update(RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
+            replacements: batch_replacements(&fleet.members, &next_policy),
+            reply,
+        });
+    assert_eq!(response.try_recv().unwrap(), Ok(()));
+
+    let stats = fleet.manager.policy_transition_stats;
+    assert_eq!(stats.batched_authoritative_shared_members, 4);
+    assert_eq!(stats.batched_authoritative_fallback_members, 0);
+    assert_eq!(
+        fleet.manager.adj_rib_out_commit_stats.metrics_handle_clones,
+        passes_before
+    );
+
+    let destination_gid = fleet.manager.grouped_member_of(fleet.members[0]).unwrap();
+    let winner = fleet.manager.group_ribs[&destination_gid]
+        .table
+        .get(&Prefix::V4(shared_prefix), 0)
+        .unwrap()
+        .peer;
+    for (index, receiver) in fleet.receivers.iter_mut().enumerate() {
+        let member = fleet.members[index];
+        let shared = receiver.try_recv().unwrap();
+        assert_eq!(
+            shared.announce.len(),
+            1,
+            "only the changed slot is announced — O(changed), not O(table)"
+        );
+        assert_eq!(shared.announce[0].prefix, Prefix::V4(shared_prefix));
+        assert_eq!(shared.announce_source_exclusion, Some(member));
+        assert!(shared.withdraw.is_empty());
+        if member == winner {
+            let supplement = receiver.try_recv().unwrap();
+            assert_eq!(supplement.announce.len(), 1);
+            assert_eq!(supplement.announce[0].prefix, Prefix::V4(shared_prefix));
+        }
+        assert!(receiver.try_recv().is_err());
+    }
+}
+
+/// Failure injection: an unregistered peer in the batch is skipped
+/// (serial-loop parity), and a member whose outbound channel is gone
+/// still commits its policy and membership — delivery degrades to the
+/// established dead-channel handling, never a partial-state error.
+#[test]
+fn batched_authoritative_apply_skips_unregistered_and_degrades_dead_channels() {
+    let old_policy = community_chain(0xFDE8_0001);
+    let next_policy = community_chain(0xFDE8_0002);
+    let mut fleet = batched_pcb_fleet(Some(&old_policy));
+    // Kill the last member's outbound channel before the batch.
+    let dead = fleet.members[3];
+    drop(fleet.receivers.pop().unwrap());
+    let unregistered = IpAddr::V4(Ipv4Addr::new(10, 40, 9, 9));
+    let mut replacements = batch_replacements(&fleet.members, &next_policy);
+    replacements.push(crate::update::PeerExportPolicyReplacement {
+        peer: unregistered,
+        export_policy: Some(next_policy.clone()),
+    });
+
+    let (reply, mut response) = oneshot::channel();
+    fleet
+        .manager
+        .handle_update(RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
+            replacements,
+            reply,
+        });
+    assert_eq!(response.try_recv().unwrap(), Ok(()));
+
+    let stats = fleet.manager.policy_transition_stats;
+    assert_eq!(stats.batched_authoritative_batches, 1);
+    assert_eq!(stats.batched_authoritative_shared_members, 4);
+    assert!(
+        !fleet
+            .manager
+            .update_groups
+            .members
+            .contains_key(&unregistered)
+    );
+    // The dead-channel member's state committed with the cohort; its
+    // emission was dropped through the established gone-channel path
+    // (no dirty retry against a channel that can never accept).
+    let destination_gid = fleet.manager.grouped_member_of(fleet.members[0]).unwrap();
+    assert_eq!(fleet.manager.grouped_member_of(dead), Some(destination_gid));
+    assert!(!fleet.manager.dirty_peers.contains(&dead));
+    for receiver in &mut fleet.receivers {
+        let shared = receiver.try_recv().unwrap();
+        assert_eq!(shared.announce.len(), 5);
+    }
+}
+
+/// An already-owned destination group disqualifies the shared cohort:
+/// the batch degrades to the ordinary per-member regroup machinery
+/// (baseline snapshot + dirty resync) — drained by ONE trailing
+/// distribution pass, not one pass per member.
+#[test]
+fn batched_authoritative_apply_degrades_to_one_pass_when_destination_is_owned() {
+    let old_policy = community_chain(0xFDE8_0001);
+    let next_policy = community_chain(0xFDE8_0002);
+    let mut fleet = batched_pcb_fleet(Some(&old_policy));
+    // A fifth member already runs the destination chain, so the
+    // destination group exists and is owned.
+    let incumbent = IpAddr::V4(Ipv4Addr::new(10, 40, 0, 9));
+    let probes = Arc::new(AtomicUsize::new(0));
+    let reuses = Arc::new(AtomicUsize::new(0));
+    let mut incumbent_rx = register_direct_pcb_peer(
+        &mut fleet.manager,
+        incumbent,
+        Some(next_policy.clone()),
+        Arc::new(CohortExactEncoder {
+            owner: 9,
+            profile: 23,
+            max_len: 4_096,
+            generation: AtomicUsize::new(0),
+            advance_generation: false,
+            probes,
+            reuses,
+        }),
+    );
+    while incumbent_rx.try_recv().is_ok() {}
+    let destination_gid = fleet.manager.grouped_member_of(incumbent).unwrap();
+    let passes_before = fleet.manager.adj_rib_out_commit_stats.metrics_handle_clones;
+
+    let (reply, mut response) = oneshot::channel();
+    fleet
+        .manager
+        .handle_update(RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
+            replacements: batch_replacements(&fleet.members, &next_policy),
+            reply,
+        });
+    assert_eq!(response.try_recv().unwrap(), Ok(()));
+
+    let stats = fleet.manager.policy_transition_stats;
+    assert_eq!(stats.batched_authoritative_batches, 1);
+    assert_eq!(stats.batched_authoritative_shared_members, 0);
+    assert_eq!(stats.batched_authoritative_fallback_members, 4);
+    assert_eq!(
+        fleet.manager.adj_rib_out_commit_stats.metrics_handle_clones,
+        passes_before + 1,
+        "the per-member fallback drains through exactly ONE distribution pass"
+    );
+    for peer in &fleet.members {
+        assert_eq!(
+            fleet.manager.grouped_member_of(*peer),
+            Some(destination_gid)
+        );
+        assert!(!fleet.manager.dirty_peers.contains(peer));
+    }
+    assert_eq!(fleet.manager.group_ribs[&destination_gid].members.len(), 5);
+}

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -785,6 +785,133 @@ impl GroupStageOutput {
     }
 }
 
+/// Shared old→new wire delta of one batched authoritative cohort
+/// transition ([`RibManager::batched_transition_inventory`]): the
+/// equality-suppressed announce/withdraw payload every member shares
+/// (split horizon via `announce_source_exclusion`), the member-scoped
+/// lane/source-flip corrections, and the pre-aggregated counter rows.
+pub(in crate::manager) struct BatchedTransitionInventory {
+    /// Destination entries whose wire form differs from the source
+    /// entry at the same key — `Arc`-shared across every member
+    /// envelope (one `Route` shell clone per changed entry, total).
+    pub(in crate::manager) announce: Arc<[Route]>,
+    /// Next-hop-override flags aligned with `announce`.
+    pub(in crate::manager) next_hop_override: Arc<[Option<NextHopAction>]>,
+    /// Keys the destination no longer stages (over-withdraw safe).
+    pub(in crate::manager) withdraw: Vec<(Prefix, u32)>,
+    /// Member-scoped corrections the shared exclusion cannot express:
+    /// the ADR-0126 lane substitution toward each winner's source
+    /// (announce) and the displaced/retired own-sourced slot (withdraw).
+    pub(in crate::manager) supplements: FxHashMap<IpAddr, BatchedMemberSupplement>,
+    counters: BatchedTransitionCounters,
+}
+
+/// One member's corrections beside the shared batched-transition payload.
+#[derive(Default)]
+pub(in crate::manager) struct BatchedMemberSupplement {
+    pub(in crate::manager) announce: Vec<(Route, Option<NextHopAction>)>,
+    pub(in crate::manager) withdraw: Vec<(Prefix, u32)>,
+}
+
+/// Pre-aggregated export-counter rows of one batched cohort transition:
+/// permit totals per label with per-source breakdown, the lane's
+/// per-winner-source substitution labels, and the denial residue rows —
+/// the inputs of the ADR-0126 Decision 4 `totals − own + lane`
+/// synthesis, folded once per cohort so the per-member replay is
+/// O(labels) instead of the O(table) walk
+/// [`RibManager::apply_group_join_counters`] performs.
+#[derive(Default)]
+struct BatchedTransitionCounters {
+    permit_totals: FxHashMap<Option<PolicyLabel>, u64>,
+    permit_by_source: FxHashMap<IpAddr, FxHashMap<Option<PolicyLabel>, u64>>,
+    lane_by_winner_source: FxHashMap<IpAddr, FxHashMap<Option<PolicyLabel>, u64>>,
+    deny_totals: FxHashMap<Option<PolicyLabel>, u64>,
+    deny_by_source: FxHashMap<IpAddr, FxHashMap<Option<PolicyLabel>, u64>>,
+}
+
+impl BatchedTransitionCounters {
+    fn record_permit(&mut self, source: IpAddr, label: Option<PolicyLabel>) {
+        *self
+            .permit_by_source
+            .entry(source)
+            .or_default()
+            .entry(label.clone())
+            .or_default() += 1;
+        *self.permit_totals.entry(label).or_default() += 1;
+    }
+
+    fn record_lane(&mut self, winner_source: IpAddr, label: Option<PolicyLabel>) {
+        *self
+            .lane_by_winner_source
+            .entry(winner_source)
+            .or_default()
+            .entry(label)
+            .or_default() += 1;
+    }
+
+    fn record_deny(&mut self, source: IpAddr, label: Option<PolicyLabel>) {
+        *self
+            .deny_by_source
+            .entry(source)
+            .or_default()
+            .entry(label.clone())
+            .or_default() += 1;
+        *self.deny_totals.entry(label).or_default() += 1;
+    }
+
+    /// One member's replay rows: `totals − own-sourced (+ lane
+    /// substitutions)` per label, permits and denials alike — the fold
+    /// [`RibManager::apply_group_join_counters`] derives per member from
+    /// a full table walk.
+    fn rows_for(&self, peer: IpAddr) -> Vec<(Option<String>, PolicyAction, u64)> {
+        let mut rows = Vec::new();
+        let own_permits = self.permit_by_source.get(&peer);
+        let lane = self.lane_by_winner_source.get(&peer);
+        let mut labels: Vec<&Option<PolicyLabel>> = self.permit_totals.keys().collect();
+        if let Some(lane) = lane {
+            labels.extend(
+                lane.keys()
+                    .filter(|label| !self.permit_totals.contains_key(*label)),
+            );
+        }
+        for label in labels {
+            let total = self.permit_totals.get(label).copied().unwrap_or(0);
+            let own = own_permits
+                .and_then(|counts| counts.get(label))
+                .copied()
+                .unwrap_or(0);
+            let substituted = lane
+                .and_then(|counts| counts.get(label))
+                .copied()
+                .unwrap_or(0);
+            let count = total.saturating_sub(own) + substituted;
+            if count > 0 {
+                rows.push((
+                    label.as_ref().map(ToString::to_string),
+                    PolicyAction::Permit,
+                    count,
+                ));
+            }
+        }
+        let own_denies = self.deny_by_source.get(&peer);
+        for (label, total) in &self.deny_totals {
+            let own = own_denies
+                .and_then(|counts| counts.get(label))
+                .copied()
+                .unwrap_or(0);
+            let count = total.saturating_sub(own);
+            if count > 0 {
+                rows.push((
+                    label.as_ref().map(ToString::to_string),
+                    PolicyAction::Deny,
+                    count,
+                ));
+            }
+        }
+        rows
+    }
+}
+
 /// Export-policy verdicts of one shared staging pass, aggregated by
 /// (terminal policy, action) with a per-source-peer breakdown so each
 /// member can be bumped by `totals − own-sourced` — exactly what the
@@ -3730,6 +3857,15 @@ impl RibManager {
         // without ever emitting them (LAN-463). The discard makes the
         // group absent again, so the ordinary rebuild below runs.
         self.discard_destination_prestage_on_membership(gid);
+        self.ensure_group_table(gid, peer);
+        self.install_group_member(gid, peer);
+    }
+
+    /// Build the group's staged table when it does not exist yet — the
+    /// join-time build pass (one shared staging walk, deltas discarded:
+    /// correct only while the group is memberless). `peer` is the
+    /// exemplar whose group-uniform staging inputs seed the profile.
+    pub(in crate::manager) fn ensure_group_table(&mut self, gid: usize, peer: IpAddr) {
         if !self.group_ribs.contains_key(&gid) {
             let group = GroupRibOut::new(
                 // `share()`, not `clone()`: the snapshot must keep
@@ -3773,7 +3909,6 @@ impl RibManager {
                 }
             }
         }
-        self.install_group_member(gid, peer);
     }
 
     /// Install one peer into an already-created group and make the peer's
@@ -3874,9 +4009,32 @@ impl RibManager {
         self.distribute_changes_after_advertised_page_advance(&HashSet::new(), &HashSet::new());
     }
 
+    /// Whether a source/destination group pair qualifies for the shared
+    /// batched authoritative transition: unicast-only on both sides and
+    /// differing only in export-chain content (the clean transition's
+    /// narrow shape, checked on the interned keys).
+    pub(in crate::manager) fn batched_transition_keys_qualify(
+        &self,
+        source: usize,
+        destination: usize,
+    ) -> bool {
+        let (Some(source_key), Some(destination_key)) = (
+            self.update_groups.group_key(source),
+            self.update_groups.group_key(destination),
+        ) else {
+            return false;
+        };
+        source_key.is_unicast_only()
+            && destination_key.is_unicast_only()
+            && source_key.same_staging_profile_except_chain(destination_key)
+    }
+
     /// The fingerprint itself: disqualifiers first (design §1), then
     /// the group key from RIB-staging inputs.
-    fn compute_update_group_membership(&mut self, peer: IpAddr) -> GroupMembership {
+    pub(in crate::manager) fn compute_update_group_membership(
+        &mut self,
+        peer: IpAddr,
+    ) -> GroupMembership {
         let chain = self.export_policy_for(peer).cloned();
         self.compute_update_group_membership_for_policy(peer, chain.as_ref())
     }
@@ -4086,6 +4244,186 @@ impl RibManager {
     pub(in crate::manager) fn finish_clean_policy_transition_commit(&mut self) {
         self.refresh_update_group_gauges();
         self.refresh_group_residue_gauge();
+    }
+
+    /// Build the shared old→new inventory for one batched authoritative
+    /// cohort transition ([`crate::update::RibUpdate::ReplacePeerExportPoliciesAuthoritatively`]):
+    /// every batch member of `source` moves to the freshly staged
+    /// `destination` (same staging profile except the chain — validated
+    /// by the caller). Returns `None` when the delta carries an RFC 7947
+    /// control-form community for one of the cohort's rs-control ASNs on
+    /// either side of policy — per-target suppress/prepend/scrub cannot
+    /// ride a shared payload, so the caller degrades the cohort to the
+    /// ordinary per-member machinery (the clean transition's
+    /// tagged-inventory posture).
+    ///
+    /// The shared announce carries each destination entry whose wire
+    /// form differs from the source entry at the same key
+    /// (equality-suppressed — O(actual policy diff), a content-equal
+    /// restage emits nothing); the shared withdraw carries the keys the
+    /// destination no longer stages (over-withdraw safe toward members
+    /// whose wire never held them). Per-member divergence is exactly the
+    /// ADR-0126 Decision 4 emit-time exception set: split horizon rides
+    /// the envelope's `announce_source_exclusion`, and the lane
+    /// substitution toward each winner's source rides the member-scoped
+    /// supplements built here. Counter aggregates are folded once so the
+    /// per-member replay is O(labels), not O(table) — the same rows
+    /// [`RibManager::apply_group_join_counters`] would derive per member.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one walk keeps the shared delta, the lane supplements, the \
+                  OTC/rs-control degrade gates, and the counter fold aligned"
+    )]
+    pub(in crate::manager) fn batched_transition_inventory(
+        source: &GroupRibOut,
+        destination: &GroupRibOut,
+        rs_asns: &[u32],
+    ) -> Option<BatchedTransitionInventory> {
+        use super::distribution::rs_control::rs_control_route_tagged;
+        // RFC 9234 OTC residue on either side means blocked staged
+        // winners (or lane runner-ups) whose per-member diagnostics and
+        // withdraw conversions belong to the pre-commit backstop this
+        // shared emission does not run — the per-member path owns those.
+        // A role-bearing fleet with no OTC-attributed routes (the
+        // rendered route-server default) carries no residue and shares.
+        if !source.otc_blocked.is_empty() || !destination.otc_blocked.is_empty() {
+            return None;
+        }
+        let attrs_tagged = |attrs: (&[u32], &[LargeCommunity])| {
+            rs_asns
+                .iter()
+                .any(|&rs_asn| rs_control_route_tagged(attrs.0, attrs.1, rs_asn))
+        };
+        let route_tagged = |route: &Route| {
+            rs_asns.iter().any(|&rs_asn| {
+                rs_control_route_tagged(route.communities(), route.large_communities(), rs_asn)
+            })
+        };
+        // The pre-commit backstop strips an OTC-blocked route from every
+        // emission; an emitted delta containing one cannot ride the
+        // shared payload, so its cohort degrades to the per-member path
+        // (which runs the backstop at its own seams).
+        let blocked =
+            |route: &Route| super::distribution::otc_egress_blocked(route, destination.local_role);
+        let mut announce: Vec<Route> = Vec::new();
+        let mut next_hop_override: Vec<Option<NextHopAction>> = Vec::new();
+        let mut supplements: FxHashMap<IpAddr, BatchedMemberSupplement> = FxHashMap::default();
+        let mut counters = BatchedTransitionCounters::default();
+        for route in destination.table.iter() {
+            let key = (route.prefix, route.path_id);
+            let next_hop = destination.nh_override(key);
+            let prior = source.table.get(&route.prefix, route.path_id);
+            let changed = match prior {
+                None => true,
+                Some(prior_route) => {
+                    !routes_equal(prior_route, route) || source.nh_override(key) != next_hop
+                }
+            };
+            if changed {
+                if blocked(route)
+                    || (!rs_asns.is_empty()
+                        && (route_tagged(route)
+                            || attrs_tagged(destination.source_control(key))
+                            || attrs_tagged(source.source_control(key))))
+                {
+                    return None;
+                }
+                next_hop_override.push(next_hop);
+                announce.push(route.clone());
+            }
+            // Counter fold: one permit per staged entry, labelled by its
+            // retained terminal policy; per-source rows feed the
+            // Decision 4 `totals − own + lane` synthesis below.
+            let label = destination.staged_labels.get(&key).cloned().unwrap_or(None);
+            counters.record_permit(route.peer, label);
+            // Member-scoped correction for the slot's own source — the
+            // one member the shared exclusion silences at this key. Its
+            // wire held `adv_source(m)` (the source group's lane
+            // substitution when it also sourced the old winner, the old
+            // entry otherwise); its target is the destination lane's
+            // substitution or nothing (ADR-0126 Decision 4).
+            let lane_new = destination.runner_up.get(&route.prefix);
+            let prior_source = prior.map(|prior_route| prior_route.peer);
+            let lane_old = source.runner_up.get(&route.prefix);
+            if let Some(entry) = lane_new {
+                let suppressed = prior_source == Some(route.peer)
+                    && lane_old.is_some_and(|prev| {
+                        routes_equal(&prev.route, &entry.route) && prev.nh == entry.nh
+                    });
+                if !suppressed {
+                    if blocked(&entry.route)
+                        || (!rs_asns.is_empty()
+                            && (route_tagged(&entry.route)
+                                || attrs_tagged(source_control_input(entry.source_attrs.as_ref()))
+                                || lane_old.is_some_and(|prev| {
+                                    attrs_tagged(source_control_input(prev.source_attrs.as_ref()))
+                                })))
+                    {
+                        return None;
+                    }
+                    supplements
+                        .entry(route.peer)
+                        .or_default()
+                        .announce
+                        .push((entry.route.clone(), entry.nh.clone()));
+                }
+            } else {
+                // Over-withdraw-safe: emit whenever the source group
+                // staged the key and the member's wire could hold
+                // anything there (a displaced other-sourced entry — the
+                // source-flip arm — or a retired substitution). A no-op
+                // when the wire was already empty.
+                let had_wire =
+                    prior.is_some() && (prior_source != Some(route.peer) || lane_old.is_some());
+                if had_wire {
+                    supplements
+                        .entry(route.peer)
+                        .or_default()
+                        .withdraw
+                        .push(key);
+                }
+            }
+        }
+        let mut withdraw: Vec<(Prefix, u32)> = Vec::new();
+        for route in source.table.iter() {
+            if destination
+                .table
+                .get(&route.prefix, route.path_id)
+                .is_none()
+            {
+                withdraw.push((route.prefix, route.path_id));
+            }
+        }
+        for entry in destination.runner_up.values() {
+            counters.record_lane(entry.winner_source, entry.policy_label.clone());
+        }
+        for (key, label) in &destination.policy_filtered {
+            counters.record_deny(key.source_peer, label.clone());
+        }
+        Some(BatchedTransitionInventory {
+            announce: announce.into(),
+            next_hop_override: next_hop_override.into(),
+            withdraw,
+            supplements,
+            counters,
+        })
+    }
+
+    /// Replay one cohort member's export counters from the batched
+    /// inventory's pre-aggregated rows — the exact rows
+    /// [`Self::apply_group_join_counters`] would fold from a full table
+    /// walk (`totals − own-sourced + lane substitutions` on the permit
+    /// side, `totals − own-sourced` on the denial side), at O(labels)
+    /// per member instead of O(table).
+    pub(in crate::manager) fn apply_batched_transition_counters(
+        &mut self,
+        peer: IpAddr,
+        inventory: &BatchedTransitionInventory,
+    ) {
+        let rows = inventory.counters.rows_for(peer);
+        if !rows.is_empty() {
+            self.bump_export_counters(peer, &rows);
+        }
     }
 
     /// Build the classifier input for one peer.

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -801,8 +801,10 @@ pub struct PeerExportPolicyReplacement {
 ///
 /// A handoff is fail-closed: the RIB has removed every uncommitted destination
 /// and has not changed any peer policy, group membership, counter, or wire
-/// state. The caller must then apply the replacements through ordinary
-/// [`RibUpdate::ReplacePeerExportPolicy`] commands.
+/// state. The caller must then apply the replacements through one
+/// [`RibUpdate::ReplacePeerExportPoliciesAuthoritatively`] batch (or ordinary
+/// per-peer [`RibUpdate::ReplacePeerExportPolicy`] commands for genuinely
+/// single-peer operations).
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ExportPolicyCohortOutcome {
     /// The cohort transition committed atomically.
@@ -2077,6 +2079,29 @@ pub enum RibUpdate {
         replacements: Vec<PeerExportPolicyReplacement>,
         /// Response channel for failure or the committed/per-peer-handoff outcome.
         reply: oneshot::Sender<Result<ExportPolicyCohortOutcome, String>>,
+    },
+    /// Apply a batch of authoritative export-policy replacements in one
+    /// actor call with one trailing distribution pass — the batched form
+    /// of [`RibUpdate::ReplacePeerExportPolicy`] used when the optimized
+    /// clean-transition cohort replies
+    /// [`ExportPolicyCohortOutcome::RequiresAuthoritativePerPeerApply`]
+    /// (ADR-0105's complete fallback; per-client-best groups always land
+    /// here per ADR-0126 Decision 8).
+    ///
+    /// Contract: replacements naming peers no longer registered for
+    /// outbound updates are skipped (a reconnect installs the desired
+    /// policy — the same posture as the serial per-peer loop this
+    /// replaces). Everything else commits in the one synchronous call:
+    /// there is no partial-state failure mode after the first mutation.
+    /// Per-member wire delivery is best-effort — a member whose emission
+    /// cannot be prepared (closed channel, encoder churn, exact-export
+    /// rejection) is marked dirty and healed by the ordinary resync from
+    /// the already-committed state.
+    ReplacePeerExportPoliciesAuthoritatively {
+        /// Replacements in caller transaction order.
+        replacements: Vec<PeerExportPolicyReplacement>,
+        /// Response channel for success/failure.
+        reply: oneshot::Sender<Result<(), RibCommandError>>,
     },
     /// Create and stage the prospective destination update-group of an
     /// upcoming [`RibUpdate::ReplacePeerExportPolicies`] cohort — without

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -96,6 +96,15 @@ const READINESS_QUERY_BUDGET_PER_POLICY_STEP: usize = 1;
 /// therefore SIGHUP reload / gRPC policy apply) forever.
 const RIB_REPLY_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Hard deadline for the batched authoritative export-policy apply
+/// (`RibUpdate::ReplacePeerExportPoliciesAuthoritatively`). One command
+/// carries the whole fallback cohort, so unlike the inline replies above
+/// it legitimately performs a destination-table build plus a cohort-wide
+/// emission — seconds at route-server scale. Twice the clean
+/// transition's 60-second pre-commit ownership budget, and still bounded
+/// so a wedged RIB task cannot park the peer-manager actor forever.
+const RIB_BATCH_REPLY_TIMEOUT: Duration = Duration::from_mins(2);
+
 /// ADR-0073: deadline for an `ExplainImportPolicy` round-trip to a
 /// session task. Bounded for the same reason as the policy-update
 /// timeout — a session parked on TCP back-pressure must not park the

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -1209,37 +1209,50 @@ impl PeerManager {
         }
     }
 
-    /// Complete a cohort handoff through the ordinary authoritative RIB seam.
+    /// Complete a cohort handoff through the batched authoritative RIB seam.
     ///
-    /// Session chains were already applied during cohort setup. Sending one
-    /// ordinary RIB replacement at a time avoids a second session hot-apply,
-    /// keeps the next peer out of the RIB queue until the prior peer replies,
-    /// and admits the dedicated readiness lane throughout each send/reply.
+    /// Session chains were already applied during cohort setup. One RIB
+    /// command carries every replacement of the cohort: the RIB recomputes
+    /// the memberships together, shares the destination-group build and the
+    /// old→new wire delta across the cohort, and runs ONE distribution pass
+    /// — instead of one full-table resync per member. Peers no longer
+    /// registered in the RIB are skipped inside the batch (a reconnect
+    /// installs the desired policy), matching the prior per-peer loop. The
+    /// dedicated readiness lane is admitted throughout the send/reply.
     async fn apply_export_policy_replacements_authoritatively(
         &mut self,
         replacements: &[PeerExportPolicyReplacement],
     ) -> Result<(), String> {
-        for replacement in replacements {
-            match self
-                .replace_peer_export_policy_in_rib(
-                    replacement.peer,
-                    replacement.export_policy.clone(),
-                )
-                .await
-            {
-                Ok(()) => {}
-                Err(error @ RibCommandError::NotFound(_)) => {
-                    info!(
-                        peer = %replacement.peer,
-                        %error,
-                        "authoritative export-policy handoff skipped a peer no longer registered in the RIB; a reconnect will install the desired policy"
-                    );
-                }
-                Err(error) => return Err(format!("{}: {error}", replacement.peer)),
-            }
-            self.drain_readiness_queries().await;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let rib_tx = self.rib_tx.clone();
+        if self
+            .await_with_readiness(rib_tx.send(
+                RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
+                    replacements: replacements.to_vec(),
+                    reply: reply_tx,
+                },
+            ))
+            .await
+            .is_err()
+        {
+            return Err("RIB manager unavailable".to_string());
         }
-        Ok(())
+        let result = match tokio::time::timeout(
+            super::RIB_BATCH_REPLY_TIMEOUT,
+            self.await_with_readiness(reply_rx),
+        )
+        .await
+        {
+            Err(_) => Err(format!(
+                "RIB manager did not reply within {:?} while applying the authoritative export-policy batch",
+                super::RIB_BATCH_REPLY_TIMEOUT
+            )),
+            Ok(Err(_)) => Err("RIB manager dropped authoritative batch reply".to_string()),
+            Ok(Ok(Err(error))) => Err(error.to_string()),
+            Ok(Ok(Ok(()))) => Ok(()),
+        };
+        self.drain_readiness_queries().await;
+        result
     }
 
     /// Run one ordinary RIB export-policy replacement while servicing the

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -14811,21 +14811,21 @@ async fn import_tolerant_cohort_handoff_fires_deferred_refresh_once() {
                 rustbgpd_rib::ExportPolicyCohortOutcome::RequiresAuthoritativePerPeerApply,
             ))
             .unwrap();
-        for expected_peer in peers {
-            let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } =
-                rib_rx.recv().await.unwrap()
-            else {
-                panic!("expected ordinary per-peer RIB command");
-            };
-            assert_eq!(peer, expected_peer);
-            assert!(
-                refresh_watch
-                    .iter()
-                    .all(|counter| counter.refreshes.load(Ordering::SeqCst) == 0),
-                "no Route Refresh may fire before the authoritative handoff completes"
-            );
-            reply.send(Ok(())).unwrap();
-        }
+        let RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
+            replacements,
+            reply,
+        } = rib_rx.recv().await.unwrap()
+        else {
+            panic!("expected batched authoritative RIB command");
+        };
+        assert_eq!(replacements.len(), peers.len());
+        assert!(
+            refresh_watch
+                .iter()
+                .all(|counter| counter.refreshes.load(Ordering::SeqCst) == 0),
+            "no Route Refresh may fire before the authoritative handoff completes"
+        );
+        reply.send(Ok(())).unwrap();
     };
     let (result, ()) = tokio::join!(apply, drive_rib);
     result.expect("handoff cohort snapshot must commit");
@@ -15169,7 +15169,11 @@ async fn cohort_export_failure_repair_arms_pending_refresh_when_not_established(
 }
 
 #[tokio::test]
-async fn export_only_snapshot_handoff_applies_one_rib_peer_at_a_time() {
+#[expect(
+    clippy::too_many_lines,
+    reason = "the handoff fixture scripts the full prestage + cohort + batch dialogue"
+)]
+async fn export_only_snapshot_handoff_batches_the_authoritative_apply() {
     use rustbgpd_api::peer_types::{PeerManagerReadinessQuery, ResolvedPeerPolicy};
 
     let peers = [
@@ -15223,34 +15227,42 @@ async fn export_only_snapshot_handoff_applies_one_rib_peer_at_a_time() {
             ))
             .unwrap();
 
-        for (index, expected_peer) in peers.into_iter().enumerate() {
-            let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } =
-                rib_rx.recv().await.unwrap()
-            else {
-                panic!("expected ordinary per-peer RIB command");
-            };
-            assert_eq!(peer, expected_peer);
-            assert!(
-                matches!(rib_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
-                "the next peer must not be queued before peer {index} replies"
-            );
-            let (readiness_reply, readiness_response) = oneshot::channel();
-            readiness_tx
-                .send(PeerManagerReadinessQuery::ListPeers {
-                    reply: readiness_reply,
-                })
-                .await
-                .unwrap();
-            let infos = tokio::time::timeout(
-                rustbgpd_api::health_probe::CORE_READINESS_DEADLINE,
-                readiness_response,
-            )
+        // The handoff is ONE batched command carrying the whole cohort in
+        // caller order — never a serial per-peer dialogue.
+        let RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
+            replacements,
+            reply,
+        } = rib_rx.recv().await.unwrap()
+        else {
+            panic!("expected batched authoritative RIB command");
+        };
+        assert_eq!(
+            replacements
+                .iter()
+                .map(|replacement| replacement.peer)
+                .collect::<Vec<_>>(),
+            peers.to_vec()
+        );
+        assert!(
+            matches!(rib_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+            "no per-peer command may accompany the batch"
+        );
+        let (readiness_reply, readiness_response) = oneshot::channel();
+        readiness_tx
+            .send(PeerManagerReadinessQuery::ListPeers {
+                reply: readiness_reply,
+            })
             .await
-            .expect("readiness must remain live while an ordinary RIB reply is held")
             .unwrap();
-            assert_eq!(infos.len(), peers.len());
-            reply.send(Ok(())).unwrap();
-        }
+        let infos = tokio::time::timeout(
+            rustbgpd_api::health_probe::CORE_READINESS_DEADLINE,
+            readiness_response,
+        )
+        .await
+        .expect("readiness must remain live while the batched RIB reply is held")
+        .unwrap();
+        assert_eq!(infos.len(), peers.len());
+        reply.send(Ok(())).unwrap();
     };
     let (result, ()) = tokio::join!(apply, drive_rib);
 
@@ -15272,11 +15284,14 @@ async fn export_only_snapshot_handoff_applies_one_rib_peer_at_a_time() {
     }
 }
 
+/// A peer that deregistered from the RIB between the cohort hot-apply
+/// and the handoff must stay benign: the skip now happens INSIDE the
+/// batched authoritative apply (the RIB logs and continues — proven at
+/// the RIB seam by
+/// `batched_authoritative_apply_skips_unregistered_and_degrades_dead_channels`),
+/// so the peer manager observes one successful batch reply and performs
+/// no rollback.
 #[tokio::test]
-#[expect(
-    clippy::too_many_lines,
-    reason = "the handoff fixture scripts the full prestage + cohort + per-peer dialogue"
-)]
 async fn export_only_snapshot_handoff_skips_missing_peer_and_continues_without_rollback() {
     use rustbgpd_api::peer_types::{PeerManagerReadinessQuery, ResolvedPeerPolicy};
 
@@ -15331,16 +15346,16 @@ async fn export_only_snapshot_handoff_skips_missing_peer_and_continues_without_r
             ))
             .unwrap();
 
-        let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } = rib_rx.recv().await.unwrap()
+        let RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
+            replacements,
+            reply,
+        } = rib_rx.recv().await.unwrap()
         else {
-            panic!("expected first ordinary per-peer RIB command");
+            panic!("expected batched authoritative RIB command");
         };
-        assert_eq!(peer, peers[0]);
-        reply
-            .send(Err(rustbgpd_rib::RibCommandError::not_found(
-                "peer disappeared after cohort handoff",
-            )))
-            .unwrap();
+        // The departed peer still rides the batch; the RIB skips it
+        // internally and the whole apply succeeds.
+        assert_eq!(replacements.len(), peers.len());
 
         let (readiness_reply, readiness_response) = oneshot::channel();
         readiness_tx
@@ -15352,11 +15367,6 @@ async fn export_only_snapshot_handoff_skips_missing_peer_and_continues_without_r
         let infos = readiness_response.await.unwrap();
         assert_eq!(infos.len(), peers.len());
 
-        let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } = rib_rx.recv().await.unwrap()
-        else {
-            panic!("expected second ordinary per-peer RIB command");
-        };
-        assert_eq!(peer, peers[1]);
         reply.send(Ok(())).unwrap();
         tokio::task::yield_now().await;
         assert!(matches!(
@@ -15368,7 +15378,7 @@ async fn export_only_snapshot_handoff_skips_missing_peer_and_continues_without_r
 
     assert!(
         result.is_ok(),
-        "NotFound handoff race must be benign: {result:?}"
+        "a departed-peer handoff race must be benign: {result:?}"
     );
     assert_eq!(
         installs.load(Ordering::SeqCst),
@@ -15412,25 +15422,30 @@ async fn export_only_snapshot_handoff_failure_restores_every_peer_newest_first()
             ))
             .unwrap();
 
+        // Forward: ONE batched command for the whole cohort; its failure
+        // fails the whole handoff at once.
+        let RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
+            replacements,
+            reply,
+        } = rib_rx.recv().await.unwrap()
+        else {
+            panic!("expected batched authoritative RIB command");
+        };
+        assert_eq!(
+            replacements
+                .iter()
+                .map(|replacement| replacement.peer)
+                .collect::<Vec<_>>(),
+            peers.to_vec()
+        );
+        reply
+            .send(Err(rustbgpd_rib::RibCommandError::internal(
+                "synthetic batch failure",
+            )))
+            .unwrap();
+
+        // Rollback stays on the per-peer restore seam, newest first.
         let mut order = Vec::new();
-        for expected_peer in peers {
-            let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } =
-                rib_rx.recv().await.unwrap()
-            else {
-                panic!("expected forward ordinary RIB command");
-            };
-            assert_eq!(peer, expected_peer);
-            order.push(peer);
-            if peer == peers[1] {
-                reply
-                    .send(Err(rustbgpd_rib::RibCommandError::internal(
-                        "synthetic second-peer failure",
-                    )))
-                    .unwrap();
-            } else {
-                reply.send(Ok(())).unwrap();
-            }
-        }
         for expected_peer in peers.into_iter().rev() {
             let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } =
                 rib_rx.recv().await.unwrap()
@@ -15479,20 +15494,17 @@ async fn export_only_snapshot_handoff_failure_restores_every_peer_newest_first()
         .await;
     assert!(
         result.as_ref().is_err_and(|error| {
-            error.contains("synthetic second-peer failure")
+            error.contains("synthetic batch failure")
                 && error.contains("already-applied peers restored")
         }),
-        "a later handoff failure must surface after a complete rollback: {result:?}"
+        "a handoff failure must surface after a complete rollback: {result:?}"
     );
     assert_eq!(
         installs.load(Ordering::SeqCst),
         peers.len() * 2,
         "handoff must avoid a second forward session apply and restore every session once"
     );
-    assert_eq!(
-        rib_task.await.unwrap(),
-        vec![peers[0], peers[1], peers[1], peers[0]]
-    );
+    assert_eq!(rib_task.await.unwrap(), vec![peers[1], peers[0]]);
     for peer in peers {
         let peer_state = manager.peers.get(&key(peer)).unwrap();
         assert!(peer_state.export_policy.is_none());
@@ -15559,23 +15571,32 @@ async fn export_only_snapshot_handoff_timeout_restores_after_the_owned_forward_c
             ))
             .unwrap();
 
-        let RibUpdate::ReplacePeerExportPolicy {
-            peer: forward_peer,
-            export_policy: forward_policy,
+        let RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
+            replacements,
             reply: late_forward_reply,
         } = rib_rx.recv().await.unwrap()
         else {
-            panic!("expected first ordinary forward command");
+            panic!("expected batched authoritative forward command");
         };
-        assert_eq!(forward_peer, peers[0]);
-        assert_eq!(forward_policy, Some(next.clone()));
+        assert_eq!(
+            replacements
+                .iter()
+                .map(|replacement| replacement.peer)
+                .collect::<Vec<_>>(),
+            peers.to_vec()
+        );
+        assert!(
+            replacements
+                .iter()
+                .all(|replacement| replacement.export_policy == Some(next.clone()))
+        );
         assert!(matches!(
             rib_rx.try_recv(),
             Err(mpsc::error::TryRecvError::Empty)
         ));
 
         tokio::task::yield_now().await;
-        tokio::time::advance(RIB_REPLY_TIMEOUT + Duration::from_millis(1)).await;
+        tokio::time::advance(RIB_BATCH_REPLY_TIMEOUT + Duration::from_millis(1)).await;
         tokio::task::yield_now().await;
 
         assert!(


### PR DESCRIPTION
## Problem

A SIGHUP reload that changes every member's export-chain content on a 320-member per-client-best group (canonical IRR shape, 183,040 prefixes) completes in 140–148 s against the ~4.5 s grouped-control class. The clean-transition path refuses per-client-best cohorts by design (ADR-0126 Decision 8) and replies `RequiresAuthoritativePerPeerApply` on the first member; the peer manager then looped **serially** over all 320 replacements, one synchronous RIB round-trip each, and every round-trip drained one member through a full-table dirty resync — an O(table) clone-walk, a full per-member exact-export probe, and a full per-member encode. 320 × ~182k announces × ~4.7 µs ≈ 274 s = 99.8 % of the reload, while the destination group's entire table build costs 0.58 s.

## Change

The handoff is now **one RIB command**, `RibUpdate::ReplacePeerExportPoliciesAuthoritatively`, applied in one synchronous actor call with one trailing distribution pass.

**Shared cohort transition** — a source group whose batched members all move to one fresh destination differing only in chain content (unicast-only both sides, the clean transition's narrow shape):

- The destination table is built **once** (the existing join-time build pass; an unowned prestaged table is adopted).
- The wire delta is derived **once** by an equality-suppressed diff of the source and destination group tables: announce only entries whose wire form changed, withdraw only keys the destination no longer stages. O(actual policy diff), never O(table × members); a content-equal restage emits nothing.
- Per-member divergence is exactly the ADR-0126 Decision 4 emit-time exception set: split horizon rides the envelope's `announce_source_exclusion`, and each winner's source receives its exception-lane substitution (equality-suppressed against the source lane) as a member-scoped supplement envelope.
- The announce payload is one `Arc` across the cohort with the encode-once `SharedGroupEncode` cell — the clean transition's proven fan-out seam — so a marker-style all-slots change costs one staging pass, one probe, one encode, not 320.
- Exact-export probing follows the clean transition's reuse shape: the first member's full batch probe seeds a cohort-local cache; every compatible member afterwards proves only the largest encoded message against its own ceiling.
- Counter replay keeps join-fold parity via pre-aggregated `totals − own-sourced + lane` rows: O(labels) per member instead of the O(table) walk. Per-member policy-denial records are restamped from the destination group, and advertised gauges refresh per member.

**Baseline derivation shape**: the shared-baseline optimization was **required**. Per-member `member_view_snapshot` baselines would cost 320 × O(table) route clones before any diffing, and per-member resync walks and encodes after it. Instead the source group's table *is* the shared baseline — diffed in place before the members leave it, zero copies — and the per-member patch is own-source exclusion plus the lane substitution, exactly the derivation ADR-0126 Decision 4 defines for `adv(m)`.

**Everything else degrades safely.** Partial-group moves, already-owned destinations, ungrouped members or destinations, non-unicast profiles, rs-control-tagged deltas, OTC-blocked routes or residue, and duplicate targets all take the existing per-member regroup machinery (baseline snapshot + dirty resync) — still inside the one command, drained by **one** trailing `distribute_changes` pass instead of one pass per member. RFC 9234 enforcement is per emitted route: a `RouteServer`-role fleet with no OTC-attributed routes (the rendered route-server default) shares normally; any blocked route or blocked-winner residue degrades its cohort to the per-member path, whose seams run the pre-commit backstop.

## Atomicity contract

- **Validation before mutation**: a pending clean transition rejects the batch; duplicate targets fall to sequential single-peer semantics; unregistered peers are skipped with the serial loop's exact posture (a reconnect installs the desired policy). Nothing externally visible mutates before these checks pass.
- **State commits all-or-nothing**: policy installs, membership moves, counters, and denial restamps complete inside the one actor call. There is no fallible step after the first mutation, so no partial-state outcome exists — stronger than the serial loop, which could fail at member N leaving N−1 applied.
- **Delivery is per-member best-effort**: an emission that cannot be prepared (closed/full channel, encoder churn, exact-export rejection, ceiling breach) marks that member dirty; the ordinary resync heals it from the already-committed state — the same posture as `CommitMembers`' benign mid-flush drop and every existing emission seam. Everything is probed and its permits reserved before anything is sent, so a member is never half-emitted.
- **Caller failure handling unchanged**: the peer manager awaits the single reply under a 2-minute deadline (twice the clean transition's 60 s pre-commit ownership budget); an error or timeout rolls the whole cohort back through the unchanged per-peer restore seam, newest first.

The per-peer `ReplacePeerExportPolicy` command is untouched and remains the shape for genuinely single-peer operations (per-item RPC path, rollback restores).

## Untouched

The clean-transition per-client-best exclusion (ADR-0126 Decision 8), the winner walk, the lane machinery, `adv_entry`, and the classifier. `per_client_best.rs`, `update_groups_oracle.rs`, and `comparison_reasons_cover_every_group_key_axis` are unmodified and green. ADR-0105's transaction is unchanged; the batched path composes from existing regroup, staging, probe-cache, and shared-encode seams.

Five peer-manager tests that scripted the serial handoff dialogue (`export_only_snapshot_handoff_*`, `import_tolerant_cohort_handoff_fires_deferred_refresh_once`) now script the batched dialogue; their meanings — readiness liveness during the handoff, benign departed-peer race, error/timeout → complete newest-first rollback, no double hot-apply, deferred-refresh-after-commit — are preserved, with the departed-peer skip now proven at the RIB seam.

## Instrumentation

The RIB emits one structured line per batch — `authoritative export-policy batch applied` with `outcome`, `n_replacements`, `n_destination_groups`, `n_shared_members`, `n_fallback_members`, `n_skipped_unregistered`, `elapsed_ms` — plus one per shared cohort (`applied batched authoritative export-policy transition` with source/destination group ids, members, announced/withdrawn/supplemented counts). The existing `committed partitioned resolved policy snapshot` span now brackets the batched pass.

## Evidence

IRR reload harness smoke (`SMOKE=1 OVERLAP_FRACTION=0.3 … rustbgpd-sighup`), exit code 0, receipt verifier `pass`:

```
1 "outcome":"fallback_handoff"        (clean transition refuses the pcb cohort, elapsed_ms=0)
1 "outcome":"batched_authoritative"   (n_replacements=10, n_destination_groups=1,
                                       n_shared_members=10, n_fallback_members=0)
applied batched authoritative export-policy transition
  source_group=0 destination_group=1 members=10 announced=148 withdrawn=0 supplemented=8
"outbound routes resynced" lines: 0   (previously one full-table resync per member)
```

The reload outcome is no longer per-member-resync-shaped: zero dirty resyncs, one shared transition.

## Gates

- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- `cargo test --workspace` — pass
- `cargo doc --workspace --no-deps` — pass
- `python3 scripts/check-clippy-reasons.py` — pass
- `cargo check -p rustbgpd-rib --features bench-internals --benches` — pass
- `bash bench/smoke-benches.sh` — pass
