### PR TITLE
Anchor extraction on code, not comment prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   otherwise authenticated handshake before rustbgpd saw the connection. Live
   GTSM policy additions update the existing listener before any MD5 inventory
   mutation (LAN-935).
+- `.deb`/`.rpm` packages now install a complete `/etc/rustbgpd/config.toml`.
+  The packaging step rewrites the example config's dev-paths comment paragraph
+  by line range, and the range ended on a comment line that 0.64.0 reflowed, so
+  the rewrite ran to end of file and deleted `[global]`, `[policy]`, and
+  `[[neighbors]]`. The 0.64.0 packages shipped a comment-only stub; the range
+  now ends on the paragraph's terminating blank line, and the packaged config
+  body is asserted positively rather than only checked for a leftover dev path.
 
 ## [0.64.0] — 2026-08-08
 

--- a/bench/scale/rebaseline/test_classifiers.py
+++ b/bench/scale/rebaseline/test_classifiers.py
@@ -17,11 +17,38 @@ sys.path.insert(0, str(HERE))
 
 import classify_dhat  # noqa: E402
 
+# The summary block is the one embedded Python the runner invokes outside any
+# shell function, so its own invocation line is the anchor.
+SUMMARY_HEREDOC = "python3 - \"$OUT\" <<'PY'"
+
+
+def runner_script() -> tuple[Path, str]:
+    runner = HERE.parents[2] / "docs" / "perf" / "run-explain-cache-variant.sh"
+    return runner, runner.read_text(encoding="utf-8")
+
+
+def require_anchor(script: str, marker: str, runner: Path) -> None:
+    """Fail with the fix, not a bare ``substring not found``.
+
+    These tests locate embedded Python by the shell code around it. Anchor on
+    a function definition or the ``python3`` invocation line -- never on
+    comment prose, which gets reworded and silently stops matching.
+    """
+    if marker in script:
+        return
+    raise AssertionError(
+        f"anchor {marker!r} no longer appears in {runner}. This test extracts "
+        "embedded Python by the shell code around it; update the anchor to "
+        "match the renamed shell code. Do not re-anchor on comment prose -- "
+        "prose gets reworded and takes the test red with it."
+    )
+
 
 class ClassifierFixtures(unittest.TestCase):
     def runner_embedded_python(self, marker: str) -> str:
-        runner = HERE.parents[2] / "docs" / "perf" / "run-explain-cache-variant.sh"
-        script = runner.read_text(encoding="utf-8")
+        """Extract the ``<<'PY'`` heredoc that follows ``marker`` in the runner."""
+        runner, script = runner_script()
+        require_anchor(script, marker, runner)
         start = script.index(marker)
         body_start = script.index("<<'PY'\n", start) + len("<<'PY'\n")
         body_end = script.index("\nPY\n", body_start)
@@ -278,15 +305,7 @@ class ClassifierFixtures(unittest.TestCase):
         self.assertIn("stripped release profile", result.stderr)
 
     def test_explain_cache_peak_uses_daemon_vmhwm_not_sampled_tree_max(self) -> None:
-        runner = HERE.parents[2] / "docs" / "perf" / "run-explain-cache-variant.sh"
-        marker = (
-            "# Summary: steady = median of post-convergence samples; "
-            "peak = daemon kernel VmHWM.\n"
-        )
-        script = runner.read_text(encoding="utf-8")
-        summary = script.split(marker, 1)[1].split("\nPY\n", 1)[0]
-        self.assertTrue(summary.startswith("python3 - \"$OUT\" <<'PY'\n"))
-        python = summary.split("\n", 1)[1]
+        python = self.runner_embedded_python(SUMMARY_HEREDOC)
 
         with tempfile.TemporaryDirectory() as directory:
             out = Path(directory)
@@ -363,9 +382,7 @@ class ClassifierFixtures(unittest.TestCase):
     def run_settled_metrics_validator(
         self, fixture: str, *, dhat: int = 0
     ) -> subprocess.CompletedProcess[str]:
-        python = self.runner_embedded_python(
-            "# LAN-630 settled-state gates: missing metrics are failures, never zero."
-        )
+        python = self.runner_embedded_python("validate_settled_metrics()")
         with tempfile.TemporaryDirectory() as directory:
             metrics = Path(directory) / "metrics.prom"
             metrics.write_text(fixture, encoding="utf-8")
