### PR TITLE
cleanup: remove non-Linux daemon fallbacks

### DIFF
--- a/src/bfd_runtime.rs
+++ b/src/bfd_runtime.rs
@@ -295,45 +295,6 @@ pub struct BfdRuntimeEvent {
 #[allow(unused_imports)]
 pub use linux::{BfdRuntimeHandle, spawn};
 
-#[cfg(not(target_os = "linux"))]
-pub use stub::{BfdRuntimeHandle, spawn};
-
-#[cfg(not(target_os = "linux"))]
-mod stub {
-    use super::{BfdRuntimeConfig, BfdRuntimeEvent, BfdStateChangeSender, BfdStatus};
-    use rustbgpd_telemetry::BgpMetrics;
-    use tokio::sync::{broadcast, watch};
-    use tokio_util::sync::CancellationToken;
-
-    /// Non-Linux placeholder handle (BFD sockets are Linux-only).
-    pub struct BfdRuntimeHandle;
-
-    impl BfdRuntimeHandle {
-        /// No-op shutdown.
-        pub async fn shutdown(self) {}
-    }
-
-    /// BFD is unsupported off Linux; disabled startup is a no-op and
-    /// configured startup fails closed.
-    pub fn spawn(
-        desired_rx: watch::Receiver<BfdRuntimeConfig>,
-        _metrics: BgpMetrics,
-        _status_tx: watch::Sender<Vec<BfdStatus>>,
-        _event_tx: broadcast::Sender<BfdRuntimeEvent>,
-        _state_change_tx: BfdStateChangeSender,
-        _shutdown: CancellationToken,
-    ) -> std::io::Result<Option<BfdRuntimeHandle>> {
-        if desired_rx.borrow().enabled() {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::Unsupported,
-                "configured BFD runtime requires Linux",
-            ))
-        } else {
-            Ok(None)
-        }
-    }
-}
-
 /// RFC 5880 §6.8.6 demultiplexing decision (pure, testable): pick the session a
 /// received packet belongs to. A non-zero Your Discriminator selects the session
 /// by *our* local discriminator (which the peer echoes back in that field); a
@@ -342,8 +303,7 @@ mod stub {
 /// 5881 §5 warns against identifying an established single-hop session by source
 /// address). Returns the peer key, or `None` if no session matches.
 ///
-/// Gated to Linux (where the actor runs) plus test builds; the non-Linux stub
-/// has no receive path, so without this gate it would be dead code there.
+/// Gated to Linux (where the actor runs) plus test builds.
 #[cfg(any(test, target_os = "linux"))]
 fn demux_target(
     by_discriminator: &std::collections::HashMap<u32, std::net::IpAddr>,

--- a/src/blackhole.rs
+++ b/src/blackhole.rs
@@ -281,14 +281,6 @@ pub fn spawn(
             }
         }
     }
-
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = (rib_tx, status_tx, shutdown);
-        metrics.record_blackhole_discard_kernel_failure("unsupported_platform");
-        warn!("BLACKHOLE discard install requested, but kernel FIB programming is Linux-only");
-        None
-    }
 }
 
 fn spawn_with_fib<F>(

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -449,24 +449,6 @@ pub async fn spawn_with_quarantine(
             }
         }
     }
-
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = (
-            config,
-            managed_netdevs,
-            rib_tx,
-            metrics,
-            daemon_shutdown,
-            duplicate_mac_quarantine_rx,
-        );
-        info!(
-            target = std::env::consts::OS,
-            "EVPN Linux dataplane not available on this platform; \
-             skipping reconciler spawn"
-        );
-        None
-    }
 }
 
 /// Generic spawn shared by the production path and the integration

--- a/src/evpn_es_link_drain.rs
+++ b/src/evpn_es_link_drain.rs
@@ -11,7 +11,7 @@
 //!
 //! - **Carrier down → drain immediately.** A bound name absent from
 //!   the kernel projection counts as down (fail-closed), as does a
