### PR TITLE
ci: host the M92 route-server differential

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -1747,3 +1747,53 @@ jobs:
           label: M91
           topology: tests/interop/m91-rfc7606-malformed.clab.yml
           script: tests/interop/scripts/test-m91-rfc7606-malformed.sh
+
+  m92:
+    needs: prime_dev_image
+    name: M92 — GoBGP 4.7 route-server differential
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install containerlab
+        uses: ./.github/actions/install-containerlab
+
+      - name: Install grpcurl + jq
+        run: |
+          bash .github/scripts/install-grpcurl.sh
+          command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build rustbgpd:dev
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          tags: rustbgpd:dev
+          target: dev
+          cache-from: type=gha,scope=rustbgpd-dev
+
+      - name: Build bird:2-bookworm
+        run: docker build -t bird:2-bookworm -f tests/interop/Dockerfile.bird tests/interop
+
+      - name: Build gobgp:v4.7.0-m92
+        run: docker build -t gobgp:v4.7.0-m92 -f tests/interop/Dockerfile.gobgp-v47 tests/interop
+
+      - name: Run M92
+        uses: ./.github/actions/run-interop-test
+        with:
+          label: M92
+          topology: tests/interop/m92-gobgp-v47-rs-differential.clab.yml
+          script: tests/interop/scripts/test-m92-gobgp-v47-rs-differential.sh
+
+      - name: Run M92 negative completeness proof
+        uses: ./.github/actions/run-interop-test
+        env:
+          M92_COMPLETENESS_NEGATIVE: "1"
+        with:
+          label: M92-negative
+          topology: tests/interop/m92-gobgp-v47-rs-differential.clab.yml
+          script: tests/interop/scripts/test-m92-gobgp-v47-rs-differential.sh

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -71,7 +71,8 @@ dispatch always run.
   path-hiding contrast (single-best / `per_client_best` / Add-Path, ADR-0101)
   against BIRD 2 + GoBGP + FRR at once (**M83**); exact post-policy
   message-size rejection and stale-route withdrawal against GoBGP 4.6 + BIRD
-  2.0.12 (**M87**).
+  2.0.12 (**M87**); dual-stack GoBGP 4.7/BIRD differential with a separate
+  negative-completeness deployment (**M92**).
 - **Core RR against incumbents** — RFC 4456 reflection + RFC 4724 GR helper-truth against BIRD 2 clients and OpenBGPD 9.1 clients, plus required-family OPEN enforcement against BIRD: **M85**, **M86**, **M93**.
 - **Live policy-presence safety** — ADR-0112 RFC 8212 import-presence transitions qualified for Route Refresh, rejected whole when one peer cannot converge, and converged on the wire when it can: **M95**.
 - **Graceful Shutdown** — receiver/initiator coverage across unicast, FlowSpec, and EVPN: **M35**, **M35b**, **M35c**.
@@ -129,8 +130,7 @@ prove the positive state and final withdrawal or cleanup.
 The remaining interop scripts are local / manual gates because they
 need substantial wall-clock (M11/M16 GR/LLGR, M33 scale soak),
 additional fixtures (StayRTR / mock RTR v2 server), or
-broader platform-diversity validation (BIRD and non-CI GoBGP cases beyond
-the protected BIRD TCP-AO smoke and M73 BGP-LS receipt).
+broader platform-diversity validation beyond the protected hosted matrix.
 
 | Peer | Version | Topology | Status | Notes | Known Quirks | NOTIFICATIONs Observed |
 |------|---------|----------|--------|-------|--------------|------------------------|
