### PR TITLE
fix(transport): set listener TTL for passive GTSM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `/usr/share/doc/rustbgpd/monitoring/` after a `.deb`/`.rpm` install; the
   canonical dashboard and rule files remain the packaging sources (LAN-928).
 
+### Fixed
+
+- Passive-open GTSM sessions now send the listener's SYN-ACK with IPv4 TTL or
+  IPv6 Hop Limit 255. Previously the peer-specific receive threshold was
+  installed only after `accept()`, so conformant peers could reject the
+  otherwise authenticated handshake before rustbgpd saw the connection. Live
+  GTSM policy additions update the existing listener before any MD5 inventory
+  mutation (LAN-935).
+
 ## [0.64.0] — 2026-08-08
 
 ### Security

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -64,5 +64,5 @@ pub use session::import_decision_cache::{
 // binary layers (PeerManagerCommand reply, PolicyService mapping).
 pub use session::rejected_routes::{RejectedRouteEntry, RejectedRoutesReply};
 pub use socket_opts::{
-    TcpAoInfoSnapshot, TcpAoKeyState, TcpAoSupport, probe_tcp_ao_support, set_tcp_md5sig,
+    TcpAoInfoSnapshot, TcpAoKeyState, TcpAoSupport, probe_tcp_ao_support, set_gtsm, set_tcp_md5sig,
 };

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -1900,6 +1900,15 @@ impl BgpListener {
         // its family's desired subset. A key whose family has no bound
         // socket is unreachable by definition (that family accepts no
         // inbound connections at all) and is skipped.
+        // Raise every required outbound hop value before mutating any MD5
+        // inventory, so an option failure leaves the current keys intact.
+        for family in &self.listeners {
+            enable_listener_gtsm_outbound(
+                &socket2::SockRef::from(&family.socket),
+                family.is_v4,
+                &ttl_security,
+            )?;
+        }
         for family in &self.listeners {
             let current: Vec<Md5ListenerKey> = self
                 .md5_keys
@@ -2711,6 +2720,7 @@ where
         install_listener_md5_key(&socket, key)?;
         debug!(peer = %key.peer, prefix_len = key.prefix_len, "TCP MD5 listener key configured");
     }
+    enable_listener_gtsm_outbound(&socket, addr.is_ipv4(), &options.ttl_security)?;
     socket.listen(DEFAULT_LISTEN_BACKLOG)?;
     socket.set_nonblocking(true)?;
 
@@ -2782,6 +2792,29 @@ fn apply_md5_inventory(
         }
     }
     Ok(())
+}
+
+fn enable_listener_gtsm_outbound(
+    socket: &Socket,
+    is_v4: bool,
+    policies: &[TtlSecurityListenerPolicy],
+) -> std::io::Result<()> {
+    if listener_gtsm_outbound_required(is_v4, policies) {
+        crate::socket_opts::set_gtsm_outbound(socket, is_v4).map_err(|error| {
+            let family = if is_v4 { "IPv4" } else { "IPv6" };
+            std::io::Error::new(
+                error.kind(),
+                format!("failed to set {family} listener outbound GTSM TTL/Hop Limit 255: {error}"),
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn listener_gtsm_outbound_required(is_v4: bool, policies: &[TtlSecurityListenerPolicy]) -> bool {
+    policies
+        .iter()
+        .any(|policy| policy.enforce && policy.peer.is_ipv4() == is_v4)
 }
 
 fn validate_listener_tcp_ao_capacity(options: &ListenerSocketOptions) -> std::io::Result<()> {
@@ -2877,6 +2910,77 @@ mod tests {
             accept_error_class(&std::io::Error::other("synthetic")),
             AcceptErrorClass::Transient
         );
+    }
+
+    #[test]
+    fn listener_gtsm_outbound_policy_is_enforcing_and_family_scoped() {
+        let policies = [
+            TtlSecurityListenerPolicy {
+                owner: TcpAoListenerOwnerKind::Static,
+                peer: "192.0.2.1".parse().unwrap(),
+                prefix_len: 32,
+                enforce: false,
+            },
+            TtlSecurityListenerPolicy {
+                owner: TcpAoListenerOwnerKind::Dynamic,
+                peer: "2001:db8::".parse().unwrap(),
+                prefix_len: 32,
+                enforce: true,
+            },
+        ];
+
+        assert!(!listener_gtsm_outbound_required(true, &policies));
+        assert!(listener_gtsm_outbound_required(false, &policies));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn gtsm_option_failure_precedes_all_live_md5_mutation() {
+        let options = ListenerSocketOptions::default();
+        let v4_socket = bind_socket2_listener("127.0.0.1:0".parse().unwrap(), &options).unwrap();
+        let v4_addr = v4_socket.local_addr().unwrap();
+        let wrong_family_socket =
+            bind_socket2_listener("127.0.0.1:0".parse().unwrap(), &options).unwrap();
+        let (accept_tx, _accept_rx) = mpsc::channel(1);
+        let mut listener = BgpListener::from_sockets(
+            vec![
+                FamilyListener {
+                    is_v4: true,
+                    socket: v4_socket,
+                },
+                FamilyListener {
+                    is_v4: false,
+                    socket: wrong_family_socket,
+                },
+            ],
+            accept_tx,
+            options,
+        );
+
+        let error = listener
+            .replace_inbound_auth(
+                vec![Md5ListenerKey {
+                    peer: "127.0.0.1".parse().unwrap(),
+                    prefix_len: 32,
+                    password: "must-not-be-installed".into(),
+                }],
+                vec![TtlSecurityListenerPolicy {
+                    owner: TcpAoListenerOwnerKind::Static,
+                    peer: "::1".parse().unwrap(),
+                    prefix_len: 128,
+                    enforce: true,
+                }],
+            )
+            .expect_err("IPv6 hop-limit option on an IPv4 test socket must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to set IPv6 listener outbound GTSM TTL/Hop Limit 255"),
+            "unexpected error: {error}"
+        );
+
+        std::net::TcpStream::connect_timeout(&v4_addr, std::time::Duration::from_secs(1))
+            .expect("GTSM option failure must leave the IPv4 listener without the desired MD5 key");
     }
 
     fn tcp_ao_config() -> TcpAoKeyring {

--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -3191,6 +3191,11 @@ fn read_sockaddr(storage: &libc::sockaddr_storage) -> io::Result<IpAddr> {
 ///
 /// Sets GTSM for the remote address family: accept only directly connected
 /// packets and send with TTL/Hop-Limit 255.
+///
+/// # Errors
+///
+/// Returns an error if the platform does not support GTSM or a required
+/// socket option cannot be installed.
 #[cfg(target_os = "linux")]
 #[allow(
     unsafe_code,
@@ -3239,10 +3244,7 @@ fn set_gtsm_v4(socket: &Socket) -> io::Result<()> {
         return Err(io::Error::last_os_error());
     }
 
-    // socket2 0.6 renamed `set_ttl` → `set_ttl_v4` for the IPv4 path.
-    // GTSM (RFC 5082) on this socket is IPv4-only, so the IPv4-specific
-    // setter is the correct call.
-    socket.set_ttl_v4(255)?;
+    set_gtsm_outbound(socket, true)?;
 
     Ok(())
 }
@@ -3270,11 +3272,29 @@ fn set_gtsm_v6(socket: &Socket) -> io::Result<()> {
     if ret < 0 {
         return Err(io::Error::last_os_error());
     }
-    socket.set_unicast_hops_v6(255)?;
+    set_gtsm_outbound(socket, false)?;
     Ok(())
 }
 
-/// Stub for non-Linux platforms.
+/// Set the outbound TTL/Hop Limit required by GTSM for one socket family.
+///
+/// Listening sockets need this before `listen(2)` so the kernel's passive-open
+/// SYN-ACK is emitted with 255; accepted children get the inbound minimum from
+/// [`set_gtsm`] once the peer-specific policy has been resolved.
+pub(crate) fn set_gtsm_outbound(socket: &Socket, is_v4: bool) -> io::Result<()> {
+    if is_v4 {
+        // socket2 0.6 renamed `set_ttl` → `set_ttl_v4` for IPv4.
+        socket.set_ttl_v4(255)
+    } else {
+        socket.set_unicast_hops_v6(255)
+    }
+}
+
+/// Report that GTSM receive enforcement is unavailable on non-Linux systems.
+///
+/// # Errors
+///
+/// Always returns [`io::ErrorKind::Unsupported`].
 #[cfg(not(target_os = "linux"))]
 pub fn set_gtsm(_socket: &Socket, _remote: SocketAddr) -> io::Result<()> {
     Err(io::Error::new(

--- a/crates/transport/tests/listener.rs
+++ b/crates/transport/tests/listener.rs
@@ -12,7 +12,7 @@ mod inbound_auth {
 
     use rustbgpd_transport::{
         AcceptedConnection, BgpListener, ListenerSocketOptions, Md5ListenerKey,
-        TcpAoListenerOwnerKind, TtlSecurityListenerPolicy, set_tcp_md5sig,
+        TcpAoListenerOwnerKind, TtlSecurityListenerPolicy, set_gtsm, set_tcp_md5sig,
     };
     use tokio::io::AsyncReadExt;
     use tokio::sync::mpsc;
@@ -107,6 +107,32 @@ mod inbound_auth {
         })
         .await
         .expect("client connect task")
+    }
+
+    /// Connect with full GTSM enabled before the handshake. This makes the
+    /// client send its SYN with TTL/Hop-Limit 255 and reject a passive-open
+    /// SYN-ACK unless the listening socket also emitted it with 255.
+    async fn spawn_gtsm_connect(
+        server: SocketAddr,
+        source: Option<IpAddr>,
+    ) -> std::io::Result<std::net::TcpStream> {
+        tokio::task::spawn_blocking(move || {
+            let domain = if server.is_ipv4() {
+                socket2::Domain::IPV4
+            } else {
+                socket2::Domain::IPV6
+            };
+            let socket =
+                socket2::Socket::new(domain, socket2::Type::STREAM, Some(socket2::Protocol::TCP))?;
+            set_gtsm(&socket, server)?;
+            if let Some(source) = source {
+                socket.bind(&SocketAddr::new(source, 0).into())?;
+            }
+            socket.connect_timeout(&server.into(), CONNECT_TIMEOUT)?;
+            Ok(socket.into())
+        })
+        .await
+        .expect("GTSM client connect task")
     }
 
     async fn expect_accept(rx: &mut mpsc::Receiver<AcceptedConnection>) -> AcceptedConnection {
@@ -258,9 +284,9 @@ mod inbound_auth {
         let accepted = expect_accept(&mut accept_rx).await;
         expect_data_blocked(low_ttl, accepted).await;
 
-        let compliant = spawn_connect(addr, None, None, Some(255))
+        let compliant = spawn_gtsm_connect(addr, None)
             .await
-            .expect("TCP handshake for TTL-255 client");
+            .expect("GTSM TCP handshake with TTL-255 SYN-ACK");
         let accepted = expect_accept(&mut accept_rx).await;
         expect_data_flows(compliant, accepted).await;
     }
@@ -360,6 +386,44 @@ mod inbound_auth {
         expect_data_flows(plaintext, accepted).await;
     }
 
+    /// Reload-time GTSM addition must raise the already-listening socket's
+    /// outbound TTL before the next passive open. The GTSM client enforces
+    /// TTL 255 on the SYN-ACK, so this handshake fails against the kernel's
+    /// ordinary listener default even though accepted-child setup is correct.
+    #[tokio::test]
+    async fn replace_inbound_auth_enables_passive_open_gtsm() {
+        let (accept_tx, mut accept_rx) = mpsc::channel(4);
+        let listener = BgpListener::bind_with_options(
+            "127.0.0.1:0".parse().unwrap(),
+            accept_tx,
+            ListenerSocketOptions::default(),
+        )
+        .await
+        .expect("listener bind without initial GTSM policy");
+        let addr = listener.local_addr().unwrap();
+        let control = listener.tcp_ao_rotation_handle();
+        tokio::spawn(listener.run());
+
+        control
+            .replace_inbound_auth(
+                Vec::new(),
+                vec![TtlSecurityListenerPolicy {
+                    owner: TcpAoListenerOwnerKind::Static,
+                    peer: "127.0.0.1".parse().unwrap(),
+                    prefix_len: 32,
+                    enforce: true,
+                }],
+            )
+            .await
+            .expect("add GTSM policy to live listener");
+
+        let client = spawn_gtsm_connect(addr, None)
+            .await
+            .expect("GTSM TCP handshake after live policy addition");
+        let accepted = expect_accept(&mut accept_rx).await;
+        expect_data_flows(client, accepted).await;
+    }
+
     /// LAN-907: an IPv6 neighbor's MD5 password must be enforced on the
     /// inbound half of the dual-family listener — unsigned IPv6 connections
     /// are rejected in the kernel, signed ones establish — while the
@@ -430,9 +494,9 @@ mod inbound_auth {
         let accepted = expect_accept(&mut accept_rx).await;
         expect_data_blocked(low_hops, accepted).await;
 
-        let compliant = spawn_connect(v6_addr, None, None, Some(255))
+        let compliant = spawn_gtsm_connect(v6_addr, None)
             .await
-            .expect("TCP handshake for hop-limit-255 client");
+            .expect("GTSM TCP handshake with hop-limit-255 SYN-ACK");
         let accepted = expect_accept(&mut accept_rx).await;
         expect_data_flows(compliant, accepted).await;
     }


### PR DESCRIPTION
## Summary

- set IPv4 TTL / IPv6 Hop Limit 255 on a family listener before `listen()` whenever that family has an enforcing GTSM selector
- update already-bound listeners when GTSM policy is added live, before any MD5 inventory mutation
- keep inbound minimum-hop enforcement peer-specific on accepted children and document the operator-visible fix

This fixes passive-open sessions where a conformant peer sent an authenticated SYN at 255 but rejected rustbgpd's authenticated SYN-ACK at the kernel default of 64. RFC 5082 requires every packet associated with the protected session to use 255.

## Verification

- focused listener integration suite (16/16)
- focused failure-ordering unit test
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps`

## Load-bearing proof

With only the two production listener-option calls temporarily removed, the IPv4 initial-policy test, IPv6 initial-policy test, and live-policy-add test each failed at the GTSM client handshake. Restoring the calls made all three green. The live update also has a failure-injection test proving an IPv6 option error occurs before an earlier IPv4 listener receives its new MD5 key. The dependent real M25 lab independently captured the pre-fix MD5-valid SYN/SYN-ACK/RST sequence and passes 17/17 under a diagnostic Hop Limit 255 control.

Tracks LAN-935 and unblocks LAN-923.

[RFC 5082 §3](https://www.rfc-editor.org/rfc/rfc5082.html#section-3)