### PR TITLE
docs: bound fail-stop supervisor recovery

### DIFF
--- a/.github/workflows/release-install-contract.yml
+++ b/.github/workflows/release-install-contract.yml
@@ -9,12 +9,17 @@ on:
       - README.md
       - docs/deployment.md
       - docs/QUICKSTART.md
+      - docs/OPERATIONS.md
+      - docs/adr/0127-config-transaction-settlement-watchdog.md
       - docs/grafana/rustbgpd-overview.json
       - docs/cookbook/ixp-filter-pipeline.md
       - docs/cookbook/monitoring-feed.md
       - examples/birdwatcher-adapter/Cargo.toml
       - examples/birdwatcher-adapter/src/main.rs
       - examples/birdwatcher-adapter/README.md
+      - examples/docker-compose/docker-compose.yml
+      - examples/docker-compose/README.md
+      - examples/systemd/rustbgpd.service
       - examples/prometheus/rustbgpd-alerts.yml
       - examples/prometheus/rustbgpd-alerts_test.yml
       - tests/birdwatcher_adapter_smoke.rs
@@ -24,6 +29,7 @@ on:
       - scripts/check_release_install_contract.py
       - scripts/test_check_release_install_contract.py
       - .github/workflows/release-install-contract.yml
+      - CHANGELOG.md
   push:
     branches: [main]
     paths:
@@ -33,12 +39,17 @@ on:
       - README.md
       - docs/deployment.md
       - docs/QUICKSTART.md
+      - docs/OPERATIONS.md
+      - docs/adr/0127-config-transaction-settlement-watchdog.md
       - docs/grafana/rustbgpd-overview.json
       - docs/cookbook/ixp-filter-pipeline.md
       - docs/cookbook/monitoring-feed.md
       - examples/birdwatcher-adapter/Cargo.toml
       - examples/birdwatcher-adapter/src/main.rs
       - examples/birdwatcher-adapter/README.md
+      - examples/docker-compose/docker-compose.yml
+      - examples/docker-compose/README.md
+      - examples/systemd/rustbgpd.service
       - examples/prometheus/rustbgpd-alerts.yml
       - examples/prometheus/rustbgpd-alerts_test.yml
       - tests/birdwatcher_adapter_smoke.rs
@@ -48,6 +59,7 @@ on:
       - scripts/check_release_install_contract.py
       - scripts/test_check_release_install_contract.py
       - .github/workflows/release-install-contract.yml
+      - CHANGELOG.md
 permissions:
   contents: read
 jobs:
@@ -119,6 +131,21 @@ jobs:
             # installs. A textual check on the skeleton goes stale as the
             # config schema evolves; the daemon's own validator does not.
             "$tree/usr/bin/rustbgpd" --check "$tree/etc/rustbgpd/config.toml"
+            unit="$tree/lib/systemd/system/rustbgpd.service"
+            for directive in StartLimitIntervalSec=10min StartLimitBurst=5 Restart=on-failure RestartSec=5 TimeoutStopSec=32min; do
+              grep -qxF "$directive" "$unit"
+            done
+          python3 - "$unit" <<'PY'
+          import sys
+          from pathlib import Path
+          from scripts.check_release_install_contract import systemd_assignments, systemd_status_is_70
+
+          for _, key, value in systemd_assignments(Path(sys.argv[1]).read_text()):
+              if key in {"SuccessExitStatus", "RestartPreventExitStatus"} and any(
+                  systemd_status_is_70(token) for token in value.split()
+              ):
+                  raise SystemExit(f"exit 70/SOFTWARE must remain restartable: {sys.argv[1]}")
+          PY
           done
       - uses: docker/setup-buildx-action@v4
       - name: Build production runtime image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Persisted runtime-config owners now fail stop with exit 70 five seconds after
+  settlement ambiguity is detected, or when an owner remains unsettled for the
+  fixed 30-minute budget plus that grace. Transaction/Apply, Neighbor4, FIB2,
+  PeerGroup4, and Policy12 are wired; SIGHUP, observability, and final recovery
+  proofs remain before LAN-974 is complete. The shipped systemd unit keeps exit
+  70 restartable, caps recovery at five starts per ten minutes, and gives
+  explicit stops 32 minutes to settle.
 - Config transaction apply now bounds its pre-ownership wait for the shared runtime config coordinator at ten minutes. (LAN-974)
 - Ambiguous `rustbgpd` invocations now fail with exit 2 instead of silently
   overwriting a config path or option value, consuming a flag as a value, or

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -43,6 +43,36 @@ signal; it returns ready once the PeerManager and RIB actors answer their
 bounded probes. The `starting rustbgpd` log line means process startup reached
 runtime wiring, not that every actor has answered a readiness probe yet.
 
