### PR TITLE
test: link policy alert fixtures to production labels

### DIFF
--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -1880,4 +1880,24 @@ mod tests {
         assert_eq!(counters.snapshot(), vec![vec![1]]);
         assert_eq!(counters.evals(), 1);
     }
+
+    #[test]
+    fn prometheus_alert_fixture_uses_production_eval_error_labels() {
+        let fixture = include_str!("../../../examples/prometheus/rustbgpd-alerts_test.yml");
+        let mut found = 0;
+        for series in fixture
+            .lines()
+            .map(str::trim)
+            .filter(|line| line.starts_with("- series: 'bgp_policy_eval_errors_total{"))
+        {
+            found += 1;
+            let kind = series
+                .split_once("kind=\"")
+                .and_then(|(_, rest)| rest.split_once('"'))
+                .map(|(kind, _)| kind)
+                .expect("policy eval-error fixture series has a kind label");
+            assert!(super::EvalErrorKind::LABELS.contains(&kind), "{kind}");
+        }
+        assert!(found > 0, "policy eval-error fixture has input series");
+    }
 }

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -665,10 +665,10 @@ tests:
   - interval: 1m
     input_series:
       # Two eval errors at minute 5 — fires.
-      - series: 'bgp_policy_eval_errors_total{direction="import", kind="arithmetic", instance="edge1:9179"}'
+      - series: 'bgp_policy_eval_errors_total{direction="import", kind="overflow", instance="edge1:9179"}'
         values: "0 0 0 0 0 2 2 2 2 2 2 2 2 2 2 2"
       # Flat counter — must not fire.
-      - series: 'bgp_policy_eval_errors_total{direction="export", kind="dataset", instance="edge2:9179"}'
+      - series: 'bgp_policy_eval_errors_total{direction="export", kind="dataset-unpinned", instance="edge2:9179"}'
         values: "7x15"
     alert_rule_test:
       - eval_time: 2m
@@ -680,13 +680,13 @@ tests:
           - exp_labels:
               severity: warning
               direction: import
-              kind: arithmetic
+              kind: overflow
               instance: edge1:9179
             exp_annotations:
-              summary: "Policy evaluation errors (import, arithmetic)"
+              summary: "Policy evaluation errors (import, overflow)"
               description: >-
                 bgp_policy_eval_errors_total{direction="import",
-                kind="arithmetic"} on edge1:9179 increased by 2 in the
+                kind="overflow"} on edge1:9179 increased by 2 in the
                 last 15 minutes. Routes hitting the failing statement
                 are being denied.
 


### PR DESCRIPTION
## Summary

- replace impossible policy-evaluation alert fixture labels with values the daemon emits
- add a non-vacuous dependency-free check that every fixture kind belongs to the production label vocabulary
- keep alert expressions, metrics, and runtime behavior unchanged

## Validation

- full policy crate tests and clippy
- pinned promtool 3.4.1 rule and fixture tests
- orthogonal destructive proofs for producer vocabulary and alert output matching

Linear: LAN-952