### PR TITLE
fix: watchdog config apply settlement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2970,6 +2970,7 @@ dependencies = [
  "bytes",
  "criterion",
  "futures",
+ "libc",
  "nix 0.31.3",
  "prometheus",
  "prost",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -37,6 +37,7 @@ tracing.workspace = true
 thiserror.workspace = true
 tokio-stream.workspace = true
 tokio-rustls.workspace = true
+libc.workspace = true
 arc-swap.workspace = true
 futures = "0.3"
 prometheus.workspace = true

--- a/crates/api/src/config_service.rs
+++ b/crates/api/src/config_service.rs
@@ -20,8 +20,9 @@ use crate::peer_types::{
 };
 use crate::proto;
 use crate::server::{
-    ConfigHistoryListFn, ConfigRollbackFn, ConfigTransactionAbortFn, ConfigTransactionApplyError,
-    ConfigTransactionApplyFn, ConfigTransactionConfirmFn, ConfigTransactionStatusFn,
+    ConfigHistoryListFn, ConfigRollbackFn, ConfigTransactionAbortFn, ConfigTransactionApplyContext,
+    ConfigTransactionApplyError, ConfigTransactionApplyFn, ConfigTransactionConfirmFn,
+    ConfigTransactionStatusFn,
 };
 
 pub(super) const CONFIG_OPERATION_TIMEOUT: Duration = Duration::from_mins(30);
@@ -309,7 +310,8 @@ impl proto::config_service_server::ConfigService for ConfigService {
                 "ConfigService.ApplyConfigTransaction executor is unavailable",
             ));
         };
-        transaction_apply(request)
+        let (context, _attachment) = ConfigTransactionApplyContext::unary();
+        transaction_apply(request, context)
             .await
             .map(Response::new)
             .map_err(ConfigTransactionApplyError::into_status)
