### PR TITLE
fix: bound config transaction coordinator acquisition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Config transaction apply now bounds its pre-ownership wait for the shared runtime config coordinator at ten minutes. (LAN-974)
 - Ambiguous `rustbgpd` invocations now fail with exit 2 instead of silently
   overwriting a config path or option value, consuming a flag as a value, or
   letting a display or one-shot mode ignore companion arguments. (LAN-979)

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -83,6 +83,8 @@ pub enum ConfigTransactionApplyError {
     FailedPrecondition(String),
     /// Required runtime actor or persistence channel is unavailable.
     Unavailable(String),
+    /// The request could not acquire the runtime config coordinator in time.
+    DeadlineExceeded(String),
     /// Internal actor/rollback failure.
     Internal(String),
 }
@@ -93,6 +95,7 @@ impl ConfigTransactionApplyError {
             Self::InvalidArgument(message) => Status::invalid_argument(message),
             Self::FailedPrecondition(message) => Status::failed_precondition(message),
             Self::Unavailable(message) => Status::unavailable(message),
+            Self::DeadlineExceeded(message) => Status::deadline_exceeded(message),
             Self::Internal(message) => Status::internal(message),
         }
     }
@@ -104,6 +107,7 @@ impl std::fmt::Display for ConfigTransactionApplyError {
             Self::InvalidArgument(message)
             | Self::FailedPrecondition(message)
             | Self::Unavailable(message)
+            | Self::DeadlineExceeded(message)
             | Self::Internal(message) => f.write_str(message),
         }
     }
@@ -1873,6 +1877,27 @@ mod tests {
     use crate::proto::global_service_client::GlobalServiceClient;
     use crate::proto::{EventCategory, WatchEventsRequest};
     use crate::test_support::{session_event, spawn_fake_peer_manager, spawn_fake_rib};
+
+    #[test]
+    fn config_transaction_deadline_maps_exactly_to_grpc() {
+        let error = ConfigTransactionApplyError::DeadlineExceeded(
+            "config transaction timed out waiting for the runtime config coordinator; \
+             coordinator ownership was not acquired and apply did not begin"
+                .to_string(),
+        );
+        assert_eq!(
+            error.to_string(),
+            "config transaction timed out waiting for the runtime config coordinator; \
+             coordinator ownership was not acquired and apply did not begin"
+        );
+        let status = error.into_status();
+        assert_eq!(status.code(), tonic::Code::DeadlineExceeded);
+        assert_eq!(
+            status.message(),
+            "config transaction timed out waiting for the runtime config coordinator; \
+             coordinator ownership was not acquired and apply did not begin"
+        );
+    }
 
     #[test]
     fn streamed_config_production_wiring_is_singleton_and_authentication_is_explicit() {

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -36,6 +36,7 @@ use crate::peer_manager::InternalCommand;
 use crate::reload::transaction_config_snapshot_accepted;
 
 const PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
+const CONFIG_TRANSACTION_COORDINATOR_ACQUIRE_TIMEOUT: Duration = Duration::from_mins(10);
 const DEFAULT_CONFIRM_TIMEOUT_SECONDS: u32 = 600;
 const MAX_CONFIRM_TIMEOUT_SECONDS: u32 = 86_400;
 const MAX_CONFIRM_ID_CHARS: usize = 128;
@@ -460,7 +461,18 @@ impl ConfigTransactionController {
         validate_apply_request(&request)?;
         let confirmed = parse_confirmed_apply_mode(&request)?;
         let join = tokio::spawn(async move {
-            let _guard = self.deps.lock.lock().await;
+            let _guard = tokio::time::timeout(
+                CONFIG_TRANSACTION_COORDINATOR_ACQUIRE_TIMEOUT,
+                Arc::clone(&self.deps.lock).lock_owned(),
+            )
+            .await
+            .map_err(|_| {
+                ConfigTransactionApplyError::DeadlineExceeded(
+                    "config transaction timed out waiting for the runtime config coordinator; \
+                     coordinator ownership was not acquired and apply did not begin"
+                        .to_string(),
+                )
+            })?;
             self.apply_locked(request, confirmed).await
         });
 
@@ -1618,6 +1630,9 @@ fn append_error_context(
         }
         ConfigTransactionApplyError::Unavailable(message) => {
             ConfigTransactionApplyError::Unavailable(format!("{message}; {context}"))
+        }
+        ConfigTransactionApplyError::DeadlineExceeded(message) => {
+            ConfigTransactionApplyError::DeadlineExceeded(format!("{message}; {context}"))
         }
         ConfigTransactionApplyError::Internal(message) => {
             ConfigTransactionApplyError::Internal(format!("{message}; {context}"))
@@ -3471,6 +3486,12 @@ fn apply_error_to_gnmi_set_error(error: ConfigTransactionApplyError) -> GnmiSetE
             GnmiSetError::FailedPrecondition(message)
         }
         ConfigTransactionApplyError::Unavailable(message) => GnmiSetError::Unavailable(message),
+        // gNMI Set owns the coordinator before it calls the locked apply helpers, so Apply's
+        // pre-ownership deadline is unreachable here. Keep the exhaustive mapping inside the
+        // existing gNMI vocabulary unless gNMI coordinator acquisition gains its own deadline.
+        ConfigTransactionApplyError::DeadlineExceeded(message) => {
+            GnmiSetError::Unavailable(message)
+        }
         ConfigTransactionApplyError::Internal(message) => GnmiSetError::Internal(message),
     }
 }
@@ -3552,6 +3573,9 @@ fn confirm_abort_rollback_error(
         }
         ConfigTransactionApplyError::Unavailable(_) => {
             ConfigTransactionApplyError::Unavailable(message)
+        }
+        ConfigTransactionApplyError::DeadlineExceeded(_) => {
+            ConfigTransactionApplyError::DeadlineExceeded(message)
         }
         ConfigTransactionApplyError::Internal(_) => ConfigTransactionApplyError::Internal(message),
     }