@@ -492,7 +509,8 @@ class ClassifierFixtures(unittest.TestCase):
         required = gate_start + gate.index(
             '[[ -f "$OUT/dhat-heap.json" && -s "$OUT/dhat-heap.json" ]] || {'
         )
-        summary = script.index("# Summary: steady = median")
+        require_anchor(script, SUMMARY_HEREDOC, runner)
+        summary = script.index(SUMMARY_HEREDOC)
         success = script.index("printf 'status=success\\n'")
         self.assertLess(required, summary)
         self.assertLess(required, success)

--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -85,15 +85,28 @@ mkdir -p "$pkgroot/etc/rustbgpd"
 # Swap the dev-paths comment paragraph for a package-accurate one, then
 # point the runtime state at the production directory. The implicit gRPC UDS
 # follows runtime_state_dir, so it needs no independent rewrite or drift fence.
-sed -e '/^# For local development/,/^# systemd unit (examples\/systemd\/)/c\
+# The paragraph ends at the blank line before [global]; the range ends there
+# rather than on a closing comment line, which reflows without warning.
+sed -e '/^# For local development/,/^$/c\
 # Installed by the rustbgpd package. State lives in /var/lib/rustbgpd,\
-# created and owned by the systemd unit (StateDirectory=rustbgpd).' \
+# created and owned by the systemd unit (StateDirectory=rustbgpd).\
+' \
     -e 's|/tmp/rustbgpd|/var/lib/rustbgpd|g' \
     examples/minimal/config.toml > "$pkgroot/etc/rustbgpd/config.toml"
 if grep -q '/tmp/rustbgpd' "$pkgroot/etc/rustbgpd/config.toml"; then
     echo "error: dev path survived the config skeleton rewrite" >&2
     exit 1
 fi
+# A drifted range anchor deletes to end of file rather than failing, and the
+# dev-path check above then passes because the path went with it. Assert the
+# config body positively instead.
+for required in '^\[global\]$' '^\[\[neighbors\]\]$' '^\[policy\]$' \
+        '^runtime_state_dir = "/var/lib/rustbgpd"$'; do
+    grep -Eq "$required" "$pkgroot/etc/rustbgpd/config.toml" || {
+        echo "error: config skeleton rewrite consumed ${required}; update this script" >&2
+        exit 1
+    }
+done
 
 # Man pages (gzipped per packaging convention) + completions.
 install -D -m 0644 "$staging/share/man/man1/rbgp.1" "$pkgroot/usr/share/man/man1/rbgp.1"

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -204,7 +204,15 @@ def check(root: Path) -> list[str]:
     action = (
         root / ".github" / "actions" / "setup-dataplane-host" / "action.yml"
     ).read_text()
