### PR TITLE
fix: watchdog peer-group settlement ownership

### DIFF
--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -7,21 +7,28 @@ use tonic::{Request, Response, Status};
 
 use crate::actor_read::peer_manager_read;
 use crate::audit::{set_peer_group_summary, set_request_summary};
+use crate::health_probe::DaemonGate;
 use crate::neighbor_service::{
     family_to_string, parse_families_proto, parse_remove_private_as_proto,
 };
 use crate::peer_types::{
-    AddPathDefinition, ConfigEvent, PeerGroupDefinition, PeerManagerCommand,
-    PolicyStatementDefinition,
+    AddPathDefinition, ConfigEvent, OwnedPeerGroupMutation, OwnedPeerGroupMutationOutcome,
+    PeerGroupDefinition, PeerManagerCommand, PolicyStatementDefinition,
 };
 use crate::policy_helpers::proto_statement_to_input;
 use crate::proto;
+use crate::runtime_config_settlement::{
+    OwnedRuntimeConfigOperation, OwnedRuntimeConfigOutcome, OwnedRuntimeConfigRequestContext,
+    RuntimeConfigOperationKind, RuntimeConfigSettlementPhase, RuntimeConfigSettlementWatchdog,
+};
 use crate::server::{
-    AccessMode, ConfigMutationGateFn, RuntimeConfigCoordinator, apply_catalog_mutation,
-    peer_manager_request, persist_then_apply, read_only_rejection, run_shielded_catalog_mutation,
+    AccessMode, ConfigMutationGateFn, RuntimeConfigCoordinator, catalog_mutation_error_to_status,
+    check_config_mutation_gate, peer_manager_request, read_only_rejection,
+    stage_runtime_config_event_typed,
 };
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
+const OWNED_PEER_GROUP_ACTOR_TIMEOUT: Duration = Duration::from_mins(10);
 
 fn input_statement_to_proto(statement: &PolicyStatementDefinition) -> proto::PolicyStatement {
     proto::PolicyStatement {
@@ -277,6 +284,8 @@ pub struct PeerGroupService {
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
     runtime_config_lock: RuntimeConfigCoordinator,
     config_mutation_gate: Option<ConfigMutationGateFn>,
+    settlement: Option<(RuntimeConfigSettlementWatchdog, DaemonGate)>,
+    owned_actor_timeout: Duration,
 }
 
 impl PeerGroupService {
@@ -314,24 +323,305 @@ impl PeerGroupService {
             config_tx,
             runtime_config_lock,
             config_mutation_gate,
+            settlement: None,
+            owned_actor_timeout: OWNED_PEER_GROUP_ACTOR_TIMEOUT,
         }
     }
 
-    /// Run `body` under the ADR-0080 detached-task shield with the
-    /// runtime-config lock held and the transaction gate checked inside
-    /// it (see `server::run_shielded_catalog_mutation`).
-    async fn run_mutation<F, Fut>(&self, operation: &'static str, body: F) -> Result<(), Status>
-    where
-        F: FnOnce() -> Fut + Send + 'static,
-        Fut: std::future::Future<Output = Result<(), Status>> + Send,
-    {
-        run_shielded_catalog_mutation(
-            self.runtime_config_lock.clone(),
-            self.config_mutation_gate.clone(),
-            operation,
-            body,
-        )
+    /// Arm peer-group CRUD with the process-wide fail-stop settlement owner.
+    #[must_use]
+    pub fn with_runtime_config_settlement(
+        mut self,
+        watchdog: RuntimeConfigSettlementWatchdog,
+        daemon_gate: DaemonGate,
+    ) -> Self {
+        self.settlement = Some((watchdog, daemon_gate));
+        self
+    }
+
+    async fn execute_owned_peer_group_mutation(
+        &self,
+        kind: RuntimeConfigOperationKind,
+        operation_name: &'static str,
+        intent: PeerGroupMutationIntent,
+        persist_permit: Option<mpsc::OwnedPermit<ConfigEvent>>,
+    ) -> Result<(), Status> {
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let config_mutation_gate = self.config_mutation_gate.clone();
+        let actor_timeout = self.owned_actor_timeout;
+        let settlement = self.settlement.clone();
+        let daemon_gate = settlement.as_ref().map(|(_, gate)| gate.clone());
+        let body = move |owned: Option<OwnedRuntimeConfigOperation>| async move {
+            owned_peer_group_mutation_body(
+                owned,
+                daemon_gate,
+                config_mutation_gate,
+                operation_name,
+                peer_mgr_tx,
+                actor_timeout,
+                intent,
+                persist_permit,
+            )
+            .await
+        };
+        let (context, attachment) = OwnedRuntimeConfigRequestContext::unary();
+        let result = if let Some((watchdog, daemon_gate)) = settlement {
+            watchdog
+                .execute_owned(
+                    kind,
+                    self.runtime_config_lock.clone(),
+                    daemon_gate,
+                    context.response_attached(),
+                    move |operation| body(Some(operation)),
+                )
+                .await
+        } else {
+            let coordinator = self.runtime_config_lock.clone();
+            let join = tokio::spawn(async move {
+                let _permit = coordinator.acquire().await?;
+                match body(None).await {
+                    OwnedRuntimeConfigOutcome::Clean(result) => result,
+                    OwnedRuntimeConfigOutcome::Ambiguous(error) => {
+                        let _ = error;
+                        std::future::pending().await
+                    }
+                }
+            });
+            join.await
+                .map_err(|_| Status::internal("owned peer-group mutation task did not complete"))?
+        };
+        drop(attachment);
+        result
+    }
+}
+
+enum PeerGroupMutationIntent {
+    Set {
+        name: String,
+        definition: Box<PeerGroupDefinition>,
+        preserve_md5_password: bool,
+        allow_passwordless_create: bool,
+    },
+    Delete {
+        name: String,
+    },
+    SetNeighbor {
+        address: std::net::IpAddr,
+        peer_group: String,
+    },
+    ClearNeighbor {
+        address: std::net::IpAddr,
+    },
+}
+
+enum OwnedPeerGroupDispatch {
+    NotAccepted(Status),
+    Replied(OwnedPeerGroupMutationOutcome),
+    AcceptedReplyLost(Status),
+}
+
+fn with_peer_group_persist_ack(
+    event: ConfigEvent,
+    ack: crate::peer_types::ConfigPersistAck,
+) -> ConfigEvent {
+    match event {
+        ConfigEvent::SetPeerGroup {
+            name, definition, ..
+        } => ConfigEvent::SetPeerGroup {
+            name,
+            definition,
+            ack: Some(ack),
+        },
+        ConfigEvent::DeletePeerGroup { name, .. } => ConfigEvent::DeletePeerGroup {
+            name,
+            ack: Some(ack),
+        },
+        ConfigEvent::SetNeighborPeerGroup {
+            address,
+            peer_group,
+            ..
+        } => ConfigEvent::SetNeighborPeerGroup {
+            address,
+            peer_group,
+            ack: Some(ack),
+        },
+        ConfigEvent::ClearNeighborPeerGroup { address, .. } => {
+            ConfigEvent::ClearNeighborPeerGroup {
+                address,
+                ack: Some(ack),
+            }
+        }
+        _ => unreachable!("owned peer-group intent produced a non-peer-group event"),
+    }
+}
+
+async fn dispatch_owned_peer_group_mutation(
+    peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+    timeout: Duration,
+    mutation: OwnedPeerGroupMutation,
+) -> OwnedPeerGroupDispatch {
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    let command = PeerManagerCommand::OwnedPeerGroupMutation {
+        mutation,
+        reply: reply_tx,
+    };
+    match tokio::time::timeout(timeout, peer_mgr_tx.send(command)).await {
+        Err(_) => OwnedPeerGroupDispatch::NotAccepted(Status::unavailable(
+            "peer manager mutation queue timed out before accepting command",
+        )),
+        Ok(Err(_)) => OwnedPeerGroupDispatch::NotAccepted(Status::unavailable(
+            "peer manager unavailable before accepting command",
+        )),
+        Ok(Ok(())) => match tokio::time::timeout(timeout, reply_rx).await {
+            Err(_) => OwnedPeerGroupDispatch::AcceptedReplyLost(Status::deadline_exceeded(
+                "peer manager accepted owned peer-group mutation but reply timed out",
+            )),
+            Ok(Err(_)) => OwnedPeerGroupDispatch::AcceptedReplyLost(Status::internal(
+                "peer manager accepted owned peer-group mutation but dropped its reply",
+            )),
+            Ok(Ok(outcome)) => OwnedPeerGroupDispatch::Replied(outcome),
+        },
+    }
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the closed owner body lists each retained mutation and settlement dependency explicitly"
+)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "the closed four-operation state machine remains linear so phase and ambiguity transitions stay auditable"
+)]
+async fn owned_peer_group_mutation_body(
+    owned: Option<OwnedRuntimeConfigOperation>,
+    daemon_gate: Option<DaemonGate>,
+    config_mutation_gate: Option<ConfigMutationGateFn>,
+    operation_name: &'static str,
+    peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+    actor_timeout: Duration,
+    intent: PeerGroupMutationIntent,
+    persist_permit: Option<mpsc::OwnedPermit<ConfigEvent>>,
+) -> OwnedRuntimeConfigOutcome<(), Status> {
+    if daemon_gate.is_some_and(|gate| gate.is_shutting_down()) {
+        return OwnedRuntimeConfigOutcome::Clean(Err(Status::unavailable(format!(
+            "{operation_name} rejected: daemon is shutting down"
+        ))));
+    }
+    if let Err(error) = check_config_mutation_gate(&config_mutation_gate, operation_name).await {
+        return OwnedRuntimeConfigOutcome::Clean(Err(error));
+    }
+
+    let (mutation, event) = match intent {
+        PeerGroupMutationIntent::Set {
+            name,
+            mut definition,
+            preserve_md5_password,
+            allow_passwordless_create,
+        } => {
+            if preserve_md5_password {
+                let prior = match peer_manager_request(&peer_mgr_tx, |reply| {
+                    PeerManagerCommand::GetPeerGroup {
+                        name: name.clone(),
+                        reply,
+                    }
+                })
+                .await
+                {
+                    Ok(prior) => prior,
+                    Err(error) => return OwnedRuntimeConfigOutcome::Clean(Err(error)),
+                };
+                match prior {
+                    Some(prior) => definition.md5_password = prior.md5_password,
+                    None if allow_passwordless_create => {}
+                    None => {
+                        return OwnedRuntimeConfigOutcome::Clean(Err(Status::not_found(format!(
+                            "peer group {name} not found"
+                        ))));
+                    }
+                }
+            }
+            (
+                OwnedPeerGroupMutation::Set {
+                    name: name.clone(),
+                    definition: definition.clone(),
+                },
+                ConfigEvent::SetPeerGroup {
+                    name,
+                    definition: *definition,
+                    ack: None,
+                },
+            )
+        }
+        PeerGroupMutationIntent::Delete { name } => (
+            OwnedPeerGroupMutation::Delete { name: name.clone() },
+            ConfigEvent::DeletePeerGroup { name, ack: None },
+        ),
+        PeerGroupMutationIntent::SetNeighbor {
+            address,
+            peer_group,
+        } => (
+            OwnedPeerGroupMutation::SetNeighbor {
+                address,
+                peer_group: peer_group.clone(),
+            },
+            ConfigEvent::SetNeighborPeerGroup {
+                address,
+                peer_group,
+                ack: None,
+            },
+        ),
+        PeerGroupMutationIntent::ClearNeighbor { address } => (
+            OwnedPeerGroupMutation::ClearNeighbor { address },
+            ConfigEvent::ClearNeighborPeerGroup { address, ack: None },
+        ),
+    };
+
+    if let Some(operation) = &owned {
+        operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
+    }
+    let staged = if let Some(permit) = persist_permit {
+        match stage_runtime_config_event_typed(permit, |ack| {
+            with_peer_group_persist_ack(event, ack)
+        })
         .await
+        {
+            Ok(staged) => Some(staged),
+            Err(error) => return OwnedRuntimeConfigOutcome::Clean(Err(error.into_status())),
+        }
+    } else {
+        None
+    };
+
+    match dispatch_owned_peer_group_mutation(peer_mgr_tx, actor_timeout, mutation).await {
+        OwnedPeerGroupDispatch::NotAccepted(error) => {
+            drop(staged);
+            OwnedRuntimeConfigOutcome::Clean(Err(error))
+        }
+        OwnedPeerGroupDispatch::AcceptedReplyLost(error) => {
+            OwnedRuntimeConfigOutcome::Ambiguous(error)
+        }
+        OwnedPeerGroupDispatch::Replied(
+            OwnedPeerGroupMutationOutcome::RejectedNoEffect(error)
+            | OwnedPeerGroupMutationOutcome::FullyCompensated(error),
+        ) => {
+            drop(staged);
+            OwnedRuntimeConfigOutcome::Clean(Err(catalog_mutation_error_to_status(&error)))
+        }
+        OwnedPeerGroupDispatch::Replied(OwnedPeerGroupMutationOutcome::CompensationAmbiguous(
+            error,
+        )) => OwnedRuntimeConfigOutcome::Ambiguous(catalog_mutation_error_to_status(&error)),
+        OwnedPeerGroupDispatch::Replied(OwnedPeerGroupMutationOutcome::Success) => {
+            let Some(staged) = staged else {
+                return OwnedRuntimeConfigOutcome::Clean(Ok(()));
+            };
+            if let Some(operation) = &owned {
+                operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
+            }
+            match staged.commit_typed().await {
+                Ok(()) => OwnedRuntimeConfigOutcome::Clean(Ok(())),
+                Err(error) => OwnedRuntimeConfigOutcome::Ambiguous(error.into_status()),
+            }
+        }
     }
 }
 
@@ -411,53 +701,17 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
         let definition = proto_definition_to_input(definition)?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
 
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
-        let name = req.name;
-        self.run_mutation("PeerGroupService.SetPeerGroup", move || async move {
-            // A request that omits md5_password keeps the stored secret. Read
-            // it here rather than merging inside the peer manager: the prior
-            // definition is unredacted, and this runs under the
-            // runtime-config lock every catalog writer takes, so carrying the
-            // secret forward is race-free and leaves one definition to both
-            // stage and apply.
-            let mut persisted = definition;
-            if preserve_md5_password {
-                let prior =
-                    peer_manager_request(&peer_mgr_tx, |reply| PeerManagerCommand::GetPeerGroup {
-                        name: name.clone(),
-                        reply,
-                    })
-                    .await?;
-                match prior {
-                    Some(prior) => persisted.md5_password = prior.md5_password,
-                    None if allow_passwordless_create => {}
-                    None => {
-                        return Err(Status::not_found(format!("peer group {name} not found")));
-                    }
-                }
-            }
-
-            // A group edit that is not policy-only rebuilds every inheriting
-            // member's session. Stage the write first so a persistence
-            // failure cannot bounce them once on the way out and again on the
-            // way back.
-            persist_then_apply(
-                persist_permit,
-                |ack| ConfigEvent::SetPeerGroup {
-                    name: name.clone(),
-                    definition: persisted.clone(),
-                    ack: Some(ack),
-                },
-                || {
-                    apply_catalog_mutation(&peer_mgr_tx, |reply| PeerManagerCommand::SetPeerGroup {
-                        name: name.clone(),
-                        definition: persisted.clone(),
-                        reply,
-                    })
-                },
-            )
-            .await
-        })
+        self.execute_owned_peer_group_mutation(
+            RuntimeConfigOperationKind::PeerGroupSet,
+            "PeerGroupService.SetPeerGroup",
+            PeerGroupMutationIntent::Set {
+                name: req.name,
+                definition: Box::new(definition),
+                preserve_md5_password,
+                allow_passwordless_create,
+            },
+            persist_permit,
+        )
         .await?;
 
         Ok(Response::new(proto::SetPeerGroupResponse {}))
@@ -476,26 +730,12 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
         }
 
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
-        let name = req.name;
-        self.run_mutation("PeerGroupService.DeletePeerGroup", move || async move {
-            persist_then_apply(
-                persist_permit,
-                |ack| ConfigEvent::DeletePeerGroup {
-                    name: name.clone(),
-                    ack: Some(ack),
-                },
-                || {
-                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                        PeerManagerCommand::DeletePeerGroup {
-                            name: name.clone(),
-                            reply,
-                        }
-                    })
-                },
-            )
-            .await
-        })
+        self.execute_owned_peer_group_mutation(
+            RuntimeConfigOperationKind::PeerGroupDelete,
+            "PeerGroupService.DeletePeerGroup",
+            PeerGroupMutationIntent::Delete { name: req.name },
+            persist_permit,
+        )
         .await?;
 
         Ok(Response::new(proto::DeletePeerGroupResponse {}))
