### PR TITLE
test: fail closed in M67 soak observations

### DIFF
--- a/tests/soak/m67-vtep-route-oracles.sh
+++ b/tests/soak/m67-vtep-route-oracles.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Source-only route-observation helpers for the standalone M67 soak.
+
+vtep_routes() {
+    local route_type=${1:?} peer=${2:?} raw routes
+    if ! raw=$(vtep_ctl evpn --route-type "$route_type" --peer "$peer" -j 2>/dev/null); then
+        printf 'ERROR: VTEP route observation failed for route type %s peer %s\n' \
+            "$route_type" "$peer" >&2
+        return 2
+    fi
+    if ! routes=$(printf '%s\n' "$raw" | jq -ces '
+        if length == 1 and
+           (.[0] | type == "array" and all(.[]; type == "object"))
+        then .[0]
+        else error("expected exactly one array of objects")
+        end
+    ' 2>/dev/null); then
+        printf 'ERROR: unusable VTEP route JSON for route type %s peer %s\n' \
+            "$route_type" "$peer" >&2
+        return 2
+    fi
+    printf '%s\n' "$routes"
+}
+
+vtep_route_count() {
+    local route_type=${1:?} peer=${2:?} predicate=${3:-true} routes count
+    if ! routes=$(vtep_routes "$route_type" "$peer"); then
+        return 2
+    fi
+    if ! count=$(printf '%s\n' "$routes" \
+        | jq -er "[.[] | select(${predicate})] | length" 2>/dev/null); then
+        printf 'ERROR: VTEP route filter failed for route type %s peer %s\n' \
+            "$route_type" "$peer" >&2
+        return 2
+    fi
+    if [[ ! "$count" =~ ^[0-9]+$ ]]; then
+        printf 'ERROR: non-integer VTEP route count for route type %s peer %s\n' \
+            "$route_type" "$peer" >&2
+        return 2
+    fi
+    printf '%s\n' "$count"
+}
+
+wait_vtep_routes_at_least() {
+    local route_type=${1:?} peer=${2:?} predicate=${3:?} want=${4:?} attempts=${5:-90}
+    local got last_rc=1
+    for _ in $(seq 1 "$attempts"); do
+        if got=$(vtep_route_count "$route_type" "$peer" "$predicate"); then
+            last_rc=1
+        else
+            last_rc=2
+            sleep 1
+            continue
+        fi
+        if [ "$got" -ge "$want" ]; then
+            return 0
+        fi
+        sleep 1
+    done
+    return "$last_rc"
+}
+
+wait_vtep_routes_gone() {
+    local route_type=${1:?} peer=${2:?} predicate=${3:?} attempts=${4:-90}
+    local got last_rc=1
+    for _ in $(seq 1 "$attempts"); do
+        if got=$(vtep_route_count "$route_type" "$peer" "$predicate"); then
+            last_rc=1
+        else
+            last_rc=2
+            sleep 1
+            continue
+        fi
+        if [ "$got" -eq 0 ]; then
+            return 0
+        fi
+        sleep 1
+    done
+    return "$last_rc"
+}

--- a/tests/soak/run-m67-link-drain-churn-soak.sh
+++ b/tests/soak/run-m67-link-drain-churn-soak.sh
@@ -136,42 +136,9 @@ vtep_ctl() {
     docker exec "$VTEP" rbgp -s http://127.0.0.1:50051 "$@"
 }
 
-vtep_routes() {
-    local route_type=${1:?} peer=${2:?}
-    vtep_ctl evpn --route-type "$route_type" --peer "$peer" -j 2>/dev/null || echo "[]"
-}
-
-vtep_route_count() {
-    local route_type=${1:?} peer=${2:?} predicate=${3:-true}
-    vtep_routes "$route_type" "$peer" \
-        | jq "[.[] | select(${predicate})] | length" 2>/dev/null || echo 0
-}
-
-wait_vtep_routes_at_least() {
-    local route_type=${1:?} peer=${2:?} predicate=${3:?} want=${4:?} attempts=${5:-90}
-    local got=0
-    for _ in $(seq 1 "$attempts"); do
-        got=$(vtep_route_count "$route_type" "$peer" "$predicate")
-        if [ "${got:-0}" -ge "$want" ] 2>/dev/null; then
-            return 0
-        fi
-        sleep 1
-    done
-    return 1
-}
-
-wait_vtep_routes_gone() {
-    local route_type=${1:?} peer=${2:?} predicate=${3:?} attempts=${4:-90}
-    local got=1
-    for _ in $(seq 1 "$attempts"); do
-        got=$(vtep_route_count "$route_type" "$peer" "$predicate")
-        if [ "${got:-1}" -eq 0 ] 2>/dev/null; then
-            return 0
-        fi
-        sleep 1
-    done
-    return 1
-}
+# Shared fail-closed route observation and wait helpers.
+# shellcheck source=tests/soak/m67-vtep-route-oracles.sh
+source "$SOAK_SCRIPT_DIR/m67-vtep-route-oracles.sh"
 
 df_role() {
     local container=${1:?} role=${2:?}

--- a/tests/soak/test_m67_link_drain_analyzer.py
+++ b/tests/soak/test_m67_link_drain_analyzer.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 
 HERE = Path(__file__).parent
+ORACLE = HERE / "m67-vtep-route-oracles.sh"
 FIELDS = [
     "elapsed_sec", "cycle", "phase", "pe1_rss_mb", "pe2_rss_mb",
     "vtep_rss_mb", "pe1_session_established", "pe2_session_established",
@@ -87,6 +88,116 @@ class M67AnalyzerContracts(unittest.TestCase):
                         gate["pass"] for name, gate in gates.items()
                         if name != "sessions_established_at_end"
                     ), payload)
+
+
+class M67VtepRouteOracleContracts(unittest.TestCase):
+    def run_shell(self, body):
+        return subprocess.run(
+            ["bash", "-c", body, "bash", str(ORACLE)],
+            text=True, capture_output=True, check=False,
+        )
+
+    def test_source_is_inert(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = subprocess.run(
+                ["bash", "-c", r'''
+                    set -u
+                    cd "$2"
+                    docker() { return 99; }
+                    before=$(trap -p)
+                    source "$1"
+                    [ "$(trap -p)" = "$before" ]
+                    [ "$(find . -mindepth 1 -print -quit)" = "" ]
+                    [ "$(declare -F | awk '{print $3}' | sort)" = \
+                      "docker
+vtep_route_count
+vtep_routes
+wait_vtep_routes_at_least
+wait_vtep_routes_gone" ]
+                ''', "bash", str(ORACLE), tmp],
+                text=True, capture_output=True, check=False,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr, "")
+
+    def test_route_oracle_matrix(self):
+        result = self.run_shell(r'''
+            set -euo pipefail
+            source "$1"
+            sleep() { :; }
+            case_name=""
+            counter=$(mktemp)
+            trap 'rm -f "$counter"' EXIT
+            printf '0\n' >"$counter"
+
+            vtep_ctl() {
+                case "$case_name" in
+                    exit42) printf '[]\n'; return 42 ;;
+                    malformed) printf '[\n' ;;
+                    object) printf '{"route":1}\n' ;;
+                    null) printf 'null\n' ;;
+                    scalar) printf '7\n' ;;
+                    nonobject) printf '[{"up":true},7]\n' ;;
+                    multiple) printf '[]\n[]\n' ;;
+                    empty) printf '[]\n' ;;
+                    routes) printf '[{"up":true},{"up":false}]\n' ;;
+                    transient|nonmatch_failure)
+                        seen=$(<"$counter")
+                        printf '%s\n' "$((seen + 1))" >"$counter"
+                        if [ "$seen" -eq 0 ]; then
+                            if [ "$case_name" = transient ]; then
+                                printf '[]\n'; return 42
+                            fi
+                            printf '[]\n'; return 0
+                        fi
+                        printf '[]\n'
+                        if [ "$case_name" = transient ]; then return 0; fi
+                        return 42 ;;
+                    *) return 99 ;;
+                esac
+            }
+
+            expect() {
+                want_rc=$1 want_out=$2 want_err=$3
+                shift 3
+                out=$(mktemp) err=$(mktemp)
+                set +e
+                "$@" >"$out" 2>"$err"
+                rc=$?
+                set -e
+                [ "$rc" -eq "$want_rc" ]
+                [ "$(cat "$out")" = "$want_out" ]
+                if [ "$want_err" = yes ]; then [ -s "$err" ]; else [ ! -s "$err" ]; fi
+                rm -f "$out" "$err"
+            }
+            sample_field() { printf 'x,%s,y\n' "$(vtep_route_count 2 192.0.2.1)"; }
+
+            for case_name in exit42 malformed object null scalar nonobject multiple; do
+                expect 2 "" yes vtep_routes 2 192.0.2.1
+            done
+            case_name=exit42
+            expect 2 "" yes vtep_route_count 2 192.0.2.1 true
+            expect 2 "" yes wait_vtep_routes_at_least 2 192.0.2.1 true 1 1
+            expect 2 "" yes wait_vtep_routes_gone 2 192.0.2.1 true 1
+            case_name=empty
+            expect 0 '[]' no vtep_routes 2 192.0.2.1
+            expect 0 0 no vtep_route_count 2 192.0.2.1 true
+            expect 0 "" no wait_vtep_routes_gone 2 192.0.2.1 true 1
+            case_name=routes
+            expect 0 1 no vtep_route_count 2 192.0.2.1 '.up == true'
+            expect 0 "" no wait_vtep_routes_at_least 2 192.0.2.1 '.up == true' 1 1
+            expect 1 "" no wait_vtep_routes_gone 2 192.0.2.1 true 1
+            expect 2 "" yes vtep_route_count 2 192.0.2.1 'invalid('
+            case_name=transient; printf '0\n' >"$counter"
+            expect 0 "" yes wait_vtep_routes_gone 2 192.0.2.1 true 2
+            case_name=nonmatch_failure; printf '0\n' >"$counter"
+            expect 2 "" yes wait_vtep_routes_at_least 2 192.0.2.1 true 1 2
+            case_name=exit42
+            expect 0 'x,,y' yes sample_field
+        ''')
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extract the standalone M67 soak route oracles into a side-effect-free local helper
- reject command, JSON-shape, and filter failures instead of fabricating absence
- add a daemon-free matrix through the existing hosted analyzer test seam

## Preserved behavior
- soak bootstrap, host lock, logging, cleanup, topology, cycle phases, CSV schema, and analyzer behavior
- 90-attempt one-second status-only waits
- archived receipt claims

## Validation
- python3 -m unittest -v tests/soak/test_m67_link_drain_analyzer.py
- bash -n and shellcheck for the helper and runner
- destructive fallback-to-empty and filter-to-zero proofs

Linear: LAN-982