### PR TITLE
fix(renderer): refuse unsupported RPKI not-performed tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `rs-config-render` now fails stale when
+  `communities.rpki_bgp_origin_validation_not_performed` configures a standard,
+  large, or extended tag instead of silently dropping its tagging and inbound
+  anti-spoof scrubbing semantics. Missing and all-null values remain output-identical.
+  (LAN-978)
 - An RTR cache that rejects a resumed session no longer blanks its RPKI data.
   A restarted cache answers the Serial Query naming its previous session with
   an Error Report code 0 ("Corrupt Data") rather than the Cache Reset that

--- a/tests/rs_config_render_emitted_check.rs
+++ b/tests/rs_config_render_emitted_check.rs
@@ -162,11 +162,18 @@ fn emitted_blackhole_policy_passes_rpol_and_daemon_checks() {
         .filter(|(path, _)| path.ends_with(".rpol"))
     {
         let mut source = source.clone();
+        if path == "policy/rs-hygiene.rpol" {
+            source.push_str(r#"
+test bh-invalid-passes-hygiene { route { family ipv4-unicast; prefix 203.0.113.0/26; communities [BLACKHOLE]; as-path "4242"; rpki invalid } expect rs-hygiene == accept }
+"#);
+        }
         if path == "policy/client-as4242-1.rpol" {
             source.push_str(r#"
 test bh-v25-reject { route { family ipv4-unicast; prefix 203.0.113.0/25; communities [BLACKHOLE]; as-path "4242" } expect client-as4242-1 == reject }
 test bh-v26-accept { route { family ipv4-unicast; prefix 203.0.113.0/26; communities [BLACKHOLE]; as-path "4242" } expect client-as4242-1 == accept with community BLACKHOLE }
+test bh-v26-invalid-accept { route { family ipv4-unicast; prefix 203.0.113.0/26; communities [BLACKHOLE]; as-path "4242"; rpki invalid } expect client-as4242-1 == accept with community BLACKHOLE }
 test bh-v32-accept { route { family ipv4-unicast; prefix 203.0.113.0/32; communities [BLACKHOLE]; as-path "4242" } expect client-as4242-1 == accept with community BLACKHOLE }
+test ordinary-v24-invalid-reject { route { family ipv4-unicast; prefix 198.51.100.0/24; as-path "4242"; rpki invalid } expect client-as4242-1 == reject }
 test bh-unmarked-reject { route { family ipv4-unicast; prefix 203.0.113.0/32; as-path "4242" } expect client-as4242-1 == reject }
 test bh-uncovered-reject { route { family ipv4-unicast; prefix 8.8.8.8/32; communities [BLACKHOLE]; as-path "4242" } expect client-as4242-1 == reject }
 test bh-origin-reject { route { family ipv4-unicast; prefix 203.0.113.0/32; communities [BLACKHOLE]; as-path "4244" } expect client-as4242-1 == reject }

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -111,7 +111,10 @@ from "fix the data":
 | 4 | **shape mismatch** — the context's top-level structure (document keys or report sections) drifted from the pinned fingerprint |
 
 Refused knobs: RTT-based communities and `rtt_thresholds` (the daemon
-has no RTT source; permanent), `next_hop.policy` other than `strict`
+has no RTT source; permanent), configured
+`communities.rpki_bgp_origin_validation_not_performed` tagging (the renderer
+cannot reproduce its tagging and inbound anti-spoof scrubbing), `next_hop.policy` other
+than `strict`
 (`same-as` needs the deferred fleet-inventory mode), `reject_policy`
 `tag`/`tag_and_reject` (reject-reason community wiring is a tracked
 follow-up; the daemon retains rejected routes with reasons natively —

--- a/tools/rs-config-render/src/lib.rs
+++ b/tools/rs-config-render/src/lib.rs
@@ -1385,6 +1385,16 @@ fn check_refusals(ctx: &Context, opts: &Options) -> Result<(), RenderError> {
             ));
         }
     }
+    const RPKI_NOT_PERFORMED: &str = "rpki_bgp_origin_validation_not_performed";
+    if cfg
+        .communities
+        .get(RPKI_NOT_PERFORMED)
+        .is_some_and(community_configured)
+    {
+        refusals.push(format!(
+            "communities.{RPKI_NOT_PERFORMED} is configured; unsupported tagging/scrubbing cannot be rendered"
+        ));
+    }
     if cfg.prepend_rs_as {
         refusals.push(
             "prepend_rs_as: the rendered sessions are transparent route-server-client \

--- a/tools/rs-config-render/tests/golden.rs
+++ b/tools/rs-config-render/tests/golden.rs
@@ -93,6 +93,13 @@ fn refusals(result: Result<rs_config_render::Rendered, RenderError>) -> Vec<Stri
     }
 }
 
+fn set_general_community(root: &mut serde_yaml::Value, name: &str, value: serde_yaml::Value) {
+    root["cfg"]["communities"]
+        .as_mapping_mut()
+        .expect("fixture cfg.communities is a mapping")
+        .insert(serde_yaml::Value::String(name.to_owned()), value);
+}
+
 #[test]
 fn golden_files_match() {
     let rendered = render(&to_yaml(&healthy_value()), &rtr_options()).expect("healthy render");
@@ -352,6 +359,50 @@ fn refusal_matrix() {
             items.iter().any(|i| i.contains(marker)),
             "no refusal containing {marker:?} for {path:?}: {items:?}"
         );
+    }
+}
+
+#[test]
+fn rpki_not_performed_community_refuses_configured_forms() {
+    for (kind, marker) in [
+        ("std", "65000:1"),
+        ("lrg", "65000:1:1"),
+        ("ext", "RT:65000:1"),
+    ] {
+        let mut value = healthy_value();
+        set_general_community(
+            &mut value,
+            "rpki_bgp_origin_validation_not_performed",
+            serde_yaml::from_str(&format!("{{{kind}: '{marker}'}}")).unwrap(),
+        );
+        assert_eq!(
+            refusals(render(&to_yaml(&value), &rtr_options())),
+            [
+                "communities.rpki_bgp_origin_validation_not_performed is configured; unsupported tagging/scrubbing cannot be rendered"
+            ]
+        );
+    }
+}
+
+#[test]
+fn null_rpki_not_performed_community_is_output_identity() {
+    let missing = render(&to_yaml(&healthy_value()), &rtr_options()).unwrap();
+    let mut value = healthy_value();
+    set_general_community(
+        &mut value,
+        "rpki_bgp_origin_validation_not_performed",
+        serde_yaml::from_str("{std: null, lrg: null, ext: null}").unwrap(),
+    );
+    let all_null = render(&to_yaml(&value), &rtr_options()).unwrap();
+    assert_eq!(all_null.files, missing.files);
+    assert_eq!(all_null.warnings, missing.warnings);
+    for field in [
+        "context_fingerprint",
+        "source_data_ages",
+        "clients",
+        "warnings",
+    ] {
+        assert_eq!(all_null.receipt[field], missing.receipt[field], "{field}");
     }
 }
 
@@ -630,10 +681,13 @@ fn active_blackhole_requires_irr_origin_enforcement() {
 #[test]
 /// Load-bearing: deleting the refusal exits zero and overwrites the sentinel bytes.
 fn cli_refusal_is_exit_two_and_writes_nothing() {
-    use serde_yaml::Value;
     use std::{fs, process::Command};
     let mut value = healthy_value();
-    set_client(&mut value, 1, &["cfg", "rfc8950"], Value::Bool(true));
+    set_general_community(
+        &mut value,
+        "rpki_bgp_origin_validation_not_performed",
+        serde_yaml::from_str("{std: '65000:1'}").unwrap(),
+    );
     let tmp = tempfile::tempdir().unwrap();
     let context = tmp.path().join("context.yml");
     let out = tmp.path().join("out");
@@ -654,7 +708,7 @@ fn cli_refusal_is_exit_two_and_writes_nothing() {
     assert_eq!(output.status.code(), Some(2), "{output:?}");
     assert!(
         String::from_utf8_lossy(&output.stderr)
-            .contains("client AS197000_1: effective rfc8950=true is not rendered on IPv6 sessions"),
+            .contains("communities.rpki_bgp_origin_validation_not_performed is configured; unsupported tagging/scrubbing cannot be rendered"),
         "{output:?}"
     );
     assert_eq!(fs::read(config).unwrap(), b"last-good\n");


### PR DESCRIPTION
## Summary

- fail stale when ARouteServer configures `rpki_bgp_origin_validation_not_performed`
- preserve byte-identical output for missing and all-null values
- pin authorized BLACKHOLE-before-RPKI behavior with executable RPoL tests

## Validation

- `cargo test -p rs-config-render`
- `cargo test --test rs_config_render_emitted_check`
- `cargo clippy -p rs-config-render --all-targets -- -D warnings`
- `cargo clippy --test rs_config_render_emitted_check -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Linear: LAN-978
