### PR TITLE
cli: preserve bare BIRD channels during import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `rbgp config import` now retains bare BIRD `ipv4;` and `ipv6;` channel
+  declarations and reports `rr client on;` with route-reflector guidance.
 - SIGINT, SIGTERM, and SIGHUP handlers are now registered before gRPC, BGP,
   metrics/readiness, or gNMI dial-out can become externally reachable. A
   SIGTERM delivered during startup is retained for graceful shutdown instead

--- a/crates/cli/src/importer/bird.rs
+++ b/crates/cli/src/importer/bird.rs
@@ -397,6 +397,8 @@ fn scope(acc: &BgpAcc) -> String {
 fn bgp_stmt(model: &mut Model, acc: &mut BgpAcc, line: usize, text: &str) {
     let words: Vec<&str> = text.split_whitespace().collect();
     match words.as_slice() {
+        ["ipv4"] => acc.families.push("ipv4_unicast".to_owned()),
+        ["ipv6"] => acc.families.push("ipv6_unicast".to_owned()),
         // `local as N;` and `local <ip> as N;`
         ["local", rest @ ..] if rest.len() >= 2 && rest[rest.len() - 2] == "as" => {
             if let Ok(asn) = rest[rest.len() - 1].parse::<u32>() {
@@ -439,10 +441,10 @@ fn bgp_stmt(model: &mut Model, acc: &mut BgpAcc, line: usize, text: &str) {
             Err(_) => skip(model, line, text.to_owned(), GENERIC_GUIDANCE),
         },
         ["password", ..] => acc.auth_present = true,
-        ["rr", "client"] => skip(
+        ["rr", "client"] | ["rr", "client", "on"] => skip(
             model,
             line,
-            format!("{}: rr client", scope(acc)),
+            format!("{}: {text}", scope(acc)),
             "set route_reflector_client = true on the neighbor by hand (iBGP only)",
         ),
         ["rs", "client"] | ["rs", "client", "on"] => skip(

--- a/crates/cli/tests/config_import.rs
+++ b/crates/cli/tests/config_import.rs
@@ -63,6 +63,39 @@ fn bird3_golden_translation_and_operational_guidance() {
 }
 
 #[test]
+fn bird_empty_channels_and_rr_client_on_are_recognized() {
+    let source = "router id 192.0.2.10;\n\
+                  protocol bgp edge { local as 64500; neighbor 192.0.2.1 as 64500; \
+                  ipv4; ipv6; rr client on; }\n";
+    let imported =
+        import_source(SourceFormat::Bird, "empty-channels.conf", source).expect("translates");
+
+    assert!(
+        imported
+            .config_toml
+            .contains("families = [\"ipv4_unicast\", \"ipv6_unicast\"]"),
+        "{}",
+        imported.config_toml
+    );
+    assert_eq!(imported.report.skipped.len(), 1);
+    assert_eq!(imported.report.exit_code, 2);
+    assert!(!imported.config_toml.contains("route_reflector_client"));
+    assert!(
+        imported
+            .report
+            .skipped
+            .iter()
+            .all(|skip| !skip.stanza.ends_with("ipv4") && !skip.stanza.ends_with("ipv6"))
+    );
+    let skip = &imported.report.skipped[0];
+    assert_eq!(skip.line, Some(2));
+    assert_eq!(skip.stanza, "protocol edge: rr client on");
+    assert!(skip.guidance.contains("route_reflector_client = true"));
+    assert!(skip.guidance.contains("by hand"));
+    assert!(skip.guidance.contains("iBGP only"));
+}
+
+#[test]
 fn frr_golden_translation() {
     let imported = import_source(SourceFormat::Frr, "frr.conf", FRR).expect("translates");
     assert_eq!(

--- a/tests/config_import_emitted_check.rs
+++ b/tests/config_import_emitted_check.rs
@@ -66,6 +66,36 @@ fn emitted_configs_pass_rustbgpd_check() {
     }
 }
 
+#[test]
+fn bird_empty_channels_emit_a_daemon_valid_config() {
+    let source = "router id 192.0.2.10;\n\
+                  protocol bgp edge { local as 64500; neighbor 192.0.2.1 as 64500; \
+                  ipv4; ipv6; rr client on; }\n";
+    let imported =
+        import_source(SourceFormat::Bird, "empty-channels.conf", source).expect("import");
+    assert!(
+        imported
+            .config_toml
+            .contains("families = [\"ipv4_unicast\", \"ipv6_unicast\"]")
+    );
+    assert!(!imported.config_toml.contains("route_reflector_client"));
+    assert!(
+        imported.report.skipped.iter().any(|skip| {
+            skip.stanza.ends_with("rr client on")
+                && skip.guidance.contains("route_reflector_client = true")
+        }),
+        "{:?}",
+        imported.report.skipped
+    );
+
+    let (code, stdout, stderr) = run_check(&imported.config_toml);
+    assert_eq!(
+        code,
+        Some(0),
+        "rustbgpd --check rejected the import\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
 /// Fail-closed exit contract: when the emitted config is one the daemon's
 /// `--check` rejects, the import itself must exit nonzero — a clean exit 0
 /// alongside a rejected translation would break the ladder's "operator


### PR DESCRIPTION
## Summary

- preserve statement-form empty BIRD `ipv4;` and `ipv6;` channels in emitted neighbor families
- recognize `rr client on;` and retain the existing explicit manual route-reflector guidance
- prove the generated dual-stack config passes the real daemon `--check` path

## Testing

- `cargo test --locked -p rustbgpctl --test config_import`
- `cargo test --locked --test config_import_emitted_check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`

Linear: https://linear.app/lance0/issue/LAN-951/bird-importer-silently-drops-bare-ipv4ipv6-channel-declarations-and