### PR TITLE
docs: correct example, bench, and soak README claims

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -47,14 +47,14 @@ summary, command logs, environment metadata, and raw Criterion artifacts under
 `target/bench-compare/`. Use `--features LIST` when the selected benchmark is
 feature-gated; the same Cargo feature set is applied to both refs.
 
-LAN-395 retained comparisons additionally use `--lan395-gate-out PATH`. That
+Retained fanout comparisons additionally use `--lan395-gate-out PATH`. That
 mode rejects any missing or unexpected fanout row, requires the exact pinned
 two-attempt transport matrix on a performance-governor CPU, applies every
 acceptance threshold, and writes only a checksummed sanitized receipt. Generic
 metadata, logs, absolute paths, and Criterion reports are local diagnostics and
 must not be published.
 
-`route_paging` is a manager-level custom harness for the long-running LAN-391
+`route_paging` is a manager-level custom harness for the long-running
 complete-traversal shape. One harness process runs exactly one scope/route/page
 cell and reports one CSV row plus per-page synchronous handler-boundary
 p50/p99/max. Those page timings include oneshot setup/retrieval around the
@@ -250,9 +250,11 @@ directories.
 
 `compare-rib-memory.sh` runs the ignored high-N RIB structural memory profile
 at two git refs and writes a Markdown summary, CSV, logs, and metadata under
-`target/rib-memory-compare/`. It measures allocator-tracked live heap for three
-RIB shapes: one-peer Adj-RIB-In, two-peer Adj-RIB-In + Loc-RIB, and a
-route-server / route-reflector fanout shape with two Adj-RIB-Out peers.
+`target/rib-memory-compare/`. It measures allocator-tracked live heap for four
+RIB shapes: one-peer Adj-RIB-In (`adj_rib_in`), two-peer Adj-RIB-In + Loc-RIB
+(`full_rib`), the same two-peer shape with a distinct attribute set per prefix
+so attribute interning cannot dedupe (`full_rib_diverse`), and a route-server /
+route-reflector fanout shape with two Adj-RIB-Out peers (`rr_fanout`).
 
 Requirements: `bash`, `git`, `cargo`, and `python3`. The compared refs must
 already include the structured `memory_profile_high_n` harness.

--- a/crates/evpn-linux/src/l3_diff.rs
+++ b/crates/evpn-linux/src/l3_diff.rs
@@ -1859,7 +1859,8 @@ mod tests {
         );
     }
 
-    /// Regression for Copilot finding `reconcile.rs:489`:
+    /// Regression for the reconcile L3 sweep gate
+    /// (`!intent.ip_vrfs.is_empty() || !self.state.l3_owned.is_empty()`):
     /// when config reload removes every `[[evpn_ip_vrfs]]`
     /// entry, the `IpVrfTable` carried on `DataplaneIntent`
     /// becomes empty, but `L3OwnedState` can still hold the

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -2367,9 +2367,9 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         }
 
         // Drain in dependency order: NHG IDs before per-VTEP members
-        // (Copilot finding — `BTreeSet<u32>` ascending iteration plus
-        // our tag scheme would delete members first and let the
-        // kernel reject the group del with `EINVAL`).
+        // (`BTreeSet<u32>` ascending iteration plus our tag scheme
+        // would delete members first and let the kernel reject the
+        // group del with `EINVAL`).
         let (stale_groups, stale_members): (Vec<u32>, Vec<u32>) = self
             .state
             .adopted_unreferenced

--- a/examples/envoy-mtls/README.md
+++ b/examples/envoy-mtls/README.md
@@ -30,11 +30,19 @@ prometheus_addr = "0.0.0.0:9179"
 log_format = "json"
 ```
 
-If you prefer a loopback TCP backend instead, add:
+A loopback TCP backend is also possible, but it must carry its own
+credential: `security.grpc.enforcement = "tier"` is the only enforcement
+mode, and an unauthenticated TCP listener is rejected at config load. Use a
+bearer token (Envoy then has to inject the header itself):
 
 ```toml
 [global.telemetry.grpc_tcp]
 address = "127.0.0.1:50051"
+token_file = "/etc/rustbgpd/grpc.token"
+principal = "envoy-frontend"
+
+[security.grpc.roles]
+"envoy-frontend" = "operator"
 ```
 
 ## Certificate layout
@@ -53,6 +61,10 @@ Remote operators need a client certificate and key signed by the same CA.
 envoy -c examples/envoy-mtls/envoy.yaml
 ```
 
