### PR TITLE
config: materialize RFC 8212 tuple in transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   explicit `[global].ebgp_requires_policy = true|false`. Durable/effective
   renderings materialize the effective epoch (omission becomes epoch 1;
   explicit epoch 2 remains epoch 2) and boolean, while boot and
-  runtime-candidate inputs retain their raw representation.
+  runtime-candidate inputs retain their raw representation. A supported config
+  transaction with another real mutation now plans, receipts, stages, and persists that
+  materialization atomically; posture-only changes remain rejected. FIB failures before durable
+  finalization attempt to restore both tables and the raw prior snapshot. Lost persistence acknowledgement remains ambiguous after attempted restore; rollback failure remains ambiguous.
 - `birdwatcher-adapter` now accepts strict `unix:///absolute/path` daemon
   endpoints plus TCP, preserves lazy 502 recovery, and ships in native packages
   and the production container alongside release tarballs (LAN-925).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -534,7 +534,7 @@ Details in the "Recently shipped" section below and ADR-0097.
 - **RFC 8212 secure-by-default.** Opt-in enforcement
   (`ebgp_requires_policy`, ADR-0112) is shipped and receipted; the
   typed config-epoch/raw-presence representation, pre-activation rejection,
-  full-tuple restart pin, and allocation-safe canonical rendering are shipped.
+  full-tuple restart pin, allocation-safe canonical rendering, and transaction-scoped canonical tuple materialization are shipped.
   ADR-0125 authorizes activation only after ADR-0119's remaining mutation and
   interop proofs pass; activation changes only epoch-2 omission to effective
   `true`. Epoch-less and epoch-1 omission stay permissive, and explicit

--- a/crates/api/src/config_service.rs
+++ b/crates/api/src/config_service.rs
@@ -640,17 +640,23 @@ mod tests {
             ..rustbgpd_rib::UpdateGroupImpactPlan::default()
         };
         let expected = update_group_impact_to_proto(impact.clone());
-        let response = transaction_plan_to_proto(RuntimeConfigTransactionPlan {
+        let plan = RuntimeConfigTransactionPlan {
             status: RuntimeConfigTransactionStatus::Committable,
             runtime_snapshot_token: "before".to_string(),
             post_commit_runtime_snapshot_token: "after".to_string(),
+            committed_candidate: Some(crate::peer_types::RuntimeConfigTransactionCandidate::new(
+                "tcp_ao_key = \"transaction-secret\"".to_string(),
+            )),
             diff: sample_runtime_diff(),
             supported_sections: vec!["[policy]".to_string()],
             unsupported_sections: vec![],
             restart_required_sections: vec![],
             human_text: String::new(),
             update_group_impact: impact,
-        });
+        };
+        let debug = format!("{plan:?}");
+        assert!(!debug.contains("transaction-secret") && debug.contains("<redacted>"));
+        let response = transaction_plan_to_proto(plan);
         assert_eq!(response.update_group_impact, Some(expected));
     }
 
