### PR TITLE
cli: remove config transaction --from-file aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `/usr/share/doc/rustbgpd/monitoring/` after a `.deb`/`.rpm` install; the
   canonical dashboard and rule files remain the packaging sources (LAN-928).
 
+### Removed
+
+- `rbgp config diff`, `config plan`, and `config apply` no longer accept the
+  hidden `--from-file PATH` compatibility alias. Pass the candidate TOML as
+  the positional `CANDIDATE` argument instead, for example
+  `rbgp config plan candidate.toml`. The unrelated JSON CRUD commands
+  `policy set`, `neighbor-set set`, and `peer-group set` retain their
+  established `--from-file` flag.
+
 ### Fixed
 
 - BIRD 3.3.1 migrations now retain lowercase `bgp_*` attributes from a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -367,8 +367,8 @@ new AFI/SAFI and EVPN dataplane expansion.
   deprecation policy — is accepted in
   [ADR-0125](docs/adr/0125-v1-stability-contract.md). The remaining hard gates
   are execution, not design: exactly two ≥24 h RS/RR soak receipts, the
-  v0.65 compatibility-debt batch, proof-gated RFC 8212 epoch-2 activation,
-  the latest-1.x security-support row, and the final upgrade-chain
+  remaining v0.65 compatibility-debt batch, proof-gated RFC 8212 epoch-2
+  activation, the latest-1.x security-support row, and the final upgrade-chain
   extension. The external shadow pilot is advisory since the 2026-08-08
   DR1 revision — actively pursued, disclosed if absent at tag time, not
   blocking. The comparative IRR-scale gate is already satisfied.
@@ -1742,11 +1742,11 @@ branch is between features.
   frozen legacy commit-confirm/history readers, the Paths-Limit raw cap,
   the dead `enforcement = "legacy"` enum variant, the `rbgp rib diff`
   older-daemon fallbacks, `AddNeighborRequest.config`,