+### Runtime-config settlement fail-stop
+
+Persisted runtime mutations use a cancellation-shielded owner. If creation of
+the initial persistence stage fails because the config directory is not
+writable, the request is rejected cleanly before runtime state changes and the
+daemon remains available. That is different from failure after durable staging
+and runtime mutation have begun: if rename or directory fsync publication
+cannot be proved, the outcome is ambiguous. A read-only bind-mounted config
+*file* in an otherwise writable directory is especially dangerous because the
+temporary stage can succeed while replacement of the mount point cannot.
+
+An ambiguous owner immediately makes `/readyz` fail, closes admission for new
+persisted mutations, and retains ownership until process death. Detected
+ambiguity or executor loss exits with status 70 after a five-second fencing
+grace. A silent owner is fenced after the fixed 30-minute owned-settlement
+budget and exits five seconds later. Do not classify 70 as success or suppress
+its restart: the new process re-establishes authority from durable state.
+
+The shipped systemd unit uses `Restart=on-failure`, but caps recovery at five
+starts per ten minutes so a deterministic persistence fault cannot flap every
+five seconds forever. `TimeoutStopSec=32min` lets an explicit stop wait through
+the watchdog; systemd suppresses automatic restart for an explicit
+`systemctl stop`. After inspecting and fixing the config directory, bind mount,
+and on-disk authority, recover a rate-limited unit with:
+
+```bash
+sudo systemctl reset-failed rustbgpd
+sudo systemctl start rustbgpd
+```
+
 ### Per-peer log filtering
 
 Set `log_level` on any neighbor or peer group to override the global log level:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -281,6 +281,7 @@ starting from `--init-config edge` needs no such edit.
 
 ```bash
 docker run -d --name rustbgpd \
+  --stop-timeout=1920 \
   -v "$(pwd)/config.toml":/etc/rustbgpd/config.template.toml:ro \
   -v rustbgpd-state:/var/lib/rustbgpd \
   -p 179:179 -p 9179:9179 \
@@ -323,6 +324,13 @@ rejected. Mount it read-write and the write still fails, because the image's
 
 Deployments that manage the config exclusively from the outside — SIGHUP after
 an external edit, no runtime mutation — can mount it read-only and skip this.
+
+`--stop-timeout=1920` gives an explicit container stop 32 minutes to wait for
+an owned runtime-config mutation. If settlement becomes ambiguous, readiness
+fails and new persisted mutations are rejected before the daemon exits 70:
+within five seconds when ambiguity is detected, or by 30 minutes plus five
+seconds when an owner goes silent. Docker does not restart this standalone
+example; production supervision should bound retries.
 
 Or use systemd with
 [`examples/systemd/rustbgpd.service`](../examples/systemd/rustbgpd.service).

--- a/docs/adr/0127-config-transaction-settlement-watchdog.md
+++ b/docs/adr/0127-config-transaction-settlement-watchdog.md
@@ -33,6 +33,18 @@ exists in current source, but Proposed status does not claim the complete owner
 roster, SIGHUP settlement/shutdown rules, or required recovery proof has
 shipped.
 
+### Implementation status (2026-08-12)
+
+The shared watchdog, readiness/admission fence, Linux exit-70 terminal action,
+and typed settlement wiring have shipped for transaction/Apply owners,
+Neighbor4, FIB2, PeerGroup4, and Policy12. That is a partial roster, not
+acceptance of this ADR or closure of the underlying issue.
+
+SIGHUP ownership remains incomplete. The bounded metrics/log observability
+described below and the final cross-roster recovery proofs also remain
+incomplete. Until those land, this ADR stays Proposed and the source inventory
+must distinguish shipped owners from the decision's full target roster.
+
 ## Decision
 
 ### One operation, one owner, one candidate
@@ -97,9 +109,10 @@ arms the watchdog before any further await or side effect.
 
 ### Independent terminal watchdog
 
-The 30-minute budget, five-second grace, and exit status 70 remain Proposed
-owner acceptance choices for the complete roster. Existing transaction
-watchdog code does not by itself satisfy this amended contract or its gates.
+The 30-minute budget, five-second grace, and exit status 70 are implemented for
+the shipped partial roster, but remain Proposed as complete-roster acceptance
+criteria. Existing watchdog code does not by itself satisfy this amended
+contract or its gates.
 
 An owned operation gets one fixed, non-resettable 30-minute monotonic
 settlement budget. This is the latest normal settlement deadline; independently

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -336,11 +336,16 @@ Notes on the sandbox:
   listener failing to bind, or the gRPC server exiting unexpectedly.
   None of these listeners is rebound without a restart, so the daemon exits
   rather than run on deaf; the supervisor's retry is the recovery path.
-  With `RestartSec=5` a transient bind failure clears on the next
-  attempt, and a permanent one (port held by another speaker, missing
-  `CAP_NET_BIND_SERVICE`) repeats the bind error in the journal on every
-  attempt. `rbgp doctor` reports the same cause against the down daemon
-  through its `bgp.listener` check.
+  Exit 70 is also a failure: it is the runtime-config settlement watchdog's
+  fail-stop recovery request and must remain restartable. `RestartSec=5`
+  retries a transient failure, while `StartLimitBurst=5` and
+  `StartLimitIntervalSec=10min` stop a deterministic failure from flapping
+  forever. After correcting config authority or permissions, recover a
+  rate-limited unit with `systemctl reset-failed rustbgpd` followed by
+  `systemctl start rustbgpd`. An explicit `systemctl stop` suppresses restart,
+  and `TimeoutStopSec=32min` gives an already-owned mutation longer than its
+  30-minute watchdog plus five-second terminal grace to settle or fail-stop.
+  `rbgp doctor` reports listener failures through its `bgp.listener` check.
 
 ### Installation
 
@@ -481,6 +486,7 @@ For your own deployment:
 
   docker run --rm -d \
     --name rustbgpd \
+    --stop-timeout=1920 \
     -v /etc/rustbgpd:/etc/rustbgpd \
     -v /var/lib/rustbgpd:/var/lib/rustbgpd \
     -p 179:179 \
@@ -508,6 +514,18 @@ For your own deployment:
   *directory*, not just the file, has to be writable, and every mutating
   RPC is rejected without it. Mount it `:ro` only when the config is
   managed entirely from outside and reloaded with SIGHUP.
+
+- **Settlement fail-stop**: `--stop-timeout=1920` gives an explicit stop the
+  same 32-minute grace as the shipped systemd unit. A failure to create the
+  initial persistence stage rejects cleanly before runtime mutation. After
+  staging and runtime mutation begin, an unprovable rename or directory fsync
+  is ambiguous; a read-only bind-mounted config *file* can have a writable
+  parent yet still fail replacement in this window. The daemon then marks
+  readiness unavailable, closes persisted-mutation admission, and exits 70
+  within five seconds of detected ambiguity. A silent owner is fenced at 30
+  minutes and exits five seconds later. This standalone command has no restart
+  policy; use bounded supervisor retries and inspect durable config authority
+  before recovery.
 
 - **Health**: the image declares a `HEALTHCHECK` that runs `rbgp
   --json health` against the daemon's local gRPC socket and requires a

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -50,6 +50,13 @@ temp-file + rename write that config persistence uses, and every mutating
 command would fail. Edit the template and `docker compose down -v` to start
 over from it.
 
+The service has a 32-minute stop grace so an explicit Compose stop does not
+kill a runtime-config owner before its fixed 30-minute settlement watchdog.
+There is deliberately no Compose restart policy: production supervisors
+should choose their own bounded retry policy. A detected ambiguous mutation
+turns readiness red, closes persisted-mutation admission, and exits 70 within
+five seconds; a silent owner exits by 30 minutes plus five seconds.
+
 ## Stop
 
 ```bash

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -56,6 +56,9 @@ services:
       nofile:
         soft: 65536
         hard: 524288
