### PR TITLE
Bound the EHM shutdown drain test by deadline fallbacks, not a stopwatch

### DIFF
--- a/crates/event-history/src/lib.rs
+++ b/crates/event-history/src/lib.rs
@@ -933,6 +933,10 @@ impl EventHistoryManager {
             let result = match tokio::time::timeout_at(deadline, &mut actor).await {
                 Ok(result) => result,
                 Err(_) => {
+                    #[cfg(test)]
+                    self.shutdown_progress
+                        .deadline_expiries
+                        .fetch_add(1, Ordering::AcqRel);
                     actor.abort();
                     actor.await
                 }
@@ -976,6 +980,13 @@ struct ShutdownProgress {
     accepted_complete: AtomicBool,
     #[cfg(test)]
     loss_latches: AtomicU64,
+    /// Times shutdown fell back to the shared deadline instead of
+    /// finishing on its own. Counts both arms of that race: the actor's
+    /// drain loop timing out on `rx.recv`, and the manager timing out on
+    /// the actor and aborting it. Lets tests assert a finite queue drains
+    /// on channel closure without timing the drain with a stopwatch.
+    #[cfg(test)]
+    deadline_expiries: AtomicU64,
 }
 
 fn record_shutdown_loss(
@@ -1090,7 +1101,13 @@ async fn run_actor(
                         receive_event(env, &mut buffer, &queue_depths, config.metrics.as_ref())
                     }
                     Ok(None) => accepted_drained = true,
-                    Err(_) => break,
+                    Err(_) => {
+                        #[cfg(test)]
+                        shutdown_progress
+                            .deadline_expiries
+                            .fetch_add(1, Ordering::AcqRel);
+                        break;
+                    }
                 }
             }
         } else {
@@ -1317,6 +1334,11 @@ mod tests {
     use super::*;
     use storage::TestStoreOp::{Append, Flush, Shutdown};
 
+    /// Hang preventer, not a timing property. Every assertion below is on
+    /// observed state, never on how long something took, so this only has
+    /// to be large enough that a loaded box never reaches it.
+    const TEST_BACKSTOP: Duration = Duration::from_secs(60);
+
     fn test_config(path: PathBuf, batch_size: usize) -> EventHistoryConfig {
         EventHistoryConfig {
             path,
@@ -1343,7 +1365,7 @@ mod tests {
     }
 
     async fn wait_for_store(store: &storage::StoreHandle, op: storage::TestStoreOp) {
-        tokio::time::timeout(Duration::from_secs(1), store.test_wait_for_send(op))
+        tokio::time::timeout(TEST_BACKSTOP, store.test_wait_for_send(op))
             .await
             .expect("storage request backstop elapsed");
     }
@@ -1364,7 +1386,7 @@ mod tests {
             .sender()
             .try_send(event(Category::Route, 1))
             .unwrap();
-        tokio::time::timeout(Duration::from_secs(1), losses.changed())
+        tokio::time::timeout(TEST_BACKSTOP, losses.changed())
             .await
             .expect("append-error loss generation backstop elapsed")
             .unwrap();
@@ -1378,13 +1400,17 @@ mod tests {
     #[tokio::test]
     async fn shutdown_drains_every_accepted_event_with_live_sender() {
         // Load-bearing breaks: the old batch_size*2 cap loses five events;
-        // omitting receiver close exceeds the one-second backstop.
+        // omitting the receiver close leaves the drain with nothing to end
+        // it but the shared deadline, which the expiry count catches on
+        // either arm of that race — without timing the drain, so a slow
+        // box cannot fail a correct drain.
         let dir = tempfile::tempdir().unwrap();
         let manager = EventHistoryManager::start(test_config(dir.path().join("events.db"), 4))
             .await
             .unwrap();
         let sender = manager.sender();
         let state = manager.state();
+        let progress = Arc::clone(&manager.shutdown_progress);
         let queue_depths = Arc::clone(&manager.sender.queue_depths);
         let mut committed = manager.subscribe();
         let categories = Category::ALL;
@@ -1397,9 +1423,14 @@ mod tests {
                 .unwrap();
         }
 
-        tokio::time::timeout(Duration::from_secs(1), manager.shutdown())
+        tokio::time::timeout(TEST_BACKSTOP, manager.shutdown())
             .await
-            .expect("finite accepted queue did not drain within the aggregate bound");
+            .expect("shutdown never returned");
+        assert_eq!(
+            progress.deadline_expiries.load(Ordering::Acquire),
+            0,
+            "a finite accepted queue must drain on channel closure, not on the shutdown deadline"
+        );
         assert_eq!(state.latest_event_id(), 13);
         for expected in 0..13 {
             let observed = committed.try_recv().unwrap();
@@ -1440,9 +1471,9 @@ mod tests {
         let shutdown = tokio::spawn(manager.shutdown());
         tokio::task::yield_now().await;
         store.test_release(Append);
-        tokio::time::timeout(Duration::from_secs(6), shutdown)
+        tokio::time::timeout(TEST_BACKSTOP, shutdown)
             .await
-            .expect("submitted append was not continued within the shutdown bound")
+            .expect("shutdown never returned")
             .unwrap();
 
         assert_eq!(store.test_append_calls(), 1);
@@ -1533,7 +1564,7 @@ mod tests {
                 store.test_pause_after_send(Flush);
             }
             manager.sender().try_send(event(Category::Bfd, 3)).unwrap();
-            tokio::time::timeout(Duration::from_secs(1), committed.recv())
+            tokio::time::timeout(TEST_BACKSTOP, committed.recv())
                 .await
                 .expect("committed event backstop elapsed")
                 .unwrap();


### PR DESCRIPTION
`crates/event-history/src/lib.rs`'s `shutdown_drains_every_accepted_event_with_live_sender`
wrapped `manager.shutdown()` in a one-second wall-clock `tokio::time::timeout`
to drain 13 events. The bound guarded a real property — a finite accepted
queue must drain on channel closure, not wait out the shared shutdown
deadline — but expressing that property as elapsed time made it
load-sensitive by construction. On a loaded box a correct drain
legitimately exceeds one second and the test reds with nothing wrong. It
sits on the required `cargo test --workspace` path, so it lands as a random
red on unrelated changes. Instance #2 of LAN-941.

## Approach taken

Keep the property, drop the stopwatch.

`ShutdownProgress` gains a test-only `deadline_expiries` counter,
incremented at both places shutdown can fall back to the shared deadline:

* the actor's drain loop timing out on `rx.recv` in `run_actor`;
* `EventHistoryManager::shutdown` timing out on the actor and aborting it.

Both timers are armed on the same deadline instant, so a broken drain can
surface at either one; counting both makes the assertion insensitive to
which arm wins. The test then asserts the count is zero.

This is strictly a different question from the old one. Before: *did the
drain finish inside one second?* Now: *did the drain ever fall back to the
deadline?* A slow-but-correct drain passes at any duration, and a drain
that ends on the deadline reds no matter how long it took.

The other `tokio::time::timeout` calls in the module (`wait_for_store`, the
loss-generation wait, the continued-append shutdown, the committed-event
wait) do share the wall-clock shape, but not the load-bearing role — every
assertion they guard is on observed state, and they only exist so a broken
path fails instead of hanging. They are hoisted to one generous
`TEST_BACKSTOP`, documented as a hang preventer, so the module carries no
wall-clock bound a loaded box can trip. The 6s bound in
`shutdown_continues_the_same_append_after_store_send` was already looser
than the production deadline it nominally described; its real assertions
are `test_append_calls() == 1` and `latest_event_id() == 1`, which are
untouched.

## Why virtual time was rejected

Tried first, as the preferred option, and probed before committing to it.

tokio inhibits clock auto-advance while a blocking task is live
(`tokio-1.50.0/src/runtime/blocking/schedule.rs:25`), and the SQLite store
is a single long-lived `spawn_blocking` task alive for the whole test. The
clock therefore stays frozen for the entire test unless explicitly
advanced. That cuts both ways:

* correct path under `#[tokio::test(start_paused = true)]`: passes, drain
  completes in zero virtual time — probed green;
* receiver-close break under the same attribute: the drain has nothing left
  to end it but a 5s timer that can never fire, so the test **hangs** rather
  than failing. Probed: `timeout 75 cargo test -p rustbgpd-event-history
  --lib shutdown_drains` exited **124**, with libtest printing `has been
  running for over 60 seconds`.

Trading a flake for an indefinite CI hang is worse than the flake. The
inhibition is exactly what makes the correct path deterministic and exactly
what makes the break undetectable, so it cannot be tuned around.

Raising 1s to a larger constant was not considered acceptable: it trades a
frequent flake for a rare one and weakens the backstop it claims to be.

## Red proofs

Both load-bearing breaks the original comment records still red.

**1. Restore the `batch_size * 2` drain cap** — capping the shutdown drain
at `config.batch_size * 2` received events:

```
RED1_EXIT:101
crates/event-history/src/lib.rs:1435 assertion `left == right` failed
  left: 8
 right: 13
```

Exactly five of thirteen events lost, as documented.

**2. Omit the receiver close** — commenting out `rx.close()` in
`begin_actor_shutdown`:

```
RED2_RUN1_EXIT:101  RED2_RUN2_EXIT:101  RED2_RUN3_EXIT:101
RED2_RUN4_EXIT:101  RED2_RUN5_EXIT:101

crates/event-history/src/lib.rs:1429 assertion `left == right` failed:
a finite accepted queue must drain on channel closure, not on the shutdown deadline
  left: 1
 right: 0
```

Five consecutive runs, all red. Worth recording that an earlier revision of
this fix instrumented only the actor's drain arm and that break **passed**:
the manager's abort won the deadline race, so the actor never reached its
own timeout arm. Covering both arms is what makes this proof stable.

## Gates

```
cargo fmt --all -- --check                                    exit 0
cargo clippy --workspace --all-targets -- -D warnings         exit 0
python3 scripts/check-clippy-reasons.py                       exit 0
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps     exit 0
cargo test --workspace --no-fail-fast                         exit 0
```

12 runs of `cargo test --workspace --lib` under 64-way CPU load: **12/12
exit 0**, with `shutdown_drains_every_accepted_event_with_live_sender`
green in every run.

A first `cargo test --workspace` run did red on
`rustbgpd-rib manager::tests::rpki::aspa_cache_update_emits_one_bounded_completion_event`
(`left: 0, right: 1`) — that is LAN-941 instance #1, unrelated to this
change and owned elsewhere. It passed on rerun and in all 12 loop runs.

## Relationship to LAN-824

LAN-824 (linearizable EHM shutdown fallback loss accounting) touches the
same shutdown path and is held pending a weak-memory review of its frozen
candidate. This change does not touch loss accounting, admission, gauges,
or memory ordering of any production counter: the two additions are
`#[cfg(test)]` fields and increments on `ShutdownProgress`, mirroring the
existing `#[cfg(test)] loss_latches`. It neither pre-empts nor constrains
that design; at worst it is an additive rebase alongside it.

Refs LAN-941.
