### PR TITLE
ci: link Grafana queries to registered metrics

### DIFF
--- a/.github/workflows/alert-rules.yml
+++ b/.github/workflows/alert-rules.yml
@@ -10,13 +10,17 @@ on:
     paths:
       - "examples/prometheus/**"
       - "docs/grafana/rustbgpd-overview.json"
+      - "crates/telemetry/src/metrics.rs"
       - "scripts/check-grafana-dashboard.py"
+      - "scripts/test_check_grafana_dashboard.py"
       - ".github/workflows/alert-rules.yml"
   pull_request:
     paths:
       - "examples/prometheus/**"
       - "docs/grafana/rustbgpd-overview.json"
+      - "crates/telemetry/src/metrics.rs"
       - "scripts/check-grafana-dashboard.py"
+      - "scripts/test_check_grafana_dashboard.py"
       - ".github/workflows/alert-rules.yml"
 
 permissions:
@@ -28,6 +32,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
+      - name: Test Grafana dashboard checker
+        run: python3 -m unittest -v scripts/test_check_grafana_dashboard.py
       - name: Check Grafana dashboard
         run: python3 scripts/check-grafana-dashboard.py
       - name: Install promtool (pinned)

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -178,28 +178,22 @@ inside the bounded window does.
 Run the same checks as CI with:
 
 ```bash
+python3 -m unittest -v scripts/test_check_grafana_dashboard.py
 python3 scripts/check-grafana-dashboard.py
 promtool check rules examples/prometheus/rustbgpd-alerts.yml
 (cd examples/prometheus && promtool test rules rustbgpd-alerts_test.yml)
 ```
 
-The dashboard checker parses JSON, rejects duplicate panel IDs, validates the
-multi/All selector definitions, compares the required PromQL targets after
-whitespace normalization, pins the expanded full-width Route safety row, its
-three 8-by-8 panels, and discrete selection-state rendering, and checks both
-workflow path filters plus the real checker step. Its mutation proof makes
-each of these changes red: malformed JSON, a non-integer or duplicate ID,
-renaming, collapsing, resizing, or moving the required row; changing its type;
-moving or changing the type of a required panel; renaming any of the six
-route-safety metrics; declaring a second template variable over the `peer`
-label; changing either raw selection gauge to a rate; removing step
-rendering; dropping `instance` from a route-safety aggregation; weakening any of the six
-label-rich legends; dropping any seeded-series `> 0` filter; or replacing the
-executable workflow step with only a comment.
-It also pins capacity panel IDs 62–65 and their 12-by-8 layout, the exact
-queries and legends, RFC 8212 0/1 mappings and steps, the query-D-only right-axis
-override, and dynamic-neighbor panel target sets, units, and minima. Removing
-either dynamic-neighbor panel or changing any of its four queries is red.
+The dashboard checker parses JSON, rejects non-integer and duplicate panel IDs,
+and links every target and query-variable metric to a registered constructor in
+`crates/telemetry/src/metrics.rs`. Histogram `_bucket`, `_count`, and `_sum`
+series resolve only from registered histograms; aliases, empty discovery,
+unregistered constructors, comments, free strings, and test literals fail
+closed. It retains the canonical multi/All peer selector, load-bearing PromQL
+and legends, panel types, discrete state rendering, RFC 8212 mappings,
+outbound-blocking axis and exclusion, and dynamic-neighbor capacity/rejection
+semantics. Descriptions, layout, row collapsed state, and particular unique IDs
+are intentionally presentation choices rather than validation contracts.
 
 The slow-peer fixture is red if its `== 1` predicate or five-minute hold is
 changed. The RFC 8212 matrix covers import-only, export-only, and healthy peers;

