### PR TITLE
docs: add package rollback and OpenBGPD migration guidance

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -551,18 +551,26 @@ keeps its comments; SIGHUP alone never writes the file.
 
 ## Upgrading
 
-1. Build the new version: `cargo build --release`
-2. Stop the daemon: `systemctl stop rustbgpd` (or `rbgp shutdown`)
-3. Replace the binary at `/usr/local/bin/rustbgpd`
-4. Start: `systemctl start rustbgpd`
+For native `.deb` and `.rpm` installs, follow the canonical
+[package upgrade and rollback procedure](deployment.md#package-upgrade-and-rollback).
+It preflights the candidate binary against the live configuration **before**
+the stop, stops rustbgpd cleanly so the restart marker is written, checks the
+package manager's preserved-config files, and verifies the restarted daemon.
+The package hooks do not stop or restart a running service.
 
-When Graceful Restart is enabled (the default), the coordinated shutdown in
-step 2 writes a GR restart marker. On step 4, the daemon advertises `R=1` to
-static peers, asking them to retain our routes while we reconnect. The restart
-window is the largest `gr_restart_time` among all GR-enabled peers.
-rustbgpd still advertises `forwarding_preserved = false`; use a drained
-route-server pair or another traffic-shift procedure when forwarding
-continuity matters.
+Before installing v0.65, finish any pending confirmed transaction and clear
+retired v1/v2 authority. The candidate binary's `--check` validates the config
+only; it cannot inspect `runtime_state_dir` or config-adjacent commit-confirm
+authority. If retired authority remains or is inaccessible, recover it with
+exactly rustbgpd v0.64.0. Delete it only after proving the transaction is
+terminal and the current config is intended.
+
+When Graceful Restart is enabled (the default), a coordinated stop writes a GR
+restart marker. On the next start, the daemon advertises `R=1` to static peers,
+asking them to retain eligible routes while sessions rebuild. rustbgpd still
+advertises `forwarding_preserved = false`; this is not a continuity guarantee.
+Use a drained route-server pair or another traffic-shift procedure when
+forwarding continuity matters.
 
 In a matching domain, marker v3 makes the shutdown-to-startup deadline
 resistant to discontinuous `CLOCK_REALTIME` steps and includes suspend time
@@ -570,11 +578,9 @@ before the new process resolves it. The daemon then uses its normal
 process-local monotonic timer for the remaining live window; it does not claim
 suspend-inclusive timing after startup.
 
-Rolling back to a binary that predates marker v3 is a cold-start compatibility
-event: that binary rejects the v3 marker and starts without restarting-speaker
-mode. This does not guarantee a traffic blackhole; impact depends on peer and
-topology behavior. Operators requiring continuity should still use the drained
-route-server-pair procedure below.
+Rolling back across the marker-v3 or commit-confirm-v3 boundaries needs the
+state checks in the canonical procedure. A pre-marker-v3 binary rejects a v3
+marker and cold-starts without restarting-speaker mode.
 
 For zero-downtime upgrades in a route-server pair, drain traffic to the
 standby, upgrade, then swap.

--- a/docs/cookbook/ixp-filter-pipeline.md
+++ b/docs/cookbook/ixp-filter-pipeline.md
@@ -28,9 +28,9 @@ rbgp verification  +  Alice-LG via the birdwatcher adapter
 
 This recipe assumes the [route-server cookbook](route-server.md)
 shapes: transparent `route_server_client` sessions, RFC 9234
-`route_server` role, per-client best-path. Migration mapping from an
-existing BIRD/OpenBGPD deployment is in
-[route-server-migration.md](route-server-migration.md).
+`route_server` role, per-client best-path. Migration mapping from an existing
+BIRD/OpenBGPD deployment—including the manual OpenBGPD advertised-view
+boundary—is in [route-server-migration.md](route-server-migration.md).
 
 ## 1. Generate the resolved member data
 

--- a/docs/cookbook/route-server-migration.md
+++ b/docs/cookbook/route-server-migration.md
@@ -1,14 +1,14 @@
 # Route-server migration notes
 
-This page maps common FRR, BIRD, and ARouteServer route-server concepts to
-rustbgpd's config and verification surfaces. Structure is mechanical now —
-policy is not: `rbgp config import` translates the structural subset of a
-BIRD 2/3, FRR, or GoBGP config and refuses to guess at anything else, so use
-the importer for the skeleton, this page for the policy concepts it lists as
-untranslated, then run the shadow trial from the route-server cookbook
-before carrying production traffic.
+This page maps common FRR, BIRD, OpenBGPD, and ARouteServer route-server
+concepts to rustbgpd's config and verification surfaces. Structure is
+mechanical for BIRD 2/3, FRR, and GoBGP: `rbgp config import` translates their
+supported structural subset and refuses to guess at anything else. There is
+**no OpenBGPD importer**; use the manual mapping below. In every case, hand-map
+untranslated policy and run the shadow trial before carrying production
+traffic.
 
-## The mechanical first step
+## The mechanical first step (BIRD, FRR, and GoBGP)
 
 ```bash
 # 1. Translate the structure; the report lists every warning and stanza that
@@ -57,6 +57,10 @@ named by standalone `include` statements. Flatten every referenced file into
 one source before importing. Standalone `include` statements that remain are
 reported with their source line and make the translated skeleton exit 2 for
 operator review.
+
+Do not pass an OpenBGPD `bgpd.conf` under another `--format`: its grammar and
+semantics are not supported. Start with the baseline below and migrate each
+peer and policy explicitly.
 
 ## Baseline rustbgpd shape
 
@@ -188,6 +192,32 @@ Notes:
 - BIRD filter functions map best to `.rpol` named policies and parameterized
   policies. Keep prefix/community data in named sets so `rbgp policy check` and
   `rbgp policy test` can validate changes before reload.
+
+## OpenBGPD
+
+OpenBGPD route-server deployments commonly combine global
+[`transparent-as yes`][openbgpd-transparent-as] with per-neighbor policy and,
+where path hiding must be mitigated,
+[`rde evaluate all`][openbgpd-rde-evaluate]. Map those concepts as follows:
+
+- The closest mapping for transparent route-server export is
+  `route_server_client = true` on each member; also set
+  `role = "route_server"` so RFC 9234 role negotiation is explicit.
+  The flags are not a complete policy conversion. One important
+  non-equivalence is `NO_ADVERTISE`: OpenBGPD's `transparent-as` disables its
+  automatic well-known-community filtering, while rustbgpd always enforces
+  RFC 1997 `NO_ADVERTISE`. Audit any site policy that expected that community
+  to pass through the incumbent.
+- Map inbound and outbound rules to `import_policy_chain` and
+  `export_policy_chain`; translate the policy itself by hand to `.rpol`.
+- `rde evaluate all` maps to `per_client_best = true` for a member that cannot
+  receive Add-Path. Prefer negotiated Add-Path where the member supports it.
+- Translate authentication, timers, max-prefix limits, and address-family
+  enablement peer by peer. The importer cannot inventory or warn about omitted
+  OpenBGPD-only settings for you.
+
+Validate the completed config with `rustbgpd --check --strict`, then compare
+each member's post-filter view manually as described below.
 
 ## ARouteServer
 
@@ -321,6 +351,28 @@ Prerequisites and limitations:
 - Extended communities are rendered structurally and skipped (stderr
   note).
 
+### OpenBGPD (manual post-filter view)
+
+OpenBGPD's documented [`show rib out`][openbgpd-bgpctl-out] view of the
+filtered routes sent to one neighbor is:
+
+```sh
+bgpctl show rib out neighbor <member-ip> detail
+```
+
+Inspect this per member during the shadow trial. rustbgpd does not ship a
+`bgpctl` output adapter, so this text cannot be passed directly to `rbgp diff
+advertised` and must not be relabeled as an `rbgp-ribsnap/1` snapshot.
+
+OpenBGPD's generic [`dump table-v2`][openbgpd-dump] is a dump of a named RIB,
+not proof of a per-member post-policy Adj-RIB-Out. Likewise, neighbor-scoped
+[`dump updates out`][openbgpd-neighbor-dump] records ongoing BGP activity after
+capture starts; it is not a complete point-in-time advertised snapshot.
+Neither source satisfies
+`--view adj-rib-out-capture` on its own. Use the manual `bgpctl` view, or an
+independently captured source that can genuinely attest to the MRT/BMP
+post-policy boundaries below.
+
 ### MRT dumps
 
 If the incumbent's advertised view exists as an MRT `TABLE_DUMP_V2`
@@ -421,7 +473,9 @@ cutover blockers.
 
    Then run the systematic per-member advertised-view diff: export the
    incumbent's advertised routes to an `rbgp-ribsnap/1` NDJSON snapshot
-   with the bundled adapters (below; format details in
+   with a bundled BIRD/FRR/GoBGP adapter (below; OpenBGPD is manual unless an
+   independently captured MRT/BMP source satisfies the stated boundary;
+   format details in
    [`docs/ribdiff.md`](../ribdiff.md)) and compare it against the live
    Adj-RIB-Out:
 
@@ -443,3 +497,9 @@ cutover blockers.
 
 6. Cut member sessions in small batches. Keep the incumbent read-only during the
    first batch so advertised-view diffs remain available.
+
+[openbgpd-bgpctl-out]: https://man.openbsd.org/OpenBSD-7.7/bgpctl.8#out
+[openbgpd-dump]: https://man.openbsd.org/OpenBSD-7.7/bgpd.conf.5#dump
+[openbgpd-neighbor-dump]: https://man.openbsd.org/OpenBSD-7.7/bgpd.conf.5#dump~3
+[openbgpd-rde-evaluate]: https://man.openbsd.org/OpenBSD-7.7/bgpd.conf.5#rde
+[openbgpd-transparent-as]: https://man.openbsd.org/OpenBSD-7.7/bgpd.conf.5#transparent-as

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -826,36 +826,131 @@ bytes). The JSON fields preserve `false` as an explicit negotiated result and
 omit values an older daemon did not expose; a missing live-session snapshot is
 reported separately by `negotiation_available`.
 
-## Upgrade & state migration
+## Package upgrade and rollback
 
-### Routine upgrade (no schema change)
+This is the canonical procedure for the release `.deb` and `.rpm` packages.
+The package scripts create the service user and run `systemctl daemon-reload`;
+they deliberately do **not** stop, start, or restart rustbgpd. An operator must
+therefore own the graceful stop and the verification that follows it.
+
+### Upgrade
+
+1. Read the target release's CHANGELOG section and verify the downloaded
+   package against its release checksum. Config compatibility is not assumed
+   across minor releases.
+2. Extract the package into a temporary directory and run the **new** binary's
+   strict check against the configuration that the service will use:
+
+   ```sh
+   candidate_pkg=/path/to/rustbgpd_X.Y.Z_amd64.deb # or the .rpm
+   candidate_root=$(mktemp -d)
+   chmod 0755 "$candidate_root"
+
+   case "$candidate_pkg" in
+     *.deb) dpkg-deb --extract "$candidate_pkg" "$candidate_root" ;;
+     *.rpm) rpm2cpio "$candidate_pkg" |
+              (cd "$candidate_root" && cpio --quiet -id --no-absolute-filenames) ;;
+     *) echo "expected a .deb or .rpm" >&2; exit 2 ;;
+   esac
+
+   sudo -u rustbgpd \
+     "$candidate_root/usr/bin/rustbgpd" --check --strict \
+     /etc/rustbgpd/config.toml
+   ```
+
+   Fix every error before proceeding. There is no in-place schema migration
+   tool; make release-note field renames in the config by hand, then repeat the
+   candidate check.
+   This check validates candidate config bytes only: it does **not** inspect
+   `runtime_state_dir` or config-adjacent commit-confirm authority.
+
+   Before installing v0.65, use the still-running v0.64.0 daemon to run
+   `rbgp config status` and confirm or abort every pending transaction. A
+   locator-free `commit-confirm-journal.json` or a retired v2
+   `*.commit-confirm-locator.json` must be recovered with exactly rustbgpd
+   v0.64.0. Do not proceed while either artifact is present or inaccessible;
+   delete one only after proving the transaction terminal and the current
+   config intended. v0.65 otherwise refuses boot and leaves the authority
+   untouched.
+3. Stop the running daemon cleanly, then confirm it is down:
+
+   ```sh
+   sudo systemctl stop rustbgpd
+   systemctl is-active rustbgpd # expected: inactive
+   ```
+
+   The coordinated stop writes the GR restart marker. With GR enabled, the new
+   process can advertise `R=1` while sessions rebuild, but it advertises
+   `forwarding_preserved = false`; use a drained route-server pair when traffic
+   continuity matters.
+4. Install the already-checked package:
+
+   ```sh
+   sudo apt-get install -y "$candidate_pkg" # Debian / Ubuntu
+   sudo dnf install -y "$candidate_pkg"     # RHEL / Rocky / Alma
+   ```
+
+   Use the command for the host's package manager, not both. The package marks
+   `/etc/rustbgpd/config.toml` as `config|noreplace`: a locally modified config
+   stays in place. Inspect any replacement candidate reported by the package
+   manager before starting (normally `.dpkg-dist` or `.rpmnew`):
+
+   ```sh
+   sudo find /etc/rustbgpd -maxdepth 1 -type f \
+     \( -name '*.dpkg-dist' -o -name '*.rpmnew' \) -print
+   sudo -u rustbgpd /usr/bin/rustbgpd --check --strict \
+     /etc/rustbgpd/config.toml
+   ```
+
+5. Start and verify the installed version and its operator surfaces:
+
+   ```sh
+   sudo systemctl start rustbgpd
+   sudo systemctl --no-pager --full status rustbgpd
+   /usr/bin/rustbgpd --version
+   sudo -u rustbgpd rbgp health
+   sudo -u rustbgpd rbgp summary
+   ```
+
+   Confirm the reported version is the package you selected and wait for every
+   expected session to return to `Established`; `systemd` active alone does not
+   prove routing convergence.
+
+### Rollback
+
+A rollback is another compatibility migration, not merely a package command.
+Read the target version's release notes. Extract the old package as above and
+run its `rustbgpd --check --strict` against the intended rollback config before
+stopping the current daemon. If the old binary rejects the current config,
+restore a version-controlled config known to that release, preflight that exact
+file with the old binary, and install it only after the stop.
+
+Before downgrading, run `rbgp config status` and finish a pending confirmed
+transaction with `rbgp config confirm <id>` or `rbgp config abort <id>`. Do not
+delete a live locator to force the downgrade. Once the transaction is terminal,
+verify that the config-adjacent `*.commit-confirm-locator.json` and the retired
+locator-free `commit-confirm-journal.json` are absent. The fixed v3 raw prior
+and metadata may remain after a warning-only cleanup failure: once locator
+absence is verified they are non-authoritative, and rustbgpd v0.64.0 ignores
+those v3-only names. If the target predates v2 history, move the complete
+`config-history/` directory aside; do not let an old reader interpret a newer
+record layout.
+
+Then stop cleanly and install the selected older package:
 
 ```sh
