### PR TITLE
feat: activate Neighbor4 settlement ownership

### DIFF
--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -10,15 +10,21 @@ use tokio::sync::mpsc;
 use tonic::{Request, Response, Status};
 
 use crate::actor_read::{peer_manager_read, rib_manager_read};
+use crate::health_probe::DaemonGate;
 use crate::peer_types::{
-    ConfigEvent, DynamicRangeError, NeighborCreateAddPath, OutboundRefreshError, PeerInfo, PeerKey,
-    PeerLifecycleError, PeerManagerCommand, PeerManagerNeighborConfig, PresenceAwareNeighborCreate,
-    RemovedDynamicRange, Rfc8212PolicyStatus,
+    ConfigEvent, DynamicRangeError, NeighborCreateAddPath, OutboundRefreshError,
+    OwnedNeighborMutation, OwnedNeighborMutationError, OwnedNeighborMutationOutcome, PeerInfo,
+    PeerKey, PeerLifecycleError, PeerManagerCommand, PresenceAwareNeighborCreate,
+    Rfc8212PolicyStatus,
 };
 use crate::proto;
+use crate::runtime_config_settlement::{
+    OwnedRuntimeConfigOperation, OwnedRuntimeConfigOutcome, OwnedRuntimeConfigRequestContext,
+    RuntimeConfigOperationKind, RuntimeConfigSettlementPhase, RuntimeConfigSettlementWatchdog,
+};
 use crate::server::{
     AccessMode, ConfigMutationGateFn, RuntimeConfigCoordinator, check_config_mutation_gate,
-    peer_manager_request, persist_then_apply, read_only_rejection,
+    peer_manager_request, read_only_rejection, stage_runtime_config_event_typed,
 };
 use rustbgpd_rib::{
     EffectiveDistributionMode, NeighborRibSnapshot, NeighborRibSnapshotResponse, RibUpdate,
@@ -27,6 +33,7 @@ use rustbgpd_rib::{
 };
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
+const OWNED_NEIGHBOR_ACTOR_TIMEOUT: Duration = Duration::from_mins(10);
 /// Bound both channel admission and the reply from the single-threaded RIB
 /// actor.  This matches the existing internal RIB-query timeout precedent and
 /// prevents an operator inventory request from waiting indefinitely behind a
@@ -88,6 +95,8 @@ pub struct NeighborService {
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
     runtime_config_lock: RuntimeConfigCoordinator,
     config_mutation_gate: Option<ConfigMutationGateFn>,
+    settlement: Option<(RuntimeConfigSettlementWatchdog, DaemonGate)>,
+    owned_actor_timeout: Duration,
 }
 
 impl NeighborService {
@@ -133,7 +142,20 @@ impl NeighborService {
             config_tx,
             runtime_config_lock,
             config_mutation_gate,
+            settlement: None,
+            owned_actor_timeout: OWNED_NEIGHBOR_ACTOR_TIMEOUT,
         }
+    }
+
+    /// Arm Neighbor4 CRUD with the process-wide fail-stop settlement owner.
+    #[must_use]
+    pub fn with_runtime_config_settlement(
+        mut self,
+        watchdog: RuntimeConfigSettlementWatchdog,
+        daemon_gate: DaemonGate,
+    ) -> Self {
+        self.settlement = Some((watchdog, daemon_gate));
+        self
     }
 
     async fn add_presence_aware_neighbor(
@@ -142,27 +164,194 @@ impl NeighborService {
     ) -> Result<Response<proto::AddNeighborResponse>, Status> {
         let spec = parse_presence_aware_create(intent)?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
-        let runtime_config_lock = self.runtime_config_lock.clone();
-        let config_mutation_gate = self.config_mutation_gate.clone();
         let persisted_spec = spec.clone();
-        let join = tokio::spawn(async move {
-            let _guard = runtime_config_lock.acquire().await?;
-            check_config_mutation_gate(&config_mutation_gate, "NeighborService.AddNeighbor")
-                .await?;
-            persist_then_apply(
+        self.execute_owned_neighbor_mutation(
+            RuntimeConfigOperationKind::NeighborAdd,
+            "NeighborService.AddNeighbor",
+            OwnedNeighborMutation::Add(spec),
+            persist_permit,
+            |ack| ConfigEvent::PresenceAwareNeighborAdded {
+                spec: persisted_spec,
+                ack: Some(ack),
+            },
+        )
+        .await?;
+        Ok(Response::new(proto::AddNeighborResponse {}))
+    }
+
+    async fn execute_owned_neighbor_mutation<B>(
+        &self,
+        kind: RuntimeConfigOperationKind,
+        operation_name: &'static str,
+        mutation: OwnedNeighborMutation,
+        persist_permit: Option<mpsc::OwnedPermit<ConfigEvent>>,
+        build_event: B,
+    ) -> Result<(), Status>
+    where
+        B: FnOnce(crate::peer_types::ConfigPersistAck) -> ConfigEvent + Send + 'static,
+    {
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let config_mutation_gate = self.config_mutation_gate.clone();
+        let actor_timeout = self.owned_actor_timeout;
+        let settlement = self.settlement.clone();
+        let daemon_gate = settlement.as_ref().map(|(_, gate)| gate.clone());
+        let body = move |owned: Option<OwnedRuntimeConfigOperation>| async move {
+            owned_neighbor_mutation_body(
+                owned,
+                daemon_gate,
+                config_mutation_gate,
+                operation_name,
+                peer_mgr_tx,
+                actor_timeout,
+                mutation,
                 persist_permit,
-                |ack| ConfigEvent::PresenceAwareNeighborAdded {
-                    spec: persisted_spec,
-                    ack: Some(ack),
-                },
-                || add_presence_aware_peer(&peer_mgr_tx, spec),
+                build_event,
             )
             .await
-        });
-        join.await
-            .map_err(|_| Status::internal("neighbor add task did not complete"))??;
-        Ok(Response::new(proto::AddNeighborResponse {}))
+        };
+        let (context, attachment) = OwnedRuntimeConfigRequestContext::unary();
+        let result = if let Some((watchdog, daemon_gate)) = settlement {
+            watchdog
+                .execute_owned(
+                    kind,
+                    self.runtime_config_lock.clone(),
+                    daemon_gate,
+                    context.response_attached(),
+                    move |operation| body(Some(operation)),
+                )
+                .await
+        } else {
+            let coordinator = self.runtime_config_lock.clone();
+            let join = tokio::spawn(async move {
+                let _permit = coordinator.acquire().await?;
+                match body(None).await {
+                    OwnedRuntimeConfigOutcome::Clean(result) => result,
+                    OwnedRuntimeConfigOutcome::Ambiguous(error) => {
+                        let _ = error;
+                        std::future::pending().await
+                    }
+                }
+            });
+            join.await
+                .map_err(|_| Status::internal("owned neighbor mutation task did not complete"))?
+        };
+        drop(attachment);
+        result
+    }
+
+    #[cfg(test)]
+    fn with_owned_actor_timeout(mut self, timeout: Duration) -> Self {
+        self.owned_actor_timeout = timeout;
+        self
+    }
+}
+
+enum OwnedNeighborDispatch {
+    NotAccepted(Status),
+    Replied(OwnedNeighborMutationOutcome),
+    AcceptedReplyLost(Status),
+}
+
+async fn dispatch_owned_neighbor_mutation(
+    peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+    timeout: Duration,
+    mutation: OwnedNeighborMutation,
+) -> OwnedNeighborDispatch {
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    let command = PeerManagerCommand::OwnedNeighborMutation {
+        mutation,
+        reply: reply_tx,
+    };
+    match tokio::time::timeout(timeout, peer_mgr_tx.send(command)).await {
+        Err(_) => OwnedNeighborDispatch::NotAccepted(Status::unavailable(
+            "peer manager mutation queue timed out before accepting command",
+        )),
+        Ok(Err(_)) => OwnedNeighborDispatch::NotAccepted(Status::unavailable(
+            "peer manager unavailable before accepting command",
+        )),
+        Ok(Ok(())) => match tokio::time::timeout(timeout, reply_rx).await {
+            Err(_) => OwnedNeighborDispatch::AcceptedReplyLost(Status::deadline_exceeded(
+                "peer manager accepted owned neighbor mutation but reply timed out",
+            )),
+            Ok(Err(_)) => OwnedNeighborDispatch::AcceptedReplyLost(Status::internal(
+                "peer manager accepted owned neighbor mutation but dropped its reply",
+            )),
+            Ok(Ok(outcome)) => OwnedNeighborDispatch::Replied(outcome),
+        },
+    }
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the closed owner body lists each retained mutation and settlement dependency explicitly"
+)]
+async fn owned_neighbor_mutation_body<B>(
+    owned: Option<OwnedRuntimeConfigOperation>,
+    daemon_gate: Option<DaemonGate>,
+    config_mutation_gate: Option<ConfigMutationGateFn>,
+    operation_name: &'static str,
+    peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+    actor_timeout: Duration,
+    mutation: OwnedNeighborMutation,
+    persist_permit: Option<mpsc::OwnedPermit<ConfigEvent>>,
+    build_event: B,
+) -> OwnedRuntimeConfigOutcome<(), Status>
+where
+    B: FnOnce(crate::peer_types::ConfigPersistAck) -> ConfigEvent,
+{
+    if daemon_gate.is_some_and(|gate| gate.is_shutting_down()) {
+        return OwnedRuntimeConfigOutcome::Clean(Err(Status::unavailable(format!(
+            "{operation_name} rejected: daemon is shutting down"
+        ))));
+    }
+    if let Err(error) = check_config_mutation_gate(&config_mutation_gate, operation_name).await {
+        return OwnedRuntimeConfigOutcome::Clean(Err(error));
+    }
+    if let Some(operation) = &owned {
+        operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
+    }
+    let staged = if let Some(permit) = persist_permit {
+        match stage_runtime_config_event_typed(permit, build_event).await {
+            Ok(staged) => Some(staged),
+            Err(error) => {
+                return OwnedRuntimeConfigOutcome::Clean(Err(error.into_status()));
+            }
+        }
+    } else {
+        None
+    };
+
+    let outcome = dispatch_owned_neighbor_mutation(peer_mgr_tx, actor_timeout, mutation).await;
+    match outcome {
+        OwnedNeighborDispatch::NotAccepted(error) => {
+            drop(staged);
+            OwnedRuntimeConfigOutcome::Clean(Err(error))
+        }
+        OwnedNeighborDispatch::AcceptedReplyLost(error) => {
+            OwnedRuntimeConfigOutcome::Ambiguous(error)
+        }
+        OwnedNeighborDispatch::Replied(
+            OwnedNeighborMutationOutcome::RejectedNoEffect(error)
+            | OwnedNeighborMutationOutcome::FullyCompensated(error),
+        ) => {
+            drop(staged);
+            OwnedRuntimeConfigOutcome::Clean(Err(owned_neighbor_error_status(error)))
+        }
+        OwnedNeighborDispatch::Replied(OwnedNeighborMutationOutcome::CompensationAmbiguous(
+            error,
+        )) => OwnedRuntimeConfigOutcome::Ambiguous(owned_neighbor_error_status(error)),
+        OwnedNeighborDispatch::Replied(OwnedNeighborMutationOutcome::Success) => {
+            let Some(staged) = staged else {
+                return OwnedRuntimeConfigOutcome::Clean(Ok(()));
+            };
+            if let Some(operation) = &owned {
+                operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
+            }
+            match staged.commit_typed().await {
+                Ok(()) => OwnedRuntimeConfigOutcome::Clean(Ok(())),
+                Err(error) => OwnedRuntimeConfigOutcome::Ambiguous(error.into_status()),
+            }
+        }
     }
 }
 
@@ -297,6 +486,13 @@ fn dynamic_range_error_status(error: DynamicRangeError) -> Status {
     }
 }
 