--- a/scripts/check-grafana-dashboard.py
+++ b/scripts/check-grafana-dashboard.py
@@ -12,7 +12,7 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 DASHBOARD = ROOT / "docs/grafana/rustbgpd-overview.json"
-WORKFLOW = ROOT / ".github/workflows/alert-rules.yml"
+METRICS = ROOT / "crates/telemetry/src/metrics.rs"
 
 VARIABLES = {
     "peer": 'label_values(bgp_peer_admin_enabled{instance=~"$instance"}, peer)',
@@ -161,19 +161,6 @@ REQUIRED_LEGENDS = {
     ("RIB ingest pressure", "C"): "outbound work lost {{peer}}",
 }
 
-REQUIRED_DESCRIPTIONS = {
-    "Event outbox health": (
-        "Latched durability-impacting loss, committed-event delivery skip, or DB "
-        "open/recovery/quarantine failure. Expected shutdown reason=closed drops "
-        "are excluded; replay can remain available."
-    ),
-    "RIB ingest pressure": (
-        "Inbound RIB pressure safely parks producers and paces senders without "
-        "loss. Outbound drops mean BGP work was lost because a peer writer "
-        "channel was full or closed."
-    ),
-}
-
 ROUTE_SAFETY_PANELS = {
     "Export rejections / malformed UPDATEs": 0,
     "Selection-deferral state": 8,
@@ -181,17 +168,10 @@ ROUTE_SAFETY_PANELS = {
 }
 
 CAPACITY_PANELS = {
-    "RFC 8212 missing policy": (62, 0, 161),
-    "Outbound prefix capacity": (63, 12, 161),
-    "Dynamic-neighbor admission capacity": (64, 0, 169),
-    "Dynamic-neighbor admission rejections": (65, 12, 169),
-}
-
-WORKFLOW_PATHS = {
-    "examples/prometheus/**",
-    "docs/grafana/rustbgpd-overview.json",
-    "scripts/check-grafana-dashboard.py",
-    ".github/workflows/alert-rules.yml",
+    "RFC 8212 missing policy",
+    "Outbound prefix capacity",
+    "Dynamic-neighbor admission capacity",
+    "Dynamic-neighbor admission rejections",
 }
 
 
@@ -215,30 +195,155 @@ def all_panels(panels: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return flattened
 
 
-def workflow_trigger_paths(text: str) -> dict[str, set[str]]:
-    triggers: dict[str, set[str]] = {"push": set(), "pull_request": set()}
-    event: str | None = None
-    in_paths = False
-    for line in text.splitlines():
-        event_match = re.fullmatch(r"  (push|pull_request):", line)
-        if event_match:
-            event = event_match.group(1)
-            in_paths = False
-            continue
-        if event is not None and re.fullmatch(r"    paths:", line):
-            in_paths = True
-            continue
-        if in_paths:
-            path_match = re.fullmatch(r'      - ["\']([^"\']+)["\']', line)
-            if path_match:
-                triggers[event].add(path_match.group(1))
+def rust_lex(source: str) -> tuple[str, list[str]]:
+    """Mask Rust comments and literals, retaining string values as opaque tokens."""
+    output: list[str] = []
+    strings: list[str] = []
+    index = 0
+    while index < len(source):
+        if source.startswith("//", index):
+            end = source.find("\n", index)
+            index = len(source) if end < 0 else end
+        elif source.startswith("/*", index):
+            depth, end = 1, index + 2
+            while end < len(source) and depth:
+                if source.startswith("/*", end):
+                    depth += 1
+                    end += 2
+                elif source.startswith("*/", end):
+                    depth -= 1
+                    end += 2
+                else:
+                    end += 1
+            output.append(" ")
+            index = end
+        else:
+            raw = re.match(r'(?:br|r)(?P<hashes>#{0,255})"', source[index:])
+            normal = re.match(r'(?:b)?"', source[index:])
+            if raw:
+                marker = '"' + raw.group("hashes")
+                start = index + raw.end()
+                end = source.find(marker, start)
+                if end < 0:
+                    raise ValueError("unterminated Rust raw string")
+                value, index = source[start:end], end + len(marker)
+            elif normal:
+                start, end = index + normal.end(), index + normal.end()
+                while end < len(source):
+                    if source[end] == '"':
+                        slashes = 0
+                        while end > start + slashes and source[end - slashes - 1] == "\\":
+                            slashes += 1
+                        if slashes % 2 == 0:
+                            break
+                    end += 2 if source[end] == "\\" else 1
+                if end >= len(source):
+                    raise ValueError("unterminated Rust string")
+                value, index = source[start:end], end + 1
+            else:
+                output.append(source[index])
+                index += 1
                 continue
-            if line.strip() and not line.startswith("      "):
-                in_paths = False
-        if event is not None and line and not line.startswith("  "):
-            event = None
-            in_paths = False
-    return triggers
+            output.append(f"__RUST_STRING_{len(strings)}__")
+            strings.append(value)
+    return "".join(output), strings
+
+
+def dashboard_metric_references(dashboard: dict[str, Any]) -> dict[str, list[str]]:
+    references: dict[str, list[str]] = {}
+
+    def add(expression: object, context: str) -> None:
+        if not isinstance(expression, str) or not expression.strip():
+            raise ValueError(f"empty query at {context}")
+        syntax = re.sub(r'"(?:\\.|[^"\\])*"', '""', expression)
+        if re.search(r"[A-Za-z_:][A-Za-z0-9_:]*:[A-Za-z0-9_:]*", syntax):
+            raise ValueError(f"unsupported bare/colon metric alias at {context}: {expression}")
+        names = re.findall(r"(?<![$\w:])([A-Za-z_:][A-Za-z0-9_:]*)\s*(?=\{)", syntax)
+        if re.search(r"(?<![\w:])\{[^}]*__name__\s*=", syntax):
+            raise ValueError(f"metric-less __name__ selector at {context}")
+        remainder = re.sub(r"[A-Za-z_:][\w:]*\s*\{[^}]*\}", " ", syntax)
+        remainder = re.sub(r"\{[^}]*\}|\[[^]]*\]|\$\w+", " ", remainder)
+        remainder = re.sub(
+            r"\b(?:by|without|on|ignoring|group_left|group_right)\s*\([^)]*\)",
+            " ", remainder,
+        )
+        remainder = re.sub(r"\b[A-Za-z_]\w*\s*(?=\()", " ", remainder)
+        aliases = re.findall(r"\b[A-Za-z_:][\w:]*\b", remainder)
+        if aliases:
+            raise ValueError(f"unsupported bare/colon metric alias at {context}: {aliases[0]}")
+        for name in names:
+            references.setdefault(name, []).append(context)
+        if not names and "label_values" not in expression:
+            raise ValueError(f"unsupported metric-free query at {context}: {expression}")
+
+    for variable in dashboard.get("templating", {}).get("list", []):
+        if variable.get("type") != "query":
+            continue
+        query = variable.get("query")
+        match = re.fullmatch(r"\s*label_values\(\s*([A-Za-z_:][\w:]*)\s*(?:\{[^}]*\})?\s*,[^)]+\)\s*", str(query))
+        if not match:
+            raise ValueError(f"unsupported template query at ${variable.get('name')}: {query}")
+        references.setdefault(match.group(1), []).append(f"${variable.get('name')}")
+    for panel in all_panels(dashboard.get("panels", [])):
+        for target in panel.get("targets", []):
+            add(target.get("expr"), f"{panel.get('title')}/{target.get('refId')}")
+    if not references:
+        raise ValueError("no dashboard metric references discovered")
+    return references
+
+
+def rust_metric_inventory(source: str) -> dict[str, str]:
+    source, strings = rust_lex(source)
+    source = source.split("#[cfg(test)]", 1)[0]
+    constructors: dict[str, tuple[str, str]] = {}
+    pattern = re.compile(
+        r"let\s+(\w+)\s*=\s*(IntCounter(?:Vec)?|IntGauge(?:Vec)?|HistogramVec)::new\(\s*"
+        r"(?:(?:Opts|HistogramOpts)::new\(\s*)?__RUST_STRING_(\d+)__",
+        re.DOTALL,
+    )
+    for variable, kind, string_index in pattern.findall(source):
+        if variable in constructors:
+            raise ValueError(f"ambiguous metric constructor variable {variable}")
+        constructors[variable] = (strings[int(string_index)], "histogram" if kind == "HistogramVec" else "ordinary")
+    registered = re.findall(
+        r"\.register\(\s*Box::new\(\s*(\w+)\.clone\(\)\s*,?\s*\)\s*\)", source
+    )
+    inventory: dict[str, str] = {}
+    for variable in registered:
+        if variable not in constructors:
+            continue
+        name, kind = constructors[variable]
+        if name in inventory:
+            raise ValueError(f"duplicate registered metric name {name}")
+        inventory[name] = kind
+    if re.search(r"register\(\s*Box::new\(\s*jemalloc_stats::JemallocCollector::new\(\)\s*\)\s*\)", source):
+        fields = set(re.findall(r"\b(\w+)\s*:\s*IntGauge\b", source))
+        bodies = re.findall(r"(?<!-> )\bSelf\s*\{([^}]*)\}", source)
+        wired: dict[str, set[str]] = {}
+        for body in bodies:
+            for entry in body.split(","):
+                parts = [part.strip() for part in entry.split(":", 1)]
+                field, variable = (parts[0], parts[-1])
+                wired.setdefault(variable, set()).add(field)
+        emitted = set(re.findall(r"self\.(\w+)\.collect\(\)", source))
+        for variable, (name, kind) in constructors.items():
+            if name.startswith("jemalloc_") and wired.get(variable, set()) & fields & emitted:
+                inventory[name] = kind
+    if not inventory:
+        raise ValueError("no registered Rust metrics discovered")
+    return inventory
+
+
+def check_metric_linkage(references: dict[str, list[str]], inventory: dict[str, str]) -> None:
+    unresolved: list[str] = []
+    for name, contexts in sorted(references.items()):
+        if name in inventory:
+            continue
+        base = next((name.removesuffix(suffix) for suffix in ("_bucket", "_count", "_sum") if name.endswith(suffix)), None)
+        if base is None or inventory.get(base) != "histogram":
+            unresolved.append(f"{name} ({', '.join(contexts)})")
+    if unresolved:
+        raise ValueError("unregistered dashboard metrics: " + "; ".join(unresolved))
 
 
 def main() -> None:
@@ -303,11 +408,6 @@ def main() -> None:
         if actual != [expected]:
             fail(f"target {key[0]!r}/{key[1]} must use legend {expected!r}; got {actual!r}")
 
-    for title, expected in REQUIRED_DESCRIPTIONS.items():
-        panel = next((item for item in panels if item.get("title") == title), None)
-        if panel is None or panel.get("description") != expected:
-            fail(f"panel {title!r} must use exact contract description {expected!r}")
-
     update_group_panel = next(
         panel for panel in panels if panel.get("title") == "Update group by peer"
     )
@@ -333,8 +433,6 @@ def main() -> None:
     )
     if truth_panel.get("type") != "timeseries":
         fail("peer administrative/session truth must use a timeseries panel")
-    if truth_panel.get("gridPos") != {"h": 8, "w": 8, "x": 16, "y": 5}:
-        fail("peer administrative/session truth must remain compact in Session health")
     truth_defaults = truth_panel.get("fieldConfig", {}).get("defaults", {})
     if (
         truth_defaults.get("decimals") != 0
@@ -350,20 +448,10 @@ def main() -> None:
     )
     if route_safety_row is None or route_safety_row.get("type") != "row":
         fail("Route safety must exist as a dashboard row")
-    if route_safety_row.get("collapsed") is not False:
-        fail("Route safety row must be expanded by default")
-    row_position = route_safety_row.get("gridPos", {})
-    expected_row_position = {"h": 1, "w": 24, "x": 0, "y": 152}
-    if row_position != expected_row_position:
-        fail(f"Route safety row must use grid position {expected_row_position}")
-    for title, expected_x in ROUTE_SAFETY_PANELS.items():
+    for title in ROUTE_SAFETY_PANELS:
         panel = next((item for item in panels if item.get("title") == title), None)
         if panel is None or panel.get("type") != "timeseries":
             fail(f"{title} must exist as a timeseries panel")
-        position = panel.get("gridPos", {})
-        expected_position = {"h": 8, "w": 8, "x": expected_x, "y": 153}
-        if position != expected_position:
-            fail(f"{title} must use route-safety grid position {expected_position}")
 
     selection_panel = next(
         panel for panel in panels if panel.get("title") == "Selection-deferral state"
@@ -374,15 +462,10 @@ def main() -> None:
     if selection_defaults.get("custom", {}).get("lineInterpolation") != "stepAfter":
         fail("selection-deferral state must use step interpolation")
 
-    for title, (expected_id, expected_x, expected_y) in CAPACITY_PANELS.items():
+    for title in CAPACITY_PANELS:
         panel = next((item for item in panels if item.get("title") == title), None)
         if panel is None or panel.get("type") != "timeseries":
             fail(f"{title} must exist as a timeseries panel")
-        if panel.get("id") != expected_id:
-            fail(f"{title} must use panel id {expected_id}")
-        expected_position = {"h": 8, "w": 12, "x": expected_x, "y": expected_y}
-        if panel.get("gridPos") != expected_position:
-            fail(f"{title} must use compact grid position {expected_position}")
 
     rfc8212_panel = next(
         panel for panel in panels if panel.get("title") == "RFC 8212 missing policy"
@@ -471,23 +554,15 @@ def main() -> None:
         fail("dynamic-neighbor rejection rate must render as nonnegative operations")
 
     try:
-        workflow_text = WORKFLOW.read_text(encoding="utf-8")
-    except OSError as error:
-        fail(f"cannot read {WORKFLOW.relative_to(ROOT)}: {error}")
-    for event, paths in workflow_trigger_paths(workflow_text).items():
-        missing = sorted(WORKFLOW_PATHS - paths)
-        if missing:
-            fail(f"{event} paths are missing {missing}")
-    checker_steps = sum(
-        line.strip() == "run: python3 scripts/check-grafana-dashboard.py"
-        for line in workflow_text.splitlines()
-    )
-    if checker_steps != 1:
-        fail("workflow must contain exactly one executable dashboard-checker step")
+        references = dashboard_metric_references(dashboard)
+        inventory = rust_metric_inventory(METRICS.read_text(encoding="utf-8"))
+        check_metric_linkage(references, inventory)
+    except (OSError, ValueError) as error:
+        fail(str(error))
 
     print(
         f"dashboard check: {len(panels)} unique panels, "
-        f"{len(TARGETS)} operator targets, and workflow triggers are valid"
+        f"{len(TARGETS)} operator targets, and {len(references)} linked metrics"
     )
 
 

--- a/scripts/test_check_grafana_dashboard.py
+++ b/scripts/test_check_grafana_dashboard.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+import importlib.util
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+PATH = Path(__file__).with_name("check-grafana-dashboard.py")
+SPEC = importlib.util.spec_from_file_location("dashboard_check", PATH)
+CHECK = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECK)
+
+
+class DashboardMetricLinkTests(unittest.TestCase):
+    def rust(self, kind="IntGauge", name="bgp_ready", registered=True):
+        registration = (
+            "registry.register(Box::new(ready.clone())).unwrap();" if registered else ""
+        )
+        return f'''let ready = {kind}::new("{name}", "help").unwrap();
+{registration}
+#[cfg(test)] mod tests {{ const OLD: &str = "bgp_old"; }}'''
+
+    def refs(self, expression='bgp_ready{instance="$instance"}'):
+        dashboard = {
+            "templating": {"list": [{"name": "instance", "type": "query",
+                "query": "label_values(bgp_ready, instance)"}]},
+            "panels": [{"id": 1, "title": "Health", "targets": [
+                {"refId": "A", "expr": expression}]}],
+        }
+        return CHECK.dashboard_metric_references(dashboard)
+
+    def test_registered_metric_resolves(self):
+        CHECK.check_metric_linkage(self.refs(), CHECK.rust_metric_inventory(self.rust()))
+
+    def test_line_comments_preserve_one_newline_and_handle_eof(self):
+        self.assertEqual(CHECK.rust_lex("left// one\nright"), ("left\nright", []))
+        self.assertEqual(CHECK.rust_lex("left// one\n// two\nright"), ("left\n\nright", []))
+        self.assertEqual(CHECK.rust_lex("left// eof"), ("left", []))
+
+    def test_registration_rename_ignores_old_comment_and_test_literal(self):
+        rust = self.rust(name="bgp_new").replace(
+            "#[cfg(test)]", "// bgp_ready remains documented here\n#[cfg(test)]"
+        )
+        with self.assertRaisesRegex(ValueError, "bgp_ready.*Health/A"):
+            CHECK.check_metric_linkage(self.refs(), CHECK.rust_metric_inventory(rust))
+
+    def test_dashboard_typo_reports_context(self):
+        with self.assertRaisesRegex(ValueError, "bgp_typo.*Health/A"):
+            CHECK.check_metric_linkage(
+                self.refs("bgp_typo{instance=\"x\"}"),
+                CHECK.rust_metric_inventory(self.rust()),
+            )
+
+    def test_histogram_suffixes_are_kind_aware(self):
+        histogram = CHECK.rust_metric_inventory(
+            self.rust("HistogramVec", "bgp_latency_seconds")
+        )
+        refs = {"bgp_latency_seconds_bucket": ["Health/A"],
+                "bgp_latency_seconds_count": ["Health/B"],
+                "bgp_latency_seconds_sum": ["Health/C"]}
+        CHECK.check_metric_linkage(refs, histogram)
+        with self.assertRaisesRegex(ValueError, "bgp_ready_bucket"):
+            CHECK.check_metric_linkage(
+                {"bgp_ready_bucket": ["Health/A"]},
+                CHECK.rust_metric_inventory(self.rust()),
+            )
+
+    def test_functions_labels_and_literals_are_not_metrics(self):
+        refs = self.refs('sum by (peer) (rate(bgp_ready{state="up"}[5m])) > 0')
+        self.assertEqual(set(refs), {"bgp_ready"})
+
+    def test_recording_rule_alias_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "unsupported.*recording:alias"):
+            CHECK.dashboard_metric_references({"templating": {"list": []},
+                "panels": [{"id": 1, "title": "X", "targets": [
+                    {"refId": "A", "expr": "recording:alias"}]}]})
+
+    def test_empty_reference_and_inventory_fail_closed(self):
+        with self.assertRaisesRegex(ValueError, "no dashboard metric"):
+            CHECK.dashboard_metric_references({"templating": {"list": []}, "panels": []})
+        with self.assertRaisesRegex(ValueError, "no registered Rust metrics"):
+            CHECK.rust_metric_inventory("// bgp_ready")
+
+    def test_unregistered_constructor_and_free_strings_do_not_count(self):
+        rust = self.rust(registered=False).replace(
+            "#[cfg(test)]",
+            '// let fake = IntGauge::new("bgp_ready", "help").unwrap();\n'
+            "// registry.register(Box::new(fake.clone())).unwrap();\n"
+            "#[cfg(test)]",
+        ) + '\nlet note = "bgp_ready";'
+        with self.assertRaisesRegex(ValueError, "no registered Rust metrics"):
+            CHECK.rust_metric_inventory(rust)
+
+    def test_jemalloc_metric_requires_collect_emission(self):
+        rust = '''registry.register(Box::new(jemalloc_stats::JemallocCollector::new()));
+struct JemallocCollector { allocated: IntGauge }
+let allocated = IntGauge::new("jemalloc_allocated_bytes", "help").unwrap();
+Self { allocated }
+let families = self.allocated.collect();'''
+        self.assertIn("jemalloc_allocated_bytes", CHECK.rust_metric_inventory(rust))
+        for old, new in [
+            ("JemallocCollector::new()", "OtherCollector::new()"),
+            ("allocated: IntGauge", "other: IntGauge"),
+            ("Self { allocated }", "Self { other: allocated }"),
+            ("self.allocated.collect()", "vec![]"),
+        ]:
+            with self.subTest(mutation=old), self.assertRaises(ValueError):
+                CHECK.rust_metric_inventory(rust.replace(old, new))
+
+    def test_mixed_bare_alias_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "recording_alias"):
+            self.refs('bgp_ready{x="y"} + recording_alias')
+
+    def test_mixed_metricless_name_selector_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "__name__"):
+            self.refs('bgp_ready{x="y"} + {__name__=~"bgp_.*"}')
+
+    def test_code_shaped_normal_and_raw_strings_do_not_count(self):
+        fake = 'let fake = IntGauge::new("bgp_fake", "help").unwrap(); registry.register(Box::new(fake.clone()));'
+        escaped = fake.replace('"', '\\"')
+        source = f'let text = "{escaped}"; let raw = r#"{fake}"#;'
+        with self.assertRaisesRegex(ValueError, "no registered Rust metrics"):
+            CHECK.rust_metric_inventory(source)
+
+    def test_live_dashboard_presentation_mutations_pass_full_check(self):
+        dashboard = json.loads(CHECK.DASHBOARD.read_text())
+        for index, panel in enumerate(CHECK.all_panels(dashboard["panels"])):
+            panel.update(description="changed", collapsed=not panel.get("collapsed", False),
+                         gridPos={"x": index % 24}, id=panel["id"] + 1000)
+        with tempfile.TemporaryDirectory() as directory:
+            copy = Path(directory) / "dashboard.json"
+            copy.write_text(json.dumps(dashboard))
+            original, CHECK.DASHBOARD = CHECK.DASHBOARD, copy
+            try:
+                with redirect_stdout(io.StringIO()):
+                    CHECK.main()
+            finally:
+                CHECK.DASHBOARD = original
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Link every shipped Grafana query metric to a recognized Rust metric constructor that is actually registered or emitted.
- Preserve the load-bearing peer selector, PromQL, legends, discrete-state rendering, RFC 8212, outbound-capacity, and dynamic-neighbor checks.
- Stop treating descriptions, layout, row expansion, fixed IDs, and workflow self-inspection as product contracts.
- Run focused mutation tests and the live checker whenever the dashboard, telemetry metrics, or checker changes.

