### PR TITLE
Size the criterion bench timeout to the measured rib_ops matrix

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -58,7 +58,15 @@ jobs:
     # Defensive: never run on a fork that inherits the runner registration.
     if: github.repository == 'lance0/rustbgpd'
     runs-on: [self-hosted, rustbgpd-bench]
-    timeout-minutes: 120
+    # Sized against the measured `rib_ops` matrix, not guessed. Four attempts
+    # are eight half-runs: ~19.5 min each for the two that pay cold
+    # compilation and ~14.3 min at steady state, so a full comparison needs
+    # ~127 min. The previous 120 was set when `rib_ops` had 10 bench sites;
+    # #1374 took it to 15 (35 of the 53 measured rows are the `attr_*`
+    # groups). Runs only began cancelling once v0.63.0 was tagged and the
+    # baseline side inherited those rows too — before that the cheaper
+    # baseline half kept the total under the cap.
+    timeout-minutes: 180
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -83,7 +83,11 @@ jobs:
     # noisy for these numbers and cannot provide the CPU pinning /
     # governor posture this workflow assumes.
     runs-on: [self-hosted, rustbgpd-bench]
-    timeout-minutes: 120
+    # Same runner and same harness as bench-nightly.yml, so the same ceiling
+    # applies: an unfiltered `rib_ops` half-run is ~14.3 min at steady state,
+    # which puts the default 3 attempts near 96 min and a 4-attempt dispatch
+    # past the old 120-minute cap. See bench-nightly.yml for the measurement.
+    timeout-minutes: 180
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
The Criterion Bench Nightly tripwire has produced no usable result since
2026-08-04. Diagnosis first, then a change sized to what the evidence
supports.

## Per-run cause

| Run | Date | Conclusion | Cause |
|---|---|---|---|
| 30689706751 | 08-01 | success | ran before #1374 merged |
| 30737933154 | 08-02 | failure | real verdict: confident regressions vs `v0.62.0` |
| 30797359329 | 08-03 | failure | real verdict: confident regressions vs `v0.62.0` |
| 30985758938 | 08-05 | cancelled | job timeout at 120:01 |
| 31081476572 | 08-06 | cancelled | job timeout at 120:01 |
| 31152792217 | 08-07 | cancelled | job timeout at 120:01 |
| 31297125595 | 08-09 | cancelled | job timeout at 120:01 |

Every cancelled run shows the same shape: `Run Criterion comparison`
starts within a second of the job and is killed at exactly 120 minutes,
with the runner then reaping orphaned `cargo` / `rib_ops-*` processes.

The other candidate causes are ruled out by evidence, not by assumption:

- **Not the concurrency group.** `criterion-bench-compare` is
  `cancel-in-progress: false`, and no run was superseded.
- **Not the host lock.** `bench/compare-criterion.sh` takes it with
  `flock -n` and exits 75 immediately if held. Every cancelled run logs
  `acquired host lock` in its first second. No soak was left paused.
- **Not runner availability.** `lancebox-cloud` is online, idle, and
  carries both required labels.
- **Not manual cancellation.** No `cancelled` actor in the run metadata.

## Why 120 minutes stopped being enough

Half-run durations from the 08-09 log:

| Half | Duration |
|---|---|
| attempt 1 base / head | 19.5 min each (cold compile) |
| attempts 2-4 | 14.3-14.6 min each |

Seven halves completed in 111.2 min; the eighth was 8.8 min in when the
job was killed. A full comparison needs ~125 min of step time and
~127 min of job time against a 120-minute cap — an overrun of about 6%.

The matrix outgrew the cap in two steps:

1. **#1374 (08-01)** took `rib_ops` from 10 bench sites to 15. Its five
   `attr_*` groups account for 35 of the 53 rows now measured. This only
   slowed the head side, so the 08-02 and 08-03 runs still finished (88
   min) — their baseline halves were still ~5 min.
2. **Tagging v0.63.0 (08-04)** pulled those rows into the baseline side
   too. Baseline halves went ~5 min to ~14.3 min, and the next scheduled
   run cancelled. Every one since has.

## The change

Raise `timeout-minutes` to 180 in both workflows. `bench.yml` shares the
runner, harness and matrix, so a 4-attempt manual dispatch was already
past the old cap; the default 3 attempts sat at ~96 min with little room.

This lets the job finish and emit a real verdict rather than converting
a cancellation into a green no-op. Attempts stay at 4 — the workflow
relies on an even count to cancel base/head order bias, so trimming to 3
would trade a real design property for wall time.

## Follow-up, not addressed here

The 08-02 and 08-03 failures were correct and reproducible:
`adj_rib_in_insert/500000` at +49.31% and +49.77% vs `v0.62.0`, 4/4
attempts, stddev 1.20% and 3.71%. #1374 is bench-only and its
`make_route` refactor is behavior-preserving, so this is not a fixture
artifact. The regression window is `v0.62.0..40fe21ea`, which contains
five commits touching `crates/rib/src` (#1356, #1363, #1369, #1371,
#1372).

Because `v0.63.0` was tagged after the regression landed, it is now
baked into the baseline and the tripwire can no longer see it. Raising
the timeout will make the job green without that regression having been
resolved. It needs its own ticket and a pinned A/B against `v0.62.0`.

Refs LAN-940.