+fn owned_neighbor_error_status(error: OwnedNeighborMutationError) -> Status {
+    match error {
+        OwnedNeighborMutationError::Peer(error) => peer_lifecycle_error_status(error),
+        OwnedNeighborMutationError::Dynamic(error) => dynamic_range_error_status(error),
+    }
+}
+
 pub(crate) fn peer_lifecycle_error_status(error: PeerLifecycleError) -> Status {
     match error {
         PeerLifecycleError::AlreadyExists(peer) => {
@@ -319,61 +515,6 @@ fn outbound_refresh_error_status(error: OutboundRefreshError) -> Status {
         }
         OutboundRefreshError::Internal(message) => Status::internal(message),
     }
-}
-
-async fn add_dynamic_range(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    prefix: String,
-    peer_group: String,
-    remote_asn: u32,
-    description: Option<String>,
-) -> Result<(), Status> {
-    peer_manager_request(peer_mgr_tx, |reply| PeerManagerCommand::AddDynamicRange {
-        prefix,
-        peer_group,
-        remote_asn,
-        description,
-        reply,
-    })
-    .await?
-    .map_err(dynamic_range_error_status)
-}
-
-async fn add_presence_aware_peer(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    spec: Box<PresenceAwareNeighborCreate>,
-) -> Result<(), Status> {
-    peer_manager_request(peer_mgr_tx, |reply| PeerManagerCommand::RuntimeCreatePeer {
-        spec,
-        reply,
-    })
-    .await?
-    .map_err(peer_lifecycle_error_status)
-}
-
-async fn delete_static_peer(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    peer: PeerKey,
-    sync_config_snapshot: bool,
-) -> Result<PeerManagerNeighborConfig, Status> {
-    peer_manager_request(peer_mgr_tx, |reply| PeerManagerCommand::DeletePeer {
-        peer,
-        sync_config_snapshot,
-        reply,
-    })
-    .await?
-    .map_err(peer_lifecycle_error_status)
-}
-
-async fn delete_dynamic_range(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    prefix: String,
-) -> Result<RemovedDynamicRange, Status> {
-    peer_manager_request(peer_mgr_tx, |reply| {
-        PeerManagerCommand::DeleteDynamicRange { prefix, reply }
-    })
-    .await?
-    .map_err(dynamic_range_error_status)
 }
 
 pub(crate) fn family_to_string(afi: Afi, safi: Safi) -> String {
@@ -1026,37 +1167,18 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         // This makes DeleteNeighbor fail-fast when persistence is unavailable.
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
 
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
-        let runtime_config_lock = self.runtime_config_lock.clone();
-        let config_mutation_gate = self.config_mutation_gate.clone();
-        let join = tokio::spawn(async move {
-            let _guard = runtime_config_lock.acquire().await?;
-            check_config_mutation_gate(&config_mutation_gate, "NeighborService.DeleteNeighbor")
-                .await?;
-            // The session teardown below is irreversible: re-adding the peer
-            // builds a *new* session with a new identity, a zeroed uptime,
-            // zeroed counters, and a fresh metric series, and the teardown
-            // never reaches the operator's flap count. So the write is staged
-            // and acknowledged first — a persistence failure is reported while
-            // the session is still up and untouched. The shared runtime-config
-            // lock is held across the whole window so SIGHUP cannot rebuild
-            // from stale TOML in the middle.
-            persist_then_apply(
-                persist_permit,
-                |ack| ConfigEvent::NeighborDeleted {
-                    peer: peer.clone(),
-                    ack: Some(ack),
-                },
-                || async {
-                    delete_static_peer(&peer_mgr_tx, peer.clone(), true)
-                        .await
-                        .map(|_| ())
-                },
-            )
-            .await
-        });
-        join.await
-            .map_err(|_| Status::internal("neighbor delete task did not complete"))??;
+        let persisted_peer = peer.clone();
+        self.execute_owned_neighbor_mutation(
+            RuntimeConfigOperationKind::NeighborDelete,
+            "NeighborService.DeleteNeighbor",
+            OwnedNeighborMutation::Delete(peer),
+            persist_permit,
+            |ack| ConfigEvent::NeighborDeleted {
+                peer: persisted_peer,
+                ack: Some(ack),
+            },
+        )
+        .await?;
 
         Ok(Response::new(proto::DeleteNeighborResponse {}))
     }
@@ -1320,42 +1442,31 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         // (fail-fast when persistence is unavailable), mirroring AddNeighbor.
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
 
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
-        let runtime_config_lock = self.runtime_config_lock.clone();
-        let config_mutation_gate = self.config_mutation_gate.clone();
-        let join = tokio::spawn(async move {
-            let _guard = runtime_config_lock.acquire().await?;
-            check_config_mutation_gate(&config_mutation_gate, "NeighborService.AddDynamicNeighbor")
-                .await?;
-            // Stage the write before the matcher changes, so a persistence
-            // failure cannot leave a range that briefly accepted a session.
-            // This runs inside the spawned task so a canceled gRPC request
-            // cannot split the runtime add from the queued config event, and
-            // the shared runtime-config lock is held across the whole window
-            // so a concurrent SIGHUP cannot reload stale disk in the middle.
-            persist_then_apply(
-                persist_permit,
-                |ack| ConfigEvent::DynamicNeighborAdded {
-                    prefix: range.prefix.clone(),
-                    peer_group: range.peer_group.clone(),
-                    remote_asn: range.remote_asn,
-                    description: description.clone(),
-                    ack: Some(ack),
-                },
-                || {
-                    add_dynamic_range(
-                        &peer_mgr_tx,
-                        range.prefix.clone(),
-                        range.peer_group.clone(),
-                        range.remote_asn,
-                        description.clone(),
-                    )
-                },
-            )
-            .await
-        });
-        join.await
-            .map_err(|_| Status::internal("dynamic-neighbor add task did not complete"))??;
+        let prefix = range.prefix;
+        let peer_group = range.peer_group;
+        let remote_asn = range.remote_asn;
+        let persisted_prefix = prefix.clone();
+        let persisted_peer_group = peer_group.clone();
+        let persisted_description = description.clone();
+        self.execute_owned_neighbor_mutation(
+            RuntimeConfigOperationKind::DynamicNeighborAdd,
+            "NeighborService.AddDynamicNeighbor",
+            OwnedNeighborMutation::DynamicAdd {
+                prefix,
+                peer_group,
+                remote_asn,
+                description,
+            },
+            persist_permit,
+            move |ack| ConfigEvent::DynamicNeighborAdded {
+                prefix: persisted_prefix,
+                peer_group: persisted_peer_group,
+                remote_asn,
+                description: persisted_description,
+                ack: Some(ack),
+            },
+        )
+        .await?;
 
         Ok(Response::new(proto::AddDynamicNeighborResponse {}))
     }