## Why

The previous checker could stay green after a daemon-side metric rename while panels went blank, yet ordinary dashboard prose or layout edits failed CI. This changes the guard to follow the real failure boundary: dashboard references must resolve to metrics the daemon can export.

The Rust inventory is fail closed. It masks comments and strings, intersects recognized constructors with explicit registration, verifies custom jemalloc field wiring and collection, and only derives histogram suffixes from registered histograms. Mixed bare aliases and metric-less name selectors are rejected.

## Impact

This is maintainer-facing CI only. The dashboard JSON, exported metrics, alert rules, and operator-visible PromQL are unchanged. Presentation edits no longer require checker maintenance; missing or unexported metrics now fail with panel or template context.

## Validation

- `python3 -m unittest -v scripts/test_check_grafana_dashboard.py` — 13 passed
- `python3 scripts/check-grafana-dashboard.py` — 87 linked metrics
- `python3 -m unittest discover -s scripts -p 'test_check_*.py'` — 102 passed
- Independent destructive replay covered jemalloc emission, mixed aliases, metric-less name selectors, code-shaped strings, registration wiring, and histogram kind
- `git diff --check`
- Commit and push hooks: formatting, clippy, tests, and rustdoc green where applicable

The pinned promtool workflow steps and rule assets are unchanged; those checks run in hosted CI.

Refs LAN-962.