@@ -909,7 +911,7 @@ mod tests {
     async fn apply_config_transaction_forwards_to_hook() {
         let (tx, _rx) = mpsc::channel(1);
         let svc = ConfigService::new(tx).with_transaction_hooks(
-            Some(Arc::new(|request| {
+            Some(Arc::new(|request, _context| {
                 Box::pin(async move {
                     assert_eq!(request.candidate_toml, "candidate");
                     assert_eq!(request.expected_runtime_snapshot_token, "kv1:abc:9");

--- a/crates/api/src/config_service/stream.rs
+++ b/crates/api/src/config_service/stream.rs
@@ -1291,9 +1291,10 @@ mod tests {
         let (peer_tx, _peer_rx) = mpsc::channel(1);
         let (hook_tx, mut hook_rx) =
             mpsc::channel::<(proto::ApplyConfigTransactionRequest, HookReply)>(2);
-        let hook: ConfigTransactionApplyFn = Arc::new(move |request| {
+        let hook: ConfigTransactionApplyFn = Arc::new(move |request, context| {
             let hook_tx = hook_tx.clone();
             Box::pin(async move {
+                let _context = context;
                 let (reply, receive) = oneshot::channel();
                 hook_tx.send((request, reply)).await.unwrap();
                 receive.await.unwrap()
@@ -1576,9 +1577,12 @@ mod tests {
             .unwrap();
         let calls = Arc::new(AtomicUsize::new(0));
         let hook_calls = Arc::clone(&calls);
-        let hook: ConfigTransactionApplyFn = Arc::new(move |_request| {
+        let hook: ConfigTransactionApplyFn = Arc::new(move |_request, context| {
             hook_calls.fetch_add(1, Ordering::SeqCst);
-            Box::pin(async { Ok(applied_response()) })
+            Box::pin(async move {
+                let _context = context;
+                Ok(applied_response())
+            })
         });
         let (peer_tx, _peer_rx) = mpsc::channel(1);
         let listener = spawn_listener_with_apply(
@@ -1681,9 +1685,12 @@ mod tests {
         drop(held);
         let calls = Arc::new(AtomicUsize::new(0));
         let hook_calls = Arc::clone(&calls);
-        let hook: ConfigTransactionApplyFn = Arc::new(move |_request| {
+        let hook: ConfigTransactionApplyFn = Arc::new(move |_request, context| {
             hook_calls.fetch_add(1, Ordering::SeqCst);
-            Box::pin(async { Ok(applied_response()) })
+            Box::pin(async move {
+                let _context = context;
+                Ok(applied_response())
+            })
         });
         let (peer_tx, _peer_rx) = mpsc::channel(1);
         let listener = spawn_listener_with_apply(
@@ -1740,9 +1747,12 @@ mod tests {
             .unwrap();
         let calls = Arc::new(AtomicUsize::new(0));
         let hook_calls = Arc::clone(&calls);
-        let hook: ConfigTransactionApplyFn = Arc::new(move |_request| {
+        let hook: ConfigTransactionApplyFn = Arc::new(move |_request, context| {
             hook_calls.fetch_add(1, Ordering::SeqCst);
-            Box::pin(async { Ok(applied_response()) })
+            Box::pin(async move {
+                let _context = context;
+                Ok(applied_response())
+            })
         });
         let (peer_tx, _peer_rx) = mpsc::channel(1);
         let listener = spawn_listener_with_apply(
@@ -1816,9 +1826,10 @@ mod tests {
         let (peer_tx, _peer_rx) = mpsc::channel(1);
         let (hook_tx, mut hook_rx) =
             mpsc::channel::<(proto::ApplyConfigTransactionRequest, HookReply)>(1);
-        let hook: ConfigTransactionApplyFn = Arc::new(move |request| {
+        let hook: ConfigTransactionApplyFn = Arc::new(move |request, context| {
             let hook_tx = hook_tx.clone();
             Box::pin(async move {
+                let _context = context;
                 let (reply, receive) = oneshot::channel();
                 hook_tx.send((request, reply)).await.unwrap();
                 receive.await.unwrap()
@@ -1921,9 +1932,10 @@ mod tests {
         let (peer_tx, mut peer_rx) = mpsc::channel(1);
         let (hook_tx, mut hook_rx) =
             mpsc::channel::<(proto::ApplyConfigTransactionRequest, HookReply)>(1);
-        let hook: ConfigTransactionApplyFn = Arc::new(move |request| {
+        let hook: ConfigTransactionApplyFn = Arc::new(move |request, context| {
             let hook_tx = hook_tx.clone();
             Box::pin(async move {
+                let _context = context;
                 let (reply, receive) = oneshot::channel();
                 hook_tx.send((request, reply)).await.unwrap();
                 receive.await.unwrap()
@@ -2108,9 +2120,10 @@ mod tests {
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
         let (hook_tx, mut hook_rx) =
             mpsc::channel::<(proto::ApplyConfigTransactionRequest, HookReply)>(1);
-        let hook: ConfigTransactionApplyFn = Arc::new(move |request| {
+        let hook: ConfigTransactionApplyFn = Arc::new(move |request, context| {
             let hook_tx = hook_tx.clone();
             Box::pin(async move {
+                let _context = context;
                 let (reply, receive) = oneshot::channel();
                 hook_tx.send((request, reply)).await.unwrap();
                 receive.await.unwrap()

--- a/crates/api/src/config_service/stream/apply.rs
+++ b/crates/api/src/config_service/stream/apply.rs
@@ -4,14 +4,17 @@ use std::sync::Arc;
 
 use sha2::{Digest as _, Sha256};
 use tokio::io::{AsyncReadExt as _, AsyncSeekExt as _, AsyncWriteExt as _};
-use tokio::sync::{OwnedSemaphorePermit, oneshot};
+use tokio::sync::oneshot;
 use tokio::time::{Instant, timeout_at};
 use tonic::{Request, Response, Status};
 
 use super::{AdmissionAudit, FRAME_VERSION, StreamPlanState, principal_role};
 use crate::audit::{GrpcAuditHandle, stream_apply_config_transaction_summary};
 use crate::proto;
-use crate::server::{ConfigTransactionApplyFn, validate_config_transaction_apply_metadata};
+use crate::server::{
+    ConfigTransactionApplyContext, ConfigTransactionApplyFn,
+    validate_config_transaction_apply_metadata,
+};
 
 struct ApplyAudit {
     handle: Option<GrpcAuditHandle>,
@@ -128,23 +131,26 @@ pub(crate) async fn stream_apply_config_transaction(
     audit.outcome = "handed_off";
     audit.publish();
     let (response_tx, response_rx) = oneshot::channel();
+    let (context, attachment) =
+        ConfigTransactionApplyContext::streamed(admission.permit, Arc::clone(&state.admission));
     tokio::spawn(run_detached_apply(
         transaction_apply,
         apply_request,
-        admission.permit,
+        context,
         admission.after_operator_wait,
         audit,
         response_tx,
     ));
-    timeout_at(deadline, response_rx)
+    let response = timeout_at(deadline, response_rx)
         .await
         .map_err(|_| {
             Status::deadline_exceeded(
                 "streamed config apply response exceeded total deadline; apply continues to settlement",
             )
         })?
-        .map_err(|_| Status::internal("streamed config apply task did not complete"))?
-        .map(Response::new)
+        .map_err(|_| Status::internal("streamed config apply task did not complete"))?;
+    drop(attachment);
+    response.map(Response::new)
 }
 
 struct ApplyMetadata {
@@ -333,12 +339,12 @@ async fn read_candidate(
 async fn run_detached_apply(
     transaction_apply: ConfigTransactionApplyFn,
     request: proto::ApplyConfigTransactionRequest,
-    _permit: OwnedSemaphorePermit,
+    context: ConfigTransactionApplyContext,
     after_operator_wait: bool,
     mut audit: ApplyAudit,
     response_tx: oneshot::Sender<Result<proto::ConfigTransactionApplyResponse, Status>>,
 ) {
-    let response = transaction_apply(request)
+    let response = transaction_apply(request, context)
         .await
         .map_err(crate::server::ConfigTransactionApplyError::into_status);
     audit.outcome = if response.is_ok() {

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -34,6 +34,7 @@ pub mod peer_types;
 mod policy_helpers;
 mod policy_service;
 pub mod rib_service;
+pub mod runtime_config_settlement;
 pub mod server;
 #[cfg(test)]
 mod test_support;

--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -8,17 +8,13 @@ use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::thread;
 use std::time::{Duration, Instant};
-
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::health_probe::DaemonGate;
 use crate::server::{RuntimeConfigCoordinator, RuntimeConfigCoordinatorPermit};
 
-/// Fixed maximum time from coordinator ownership to proved settlement.
 pub const OWNED_SETTLEMENT_BUDGET: Duration = Duration::from_mins(30);
-/// Fixed propagation interval between fencing and fail-stop.
 pub const AMBIGUITY_FENCE_GRACE: Duration = Duration::from_secs(5);
-/// Process exit status used after an ambiguous runtime-config mutation.
 pub const AMBIGUOUS_CONFIG_EXIT_STATUS: i32 = 70;
 
 /// Closed roster of runtime-config operations that can own the coordinator.
@@ -55,7 +51,6 @@ pub enum RuntimeConfigOperationKind {
     PolicyNeighborExportClear,
 }
 
-/// Monotonic nonterminal phase of an owned mutation.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum RuntimeConfigSettlementPhase {
     OwnedPreflight,
@@ -63,7 +58,6 @@ pub enum RuntimeConfigSettlementPhase {
     SettlingRollback,
 }
 
-/// Immutable terminal state of an owned mutation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RuntimeConfigSettlementTerminal {
     Owned,
@@ -71,7 +65,6 @@ pub enum RuntimeConfigSettlementTerminal {
     AmbiguousFenced,
 }
 
-/// Cause of an ambiguity fence.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RuntimeConfigFenceReason {
     BudgetExpired,
@@ -132,20 +125,23 @@ struct RegistryState {
     stopping: bool,
 }
 
-enum TerminalAction {
-    Exit(fn(i32) -> !),
-    #[cfg(test)]
-    Notify(std::sync::mpsc::Sender<i32>),
-}
-
 struct Registry {
     state: Mutex<RegistryState>,
     wake: Condvar,
     next_id: AtomicU64,
     budget: Duration,
     grace: Duration,
-    terminal: TerminalAction,
     thread_id: Mutex<Option<thread::ThreadId>>,
+    #[cfg(test)]
+    terminal: std::sync::mpsc::Sender<i32>,
+    #[cfg(test)]
+    pre_wait_hook: Mutex<Option<PreWaitHook>>,
+}
+
+#[cfg(test)]
+struct PreWaitHook {
+    reached: std::sync::mpsc::Sender<()>,
+    resume: std::sync::mpsc::Receiver<()>,
 }
 
 impl Registry {
@@ -168,10 +164,11 @@ impl Registry {
     }
 }
 
-/// Cloneable owner of one OS-thread clock multiplexer.
 #[derive(Clone)]
 pub struct RuntimeConfigSettlementWatchdog {
     registry: Arc<Registry>,
+    #[cfg(test)]
+    thread: Arc<Mutex<Option<thread::JoinHandle<()>>>>,
 }
 
 impl std::fmt::Debug for RuntimeConfigSettlementWatchdog {
@@ -185,15 +182,14 @@ impl std::fmt::Debug for RuntimeConfigSettlementWatchdog {
 impl RuntimeConfigSettlementWatchdog {
     /// Start the process watchdog using fixed production durations.
     #[must_use]
-    pub fn new(exit: fn(i32) -> !) -> Self {
-        Self::start(
-            OWNED_SETTLEMENT_BUDGET,
-            AMBIGUITY_FENCE_GRACE,
-            TerminalAction::Exit(exit),
-        )
+    #[cfg(not(test))]
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self::start(OWNED_SETTLEMENT_BUDGET, AMBIGUITY_FENCE_GRACE)
     }
 
-    fn start(budget: Duration, grace: Duration, terminal: TerminalAction) -> Self {
+    #[cfg(not(test))]
+    fn start(budget: Duration, grace: Duration) -> Self {
         let registry = Arc::new(Registry {
             state: Mutex::new(RegistryState {
                 registrations: HashMap::new(),
@@ -203,7 +199,6 @@ impl RuntimeConfigSettlementWatchdog {
             next_id: AtomicU64::new(1),
             budget,
             grace,
-            terminal,
             thread_id: Mutex::new(None),
         });
         let thread_registry = Arc::clone(&registry);
@@ -214,7 +209,32 @@ impl RuntimeConfigSettlementWatchdog {
         Self { registry }
     }
 
-    /// Register resources after physical coordinator ownership is acquired.
+    #[cfg(test)]
+    fn start(budget: Duration, grace: Duration, terminal: std::sync::mpsc::Sender<i32>) -> Self {
+        let registry = Arc::new(Registry {
+            state: Mutex::new(RegistryState {
+                registrations: HashMap::new(),
+                stopping: false,
+            }),
+            wake: Condvar::new(),
+            next_id: AtomicU64::new(1),
+            budget,
+            grace,
+            thread_id: Mutex::new(None),
+            terminal,
+            pre_wait_hook: Mutex::new(None),
+        });
+        let thread_registry = Arc::clone(&registry);
+        let thread = thread::Builder::new()
+            .name("config-settlement-watchdog".into())
+            .spawn(move || watchdog_loop(&thread_registry))
+            .expect("config settlement watchdog OS thread must start");
+        Self {
+            registry,
+            thread: Arc::new(Mutex::new(Some(thread))),
+        }
+    }
+
     pub fn register_owned(
         &self,
         kind: RuntimeConfigOperationKind,
@@ -414,13 +434,13 @@ fn watchdog_loop(registry: &Arc<Registry>) {
         .thread_id
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(thread::current().id());
-    loop {
-        let now = Instant::now();
-        let (expired, terminal, wait) = {
-            let state = registry.lock();
+    'watchdog: loop {
+        let mut state = registry.lock();
+        loop {
             if state.stopping {
-                return;
+                break 'watchdog;
             }
+            let now = Instant::now();
             let expired = state
                 .registrations
                 .values()
@@ -450,61 +470,108 @@ fn watchdog_loop(registry: &Arc<Registry>) {
                 })
                 .min()
                 .map_or(registry.budget, |next| next.saturating_duration_since(now));
-            (expired, terminal, wait)
-        };
-        for operation in expired {
-            fence(&operation, RuntimeConfigFenceReason::BudgetExpired);
-        }
-        if let Some(operation) = terminal {
-            run_terminal_action(registry, &operation);
-        }
-        let state = registry.lock();
-        drop(
-            registry
+            if !expired.is_empty() || terminal.is_some() {
+                drop(state);
+                for operation in expired {
+                    fence(&operation, RuntimeConfigFenceReason::BudgetExpired);
+                }
+                if let Some(operation) = terminal {
+                    run_terminal_action(registry, &operation);
+                }
+                continue 'watchdog;
+            }
+            #[cfg(test)]
+            if let Some(hook) = registry
+                .pre_wait_hook
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take()
+            {
+                let _ = hook.reached.send(());
+                let _ = hook.resume.recv();
+            }
+            (state, _) = registry
                 .wake
                 .wait_timeout(state, wait)
-                .unwrap_or_else(std::sync::PoisonError::into_inner),
-        );
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
     }
+    *registry
+        .thread_id
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+    registry.wake.notify_all();
 }
 
 #[cfg(not(test))]
-fn run_terminal_action(registry: &Registry, _operation: &OperationInner) -> ! {
-    match registry.terminal {
-        TerminalAction::Exit(exit) => exit(AMBIGUOUS_CONFIG_EXIT_STATUS),
-    }
+#[allow(unsafe_code)]
+fn run_terminal_action(_registry: &Registry, _operation: &OperationInner) -> ! {
+    // SAFETY: `_exit` is the fail-stop contract and must skip cleanup.
+    unsafe { libc::_exit(AMBIGUOUS_CONFIG_EXIT_STATUS) }
 }
 
 #[cfg(test)]
 fn run_terminal_action(registry: &Registry, operation: &OperationInner) {
-    match &registry.terminal {
-        TerminalAction::Exit(exit) => exit(AMBIGUOUS_CONFIG_EXIT_STATUS),
-        TerminalAction::Notify(sender) => {
-            let _ = sender.send(AMBIGUOUS_CONFIG_EXIT_STATUS);
-            registry.unregister(operation.id);
-            operation
-                .resources
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .take();
-        }
-    }
+    let _ = registry.terminal.send(AMBIGUOUS_CONFIG_EXIT_STATUS);
+    registry.unregister(operation.id);
+    operation
+        .resources
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take();
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    struct TestWatchdog(RuntimeConfigSettlementWatchdog);
+
+    impl std::ops::Deref for TestWatchdog {
+        type Target = RuntimeConfigSettlementWatchdog;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl Drop for TestWatchdog {
+        fn drop(&mut self) {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            let mut state = self.registry.lock();
+            while !state.registrations.is_empty() {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                assert!(
+                    !remaining.is_zero(),
+                    "watchdog cleanup refused owned registrations"
+                );
+                (state, _) = self
+                    .registry
+                    .wake
+                    .wait_timeout(state, remaining)
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+            }
+            state.stopping = true;
+            self.registry.wake.notify_all();
+            drop(state);
+            if let Some(thread) = self.0.thread.lock().unwrap().take() {
+                thread
+                    .join()
+                    .expect("watchdog test thread must stop cleanly");
+            }
+            assert!(self.registry.thread_id.lock().unwrap().is_none());
+        }
+    }
+
     fn test_watchdog(
         budget: Duration,
         grace: Duration,
-    ) -> (
-        RuntimeConfigSettlementWatchdog,
-        std::sync::mpsc::Receiver<i32>,
-    ) {
+    ) -> (TestWatchdog, std::sync::mpsc::Receiver<i32>) {
         let (sender, receiver) = std::sync::mpsc::channel();
         (
-            RuntimeConfigSettlementWatchdog::start(budget, grace, TerminalAction::Notify(sender)),
+            TestWatchdog(RuntimeConfigSettlementWatchdog::start(
+                budget, grace, sender,
+            )),
             receiver,
         )
     }
@@ -614,10 +681,15 @@ mod tests {
     #[tokio::test]
     async fn many_settlements_leave_no_registrations_and_share_thread() {
         let (watchdog, _receiver) = test_watchdog(Duration::from_secs(5), Duration::from_secs(1));
+        let start_deadline = Instant::now() + Duration::from_secs(5);
         let thread_id = loop {
             if let Some(thread_id) = *watchdog.registry.thread_id.lock().unwrap() {
                 break thread_id;
             }
+            assert!(
+                Instant::now() < start_deadline,
+                "watchdog thread failed to start"
+            );
             thread::yield_now();
         };
         for _ in 0..32 {
@@ -687,5 +759,40 @@ mod tests {
             assert_eq!(receiver.recv_timeout(Duration::from_secs(5)).unwrap(), 70);
         }
         drop(guard);
+    }
+
+    #[tokio::test]
+    async fn executor_loss_at_pre_wait_boundary_terminates_by_grace() {
+        let old_deadline = Duration::from_secs(4);
+        let grace = Duration::from_millis(20);
+        let (watchdog, receiver) = test_watchdog(old_deadline, grace);
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        let (reached_sender, reached_receiver) = std::sync::mpsc::channel();
+        let (resume_sender, resume_receiver) = std::sync::mpsc::channel();
+        *watchdog.registry.pre_wait_hook.lock().unwrap() = Some(PreWaitHook {
+            reached: reached_sender,
+            resume: resume_receiver,
+        });
+        watchdog.registry.wake.notify_one();
+        reached_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap();
+        let (dropping_sender, dropping_receiver) = std::sync::mpsc::channel();
+        let losing_executor = thread::spawn(move || {
+            dropping_sender.send(()).unwrap();
+            drop(guard);
+        });
+        dropping_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+        let started = Instant::now();
+        resume_sender.send(()).unwrap();
+        assert_eq!(receiver.recv_timeout(Duration::from_secs(1)).unwrap(), 70);
+        assert!(started.elapsed() < old_deadline);
+        losing_executor.join().unwrap();
+        assert_eq!(
+            operation.fence_reason(),
+            Some(RuntimeConfigFenceReason::ExecutorLost)
+        );
     }
 }

--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -1,0 +1,691 @@
+//! Process-independent settlement watchdog for owned runtime-config mutations.
+//!
+//! This module supplies the fail-stop ownership kernel. Call sites arm it only
+//! after acquiring [`RuntimeConfigCoordinatorPermit`].
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::health_probe::DaemonGate;
+use crate::server::{RuntimeConfigCoordinator, RuntimeConfigCoordinatorPermit};
+
+/// Fixed maximum time from coordinator ownership to proved settlement.
+pub const OWNED_SETTLEMENT_BUDGET: Duration = Duration::from_mins(30);
+/// Fixed propagation interval between fencing and fail-stop.
+pub const AMBIGUITY_FENCE_GRACE: Duration = Duration::from_secs(5);
+/// Process exit status used after an ambiguous runtime-config mutation.
+pub const AMBIGUOUS_CONFIG_EXIT_STATUS: i32 = 70;
+
+/// Closed roster of runtime-config operations that can own the coordinator.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RuntimeConfigOperationKind {
+    Apply,
+    Rollback,
+    Confirm,
+    Abort,
+    AutoRevert,
+    GnmiSet,
+    Sighup,
+    NeighborAdd,
+    NeighborDelete,
+    DynamicNeighborAdd,
+    DynamicNeighborDelete,
+    FibTableSet,
+    FibTableDelete,
+    PeerGroupSet,
+    PeerGroupDelete,
+    PeerGroupSetNeighbor,
+    PeerGroupClearNeighbor,
+    PolicySet,
+    PolicyDelete,
+    PolicyNeighborSet,
+    PolicyNeighborSetDelete,
+    PolicyGlobalImportSet,
+    PolicyGlobalExportSet,
+    PolicyGlobalImportClear,
+    PolicyGlobalExportClear,
+    PolicyNeighborImportSet,
+    PolicyNeighborExportSet,
+    PolicyNeighborImportClear,
+    PolicyNeighborExportClear,
+}
+
+/// Monotonic nonterminal phase of an owned mutation.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum RuntimeConfigSettlementPhase {
+    OwnedPreflight,
+    Mutating,
+    SettlingRollback,
+}
+
+/// Immutable terminal state of an owned mutation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RuntimeConfigSettlementTerminal {
+    Owned,
+    Settled,
+    AmbiguousFenced,
+}
+
+/// Cause of an ambiguity fence.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RuntimeConfigFenceReason {
+    BudgetExpired,
+    ExecutorLost,
+}
+
+const TERMINAL_OWNED: u8 = 0;
+const TERMINAL_SETTLED: u8 = 1;
+const TERMINAL_AMBIGUOUS: u8 = 2;
+const PHASE_PREFLIGHT: u8 = 0;
+const PHASE_MUTATING: u8 = 1;
+const PHASE_SETTLING: u8 = 2;
+const AMBIGUITY_REASON_NONE: u8 = 0;
+const AMBIGUITY_REASON_BUDGET: u8 = 1;
+const AMBIGUITY_REASON_EXECUTOR: u8 = 2;
+const AMBIGUITY_NOT_READY: &str = "runtime config settlement is ambiguous";
+
+#[derive(Debug)]
+struct OwnedResources {
+    _coordinator_permit: RuntimeConfigCoordinatorPermit,
+    _stream_permit: Option<OwnedSemaphorePermit>,
+    stream_admission: Option<Arc<Semaphore>>,
+}
+
+struct OperationInner {
+    id: u64,
+    kind: RuntimeConfigOperationKind,
+    deadline: Instant,
+    phase: AtomicU8,
+    terminal: AtomicU8,
+    fence_reason: AtomicU8,
+    response_attached: AtomicBool,
+    coordinator: RuntimeConfigCoordinator,
+    daemon_gate: DaemonGate,
+    resources: Mutex<Option<OwnedResources>>,
+    registry: Arc<Registry>,
+}
+
+impl std::fmt::Debug for OperationInner {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("OperationInner")
+            .field("id", &self.id)
+            .field("kind", &self.kind)
+            .field("deadline", &self.deadline)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug)]
+struct Registration {
+    operation: Arc<OperationInner>,
+    terminal_at: Instant,
+}
+
+struct RegistryState {
+    registrations: HashMap<u64, Registration>,
+    stopping: bool,
+}
+
+enum TerminalAction {
+    Exit(fn(i32) -> !),
+    #[cfg(test)]
+    Notify(std::sync::mpsc::Sender<i32>),
+}
+
+struct Registry {
+    state: Mutex<RegistryState>,
+    wake: Condvar,
+    next_id: AtomicU64,
+    budget: Duration,
+    grace: Duration,
+    terminal: TerminalAction,
+    thread_id: Mutex<Option<thread::ThreadId>>,
+}
+
+impl Registry {
+    fn lock(&self) -> MutexGuard<'_, RegistryState> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn unregister(&self, id: u64) {
+        self.lock().registrations.remove(&id);
+        self.wake.notify_one();
+    }
+
+    fn advance_terminal(&self, id: u64, when: Instant) {
+        if let Some(registration) = self.lock().registrations.get_mut(&id) {
+            registration.terminal_at = when;
+        }
+        self.wake.notify_one();
+    }
+}
+
+/// Cloneable owner of one OS-thread clock multiplexer.
+#[derive(Clone)]
+pub struct RuntimeConfigSettlementWatchdog {
+    registry: Arc<Registry>,
+}
+
+impl std::fmt::Debug for RuntimeConfigSettlementWatchdog {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RuntimeConfigSettlementWatchdog")
+            .finish_non_exhaustive()
+    }
+}
+
+impl RuntimeConfigSettlementWatchdog {
+    /// Start the process watchdog using fixed production durations.
+    #[must_use]
+    pub fn new(exit: fn(i32) -> !) -> Self {
+        Self::start(
+            OWNED_SETTLEMENT_BUDGET,
+            AMBIGUITY_FENCE_GRACE,
+            TerminalAction::Exit(exit),
+        )
+    }
+
+    fn start(budget: Duration, grace: Duration, terminal: TerminalAction) -> Self {
+        let registry = Arc::new(Registry {
+            state: Mutex::new(RegistryState {
+                registrations: HashMap::new(),
+                stopping: false,
+            }),
+            wake: Condvar::new(),
+            next_id: AtomicU64::new(1),
+            budget,
+            grace,
+            terminal,
+            thread_id: Mutex::new(None),
+        });
+        let thread_registry = Arc::clone(&registry);
+        thread::Builder::new()
+            .name("config-settlement-watchdog".into())
+            .spawn(move || watchdog_loop(&thread_registry))
+            .expect("config settlement watchdog OS thread must start");
+        Self { registry }
+    }
+
+    /// Register resources after physical coordinator ownership is acquired.
+    pub fn register_owned(
+        &self,
+        kind: RuntimeConfigOperationKind,
+        coordinator: RuntimeConfigCoordinator,
+        coordinator_permit: RuntimeConfigCoordinatorPermit,
+        daemon_gate: DaemonGate,
+        stream_permit: Option<OwnedSemaphorePermit>,
+        stream_admission: Option<Arc<Semaphore>>,
+    ) -> (OwnedRuntimeConfigOperation, RuntimeConfigExecutorGuard) {
+        let deadline = Instant::now() + self.registry.budget;
+        let id = self.registry.next_id.fetch_add(1, Ordering::Relaxed);
+        let operation = Arc::new(OperationInner {
+            id,
+            kind,
+            deadline,
+            phase: AtomicU8::new(PHASE_PREFLIGHT),
+            terminal: AtomicU8::new(TERMINAL_OWNED),
+            fence_reason: AtomicU8::new(AMBIGUITY_REASON_NONE),
+            response_attached: AtomicBool::new(true),
+            coordinator,
+            daemon_gate,
+            resources: Mutex::new(Some(OwnedResources {
+                _coordinator_permit: coordinator_permit,
+                _stream_permit: stream_permit,
+                stream_admission,
+            })),
+            registry: Arc::clone(&self.registry),
+        });
+        self.registry.lock().registrations.insert(
+            id,
+            Registration {
+                operation: Arc::clone(&operation),
+                terminal_at: deadline + self.registry.grace,
+            },
+        );
+        self.registry.wake.notify_one();
+        (
+            OwnedRuntimeConfigOperation {
+                inner: Arc::clone(&operation),
+            },
+            RuntimeConfigExecutorGuard {
+                inner: Some(operation),
+            },
+        )
+    }
+}
+
+/// Handle used by the daemon-owned operation to report progress and settlement.
+#[derive(Clone, Debug)]
+pub struct OwnedRuntimeConfigOperation {
+    inner: Arc<OperationInner>,
+}
+
+impl OwnedRuntimeConfigOperation {
+    #[must_use]
+    pub fn kind(&self) -> RuntimeConfigOperationKind {
+        self.inner.kind
+    }
+
+    #[must_use]
+    pub fn deadline(&self) -> Instant {
+        self.inner.deadline
+    }
+
+    #[must_use]
+    pub fn phase(&self) -> RuntimeConfigSettlementPhase {
+        match self.inner.phase.load(Ordering::Acquire) {
+            PHASE_PREFLIGHT => RuntimeConfigSettlementPhase::OwnedPreflight,
+            PHASE_MUTATING => RuntimeConfigSettlementPhase::Mutating,
+            _ => RuntimeConfigSettlementPhase::SettlingRollback,
+        }
+    }
+
+    /// Advance the phase monotonically. Regressions are ignored.
+    pub fn advance_phase(&self, phase: RuntimeConfigSettlementPhase) {
+        let desired = match phase {
+            RuntimeConfigSettlementPhase::OwnedPreflight => PHASE_PREFLIGHT,
+            RuntimeConfigSettlementPhase::Mutating => PHASE_MUTATING,
+            RuntimeConfigSettlementPhase::SettlingRollback => PHASE_SETTLING,
+        };
+        self.inner.phase.fetch_max(desired, Ordering::AcqRel);
+    }
+
+    #[must_use]
+    pub fn terminal(&self) -> RuntimeConfigSettlementTerminal {
+        match self.inner.terminal.load(Ordering::Acquire) {
+            TERMINAL_OWNED => RuntimeConfigSettlementTerminal::Owned,
+            TERMINAL_SETTLED => RuntimeConfigSettlementTerminal::Settled,
+            _ => RuntimeConfigSettlementTerminal::AmbiguousFenced,
+        }
+    }
+
+    #[must_use]
+    pub fn fence_reason(&self) -> Option<RuntimeConfigFenceReason> {
+        match self.inner.fence_reason.load(Ordering::Acquire) {
+            AMBIGUITY_REASON_BUDGET => Some(RuntimeConfigFenceReason::BudgetExpired),
+            AMBIGUITY_REASON_EXECUTOR => Some(RuntimeConfigFenceReason::ExecutorLost),
+            _ => None,
+        }
+    }
+
+    /// Mark whether a transport is still waiting; this never changes ownership.
+    pub fn set_response_attached(&self, attached: bool) {
+        self.inner
+            .response_attached
+            .store(attached, Ordering::Release);
+    }
+
+    #[must_use]
+    pub fn response_attached(&self) -> bool {
+        self.inner.response_attached.load(Ordering::Acquire)
+    }
+
+    /// Prove settlement and release physical ownership. Returns false after fencing.
+    pub fn try_settle(&self) -> bool {
+        if self
+            .inner
+            .terminal
+            .compare_exchange(
+                TERMINAL_OWNED,
+                TERMINAL_SETTLED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return false;
+        }
+        self.inner.registry.unregister(self.inner.id);
+        let resources = self
+            .inner
+            .resources
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        drop(resources);
+        true
+    }
+}
+
+/// Drop sentinel for loss of the daemon-owned executor after ownership.
+#[must_use = "keep the executor guard alive until settlement is proved"]
+#[derive(Debug)]
+pub struct RuntimeConfigExecutorGuard {
+    inner: Option<Arc<OperationInner>>,
+}
+
+impl Drop for RuntimeConfigExecutorGuard {
+    fn drop(&mut self) {
+        let Some(operation) = self.inner.take() else {
+            return;
+        };
+        fence(&operation, RuntimeConfigFenceReason::ExecutorLost);
+    }
+}
+
+fn fence(operation: &Arc<OperationInner>, reason: RuntimeConfigFenceReason) -> bool {
+    if operation
+        .terminal
+        .compare_exchange(
+            TERMINAL_OWNED,
+            TERMINAL_AMBIGUOUS,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        )
+        .is_err()
+    {
+        return false;
+    }
+    let reason_value = match reason {
+        RuntimeConfigFenceReason::BudgetExpired => AMBIGUITY_REASON_BUDGET,
+        RuntimeConfigFenceReason::ExecutorLost => AMBIGUITY_REASON_EXECUTOR,
+    };
+    operation
+        .fence_reason
+        .store(reason_value, Ordering::Release);
+    operation.daemon_gate.mark_not_ready(AMBIGUITY_NOT_READY);
+    operation.daemon_gate.begin_shutdown();
+    operation.coordinator.close();
+    if let Some(admission) = operation
+        .resources
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .as_ref()
+        .and_then(|resources| resources.stream_admission.as_ref())
+    {
+        admission.close();
+    }
+    operation
+        .registry
+        .advance_terminal(operation.id, Instant::now() + operation.registry.grace);
+    true
+}
+
+fn watchdog_loop(registry: &Arc<Registry>) {
+    *registry
+        .thread_id
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(thread::current().id());
+    loop {
+        let now = Instant::now();
+        let (expired, terminal, wait) = {
+            let state = registry.lock();
+            if state.stopping {
+                return;
+            }
+            let expired = state
+                .registrations
+                .values()
+                .filter(|entry| {
+                    entry.operation.terminal.load(Ordering::Acquire) == TERMINAL_OWNED
+                        && entry.operation.deadline <= now
+                })
+                .map(|entry| Arc::clone(&entry.operation))
+                .collect::<Vec<_>>();
+            let terminal = state
+                .registrations
+                .values()
+                .find(|entry| {
+                    entry.operation.terminal.load(Ordering::Acquire) == TERMINAL_AMBIGUOUS
+                        && entry.terminal_at <= now
+                })
+                .map(|entry| Arc::clone(&entry.operation));
+            let wait = state
+                .registrations
+                .values()
+                .map(|entry| {
+                    if entry.operation.terminal.load(Ordering::Acquire) == TERMINAL_OWNED {
+                        entry.operation.deadline
+                    } else {
+                        entry.terminal_at
+                    }
+                })
+                .min()
+                .map_or(registry.budget, |next| next.saturating_duration_since(now));
+            (expired, terminal, wait)
+        };
+        for operation in expired {
+            fence(&operation, RuntimeConfigFenceReason::BudgetExpired);
+        }
+        if let Some(operation) = terminal {
+            run_terminal_action(registry, &operation);
+        }
+        let state = registry.lock();
+        drop(
+            registry
+                .wake
+                .wait_timeout(state, wait)
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        );
+    }
+}
+
+#[cfg(not(test))]
+fn run_terminal_action(registry: &Registry, _operation: &OperationInner) -> ! {
+    match registry.terminal {
+        TerminalAction::Exit(exit) => exit(AMBIGUOUS_CONFIG_EXIT_STATUS),
+    }
+}
+
+#[cfg(test)]
+fn run_terminal_action(registry: &Registry, operation: &OperationInner) {
+    match &registry.terminal {
+        TerminalAction::Exit(exit) => exit(AMBIGUOUS_CONFIG_EXIT_STATUS),
+        TerminalAction::Notify(sender) => {
+            let _ = sender.send(AMBIGUOUS_CONFIG_EXIT_STATUS);
+            registry.unregister(operation.id);
+            operation
+                .resources
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_watchdog(
+        budget: Duration,
+        grace: Duration,
+    ) -> (
+        RuntimeConfigSettlementWatchdog,
+        std::sync::mpsc::Receiver<i32>,
+    ) {
+        let (sender, receiver) = std::sync::mpsc::channel();
+        (
+            RuntimeConfigSettlementWatchdog::start(budget, grace, TerminalAction::Notify(sender)),
+            receiver,
+        )
+    }
+
+    async fn operation(
+        watchdog: &RuntimeConfigSettlementWatchdog,
+        stream: bool,
+    ) -> (
+        OwnedRuntimeConfigOperation,
+        RuntimeConfigExecutorGuard,
+        RuntimeConfigCoordinator,
+        Option<Arc<Semaphore>>,
+    ) {
+        let coordinator = RuntimeConfigCoordinator::new();
+        let permit = coordinator.acquire().await.unwrap();
+        let admission = stream.then(|| Arc::new(Semaphore::new(1)));
+        let stream_permit = match &admission {
+            Some(value) => Some(value.clone().acquire_owned().await.unwrap()),
+            None => None,
+        };
+        let (operation, guard) = watchdog.register_owned(
+            RuntimeConfigOperationKind::Apply,
+            coordinator.clone(),
+            permit,
+            DaemonGate::new(),
+            stream_permit,
+            admission.clone(),
+        );
+        (operation, guard, coordinator, admission)
+    }
+
+    #[test]
+    fn constants_and_closed_states_are_exact() {
+        assert_eq!(OWNED_SETTLEMENT_BUDGET, Duration::from_mins(30));
+        assert_eq!(AMBIGUITY_FENCE_GRACE, Duration::from_secs(5));
+        assert_eq!(AMBIGUOUS_CONFIG_EXIT_STATUS, 70);
+        assert_eq!(RuntimeConfigSettlementTerminal::Owned as u8, 0);
+        assert_eq!(RuntimeConfigFenceReason::BudgetExpired as u8, 0);
+    }
+
+    #[tokio::test]
+    async fn phase_is_monotonic_and_deadline_is_fixed() {
+        let (watchdog, _receiver) = test_watchdog(Duration::from_secs(1), Duration::from_secs(1));
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        let deadline = operation.deadline();
+        operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
+        operation.advance_phase(RuntimeConfigSettlementPhase::OwnedPreflight);
+        assert_eq!(
+            operation.phase(),
+            RuntimeConfigSettlementPhase::SettlingRollback
+        );
+        assert_eq!(operation.deadline(), deadline);
+        assert!(operation.try_settle());
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn settlement_releases_both_permits() {
+        let (watchdog, _receiver) = test_watchdog(Duration::from_secs(1), Duration::from_secs(1));
+        let (operation, guard, coordinator, admission) = operation(&watchdog, true).await;
+        let coordinator_waiter = tokio::spawn({
+            let coordinator = coordinator.clone();
+            async move { coordinator.acquire().await }
+        });
+        let admission_waiter = tokio::spawn(admission.unwrap().acquire_owned());
+        assert!(operation.try_settle());
+        drop(guard);
+        assert!(coordinator_waiter.await.unwrap().is_ok());
+        assert!(admission_waiter.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn executor_loss_fences_before_resources_release() {
+        let (watchdog, receiver) = test_watchdog(Duration::from_secs(5), Duration::from_millis(20));
+        let (operation, guard, coordinator, admission) = operation(&watchdog, true).await;
+        drop(guard);
+        assert_eq!(
+            operation.terminal(),
+            RuntimeConfigSettlementTerminal::AmbiguousFenced
+        );
+        assert_eq!(
+            operation.fence_reason(),
+            Some(RuntimeConfigFenceReason::ExecutorLost)
+        );
+        assert!(coordinator.is_closed());
+        assert!(admission.unwrap().is_closed());
+        assert!(!operation.try_settle());
+        assert_eq!(receiver.recv_timeout(Duration::from_secs(5)).unwrap(), 70);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn std_thread_deadline_ignores_paused_tokio_clock_and_detach() {
+        let (watchdog, receiver) =
+            test_watchdog(Duration::from_millis(40), Duration::from_millis(20));
+        let (operation, guard, coordinator, _) = operation(&watchdog, false).await;
+        operation.set_response_attached(false);
+        assert!(!operation.response_attached());
+        assert_eq!(receiver.recv_timeout(Duration::from_secs(5)).unwrap(), 70);
+        assert!(coordinator.is_closed());
+        assert_eq!(
+            operation.fence_reason(),
+            Some(RuntimeConfigFenceReason::BudgetExpired)
+        );
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn many_settlements_leave_no_registrations_and_share_thread() {
+        let (watchdog, _receiver) = test_watchdog(Duration::from_secs(5), Duration::from_secs(1));
+        let thread_id = loop {
+            if let Some(thread_id) = *watchdog.registry.thread_id.lock().unwrap() {
+                break thread_id;
+            }
+            thread::yield_now();
+        };
+        for _ in 0..32 {
+            let (operation, guard, _, _) = operation(&watchdog, false).await;
+            assert!(operation.try_settle());
+            drop(guard);
+        }
+        assert!(watchdog.registry.lock().registrations.is_empty());
+        assert_eq!(
+            *watchdog.registry.thread_id.lock().unwrap(),
+            Some(thread_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn settlement_and_executor_loss_have_exactly_one_winner() {
+        let (watchdog, receiver) = test_watchdog(Duration::from_secs(5), Duration::from_millis(20));
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        let barrier = Arc::new(std::sync::Barrier::new(3));
+        let settle = {
+            let operation = operation.clone();
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                operation.try_settle()
+            })
+        };
+        let lose = {
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                drop(guard);
+            })
+        };
+        barrier.wait();
+        let settled = settle.join().unwrap();
+        lose.join().unwrap();
+        assert_eq!(
+            settled,
+            operation.terminal() == RuntimeConfigSettlementTerminal::Settled
+        );
+        if settled {
+            assert!(receiver.recv_timeout(Duration::from_millis(50)).is_err());
+        } else {
+            assert_eq!(receiver.recv_timeout(Duration::from_secs(5)).unwrap(), 70);
+        }
+    }
+
+    #[tokio::test]
+    async fn settlement_and_deadline_have_exactly_one_winner() {
+        let (watchdog, receiver) =
+            test_watchdog(Duration::from_millis(2), Duration::from_millis(20));
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        thread::sleep(Duration::from_millis(2));
+        let settled = operation.try_settle();
+        assert_eq!(
+            settled,
+            operation.terminal() == RuntimeConfigSettlementTerminal::Settled
+        );
+        if settled {
+            assert!(receiver.recv_timeout(Duration::from_millis(50)).is_err());
+        } else {
+            assert_eq!(
+                operation.fence_reason(),
+                Some(RuntimeConfigFenceReason::BudgetExpired)
+            );
+            assert_eq!(receiver.recv_timeout(Duration::from_secs(5)).unwrap(), 70);
+        }
+        drop(guard);
+    }
+}

--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -17,38 +17,10 @@ pub const OWNED_SETTLEMENT_BUDGET: Duration = Duration::from_mins(30);
 pub const AMBIGUITY_FENCE_GRACE: Duration = Duration::from_secs(5);
 pub const AMBIGUOUS_CONFIG_EXIT_STATUS: i32 = 70;
 
-/// Closed roster of runtime-config operations that can own the coordinator.
+/// Closed roster of runtime-config operations wired into settlement ownership.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RuntimeConfigOperationKind {
     Apply,
-    Rollback,
-    Confirm,
-    Abort,
-    AutoRevert,
-    GnmiSet,
-    Sighup,
-    NeighborAdd,
-    NeighborDelete,
-    DynamicNeighborAdd,
-    DynamicNeighborDelete,
-    FibTableSet,
-    FibTableDelete,
-    PeerGroupSet,
-    PeerGroupDelete,
-    PeerGroupSetNeighbor,
-    PeerGroupClearNeighbor,
-    PolicySet,
-    PolicyDelete,
-    PolicyNeighborSet,
-    PolicyNeighborSetDelete,
-    PolicyGlobalImportSet,
-    PolicyGlobalExportSet,
-    PolicyGlobalImportClear,
-    PolicyGlobalExportClear,
-    PolicyNeighborImportSet,
-    PolicyNeighborExportSet,
-    PolicyNeighborImportClear,
-    PolicyNeighborExportClear,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -69,6 +41,7 @@ pub enum RuntimeConfigSettlementTerminal {
 pub enum RuntimeConfigFenceReason {
     BudgetExpired,
     ExecutorLost,
+    DetectedAmbiguousOutcome,
 }
 
 const TERMINAL_OWNED: u8 = 0;
@@ -80,6 +53,7 @@ const PHASE_SETTLING: u8 = 2;
 const AMBIGUITY_REASON_NONE: u8 = 0;
 const AMBIGUITY_REASON_BUDGET: u8 = 1;
 const AMBIGUITY_REASON_EXECUTOR: u8 = 2;
+const AMBIGUITY_REASON_DETECTED: u8 = 3;
 const AMBIGUITY_NOT_READY: &str = "runtime config settlement is ambiguous";
 
 #[derive(Debug)]
@@ -96,7 +70,7 @@ struct OperationInner {
     phase: AtomicU8,
     terminal: AtomicU8,
     fence_reason: AtomicU8,
-    response_attached: AtomicBool,
+    response_attached: Arc<AtomicBool>,
     coordinator: RuntimeConfigCoordinator,
     daemon_gate: DaemonGate,
     resources: Mutex<Option<OwnedResources>>,
@@ -153,7 +127,7 @@ impl Registry {
 
     fn unregister(&self, id: u64) {
         self.lock().registrations.remove(&id);
-        self.wake.notify_one();
+        self.wake.notify_all();
     }
 
     fn advance_terminal(&self, id: u64, when: Instant) {
@@ -183,7 +157,10 @@ impl RuntimeConfigSettlementWatchdog {
     /// Start the process watchdog using fixed production durations.
     #[must_use]
     #[cfg(not(test))]
-    #[allow(clippy::new_without_default)]
+    #[allow(
+        clippy::new_without_default,
+        reason = "construction starts the process watchdog thread, so Default would hide lifecycle side effects"
+    )]
     pub fn new() -> Self {
         Self::start(OWNED_SETTLEMENT_BUDGET, AMBIGUITY_FENCE_GRACE)
     }
@@ -235,6 +212,10 @@ impl RuntimeConfigSettlementWatchdog {
         }
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the closed ownership registration lists every retained fail-stop resource explicitly"
+    )]
     pub fn register_owned(
         &self,
         kind: RuntimeConfigOperationKind,
@@ -243,6 +224,7 @@ impl RuntimeConfigSettlementWatchdog {
         daemon_gate: DaemonGate,
         stream_permit: Option<OwnedSemaphorePermit>,
         stream_admission: Option<Arc<Semaphore>>,
+        response_attached: Arc<AtomicBool>,
     ) -> (OwnedRuntimeConfigOperation, RuntimeConfigExecutorGuard) {
         let deadline = Instant::now() + self.registry.budget;
         let id = self.registry.next_id.fetch_add(1, Ordering::Relaxed);
@@ -253,7 +235,7 @@ impl RuntimeConfigSettlementWatchdog {
             phase: AtomicU8::new(PHASE_PREFLIGHT),
             terminal: AtomicU8::new(TERMINAL_OWNED),
             fence_reason: AtomicU8::new(AMBIGUITY_REASON_NONE),
-            response_attached: AtomicBool::new(true),
+            response_attached,
             coordinator,
             daemon_gate,
             resources: Mutex::new(Some(OwnedResources {
@@ -279,6 +261,19 @@ impl RuntimeConfigSettlementWatchdog {
                 inner: Some(operation),
             },
         )
+    }
+
+    /// Block the calling OS thread until every clean registration settles.
+    /// Ambiguous ownership deliberately never unregisters; its fail-stop wins.
+    pub fn wait_until_idle(&self) {
+        let mut state = self.registry.lock();
+        while !state.registrations.is_empty() {
+            state = self
+                .registry
+                .wake
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
     }
 }
 
@@ -332,6 +327,7 @@ impl OwnedRuntimeConfigOperation {
         match self.inner.fence_reason.load(Ordering::Acquire) {
             AMBIGUITY_REASON_BUDGET => Some(RuntimeConfigFenceReason::BudgetExpired),
             AMBIGUITY_REASON_EXECUTOR => Some(RuntimeConfigFenceReason::ExecutorLost),
+            AMBIGUITY_REASON_DETECTED => Some(RuntimeConfigFenceReason::DetectedAmbiguousOutcome),
             _ => None,
         }
     }
@@ -341,6 +337,15 @@ impl OwnedRuntimeConfigOperation {
         self.inner
             .response_attached
             .store(attached, Ordering::Release);
+    }
+
+    /// Fence a known ambiguous result before any response can be published.
+    #[must_use]
+    pub fn fence_ambiguous_outcome(&self) -> bool {
+        fence(
+            self.inner.as_ref(),
+            RuntimeConfigFenceReason::DetectedAmbiguousOutcome,
+        )
     }
 
     #[must_use]
@@ -391,7 +396,7 @@ impl Drop for RuntimeConfigExecutorGuard {
     }
 }
 
-fn fence(operation: &Arc<OperationInner>, reason: RuntimeConfigFenceReason) -> bool {
+fn fence(operation: &OperationInner, reason: RuntimeConfigFenceReason) -> bool {
     if operation
         .terminal
         .compare_exchange(
@@ -407,6 +412,7 @@ fn fence(operation: &Arc<OperationInner>, reason: RuntimeConfigFenceReason) -> b
     let reason_value = match reason {
         RuntimeConfigFenceReason::BudgetExpired => AMBIGUITY_REASON_BUDGET,
         RuntimeConfigFenceReason::ExecutorLost => AMBIGUITY_REASON_EXECUTOR,
+        RuntimeConfigFenceReason::DetectedAmbiguousOutcome => AMBIGUITY_REASON_DETECTED,
     };
     operation
         .fence_reason
@@ -599,6 +605,7 @@ mod tests {
             DaemonGate::new(),
             stream_permit,
             admission.clone(),
+            Arc::new(AtomicBool::new(true)),
         );
         (operation, guard, coordinator, admission)
     }
@@ -660,6 +667,37 @@ mod tests {
         assert!(admission.unwrap().is_closed());
         assert!(!operation.try_settle());
         assert_eq!(receiver.recv_timeout(Duration::from_secs(5)).unwrap(), 70);
+    }
+
+    #[tokio::test]
+    async fn detected_ambiguity_closes_both_admission_resources() {
+        let (watchdog, receiver) = test_watchdog(Duration::from_secs(5), Duration::from_millis(20));
+        let (operation, guard, coordinator, admission) = operation(&watchdog, true).await;
+        assert!(operation.fence_ambiguous_outcome());
+        assert_eq!(
+            operation.fence_reason(),
+            Some(RuntimeConfigFenceReason::DetectedAmbiguousOutcome)
+        );
+        assert!(coordinator.is_closed());
+        assert!(admission.unwrap().is_closed());
+        assert!(!operation.try_settle());
+        assert_eq!(receiver.recv_timeout(Duration::from_secs(5)).unwrap(), 70);
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn wait_until_idle_returns_only_after_clean_settlement() {
+        let (watchdog, _receiver) = test_watchdog(Duration::from_secs(5), Duration::from_secs(1));
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        let waiter = {
+            let watchdog = watchdog.clone();
+            thread::spawn(move || watchdog.wait_until_idle())
+        };
+        thread::sleep(Duration::from_millis(10));
+        assert!(!waiter.is_finished());
+        assert!(operation.try_settle());
+        drop(guard);
+        waiter.join().unwrap();
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -153,6 +153,8 @@ pub enum ConfigTransactionApplyError {
     DeadlineExceeded(String),
     /// Internal actor/rollback failure.
     Internal(String),
+    /// The daemon cannot prove whether the candidate took effect.
+    DetectedAmbiguousOutcome(String),
 }
 
 impl ConfigTransactionApplyError {
@@ -163,6 +165,7 @@ impl ConfigTransactionApplyError {
             Self::Unavailable(message) => Status::unavailable(message),
             Self::DeadlineExceeded(message) => Status::deadline_exceeded(message),
             Self::Internal(message) => Status::internal(message),
+            Self::DetectedAmbiguousOutcome(message) => Status::aborted(message),
         }
     }
 }
@@ -174,7 +177,8 @@ impl std::fmt::Display for ConfigTransactionApplyError {
             | Self::FailedPrecondition(message)
             | Self::Unavailable(message)
             | Self::DeadlineExceeded(message)
-            | Self::Internal(message) => f.write_str(message),
+            | Self::Internal(message)
+            | Self::DetectedAmbiguousOutcome(message) => f.write_str(message),
         }
     }
 }
@@ -373,11 +377,70 @@ pub type ConfigTransactionApplyFuture = Pin<
 /// The binary crate owns this because config transactions need runtime actor
 /// senders, config persistence, and the shared SIGHUP/runtime-CRUD lock.
 pub type ConfigTransactionApplyFn = Arc<
-    dyn Fn(crate::proto::ApplyConfigTransactionRequest) -> ConfigTransactionApplyFuture
+    dyn Fn(
+            crate::proto::ApplyConfigTransactionRequest,
+            ConfigTransactionApplyContext,
+        ) -> ConfigTransactionApplyFuture
         + Send
         + Sync
         + 'static,
 >;
+
+/// Transport state transferred to the daemon-owned Apply executor.
+pub struct ConfigTransactionApplyContext {
+    response_attached: Arc<std::sync::atomic::AtomicBool>,
+    stream: Option<StreamApplyOwnership>,
+}
+
+impl ConfigTransactionApplyContext {
+    #[must_use]
+    pub fn unary() -> (Self, ConfigTransactionResponseAttachment) {
+        let attached = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        (
+            Self {
+                response_attached: Arc::clone(&attached),
+                stream: None,
+            },
+            ConfigTransactionResponseAttachment(attached),
+        )
+    }
+
+    #[must_use]
+    pub(crate) fn streamed(
+        permit: OwnedSemaphorePermit,
+        admission: Arc<Semaphore>,
+    ) -> (Self, ConfigTransactionResponseAttachment) {
+        let (mut context, attachment) = Self::unary();
+        context.stream = Some(StreamApplyOwnership { permit, admission });
+        (context, attachment)
+    }
+
+    #[must_use]
+    pub fn response_attached(&self) -> Arc<std::sync::atomic::AtomicBool> {
+        Arc::clone(&self.response_attached)
+    }
+
+    #[must_use]
+    pub fn take_stream_ownership(&mut self) -> Option<(OwnedSemaphorePermit, Arc<Semaphore>)> {
+        self.stream
+            .take()
+            .map(|stream| (stream.permit, stream.admission))
+    }
+}
+
+struct StreamApplyOwnership {
+    permit: OwnedSemaphorePermit,
+    admission: Arc<Semaphore>,
+}
+
+/// Response-lifetime sentinel; dropping it records transport cancellation.
+pub struct ConfigTransactionResponseAttachment(Arc<std::sync::atomic::AtomicBool>);
+
+impl Drop for ConfigTransactionResponseAttachment {
+    fn drop(&mut self) {
+        self.0.store(false, std::sync::atomic::Ordering::Release);
+    }
+}
 
 /// Future returned by the daemon-owned config transaction confirm hook.
 pub type ConfigTransactionConfirmFuture = Pin<

--- a/crates/api/tests/runtime_config_settlement_exit.rs
+++ b/crates/api/tests/runtime_config_settlement_exit.rs
@@ -1,0 +1,54 @@
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::time::{Duration, Instant};
+
+use rustbgpd_api::health_probe::DaemonGate;
+use rustbgpd_api::runtime_config_settlement::{
+    AMBIGUOUS_CONFIG_EXIT_STATUS, RuntimeConfigOperationKind, RuntimeConfigSettlementWatchdog,
+};
+use rustbgpd_api::server::RuntimeConfigCoordinator;
+use tokio::sync::Semaphore;
+
+const CHILD_ENV: &str = "RUSTBGPD_SETTLEMENT_EXIT_CHILD";
+
+#[test]
+fn executor_loss_uses_production_exit_status() {
+    if std::env::var_os(CHILD_ENV).is_some() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let coordinator = RuntimeConfigCoordinator::new();
+            let coordinator_permit = coordinator.acquire().await.unwrap();
+            let stream_admission = Arc::new(Semaphore::new(1));
+            let stream_permit = Arc::clone(&stream_admission).acquire_owned().await.unwrap();
+            let watchdog = RuntimeConfigSettlementWatchdog::new();
+            let (_operation, guard) = watchdog.register_owned(
+                RuntimeConfigOperationKind::Apply,
+                coordinator,
+                coordinator_permit,
+                DaemonGate::new(),
+                Some(stream_permit),
+                Some(stream_admission),
+                Arc::new(AtomicBool::new(false)),
+            );
+            drop(guard);
+            std::future::pending::<()>().await;
+        });
+        unreachable!();
+    }
+
+    let started = Instant::now();
+    let status = Command::new(std::env::current_exe().unwrap())
+        .arg("--exact")
+        .arg("executor_loss_uses_production_exit_status")
+        .arg("--nocapture")
+        .env(CHILD_ENV, "1")
+        .status()
+        .unwrap();
+    assert_eq!(status.code(), Some(AMBIGUOUS_CONFIG_EXIT_STATUS));
+    assert!(started.elapsed() <= Duration::from_secs(15));
+}

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -11,16 +11,21 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use tokio::sync::{Mutex, mpsc, oneshot, watch};
 
+use rustbgpd_api::health_probe::DaemonGate;
 use rustbgpd_api::peer_types::{
     ConfigEvent, ConfigPersistAck, DynamicPeerBounceOutcome, DynamicRangeTarget, PeerKey,
     PeerLifecycleError, PeerManagerCommand, PeerManagerNeighborConfig, ResolvedPeerPolicy,
     RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus, StageConfigSnapshotError,
 };
 use rustbgpd_api::proto;
+use rustbgpd_api::runtime_config_settlement::{
+    RuntimeConfigOperationKind, RuntimeConfigSettlementPhase, RuntimeConfigSettlementWatchdog,
+};
 use rustbgpd_api::server::{
     ConfigHistoryListFn, ConfigMutationGateFn, ConfigRollbackFn, ConfigTransactionAbortFn,
-    ConfigTransactionApplyError, ConfigTransactionApplyFn, ConfigTransactionConfirmFn,
-    ConfigTransactionStatusFn, GnmiSetCommitAction, GnmiSetError, GnmiSetFn, GnmiSetOutcome,
+    ConfigTransactionApplyContext, ConfigTransactionApplyError, ConfigTransactionApplyFn,
+    ConfigTransactionConfirmFn, ConfigTransactionStatusFn, GnmiSetCommitAction, GnmiSetError,
+    GnmiSetFn, GnmiSetOutcome,
 };
 use rustbgpd_telemetry::BgpMetrics;
 use tracing::{error, info, warn};
@@ -62,6 +67,7 @@ pub struct ConfigTransactionController {
     peer_mgr_internal_tx: Option<mpsc::UnboundedSender<InternalCommand>>,
     confirm_v3_launch: Option<crate::confirm_journal::v3::LaunchIdentity>,
     v3_residue_cleanup_active: Arc<AtomicBool>,
+    settlement: Option<(RuntimeConfigSettlementWatchdog, DaemonGate)>,
     #[cfg(test)]
     v3_residue_cleanup_spawn_fail: Arc<AtomicBool>,
 }
@@ -135,6 +141,7 @@ impl ConfigTransactionController {
             peer_mgr_internal_tx: None,
             confirm_v3_launch: None,
             v3_residue_cleanup_active: Arc::new(AtomicBool::new(false)),
+            settlement: None,
             v3_residue_cleanup_spawn_fail: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -153,9 +160,20 @@ impl ConfigTransactionController {
             peer_mgr_internal_tx: None,
             confirm_v3_launch: None,
             v3_residue_cleanup_active: Arc::new(AtomicBool::new(false)),
+            settlement: None,
             #[cfg(test)]
             v3_residue_cleanup_spawn_fail: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    #[must_use]
+    pub(crate) fn with_runtime_config_settlement(
+        mut self,
+        watchdog: RuntimeConfigSettlementWatchdog,
+        daemon_gate: DaemonGate,
+    ) -> Self {
+        self.settlement = Some((watchdog, daemon_gate));
+        self
     }
 
     #[must_use]
@@ -367,9 +385,9 @@ impl ConfigTransactionController {
     #[must_use]
     pub fn apply_fn(&self) -> ConfigTransactionApplyFn {
         let controller = self.clone();
-        Arc::new(move |request| {
+        Arc::new(move |request, context| {
             let controller = controller.clone();
-            Box::pin(async move { controller.apply(request).await })
+            Box::pin(async move { controller.apply_with_context(request, context).await })
         })
     }
 
@@ -463,14 +481,25 @@ impl ConfigTransactionController {
         Ok(())
     }
 
+    #[cfg(test)]
     async fn apply(
         self,
         request: proto::ApplyConfigTransactionRequest,
     ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
+        let (context, _attachment) = ConfigTransactionApplyContext::unary();
+        self.apply_with_context(request, context).await
+    }
+
+    async fn apply_with_context(
+        self,
+        request: proto::ApplyConfigTransactionRequest,
+        mut context: ConfigTransactionApplyContext,
+    ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
         validate_apply_request(&request)?;
         let confirmed = parse_confirmed_apply_mode(&request)?;
+        let watched = self.settlement.is_some();
         let join = tokio::spawn(async move {
-            let _guard = tokio::time::timeout(
+            let coordinator_permit = tokio::time::timeout(
                 CONFIG_TRANSACTION_COORDINATOR_ACQUIRE_TIMEOUT,
                 self.deps.lock.acquire(),
             )
@@ -482,14 +511,62 @@ impl ConfigTransactionController {
                         .to_string(),
                 )
             })??;
-            self.apply_locked(request, confirmed).await
+            let Some((watchdog, daemon_gate)) = self.settlement.clone() else {
+                drop(context);
+                return self.apply_locked(request, confirmed).await;
+            };
+            let response_attached = context.response_attached();
+            let stream = context.take_stream_ownership();
+            let (stream_permit, stream_admission) = stream
+                .map_or((None, None), |(permit, admission)| {
+                    (Some(permit), Some(admission))
+                });
+            let (operation, executor_guard) = watchdog.register_owned(
+                RuntimeConfigOperationKind::Apply,
+                self.deps.lock.clone(),
+                coordinator_permit,
+                daemon_gate,
+                stream_permit,
+                stream_admission,
+                response_attached,
+            );
+            drop(context);
+            if self
+                .settlement
+                .as_ref()
+                .is_some_and(|(_, gate)| gate.is_shutting_down())
+            {
+                if !operation.try_settle() {
+                    std::future::pending::<()>().await;
+                }
+                drop(executor_guard);
+                return Err(ConfigTransactionApplyError::Unavailable(
+                    "config transaction rejected: daemon is shutting down".to_string(),
+                ));
+            }
+            operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
+            let result = self.apply_locked(request, confirmed).await;
+            if matches!(
+                result,
+                Err(ConfigTransactionApplyError::DetectedAmbiguousOutcome(_))
+            ) {
+                let _ = operation.fence_ambiguous_outcome();
+                std::future::pending::<()>().await;
+            }
+            if !operation.try_settle() {
+                std::future::pending::<()>().await;
+            }
+            drop(executor_guard);
+            result
         });
 
-        join.await.map_err(|_| {
-            ConfigTransactionApplyError::Internal(
+        match join.await {
+            Ok(result) => result,
+            Err(_) if watched => std::future::pending().await,
+            Err(_) => Err(ConfigTransactionApplyError::Internal(
                 "config transaction apply task did not complete".to_string(),
-            )
-        })?
+            )),
+        }
     }
 
     async fn apply_gnmi_set(
@@ -625,7 +702,15 @@ impl ConfigTransactionController {
                 .await?;
             apply_config_transaction_locked(&self.deps, request, self.peer_mgr_internal_tx.as_ref())
                 .await
-                .map_err(|failure| failure.error)
+                .map_err(|failure| {
+                    if failure.ambiguous {
+                        ConfigTransactionApplyError::DetectedAmbiguousOutcome(
+                            failure.error.to_string(),
+                        )
+                    } else {
+                        failure.error
+                    }
+                })
         }
     }
 
@@ -708,7 +793,7 @@ impl ConfigTransactionController {
                         self.state.lock().await.ambiguous_failure_confirm_id =
                             Some(confirmed.confirm_id.clone());
                     }
-                    return Err(ConfigTransactionApplyError::Internal(format!(
+                    let message = format!(
                         "refusing confirmed apply: v3 pending authority publication failed ({:?}); {}",
                         error.kind(),
                         if error.authority_retained() {
@@ -716,7 +801,12 @@ impl ConfigTransactionController {
                         } else {
                             "the candidate and runtime remain untouched"
                         }
-                    )));
+                    );
+                    return Err(if error.authority_retained() {
+                        ConfigTransactionApplyError::DetectedAmbiguousOutcome(message)
+                    } else {
+                        ConfigTransactionApplyError::Internal(message)
+                    });
                 }
             }
         } else {
@@ -755,9 +845,11 @@ impl ConfigTransactionController {
                         error = %failure.error,
                         "confirmed config transaction failed with an ambiguous outcome; retaining the revert journal and blocking config mutations until restart"
                     );
-                    return Err(append_error_context(
-                        failure.error,
-                        "the transaction outcome is ambiguous; the commit-confirm revert journal is retained and config mutations are blocked; restart rustbgpd to boot-revert to the pre-transaction config",
+                    return Err(ConfigTransactionApplyError::DetectedAmbiguousOutcome(
+                        format!(
+                            "{}; the transaction outcome is ambiguous; the commit-confirm revert journal is retained and config mutations are blocked; restart rustbgpd to boot-revert to the pre-transaction config",
+                            failure.error
+                        ),
                     ));
                 }
                 // Provably nothing committed — a stale journal would only
@@ -1470,10 +1562,12 @@ impl ConfigTransactionController {
             Err(error) => {
                 let mut state = self.state.lock().await;
                 state.ambiguous_failure_confirm_id = Some(confirm_id.to_string());
-                Err(ConfigTransactionApplyError::Internal(format!(
-                    "v3 commit-confirm operation is nonterminal because durable locator removal failed ({:?}); config mutations remain blocked",
-                    error.kind()
-                )))
+                Err(ConfigTransactionApplyError::DetectedAmbiguousOutcome(
+                    format!(
+                        "v3 commit-confirm operation is nonterminal because durable locator removal failed ({:?}); config mutations remain blocked",
+                        error.kind()
+                    ),
+                ))
             }
         }
     }
@@ -1688,31 +1782,6 @@ fn ambiguous_failure_fence_error(operation: &str, confirm_id: &str) -> ConfigTra
          ambiguous outcome and its revert journal is retained; restart rustbgpd to boot-revert \
          to the pre-transaction config before further config mutations"
     ))
-}
-
-/// Append operator guidance to an apply error without changing its variant
-/// (the variant maps to the gRPC status code).
-fn append_error_context(
-    error: ConfigTransactionApplyError,
-    context: &str,
-) -> ConfigTransactionApplyError {
-    match error {
-        ConfigTransactionApplyError::InvalidArgument(message) => {
-            ConfigTransactionApplyError::InvalidArgument(format!("{message}; {context}"))
-        }
-        ConfigTransactionApplyError::FailedPrecondition(message) => {
-            ConfigTransactionApplyError::FailedPrecondition(format!("{message}; {context}"))
-        }
-        ConfigTransactionApplyError::Unavailable(message) => {
-            ConfigTransactionApplyError::Unavailable(format!("{message}; {context}"))
-        }
-        ConfigTransactionApplyError::DeadlineExceeded(message) => {
-            ConfigTransactionApplyError::DeadlineExceeded(format!("{message}; {context}"))
-        }
-        ConfigTransactionApplyError::Internal(message) => {
-            ConfigTransactionApplyError::Internal(format!("{message}; {context}"))
-        }
-    }
 }
 
 fn validate_apply_request(
@@ -3568,6 +3637,9 @@ fn apply_error_to_gnmi_set_error(error: ConfigTransactionApplyError) -> GnmiSetE
             GnmiSetError::Unavailable(message)
         }
         ConfigTransactionApplyError::Internal(message) => GnmiSetError::Internal(message),
+        ConfigTransactionApplyError::DetectedAmbiguousOutcome(message) => {
+            GnmiSetError::Internal(message)
+        }
     }
 }
 
@@ -3653,6 +3725,9 @@ fn confirm_abort_rollback_error(
             ConfigTransactionApplyError::DeadlineExceeded(message)
         }
         ConfigTransactionApplyError::Internal(_) => ConfigTransactionApplyError::Internal(message),
+        ConfigTransactionApplyError::DetectedAmbiguousOutcome(_) => {
+            ConfigTransactionApplyError::DetectedAmbiguousOutcome(message)
+        }
     }
 }
 
@@ -3787,7 +3862,10 @@ remote_asn = 65002
             (main, "\n                lock: runtime_config_lock.clone(),", 2),
             (main, "runtime_config_lock: runtime_config_lock.clone(),", 1),
             (main, "let Ok(_runtime_config_guard) = runtime_config_lock.acquire().await else {", 1),
-            (main, "tokio::time::timeout_at(deadline, runtime_config_lock.acquire()).await", 1),
+            (main, "tokio::time::timeout_at(runtime_config_deadline, runtime_config_lock.acquire())", 1),
+            (main, "RuntimeConfigSettlementWatchdog::new()", 1),
+            (main, ".with_runtime_config_settlement(", 1),
+            (main, "move || settlement_wait.wait_until_idle()", 1),
             (transaction, "self.deps.lock.acquire()", 6),
             (fib, ".acquire()", 2),
             (neighbor, "runtime_config_lock.acquire()", 4),
@@ -3807,8 +3885,20 @@ remote_asn = 65002
             assert!(!server.contains(prohibited), "{prohibited}");
         }
         assert_eq!(server.matches(".close();").count(), 1);
+        assert_eq!(main.matches("runtime_config_lock.close();").count(), 1);
+        let shutdown_gate = main.find("daemon_gate.begin_shutdown();").unwrap();
+        let watched_idle = main
+            .find("move || settlement_wait.wait_until_idle()")
+            .unwrap();
+        let bounded_fence = main
+            .find("tokio::time::timeout_at(runtime_config_deadline, runtime_config_lock.acquire())")
+            .unwrap();
+        let closed = main.find("runtime_config_lock.close();").unwrap();
         assert!(
-            owners[1..]
+            shutdown_gate < watched_idle && watched_idle < bounded_fence && bounded_fence < closed
+        );
+        assert!(
+            owners[1..6]
                 .iter()
                 .all(|source| !source.contains(".close();"))
         );
@@ -6617,6 +6707,48 @@ families = ["ipv4_unicast"]
     }
 
     #[tokio::test]
+    async fn uncommitted_authority_locator_sync_failure_is_ambiguous() {
+        let harness = external_fib_harness(60, None).await;
+        let files = harness
+            .controller
+            .state
+            .lock()
+            .await
+            .pending
+            .as_ref()
+            .unwrap()
+            .v3_files
+            .clone()
+            .unwrap();
+        files.fail_locator_directory_sync_once_for_test();
+        let error = harness
+            .controller
+            .cleanup_uncommitted_authority(
+                "external-fib",
+                Some(files.as_ref()),
+                "fault-injected cleanup",
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            ConfigTransactionApplyError::DetectedAmbiguousOutcome(ref message)
+                if message.contains("nonterminal") && message.contains("locator removal failed")
+        ));
+        assert_eq!(
+            harness
+                .controller
+                .state
+                .lock()
+                .await
+                .ambiguous_failure_confirm_id
+                .as_deref(),
+            Some("external-fib")
+        );
+        harness.ack_task.abort();
+    }
+
+    #[tokio::test]
     async fn stalled_v3_residue_cleanup_releases_terminal_paths_and_is_singleton() {
         use std::os::unix::fs::PermissionsExt as _;
 
@@ -6902,7 +7034,7 @@ families = ["ipv4_unicast"]
 
         let err = assert_ambiguous_apply_failure_wedges(&controller, &dir, &previous_toml).await;
         assert!(
-            matches!(err, ConfigTransactionApplyError::Unavailable(ref message)
+            matches!(err, ConfigTransactionApplyError::DetectedAmbiguousOutcome(ref message)
                 if message.contains("snapshot commit") && message.contains("ambiguous")),
             "{err:?}"
         );
@@ -6943,7 +7075,7 @@ families = ["ipv4_unicast"]
 
         let err = assert_ambiguous_apply_failure_wedges(&controller, &dir, &previous_toml).await;
         assert!(
-            matches!(err, ConfigTransactionApplyError::Internal(ref message)
+            matches!(err, ConfigTransactionApplyError::DetectedAmbiguousOutcome(ref message)
                 if message.contains("persistence acknowledgement") && message.contains("ambiguous")),
             "{err:?}"
         );
@@ -6992,7 +7124,7 @@ families = ["ipv4_unicast"]
 
         let err = assert_ambiguous_apply_failure_wedges(&controller, &dir, &previous_toml).await;
         assert!(
-            matches!(err, ConfigTransactionApplyError::Internal(ref message)
+            matches!(err, ConfigTransactionApplyError::DetectedAmbiguousOutcome(ref message)
                 if message.contains("rollback failed") && message.contains("ambiguous")),
             "{err:?}"
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,7 @@ use rustbgpd_api::peer_types::{
     ImportValidationDependency, PeerManagerCommand, PeerManagerNeighborConfig,
     PeerManagerReadinessQuery, WarmCheckpointCapture, WarmCheckpointSession,
 };
+use rustbgpd_api::runtime_config_settlement::RuntimeConfigSettlementWatchdog;
 use rustbgpd_api::server::{
     AccessMode as GrpcServerAccessMode, ConfigMutationGateFn, ListenerConfig as GrpcListenerConfig,
     ListenerEndpoint, RuntimeConfigCoordinator, ServeConfig,
@@ -4468,6 +4469,10 @@ async fn run<T>(
     // read/apply/persist sequence so stale TOML snapshots cannot clobber
     // accepted runtime changes.
     let runtime_config_lock = RuntimeConfigCoordinator::new();
+    // The gate and watchdog are process singletons shared by every watched
+    // runtime-config owner and the readiness/admission surfaces.
+    let daemon_gate = DaemonGate::new();
+    let runtime_config_settlement = RuntimeConfigSettlementWatchdog::new();
     let config_transaction_controller =
         config_transaction_control::ConfigTransactionController::new_accepted(
             fib_table_control::FibTableControlDeps {
@@ -4494,12 +4499,12 @@ async fn run<T>(
                 .expect("daemon config transactions require accepted-config authority")
                 .clone(),
         )
+        .with_runtime_config_settlement(runtime_config_settlement.clone(), daemon_gate.clone())
         .with_preloaded_planner(peer_mgr_internal_tx.clone())
         .with_confirm_v3_launch(launch_identity);
     // Process-wide availability gate (LAN-286): BGP-listener bind failure
     // turns readiness red; coordinated shutdown turns readiness red AND
     // stops admitting persisted config mutations and inbound BGP sessions.
-    let daemon_gate = DaemonGate::new();
     let config_mutation_gate: ConfigMutationGateFn = {
         let inner = config_transaction_controller.mutation_gate_fn();
         let gate = daemon_gate.clone();
@@ -5202,28 +5207,38 @@ async fn run<T>(
     // 1. Tell PeerManager to shut down (sends NOTIFICATIONs to all peers)
     daemon_gate.begin_shutdown();
     info!("initiating coordinated shutdown");
+    let settlement_wait = runtime_config_settlement.clone();
+    tokio::task::spawn_blocking(move || settlement_wait.wait_until_idle())
+        .await
+        .expect("runtime-config settlement wait task must not panic");
+    let runtime_config_deadline = tokio::time::Instant::now() + WARM_CHECKPOINT_DEADLINE;
+    let mut runtime_config_fence_failure = None;
+    let runtime_config_fence =
+        match tokio::time::timeout_at(runtime_config_deadline, runtime_config_lock.acquire()).await
+        {
+            Ok(Ok(permit)) => Some(permit),
+            Ok(Err(_)) => {
+                runtime_config_fence_failure =
+                    Some("authoritative runtime-config coordinator is closed".to_string());
+                None
+            }
+            Err(_) => {
+                runtime_config_fence_failure =
+                    Some("timed out acquiring the authoritative runtime-config fence".to_string());
+                None
+            }
+        };
+    runtime_config_lock.close();
     let mut restart_time_secs = max_gr_restart_time_secs(&config);
     let mut checkpoint_generation = None;
     let mut checkpoint_failure = None;
-    let mut _runtime_config_fence = None;
     let mut evpn_apply_fence = None;
 
     if warm_checkpoint_on_shutdown {
         if let Some(directory) = warm_bundle_directory.clone() {
-            let deadline = tokio::time::Instant::now() + WARM_CHECKPOINT_DEADLINE;
-            match tokio::time::timeout_at(deadline, runtime_config_lock.acquire()).await {
-                Ok(Ok(guard)) => _runtime_config_fence = Some(guard),
-                Ok(Err(_)) => {
-                    checkpoint_failure =
-                        Some("authoritative runtime-config coordinator is closed".to_string());
-                }
-                Err(_) => {
-                    checkpoint_failure = Some(
-                        "timed out acquiring the authoritative runtime-config fence".to_string(),
-                    );
-                }
-            }
-            if checkpoint_failure.is_none() {
+            let deadline = runtime_config_deadline;
+            checkpoint_failure = runtime_config_fence_failure.take();
+            if checkpoint_failure.is_none() && runtime_config_fence.is_some() {
                 match tokio::time::timeout_at(deadline, evpn_runtime_apply_lock.lock()).await {
                     Ok(guard) => evpn_apply_fence = Some(guard),
                     Err(_) => {
@@ -5231,6 +5246,9 @@ async fn run<T>(
                             Some("timed out waiting for the EVPN runtime-apply fence".to_string());
                     }
                 }
+            } else if checkpoint_failure.is_none() {
+                checkpoint_failure =
+                    Some("authoritative runtime-config coordinator is closed".to_string());
             }
             if checkpoint_failure.is_none() {
                 match tokio::time::timeout_at(deadline, query_warm_checkpoint_capture(&peer_mgr_tx))


### PR DESCRIPTION
## What changed

- add a process-wide, runtime-independent config-settlement watchdog with fixed 30-minute ownership budget, five-second terminal grace, and exit status 70
- transfer unary and streamed Apply ownership into one guarded settlement record immediately after coordinator acquisition
- retain the exact streamed candidate permit and admission semaphore through clean settlement or process death
- fence readiness and mutation admission before resources can drop on deadline, executor loss, or a detected ambiguous outcome
- prevent late success/error responses after ambiguity wins
- make ordinary shutdown wait for watched Apply settlement before the existing bounded fence for still-unwatched owners
- add a real multithreaded subprocess proof for exact process exit 70

## Why

After a streamed Apply consumed its token, the daemon-owned Apply task could wait forever on coordinator, actor, persistence, or settlement acknowledgements while retaining the only large-candidate permit. That permanently denied later streamed Plan/Apply requests until an operator restarted the daemon.

A response-local timeout is unsafe because the inner transaction task survives caller cancellation and may still mutate state. This change keeps the existing cancellation shield and single-candidate bound, but gives owned Apply a terminal safety bound: settle normally or fence the process and fail-stop for supervised restart.

## Operator impact

Unary and streamed Apply now have a fixed post-ownership settlement budget. If a transaction cannot establish a terminal outcome within 30 minutes—or loses its executor/encounters a known ambiguous durable-authority outcome—the daemon marks readiness unavailable, closes config mutation admission, retains the in-flight ownership, and exits with status 70 after five seconds.

This is the first activation tranche. LAN-974 remains open for gNMI Set, Confirm, Abort, Rollback, AutoRevert, SIGHUP, persisted CRUD owners, metrics, supervisor policy, deployment documentation, and ADR acceptance.

## Verification

- full `rustbgpd-api` test suite (623 tests plus production exit subprocess)
- full `rustbgpd` binary suite (1,940 passed, 3 ignored)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/check-v1-stable-surface.py`
- CAS and stream-cancellation proofs repeated 10 times under process-group timeouts
- production exit-70 subprocess repeated 10 times under process-group timeouts
- post-run process scan confirmed no orphaned test processes
- `git diff --check`