+Envoy must be able to open the backend socket. The default UDS is created with
+mode `0o600` owned by the daemon user, so run Envoy as that user (or as root);
+any other identity gets `EACCES` on connect.
+
 ## Example client call
 
 ```bash
@@ -68,6 +80,16 @@ grpcurl \
 
 ## Operational notes
 
+- **Every client Envoy admits becomes `local-operator` at operator tier.** The
+  default UDS is owner-only, so the daemon authorizes its clients by filesystem
+  ownership; the client certificate identity stops at Envoy and never reaches
+  the authorization layer. mTLS is an admission gate here, not per-client RBAC
+  — a monitoring-only certificate gets full mutating control. For tier
+  separation, either cap the backend with an explicit
+  `[global.telemetry.grpc_uds] max_tier` and run a second socket for mutating
+  access, or use the native mTLS TCP listener, which derives a per-certificate
+  principal that `[security.grpc.roles]` maps to `observer` / `automation` /
+  `operator`.
 - Firewall the exposed Envoy listener to known management hosts even when mTLS
   is enabled.
 - Prefer a dedicated management VLAN/interface instead of `0.0.0.0` where

--- a/examples/event-bridge/README.md
+++ b/examples/event-bridge/README.md
@@ -28,10 +28,14 @@ operator's preferred sink. The patterns to preserve are:
 
 ## Build + run
 
-The plaintext TCP command below requires an explicitly configured, suitable
-`[global.telemetry.grpc_tcp]` listener. The default API listener is a Unix
-domain socket, but this reference bridge does not implement UDS, bearer-token,
-or mTLS client transports.
+This skeleton opens an unauthenticated plaintext gRPC channel, so it cannot
+connect to a conformant daemon as shipped. `security.grpc.enforcement = "tier"`
+is the only enforcement mode (v0.63.0+), and every legal listener is therefore
+authenticated: an owner-only UDS, a bearer-token TCP listener (`token_file` plus
+`principal`), or native mTLS. Add the matching client transport before running
+this bridge — a `tonic` interceptor setting `authorization: Bearer <token>`, or
+a UDS connector for the default socket. The command below is the shape of the
+invocation, not a runnable one against a stock daemon.
 
 ```sh
 cargo run --release -p event-bridge -- \

--- a/examples/evpn-vtep-leaf/README.md
+++ b/examples/evpn-vtep-leaf/README.md
@@ -49,23 +49,35 @@ The starter config is expected to pass strict validation without warnings.
 Most `[[evpn_instances]]` edits now **hot-apply** at runtime via the
 ADR-0063 EVPN runtime coordinator — through both SIGHUP file-driven reload
 and the gRPC `EvpnService.ApplyEvpnRuntime`. `--diff` classifies each edit
-as **reload-applied** or **restart-required**: only the two by-design
-restart-required shape classes stay restart-required — L3VNI/device/table
-IP-VRF identity changes (kernel VRF lifecycle) and the broader ES / IP-VRF
-mixed-row edits that fall outside the L2VNI-only composer. See ADR-0063 and
-`KNOWN_ISSUES.md` for the full supported-shape list.
+as **reload-applied** or **restart-required**. What stays restart-required is
+IP-VRF L3VNI/device/table identity redefines (kernel VRF identity lifecycle),
+plus the shapes the plan decomposer's fixed phase order cannot express: a
+relink away from an IP-VRF deleted in the same candidate, a relink onto an
+IP-VRF added in the same candidate, and an Ethernet Segment left memberless
+mid-sequence. Every other mixed ES / IP-VRF edit hot-applies through the
+decomposer, one committed runtime generation per step. See ADR-0063,
+`docs/reload-matrix.md`, and `KNOWN_ISSUES.md`.
 
 ## Pre-create the Linux bridge/VXLAN devices
 
-Gate 7b deliberately does not create bridge or VXLAN netdevs. The
+rustbgpd does not create bridge or VXLAN netdevs by default — this example
+pre-creates them out of band. To have the daemon own their lifecycle instead,
+opt into the ADR-0091 `[[managed_netdevs.bridges]]` / `[[managed_netdevs.vxlans]]`
+rows (status via `rbgp evpn managed-netdevs`); that table is restart-required.
+
+For a legacy instance (`bridge_vlan` unset, the shape this example uses) the
 readiness probe requires:
 
 - bridge exists;
+- bridge VLAN filtering is disabled;
 - exactly one VXLAN port is enslaved to the bridge;
 - VXLAN VNI matches the `[[evpn_instances]].vni`;
 - VXLAN local IP matches `local_vtep_ip`;
-- VXLAN learning is disabled;
-- bridge VLAN filtering is disabled.
+- VXLAN learning is disabled.
+
+On a `vlan_filtering=1` bridge, set `[[evpn_instances]].bridge_vlan` instead —
+the ADR-0089 VLAN-aware path then selects either a fixed-VNI VXLAN member or a
+collect-metadata / SVD member via the bridge VLAN tunnel mapping.
 
 Example for the first instance (`vni = 10100`, `bridge = "br100"`,
 `local_vtep_ip = "10.0.0.10"`):