-  `RouteEvent.event_id`, and the three hidden `--from-file` aliases on
-  `config diff|plan|apply`. Unary Plan/Apply is retained permanently as the
-  small-candidate path; streaming remains additive and outside the initial v1
-  freeze. New compat retentions add a row to the ADR in the PR that introduces
-  them.
+  and `RouteEvent.event_id`. The three hidden `--from-file` aliases on
+  `config diff|plan|apply` were removed during v0.65 development. Unary
+  Plan/Apply is retained permanently as the small-candidate path; streaming
+  remains additive and outside the initial v1 freeze. New compat retentions
+  add a row to the ADR in the PR that introduces them.
 
 - [x] **Legacy GR/LLGR RFC gaps in unicast/FlowSpec/EVPN — RESOLVED.**
   The RR families (VPN/BGP-LS/RTC, #636–#638) implement the strict

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -36,10 +36,11 @@ const BINARY_NAME: &str = "rbgp";
 //   keep it positional.
 // - ASNs: a remote AS flag is `--remote-asn` (visible alias
 //   `--asn`); an unqualified "ASN" in output means the local AS.
-// - File arguments are positional (`policy check FILE`, `policy fmt
-//   FILE...`, `config diff [CANDIDATE]`), never new `--from-file`
-//   flags. Existing `--from-file` spellings stay as hidden
-//   compatibility aliases and must never be removed.
+// - TOML and policy-program file arguments are positional (`policy check
+//   FILE`, `policy fmt FILE...`, `config diff CANDIDATE`), never
+//   `--from-file` flags. The JSON CRUD commands (`policy set`,
+//   `neighbor-set set`, and `peer-group set`) retain their established
+//   `--from-file` spelling.
 // - `-j`/`--json` purity: JSON goes to stdout and carries the
 //   complete result. A command where `-j` provably has no effect
 //   (`metrics`, `top`) warns once on stderr instead of silently
@@ -416,12 +417,8 @@ enum ConfigAction {
         2  changes present")]
     Diff {
         /// Candidate TOML file to validate and compare
-        #[arg(value_name = "CANDIDATE", required_unless_present = "from_file")]
-        candidate: Option<String>,
-
-        /// Hidden compatibility alias for the positional `CANDIDATE`
-        #[arg(long, value_name = "PATH", hide = true, conflicts_with = "candidate")]
-        from_file: Option<String>,
+        #[arg(value_name = "CANDIDATE")]
+        candidate: String,
     },
 
     /// Validate and classify a candidate transaction without mutation
@@ -434,12 +431,8 @@ enum ConfigAction {
         2  changes present (plan is committable or rejected)")]
     Plan {
         /// Candidate TOML file to validate and classify
-        #[arg(value_name = "CANDIDATE", required_unless_present = "from_file")]
-        candidate: Option<String>,
-
-        /// Hidden compatibility alias for the positional `CANDIDATE`
-        #[arg(long, value_name = "PATH", hide = true, conflicts_with = "candidate")]
-        from_file: Option<String>,
+        #[arg(value_name = "CANDIDATE")]
+        candidate: String,
 
         /// Optional runtime snapshot token to check while planning
         #[arg(long, value_name = "TOKEN")]
@@ -449,12 +442,8 @@ enum ConfigAction {
     /// Commit a previously planned candidate transaction
     Apply {
         /// Candidate TOML file to validate and commit
-        #[arg(value_name = "CANDIDATE", required_unless_present = "from_file")]
-        candidate: Option<String>,
-
-        /// Hidden compatibility alias for the positional `CANDIDATE`
-        #[arg(long, value_name = "PATH", hide = true, conflicts_with = "candidate")]
-        from_file: Option<String>,
+        #[arg(value_name = "CANDIDATE")]
+        candidate: String,
 
         /// Runtime snapshot token returned by config plan
         #[arg(long, value_name = "TOKEN")]
@@ -1998,16 +1987,6 @@ fn render_subcommand_sections(
     Ok(())
 }
 
-/// Resolve the `config diff|plan|apply` candidate path from either the
-/// positional CANDIDATE or the hidden `--from-file` compatibility
-/// alias. Clap guarantees exactly one is present
-/// (`required_unless_present` + `conflicts_with`).
-fn candidate_file(candidate: Option<String>, from_file: Option<String>) -> String {
-    candidate
-        .or(from_file)
-        .expect("clap requires CANDIDATE or --from-file")
-}
-
 fn flush_stdout_result<W: std::io::Write + ?Sized>(
     writer: &mut W,
     result: Result<i32, CliError>,
@@ -2218,24 +2197,18 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
         },
 
         Command::Config { action } => match action {
-            ConfigAction::Diff {
-                candidate,
-                from_file,
-            } => {
-                let from_file = candidate_file(candidate, from_file);
-                let has_changes = commands::config::diff(connection, &from_file, json).await?;
+            ConfigAction::Diff { candidate } => {
+                let has_changes = commands::config::diff(connection, &candidate, json).await?;
                 let code = commands::config::change_status_exit_code(has_changes);
                 std::process::exit(flush_stdout_result(&mut std::io::stdout(), Ok(code))?);
             }
             ConfigAction::Plan {
                 candidate,
-                from_file,
                 expected_runtime_snapshot_token,
             } => {
-                let from_file = candidate_file(candidate, from_file);
                 let has_changes = commands::config::plan(
                     connection,
-                    &from_file,
+                    &candidate,
                     expected_runtime_snapshot_token.as_deref(),
                     json,
                 )
@@ -2245,7 +2218,6 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
             }
             ConfigAction::Apply {
                 candidate,
-                from_file,
                 expected_runtime_snapshot_token,
                 plan_token,
                 client_request_id,
@@ -2253,11 +2225,10 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                 confirm_id,
                 confirm_timeout_seconds,
             } => {
-                let from_file = candidate_file(candidate, from_file);
                 commands::config::apply(
                     connection,
                     commands::config::ApplyOptions {
-                        from_file: &from_file,
+                        from_file: &candidate,
                         expected_runtime_snapshot_token: &expected_runtime_snapshot_token,
                         plan_token: plan_token.as_deref(),
                         client_request_id: client_request_id.as_deref(),
@@ -3667,7 +3638,6 @@ mod tests {
             "rbgp",
             "config",
             "apply",
-            "--from-file",
             "candidate.toml",
             "--expected-runtime-snapshot-token",
             "kv1:old:1",
@@ -3698,7 +3668,6 @@ mod tests {
             "rbgp",
             "config",
             "apply",
-            "--from-file",
             "candidate.toml",
             "--expected-runtime-snapshot-token",
             "kv1:old:1",
@@ -5969,86 +5938,47 @@ mod tests {
         }
     }
 
-    /// LAN-329 file-arg convention: the candidate is positional;
-    /// `--from-file` still parses as a hidden compatibility alias, and
-    /// giving both is rejected.
+    /// ADR-0122 L1: config candidates are positional, while JSON CRUD keeps
+    /// its separate `--from-file` contract.
     #[test]
-    fn config_candidate_is_positional_with_from_file_alias() {
-        let cli = Cli::try_parse_from(["rbgp", "config", "diff", "candidate.toml"]).unwrap();
-        let Command::Config {
-            action:
-                ConfigAction::Diff {
-                    candidate,
-                    from_file,
-                },
-        } = cli.command
-        else {
-            panic!("expected Config Diff");
-        };
-        assert_eq!(candidate.as_deref(), Some("candidate.toml"));
-        assert!(from_file.is_none());
-
-        let cli = Cli::try_parse_from(["rbgp", "config", "diff", "--from-file", "candidate.toml"])
-            .unwrap();
-        let Command::Config {
-            action:
-                ConfigAction::Diff {
-                    candidate,
-                    from_file,
-                },
-        } = cli.command
-        else {
-            panic!("expected Config Diff");
-        };
-        assert!(candidate.is_none());
-        assert_eq!(
-            candidate_file(candidate, from_file),
-            "candidate.toml".to_string()
-        );
-
-        // Neither → missing required argument; both → conflict.
-        assert!(Cli::try_parse_from(["rbgp", "config", "diff"]).is_err());
-        assert!(
-            Cli::try_parse_from([
+    fn config_candidate_is_positional_and_rejects_retired_alias() {
+        // Load-bearing: removing a positional CANDIDATE makes one of these
+        // parse checks red; restoring any retired alias makes the matching
+        // UnknownArgument check below red.
+        for args in [
+            vec!["rbgp", "config", "diff", "candidate.toml"],
+            vec!["rbgp", "config", "plan", "candidate.toml"],
+            vec![
                 "rbgp",
                 "config",
-                "diff",
+                "apply",
                 "candidate.toml",
-                "--from-file",
-                "other.toml"
-            ])
-            .is_err()
-        );
+                "--expected-runtime-snapshot-token",
+                "kv1:old:1",
+            ],
+        ] {
+            assert!(Cli::try_parse_from(args).is_ok());
+        }
 
-        // `plan` and `apply` share the same shape.
-        let cli = Cli::try_parse_from(["rbgp", "config", "plan", "candidate.toml"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Command::Config {
-                action: ConfigAction::Plan {
-                    candidate: Some(_),
-                    ..
-                }
-            }
-        ));
-        let cli = Cli::try_parse_from([
-            "rbgp",
-            "config",
-            "apply",
-            "candidate.toml",
-            "--expected-runtime-snapshot-token",
-            "kv1:old:1",
-        ])
-        .unwrap();
-        assert!(matches!(
-            cli.command,
-            Command::Config {
-                action: ConfigAction::Apply {
-                    candidate: Some(_),
-                    ..
-                }
-            }
-        ));
+        assert!(Cli::try_parse_from(["rbgp", "config", "diff"]).is_err());
+        for args in [
+            vec!["rbgp", "config", "diff", "--from-file", "candidate.toml"],
+            vec!["rbgp", "config", "plan", "--from-file", "candidate.toml"],
+            vec![
+                "rbgp",
+                "config",
+                "apply",
+                "--from-file",
+                "candidate.toml",
+                "--expected-runtime-snapshot-token",
+                "kv1:old:1",
+            ],
+        ] {
+            let Err(error) = Cli::try_parse_from(args) else {
+                panic!("retired --from-file alias parsed");
+            };
+            assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
+        }
     }
 
     #[test]

--- a/docs/adr/0122-compatibility-debt-inventory.md
+++ b/docs/adr/0122-compatibility-debt-inventory.md
@@ -20,7 +20,7 @@ This ADR is the single inventory of that debt and its removal schedule.
 Nothing is removed by this ADR; each scheduled entry lands as its own PR
 against the release named here. ADR-0125 records the remaining owner outcomes:
 unary Plan/Apply stays as a permanent small-candidate path, and the three
-hidden `--from-file` aliases are scheduled for v0.65 removal.
+hidden `--from-file` aliases were removed in the v0.65 development cycle.
 
 Not listed, by deliberate judgment: protocol-mandated compatibility (RFC 6793
 AS4 compat attributes, RFC 8277 §2.4 compatibility field, RFC 5925 TCP-AO
@@ -65,7 +65,7 @@ as inventory history).
 
 | # | Item | What it preserves | Cost of keeping | Classification | Removal mechanics |
 |---|------|-------------------|-----------------|----------------|-------------------|
-| L1 | Hidden `--from-file` compatibility aliases on `config diff` / `config plan` / `config apply` (`crates/cli/src/main.rs`), kept when LAN-329 made file arguments positional. The conventions comment pledges they "must never be removed" in the same file. | Old scripts invoking the pre-LAN-329 flag spelling. | Three hidden args + `candidate_file()` merge helper; near zero. The real debt is the "never" pledge, which contradicts the alpha posture. | deprecate → v0.65 | Delete the three hidden args + helper, regenerate checked-in shell completions, reword the conventions comment, and add a CHANGELOG migration note naming the positional spelling. |
+| L1 | Hidden `--from-file` compatibility aliases on `config diff` / `config plan` / `config apply` (`crates/cli/src/main.rs`), kept when LAN-329 made file arguments positional. The conventions comment pledged they "must never be removed" in the same file. | Old scripts invoking the pre-LAN-329 flag spelling. | Three hidden args + `candidate_file()` merge helper; near zero. The real debt was the "never" pledge, which contradicted the alpha posture. | removed (v0.65) | The three hidden args and helper were deleted, first-party callers and checked-in shell completions were migrated, and the CHANGELOG names the positional `CANDIDATE` spelling. The unrelated JSON CRUD `--from-file` flags remain. |
 | L2 | Visible aliases `--peer` (for `--neighbor`) and `--asn` (for `--remote-asn`) throughout `crates/cli/src/main.rs`. | Both product-language spellings, by design (LAN-329 conventions block). | Zero; clap renders them in help. | keep | Canonical convention, not a shim. |
 | L3 | `rbgp rib diff` older-daemon fallbacks from #1367: single-peer tolerance for daemons that omit `page_version` (`observe_page_version`, `crates/cli/src/commands/diff.rs`) and the MED 0-maps-to-absent fallback for daemons without `med_attr` (including the caveat machinery in the same file). | Version-less legacy path: diffing against a ≤v0.62 daemon that predates the fenced advertised-RIB pages. | A fallback state machine, mixed present/absent fail-closed arms, and a caveat surface — the largest single compat structure in the CLI. | deprecate → v0.65 | Fail closed on any response omitting `page_version` (message: upgrade the daemon); delete the single-peer tolerance + `med_attr` fallback + caveat; CHANGELOG note. Rolling-upgrade policy above (N-1) makes v0.65 the earliest release whose N-1 daemon always emits both fields. |
 | L4 | Assorted CLI rolling-upgrade fallbacks for absent additive fields: the `neighbor_source_label` "range unavailable" arm (`crates/cli/src/output.rs`) and max-prefix action absence handling (`crates/cli/src/commands/neighbor.rs`). | `rbgp` from HEAD reading the previous minor's daemon during an upgrade. | Small, individually tested branches. | keep (policy-bounded) | Governed by the N-1 rule: each branch is prunable once its emitting release is two minors old; no per-branch decision needed. |
@@ -101,8 +101,9 @@ as inventory history).
 - The three-minor / N-1 lifetime policies convert future removals from
   per-item debates into scheduled cleanups.
 - The former open calls are closed: unary Plan/Apply remains permanent, and
-  the hidden `--from-file` aliases leave in v0.65. D1, D3, and A2 carry an
-  explicit v0.65 deadline after missing v0.64 rather than silently slipping.
+  the hidden `--from-file` aliases were removed for v0.65. D1, D3, and A2
+  carry an explicit v0.65 deadline after missing v0.64 rather than silently
+  slipping.
 - Scheduled removals (C1, A1, A3) touch the blessed v1 surface; each needs
   the re-bless procedure and a CHANGELOG migration note, which this ADR's
   mechanics columns pre-write.

--- a/docs/adr/0125-v1-stability-contract.md
+++ b/docs/adr/0125-v1-stability-contract.md
@@ -17,7 +17,7 @@ is expanded in the section named in the last column.
 | DR2 | How many archived soak receipts at RS/RR flagship shapes gate the tag? | Exactly two receipts, each at least 24 hours. Together they must cover route-server and route-reflector flagship shapes, a real SIGHUP file reload, and a max-prefix trip followed by timed restart. | Evidence bar E2 |
 | DR3 | Does the tag require a comparative IRR-scale reload row against BIRD and OpenBGPD, or is the existing IXP matrix sufficient? | Yes, and the gate is satisfied by the published four-root IRR-scale comparison against BIRD 3.3.1 and OpenBGPD 9.1. | Evidence bar E3 |
 | DR4 | RFC 8212 secure-by-default: activate per ADR-0119, or record a decision not to flip the default in 1.0? | Activate only the `config_epoch = 2` plus omitted-boolean cell after ADR-0119's representation and production-mutation proofs land. Epoch-less and epoch-1 omission remain permissive forever; explicit booleans retain their value. | Evidence bar E5 |
-| DR5 | ADR-0122 open items: D2 (unary vs streaming Plan/Apply) and L1 (`--from-file` pledge) | Unary Plan/Apply is the permanent small-candidate path. Remove the hidden `--from-file` aliases from `config diff`, `config plan`, and `config apply` in v0.65. | Evidence bar E4 |
+| DR5 | ADR-0122 open items: D2 (unary vs streaming Plan/Apply) and L1 (`--from-file` pledge) | Unary Plan/Apply is the permanent small-candidate path. The hidden `--from-file` aliases were removed from `config diff`, `config plan`, and `config apply` during v0.65 development. | Evidence bar E4 |
 | DR6 | Are streaming Plan/Apply, `ListConfigHistory`, and `RollbackConfigTransaction` re-blessed into the frozen inventory at 1.0? | No. They remain outside the initial frozen inventory and may be added deliberately in a later 1.x minor. | Freeze scope |
 | DR7 | Post-1.0 removal floor for inventoried surface | An inventoried surface deprecated in 1.x remains functional throughout 1.x and is removable no earlier than 2.0. | Deprecation policy |
 | DR8 | Supported-versions window after 1.0 (SECURITY.md currently says "0.x") | Security fixes support the latest 1.x release. N-1 is a separate migration-compatibility promise, not a security-support promise. | Deprecation policy |
@@ -142,9 +142,9 @@ land before the tag. The v0.64 deadline was missed for the frozen v1/v2
 commit-confirm and legacy-history readers and the Paths-Limit raw-cap field;
 those join the existing v0.65 batch. Unary Plan/Apply remains the permanent
 small-candidate path. The hidden `--from-file` compatibility aliases on
-`config diff`, `config plan`, and `config apply` are scheduled for v0.65.
-Current state: inventory and decisions complete; the v0.65 removals remain to
-land.
+`config diff`, `config plan`, and `config apply` were removed during v0.65
+development. Current state: L1 is complete; the rest of the v0.65 removals
+remain to land.
 
 **E5 — RFC 8212 secure default (DR4).** Opt-in enforcement is shipped and
 receipted (ADR-0112, M95). ADR-0119's config-epoch representation and
@@ -197,7 +197,7 @@ The actionable backlog seed: criterion → current state → what closes it.
 | E1 external pilot | Zero pilots; cookbook + tooling shipped, unused externally | Advisory since the 2026-08-08 DR1 revision — pursue per the shadow-pilot cookbook (weekly checkpoints, semantic diff, support bundle, tested rollback, recorded feedback); absence is disclosed at tag time, not blocking |
 | E2 RS/RR soaks | Archived soaks are EVPN-shaped; eight precommitted gates uninjected | Archive exactly two receipts of at least 24 h that collectively cover flagship RS/RR, real SIGHUP reload, and max-prefix trip/timed restart |
 | E3 comparative IRR row | **Satisfied:** four-root same-harness comparison against BIRD and OpenBGPD publishes wins and losses | Keep the published receipt linked from the evidence index |
-| E4 debt schedule | Decisions recorded; v0.64 removals slipped into the v0.65 batch | Land the complete v0.65 removal batch before the tag |
+| E4 debt schedule | L1 is complete; the v0.64 removals and remaining v0.65 items are still open | Land the rest of the v0.65 removal batch before the tag |
 | E5 RFC 8212 | Activation authorized; ADR-0119 representation and proofs unimplemented | Land the representation and every named production-mutation proof; activate only epoch-2 omission |
 | E6 security posture | Fuzz/audit/reporting in place | SECURITY.md 1.x supported-versions row; keep artifact build floor |
 | E7 upgrade chain | Chain contiguous through the current anchor | Extend to the v1.0 anchor at tag time (existing process) |

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -68,7 +68,6 @@ _arguments "${_arguments_options[@]}" : \
         case $line[1] in
             (diff)
 _arguments "${_arguments_options[@]}" : \
-'()--from-file=[Hidden compatibility alias for the positional \`CANDIDATE\`]:PATH:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -77,12 +76,11 @@ _arguments "${_arguments_options[@]}" : \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-'::candidate -- Candidate TOML file to validate and compare:_default' \
+':candidate -- Candidate TOML file to validate and compare:_default' \
 && ret=0
 ;;
 (plan)
 _arguments "${_arguments_options[@]}" : \
-'()--from-file=[Hidden compatibility alias for the positional \`CANDIDATE\`]:PATH:_default' \
 '--expected-runtime-snapshot-token=[Optional runtime snapshot token to check while planning]:TOKEN:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
@@ -92,12 +90,11 @@ _arguments "${_arguments_options[@]}" : \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-'::candidate -- Candidate TOML file to validate and classify:_default' \
+':candidate -- Candidate TOML file to validate and classify:_default' \
 && ret=0
 ;;
 (apply)
 _arguments "${_arguments_options[@]}" : \
-'()--from-file=[Hidden compatibility alias for the positional \`CANDIDATE\`]:PATH:_default' \
 '--expected-runtime-snapshot-token=[Runtime snapshot token returned by config plan]:TOKEN:_default' \
 '--plan-token=[Ephemeral token returned by a streamed config plan]:TOKEN:_default' \
 '--client-request-id=[Optional audit/correlation identifier]:ID:_default' \
@@ -112,7 +109,7 @@ _arguments "${_arguments_options[@]}" : \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-'::candidate -- Candidate TOML file to validate and commit:_default' \
+':candidate -- Candidate TOML file to validate and commit:_default' \
 && ret=0
 ;;
 (confirm)

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -1371,16 +1371,12 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__apply)
-            opts="-s -j -h --from-file --expected-runtime-snapshot-token --plan-token --client-request-id --comment --confirm-id --confirm-timeout --addr --token-file --json --no-color --help"
+            opts="-s -j -h --expected-runtime-snapshot-token --plan-token --client-request-id --comment --confirm-id --confirm-timeout --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --from-file)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --expected-runtime-snapshot-token)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -1451,16 +1447,12 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__diff)
-            opts="-s -j -h --from-file --addr --token-file --json --no-color --help"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --from-file)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --addr)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -1735,16 +1727,12 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__plan)
-            opts="-s -j -h --from-file --expected-runtime-snapshot-token --addr --token-file --json --no-color --help"
+            opts="-s -j -h --expected-runtime-snapshot-token --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --from-file)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --expected-runtime-snapshot-token)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -79,20 +79,17 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_su
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -f -a "effective" -d 'Dump the daemon\'s effective running config (defaults resolved)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -f -a "import" -d 'Import a BIRD 2/3 / FRR / GoBGP config into a rustbgpd config.toml'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status history rollback effective import help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -l from-file -d 'Hidden compatibility alias for the positional `CANDIDATE`' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l from-file -d 'Hidden compatibility alias for the positional `CANDIDATE`' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l expected-runtime-snapshot-token -d 'Optional runtime snapshot token to check while planning' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l from-file -d 'Hidden compatibility alias for the positional `CANDIDATE`' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l expected-runtime-snapshot-token -d 'Runtime snapshot token returned by config plan' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l plan-token -d 'Ephemeral token returned by a streamed config plan' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l client-request-id -d 'Optional audit/correlation identifier' -r

--- a/tests/commit_confirm_binary.rs
+++ b/tests/commit_confirm_binary.rs
@@ -126,6 +126,32 @@ fn rbgp_json(grpc_addr: &str, args: &[&str]) -> serde_json::Value {
     serde_json::from_slice(&output.stdout).expect("rbgp JSON output must parse")
 }
 
+#[test]
+fn actual_binary_rejects_retired_config_from_file_aliases() {
+    // Load-bearing: restoring any hidden alias makes the real parser accept
+    // that invocation, so its exit/stderr assertions go red before connect.
+    for args in [
+        vec!["config", "diff", "--from-file", "candidate.toml"],
+        vec!["config", "plan", "--from-file", "candidate.toml"],
+        vec![
+            "config",
+            "apply",
+            "--from-file",
+            "candidate.toml",
+            "--expected-runtime-snapshot-token",
+            "kv1:old:1",
+        ],
+    ] {
+        let output = rbgp("http://127.0.0.1:1", &args);
+        assert_eq!(output.status.code(), Some(2), "args: {args:?}");
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("unexpected argument '--from-file'"),
+            "args: {args:?}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
 fn wait_until_serving(grpc_addr: &str, daemon: &mut Daemon) {
     let deadline = Instant::now() + Duration::from_secs(30);
     while Instant::now() < deadline {
@@ -327,13 +353,7 @@ impl Lab {
     fn apply_plain(&self, candidate: &Path) {
         let plan = rbgp_json(
             &self.grpc_addr,
-            &[
-                "--json",
-                "config",
-                "plan",
-                "--from-file",
-                candidate.to_str().unwrap(),
-            ],
+            &["--json", "config", "plan", candidate.to_str().unwrap()],
         );
         let token = plan["runtime_snapshot_token"].as_str().unwrap();
         let output = rbgp(
@@ -342,7 +362,6 @@ impl Lab {
                 "--json",
                 "config",
                 "apply",
-                "--from-file",
                 candidate.to_str().unwrap(),
                 "--expected-runtime-snapshot-token",
                 token,
@@ -366,7 +385,6 @@ impl Lab {
                 "--json",
                 "config",
                 "plan",
-                "--from-file",
                 self.candidate_path.to_str().unwrap(),
             ],
         );
@@ -393,7 +411,6 @@ impl Lab {
                 "--json",
                 "config",
                 "apply",
-                "--from-file",
                 self.candidate_path.to_str().unwrap(),
                 "--expected-runtime-snapshot-token",
                 token,
@@ -480,12 +497,7 @@ fn streamed_confirmed_apply_above_eight_mib_aborts_to_previous_config() {
     );
     let human_plan = rbgp(
         &lab.grpc_addr,
-        &[
-            "config",
-            "plan",
-            "--from-file",
-            lab.candidate_path.to_str().unwrap(),
-        ],
+        &["config", "plan", lab.candidate_path.to_str().unwrap()],
     );
     assert_eq!(human_plan.status.code(), Some(2));
     let human_stdout = String::from_utf8(human_plan.stdout).unwrap();
@@ -538,7 +550,6 @@ fn unsafe_fixed_raw_slot_refuses_before_real_binary_apply() {
             "--json",
             "config",
             "plan",
-            "--from-file",
             lab.candidate_path.to_str().unwrap(),
         ],
     );
@@ -550,7 +561,6 @@ fn unsafe_fixed_raw_slot_refuses_before_real_binary_apply() {
             "--json",
             "config",
             "apply",
-            "--from-file",
             lab.candidate_path.to_str().unwrap(),
             "--expected-runtime-snapshot-token",
             token,
@@ -814,7 +824,6 @@ fn v2_history_survives_restart_and_restores_after_source_verification() {
             "--json",
             "config",
             "plan",
-            "--from-file",
             lab.candidate_path.to_str().unwrap(),
         ],
     );
@@ -826,7 +835,6 @@ fn v2_history_survives_restart_and_restores_after_source_verification() {
             "--json",
             "config",
             "apply",
-            "--from-file",
             lab.candidate_path.to_str().unwrap(),
             "--expected-runtime-snapshot-token",
             token,

--- a/tests/soak/run-soak-hot-reload.sh
+++ b/tests/soak/run-soak-hot-reload.sh
@@ -194,7 +194,7 @@ plan_and_extract_token() {
     local output status
     set +e
     output=$(docker exec "$RUSTBGPD" rbgp -s "$GRPC_ADDR" config plan \
-        --from-file /tmp/candidate.toml -j)
+        /tmp/candidate.toml -j)
     status=$?
     set -e
     case "$status" in 0|2) ;; *) return "$status";; esac
@@ -213,7 +213,7 @@ run_apply_cycle() {
     local cycle=${1:?}
     write_candidate_toml "$cycle"
     cycle_log "cycle $cycle: writing candidate TOML"
-    # Copy candidate into the container (rbgp reads from_file locally).
+    # Copy candidate into the container (rbgp reads the candidate locally).
     docker cp "$CANDIDATE_TOML" "$RUSTBGPD:/tmp/candidate.toml" >/dev/null
     local token
     token=$(plan_and_extract_token)
@@ -223,7 +223,7 @@ run_apply_cycle() {
     fi
     cycle_log "cycle $cycle: token=$token, applying"
     docker exec "$RUSTBGPD" rbgp -s "$GRPC_ADDR" config apply \
-        --from-file /tmp/candidate.toml \
+        /tmp/candidate.toml \
         --expected-runtime-snapshot-token "$token" -j >/dev/null 2>&1 || {
         cycle_log "cycle $cycle: apply failed"
         return 1

--- a/tests/soak/test_intern_churn_analyzers.py
+++ b/tests/soak/test_intern_churn_analyzers.py
@@ -333,6 +333,14 @@ run_apply_cycle 1
                 result = self.bash("run-soak-hot-reload.sh", f"MODE={mode}\n{body}")
                 self.assertEqual(result.returncode, code, result.stderr)
 
+    def test_hot_runner_uses_positional_config_candidates(self):
+        # Load-bearing: restoring either runner call to the retired alias
+        # makes this structural fence red before a multi-hour soak starts.
+        source = (HERE / "run-soak-hot-reload.sh").read_text()
+        self.assertNotIn("--from-file", source)
+        self.assertIn("config plan \\\n        /tmp/candidate.toml -j)", source)
+        self.assertIn("config apply \\\n        /tmp/candidate.toml", source)
+
     def test_injection_mutates_counts_only_after_commands_succeed(self):
         body = r'''
 CHURN_BATCH=1; LIVE_SET_FILE=$(mktemp); echo 1 >"$LIVE_SET_FILE"


### PR DESCRIPTION
## Summary

- remove the scheduled v0.65 compatibility aliases from `rbgp config diff`, `plan`, and `apply`
- migrate all 11 first-party callers to positional candidate paths
- preserve the separate `--from-file` contract on policy, neighbor-set, and peer-group JSON CRUD commands
- regenerate completions and mark only ADR-0122 L1 complete

## Migration

Use:

- `rbgp config diff PATH`
- `rbgp config plan PATH`
- `rbgp config apply PATH ...`

The policy/neighbor-set/peer-group `set --from-file` flags are unchanged.

## Load-bearing proof

- restoring any retired alias makes both the Clap and real-binary rejection gates red
- restoring either old soak invocation makes the soak structural fence red
- all three retained JSON CRUD flags are asserted and remain in generated completions
- stable-surface validation remains green because v1 freezes command paths/names, which do not change

## Verification

- CLI suite: 607/607
- real commit-confirm binary suite: 9/9
- soak harness: 13/13
- exact Bash/Zsh/Fish completion regeneration
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- `python3 scripts/check-v1-stable-surface.py`
- independent review: clean

One unrelated RIB ASPA timing test flaked once, passed immediately in isolation, and passed in the full workspace rerun.