### PR TITLE
docs: correct crate README citations and stale claims

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -48,8 +48,10 @@ rbgp config import <source> [--format bird|frr|gobgp] [--out <path>]
 
 ```bash
 rbgp neighbor
+rbgp neighbor --wide                        # add MsgRcvd/MsgSent/Flaps/RRC/Slow/PfxRcd columns
 rbgp summary                                # alias for neighbor list
 rbgp neighbor <addr>
+rbgp neighbor <addr> --compare <NEIGHBOR>   # compare live update-group membership
 rbgp neighbor <addr> add --remote-asn <asn> [--peer-group <name>] [--families <list>] [--route-server-client|--no-route-server-client] [--per-client-best|--no-per-client-best] [--role <role>] [--strict-role|--no-strict-role] [--no-add-path]
 rbgp neighbor <addr> enable
 rbgp neighbor <addr> disable --reason "maintenance"
@@ -78,9 +80,10 @@ passwordless `ix-members` group from ordinary JSON before adding the range.
 
 `neighbor add` preserves omission for peer-group inheritance. Positive and
 `--no-*` forms create explicit boolean overrides; any Add-Path option emits the
-complete atomic block, while `--no-add-path` explicitly disables it. Old
-daemons fail the one wrapper-only RPC with an upgrade diagnostic; the CLI never
-retries with legacy semantics.
+complete atomic block, while `--no-add-path` explicitly disables it. The CLI
+sends only the presence-aware `intent` carrier and never retries with legacy
+semantics; a daemon predating v0.65 rejects the RPC because it does not read
+that field.
 
 ### Routes, Policy, and Dataplane
 
@@ -98,6 +101,7 @@ rbgp rib advertised <addr> --age
 rbgp rib advertised <addr> --count
 rbgp rib sent <addr>                        # alias
 rbgp rib --prefix <prefix> --explain
+rbgp rib --prefix <prefix> --explain --explain-peer <peer>   # scope the explain to one peer's Add-Path send view
 rbgp rib blackholes
 rbgp rib fib
 rbgp rib bgpls    # BGP-LS routes learned from peers (RFC 9552)

--- a/crates/event-history/README.md
+++ b/crates/event-history/README.md
@@ -22,12 +22,15 @@ one SQLite transaction, and serves cursor-based replay through the
   `EventEnvelope`, `CommittedEvent`, `EventHistorySender`,
   `Category`, `Severity`, `PayloadCodec`, `EnvelopePeers`, plus the
   shared `EhmState` and the async actor loop (`run_actor`). It also
-  re-exports `EventSubscription` / `SubscribeFilter` /
-  `SubscribeRequest` / `SubscribeStats` from `cursor.rs`.
+  re-exports `EventSubscription` / `EventSubscriptionItem` /
+  `SubscribeFilter` / `SubscribeRequest` / `SubscribeStats` /
+  `SubscribeStatsSnapshot` from `cursor.rs`.
 - `storage.rs` — the `spawn_blocking` boundary. Owns the rusqlite
   `Connection` on a dedicated thread; processes batches via an
-  internal channel. Only place in the crate that touches
-  `rusqlite::Connection`. Contains the batching + retention SQL paths
+  internal channel. Sole owner of the live `Connection`:
+  `migrations.rs` and `sequence.rs` execute against a borrowed
+  handle, and `quarantine.rs` opens a separate read-only connection
+  against a quarantined DB. Contains the batching + retention SQL paths
   (no separate `batch.rs` / `retention.rs` modules; both are method
   groups on the storage thread for atomic coupling with the
   connection).

--- a/crates/transport/README.md
+++ b/crates/transport/README.md
@@ -6,11 +6,17 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 
 ## Architecture
 
-Single tokio task per peer. `tokio::select!` multiplexes TCP reads,
-keepalive/hold/connect timers, inbound commands, and outbound route
-updates. The transport layer intercepts UPDATEs (parse, validate, apply
-policy) before forwarding to the RIB — the FSM sees only payloadless
-events.
+Two tokio tasks per peer (ADR-0051): a session task, and a dedicated
+outbound writer task that owns the TCP write half plus a bounded bulk /
+unbounded priority queue, so TCP back-pressure cannot park the session
+loop. The session task's `tokio::select!` multiplexes TCP reads,
+hold/connect-retry/reconnect timers, inbound commands, outbound route
+updates from the RIB, and outbound-connect completion. The KEEPALIVE
+cadence is owned by the writer task (ADR-0078), so it keeps running
+while the session task is parked on a blocking RIB delivery.
+
+The transport layer intercepts UPDATEs (parse, validate, apply policy)
+before forwarding to the RIB — the FSM sees only payloadless events.
 
 ## Features
 
@@ -48,6 +54,17 @@ events.
 - **Extended messages** (RFC 8654) — dynamic buffer sizing up to 65535 bytes
 - **Add-Path** (RFC 7911) — per-family path ID encode/decode
 - **Extended next hop** (RFC 8950) — IPv4 NLRI over IPv6 next hop
+- **Graceful Restart + LLGR** (RFC 4724, RFC 9494) — stale-route retention
+  across peer restart, with long-lived retention via `llgr_stale_time`
+- **BGP Roles + Only-to-Customer** (RFC 9234) — OPEN-time role-mismatch
+  NOTIFICATION 2/11 plus the OTC ingress/egress leak gates
+- **Outbound route filtering** (RFC 5291/5292) — inbound ORF ROUTE-REFRESH
+  handling applied to the peer's Adj-RIB-Out
+- **Enhanced route refresh** (RFC 7313) — BoRR/EoRR demarcation accounting
+  per inbound refresh window
+- **Slow-peer detection** — outbound-backlog episodes flagged via
+  `slow_peer_threshold_pct` / `slow_peer_duration`, with opt-in isolation
+  (`slow_peer_isolation`, default off — detection alone is observational)
 
 ## License
 

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -56,7 +56,7 @@ impl PeerSession {
             }
             let entries = match &group.entries {
                 OrfEntries::AddressPrefix(entries) => entries.clone(),
-                // RFC 5291 §5.2: a malformed entry of a negotiated type removes
+                // RFC 5291 §6: a malformed entry of a negotiated type removes
                 // the previously installed list of that type — emit a reset.
                 OrfEntries::Malformed(_) => vec![AddressPrefixOrf {
                     action: OrfAction::RemoveAll,

--- a/crates/transport/src/session/tests/orf.rs
+++ b/crates/transport/src/session/tests/orf.rs
@@ -70,7 +70,7 @@ async fn inbound_orf_malformed_group_resets_via_remove_all() {
     let mut neg = negotiated_session(65002, false);
     neg.negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
     session.negotiated = Some(neg);
-    // A malformed Address-Prefix group → RFC 5291 §5.2 reset (REMOVE-ALL).
+    // A malformed Address-Prefix group → RFC 5291 §6 reset (REMOVE-ALL).
     let rr = orf_rr(
         OrfType::AddressPrefix,
         OrfEntries::Malformed(Bytes::from_static(&[0x40])),

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -1,11 +1,11 @@
 # rustbgpd-wire
 
-BGP message codec for Rust. Encode and decode OPEN, UPDATE, KEEPALIVE,
-NOTIFICATION, and ROUTE-REFRESH messages per RFC 4271, with extensions for
-MP-BGP, EVPN (including PMSI Tunnel for ingress-replication BUM), FlowSpec,
-VPNv4/VPNv6 labeled NLRI substrate, BGP-LS/BGP-LS-VPN codec support,
-Add-Path, Extended Messages, Outbound Route Filtering (RFC 5291/5292), BGP
-Roles + Only-to-Customer (RFC 9234), and more.
+BGP message codec for Rust. Encode and decode the RFC 4271 messages — OPEN,
+UPDATE, KEEPALIVE, NOTIFICATION — plus ROUTE-REFRESH (RFC 2918, RFC 7313),
+with extensions for MP-BGP, EVPN (including PMSI Tunnel for
+ingress-replication BUM), FlowSpec, VPNv4/VPNv6 labeled NLRI substrate,
+BGP-LS/BGP-LS-VPN codec support, Add-Path, Extended Messages, Outbound Route
+Filtering (RFC 5291/5292), BGP Roles + Only-to-Customer (RFC 9234), and more.
 
 This crate is the wire-protocol foundation of
 [rustbgpd](https://github.com/lance0/rustbgpd) but is designed for standalone
@@ -29,7 +29,6 @@ analyzers, test harnesses, MRT readers, etc.
 | 4684 | Route Target Constrain (RTC) NLRI codec (SAFI 132): `RtcNlri` encode/decode with default-route and prefix-bit bounds. Inert codec substrate — negotiation/distribution live in the daemon |
 | 4724 | Graceful restart capability |
 | 4760 | MP-BGP: `MP_REACH_NLRI` / `MP_UNREACH_NLRI` |
-| 4761 §3.2.5 | Default Gateway extended community (decode) |
 | 5291 | Outbound Route Filtering (ORF) capability (code 3) + ORF-carrying Route Refresh |
 | 5292 | Address-Prefix ORF-Type (64), with the legacy pre-standard type (128) decoded for interoperability |
 | 5492 | BGP capabilities |
@@ -39,9 +38,9 @@ analyzers, test harnesses, MRT readers, etc.
 | 6811 | RPKI prefix-origin validation state — the `RpkiValidation` routing-domain enum (no extended-community codec) |
 | 7313 | Enhanced Route Refresh (BoRR / EoRR markers) |
 | 7385 | PMSI Tunnel Type IANA registry — `PmsiTunnelType` preserves unknown values via an `Other(u8)` variant |
-| 7432 | EVPN: Types 1–4 (EAD, MAC/IP, IMET, Ethernet Segment) including MAC Mobility extended community (§7.7) |
+| 7432 | EVPN: Types 1–4 (EAD, MAC/IP, IMET, Ethernet Segment) including the MAC Mobility extended community (§7.7) and the flag-only Default Gateway extended community (§7.8, type 0x03 / subtype 0x0D, decode + construct) |
 | 7606 | Revised UPDATE error handling: `UpdateMessage::parse_revised` recovers malformed path attributes without aborting the parse, each carrying its §7 per-attribute disposition (treat-as-withdraw / attribute-discard / session-reset) from `malformed_attr_disposition`; an attribute that decodes but fails validation may be retained in `update.attributes` for observation alongside its disposition; malformed or duplicated `MP_REACH_NLRI` / `MP_UNREACH_NLRI` and unparseable NLRI stay session-reset (§5.3, §7.11) |
-| 7674 | Clarification of MP_REACH_NLRI next-hop encoding |
+| 7674 | FlowSpec Redirect Extended Community formatting (updates RFC 5575): redirect-to-IPv4 type 0x8108 and redirect-to-4-octet-AS type 0x8208 in `FlowSpecAction` |
 | 7911 | Add-Path: path ID in NLRI encode/decode |
 | 7999 | `BLACKHOLE` well-known community (`0xFFFF_029A`, rendered as `65535:666`) |
 | 8092 | Large communities (3× u32) |
@@ -53,7 +52,7 @@ analyzers, test harnesses, MRT readers, etc.
 | 8584 §2.2 | DF Election Extended Community (type 0x06, subtype 0x06): decode + construct of the algorithm / capabilities / DF-preference fields |
 | 8654 | Extended messages (up to 65535 bytes). `encode_message_with_limit()` and the per-message `encode_with_limit()` helpers (on `NotificationMessage` / `RouteRefreshMessage`) encode against a caller-supplied size ceiling; the default `encode()` keeps the 4096-byte base limit |
 | 8950 | Extended next hop (IPv4 NLRI over IPv6 NH); optional acceptance of a link-local-primary `MP_REACH_NLRI` next-hop for unnumbered peers via `UpdateValidationOptions` |
-| 8955/8956 | FlowSpec: 13 component types, numeric/bitmask operators; §6.1-compliant `NEXT_HOP` validation (the irrelevant-next-hop case is accepted, not rejected); `FlowSpecRule::validate_encoded_len` rejects rules above the 12-bit `MAX_FLOWSPEC_NLRI_RULE_LEN` (4095 bytes) before they reach the wire |
+| 8955/8956 | FlowSpec: 13 component types, numeric/bitmask operators; §4-compliant `NEXT_HOP` handling (the irrelevant-next-hop case is accepted, not rejected); `FlowSpecRule::validate_encoded_len` rejects rules above the 12-bit `MAX_FLOWSPEC_NLRI_RULE_LEN` (4095 bytes) before they reach the wire |
 | 9003 | Administrative Shutdown Communication (obsoletes RFC 8203) |
 | 9012 | BGP Encapsulation extended community (§4.1) — VXLAN sub-type used by EVPN encap |
 | 9072 | Extended Optional Parameters Length for BGP OPEN: classic encoding through 255 optional-parameter octets, extended aggregate and per-parameter lengths above that boundary, and permissive extended-format receive at smaller lengths |
@@ -65,8 +64,8 @@ analyzers, test harnesses, MRT readers, etc.
 | 9687 | Send Hold Timer: NOTIFICATION code 8 (`NotificationCode::SendHoldTimerExpired`, subcode always 0 per §6). Codec only — the timer itself lives in the daemon |
 | 9774 | AS_SET / AS_CONFED_SET deprecation: prohibited segment types in `AS_PATH` / `AS4_PATH` are rejected on decode with RFC 7606 treat-as-withdraw disposition, and an `AS_PATH` containing an AS_SET refuses to encode (`EncodeError::ValueOutOfRange`) |
 | 9785 §3 | DF Election preference algorithms + Don't-Preempt bit, extending the RFC 8584 DF Election Extended Community |
-| draft-abraitis-idr-addpath-paths-limit-04 | Experimental Paths-Limit capability (`PathsLimitFamily`, IANA-assigned capability code 76). The draft is expired and archived; interoperability and behavior remain experimental |
 | 10005 | Link Bandwidth Extended Community receiver subset: decode exact transitive/non-transitive types 0x00/0x40, subtype 0x04, as raw AS + IEEE-754 bytes/second; the constructor remains non-transitive type 0x40 |
+| draft-abraitis-idr-addpath-paths-limit-04 | Experimental Paths-Limit capability (`PathsLimitFamily`, IANA-assigned capability code 76). The draft is expired and archived; interoperability and behavior remain experimental |
 
 ### 0.17.0 compatibility note
 
@@ -149,30 +148,31 @@ Decode a single BGP message from raw bytes:
 use bytes::Bytes;
 use rustbgpd_wire::{decode_message, Message, MAX_MESSAGE_LEN};
 
-# fn handle(raw_bytes: Vec<u8>) -> Result<(), Box<dyn std::error::Error>> {
-let mut buf = Bytes::from(raw_bytes);
-let msg = decode_message(&mut buf, MAX_MESSAGE_LEN)?;
+fn handle(raw_bytes: Vec<u8>) -> Result<(), Box<dyn std::error::Error>> {
+    let mut buf = Bytes::from(raw_bytes);
+    let msg = decode_message(&mut buf, MAX_MESSAGE_LEN)?;
 
-match msg {
-    Message::Update(update) => {
-        let parsed = update.parse(
-            true,   // 4-octet AS numbers negotiated
-            false,  // Add-Path not negotiated for body NLRI
-            &[],    // Add-Path families for MP NLRI (empty = none)
-        )?;
-        for entry in &parsed.announced {
-            println!("announced: {}", entry.prefix);
+    match msg {
+        Message::Update(update) => {
+            let parsed = update.parse(
+                true,   // 4-octet AS numbers negotiated
+                false,  // Add-Path not negotiated for body NLRI
+                &[],    // Add-Path families for MP NLRI (empty = none)
+            )?;
+            for entry in &parsed.announced {
+                println!("announced: {}", entry.prefix);
+            }
+            for attr in &parsed.attributes {
+                println!("attribute: {:?}", attr);
+            }
         }
-        for attr in &parsed.attributes {
-            println!("attribute: {:?}", attr);
+        Message::Open(open) => {
+            println!("OPEN: as={} hold={} caps={}", open.my_as, open.hold_time, open.capabilities.len());
         }
+        _ => {}
     }
-    Message::Open(open) => {
-        println!("OPEN: as={} hold={} caps={}", open.my_as, open.hold_time, open.capabilities.len());
-    }
-    _ => {}
+    Ok(())
 }
-# Ok(()) }
 ```
 
 Build and encode an OPEN message:
@@ -208,7 +208,7 @@ let bytes = encode_message(&Message::Open(open)).expect("encode OPEN");
 - **`Capability`** — OPEN capabilities: multi-protocol, 4-octet AS, Add-Path,
   experimental Paths-Limit (`Capability::PathsLimit` / `PathsLimitFamily`,
   code 76), graceful restart, Outbound Route Filtering, etc.
-- **ORF types** (`orf` module, RFC 5291/5292) — `OrfCapEntry` (capability blocks), `OrfPayload` / `OrfEntryGroup` / `OrfEntries` (the Route Refresh ORF section), and `AddressPrefixOrf` (one Address-Prefix entry: action, match, sequence, min/max length, prefix). `RouteRefreshMessage::orf` carries the decoded section; a malformed IPv4/IPv6 unicast Address-Prefix group decodes to `OrfEntries::Malformed` (RFC 5291 §5.2 reset) rather than failing the message, while non-unicast / future-family Address-Prefix groups are preserved as raw bytes until those family encodings are implemented. Adding `orf` to `RouteRefreshMessage` made that struct `Clone` rather than `Copy` (0.11.0)
+- **ORF types** (`orf` module, RFC 5291/5292) — `OrfCapEntry` (capability blocks), `OrfPayload` / `OrfEntryGroup` / `OrfEntries` (the Route Refresh ORF section), and `AddressPrefixOrf` (one Address-Prefix entry: action, match, sequence, min/max length, prefix). `RouteRefreshMessage::orf` carries the decoded section; a malformed IPv4/IPv6 unicast Address-Prefix group decodes to `OrfEntries::Malformed` (RFC 5291 §6 reset) rather than failing the message, while non-unicast / future-family Address-Prefix groups are preserved as raw bytes until those family encodings are implemented. Adding `orf` to `RouteRefreshMessage` made that struct `Clone` rather than `Copy` (0.11.0)
 - **`FlowSpecRule`** / **`FlowSpecComponent`** — FlowSpec NLRI with all 13 match types
 - **`EvpnRoute`** / **`EvpnRouteKey`** — typed EVPN routes (Types 1–5) with
   full payloads (RFC 7432, RFC 9136); `EvpnRouteKey` implements `Ord` for