@@ -518,32 +758,14 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
         }
 
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
-        let peer_group = req.peer_group;
-        self.run_mutation(
+        self.execute_owned_peer_group_mutation(
+            RuntimeConfigOperationKind::NeighborPeerGroupSet,
             "PeerGroupService.SetNeighborPeerGroup",
-            move || async move {
-                // A membership change reshapes the neighbor's session. Stage
-                // the write first so a persistence failure cannot bounce it.
-                persist_then_apply(
-                    persist_permit,
-                    |ack| ConfigEvent::SetNeighborPeerGroup {
-                        address,
-                        peer_group: peer_group.clone(),
-                        ack: Some(ack),
-                    },
-                    || {
-                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                            PeerManagerCommand::SetNeighborPeerGroup {
-                                address,
-                                peer_group: peer_group.clone(),
-                                reply,
-                            }
-                        })
-                    },
-                )
-                .await
+            PeerGroupMutationIntent::SetNeighbor {
+                address,
+                peer_group: req.peer_group,
             },
+            persist_permit,
         )
         .await?;
 
@@ -564,24 +786,11 @@ impl proto::peer_group_service_server::PeerGroupService for PeerGroupService {
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
 
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
-        self.run_mutation(
+        self.execute_owned_peer_group_mutation(
+            RuntimeConfigOperationKind::NeighborPeerGroupClear,
             "PeerGroupService.ClearNeighborPeerGroup",
-            move || async move {
-                persist_then_apply(
-                    persist_permit,
-                    |ack| ConfigEvent::ClearNeighborPeerGroup {
-                        address,
-                        ack: Some(ack),
-                    },
-                    || {
-                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                            PeerManagerCommand::ClearNeighborPeerGroup { address, reply }
-                        })
-                    },
-                )
-                .await
-            },
+            PeerGroupMutationIntent::ClearNeighbor { address },
+            persist_permit,
         )
         .await?;
 
