### PR TITLE
bench: pin cross-version comparison harnesses

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -121,6 +121,13 @@ jobs:
           # a real failure and propagates.
           set -uo pipefail
           rc=0
+          harness_args=()
+          if [ "$PACKAGE" = "rustbgpd-rib" ] && [ "$BENCH" = "rib_ops" ]; then
+            harness_args=(
+              --harness-ref HEAD
+              --harness-path crates/rib/benches/rib_ops.rs
+            )
+          fi
           bench/compare-criterion.sh \
             --base "$BASE_REF" \
             --head "HEAD" \
@@ -128,6 +135,7 @@ jobs:
             --bench "$BENCH" \
             --core "$CORE" \
             --attempts "$ATTEMPTS" \
+            "${harness_args[@]}" \
             --fail-on-regression \
             --out-dir "target/bench-compare" || rc=$?
           if [ "$rc" -eq 75 ]; then

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -134,6 +134,12 @@ jobs:
           if [ "$REQUIRE_PERFORMANCE" = "true" ]; then
             args+=(--require-performance)
           fi
+          if [ "$PACKAGE" = "rustbgpd-rib" ] && [ "$BENCH" = "rib_ops" ]; then
+            args+=(
+              --harness-ref HEAD
+              --harness-path crates/rib/benches/rib_ops.rs
+            )
+          fi
           bench/compare-criterion.sh "${args[@]}"
 
       - name: Publish summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,8 @@ jobs:
           # renderer, so make that prerequisite explicit on a clean runner.
           cargo build -p rs-config-render
           cargo test --test reloadstall_scenario_emitted_check
-          bash -n bench/compare-criterion.sh
+          bash -n bench/compare-criterion.sh bench/tests/test-compare-criterion-harness.sh
+          shellcheck bench/compare-criterion.sh bench/tests/test-compare-criterion-harness.sh
           shellcheck bench/smoke-benches.sh
           bash -n bench/scale/route-server-1000/run-receipt.sh
           bash -n bench/scale/outbound-prefix-limits/run-receipt.sh
@@ -354,6 +355,7 @@ jobs:
           bash bench/tests/test-route-server-1000-receipt.sh
           bash bench/tests/test-vpn-query-receipt.sh
           bash bench/tests/test-vpn-query-campaign.sh
+          bash bench/tests/test-compare-criterion-harness.sh
           bash -n bench/scale/compare-rrharness.sh
           bash bench/tests/test-rrharness-driver.sh
           python3 -m unittest discover \

--- a/bench/compare-criterion.sh
+++ b/bench/compare-criterion.sh
@@ -15,6 +15,9 @@ Options:
   --bench NAME            Criterion bench target (default: rib_ops)
   --features LIST         Cargo feature list forwarded to both refs
   --filter TEXT           Criterion benchmark filter, for example adj_rib_in_insert
