### PR TITLE
cleanup(cli): remove legacy TUI route fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 
+- `rbgp top` now requires `EventService.WatchEvents`; the degraded
+  `RibService.WatchRoutes` fallback for daemons through v0.62 was removed.
+  `RibService.WatchRoutes` and direct `rbgp watch` remain available.
 - Root-daemon non-Linux fallbacks were removed in #1581. Distributed and
   supported daemon targets are Linux x86_64 and aarch64; portable component
   and transport abstractions do not expand daemon support.

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -47,11 +47,6 @@ pub(crate) struct MockState {
     pub(crate) watch_events_response: Mutex<Vec<server_proto::BgpEvent>>,
     pub(crate) last_watch_events: Mutex<Option<server_proto::WatchEventsRequest>>,
     pub(crate) watch_routes_calls: AtomicUsize,
-    pub(crate) watch_routes_active: AtomicUsize,
-    pub(crate) watch_routes_clean_end: AtomicBool,
-    pub(crate) watch_routes_failures_remaining: AtomicUsize,
-    pub(crate) watch_routes_terminations: AtomicUsize,
-    pub(crate) watch_routes_response: Mutex<Vec<server_proto::RouteEvent>>,
     pub(crate) list_session_events_calls: AtomicUsize,
     pub(crate) list_policy_events_calls: AtomicUsize,
     pub(crate) config_diff_calls: AtomicUsize,
@@ -1246,12 +1241,6 @@ impl rustbgpd_api::proto::injection_service_server::InjectionService for MockInj
     }
 }
 
-struct MockWatchRoutesStream {
-    state: Arc<MockState>,
-    events: std::collections::VecDeque<server_proto::RouteEvent>,
-    clean_end: bool,
-}
-
 struct MockWatchEventsStream {
     state: Arc<MockState>,
     events: std::collections::VecDeque<Result<server_proto::BgpEvent, Status>>,
@@ -1277,29 +1266,6 @@ impl Drop for MockWatchEventsStream {
             .fetch_sub(1, Ordering::SeqCst);
         self.state
             .watch_events_terminations
-            .fetch_add(1, Ordering::SeqCst);
-    }
-}
-
-impl Stream for MockWatchRoutesStream {
-    type Item = Result<server_proto::RouteEvent, Status>;
-
-    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match self.events.pop_front() {
-            Some(event) => Poll::Ready(Some(Ok(event))),
-            None if self.clean_end => Poll::Ready(None),
-            None => Poll::Pending,
-        }
-    }
-}
-
-impl Drop for MockWatchRoutesStream {
-    fn drop(&mut self) {
-        self.state
-            .watch_routes_active
-            .fetch_sub(1, Ordering::SeqCst);
-        self.state
-            .watch_routes_terminations
             .fetch_add(1, Ordering::SeqCst);
     }
 }
