### PR TITLE
Hold ephemeral test ports instead of rebinding them

### DIFF
--- a/bench/scale/irrreload/bmp-loc-rib-sink.py
+++ b/bench/scale/irrreload/bmp-loc-rib-sink.py
@@ -55,8 +55,11 @@ def parse_listen(value: str) -> tuple[str, int]:
         parsed_port = int(port)
     except ValueError as error:
         raise argparse.ArgumentTypeError("listen port must be numeric") from error
-    if not 1 <= parsed_port <= 65535:
-        raise argparse.ArgumentTypeError("listen port must be in 1..65535")
+    # Port 0 lets the sink pick its own port and report it in the
+    # "listening" marker, so a caller never has to reserve one by binding
+    # and releasing it — that reserves nothing and loses races.
+    if not 0 <= parsed_port <= 65535:
+        raise argparse.ArgumentTypeError("listen port must be in 0..65535")
     return host, parsed_port
 
 
@@ -478,7 +481,8 @@ def run_sink(args: argparse.Namespace) -> int:
             server.bind(args.listen)
             server.listen(1)
             server.settimeout(1)
-            atomic_text(output / "listening", "ready\n")
+            bound_host, bound_port = server.getsockname()[:2]
+            atomic_text(output / "listening", f"{bound_host}:{bound_port}\n")
             while True:
                 if time.monotonic() >= deadline:
                     raise ReceiptError("timed out waiting for sole BMP connection")
@@ -715,12 +719,12 @@ def self_test() -> int:
             finally:
                 receiver.close()
                 sender.close()
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as reservation:
-                reservation.bind(("127.0.0.1", 0))
-                port = reservation.getsockname()[1]
+            # Let the sink bind its own port and report it: binding
+            # 127.0.0.1:0 here and closing it reserves nothing, so a
+            # parallel binder can take the port before the sink starts.
             command = [
                 sys.executable, str(pathlib.Path(__file__).resolve()),
-                "--listen", f"127.0.0.1:{port}", "--output-dir", str(output),
+                "--listen", "127.0.0.1:0", "--output-dir", str(output),
                 "--start-file", str(start_file), "--stop-file", str(stop_file),
                 "--total-prefixes", "2", "--timeout", "5",
             ]
@@ -743,7 +747,8 @@ def self_test() -> int:
 
             try:
                 wait_for_sink(output / "listening")
-                client = socket.create_connection(("127.0.0.1", port), timeout=1)
+                host, _, port = (output / "listening").read_text().strip().rpartition(":")
+                client = socket.create_connection((host, int(port)), timeout=1)
                 start_file.write_text("start\n")
                 frames = [init, sample_peer_up(peer_type=0), sample_peer_up(), sample_per_peer(1)]
                 frames.append(sample_rm(sample_update(announced="20.0.0.0/24")))

--- a/crates/api/src/gnmi_dialout.rs
+++ b/crates/api/src/gnmi_dialout.rs
@@ -478,7 +478,7 @@ mod tests {
     use std::pin::Pin;
     use std::time::Duration;
 
-    use tokio::net::TcpListener;
+    use tokio::net::{TcpListener, TcpSocket};
     use tokio::sync::mpsc;
     use tokio_stream::{Stream, wrappers::TcpListenerStream};
     use tonic::{Request, Response, Status, Streaming};
@@ -666,19 +666,39 @@ mod tests {
         }
     }
 