+previous_pkg=/path/to/rustbgpd_W.X.Y_amd64.deb # or the .rpm
 sudo systemctl stop rustbgpd
-sudo install -m 0755 /tmp/rustbgpd-vX.Y.Z /usr/local/bin/rustbgpd
-sudo systemctl start rustbgpd
+sudo apt-get install -y --allow-downgrades "$previous_pkg" # Debian / Ubuntu
+sudo dnf install -y "$previous_pkg"                       # RHEL / Rocky / Alma
 ```
 
-GR is on by default; after a coordinated shutdown rustbgpd advertises `R=1`
-on the next OPEN. A GR-aware peer may retain eligible routes while sessions
-rebuild, but rustbgpd advertises `forwarding_preserved = false`: this is not a
-guarantee of forwarding continuity, and the peer may withdraw or replace routes
-until normal convergence.
-
-### Schema migration
-
-TOML format is **not frozen** between minor versions while rustbgpd is
-public alpha. Before upgrading across a minor version:
-
-1. Read the CHANGELOG entry for the target version. Breaking config
-   changes are called out under `### Changed` / `### Removed`.
-2. Build the new binary or pull the new container image.
-3. Run `rustbgpd --check /etc/rustbgpd/config.toml` against the **new**
-   binary. Fix any errors before swapping.
-4. Swap and start.
-
-There is no in-place schema migration tool. If the CHANGELOG describes
-a field rename, edit the config file by hand.
+Inspect any `.dpkg-dist`/`.rpmnew`, install the preflighted compatible config,
+then repeat the start and verification commands from the upgrade procedure.
+A binary that predates GR marker v3 rejects the v3 marker and cold-starts
+without restarting-speaker mode. Do not count on peer route retention across
+that boundary; drain the route-server member of a redundant pair first when
+continuity matters.
 
 ### Persistent state on disk
 