+  --harness-ref REF       Git ref supplying one benchmark source file to both sides
+  --harness-path PATH     Repository-relative */benches/*.rs file paired with
+                          --harness-ref; both installed copies are verified
   --core CPU              CPU core passed to taskset -c (default: 0)
   --attempts N            Number of A/B attempts with alternating order to
                           dampen base/head cache-warming bias (default: 1).
@@ -74,6 +77,8 @@ package="rustbgpd-rib"
 bench_name="rib_ops"
 filter=""
 features=""
+harness_ref=""
+harness_path=""
 core="0"
 attempts=1
 out_root="target/bench-compare"
@@ -111,6 +116,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --features)
       features="${2:?missing value for --features}"
+      shift 2
+      ;;
+    --harness-ref)
+      harness_ref="${2:?missing value for --harness-ref}"
+      shift 2
+      ;;
+    --harness-path)
+      harness_path="${2:?missing value for --harness-path}"
       shift 2
       ;;
     --core)
@@ -188,6 +201,54 @@ head_sha="$(git rev-parse --verify "${head_ref}^{commit}")"
 base_short="$(git rev-parse --short=12 "$base_sha")"
 head_short="$(git rev-parse --short=12 "$head_sha")"
 
+if [[ -n $harness_ref || -n $harness_path ]]; then
+  harness_enabled=1
+  [[ -n $harness_ref && -n $harness_path ]] || {
+    echo "error: --harness-ref and --harness-path must be provided together" >&2
+    exit 2
+  }
+  [[ $harness_path =~ ^([A-Za-z0-9._+@-]+/)*benches/[A-Za-z0-9._+@-]+\.rs$ \
+    && "/${harness_path}/" != *"/../"* \
+    && "/${harness_path}/" != *"/./"* ]] || {
+    echo "error: --harness-path must be a safe repository-relative */benches/*.rs path" >&2
+    exit 2
+  }
+  command -v sha256sum >/dev/null 2>&1 || {
+    echo "error: sha256sum not found; required for fixed-harness verification" >&2
+    exit 1
+  }
+  harness_sha="$(git rev-parse --verify "${harness_ref}^{commit}")"
+  harness_object="${harness_sha}:${harness_path}"
+  [[ $(git cat-file -t "$harness_object" 2>/dev/null) == blob ]] || {
+    echo "error: fixed harness is not a blob at ${harness_ref}:${harness_path}" >&2
+    exit 2
+  }
+  harness_mode="$(git ls-tree "$harness_sha" -- "$harness_path" | awk '{print $1}')"
+  [[ $harness_mode == 100644 || $harness_mode == 100755 ]] || {
+    echo "error: fixed harness must be a regular git file at ${harness_ref}:${harness_path}" >&2
+    exit 2
+  }
+  harness_blob="$(git rev-parse "$harness_object")"
+  harness_sha256="$(git cat-file blob "$harness_object" | sha256sum | awk '{print $1}')"
+else
+  harness_enabled=0
+  harness_sha=""
+  harness_object=""
+  harness_mode=""
+  harness_blob=""
+  harness_sha256=""
+fi
+base_original_harness_blob=""
+base_original_harness_sha256=""
+base_installed_harness_blob=""
+base_installed_harness_sha256=""
+base_harness_overlay=""
+head_original_harness_blob=""
+head_original_harness_sha256=""
+head_installed_harness_blob=""
+head_installed_harness_sha256=""
+head_harness_overlay=""
+
 if [[ -n $lan395_gate_out ]]; then
   [[ $package == rustbgpd-transport \
     && $bench_name == fanout \
@@ -200,8 +261,10 @@ if [[ -n $lan395_gate_out ]]; then
     && $fail_on_regression == 0 \
     && $regression_threshold_pct == 3 \
     && $regression_max_stddev_pct == 10 \
-    && $verdict_min_attempts == 3 ]] || {
+    && $verdict_min_attempts == 3 \
+    && $harness_enabled == 0 ]] || {
     echo "error: --lan395-gate-out requires rustbgpd-transport/fanout, filter distribute_fanout, feature bench-internals, two attempts on CPU 5, taskset, --require-performance, and the default generic verdict settings" >&2
+    echo "       fixed-harness overlays are not permitted in LAN-395 exact mode" >&2
     exit 2
   }
   [[ ! -e $lan395_gate_out && ! -L $lan395_gate_out ]] || {
@@ -334,6 +397,67 @@ echo "Creating detached worktrees under ${run_dir}"
 git worktree add --detach "$base_dir" "$base_sha" >/dev/null
 git worktree add --detach "$head_dir" "$head_sha" >/dev/null
 
+install_fixed_harness() {
+  local worktree="$1"
+  local source_sha="$2"
+  local side="$3"
+  local source_object="${source_sha}:${harness_path}"
+  local original_blob="missing"
+  local original_sha256="missing"
+  local installed_blob
+  local installed_sha256
+  local overlay
+  local status_file="${run_dir}/.${side}-harness-status"
+  local -a dirty=()
+
+  if git cat-file -e "$source_object" 2>/dev/null; then
+    [[ $(git cat-file -t "$source_object") == blob ]] || {
+      echo "error: ${side} harness path is not a blob at ${source_object}" >&2
+      exit 1
+    }
+    original_blob="$(git rev-parse "$source_object")"
+    original_sha256="$(git cat-file blob "$source_object" | sha256sum | awk '{print $1}')"
+  fi
+
+  GIT_LITERAL_PATHSPECS=1 git -C "$worktree" \
+    checkout "$harness_sha" -- "$harness_path"
+  installed_blob="$(git -C "$worktree" hash-object -- "$harness_path")"
+  installed_sha256="$(sha256sum "${worktree}/${harness_path}" | awk '{print $1}')"
+  [[ $installed_blob == "$harness_blob" && $installed_sha256 == "$harness_sha256" ]] || {
+    echo "error: ${side} fixed harness differs from selected ${harness_object}" >&2
+    exit 1
+  }
+
+  if ! git -C "$worktree" status --porcelain=v1 -z --untracked-files=all \
+    >"$status_file"; then
+    rm -f "$status_file"
+    echo "error: cannot inspect ${side} fixed-harness overlay" >&2
+    exit 1
+  fi
+  mapfile -d '' -t dirty <"$status_file"
+  rm -f "$status_file"
+  if (( ${#dirty[@]} == 0 )); then
+    overlay="clean"
+  elif (( ${#dirty[@]} == 1 )) && [[ ${dirty[0]:3} == "$harness_path" ]]; then
+    overlay="overlaid"
+  else
+    echo "error: ${side} fixed-harness overlay dirtied unexpected paths:" >&2
+    printf '  %s\n' "${dirty[@]}" >&2
+    exit 1
+  fi
+
+  printf -v "${side}_original_harness_blob" '%s' "$original_blob"
+  printf -v "${side}_original_harness_sha256" '%s' "$original_sha256"
+  printf -v "${side}_installed_harness_blob" '%s' "$installed_blob"
+  printf -v "${side}_installed_harness_sha256" '%s' "$installed_sha256"
+  printf -v "${side}_harness_overlay" '%s' "$overlay"
+}
+
+if [[ -n $harness_ref ]]; then
+  install_fixed_harness "$base_dir" "$base_sha" base
+  install_fixed_harness "$head_dir" "$head_sha" head
+fi
+
 write_metadata() {
   {
     echo "run_id=${run_id}"
@@ -356,6 +480,24 @@ write_metadata() {
     echo "base_target_dir=${base_target_dir}"
     echo "head_target_dir=${head_target_dir}"
     echo "criterion_dir=${criterion_home}"
+    echo
+    echo "harness_enabled=${harness_enabled}"
+    echo "harness_ref=${harness_ref}"
+    echo "harness_path=${harness_path}"
+    echo "harness_sha=${harness_sha}"
+    echo "harness_mode=${harness_mode}"
+    echo "harness_blob=${harness_blob}"
+    echo "harness_sha256=${harness_sha256}"
+    echo "base_original_harness_blob=${base_original_harness_blob}"
+    echo "base_original_harness_sha256=${base_original_harness_sha256}"
+    echo "base_installed_harness_blob=${base_installed_harness_blob}"
+    echo "base_installed_harness_sha256=${base_installed_harness_sha256}"
+    echo "base_harness_overlay=${base_harness_overlay}"
+    echo "head_original_harness_blob=${head_original_harness_blob}"
+    echo "head_original_harness_sha256=${head_original_harness_sha256}"
+    echo "head_installed_harness_blob=${head_installed_harness_blob}"
+    echo "head_installed_harness_sha256=${head_installed_harness_sha256}"
+    echo "head_harness_overlay=${head_harness_overlay}"
     echo
     uname -a
     echo

--- a/bench/tests/test-compare-criterion-harness.sh
+++ b/bench/tests/test-compare-criterion-harness.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+driver="${source_root}/bench/compare-criterion.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+repo="${tmp}/repo"
+fake_bin="${tmp}/bin"
+harness_path="crates/rib/benches/rib_ops.rs"
+dash_harness_path="-crates/rib/benches/rib_ops.rs"
+real_git="$(command -v git)"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_metadata() {
+  local file="$1"
+  local key="$2"
+  local expected="$3"
+  grep -Fxq "${key}=${expected}" "$file" \
+    || fail "${file}: expected ${key}=${expected}"
+}
+
+expect_failure() {
+  local expected="$1"
+  local expected_rc="$2"
+  shift 2
+  local output
+  local rc
+  set +e
+  output="$(cd "$repo" && "$driver" \
+    --base "$base_sha" --head "$head_sha" --no-taskset --attempts 1 \
+    --allow-dirty --out-dir "${tmp}/rejected-$RANDOM" "$@" 2>&1)"
+  rc=$?
+  set -e
+  [[ $rc -eq $expected_rc ]] \
+    || fail "expected rc ${expected_rc} for '${expected}', got ${rc}: ${output}"
+  grep -Fq -- "$expected" <<<"$output" \
+    || fail "missing rejection '${expected}' in: ${output}"
+}
+
+mkdir -p "$repo/$(dirname -- "$harness_path")" "$fake_bin"
+git -C "$repo" init -q
+git -C "$repo" config user.email test@example.invalid
+git -C "$repo" config user.name "Harness Test"
+printf '%s\n' 'duplicate-prefix fixture' >"${repo}/${harness_path}"
+git -C "$repo" add -- "$harness_path"
+git -C "$repo" commit -qm base
+base_sha="$(git -C "$repo" rev-parse HEAD)"
+base_blob="$(git -C "$repo" rev-parse "HEAD:${harness_path}")"
+base_sha256="$(git -C "$repo" cat-file blob "$base_blob" | sha256sum | awk '{print $1}')"
+
+printf '%s\n' 'unique-prefix fixture' >"${repo}/${harness_path}"
+git -C "$repo" commit -qam head
+head_sha="$(git -C "$repo" rev-parse HEAD)"
+head_blob="$(git -C "$repo" rev-parse "HEAD:${harness_path}")"
+head_sha256="$(git -C "$repo" cat-file blob "$head_blob" | sha256sum | awk '{print $1}')"
+
+printf '%s\n' 'fixed comparison fixture' >"${repo}/${harness_path}"
+mkdir -p "$repo/$(dirname -- "$dash_harness_path")"
+printf '%s\n' 'fixed comparison fixture' >"${repo}/${dash_harness_path}"
+git -C "$repo" add -- "$dash_harness_path"
+git -C "$repo" commit -qam harness
+harness_sha="$(git -C "$repo" rev-parse HEAD)"
+harness_blob="$(git -C "$repo" rev-parse "HEAD:${harness_path}")"
+harness_sha256="$(git -C "$repo" cat-file blob "$harness_blob" | sha256sum | awk '{print $1}')"
+ln -s rib_ops.rs "${repo}/crates/rib/benches/link.rs"
+git -C "$repo" add crates/rib/benches/link.rs
+git -C "$repo" commit -qm symlink
+symlink_sha="$(git -C "$repo" rev-parse HEAD)"
+mkdir "${repo}/crates/rib/benches/tree.rs"
+printf '%s\n' member >"${repo}/crates/rib/benches/tree.rs/member"
+git -C "$repo" add crates/rib/benches/tree.rs
+git -C "$repo" commit -qm tree
+tree_sha="$(git -C "$repo" rev-parse HEAD)"
+
+rm -rf "${repo}/crates/rib/benches/tree.rs"
+rm "${repo}/${harness_path}"
+printf '%s\n' 'outside sentinel' >"${tmp}/escaped.rs"
+ln -s "${tmp}/escaped.rs" "${repo}/${harness_path}"
+git -C "$repo" add -A crates/rib/benches
+git -C "$repo" commit -qm side-symlink
+side_symlink_sha="$(git -C "$repo" rev-parse HEAD)"
+
+expected_harness="${tmp}/expected-rib-ops.rs"
+git -C "$repo" cat-file blob "$harness_blob" >"$expected_harness"
+rm "${repo}/${harness_path}"
+printf '%s\n' 'dirty working-tree decoy' >"${repo}/${harness_path}"
+
+cat >"${fake_bin}/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ ${1:-} == -V ]]; then
+  echo 'cargo 1.95.0 (fixture)'
+  exit 0
+fi
+[[ -n ${FAKE_HARNESS_PATH:-} && -n ${FAKE_CARGO_LOG:-} ]]
+git hash-object -- "$FAKE_HARNESS_PATH" >>"$FAKE_CARGO_LOG"
+baseline=''
+while (( $# )); do
+  if [[ $1 == --save-baseline ]]; then
+    baseline="${2:?missing fake baseline}"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n $baseline && -n ${CRITERION_HOME:-} ]]
+result="${CRITERION_HOME}/adj_rib_in_insert/500000/${baseline}/estimates.json"
+mkdir -p "$(dirname "$result")"
+printf '%s\n' '{"median":{"point_estimate":1000,"confidence_interval":{"lower_bound":990,"upper_bound":1010}}}' >"$result"
+EOF
+chmod +x "${fake_bin}/cargo"
+cat >"${fake_bin}/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ ${FAIL_GIT_STATUS:-0} == 1 && " $* " == *" status --porcelain=v1 "* ]]; then
+  exit 1
+fi
+exec "$REAL_GIT" "$@"
+EOF
+chmod +x "${fake_bin}/git"
+export REAL_GIT="$real_git"
+export PATH="${fake_bin}:${PATH}"
+export RUSTBGPD_HOST_LOCK="${tmp}/host.lock"
+export FAKE_HARNESS_PATH="$harness_path"
+export FAKE_CARGO_LOG="${tmp}/cargo-harness.log"
+: >"$FAKE_CARGO_LOG"
+
+out="${tmp}/different"
+(cd "$repo" && "$driver" \
+  --base "$base_sha" --head "$head_sha" --no-taskset --attempts 1 \
+  --harness-ref "$harness_sha" --harness-path "$harness_path" \
+  --allow-dirty --out-dir "$out" --keep-worktrees >/dev/null)
+metadata="$(find "$out" -name metadata.txt -print -quit)"
+[[ -n $metadata ]] || fail 'comparison did not write metadata'
+python3 - "$metadata" <<'PY'
+import sys
+
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+expected = "run_id base_ref base_sha head_ref head_sha package bench filter features core attempts fail_on_regression regression_threshold_pct regression_max_stddev_pct verdict_min_attempts governor use_taskset base_target_dir head_target_dir criterion_dir".split()
+assert [line.split("=", 1)[0] for line in lines[:len(expected)]] == expected
+assert lines[len(expected)] == ""
+PY
+run_dir="$(dirname "$metadata")"
+cmp "${run_dir}/base/${harness_path}" "$expected_harness"
+cmp "${run_dir}/head/${harness_path}" "$expected_harness"
+assert_metadata "$metadata" harness_sha "$harness_sha"
+assert_metadata "$metadata" harness_enabled 1
+assert_metadata "$metadata" harness_mode 100644
+assert_metadata "$metadata" harness_path "$harness_path"
+assert_metadata "$metadata" harness_blob "$harness_blob"
+assert_metadata "$metadata" harness_sha256 "$harness_sha256"
+assert_metadata "$metadata" base_original_harness_blob "$base_blob"
+assert_metadata "$metadata" base_original_harness_sha256 "$base_sha256"
+assert_metadata "$metadata" head_original_harness_blob "$head_blob"
+assert_metadata "$metadata" head_original_harness_sha256 "$head_sha256"
+assert_metadata "$metadata" base_installed_harness_blob "$harness_blob"
+assert_metadata "$metadata" base_installed_harness_sha256 "$harness_sha256"
+assert_metadata "$metadata" head_installed_harness_blob "$harness_blob"
+assert_metadata "$metadata" head_installed_harness_sha256 "$harness_sha256"
+assert_metadata "$metadata" base_harness_overlay overlaid
+assert_metadata "$metadata" head_harness_overlay overlaid
+mapfile -t measured_blobs <"$FAKE_CARGO_LOG"
+[[ ${#measured_blobs[@]} -eq 2 ]] || fail 'expected two measured harness blobs'
+[[ ${measured_blobs[0]} == "$harness_blob" && ${measured_blobs[1]} == "$harness_blob" ]] \
+  || fail 'cargo did not measure the selected harness blob on both sides'
+
+symlink_out="${tmp}/side-symlink"
+(cd "$repo" && "$driver" \
+  --base "$side_symlink_sha" --head "$harness_sha" --no-taskset --attempts 1 \
+  --harness-ref "$harness_sha" --harness-path "$harness_path" \
+  --allow-dirty --out-dir "$symlink_out" --keep-worktrees >/dev/null)
+symlink_metadata="$(find "$symlink_out" -name metadata.txt -print -quit)"
+cmp "$(dirname "$symlink_metadata")/base/${harness_path}" "$expected_harness"
+grep -Fxq 'outside sentinel' "${tmp}/escaped.rs" \
+  || fail 'fixed-harness install followed a side-worktree symlink'
+
+same_out="${tmp}/same"
+: >"$FAKE_CARGO_LOG"
+FAKE_HARNESS_PATH="$dash_harness_path"
+(cd "$repo" && "$driver" \
+  --base "$harness_sha" --head "$harness_sha" --no-taskset --attempts 1 \
+  --harness-ref "$harness_sha" --harness-path "$dash_harness_path" \
+  --allow-dirty --out-dir "$same_out" --keep-worktrees >/dev/null)
+same_metadata="$(find "$same_out" -name metadata.txt -print -quit)"
+assert_metadata "$same_metadata" harness_path "$dash_harness_path"
+assert_metadata "$same_metadata" base_harness_overlay clean
+assert_metadata "$same_metadata" head_harness_overlay clean
+mapfile -t measured_blobs <"$FAKE_CARGO_LOG"
+[[ ${#measured_blobs[@]} -eq 2 && ${measured_blobs[0]} == "$harness_blob" \
+  && ${measured_blobs[1]} == "$harness_blob" ]] || fail 'leading-dash harness was not measured'
+FAKE_HARNESS_PATH="$harness_path"
+[[ -z $(git -C "$(dirname "$same_metadata")/base" status --porcelain) ]]
+[[ -z $(git -C "$(dirname "$same_metadata")/head" status --porcelain) ]]
+
+plain_out="${tmp}/plain"
+(cd "$repo" && "$driver" \
+  --base "$base_sha" --head "$head_sha" --no-taskset --attempts 1 \
+  --allow-dirty --package example --bench other --out-dir "$plain_out" >/dev/null)
+plain_metadata="$(find "$plain_out" -name metadata.txt -print -quit)"
+assert_metadata "$plain_metadata" harness_enabled 0
+assert_metadata "$plain_metadata" harness_ref ''
+
+expect_failure 'must be provided together' 2 --harness-ref "$harness_sha"
+expect_failure 'must be provided together' 2 --harness-path "$harness_path"
+expect_failure 'must be a safe repository-relative' 2 \
+  --harness-ref "$harness_sha" --harness-path '/tmp/rib_ops.rs'
+expect_failure 'must be a safe repository-relative' 2 \
+  --harness-ref "$harness_sha" --harness-path '../benches/rib_ops.rs'
+expect_failure 'must be a safe repository-relative' 2 \
+  --harness-ref "$harness_sha" --harness-path 'crates/rib/src/rib_ops.rs'
+expect_failure 'fixed harness is not a blob' 2 \
+  --harness-ref "$harness_sha" --harness-path 'crates/rib/benches/missing.rs'
+expect_failure 'fixed harness is not a blob' 2 \
+  --harness-ref "$tree_sha" --harness-path 'crates/rib/benches/tree.rs'
+expect_failure 'fixed harness must be a regular git file' 2 \
+  --harness-ref "$symlink_sha" --harness-path 'crates/rib/benches/link.rs'
+
+: >"$FAKE_CARGO_LOG"
+export FAIL_GIT_STATUS=1
+expect_failure 'cannot inspect base fixed-harness overlay' 1 \
+  --harness-ref "$harness_sha" --harness-path "$harness_path"
+unset FAIL_GIT_STATUS
+[[ ! -s $FAKE_CARGO_LOG ]] || fail 'cargo ran after fixed-harness status failure'
+
+cat >"${repo}/.git/hooks/post-checkout" <<'EOF'
+#!/bin/sh
+: >unexpected.txt
+EOF
+chmod +x "${repo}/.git/hooks/post-checkout"
+expect_failure 'overlay dirtied unexpected paths' 1 \
+  --harness-ref "$harness_sha" --harness-path "$harness_path"
+rm "${repo}/.git/hooks/post-checkout"
+
+grep -Fq "install_fixed_harness \"\$base_dir\" \"\$base_sha\" base" "$driver"
+grep -Fq "install_fixed_harness \"\$head_dir\" \"\$head_sha\" head" "$driver"
+for workflow in bench-nightly.yml bench.yml; do
+  file="${source_root}/.github/workflows/${workflow}"
+  python3 - "$file" <<'PY'
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+marker = 'if [ "$PACKAGE" = "rustbgpd-rib" ] && [ "$BENCH" = "rib_ops" ]; then'
+start = text.index(marker)
+end = text.index("\n          fi", start)
+block = text[start:end]
+assert block.count("--harness-ref HEAD") == 1
+assert block.count("--harness-path crates/rib/benches/rib_ops.rs") == 1
+assert text.count("--harness-ref HEAD") == 1
+assert text.count("--harness-path crates/rib/benches/rib_ops.rs") == 1
+if sys.argv[1].endswith("bench-nightly.yml"):
+    invocation = text.index("bench/compare-criterion.sh", end)
+    assert text.count('"${harness_args[@]}"') == 1
+    assert text.index('"${harness_args[@]}"', invocation) > invocation
+else:
+    assert text.count('bench/compare-criterion.sh "${args[@]}"') == 1
+    assert text.index('bench/compare-criterion.sh "${args[@]}"') > end
+PY
+done
+ci="${source_root}/.github/workflows/ci.yml"
+grep -Fq 'bash -n bench/compare-criterion.sh bench/tests/test-compare-criterion-harness.sh' "$ci"
+grep -Fq 'shellcheck bench/compare-criterion.sh bench/tests/test-compare-criterion-harness.sh' "$ci"
+grep -Fq 'bash bench/tests/test-compare-criterion-harness.sh' "$ci"
+grep -Fq "&& \$harness_enabled == 0" "$driver"
+
+echo 'fixed comparison harness tests passed'

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -185,10 +185,13 @@ HTML reports are generated to `target/criterion/`.
 
 Use `bench/compare-criterion.sh` when judging a performance PR locally. It
 creates detached worktrees for the baseline and head refs, runs both with a
-shared Criterion target directory, and writes a Markdown summary plus raw
-Criterion artifacts under `target/bench-compare/`.
+separate Cargo target directory per side and a shared Criterion results tree,
+and writes a Markdown summary plus raw Criterion artifacts under
+`target/bench-compare/`.
 
 It requires `bash`, `git`, `cargo`, `python3`, and `taskset` from util-linux.
+Fixed-harness mode also requires GNU `sha256sum` from coreutils and is supported
+on Linux only; it does not promise macOS portability.
 
 ```bash
 bench/compare-criterion.sh \
@@ -199,6 +202,28 @@ bench/compare-criterion.sh \
   --bench rib_ops \
   --filter adj_rib_in_insert
 ```
+
+When source revisions contain different benchmark fixtures, select one exact
+harness blob for both sides. The driver records each side's original blob and
+SHA-256 separately from the selected and installed provenance, then rejects
+any overlay that changes an unrelated path:
+
+```bash
+bench/compare-criterion.sh \
+  --base v0.62.0 \
+  --head v0.63.0 \
+  --package rustbgpd-rib \
+  --bench rib_ops \
+  --filter '^adj_rib_in_insert/500000$' \
+  --harness-ref 13d542c3 \
+  --harness-path crates/rib/benches/rib_ops.rs
+```
+
+The historical v0.62-to-v0.63 `adj_rib_in_insert/500000` comparison did not
+hold this fixture constant: v0.62 repeated 65,536 prefix keys while v0.63 used
+500,000 unique keys. Its roughly 50% delta is fixture-confounded and is not
+evidence of a shipped-code regression. Re-measure it with a fixed harness and
+a fresh same-SHA control before attributing a source regression or bisecting.
 
 For pinned runs, put the selected CPU into the `performance` governor first
 where the host allows it:

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -22,12 +22,12 @@ PERMISSION_HASH = "9691400b3b1036bcdfe724926816dbe71b0aa22ed9b5eb89627e2eeb75079
 JOB_HASHES = {
     "core": "4eb93b493beb95530d53b696901b0d4ee03c880fd3499fece71ec133e39d621b",
     "core_tests": "a600b370f7ad23208c65872684eba87f037b245d6074336626ca4175deca1e2f",
-    "scale_receipts": "2fef431828f2dc4dd879a10774752be598082a91435356771a5f61a3caaf9bd5",
+    "scale_receipts": "18b47124c6a93c50e44f385eb762b41493fb33fd3ea251ac952b3bb3a46d5639",
     "check": "cfc655ca80392ab0699390b461e5e8e9b41410cc724201aafe75ae6da7d83213",
     "msrv": "273de02a6a1e67e17913b50023326214261b8f4d6399f8f8867188e7e3d2acb9",
     "evpn_bum_filter_kernel": "d427ed2c650d619d926cad0a4cbb6b558dd013ace9b18ba48757be529420863a",
 }
-COMMAND_BODY_HASH = "9e3c949873c8c0872a1a5403b69300c3a5306025af3cf893782ff1d60a1a2b2f"
+COMMAND_BODY_HASH = "81b47dcabf6ee4349b09c070932176004a517f692506544a12eb0c28b56f12f3"
 STEP_NAME = "Check standalone scale harnesses and receipt classifiers"
 CHECKOUT = "uses: actions/checkout@v7"
 TOOLCHAIN = (


### PR DESCRIPTION
## Summary

- add paired `--harness-ref` / `--harness-path` support to the Criterion A/B driver
- install and verify the exact selected benchmark blob on both detached worktrees before cargo runs
- retain original, selected, and installed Git/SHA-256 provenance without changing the LAN-395 canonical metadata prefix
- pin the current `rib_ops` harness in nightly and manual workflows
- document that the historical v0.62-to-v0.63 500k row compared duplicate-prefix and unique-prefix fixtures

## Why

LAN-948 was filed from an apparent roughly 50% `adj_rib_in_insert/500000` slowdown. The old and new measurements used different harness fixtures: v0.62 repeated 65,536 keys, while v0.63 generated 500,000 unique keys. This change makes the next A/B comparable before any attribution or bisect. The expensive campaign remains intentionally deferred until this primitive lands.

## Verification

- `bash -n` and `shellcheck` for the driver and new contract test
- fixed-harness temp-repo / fake-Criterion contract test
- 11 retained LAN-395 validator tests
- workflow YAML parse
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- `python3 scripts/check-v1-stable-surface.py`
- `git diff --check`

Linear: LAN-948