@@ -222,8 +222,10 @@ let bytes = encode_message(&Message::Open(open)).expect("encode OPEN");
   (`bgp_ls_attribute_tlvs`, `igp_metric`, `prefix_metric`, `te_default_metric`,
   `BgpLsNodeKey`, and the `BGP_LS_TLV_*` type constants)
 - **`labeled` module** — IPv4/IPv6 labeled-unicast NLRI codec (SAFI 4, RFC 8277):
-  `LabeledNlri` / `LabeledNlriEntry` / `LABELED_UNICAST_SAFI`, label-stack +
-  prefix encode/decode with Add-Path and withdraw forms
+  `LabeledNlri` / `LabeledNlriEntry` / `LabeledAddressFamily`, label-stack +
+  prefix encode/decode with Add-Path and withdraw forms. The SAFI-4 constant
+  `LABELED_UNICAST_SAFI` is defined in the `vpn` module and re-exported at the
+  crate root
 - **`rtc` module** — Route Target Constrain NLRI codec (SAFI 132, RFC 4684):
   `RtcNlri` / `RTC_SAFI` / `RTC_MAX_PREFIX_BITS`, `decode_rtc_nlri` /
   `encode_rtc_nlri` with default-route and prefix-bit bounds
@@ -233,7 +235,7 @@ let bytes = encode_message(&Message::Open(open)).expect("encode OPEN");
   `ipv4:val` textual encodings and the exact `0x<16-hex-digits>` display
   fallback for unknown RD types; malformed or noncanonical fallback text
   returns `RouteDistinguisherParseError::InvalidHexFallback`