-    /// Bind (or rebind) a stub collector on `addr` (`None` = ephemeral) and
-    /// return its address, the serve task handle, and the received-message
-    /// channel.
-    async fn spawn_stub_collector(
-        addr: Option<SocketAddr>,
+    /// Hold a loopback port for the lifetime of the test without serving on
+    /// it: bind a socket and never `listen` on it.
+    ///
+    /// Binding `127.0.0.1:0` and dropping the listener to "reserve" the
+    /// address reserves nothing — the kernel hands that exact port to the
+    /// next binder, and under parallel test execution a rebind of it then
+    /// fails `EADDRINUSE` (LAN-941). A bound socket does hold the port, and
+    /// while it is not listening the address still refuses connections,
+    /// which is the "collector down" condition these tests need.
+    ///
+    /// `spawn_stub_collector` serves by calling `listen` on this same
+    /// socket, so no address is ever bound a second time. Passing `Some`
+    /// takes a second reservation of an already-reserved port (hence
+    /// `SO_REUSEPORT`), which keeps it held across a collector restart.
+    fn reserve_port(addr: Option<SocketAddr>) -> (TcpSocket, SocketAddr) {
+        let socket = TcpSocket::new_v4().expect("reservation socket");
+        socket.set_reuseport(true).expect("set SO_REUSEPORT");
+        socket
+            .bind(addr.unwrap_or_else(|| "127.0.0.1:0".parse().expect("valid addr")))
+            .expect("bind reservation");
+        let addr = socket.local_addr().expect("reservation addr");
+        (socket, addr)
+    }
+
+    /// Serve a stub collector on a port reserved by [`reserve_port`], and
+    /// return the serve task handle plus the received-message channel.
+    fn spawn_stub_collector(
+        reservation: TcpSocket,
     ) -> (
-        SocketAddr,
         tokio::task::JoinHandle<()>,
         mpsc::Receiver<gnmi::SubscribeResponse>,
     ) {
-        let bind = addr.unwrap_or_else(|| "127.0.0.1:0".parse().expect("valid addr"));
-        let listener = TcpListener::bind(bind).await.expect("bind stub collector");
-        let addr = listener.local_addr().expect("local addr");
+        let listener = reservation.listen(1024).expect("serve stub collector");
         let (tx, rx) = mpsc::channel(64);
         let handle = tokio::spawn(async move {
             let _ = tonic::transport::Server::builder()
@@ -686,7 +706,7 @@ mod tests {
                 .serve_with_incoming(TcpListenerStream::new(listener))
                 .await;
         });
-        (addr, handle, rx)
+        (handle, rx)
     }
 
     fn test_service() -> GnmiService {
@@ -822,7 +842,11 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn dial_out_streams_updates_and_reconnects_after_collector_restart() {
         let metrics = BgpMetrics::new();
-        let (addr, server, mut received) = spawn_stub_collector(None).await;
+        let (first, addr) = reserve_port(None);
+        // Second reservation of the same port: it stays held while the
+        // collector is down, so the restart below never rebinds.
+        let (restart, _) = reserve_port(Some(addr));
+        let (server, mut received) = spawn_stub_collector(first);
         let mut manager = DialoutManager::new(test_service(), metrics.clone());
         manager.apply(&[test_target("collector-a", addr)]);
 
@@ -831,14 +855,18 @@ mod tests {
         wait_for_gauge(&metrics, "collector-a", 1).await;
 
         // Kill the collector (stop accepting, then end the live stream):
-        // the gauge must drop (disconnect transition).
+        // the gauge must drop (disconnect transition). Await the aborted
+        // task so its listener is really closed before the restart takes
+        // the port over — both sockets are in the same `SO_REUSEPORT`
+        // group, and a listening corpse would keep drawing connections.
         server.abort();
+        let _ = server.await;
         drop(received);
         wait_for_gauge(&metrics, "collector-a", 0).await;
 
         // Restart the collector on the same address: the client reconnects
         // by itself and streams a fresh initial snapshot.
-        let (_addr, server2, mut received2) = spawn_stub_collector(Some(addr)).await;
+        let (server2, mut received2) = spawn_stub_collector(restart);
         expect_update_with_as(&mut received2).await;
         wait_for_gauge(&metrics, "collector-a", 1).await;
 
@@ -927,7 +955,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn manager_reaps_gauge_series_on_target_removal() {
         let metrics = BgpMetrics::new();
-        let (addr, server, mut received) = spawn_stub_collector(None).await;
+        let (reservation, addr) = reserve_port(None);
+        let (server, mut received) = spawn_stub_collector(reservation);
         let mut manager = DialoutManager::new(test_service(), metrics.clone());
         manager.apply(&[test_target("collector-reap", addr)]);
         expect_update_with_as(&mut received).await;
@@ -943,10 +972,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn collector_down_at_startup_keeps_retrying_without_task_exit() {
         let metrics = BgpMetrics::new();
-        // Reserve an address with nothing listening on it.
-        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
-        let addr = listener.local_addr().expect("addr");
-        drop(listener);
+        // An address held by a bound socket that never listens: nothing
+        // serves it, so connections are refused, and nothing else can take
+        // the port before the collector comes up on it below.
+        let (reservation, addr) = reserve_port(None);
 
         let mut manager = DialoutManager::new(test_service(), metrics.clone());
         manager.apply(&[test_target("collector-late", addr)]);
@@ -957,7 +986,7 @@ mod tests {
         assert_eq!(gauge_value(&metrics, "collector-late"), Some(0));
 
         // The collector comes up later; the retry loop finds it.
-        let (_addr, server, mut received) = spawn_stub_collector(Some(addr)).await;
+        let (server, mut received) = spawn_stub_collector(reservation);
         expect_update_with_as(&mut received).await;
         wait_for_gauge(&metrics, "collector-late", 1).await;
         server.abort();

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -3293,7 +3293,11 @@ paths = ["x"]
 
     #[test]
     fn listener_test_bind_maps_bind_errors_to_advice() {
-        // Free port: bindable.
+        // Free port: bindable. The port has to be genuinely released —
+        // `listener_bind_check` is itself the binder, so holding it would
+        // test the opposite branch. That leaves the one window this file
+        // cannot close (LAN-941): the two statements between the release
+        // and the check, with no await or sleep between them.
         let free = {
             let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
             l.local_addr().unwrap().port()

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -4267,6 +4267,11 @@ mod tests {
     /// so a connection it accepted on the listen port lingers in
     /// `FIN_WAIT`/`TIME_WAIT` while the next generation binds. Without
     /// `SO_REUSEADDR` on both generations that bind fails `EADDRINUSE`.
+    ///
+    /// Rebinding the released address is the behaviour under test, so the
+    /// port cannot be held across the gap the way the reserve-then-serve
+    /// tests elsewhere hold theirs (LAN-941); the exposure is the three
+    /// synchronous drops below, with no await or sleep between them.
     #[tokio::test]
     async fn bind_socket2_listener_rebinds_over_a_lingering_accepted_connection() {
         let options = ListenerSocketOptions::default();

--- a/crates/transport/tests/session_lifecycle.rs
+++ b/crates/transport/tests/session_lifecycle.rs
@@ -16,7 +16,7 @@ use rustbgpd_wire::{
     encode_message, notification::NotificationCode, peek_message_length,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpListener;
+use tokio::net::{TcpListener, TcpSocket};
 use tokio::sync::mpsc;
 
 /// Local ASN for tests.
@@ -544,10 +544,14 @@ async fn stop_command_sends_cease() {
 
 #[tokio::test]
 async fn connect_failure_retries() {
-    // Learn an ephemeral port, then release it so the first connection attempt fails.
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
+    // Hold an ephemeral port with a socket that never listens: the first
+    // connection attempt is refused, and no parallel test's `:0` bind can
+    // be handed the port before the retry listener takes it over below.
+    // (Learning a port by binding `:0` and dropping the listener reserves
+    // nothing — the rebind then fails `EADDRINUSE`; see LAN-941.)
+    let reservation = TcpSocket::new_v4().unwrap();
+    reservation.bind("127.0.0.1:0".parse().unwrap()).unwrap();
+    let addr = reservation.local_addr().unwrap();
 
     let metrics = BgpMetrics::new();
     let mut config = transport_config(addr);
@@ -583,8 +587,8 @@ async fn connect_failure_retries() {
     }
 
     // Load-bearing: without InitiateTcpConnection on Active's retry-timer
-    // transition, this second accept times out instead of receiving an OPEN.
-    let listener = TcpListener::bind(addr).await.unwrap();
+    // transition, this accept times out instead of receiving an OPEN.
+    let listener = reservation.listen(1024).unwrap();
     let (mut peer_stream, _) = tokio::time::timeout(Duration::from_millis(1500), listener.accept())
         .await
         .expect("Active retry should connect within 1.5s")

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -228,8 +228,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/routes/noexport/{id}", get(routes_noexport))
         .with_state(state);
 
-    info!(addr = %args.listen, "starting Birdwatcher-shaped looking glass subset");
     let listener = tokio::net::TcpListener::bind(args.listen).await?;
+    // Log the address actually bound rather than the one requested: with a
+    // `:0` port the two differ, and only the bound one is reachable.
+    let addr = listener.local_addr().unwrap_or(args.listen);
+    info!(%addr, "starting Birdwatcher-shaped looking glass subset");
     axum::serve(listener, app).await?;
     Ok(())
 }

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -27,7 +27,7 @@
 //! noexport-reason community).
 
 use std::io::{Read, Write};
-use std::net::{TcpListener, TcpStream};
+use std::net::TcpStream;
 use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -56,13 +56,55 @@ impl Drop for Proc {
     }
 }
 
-/// Grab a free localhost port. Racy in principle, fine for a test.
-fn free_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("bind 127.0.0.1:0")
-        .local_addr()
-        .unwrap()
-        .port()
+/// Port the spawned process is asked for when it should choose its own.
+///
+/// This test never picks a port itself. Discovering one by binding
+/// `127.0.0.1:0` and dropping the listener reserves nothing — the kernel
+/// can hand that exact port to a parallel test before the spawned process
+/// binds it, and the spawn then dies with `AddrInUse` (LAN-941, reproduced
+/// here as `birdwatcher-adapter exited before serving /status`). Asking
+/// for port 0 makes the process that serves the port the one that binds
+/// it; it reports the address it got and the test reads it back.
+const PROCESS_CHOOSES: u16 = 0;
+
+/// Poll `log` until `extract` finds what the process reported, failing
+/// fast if the process dies first.
+fn wait_for_logged<T>(
+    proc_: &mut Proc,
+    log: &Path,
+    what: &str,
+    extract: impl Fn(&str) -> Option<T>,
+) -> T {
+    let deadline = Instant::now() + Duration::from_secs(120);
+    while Instant::now() < deadline {
+        let logged = std::fs::read_to_string(log).unwrap_or_default();
+        if let Some(value) = extract(&logged) {
+            return value;
+        }
+        if let Ok(Some(status)) = proc_.child.try_wait() {
+            panic!(
+                "{} exited before reporting {what}: {status}\nstderr:\n{}",
+                proc_.name,
+                proc_.stderr()
+            );
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!(
+        "{} did not report {what} within timeout\nstderr:\n{}",
+        proc_.name,
+        proc_.stderr()
+    );
+}
+
+/// Port from the first `"<field>":"<addr>:<port>"` pair in the daemon's
+/// JSON log whose address starts with `prefix`.
+fn logged_port(logs: &str, field: &str, prefix: &str) -> Option<u16> {
+    logs.split(&format!("\"{field}\":\""))
+        .skip(1)
+        .filter_map(|rest| rest.split('"').next())
+        .find(|addr| addr.starts_with(prefix))
+        .and_then(|addr| addr.rsplit(':').next()?.parse().ok())
 }
 
 /// Minimal HTTP/1.1 GET over a raw TcpStream — avoids an HTTP client
@@ -122,17 +164,18 @@ fn wait_for_http(port: u16, path: &str, proc_: &mut Proc) {
 }
 
 /// Wait until `port` accepts a TCP connection (daemon gRPC readiness).
-/// `Err` carries the exit status when the process died before listening
-/// (the caller may retry — see `spawn_daemon_listening`); a still-running
-/// process that never listens within the timeout panics.
-fn wait_for_tcp(port: u16, proc_: &mut Proc) -> Result<(), std::process::ExitStatus> {
+fn wait_for_tcp(port: u16, proc_: &mut Proc) {
     let deadline = Instant::now() + Duration::from_secs(120);
     while Instant::now() < deadline {
         if TcpStream::connect(("127.0.0.1", port)).is_ok() {
-            return Ok(());
+            return;
         }
         if let Ok(Some(status)) = proc_.child.try_wait() {
-            return Err(status);
+            panic!(
+                "{} exited before listening on {port}: {status}\nstderr:\n{}",
+                proc_.name,
+                proc_.stderr()
+            );
         }
         thread::sleep(Duration::from_millis(100));
     }
@@ -143,51 +186,54 @@ fn wait_for_tcp(port: u16, proc_: &mut Proc) -> Result<(), std::process::ExitSta
     );
 }
 
-/// Spawn the daemon and wait for its gRPC TCP listener. `free_port()` is
-/// bind-then-release, so a parallel workspace test can steal the port
-/// before the daemon binds it; the daemon treats the lost gRPC bind as a
-/// component failure and exits non-zero. Retry the whole spawn with
-/// fresh ports (bounded) instead of failing the test on that race.
-/// Returns the daemon plus the TCP gRPC and BGP ports the rest of the test
-/// needs; the adapter still talks to `grpc_socket`.
+/// Spawn the daemon on ports it chooses itself and wait for its gRPC TCP
+/// listener. Returns the daemon plus the TCP gRPC and IPv4 BGP ports it
+/// reports binding, which the rest of the test needs; the adapter still
+/// talks to `grpc_socket`.
 fn spawn_daemon_listening(dir: &Path, grpc_socket: &Path, token_path: &Path) -> (Proc, u16, u16) {
-    const ATTEMPTS: u32 = 3;
-    for attempt in 1..=ATTEMPTS {
-        let grpc_port = free_port();
-        let bgp_port = free_port();
-        if grpc_socket.exists() {
-            std::fs::remove_file(grpc_socket).expect("remove stale test gRPC socket");
-        }
-        let config_path = write_config(dir, grpc_port, bgp_port, grpc_socket, token_path);
-        let daemon_stdout = dir.join("rustbgpd.stdout.log");
-        let daemon_stderr = dir.join("rustbgpd.stderr.log");
-        let mut daemon = Proc {
-            child: Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
-                .arg(&config_path)
-                .stdout(Stdio::from(
-                    std::fs::File::create(&daemon_stdout).expect("daemon stdout log"),
-                ))
-                .stderr(Stdio::from(
-                    std::fs::File::create(&daemon_stderr).expect("daemon stderr log"),
-                ))
-                .spawn()
-                .expect("spawn rustbgpd"),
-            name: "rustbgpd",
-            stderr_path: daemon_stderr,
-        };
-        match wait_for_tcp(grpc_port, &mut daemon) {
-            Ok(()) => return (daemon, grpc_port, bgp_port),
-            Err(status) if attempt < ATTEMPTS => eprintln!(
-                "rustbgpd exited before listening on {grpc_port} (attempt {attempt}): \
-                 {status}; retrying with fresh ports"
-            ),
-            Err(status) => panic!(
-                "rustbgpd exited before listening on {grpc_port}: {status}\nstderr:\n{}",
-                daemon.stderr()
-            ),
-        }
+    if grpc_socket.exists() {
+        std::fs::remove_file(grpc_socket).expect("remove stale test gRPC socket");
     }
-    unreachable!("spawn retry loop returns or panics");
+    let config_path = write_config(
+        dir,
+        PROCESS_CHOOSES,
+        PROCESS_CHOOSES,
+        grpc_socket,
+        token_path,
+    );
+    let daemon_stdout = dir.join("rustbgpd.stdout.log");
+    let daemon_stderr = dir.join("rustbgpd.stderr.log");
+    let mut daemon = Proc {
+        child: Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
+            .arg(&config_path)
+            .stdout(Stdio::from(
+                std::fs::File::create(&daemon_stdout).expect("daemon stdout log"),
+            ))
+            .stderr(Stdio::from(
+                std::fs::File::create(&daemon_stderr).expect("daemon stderr log"),
+            ))
+            .spawn()
+            .expect("spawn rustbgpd"),
+        name: "rustbgpd",
+        stderr_path: daemon_stderr,
+    };
+    // The daemon logs JSON to stdout: `bound_addr` on the gRPC TCP
+    // listener, and `addr` on each bound BGP listener family (the test
+    // speaks IPv4, so take the `0.0.0.0` one).
+    let grpc_port = wait_for_logged(
+        &mut daemon,
+        &daemon_stdout,
+        "a bound gRPC listener",
+        |logs| logged_port(logs, "bound_addr", "127.0.0.1:"),
+    );
+    let bgp_port = wait_for_logged(
+        &mut daemon,
+        &daemon_stdout,
+        "a bound IPv4 BGP listener",
+        |logs| logged_port(logs, "addr", "0.0.0.0:"),
+    );
+    wait_for_tcp(grpc_port, &mut daemon);
+    (daemon, grpc_port, bgp_port)
 }
 
 /// Mutation proof: dropping Tier enforcement, the bearer credential, or the
@@ -457,7 +503,6 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
     let temp = tempfile::tempdir().expect("create temp dir");
     std::fs::set_permissions(temp.path(), std::fs::Permissions::from_mode(0o700))
         .expect("make temp dir private");
-    let adapter_port = free_port();
     let grpc_socket = temp.path().join("rustbgpd.grpc.sock");
     let token_path = temp.path().join("grpc-token");
     std::fs::write(&token_path, "birdwatcher-smoke-token\n").expect("write test token");
@@ -475,7 +520,7 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
             .arg("--grpc-token-file")
             .arg(&token_path)
             .arg("--listen")
-            .arg(format!("127.0.0.1:{adapter_port}"))
+            .arg(format!("127.0.0.1:{PROCESS_CHOOSES}"))
             .stdout(Stdio::null())
             .stderr(Stdio::from(
                 std::fs::File::create(&adapter_stderr).expect("adapter stderr log"),
@@ -483,9 +528,26 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
             .spawn()
             .expect("spawn birdwatcher-adapter"),
         name: "birdwatcher-adapter",
-        stderr_path: adapter_stderr,
+        stderr_path: adapter_stderr.clone(),
     };
     let adapter_pid = adapter.child.id();
+    // The adapter logs the address it bound. Its only loopback address is
+    // that listener (the daemon endpoint is a Unix socket), and the text
+    // format interleaves ANSI escapes with the field name, so match on the
+    // address itself rather than on `addr=`.
+    let adapter_port = wait_for_logged(
+        &mut adapter,
+        &adapter_stderr,
+        "a bound HTTP listener",
+        |logs| {
+            logs.split("127.0.0.1:")
+                .nth(1)?
+                .split(|c: char| !c.is_ascii_digit())
+                .next()?
+                .parse()
+                .ok()
+        },
+    );
     wait_for_http_status(adapter_port, "/status", 502, &mut adapter);
 
     // Now start the daemon. The adapter's lazy UDS channel must reconnect on

--- a/tests/grpc_failure_exit_code.rs
+++ b/tests/grpc_failure_exit_code.rs
@@ -130,13 +130,38 @@ fn spawn_daemon(dir: &Path, config_path: &Path) -> Daemon {
     }
 }
 
-/// Grab a free localhost port. Racy in principle, fine for a test.
-fn free_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("bind 127.0.0.1:0")
-        .local_addr()
-        .unwrap()
-        .port()
+/// Port the config asks for when the test does not care about the value.
+///
+/// Picking one by binding `127.0.0.1:0` and dropping the listener reserves
+/// nothing: the kernel can hand that exact port to a parallel test before
+/// the daemon binds it, and this suite would read the resulting `AddrInUse`
+/// as the bind failure it is asserting on (LAN-941). Port 0 lets the
+/// process that serves the port be the one that binds it.
+const DAEMON_CHOOSES: u16 = 0;
+
+/// The gRPC TCP port the daemon reports it actually bound, for tests that
+/// have to talk to it. Only the gRPC TCP listener logs `bound_addr`.
+fn wait_for_bound_grpc_port(daemon: &mut Daemon) -> u16 {
+    let deadline = Instant::now() + Duration::from_secs(120);
+    while Instant::now() < deadline {
+        let logs = daemon.logs();
+        if let Some(port) = logs
+            .split("\"bound_addr\":\"")
+            .nth(1)
+            .and_then(|rest| rest.split('"').next())
+            .and_then(|addr| addr.rsplit(':').next()?.parse().ok())
+        {
+            return port;
+        }
+        if let Ok(Some(status)) = daemon.child.try_wait() {
+            panic!("rustbgpd exited before binding its gRPC listener: {status}\n{logs}");
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!(
+        "rustbgpd never logged a bound gRPC listener\n{}",
+        daemon.logs()
+    );
 }
 
 #[test]
@@ -147,7 +172,7 @@ fn grpc_bind_failure_exits_nonzero() {
     // daemon down with a non-zero exit code.
     let occupied = TcpListener::bind("127.0.0.1:0").expect("bind occupied port");
     let grpc_port = occupied.local_addr().unwrap().port();
-    let config_path = write_config(temp.path(), grpc_port, free_port());
+    let config_path = write_config(temp.path(), grpc_port, DAEMON_CHOOSES);
 
     let mut daemon = spawn_daemon(temp.path(), &config_path);
     let status = daemon.wait_within(Duration::from_secs(120));
@@ -164,8 +189,12 @@ fn metrics_listener_bind_failure_exits_nonzero() {
     let temp = private_tempdir();
     let occupied = TcpListener::bind("127.0.0.1:0").expect("bind occupied metrics port");
     let metrics_port = occupied.local_addr().unwrap().port();
-    let config_path =
-        write_config_with_metrics(temp.path(), free_port(), free_port(), Some(metrics_port));
+    let config_path = write_config_with_metrics(
+        temp.path(),
+        DAEMON_CHOOSES,
+        DAEMON_CHOOSES,
+        Some(metrics_port),
+    );
 
     let mut daemon = spawn_daemon(temp.path(), &config_path);
     let status = daemon.wait_within(Duration::from_secs(30));
@@ -214,7 +243,7 @@ fn bgp_listener_bind_failure_exits_nonzero() {
             }
         }
     };
-    let config_path = write_config(temp.path(), free_port(), bgp_port);
+    let config_path = write_config(temp.path(), DAEMON_CHOOSES, bgp_port);
 
     let mut daemon = spawn_daemon(temp.path(), &config_path);
     let status = daemon.wait_within(Duration::from_secs(120));
@@ -238,13 +267,13 @@ fn bgp_listener_single_family_bind_failure_degrades_and_serves() {
     // other, then still shuts down cleanly on SIGTERM.
     let occupied = TcpListener::bind("0.0.0.0:0").expect("bind occupied v4 port");
     let bgp_port = occupied.local_addr().unwrap().port();
-    let grpc_port = free_port();
-    let config_path = write_config(temp.path(), grpc_port, bgp_port);
+    let config_path = write_config(temp.path(), DAEMON_CHOOSES, bgp_port);
 
     let mut daemon = spawn_daemon(temp.path(), &config_path);
 
     // Startup completed: the gRPC listener answers while the v4 BGP bind
     // failed, proving the daemon degraded instead of exiting.
+    let grpc_port = wait_for_bound_grpc_port(&mut daemon);
     let deadline = Instant::now() + Duration::from_secs(120);
     loop {
         if TcpStream::connect(("127.0.0.1", grpc_port)).is_ok() {
@@ -290,45 +319,31 @@ fn bgp_listener_single_family_bind_failure_degrades_and_serves() {
 fn sigterm_exits_zero() {
     let temp = private_tempdir();
 
-    // `free_port()` is bind-then-release, so a parallel workspace test can
-    // steal the port before the daemon binds it; the daemon then exits
-    // non-zero (the very contract under test). Retry with fresh ports.
-    let mut daemon = 'spawned: {
-        for attempt in 1..=3 {
-            let grpc_port = free_port();
-            let config_path = write_config(temp.path(), grpc_port, free_port());
-            let mut daemon = spawn_daemon(temp.path(), &config_path);
+    let config_path = write_config(temp.path(), DAEMON_CHOOSES, DAEMON_CHOOSES);
+    let mut daemon = spawn_daemon(temp.path(), &config_path);
 
-            // Wait until the gRPC listener is up so SIGTERM lands on a
-            // fully started daemon.
-            let deadline = Instant::now() + Duration::from_secs(120);
-            loop {
-                if TcpStream::connect(("127.0.0.1", grpc_port)).is_ok() {
-                    break 'spawned daemon;
-                }
-                if let Ok(Some(status)) = daemon.child.try_wait() {
-                    if attempt < 3 {
-                        eprintln!(
-                            "rustbgpd exited before listening on {grpc_port} \
-                             (attempt {attempt}): {status}; retrying with fresh ports"
-                        );
-                        break;
-                    }
-                    panic!(
-                        "rustbgpd exited before listening on {grpc_port}: {status}\n{}",
-                        daemon.logs()
-                    );
-                }
-                assert!(
-                    Instant::now() < deadline,
-                    "rustbgpd did not listen on {grpc_port} within timeout\n{}",
-                    daemon.logs()
-                );
-                thread::sleep(Duration::from_millis(100));
-            }
+    // Wait until the gRPC listener is up so SIGTERM lands on a fully
+    // started daemon. No spawn retry: the daemon picks its own ports, so a
+    // bind failure here is a real one rather than a lost port race.
+    let grpc_port = wait_for_bound_grpc_port(&mut daemon);
+    let deadline = Instant::now() + Duration::from_secs(120);
+    loop {
+        if TcpStream::connect(("127.0.0.1", grpc_port)).is_ok() {
+            break;
         }
-        unreachable!("spawn retry loop either breaks 'spawned or panics");
-    };
+        if let Ok(Some(status)) = daemon.child.try_wait() {
+            panic!(
+                "rustbgpd exited before listening on {grpc_port}: {status}\n{}",
+                daemon.logs()
+            );
+        }
+        assert!(
+            Instant::now() < deadline,
+            "rustbgpd did not listen on {grpc_port} within timeout\n{}",
+            daemon.logs()
+        );
+        thread::sleep(Duration::from_millis(100));
+    }
 
     let sigterm = Command::new("kill")
         .args(["-TERM", &daemon.child.id().to_string()])


### PR DESCRIPTION
Refs LAN-941 (instance #3, plus the second site found in the sweep).

Several tests learned a free port by binding `127.0.0.1:0`, dropped the
listener, and later had something bind that same port. Releasing a port
reserves nothing — the kernel is free to hand it to any concurrent binder —
so the second bind can fail `EADDRINUSE` and red `cargo test --workspace`
on an unrelated change.

## Reproduction

The natural rate is low, so the mechanism was reproduced under a controlled
competitor: a process that holds all but ~200 of the ephemeral range
(`32768-60999` here) and keeps re-grabbing whatever is released, which is the
same competition a loaded workspace run creates, at a rate that makes it
deterministic.

| condition | `collector_down_at_startup_keeps_retrying_without_task_exit` |
| --- | --- |
| unloaded, 12 runs of the api lib suite | 0 failures |
| 8 processes churning `127.0.0.1:0` binds (~93k binds/s each), 12 runs | 0 failures |
| ephemeral range held down to ~200 free ports, 5 runs | **5 failures** |
| same, after this change, 8 runs | 0 failures |

The failure is exactly the reported one:

```
thread '...collector_down_at_startup_keeps_retrying_without_task_exit'
  panicked at crates/api/src/gnmi_dialout.rs:680:54:
bind stub collector: Os { code: 98, kind: AddrInUse, message: "Address already in use" }
```

Note which competitor reproduces it: bind churn alone does not, because a
stealer must bind the port *during* the window **and** still hold it at the
rebind. That is the profile of a workspace run full of tests that open
listeners and keep them, not of a tight bind/close loop.

## The approach

One rule, applied everywhere: **whatever serves the port is what binds it,
and the port is held by a live socket from the moment it is chosen.**

*In-process* — a bound-but-not-listening `TcpSocket` holds the address while
still refusing connections, which is exactly the "nothing is serving it"
condition these tests need. The server comes up by calling `listen` on that
same socket, so no address is ever bound twice. Residual window: none, no
second bind exists.

*Across a process boundary* — nothing can hold a port for a child that binds
it plainly, so the child is asked for port 0 and reports the address it got;
the test reads it back. The daemon already logs `bound_addr` and already
accepts `listen_port = 0` / `address = "127.0.0.1:0"` (verified against the
built binary), so no daemon change was needed. Residual window: none, the
binder and the server are the same process.

The gnmi dial-out restart test needs the port held while the collector is
*down*, which means two live sockets on one port, so the reservations set
`SO_REUSEPORT`. Verified before adopting it: 5000
`:0` binds with `SO_REUSEPORT` returned 5000 distinct ports (it does not make
ephemeral allocation collide), a non-listening reservation still gets
connections refused, a plain bind cannot steal it, and while one socket in
the group listens the other never draws connections. That test also awaits
the aborted serve task, so the old listener cannot sit in the group holding
connections after the restart.

## Sites

Fixed (were the bad shape):

- `crates/api/src/gnmi_dialout.rs` — `collector_down_at_startup_...` (the
  reported failure) and `dial_out_streams_..._reconnects_after_collector_restart`.
- `crates/transport/tests/session_lifecycle.rs::connect_failure_retries` —
  same shape, ~10 ms window; never reproduced even under maximum pressure,
  fixed structurally.
- `tests/birdwatcher_adapter_smoke.rs` — the adapter port and the daemon's
  gRPC/BGP ports. The bounded spawn retry that worked around the lost race is
  gone with it.
- `tests/grpc_failure_exit_code.rs` — every `free_port()` use. Ports the test
  does not care about are now `0`; the one it talks to is read back from the
  daemon's log. Its spawn retry loop is gone too.
- `bench/scale/irrreload/bmp-loc-rib-sink.py` — the sink self-test spawned the
  sink on a reserved-then-released port.

Deliberately **not** fixed, commented in place with the residual:

- `crates/cli/src/commands/doctor.rs::listener_test_bind_maps_bind_errors_to_advice`
- `crates/transport/src/listener.rs::bind_socket2_listener_rebinds_over_a_lingering_accepted_connection`

In both, the code under test *is* the binder — holding the port would test the
opposite branch — so the release is required. What is left is a few
synchronous statements with no await or sleep between them.

## Production changes (called out deliberately)

Two non-test files changed, both in the first commit so they can be gated
separately. Neither touches the daemon.

- `examples/birdwatcher-adapter/src/main.rs` — binds before logging and logs
  `local_addr()` instead of the requested address. Operator-visible
  difference: the `starting Birdwatcher-shaped looking glass subset` line now
  reports the port actually bound (identical unless `:0` was requested), and
  `--listen 127.0.0.1:0` becomes usable. Message text unchanged.
- `bench/scale/irrreload/bmp-loc-rib-sink.py` — accepts port 0, and its
  `listening` marker now contains `host:port` instead of `ready`. The only
  other consumer (`run-bmp-buffer-receipt.sh`) waits on that file's existence.

The two comment-only edits in `crates/cli/src/commands/doctor.rs` and
`crates/transport/src/listener.rs` are both inside `#[cfg(test)]` modules — no
shipped behavior changes there.

`sigterm_exits_zero` is not papered over: SIGTERM is still sent only after a
TCP connection to the gRPC listener succeeds, the same readiness bar as
before. The separately filed SIGTERM-registration window is untouched by this
change.

## Red proofs

Each fixed test still fails when the property it guards is broken:

| break | result |
| --- | --- |
| dial-out target task returns after the first failed connect / after a disconnect | `collector_down_at_startup_...`, `dial_out_streams_..._restart` and `subscription_error_reconnects_...` FAIL; the other 7 gnmi tests pass |
| drop `Action::InitiateTcpConnection` from `Active`'s retry transition | `connect_failure_retries` FAILS: `Active retry should connect within 1.5s: Elapsed(())` |
| daemon reports a component failure as a clean stop | `grpc_bind_failure_exits_nonzero` FAILS |
| learned port returned off by one | `sigterm_exits_zero`, `bgp_listener_single_family_bind_failure_degrades_and_serves` and the birdwatcher smoke FAIL — the reported port is load-bearing, the readiness wait is not vacuous |

All reverted afterwards.

## Gates

`cargo fmt --all -- --check` 0 · `cargo clippy --workspace --all-targets -D warnings` 0 ·
`cargo test --workspace` 0 · `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` 0 ·
`scripts/check-clippy-reasons.py` 0 · `bmp-loc-rib-sink.py --self-test` 0 ·
12 consecutive `cargo test --workspace --lib` runs under 32-way CPU load: 12/12 green.