-//!   monitor that cannot run at all (spawn failure, non-Linux build).
+//!   monitor that cannot run at all (spawn failure).
 //! - **Carrier up → hold `recovery_delay_secs`, then undrain.** The
 //!   hold re-arms on every up edge, so a flapping circuit stays
 //!   drained until it holds carrier for the full window (decision 3).
@@ -81,8 +81,7 @@ pub(crate) struct EsLinkDrainDeps {
 /// Where carrier state comes from.
 pub(crate) enum CarrierFeed {
     /// Lazily spawn and own the slice-1 kernel monitor for the bound
-    /// link names (Linux only; elsewhere bound links fail closed to
-    /// down).
+    /// link names; monitor failures fail closed to down.
     Kernel,
     /// Test-injected carrier watch; the watched-name set is whatever
     /// the test publishes.
@@ -323,14 +322,6 @@ impl FeedState {
                     self.fail_closed(watched, fallback_tx);
                 }
             }
-        }
-        #[cfg(not(target_os = "linux"))]
-        {
-            warn!(
-                "Ethernet Segment interface bindings require Linux rtnetlink; bound \
-                 segments fail closed to drained on this platform"
-            );
-            self.fail_closed(watched, fallback_tx);
         }
     }
 }

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -227,14 +227,6 @@ pub fn spawn(
             }
         }
     }
-
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = (rib_tx, rib_query_tx, status_tx, event_tx, shutdown);
-        metrics.record_fib_kernel_failure("unsupported_platform");
-        warn!("general FIB install requested, but kernel route programming is Linux-only");
-        None
-    }
 }
 
 #[expect(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1347,11 +1347,6 @@ fn sample_gr_restart_clock() -> Result<GrRestartClockSample, String> {
     })
 }
 
-#[cfg(not(target_os = "linux"))]
-fn sample_gr_restart_clock() -> Result<GrRestartClockSample, String> {
-    Err("boottime clock-domain sampling is supported only on Linux".to_string())
-}
-
 fn valid_checkpoint_generation(generation: &str) -> bool {
     !generation.is_empty()
         && generation.len() <= MAX_CHECKPOINT_GENERATION_BYTES
@@ -4271,8 +4266,7 @@ async fn run<T>(
     // Spawn the BFD actor (single-hop async, ADR-0067). Runs the sessions in the
     // PeerManager-owned desired set, publishes their state, and emits state
     // changes that PeerManager couples to BGP (non-strict RFC 5882 teardown).
-    // No-op when no neighbor has BFD configured; configured BFD fails closed
-    // off Linux.
+    // No-op when no neighbor has BFD configured; the actor owns the Linux sockets.
     let (bfd_status_tx, bfd_status_rx) =
         tokio::sync::watch::channel(Vec::<bfd_runtime::BfdStatus>::new());
     // Actor state-change events (ADR-0067 step 3b): the actor broadcasts


### PR DESCRIPTION
## Summary

- remove six dead `cfg(not(target_os = "linux"))` fallbacks from the root daemon now that rustbgpd is explicitly Linux-only
- keep every supported Linux path and every transport/socket portability fallback unchanged
- remove adjacent comments that still promised the deleted off-Linux behavior; leave the separate support-documentation branch untouched

## Validation

- focused FIB, EVPN, BFD, ES-link-drain, and BLACKHOLE tests
- `cargo test --bin rustbgpd --no-fail-fast`
- `cargo test -p rustbgpd-transport --no-fail-fast`
- `cargo test --workspace --no-fail-fast`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- exact scope, zero-roster, destructive, and forbidden-surface audits

Combined diff: six files, +4/-93 (net -89). No Cargo, workflow, public API, config, wire, transport, or documentation changes.

Linear: [LAN-946](https://linear.app/lance0/issue/LAN-946/decide-the-non-linux-platform-story-the-target-does-not-compile-so-21)