+    # Let an explicit stop wait beyond the 30-minute runtime-config settlement
+    # watchdog. Compose intentionally leaves restart policy to the operator.
+    stop_grace_period: 32m
 
   frr:
     image: quay.io/frrouting/frr:10.3.1

--- a/examples/systemd/rustbgpd.service
+++ b/examples/systemd/rustbgpd.service
@@ -3,6 +3,9 @@ Description=rustbgpd BGP daemon
 Documentation=https://github.com/lance0/rustbgpd
 After=network-online.target
 Wants=network-online.target
+# Bound repeated fail-stop recovery: five starts per ten-minute window.
+StartLimitIntervalSec=10min
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -37,6 +40,9 @@ CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 # Restart on failure, but not on clean shutdown (exit 0) or SIGTERM
 Restart=on-failure
 RestartSec=5
+# An owned runtime-config mutation may need its full 30-minute settlement
+# watchdog plus the five-second fail-stop grace during an explicit stop.
+TimeoutStopSec=32min
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/check_release_install_contract.py
+++ b/scripts/check_release_install_contract.py
@@ -30,6 +30,15 @@ MONITORING = (
         "/usr/share/doc/rustbgpd/monitoring/rustbgpd-alerts_test.yml",
     ),
 )
+SYSTEMD_UNIT = "examples/systemd/rustbgpd.service"
+COMPOSE_FILE = "examples/docker-compose/docker-compose.yml"
+SYSTEMD_DIRECTIVES = {
+    ("Unit", "StartLimitIntervalSec"): "10min",
+    ("Unit", "StartLimitBurst"): "5",
+    ("Service", "Restart"): "on-failure",
+    ("Service", "RestartSec"): "5",
+    ("Service", "TimeoutStopSec"): "32min",
+}
 
 
 def exact(command: str) -> str:
