### PR TITLE
test: replace reloadstall source pins with executable checks

### DIFF
--- a/tests/reloadstall_scenario_emitted_check.rs
+++ b/tests/reloadstall_scenario_emitted_check.rs
@@ -86,111 +86,34 @@ fn emitted_1000_peer_scenario_is_all_ebgp_and_daemon_valid() {
 }
 
 #[test]
-/// Red proof: replacing the fingerprint-qualified status match with the old
-/// bare `pass` match, or removing the sampler wait/data gate, makes this fail.
-/// The column assertion likewise fails if the ambiguous historical label is
-/// restored in future output.
-fn irr_reload_campaign_seals_resume_rows_and_rss_evidence() {
-    let runner = std::fs::read_to_string(format!(
-        "{}/bench/scale/irrreload/run-irr-reload.sh",
-        env!("CARGO_MANIFEST_DIR")
-    ))
-    .expect("read IRR reload runner");
-
-    for required in [
-        "pass $CAMPAIGN_FINGERPRINT",
-        "provenance.json",
-        "DIRTY_STATE_SHA256",
-        "bird_image_id",
-        "openbgpd_image_id",
-        "scenario.sha256",
-        "dataset.sha256",
-        "dataset_sha256",
-        ".runtime_files | select(type == \"array\" and length > 0)[]",
-        "cell_receipt_matches",
-        "[ \"$actual_sha\" = \"$scenario_sha\" ] || return 1",
-        "evidence.sha256",
-        "sha256sum --check --strict --status evidence.sha256",
-        "cmp -s \"$cdir/rows.csv\" \"$rows_tmp\"",
-        "validate_cell_rows \"$cdir/rows.csv\" \"$cell\"",
-        "pass $CAMPAIGN_FINGERPRINT $CELL_SCENARIO_SHA256 $CELL_DATASET_SHA256 $CELL_EVIDENCE_SHA256",
-        "wait \"$sampler_pid\"",
-        "RSS sampler produced empty or invalid data",
-        "changed_first_generation_update_p50_ms",
-        "changed_first_generation_update_p95_ms",
-        "changed_first_generation_update_max_ms",
-        "artifact root belongs to campaign",
-        "existing failed, interrupted, or inconsistent evidence is immutable",
-        "choose a fresh ARTIFACTS_DIR",
-        "artifact root has malformed provenance; refusing to overwrite it",
-        "non-empty artifact root has no provenance; refusing to overwrite it",
-        "refusing to overwrite or repair its provenance",
-        "if [ \"$PRIOR_PROVENANCE\" != \"$SEALED_CAMPAIGN_PROVENANCE\" ]; then",
-        "if [ -e \"$ART/$cell\" ] || [ \"${existing_rows:-0}\" -ne 0 ]; then",
-        "CELLS=(rustbgpd-sighup bird openbgpd)",
-        "rustbgpd-txn must use a separate measured campaign",
-        "TXN_MAX_CANDIDATE_BYTES",
-        "if [ \"$candidate_bytes\" -gt \"$TXN_MAX_CANDIDATE_BYTES\" ]; then",
-        "candidate exceeds the ${TXN_MAX_CANDIDATE_BYTES}-byte streamed request budget",
-        "cleanup_active_processes",
-        "terminate_process_group \"$pid\"",
-        "ACTIVE_HARNESS_PID",
-        "ACTIVE_SAMPLER_PID",
-        "ACTIVE_DAEMON_PID",
-        "kill -TERM -- \"-$pid\"",
-        "kill -KILL -- \"-$pid\"",
-        "trap 'exit 130' INT",
-        "trap 'exit 143' TERM",
-        "required manifest/provenance retention failed",
-        "rc=97",
-        "NF != 23 || $1 != cell || $2 != sprintf(\"%d\", NR)",
-        "NR != expected",
-        "invalid, missing, or duplicate measurement rows",
-        "failed to retain measurement rows",
-        "rc=96",
-        "[ \"${existing_rows:-0}\" -eq \"$RELOADS\" ]",
-        "[ \"${rows:-0}\" -ne \"$RELOADS\" ]",
+/// Parse every shell script exercised by this integration target.
+fn irr_reload_shell_scripts_parse_as_bash() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    for relative in [
+        "bench/scale/irrreload/run-irr-reload.sh",
+        "bench/scale/irrreload/txn-apply.sh",
+        "bench/scale/irrreload/txn-lifecycle.sh",
+        "bench/scale/matrix/rss-sampler.sh",
+        "bench/scale/irrreload/run-bmp-buffer-receipt.sh",
+        "bench/scale/config-persistence/run-receipt.sh",
+        "bench/scale/outbound-prefix-limits/run-receipt.sh",
     ] {
+        let output = std::process::Command::new("bash")
+            .args(["-n", &format!("{root}/{relative}")])
+            .output()
+            .unwrap_or_else(|error| panic!("parse {relative}: {error}"));
         assert!(
-            runner.contains(required),
-            "missing receipt seal: {required}"
+            output.status.success(),
+            "{relative} is not valid bash\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
         );
     }
-    assert!(
-        !runner.contains("changed_first_update_p50_ms"),
-        "future rows must not reuse the ambiguous historical column name"
-    );
-    let retention_gate = runner
-        .find("required manifest/provenance retention failed")
-        .expect("retention failure gate");
-    let scenario_delete = runner
-        .rfind("rm -rf \"$run\"")
-        .expect("successful scenario deletion");
-    assert!(
-        retention_gate < scenario_delete,
-        "retention must fail closed before successful scenario deletion"
-    );
-    let cleanup = runner
-        .split_once("cleanup() {")
-        .and_then(|(_, rest)| rest.split_once("trap cleanup EXIT"))
-        .map(|(body, _)| body)
-        .expect("cleanup function body");
-    assert!(cleanup.contains("cleanup_active_processes"));
-    let terminate = runner
-        .split_once("terminate_process_group() {")
-        .and_then(|(_, rest)| rest.split_once("cleanup_active_processes() {"))
-        .map(|(body, _)| body)
-        .expect("bounded process-group terminator");
-    assert!(terminate.contains("kill -TERM -- \"-$pid\""));
-    assert!(terminate.contains("kill -KILL -- \"-$pid\""));
-    assert!(terminate.contains("wait \"$pid\""));
 }
 
 #[test]
-/// Red proof: removing the rustbgpd `/readyz` request, moving it before the
-/// BGP-listener gate, or restoring the listener-only early return makes the
-/// source contract or executable failure fixture turn red. BIRD remains gated
-/// only by its BGP listener.
+/// Red proof: bypassing the rustbgpd `/readyz` request or moving it before the
+/// BGP-listener gate makes an executable fixture fail. BIRD remains gated only
+/// by its BGP listener.
 fn irr_reload_rustbgpd_startup_requires_readyz_after_bgp_listener() {
     let runner = std::fs::read_to_string(format!(
         "{}/bench/scale/irrreload/run-irr-reload.sh",
@@ -202,28 +125,15 @@ fn irr_reload_rustbgpd_startup_requires_readyz_after_bgp_listener() {
         .and_then(|(_, rest)| rest.split_once("run_cell() {"))
         .map(|(body, _)| format!("wait_ready() {{{body}"))
         .expect("wait_ready function body");
-    let bgp_listener = wait_ready
-        .find("ss -ltnH \"sport = :$PORT\" | grep -q .; then")
-        .expect("BGP listener gate");
-    let rustbgpd_cells = wait_ready
-        .find("rustbgpd-sighup | rustbgpd-txn | \"$GROUPED_CELL\")")
-        .expect("rustbgpd cell branch");
-    let readyz = wait_ready
-        .find("curl -fsS --max-time 2 'http://127.0.0.1:9179/readyz' >/dev/null 2>&1 &&")
-        .expect("rustbgpd readiness gate");
-    assert!(
-        bgp_listener < rustbgpd_cells && rustbgpd_cells < readyz,
-        "rustbgpd must pass BGP and /readyz gates before startup succeeds"
-    );
-
     let fixture_dir = tempfile::tempdir().expect("fixture directory");
     let run_fixture = |cell: &str, readyz_rc: u8, ss_rc: u8| {
         std::process::Command::new("bash")
             .arg("-c")
             .arg(format!(
                 r#"{wait_ready}
+exec 3>&2
 ss() {{ [ "$SS_RC" -eq 0 ] && printf 'LISTEN\n'; }}
-curl() {{ return "$READYZ_RC"; }}
+curl() {{ printf '/readyz probed\n' >&3; return "$READYZ_RC"; }}
 container=
 daemon_pid=$$
 PORT=1790
@@ -252,7 +162,7 @@ wait_ready "$CELL" "$CDIR"
         blocked_stderr.contains("startup readiness did not complete after 0s; rustbgpd also requires http://127.0.0.1:9179/readyz"),
         "rustbgpd readiness timeout was misleading: {blocked_stderr}"
     );
-    let rustbgpd_no_listener = run_fixture("rustbgpd-txn", 0, 1);
+    let rustbgpd_no_listener = run_fixture("rustbgpd-txn", 22, 1);
     let no_listener_stderr = String::from_utf8_lossy(&rustbgpd_no_listener.stderr);
     assert!(!rustbgpd_no_listener.status.success());
     assert_eq!(
@@ -1011,45 +921,6 @@ fn irr_reload_counterbalanced_receipt_protocol_is_load_bearing() {
     );
 
     let script = std::fs::read_to_string(&runner).expect("read runner");
-    assert!(
-        script.lines().count() <= 1_050,
-        "runner parsing belongs in Python"
-    );
-    for guard in [
-        "RELOADSTALL_PRE_CHURN_EVIDENCE_DIR=\"$barrier\"",
-        "RELOADSTALL_EVIDENCE_DIR=\"$final_barrier\"",
-        "jq -cS . | sha256sum",
-        "320,183040,1000,40000,61,4,0.1,1790,30,402653184,7200,600,8",
-        "capture_topology \"$topology_mode\" \"$cdir\" \"$run\" \"$hpid\" \"$barrier\"",
-        "ack_pre_churn \"$barrier\" true \"$cdir\"",
-        "--peers \"$N_MEMBERS\" --total \"$TOTAL_PREFIXES\"",
-        "--manifest \"$run/manifest.json\"",
-        "RELOADSTALL_OVERLAP_FILE=\"$run/overlap.tsv\"",
-        "RELOADSTALL_RECEIVED_VIEW_FILE=\"$cdir/received-view.tsv\"",
-        "--overlap-fraction \"$OVERLAP_FRACTION\"",
-        "TOPOLOGY_CAPTURE_TIMEOUT=50",
-        "deadline=$((SECONDS + TOPOLOGY_CAPTURE_TIMEOUT))",
-        "rm -f \"$cdir/topology.json\" \"$cdir\"/metrics-{1,2,3}.prom",
-        "bind_first_trigger \"$cdir\"",
-        "full measured campaigns require a clean HEAD exactly at origin/main",
-        "printf 'sample\\tepoch_s\\tload1\\tpswpin\\tpswpout",
-        "[ \"$sample\" -gt 2 ] || sleep 30",
-        "daemon PID/start identity changed",
-        "transactions/cycles.jsonl transactions/lifecycle.json",
-        "txn-lifecycle.sh",
-        "shlex.join(sys.argv[1:])",
-        "env TXN_SMOKE=1",
-        "pswpin\\tpswpout\\tport1790_free\\tport9179_free\\tdisk_available_kib",
-        "[ \"$disk_kib\" -ge $((40 * 1024 * 1024)) ]",
-        "find . -type f ! -name SHA256SUMS",
-        "chmod -R a-w \"$ART\"",
-    ] {
-        assert!(script.contains(guard), "missing protocol guard: {guard}");
-    }
-    assert!(
-        script.contains("if [ -z \"$SMOKE\" ]; then\n    if [ -n \"${SKIP_PREFLIGHT:-}\" ]; then"),
-        "every full campaign, including rustbgpd-txn, must enter the preflight gate"
-    );
     let private_runtime = "rm -rf -- \"$run\" || return 1\n    mkdir -p \"$cdir\" || return 1\n    mkdir -m 0700 -- \"$run\" || return 1";
     let private_runtime_pos = script
         .find(private_runtime)
@@ -1064,15 +935,6 @@ fn irr_reload_counterbalanced_receipt_protocol_is_load_bearing() {
     assert!(
         !script.contains("mkdir -p \"$cdir\" \"$run\""),
         "caller umask must not control runtime-state directory permissions"
-    );
-    let load_gate = script
-        .split_once("load_gate() {")
-        .and_then(|(_, rest)| rest.split_once("capture_topology() {"))
-        .map(|(body, _)| body)
-        .expect("load_gate body must remain structurally inspectable");
-    assert!(
-        !load_gate.contains("TXN_ONLY"),
-        "full transaction campaigns must not bypass quiet-host sampling"
     );
 }
 
@@ -1563,10 +1425,6 @@ fn irr_memory_protocol_self_test_exercises_semantic_rejections() {
     assert!(stdout.contains("SELF_TEST pass"));
 
     let script = std::fs::read_to_string(&runner).expect("runner source");
-    let (_, after_start) = script.split_once("full_source_admission() {").unwrap();
-    let (admission_body, _) = after_start.split_once("source_admission() {").unwrap();
-    let exact_fetch = "GIT_TERMINAL_PROMPT=0 timeout -k 5 60 git -C \"$REPO\" fetch origin '+refs/heads/main:refs/remotes/origin/main'";
-    assert!(admission_body.contains(exact_fetch));
     let admission = script.find("source_admission \"$MODE\" || die").unwrap();
     for later in r#"mkdir -p "$(dirname "$ARTIFACT_ROOT")"|mkdir "$ARTIFACT_ROOT"|tests/soak/preflight.sh|RUSTBGPD_HOST_LOCK|flock -n "$LOCK_FD"|cargo build --locked --profile|cargo build --locked --release --manifest-path"#.split('|') {
         assert!(


### PR DESCRIPTION
## Summary

- replace a shell-source prose roster with executable syntax checks over seven exercised scripts
- remove redundant source-order and literal inventories already covered by behavior/self-tests
- retain all 17 executable reloadstall tests and every historical sole-defense assertion

## Validation

- `cargo test --locked --test reloadstall_scenario_emitted_check -- --list`
- `cargo test --locked --test reloadstall_scenario_emitted_check`
- `cargo clippy --locked --test reloadstall_scenario_emitted_check -- -D warnings`
- `cargo fmt --all -- --check`
- direct `bash -n` over all seven exercised scripts
- `git diff --check`

Linear: LAN-971
