### PR TITLE
feat: add TUI unicast export explanation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- The TUI peer detail now opens an on-demand unicast export-explain view with
+  `r`: page through the global Best-RIB and explain advertise/deny gates,
+  ordered policy reasons, and modifications for the selected peer. (LAN-995)
 - `rbgp` Bash completions now offer filesystem paths for file positionals,
   including filenames with spaces and repeatable `policy fmt` inputs. (LAN-938)
 - `rustbgpd --migrate-config ACTION --offline` now performs explicit Linux-only

--- a/README.md
+++ b/README.md
@@ -83,13 +83,15 @@ docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 summary
 # Browse the RIB
 docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 rib
 
-# Live TUI dashboard — sessions, prefix counts, message rates
+# Live TUI dashboard — sessions, prefix counts, message rates, export explain
 docker compose exec rustbgpd rbgp -s http://127.0.0.1:50051 top
 ```
 
 ![rbgp top — live TUI dashboard](docs/images/tui-screenshot.png)
 
-Press `q` to exit the TUI. When you're done: `docker compose down`.
+Select a peer, open its detail, then press `r` to browse the point-in-time
+unicast Best-RIB and explain export decisions for that peer. Press `q` to exit
+the TUI. When you're done: `docker compose down`.
 
 ## Policy you can test before it touches a route
 
@@ -144,7 +146,8 @@ config from their existing `general.yml`/`clients.yml`:
   looking-glass stack for less. Best-path, export-gate, and filtered-route
   views are always on; the **import**-decision surface is opt-in
   (`[policy.explain] enabled = true`), because it retains a decision cache
-  per session ([docs/explain.md](docs/explain.md))
+  per session. The TUI also exposes the unicast export-gate slice for a
+  selected peer ([docs/explain.md](docs/explain.md))
 - **Update-group fanout** — peers with provably identical staged output share
   one staging pass: ~27x faster 100k-route convergence at 256 uniform RR
   clients (15.1 s to 0.56 s); v2 extends sharing to VPNv4/v6 with per-member

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -17,6 +17,12 @@ rbgp metrics      # Prometheus metrics snapshot
 rbgp top          # live terminal dashboard
 ```
 
