### PR TITLE
feat: add safe site-local route-server policy hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2820,10 +2820,13 @@ name = "rs-config-render"
 version = "0.64.0"
 dependencies = [
  "clap",
+ "rustbgpd-policy",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.11.0",
  "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -18,7 +18,7 @@ This document is the contract for embedders: which crate to depend on, what the
 |---------|---------------|-----------------------------------------|------|
 | `birdwatcher-adapter` | Disabled | `rustbgpd-api` | Birdwatcher-compatible REST adapter backed by the daemon gRPC API. |
 | `event-bridge` | Disabled | `rustbgpd-api` | Reference durable-event collector bridge. |
-| `rs-config-render` | Disabled | None | Route-server configuration rendering tool. |
+| `rs-config-render` | Disabled | `rustbgpd-policy` | Route-server configuration rendering tool. |
 | `rustbgpctl` | Disabled | `rustbgpd-policy`, `rustbgpd-wire` | Thin gRPC management CLI and support library. |
 | `rustbgpd` | Disabled | `rustbgpd-api`, `rustbgpd-bfd`, `rustbgpd-bmp`, `rustbgpd-event-history`, `rustbgpd-evpn`, `rustbgpd-evpn-linux`, `rustbgpd-fsm`, `rustbgpd-mrt`, `rustbgpd-policy`, `rustbgpd-rib`, `rustbgpd-rpki`, `rustbgpd-telemetry`, `rustbgpd-transport`, `rustbgpd-wire` | Daemon binary and internal assembly library. |
 | `rustbgpd-api` | Disabled | `rustbgpd-event-history`, `rustbgpd-evpn`, `rustbgpd-fsm`, `rustbgpd-policy`, `rustbgpd-rib`, `rustbgpd-telemetry`, `rustbgpd-transport`, `rustbgpd-wire` | gRPC server, generated bindings, and service types. |

--- a/docs/adr/0110-irr-peeringdb-filtering-pipeline.md
+++ b/docs/adr/0110-irr-peeringdb-filtering-pipeline.md
@@ -199,7 +199,7 @@ still refuses an untranslated mode.
 | RFC 8950 IPv6 next hop for IPv4 | extended-nexthop (ADR-0037) | Shipped (BIRD-1.x and OpenBGPD lack this) |
 | 16/32-bit ASN community forms, large communities (RFC 8092) | standard/extended/large community model | Shipped |
 | Client blacklists | omit neighbor from generated TOML | Trivial |
-| Operator local-customization hooks (`.local` files) | rpol `import` + `rpol_roots` for policy; **TOML has no include** — the renderer owns the whole TOML and must provide merge-in points itself | Design point for the renderer, not a daemon gap |
+| Operator local-customization hooks (`.local` files) | renderer `--extra-rpol` plus strict `--merge-toml`; exact bytes and hashes in the receipt | Shipped as confined append hooks. Global hooks are expanded into each neighbor, before the generated client deny/import or transparent/BLACKHOLE export base; arbitrary TOML, imported graphs, datasets, parameters, next-hop/AS-prepend changes, community removal/variables, BLACKHOLE-marker synthesis, generated collisions, and unused hooks fail closed before output. |
 
 Summary: the daemon primitives needed for a pilot are shipped except the
 explicitly deferred NEXT_HOP same-AS inventory mode. The renderer remains

--- a/tests/rs_config_render_emitted_check.rs
+++ b/tests/rs_config_render_emitted_check.rs
@@ -10,7 +10,10 @@
 //! warned about for resolving no export policy — the tool taught operators
 //! that the gate they run is noise.
 
-use rs_config_render::{Options, RenderError, render};
+use rs_config_render::{
+    Options, RenderError, SiteLocalFile, SiteLocalInput, render, render_site_local,
+};
+use sha2::{Digest, Sha256};
 
 const FIXTURE: &str = include_str!("../tools/rs-config-render/tests/fixtures/context-small.yml");
 
@@ -19,6 +22,13 @@ fn rtr_options() -> Options {
         rtr_caches: vec!["127.0.0.1:3323".to_owned()],
         ..Options::default()
     }
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
 }
 
 #[test]