@@ -1374,38 +1485,18 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
 
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
 
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
-        let runtime_config_lock = self.runtime_config_lock.clone();
-        let config_mutation_gate = self.config_mutation_gate.clone();
-        let join = tokio::spawn(async move {
-            let _guard = runtime_config_lock.acquire().await?;
-            check_config_mutation_gate(
-                &config_mutation_gate,
-                "NeighborService.DeleteDynamicNeighbor",
-            )
-            .await?;
-            // Stage the write first so a persistence failure leaves the range
-            // in place rather than removing and re-adding it. This runs inside
-            // the spawned task so cancellation cannot split runtime delete
-            // from the queued config event, and the shared runtime-config lock
-            // is held across the window so SIGHUP cannot rebuild from stale
-            // TOML in the middle.
-            persist_then_apply(
-                persist_permit,
-                |ack| ConfigEvent::DynamicNeighborDeleted {
-                    prefix: prefix.clone(),
-                    ack: Some(ack),
-                },
-                || async {
-                    delete_dynamic_range(&peer_mgr_tx, prefix.clone())
-                        .await
-                        .map(|_| ())
-                },
-            )
-            .await
-        });
-        join.await
-            .map_err(|_| Status::internal("dynamic-neighbor delete task did not complete"))??;
+        let persisted_prefix = prefix.clone();
+        self.execute_owned_neighbor_mutation(
+            RuntimeConfigOperationKind::DynamicNeighborDelete,
+            "NeighborService.DeleteDynamicNeighbor",
+            OwnedNeighborMutation::DynamicDelete { prefix },
+            persist_permit,
+            |ack| ConfigEvent::DynamicNeighborDeleted {
+                prefix: persisted_prefix,
+                ack: Some(ack),
+            },
+        )
+        .await?;
 
         Ok(Response::new(proto::DeleteDynamicNeighborResponse {}))
     }
@@ -1791,12 +1882,15 @@ mod tests {
         let svc = NeighborService::new(65001, AccessMode::ReadWrite, peer_tx, rib_tx, None);
         let call = tokio::spawn(async move { svc.add_neighbor(Request::new(request)).await });
         match peer_rx.recv().await.unwrap() {
-            PeerManagerCommand::RuntimeCreatePeer { spec, reply } => {
+            PeerManagerCommand::OwnedNeighborMutation {
+                mutation: OwnedNeighborMutation::Add(spec),
+                reply,
+            } => {
                 assert_eq!(spec.address.to_string(), "10.0.0.9");
                 assert_eq!(spec.remote_asn, 65009);
-                reply.send(Ok(())).unwrap();
+                reply.send(OwnedNeighborMutationOutcome::Success).unwrap();
             }
-            _ => panic!("expected RuntimeCreatePeer"),
+            _ => panic!("expected owned neighbor add"),
         }
         call.await.unwrap().unwrap();
     }
@@ -2138,57 +2232,6 @@ mod tests {
         );
     }
 
