### PR TITLE
test(import): cover malformed BIRD sources in the config importer

### DIFF
--- a/crates/cli/src/importer/bird.rs
+++ b/crates/cli/src/importer/bird.rs
@@ -43,9 +43,14 @@ enum Event {
 ///   empty header.
 ///
 /// Both are handled with depth counters rather than a real expression parser.
-/// A statement terminator and a block boundary each reset the counters, so a
-/// stray bracket or paren in unexpected input can never swallow more than the
-/// construct it appears in.
+/// Each counter clears at one token — a bracket run at the next `;`, a paren
+/// run at the next `{` or `}` — and that token need not be on the same line.
+/// An unterminated `[` or `(` in unexpected input therefore absorbs the text up
+/// to its reset, including whatever construct that text belonged to. The reach
+/// is that one token and no further: the scanner resumes normally after it, and
+/// a session lost that way is refused rather than half-translated. Both bounds
+/// are pinned by `bird_stray_punctuation_recovers_at_the_next_reset_token` in
+/// `crates/cli/tests/config_import.rs`.
 fn scan(input: &str) -> Vec<Event> {
     let mut events = Vec::new();
     let mut buf = String::new();

--- a/crates/cli/tests/config_import.rs
+++ b/crates/cli/tests/config_import.rs
@@ -904,10 +904,13 @@ fn bird_malformed_sources_refuse_instead_of_emitting_partial_sessions() {
     }
 }
 
-/// The other half: unbalanced punctuation BIRD itself would reject must stay
-/// bounded to its own construct instead of swallowing the rest of the file.
+/// The other half: unbalanced punctuation BIRD itself would reject must stop at
+/// the scanner's next reset token instead of swallowing the rest of the file.
+/// The two depth counters clear at different tokens — a bracket run at the next
+/// `;`, a paren run at the next `{`/`}` — so each bound is pinned separately,
+/// together with the recovery after it.
 #[test]
-fn bird_stray_punctuation_stays_bounded_to_its_construct() {
+fn bird_stray_punctuation_recovers_at_the_next_reset_token() {
     // Closes with no opener pop an empty frame stack; the file still translates.
     let source = "}\nrouter id 192.0.2.10;\n\
                   protocol bgp up { local as 64500; neighbor 192.0.2.1 as 64496; \
@@ -917,8 +920,7 @@ fn bird_stray_punctuation_stays_bounded_to_its_construct() {
     assert_eq!(imported.report.neighbor_count, 1);
     assert_eq!(imported.report.exit_code, 0);
 
-    // An unterminated set literal keeps `{`/`}` literal only until the next
-    // statement terminator resets the bracket depth.
+    // An unterminated set literal keeps `{`/`}` literal until the next `;`.
     let source = "define bogons = [ 1.0.0.0/8{8,32};\n\
                   protocol bgp up { local as 64500; neighbor 192.0.2.1 as 64496; }\n";
     let imported =
@@ -932,6 +934,36 @@ fn bird_stray_punctuation_stays_bounded_to_its_construct() {
             .any(|s| s.stanza.starts_with("define bogons")),
         "{:?}",
         skip_lines(&imported.report)
+    );
+
+    // With no `;` before it, the same run absorbs the following peer's header
+    // and body text up to the first `;` inside it — that terminator is the
+    // reset, and the peer after it translates.
+    let source = "define bogons = [ 1.0.0.0/8\n\
+                  protocol bgp lost { local as 64500; neighbor 192.0.2.1 as 64496; }\n\
+                  protocol bgp kept { local as 64500; neighbor 192.0.2.2 as 64497; }\n";
+    let imported =
+        import_source(SourceFormat::Bird, "open-bracket-run.conf", source).expect("translates");
+    assert_eq!(imported.report.neighbor_count, 1);
+    assert!(imported.config_toml.contains("address = \"192.0.2.2\""));
+
+    // A paren run ignores `;` entirely: it absorbs whole statements — across
+    // lines, and with them the next block's header — until the `{` that resets
+    // it. That block is framed and ignored; the peer after it translates.
+    let source = "function f (int a;\nrouter id 192.0.2.10;\nlog syslog all;\n\
+                  protocol bgp lost { local as 64500; neighbor 192.0.2.1 as 64496; }\n\
+                  protocol bgp kept { local as 64500; neighbor 192.0.2.2 as 64497; }\n";
+    let imported =
+        import_source(SourceFormat::Bird, "open-paren-run.conf", source).expect("translates");
+    assert_eq!(imported.report.neighbor_count, 1);
+    assert!(imported.config_toml.contains("address = \"192.0.2.2\""));
+    assert_eq!(
+        skip_lines(&imported.report),
+        vec![(
+            Some(1),
+            "function f (int a; router id 192.0.2.10; log syslog all; protocol bgp lost".to_owned()
+        )],
+        "the absorbed run must be one report entry, ending at the resetting brace"
     );
 
     // Braces and semicolons inside a quoted value are text, not structure.

--- a/crates/cli/tests/config_import.rs
+++ b/crates/cli/tests/config_import.rs
@@ -826,6 +826,181 @@ fn keepalive_mismatch_is_warned_never_guessed() {
 }
 
 // ---------------------------------------------------------------------------
+// Malformed BIRD sources: the scanner has no error recovery, so every
+// unbalanced or truncated construct must end as a refusal or a report
+// entry — never a panic, never a half-built session
+// ---------------------------------------------------------------------------
+
+/// A `protocol bgp` body is only finalized at its matching `}`, so anything
+/// that eats the close brace drops the session instead of emitting it half
+/// translated. Exit 3 with nothing written is the contract for all of it.
+#[test]
+fn bird_malformed_sources_refuse_instead_of_emitting_partial_sessions() {
+    for (case, source) in [
+        (
+            "missing closing brace",
+            "router id 192.0.2.10;\nprotocol bgp up {\n local as 64500;\n \
+             neighbor 192.0.2.1 as 64496;\n",
+        ),
+        (
+            "unterminated string",
+            "router id 192.0.2.10;\nprotocol bgp up {\n local as 64500;\n \
+             neighbor 192.0.2.1 as 64496;\n description \"never closed;\n}\n",
+        ),
+        (
+            // A second `"` inside an already-quoted value re-opens the string,
+            // so the rest of the file is swallowed as text.
+            "unbalanced quotes",
+            "protocol bgp up { local as 64500; neighbor 192.0.2.1 as 64496; \
+             description \"a\"b\"; }\n",
+        ),
+        (
+            "nested protocol blocks, none terminated",
+            "protocol bgp a {\n local as 64500;\n neighbor 192.0.2.1 as 64496;\n ipv4 {\n \
+             import all;\n protocol bgp b {\n neighbor 192.0.2.2 as 64497;\n",
+        ),
+        (
+            "empty peer definition",
+            "router id 192.0.2.10;\nprotocol bgp {\n}\n",
+        ),
+        (
+            "peer definition with no neighbor statement",
+            "router id 192.0.2.10;\nprotocol bgp lonely {\n local as 64500;\n}\n",
+        ),
+        (
+            "neighbor without a remote AS",
+            "protocol bgp up { local as 64500; neighbor 192.0.2.1; }\n",
+        ),
+        (
+            "truncated mid-token",
+            "router id 192.0.2.10;\nprotocol bgp up {\n local as 64500;\n \
+             neighbor 192.0.2.1 as 64",
+        ),
+        (
+            // The stray close pops the peer frame early; the neighbor then
+            // lands at top level, where it is reported rather than attached.
+            "stray closing brace inside a peer body",
+            "protocol bgp up {\n local as 64500;\n }\n neighbor 192.0.2.1 as 64496;\n}\n",
+        ),
+        (
+            "unterminated block comment",
+            "/* router id 192.0.2.10;\nprotocol bgp up { local as 64500; \
+             neighbor 192.0.2.1 as 64496; }\n",
+        ),
+        (
+            // `;` inside a parameter list separates declarations, so the peer
+            // header is absorbed into the unterminated `function` header.
+            "unterminated parameter list",
+            "function f (int a;\nprotocol bgp up { local as 64500; \
+             neighbor 192.0.2.1 as 64496; }\n",
+        ),
+    ] {
+        let error = import_source(SourceFormat::Bird, "malformed.conf", source)
+            .err()
+            .unwrap_or_else(|| panic!("{case}: expected a refusal, got a translation"));
+        assert!(matches!(error, ImportError::Empty(_)), "{case}: {error:?}");
+        assert_eq!(error.exit_code(), 3, "{case}");
+        assert!(error.to_string().contains("nothing written"), "{case}");
+    }
+}
+
+/// The other half: unbalanced punctuation BIRD itself would reject must stay
+/// bounded to its own construct instead of swallowing the rest of the file.
+#[test]
+fn bird_stray_punctuation_stays_bounded_to_its_construct() {
+    // Closes with no opener pop an empty frame stack; the file still translates.
+    let source = "}\nrouter id 192.0.2.10;\n\
+                  protocol bgp up { local as 64500; neighbor 192.0.2.1 as 64496; \
+                  ipv4 { import all; }; }\n};\n};\n";
+    let imported =
+        import_source(SourceFormat::Bird, "stray-close.conf", source).expect("translates");
+    assert_eq!(imported.report.neighbor_count, 1);
+    assert_eq!(imported.report.exit_code, 0);
+
+    // An unterminated set literal keeps `{`/`}` literal only until the next
+    // statement terminator resets the bracket depth.
+    let source = "define bogons = [ 1.0.0.0/8{8,32};\n\
+                  protocol bgp up { local as 64500; neighbor 192.0.2.1 as 64496; }\n";
+    let imported =
+        import_source(SourceFormat::Bird, "open-bracket.conf", source).expect("translates");
+    assert_eq!(imported.report.neighbor_count, 1);
+    assert!(
+        imported
+            .report
+            .skipped
+            .iter()
+            .any(|s| s.stanza.starts_with("define bogons")),
+        "{:?}",
+        skip_lines(&imported.report)
+    );
+
+    // Braces and semicolons inside a quoted value are text, not structure.
+    let source = "protocol bgp up { local as 64500; neighbor 192.0.2.1 as 64496; \
+                  description \"}; protocol bgp x {\"; }\n";
+    let imported =
+        import_source(SourceFormat::Bird, "string-braces.conf", source).expect("translates");
+    assert_eq!(imported.report.neighbor_count, 1);
+    assert!(
+        imported
+            .config_toml
+            .contains("description = \"}; protocol bgp x {\"")
+    );
+}
+
+/// Every prefix of both golden fixtures — files cut mid-token, mid-string,
+/// mid-comment, mid-block. Each must return, and whatever it does emit must be
+/// complete: `finish` resolves each emitted neighbor's remote AS through an
+/// `expect`, so a half-built session reaching the emitter would abort here.
+#[test]
+fn bird_truncation_at_every_boundary_emits_a_complete_config_or_refuses() {
+    for (name, full) in [("bird.conf", BIRD), ("bird3.conf", BIRD3)] {
+        for (cut, _) in full.char_indices() {
+            let Ok(imported) = import_source(SourceFormat::Bird, name, &full[..cut]) else {
+                continue;
+            };
+            let neighbors = imported.report.neighbor_count;
+            assert_eq!(
+                imported.config_toml.matches("\n[[neighbors]]\n").count(),
+                neighbors,
+                "{name} cut at {cut}"
+            );
+            assert_eq!(
+                imported.config_toml.matches("\nremote_asn = ").count(),
+                neighbors,
+                "{name} cut at {cut}: every emitted neighbor needs a remote AS"
+            );
+        }
+    }
+}
+
+/// Block depth lives on the heap, not the call stack: a pathologically nested
+/// file — closed or not — must not recurse, and must not lose the peer it
+/// already parsed.
+#[test]
+fn bird_deeply_nested_blocks_do_not_recurse() {
+    const PEER: &str = "protocol bgp up { local as 64500; neighbor 192.0.2.1 as 64496; }\n";
+    for source in [
+        format!("{PEER}{}{}", "x {".repeat(10_000), "}".repeat(10_000)),
+        format!("{PEER}{}", "x {".repeat(10_000)),
+    ] {
+        let imported =
+            import_source(SourceFormat::Bird, "nested.conf", &source).expect("translates");
+        assert_eq!(imported.report.neighbor_count, 1);
+    }
+}
+
+/// The importer's only raw byte index (`text["description".len()..]`) runs on
+/// statement text, so an argument-less `description;` slices at the very end of
+/// the string. It translates the session (with an empty description); the point
+/// is that the index is in bounds.
+#[test]
+fn bird_argument_less_description_indexes_in_bounds() {
+    let source = "protocol bgp up { local as 64500; neighbor 192.0.2.1 as 64496; description; }\n";
+    let imported = import_source(SourceFormat::Bird, "desc.conf", source).expect("translates");
+    assert_eq!(imported.report.neighbor_count, 1);
+}
+
+// ---------------------------------------------------------------------------
 // run_import (the CLI surface): I/O paths of the ladder
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`crates/cli/src/importer/bird.rs` gained BIRD 3.3.1 handling without explicit malformed-input coverage. Its scanner is brace/statement-aware but has no error recovery, so its degradation behavior was assumed rather than proven. This adds coverage of that behavior, and corrects one `scan` doc comment the coverage proved wrong. No importer behavior changed.

The frontend's error model is infallible-parse-plus-report: `bird::parse` always returns a `Model`, and `finish` turns an unusable one into `ImportError::Empty` (exit 3, nothing written) or a `Report` carrying skips/warnings (exit 2). The tests assert against that model.

Observed behavior, per case:

| malformed input | observed |
|---|---|
| missing closing brace | `Empty`, exit 3 — the peer accumulator is only finalized at its matching `}`, so the session is dropped rather than half-emitted |
| unterminated string | `Empty`, exit 3 — the rest of the file is consumed as string text |
| unbalanced quotes (`description "a"b";`) | `Empty`, exit 3 — the second quote re-opens the string |
| nested protocol blocks, none terminated | `Empty`, exit 3 |
| empty peer definition (`protocol bgp {}`) | `Empty`, exit 3 — no local AS |
| peer body with no `neighbor` statement | `Empty`, exit 3 — no translatable neighbors |
| `neighbor` without a remote AS | `Empty`, exit 3 |
| file truncated mid-token | `Empty`, exit 3 |
| stray closing brace inside a peer body | `Empty`, exit 3 — the frame pops early and the trailing `neighbor` lands at top level |
| unterminated block comment | `Empty`, exit 3 |
| unterminated parameter list | `Empty`, exit 3 — `;` inside parens separates declarations, so the following peer header is absorbed into the `function` header |
| stray closing brace with no opener (leading and trailing) | translates cleanly, exit 0 — closes pop an empty frame stack |
| unterminated set literal (`[ 1.0.0.0/8{8,32};`) | reported as one skip; the following peer still translates — the `;` resets the bracket depth |
| unterminated set literal with no `;` before the next peer | absorbs that peer up to the first `;` in its body; the peer after it translates |
| unterminated parameter list followed by statements and two peers | absorbs the statements and the first peer's header into one report entry, ending at the resetting `{`; the second peer translates |
| braces/semicolons inside a quoted value | treated as text; the peer translates and the description round-trips |
| every character-boundary prefix of `bird.conf` and `bird3.conf` | returns at every cut; whatever config it emits is complete (`[[neighbors]]` count matches the report, every emitted neighbor carries a `remote_asn`) |
| 10k-deep nesting, closed and unclosed | translates; depth is held on the heap, so no recursion and the already-parsed peer survives |
| argument-less `description;` | translates — this is the frontend's only raw byte index (`text["description".len()..]`), and it slices in bounds at the end of the string |

**No input panicked.** The truncation sweep is the load-bearing one: `emit_toml` resolves each neighbor's remote AS through an `expect`, so any prefix that produced a half-built session reaching the emitter would abort the test.

An argument-less `description;` emits `description = ""`. The input is invalid BIRD to begin with and the schema takes a free-form `Option<String>`, so the test asserts only that the index is in bounds, not the empty value. Not a defect.

## Doc correction

The coverage contradicted the `scan` doc comment, which claimed a stray bracket or paren "can never swallow more than the construct it appears in". It can. The two depth counters clear at *different* tokens, and neither has to be on the same line:

- a bracket run ends at the next `;` — with no `;` before it, an unterminated `[` absorbs the following peer's header and body text up to the first `;` inside that body;
- a paren run ends at the next `{` or `}` — an unterminated `(` ignores `;` entirely and absorbs whole statements across lines, taking the next block's header with them.

The reach is one reset token and no further, in both cases and at any nesting depth (`((((` behaves identically — the counter is assigned zero, not decremented). The scanner resumes normally after the reset, and a session lost to an absorbed run is refused rather than half-translated. That is what the comment now says. `scan` itself is unchanged; the test that pins both bounds and the recovery after each is cross-referenced from the comment, and was extended with the two absorb-then-recover shapes so the doc and the assertions describe the same scanner.

## Verification

All gates run in a clean worktree at this branch head; exit codes captured directly, no pipes.

| gate | exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace` | 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | 0 |
| `python3 scripts/check-clippy-reasons.py` | 0 |

`crates/cli/tests/config_import.rs`: 37 passed, 0 failed.

Run once for the tests and re-run in full for the doc correction; the table above is the second pass at head `12958e39`. On the first pass one `cargo test --workspace` run hit the known `rustbgpd-event-history` flake (`shutdown_drains_every_accepted_event_with_live_sender`, LAN-941); three subsequent full runs, including one with `--no-fail-fast`, were green.

Refs LAN-945.
