### PR TITLE
Iterate the staged side in scoped group derived-view queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,24 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The RIB actor no longer saturates under churn on per-client-best
+  fleets at high announcement overlap. Every distribution pass asked
+  each member's derived-view queries — the OTC-blocked view and the
+  export-policy-denial view — to scan the whole runner-up lane and
+  denial residue per member while filtering for the pass's few staged
+  prefixes: at the canonical IRR shape with half the table overlapped,
+  tens of millions of map visits per churn pass for an almost-always-
+  empty result, leaving the actor several times oversubscribed at
+  steady churn. The scoped queries now iterate whichever side is
+  smaller — probing the residue per staged prefix on the churn hot
+  path — keeping each pass at O(members × staged prefixes), with
+  resync-scale scopes keeping the residue scan; a test/bench-internals
+  visit-bound assertion trips any reintroduction of the per-member full
+  scan. On the same seam, an authoritative export-policy batch whose
+  caller already abandoned the reply (reload deadline lapse while the
+  command sat in the actor queue) is now skipped and logged instead of
+  applying long after the reload rolled back, which left RIB export
+  state diverged from the rolled-back session chains.
 - Fleet-wide policy reloads on high-overlap per-client-best fleets no
   longer halt partway through cohort setup with healthy sessions timed
   out and every applied peer rolled back. Two peer-manager actor waits

--- a/bench/scale/irrreload/run-irr-reload.sh
+++ b/bench/scale/irrreload/run-irr-reload.sh
@@ -407,7 +407,7 @@ seal_cell_evidence() {
         fi
         ;;
     rustbgpd-sighup | "$GROUPED_CELL")
-        evidence_files+=(config.toml topology.json topology.tsv metrics-1.prom metrics-2.prom metrics-3.prom pre-churn/ready pre-churn/ack received-view.tsv)
+        evidence_files+=(config.toml topology.json topology.tsv metrics-1.prom metrics-2.prom metrics-3.prom metrics-mid.prom pre-churn/ready pre-churn/ack received-view.tsv)
         ;;
     esac
     : >"$cdir/evidence.sha256.tmp"