-- **`DfElectionExtendedCommunity`** (`attribute`) — RFC 8584 §2.2 / RFC 9785 §3 DF Election Extended Community: `ExtendedCommunity::as_df_election()` decodes one, `ExtendedCommunity::df_election(algorithm, capabilities, preference: Option<u16>)` constructs it (EVPN DF election algorithm, capabilities, and the RFC 9785 preference / Don't-Preempt fields)
+- **`DfElectionExtendedCommunity`** (`attribute`) — RFC 8584 §2.2 / RFC 9785 §3 DF Election Extended Community: `ExtendedCommunity::as_df_election()` decodes one, `ExtendedCommunity::df_election(algorithm_id: u8, capabilities: u16, preference: Option<u16>)` constructs it (EVPN DF election algorithm, capabilities, and the RFC 9785 preference / Don't-Preempt fields). `algorithm_id` is masked to the five-bit DF Alg field, so wider values truncate silently
 - **Link Bandwidth** (RFC 10005 §§2, 3.2) — `ExtendedCommunity::as_link_bandwidth()` decodes exact type 0x00/0x40, subtype 0x04, without interpreting the raw AS/float payload; `ExtendedCommunity::link_bandwidth(asn, bytes_per_sec)` continues to construct non-transitive type 0x40
 - **Origin Validation State** (RFC 8097) — `ExtendedCommunity::ORIGIN_VALIDATION_VALID` /
   `_NOT_FOUND` / `_INVALID` constants (type 0x43) for the RPKI prefix-origin

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -573,11 +573,12 @@ impl ExtendedCommunity {
         let raw = u64::from_be_bytes([0x06, 0x03, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]]);
         Self(raw)
     }
-    /// Decode as Default Gateway Extended Community (RFC 4761 §3.2.5 /
-    /// RFC 7432). Type 0x03, subtype 0x0D. This is a flag-only community:
-    /// presence is the signal and the 6-byte value field must be all zeros.
-    /// Malformed advertisements with non-zero value bytes are treated as
-    /// non-matches rather than silently accepted — downstream policy and
+    /// Decode as Default Gateway Extended Community (RFC 7432 §7.8).
+    /// Type 0x03, subtype 0x0D. This is a flag-only community: presence is
+    /// the signal and the 6-byte value field is reserved, set to zero by
+    /// senders. rustbgpd is deliberately stricter than the RFC's "ignored by
+    /// the receivers": advertisements with non-zero value bytes are treated
+    /// as non-matches rather than silently accepted — downstream policy and
     /// validation consumers treat this accessor as semantic truth.
     #[must_use]
     pub fn as_default_gateway(self) -> bool {
@@ -4975,7 +4976,7 @@ mod tests {
     }
     /// Audit follow-up: a peer sending an `MP_REACH` for `FlowSpec`
     /// (SAFI 133) with a non-zero `NH-Len` is malformed per RFC
-    /// 8955 §6.1 — the decoder must reject so the rest of the
+    /// 8955 §4 — the decoder must reject so the rest of the
     /// pipeline never sees a misshapen `FlowSpec` advertisement.
     /// Logic exists at `decode_mp_reach_nlri` but had no direct
     /// regression test; adding one cheaply pins the wire-level

--- a/crates/wire/src/capability.rs
+++ b/crates/wire/src/capability.rs
@@ -546,7 +546,7 @@ impl Capability {
                 }
             }
             capability_code::OUTBOUND_ROUTE_FILTERING => {
-                // RFC 5291 §4: per-family blocks. Preserve as Unknown on a
+                // RFC 5291 §5: per-family blocks. Preserve as Unknown on a
                 // structural error or unrecognized AFI/SAFI (lossless
                 // round-trip, mirroring Add-Path).
                 let raw = buf.copy_to_bytes(usize::from(length));
@@ -744,7 +744,7 @@ impl Capability {
                 }
             }
             Capability::OutboundRouteFilter(entries) => {
-                // RFC 5291 §4: the value carries one or more blocks. An empty
+                // RFC 5291 §5: the value carries one or more blocks. An empty
                 // list would encode to a zero-length value, which the decoder
                 // (correctly) treats as malformed and round-trips as Unknown —
                 // reject it here so encode/decode stay symmetric.
@@ -1787,7 +1787,7 @@ mod tests {
         }
     }
 
-    // --- Outbound Route Filtering capability (RFC 5291 §4) tests ---
+    // --- Outbound Route Filtering capability (RFC 5291 §5) tests ---
 
     #[test]
     fn roundtrip_outbound_route_filter() {
@@ -1812,7 +1812,7 @@ mod tests {
 
     #[test]
     fn outbound_route_filter_rejects_empty_entries() {
-        // An empty block list has no valid wire form (RFC 5291 §4 requires one
+        // An empty block list has no valid wire form (RFC 5291 §5 requires one
         // or more), and the decoder treats a zero-length value as Unknown —
         // encode must refuse it so the codec stays symmetric.
         let cap = Capability::OutboundRouteFilter(vec![]);

--- a/crates/wire/src/constants.rs
+++ b/crates/wire/src/constants.rs
@@ -96,19 +96,19 @@ pub mod orf {
     /// interoperability; never advertised. Applied only if negotiated.
     pub const TYPE_ADDRESS_PREFIX_LEGACY: u8 = 128;
 
-    /// Capability Send/Receive (RFC 5291 §4): willing to receive ORF entries.
+    /// Capability Send/Receive (RFC 5291 §5): willing to receive ORF entries.
     pub const SEND_RECEIVE_RECEIVE: u8 = 1;
     /// Capability Send/Receive: willing to send ORF entries.
     pub const SEND_RECEIVE_SEND: u8 = 2;
     /// Capability Send/Receive: willing to both send and receive.
     pub const SEND_RECEIVE_BOTH: u8 = 3;
 
-    /// ROUTE-REFRESH When-to-refresh (RFC 5291 §5.2): refresh immediately.
+    /// ROUTE-REFRESH When-to-refresh (RFC 5291 §4): refresh immediately.
     pub const WHEN_IMMEDIATE: u8 = 1;
     /// ROUTE-REFRESH When-to-refresh: defer the re-advertisement sweep.
     pub const WHEN_DEFER: u8 = 2;
 
-    /// Common ORF entry header — Action field mask (top 2 bits, RFC 5291 §5.1.1).
+    /// Common ORF entry header — Action field mask (top 2 bits, RFC 5291 §4).
     pub const ACTION_MASK: u8 = 0xC0;
     /// Common ORF entry Action: ADD.
     pub const ACTION_ADD: u8 = 0x00;
@@ -116,7 +116,7 @@ pub mod orf {
     pub const ACTION_REMOVE: u8 = 0x80;
     /// Common ORF entry Action: REMOVE-ALL (entry carries only the header byte).
     pub const ACTION_REMOVE_ALL: u8 = 0xC0;
-    /// Common ORF entry header — Match field mask (bit 5, RFC 5291 §5.1.1).
+    /// Common ORF entry header — Match field mask (bit 5, RFC 5291 §4).
     pub const MATCH_MASK: u8 = 0x20;
     /// Common ORF entry Match: DENY (PERMIT is the mask cleared).
     pub const MATCH_DENY: u8 = 0x20;

--- a/crates/wire/src/orf.rs
+++ b/crates/wire/src/orf.rs
@@ -12,7 +12,7 @@
 //! group length that overruns the message body) return a `DecodeError`; a
 //! malformed Address-Prefix *entry* (undefined Action, or a prefix length
 //! beyond the address family) decodes into [`OrfEntries::Malformed`] so the
-//! caller can apply the RFC 5291 §5.2 reset instead of tearing the session down.
+//! caller can apply the RFC 5291 §6 reset instead of tearing the session down.
 
 use bytes::{Buf, BufMut, Bytes};
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -63,7 +63,7 @@ impl OrfType {
     }
 }
 
-/// Capability Send/Receive field (RFC 5291 §4). Unknown values are preserved.
+/// Capability Send/Receive field (RFC 5291 §5). Unknown values are preserved.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum OrfSendReceive {
     /// The speaker is willing to receive ORF entries from its peer.
@@ -121,7 +121,7 @@ pub struct OrfCapType {
     pub send_receive: OrfSendReceive,
 }
 
-/// One per-(AFI,SAFI) block of the ORF capability value (RFC 5291 §4).
+/// One per-(AFI,SAFI) block of the ORF capability value (RFC 5291 §5).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrfCapEntry {
     /// Address family.
@@ -132,7 +132,7 @@ pub struct OrfCapEntry {
     pub orf_types: Vec<OrfCapType>,
 }
 
-/// ROUTE-REFRESH When-to-refresh octet (RFC 5291 §5.2). Unknown values preserved.
+/// ROUTE-REFRESH When-to-refresh octet (RFC 5291 §4). Unknown values preserved.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum WhenToRefresh {
     /// Re-run the outbound advertisement sweep immediately.
@@ -165,7 +165,7 @@ impl WhenToRefresh {
     }
 }
 
-/// Action field of a common ORF entry header (RFC 5291 §5.1.1).
+/// Action field of a common ORF entry header (RFC 5291 §4).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum OrfAction {
     /// Add this entry to the ORF list.
@@ -176,7 +176,7 @@ pub enum OrfAction {
     RemoveAll,
 }
 
-/// Match field of a common ORF entry header (RFC 5291 §5.1.1).
+/// Match field of a common ORF entry header (RFC 5291 §4).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum OrfMatch {
     /// Permit routes matching this entry.
@@ -185,7 +185,7 @@ pub enum OrfMatch {
     Deny,
 }
 
-/// A single Address-Prefix ORF entry (RFC 5291 §5.1.1 header + RFC 5292 §4).
+/// A single Address-Prefix ORF entry (RFC 5291 §4 header + RFC 5292 Address-Prefix encoding).
 ///
 /// For [`OrfAction::RemoveAll`], only the action is meaningful — `prefix` is
 /// `None` and the length/sequence fields are zero.
@@ -215,7 +215,7 @@ pub enum OrfEntries {
     /// for lossless round-trip (the caller ignores un-negotiated types).
     Raw(Bytes),
     /// An Address-Prefix group whose entries could not be parsed (undefined
-    /// Action, prefix length beyond the family, etc.). Per RFC 5291 §5.2 the
+    /// Action, prefix length beyond the family, etc.). Per RFC 5291 §6 the
     /// receiver ignores the malformed entries and removes the previously
     /// installed ORF list of that type — it does not tear the session down,
     /// so this is surfaced as data rather than a `DecodeError`. The raw bytes
@@ -223,7 +223,7 @@ pub enum OrfEntries {
     Malformed(Bytes),
 }
 
-/// One ORF-Type group within a ROUTE-REFRESH ORF payload (RFC 5291 §5.2).
+/// One ORF-Type group within a ROUTE-REFRESH ORF payload (RFC 5291 §4).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrfEntryGroup {
     /// The ORF-Type of this group.
@@ -232,7 +232,7 @@ pub struct OrfEntryGroup {
     pub entries: OrfEntries,
 }
 
-/// The ORF section carried in a ROUTE-REFRESH message (RFC 5291 §5.2),
+/// The ORF section carried in a ROUTE-REFRESH message (RFC 5291 §4),
 /// following the standard AFI/Reserved/SAFI header.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrfPayload {
@@ -242,7 +242,7 @@ pub struct OrfPayload {
     pub groups: Vec<OrfEntryGroup>,
 }
 
-// ── Capability value codec (RFC 5291 §4) ─────────────────────────────────
+// ── Capability value codec (RFC 5291 §5) ─────────────────────────────────
 
 /// Encoded length of the ORF capability value (sum over blocks).
 #[must_use]
@@ -273,7 +273,7 @@ pub fn encode_capability_value(entries: &[OrfCapEntry], buf: &mut impl BufMut) {
 /// `Capability::Unknown` for a lossless round-trip (mirroring Add-Path).
 #[must_use]
 pub fn decode_capability_value(mut raw: &[u8]) -> Option<Vec<OrfCapEntry>> {
-    // RFC 5291 §4: the value carries one or more blocks. An empty value is
+    // RFC 5291 §5: the value carries one or more blocks. An empty value is
     // malformed — return None so the caller preserves it as Unknown.
     if raw.is_empty() {
         return None;
@@ -309,7 +309,7 @@ pub fn decode_capability_value(mut raw: &[u8]) -> Option<Vec<OrfCapEntry>> {
     Some(entries)
 }
 
-// ── ROUTE-REFRESH ORF payload codec (RFC 5291 §5.2) ──────────────────────
+// ── ROUTE-REFRESH ORF payload codec (RFC 5291 §4) ────────────────────────
 
 /// Decode the ORF section of a ROUTE-REFRESH body, after the AFI/Reserved/SAFI
 /// header. `family` is the resolved AFI/SAFI pair of the message. Address-
@@ -322,7 +322,7 @@ pub fn decode_capability_value(mut raw: &[u8]) -> Option<Vec<OrfCapEntry>> {
 /// group length that overruns the body. A malformed Address-Prefix *entry*
 /// (undefined Action, or a prefix length beyond the address family) does not
 /// error — that group decodes into [`OrfEntries::Malformed`] for the caller to
-/// reset (RFC 5291 §5.2).
+/// reset (RFC 5291 §6).
 pub fn decode_route_refresh_orf(
     buf: &mut impl Buf,
     family: Option<(Afi, Safi)>,
@@ -362,7 +362,7 @@ pub fn decode_route_refresh_orf(
         };
         let entries = if let Some(afi) = parse_family {
             // A parse failure here is a malformed-but-framed group: surface it
-            // as data (RFC 5291 §5.2 reset semantics), not a session error.
+            // as data (RFC 5291 §6 reset semantics), not a session error.
             match decode_address_prefix_entries(&group_bytes, afi) {
                 Ok(parsed) => OrfEntries::AddressPrefix(parsed),
                 Err(_) => OrfEntries::Malformed(group_bytes),
@@ -896,7 +896,7 @@ mod tests {
     #[test]
     fn rr_orf_prefix_len_over_family_max_is_malformed_not_error() {
         // prefixlen 40 for IPv4 is a malformed-but-framed group: it decodes
-        // into Malformed (RFC 5291 §5.2 reset semantics), not a session error.
+        // into Malformed (RFC 5291 §6 reset semantics), not a session error.
         let mut buf = BytesMut::new();
         buf.put_u8(WhenToRefresh::Immediate.as_u8());
         buf.put_u8(OrfType::AddressPrefix.as_u8());

--- a/crates/wire/src/route_refresh.rs
+++ b/crates/wire/src/route_refresh.rs
@@ -8,7 +8,7 @@ use crate::orf::{
 };
 
 /// ROUTE-REFRESH base body length (AFI u16 + subtype u8 + SAFI u8). An ORF
-/// message (RFC 5291 §5.2) extends the body beyond this with ORF entries.
+/// message (RFC 5291 §4) extends the body beyond this with ORF entries.
 const BODY_LEN: usize = 4;
 
 /// Total wire length of a plain ROUTE-REFRESH message (header + base body).
@@ -99,7 +99,7 @@ impl RouteRefreshMessage {
         }
     }
 
-    /// Create an ORF-carrying ROUTE-REFRESH (RFC 5291 §5.2). The third octet
+    /// Create an ORF-carrying ROUTE-REFRESH (RFC 5291 §4). The third octet
     /// is Reserved (subtype 0) for an ORF message.
     #[must_use]
     pub fn new_with_orf(afi: Afi, safi: Safi, orf: OrfPayload) -> Self {
@@ -135,7 +135,7 @@ impl RouteRefreshMessage {
     /// carries an RFC 5291 ORF section, decoded into `orf`. A malformed ORF
     /// *entry* does not fail the decode — it is surfaced via
     /// [`crate::orf::OrfEntries::Malformed`] so the caller can apply the RFC
-    /// 5291 §5.2 reset semantics instead of tearing the session down.
+    /// 5291 §6 reset semantics instead of tearing the session down.
     ///
     /// # Errors
     ///

--- a/crates/wire/src/validate.rs
+++ b/crates/wire/src/validate.rs
@@ -135,7 +135,7 @@ pub fn validate_update_attributes_with_options(
         match attr {
             PathAttribute::NextHop(addr) => check_next_hop(*addr)?,
             PathAttribute::AsPath(path) => check_as_path(path)?,
-            // RFC 8955 §6.1: for FlowSpec (SAFI 133), the NEXT_HOP
+            // RFC 8955 §4: for FlowSpec (SAFI 133), the NEXT_HOP
             // attribute value is "irrelevant" and is recommended
             // to be 0 when advertising. The on-wire NH-Len for
             // FlowSpec is 0 and the decoder fills `mp.next_hop`
@@ -755,7 +755,7 @@ mod tests {
         assert_eq!(err.subcode, update_subcode::INVALID_NEXT_HOP);
     }
     /// Regression: an `MP_REACH` for `FlowSpec` (SAFI 133) with
-    /// the recommended-by-RFC-8955-§6.1 next-hop value of 0.0.0.0
+    /// the recommended-by-RFC-8955-§4 next-hop value of 0.0.0.0
     /// must NOT trip `NEXT_HOP` validation. Before the `FlowSpec`
     /// guard, validate ran the standard `check_next_hop` against
     /// every `MP_REACH` next-hop and rejected 0.0.0.0 with subcode
@@ -776,7 +776,7 @@ mod tests {
             PathAttribute::MpReachNlri(MpReachNlri {
                 afi: Afi::Ipv4,
                 safi: Safi::FlowSpec,
-                // RFC 8955 §6.1 recommends 0.0.0.0 for FlowSpec
+                // RFC 8955 §4 recommends 0.0.0.0 for FlowSpec
                 // advertisements; on the wire NH-Len is 0 and the
                 // decoder defaults this to 0.0.0.0.
                 next_hop: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
@@ -794,7 +794,7 @@ mod tests {
         // shape FRR sends post-handshake. Must pass validation.
         assert!(
             validate_update_attributes(&attrs, false, false, true).is_ok(),
-            "FlowSpec MP_REACH with 0.0.0.0 next-hop must pass — RFC 8955 §6.1 \
+            "FlowSpec MP_REACH with 0.0.0.0 next-hop must pass — RFC 8955 §4 \
              specifies the next-hop value is irrelevant for FlowSpec and \
              recommends 0. The pre-fix path tore sessions against every \
              RFC-compliant FlowSpec peer."


### PR DESCRIPTION
Documentation accuracy pass over the crate READMEs. No code behavior
changes; no version bumps.

## Wrong RFC citations (published to crates.io as `rustbgpd-wire` 0.17.0)

Each was verified against the RFC text, and every source doc-comment that
mirrored it is corrected in the same commit.

| Was | Is | Evidence |
|-----|----|----------|
| Default Gateway ext. community = RFC 4761 §3.2.5 | RFC 7432 §7.8 | RFC 4761 §3.2 stops at §3.2.4 and never mentions Default Gateway; RFC 7432 §7.8 defines type 0x03 / subtype 0x0D with a reserved zero value, which is what `as_default_gateway` / `default_gateway` implement |
| RFC 7674 = "Clarification of MP_REACH_NLRI next-hop encoding" | "Clarification of the Flowspec Redirect Extended Community" (updates RFC 5575) | RFC 7674 contains no MP_REACH next-hop text; the crate already uses it correctly for redirect types 0x8108 / 0x8208 in `FlowSpecAction` |
| FlowSpec `NEXT_HOP` per RFC 8955 §6.1 | RFC 8955 §4 | §6 is "Validation Procedure" and has no subsections; §4 carries "the Length of the Next-Hop Network Address MUST be set to 0. The Network Address of the Next-Hop field MUST be ignored." |
| ORF: §5.2 reset, §5.1.1 entry header, §4 capability | §6 reset, §4 entry header, §5 capability | RFC 5291 §4 "Carrying ORF Entries in BGP", §5 "Outbound Route Filtering Capability", §6 "Operation" — the section that removes a previously received ORF on an unrecognized field. §5 has no subsections, so §5.1.1 and §5.2 do not exist |

The ORF citations were inverted consistently, so the correction spans
`crates/wire/src/{orf,constants,capability,route_refresh}.rs` and
`crates/transport/src/session/{io.rs,tests/orf.rs}` in addition to the
README.

## Other wire README corrections

- The first usage example used rustdoc hidden-line syntax (`# fn handle(…)`,
  `# Ok(()) }`), but the README is not included in the crate docs, so
  crates.io and GitHub render the `#` markers literally and the published
  snippet is not copy-pastable. The wrapper is now visible and the body
  indented. All three examples were compile-checked against the current
  public API.
- `LABELED_UNICAST_SAFI` is defined in `vpn.rs` and re-exported from there;
  it was listed under the `labeled` module, so a reader copying
  `use rustbgpd_wire::labeled::LABELED_UNICAST_SAFI;` gets E0432. Replaced
  with `LabeledAddressFamily` (which is exported and was omitted) and a
  pointer to the constant's real home.
- `df_election` signature corrected to `(algorithm_id: u8, capabilities: u16,
  preference: Option<u16>)`, with a note that `algorithm_id` is masked to the
  five-bit DF Alg field.
- ROUTE-REFRESH attributed to RFC 2918 / RFC 7313 rather than RFC 4271.
- The `10005` row sorts numerically instead of below the draft row.

## Other crate READMEs

- **cli** — the claim that old daemons return an upgrade diagnostic is stale:
  that diagnostic was deleted with the legacy neighbor create carrier, and
  `neighbor::add` is now a bare `add_neighbor` call with no `InvalidArgument`
  arm. Also documents three shipped operator flags that were missing:
  `neighbor --wide`, `neighbor <addr> --compare <NEIGHBOR>`, and
  `rib --explain-peer`.
- **event-history** — storage.rs is the sole owner of the *live* connection,
  not the only place touching `rusqlite::Connection`: migrations.rs and
  sequence.rs execute against a borrowed handle, and quarantine.rs opens its
  own read-only connection (which is what its corrupted-DB detection needs).
  The cursor re-export list also named 4 of the 6 items actually re-exported.
- **transport** — the architecture paragraph described one task per peer with
  a keepalive select arm. Since ADR-0051 there are two tasks (session +
  writer), and per ADR-0078 the KEEPALIVE cadence is owned by the writer so
  it survives a session parked on a blocking RIB delivery; `timers.keepalive`
  is never armed. The feature list gains Graceful Restart / LLGR,
  Only-to-Customer, ORF, enhanced route refresh, and slow-peer detection.

## Gates

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`,
`cargo test --workspace`, `RUSTDOCFLAGS=-D warnings cargo doc --workspace
--no-deps`, `cargo test --doc -p rustbgpd-wire`, `check-clippy-reasons.py`,
`check_public_tracker_ids.py`, `check_embedding_versions.py`,
`check_embedding_crate_map.py` — all exit 0.