@@ -52,7 +61,9 @@ def select_script(text: str, label: str, discriminator: str) -> str:
         if re.search(exact(discriminator), script, re.MULTILINE)
     ]
     if len(matches) != 1:
-        raise ValueError(f"{label}: expected one matching run body, found {len(matches)}")
+        raise ValueError(
+            f"{label}: expected one matching run body, found {len(matches)}"
+        )
     return matches[0]
 
 
@@ -81,23 +92,142 @@ def active_script(step: str) -> str:
     return "\n".join(commands)
 
 
-def require_patterns(errors: list[str], label: str, text: str, patterns: tuple[str, ...]) -> None:
-    missing = [pattern for pattern in patterns if not re.search(pattern, text, re.MULTILINE)]
+def require_patterns(
+    errors: list[str], label: str, text: str, patterns: tuple[str, ...]
+) -> None:
+    missing = [
+        pattern for pattern in patterns if not re.search(pattern, text, re.MULTILINE)
+    ]
     if missing:
         errors.append(f"{label}: missing active commands {missing!r}")
+
+
+def systemd_logical_lines(text: str) -> tuple[str, ...]:
+    logical = []
+    continued = ""
+    for raw_line in text.splitlines():
+        if raw_line.lstrip().startswith(("#", ";")):
+            continue
+        line = raw_line.rstrip()
+        if continued:
+            line = continued + " " + line.lstrip()
+        if line.endswith("\\"):
+            continued = line[:-1].rstrip()
+        else:
+            logical.append(line)
+            continued = ""
+    if continued:
+        logical.append(continued)
+    return tuple(logical)
+
+
+def systemd_assignments(text: str) -> tuple[tuple[str | None, str, str], ...]:
+    section: str | None = None
+    assignments = []
+    for raw_line in systemd_logical_lines(text):
+        line = raw_line.strip()
+        if not line or line.startswith(("#", ";")):
+            continue
+        if match := re.fullmatch(r"\[([^]]+)\]", line):
+            section = match.group(1)
+        elif "=" in line:
+            key, value = line.split("=", 1)
+            assignments.append((section, key.strip(), value.strip()))
+    return tuple(assignments)
+
+
+def systemd_status_is_70(token: str) -> bool:
+    token = token.removeprefix("+")
+    if token == "SOFTWARE":
+        return True
+    try:
+        if token.lower().startswith("0b"):
+            base = 2
+        elif token.lower().startswith("0x"):
+            base = 16
+        elif len(token) > 1 and token.startswith("0"):
+            base = 8
+        else:
+            base = 10
+        return int(token, base) == 70
+    except ValueError:
+        return False
+
+
+def check_systemd_unit(errors: list[str], text: str) -> None:
+    assignments = systemd_assignments(text)
+    for (section, key), expected in SYSTEMD_DIRECTIVES.items():
+        actual = [
+            value
+            for found_section, found_key, value in assignments
+            if found_section == section and found_key == key
+        ]
+        if actual != [expected]:
+            errors.append(
+                f"systemd unit: [{section}] {key} must occur once with value {expected!r}, got {actual!r}"
+            )
+    for _, key, value in assignments:
+        if key in {"SuccessExitStatus", "RestartPreventExitStatus"} and any(
+            systemd_status_is_70(token) for token in value.split()
+        ):
+            errors.append(
+                f"systemd unit: {key} must not classify exit 70/SOFTWARE as non-restartable"
+            )
+
+
+def compose_service(text: str, name: str) -> tuple[str, ...]:
+    lines = text.splitlines()
+    marker = f"  {name}:"
+    try:
+        start = lines.index(marker) + 1
+    except ValueError:
+        return ()
+    body = []
+    for line in lines[start:]:
+        if (
+            line.strip()
+            and not line.lstrip().startswith("#")
+            and len(line) - len(line.lstrip()) <= 2
+        ):
+            break
+        body.append(line)
+    return tuple(body)
+
+
+def check_compose(errors: list[str], text: str) -> None:
+    service = compose_service(text, "rustbgpd")
+    if not service:
+        errors.append("docker compose: rustbgpd service missing or empty")
+        return
+    grace = [
+        match.group(1).strip()
+        for line in service
+        if (match := re.fullmatch(r"    stop_grace_period:\s*(.*?)\s*", line))
+    ]
+    if grace != ["32m"]:
+        errors.append(
+            f"docker compose: rustbgpd stop_grace_period must occur once as 32m, got {grace!r}"
+        )
+    if any(re.match(r"^\s+(?:restart|restart_policy):", line) for line in service):
+        errors.append("docker compose: rustbgpd must not declare a restart policy")
 
 
 def check(root: Path) -> list[str]:
     errors: list[str] = []
     read = lambda path: (root / path).read_text(encoding="utf-8")
     try:
