### PR TITLE
docs: enforce performance receipt seals

### DIFF
--- a/docs/perf/artifacts/policy-set-store-2026-07/README.md
+++ b/docs/perf/artifacts/policy-set-store-2026-07/README.md
@@ -1,10 +1,5 @@
 # Bounded eager policy-set sharing receipt — 2026-07
 
-> **Historical receipt.** This captures the superseded 32-neighbor chunk
-> implementation. Current loading interns sets once for the whole compiled
-> unit; the measurements and rows below are preserved as historical evidence,
-> not as the current sharing contract.
-
 This is the implementation gate for sharing content-equal indexed `.rpol`
 sets while resolving a retained neighbor roster. The accepted implementation
 uses one content-keyed `SetStore` per contiguous 32-neighbor chunk. It

--- a/scripts/check_public_tracker_ids.py
+++ b/scripts/check_public_tracker_ids.py
@@ -23,6 +23,7 @@ by editing this guard.
 
 from __future__ import annotations
 
+import hashlib
 import re
 import subprocess
 import sys
@@ -54,6 +55,8 @@ SKIPPED_SUFFIXES = frozenset({".gz", ".png", ".svg", ".zst", ".bin"})
 TRACKER_ID = re.compile(r"\bLAN-\d+\b")
 
 SEAL_NAME = "SHA256SUMS"
+SEAL_ROOT = Path("docs/perf/artifacts")
+SEAL_LINE = re.compile(r"([0-9a-f]{64})  (.+)")
 
 
 class TrackerIdGuardError(RuntimeError):
@@ -80,25 +83,108 @@ def tracked_files() -> list[Path]:
     return paths
 
 
-def sealed_paths(paths: list[Path]) -> set[str]:
-    """Return every repository-relative path pinned by a tracked SHA256SUMS."""
-    sealed: set[str] = set()
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def sealed_paths(paths: list[Path], root: Path | None = None) -> set[str]:
+    """Verify tracked receipt manifests and return their sealed paths."""
+    root = (root or ROOT).resolve()
+    tracked: dict[str, Path] = {}
     for path in paths:
-        if path.name != SEAL_NAME:
-            continue
         try:
-            text = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            continue
-        for line in text.splitlines():
-            _, separator, name = line.partition("  ")
-            if not separator:
-                continue
-            entry = (path.parent / name.strip()).resolve()
+            relative = path.relative_to(root).as_posix()
+        except ValueError as error:
+            raise TrackerIdGuardError(
+                f"tracked path escapes the repository root: {path}"
+            ) from error
+        tracked[relative] = path
+
+    manifests = [
+        path
+        for relative, path in tracked.items()
+        if path.name == SEAL_NAME
+        and Path(relative).is_relative_to(SEAL_ROOT)
+    ]
+    if not manifests:
+        raise TrackerIdGuardError(
+            "no tracked performance-receipt SHA256SUMS manifests were found"
+        )
+
+    sealed: set[str] = set()
+    for manifest in sorted(manifests):
+        if manifest.is_symlink():
+            raise TrackerIdGuardError(f"seal {manifest} is a symlink")
+        try:
+            lines = manifest.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError) as error:
+            raise TrackerIdGuardError(f"cannot read seal {manifest}: {error}") from error
+        if not lines:
+            raise TrackerIdGuardError(f"seal {manifest} is empty")
+
+        receipt_root = manifest.parent.resolve()
+        manifest_entries: set[str] = set()
+        for line_number, line in enumerate(lines, start=1):
+            match = SEAL_LINE.fullmatch(line)
+            if match is None:
+                raise TrackerIdGuardError(
+                    f"{manifest}:{line_number} is not lowercase SHA-256, two spaces, "
+                    "and a filename"
+                )
+            expected, name = match.groups()
+            name_path = Path(name)
+            if name_path.is_absolute() or ".." in name_path.parts:
+                raise TrackerIdGuardError(
+                    f"{manifest}:{line_number} entry {name!r} escapes its receipt root"
+                )
+            entry = manifest.parent / name_path
             try:
