### PR TITLE
fix: make runtime config coordination closeable

### DIFF
--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -2,12 +2,11 @@
 
 use std::collections::BTreeSet;
 use std::net::IpAddr;
-use std::sync::Arc;
 use std::time::Duration;
 
 use rustbgpd_transport::RemovePrivateAs;
 use rustbgpd_wire::{Afi, BgpRole, Safi};
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::mpsc;
 use tonic::{Request, Response, Status};
 
 use crate::actor_read::{peer_manager_read, rib_manager_read};
@@ -18,8 +17,8 @@ use crate::peer_types::{
 };
 use crate::proto;
 use crate::server::{
-    AccessMode, ConfigMutationGateFn, check_config_mutation_gate, peer_manager_request,
-    persist_then_apply, read_only_rejection,
+    AccessMode, ConfigMutationGateFn, RuntimeConfigCoordinator, check_config_mutation_gate,
+    peer_manager_request, persist_then_apply, read_only_rejection,
 };
 use rustbgpd_rib::{
     EffectiveDistributionMode, NeighborRibSnapshot, NeighborRibSnapshotResponse, RibUpdate,
@@ -87,7 +86,7 @@ pub struct NeighborService {
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
     rib_tx: mpsc::Sender<RibUpdate>,
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
-    runtime_config_lock: Arc<Mutex<()>>,
+    runtime_config_lock: RuntimeConfigCoordinator,
     config_mutation_gate: Option<ConfigMutationGateFn>,
 }
 
@@ -102,28 +101,29 @@ impl NeighborService {
         rib_tx: mpsc::Sender<RibUpdate>,
         config_tx: Option<mpsc::Sender<ConfigEvent>>,
     ) -> Self {
-        Self::with_runtime_config_lock(
+        Self::with_runtime_config_coordinator(
             local_asn,
             access_mode,
             peer_mgr_tx,
             rib_tx,
             config_tx,
-            Arc::new(Mutex::new(())),
+            RuntimeConfigCoordinator::new(),
             None,
         )
     }
 
-    /// Create a new neighbor service using the shared runtime config lock.
+    /// Create a new neighbor service using the shared runtime config coordinator.
     ///
     /// The daemon wires the same lock into SIGHUP reload and FIB-table CRUD so
     /// persisted runtime mutations cannot interleave with a TOML reload.
-    pub fn with_runtime_config_lock(
+    #[must_use]
+    pub fn with_runtime_config_coordinator(
         _local_asn: u32,
         access_mode: AccessMode,
         peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
         rib_tx: mpsc::Sender<RibUpdate>,
         config_tx: Option<mpsc::Sender<ConfigEvent>>,
-        runtime_config_lock: Arc<Mutex<()>>,
+        runtime_config_lock: RuntimeConfigCoordinator,
         config_mutation_gate: Option<ConfigMutationGateFn>,
     ) -> Self {
         Self {
@@ -147,7 +147,7 @@ impl NeighborService {
         let config_mutation_gate = self.config_mutation_gate.clone();
         let persisted_spec = spec.clone();
         let join = tokio::spawn(async move {
-            let _guard = runtime_config_lock.lock().await;
+            let _guard = runtime_config_lock.acquire().await?;
             check_config_mutation_gate(&config_mutation_gate, "NeighborService.AddNeighbor")
                 .await?;
             persist_then_apply(
@@ -1030,7 +1030,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         let runtime_config_lock = self.runtime_config_lock.clone();
         let config_mutation_gate = self.config_mutation_gate.clone();
         let join = tokio::spawn(async move {
-            let _guard = runtime_config_lock.lock().await;
+            let _guard = runtime_config_lock.acquire().await?;
             check_config_mutation_gate(&config_mutation_gate, "NeighborService.DeleteNeighbor")
                 .await?;
             // The session teardown below is irreversible: re-adding the peer
@@ -1324,7 +1324,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         let runtime_config_lock = self.runtime_config_lock.clone();
         let config_mutation_gate = self.config_mutation_gate.clone();
         let join = tokio::spawn(async move {
-            let _guard = runtime_config_lock.lock().await;
+            let _guard = runtime_config_lock.acquire().await?;
             check_config_mutation_gate(&config_mutation_gate, "NeighborService.AddDynamicNeighbor")
                 .await?;
             // Stage the write before the matcher changes, so a persistence
@@ -1378,7 +1378,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         let runtime_config_lock = self.runtime_config_lock.clone();
         let config_mutation_gate = self.config_mutation_gate.clone();
         let join = tokio::spawn(async move {
-            let _guard = runtime_config_lock.lock().await;
+            let _guard = runtime_config_lock.acquire().await?;
             check_config_mutation_gate(
                 &config_mutation_gate,
                 "NeighborService.DeleteDynamicNeighbor",
@@ -1707,6 +1707,40 @@ mod tests {
                 }),
             }),
         }
+    }
+
+    #[tokio::test]
+    async fn closed_coordinator_rejects_neighbor_before_actor_or_persistence() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        let (rib_tx, _rib_rx) = mpsc::channel(1);
+        let (config_tx, mut config_rx) = mpsc::channel(1);
+        let coordinator = RuntimeConfigCoordinator::new();
+        coordinator.close();
+        let service = NeighborService::with_runtime_config_coordinator(
+            65001,
+            AccessMode::ReadWrite,
+            peer_tx,
+            rib_tx,
+            Some(config_tx),
+            coordinator,
+            None,
+        );
+        let request = intent_request(
+            Some(proto::NeighborConfig {
+                address: "192.0.2.1".to_string(),
+                remote_asn: 65002,
+                ..Default::default()
+            }),
+            Some(Vec::new()),
+        );
+
+        let error = service
+            .add_neighbor(Request::new(request))
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), tonic::Code::Unavailable);
+        assert!(matches!(peer_rx.try_recv(), Err(TryRecvError::Empty)));
+        assert!(matches!(config_rx.try_recv(), Err(TryRecvError::Empty)));
     }
 
     #[derive(Clone, PartialEq, Message)]

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -1,6 +1,5 @@
 //! gRPC peer-group service — reusable neighbor defaults and membership.
 
-use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -18,8 +17,8 @@ use crate::peer_types::{
 use crate::policy_helpers::proto_statement_to_input;
 use crate::proto;
 use crate::server::{
-    AccessMode, ConfigMutationGateFn, apply_catalog_mutation, peer_manager_request,
-    persist_then_apply, read_only_rejection, run_shielded_catalog_mutation,
+    AccessMode, ConfigMutationGateFn, RuntimeConfigCoordinator, apply_catalog_mutation,
+    peer_manager_request, persist_then_apply, read_only_rejection, run_shielded_catalog_mutation,
 };
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -276,7 +275,7 @@ pub struct PeerGroupService {
     access_mode: AccessMode,
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
-    runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
+    runtime_config_lock: RuntimeConfigCoordinator,
     config_mutation_gate: Option<ConfigMutationGateFn>,
 }
 
@@ -290,24 +289,24 @@ impl PeerGroupService {
         config_tx: Option<mpsc::Sender<ConfigEvent>>,
         config_mutation_gate: Option<ConfigMutationGateFn>,
     ) -> Self {
-        Self::with_runtime_config_lock(
+        Self::with_runtime_config_coordinator(
             access_mode,
             peer_mgr_tx,
             config_tx,
             config_mutation_gate,
-            Arc::new(tokio::sync::Mutex::new(())),
+            RuntimeConfigCoordinator::new(),
         )
     }
 
     /// Create a peer-group service sharing the daemon-wide runtime-config
     /// coordinator lock, so catalog mutations serialize with SIGHUP
     /// reload, neighbor / FIB-table CRUD, and config transactions.
-    pub fn with_runtime_config_lock(
+    pub fn with_runtime_config_coordinator(
         access_mode: AccessMode,
         peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
         config_tx: Option<mpsc::Sender<ConfigEvent>>,
         config_mutation_gate: Option<ConfigMutationGateFn>,
-        runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
+        runtime_config_lock: RuntimeConfigCoordinator,
     ) -> Self {
         Self {
             access_mode,

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -18,10 +18,9 @@ use crate::peer_types::{
 use crate::policy_helpers::{proto_statement_to_input, validate_policy_action};
 use crate::proto;
 use crate::server::{
-    AccessMode, ConfigMutationGateFn, apply_catalog_mutation, peer_manager_request,
-    persist_then_apply, read_only_rejection, run_shielded_catalog_mutation,
+    AccessMode, ConfigMutationGateFn, RuntimeConfigCoordinator, apply_catalog_mutation,
+    peer_manager_request, persist_then_apply, read_only_rejection, run_shielded_catalog_mutation,
 };
-use std::sync::Arc;
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
 const POLICY_STATS_AGGREGATE_TIMEOUT: Duration = Duration::from_millis(500);
@@ -297,7 +296,7 @@ pub struct PolicyService {
     access_mode: AccessMode,
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
-    runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
+    runtime_config_lock: RuntimeConfigCoordinator,
     config_mutation_gate: Option<ConfigMutationGateFn>,
     /// RIB query channel backing `TestPolicy`'s read-only snapshot
     /// (ADR-0096 Decision 6). `None` when the service was built
@@ -315,24 +314,24 @@ impl PolicyService {
         config_tx: Option<mpsc::Sender<ConfigEvent>>,
         config_mutation_gate: Option<ConfigMutationGateFn>,
     ) -> Self {
-        Self::with_runtime_config_lock(
+        Self::with_runtime_config_coordinator(
             access_mode,
             peer_mgr_tx,
             config_tx,
             config_mutation_gate,
-            Arc::new(tokio::sync::Mutex::new(())),
+            RuntimeConfigCoordinator::new(),
         )
     }
 
     /// Create a policy service sharing the daemon-wide runtime-config
     /// coordinator lock, so catalog mutations serialize with SIGHUP
     /// reload, neighbor / FIB-table CRUD, and config transactions.
-    pub fn with_runtime_config_lock(
+    pub fn with_runtime_config_coordinator(
         access_mode: AccessMode,
         peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
         config_tx: Option<mpsc::Sender<ConfigEvent>>,
         config_mutation_gate: Option<ConfigMutationGateFn>,
-        runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
+        runtime_config_lock: RuntimeConfigCoordinator,
     ) -> Self {
         Self {
             access_mode,
@@ -1626,6 +1625,8 @@ fn render_modification_changes(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::peer_types::{CatalogMutationError, PolicyAsPathPrependConfig};
     use crate::proto::policy_service_server::PolicyService as PolicyServiceRpc;

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use futures::StreamExt as FuturesStreamExt;
 use futures::{Future, Stream};
 use tokio::net::{TcpListener, UnixListener};
-use tokio::sync::{mpsc, oneshot, watch};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc, oneshot, watch};
 use tokio::task::JoinSet;
 use tokio_rustls::TlsAcceptor;
 use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
@@ -61,6 +61,72 @@ use rustbgpd_telemetry::BgpMetrics;
 
 const MAX_CONCURRENT_GRPC_TLS_HANDSHAKES: usize = 64;
 const GRPC_TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Closeable, one-permit serializer for persisted runtime-config mutations.
+#[derive(Clone, Debug)]
+pub struct RuntimeConfigCoordinator(Arc<Semaphore>);
+
+impl RuntimeConfigCoordinator {
+    /// Create an open coordinator.
+    #[must_use]
+    #[allow(
+        clippy::new_without_default,
+        reason = "Default is intentionally absent so coordinator creation stays explicit"
+    )]
+    pub fn new() -> Self {
+        Self(Arc::new(Semaphore::new(1)))
+    }
+
+    /// Wait for exclusive ownership.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeConfigCoordinatorClosed`] after closure.
+    pub async fn acquire(
+        &self,
+    ) -> Result<RuntimeConfigCoordinatorPermit, RuntimeConfigCoordinatorClosed> {
+        self.0
+            .clone()
+            .acquire_owned()
+            .await
+            .map(RuntimeConfigCoordinatorPermit)
+            .map_err(|_| RuntimeConfigCoordinatorClosed)
+    }
+
+    /// Permanently reject queued and future acquisitions.
+    pub fn close(&self) {
+        self.0.close();
+    }
+
+    /// Whether the coordinator has been permanently closed.
+    #[must_use]
+    pub fn is_closed(&self) -> bool {
+        self.0.is_closed()
+    }
+}
+
+/// Error returned when the runtime-config coordinator is closed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RuntimeConfigCoordinatorClosed;
+
+impl std::fmt::Display for RuntimeConfigCoordinatorClosed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("runtime config coordinator is closed")
+    }
+}
+
+impl std::error::Error for RuntimeConfigCoordinatorClosed {}
+
+impl From<RuntimeConfigCoordinatorClosed> for Status {
+    fn from(error: RuntimeConfigCoordinatorClosed) -> Self {
+        Self::unavailable(error.to_string())
+    }
+}
+
+/// Opaque exclusive runtime-config ownership, released on drop.
+#[must_use = "dropping the runtime-config permit immediately releases ownership"]
+#[derive(Debug)]
+pub struct RuntimeConfigCoordinatorPermit(#[allow(dead_code)] OwnedSemaphorePermit);
 
 fn bounded_handshakes<S, F, T, E>(incoming: S) -> impl Stream<Item = Result<T, E>>
 where
@@ -114,6 +180,12 @@ impl std::fmt::Display for ConfigTransactionApplyError {
 }
 
 impl std::error::Error for ConfigTransactionApplyError {}
+
+impl From<RuntimeConfigCoordinatorClosed> for ConfigTransactionApplyError {
+    fn from(error: RuntimeConfigCoordinatorClosed) -> Self {
+        Self::Unavailable(error.to_string())
+    }
+}
 
 const MAX_CONFIG_CONFIRM_ID_CHARS: usize = 128;
 const MAX_CONFIG_CONFIRM_TIMEOUT_SECONDS: u32 = 86_400;
@@ -219,6 +291,12 @@ impl std::fmt::Display for GnmiSetError {
 }
 
 impl std::error::Error for GnmiSetError {}
+
+impl From<RuntimeConfigCoordinatorClosed> for GnmiSetError {
+    fn from(error: RuntimeConfigCoordinatorClosed) -> Self {
+        Self::Unavailable(error.to_string())
+    }
+}
 
 /// One normalized gNMI Set operation in the wire-mandated application order.
 #[derive(Clone, PartialEq)]
@@ -563,7 +641,7 @@ where
 /// Returns the gate's `FAILED_PRECONDITION`, the body's error, or
 /// `INTERNAL` if the detached task is lost.
 pub(crate) async fn run_shielded_catalog_mutation<F, Fut>(
-    runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
+    runtime_config_lock: RuntimeConfigCoordinator,
     config_mutation_gate: Option<ConfigMutationGateFn>,
     operation: &'static str,
     body: F,
@@ -573,7 +651,7 @@ where
     Fut: std::future::Future<Output = Result<(), Status>> + Send,
 {
     let join = tokio::spawn(async move {
-        let _guard = runtime_config_lock.lock().await;
+        let _guard = runtime_config_lock.acquire().await?;
         check_config_mutation_gate(&config_mutation_gate, operation).await?;
         body().await
     });
@@ -750,7 +828,7 @@ pub struct ServeConfig {
     /// SIGHUP reload. The daemon wires this to dynamic-neighbor CRUD and
     /// FIB-table CRUD so accepted runtime mutations cannot be clobbered by a
     /// reload that read stale TOML before the persistence acknowledgement.
-    pub runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
+    pub runtime_config_lock: RuntimeConfigCoordinator,
     /// Live ADR-0061 per-route FIB dataplane event source. This is
     /// separate from the aggregate dataplane poller so route events
     /// are not delayed by snapshot polling.
@@ -1368,7 +1446,7 @@ async fn run_tcp_listener(
     config_history_list: Option<ConfigHistoryListFn>,
     config_rollback: Option<ConfigRollbackFn>,
     config_mutation_gate: Option<ConfigMutationGateFn>,
-    runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
+    runtime_config_lock: RuntimeConfigCoordinator,
     dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
     bfd_session_snapshot: crate::bfd_service::BfdSessionSnapshotFn,
     bfd_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
@@ -1477,7 +1555,7 @@ async fn run_tcp_listener(
         interceptor.clone(),
     ));
     routes.add_service(NeighborServiceServer::with_interceptor(
-        NeighborService::with_runtime_config_lock(
+        NeighborService::with_runtime_config_coordinator(
             asn,
             access_mode,
             peer_mgr_tx.clone(),
@@ -1489,7 +1567,7 @@ async fn run_tcp_listener(
         interceptor.clone(),
     ));
     routes.add_service(PeerGroupServiceServer::with_interceptor(
-        PeerGroupService::with_runtime_config_lock(
+        PeerGroupService::with_runtime_config_coordinator(
             access_mode,
             peer_mgr_tx.clone(),
             config_tx.clone(),
@@ -1499,7 +1577,7 @@ async fn run_tcp_listener(
         interceptor.clone(),
     ));
     routes.add_service(PolicyServiceServer::with_interceptor(
-        PolicyService::with_runtime_config_lock(
+        PolicyService::with_runtime_config_coordinator(
             access_mode,
             peer_mgr_tx.clone(),
             config_tx.clone(),
@@ -1631,7 +1709,7 @@ async fn run_uds_listener(
     config_history_list: Option<ConfigHistoryListFn>,
     config_rollback: Option<ConfigRollbackFn>,
     config_mutation_gate: Option<ConfigMutationGateFn>,
-    runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
+    runtime_config_lock: RuntimeConfigCoordinator,
     dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
     bfd_session_snapshot: crate::bfd_service::BfdSessionSnapshotFn,
     bfd_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
@@ -1701,7 +1779,7 @@ async fn run_uds_listener(
         interceptor.clone(),
     ));
     routes.add_service(NeighborServiceServer::with_interceptor(
-        NeighborService::with_runtime_config_lock(
+        NeighborService::with_runtime_config_coordinator(
             asn,
             access_mode,
             peer_mgr_tx.clone(),
@@ -1713,7 +1791,7 @@ async fn run_uds_listener(
         interceptor.clone(),
     ));
     routes.add_service(PeerGroupServiceServer::with_interceptor(
-        PeerGroupService::with_runtime_config_lock(
+        PeerGroupService::with_runtime_config_coordinator(
             access_mode,
             peer_mgr_tx.clone(),
             config_tx.clone(),
@@ -1723,7 +1801,7 @@ async fn run_uds_listener(
         interceptor.clone(),
     ));
     routes.add_service(PolicyServiceServer::with_interceptor(
-        PolicyService::with_runtime_config_lock(
+        PolicyService::with_runtime_config_coordinator(
             access_mode,
             peer_mgr_tx.clone(),
             config_tx.clone(),
@@ -1897,6 +1975,80 @@ mod tests {
             "config transaction timed out waiting for the runtime config coordinator; \
              coordinator ownership was not acquired and apply did not begin"
         );
+    }
+
+    #[tokio::test]
+    async fn runtime_config_coordinator_close_rejects_waiters_and_future_acquirers() {
+        let coordinator = RuntimeConfigCoordinator::new();
+        let owner = coordinator.acquire().await.expect("initial owner");
+        let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+        let mut waiters = Vec::new();
+        for _ in 0..2 {
+            let coordinator = coordinator.clone();
+            let started_tx = started_tx.clone();
+            waiters.push(tokio::spawn(async move {
+                started_tx.send(()).expect("started receiver");
+                coordinator.acquire().await
+            }));
+        }
+        drop(started_tx);
+        started_rx.recv().await.expect("first waiter started");
+        started_rx.recv().await.expect("second waiter started");
+        tokio::task::yield_now().await;
+
+        coordinator.close();
+        coordinator.close();
+        assert!(coordinator.is_closed());
+        for waiter in waiters {
+            assert_eq!(
+                waiter.await.expect("waiter task").unwrap_err(),
+                RuntimeConfigCoordinatorClosed
+            );
+        }
+
+        // Closure does not revoke the already-issued opaque owner, and
+        // releasing that owner cannot reopen the coordinator.
+        drop(owner);
+        assert!(coordinator.acquire().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn runtime_config_coordinator_preserves_fifo_acquisition() {
+        let coordinator = RuntimeConfigCoordinator::new();
+        let owner = coordinator.acquire().await.expect("initial owner");
+        let (order_tx, mut order_rx) = mpsc::unbounded_channel();
+        for index in 0..3 {
+            let coordinator = coordinator.clone();
+            let order_tx = order_tx.clone();
+            tokio::spawn(async move {
+                let _guard = coordinator.acquire().await.expect("queued owner");
+                order_tx.send(index).expect("order receiver");
+            });
+            tokio::task::yield_now().await;
+        }
+        drop(order_tx);
+        drop(owner);
+
+        assert_eq!(order_rx.recv().await, Some(0));
+        assert_eq!(order_rx.recv().await, Some(1));
+        assert_eq!(order_rx.recv().await, Some(2));
+    }
+
+    #[tokio::test]
+    async fn closed_coordinator_rejects_catalog_before_body() {
+        let coordinator = RuntimeConfigCoordinator::new();
+        coordinator.close();
+        let body_ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let body_ran_task = body_ran.clone();
+        let result =
+            run_shielded_catalog_mutation(coordinator, None, "test.closed", move || async move {
+                body_ran_task.store(true, std::sync::atomic::Ordering::SeqCst);
+                Ok(())
+            })
+            .await;
+
+        assert_eq!(result.unwrap_err().code(), tonic::Code::Unavailable);
+        assert!(!body_ran.load(std::sync::atomic::Ordering::SeqCst));
     }
 
     #[test]
@@ -2312,8 +2464,8 @@ mod tests {
     /// A timeout that leaked the lock would leave the second mutation
     /// parked on `lock().await` until this test's own guard expires.
     #[tokio::test(start_paused = true)]
-    async fn catalog_mutation_after_peer_manager_timeout_acquires_lock() {
-        let lock = Arc::new(tokio::sync::Mutex::new(()));
+    async fn catalog_mutation_after_peer_manager_timeout_acquires_coordinator() {
+        let coordinator = RuntimeConfigCoordinator::new();
         let (tx, mut rx) = mpsc::channel(2);
         let responder = tokio::spawn(async move {
             // First mutation: accept the command but never answer it, so
@@ -2333,13 +2485,20 @@ mod tests {
         let wedged_tx = tx.clone();
         let first = tokio::time::timeout(
             Duration::from_hours(1),
-            run_shielded_catalog_mutation(lock.clone(), None, "test.wedged", move || async move {
-                apply_catalog_mutation(&wedged_tx, |reply| PeerManagerCommand::DeletePeerGroup {
-                    name: "wedged".into(),
-                    reply,
-                })
-                .await
-            }),
+            run_shielded_catalog_mutation(
+                coordinator.clone(),
+                None,
+                "test.wedged",
+                move || async move {
+                    apply_catalog_mutation(&wedged_tx, |reply| {
+                        PeerManagerCommand::DeletePeerGroup {
+                            name: "wedged".into(),
+                            reply,
+                        }
+                    })
+                    .await
+                },
+            ),
         )
         .await
         .expect("catalog mutation must be bounded server-side");
@@ -2348,7 +2507,7 @@ mod tests {
         let healthy_tx = tx.clone();
         let second = tokio::time::timeout(
             Duration::from_secs(5),
-            run_shielded_catalog_mutation(lock, None, "test.healthy", move || async move {
+            run_shielded_catalog_mutation(coordinator, None, "test.healthy", move || async move {
                 apply_catalog_mutation(&healthy_tx, |reply| PeerManagerCommand::DeletePeerGroup {
                     name: "healthy".into(),
                     reply,

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -463,7 +463,7 @@ impl ConfigTransactionController {
         let join = tokio::spawn(async move {
             let _guard = tokio::time::timeout(
                 CONFIG_TRANSACTION_COORDINATOR_ACQUIRE_TIMEOUT,
-                Arc::clone(&self.deps.lock).lock_owned(),
+                self.deps.lock.acquire(),
             )
             .await
             .map_err(|_| {
@@ -472,7 +472,7 @@ impl ConfigTransactionController {
                      coordinator ownership was not acquired and apply did not begin"
                         .to_string(),
                 )
-            })?;
+            })??;
             self.apply_locked(request, confirmed).await
         });
 
@@ -488,7 +488,7 @@ impl ConfigTransactionController {
         transaction: rustbgpd_api::server::GnmiSetTransaction,
     ) -> Result<GnmiSetOutcome, GnmiSetError> {
         let join = tokio::spawn(async move {
-            let _guard = self.deps.lock.lock().await;
+            let _guard = self.deps.lock.acquire().await?;
             match transaction.commit_action.clone() {
                 Some(GnmiSetCommitAction::Confirm { confirm_id }) => {
                     let confirm_id =
@@ -812,7 +812,7 @@ impl ConfigTransactionController {
     ) -> Result<proto::ConfirmConfigTransactionResponse, ConfigTransactionApplyError> {
         let confirm_id = validate_confirm_id(&request.confirm_id)?;
         let join = tokio::spawn(async move {
-            let _guard = self.deps.lock.lock().await;
+            let _guard = self.deps.lock.acquire().await?;
             self.confirm_locked(confirm_id).await
         });
         join.await.map_err(|_| {
@@ -869,7 +869,7 @@ impl ConfigTransactionController {
     ) -> Result<proto::AbortConfigTransactionResponse, ConfigTransactionApplyError> {
         let confirm_id = validate_confirm_id(&request.confirm_id)?;
         let join = tokio::spawn(async move {
-            let _guard = self.deps.lock.lock().await;
+            let _guard = self.deps.lock.acquire().await?;
             self.abort_locked(confirm_id).await
         });
         join.await.map_err(|_| {
@@ -1107,7 +1107,7 @@ impl ConfigTransactionController {
             ));
         }
         let join = tokio::spawn(async move {
-            let _guard = self.deps.lock.lock().await;
+            let _guard = self.deps.lock.acquire().await?;
             // Resolve the entry under the coordinator lock so a concurrent
             // commit cannot shift indexes between resolution and apply.
             let dir = self.history_dir()?;
@@ -1281,7 +1281,7 @@ impl ConfigTransactionController {
 
     async fn auto_revert(self, confirm_id: String) -> Result<(), ConfigTransactionApplyError> {
         let join = tokio::spawn(async move {
-            let _guard = self.deps.lock.lock().await;
+            let _guard = self.deps.lock.acquire().await?;
             let Some(pending) = self.pending_for_timeout(&confirm_id).await else {
                 return Ok(());
             };
@@ -1737,7 +1737,7 @@ async fn apply_config_transaction(
     validate_apply_request(&request)?;
 
     let join = tokio::spawn(async move {
-        let _guard = deps.lock.lock().await;
+        let _guard = deps.lock.acquire().await?;
         apply_config_transaction_locked(&deps, request, None)
             .await
             .map_err(|failure| failure.error)
@@ -1758,7 +1758,7 @@ async fn apply_config_transaction_with_internal(
 ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
     validate_apply_request(&request)?;
     let join = tokio::spawn(async move {
-        let _guard = deps.lock.lock().await;
+        let _guard = deps.lock.acquire().await?;
         apply_config_transaction_locked(&deps, request, Some(&peer_mgr_internal_tx))
             .await
             .map_err(|failure| failure.error)
@@ -3686,6 +3686,68 @@ remote_asn = 65002
         assert!(reload[..legacy].ends_with("#[cfg(test)]\n"));
     }
 
+    #[test]
+    fn runtime_config_coordinator_inventory_is_complete_and_closed() {
+        fn production(source: &'static str) -> &'static str {
+            source
+                .split_once("\n#[cfg(test)]\nmod tests")
+                .map_or(source, |v| v.0)
+        }
+
+        let server = production(include_str!("../crates/api/src/server.rs"));
+        let neighbor = production(include_str!("../crates/api/src/neighbor_service.rs"));
+        let peer_group = production(include_str!("../crates/api/src/peer_group_service.rs"));
+        let policy = production(include_str!("../crates/api/src/policy_service.rs"));
+        let fib = production(include_str!("fib_table_control.rs"));
+        let transaction = production(include_str!("config_transaction_control.rs"))
+            .split_once("\n#[cfg(test)]\nasync fn apply_config_transaction(")
+            .unwrap()
+            .0;
+        let main = production(include_str!("main.rs"));
+        let owners = [server, neighbor, peer_group, policy, fib, transaction, main];
+
+        #[rustfmt::skip]
+        let inventory = [
+            (main, "RuntimeConfigCoordinator::new()", 1),
+            (main, "\n                lock: runtime_config_lock.clone(),", 2),
+            (main, "runtime_config_lock: runtime_config_lock.clone(),", 1),
+            (main, "let Ok(_runtime_config_guard) = runtime_config_lock.acquire().await else {", 1),
+            (main, "tokio::time::timeout_at(deadline, runtime_config_lock.acquire()).await", 1),
+            (transaction, "self.deps.lock.acquire()", 6),
+            (fib, ".acquire()", 2),
+            (neighbor, "runtime_config_lock.acquire()", 4),
+            (server, "runtime_config_lock.acquire()", 1),
+            (peer_group, "run_shielded_catalog_mutation(", 1),
+            (policy, "run_shielded_catalog_mutation(", 1),
+            (peer_group, "self.run_mutation(", 4),
+            (policy, "self.run_mutation(", 12),
+        ];
+        for (source, shape, count) in inventory {
+            assert_eq!(source.matches(shape).count(), count, "{shape}");
+        }
+
+        #[rustfmt::skip]
+        let prohibited_apis = ["add_permits", "forget", "acquire_many", "wait_idle", "reopen", "pub fn reset", "impl Default for RuntimeConfigCoordinator"];
+        for prohibited in prohibited_apis {
+            assert!(!server.contains(prohibited), "{prohibited}");
+        }
+        assert_eq!(server.matches(".close();").count(), 1);
+        assert!(
+            owners[1..]
+                .iter()
+                .all(|source| !source.contains(".close();"))
+        );
+        let qualified_mutex = ["Arc<tokio::sync::Mutex<", "()>>"].concat();
+        let imported_mutex = ["Arc<Mutex<", "()>>"].concat();
+        for source in &owners[..6] {
+            assert!(!source.contains(&qualified_mutex));
+            assert!(!source.contains(&imported_mutex));
+        }
+        assert!(!main.contains(
+            "let runtime_config_lock = std::sync::Arc::new(tokio::sync::Mutex::new(()));"
+        ));
+    }
+
     /// LAN-910: the `[[dynamic_neighbors]]` executor commits by snapshot
     /// replacement, so this inventory comparison is its only listener fence —
     /// `delete_dynamic_range`'s per-range fence never runs for transactions.
@@ -5090,7 +5152,7 @@ peer_group = "{group}"
             peer_mgr_tx,
             rib_tx: None,
             config_tx,
-            lock: Arc::new(Mutex::new(())),
+            lock: rustbgpd_api::server::RuntimeConfigCoordinator::new(),
             config_mutation_gate: None,
             startup_tables,
             confirm_journal_path: None,
@@ -5114,8 +5176,8 @@ peer_group = "{group}"
 
     #[tokio::test(start_paused = true)]
     async fn apply_times_out_before_coordinator_ownership_without_mutation() {
-        let coordinator = Arc::new(Mutex::new(()));
-        let blocker = coordinator.lock().await;
+        let coordinator = rustbgpd_api::server::RuntimeConfigCoordinator::new();
+        let blocker = coordinator.acquire().await.expect("coordinator owner");
         let (peer_tx, mut peer_rx) = mpsc::channel(1);
         let (fib_tx, mut fib_rx) = mpsc::channel(1);
         let (rib_tx, mut rib_rx) = mpsc::channel(1);
@@ -5124,7 +5186,7 @@ peer_group = "{group}"
         let journal = runtime.path().join("commit-confirm-journal.json");
         let controller = ConfigTransactionController::new(
             FibTableControlDeps {
-                lock: Arc::clone(&coordinator),
+                lock: coordinator.clone(),
                 rib_tx: Some(rib_tx),
                 confirm_journal_path: Some(journal.clone()),
                 ..deps_value(Some(fib_tx), peer_tx, Some(config_tx), Vec::new())
@@ -5203,6 +5265,57 @@ peer_group = "{group}"
         assert!(fib_rx.try_recv().is_err());
         assert!(rib_rx.try_recv().is_err());
         assert!(config_rx.try_recv().is_err());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn apply_close_before_deadline_is_unavailable_without_mutation() {
+        let coordinator = rustbgpd_api::server::RuntimeConfigCoordinator::new();
+        let _owner = coordinator.acquire().await.expect("coordinator owner");
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        let (fib_tx, mut fib_rx) = mpsc::channel(1);
+        let (rib_tx, mut rib_rx) = mpsc::channel(1);
+        let (config_tx, mut config_rx) = mpsc::channel(1);
+        let runtime = tempfile::tempdir().unwrap();
+        let journal = runtime.path().join("commit-confirm-journal.json");
+        let controller = ConfigTransactionController::new(
+            FibTableControlDeps {
+                lock: coordinator.clone(),
+                rib_tx: Some(rib_tx),
+                confirm_journal_path: Some(journal.clone()),
+                ..deps_value(Some(fib_tx), peer_tx, Some(config_tx), Vec::new())
+            },
+            BgpMetrics::new(),
+        );
+        let apply = tokio::spawn(controller.clone().apply(confirmed_dynamic_request(
+            base_toml("[peer_groups.blocked]"),
+            "closed-apply",
+            60,
+        )));
+        tokio::task::yield_now().await;
+
+        tokio::time::advance(Duration::from_secs(599)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            !apply.is_finished(),
+            "apply ended before coordinator closure"
+        );
+        coordinator.close();
+        let error = apply.await.unwrap().unwrap_err();
+        assert!(
+            matches!(error, ConfigTransactionApplyError::Unavailable(ref message)
+                if message.contains("coordinator is closed")),
+            "{error:?}"
+        );
+        assert!(peer_rx.try_recv().is_err());
+        assert!(fib_rx.try_recv().is_err());
+        assert!(rib_rx.try_recv().is_err());
+        assert!(config_rx.try_recv().is_err());
+        assert!(!journal.exists());
+        let state = controller.state.lock().await;
+        assert!(state.applying_confirm_id.is_none());
+        assert!(state.pending.is_none());
+        assert!(state.last.is_none());
+        assert!(state.ambiguous_failure_confirm_id.is_none());
     }
 
     #[tokio::test]
@@ -6128,7 +6241,7 @@ families = ["ipv4_unicast"]
                 peer_mgr_tx: peer_tx,
                 rib_tx: None,
                 config_tx: Some(config_tx),
-                lock: Arc::new(Mutex::new(())),
+                lock: rustbgpd_api::server::RuntimeConfigCoordinator::new(),
                 config_mutation_gate: None,
                 startup_tables: vec![original],
                 confirm_journal_path: Some(journal.clone()),

--- a/src/fib_table_control.rs
+++ b/src/fib_table_control.rs
@@ -27,7 +27,7 @@ use std::fmt::Write as _;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 
 use rustbgpd_api::peer_types::{
     ConfigEvent, ConfigPersistAck, FibTableSnapshot, PeerManagerCommand,
@@ -36,7 +36,7 @@ use rustbgpd_api::proto;
 use rustbgpd_api::rib_service::{
     FibTableControlError, FibTableControlFn, FibTableControlFuture, FibTableControlRequest,
 };
-use rustbgpd_api::server::ConfigMutationGateFn;
+use rustbgpd_api::server::{ConfigMutationGateFn, RuntimeConfigCoordinator};
 use tracing::error;
 
 use crate::config::FibTableConfig;
@@ -45,6 +45,7 @@ use crate::fib_runtime::FibRuntimeCommand;
 /// How long to wait for a config-persistence permit before refusing the
 /// mutation (mirrors the dynamic-neighbor CRUD reserve deadline).
 const PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
+const COORDINATOR_CLOSED: &str = "runtime config coordinator is closed";
 
 /// Dependencies for the FIB-table control hook, wired from `main.rs`.
 pub struct FibTableControlDeps {
@@ -62,7 +63,7 @@ pub struct FibTableControlDeps {
     /// loads its config from a file, so it always supplies one.
     pub config_tx: Option<mpsc::Sender<ConfigEvent>>,
     /// Coordinator lock shared with the SIGHUP reload FIB step.
-    pub lock: Arc<Mutex<()>>,
+    pub lock: RuntimeConfigCoordinator,
     /// Optional confirmed config transaction gate. While a confirmed
     /// transaction is applying or pending confirmation, targeted FIB-table CRUD
     /// must fail closed so it cannot be overwritten by timeout rollback.
@@ -113,7 +114,11 @@ async fn handle(
 ) -> Result<proto::ListFibTablesResponse, FibTableControlError> {
     match request {
         FibTableControlRequest::List => {
-            let _guard = deps.lock.lock().await;
+            let _guard = deps
+                .lock
+                .acquire()
+                .await
+                .map_err(|_| FibTableControlError::Unavailable(COORDINATOR_CLOSED.into()))?;
             // A running reconciler is the source of truth; otherwise fall back
             // to the startup set so configured tables stay visible even when
             // the actor failed to spawn (non-Linux / netlink failure).
@@ -177,7 +182,10 @@ async fn mutate(
     // cannot split a successful `ReplaceTables` from its persistence: once the
     // task starts it runs to completion regardless of the awaiting future.
     let join = tokio::spawn(async move {
-        let _guard = lock.lock().await;
+        let _guard = lock
+            .acquire()
+            .await
+            .map_err(|_| FibTableControlError::Unavailable(COORDINATOR_CLOSED.into()))?;
         if let Some(gate) = &config_mutation_gate {
             gate(operation)
                 .await
@@ -564,6 +572,7 @@ mod tests {
     use rustbgpd_api::proto::rib_service_server::RibService as _;
     use rustbgpd_api::rib_service::RibService;
     use rustbgpd_api::server::AccessMode;
+    use tokio::sync::Mutex;
     use tonic::{Code, Request, Status};
 
     use crate::test_support::basic_fib_table as table;
@@ -655,7 +664,7 @@ mod tests {
             peer_mgr_tx,
             rib_tx: None,
             config_tx: Some(config_tx),
-            lock: Arc::new(Mutex::new(())),
+            lock: RuntimeConfigCoordinator::new(),
             config_mutation_gate: None,
             startup_tables,
             confirm_journal_path: None,
@@ -663,6 +672,47 @@ mod tests {
         });
         let (rib_tx, _rib_rx) = mpsc::channel(1);
         RibService::new(rib_tx).with_fib_table_control(AccessMode::ReadWrite, Some(control))
+    }
+
+    #[tokio::test]
+    async fn closed_coordinator_rejects_fib_before_actor_or_persistence() {
+        let (fib_tx, mut fib_rx) = mpsc::channel(1);
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        let (config_tx, mut config_rx) = mpsc::channel(1);
+        let coordinator = RuntimeConfigCoordinator::new();
+        coordinator.close();
+        let deps = Arc::new(FibTableControlDeps {
+            fib_cmd_tx: Some(fib_tx),
+            peer_mgr_tx: peer_tx,
+            rib_tx: None,
+            config_tx: Some(config_tx),
+            lock: coordinator,
+            config_mutation_gate: None,
+            startup_tables: vec![table("edge", 1000)],
+            confirm_journal_path: None,
+            config_history_dir: None,
+        });
+
+        let list_error = handle(deps.clone(), FibTableControlRequest::List)
+            .await
+            .unwrap_err();
+        assert!(matches!(list_error, FibTableControlError::Unavailable(_)));
+        let set_error = mutate(deps.clone(), Mutation::Upsert(table("core", 1001)))
+            .await
+            .unwrap_err();
+        assert!(matches!(set_error, FibTableControlError::Unavailable(_)));
+        assert!(matches!(
+            fib_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+        assert!(matches!(
+            peer_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+        assert!(matches!(
+            config_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
     }
 
     fn assert_actor_read_error(status: &Status, code: Code, failure: ReadFailure) {
@@ -800,7 +850,7 @@ mod tests {
             peer_mgr_tx: peer_tx,
             rib_tx: None,
             config_tx: Some(config_tx),
-            lock: Arc::new(Mutex::new(())),
+            lock: RuntimeConfigCoordinator::new(),
             config_mutation_gate: None,
             startup_tables: vec![original.clone()],
             confirm_journal_path: None,
@@ -871,7 +921,7 @@ mod tests {
             peer_mgr_tx: peer_tx,
             rib_tx: None,
             config_tx: Some(config_tx),
-            lock: Arc::new(Mutex::new(())),
+            lock: RuntimeConfigCoordinator::new(),
             config_mutation_gate: None,
             startup_tables: vec![original.clone()],
             confirm_journal_path: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ use rustbgpd_api::peer_types::{
 };
 use rustbgpd_api::server::{
     AccessMode as GrpcServerAccessMode, ConfigMutationGateFn, ListenerConfig as GrpcListenerConfig,
-    ListenerEndpoint, ServeConfig,
+    ListenerEndpoint, RuntimeConfigCoordinator, ServeConfig,
 };
 use rustbgpd_wire::{Afi, Safi};
 
@@ -4467,7 +4467,7 @@ async fn run<T>(
     // catalog CRUD, and the SIGHUP reload path hold it across their
     // read/apply/persist sequence so stale TOML snapshots cannot clobber
     // accepted runtime changes.
-    let runtime_config_lock = std::sync::Arc::new(tokio::sync::Mutex::new(()));
+    let runtime_config_lock = RuntimeConfigCoordinator::new();
     let config_transaction_controller =
         config_transaction_control::ConfigTransactionController::new_accepted(
             fib_table_control::FibTableControlDeps {
@@ -5045,7 +5045,10 @@ async fn run<T>(
                 let accepted_rx = accepted_rx.clone();
                 let live_bindings = config.policy.dataset_bindings.clone();
                 reload_in_flight = Some(tokio::spawn(async move {
-                    let _runtime_config_guard = runtime_config_lock.lock().await;
+                    let Ok(_runtime_config_guard) = runtime_config_lock.acquire().await else {
+                        error!("SIGHUP reload rejected: runtime config coordinator is closed");
+                        return None;
+                    };
                     if let Err(error) = config_transaction_controller
                         .reject_if_pending("SIGHUP reload")
                         .await
@@ -5208,8 +5211,12 @@ async fn run<T>(
     if warm_checkpoint_on_shutdown {
         if let Some(directory) = warm_bundle_directory.clone() {
             let deadline = tokio::time::Instant::now() + WARM_CHECKPOINT_DEADLINE;
-            match tokio::time::timeout_at(deadline, runtime_config_lock.lock()).await {
-                Ok(guard) => _runtime_config_fence = Some(guard),
+            match tokio::time::timeout_at(deadline, runtime_config_lock.acquire()).await {
+                Ok(Ok(guard)) => _runtime_config_fence = Some(guard),
+                Ok(Err(_)) => {
+                    checkpoint_failure =
+                        Some("authoritative runtime-config coordinator is closed".to_string());
+                }
                 Err(_) => {
                     checkpoint_failure = Some(
                         "timed out acquiring the authoritative runtime-config fence".to_string(),

--- a/src/peer_manager/tests/persistence.rs
+++ b/src/peer_manager/tests/persistence.rs
@@ -202,13 +202,13 @@ hold_time = 90
         );
         tokio::spawn(mgr.run());
 
-        let service = rustbgpd_api::NeighborService::with_runtime_config_lock(
+        let service = rustbgpd_api::NeighborService::with_runtime_config_coordinator(
             65001,
             rustbgpd_api::server::AccessMode::ReadWrite,
             peer_mgr_tx.clone(),
             rib_tx,
             Some(event_tx),
-            Arc::new(tokio::sync::Mutex::new(())),
+            rustbgpd_api::server::RuntimeConfigCoordinator::new(),
             None,
         );
 


### PR DESCRIPTION
## Summary

- replace the daemon-wide runtime-config mutex with an opaque one-permit closeable coordinator
- migrate every persisted mutation producer while preserving FIFO serialization and the existing ten-minute Apply acquisition bound
- prove closure wakes/rejects queued and future work without revoking the active owner or reopening after release

## Why

ADR-0127 needs an atomic way to fence queued and future persisted mutations without releasing or overlapping the current transaction owner. A side-band flag around the old mutex has a check/acquire race; the closeable coordinator provides the safe foundation. This PR does not call close in production and does not activate watchdog or fail-stop behavior.

## Validation

- coordinator FIFO, active-owner, queued/future close, idempotence, and no-reopen tests
- closed catalog, Neighbor, FIB, and Apply no-work tests
- Apply 9:59-close Unavailable and retained exact 10:00 DeadlineExceeded proofs
- exhaustive source inventory with destructive producer-route mutations
- rustbgpd-api 612 tests; rustbgpd 1,931 tests plus integrations; full workspace tests
- workspace all-target Clippy with warnings denied
- fmt, clippy-reasons, v1 stable-surface, diff/scope/cap checks