### PR TITLE
Bump rustbgpd-wire to 0.17.0 for the fallible EVPN NLRI encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,7 +335,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   back as EAD-per-ES — an identity flip), and synthesize a zero-ESI
   Type 4 fallback that the decoder itself rejects as malformed. The
   first three are now hard encode errors — **breaking**:
-  `rustbgpd-wire`'s `encode_evpn_nlri` now returns
+  `rustbgpd-wire` 0.16.2 → 0.17.0, `encode_evpn_nlri` now returns
   `Result<(), EncodeError>` — and the Type 4 fallback is skipped with a
   warning instead of emitted.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ categories = ["network-programming"]
 
 [workspace.dependencies]
 # Internal crates
-rustbgpd-wire = { path = "crates/wire", version = "0.16.2" }
+rustbgpd-wire = { path = "crates/wire", version = "0.17.0" }
 rustbgpd-bfd = { path = "crates/bfd", version = "0.63.0" }
 rustbgpd-fsm = { path = "crates/fsm", version = "0.3.1" }
 rustbgpd-transport = { path = "crates/transport", version = "0.63.0" }

--- a/bench/scale/config-persistence/Cargo.lock
+++ b/bench/scale/config-persistence/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "thiserror",

--- a/bench/scale/enhanced-route-refresh/Cargo.lock
+++ b/bench/scale/enhanced-route-refresh/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "thiserror",

--- a/bench/scale/outbound-prefix-limit-scale/Cargo.lock
+++ b/bench/scale/outbound-prefix-limit-scale/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "thiserror",

--- a/bench/scale/outbound-prefix-limits/Cargo.lock
+++ b/bench/scale/outbound-prefix-limits/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "thiserror",

--- a/bench/scale/reloadstall/Cargo.lock
+++ b/bench/scale/reloadstall/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "thiserror",

--- a/bench/scale/rrharness/Cargo.lock
+++ b/bench/scale/rrharness/Cargo.lock
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "thiserror 2.0.18",

--- a/bench/scale/rrtransport/Cargo.lock
+++ b/bench/scale/rrtransport/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "thiserror 2.0.19",

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbgpd-wire"
-version = "0.16.2"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -68,6 +68,30 @@ analyzers, test harnesses, MRT readers, etc.
 | draft-abraitis-idr-addpath-paths-limit-04 | Experimental Paths-Limit capability (`PathsLimitFamily`, IANA-assigned capability code 76). The draft is expired and archived; interoperability and behavior remain experimental |
 | 10005 | Link Bandwidth Extended Community receiver subset: decode exact transitive/non-transitive types 0x00/0x40, subtype 0x04, as raw AS + IEEE-754 bytes/second; the constructor remains non-transitive type 0x40 |
 
+### 0.17.0 compatibility note
+
+`rustbgpd-wire` 0.17.0 is a **breaking release**: `encode_evpn_nlri` now
+returns `Result<(), EncodeError>` instead of `()`. Direct callers must handle
+or propagate the result; on `Err` the output buffer may hold a partial
+encoding and must be discarded.
+
+The fallibility is not decorative. Three EVPN wire invariants that the
+decoder discriminates on were previously enforced only by debug assertions —
+release builds silently encoded substitute bytes (an `UNSPECIFIED` gateway,
+a pinned `MAX_ET` tag) that could round-trip as a *different* route. They now
+refuse to encode with `EncodeError::ValueOutOfRange`:
+
+- an EVPN Type 5 route whose gateway address family differs from its prefix
+  family (RFC 9136 §3),
+- an EAD-per-ES route whose ethernet tag is not `MAX_ET` (RFC 7432 §7.1),
+- an EAD-per-EVI route whose ethernet tag is `MAX_ET`.
+
+Indirect encode paths inherit the change: `MP_REACH_NLRI` / `MP_UNREACH_NLRI`
+encoding via `UpdateMessage::try_build` or `encode_message` now returns these
+errors for EVPN route lists that previously emitted silently altered wire
+bytes. Consumers that never encode EVPN NLRI are unaffected beyond the
+signature change at direct call sites.
+
 ### 0.16.0 compatibility note
 
 `rustbgpd-wire` 0.16.0 keeps the public API additive, but **decode acceptance

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -153,7 +153,7 @@ This is the "MRT reader / monitor / analyzer" consumer. Links only
 ```toml
 # Cargo.toml
 [dependencies]
-rustbgpd-wire = "0.16.2"
+rustbgpd-wire = "0.17.0"
 bytes = "1"
 ```
 
@@ -213,7 +213,7 @@ intentional split (ADR-0002: inherent methods, no I/O in the FSM).
 ```toml
 # Cargo.toml
 [dependencies]
-rustbgpd-wire = "0.16.2"
+rustbgpd-wire = "0.17.0"
 rustbgpd-fsm = "0.3.1"
 bytes = "1"
 tokio = { version = "1", features = ["net", "io-util", "time", "rt"] }
@@ -312,16 +312,27 @@ once that crate is published.
 **Status: `wire` → `fsm` are published; `rpki` is next; `rib`, `bmp`, `mrt`,
 and `policy` are later.**
 
-1. **`rustbgpd-wire` (published as `0.16.2`).** This is the
+1. **`rustbgpd-wire` (published as `0.17.0`).** This is the
    foundation — dependent crate versions cannot publish before their wire
    dependency exists on crates.io. `0.15.0` brought `Capability::PathsLimit`
    with its `PathsLimitFamily` entry type (experimental capability code 76),
    the `Ord` implementation on `EvpnRouteKey`, and `#[non_exhaustive]` across
    the registry-tracking enums. The `0.16.0` release is additive at the API
    level with six binary decode-acceptance changes plus the separate additive
