### PR TITLE
cleanup: remove stale unsupported-platform metric vocabulary

### DIFF
--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -3527,8 +3527,7 @@ impl BgpMetrics {
 
     /// Record a kernel apply failure for RFC 7999 discard state.
     ///
-    /// `action` is expected to be `setup`, `install`, `remove`,
-    /// `dump`, or `unsupported_platform`.
+    /// `action` is expected to be `setup`, `install`, `remove`, or `dump`.
     pub fn record_blackhole_discard_kernel_failure(&self, action: &str) {
         self.blackhole_discard_kernel_failures
             .with_label_values(&[action])
@@ -3552,8 +3551,7 @@ impl BgpMetrics {
 
     /// Record a kernel apply failure for general unicast FIB state.
     ///
-    /// `action` is expected to be `setup`, `dump`, `install`,
-    /// `replace`, `remove`, or `unsupported_platform`.
+    /// `action` is expected to be `setup`, `dump`, `install`, `replace`, or `remove`.
     pub fn record_fib_kernel_failure(&self, action: &str) {
         self.fib_kernel_failures.with_label_values(&[action]).inc();
     }
@@ -4877,10 +4875,10 @@ mod tests {
     }
 
     #[test]
-    fn blackhole_kernel_failure_counter_accepts_setup_labels() {
+    fn blackhole_kernel_failure_counter_accepts_production_labels() {
         let m = BgpMetrics::new();
         m.record_blackhole_discard_kernel_failure("setup");
-        m.record_blackhole_discard_kernel_failure("unsupported_platform");
+        m.record_blackhole_discard_kernel_failure("dump");
 
         assert_eq!(
             m.blackhole_discard_kernel_failures
@@ -4890,7 +4888,7 @@ mod tests {
         );
         assert_eq!(
             m.blackhole_discard_kernel_failures
-                .with_label_values(&["unsupported_platform"])
+                .with_label_values(&["dump"])
                 .get(),
             1
         );


### PR DESCRIPTION
## Summary
- remove the retired unsupported_platform value from BLACKHOLE and general-FIB metric helper documentation after #1581 removed its sole production emitters
- replace the synthetic blackhole test value with the reachable dump action, preserving two-label recording coverage
- leave metric APIs, names, collectors, and production labels unchanged

## Validation
- cargo test -p rustbgpd-telemetry blackhole_kernel_failure_counter_accepts_production_labels
- cargo test -p rustbgpd-telemetry
- cargo clippy -p rustbgpd-telemetry --all-targets -- -D warnings
- cargo fmt --all -- --check
- exact one-file scope and no-production-change audits

No new Linear issue: this is a maintainer-only cleanup tail after LAN-946.