### PR TITLE
Release-prep documentation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   RIB/PeerManager→BmpManager channel. This path previously only warned;
   `bmp_source_drops_total` covers only the PeerSession→BmpManager path.
 
+- Structured phase timing for the SIGHUP policy-reload path (LAN-888). A
+  config load now logs one `config source loaded` line with `toml_parse_ms`,
+  `rpol_load_ms`, `dataset_bind_ms`, and `validate_ms` alongside the total
+  `elapsed_ms`; the once-per-file rpol set-table intern logs
+  `interned rpol set tables built` with `elapsed_ms` at the moment it fires;
+  and an rpol registry swap logs `resolved live peer policy chains` with
+  `elapsed_ms` for the per-peer chain re-resolution before the snapshot
+  apply fan-out. Together with the existing partitioned-snapshot and RIB
+  export-policy transition lines, the daemon log alone attributes where a
+  reload spends its time. Measurement only — no behavior change.
+
 ### Changed
 
 - ADR-0126 (shared-group per-client best-path) is Accepted: the Phase 4
@@ -170,6 +181,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   conformant directly connected peer always emits 255; a session that
   depended on the previous one-hop-off leniency will no longer
   establish.
+
+- SIGHUP reloads skip the outbound prefix-limit RIB preflight when the
+  configured maxima are unchanged. The preflight is two awaited
+  round-trips through the RIB manager's update channel — FIFO behind
+  whatever redistribution backlog the previous reload left in flight,
+  tens of seconds at IRR scale — and it only ever rejects a lowering
+  below current advertised usage, so an unchanged limit set can never be
+  rejected: an rpol-content-only reload now never touches the RIB before
+  the policy sync. The previously silent stretches of that window
+  (registry clone, dispatch moment, peer-manager command receipt,
+  config-snapshot clone) are also stamped with `elapsed_ms` log lines.
 
 ### Fixed
 
@@ -375,21 +397,41 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   instead of fencing the actor until an invalidation event — previously
   nothing could trigger the fallback while sessions stayed healthy. Transition phase entries and per-member probe
   decisions are now logged at debug level.
