### PR TITLE
maintenance: remove obsolete EVPN spawn glue

### DIFF
--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -7765,13 +7765,6 @@ fn op_to_applied(op: &DataplaneOp) -> AppliedOp {
     }
 }
 
-// Suppress dead-code on a potentially-unused snapshot return-path
-// helper used only when the dump errors.
-#[allow(dead_code)]
-fn empty_snapshot() -> KernelSnapshot {
-    KernelSnapshot::new()
-}
-
 #[cfg(test)]
 mod managed_netdev_tests {
     use super::*;

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -44,7 +44,7 @@
 //!
 //! ## RR-only deployments
 //!
-//! When `[[evpn_instances]]` is empty, [`spawn`] returns `None` and no
+//! When `[[evpn_instances]]` is empty, [`spawn_with_quarantine`] returns `None` and no
 //! background tasks are created. Route-reflector deployments incur
 //! zero cost from this module.
 //!
@@ -67,7 +67,7 @@ use rustbgpd_evpn::{
 use rustbgpd_evpn_linux::{Dataplane, ReconcileActor, ReconcileActorConfig};
 use rustbgpd_rib::{RibUpdate, route::EvpnRibRoute};
 use rustbgpd_telemetry::BgpMetrics;
-use rustbgpd_wire::{EvpnRoute, ExtendedCommunity, PathAttribute};
+use rustbgpd_wire::{EvpnRoute, PathAttribute};
 use tokio::sync::{broadcast, mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -345,47 +345,6 @@ impl EvpnDataplaneHandle {
     }
 }
 
-/// Spawn the EVPN dataplane stack. Returns `None` if
-/// `evpn_instances`, `ip_vrfs`, and `managed_netdevs` are all empty
-/// (RR-only deployments take this path — no netlink socket is opened,
-/// no background task is spawned).
-///
-/// Otherwise spawns:
-///
-/// 1. The polling supervisor task that periodically queries the RIB
-///    via `rib_tx`, projects best-path Type 2 routes into a
-///    [`RemoteMacTable`], and publishes a [`DataplaneIntent`].
-/// 2. The [`ReconcileActor`] consuming intents, driving the
-///    [`rustbgpd_evpn_linux::Dataplane`] implementation. On Linux
-///    this is the real `LinuxDataplane` (rtnetlink-backed FDB
-///    program/withdraw against the bridge/master path); on other
-///    platforms the function returns `None` because the dataplane
-///    is meaningless.
-#[must_use = "drop the handle to shut down the EVPN dataplane stack"]
-#[allow(dead_code)]
-pub async fn spawn(
-    config: SupervisorConfig,
-    evpn_instances: &Arc<EvpnInstanceTable>,
-    ip_vrfs: &Arc<IpVrfTable>,
-    managed_netdevs: &Arc<ManagedNetdevTable>,
-    rib_tx: mpsc::Sender<RibUpdate>,
-    metrics: BgpMetrics,
-    daemon_shutdown: CancellationToken,
-) -> Option<EvpnDataplaneHandle> {
-    let (_, duplicate_mac_quarantine_rx) = watch::channel(Arc::new(BTreeSet::new()));
-    spawn_with_quarantine(
-        config,
-        evpn_instances,
-        ip_vrfs,
-        managed_netdevs,
-        rib_tx,
-        metrics,
-        daemon_shutdown,
-        duplicate_mac_quarantine_rx,
-    )
-    .await
-}
-
 /// Spawn the EVPN dataplane stack with an external duplicate-MAC
 /// quarantine feed from the local originator.
 ///
@@ -454,7 +413,7 @@ pub async fn spawn_with_quarantine(
 /// Generic spawn shared by the production path and the integration
 /// tests (which inject [`rustbgpd_evpn_linux::InMemoryDataplane`]).
 ///
-/// On the production path, [`spawn`] takes ownership of the dataplane,
+/// On the production path, [`spawn_with_quarantine`] takes ownership of the dataplane,
 /// extracts the local-MAC observation receiver via
 /// [`rustbgpd_evpn_linux::Dataplane::take_local_mac_rx`], and stamps
 /// it onto the returned handle. Tests calling this function directly
@@ -1787,13 +1746,6 @@ enum RibQueryError {
     SendFailed,
     #[error("RIB query reply channel dropped")]
     ReplyDropped,
-}
-
-// Suppress dead-code on a helper that may be unused on platforms
-// where the dataplane spawn returns None.
-#[allow(dead_code)]
-const fn _force_link() -> &'static dyn Fn(&[ExtendedCommunity]) -> Option<u32> {
-    &|_ecs| None
 }
 
 #[cfg(test)]
@@ -3304,7 +3256,8 @@ mod tests {
         let managed_netdevs = Arc::new(ManagedNetdevTable::new());
         let (rib_tx, _rib_rx) = mpsc::channel(8);
         let shutdown = CancellationToken::new();
-        let h = spawn(
+        let (_, duplicate_mac_quarantine_rx) = watch::channel(Arc::new(BTreeSet::new()));
+        let h = spawn_with_quarantine(
             SupervisorConfig::default(),
             &instances,
             &ip_vrfs,
@@ -3312,6 +3265,7 @@ mod tests {
             rib_tx,
             BgpMetrics::new(),
             shutdown,
+            duplicate_mac_quarantine_rx,
         )
         .await;
         assert!(h.is_none(), "RR-only path should not spawn the actor");

--- a/src/evpn_originator/mod.rs
+++ b/src/evpn_originator/mod.rs
@@ -1,6 +1,6 @@
 //! Daemon-side EVPN local-MAC originator (Gate 7b+1).
 //!
-//! Mirrors `crate::evpn_dataplane::spawn` but on the **opposite
+//! Mirrors `crate::evpn_dataplane::spawn_with_quarantine` but on the **opposite
 //! flow**: kernel `LocalMacObservation` events become BGP EVPN Type 2
 //! originations (RFC 7432 §7.2 + §15.1).
 //!
@@ -40,7 +40,7 @@
 //!
 //! ## RR-only deployments
 //!
-//! When `[[evpn_instances]]` is empty, [`spawn`] returns `None`. No
+//! When `[[evpn_instances]]` is empty, [`spawn_with_quarantine`] returns `None`. No
 //! background task is created; the EVPN originator counters remain at
 //! zero-label-vector state until an originator action is observed.
 //!
@@ -394,14 +394,13 @@ pub(crate) fn vni_is_drained(
         .is_some_and(|esi| drained_esis.contains(esi))
 }
 
-/// Spawn the originator. Returns `None` for RR-only deployments
-/// (empty `evpn_instances`).
+/// Test helper that spawns the originator with an empty duplicate-MAC quarantine.
+/// Returns `None` for RR-only deployments (empty `evpn_instances`).
 #[allow(
     clippy::too_many_arguments,
     reason = "originator spawn keeps each explicit actor dependency visible"
 )]
-// ESI-aware origination nudged the count over the threshold; the daemon-side spawn is the only caller.
-#[allow(dead_code)]
+#[cfg(test)]
 #[must_use = "call `EvpnOriginatorHandle::shutdown` to stop the originator — \
               dropping the handle leaves the task running"]
 pub fn spawn(

--- a/src/main.rs
+++ b/src/main.rs
@@ -3869,7 +3869,7 @@ async fn run<T>(
     // Consumes the upward `LocalMacObservation` channel surfaced by
     // the dataplane (Phase D); kernel-learned MACs become BGP EVPN
     // Type 2 originations per RFC 7432 §15.1. RR-only deployments
-    // skip this entirely — `evpn_dataplane::spawn` returned `None`
+    // skip this entirely — `evpn_dataplane::spawn_with_quarantine` returned `None`
     // and `local_mac_rx` is therefore `None`.
     let evpn_originator_shutdown = tokio_util::sync::CancellationToken::new();
     let evpn_originated_local_mac_counts = evpn_originator::OriginatedLocalMacCounts::default();


### PR DESCRIPTION
## Summary

- remove the obsolete unquarantined EVPN dataplane spawn shim
- delete two zero-caller fallback helpers and truth nearby comments
- keep the originator convenience wrapper test-only for its semantic actor tests

## Validation

- cargo test -p rustbgpd --bin rustbgpd
- cargo test -p rustbgpd-evpn-linux --lib
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- private rustdoc broken-link gate
- destructive RR-only and test-helper visibility proofs

Linear: LAN-986