### PR TITLE
docs: correct commit-confirm artifacts, check warnings, and stale figures

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ gRPC request
 | FlowSpec NLRI | `crates/wire/src/flowspec.rs` |
 | FSM state transitions | `crates/fsm/src/lib.rs` |
 | Capability negotiation | `crates/fsm/src/negotiation.rs` |
-| Peer session runtime | `crates/transport/src/session/` (split into `mod.rs`, `fsm.rs`, `inbound.rs`, `outbound.rs`, `io.rs`, `commands.rs`, `writer.rs`, `import_decision_cache.rs`, `rejected_routes.rs`, `export.rs`, `refresh_accounting.rs`, `shared_group.rs`, `tests.rs`) |
+| Peer session runtime | `crates/transport/src/session/` (split into `mod.rs`, `fsm.rs`, `inbound.rs`, `outbound.rs`, `io.rs`, `commands.rs`, `writer.rs`, `import_decision_cache.rs`, `rejected_routes.rs`, `export.rs`, `refresh_accounting.rs`, `shared_group.rs`, `tests/`) |
 | Outbound UPDATE construction | `crates/transport/src/session/outbound.rs` — `prepare_outbound_attributes()` |
 | Policy evaluation | `crates/policy/src/engine.rs` |
 | Best-path selection | `crates/rib/src/best_path.rs` — `best_path_cmp` / `best_path_cmp_with_reason` |
@@ -249,6 +249,14 @@ gRPC request
 ## Lifecycle Flows
 
 ### Startup
+
+Every Unix signal handler (SIGINT, SIGTERM, SIGHUP) is registered before any
+step below binds or spawns an externally reachable service — the gRPC server,
+the BGP listener, the metrics/readiness listener, or gNMI dial-out. A signal
+delivered during startup stays pending until the select loop begins, so a
+SIGTERM in that window is retained and honored as a graceful shutdown instead
+of taking its default process action. The ordering is a contract, asserted by
+`signal_handlers_are_registered_before_external_reachability`.
 
 1. `main.rs` loads TOML config, validates, initializes logging and metrics.
 2. Checks for GR restart marker file (`runtime_state_dir/gr-restart.toml`). If present and not expired, static peers will advertise `R=1` in OPEN.
@@ -329,13 +337,22 @@ gRPC request
    pending confirmation, other persisted runtime config mutators return
    `FAILED_PRECONDITION`.
 5. Commit-confirm survives a restart durably (ADR-0076 Decision 6 amendment).
-   The pre-commit snapshot is journaled to
-   `<runtime_state_dir>/commit-confirm-journal.json` before the candidate
-   commits. A daemon restart inside the confirm window triggers a boot-time
-   revert (`boot_revert_check()`, per RFC 6241 §8.4): the pre-transaction
-   config is restored and the unconfirmed candidate is saved aside as
-   `<config>.unconfirmed`. A torn or unusable journal refuses boot rather than
-   guessing. See `tests/commit_confirm_binary.rs`.
+   Before the candidate commits, the v3 authority is published in durability
+   order: the normalized pre-commit snapshot to
+   `<runtime_state_dir>/commit-confirm-v3-prior.toml`, then provenance and
+   file-identity digests to `<runtime_state_dir>/commit-confirm-v3-metadata.json`,
+   then the config-adjacent `<config>.commit-confirm-locator.json`. The locator
+   is the sole boot authority — its absence carries no pending state, so a
+   restart that finds no locator boots the candidate normally. A daemon restart
+   inside the confirm window triggers a boot-time revert
+   (`boot_revert_check()`, per RFC 6241 §8.4): the pre-transaction config is
+   restored and the unconfirmed candidate is saved aside as
+   `<config>.unconfirmed`. Torn or unusable v3 state refuses boot rather than
+   guessing, and so does a retired locator-free
+   `<runtime_state_dir>/commit-confirm-journal.json` or retired v2 locator —
+   both are left untouched for recovery with rustbgpd v0.64.0. Never create
+   either retired artifact by hand; their presence alone blocks startup. See
+   `tests/commit_confirm_binary.rs`.
 
 ### Graceful Shutdown
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   with inspect-before-retry guidance.
   (LAN-779)
 
