### PR TITLE
fix: detach terminal v3 residue cleanup

### DIFF
--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -6,6 +6,7 @@
 
 use std::fmt::Write as _;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use tokio::sync::{Mutex, mpsc, oneshot, watch};
@@ -60,6 +61,9 @@ pub struct ConfigTransactionController {
     accepted_rx: Option<watch::Receiver<Arc<AcceptedConfigSnapshot>>>,
     peer_mgr_internal_tx: Option<mpsc::UnboundedSender<InternalCommand>>,
     confirm_v3_launch: Option<crate::confirm_journal::v3::LaunchIdentity>,
+    v3_residue_cleanup_active: Arc<AtomicBool>,
+    #[cfg(test)]
+    v3_residue_cleanup_spawn_fail: Arc<AtomicBool>,
 }
 
 #[derive(Default)]
@@ -130,6 +134,8 @@ impl ConfigTransactionController {
             accepted_rx: None,
             peer_mgr_internal_tx: None,
             confirm_v3_launch: None,
+            v3_residue_cleanup_active: Arc::new(AtomicBool::new(false)),
+            v3_residue_cleanup_spawn_fail: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -146,6 +152,9 @@ impl ConfigTransactionController {
             accepted_rx: Some(accepted_rx),
             peer_mgr_internal_tx: None,
             confirm_v3_launch: None,
+            v3_residue_cleanup_active: Arc::new(AtomicBool::new(false)),
+            #[cfg(test)]
+            v3_residue_cleanup_spawn_fail: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -832,17 +841,17 @@ impl ConfigTransactionController {
         // timer stay armed — a leftover journal would boot-revert a config
         // the operator explicitly confirmed.
         let matched = self.matching_pending(&confirm_id).await?;
-        if let Some(files) = &matched.v3_files {
-            let residue_cleanup_failed = files.terminal_cleanup().map_err(|error| {
+        let residue_cleanup = if let Some(files) = &matched.v3_files {
+            files.remove_locator_authority().map_err(|error| {
                 ConfigTransactionApplyError::Internal(format!(
                     "confirm not recorded: durable v3 locator removal failed ({:?}); the transaction is still pending and will roll back on timeout",
                     error.kind()
                 ))
             })?;
-            if residue_cleanup_failed {
-                warn!("confirmed transaction is terminal, but exact v3 residue cleanup failed");
-            }
-        }
+            self.claim_v3(files, "confirmed transaction")
+        } else {
+            None
+        };
         let pending = self.take_matching_pending(&confirm_id).await?;
         let record = ConfirmedTransactionRecord {
             confirm_id: pending.confirm_id,
@@ -855,6 +864,7 @@ impl ConfigTransactionController {
         };
         let confirmation = record_confirmation_proto(&record);
         self.set_last_record(record).await;
+        self.hand_off_v3(residue_cleanup, "confirmed transaction");
         self.metrics
             .record_config_transaction_lifecycle("confirm", "success");
         Ok(proto::ConfirmConfigTransactionResponse {
@@ -1446,14 +1456,15 @@ impl ConfigTransactionController {
         let Some(files) = files else {
             return Ok(());
         };
-        match files.terminal_cleanup() {
-            Ok(residue_cleanup_failed) => {
-                if residue_cleanup_failed {
-                    warn!(
-                        context,
-                        "v3 locator is durably absent, but exact pending residue cleanup failed"
-                    );
+        match files.remove_locator_authority() {
+            Ok(()) => {
+                let cleanup = self.claim_v3(files, context);
+                let mut state = self.state.lock().await;
+                if state.applying_confirm_id.as_deref() == Some(confirm_id) {
+                    state.applying_confirm_id = None;
                 }
+                drop(state);
+                self.hand_off_v3(cleanup, context);
                 Ok(())
             }
             Err(error) => {
@@ -1481,17 +1492,17 @@ impl ConfigTransactionController {
         abort_timer: bool,
     ) -> Result<(), ConfigTransactionApplyError> {
         let matched = self.matching_pending(confirm_id).await?;
-        if let Some(files) = &matched.v3_files {
-            let residue_cleanup_failed = files.terminal_cleanup().map_err(|error| {
+        let residue_cleanup = if let Some(files) = &matched.v3_files {
+            files.remove_locator_authority().map_err(|error| {
                 ConfigTransactionApplyError::Internal(format!(
                     "rollback restored the prior config but remains nonterminal because durable v3 locator removal failed ({:?})",
                     error.kind()
                 ))
             })?;
-            if residue_cleanup_failed {
-                warn!("rollback is terminal, but exact v3 residue cleanup failed");
-            }
-        }
+            self.claim_v3(files, "confirmed rollback")
+        } else {
+            None
+        };
         let mut state = self.state.lock().await;
         let Some(pending) = state.pending.take() else {
             return Ok(());
@@ -1513,7 +1524,58 @@ impl ConfigTransactionController {
             runtime_snapshot_token,
             human_text: human_text.to_string(),
         });
+        drop(state);
+        self.hand_off_v3(residue_cleanup, "confirmed rollback");
         Ok(())
+    }
+
+    fn claim_v3(
+        &self,
+        files: &crate::confirm_journal::v3::PendingFiles,
+        context: &'static str,
+    ) -> Option<V3Handoff> {
+        let active = Arc::clone(&self.v3_residue_cleanup_active);
+        if active
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            warn!(context, "v3 terminal residue cleanup is already active");
+            return None;
+        }
+        let reservation = V3Reservation(active);
+        let (cleanup, failed) = files.claim_terminal_residue();
+        failed.then(|| warn!(context, "v3 terminal residue claim was incomplete"));
+        cleanup.map(|cleanup| (cleanup, reservation))
+    }
+
+    fn hand_off_v3(&self, handoff: Option<V3Handoff>, context: &'static str) {
+        let Some((cleanup, reservation)) = handoff else {
+            return;
+        };
+        debug_assert!(self.v3_residue_cleanup_active.load(Ordering::Acquire));
+        #[cfg(test)]
+        if self
+            .v3_residue_cleanup_spawn_fail
+            .swap(false, Ordering::AcqRel)
+        {
+            warn!(context, "v3 residue cleanup could not start");
+            return;
+        }
+        if let Err(error) = std::thread::Builder::new()
+            .name("rustbgpd-v3-cleanup".to_string())
+            .spawn(move || {
+                let _reservation = reservation;
+                if cleanup.cleanup() {
+                    warn!(context, "v3 residue cleanup failed");
+                }
+            })
+        {
+            warn!(
+                context,
+                error_kind = ?error.kind(),
+                "v3 locator is durably absent, but residue cleanup could not start"
+            );
+        }
     }
 
     /// LAN-277: record a FAILED abort/auto-revert rollback on the still-pending
@@ -1560,6 +1622,19 @@ impl ConfigTransactionController {
             .last
             .as_ref()
             .map(record_confirmation_proto)
+    }
+}
+
+type V3Handoff = (
+    crate::confirm_journal::v3::TerminalResidueCleanup,
+    V3Reservation,
+);
+
+struct V3Reservation(Arc<AtomicBool>);
+
+impl Drop for V3Reservation {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
     }
 }
 
@@ -6404,12 +6479,7 @@ families = ["ipv4_unicast"]
             harness.seen_preloaded.lock().await.as_ref().unwrap()
         ));
         assert_eq!(*harness.fib_state.lock().await, vec![table("edge", 1000)]);
-        assert!(
-            !harness.locator.exists()
-                && !harness.metadata.exists()
-                && !harness.raw.exists()
-                && !harness.journal.exists()
-        );
+        assert!(!harness.locator.exists() && !harness.journal.exists());
         harness.ack_task.abort();
     }
 
@@ -6502,6 +6572,184 @@ families = ["ipv4_unicast"]
         assert!(!harness.locator.exists());
         assert!(!harness.journal.exists());
         assert_eq!(*harness.fib_state.lock().await, vec![table("core", 1001)]);
+        harness.ack_task.abort();
+    }
+
+    #[tokio::test]
+    async fn v3_locator_sync_failure_keeps_confirm_pending_until_retry() {
+        let harness = external_fib_harness(60, None).await;
+        let files = harness
+            .controller
+            .state
+            .lock()
+            .await
+            .pending
+            .as_ref()
+            .unwrap()
+            .v3_files
+            .clone()
+            .unwrap();
+        files.fail_locator_directory_sync_once_for_test();
+        assert!(
+            harness
+                .controller
+                .clone()
+                .confirm(proto::ConfirmConfigTransactionRequest {
+                    confirm_id: "external-fib".to_string(),
+                })
+                .await
+                .is_err()
+        );
+        assert!(harness.controller.state.lock().await.pending.is_some());
+        assert!(!harness.locator.exists());
+        assert!(harness.raw.exists() && harness.metadata.exists());
+
+        harness
+            .controller
+            .clone()
+            .confirm(proto::ConfirmConfigTransactionRequest {
+                confirm_id: "external-fib".to_string(),
+            })
+            .await
+            .expect("retry must record terminal confirmation");
+        assert!(harness.controller.state.lock().await.pending.is_none());
+        harness.ack_task.abort();
+    }
+
+    #[tokio::test]
+    async fn stalled_v3_residue_cleanup_releases_terminal_paths_and_is_singleton() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let harness = external_fib_harness(60, None).await;
+        let files = harness
+            .controller
+            .state
+            .lock()
+            .await
+            .pending
+            .as_ref()
+            .unwrap()
+            .v3_files
+            .clone()
+            .unwrap();
+        let stall = crate::confirm_journal::v3::ResidueCleanupStall::default();
+        files.stall_residue_cleanup_for_test(stall.clone());
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            harness
+                .controller
+                .clone()
+                .confirm(proto::ConfirmConfigTransactionRequest {
+                    confirm_id: "external-fib".to_string(),
+                }),
+        )
+        .await
+        .expect("residue cleanup must not delay confirm")
+        .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !stall.started() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("detached residue cleanup must start");
+        assert!(!harness.locator.exists());
+        assert!(!harness.raw.exists() && !harness.metadata.exists());
+        assert!(harness.controller.state.lock().await.pending.is_none());
+        harness
+            .controller
+            .reject_if_pending("ordinary or streamed config mutation")
+            .await
+            .expect("terminal state must reopen config admission");
+        let _coordinator = tokio::time::timeout(
+            Duration::from_secs(1),
+            harness.controller.deps.lock.acquire(),
+        )
+        .await
+        .expect("cleanup must not retain the coordinator")
+        .unwrap();
+        assert!(
+            harness
+                .controller
+                .v3_residue_cleanup_active
+                .load(Ordering::Acquire)
+        );
+
+        let second_root = tempfile::tempdir().unwrap();
+        let second_state = second_root.path().join("state");
+        std::fs::create_dir(&second_state).unwrap();
+        std::fs::set_permissions(second_root.path(), std::fs::Permissions::from_mode(0o700))
+            .unwrap();
+        std::fs::set_permissions(&second_state, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let second_config = second_root.path().join("rustbgpd.toml");
+        std::fs::write(&second_config, base_toml("")).unwrap();
+        let second_prior = AcceptedConfigSnapshot::load(&second_config, None).unwrap();
+        let second_launch =
+            crate::confirm_journal::v3::LaunchIdentity::resolve(&second_config).unwrap();
+        let second_files = second_launch
+            .publish(&second_state, "second", 9, &second_prior)
+            .unwrap();
+        second_files.remove_locator_authority().unwrap();
+        let second_handoff = harness
+            .controller
+            .claim_v3(&second_files, "second terminal transaction");
+        assert!(second_handoff.is_none());
+        let residue = [
+            crate::confirm_journal::v3::RAW_FILE_NAME,
+            crate::confirm_journal::v3::METADATA_FILE_NAME,
+        ];
+        assert!(residue.iter().all(|name| second_state.join(name).exists()));
+
+        let cleanup_active = Arc::clone(&harness.controller.v3_residue_cleanup_active);
+        harness.ack_task.abort();
+        let drop_started = std::time::Instant::now();
+        drop(harness.controller);
+        assert!(drop_started.elapsed() < Duration::from_secs(1));
+        stall.release();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while cleanup_active.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("detached cleanup must finish after release");
+    }
+
+    #[tokio::test]
+    async fn residue_thread_spawn_failure_is_terminal_and_releases_singleton() {
+        let harness = external_fib_harness(60, None).await;
+        harness
+            .controller
+            .v3_residue_cleanup_spawn_fail
+            .store(true, Ordering::Release);
+        harness
+            .controller
+            .clone()
+            .confirm(proto::ConfirmConfigTransactionRequest {
+                confirm_id: "external-fib".to_string(),
+            })
+            .await
+            .expect("thread spawn failure must be terminal warning-only");
+        assert!(!harness.locator.exists());
+        assert!(harness.controller.state.lock().await.pending.is_none());
+        assert!(
+            !harness
+                .controller
+                .v3_residue_cleanup_active
+                .load(Ordering::Acquire)
+        );
+        assert!(!harness.raw.exists() && !harness.metadata.exists());
+        assert!(
+            harness
+                .raw
+                .with_file_name("commit-confirm-v3-prior.cleanup")
+                .exists()
+                || harness
+                    .metadata
+                    .with_file_name("commit-confirm-v3-metadata.cleanup")
+                    .exists()
+        );
         harness.ack_task.abort();
     }
 

--- a/src/confirm_journal/v3.rs
+++ b/src/confirm_journal/v3.rs
@@ -15,6 +15,9 @@ use std::os::unix::fs::MetadataExt as _;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+#[cfg(test)]
+use std::sync::{Condvar, atomic::AtomicBool, atomic::Ordering};
+
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
@@ -33,6 +36,8 @@ const RETIRED_V2_LOCATOR: &str = "retired v2 commit-confirm locator";
 const RETIRED_LOCATOR_FREE_AUTHORITY: &str = "retired locator-free commit-confirm authority exists; recover it with rustbgpd v0.64.0, or delete it only after proving the transaction is terminal and the current config is intended; the artifact was left untouched";
 pub(crate) const RAW_FILE_NAME: &str = "commit-confirm-v3-prior.toml";
 pub(crate) const METADATA_FILE_NAME: &str = "commit-confirm-v3-metadata.json";
+const RAW_TOMBSTONE_NAME: &str = "commit-confirm-v3-prior.cleanup";
+const METADATA_TOMBSTONE_NAME: &str = "commit-confirm-v3-metadata.cleanup";
 
 const fn normalized_prior_length_within_limit(length: usize, limit: usize) -> bool {
     length <= limit
@@ -348,10 +353,15 @@ impl LaunchIdentity {
                 locator_identity,
                 metadata_wire,
                 metadata_identity,
+                metadata_sha256: Sha256::digest(&metadata_bytes).into(),
                 raw_identity,
                 locator_phase: CleanupPhase::Published,
-                metadata_phase: CleanupPhase::Published,
-                raw_phase: CleanupPhase::Published,
+                #[cfg(test)]
+                fail_locator_directory_sync_once: false,
+                #[cfg(test)]
+                fail_metadata_clone_once: false,
+                #[cfg(test)]
+                residue_cleanup_stall: None,
             }),
         })
     }
@@ -454,10 +464,15 @@ struct PendingState {
     locator_identity: FileIdentity,
     metadata_wire: Metadata,
     metadata_identity: FileIdentity,
+    metadata_sha256: [u8; 32],
     raw_identity: FileIdentity,
     locator_phase: CleanupPhase,
-    metadata_phase: CleanupPhase,
-    raw_phase: CleanupPhase,
+    #[cfg(test)]
+    fail_locator_directory_sync_once: bool,
+    #[cfg(test)]
+    fail_metadata_clone_once: bool,
+    #[cfg(test)]
+    residue_cleanup_stall: Option<ResidueCleanupStall>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -468,9 +483,7 @@ enum CleanupPhase {
 }
 
 impl PendingFiles {
-    /// Durably remove locator authority first. Fixed residue cleanup after
-    /// that terminal point is warning-only and never re-arms authority.
-    pub(crate) fn terminal_cleanup(&self) -> io::Result<bool> {
+    pub(crate) fn remove_locator_authority(&self) -> io::Result<()> {
         let mut state = self
             .state
             .lock()
@@ -481,32 +494,77 @@ impl PendingFiles {
             state.locator_phase = CleanupPhase::Unlinked;
         }
         if state.locator_phase == CleanupPhase::Unlinked {
+            #[cfg(test)]
+            if std::mem::take(&mut state.fail_locator_directory_sync_once) {
+                return Err(io::Error::other("injected locator-directory sync failure"));
+            }
             self.locator.directory.file.sync_all()?;
             state.locator_phase = CleanupPhase::Synced;
         }
-        let residue_result: io::Result<()> = (|| {
-            if state.metadata_phase == CleanupPhase::Published {
-                self.metadata
-                    .verify_metadata(state.metadata_identity, &state.metadata_wire)?;
-                self.metadata.remove_matching(state.metadata_identity)?;
-                state.metadata_phase = CleanupPhase::Unlinked;
-            }
-            if state.raw_phase == CleanupPhase::Published {
-                self.raw
-                    .verify_raw(state.raw_identity, &state.metadata_wire)?;
-                self.raw.remove_matching(state.raw_identity)?;
-                state.raw_phase = CleanupPhase::Unlinked;
-            }
-            if state.metadata_phase == CleanupPhase::Unlinked
-                || state.raw_phase == CleanupPhase::Unlinked
-            {
-                self.metadata.directory.file.sync_all()?;
-                state.metadata_phase = CleanupPhase::Synced;
-                state.raw_phase = CleanupPhase::Synced;
-            }
-            Ok(())
-        })();
-        Ok(residue_result.is_err())
+        Ok(())
+    }
+
+    pub(crate) fn claim_terminal_residue(&self) -> (Option<TerminalResidueCleanup>, bool) {
+        let state = match self.state.lock() {
+            Ok(state) if state.locator_phase == CleanupPhase::Synced => state,
+            _ => return (None, true),
+        };
+        #[cfg(test)]
+        let fail_metadata_clone = state.fail_metadata_clone_once;
+        let claim = |source: &Entry, target, identity, cap, sha256| {
+            source
+                .rename_to(target)
+                .and_then(|claimed| {
+                    #[cfg(test)]
+                    if fail_metadata_clone && target == METADATA_TOMBSTONE_NAME {
+                        Err(io::Error::other("injected tombstone clone failure"))
+                    } else {
+                        claimed.detached_capability()
+                    }
+                    #[cfg(not(test))]
+                    claimed.detached_capability()
+                })
+                .map(|entry| ClaimedResidue(entry, identity, cap, sha256))
+                .ok()
+        };
+        let m = claim(
+            &self.metadata,
+            METADATA_TOMBSTONE_NAME,
+            state.metadata_identity,
+            MAX_METADATA_BYTES,
+            state.metadata_sha256,
+        );
+        let r = claim(
+            &self.raw,
+            RAW_TOMBSTONE_NAME,
+            state.raw_identity,
+            MAX_RAW_BYTES,
+            state.metadata_wire.raw_sha256,
+        );
+        let failed = m.is_none() | r.is_none() | self.metadata.directory.file.sync_all().is_err();
+        (
+            Some(TerminalResidueCleanup {
+                residue: [m, r],
+                #[cfg(test)]
+                stall: state.residue_cleanup_stall.clone(),
+            }),
+            failed,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_locator_directory_sync_once_for_test(&self) {
+        self.state.lock().unwrap().fail_locator_directory_sync_once = true;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_metadata_clone_once_for_test(&self) {
+        self.state.lock().unwrap().fail_metadata_clone_once = true;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn stall_residue_cleanup_for_test(&self, stall: ResidueCleanupStall) {
+        self.state.lock().unwrap().residue_cleanup_stall = Some(stall);
     }
 
     /// Replace compact metadata only; locator linkage deliberately excludes
@@ -516,10 +574,7 @@ impl PendingFiles {
             .state
             .lock()
             .map_err(|_| invalid("pending metadata state is unavailable"))?;
-        if state.locator_phase != CleanupPhase::Published
-            || state.metadata_phase != CleanupPhase::Published
-            || state.raw_phase != CleanupPhase::Published
-        {
+        if state.locator_phase != CleanupPhase::Published {
             return Err(invalid("pending cleanup has already started"));
         }
         self.locator.verify_locator(&state.locator_wire)?;
@@ -533,7 +588,69 @@ impl PendingFiles {
         let identity = self.metadata.replace(&bytes)?;
         state.metadata_wire = updated;
         state.metadata_identity = identity;
+        state.metadata_sha256 = Sha256::digest(&bytes).into();
         Ok(())
+    }
+}
+
+struct ClaimedResidue(Entry, FileIdentity, usize, [u8; 32]);
+
+pub(crate) struct TerminalResidueCleanup {
+    residue: [Option<ClaimedResidue>; 2],
+    #[cfg(test)]
+    stall: Option<ResidueCleanupStall>,
+}
+
+impl TerminalResidueCleanup {
+    pub(crate) fn cleanup(self) -> bool {
+        #[cfg(test)]
+        if let Some(stall) = &self.stall {
+            stall.block();
+        }
+        let [metadata, raw] = self.residue;
+        metadata.is_some_and(ClaimedResidue::cleanup_failed)
+            | raw.is_some_and(ClaimedResidue::cleanup_failed)
+    }
+}
+
+impl ClaimedResidue {
+    fn cleanup_failed(self) -> bool {
+        let Ok((bytes, identity)) = self.0.read_bounded(self.2) else {
+            return true;
+        };
+        identity != self.1
+            || <[u8; 32]>::from(Sha256::digest(&bytes)) != self.3
+            || self.0.remove_matching(self.1).is_err()
+            || self.0.directory.file.sync_all().is_err()
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ResidueCleanupStall {
+    started: Arc<AtomicBool>,
+    release: Arc<(Mutex<bool>, Condvar)>,
+}
+
+#[cfg(test)]
+impl ResidueCleanupStall {
+    fn block(&self) {
+        self.started.store(true, Ordering::Release);
+        let (lock, ready) = &*self.release;
+        let mut released = lock.lock().unwrap();
+        while !*released {
+            released = ready.wait(released).unwrap();
+        }
+    }
+
+    pub(crate) fn started(&self) -> bool {
+        self.started.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn release(&self) {
+        let (lock, ready) = &*self.release;
+        *lock.lock().unwrap() = true;
+        ready.notify_all();
     }
 }
 
@@ -798,6 +915,30 @@ impl Entry {
         self.directory.real_path.join(&self.name)
     }
 
+    fn detached_capability(&self) -> io::Result<Self> {
+        Ok(Self {
+            directory: Arc::new(Directory {
+                file: self.directory.file.try_clone()?,
+                real_path: PathBuf::new(),
+            }),
+            name: self.name.clone(),
+        })
+    }
+
+    fn rename_to(&self, target: &str) -> io::Result<Self> {
+        use nix::fcntl::{RenameFlags, renameat2};
+
+        renameat2(
+            &self.directory.file,
+            Path::new(&self.name),
+            &self.directory.file,
+            Path::new(target),
+            RenameFlags::RENAME_NOREPLACE,
+        )
+        .map_err(errno)?;
+        Ok(Self::fixed(Arc::clone(&self.directory), target))
+    }
+
     fn stage_name(&self) -> io::Result<OsString> {
         append_name(&self.name, b".tmp")
     }
@@ -1018,6 +1159,9 @@ fn cleanup_created(entry: &Entry, identity: FileIdentity) {
 }
 
 fn cleanup_locator_absent_residue_pinned(pending: &Arc<Directory>) -> io::Result<()> {
+    remove_named_safe(&pending.file, OsStr::new(METADATA_TOMBSTONE_NAME))?;
+    remove_named_safe(&pending.file, OsStr::new(RAW_TOMBSTONE_NAME))?;
+    pending.file.sync_all()?;
     let metadata = Entry::fixed(Arc::clone(pending), METADATA_FILE_NAME);
     let raw = Entry::fixed(Arc::clone(pending), RAW_FILE_NAME);
     let metadata_read = metadata.read_bounded(MAX_METADATA_BYTES);
@@ -1478,6 +1622,174 @@ log_format = "json"
             .unwrap_err();
         assert!(!error.authority_retained());
         assert_eq!(fs::read(&fixture.raw).unwrap(), b"replacement");
+    }
+
+    #[test]
+    fn locator_durability_precedes_every_residue_claim() {
+        let fixture = fixture();
+        let files = fixture
+            .launch
+            .publish(&fixture.state, "deploy-1", 9, &fixture.prior)
+            .unwrap();
+        files.fail_locator_directory_sync_once_for_test();
+        assert!(files.remove_locator_authority().is_err());
+        assert!(!fixture.launch.locator_path().exists());
+        assert!(fixture.metadata.exists() && fixture.raw.exists());
+        let premature = files.claim_terminal_residue();
+        assert!(premature.1 && premature.0.is_none());
+        assert!(!fixture.state.join(METADATA_TOMBSTONE_NAME).exists());
+        assert!(!fixture.state.join(RAW_TOMBSTONE_NAME).exists());
+
+        files
+            .remove_locator_authority()
+            .expect("retry must establish durable terminal authority state");
+        let (cleanup, failed) = files.claim_terminal_residue();
+        assert!(!failed);
+        assert!(!cleanup.unwrap().cleanup());
+        assert!(!fixture.metadata.exists() && !fixture.raw.exists());
+    }
+
+    #[test]
+    fn delayed_terminal_cleanup_cannot_delete_successor_publication() {
+        let fixture = fixture();
+        let old = fixture
+            .launch
+            .publish(&fixture.state, "deploy-1", 9, &fixture.prior)
+            .unwrap();
+        old.remove_locator_authority().unwrap();
+        let delayed = old.claim_terminal_residue().0.unwrap();
+        let successor = fixture
+            .launch
+            .publish(&fixture.state, "deploy-1", 9, &fixture.prior)
+            .unwrap();
+        let raw_before = fs::read(&fixture.raw).unwrap();
+        let metadata_before = fs::read(&fixture.metadata).unwrap();
+        let raw_identity = FileIdentity::from_metadata(&fs::metadata(&fixture.raw).unwrap());
+        let metadata_identity =
+            FileIdentity::from_metadata(&fs::metadata(&fixture.metadata).unwrap());
+
+        assert!(delayed.cleanup());
+        assert!(fixture.launch.locator_path().exists());
+        assert_eq!(fs::read(&fixture.raw).unwrap(), raw_before);
+        assert_eq!(fs::read(&fixture.metadata).unwrap(), metadata_before);
+        assert_eq!(
+            FileIdentity::from_metadata(&fs::metadata(&fixture.raw).unwrap()),
+            raw_identity
+        );
+        assert_eq!(
+            FileIdentity::from_metadata(&fs::metadata(&fixture.metadata).unwrap()),
+            metadata_identity
+        );
+
+        successor.remove_locator_authority().unwrap();
+        assert!(!successor.claim_terminal_residue().0.unwrap().cleanup());
+    }
+
+    #[test]
+    fn terminal_cleanup_refuses_tombstone_content_change() {
+        let fixture = fixture();
+        let files = fixture
+            .launch
+            .publish(&fixture.state, "deploy-1", 9, &fixture.prior)
+            .unwrap();
+        files.remove_locator_authority().unwrap();
+        let cleanup = files.claim_terminal_residue().0.unwrap();
+        let metadata_tombstone = fixture.state.join(METADATA_TOMBSTONE_NAME);
+        let mut changed = fs::read(&metadata_tombstone).unwrap();
+        changed[0] ^= 1;
+        fs::write(&metadata_tombstone, changed).unwrap();
+        let raw_tombstone = fixture.state.join(RAW_TOMBSTONE_NAME);
+        let raw = fs::read(&raw_tombstone).unwrap();
+        let replacement = fixture.state.join("identity-replacement");
+        fs::write(&replacement, raw).unwrap();
+        fs::set_permissions(&replacement, fs::Permissions::from_mode(0o600)).unwrap();
+        fs::rename(replacement, &raw_tombstone).unwrap();
+        assert!(cleanup.cleanup());
+        assert!(metadata_tombstone.exists());
+        assert!(raw_tombstone.exists());
+    }
+
+    #[test]
+    fn tombstone_collision_is_no_clobber_and_partial_claim_is_bounded() {
+        let collision = fixture();
+        let files = collision
+            .launch
+            .publish(&collision.state, "deploy-1", 9, &collision.prior)
+            .unwrap();
+        files.remove_locator_authority().unwrap();
+        let metadata_tombstone = collision.state.join(METADATA_TOMBSTONE_NAME);
+        fs::write(&metadata_tombstone, b"collision sentinel").unwrap();
+        fs::set_permissions(&metadata_tombstone, fs::Permissions::from_mode(0o600)).unwrap();
+
+        let (cleanup, failed) = files.claim_terminal_residue();
+        assert!(failed);
+        assert_eq!(
+            fs::read(&metadata_tombstone).unwrap(),
+            b"collision sentinel"
+        );
+        assert!(collision.metadata.exists(), "colliding fixed residue moved");
+        assert!(
+            !collision.raw.exists(),
+            "raw half was not atomically claimed"
+        );
+        assert!(!cleanup.unwrap().cleanup());
+        assert!(!collision.state.join(RAW_TOMBSTONE_NAME).exists());
+
+        let clone_failure = fixture();
+        let files = clone_failure
+            .launch
+            .publish(
+                &clone_failure.state,
+                "clone-failure",
+                9,
+                &clone_failure.prior,
+            )
+            .unwrap();
+        files.remove_locator_authority().unwrap();
+        files.fail_metadata_clone_once_for_test();
+        let (cleanup, failed) = files.claim_terminal_residue();
+        assert!(failed);
+        assert!(clone_failure.state.join(METADATA_TOMBSTONE_NAME).exists());
+        assert!(!cleanup.unwrap().cleanup());
+        assert!(!clone_failure.state.join(RAW_TOMBSTONE_NAME).exists());
+        let successor = clone_failure
+            .launch
+            .publish(&clone_failure.state, "successor", 10, &clone_failure.prior)
+            .unwrap();
+        assert!(!clone_failure.state.join(METADATA_TOMBSTONE_NAME).exists());
+        successor.remove_locator_authority().unwrap();
+        assert!(!successor.claim_terminal_residue().0.unwrap().cleanup());
+    }
+
+    #[test]
+    fn missing_residue_cannot_block_terminal_locator_retirement() {
+        let missing = fixture();
+        let files = missing
+            .launch
+            .publish(&missing.state, "deploy-1", 9, &missing.prior)
+            .unwrap();
+        fs::remove_file(&missing.metadata).unwrap();
+        files.remove_locator_authority().unwrap();
+        let (cleanup, failed) = files.claim_terminal_residue();
+        assert!(failed);
+        assert!(!missing.launch.locator_path().exists());
+        assert!(!cleanup.unwrap().cleanup());
+        assert!(!missing.raw.exists());
+
+        let tampered = fixture();
+        let files = tampered
+            .launch
+            .publish(&tampered.state, "deploy-2", 10, &tampered.prior)
+            .unwrap();
+        let mut bytes = fs::read(&tampered.metadata).unwrap();
+        bytes[0] ^= 1;
+        fs::write(&tampered.metadata, bytes).unwrap();
+        files.remove_locator_authority().unwrap();
+        let (cleanup, failed) = files.claim_terminal_residue();
+        assert!(!failed, "tampering does not impede atomic claim");
+        assert!(cleanup.unwrap().cleanup());
+        assert!(!tampered.launch.locator_path().exists());
+        assert!(tampered.state.join(METADATA_TOMBSTONE_NAME).exists());
     }
 
     #[test]

--- a/tests/commit_confirm_binary.rs
+++ b/tests/commit_confirm_binary.rs
@@ -346,8 +346,27 @@ impl Lab {
 
     fn assert_no_v3_authority(&self, context: &str) {
         assert!(!self.locator_path.exists(), "{context}: locator remains");
-        assert!(!self.raw_path.exists(), "{context}: raw prior remains");
-        assert!(!self.metadata_path.exists(), "{context}: metadata remains");
+    }
+
+    fn assert_no_v3_residue_eventually(&self, context: &str) {
+        let raw_tombstone = self
+            .raw_path
+            .with_file_name("commit-confirm-v3-prior.cleanup");
+        let metadata_tombstone = self
+            .metadata_path
+            .with_file_name("commit-confirm-v3-metadata.cleanup");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while self.raw_path.exists()
+            || self.metadata_path.exists()
+            || raw_tombstone.exists()
+            || metadata_tombstone.exists()
+        {
+            assert!(
+                Instant::now() < deadline,
+                "{context}: non-authoritative v3 residue remains"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
     }
 
     fn apply_plain(&self, candidate: &Path) {
@@ -529,6 +548,7 @@ fn streamed_confirmed_apply_above_eight_mib_aborts_to_previous_config() {
         "abort must restore the pre-transaction config"
     );
     lab.assert_no_v3_authority("abort must consume v3 authority");
+    lab.assert_no_v3_residue_eventually("abort must clean v3 residue");
     let ranges = rbgp_json(&lab.grpc_addr, &["--json", "dynamic-neighbor", "list"]);
     assert_eq!(
         ranges.as_array().map(Vec::len),
@@ -604,6 +624,7 @@ fn sigkill_in_confirm_window_boots_previous_config_and_saves_candidate_aside() {
         "saved-aside file must hold the unconfirmed candidate:\n{saved_aside}"
     );
     lab.assert_no_v3_authority("boot revert must consume v3 authority");
+    lab.assert_no_v3_residue_eventually("boot revert must clean v3 residue");
     let stderr = daemon.stderr();
     assert!(
         stderr.contains("commit-confirm boot revert")
@@ -647,6 +668,7 @@ fn confirm_then_sigkill_retains_new_config_and_leaves_no_journal() {
     );
     assert_eq!(confirm["confirmation"]["status"], "confirmed", "{confirm}");
     lab.assert_no_v3_authority("confirm must consume v3 authority");
+    lab.assert_no_v3_residue_eventually("confirm must clean v3 residue");
     daemon.sigkill();
 
     let mut daemon = lab.spawn("second.stderr.log");
@@ -692,6 +714,7 @@ fn in_process_timeout_auto_revert_consumes_journal() {
     }
 
     lab.assert_no_v3_authority("timeout auto-revert must consume v3 authority");
+    lab.assert_no_v3_residue_eventually("timeout auto-revert must clean v3 residue");
     let on_disk = std::fs::read_to_string(&lab.config_path).unwrap();
     assert!(
         !on_disk.contains("192.0.2.0/24"),


### PR DESCRIPTION
## Summary

- make durable locator removal the terminal v3 commit-confirm authority transition
- atomically quarantine fixed residue into bounded private tombstones before config admission reopens
- clean tombstones asynchronously without retaining coordinator, stream, response, or candidate state
- preserve successor publications and treat residue failures as warning-only after terminality

## Validation

- `cargo test --bin rustbgpd`
- `cargo test --test commit_confirm_binary`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `python3 scripts/check-clippy-reasons.py`
- `python3 scripts/check-v1-stable-surface.py`
- `cargo fmt --all -- --check`
