### PR TITLE
Scope cohort-setup deadlines to actor attention; skip the statically-dead prestage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,23 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fleet-wide policy reloads on high-overlap per-client-best fleets no
+  longer halt partway through cohort setup with healthy sessions timed
+  out and every applied peer rolled back. Two peer-manager actor waits
+  starved the per-peer session hot-apply deadlines: the cohort opened
+  with an unbounded clean-transition destination-prestage round trip to
+  the RIB — statically dead for a per-client-best source group (ADR-0126
+  Decision 8) yet still queued behind the reload's lane-heavy RIB work —
+  and readiness-query servicing interleaved with an in-flight session
+  command was wall-clock-deducted from that command's 500 ms budget. The
+  prestage is now skipped outright when the source group's per-client-best
+  classification makes it statically dead, and bounded by the standard
+  RIB-reply deadline otherwise (elapsing degrades to the existing
+  best-effort unprestaged path); session hot-apply deadlines now accrue
+  only while the actor is actually driving the round trip, so readiness
+  servicing and RIB dequeue latency can no longer time out a healthy
+  session. Cohort setup also logs progress (applied count + elapsed) and
+  a stamped prestage outcome instead of running silent.
 - The authoritative per-peer export-policy handoff no longer costs one
   full-table resync per member. When the optimized clean transition
   declines a reload cohort — per-client-best groups always decline it

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -1655,18 +1655,7 @@ impl PeerHandle {
         policy: Option<PolicyChain>,
         deadline: Duration,
     ) -> Result<(), PeerCommandError> {
-        match tokio::time::timeout(deadline, async move {
-            let (reply_tx, reply_rx) = oneshot::channel();
-            commands
-                .send(PeerCommand::UpdateImportPolicy {
-                    policy,
-                    reply: reply_tx,
-                })
-                .await
-                .map_err(|_| PeerCommandError::SessionExited)?;
-            reply_rx.await.map_err(|_| PeerCommandError::ReplyDropped)?
-        })
-        .await
+        match tokio::time::timeout(deadline, Self::update_import_policy_via(commands, policy)).await
         {
             Ok(result) => result,
             Err(_elapsed) => Err(PeerCommandError::TimedOut {
@@ -1674,6 +1663,29 @@ impl PeerHandle {
                 deadline,
             }),
         }
+    }
+
+    /// Owned-sender, deadline-free variant of [`Self::update_import_policy`].
+    /// See [`Self::update_export_policy_via`] for rationale.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PeerCommandError::SessionExited`] if the session task's
+    /// command channel is closed, or [`PeerCommandError::ReplyDropped`] if the
+    /// task accepted the command but dropped the reply before responding.
+    pub async fn update_import_policy_via(
+        commands: mpsc::Sender<PeerCommand>,
+        policy: Option<PolicyChain>,
+    ) -> Result<(), PeerCommandError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        commands
+            .send(PeerCommand::UpdateImportPolicy {
+                policy,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| PeerCommandError::SessionExited)?;
+        reply_rx.await.map_err(|_| PeerCommandError::ReplyDropped)?
     }
 
     /// Query this session's import-decision cache (ADR-0073).
@@ -1797,18 +1809,7 @@ impl PeerHandle {
         policy: Option<PolicyChain>,
         deadline: Duration,
     ) -> Result<(), PeerCommandError> {
-        match tokio::time::timeout(deadline, async move {
-            let (reply_tx, reply_rx) = oneshot::channel();
-            commands
-                .send(PeerCommand::UpdateExportPolicy {
-                    policy,
-                    reply: reply_tx,
-                })
-                .await
-                .map_err(|_| PeerCommandError::SessionExited)?;
-            reply_rx.await.map_err(|_| PeerCommandError::ReplyDropped)?
-        })
-        .await
+        match tokio::time::timeout(deadline, Self::update_export_policy_via(commands, policy)).await
         {
             Ok(result) => result,
             Err(_elapsed) => Err(PeerCommandError::TimedOut {
@@ -1816,6 +1817,36 @@ impl PeerHandle {
                 deadline,
             }),
         }
+    }
+
+    /// Owned-sender, deadline-free variant of [`Self::update_export_policy`].
+    ///
+    /// The round trip carries no internal wall-clock timeout: a caller that
+    /// interleaves other work with this future (the peer-manager actor
+    /// servicing its readiness lane) owns the deadline and charges it only
+    /// for the time it actually spends driving the round trip. A wall-clock
+    /// `tokio::time::timeout` inside the round trip would keep counting
+    /// while the caller is busy elsewhere, deducting that time from the
+    /// session's allowance.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PeerCommandError::SessionExited`] if the session task's
+    /// command channel is closed, or [`PeerCommandError::ReplyDropped`] if the
+    /// task accepted the command but dropped the reply before responding.
+    pub async fn update_export_policy_via(
+        commands: mpsc::Sender<PeerCommand>,
+        policy: Option<PolicyChain>,
+    ) -> Result<(), PeerCommandError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        commands
+            .send(PeerCommand::UpdateExportPolicy {
+                policy,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| PeerCommandError::SessionExited)?;
+        reply_rx.await.map_err(|_| PeerCommandError::ReplyDropped)?
     }
 
     /// Bounded hot-apply of reload-matrix `live` per-session runtime

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -551,6 +551,48 @@ impl PeerManager {
         }
     }
 
+    /// Like [`Self::await_with_readiness`], but bound the transaction step by
+    /// a budget that accrues only while the step itself is being driven. Wall
+    /// time spent servicing an interleaved readiness query is not charged: a
+    /// `tokio::time::timeout` inside the step would keep counting during that
+    /// servicing, so a probe flood (or any long servicing burst) would be
+    /// deducted from a healthy session command's deadline — the mechanism
+    /// behind the cohort-setup starvation. Returns `None` when the accrued
+    /// budget elapses before the future completes.
+    async fn await_with_readiness_budget<F>(
+        &mut self,
+        future: F,
+        budget: Duration,
+    ) -> Option<F::Output>
+    where
+        F: Future,
+    {
+        tokio::pin!(future);
+        let mut remaining = budget;
+        loop {
+            let Some(readiness_rx) = self.readiness_rx.as_mut() else {
+                return tokio::time::timeout(remaining, future).await.ok();
+            };
+            let attended = tokio::time::Instant::now();
+            tokio::select! {
+                biased;
+                result = tokio::time::timeout(remaining, &mut future) => return result.ok(),
+                query = readiness_rx.recv() => {
+                    // Time until the query arrived was genuine waiting on the
+                    // step; the servicing below is not, so stop the clock.
+                    remaining = remaining.saturating_sub(attended.elapsed());
+                    match query {
+                        Some(query) => self.handle_readiness_query(query).await,
+                        None => self.readiness_rx = None,
+                    }
+                    if remaining.is_zero() {
+                        return None;
+                    }
+                }
+            }
+        }
+    }
+
     async fn receive_readiness_query(
         readiness_rx: &mut Option<mpsc::Receiver<PeerManagerReadinessQuery>>,
     ) -> Option<PeerManagerReadinessQuery> {

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -24,7 +24,14 @@ use crate::policy_admin::{
     peer_group_references, policy_references,
 };
 
-use super::{ManagedPeer, PEER_POLICY_UPDATE_TIMEOUT, PEER_QUERY_TIMEOUT, PeerManager};
+use super::{
+    ManagedPeer, PEER_POLICY_UPDATE_TIMEOUT, PEER_QUERY_TIMEOUT, PeerManager, RIB_REPLY_TIMEOUT,
+};
+
+/// Peers applied between cohort-setup progress lines. Sized so a
+/// route-server-scale fleet (hundreds of members) logs a handful of `info!`
+/// lines instead of either silence or one line per peer.
+const COHORT_SETUP_PROGRESS_INTERVAL: usize = 64;
 
 /// How `update_runtime_policies_for_peer_key` reacts when the Route Refresh
 /// send fails after the session already acked the new policy.
@@ -750,6 +757,31 @@ impl PeerManager {
         Ok(applied)
     }
 
+    /// Session policy hot-apply bounded by attention time, not wall time.
+    ///
+    /// The round trip carries no internal timeout;
+    /// `await_with_readiness_budget` charges the `PEER_POLICY_UPDATE_TIMEOUT`
+    /// budget only while this actor is actually driving the round trip. Wall
+    /// time spent servicing interleaved readiness queries is not deducted, so
+    /// a probe flood cannot spend a healthy session's deadline for it — the
+    /// cohort-setup starvation that halted high-overlap reloads.
+    async fn hot_apply_session_policy(
+        &mut self,
+        round_trip: impl Future<Output = Result<(), rustbgpd_transport::PeerCommandError>>,
+        operation: &'static str,
+    ) -> Result<(), rustbgpd_transport::PeerCommandError> {
+        match self
+            .await_with_readiness_budget(round_trip, PEER_POLICY_UPDATE_TIMEOUT)
+            .await
+        {
+            Some(result) => result,
+            None => Err(rustbgpd_transport::PeerCommandError::TimedOut {
+                operation,
+                deadline: PEER_POLICY_UPDATE_TIMEOUT,
+            }),
+        }
+    }
+
     /// Fast path for the dominant reload shape: two or more Established peers
     /// share one export-chain move. Session hot-apply still precedes the RIB
     /// commit, but one batched RIB command lets equivalent clean update-group
@@ -802,21 +834,54 @@ impl PeerManager {
         // route-server scale. Best-effort: on any error the transition
         // stages the destination itself, exactly as before. This must
         // precede the session hot-applies so a failure here costs nothing.
-        let prestaged = {
+        //
+        // A per-client-best source group is statically excluded from the
+        // clean transition and therefore from its prestage (ADR-0126
+        // Decision 8): the RIB's `clean_policy_transition_destination`
+        // preflight answers `None` for it unconditionally. The registered
+        // transport config carries the same classification, so skip the
+        // round trip outright instead of parking the reload behind a
+        // statically-dead command queued after the RIB's in-flight work.
+        // The live round trip is bounded by `RIB_REPLY_TIMEOUT` on the
+        // budget clock (readiness servicing is not charged); elapsing
+        // degrades to `prestaged = false` on the same best-effort contract.
+        let setup_started = Instant::now();
+        let prestage_excluded = self
+            .peers
+            .get(&peer_keys[0])
+            .is_some_and(|managed| managed.transport_config.per_client_best);
+        let prestaged = if prestage_excluded {
+            false
+        } else {
             let (reply_tx, reply_rx) = oneshot::channel();
-            let send_result = self
-                .rib_tx
-                .send(RibUpdate::PrepareExportPolicyDestination {
-                    peer: targets[0].address,
-                    export_policy: targets[0].export_policy.clone(),
-                    reply: reply_tx,
-                })
-                .await;
-            match send_result {
-                Err(_) => false,
-                Ok(()) => matches!(self.await_with_readiness(reply_rx).await, Ok(Ok(()))),
-            }
+            let rib_tx = self.rib_tx.clone();
+            let peer = targets[0].address;
+            let export_policy = targets[0].export_policy.clone();
+            let round_trip = async move {
+                if rib_tx
+                    .send(RibUpdate::PrepareExportPolicyDestination {
+                        peer,
+                        export_policy,
+                        reply: reply_tx,
+                    })
+                    .await
+                    .is_err()
+                {
+                    return false;
+                }
+                matches!(reply_rx.await, Ok(Ok(())))
+            };
+            self.await_with_readiness_budget(round_trip, RIB_REPLY_TIMEOUT)
+                .await
+                .unwrap_or(false)
         };
+        info!(
+            cohort_targets = targets.len(),
+            prestaged,
+            prestage_excluded,
+            elapsed_ms = u64::try_from(setup_started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "cohort destination prestage round trip"
+        );
 
         let mut captured = Vec::with_capacity(targets.len());
         for ((target, peer_key), &import_changed) in
@@ -853,12 +918,12 @@ impl PeerManager {
                     .handle
                     .commands_sender();
                 let import_result = self
-                    .await_with_readiness(
-                        rustbgpd_transport::PeerHandle::update_import_policy_with(
+                    .hot_apply_session_policy(
+                        rustbgpd_transport::PeerHandle::update_import_policy_via(
                             import_commands,
                             target.import_policy.clone(),
-                            PEER_POLICY_UPDATE_TIMEOUT,
                         ),
+                        "update_import_policy",
                     )
                     .await;
                 if let Err(error) = import_result {
@@ -903,11 +968,13 @@ impl PeerManager {
                 .handle
                 .commands_sender();
             let apply_result = self
-                .await_with_readiness(rustbgpd_transport::PeerHandle::update_export_policy_with(
-                    commands,
-                    target.export_policy.clone(),
-                    PEER_POLICY_UPDATE_TIMEOUT,
-                ))
+                .hot_apply_session_policy(
+                    rustbgpd_transport::PeerHandle::update_export_policy_via(
+                        commands,
+                        target.export_policy.clone(),
+                    ),
+                    "update_export_policy",
+                )
                 .await;
             if let Err(error) = apply_result {
                 if prestaged {
@@ -924,12 +991,12 @@ impl PeerManager {
                     .handle
                     .commands_sender();
                 let failing_restore = self
-                    .await_with_readiness(
-                        rustbgpd_transport::PeerHandle::update_export_policy_with(
+                    .hot_apply_session_policy(
+                        rustbgpd_transport::PeerHandle::update_export_policy_via(
                             restore_commands,
                             prior.policy.export_policy.clone(),
-                            PEER_POLICY_UPDATE_TIMEOUT,
                         ),
+                        "update_export_policy",
                     )
                     .await
                     .map_err(|restore_error| {
@@ -947,12 +1014,12 @@ impl PeerManager {
                         .handle
                         .commands_sender();
                     match self
-                        .await_with_readiness(
-                            rustbgpd_transport::PeerHandle::update_import_policy_with(
+                        .hot_apply_session_policy(
+                            rustbgpd_transport::PeerHandle::update_import_policy_via(
                                 import_restore_commands,
                                 prior.policy.import_policy.clone(),
-                                PEER_POLICY_UPDATE_TIMEOUT,
                             ),
+                            "update_import_policy",
                         )
                         .await
                     {
@@ -1044,6 +1111,17 @@ impl PeerManager {
                 .export_policy
                 .clone_from(&target.export_policy);
             captured.push(prior);
+            if captured.len() % COHORT_SETUP_PROGRESS_INTERVAL == 0
+                || captured.len() == targets.len()
+            {
+                info!(
+                    applied = captured.len(),
+                    cohort_targets = targets.len(),
+                    elapsed_ms =
+                        u64::try_from(setup_started.elapsed().as_millis()).unwrap_or(u64::MAX),
+                    "cohort session hot-apply progress"
+                );
+            }
             self.drain_readiness_queries().await;
         }
 

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -22897,3 +22897,360 @@ async fn rfc8212_gate_ignores_an_ordinary_import_edit() {
     drop(mgr);
     rib.await.unwrap();
 }
+
+/// Established session that acknowledges an export hot-apply only after
+/// `ack_delay`: healthy, but busy with concurrent reload work. State queries
+/// answer immediately so cohort preflight sees Established.
+fn busy_established_export_session(
+    addr: IpAddr,
+    ack_delay: Duration,
+    installs: Arc<AtomicUsize>,
+) -> PeerHandle {
+    let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(16);
+    let task = tokio::spawn(async move {
+        while let Some(command) = session_rx.recv().await {
+            match command {
+                PeerCommand::UpdateExportPolicy { reply, .. } => {
+                    tokio::time::sleep(ack_delay).await;
+                    installs.fetch_add(1, Ordering::SeqCst);
+                    let _ = reply.send(Ok(()));
+                }
+                PeerCommand::QueryState { reply } => {
+                    let _ = reply.send(policy_test_peer_state(addr, SessionState::Established));
+                }
+                PeerCommand::Shutdown => break,
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    PeerHandle::from_parts(session_tx, task)
+}
+
+/// Cohort-setup starvation, RIB shape: the destination-prestage answer sits
+/// behind queued reload work in the RIB for ten (virtual) minutes. The wait
+/// must be bounded by `RIB_REPLY_TIMEOUT` and degrade to an unprestaged
+/// cohort, not park the whole reload behind the RIB's dequeue latency.
+#[tokio::test(start_paused = true)]
+async fn cohort_prestage_wait_is_bounded_when_rib_dequeue_lags() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let first = IpAddr::V4(Ipv4Addr::new(10, 37, 0, 1));
+    let second = IpAddr::V4(Ipv4Addr::new(10, 37, 0, 2));
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(8);
+    let rib = tokio::spawn(async move {
+        while let Some(update) = rib_rx.recv().await {
+            match update {
+                RibUpdate::PrepareExportPolicyDestination { reply, .. } => {
+                    tokio::spawn(async move {
+                        tokio::time::sleep(Duration::from_mins(10)).await;
+                        let _ = reply.send(Err("test: prestage dequeued late".to_string()));
+                    });
+                }
+                RibUpdate::ReplacePeerExportPolicies { reply, .. } => {
+                    let _ = reply.send(Ok(rustbgpd_rib::ExportPolicyCohortOutcome::Committed));
+                }
+                _ => {}
+            }
+        }
+    });
+
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    let installs = Arc::new(AtomicUsize::new(0));
+    for peer in [first, second] {
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            established_export_policy_test_session(peer, Arc::clone(&installs), None),
+            false,
+        );
+    }
+    let next = deny_policy_chain();
+    let targets = [first, second]
+        .into_iter()
+        .map(|address| ResolvedPeerPolicy {
+            address,
+            interface: None,
+            import_policy: None,
+            export_policy: Some(next.clone()),
+        })
+        .collect::<Vec<_>>();
+
+    let started = tokio::time::Instant::now();
+    manager
+        .apply_resolved_policy_snapshot(targets)
+        .await
+        .expect("healthy sessions must commit despite a lagging prestage answer");
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed >= RIB_REPLY_TIMEOUT,
+        "the live prestage round trip still waits its bounded budget: {elapsed:?}"
+    );
+    assert!(
+        elapsed < Duration::from_mins(1),
+        "the prestage wait must be bounded, not tied to RIB dequeue latency: {elapsed:?}"
+    );
+    assert_eq!(installs.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        manager.peers.get(&key(first)).unwrap().export_policy,
+        Some(next)
+    );
+
+    drop(manager);
+    rib.await.unwrap();
+}
+
+/// Cohort-setup starvation, readiness shape: a continuous readiness-query
+/// flood is serviced while each session command is in flight. Servicing time
+/// must not be charged against `PEER_POLICY_UPDATE_TIMEOUT`, so a session
+/// that acknowledges while the actor is busy with the flood (650 ms wall, of
+/// which almost none is time the actor spent waiting on the session) still
+/// commits instead of timing out the reload.
+#[tokio::test(start_paused = true)]
+async fn readiness_servicing_is_not_charged_to_cohort_session_deadlines() {
+    use rustbgpd_api::peer_types::{PeerManagerReadinessQuery, ResolvedPeerPolicy};
+
+    let first = IpAddr::V4(Ipv4Addr::new(10, 37, 1, 1));
+    let second = IpAddr::V4(Ipv4Addr::new(10, 37, 1, 2));
+    let parked = IpAddr::V4(Ipv4Addr::new(10, 37, 1, 3));
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(8);
+    let rib = tokio::spawn(async move {
+        while let Some(update) = rib_rx.recv().await {
+            match update {
+                RibUpdate::PrepareExportPolicyDestination { reply, .. } => {
+                    let _ = reply.send(Err("test: prestage skipped".to_string()));
+                }
+                RibUpdate::ReplacePeerExportPolicies { reply, .. } => {
+                    let _ = reply.send(Ok(rustbgpd_rib::ExportPolicyCohortOutcome::Committed));
+                }
+                _ => {}
+            }
+        }
+    });
+
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let (readiness_tx, readiness_rx) = mpsc::channel(4);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    )
+    .with_readiness_queries(readiness_rx);
+    let installs = Arc::new(AtomicUsize::new(0));
+    for peer in [first, second] {
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            busy_established_export_session(
+                peer,
+                Duration::from_millis(650),
+                Arc::clone(&installs),
+            ),
+            false,
+        );
+    }
+    // A parked bystander session that never answers state queries makes every
+    // serviced `ListPeers` cost the full `PEER_QUERY_TIMEOUT`.
+    insert_test_managed_peer(&mut manager, parked, stalled_policy_query_handle(), false);
+
+    // Continuous flood: one query queued at all times, the next sent as soon
+    // as the previous one is answered.
+    let flooder = tokio::spawn(async move {
+        loop {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            if readiness_tx
+                .send(PeerManagerReadinessQuery::ListPeers { reply: reply_tx })
+                .await
+                .is_err()
+            {
+                break;
+            }
+            if reply_rx.await.is_err() {
+                break;
+            }
+        }
+    });
+
+    let next = deny_policy_chain();
+    let targets = [first, second]
+        .into_iter()
+        .map(|address| ResolvedPeerPolicy {
+            address,
+            interface: None,
+            import_policy: None,
+            export_policy: Some(next.clone()),
+        })
+        .collect::<Vec<_>>();
+    manager
+        .apply_resolved_policy_snapshot(targets)
+        .await
+        .expect("readiness servicing must not consume the session hot-apply deadlines");
+    assert_eq!(installs.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        manager.peers.get(&key(first)).unwrap().export_policy,
+        Some(next.clone())
+    );
+    assert_eq!(
+        manager.peers.get(&key(second)).unwrap().export_policy,
+        Some(next)
+    );
+
+    drop(manager);
+    flooder.abort();
+    rib.await.unwrap();
+}
+
+/// A per-client-best source group is statically excluded from the clean
+/// transition (its RIB preflight answers `None` unconditionally), so the
+/// cohort must not queue the destination-prestage round trip at all: the
+/// only RIB command in the dialogue is the batched replacement.
+#[tokio::test]
+async fn per_client_best_cohort_skips_statically_dead_prestage() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let first = IpAddr::V4(Ipv4Addr::new(10, 37, 2, 1));
+    let second = IpAddr::V4(Ipv4Addr::new(10, 37, 2, 2));
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(8);
+    let rib = tokio::spawn(async move {
+        let mut sequence = Vec::new();
+        while let Some(update) = rib_rx.recv().await {
+            match update {
+                RibUpdate::PrepareExportPolicyDestination { reply, .. } => {
+                    sequence.push("prestage");
+                    let _ = reply.send(Err("test: statically dead".to_string()));
+                }
+                RibUpdate::ReplacePeerExportPolicies { reply, .. } => {
+                    sequence.push("batch");
+                    let _ = reply.send(Ok(rustbgpd_rib::ExportPolicyCohortOutcome::Committed));
+                }
+                _ => {}
+            }
+        }
+        sequence
+    });
+
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    let installs = Arc::new(AtomicUsize::new(0));
+    for peer in [first, second] {
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            established_export_policy_test_session(peer, Arc::clone(&installs), None),
+            false,
+        );
+        manager
+            .peers
+            .get_mut(&key(peer))
+            .unwrap()
+            .transport_config
+            .per_client_best = true;
+    }
+    let next = deny_policy_chain();
+    let targets = [first, second]
+        .into_iter()
+        .map(|address| ResolvedPeerPolicy {
+            address,
+            interface: None,
+            import_policy: None,
+            export_policy: Some(next.clone()),
+        })
+        .collect::<Vec<_>>();
+    manager
+        .apply_resolved_policy_snapshot(targets)
+        .await
+        .expect("per-client-best cohort must commit through the batched seam");
+    assert_eq!(installs.load(Ordering::SeqCst), 2);
+
+    drop(manager);
+    assert_eq!(
+        rib.await.unwrap(),
+        vec!["batch"],
+        "no statically-dead prestage command may reach the RIB"
+    );
+}
+
+/// The attention-time budget still bounds a genuinely stalled session: a
+/// peer that never acknowledges within the budget fails the apply with the
+/// same timed-out error as before, rather than hanging the actor.
+#[tokio::test(start_paused = true)]
+async fn cohort_hot_apply_budget_still_bounds_a_stalled_session() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let first = IpAddr::V4(Ipv4Addr::new(10, 37, 3, 1));
+    let second = IpAddr::V4(Ipv4Addr::new(10, 37, 3, 2));
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(8);
+    let rib = tokio::spawn(async move {
+        while let Some(update) = rib_rx.recv().await {
+            if let RibUpdate::PrepareExportPolicyDestination { reply, .. } = update {
+                let _ = reply.send(Err("test: prestage skipped".to_string()));
+            }
+        }
+    });
+
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    let installs = Arc::new(AtomicUsize::new(0));
+    for peer in [first, second] {
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            busy_established_export_session(peer, Duration::from_secs(30), Arc::clone(&installs)),
+            false,
+        );
+    }
+    let next = deny_policy_chain();
+    let targets = [first, second]
+        .into_iter()
+        .map(|address| ResolvedPeerPolicy {
+            address,
+            interface: None,
+            import_policy: None,
+            export_policy: Some(next.clone()),
+        })
+        .collect::<Vec<_>>();
+    let error = manager
+        .apply_resolved_policy_snapshot(targets)
+        .await
+        .expect_err("a stalled session must still fail the apply within its budget");
+    assert!(
+        error.contains("update_export_policy timed out"),
+        "budget exhaustion must surface as the timed-out command error: {error}"
+    );
+
+    drop(manager);
+    rib.await.unwrap();
+}


### PR DESCRIPTION
## Problem

A fleet-wide policy reload on a grouped per-client-best fleet at high announcement overlap halts partway through cohort setup: only a fraction of the fleet is applied before one healthy session's `PEER_POLICY_UPDATE_TIMEOUT` (500 ms) lapses, unwinding the whole snapshot. The deadline is spent by the peer-manager actor, not the sessions:

1. The cohort opens with a `PrepareExportPolicyDestination` round trip with no bound on send or reply — its latency is the RIB actor's dequeue latency, which scales with the reload's lane-heavy work. For a per-client-best source group the answer is statically `Err`: `clean_policy_transition_destination` rejects such a source unconditionally (ADR-0126 Decision 8), so the wait purchases nothing.
2. Session hot-applies run under `await_with_readiness`, which pauses the in-flight command future to service readiness queries; the command's internal `tokio::time::timeout` measures wall time, so every serviced query is deducted from that session's 500 ms.

The setup section also emitted no log line between "partitioned resolved policy snapshot" and the commit/rollback lines — tens of seconds of production silence at scale.

## Fix (wire-behavior-neutral)

- **Statically-dead prestage skipped.** The peer-manager checks the cohort's registered `transport_config.per_client_best` — the same classification the RIB's group-key bit carries, pinned at session registration — and skips the prestage round trip outright. No extra RIB query is needed.
- **Live prestage bounded.** The remaining prestage send+reply is bounded by `RIB_REPLY_TIMEOUT` on the budget clock; elapsing degrades to `prestaged = false`. That is the contract the call site already documents ("Best-effort: on any error the transition stages the destination itself, exactly as before"), and the RIB keeps its existing abandoned-preparation handling: removal is memberless-only, and a prepared destination overtaken by a membership change is discarded at adoption.
- **Attention-time budgets for session hot-applies.** A new `await_with_readiness_budget` drives an untimed session round trip under a budget that accrues only while the actor is actually driving the step; the clock stops during readiness servicing. All four cohort session commands (forward import/export hot-applies, bail-path import/export restores) now use it with the unchanged 500 ms budget, through new untimed owned-sender `update_{import,export}_policy_via` transport variants (the bounded `_with` variants now wrap them). No deadline starts before its round trip is first polled.
- **Observability.** An `info!` for the prestage round trip (outcome, whether it was statically excluded, elapsed_ms) and a progress line every 64 applied peers (about five lines on a 320-peer fleet) carrying applied count and elapsed_ms, matching the existing field style of the partition/commit lines.

### Why per-send budgets instead of a concurrent fan-out

The cohort bail path is built on the single-command-in-flight invariant (ambiguous-reply reassert of the failing member, cross-side carry, newest-first unwind of acknowledged members). Per-send attention-scoped budgets remove both starvation mechanisms — readiness servicing and RIB dequeue latency can no longer consume a session command's deadline — without re-deriving that rollback argument for a batch. A concurrent fan-out would only compress wall time on a genuinely slow fleet, which is not the defect: the sessions were healthy; the actor was busy elsewhere.

## Tests

- `cohort_prestage_wait_is_bounded_when_rib_dequeue_lags` — the prestage answer sits behind ten virtual minutes of queued RIB work; the reload must complete in bounded time on the unprestaged path. Pre-fix: fails (`the prestage wait must be bounded ... 600s`).
- `readiness_servicing_is_not_charged_to_cohort_session_deadlines` — a continuous `ListPeers` flood is serviced while each session command is in flight; sessions acknowledge at 650 ms wall, of which almost none is actor attention. Pre-fix: fails with the production failure shape (`update_export_policy timed out after 500ms` on a healthy peer, with the rollback restore starved the same way).
- `per_client_best_cohort_skips_statically_dead_prestage` — the only RIB command in a per-client-best cohort dialogue is the batched replacement. Pre-fix: fails (`["prestage", "batch"]`).
- `cohort_hot_apply_budget_still_bounds_a_stalled_session` — a session that never acknowledges within the budget still fails the apply with the same timed-out error; passes pre- and post-fix (guards that the budget shape did not lose the bound).

Tripwires: `per_client_best.rs`, `update_groups_oracle.rs`, `tests/update_groups.rs` untouched.

## Smoke (F=0.5 IRR reload harness, rustbgpd-sighup cell)

`SMOKE=1 OVERLAP_FRACTION=0.5` run: exit code 0, cell PASS, receipt `status` = pass, `sessions_up 10/10`, `parse_errors 0`, `reload 1 completion_s: p50=0.01 p95=0.04 max=0.04 (n=10)`. The new instrumentation on the per-client-best fleet:

```
INFO partitioned resolved policy snapshot            total_targets=10 cohort_targets=10 remainder_targets=0
INFO cohort destination prestage round trip          cohort_targets=10 prestaged=false prestage_excluded=true elapsed_ms=0
INFO cohort session hot-apply progress               applied=10 cohort_targets=10 elapsed_ms=0
INFO committed partitioned resolved policy snapshot  total_targets=10 cohort_targets=10 remainder_targets=0 elapsed_ms=0
```

The prestage is skipped (`prestage_excluded=true`, no RIB round trip queued), and the setup section now reports where its time goes instead of running silent.

## Gates (exit-code)

- `cargo fmt --all -- --check` — 0
- `cargo clippy --workspace --all-targets -- -D warnings` — 0
- `cargo test --workspace` — 0 (7664 passed across 96 targets)
- `cargo doc --workspace --no-deps` — 0
- `python3 scripts/check-clippy-reasons.py` — 0
- `cargo check -p rustbgpd-rib --features bench-internals --benches` — 0
- `bash bench/smoke-benches.sh` — 0
