### PR TITLE
ci: anchor embedding checks on semantics

### DIFF
--- a/scripts/check_embedding_crate_map.py
+++ b/scripts/check_embedding_crate_map.py
@@ -15,11 +15,6 @@ DOCUMENT = ROOT / "docs" / "EMBEDDING.md"
 COMMAND = "cargo metadata --locked --offline --format-version 1 --no-deps".split()
 BEGIN = "<!-- BEGIN EMBEDDING CRATE MAP -->"
 END = "<!-- END EMBEDDING CRATE MAP -->"
-SCOPE = (
-    "All Cargo workspace packages are listed. Internal dependencies include "
-    "normal and build dependencies, including target-specific dependencies; "
-    "dev dependencies are excluded."
-)
 
 
 def cargo_metadata(root: Path = ROOT) -> dict:
@@ -53,8 +48,12 @@ def expected_rows(metadata: dict) -> dict[str, tuple[str, tuple[str, ...]]]:
 
 
 def table_rows(document: str) -> list[tuple[str, str, str]]:
-    if document.count(BEGIN) != 1 or document.count(END) != 1:
-        raise ValueError("crate-map markers must each appear exactly once")
+    if (
+        document.count(BEGIN) != 1
+        or document.count(END) != 1
+        or document.index(BEGIN) >= document.index(END)
+    ):
+        raise ValueError("crate-map markers must each appear exactly once and BEGIN must precede END")
     _, _, rest = document.partition(BEGIN)
     body, _, _ = rest.partition(END)
     rows = []
@@ -79,13 +78,11 @@ def diagnostic(kind: str, detail: str) -> str:
 
 def check(document: str, metadata: dict) -> list[str]:
     errors = []
-    if document.count(f"{END}\n\n{SCOPE}\n") != 1:
-        errors.append(diagnostic("SCOPE", "checked-scope sentence differs"))
     try:
         rows = table_rows(document)
         expected = expected_rows(metadata)
     except ValueError as error:
-        return errors + [diagnostic("SCOPE", str(error))]
+        return errors + [diagnostic("MARKERS", str(error))]
     except (KeyError, TypeError) as error:
         return errors + [diagnostic("METADATA", str(error))]
 

--- a/scripts/check_embedding_versions.py
+++ b/scripts/check_embedding_versions.py
@@ -5,28 +5,49 @@ from pathlib import Path
 
 
 PACKAGES = ("wire", "fsm")
+HEADING = re.compile(r"^(#{1,6})\s+(?:\d+(?:\.\d+)*\.?\s+)?(.+?)\s*$", re.MULTILINE)
+SECTION_HEADING = re.compile(r"^(#{2,3})\s+", re.MULTILINE)
 
 
-def section(document: str, start: str, end: str) -> str:
-    rest = document.partition(start)[2].partition("\n")[2]
-    body, marker, _ = rest.partition(end)
-    return body if marker else ""
+def section(document: str, level: int, title: str) -> tuple[str, str | None]:
+    headings = [match for match in HEADING.finditer(document) if match[2] == title]
+    if len(headings) != 1 or len(headings[0][1]) != level:
+        state = "missing" if not headings else "duplicate-or-wrong-level"
+        return "", f"semantic-heading:{title}:{state}"
+    heading = headings[0]
+    end = len(document)
+    for following in SECTION_HEADING.finditer(document, heading.end()):
+        if len(following[1]) <= level:
+            end = following.start()
+            break
+    return document[heading.end() : end], None
 
 
 def check(document: str) -> list[str]:
     errors: list[str] = []
-    boundary = section(document, "## 7. ", "## 8. ").lstrip().split("\n\n", 1)[0]
+    requested = {
+        "boundary": (2, "Published-crate release boundary"),
+        "decode": (3, "Decode an UPDATE (codec-only — the canonical embedder)"),
+        "session": (3, 'Build a session (codec + FSM — the "minimal speaker" consumer)'),
+        "publish": (2, "Which crate to publish next, and why"),
+    }
+    sections = {}
+    for name, (level, title) in requested.items():
+        sections[name], error = section(document, level, title)
+        if error:
+            errors.append(error)
+    if errors:
+        return errors
+
+    boundary = sections["boundary"].lstrip().split("\n\n", 1)[0]
     current = re.findall(r"`rustbgpd-(wire|fsm) ([^`]+)`", boundary)
     versions = dict(current)
     if len(current) != len(PACKAGES) or set(versions) != set(PACKAGES):
         return ["current-boundary-version"]
 
     examples = {
-        "wire": (
-            section(document, "### 3.1 ", "### 3.2 "),
-            section(document, "### 3.3 ", "### 3.4 "),
-        ),
-        "fsm": (section(document, "### 3.3 ", "### 3.4 "),),
+        "wire": (sections["decode"], sections["session"]),
+        "fsm": (sections["session"],),
     }
     for package, bodies in examples.items():
         assignment = re.compile(rf'^rustbgpd-{package} = "([^"]+)"$', re.MULTILINE)
@@ -36,14 +57,12 @@ def check(document: str) -> list[str]:
 
     publish = re.findall(
         r"^\d+\. \*\*`rustbgpd-(wire|fsm)` \(published as `([^`]+)`\)\.\*\*",
-        section(document, "## 4. ", "## 5. "),
+        sections["publish"],
         re.MULTILINE,
     )
     if len(publish) != len(PACKAGES) or dict(publish) != versions:
         errors.append("publish-status-version")
 
