### PR TITLE
docs: define supported daemon platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 
+- Root-daemon non-Linux fallbacks were removed in #1581. Distributed and
+  supported daemon targets are Linux x86_64 and aarch64; portable component
+  and transport abstractions do not expand daemon support.
 - Retired stale subsystem stress scripts and a checked-in benchmark scratch
   artifact; maintained soak and interop coverage remain authoritative. (LAN-968)
 - `NeighborService.AddNeighbor` now requires field-2 `intent` with its inner

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,9 @@
 
 - Rust 1.95+ (edition 2024 — workspace MSRV; raised to 1.95 because the bundled SQLite build (libsqlite3-sys) uses the `cfg_select!` macro stabilized in Rust 1.95)
 - `protobuf-compiler` (`apt-get install protobuf-compiler` on Debian/Ubuntu)
-- Linux x86_64 or aarch64 (primary targets)
-- macOS works for development but is not CI-tested
+- Linux x86_64 for native daemon/runtime CI; Linux aarch64 is cross-built
+- Non-Linux work is limited to portable components; see the
+  [platform support contract](SUPPORT.md#platform-support)
 - Docker + [containerlab](https://containerlab.dev/) for interop tests
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ control-plane target and expanding toward cloud / AI-scale data-center
 fabric use.
 
 > **Alpha expectations:** The config format and gRPC API are not yet frozen.
-> Breaking changes are possible between minor versions. The daemon runs on
-> Linux (the primary target); other platforms are not tested. See
+> Breaking changes are possible between minor versions. The supported daemon
+> targets are Linux x86_64 and aarch64; see the canonical
+> [platform support contract](SUPPORT.md#platform-support) and
 > [Project Status](#project-status) for details.
 
 ## Try it (60 seconds)
@@ -437,7 +438,7 @@ evolving API.**
 | **Adopter support** | Reporting channels, compatibility boundaries, and proof limits are documented in [SUPPORT.md](SUPPORT.md). |
 | **Narrow stable contract** | The machine-pinned [route-server / route-reflector v1 contract](docs/v1-stable-contract.md) covers only its inventoried control-plane roles and surfaces; the project and all unlisted features remain alpha. |
 | **Implemented** | Dual-stack BGP/MP-BGP, Add-Path, GR/LLGR, RPKI/RTR, ASPA path verification, FlowSpec, BMP, MRT, BFD, EVPN/VXLAN (alpha), and full gRPC/CLI management. Linux FIB integration is default-off and scoped to RFC 7999 discard routes and configured unicast tables (including ECMP and weighted multipath); broader routing-suite features remain future work. |
-| **Supported OS** | Linux (primary target). Requires `CAP_NET_BIND_SERVICE` for port 179. |
+| **Supported OS** | Linux x86_64 and aarch64 only; see the [platform support contract](SUPPORT.md#platform-support). Requires `CAP_NET_BIND_SERVICE` for port 179. |
 | **Runtime** | Rust 1.95+ (workspace MSRV — set by the bundled SQLite build), single binary, no external dependencies except optional RPKI/BMP/MRT backends |
 | **Config stability** | Inventoried RS/RR v1 fields follow the narrow compatibility policy; unlisted TOML may change between minor versions with migrations documented in CHANGELOG. |
 | **API stability** | Inventoried native gRPC/CLI/JSON surfaces follow the narrow v1 policy; unlisted API remains alpha and may evolve between minor versions. |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2154,7 +2154,9 @@ rustbgpd is an API-first BGP daemon. The following are explicitly out of scope:
   TUI are polished convenience wrappers, but gRPC is the contract.
 - **GoBGP proto compatibility.** Our protos are our own. A compat adapter can
   exist as a separate project if anyone wants it.
-- **Windows support.** Linux is the target; macOS for dev builds only.
+- **Non-Linux daemon support.** macOS, BSD, and Windows remain outside the
+  supported daemon targets; portable component work does not change that
+  [platform contract](SUPPORT.md#platform-support).
 - **Full web UI / dashboard.** Grafana + Prometheus is the monitoring story; the
   built-in looking glass is read-only JSON for NOC integration. (Market research
   shows IXPs use external presentation layers — Alice-LG, IXP Manager — so a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,9 @@ logging — see [docs/SECURITY.md](docs/SECURITY.md).
 |---------|-----------|
 | 0.x     | Yes (current development) |
 
+Daemon security support follows the Linux-only
+[platform support contract](SUPPORT.md#platform-support).
+
 ## Reporting a Vulnerability
 
 Report security vulnerabilities via

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -12,6 +12,20 @@ The only narrow compatibility promise is the machine-inventoried
 That promise applies only to the roles and surfaces listed by its inventory.
 The rest of the project remains alpha and may change between minor releases.
 
+## Platform support
+
+The distributed and supported `rustbgpd` daemon targets are Linux x86_64 and
+Linux aarch64. Published binaries use a glibc 2.31 baseline; see the
+[deployment guide](docs/deployment.md#pre-built-binary-tarball). macOS, BSD,
+and Windows daemon builds are unsupported: they may not compile or run, and
+there is no degraded daemon mode for those systems.
+
+Daemon runtime, interoperability, and privileged CI run on Linux x86_64.
+Linux aarch64 is cross-built and release-packaged, but is not natively
+executed in CI. Pure, kernel-independent crates and transport or socket
+abstractions with non-Linux fallbacks may remain portable and testable; that
+does not expand daemon platform support.
+
 RFC 8212 enforcement remains opt-in under
 [ADR-0112](docs/adr/0112-rfc-8212-ebgp-requires-policy.md).
 [ADR-0119](docs/adr/0119-rfc-8212-secure-default-config-epoch.md) is Accepted;

--- a/crates/evpn-linux/Cargo.toml
+++ b/crates/evpn-linux/Cargo.toml
@@ -17,8 +17,8 @@ tokio = { workspace = true, features = ["sync", "time", "macros", "rt"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing.workspace = true
 
-# Linux-only — real netlink. cfg-gated so the crate type-checks on
-# macOS dev builds. The four netlink crates form a coherent ecosystem
+# Linux-only real netlink; cfg-gating preserves portable trait/test surfaces
+# without promising non-Linux daemon support. The four netlink crates form a coherent ecosystem
 # released together; bump them as a set or transitive resolution
 # pulls in two copies of `netlink-packet-utils`.
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/evpn/src/dataplane.rs
+++ b/crates/evpn/src/dataplane.rs
@@ -10,8 +10,8 @@
 //! These types live in `crates/evpn` rather than `crates/evpn-linux`
 //! deliberately — see ADR-0054 §1 / §2 — so that:
 //!
-//! - The daemon can construct intents on platforms that don't compile
-//!   the netlink crate (macOS dev builds).
+//! - Kernel-independent code can construct and test intents without compiling
+//!   netlink; this portability does not imply non-Linux daemon support.
 //! - A future RR-only feature flag can drop `rustbgpd-evpn-linux`
 //!   entirely while leaving the intent surface untouched.
 //! - The diff and projection unit tests run with no Linux dependencies.

--- a/crates/evpn/src/df_election.rs
+++ b/crates/evpn/src/df_election.rs
@@ -4,7 +4,8 @@
 //! carving, RFC 8584 §2.2 algorithm negotiation, and the RFC 8584
 //! §3.2 Highest Random Weight algorithm. Lives in
 //! `crates/evpn` for the same reasons the local-MAC originator does:
-//! deterministic, no I/O, no tokio, testable on macOS dev builds.
+//! deterministic, no I/O, no tokio, and portable for component testing without
+//! implying non-Linux daemon support.
 //!
 //! The daemon-side orchestrator (slice 3 in `src/evpn_segment.rs`)
 //! gathers candidate PEs from the RIB's Type 4 ES routes, calls

--- a/crates/evpn/src/origination.rs
+++ b/crates/evpn/src/origination.rs
@@ -18,9 +18,9 @@
 //! the daemon translates into `RibUpdate::InjectEvpn` /
 //! `RibUpdate::WithdrawEvpn`.
 //!
-//! Living in `crates/evpn` keeps the whole sequencer testable on macOS
-//! dev builds and isolated from the netlink-only `crates/evpn-linux`
-//! per ADR-0054 §1's portability rule.
+//! Living in `crates/evpn` keeps the sequencer portable for component testing
+//! and isolated from the netlink-only `crates/evpn-linux`; this does not imply
+//! non-Linux daemon support (ADR-0054 §1).
 //!
 //! # Inputs
 //!

--- a/crates/evpn/src/origination_es.rs
+++ b/crates/evpn/src/origination_es.rs
@@ -11,8 +11,8 @@
 //! | [`LocalEadPerEviOriginator`] | Type 1 EAD-per-EVI (RFC 7432 §7.1) | One per `(ESI, VNI)` |
 //!
 //! All three live in `crates/evpn` for the same reasons the local-MAC
-//! originators do: deterministic, no I/O, no tokio, testable on macOS
-//! dev builds. Daemon-side wiring (slice 3) composes them per ESI
+//! originators do: deterministic, no I/O, no tokio, and portable for component
+//! testing without implying non-Linux daemon support. Daemon-side wiring composes them per ESI
 //! alongside the [`crate::DfElection`] state machine.
 //!
 //! ## Why no mobility sequencing

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -419,10 +419,10 @@ error). The same surface is available as JSON with
 `rbgp -j rib blackholes`. Adoption and reaping are counted by
 `bgp_blackhole_discard_adopted_total` and
 `bgp_blackhole_discard_reaped_total`.
-If the reconciler cannot start at all (for example netlink setup failure, or
-requesting FIB install on a non-Linux build), the status list is empty and
-`bgp_blackhole_discard_kernel_failures_total{action="setup"}` or
-`{action="unsupported_platform"}` carries the failure signal.
+If the reconciler cannot start at all (for example a netlink setup failure),
+the status list is empty and
+`bgp_blackhole_discard_kernel_failures_total{action="setup"}` carries the
+failure signal.
 
 SIGHUP hot-applies this field with the same best-effort partial-apply
 semantics as `honor_graceful_shutdown`: rustbgpd recomputes runtime policies

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -606,7 +606,10 @@ This section defines the security stance for rustbgpd. Not all items are v1 impl
 
 ### Session Authentication
 
-**Supported platforms (v1): Linux (x86_64, aarch64).** TCP MD5, GTSM via `IP_TTL`, and certain socket options are Linux-specific. macOS and BSD may work for development builds but are not tested or supported targets. This is stated explicitly to prevent bug reports about platform-specific socket behavior.
+**Supported platforms (v1): Linux (x86_64, aarch64).** TCP MD5, GTSM via
+`IP_TTL`, and certain socket options are Linux-specific. Non-Linux daemon
+builds are unsupported; portable components do not expand the canonical
+[platform support contract](../SUPPORT.md#platform-support).
 
 **Dual-family BGP listener:** The daemon always listens for inbound BGP on both address families — `0.0.0.0:{listen_port}` and `[::]:{listen_port}` — behind one accept loop and one accept channel; there is no listen-address knob (ADR-0019). `IPV6_V6ONLY` is set explicitly on the IPv6 socket so v4-mapped connections always arrive through the IPv4 socket. Every listener-side authentication entry below (MD5 key, TCP-AO MKT, GTSM selector) is installed on the socket matching the peer's address family, so IPv6 peers get the same inbound enforcement as IPv4 peers. If one family cannot be bound (for example IPv6 disabled on the host), a warning names the family and the other keeps serving; startup fails only when neither family binds.
 
@@ -759,9 +762,10 @@ privileged runner is available.
 
 ### Supported Platforms
 
-- **v1:** Linux (x86_64, aarch64). These are the only tested and supported targets.
-- macOS and BSD may compile and run for development purposes but are not CI-tested. Platform-specific socket options (TCP_MD5SIG, IP_TTL for GTSM) are Linux-only.
-- Windows is not supported.
+- **v1:** Linux x86_64 and aarch64 are the supported daemon targets.
+- Native daemon/runtime CI is Linux x86_64; aarch64 is cross-built and packaged.
+- Non-Linux daemon builds are unsupported. See the canonical
+  [platform support contract](../SUPPORT.md#platform-support).
 
 ### Compatibility Targets
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1307,7 +1307,6 @@ FIB runtime. The actor is still default-off; configure at least one
 | `bgp_fib_kernel_failures_total{action="install"}` | Kernel rejected an add operation |
 | `bgp_fib_kernel_failures_total{action="replace"}` | Kernel rejected a replace operation |
 | `bgp_fib_kernel_failures_total{action="remove"}` | Kernel rejected a remove operation |
-| `bgp_fib_kernel_failures_total{action="unsupported_platform"}` | Config requested FIB programming on a non-Linux build |
 | `bgp_kernel_route_notify_dropped_total{actor,reason="channel_full"}` | Kernel route-event wake feed dropped an event before the FIB or BLACKHOLE reconciler could consume it; periodic reconcile remains the repair backstop |
 | `bgp_kernel_route_notify_subscription_failures_total{actor,group}` | The FIB or BLACKHOLE reconciler failed to subscribe to an IPv4/IPv6 route multicast group and is running with periodic-only kernel-drift repair |
 

--- a/docs/adr/0055-evpn-local-mac-origination.md
+++ b/docs/adr/0055-evpn-local-mac-origination.md
@@ -51,8 +51,9 @@ The relevant source constraints are:
 The constraints from ADR-0054 carry over unchanged:
 
 - `crates/evpn-linux` may not depend on `crates/rib` or `crates/transport`.
-- `crates/evpn` must remain portable to non-Linux dev builds (no
-  netlink, no tokio, no I/O).
+- `crates/evpn` remains pure and kernel-independent (no netlink, no tokio, no
+  I/O), so its logic can be tested across platforms without promising daemon
+  support there.
 - Route-reflector deployments with empty `[[evpn_instances]]` must
   spawn no background tasks.
 
@@ -97,8 +98,8 @@ explicitly:
 
 A pure-function shape (`on_local_learned`, `on_local_aged`,
 `on_remote_changed` each return `Vec<OriginationAction>` and never
-touch I/O) keeps the sequencer testable on macOS dev builds with no
-tokio or RIB scaffolding. The proptest invariant in
+touch I/O) keeps the sequencer portable and testable with no tokio or RIB
+scaffolding. The proptest invariant in
 `crates/evpn/src/origination.rs#tests` exercises the monotonic
 ratchet across mixed-handler sequences.
 
@@ -238,10 +239,8 @@ tracked separately.
 - Sequence-rule logic is unit-testable with no kernel, no RIB, and no
   tokio. The state machine's 17 in-module tests cover every RFC §15.1
   branch including a proptest-style monotonic ratchet invariant.
-- macOS dev builds still build the originator (the channel is a
-  `crates/evpn-linux` trait method that returns `None` on macOS-bound
-  fake impls; the originator's `spawn` path returns `None` too,
-  cleanly skipping the actor).
+- Kernel-independent originator logic remains portable and testable; this does
+  not imply that the daemon is supported on non-Linux systems.
 - RR-only deployments still spawn no background tasks. The empty
   `[[evpn_instances]]` gate covers both the dataplane reconciler
   (Gate 7b) and the originator (Gate 7b+1).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -23,7 +23,10 @@ change between minor versions. See [`CHANGELOG.md`](../CHANGELOG.md) for
 migration notes and run `rustbgpd --check <new config>` against the new binary
 before swapping it in.
 
-It runs on Linux. Other platforms are not tested.
+The supported daemon targets are Linux x86_64 and aarch64. Published binaries
+use a glibc 2.31 baseline. See the canonical
+[platform support contract](../SUPPORT.md#platform-support) for CI and
+non-Linux boundaries.
 
 Suitable for: lab pilots, data-center fabric pilots, IX route-server
 pilots, automation-heavy control-plane work where the API surface


### PR DESCRIPTION
## Summary
- define Linux x86_64 and aarch64 as the supported daemon targets
- distinguish x86_64 runtime CI from aarch64 cross-build and packaging coverage
- remove stale non-Linux fallback promises while preserving portable component and transport abstractions

## Validation
- cargo fmt --all -- --check
- cargo check -p rustbgpd-evpn -p rustbgpd-evpn-linux --all-targets
- public tracker contract: 11 tests plus live check
- release install contract: 10 tests plus live check

Linear: LAN-946