@@ -115,8 +125,37 @@ fn emitted_blackhole_policy_passes_rpol_and_daemon_checks() {
     prefix["exact"] = false.into();
     prefix["ge"] = 26.into();
     prefix["le"] = 28.into();
-    let rendered = render(&serde_yaml::to_string(&value).unwrap(), &rtr_options()).unwrap();
+    let policy = b"policy site-tag { term t { add community 65000:42; accept } }";
+    let merge = b"[policy]\nexport_chain=[\"site-tag\"]";
+    let site = SiteLocalInput {
+        merge: SiteLocalFile {
+            source_path: "merge.toml".into(),
+            bytes: merge.to_vec(),
+        },
+        policies: vec![SiteLocalFile {
+            source_path: "site.rpol".into(),
+            bytes: policy.to_vec(),
+        }],
+    };
+    let rendered = render_site_local(
+        &serde_yaml::to_string(&value).unwrap(),
+        &rtr_options(),
+        &site,
+    )
+    .unwrap();
     assert!(rendered.files["config.toml"].contains("set_next_hop = \"192.0.2.66\""));
+    assert!(
+        rendered.files["config.toml"]
+            .contains("export_policy_chain = [\"site-tag\", \"rs-blackhole-export-1\"]")
+    );
+    assert_eq!(
+        rendered.receipt["site_local"]["config_sha256"],
+        sha256(rendered.files["config.toml"].as_bytes())
+    );
+    assert_eq!(
+        rendered.receipt["site_local"]["extra_policies"][0]["emitted_sha256"],
+        sha256(policy)
+    );
     for (path, source) in rendered
         .files
         .iter()

--- a/tools/rs-config-render/Cargo.toml
+++ b/tools/rs-config-render/Cargo.toml
@@ -13,6 +13,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 clap = { workspace = true }
+sha2 = { workspace = true }
+toml = { workspace = true }
+rustbgpd-policy = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -165,12 +165,39 @@ and `EXPECTED_SECTION_NAMES` (`src/lib.rs`).
 --min-prefixes <N>     per-client prefix-set plausibility floor (default 1)
 --min-origins <N>      per-client origin-set plausibility floor (default 1)
 --allow-shape-drift    proceed despite a fingerprint mismatch
+--extra-rpol <PATH>    exact site-local policy bytes; repeatable
+--merge-toml <PATH>    one strict site-local hook file (requires --extra-rpol)
 ```
 
 ## Local customization
 
-The renderer owns the whole output directory — do not hand-edit
-generated files. Site-local policy belongs in a separate `.rpol` file
-appended to the daemon's `[policy] rpol_files` by your own tooling
-after the rsync step, or in a wrapper that post-processes
-`config.toml`; a first-class merge-in point is a tracked follow-up.
+The renderer owns the whole output directory — do not hand-edit generated
+files. Supply one or more site policies together with exactly one merge file:
+
+```console
+rs-config-render --context context.yml --out-dir candidate \
+  --extra-rpol site-global.rpol --extra-rpol site-peer.rpol \
+  --merge-toml site-hooks.toml --rtr-cache 127.0.0.1:3323
+```
+
+```toml
+[policy]
+import_chain = ["site-global-in"]
+export_chain = ["site-global-out"]
+
+[[neighbors]]
+address = "192.0.2.11"
+import_policy_chain = ["site-peer-in"]
+export_policy_chain = ["site-peer-out"]
+```
+
+This is intentionally not arbitrary TOML. Only those hook keys are accepted,
+every hook must name a supplied policy, each final direction chain is unique,
+and every policy must be used. Imports, datasets, parameters, generated-name collisions,
+next-hop changes, AS prepends, community removals or variables, and configured
+BLACKHOLE-marker synthesis are refused. The renderer validates and compiles the
+whole bundle in memory before touching the output directory, emits exact source
+bytes as `policy/site-local-NNN.rpol`, and attests source/emitted/config hashes
+and requested/final chains under `site_local` in the receipt. Generated safety
+always stays final: import is hygiene, global hook, neighbor hook, client deny;
+export is global hook, neighbor hook, then transparent or BLACKHOLE base.

--- a/tools/rs-config-render/src/lib.rs
+++ b/tools/rs-config-render/src/lib.rs
@@ -40,7 +40,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 /// Top-level keys of the supported `template-context` shape, sorted.
 ///
@@ -214,6 +215,55 @@ pub struct Rendered {
     /// part of the deterministic file set).
     pub receipt: serde_json::Value,
     pub warnings: Vec<String>,
+}
+
+/// One exact UTF-8 customization input and its operator-facing source path.
+#[derive(Debug, Clone)]
+pub struct SiteLocalFile {
+    pub source_path: String,
+    pub bytes: Vec<u8>,
+}
+
+/// Strict site-local merge request. At least one policy file is required.
+#[derive(Debug, Clone)]
+pub struct SiteLocalInput {
+    pub merge: SiteLocalFile,
+    pub policies: Vec<SiteLocalFile>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct SitePolicyHooks {
+    #[serde(default)]
+    import_chain: Vec<String>,
+    #[serde(default)]
+    export_chain: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct SiteNeighborHooks {
+    address: String,
+    #[serde(default)]
+    import_policy_chain: Vec<String>,
+    #[serde(default)]
+    export_policy_chain: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct SiteMerge {
+    #[serde(default)]
+    policy: SitePolicyHooks,
+    #[serde(default)]
+    neighbors: Vec<SiteNeighborHooks>,
+}
+
+struct ValidatedSite {
+    merge: SiteMerge,
+    neighbors: BTreeMap<std::net::IpAddr, SiteNeighborHooks>,
+    emitted: Vec<(String, String)>,
+    receipt: serde_json::Value,
 }
 
 // ---------------------------------------------------------------------------
@@ -876,6 +926,23 @@ enum CommunityKind {
 }
 
 pub fn render(context_input: &str, opts: &Options) -> Result<Rendered, RenderError> {
+    render_inner(context_input, opts, None)
+}
+
+/// Render a validated site-local bundle whose compiled effects cannot bypass generated safety.
+pub fn render_site_local(
+    context_input: &str,
+    opts: &Options,
+    site: &SiteLocalInput,
+) -> Result<Rendered, RenderError> {
+    render_inner(context_input, opts, Some(site))
+}
+
+fn render_inner(
+    context_input: &str,
+    opts: &Options,
+    site: Option<&SiteLocalInput>,
+) -> Result<Rendered, RenderError> {
     let mut warnings = Vec::new();
     let (value, found_fingerprint) = if looks_sectioned(context_input) {
         ingest_sectioned(context_input, opts, &mut warnings)?
@@ -908,6 +975,9 @@ pub fn render(context_input: &str, opts: &Options) -> Result<Rendered, RenderErr
         }
     };
 
+    let site = site
+        .map(|input| validate_site_local(&ctx, &resolved, input))
+        .transpose()?;
     let mut files = BTreeMap::new();
     files.insert(
         "policy/rs-hygiene.rpol".to_owned(),
@@ -921,16 +991,372 @@ pub fn render(context_input: &str, opts: &Options) -> Result<Rendered, RenderErr
     }
     files.insert(
         "config.toml".to_owned(),
-        render_toml(&ctx, &resolved, &router_id, &found_fingerprint, opts),
+        render_toml(
+            &ctx,
+            &resolved,
+            &router_id,
+            &found_fingerprint,
+            opts,
+            site.as_ref(),
+        ),
     );
 
-    let receipt = build_receipt(&resolved, &found_fingerprint, &warnings);
+    if let Some(site) = &site {
+        files.extend(site.emitted.iter().cloned());
+    }
+
+    let mut receipt = build_receipt(&resolved, &found_fingerprint, &warnings);
+    if let Some(site) = &site {
+        let mut attestation = site.receipt.clone();
+        attestation["final_neighbors"] = final_neighbor_receipt(&resolved, site);
+        attestation["config_sha256"] = sha256(files["config.toml"].as_bytes()).into();
+        receipt["site_local"] = attestation;
+    }
 
     Ok(Rendered {
         files,
         receipt,
         warnings,
     })
+}
+
+fn validate_site_local(
+    ctx: &Context,
+    clients: &[ResolvedClient<'_>],
+    input: &SiteLocalInput,
+) -> Result<ValidatedSite, RenderError> {
+    use rustbgpd_policy::rpol::RpolFile;
+    use rustbgpd_policy::sets::SetStore;
+
+    let mut refusals = Vec::new();
+    if input.policies.is_empty() {
+        refusals.push("site-local customization requires at least one --extra-rpol".into());
+    }
+    let merge_text = std::str::from_utf8(&input.merge.bytes)
+        .map_err(|error| RenderError::Refused(vec![format!("merge TOML is not UTF-8: {error}")]))?;
+    let merge: SiteMerge = toml::from_str(merge_text)
+        .map_err(|error| RenderError::Refused(vec![format!("invalid merge TOML: {error}")]))?;
+    let mut generated =
+        BTreeSet::from(["rs-hygiene".to_owned(), "rs-transparent-export".to_owned()]);
+    generated.extend(
+        clients
+            .iter()
+            .map(|client| format!("client-{}", client.slug)),
+    );
+    generated.extend(export_policy_names(clients).0.into_values());
+    let mut roster = BTreeSet::new();
+    let mut flattened = BTreeSet::new();
+    let mut emitted = Vec::new();
+    let mut attestations = Vec::new();
+    let forbidden = forbidden_markers(ctx);
+    for (index, source) in input.policies.iter().enumerate() {
+        let text = match std::str::from_utf8(&source.bytes) {
+            Ok(text) => text,
+            Err(error) => {
+                refusals.push(format!("{} is not UTF-8: {error}", source.source_path));
+                continue;
+            }
+        };
+        let file = match RpolFile::parse(text) {
+            Ok(file) => file,
+            Err(error) => {
+                refusals.push(format!(
+                    "{}: imports or invalid RPOL are refused: {error:?}",
+                    source.source_path
+                ));
+                continue;
+            }
+        };
+        if file.dataset_decls().next().is_some() {
+            refusals.push(format!("{}: datasets are refused", source.source_path));
+        }
+        let policies = file
+            .policies()
+            .map(|(name, arity)| (name.to_owned(), arity))
+            .collect::<Vec<_>>();
+        if policies.is_empty() {
+            refusals.push(format!("{}: empty policy roster", source.source_path));
+        }
+        let mut declared = Vec::new();
+        let mut file_flattened = Vec::new();
+        let mut store = SetStore::new();
+        for (name, arity) in policies {
+            declared.push(name.clone());
+            if arity != 0 {
+                refusals.push(format!("{name}: parameters are refused"));
+                continue;
+            }
+            if generated.contains(&name) {
+                refusals.push(format!("{name}: generated policy name collision"));
+            }
+            if !roster.insert(name.clone()) {
+                refusals.push(format!("duplicate policy `{name}` across extra files"));
+            }
+            let Some(compiled) = file.compile_policy_bound(
+                &name,
+                &[],
+                &mut store,
+                &rustbgpd_policy::datasets::DatasetBindings::new(),
+            ) else {
+                unreachable!("policy came from the parsed roster")
+            };
+            let chain = match compiled {
+                Ok(chain) => chain,
+                Err(missing) => {
+                    refusals.push(format!("{name}: datasets are refused: {missing:?}"));
+                    continue;
+                }
+            };
+            for policy in &chain.policies {
+                file_flattened.push(policy.name.as_deref().unwrap_or(&name).to_string());
+            }
+            if let Some(reason) = unsafe_chain(&chain, &forbidden) {
+                refusals.push(format!("{name}: {reason}"));
+            }
+        }
+        flattened.extend(file_flattened.iter().cloned());
+        let emitted_path = format!("policy/site-local-{:03}.rpol", index + 1);
+        let digest = sha256(&source.bytes);
+        attestations.push(serde_json::json!({
+            "source_path": source.source_path,
+            "source_sha256": digest,
+            "emitted_path": emitted_path,
+            "emitted_sha256": digest,
+            "declared_policies": declared,
+            "flattened_policies": file_flattened,
+        }));
+        emitted.push((emitted_path, text.to_owned()));
+    }
+
+    let known_addresses = clients
+        .iter()
+        .filter_map(|client| client.client.ip.parse::<std::net::IpAddr>().ok())
+        .collect::<BTreeSet<_>>();
+    let mut used = BTreeSet::new();
+    validate_hooks(
+        "policy.import_chain",
+        &merge.policy.import_chain,
+        &roster,
+        &generated,
+        &mut used,
+        &mut refusals,
+    );
+    validate_hooks(
+        "policy.export_chain",
+        &merge.policy.export_chain,
+        &roster,
+        &generated,
+        &mut used,
+        &mut refusals,
+    );
+    let mut neighbors = BTreeMap::new();
+    for neighbor in &merge.neighbors {
+        let address = match neighbor.address.parse::<std::net::IpAddr>() {
+            Ok(address) => address,
+            Err(_) => {
+                refusals.push(format!("malformed neighbor address `{}`", neighbor.address));
+                continue;
+            }
+        };
+        if !known_addresses.contains(&address) {
+            refusals.push(format!("unknown neighbor `{address}`"));
+        }
+        if neighbors.insert(address, neighbor.clone()).is_some() {
+            refusals.push(format!("duplicate neighbor `{address}`"));
+        }
+        validate_hooks(
+            "neighbor import",
+            &neighbor.import_policy_chain,
+            &roster,
+            &generated,
+            &mut used,
+            &mut refusals,
+        );
+        validate_hooks(
+            "neighbor export",
+            &neighbor.export_policy_chain,
+            &roster,
+            &generated,
+            &mut used,
+            &mut refusals,
+        );
+        for (direction, global, local) in [
+            (
+                "import",
+                &merge.policy.import_chain,
+                &neighbor.import_policy_chain,
+            ),
+            (
+                "export",
+                &merge.policy.export_chain,
+                &neighbor.export_policy_chain,
+            ),
+        ] {
+            for hook in local.iter().filter(|hook| global.contains(hook)) {
+                refusals.push(format!(
+                    "duplicate hook `{hook}` in final {direction} chain for `{address}`"
+                ));
+            }
+        }
+    }
+    for name in roster.difference(&used) {
+        refusals.push(format!("unused site-local policy `{name}`"));
+    }
+    if !refusals.is_empty() {
+        return Err(RenderError::Refused(refusals));
+    }
+    Ok(ValidatedSite {
+        receipt: serde_json::json!({
+            "merge_source": {"path": input.merge.source_path, "sha256": sha256(&input.merge.bytes)},
+            "extra_policies": attestations,
+            "declared_policy_roster": roster,
+            "flattened_policy_roster": flattened,
+            "requested": merge,
+        }),
+        merge,
+        neighbors,
+        emitted,
+    })
+}
+
+fn validate_hooks(
+    scope: &str,
+    hooks: &[String],
+    roster: &BTreeSet<String>,
+    generated: &BTreeSet<String>,
+    used: &mut BTreeSet<String>,
+    refusals: &mut Vec<String>,
+) {
+    let mut local = BTreeSet::new();
+    for hook in hooks {
+        if !local.insert(hook) {
+            refusals.push(format!("duplicate hook `{hook}` in {scope}"));
+        }
+        if generated.contains(hook) {
+            refusals.push(format!("generated policy hook `{hook}` in {scope}"));
+        } else if roster.contains(hook) {
+            used.insert(hook.clone());
+        } else {
+            refusals.push(format!("unknown policy hook `{hook}` in {scope}"));
+        }
+    }
+}
+
+fn forbidden_markers(ctx: &Context) -> Vec<rustbgpd_policy::CommunityMatch> {
+    let mut markers = vec![rustbgpd_policy::parse_community_match("BLACKHOLE").unwrap()];
+    if let Some(values) = ctx.cfg.communities.get("blackholing") {
+        for value in [&values.std, &values.lrg, &values.ext]
+            .into_iter()
+            .flatten()
+        {
+            let value = if value.matches(':').count() == 2
+                && !value.starts_with("RT:")
+                && !value.starts_with("RO:")
+            {
+                format!("LC:{value}")
+            } else {
+                value.clone()
+            };
+            if let Ok(marker) = rustbgpd_policy::parse_community_match(&value) {
+                markers.push(marker);
+            }
+        }
+    }
+    markers
+}
+
+fn unsafe_chain(
+    chain: &rustbgpd_policy::ir::CompiledChain,
+    forbidden: &[rustbgpd_policy::CommunityMatch],
+) -> Option<&'static str> {
+    chain.policies.iter().find_map(|policy| {
+        match policy.default_action {
+            rustbgpd_policy::PolicyAction::Permit | rustbgpd_policy::PolicyAction::Deny => {}
+        }
+        policy
+            .terms
+            .iter()
+            .find_map(|term| unsafe_term(term, forbidden))
+    })
+}
+
+fn unsafe_term(
+    term: &rustbgpd_policy::ir::Term,
+    forbidden: &[rustbgpd_policy::CommunityMatch],
+) -> Option<&'static str> {
+    use rustbgpd_policy::ir::TermAction;
+    match &term.action {
+        TermAction::Permit(mods) | TermAction::Continue(mods) => unsafe_mods(mods, forbidden),
+        TermAction::CommunityVar { .. } => Some("community variables are refused"),
+        TermAction::ForEach(node) => node
+            .body
+            .iter()
+            .find_map(|term| unsafe_term(term, forbidden)),
+        TermAction::Deny
+        | TermAction::Bind { .. }
+        | TermAction::Break
+        | TermAction::ContinueLoop => None,
+    }
+}
+
+fn unsafe_mods(
+    mods: &rustbgpd_policy::RouteModifications,
+    forbidden: &[rustbgpd_policy::CommunityMatch],
+) -> Option<&'static str> {
+    let rustbgpd_policy::RouteModifications {
+        set_local_pref,
+        set_med,
+        set_next_hop,
+        communities_add,
+        communities_remove,
+        extended_communities_add,
+        extended_communities_remove,
+        large_communities_add,
+        large_communities_remove,
+        as_path_prepend,
+        as_path_prepend_computed,
+        set_local_pref_computed,
+        set_med_computed,
+    } = mods;
+    if !communities_remove.is_empty()
+        || !large_communities_remove.is_empty()
+        || !extended_communities_remove.is_empty()
+    {
+        return Some("community removal is refused");
+    }
+    if set_next_hop.is_some() {
+        return Some("next-hop changes are refused");
+    }
+    if as_path_prepend.is_some() || as_path_prepend_computed.is_some() {
+        return Some("AS prepend is refused");
+    }
+    let _ = (
+        set_local_pref,
+        set_med,
+        set_local_pref_computed,
+        set_med_computed,
+    );
+    let adds_marker = forbidden.iter().any(|marker| {
+        communities_add
+            .iter()
+            .any(|value| marker.matches_standard(*value))
+            || large_communities_add
+                .iter()
+                .any(|value| marker.matches_large(value))
+            || extended_communities_add
+                .iter()
+                .any(|value| marker.matches_ec(value))
+    });
+    adds_marker.then_some("blackhole add/local marker add is refused")
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .fold(String::with_capacity(64), |mut output, byte| {
+            write!(output, "{byte:02x}").expect("writing to String cannot fail");
+            output
+        })
 }
 
 fn check_refusals(ctx: &Context, opts: &Options) -> Result<(), RenderError> {
@@ -1528,6 +1954,7 @@ fn render_toml(
     router_id: &str,
     fingerprint: &str,
     opts: &Options,
+    site: Option<&ValidatedSite>,
 ) -> String {
     let mut out = generated_header("Route-server configuration", fingerprint);
     let cfg = &ctx.cfg;
@@ -1601,19 +2028,7 @@ fn render_toml(
          [policy.definitions.rs-transparent-export]\ndefault_action = \"permit\"\n",
     );
 
-    let mut export_names = BTreeMap::new();
-    let mut client_exports = BTreeMap::new();
-    for rc in clients {
-        if let Some(blackhole) = &rc.blackhole {
-            let key = blackhole_export_key(blackhole);
-            let next = export_names.len() + 1;
-            let name = export_names
-                .entry(key)
-                .or_insert_with(|| format!("rs-blackhole-export-{next}"))
-                .clone();
-            client_exports.insert(rc.slug.clone(), name);
-        }
-    }
+    let (export_names, client_exports) = export_policy_names(clients);
     for (key, name) in &export_names {
         render_blackhole_export_toml(&mut out, name, key);
     }
@@ -1621,6 +2036,11 @@ fn render_toml(
     out.push_str("\n[policy]\nrpol_files = [\n    \"policy/rs-hygiene.rpol\",\n");
     for rc in clients {
         let _ = writeln!(out, "    \"policy/client-{}.rpol\",", rc.slug);
+    }
+    if let Some(site) = site {
+        for (path, _) in &site.emitted {
+            let _ = writeln!(out, "    \"{path}\",");
+        }
     }
     out.push_str("]\nexport_chain = [\"rs-transparent-export\"]\n");
 
@@ -1656,19 +2076,66 @@ fn render_toml(
         if let Some(seconds) = rc.max_prefix_restart_seconds {
             let _ = writeln!(out, "max_prefix_restart_seconds = {seconds}");
         }
-        let _ = writeln!(
-            out,
-            "import_policy_chain = [\"rs-hygiene\", \"client-{}\"]",
-            rc.slug
-        );
-        if let Some(export) = client_exports.get(&rc.slug) {
-            let _ = writeln!(out, "export_policy_chain = [\"{export}\"]");
+        if let Some(site) = site {
+            let base = client_exports
+                .get(&rc.slug)
+                .map_or("rs-transparent-export", String::as_str);
+            let (imports, exports) = site_chains(rc, site, base);
+            write_chain(&mut out, "import_policy_chain", &imports);
+            write_chain(&mut out, "export_policy_chain", &exports);
+        } else {
+            let _ = writeln!(
+                out,
+                "import_policy_chain = [\"rs-hygiene\", \"client-{}\"]",
+                rc.slug
+            );
+            if let Some(export) = client_exports.get(&rc.slug) {
+                let _ = writeln!(out, "export_policy_chain = [\"{export}\"]");
+            }
         }
         if rc.add_path {
             out.push_str("\n[neighbors.add_path]\nsend = true\nsend_max = 8\n");
         }
     }
     out
+}
+
+fn write_chain(out: &mut String, key: &str, chain: &[String]) {
+    let values = chain
+        .iter()
+        .map(|name| format!("\"{}\"", toml_escape(name)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let _ = writeln!(out, "{key} = [{values}]");
+}
+
+fn site_chains(
+    client: &ResolvedClient<'_>,
+    site: &ValidatedSite,
+    export_base: &str,
+) -> (Vec<String>, Vec<String>) {
+    let hooks = client
+        .client
+        .ip
+        .parse::<std::net::IpAddr>()
+        .ok()
+        .and_then(|address| site.neighbors.get(&address));
+    let mut import = vec!["rs-hygiene".to_owned()];
+    import.extend(site.merge.policy.import_chain.iter().cloned());
+    import.extend(
+        hooks
+            .into_iter()
+            .flat_map(|hook| hook.import_policy_chain.iter().cloned()),
+    );
+    import.push(format!("client-{}", client.slug));
+    let mut export = site.merge.policy.export_chain.clone();
+    export.extend(
+        hooks
+            .into_iter()
+            .flat_map(|hook| hook.export_policy_chain.iter().cloned()),
+    );
+    export.push(export_base.to_owned());
+    (import, export)
 }
 
 fn blackhole_export_key(b: &ResolvedBlackhole) -> String {
@@ -1699,6 +2166,25 @@ fn blackhole_export_key(b: &ResolvedBlackhole) -> String {
         b.rewrite_next_hop.as_deref().unwrap_or(""),
         markers
     )
+}
+
+fn export_policy_names(
+    clients: &[ResolvedClient<'_>],
+) -> (BTreeMap<String, String>, BTreeMap<String, String>) {
+    let mut names = BTreeMap::new();
+    let mut clients_by_name = BTreeMap::new();
+    for client in clients {
+        if let Some(blackhole) = &client.blackhole {
+            let key = blackhole_export_key(blackhole);
+            let next = names.len() + 1;
+            let name = names
+                .entry(key)
+                .or_insert_with(|| format!("rs-blackhole-export-{next}"))
+                .clone();
+            clients_by_name.insert(client.slug.clone(), name);
+        }
+    }
+    (names, clients_by_name)
 }
 
 fn render_blackhole_export_toml(out: &mut String, name: &str, key: &str) {
@@ -2204,6 +2690,25 @@ fn unregistered_origin(origins: &[u32]) -> u32 {
 // ---------------------------------------------------------------------------
 // Receipt
 // ---------------------------------------------------------------------------
+
+fn final_neighbor_receipt(
+    clients: &[ResolvedClient<'_>],
+    site: &ValidatedSite,
+) -> serde_json::Value {
+    let (_, client_exports) = export_policy_names(clients);
+    serde_json::Value::Array(
+        clients
+            .iter()
+            .map(|client| {
+                let base = client_exports
+                    .get(&client.slug)
+                    .map_or("rs-transparent-export", String::as_str);
+                let (import, export) = site_chains(client, site, base);
+                serde_json::json!({"address": client.client.ip, "import_policy_chain": import, "export_policy_chain": export})
+            })
+            .collect(),
+    )
+}
 
 fn build_receipt(
     clients: &[ResolvedClient<'_>],

--- a/tools/rs-config-render/src/main.rs
+++ b/tools/rs-config-render/src/main.rs
@@ -8,7 +8,9 @@ use std::process::ExitCode;
 
 use clap::Parser;
 
-use rs_config_render::{Options, render};
+use rs_config_render::{
+    Options, RenderError, SiteLocalFile, SiteLocalInput, render, render_site_local,
+};
 
 #[derive(Parser)]
 #[command(
@@ -36,6 +38,12 @@ struct Cli {
     /// Proceed despite a context-shape fingerprint mismatch
     #[arg(long)]
     allow_shape_drift: bool,
+    /// Exact UTF-8 site-local .rpol source; repeatable and requires --merge-toml
+    #[arg(long = "extra-rpol")]
+    extra_rpol: Vec<PathBuf>,
+    /// Strict site-local hook TOML; exactly one when --extra-rpol is used
+    #[arg(long = "merge-toml")]
+    merge_toml: Vec<PathBuf>,
 }
 
 #[derive(Debug)]
@@ -89,6 +97,17 @@ fn stdout_exit(result: Result<(), StdoutWriteError>) -> ExitCode {
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
+    let customized = !cli.extra_rpol.is_empty() || !cli.merge_toml.is_empty();
+    if customized && (cli.extra_rpol.is_empty() || cli.merge_toml.len() != 1) {
+        eprintln!(
+            "rs-config-render: {}",
+            RenderError::Refused(vec![
+                "customization requires at least one --extra-rpol and exactly one --merge-toml"
+                    .into(),
+            ])
+        );
+        return ExitCode::from(2);
+    }
     let context = match std::fs::read_to_string(&cli.context) {
         Ok(context) => context,
         Err(e) => {
@@ -105,7 +124,31 @@ fn main() -> ExitCode {
         rtr_caches: cli.rtr_cache,
         allow_shape_drift: cli.allow_shape_drift,
     };
-    let rendered = match render(&context, &opts) {
+    let site = customized.then(|| {
+        let read = |path: &PathBuf| {
+            std::fs::read(path)
+                .map(|bytes| SiteLocalFile {
+                    source_path: path.display().to_string(),
+                    bytes,
+                })
+                .map_err(|error| format!("cannot read {}: {error}", path.display()))
+        };
+        Ok::<_, String>(SiteLocalInput {
+            merge: read(&cli.merge_toml[0])?,
+            policies: cli.extra_rpol.iter().map(read).collect::<Result<_, _>>()?,
+        })
+    });
+    let site = match site.transpose() {
+        Ok(site) => site,
+        Err(error) => {
+            eprintln!("rs-config-render: {error}");
+            return ExitCode::from(1);
+        }
+    };
+    let rendered = match site.as_ref().map_or_else(
+        || render(&context, &opts),
+        |site| render_site_local(&context, &opts, site),
+    ) {
         Ok(rendered) => rendered,
         Err(e) => {
             eprintln!("rs-config-render: {e}");

--- a/tools/rs-config-render/tests/site_local.rs
+++ b/tools/rs-config-render/tests/site_local.rs
@@ -1,0 +1,388 @@
+use rs_config_render::{
+    Options, RenderError, SiteLocalFile, SiteLocalInput, render, render_site_local,
+};
+use sha2::{Digest, Sha256};
+
+const FIXTURE: &str = include_str!("fixtures/context-small.yml");
+
+fn healthy_context() -> String {
+    let mut value: serde_yaml::Value = serde_yaml::from_str(FIXTURE).unwrap();
+    value["clients"]
+        .as_sequence_mut()
+        .unwrap()
+        .retain(|client| client["id"].as_str() != Some("AS51325_1"));
+    value["irrdb_info"]
+        .as_mapping_mut()
+        .unwrap()
+        .remove(serde_yaml::Value::String("AS51325_bundle".into()));
+    serde_yaml::to_string(&value).unwrap()
+}
+
+fn opts() -> Options {
+    Options {
+        rtr_caches: vec!["127.0.0.1:3323".into()],
+        ..Options::default()
+    }
+}
+
+fn file(path: &str, source: &str) -> SiteLocalFile {
+    SiteLocalFile {
+        source_path: path.into(),
+        bytes: source.as_bytes().to_vec(),
+    }
+}
+
+fn digest(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn input(merge: &str, policies: &[(&str, &str)]) -> SiteLocalInput {
+    SiteLocalInput {
+        merge: file("merge.toml", merge),
+        policies: policies
+            .iter()
+            .map(|(path, source)| file(path, source))
+            .collect(),
+    }
+}
+
+fn refused(merge: &str, policies: &[(&str, &str)]) -> String {
+    match render_site_local(&healthy_context(), &opts(), &input(merge, policies)) {
+        Err(RenderError::Refused(items)) => items.join("\n"),
+        other => panic!("expected refusal, got {other:?}"),
+    }
+}
+
+#[test]
+fn exact_bytes_chains_and_receipt_are_load_bearing() {
+    assert!(
+        render(&healthy_context(), &opts())
+            .unwrap()
+            .receipt
+            .get("site_local")
+            .is_none(),
+        "the no-flags receipt shape must remain unchanged"
+    );
+    let first = "policy global-deny {\r\n  term stop { reject }\r\n}";
+    let second = "policy peer-tag { term tag { add community 65000:100; accept } }";
+    let merge = r#"
+[policy]
+import_chain = ["global-deny"]
+export_chain = ["peer-tag"]
+
+[[neighbors]]
+address = "192.0.2.11"
+import_policy_chain = ["peer-tag"]
+export_policy_chain = ["global-deny"]
+"#;
+    let rendered = render_site_local(
+        &healthy_context(),
+        &opts(),
+        &input(merge, &[("global.rpol", first), ("peer.rpol", second)]),
+    )
+    .unwrap();
+    assert_eq!(
+        rendered.files["policy/site-local-001.rpol"].as_bytes(),
+        first.as_bytes()
+    );
+    assert_eq!(
+        rendered.files["policy/site-local-002.rpol"].as_bytes(),
+        second.as_bytes()
+    );
+    let config = &rendered.files["config.toml"];
+    assert!(config.contains("\"policy/client-as197000-1.rpol\",\n    \"policy/site-local-001.rpol\",\n    \"policy/site-local-002.rpol\",\n]"));
+    assert!(config.contains(
+        "import_policy_chain = [\"rs-hygiene\", \"global-deny\", \"peer-tag\", \"client-as4242-1\"]"
+    ));
+    assert!(config.contains(
+        "export_policy_chain = [\"peer-tag\", \"global-deny\", \"rs-transparent-export\"]"
+    ));
+    assert!(config.contains(
+        "import_policy_chain = [\"rs-hygiene\", \"global-deny\", \"client-as197000-1\"]"
+    ));
+    assert!(config.contains("export_policy_chain = [\"peer-tag\", \"rs-transparent-export\"]"));
+    assert!(config.contains("export_chain = [\"rs-transparent-export\"]"));
+    let site = &rendered.receipt["site_local"];
+    assert_eq!(site["merge_source"]["path"], "merge.toml");
+    assert_eq!(site["extra_policies"].as_array().unwrap().len(), 2);
+    assert_eq!(
+        site["declared_policy_roster"],
+        serde_json::json!(["global-deny", "peer-tag"])
+    );
+    assert_eq!(
+        site["flattened_policy_roster"],
+        serde_json::json!(["global-deny", "peer-tag"])
+    );
+    for digest in [
+        site["merge_source"]["sha256"].as_str().unwrap(),
+        site["extra_policies"][0]["source_sha256"].as_str().unwrap(),
+        site["extra_policies"][0]["emitted_sha256"]
+            .as_str()
+            .unwrap(),
+        site["config_sha256"].as_str().unwrap(),
+    ] {
+        assert_eq!(digest.len(), 64);
+        assert!(
+            digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        );
+    }
+    assert_eq!(
+        site["extra_policies"][0]["source_sha256"],
+        site["extra_policies"][0]["emitted_sha256"]
+    );
+    assert_eq!(site["merge_source"]["sha256"], digest(merge.as_bytes()));
+    assert_eq!(
+        site["extra_policies"][0]["source_sha256"],
+        digest(first.as_bytes())
+    );
+    assert_eq!(
+        site["extra_policies"][0]["emitted_sha256"],
+        digest(rendered.files["policy/site-local-001.rpol"].as_bytes())
+    );
+    assert_eq!(site["config_sha256"], digest(config.as_bytes()));
+    assert_eq!(
+        site["requested"]["policy"]["import_chain"],
+        serde_json::json!(["global-deny"])
+    );
+    assert_eq!(
+        site["final_neighbors"],
+        serde_json::json!([
+            {"address":"192.0.2.11","import_policy_chain":["rs-hygiene","global-deny","peer-tag","client-as4242-1"],"export_policy_chain":["peer-tag","global-deny","rs-transparent-export"]},
+            {"address":"2001:db8:0:1::22","import_policy_chain":["rs-hygiene","global-deny","client-as197000-1"],"export_policy_chain":["peer-tag","rs-transparent-export"]}
+        ])
+    );
+}
+
+#[test]
+fn blackhole_base_stays_final() {
+    let mut value: serde_yaml::Value = serde_yaml::from_str(&healthy_context()).unwrap();
+    value["cfg"]["blackhole_filtering"]["policy_ipv4"] = "propagate-unchanged".into();
+    let context = serde_yaml::to_string(&value).unwrap();
+    let rendered = render_site_local(
+        &context,
+        &opts(),
+        &input(
+            "[policy]\nexport_chain=[\"tag\"]",
+            &[(
+                "tag.rpol",
+                "policy tag { term t { add community 65000:1; accept } }",
+            )],
+        ),
+    )
+    .unwrap();
+    assert!(
+        rendered.files["config.toml"]
+            .contains("export_policy_chain = [\"tag\", \"rs-blackhole-export-1\"]")
+    );
+}
+
+#[test]
+fn policy_and_merge_refusal_matrix() {
+    let safe = "policy safe { term t { reject } }";
+    let cases = [
+        (
+            "blackhole add",
+            "policy p { term t { add community BLACKHOLE; accept } }",
+        ),
+        (
+            "blackhole add",
+            "policy p { term t { add community 65535:666 } }",
+        ),
+        (
+            "community removal",
+            "policy p { term t { remove community 65000:1; accept } }",
+        ),
+        (
+            "next-hop",
+            "policy p { term t { set next-hop self; accept } }",
+        ),
+        (
+            "AS prepend",
+            "policy p { term t { prepend as 65001 2; accept } }",
+        ),
+        (
+            "AS prepend",
+            "policy p { term t { prepend as self 2; accept } }",
+        ),
+        (
+            "next-hop",
+            "policy helper { term t { set next-hop self; accept } } policy p { term t { if apply(helper) { reject } accept } }",
+        ),
+        (
+            "blackhole add",
+            "asn-set s { 1 } policy p { term t { for a in s { for b in s { add community BLACKHOLE } } accept } }",
+        ),
+        (
+            "community variables",
+            "policy p { term t { for c in route.communities { add community c } accept } }",
+        ),
+        (
+            "imports",
+            "import \"other.rpol\"\npolicy p { term t { reject } }",
+        ),
+        (
+            "datasets",
+            "dataset asn-set d\npolicy p { term t { reject } }",
+        ),
+        (
+            "datasets",
+            "dataset asn-set d\npolicy p { term t { if route.origin-as in d { reject } } }",
+        ),
+        ("parameters", "policy p(n: u32) { term t { reject } }"),
+        ("generated", "policy rs-hygiene { term t { reject } }"),
+    ];
+    for (needle, source) in cases {
+        let message = refused("[policy]\nimport_chain=[\"p\"]", &[("bad.rpol", source)]);
+        assert!(message.contains(needle), "{needle}: {message}");
+    }
+    for (kind, marker, action) in [
+        ("std", "65500:666", "add community 65500:666"),
+        ("lrg", "65500:666:1", "add large-community 65500:666:1"),
+        ("ext", "RT:65000:666", "add ext-community RT:65000:666"),
+        ("ext", "RO:65000:667", "add ext-community RO:65000:667"),
+        (
+            "ext",
+            "RT:192.0.2.1:668",
+            "add ext-community RT:192.0.2.1:668",
+        ),
+    ] {
+        let mut context: serde_yaml::Value = serde_yaml::from_str(&healthy_context()).unwrap();
+        context["cfg"]["communities"]["blackholing"][kind] = marker.into();
+        let source = format!("policy p {{ term t {{ {action}; accept }} }}");
+        let result = render_site_local(
+            &serde_yaml::to_string(&context).unwrap(),
+            &opts(),
+            &input("[policy]\nimport_chain=[\"p\"]", &[("bad.rpol", &source)]),
+        );
+        assert!(
+            matches!(result, Err(RenderError::Refused(ref items)) if items.iter().any(|item| item.contains("local marker add"))),
+            "{kind} {marker}: {result:?}"
+        );
+    }
+    render_site_local(
+        &healthy_context(),
+        &opts(),
+        &input(
+            "[policy]\nimport_chain=[\"p\"]",
+            &[(
+                "safe.rpol",
+                "policy p { term t { set local-pref route.med + 1; set med 10; accept } }",
+            )],
+        ),
+    )
+    .expect("literal and computed local-pref/MED remain confined");
+    let duplicate = refused(
+        "[policy]\nimport_chain=[\"same\"]",
+        &[
+            ("a.rpol", "policy same { term t { reject } }"),
+            ("b.rpol", "policy same { term t { reject } }"),
+        ],
+    );
+    assert!(duplicate.contains("duplicate policy"), "{duplicate}");
+
+    let merges = [
+        (
+            "unknown field `unsafe`",
+            "unsafe = true\n[policy]\nimport_chain=[\"safe\"]",
+        ),
+        ("invalid merge TOML", "[policy"),
+        (
+            "unknown policy hook",
+            "[policy]\nimport_chain=[\"missing\"]",
+        ),
+        ("unused", "[policy]\nimport_chain=[]"),
+        (
+            "duplicate hook",
+            "[policy]\nimport_chain=[\"safe\",\"safe\"]",
+        ),
+        (
+            "malformed neighbor",
+            "[[neighbors]]\naddress=\"not-an-ip\"\nimport_policy_chain=[\"safe\"]",
+        ),
+        (
+            "unknown neighbor",
+            "[[neighbors]]\naddress=\"192.0.2.99\"\nimport_policy_chain=[\"safe\"]",
+        ),
+        (
+            "generated policy",
+            "[policy]\nimport_chain=[\"rs-hygiene\"]",
+        ),
+    ];
+    for (needle, merge) in merges {
+        let message = refused(merge, &[("safe.rpol", safe)]);
+        assert!(message.contains(needle), "{needle}: {message}");
+    }
+    let duplicate_neighbor = refused(
+        "[[neighbors]]\naddress=\"192.0.2.11\"\nimport_policy_chain=[\"safe\"]\n[[neighbors]]\naddress=\"192.0.2.11\"",
+        &[("safe.rpol", safe)],
+    );
+    assert!(
+        duplicate_neighbor.contains("duplicate neighbor"),
+        "{duplicate_neighbor}"
+    );
+    let composed = refused(
+        "[policy]\nimport_chain=[\"safe\"]\n[[neighbors]]\naddress=\"192.0.2.11\"\nimport_policy_chain=[\"safe\"]",
+        &[("safe.rpol", safe)],
+    );
+    assert!(composed.contains("duplicate hook"), "{composed}");
+}
+
+#[test]
+fn cli_flag_and_fail_stale_matrix() {
+    let temp = tempfile::tempdir().unwrap();
+    let context = temp.path().join("context.yml");
+    let merge = temp.path().join("merge.toml");
+    let policy = temp.path().join("site.rpol");
+    std::fs::write(&context, healthy_context()).unwrap();
+    std::fs::write(&merge, "[policy]\nimport_chain=[\"missing\"]").unwrap();
+    std::fs::write(&policy, "policy safe { term t { reject } }").unwrap();
+    for (name, args) in [
+        ("extra-only", vec!["--extra-rpol", policy.to_str().unwrap()]),
+        ("merge-only", vec!["--merge-toml", merge.to_str().unwrap()]),
+        (
+            "repeated-merge",
+            vec![
+                "--extra-rpol",
+                policy.to_str().unwrap(),
+                "--merge-toml",
+                merge.to_str().unwrap(),
+                "--merge-toml",
+                merge.to_str().unwrap(),
+            ],
+        ),
+        (
+            "validation",
+            vec![
+                "--extra-rpol",
+                policy.to_str().unwrap(),
+                "--merge-toml",
+                merge.to_str().unwrap(),
+            ],
+        ),
+    ] {
+        let out = temp.path().join(name);
+        std::fs::create_dir(&out).unwrap();
+        let sentinel = out.join("sentinel");
+        std::fs::write(&sentinel, b"keep\0exact").unwrap();
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_rs-config-render"))
+            .args([
+                "--context",
+                context.to_str().unwrap(),
+                "--out-dir",
+                out.to_str().unwrap(),
+                "--rtr-cache",
+                "127.0.0.1:3323",
+            ])
+            .args(args)
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(2), "{name}: {output:?}");
+        assert_eq!(std::fs::read(&sentinel).unwrap(), b"keep\0exact");
+        assert_eq!(std::fs::read_dir(&out).unwrap().count(), 1, "{name}");
+    }
+}


### PR DESCRIPTION
## Summary

- add repeatable `--extra-rpol` inputs plus a strict `--merge-toml` hook schema to `rs-config-render`
- validate every compiled policy effect and composed neighbor chain before touching output, preserving generated hygiene, deny, and BLACKHOLE export ordering
- preserve extra policy bytes exactly and attest merge, source, emitted, chain, and final config hashes in customized receipts
- keep no-customization output and receipt bytes unchanged

## Validation

- `cargo test --locked -p rs-config-render`
- `cargo clippy --locked -p rs-config-render --all-targets -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --locked -p rs-config-render --no-deps`
- `cargo test --locked --test rs_config_render_emitted_check`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `git diff --check`

Linear: LAN-927