### PR TITLE
Clarify the non-Linux GTSM and RFC 8212 epoch-2 diagnostics

### DIFF
--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -3299,7 +3299,10 @@ pub(crate) fn set_gtsm_outbound(socket: &Socket, is_v4: bool) -> io::Result<()> 
 pub fn set_gtsm(_socket: &Socket, _remote: SocketAddr) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
-        "GTSM / TTL security is only supported on Linux",
+        "ttl_security (GTSM / TTL security, RFC 5082) requires Linux: this platform has no \
+         IP_MINTTL / IPV6_MINHOPCOUNT equivalent, so inbound TTL enforcement cannot be \
+         installed. This is a platform limitation, not a config error. Remove ttl_security \
+         from the neighbor config, or run rustbgpd on Linux",
     ))
 }
 

--- a/docs/adr/0119-rfc-8212-secure-default-config-epoch.md
+++ b/docs/adr/0119-rfc-8212-secure-default-config-epoch.md
@@ -71,10 +71,11 @@ change only the epoch-2/omitted cell from rejected to effective `true`.
 Before activation, the epoch-2 omission diagnostic is exactly:
 
 ```text
-config_epoch = 2 requires [global].ebgp_requires_policy = true or [global].ebgp_requires_policy = false before secure-default activation; add one explicit assignment
+config_epoch = 2 requires [global].ebgp_requires_policy = true or [global].ebgp_requires_policy = false: the RFC 8212 secure default is not activated yet (ADR-0119 gates activation on its production-mutation proofs), so epoch 2 does not infer the omitted value. This is a pending activation, not a misconfiguration; add one explicit assignment
 ```
 
-The diagnostic points at the absent/required field and rejects startup,
+The diagnostic points at the absent/required field, states that the rejection is
+the pending activation gate rather than an operator mistake, and rejects startup,
 `--check`, SIGHUP candidates, gRPC transactions, gNMI-generated candidates,
 history rollback, and generated/imported output validation alike.
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -2610,7 +2610,7 @@ pub enum ConfigError {
     #[error("failed to parse TOML: {0}")]
     Parse(#[from] toml::de::Error),
     #[error(
-        "config_epoch = 2 requires [global].ebgp_requires_policy = true or [global].ebgp_requires_policy = false before secure-default activation; add one explicit assignment"
+        "config_epoch = 2 requires [global].ebgp_requires_policy = true or [global].ebgp_requires_policy = false: the RFC 8212 secure default is not activated yet (ADR-0119 gates activation on its production-mutation proofs), so epoch 2 does not infer the omitted value. This is a pending activation, not a misconfiguration; add one explicit assignment"
     )]
     Rfc8212Epoch2PolicyOmission,
     #[error("invalid local ASN {value}: AS 0 is reserved (RFC 7607 section 2)")]

--- a/src/config/tests/rfc8212.rs
+++ b/src/config/tests/rfc8212.rs
@@ -48,7 +48,7 @@ fn rfc8212_epoch_and_policy_presence_matrix_is_lossless_without_flipping_default
 
 #[test]
 fn rfc8212_epoch_two_omission_and_invalid_epochs_fail_closed() {
-    const EXACT: &str = "config_epoch = 2 requires [global].ebgp_requires_policy = true or [global].ebgp_requires_policy = false before secure-default activation; add one explicit assignment";
+    const EXACT: &str = "config_epoch = 2 requires [global].ebgp_requires_policy = true or [global].ebgp_requires_policy = false: the RFC 8212 secure default is not activated yet (ADR-0119 gates activation on its production-mutation proofs), so epoch 2 does not infer the omitted value. This is a pending activation, not a misconfiguration; add one explicit assignment";
     let source = rfc8212_representation_toml(Some("2"), None);
     assert_eq!(parse(&source).unwrap_err().to_string(), EXACT);
     let schema_only = parse_schema_only(&source).unwrap();


### PR DESCRIPTION
## Summary

Two operator-facing diagnostics read as "you misconfigured this" when neither
condition is a config defect. Text and context only — no control-flow, error
type, or exit-code changes.

### 1. Non-Linux GTSM (`crates/transport/src/socket_opts.rs`)

The `#[cfg(not(target_os = "linux"))]` `set_gtsm` stub returns
`io::ErrorKind::Unsupported`. The old text named neither the config knob nor a
remedy.

**Before**

```text
GTSM / TTL security is only supported on Linux
```

**After**

```text
ttl_security (GTSM / TTL security, RFC 5082) requires Linux: this platform has no IP_MINTTL / IPV6_MINHOPCOUNT equivalent, so inbound TTL enforcement cannot be installed. This is a platform limitation, not a config error. Remove ttl_security from the neighbor config, or run rustbgpd on Linux
```

Names the `ttl_security` knob an operator can grep their config for, the absent
kernel primitive, and both remedies.

### 2. RFC 8212 `config_epoch = 2` omission (`src/config/schema.rs`)

`ConfigError::Rfc8212Epoch2PolicyOmission` rejects `config_epoch = 2` with an
omitted `[global].ebgp_requires_policy` because ADR-0119 gates secure-default
activation on its production-mutation proofs. The old text pointed at the field
but never said the rejection is a pending activation, so it reads as either a
misconfiguration or a broken feature.

**Before**

```text
config_epoch = 2 requires [global].ebgp_requires_policy = true or [global].ebgp_requires_policy = false before secure-default activation; add one explicit assignment
```

**After**

```text
config_epoch = 2 requires [global].ebgp_requires_policy = true or [global].ebgp_requires_policy = false: the RFC 8212 secure default is not activated yet (ADR-0119 gates activation on its production-mutation proofs), so epoch 2 does not infer the omitted value. This is a pending activation, not a misconfiguration; add one explicit assignment
```

The variant stays a unit variant and every raise site (validation, `render`,
`render_document_bounded`, the test-only phase observer) is untouched.

### Documentation and tests

- `docs/adr/0119-rfc-8212-secure-default-config-epoch.md` quotes the diagnostic
  verbatim under "Before activation, the epoch-2 omission diagnostic is
  exactly:". Updated to the new text, and the following sentence now records
  that the diagnostic states the rejection is the activation gate.
- `src/config/tests/rfc8212.rs::rfc8212_epoch_two_omission_and_invalid_epochs_fail_closed`
  holds the text in a `const EXACT` and asserts exact equality against both the
  `parse` and the `persisted_config_document` error. The constant is updated;
  both assertions remain exact equality against the same two paths, so the
  property they defend — that both paths emit the identical diagnostic — is
  unchanged.

No other test or document quotes either string. Prose references in
`docs/CONFIGURATION.md`, `docs/reload-matrix.md`, and `docs/rustbgpd.schema.json`
describe the behavior rather than quoting the message and remain accurate; the
committed JSON Schema is unchanged, so its freshness check still passes.

## Verification

All run at `b89fa4e4`. Exit codes:

| Gate | Exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace` | 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | 0 |
| `python3 scripts/check-clippy-reasons.py` | 0 |
| `python3 scripts/check-v1-stable-surface.py` | 0 |

The GTSM stub is `cfg`-gated off on Linux, so the gates above do not compile it.
`cargo check -p rustbgpd-transport --target x86_64-apple-darwin` was run to
type-check it. It reports exactly one error, pre-existing and unrelated: the
non-Linux `apply_tcp_ao_rnext` stub takes `TcpAoRnextPreflight` by value while
its caller passes `&preflight` (`crates/transport/src/socket_opts.rs:416`
against the stub at `:2908`). No diagnostic was emitted for the changed
`set_gtsm` stub, which is the crate's only line this branch touches.

Refs LAN-944