+In `rbgp top`, select a peer and open its detail, then press `r` to browse a
+point-in-time page of the global unicast Best-RIB with that peer retained as
+the export target. Use `n`/`p` for pages and `Enter` to run the existing export
+explanation for the highlighted prefix and peer. This view is on demand; it
+does not continuously poll the RIB.
+
 ### Config Transactions
 
 ```bash

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -71,12 +71,57 @@ fn make_route_request(
     })
 }
 
-type RibClient = RibServiceClient<
+pub(crate) type RibClient = RibServiceClient<
     tonic::service::interceptor::InterceptedService<
         tonic::transport::Channel,
         crate::connection::AuthInterceptor,
     >,
 >;
+
+/// Fetch one bounded, unfiltered Best-RIB page for the interactive TUI.
+///
+/// Pagination tokens are opaque server state. Keep the caller's bytes intact
+/// and return the server response verbatim; navigation belongs to the view.
+#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
+pub(crate) async fn fetch_tui_best_route_page(
+    client: &mut RibClient,
+    page_token: String,
+) -> Result<crate::proto::ListRoutesResponse, tonic::Status> {
+    client
+        .list_best_routes(ListRoutesRequest {
+            page_size: 100,
+            page_token,
+            ..Default::default()
+        })
+        .await
+        .map(tonic::Response::into_inner)
+}
+
+/// Explain export of one Best-RIB prefix to the selected TUI peer.
+///
+/// This is deliberately the unicast winner form: no RD, label, or source
+/// identity. Scoped link-local peer rendering follows the CLI path exactly.
+#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
+pub(crate) async fn fetch_tui_explain_advertised(
+    client: &mut RibClient,
+    peer_address: &str,
+    prefix: String,
+    prefix_length: u32,
+) -> Result<crate::proto::ExplainAdvertisedRouteResponse, tonic::Status> {
+    let mut response = client
+        .explain_advertised_route(ExplainAdvertisedRouteRequest {
+            peer_address: bare_ip_rpc_address(peer_address).to_string(),
+            prefix,
+            prefix_length,
+            rd: String::new(),
+            labeled: false,
+            source: None,
+        })
+        .await?
+        .into_inner();
+    restore_matching_scoped_address(Some(peer_address), &mut response.peer_address);
+    Ok(response)
+}
 
 /// Which unicast route-listing RPC [`fetch_all_route_pages`] drives.
 enum RouteListRpc {
@@ -1075,7 +1120,7 @@ fn fib_state_label(state: i32) -> &'static str {
     }
 }
 
-fn explain_to_json(
+pub(crate) fn explain_to_json(
     explain: &crate::proto::ExplainAdvertisedRouteResponse,
 ) -> JsonExplainAdvertisedRoute {
     JsonExplainAdvertisedRoute {

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -124,6 +124,14 @@ pub(crate) struct MockState {
     pub(crate) list_best_route_calls: AtomicUsize,
     pub(crate) list_received_route_calls: AtomicUsize,
     pub(crate) list_advertised_route_calls: AtomicUsize,
+    pub(crate) list_best_route_error: Mutex<Option<(Code, String)>>,
+    pub(crate) explain_advertised_error: Mutex<Option<(Code, String)>>,
+    pub(crate) rib_query_pause: AtomicBool,
+    pub(crate) rib_query_active: AtomicUsize,
+    pub(crate) rib_query_max_active: AtomicUsize,
+    pub(crate) rib_query_cancellations: AtomicUsize,
+    pub(crate) rib_query_started: Notify,
+    pub(crate) rib_query_resume: Notify,
     pub(crate) add_path_calls: AtomicUsize,
     pub(crate) delete_path_calls: AtomicUsize,
     pub(crate) list_rejected_route_calls: AtomicUsize,
@@ -1186,6 +1194,46 @@ struct MockRibService {
     state: Arc<MockState>,
 }
 
+struct ActiveRibQuery<'a> {
+    state: &'a MockState,
+    completed: bool,
+}
+
+impl<'a> ActiveRibQuery<'a> {
+    fn start(state: &'a MockState) -> Self {
+        let active = state.rib_query_active.fetch_add(1, Ordering::SeqCst) + 1;
+        state
+            .rib_query_max_active
+            .fetch_max(active, Ordering::SeqCst);
+        state.rib_query_started.notify_waiters();
+        Self {
+            state,
+            completed: false,
+        }
+    }
+
+    fn complete(mut self) {
+        self.completed = true;
+    }
+}
+
+impl Drop for ActiveRibQuery<'_> {
+    fn drop(&mut self) {
+        self.state.rib_query_active.fetch_sub(1, Ordering::SeqCst);
+        if !self.completed {
+            self.state
+                .rib_query_cancellations
+                .fetch_add(1, Ordering::SeqCst);
+        }
+    }
+}
+
+async fn pause_rib_query_if_requested(state: &MockState) {
+    if state.rib_query_pause.load(Ordering::SeqCst) {
+        state.rib_query_resume.notified().await;
+    }
+}
+
 struct MockInjectionService {
     state: Arc<MockState>,
 }
@@ -1608,9 +1656,15 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         self.state
             .list_best_route_calls
             .fetch_add(1, Ordering::SeqCst);
-        Ok(Response::new(
-            self.next_route_page(request.into_inner()).await,
-        ))
+        let active = ActiveRibQuery::start(&self.state);
+        pause_rib_query_if_requested(&self.state).await;
+        if let Some((code, message)) = self.state.list_best_route_error.lock().await.clone() {
+            active.complete();
+            return Err(Status::new(code, message));
+        }
+        let response = self.next_route_page(request.into_inner()).await;
+        active.complete();
+        Ok(Response::new(response))
     }
 
     async fn list_advertised_routes(
@@ -1667,6 +1721,12 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
         &self,
         request: Request<server_proto::ExplainAdvertisedRouteRequest>,
     ) -> Result<Response<server_proto::ExplainAdvertisedRouteResponse>, Status> {
+        let active = ActiveRibQuery::start(&self.state);
+        pause_rib_query_if_requested(&self.state).await;
+        if let Some((code, message)) = self.state.explain_advertised_error.lock().await.clone() {
+            active.complete();
+            return Err(Status::new(code, message));
+        }
         let req = request.into_inner();
         *self.state.last_explain_advertised.lock().await = Some(req.clone());
         let response_peer = canonical_ip_or_original(&req.peer_address);
@@ -1681,65 +1741,65 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
             || "198.51.100.2".to_string(),
             |source| source.peer_address.clone(),
         );
-        Ok(Response::new(
-            server_proto::ExplainAdvertisedRouteResponse {
-                decision: server_proto::ExplainDecision::Advertise as i32,
-                peer_address: response_peer,
-                prefix: "203.0.113.0".to_string(),
-                prefix_length: 24,
-                next_hop: "198.51.100.1".to_string(),
-                path_id: 0,
-                route_peer_address,
-                route_type: "external".to_string(),
-                reasons: vec![server_proto::ExplainReason {
-                    code: "policy_permitted".to_string(),
-                    message: "export policy permitted this route".to_string(),
-                }],
-                modifications: Some(server_proto::ExplainModifications {
-                    set_local_pref: Some(200),
-                    set_med: None,
-                    set_next_hop: String::new(),
-                    communities_add: vec![],
-                    communities_remove: vec![],
-                    extended_communities_add: vec![],
-                    extended_communities_remove: vec![],
-                    large_communities_add: vec![],
-                    large_communities_remove: vec![],
-                    as_path_prepend_asn: None,
-                    as_path_prepend_count: None,
-                }),
-                orr_vantage: String::new(),
-                orr_candidates: vec![],
-                gates: vec![
-                    server_proto::ExportGateStep {
-                        gate: "best_route".to_string(),
-                        code: "ebgp_route".to_string(),
-                        verdict: server_proto::ExportGateVerdict::Pass as i32,
-                        detail: "best route was learned from an eBGP peer (Loc-RIB best \
+        let response = Response::new(server_proto::ExplainAdvertisedRouteResponse {
+            decision: server_proto::ExplainDecision::Advertise as i32,
+            peer_address: response_peer,
+            prefix: "203.0.113.0".to_string(),
+            prefix_length: 24,
+            next_hop: "198.51.100.1".to_string(),
+            path_id: 0,
+            route_peer_address,
+            route_type: "external".to_string(),
+            reasons: vec![server_proto::ExplainReason {
+                code: "policy_permitted".to_string(),
+                message: "export policy permitted this route".to_string(),
+            }],
+            modifications: Some(server_proto::ExplainModifications {
+                set_local_pref: Some(200),
+                set_med: None,
+                set_next_hop: String::new(),
+                communities_add: vec![],
+                communities_remove: vec![],
+                extended_communities_add: vec![],
+                extended_communities_remove: vec![],
+                large_communities_add: vec![],
+                large_communities_remove: vec![],
+                as_path_prepend_asn: None,
+                as_path_prepend_count: None,
+            }),
+            orr_vantage: String::new(),
+            orr_candidates: vec![],
+            gates: vec![
+                server_proto::ExportGateStep {
+                    gate: "best_route".to_string(),
+                    code: "ebgp_route".to_string(),
+                    verdict: server_proto::ExportGateVerdict::Pass as i32,
+                    detail: "best route was learned from an eBGP peer (Loc-RIB best \
                                  from 198.51.100.2)"
-                            .to_string(),
-                    },
-                    server_proto::ExportGateStep {
-                        gate: "export_policy".to_string(),
-                        code: "policy_permitted".to_string(),
-                        verdict: server_proto::ExportGateVerdict::Pass as i32,
-                        detail: "export policy \"lp200\" permitted this route".to_string(),
-                    },
-                    server_proto::ExportGateStep {
-                        gate: "adj_rib_out".to_string(),
-                        code: "already_advertised".to_string(),
-                        verdict: server_proto::ExportGateVerdict::Pass as i32,
-                        detail: "identical route already advertised — Adj-RIB-Out in sync, no \
+                        .to_string(),
+                },
+                server_proto::ExportGateStep {
+                    gate: "export_policy".to_string(),
+                    code: "policy_permitted".to_string(),
+                    verdict: server_proto::ExportGateVerdict::Pass as i32,
+                    detail: "export policy \"lp200\" permitted this route".to_string(),
+                },
+                server_proto::ExportGateStep {
+                    gate: "adj_rib_out".to_string(),
+                    code: "already_advertised".to_string(),
+                    verdict: server_proto::ExportGateVerdict::Pass as i32,
+                    detail: "identical route already advertised — Adj-RIB-Out in sync, no \
                                  re-announcement; remote acceptance is not observable"
-                            .to_string(),
-                    },
-                ],
-                update_group_id: Some(1),
-                already_advertised: true,
-                rd: String::new(),
-                source: response_source,
-            },
-        ))
+                        .to_string(),
+                },
+            ],
+            update_group_id: Some(1),
+            already_advertised: true,
+            rd: String::new(),
+            source: response_source,
+        });
+        active.complete();
+        Ok(response)
     }
 
     async fn list_blackhole_discards(

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -4,8 +4,13 @@ use std::time::Instant;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::widgets::TableState;
 
-use crate::proto::{GlobalState, HealthResponse, NeighborState};
-use crate::tui::data::{DataSnapshot, Freshness, RouteEventEntry, RouteEventUpdate};
+use crate::proto::{
+    ExplainAdvertisedRouteResponse, GlobalState, HealthResponse, ListRoutesResponse, NeighborState,
+};
+use crate::tui::data::{
+    DataSnapshot, Freshness, RibQueryError, RibQueryIdentity, RibQueryKind, RibQueryResponse,
+    RibQueryResult, RouteEventEntry, RouteEventUpdate,
+};
 
 const MAX_EVENTS: usize = 100;
 
@@ -13,6 +18,32 @@ const MAX_EVENTS: usize = 100;
 pub enum View {
     PeerTable,
     PeerDetail(String),
+    BestRib(String),
+    AdvertisedExplain(String),
+}
+
+#[derive(Debug)]
+pub enum RibPageState {
+    Loading,
+    Ready(ListRoutesResponse),
+    Error(String),
+}
+
+#[derive(Debug)]
+pub enum ExplainState {
+    Loading,
+    Ready(Box<ExplainAdvertisedRouteResponse>),
+    Error(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RibIntent {
+    Query {
+        view_id: u64,
+        peer_address: String,
+        query: RibQueryKind,
+    },
+    Cancel,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -103,6 +134,18 @@ pub struct App {
     pub detail_scroll: usize,
     pub detail_max_scroll: usize,
     pub detail_page_height: usize,
+    pub view_id: u64,
+    pub rib_page: Option<RibPageState>,
+    pub rib_page_token: String,
+    pub rib_previous_tokens: Vec<String>,
+    pub rib_table_state: TableState,
+    pub active_rib_query: Option<RibQueryIdentity>,
+    pub explain: Option<ExplainState>,
+    pub explain_scroll: usize,
+    pub explain_max_scroll: usize,
+    pub explain_page_height: usize,
+    rib_intents: VecDeque<RibIntent>,
+    aborted_reset_used: bool,
 
     pub connected: bool,
     pub last_error: Option<String>,
@@ -137,6 +180,18 @@ impl App {
             detail_scroll: 0,
             detail_max_scroll: 0,
             detail_page_height: 0,
+            view_id: 1,
+            rib_page: None,
+            rib_page_token: String::new(),
+            rib_previous_tokens: Vec::new(),
+            rib_table_state: TableState::default(),
+            active_rib_query: None,
+            explain: None,
+            explain_scroll: 0,
+            explain_max_scroll: 0,
+            explain_page_height: 0,
+            rib_intents: VecDeque::new(),
+            aborted_reset_used: false,
             connected: false,
             last_error: None,
             last_poll: Instant::now(),
@@ -145,6 +200,7 @@ impl App {
 
     pub fn on_key(&mut self, key: KeyEvent) {
         if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            self.cancel_rib();
             self.should_quit = true;
             return;
         }
@@ -157,12 +213,17 @@ impl App {
         match self.view {
             View::PeerTable => self.handle_table_key(key),
             View::PeerDetail(_) => self.handle_detail_key(key),
+            View::BestRib(_) => self.handle_rib_key(key),
+            View::AdvertisedExplain(_) => self.handle_explain_key(key),
         }
     }
 
     fn handle_table_key(&mut self, key: KeyEvent) {
         match key.code {
-            KeyCode::Char('q') => self.should_quit = true,
+            KeyCode::Char('q') => {
+                self.cancel_rib();
+                self.should_quit = true
+            }
             KeyCode::Char('h') => self.show_help = true,
             KeyCode::Char('e') => self.show_events = !self.show_events,
             KeyCode::Char('s') => self.sort_column = self.sort_column.next(),
@@ -183,8 +244,16 @@ impl App {
 
     fn handle_detail_key(&mut self, key: KeyEvent) {
         match key.code {
-            KeyCode::Char('q') => self.should_quit = true,
+            KeyCode::Char('q') => {
+                self.cancel_rib();
+                self.should_quit = true
+            }
             KeyCode::Esc | KeyCode::Backspace => self.return_to_table(),
+            KeyCode::Char('r') => {
+                if let View::PeerDetail(peer) = self.view.clone() {
+                    self.open_best_rib(peer);
+                }
+            }
             KeyCode::Char('j') | KeyCode::Down => self.scroll_detail_by(1),
             KeyCode::Char('k') | KeyCode::Up => self.scroll_detail_up(1),
             KeyCode::PageDown => self.scroll_detail_by(self.detail_page_height.max(1)),
@@ -193,6 +262,255 @@ impl App {
             KeyCode::End => self.detail_scroll = self.detail_max_scroll,
             _ => {}
         }
+    }
+
+    fn next_view_id(&mut self) -> u64 {
+        self.view_id = self.view_id.wrapping_add(1).max(1);
+        self.view_id
+    }
+
+    fn queue_query(&mut self, peer_address: String, query: RibQueryKind) {
+        self.active_rib_query = None;
+        self.rib_intents.push_back(RibIntent::Query {
+            view_id: self.view_id,
+            peer_address,
+            query,
+        });
+    }
+
+    fn open_best_rib(&mut self, peer: String) {
+        self.next_view_id();
+        self.view = View::BestRib(peer.clone());
+        self.rib_page_token.clear();
+        self.rib_previous_tokens.clear();
+        self.rib_table_state.select(None);
+        self.rib_page = Some(RibPageState::Loading);
+        self.aborted_reset_used = false;
+        self.queue_query(
+            peer,
+            RibQueryKind::BestPage {
+                page_token: String::new(),
+            },
+        );
+    }
+
+    fn request_page(&mut self, peer: String, token: String) {
+        self.rib_page = Some(RibPageState::Loading);
+        self.queue_query(peer, RibQueryKind::BestPage { page_token: token });
+    }
+
+    fn handle_rib_key(&mut self, key: KeyEvent) {
+        let peer = match &self.view {
+            View::BestRib(peer) => peer.clone(),
+            _ => return,
+        };
+        match key.code {
+            KeyCode::Char('q') => {
+                self.cancel_rib();
+                self.should_quit = true;
+            }
+            KeyCode::Esc | KeyCode::Backspace => {
+                self.cancel_rib();
+                self.view = View::PeerDetail(peer);
+            }
+            KeyCode::Char('j') | KeyCode::Down => self.select_next_route(),
+            KeyCode::Char('k') | KeyCode::Up => self.select_prev_route(),
+            KeyCode::Char('n') => {
+                if let Some(RibPageState::Ready(page)) = &self.rib_page
+                    && !page.next_page_token.is_empty()
+                {
+                    self.request_page(peer, page.next_page_token.clone());
+                }
+            }
+            KeyCode::Char('p') => {
+                if let Some(token) = self.rib_previous_tokens.last().cloned() {
+                    self.request_page(peer, token);
+                }
+            }
+            KeyCode::Enter => {
+                let selected = self.rib_table_state.selected();
+                let route = match (&self.rib_page, selected) {
+                    (Some(RibPageState::Ready(page)), Some(i)) => page.routes.get(i),
+                    _ => None,
+                };
+                if let Some(route) = route {
+                    let prefix = route.prefix.clone();
+                    let prefix_length = route.prefix_length;
+                    self.next_view_id();
+                    self.view = View::AdvertisedExplain(peer.clone());
+                    self.explain = Some(ExplainState::Loading);
+                    self.explain_scroll = 0;
+                    self.queue_query(
+                        peer,
+                        RibQueryKind::ExplainAdvertised {
+                            prefix,
+                            prefix_length,
+                        },
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_explain_key(&mut self, key: KeyEvent) {
+        let peer = match &self.view {
+            View::AdvertisedExplain(peer) => peer.clone(),
+            _ => return,
+        };
+        match key.code {
+            KeyCode::Char('q') => {
+                self.cancel_rib();
+                self.should_quit = true;
+            }
+            KeyCode::Esc | KeyCode::Backspace => {
+                self.cancel_rib();
+                self.view = View::BestRib(peer);
+                self.explain = None;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.explain_scroll = self
+                    .explain_scroll
+                    .saturating_add(1)
+                    .min(self.explain_max_scroll)
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.explain_scroll = self.explain_scroll.saturating_sub(1)
+            }
+            KeyCode::PageDown => {
+                self.explain_scroll = self
+                    .explain_scroll
+                    .saturating_add(self.explain_page_height.max(1))
+                    .min(self.explain_max_scroll)
+            }
+            KeyCode::PageUp => {
+                self.explain_scroll = self
+                    .explain_scroll
+                    .saturating_sub(self.explain_page_height.max(1))
+            }
+            KeyCode::Home => self.explain_scroll = 0,
+            KeyCode::End => self.explain_scroll = self.explain_max_scroll,
+            _ => {}
+        }
+    }
+
+    fn route_count(&self) -> usize {
+        match &self.rib_page {
+            Some(RibPageState::Ready(p)) => p.routes.len(),
+            _ => 0,
+        }
+    }
+    fn select_next_route(&mut self) {
+        let n = self.route_count();
+        if n > 0 {
+            let i = self
+                .rib_table_state
+                .selected()
+                .map_or(0, |i| (i + 1).min(n - 1));
+            self.rib_table_state.select(Some(i));
+        }
+    }
+    fn select_prev_route(&mut self) {
+        if self.route_count() > 0 {
+            self.rib_table_state.select(Some(
+                self.rib_table_state
+                    .selected()
+                    .unwrap_or(0)
+                    .saturating_sub(1),
+            ));
+        }
+    }
+
+    pub(crate) fn take_rib_intent(&mut self) -> Option<RibIntent> {
+        self.rib_intents.pop_front()
+    }
+    pub(crate) fn record_rib_request(&mut self, identity: RibQueryIdentity) {
+        self.active_rib_query = Some(identity);
+    }
+    pub(crate) fn rib_unavailable(&mut self, message: impl Into<String>) {
+        let text = format!("RIB unavailable: {}", message.into());
+        match self.view {
+            View::AdvertisedExplain(_) => self.explain = Some(ExplainState::Error(text)),
+            _ => self.rib_page = Some(RibPageState::Error(text)),
+        }
+        self.active_rib_query = None;
+    }
+    fn cancel_rib(&mut self) {
+        if self.active_rib_query.take().is_some()
+            || matches!(self.view, View::BestRib(_) | View::AdvertisedExplain(_))
+        {
+            self.rib_intents.push_back(RibIntent::Cancel);
+        }
+    }
+
+    pub(crate) fn on_rib_result(&mut self, result: RibQueryResult) {
+        let Some(active) = self.active_rib_query.take() else {
+            return;
+        };
+        if result.identity != active
+            || result.identity.request_id != active.request_id
+            || result.identity.view_id != self.view_id
+        {
+            self.active_rib_query = Some(active);
+            return;
+        }
+        let expected_view = match (&self.view, &active.query) {
+            (View::BestRib(peer), RibQueryKind::BestPage { .. })
+            | (View::AdvertisedExplain(peer), RibQueryKind::ExplainAdvertised { .. }) => {
+                peer == &active.peer_address
+            }
+            _ => false,
+        };
+        if !expected_view {
+            self.active_rib_query = Some(active);
+            return;
+        }
+        match result.result {
+            Ok(RibQueryResponse::BestPage(page)) => {
+                let RibQueryKind::BestPage { page_token } = active.query else {
+                    return;
+                };
+                if page_token != self.rib_page_token {
+                    if self.rib_previous_tokens.last() == Some(&page_token) {
+                        self.rib_previous_tokens.pop();
+                    } else {
+                        self.rib_previous_tokens.push(self.rib_page_token.clone());
+                    }
+                    self.rib_page_token = page_token;
+                }
+                self.rib_table_state
+                    .select((!page.routes.is_empty()).then_some(0));
+                self.rib_page = Some(RibPageState::Ready(page));
+            }
+            Ok(RibQueryResponse::ExplainAdvertised(explain)) => {
+                self.explain = Some(ExplainState::Ready(explain))
+            }
+            Err(error)
+                if error.code == tonic::Code::Aborted
+                    && matches!(active.query, RibQueryKind::BestPage { ref page_token } if !page_token.is_empty())
+                    && !self.aborted_reset_used =>
+            {
+                self.aborted_reset_used = true;
+                self.rib_previous_tokens.clear();
+                self.rib_page_token.clear();
+                self.request_page(active.peer_address, String::new());
+            }
+            Err(error) => {
+                let text = format_rib_error(&error);
+                match active.query {
+                    RibQueryKind::ExplainAdvertised { .. } => {
+                        self.explain = Some(ExplainState::Error(text))
+                    }
+                    _ => self.rib_page = Some(RibPageState::Error(text)),
+                }
+            }
+        }
+    }
+
+    pub(crate) fn set_explain_layout(&mut self, rows: usize, page: usize) {
+        self.explain_page_height = page;
+        self.explain_max_scroll = rows.saturating_sub(page);
+        self.explain_scroll = self.explain_scroll.min(self.explain_max_scroll);
     }
 
     fn scroll_detail_by(&mut self, rows: usize) {
@@ -213,6 +531,7 @@ impl App {
     }
 
     pub(crate) fn return_to_table(&mut self) {
+        self.cancel_rib();
         self.view = View::PeerTable;
         self.reset_detail_scroll();
     }
@@ -322,15 +641,19 @@ impl App {
 
         if self.neighbors.is_empty() {
             self.peer_table_state.select(None);
-            if matches!(self.view, View::PeerDetail(_)) {
+            if !matches!(self.view, View::PeerTable) {
                 self.return_to_table();
             }
             return;
         }
 
-        if let View::PeerDetail(address) = &self.view
-            && !current_keys.contains(address)
-        {
+        let viewed_peer = match &self.view {
+            View::PeerDetail(peer) | View::BestRib(peer) | View::AdvertisedExplain(peer) => {
+                Some(peer)
+            }
+            View::PeerTable => None,
+        };
+        if viewed_peer.is_some_and(|peer| !current_keys.contains(peer)) {
             self.return_to_table();
         }
 
@@ -432,6 +755,36 @@ impl App {
 
     pub fn total_routes(&self) -> u32 {
         self.health.as_ref().map(|h| h.total_routes).unwrap_or(0)
+    }
+}
+
+fn format_rib_error(error: &RibQueryError) -> String {
+    let code = match error.code {
+        tonic::Code::Ok => "OK",
+        tonic::Code::Cancelled => "CANCELLED",
+        tonic::Code::Unknown => "UNKNOWN",
+        tonic::Code::InvalidArgument => "INVALID_ARGUMENT",
+        tonic::Code::DeadlineExceeded => "DEADLINE_EXCEEDED",
+        tonic::Code::NotFound => "NOT_FOUND",
+        tonic::Code::AlreadyExists => "ALREADY_EXISTS",
+        tonic::Code::PermissionDenied => "PERMISSION_DENIED",
+        tonic::Code::ResourceExhausted => "RESOURCE_EXHAUSTED",
+        tonic::Code::FailedPrecondition => "FAILED_PRECONDITION",
+        tonic::Code::Aborted => "ABORTED",
+        tonic::Code::OutOfRange => "OUT_OF_RANGE",
+        tonic::Code::Unimplemented => "UNIMPLEMENTED",
+        tonic::Code::Internal => "INTERNAL",
+        tonic::Code::Unavailable => "UNAVAILABLE",
+        tonic::Code::DataLoss => "DATA_LOSS",
+        tonic::Code::Unauthenticated => "UNAUTHENTICATED",
+    };
+    match error.code {
+        tonic::Code::Unauthenticated | tonic::Code::PermissionDenied => {
+            format!("Authorization failed ({code}): {}", error.message)
+        }
+        tonic::Code::Unavailable => format!("RIB unavailable: {}", error.message),
+        tonic::Code::Aborted => format!("RIB snapshot expired: {}", error.message),
+        _ => format!("RIB query failed ({code}): {}", error.message),
     }
 }
 
@@ -786,5 +1139,250 @@ mod tests {
         assert_eq!(app.detail_max_scroll, usize::from(u16::MAX));
         app.on_key(KeyEvent::new(KeyCode::End, KeyModifiers::NONE));
         assert_eq!(app.detail_scroll, usize::from(u16::MAX));
+    }
+
+    fn open_rib(app: &mut App) -> RibQueryIdentity {
+        app.on_data(snapshot(vec![neighbor("198.51.100.1", 10)]));
+        app.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        app.on_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
+        let RibIntent::Query {
+            view_id,
+            peer_address,
+            query,
+        } = app.take_rib_intent().unwrap()
+        else {
+            panic!("query")
+        };
+        assert_eq!(peer_address, "198.51.100.1");
+        assert!(view_id > 1);
+        assert_eq!(
+            query,
+            RibQueryKind::BestPage {
+                page_token: String::new()
+            }
+        );
+        let identity = RibQueryIdentity {
+            request_id: 7,
+            view_id,
+            peer_address,
+            query,
+        };
+        app.record_rib_request(identity.clone());
+        identity
+    }
+
+    fn page(prefix: &str, next: &str) -> ListRoutesResponse {
+        ListRoutesResponse {
+            routes: vec![crate::proto::Route {
+                prefix: prefix.into(),
+                prefix_length: 24,
+                next_hop: "192.0.2.1".into(),
+                peer_address: "192.0.2.2".into(),
+                ..Default::default()
+            }],
+            next_page_token: next.into(),
+            total_count: 2,
+            page_version: None,
+        }
+    }
+
+    #[test]
+    fn rib_scope_paging_selection_and_explain_identity_are_exact() {
+        let mut app = App::new();
+        let first = open_rib(&mut app);
+        app.on_rib_result(RibQueryResult {
+            identity: first,
+            result: Ok(RibQueryResponse::BestPage(page(
+                "203.0.113.0",
+                "next\0opaque",
+            ))),
+        });
+        assert_eq!(app.rib_table_state.selected(), Some(0));
+        app.on_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE));
+        let RibIntent::Query {
+            view_id,
+            peer_address,
+            query,
+        } = app.take_rib_intent().unwrap()
+        else {
+            panic!()
+        };
+        assert_eq!(
+            query,
+            RibQueryKind::BestPage {
+                page_token: "next\0opaque".into()
+            }
+        );
+        let next = RibQueryIdentity {
+            request_id: 8,
+            view_id,
+            peer_address,
+            query,
+        };
+        app.record_rib_request(next.clone());
+        app.on_rib_result(RibQueryResult {
+            identity: next,
+            result: Ok(RibQueryResponse::BestPage(page("203.0.114.0", ""))),
+        });
+        assert_eq!(app.rib_previous_tokens, vec![String::new()]);
+        assert_eq!(app.rib_page_token, "next\0opaque");
+        app.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        let RibIntent::Query {
+            peer_address,
+            query,
+            ..
+        } = app.take_rib_intent().unwrap()
+        else {
+            panic!()
+        };
+        assert_eq!(peer_address, "198.51.100.1");
+        assert_eq!(
+            query,
+            RibQueryKind::ExplainAdvertised {
+                prefix: "203.0.114.0".into(),
+                prefix_length: 24
+            }
+        );
+        assert!(matches!(app.view, View::AdvertisedExplain(_)));
+        assert!(!app.route_events_visible());
+    }
+
+    #[test]
+    fn stale_results_fail_every_identity_and_view_guard() {
+        let mut app = App::new();
+        let active = open_rib(&mut app);
+        for mutate in 0..5 {
+            let mut stale = active.clone();
+            match mutate {
+                0 => stale.request_id += 1,
+                1 => stale.view_id += 1,
+                2 => stale.peer_address.push('x'),
+                3 => {
+                    stale.query = RibQueryKind::BestPage {
+                        page_token: "x".into(),
+                    }
+                }
+                _ => app.view = View::PeerDetail(active.peer_address.clone()),
+            }
+            app.on_rib_result(RibQueryResult {
+                identity: stale,
+                result: Ok(RibQueryResponse::BestPage(page("203.0.113.0", ""))),
+            });
+            assert!(matches!(app.rib_page, Some(RibPageState::Loading)));
+            assert_eq!(app.active_rib_query, Some(active.clone()));
+            app.view = View::BestRib(active.peer_address.clone());
+        }
+    }
+
+    #[test]
+    fn aborted_page_resets_once_and_errors_are_exact() {
+        let mut app = App::new();
+        let first = open_rib(&mut app);
+        app.on_rib_result(RibQueryResult {
+            identity: first,
+            result: Ok(RibQueryResponse::BestPage(page("203.0.113.0", "opaque"))),
+        });
+        app.on_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE));
+        let RibIntent::Query {
+            view_id,
+            peer_address,
+            query,
+        } = app.take_rib_intent().unwrap()
+        else {
+            panic!()
+        };
+        let paged = RibQueryIdentity {
+            request_id: 8,
+            view_id,
+            peer_address,
+            query,
+        };
+        app.record_rib_request(paged.clone());
+        app.on_rib_result(RibQueryResult {
+            identity: paged,
+            result: Err(RibQueryError {
+                code: tonic::Code::Aborted,
+                message: "changed".into(),
+            }),
+        });
+        let RibIntent::Query { query, .. } = app.take_rib_intent().unwrap() else {
+            panic!()
+        };
+        assert_eq!(
+            query,
+            RibQueryKind::BestPage {
+                page_token: String::new()
+            }
+        );
+        assert!(app.rib_previous_tokens.is_empty());
+        assert_eq!(
+            format_rib_error(&RibQueryError {
+                code: tonic::Code::PermissionDenied,
+                message: "no".into()
+            }),
+            "Authorization failed (PERMISSION_DENIED): no"
+        );
+        assert_eq!(
+            format_rib_error(&RibQueryError {
+                code: tonic::Code::Unavailable,
+                message: "down".into()
+            }),
+            "RIB unavailable: down"
+        );
+        assert_eq!(
+            format_rib_error(&RibQueryError {
+                code: tonic::Code::Aborted,
+                message: "old".into()
+            }),
+            "RIB snapshot expired: old"
+        );
+    }
+
+    #[test]
+    fn rib_departures_cancel_only_on_fresh_roster() {
+        let mut app = App::new();
+        open_rib(&mut app);
+        let mut stale = snapshot(Vec::new());
+        stale.neighbors_freshness = Freshness::Stale;
+        app.on_data(stale);
+        assert!(matches!(app.view, View::BestRib(_)));
+        assert!(app.take_rib_intent().is_none());
+        app.on_data(snapshot(Vec::new()));
+        assert_eq!(app.view, View::PeerTable);
+        assert_eq!(app.take_rib_intent(), Some(RibIntent::Cancel));
+    }
+
+    #[test]
+    fn every_rib_departure_cancels_and_explain_back_retains_page() {
+        for key in [
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
+        ] {
+            let mut app = App::new();
+            open_rib(&mut app);
+            app.on_key(key);
+            assert_eq!(app.take_rib_intent(), Some(RibIntent::Cancel));
+        }
+
+        let mut app = App::new();
+        let first = open_rib(&mut app);
+        app.on_rib_result(RibQueryResult {
+            identity: first,
+            result: Ok(RibQueryResponse::BestPage(page("203.0.113.0", ""))),
+        });
+        app.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        let retained_prefix = match &app.rib_page {
+            Some(RibPageState::Ready(page)) => page.routes[0].prefix.clone(),
+            _ => panic!(),
+        };
+        app.on_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert_eq!(app.view, View::BestRib("198.51.100.1".into()));
+        assert_eq!(retained_prefix, "203.0.113.0");
+        assert!(matches!(
+            app.take_rib_intent(),
+            Some(RibIntent::Query { .. })
+        ));
+        assert_eq!(app.take_rib_intent(), Some(RibIntent::Cancel));
     }
 }

--- a/crates/cli/src/tui/data.rs
+++ b/crates/cli/src/tui/data.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use tokio::sync::{mpsc, watch};
@@ -5,16 +7,201 @@ use tokio::task::JoinHandle;
 use tokio::time::Instant;
 
 use crate::commands::control::rpki_vrp_count_sum;
+use crate::commands::rib::{RibClient, fetch_tui_best_route_page, fetch_tui_explain_advertised};
 use crate::connection::Connection;
 use crate::proto::control_service_client::ControlServiceClient;
 use crate::proto::event_service_client::EventServiceClient;
 use crate::proto::global_service_client::GlobalServiceClient;
 use crate::proto::neighbor_service_client::NeighborServiceClient;
+use crate::proto::rib_service_client::RibServiceClient;
 use crate::proto::{
-    BgpEvent, BgpEventType, EventCategory, GetGlobalRequest, GlobalState, HealthRequest,
-    HealthResponse, ListDynamicNeighborsRequest, ListNeighborsRequest, MetricsRequest,
-    NeighborState, RouteEvent, WatchEventsRequest, bgp_event,
+    BgpEvent, BgpEventType, EventCategory, ExplainAdvertisedRouteResponse, GetGlobalRequest,
+    GlobalState, HealthRequest, HealthResponse, ListDynamicNeighborsRequest, ListNeighborsRequest,
+    ListRoutesResponse, MetricsRequest, NeighborState, RouteEvent, WatchEventsRequest, bgp_event,
 };
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
+pub(super) enum RibQueryKind {
+    BestPage { page_token: String },
+    ExplainAdvertised { prefix: String, prefix_length: u32 },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
+pub(super) struct RibQueryIdentity {
+    pub request_id: u64,
+    pub view_id: u64,
+    pub peer_address: String,
+    pub query: RibQueryKind,
+}
+
+#[derive(Debug)]
+#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
+pub(super) enum RibQueryResponse {
+    BestPage(ListRoutesResponse),
+    ExplainAdvertised(Box<ExplainAdvertisedRouteResponse>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
+pub(super) struct RibQueryError {
+    pub code: tonic::Code,
+    pub message: String,
+}
+
+impl From<tonic::Status> for RibQueryError {
+    fn from(status: tonic::Status) -> Self {
+        Self {
+            code: status.code(),
+            message: status.message().to_string(),
+        }
+    }
+}
+
+#[derive(Debug)]
+#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
+pub(super) struct RibQueryResult {
+    pub identity: RibQueryIdentity,
+    pub result: Result<RibQueryResponse, RibQueryError>,
+}
+
+#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
+enum RibQueryCommand {
+    Query(RibQueryIdentity),
+    Cancel,
+    Close,
+}
+
+#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
+pub(super) struct RibQueryHandle {
+    command_tx: mpsc::UnboundedSender<RibQueryCommand>,
+    next_request_id: Arc<AtomicU64>,
+    task: JoinHandle<()>,
+}
+
+#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
+impl RibQueryHandle {
+    pub fn query(&self, view_id: u64, peer_address: String, query: RibQueryKind) -> Option<u64> {
+        let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
+        let identity = RibQueryIdentity {
+            request_id,
+            view_id,
+            peer_address,
+            query,
+        };
+        self.command_tx
+            .send(RibQueryCommand::Query(identity))
+            .ok()
+            .map(|()| request_id)
+    }
+
+    pub fn cancel(&self) {
+        let _ = self.command_tx.send(RibQueryCommand::Cancel);
+    }
+
+    pub fn close(&self) {
+        let _ = self.command_tx.send(RibQueryCommand::Close);
+    }
+}
+
+impl Drop for RibQueryHandle {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+/// Spawn the TUI's isolated unary RIB lane.
+///
+/// The lane owns one client and one RPC future. Receiving another command
+/// drops that future before any replacement starts; results use an unbounded
+/// sender so a stopped UI can never hold shutdown open.
+#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
+pub(super) fn spawn_rib_query_lane(
+    connection: Connection,
+) -> (RibQueryHandle, mpsc::UnboundedReceiver<RibQueryResult>) {
+    let (command_tx, command_rx) = mpsc::unbounded_channel();
+    let (result_tx, result_rx) = mpsc::unbounded_channel();
+    let task = tokio::spawn(rib_query_loop(connection, command_rx, result_tx));
+    (
+        RibQueryHandle {
+            command_tx,
+            next_request_id: Arc::new(AtomicU64::new(1)),
+            task,
+        },
+        result_rx,
+    )
+}
+
+#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
+async fn run_rib_query(
+    client: &mut RibClient,
+    identity: &RibQueryIdentity,
+) -> Result<RibQueryResponse, tonic::Status> {
+    match &identity.query {
+        RibQueryKind::BestPage { page_token } => {
+            fetch_tui_best_route_page(client, page_token.clone())
+                .await
+                .map(RibQueryResponse::BestPage)
+        }
+        RibQueryKind::ExplainAdvertised {
+            prefix,
+            prefix_length,
+        } => fetch_tui_explain_advertised(
+            client,
+            &identity.peer_address,
+            prefix.clone(),
+            *prefix_length,
+        )
+        .await
+        .map(Box::new)
+        .map(RibQueryResponse::ExplainAdvertised),
+    }
+}
+
+#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
+async fn rib_query_loop(
+    connection: Connection,
+    mut command_rx: mpsc::UnboundedReceiver<RibQueryCommand>,
+    result_tx: mpsc::UnboundedSender<RibQueryResult>,
+) {
+    let mut client =
+        RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let mut pending = None;
+    loop {
+        let command = match pending.take() {
+            Some(command) => command,
+            None => match command_rx.recv().await {
+                Some(command) => command,
+                None => return,
+            },
+        };
+        let RibQueryCommand::Query(identity) = command else {
+            if matches!(command, RibQueryCommand::Close) {
+                return;
+            }
+            continue;
+        };
+
+        let mut rpc = std::pin::pin!(run_rib_query(&mut client, &identity));
+        tokio::select! {
+            biased;
+            _ = result_tx.closed() => return,
+            command = command_rx.recv() => {
+                match command {
+                    Some(RibQueryCommand::Close) | None => return,
+                    Some(command) => pending = Some(command),
+                }
+            }
+            result = &mut rpc => {
+                let result = result.map_err(RibQueryError::from);
+                if result_tx.send(RibQueryResult { identity: identity.clone(), result }).is_err() {
+                    return;
+                }
+            }
+        }
+    }
+}
 
 pub struct DataSnapshot {
     pub global: Option<GlobalState>,
@@ -399,6 +586,21 @@ mod tests {
     use crate::connection::connect;
     use crate::test_support::spawn_mock_server;
 
+    fn best_query(token: &str) -> RibQueryKind {
+        RibQueryKind::BestPage {
+            page_token: token.to_string(),
+        }
+    }
+
+    async fn receive_result(
+        results: &mut mpsc::UnboundedReceiver<RibQueryResult>,
+    ) -> RibQueryResult {
+        tokio::time::timeout(Duration::from_secs(2), results.recv())
+            .await
+            .expect("RIB query result timed out")
+            .expect("RIB query lane closed")
+    }
+
     async fn wait_for(mut predicate: impl FnMut() -> bool) {
         for _ in 0..1_000 {
             if predicate() {
@@ -412,6 +614,248 @@ mod tests {
     async fn settle_tasks() {
         for _ in 0..100 {
             tokio::task::yield_now().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn rib_query_best_page_preserves_request_token_and_response() {
+        let server = spawn_mock_server(None).await;
+        *server.state.list_route_pages.lock().await =
+            vec![rustbgpd_api::proto::ListRoutesResponse {
+                routes: vec![rustbgpd_api::proto::Route {
+                    prefix: "203.0.113.0".into(),
+                    prefix_length: 24,
+                    ..Default::default()
+                }],
+                next_page_token: "opaque-next\0token".into(),
+                total_count: 501,
+                page_version: Some(rustbgpd_api::proto::RoutePageVersion {
+                    epoch: 7,
+                    generation: 77,
+                }),
+            }];
+        let connection = connect(&server.addr, None).await.unwrap();
+        let (lane, mut results) = spawn_rib_query_lane(connection);
+
+        let request_id = lane
+            .query(9, "fe80::1%eth0".into(), best_query("opaque-in\0token"))
+            .unwrap();
+        let result = receive_result(&mut results).await;
+
+        assert_eq!(request_id, 1);
+        assert_eq!(result.identity.request_id, request_id);
+        assert_eq!(result.identity.view_id, 9);
+        assert_eq!(result.identity.peer_address, "fe80::1%eth0");
+        assert_eq!(result.identity.query, best_query("opaque-in\0token"));
+        let RibQueryResponse::BestPage(page) = result.result.unwrap() else {
+            panic!("expected Best-RIB page");
+        };
+        assert_eq!(page.routes.len(), 1);
+        assert_eq!(page.total_count, 501);
+        assert_eq!(page.next_page_token, "opaque-next\0token");
+        assert_eq!(
+            page.page_version,
+            Some(crate::proto::RoutePageVersion {
+                epoch: 7,
+                generation: 77,
+            })
+        );
+        let requests = server.state.list_route_requests.lock().await;
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0],
+            rustbgpd_api::proto::ListRoutesRequest {
+                page_size: 100,
+                page_token: "opaque-in\0token".into(),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn rib_query_explain_uses_unicast_winner_shape_and_shared_json() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        let (lane, mut results) = spawn_rib_query_lane(connection);
+        let query = RibQueryKind::ExplainAdvertised {
+            prefix: "203.0.113.0".into(),
+            prefix_length: 24,
+        };
+
+        lane.query(12, "fe80::1%eth0".into(), query.clone())
+            .unwrap();
+        let result = receive_result(&mut results).await;
+        assert_eq!(result.identity.query, query);
+        let RibQueryResponse::ExplainAdvertised(response) = result.result.unwrap() else {
+            panic!("expected advertised-route explain");
+        };
+        assert_eq!(response.peer_address, "fe80::1%eth0");
+        let request = server
+            .state
+            .last_explain_advertised
+            .lock()
+            .await
+            .clone()
+            .unwrap();
+        assert_eq!(request.peer_address, "fe80::1");
+        assert_eq!(request.prefix, "203.0.113.0");
+        assert_eq!(request.prefix_length, 24);
+        assert_eq!(request.rd, "");
+        assert!(!request.labeled);
+        assert!(request.source.is_none());
+
+        let shared_bytes = serde_json::to_vec(&crate::commands::rib::explain_to_json(&response))
+            .expect("shared CLI/TUI explain JSON serializes");
+        let shared_value: serde_json::Value = serde_json::from_slice(&shared_bytes).unwrap();
+        assert_eq!(shared_value["decision"], "advertise");
+        assert_eq!(shared_value["prefix"], "203.0.113.0/24");
+        assert_eq!(shared_value["peer_address"], "fe80::1%eth0");
+        assert_eq!(shared_value["gates"][1]["code"], "policy_permitted");
+    }
+
+    #[tokio::test]
+    async fn rib_query_lane_replaces_and_explicitly_cancels_without_overlap() {
+        let server = spawn_mock_server(None).await;
+        server.state.rib_query_pause.store(true, Ordering::SeqCst);
+        let connection = connect(&server.addr, None).await.unwrap();
+        let (lane, mut results) = spawn_rib_query_lane(connection);
+
+        lane.query(1, "192.0.2.1".into(), best_query("old"))
+            .unwrap();
+        wait_for(|| server.state.rib_query_active.load(Ordering::SeqCst) == 1).await;
+        server.state.rib_query_pause.store(false, Ordering::SeqCst);
+        let replacement = lane
+            .query(2, "192.0.2.2".into(), best_query("new"))
+            .unwrap();
+        let result = receive_result(&mut results).await;
+        assert_eq!(result.identity.request_id, replacement);
+        assert_eq!(result.identity.view_id, 2);
+        assert_eq!(server.state.rib_query_max_active.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            server.state.rib_query_cancellations.load(Ordering::SeqCst),
+            1
+        );
+
+        server.state.rib_query_pause.store(true, Ordering::SeqCst);
+        lane.query(3, "192.0.2.3".into(), best_query("cancel"))
+            .unwrap();
+        wait_for(|| server.state.rib_query_active.load(Ordering::SeqCst) == 1).await;
+        lane.cancel();
+        wait_for(|| server.state.rib_query_active.load(Ordering::SeqCst) == 0).await;
+        assert_eq!(
+            server.state.rib_query_cancellations.load(Ordering::SeqCst),
+            2
+        );
+        assert!(results.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn rib_query_lane_drop_and_receiver_close_cancel_inflight_rpc() {
+        for shutdown in ["drop", "receiver", "close"] {
+            let server = spawn_mock_server(None).await;
+            server.state.rib_query_pause.store(true, Ordering::SeqCst);
+            let connection = connect(&server.addr, None).await.unwrap();
+            let (lane, results) = spawn_rib_query_lane(connection);
+            lane.query(1, "192.0.2.1".into(), best_query("")).unwrap();
+            wait_for(|| server.state.rib_query_active.load(Ordering::SeqCst) == 1).await;
+            match shutdown {
+                "receiver" => drop(results),
+                "close" => lane.close(),
+                _ => drop(lane),
+            }
+            wait_for(|| server.state.rib_query_active.load(Ordering::SeqCst) == 0).await;
+            assert_eq!(
+                server.state.rib_query_cancellations.load(Ordering::SeqCst),
+                1
+            );
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn rib_query_errors_are_exact_once_and_never_retried() {
+        for (code, message) in [
+            (tonic::Code::Aborted, "page version expired"),
+            (tonic::Code::Unavailable, "RIB unavailable"),
+        ] {
+            let server = spawn_mock_server(None).await;
+            *server.state.list_best_route_error.lock().await = Some((code, message.into()));
+            let connection = connect(&server.addr, None).await.unwrap();
+            let (lane, mut results) = spawn_rib_query_lane(connection);
+            lane.query(1, "192.0.2.1".into(), best_query("opaque"))
+                .unwrap();
+            let result = loop {
+                if let Ok(result) = results.try_recv() {
+                    break result;
+                }
+                tokio::task::yield_now().await;
+            };
+            let error = result.result.unwrap_err();
+            assert_eq!(error.code, code);
+            assert_eq!(error.message, message);
+            tokio::time::advance(Duration::from_secs(600)).await;
+            settle_tasks().await;
+            assert_eq!(server.state.list_best_route_calls.load(Ordering::SeqCst), 1);
+            assert!(results.try_recv().is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn rib_query_lane_preserves_bearer_auth_for_both_rpcs() {
+        let server = spawn_mock_server(Some("rib-secret")).await;
+        let token_file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(token_file.path(), "rib-secret\n").unwrap();
+        let connection = connect(&server.addr, token_file.path().to_str())
+            .await
+            .unwrap();
+        let (lane, mut results) = spawn_rib_query_lane(connection);
+        lane.query(1, "192.0.2.1".into(), best_query("")).unwrap();
+        assert!(receive_result(&mut results).await.result.is_ok());
+        lane.query(
+            1,
+            "192.0.2.1".into(),
+            RibQueryKind::ExplainAdvertised {
+                prefix: "203.0.113.0".into(),
+                prefix_length: 24,
+            },
+        )
+        .unwrap();
+        assert!(receive_result(&mut results).await.result.is_ok());
+
+        for supplied in [None, Some("wrong-secret")] {
+            let token_file = supplied.map(|token| {
+                let file = tempfile::NamedTempFile::new().unwrap();
+                std::fs::write(file.path(), token).unwrap();
+                file
+            });
+            let connection = connect(
+                &server.addr,
+                token_file.as_ref().and_then(|file| file.path().to_str()),
+            )
+            .await
+            .unwrap();
+            let (lane, mut results) = spawn_rib_query_lane(connection);
+            lane.query(1, "192.0.2.1".into(), best_query("")).unwrap();
+            let error = receive_result(&mut results).await.result.unwrap_err();
+            assert_eq!(error.code, tonic::Code::Unauthenticated);
+            assert_eq!(
+                error.message,
+                if supplied.is_none() {
+                    "missing authorization metadata"
+                } else {
+                    "invalid bearer token"
+                }
+            );
+            lane.query(
+                1,
+                "192.0.2.1".into(),
+                RibQueryKind::ExplainAdvertised {
+                    prefix: "203.0.113.0".into(),
+                    prefix_length: 24,
+                },
+            )
+            .unwrap();
+            let explain_error = receive_result(&mut results).await.result.unwrap_err();
+            assert_eq!(explain_error, error);
         }
     }
 

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -17,7 +17,7 @@ use tokio::sync::{mpsc, watch};
 
 use crate::connection::Connection;
 use crate::error::CliError;
-use app::App;
+use app::{App, RibIntent};
 use theme::Theme;
 
 struct TerminalGuard;
@@ -44,6 +44,7 @@ pub async fn run(connection: Connection, interval: u64) -> Result<(), CliError> 
     let (data_tx, mut data_rx) = mpsc::channel(4);
     let (event_tx, mut event_rx) = mpsc::channel(64);
     let (event_watch_tx, event_watch_rx) = watch::channel(false);
+    let (rib_lane, mut rib_rx) = data::spawn_rib_query_lane(connection.clone());
 
     let _fetcher = data::spawn_fetcher(
         connection,
@@ -62,6 +63,8 @@ pub async fn run(connection: Connection, interval: u64) -> Result<(), CliError> 
         {
             app.on_key(key);
             if app.should_quit {
+                rib_lane.cancel();
+                rib_lane.close();
                 break;
             }
         }
@@ -72,6 +75,34 @@ pub async fn run(connection: Connection, interval: u64) -> Result<(), CliError> 
 
         while let Ok(route_event) = event_rx.try_recv() {
             app.on_route_event(route_event);
+        }
+
+        while let Ok(result) = rib_rx.try_recv() {
+            app.on_rib_result(result);
+        }
+
+        while let Some(intent) = app.take_rib_intent() {
+            match intent {
+                RibIntent::Cancel => rib_lane.cancel(),
+                RibIntent::Query {
+                    view_id,
+                    peer_address,
+                    query,
+                } => {
+                    let Some(request_id) =
+                        rib_lane.query(view_id, peer_address.clone(), query.clone())
+                    else {
+                        app.rib_unavailable("query lane closed");
+                        continue;
+                    };
+                    app.record_rib_request(data::RibQueryIdentity {
+                        request_id,
+                        view_id,
+                        peer_address,
+                        query,
+                    });
+                }
+            }
         }
 
         let should_watch_events = app.route_events_visible();

--- a/crates/cli/src/tui/ui.rs
+++ b/crates/cli/src/tui/ui.rs
@@ -9,7 +9,6 @@ use crate::commands::neighbor::{
     optional_seconds_label, rfc8212_policy_status_label,
 };
 use crate::output::{format_duration, format_state_with_stale, neighbor_source_label};
-use crate::proto::{ExplainDecision, ExportGateVerdict};
 use crate::tui::app::{App, ExplainState, RibPageState, SortColumn, View, neighbor_key};
 use crate::tui::data::{Freshness, RouteEventEntry, RouteEventKind};
 use crate::tui::theme::Theme;
@@ -752,14 +751,14 @@ fn explain_lines(
     explain: &crate::proto::ExplainAdvertisedRouteResponse,
     theme: &Theme,
 ) -> Vec<Line<'static>> {
-    let decision =
-        match ExplainDecision::try_from(explain.decision).unwrap_or(ExplainDecision::Unspecified) {
-            ExplainDecision::Advertise => "Advertise",
-            ExplainDecision::Deny => "Deny",
-            ExplainDecision::NoBestRoute => "No Best Route",
-            ExplainDecision::UnsupportedFamily => "Unsupported",
-            ExplainDecision::Unspecified => "Unspecified",
-        };
+    let normalized = crate::commands::rib::explain_to_json(explain);
+    let decision = match normalized.decision.as_str() {
+        "advertise" => "Advertise",
+        "deny" => "Deny",
+        "no_best_route" => "No Best Route",
+        "unsupported_family" => "Unsupported",
+        _ => "Unspecified",
+    };
     let mut lines = vec![
         Line::styled(
             format!("Decision: {decision}"),
@@ -767,33 +766,30 @@ fn explain_lines(
                 .fg(theme.header_fg)
                 .add_modifier(Modifier::BOLD),
         ),
-        Line::from(format!("Peer: {}", explain.peer_address)),
-        Line::from(format!(
-            "Prefix: {}/{}",
-            explain.prefix, explain.prefix_length
-        )),
+        Line::from(format!("Peer: {}", normalized.peer_address)),
+        Line::from(format!("Prefix: {}", normalized.prefix)),
     ];
-    if !explain.route_peer_address.is_empty() {
+    if !normalized.route_peer_address.is_empty() {
         lines.push(Line::from(format!(
             "Route peer: {}",
-            explain.route_peer_address
+            normalized.route_peer_address
         )));
     }
-    if !explain.next_hop.is_empty() {
-        lines.push(Line::from(format!("Next hop: {}", explain.next_hop)));
+    if !normalized.next_hop.is_empty() {
+        lines.push(Line::from(format!("Next hop: {}", normalized.next_hop)));
     }
-    if let Some(group) = explain.update_group_id {
+    if let Some(group) = normalized.update_group_id {
         lines.push(Line::from(format!("Update group: {group}")));
     }
     lines.push(Line::from(format!(
         "Adj-RIB-Out sync: {}",
-        if explain.already_advertised {
+        if normalized.already_advertised {
             "already advertised"
         } else {
             "not already advertised"
         }
     )));
-    if !explain.reasons.is_empty() {
+    if !normalized.reasons.is_empty() {
         lines.push(Line::styled(
             "Reasons",
             Style::default()
@@ -801,35 +797,28 @@ fn explain_lines(
                 .add_modifier(Modifier::BOLD),
         ));
         lines.extend(
-            explain
+            normalized
                 .reasons
                 .iter()
                 .map(|r| Line::from(format!("  {}: {}", r.code, r.message))),
         );
     }
-    if !explain.gates.is_empty() {
+    if !normalized.gates.is_empty() {
         lines.push(Line::styled(
             "Export gates",
             Style::default()
                 .fg(theme.header_fg)
                 .add_modifier(Modifier::BOLD),
         ));
-        lines.extend(explain.gates.iter().map(|g| {
-            let verdict = match ExportGateVerdict::try_from(g.verdict)
-                .unwrap_or(ExportGateVerdict::Unspecified)
-            {
-                ExportGateVerdict::Pass => "pass",
-                ExportGateVerdict::Stop => "stop",
-                ExportGateVerdict::NotApplicable => "not applicable",
-                ExportGateVerdict::Unspecified => "unspecified",
-            };
+        lines.extend(normalized.gates.iter().map(|g| {
             Line::from(format!(
-                "  {} | {verdict} | {} | {}",
-                g.gate, g.code, g.detail
+                "  {} | {} | {} | {}",
+                g.gate, g.verdict, g.code, g.detail
             ))
         }));
     }
-    if let Some(m) = &explain.modifications {
+    {
+        let m = &normalized.modifications;
         let mut mods = Vec::new();
         if let Some(v) = m.set_local_pref {
             mods.push(format!("local-pref={v}"));
@@ -841,10 +830,10 @@ fn explain_lines(
             mods.push(format!("next-hop={}", m.set_next_hop));
         }
         if !m.communities_add.is_empty() {
-            mods.push(format!("communities+={:?}", m.communities_add));
+            mods.push(format!("communities+={}", m.communities_add.join(",")));
         }
         if !m.communities_remove.is_empty() {
-            mods.push(format!("communities-={:?}", m.communities_remove));
+            mods.push(format!("communities-={}", m.communities_remove.join(",")));
         }
         if !m.extended_communities_add.is_empty() {
             mods.push(format!(
@@ -1007,7 +996,10 @@ fn optional_u32(value: Option<u32>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::proto::{GlobalState, HealthResponse, NeighborConfig, NeighborState};
+    use crate::proto::{
+        ExplainDecision, ExportGateVerdict, GlobalState, HealthResponse, NeighborConfig,
+        NeighborState,
+    };
     use crate::tui::data::DataSnapshot;
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
@@ -1613,9 +1605,11 @@ mod tests {
             "local-pref=200",
             "MED=0",
             "prepend=64512x2",
+            "communities+=65000:1",
         ] {
             assert!(rendered.contains(text), "missing {text}");
         }
+        assert!(!rendered.contains("4259840001"));
         app.explain = Some(ExplainState::Ready(Box::new(
             crate::proto::ExplainAdvertisedRouteResponse {
                 decision: ExplainDecision::Advertise as i32,

--- a/crates/cli/src/tui/ui.rs
+++ b/crates/cli/src/tui/ui.rs
@@ -9,7 +9,8 @@ use crate::commands::neighbor::{
     optional_seconds_label, rfc8212_policy_status_label,
 };
 use crate::output::{format_duration, format_state_with_stale, neighbor_source_label};
-use crate::tui::app::{App, SortColumn, View, neighbor_key};
+use crate::proto::{ExplainDecision, ExportGateVerdict};
+use crate::tui::app::{App, ExplainState, RibPageState, SortColumn, View, neighbor_key};
 use crate::tui::data::{Freshness, RouteEventEntry, RouteEventKind};
 use crate::tui::theme::Theme;
 
@@ -17,6 +18,8 @@ pub fn draw(f: &mut Frame, app: &mut App, theme: &Theme) {
     match app.view.clone() {
         View::PeerTable => draw_main(f, app, theme),
         View::PeerDetail(address) => draw_peer_detail(f, app, &address, theme),
+        View::BestRib(peer) => draw_best_rib(f, app, &peer, theme),
+        View::AdvertisedExplain(peer) => draw_advertised_explain(f, app, &peer, theme),
     }
 
     if app.show_help {
@@ -622,6 +625,267 @@ fn draw_peer_detail(f: &mut Frame, app: &mut App, address: &str, theme: &Theme) 
     f.render_widget(paragraph, inner);
 }
 
+fn draw_best_rib(f: &mut Frame, app: &mut App, peer: &str, theme: &Theme) {
+    let block = Block::default()
+        .title(format!(" Best RIB (point-in-time) | target {peer} "))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.border));
+    let inner = block.inner(f.area());
+    f.render_widget(block, f.area());
+    match app.rib_page.as_ref() {
+        Some(RibPageState::Loading) | None => {
+            f.render_widget(Paragraph::new("Loading routes..."), inner)
+        }
+        Some(RibPageState::Error(message)) => f.render_widget(
+            Paragraph::new(message.as_str()).style(Style::default().fg(theme.error)),
+            inner,
+        ),
+        Some(RibPageState::Ready(page)) if page.routes.is_empty() => {
+            let message = if page.total_count == 0 {
+                "No best routes"
+            } else {
+                "Empty page"
+            };
+            f.render_widget(Paragraph::new(format!("{message}\n\nEsc Back")), inner);
+        }
+        Some(RibPageState::Ready(page)) => {
+            let rows = page.routes.iter().take(100).map(|route| {
+                Row::new(vec![
+                    Cell::from(format!("{}/{}", route.prefix, route.prefix_length)),
+                    Cell::from(route.next_hop.clone()),
+                    Cell::from(route.peer_address.clone()),
+                    Cell::from(
+                        route
+                            .as_path
+                            .iter()
+                            .map(u32::to_string)
+                            .collect::<Vec<_>>()
+                            .join(" "),
+                    ),
+                    Cell::from(route.local_pref.to_string()),
+                    Cell::from(route.med_attr.map_or_else(|| "-".into(), |v| v.to_string())),
+                    Cell::from(route.validation_state.clone()),
+                    Cell::from(route.aspa_state.clone()),
+                ])
+            });
+            let footer = format!(
+                "row {}/{} | page rows {} | total {} | n Next | p Previous | Enter Explain | Esc Back",
+                app.rib_table_state.selected().map_or(0, |i| i + 1),
+                page.routes.len(),
+                page.routes.len(),
+                page.total_count
+            );
+            let chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(inner);
+            let table = Table::new(
+                rows,
+                [
+                    Constraint::Min(16),
+                    Constraint::Min(13),
+                    Constraint::Min(13),
+                    Constraint::Min(12),
+                    Constraint::Length(9),
+                    Constraint::Length(7),
+                    Constraint::Length(9),
+                    Constraint::Length(8),
+                ],
+            )
+            .header(
+                Row::new([
+                    "Prefix",
+                    "Next Hop",
+                    "Source Peer",
+                    "AS Path",
+                    "LocalPref",
+                    "MED",
+                    "RPKI",
+                    "ASPA",
+                ])
+                .style(
+                    Style::default()
+                        .fg(theme.header_fg)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            )
+            .row_highlight_style(
+                Style::default()
+                    .fg(theme.highlight)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol("> ");
+            f.render_stateful_widget(table, chunks[0], &mut app.rib_table_state);
+            f.render_widget(
+                Paragraph::new(footer).style(Style::default().fg(theme.text_dim)),
+                chunks[1],
+            );
+        }
+    }
+}
+
+fn draw_advertised_explain(f: &mut Frame, app: &mut App, peer: &str, theme: &Theme) {
+    let block = Block::default()
+        .title(format!(" Advertised Route Explain | target {peer} "))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.border));
+    let inner = block.inner(f.area());
+    f.render_widget(block, f.area());
+    let mut lines = match app.explain.as_ref() {
+        Some(ExplainState::Loading) | None => vec![Line::from("Loading route explanation...")],
+        Some(ExplainState::Error(message)) => vec![Line::styled(
+            message.clone(),
+            Style::default().fg(theme.error),
+        )],
+        Some(ExplainState::Ready(explain)) => explain_lines(explain, theme),
+    };
+    lines.push(Line::from(""));
+    lines.push(Line::styled(
+        "j/k/Pg/Home/End Scroll | Esc Back",
+        Style::default().fg(theme.text_dim),
+    ));
+    app.set_explain_layout(lines.len(), usize::from(inner.height));
+    f.render_widget(
+        Paragraph::new(lines).scroll((u16::try_from(app.explain_scroll).unwrap_or(u16::MAX), 0)),
+        inner,
+    );
+}
+
+fn explain_lines(
+    explain: &crate::proto::ExplainAdvertisedRouteResponse,
+    theme: &Theme,
+) -> Vec<Line<'static>> {
+    let decision =
+        match ExplainDecision::try_from(explain.decision).unwrap_or(ExplainDecision::Unspecified) {
+            ExplainDecision::Advertise => "Advertise",
+            ExplainDecision::Deny => "Deny",
+            ExplainDecision::NoBestRoute => "No Best Route",
+            ExplainDecision::UnsupportedFamily => "Unsupported",
+            ExplainDecision::Unspecified => "Unspecified",
+        };
+    let mut lines = vec![
+        Line::styled(
+            format!("Decision: {decision}"),
+            Style::default()
+                .fg(theme.header_fg)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Line::from(format!("Peer: {}", explain.peer_address)),
+        Line::from(format!(
+            "Prefix: {}/{}",
+            explain.prefix, explain.prefix_length
+        )),
+    ];
+    if !explain.route_peer_address.is_empty() {
+        lines.push(Line::from(format!(
+            "Route peer: {}",
+            explain.route_peer_address
+        )));
+    }
+    if !explain.next_hop.is_empty() {
+        lines.push(Line::from(format!("Next hop: {}", explain.next_hop)));
+    }
+    if let Some(group) = explain.update_group_id {
+        lines.push(Line::from(format!("Update group: {group}")));
+    }
+    lines.push(Line::from(format!(
+        "Adj-RIB-Out sync: {}",
+        if explain.already_advertised {
+            "already advertised"
+        } else {
+            "not already advertised"
+        }
+    )));
+    if !explain.reasons.is_empty() {
+        lines.push(Line::styled(
+            "Reasons",
+            Style::default()
+                .fg(theme.header_fg)
+                .add_modifier(Modifier::BOLD),
+        ));
+        lines.extend(
+            explain
+                .reasons
+                .iter()
+                .map(|r| Line::from(format!("  {}: {}", r.code, r.message))),
+        );
+    }
+    if !explain.gates.is_empty() {
+        lines.push(Line::styled(
+            "Export gates",
+            Style::default()
+                .fg(theme.header_fg)
+                .add_modifier(Modifier::BOLD),
+        ));
+        lines.extend(explain.gates.iter().map(|g| {
+            let verdict = match ExportGateVerdict::try_from(g.verdict)
+                .unwrap_or(ExportGateVerdict::Unspecified)
+            {
+                ExportGateVerdict::Pass => "pass",
+                ExportGateVerdict::Stop => "stop",
+                ExportGateVerdict::NotApplicable => "not applicable",
+                ExportGateVerdict::Unspecified => "unspecified",
+            };
+            Line::from(format!(
+                "  {} | {verdict} | {} | {}",
+                g.gate, g.code, g.detail
+            ))
+        }));
+    }
+    if let Some(m) = &explain.modifications {
+        let mut mods = Vec::new();
+        if let Some(v) = m.set_local_pref {
+            mods.push(format!("local-pref={v}"));
+        }
+        if let Some(v) = m.set_med {
+            mods.push(format!("MED={v}"));
+        }
+        if !m.set_next_hop.is_empty() {
+            mods.push(format!("next-hop={}", m.set_next_hop));
+        }
+        if !m.communities_add.is_empty() {
+            mods.push(format!("communities+={:?}", m.communities_add));
+        }
+        if !m.communities_remove.is_empty() {
+            mods.push(format!("communities-={:?}", m.communities_remove));
+        }
+        if !m.extended_communities_add.is_empty() {
+            mods.push(format!(
+                "extended-communities+={:?}",
+                m.extended_communities_add
+            ));
+        }
+        if !m.extended_communities_remove.is_empty() {
+            mods.push(format!(
+                "extended-communities-={:?}",
+                m.extended_communities_remove
+            ));
+        }
+        if !m.large_communities_add.is_empty() {
+            mods.push(format!(
+                "large-communities+={}",
+                m.large_communities_add.join(",")
+            ));
+        }
+        if !m.large_communities_remove.is_empty() {
+            mods.push(format!(
+                "large-communities-={}",
+                m.large_communities_remove.join(",")
+            ));
+        }
+        if let (Some(asn), Some(count)) = (m.as_path_prepend_asn, m.as_path_prepend_count) {
+            mods.push(format!("prepend={asn}x{count}"));
+        }
+        if !mods.is_empty() {
+            lines.push(Line::styled(
+                "Modifications",
+                Style::default()
+                    .fg(theme.header_fg)
+                    .add_modifier(Modifier::BOLD),
+            ));
+            lines.extend(mods.into_iter().map(|m| Line::from(format!("  {m}"))));
+        }
+    }
+    lines
+}
+
 fn draw_help_overlay(f: &mut Frame, theme: &Theme) {
     let area = centered_rect(50, 60, f.area());
     f.render_widget(Clear, area);
@@ -674,7 +938,21 @@ fn draw_help_overlay(f: &mut Frame, theme: &Theme) {
         ]),
         Line::from(vec![
             Span::styled("  Enter       ", Style::default().fg(theme.accent)),
-            Span::styled("Show peer detail", Style::default().fg(theme.text)),
+            Span::styled(
+                "Show detail / explain selected route",
+                Style::default().fg(theme.text),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  r           ", Style::default().fg(theme.accent)),
+            Span::styled(
+                "Open point-in-time Best RIB",
+                Style::default().fg(theme.text),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  n / p       ", Style::default().fg(theme.accent)),
+            Span::styled("Next / previous RIB page", Style::default().fg(theme.text)),
         ]),
         Line::from(vec![
             Span::styled("  Esc         ", Style::default().fg(theme.accent)),
@@ -1210,5 +1488,131 @@ mod tests {
                 assert!(!rendered.contains("no peers or dynamic ranges configured"));
             }
         }
+    }
+
+    fn rendered_app(app: &mut App, width: u16, height: u16) -> String {
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal
+            .draw(|frame| draw(frame, app, &Theme::default()))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn best_rib_test_backend_renders_all_states_and_columns_without_tiny_panic() {
+        let mut app = App::new();
+        app.view = View::BestRib("198.51.100.1".into());
+        app.rib_page = Some(RibPageState::Loading);
+        assert!(rendered_app(&mut app, 100, 8).contains("Loading routes"));
+        app.rib_page = Some(RibPageState::Error("RIB unavailable: down".into()));
+        assert!(rendered_app(&mut app, 100, 8).contains("RIB unavailable: down"));
+        app.rib_page = Some(RibPageState::Ready(crate::proto::ListRoutesResponse {
+            total_count: 0,
+            ..Default::default()
+        }));
+        assert!(rendered_app(&mut app, 100, 8).contains("No best routes"));
+        app.rib_page = Some(RibPageState::Ready(crate::proto::ListRoutesResponse {
+            routes: vec![crate::proto::Route {
+                prefix: "203.0.113.0".into(),
+                prefix_length: 24,
+                next_hop: "192.0.2.1".into(),
+                peer_address: "192.0.2.2".into(),
+                as_path: vec![64512, 64496],
+                local_pref: 100,
+                med_attr: Some(0),
+                validation_state: "valid".into(),
+                aspa_state: "unknown".into(),
+                ..Default::default()
+            }],
+            total_count: 1,
+            ..Default::default()
+        }));
+        app.rib_table_state.select(Some(0));
+        let rendered = rendered_app(&mut app, 150, 8);
+        for text in [
+            "Best RIB (point-in-time)",
+            "203.0.113.0/24",
+            "192.0.2.1",
+            "64512 64496",
+            "LocalPref",
+            "MED",
+            "RPKI",
+            "ASPA",
+            "Enter Explain",
+        ] {
+            assert!(rendered.contains(text), "missing {text}");
+        }
+        let _ = rendered_app(&mut app, 1, 1);
+    }
+
+    #[test]
+    fn explain_test_backend_renders_verdict_reasons_gates_and_modifications() {
+        let mut app = App::new();
+        app.view = View::AdvertisedExplain("198.51.100.1".into());
+        app.explain = Some(ExplainState::Ready(Box::new(
+            crate::proto::ExplainAdvertisedRouteResponse {
+                decision: ExplainDecision::Deny as i32,
+                peer_address: "198.51.100.1".into(),
+                prefix: "203.0.113.0".into(),
+                prefix_length: 24,
+                next_hop: "192.0.2.1".into(),
+                route_peer_address: "192.0.2.2".into(),
+                update_group_id: Some(7),
+                already_advertised: true,
+                reasons: vec![crate::proto::ExplainReason {
+                    code: "policy_denied".into(),
+                    message: "term reject-bogon".into(),
+                }],
+                gates: vec![crate::proto::ExportGateStep {
+                    gate: "export_policy".into(),
+                    code: "policy_denied".into(),
+                    verdict: ExportGateVerdict::Stop as i32,
+                    detail: "term reject-bogon".into(),
+                }],
+                modifications: Some(crate::proto::ExplainModifications {
+                    set_local_pref: Some(200),
+                    set_med: Some(0),
+                    set_next_hop: "192.0.2.9".into(),
+                    communities_add: vec![4_259_840_001],
+                    large_communities_add: vec!["64512:1:2".into()],
+                    as_path_prepend_asn: Some(64512),
+                    as_path_prepend_count: Some(2),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        )));
+        let rendered = rendered_app(&mut app, 160, 24);
+        for text in [
+            "Decision: Deny",
+            "Route peer: 192.0.2.2",
+            "Update group: 7",
+            "already advertised",
+            "Reasons",
+            "policy_denied",
+            "Export gates",
+            "export_policy",
+            "stop",
+            "Modifications",
+            "local-pref=200",
+            "MED=0",
+            "prepend=64512x2",
+        ] {
+            assert!(rendered.contains(text), "missing {text}");
+        }
+        app.explain = Some(ExplainState::Ready(Box::new(
+            crate::proto::ExplainAdvertisedRouteResponse {
+                decision: ExplainDecision::Advertise as i32,
+                ..Default::default()
+            },
+        )));
+        assert!(rendered_app(&mut app, 40, 4).contains("Decision: Advertise"));
+        let _ = rendered_app(&mut app, 1, 1);
     }
 }

--- a/crates/cli/src/tui/ui.rs
+++ b/crates/cli/src/tui/ui.rs
@@ -662,8 +662,8 @@ fn draw_best_rib(f: &mut Frame, app: &mut App, peer: &str, theme: &Theme) {
                             .collect::<Vec<_>>()
                             .join(" "),
                     ),
-                    Cell::from(route.local_pref.to_string()),
-                    Cell::from(route.med_attr.map_or_else(|| "-".into(), |v| v.to_string())),
+                    Cell::from(optional_u32(route.local_pref_attr)),
+                    Cell::from(optional_u32(route.med_attr)),
                     Cell::from(route.validation_state.clone()),
                     Cell::from(route.aspa_state.clone()),
                 ])
@@ -1000,6 +1000,10 @@ fn format_number(n: u64) -> String {
     result.chars().rev().collect()
 }
 
+fn optional_u32(value: Option<u32>) -> String {
+    value.map_or_else(|| "-".to_string(), |value| value.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1016,6 +1020,12 @@ mod tests {
         assert_eq!(format_number(1000), "1,000");
         assert_eq!(format_number(12345), "12,345");
         assert_eq!(format_number(1234567), "1,234,567");
+    }
+
+    #[test]
+    fn optional_route_attributes_distinguish_absent_from_explicit_zero() {
+        assert_eq!(optional_u32(None), "-");
+        assert_eq!(optional_u32(Some(0)), "0");
     }
 
     /// Red proof: restoring the source-only event row or storing the primary

--- a/crates/cli/src/tui/ui.rs
+++ b/crates/cli/src/tui/ui.rs
@@ -837,14 +837,22 @@ fn explain_lines(
         }
         if !m.extended_communities_add.is_empty() {
             mods.push(format!(
-                "extended-communities+={:?}",
+                "extended-communities+={}",
                 m.extended_communities_add
+                    .iter()
+                    .map(u64::to_string)
+                    .collect::<Vec<_>>()
+                    .join(",")
             ));
         }
         if !m.extended_communities_remove.is_empty() {
             mods.push(format!(
-                "extended-communities-={:?}",
+                "extended-communities-={}",
                 m.extended_communities_remove
+                    .iter()
+                    .map(u64::to_string)
+                    .collect::<Vec<_>>()
+                    .join(",")
             ));
         }
         if !m.large_communities_add.is_empty() {
@@ -1582,6 +1590,8 @@ mod tests {
                     set_med: Some(0),
                     set_next_hop: "192.0.2.9".into(),
                     communities_add: vec![4_259_840_001],
+                    extended_communities_add: vec![4_294_967_297, 4_294_967_298],
+                    extended_communities_remove: vec![8_589_934_593],
                     large_communities_add: vec!["64512:1:2".into()],
                     as_path_prepend_asn: Some(64512),
                     as_path_prepend_count: Some(2),
@@ -1606,10 +1616,13 @@ mod tests {
             "MED=0",
             "prepend=64512x2",
             "communities+=65000:1",
+            "extended-communities+=4294967297,4294967298",
+            "extended-communities-=8589934593",
         ] {
             assert!(rendered.contains(text), "missing {text}");
         }
         assert!(!rendered.contains("4259840001"));
+        assert!(!rendered.contains("[4294967297"));
         app.explain = Some(ExplainState::Ready(Box::new(
             crate::proto::ExplainAdvertisedRouteResponse {
                 decision: ExplainDecision::Advertise as i32,

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1983,6 +1983,26 @@ initially unavailable inventory, and a retained stale count; failure of this
 optional inventory does not mark the core connection disconnected.
 Press `h` for keybindings.
 
+From peer detail, `r` opens the unicast export-explain browser. It takes a
+point-in-time page of the global Best-RIB (100 routes per page) while retaining
+the selected peer only as the export target. Use `n` and `p` to follow the
+server's opaque page tokens, and `Enter` to evaluate the highlighted prefix
+with `ExplainAdvertisedRoute`. The result shows advertise or deny, ordered
+gates and reasons, policy attribution, and route modifications. A denial is
+explainable even when the route is absent from Adj-RIB-Out.
+
+The browser does not poll the RIB or retry general failures automatically.
+Leaving or quitting the view, or removal of the selected peer on a fresh
+snapshot, cancels its request. If pagination becomes stale and the daemon
+returns `ABORTED`, the browser restarts at page 1 once. Both the Best-RIB list
+and export-explain requests use the existing bearer credentials and require
+`SensitiveRead` authorization.
+
+This view deliberately does not provide arbitrary search, import/rejected-route
+browsing, best-path comparison, VPN, labeled-unicast, or source-candidate
+explanations. It also does not imply that a route must exist in Adj-RIB-Out.
+Use the CLI explain catalog for those broader questions.
+
 ### Watch live events
 
 ```bash

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -145,6 +145,12 @@ rbgp bfd       # BFD sessions, if configured
 rbgp top       # live TUI dashboard
 ```
 
+From the TUI peer detail, press `r` to browse the point-in-time global unicast
+Best-RIB for that peer as an export target. Use `n`/`p` to page and `Enter` to
+show whether the selected prefix would be advertised or denied, including the
+ordered export gates and policy reasons. This is an on-demand export view, not
+a live RIB feed.
+
 If `prometheus_addr` is configured, HTTP probes share that listener:
 
 ```bash