+        check_systemd_unit(errors, read(SYSTEMD_UNIT))
+        check_compose(errors, read(COMPOSE_FILE))
         release = read(".github/workflows/release.yml")
         package_tar = (
             "tar -C staging -czf dist/rustbgpd-${SUFFIX}.tar.gz rustbgpd rbgp "
             "rs-config-render birdwatcher-adapter LICENSE-MIT LICENSE-APACHE rustbgpd.schema.json share"
         )
         package = select_script(release, "tarball package commands", package_tar)
-        package_patterns = tuple(rf"^cp target/\$\{{\{{ matrix\.target \}}\}}/release/{binary} staging/$" for binary in BINARIES) + (
+        package_patterns = tuple(
+            rf"^cp target/\$\{{\{{ matrix\.target \}}\}}/release/{binary} staging/$"
+            for binary in BINARIES
+        ) + (
             r"^cp examples/systemd/rustbgpd\.service examples/systemd/rustbgpd-dataplane\.conf staging/share/systemd/$",
             r"^cp docs/grafana/rustbgpd-overview\.json staging/share/monitoring/$",
             r"^cp examples/prometheus/rustbgpd-alerts\.yml examples/prometheus/rustbgpd-alerts_test\.yml staging/share/monitoring/$",
@@ -115,10 +245,14 @@ def check(root: Path) -> list[str]:
         asserted = set(inventory.group(1).split()) if inventory else set()
         missing_payloads = set(payloads) - asserted
         if missing_payloads:
-            errors.append(f"tarball payload assertions: missing {sorted(missing_payloads)!r}")
+            errors.append(
+                f"tarball payload assertions: missing {sorted(missing_payloads)!r}"
+            )
         tar_checks = (
             exact('if ! grep -qxF "$f" <<<"$entries"; then'),
-            exact('if [ "$(tar -xOzf "dist/rustbgpd-${SUFFIX}.tar.gz" "$f" | wc -c)" -eq 0 ]; then'),
+            exact(
+                'if [ "$(tar -xOzf "dist/rustbgpd-${SUFFIX}.tar.gz" "$f" | wc -c)" -eq 0 ]; then'
+            ),
         )
         require_patterns(errors, "tarball active assertions", assertion, tar_checks)
 
@@ -136,14 +270,18 @@ def check(root: Path) -> list[str]:
         expected_monitoring = {(source, native) for source, _, native in MONITORING}
         missing_monitoring = expected_monitoring - mappings
         if missing_monitoring:
-            errors.append(f"native monitoring mappings missing {sorted(missing_monitoring)!r}")
+            errors.append(
+                f"native monitoring mappings missing {sorted(missing_monitoring)!r}"
+            )
         for source, _, _ in MONITORING:
             if not (root / source).is_file() or (root / source).stat().st_size == 0:
                 errors.append(f"monitoring source missing or empty: {source}")
 
         contract = read(".github/workflows/release-install-contract.yml")
         native = select_script(
-            contract, "real native package assertions", 'dpkg-deb -x "$deb" extracted/deb'
+            contract,
+            "real native package assertions",
+            'dpkg-deb -x "$deb" extracted/deb',
         )
         require_patterns(
             errors,
@@ -159,6 +297,13 @@ def check(root: Path) -> list[str]:
                 r"^for exe in rustbgpd rbgp rs-config-render birdwatcher-adapter; do$",
                 r'^test -x "\$tree/usr/bin/\$exe" ',
                 r'^"\$tree/usr/bin/rustbgpd" --check "\$tree/etc/rustbgpd/config\.toml"$',
+                r'^unit="\$tree/lib/systemd/system/rustbgpd\.service"$',
+                r"^for directive in StartLimitIntervalSec=10min StartLimitBurst=5 Restart=on-failure RestartSec=5 TimeoutStopSec=32min; do$",
+                r'^grep -qxF "\$directive" "\$unit"$',
+                r"^from scripts\.check_release_install_contract import systemd_assignments, systemd_status_is_70$",
+                r"^for _, key, value in systemd_assignments\(Path\(sys\.argv\[1\]\)\.read_text\(\)\):$",
+                r'^if key in \{"SuccessExitStatus", "RestartPreventExitStatus"\} and any\($',
+                r"^systemd_status_is_70\(token\) for token in value\.split\(\)$",
             ),
         )
         if "--to-stdout" in native:

--- a/scripts/test_check_release_install_contract.py
+++ b/scripts/test_check_release_install_contract.py
@@ -15,9 +15,13 @@ CHECK = '"$tree/usr/bin/rustbgpd" --check "$tree/etc/rustbgpd/config.toml"'
 RPM_EXTRACT = "cpio --quiet -id --no-absolute-filenames --directory=extracted/rpm"
 EXE_LOOP = "for exe in rustbgpd rbgp rs-config-render birdwatcher-adapter; do"
 IMAGE_RUN = "run: docker run --rm --entrypoint birdwatcher-adapter"
+UNIT_ASSERT = 'grep -qxF "$directive" "$unit"'
+STATUS_GUARD = "from scripts.check_release_install_contract import systemd_assignments, systemd_status_is_70"
 MONITORING_MAPPING = "native monitoring mappings"
 GREP_ASSERT = 'if ! grep -qxF "$f" <<<"$entries"; then'
-TAR_SIZE_ASSERT = 'if [ "$(tar -xOzf "dist/rustbgpd-${SUFFIX}.tar.gz" "$f" | wc -c)" -eq 0 ]; then'
+TAR_SIZE_ASSERT = (
+    'if [ "$(tar -xOzf "dist/rustbgpd-${SUFFIX}.tar.gz" "$f" | wc -c)" -eq 0 ]; then'
+)
 INPUTS = (
     WORKFLOW,
     RELEASE,
@@ -25,6 +29,8 @@ INPUTS = (
     "docs/grafana/rustbgpd-overview.json",
     "examples/prometheus/rustbgpd-alerts.yml",
     "examples/prometheus/rustbgpd-alerts_test.yml",
+    contract.SYSTEMD_UNIT,
+    contract.COMPOSE_FILE,
 )
 MUTATIONS = (
     (
@@ -33,15 +39,146 @@ MUTATIONS = (
         "                   removed-alert-tests.yml; do\n          # share/monitoring/rustbgpd-alerts_test.yml; do",
         "tarball payload assertions",
     ),
-    ("packaging/nfpm.yaml", "contents:\n", "contents:\n  - src: extra\n    dst: /usr/bin/extra\n", "native binary destinations"),
-    (WORKFLOW, 'dpkg-deb -x "$deb" extracted/deb', 'echo dpkg-deb -x "$deb" extracted/deb', "real native package assertions"),
-    (WORKFLOW, RPM_EXTRACT, "cpio --quiet -i --to-stdout", "real native package assertions"),
-    (WORKFLOW, EXE_LOOP, "for exe in rustbgpd rbgp rs-config-render; do", "real native package assertions"),
-    (WORKFLOW, CHECK, CHECK.replace('"$tree/etc', '"/etc'), "real native package assertions"),
+    (
+        "packaging/nfpm.yaml",
+        "contents:\n",
+        "contents:\n  - src: extra\n    dst: /usr/bin/extra\n",
+        "native binary destinations",
+    ),
+    (
+        WORKFLOW,
+        'dpkg-deb -x "$deb" extracted/deb',
+        'echo dpkg-deb -x "$deb" extracted/deb',
+        "real native package assertions",
+    ),
+    (
+        WORKFLOW,
+        RPM_EXTRACT,
+        "cpio --quiet -i --to-stdout",
+        "real native package assertions",
+    ),
+    (
+        WORKFLOW,
+        EXE_LOOP,
+        "for exe in rustbgpd rbgp rs-config-render; do",
+        "real native package assertions",
+    ),
+    (
+        WORKFLOW,
+        CHECK,
+        CHECK.replace('"$tree/etc', '"/etc'),
+        "real native package assertions",
+    ),
     (WORKFLOW, CHECK, "true\n            # " + CHECK, "real native package assertions"),
-    (WORKFLOW, IMAGE_RUN, IMAGE_RUN.replace("birdwatcher-adapter", "rustbgpd"), "production image adapter assertion"),
-    (RELEASE, GREP_ASSERT, 'if ! echo \'grep -qxF "$f" <<<"$entries"\'; then', "tarball active assertions"),
-    (RELEASE, TAR_SIZE_ASSERT, TAR_SIZE_ASSERT.replace("tar -xOzf", "echo 'tar -xOzf") + "'", "tarball active assertions"),
+    (
+        WORKFLOW,
+        IMAGE_RUN,
+        IMAGE_RUN.replace("birdwatcher-adapter", "rustbgpd"),
+        "production image adapter assertion",
+    ),
+    (
+        RELEASE,
+        GREP_ASSERT,
+        'if ! echo \'grep -qxF "$f" <<<"$entries"\'; then',
+        "tarball active assertions",
+    ),
+    (
+        RELEASE,
+        TAR_SIZE_ASSERT,
+        TAR_SIZE_ASSERT.replace("tar -xOzf", "echo 'tar -xOzf") + "'",
+        "tarball active assertions",
+    ),
+    (
+        contract.SYSTEMD_UNIT,
+        "StartLimitIntervalSec=10min",
+        "StartLimitIntervalSec=9min",
+        "systemd unit",
+    ),
+    (
+        contract.SYSTEMD_UNIT,
+        "TimeoutStopSec=32min",
+        "TimeoutStopSec=31min",
+        "systemd unit",
+    ),
+    (
+        contract.SYSTEMD_UNIT,
+        "[Service]",
+        "[Service]\nSuccessExitStatus=SOFTWARE",
+        "systemd unit",
+    ),
+    (
+        contract.SYSTEMD_UNIT,
+        "[Service]",
+        "[Service]\nSuccessExitStatus=0x46",
+        "systemd unit",
+    ),
+    (
+        contract.SYSTEMD_UNIT,
+        "[Service]",
+        "[Service]\nRestartPreventExitStatus=+70",
+        "systemd unit",
+    ),
+    (
+        contract.SYSTEMD_UNIT,
+        "[Service]",
+        "[Service]\nRestartPreventExitStatus=0106",
+        "systemd unit",
+    ),
+    (
+        contract.SYSTEMD_UNIT,
+        "[Service]",
+        "[Service]\nSuccessExitStatus=0b1000110",
+        "systemd unit",
+    ),
+    (
+        contract.SYSTEMD_UNIT,
+        "[Service]",
+        "[Service]\nRestartPreventExitStatus=+0B1000110",
+        "systemd unit",
+    ),
+    (
+        contract.SYSTEMD_UNIT,
+        "[Service]",
+        "[Service]\nSuccessExitStatus=\\\n 70",
+        "systemd unit",
+    ),
+    (
+        contract.SYSTEMD_UNIT,
+        "[Service]",
+        "[Service]\nRestartPreventExitStatus=\\\n 0x46",
+        "systemd unit",
+    ),
+    (
+        contract.SYSTEMD_UNIT,
+        "[Service]",
+        "[Service]\n# ignored comment \\\nSuccessExitStatus=70",
+        "systemd unit",
+    ),
+    (
+        contract.SYSTEMD_UNIT,
+        "[Service]",
+        "[Service]\nRestartPreventExitStatus=\\\n# ignored comment\n; ignored too\n 0x46",
+        "systemd unit",
+    ),
+    (
+        contract.COMPOSE_FILE,
+        "stop_grace_period: 32m",
+        "stop_grace_period: 31m",
+        "docker compose",
+    ),
+    (
+        contract.COMPOSE_FILE,
+        "stop_grace_period: 32m",
+        "restart: on-failure\n    stop_grace_period: 32m",
+        "docker compose",
+    ),
+    (WORKFLOW, UNIT_ASSERT, "true # " + UNIT_ASSERT, "real native package assertions"),
+    (
+        WORKFLOW,
+        STATUS_GUARD,
+        "if false; then # " + STATUS_GUARD,
+        "real native package assertions",
+    ),
 )
 
 
@@ -72,46 +209,122 @@ class ReleaseInstallContractTest(unittest.TestCase):
 
     def test_every_tarball_payload_is_asserted(self) -> None:
         marker = "          for f in "
-        for payload in contract.BINARIES + contract.SYSTEMD + tuple(item[1] for item in contract.MONITORING):
+        for payload in (
+            contract.BINARIES
+            + contract.SYSTEMD
+            + tuple(item[1] for item in contract.MONITORING)
+        ):
             with self.subTest(payload=payload):
                 root = self.fixture()
                 path = root / RELEASE
                 before, after = path.read_text().split(marker, 1)
                 self.assertIn(payload, after)
-                path.write_text(before + marker + after.replace(payload, "removed-payload", 1))
-                self.assertTrue(any("tarball payload assertions" in error for error in contract.check(root)))
+                path.write_text(
+                    before + marker + after.replace(payload, "removed-payload", 1)
+                )
+                self.assertTrue(
+                    any(
+                        "tarball payload assertions" in error
+                        for error in contract.check(root)
+                    )
+                )
 
     def test_every_monitoring_source_is_packaged_and_mapped(self) -> None:
         for source, _, native in contract.MONITORING:
-            for path, token, label in ((RELEASE, source, "tarball package commands"), ("packaging/nfpm.yaml", native, MONITORING_MAPPING)):
+            for path, token, label in (
+                (RELEASE, source, "tarball package commands"),
+                ("packaging/nfpm.yaml", native, MONITORING_MAPPING),
+            ):
                 with self.subTest(path=path, token=token):
                     root = self.fixture()
                     target = root / path
-                    target.write_text(target.read_text().replace(token, "removed-monitoring", 1))
+                    target.write_text(
+                        target.read_text().replace(token, "removed-monitoring", 1)
+                    )
                     errors = contract.check(root)
                     self.assertTrue(any(label in error for error in errors))
                     if path == "packaging/nfpm.yaml":
-                        self.assertTrue(any(repr((source, native)) in error for error in errors), errors)
+                        self.assertTrue(
+                            any(repr((source, native)) in error for error in errors),
+                            errors,
+                        )
 
     def test_every_native_binary_destination_is_exact(self) -> None:
         for binary in contract.BINARIES:
             with self.subTest(binary=binary):
                 root = self.fixture()
                 path = root / "packaging/nfpm.yaml"
-                text = path.read_text().replace(f"dst: /usr/bin/{binary}", "dst: /usr/bin/removed", 1)
+                text = path.read_text().replace(
+                    f"dst: /usr/bin/{binary}", "dst: /usr/bin/removed", 1
+                )
                 path.write_text(text)
-                self.assertTrue(any("native binary destinations" in error for error in contract.check(root)))
+                self.assertTrue(
+                    any(
+                        "native binary destinations" in error
+                        for error in contract.check(root)
+                    )
+                )
+
+    def test_systemd_directive_section_is_exact(self) -> None:
+        root = self.fixture()
+        path = root / contract.SYSTEMD_UNIT
+        text = path.read_text()
+        text = text.replace("StartLimitBurst=5\n", "", 1).replace(
+            "[Service]\n", "[Service]\nStartLimitBurst=5\n", 1
+        )
+        path.write_text(text)
+        self.assertTrue(any("systemd unit" in error for error in contract.check(root)))
+
+    def test_systemd_exit_70_spellings_are_closed(self) -> None:
+        for token in (
+            "70",
+            "+70",
+            "0x46",
+            "+0X46",
+            "0b1000110",
+            "+0B1000110",
+            "0106",
+            "+0106",
+            "SOFTWARE",
+            "+SOFTWARE",
+        ):
+            with self.subTest(token=token):
+                self.assertTrue(contract.systemd_status_is_70(token))
+        for token in ("69", "0x47", "0105", "EX_SOFTWARE", "SIGTERM"):
+            with self.subTest(token=token):
+                self.assertFalse(contract.systemd_status_is_70(token))
+
+    def test_systemd_continuations_are_unfolded(self) -> None:
+        text = (
+            "[Service]\n"
+            "# standalone ignored \\\n"
+            "SuccessExitStatus=\\\n"
+            "# continued comment ignored\n"
+            "; another ignored comment \\\n"
+            " +0x46\\\n"
+            " 69\n"
+        )
+        self.assertEqual(
+            contract.systemd_assignments(text),
+            (("Service", "SuccessExitStatus", "+0x46 69"),),
+        )
 
     def test_empty_monitoring_source_fails(self) -> None:
         root = self.fixture()
         (root / "docs/grafana/rustbgpd-overview.json").write_text("")
-        self.assertTrue(any("missing or empty" in error for error in contract.check(root)))
+        self.assertTrue(
+            any("missing or empty" in error for error in contract.check(root))
+        )
 
     def test_presentation_edits_do_not_gate_artifacts(self) -> None:
         root = self.fixture()
         path = root / WORKFLOW
         text = path.read_text()
-        for old in ("- README.md", "- scripts/check_release_install_contract.py", "cargo test -p birdwatcher-adapter"):
+        for old in (
+            "- README.md",
+            "- scripts/check_release_install_contract.py",
+            "cargo test -p birdwatcher-adapter",
+        ):
             text = text.replace(old, "removed-presentation")
         path.write_text(text)
         self.assertEqual(contract.check(root), [])
@@ -147,7 +360,10 @@ class ReleaseInstallContractTest(unittest.TestCase):
         text = text.replace(decoy, TAR_SIZE_ASSERT, 1)
         path.write_text(text)
         errors = contract.check(root)
-        self.assertTrue(any("tarball active assertions" in error for error in errors), errors)
+        self.assertTrue(
+            any("tarball active assertions" in error for error in errors), errors
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- cap systemd restart recovery at five starts per ten minutes and retain exit 70 as a restartable failure
- give systemd, Compose, and standalone Docker the full settlement watchdog stop window
- document shipped fail-stop behavior, read-only publication ambiguity, and operator recovery while keeping ADR-0127 Proposed
- harden source and packaged-unit release checks against every systemd spelling of exit 70

## Validation

- `python3 -m unittest -v scripts/test_check_release_install_contract.py`
- `python3 scripts/check_release_install_contract.py`
- `docker compose -f examples/docker-compose/docker-compose.yml config --quiet`
- `systemd-analyze verify` with a temporary valid `ExecStart`
- `python3 scripts/check_public_tracker_ids.py`
- `cargo fmt --all -- --check`
- `git diff --check`

ADR-0127 remains Proposed: transaction/Apply, Neighbor4, FIB2, PeerGroup4, and Policy12 are wired; SIGHUP, observability, and the final recovery matrix remain.