@@ -107,8 +119,12 @@ Expected output (human format):
 ```
 vni=10100 rd=10.0.0.10:10100 vtep=10.0.0.10 rts=[65000:10100] readiness=ready bridge=br100 originated-local-macs=0
 vni=10200 rd=10.0.0.10:10200 vtep=10.0.0.10 rts=[65000:10200] readiness=ready bridge=br200 advertise-svi-mac originated-local-macs=0
-vni=10300 rd=4200000000:300 vtep=10.0.0.10 rts=[65000:10300,65000:55000] readiness=ready originated-local-macs=0
+vni=10300 rd=4200000000:300 vtep=10.0.0.10 rts=[65000:10300,65000:55000] readiness=unbound originated-local-macs=0
 ```
+
+VNI 10300 has no `bridge` binding in this config, so it reports
+`readiness=unbound` — the probe does not apply to it. Add a `bridge` key (and
+the matching netdevs) to move it to `ready`.
 
 The same state plus route/metric presence can be summarized with:
 
@@ -118,7 +134,8 @@ rbgp evpn diagnose
 
 ## What this example does NOT do (yet)
 
-- Create Linux bridge or VXLAN netdevs for you.
+- Create Linux bridge or VXLAN netdevs for you: it declares no
+  `[managed_netdevs]` rows, so the ADR-0091 lifecycle is off here.
 - Enforce RFC 7432 §15 duplicate-MAC quarantine beyond what ships today:
   detect-only quarantine (detection metrics exposed) plus the optional
   `action = "suppress_local"` enforcement both ship. The M/N detector

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -2,12 +2,12 @@
 
 Every soak entrypoint in this directory acquires an exclusive `flock` on
 `${RUSTBGPD_HOST_LOCK:-$HOME/.local/state/rustbgpd-host.lock}` before
-doing real work. The `bench/compare-criterion.sh` script (and the
-`Criterion Bench Compare` GitHub Actions workflow that drives it) takes
-the same lock on the same path. When the soak host is also the bench
-host, this guarantees only one workload runs at a time — a bench
-dispatch refuses to start while a soak is active, and a soak refuses to
-start while a bench is mid-attempt.
+doing real work. The `bench/compare-criterion.sh` script (and both GitHub
+Actions workflows that drive it — `Criterion Bench Compare` on dispatch
+and `Criterion Bench Nightly` on cron) takes the same lock on the same
+path. When the soak host is also the bench host, this guarantees only one
+workload runs at a time — a bench dispatch refuses to start while a soak
+is active, and a soak refuses to start while a bench is mid-attempt.
 
 The shared logic lives in `tests/soak/host-lock.sh`; sourcing it and
 calling `acquire_rustbgpd_host_lock` is a two-line block right after
@@ -49,7 +49,7 @@ where that directory was absent, so a soak and the nightly bench could
 run unprotected. An uncontended lock is free, so always taking it is
 transparent on laptops / dev boxes too. On contention the entrypoint
 exits `75` (`EX_TEMPFAIL`, "host busy") so an unattended caller — the
-nightly bench workflow — can skip cleanly rather than fail.
+`Criterion Bench Nightly` workflow — can skip cleanly rather than fail.
 
 ---
 
@@ -304,8 +304,8 @@ Publish the 24h postmortem only after checking:
   advance with churn.
 - `evpn_local_origination_errors_total` stays flat at zero.
 - `evpn_local_observations_dropped_total` stays flat at zero.
-- `duplicate_mac_moves_total` stays flat unless the test deliberately reuses
-  a MAC before its withdraw converges.
+- `evpn_duplicate_mac_moves_total` stays flat unless the test deliberately
+  reuses a MAC before its withdraw converges.
 - Steady-state RSS slope after `WARMUP_SEC` is flat enough to rule out a
   retained-state leak.
 
@@ -548,7 +548,8 @@ so the soak exercises:
 The base Gate 8b soak validated steady memory under DF-flip churn
 only (no FDB churn). This variant was the alpha-checklist exit
 condition for the production-default flip of `apply_bum_enforcement`