-    fn test_static_peer_config() -> PeerManagerNeighborConfig {
-        PeerManagerNeighborConfig {
-            min_hold_time: None,
-            address: "10.0.0.2".parse().unwrap(),
-            interface: None,
-            scope_id: None,
-            remote_asn: 65002,
-            description: "static peer".to_string(),
-            peer_group: None,
-            hold_time: Some(90),
-            send_hold_time: None,
-            max_prefixes: None,
-            max_prefixes_ipv4: None,
-            max_prefixes_ipv6: None,
-            max_prefix_restart_seconds: None,
-            md5_password: None,
-            tcp_ao: None,
-            ttl_security: false,
-            families: vec![(Afi::Ipv4, Safi::Unicast)],
-            required_families: Vec::new(),
-            graceful_restart: true,
-            gr_restart_time: 120,
-            gr_peer_restart_time_max: 4095,
-            gr_stale_routes_time: 360,
-            llgr_stale_time: 0,
-            gr_restart_eligible: false,
-            local_ipv6_nexthop: None,
-            route_reflector_client: false,
-            orr_vantage: None,
-            route_server_client: false,
-            per_client_best: false,
-            next_hop_ownership_strict_peer: false,
-            slow_peer_threshold_pct: rustbgpd_transport::DEFAULT_SLOW_PEER_THRESHOLD_PCT,
-            slow_peer_duration: rustbgpd_transport::DEFAULT_SLOW_PEER_DURATION_SECS,
-            slow_peer_isolation: false,
-            interpret_rfc1997: true,
-            rs_control_communities: false,
-            remove_private_as: RemovePrivateAs::Disabled,
-            add_path_receive: false,
-            add_path_send: false,
-            add_path_send_max: 0,
-            paths_limit_receive_max: 0,
-            local_role: None,
-            strict_role: false,
-            prefix_orf_receive: false,
-            disable_ipv4_unicast: false,
-            import_policy: None,
-            export_policy: None,
-        }
-    }
-
     #[test]
     fn peer_lifecycle_errors_map_by_variant() {
         let peer = PeerKey::new("10.0.0.2".parse().unwrap(), None);
@@ -2311,11 +2354,14 @@ mod tests {
         let staged = tokio::spawn(staged.accept());
 
         match peer_mgr_rx.recv().await.unwrap() {
-            PeerManagerCommand::AddDynamicRange {
-                prefix,
-                peer_group,
-                remote_asn,
-                description,
+            PeerManagerCommand::OwnedNeighborMutation {
+                mutation:
+                    OwnedNeighborMutation::DynamicAdd {
+                        prefix,
+                        peer_group,
+                        remote_asn,
+                        description,
+                    },
                 reply,
             } => {
                 assert_eq!(prefix, "192.0.2.0/24");
@@ -2328,9 +2374,9 @@ mod tests {
                         .is_err(),
                     "call must wait for the staged write to be committed"
                 );
-                reply.send(Ok(())).unwrap();
+                reply.send(OwnedNeighborMutationOutcome::Success).unwrap();
             }
-            _ => panic!("expected AddDynamicRange"),
+            _ => panic!("expected owned dynamic add"),
         }
         assert!(staged.await.unwrap(), "the staged write must be committed");
         call.await.unwrap();
@@ -2399,18 +2445,141 @@ mod tests {
         });
 
         match peer_mgr_rx.recv().await.unwrap() {
-            PeerManagerCommand::AddDynamicRange { reply, .. } => {
+            PeerManagerCommand::OwnedNeighborMutation {
+                mutation: OwnedNeighborMutation::DynamicAdd { .. },
+                reply,
+            } => {
                 reply
-                    .send(Err(DynamicRangeError::NotFound(
-                        "peer_group \"missing\" not defined".to_string(),
-                    )))
+                    .send(OwnedNeighborMutationOutcome::RejectedNoEffect(
+                        OwnedNeighborMutationError::Dynamic(DynamicRangeError::NotFound(
+                            "peer_group \"missing\" not defined".to_string(),
+                        )),
+                    ))
                     .unwrap();
             }
-            _ => panic!("expected AddDynamicRange"),
+            _ => panic!("expected owned dynamic add"),
         }
 
         let err = call.await.unwrap().unwrap_err();
         assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    #[tokio::test]
+    async fn owned_neighbor_gate_rejection_is_clean_and_precedes_actor_dispatch() {
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(1);
+        let (rib_tx, _rib_rx) = mpsc::channel(1);
+        let coordinator = RuntimeConfigCoordinator::new();
+        let gate: ConfigMutationGateFn = std::sync::Arc::new(|operation| {
+            Box::pin(async move { Err(format!("{operation} rejected by test gate")) })
+        });
+        let svc = NeighborService::with_runtime_config_coordinator(
+            65001,
+            AccessMode::ReadWrite,
+            peer_mgr_tx,
+            rib_tx,
+            None,
+            coordinator.clone(),
+            Some(gate),
+        );
+        let error = svc
+            .delete_dynamic_neighbor(Request::new(proto::DeleteDynamicNeighborRequest {
+                prefix: "192.0.2.0/24".to_string(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+        assert!(matches!(peer_mgr_rx.try_recv(), Err(TryRecvError::Empty)));
+        assert!(coordinator.acquire().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn fully_acknowledged_actor_compensation_is_clean() {
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(1);
+        let (rib_tx, _rib_rx) = mpsc::channel(1);
+        let coordinator = RuntimeConfigCoordinator::new();
+        let svc = NeighborService::with_runtime_config_coordinator(
+            65001,
+            AccessMode::ReadWrite,
+            peer_mgr_tx,
+            rib_tx,
+            None,
+            coordinator.clone(),
+            None,
+        );
+        let call = tokio::spawn(async move {
+            svc.delete_dynamic_neighbor(Request::new(proto::DeleteDynamicNeighborRequest {
+                prefix: "192.0.2.0/24".to_string(),
+            }))
+            .await
+        });
+        let PeerManagerCommand::OwnedNeighborMutation { reply, .. } =
+            peer_mgr_rx.recv().await.unwrap()
+        else {
+            panic!("expected owned neighbor mutation");
+        };
+        reply
+            .send(OwnedNeighborMutationOutcome::FullyCompensated(
+                OwnedNeighborMutationError::Dynamic(DynamicRangeError::NotFound(
+                    "range disappeared before mutation".to_string(),
+                )),
+            ))
+            .unwrap();
+        assert_eq!(
+            call.await.unwrap().unwrap_err().code(),
+            tonic::Code::NotFound
+        );
+        assert!(coordinator.acquire().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn accepted_reply_loss_and_timeout_never_release_or_return() {
+        for drop_reply in [true, false] {
+            let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(1);
+            let (rib_tx, _rib_rx) = mpsc::channel(1);
+            let coordinator = RuntimeConfigCoordinator::new();
+            let svc = NeighborService::with_runtime_config_coordinator(
+                65001,
+                AccessMode::ReadWrite,
+                peer_mgr_tx,
+                rib_tx,
+                None,
+                coordinator.clone(),
+                None,
+            )
+            .with_owned_actor_timeout(Duration::from_millis(20));
+            let mut call = tokio::spawn(async move {
+                svc.delete_dynamic_neighbor(Request::new(proto::DeleteDynamicNeighborRequest {
+                    prefix: "192.0.2.0/24".to_string(),
+                }))
+                .await
+            });
+            let PeerManagerCommand::OwnedNeighborMutation { reply, .. } =
+                peer_mgr_rx.recv().await.unwrap()
+            else {
+                panic!("expected owned neighbor mutation");
+            };
+            if drop_reply {
+                drop(reply);
+            } else {
+                tokio::spawn(async move {
+                    std::future::pending::<()>().await;
+                    drop(reply);
+                });
+            }
+            assert!(
+                tokio::time::timeout(Duration::from_millis(60), &mut call)
+                    .await
+                    .is_err(),
+                "accepted actor ambiguity must never return an RPC result"
+            );
+            assert!(
+                tokio::time::timeout(Duration::from_millis(20), coordinator.acquire())
+                    .await
+                    .is_err(),
+                "accepted actor ambiguity must retain coordinator ownership"
+            );
+            call.abort();
+        }
     }
 
     #[tokio::test]
@@ -2448,7 +2617,10 @@ mod tests {
         let staged = tokio::spawn(staged.accept());
 
         match peer_mgr_rx.recv().await.unwrap() {
-            PeerManagerCommand::DeleteDynamicRange { prefix, reply } => {
+            PeerManagerCommand::OwnedNeighborMutation {
+                mutation: OwnedNeighborMutation::DynamicDelete { prefix },
+                reply,
+            } => {
                 assert_eq!(prefix, "192.0.2.0/24");
                 assert!(
                     tokio::time::timeout(Duration::from_millis(20), &mut call)
@@ -2456,16 +2628,9 @@ mod tests {
                         .is_err(),
                     "call must wait for the staged write to be committed"
                 );
-                reply
-                    .send(Ok(RemovedDynamicRange {
-                        prefix,
-                        peer_group: "fabric".to_string(),
-                        remote_asn: 65002,
-                        description: Some("lab range".to_string()),
-                    }))
-                    .unwrap();
+                reply.send(OwnedNeighborMutationOutcome::Success).unwrap();
             }
-            _ => panic!("expected DeleteDynamicRange"),
+            _ => panic!("expected owned dynamic delete"),
         }
         assert!(staged.await.unwrap(), "the staged write must be committed");
         call.await.unwrap();
@@ -3861,7 +4026,10 @@ mod tests {
         let staged = tokio::spawn(ack.accept());
 
         match peer_mgr_rx.recv().await.unwrap() {
-            PeerManagerCommand::RuntimeCreatePeer { spec, reply } => {
+            PeerManagerCommand::OwnedNeighborMutation {
+                mutation: OwnedNeighborMutation::Add(spec),
+                reply,
+            } => {
                 assert_eq!(spec, persisted);
                 assert!(
                     tokio::time::timeout(Duration::from_millis(20), &mut call)
@@ -3869,9 +4037,9 @@ mod tests {
                         .is_err(),
                     "the RPC must wait for actor apply and persistence commit"
                 );
-                reply.send(Ok(())).unwrap();
+                reply.send(OwnedNeighborMutationOutcome::Success).unwrap();
             }
-            _ => panic!("expected RuntimeCreatePeer"),
+            _ => panic!("expected owned neighbor add"),
         }
         assert!(staged.await.unwrap());
         call.await.unwrap().unwrap();
@@ -3913,24 +4081,20 @@ mod tests {
         let staged = tokio::spawn(staged.accept());
 
         match peer_mgr_rx.recv().await.unwrap() {
-            PeerManagerCommand::DeletePeer {
-                peer,
-                sync_config_snapshot,
+            PeerManagerCommand::OwnedNeighborMutation {
+                mutation: OwnedNeighborMutation::Delete(peer),
                 reply,
             } => {
                 assert_eq!(peer.address.to_string(), "10.0.0.2");
-                // One command now does both: there is no separate snapshot
-                // fix-up, because the config row is no longer rollback state.
-                assert!(sync_config_snapshot);
                 assert!(
                     tokio::time::timeout(Duration::from_millis(20), &mut call)
                         .await
                         .is_err(),
                     "call must wait for the staged write to be committed"
                 );
-                assert!(reply.send(Ok(test_static_peer_config())).is_ok());
+                assert!(reply.send(OwnedNeighborMutationOutcome::Success).is_ok());
             }
-            _ => panic!("expected DeletePeer"),
+            _ => panic!("expected owned neighbor delete"),
         }
         assert!(staged.await.unwrap(), "the staged write must be committed");
         call.await.unwrap().unwrap();

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -706,6 +706,10 @@ pub enum PeerManagerCommand {
         /// Reply channel returning the removed config on success.
         reply: oneshot::Sender<Result<PeerManagerNeighborConfig, PeerLifecycleError>>,
     },
+    OwnedNeighborMutation {
+        mutation: OwnedNeighborMutation,
+        reply: oneshot::Sender<OwnedNeighborMutationOutcome>,
+    },
     /// Reconfigure an existing static peer by replacing its live session with
     /// a newly resolved configuration.
     ReconfigurePeer {
@@ -1423,6 +1427,47 @@ pub enum PeerManagerCommand {
         /// persist can roll the deletion back by re-adding the exact range.
         reply: oneshot::Sender<Result<RemovedDynamicRange, DynamicRangeError>>,
     },
+}
+
+pub enum OwnedNeighborMutation {
+    Add(Box<PresenceAwareNeighborCreate>),
+    Delete(PeerKey),
+    /// Add a dynamic-neighbor range.
+    DynamicAdd {
+        /// IP prefix range.
+        prefix: String,
+        /// Inherited peer group.
+        peer_group: String,
+        /// Expected remote ASN (`0` accepts any ASN).
+        remote_asn: u32,
+        /// Optional range description.
+        description: Option<String>,
+    },
+    DynamicDelete {
+        prefix: String,
+    },
+}
+
+/// Typed error returned by an owned Neighbor4 actor command.
+#[derive(Debug)]
+pub enum OwnedNeighborMutationError {
+    /// Static-neighbor lifecycle failure.
+    Peer(PeerLifecycleError),
+    /// Dynamic-neighbor range failure.
+    Dynamic(DynamicRangeError),
+}
+
+/// Actor-owned settlement proof for a Neighbor4 mutation.
+#[derive(Debug)]
+pub enum OwnedNeighborMutationOutcome {
+    /// The requested runtime mutation completed.
+    Success,
+    /// The actor rejected before producing any runtime effect.
+    RejectedNoEffect(OwnedNeighborMutationError),
+    /// The actor acknowledged restoration of every forward effect.
+    FullyCompensated(OwnedNeighborMutationError),
+    /// A compensation send, reply, or effect failed and final state is unknown.
+    CompensationAmbiguous(OwnedNeighborMutationError),
 }
 
 /// Read-only peer-manager queries admitted between bounded policy-transaction

--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -26,6 +26,10 @@ pub enum RuntimeConfigOperationKind {
     Abort,
     Rollback,
     AutoRevert,
+    NeighborAdd,
+    NeighborDelete,
+    DynamicNeighborAdd,
+    DynamicNeighborDelete,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -268,6 +272,63 @@ impl RuntimeConfigSettlementWatchdog {
         )
     }
 
+    /// Run one detached, owned mutation from coordinator acquisition through
+    /// typed settlement. Registration is the first post-acquire operation.
+    /// Caller cancellation detaches only the response; typed ambiguity,
+    /// deadline, or executor loss fences and parks the retained owner.
+    ///
+    /// # Errors
+    ///
+    /// Returns only the error carried by a typed clean outcome or coordinator
+    /// acquisition before ownership. Ambiguous owned outcomes never return.
+    pub async fn execute_owned<T, E, F, Fut>(
+        &self,
+        kind: RuntimeConfigOperationKind,
+        coordinator: RuntimeConfigCoordinator,
+        daemon_gate: DaemonGate,
+        response_attached: Arc<AtomicBool>,
+        body: F,
+    ) -> Result<T, E>
+    where
+        T: Send + 'static,
+        E: From<crate::server::RuntimeConfigCoordinatorClosed> + Send + 'static,
+        F: FnOnce(OwnedRuntimeConfigOperation) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = OwnedRuntimeConfigOutcome<T, E>> + Send + 'static,
+    {
+        let watchdog = self.clone();
+        let join = tokio::spawn(async move {
+            let coordinator_permit = coordinator.acquire().await?;
+            let (operation, executor_guard) = watchdog.register_owned(
+                kind,
+                coordinator,
+                coordinator_permit,
+                daemon_gate,
+                None,
+                None,
+                response_attached,
+            );
+            let outcome = body(operation.clone()).await;
+            match outcome {
+                OwnedRuntimeConfigOutcome::Clean(result) => {
+                    if !operation.try_settle() {
+                        std::future::pending::<()>().await;
+                    }
+                    drop(executor_guard);
+                    result
+                }
+                OwnedRuntimeConfigOutcome::Ambiguous(error) => {
+                    let _ = error;
+                    let _ = operation.fence_ambiguous_outcome();
+                    std::future::pending().await
+                }
+            }
+        });
+        match join.await {
+            Ok(result) => result,
+            Err(_) => std::future::pending().await,
+        }
+    }
+
     /// Block the calling OS thread until every clean registration settles.
     /// Ambiguous ownership deliberately never unregisters; its fail-stop wins.
     pub fn wait_until_idle(&self) {
@@ -279,6 +340,48 @@ impl RuntimeConfigSettlementWatchdog {
                 .wait(state)
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
         }
+    }
+}
+
+/// Typed result from an owned body; never inferred from transport status.
+pub enum OwnedRuntimeConfigOutcome<T, E> {
+    /// Success or a proven no-effect or fully-compensated failure.
+    Clean(Result<T, E>),
+    /// An accepted effect whose final state cannot be proved.
+    Ambiguous(E),
+}
+
+/// Response attachment shared with a detached owned executor.
+pub struct OwnedRuntimeConfigRequestContext {
+    response_attached: Arc<AtomicBool>,
+}
+
+impl OwnedRuntimeConfigRequestContext {
+    /// Create a unary response attachment owned by the outer RPC future.
+    #[must_use]
+    pub fn unary() -> (Self, OwnedRuntimeConfigResponseAttachment) {
+        let attached = Arc::new(AtomicBool::new(true));
+        (
+            Self {
+                response_attached: Arc::clone(&attached),
+            },
+            OwnedRuntimeConfigResponseAttachment(attached),
+        )
+    }
+
+    /// Transfer the shared attachment sentinel to the detached executor.
+    #[must_use]
+    pub fn response_attached(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.response_attached)
+    }
+}
+
+/// Outer-RPC sentinel; dropping it records cancellation without releasing ownership.
+pub struct OwnedRuntimeConfigResponseAttachment(Arc<AtomicBool>);
+
+impl Drop for OwnedRuntimeConfigResponseAttachment {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
     }
 }
 
@@ -703,6 +806,120 @@ mod tests {
         assert!(operation.try_settle());
         drop(guard);
         waiter.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn shared_executor_outlives_rpc_cancellation_and_settles_cleanly() {
+        let (watchdog, _receiver) = test_watchdog(Duration::from_secs(5), Duration::from_secs(1));
+        let coordinator = RuntimeConfigCoordinator::new();
+        let gate = DaemonGate::new();
+        let (context, attachment) = OwnedRuntimeConfigRequestContext::unary();
+        let (operation_tx, operation_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let executor = tokio::spawn({
+            let watchdog = watchdog.clone();
+            let coordinator = coordinator.clone();
+            async move {
+                watchdog
+                    .execute_owned(
+                        RuntimeConfigOperationKind::NeighborAdd,
+                        coordinator,
+                        gate,
+                        context.response_attached(),
+                        move |operation| async move {
+                            let _ = operation_tx.send(operation);
+                            let _ = release_rx.await;
+                            OwnedRuntimeConfigOutcome::<(), tonic::Status>::Clean(Ok(()))
+                        },
+                    )
+                    .await
+            }
+        });
+        let operation = operation_rx.await.unwrap();
+        executor.abort();
+        let _ = executor.await;
+        drop(attachment);
+        assert!(!operation.response_attached());
+        assert_eq!(operation.terminal(), RuntimeConfigSettlementTerminal::Owned);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), coordinator.acquire())
+                .await
+                .is_err(),
+            "caller cancellation must not release coordinator ownership"
+        );
+        release_tx.send(()).unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), coordinator.acquire())
+                .await
+                .unwrap()
+                .is_ok()
+        );
+        assert_eq!(
+            operation.terminal(),
+            RuntimeConfigSettlementTerminal::Settled
+        );
+    }
+
+    #[tokio::test]
+    async fn shared_executor_ambiguity_fences_queued_and_future_owners() {
+        let (watchdog, receiver) = test_watchdog(Duration::from_secs(5), Duration::from_millis(20));
+        let coordinator = RuntimeConfigCoordinator::new();
+        let gate = DaemonGate::new();
+        let (context, _attachment) = OwnedRuntimeConfigRequestContext::unary();
+        let (operation_tx, operation_rx) = tokio::sync::oneshot::channel();
+        let (ambiguous_tx, ambiguous_rx) = tokio::sync::oneshot::channel();
+        let executor = tokio::spawn({
+            let watchdog = watchdog.clone();
+            let coordinator = coordinator.clone();
+            let gate = gate.clone();
+            async move {
+                watchdog
+                    .execute_owned(
+                        RuntimeConfigOperationKind::NeighborDelete,
+                        coordinator,
+                        gate,
+                        context.response_attached(),
+                        move |operation| async move {
+                            let _ = operation_tx.send(operation);
+                            let _ = ambiguous_rx.await;
+                            OwnedRuntimeConfigOutcome::<(), tonic::Status>::Ambiguous(
+                                tonic::Status::internal("typed ambiguous test outcome"),
+                            )
+                        },
+                    )
+                    .await
+            }
+        });
+        let operation = operation_rx.await.unwrap();
+        let queued = tokio::spawn({
+            let coordinator = coordinator.clone();
+            async move { coordinator.acquire().await }
+        });
+        ambiguous_tx.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while operation.terminal() == RuntimeConfigSettlementTerminal::Owned {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            operation.terminal(),
+            RuntimeConfigSettlementTerminal::AmbiguousFenced
+        );
+        assert_eq!(
+            operation.fence_reason(),
+            Some(RuntimeConfigFenceReason::DetectedAmbiguousOutcome)
+        );
+        assert!(gate.is_shutting_down());
+        assert!(queued.await.unwrap().is_err());
+        assert!(coordinator.acquire().await.is_err());
+        assert!(
+            !executor.is_finished(),
+            "ambiguous outcome must never return"
+        );
+        assert_eq!(receiver.recv_timeout(Duration::from_secs(5)).unwrap(), 70);
+        executor.abort();
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -37,6 +37,7 @@ use crate::evpn_service::{
 use crate::global_service::GlobalService;
 use crate::gnmi::g_nmi_server::GNmiServer;
 use crate::gnmi_service::GnmiService;
+use crate::health_probe::DaemonGate;
 use crate::injection_service::InjectionService;
 use crate::neighbor_service::NeighborService;
 use crate::peer_group_service::PeerGroupService;
@@ -56,6 +57,7 @@ use crate::proto::peer_group_service_server::PeerGroupServiceServer;
 use crate::proto::policy_service_server::PolicyServiceServer;
 use crate::proto::rib_service_server::RibServiceServer;
 use crate::rib_service::RibService;
+use crate::runtime_config_settlement::RuntimeConfigSettlementWatchdog;
 use rustbgpd_rib::{RibReadinessQuery, RibUpdate};
 use rustbgpd_telemetry::BgpMetrics;
 
@@ -594,20 +596,62 @@ impl StagedConfigWrite {
     /// already applied: runtime and disk have drifted and only SIGHUP or a
     /// restart reconciles them.
     pub(crate) async fn commit(self) -> Result<(), Status> {
+        self.commit_typed()
+            .await
+            .map_err(RuntimeConfigCommitError::into_status)
+    }
+
+    /// Publish a staged write with a typed post-runtime result.
+    pub(crate) async fn commit_typed(self) -> Result<(), RuntimeConfigCommitError> {
         let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
         self.commit_tx
             .send(ack_tx)
-            .map_err(|_| Status::internal(COMMIT_LOST))?;
+            .map_err(|_| RuntimeConfigCommitError::HandoffLost)?;
         ack_rx
             .await
-            .map_err(|_| Status::internal(COMMIT_LOST))?
-            .map_err(|error| {
-                Status::internal(format!(
-                    "config persistence commit failed after the runtime change was applied \
-                     (runtime and persisted config have drifted — SIGHUP or restart to \
-                     reconcile): {error}"
-                ))
-            })
+            .map_err(|_| RuntimeConfigCommitError::AcknowledgementLost)?
+            .map_err(RuntimeConfigCommitError::Failed)
+    }
+}
+
+/// Typed failure before any runtime mutation has been dispatched.
+pub(crate) enum RuntimeConfigStageError {
+    AcknowledgementLost,
+    Rejected(crate::peer_types::CatalogMutationError),
+    Write(String),
+}
+
+impl RuntimeConfigStageError {
+    pub(crate) fn into_status(self) -> Status {
+        match self {
+            Self::AcknowledgementLost => {
+                Status::internal("config bridge dropped persistence acknowledgement")
+            }
+            Self::Rejected(error) => catalog_mutation_error_to_status(&error),
+            Self::Write(message) => {
+                Status::failed_precondition(format!("config persistence failed: {message}"))
+            }
+        }
+    }
+}
+
+/// Typed failure after runtime mutation and publication began.
+pub(crate) enum RuntimeConfigCommitError {
+    HandoffLost,
+    AcknowledgementLost,
+    Failed(String),
+}
+
+impl RuntimeConfigCommitError {
+    pub(crate) fn into_status(self) -> Status {
+        match self {
+            Self::HandoffLost | Self::AcknowledgementLost => Status::internal(COMMIT_LOST),
+            Self::Failed(error) => Status::internal(format!(
+                "config persistence commit failed after the runtime change was applied \
+                 (runtime and persisted config have drifted — SIGHUP or restart to \
+                 reconcile): {error}"
+            )),
+        }
     }
 }
 
@@ -642,6 +686,16 @@ pub(crate) async fn stage_runtime_config_event(
     permit: tokio::sync::mpsc::OwnedPermit<crate::peer_types::ConfigEvent>,
     build_event: impl FnOnce(crate::peer_types::ConfigPersistAck) -> crate::peer_types::ConfigEvent,
 ) -> Result<StagedConfigWrite, Status> {
+    stage_runtime_config_event_typed(permit, build_event)
+        .await
+        .map_err(RuntimeConfigStageError::into_status)
+}
+
+/// Typed form of [`stage_runtime_config_event`] for settlement owners.
+pub(crate) async fn stage_runtime_config_event_typed(
+    permit: tokio::sync::mpsc::OwnedPermit<crate::peer_types::ConfigEvent>,
+    build_event: impl FnOnce(crate::peer_types::ConfigPersistAck) -> crate::peer_types::ConfigEvent,
+) -> Result<StagedConfigWrite, RuntimeConfigStageError> {
     let (staged_tx, staged_rx) = tokio::sync::oneshot::channel();
     let (commit_tx, commit_rx) = tokio::sync::oneshot::channel();
     permit.send(build_event(crate::peer_types::ConfigPersistAck {
@@ -650,13 +704,13 @@ pub(crate) async fn stage_runtime_config_event(
     }));
     staged_rx
         .await
-        .map_err(|_| Status::internal("config bridge dropped persistence acknowledgement"))?
+        .map_err(|_| RuntimeConfigStageError::AcknowledgementLost)?
         .map_err(|error| match error {
             crate::peer_types::ConfigPersistError::Rejected(error) => {
-                catalog_mutation_error_to_status(&error)
+                RuntimeConfigStageError::Rejected(error)
             }
             crate::peer_types::ConfigPersistError::Write(message) => {
-                Status::failed_precondition(format!("config persistence failed: {message}"))
+                RuntimeConfigStageError::Write(message)
             }
         })?;
     Ok(StagedConfigWrite { commit_tx })
@@ -892,6 +946,11 @@ pub struct ServeConfig {
     /// FIB-table CRUD so accepted runtime mutations cannot be clobbered by a
     /// reload that read stale TOML before the persistence acknowledgement.
     pub runtime_config_lock: RuntimeConfigCoordinator,
+    /// Process-wide fail-stop owner roster used by settlement-owned runtime
+    /// mutations.
+    pub runtime_config_settlement: RuntimeConfigSettlementWatchdog,
+    /// The same process availability gate retained by every registered owner.
+    pub daemon_gate: DaemonGate,
     /// Live ADR-0061 per-route FIB dataplane event source. This is
     /// separate from the aggregate dataplane poller so route events
     /// are not delayed by snapshot polling.
@@ -1322,6 +1381,8 @@ async fn run_listener(
     let config_rollback = config.config_rollback;
     let config_mutation_gate = config.config_mutation_gate;
     let runtime_config_lock = config.runtime_config_lock;
+    let runtime_config_settlement = config.runtime_config_settlement;
+    let daemon_gate = config.daemon_gate;
     let dataplane_route_events = config.dataplane_route_events;
     let bfd_session_snapshot = config.bfd_session_snapshot;
     let bfd_events = config.bfd_events;
@@ -1384,6 +1445,8 @@ async fn run_listener(
                 config_rollback,
                 config_mutation_gate,
                 runtime_config_lock,
+                runtime_config_settlement,
+                daemon_gate,
                 dataplane_route_events,
                 bfd_session_snapshot,
                 bfd_events,
@@ -1444,6 +1507,8 @@ async fn run_listener(
                 config_rollback,
                 config_mutation_gate,
                 runtime_config_lock,
+                runtime_config_settlement,
+                daemon_gate,
                 dataplane_route_events,
                 bfd_session_snapshot,
                 bfd_events,
@@ -1510,6 +1575,8 @@ async fn run_tcp_listener(
     config_rollback: Option<ConfigRollbackFn>,
     config_mutation_gate: Option<ConfigMutationGateFn>,
     runtime_config_lock: RuntimeConfigCoordinator,
+    runtime_config_settlement: RuntimeConfigSettlementWatchdog,
+    daemon_gate: DaemonGate,
     dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
     bfd_session_snapshot: crate::bfd_service::BfdSessionSnapshotFn,
     bfd_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
@@ -1626,7 +1693,8 @@ async fn run_tcp_listener(
             config_tx.clone(),
             runtime_config_lock.clone(),
             config_mutation_gate.clone(),
-        ),
+        )
+        .with_runtime_config_settlement(runtime_config_settlement, daemon_gate),
         interceptor.clone(),
     ));
     routes.add_service(PeerGroupServiceServer::with_interceptor(
@@ -1773,6 +1841,8 @@ async fn run_uds_listener(
     config_rollback: Option<ConfigRollbackFn>,
     config_mutation_gate: Option<ConfigMutationGateFn>,
     runtime_config_lock: RuntimeConfigCoordinator,
+    runtime_config_settlement: RuntimeConfigSettlementWatchdog,
+    daemon_gate: DaemonGate,
     dataplane_route_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
     bfd_session_snapshot: crate::bfd_service::BfdSessionSnapshotFn,
     bfd_events: Option<tokio::sync::broadcast::Sender<crate::proto::BgpEvent>>,
@@ -1850,7 +1920,8 @@ async fn run_uds_listener(
             config_tx.clone(),
             runtime_config_lock.clone(),
             config_mutation_gate.clone(),
-        ),
+        )
+        .with_runtime_config_settlement(runtime_config_settlement, daemon_gate),
         interceptor.clone(),
     ));
     routes.add_service(PeerGroupServiceServer::with_interceptor(

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -4054,6 +4054,10 @@ remote_asn = 65002
     }
 
     #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one closed source inventory covers every runtime-config owner and prohibited bypass"
+    )]
     fn runtime_config_coordinator_inventory_is_complete_and_closed() {
         fn production(source: &'static str) -> &'static str {
             source
@@ -4062,6 +4066,9 @@ remote_asn = 65002
         }
 
         let server = production(include_str!("../crates/api/src/server.rs"));
+        let settlement = production(include_str!(
+            "../crates/api/src/runtime_config_settlement.rs"
+        ));
         let neighbor = production(include_str!("../crates/api/src/neighbor_service.rs"));
         let peer_group = production(include_str!("../crates/api/src/peer_group_service.rs"));
         let policy = production(include_str!("../crates/api/src/policy_service.rs"));
@@ -4085,8 +4092,11 @@ remote_asn = 65002
             (main, "move || settlement_wait.wait_until_idle()", 1),
             (transaction, "self.deps.lock.acquire()", 2),
             (transaction, ".execute_owned_operation(", 5),
+            (settlement, "let coordinator_permit = coordinator.acquire().await?;", 1),
+            (settlement, "watchdog.register_owned(", 1),
             (fib, ".acquire()", 2),
-            (neighbor, "runtime_config_lock.acquire()", 4),
+            (neighbor, "self.execute_owned_neighbor_mutation(", 4),
+            (neighbor, "reserve_config_event_slot(self.config_tx.clone()).await?", 4),
             (server, "runtime_config_lock.acquire()", 1),
             (peer_group, "run_shielded_catalog_mutation(", 1),
             (policy, "run_shielded_catalog_mutation(", 1),
@@ -4105,6 +4115,74 @@ remote_asn = 65002
                 "settlement registration inventory for {kind}"
             );
         }
+        for kind in [
+            "NeighborAdd",
+            "NeighborDelete",
+            "DynamicNeighborAdd",
+            "DynamicNeighborDelete",
+        ] {
+            assert_eq!(
+                neighbor
+                    .matches(&format!("RuntimeConfigOperationKind::{kind}"))
+                    .count(),
+                1,
+                "Neighbor4 settlement registration inventory for {kind}"
+            );
+            assert_eq!(
+                settlement.matches(&format!("    {kind},")).count(),
+                1,
+                "closed operation-kind roster for {kind}"
+            );
+        }
+        let acquired = settlement
+            .find("let coordinator_permit = coordinator.acquire().await?;")
+            .unwrap();
+        let registered = settlement.find("watchdog.register_owned(").unwrap();
+        let body = settlement
+            .find("let outcome = body(operation.clone()).await;")
+            .unwrap();
+        assert!(acquired < registered && registered < body);
+        let owned_body = neighbor
+            .split_once("async fn owned_neighbor_mutation_body")
+            .unwrap()
+            .1
+            .split_once("async fn reserve_config_event_slot")
+            .unwrap()
+            .0;
+        assert!(!owned_body.contains(".code()"));
+        assert!(!owned_body.contains(".message()"));
+        assert!(!owned_body.contains("to_string().contains"));
+        let gate = owned_body.find("check_config_mutation_gate(").unwrap();
+        let mutating = owned_body
+            .find("advance_phase(RuntimeConfigSettlementPhase::Mutating)")
+            .unwrap();
+        let stage = owned_body
+            .find("stage_runtime_config_event_typed(")
+            .unwrap();
+        let actor = owned_body
+            .find("dispatch_owned_neighbor_mutation(")
+            .unwrap();
+        let settling = owned_body
+            .find("advance_phase(RuntimeConfigSettlementPhase::SettlingRollback)")
+            .unwrap();
+        let commit = owned_body.find("staged.commit_typed()").unwrap();
+        assert!(gate < mutating && mutating < stage && stage < actor);
+        assert!(actor < settling && settling < commit);
+        for legacy in [
+            "PeerManagerCommand::RuntimeCreatePeer",
+            "PeerManagerCommand::DeletePeer",
+            "PeerManagerCommand::AddDynamicRange",
+            "PeerManagerCommand::DeleteDynamicRange",
+        ] {
+            assert!(!neighbor.contains(legacy), "Neighbor4 bypass: {legacy}");
+        }
+        let peer_manager = production(include_str!("peer_manager/mod.rs"));
+        assert_eq!(
+            peer_manager
+                .matches("PeerManagerCommand::OwnedNeighborMutation")
+                .count(),
+            1
+        );
 
         #[rustfmt::skip]
         let prohibited_apis = ["add_permits", "forget", "acquire_many", "wait_idle", "reopen", "pub fn reset", "impl Default for RuntimeConfigCoordinator"];

--- a/src/main.rs
+++ b/src/main.rs
@@ -4710,6 +4710,8 @@ async fn run<T>(
         ),
         config_mutation_gate: Some(config_mutation_gate.clone()),
         runtime_config_lock: runtime_config_lock.clone(),
+        runtime_config_settlement: runtime_config_settlement.clone(),
+        daemon_gate: daemon_gate.clone(),
         dataplane_route_events: Some(fib_bgp_event_tx),
         bfd_session_snapshot: {
             let rx = bfd_status_rx.clone();

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -19,6 +19,11 @@ use super::{
     PeerShutdownOutcome,
 };
 
+pub(super) enum RuntimeCreatePeerFailureEffect {
+    NoEffect,
+    FullyCompensated,
+}
+
 async fn send_max_prefix_start_before(
     commands: tokio::sync::mpsc::Sender<PeerCommand>,
     deadline: tokio::time::Instant,
@@ -489,6 +494,14 @@ impl PeerManager {
         &mut self,
         spec: Box<PresenceAwareNeighborCreate>,
     ) -> Result<(), PeerLifecycleError> {
+        self.runtime_create_peer_classified(spec, None).await
+    }
+
+    pub(super) async fn runtime_create_peer_classified(
+        &mut self,
+        spec: Box<PresenceAwareNeighborCreate>,
+        mut failure_effect: Option<&mut RuntimeCreatePeerFailureEffect>,
+    ) -> Result<(), PeerLifecycleError> {
         let peer = PeerKey::new(spec.address, spec.interface.clone());
         if self.peers.contains_key(&peer) {
             return Err(PeerLifecycleError::AlreadyExists(peer));
@@ -531,6 +544,9 @@ impl PeerManager {
             Ok(()) => Ok(()),
             Err(error) => {
                 self.current_config = previous_config;
+                if let Some(effect) = &mut failure_effect {
+                    **effect = RuntimeCreatePeerFailureEffect::FullyCompensated;
+                }
                 Err(error)
             }
         }
@@ -1392,6 +1408,25 @@ impl PeerManager {
             )));
         }
 
+        // Build and validate the next actor-owned snapshot before the first
+        // teardown effect. This ordering is the proof used by the settlement-
+        // owned Neighbor4 envelope: every returned delete error is a no-effect
+        // rejection, never a partially removed live session.
+        let next_config = if sync_config_snapshot {
+            let mut next_config = self.current_config.clone();
+            apply_config_event(
+                &mut next_config,
+                &ConfigEvent::NeighborDeleted {
+                    peer: peer.clone(),
+                    ack: None,
+                },
+            )
+            .map_err(|error| PeerLifecycleError::Invalid(error.to_string()))?;
+            Some(next_config)
+        } else {
+            None
+        };
+
         // Linearize any terminal signal already emitted by this generation
         // before moving it out of the live ownership table.
         self.drain_ready_session_notifications().await;
@@ -1435,12 +1470,8 @@ impl PeerManager {
         }
 
         let peer_for_reap = peer.clone();
-        if sync_config_snapshot {
-            apply_config_event(
-                &mut self.current_config,
-                &ConfigEvent::NeighborDeleted { peer, ack: None },
-            )
-            .map_err(|e| PeerLifecycleError::Invalid(e.to_string()))?;
+        if let Some(next_config) = next_config {
+            self.current_config = next_config;
         }
 
         // ADR-0067 step 4: drain the deleted peer's BFD session.

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -5,7 +5,8 @@ use std::time::{Duration, Instant};
 
 use futures::stream::{self, StreamExt};
 use rustbgpd_api::peer_types::{
-    ConfigEvent, DynamicNeighborInfo, POLICY_EVENT_HISTORY_CAPACITY, PeerKey, PeerManagerCommand,
+    ConfigEvent, DynamicNeighborInfo, OwnedNeighborMutation, OwnedNeighborMutationError,
+    OwnedNeighborMutationOutcome, POLICY_EVENT_HISTORY_CAPACITY, PeerKey, PeerManagerCommand,
     PeerManagerNeighborConfig, PeerManagerReadinessQuery, PolicyDatasetStatusRow, PolicyEvent,
     SESSION_EVENT_HISTORY_CAPACITY, SessionEvent, SessionLifecycleEvent, StageConfigSnapshotError,
 };
@@ -948,6 +949,67 @@ impl PeerManager {
                         PeerManagerCommand::DeletePeer { peer, sync_config_snapshot, reply } => {
                             let result = self.delete_peer_runtime(peer, sync_config_snapshot).await;
                             let _ = reply.send(result);
+                        }
+                        PeerManagerCommand::OwnedNeighborMutation { mutation, reply } => {
+                            // Static delete and both dynamic operations validate
+                            // before effect; static add reports cleanup explicitly.
+                            let outcome = match mutation {
+                                OwnedNeighborMutation::Add(spec) => {
+                                    let mut effect =
+                                        lifecycle::RuntimeCreatePeerFailureEffect::NoEffect;
+                                    match self
+                                        .runtime_create_peer_classified(spec, Some(&mut effect))
+                                        .await
+                                    {
+                                        Ok(()) => OwnedNeighborMutationOutcome::Success,
+                                        Err(error) => match effect {
+                                            lifecycle::RuntimeCreatePeerFailureEffect::NoEffect => {
+                                                OwnedNeighborMutationOutcome::RejectedNoEffect(
+                                                    OwnedNeighborMutationError::Peer(error),
+                                                )
+                                            }
+                                            lifecycle::RuntimeCreatePeerFailureEffect::FullyCompensated => {
+                                                OwnedNeighborMutationOutcome::FullyCompensated(
+                                                    OwnedNeighborMutationError::Peer(error),
+                                                )
+                                            }
+                                        },
+                                    }
+                                }
+                                OwnedNeighborMutation::Delete(peer) => {
+                                    match self.delete_peer_runtime(peer, true).await {
+                                        Ok(_) => OwnedNeighborMutationOutcome::Success,
+                                        Err(error) => OwnedNeighborMutationOutcome::RejectedNoEffect(
+                                            OwnedNeighborMutationError::Peer(error),
+                                        ),
+                                    }
+                                }
+                                OwnedNeighborMutation::DynamicAdd {
+                                    prefix,
+                                    peer_group,
+                                    remote_asn,
+                                    description,
+                                } => match self.add_dynamic_range(
+                                        prefix,
+                                        peer_group,
+                                        remote_asn,
+                                        description,
+                                    ) {
+                                        Ok(()) => OwnedNeighborMutationOutcome::Success,
+                                        Err(error) => OwnedNeighborMutationOutcome::RejectedNoEffect(
+                                            OwnedNeighborMutationError::Dynamic(error),
+                                        ),
+                                    },
+                                OwnedNeighborMutation::DynamicDelete { prefix } => {
+                                    match self.delete_dynamic_range(&prefix) {
+                                        Ok(_) => OwnedNeighborMutationOutcome::Success,
+                                        Err(error) => OwnedNeighborMutationOutcome::RejectedNoEffect(
+                                            OwnedNeighborMutationError::Dynamic(error),
+                                        ),
+                                    }
+                                }
+                            };
+                            let _ = reply.send(outcome);
                         }
                         PeerManagerCommand::ReconfigurePeer { config, reply } => {
                             let result = self.reconfigure_peer_runtime(config).await;


### PR DESCRIPTION
## Summary

- add a shared typed owned-mutation executor that retains coordinator ownership through clean settlement or irreversible ambiguity fencing
- activate the watchdog for static and dynamic Neighbor add/delete operations with exact response-detachment and phase handling
- distinguish no-effect/full-compensation actor outcomes from accepted reply loss and post-runtime persistence ambiguity

## Validation

- workspace all-target/all-feature Clippy and strict rustdoc
- Neighbor, settlement kernel, production exit, peer lifecycle, dynamic-neighbor, and source-inventory suites
- full API and root suites
- exact-head rebase gate on current main

This is the Neighbor4 tranche of LAN-1003; FIB, peer-group, and policy owners remain follow-ups.

Linear: LAN-1003