@@ -676,6 +682,7 @@ mod tests {
                 status: RuntimeConfigTransactionStatus::Committable,
                 runtime_snapshot_token: "kv1:abc:9".to_string(),
                 post_commit_runtime_snapshot_token: "kv1:def:10".to_string(),
+                committed_candidate: None,
                 diff: sample_runtime_diff(),
                 supported_sections: vec!["[[fib_tables]]".to_string()],
                 unsupported_sections: Vec::new(),
@@ -770,6 +777,7 @@ mod tests {
                 status: RuntimeConfigTransactionStatus::Noop,
                 runtime_snapshot_token: "kv1:abc:9".to_string(),
                 post_commit_runtime_snapshot_token: "kv1:abc:9".to_string(),
+                committed_candidate: None,
                 diff: RuntimeConfigDiff {
                     has_actionable_changes: false,
                     has_reload_applied_changes: false,

--- a/crates/api/src/config_service/stream.rs
+++ b/crates/api/src/config_service/stream.rs
@@ -859,6 +859,7 @@ mod tests {
             status,
             runtime_snapshot_token: "kv1:runtime:7".to_string(),
             post_commit_runtime_snapshot_token: "kv1:runtime:8".to_string(),
+            committed_candidate: None,
             diff: crate::peer_types::RuntimeConfigDiff {
                 has_actionable_changes: true,
                 has_reload_applied_changes: true,

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -430,6 +430,37 @@ pub enum RuntimeConfigTransactionStatus {
     Rejected,
 }
 
+/// Exact normalized candidate selected by the transaction planner.
+///
+/// The document can contain transport authentication secrets. Its `Debug`
+/// implementation is deliberately redacted so deriving `Debug` on the plan
+/// cannot disclose candidate content in logs or assertion failures.
+#[derive(Clone, PartialEq, Eq)]
+pub struct RuntimeConfigTransactionCandidate(String);
+
+impl RuntimeConfigTransactionCandidate {
+    #[must_use]
+    pub fn new(candidate_toml: String) -> Self {
+        Self(candidate_toml)
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl std::fmt::Debug for RuntimeConfigTransactionCandidate {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("RuntimeConfigTransactionCandidate(<redacted>)")
+    }
+}
+
 /// Validate-only transaction plan returned by the peer manager.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RuntimeConfigTransactionPlan {
@@ -441,6 +472,9 @@ pub struct RuntimeConfigTransactionPlan {
     /// it, so clients can safely chain a follow-up plan. Not surfaced in the
     /// gRPC plan response.
     pub post_commit_runtime_snapshot_token: String,
+    /// Exact canonical document every apply stage must consume if this plan
+    /// commits. Not surfaced through the public API.
+    pub committed_candidate: Option<RuntimeConfigTransactionCandidate>,
     pub diff: RuntimeConfigDiff,
     pub supported_sections: Vec<String>,
     pub unsupported_sections: Vec<String>,

--- a/docs/API.md
+++ b/docs/API.md
@@ -451,6 +451,12 @@ retain tonic's 4 MiB decode default.
 | `ListConfigHistory` | List bounded v2 config history — newest row at index 0, then older entries; per-entry timestamp, normalized-TOML SHA-256, config-source SHA-256 over that TOML digest plus the canonical accepted rpol/dataset source roster, provenance status, and one-line summary; never config documents (`rbgp config history`). Valid rows are `RECORDED`; corrupt or duplicate-sequence rows are `UNREADABLE` with both digests empty. Retired TOML files are ignored and retained. |
 | `RollbackConfigTransaction` | Restore a provenance-verified v2 row through the same transaction executor as apply — same plan/impact classification and receipts (`rbgp config rollback N`). Unreadable rows and provenance mismatches fail closed before planning or mutation. |
 
+For a supported transaction with an independent mutation, the plan carries one canonical committed candidate
+through token, runtime stage, persistence, and accepted history. It may materialize omitted RFC 8212 epoch-1/false
+presence without changing effective policy. Representation-only or posture-changing candidates are rejected before
+mutation. FIB transactions stage the full tables-plus-posture snapshot;
+determinate failures attempt to restore both. Lost persistence acknowledgement remains ambiguous after attempted restore; rollback or post-durable finalization failure is also ambiguous.
+
 Index 0 is not necessarily the running or currently persisted config. V2 rows
 hash the accepted external-source identity, but do not archive the
 `.rpol` or dataset bytes. Rollback performs one detached load and requires the

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -143,6 +143,10 @@ boolean: omission becomes `config_epoch = 1`, while an explicit epoch 2 remains
 `config_epoch = 2`. Merely booting an epoch-less operator file does not rewrite
 its bytes.
 
+A supported config transaction with a real non-posture mutation atomically materializes the exact unchanged
+effective posture (for example, omission becomes epoch 1 plus explicit false). Posture-only, effective-value, or partial materialization changes are rejected.
+Boot, SIGHUP, and general diff candidates remain source-preserving; targeted CRUD is unchanged.
+
 ---
 
 ## `[global]`

--- a/docs/adr/0119-rfc-8212-secure-default-config-epoch.md
+++ b/docs/adr/0119-rfc-8212-secure-default-config-epoch.md
@@ -22,11 +22,10 @@ authorizes activation only after the production-mutation proof gate below is
 complete. Acceptance itself does not change route handling, activate a new
 default, or supersede ADR-0112 and its M95 real-session receipt.
 
-The representation tranche is implemented: typed raw epoch/boolean presence,
-the pre-activation epoch-2 rejection, full-tuple diff/reload pinning, and the
-shared borrowed canonical renderer have landed. The advisory, runtime-mutation
-materialization-transition planning/receipt proof, migration/downgrade tooling,
-M95 extension, and activation are still gated by the proof plan below.
+The representation and transaction-materialization tranches are implemented: typed raw
+presence, pre-activation epoch-2 rejection, full-tuple restart pinning, shared canonical
+rendering, and atomic transaction planning/receipt proofs have landed. The advisory,
+migration/downgrade tooling, M95 extension, and activation remain gated by the proof plan below.
 
 ## Decision
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2930,6 +2930,58 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
     class
 }
 
+/// Materialize the RFC 8212 tuple for a real v1 transaction mutation.
+///
+/// A caller may preserve the live raw tuple or supply its exact canonical
+/// representation. Every partial representation edit, effective-value move,
+/// or regression from canonical back to omitted remains restart-required.
+/// The candidate is changed only when the non-tuple diff is independently
+/// committable, so a representation-only request remains rejected/no-op.
+pub(crate) fn materialize_rfc8212_transaction_candidate(
+    live: &Config,
+    candidate: &mut Config,
+) -> Option<ConfigDiff> {
+    let live_posture = live.rfc8212_posture();
+    let candidate_posture = candidate.rfc8212_posture();
+    if live_posture.config_epoch_effective != candidate_posture.config_epoch_effective
+        || live_posture.policy_effective != candidate_posture.policy_effective
+    {
+        return None;
+    }
+
+    let live_raw = (live_posture.config_epoch_raw, live_posture.policy_raw);
+    let candidate_raw = (
+        candidate_posture.config_epoch_raw,
+        candidate_posture.policy_raw,
+    );
+    let canonical = (
+        Some(live_posture.config_epoch_effective),
+        Some(live_posture.policy_effective),
+    );
+    if candidate_raw != live_raw && candidate_raw != canonical {
+        return None;
+    }
+    if live_raw == canonical {
+        return None;
+    }
+
+    // Classify only the real mutation. Restoring the live raw tuple prevents
+    // this helper from using its own representation change as authorization.
+    candidate.config_epoch = live_raw.0;
+    candidate.global.ebgp_requires_policy = live_raw.1;
+    let operational_diff = diff_config(live, candidate);
+    let mutation = classify_config_transaction_v1(&operational_diff);
+    candidate.config_epoch = candidate_raw.0;
+    candidate.global.ebgp_requires_policy = candidate_raw.1;
+    if !mutation.is_committable() {
+        return None;
+    }
+
+    candidate.config_epoch = canonical.0;
+    candidate.global.ebgp_requires_policy = canonical.1;
+    Some(operational_diff)
+}
+
 fn session_reshape_transaction(diff: &ConfigDiff) -> bool {
     if !diff.neighbors.added.is_empty() || !diff.neighbors.removed.is_empty() {
         return false;
@@ -3443,6 +3495,40 @@ const fn format_policy_source(source: Rfc8212PolicySource) -> &'static str {
         Rfc8212PolicySource::ExplicitFalse => "explicit_false",
         Rfc8212PolicySource::ExplicitTrue => "explicit_true",
     }
+}
+
+/// Render the exact tuple transition that accompanies an otherwise supported
+/// transaction. The same raw edit remains restart-required in generic diffs.
+pub(crate) fn format_rfc8212_transaction_materialization(diff: &ConfigDiff) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::from("Informational transaction materialization:\n");
+    if let Some(change) = diff.config_epoch {
+        let _ = writeln!(
+            out,
+            "config_epoch: raw={} effective={} source={} -> raw={} effective={} source={}",
+            format_epoch_raw(change.before.raw),
+            change.before.effective.value(),
+            format_epoch_source(change.before.source),
+            format_epoch_raw(change.after.raw),
+            change.after.effective.value(),
+            format_epoch_source(change.after.source),
+        );
+    }
+    if let Some(change) = diff.ebgp_requires_policy {
+        let _ = writeln!(
+            out,
+            "[global].ebgp_requires_policy: raw={} effective={} source={} -> raw={} effective={} source={}",
+            format_policy_raw(change.before.raw),
+            change.before.effective,
+            format_policy_source(change.before.source),
+            format_policy_raw(change.after.raw),
+            change.after.effective,
+            format_policy_source(change.after.source),
+        );
+    }
+    out.push_str("Route behavior is unchanged.\n");
+    out
 }
 
 /// Compare two full configurations and return a structured diff.

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -13347,6 +13347,79 @@ fn rfc8212_canonical_sinks_materialize_without_rewriting_boot_input() {
     );
 }
 
+fn rfc8212_transaction_fixture(
+    epoch: Option<&str>,
+    policy: Option<bool>,
+    add_neighbor: bool,
+) -> Config {
+    let mut source = rfc8212_representation_toml(epoch, policy);
+    if add_neighbor {
+        source.push_str(
+            r#"
+[[neighbors]]
+address = "192.0.2.44"
+remote_asn = 65044
+"#,
+        );
+    }
+    parse(&source).unwrap()
+}
+
+/// Load-bearing transaction matrix. Removing the supported-mutation fence,
+/// accepting a partial/source-regressing tuple, or changing the exact
+/// canonical target makes a named row red.
+#[test]
+fn rfc8212_transaction_materialization_requires_real_mutation_and_exact_posture() {
+    for (label, live_epoch, live_policy, candidate_epoch, candidate_policy) in [
+        ("raw legacy", None, None, None, None),
+        ("caller canonical", None, None, Some("1"), Some(false)),
+        ("true posture", None, Some(true), None, Some(true)),
+        ("epoch-only omission", Some("1"), None, Some("1"), None),
+    ] {
+        let live = rfc8212_transaction_fixture(live_epoch, live_policy, false);
+        let mut candidate = rfc8212_transaction_fixture(candidate_epoch, candidate_policy, true);
+        let operational = materialize_rfc8212_transaction_candidate(&live, &mut candidate)
+            .unwrap_or_else(|| panic!("{label} must materialize"));
+        assert_eq!(
+            classify_config_transaction_v1(&operational).supported_sections,
+            vec!["[[neighbors]] add"],
+            "{label}"
+        );
+        let posture = candidate.rfc8212_posture();
+        assert_eq!(posture.config_epoch_raw, Some(ConfigEpoch::V1), "{label}");
+        assert_eq!(
+            posture.policy_raw,
+            Some(posture.policy_effective),
+            "{label}"
+        );
+    }
+
+    for (label, live_epoch, live_policy, candidate_epoch, candidate_policy, mutate) in [
+        ("no-op", None, None, None, None, false),
+        ("representation", None, None, Some("1"), Some(false), false),
+        ("partial", None, None, Some("1"), None, true),
+        ("effective change", None, None, None, Some(true), true),
+        (
+            "source regression",
+            Some("1"),
+            Some(false),
+            None,
+            None,
+            true,
+        ),
+        ("epoch move", None, None, Some("2"), Some(false), true),
+    ] {
+        let live = rfc8212_transaction_fixture(live_epoch, live_policy, false);
+        let mut candidate = rfc8212_transaction_fixture(candidate_epoch, candidate_policy, mutate);
+        let before = candidate.rfc8212_posture();
+        assert!(
+            materialize_rfc8212_transaction_candidate(&live, &mut candidate).is_none(),
+            "{label}"
+        );
+        assert_eq!(candidate.rfc8212_posture(), before, "{label}");
+    }
+}
+
 /// Structural companion to the release HWM receipt: the runtime A/B alone
 /// cannot detect adding the same internal deep clone to both arms. This pins
 /// every large projection field as borrowed, the one allowed small Global

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -29,7 +29,7 @@ use crate::config::{
     diff_neighbors,
 };
 use crate::fib_table_control::{
-    FibTableControlDeps, commit_fib_tables_locked, runtime_unavailable_error,
+    FibTableControlDeps, read_current_tables, replace_tables, runtime_unavailable_error,
 };
 use crate::gnmi_set_bridge;
 use crate::peer_manager::InternalCommand;
@@ -311,9 +311,14 @@ impl ConfigTransactionController {
         } else if let Some(preloaded) = preloaded {
             self.reject_if_pending("ConfigService.RollbackConfigTransaction")
                 .await?;
-            apply_config_transaction_locked_with_preloaded(&self.deps, request, Some(preloaded))
-                .await
-                .map_err(|failure| failure.error)
+            apply_config_transaction_locked_with_preloaded(
+                &self.deps,
+                request,
+                Some(preloaded),
+                self.peer_mgr_internal_tx.as_ref(),
+            )
+            .await
+            .map_err(|failure| failure.error)
         } else {
             self.apply_locked(request, None).await
         }
@@ -558,9 +563,13 @@ impl ConfigTransactionController {
                 // and the candidate was just built from the live runtime
                 // snapshot. Let the shared apply executor do the single
                 // authoritative plan.
-                apply_config_transaction_locked(&self.deps, request)
-                    .await
-                    .map_err(|failure| apply_error_to_gnmi_set_error(failure.error))?
+                apply_config_transaction_locked(
+                    &self.deps,
+                    request,
+                    self.peer_mgr_internal_tx.as_ref(),
+                )
+                .await
+                .map_err(|failure| apply_error_to_gnmi_set_error(failure.error))?
             };
             gnmi_set_outcome_from_apply_response(response)
         });
@@ -593,7 +602,7 @@ impl ConfigTransactionController {
         } else {
             self.reject_if_pending("ConfigService.ApplyConfigTransaction")
                 .await?;
-            apply_config_transaction_locked(&self.deps, request)
+            apply_config_transaction_locked(&self.deps, request, self.peer_mgr_internal_tx.as_ref())
                 .await
                 .map_err(|failure| failure.error)
         }
@@ -699,7 +708,10 @@ impl ConfigTransactionController {
         };
 
         let mut response = match apply_config_transaction_locked_with_preloaded(
-            &self.deps, request, preloaded,
+            &self.deps,
+            request,
+            preloaded,
+            self.peer_mgr_internal_tx.as_ref(),
         )
         .await
         {
@@ -1381,6 +1393,7 @@ impl ConfigTransactionController {
             &self.deps,
             request,
             Some((plan, Arc::clone(prior))),
+            self.peer_mgr_internal_tx.as_ref(),
         )
         .await;
         let response = result
@@ -1710,7 +1723,7 @@ async fn apply_config_transaction(
 
     let join = tokio::spawn(async move {
         let _guard = deps.lock.lock().await;
-        apply_config_transaction_locked(&deps, request)
+        apply_config_transaction_locked(&deps, request, None)
             .await
             .map_err(|failure| failure.error)
     });
@@ -1722,11 +1735,32 @@ async fn apply_config_transaction(
     })?
 }
 
+#[cfg(test)]
+async fn apply_config_transaction_with_internal(
+    deps: Arc<FibTableControlDeps>,
+    request: proto::ApplyConfigTransactionRequest,
+    peer_mgr_internal_tx: mpsc::UnboundedSender<InternalCommand>,
+) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
+    validate_apply_request(&request)?;
+    let join = tokio::spawn(async move {
+        let _guard = deps.lock.lock().await;
+        apply_config_transaction_locked(&deps, request, Some(&peer_mgr_internal_tx))
+            .await
+            .map_err(|failure| failure.error)
+    });
+    join.await.map_err(|_| {
+        ConfigTransactionApplyError::Internal(
+            "config transaction apply task did not complete".to_string(),
+        )
+    })?
+}
+
 async fn apply_config_transaction_locked(
     deps: &FibTableControlDeps,
     request: proto::ApplyConfigTransactionRequest,
+    peer_mgr_internal_tx: Option<&mpsc::UnboundedSender<InternalCommand>>,
 ) -> Result<proto::ConfigTransactionApplyResponse, ApplyFailure> {
-    apply_config_transaction_locked_with_preloaded(deps, request, None).await
+    apply_config_transaction_locked_with_preloaded(deps, request, None, peer_mgr_internal_tx).await
 }
 
 async fn apply_config_transaction_locked_with_preloaded(
@@ -1736,6 +1770,7 @@ async fn apply_config_transaction_locked_with_preloaded(
         rustbgpd_api::peer_types::RuntimeConfigTransactionPlan,
         Arc<AcceptedConfigSnapshot>,
     )>,
+    peer_mgr_internal_tx: Option<&mpsc::UnboundedSender<InternalCommand>>,
 ) -> Result<proto::ConfigTransactionApplyResponse, ApplyFailure> {
     let plan = match &preloaded {
         Some((plan, _)) => plan.clone(),
@@ -1772,13 +1807,33 @@ async fn apply_config_transaction_locked_with_preloaded(
         return Ok(rejected_response(plan.runtime_snapshot_token));
     };
 
+    let committed_candidate_toml = plan
+        .committed_candidate
+        .clone()
+        .ok_or_else(|| {
+            ConfigTransactionApplyError::Internal(
+                "committable config transaction plan omitted its candidate".to_string(),
+            )
+        })?
+        .into_inner();
     let candidate = match preloaded {
-        Some((_, snapshot)) => snapshot.config(),
+        Some((_, snapshot)) => {
+            let representation: Config =
+                toml::from_str(&committed_candidate_toml).map_err(|error| {
+                    ConfigTransactionApplyError::Internal(format!(
+                        "planned config transaction candidate became invalid: {error}"
+                    ))
+                })?;
+            let mut candidate = snapshot.config();
+            candidate.config_epoch = representation.config_epoch;
+            candidate.global.ebgp_requires_policy = representation.global.ebgp_requires_policy;
+            candidate
+        }
         None => Config::load_toml_with_diagnostics(
-            &request.candidate_toml,
-            "candidate config transaction",
+            &committed_candidate_toml,
+            "planned config transaction candidate",
         )
-        .map_err(ConfigTransactionApplyError::InvalidArgument)?,
+        .map_err(ConfigTransactionApplyError::Internal)?,
     };
     let config_tx = deps.config_tx.clone().ok_or_else(|| {
         ConfigTransactionApplyError::FailedPrecondition(
@@ -1791,12 +1846,13 @@ async fn apply_config_transaction_locked_with_preloaded(
     // key); the apply path can't recompute a key-consistent token itself.
     let post_commit_runtime_snapshot_token = plan.post_commit_runtime_snapshot_token;
     let update_group_impact = rustbgpd_api::update_group_impact_to_proto(plan.update_group_impact);
-    let committed_candidate_toml = request.candidate_toml.clone();
+    let authoritative_candidate_toml = committed_candidate_toml.clone();
     let mut response = commit_apply_family(
         deps,
+        peer_mgr_internal_tx,
         &config_tx,
         family,
-        request.candidate_toml,
+        committed_candidate_toml,
         candidate,
         plan.supported_sections,
         post_commit_runtime_snapshot_token,
@@ -1804,8 +1860,12 @@ async fn apply_config_transaction_locked_with_preloaded(
     )
     .await?;
     if family == ApplyFamily::LivePolicyImpact {
-        let authoritative =
-            plan_candidate(&deps.peer_mgr_tx, committed_candidate_toml, String::new()).await?;
+        let authoritative = plan_candidate(
+            &deps.peer_mgr_tx,
+            authoritative_candidate_toml,
+            String::new(),
+        )
+        .await?;
         response.runtime_snapshot_token = authoritative.runtime_snapshot_token;
     }
     Ok(response)
@@ -1817,6 +1877,7 @@ async fn apply_config_transaction_locked_with_preloaded(
 )]
 async fn commit_apply_family(
     deps: &FibTableControlDeps,
+    peer_mgr_internal_tx: Option<&mpsc::UnboundedSender<InternalCommand>>,
     config_tx: &mpsc::Sender<ConfigEvent>,
     family: ApplyFamily,
     candidate_toml: String,
@@ -1839,6 +1900,7 @@ async fn commit_apply_family(
     // future by that snapshot.
     let committed = Box::pin(commit_apply_family_inner(
         deps,
+        peer_mgr_internal_tx,
         config_tx,
         family,
         candidate_toml,
@@ -1917,6 +1979,7 @@ async fn finish_outbound_prefix_limit_transaction(
 )]
 async fn commit_apply_family_inner(
     deps: &FibTableControlDeps,
+    peer_mgr_internal_tx: Option<&mpsc::UnboundedSender<InternalCommand>>,
     config_tx: &mpsc::Sender<ConfigEvent>,
     family: ApplyFamily,
     candidate_toml: String,
@@ -1929,8 +1992,10 @@ async fn commit_apply_family_inner(
         ApplyFamily::FibTables => {
             commit_fib_transaction(
                 deps,
+                peer_mgr_internal_tx,
                 config_tx,
-                &candidate,
+                candidate_toml,
+                candidate,
                 post_commit_runtime_snapshot_token,
                 update_group_impact,
             )
@@ -2021,34 +2086,148 @@ async fn commit_apply_family_inner(
 
 async fn commit_fib_transaction(
     deps: &FibTableControlDeps,
+    peer_mgr_internal_tx: Option<&mpsc::UnboundedSender<InternalCommand>>,
     config_tx: &mpsc::Sender<ConfigEvent>,
-    candidate: &Config,
+    candidate_toml: String,
+    candidate: Config,
     post_commit_runtime_snapshot_token: String,
     update_group_impact: proto::UpdateGroupImpactPlan,
 ) -> Result<proto::ConfigTransactionApplyResponse, ApplyFailure> {
     let fib_cmd_tx = deps.fib_cmd_tx.clone().ok_or_else(|| {
         fib_error_to_apply_error(runtime_unavailable_error(!deps.startup_tables.is_empty()))
     })?;
-    let response = commit_fib_tables_locked(
-        &fib_cmd_tx,
-        &deps.peer_mgr_tx,
-        config_tx,
-        candidate.fib_tables.clone(),
+    let Some(peer_mgr_internal_tx) = peer_mgr_internal_tx else {
+        return Err(ConfigTransactionApplyError::Unavailable(
+            "FIB config-transaction snapshot staging is unavailable".to_string(),
+        )
+        .into());
+    };
+
+    let permit = reserve_persist_permit(config_tx).await?;
+    let previous_tables = read_current_tables(
+        Some(&fib_cmd_tx),
+        rustbgpd_api::rib_service::FibTableControlError::Internal,
     )
     .await
-    .map_err(|failure| ApplyFailure {
-        error: fib_error_to_apply_error(failure.error),
-        ambiguous: failure.ambiguous,
-    })?;
+    .map_err(fib_error_to_apply_error)?
+    .unwrap_or_default();
+    let staged_tables = candidate.fib_tables.clone();
+    let previous = stage_preloaded_config_snapshot(peer_mgr_internal_tx, candidate).await?;
+    if let Err(error) = replace_tables(&fib_cmd_tx, staged_tables.clone()).await {
+        return Err(restore_preloaded_snapshot_after_error(
+            peer_mgr_internal_tx,
+            previous,
+            fib_error_to_apply_error(error).into(),
+        )
+        .await);
+    }
+    if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
+        return Err(rollback_fib_transaction_after_error(
+            &fib_cmd_tx,
+            peer_mgr_internal_tx,
+            previous_tables,
+            previous,
+            failure,
+        )
+        .await);
+    }
+    commit_config_snapshot_stage(&deps.peer_mgr_tx)
+        .await
+        .map_err(ApplyFailure::ambiguous)?;
     Ok(committable_response(
         post_commit_runtime_snapshot_token,
         vec![FIB_SECTION.to_string()],
         format!(
             "Committed [[fib_tables]] transaction.\n{} table(s) active.\n",
-            response.tables.len()
+            staged_tables.len()
         ),
         Some(update_group_impact),
     ))
+}
+
+async fn stage_preloaded_config_snapshot(
+    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    candidate: Config,
+) -> Result<Box<Config>, ApplyFailure> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_internal_tx
+        .send(InternalCommand::StageTransactionConfig {
+            candidate: Box::new(candidate),
+            reply: reply_tx,
+        })
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable("peer manager is unavailable".to_string())
+        })?;
+    reply_rx
+        .await
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable(
+                "peer manager dropped config transaction snapshot stage reply".to_string(),
+            )
+        })?
+        .map_err(|error| ConfigTransactionApplyError::InvalidArgument(error).into())
+}
+
+async fn restore_preloaded_config_snapshot(
+    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    previous: Box<Config>,
+) -> Result<(), ConfigTransactionApplyError> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    peer_mgr_internal_tx
+        .send(InternalCommand::RestoreTransactionConfig {
+            previous,
+            reply: reply_tx,
+        })
+        .map_err(|_| {
+            ConfigTransactionApplyError::Unavailable(
+                "peer manager is unavailable during config transaction rollback".to_string(),
+            )
+        })?;
+    reply_rx.await.map_err(|_| {
+        ConfigTransactionApplyError::Unavailable(
+            "peer manager dropped config transaction snapshot rollback reply".to_string(),
+        )
+    })
+}
+
+async fn restore_preloaded_snapshot_after_error(
+    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    previous: Box<Config>,
+    original: ApplyFailure,
+) -> ApplyFailure {
+    match restore_preloaded_config_snapshot(peer_mgr_internal_tx, previous).await {
+        Ok(()) => original,
+        Err(rollback) => ApplyFailure::ambiguous(ConfigTransactionApplyError::Internal(format!(
+            "{}; config snapshot rollback failed: {rollback}",
+            original.error
+        ))),
+    }
+}
+
+async fn rollback_fib_transaction_after_error(
+    fib_cmd_tx: &mpsc::Sender<crate::fib_runtime::FibRuntimeCommand>,
+    peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
+    previous_tables: Vec<crate::config::FibTableConfig>,
+    previous: Box<Config>,
+    original: ApplyFailure,
+) -> ApplyFailure {
+    let runtime_rollback = replace_tables(fib_cmd_tx, previous_tables).await;
+    let snapshot_rollback = restore_preloaded_config_snapshot(peer_mgr_internal_tx, previous).await;
+    match (runtime_rollback, snapshot_rollback) {
+        (Ok(()), Ok(())) => original,
+        (runtime, snapshot) => {
+            ApplyFailure::ambiguous(ConfigTransactionApplyError::Internal(format!(
+                "{}; FIB transaction rollback failed; runtime: {}; snapshot: {}",
+                original.error,
+                runtime
+                    .err()
+                    .map_or_else(|| "ok".to_string(), |error| error.to_string()),
+                snapshot
+                    .err()
+                    .map_or_else(|| "ok".to_string(), |error| error.to_string()),
+            )))
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -3418,8 +3597,8 @@ mod tests {
         assert_tier_authorized_test_config, tier_authorized_uds_test_config,
     };
     use rustbgpd_api::peer_types::{
-        FibTableSnapshot, RuntimeConfigDiff, RuntimeConfigTransactionPlan,
-        RuntimeConfigTransactionPlanError,
+        FibTableSnapshot, RuntimeConfigDiff, RuntimeConfigTransactionCandidate,
+        RuntimeConfigTransactionPlan, RuntimeConfigTransactionPlanError,
     };
     use rustbgpd_api::rib_service::FibTableControlError;
     use rustbgpd_policy::PolicyAction;
@@ -3502,6 +3681,11 @@ remote_asn = 65002
             "confirmed rollback must bind one accepted provenance generation"
         );
         assert!(!production.contains("use crate::reload::runtime_config_snapshot;"));
+        let apply = production
+            .rsplit_once("let committed_candidate_toml")
+            .unwrap()
+            .1;
+        assert!(!apply.contains("request.candidate_toml"));
 
         let reload = include_str!("reload.rs");
         let legacy = reload
@@ -3790,6 +3974,17 @@ ttl_security = true
             maximum_paths_ebgp: table.maximum_paths_ebgp,
             maximum_paths_ibgp: table.maximum_paths_ibgp,
         }
+    }
+
+    fn fib_config(table: &FibTableConfig) -> Config {
+        Config::load_toml_with_diagnostics(
+            &base_toml(&format!(
+                "[[fib_tables]]\nname = {:?}\ntable_id = {}\nmetric = {}\nfamilies = [\"ipv4_unicast\"]\n",
+                table.name, table.table_id, table.metric
+            )),
+            "FIB transaction fixture",
+        )
+        .unwrap()
     }
 
     fn peer_config_from_toml(toml: &str, address: &str) -> PeerManagerNeighborConfig {
@@ -4149,6 +4344,7 @@ peer_group = "edge"
             status,
             runtime_snapshot_token: "kv1:old:1".to_string(),
             post_commit_runtime_snapshot_token: "kv1:new:2".to_string(),
+            committed_candidate: None,
             diff: diff(),
             supported_sections,
             unsupported_sections: Vec::new(),
@@ -4158,6 +4354,26 @@ peer_group = "edge"
         }
     }
 
+    fn attach_committed_candidate(
+        mut plan: RuntimeConfigTransactionPlan,
+        candidate_toml: &str,
+    ) -> RuntimeConfigTransactionPlan {
+        if plan.status == RuntimeConfigTransactionStatus::Committable
+            && plan.committed_candidate.is_none()
+        {
+            let candidate = Config::load_toml_with_diagnostics(
+                candidate_toml,
+                "fake transaction planner candidate",
+            )
+            .expect("fake planner candidate must load");
+            plan.committed_candidate = Some(RuntimeConfigTransactionCandidate::new(
+                crate::config::persisted_config_document(&candidate)
+                    .expect("fake planner candidate must serialize"),
+            ));
+        }
+        plan
+    }
+
     async fn fake_peer_manager(
         mut rx: mpsc::Receiver<PeerManagerCommand>,
         plan: RuntimeConfigTransactionPlan,
@@ -4165,8 +4381,15 @@ peer_group = "edge"
     ) {
         while let Some(cmd) = rx.recv().await {
             match cmd {
-                PeerManagerCommand::PlanConfigTransaction { reply, .. } => {
-                    let _ = reply.send(Ok(plan.clone()));
+                PeerManagerCommand::PlanConfigTransaction {
+                    candidate_toml,
+                    reply,
+                    ..
+                } => {
+                    let _ = reply.send(Ok(attach_committed_candidate(
+                        plan.clone(),
+                        &candidate_toml,
+                    )));
                 }
                 PeerManagerCommand::StageFibTables { tables, reply } => {
                     *staged.lock().await = tables;
@@ -4174,6 +4397,9 @@ peer_group = "edge"
                 }
                 PeerManagerCommand::SetFibTablesSnapshot { tables, reply } => {
                     *staged.lock().await = tables;
+                    let _ = reply.send(());
+                }
+                PeerManagerCommand::CommitConfigSnapshotStage { reply } => {
                     let _ = reply.send(());
                 }
                 _ => panic!("unexpected peer-manager command in config transaction test"),
@@ -4198,6 +4424,25 @@ peer_group = "edge"
                     }
                     let _ = reply.send(result);
                 }
+            }
+        }
+    }
+
+    async fn fake_transaction_snapshot_manager(
+        mut rx: mpsc::UnboundedReceiver<InternalCommand>,
+        current: Arc<Mutex<Config>>,
+    ) {
+        while let Some(command) = rx.recv().await {
+            match command {
+                InternalCommand::StageTransactionConfig { candidate, reply } => {
+                    let previous = std::mem::replace(&mut *current.lock().await, *candidate);
+                    let _ = reply.send(Ok(Box::new(previous)));
+                }
+                InternalCommand::RestoreTransactionConfig { previous, reply } => {
+                    *current.lock().await = *previous;
+                    let _ = reply.send(());
+                }
+                _ => panic!("unexpected internal command in transaction snapshot fake"),
             }
         }
     }
@@ -4230,8 +4475,15 @@ peer_group = "edge"
     ) {
         while let Some(cmd) = rx.recv().await {
             match cmd {
-                PeerManagerCommand::PlanConfigTransaction { reply, .. } => {
-                    let _ = reply.send(Ok(plan.clone()));
+                PeerManagerCommand::PlanConfigTransaction {
+                    candidate_toml,
+                    reply,
+                    ..
+                } => {
+                    let _ = reply.send(Ok(attach_committed_candidate(
+                        plan.clone(),
+                        &candidate_toml,
+                    )));
                 }
                 PeerManagerCommand::StageConfigSnapshot {
                     candidate_toml,
@@ -4358,13 +4610,17 @@ peer_group = "edge"
     ) {
         while let Some(cmd) = rx.recv().await {
             match cmd {
-                PeerManagerCommand::PlanConfigTransaction { reply, .. } => {
+                PeerManagerCommand::PlanConfigTransaction {
+                    candidate_toml,
+                    reply,
+                    ..
+                } => {
                     let plan = plans
                         .lock()
                         .await
                         .pop_front()
                         .expect("test queued too few transaction plans");
-                    let _ = reply.send(Ok(plan));
+                    let _ = reply.send(Ok(attach_committed_candidate(plan, &candidate_toml)));
                 }
                 PeerManagerCommand::StageConfigSnapshot {
                     candidate_toml,
@@ -4410,8 +4666,15 @@ peer_group = "edge"
     ) {
         while let Some(cmd) = rx.recv().await {
             match cmd {
-                PeerManagerCommand::PlanConfigTransaction { reply, .. } => {
-                    let _ = reply.send(Ok(plan.clone()));
+                PeerManagerCommand::PlanConfigTransaction {
+                    candidate_toml,
+                    reply,
+                    ..
+                } => {
+                    let _ = reply.send(Ok(attach_committed_candidate(
+                        plan.clone(),
+                        &candidate_toml,
+                    )));
                 }
                 PeerManagerCommand::StageConfigSnapshot {
                     candidate_toml,
@@ -4740,11 +5003,11 @@ peer_group = "{group}"
         while let Some(cmd) = rx.recv().await {
             match cmd {
                 PeerManagerCommand::PlanConfigTransaction {
+                    candidate_toml,
                     expected_runtime_snapshot_token,
                     reply,
-                    ..
                 } => {
-                    let mut response = plan.clone();
+                    let mut response = attach_committed_candidate(plan.clone(), &candidate_toml);
                     if plan_calls > 0 {
                         response.runtime_snapshot_token =
                             plan.post_commit_runtime_snapshot_token.clone();
@@ -4988,7 +5251,7 @@ remote_asn = 65010
             proto::ConfigTransactionPlanStatus::Committable as i32
         );
         assert_eq!(response.committed_sections, vec!["[[dynamic_neighbors]]"]);
-        assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &candidate_toml);
     }
 
     async fn ack_config_transaction_commits(mut config_rx: mpsc::Receiver<ConfigEvent>) {
@@ -5031,8 +5294,15 @@ remote_asn = 65010
     ) {
         while let Some(cmd) = rx.recv().await {
             match cmd {
-                PeerManagerCommand::PlanConfigTransaction { reply, .. } => {
-                    let _ = reply.send(Ok(plan.clone()));
+                PeerManagerCommand::PlanConfigTransaction {
+                    candidate_toml,
+                    reply,
+                    ..
+                } => {
+                    let _ = reply.send(Ok(attach_committed_candidate(
+                        plan.clone(),
+                        &candidate_toml,
+                    )));
                 }
                 PeerManagerCommand::StageConfigSnapshot {
                     candidate_toml,
@@ -5150,7 +5420,7 @@ remote_asn = 65010
             proto::ConfigTransactionConfirmationStatus::Pending as i32
         );
         assert_eq!(confirmation.confirm_id, "deploy-1");
-        assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &candidate_toml);
         (controller, snapshot_toml, ack_task)
     }
 
@@ -5191,10 +5461,19 @@ remote_asn = 65010
         let (internal_tx, mut internal_rx) = mpsc::unbounded_channel();
         tokio::spawn(async move {
             while let Some(command) = internal_rx.recv().await {
-                let InternalCommand::PlanAcceptedSnapshot { reply, .. } = command else {
+                let InternalCommand::PlanAcceptedSnapshot {
+                    snapshot, reply, ..
+                } = command
+                else {
                     panic!("rollback planner received an unexpected reload command");
                 };
-                let _ = reply.send(Ok(response.clone()));
+                let candidate_toml =
+                    crate::config::persisted_config_document(snapshot.config_ref())
+                        .expect("preloaded fake planner candidate must serialize");
+                let _ = reply.send(Ok(attach_committed_candidate(
+                    response.clone(),
+                    &candidate_toml,
+                )));
             }
         });
         controller.with_preloaded_planner(internal_tx)
@@ -5507,8 +5786,15 @@ remote_asn = 65010
                                 rpol: runtime_rpol.clone(),
                             }));
                     }
-                    PeerManagerCommand::PlanConfigTransaction { reply, .. } => {
-                        let _ = reply.send(Ok(plan.clone()));
+                    PeerManagerCommand::PlanConfigTransaction {
+                        candidate_toml,
+                        reply,
+                        ..
+                    } => {
+                        let _ = reply.send(Ok(attach_committed_candidate(
+                            plan.clone(),
+                            &candidate_toml,
+                        )));
                     }
                     _ => panic!("unexpected peer-manager command in v3 external fence harness"),
                 }
@@ -5653,6 +5939,7 @@ families = ["ipv4_unicast"]
         std::fs::write(&config_path, &previous_toml).unwrap();
         let accepted = Arc::new(AcceptedConfigSnapshot::load(&config_path, None).unwrap());
         let runtime_rpol_files = accepted.config_ref().policy.rpol_files.clone();
+        let runtime_config = Arc::new(Mutex::new(accepted.config_ref().clone()));
         let (_accepted_tx, accepted_rx) = watch::channel(accepted);
 
         let original = table("edge", 1000);
@@ -5675,11 +5962,17 @@ families = ["ipv4_unicast"]
                                 rpol: rustbgpd_policy::rpol::RpolPolicySet::default(),
                             }));
                     }
-                    PeerManagerCommand::PlanConfigTransaction { reply, .. } => {
-                        let _ = reply.send(Ok(plan(
+                    PeerManagerCommand::PlanConfigTransaction {
+                        candidate_toml,
+                        reply,
+                        ..
+                    } => {
+                        let response = plan(
                             RuntimeConfigTransactionStatus::Committable,
                             vec!["[[fib_tables]]".to_string()],
-                        )));
+                        );
+                        let _ =
+                            reply.send(Ok(attach_committed_candidate(response, &candidate_toml)));
                     }
                     PeerManagerCommand::StageFibTables { tables, reply } => {
                         *staged.lock().await = tables;
@@ -5689,6 +5982,9 @@ families = ["ipv4_unicast"]
                         *staged.lock().await = tables;
                         let _ = reply.send(());
                     }
+                    PeerManagerCommand::CommitConfigSnapshotStage { reply } => {
+                        let _ = reply.send(());
+                    }
                     _ => panic!("unexpected peer-manager command in v3 FIB harness"),
                 }
             }
@@ -5696,26 +5992,42 @@ families = ["ipv4_unicast"]
 
         let seen_preloaded = Arc::new(Mutex::new(None));
         let seen = seen_preloaded.clone();
+        let current = runtime_config.clone();
         let (internal_tx, mut internal_rx) = mpsc::unbounded_channel();
         tokio::spawn(async move {
             while let Some(command) = internal_rx.recv().await {
-                let InternalCommand::PlanAcceptedSnapshot {
-                    snapshot,
-                    expected_runtime_snapshot_token,
-                    reply,
-                } = command
-                else {
-                    panic!("unexpected private command in v3 FIB harness");
-                };
-                *seen.lock().await = Some(snapshot);
-                let mut response = plan(
-                    RuntimeConfigTransactionStatus::Committable,
-                    vec!["[[fib_tables]]".to_string()],
-                );
-                response.runtime_snapshot_token =
-                    expected_runtime_snapshot_token.unwrap_or_else(|| "kv1:new:2".to_string());
-                response.post_commit_runtime_snapshot_token = "kv1:rollback:3".to_string();
-                let _ = reply.send(Ok(response));
+                match command {
+                    InternalCommand::PlanAcceptedSnapshot {
+                        snapshot,
+                        expected_runtime_snapshot_token,
+                        reply,
+                    } => {
+                        let candidate_toml =
+                            crate::config::persisted_config_document(snapshot.config_ref())
+                                .expect("v3 FIB fake planner candidate must serialize");
+                        *seen.lock().await = Some(snapshot);
+                        let mut response = plan(
+                            RuntimeConfigTransactionStatus::Committable,
+                            vec!["[[fib_tables]]".to_string()],
+                        );
+                        response.runtime_snapshot_token = expected_runtime_snapshot_token
+                            .unwrap_or_else(|| "kv1:new:2".to_string());
+                        response.post_commit_runtime_snapshot_token = "kv1:rollback:3".to_string();
+                        let _ =
+                            reply.send(Ok(attach_committed_candidate(response, &candidate_toml)));
+                    }
+                    InternalCommand::StageTransactionConfig { candidate, reply } => {
+                        let previous = std::mem::replace(&mut *current.lock().await, *candidate);
+                        let _ = reply.send(Ok(Box::new(previous)));
+                    }
+                    InternalCommand::RestoreTransactionConfig { previous, reply } => {
+                        *current.lock().await = *previous;
+                        let _ = reply.send(());
+                    }
+                    InternalCommand::ReplaceConfigSnapshot { .. } => {
+                        panic!("unexpected private command in v3 FIB harness")
+                    }
+                }
             }
         });
 
@@ -7074,7 +7386,7 @@ default_action = "permit"
                 "[peer_groups] catalog",
             ]
         );
-        assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &candidate_toml);
         assert!(response.human_text.contains("catalog-only"));
     }
 
@@ -7193,7 +7505,7 @@ default_action = "permit"
             response.committed_sections,
             vec!["[policy] definitions", "[policy] live impact"]
         );
-        assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &candidate_toml);
         assert!(response.human_text.contains("live policy-impact"));
         assert_eq!(response.runtime_snapshot_token, "kv1:new:2");
         let chained = plan_candidate(
@@ -7271,7 +7583,7 @@ default_action = "permit"
             response.committed_sections,
             vec!["[policy] definitions", "[policy] live impact"]
         );
-        assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &candidate_toml);
         assert!(response.human_text.contains("1 live session"));
         let calls = apply_calls.lock().await;
         assert_eq!(calls.len(), 1);
@@ -7338,7 +7650,7 @@ default_action = "permit"
                 "effective neighbor session reshape",
             ]
         );
-        assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &candidate_toml);
         assert!(response.human_text.contains("1 live session"));
         let peers = peers.lock().await;
         assert_eq!(peers.len(), 1);
@@ -7399,7 +7711,7 @@ default_action = "permit"
             response.committed_sections,
             vec!["[[neighbors]] modify", "effective neighbor session reshape"]
         );
-        assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &candidate_toml);
         let peers = peers.lock().await;
         assert_eq!(peers.len(), 1);
         assert_eq!(peers[0].peer_group.as_deref(), Some("core"));
@@ -7451,7 +7763,7 @@ default_action = "permit"
             response.status,
             proto::ConfigTransactionPlanStatus::Committable as i32
         );