-    build = action.split("- name: Build rustbgpd:dev", 1)[-1]
+    # split(...)[-1] returns the whole file when the step name drifts, which
+    # turns every seam check below into a file-wide search that passes
+    # vacuously. Scope the region only once the anchor is known to be present.
+    build_step = "- name: Build rustbgpd:dev"
+    if build_step not in action:
+        errors.append(
+            f"setup-dataplane-host: build step name drifted from {build_step!r}"
+        )
+    build = action.split(build_step, 1)[-1] if build_step in action else ""
     if BUILDX not in action:
         errors.append(f"setup-dataplane-host: consumer missing {BUILDX}")
     for seam in (

--- a/tests/quickstart_dynamic_neighbor.rs
+++ b/tests/quickstart_dynamic_neighbor.rs
@@ -149,9 +149,11 @@ fn documented_flow() -> (String, Vec<String>) {
         .find("cat > ix-members.json <<'JSON'")
         .expect("Quickstart passwordless JSON start");
     let block = &quickstart[start..];
+    // Bound the block on the next documented command, not on the comment above
+    // it: comment prose gets reworded and the anchor stops matching silently.
     let end = block
-        .find("# Manage Linux unicast FIB-export tables.")
-        .expect("Quickstart passwordless flow end");
+        .find("rbgp fib-table list")
+        .expect("Quickstart passwordless flow must still end at `rbgp fib-table list`");
     let block = &block[..end];
     let json_start = block.find('{').expect("documented JSON object");
     let json_end = block.find("\nJSON\n").expect("documented JSON terminator");


### PR DESCRIPTION
## Problem

`scale / receipt checks` has failed since c0c4dc0c, taking the aggregate `check` job with it, so main has been red across nine subsequent merges.

`bench/scale/rebaseline/test_classifiers.py` extracts embedded Python heredocs out of `docs/perf/run-explain-cache-variant.sh` by locating a literal anchor and taking the `<<'PY'` block that follows. One call anchored on a comment sentence. #1553 reworded that comment to drop a tracker ID, the anchor stopped matching, and the extraction raised `ValueError: substring not found` from inside `str.index`. The comment was load-bearing code, not documentation.

The suite is CI-only — `cargo test --workspace` does not run it — so the break was invisible locally and every branch cut afterwards inherited it.

## Change

Anchor on the enclosing shell function `validate_settled_metrics()`, matching the sibling call that already anchored on `validate_settled_proc_status()`. The two remaining prose anchors in the same file, both naming the summary block's comment, move to that block's own `python3 - "$OUT" <<'PY'` invocation line.

Extraction is unchanged. The heredoc body the new anchor resolves is byte-identical to the body the pre-#1553 anchor produced (2215 bytes, verified against the pre-#1553 script), and the ordering assertion that used the summary comment's offset resolves to the immediately following line, preserving its comparisons.

A missing anchor now fails with the file path, the anchor, and the correction instead of a bare `substring not found`. For a CI-only suite that message is the entire diagnosis a maintainer receives.

## Seam sweep

Searched `bench/`, `scripts/`, `tests/`, `.github/`, and `docs/perf/` for other places that locate code by matching editable non-identifier text.

Fixed:

- **`scripts/build-packages.sh` — already broken, silently.** The packaging step rewrites the example config's dev-paths comment paragraph over a `sed` line range whose end anchor was a comment line. 0.64.0 reflowed that line, so the range matched no end and ran to end of file: the packaged `/etc/rustbgpd/config.toml` lost `[global]`, `[policy]`, and `[[neighbors]]`, leaving a comment-only stub. The 0.64.0 `.deb`/`.rpm` shipped it. The one downstream check searched the output for a leftover `/tmp/rustbgpd` and passed precisely because that line had been deleted with everything else. The range now ends on the paragraph's terminating blank line, and the packaged config body is asserted positively.
- **`tests/quickstart_dynamic_neighbor.rs`** bounded the documented passwordless flow on a shell comment inside a Quickstart code fence. It now bounds on the next documented command. The extracted JSON and the four-command list are unchanged.
- **`scripts/check_ci_image_primer_contract.py`** scoped its build-step seam checks with `split(...)[-1]`, which returns the whole file when the step name drifts, turning every seam check into a file-wide search that passes vacuously. The drift is now reported and the region scoped to empty.

Left in place, deliberately:

- **`src/main.rs`** startup-ordering proof anchors two offsets on comments. Re-anchoring is not mechanical: the slice they bound feeds `ends_with("\n    }\n\n    ")`, which asserts the region ends exactly where the comment begins, so moving the anchor requires re-deriving that assertion. Both anchors also sit in the same file as the code they pin, which narrows the reword-blindness this PR targets.
- **`bench/scale/reloadstall/gen-irr-scenario.py`** splices on `# --- Export policy`, a banner emitted from `tools/rs-config-render`. The matched prefix is the stable part and the banner shape reads as deliberate, though the cross-language coupling carries no fence.
- **`tests/interop_topology_commands.rs`** bounds a shell function body on a `# Main` banner. The start anchor is a function name; only the terminator is prose, and the prefix survives most edits.

Machine-marker extractions (`<!-- BEGIN/END -->` in `check_embedding_crate_map.py`, `check_release_install_contract.py`, `starter_configs_check_strict.rs`), assertions on program output, and grep-based gates whose needle is the literal being policed were reviewed and are correct as written.

## Verification

All gates exit 0: the rebaseline suite (18 tests), `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`, `scripts/check-clippy-reasons.py`, `scripts/check_public_tracker_ids.py`, and `scripts/check_ci_image_primer_contract.py`.

The fix is proven to still fail when what it guards actually breaks:

- Renaming `validate_settled_metrics()` in the runner fails both dependent tests with the actionable message rather than passing vacuously.
- Changing the summary block's `python3` invocation fails both of its dependent tests the same way.
- Rewording both anchored comments — the exact edit that caused this outage — leaves the suite green.
- For the packaging fix, deleting the paragraph's terminating blank line is caught with a named error and a non-zero exit, where the previous script would have shipped a truncated config.