@@ -150,7 +150,7 @@ the protected BIRD TCP-AO smoke and M73 BGP-LS receipt).
 | FRR (bgpd) | 10.3.1 | `tests/interop/m89-paths-limit-frr.clab.yml` | Tested (M89) | Experimental Paths-Limit (IANA capability 76; expired `draft-abraitis-idr-addpath-paths-limit-04`) | Unequal IPv4/IPv6 receive limits cap Add-Path export at 2/3 | Digest-pinned image; outside v1 contract |
 | BIRD 2 + GoBGP ×3 + arouteserver | BIRD 2.0.12, GoBGP 3.37.0, arouteserver 1.23.2 | `tests/interop/m90-differential.clab.yml` | Tested (M90, local) | ADR-0110 route-server filtering differential | One site input drives arouteserver/BIRD and `rs-config-render`/rustbgpd; 11/11 accept/reject verdicts and rustbgpd explain terms agree | Pinned arouteserver digest; 65/65, with a rust-only policy mutation making the differential red |
 | Raw BGP fixture | in-tree Python | `tests/interop/m91-rfc7606-malformed.clab.yml` | Tested (M91, hosted CI) | RFC 7606 revised UPDATE error handling | Malformed MED and AGGREGATOR inputs pin treat-as-withdraw, attribute-discard, session-reset, counters, and the §6 DEBUG capture | Runs in the combined cheap-protocol job |
