### PR TITLE
fix: restore all-features clippy gate

### DIFF
--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -347,7 +347,7 @@ impl RibManager {
     /// per-client-best per-peer fallback. Since the ADR-0126 Phase 3
     /// classifier flip a unicast-only per-client-best peer GROUPS, so the
     /// fallback these fixtures promise requires a non-unicast-only session:
-    /// each peer also negotiates VPNv4 (no VPN routes exist in any fixture,
+    /// each peer also negotiates `VPNv4` (no VPN routes exist in any fixture,
     /// so the wire stays pure IPv4-unicast). The explicit seam keeps the
     /// grouping disqualifier visible instead of adding a positional flag to
     /// callers.


### PR DESCRIPTION
## Summary
- mark `VPNv4` as code in the bench-support rustdoc
- restore the warning-denying API all-target/all-features Clippy gate
- keep benchmark behavior and lint policy unchanged

## Validation
- `cargo clippy -p rustbgpd-api --all-targets --all-features -- -D warnings`
- `cargo test -p rustbgpd-rib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- temporary backtick removal reproduces the exact `clippy::doc_markdown` failure

Linear: LAN-985