-        assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &candidate_toml);
         // No static members: the reshape fan-out reconfigures nothing.
         assert!(peers.lock().await.is_empty());
         let bounce_calls = bounce_calls.lock().await;
@@ -7577,7 +7889,7 @@ default_action = "permit"
             response.status,
             proto::ConfigTransactionPlanStatus::Committable as i32
         );
-        assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &candidate_toml);
         let bounce_calls = bounce_calls.lock().await;
         assert_eq!(bounce_calls.len(), 1, "{bounce_calls:?}");
         assert_eq!(bounce_calls[0].len(), 1);
@@ -7631,7 +7943,7 @@ default_action = "permit"
             response.status,
             proto::ConfigTransactionPlanStatus::Committable as i32
         );
-        assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &candidate_toml);
         {
             let peers = peers.lock().await;
             assert_eq!(peers.len(), 1);
@@ -8732,7 +9044,7 @@ remote_asn = 65003
             proto::ConfigTransactionPlanStatus::Committable as i32
         );
         assert_eq!(response.committed_sections, vec!["[[neighbors]] modify"]);
-        assert_eq!(*snapshot_toml.lock().await, candidate_toml);
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &candidate_toml);
         let peers = peers.lock().await;
         assert_eq!(peers.len(), 1);
         assert_eq!(peers[0].address.to_string(), "10.0.0.2");