-                sealed.add(entry.relative_to(ROOT).as_posix())
-            except ValueError:
-                continue
+                resolved = entry.resolve(strict=True)
+                resolved.relative_to(receipt_root)
+                relative = entry.relative_to(root).as_posix()
+            except (OSError, ValueError) as error:
+                raise TrackerIdGuardError(
+                    f"{manifest}:{line_number} entry {name!r} is missing or escapes "
+                    "its receipt root"
+                ) from error
+            cursor = manifest.parent
+            for part in name_path.parts:
+                if part == ".":
+                    continue
+                cursor /= part
+                if cursor.is_symlink():
+                    raise TrackerIdGuardError(
+                        f"{manifest}:{line_number} entry {name!r} is a symlink"
+                    )
+            if relative not in tracked:
+                raise TrackerIdGuardError(
+                    f"{manifest}:{line_number} entry {name!r} is not tracked"
+                )
+            if not resolved.is_file():
+                raise TrackerIdGuardError(
+                    f"{manifest}:{line_number} entry {name!r} is not a regular file"
+                )
+            if relative in manifest_entries:
+                raise TrackerIdGuardError(
+                    f"{manifest}:{line_number} duplicates entry {name!r}"
+                )
+            manifest_entries.add(relative)
+            try:
+                actual = _sha256(resolved)
+            except OSError as error:
+                raise TrackerIdGuardError(
+                    f"cannot hash {manifest}:{line_number} entry {name!r}: {error}"
+                ) from error
+            if actual != expected:
+                raise TrackerIdGuardError(
+                    f"{manifest}:{line_number} entry {name!r} has SHA-256 {actual}, "
+                    f"expected {expected}"
+                )
+            sealed.add(relative)
     return sealed
 
 

--- a/scripts/test_check_public_tracker_ids.py
+++ b/scripts/test_check_public_tracker_ids.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import hashlib
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -24,6 +26,20 @@ CLEAN_LINES = (
     "The LAN party ran until LANE-4 closed.",
     "Milestone M84 covers multi-cache RTR conformance.",
 )
+
+
+def write_fixture(root: Path, relative: str, contents: str | bytes) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(contents, str):
+        path.write_text(contents, encoding="utf-8")
+    else:
+        path.write_bytes(contents)
+    return path
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 class PublicTrackerIdTests(unittest.TestCase):
@@ -71,14 +87,114 @@ class PublicTrackerIdTests(unittest.TestCase):
         # file must never inherit it.
         self.assertNotIn("README.md", sealed)
 