-   Route Distinguisher text-parser change described in §2.3. `0.16.2` is a
-   documentation/rustdoc-only release correcting RFC 7606 retained-attribute
-   wording; it has no library-code, public-API, or decode-behavior change.
+   Route Distinguisher text-parser change described in §2.3. `0.17.0` is a
+   **breaking release**: `encode_evpn_nlri` now returns
+   `Result<(), EncodeError>` instead of `()`. Direct callers must handle or
+   propagate the result, and on `Err` the output buffer may hold a partial
+   encoding and must be discarded. Three EVPN wire invariants that release
+   builds previously papered over (encoding substitute bytes) now refuse to
+   encode with `EncodeError::ValueOutOfRange`: a Type 5 gateway whose address
+   family differs from its prefix, an EAD-per-ES route whose ethernet tag is
+   not `MAX_ET`, and an EAD-per-EVI route whose ethernet tag is `MAX_ET`.
+   Indirect encode paths (`MP_REACH_NLRI`/`MP_UNREACH_NLRI` via
+   `UpdateMessage::try_build` / `encode_message`) surface the same routes as
+   errors where they previously emitted silently altered wire bytes.
+   `crates/wire/README.md` carries the itemized note under "0.17.0
+   compatibility note".
 
 2. **`rustbgpd-fsm` (published as `0.3.1`).** The `0.3.1` release keeps the
    public API backward-compatible: `PeerConfig` gains
@@ -417,7 +428,7 @@ To be the de facto Rust BGP codec, the concrete gaps:
 
 ## 7. Published-crate release boundary
 
-`rustbgpd-wire 0.16.2` and `rustbgpd-fsm 0.3.1` are published and are the
+`rustbgpd-wire 0.17.0` and `rustbgpd-fsm 0.3.1` are published and are the
 versions the §3 dependency examples name. The ordering rules that govern every
 future publish are:
 

--- a/scripts/test_check_embedding_versions.py
+++ b/scripts/test_check_embedding_versions.py
@@ -38,7 +38,7 @@ class EmbeddingVersionContractTests(unittest.TestCase):
 
     def test_each_wire_snippet_is_guarded(self) -> None:
         """Red if either wire dependency example drifts to 0.15.0."""
-        old = 'rustbgpd-wire = "0.16.2"'
+        old = 'rustbgpd-wire = "0.17.0"'
         for occurrence in (0, 1):
             with self.subTest(occurrence=occurrence):
                 self.assert_fails(
@@ -55,7 +55,7 @@ class EmbeddingVersionContractTests(unittest.TestCase):
 
     def test_publish_statuses_are_guarded(self) -> None:
         """Red if either numbered publish heading names an old version."""
-        mutations = (("wire", "0.16.2", "0.16.1"), ("fsm", "0.3.1", "0.3.0"))
+        mutations = (("wire", "0.17.0", "0.16.2"), ("fsm", "0.3.1", "0.3.0"))
         for package, current, old in mutations:
             with self.subTest(package=package):
                 self.assert_fails(


### PR DESCRIPTION
## What

Version sweep for the next `rustbgpd-wire` publish: 0.16.2 -> 0.17.0. No publish happens here; the workspace package version is untouched.

## Why

`encode_evpn_nlri` became fallible after 0.16.2 shipped: it returns `Result<(), EncodeError>` instead of `()`. Three EVPN wire invariants the decoder discriminates on now refuse to encode with `EncodeError::ValueOutOfRange` where release builds previously emitted substitute bytes:

- a Type 5 gateway whose address family differs from its prefix (RFC 9136 §3),
- an EAD-per-ES route whose ethernet tag is not `MAX_ET` (RFC 7432 §7.1),
- an EAD-per-EVI route whose ethernet tag is `MAX_ET`.

That is a source-breaking public API change, so the 0.x rule makes the next publish 0.17.0.

## Sweep contents

- `crates/wire/Cargo.toml` — version 0.17.0.
- Root `Cargo.toml` — workspace dependency line moved to 0.17.0 (`rustbgpd-fsm` inherits it via `rustbgpd-wire.workspace = true`; no separate fsm manifest edit).
- `docs/EMBEDDING.md` — §3 dependency snippets, §4 publish status, and the §7 boundary moved to 0.17.0; the §4 wire entry now describes the breaking transition, the buffer-discard rule on `Err`, and the indirect `MP_REACH_NLRI`/`MP_UNREACH_NLRI` encode paths.
- `crates/wire/README.md` — new "0.17.0 compatibility note" itemizing the fallible encoder and the three invariants; RFC table and key-types list reconciled against the source (RFCs 5398/6996/7947/9107 appear in source only incidentally and stay out of the table; no usage example calls `encode_evpn_nlri`).
- `scripts/test_check_embedding_versions.py` — expected versions updated.
- Workspace `Cargo.lock` and the seven `bench/scale/*` standalone harness lockfiles refreshed.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps` — all exit 0.
- `scripts/check-clippy-reasons.py`, `scripts/check-v1-stable-surface.py` — exit 0.
- `python3 -m unittest scripts/test_check_embedding_versions.py` + both embedding checkers — exit 0.
- All seven standalone harnesses: `cargo test --manifest-path <dir>/Cargo.toml --locked` — exit 0.
- `cargo publish -p rustbgpd-wire --dry-run --allow-dirty` — packages, verifies, and aborts at upload as expected.

## Release-time note

The published `rustbgpd-fsm 0.3.1` depends on wire `^0.16` and exposes wire types in its public API. Once wire 0.17.0 is on crates.io, a consumer pairing it with fsm 0.3.1 would resolve two wire versions, so fsm needs its own publish (with the wire requirement moved to `^0.17`) in the same release window. That decision and version choice belong to release day, not this sweep.