@@ -8853,6 +9165,12 @@ remote_asn = 65004
         let replacement = table("core", 1001);
         let fib_state = Arc::new(Mutex::new(vec![original.clone()]));
         let staged = Arc::new(Mutex::new(vec![snapshot(&original)]));
+        let current = Arc::new(Mutex::new(fib_config(&original)));
+        let (internal_tx, internal_rx) = mpsc::unbounded_channel();
+        tokio::spawn(fake_transaction_snapshot_manager(
+            internal_rx,
+            current.clone(),
+        ));
 
         let (fib_tx, fib_rx) = mpsc::channel(8);
         tokio::spawn(fake_fib_actor(fib_rx, fib_state.clone(), None));
@@ -8867,19 +9185,24 @@ remote_asn = 65004
         ));
         let (config_tx, mut config_rx) = mpsc::channel(8);
         tokio::spawn(async move {
-            if let Some(rustbgpd_api::peer_types::ConfigEvent::FibTablesReplaced {
-                tables,
+            if let Some(rustbgpd_api::peer_types::ConfigEvent::ConfigTransactionCommitted {
+                candidate_toml,
                 ack: Some(ack),
             }) = config_rx.recv().await
             {
-                assert_eq!(tables.len(), 1);
-                assert_eq!(tables[0].name, "core");
+                assert!(candidate_toml.contains("config_epoch = 1"));
+                assert!(candidate_toml.contains("name = \"core\""));
                 ack.accept().await;
             }
         });
 
-        let response = apply_config_transaction(
-            deps(Some(fib_tx), peer_tx, Some(config_tx), vec![original]),
+        let response = apply_config_transaction_with_internal(
+            deps(
+                Some(fib_tx),
+                peer_tx,
+                Some(config_tx),
+                vec![original.clone()],
+            ),
             proto::ApplyConfigTransactionRequest {
                 candidate_toml: base_toml(
                     r#"
@@ -8896,6 +9219,7 @@ families = ["ipv4_unicast"]
                 confirm_id: String::new(),
                 confirm_timeout_seconds: 0,
             },
+            internal_tx,
         )
         .await
         .unwrap();
@@ -8907,7 +9231,8 @@ families = ["ipv4_unicast"]
         assert_eq!(response.committed_sections, vec!["[[fib_tables]]"]);
         assert!(response.runtime_snapshot_token.starts_with("kv1:"));
         assert_eq!(*fib_state.lock().await, vec![replacement.clone()]);
-        assert_eq!(*staged.lock().await, vec![snapshot(&replacement)]);
+        assert_eq!(current.lock().await.fib_tables, vec![replacement]);
+        assert_eq!(*staged.lock().await, vec![snapshot(&original)]);
     }
 
     #[tokio::test]
@@ -8915,6 +9240,13 @@ families = ["ipv4_unicast"]
         let original = table("edge", 1000);
         let fib_state = Arc::new(Mutex::new(vec![original.clone()]));
         let staged = Arc::new(Mutex::new(vec![snapshot(&original)]));
+        let prior = fib_config(&original);
+        let current = Arc::new(Mutex::new(prior.clone()));
+        let (internal_tx, internal_rx) = mpsc::unbounded_channel();
+        tokio::spawn(fake_transaction_snapshot_manager(
+            internal_rx,
+            current.clone(),
+        ));
 
         let (fib_tx, fib_rx) = mpsc::channel(8);
         tokio::spawn(fake_fib_actor(fib_rx, fib_state.clone(), None));
@@ -8929,7 +9261,7 @@ families = ["ipv4_unicast"]
         ));
         let (config_tx, mut config_rx) = mpsc::channel(8);
         tokio::spawn(async move {
-            if let Some(rustbgpd_api::peer_types::ConfigEvent::FibTablesReplaced {
+            if let Some(rustbgpd_api::peer_types::ConfigEvent::ConfigTransactionCommitted {
                 ack: Some(ack),
                 ..
             }) = config_rx.recv().await
@@ -8938,7 +9270,7 @@ families = ["ipv4_unicast"]
             }
         });
 
-        let err = apply_config_transaction(
+        let err = apply_config_transaction_with_internal(
             deps(
                 Some(fib_tx),
                 peer_tx,
@@ -8961,6 +9293,7 @@ families = ["ipv4_unicast"]
                 confirm_id: String::new(),
                 confirm_timeout_seconds: 0,
             },
+            internal_tx,
         )
         .await
         .unwrap_err();
@@ -8971,6 +9304,106 @@ families = ["ipv4_unicast"]
         );
         assert_eq!(*fib_state.lock().await, vec![original.clone()]);
         assert_eq!(*staged.lock().await, vec![snapshot(&original)]);
+        assert_eq!(*current.lock().await, prior);
+    }
+
+    #[tokio::test]
+    async fn fib_stage_rejection_precedes_reconciler_and_persistence() {
+        let edge = table("edge", 1000);
+        let core = table("core", 1001);
+        let (fib_tx, mut fib_rx) = mpsc::channel(4);
+        let fib_task = tokio::spawn(async move {
+            let Some(FibRuntimeCommand::GetTables { reply }) = fib_rx.recv().await else {
+                panic!("FIB stage ordering must read the prior first");
+            };
+            reply.send(vec![edge]).unwrap();
+            assert!(
+                fib_rx.recv().await.is_none(),
+                "stage rejection must precede ReplaceTables"
+            );
+        });
+        let (internal_tx, mut internal_rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            let Some(InternalCommand::StageTransactionConfig { reply, .. }) =
+                internal_rx.recv().await
+            else {
+                panic!("transaction must stage its full snapshot");
+            };
+            reply.send(Err("stage rejected".to_string())).unwrap();
+        });
+        let (config_tx, mut config_rx) = mpsc::channel(1);
+        let deps = deps(
+            Some(fib_tx),
+            mpsc::channel(1).0,
+            Some(config_tx.clone()),
+            Vec::new(),
+        );
+        let error = commit_fib_transaction(
+            &deps,
+            Some(&internal_tx),
+            &config_tx,
+            "candidate".to_string(),
+            fib_config(&core),
+            "next".to_string(),
+            proto::UpdateGroupImpactPlan::default(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            error.error,
+            ConfigTransactionApplyError::InvalidArgument(_)
+        ));
+        drop(deps);
+        drop(config_tx);
+        fib_task.await.unwrap();
+        assert!(
+            config_rx.try_recv().is_err(),
+            "rejected stage must not persist"
+        );
+    }
+
+    #[tokio::test]
+    async fn fib_ack_loss_is_ambiguous_but_restores_tables_and_raw_snapshot() {
+        let edge = table("edge", 1000);
+        let core = table("core", 1001);
+        let fib_state = Arc::new(Mutex::new(vec![edge.clone()]));
+        let current = Arc::new(Mutex::new(fib_config(&edge)));
+        let prior = current.lock().await.clone();
+        let (fib_tx, fib_rx) = mpsc::channel(8);
+        tokio::spawn(fake_fib_actor(fib_rx, fib_state.clone(), None));
+        let (internal_tx, internal_rx) = mpsc::unbounded_channel();
+        tokio::spawn(fake_transaction_snapshot_manager(
+            internal_rx,
+            current.clone(),
+        ));
+        let (config_tx, mut config_rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            let Some(ConfigEvent::ConfigTransactionCommitted { ack, .. }) = config_rx.recv().await
+            else {
+                panic!("FIB transaction must use the full-config persistence seam")
+            };
+            drop(ack);
+        });
+        let deps = deps(
+            Some(fib_tx),
+            mpsc::channel(1).0,
+            Some(config_tx.clone()),
+            vec![edge.clone()],
+        );
+        let failure = commit_fib_transaction(
+            &deps,
+            Some(&internal_tx),
+            &config_tx,
+            "candidate".to_string(),
+            fib_config(&core),
+            "next".to_string(),
+            proto::UpdateGroupImpactPlan::default(),
+        )
+        .await
+        .unwrap_err();
+        assert!(failure.ambiguous);
+        assert_eq!(*fib_state.lock().await, vec![edge]);
+        assert_eq!(*current.lock().await, prior);
     }
 
     #[test]