@@ -2015,27 +1981,7 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         _request: Request<server_proto::WatchRoutesRequest>,
     ) -> Result<Response<Self::WatchRoutesStream>, Status> {
         self.state.watch_routes_calls.fetch_add(1, Ordering::SeqCst);
-        if consume_failure(&self.state.watch_routes_failures_remaining) {
-            self.state
-                .watch_routes_terminations
-                .fetch_add(1, Ordering::SeqCst);
-            return Err(Status::unavailable("transient route-watch failure"));
-        }
-        self.state
-            .watch_routes_active
-            .fetch_add(1, Ordering::SeqCst);
-        let events = self
-            .state
-            .watch_routes_response
-            .lock()
-            .await
-            .drain(..)
-            .collect();
-        Ok(Response::new(Box::pin(MockWatchRoutesStream {
-            state: Arc::clone(&self.state),
-            events,
-            clean_end: self.state.watch_routes_clean_end.load(Ordering::SeqCst),
-        })))
+        Err(Status::unimplemented("not used in CLI tests"))
     }
 
     async fn watch_route_events(

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -528,13 +528,13 @@ mod tests {
         assert_eq!(app.view, View::PeerDetail("198.51.100.1".into()));
     }
 
-    /// Red proof: storing compatibility state in the bounded event deque (or
-    /// clearing it while evicting rows) loses the warning after 101 events.
+    /// Red proof: storing stream status in the bounded event deque (or clearing
+    /// it while evicting rows) loses the error after 101 events.
     #[test]
-    fn degraded_stream_warning_survives_event_deque_eviction() {
+    fn primary_stream_error_survives_event_deque_eviction() {
         let mut app = App::new();
-        let warning = "DEGRADED: WatchEvents unsupported; using legacy WatchRoutes; missed-event counts unavailable";
-        app.on_route_event(RouteEventUpdate::StreamStatus(Some(warning.into())));
+        let status = "route event stream error: primary unavailable; retrying";
+        app.on_route_event(RouteEventUpdate::StreamStatus(Some(status.into())));
         for index in 0..=MAX_EVENTS {
             app.on_route_event(RouteEventUpdate::Event(RouteEventEntry {
                 kind: crate::tui::data::RouteEventKind::Route,
@@ -551,7 +551,7 @@ mod tests {
         }
 
         assert_eq!(app.route_events.len(), MAX_EVENTS);
-        assert_eq!(app.route_event_stream_status.as_deref(), Some(warning));
+        assert_eq!(app.route_event_stream_status.as_deref(), Some(status));
         app.on_route_event(RouteEventUpdate::StreamStatus(None));
         assert!(app.route_event_stream_status.is_none());
     }

--- a/crates/cli/src/tui/data.rs
+++ b/crates/cli/src/tui/data.rs
@@ -10,11 +10,10 @@ use crate::proto::control_service_client::ControlServiceClient;
 use crate::proto::event_service_client::EventServiceClient;
 use crate::proto::global_service_client::GlobalServiceClient;
 use crate::proto::neighbor_service_client::NeighborServiceClient;
-use crate::proto::rib_service_client::RibServiceClient;
 use crate::proto::{
     BgpEvent, BgpEventType, EventCategory, GetGlobalRequest, GlobalState, HealthRequest,
     HealthResponse, ListDynamicNeighborsRequest, ListNeighborsRequest, MetricsRequest,
-    NeighborState, RouteEvent, RouteEventType, WatchEventsRequest, WatchRoutesRequest, bgp_event,
+    NeighborState, RouteEvent, WatchEventsRequest, bgp_event,
 };
 
 pub struct DataSnapshot {
@@ -81,16 +80,6 @@ fn format_event_type(t: BgpEventType) -> &'static str {
     }
 }
 
-fn format_legacy_event_type(t: i32) -> &'static str {
-    match RouteEventType::try_from(t) {
-        Ok(RouteEventType::Added) => "added",
-        Ok(RouteEventType::Withdrawn) => "withdrawn",
-        Ok(RouteEventType::BestChanged) => "best_changed",
-        Ok(RouteEventType::PolicyFiltered) => "policy_filtered",
-        _ => "unknown",
-    }
-}
-
 fn parse_vrp_count(prometheus_text: &str) -> Option<u64> {
     rpki_vrp_count_sum(prometheus_text)
 }
@@ -98,8 +87,6 @@ fn parse_vrp_count(prometheus_text: &str) -> Option<u64> {
 const METRICS_POLL_INTERVAL: Duration = Duration::from_secs(60);
 const DYNAMIC_RANGES_POLL_INTERVAL: Duration = Duration::from_secs(60);
 const ROUTE_STREAM_RECONNECT_BACKOFF: Duration = Duration::from_secs(2);
-const LEGACY_ROUTE_STREAM_WARNING: &str =
-    "DEGRADED: WatchEvents unsupported; using legacy WatchRoutes; missed-event counts unavailable";
 
 struct FetcherState {
     global: Option<GlobalState>,
@@ -307,29 +294,10 @@ async fn route_event_loop(
     }
 }
 
-enum PrimaryStreamOutcome {
-    Unsupported,
-    Finished(Result<(), tonic::Status>),
-}
-
 async fn stream_route_events(connection: &Connection, event_tx: &mpsc::Sender<RouteEventUpdate>) {
-    match stream_events(connection, event_tx).await {
-        PrimaryStreamOutcome::Unsupported => {
-            if send_stream_status(event_tx, LEGACY_ROUTE_STREAM_WARNING.to_string()).await
-                && let Err(error) = stream_routes(connection, event_tx).await
-            {
-                let status = format!(
-                    "{LEGACY_ROUTE_STREAM_WARNING}; legacy stream error: {}; retrying",
-                    error.message()
-                );
-                send_stream_status(event_tx, status).await;
-            }
-        }
-        PrimaryStreamOutcome::Finished(Err(error)) => {
-            let status = format!("route event stream error: {}; retrying", error.message());
-            send_stream_status(event_tx, status).await;
-        }
-        PrimaryStreamOutcome::Finished(Ok(())) => {}
+    if let Err(error) = stream_events(connection, event_tx).await {
+        let status = format!("route event stream error: {}; retrying", error.message());
+        send_stream_status(event_tx, status).await;
     }
 }
 
@@ -343,28 +311,22 @@ async fn send_stream_status(event_tx: &mpsc::Sender<RouteEventUpdate>, status: S
 async fn stream_events(
     connection: &Connection,
     event_tx: &mpsc::Sender<RouteEventUpdate>,
-) -> PrimaryStreamOutcome {
+) -> Result<(), tonic::Status> {
     let mut client =
         EventServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let mut stream = match client
+    let mut stream = client
         .watch_events(WatchEventsRequest {
             categories: vec![EventCategory::Route as i32],
             ..Default::default()
         })
-        .await
-    {
-        Ok(response) => response.into_inner(),
-        Err(error) if error.code() == tonic::Code::Unimplemented => {
-            return PrimaryStreamOutcome::Unsupported;
-        }
-        Err(error) => return PrimaryStreamOutcome::Finished(Err(error)),
-    };
+        .await?
+        .into_inner();
     if event_tx
         .send(RouteEventUpdate::StreamStatus(None))
         .await
         .is_err()
     {
-        return PrimaryStreamOutcome::Finished(Ok(()));
+        return Ok(());
     }
 
     loop {
@@ -373,11 +335,11 @@ async fn stream_events(
                 if let Some(entry) = route_event_entry(event)
                     && event_tx.send(RouteEventUpdate::Event(entry)).await.is_err()
                 {
-                    return PrimaryStreamOutcome::Finished(Ok(()));
+                    return Ok(());
                 }
             }
-            Ok(None) => return PrimaryStreamOutcome::Finished(Ok(())),
-            Err(error) => return PrimaryStreamOutcome::Finished(Err(error)),
+            Ok(None) => return Ok(()),
+            Err(error) => return Err(error),
         }
     }
 }
@@ -429,33 +391,6 @@ fn route_entry(event_type: &str, event: RouteEvent) -> RouteEventEntry {
     }
 }
 
-async fn stream_routes(
-    connection: &Connection,
-    event_tx: &mpsc::Sender<RouteEventUpdate>,
-) -> Result<(), tonic::Status> {
-    let mut client =
-        RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let mut stream = client
-        .watch_routes(WatchRoutesRequest {
-            neighbor_address: String::new(),
-            afi_safi: 0,
-        })
-        .await?
-        .into_inner();
-
-    while let Some(event) = stream.message().await? {
-        let event_type = format_legacy_event_type(event.event_type);
-        if event_tx
-            .send(RouteEventUpdate::Event(route_entry(event_type, event)))
-            .await
-            .is_err()
-        {
-            break;
-        }
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::Ordering;
@@ -488,7 +423,7 @@ mod tests {
             summary: summary.into(),
             payload: Some(rustbgpd_api::proto::bgp_event::Payload::Route(
                 rustbgpd_api::proto::RouteEvent {
-                    event_type: RouteEventType::PolicyFiltered as i32,
+                    event_type: rustbgpd_api::proto::RouteEventType::PolicyFiltered as i32,
                     prefix: "203.0.113.0".into(),
                     prefix_length: 24,
                     peer_address: "192.0.2.1".into(),
@@ -535,40 +470,6 @@ mod tests {
             .state
             .list_dynamic_neighbors_calls
             .load(Ordering::SeqCst)
-    }
-
-    async fn assert_route_reconnect_backoff(server: &crate::test_support::MockServerHandle) {
-        *server.state.watch_events_admission_error.lock().await = Some((
-            tonic::Code::Unimplemented,
-            "WatchEvents unavailable on this daemon".into(),
-        ));
-        let connection = connect(&server.addr, None).await.unwrap();
-        let (enabled_tx, enabled_rx) = watch::channel(true);
-        let (event_tx, _event_rx) = mpsc::channel(8);
-        let task = tokio::spawn(route_event_loop(connection, event_tx, enabled_rx));
-
-        wait_for(|| server.state.watch_routes_calls.load(Ordering::SeqCst) == 1).await;
-        wait_for(|| {
-            server
-                .state
-                .watch_routes_terminations
-                .load(Ordering::SeqCst)
-                == 1
-        })
-        .await;
-        settle_tasks().await;
-        tokio::time::advance(ROUTE_STREAM_RECONNECT_BACKOFF - Duration::from_millis(1)).await;
-        tokio::task::yield_now().await;
-        assert_eq!(server.state.watch_events_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(server.state.watch_routes_calls.load(Ordering::SeqCst), 1);
-
-        tokio::time::advance(Duration::from_millis(1)).await;
-        wait_for(|| server.state.watch_events_calls.load(Ordering::SeqCst) == 2).await;
-        wait_for(|| server.state.watch_routes_calls.load(Ordering::SeqCst) == 2).await;
-
-        drop(enabled_tx);
-        task.abort();
-        let _ = task.await;
     }
 
     /// Red proof: the old polling parser loses this production-shaped value.
@@ -859,36 +760,14 @@ mod tests {
         wait_for(|| server.state.watch_events_active.load(Ordering::SeqCst) == 0).await;
     }
 
-    /// Red proof: detaching the fallback stream from the visibility select
-    /// leaves its active counter nonzero after hide and handle drop.
+    /// Red proof: restoring the admission fallback calls WatchRoutes, while
+    /// suppressing the primary error loses the exact visible status.
     #[tokio::test]
-    async fn legacy_fallback_is_cancellable() {
-        let server = spawn_mock_server(None).await;
-        *server.state.watch_events_admission_error.lock().await =
-            Some((tonic::Code::Unimplemented, "old daemon".into()));
-        let connection = connect(&server.addr, None).await.unwrap();
-        let (enabled_tx, enabled_rx) = watch::channel(true);
-        let (event_tx, _event_rx) = mpsc::channel(4);
-        let task = tokio::spawn(route_event_loop(connection, event_tx, enabled_rx));
-
-        wait_for(|| server.state.watch_routes_active.load(Ordering::SeqCst) == 1).await;
-        enabled_tx.send(false).unwrap();
-        wait_for(|| server.state.watch_routes_active.load(Ordering::SeqCst) == 0).await;
-        enabled_tx.send(true).unwrap();
-        wait_for(|| server.state.watch_routes_active.load(Ordering::SeqCst) == 1).await;
-        task.abort();
-        let _ = task.await;
-        wait_for(|| server.state.watch_routes_active.load(Ordering::SeqCst) == 0).await;
-    }
-
-    /// Red proof: broadening fallback beyond admission UNIMPLEMENTED makes the
-    /// PermissionDenied and Unavailable rows call legacy WatchRoutes.
-    #[tokio::test]
-    async fn only_admission_unimplemented_enters_legacy_stream() {
-        for (code, expected_legacy_calls) in [
-            (tonic::Code::Unimplemented, 1),
-            (tonic::Code::PermissionDenied, 0),
-            (tonic::Code::Unavailable, 0),
+    async fn primary_admission_errors_are_visible_without_fallback() {
+        for code in [
+            tonic::Code::Unimplemented,
+            tonic::Code::PermissionDenied,
+            tonic::Code::Unavailable,
         ] {
             let server = spawn_mock_server(None).await;
             *server.state.watch_events_admission_error.lock().await =
@@ -902,19 +781,17 @@ mod tests {
             settle_tasks().await;
             assert_eq!(
                 server.state.watch_routes_calls.load(Ordering::SeqCst),
-                expected_legacy_calls,
+                0,
                 "admission status {code:?}"
             );
             let RouteEventUpdate::StreamStatus(Some(status)) = event_rx.recv().await.unwrap()
             else {
                 panic!("stream admission must publish visible status");
             };
-            if code == tonic::Code::Unimplemented {
-                assert_eq!(
-                    status,
-                    "DEGRADED: WatchEvents unsupported; using legacy WatchRoutes; missed-event counts unavailable"
-                );
-            }
+            assert_eq!(
+                status,
+                "route event stream error: primary admission rejected; retrying"
+            );
             task.abort();
             let _ = task.await;
         }
@@ -958,67 +835,35 @@ mod tests {
         let _ = task.await;
     }
 
-    /// Red proof: bypassing the typed legacy mapper drops one or more policy
-    /// source/previous/target/reason/path fields from the fallback result.
-    #[tokio::test]
-    async fn legacy_fallback_preserves_policy_context_through_mock_grpc() {
-        let server = spawn_mock_server(None).await;
-        *server.state.watch_events_admission_error.lock().await =
-            Some((tonic::Code::Unimplemented, "old daemon".into()));
-        let route = match policy_event("legacy policy summary").payload.unwrap() {
-            rustbgpd_api::proto::bgp_event::Payload::Route(route) => route,
-            _ => unreachable!(),
-        };
-        *server.state.watch_routes_response.lock().await = vec![route];
-        let connection = connect(&server.addr, None).await.unwrap();
-        let (_enabled_tx, enabled_rx) = watch::channel(true);
-        let (event_tx, mut event_rx) = mpsc::channel(4);
-        let task = tokio::spawn(route_event_loop(connection, event_tx, enabled_rx));
-
-        let policy = next_event(&mut event_rx).await;
-        assert_eq!(policy.event_type, "policy_filtered");
-        assert_eq!(policy.peer_address, "192.0.2.1");
-        assert_eq!(policy.previous_peer_address, "192.0.2.2");
-        assert_eq!(policy.target_peer_address, "192.0.2.3");
-        assert_eq!(policy.reason, "policy_denied");
-        assert_eq!(policy.path_id, 77);
-        task.abort();
-        let _ = task.await;
-    }
-
-    /// Red proof: decoding the legacy enum as BgpEventType makes the invalid
-    /// legacy value inherit an unrelated BGP-event label.
-    #[test]
-    fn legacy_route_event_type_has_an_independent_mapping() {
-        assert_eq!(
-            format_legacy_event_type(RouteEventType::PolicyFiltered as i32),
-            "policy_filtered"
-        );
-        assert_eq!(
-            format_legacy_event_type(BgpEventType::SessionEstablished as i32),
-            "unknown"
-        );
-    }
-
-    /// Red proof: treating a post-admission UNIMPLEMENTED as legacy support
-    /// increments WatchRoutes instead of surfacing the primary error.
+    /// Red proof: suppressing a stream error loses the visible status; removing
+    /// the delay reprobes before the exact two-second deadline.
     #[tokio::test(start_paused = true)]
-    async fn post_admission_unimplemented_never_falls_back() {
+    async fn primary_stream_errors_are_visible_and_reprobe_after_backoff() {
         let server = spawn_mock_server(None).await;
         *server.state.watch_events_stream_error.lock().await =
-            Some((tonic::Code::Unimplemented, "stream item failed".into()));
+            Some((tonic::Code::Unavailable, "stream item failed".into()));
         let connection = connect(&server.addr, None).await.unwrap();
         let (_enabled_tx, enabled_rx) = watch::channel(true);
         let (event_tx, mut event_rx) = mpsc::channel(4);
         let task = tokio::spawn(route_event_loop(connection, event_tx, enabled_rx));
 
+        assert!(matches!(
+            event_rx.recv().await,
+            Some(RouteEventUpdate::StreamStatus(None))
+        ));
         let mut visible_error = None;
-        while visible_error.is_none() {
-            if let RouteEventUpdate::StreamStatus(status) = event_rx.recv().await.unwrap() {
-                visible_error = status;
+        for _ in 0..1_000 {
+            if let Ok(update) = event_rx.try_recv() {
+                visible_error = Some(update);
+                break;
             }
+            tokio::task::yield_now().await;
         }
-        assert!(visible_error.unwrap().contains("stream item failed"));
+        let visible_error = visible_error.expect("stream error status");
+        let RouteEventUpdate::StreamStatus(Some(visible_error)) = visible_error else {
+            panic!("stream failure must publish visible status");
+        };
+        assert!(visible_error.contains("stream item failed"));
         assert_eq!(server.state.watch_routes_calls.load(Ordering::SeqCst), 0);
         tokio::time::advance(ROUTE_STREAM_RECONNECT_BACKOFF - Duration::from_millis(1)).await;
         assert_eq!(server.state.watch_events_calls.load(Ordering::SeqCst), 1);
@@ -1059,28 +904,6 @@ mod tests {
         assert_eq!(server.state.watch_routes_calls.load(Ordering::SeqCst), 0);
         task.abort();
         let _ = task.await;
-    }
-
-    /// Red proof: removing the clean-end delay reconnects before the deadline.
-    #[tokio::test(start_paused = true)]
-    async fn clean_route_stream_end_uses_reconnect_backoff() {
-        let server = spawn_mock_server(None).await;
-        server
-            .state
-            .watch_routes_clean_end
-            .store(true, Ordering::SeqCst);
-        assert_route_reconnect_backoff(&server).await;
-    }
-
-    /// Red proof: removing the error delay reconnects before the deadline.
-    #[tokio::test(start_paused = true)]
-    async fn route_stream_error_uses_reconnect_backoff() {
-        let server = spawn_mock_server(None).await;
-        server
-            .state
-            .watch_routes_failures_remaining
-            .store(1, Ordering::SeqCst);
-        assert_route_reconnect_backoff(&server).await;
     }
 
     /// Red proof: calling first failure stale or dropping cached values changes assertions.

--- a/crates/cli/src/tui/ui.rs
+++ b/crates/cli/src/tui/ui.rs
@@ -740,16 +740,16 @@ mod tests {
         assert_eq!(format_number(1234567), "1,234,567");
     }
 
-    /// Red proof: restoring the source-only event row or storing the degraded
-    /// warning in the bounded route rows removes these strings from the real
+    /// Red proof: restoring the source-only event row or storing the primary
+    /// status in the bounded route rows removes these strings from the real
     /// rendered event panel.
     #[test]
-    fn event_panel_test_backend_renders_context_lag_and_degraded_status() {
+    fn event_panel_test_backend_renders_context_lag_and_primary_status() {
         let mut app = App::new();
         app.show_events = true;
         app.on_data(snapshot(Vec::new(), Freshness::Fresh));
         app.on_route_event(crate::tui::data::RouteEventUpdate::StreamStatus(Some(
-            "DEGRADED: WatchEvents unsupported; using legacy WatchRoutes; missed-event counts unavailable".into(),
+            "route event stream error: primary unavailable; retrying".into(),
         )));
         let lag = |missed_count| RouteEventEntry {
             kind: RouteEventKind::StreamLag,
@@ -789,7 +789,7 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect::<String>();
 
-        assert!(rendered.contains("DEGRADED: WatchEvents unsupported"));
+        assert!(rendered.contains("route event stream error: primary unavailable; retrying"));
         assert!(rendered.contains(
             "from 192.0.2.1 previous=192.0.2.2 to=192.0.2.3 reason=policy_denied path_id=77"
         ));


### PR DESCRIPTION
## Summary

- remove `rbgp top`'s expired WatchEvents-to-WatchRoutes fallback
- keep primary stream errors visible and retry after the existing two-second backoff
- preserve both stable RPCs and direct `rbgp watch`

Linear: https://linear.app/lance0/issue/LAN-990/rip-out-all-n-1-rolling-upgrade-fallbacks-in-cliapi-12-sites-240-lines

## Validation

- seven focused primary-stream tests
- `cargo test -p rustbgpctl`
- `cargo clippy -p rustbgpctl --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/check-v1-stable-surface.py`
- five destructive stream-control mutations