+- `rs-config-render` now accepts confined site-local policy hooks: `--extra-rpol
+  PATH` (repeatable, exact UTF-8 `.rpol` bytes) together with exactly one
+  `--merge-toml PATH` strict hook file. Only `[policy]` and `[[neighbors]]` hook
+  keys are accepted, every hook must name a supplied policy, each final
+  direction chain is unique, and every supplied policy must be used. Imports,
+  datasets, parameters, generated-name collisions, next-hop changes, AS
+  prepends, community removals or variables, and BLACKHOLE-marker synthesis are
+  refused. The whole bundle validates and compiles in memory before the output
+  directory is touched; emitted bytes land as `policy/site-local-NNN.rpol`, and
+  the receipt attests source/emitted/config hashes plus requested and final
+  chains under `site_local`. Generated safety stays final.
 - `rs-config-render` now translates ARouteServer IPv4/IPv6 blackhole policies
   into explicit import and per-client export policy. Authorized marked
   more-specifics use IRR origin plus covering-prefix checks, local marker forms
@@ -62,7 +73,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   config and mask. Field 1/name `config` are reserved; custom clients must
   move the former top-level config under `intent` and mask each selected
   supported override (an empty present mask means no overrides).
-- `rbgp rib diff advertised` now requires `page_version` on every live page
+- `rbgp diff advertised` now requires `page_version` on every live page
   and uses `med_attr` as the sole MED-presence authority. Daemons through
   v0.62 now fail with upgrade guidance instead of using the single-peer and
   bare-MED fallbacks; BIRD, GoBGP, and MRT snapshots preserve explicit MED 0.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -113,14 +113,19 @@ resolved.
   (resolved).** The confirm timer and the pre-commit rollback snapshot used to
   be held in memory only, so a restart inside the confirm window left the
   already-committed candidate live (confirmed-by-restart) and the auto-revert
-  never fired. The daemon now journals the pre-commit config snapshot to
-  `<runtime_state_dir>/commit-confirm-journal.json` (atomic write) before the
-  candidate commits; a restart that finds an unconfirmed journal reverts to
-  the journaled config at boot — regardless of remaining confirm time, since
+  never fired. The daemon now publishes the pre-commit config snapshot to
+  `<runtime_state_dir>/commit-confirm-v3-prior.toml` plus
+  `commit-confirm-v3-metadata.json`, with the config-adjacent
+  `<config>.commit-confirm-locator.json` as the sole boot authority, before the
+  candidate commits; a restart that finds a live locator reverts to the
+  recorded prior snapshot at boot — regardless of remaining confirm time, since
   the confirming session died with the old process (NETCONF RFC 6241 §8.4
   cancel-on-session-loss semantics) — saving the unconfirmed candidate aside
-  as `<config>.unconfirmed`. A torn or unusable journal refuses boot naming
-  both files. Proven by SIGKILL-mid-window real-binary tests
+  as `<config>.unconfirmed`. Torn or unusable v3 state refuses boot naming the
+  files, as does a retired locator-free
+  `<runtime_state_dir>/commit-confirm-journal.json` or retired v2 locator —
+  each is left untouched, and only rustbgpd v0.64.0 can recover it. Proven by
+  SIGKILL-mid-window real-binary tests
   (`tests/commit_confirm_binary.rs`). See ADR-0076 Decision 6 amendment.
 
 - **Implicit LOCAL_PREF/MED policy defaults (resolved).** Policy matches now

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ config from their existing `general.yml`/`clients.yml`:
   (`[policy.explain] enabled = true`), because it retains a decision cache
   per session ([docs/explain.md](docs/explain.md))
 - **Update-group fanout** — peers with provably identical staged output share
-  one staging pass: ~28x faster 100k-route convergence at 256 uniform RR
-  clients (15.1 s to 0.54 s); v2 extends sharing to VPNv4/v6 with per-member
+  one staging pass: ~27x faster 100k-route convergence at 256 uniform RR
+  clients (15.1 s to 0.56 s); v2 extends sharing to VPNv4/v6 with per-member
   RT filtering at emit ([receipt](docs/perf/scale-receipt-2026-07.md))
 - **Full BMP monitoring trio** — per-collector Adj-RIB-In / Adj-RIB-Out
   (byte-exact wire PDUs) / Loc-RIB on one exporter, validated against pmacct,
