### PR TITLE
ci: skip heavy labs for proven-independent changes

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -149,9 +149,29 @@ permissions:
   contents: read
 
 jobs:
+  classify_changes:
+    name: Classify interop heavy-lab paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      run_labs: ${{ steps.classify.outputs.run_labs }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Classify complete pull-request diff
+        id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/classify_heavy_ci_paths.py
+
   # Warm one fixed-scope cache per source SHA; jobs still build and load their
   # own image, falling back to an uncached build if the cache is unavailable.
   prime_dev_image:
+    needs: classify_changes
+    if: needs.classify_changes.outputs.run_labs == 'true'
     name: Prime rustbgpd:dev build cache
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -37,9 +37,29 @@ permissions:
   contents: read
 
 jobs:
+  classify_changes:
+    name: Classify kernel heavy-lab paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      run_labs: ${{ steps.classify.outputs.run_labs }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Classify complete pull-request diff
+        id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/classify_heavy_ci_paths.py
+
   # Warm one fixed-scope cache per source SHA; jobs still build and load their
   # own image, falling back to an uncached build if the cache is unavailable.
   prime_dev_image:
+    needs: classify_changes
+    if: needs.classify_changes.outputs.run_labs == 'true'
     name: Prime rustbgpd:dev build cache
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -684,6 +704,8 @@ jobs:
           script: tests/interop/scripts/test-m68-evpn-type5-gwip-overlay-index-frr.sh
 
   netns:
+    needs: classify_changes
+    if: needs.classify_changes.outputs.run_labs == 'true'
     name: Privileged netns selectors (fdb_nhg + fib_runtime + bfd_runtime + dataplane_vlan_fdb + svd_fdb_vni + managed_bridge + managed_vxlan + managed_svd_vxlan + managed_vlan_upper + managed_ready + managed_ip_vrf_ready + l3_multipath + l3_all_active_writer)
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -26,6 +26,20 @@ EXPORT = "cache-to: type=gha,scope=rustbgpd-dev,mode=max,ignore-error=true"
 CHECKOUT = "uses: actions/checkout@v7"
 BUILDX = "uses: docker/setup-buildx-action@v4"
 BUILD_PUSH = "uses: docker/build-push-action@v7"
+CLASSIFIER_NEEDS = "needs: classify_changes"
+CLASSIFIER_IF = "if: needs.classify_changes.outputs.run_labs == 'true'"
+CLASSIFIER_SEAMS = (
+    "    runs-on: ubuntu-latest",
+    "    timeout-minutes: 1",
+    "      run_labs: ${{ steps.classify.outputs.run_labs }}",
+    "      - uses: actions/checkout@v7",
+    "          fetch-depth: 0",
+    "        id: classify",
+    "          EVENT_NAME: ${{ github.event_name }}",
+    "          BASE_SHA: ${{ github.event.pull_request.base.sha }}",
+    "          HEAD_SHA: ${{ github.event.pull_request.head.sha }}",
+    "        run: python3 scripts/classify_heavy_ci_paths.py",
+)
 GOBGP_VERSION = "3.37.0"
 GOBGP_CHECKSUMS = {
     "amd64": "e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522",
@@ -50,7 +64,7 @@ CALL_HASHES = {
 }
 PINS = collections.Counter(
     {
-        "actions/checkout@v7": 77,
+        "actions/checkout@v7": 79,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 3,
         "Swatinem/rust-cache@v2": 5,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 2,
@@ -83,6 +97,10 @@ def _jobs(text: str) -> dict[str, str]:
     }
 
 
+def _has_line(block: str, line: str) -> bool:
+    return re.search(rf"(?m)^{re.escape(line)}$", block) is not None
+
+
 def check(root: Path) -> list[str]:
     errors: list[str] = []
     workflow_dir = root / ".github" / "workflows"
@@ -105,10 +123,25 @@ def check(root: Path) -> list[str]:
         ("kernel-dataplane.yml", KERNEL, True),
     ):
         jobs = _jobs(texts[name])
-        expected = ["prime_dev_image", *roster] + (["netns"] if setup else [])
+        expected = ["classify_changes", "prime_dev_image", *roster] + (
+            ["netns"] if setup else []
+        )
         if list(jobs) != expected:
             errors.append(f"{name}: exact job roster/order drifted")
+        classifier = jobs.get("classify_changes", "")
+        kind = "interop" if name == "interop.yml" else "kernel"
+        if not _has_line(classifier, f"    name: Classify {kind} heavy-lab paths"):
+            errors.append(f"{name}: classifier check name drifted")
+        for seam in CLASSIFIER_SEAMS:
+            if not _has_line(classifier, seam):
+                errors.append(f"{name}: classifier missing {seam}")
+        for forbidden in ("continue-on-error:", "if:"):
+            if re.search(rf"(?m)^ +{re.escape(forbidden)}", classifier):
+                errors.append(f"{name}: classifier permits active {forbidden}")
         primer = jobs.get("prime_dev_image", "")
+        for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
+            if not _has_line(primer, f"    {seam}"):
+                errors.append(f"{name}: primer missing job-level {seam}")
         for seam in (
             "timeout-minutes: 30",
             PRIMER_GROUP,
@@ -153,8 +186,19 @@ def check(root: Path) -> list[str]:
         )
         if _hash(calls) != CALL_HASHES[name]:
             errors.append(f"{name}: existing test/setup calls drifted")
+    interop_classifier = _jobs(texts["interop.yml"]).get("classify_changes", "")
     kernel_jobs = _jobs(texts["kernel-dataplane.yml"])
-    if "needs: prime_dev_image" in kernel_jobs.get("netns", ""):
+    interop_classifier = interop_classifier.replace("interop heavy-lab", "heavy-lab")
+    kernel_classifier = kernel_jobs.get("classify_changes", "").replace(
+        "kernel heavy-lab", "heavy-lab"
+    )
+    if interop_classifier != kernel_classifier:
+        errors.append("heavy workflows must share an identical classifier job")
+    netns = kernel_jobs.get("netns", "")
+    for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
+        if not _has_line(netns, f"    {seam}"):
+            errors.append(f"kernel-dataplane.yml:netns missing job-level {seam}")
+    if "needs: prime_dev_image" in netns:
         errors.append("kernel-dataplane.yml:netns must remain independent")
 
     action = (

--- a/scripts/classify_heavy_ci_paths.py
+++ b/scripts/classify_heavy_ci_paths.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Fail-closed path classifier for the Interop and Kernel lab rosters."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PULL_REQUEST = "pull_request"
+FUZZ_ROOTS = (
+    "crates/bfd/fuzz",
+    "crates/evpn/fuzz",
+    "crates/mrt/fuzz",
+    "crates/policy/fuzz",
+    "crates/rpki/fuzz",
+    "crates/wire/fuzz",
+)
+FUZZ_FILES = frozenset(
+    {
+        ".github/workflows/clusterfuzzlite.yml",
+        ".github/workflows/fuzz.yml",
+        "fuzz/build-fuzzers.sh",
+        "fuzz/oss-fuzz/Dockerfile",
+        "fuzz/oss-fuzz/build.sh",
+        "fuzz/oss-fuzz/project.yaml",
+        "fuzz/rust-nightly.txt",
+        "scripts/check_fuzz_target_inventory.py",
+        "scripts/test_check_fuzz_target_inventory.py",
+        "scripts/check_fuzz_toolchain_pin.py",
+        "scripts/test_check_fuzz_toolchain_pin.py",
+    }
+)
+PACKAGE_ROOTS = ("packaging",)
+PACKAGE_FILES = frozenset(
+    {
+        ".github/workflows/release.yml",
+        ".github/workflows/release-install-contract.yml",
+        "scripts/build-packages.sh",
+        "scripts/check_release_install_contract.py",
+        "scripts/test_check_release_install_contract.py",
+    }
+)
+SHA = re.compile(r"[0-9a-f]{40}(?:[0-9a-f]{24})?\Z")
+
+
+class ClassificationError(RuntimeError):
+    """The complete PR diff could not be classified."""
+
+
+def _under(path: str, roots: Sequence[str]) -> bool:
+    return any(path == root or path.startswith(f"{root}/") for root in roots)
+
+
+def _well_formed(path: str) -> bool:
+    parts = path.split("/")
+    return (
+        bool(path)
+        and not path.startswith("/")
+        and all(
+            part not in {"", ".", ".."} and not any(ord(char) < 32 for char in part)
+            for part in parts
+        )
+    )
+
+
+def _documentation(path: str) -> bool:
+    return path.endswith(".md") or path == "docs" or path.startswith("docs/")
+
+
+def classify_paths(paths: Sequence[str]) -> tuple[bool, str]:
+    """Return ``(run_labs, reason)`` for one complete PR path set."""
+    if not paths:
+        return True, "empty diff"
+    if any(not _well_formed(path) for path in paths):
+        return True, "malformed path"
+
+    material = tuple(path for path in paths if not _documentation(path))
+    if not material:
+        return False, "documentation only"
+    if all(path in FUZZ_FILES or _under(path, FUZZ_ROOTS) for path in material):
+        return False, "standalone fuzz only"
+    if all(path in PACKAGE_FILES or _under(path, PACKAGE_ROOTS) for path in material):
+        return False, "release/package only"
+    return True, "mixed or lab-relevant paths"
+
+
+def changed_paths(repo: Path, base: str, head: str) -> tuple[str, ...]:
+    """Read the complete three-dot PR diff without API file-count limits."""
+    if not SHA.fullmatch(base) or not SHA.fullmatch(head):
+        raise ClassificationError("pull request base/head must be full commit IDs")
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--no-ext-diff",
+            "--no-renames",
+            "--name-only",
+            "-z",
+            f"{base}...{head}",
+            "--",
+        ],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise ClassificationError(detail or f"git diff exited {result.returncode}")
+    if result.stdout and not result.stdout.endswith(b"\0"):
+        raise ClassificationError("git diff returned malformed path framing")
+    try:
+        return (
+            tuple(
+                path.decode("utf-8")
+                for path in result.stdout.removesuffix(b"\0").split(b"\0")
+            )
+            if result.stdout
+            else ()
+        )
+    except UnicodeDecodeError as error:
+        raise ClassificationError(
+            f"git diff returned a non-UTF-8 path: {error}"
+        ) from error
+
+
+def classify_event(
+    event: str, base: str, head: str, repo: Path = ROOT
+) -> tuple[bool, str]:
+    """Only pull requests may take the narrow lab-independent skip path."""
+    if event != PULL_REQUEST:
+        return True, f"{event or 'unknown'} event"
+    return classify_paths(changed_paths(repo, base, head))
+
+
+def main() -> int:
+    try:
+        run_labs, reason = classify_event(
+            os.environ.get("EVENT_NAME", ""),
+            os.environ.get("BASE_SHA", ""),
+            os.environ.get("HEAD_SHA", ""),
+        )
+        output = os.environ.get("GITHUB_OUTPUT")
+        if not output:
+            raise ClassificationError("GITHUB_OUTPUT is not set")
+        with Path(output).open("a", encoding="utf-8") as handle:
+            handle.write(f"run_labs={'true' if run_labs else 'false'}\n")
+        print(f"run_labs={str(run_labs).lower()} ({reason})")
+        return 0
+    except (ClassificationError, OSError) as error:
+        print(f"heavy-lab path classification failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -1,14 +1,87 @@
 #!/usr/bin/env python3
 
+import json
+import os
 import shutil
+import subprocess
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
+from scripts import classify_heavy_ci_paths as heavy
 from scripts.check_ci_image_primer_contract import check
 
 
 ROOT = Path(__file__).resolve().parents[1]
+
+PR_FILES = {
+    1523: (
+        ".github/workflows/release-install-contract.yml",
+        ".github/workflows/release.yml",
+        "CHANGELOG.md",
+        "docs/QUICKSTART.md",
+        "docs/deployment.md",
+        "packaging/nfpm.yaml",
+        "scripts/check_release_install_contract.py",
+        "scripts/test_check_release_install_contract.py",
+    ),
+    1524: (
+        ".github/workflows/clusterfuzzlite.yml",
+        ".github/workflows/fuzz.yml",
+        "ROADMAP.md",
+        "crates/bfd/fuzz/.gitignore",
+        "crates/bfd/fuzz/Cargo.toml",
+        "crates/bfd/fuzz/decode_bfd_control.options",
+        "crates/bfd/fuzz/fuzz_targets/decode_bfd_control.rs",
+        "crates/bfd/fuzz/seeds/decode_bfd_control/valid_down",
+        "crates/rpki/fuzz/.gitignore",
+        "crates/rpki/fuzz/Cargo.toml",
+        "crates/rpki/fuzz/decode_rtr_pdu.options",
+        "crates/rpki/fuzz/fuzz_targets/decode_rtr_pdu.rs",
+        "crates/rpki/fuzz/seeds/decode_rtr_pdu/reset_query_v1",
+        "crates/wire/fuzz/seeds/decode_update/malformed_next_hop_length",
+        "docs/FUZZING.md",
+        "docs/RECEIPTS.md",
+        "docs/adr/0125-v1-stability-contract.md",
+        "fuzz/build-fuzzers.sh",
+        "scripts/check_fuzz_target_inventory.py",
+        "scripts/test_check_fuzz_target_inventory.py",
+    ),
+    1525: (
+        "CHANGELOG.md",
+        "crates/transport/src/lib.rs",
+        "crates/transport/src/listener.rs",
+        "crates/transport/src/socket_opts.rs",
+        "crates/transport/tests/listener.rs",
+    ),
+    1527: (
+        ".github/workflows/interop.yml",
+        "docs/INTEROP.md",
+        "docs/RECEIPTS.md",
+        "tests/interop/configs/frr-bgpd-m25-ipv6-auth.conf",
+        "tests/interop/configs/rustbgpd-m25-md5-gtsm.toml",
+        "tests/interop/m25-md5-gtsm-frr.clab.yml",
+        "tests/interop/scripts/test-m25-md5-gtsm-frr.sh",
+    ),
+    1528: (
+        ".github/workflows/release-install-contract.yml",
+        "CHANGELOG.md",
+        "Dockerfile",
+        "README.md",
+        "docs/QUICKSTART.md",
+        "docs/cookbook/ixp-filter-pipeline.md",
+        "docs/cookbook/monitoring-feed.md",
+        "docs/deployment.md",
+        "examples/birdwatcher-adapter/README.md",
+        "examples/birdwatcher-adapter/src/main.rs",
+        "packaging/nfpm.yaml",
+        "scripts/build-packages.sh",
+        "scripts/check_release_install_contract.py",
+        "scripts/test_check_release_install_contract.py",
+        "tests/birdwatcher_adapter_smoke.rs",
+    ),
+}
 
 
 class PrimerContractTests(unittest.TestCase):
@@ -41,6 +114,36 @@ class PrimerContractTests(unittest.TestCase):
 
     def test_live_contract(self):
         self.assertEqual([], check(ROOT))
+
+    def test_classifier_workflow_wiring_is_load_bearing(self):
+        for workflow in ("interop.yml", "kernel-dataplane.yml"):
+            relative = f".github/workflows/{workflow}"
+            for old in (
+                "run: python3 scripts/classify_heavy_ci_paths.py",
+                "needs: classify_changes",
+                "if: needs.classify_changes.outputs.run_labs == 'true'",
+            ):
+                with self.subTest(workflow=workflow, seam=old):
+                    self.mutate(relative, old, f"# {old}")
+            for old, forbidden, indent in (
+                ("runs-on: ubuntu-latest", "if: false", "    "),
+                ("timeout-minutes: 1", "continue-on-error: true", "    "),
+                ("id: classify", "continue-on-error: true", "        "),
+            ):
+                with self.subTest(workflow=workflow, forbidden=forbidden, at=old):
+                    self.mutate(relative, old, f"{forbidden}\n{indent}{old}")
+
+        for old in (
+            "needs: classify_changes",
+            "if: needs.classify_changes.outputs.run_labs == 'true'",
+        ):
+            with self.subTest(workflow="kernel netns", seam=old):
+                self.mutate(
+                    ".github/workflows/kernel-dataplane.yml",
+                    old,
+                    f"# {old}",
+                    occurrence=1,
+                )
 
     def test_destructive_workflow_seams(self):
         cases = (
@@ -296,6 +399,200 @@ class PrimerContractTests(unittest.TestCase):
         for old, new in cases:
             with self.subTest(seam=old):
                 self.mutate(relative, old, new)
+
+
+class HeavyLabPathClassifierTests(unittest.TestCase):
+    def git(self, repo: Path, *args: str) -> str:
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "CI contract",
+            "GIT_AUTHOR_EMAIL": "ci-contract@example.invalid",
+            "GIT_COMMITTER_NAME": "CI contract",
+            "GIT_COMMITTER_EMAIL": "ci-contract@example.invalid",
+        }
+        return subprocess.check_output(
+            ["git", *args], cwd=repo, env=env, text=True, stderr=subprocess.STDOUT
+        ).strip()
+
+    def commit_file(self, repo: Path, relative: str, content: str) -> str:
+        path = repo / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        self.git(repo, "add", "--", relative)
+        self.git(repo, "commit", "-qm", relative)
+        return self.git(repo, "rev-parse", "HEAD")
+
+    def test_reference_pull_request_manifests(self):
+        for number in (1523, 1524):
+            with self.subTest(pr=number):
+                self.assertFalse(heavy.classify_paths(PR_FILES[number])[0])
+        for number in (1525, 1527, 1528):
+            with self.subTest(pr=number):
+                self.assertTrue(heavy.classify_paths(PR_FILES[number])[0])
+
+    def test_exact_safe_roster_and_fail_closed_boundaries(self):
+        self.assertEqual(
+            heavy.FUZZ_ROOTS,
+            (
+                "crates/bfd/fuzz",
+                "crates/evpn/fuzz",
+                "crates/mrt/fuzz",
+                "crates/policy/fuzz",
+                "crates/rpki/fuzz",
+                "crates/wire/fuzz",
+            ),
+        )
+        self.assertEqual(heavy.PACKAGE_ROOTS, ("packaging",))
+        self.assertEqual(
+            heavy.FUZZ_FILES,
+            frozenset(
+                {
+                    ".github/workflows/clusterfuzzlite.yml",
+                    ".github/workflows/fuzz.yml",
+                    "fuzz/build-fuzzers.sh",
+                    "fuzz/oss-fuzz/Dockerfile",
+                    "fuzz/oss-fuzz/build.sh",
+                    "fuzz/oss-fuzz/project.yaml",
+                    "fuzz/rust-nightly.txt",
+                    "scripts/check_fuzz_target_inventory.py",
+                    "scripts/test_check_fuzz_target_inventory.py",
+                    "scripts/check_fuzz_toolchain_pin.py",
+                    "scripts/test_check_fuzz_toolchain_pin.py",
+                }
+            ),
+        )
+        self.assertEqual(
+            heavy.PACKAGE_FILES,
+            frozenset(
+                {
+                    ".github/workflows/release.yml",
+                    ".github/workflows/release-install-contract.yml",
+                    "scripts/build-packages.sh",
+                    "scripts/check_release_install_contract.py",
+                    "scripts/test_check_release_install_contract.py",
+                }
+            ),
+        )
+        for path in (
+            "Cargo.toml",
+            "Cargo.lock",
+            "Dockerfile",
+            ".dockerignore",
+            "src/main.rs",
+            "crates/wire/src/lib.rs",
+            "examples/minimal/config.toml",
+            "proto/rustbgpd.proto",
+            "tests/interop/scripts/test-m1-frr.sh",
+            ".github/actions/run-interop-test/action.yml",
+            "fuzz/future-file",
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(heavy.classify_paths(("docs/RECEIPTS.md", path))[0])
+        self.assertTrue(
+            heavy.classify_paths(
+                ("fuzz/build-fuzzers.sh", "scripts/build-packages.sh")
+            )[0]
+        )
+
+    def test_empty_malformed_and_non_pull_events_run_labs(self):
+        self.assertTrue(heavy.classify_paths(())[0])
+        for path in ("", "/absolute", "fuzz//seed", "fuzz/../src", "fuzz/bad\nname"):
+            with self.subTest(path=path):
+                self.assertTrue(heavy.classify_paths((path,))[0])
+        for event in ("push", "schedule", "workflow_dispatch", "merge_group", ""):
+            with self.subTest(event=event):
+                self.assertTrue(heavy.classify_event(event, "", "")[0])
+        with self.assertRaises(heavy.ClassificationError):
+            heavy.classify_event("pull_request", "", "")
+
+    def test_main_writes_exact_output_and_requires_target(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "output"
+            for verdict in (False, True):
+                with self.subTest(run_labs=verdict), mock.patch.object(
+                    heavy, "classify_event", return_value=(verdict, "test")
+                ), mock.patch.dict(
+                    os.environ, {"GITHUB_OUTPUT": str(output)}, clear=True
+                ):
+                    self.assertEqual(heavy.main(), 0)
+                    self.assertEqual(
+                        output.read_text(),
+                        f"run_labs={'true' if verdict else 'false'}\n",
+                    )
+                    output.unlink()
+            with mock.patch.object(
+                heavy, "classify_event", return_value=(True, "test")
+            ), mock.patch.dict(os.environ, {}, clear=True):
+                self.assertEqual(heavy.main(), 1)
+
+    def test_three_dot_diff_excludes_base_only_change(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            self.git(repo, "init", "-q")
+            root = self.commit_file(repo, "README", "root")
+            self.git(repo, "checkout", "-qb", "feature")
+            head = self.commit_file(repo, "fuzz/seeds/new", "seed")
+            self.git(repo, "checkout", "-qB", "main", root)
+            base = self.commit_file(repo, "src/base_only.rs", "base only")
+            self.assertEqual(
+                heavy.changed_paths(repo, base, head), ("fuzz/seeds/new",)
+            )
+
+    def test_unsafe_rename_and_missing_merge_base_fail_closed(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            self.git(repo, "init", "-q")
+            base = self.commit_file(repo, "src/old.rs", "production")
+            self.git(repo, "checkout", "-qb", "rename")
+            (repo / "fuzz").mkdir()
+            self.git(repo, "mv", "src/old.rs", "fuzz/old.rs")
+            self.git(repo, "commit", "-qm", "rename")
+            renamed = self.git(repo, "rev-parse", "HEAD")
+            paths = heavy.changed_paths(repo, base, renamed)
+            self.assertEqual(paths, ("fuzz/old.rs", "src/old.rs"))
+            self.assertTrue(heavy.classify_paths(paths)[0])
+
+            self.git(repo, "checkout", "--orphan", "unrelated")
+            self.git(repo, "rm", "-qrf", ".")
+            unrelated = self.commit_file(repo, "fuzz/only", "unrelated")
+            with self.assertRaises(heavy.ClassificationError):
+                heavy.changed_paths(repo, base, unrelated)
+
+    def test_allowed_fuzz_roots_are_standalone_workspaces(self):
+        main = json.loads(
+            subprocess.check_output(
+                ["cargo", "metadata", "--no-deps", "--format-version=1"],
+                cwd=ROOT,
+                text=True,
+            )
+        )
+        main_members = set(main["workspace_members"])
+        discovered = tuple(
+            sorted(
+                path.parent.relative_to(ROOT).as_posix()
+                for path in ROOT.glob("crates/*/fuzz/Cargo.toml")
+            )
+        )
+        self.assertEqual(discovered, heavy.FUZZ_ROOTS)
+        for fuzz_root in discovered:
+            manifest = ROOT / fuzz_root / "Cargo.toml"
+            metadata = json.loads(
+                subprocess.check_output(
+                    [
+                        "cargo",
+                        "metadata",
+                        "--no-deps",
+                        "--format-version=1",
+                        "--manifest-path",
+                        str(manifest),
+                    ],
+                    cwd=ROOT,
+                    text=True,
+                )
+            )
+            self.assertEqual(Path(metadata["workspace_root"]), manifest.parent)
+            self.assertEqual(len(metadata["workspace_members"]), 1)
+            self.assertNotIn(metadata["workspace_members"][0], main_members)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- classify the complete pull-request three-dot diff before starting the Interop and Kernel Dataplane image primers
- skip both heavy rosters only for documentation-only diffs or exact standalone-fuzz or release/package cohorts; mixed, unknown, production, config, proto, Cargo, Docker, interop, and shared-action changes still run everything
- keep push, schedule, manual, and unknown event types on the full-lab path
- gate the independent Kernel netns job with the same decision

## Why

Recent fuzz-only and package-only PRs each started 70 heavy jobs, consumed about 82 runner-minutes, and added 14–15 minutes of wall time even though they could not affect the daemon or lab topology. This removes that known waste without broad path guesses or per-lab selection.

The safe boundary is intentionally narrow: documentation already ignored by both workflow triggers, six proven standalone fuzz workspaces plus an exact top-level fuzz-support roster, or the exact release/package surfaces. Any mixed cohort runs the full suites.

## Fail-closed behavior

- pull requests diff the event base/head SHAs with full history and `--no-renames`
- missing history, malformed input, classifier failure, empty output, or an unknown path cannot produce a safe skip
- both workflows expose uniquely named classifier checks
- the contract rejects commented-out seams, `continue-on-error`, classifier `if` conditions, missing output emission, and missing primer/netns dependencies

The repository currently has no branch protection or rulesets, so classifier failure is workflow-red but not mechanically merge-blocking today. If required checks are introduced, both unique classifier checks should be required.

## Verification

- 14 classifier/contract tests plus the live repository contract
- exact #1523/#1524 safe manifests and #1525/#1527/#1528 full manifests
- real divergent-history three-dot and unsafe-rename proofs
- standalone one-member Cargo-workspace proof for all six fuzz roots
- actionlint 1.7.12 on both workflows
- Python compilation, workspace fmt/clippy/tests/rustdoc, and diff check

The PR itself changes the heavy workflows and therefore runs both complete rosters. A safe follow-up PR will prove classifier-only execution before the ticket closes.