@@ -816,7 +816,25 @@ run_cell() {
             rc=94
             break
         fi
-        if [ "$final_acked" != true ] && [ -e "$final_barrier/ready" ]; then
+        # Mid-reload scrape: one metrics capture inside the measured
+        # window, after the first reload trigger — the pre-churn scrapes
+        # are all pre-trigger, so ingest-depth/backpressure signals of a
+        # mid-window stall were previously invisible in the evidence.
+        # Same single-curl cost as one existing pre-churn capture.
+        if [ -n "$topology_mode" ] && [ ! -f "$cdir/metrics-mid.prom" ] &&
+            grep -q '^reload 1 .*wall_us=' "$cdir/reloadstall.log" 2>/dev/null; then
+            if curl -fsS --max-time 2 'http://127.0.0.1:9179/metrics' \
+                >"$cdir/metrics-mid.prom.tmp" 2>/dev/null; then
+                mv "$cdir/metrics-mid.prom.tmp" "$cdir/metrics-mid.prom"
+            else
+                rm -f "$cdir/metrics-mid.prom.tmp"
+            fi
+        fi
+        # The harness waits at the final barrier for this ack, so
+        # withholding it until the mid-window scrape landed keeps the
+        # window open for a retry on a failed capture.
+        if [ "$final_acked" != true ] && [ -e "$final_barrier/ready" ] &&
+            { [ -z "$topology_mode" ] || [ -f "$cdir/metrics-mid.prom" ]; }; then
             entries=$(find "$final_barrier" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)
             if [ "$entries" != ready ] || ! ack_final_evidence \
                 "$final_barrier" "$cdir" "$daemon_pid" "$daemon_start"; then

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -2955,6 +2955,18 @@ impl RibManager {
         replacements: Vec<PeerExportPolicyReplacement>,
         reply: tokio::sync::oneshot::Sender<Result<(), RibCommandError>>,
     ) {
+        // The caller's deadline may have lapsed while this command sat
+        // in the actor queue — by then the reload has rolled back its
+        // session chains, so applying the batch anyway would diverge
+        // RIB export state from the rolled-back sessions with nobody
+        // reading the outcome. An abandoned batch is skipped whole.
+        if reply.is_closed() {
+            info!(
+                replacements = replacements.len(),
+                "skipping abandoned authoritative export-policy batch: caller dropped the reply"
+            );
+            return;
+        }
         let _ = reply.send(self.apply_export_policy_replacements_synchronously(replacements));
     }
 
@@ -3325,6 +3337,7 @@ impl RibManager {
                 .map(|group| {
                     group
                         .policy_filtered_for_member(peer, &filtered_scope)
+                        .into_iter()
                         .collect()
                 })
                 .unwrap_or_default();

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -2621,6 +2621,98 @@ async fn rejected_policy_transition_batches_leave_observability_idle() {
     );
 }
 
+/// An authoritative replacement batch whose caller already abandoned
+/// the reply (its deadline lapsed while the command sat in the actor
+/// queue) is skipped whole — applying it would diverge RIB export
+/// state from the caller's rolled-back session chains: no chain is
+/// installed, nothing reaches the wire, and the skip is logged with
+/// the batch size.
+#[tokio::test]
+async fn abandoned_authoritative_replacement_batch_is_skipped() {
+    use std::collections::BTreeMap;
+    use std::sync::Arc as StdArc;
+
+    use tracing::field::{Field, Visit};
+    use tracing::span::{Attributes, Id, Record};
+    use tracing::{Event, Metadata, Subscriber};
+
+    #[derive(Default)]
+    struct Fields(BTreeMap<String, String>);
+    impl Visit for Fields {
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.0.insert(field.name().to_string(), value.to_string());
+        }
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            self.0
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+    }
+
+    struct Capture(StdArc<Mutex<Vec<Fields>>>);
+    impl Subscriber for Capture {
+        fn enabled(&self, _: &Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+        fn record(&self, _: &Id, _: &Record<'_>) {}
+        fn record_follows_from(&self, _: &Id, _: &Id) {}
+        fn event(&self, event: &Event<'_>) {
+            let mut fields = Fields::default();
+            event.record(&mut fields);
+            self.0.lock().unwrap().push(fields);
+        }
+        fn enter(&self, _: &Id) {}
+        fn exit(&self, _: &Id) {}
+    }
+
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer: IpAddr = "192.0.2.254".parse().unwrap();
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(1);
+    manager.outbound_peers.insert(peer, outbound_tx);
+
+    let deny_all = PolicyChain::new(vec![Policy {
+        entries: vec![],
+        default_action: PolicyAction::Deny,
+    }]);
+    let (reply, response) = oneshot::channel();
+    drop(response);
+    let captured = StdArc::new(Mutex::new(Vec::new()));
+    tracing::subscriber::with_default(Capture(StdArc::clone(&captured)), || {
+        manager.handle_replace_peer_export_policies_authoritatively(
+            vec![crate::update::PeerExportPolicyReplacement {
+                peer,
+                export_policy: Some(deny_all),
+            }],
+            reply,
+        );
+    });
+
+    assert!(
+        !manager.peer_export_policies.contains_key(&peer),
+        "abandoned batch must not install its chains"
+    );
+    assert!(
+        matches!(
+            outbound_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ),
+        "abandoned batch must not reach the wire"
+    );
+    let events = captured.lock().unwrap();
+    assert_eq!(events.len(), 1, "exactly the skip line is logged");
+    let fields = &events[0].0;
+    assert!(
+        fields.get("message").is_some_and(
+            |message| message.contains("skipping abandoned authoritative export-policy batch")
+        ),
+        "skip message missing: {fields:?}"
+    );
+    assert_eq!(fields.get("replacements").map(String::as_str), Some("1"));
+}
+
 #[tokio::test]
 async fn duplicate_pending_policy_transition_returns_internal_error_without_gauge_churn() {
     let (_tx, rx) = mpsc::channel(1);

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -1430,10 +1430,17 @@ pub(in crate::manager) struct GroupRibOut {
     pub(in crate::manager) vpn_tombstones: HashSet<VpnRouteKey>,
     pub(in crate::manager) members: HashSet<IpAddr>,
     pub(in crate::manager) dirty_members: HashSet<IpAddr>,
-    /// Persistent group-verdict export-policy denials (target stamped
-    /// with [`GROUP_FILTERED_PLACEHOLDER`], restamped per member) with
-    /// the denying policy's label for join-time counter replay.
-    policy_filtered: FxHashMap<PolicyFilteredRouteKey, Option<PolicyLabel>>,
+    /// Persistent group-verdict export-policy denials with the denying
+    /// policy's label for join-time counter replay, keyed by prefix so
+    /// a scoped per-member query probes the pass's staged set instead
+    /// of scanning the whole residue. The stored target is always
+    /// [`GROUP_FILTERED_PLACEHOLDER`] (every record funnels through
+    /// [`Self::record_policy_filtered`] from the group walk), so only
+    /// the varying key parts — `(source_peer, path_id)` — are kept;
+    /// readers restamp the concrete member. Inner maps are never left
+    /// empty ([`Self::record_policy_filtered`] removes whole prefixes),
+    /// so outer emptiness remains "no denials".
+    policy_filtered: FxHashMap<Prefix, FxHashMap<(IpAddr, u32), Option<PolicyLabel>>>,
     /// Terminal policy label per staged entry — join-time counter replay
     /// residue. Entries ONLY for labelled entries: an inline (unlabelled)
     /// entry stores nothing and its key is removed, so absent and
@@ -1644,18 +1651,53 @@ impl GroupRibOut {
         // `source(w)`. Together the two terms reproduce the pre-commit
         // backstop's per-member outcome, blocked(adv(m)), exactly.
         if self.per_client_best {
-            blocked.extend(
-                self.runner_up
-                    .iter()
-                    .filter(|(prefix, entry)| {
-                        entry.winner_source == member
-                            && prefixes.is_none_or(|prefixes| prefixes.contains(prefix))
-                            && super::distribution::otc_egress_blocked(
-                                &entry.route,
-                                self.local_role,
-                            )
-                    })
-                    .map(|(_, entry)| entry.route.clone()),
+            #[cfg(any(test, feature = "bench-internals"))]
+            let mut visits = 0_usize;
+            let lane_blocked = |entry: &RunnerUp| {
+                entry.winner_source == member
+                    && super::distribution::otc_egress_blocked(&entry.route, self.local_role)
+            };
+            match prefixes {
+                // The staged scope is the small side on the churn hot
+                // path: probe the lane per staged prefix instead of
+                // scanning the whole lane per member, keeping the pass
+                // at O(members × staged) rather than O(members × lane).
+                Some(prefixes) if prefixes.len() <= self.runner_up.len() => {
+                    for prefix in prefixes {
+                        #[cfg(any(test, feature = "bench-internals"))]
+                        {
+                            visits += 1;
+                        }
+                        if let Some(entry) = self.runner_up.get(prefix)
+                            && lane_blocked(entry)
+                        {
+                            blocked.push(entry.route.clone());
+                        }
+                    }
+                }
+                // Resync (`None`): the whole table IS the scope, so the
+                // lane scan is the small side by definition. A `Some`
+                // scope wider than the lane keeps the scan for the same
+                // reason.
+                _ => {
+                    for (prefix, entry) in &self.runner_up {
+                        #[cfg(any(test, feature = "bench-internals"))]
+                        {
+                            visits += 1;
+                        }
+                        if prefixes.is_none_or(|prefixes| prefixes.contains(prefix))
+                            && lane_blocked(entry)
+                        {
+                            blocked.push(entry.route.clone());
+                        }
+                    }
+                }
+            }
+            #[cfg(any(test, feature = "bench-internals"))]
+            assert_scoped_visit_bound(
+                visits,
+                prefixes.map_or(usize::MAX, HashSet::len),
+                self.runner_up.len(),
             );
         }
         blocked
@@ -2167,9 +2209,15 @@ impl GroupRibOut {
         staged: &HashSet<Prefix>,
         current: &[(PolicyFilteredRouteKey, Option<PolicyLabel>)],
     ) {
-        self.policy_filtered
-            .retain(|key, _| !staged.contains(&key.prefix));
-        self.policy_filtered.extend(current.iter().cloned());
+        for prefix in staged {
+            self.policy_filtered.remove(prefix);
+        }
+        for (key, label) in current {
+            self.policy_filtered
+                .entry(key.prefix)
+                .or_default()
+                .insert((key.source_peer, key.path_id), label.clone());
+        }
     }
 
     /// The member's view of the group-verdict denial set, restamped
@@ -2177,19 +2225,78 @@ impl GroupRibOut {
     /// pass's evaluation scope). The member's own-sourced denials are
     /// excluded — the per-peer path's split horizon returns before the
     /// policy evaluation for those.
-    pub(in crate::manager) fn policy_filtered_for_member<'a>(
-        &'a self,
+    ///
+    /// Iterates whichever side is smaller: on the churn hot path the
+    /// staged scope is a handful of prefixes against a residue that can
+    /// hold most of the table, so probing the residue per staged prefix
+    /// keeps each distribution pass at O(members × staged) instead of
+    /// O(members × residue) — the per-pass lane-scan shape that
+    /// saturated the actor at high overlap. A scope wider than the
+    /// residue (resync-scale callers pass the whole table) keeps the
+    /// residue scan, which is the small side by the same argument.
+    pub(in crate::manager) fn policy_filtered_for_member(
+        &self,
         member: IpAddr,
-        prefixes: &'a HashSet<Prefix>,
-    ) -> impl Iterator<Item = PolicyFilteredRouteKey> + 'a {
-        self.policy_filtered
-            .keys()
-            .filter(move |key| key.source_peer != member && prefixes.contains(&key.prefix))
-            .map(move |key| PolicyFilteredRouteKey {
-                target_peer: member,
-                ..*key
-            })
+        prefixes: &HashSet<Prefix>,
+    ) -> Vec<PolicyFilteredRouteKey> {
+        #[cfg(any(test, feature = "bench-internals"))]
+        let mut visits = 0_usize;
+        let mut restamped = Vec::new();
+        let mut collect =
+            |prefix: Prefix, denials: &FxHashMap<(IpAddr, u32), Option<PolicyLabel>>| {
+                restamped.extend(
+                    denials
+                        .keys()
+                        .filter(|(source_peer, _)| *source_peer != member)
+                        .map(|&(source_peer, path_id)| PolicyFilteredRouteKey {
+                            target_peer: member,
+                            source_peer,
+                            prefix,
+                            path_id,
+                        }),
+                );
+            };
+        if prefixes.len() <= self.policy_filtered.len() {
+            for prefix in prefixes {
+                #[cfg(any(test, feature = "bench-internals"))]
+                {
+                    visits += 1;
+                }
+                if let Some(denials) = self.policy_filtered.get(prefix) {
+                    collect(*prefix, denials);
+                }
+            }
+        } else {
+            for (prefix, denials) in &self.policy_filtered {
+                #[cfg(any(test, feature = "bench-internals"))]
+                {
+                    visits += 1;
+                }
+                if prefixes.contains(prefix) {
+                    collect(*prefix, denials);
+                }
+            }
+        }
+        #[cfg(any(test, feature = "bench-internals"))]
+        assert_scoped_visit_bound(visits, prefixes.len(), self.policy_filtered.len());
+        restamped
     }
+}
+
+/// Tripwire for the scoped derived-view queries: a query must touch at
+/// most `min(scope, residue)` slots of the residue it consults, keeping
+/// the per-pass emit cost O(members × staged prefixes). Restoring a
+/// per-member full scan of the lane or denial residue trips this in
+/// `cargo test` and in the bench-internals smoke instead of surfacing
+/// as actor saturation four hours into a campaign. Compiled into test
+/// and bench-internals builds only.
+#[cfg(any(test, feature = "bench-internals"))]
+fn assert_scoped_visit_bound(visits: usize, scope: usize, residue: usize) {
+    assert!(
+        visits <= scope.min(residue),
+        "scoped derived-view query visited {visits} residue slots; \
+         bound is min(scope {scope}, residue {residue})"
+    );
 }
 
 impl RibManager {
@@ -3366,11 +3473,16 @@ impl RibManager {
                 };
                 bump(&adv.policy_label.cloned(), PolicyAction::Permit);
             }
-            for (key, label) in &group.policy_filtered {
-                if key.source_peer == peer || !in_family(&key.prefix) {
+            for (prefix, denials) in &group.policy_filtered {
+                if !in_family(prefix) {
                     continue;
                 }
-                bump(label, PolicyAction::Deny);
+                for (&(source_peer, _), label) in denials {
+                    if source_peer == peer {
+                        continue;
+                    }
+                    bump(label, PolicyAction::Deny);
+                }
             }
             // VPN dimension (only staged for non-RTC groups): permits
             // from the staged labels, denies from the denial residue —
@@ -4397,8 +4509,10 @@ impl RibManager {
         for entry in destination.runner_up.values() {
             counters.record_lane(entry.winner_source, entry.policy_label.clone());
         }
-        for (key, label) in &destination.policy_filtered {
-            counters.record_deny(key.source_peer, label.clone());
+        for denials in destination.policy_filtered.values() {
+            for (&(source_peer, _), label) in denials {
+                counters.record_deny(source_peer, label.clone());
+            }
         }
         Some(BatchedTransitionInventory {
             announce: announce.into(),
@@ -5746,13 +5860,12 @@ mod tests {
             HashSet::from([OTHER1, OTHER2, MEMBER])
         );
         let group = m.group_ribs.get(&PCB_GID).unwrap();
-        let denied = PolicyFilteredRouteKey {
-            target_peer: GROUP_FILTERED_PLACEHOLDER,
-            source_peer: OTHER1,
-            prefix: p,
-            path_id: 0,
-        };
-        assert!(group.policy_filtered.contains_key(&denied));
+        assert!(
+            group
+                .policy_filtered
+                .get(&p)
+                .is_some_and(|denials| denials.contains_key(&(OTHER1, 0)))
+        );
     }
 
     /// A same-source remainder is stepped over WITHOUT evaluation: the
@@ -5903,16 +6016,11 @@ mod tests {
                 .and_then(|label| label.as_deref()),
             Some("tail")
         );
-        let denied = PolicyFilteredRouteKey {
-            target_peer: GROUP_FILTERED_PLACEHOLDER,
-            source_peer: OTHER2,
-            prefix: p,
-            path_id: 0,
-        };
         assert_eq!(
             group
                 .policy_filtered
-                .get(&denied)
+                .get(&p)
+                .and_then(|denials| denials.get(&(OTHER2, 0)))
                 .and_then(|label| label.as_deref()),
             Some("screen")
         );
@@ -9419,6 +9527,132 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![OTHER2]
         );
+    }
+
+    /// The scoped lane query returns exactly the unscoped result
+    /// restricted to the scope, whichever side it iterates (staged
+    /// scope smaller or larger than the lane), for every member shape
+    /// — including a prefix whose winner AND runner-up are both
+    /// blocked (residue arm + lane arm overlap). Every scoped call
+    /// also runs the `assert_scoped_visit_bound` tripwire: restoring
+    /// the per-member full lane scan makes the one-prefix scopes here
+    /// visit the whole lane and panics the bound.
+    #[test]
+    fn pcb_otc_blocked_scoped_query_matches_unscoped_across_scope_shapes() {
+        let mut m = staging_manager();
+        let staged: Vec<Prefix> = (1..=3).map(prefix).collect();
+        for &p in &staged {
+            seed(&mut m, cand(p, OTHER1, 300));
+            seed(&mut m, with_otc_attr(cand(p, OTHER2, 200)));
+        }
+        m.group_ribs
+            .insert(PCB_GID, per_client_best_customer_group());
+        stage_pcb(&mut m, &staged);
+        // Overlap cell: prefix 2's winner turns blocked too, so its
+        // residue entry (toward everyone but the source) coexists with
+        // its blocked lane entry (toward the winner source).
+        seed(&mut m, with_otc_attr(cand(prefix(2), OTHER1, 300)));
+        stage_pcb(&mut m, &[prefix(2)]);
+        let group = m.group_ribs.get(&PCB_GID).unwrap();
+        assert_eq!(group.runner_up.len(), 3);
+
+        let view = |routes: Vec<Route>| {
+            let mut view: Vec<(Prefix, IpAddr)> = routes
+                .iter()
+                .map(|route| (route.prefix, route.peer))
+                .collect();
+            view.sort_unstable();
+            view
+        };
+        for member in [MEMBER, OTHER1, OTHER2] {
+            let unscoped = view(group.otc_blocked_for_member(member, None));
+            // Probe branch: scopes smaller than the lane, hitting and
+            // missing entries.
+            for scope in [
+                HashSet::from([prefix(1)]),
+                HashSet::from([prefix(2)]),
+                HashSet::from([prefix(9)]),
+                HashSet::from([prefix(2), prefix(9)]),
+            ] {
+                let expected: Vec<(Prefix, IpAddr)> = unscoped
+                    .iter()
+                    .copied()
+                    .filter(|(p, _)| scope.contains(p))
+                    .collect();
+                assert_eq!(
+                    view(group.otc_blocked_for_member(member, Some(&scope))),
+                    expected,
+                    "member {member} scope {scope:?}"
+                );
+            }
+            // Scan branch: a scope wider than the lane covers it all.
+            let wide: HashSet<Prefix> = (1..=4).map(prefix).collect();
+            assert_eq!(
+                view(group.otc_blocked_for_member(member, Some(&wide))),
+                unscoped,
+                "member {member} wide scope"
+            );
+        }
+    }
+
+    /// The scoped denial query returns the member-restamped denial set
+    /// restricted to the scope, on both iteration sides, with the
+    /// member's own-sourced denials excluded — asserted against an
+    /// expectation built from the staging inputs, not the residue.
+    #[test]
+    fn pcb_policy_filtered_scoped_query_matches_full_residue() {
+        let mut m = staging_manager();
+        let staged: Vec<Prefix> = (1..=3).map(prefix).collect();
+        for &p in &staged {
+            seed(&mut m, cand(p, OTHER1, 300));
+            seed(&mut m, cand(p, OTHER2, 200));
+        }
+        m.group_ribs.insert(
+            PCB_GID,
+            per_client_best_group(Some(deny_sources_chain(&[OTHER1]))),
+        );
+        stage_pcb(&mut m, &staged);
+        let group = m.group_ribs.get(&PCB_GID).unwrap();
+        assert_eq!(group.policy_filtered.len(), 3);
+
+        let sorted = |mut keys: Vec<PolicyFilteredRouteKey>| {
+            keys.sort_unstable_by_key(|key| (key.prefix, key.source_peer, key.path_id));
+            keys
+        };
+        let wide: HashSet<Prefix> = (1..=4).map(prefix).collect();
+        let scopes = [
+            HashSet::from([prefix(1)]),
+            HashSet::from([prefix(9)]),
+            HashSet::from([prefix(1), prefix(9)]),
+            wide,
+        ];
+        // Every staged prefix denied OTHER1's candidate at path 0 —
+        // visible to every member except OTHER1 itself.
+        for member in [MEMBER, OTHER2] {
+            for scope in &scopes {
+                let expected: Vec<PolicyFilteredRouteKey> = staged
+                    .iter()
+                    .filter(|p| scope.contains(p))
+                    .map(|&p| PolicyFilteredRouteKey {
+                        target_peer: member,
+                        source_peer: OTHER1,
+                        prefix: p,
+                        path_id: 0,
+                    })
+                    .collect();
+                assert_eq!(
+                    sorted(group.policy_filtered_for_member(member, scope)),
+                    sorted(expected),
+                    "member {member} scope {scope:?}"
+                );
+            }
+        }
+        for scope in &scopes {
+            assert!(
+                group.policy_filtered_for_member(OTHER1, scope).is_empty(),
+                "own-sourced denials are excluded, scope {scope:?}"
+            );
+        }
     }
 
     /// Backstop parity through the REAL commit path: a delivered clean

--- a/docs/adr/0126-shared-group-per-client-best.md
+++ b/docs/adr/0126-shared-group-per-client-best.md
@@ -102,7 +102,11 @@ today's grouped pass. Each overlapped prefix adds one candidate evaluation.
 No term anywhere scales with member count: the receipt's steady-state
 plateau (per-client-best-only, F-scaling, upstream of the commit fan-out)
 belongs to the per-member candidate-multiplicity class this design removes
-structurally, and no phase of this design reintroduces it.
+structurally, and no phase of this design reintroduces it. The bound
+extends to the emit seam's per-member derived-view queries (the OTC and
+denial views): each probes the pass's staged set against the lane and
+denial residues rather than scanning a residue per member, keeping the
+per-pass cost O(members × staged prefixes).
 
 **Staging trigger:** the pass hands per-client-best groups the same
 widened changed-prefix set the ungrouped per-client-best path enumerates


### PR DESCRIPTION
## Summary

- **Per-pass lane scan inverted (both sites).** `GroupRibOut::otc_blocked_for_member` and `policy_filtered_for_member` scanned the whole runner-up lane / denial residue per member per distribution pass while filtering for the pass's staged prefixes — O(members × residue) per pass, oversubscribing the RIB actor several times over at high announcement overlap. Both scoped queries now iterate whichever side is smaller, probing the residue per staged prefix on the churn hot path (O(members × staged) per pass); resync-scale scopes (`None`, or a scope wider than the residue) keep the residue scan, which is the small side there by definition.
- **Denial residue re-keyed by prefix.** The stored `PolicyFilteredRouteKey` target was constant (`GROUP_FILTERED_PLACEHOLDER`), so the map is now `prefix → (source_peer, path_id) → label` — per-prefix probing with zero duplicated state, and `record_policy_filtered` drops its own per-pass full-map retain as a side effect.
- **Visit-bound tripwire.** A test/bench-internals-gated assertion bounds each scoped query's residue visits by `min(scope, residue)`; restoring the per-member full scan panics in `cargo test` and the bench-internals smoke instead of surfacing as actor saturation hours into a campaign.
- **Abandoned-batch guard.** `handle_replace_peer_export_policies_authoritatively` now skips (and logs, with the replacement count) a batch whose caller already dropped the reply — previously it applied long after the caller's reload rolled back, leaving RIB export state diverged from the rolled-back session chains.
- **Harness mid-window scrape.** `run-irr-reload.sh` captures one `metrics-mid.prom` after the first reload trigger (final-evidence ack withheld until it lands, so the capture cannot be raced out); the file joins the sealed cell evidence roster. `verify-receipt.py` needed no change — its per-cell roster is derived dynamically and cross-checked against `evidence.sha256`.
- ADR-0126 Decision 2's cost model now records the staged-side probe bound; one CHANGELOG Fixed entry.

## Testing

- New scoped-vs-unscoped equivalence tests for both queries across scope shapes (hit/miss/mixed/wider-than-residue, member == / != winner source, residue+lane overlap cell); existing pins unmodified.
- New abandoned-batch test: dropped reply → no chain installed, nothing on the wire, exactly the skip line logged.
- Red check: forcing the old always-scan shape trips the visit-bound assertion in both new tests (`visited 3 residue slots; bound is min(scope 1, residue 3)`).
- Full gate battery green: fmt, clippy `-D warnings`, workspace tests, doc, clippy-reasons, bench-internals check, bench smoke, verifier self-test.
- `SMOKE=1 OVERLAP_FRACTION=0.5` sighup cell: rc=0, `metrics-mid.prom` present post-trigger and sealed in `evidence.sha256`.