+    def test_nested_seals_and_dot_paths_verify_without_widening_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            readme = write_fixture(
+                root, "docs/perf/artifacts/example/README.md", "sealed\n"
+            )
+            data = write_fixture(
+                root, "docs/perf/artifacts/example/nested/data.tsv", "row\n"
+            )
+            nested = write_fixture(
+                root,
+                "docs/perf/artifacts/example/nested/SHA256SUMS",
+                f"{digest(data)}  data.tsv\n",
+            )
+            manifest = write_fixture(
+                root,
+                "docs/perf/artifacts/example/SHA256SUMS",
+                f"{digest(readme)}  ./README.md\n"
+                f"{digest(nested)}  ./nested/SHA256SUMS\n"
+                f"{digest(data)}  ./nested/data.tsv\n",
+            )
+            public = write_fixture(root, "docs/public.md", "living\n")
+            outside = write_fixture(
+                root, "docs/SHA256SUMS", f"{digest(public)}  public.md\n"
+            )
+            sealed = guard.sealed_paths(
+                [manifest, readme, nested, data, outside, public], root
+            )
+            self.assertIn("docs/perf/artifacts/example/README.md", sealed)
+            self.assertIn("docs/perf/artifacts/example/nested/data.tsv", sealed)
+            self.assertNotIn("docs/public.md", sealed)
+
+    def test_malformed_or_unsafe_seals_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            payload = write_fixture(
+                root, "docs/perf/artifacts/example/README.md", "sealed\n"
+            )
+            outside = write_fixture(root, "docs/perf/artifacts/README.md", "outside\n")
+            checksum = digest(payload)
+            manifest = root / "docs/perf/artifacts/example/SHA256SUMS"
+            cases = {
+                "empty": "",
+                "malformed": f"{checksum} README.md\n",
+                "absolute": f"{checksum}  {payload}\n",
+                "escape": f"{digest(outside)}  ../README.md\n",
+                "duplicate": (
+                    f"{checksum}  README.md\n{checksum}  ./README.md\n"
+                ),
+                "digest mismatch": f"{'0' * 64}  README.md\n",
+            }
+            for label, contents in cases.items():
+                with self.subTest(label=label):
+                    write_fixture(root, manifest.relative_to(root).as_posix(), contents)
+                    with self.assertRaises(guard.TrackerIdGuardError):
+                        guard.sealed_paths([manifest, payload, outside], root)
+
+    def test_missing_untracked_and_symlink_entries_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = write_fixture(
+                root,
+                "docs/perf/artifacts/example/SHA256SUMS",
+                f"{'0' * 64}  missing.txt\n",
+            )
+            with self.assertRaisesRegex(guard.TrackerIdGuardError, "is missing or escapes"):
+                guard.sealed_paths([manifest], root)
+
+            payload = write_fixture(
+                root, "docs/perf/artifacts/example/untracked.txt", "sealed\n"
+            )
+            manifest.write_text(
+                f"{digest(payload)}  untracked.txt\n", encoding="utf-8"
+            )
+            with self.assertRaisesRegex(guard.TrackerIdGuardError, "not tracked"):
+                guard.sealed_paths([manifest], root)
+
+            target = write_fixture(
+                root, "docs/perf/artifacts/example/target.txt", "sealed\n"
+            )
+            symlink = root / "docs/perf/artifacts/example/link.txt"
+            symlink.symlink_to(target)
+            manifest.write_text(f"{digest(target)}  link.txt\n", encoding="utf-8")
+            with self.assertRaisesRegex(guard.TrackerIdGuardError, "symlink"):
+                guard.sealed_paths([manifest, symlink], root)
+            manifest.unlink()
+            manifest.symlink_to(target)
+            with self.assertRaisesRegex(guard.TrackerIdGuardError, "seal .* is a symlink"):
+                guard.sealed_paths([manifest], root)
+
+    def test_missing_receipt_manifest_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            public = write_fixture(root, "docs/README.md", "living\n")
+            with self.assertRaisesRegex(guard.TrackerIdGuardError, "no tracked"):
+                guard.sealed_paths([public], root)
+
     def test_broken_walk_fails_loudly(self) -> None:
-        original = guard.tracked_files
+        original_tracked = guard.tracked_files
+        original_sealed = guard.sealed_paths
         guard.tracked_files = lambda: [guard.ROOT / "Cargo.toml"]
+        guard.sealed_paths = lambda _paths: set()
         try:
             with self.assertRaisesRegex(guard.TrackerIdGuardError, "walk is broken"):
                 guard.discover_documents()
         finally:
-            guard.tracked_files = original
+            guard.tracked_files = original_tracked
+            guard.sealed_paths = original_sealed
 
     def test_empty_tracked_tree_fails_loudly(self) -> None:
         original = guard.tracked_files


### PR DESCRIPTION
## Summary

- restore the policy-set-store receipt README to its original sealed bytes
- verify every tracked performance-receipt SHA256SUMS before exempting sealed prose from the public-doc scan
- fail closed on malformed manifests, unsafe paths, symlinks, missing or untracked entries, and digest drift

## Validation

- Python seal/tracker unit tests and live checker
- all 36 tracked receipt manifests with sha256sum
- workspace fmt, clippy, tests, and rustdoc
- v1 stable-surface and diff checks

Linear: LAN-947