### PR TITLE
fix: reject ambiguous rustbgpd CLI invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Ambiguous `rustbgpd` invocations now fail with exit 2 instead of silently
+  overwriting a config path or option value, consuming a flag as a value, or
+  letting a display or one-shot mode ignore companion arguments. (LAN-979)
 - `rs-config-render` now fails stale when
   `communities.rpki_bgp_origin_validation_not_performed` configures a standard,
   large, or extended tag instead of silently dropping its tagging and inbound

--- a/src/main.rs
+++ b/src/main.rs
@@ -2065,6 +2065,11 @@ fn stdout_exit(result: Result<(), StdoutWriteError>) -> ExitCode {
     }
 }
 
+fn invalid_invocation(message: impl std::fmt::Display) -> ! {
+    eprintln!("error: {message}");
+    process::exit(2);
+}
+
 async fn trigger_import_validation_refresh(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     dependency: ImportValidationDependency,
@@ -2400,35 +2405,22 @@ Default configuration file.
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
 
-    if args.iter().any(|arg| {
-        matches!(
-            arg.as_str(),
-            "--migrate-config" | "--offline" | "--dry-run" | "--validator"
-        )
-    }) {
-        return config_migration::run(&args);
-    }
-
-    // Handle --version / -V before anything else.
-    if args.iter().any(|a| a == "--version" || a == "-V") {
-        return stdout_exit(write_stdout(|writer| {
-            writeln!(writer, "rustbgpd {}", env!("CARGO_PKG_VERSION"))
-        }));
-    }
-
-    // Handle --man: print the roff man page (section 8) to stdout and
-    // exit. Render with `rustbgpd --man | man -l -` or install with
-    // `rustbgpd --man > /usr/local/share/man/man8/rustbgpd.8`.
-    if args.iter().any(|a| a == "--man") {
-        return stdout_exit(write_stdout(|writer| write!(writer, "{}", man_page())));
-    }
-
-    // Handle --help / -h.
-    if args.iter().any(|a| a == "--help" || a == "-h") {
-        return stdout_exit(write_stdout(|writer| {
-            writeln!(
-                writer,
-                "rustbgpd {} — API-first BGP daemon\n\n\
+    let display_mode = args[1..]
+        .iter()
+        .find(|arg| matches!(arg.as_str(), "--version" | "-V" | "--man" | "--help" | "-h"));
+    if let Some(mode) = display_mode {
+        if args.len() != 2 {
+            invalid_invocation(format_args!("{mode} must be used alone"));
+        }
+        return match mode.as_str() {
+            "--version" | "-V" => stdout_exit(write_stdout(|writer| {
+                writeln!(writer, "rustbgpd {}", env!("CARGO_PKG_VERSION"))
+            })),
+            "--man" => stdout_exit(write_stdout(|writer| write!(writer, "{}", man_page()))),
+            "--help" | "-h" => stdout_exit(write_stdout(|writer| {
+                writeln!(
+                    writer,
+                    "rustbgpd {} — API-first BGP daemon\n\n\
              Usage: rustbgpd [OPTIONS] [CONFIG_PATH]\n\n\
              Arguments:\n  \
                CONFIG_PATH  Path to TOML config file [default: /etc/rustbgpd/config.toml]\n\n\
@@ -2459,9 +2451,20 @@ fn main() -> ExitCode {
                   (BGP or metrics/readiness listener bind, unexpected gRPC server exit)\n  \
                2  Invalid invocation (unknown flag combination, missing argument)\n  \
                70 Internal error",
-                env!("CARGO_PKG_VERSION")
-            )
-        }));
+                    env!("CARGO_PKG_VERSION")
+                )
+            })),
+            _ => unreachable!("display mode was matched above"),
+        };
+    }
+
+    if args.iter().any(|arg| {
+        matches!(
+            arg.as_str(),
+            "--migrate-config" | "--offline" | "--dry-run" | "--validator"
+        )
+    }) {
+        return config_migration::run(&args);
     }
 
     // Parse flags and config path from remaining args.
@@ -2472,14 +2475,23 @@ fn main() -> ExitCode {
     let mut init_profile: Option<String> = None;
     let mut to_stdout = false;
     let mut dump_schema = false;
-    let mut config_path = "/etc/rustbgpd/config.toml".to_string();
+    let mut config_path: Option<String> = None;
     let mut expect_diff_path = false;
     let mut expect_init_profile = false;
     for arg in &args[1..] {
         if expect_diff_path {
+            if arg.starts_with('-') {
+                invalid_invocation("--diff requires a path argument");
+            }
             diff_path = Some(arg.clone());
             expect_diff_path = false;
         } else if expect_init_profile {
+            if arg.starts_with('-') {
+                invalid_invocation(format_args!(
+                    "--init-config requires a profile name (one of: {})",
+                    crate::config::profiles::PROFILE_NAMES.join(", ")
+                ));
+            }
             init_profile = Some(arg.clone());
             expect_init_profile = false;
         } else if arg == "--check" {
@@ -2487,23 +2499,32 @@ fn main() -> ExitCode {
         } else if arg == "--strict" {
             strict = true;
         } else if arg == "--diff" {
+            if diff_path.is_some() {
+                invalid_invocation("--diff may only be specified once");
+            }
             expect_diff_path = true;
         } else if arg == "--json" {
             json_output = true;
         } else if arg == "--init-config" {
+            if init_profile.is_some() {
+                invalid_invocation("--init-config may only be specified once");
+            }
             expect_init_profile = true;
         } else if arg == "--stdout" {
             to_stdout = true;
         } else if arg == "--dump-config-schema" {
             dump_schema = true;
         } else if !arg.starts_with('-') {
-            config_path.clone_from(arg);
+            if config_path.is_some() {
+                invalid_invocation("multiple CONFIG_PATH arguments");
+            }
+            config_path = Some(arg.clone());
         } else {
             eprintln!("error: unknown option: {arg}");
             eprintln!(
-                "usage: rustbgpd [--check [--strict]] [--diff PATH] [--json] [--init-config PROFILE --stdout] [--dump-config-schema] [--version] [CONFIG_PATH]"
+                "usage: rustbgpd [--check [--strict]] [--diff PATH] [--json] [--init-config PROFILE --stdout] [--dump-config-schema] [CONFIG_PATH]\n       rustbgpd (--help | -h)\n       rustbgpd (--version | -V)\n       rustbgpd --man"
             );
-            process::exit(1);
+            process::exit(2);
         }
     }
     if expect_diff_path {
@@ -2528,6 +2549,9 @@ fn main() -> ExitCode {
         eprintln!("error: --strict can only be used with --check");
         process::exit(2);
     }
+    if check_only && diff_path.is_some() {
+        invalid_invocation("--check cannot be combined with --diff");
+    }
     // `--stdout` is only the `--init-config` output target. Without it,
     // a bare `--stdout` would otherwise fall through to normal daemon
     // startup (silently, on a box with /etc/rustbgpd/config.toml).
@@ -2542,9 +2566,15 @@ fn main() -> ExitCode {
         eprintln!("error: --init-config cannot be combined with --check or --diff");
         process::exit(2);
     }
+    if init_profile.is_some() && config_path.is_some() {
+        invalid_invocation("--init-config cannot be combined with CONFIG_PATH");
+    }
     // `--dump-config-schema` is a standalone mode, like `--init-config`:
     // reject combining it rather than silently letting one mode win.
     if dump_schema {
+        if config_path.is_some() {
+            invalid_invocation("--dump-config-schema cannot be combined with CONFIG_PATH");
+        }
         if check_only || diff_path.is_some() || init_profile.is_some() || to_stdout {
             eprintln!("error: --dump-config-schema cannot be combined with other modes");
             process::exit(2);
@@ -2584,6 +2614,8 @@ fn main() -> ExitCode {
         }
         return stdout_exit(write_stdout(|writer| write!(writer, "{toml}")));
     }
+
+    let config_path = config_path.unwrap_or_else(|| "/etc/rustbgpd/config.toml".to_string());
 
     // Removed escape hatch: fail loudly rather than silently ignoring it,
     // so automation still setting the variable can't restart into changed

--- a/tests/cli_invocation.rs
+++ b/tests/cli_invocation.rs
@@ -1,0 +1,158 @@
+//! Real-binary contract for rustbgpd's hand-rolled invocation parser.
+//!
+//! Ambiguous commands must fail before loading a config or printing one-shot
+//! output. Valid flag/positional interleavings remain supported.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn run(args: &[&str], cwd: Option<&Path>) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_rustbgpd"));
+    command.args(args).env("NO_COLOR", "1");
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    command.output().expect("run rustbgpd")
+}
+
+fn assert_invalid(args: &[&str], diagnostic: &str) {
+    let output = run(args, None);
+    assert_eq!(output.status.code(), Some(2), "{args:?}: {output:?}");
+    assert!(
+        output.stdout.is_empty(),
+        "{args:?}: printed one-shot output"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(diagnostic),
+        "{args:?}: missing {diagnostic:?}:\n{stderr}"
+    );
+}
+
+fn starter_config() -> String {
+    let output = run(&["--init-config", "lab", "--stdout"], None);
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+    assert!(output.stderr.is_empty(), "{output:?}");
+    String::from_utf8(output.stdout).expect("starter config is UTF-8")
+}
+
+#[test]
+fn duplicate_paths_and_value_options_are_rejected() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let first = temp.path().join("first.toml");
+    let second = temp.path().join("second.toml");
+    let config = starter_config();
+    std::fs::write(&first, &config).expect("write first config");
+    std::fs::write(&second, &config).expect("write second config");
+    let first = first.to_str().expect("UTF-8 path");
+    let second = second.to_str().expect("UTF-8 path");
+
+    assert_invalid(&["--check", first, second], "multiple CONFIG_PATH");
+    assert_invalid(
+        &[first, "--diff", second, "--diff", first],
+        "--diff may only be specified once",
+    );
+    assert_invalid(
+        &["--init-config", "lab", "--init-config", "edge", "--stdout"],
+        "--init-config may only be specified once",
+    );
+}
+
+#[test]
+fn option_values_cannot_consume_another_flag() {
+    assert_invalid(&["--diff", "--check"], "--diff requires a path argument");
+    assert_invalid(
+        &["--init-config", "--stdout"],
+        "--init-config requires a profile name",
+    );
+}
+
+#[test]
+fn unknown_options_use_the_documented_invocation_exit() {
+    let output = run(&["--not-an-option"], None);
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+    assert!(output.stdout.is_empty(), "{output:?}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unknown option: --not-an-option"),
+        "{stderr}"
+    );
+    let usage = concat!(
+        "usage: rustbgpd [--check [--strict]] [--diff PATH] [--json] ",
+        "[--init-config PROFILE --stdout] [--dump-config-schema] [CONFIG_PATH]\n",
+        "       rustbgpd (--help | -h)\n",
+        "       rustbgpd (--version | -V)\n",
+        "       rustbgpd --man\n",
+    );
+    assert!(stderr.ends_with(usage), "unexpected usage:\n{stderr}");
+    let normal_form = usage.lines().next().expect("normal usage form");
+    for standalone in ["--help", "-h", "--version", "-V", "--man"] {
+        assert!(
+            !normal_form.contains(standalone),
+            "standalone mode {standalone} presented as combinable: {normal_form}"
+        );
+    }
+}
+
+#[test]
+fn display_modes_are_standalone() {
+    for args in [
+        &["--help", "--check"][..],
+        &["-h", "config.toml"][..],
+        &["--version", "--offline"][..],
+        &["-V", "--version"][..],
+        &["--man", "--dump-config-schema"][..],
+    ] {
+        assert_invalid(args, "must be used alone");
+    }
+}
+
+#[test]
+fn one_shot_modes_do_not_ignore_competing_inputs() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config_path = temp.path().join("config.toml");
+    std::fs::write(&config_path, starter_config()).expect("write config");
+    let config_path = config_path.to_str().expect("UTF-8 path");
+
+    assert_invalid(
+        &["--init-config", "lab", "--stdout", config_path],
+        "--init-config cannot be combined with CONFIG_PATH",
+    );
+    assert_invalid(
+        &["--dump-config-schema", config_path],
+        "--dump-config-schema cannot be combined with CONFIG_PATH",
+    );
+    assert_invalid(
+        &["--check", config_path, "--diff", config_path],
+        "--check cannot be combined with --diff",
+    );
+}
+
+#[test]
+fn valid_one_shot_interleavings_and_literal_dash_paths_still_work() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config = starter_config();
+    let config_path = temp.path().join("config.toml");
+    std::fs::write(&config_path, &config).expect("write config");
+    let config_path = config_path.to_str().expect("UTF-8 path");
+
+    for args in [
+        vec!["--check", config_path],
+        vec![config_path, "--check"],
+        vec!["--diff", config_path, config_path],
+        vec![config_path, "--diff", config_path],
+        vec!["--init-config", "edge", "--stdout"],
+        vec!["--dump-config-schema"],
+    ] {
+        let output = run(&args, None);
+        assert_eq!(output.status.code(), Some(0), "{args:?}: {output:?}");
+        assert!(!output.stdout.is_empty(), "{args:?}: no one-shot output");
+        assert!(output.stderr.is_empty(), "{args:?}: {output:?}");
+    }
+
+    std::fs::write(temp.path().join("-config.toml"), config).expect("write dash config");
+    let output = run(&["--check", "./-config.toml"], Some(temp.path()));
+    assert_eq!(output.status.code(), Some(0), "{output:?}");
+    assert!(output.stdout.starts_with(b"config OK:"), "{output:?}");
+    assert!(output.stderr.is_empty(), "{output:?}");
+}


### PR DESCRIPTION
## Summary

- reject ambiguous duplicate config paths and value options
- prevent `--diff` and `--init-config` from consuming another flag as a value
- make help, version, and man display modes standalone and align invalid invocations on exit 2

## Validation

- `cargo test --locked --test cli_invocation`
- `cargo test --locked --test check_strict`
- `cargo test --locked --test daemon_stdout_closed`
- `cargo test --locked --test config_migration`
- `cargo test --locked --workspace`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Linear: LAN-979
