### PR TITLE
ci: aim release install checks at artifacts

### DIFF
--- a/scripts/check_release_install_contract.py
+++ b/scripts/check_release_install_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail closed when release payloads and copyable install docs diverge."""
+"""Check release artifacts through the commands that build and exercise them."""
 
 from __future__ import annotations
 
@@ -8,7 +8,12 @@ import sys
 from pathlib import Path
 
 
-MONITORING_PAYLOADS = (
+BINARIES = ("rustbgpd", "rbgp", "rs-config-render", "birdwatcher-adapter")
+SYSTEMD = (
+    "share/systemd/rustbgpd.service",
+    "share/systemd/rustbgpd-dataplane.conf",
+)
+MONITORING = (
     (
         "docs/grafana/rustbgpd-overview.json",
         "share/monitoring/rustbgpd-overview.json",
@@ -26,282 +31,141 @@ MONITORING_PAYLOADS = (
     ),
 )
 
-BIRDWATCHER_WORKFLOW_INPUTS = (
-    "Cargo.toml",
-    "Cargo.lock",
-    "Dockerfile",
-    "README.md",
-    "docs/cookbook/ixp-filter-pipeline.md",
-    "docs/cookbook/monitoring-feed.md",
-    "examples/birdwatcher-adapter/Cargo.toml",
-    "examples/birdwatcher-adapter/src/main.rs",
-    "examples/birdwatcher-adapter/README.md",
-    "tests/birdwatcher_adapter_smoke.rs",
-    "packaging/nfpm.yaml",
-    "scripts/build-packages.sh",
-    "scripts/check_release_install_contract.py",
-    "scripts/test_check_release_install_contract.py",
-    "docs/deployment.md",
-    "docs/QUICKSTART.md",
-    ".github/workflows/release-install-contract.yml",
-)
+
+def exact(command: str) -> str:
+    return rf"^{re.escape(command)}$"
 
 
-def marked(text: str, name: str, label: str) -> str:
-    start = f"<!-- release-install-contract:{name}:start -->"
-    end = f"<!-- release-install-contract:{name}:end -->"
-    if text.count(start) != 1 or text.count(end) != 1:
-        raise ValueError(f"{label}: expected one {name} marker pair")
-    body = text.split(start, 1)[1].split(end, 1)[0]
-    if not body.strip():
-        raise ValueError(f"{label}: empty {name} region")
-    return body
-
-
-def workflow_step(text: str, name: str) -> str:
-    match = re.search(
-        rf"(?ms)^      - name: {re.escape(name)}\n(.*?)(?=^      - name: |^  [a-zA-Z0-9_-]+:|\Z)",
-        text,
+def workflow_scripts(text: str) -> tuple[str, ...]:
+    steps = re.findall(r"(?ms)^      - .*?(?=^      - |^  [\w-]+:|\Z)", text)
+    return tuple(
+        active_script(step)
+        for step in steps
+        if re.search(r"(?m)^(?:      - |        )run:", step)
     )
-    if not match:
-        raise ValueError(f"release.yml: missing step {name!r}")
-    return match.group(1)
 
 
-def require(errors: list[str], label: str, text: str, tokens: tuple[str, ...]) -> None:
-    for token in tokens:
-        if token not in text:
-            errors.append(f"{label}: missing {token!r}")
+def select_script(text: str, label: str, discriminator: str) -> str:
+    matches = [
+        script
+        for script in workflow_scripts(text)
+        if re.search(exact(discriminator), script, re.MULTILINE)
+    ]
+    if len(matches) != 1:
+        raise ValueError(f"{label}: expected one matching run body, found {len(matches)}")
+    return matches[0]
+
+
+def active_script(step: str) -> str:
+    block = re.search(r"(?ms)^(?:      - |        )run: \|\n(.*)\Z", step)
+    if block:
+        lines = block.group(1).splitlines()
+    else:
+        inline = re.search(r"(?m)^(?:      - |        )run: (.+)$", step)
+        if not inline:
+            raise ValueError("workflow step has no run command")
+        lines = [inline.group(1)]
+    commands = []
+    pending = ""
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        line = line.split(" #", 1)[0].rstrip()
+        pending += (" " if pending else "") + line.removesuffix("\\").rstrip()
+        if not line.endswith("\\"):
+            commands.append(pending)
+            pending = ""
+    if pending:
+        commands.append(pending)
+    return "\n".join(commands)
+
+
+def require_patterns(errors: list[str], label: str, text: str, patterns: tuple[str, ...]) -> None:
+    missing = [pattern for pattern in patterns if not re.search(pattern, text, re.MULTILINE)]
+    if missing:
+        errors.append(f"{label}: missing active commands {missing!r}")
 
 
 def check(root: Path) -> list[str]:
     errors: list[str] = []
     read = lambda path: (root / path).read_text(encoding="utf-8")
-    monitoring_sources = tuple(source for source, _, _ in MONITORING_PAYLOADS)
-    monitoring_tar_paths = tuple(tar for _, tar, _ in MONITORING_PAYLOADS)
-    monitoring_names = tuple(Path(source).name for source in monitoring_sources)
     try:
         release = read(".github/workflows/release.yml")
-        package = workflow_step(release, "Package binaries")
-        assertion = workflow_step(
+        package_tar = (
+            "tar -C staging -czf dist/rustbgpd-${SUFFIX}.tar.gz rustbgpd rbgp "
+            "rs-config-render birdwatcher-adapter LICENSE-MIT LICENSE-APACHE rustbgpd.schema.json share"
+        )
+        package = select_script(release, "tarball package commands", package_tar)
+        package_patterns = tuple(rf"^cp target/\$\{{\{{ matrix\.target \}}\}}/release/{binary} staging/$" for binary in BINARIES) + (
+            r"^cp examples/systemd/rustbgpd\.service examples/systemd/rustbgpd-dataplane\.conf staging/share/systemd/$",
+            r"^cp docs/grafana/rustbgpd-overview\.json staging/share/monitoring/$",
+            r"^cp examples/prometheus/rustbgpd-alerts\.yml examples/prometheus/rustbgpd-alerts_test\.yml staging/share/monitoring/$",
+            exact(package_tar),
+        )
+        require_patterns(errors, "tarball package commands", package, package_patterns)
+
+        assertion = select_script(
             release,
-            "Assert tarball release payload is complete",
+            "tarball payload assertions",
+            'entries="$(tar -tzf "dist/rustbgpd-${SUFFIX}.tar.gz")"',
         )
-        require(
-            errors,
-            "release package step",
-            package,
-            (
-                "target/${{ matrix.target }}/release/birdwatcher-adapter",
-                "examples/systemd/rustbgpd.service",
-                "examples/systemd/rustbgpd-dataplane.conf",
-                "staging/share/systemd/",
-                "staging/share/monitoring",
-                "rustbgpd rbgp rs-config-render birdwatcher-adapter",
-            )
-            + monitoring_sources,
+        payloads = BINARIES + SYSTEMD + tuple(tar for _, tar, _ in MONITORING)
+        inventory = re.search(r"(?m)^for f in (.+); do$", assertion)
+        asserted = set(inventory.group(1).split()) if inventory else set()
+        missing_payloads = set(payloads) - asserted
+        if missing_payloads:
+            errors.append(f"tarball payload assertions: missing {sorted(missing_payloads)!r}")
+        tar_checks = (
+            exact('if ! grep -qxF "$f" <<<"$entries"; then'),
+            exact('if [ "$(tar -xOzf "dist/rustbgpd-${SUFFIX}.tar.gz" "$f" | wc -c)" -eq 0 ]; then'),
         )
-        require(
-            errors,
-            "release assertion step",
-            assertion,
-            (
-                "birdwatcher-adapter",
-                "share/systemd/rustbgpd.service",
-                "share/systemd/rustbgpd-dataplane.conf",
-            )
-            + monitoring_tar_paths,
-        )
+        require_patterns(errors, "tarball active assertions", assertion, tar_checks)
 
         nfpm = read("packaging/nfpm.yaml")
-        native_bins = set(re.findall(r"(?m)^\s+dst: (/usr/bin/[^\s]+)\s*$", nfpm))
-        expected = {
-            "/usr/bin/rustbgpd",
-            "/usr/bin/rbgp",
-            "/usr/bin/rs-config-render",
-            "/usr/bin/birdwatcher-adapter",
-        }
-        if native_bins != expected:
-            errors.append(f"packaging/nfpm.yaml: /usr/bin payload {sorted(native_bins)!r}")
-        package_builder = read("scripts/build-packages.sh")
-        require(
-            errors,
-            "native package builder",
-            package_builder,
-            (
-                "for f in rustbgpd rbgp rs-config-render birdwatcher-adapter",
-                'install -D -m 0755 "$staging/birdwatcher-adapter" '
-                '"$pkgroot/usr/bin/birdwatcher-adapter"',
-            ),
-        )
-
-        dockerfile = read("Dockerfile")
-        require(
-            errors,
-            "production container",
-            dockerfile,
-            (
-                "-p rustbgpd -p rustbgpctl -p birdwatcher-adapter",
-                "cp target/release/birdwatcher-adapter /out/",
-                "COPY --from=builder-release /out/birdwatcher-adapter "
-                "/usr/local/bin/birdwatcher-adapter",
-            ),
-        )
-        native_files = set(
+        destinations = set(re.findall(r"(?m)^\s+dst: (/usr/bin/\S+)\s*$", nfpm))
+        expected_bins = {f"/usr/bin/{binary}" for binary in BINARIES}
+        if destinations != expected_bins:
+            errors.append(f"native binary destinations: {sorted(destinations)!r}")
+        mappings = set(
             re.findall(
-                r"(?m)^[ \t]+- src: ([^ \t\r\n]+)\r?\n"
-                r"[ \t]+dst: ([^ \t\r\n]+)[ \t]*$",
+                r"(?m)^\s+- src: (\S+)\s*\n\s+dst: (\S+)\s*$",
                 nfpm,
             )
         )
-        expected_monitoring = {(source, native) for source, _, native in MONITORING_PAYLOADS}
-        missing_monitoring = expected_monitoring - native_files
+        expected_monitoring = {(source, native) for source, _, native in MONITORING}
+        missing_monitoring = expected_monitoring - mappings
         if missing_monitoring:
-            errors.append(
-                "packaging/nfpm.yaml: native monitoring payloads missing exact canonical mappings "
-                f"{sorted(missing_monitoring)!r}"
-            )
+            errors.append(f"native monitoring mappings missing {sorted(missing_monitoring)!r}")
+        for source, _, _ in MONITORING:
+            if not (root / source).is_file() or (root / source).stat().st_size == 0:
+                errors.append(f"monitoring source missing or empty: {source}")
 
-        for source, _, _ in MONITORING_PAYLOADS:
-            asset = root / source
-            if not asset.is_file() or asset.stat().st_size == 0:
-                errors.append(f"monitoring payload source missing or empty: {source}")
-
-        alert_test = read("examples/prometheus/rustbgpd-alerts_test.yml")
-        if not re.search(r"(?m)^rule_files:\n  - rustbgpd-alerts\.yml\s*$", alert_test):
-            errors.append(
-                "examples/prometheus/rustbgpd-alerts_test.yml: rule_files must resolve "
-                "rustbgpd-alerts.yml beside the test payload"
-            )
-
-        for path in ("docs/deployment.md", "docs/QUICKSTART.md"):
-            doc = read(path)
-            tarball = marked(doc, "tarball", path)
-            require(
-                errors,
-                f"{path} tarball region",
-                tarball,
-                (
-                    "share/systemd/rustbgpd.service",
-                    "share/systemd/rustbgpd-dataplane.conf",
-                    "rustbgpd --init-config edge --stdout",
-                    "rustbgpd rbgp rs-config-render birdwatcher-adapter",
-                ),
-            )
-            if "examples/systemd/" in tarball:
-                errors.append(f"{path}: tarball region uses source-checkout systemd paths")
-
-            require(
-                errors,
-                f"{path} monitoring discovery",
-                doc,
-                (
-                    "share/monitoring/",
-                    "/usr/share/doc/rustbgpd/monitoring/",
-                )
-                + monitoring_names,
-            )
-            birdwatcher = marked(doc, "birdwatcher-production", path)
-            require(
-                errors,
-                f"{path} birdwatcher production region",
-                birdwatcher,
-                (
-                    "birdwatcher-adapter",
-                    "unix:///var/lib/rustbgpd/grpc.sock",
-                    "http://127.0.0.1:50051",
-                    "502 Bad Gateway",
-                    "without restart",
-                    "service unit",
-                ),
-            )
-
-        root_install = marked(read("README.md"), "root-install", "README.md")
-        require(
-            errors,
-            "README.md canonical install",
-            root_install,
-            (
-                "rustbgpd rbgp rs-config-render birdwatcher-adapter",
-                "-p rs-config-render -p birdwatcher-adapter",
-                "daemon + rbgp + birdwatcher-adapter",
-            ),
+        contract = read(".github/workflows/release-install-contract.yml")
+        native = select_script(
+            contract, "real native package assertions", 'dpkg-deb -x "$deb" extracted/deb'
         )
-        for path, tokens in (
-            ("docs/cookbook/ixp-filter-pipeline.md", ("unix:///var/lib/rustbgpd/grpc.sock", "operator-tier", "`observer`")),
-            ("docs/cookbook/monitoring-feed.md", ("local Unix socket", "`observer`")),
-        ):
-            require(errors, f"{path} Birdwatcher transport", read(path), tokens)
-
-        contract_workflow = read(".github/workflows/release-install-contract.yml")
-        for source, _, _ in MONITORING_PAYLOADS:
-            if contract_workflow.count(f"- {source}") != 2:
-                errors.append(
-                    ".github/workflows/release-install-contract.yml: expected pull/push "
-                    f"enrollment for {source}"
-                )
-        for source in BIRDWATCHER_WORKFLOW_INPUTS:
-            if contract_workflow.count(f"- {source}") != 2:
-                errors.append(
-                    ".github/workflows/release-install-contract.yml: expected pull/push "
-                    f"enrollment for {source}"
-                )
-        require(
+        require_patterns(
             errors,
-            "release install contract workflow",
-            contract_workflow,
-            (
-                "cargo test -p birdwatcher-adapter",
-                "cargo test --test birdwatcher_adapter_smoke",
-                "scripts/build-packages.sh staging amd64",
-                "for tree in extracted/deb extracted/rpm; do",
-                "for exe in rustbgpd rbgp rs-config-render birdwatcher-adapter; do",
-                'test -x "$tree/usr/bin/$exe"',
-                '"$tree/usr/bin/rustbgpd" --check "$tree/etc/rustbgpd/config.toml"',
-                "cpio --quiet -id --no-absolute-filenames --directory=extracted/rpm",
-                "--entrypoint birdwatcher-adapter",
-            ),
-        )
-
-        deployment = read("docs/deployment.md")
-        native = marked(deployment, "native-package", "docs/deployment.md")
-        require(
-            errors,
-            "docs/deployment.md native-package region",
+            "real native package assertions",
             native,
-            ("/usr/share/doc/rustbgpd/monitoring/",),
-        )
-        sentence = re.search(
-            r"installs the four binaries \((.*?)\) to `/usr/bin`",
-            " ".join(native.split()),
-        )
-        documented = re.findall(r"`([^`]+)`", sentence.group(1)) if sentence else []
-        if documented != ["rustbgpd", "rbgp", "rs-config-render", "birdwatcher-adapter"]:
-            errors.append(f"docs/deployment.md: documented native binaries {documented!r}")
-        source = marked(deployment, "source-checkout", "docs/deployment.md")
-        require(
-            errors,
-            "docs/deployment.md source-checkout region",
-            source,
-            ("examples/systemd/rustbgpd.service", "examples/minimal/config.toml"),
-        )
-
-        adapter = marked(
-            read("examples/birdwatcher-adapter/README.md"),
-            "birdwatcher-boundary",
-            "birdwatcher README",
-        )
-        require(
-            errors,
-            "birdwatcher README boundary",
-            adapter,
             (
-                "included in release tarballs",
-                "native `.deb`/`.rpm` packages",
-                "production container image",
-                "excluded from the default source-checkout `cargo build`",
+                r'^deb="\$\(find dist -maxdepth 1 -name \'\*\.deb\' -print -quit\)"$',
+                r'^rpm="\$\(find dist -maxdepth 1 -name \'\*\.rpm\' -print -quit\)"$',
+                r'^test -n "\$deb" && test -n "\$rpm"$',
+                r'^dpkg-deb -x "\$deb" extracted/deb$',
+                r'^rpm2cpio "\$rpm" \| cpio --quiet -id --no-absolute-filenames --directory=extracted/rpm$',
+                r"^for tree in extracted/deb extracted/rpm; do$",
+                r"^for exe in rustbgpd rbgp rs-config-render birdwatcher-adapter; do$",
+                r'^test -x "\$tree/usr/bin/\$exe" ',
+                r'^"\$tree/usr/bin/rustbgpd" --check "\$tree/etc/rustbgpd/config\.toml"$',
             ),
         )
+        if "--to-stdout" in native:
+            errors.append("RPM extraction must populate extracted/rpm, not stdout")
+
+        image_command = "docker run --rm --entrypoint birdwatcher-adapter rustbgpd:release-install-contract --help"
+        select_script(contract, "production image adapter assertion", image_command)
     except (OSError, ValueError) as error:
         errors.append(str(error))
     return errors

--- a/scripts/test_check_release_install_contract.py
+++ b/scripts/test_check_release_install_contract.py
@@ -7,28 +7,43 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import check_release_install_contract as contract
+
 ROOT = Path(__file__).resolve().parents[1]
+RELEASE = ".github/workflows/release.yml"
+WORKFLOW = ".github/workflows/release-install-contract.yml"
+CHECK = '"$tree/usr/bin/rustbgpd" --check "$tree/etc/rustbgpd/config.toml"'
+RPM_EXTRACT = "cpio --quiet -id --no-absolute-filenames --directory=extracted/rpm"
+EXE_LOOP = "for exe in rustbgpd rbgp rs-config-render birdwatcher-adapter; do"
+IMAGE_RUN = "run: docker run --rm --entrypoint birdwatcher-adapter"
+MONITORING_MAPPING = "native monitoring mappings"
+GREP_ASSERT = 'if ! grep -qxF "$f" <<<"$entries"; then'
+TAR_SIZE_ASSERT = 'if [ "$(tar -xOzf "dist/rustbgpd-${SUFFIX}.tar.gz" "$f" | wc -c)" -eq 0 ]; then'
 INPUTS = (
-    "Cargo.toml",
-    "Cargo.lock",
-    "Dockerfile",
-    "README.md",
-    "docs/cookbook/ixp-filter-pipeline.md",
-    "docs/cookbook/monitoring-feed.md",
-    ".github/workflows/release-install-contract.yml",
-    ".github/workflows/release.yml",
+    WORKFLOW,
+    RELEASE,
     "packaging/nfpm.yaml",
-    "scripts/build-packages.sh",
-    "docs/deployment.md",
-    "docs/QUICKSTART.md",
     "docs/grafana/rustbgpd-overview.json",
-    "examples/birdwatcher-adapter/Cargo.toml",
-    "examples/birdwatcher-adapter/src/main.rs",
-    "examples/birdwatcher-adapter/README.md",
     "examples/prometheus/rustbgpd-alerts.yml",
     "examples/prometheus/rustbgpd-alerts_test.yml",
-    "tests/birdwatcher_adapter_smoke.rs",
 )
+MUTATIONS = (
+    (
+        RELEASE,
+        "                   share/monitoring/rustbgpd-alerts_test.yml; do",
+        "                   removed-alert-tests.yml; do\n          # share/monitoring/rustbgpd-alerts_test.yml; do",
+        "tarball payload assertions",
+    ),
+    ("packaging/nfpm.yaml", "contents:\n", "contents:\n  - src: extra\n    dst: /usr/bin/extra\n", "native binary destinations"),
+    (WORKFLOW, 'dpkg-deb -x "$deb" extracted/deb', 'echo dpkg-deb -x "$deb" extracted/deb', "real native package assertions"),
+    (WORKFLOW, RPM_EXTRACT, "cpio --quiet -i --to-stdout", "real native package assertions"),
+    (WORKFLOW, EXE_LOOP, "for exe in rustbgpd rbgp rs-config-render; do", "real native package assertions"),
+    (WORKFLOW, CHECK, CHECK.replace('"$tree/etc', '"/etc'), "real native package assertions"),
+    (WORKFLOW, CHECK, "true\n            # " + CHECK, "real native package assertions"),
+    (WORKFLOW, IMAGE_RUN, IMAGE_RUN.replace("birdwatcher-adapter", "rustbgpd"), "production image adapter assertion"),
+    (RELEASE, GREP_ASSERT, 'if ! echo \'grep -qxF "$f" <<<"$entries"\'; then', "tarball active assertions"),
+    (RELEASE, TAR_SIZE_ASSERT, TAR_SIZE_ASSERT.replace("tar -xOzf", "echo 'tar -xOzf") + "'", "tarball active assertions"),
+)
+
 
 class ReleaseInstallContractTest(unittest.TestCase):
     def fixture(self) -> Path:
@@ -41,182 +56,98 @@ class ReleaseInstallContractTest(unittest.TestCase):
             shutil.copyfile(ROOT / relative, target)
         return root
 
-    def mutate(self, root: Path, relative: str, old: str, new: str) -> list[str]:
-        path = root / relative
-        text = path.read_text()
-        self.assertIn(old, text)
-        path.write_text(text.replace(old, new))
-        return contract.check(root)
-
     def test_repository_contract(self) -> None:
         self.assertEqual(contract.check(ROOT), [])
 
-    def test_wrong_examples_unit_path_fails(self) -> None:
-        errors = self.mutate(
-            self.fixture(),
-            "docs/deployment.md",
-            "share/systemd/rustbgpd.service",
-            "examples/systemd/rustbgpd.service",
-        )
-        self.assertTrue(any("tarball region" in error for error in errors), errors)
+    def test_destructive_mutations_fail(self) -> None:
+        for relative, old, new, label in MUTATIONS:
+            with self.subTest(old=old):
+                root = self.fixture()
+                path = root / relative
+                text = path.read_text()
+                self.assertIn(old, text)
+                path.write_text(text.replace(old, new, 1))
+                errors = contract.check(root)
+                self.assertTrue(any(label in error for error in errors), errors)
 
-    def test_removed_release_assertion_unit_fails(self) -> None:
-        root = self.fixture()
-        path = root / ".github/workflows/release.yml"
-        text = path.read_text()
-        marker = "      - name: Assert tarball release payload is complete"
-        before, after = text.split(marker, 1)
-        after = after.replace("share/systemd/rustbgpd.service", "share/systemd/removed.service", 1)
-        path.write_text(before + marker + after)
-        errors = contract.check(root)
-        self.assertTrue(any("release assertion step" in error for error in errors), errors)
+    def test_every_tarball_payload_is_asserted(self) -> None:
+        marker = "          for f in "
+        for payload in contract.BINARIES + contract.SYSTEMD + tuple(item[1] for item in contract.MONITORING):
+            with self.subTest(payload=payload):
+                root = self.fixture()
+                path = root / RELEASE
+                before, after = path.read_text().split(marker, 1)
+                self.assertIn(payload, after)
+                path.write_text(before + marker + after.replace(payload, "removed-payload", 1))
+                self.assertTrue(any("tarball payload assertions" in error for error in contract.check(root)))
 
-    def test_removed_tarball_monitoring_copy_fails(self) -> None:
-        errors = self.mutate(
-            self.fixture(),
-            ".github/workflows/release.yml",
-            "cp docs/grafana/rustbgpd-overview.json staging/share/monitoring/",
-            "cp generated/rustbgpd-overview.json staging/share/monitoring/",
-        )
-        self.assertTrue(any("release package step" in error for error in errors), errors)
+    def test_every_monitoring_source_is_packaged_and_mapped(self) -> None:
+        for source, _, native in contract.MONITORING:
+            for path, token, label in ((RELEASE, source, "tarball package commands"), ("packaging/nfpm.yaml", native, MONITORING_MAPPING)):
+                with self.subTest(path=path, token=token):
+                    root = self.fixture()
+                    target = root / path
+                    target.write_text(target.read_text().replace(token, "removed-monitoring", 1))
+                    errors = contract.check(root)
+                    self.assertTrue(any(label in error for error in errors))
+                    if path == "packaging/nfpm.yaml":
+                        self.assertTrue(any(repr((source, native)) in error for error in errors), errors)
 
-    def test_removed_tarball_monitoring_assertion_fails(self) -> None:
-        root = self.fixture()
-        path = root / ".github/workflows/release.yml"
-        text = path.read_text()
-        marker = "      - name: Assert tarball release payload is complete"
-        before, after = text.split(marker, 1)
-        after = after.replace(
-            "share/monitoring/rustbgpd-alerts_test.yml",
-            "share/monitoring/removed-alert-tests.yml",
-            1,
-        )
-        path.write_text(before + marker + after)
-        errors = contract.check(root)
-        self.assertTrue(any("release assertion step" in error for error in errors), errors)
+    def test_every_native_binary_destination_is_exact(self) -> None:
+        for binary in contract.BINARIES:
+            with self.subTest(binary=binary):
+                root = self.fixture()
+                path = root / "packaging/nfpm.yaml"
+                text = path.read_text().replace(f"dst: /usr/bin/{binary}", "dst: /usr/bin/removed", 1)
+                path.write_text(text)
+                self.assertTrue(any("native binary destinations" in error for error in contract.check(root)))
 
-    def test_removed_native_monitoring_mapping_fails(self) -> None:
-        errors = self.mutate(
-            self.fixture(),
-            "packaging/nfpm.yaml",
-            "dst: /usr/share/doc/rustbgpd/monitoring/rustbgpd-overview.json",
-            "dst: /usr/share/doc/rustbgpd/monitoring/removed-overview.json",
-        )
-        self.assertTrue(any("native monitoring payloads" in error for error in errors), errors)
-
-    def test_non_relative_promtool_rule_file_fails(self) -> None:
-        errors = self.mutate(
-            self.fixture(),
-            "examples/prometheus/rustbgpd-alerts_test.yml",
-            "  - rustbgpd-alerts.yml",
-            "  - /etc/prometheus/rustbgpd-alerts.yml",
-        )
-        self.assertTrue(any("rule_files must resolve" in error for error in errors), errors)
-
-    def test_empty_canonical_monitoring_source_fails(self) -> None:
+    def test_empty_monitoring_source_fails(self) -> None:
         root = self.fixture()
         (root / "docs/grafana/rustbgpd-overview.json").write_text("")
+        self.assertTrue(any("missing or empty" in error for error in contract.check(root)))
+
+    def test_presentation_edits_do_not_gate_artifacts(self) -> None:
+        root = self.fixture()
+        path = root / WORKFLOW
+        text = path.read_text()
+        for old in ("- README.md", "- scripts/check_release_install_contract.py", "cargo test -p birdwatcher-adapter"):
+            text = text.replace(old, "removed-presentation")
+        path.write_text(text)
+        self.assertEqual(contract.check(root), [])
+
+    def test_step_names_are_presentation(self) -> None:
+        names = (
+            (RELEASE, "Package binaries"),
+            (RELEASE, "Assert tarball release payload is complete"),
+            (WORKFLOW, "Assert real native package payloads"),
+            (WORKFLOW, "Assert production image runs the adapter"),
+        )
+        for relative, name in names:
+            with self.subTest(name=name):
+                root = self.fixture()
+                path = root / relative
+                path.write_text(path.read_text().replace(name, "Renamed step", 1))
+                self.assertEqual(contract.check(root), [])
+
+    def test_duplicate_semantic_run_body_fails(self) -> None:
+        root = self.fixture()
+        path = root / WORKFLOW
+        duplicate = f"\n      - name: Duplicate adapter assertion\n        {IMAGE_RUN} rustbgpd:release-install-contract --help\n"
+        path.write_text(path.read_text() + duplicate)
         errors = contract.check(root)
-        self.assertTrue(any("source missing or empty" in error for error in errors), errors)
+        self.assertTrue(any("found 2" in error for error in errors), errors)
 
-    def test_removed_monitoring_workflow_trigger_fails(self) -> None:
-        errors = self.mutate(
-            self.fixture(),
-            ".github/workflows/release-install-contract.yml",
-            "- docs/grafana/rustbgpd-overview.json",
-            "- docs/grafana/removed-overview.json",
-        )
-        self.assertTrue(any("expected pull/push enrollment" in error for error in errors), errors)
-
-    def test_undocumented_native_monitoring_path_fails(self) -> None:
-        errors = self.mutate(
-            self.fixture(),
-            "docs/QUICKSTART.md",
-            "/usr/share/doc/rustbgpd/monitoring/",
-            "/usr/share/doc/rustbgpd/missing-monitoring/",
-        )
-        self.assertTrue(any("monitoring discovery" in error for error in errors), errors)
-
-    def test_reverted_birdwatcher_boundary_fails(self) -> None:
-        errors = self.mutate(
-            self.fixture(),
-            "examples/birdwatcher-adapter/README.md",
-            "included in release tarballs",
-            "not part of release tarballs",
-        )
-        self.assertTrue(any("birdwatcher" in error for error in errors), errors)
-
-    def test_removed_adapter_from_native_inventory_fails(self) -> None:
-        errors = self.mutate(
-            self.fixture(),
-            "packaging/nfpm.yaml",
-            "dst: /usr/bin/birdwatcher-adapter",
-            "dst: /usr/bin/removed-birdwatcher-adapter",
-        )
-        self.assertTrue(any("/usr/bin payload" in error for error in errors), errors)
-
-    def test_fifth_documented_native_binary_fails(self) -> None:
-        errors = self.mutate(
-            self.fixture(),
-            "docs/deployment.md",
-            "`birdwatcher-adapter`) to",
-            "`birdwatcher-adapter`, `extra`) to",
-        )
-        self.assertTrue(any("documented native binaries" in error for error in errors), errors)
-
-    def test_removed_adapter_from_container_fails(self) -> None:
-        errors = self.mutate(
-            self.fixture(),
-            "Dockerfile",
-            "COPY --from=builder-release /out/birdwatcher-adapter /usr/local/bin/birdwatcher-adapter",
-            "COPY --from=builder-release /out/birdwatcher-adapter /tmp/birdwatcher-adapter",
-        )
-        self.assertTrue(any("production container" in error for error in errors), errors)
-
-    def test_removed_adapter_from_quickstart_fails(self) -> None:
-        errors = self.mutate(
-            self.fixture(),
-            "docs/QUICKSTART.md",
-            "unix:///var/lib/rustbgpd/grpc.sock",
-            "unix:///var/lib/rustbgpd/removed.sock",
-        )
-        self.assertTrue(any("birdwatcher production" in error for error in errors), errors)
-
-    def test_removed_adapter_from_root_install_fails(self) -> None:
-        errors = self.mutate(
-            self.fixture(),
-            "README.md",
-            "rs-config-render birdwatcher-adapter /usr/local/bin/",
-            "rs-config-render /usr/local/bin/",
-        )
-        self.assertTrue(any("canonical install" in error for error in errors), errors)
-
-    def test_removed_adapter_workflow_enrollment_fails(self) -> None:
-        errors = self.mutate(
-            self.fixture(),
-            ".github/workflows/release-install-contract.yml",
-            "- Dockerfile",
-            "- removed.Dockerfile",
-        )
-        self.assertTrue(any("enrollment for Dockerfile" in error for error in errors), errors)
-
-    def test_removed_packaged_config_validation_fails(self) -> None:
-        errors = self.mutate(
-            self.fixture(),
-            ".github/workflows/release-install-contract.yml",
-            '"$tree/usr/bin/rustbgpd" --check "$tree/etc/rustbgpd/config.toml"',
-            'true # config skeleton unvalidated',
-        )
-        self.assertTrue(any("contract workflow" in error for error in errors), errors)
-
-    def test_stdout_rpm_extraction_regression_fails(self) -> None:
-        errors = self.mutate(
-            self.fixture(),
-            ".github/workflows/release-install-contract.yml",
-            "cpio --quiet -id --no-absolute-filenames --directory=extracted/rpm",
-            "cpio --quiet -i --to-stdout",
-        )
-        self.assertTrue(any("contract workflow" in error for error in errors), errors)
+    def test_commands_from_separate_run_bodies_are_not_concatenated(self) -> None:
+        root = self.fixture()
+        path = root / RELEASE
+        text = path.read_text().replace(TAR_SIZE_ASSERT, "if false; then", 1)
+        decoy = "cat checksums-${{ matrix.suffix }}.txt"
+        self.assertIn(decoy, text)
+        text = text.replace(decoy, TAR_SIZE_ASSERT, 1)
+        path.write_text(text)
+        errors = contract.check(root)
+        self.assertTrue(any("tarball active assertions" in error for error in errors), errors)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- aim release-install checks at active packaged artifacts and executable validation
- remove prose, display-name, and workflow self-enrollment mirroring
- preserve native/tarball payloads, real deb/RPM extraction, same-tree config checks, and image adapter execution

## Validation

- `python3 -m unittest -v scripts/test_check_release_install_contract.py`
- `python3 scripts/check_release_install_contract.py`
- `python3 -m unittest discover -s scripts -p 'test_check_*.py'`
- `python3 -m py_compile scripts/check_release_install_contract.py scripts/test_check_release_install_contract.py`
- `git diff --check`

Linear: LAN-962
