### PR TITLE
config: warn on legacy RFC 8212 omission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Epoch-less and explicit epoch-1 RFC 8212 policy omission now raises the
+  `rfc8212_secure_default_ready` advisory. It keeps permissive behavior
+  unchanged while spelling out the exact epoch-1/false and epoch-2/true edits;
+  ordinary `--check` warns and exits 0, while `--check --strict` exits 1.
 - Persisted config normalization now serializes large policy-statement lanes in
   bounded borrowed chunks, preserving exact bytes while sharply reducing peak
   memory on the retained 3.2-million-statement receipt.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -535,6 +535,9 @@ Details in the "Recently shipped" section below and ADR-0097.
   (`ebgp_requires_policy`, ADR-0112) is shipped and receipted; the
   typed config-epoch/raw-presence representation, pre-activation rejection,
   full-tuple restart pin, allocation-safe canonical rendering, and transaction-scoped canonical tuple materialization are shipped.
+  The pre-activation `rfc8212_secure_default_ready` advisory is also shipped:
+  legacy omission remains effective `false`, but `--check` now gives both exact
+  operator choices and `--check --strict` gates on that warning.
   ADR-0125 authorizes activation only after ADR-0119's remaining mutation and
   interop proofs pass; activation changes only epoch-2 omission to effective
   `true`. Epoch-less and epoch-1 omission stay permissive, and explicit

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -291,6 +291,7 @@ selected unicast best routes into explicit non-reserved kernel tables.
 asn = 65100
 router_id = "10.255.0.1"
 listen_port = 1179           # non-standard port (edge routers own 179)
+ebgp_requires_policy = false
 
 [global.telemetry]
 prometheus_addr = "127.0.0.1:9179"
@@ -717,6 +718,7 @@ peers in AS 65000 with `families = ["l2vpn_evpn"]` and
 asn = 65000
 router_id = "10.0.0.100"
 cluster_id = "10.0.0.100"
+ebgp_requires_policy = false
 
 [[neighbors]]
 address = "10.0.0.1"

--- a/docs/adr/0119-rfc-8212-secure-default-config-epoch.md
+++ b/docs/adr/0119-rfc-8212-secure-default-config-epoch.md
@@ -22,10 +22,12 @@ authorizes activation only after the production-mutation proof gate below is
 complete. Acceptance itself does not change route handling, activate a new
 default, or supersede ADR-0112 and its M95 real-session receipt.
 
-The representation and transaction-materialization tranches are implemented: typed raw
-presence, pre-activation epoch-2 rejection, full-tuple restart pinning, shared canonical
-rendering, and atomic transaction planning/receipt proofs have landed. The advisory,
-migration/downgrade tooling, M95 extension, and activation remain gated by the proof plan below.
+The representation, transaction-materialization, and legacy-advisory tranches
+are implemented: typed raw presence, pre-activation epoch-2 rejection,
+full-tuple restart pinning, shared canonical rendering, atomic transaction
+planning/receipt proofs, and the human-visible
+`rfc8212_secure_default_ready` warning have landed. Migration/downgrade
+tooling, the M95 extension, and activation remain gated by the proof plan below.
 
 ## Decision
 
@@ -94,6 +96,9 @@ and prints both exact edits: `config_epoch = 1` plus
 This advisory alone leaves ordinary `rustbgpd --check` at exit 0; it contributes
 to the warning count that makes `rustbgpd --check --strict` exit 1. Other
 warnings remain independently counted. Explicit `false` never triggers it.
+
+This pre-activation advisory is now shipped. It changes diagnostics only: no
+default, route behavior, activation gate, schema, or configuration API changed.
 
 ### Reload, transactions, and receipts
 

--- a/docs/cookbook/evpn-fabric-rr.md
+++ b/docs/cookbook/evpn-fabric-rr.md
@@ -29,6 +29,7 @@ asn = 65000
 router_id = "10.0.0.100"
 listen_port = 179
 cluster_id = "10.0.0.100"
+ebgp_requires_policy = false
 
 [global.telemetry]
 prometheus_addr = "127.0.0.1:9179"

--- a/examples/evpn-vtep-leaf/config.toml
+++ b/examples/evpn-vtep-leaf/config.toml
@@ -15,6 +15,7 @@
 asn = 65000
 router_id = "10.0.0.10"
 listen_port = 179
