### PR TITLE
fix(rib): warm the ASPA completion callsite before capturing it

### DIFF
--- a/crates/rib/src/manager/tests/rpki.rs
+++ b/crates/rib/src/manager/tests/rpki.rs
@@ -115,10 +115,36 @@ fn aspa_cache_update_emits_one_bounded_completion_event() {
         },
     ]));
     tracing::subscriber::with_default(Capture(StdArc::clone(&captured)), || {
+        // Sibling tests in this module drive the same completion callsite
+        // through `manager.run()` on tokio workers that have no subscriber
+        // installed. Whichever thread wins a callsite's one-shot registration
+        // decides its cached `Interest`, and a no-subscriber thread caches
+        // `Interest::never()` for it process-wide; a scoped subscriber does
+        // not invalidate that cache, so the measured call below can be
+        // dropped on the macro's cached-interest fast path before any
+        // subscriber sees it. Warm the callsite on a throwaway manager, then
+        // re-register it against this subscriber — a callsite registers once,
+        // so the measured call cannot lose that race afterwards.
+        let (_warm_tx, warm_rx) = mpsc::channel(1);
+        let mut warm = RibManager::new(warm_rx, dummy_query_rx(), None, None, BgpMetrics::new());
+        warm.handle_aspa_cache_update(Arc::clone(&table));
+        tracing::callsite::rebuild_interest_cache();
+        captured.lock().unwrap().clear();
+
         manager.handle_aspa_cache_update(table);
     });
 
-    let events = captured.lock().unwrap();
+    // Count *the* completion event, not this thread's global event volume.
+    let all = captured.lock().unwrap();
+    let events: Vec<&Fields> = all
+        .iter()
+        .filter(|fields| {
+            fields
+                .0
+                .get("message")
+                .is_some_and(|message| message == "ASPA cache update re-validation complete")
+        })
+        .collect();
     assert_eq!(events.len(), 1);
     let fields = &events[0].0;
     for (name, value) in [


### PR DESCRIPTION
## Summary

`manager::tests::rpki::aspa_cache_update_emits_one_bounded_completion_event` failed roughly 1 in 30 full-binary runs under load with `left: 0, right: 1` — the completion event missing, never duplicated, never in isolation (LAN-941 instance #1).

**The ticket's leading hypothesis is refuted.** The suppression is not the process-wide max-level hint; it is tracing's per-callsite `Interest` cache.

A callsite's `Interest` is computed once, by whichever thread wins its one-shot registration (`DefaultCallsite::register`, tracing-core 0.1.36 `callsite.rs:308`), and cached process-wide. Three sibling tests in this module (`rpki.rs:565`, `:613`, `:675`) drive the same completion callsite through `manager.run()` on tokio workers with no subscriber installed; `NoSubscriber::register_callsite` returns `Interest::never()` (`subscriber.rs:676`). A scoped `with_default` subscriber does not invalidate that cached value. When a sibling's registration lands between this test's `Dispatch::new` rebuild and its measured call, the event is dropped on the macro's cached-interest fast path before any subscriber sees it — yielding exactly `0`, never `2`.

`max_level_hint()` is not implicated: tracing-core already treats a subscriber that returns `None` as `TRACE` (`callsite.rs:412`, `dispatch.max_level_hint().unwrap_or(LevelFilter::TRACE)`), so implementing it on `Capture` would have been a literal no-op. It is deliberately not added here — a change that looks like the fix but is not would mislead the next reader of this test.

The fix follows the existing in-repo treatment of the identical mechanism in `src/config/tests/rpol.rs:104`: warm the callsite on a throwaway manager inside the capture scope, then re-register it against this subscriber. A callsite registers once, so the measured call cannot lose that race afterwards.

The count assertion also now selects *the* completion event by message rather than asserting on the capturing thread's global event volume, so an unrelated neighbouring log line on the same path cannot red the test for the wrong reason.

## Phase 1 — bracketing evidence

| Bracket | Result |
| --- | --- |
| `cargo test -p rustbgpd-rib --lib -- --test-threads=1`, 15 iterations | 15/15 pass — never reproduces serially |
| rib lib test binary, default parallelism, 48-way CPU load, 30 iterations | **1/30 failed** at `rpki.rs` |

The failing iteration was instrumented to discriminate the two candidate mechanisms. It emitted a *probe* `info!` from a fresh callsite in the test, on the same thread, inside the same `with_default`, immediately after the production call, and read back the global max level:

```
assertion `left == right` failed: LAN941DIAG max_level=LevelFilter::TRACE after_prod=0 after_probe=1
  left: 0
 right: 1
```

- `max_level=LevelFilter::TRACE` — the macro's `level_enabled!` fast path was wide open. The max-level hypothesis is refuted directly, and is structurally impossible besides: the max is taken over every live dispatcher and a hint-less one counts as `TRACE`, so it cannot fall below `TRACE` while `Capture` is installed.
- `after_prod=0`, `after_probe=1` — a callsite first registered on the capturing thread was captured, while the production callsite was not. The filter is per-callsite.

`crates/rib/src/manager/tests/update_groups.rs:2683` carries the same `Capture` shape, but its production callsite is the closed-reply early return in `handle_replace_peer_export_policies_authoritatively`; all four sibling drivers (`update_groups.rs:6437/6583/6645/6708`) hold their reply alive, so that callsite is reached only by its own test and is not exposed. Left alone. `src/config/tests/rpol.rs:104` already carries this fix.

## Phase 3 — proof

100 iterations of the rib lib test binary under the identical 48-way load: **0 failures** (500 s). At the measured 1/30 base rate that run expected ~3.3 failures.

The reproduction recipe is unchanged and preserved: run the `rustbgpd_rib` lib test binary directly at default parallelism with the box loaded, revert this commit, and instrument the assertion with the probe callsite above.

Red proofs — the assertion still fails when the property it guards is broken:

| Mutation to `handle_aspa_cache_update` | Result |
| --- | --- |
| A: completion `info!` deleted | **RED**, `left: 0, right: 1` |
| B: completion `info!` emitted twice | **RED**, `left: 2, right: 1` |
| C: unrelated neighbouring `info!` added on the same path | GREEN — the point of the message filter; this red the test before |

## Gates

| Gate | Exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace` | 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | 0 |
| `python3 scripts/check-clippy-reasons.py` | 0 |
| `cargo check -p rustbgpd-rib --features bench-internals --benches` | 0 |

LAN-941 instance #2 (`event-history` shutdown drain) is untouched — it is owned by a separate effort.

Refs LAN-941.
