### PR TITLE
Harden the RIB update-group staging and clean-transition paths

### DIFF
--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -1325,7 +1325,7 @@ impl RibManager {
                     if let Some(prepared) = self.prepared_destination.take()
                         && prepared != destination
                     {
-                        self.discard_uncommitted_policy_transition_group(prepared);
+                        let _ = self.discard_uncommitted_policy_transition_group(prepared);
                     }
                     pending.phase = Some(CleanPolicyTransitionPhase::StageDestination {
                         source,
@@ -2943,7 +2943,7 @@ impl RibManager {
         // (The peer manager awaits the prepare reply before sending the
         // transition, so this is a belt-and-braces guard.)
         if let Some(prestage) = self.pending_destination_prestage.take() {
-            self.discard_uncommitted_policy_transition_group(prestage.destination);
+            let _ = self.discard_uncommitted_policy_transition_group(prestage.destination);
         }
         self.metrics.set_rib_policy_transition_in_progress(true);
         self.pending_clean_policy_transition =
@@ -3034,7 +3034,7 @@ impl RibManager {
         // A still-running destination preparation cannot be trusted
         // mid-walk (same guard as the cohort transition command).
         if let Some(prestage) = self.pending_destination_prestage.take() {
-            self.discard_uncommitted_policy_transition_group(prestage.destination);
+            let _ = self.discard_uncommitted_policy_transition_group(prestage.destination);
         }
 
         let mut present: Vec<PeerExportPolicyReplacement> = Vec::with_capacity(replacements.len());
@@ -3228,7 +3228,7 @@ impl RibManager {
         if let Some(prepared) = self.prepared_destination.take()
             && prepared != destination
         {
-            self.discard_uncommitted_policy_transition_group(prepared);
+            let _ = self.discard_uncommitted_policy_transition_group(prepared);
         }
         let Some(&exemplar) = members.first() else {
             return false;
@@ -3540,12 +3540,12 @@ impl RibManager {
         // cohort never arrived) is discarded before a new one begins;
         // the record must only ever name the latest staged group.
         if let Some(stale) = self.prepared_destination.take() {
-            self.discard_uncommitted_policy_transition_group(stale);
+            let _ = self.discard_uncommitted_policy_transition_group(stale);
         }
         // A leftover unowned group under this id may be partially staged
         // from an aborted attempt; recreate it deterministically. An OWNED
         // group is maintained by definition — nothing to stage.
-        self.discard_uncommitted_policy_transition_group(destination);
+        let _ = self.discard_uncommitted_policy_transition_group(destination);
         match self.begin_policy_transition_group(destination, peer, export_policy) {
             super::update_groups::PolicyTransitionGroupStart::Maintained => {
                 let _ = reply.send(Ok(()));
@@ -3576,7 +3576,7 @@ impl RibManager {
         else {
             return;
         };
-        self.discard_uncommitted_policy_transition_group(gid);
+        let _ = self.discard_uncommitted_policy_transition_group(gid);
         if let Some(reply) = prestage.reply {
             let _ = reply.send(Err(
                 "prepared destination group adopted by a membership change; preparation discarded"
@@ -3644,10 +3644,10 @@ impl RibManager {
     /// adopted destination has members and stays.
     pub(super) fn discard_prepared_export_destination(&mut self) {
         if let Some(prestage) = self.pending_destination_prestage.take() {
-            self.discard_uncommitted_policy_transition_group(prestage.destination);
+            let _ = self.discard_uncommitted_policy_transition_group(prestage.destination);
         }
         if let Some(prepared) = self.prepared_destination.take() {
-            self.discard_uncommitted_policy_transition_group(prepared);
+            let _ = self.discard_uncommitted_policy_transition_group(prepared);
         }
     }
 

--- a/crates/rib/src/manager/update_groups/policy_transition.rs
+++ b/crates/rib/src/manager/update_groups/policy_transition.rs
@@ -5,6 +5,21 @@ use super::{
     PolicyChain, PolicyTransitionGroupStart, Prefix, RibManager, Route, UpdateGroupClassification,
     classify_update_group, routes_equal, source_control_input,
 };
+use tracing::debug;
+
+/// One `None` arm of the clean-transition inventory walk. Every arm
+/// degrades the WHOLE cohort back to the authoritative per-peer path,
+/// so name the group pair and the term that fired: a degraded cohort
+/// is otherwise indistinguishable in the log from one that never
+/// qualified for the fast path at all.
+fn inventory_degraded(source: usize, destination: usize, key: Option<(Prefix, u32)>, term: &str) {
+    debug!(
+        source,
+        destination,
+        ?key,
+        "clean transition inventory degraded: {term}"
+    );
+}
 
 impl RibManager {
     /// Snapshot route identities for the strict clean transition inventory.
@@ -63,8 +78,14 @@ impl RibManager {
         inventory: &mut CleanPolicyTransitionInventoryBuilder,
     ) -> Option<()> {
         use crate::manager::distribution::rs_control::rs_control_route_tagged;
-        let old = self.group_ribs.get(&source)?;
-        let new = self.group_ribs.get(&destination)?;
+        let Some(old) = self.group_ribs.get(&source) else {
+            inventory_degraded(source, destination, None, "source group missing");
+            return None;
+        };
+        let Some(new) = self.group_ribs.get(&destination) else {
+            inventory_degraded(source, destination, None, "destination group missing");
+            return None;
+        };
         // Fold permit counts per chunk keyed by borrowed labels, then merge
         // into the owned builder maps once: the per-route path used to clone
         // the `Option<String>` label twice per route, which dominated this
@@ -79,10 +100,17 @@ impl RibManager {
         // touch the maps once per flip instead of twice per route.
         let mut run: Option<(IpAddr, Option<&str>, u64)> = None;
         for &(prefix, path_id) in keys {
-            let route = new.table.get(&prefix, path_id)?;
             let key = (prefix, path_id);
-            let prior = old.table.get(&prefix, path_id)?;
+            let Some(route) = new.table.get(&prefix, path_id) else {
+                inventory_degraded(source, destination, Some(key), "destination table drift");
+                return None;
+            };
+            let Some(prior) = old.table.get(&prefix, path_id) else {
+                inventory_degraded(source, destination, Some(key), "source table drift");
+                return None;
+            };
             if prior.peer != route.peer {
+                inventory_degraded(source, destination, Some(key), "source flip");
                 return None;
             }
             let next_hop = new.nh_override(key);
@@ -99,6 +127,7 @@ impl RibManager {
                             || rs_control_route_tagged(new_communities, new_large, rs_asn)
                     });
                     if tagged {
+                        inventory_degraded(source, destination, Some(key), "rs-control tag");
                         return None;
                     }
                 }
@@ -370,6 +399,12 @@ impl RibManager {
 
     /// Remove a partially or fully staged, still-unowned destination before
     /// the caller hands the transition back to the authoritative per-peer path.
+    ///
+    /// `false` means the group had members and was therefore KEPT — it is
+    /// now an owned, maintained group, not a leak. Callers that can only
+    /// reach this with a group they created must treat `false` as an error;
+    /// callers cleaning up a possibly-adopted prestage discard it explicitly.
+    #[must_use = "false leaves the group in place; a caller that created it must treat that as an error"]
     pub(in crate::manager) fn discard_uncommitted_policy_transition_group(
         &mut self,
         gid: usize,

--- a/crates/rib/src/manager/update_groups/staging.rs
+++ b/crates/rib/src/manager/update_groups/staging.rs
@@ -1,11 +1,26 @@
 use super::{
-    GroupDelta, GroupStageOutput, HashMap, HashSet, IpAddr, LaneDelta, NextHopAction, PolicyAction,
-    PolicyChain, PolicyFilteredRouteKey, PolicyLabel, Prefix, RibManager, Route, RunnerUp,
-    VpnDenialRecord, VpnGroupDelta, VpnGroupStageOutput, VpnRibRoute, VpnRibRouteKey, VpnRouteKey,
-    capture_source_attrs, routes_equal, source_control_input,
+    GroupDelta, GroupRibOut, GroupStageOutput, HashMap, HashSet, IpAddr, LaneDelta, NextHopAction,
+    PolicyAction, PolicyChain, PolicyFilteredRouteKey, PolicyLabel, Prefix, RibManager, Route,
+    RunnerUp, VpnDenialRecord, VpnGroupDelta, VpnGroupStageOutput, VpnRibRoute, VpnRibRouteKey,
+    VpnRouteKey, capture_source_attrs, routes_equal, source_control_input,
 };
 
 impl RibManager {
+    /// The group a staging pass read at its top, for the commit block
+    /// at its bottom. `&mut self` held across the whole pass is the
+    /// only thing that makes this lookup infallible; a future
+    /// re-entrant (async) staging pass would break that exclusivity
+    /// silently, so assert the invariant rather than only unwrap it.
+    fn staged_group_mut(&mut self, gid: usize) -> &mut GroupRibOut {
+        debug_assert!(
+            self.group_ribs.contains_key(&gid),
+            "staging exclusivity: group {gid} read at the top of the pass must still exist at commit"
+        );
+        self.group_ribs
+            .get_mut(&gid)
+            .expect("group staged above still exists")
+    }
+
     /// Run the shared staging pass for every live group over the pass's
     /// changed prefixes. Deltas are committed to the group tables here;
     /// the per-peer loop emits them per member via the source-flip
@@ -296,10 +311,7 @@ impl RibManager {
                 labeled_filtered.extend(filtered.drain(..).map(|key| (key, label.clone())));
             }
         }
-        let group = self
-            .group_ribs
-            .get_mut(&gid)
-            .expect("group staged above still exists");
+        let group = self.staged_group_mut(gid);
         for delta in &out.deltas {
             group.apply_delta(delta);
         }
@@ -474,10 +486,7 @@ impl RibManager {
                 }
             }
         }
-        let group = self
-            .group_ribs
-            .get_mut(&gid)
-            .expect("group staged above still exists");
+        let group = self.staged_group_mut(gid);
         for delta in &out.deltas {
             group.apply_vpn_delta(delta);
         }

--- a/crates/rib/src/manager/update_groups/tests.rs
+++ b/crates/rib/src/manager/update_groups/tests.rs
@@ -5364,3 +5364,132 @@ fn per_client_best_groups_are_excluded_from_clean_transition_inventory() {
         );
     }
 }
+
+/// [`route`] plus one standard community — the smallest wire-form
+/// difference between a source and a destination staged entry, and,
+/// with a control-space value, an RFC 7947 tag for [`RS_ASN`].
+fn route_with_comm(p: Prefix, src: IpAddr, comm: u32) -> Route {
+    let mut route = route(p, src);
+    let mut attrs = (*route.attributes).clone();
+    attrs.push(PathAttribute::Communities(vec![comm]));
+    route.attributes = Arc::new(attrs);
+    route
+}
+
+/// [`announce_delta`] for a caller-built route (which carries its own
+/// prefix and source), so the source attrs match the staged entry.
+fn announce_route_delta(new: Route) -> GroupDelta {
+    let source_attrs = capture_source_attrs(&new);
+    GroupDelta {
+        prefix: new.prefix,
+        path_id: 0,
+        new: Some((new, None)),
+        old_source: None,
+        policy_label: None,
+        source_attrs,
+        lane: None,
+    }
+}
+
+/// A group whose table holds exactly the given staged entries.
+fn group_with(deltas: &[GroupDelta]) -> GroupRibOut {
+    let mut group = empty_group();
+    for delta in deltas {
+        group.apply_delta(delta);
+    }
+    group
+}
+
+const CLEAN_SOURCE: usize = 1;
+const CLEAN_DESTINATION: usize = 2;
+
+/// Run one inventory chunk over `keys` against the manager's current
+/// group tables.
+fn extend_inventory(m: &RibManager, keys: &[(Prefix, u32)], rs_asns: &[u32]) -> Option<()> {
+    let mut inventory = CleanPolicyTransitionInventoryBuilder::default();
+    m.extend_clean_policy_transition_inventory(
+        CLEAN_SOURCE,
+        CLEAN_DESTINATION,
+        keys,
+        rs_asns,
+        &mut inventory,
+    )
+}
+
+fn inventory_manager(source: GroupRibOut, destination: GroupRibOut) -> RibManager {
+    let mut m = staging_manager();
+    m.group_ribs.insert(CLEAN_SOURCE, source);
+    m.group_ribs.insert(CLEAN_DESTINATION, destination);
+    m
+}
+
+/// Degradation paths of the clean-transition inventory walk, each of
+/// which hands the whole cohort back to the authoritative per-peer
+/// machinery: a source flip under the snapshot, and an RFC 7947
+/// control-form community in the delta. Both are asserted against the
+/// accepting shape so the `None` is attributable to the tested term
+/// and not to the wire-form change that carries it.
+#[test]
+fn clean_transition_inventory_degrades_on_source_flip_and_control_tag() {
+    // Control-space for RS_ASN: administrator 0 (`0:TARGET_ASN`, the
+    // "do not announce to TARGET_ASN" form).
+    const TAGGED_COMM: u32 = TARGET_ASN;
+    // Administrator is neither 0 nor RS_ASN nor the RFC 1997
+    // well-known space: a pure wire-form change, no per-target
+    // divergence.
+    const PLAIN_COMM: u32 = (64513 << 16) | 7;
+    let keys = [(prefix(1), 0)];
+    let staged = |src, comm: Option<u32>| match comm {
+        Some(comm) => group_with(&[announce_route_delta(route_with_comm(prefix(1), src, comm))]),
+        None => group_with(&[announce_delta(prefix(1), src, None)]),
+    };
+
+    let m = inventory_manager(staged(OTHER1, None), staged(OTHER2, None));
+    assert!(
+        extend_inventory(&m, &keys, &[]).is_none(),
+        "a source flip under the snapshot degrades the cohort"
+    );
+
+    let m = inventory_manager(staged(OTHER1, None), staged(OTHER1, Some(PLAIN_COMM)));
+    assert!(
+        extend_inventory(&m, &keys, &[RS_ASN]).is_some(),
+        "the same-source wire-form change alone stays on the shared path"
+    );
+
+    let m = inventory_manager(staged(OTHER1, None), staged(OTHER1, Some(TAGGED_COMM)));
+    assert!(
+        extend_inventory(&m, &keys, &[RS_ASN]).is_none(),
+        "a control-form community in the delta degrades the cohort"
+    );
+    assert!(
+        extend_inventory(&m, &keys, &[]).is_some(),
+        "with no rs-control ASN in the cohort the same delta stays shared"
+    );
+}
+
+/// Table drift on either side between the snapshot and the walk:
+/// a key the snapshot recorded is gone, so the inventory can no
+/// longer describe the old-to-new wire delta and degrades.
+#[test]
+fn clean_transition_inventory_degrades_on_table_drift() {
+    let keys = [(prefix(1), 0)];
+    let staged = || group_with(&[announce_delta(prefix(1), OTHER1, None)]);
+
+    let m = inventory_manager(staged(), group_with(&[]));
+    assert!(
+        extend_inventory(&m, &keys, &[]).is_none(),
+        "the destination no longer stages the snapshot key"
+    );
+
+    let m = inventory_manager(group_with(&[]), staged());
+    assert!(
+        extend_inventory(&m, &keys, &[]).is_none(),
+        "the source no longer stages the snapshot key"
+    );
+
+    let m = inventory_manager(staged(), staged());
+    assert!(
+        extend_inventory(&m, &keys, &[]).is_some(),
+        "an undrifted pair completes the chunk"
+    );
+}


### PR DESCRIPTION
## Summary

Four bounded defensive changes from a post-v0.64 review of the update-group staging path. No happy-path behavior change; no control flow changed.

**RIB-1 — staging exclusivity is asserted, not assumed.** Both `stage_group_prefixes` and `stage_group_vpn_keys` read a group at the top of the pass and re-resolve it with `.expect()` at the commit block. Today `&mut self` held across the whole pass is the only thing making that infallible. Both call sites now go through `staged_group_mut`, which `debug_assert!`s the invariant (naming it) before unwrapping — a future re-entrant/async staging pass trips the assert instead of panicking on an opaque `expect`. Folding the two identical sites into one accessor also removes the duplicated expect string.

**RIB-2 — the clean-transition inventory degradations are debuggable.** Every `None` arm of `extend_clean_policy_transition_inventory` degrades the *whole cohort* back to the authoritative per-peer path, and did so silently: in a log capture a degraded cohort was indistinguishable from one that never qualified for the fast path. Each arm now emits `debug!` naming the source/destination pair, the key, and the term that fired (`source group missing`, `destination group missing`, `destination table drift`, `source table drift`, `source flip`, `rs-control tag`). The six sites share one `inventory_degraded` logger so the walk body stays under the length ratchet without an `#[expect]`.

**RIB-5 — `discard_uncommitted_policy_transition_group` is `#[must_use]`.** `false` means the group had members and was therefore *kept*. A caller that created the group and ignores that would leave an unowned-but-nonempty zombie group behind. The attribute carries that contract in its message. All nine flagged call sites were audited: each is cleaning up a prestage that may legitimately have been adopted by a membership event ("an adopted destination has members and stays" — the behavior their surrounding comments already document), so each discards explicitly with `let _ =` rather than silencing the lint. The one call site that *does* consume the value — `discard_uncommitted_transition`, which owns the destination it created — already turns `false` into an error and is unchanged.

**RIB-6 — tests for the degradation paths.** `extend_clean_policy_transition_inventory` had no direct coverage of any of its `None` arms. Two tests now cover source flip, RFC 7947 control-form community, and table drift on either side. The flip and tag cases are each asserted against their accepting shape (same-source wire-form change; the same tagged delta with an empty `rs_asns`), so a `None` is attributable to the tested term rather than to the wire-form change that carries it.

## Verification

All gates run locally at `010eb353`, exit codes only:

| Gate | Exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace` | 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | 0 |
| `python3 scripts/check-clippy-reasons.py` | 0 |
| `cargo check -p rustbgpd-rib --features bench-internals --benches` | 0 |
| `bash bench/smoke-benches.sh` | 0 |

No `debug_assert` fires anywhere in the workspace suite.

## Load-bearing proof

Each new assertion was proven against deliberately broken production code, then restored. All four breaks were re-run against the final code shape after the logger refactor.

| Break applied to `extend_clean_policy_transition_inventory` | Test that went red |
| --- | --- |
| `if prior.peer != route.peer { return None; }` deleted | `clean_transition_inventory_degrades_on_source_flip_and_control_tag` — *"a source flip under the snapshot degrades the cohort"* |
| `if tagged { return None; }` replaced with `let _ = tagged;` | `clean_transition_inventory_degrades_on_source_flip_and_control_tag` — *"a control-form community in the delta degrades the cohort"* |
| destination-drift arm `return None` → `continue` | `clean_transition_inventory_degrades_on_table_drift` — *"the destination no longer stages the snapshot key"* |
| source-drift arm `return None` → `continue` | `clean_transition_inventory_degrades_on_table_drift` — *"the source no longer stages the snapshot key"* |

Each break produced exit 101 with exactly the paired assertion failing and the sibling test still passing.

The `#[must_use]` was proven live the same way: removing one `let _ =` reproduces

```
warning: unused return value of `...::discard_uncommitted_policy_transition_group` that must be used
    --> crates/rib/src/manager/distribution/mod.rs:3579:9
     = note: false leaves the group in place; a caller that created it must treat that as an error
```

which is a hard error under the `-D warnings` clippy gate.

Refs LAN-943.