+- Policy `peer.address` / `peer.asn` / `peer.group` `!=` matchers no
+  longer match routes with absent peer context. `!=` lowered to a
+  negated `==` match, and `==` evaluates false when the compared peer
+  field is unset — so the negation matched every such route:
+  `peer.group` is routinely unset for ungrouped peers, and policy
+  explain dry-runs may carry no peer identity at all. `!=` now lowers to
+  a dedicated matcher that matches only when the peer field is present
+  and outside the compared set, mirroring the `==` absence rule, and
+  policy explain renders it as its own node. Update-group
+  disqualification for peer-context policies is unchanged.
+- Two EVPN convergence defects. A Type 5 (IP-prefix) withdraw the RIB
+  applied but whose reply was lost left the route stuck in the
+  originator's tracking map: every later reconcile retried the withdraw,
+  got NotFound, and failed forever — in the key-change path this also
+  blocked re-origination of a redefined IP-VRF's new route. NotFound now
+  resolves as withdrawn (absence is the withdraw's goal) on the single
+  path every withdraw site routes through, matching the existing Type 2
+  and IMET handling. Separately, IMET inject/withdraw RIB acks were
+  awaited unbounded while every EVPN runtime converge path holds the
+  IMET controller mutex, so a wedged RIB actor locked all subsequent
+  EVPN runtime converges out until restart; both operations now bound
+  the wait at the standard RIB ack timeout and report the converge as
+  failed instead of claiming success against a RIB that never answered.
+- FIB `ReplaceTables` no longer rewrites the owned-state file when the
+  reconcile bailed before the apply phase: that cancel path never
+  touches owned state, so the persist only stamped a plan signature
+  nothing had acted on. The orphan-revert case keeps its repair persist.
+- RPKI incremental VRP withdraws are no longer quadratic: per-server VRP
+  tables are stored as hash sets instead of vectors, making an
+  incremental withdraw O(withdrawn records) instead of
+  O(withdrawn × table size) against a full-table cache.
 
 ## [0.63.0] — 2026-08-04
 
 ### Added
-
-- Structured phase timing for the SIGHUP policy-reload path (LAN-888). A
-  config load now logs one `config source loaded` line with `toml_parse_ms`,
-  `rpol_load_ms`, `dataset_bind_ms`, and `validate_ms` alongside the total
-  `elapsed_ms`; the once-per-file rpol set-table intern logs
-  `interned rpol set tables built` with `elapsed_ms` at the moment it fires;
-  and an rpol registry swap logs `resolved live peer policy chains` with
-  `elapsed_ms` for the per-peer chain re-resolution before the snapshot
-  apply fan-out. Together with the existing partitioned-snapshot and RIB
-  export-policy transition lines, the daemon log alone attributes where a
-  reload spends its time. Measurement only — no behavior change.
 
 - ASPA-invalid policy rejections retain the first proven `NotProviderPlus` hop;
   cache refresh emits one bounded top-eight summary without changing routing.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -805,7 +805,7 @@ complete atomic block. There is no probe or automatic legacy fallback.
 | `md5_password`         | string   | no       | --      | TCP MD5 authentication password (RFC 2385, Linux only) |
 | `tcp_ao`               | table or array | no | -- | Ordered TCP-AO keyring for static neighbors (RFC 5925; Linux; append a non-preferred successor, then select it in a later observation-gated SIGHUP generation) |
 | `bfd`                  | table    | no       | --      | Single-hop BFD attachment referencing a `[[bfd_profiles]]` entry (RFC 5880/5881/5882; static neighbors only, restart-required edits) |
-| `ttl_security`         | bool     | no       | false   | Enable GTSM / TTL security (RFC 5082, Linux only) |
+| `ttl_security`         | bool     | no       | false   | Enable GTSM / TTL security (RFC 5082, Linux only). Strict: inbound packets must arrive with TTL/Hop-Limit exactly 255 (`IP_MINTTL` / `IPV6_MINHOPCOUNT`, RFC 5082 §3.2) and outbound packets are sent with 255. Earlier releases accepted 254; a peer that depended on that leniency will not establish |
 | `families`             | [string] | no       | (auto)  | Address families to negotiate (see below)        |
 | `required_families`    | [string] | no       | `[]`    | Families that must appear in the final negotiated intersection; must be a subset of effective `families` |
 | `graceful_restart`     | bool     | no       | true    | Enable Graceful Restart receiving speaker (RFC 4724) |

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1003,6 +1003,16 @@ query with a new live watch.
 |--------|-------------------|
 | `gnmi_dialout_connected{target}` | 1 while the dial-out Publish stream to this `[gnmi_dialout]` target is established, 0 while disconnected/retrying. Refreshed on both transitions; the series exists (at 0) from startup even when the collector is down, and is reaped when the target is removed from config (SIGHUP) |
 
+### BMP
+
+| Metric | What it tells you |
+|--------|-------------------|
+| `bmp_loc_rib_source_drops_total{event,reason}` | RFC 9069 Loc-RIB events dropped before they reached the BMP manager, at the internal RIB/PeerManager→BmpManager channel. `event` is `route_monitoring` (a Loc-RIB route install/withdraw that will never reach any collector's Loc-RIB view) or `stats` (one periodic Loc-RIB statistics report skipped; the next tick reports current totals). `reason` is `channel_full` (the BMP manager is not draining as fast as RIB churn produces events) or `channel_closed` (BMP teardown). Both label sets are bounded; the series is process-global, not per-collector. A dropped `route_monitoring` event silently diverges every connected Loc-RIB collector until its next reconnect-triggered table dump, so alert on any sustained `channel_full` increase and correlate with the per-collector `bmp_collector_drops_total` and the `bmp_loc_rib_dump_live_buffer_*` gauges to find the slow consumer; each increment also emits a warn log line |
+
+The sibling `bmp_source_drops_total{peer,reason}` counts the same kind of
+loss on the per-peer PeerSession→BmpManager path (RFC 7854 Adj-RIB
+monitoring) with the same `reason` vocabulary.
+
 ### Durable Event Cursor (ADR-0072)
 
 The durable outbox (`SubscribeFromEvent` RPC, CLI

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -134,6 +134,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0123](0123-aspa-v27-mitigation-and-retention.md) | ASPA draft-v27 mitigation requires lossless retention | Proposed (behavior activation NO-GO until retention gates pass) | 2026-08-03 |
 | [0124](0124-bounded-config-history-retention.md) | Bounded config-history retention for oversized snapshots | Proposed (owner decisions recorded; implementation pending) | 2026-08-04 |
 | [0125](0125-v1-stability-contract.md) | v1.0 stability contract | Proposed (decision draft for the project owner; nothing freezes until Accepted) | 2026-08-04 |
+| [0126](0126-shared-group-per-client-best.md) | Shared-group per-client best-path — path-hiding mitigation inside update groups | Accepted | 2026-08-05 |
 
 ## Template
 


### PR DESCRIPTION
Release-prep corrections across the CHANGELOG and docs.

**CHANGELOG**
- Add five missing `[Unreleased]` entries: the `peer.address`/`peer.asn`/`peer.group` `!=` absent-context matcher fix; the two EVPN convergence fixes (Type 5 NotFound withdraw resolution, bounded IMET RIB acks); the unchanged-maxima outbound prefix-limit preflight skip on SIGHUP; the FIB `ReplaceTables` cancel-path owned-state persist skip; and the RPKI incremental-withdraw complexity fix.
- Move the structured reload phase-timing entry from `[0.63.0]` to `[Unreleased]`: its commit is not an ancestor of the `v0.63.0` tag.

**docs**
- `docs/adr/README.md`: add the ADR-0126 index row (Accepted).
- `docs/OPERATIONS.md`: document `bmp_loc_rib_source_drops_total` in the key-metrics tables — labels, when it moves, and the operator response — with a pointer to the sibling `bmp_source_drops_total` path.
- `docs/CONFIGURATION.md`: the `ttl_security` field doc now states the strict inbound TTL/Hop-Limit 255 enforcement (earlier releases accepted 254; peers depending on the leniency will not establish).

Docs-only; no code changes. Gates: `cargo fmt --all -- --check`, `cargo doc --workspace --no-deps`, and `scripts/check-v1-stable-surface.py` all pass.