+ebgp_requires_policy = false
 
 [global.telemetry]
 prometheus_addr = "127.0.0.1:9179"

--- a/examples/hosting-provider/config.toml
+++ b/examples/hosting-provider/config.toml
@@ -14,6 +14,7 @@
 asn = 65100
 router_id = "10.255.0.1"
 listen_port = 1179               # Non-standard port — edge routers own 179
+ebgp_requires_policy = false
 
 [global.telemetry]
 prometheus_addr = "127.0.0.1:9179"

--- a/examples/rr-evpn-fabric/config.toml
+++ b/examples/rr-evpn-fabric/config.toml
@@ -19,6 +19,7 @@ asn = 65000
 router_id = "10.0.0.100"
 listen_port = 179
 cluster_id = "10.0.0.100"         # route-reflector cluster identifier
+ebgp_requires_policy = false
 
 [global.telemetry]
 prometheus_addr = "127.0.0.1:9179"

--- a/src/config/tests/grpc_security.rs
+++ b/src/config/tests/grpc_security.rs
@@ -850,6 +850,10 @@ fn tier_grpc_enforcement_does_not_warn() {
     let toml_str = format!(
         "{}\n[security.grpc]\nenforcement = \"tier\"\n\n[security.grpc.roles]\n\"local-admin\" = \"operator\"\n\n[global.telemetry.grpc_uds]\npath = \"/tmp/rustbgpd-test.sock\"\nprincipal = \"local-admin\"\n",
         valid_toml_no_grpc_security()
+    )
+    .replace(
+        "listen_port = 179",
+        "listen_port = 179\nebgp_requires_policy = false",
     );
     let config = parse_strict(&toml_str).unwrap();
     assert!(

--- a/src/config/tests/rfc8212.rs
+++ b/src/config/tests/rfc8212.rs
@@ -68,6 +68,43 @@ fn rfc8212_epoch_two_omission_and_invalid_epochs_fail_closed() {
     }
 }
 
+#[test]
+fn legacy_omission_advisory_is_stable_and_independent_of_policy_completeness() {
+    for epoch in [None, Some("1")] {
+        let config = parse(&rfc8212_representation_toml(epoch, None)).unwrap();
+        let advisory = config
+            .advisories()
+            .into_iter()
+            .find(|advisory| advisory.headline.contains("rfc8212_secure_default_ready"))
+            .expect("legacy omission must raise the readiness advisory");
+        let text = advisory.one_line();
+        for exact in [
+            "source=legacy_omission, effective=false",
+            "RFC 8212 enforcement remains disabled",
+            "missing chains remain permit-all",
+            "config_epoch = 1",
+            "[global].ebgp_requires_policy = false",
+            "config_epoch = 2",
+            "[global].ebgp_requires_policy = true",
+        ] {
+            assert!(text.contains(exact), "missing {exact:?}: {text}");
+        }
+    }
+
+    for epoch in [None, Some("1"), Some("2")] {
+        for explicit in [false, true] {
+            let config = parse(&rfc8212_representation_toml(epoch, Some(explicit))).unwrap();
+            assert!(
+                config
+                    .advisories()
+                    .iter()
+                    .all(|advisory| !advisory.headline.contains("rfc8212_secure_default_ready")),
+                "explicit {explicit} at epoch {epoch:?} must not warn"
+            );
+        }
+    }
+}
+
 /// ADR-0112 restart pinning. Changing only `[global] ebgp_requires_policy` must
 /// classify as restart-required, name the *field* (not just `[global]`) in the
 /// human diff and in the v1 transaction rejection, and leave the running

--- a/src/config/tests/route_server.rs
+++ b/src/config/tests/route_server.rs
@@ -211,6 +211,10 @@ fn orr_vantage_without_linkstate_raises_an_advisory() {
     let toml = orr_toml(
         "orr_vantage = \"192.0.2.7\"\nroute_reflector_client = true",
         "",
+    )
+    .replace(
+        "listen_port = 179",
+        "listen_port = 179\nebgp_requires_policy = false",
     );
     let config = parse(&toml).unwrap();
     let advisory = config
@@ -236,17 +240,25 @@ fn orr_vantage_without_linkstate_raises_an_advisory() {
     assert!(!text.contains('\n'), "one_line kept a newline: {text}");
 
     // Static peer-group inheritance raises the identical final advisory.
-    let inherited = parse(&orr_toml(
+    let inherited_toml = orr_toml(
         "",
         "orr_vantage = \"192.0.2.7\"\nroute_reflector_client = true",
-    ))
-    .unwrap();
+    )
+    .replace(
+        "listen_port = 179",
+        "listen_port = 179\nebgp_requires_policy = false",
+    );
+    let inherited = parse(&inherited_toml).unwrap();
     assert_eq!(inherited.advisories(), vec![advisory]);
 
     // Cleared once a neighbor carries the feed.
     let toml = orr_toml(
         "orr_vantage = \"192.0.2.7\"\nroute_reflector_client = true\nfamilies = [\"ipv4_unicast\", \"linkstate\"]",
         "",
+    )
+    .replace(
+        "listen_port = 179",
+        "listen_port = 179\nebgp_requires_policy = false",
     );
     let config = parse(&toml).unwrap();
     assert!(config.advisories().is_empty(), "{:?}", config.advisories());

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -13,7 +13,7 @@ use super::parse::{
 use super::schema::{
     ManagedBridgeNetdevConfig, ManagedL3VxlanNetdevConfig, ManagedNetdevsConfig,
     ManagedSvdVxlanNetdevConfig, ManagedVlanUpperNetdevConfig, ManagedVrfNetdevConfig,
-    ManagedVxlanNetdevConfig,
+    ManagedVxlanNetdevConfig, Rfc8212PolicySource,
 };
 use super::{
     Config, ConfigError, DEFAULT_HOLD_TIME, EventHistoryConfig, InboundAdmissionConfig, Neighbor,
@@ -1399,6 +1399,17 @@ impl Config {
     /// testable without standing up a subscriber.
     pub(crate) fn advisories(&self) -> Vec<ConfigAdvisory> {
         let mut advisories = Vec::new();
+
+        if self.rfc8212_posture().policy_source == Rfc8212PolicySource::LegacyOmission {
+            advisories.push(ConfigAdvisory {
+                headline: "rfc8212_secure_default_ready: RFC 8212 policy mode is inherited from legacy omission.",
+                detail: "The retained posture is source=legacy_omission, effective=false: RFC 8212 \
+                         enforcement remains disabled and missing chains remain permit-all. Choose \
+                         exactly one explicit posture: set root config_epoch = 1 and \
+                         [global].ebgp_requires_policy = false, or set root config_epoch = 2 and \
+                         [global].ebgp_requires_policy = true.",
+            });
+        }
 
         // RFC 9107 ORR: a vantage without a BGP-LS feed can never resolve.
         // Legal — linkstate peers may be added later — so it warns rather

--- a/tests/check_strict.rs
+++ b/tests/check_strict.rs
@@ -18,6 +18,7 @@ asn = 65001
 router_id = "10.0.0.1"
 listen_port = 179
 runtime_state_dir = "/tmp/rustbgpd-check-strict"
+ebgp_requires_policy = false
 
 [global.telemetry]
 log_format = "json"
@@ -47,6 +48,7 @@ asn = 65001
 router_id = "10.0.0.1"
 listen_port = 179
 runtime_state_dir = "/tmp/rustbgpd-check-strict"
+ebgp_requires_policy = false
 
 [global.telemetry]
 log_format = "json"
@@ -88,6 +90,7 @@ asn = 65001
 router_id = "10.0.0.1"
 listen_port = 179
 runtime_state_dir = "/tmp/rustbgpd-check-strict"
+ebgp_requires_policy = false
 
 [global.telemetry]
 log_format = "json"
@@ -120,6 +123,7 @@ asn = 65001
 router_id = "10.0.0.1"
 listen_port = 179
 runtime_state_dir = "/tmp/rustbgpd-check-strict"
+ebgp_requires_policy = false
 
 [global.telemetry]
 log_format = "json"
@@ -142,6 +146,7 @@ asn = 65001
 router_id = "10.0.0.1"
 listen_port = 179
 runtime_state_dir = "/tmp/rustbgpd-check-strict"
+ebgp_requires_policy = false
 
 [global.telemetry]
 log_format = "json"
@@ -177,6 +182,10 @@ fn run(config_toml: &str, args: &[&str]) -> (Option<i32>, String, String) {
     )
 }
 
+fn legacy_omission(config: &str) -> String {
+    config.replace("ebgp_requires_policy = false\n", "")
+}
+
 fn dynamic_config(enforced: bool, policy_complete: bool) -> String {
     let group_policy = if policy_complete {
         "import_policy = [{ action = \"permit\", prefix = \"0.0.0.0/0\", le = 32 }]\n\
@@ -202,8 +211,8 @@ remote_asn = 0
     );
     if enforced {
         config = config.replacen(
-            "runtime_state_dir = \"/tmp/rustbgpd-check-strict\"",
-            "runtime_state_dir = \"/tmp/rustbgpd-check-strict\"\nebgp_requires_policy = true",
+            "ebgp_requires_policy = false",
+            "ebgp_requires_policy = true",
             1,
         );
     }
@@ -281,6 +290,30 @@ fn check_strict_exits_zero_on_a_clean_config() {
         stdout.contains("config OK"),
         "clean check did not print the OK summary:\n{stdout}"
     );
+}
+
+#[test]
+fn legacy_omission_advisory_obeys_check_and_strict_exit_contract() {
+    let config = legacy_omission(CLEAN);
+    let (code, stdout, stderr) = run(&config, &["--check"]);
+    assert_eq!(code, Some(0), "stdout:\n{stdout}\nstderr:\n{stderr}");
+    assert!(stdout.contains("config VALID, 1 WARNING — NOT a clean check"));
+    assert!(stderr.contains("rfc8212_secure_default_ready"), "{stderr}");
+
+    let (code, stdout, stderr) = run(&config, &["--check", "--strict"]);
+    assert_eq!(code, Some(1), "stdout:\n{stdout}\nstderr:\n{stderr}");
+    assert!(stdout.contains("config VALID, 1 WARNING — NOT a clean check"));
+}
+
+#[test]
+fn unpoliced_legacy_omission_aggregates_two_independent_warnings() {
+    let config = legacy_omission(WARNS);
+    let (code, stdout, stderr) = run(&config, &["--check"]);
+    assert_eq!(code, Some(0), "stdout:\n{stdout}\nstderr:\n{stderr}");
+    assert!(stdout.contains("config VALID, 2 WARNINGS — NOT a clean check"));
+    assert!(stderr.contains("rfc8212_secure_default_ready"), "{stderr}");
+    assert!(stderr.contains("eBGP neighbor"), "{stderr}");
+    assert_eq!(stderr.matches("WARNING:").count(), 2, "{stderr}");
 }
 
 /// A warning raised inside `Config::validate` has to reach the operator.

--- a/tests/daemon_stdout_closed.rs
+++ b/tests/daemon_stdout_closed.rs
@@ -17,6 +17,7 @@ asn = 65001
 router_id = "10.0.0.1"
 listen_port = {port}
 runtime_state_dir = "/tmp/rustbgpd-daemon-stdout-closed"
+ebgp_requires_policy = false
 
 [global.telemetry]
 log_format = "json"

--- a/tests/starter_configs_check_strict.rs
+++ b/tests/starter_configs_check_strict.rs
@@ -94,9 +94,9 @@ fn assert_clean(label: &str, code: Option<i32>, stdout: &str, stderr: &str) {
         code,
         Some(0),
         "{label} does not pass `rustbgpd --check --strict`.\n\
-         A shipped starter must be policy-complete: give every eBGP neighbor \
-         an explicit import and export chain (permit-all is fine when the \
-         comment says it is deliberate).\nstdout:\n{stdout}\nstderr:\n{stderr}"
+         A shipped starter must pin an explicit RFC 8212 posture and give every \
+         eBGP neighbor explicit import and export chains (permit-all is fine when \
+         the comment says it is deliberate).\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
     assert!(
         stdout.contains("config OK"),


### PR DESCRIPTION
## Summary

- emit a stable rfc8212_secure_default_ready advisory when valid epoch-less or epoch-1 configuration inherits the legacy permissive posture
- keep route/default behavior unchanged while giving the exact epoch-1/false and epoch-2/true operator choices
- pin shipped starter configurations to their existing effective false posture and update ADR, roadmap, and changelog state

## Verification

- focused RFC 8212, warning aggregation, starter-config, ORR, gRPC, and daemon-output tests
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- destructive proofs for predicate narrowing/broadening, required operator actions, warning aggregation, and strict starter contracts

Part of LAN-779.