### PR TITLE
refactor: pass EVPN convergence results into commit gate

### DIFF
--- a/crates/evpn/src/lib.rs
+++ b/crates/evpn/src/lib.rs
@@ -162,9 +162,9 @@ pub use projection::{
 pub use route_target::{RouteTarget, RouteTargetParseError};
 pub use runtime::{
     EvpnRuntimeApplyError, EvpnRuntimeApplyOutcome, EvpnRuntimeApplyReport, EvpnRuntimeCandidate,
-    EvpnRuntimeChangeSet, EvpnRuntimeConvergeError, EvpnRuntimeConverger, EvpnRuntimeCoordinator,
-    EvpnRuntimeGeneration, EvpnRuntimeLifecycle, EvpnRuntimeModel, EvpnRuntimeMutationState,
-    EvpnRuntimePlan, EvpnRuntimeSnapshot,
+    EvpnRuntimeChangeSet, EvpnRuntimeConvergeError, EvpnRuntimeCoordinator, EvpnRuntimeGeneration,
+    EvpnRuntimeLifecycle, EvpnRuntimeModel, EvpnRuntimeMutationState, EvpnRuntimePlan,
+    EvpnRuntimeSnapshot,
 };
 pub use segment::{DfAlgorithm, DfRole, EthernetSegment, RedundancyMode};
 

--- a/crates/evpn/src/runtime.rs
+++ b/crates/evpn/src/runtime.rs
@@ -337,31 +337,6 @@ impl EvpnRuntimeCandidate {
     }
 }
 
-/// Accepts or rejects the convergence work required before a candidate
-/// model may become the committed EVPN runtime generation.
-///
-/// The first coordinator slice keeps this trait synchronous and domain
-/// local so tests can prove the commit gate without daemon actor wiring.
-/// Later daemon code can back the trait with command queues that drain
-/// and replay IMET, Type 2, Type 5, ES/DF, SVI, and dataplane state.
-pub trait EvpnRuntimeConverger {
-    /// Queue or perform all convergence required by `plan`.
-    ///
-    /// Returning `Ok(())` authorizes the coordinator to publish the
-    /// candidate as the next committed generation. Returning an error
-    /// leaves the previous generation committed.
-    ///
-    /// # Errors
-    /// Returns [`EvpnRuntimeConvergeError`] when downstream convergence
-    /// could not be queued safely.
-    fn converge(
-        &mut self,
-        current: &EvpnRuntimeModel,
-        candidate: &EvpnRuntimeCandidate,
-        plan: &EvpnRuntimePlan,
-    ) -> Result<(), EvpnRuntimeConvergeError>;
-}
-
 /// Convergence failure reported by a coordinator backend.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[error("{message}")]