@@ -179,7 +179,8 @@ fanout numbers — is the [feature tour](docs/feature-tour.md).
 - **SDN / network automation controllers** — programmable BGP control plane
 - **Route collectors and looking glasses** — structured data via gRPC, MRT, BMP,
   plus a Birdwatcher-shaped status/peer/accepted/filtered/noexport subset via
-  the external `examples/birdwatcher-adapter`
+  the shipped `birdwatcher-adapter` binary (`examples/birdwatcher-adapter`
+  carries the source and deployment notes)
 - **Lab and test environments** — clean API, structured logs, containerlab interop
 
 See [docs/USE_CASES.md](docs/USE_CASES.md) for detailed deployment scenarios with
@@ -234,7 +235,10 @@ Four binaries: the daemon, the `rbgp` CLI, `rs-config-render` (the
 [IXP route-server config renderer](tools/rs-config-render/README.md) —
 harmless if you don't run one), and the optional Alice-LG
 `birdwatcher-adapter`. The tarball also carries man pages and
-bash/zsh/fish completions under `share/` — the
+bash/zsh/fish completions under `share/`, plus the version-matched Grafana
+dashboard, Prometheus alert rules, and promtool test suite under
+`share/monitoring/` (`/usr/share/doc/rustbgpd/monitoring/` after a
+`.deb`/`.rpm` install) — the
 [install walkthrough](docs/deployment.md#install) covers installing those
 and pinning a specific version.
 
@@ -251,7 +255,7 @@ cargo build --release -p rustbgpd -p rustbgpctl -p rs-config-render -p birdwatch
 ### Docker
 
 Release images are published to GHCR (versioned tags, e.g.
-`ghcr.io/lance0/rustbgpd:0.61.0`), or build locally:
+`ghcr.io/lance0/rustbgpd:0.64.0`), or build locally:
 
 ```bash
 docker build -t rustbgpd .                    # daemon + rbgp + birdwatcher-adapter, nonroot
@@ -289,22 +293,22 @@ two independent campaign runs, losses published alongside wins:
 
 | KPI (700 clients × 400,400 routes, p50) | rustbgpd | BIRD 3.3.1 | OpenBGPD 9.1 |
 |---|---|---|---|
-| Sessions Established | **0.7 s** | 18.4–20.8 s | 66.7–155.7 s |
-| Cold start, full table to all members | **4.7–5.0 s** | 61.6–65.3 s | 338.8–422.1 s |
-| Reload: UPDATE stall | 0.42–0.73 s | 1.74–2.68 s | **0.24–0.28 s** |
-| Reload: new policy fully delivered | **1.29–1.67 s** | 68–85 s | 247–253 s |
-| Flapstorm: withdraw propagation | **0.25–0.48 s** | 0.38–0.57 s | 10.3–12.6 s |
-| Flapstorm: re-announce | **0.46–0.49 s** | 2.7–3.7 s | 20.9–21.4 s |
-| Settled RSS (S2, runs A/B) | **412 / 410 MiB** | 425 / 417 MiB | 768 / 773 MiB |
-| Settled RSS (S3, runs A/B) | 440 / 502 MiB | **337 / 292 MiB** | 824 / 821 MiB |
+| Sessions Established | **0.7 s** | 18.2–20.5 s | 68.9–85.8 s |
+| Cold start, full table to all members | **4.8–5.0 s** | 60.9–63.3 s | 338.0–352.1 s |
+| Reload: UPDATE stall | 0.42–0.60 s | 1.70–2.70 s | **0.25–0.29 s** |
+| Reload: new policy fully delivered | **1.28–1.57 s** | 64.3–84.5 s | 244.0–251.3 s |
+| Flapstorm: withdraw propagation | **0.31–0.47 s** | 0.47–0.61 s | 10.45–11.47 s |
+| Flapstorm: re-announce | **0.49–0.55 s** | 2.85–3.74 s | 21.14–21.54 s |
+| Settled RSS (S2, runs A/B) | 419 / 419 MiB | 422 / 412 MiB | 756 / 753 MiB |
+| Settled RSS (S3, runs A/B) | 441 / 451 MiB | **337 / 328 MiB** | 813 / 815 MiB |
 
-Figures are the v0.61.0 same-host refresh (2026-07-27); the original
+Figures are the v0.64.0 same-host refresh (2026-08-08); the original
 campaign's tables and artifacts are preserved unchanged in the receipt.
 rustbgpd is the only daemon in the matrix holding both a sub-second median
 stall **and** single-digit-seconds completion; OpenBGPD has the smallest
-stall at every scale rung; the settled-memory picture is split — rustbgpd
-edged BIRD at S2 in these runs after the explain-cache default change,
-while BIRD's S3 advantage remains clear. The receipt includes the full
+stall at every scale rung; the settled-memory picture is split — S2 settled
+RSS is a dead heat (one run each way), while BIRD's S3 advantage remains
+clear. The receipt includes the full
 method, configuration disclosure, honesty notes, raw artifacts — and a
 post-publication note where the receipt's own tables exposed a rustbgpd
 re-announce plateau that was root-caused, fixed, and rerun (9.5–9.8 s →

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,8 +58,8 @@ input from the network. It runs under continuous fuzzing in CI.
   v3 in durability order: secret-bearing normalized configuration at
   `<runtime_state_dir>/commit-confirm-v3-prior.toml`, confidential provenance
   and file-identity metadata at `commit-confirm-v3-metadata.json`, then the
-  confidential config-adjacent `commit-confirm-locator.json`. Metadata and the
-  locator contain paths and digests, not raw TOML; the locator is the sole boot
+  confidential config-adjacent `<config>.commit-confirm-locator.json`. Metadata
+  and the locator contain paths and digests, not raw TOML; the locator is the sole boot
   authority. All are bounded daemon-owned regular `0600` files, and a writer or
   present pending object requires daemon-owned real parents that are not group-
   or world-writable. Reads are descriptor-relative, no-follow, same-FD
@@ -110,10 +110,11 @@ see the full ~16,000-ASN path.
 
 ### Fuzzing
 
-Four fuzz crates (`crates/wire`, `crates/policy`, `crates/mrt`,
-`crates/evpn`) carry 17 fuzz targets covering the message decoders, the
-policy frontend, MRT snapshot and warm-bundle readers, and EVPN parsing.
-A nightly CI campaign (`.github/workflows/fuzz.yml`) runs every target
+Six fuzz crates (`crates/wire`, `crates/policy`, `crates/mrt`,
+`crates/evpn`, `crates/bfd`, `crates/rpki`) carry 19 fuzz targets covering
+the message decoders, the policy frontend, MRT snapshot and warm-bundle
+readers, EVPN parsing, the BFD control-packet decoder, and the RTR PDU
+decoder. A nightly CI campaign (`.github/workflows/fuzz.yml`) runs every target
 in each crate against tracked seed corpora and fails loudly if target
 enumeration returns nothing. A ClusterFuzzLite workflow builds all
 targets with AddressSanitizer for on-demand campaigns. The target

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -137,6 +137,12 @@ Epoch 2 currently requires the boolean to be written explicitly as `true` or
 with the exact edit required. Explicit booleans retain their value in either
 epoch.
 
+Leaving the posture at legacy omission has one operator-visible consequence:
+every `rustbgpd --check` raises the `rfc8212_secure_default_ready` advisory,
+which exits 0 ordinarily and exits 1 under `--strict`. It fires on the
+omission alone, however well policed the config is; writing an explicit epoch
+plus boolean pair clears it.
+
 Daemon-written canonical config, applied history, runtime snapshot tokens, and
 effective config output materialize the effective epoch plus the effective
 boolean: omission becomes `config_epoch = 1`, while an explicit epoch 2 remains
@@ -488,7 +494,10 @@ unfiltered. It stays a warning — a permit-all route server is a legitimate
 configuration — but a check with warnings summarizes as `config VALID, <n>
 WARNINGS — NOT a clean check` rather than `config OK`. The exit code is 0
 either way; add `--strict` (see [deployment.md](deployment.md)) to make any
-warning exit 1 in a CI or deployment gate. `rbgp config import` sets the knob
+warning exit 1 in a CI or deployment gate. A config that omits the knob
+entirely also raises the separate `rfc8212_secure_default_ready` advisory
+described under [`config_epoch`](#config_epoch), which the same `--strict`
+gate counts. `rbgp config import` sets the knob
 in every config it generates,
 since it never translates policy; its report says so. Every shipped starter —
 both `--init-config` profiles and every config under `examples/` — sets it too
@@ -521,12 +530,14 @@ Every affected peer is checked before any peer is modified, and one
 unqualified peer rejects the whole edit:
 
 - an Established peer that never negotiated RFC 2918 Route Refresh is
-  rejected. Clear the session (`rbgp neighbor clear <addr>`) or let it
+  rejected. Bounce the session (`rbgp neighbor <addr> disable --reason
+  "rfc8212 policy transition"` then `rbgp neighbor <addr> enable`) or let it
   reconnect — it relearns everything under the new chain — then reapply.
 - a peer that is down while the RIB still holds its graceful-restart or
   long-lived-graceful-restart stale routes is deferred, so those routes stay
   paired with the verdict they were accepted under. Retry once retention
-  expires, or clear the peer to purge them.
+  expires, or bounce the peer with the same `disable` / `enable` pair to purge
+  them.
 - a peer whose session cannot report its state in time is rejected rather than
   guessed at; retry the edit.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -75,11 +75,22 @@ Prints rustc-style diagnostics on error, or `config OK` on success.
 A valid config can still be worth flagging. When it is, the summary reads
 `config VALID, <n> WARNINGS — NOT a clean check` instead of `config OK`,
 the warnings are framed on stderr above it, and the exit code stays 0 —
-these are things to look at, not failures. Today this means a configured eBGP
-neighbor or dynamic range with no explicit policy in a direction: unfiltered with
-`[global] ebgp_requires_policy` off, carrying no routes in that direction
-with it on. Both are legitimate configurations; neither should reach
-production unnoticed.
+these are things to look at, not failures. Three conditions are counted today:
+
+1. a configured eBGP neighbor or dynamic range with no explicit policy in a
+   direction — unfiltered with `[global] ebgp_requires_policy` off, carrying no
+   routes in that direction with it on;
+2. `rfc8212_secure_default_ready` — the RFC 8212 posture is still inherited
+   from legacy omission. It clears by writing an explicit pair: root
+   `config_epoch = 1` with `[global] ebgp_requires_policy = false`, or
+   `config_epoch = 2` with `ebgp_requires_policy = true`;
+3. `orr_vantage` configured while no neighbor negotiates the `linkstate`
+   family, so the optimal-route-reflection topology feed stays empty.
+
+All are legitimate configurations and none is rejected; none should reach
+production unnoticed. Note that (2) fires on the omission alone, however well
+policed the config is — a `--strict` gate on an epoch-less config exits 1 for
+that reason and no other.
 
 Add `--strict` to make any warning exit 1 instead of 0
 (`rustbgpd --check --strict /etc/rustbgpd/config.toml`) — for CI and
@@ -564,6 +575,13 @@ only; it cannot inspect `runtime_state_dir` or config-adjacent commit-confirm
 authority. If retired authority remains or is inaccessible, recover it with
 exactly rustbgpd v0.64.0. Delete it only after proving the transaction is
 terminal and the current config is intended.
+
+Moving a config between RFC 8212 epochs is a separate, offline step:
+`rustbgpd --migrate-config pin-legacy|prepare-secure|downgrade-v0.64 --offline
+[--dry-run] CONFIG_PATH` rewrites the posture representation in place. Stop or
+quiesce the daemon first — `--offline` is an operator assertion, not a daemon
+probe — and see [`CONFIGURATION.md`](CONFIGURATION.md) → `config_epoch` for
+what each action writes.
 
 When Graceful Restart is enabled (the default), a coordinated stop writes a GR
 restart marker. On the next start, the daemon advertises `R=1` to static peers,

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -196,13 +196,16 @@ Mitigations, in preference order:
 - Keep the loopback default, or bind the adapter to a management network,
   and put an authenticating reverse proxy in front of it before any wider
   exposure — the same network-level discipline as Prometheus.
-- Point the adapter at a dedicated gRPC listener and cap it:
-  `ListRejectedRoutes` and the noexport view's backing RPCs
-  (`ListBestRoutes`, `ListAdvertisedRoutes`, `ExplainAdvertisedRoute`) are
-  all `sensitive_read`-tier methods — the noexport view raises no tier
-  requirement beyond what the adapter already needed — so `max_tier =
-  "read"` on that listener denies both the filtered and noexport views
-  while keeping liveness reads working.
+- Do not expect a listener tier cap to help here. `ListRejectedRoutes` and
+  the noexport view's backing RPCs (`ListBestRoutes`,
+  `ListAdvertisedRoutes`, `ExplainAdvertisedRoute`) are all
+  `sensitive_read`-tier methods — the same tier the adapter's other reads
+  need — so no `max_tier` value denies the filtered and noexport views while
+  leaving the rest of the adapter working. `max_tier = "read"` denies every
+  RPC, because no method carries the `read` tier (see
+  [`grpc-method-inventory.md`](grpc-method-inventory.md)); even `GetHealth`
+  is `sensitive_read`. A dedicated listener is still worth having, but for
+  the network isolation and separate credentials, not for tier filtering.
 - Disable retention daemon-side with `[policy.reject_retention]
   enabled = false`: the reject store is never populated and the filtered
   view is served empty as a configuration fact.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -595,11 +595,14 @@ scaling out.
    A check that finds nothing to flag prints `config OK`. A check that
    flags something still exits 0, but the summary reads
    `config VALID, <n> WARNINGS — NOT a clean check` and the warnings are
-   framed on stderr above it. The warning identifies a configured eBGP neighbor
-   or dynamic range with no explicit policy in a direction: unfiltered when
-   `[global] ebgp_requires_policy` is off, and carrying no routes in that
-   direction when it is on. Neither is rejected — a permit-all route
-   server is a legitimate configuration — but neither should reach
+   framed on stderr above it. The warnings identify: a configured eBGP neighbor
+   or dynamic range with no explicit policy in a direction (unfiltered when
+   `[global] ebgp_requires_policy` is off, carrying no routes in that
+   direction when it is on); an RFC 8212 posture still inherited from legacy
+   omission (`rfc8212_secure_default_ready` — set an explicit root
+   `config_epoch` plus `[global] ebgp_requires_policy`); and an `orr_vantage`
+   with no `linkstate`-negotiating neighbor. None is rejected — a permit-all
+   route server is a legitimate configuration — but none should reach
    production unnoticed.
 
 4. **First start.**
@@ -669,6 +672,7 @@ These cover the config lifecycle, from bootstrap to reload:
 | `rustbgpd --init-config <lab\|edge> --stdout` | Print a curated, commented starter TOML to stdout and exit (file output is not yet supported). `lab` is a minimal single-box profile; `edge` is an eBGP edge skeleton with a default-route-dropping import chain and a default-deny export chain to fill in. Both use a mode-`0600` local UDS whose filesystem permissions authenticate access and whose stable `operator` principal is tier-authorized, set `[global] ebgp_requires_policy = true`, and pass `--check --strict` as emitted. Cannot be combined with `--check` / `--diff`. |
 | `rustbgpd --check <file>` | Parse + validate; print `config OK`, `config VALID, <n> WARNINGS — NOT a clean check` (warnings framed on stderr; still exit 0), or a rustc-style diagnostic (exit 1). Does not start the daemon. |
 | `rustbgpd --check --strict <file>` | The same check, but any warning exits 1 instead of 0 — for CI and deployment gates that must not accept a valid-but-risky config. A clean check still exits 0. `--strict` without `--check` is an error (exit 2). |
+| `rustbgpd --migrate-config <pin-legacy\|prepare-secure\|downgrade-v0.64> --offline [--dry-run] <file>` | Rewrite the RFC 8212 posture representation in place, offline (Linux only). `pin-legacy` writes epoch 1 + explicit `false`; `prepare-secure` writes epoch 2 + explicit `true`; `downgrade-v0.64` preserves the effective boolean, removes the epoch, and requires `--validator` naming an exact v0.64.0 binary. `--dry-run` performs the same validation proof and discards the stage. `--offline` is an operator assertion, not a daemon probe — stop or quiesce the daemon first. |
 | `rustbgpd --diff <candidate> [<current>]` | Compare a candidate file against the current on-disk config (`<current>` defaults to `/etc/rustbgpd/config.toml`); print per-section change list with expected reload class. This is a static file-vs-file compare — to compare against the running daemon's view, use `rbgp config diff`. |
 | `systemctl reload rustbgpd` (or `kill -HUP $(pidof rustbgpd)`) | Apply the diff. Live fields hot-apply; restart-required fields are pinned and logged at `ERROR` (the live values are kept). |
 
@@ -858,9 +862,13 @@ therefore own the graceful stop and the verification that follows it.
      /etc/rustbgpd/config.toml
    ```
 
-   Fix every error before proceeding. There is no in-place schema migration
-   tool; make release-note field renames in the config by hand, then repeat the
-   candidate check.
+   Fix every error before proceeding. There is no general schema-migration
+   tool; make release-note field renames by hand, then repeat the candidate
+   check. The one exception is the RFC 8212 posture representation, which
+   `rustbgpd --migrate-config pin-legacy|prepare-secure|downgrade-v0.64
+   --offline [--dry-run] CONFIG_PATH` rewrites in place (see
+   [`CONFIGURATION.md`](CONFIGURATION.md) → `config_epoch`); stop or quiesce
+   the daemon first — `--offline` is an operator assertion, not a daemon probe.
    This check validates candidate config bytes only: it does **not** inspect
    `runtime_state_dir` or config-adjacent commit-confirm authority.
 
@@ -1001,7 +1009,7 @@ operations via gRPC persist back to the config file (see
 
 ## Sample profiles
 
-The repo ships nine config profiles under
+The repo ships ten config profiles under
 [`examples/`](../examples/) covering the standard deployment
 shapes. Pick the closest match, copy, edit:
 
@@ -1009,6 +1017,7 @@ shapes. Pick the closest match, copy, edit:
 |---|---|---|
 | Minimal | [`examples/minimal/config.toml`](../examples/minimal/config.toml) | Single eBGP peer; dev-friendly, state in `/tmp`. |
 | IX route server | [`examples/route-server/config.toml`](../examples/route-server/config.toml) | RPKI, Add-Path, dual-stack, per-member policy chains. |
+| MANRS IXP Action 1 | [`examples/manrs-action1/config.toml`](../examples/manrs-action1/config.toml) | Route server with RPKI-invalid rejection and IRR-derived member filtering; walkthrough in [`cookbook/manrs-ixp-action1.md`](cookbook/manrs-ixp-action1.md). |
 | Fabric edge / Linux FIB | [`examples/linux-edge-fib/config.toml`](../examples/linux-edge-fib/config.toml) | FIB integration on configured unicast tables; ECMP, weighted multipath. |
 | EVPN VTEP leaf | [`examples/evpn-vtep-leaf/config.toml`](../examples/evpn-vtep-leaf/config.toml) | Bidirectional VTEP: kernel FDB → Type 2 origination. |
 | EVPN RR fabric | [`examples/rr-evpn-fabric/config.toml`](../examples/rr-evpn-fabric/config.toml) | Route Reflector mode, stateless EVI (no `[[evpn_instances]]`). |


### PR DESCRIPTION
Documentation accuracy pass over the top-level operator surface. Every claim
was re-derived from HEAD source before editing; findings that did not hold up
were left alone.

## Correctness fixes an operator could act on

**Commit-confirm artifacts (ARCHITECTURE.md, KNOWN_ISSUES.md).** Both pages
said the daemon journals the pre-commit snapshot to
`<runtime_state_dir>/commit-confirm-journal.json`. On HEAD that is the retired
v1/v2 authority, and `refuse_retired_journal()` (`src/confirm_journal.rs:43`)
makes its mere presence refuse boot. An operator inspecting or hand-creating
that path was being pointed at the one file that blocks startup. Both pages now
describe the v3 model derived from `src/confirm_journal/v3.rs`: publication in
durability order (`commit-confirm-v3-prior.toml`, then
`commit-confirm-v3-metadata.json`, then the config-adjacent
`<config>.commit-confirm-locator.json`), the locator as the sole boot
authority, the boot revert that saves the candidate aside as
`<config>.unconfirmed`, and the fact that a retired locator-free journal or
retired v2 locator is refused untouched for recovery with v0.64.0.

**`rbgp neighbor clear` does not exist (docs/CONFIGURATION.md).** The RFC 8212
policy-presence-transition remediation handed operators a command that fails.
`NeighborAction` carries only `Add`, `Delete`, `Enable`, `Disable`,
`Softreset`, `RefreshOut`. Replaced with the supported disable/enable bounce.

**`max_tier = "read"` serves nothing (docs/SECURITY.md).** The birdwatcher
adapter mitigation claimed a `read` cap denies the filtered and noexport views
while keeping liveness reads working. No method carries the `read` tier
(`method_count_by_tier(AuthTier::Read) == 0`; `GetHealth` is `sensitive_read`),
so that listener denies every RPC. The bullet now states what a tier cap can
and cannot separate.

**`--check` warning set (docs/OPERATIONS.md, docs/deployment.md).** Both pages
enumerated only unpoliced eBGP. `check_warnings()` also sums
`Config::advisories()`, adding `rfc8212_secure_default_ready` and the
`orr_vantage`-without-`linkstate` advisory. Confirmed empirically: a clean
starter exits 0 under `--check --strict`, while the same config with
`[global] ebgp_requires_policy` removed exits 1 on the advisory alone.

**`--migrate-config` (docs/deployment.md, docs/OPERATIONS.md).** The v0.64 →
v0.65 upgrade procedure asserted there is no in-place migration tool. The
offline RFC 8212 posture migration ships in this cycle; the statement is
narrowed to schema migration and the tool is documented in the upgrade
procedure, the validation-workflow table, and the Upgrading section.

**Fuzz inventory (SECURITY.md).** Said four crates and 17 targets; the tree has
six crates and 19 targets, the count `check_fuzz_target_inventory.py` pins and
that ROADMAP.md already stated.

**README KPI table.** Still the v0.61.0 refresh while the file's own headline
bullets quoted v0.64.0 — including the S2 settled-RSS claim the receipt
explicitly retracts. Every cell is now traceable to the receipt's
`## v0.64.0 refresh (2026-08-08)` section, and S2 settled RSS is stated as the
dead heat it is.

## Smaller corrections

- `[Unreleased]` had no entry for the shipped `rs-config-render` site-local
  hook surface (`--extra-rpol` / `--merge-toml`, `policy/site-local-NNN.rpol`,
  the `site_local` receipt block).
- `rbgp rib diff advertised` → `rbgp diff advertised`; `Diff` is a top-level
  subcommand, and every other changelog entry uses the correct form.
- `crates/transport/src/session/tests` is a directory, not `tests.rs`.
- Startup signal-handler registration ordering is documented as the contract it
  became, matching the assertion that enforces it.
- README: update-group figures aligned to the receipt headline (0.56 s, ~27x)
  rather than the more favourable same-receipt run; monitoring payloads named
  in the tarball contents; GHCR example tag refreshed to the shipped release;
  the birdwatcher adapter described as the shipped binary it now is.
- docs/CONFIGURATION.md: the `config_epoch` and `ebgp_requires_policy` sections
  now name the `--check` / `--strict` consequence of leaving the posture at
  legacy omission.
- docs/deployment.md: the sample-profile table was missing the MANRS IXP
  Action 1 starter.

## Gates

    python3 scripts/check_public_tracker_ids.py          exit 0
    python3 scripts/check-v1-stable-surface.py           exit 0
    python3 scripts/check-clippy-reasons.py              exit 0
    python3 scripts/check_release_install_contract.py    exit 0
    python3 -m unittest scripts/test_check_release_install_contract.py   exit 0

`ci.yml` carries `paths-ignore: "**/*.md"`, so main CI skips a docs-only
change; `public-docs-contract.yml` and `release-install-contract.yml` are the
path-scoped gates that actually run, and both were run locally.

No `.rs` files are touched.