-    if re.search(r"\bprepared\b", document, re.IGNORECASE):
-        errors.append("forbidden-prepared")
     return errors
 
 

--- a/scripts/test_check_embedding_crate_map.py
+++ b/scripts/test_check_embedding_crate_map.py
@@ -70,15 +70,25 @@ class EmbeddingCrateMapTests(unittest.TestCase):
         changed = DOCUMENT.replace(checker.END, row + checker.END, 1)
         self.assert_red(changed, "EMBEDDING_CRATE_MAP_EXTRA")
 
-    def test_scope_sentence_is_guarded(self) -> None:
-        """Red if scope or either marker's exact cardinality drifts."""
-        start, end = DOCUMENT.index(checker.BEGIN), DOCUMENT.index(checker.END)
-        fenced = DOCUMENT[start : end + len(checker.END)]
-        suffixes = (checker.BEGIN, checker.END, fenced)
-        changes = [DOCUMENT.replace(checker.SCOPE, "Drifted.", 1)]
-        changes.extend(DOCUMENT + suffix for suffix in suffixes)
+    def test_scope_paragraph_may_be_reworded(self) -> None:
+        old = "All Cargo workspace packages are listed. Internal dependencies include"
+        changed = DOCUMENT.replace(old, "The complete workspace map includes", 1)
+        self.assertEqual(checker.check(changed, self.metadata), [])
+
+    def test_markers_are_unique_and_ordered(self) -> None:
+        changes = [
+            DOCUMENT.replace(checker.BEGIN, "", 1),
+            DOCUMENT.replace(checker.END, "", 1),
+            DOCUMENT + checker.BEGIN,
+            DOCUMENT + checker.END,
+            DOCUMENT.replace(checker.BEGIN, "TEMP", 1)
+            .replace(checker.END, checker.BEGIN, 1)
+            .replace("TEMP", checker.END, 1),
+        ]
         for changed in changes:
-            self.assert_red(changed, "EMBEDDING_CRATE_MAP_SCOPE")
+            self.assertEqual(checker.check(changed, self.metadata), [
+                "EMBEDDING_CRATE_MAP_MARKERS: crate-map markers must each appear exactly once and BEGIN must precede END"
+            ])
 
     def test_dependency_kind_scope_is_load_bearing(self) -> None:
         """Red if build/target edges are dropped or dev edges are included."""

--- a/scripts/test_check_embedding_versions.py
+++ b/scripts/test_check_embedding_versions.py
@@ -72,14 +72,47 @@ class EmbeddingVersionContractTests(unittest.TestCase):
             "current-boundary-version",
         )
 
-    def test_prepared_language_is_forbidden(self) -> None:
-        """Red if a published release is again described as prepared."""
+    def test_status_parser_rejects_prepared_as(self) -> None:
+        """Red if an actual publish status changes from published to prepared."""
         self.assert_fails(
             self.replace_nth(
-                "**The 0.16.0 release**", "**The prepared 0.16.0 release**"
+                "(published as `0.17.0`)", "(prepared as `0.17.0`)"
             ),
-            "forbidden-prepared",
+            "publish-status-version",
         )
+
+    def test_heading_renumbering_and_unrelated_prepared_prose_are_allowed(self) -> None:
+        changed = DOCUMENT
+        for old, new in (("## 7. ", "## 70. "), ("### 3.1 ", "### 30.1 "),
+                         ("### 3.3 ", "### 30.3 "), ("## 4. ", "## 40. ")):
+            changed = changed.replace(old, new, 1)
+        changed += "\nAn unrelated consumer prepared its own deployment.\n"
+        self.assertEqual(self.run_checker(changed).returncode, 0)
+
+    def test_each_semantic_heading_is_required(self) -> None:
+        titles = (
+            "Published-crate release boundary",
+            "Decode an UPDATE (codec-only — the canonical embedder)",
+            'Build a session (codec + FSM — the "minimal speaker" consumer)',
+            "Which crate to publish next, and why",
+        )
+        for title in titles:
+            with self.subTest(title=title):
+                self.assert_fails(
+                    DOCUMENT.replace(title, f"{title} drifted", 1),
+                    f"semantic-heading:{title}:missing",
+                )
+
+    def test_duplicate_semantic_heading_is_rejected(self) -> None:
+        title = "Published-crate release boundary"
+        self.assert_fails(DOCUMENT + f"\n## {title}\n", f"semantic-heading:{title}")
+
+    def test_wrong_semantic_heading_levels_are_rejected(self) -> None:
+        title = "Published-crate release boundary"
+        for level in (1, 4, 5, 6):
+            with self.subTest(level=level):
+                changed = DOCUMENT.replace(f"## 7. {title}", f"{'#' * level} 7. {title}")
+                self.assert_fails(changed, f"semantic-heading:{title}:duplicate-or-wrong-level")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- locate embedding contract sections by unique semantic headings instead of numbered ordinals
- allow unrelated prepared prose while retaining exact publish-status and version checks
- remove the crate-map scope paragraph pin while preserving marker and Cargo metadata invariants

## Validation
- 18 focused checker tests
- both live embedding checkers
- Python bytecode compilation
- adversarial heading, marker, version, package, publishability, and dependency mutations

Linear: LAN-962