@@ -9255,6 +9688,12 @@ peer_group = "ge"
             .await
             .expect("real PlanConfigTransaction flow must succeed");
         assert_eq!(planned.status, RuntimeConfigTransactionStatus::Committable);
+        let committed_candidate_toml = planned
+            .committed_candidate
+            .as_ref()
+            .expect("committable plan carries the exact committed candidate")
+            .as_str()
+            .to_string();
         assert_eq!(planned.update_group_impact.entries.len(), 10);
         assert_eq!(
             planned.update_group_impact.rollup,
@@ -9366,7 +9805,7 @@ peer_group = "ge"
         assert_eq!(response.update_group_impact, Some(expected_apply_impact));
         assert_eq!(
             persisted.lock().await.as_deref(),
-            Some(candidate_toml.as_str())
+            Some(committed_candidate_toml.as_str())
         );
 
         let after = query_real_update_group_snapshot(&rib_tx).await;
@@ -9464,9 +9903,9 @@ peer_group = "ge"
             assert_eq!(acks.route_refreshes(), 0, "export-only peer {peer}");
         }
 
-        let replanned = plan_candidate(&peer_tx, candidate_toml, String::new())
+        let replanned = plan_candidate(&peer_tx, committed_candidate_toml, String::new())
             .await
-            .expect("re-plan of committed candidate must succeed");
+            .expect("re-plan of the committed candidate must succeed");
         assert_eq!(replanned.status, RuntimeConfigTransactionStatus::Noop);
         assert_eq!(replanned.update_group_impact.entries.len(), 10);
         assert!(
@@ -9604,6 +10043,12 @@ log_format = "json"
             .await
             .expect("heterogeneous plan must succeed");
         assert_eq!(planned.status, RuntimeConfigTransactionStatus::Committable);
+        let committed_candidate_toml = planned
+            .committed_candidate
+            .as_ref()
+            .expect("committable plan carries the exact committed candidate")
+            .as_str()
+            .to_string();
         let impact = &planned.update_group_impact;
         assert_eq!(impact.entries.len(), 5);
         assert_eq!(
@@ -9715,9 +10160,9 @@ log_format = "json"
             assert_eq!((acks.import_updates(), acks.route_refreshes()), (0, 0));
         }
 
-        let replanned = plan_candidate(&peer_tx, candidate_toml, String::new())
+        let replanned = plan_candidate(&peer_tx, committed_candidate_toml, String::new())
             .await
-            .expect("identical re-plan must succeed");
+            .expect("re-plan of the committed candidate must succeed");
         assert_eq!(replanned.status, RuntimeConfigTransactionStatus::Noop);
         assert!(
             replanned
@@ -9851,13 +10296,20 @@ log_format = "json"
         let (internal_tx, mut internal_rx) = mpsc::unbounded_channel();
         tokio::spawn(async move {
             while let Some(command) = internal_rx.recv().await {
-                let InternalCommand::PlanAcceptedSnapshot { reply, .. } = command else {
+                let InternalCommand::PlanAcceptedSnapshot {
+                    snapshot, reply, ..
+                } = command
+                else {
                     panic!("rollback planner received unexpected reload command");
                 };
-                let _ = reply.send(Ok(plan(
+                let candidate_toml =
+                    crate::config::persisted_config_document(snapshot.config_ref())
+                        .expect("rollback fake planner candidate must serialize");
+                let response = plan(
                     RuntimeConfigTransactionStatus::Committable,
                     vec!["[[dynamic_neighbors]]".to_string()],
-                )));
+                );
+                let _ = reply.send(Ok(attach_committed_candidate(response, &candidate_toml)));
             }
         });
         let controller = ConfigTransactionController::new_accepted(

--- a/src/fib_table_control.rs
+++ b/src/fib_table_control.rs
@@ -87,23 +87,13 @@ pub struct FibTableControlDeps {
     pub config_history_dir: Option<std::path::PathBuf>,
 }
 
-/// FIB commit failure carrying whether the commit's completion state is
-/// provably clean (LAN-277, mirrors `ApplyFailure` in
-/// `config_transaction_control`). `ambiguous == true` when the persistence
-/// acknowledgement was lost or a rollback component failed — the confirmed
-/// config-transaction path must then retain its revert journal. Targeted FIB
-/// CRUD strips the flag.
 pub(crate) struct FibCommitFailure {
     pub(crate) error: FibTableControlError,
-    pub(crate) ambiguous: bool,
 }
 
 impl From<FibTableControlError> for FibCommitFailure {
     fn from(error: FibTableControlError) -> Self {
-        Self {
-            error,
-            ambiguous: false,
-        }
+        Self { error }
     }
 }
 
@@ -282,7 +272,6 @@ pub(crate) async fn commit_fib_tables_locked(
             error: FibTableControlError::Internal(
                 "config bridge dropped FIB-table persistence acknowledgement".to_string(),
             ),
-            ambiguous: true,
         });
     };
     if let Err(error) = persist_result {
@@ -304,7 +293,7 @@ pub(crate) async fn commit_fib_tables_locked(
 
 /// Read the reconciler's current table set. `Ok(None)` means no reconciler is
 /// running (used by `List` to report `runtime_available = false`).
-async fn read_current_tables(
+pub(crate) async fn read_current_tables(
     fib_cmd_tx: Option<&mpsc::Sender<FibRuntimeCommand>>,
     actor_error: fn(String) -> FibTableControlError,
 ) -> Result<Option<Vec<FibTableConfig>>, FibTableControlError> {
@@ -455,7 +444,6 @@ fn combine_fib_rollback_errors(
     }
     FibCommitFailure {
         error: FibTableControlError::Internal(message),
-        ambiguous: true,
     }
 }
 
@@ -474,7 +462,7 @@ async fn reserve_persist_permit(
         })
 }
 
-async fn replace_tables(
+pub(crate) async fn replace_tables(
     fib_cmd_tx: &mpsc::Sender<FibRuntimeCommand>,
     tables: Vec<FibTableConfig>,
 ) -> Result<(), FibTableControlError> {

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -136,6 +136,19 @@ pub(crate) enum InternalCommand {
             >,
         >,
     },
+    /// Stage the FIB tables and RFC 8212 tuple from an already validated
+    /// transaction candidate. All other state stays attached to the live
+    /// snapshot, preserving the pure-FIB external-input exception.
+    StageTransactionConfig {
+        candidate: Box<Config>,
+        reply: oneshot::Sender<Result<Box<Config>, String>>,
+    },
+    /// Restore the exact raw/source-attached snapshot returned by
+    /// [`InternalCommand::StageTransactionConfig`].
+    RestoreTransactionConfig {
+        previous: Box<Config>,
+        reply: oneshot::Sender<()>,
+    },
 }
 
 #[allow(
@@ -1602,13 +1615,51 @@ impl PeerManager {
                             expected_runtime_snapshot_token,
                             reply,
                         }) => {
+                            let mut candidate = snapshot.config();
                             let result = self
                                 .plan_preloaded_config_transaction(
-                                    snapshot.config_ref(),
+                                    &mut candidate,
                                     expected_runtime_snapshot_token.as_deref(),
                                 )
                                 .await;
                             let _ = reply.send(result);
+                        }
+                        Some(InternalCommand::StageTransactionConfig {
+                            candidate,
+                            reply,
+                        }) => {
+                            let mut staged = self.current_config.clone();
+                            staged.fib_tables.clone_from(&candidate.fib_tables);
+                            staged.config_epoch = candidate.config_epoch;
+                            staged.global.ebgp_requires_policy =
+                                candidate.global.ebgp_requires_policy;
+                            let result = staged
+                                .validate()
+                                .map_err(|error| error.to_string())
+                                .map(|()| {
+                                    let previous = std::mem::replace(
+                                        &mut self.current_config,
+                                        staged,
+                                    );
+                                    self.dynamic_ranges =
+                                        Self::parse_dynamic_ranges(&self.current_config);
+                                    self.reconcile_stale_dynamic_max_prefix_restarts();
+                                    self.config_snapshot_staged = true;
+                                    self.metrics.record_policy_generation_loaded();
+                                    Box::new(previous)
+                                });
+                            let _ = reply.send(result);
+                        }
+                        Some(InternalCommand::RestoreTransactionConfig {
+                            previous,
+                            reply,
+                        }) => {
+                            self.current_config = *previous;
+                            self.dynamic_ranges = Self::parse_dynamic_ranges(&self.current_config);
+                            self.reconcile_stale_dynamic_max_prefix_restarts();
+                            self.config_snapshot_staged = false;
+                            self.metrics.record_policy_generation_loaded();
+                            let _ = reply.send(());
                         }
                         None => {}
                     }

--- a/src/peer_manager/reconcile.rs
+++ b/src/peer_manager/reconcile.rs
@@ -127,7 +127,7 @@ impl PeerManager {
             Config::load_toml_with_diagnostics(candidate_toml, "candidate runtime config")
                 .map_err(RuntimeConfigDiffError::InvalidCandidate)?;
         let diff = crate::config::diff_config(&self.current_config, &candidate);
-        runtime_config_diff_from_config_diff(&diff).map_err(RuntimeConfigDiffError::Internal)
+        runtime_config_diff_from_config_diff(&diff, None).map_err(RuntimeConfigDiffError::Internal)
     }
 
     pub(super) async fn plan_config_transaction(
@@ -138,11 +138,16 @@ impl PeerManager {
         let (live_snapshot, live_snapshot_identity, runtime_snapshot_token) = self
             .config_transaction_plan_context(expected_runtime_snapshot_token)
             .await?;
-        let candidate =
+        let mut candidate =
             Config::load_toml_with_diagnostics(candidate_toml, "candidate runtime config")
                 .map_err(RuntimeConfigTransactionPlanError::InvalidCandidate)?;
+        let materialization = crate::config::materialize_rfc8212_transaction_candidate(
+            &self.current_config,
+            &mut candidate,
+        );
         self.finish_config_transaction_plan(
             &candidate,
+            materialization.as_ref(),
             live_snapshot,
             live_snapshot_identity,
             runtime_snapshot_token,
@@ -151,14 +156,29 @@ impl PeerManager {
 
     pub(super) async fn plan_preloaded_config_transaction(
         &self,
-        candidate: &Config,
+        candidate: &mut Config,
         expected_runtime_snapshot_token: Option<&str>,
     ) -> Result<RuntimeConfigTransactionPlan, RuntimeConfigTransactionPlanError> {
         let (live_snapshot, live_snapshot_identity, runtime_snapshot_token) = self
             .config_transaction_plan_context(expected_runtime_snapshot_token)
             .await?;
+        // A retained snapshot is trusted rollback authority. Preserve every
+        // non-tuple field, but carry forward an unchanged live tuple.
+        let live_posture = self.current_config.rfc8212_posture();
+        let candidate_posture = candidate.rfc8212_posture();
+        if live_posture.config_epoch_effective == candidate_posture.config_epoch_effective
+            && live_posture.policy_effective == candidate_posture.policy_effective
+        {
+            candidate.config_epoch = live_posture.config_epoch_raw;
+            candidate.global.ebgp_requires_policy = live_posture.policy_raw;
+        }
+        let materialization = crate::config::materialize_rfc8212_transaction_candidate(
+            &self.current_config,
+            candidate,
+        );
         self.finish_config_transaction_plan(
             candidate,
+            materialization.as_ref(),
             live_snapshot,
             live_snapshot_identity,
             runtime_snapshot_token,
@@ -203,6 +223,7 @@ impl PeerManager {
     fn finish_config_transaction_plan(
         &self,
         candidate: &Config,
+        materialization: Option<&crate::config::ConfigDiff>,
         live_snapshot: rustbgpd_rib::UpdateGroupSnapshot,
         live_snapshot_identity: [u8; 8],
         runtime_snapshot_token: String,
@@ -227,8 +248,9 @@ impl PeerManager {
             .snapshot_key
             .token_with_context(candidate, &live_snapshot_identity)
             .map_err(RuntimeConfigTransactionPlanError::Internal)?;
-        let diff = crate::config::diff_config(&self.current_config, candidate);
-        let classification = crate::config::classify_config_transaction_v1(&diff);
+        let committed_diff = crate::config::diff_config(&self.current_config, candidate);
+        let operational_diff = materialization.unwrap_or(&committed_diff);
+        let classification = crate::config::classify_config_transaction_v1(operational_diff);
         let status = if classification.is_noop() {
             RuntimeConfigTransactionStatus::Noop
         } else if classification.is_committable() {
@@ -236,19 +258,39 @@ impl PeerManager {
         } else {
             RuntimeConfigTransactionStatus::Rejected
         };
-        let diff = runtime_config_diff_from_config_diff(&diff)
-            .map_err(RuntimeConfigTransactionPlanError::Internal)?;
-        let human_text = format_transaction_plan_text(
+        let diff = runtime_config_diff_from_config_diff(
+            operational_diff,
+            materialization.map(|_| &committed_diff),
+        )
+        .map_err(RuntimeConfigTransactionPlanError::Internal)?;
+        let mut human_text = format_transaction_plan_text(
             status,
             &classification.supported_sections,
             &classification.unsupported_sections,
             &classification.restart_required_sections,
         );
+        if materialization.is_some() {
+            human_text.push_str(
+                "The RFC 8212 tuple is materialized to its exact unchanged effective posture.\n",
+            );
+        }
+        let committed_candidate = if status == RuntimeConfigTransactionStatus::Committable {
+            Some(
+                crate::config::persisted_config_document(candidate)
+                    .map(rustbgpd_api::peer_types::RuntimeConfigTransactionCandidate::new)
+                    .map_err(|error| {
+                        RuntimeConfigTransactionPlanError::Internal(error.to_string())
+                    })?,
+            )
+        } else {
+            None
+        };
 
         Ok(RuntimeConfigTransactionPlan {
             status,
             runtime_snapshot_token,
             post_commit_runtime_snapshot_token,
+            committed_candidate,
             diff,
             supported_sections: classification.supported_sections,
             unsupported_sections: classification.unsupported_sections,
@@ -291,16 +333,37 @@ impl PeerManager {
 
 fn runtime_config_diff_from_config_diff(
     diff: &crate::config::ConfigDiff,
+    materialized: Option<&crate::config::ConfigDiff>,
 ) -> Result<RuntimeConfigDiff, String> {
-    let diff_json = serde_json::to_string_pretty(&crate::config::config_diff_json_value(diff))
+    let mut diff_value = crate::config::config_diff_json_value(diff);
+    if let Some(materialized) = materialized {
+        diff_value["has_informational_changes"] = serde_json::Value::Bool(true);
+        diff_value["config_epoch"] = serde_json::to_value(materialized.config_epoch)
+            .map_err(|error| format!("failed to serialize config epoch change: {error}"))?;
+        diff_value["ebgp_requires_policy"] =
+            serde_json::to_value(materialized.ebgp_requires_policy)
+                .map_err(|error| format!("failed to serialize RFC 8212 policy change: {error}"))?;
+        diff_value["informational"]["rfc8212_materialization"] = serde_json::json!({
+            "config_epoch": &materialized.config_epoch,
+            "ebgp_requires_policy": &materialized.ebgp_requires_policy,
+            "route_behavior_changed": false,
+        });
+    }
+    let diff_json = serde_json::to_string_pretty(&diff_value)
         .map_err(|error| format!("failed to serialize config diff: {error}"))?;
+    let mut human_text = crate::config::format_config_diff(diff);
+    if let Some(materialized) = materialized {
+        human_text.push_str(&crate::config::format_rfc8212_transaction_materialization(
+            materialized,
+        ));
+    }
     Ok(RuntimeConfigDiff {
         has_actionable_changes: diff.has_actionable_changes(),
         has_reload_applied_changes: diff.has_reload_applied_changes(),
         has_restart_required_changes: diff.has_restart_required_changes(),
-        has_informational_changes: diff.has_informational_changes(),
+        has_informational_changes: materialized.is_some() || diff.has_informational_changes(),
         has_any_changes: diff.has_any_changes(),
-        human_text: crate::config::format_config_diff(diff),
+        human_text,
         diff_json,
     })
 }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1062,7 +1062,8 @@ export_policy_chain = ["dataset-export"]
     let (tx, rx) = mpsc::channel(4);
     let (internal_tx, internal_rx) = mpsc::unbounded_channel();
     let (rib_tx, mut rib_rx) = mpsc::channel(4);
-    let mgr = PeerManager::new_with_config(
+    let raw_prior = current.clone();
+    let mut mgr = PeerManager::new_with_config(
         rx,
         internal_rx,
         65001,
@@ -1076,7 +1077,7 @@ export_policy_chain = ["dataset-export"]
         current,
     );
     let responder = tokio::spawn(async move {
-        for _ in 0..3 {
+        for _ in 0..5 {
             let Some(RibUpdate::QueryUpdateGroupSnapshot { reply }) = rib_rx.recv().await else {
                 panic!("plan snapshot query missing");
             };
@@ -1115,6 +1116,7 @@ export_policy_chain = ["dataset-export"]
     assert_eq!(noop.update_group_impact.rollup.affected_families, 0);
     assert_eq!(noop.update_group_impact.rollup.local_resyncs, 0);
     assert_eq!(noop.update_group_impact.rollup.no_op, 1);
+    assert!(noop.committed_candidate.is_none());
     assert_eq!(
         fib.status,
         rustbgpd_api::peer_types::RuntimeConfigTransactionStatus::Committable
@@ -1128,6 +1130,62 @@ export_policy_chain = ["dataset-export"]
     assert_eq!(fib.update_group_impact.rollup.affected_families, 0);
     assert_eq!(fib.update_group_impact.rollup.local_resyncs, 0);
     assert_eq!(fib.update_group_impact.rollup.no_op, 1);
+    assert!(fib.diff.has_informational_changes);
+    assert!(!fib.diff.has_restart_required_changes);
+    assert!(
+        fib.diff
+            .human_text
+            .contains("Informational transaction materialization")
+    );
+    let diff_json: serde_json::Value = serde_json::from_str(&fib.diff.diff_json).unwrap();
+    assert_eq!(diff_json["has_informational_changes"], true);
+    assert_eq!(
+        diff_json["informational"]["rfc8212_materialization"]["route_behavior_changed"],
+        false
+    );
+    let committed = fib
+        .committed_candidate
+        .as_ref()
+        .expect("committable plan must retain one candidate")
+        .as_str();
+    assert!(committed.contains("config_epoch = 1"), "{committed}");
+    assert!(
+        committed.contains("ebgp_requires_policy = false"),
+        "{committed}"
+    );
+    let chained = mgr.plan_config_transaction(committed, None).await.unwrap();
+    assert_eq!(
+        chained.post_commit_runtime_snapshot_token,
+        fib.post_commit_runtime_snapshot_token
+    );
+
+    // After materialization, trusted rollback must carry the live tuple
+    // without losing the accepted raw prior's FIB/source state.
+    mgr.current_config.config_epoch = Some(crate::config::ConfigEpoch::V1);
+    mgr.current_config.global.ebgp_requires_policy = Some(false);
+    mgr.current_config.fib_tables[0].metric = 201;
+    let mut rollback_prior = raw_prior.clone();
+    let rollback = mgr
+        .plan_preloaded_config_transaction(&mut rollback_prior, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        rollback.status,
+        rustbgpd_api::peer_types::RuntimeConfigTransactionStatus::Committable
+    );
+    assert_eq!(rollback.supported_sections, vec!["[[fib_tables]]"]);
+    assert_eq!(
+        rollback_prior.config_epoch,
+        Some(crate::config::ConfigEpoch::V1)
+    );
+    assert_eq!(rollback_prior.global.ebgp_requires_policy, Some(false));
+    assert_eq!(rollback_prior.fib_tables[0].metric, 200);
+    assert_eq!(
+        rollback_prior.policy.rpol_files,
+        raw_prior.policy.rpol_files
+    );
+    assert_eq!(rollback_prior.policy.datasets, raw_prior.policy.datasets);
+    mgr.current_config = raw_prior;
 
     // Capture one accepted candidate, then remove both external sources before
     // the real actor consumes the private command. Any planner reparse or
@@ -1154,6 +1212,7 @@ export_policy_chain = ["dataset-export"]
     );
     assert_eq!(preloaded.supported_sections, vec!["[[fib_tables]]"]);
     assert_eq!(preloaded.update_group_impact.rollup.no_op, 1);
+    assert!(preloaded.committed_candidate.is_some());
     tx.send(PeerManagerCommand::Shutdown).await.unwrap();
     task.await.unwrap();
     responder.await.unwrap();
@@ -1941,6 +2000,80 @@ async fn replace_config_snapshot_rebuilds_dynamic_range_matcher() {
     assert_eq!(ranges[0].peer_group, "ix-members");
     assert_eq!(ranges[0].remote_asn, 65010);
 
+    tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn transaction_fib_stage_overlays_only_tables_and_posture_and_restores_raw_prior() {
+    let (tx, rx) = mpsc::channel(8);
+    let (internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (rib_tx, _rib_rx) = mpsc::channel(8);
+    let mut live = make_dynamic_manager_config();
+    live.policy.rpol_files = vec!["live-source.rpol".to_string()];
+    live.fib_tables = vec![crate::test_support::basic_fib_table("edge", 1000)];
+    let mut candidate = live.clone();
+    candidate.global.asn = 64512;
+    candidate.policy.rpol_files = vec!["candidate-source.rpol".to_string()];
+    candidate.config_epoch = Some(crate::config::ConfigEpoch::V1);
+    candidate.global.ebgp_requires_policy = Some(false);
+    candidate.fib_tables[0].name = "core".to_string();
+    candidate.fib_tables[0].table_id = 1001;
+
+    let manager = PeerManager::new_with_config(
+        rx,
+        internal_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+        None,
+        live.clone(),
+    );
+    let handle = tokio::spawn(manager.run());
+    let (stage_tx, stage_rx) = oneshot::channel();
+    internal_tx
+        .send(InternalCommand::StageTransactionConfig {
+            candidate: Box::new(candidate),
+            reply: stage_tx,
+        })
+        .unwrap();
+    let previous = stage_rx.await.unwrap().unwrap();
+    assert_eq!(previous.config_epoch, None);
+    assert_eq!(previous.global.ebgp_requires_policy, None);
+    assert_eq!(previous.fib_tables[0].name, "edge");
+
+    let (snapshot_tx, snapshot_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::RuntimeConfigSnapshot { reply: snapshot_tx })
+        .await
+        .unwrap();
+    let staged: Config = toml::from_str(&snapshot_rx.await.unwrap().unwrap().toml).unwrap();
+    assert_eq!(staged.global.asn, live.global.asn);
+    assert_eq!(staged.policy.rpol_files, live.policy.rpol_files);
+    assert_eq!(staged.fib_tables[0].name, "core");
+    assert_eq!(staged.config_epoch, Some(crate::config::ConfigEpoch::V1));
+    assert_eq!(staged.global.ebgp_requires_policy, Some(false));
+
+    let (restore_tx, restore_rx) = oneshot::channel();
+    internal_tx
+        .send(InternalCommand::RestoreTransactionConfig {
+            previous,
+            reply: restore_tx,
+        })
+        .unwrap();
+    restore_rx.await.unwrap();
+    let (snapshot_tx, snapshot_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::RuntimeConfigSnapshot { reply: snapshot_tx })
+        .await
+        .unwrap();
+    let restored: Config = toml::from_str(&snapshot_rx.await.unwrap().unwrap().toml).unwrap();
+    assert_eq!(restored.config_epoch, None);
+    assert_eq!(restored.global.ebgp_requires_policy, None);
+    assert_eq!(restored.fib_tables[0].name, "edge");
+    assert_eq!(restored.policy.rpol_files, live.policy.rpol_files);
     tx.send(PeerManagerCommand::Shutdown).await.unwrap();
     handle.await.unwrap();
 }

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -7533,6 +7533,10 @@ peer_group = "secure"
                 Some(InternalCommand::PlanAcceptedSnapshot { .. }) => {
                     panic!("reload test expected only ReplaceConfigSnapshot")
                 }
+                Some(
+                    InternalCommand::StageTransactionConfig { .. }
+                    | InternalCommand::RestoreTransactionConfig { .. },
+                ) => panic!("reload test expected no config transaction snapshot command"),
                 None => panic!("peer manager must receive the snapshot"),
             }
         });


### PR DESCRIPTION
## Summary\n\n- materialize the canonical RFC 8212 epoch/policy tuple only alongside supported config transactions\n- carry one canonical candidate through planning, tokens, staging, persistence, FIB rollback, confirmed/history rollback, and the shared gNMI apply path\n- preserve raw boot, SIGHUP, generic diff, prior-authority, and per-resource CRUD behavior\n- report the representation change as informational without changing route behavior or the public protocol\n\n## Validation\n\n- 85/85 focused config-transaction tests plus exact RFC 8212, FIB actor, trusted rollback, API projection, and secret-redaction proofs\n- destructive proofs for direct source regression, trusted rollback carry, stage ordering, and acknowledgement-loss rollback\n- cargo fmt --all -- --check\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo test --workspace\n- cargo doc --workspace --lib --no-deps\n- cargo +1.95.0 check --workspace --all-targets\n- stable-surface and diff checks