### PR TITLE
docs: refresh the mega-module inventory in ROADMAP.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2059,21 +2059,41 @@ branch is between features.
   than at PR time. `--lib` keeps the root daemon bin out of the doc target set
   (avoiding the lib/bin same-name collision); Cargo's default job parallelism is
   intentionally left enabled so rustdoc does not serialize the whole workspace.
-- [ ] **Mega-module splits.** The large `src/` modules have been split, and
+- [ ] **Mega-module splits.** The large `src/` modules have been split;
   `crates/rib/src/manager/distribution.rs` (which had absorbed the BGP-LS/VPN/
-  RTC/ORR arcs) is now a directory module with per-family concern submodules.
-  `crates/rib/src/manager/tests.rs` (the largest file in the repo) is now
-  `manager/tests/` — shared fixtures in `mod.rs` plus per-concern sibling test
-  modules. `crates/api/src/event_service.rs` is no longer a candidate — its
-  2,318-line total is mostly the test module; real production body is ~630
-  lines. `src/config/mod.rs` has since had its resolution concern split out
-  into `src/config/resolution.rs` (#1215). The current largest *production*
-  bodies (test modules excluded, 2026-07-31) are
-  `crates/evpn-linux/src/reconcile.rs` (~7,647 lines — unchanged; the file's
-  9,095-line total includes its in-file test module), `src/config/mod.rs`
-  (~5,871), and `src/main.rs` (~5,295). `crates/rib/src/manager/mod.rs` is
-  3,534 lines total and is no longer in the top three. Further splitting remains
-  driven by demand, conflicts, and review cost, not a commitment.
+  RTC/ORR arcs) is a directory module with per-family concern submodules,
+  `src/config/mod.rs` had its resolution concern split out into
+  `src/config/resolution.rs` (#1215), and `crates/rib/src/manager/tests.rs`
+  became `manager/tests/` — shared fixtures in `mod.rs` plus per-concern
+  sibling test modules. Two later waves continued it:
+  - `crates/rib/src/manager/update_groups.rs` (10,290 lines) became a
+    2,032-line production body plus `update_groups/` — `membership.rs`,
+    `payload.rs`, `policy_transition.rs`, `staging.rs`, `views.rs`, and a
+    sibling test module (#1532, #1534, #1536, #1539).
+  - The three remaining mega test modules became per-concern siblings:
+    `src/peer_manager/tests.rs` (23,389 lines, #1548),
+    `src/config/tests.rs` (19,754 lines, #1550), and
+    `crates/transport/src/session/tests.rs` (19,048 lines, #1549).
+
+  Total line count and production body are now distinct measures, and only the
+  latter motivates a split. Production body means the lines before the
+  *trailing* `#[cfg(test)]` item — matching the first one instead is
+  misleading, because many files carry test-only imports and helpers near the
+  top, and some keep their tests in a sibling file or directory and have no
+  in-file test module at all. The current largest *production* bodies (test
+  modules excluded, 2026-08-09) are `crates/evpn-linux/src/reconcile.rs`
+  (7,774 lines of a 9,222 total), `src/config/mod.rs` (6,202 of 6,204; its
+  tests live in `src/config/tests/`),
+  `crates/rib/src/manager/distribution/mod.rs` (5,606, no in-file tests),
+  `src/main.rs` (5,503 of 7,392), and `crates/telemetry/src/metrics.rs`
+  (4,652 of 6,760). The largest *files* are a different set and are not split
+  candidates on production grounds:
+  `src/evpn_runtime_converger.rs` (12,132 total, 4,092 production),
+  `src/config_transaction_control.rs` (10,746 / 3,590), and `src/reload.rs`
+  (8,774 / 2,906) are each roughly two-thirds test module.
+  `crates/api/src/event_service.rs` is likewise not a candidate — 608
+  production lines of a 2,811-line total. Further splitting remains driven by
+  demand, conflicts, and review cost, not a commitment.
 - [ ] **Doc-precision + lint-policy consistency sweep (v0.41.0 review).** A
   whole-codebase review found no correctness or security defects; the residue was
   documentation/policy drift, all low-risk. The documentation and lint-policy


### PR DESCRIPTION
## Summary

The ROADMAP "Mega-module splits" bullet carried an inventory measured
2026-07-31 that has since drifted in three ways:

- It named `crates/rib/src/manager/tests.rs` as "the largest file in the repo".
  That was already wrong at the time it was written (`src/peer_manager/tests.rs`
  was 23,389 lines) and is doubly wrong now that all four mega test modules are
  split.
- Its top-three production bodies (`reconcile.rs` ~7,647, `src/config/mod.rs`
  ~5,871, `src/main.rs` ~5,295) have all grown, and the top three are no longer
  those three files.
- It predated the `update_groups` split (#1532, #1534, #1536, #1539) and the
  three test-module splits (#1548, #1549, #1550).

The bullet is rewritten with re-measured figures, records the splits that
landed, and separates total line count from production body so the largest
*files* — now roughly two-thirds test module — are not misread as split
candidates. The existing demand-driven posture is unchanged: further splitting
is driven by demand, conflicts, and review cost, not a commitment.

Documentation only; `ROADMAP.md` is the sole file touched.

## Measurement method

Production body = the lines before the **trailing** `#[cfg(test)]`-gated
top-level item, not the first one. Matching the first `#[cfg(test)]` reports
`src/main.rs` as 47 production lines, because it carries a test-only item near
the top. Two further cases the naive match gets wrong:

- The trailing test module is not always named `tests` — `reconcile.rs` uses
  `managed_netdev_tests`, `peer_manager/policy.rs` uses `first_poll_tests`,
  and `session/inbound.rs` ends in three separately-named test modules.
- The gate is not always literally `#[cfg(test)]` — `transport/socket_opts.rs`
  uses `#[cfg(all(test, target_os = "linux"))]`.
- Some files have no in-file test module at all and keep their tests in a
  sibling file or directory (`src/config/mod.rs`, `manager/distribution/mod.rs`);
  those report their full length as production.

Measured by blanking string/char/comment contents (newlines preserved),
brace-tracking to identify depth-0 lines, classifying each top-level item as
test-gated or production, and taking the start of the final uninterrupted run
of test-gated items. Brace balance was asserted per file; no file tripped it.

## Largest production bodies

| File | Production | Total | % test |
| --- | ---: | ---: | ---: |
| `crates/evpn-linux/src/reconcile.rs` | 7,774 | 9,222 | 16% |
| `src/config/mod.rs` | 6,202 | 6,204 | tests in `src/config/tests/` |
| `crates/rib/src/manager/distribution/mod.rs` | 5,606 | 5,606 | 0% |
| `src/main.rs` | 5,503 | 7,392 | 26% |
| `crates/telemetry/src/metrics.rs` | 4,652 | 6,760 | 31% |
| `crates/rib/src/manager/mod.rs` | 3,568 | 3,568 | tests in `manager/tests/` |
| `crates/transport/src/socket_opts.rs` | 3,305 | 4,720 | 30% |
| `src/config/validation.rs` | 3,150 | 3,150 | 0% |

## Largest totals — not split candidates on production grounds

| File | Total | Production | % test |
| --- | ---: | ---: | ---: |
| `src/evpn_runtime_converger.rs` | 12,132 | 4,092 | 66% |
| `src/config_transaction_control.rs` | 10,746 | 3,590 | 67% |
| `src/reload.rs` | 8,774 | 2,906 | 67% |
| `crates/wire/src/attribute.rs` | 7,018 | 2,995 | 57% |
| `crates/api/src/gnmi_service.rs` | 6,093 | 2,550 | 58% |
| `crates/api/src/event_service.rs` | 2,811 | 608 | 78% |

`src/evpn_runtime_converger.rs` is the largest Rust source in the repo at
12,132 lines; the bullet's previous "largest file" claim named a file an order
of magnitude down the list.

## Splits recorded

| Split | Before | After |
| --- | ---: | --- |
| `manager/update_groups.rs` (#1532, #1534, #1536, #1539) | 10,290 | 2,032 + `update_groups/{membership,payload,policy_transition,staging,views,tests}.rs` |
| `src/peer_manager/tests.rs` (#1548) | 23,389 | 25 per-concern siblings |
| `src/config/tests.rs` (#1550) | 19,754 | 23 per-concern siblings |
| `crates/transport/src/session/tests.rs` (#1549) | 19,048 | 25 per-concern siblings |

## Gates

| Gate | Exit |
| --- | ---: |
| `cargo fmt --all -- --check` | 0 |
| `cargo test --workspace` | 0 (73 suites, no failures) |
| `python3 scripts/check-clippy-reasons.py` | 0 |

Refs LAN-937. The distribution/`mod.rs` code-split half of the ticket remains
open — `crates/rib/src/manager/distribution/mod.rs` is 5,606 production lines
and is the third-largest production body in the repo; this PR only refreshes
the inventory.