--- a/docs/explain.md
+++ b/docs/explain.md
@@ -11,6 +11,14 @@ command.
 Every command below also takes `--json` for scripting and portal
 backends.
 
+The TUI exposes one focused part of this catalog: from a selected peer's detail,
+press `r` to browse the point-in-time global unicast Best-RIB, then `Enter` to
+explain the export decision for that prefix and peer. It shows advertise/deny,
+ordered gates and policy reasons, and modifications, including denials absent
+from Adj-RIB-Out. It is not a live RIB feed and does not cover import/rejected
+routes, best-path comparison, VPN, labeled-unicast, or source candidates; use
+the commands below for the full catalog.
+
 | Question | Command |
 |----------|---------|
 | Why was this path selected as best? | `rbgp rib --prefix <cidr> --explain` |


### PR DESCRIPTION
## What changed

- add a cancellable, single-flight TUI query lane for one Best-RIB page and advertised-route explanation
- add point-in-time Best-RIB and per-peer unicast export-explain views to `rbgp top`
- preserve opaque server pagination, exact request identity, cancellation, authorization, and existing CLI explanation normalization
- render presence-aware route attributes and bounded loading, empty, error, table, and explanation states
- document the operator workflow, authorization requirements, cancellation behavior, and explicit non-goals

## Why

Route explanation was available from the CLI but absent from the live dashboard operators keep open. The new flow starts from a selected peer, pages through the global Best-RIB, and explains whether the selected winner would be advertised to that peer, including ordered gates, reasons, and policy modifications.

The slice deliberately remains point-in-time and unicast-only. It does not add polling, new RPCs, arbitrary prefix search, import/rejected-route browsing, VPN/labeled/source-candidate explain, or an Adj-RIB-Out dependency.

## Operator impact

From peer detail, press `r` to open the Best-RIB page, use `n`/`p` for opaque server pages, and press Enter on a selected prefix for its export explanation. Leaving the view, quitting, or losing the selected peer cancels the outstanding query. An expired paged snapshot automatically restarts at page one once.

## Verification

- `cargo test -p rustbgpctl`
- `cargo clippy -p rustbgpctl --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/check_public_tracker_ids.py`
- `python3 scripts/check_release_install_contract.py`
- `cargo test -p rustbgpctl curated_documentation_commands_parse_with_the_real_cli`
- `git diff --check`

