### PR TITLE
chore: upgrade released rtnetlink pair

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,15 +45,6 @@ updates:
       # Workspace-internal crates are path deps; updates land via the
       # release process, not Dependabot.
       - dependency-name: "rustbgpd-*"
-      # netlink-packet-route 0.31 is code-compatible (proven in PR #538) but
-      # cannot merge until upstream rtnetlink moves off netlink-packet-route
-      # ^0.30 — crates.io rtnetlink 0.21.0 still pins ^0.30, so a lone bump
-      # creates a duplicate-version tree. Ignore 0.31+ until rtnetlink catches
-      # up (0.30.x security patches still flow). REMOVE this when bumping the
-      # pair together — see ROADMAP "netlink-packet-route 0.31 upgrade" + #452.
-      - dependency-name: "netlink-packet-route"
-        versions: [">= 0.31"]
-
   # Wire crate: published to crates.io; its dependencies must stay
   # current independently because external consumers pin against it.
   - package-ecosystem: "cargo"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,18 +1773,18 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
+checksum = "b897d7bd4f0af82e68d40d0344cf37e97f9c97ddf74a098de3e4da05e96ca395"
 dependencies = [
  "paste",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.30.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+checksum = "98e26a74571b93d1d52a9a5582e7c47aa9464dde57a17ea9841795eef45febd9"
 dependencies = [
  "bitflags 2.13.0",
  "libc",
@@ -2841,9 +2841,9 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc19f84f710fa2f337617f9bc0400260a94224bde7bae28fd8879f3771ca5784"
+checksum = "ee647c6484f6a1515dba20d2cc884b11bf5d79fcdc7f0defdf18e3620f52c18c"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -2853,7 +2853,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "nix 0.30.1",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "tokio",
 ]
 
@@ -3255,7 +3255,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3708,7 +3708,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4565,7 +4565,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,8 +176,8 @@ socket2.workspace = true
 tokio-util = { version = "0.7", features = ["rt"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rtnetlink = "0.21"
-netlink-packet-route = "0.30"
+rtnetlink = "0.22"
+netlink-packet-route = "0.32.1"
 libc.workspace = true
 nix = { workspace = true, features = ["fs", "signal", "time", "user"] }
 futures = "0.3"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2035,29 +2035,21 @@ branch is between features.
   deliberately differ: cargo-deny warns (not fails) on unsound-class
   advisories, so only the unmaintained `paste` entry needs a deny.toml
   ignore while `.cargo/audit.toml` also carries the rand unsoundness entry.
-- [ ] **`netlink-packet-route` 0.31 upgrade — proven ready, blocked on rtnetlink
-  lockstep.** 0.31.0's two breaking changes (`InfoIpTunnel::CollectMetadata`,
-  `InfoVxlan::Df`) don't affect us — rustbgpd compiles clean against 0.31 with no
-  source changes. The blocker is upstream: `rtnetlink` (latest crates.io 0.21.0)
-  pins `netlink-packet-route ^0.30`, and our code feeds `netlink_packet_route`
-  types straight into `rtnetlink::Handle`, so a lone bump produces a
-  duplicate-version tree and ~31 type-mismatch errors. **Readiness is proven** —
-  draft PR #538 validates the upgrade against a git-pinned upstream `rtnetlink`
-  revision already on 0.31: workspace check/clippy/test/doc, the privileged netns
-  selectors, and M42/M50/M58/M70 containerlab receipts all green. To stop the
-  un-mergeable nag, Dependabot now **ignores `netlink-packet-route` `>= 0.31`**
-  (0.30.x security patches still flow). **Revisit when `rtnetlink` 0.22+ lands on
-  crates.io with 0.31 support**: drop the Dependabot ignore + the
-  `[patch.crates-io]` pin, bump the pair together in one PR, rerun the #538 matrix
-  (raw `IFLA_PROTINFO` AC-gate encode + `link_carrier` flag reads are the surfaces
-  to re-verify), and merge. LAN-643 is the sole live upstream-watch tracker;
-  closed Dependabot PR #452 remains the duplicate-version/type-mismatch proof.
-  Verified during the FIB route-drift eventing work (#482). **Upstream nudge
-  filed 2026-06-23:**
-  rust-netlink/rtnetlink#173 — a "New release 0.22.0" version-bump + CHANGELOG PR
-  against their `main` (which already carries the 0.31 dep) — requests the release
-  that unblocks this; execute the close-out above if/when any `rtnetlink` 0.22+
-  publishes.
+- [x] **Upgrade the released rtnetlink pair.** Done: rustbgpd now uses
+  `rtnetlink 0.22.0` with its coherent `netlink-packet-route 0.32.1` dependency,
+  with one resolved copy of each crate and no git patch or compatibility shim.
+  The obsolete Dependabot ignore for `netlink-packet-route >= 0.31` is removed.
+  Upstream release-preparation PR rust-netlink/rtnetlink#173 was closed unmerged
+  after the maintainer published 0.22.0 directly, so the old intermediate proof
+  PR #538 was closed rather than revived. Validation on the released crates
+  covers locked workspace check/test/Clippy, strict `rustbgpd-evpn-linux`
+  rustdoc, no-default/all-feature builds, and the privileged FDB-NHG,
+  FIB-runtime, BFD-runtime, VLAN-aware FDB,
+  MAC+IP/VLAN attribution, SVD FDB/VNI, managed SVD VXLAN, and managed IP-VRF
+  netns selectors. The raw `NDA_NH_ID`, `RT_TABLE_COMPAT`, and nested
+  `IFLA_PROTINFO` escape hatches remain because 0.32.1 still does not expose the
+  required typed kernel encodings. LAN-643 records the completion; closed
+  Dependabot PR #452 remains the historical duplicate-version proof.
 - [x] **Workspace `cargo doc` warning posture.** `.github/workflows/ci.yml` runs
   `cargo doc --workspace --lib --no-deps` with
   `RUSTDOCFLAGS="-D warnings"`; keep that as the standing local pre-flight

--- a/crates/evpn-linux/Cargo.toml
+++ b/crates/evpn-linux/Cargo.toml
@@ -22,8 +22,8 @@ tracing.workspace = true
 # released together; bump them as a set or transitive resolution
 # pulls in two copies of `netlink-packet-utils`.
 [target.'cfg(target_os = "linux")'.dependencies]
-rtnetlink = "0.21"
-netlink-packet-route = "0.30"
+rtnetlink = "0.22"
+netlink-packet-route = "0.32.1"
 netlink-packet-core = "0.8"
 netlink-packet-utils = "0.6"
 netlink-sys = { version = "0.8", features = ["tokio_socket"] }

--- a/crates/evpn-linux/src/linux/ac_gate.rs
+++ b/crates/evpn-linux/src/linux/ac_gate.rs
@@ -28,7 +28,7 @@
 //! `tests/netns_ac_gate.rs` (`EVPN_LINUX_NETNS=1`).
 //!
 //! The `IFLA_PROTINFO` attribute is hand-built via [`DefaultNla`]:
-//! netlink-packet-route 0.30's typed `LinkAttribute::ProtoInfoBridge`
+//! netlink-packet-route 0.32.1's typed `LinkAttribute::ProtoInfoBridge`
 //! emits `IFLA_PROTINFO` *without* `NLA_F_NESTED`, which the kernel's
 //! `br_setlink` would interpret through its legacy non-nested
 //! "binary compatibility with old RSTP" branch — reading the first

--- a/crates/evpn-linux/src/linux/fdb.rs
+++ b/crates/evpn-linux/src/linux/fdb.rs
@@ -44,7 +44,7 @@ use crate::snapshot::{KernelFdbEntry, KernelFdbFlags};
 use super::links::{LinkCache, matching_svd_vxlan_ports, unique_fdb_vxlan_target_for_vni};
 
 /// `NDA_NH_ID` neighbour attribute (kind = 13). Not exposed as a typed
-/// variant by `netlink-packet-route 0.30`; we read it via the
+/// variant by `netlink-packet-route 0.32.1`; we read it via the
 /// `Nla` trait's `kind()` accessor on the `Other(DefaultNla)` escape
 /// hatch.
 const NDA_NH_ID: u16 = 13;
@@ -173,7 +173,7 @@ fn parse_fdb_entry(msg: &NeighbourMessage, cache: &LinkCache) -> Option<FdbSnaps
                 NeighbourAddress::Inet6(v6) => dst = Some(std::net::IpAddr::V6(*v6)),
                 _ => {}
             },
-            // NDA_NH_ID (kind = 13) — `netlink-packet-route 0.30` doesn't
+            // NDA_NH_ID (kind = 13) — `netlink-packet-route 0.32.1` doesn't
             // expose a typed variant, so the kernel sends it through the
             // `Other` escape hatch with a 4-byte native-endian payload.
             // `DefaultNla` keeps its fields private; we read via the

--- a/crates/evpn-linux/src/linux/fdb_nhg.rs
+++ b/crates/evpn-linux/src/linux/fdb_nhg.rs
@@ -61,7 +61,7 @@ use crate::error::DataplaneError;
 use super::links::{FdbVxlanTarget, LinkCache, unique_fdb_vxlan_target_for_vni};
 
 /// `NDA_NH_ID` (kind = 13). Not exposed as a typed variant by
-/// `netlink-packet-route 0.30`; emit via the `Other(DefaultNla)`
+/// `netlink-packet-route 0.32.1`; emit via the `Other(DefaultNla)`
 /// escape hatch.
 const NDA_NH_ID: u16 = 13;
 

--- a/crates/evpn-linux/src/linux/l3.rs
+++ b/crates/evpn-linux/src/linux/l3.rs
@@ -64,7 +64,7 @@ use crate::error::DataplaneError;
 /// (`<linux/rtnetlink.h>`) that tells dump-side parsers "the real
 /// 32-bit table id rides in `RouteAttribute::Table`." Used as the
 /// `header.table` byte for any IP-VRF whose `table_id ≥ 256`.
-/// `netlink-packet-route` 0.30 doesn't expose this constant
+/// `netlink-packet-route` 0.32.1 doesn't expose this constant
 /// directly; inlining the well-known uapi value keeps the apply
 /// path self-contained.
 const RT_TABLE_COMPAT: u8 = 252;
@@ -81,7 +81,7 @@ const NUD_PERMANENT: u16 = 0x80;
 /// constant so the L2 and L3 paths use the same shape.
 const NUD_NOARP_PERMANENT: u16 = NUD_NOARP | NUD_PERMANENT;
 /// `NDA_NH_ID` (kind = 13). Exposed in iproute2 as `bridge fdb ...
-/// nhid N`; `netlink-packet-route 0.30` keeps it behind the raw NLA
+/// nhid N`; `netlink-packet-route 0.32.1` keeps it behind the raw NLA
 /// escape hatch.
 const NDA_NH_ID: u16 = 13;
 

--- a/crates/evpn-linux/src/linux/l3_adoption.rs
+++ b/crates/evpn-linux/src/linux/l3_adoption.rs
@@ -73,7 +73,7 @@ const NUD_PERMANENT: u16 = 0x80;
 /// reachability probing. Read alongside `NUD_PERMANENT` by the
 /// LAN-283 foreign-neighbor classifier.
 const NUD_NOARP: u16 = 0x40;
-/// `NDA_NH_ID` (kind = 13). `netlink-packet-route 0.30` exposes it
+/// `NDA_NH_ID` (kind = 13). `netlink-packet-route 0.32.1` exposes it
 /// through `NeighbourAttribute::Other(DefaultNla)`.
 const NDA_NH_ID: u16 = 13;
 


### PR DESCRIPTION
## Summary

- upgrade to the released `rtnetlink 0.22.0` / `netlink-packet-route 0.32.1` pair without git patches or compatibility shims
- remove the obsolete Dependabot hold and retain the raw kernel encodings still absent from the typed API
- close the stale roadmap blocker with exact released-crate validation receipts

## Validation

- locked workspace check, all-feature tests, and all-target/all-feature Clippy
- `rustbgpd-evpn-linux` tests and strict rustdoc
- no-default-features root build and v1 stable-surface check
- privileged FDB-NHG, FIB, BFD, VLAN FDB, SVD/VNI, managed VXLAN, and IP-VRF netns selectors

Linear: LAN-643