### PR TITLE
test: remove expired compatibility assertions

### DIFF
--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -1737,31 +1737,6 @@ mod tests {
         config: Option<FrozenNeighborConfig>,
     }
 
-    #[test]
-    fn add_neighbor_proto_reserves_only_the_retired_carrier() {
-        let source = include_str!("../../../proto/rustbgpd.proto");
-        let request_body = source
-            .split_once("message AddNeighborRequest {")
-            .unwrap()
-            .1
-            .split_once('}')
-            .unwrap()
-            .0;
-        let active: Vec<_> = request_body
-            .lines()
-            .map(str::trim)
-            .filter(|line| !line.is_empty() && !line.starts_with("//"))
-            .collect();
-        assert_eq!(
-            active,
-            [
-                "reserved 1;",
-                "reserved \"config\";",
-                "NeighborCreateIntent intent = 2;",
-            ]
-        );
-    }
-
     #[tokio::test]
     async fn frozen_v064_intent_wire_is_accepted_unchanged() {
         let frozen = FrozenV064AddNeighborRequest {
@@ -2055,8 +2030,6 @@ mod tests {
             .split_once("\n}")
             .unwrap()
             .0;
-        assert!(paths_limit.contains("reserved 5;"));
-        assert!(paths_limit.contains("reserved \"effective_send_max\";"));
         assert!(paths_limit.contains("optional uint32 effective_send_limit = 6;"));
         assert!(source.contains("optional uint32 max_prefix_restart_seconds = 19;"));
         assert!(source.contains("string max_prefix_action = 38;"));

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6188,10 +6188,9 @@ printf '%s\n' "${COMPREPLY[@]}"
     /// ADR-0122 L1: config candidates are positional, while JSON CRUD keeps
     /// its separate `--from-file` contract.
     #[test]
-    fn config_candidate_is_positional_and_rejects_retired_alias() {
-        // Load-bearing: removing a positional CANDIDATE makes one of these
-        // parse checks red; restoring any retired alias makes the matching
-        // UnknownArgument check below red.
+    fn config_candidate_is_positional() {
+        // Load-bearing: removing the positional CANDIDATE or making it optional
+        // changes one of these parse results.
         for args in [
             vec!["rbgp", "config", "diff", "candidate.toml"],
             vec!["rbgp", "config", "plan", "candidate.toml"],
@@ -6208,24 +6207,6 @@ printf '%s\n' "${COMPREPLY[@]}"
         }
 
         assert!(Cli::try_parse_from(["rbgp", "config", "diff"]).is_err());
-        for args in [
-            vec!["rbgp", "config", "diff", "--from-file", "candidate.toml"],
-            vec!["rbgp", "config", "plan", "--from-file", "candidate.toml"],
-            vec![
-                "rbgp",
-                "config",
-                "apply",
-                "--from-file",
-                "candidate.toml",
-                "--expected-runtime-snapshot-token",
-                "kv1:old:1",
-            ],
-        ] {
-            let Err(error) = Cli::try_parse_from(args) else {
-                panic!("retired --from-file alias parsed");
-            };
-            assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
-        }
     }
 
     #[test]

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -1311,11 +1311,8 @@ mod tests {
         let unlimited = serde_json::to_value(row(Some(0))).unwrap();
         let finite = serde_json::to_value(row(Some(4))).unwrap();
 
-        // Load-bearing: restoring the raw sentinel key or changing any
-        // presence state makes these exact machine-format assertions red.
-        for value in [&inactive, &unlimited, &finite] {
-            assert!(value.get("effective_send_max").is_none());
-        }
+        // Load-bearing: changing any presence state makes these exact
+        // machine-format assertions red.
         assert_eq!(inactive["effective_send_active"], false);
         assert!(inactive.get("effective_send_limit").is_none());
         assert_eq!(unlimited["effective_send_active"], true);

--- a/src/config/tests/neighbor_validation.rs
+++ b/src/config/tests/neighbor_validation.rs
@@ -969,27 +969,6 @@ fn send_hold_time_change_is_a_runtime_neighbor_change() {
     );
 }
 
-// ── Expired retired-key pointers (ADR-0122) ─────────
-
-#[test]
-fn retired_global_inline_policy_uses_generic_unknown_field_error() {
-    let toml_str = format!(
-        "{}\n[[policy.import]]\nprefix = \"10.0.0.0/8\"\nge = 8\nle = 24\naction = \"permit\"\n",
-        valid_toml()
-    );
-    let err = Config::load_toml_with_diagnostics(&toml_str, "test.toml").unwrap_err();
-    assert!(
-        err.contains("unknown field") && err.contains("import"),
-        "must use the ordinary typed-config diagnostic: {err}"
-    );
-    assert!(
-        !err.contains("global inline policy fallback")
-            && !err.contains("Named policy definitions")
-            && !err.contains("Per-neighbor and per-group"),
-        "the expired bespoke migration pointer must stay removed: {err}"
-    );
-}
-
 #[test]
 fn per_neighbor_inline_policy_still_loads() {
     // Per-neighbor and per-group inline policy is NOT removed — only
@@ -1004,23 +983,4 @@ fn per_neighbor_inline_policy_still_loads() {
     )
     .unwrap();
     assert!(!config.neighbors[0].import_policy.is_empty());
-}
-
-// ── In-daemon looking glass pointer expiry ───────────────────────────
-
-#[test]
-fn retired_looking_glass_uses_generic_unknown_field_error() {
-    let toml_str = format!(
-        "{}\n[global.telemetry.looking_glass]\naddr = \"127.0.0.1:8080\"\n",
-        valid_toml()
-    );
-    let err = Config::load_toml_with_diagnostics(&toml_str, "test.toml").unwrap_err();
-    assert!(
-        err.contains("unknown field") && err.contains("looking_glass"),
-        "must use the ordinary typed-config diagnostic: {err}"
-    );
-    assert!(
-        !err.contains("birdwatcher-adapter") && !err.contains("has been removed"),
-        "the expired bespoke migration pointer must stay removed: {err}"
-    );
 }


### PR DESCRIPTION
Linear: LAN-992

Removes the narrowly approved compatibility-test ceremony while preserving live behavior and stronger correctness gates:

- keeps positional config-candidate parsing coverage while dropping the retired alias negative loop
- removes two expired migration-pointer negative tests
- removes a source-text AddNeighbor reservation assertion already enforced by the v1 message-graph checker
- trims retired Paths-Limit field/key absence assertions while retaining active field and presence-state coverage

This changes exactly four test files: 5 insertions, 94 deletions (89 net lines removed). No production, protobuf, stable-inventory, ADR, or operator behavior changes.

Validated with focused CLI/config/API tests, the v1 stable-surface checker, formatting, and diff/scope checks.