### PR TITLE
ci: verify heavy-lab safe-path classification

### DIFF
--- a/fuzz/build-fuzzers.sh
+++ b/fuzz/build-fuzzers.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Heavy-lab classifier receipt: this standalone builder is lab-independent.
 # Shared OSS-Fuzz / ClusterFuzzLite build: inventory validation remains on the
 # path that produces binaries, rather than being only a separate CI assertion.
 repo_root=${1:-"$SRC/rustbgpd"}


### PR DESCRIPTION
Verification-only stacked PR for #1530. It changes one comment in an exact safe-path file.

Expected receipt:
- `Classify interop heavy-lab paths` succeeds.
- `Classify kernel heavy-lab paths` succeeds.
- Interop primers/labs and Kernel primer/netns are skipped.
- Both classifier jobs finish well under 60 seconds.

This PR will be closed unmerged after the receipt is captured.