### PR TITLE
test(interop): cover IPv6 passive-open authentication

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -99,10 +99,11 @@ name: Interop
 #     digest-pinned) and a raw byte sink with tshark 4.4 pcap
 #     dissection for the v4 frames. 50 assertions; the wall time is
 #     dominated by the 60 s stats cadence.
-#   - M25 (~10 s test): TCP MD5 (RFC 2385) + GTSM / TTL security
-#     (RFC 5082). Two FRR peers — one over MD5, one over GTSM —
-#     prove both auth/integrity mechanisms hold a session and
-#     deliver routes. Catches transport-layer regressions.
+#   - M25 (~45 s test): TCP MD5 (RFC 2385) + GTSM / TTL security
+#     (RFC 5082). Two static FRR peers cover MD5 and GTSM separately;
+#     a third FRR peer active-opens over IPv6 into a dynamic range
+#     requiring both, including wrong-MD5 and missing-GTSM negative
+#     phases. Catches active- and accepted-socket transport regressions.
 #
 # EVPN + SIGHUP tier:
 #   - M29 (~10 s test): control-plane sanity — session Established

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -155,7 +155,7 @@ the protected BIRD TCP-AO smoke and M73 BGP-LS receipt).
 | GoBGP ×2 | 3.37.0 | `tests/interop/m82-evpn-bundle-synthetic-gobgp.clab.yml` | Tested (M82) | ADR-0092 EVPN VLAN-Aware Bundle (non-zero Ethernet Tag) reflection — GoBGP-synthetic slice | Three-node iBGP topology: GoBGP source -> rustbgpd RR -> GoBGP sink, all negotiating `l2vpn-evpn`. The source originates the RFC 7432 §6.3 bundle route shape — one EVI (RD 65000:100, RT 65000:100) with two bridge domains under distinct non-zero Ethernet Tags (10 → VNI 10010, 20 → VNI 10020) including **the SAME MAC address under both tags** — as Type 2 MAC/IP + Type 3 IMET routes. 26/26: the RR keys the same (RD, MAC) under two tags as **two distinct RIB entries** (no (VNI, MAC) collapse) with the tags surfaced via `rbgp evpn`; distinct per-tag IMET entries; the sink receives all four routes with ORIGINATOR_ID / CLUSTER_LIST and **tag-verbatim NLRIs** (RD admin/assigned, 4-byte Ethernet Tag, MAC, IP, label all field-equal on the sink's re-decoded NLRI); withdrawing the tag-10 Type 2 removes exactly that entry everywhere (the tag-20 twin and both IMETs survive); the RR touches no dataplane. **Hosted CI** in `.github/workflows/interop.yml`. | Stock `gobgp:interop` image |
 | **Nokia SR Linux** + GoBGP | 25.10.1 + 3.37.0 | `tests/interop/m82-evpn-bundle-srlinux.clab.yml` | Tested (M82, local lab) | ADR-0092 EVPN VLAN-Aware Bundle vendor ground truth — **rustbgpd's first vendor-NOS interop receipt** | Four-node topology: SR Linux VTEP -> rustbgpd RR -> GoBGP sink (+ an access-side link partner). SR Linux runs two mac-vrf bridge domains in its VLAN-aware-bundle control-plane interoperability mode (`protocols bgp-evpn bgp-instance 1 routes bridge-table vlan-aware-bundle-eth-tag 10 / 20`, shared RT target:65000:100, VNIs 10010/10020, the same static MAC in both bridge domains) and originates real vendor Type 3 IMET + Type 2 MAC routes with non-zero Ethernet Tags. 20/20: session Established; the RR holds per-tag IMET entries and the same MAC keyed under tags 10/20 as distinct entries with per-tag VNI labels; the sink receives all four reflected with ORIGINATOR_ID = SR Linux, CLUSTER_LIST = the RR cluster-id, and tag-verbatim NLRIs; deleting the bd10 static MAC on SR Linux withdraws exactly the tag-10 Type 2 end-to-end. SR Linux quirks: one EVI per mac-vrf enforced (the bundle identity rides the shared RT + eth-tag, per-BD RDs), and the session needs an explicit `transport local-address` or SR Linux sources/accepts only on the system0 address. Local-only (SR Linux image ~750 MB compressed); the CI-gated proof is the synthetic leg above. | `docker pull ghcr.io/nokia/srlinux:latest` |
 | BIRD 2 + GoBGP + FRR + StayRTR | BIRD 2.0.12, GoBGP 3.37.0, FRR 10.3.1, StayRTR | `tests/interop/m83-routeserver-multistack.clab.yml` | Tested (M83) | RFC 7947 route-server profile, multi-stack — the ADR-0101 proof-ladder closer | rustbgpd is the route server (AS 65500) for three member stacks with `route_server_client` + `role = "route_server"` per member, a dedicated reduced IPv4 lab hygiene/ROV projection (`.rpol` + TOML mixed), and a StayRTR RTR fixture. RFC 6598 and TEST-NET-3 remain usable only as deterministic lab probes; M83 does not exercise the public example's dated dual-stack special-purpose snapshot. 46 assertions: **transparency** on all three client views AND at byte level via tshark on the RS↔BIRD link (no 65500 in any AS_PATH segment, NEXT_HOP = originator verbatim, MED + standard/large communities verbatim on the wire); RFC 9234 **OTC** attached toward members (attribute 35 on the wire, `BGP.otc` on BIRD, FRR JSON); **per-member policy views** (a deny chain scoped to one member, `rbgp rib advertised` agreeing per member); **ROV** reject-at-import with `rbgp policy explain` naming the deciding term; the **RFC 7947 §2.3 path-hiding contrast** — the FRR member whose export chain denies the Loc-RIB best receives NOTHING in single-best mode (pinned), receives the runner-up after a live `per_client_best` flip (sed + SIGHUP + session bounce), with `rbgp rib advertised --explain` walking the per-client candidate ladder (“candidate 1 of 2 denied … runner-up advertised”), and the Add-Path member holds BOTH candidate paths; runner-up withdraw converges to nothing; EoR-after-flood ordering; withdraw propagation to both other stacks; session stability through a policy SIGHUP. **Caught product bug pre-CI:** `per_client_best` was dropped at the `build_transport_config` seam (parsed + validated + displayed in docs, never reached the session) — fixed in the same change, unit-pinned. First-AS relaxation per stack recorded in the script header (FRR needs per-neighbor `no enforce-first-as`; BIRD `enforce first as off`; GoBGP has none). **Hosted CI** in `.github/workflows/interop.yml`. | `docker build -t bird:2-bookworm -f tests/interop/Dockerfile.bird tests/interop` (bird2 + tshark); stock `gobgp:interop` |
-| FRR (2x) | 10.3.1 | `tests/interop/m25-md5-gtsm-frr.clab.yml` | Tested (M25) | TCP MD5 + GTSM / TTL security | Two peers: MD5 auth + GTSM separately | — |
+| FRR (3x) | 10.3.1 | `tests/interop/m25-md5-gtsm-frr.clab.yml` | Tested (M25) | TCP MD5 + GTSM / TTL security | Two static peers cover MD5 and GTSM separately; an IPv6 dynamic accepted socket requires both and proves each negative independently | — |
 | FRR (bgpd) | 10.3.1 | `tests/interop/m26-cease-frr.clab.yml` | Tested (M26) | Cease/Max-Prefixes subcode 1 | max_prefixes=2, FRR sends 3 | Cease/Maximum Number of Prefixes Reached |
 | FRR (2x) + RTR v2 | 10.3.1 | `tests/interop/m27-aspa-rtr2.clab.yml` | Tested (M27) | ASPA/RTR v2: validation states, best-path preference | Python RTR v2 mock server (StayRTR lacks ASPA); 2 FRR peers for best-path tiebreak | — |
 | FRR + RTR v2 | 10.3.1 | `tests/interop/m59-aspa-roles-rtr2.clab.yml` | Tested (M59) | Role-aware ASPA: downstream (customer-cone) verification (draft-ietf-sidrops-aspa-verification-26 §5.5, ADR-0049) | rustbgpd (AS 65001) configures a local BGP Role of `customer` toward the FRR peer (AS 65003, its provider), so routes received from it are verified with the **downstream** procedure rather than upstream (M27 covers the roleless/upstream half). FRR advertises two prefixes with crafted AS_PATHs and the Python RTR v2 mock feeds ASPA records that make one downstream-Valid and one downstream-Invalid: `192.168.20.0/24` `[65003, 65011, 65010]` → an unbroken up-ramp ⇒ `aspaState = valid`; `192.168.21.0/24` `[65003, 65007, 65008]` → neither up- nor down-ramp covers (65008 and 65003 each attest only 65099) ⇒ `aspaState = invalid`. Driver asserts both verdicts via `RibService/ListReceivedRoutes`. Local-only, like M21/M27 (RTR-cache-dependent; not in hosted CI). | — |
@@ -1905,10 +1905,13 @@ types and ordering.
 
 ---
 
-## M25 Test Results (2026-03-15, FRR 10.3.1)
+## M25 Test Results (2026-08-08, FRR 10.3.1)
 
 TCP MD5 authentication (RFC 2385) and GTSM / TTL security (RFC 5082)
-with two separate FRR peers.
+with three separate FRR peers. FRR-A and FRR-B cover active-open MD5 and
+GTSM separately. FRR-C is the only side that can active-open its IPv6 session;
+rustbgpd has no static neighbor for it and must accept it from a dynamic range
+whose peer group requires both MD5 and GTSM.
 
 | Test | Result | Details |
 |------|--------|---------|
@@ -1917,9 +1920,19 @@ with two separate FRR peers.
 | Route received over MD5 session | PASS | 192.168.1.0/24 from FRR-A |
 | GTSM session established | PASS | ttl-security hops 1 on FRR-B |
 | Route received over GTSM session | PASS | 172.16.0.0/16 from FRR-B |
-| Both peers active | PASS | activePeers=2 |
-| Routes from both peers | PASS | totalRoutes=2 |
-| **Total** | **7/7** | |
+| IPv6 dynamic MD5+GTSM session established | PASS | FRR-C active-open to `2001:db8:25::1`; no static rustbgpd neighbor |
+| IPv6 dynamic route received | PASS | 2001:db8:2500::/48 from FRR-C |
+| Dynamic child provenance | PASS | `isDynamic=true`, peer group `ipv6-dynamic-auth` |
+| Dynamic range inventory | PASS | `2001:db8:25::/64`, remote AS 65004 |
+| All peers active | PASS | activePeers=3 |
+| Routes from all peers | PASS | totalRoutes=3 |
+| Wrong IPv6 MD5 rejected | PASS | Session stays down for a 10-second reconnect window |
+| IPv6 MD5 restore established | PASS | Correct password restores the dynamic session |
+| IPv6 MD5 restore route | PASS | 2001:db8:2500::/48 returns |
+| Missing IPv6 GTSM rejected | PASS | Removing FRR TTL security leaves hop limit below rustbgpd's strict 255 minimum |
+| IPv6 GTSM restore established | PASS | `ttl-security hops 1` restores the dynamic session |
+| IPv6 GTSM restore route | PASS | 2001:db8:2500::/48 returns |
+| **Total** | **17/17** | |
 
 ---
 

--- a/docs/RECEIPTS.md
+++ b/docs/RECEIPTS.md
@@ -50,7 +50,7 @@ id matches the milestone. Full procedures: [`INTEROP.md`](INTEROP.md).
 | M17 | Add-Path (RFC 7911) multi-path send with distinct path ids | FRR 10.3.1 |
 | M22 | FlowSpec inject + distribute + withdraw | FRR 10.3.1 |
 | M24 | BMP Initiation, PeerUp, RouteMonitoring ordering | FRR + BMP receiver |
-| M25 | TCP MD5 authentication + GTSM/TTL security | FRR 10.3.1 ×2 |
+| M25 | TCP MD5 + GTSM/TTL security, including IPv6 dynamic accepted sockets | FRR 10.3.1 ×3 |
 | M29 | EVPN RR capability sanity (RFC 7432) + `ListEvpnRoutes` | FRR 10.3.1 |
 | M30 | EVPN Type 2 MAC reflection end-to-end with kernel VXLAN VTEPs | FRR 10.3.1 ×2 |
 | M34 | SIGHUP policy soft-reset auto-fire | FRR 10.3.1 |

--- a/tests/interop/configs/frr-bgpd-m25-ipv6-auth.conf
+++ b/tests/interop/configs/frr-bgpd-m25-ipv6-auth.conf
@@ -1,0 +1,25 @@
+frr version 10.3.1
+frr defaults traditional
+hostname frr-m25-ipv6-auth
+log stdout informational
+
+router bgp 65004
+ bgp router-id 10.25.0.4
+ no bgp ebgp-requires-policy
+ neighbor 2001:db8:25::1 remote-as 65001
+ neighbor 2001:db8:25::1 description rustbgpd-m25-ipv6-dynamic-auth
+ neighbor 2001:db8:25::1 timers 30 90
+ neighbor 2001:db8:25::1 password interop-secret-m25-v6
+ neighbor 2001:db8:25::1 ttl-security hops 1
+ !
+ address-family ipv4 unicast
+  no neighbor 2001:db8:25::1 activate
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  neighbor 2001:db8:25::1 activate
+  network 2001:db8:2500::/48
+ exit-address-family
+!
+ipv6 route 2001:db8:2500::/48 Null0
+!

--- a/tests/interop/configs/rustbgpd-m25-md5-gtsm.toml
+++ b/tests/interop/configs/rustbgpd-m25-md5-gtsm.toml
@@ -28,6 +28,21 @@ description = "frr-b-gtsm"
 hold_time = 90
 ttl_security = true
 
+# Peer C has no static neighbor. FRR-C must active-open into this dynamic
+# range; the accepted IPv6 socket inherits both transport protections.
+[peer_groups.ipv6-dynamic-auth]
+hold_time = 90
+md5_password = "interop-secret-m25-v6"
+ttl_security = true
+families = ["ipv6_unicast"]
+disable_ipv4_unicast = true
+
+[[dynamic_neighbors]]
+prefix = "2001:db8:25::/64"
+peer_group = "ipv6-dynamic-auth"
+remote_asn = 65004
+description = "frr-c-ipv6-dynamic-md5-gtsm"
+
 [security.grpc]
 enforcement = "tier"
 

--- a/tests/interop/m25-md5-gtsm-frr.clab.yml
+++ b/tests/interop/m25-md5-gtsm-frr.clab.yml
@@ -3,9 +3,10 @@
 # Validates: BGP session establishment with TCP MD5 authentication
 # (RFC 2385) and GTSM / TTL security (RFC 5082) enabled on both sides.
 #
-# Two FRR peers:
+# Three FRR peers:
 #   - FRR-A (AS 65002): TCP MD5 password "interop-secret-m25"
-#   - FRR-B (AS 65003): GTSM / TTL security (ebgp-multihop 1 + ttl-security 254)
+#   - FRR-B (AS 65003): GTSM / TTL security
+#   - FRR-C (AS 65004): IPv6 active-open into a dynamic range with MD5 + GTSM
 #
 # Usage:
 #   containerlab deploy -t tests/interop/m25-md5-gtsm-frr.clab.yml
@@ -28,6 +29,8 @@ topology:
         - ip link set eth1 up
         - ip addr add 10.0.1.1/24 dev eth2
         - ip link set eth2 up
+        - ip -6 addr add 2001:db8:25::1/64 dev eth3 nodad
+        - ip link set eth3 up
       env:
         RUST_LOG: info
 
@@ -51,9 +54,22 @@ topology:
         - ip addr add 10.0.1.2/24 dev eth1
         - ip link set eth1 up
 
+    frr-c:
+      kind: linux
+      image: quay.io/frrouting/frr:10.3.1
+      binds:
+        - ./configs/frr-daemons:/etc/frr/daemons:ro
+        - ./configs/frr-bgpd-m25-ipv6-auth.conf:/etc/frr/frr.conf:ro
+      exec:
+        - ip -6 addr add 2001:db8:25::2/64 dev eth1 nodad
+        - ip link set eth1 up
+
   links:
     - endpoints: ["rustbgpd:eth1", "frr-a:eth1"]
     - endpoints: ["rustbgpd:eth2", "frr-b:eth1"]
+    - endpoints: ["rustbgpd:eth3", "frr-c:eth1"]
 
 # Network A: 10.0.0.0/24 — rustbgpd (10.0.0.1) ↔ FRR-A (10.0.0.2, AS 65002) — TCP MD5
 # Network B: 10.0.1.0/24 — rustbgpd (10.0.1.1) ↔ FRR-B (10.0.1.2, AS 65003) — GTSM
+# Network C: 2001:db8:25::/64 — rustbgpd (::1) accepts FRR-C (::2, AS 65004)
+# through an IPv6 dynamic range with MD5 + GTSM.

--- a/tests/interop/scripts/test-m25-md5-gtsm-frr.sh
+++ b/tests/interop/scripts/test-m25-md5-gtsm-frr.sh
@@ -5,7 +5,9 @@
 #   1. BGP session with TCP MD5 authentication (RFC 2385)
 #   2. BGP session with GTSM / TTL security (RFC 5082)
 #   3. Routes exchanged over both secured sessions
-#   4. Wrong MD5 password prevents session (negative test)
+#   4. IPv6 dynamic accepted sockets inherit MD5 + GTSM from their peer group
+#   5. Wrong MD5 and missing GTSM each prevent the IPv6 session
+#   6. Restoring each protection restores the session and route
 #
 # Prerequisites:
 #   - containerlab deployed: containerlab deploy -t tests/interop/m25-md5-gtsm-frr.clab.yml
@@ -19,9 +21,14 @@ TOPO="m25-md5-gtsm-frr"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INTEROP_TEST_OPERATOR_AUTH=1
 export INTEROP_TEST_OPERATOR_AUTH
+# shellcheck source=test-lib.sh
 source "$SCRIPT_DIR/test-lib.sh"
 FRR_A="clab-${TOPO}-frr-a"
 FRR_B="clab-${TOPO}-frr-b"
+FRR_C="clab-${TOPO}-frr-c"
+RUSTBGPD_V6="2001:db8:25::1"
+FRR_C_V6="2001:db8:25::2"
+FRR_C_PREFIX="2001:db8:2500::/48"
 
 
 grpc_list_received() {
@@ -30,28 +37,82 @@ grpc_list_received() {
         "$GRPC_ADDR" rustbgpd.v1.RibService/ListReceivedRoutes 2>/dev/null
 }
 
+grpc_list_neighbors() {
+    grpcurl_call \
+        "$GRPC_ADDR" rustbgpd.v1.NeighborService/ListNeighbors 2>/dev/null
+}
 
-# Use the standardized `start_rustbgpd` from test-lib.sh — handles
-# both the /proc poll loop and the gRPC-ready wait.
+grpc_list_dynamic_neighbors() {
+    grpcurl_call \
+        "$GRPC_ADDR" rustbgpd.v1.NeighborService/ListDynamicNeighbors 2>/dev/null
+}
 
-wait_frr_established() {
-    local frr_container=$1
-    local peer_addr=$2
+wait_route_received() {
+    local peer_addr=$1
+    local prefix=$2
     local label=$3
+    local prefix_addr=${prefix%/*}
+    local prefix_length=${prefix#*/}
 
-    log "Waiting for $label session to reach Established..."
-    for i in $(seq 1 45); do
-        local state
-        state=$(docker exec "$frr_container" vtysh -c "show bgp neighbors $peer_addr json" 2>/dev/null \
-            | grep -o '"bgpState":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
-        if [ "$state" = "Established" ]; then
-            ok "$label session established (attempt $i)"
+    for i in $(seq 1 15); do
+        if grpc_list_received "$peer_addr" \
+            | jq -e --arg prefix "$prefix_addr" --argjson prefix_length "$prefix_length" '
+                any(.routes[]?;
+                    .prefix == $prefix and .prefixLength == $prefix_length)
+            ' >/dev/null 2>&1; then
+            ok "$label route $prefix received (attempt $i)"
             return 0
         fi
         sleep 2
     done
-    fail "$label session did not reach Established within 90s"
+    fail "$label route $prefix was not received within 30s"
     return 1
+}
+
+wait_frr_not_established() {
+    local frr_container=$1
+    local peer_addr=$2
+    local label=$3
+
+    # Require a full 10-second stable window. A one-shot non-Established read
+    # immediately after `clear bgp` would be vacuous even if the bad transport
+    # configuration re-established on the next connect attempt.
+    for i in $(seq 1 5); do
+        local neighbor_json state
+        if ! neighbor_json=$(docker exec "$frr_container" \
+            vtysh -c "show bgp neighbors $peer_addr json" 2>/dev/null); then
+            fail "$label could not read the FRR neighbor state (attempt $i)"
+            return 1
+        fi
+        if ! state=$(jq -er '
+            [.. | objects | .bgpState?
+                | select(type == "string" and length > 0)][0]
+        ' <<<"$neighbor_json" 2>/dev/null); then
+            fail "$label received no verifiable FRR neighbor state (attempt $i)"
+            return 1
+        fi
+        if [ "$state" = "Established" ]; then
+            fail "$label unexpectedly re-established during negative window (attempt $i)"
+            return 1
+        fi
+        sleep 2
+    done
+    ok "$label stayed down for the 10-second negative window"
+}
+
+frr_c_neighbor_command() {
+    local command=$1
+
+    docker exec "$FRR_C" vtysh \
+        -c "configure terminal" \
+        -c "router bgp 65004" \
+        -c "$command" >/dev/null 2>&1
+    # FRR resets the peer asynchronously after a transport command. Let that
+    # reset leave Idle before clearing, otherwise a clear issued in the same
+    # instant can be consumed by the old FSM and leave the next active-open on
+    # its full connect-retry timer.
+    sleep 1
+    docker exec "$FRR_C" vtysh -c "clear bgp $RUSTBGPD_V6" >/dev/null 2>&1
 }
 
 # ---------------------------------------------------------------------------
@@ -95,7 +156,7 @@ test_gtsm_session() {
 }
 
 test_both_peers_active() {
-    log "Test 3: Both secured sessions active simultaneously"
+    log "Test 4: All secured sessions active simultaneously"
 
     local health
     health=$(grpc_health)
@@ -105,10 +166,10 @@ import sys, json
 print(json.load(sys.stdin).get('activePeers', 0))
 " 2>/dev/null || echo 0)
 
-    if [ "$peers" -ge 2 ]; then
-        ok "Both peers active (activePeers=$peers)"
+    if [ "$peers" -eq 3 ]; then
+        ok "All three peers active (activePeers=$peers)"
     else
-        fail "Expected 2 active peers, got $peers"
+        fail "Expected 3 active peers, got $peers"
     fi
 
     local routes
@@ -117,26 +178,98 @@ import sys, json
 print(json.load(sys.stdin).get('totalRoutes', 0))
 " 2>/dev/null || echo 0)
 
-    if [ "$routes" -ge 2 ]; then
-        ok "Routes from both peers present (totalRoutes=$routes)"
+    if [ "$routes" -eq 3 ]; then
+        ok "Routes from all three peers present (totalRoutes=$routes)"
     else
-        fail "Expected >= 2 routes, got $routes"
+        fail "Expected exactly 3 routes, got $routes"
     fi
+}
+
+test_ipv6_dynamic_auth() {
+    log "Test 3: IPv6 dynamic accepted socket with MD5 + GTSM (FRR-C, AS 65004)"
+
+    wait_frr_established "$FRR_C" "$RUSTBGPD_V6" "IPv6 dynamic MD5+GTSM" || return 1
+    wait_route_received "$FRR_C_V6" "$FRR_C_PREFIX" "IPv6 dynamic MD5+GTSM" || return 1
+
+    local neighbors ranges result
+    neighbors=$(grpc_list_neighbors)
+    ranges=$(grpc_list_dynamic_neighbors)
+    result=$(NEIGHBORS="$neighbors" RANGES="$ranges" python3 - <<'PY'
+import json
+import os
+
+neighbors = json.loads(os.environ["NEIGHBORS"])
+ranges = json.loads(os.environ["RANGES"])
+peer_ok = any(
+    row.get("config", {}).get("address") == "2001:db8:25::2"
+    and row.get("config", {}).get("peerGroup") == "ipv6-dynamic-auth"
+    and row.get("isDynamic") is True
+    for row in neighbors.get("neighbors", [])
+)
+range_ok = any(
+    row.get("prefix") == "2001:db8:25::/64"
+    and row.get("peerGroup") == "ipv6-dynamic-auth"
+    and row.get("remoteAsn") == 65004
+    for row in ranges.get("ranges", [])
+)
+if peer_ok:
+    print("peer_ok")
+if range_ok:
+    print("range_ok")
+PY
+)
+    if grep -q '^peer_ok$' <<<"$result"; then
+        ok "IPv6 peer is dynamic and inherits the authenticated peer group"
+    else
+        fail "IPv6 peer was not exposed as a dynamic peer in the authenticated group"
+    fi
+    if grep -q '^range_ok$' <<<"$result"; then
+        ok "IPv6 authenticated dynamic range is exposed with AS 65004"
+    else
+        fail "IPv6 authenticated dynamic range was not exposed as configured"
+    fi
+}
+
+test_ipv6_md5_negative_and_restore() {
+    log "Test 5: Wrong IPv6 MD5 password fails closed, then restores"
+
+    frr_c_neighbor_command \
+        "neighbor $RUSTBGPD_V6 password wrong-interop-secret-m25-v6"
+    wait_frr_not_established "$FRR_C" "$RUSTBGPD_V6" "Wrong-MD5 IPv6 session" || return 1
+
+    frr_c_neighbor_command \
+        "neighbor $RUSTBGPD_V6 password interop-secret-m25-v6"
+    wait_frr_established "$FRR_C" "$RUSTBGPD_V6" "IPv6 MD5 restore" || return 1
+    wait_route_received "$FRR_C_V6" "$FRR_C_PREFIX" "IPv6 MD5 restore"
+}
+
+test_ipv6_gtsm_negative_and_restore() {
+    log "Test 6: Missing IPv6 GTSM fails closed, then restores"
+
+    frr_c_neighbor_command "no neighbor $RUSTBGPD_V6 ttl-security hops 1"
+    wait_frr_not_established "$FRR_C" "$RUSTBGPD_V6" "No-GTSM IPv6 session" || return 1
+
+    frr_c_neighbor_command "neighbor $RUSTBGPD_V6 ttl-security hops 1"
+    wait_frr_established "$FRR_C" "$RUSTBGPD_V6" "IPv6 GTSM restore" || return 1
+    wait_route_received "$FRR_C_V6" "$FRR_C_PREFIX" "IPv6 GTSM restore"
 }
 
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 main() {
-    log "M25 interop test: TCP MD5 + GTSM with FRR"
+    log "M25 interop test: TCP MD5 + GTSM with FRR (static + IPv6 dynamic accept)"
     log "Topology: $TOPO"
 
     resolve_grpc_addr
-    start_rustbgpd
+    start_rustbgpd "/usr/local/bin/start-rustbgpd.sh"
 
     test_md5_session
     test_gtsm_session
+    test_ipv6_dynamic_auth
     test_both_peers_active
+    test_ipv6_md5_negative_and_restore
+    test_ipv6_gtsm_negative_and_restore
 
     echo ""
     log "Results: $pass passed, $fail failed"


### PR DESCRIPTION
## Summary

- extend the existing M25 FRR lab with an IPv6 dynamic peer that active-opens into rustbgpd
- require the accepted socket to inherit both TCP MD5 and GTSM from its peer group
- prove wrong-MD5 and missing-GTSM failures independently, then restore each session and route
- keep the hosted workflow and receipt inventory truthful for the three-peer, 17-assertion lab

## Why

The new positive path exposed the passive-open SYN-ACK Hop Limit defect fixed in #1525: FRR sent a valid MD5 SYN at Hop Limit 255, rustbgpd replied with a valid MD5 SYN-ACK at Hop Limit 64, and FRR rejected it. With that production fix merged, this preserves the interop boundary that found the bug.

## Load-bearing proof

- before #1525, the positive IPv6 phase failed and a temporary route Hop Limit 255 made the unchanged harness pass
- the wrong-password phase holds the peer down for a full 10-second window while GTSM remains correct
- the missing-GTSM phase holds the peer down separately while MD5 remains correct
- restoring each control re-establishes the same dynamic peer and route

## Verification

- fresh `rustbgpd:dev` image from this head
- real containerlab M25 run: **17 passed, 0 failed**
- `bash -n` and `shellcheck -x` for the M25 script
- strict daemon config validation in the lab
- full workspace fmt, clippy, tests, and rustdoc on the test-only branch
- clean rebase on current main and `git diff --check`