-and `apply_aliasing_ecmp` to `true`; it PASSED 2026-05-16 (postmortem
+to `true` (`apply_aliasing_ecmp` already defaulted to `true` since
+v0.20.0, ADR-0059 slice 3.5); it PASSED 2026-05-16 (postmortem
 `docs/soaks/soak-gate8b-mac-churn-24h.md`) and the flip shipped in v0.23.0.
 Future runs guard the production default rather than gate its
 initial flip.
@@ -691,9 +692,10 @@ CSV inspection.
 ## When to run
 
 - **As a regression guard** for the production defaults of
-  `apply_bum_enforcement` and `apply_aliasing_ecmp` (`true` since
-  v0.23.0; gating evidence: Gate 8b 24 h MAC-churn 2026-05-16 +
-  M37 local-origination 24 h MAC-churn 2026-05-19). See
+  `apply_bum_enforcement` (`true` since v0.23.0) and
+  `apply_aliasing_ecmp` (`true` since v0.20.0, ADR-0059 slice 3.5);
+  gating evidence for both: Gate 8b 24 h MAC-churn 2026-05-16 +
+  M37 local-origination 24 h MAC-churn 2026-05-19. See
   `docs/evpn-alpha-soak.md`.
 - **After any change to** the local-MAC origination / withdraw
   path (`crates/evpn-linux/src/reconcile.rs`,
@@ -842,6 +844,8 @@ per-cycle events recorded in `churn.log`.
   or the `evpn_l3_originator` / `evpn_l3_installer` daemon tasks.
 - **Before tagging any release that touches the symmetric IRB
   packet path or the L3 owned-state model.**
+
+---
 
 # Intern-table / churn soak harnesses
 


### PR DESCRIPTION
Documentation accuracy pass over the example, bench, and soak READMEs, plus
two source comments in `crates/evpn-linux`. Every claim below was re-checked
against HEAD before editing.

## Corrections

**`bench/README.md`**

- The RIB memory compare measures **four** shapes, not three.
  `crates/rib/tests/memory_profile.rs` pushes `adj_rib_in`, `full_rib`,
  `full_rib_diverse`, and `rr_fanout`, and `memory_profile_schema_quick`
  asserts `rows.len() == 4`; `compare-rib-memory.sh` keys on
  `(shape, prefixes)` and reports all four. The undocumented row is
  `full_rib_diverse`, the interning-defeating shape.
- Dropped two private tracker IDs from prose. The `--lan395-gate-out` flag keeps
  its literal spelling because `compare-criterion.sh` parses it.

**`crates/evpn-linux/src/l3_diff.rs`, `crates/evpn-linux/src/reconcile.rs`**

- Two comments carried review-process residue naming an external review tool.
  Both now state the technical fact they record. The `l3_diff.rs` comment also
  carried a line-number cross-reference that no longer resolves to the code it
  described; it names the reconcile L3 sweep gate predicate instead.

**`examples/envoy-mtls/README.md`**

- The suggested loopback TCP backend was not a loadable config: tier enforcement
  rejects an unauthenticated TCP listener, so `--check` exits 1. The block now
  carries `token_file` + `principal` and the matching `[security.grpc.roles]`
  entry, verified with `--check`.
- Added the authorization consequence of the pattern: every client Envoy admits
  reaches the daemon as the implicit `local-operator` principal at operator
  tier. The client certificate identity stops at Envoy, so mTLS here is an
  admission gate, not per-client RBAC.
- Noted the process-identity requirement — the default UDS is mode `0o600` owned
  by the daemon user.

**`examples/event-bridge/README.md`**

- The preamble implied a "suitable" plaintext TCP listener could be configured.
  Since `enforcement = "tier"` is the only mode, every legal listener is
  authenticated, and the bridge builds a bare channel with no interceptor. The
  section now states that the skeleton has no credential transport and names
  what has to be added before it can connect.

**`examples/evpn-vtep-leaf/README.md`**

- Mixed ES / IP-VRF edits no longer blanket-require a restart: the #268 plan
  decomposer hot-applies them as ordered primitive steps. The text now names the
  shapes that genuinely stay restart-required.
- The netdev section predated ADR-0091 managed netdevs and stated VLAN filtering
  must be disabled unconditionally. It now separates the default (out-of-band
  netdevs) from the opt-in `[managed_netdevs]` lifecycle, scopes the probe list
  to legacy instances, and points VLAN-aware bridges at `bridge_vlan`.
- The sample output showed `readiness=ready` for VNI 10300, which has no `bridge`
  key in the shipped config and therefore always reports `unbound`.

**`tests/soak/README.md`**

- `duplicate_mac_moves_total` → `evpn_duplicate_mac_moves_total`; the unqualified
  name matches no series.
- `apply_aliasing_ecmp` did not flip in v0.23.0 — it has defaulted to `true`
  since v0.20.0 (ADR-0059 slice 3.5). Only `apply_bum_enforcement` flipped.
- Named the second workflow that drives `compare-criterion.sh` and takes the host
  lock, and restored the missing section rule before the last heading.

## Verification

Both documented commands in `examples/evpn-vtep-leaf/README.md` were executed
against the shipped config (`--check --strict` exits 0; `--diff` renders the
decomposed-coordinator line). The envoy backend TOML was checked with
`rustbgpd --check` in both the rejected and the corrected form.
