### PR TITLE
fix: settle policy catalog mutations safely

### DIFF
--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -12,7 +12,7 @@ use crate::neighbor_service::{
     family_to_string, parse_families_proto, parse_remove_private_as_proto,
 };
 use crate::peer_types::{
-    AddPathDefinition, ConfigEvent, OwnedPeerGroupMutation, OwnedPeerGroupMutationOutcome,
+    AddPathDefinition, ConfigEvent, OwnedCatalogMutation, OwnedCatalogMutationOutcome,
     PeerGroupDefinition, PeerManagerCommand, PolicyStatementDefinition,
 };
 use crate::policy_helpers::proto_statement_to_input;
@@ -22,9 +22,10 @@ use crate::runtime_config_settlement::{
     RuntimeConfigOperationKind, RuntimeConfigSettlementPhase, RuntimeConfigSettlementWatchdog,
 };
 use crate::server::{
-    AccessMode, ConfigMutationGateFn, RuntimeConfigCoordinator, catalog_mutation_error_to_status,
-    check_config_mutation_gate, peer_manager_request, read_only_rejection,
-    stage_runtime_config_event_typed,
+    AccessMode, ConfigMutationGateFn, OwnedCatalogDispatch, RuntimeConfigCoordinator,
+    catalog_mutation_error_to_status, check_config_mutation_gate, dispatch_owned_catalog_mutation,
+    peer_manager_request, read_only_rejection, stage_runtime_config_event_typed,
+    with_catalog_persist_ack,
 };
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -414,76 +415,6 @@ enum PeerGroupMutationIntent {
     },
 }
 
-enum OwnedPeerGroupDispatch {
-    NotAccepted(Status),
-    Replied(OwnedPeerGroupMutationOutcome),
-    AcceptedReplyLost(Status),
-}
-
-fn with_peer_group_persist_ack(
-    event: ConfigEvent,
-    ack: crate::peer_types::ConfigPersistAck,
-) -> ConfigEvent {
-    match event {
-        ConfigEvent::SetPeerGroup {
-            name, definition, ..
-        } => ConfigEvent::SetPeerGroup {
-            name,
-            definition,
-            ack: Some(ack),
-        },
-        ConfigEvent::DeletePeerGroup { name, .. } => ConfigEvent::DeletePeerGroup {
-            name,
-            ack: Some(ack),
-        },
-        ConfigEvent::SetNeighborPeerGroup {
-            address,
-            peer_group,
-            ..
-        } => ConfigEvent::SetNeighborPeerGroup {
-            address,
-            peer_group,
-            ack: Some(ack),
-        },
-        ConfigEvent::ClearNeighborPeerGroup { address, .. } => {
-            ConfigEvent::ClearNeighborPeerGroup {
-                address,
-                ack: Some(ack),
-            }
-        }
-        _ => unreachable!("owned peer-group intent produced a non-peer-group event"),
-    }
-}
-
-async fn dispatch_owned_peer_group_mutation(
-    peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
-    timeout: Duration,
-    mutation: OwnedPeerGroupMutation,
-) -> OwnedPeerGroupDispatch {
-    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-    let command = PeerManagerCommand::OwnedPeerGroupMutation {
-        mutation,
-        reply: reply_tx,
-    };
-    match tokio::time::timeout(timeout, peer_mgr_tx.send(command)).await {
-        Err(_) => OwnedPeerGroupDispatch::NotAccepted(Status::unavailable(
-            "peer manager mutation queue timed out before accepting command",
-        )),
-        Ok(Err(_)) => OwnedPeerGroupDispatch::NotAccepted(Status::unavailable(
-            "peer manager unavailable before accepting command",
-        )),
-        Ok(Ok(())) => match tokio::time::timeout(timeout, reply_rx).await {
-            Err(_) => OwnedPeerGroupDispatch::AcceptedReplyLost(Status::deadline_exceeded(
-                "peer manager accepted owned peer-group mutation but reply timed out",
-            )),
-            Ok(Err(_)) => OwnedPeerGroupDispatch::AcceptedReplyLost(Status::internal(
-                "peer manager accepted owned peer-group mutation but dropped its reply",
-            )),
-            Ok(Ok(outcome)) => OwnedPeerGroupDispatch::Replied(outcome),
-        },
-    }
-}
-
 #[expect(
     clippy::too_many_arguments,
     reason = "the closed owner body lists each retained mutation and settlement dependency explicitly"