@@ -5086,6 +5110,99 @@ peer_group = "{group}"
             config_tx,
             startup_tables,
         ))
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn apply_times_out_before_coordinator_ownership_without_mutation() {
+        let coordinator = Arc::new(Mutex::new(()));
+        let blocker = coordinator.lock().await;
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        let (fib_tx, mut fib_rx) = mpsc::channel(1);
+        let (rib_tx, mut rib_rx) = mpsc::channel(1);
+        let (config_tx, mut config_rx) = mpsc::channel(1);
+        let runtime = tempfile::tempdir().unwrap();
+        let journal = runtime.path().join("commit-confirm-journal.json");
+        let controller = ConfigTransactionController::new(
+            FibTableControlDeps {
+                lock: Arc::clone(&coordinator),
+                rib_tx: Some(rib_tx),
+                confirm_journal_path: Some(journal.clone()),
+                ..deps_value(Some(fib_tx), peer_tx, Some(config_tx), Vec::new())
+            },
+            BgpMetrics::new(),
+        );
+        let apply = tokio::spawn(controller.clone().apply(confirmed_dynamic_request(
+            base_toml("[peer_groups.blocked]"),
+            "blocked-apply",
+            60,
+        )));
+        tokio::task::yield_now().await;
+
+        // This wall-clock oracle intentionally does not use the implementation constant: any
+        // production drift from the ten-minute contract must make the test fail.
+        tokio::time::advance(Duration::from_secs(599)).await;
+        tokio::task::yield_now().await;
+        assert!(!apply.is_finished(), "apply timed out before ten minutes");
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let error = apply.await.unwrap().unwrap_err();
+        assert_eq!(
+            error,
+            ConfigTransactionApplyError::DeadlineExceeded(
+                "config transaction timed out waiting for the runtime config coordinator; \
+                 coordinator ownership was not acquired and apply did not begin"
+                    .to_string()
+            )
+        );
+
+        assert!(peer_rx.try_recv().is_err());
+        assert!(fib_rx.try_recv().is_err());
+        assert!(rib_rx.try_recv().is_err());
+        assert!(config_rx.try_recv().is_err());
+        assert!(!journal.exists());
+        let state = controller.state.lock().await;
+        assert!(state.applying_confirm_id.is_none());
+        assert!(state.pending.is_none());
+        assert!(state.last.is_none());
+        assert!(state.ambiguous_failure_confirm_id.is_none());
+        drop(state);
+
+        drop(blocker);
+        let next = tokio::spawn(
+            controller
+                .clone()
+                .apply(proto::ApplyConfigTransactionRequest {
+                    candidate_toml: base_toml(""),
+                    expected_runtime_snapshot_token: "kv1:old:1".to_string(),
+                    client_request_id: "after-timeout".to_string(),
+                    comment: String::new(),
+                    confirm_id: String::new(),
+                    confirm_timeout_seconds: 0,
+                }),
+        );
+        let PeerManagerCommand::PlanConfigTransaction {
+            candidate_toml,
+            reply,
+            ..
+        } = peer_rx.recv().await.unwrap()
+        else {
+            panic!("unexpected peer-manager command after coordinator timeout");
+        };
+        assert_eq!(
+            candidate_toml,
+            base_toml(""),
+            "timed-out apply remained queued"
+        );
+        reply
+            .send(Ok(plan(RuntimeConfigTransactionStatus::Noop, Vec::new())))
+            .unwrap();
+        let response = next.await.unwrap().unwrap();
+        assert_eq!(
+            response.status,
+            proto::ConfigTransactionPlanStatus::Noop as i32
+        );
+        assert!(fib_rx.try_recv().is_err());
+        assert!(rib_rx.try_recv().is_err());
+        assert!(config_rx.try_recv().is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- bound Apply waiting for the shared runtime-config coordinator at ten minutes
- return `DEADLINE_EXCEEDED` only before ownership, with an explicit no-apply-began diagnostic
- preserve post-ownership settlement shielding and streamed admission ownership

## Verification

- paused-clock pre-ownership timeout and no-hidden-waiter proof
- config transaction controller tests
- API library and root daemon tests
- workspace all-target/all-feature Clippy with warnings denied
- v1 stable-surface checker
- formatting and diff checks

LAN-974 remains open: this tranche bounds only coordinator acquisition before transaction ownership; post-ownership settlement liveness is separate work.