@@ -902,9 +1111,8 @@ mod tests {
                         stored.md5_password = Some("secret".into());
                         let _ = reply.send(Some(stored));
                     }
-                    PeerManagerCommand::SetPeerGroup {
-                        name,
-                        definition,
+                    PeerManagerCommand::OwnedPeerGroupMutation {
+                        mutation: OwnedPeerGroupMutation::Set { name, definition },
                         reply,
                     } => {
                         assert_eq!(name, "rs-clients");
@@ -916,7 +1124,7 @@ mod tests {
                             Some("secret")
                         );
                         assert_eq!(definition.families, vec!["ipv6_unicast"]);
-                        let _ = reply.send(Ok(()));
+                        let _ = reply.send(OwnedPeerGroupMutationOutcome::Success);
                     }
                     _ => panic!("unexpected peer-manager command"),
                 }
@@ -991,8 +1199,9 @@ mod tests {
                     PeerManagerCommand::GetPeerGroup { reply, .. } => {
                         let _ = reply.send(None);
                     }
-                    PeerManagerCommand::SetPeerGroup {
-                        definition, reply, ..
+                    PeerManagerCommand::OwnedPeerGroupMutation {
+                        mutation: OwnedPeerGroupMutation::Set { definition, .. },
+                        reply,
                     } => {
                         assert_eq!(
                             definition
@@ -1001,7 +1210,7 @@ mod tests {
                                 .map(std::convert::AsRef::as_ref),
                             Some("super-secret")
                         );
-                        let _ = reply.send(Ok(()));
+                        let _ = reply.send(OwnedPeerGroupMutationOutcome::Success);
                     }
                     _ => panic!("unexpected peer-manager command"),
                 }
@@ -1050,9 +1259,8 @@ mod tests {
                         stored.md5_password = Some("secret".into());
                         let _ = reply.send(Some(stored));
                     }
-                    PeerManagerCommand::SetPeerGroup {
-                        name,
-                        definition,
+                    PeerManagerCommand::OwnedPeerGroupMutation {
+                        mutation: OwnedPeerGroupMutation::Set { name, definition },
                         reply,
                     } => {
                         assert_eq!(name, "rs-clients");
@@ -1063,7 +1271,7 @@ mod tests {
                                 .map(std::convert::AsRef::as_ref),
                             Some("secret")
                         );
-                        let _ = reply.send(Ok(()));
+                        let _ = reply.send(OwnedPeerGroupMutationOutcome::Success);
                     }
                     _ => panic!("unexpected peer-manager command"),
                 }
@@ -1126,16 +1334,17 @@ mod tests {
         };
         let staged = tokio::spawn(staged.accept());
         match peer_rx.recv().await.expect("expected passwordless create") {
-            PeerManagerCommand::SetPeerGroup {
-                name,
-                definition,
+            PeerManagerCommand::OwnedPeerGroupMutation {
+                mutation: OwnedPeerGroupMutation::Set { name, definition },
                 reply,
             } => {
                 assert_eq!(name, "ix-members");
                 assert_eq!(definition.md5_password, None);
                 assert_eq!(definition.families, vec!["ipv4_unicast"]);
                 assert_eq!(definition.route_server_client, Some(true));
-                reply.send(Ok(())).expect("service dropped create reply");
+                reply
+                    .send(OwnedPeerGroupMutationOutcome::Success)
+                    .expect("service dropped create reply");
             }
             _ => panic!("unexpected peer-manager command"),
         }
@@ -1214,14 +1423,13 @@ mod tests {
                     PeerManagerCommand::GetPeerGroup { reply, .. } => {
                         let _ = reply.send(None);
                     }
-                    PeerManagerCommand::SetPeerGroup {
-                        name,
-                        definition,
+                    PeerManagerCommand::OwnedPeerGroupMutation {
+                        mutation: OwnedPeerGroupMutation::Set { name, definition },
                         reply,
                     } => {
                         assert_eq!(name, "rs-clients");
                         assert_eq!(definition.md5_password, None);
-                        let _ = reply.send(Ok(()));
+                        let _ = reply.send(OwnedPeerGroupMutationOutcome::Success);
                     }
                     _ => panic!("unexpected peer-manager command"),
                 }
@@ -1492,6 +1700,187 @@ mod tests {
         assert!(
             memberships.lock().await.is_empty(),
             "a rejected membership change must not bounce the session"
+        );
+    }
+
+    async fn staged_delete_call(
+        svc: PeerGroupService,
+        config_rx: &mut mpsc::Receiver<ConfigEvent>,
+    ) -> (
+        tokio::task::JoinHandle<Result<Response<proto::DeletePeerGroupResponse>, Status>>,
+        crate::peer_types::ConfigPersistAck,
+    ) {
+        let call = tokio::spawn(async move {
+            PeerGroupServiceRpc::delete_peer_group(
+                &svc,
+                Request::new(proto::DeletePeerGroupRequest {
+                    name: "edge".into(),
+                }),
+            )
+            .await
+        });
+        let ack = match config_rx.recv().await.expect("expected staged delete") {
+            ConfigEvent::DeletePeerGroup { name, ack } => {
+                assert_eq!(name, "edge");
+                ack.expect("owned delete must use two-phase persistence")
+            }
+            _ => panic!("expected DeletePeerGroup"),
+        };
+        (call, ack)
+    }
+
+    #[tokio::test]
+    async fn owned_rejected_no_effect_discards_stage_and_returns() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(4);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+        let (call, ack) = staged_delete_call(svc, &mut config_rx).await;
+        let staged = tokio::spawn(ack.accept());
+        match peer_rx.recv().await.expect("expected owned delete") {
+            PeerManagerCommand::OwnedPeerGroupMutation {
+                mutation: OwnedPeerGroupMutation::Delete { name },
+                reply,
+            } => {
+                assert_eq!(name, "edge");
+                reply
+                    .send(OwnedPeerGroupMutationOutcome::RejectedNoEffect(
+                        crate::peer_types::CatalogMutationError::not_found("missing group"),
+                    ))
+                    .unwrap();
+            }
+            _ => panic!("expected owned peer-group delete"),
+        }
+        assert!(
+            !staged.await.unwrap(),
+            "rejected mutation must discard stage"
+        );
+        assert_eq!(
+            call.await.unwrap().unwrap_err().code(),
+            tonic::Code::NotFound
+        );
+    }
+
+    #[tokio::test]
+    async fn owned_fully_compensated_discards_stage_and_returns() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(4);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+        let (call, ack) = staged_delete_call(svc, &mut config_rx).await;
+        let staged = tokio::spawn(ack.accept());
+        match peer_rx.recv().await.expect("expected owned delete") {
+            PeerManagerCommand::OwnedPeerGroupMutation { reply, .. } => {
+                reply
+                    .send(OwnedPeerGroupMutationOutcome::FullyCompensated(
+                        crate::peer_types::CatalogMutationError::internal(
+                            "apply failed; prior runtime restored",
+                        ),
+                    ))
+                    .unwrap();
+            }
+            _ => panic!("expected owned peer-group delete"),
+        }
+        assert!(
+            !staged.await.unwrap(),
+            "compensated mutation must discard stage"
+        );
+        assert_eq!(
+            call.await.unwrap().unwrap_err().code(),
+            tonic::Code::Internal
+        );
+    }
+
+    #[tokio::test]
+    async fn accepted_reply_loss_parks_without_response() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(4);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+        let (mut call, ack) = staged_delete_call(svc, &mut config_rx).await;
+        let staged = tokio::spawn(ack.accept());
+        match peer_rx.recv().await.expect("expected owned delete") {
+            PeerManagerCommand::OwnedPeerGroupMutation { reply, .. } => drop(reply),
+            _ => panic!("expected owned peer-group delete"),
+        }
+        assert!(
+            !staged.await.unwrap(),
+            "reply loss must discard the unpublished stage"
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut call)
+                .await
+                .is_err(),
+            "accepted reply loss must never produce an RPC response"
+        );
+        call.abort();
+    }
+
+    #[tokio::test]
+    async fn commit_ack_loss_parks_without_response() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(4);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+        let (mut call, ack) = staged_delete_call(svc, &mut config_rx).await;
+        let crate::peer_types::ConfigPersistAck { staged, commit } = ack;
+        staged.send(Ok(())).unwrap();
+        match peer_rx.recv().await.expect("expected owned delete") {
+            PeerManagerCommand::OwnedPeerGroupMutation { reply, .. } => {
+                reply.send(OwnedPeerGroupMutationOutcome::Success).unwrap();
+            }
+            _ => panic!("expected owned peer-group delete"),
+        }
+        let reply = commit
+            .expect("owned mutation requires commit handshake")
+            .await
+            .expect("runtime owner must hand off commit acknowledgement");
+        drop(reply);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut call)
+                .await
+                .is_err(),
+            "lost commit acknowledgement must never produce an RPC response"
+        );
+        call.abort();
+    }
+
+    #[tokio::test]
+    async fn caller_cancellation_detaches_owned_mutation_until_commit() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(4);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let coordinator = RuntimeConfigCoordinator::new();
+        let svc = PeerGroupService::with_runtime_config_coordinator(
+            AccessMode::ReadWrite,
+            peer_tx,
+            Some(config_tx),
+            None,
+            coordinator.clone(),
+        );
+        let (call, ack) = staged_delete_call(svc, &mut config_rx).await;
+        let crate::peer_types::ConfigPersistAck { staged, commit } = ack;
+        staged.send(Ok(())).unwrap();
+        let PeerManagerCommand::OwnedPeerGroupMutation { reply, .. } =
+            peer_rx.recv().await.expect("expected owned delete")
+        else {
+            panic!("expected owned peer-group delete");
+        };
+        call.abort();
+        let _ = call.await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), coordinator.acquire())
+                .await
+                .is_err(),
+            "caller cancellation must not release mutation ownership"
+        );
+        reply.send(OwnedPeerGroupMutationOutcome::Success).unwrap();
+        let commit_reply = commit
+            .expect("owned mutation requires commit handshake")
+            .await
+            .expect("detached executor must request commit");
+        commit_reply.send(Ok(())).unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), coordinator.acquire())
+                .await
+                .unwrap()
+                .is_ok(),
+            "ownership releases only after detached commit settles"
         );
     }
 }

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -710,6 +710,11 @@ pub enum PeerManagerCommand {
         mutation: OwnedNeighborMutation,
         reply: oneshot::Sender<OwnedNeighborMutationOutcome>,
     },
