### PR TITLE
ci: share verified v0.64 validator artifact

### DIFF
--- a/.github/scripts/install-rustbgpd-v064-validator.sh
+++ b/.github/scripts/install-rustbgpd-v064-validator.sh
@@ -4,16 +4,292 @@ set -euo pipefail
 
 readonly VERSION=0.64.0
 readonly SHA256=bd4829de08d0c50074f9ecd5c351399fae42be06d456b3880a04aa4a7cda1137
-readonly URL="https://github.com/lance0/rustbgpd/releases/download/v${VERSION}/rustbgpd-linux-amd64.tar.gz"
+readonly ARCHIVE=rustbgpd-linux-amd64.tar.gz
+readonly BINARY=rustbgpd-v0.64.0
+readonly URL="https://github.com/lance0/rustbgpd/releases/download/v${VERSION}/${ARCHIVE}"
+readonly ATTEMPTS=3
 
-install_dir=${1:?usage: install-rustbgpd-v064-validator.sh INSTALL_DIR}
-work_dir=$(mktemp -d)
-trap 'rm -rf -- "$work_dir"' EXIT
-archive="$work_dir/rustbgpd-linux-amd64.tar.gz"
+verify_archive() {
+    local sha256=${1:?sha256}
+    local archive=${2:?archive}
 
-mkdir -p "$install_dir"
-curl -fsSL --connect-timeout 10 --max-time 120 --output "$archive" "$URL"
-printf '%s  %s\n' "$SHA256" "$archive" | sha256sum --check --status
-tar -xzf "$archive" -C "$work_dir" rustbgpd
-install -m 0755 "$work_dir/rustbgpd" "$install_dir/rustbgpd-v0.64.0"
-[[ $("$install_dir/rustbgpd-v0.64.0" --version) == "rustbgpd 0.64.0" ]]
+    [[ -f "$archive" ]] || return 1
+    if ! printf '%s  %s\n' "$sha256" "$archive" \
+        | sha256sum --check --status; then
+        echo "v0.64 validator archive checksum mismatch: ${archive}" >&2
+        return 1
+    fi
+}
+
+install_from_archive() (
+    local version=${1:?version}
+    local sha256=${2:?sha256}
+    local archive=${3:?archive}
+    local install_dir=${4:?install directory}
+    local binary_name=${5:?binary name}
+    local work_dir staged_binary reported_version
+
+    # This path is deliberately offline. The producer is the only workflow
+    # job allowed to fetch the release archive; consumers re-verify the
+    # same-run artifact before tar sees any bytes.
+    verify_archive "$sha256" "$archive" || return 1
+
+    work_dir=$(mktemp -d) || return 1
+    mkdir -p "$install_dir" || return 1
+    staged_binary=$(mktemp "${install_dir}/.${binary_name}.XXXXXX") || return 1
+    trap 'rm -rf -- "$work_dir"; rm -f -- "$staged_binary"' EXIT
+    tar -xzf "$archive" -C "$work_dir" rustbgpd || return 1
+    [[ -f "$work_dir/rustbgpd" ]] || {
+        echo "v0.64 validator archive did not contain rustbgpd" >&2
+        return 1
+    }
+    chmod 0755 "$work_dir/rustbgpd" || return 1
+    reported_version=$("$work_dir/rustbgpd" --version 2>&1) || return 1
+    if [[ "$reported_version" != "rustbgpd ${version}" ]]; then
+        echo "unexpected v0.64 validator version: ${reported_version}" >&2
+        return 1
+    fi
+
+    install -m 0755 "$work_dir/rustbgpd" "$staged_binary" || return 1
+    mv -f -- "$staged_binary" "$install_dir/$binary_name" || return 1
+    [[ $("$install_dir/$binary_name" --version 2>&1) == "rustbgpd ${version}" ]]
+)
+
+download_archive_once() {
+    local url=${1:?url}
+    local destination=${2:?destination}
+
+    curl -fsSL \
+        --connect-timeout 10 \
+        --max-time 120 \
+        --output "$destination" \
+        "$url"
+}
+
+prepare_archive() {
+    local sha256=${1:?sha256}
+    local url=${2:?url}
+    local archive=${3:?archive}
+    local attempt staged_archive
+
+    if verify_archive "$sha256" "$archive" 2>/dev/null; then
+        echo "using verified cached v0.64 validator archive"
+        return 0
+    fi
+    if [[ -e "$archive" ]]; then
+        echo "::warning::discarding invalid cached v0.64 validator archive" >&2
+        rm -f -- "$archive"
+    fi
+
+    mkdir -p "$(dirname "$archive")"
+    for ((attempt = 1; attempt <= ATTEMPTS; attempt++)); do
+        staged_archive=$(mktemp "${archive}.download.XXXXXX")
+        if download_archive_once "$url" "$staged_archive" \
+            && verify_archive "$sha256" "$staged_archive"; then
+            mv -f -- "$staged_archive" "$archive"
+            echo "downloaded and verified v0.64 validator archive"
+            return 0
+        fi
+        rm -f -- "$staged_archive"
+        if ((attempt < ATTEMPTS)); then
+            echo "::warning::v0.64 validator download/verify attempt ${attempt}/${ATTEMPTS} failed; retrying" >&2
+            sleep $((attempt * 5))
+        fi
+    done
+
+    echo "::error::v0.64 validator download/verification failed after ${ATTEMPTS} attempts: ${url}" >&2
+    return 1
+}
+
+fail_self_test() {
+    echo "v0.64 validator installer self-test failed: $*" >&2
+    return 1
+}
+
+self_test() (
+    local fixture_dir source_dir base_archive valid_archive checksum truncated_size
+    local wrong_source wrong_archive wrong_checksum counter cache_path target_path
+
+    fixture_dir=$(mktemp -d)
+    trap 'rm -rf -- "$fixture_dir"' EXIT
+    [[ "$VERSION" == "0.64.0" ]] \
+        || fail_self_test "version pin drifted"
+    [[ "$SHA256" == "bd4829de08d0c50074f9ecd5c351399fae42be06d456b3880a04aa4a7cda1137" ]] \
+        || fail_self_test "archive checksum pin drifted"
+    [[ "$ARCHIVE" == "rustbgpd-linux-amd64.tar.gz" ]] \
+        || fail_self_test "archive name drifted"
+    [[ "$BINARY" == "rustbgpd-v0.64.0" ]] \
+        || fail_self_test "installed binary name drifted"
+    [[ "$URL" == "https://github.com/lance0/rustbgpd/releases/download/v0.64.0/rustbgpd-linux-amd64.tar.gz" ]] \
+        || fail_self_test "release URL drifted"
+    [[ "$ATTEMPTS" -eq 3 ]] \
+        || fail_self_test "retry bound drifted"
+
+    source_dir="$fixture_dir/source"
+    mkdir -p "$source_dir"
+    cat >"$source_dir/rustbgpd" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' 'rustbgpd 0.64.0'
+EOF
+    chmod +x "$source_dir/rustbgpd"
+    # The extra empty gzip member makes the full fixture distinct while the
+    # truncated prefix remains an extractable tar. Only checksum verification
+    # can reject that otherwise-plausible truncated transfer before extraction.
+    base_archive="$fixture_dir/base.tar.gz"
+    valid_archive="$fixture_dir/valid.tar.gz"
+    tar -czf "$base_archive" -C "$source_dir" rustbgpd
+    cp "$base_archive" "$valid_archive"
+    printf '' | gzip >>"$valid_archive"
+    checksum=$(sha256sum "$valid_archive" | awk '{print $1}')
+
+    install_from_archive \
+        "$VERSION" "$checksum" "$valid_archive" \
+        "$fixture_dir/valid-install" "$BINARY"
+    [[ -x "$fixture_dir/valid-install/$BINARY" ]] \
+        || fail_self_test "verified archive was not installed"
+
+    truncated_size=$(wc -c <"$base_archive")
+    head -c "$truncated_size" "$valid_archive" >"$fixture_dir/truncated.tar.gz"
+    if install_from_archive \
+        "$VERSION" "$checksum" "$fixture_dir/truncated.tar.gz" \
+        "$fixture_dir/truncated-install" "$BINARY" 2>/dev/null; then
+        fail_self_test "truncated archive was accepted"
+    fi
+    [[ ! -e "$fixture_dir/truncated-install/$BINARY" ]] \
+        || fail_self_test "truncated archive installed a binary"
+
+    if install_from_archive \
+        "$VERSION" \
+        0000000000000000000000000000000000000000000000000000000000000000 \
+        "$valid_archive" "$fixture_dir/wrong-checksum-install" "$BINARY" \
+        2>/dev/null; then
+        fail_self_test "wrong checksum was accepted"
+    fi
+
+    wrong_source="$fixture_dir/wrong-source"
+    mkdir -p "$wrong_source"
+    cat >"$wrong_source/rustbgpd" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' 'rustbgpd 0.63.0'
+EOF
+    chmod +x "$wrong_source/rustbgpd"
+    wrong_archive="$fixture_dir/wrong-version.tar.gz"
+    tar -czf "$wrong_archive" -C "$wrong_source" rustbgpd
+    wrong_checksum=$(sha256sum "$wrong_archive" | awk '{print $1}')
+    if install_from_archive \
+        "$VERSION" "$wrong_checksum" "$wrong_archive" \
+        "$fixture_dir/wrong-version-install" "$BINARY" 2>/dev/null; then
+        fail_self_test "wrong binary version was accepted"
+    fi
+    [[ ! -e "$fixture_dir/wrong-version-install/$BINARY" ]] \
+        || fail_self_test "wrong-version binary reached the install path"
+
+    # Cache and retry cases stub the network primitive and sleep, keeping this
+    # suite entirely offline while exercising the real selection and bounds.
+    counter="$fixture_dir/download-count"
+    cache_path="$fixture_dir/cache/$ARCHIVE"
+    mkdir -p "$(dirname "$cache_path")"
+    cp "$valid_archive" "$cache_path"
+    printf '0' >"$counter"
+    (
+        download_archive_once() {
+            printf '%s' "$(($(cat "$counter") + 1))" >"$counter"
+            return 1
+        }
+        prepare_archive "$checksum" unused://cache-hit "$cache_path"
+    ) >/dev/null || fail_self_test "valid cache hit failed"
+    [[ $(cat "$counter") -eq 0 ]] \
+        || fail_self_test "valid cache hit used the network"
+
+    printf 'corrupt' >"$cache_path"
+    printf '0' >"$counter"
+    (
+        sleep() { :; }
+        download_archive_once() {
+            printf '%s' "$(($(cat "$counter") + 1))" >"$counter"
+            cp "$valid_archive" "$2"
+        }
+        prepare_archive "$checksum" unused://corrupt-cache "$cache_path"
+    ) >/dev/null 2>&1 || fail_self_test "corrupt cache was not replaced"
+    [[ $(cat "$counter") -eq 1 ]] \
+        || fail_self_test "corrupt cache did not perform one download"
+    verify_archive "$checksum" "$cache_path" \
+        || fail_self_test "corrupt cache replacement was not verified"
+
+    target_path="$fixture_dir/transient/$ARCHIVE"
+    printf '0' >"$counter"
+    (
+        sleep() { :; }
+        download_archive_once() {
+            local count
+            count=$(($(cat "$counter") + 1))
+            printf '%s' "$count" >"$counter"
+            if [[ "$count" -eq 1 ]]; then
+                printf 'truncated' >"$2"
+            else
+                cp "$valid_archive" "$2"
+            fi
+        }
+        prepare_archive "$checksum" unused://transient "$target_path"
+    ) >/dev/null 2>&1 || fail_self_test "retry did not recover"
+    [[ $(cat "$counter") -eq 2 ]] \
+        || fail_self_test "retry did not stop on first verified success"
+    verify_archive "$checksum" "$target_path" \
+        || fail_self_test "retry published unverified bytes"
+
+    target_path="$fixture_dir/persistent/$ARCHIVE"
+    printf '0' >"$counter"
+    if (
+        sleep() { :; }
+        download_archive_once() {
+            printf '%s' "$(($(cat "$counter") + 1))" >"$counter"
+            printf 'corrupt' >"$2"
+        }
+        prepare_archive "$checksum" unused://persistent "$target_path"
+    ) >/dev/null 2>&1; then
+        fail_self_test "persistent corruption was not surfaced"
+    fi
+    [[ $(cat "$counter") -eq "$ATTEMPTS" ]] \
+        || fail_self_test "persistent failure escaped retry bound"
+    [[ ! -e "$target_path" ]] \
+        || fail_self_test "persistent failure published an archive"
+
+    # Installing a downloaded artifact remains usable when every network
+    # primitive is disabled, proving consumers have no hidden fetch fallback.
+    (
+        # These tripwires are reachable only if install_from_archive regresses
+        # into a network consumer, which is precisely the negative under test.
+        # shellcheck disable=SC2317
+        curl() { fail_self_test "offline install invoked curl"; }
+        # shellcheck disable=SC2317
+        download_archive_once() { fail_self_test "offline install downloaded"; }
+        install_from_archive \
+            "$VERSION" "$checksum" "$valid_archive" \
+            "$fixture_dir/offline-install" "$BINARY"
+    ) || fail_self_test "offline artifact install failed"
+
+    printf '%s\n' 'v0.64 validator installer self-test passed'
+)
+
+usage() {
+    echo "usage: $0 --prepare-archive ARCHIVE | --install-archive ARCHIVE INSTALL_DIR | --self-test" >&2
+    exit 2
+}
+
+case ${1:-} in
+    --prepare-archive)
+        [[ $# -eq 2 ]] || usage
+        prepare_archive "$SHA256" "$URL" "$2"
+        ;;
+    --install-archive)
+        [[ $# -eq 3 ]] || usage
+        install_from_archive "$VERSION" "$SHA256" "$2" "$3" "$BINARY"
+        ;;
+    --self-test)
+        [[ $# -eq 1 ]] || usage
+        self_test
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,40 @@ on:
       - "**/*.md"
 
 jobs:
+  v064_validator:
+    name: prepare exact v0.64 config migration validator
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      # The cache avoids a release fetch across runs. Its key seals the exact
+      # release checksum and deliberately has no partial restore fallback.
+      - name: Restore exact v0.64 validator archive cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/rustbgpd-v064-cache/rustbgpd-linux-amd64.tar.gz
+          key: rustbgpd-v0.64.0-linux-amd64-bd4829de08d0c50074f9ecd5c351399fae42be06d456b3880a04aa4a7cda1137
+      - name: Prepare exact v0.64 validator archive
+        run: |
+          bash -n .github/scripts/install-rustbgpd-v064-validator.sh
+          shellcheck .github/scripts/install-rustbgpd-v064-validator.sh
+          .github/scripts/install-rustbgpd-v064-validator.sh --self-test
+          .github/scripts/install-rustbgpd-v064-validator.sh \
+            --prepare-archive \
+            "$RUNNER_TEMP/rustbgpd-v064-cache/rustbgpd-linux-amd64.tar.gz"
+      # Consumers use this same-run artifact instead of independently reaching
+      # GitHub Releases. They verify its pinned checksum again before extract.
+      - name: Upload verified v0.64 validator archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: rustbgpd-v0.64.0-linux-amd64
+          path: ${{ runner.temp }}/rustbgpd-v064-cache/rustbgpd-linux-amd64.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
   core:
+    needs: v064_validator
     runs-on: ubuntu-latest
     # Bound any wedge (e.g. a rustdoc hang) so a stuck step fails fast
     # instead of running to GitHub's 6-hour default. The last serial run
@@ -65,11 +98,17 @@ jobs:
           bash -n .github/scripts/install-grpcurl.sh
           shellcheck .github/scripts/install-grpcurl.sh
           bash .github/scripts/install-grpcurl.sh --self-test
-      - name: Install exact v0.64 config migration validator
+      - name: Download verified v0.64 validator archive
+        uses: actions/download-artifact@v8
+        with:
+          name: rustbgpd-v0.64.0-linux-amd64
+          path: ${{ runner.temp }}/rustbgpd-v064-artifact
+      - name: Install exact v0.64 config migration validator offline
         run: |
-          bash -n .github/scripts/install-rustbgpd-v064-validator.sh
-          shellcheck .github/scripts/install-rustbgpd-v064-validator.sh
-          .github/scripts/install-rustbgpd-v064-validator.sh "$RUNNER_TEMP/rustbgpd-v064"
+          .github/scripts/install-rustbgpd-v064-validator.sh \
+            --install-archive \
+            "$RUNNER_TEMP/rustbgpd-v064-artifact/rustbgpd-linux-amd64.tar.gz" \
+            "$RUNNER_TEMP/rustbgpd-v064"
       - name: Prove CI image-primer contract
         run: |
           python3 -m unittest -v scripts/test_check_ci_image_primer_contract.py
@@ -264,6 +303,7 @@ jobs:
 
   core_tests:
     name: core tests / rustdoc
+    needs: v064_validator
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -275,8 +315,17 @@ jobs:
           toolchain: stable
       - uses: ./.github/actions/install-protobuf
       - uses: Swatinem/rust-cache@v2
-      - name: Install exact v0.64 config migration validator
-        run: .github/scripts/install-rustbgpd-v064-validator.sh "$RUNNER_TEMP/rustbgpd-v064"
+      - name: Download verified v0.64 validator archive
+        uses: actions/download-artifact@v8
+        with:
+          name: rustbgpd-v0.64.0-linux-amd64
+          path: ${{ runner.temp }}/rustbgpd-v064-artifact
+      - name: Install exact v0.64 config migration validator offline
+        run: |
+          .github/scripts/install-rustbgpd-v064-validator.sh \
+            --install-archive \
+            "$RUNNER_TEMP/rustbgpd-v064-artifact/rustbgpd-linux-amd64.tar.gz" \
+            "$RUNNER_TEMP/rustbgpd-v064"
       - run: cargo test --workspace
         env:
           RUSTBGPD_V064_VALIDATOR: ${{ runner.temp }}/rustbgpd-v064/rustbgpd-v0.64.0
@@ -388,8 +437,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: ${{ always() }}
-    needs: [core, core_tests, scale_receipts]
+    needs: [v064_validator, core, core_tests, scale_receipts]
     env:
+      V064_VALIDATOR_RESULT: ${{ needs.v064_validator.result }}
       CORE_RESULT: ${{ needs.core.result }}
       CORE_TESTS_RESULT: ${{ needs.core_tests.result }}
       SCALE_RECEIPTS_RESULT: ${{ needs.scale_receipts.result }}
@@ -397,10 +447,11 @@ jobs:
       - name: Aggregate required CI result
         run: |
           set -euo pipefail
+          printf 'v064_validator=%s\n' "$V064_VALIDATOR_RESULT"
           printf 'core=%s\n' "$CORE_RESULT"
           printf 'core_tests=%s\n' "$CORE_TESTS_RESULT"
           printf 'scale_receipts=%s\n' "$SCALE_RECEIPTS_RESULT"
-          if [[ "$CORE_RESULT" != "success" || "$CORE_TESTS_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]; then
+          if [[ "$V064_VALIDATOR_RESULT" != "success" || "$CORE_RESULT" != "success" || "$CORE_TESTS_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]; then
             exit 1
           fi
 

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -45,6 +45,10 @@ GOBGP_CHECKSUMS = {
     "amd64": "e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522",
     "arm64": "0aaa2da6e4dcaaf57e3d0e64eae14946292b0a5894d80ef3b7ebde3bf52beb29",
 }
+V064_SHA256 = "bd4829de08d0c50074f9ecd5c351399fae42be06d456b3880a04aa4a7cda1137"
+V064_ARCHIVE = "rustbgpd-linux-amd64.tar.gz"
+V064_ARTIFACT = "rustbgpd-v0.64.0-linux-amd64"
+V064_CACHE_KEY = f"rustbgpd-v0.64.0-linux-amd64-{V064_SHA256}"
 
 TRIGGER_HASHES = {
     "ci.yml": "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8",
@@ -64,13 +68,15 @@ CALL_HASHES = {
 }
 PINS = collections.Counter(
     {
-        "actions/checkout@v7": 81,
+        "actions/checkout@v7": 82,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 3,
         "Swatinem/rust-cache@v2": 5,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 2,
         "docker/setup-buildx-action@v4": 44,
         "docker/build-push-action@v7": 45,
-        "actions/upload-artifact@v7": 1,
+        "actions/cache@v6": 1,
+        "actions/upload-artifact@v7": 2,
+        "actions/download-artifact@v8": 2,
         "rustsec/audit-check@v2.0.0": 1,
         "EmbarkStudios/cargo-deny-action@v2": 1,
     }
@@ -117,6 +123,73 @@ def check(root: Path) -> list[str]:
         )
         if _hash(permissions) != PERMISSION_HASHES[name]:
             errors.append(f"{name}: permissions drifted")
+
+    ci_jobs = _jobs(texts["ci.yml"])
+    producer = ci_jobs.get("v064_validator", "")
+    producer_seams = (
+        "name: prepare exact v0.64 config migration validator",
+        "runs-on: ubuntu-latest",
+        "timeout-minutes: 10",
+        CHECKOUT,
+        "uses: actions/cache@v6",
+        f"path: ${{{{ runner.temp }}}}/rustbgpd-v064-cache/{V064_ARCHIVE}",
+        f"key: {V064_CACHE_KEY}",
+        "--self-test",
+        "--prepare-archive",
+        "uses: actions/upload-artifact@v7",
+        f"name: {V064_ARTIFACT}",
+        "if-no-files-found: error",
+        "retention-days: 1",
+        "compression-level: 0",
+    )
+    for seam in producer_seams:
+        if seam not in producer:
+            errors.append(f"ci.yml:v064_validator missing {seam}")
+    for forbidden in ("restore-keys:", "continue-on-error:"):
+        if forbidden in producer:
+            errors.append(f"ci.yml:v064_validator permits {forbidden}")
+    if producer.count("uses: actions/cache@v6") != 1:
+        errors.append("ci.yml:v064_validator must have one cache producer")
+    if producer.count("uses: actions/upload-artifact@v7") != 1:
+        errors.append("ci.yml:v064_validator must upload one same-run artifact")
+
+    for job_name in ("core", "core_tests"):
+        consumer = ci_jobs.get(job_name, "")
+        for seam in (
+            "needs: v064_validator",
+            "uses: actions/download-artifact@v8",
+            f"name: {V064_ARTIFACT}",
+            f"path: ${{{{ runner.temp }}}}/rustbgpd-v064-artifact",
+            "--install-archive",
+            f'"$RUNNER_TEMP/rustbgpd-v064-artifact/{V064_ARCHIVE}"',
+            '"$RUNNER_TEMP/rustbgpd-v064"',
+        ):
+            if seam not in consumer:
+                errors.append(f"ci.yml:{job_name} missing validator seam {seam}")
+        if consumer.count("uses: actions/download-artifact@v8") != 1:
+            errors.append(f"ci.yml:{job_name} must download one validator artifact")
+        for forbidden in (
+            "--prepare-archive",
+            "actions/cache@",
+            "actions/upload-artifact@",
+            "releases/download/v0.64.0",
+            "restore-keys:",
+            "continue-on-error:",
+        ):
+            if forbidden in consumer:
+                errors.append(
+                    f"ci.yml:{job_name} validator consumer permits {forbidden}"
+                )
+
+    aggregate = ci_jobs.get("check", "")
+    for seam in (
+        "needs: [v064_validator, core, core_tests, scale_receipts]",
+        "V064_VALIDATOR_RESULT: ${{ needs.v064_validator.result }}",
+        "printf 'v064_validator=%s\\n' \"$V064_VALIDATOR_RESULT\"",
+        '[[ "$V064_VALIDATOR_RESULT" != "success"',
+    ):
+        if seam not in aggregate:
+            errors.append(f"ci.yml:check missing validator result seam {seam}")
 
     for name, roster, setup in (
         ("interop.yml", INTEROP, False),
@@ -274,7 +347,7 @@ def check(root: Path) -> list[str]:
         f"ENV GOBGP_VERSION={GOBGP_VERSION}",
         'archive="gobgp_${GOBGP_VERSION}_linux_${TARGETARCH}.tar.gz"',
         '*) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;;',
-        'https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/${archive}',
+        "https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/${archive}",
         'echo "${checksum}  /tmp/${archive}" | sha256sum --check --strict',
         'tar --extract --gzip --file "/tmp/${archive}" --directory /usr/local/bin gobgp gobgpd',
         'test "$(gobgp --version)" = "gobgp version ${GOBGP_VERSION}"',
@@ -287,7 +360,9 @@ def check(root: Path) -> list[str]:
     for arch, checksum in GOBGP_CHECKSUMS.items():
         if f'{arch}) checksum="{checksum}" ;;' not in gobgp:
             errors.append(f"Dockerfile.gobgp: {arch} checksum drifted")
-    if re.search(r"(?:@latest|releases/(?:latest|download/latest)|GOBGP_VERSION=latest)", gobgp):
+    if re.search(
+        r"(?:@latest|releases/(?:latest|download/latest)|GOBGP_VERSION=latest)", gobgp
+    ):
         errors.append("Dockerfile.gobgp: floating GoBGP release is forbidden")
     if "go install github.com/osrg/gobgp" in gobgp or "FROM golang:" in gobgp:
         errors.append("Dockerfile.gobgp: source build replaced pinned release archives")

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 
 ROSTER = [
+    "v064_validator",
     "core",
     "core_tests",
     "scale_receipts",
@@ -20,10 +21,11 @@ ROSTER = [
 TRIGGER_HASH = "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8"
 PERMISSION_HASH = "9691400b3b1036bcdfe724926816dbe71b0aa22ed9b5eb89627e2eeb75079898"
 JOB_HASHES = {
-    "core": "0a2dcd28b3e15df6ca51b2df4abe7d764ec0d8a07f1e52bdc0a7a2ebe06506c5",
-    "core_tests": "45cf057af044f2acd7a434361db7d40383c303e9b4e9363564fe8d133e130edd",
+    "v064_validator": "b3f0ae8906bd28397a5f82bab0db5467e09a8e312aa24a8c8f2db8fd01c6310a",
+    "core": "8a77646df5100ecbdbfe67deabd6c1c2a432367f12e668ad9df7ecc43ea261f3",
+    "core_tests": "c5d8ed560cd4e572f535bb4eabe065372fddfc1dbefe0c341a9c5af76ed6df0f",
     "scale_receipts": "18b47124c6a93c50e44f385eb762b41493fb33fd3ea251ac952b3bb3a46d5639",
-    "check": "cfc655ca80392ab0699390b461e5e8e9b41410cc724201aafe75ae6da7d83213",
+    "check": "736f69ca686c06e889962d5fb93d80ee848090718dcf63aeff695febc6cbfcc5",
     "msrv": "273de02a6a1e67e17913b50023326214261b8f4d6399f8f8867188e7e3d2acb9",
     "evpn_bum_filter_kernel": "d427ed2c650d619d926cad0a4cbb6b558dd013ace9b18ba48757be529420863a",
 }
@@ -36,7 +38,10 @@ TOOLCHAIN = (
 RUST_CACHE = "uses: Swatinem/rust-cache@v2"
 PINS = collections.Counter(
     {
-        "actions/checkout@v7": 5,
+        "actions/checkout@v7": 6,
+        "actions/cache@v6": 1,
+        "actions/upload-artifact@v7": 1,
+        "actions/download-artifact@v8": 2,
         "Swatinem/rust-cache@v2": 4,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 3,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 1,
@@ -90,9 +95,30 @@ def check(root: Path) -> list[str]:
         if _hash(jobs.get(name, "")) != expected:
             errors.append(f"{name} job body drifted")
 
+    producer = jobs.get("v064_validator", "")
+    for seam in (
+        "name: prepare exact v0.64 config migration validator",
+        "runs-on: ubuntu-latest",
+        "timeout-minutes: 10",
+        CHECKOUT,
+        "uses: actions/cache@v6",
+        "key: rustbgpd-v0.64.0-linux-amd64-bd4829de08d0c50074f9ecd5c351399fae42be06d456b3880a04aa4a7cda1137",
+        "--self-test",
+        "--prepare-archive",
+        "uses: actions/upload-artifact@v7",
+        "name: rustbgpd-v0.64.0-linux-amd64",
+        "if-no-files-found: error",
+    ):
+        if seam not in producer:
+            errors.append(f"v064_validator missing {seam}")
+    for forbidden in ("restore-keys:", "continue-on-error:"):
+        if forbidden in producer:
+            errors.append(f"v064_validator permits {forbidden}")
+
     core_tests = jobs.get("core_tests", "")
     for seam in (
         "name: core tests / rustdoc",
+        "needs: v064_validator",
         "runs-on: ubuntu-latest",
         "timeout-minutes: 30",
         CHECKOUT,
@@ -146,14 +172,16 @@ def check(root: Path) -> list[str]:
         "runs-on: ubuntu-latest",
         "timeout-minutes: 5",
         "if: ${{ always() }}",
-        "needs: [core, core_tests, scale_receipts]",
+        "needs: [v064_validator, core, core_tests, scale_receipts]",
+        "V064_VALIDATOR_RESULT: ${{ needs.v064_validator.result }}",
         "CORE_RESULT: ${{ needs.core.result }}",
         "CORE_TESTS_RESULT: ${{ needs.core_tests.result }}",
         "SCALE_RECEIPTS_RESULT: ${{ needs.scale_receipts.result }}",
+        "printf 'v064_validator=%s\\n' \"$V064_VALIDATOR_RESULT\"",
         "printf 'core=%s\\n' \"$CORE_RESULT\"",
         "printf 'core_tests=%s\\n' \"$CORE_TESTS_RESULT\"",
         "printf 'scale_receipts=%s\\n' \"$SCALE_RECEIPTS_RESULT\"",
-        '[[ "$CORE_RESULT" != "success" || "$CORE_TESTS_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]',
+        '[[ "$V064_VALIDATOR_RESULT" != "success" || "$CORE_RESULT" != "success" || "$CORE_TESTS_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]',
     ):
         if seam not in aggregate:
             errors.append(f"aggregate check missing {seam}")

--- a/scripts/test_check_ci_scale_split_contract.py
+++ b/scripts/test_check_ci_scale_split_contract.py
@@ -37,6 +37,7 @@ class ScaleSplitContractTests(unittest.TestCase):
 
     def test_destructive_roster_and_preserved_bodies(self) -> None:
         cases = (
+            ("  v064_validator:\n", "  renamed_validator:\n"),
             ("  core:\n", "  renamed_core:\n"),
             ("  core_tests:\n", "  renamed_core_tests:\n"),
             ("  scale_receipts:\n", "  renamed_scale:\n"),
@@ -68,6 +69,27 @@ class ScaleSplitContractTests(unittest.TestCase):
             target.write_text(text[:core_start] + scale + core + text[check_start:])
             self.assertTrue(check(root), "job-order mutation stayed green")
 
+    def test_destructive_validator_producer(self) -> None:
+        cache_key = (
+            "key: rustbgpd-v0.64.0-linux-amd64-"
+            "bd4829de08d0c50074f9ecd5c351399fae42be06d456b3880a04aa4a7cda1137"
+        )
+        cases = (
+            (
+                "name: prepare exact v0.64 config migration validator",
+                "name: changed validator producer",
+            ),
+            ("uses: actions/cache@v6", "uses: actions/cache@main"),
+            (cache_key, f"{cache_key}\n          restore-keys: rustbgpd-v0.64"),
+            ("--self-test", "--skipped-self-test"),
+            ("--prepare-archive", "--changed-prepare"),
+            ("uses: actions/upload-artifact@v7", "uses: actions/upload-artifact@main"),
+            ("if-no-files-found: error", "if-no-files-found: ignore"),
+        )
+        for old, new in cases:
+            with self.subTest(seam=old):
+                self.mutate(old, new)
+
     def test_destructive_extracted_step_and_setup(self) -> None:
         step_name = "- name: Check standalone scale harnesses and receipt classifiers"
         cases = (
@@ -93,7 +115,7 @@ class ScaleSplitContractTests(unittest.TestCase):
             with self.subTest(seam=old):
                 self.mutate(old, new, occurrence[0] if occurrence else 0)
         for pin, occurrence in (
-            ("actions/checkout@v7", 2),
+            ("actions/checkout@v7", 3),
             ("dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c", 2),
             ("Swatinem/rust-cache@v2", 2),
         ):
@@ -115,12 +137,12 @@ class ScaleSplitContractTests(unittest.TestCase):
             with self.subTest(seam=old):
                 self.mutate(old, new, occurrence[0] if occurrence else 0)
         for pin in (
-            "actions/checkout@v7",
             "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c",
             "Swatinem/rust-cache@v2",
         ):
             with self.subTest(pin=pin):
                 self.mutate(pin, "changed@main", 1)
+        self.mutate("actions/checkout@v7", "changed@main", 2)
         self.mutate(
             "      - name: Wire crate README freshness gate",
             "      - run: cargo test --workspace\n"
@@ -136,14 +158,25 @@ class ScaleSplitContractTests(unittest.TestCase):
             ("timeout-minutes: 5", "timeout-minutes: 6"),
             ("if: ${{ always() }}", "if: ${{ success() }}"),
             (
+                "needs: [v064_validator, core, core_tests, scale_receipts]",
                 "needs: [core, core_tests, scale_receipts]",
-                "needs: [core_tests, scale_receipts]",
             ),
             (
-                "needs: [core, core_tests, scale_receipts]",
-                "needs: [core, scale_receipts]",
+                "needs: [v064_validator, core, core_tests, scale_receipts]",
+                "needs: [v064_validator, core_tests, scale_receipts]",
             ),
-            ("needs: [core, core_tests, scale_receipts]", "needs: [core, core_tests]"),
+            (
+                "needs: [v064_validator, core, core_tests, scale_receipts]",
+                "needs: [v064_validator, core, scale_receipts]",
+            ),
+            (
+                "needs: [v064_validator, core, core_tests, scale_receipts]",
+                "needs: [v064_validator, core, core_tests]",
+            ),
+            (
+                "V064_VALIDATOR_RESULT: ${{ needs.v064_validator.result }}",
+                "V064_VALIDATOR_RESULT: success",
+            ),
             ("CORE_RESULT: ${{ needs.core.result }}", "CORE_RESULT: success"),
             (
                 "CORE_TESTS_RESULT: ${{ needs.core_tests.result }}",
@@ -156,7 +189,7 @@ class ScaleSplitContractTests(unittest.TestCase):
             ("printf 'core=%s\\n' \"$CORE_RESULT\"", "true"),
             ("printf 'core_tests=%s\\n' \"$CORE_TESTS_RESULT\"", "true"),
             (
-                '[[ "$CORE_RESULT" != "success" || "$CORE_TESTS_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]',
+                '[[ "$V064_VALIDATOR_RESULT" != "success" || "$CORE_RESULT" != "success" || "$CORE_TESTS_RESULT" != "success" || "$SCALE_RECEIPTS_RESULT" != "success" ]]',
                 "[[ false ]]",
             ),
         )
@@ -169,11 +202,14 @@ class ScaleSplitContractTests(unittest.TestCase):
         shell = aggregate_shell(_jobs(workflow)["check"])
         self.assertTrue(shell)
 
-        def run(core=None, core_tests=None, scale=None):
+        def run(validator=None, core=None, core_tests=None, scale=None):
             env = os.environ.copy()
+            env.pop("V064_VALIDATOR_RESULT", None)
             env.pop("CORE_RESULT", None)
             env.pop("CORE_TESTS_RESULT", None)
             env.pop("SCALE_RECEIPTS_RESULT", None)
+            if validator is not None:
+                env["V064_VALIDATOR_RESULT"] = validator
             if core is not None:
                 env["CORE_RESULT"] = core
             if core_tests is not None:
@@ -184,17 +220,28 @@ class ScaleSplitContractTests(unittest.TestCase):
                 ["bash", "-c", shell], env=env, capture_output=True, text=True
             )
 
-        self.assertEqual(0, run("success", "success", "success").returncode)
+        self.assertEqual(0, run("success", "success", "success", "success").returncode)
         for bad in ("failure", "cancelled", "skipped", ""):
+            with self.subTest(child="v064_validator", result=bad):
+                self.assertNotEqual(
+                    0, run(bad, "success", "success", "success").returncode
+                )
             with self.subTest(child="core", result=bad):
-                self.assertNotEqual(0, run(bad, "success", "success").returncode)
+                self.assertNotEqual(
+                    0, run("success", bad, "success", "success").returncode
+                )
             with self.subTest(child="core_tests", result=bad):
-                self.assertNotEqual(0, run("success", bad, "success").returncode)
+                self.assertNotEqual(
+                    0, run("success", "success", bad, "success").returncode
+                )
             with self.subTest(child="scale_receipts", result=bad):
-                self.assertNotEqual(0, run("success", "success", bad).returncode)
-        self.assertNotEqual(0, run(None, "success", "success").returncode)
-        self.assertNotEqual(0, run("success", None, "success").returncode)
-        self.assertNotEqual(0, run("success", "success", None).returncode)
+                self.assertNotEqual(
+                    0, run("success", "success", "success", bad).returncode
+                )
+        self.assertNotEqual(0, run(None, "success", "success", "success").returncode)
+        self.assertNotEqual(0, run("success", None, "success", "success").returncode)
+        self.assertNotEqual(0, run("success", "success", None, "success").returncode)
+        self.assertNotEqual(0, run("success", "success", "success", None).returncode)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- prepare the pinned v0.64 migration validator archive once with bounded verified retries and an immutable checksum-keyed cache
- pass the verified archive to core and core-tests as a same-run artifact, with independent offline checksum and version validation
- extend the CI contract checks to keep producer, consumers, and aggregate status fail-closed

## Validation

- installer offline self-test and ShellCheck
- CI image-primer contract: 16 tests plus live checker
- CI scale-split contract: 7 tests plus live checker
- actionlint
- workspace formatting and Clippy

Linear: LAN-1006