@@ -451,11 +426,10 @@ impl EvpnRuntimeApplyError {
 /// Coordinator-owned EVPN runtime model writer.
 ///
 /// This type is the first ADR-0063 write boundary. It does not expose a
-/// public gRPC API and does not mutate daemon actors directly; instead,
-/// it proves the state-machine contract that later daemon wiring must
-/// use: plan a fully validated candidate, ask a convergence backend to
-/// queue all required drain/replay work, and only then publish the next
-/// committed generation.
+/// public gRPC API and does not mutate daemon actors directly. Daemon
+/// convergence happens before this transition; the supplied result either
+/// publishes the candidate or retains the committed model and records the
+/// failed plan.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EvpnRuntimeCoordinator {
     model: EvpnRuntimeModel,
@@ -523,20 +497,17 @@ impl EvpnRuntimeCoordinator {
         self.last_converge_error.as_ref()
     }
 
-    /// Apply a fully validated candidate through the convergence gate.
+    /// Apply a fully validated candidate with its daemon convergence result.
     ///
     /// # Errors
-    /// Returns [`EvpnRuntimeApplyError`] when the convergence backend
-    /// rejects the plan. In that case the previous generation remains
+    /// Returns [`EvpnRuntimeApplyError`] when convergence failed. In that
+    /// case the previous generation remains
     /// committed and the coordinator snapshot reports degraded/failed.
-    pub fn apply_candidate<C>(
+    pub fn apply_candidate(
         &mut self,
         candidate: EvpnRuntimeCandidate,
-        converger: &mut C,
-    ) -> Result<EvpnRuntimeApplyReport, EvpnRuntimeApplyError>
-    where
-        C: EvpnRuntimeConverger,
-    {
+        converge_result: Result<(), EvpnRuntimeConvergeError>,
+    ) -> Result<EvpnRuntimeApplyReport, EvpnRuntimeApplyError> {
         let current = self.model.clone();
         let plan = current.plan_candidate(&candidate);
         if plan.is_noop() {
@@ -553,7 +524,7 @@ impl EvpnRuntimeCoordinator {
             COORDINATOR_IN_PROGRESS_MESSAGE,
         );
 
-        if let Err(source) = converger.converge(&current, &candidate, &plan) {
+        if let Err(source) = converge_result {
             self.model = current.with_status(
                 EvpnRuntimeLifecycle::Degraded,
                 EvpnRuntimeMutationState::Failed,
@@ -988,7 +959,7 @@ mod tests {
         observed_candidate_counts: Vec<usize>,
     }
 
-    impl EvpnRuntimeConverger for RecordingConverger {
+    impl RecordingConverger {
         fn converge(
             &mut self,
             current: &EvpnRuntimeModel,
@@ -1030,13 +1001,15 @@ mod tests {
             Vec::new(),
         );
         let candidate = EvpnRuntimeCandidate::from_model(coordinator.model());
-        let mut converger = RecordingConverger {
+        let converger = RecordingConverger {
             fail: Some(EvpnRuntimeConvergeError::new("should not be called")),
             ..RecordingConverger::default()
         };
-
         let report = coordinator
-            .apply_candidate(candidate, &mut converger)
+            .apply_candidate(
+                candidate,
+                Err(EvpnRuntimeConvergeError::new("ignored for no-op")),
+            )
             .expect("no-op candidate should not require convergence");
 
         assert_eq!(report.outcome, EvpnRuntimeApplyOutcome::Noop);
@@ -1069,9 +1042,10 @@ mod tests {
             Vec::new(),
         );
         let mut converger = RecordingConverger::default();
-
+        let plan = coordinator.plan_candidate(&candidate);
+        let converge_result = converger.converge(coordinator.model(), &candidate, &plan);
         let report = coordinator
-            .apply_candidate(candidate, &mut converger)
+            .apply_candidate(candidate, converge_result)
             .expect("accepted convergence should commit the candidate");
 
         assert_eq!(report.outcome, EvpnRuntimeApplyOutcome::Committed);
@@ -1088,12 +1062,9 @@ mod tests {
             coordinator.snapshot().message,
             COORDINATOR_COMMITTED_MESSAGE
         );
-        assert_eq!(converger.calls, 1);
-        assert_eq!(converger.observed_current_generation, vec![1]);
-        assert_eq!(converger.observed_added_vnis, vec![vec![200]]);
-        assert_eq!(converger.observed_candidate_counts, vec![2]);
         assert!(coordinator.last_failed_plan().is_none());
         assert!(coordinator.last_converge_error().is_none());
+        assert_eq!(converger.calls, 1);
     }
 
     #[test]
@@ -1115,9 +1086,10 @@ mod tests {
             fail: Some(EvpnRuntimeConvergeError::new("IMET command queue closed")),
             ..RecordingConverger::default()
         };
-
+        let plan = coordinator.plan_candidate(&candidate);
+        let converge_result = converger.converge(coordinator.model(), &candidate, &plan);
         let error = coordinator
-            .apply_candidate(candidate, &mut converger)
+            .apply_candidate(candidate.clone(), converge_result)
             .expect_err("failed convergence should reject the candidate");
 
         assert_eq!(
@@ -1150,6 +1122,32 @@ mod tests {
                 .expect("converge error retained")
                 .message(),
             "IMET command queue closed"
+        );
+
+        let noop = EvpnRuntimeCandidate::from_model(coordinator.model());
+        let report = coordinator
+            .apply_candidate(noop, Ok(()))
+            .expect("no-op after failure should retain the committed model");
+        assert_eq!(report.outcome, EvpnRuntimeApplyOutcome::Noop);
+        assert_eq!(
+            coordinator.snapshot().mutation_state,
+            EvpnRuntimeMutationState::Failed
+        );
+        assert!(
+            coordinator.last_failed_plan().is_some() && coordinator.last_converge_error().is_some()
+        );
+
+        let report = coordinator
+            .apply_candidate(candidate, Ok(()))
+            .expect("successful non-noop should clear prior failure");
+        assert_eq!(report.outcome, EvpnRuntimeApplyOutcome::Committed);
+        assert_eq!(coordinator.snapshot().generation.as_u64(), 2);
+        assert_eq!(
+            coordinator.snapshot().mutation_state,
+            EvpnRuntimeMutationState::Idle
+        );
+        assert!(
+            coordinator.last_failed_plan().is_none() && coordinator.last_converge_error().is_none()
         );
         assert_eq!(converger.calls, 1);
     }

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -146,15 +146,12 @@ pub(crate) struct EvpnRuntimeReloadApply {
 }
 
 impl EvpnRuntimeReloadApply {
-    pub(crate) fn new<C>(
+    pub(crate) fn new(
         coordinator: Arc<Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>>,
         apply_lock: Arc<tokio::sync::Mutex<()>>,
-        converger: Arc<C>,
+        converger: Arc<dyn DaemonEvpnRuntimeConverger>,
         committed_config: Config,
-    ) -> Self
-    where
-        C: DaemonEvpnRuntimeConverger + 'static,
-    {
+    ) -> Self {
         Self {
             coordinator,
             apply_lock,
@@ -364,34 +361,6 @@ fn response_to_reload_outcome(
         value => Err(GrpcEvpnRuntimeApplyError::Internal(format!(
             "EVPN runtime reload returned unexpected outcome value {value}"
         ))),
-    }
-}
-
-struct PreconvergedRuntimeConverger;
-
-impl rustbgpd_evpn::EvpnRuntimeConverger for PreconvergedRuntimeConverger {
-    fn converge(
-        &mut self,
-        _current: &rustbgpd_evpn::EvpnRuntimeModel,
-        _candidate: &rustbgpd_evpn::EvpnRuntimeCandidate,
-        _plan: &rustbgpd_evpn::EvpnRuntimePlan,
-    ) -> Result<(), rustbgpd_evpn::EvpnRuntimeConvergeError> {
-        Ok(())
-    }
-}
-
-struct FailedRuntimeConverger {
-    source: rustbgpd_evpn::EvpnRuntimeConvergeError,
-}
-
-impl rustbgpd_evpn::EvpnRuntimeConverger for FailedRuntimeConverger {
-    fn converge(
-        &mut self,
-        _current: &rustbgpd_evpn::EvpnRuntimeModel,
-        _candidate: &rustbgpd_evpn::EvpnRuntimeCandidate,
-        _plan: &rustbgpd_evpn::EvpnRuntimePlan,
-    ) -> Result<(), rustbgpd_evpn::EvpnRuntimeConvergeError> {
-        Err(self.source.clone())
     }
 }
 
@@ -3701,15 +3670,12 @@ fn evpn_runtime_candidate_from_config(
 }
 
 #[cfg(test)]
-pub(crate) async fn apply_evpn_runtime_request<C>(
+pub(crate) async fn apply_evpn_runtime_request(
     request: &proto::ApplyEvpnRuntimeRequest,
     coordinator: &Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>,
     apply_lock: &tokio::sync::Mutex<()>,
-    converger: &C,
-) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError>
-where
-    C: DaemonEvpnRuntimeConverger + ?Sized,
-{
+    converger: &dyn DaemonEvpnRuntimeConverger,
+) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError> {
     apply_evpn_runtime_request_with_metrics(
         request,
         coordinator,
@@ -3723,16 +3689,13 @@ where
 /// Same as [`apply_evpn_runtime_request`] but with a caller-owned metrics
 /// handle, so a test can assert the fail-stop counter moved.
 #[cfg(test)]
-pub(crate) async fn apply_evpn_runtime_request_with_metrics<C>(
+pub(crate) async fn apply_evpn_runtime_request_with_metrics(
     request: &proto::ApplyEvpnRuntimeRequest,
     coordinator: &Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>,
     apply_lock: &tokio::sync::Mutex<()>,
-    converger: &C,
+    converger: &dyn DaemonEvpnRuntimeConverger,
     metrics: &BgpMetrics,
-) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError>
-where
-    C: DaemonEvpnRuntimeConverger + ?Sized,
-{
+) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError> {
     let candidate = evpn_runtime_candidate_from_toml(&request.candidate_toml)?;
     let _apply_guard = apply_lock.lock().await;
     apply_evpn_runtime_candidate_locked(
@@ -3749,16 +3712,13 @@ where
     clippy::too_many_lines,
     reason = "the plan/validate-only/converge/decompose/commit sequence reads clearest as one flow"
 )]
-async fn apply_evpn_runtime_candidate_locked<C>(
+async fn apply_evpn_runtime_candidate_locked(
     candidate: rustbgpd_evpn::EvpnRuntimeCandidate,
     validate_only: bool,
     coordinator: &Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>,
-    converger: &C,
+    converger: &dyn DaemonEvpnRuntimeConverger,
     metrics: &BgpMetrics,
-) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError>
-where
-    C: DaemonEvpnRuntimeConverger + ?Sized,
-{
+) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError> {
     let (current, plan, snapshot) = {
         let coordinator = coordinator.lock().map_err(|_| {
             GrpcEvpnRuntimeApplyError::Internal(
@@ -3937,8 +3897,7 @@ where
                     "EVPN runtime coordinator lock poisoned".to_string(),
                 )
             })?;
-            let mut failed = FailedRuntimeConverger { source };
-            let _ = coordinator.apply_candidate(candidate, &mut failed);
+            let _ = coordinator.apply_candidate(candidate, Err(source));
         }
         return Err(GrpcEvpnRuntimeApplyError::FailedPrecondition(format!(
             "EVPN runtime mutation failed: {}; generation {} remains committed",
@@ -3950,9 +3909,8 @@ where
     let mut coordinator = coordinator.lock().map_err(|_| {
         GrpcEvpnRuntimeApplyError::Internal("EVPN runtime coordinator lock poisoned".to_string())
     })?;
-    let mut preconverged = PreconvergedRuntimeConverger;
     let report = coordinator
-        .apply_candidate(candidate, &mut preconverged)
+        .apply_candidate(candidate, Ok(()))
         .map_err(|err| GrpcEvpnRuntimeApplyError::FailedPrecondition(err.to_string()))?;
     let snapshot = coordinator.snapshot();
     Ok(proto::ApplyEvpnRuntimeResponse {
@@ -3974,16 +3932,13 @@ where
 /// converge pins the coordinator exactly like the single-shot path, and
 /// the error + `ERROR` log name the completed generations, the failed
 /// step, and the re-SIGHUP recovery. The caller holds the apply lock.
-async fn apply_decomposed_evpn_runtime_steps<C>(
+async fn apply_decomposed_evpn_runtime_steps(
     steps: Vec<crate::evpn_plan_decomposer::DecomposedStep>,
     overall_plan: &rustbgpd_evpn::EvpnRuntimePlan,
     coordinator: &Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>,
-    converger: &C,
+    converger: &dyn DaemonEvpnRuntimeConverger,
     metrics: &BgpMetrics,
-) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError>
-where
-    C: DaemonEvpnRuntimeConverger + ?Sized,
-{
+) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError> {
     let lock_coordinator = || {
         coordinator.lock().map_err(|_| {
             GrpcEvpnRuntimeApplyError::Internal(
@@ -4016,8 +3971,7 @@ where
         {
             if let DaemonEvpnRuntimeConvergeError::Failed(source) = error.clone() {
                 let mut coordinator = lock_coordinator()?;
-                let mut failed = FailedRuntimeConverger { source };
-                let _ = coordinator.apply_candidate(step.candidate.clone(), &mut failed);
+                let _ = coordinator.apply_candidate(step.candidate.clone(), Err(source));
                 // Fail-stop pinned the coordinator (mutation_state=Failed);
                 // the ERROR log below carries the human detail.
                 metrics.add_evpn_runtime_decomposed_fail_stops(1);
@@ -4049,9 +4003,8 @@ where
         }
         let report = {
             let mut coordinator = lock_coordinator()?;
-            let mut preconverged = PreconvergedRuntimeConverger;
             coordinator
-                .apply_candidate(step.candidate, &mut preconverged)
+                .apply_candidate(step.candidate, Ok(()))
                 .map_err(|err| GrpcEvpnRuntimeApplyError::FailedPrecondition(err.to_string()))?
         };
         tracing::info!(


### PR DESCRIPTION
## Summary

- Replace the synchronous EVPN domain converger callback with one commit-gate transition that consumes the already-known convergence result.
- Remove the daemon-side preconverged and failed adapter stubs that only replayed constant answers.
- Use the existing daemon converger as a trait object at reload/apply helper boundaries instead of carrying unnecessary generic parameters.

## Why

Actual EVPN convergence is asynchronous and actor-owned. The domain coordinator was nevertheless parameterized by a synchronous trait, so the daemon performed convergence first and then constructed a fake success or failure implementation solely to drive bookkeeping. That duplicated the boundary without adding behavior or testability.

The coordinator now receives the candidate and convergence result together. It remains the sole commit gate and preserves the same plan recomputation, no-op behavior, lifecycle transitions, generation and table publication, retained failure state, and recovery semantics.

## Impact

This is an internal simplification in an unpublished crate. There is no config, wire, protobuf, SIGHUP, actor-ordering, rollback, or operator-visible behavior change. Unsupported convergence shapes still remain outside the coordinator and do not degrade runtime state.

## Validation

- EVPN coordinator tests: 10 passed in independent audit
- Daemon EVPN converger module: 114 passed in independent audit
- Focused no-op, success, unsupported, failure, decomposition, and fail-stop recovery tests
- Four destructive mutations for accidental commit, omitted failure recording, unsupported degradation, and decomposed failure recording
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --quiet`
- `cargo fmt --all -- --check`
- `git diff --check`

The final diff removes 55 net lines across exactly three files.

Refs LAN-964.