+    /// Settlement-owned peer-group definition or membership mutation.
+    OwnedPeerGroupMutation {
+        mutation: OwnedPeerGroupMutation,
+        reply: oneshot::Sender<OwnedPeerGroupMutationOutcome>,
+    },
     /// Reconfigure an existing static peer by replacing its live session with
     /// a newly resolved configuration.
     ReconfigurePeer {
@@ -1468,6 +1473,37 @@ pub enum OwnedNeighborMutationOutcome {
     FullyCompensated(OwnedNeighborMutationError),
     /// A compensation send, reply, or effect failed and final state is unknown.
     CompensationAmbiguous(OwnedNeighborMutationError),
+}
+
+/// One of the four peer-group mutations protected by settlement ownership.
+pub enum OwnedPeerGroupMutation {
+    Set {
+        name: String,
+        definition: Box<PeerGroupDefinition>,
+    },
+    Delete {
+        name: String,
+    },
+    SetNeighbor {
+        address: IpAddr,
+        peer_group: String,
+    },
+    ClearNeighbor {
+        address: IpAddr,
+    },
+}
+
+/// Actor-owned settlement proof for a peer-group mutation.
+#[derive(Debug)]
+pub enum OwnedPeerGroupMutationOutcome {
+    /// The requested runtime mutation completed.
+    Success,
+    /// The actor rejected before producing any runtime effect.
+    RejectedNoEffect(CatalogMutationError),
+    /// The actor acknowledged restoration of every forward effect.
+    FullyCompensated(CatalogMutationError),
+    /// A forward or compensation effect left final runtime state unknown.
+    CompensationAmbiguous(CatalogMutationError),
 }
 
 /// Read-only peer-manager queries admitted between bounded policy-transaction

--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -32,6 +32,10 @@ pub enum RuntimeConfigOperationKind {
     DynamicNeighborDelete,
     FibSet,
     FibDelete,
+    PeerGroupSet,
+    PeerGroupDelete,
+    NeighborPeerGroupSet,
+    NeighborPeerGroupClear,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -1694,7 +1694,7 @@ async fn run_tcp_listener(
             runtime_config_lock.clone(),
             config_mutation_gate.clone(),
         )
-        .with_runtime_config_settlement(runtime_config_settlement, daemon_gate),
+        .with_runtime_config_settlement(runtime_config_settlement.clone(), daemon_gate.clone()),
         interceptor.clone(),
     ));
     routes.add_service(PeerGroupServiceServer::with_interceptor(
@@ -1704,7 +1704,8 @@ async fn run_tcp_listener(
             config_tx.clone(),
             config_mutation_gate.clone(),
             runtime_config_lock.clone(),
-        ),
+        )
+        .with_runtime_config_settlement(runtime_config_settlement, daemon_gate),
         interceptor.clone(),
     ));
     routes.add_service(PolicyServiceServer::with_interceptor(
@@ -1921,7 +1922,7 @@ async fn run_uds_listener(
             runtime_config_lock.clone(),
             config_mutation_gate.clone(),
         )
-        .with_runtime_config_settlement(runtime_config_settlement, daemon_gate),
+        .with_runtime_config_settlement(runtime_config_settlement.clone(), daemon_gate.clone()),
         interceptor.clone(),
     ));
     routes.add_service(PeerGroupServiceServer::with_interceptor(
@@ -1931,7 +1932,8 @@ async fn run_uds_listener(
             config_tx.clone(),
             config_mutation_gate.clone(),
             runtime_config_lock.clone(),
-        ),
+        )
+        .with_runtime_config_settlement(runtime_config_settlement, daemon_gate),
         interceptor.clone(),
     ));
     routes.add_service(PolicyServiceServer::with_interceptor(

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -4098,9 +4098,11 @@ remote_asn = 65002
             (neighbor, "self.execute_owned_neighbor_mutation(", 4),
             (neighbor, "reserve_config_event_slot(self.config_tx.clone()).await?", 4),
             (server, "runtime_config_lock.acquire()", 1),
-            (peer_group, "run_shielded_catalog_mutation(", 1),
+            (server, ".with_runtime_config_settlement(", 4),
+            (server, "PeerGroupService::with_runtime_config_coordinator(", 2),
+            (peer_group, "self.execute_owned_peer_group_mutation(", 4),
+            (peer_group, "reserve_config_event_slot(self.config_tx.clone()).await?", 4),
             (policy, "run_shielded_catalog_mutation(", 1),
-            (peer_group, "self.run_mutation(", 4),
             (policy, "self.run_mutation(", 12),
         ];
         for (source, shape, count) in inventory {
@@ -4127,6 +4129,25 @@ remote_asn = 65002
                     .count(),
                 1,
                 "Neighbor4 settlement registration inventory for {kind}"
+            );
+            assert_eq!(
+                settlement.matches(&format!("    {kind},")).count(),
+                1,
+                "closed operation-kind roster for {kind}"
+            );
+        }
+        for kind in [
+            "PeerGroupSet",
+            "PeerGroupDelete",
+            "NeighborPeerGroupSet",
+            "NeighborPeerGroupClear",
+        ] {
+            assert_eq!(
+                peer_group
+                    .matches(&format!("RuntimeConfigOperationKind::{kind}"))
+                    .count(),
+                1,
+                "PeerGroup4 settlement registration inventory for {kind}"
             );
             assert_eq!(
                 settlement.matches(&format!("    {kind},")).count(),
@@ -4180,6 +4201,48 @@ remote_asn = 65002
         assert_eq!(
             peer_manager
                 .matches("PeerManagerCommand::OwnedNeighborMutation")
+                .count(),
+            1
+        );
+        let owned_peer_group_body = peer_group
+            .split_once("async fn owned_peer_group_mutation_body")
+            .unwrap()
+            .1
+            .split_once("#[tonic::async_trait]")
+            .unwrap()
+            .0;
+        assert!(!owned_peer_group_body.contains(".code()"));
+        assert!(!owned_peer_group_body.contains(".message()"));
+        assert!(!owned_peer_group_body.contains("to_string().contains"));
+        let gate = owned_peer_group_body
+            .find("check_config_mutation_gate(")
+            .unwrap();
+        let mutating = owned_peer_group_body
+            .find("advance_phase(RuntimeConfigSettlementPhase::Mutating)")
+            .unwrap();
+        let stage = owned_peer_group_body
+            .find("stage_runtime_config_event_typed(")
+            .unwrap();
+        let actor = owned_peer_group_body
+            .find("dispatch_owned_peer_group_mutation(")
+            .unwrap();
+        let settling = owned_peer_group_body
+            .find("advance_phase(RuntimeConfigSettlementPhase::SettlingRollback)")
+            .unwrap();
+        let commit = owned_peer_group_body.find("staged.commit_typed()").unwrap();
+        assert!(gate < mutating && mutating < stage && stage < actor);
+        assert!(actor < settling && settling < commit);
+        for legacy in [
+            "PeerManagerCommand::SetPeerGroup",
+            "PeerManagerCommand::DeletePeerGroup",
+            "PeerManagerCommand::SetNeighborPeerGroup",
+            "PeerManagerCommand::ClearNeighborPeerGroup",
+        ] {
+            assert!(!peer_group.contains(legacy), "PeerGroup4 bypass: {legacy}");
+        }
+        assert_eq!(
+            peer_manager
+                .matches("PeerManagerCommand::OwnedPeerGroupMutation")
                 .count(),
             1
         );

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -24,6 +24,19 @@ pub(super) enum RuntimeCreatePeerFailureEffect {
     FullyCompensated,
 }
 
+pub(super) enum ReconfigurePeerFailureEffect {
+    NoEffect,
+    FullyCompensated,
+    CompensationAmbiguous,
+}
+
+pub(super) enum PeerReshapeSnapshotOutcome {
+    Success(Vec<PeerManagerNeighborConfig>),
+    RejectedNoEffect(PeerLifecycleError),
+    FullyCompensated(PeerLifecycleError),
+    CompensationAmbiguous(PeerLifecycleError),
+}
+
 async fn send_max_prefix_start_before(
     commands: tokio::sync::mpsc::Sender<PeerCommand>,
     deadline: tokio::time::Instant,
@@ -851,8 +864,16 @@ impl PeerManager {
         &mut self,
         config: PeerManagerNeighborConfig,
     ) -> Result<PeerManagerNeighborConfig, PeerLifecycleError> {
+        let mut effect = ReconfigurePeerFailureEffect::NoEffect;
+        self.reconfigure_peer_classified(config, &mut effect).await
+    }
+
+    async fn reconfigure_peer_classified(
+        &mut self,
+        config: PeerManagerNeighborConfig,
+        effect: &mut ReconfigurePeerFailureEffect,
+    ) -> Result<PeerManagerNeighborConfig, PeerLifecycleError> {
         let peer = PeerKey::new(config.address, config.interface.clone());
-        self.invalidate_max_prefix_restart(&peer);
         #[cfg(test)]
         if let Some(remaining) = self.inject_reconfigure_failures.get_mut(&peer) {
             if *remaining == 0 {
@@ -862,6 +883,7 @@ impl PeerManager {
             }
             *remaining -= 1;
         }
+        self.invalidate_max_prefix_restart(&peer);
         let (was_enabled, graceful_shutdown) = self
             .peers
             .get(&peer)
@@ -884,12 +906,18 @@ impl PeerManager {
                 )
                 .await
             {
-                Ok(()) => Err(PeerLifecycleError::Internal(format!(
-                    "failed to add reconfigured peer {peer}: {add_error}; previous peer restored"
-                ))),
-                Err(restore_error) => Err(PeerLifecycleError::Internal(format!(
-                    "failed to add reconfigured peer {peer}: {add_error}; restore previous peer failed: {restore_error}"
-                ))),
+                Ok(()) => {
+                    *effect = ReconfigurePeerFailureEffect::FullyCompensated;
+                    Err(PeerLifecycleError::Internal(format!(
+                        "failed to add reconfigured peer {peer}: {add_error}; previous peer restored"
+                    )))
+                }
+                Err(restore_error) => {
+                    *effect = ReconfigurePeerFailureEffect::CompensationAmbiguous;
+                    Err(PeerLifecycleError::Internal(format!(
+                        "failed to add reconfigured peer {peer}: {add_error}; restore previous peer failed: {restore_error}"
+                    )))
+                }
             };
         }
 
@@ -906,12 +934,18 @@ impl PeerManager {
                 )
                 .await
             {
-                Ok(()) => Err(PeerLifecycleError::Internal(format!(
-                    "failed to restore runtime state for reconfigured peer {peer}: {state_error}; previous peer restored"
-                ))),
-                Err(restore_error) => Err(PeerLifecycleError::Internal(format!(
-                    "failed to restore runtime state for reconfigured peer {peer}: {state_error}; restore previous peer failed: {restore_error}"
-                ))),
+                Ok(()) => {
+                    *effect = ReconfigurePeerFailureEffect::FullyCompensated;
+                    Err(PeerLifecycleError::Internal(format!(
+                        "failed to restore runtime state for reconfigured peer {peer}: {state_error}; previous peer restored"
+                    )))
+                }
+                Err(restore_error) => {
+                    *effect = ReconfigurePeerFailureEffect::CompensationAmbiguous;
+                    Err(PeerLifecycleError::Internal(format!(
+                        "failed to restore runtime state for reconfigured peer {peer}: {state_error}; restore previous peer failed: {restore_error}"
+                    )))
+                }
             };
         }
 
@@ -1128,22 +1162,37 @@ impl PeerManager {
         &mut self,
         targets: Vec<PeerManagerNeighborConfig>,
     ) -> Result<Vec<PeerManagerNeighborConfig>, PeerLifecycleError> {
+        match self.apply_peer_reshape_snapshot_classified(targets).await {
+            PeerReshapeSnapshotOutcome::Success(priors) => Ok(priors),
+            PeerReshapeSnapshotOutcome::RejectedNoEffect(error)
+            | PeerReshapeSnapshotOutcome::FullyCompensated(error)
+            | PeerReshapeSnapshotOutcome::CompensationAmbiguous(error) => Err(error),
+        }
+    }
+
+    pub(super) async fn apply_peer_reshape_snapshot_classified(
+        &mut self,
+        targets: Vec<PeerManagerNeighborConfig>,
+    ) -> PeerReshapeSnapshotOutcome {
         let mut seen = BTreeSet::new();
         for target in &targets {
             let peer = PeerKey::new(target.address, target.interface.clone());
             if !seen.insert(peer.clone()) {
-                return Err(PeerLifecycleError::Invalid(format!(
-                    "peer reshape target {peer} appears more than once"
-                )));
+                return PeerReshapeSnapshotOutcome::RejectedNoEffect(PeerLifecycleError::Invalid(
+                    format!("peer reshape target {peer} appears more than once"),
+                ));
             }
-            let managed = self
-                .peers
-                .get(&peer)
-                .ok_or_else(|| PeerLifecycleError::NotFound(peer.clone()))?;
+            let Some(managed) = self.peers.get(&peer) else {
+                return PeerReshapeSnapshotOutcome::RejectedNoEffect(PeerLifecycleError::NotFound(
+                    peer,
+                ));
+            };
             if managed.transport_config.tcp_ao != target.tcp_ao {
-                return Err(PeerLifecycleError::RestartRequired(format!(
-                    "peer reshape target {peer} changes tcp_ao; TCP-AO changes require a daemon restart"
-                )));
+                return PeerReshapeSnapshotOutcome::RejectedNoEffect(
+                    PeerLifecycleError::RestartRequired(format!(
+                        "peer reshape target {peer} changes tcp_ao; TCP-AO changes require a daemon restart"
+                    )),
+                );
             }
             // Inbound MD5 keys and GTSM selectors live on the BGP listener,
             // which only startup and the SIGHUP reload coordinator can
@@ -1153,44 +1202,60 @@ impl PeerManager {
             if managed.transport_config.md5_password != target.md5_password
                 || managed.transport_config.ttl_security != target.ttl_security
             {
-                return Err(PeerLifecycleError::RestartRequired(format!(
-                    "peer reshape target {peer} changes md5_password or ttl_security; inbound \
+                return PeerReshapeSnapshotOutcome::RejectedNoEffect(
+                    PeerLifecycleError::RestartRequired(format!(
+                        "peer reshape target {peer} changes md5_password or ttl_security; inbound \
                      listener enforcement is updated only by startup or SIGHUP reload — apply \
                      this change through the config file and SIGHUP"
-                )));
+                    )),
+                );
             }
             // Defense in depth: the transaction executor already gates dynamic
             // ranges out of reshape targets, but reconfigure's delete/re-add
             // semantics are wrong for an ephemeral dynamic peer (it would change
             // `is_dynamic` lifecycle/persistence), so refuse one here too.
             if managed.is_dynamic {
-                return Err(PeerLifecycleError::Invalid(format!(
-                    "peer reshape target {peer} is a dynamic peer; reshape transactions reconfigure static neighbors only"
-                )));
+                return PeerReshapeSnapshotOutcome::RejectedNoEffect(PeerLifecycleError::Invalid(
+                    format!(
+                        "peer reshape target {peer} is a dynamic peer; reshape transactions reconfigure static neighbors only"
+                    ),
+                ));
             }
         }
 
         let mut priors = Vec::with_capacity(targets.len());
         for target in targets {
             let peer = PeerKey::new(target.address, target.interface.clone());
-            match self.reconfigure_peer(target).await {
+            let mut effect = ReconfigurePeerFailureEffect::NoEffect;
+            match self.reconfigure_peer_classified(target, &mut effect).await {
                 Ok(previous) => priors.push(previous),
                 Err(error) => {
-                    return match self.restore_peer_reshape_priors(priors).await {
-                        Ok(()) => Err(PeerLifecycleError::Internal(format!(
+                    let had_prior_effects = !priors.is_empty();
+                    let restore = self.restore_peer_reshape_priors(priors).await;
+                    let restore_failed = restore.is_err();
+                    let composed = match restore {
+                        Ok(()) => PeerLifecycleError::Internal(format!(
                             "failed to reconfigure peer {peer}: {error}; prior peers restored"
-                        ))),
-                        // The rollback error already names exactly which prior
-                        // members were left reshaped (and notes the rest were
-                        // restored), so compose it verbatim.
-                        Err(restore_error) => Err(PeerLifecycleError::Internal(format!(
+                        )),
+                        Err(restore_error) => PeerLifecycleError::Internal(format!(
                             "failed to reconfigure peer {peer}: {error}; {restore_error}"
-                        ))),
+                        )),
+                    };
+                    return if restore_failed
+                        || matches!(effect, ReconfigurePeerFailureEffect::CompensationAmbiguous)
+                    {
+                        PeerReshapeSnapshotOutcome::CompensationAmbiguous(composed)
+                    } else if had_prior_effects
+                        || matches!(effect, ReconfigurePeerFailureEffect::FullyCompensated)
+                    {
+                        PeerReshapeSnapshotOutcome::FullyCompensated(composed)
+                    } else {
+                        PeerReshapeSnapshotOutcome::RejectedNoEffect(composed)
                     };
                 }
             }
         }
-        Ok(priors)
+        PeerReshapeSnapshotOutcome::Success(priors)
     }
 
     async fn restore_peer_reshape_priors(

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -6,9 +6,10 @@ use std::time::{Duration, Instant};
 use futures::stream::{self, StreamExt};
 use rustbgpd_api::peer_types::{
     ConfigEvent, DynamicNeighborInfo, OwnedNeighborMutation, OwnedNeighborMutationError,
-    OwnedNeighborMutationOutcome, POLICY_EVENT_HISTORY_CAPACITY, PeerKey, PeerManagerCommand,
-    PeerManagerNeighborConfig, PeerManagerReadinessQuery, PolicyDatasetStatusRow, PolicyEvent,
-    SESSION_EVENT_HISTORY_CAPACITY, SessionEvent, SessionLifecycleEvent, StageConfigSnapshotError,
+    OwnedNeighborMutationOutcome, OwnedPeerGroupMutation, OwnedPeerGroupMutationOutcome,
+    POLICY_EVENT_HISTORY_CAPACITY, PeerKey, PeerManagerCommand, PeerManagerNeighborConfig,
+    PeerManagerReadinessQuery, PolicyDatasetStatusRow, PolicyEvent, SESSION_EVENT_HISTORY_CAPACITY,
+    SessionEvent, SessionLifecycleEvent, StageConfigSnapshotError,
 };
 use rustbgpd_bmp::BmpEvent;
 use rustbgpd_fsm::PeerConfig;
@@ -1007,6 +1008,55 @@ impl PeerManager {
                                             OwnedNeighborMutationError::Dynamic(error),
                                         ),
                                     }
+                                }
+                            };
+                            let _ = reply.send(outcome);
+                        }
+                        PeerManagerCommand::OwnedPeerGroupMutation { mutation, reply } => {
+                            let outcome = match mutation {
+                                OwnedPeerGroupMutation::Set { name, definition } => {
+                                    let event = ConfigEvent::SetPeerGroup {
+                                        name: name.clone(),
+                                        definition: (*definition).clone(),
+                                        ack: None,
+                                    };
+                                    if self.peer_group_policy_only_update(&name, &definition) {
+                                        match self.apply_policy_change(event, None).await {
+                                            Ok(()) => OwnedPeerGroupMutationOutcome::Success,
+                                            Err(error) => {
+                                                // The existing policy hot-apply seam does not yet
+                                                // carry typed rollback proof. Never infer it from
+                                                // its message; Policy12 will close that boundary.
+                                                OwnedPeerGroupMutationOutcome::CompensationAmbiguous(error)
+                                            }
+                                        }
+                                    } else {
+                                        let affected: Vec<IpAddr> = self.current_config
+                                            .neighbors
+                                            .iter()
+                                            .filter(|neighbor| neighbor.peer_group.as_deref() == Some(name.as_str()))
+                                            .filter_map(|neighbor| neighbor.address.parse().ok())
+                                            .collect();
+                                        self.apply_peer_group_change_owned(event, affected).await
+                                    }
+                                }
+                                OwnedPeerGroupMutation::Delete { name } => {
+                                    self.apply_peer_group_change_owned(
+                                        ConfigEvent::DeletePeerGroup { name, ack: None },
+                                        Vec::new(),
+                                    ).await
+                                }
+                                OwnedPeerGroupMutation::SetNeighbor { address, peer_group } => {
+                                    self.apply_peer_group_change_owned(
+                                        ConfigEvent::SetNeighborPeerGroup { address, peer_group, ack: None },
+                                        vec![address],
+                                    ).await
+                                }
+                                OwnedPeerGroupMutation::ClearNeighbor { address } => {
+                                    self.apply_peer_group_change_owned(
+                                        ConfigEvent::ClearNeighborPeerGroup { address, ack: None },
+                                        vec![address],
+                                    ).await
                                 }
                             };
                             let _ = reply.send(outcome);

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -7,7 +7,8 @@ use std::time::Instant;
 
 use rustbgpd_api::peer_types::{
     CatalogMutationError, ConfigEvent, DynamicRangeTarget, ImportValidationDependency,
-    PeerGroupDefinition, PeerKey, PeerManagerNeighborConfig, ResolvedPeerPolicy,
+    OwnedPeerGroupMutationOutcome, PeerGroupDefinition, PeerKey, PeerManagerNeighborConfig,
+    ResolvedPeerPolicy,
 };
 use rustbgpd_fsm::SessionState;
 use rustbgpd_policy::PolicyChain;
@@ -26,6 +27,7 @@ use crate::policy_admin::{
 
 use super::{
     ManagedPeer, PEER_POLICY_UPDATE_TIMEOUT, PEER_QUERY_TIMEOUT, PeerManager, RIB_REPLY_TIMEOUT,
+    lifecycle::PeerReshapeSnapshotOutcome,
 };
 
 /// Peers applied between cohort-setup progress lines. Sized so a
@@ -3078,6 +3080,130 @@ impl PeerManager {
         self.reconcile_stale_dynamic_max_prefix_restarts();
         self.publish_policy_config_event(&event, priors.len());
         Ok(())
+    }
+
+    /// Settlement-owned counterpart of [`Self::apply_peer_group_change`].
+    /// It preserves the legacy behavior while carrying explicit proof of
+    /// whether an error preceded all effects, was completely restored, or
+    /// left runtime state uncertain.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the typed peer-group path keeps validation, apply, and settlement classification in one auditable flow"
+    )]
+    pub(super) async fn apply_peer_group_change_owned(
+        &mut self,
+        event: ConfigEvent,
+        affected_peers: Vec<IpAddr>,
+    ) -> OwnedPeerGroupMutationOutcome {
+        if let ConfigEvent::DeletePeerGroup { name, .. } = &event {
+            let refs = peer_group_references(&self.current_config, name);
+            if !refs.is_empty() {
+                return OwnedPeerGroupMutationOutcome::RejectedNoEffect(
+                    CatalogMutationError::StillReferenced {
+                        kind: "peer group",
+                        name: name.clone(),
+                        references: refs,
+                    },
+                );
+            }
+        }
+
+        let mut next_config = self.current_config.clone();
+        if let Err(error) = apply_config_event(&mut next_config, &event) {
+            return OwnedPeerGroupMutationOutcome::RejectedNoEffect(catalog_config_error(error));
+        }
+        if next_config == self.current_config {
+            return OwnedPeerGroupMutationOutcome::Success;
+        }
+
+        if let ConfigEvent::SetPeerGroup { name, .. } = &event
+            && let Some(old_group) = self.current_config.peer_groups.get(name)
+            && let Some(new_group) = next_config.peer_groups.get(name)
+            && (old_group.md5_password != new_group.md5_password
+                || old_group.ttl_security != new_group.ttl_security)
+        {
+            return OwnedPeerGroupMutationOutcome::RejectedNoEffect(
+                CatalogMutationError::RestartRequired(format!(
+                    "peer group {name:?} changes md5_password or ttl_security; inbound listener \
+                     enforcement is updated only by startup or SIGHUP reload — apply this change \
+                     through the config file and SIGHUP"
+                )),
+            );
+        }
+
+        if let ConfigEvent::SetPeerGroup { name, .. } = &event
+            && let Some(old_group) = self.current_config.peer_groups.get(name)
+            && let Some(new_group) = next_config.peer_groups.get(name)
+            && crate::config::peer_group_change_hot_applicable(old_group, new_group)
+        {
+            let name = name.clone();
+            return match self
+                .apply_peer_group_hot_change(event, next_config, &name, affected_peers)
+                .await
+            {
+                Ok(()) => OwnedPeerGroupMutationOutcome::Success,
+                Err(error) => OwnedPeerGroupMutationOutcome::CompensationAmbiguous(error),
+            };
+        }
+
+        let mut seen = BTreeSet::new();
+        let mut targets: Vec<PeerManagerNeighborConfig> = Vec::new();
+        for peer_key in affected_peers
+            .into_iter()
+            .flat_map(|address| self.peer_keys_for_address(address))
+        {
+            if !seen.insert(peer_key.clone()) {
+                continue;
+            }
+            if self
+                .peers
+                .get(&peer_key)
+                .is_some_and(|managed| managed.is_dynamic)
+            {
+                continue;
+            }
+            let address = peer_key.address;
+            let Some(neighbor) = next_config.neighbors.iter().find(|neighbor| {
+                neighbor.address == address.to_string() && neighbor.interface == peer_key.interface
+            }) else {
+                return OwnedPeerGroupMutationOutcome::RejectedNoEffect(
+                    CatalogMutationError::internal(format!(
+                        "static peer {peer_key} affected by the peer-group change has no neighbor \
+                         record in the updated config; refusing to reshape an inconsistent snapshot"
+                    )),
+                );
+            };
+            let resolved = match next_config.resolve_neighbor(neighbor) {
+                Ok(resolved) => resolved,
+                Err(error) => {
+                    return OwnedPeerGroupMutationOutcome::RejectedNoEffect(catalog_config_error(
+                        error,
+                    ));
+                }
+            };
+            targets.push(Self::peer_manager_config_from_resolved(resolved, false));
+        }
+
+        let priors = match self.apply_peer_reshape_snapshot_classified(targets).await {
+            PeerReshapeSnapshotOutcome::Success(priors) => priors,
+            PeerReshapeSnapshotOutcome::RejectedNoEffect(error) => {
+                return OwnedPeerGroupMutationOutcome::RejectedNoEffect(error.into());
+            }
+            PeerReshapeSnapshotOutcome::FullyCompensated(error) => {
+                return OwnedPeerGroupMutationOutcome::FullyCompensated(error.into());
+            }
+            PeerReshapeSnapshotOutcome::CompensationAmbiguous(error) => {
+                return OwnedPeerGroupMutationOutcome::CompensationAmbiguous(error.into());
+            }
+        };
+
+        self.current_config = next_config;
+        if let ConfigEvent::SetPeerGroup { name, .. } = &event {
+            self.sync_dynamic_max_prefix_restart_for_group(name);
+        }
+        self.reconcile_stale_dynamic_max_prefix_restarts();
+        self.publish_policy_config_event(&event, priors.len());
+        OwnedPeerGroupMutationOutcome::Success
     }
 
     /// The all-hot half of [`Self::apply_peer_group_change`]: apply the

--- a/src/peer_manager/tests/peer_groups.rs
+++ b/src/peer_manager/tests/peer_groups.rs
@@ -90,6 +90,37 @@ async fn targeted_required_family_edit_revalidates_dynamic_consumers() {
     assert_eq!(mgr.current_config, prior);
 }
 
+#[tokio::test]
+async fn owned_peer_group_validation_rejection_is_typed_no_effect() {
+    let config = load_test_config(&format!(
+        "{}\n[[dynamic_neighbors]]\nprefix = \"192.0.2.0/24\"\npeer_group = \"edge\"\n",
+        EDGE_GROUP_TOML
+            .replace("10.0.0.2", "2001:db8::2")
+            .replace("10.0.0.3", "2001:db8::3")
+            .replace("10.0.0.4", "2001:db8::4")
+    ));
+    let prior = config.clone();
+    let mut mgr = peer_group_reshape_manager(config);
+    let mut definition = edge_group_definition(Some(90));
+    definition.required_families = vec!["ipv6_unicast".to_string()];
+
+    let outcome = mgr
+        .apply_peer_group_change_owned(
+            rustbgpd_api::peer_types::ConfigEvent::SetPeerGroup {
+                name: "edge".to_string(),
+                definition,
+                ack: None,
+            },
+            vec!["2001:db8::2".parse().unwrap()],
+        )
+        .await;
+    assert!(matches!(
+        outcome,
+        rustbgpd_api::peer_types::OwnedPeerGroupMutationOutcome::RejectedNoEffect(_)
+    ));
+    assert_eq!(mgr.current_config, prior);
+}
+
 const EDGE_GROUP_TOML: &str = r#"
 [global]
 asn = 65001
@@ -311,6 +342,37 @@ async fn peer_group_reshape_mid_fanout_failure_restores_prior_members() {
     );
 }
 
+#[tokio::test]
+async fn owned_peer_group_reshape_reports_fully_compensated_failure() {
+    let config = load_test_config(EDGE_GROUP_TOML);
+    let mut mgr = peer_group_reshape_manager(config.clone());
+    for resolved in config.resolved_neighbors().unwrap() {
+        mgr.add_peer(
+            PeerManager::peer_manager_config_from_resolved(resolved, false),
+            false,
+        )
+        .await
+        .unwrap();
+    }
+    let a1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let a2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    mgr.inject_reconfigure_failures.insert(key(a2), 0);
+
+    let outcome = mgr
+        .apply_peer_group_change_owned(set_edge_hold_time_event(45), vec![a1, a2])
+        .await;
+    assert!(
+        matches!(
+            outcome,
+            rustbgpd_api::peer_types::OwnedPeerGroupMutationOutcome::FullyCompensated(_)
+        ),
+        "a restored fan-out must carry typed full-compensation proof"
+    );
+    assert_eq!(mgr.current_config, config);
+    assert_eq!(mgr.peers[&key(a1)].hold_time, Some(90));
+    assert_eq!(mgr.peers[&key(a2)].hold_time, Some(90));
+}
+
 /// ADR-0081: rollback of the captured priors is best-effort — a failed
 /// restore must not short-circuit the reverse sweep, so every earlier
 /// member is still attempted, and the compound error names exactly which
@@ -399,6 +461,39 @@ async fn peer_group_reshape_rollback_failure_still_restores_other_priors() {
         Some(90),
         "failed reshape must not advance current_config"
     );
+}
+
+#[tokio::test]
+async fn owned_peer_group_reshape_reports_ambiguous_rollback_failure() {
+    let config = load_test_config(EDGE_GROUP_TOML);
+    let mut mgr = peer_group_reshape_manager(config.clone());
+    for resolved in config.resolved_neighbors().unwrap() {
+        mgr.add_peer(
+            PeerManager::peer_manager_config_from_resolved(resolved, false),
+            false,
+        )
+        .await
+        .unwrap();
+    }
+    let a1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let a2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let a3 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+    mgr.inject_reconfigure_failures.insert(key(a3), 0);
+    mgr.inject_reconfigure_failures.insert(key(a2), 1);
+
+    let outcome = mgr
+        .apply_peer_group_change_owned(set_edge_hold_time_event(45), vec![a1, a2, a3])
+        .await;
+    assert!(
+        matches!(
+            outcome,
+            rustbgpd_api::peer_types::OwnedPeerGroupMutationOutcome::CompensationAmbiguous(_)
+        ),
+        "a failed restore must carry typed ambiguity"
+    );
+    assert_eq!(mgr.current_config, config);
+    assert_eq!(mgr.peers[&key(a1)].hold_time, Some(90));
+    assert_eq!(mgr.peers[&key(a2)].hold_time, Some(45));
 }
 
 /// ADR-0081 decision 2: a member whose resolved next config changes TCP-AO


### PR DESCRIPTION
## Summary

- activate typed settlement ownership for PeerGroup Set/Delete and neighbor membership Set/Clear
- reserve persistence before ownership and commit only after typed actor success
- fence and retain ownership on reply loss, rollback uncertainty, commit uncertainty, or executor loss

## Safety contract

Only success, proved no effect, or fully acknowledged compensation settles. Ambiguous outcomes publish no response and use the existing readiness fence and exit-70 recovery path. Policy12, SIGHUP, observability, and public API/config surfaces remain unchanged.

## Validation

- focused API peer-group tests: 28 passed
- focused actor/peer-group tests: 81 passed
- settlement inventory and production exit-70 integration passed
- locked workspace all-features tests passed
- locked workspace all-target/all-feature Clippy with warnings denied passed
- independent exact-head safety review: GO

Tracks LAN-1003. LAN-974 remains open until the remaining owner and operational closure tranches land.