-| GoBGP ×3 + BIRD 2 | GoBGP 4.7.0, BIRD 2.0.12 | `tests/interop/m92-gobgp-v47-rs-differential.clab.yml` | Tested (M92, local; hosted deferred) | Dual-stack route-server semantic differential | Exact source/target inventories and per-PDU EoRs authorize baseline/mutant/restore diffs; separate missing-EoR refusal | Official amd64 release hash pinned; synthetic evidence only |
+| GoBGP ×3 + BIRD 2 | GoBGP 4.7.0, BIRD 2.0.12 | `tests/interop/m92-gobgp-v47-rs-differential.clab.yml` | Tested (M92, Hosted CI) | Dual-stack route-server semantic differential | Exact source/target inventories and per-PDU EoRs authorize baseline/mutant/restore diffs; normal and negative-completeness proofs use separate deployments | Official amd64 release hash pinned; synthetic evidence only |
 | FRR (bgpd) | 10.3.1 | `tests/interop/m18-extnexthop-frr.clab.yml` | Tested (M18) | Extended Next-Hop (RFC 8950) | Dual-stack, IPv6 NH for IPv4 | — |
 | FRR (bgpd) | 10.3.1 | `tests/interop/m19-routeserver-frr.clab.yml` | Tested (M19) | Transparent Route Server | No ASN prepend, NH preservation | Needs per-neighbor `no enforce-first-as` |
 | FRR (bgpd) | 10.3.1 | `tests/interop/m20-privateas-frr.clab.yml` | Tested (M20) | Private AS Removal | remove/all/replace modes | — |

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -12,7 +12,7 @@ from pathlib import Path
 INTEROP = (
     "m1 m13 m80 m15 m10 m14 m17 m73 m74 m75 m76 m77 m78 m79 m22 "
     "m24 m81 m82 m83 m85 m94 m86 m25 m29 m30 m34 m35 m35b m35c m41 "
-    "m44 m54 m55 m56 m45 m57 m63 m64 m26_m27_m28_m59_m91"
+    "m44 m54 m55 m56 m45 m57 m63 m64 m26_m27_m28_m59_m91 m92"
 ).split()
 KERNEL = (
     "m36 m37 m37-ip m38 m39 m39b m48 m60 m61 m62 m40 m42 m50 m52 "
@@ -59,17 +59,17 @@ PERMISSION_HASHES = {
     "kernel-dataplane.yml": "6f1d70d72bad231d43c575acef6946580e439c879794ed2ea1f4a40340245172",
 }
 CALL_HASHES = {
-    "interop.yml": "24a984736b900bc3cc7b64133cb6c4d8b8dba63feb8dc0aa69791c657bfc7efe",
+    "interop.yml": "baf8da4607ed5e36ea6d2a656f05df3c87449456159dd4c847d51588ff0a96b5",
     "kernel-dataplane.yml": "decf4a7ba46c4a89f420de248790ef1badbfaba81371ae7c291ad9c9943add03",
 }
 PINS = collections.Counter(
     {
-        "actions/checkout@v7": 80,
+        "actions/checkout@v7": 81,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 3,
         "Swatinem/rust-cache@v2": 5,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 2,
-        "docker/setup-buildx-action@v4": 43,
-        "docker/build-push-action@v7": 44,
+        "docker/setup-buildx-action@v4": 44,
+        "docker/build-push-action@v7": 45,
         "actions/upload-artifact@v7": 1,
         "rustsec/audit-check@v2.0.0": 1,
         "EmbarkStudios/cargo-deny-action@v2": 1,
@@ -186,6 +186,23 @@ def check(root: Path) -> list[str]:
         )
         if _hash(calls) != CALL_HASHES[name]:
             errors.append(f"{name}: existing test/setup calls drifted")
+    m92 = _jobs(texts["interop.yml"]).get("m92", "")
+    required = {
+        "bash .github/scripts/install-grpcurl.sh": 1,
+        "docker build -t bird:2-bookworm -f tests/interop/Dockerfile.bird tests/interop": 1,
+        "docker build -t gobgp:v4.7.0-m92 -f tests/interop/Dockerfile.gobgp-v47 tests/interop": 1,
+        "uses: ./.github/actions/run-interop-test": 2,
+        "topology: tests/interop/m92-gobgp-v47-rs-differential.clab.yml": 2,
+        "script: tests/interop/scripts/test-m92-gobgp-v47-rs-differential.sh": 2,
+        "label: M92\n": 1,
+        "label: M92-negative\n": 1,
+        'M92_COMPLETENESS_NEGATIVE: "1"': 1,
+    }
+    if any(m92.count(seam) != count for seam, count in required.items()):
+        errors.append("interop.yml:m92: differential job semantics drifted")
+    negative = m92.split("- name: Run M92 negative completeness proof", 1)
+    if len(negative) != 2 or 'M92_COMPLETENESS_NEGATIVE: "1"' in negative[0]:
+        errors.append("interop.yml:m92: negative environment scope drifted")
     interop_classifier = _jobs(texts["interop.yml"]).get("classify_changes", "")
     kernel_jobs = _jobs(texts["kernel-dataplane.yml"])
     interop_classifier = interop_classifier.replace("interop heavy-lab", "heavy-lab")

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -355,6 +355,25 @@ class PrimerContractTests(unittest.TestCase):
             with self.subTest(seam=old):
                 self.mutate(relative, old, new)
 
+    def test_m92_differential_job_is_load_bearing(self):
+        relative = ".github/workflows/interop.yml"
+        with self.assertRaisesRegex(AssertionError, "missing M92 seam"):
+            count = (ROOT / relative).read_text().count("missing M92 seam")
+            self.assertGreater(count, 0, "missing M92 seam: synthetic")
+        for old in (
+            "          bash .github/scripts/install-grpcurl.sh\n",
+            "      - name: Run M92\n        uses: ./.github/actions/run-interop-test\n",
+            "      - name: Run M92 negative completeness proof\n        uses: ./.github/actions/run-interop-test\n",
+            '          M92_COMPLETENESS_NEGATIVE: "1"\n',
+            "      - name: Build bird:2-bookworm\n        run: docker build -t bird:2-bookworm -f tests/interop/Dockerfile.bird tests/interop\n",
+            "      - name: Build gobgp:v4.7.0-m92\n        run: docker build -t gobgp:v4.7.0-m92 -f tests/interop/Dockerfile.gobgp-v47 tests/interop\n",
+        ):
+            with self.subTest(seam=old):
+                count = (ROOT / relative).read_text().count(old)
+                self.assertGreater(count, 0, f"missing M92 seam: {old}")
+                occurrence = count - 1
+                self.mutate(relative, old, occurrence=occurrence)
+
     def test_dockerfile_exact_source_bridge(self):
         for binary in ("rustbgpd", "rbgp", "evpn-tester", "evpn-monitor"):
             with self.subTest(binary=binary, side="builder"):


### PR DESCRIPTION
## Summary
- add a dedicated hosted M92 GoBGP 4.7 route-server differential job
- run normal and missing-EoR proofs in separate deploy/test/destroy lifecycles
- make the image-primer contract and interop documentation pin the new evidence semantically

## Validation
- local M92 normal receipt: 56 passed, 0 failed
- local M92 missing-EoR receipt: 17 passed, 0 failed
- image-primer contract tests and live checker
- interop path classification and tier-auth tests
- adversarial removal of each M92 call, environment assignment, image build, primer dependency, cache import, and action target

Linear: LAN-973