@@ -541,7 +472,7 @@ async fn owned_peer_group_mutation_body(
                 }
             }
             (
-                OwnedPeerGroupMutation::Set {
+                OwnedCatalogMutation::SetPeerGroup {
                     name: name.clone(),
                     definition: definition.clone(),
                 },
@@ -553,14 +484,14 @@ async fn owned_peer_group_mutation_body(
             )
         }
         PeerGroupMutationIntent::Delete { name } => (
-            OwnedPeerGroupMutation::Delete { name: name.clone() },
+            OwnedCatalogMutation::DeletePeerGroup { name: name.clone() },
             ConfigEvent::DeletePeerGroup { name, ack: None },
         ),
         PeerGroupMutationIntent::SetNeighbor {
             address,
             peer_group,
         } => (
-            OwnedPeerGroupMutation::SetNeighbor {
+            OwnedCatalogMutation::SetNeighborPeerGroup {
                 address,
                 peer_group: peer_group.clone(),
             },
@@ -571,7 +502,7 @@ async fn owned_peer_group_mutation_body(
             },
         ),
         PeerGroupMutationIntent::ClearNeighbor { address } => (
-            OwnedPeerGroupMutation::ClearNeighbor { address },
+            OwnedCatalogMutation::ClearNeighborPeerGroup { address },
             ConfigEvent::ClearNeighborPeerGroup { address, ack: None },
         ),
     };
@@ -580,10 +511,8 @@ async fn owned_peer_group_mutation_body(
         operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
     }
     let staged = if let Some(permit) = persist_permit {
-        match stage_runtime_config_event_typed(permit, |ack| {
-            with_peer_group_persist_ack(event, ack)
-        })
-        .await
+        match stage_runtime_config_event_typed(permit, |ack| with_catalog_persist_ack(event, ack))
+            .await
         {
             Ok(staged) => Some(staged),
             Err(error) => return OwnedRuntimeConfigOutcome::Clean(Err(error.into_status())),
@@ -592,31 +521,34 @@ async fn owned_peer_group_mutation_body(
         None
     };
 
-    match dispatch_owned_peer_group_mutation(peer_mgr_tx, actor_timeout, mutation).await {
-        OwnedPeerGroupDispatch::NotAccepted(error) => {
+    let dispatch = dispatch_owned_catalog_mutation(peer_mgr_tx, actor_timeout, mutation).await;
+    if matches!(dispatch, OwnedCatalogDispatch::Replied(_))
+        && let Some(operation) = &owned
+    {
+        operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
+    }
+    match dispatch {
+        OwnedCatalogDispatch::NotAccepted(error) => {
             drop(staged);
             OwnedRuntimeConfigOutcome::Clean(Err(error))
         }
-        OwnedPeerGroupDispatch::AcceptedReplyLost(error) => {
+        OwnedCatalogDispatch::AcceptedReplyLost(error) => {
             OwnedRuntimeConfigOutcome::Ambiguous(error)
         }
-        OwnedPeerGroupDispatch::Replied(
-            OwnedPeerGroupMutationOutcome::RejectedNoEffect(error)
-            | OwnedPeerGroupMutationOutcome::FullyCompensated(error),
+        OwnedCatalogDispatch::Replied(
+            OwnedCatalogMutationOutcome::RejectedNoEffect(error)
+            | OwnedCatalogMutationOutcome::FullyCompensated(error),
         ) => {
             drop(staged);
             OwnedRuntimeConfigOutcome::Clean(Err(catalog_mutation_error_to_status(&error)))
         }
-        OwnedPeerGroupDispatch::Replied(OwnedPeerGroupMutationOutcome::CompensationAmbiguous(
+        OwnedCatalogDispatch::Replied(OwnedCatalogMutationOutcome::CompensationAmbiguous(
             error,
         )) => OwnedRuntimeConfigOutcome::Ambiguous(catalog_mutation_error_to_status(&error)),
-        OwnedPeerGroupDispatch::Replied(OwnedPeerGroupMutationOutcome::Success) => {
+        OwnedCatalogDispatch::Replied(OwnedCatalogMutationOutcome::Success) => {
             let Some(staged) = staged else {
                 return OwnedRuntimeConfigOutcome::Clean(Ok(()));
             };
-            if let Some(operation) = &owned {
-                operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
-            }
             match staged.commit_typed().await {
                 Ok(()) => OwnedRuntimeConfigOutcome::Clean(Ok(())),
                 Err(error) => OwnedRuntimeConfigOutcome::Ambiguous(error.into_status()),
@@ -1111,8 +1043,8 @@ mod tests {
                         stored.md5_password = Some("secret".into());
                         let _ = reply.send(Some(stored));
                     }
-                    PeerManagerCommand::OwnedPeerGroupMutation {
-                        mutation: OwnedPeerGroupMutation::Set { name, definition },
+                    PeerManagerCommand::OwnedCatalogMutation {
+                        mutation: OwnedCatalogMutation::SetPeerGroup { name, definition },
                         reply,
                     } => {
                         assert_eq!(name, "rs-clients");
@@ -1124,7 +1056,7 @@ mod tests {
                             Some("secret")
                         );
                         assert_eq!(definition.families, vec!["ipv6_unicast"]);
-                        let _ = reply.send(OwnedPeerGroupMutationOutcome::Success);
+                        let _ = reply.send(OwnedCatalogMutationOutcome::Success);
                     }
                     _ => panic!("unexpected peer-manager command"),
                 }
@@ -1199,8 +1131,8 @@ mod tests {
                     PeerManagerCommand::GetPeerGroup { reply, .. } => {
                         let _ = reply.send(None);
                     }
-                    PeerManagerCommand::OwnedPeerGroupMutation {
-                        mutation: OwnedPeerGroupMutation::Set { definition, .. },
+                    PeerManagerCommand::OwnedCatalogMutation {
+                        mutation: OwnedCatalogMutation::SetPeerGroup { definition, .. },
                         reply,
                     } => {
                         assert_eq!(
@@ -1210,7 +1142,7 @@ mod tests {
                                 .map(std::convert::AsRef::as_ref),
                             Some("super-secret")
                         );
-                        let _ = reply.send(OwnedPeerGroupMutationOutcome::Success);
+                        let _ = reply.send(OwnedCatalogMutationOutcome::Success);
                     }
                     _ => panic!("unexpected peer-manager command"),
                 }
@@ -1259,8 +1191,8 @@ mod tests {
                         stored.md5_password = Some("secret".into());
                         let _ = reply.send(Some(stored));
                     }
-                    PeerManagerCommand::OwnedPeerGroupMutation {
-                        mutation: OwnedPeerGroupMutation::Set { name, definition },
+                    PeerManagerCommand::OwnedCatalogMutation {
+                        mutation: OwnedCatalogMutation::SetPeerGroup { name, definition },
                         reply,
                     } => {
                         assert_eq!(name, "rs-clients");
@@ -1271,7 +1203,7 @@ mod tests {
                                 .map(std::convert::AsRef::as_ref),
                             Some("secret")
                         );
-                        let _ = reply.send(OwnedPeerGroupMutationOutcome::Success);
+                        let _ = reply.send(OwnedCatalogMutationOutcome::Success);
                     }
                     _ => panic!("unexpected peer-manager command"),
                 }
@@ -1334,8 +1266,8 @@ mod tests {
         };
         let staged = tokio::spawn(staged.accept());
         match peer_rx.recv().await.expect("expected passwordless create") {
-            PeerManagerCommand::OwnedPeerGroupMutation {
-                mutation: OwnedPeerGroupMutation::Set { name, definition },
+            PeerManagerCommand::OwnedCatalogMutation {
+                mutation: OwnedCatalogMutation::SetPeerGroup { name, definition },
                 reply,
             } => {
                 assert_eq!(name, "ix-members");
@@ -1343,7 +1275,7 @@ mod tests {
                 assert_eq!(definition.families, vec!["ipv4_unicast"]);
                 assert_eq!(definition.route_server_client, Some(true));
                 reply
-                    .send(OwnedPeerGroupMutationOutcome::Success)
+                    .send(OwnedCatalogMutationOutcome::Success)
                     .expect("service dropped create reply");
             }
             _ => panic!("unexpected peer-manager command"),
@@ -1423,13 +1355,13 @@ mod tests {
                     PeerManagerCommand::GetPeerGroup { reply, .. } => {
                         let _ = reply.send(None);
                     }
-                    PeerManagerCommand::OwnedPeerGroupMutation {
-                        mutation: OwnedPeerGroupMutation::Set { name, definition },
+                    PeerManagerCommand::OwnedCatalogMutation {
+                        mutation: OwnedCatalogMutation::SetPeerGroup { name, definition },
                         reply,
                     } => {
                         assert_eq!(name, "rs-clients");
                         assert_eq!(definition.md5_password, None);
-                        let _ = reply.send(OwnedPeerGroupMutationOutcome::Success);
+                        let _ = reply.send(OwnedCatalogMutationOutcome::Success);
                     }
                     _ => panic!("unexpected peer-manager command"),
                 }
@@ -1737,13 +1669,13 @@ mod tests {
         let (call, ack) = staged_delete_call(svc, &mut config_rx).await;
         let staged = tokio::spawn(ack.accept());
         match peer_rx.recv().await.expect("expected owned delete") {
-            PeerManagerCommand::OwnedPeerGroupMutation {
-                mutation: OwnedPeerGroupMutation::Delete { name },
+            PeerManagerCommand::OwnedCatalogMutation {
+                mutation: OwnedCatalogMutation::DeletePeerGroup { name },
                 reply,
             } => {
                 assert_eq!(name, "edge");
                 reply
-                    .send(OwnedPeerGroupMutationOutcome::RejectedNoEffect(
+                    .send(OwnedCatalogMutationOutcome::RejectedNoEffect(
                         crate::peer_types::CatalogMutationError::not_found("missing group"),
                     ))
                     .unwrap();
@@ -1768,9 +1700,9 @@ mod tests {
         let (call, ack) = staged_delete_call(svc, &mut config_rx).await;
         let staged = tokio::spawn(ack.accept());
         match peer_rx.recv().await.expect("expected owned delete") {
-            PeerManagerCommand::OwnedPeerGroupMutation { reply, .. } => {
+            PeerManagerCommand::OwnedCatalogMutation { reply, .. } => {
                 reply
-                    .send(OwnedPeerGroupMutationOutcome::FullyCompensated(
+                    .send(OwnedCatalogMutationOutcome::FullyCompensated(
                         crate::peer_types::CatalogMutationError::internal(
                             "apply failed; prior runtime restored",
                         ),
@@ -1797,7 +1729,7 @@ mod tests {
         let (mut call, ack) = staged_delete_call(svc, &mut config_rx).await;
         let staged = tokio::spawn(ack.accept());
         match peer_rx.recv().await.expect("expected owned delete") {
-            PeerManagerCommand::OwnedPeerGroupMutation { reply, .. } => drop(reply),
+            PeerManagerCommand::OwnedCatalogMutation { reply, .. } => drop(reply),
             _ => panic!("expected owned peer-group delete"),
         }
         assert!(
@@ -1822,8 +1754,8 @@ mod tests {
         let crate::peer_types::ConfigPersistAck { staged, commit } = ack;
         staged.send(Ok(())).unwrap();
         match peer_rx.recv().await.expect("expected owned delete") {
-            PeerManagerCommand::OwnedPeerGroupMutation { reply, .. } => {
-                reply.send(OwnedPeerGroupMutationOutcome::Success).unwrap();
+            PeerManagerCommand::OwnedCatalogMutation { reply, .. } => {
+                reply.send(OwnedCatalogMutationOutcome::Success).unwrap();
             }
             _ => panic!("expected owned peer-group delete"),
         }
@@ -1856,7 +1788,7 @@ mod tests {
         let (call, ack) = staged_delete_call(svc, &mut config_rx).await;
         let crate::peer_types::ConfigPersistAck { staged, commit } = ack;
         staged.send(Ok(())).unwrap();
-        let PeerManagerCommand::OwnedPeerGroupMutation { reply, .. } =
+        let PeerManagerCommand::OwnedCatalogMutation { reply, .. } =
             peer_rx.recv().await.expect("expected owned delete")
         else {
             panic!("expected owned peer-group delete");
@@ -1869,7 +1801,7 @@ mod tests {
                 .is_err(),
             "caller cancellation must not release mutation ownership"
         );
-        reply.send(OwnedPeerGroupMutationOutcome::Success).unwrap();
+        reply.send(OwnedCatalogMutationOutcome::Success).unwrap();
         let commit_reply = commit
             .expect("owned mutation requires commit handshake")
             .await

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -710,10 +710,10 @@ pub enum PeerManagerCommand {
         mutation: OwnedNeighborMutation,
         reply: oneshot::Sender<OwnedNeighborMutationOutcome>,
     },
-    /// Settlement-owned peer-group definition or membership mutation.
-    OwnedPeerGroupMutation {
-        mutation: OwnedPeerGroupMutation,
-        reply: oneshot::Sender<OwnedPeerGroupMutationOutcome>,
+    /// Settlement-owned peer-group or policy-catalog mutation.
+    OwnedCatalogMutation {
+        mutation: OwnedCatalogMutation,
+        reply: oneshot::Sender<OwnedCatalogMutationOutcome>,
     },
     /// Reconfigure an existing static peer by replacing its live session with
     /// a newly resolved configuration.
@@ -1475,27 +1475,63 @@ pub enum OwnedNeighborMutationOutcome {
     CompensationAmbiguous(OwnedNeighborMutationError),
 }
 
-/// One of the four peer-group mutations protected by settlement ownership.
-pub enum OwnedPeerGroupMutation {
-    Set {
+/// One of the catalog mutations protected by settlement ownership.
+pub enum OwnedCatalogMutation {
+    SetPeerGroup {
         name: String,
         definition: Box<PeerGroupDefinition>,
     },
-    Delete {
+    DeletePeerGroup {
         name: String,
     },
-    SetNeighbor {
+    SetNeighborPeerGroup {
         address: IpAddr,
         peer_group: String,
     },
-    ClearNeighbor {
+    ClearNeighborPeerGroup {
+        address: IpAddr,
+    },
+    SetPolicy {
+        name: String,
+        definition: Box<NamedPolicyDefinition>,
+    },
+    DeletePolicy {
+        name: String,
+    },
+    SetNeighborSet {
+        name: String,
+        definition: NeighborSetDefinition,
+    },
+    DeleteNeighborSet {
+        name: String,
+    },
+    SetGlobalImportChain {
+        policy_names: Vec<String>,
+    },
+    SetGlobalExportChain {
+        policy_names: Vec<String>,
+    },
+    ClearGlobalImportChain,
+    ClearGlobalExportChain,
+    SetNeighborImportChain {
+        address: IpAddr,
+        policy_names: Vec<String>,
+    },
+    SetNeighborExportChain {
+        address: IpAddr,
+        policy_names: Vec<String>,
+    },
+    ClearNeighborImportChain {
+        address: IpAddr,
+    },
+    ClearNeighborExportChain {
         address: IpAddr,
     },
 }
 
-/// Actor-owned settlement proof for a peer-group mutation.
+/// Actor-owned settlement proof for a catalog mutation.
 #[derive(Debug)]
-pub enum OwnedPeerGroupMutationOutcome {
+pub enum OwnedCatalogMutationOutcome {
     /// The requested runtime mutation completed.
     Success,
     /// The actor rejected before producing any runtime effect.

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -12,17 +12,25 @@ use tokio::sync::mpsc;
 use tonic::{Request, Response, Status};
 
 use crate::actor_read::{peer_manager_read, rib_manager_read};
+use crate::health_probe::DaemonGate;
 use crate::peer_types::{
-    ConfigEvent, NamedPolicyDefinition, PeerManagerCommand, PolicyStatementDefinition,
+    ConfigEvent, NamedPolicyDefinition, OwnedCatalogMutation, OwnedCatalogMutationOutcome,
+    PeerManagerCommand, PolicyStatementDefinition,
 };
 use crate::policy_helpers::{proto_statement_to_input, validate_policy_action};
 use crate::proto;
+use crate::runtime_config_settlement::{
+    OwnedRuntimeConfigOperation, OwnedRuntimeConfigOutcome, OwnedRuntimeConfigRequestContext,
+    RuntimeConfigOperationKind, RuntimeConfigSettlementPhase, RuntimeConfigSettlementWatchdog,
+};
 use crate::server::{
-    AccessMode, ConfigMutationGateFn, RuntimeConfigCoordinator, apply_catalog_mutation,
-    peer_manager_request, persist_then_apply, read_only_rejection, run_shielded_catalog_mutation,
+    AccessMode, ConfigMutationGateFn, OwnedCatalogDispatch, RuntimeConfigCoordinator,
+    catalog_mutation_error_to_status, check_config_mutation_gate, dispatch_owned_catalog_mutation,
+    read_only_rejection, stage_runtime_config_event_typed, with_catalog_persist_ack,
 };
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
+const OWNED_POLICY_ACTOR_TIMEOUT: Duration = Duration::from_mins(10);
 const POLICY_STATS_AGGREGATE_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Run one policy-stats backend send and reply within the RPC's shared
@@ -302,6 +310,8 @@ pub struct PolicyService {
     /// (ADR-0096 Decision 6). `None` when the service was built
     /// without it — `TestPolicy` then reports `FAILED_PRECONDITION`.
     rib_tx: Option<mpsc::Sender<rustbgpd_rib::RibUpdate>>,
+    settlement: Option<(RuntimeConfigSettlementWatchdog, DaemonGate)>,
+    owned_actor_timeout: Duration,
 }
 
 impl PolicyService {
@@ -340,7 +350,20 @@ impl PolicyService {
             runtime_config_lock,
             config_mutation_gate,
             rib_tx: None,
+            settlement: None,
+            owned_actor_timeout: OWNED_POLICY_ACTOR_TIMEOUT,
         }
+    }
+
+    /// Arm policy catalog mutations with the process-wide fail-stop owner.
+    #[must_use]
+    pub fn with_runtime_config_settlement(
+        mut self,
+        watchdog: RuntimeConfigSettlementWatchdog,
+        daemon_gate: DaemonGate,
+    ) -> Self {
+        self.settlement = Some((watchdog, daemon_gate));
+        self
     }
 
     /// Attach the RIB query channel that backs `TestPolicy`'s
@@ -351,64 +374,134 @@ impl PolicyService {
         self
     }
 
-    /// Run `body` under the ADR-0080 detached-task shield with the
-    /// runtime-config lock held and the transaction gate checked inside
-    /// it (see `server::run_shielded_catalog_mutation`).
-    async fn run_mutation<F, Fut>(&self, operation: &'static str, body: F) -> Result<(), Status>
-    where
-        F: FnOnce() -> Fut + Send + 'static,
-        Fut: std::future::Future<Output = Result<(), Status>> + Send,
-    {
-        run_shielded_catalog_mutation(
-            self.runtime_config_lock.clone(),
-            self.config_mutation_gate.clone(),
-            operation,
-            body,
-        )
-        .await
+    async fn execute_owned_policy_mutation(
+        &self,
+        kind: RuntimeConfigOperationKind,
+        operation_name: &'static str,
+        mutation: OwnedCatalogMutation,
+        event: ConfigEvent,
+        persist_permit: Option<mpsc::OwnedPermit<ConfigEvent>>,
+    ) -> Result<(), Status> {
+        let peer_mgr_tx = self.peer_mgr_tx.clone();
+        let gate = self.config_mutation_gate.clone();
+        let timeout = self.owned_actor_timeout;
+        let settlement = self.settlement.clone();
+        let daemon_gate = settlement.as_ref().map(|(_, gate)| gate.clone());
+        let body = move |owned| async move {
+            owned_policy_mutation_body(
+                owned,
+                daemon_gate,
+                gate,
+                operation_name,
+                peer_mgr_tx,
+                timeout,
+                mutation,
+                event,
+                persist_permit,
+            )
+            .await
+        };
+        let (context, attachment) = OwnedRuntimeConfigRequestContext::unary();
+        let result = if let Some((watchdog, daemon_gate)) = settlement {
+            watchdog
+                .execute_owned(
+                    kind,
+                    self.runtime_config_lock.clone(),
+                    daemon_gate,
+                    context.response_attached(),
+                    move |operation| body(Some(operation)),
+                )
+                .await
+        } else {
+            let coordinator = self.runtime_config_lock.clone();
+            tokio::spawn(async move {
+                let _permit = coordinator.acquire().await?;
+                match body(None).await {
+                    OwnedRuntimeConfigOutcome::Clean(result) => result,
+                    OwnedRuntimeConfigOutcome::Ambiguous(error) => {
+                        let _ = error;
+                        std::future::pending().await
+                    }
+                }
+            })
+            .await
+            .map_err(|_| Status::internal("owned policy mutation task did not complete"))?
+        };
+        drop(attachment);
+        result
     }
 }
 
-async fn set_policy_definition(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    name: String,
-    definition: NamedPolicyDefinition,
-) -> Result<(), Status> {
-    apply_catalog_mutation(peer_mgr_tx, |reply| PeerManagerCommand::SetPolicy {
-        name,
-        definition,
-        reply,
-    })
-    .await
-}
-
-async fn delete_policy_definition(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    name: String,
-) -> Result<(), Status> {
-    apply_catalog_mutation(peer_mgr_tx, |reply| PeerManagerCommand::DeletePolicy {
-        name,
-        reply,
-    })
-    .await
-}
-
-/// Reject a chain mutation for a neighbor that is not configured, without
-/// mutating anything.
-///
-/// The mutators used to discover this from the runtime apply. Staging now
-/// runs first, so the check has to run before it — a request naming an
-/// unknown neighbor is `NOT_FOUND`, not a persistence failure.
-async fn require_configured_neighbor(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    address: IpAddr,
-) -> Result<(), Status> {
-    peer_manager_request(peer_mgr_tx, |reply| {
-        PeerManagerCommand::GetNeighborPolicyChains { address, reply }
-    })
-    .await?
-    .ok_or_else(|| Status::not_found(format!("neighbor {address} not found")))
-    .map(|_| ())
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the owned catalog body exposes every settlement dependency"
+)]
+async fn owned_policy_mutation_body(
+    owned: Option<OwnedRuntimeConfigOperation>,
+    daemon_gate: Option<DaemonGate>,
+    config_mutation_gate: Option<ConfigMutationGateFn>,
+    operation_name: &'static str,
+    peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+    actor_timeout: Duration,
+    mutation: OwnedCatalogMutation,
+    event: ConfigEvent,
+    persist_permit: Option<mpsc::OwnedPermit<ConfigEvent>>,
+) -> OwnedRuntimeConfigOutcome<(), Status> {
+    if daemon_gate.is_some_and(|gate| gate.is_shutting_down()) {
+        return OwnedRuntimeConfigOutcome::Clean(Err(Status::unavailable(format!(
+            "{operation_name} rejected: daemon is shutting down"
+        ))));
+    }
+    if let Err(error) = check_config_mutation_gate(&config_mutation_gate, operation_name).await {
+        return OwnedRuntimeConfigOutcome::Clean(Err(error));
+    }
+    if let Some(operation) = &owned {
+        operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
+    }
+    let staged = if let Some(permit) = persist_permit {
+        match stage_runtime_config_event_typed(permit, |ack| with_catalog_persist_ack(event, ack))
+            .await
+        {
+            Ok(staged) => Some(staged),
+            Err(error) => return OwnedRuntimeConfigOutcome::Clean(Err(error.into_status())),
+        }
+    } else {
+        None
+    };
+    let dispatch = dispatch_owned_catalog_mutation(peer_mgr_tx, actor_timeout, mutation).await;
+    if matches!(dispatch, OwnedCatalogDispatch::Replied(_))
+        && let Some(operation) = &owned
+    {
+        operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
+    }
+    match dispatch {
+        OwnedCatalogDispatch::NotAccepted(error) => {
+            drop(staged);
+            OwnedRuntimeConfigOutcome::Clean(Err(error))
+        }
+        OwnedCatalogDispatch::AcceptedReplyLost(error) => {
+            OwnedRuntimeConfigOutcome::Ambiguous(error)
+        }
+        OwnedCatalogDispatch::Replied(
+            OwnedCatalogMutationOutcome::RejectedNoEffect(error)
+            | OwnedCatalogMutationOutcome::FullyCompensated(error),
+        ) => {
+            drop(staged);
+            OwnedRuntimeConfigOutcome::Clean(Err(catalog_mutation_error_to_status(&error)))
+        }
+        OwnedCatalogDispatch::Replied(OwnedCatalogMutationOutcome::CompensationAmbiguous(
+            error,
+        )) => OwnedRuntimeConfigOutcome::Ambiguous(catalog_mutation_error_to_status(&error)),
+        OwnedCatalogDispatch::Replied(OwnedCatalogMutationOutcome::Success) => {
+            let Some(staged) = staged else {
+                return OwnedRuntimeConfigOutcome::Clean(Ok(()));
+            };
+            match staged.commit_typed().await {
+                Ok(()) => OwnedRuntimeConfigOutcome::Clean(Ok(())),
+                Err(error) => OwnedRuntimeConfigOutcome::Ambiguous(error.into_status()),
+            }
+        }
+    }
 }
 
 /// Reject a policy read for an address that does not resolve to one unique
@@ -491,24 +584,21 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         let definition = proto_definition_to_input(definition)?;
 
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
         let name = req.name;
-        self.run_mutation("PolicyService.SetPolicy", move || async move {
-            // A policy edit re-evaluates live sessions: it rewrites
-            // Adj-RIB-Out and drives a Route Refresh. Stage the write first
-            // so a persistence failure does not put that churn on the wire
-            // and then a second round of it as "rollback".
-            persist_then_apply(
-                persist_permit,
-                |ack| ConfigEvent::SetPolicy {
-                    name: name.clone(),
-                    definition: definition.clone(),
-                    ack: Some(ack),
-                },
-                || set_policy_definition(&peer_mgr_tx, name.clone(), definition.clone()),
-            )
-            .await
-        })
+        self.execute_owned_policy_mutation(
+            RuntimeConfigOperationKind::PolicySet,
+            "PolicyService.SetPolicy",
+            OwnedCatalogMutation::SetPolicy {
+                name: name.clone(),
+                definition: Box::new(definition.clone()),
+            },
+            ConfigEvent::SetPolicy {
+                name,
+                definition,
+                ack: None,
+            },
+            persist_permit,
+        )
         .await?;
 
         Ok(Response::new(proto::SetPolicyResponse {}))
@@ -527,19 +617,14 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         }
 
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
         let name = req.name;
-        self.run_mutation("PolicyService.DeletePolicy", move || async move {
-            persist_then_apply(
-                persist_permit,
-                |ack| ConfigEvent::DeletePolicy {
-                    name: name.clone(),
-                    ack: Some(ack),
-                },
-                || delete_policy_definition(&peer_mgr_tx, name.clone()),
-            )
-            .await
-        })
+        self.execute_owned_policy_mutation(
+            RuntimeConfigOperationKind::PolicyDelete,
+            "PolicyService.DeletePolicy",
+            OwnedCatalogMutation::DeletePolicy { name: name.clone() },
+            ConfigEvent::DeletePolicy { name, ack: None },
+            persist_permit,
+        )
         .await?;
 
         Ok(Response::new(proto::DeletePolicyResponse {}))
@@ -615,28 +700,21 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         };
 
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
         let name = req.name;
-        self.run_mutation("PolicyService.SetNeighborSet", move || async move {
-            persist_then_apply(
-                persist_permit,
-                |ack| ConfigEvent::SetNeighborSet {
-                    name: name.clone(),
-                    definition: definition.clone(),
-                    ack: Some(ack),
-                },
-                || {
-                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                        PeerManagerCommand::SetNeighborSet {
-                            name: name.clone(),
-                            definition: definition.clone(),
-                            reply,
-                        }
-                    })
-                },
-            )
-            .await
-        })
+        self.execute_owned_policy_mutation(
+            RuntimeConfigOperationKind::NeighborSetSet,
+            "PolicyService.SetNeighborSet",
+            OwnedCatalogMutation::SetNeighborSet {
+                name: name.clone(),
+                definition: definition.clone(),
+            },
+            ConfigEvent::SetNeighborSet {
+                name,
+                definition,
+                ack: None,
+            },
+            persist_permit,
+        )
         .await?;
 
         Ok(Response::new(proto::SetNeighborSetResponse {}))
@@ -655,26 +733,14 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         }
 
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
         let name = req.name;
-        self.run_mutation("PolicyService.DeleteNeighborSet", move || async move {
-            persist_then_apply(
-                persist_permit,
-                |ack| ConfigEvent::DeleteNeighborSet {
-                    name: name.clone(),
-                    ack: Some(ack),
-                },
-                || {
-                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                        PeerManagerCommand::DeleteNeighborSet {
-                            name: name.clone(),
-                            reply,
-                        }
-                    })
-                },
-            )
-            .await
-        })
+        self.execute_owned_policy_mutation(
+            RuntimeConfigOperationKind::NeighborSetDelete,
+            "PolicyService.DeleteNeighborSet",
+            OwnedCatalogMutation::DeleteNeighborSet { name: name.clone() },
+            ConfigEvent::DeleteNeighborSet { name, ack: None },
+            persist_permit,
+        )
         .await?;
 
         Ok(Response::new(proto::DeleteNeighborSetResponse {}))
@@ -703,26 +769,19 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         }
         let req = request.into_inner();
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
         let policy_names = req.policy_names;
-        self.run_mutation("PolicyService.SetGlobalImportChain", move || async move {
-            persist_then_apply(
-                persist_permit,
-                |ack| ConfigEvent::SetGlobalImportChain {
-                    policy_names: policy_names.clone(),
-                    ack: Some(ack),
-                },
-                || {
-                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                        PeerManagerCommand::SetGlobalImportChain {
-                            policy_names: policy_names.clone(),
-                            reply,
-                        }
-                    })
-                },
-            )
-            .await
-        })
+        self.execute_owned_policy_mutation(
+            RuntimeConfigOperationKind::GlobalImportChainSet,
+            "PolicyService.SetGlobalImportChain",
+            OwnedCatalogMutation::SetGlobalImportChain {
+                policy_names: policy_names.clone(),
+            },
+            ConfigEvent::SetGlobalImportChain {
+                policy_names,
+                ack: None,
+            },
+            persist_permit,
+        )
         .await?;
 
         Ok(Response::new(proto::SetGlobalImportChainResponse {}))
@@ -737,26 +796,19 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         }
         let req = request.into_inner();
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
         let policy_names = req.policy_names;
-        self.run_mutation("PolicyService.SetGlobalExportChain", move || async move {
-            persist_then_apply(
-                persist_permit,
-                |ack| ConfigEvent::SetGlobalExportChain {
-                    policy_names: policy_names.clone(),
-                    ack: Some(ack),
-                },
-                || {
-                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                        PeerManagerCommand::SetGlobalExportChain {
-                            policy_names: policy_names.clone(),
-                            reply,
-                        }
-                    })
-                },
-            )
-            .await
-        })
+        self.execute_owned_policy_mutation(
+            RuntimeConfigOperationKind::GlobalExportChainSet,
+            "PolicyService.SetGlobalExportChain",
+            OwnedCatalogMutation::SetGlobalExportChain {
+                policy_names: policy_names.clone(),
+            },
+            ConfigEvent::SetGlobalExportChain {
+                policy_names,
+                ack: None,
+            },
+            persist_permit,
+        )
         .await?;
 
         Ok(Response::new(proto::SetGlobalExportChainResponse {}))
@@ -770,19 +822,13 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             return Err(status);
         }
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
-        self.run_mutation("PolicyService.ClearGlobalImportChain", move || async move {
-            persist_then_apply(
-                persist_permit,
-                |ack| ConfigEvent::ClearGlobalImportChain { ack: Some(ack) },
-                || {
-                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                        PeerManagerCommand::ClearGlobalImportChain { reply }
-                    })
-                },
-            )
-            .await
-        })
+        self.execute_owned_policy_mutation(
+            RuntimeConfigOperationKind::GlobalImportChainClear,
+            "PolicyService.ClearGlobalImportChain",
+            OwnedCatalogMutation::ClearGlobalImportChain,
+            ConfigEvent::ClearGlobalImportChain { ack: None },
+            persist_permit,
+        )
         .await?;
 
         Ok(Response::new(proto::ClearGlobalImportChainResponse {}))
@@ -796,19 +842,13 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             return Err(status);
         }
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
-        self.run_mutation("PolicyService.ClearGlobalExportChain", move || async move {
-            persist_then_apply(
-                persist_permit,
-                |ack| ConfigEvent::ClearGlobalExportChain { ack: Some(ack) },
-                || {
-                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                        PeerManagerCommand::ClearGlobalExportChain { reply }
-                    })
-                },
-            )
-            .await
-        })
+        self.execute_owned_policy_mutation(
+            RuntimeConfigOperationKind::GlobalExportChainClear,
+            "PolicyService.ClearGlobalExportChain",
+            OwnedCatalogMutation::ClearGlobalExportChain,
+            ConfigEvent::ClearGlobalExportChain { ack: None },
+            persist_permit,
+        )
         .await?;
 
         Ok(Response::new(proto::ClearGlobalExportChainResponse {}))
@@ -848,29 +888,21 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
         let policy_names = req.policy_names;
-        self.run_mutation("PolicyService.SetNeighborImportChain", move || async move {
-            require_configured_neighbor(&peer_mgr_tx, address).await?;
-            persist_then_apply(
-                persist_permit,
-                |ack| ConfigEvent::SetNeighborImportChain {
-                    address,
-                    policy_names: policy_names.clone(),
-                    ack: Some(ack),
-                },
-                || {
-                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                        PeerManagerCommand::SetNeighborImportChain {
-                            address,
-                            policy_names: policy_names.clone(),
-                            reply,
-                        }
-                    })
-                },
-            )
-            .await
-        })
+        self.execute_owned_policy_mutation(
+            RuntimeConfigOperationKind::NeighborImportChainSet,
+            "PolicyService.SetNeighborImportChain",
+            OwnedCatalogMutation::SetNeighborImportChain {
+                address,
+                policy_names: policy_names.clone(),
+            },
+            ConfigEvent::SetNeighborImportChain {
+                address,
+                policy_names,
+                ack: None,
+            },
+            persist_permit,
+        )
         .await?;
 
         Ok(Response::new(proto::SetNeighborImportChainResponse {}))
@@ -889,29 +921,21 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
         let policy_names = req.policy_names;
-        self.run_mutation("PolicyService.SetNeighborExportChain", move || async move {
-            require_configured_neighbor(&peer_mgr_tx, address).await?;
-            persist_then_apply(
-                persist_permit,
-                |ack| ConfigEvent::SetNeighborExportChain {
-                    address,
-                    policy_names: policy_names.clone(),
-                    ack: Some(ack),
-                },
-                || {
-                    apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                        PeerManagerCommand::SetNeighborExportChain {
-                            address,
-                            policy_names: policy_names.clone(),
-                            reply,
-                        }
-                    })
-                },
-            )
-            .await
-        })
+        self.execute_owned_policy_mutation(
+            RuntimeConfigOperationKind::NeighborExportChainSet,
+            "PolicyService.SetNeighborExportChain",
+            OwnedCatalogMutation::SetNeighborExportChain {
+                address,
+                policy_names: policy_names.clone(),
+            },
+            ConfigEvent::SetNeighborExportChain {
+                address,
+                policy_names,
+                ack: None,
+            },
+            persist_permit,
+        )
         .await?;
 
         Ok(Response::new(proto::SetNeighborExportChainResponse {}))
@@ -930,25 +954,12 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
-        self.run_mutation(
+        self.execute_owned_policy_mutation(
+            RuntimeConfigOperationKind::NeighborImportChainClear,
             "PolicyService.ClearNeighborImportChain",
-            move || async move {
-                require_configured_neighbor(&peer_mgr_tx, address).await?;
-                persist_then_apply(
-                    persist_permit,
-                    |ack| ConfigEvent::ClearNeighborImportChain {
-                        address,
-                        ack: Some(ack),
-                    },
-                    || {
-                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                            PeerManagerCommand::ClearNeighborImportChain { address, reply }
-                        })
-                    },
-                )
-                .await
-            },
+            OwnedCatalogMutation::ClearNeighborImportChain { address },
+            ConfigEvent::ClearNeighborImportChain { address, ack: None },
+            persist_permit,
         )
         .await?;
 
@@ -968,25 +979,12 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
         let persist_permit = reserve_config_event_slot(self.config_tx.clone()).await?;
-        let peer_mgr_tx = self.peer_mgr_tx.clone();
-        self.run_mutation(
+        self.execute_owned_policy_mutation(
+            RuntimeConfigOperationKind::NeighborExportChainClear,
             "PolicyService.ClearNeighborExportChain",
-            move || async move {
-                require_configured_neighbor(&peer_mgr_tx, address).await?;
-                persist_then_apply(
-                    persist_permit,
-                    |ack| ConfigEvent::ClearNeighborExportChain {
-                        address,
-                        ack: Some(ack),
-                    },
-                    || {
-                        apply_catalog_mutation(&peer_mgr_tx, |reply| {
-                            PeerManagerCommand::ClearNeighborExportChain { address, reply }
-                        })
-                    },
-                )
-                .await
-            },
+            OwnedCatalogMutation::ClearNeighborExportChain { address },
+            ConfigEvent::ClearNeighborExportChain { address, ack: None },
+            persist_permit,
         )
         .await?;
 
@@ -2332,18 +2330,14 @@ mod tests {
         tokio::spawn(async move {
             while let Some(cmd) = peer_rx.recv().await {
                 match cmd {
-                    PeerManagerCommand::GetPolicy { reply, .. } => {
-                        let _ = reply.send(None);
-                    }
-                    PeerManagerCommand::SetPolicy {
-                        name,
-                        definition,
+                    PeerManagerCommand::OwnedCatalogMutation {
+                        mutation: OwnedCatalogMutation::SetPolicy { name, definition },
                         reply,
                     } => {
                         assert_eq!(name, "tag-internal");
                         assert_eq!(definition.default_action, "permit");
                         assert_eq!(definition.statements.len(), 1);
-                        let _ = reply.send(Ok(()));
+                        let _ = reply.send(OwnedCatalogMutationOutcome::Success);
                     }
                     _ => panic!("unexpected peer-manager command"),
                 }
@@ -2621,19 +2615,18 @@ mod tests {
         tokio::spawn(async move {
             while let Some(cmd) = peer_rx.recv().await {
                 match cmd {
-                    PeerManagerCommand::GetPolicy { reply, .. } => {
-                        let _ = reply.send(Some(NamedPolicyDefinition {
-                            default_action: "permit".to_string(),
-                            statements: Vec::new(),
-                        }));
-                    }
-                    PeerManagerCommand::DeletePolicy { name, reply } => {
+                    PeerManagerCommand::OwnedCatalogMutation {
+                        mutation: OwnedCatalogMutation::DeletePolicy { name },
+                        reply,
+                    } => {
                         assert_eq!(name, "tag-internal");
-                        let _ = reply.send(Err(CatalogMutationError::StillReferenced {
-                            kind: "policy",
-                            name: "tag-internal".into(),
-                            references: vec!["global import_chain".into()],
-                        }));
+                        let _ = reply.send(OwnedCatalogMutationOutcome::RejectedNoEffect(
+                            CatalogMutationError::StillReferenced {
+                                kind: "policy",
+                                name: "tag-internal".into(),
+                                references: vec!["global import_chain".into()],
+                            },
+                        ));
                     }
                     _ => panic!("unexpected peer-manager command"),
                 }
@@ -3689,5 +3682,90 @@ policy customer-in(peer_lp: u32) {
             0,
             "validation must reject before querying the RIB"
         );
+    }
+
+    async fn staged_policy_delete(
+        svc: PolicyService,
+        config_rx: &mut mpsc::Receiver<ConfigEvent>,
+    ) -> (
+        tokio::task::JoinHandle<Result<Response<proto::DeletePolicyResponse>, Status>>,
+        crate::peer_types::ConfigPersistAck,
+    ) {
+        let call = tokio::spawn(async move {
+            PolicyServiceRpc::delete_policy(
+                &svc,
+                Request::new(proto::DeletePolicyRequest {
+                    name: "edge-policy".into(),
+                }),
+            )
+            .await
+        });
+        let ack = match config_rx
+            .recv()
+            .await
+            .expect("expected staged policy delete")
+        {
+            ConfigEvent::DeletePolicy { name, ack } => {
+                assert_eq!(name, "edge-policy");
+                ack.expect("owned policy delete must use two-phase persistence")
+            }
+            _ => panic!("expected DeletePolicy"),
+        };
+        (call, ack)
+    }
+
+    #[tokio::test]
+    async fn owned_policy_actor_reply_loss_parks_without_response() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(4);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+        let (mut call, ack) = staged_policy_delete(svc, &mut config_rx).await;
+        let staged = tokio::spawn(ack.accept());
+        match peer_rx.recv().await.expect("expected owned policy delete") {
+            PeerManagerCommand::OwnedCatalogMutation {
+                mutation: OwnedCatalogMutation::DeletePolicy { name },
+                reply,
+            } => {
+                assert_eq!(name, "edge-policy");
+                drop(reply);
+            }
+            _ => panic!("expected owned policy delete"),
+        }
+        assert!(!staged.await.unwrap(), "reply loss must discard the stage");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut call)
+                .await
+                .is_err(),
+            "accepted actor reply loss must never produce an RPC response"
+        );
+        call.abort();
+    }
+
+    #[tokio::test]
+    async fn owned_policy_commit_ack_loss_parks_without_response() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(4);
+        let (config_tx, mut config_rx) = mpsc::channel(4);
+        let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
+        let (mut call, ack) = staged_policy_delete(svc, &mut config_rx).await;
+        let crate::peer_types::ConfigPersistAck { staged, commit } = ack;
+        staged.send(Ok(())).unwrap();
+        match peer_rx.recv().await.expect("expected owned policy delete") {
+            PeerManagerCommand::OwnedCatalogMutation { reply, .. } => {
+                reply.send(OwnedCatalogMutationOutcome::Success).unwrap();
+            }
+            _ => panic!("expected owned policy delete"),
+        }
+        let reply = commit
+            .expect("owned policy mutation requires commit handshake")
+            .await
+            .expect("runtime owner must hand off commit acknowledgement");
+        drop(reply);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut call)
+                .await
+                .is_err(),
+            "lost commit acknowledgement must never produce an RPC response"
+        );
+        call.abort();
     }
 }

--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -36,6 +36,18 @@ pub enum RuntimeConfigOperationKind {
     PeerGroupDelete,
     NeighborPeerGroupSet,
     NeighborPeerGroupClear,
+    PolicySet,
+    PolicyDelete,
+    NeighborSetSet,
+    NeighborSetDelete,
+    GlobalImportChainSet,
+    GlobalExportChainSet,
+    GlobalImportChainClear,
+    GlobalExportChainClear,
+    NeighborImportChainSet,
+    NeighborExportChainSet,
+    NeighborImportChainClear,
+    NeighborExportChainClear,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -42,7 +42,8 @@ use crate::injection_service::InjectionService;
 use crate::neighbor_service::NeighborService;
 use crate::peer_group_service::PeerGroupService;
 use crate::peer_types::{
-    CatalogMutationError, ConfigEvent, PeerManagerCommand, PeerManagerReadinessQuery,
+    CatalogMutationError, ConfigEvent, ConfigPersistAck, OwnedCatalogMutation,
+    OwnedCatalogMutationOutcome, PeerManagerCommand, PeerManagerReadinessQuery,
 };
 use crate::policy_service::PolicyService;
 use crate::proto::bfd_service_server::BfdServiceServer;
@@ -588,19 +589,6 @@ pub(crate) struct StagedConfigWrite {
 }
 
 impl StagedConfigWrite {
-    /// Publish the staged write. Call only once the runtime change landed.
-    ///
-    /// # Errors
-    ///
-    /// Returns `INTERNAL` if publishing fails after the runtime change was
-    /// already applied: runtime and disk have drifted and only SIGHUP or a
-    /// restart reconciles them.
-    pub(crate) async fn commit(self) -> Result<(), Status> {
-        self.commit_typed()
-            .await
-            .map_err(RuntimeConfigCommitError::into_status)
-    }
-
     /// Publish a staged write with a typed post-runtime result.
     pub(crate) async fn commit_typed(self) -> Result<(), RuntimeConfigCommitError> {
         let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
@@ -680,18 +668,8 @@ const COMMIT_LOST: &str = "config bridge dropped the staged config write after t
 ///
 /// # Errors
 ///
-/// Returns `FAILED_PRECONDITION` when the candidate cannot be written. The
+/// Returns a typed staging error when the candidate cannot be written. The
 /// caller has not mutated anything at that point, and must not.
-pub(crate) async fn stage_runtime_config_event(
-    permit: tokio::sync::mpsc::OwnedPermit<crate::peer_types::ConfigEvent>,
-    build_event: impl FnOnce(crate::peer_types::ConfigPersistAck) -> crate::peer_types::ConfigEvent,
-) -> Result<StagedConfigWrite, Status> {
-    stage_runtime_config_event_typed(permit, build_event)
-        .await
-        .map_err(RuntimeConfigStageError::into_status)
-}
-
-/// Typed form of [`stage_runtime_config_event`] for settlement owners.
 pub(crate) async fn stage_runtime_config_event_typed(
     permit: tokio::sync::mpsc::OwnedPermit<crate::peer_types::ConfigEvent>,
     build_event: impl FnOnce(crate::peer_types::ConfigPersistAck) -> crate::peer_types::ConfigEvent,
@@ -716,66 +694,6 @@ pub(crate) async fn stage_runtime_config_event_typed(
     Ok(StagedConfigWrite { commit_tx })
 }
 
-/// Stage a runtime-config event, run `apply`, then publish the write.
-///
-/// A staging failure returns before `apply` runs at all; an `apply` failure
-/// drops the stage, so the config file is never written. `persist_permit` is
-/// `None` when the daemon has no config file to persist to, in which case
-/// only `apply` runs.
-pub(crate) async fn persist_then_apply<F, Fut>(
-    persist_permit: Option<tokio::sync::mpsc::OwnedPermit<crate::peer_types::ConfigEvent>>,
-    build_event: impl FnOnce(crate::peer_types::ConfigPersistAck) -> crate::peer_types::ConfigEvent,
-    apply: F,
-) -> Result<(), Status>
-where
-    F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = Result<(), Status>>,
-{
-    let Some(permit) = persist_permit else {
-        return apply().await;
-    };
-    let staged = stage_runtime_config_event(permit, build_event).await?;
-    // `staged` drops here on an apply failure, discarding the write.
-    apply().await?;
-    staged.commit().await
-}
-
-/// Run a persisted catalog mutation on a detached task: take the shared
-/// runtime-config lock, check the config-transaction mutation gate
-/// inside it, then run `body` (read prior state, apply, persist with
-/// acknowledgement, roll back on persist failure).
-///
-/// The detached task is the ADR-0080 cancellation shield — a client
-/// that disconnects mid-RPC loses only the response, never the
-/// runtime-vs-disk consistency of the mutation. Holding the lock across
-/// the body serializes catalog mutations with SIGHUP reload, FIB-table
-/// and neighbor CRUD, and config transactions; it also makes the
-/// read-prior-then-apply sequence inside `body` race-free, because
-/// every catalog writer takes this same lock.
-///
-/// # Errors
-///
-/// Returns the gate's `FAILED_PRECONDITION`, the body's error, or
-/// `INTERNAL` if the detached task is lost.
-pub(crate) async fn run_shielded_catalog_mutation<F, Fut>(
-    runtime_config_lock: RuntimeConfigCoordinator,
-    config_mutation_gate: Option<ConfigMutationGateFn>,
-    operation: &'static str,
-    body: F,
-) -> Result<(), Status>
-where
-    F: FnOnce() -> Fut + Send + 'static,
-    Fut: std::future::Future<Output = Result<(), Status>> + Send,
-{
-    let join = tokio::spawn(async move {
-        let _guard = runtime_config_lock.acquire().await?;
-        check_config_mutation_gate(&config_mutation_gate, operation).await?;
-        body().await
-    });
-    join.await
-        .map_err(|_| Status::internal(format!("{operation} task did not complete")))?
-}
-
 /// Server-side deadline for every peer-manager mutation request.
 ///
 /// Reads share a 2 s bound (`actor_read::PEER_MANAGER_READ_TIMEOUT`)
@@ -787,11 +705,7 @@ where
 /// occupancy at ~70 s plus a 133–145 s commit fan-out — roughly 215 s
 /// daemon-side for one legitimate pass. 600 s keeps ~3x headroom over
 /// that worst receipt while still converting a wedged actor into
-/// `DEADLINE_EXCEEDED`. That bound matters doubly here: the mutation
-/// callers run inside `run_shielded_catalog_mutation`, whose detached
-/// task holds the daemon-wide runtime-config lock and outlives client
-/// cancellation, so an unbounded await wedges every catalog mutation,
-/// SIGHUP reload, and config transaction until daemon restart.
+/// `DEADLINE_EXCEEDED`.
 const PEER_MANAGER_MUTATION_TIMEOUT: Duration = Duration::from_mins(10);
 
 /// Send a peer-manager command built around a oneshot reply channel and
@@ -821,15 +735,144 @@ pub(crate) async fn peer_manager_request<R>(
     .map_err(|_| Status::deadline_exceeded("peer manager mutation timed out"))?
 }
 
-/// Send a catalog mutation command to the peer manager and map its
-/// typed failure onto the gRPC status surface.
-pub(crate) async fn apply_catalog_mutation(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    build_command: impl FnOnce(oneshot::Sender<Result<(), CatalogMutationError>>) -> PeerManagerCommand,
-) -> Result<(), Status> {
-    peer_manager_request(peer_mgr_tx, build_command)
-        .await?
-        .map_err(|error| catalog_mutation_error_to_status(&error))
+pub(crate) enum OwnedCatalogDispatch {
+    NotAccepted(Status),
+    Replied(OwnedCatalogMutationOutcome),
+    AcceptedReplyLost(Status),
+}
+
+/// Dispatch one settlement-owned catalog mutation with transport acceptance
+/// kept distinct from loss of the actor's typed reply.
+pub(crate) async fn dispatch_owned_catalog_mutation(
+    peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+    timeout: Duration,
+    mutation: OwnedCatalogMutation,
+) -> OwnedCatalogDispatch {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let command = PeerManagerCommand::OwnedCatalogMutation {
+        mutation,
+        reply: reply_tx,
+    };
+    match tokio::time::timeout(timeout, peer_mgr_tx.send(command)).await {
+        Err(_) => OwnedCatalogDispatch::NotAccepted(Status::unavailable(
+            "peer manager mutation queue timed out before accepting command",
+        )),
+        Ok(Err(_)) => OwnedCatalogDispatch::NotAccepted(Status::unavailable(
+            "peer manager unavailable before accepting command",
+        )),
+        Ok(Ok(())) => match tokio::time::timeout(timeout, reply_rx).await {
+            Err(_) => OwnedCatalogDispatch::AcceptedReplyLost(Status::deadline_exceeded(
+                "peer manager accepted owned catalog mutation but reply timed out",
+            )),
+            Ok(Err(_)) => OwnedCatalogDispatch::AcceptedReplyLost(Status::internal(
+                "peer manager accepted owned catalog mutation but dropped its reply",
+            )),
+            Ok(Ok(outcome)) => OwnedCatalogDispatch::Replied(outcome),
+        },
+    }
+}
+
+/// Attach a two-phase persistence acknowledgement to any owned catalog event.
+pub(crate) fn with_catalog_persist_ack(event: ConfigEvent, ack: ConfigPersistAck) -> ConfigEvent {
+    match event {
+        ConfigEvent::SetPolicy {
+            name, definition, ..
+        } => ConfigEvent::SetPolicy {
+            name,
+            definition,
+            ack: Some(ack),
+        },
+        ConfigEvent::DeletePolicy { name, .. } => ConfigEvent::DeletePolicy {
+            name,
+            ack: Some(ack),
+        },
+        ConfigEvent::SetNeighborSet {
+            name, definition, ..
+        } => ConfigEvent::SetNeighborSet {
+            name,
+            definition,
+            ack: Some(ack),
+        },
+        ConfigEvent::DeleteNeighborSet { name, .. } => ConfigEvent::DeleteNeighborSet {
+            name,
+            ack: Some(ack),
+        },
+        ConfigEvent::SetGlobalImportChain { policy_names, .. } => {
+            ConfigEvent::SetGlobalImportChain {
+                policy_names,
+                ack: Some(ack),
+            }
+        }
+        ConfigEvent::SetGlobalExportChain { policy_names, .. } => {
+            ConfigEvent::SetGlobalExportChain {
+                policy_names,
+                ack: Some(ack),
+            }
+        }
+        ConfigEvent::ClearGlobalImportChain { .. } => {
+            ConfigEvent::ClearGlobalImportChain { ack: Some(ack) }
+        }
+        ConfigEvent::ClearGlobalExportChain { .. } => {
+            ConfigEvent::ClearGlobalExportChain { ack: Some(ack) }
+        }
+        ConfigEvent::SetNeighborImportChain {
+            address,
+            policy_names,
+            ..
+        } => ConfigEvent::SetNeighborImportChain {
+            address,
+            policy_names,
+            ack: Some(ack),
+        },
+        ConfigEvent::SetNeighborExportChain {
+            address,
+            policy_names,
+            ..
+        } => ConfigEvent::SetNeighborExportChain {
+            address,
+            policy_names,
+            ack: Some(ack),
+        },
+        ConfigEvent::ClearNeighborImportChain { address, .. } => {
+            ConfigEvent::ClearNeighborImportChain {
+                address,
+                ack: Some(ack),
+            }
+        }
+        ConfigEvent::ClearNeighborExportChain { address, .. } => {
+            ConfigEvent::ClearNeighborExportChain {
+                address,
+                ack: Some(ack),
+            }
+        }
+        ConfigEvent::SetPeerGroup {
+            name, definition, ..
+        } => ConfigEvent::SetPeerGroup {
+            name,
+            definition,
+            ack: Some(ack),
+        },
+        ConfigEvent::DeletePeerGroup { name, .. } => ConfigEvent::DeletePeerGroup {
+            name,
+            ack: Some(ack),
+        },
+        ConfigEvent::SetNeighborPeerGroup {
+            address,
+            peer_group,
+            ..
+        } => ConfigEvent::SetNeighborPeerGroup {
+            address,
+            peer_group,
+            ack: Some(ack),
+        },
+        ConfigEvent::ClearNeighborPeerGroup { address, .. } => {
+            ConfigEvent::ClearNeighborPeerGroup {
+                address,
+                ack: Some(ack),
+            }
+        }
+        _ => unreachable!("owned catalog mutation produced a non-catalog event"),
+    }
 }
 
 /// Configuration for the gRPC server beyond basic connectivity.
@@ -1705,7 +1748,7 @@ async fn run_tcp_listener(
             config_mutation_gate.clone(),
             runtime_config_lock.clone(),
         )
-        .with_runtime_config_settlement(runtime_config_settlement, daemon_gate),
+        .with_runtime_config_settlement(runtime_config_settlement.clone(), daemon_gate.clone()),
         interceptor.clone(),
     ));
     routes.add_service(PolicyServiceServer::with_interceptor(
@@ -1716,6 +1759,7 @@ async fn run_tcp_listener(
             config_mutation_gate.clone(),
             runtime_config_lock,
         )
+        .with_runtime_config_settlement(runtime_config_settlement, daemon_gate)
         .with_rib_query(rib_query_tx.clone()),
         interceptor.clone(),
     ));
@@ -1933,7 +1977,7 @@ async fn run_uds_listener(
             config_mutation_gate.clone(),
             runtime_config_lock.clone(),
         )
-        .with_runtime_config_settlement(runtime_config_settlement, daemon_gate),
+        .with_runtime_config_settlement(runtime_config_settlement.clone(), daemon_gate.clone()),
         interceptor.clone(),
     ));
     routes.add_service(PolicyServiceServer::with_interceptor(
@@ -1944,6 +1988,7 @@ async fn run_uds_listener(
             config_mutation_gate.clone(),
             runtime_config_lock,
         )
+        .with_runtime_config_settlement(runtime_config_settlement, daemon_gate)
         .with_rib_query(rib_query_tx.clone()),
         interceptor.clone(),
     ));
@@ -2168,23 +2213,6 @@ mod tests {
         assert_eq!(order_rx.recv().await, Some(0));
         assert_eq!(order_rx.recv().await, Some(1));
         assert_eq!(order_rx.recv().await, Some(2));
-    }
-
-    #[tokio::test]
-    async fn closed_coordinator_rejects_catalog_before_body() {
-        let coordinator = RuntimeConfigCoordinator::new();
-        coordinator.close();
-        let body_ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let body_ran_task = body_ran.clone();
-        let result =
-            run_shielded_catalog_mutation(coordinator, None, "test.closed", move || async move {
-                body_ran_task.store(true, std::sync::atomic::Ordering::SeqCst);
-                Ok(())
-            })
-            .await;
-
-        assert_eq!(result.unwrap_err().code(), tonic::Code::Unavailable);
-        assert!(!body_ran.load(std::sync::atomic::Ordering::SeqCst));
     }
 
     #[test]
@@ -2593,67 +2621,5 @@ mod tests {
         assert_eq!(result.unwrap_err().code(), tonic::Code::DeadlineExceeded);
         // Held so the command is accepted but never answered.
         drop(rx);
-    }
-
-    /// The timeout must propagate out of the shielded body so the
-    /// detached task finishes and drops the runtime-config lock guard.
-    /// A timeout that leaked the lock would leave the second mutation
-    /// parked on `lock().await` until this test's own guard expires.
-    #[tokio::test(start_paused = true)]
-    async fn catalog_mutation_after_peer_manager_timeout_acquires_coordinator() {
-        let coordinator = RuntimeConfigCoordinator::new();
-        let (tx, mut rx) = mpsc::channel(2);
-        let responder = tokio::spawn(async move {
-            // First mutation: accept the command but never answer it, so
-            // the shielded body can only finish via the server-side
-            // deadline. Holding the command keeps its reply sender alive.
-            let wedged = rx.recv().await.expect("first command");
-            // Second mutation: answer promptly.
-            match rx.recv().await.expect("second command") {
-                PeerManagerCommand::DeletePeerGroup { reply, .. } => {
-                    let _ = reply.send(Ok(()));
-                }
-                _ => panic!("unexpected command"),
-            }
-            drop(wedged);
-        });
-
-        let wedged_tx = tx.clone();
-        let first = tokio::time::timeout(
-            Duration::from_hours(1),
-            run_shielded_catalog_mutation(
-                coordinator.clone(),
-                None,
-                "test.wedged",
-                move || async move {
-                    apply_catalog_mutation(&wedged_tx, |reply| {
-                        PeerManagerCommand::DeletePeerGroup {
-                            name: "wedged".into(),
-                            reply,
-                        }
-                    })
-                    .await
-                },
-            ),
-        )
-        .await
-        .expect("catalog mutation must be bounded server-side");
-        assert_eq!(first.unwrap_err().code(), tonic::Code::DeadlineExceeded);
-
-        let healthy_tx = tx.clone();
-        let second = tokio::time::timeout(
-            Duration::from_secs(5),
-            run_shielded_catalog_mutation(coordinator, None, "test.healthy", move || async move {
-                apply_catalog_mutation(&healthy_tx, |reply| PeerManagerCommand::DeletePeerGroup {
-                    name: "healthy".into(),
-                    reply,
-                })
-                .await
-            }),
-        )
-        .await
-        .expect("timed-out mutation must release the runtime-config lock");
-        second.expect("second mutation must succeed after the first times out");
-        responder.await.expect("responder task");
     }
 }

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -4097,13 +4097,13 @@ remote_asn = 65002
             (fib, ".acquire()", 2),
             (neighbor, "self.execute_owned_neighbor_mutation(", 4),
             (neighbor, "reserve_config_event_slot(self.config_tx.clone()).await?", 4),
-            (server, "runtime_config_lock.acquire()", 1),
-            (server, ".with_runtime_config_settlement(", 4),
+            (server, "runtime_config_lock.acquire()", 0),
+            (server, ".with_runtime_config_settlement(", 6),
             (server, "PeerGroupService::with_runtime_config_coordinator(", 2),
             (peer_group, "self.execute_owned_peer_group_mutation(", 4),
             (peer_group, "reserve_config_event_slot(self.config_tx.clone()).await?", 4),
-            (policy, "run_shielded_catalog_mutation(", 1),
-            (policy, "self.run_mutation(", 12),
+            (policy, "self.execute_owned_policy_mutation(", 12),
+            (policy, "reserve_config_event_slot(self.config_tx.clone()).await?", 12),
         ];
         for (source, shape, count) in inventory {
             assert_eq!(source.matches(shape).count(), count, "{shape}");
@@ -4129,6 +4129,33 @@ remote_asn = 65002
                     .count(),
                 1,
                 "Neighbor4 settlement registration inventory for {kind}"
+            );
+            assert_eq!(
+                settlement.matches(&format!("    {kind},")).count(),
+                1,
+                "closed operation-kind roster for {kind}"
+            );
+        }
+        for kind in [
+            "PolicySet",
+            "PolicyDelete",
+            "NeighborSetSet",
+            "NeighborSetDelete",
+            "GlobalImportChainSet",
+            "GlobalExportChainSet",
+            "GlobalImportChainClear",
+            "GlobalExportChainClear",
+            "NeighborImportChainSet",
+            "NeighborExportChainSet",
+            "NeighborImportChainClear",
+            "NeighborExportChainClear",
+        ] {
+            assert_eq!(
+                policy
+                    .matches(&format!("RuntimeConfigOperationKind::{kind}"))
+                    .count(),
+                1,
+                "Policy12 settlement registration inventory for {kind}"
             );
             assert_eq!(
                 settlement.matches(&format!("    {kind},")).count(),
@@ -4224,7 +4251,7 @@ remote_asn = 65002
             .find("stage_runtime_config_event_typed(")
             .unwrap();
         let actor = owned_peer_group_body
-            .find("dispatch_owned_peer_group_mutation(")
+            .find("dispatch_owned_catalog_mutation(")
             .unwrap();
         let settling = owned_peer_group_body
             .find("advance_phase(RuntimeConfigSettlementPhase::SettlingRollback)")
@@ -4242,10 +4269,54 @@ remote_asn = 65002
         }
         assert_eq!(
             peer_manager
-                .matches("PeerManagerCommand::OwnedPeerGroupMutation")
+                .matches("PeerManagerCommand::OwnedCatalogMutation")
                 .count(),
             1
         );
+        let owned_policy_body = policy
+            .split_once("async fn owned_policy_mutation_body")
+            .unwrap()
+            .1
+            .split_once("async fn require_managed_peer_address")
+            .unwrap()
+            .0;
+        assert!(!owned_policy_body.contains(".code()"));
+        assert!(!owned_policy_body.contains(".message()"));
+        assert!(!owned_policy_body.contains("to_string().contains"));
+        let gate = owned_policy_body
+            .find("check_config_mutation_gate(")
+            .unwrap();
+        let mutating = owned_policy_body
+            .find("advance_phase(RuntimeConfigSettlementPhase::Mutating)")
+            .unwrap();
+        let stage = owned_policy_body
+            .find("stage_runtime_config_event_typed(")
+            .unwrap();
+        let actor = owned_policy_body
+            .find("dispatch_owned_catalog_mutation(")
+            .unwrap();
+        let settling = owned_policy_body
+            .find("advance_phase(RuntimeConfigSettlementPhase::SettlingRollback)")
+            .unwrap();
+        let commit = owned_policy_body.find("staged.commit_typed()").unwrap();
+        assert!(gate < mutating && mutating < stage && stage < actor);
+        assert!(actor < settling && settling < commit);
+        for legacy in [
+            "PeerManagerCommand::SetPolicy",
+            "PeerManagerCommand::DeletePolicy",
+            "PeerManagerCommand::SetNeighborSet",
+            "PeerManagerCommand::DeleteNeighborSet",
+            "PeerManagerCommand::SetGlobalImportChain",
+            "PeerManagerCommand::SetGlobalExportChain",
+            "PeerManagerCommand::ClearGlobalImportChain",
+            "PeerManagerCommand::ClearGlobalExportChain",
+            "PeerManagerCommand::SetNeighborImportChain",
+            "PeerManagerCommand::SetNeighborExportChain",
+            "PeerManagerCommand::ClearNeighborImportChain",
+            "PeerManagerCommand::ClearNeighborExportChain",
+        ] {
+            assert!(!policy.contains(legacy), "Policy12 bypass: {legacy}");
+        }
 
         #[rustfmt::skip]
         let prohibited_apis = ["add_permits", "forget", "acquire_many", "wait_idle", "reopen", "pub fn reset", "impl Default for RuntimeConfigCoordinator"];

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -5,11 +5,11 @@ use std::time::{Duration, Instant};
 
 use futures::stream::{self, StreamExt};
 use rustbgpd_api::peer_types::{
-    ConfigEvent, DynamicNeighborInfo, OwnedNeighborMutation, OwnedNeighborMutationError,
-    OwnedNeighborMutationOutcome, OwnedPeerGroupMutation, OwnedPeerGroupMutationOutcome,
-    POLICY_EVENT_HISTORY_CAPACITY, PeerKey, PeerManagerCommand, PeerManagerNeighborConfig,
-    PeerManagerReadinessQuery, PolicyDatasetStatusRow, PolicyEvent, SESSION_EVENT_HISTORY_CAPACITY,
-    SessionEvent, SessionLifecycleEvent, StageConfigSnapshotError,
+    ConfigEvent, DynamicNeighborInfo, OwnedCatalogMutation, OwnedNeighborMutation,
+    OwnedNeighborMutationError, OwnedNeighborMutationOutcome, POLICY_EVENT_HISTORY_CAPACITY,
+    PeerKey, PeerManagerCommand, PeerManagerNeighborConfig, PeerManagerReadinessQuery,
+    PolicyDatasetStatusRow, PolicyEvent, SESSION_EVENT_HISTORY_CAPACITY, SessionEvent,
+    SessionLifecycleEvent, StageConfigSnapshotError,
 };
 use rustbgpd_bmp::BmpEvent;
 use rustbgpd_fsm::PeerConfig;
@@ -1012,24 +1012,16 @@ impl PeerManager {
                             };
                             let _ = reply.send(outcome);
                         }
-                        PeerManagerCommand::OwnedPeerGroupMutation { mutation, reply } => {
+                        PeerManagerCommand::OwnedCatalogMutation { mutation, reply } => {
                             let outcome = match mutation {
-                                OwnedPeerGroupMutation::Set { name, definition } => {
+                                OwnedCatalogMutation::SetPeerGroup { name, definition } => {
                                     let event = ConfigEvent::SetPeerGroup {
                                         name: name.clone(),
                                         definition: (*definition).clone(),
                                         ack: None,
                                     };
                                     if self.peer_group_policy_only_update(&name, &definition) {
-                                        match self.apply_policy_change(event, None).await {
-                                            Ok(()) => OwnedPeerGroupMutationOutcome::Success,
-                                            Err(error) => {
-                                                // The existing policy hot-apply seam does not yet
-                                                // carry typed rollback proof. Never infer it from
-                                                // its message; Policy12 will close that boundary.
-                                                OwnedPeerGroupMutationOutcome::CompensationAmbiguous(error)
-                                            }
-                                        }
+                                        self.apply_policy_change_owned(event, None).await
                                     } else {
                                         let affected: Vec<IpAddr> = self.current_config
                                             .neighbors
@@ -1040,22 +1032,98 @@ impl PeerManager {
                                         self.apply_peer_group_change_owned(event, affected).await
                                     }
                                 }
-                                OwnedPeerGroupMutation::Delete { name } => {
+                                OwnedCatalogMutation::DeletePeerGroup { name } => {
                                     self.apply_peer_group_change_owned(
                                         ConfigEvent::DeletePeerGroup { name, ack: None },
                                         Vec::new(),
                                     ).await
                                 }
-                                OwnedPeerGroupMutation::SetNeighbor { address, peer_group } => {
+                                OwnedCatalogMutation::SetNeighborPeerGroup { address, peer_group } => {
                                     self.apply_peer_group_change_owned(
                                         ConfigEvent::SetNeighborPeerGroup { address, peer_group, ack: None },
                                         vec![address],
                                     ).await
                                 }
-                                OwnedPeerGroupMutation::ClearNeighbor { address } => {
+                                OwnedCatalogMutation::ClearNeighborPeerGroup { address } => {
                                     self.apply_peer_group_change_owned(
                                         ConfigEvent::ClearNeighborPeerGroup { address, ack: None },
                                         vec![address],
+                                    ).await
+                                }
+                                OwnedCatalogMutation::SetPolicy { name, definition } => {
+                                    self.apply_policy_change_owned(
+                                        ConfigEvent::SetPolicy {
+                                            name,
+                                            definition: *definition,
+                                            ack: None,
+                                        },
+                                        None,
+                                    ).await
+                                }
+                                OwnedCatalogMutation::DeletePolicy { name } => {
+                                    self.apply_policy_change_owned(
+                                        ConfigEvent::DeletePolicy { name, ack: None },
+                                        None,
+                                    ).await
+                                }
+                                OwnedCatalogMutation::SetNeighborSet { name, definition } => {
+                                    self.apply_policy_change_owned(
+                                        ConfigEvent::SetNeighborSet { name, definition, ack: None },
+                                        None,
+                                    ).await
+                                }
+                                OwnedCatalogMutation::DeleteNeighborSet { name } => {
+                                    self.apply_policy_change_owned(
+                                        ConfigEvent::DeleteNeighborSet { name, ack: None },
+                                        None,
+                                    ).await
+                                }
+                                OwnedCatalogMutation::SetGlobalImportChain { policy_names } => {
+                                    self.apply_policy_change_owned(
+                                        ConfigEvent::SetGlobalImportChain { policy_names, ack: None },
+                                        None,
+                                    ).await
+                                }
+                                OwnedCatalogMutation::SetGlobalExportChain { policy_names } => {
+                                    self.apply_policy_change_owned(
+                                        ConfigEvent::SetGlobalExportChain { policy_names, ack: None },
+                                        None,
+                                    ).await
+                                }
+                                OwnedCatalogMutation::ClearGlobalImportChain => {
+                                    self.apply_policy_change_owned(
+                                        ConfigEvent::ClearGlobalImportChain { ack: None },
+                                        None,
+                                    ).await
+                                }
+                                OwnedCatalogMutation::ClearGlobalExportChain => {
+                                    self.apply_policy_change_owned(
+                                        ConfigEvent::ClearGlobalExportChain { ack: None },
+                                        None,
+                                    ).await
+                                }
+                                OwnedCatalogMutation::SetNeighborImportChain { address, policy_names } => {
+                                    self.apply_policy_change_owned(
+                                        ConfigEvent::SetNeighborImportChain { address, policy_names, ack: None },
+                                        Some(vec![address]),
+                                    ).await
+                                }
+                                OwnedCatalogMutation::SetNeighborExportChain { address, policy_names } => {
+                                    self.apply_policy_change_owned(
+                                        ConfigEvent::SetNeighborExportChain { address, policy_names, ack: None },
+                                        Some(vec![address]),
+                                    ).await
+                                }
+                                OwnedCatalogMutation::ClearNeighborImportChain { address } => {
+                                    self.apply_policy_change_owned(
+                                        ConfigEvent::ClearNeighborImportChain { address, ack: None },
+                                        Some(vec![address]),
+                                    ).await
+                                }
+                                OwnedCatalogMutation::ClearNeighborExportChain { address } => {
+                                    self.apply_policy_change_owned(
+                                        ConfigEvent::ClearNeighborExportChain { address, ack: None },
+                                        Some(vec![address]),
                                     ).await
                                 }
                             };

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 
 use rustbgpd_api::peer_types::{
     CatalogMutationError, ConfigEvent, DynamicRangeTarget, ImportValidationDependency,
-    OwnedPeerGroupMutationOutcome, PeerGroupDefinition, PeerKey, PeerManagerNeighborConfig,
+    OwnedCatalogMutationOutcome, PeerGroupDefinition, PeerKey, PeerManagerNeighborConfig,
     ResolvedPeerPolicy,
 };
 use rustbgpd_fsm::SessionState;
@@ -117,6 +117,41 @@ impl From<String> for PolicyApplyFailure {
 impl std::fmt::Display for PolicyApplyFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.message)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PolicySnapshotFailureKind {
+    RejectedNoEffect,
+    FullyCompensated,
+    CompensationAmbiguous,
+}
+
+struct PolicySnapshotFailure {
+    kind: PolicySnapshotFailureKind,
+    message: String,
+}
+
+impl PolicySnapshotFailure {
+    fn rejected(message: impl Into<String>) -> Self {
+        Self {
+            kind: PolicySnapshotFailureKind::RejectedNoEffect,
+            message: message.into(),
+        }
+    }
+
+    fn compensated(message: impl Into<String>) -> Self {
+        Self {
+            kind: PolicySnapshotFailureKind::FullyCompensated,
+            message: message.into(),
+        }
+    }
+
+    fn ambiguous(message: impl Into<String>) -> Self {
+        Self {
+            kind: PolicySnapshotFailureKind::CompensationAmbiguous,
+            message: message.into(),
+        }
     }
 }
 
@@ -469,10 +504,26 @@ impl PeerManager {
         &mut self,
         targets: Vec<ResolvedPeerPolicy>,
     ) -> Result<Vec<ResolvedPeerPolicy>, String> {
+        self.apply_resolved_policy_snapshot_classified(targets, false)
+            .await
+            .map_err(|failure| failure.message)
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the partitioned policy transaction keeps cohort commit and cross-partition rollback ownership together"
+    )]
+    async fn apply_resolved_policy_snapshot_classified(
+        &mut self,
+        targets: Vec<ResolvedPeerPolicy>,
+        require_clean_convergence: bool,
+    ) -> Result<Vec<ResolvedPeerPolicy>, PolicySnapshotFailure> {
         // ADR-0112: qualify RFC 8212 import-presence transitions before
         // anything below can touch a peer, so one incapable peer rejects the
         // whole edit rather than being discovered mid-fanout and unwound.
-        self.preflight_rfc8212_import_transitions(&targets).await?;
+        self.preflight_rfc8212_import_transitions(&targets)
+            .await
+            .map_err(PolicySnapshotFailure::rejected)?;
         let mut rollback_rib_budget = PolicyRollbackRibBudget::default();
         let total_targets = targets.len();
         let mut seen = BTreeSet::new();
@@ -480,29 +531,39 @@ impl PeerManager {
             .iter()
             .any(|target| !seen.insert(PeerKey::new(target.address, target.interface.clone())));
         if has_duplicate {
+            let captured = self
+                .apply_resolved_policy_snapshot_authoritatively(
+                    targets,
+                    &mut rollback_rib_budget,
+                    require_clean_convergence,
+                )
+                .await?;
             return self
-                .apply_resolved_policy_snapshot_authoritatively(targets, &mut rollback_rib_budget)
-                .await
-                .map(|captured| {
-                    captured
-                        .into_iter()
-                        .map(|captured| captured.policy)
-                        .collect()
-                });
+                .complete_policy_snapshot(
+                    captured,
+                    &mut rollback_rib_budget,
+                    require_clean_convergence,
+                )
+                .await;
         }
 
         let cohort_mask = self.export_only_policy_cohort_mask(&targets).await;
         let cohort_targets = cohort_mask.iter().filter(|&&selected| selected).count();
         if cohort_targets < 2 {
+            let captured = self
+                .apply_resolved_policy_snapshot_authoritatively(
+                    targets,
+                    &mut rollback_rib_budget,
+                    require_clean_convergence,
+                )
+                .await?;
             return self
-                .apply_resolved_policy_snapshot_authoritatively(targets, &mut rollback_rib_budget)
-                .await
-                .map(|captured| {
-                    captured
-                        .into_iter()
-                        .map(|captured| captured.policy)
-                        .collect()
-                });
+                .complete_policy_snapshot(
+                    captured,
+                    &mut rollback_rib_budget,
+                    require_clean_convergence,
+                )
+                .await;
         }
 
         let cohort = targets
@@ -518,20 +579,29 @@ impl PeerManager {
         );
 
         let Some(cohort_result) = self
-            .try_apply_export_only_policy_cohort(&cohort, &mut rollback_rib_budget)
+            .try_apply_export_only_policy_cohort(
+                &cohort,
+                &mut rollback_rib_budget,
+                require_clean_convergence,
+            )
             .await
         else {
             // Defensive invariant fallback: no mutation occurs before this
             // helper returns `None`, so preserve original authoritative order.
+            let captured = self
+                .apply_resolved_policy_snapshot_authoritatively(
+                    targets,
+                    &mut rollback_rib_budget,
+                    require_clean_convergence,
+                )
+                .await?;
             return self
-                .apply_resolved_policy_snapshot_authoritatively(targets, &mut rollback_rib_budget)
-                .await
-                .map(|captured| {
-                    captured
-                        .into_iter()
-                        .map(|captured| captured.policy)
-                        .collect()
-                });
+                .complete_policy_snapshot(
+                    captured,
+                    &mut rollback_rib_budget,
+                    require_clean_convergence,
+                )
+                .await;
         };
         let mut captured = cohort_result?;
         drop(cohort);
@@ -541,7 +611,11 @@ impl PeerManager {
             .filter_map(|(target, selected)| (!selected).then_some(target))
             .collect();
         match self
-            .apply_resolved_policy_snapshot_authoritatively(remainder, &mut rollback_rib_budget)
+            .apply_resolved_policy_snapshot_authoritatively(
+                remainder,
+                &mut rollback_rib_budget,
+                require_clean_convergence,
+            )
             .await
         {
             Ok(mut remainder_captured) => {
@@ -553,27 +627,73 @@ impl PeerManager {
                     elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
                     "committed partitioned resolved policy snapshot"
                 );
-                Ok(captured
-                    .into_iter()
-                    .map(|captured| captured.policy)
-                    .collect())
+                self.complete_policy_snapshot(
+                    captured,
+                    &mut rollback_rib_budget,
+                    require_clean_convergence,
+                )
+                .await
             }
-            Err(remainder_error) => Err(
-                match self
-                    .restore_resolved_policies(captured, &mut rollback_rib_budget)
-                    .await
-                {
+            Err(remainder_error) => {
+                let rollback = self
+                    .restore_resolved_policies(
+                        captured,
+                        &mut rollback_rib_budget,
+                        require_clean_convergence,
+                    )
+                    .await;
+                let message = match &rollback {
                     Ok(()) => format!(
-                        "failed to apply authoritative policy remainder: {remainder_error}; \
-                     committed cohort restored"
+                        "failed to apply authoritative policy remainder: {}; committed cohort restored",
+                        remainder_error.message
                     ),
                     Err(cohort_restore_error) => format!(
-                        "failed to apply authoritative policy remainder: {remainder_error}; \
-                     restoring committed cohort also failed: {cohort_restore_error}"
+                        "failed to apply authoritative policy remainder: {}; restoring committed cohort also failed: {cohort_restore_error}",
+                        remainder_error.message
                     ),
-                },
-            ),
+                };
+                if remainder_error.kind == PolicySnapshotFailureKind::CompensationAmbiguous
+                    || rollback.is_err()
+                {
+                    Err(PolicySnapshotFailure::ambiguous(message))
+                } else {
+                    Err(PolicySnapshotFailure::compensated(message))
+                }
+            }
         }
+    }
+
+    async fn complete_policy_snapshot(
+        &mut self,
+        captured: Vec<CapturedResolvedPolicy>,
+        rollback_rib_budget: &mut PolicyRollbackRibBudget,
+        require_clean_convergence: bool,
+    ) -> Result<Vec<ResolvedPeerPolicy>, PolicySnapshotFailure> {
+        let convergence_debt = require_clean_convergence
+            && captured.iter().any(|captured| {
+                let peer_key =
+                    PeerKey::new(captured.policy.address, captured.policy.interface.clone());
+                self.peers
+                    .get(&peer_key)
+                    .is_some_and(|managed| managed.pending_refresh || managed.pending_export_apply)
+            });
+        if convergence_debt {
+            return match self
+                .restore_resolved_policies(captured, rollback_rib_budget, require_clean_convergence)
+                .await
+            {
+                Ok(()) => Err(PolicySnapshotFailure::compensated(
+                    "policy mutation retained convergence debt; candidate was fully restored",
+                )),
+                Err(error) => Err(PolicySnapshotFailure::ambiguous(format!(
+                    "policy mutation retained convergence debt and restoration failed: {error}"
+                ))),
+            };
+        }
+        Ok(captured
+            .into_iter()
+            .map(|captured| captured.policy)
+            .collect())
     }
 
     /// Select the largest locally eligible export-only cohort, with a stable
@@ -696,7 +816,8 @@ impl PeerManager {
         &mut self,
         targets: Vec<ResolvedPeerPolicy>,
         rollback_rib_budget: &mut PolicyRollbackRibBudget,
-    ) -> Result<Vec<CapturedResolvedPolicy>, String> {
+        require_clean_convergence: bool,
+    ) -> Result<Vec<CapturedResolvedPolicy>, PolicySnapshotFailure> {
         // Captured priors, in application order, for peers actually mutated.
         let mut applied: Vec<CapturedResolvedPolicy> = Vec::new();
         for target in targets {
@@ -736,23 +857,25 @@ impl PeerManager {
                 // apply did not complete.
                 applied[applied_idx].adj_rib_in_may_have_moved = apply_error.refresh_delivery_began;
                 let restored = std::mem::take(&mut applied);
-                return Err(
-                    match self
-                        .restore_resolved_policies(restored, rollback_rib_budget)
-                        .await
-                    {
-                        Ok(()) => format!(
-                            "failed to apply resolved policy to {}: {apply_error}; \
-                         already-applied peers restored",
-                            target.address
-                        ),
-                        Err(restore_error) => format!(
-                            "failed to apply resolved policy to {}: {apply_error}; \
-                         restoring already-applied peers also failed: {restore_error}",
-                            target.address
-                        ),
-                    },
-                );
+                return match self
+                    .restore_resolved_policies(
+                        restored,
+                        rollback_rib_budget,
+                        require_clean_convergence,
+                    )
+                    .await
+                {
+                    Ok(()) => Err(PolicySnapshotFailure::compensated(format!(
+                        "failed to apply resolved policy to {}: {apply_error}; \
+                             already-applied peers restored",
+                        target.address
+                    ))),
+                    Err(restore_error) => Err(PolicySnapshotFailure::ambiguous(format!(
+                        "failed to apply resolved policy to {}: {apply_error}; \
+                             restoring already-applied peers also failed: {restore_error}",
+                        target.address
+                    ))),
+                };
             }
             applied[applied_idx].adj_rib_in_may_have_moved = true;
         }
@@ -806,7 +929,8 @@ impl PeerManager {
         &mut self,
         targets: &[&ResolvedPeerPolicy],
         rollback_rib_budget: &mut PolicyRollbackRibBudget,
-    ) -> Option<Result<Vec<CapturedResolvedPolicy>, String>> {
+        require_clean_convergence: bool,
+    ) -> Option<Result<Vec<CapturedResolvedPolicy>, PolicySnapshotFailure>> {
         if targets.len() < 2 {
             return None;
         }
@@ -944,9 +1068,13 @@ impl PeerManager {
                         managed.pending_refresh = true;
                     }
                     let prior_restore = self
-                        .restore_resolved_policies(captured, rollback_rib_budget)
+                        .restore_resolved_policies(
+                            captured,
+                            rollback_rib_budget,
+                            require_clean_convergence,
+                        )
                         .await;
-                    return Some(Err(match prior_restore {
+                    return Some(Err(PolicySnapshotFailure::ambiguous(match prior_restore {
                         Ok(()) => format!(
                             "failed to apply resolved policy to {}: import: {error}; already-applied peers restored",
                             target.address
@@ -955,7 +1083,7 @@ impl PeerManager {
                             "failed to apply resolved policy to {}: import: {error}; restoring already-applied peers also failed: {restore_error}",
                             target.address
                         ),
-                    }));
+                    })));
                 }
                 self.peers
                     .get_mut(peer_key)
@@ -1066,10 +1194,17 @@ impl PeerManager {
                                         false
                                     }
                                 };
-                            if !refreshed && let Some(managed) = self.peers.get_mut(peer_key) {
-                                managed.pending_refresh = true;
+                            if refreshed {
+                                Ok(())
+                            } else {
+                                if let Some(managed) = self.peers.get_mut(peer_key) {
+                                    managed.pending_refresh = true;
+                                }
+                                Err(format!(
+                                    "{} import restore left Route Refresh debt",
+                                    target.address
+                                ))
                             }
-                            Ok(())
                         }
                         Err(restore_error) => {
                             // Cross-side carry (the authoritative bail
@@ -1090,21 +1225,25 @@ impl PeerManager {
                     Ok(())
                 };
                 let prior_restore = self
-                    .restore_resolved_policies(captured, rollback_rib_budget)
+                    .restore_resolved_policies(
+                        captured,
+                        rollback_rib_budget,
+                        require_clean_convergence,
+                    )
                     .await;
                 let restore_error = [failing_restore, failing_import_restore, prior_restore]
                     .into_iter()
                     .filter_map(Result::err)
                     .reduce(|folded, error| format!("{folded}; {error}"));
                 return Some(Err(match restore_error {
-                    None => format!(
+                    None => PolicySnapshotFailure::compensated(format!(
                         "failed to apply resolved policy to {}: export: {error}; already-applied peers restored",
                         target.address
-                    ),
-                    Some(restore_error) => format!(
+                    )),
+                    Some(restore_error) => PolicySnapshotFailure::ambiguous(format!(
                         "failed to apply resolved policy to {}: export: {error}; restoring already-applied peers also failed: {restore_error}",
                         target.address
-                    ),
+                    )),
                 }));
             }
             self.peers
@@ -1167,15 +1306,15 @@ impl PeerManager {
                 self.discard_prepared_export_destination(targets[0]).await;
             }
             let rollback = self
-                .restore_resolved_policies(captured, rollback_rib_budget)
+                .restore_resolved_policies(captured, rollback_rib_budget, require_clean_convergence)
                 .await;
             return Some(Err(match rollback {
-                Ok(()) => format!(
+                Ok(()) => PolicySnapshotFailure::compensated(format!(
                     "failed to update export policy cohort: {error}; already-applied peers restored"
-                ),
-                Err(restore_error) => format!(
+                )),
+                Err(restore_error) => PolicySnapshotFailure::ambiguous(format!(
                     "failed to update export policy cohort: {error}; restoring already-applied peers also failed: {restore_error}"
-                ),
+                )),
             }));
         }
 
@@ -1232,27 +1371,51 @@ impl PeerManager {
                     }
                     captured[index].adj_rib_in_may_have_moved = failure.delivery_began;
                     let rollback = self
-                        .restore_resolved_policies(captured, rollback_rib_budget)
+                        .restore_resolved_policies(
+                            captured,
+                            rollback_rib_budget,
+                            require_clean_convergence,
+                        )
                         .await;
                     return Some(Err(match rollback {
-                        Ok(()) => format!(
+                        Ok(()) => PolicySnapshotFailure::compensated(format!(
                             "failed to apply resolved policy to {}: route refresh: {error}; already-applied peers restored",
                             target.address
-                        ),
-                        Err(restore_error) => format!(
+                        )),
+                        Err(restore_error) => PolicySnapshotFailure::ambiguous(format!(
                             "failed to apply resolved policy to {}: route refresh: {error}; restoring already-applied peers also failed: {restore_error}",
                             target.address
-                        ),
+                        )),
                     }));
                 }
-            } else {
-                // Idle/Connect (nothing in Adj-RIB-In yet) or an ambiguous
-                // state query: arm `pending_refresh` so a later call fires the
-                // refresh once the session is reachable — the same handling
-                // the authoritative path applies to a non-Established peer.
+            } else if require_clean_convergence {
+                // The ordinary reload path may carry this refresh as retry
+                // intent. A settlement-owned mutation may not commit with
+                // convergence debt, and the state query cannot distinguish a
+                // down peer from a back-pressured Established one. Restore the
+                // complete cohort before classifying the request.
                 if let Some(managed) = self.peers.get_mut(peer_key) {
                     managed.pending_refresh = true;
                 }
+                let rollback = self
+                    .restore_resolved_policies(
+                        captured,
+                        rollback_rib_budget,
+                        require_clean_convergence,
+                    )
+                    .await;
+                return Some(Err(match rollback {
+                    Ok(()) => PolicySnapshotFailure::compensated(format!(
+                        "failed to apply resolved policy to {}: Route Refresh target state was not provably Established; already-applied peers restored",
+                        target.address
+                    )),
+                    Err(restore_error) => PolicySnapshotFailure::ambiguous(format!(
+                        "failed to apply resolved policy to {}: Route Refresh target state was not provably Established; restoring already-applied peers also failed: {restore_error}",
+                        target.address
+                    )),
+                }));
+            } else if let Some(managed) = self.peers.get_mut(peer_key) {
+                managed.pending_refresh = true;
             }
             captured[index].adj_rib_in_may_have_moved = true;
         }
@@ -1618,17 +1781,37 @@ impl PeerManager {
     /// absolute deadline across this top-level policy transaction. Timing out or
     /// dropping the caller detaches the exact registered aggregate so FIFO repair
     /// can continue while conservative pending flags retain retry intent.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "exact rollback keeps session, RIB, refresh, bookkeeping, and pending-flag acknowledgements in one owner"
+    )]
     async fn restore_resolved_policies(
         &mut self,
         priors: Vec<CapturedResolvedPolicy>,
         budget: &mut PolicyRollbackRibBudget,
+        require_exact_pending: bool,
     ) -> Result<(), String> {
+        let pending_priors = priors
+            .iter()
+            .map(|prior| {
+                (
+                    PeerKey::new(prior.policy.address, prior.policy.interface.clone()),
+                    prior.pending_refresh,
+                    prior.pending_export_apply,
+                )
+            })
+            .collect::<Vec<_>>();
         let mut errors: Vec<String> = Vec::new();
         let mut plans = Vec::new();
         for prior in priors.into_iter().rev() {
             let address = prior.policy.address;
             let peer_key = PeerKey::new(address, prior.policy.interface.clone());
             if !self.peers.contains_key(&peer_key) {
+                if require_exact_pending {
+                    errors.push(format!(
+                        "{peer_key}: peer disappeared before policy rollback could acknowledge restoration"
+                    ));
+                }
                 continue;
             }
             let refresh_failure = if prior.adj_rib_in_may_have_moved {
@@ -1712,6 +1895,25 @@ impl PeerManager {
                         }
                     }
                 }
+            }
+        }
+
+        for (peer_key, prior_refresh, prior_export) in pending_priors {
+            let Some(managed) = self.peers.get(&peer_key) else {
+                continue;
+            };
+            if require_exact_pending
+                && (managed.pending_refresh != prior_refresh
+                    || managed.pending_export_apply != prior_export)
+            {
+                errors.push(format!(
+                    "{} rollback retained convergence debt (pending_refresh={} expected {}; pending_export_apply={} expected {})",
+                    peer_key,
+                    managed.pending_refresh,
+                    prior_refresh,
+                    managed.pending_export_apply,
+                    prior_export
+                ));
             }
         }
 
@@ -2489,6 +2691,82 @@ impl PeerManager {
         Ok(())
     }
 
+    pub(super) async fn apply_policy_change_owned(
+        &mut self,
+        event: ConfigEvent,
+        affected_peers: Option<Vec<IpAddr>>,
+    ) -> OwnedCatalogMutationOutcome {
+        if let ConfigEvent::DeletePolicy { name, .. } = &event {
+            let refs = policy_references(&self.current_config, name);
+            if !refs.is_empty() {
+                return OwnedCatalogMutationOutcome::RejectedNoEffect(
+                    CatalogMutationError::StillReferenced {
+                        kind: "policy",
+                        name: name.clone(),
+                        references: refs,
+                    },
+                );
+            }
+        }
+        if let ConfigEvent::DeleteNeighborSet { name, .. } = &event {
+            let refs = neighbor_set_references(&self.current_config, name);
+            if !refs.is_empty() {
+                return OwnedCatalogMutationOutcome::RejectedNoEffect(
+                    CatalogMutationError::StillReferenced {
+                        kind: "neighbor set",
+                        name: name.clone(),
+                        references: refs,
+                    },
+                );
+            }
+        }
+        if let ConfigEvent::SetPolicy { name, .. } = &event
+            && let Some(entry) = self.current_config.policy.rpol.policies.get(name)
+        {
+            return OwnedCatalogMutationOutcome::RejectedNoEffect(CatalogMutationError::internal(
+                format!(
+                    "policy {name:?} is defined by rpol file {:?}; rpol and TOML policies share one namespace",
+                    entry.path
+                ),
+            ));
+        }
+
+        let mut next_config = self.current_config.clone();
+        if let Err(error) = apply_config_event(&mut next_config, &event) {
+            return OwnedCatalogMutationOutcome::RejectedNoEffect(catalog_config_error(error));
+        }
+        if next_config == self.current_config {
+            return OwnedCatalogMutationOutcome::Success;
+        }
+        match self
+            .refresh_policies_for_config_classified(next_config, affected_peers, true)
+            .await
+        {
+            Ok(applied) => {
+                self.publish_policy_config_event(&event, applied);
+                OwnedCatalogMutationOutcome::Success
+            }
+            Err(PolicySnapshotFailure {
+                kind: PolicySnapshotFailureKind::RejectedNoEffect,
+                message,
+            }) => OwnedCatalogMutationOutcome::RejectedNoEffect(CatalogMutationError::internal(
+                message,
+            )),
+            Err(PolicySnapshotFailure {
+                kind: PolicySnapshotFailureKind::FullyCompensated,
+                message,
+            }) => OwnedCatalogMutationOutcome::FullyCompensated(CatalogMutationError::internal(
+                message,
+            )),
+            Err(PolicySnapshotFailure {
+                kind: PolicySnapshotFailureKind::CompensationAmbiguous,
+                message,
+            }) => OwnedCatalogMutationOutcome::CompensationAmbiguous(
+                CatalogMutationError::internal(message),
+            ),
+        }
+    }
+
     /// ADR-0096: adopt a new compiled `.rpol` registry (SIGHUP reload
     /// of `[policy] rpol_files` or of referenced file content) and
     /// re-resolve every live peer's chains through it, using the same
@@ -2533,6 +2811,17 @@ impl PeerManager {
         next_config: Config,
         affected_peers: Option<Vec<IpAddr>>,
     ) -> Result<usize, CatalogMutationError> {
+        self.refresh_policies_for_config_classified(next_config, affected_peers, false)
+            .await
+            .map_err(|failure| CatalogMutationError::internal(failure.message))
+    }
+
+    async fn refresh_policies_for_config_classified(
+        &mut self,
+        next_config: Config,
+        affected_peers: Option<Vec<IpAddr>>,
+        require_clean_convergence: bool,
+    ) -> Result<usize, PolicySnapshotFailure> {
         let peers: Vec<PeerKey> = affected_peers.map_or_else(
             || self.peers.keys().cloned().collect(),
             |peers| {
@@ -2596,7 +2885,11 @@ impl PeerManager {
                     );
                     continue;
                 }
-                Err(error) => return Err(catalog_config_error(error)),
+                Err(error) => {
+                    return Err(PolicySnapshotFailure::rejected(
+                        catalog_config_error(error).to_string(),
+                    ));
+                }
             };
             targets.push(ResolvedPeerPolicy {
                 address,
@@ -2614,9 +2907,8 @@ impl PeerManager {
             "resolved live peer policy chains"
         );
         let applied = self
-            .apply_resolved_policy_snapshot(targets)
-            .await
-            .map_err(CatalogMutationError::internal)?;
+            .apply_resolved_policy_snapshot_classified(targets, require_clean_convergence)
+            .await?;
 
         // ADR-0110 freshness: adopting `next_config` is the accept moment
         // for this policy generation. Sync the per-dataset series against
@@ -3094,11 +3386,11 @@ impl PeerManager {
         &mut self,
         event: ConfigEvent,
         affected_peers: Vec<IpAddr>,
-    ) -> OwnedPeerGroupMutationOutcome {
+    ) -> OwnedCatalogMutationOutcome {
         if let ConfigEvent::DeletePeerGroup { name, .. } = &event {
             let refs = peer_group_references(&self.current_config, name);
             if !refs.is_empty() {
-                return OwnedPeerGroupMutationOutcome::RejectedNoEffect(
+                return OwnedCatalogMutationOutcome::RejectedNoEffect(
                     CatalogMutationError::StillReferenced {
                         kind: "peer group",
                         name: name.clone(),
@@ -3110,10 +3402,10 @@ impl PeerManager {
 
         let mut next_config = self.current_config.clone();
         if let Err(error) = apply_config_event(&mut next_config, &event) {
-            return OwnedPeerGroupMutationOutcome::RejectedNoEffect(catalog_config_error(error));
+            return OwnedCatalogMutationOutcome::RejectedNoEffect(catalog_config_error(error));
         }
         if next_config == self.current_config {
-            return OwnedPeerGroupMutationOutcome::Success;
+            return OwnedCatalogMutationOutcome::Success;
         }
 
         if let ConfigEvent::SetPeerGroup { name, .. } = &event
@@ -3122,7 +3414,7 @@ impl PeerManager {
             && (old_group.md5_password != new_group.md5_password
                 || old_group.ttl_security != new_group.ttl_security)
         {
-            return OwnedPeerGroupMutationOutcome::RejectedNoEffect(
+            return OwnedCatalogMutationOutcome::RejectedNoEffect(
                 CatalogMutationError::RestartRequired(format!(
                     "peer group {name:?} changes md5_password or ttl_security; inbound listener \
                      enforcement is updated only by startup or SIGHUP reload — apply this change \
@@ -3141,8 +3433,8 @@ impl PeerManager {
                 .apply_peer_group_hot_change(event, next_config, &name, affected_peers)
                 .await
             {
-                Ok(()) => OwnedPeerGroupMutationOutcome::Success,
-                Err(error) => OwnedPeerGroupMutationOutcome::CompensationAmbiguous(error),
+                Ok(()) => OwnedCatalogMutationOutcome::Success,
+                Err(error) => OwnedCatalogMutationOutcome::CompensationAmbiguous(error),
             };
         }
 
@@ -3166,7 +3458,7 @@ impl PeerManager {
             let Some(neighbor) = next_config.neighbors.iter().find(|neighbor| {
                 neighbor.address == address.to_string() && neighbor.interface == peer_key.interface
             }) else {
-                return OwnedPeerGroupMutationOutcome::RejectedNoEffect(
+                return OwnedCatalogMutationOutcome::RejectedNoEffect(
                     CatalogMutationError::internal(format!(
                         "static peer {peer_key} affected by the peer-group change has no neighbor \
                          record in the updated config; refusing to reshape an inconsistent snapshot"
@@ -3176,7 +3468,7 @@ impl PeerManager {
             let resolved = match next_config.resolve_neighbor(neighbor) {
                 Ok(resolved) => resolved,
                 Err(error) => {
-                    return OwnedPeerGroupMutationOutcome::RejectedNoEffect(catalog_config_error(
+                    return OwnedCatalogMutationOutcome::RejectedNoEffect(catalog_config_error(
                         error,
                     ));
                 }
@@ -3187,13 +3479,13 @@ impl PeerManager {
         let priors = match self.apply_peer_reshape_snapshot_classified(targets).await {
             PeerReshapeSnapshotOutcome::Success(priors) => priors,
             PeerReshapeSnapshotOutcome::RejectedNoEffect(error) => {
-                return OwnedPeerGroupMutationOutcome::RejectedNoEffect(error.into());
+                return OwnedCatalogMutationOutcome::RejectedNoEffect(error.into());
             }
             PeerReshapeSnapshotOutcome::FullyCompensated(error) => {
-                return OwnedPeerGroupMutationOutcome::FullyCompensated(error.into());
+                return OwnedCatalogMutationOutcome::FullyCompensated(error.into());
             }
             PeerReshapeSnapshotOutcome::CompensationAmbiguous(error) => {
-                return OwnedPeerGroupMutationOutcome::CompensationAmbiguous(error.into());
+                return OwnedCatalogMutationOutcome::CompensationAmbiguous(error.into());
             }
         };
 
@@ -3203,7 +3495,7 @@ impl PeerManager {
         }
         self.reconcile_stale_dynamic_max_prefix_restarts();
         self.publish_policy_config_event(&event, priors.len());
-        OwnedPeerGroupMutationOutcome::Success
+        OwnedCatalogMutationOutcome::Success
     }
 
     /// The all-hot half of [`Self::apply_peer_group_change`]: apply the

--- a/src/peer_manager/tests/peer_groups.rs
+++ b/src/peer_manager/tests/peer_groups.rs
@@ -116,7 +116,7 @@ async fn owned_peer_group_validation_rejection_is_typed_no_effect() {
         .await;
     assert!(matches!(
         outcome,
-        rustbgpd_api::peer_types::OwnedPeerGroupMutationOutcome::RejectedNoEffect(_)
+        rustbgpd_api::peer_types::OwnedCatalogMutationOutcome::RejectedNoEffect(_)
     ));
     assert_eq!(mgr.current_config, prior);
 }
@@ -364,7 +364,7 @@ async fn owned_peer_group_reshape_reports_fully_compensated_failure() {
     assert!(
         matches!(
             outcome,
-            rustbgpd_api::peer_types::OwnedPeerGroupMutationOutcome::FullyCompensated(_)
+            rustbgpd_api::peer_types::OwnedCatalogMutationOutcome::FullyCompensated(_)
         ),
         "a restored fan-out must carry typed full-compensation proof"
     );
@@ -487,7 +487,7 @@ async fn owned_peer_group_reshape_reports_ambiguous_rollback_failure() {
     assert!(
         matches!(
             outcome,
-            rustbgpd_api::peer_types::OwnedPeerGroupMutationOutcome::CompensationAmbiguous(_)
+            rustbgpd_api::peer_types::OwnedCatalogMutationOutcome::CompensationAmbiguous(_)
         ),
         "a failed restore must carry typed ambiguity"
     );

--- a/src/peer_manager/tests/policy.rs
+++ b/src/peer_manager/tests/policy.rs
@@ -957,13 +957,11 @@ async fn reconcile_sweep_rearms_dynamic_peer_on_group_duration_edit() {
     assert!(!mgr.max_prefix_latches.contains_key(&key(addr)));
 }
 
-/// A catalog mutation's fan-out is atomic: when applying the resolved
-/// chains to peer 2 fails mid-loop, peer 1 (already updated) is restored
-/// to its prior chains, peer 3 is never touched, and `current_config`
-/// does not advance — no split-brain where some sessions run the new
-/// policy and others the old.
+/// The owned actor restores peers it can prove, leaves the candidate snapshot
+/// unadopted, and reports ambiguity when the failing session cannot acknowledge
+/// restoration of its own possibly accepted update.
 #[tokio::test]
-async fn apply_policy_change_mid_fanout_failure_restores_prior_chains() {
+async fn owned_policy_change_fences_when_failing_peer_cannot_restore() {
     use rustbgpd_api::peer_types::{NamedPolicyDefinition, PolicyStatementDefinition};
 
     let mut mgr = live_policy_test_manager();
@@ -973,7 +971,7 @@ async fn apply_policy_change_mid_fanout_failure_restores_prior_chains() {
     insert_test_managed_peer(
         &mut mgr,
         a1,
-        acking_policy_handle(a1, SessionState::Idle),
+        acking_policy_handle(a1, SessionState::Established),
         false,
     );
     insert_test_managed_peer(&mut mgr, a2, closed_peer_handle(), false);
@@ -997,8 +995,8 @@ async fn apply_policy_change_mid_fanout_failure_restores_prior_chains() {
         mgr.peers.get_mut(&key(a)).unwrap().import_policy = Some(prior.clone());
     }
 
-    let result = mgr
-        .apply_policy_change(
+    let outcome = mgr
+        .apply_policy_change_owned(
             ConfigEvent::SetPolicy {
                 name: "edge-import".to_string(),
                 definition: NamedPolicyDefinition {
@@ -1012,8 +1010,11 @@ async fn apply_policy_change_mid_fanout_failure_restores_prior_chains() {
         )
         .await;
     assert!(
-        result.is_err(),
-        "a mid-fanout per-peer failure must surface as Err: {result:?}"
+        matches!(
+            &outcome,
+            rustbgpd_api::peer_types::OwnedCatalogMutationOutcome::CompensationAmbiguous(_)
+        ),
+        "unexpected outcome: {outcome:?}"
     );
 
     let expect_prior = format!("{:?}", Some(prior));
@@ -1606,4 +1607,61 @@ async fn channel_full_disable_peer_returns_timeout_instead_of_wedging_manager() 
     );
 
     let _ = finish_tx.send(());
+}
+
+#[tokio::test]
+async fn owned_neighbor_chain_validation_rejects_before_runtime_effect() {
+    let (_cmd_tx, cmd_rx) = mpsc::channel(4);
+    let (rib_tx, _rib_rx) = mpsc::channel::<RibUpdate>(4);
+    let mut mgr = PeerManager::new(
+        cmd_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    let address = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 9));
+    let outcome = mgr
+        .apply_policy_change_owned(
+            rustbgpd_api::peer_types::ConfigEvent::SetNeighborImportChain {
+                address,
+                policy_names: Vec::new(),
+                ack: None,
+            },
+            Some(vec![address]),
+        )
+        .await;
+    assert!(matches!(
+        outcome,
+        rustbgpd_api::peer_types::OwnedCatalogMutationOutcome::RejectedNoEffect(_)
+    ));
+}
+
+#[tokio::test]
+async fn owned_policy_noop_is_typed_success_without_convergence_debt() {
+    let (_cmd_tx, cmd_rx) = mpsc::channel(4);
+    let (rib_tx, _rib_rx) = mpsc::channel::<RibUpdate>(4);
+    let mut mgr = PeerManager::new(
+        cmd_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    let outcome = mgr
+        .apply_policy_change_owned(
+            rustbgpd_api::peer_types::ConfigEvent::ClearGlobalImportChain { ack: None },
+            None,
+        )
+        .await;
+    assert!(matches!(
+        outcome,
+        rustbgpd_api::peer_types::OwnedCatalogMutationOutcome::Success
+    ));
 }

--- a/src/peer_manager/tests/policy_apply.rs
+++ b/src/peer_manager/tests/policy_apply.rs
@@ -136,6 +136,90 @@ fn export_fails_once_policy_handle(peer_addr: IpAddr, state: SessionState) -> Pe
     PeerHandle::from_parts(session_tx, task)
 }
 
+#[tokio::test]
+async fn owned_policy_cohort_failure_reports_fully_compensated() {
+    use rustbgpd_api::peer_types::{
+        ConfigEvent, NamedPolicyDefinition, OwnedCatalogMutationOutcome, PolicyStatementDefinition,
+    };
+
+    let (_cmd_tx, cmd_rx) = mpsc::channel(16);
+    let first = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let failing = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let rib_driver = tokio::spawn(async move {
+        let RibUpdate::PrepareExportPolicyDestination { reply, .. } =
+            rib_rx.recv().await.expect("cohort destination preflight")
+        else {
+            panic!("expected destination preflight");
+        };
+        reply.send(Err("test: prestage skipped".into())).unwrap();
+        let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } =
+            rib_rx.recv().await.expect("cohort rollback RIB restore")
+        else {
+            panic!("expected rollback RIB restore");
+        };
+        assert_eq!(peer, first);
+        reply.send(Ok(())).unwrap();
+    });
+    let mut mgr = PeerManager::new(
+        cmd_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    insert_test_managed_peer(
+        &mut mgr,
+        first,
+        acking_policy_handle(first, SessionState::Established),
+        false,
+    );
+    insert_test_managed_peer(
+        &mut mgr,
+        failing,
+        export_fails_once_policy_handle(failing, SessionState::Established),
+        false,
+    );
+    mgr.current_config.neighbors = [first, failing]
+        .into_iter()
+        .map(|address| {
+            let mut neighbor = config_neighbor(address, 65002);
+            neighbor.export_policy_chain = vec!["edge-export".into()];
+            neighbor
+        })
+        .collect();
+
+    let outcome = mgr
+        .apply_policy_change_owned(
+            ConfigEvent::SetPolicy {
+                name: "edge-export".into(),
+                definition: NamedPolicyDefinition {
+                    default_action: "deny".into(),
+                    statements: Vec::<PolicyStatementDefinition>::new(),
+                },
+                ack: None,
+            },
+            Some(vec![first, failing]),
+        )
+        .await;
+    assert!(
+        matches!(outcome, OwnedCatalogMutationOutcome::FullyCompensated(_)),
+        "the failing member and acknowledged prefix must restore exactly: {outcome:?}"
+    );
+    assert!(!mgr.peers[&key(first)].pending_export_apply);
+    assert!(!mgr.peers[&key(failing)].pending_export_apply);
+    assert!(
+        !mgr.current_config
+            .policy
+            .definitions
+            .contains_key("edge-export")
+    );
+    rib_driver.await.unwrap();
+}
+
 /// A peer handle that acks policy hot-applies but rejects Route Refresh, as a
 /// peer that did not negotiate the Route Refresh capability would (the session
 /// returns "peer lacks Route Refresh capability"). Used to verify a live-impact


### PR DESCRIPTION
## Summary

- activate typed settlement ownership for all 12 persisted PolicyService mutations
- generalize PeerGroup4 into one forward-only owned catalog actor surface with no compatibility aliases
- preserve optimized policy cohorts while requiring acknowledged session, RIB, refresh, and pending-state restoration before clean compensation
- remove five superseded untyped service helpers and the redundant neighbor pre-read

## Safety contract

Only success, proved no effect, or fully acknowledged compensation settles. Accepted reply loss, rollback or convergence debt, commit uncertainty, executor loss, and any possibly applied unknown outcome fence and retain ownership without a response until supervised exit 70.

## Validation

- PolicyService 43; PeerGroupService 28
- actor policy 22; policy-apply/cohort 15; peer-group 17
- settlement 13, closed inventory, production exit-70 integration
- full locked workspace all-features tests
- strict locked workspace all-target/all-feature Clippy
- v1 stable-surface, fmt, and diff checks
- independent exact-head safety review: GO

Tracks LAN-1003 and LAN-974. LAN-974 remains open for SIGHUP and operational acceptance closure.