@@ -888,8 +983,9 @@ fail closed. Locator unlink plus parent `fsync` is terminal; only subsequent
 verified metadata/raw cleanup and pending-directory `fsync` are warning-only.
 
 Production reads and writes v3. Retired v1/v2 authority refuses boot untouched;
-finish it before upgrade or recover with rustbgpd v0.64.0. Before downgrade, finish or
-abort v3 and never delete its live locator manually.
+finish it before upgrade or recover with rustbgpd v0.64.0. Offline `--check`
+does not inspect this runtime state. Before downgrade, finish or abort v3 and
+never delete its live locator manually.
 
 Routing state is **not restored**. The optional shutdown checkpoint contains
 only eligible post-import-policy Adj-RIB-In views for future use; Loc-RIB,


### PR DESCRIPTION
## Summary

- make package-based upgrade and rollback the canonical deployment path, including strict candidate preflight and explicit v0.65 retired-authority handling
- document package-hook and config-noreplace behavior without claiming zero downtime
- add an honest OpenBGPD migration map and distinguish per-neighbor sent-route inspection from RIB and ongoing-update dumps

## Verification

- release install contract checker and all 18 unit tests
- exact post-#1538 range-diff and stable patch identity
- internal paths/anchors plus official OpenBSD command and format references
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- independent exact-head documentation and implementation-truth review
