### PR TITLE
ci: share verified grpcurl artifacts across heavy labs

### DIFF
--- a/.github/actions/install-grpcurl-artifact/action.yml
+++ b/.github/actions/install-grpcurl-artifact/action.yml
@@ -1,0 +1,21 @@
+name: "Install verified grpcurl artifact"
+description: >-
+  Download the same-run grpcurl archive, verify its immutable checksum and
+  version offline, and install it on the hosted runner.
+runs:
+  using: "composite"
+  steps:
+    - name: Download verified grpcurl archive
+      uses: actions/download-artifact@v8
+      with:
+        name: grpcurl-v1.9.1-linux-x86_64
+        path: ${{ runner.temp }}/grpcurl-artifact
+
+    - name: Install exact grpcurl offline
+      shell: bash
+      run: |
+        set -euo pipefail
+        .github/scripts/install-grpcurl.sh \
+          --install-archive \
+          "$RUNNER_TEMP/grpcurl-artifact/grpcurl_1.9.1_linux_x86_64.tar.gz" \
+          /usr/local/bin

--- a/.github/actions/setup-dataplane-host/action.yml
+++ b/.github/actions/setup-dataplane-host/action.yml
@@ -32,7 +32,10 @@ runs:
       with:
         version: ${{ inputs.containerlab-version }}
 
-    - name: Install grpcurl + jq
+    - name: Install exact grpcurl offline
+      uses: ./.github/actions/install-grpcurl-artifact
+
+    - name: Ensure jq
       shell: bash
       run: |
         set -euo pipefail
@@ -45,7 +48,6 @@ runs:
             echo "::warning::apt-get update reported repo errors; installing jq from cache"
           sudo apt-get install -y jq
         fi
-        bash .github/scripts/install-grpcurl.sh
 
     - name: Load kernel dataplane modules (vrf / vxlan / bridge / bonding)
       id: dataplane-modules

--- a/.github/scripts/install-grpcurl.sh
+++ b/.github/scripts/install-grpcurl.sh
@@ -8,62 +8,103 @@ readonly GRPCURL_ASSET="grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz"
 readonly GRPCURL_URL="https://github.com/fullstorydev/grpcurl/releases/download/v${GRPCURL_VERSION}/${GRPCURL_ASSET}"
 readonly GRPCURL_ATTEMPTS=3
 
-install_grpcurl() (
-    local version=${1:?version}
-    local sha256=${2:?sha256}
-    local url=${3:?url}
-    local install_dir=${4:?install directory}
-    local work_dir archive reported_version
+verify_archive() {
+    local sha256=${1:?sha256}
+    local archive=${2:?archive}
 
-    work_dir=$(mktemp -d)
-    trap 'rm -rf -- "$work_dir"' EXIT
-    archive="$work_dir/grpcurl.tar.gz"
-
-    # Download to a file rather than streaming into tar, so extraction cannot
-    # see unverified bytes. Single retry mechanism: the caller's loop owns
-    # retry and backoff, because only the checksum below catches a truncated
-    # or corrupted 200-OK body that `curl --retry` treats as success. Nesting
-    # `curl --retry` inside that loop would multiply the worst case past the
-    # interop job timeout.
-    curl -fsSL \
-        --connect-timeout 10 \
-        --max-time 120 \
-        --output "$archive" \
-        "$url"
-
-    if ! printf '%s  %s\n' "$sha256" "$archive" | sha256sum --check --status; then
-        echo "grpcurl ${version} archive checksum mismatch" >&2
+    [[ -f "$archive" ]] || return 1
+    if ! printf '%s  %s\n' "$sha256" "$archive" \
+        | sha256sum --check --status; then
+        echo "grpcurl archive checksum mismatch: ${archive}" >&2
         return 1
     fi
+}
 
-    if [[ -w "$install_dir" ]]; then
-        tar -xzf "$archive" -C "$install_dir" grpcurl
-    else
-        sudo tar -xzf "$archive" -C "$install_dir" grpcurl
-    fi
+install_from_archive() (
+    local version=${1:?version}
+    local sha256=${2:?sha256}
+    local archive=${3:?archive}
+    local install_dir=${4:?install directory}
+    local work_dir staged_target reported_version
 
-    reported_version=$("$install_dir/grpcurl" -version 2>&1)
+    # This path is deliberately offline. Producers are the only workflow jobs
+    # allowed to fetch the release archive; consumers re-verify the same-run
+    # artifact before tar sees any bytes.
+    verify_archive "$sha256" "$archive" || return 1
+
+    work_dir=$(mktemp -d) || return 1
+    trap 'rm -rf -- "$work_dir"' EXIT
+    tar -xzf "$archive" -C "$work_dir" grpcurl || return 1
+    [[ -f "$work_dir/grpcurl" ]] || {
+        echo "grpcurl archive did not contain grpcurl" >&2
+        return 1
+    }
+    chmod 0755 "$work_dir/grpcurl" || return 1
+    reported_version=$("$work_dir/grpcurl" -version 2>&1) || return 1
     if [[ "$reported_version" != "grpcurl v${version}" ]]; then
         echo "unexpected grpcurl version: ${reported_version}" >&2
         return 1
     fi
+
+    if [[ -d "$install_dir" && -w "$install_dir" ]] \
+        || { [[ ! -e "$install_dir" ]] && [[ -w "$(dirname "$install_dir")" ]]; }; then
+        mkdir -p "$install_dir"
+        staged_target=$(mktemp "${install_dir}/.grpcurl.XXXXXX")
+        trap 'rm -rf -- "$work_dir"; rm -f -- "$staged_target"' EXIT
+        install -m 0755 "$work_dir/grpcurl" "$staged_target"
+        mv -f -- "$staged_target" "$install_dir/grpcurl"
+    else
+        staged_target="${install_dir}/.grpcurl.$$.${RANDOM}"
+        sudo mkdir -p "$install_dir"
+        sudo install -m 0755 "$work_dir/grpcurl" "$staged_target"
+        trap 'rm -rf -- "$work_dir"; sudo rm -f -- "$staged_target"' EXIT
+        sudo mv -f -- "$staged_target" "$install_dir/grpcurl"
+    fi
+
+    reported_version=$("$install_dir/grpcurl" -version 2>&1) || return 1
+    [[ "$reported_version" == "grpcurl v${version}" ]] || {
+        echo "installed grpcurl version check failed: ${reported_version}" >&2
+        return 1
+    }
     printf '%s\n' "$reported_version"
 )
 
-# The hosted release download is the only external fetch every Interop job
-# shares, so one CDN hiccup reds a ~38-job run. Retry download *and*
-# verification as a unit: a truncated or corrupted archive is re-fetched
-# rather than accepted, because each attempt re-runs the checksum and version
-# checks and a rejected archive is never installed. Persistent failure still
-# fails closed after the bounded attempts, naming the URL.
-install_grpcurl_with_retry() {
-    local url=${3:?url}
-    local attempt
+download_archive_once() {
+    local url=${1:?url}
+    local destination=${2:?destination}
 
+    curl -fsSL \
+        --connect-timeout 10 \
+        --max-time 120 \
+        --output "$destination" \
+        "$url"
+}
+
+prepare_archive() {
+    local sha256=${1:?sha256}
+    local url=${2:?url}
+    local archive=${3:?archive}
+    local attempt staged_archive
+
+    if verify_archive "$sha256" "$archive" 2>/dev/null; then
+        echo "using verified cached grpcurl archive"
+        return 0
+    fi
+    if [[ -e "$archive" ]]; then
+        echo "::warning::discarding invalid cached grpcurl archive" >&2
+        rm -f -- "$archive"
+    fi
+
+    mkdir -p "$(dirname "$archive")"
     for ((attempt = 1; attempt <= GRPCURL_ATTEMPTS; attempt++)); do
-        if install_grpcurl "$@"; then
+        staged_archive=$(mktemp "${archive}.download.XXXXXX")
+        if download_archive_once "$url" "$staged_archive" \
+            && verify_archive "$sha256" "$staged_archive"; then
+            mv -f -- "$staged_archive" "$archive"
+            echo "downloaded and verified grpcurl archive"
             return 0
         fi
+        rm -f -- "$staged_archive"
         if ((attempt < GRPCURL_ATTEMPTS)); then
             echo "::warning::grpcurl download/verify attempt ${attempt}/${GRPCURL_ATTEMPTS} failed; retrying" >&2
             sleep $((attempt * 5))
@@ -80,15 +121,24 @@ fail_self_test() {
 }
 
 self_test() (
-    local repo_root fixture_dir source_dir base_archive archive checksum truncated_size
-    local wrong_version_archive wrong_version_checksum retry_counter
-    local named_steps workflow_calls setup_calls
+    local repo_root fixture_dir source_dir base_archive valid_archive checksum
+    local truncated_size wrong_source wrong_archive wrong_checksum counter
+    local cache_path target_path interop_calls setup_calls prepare_calls install_calls
 
     repo_root=$(git rev-parse --show-toplevel)
     fixture_dir=$(mktemp -d)
     trap 'rm -rf -- "$fixture_dir"' EXIT
+    [[ "$GRPCURL_VERSION" == "1.9.1" ]] \
+        || fail_self_test "version pin drifted"
     [[ "$GRPCURL_SHA256" == "588c9c429476d9ed66cd3b2ae32283a6da36e0cfbb7e446f5d6a1b68dc770214" ]] \
-        || fail_self_test "pinned grpcurl v1.9.1 checksum drifted"
+        || fail_self_test "checksum pin drifted"
+    [[ "$GRPCURL_ASSET" == "grpcurl_1.9.1_linux_x86_64.tar.gz" ]] \
+        || fail_self_test "archive name drifted"
+    [[ "$GRPCURL_URL" == "https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz" ]] \
+        || fail_self_test "release URL drifted"
+    [[ "$GRPCURL_ATTEMPTS" -eq 3 ]] \
+        || fail_self_test "retry bound drifted"
+
     source_dir="$fixture_dir/source"
     mkdir -p "$source_dir"
     cat >"$source_dir/grpcurl" <<'EOF'
@@ -96,137 +146,189 @@ self_test() (
 printf '%s\n' 'grpcurl v1.9.1' >&2
 EOF
     chmod +x "$source_dir/grpcurl"
-    # A second empty gzip member makes the full fixture distinct while the
-    # prefix remains a valid, extractable archive. Removing that final member
-    # therefore models a truncated transfer that tar alone would accept; only
-    # the checksum can make the negative case fail before extraction.
-    base_archive="$fixture_dir/grpcurl-base.tar.gz"
-    archive="$fixture_dir/grpcurl-valid.tar.gz"
+    # The extra gzip member makes the full fixture distinct while its prefix
+    # remains extractable. Only the checksum rejects that plausible truncation.
+    base_archive="$fixture_dir/base.tar.gz"
+    valid_archive="$fixture_dir/valid.tar.gz"
     tar -czf "$base_archive" -C "$source_dir" grpcurl
-    cp "$base_archive" "$archive"
-    printf '' | gzip >>"$archive"
-    checksum=$(sha256sum "$archive" | awk '{print $1}')
+    cp "$base_archive" "$valid_archive"
+    printf '' | gzip >>"$valid_archive"
+    checksum=$(sha256sum "$valid_archive" | awk '{print $1}')
 
-    mkdir "$fixture_dir/valid-install"
-    install_grpcurl \
-        "$GRPCURL_VERSION" \
-        "$checksum" \
-        "file://$archive" \
+    install_from_archive \
+        "$GRPCURL_VERSION" "$checksum" "$valid_archive" \
         "$fixture_dir/valid-install"
     [[ -x "$fixture_dir/valid-install/grpcurl" ]] \
         || fail_self_test "verified archive was not installed"
 
     truncated_size=$(wc -c <"$base_archive")
-    head -c "$truncated_size" "$archive" >"$fixture_dir/grpcurl-truncated.tar.gz"
-    mkdir "$fixture_dir/truncated-install"
-    if install_grpcurl \
-        "$GRPCURL_VERSION" \
-        "$checksum" \
-        "file://$fixture_dir/grpcurl-truncated.tar.gz" \
+    head -c "$truncated_size" "$valid_archive" >"$fixture_dir/truncated.tar.gz"
+    if install_from_archive \
+        "$GRPCURL_VERSION" "$checksum" "$fixture_dir/truncated.tar.gz" \
         "$fixture_dir/truncated-install" 2>/dev/null; then
         fail_self_test "truncated archive was accepted"
     fi
     [[ ! -e "$fixture_dir/truncated-install/grpcurl" ]] \
-        || fail_self_test "truncated archive was extracted"
+        || fail_self_test "truncated archive installed a binary"
 
-    mkdir "$fixture_dir/wrong-checksum-install"
-    if install_grpcurl \
+    if install_from_archive \
         "$GRPCURL_VERSION" \
-        "0000000000000000000000000000000000000000000000000000000000000000" \
-        "file://$archive" \
-        "$fixture_dir/wrong-checksum-install" 2>/dev/null; then
+        0000000000000000000000000000000000000000000000000000000000000000 \
+        "$valid_archive" "$fixture_dir/wrong-checksum-install" 2>/dev/null; then
         fail_self_test "wrong checksum was accepted"
     fi
     [[ ! -e "$fixture_dir/wrong-checksum-install/grpcurl" ]] \
-        || fail_self_test "wrong-checksum archive was extracted"
+        || fail_self_test "wrong-checksum archive installed a binary"
 
-    mkdir "$fixture_dir/wrong-version-source" "$fixture_dir/wrong-version-install"
-    cat >"$fixture_dir/wrong-version-source/grpcurl" <<'EOF'
+    wrong_source="$fixture_dir/wrong-source"
+    mkdir -p "$wrong_source"
+    cat >"$wrong_source/grpcurl" <<'EOF'
 #!/usr/bin/env sh
 printf '%s\n' 'grpcurl v1.9.0' >&2
 EOF
-    chmod +x "$fixture_dir/wrong-version-source/grpcurl"
-    wrong_version_archive="$fixture_dir/grpcurl-wrong-version.tar.gz"
-    tar -czf "$wrong_version_archive" \
-        -C "$fixture_dir/wrong-version-source" grpcurl
-    wrong_version_checksum=$(sha256sum "$wrong_version_archive" | awk '{print $1}')
-    if install_grpcurl \
-        "$GRPCURL_VERSION" \
-        "$wrong_version_checksum" \
-        "file://$wrong_version_archive" \
+    chmod +x "$wrong_source/grpcurl"
+    wrong_archive="$fixture_dir/wrong-version.tar.gz"
+    tar -czf "$wrong_archive" -C "$wrong_source" grpcurl
+    wrong_checksum=$(sha256sum "$wrong_archive" | awk '{print $1}')
+    if install_from_archive \
+        "$GRPCURL_VERSION" "$wrong_checksum" "$wrong_archive" \
         "$fixture_dir/wrong-version-install" 2>/dev/null; then
         fail_self_test "wrong grpcurl version was accepted"
     fi
+    [[ ! -e "$fixture_dir/wrong-version-install/grpcurl" ]] \
+        || fail_self_test "wrong-version binary reached the install path"
 
-    # Retry cases stub the installer and `sleep` so the loop is exercised
-    # without network access or real backoff waits.
-    retry_counter="$fixture_dir/retry-attempts"
-    printf '0' >"$retry_counter"
+    # Cache and retry cases replace only the network primitive and sleep, so
+    # the self-test remains offline while exercising the real selection logic.
+    counter="$fixture_dir/download-count"
+    cache_path="$fixture_dir/cache/$GRPCURL_ASSET"
+    mkdir -p "$(dirname "$cache_path")"
+    cp "$valid_archive" "$cache_path"
+    printf '0' >"$counter"
     (
-        sleep() { :; }
-        install_grpcurl() {
-            local count
-            count=$(($(cat "$retry_counter") + 1))
-            printf '%s' "$count" >"$retry_counter"
-            [[ "$count" -ge 2 ]]
-        }
-        install_grpcurl_with_retry \
-            "$GRPCURL_VERSION" "$GRPCURL_SHA256" "$GRPCURL_URL" /usr/local/bin
-    ) 2>/dev/null || fail_self_test "retry did not recover from a transient failure"
-    [[ "$(cat "$retry_counter")" -eq 2 ]] \
-        || fail_self_test "retry did not stop on the first success"
-
-    printf '0' >"$retry_counter"
-    if (
-        sleep() { :; }
-        install_grpcurl() {
-            printf '%s' "$(($(cat "$retry_counter") + 1))" >"$retry_counter"
+        download_archive_once() {
+            printf '%s' "$(($(cat "$counter") + 1))" >"$counter"
             return 1
         }
-        install_grpcurl_with_retry \
-            "$GRPCURL_VERSION" "$GRPCURL_SHA256" "$GRPCURL_URL" /usr/local/bin
-    ) 2>/dev/null; then
-        fail_self_test "persistent download failure was not surfaced"
+        prepare_archive "$checksum" unused://cache-hit "$cache_path"
+    ) >/dev/null || fail_self_test "valid cache hit failed"
+    [[ $(cat "$counter") -eq 0 ]] \
+        || fail_self_test "valid cache hit used the network"
+
+    printf 'corrupt' >"$cache_path"
+    printf '0' >"$counter"
+    (
+        sleep() { :; }
+        download_archive_once() {
+            printf '%s' "$(($(cat "$counter") + 1))" >"$counter"
+            cp "$valid_archive" "$2"
+        }
+        prepare_archive "$checksum" unused://corrupt-cache "$cache_path"
+    ) >/dev/null 2>&1 || fail_self_test "corrupt cache was not replaced"
+    [[ $(cat "$counter") -eq 1 ]] \
+        || fail_self_test "corrupt cache did not perform one download"
+    verify_archive "$checksum" "$cache_path" \
+        || fail_self_test "corrupt cache replacement was not verified"
+
+    target_path="$fixture_dir/transient/$GRPCURL_ASSET"
+    printf '0' >"$counter"
+    (
+        sleep() { :; }
+        download_archive_once() {
+            local count
+            count=$(($(cat "$counter") + 1))
+            printf '%s' "$count" >"$counter"
+            if [[ "$count" -eq 1 ]]; then
+                printf 'truncated' >"$2"
+            else
+                cp "$valid_archive" "$2"
+            fi
+        }
+        prepare_archive "$checksum" unused://transient "$target_path"
+    ) >/dev/null 2>&1 || fail_self_test "retry did not recover"
+    [[ $(cat "$counter") -eq 2 ]] \
+        || fail_self_test "retry did not stop on first verified success"
+    verify_archive "$checksum" "$target_path" \
+        || fail_self_test "retry published unverified bytes"
+
+    target_path="$fixture_dir/persistent/$GRPCURL_ASSET"
+    printf '0' >"$counter"
+    if (
+        sleep() { :; }
+        download_archive_once() {
+            printf '%s' "$(($(cat "$counter") + 1))" >"$counter"
+            printf 'corrupt' >"$2"
+        }
+        prepare_archive "$checksum" unused://persistent "$target_path"
+    ) >/dev/null 2>&1; then
+        fail_self_test "persistent corruption was not surfaced"
     fi
-    [[ "$(cat "$retry_counter")" -eq "$GRPCURL_ATTEMPTS" ]] \
-        || fail_self_test "retry did not stop after ${GRPCURL_ATTEMPTS} attempts"
+    [[ $(cat "$counter") -eq "$GRPCURL_ATTEMPTS" ]] \
+        || fail_self_test "persistent failure escaped retry bound"
+    [[ ! -e "$target_path" ]] \
+        || fail_self_test "persistent failure published an archive"
 
-    named_steps=$(grep -cE '^[[:space:]]+- name: Install grpcurl' \
-        "$repo_root/.github/workflows/interop.yml")
-    workflow_calls=$(grep -cF 'bash .github/scripts/install-grpcurl.sh' \
-        "$repo_root/.github/workflows/interop.yml")
-    [[ "$workflow_calls" -eq "$named_steps" && "$workflow_calls" -gt 0 ]] \
-        || fail_self_test \
-            "every Interop grpcurl install step must call the shared helper (steps=${named_steps}, calls=${workflow_calls})"
+    (
+        # shellcheck disable=SC2317
+        curl() { fail_self_test "offline install invoked curl"; }
+        # shellcheck disable=SC2317
+        download_archive_once() { fail_self_test "offline install downloaded"; }
+        install_from_archive \
+            "$GRPCURL_VERSION" "$checksum" "$valid_archive" \
+            "$fixture_dir/offline-install"
+    ) || fail_self_test "offline artifact install failed"
 
-    setup_calls=$(grep -cF 'bash .github/scripts/install-grpcurl.sh' \
+    interop_calls=$(grep -cF 'uses: ./.github/actions/install-grpcurl-artifact' \
+        "$repo_root/.github/workflows/interop.yml")
+    [[ "$interop_calls" -eq 40 ]] \
+        || fail_self_test "Interop must have 40 offline grpcurl consumers"
+    setup_calls=$(grep -cF 'uses: ./.github/actions/install-grpcurl-artifact' \
         "$repo_root/.github/actions/setup-dataplane-host/action.yml")
     [[ "$setup_calls" -eq 1 ]] \
-        || fail_self_test "setup-dataplane-host must call the shared helper exactly once"
+        || fail_self_test "setup-dataplane-host must have one grpcurl consumer"
+    prepare_calls=$(grep -R -F -- '--prepare-archive' \
+        "$repo_root/.github/workflows/interop.yml" \
+        "$repo_root/.github/workflows/kernel-dataplane.yml" | wc -l)
+    [[ "$prepare_calls" -eq 2 ]] \
+        || fail_self_test "heavy workflows must have two grpcurl producers"
+    install_calls=$(grep -cF -- '--install-archive' \
+        "$repo_root/.github/actions/install-grpcurl-artifact/action.yml")
+    [[ "$install_calls" -eq 1 ]] \
+        || fail_self_test "consumer action must have one offline install"
 
-    if grep -R -E -n \
-        'fullstorydev/grpcurl/releases|grpcurl_.*linux_x86_64\.tar\.gz' \
-        "$repo_root/.github/workflows" \
+    if grep -R -F -n 'fullstorydev/grpcurl/releases' \
+        "$repo_root/.github/workflows" "$repo_root/.github/actions"; then
+        fail_self_test "grpcurl release URL remains outside the installer"
+    fi
+    if grep -R -F -n 'bash .github/scripts/install-grpcurl.sh' \
+        "$repo_root/.github/workflows/interop.yml" \
+        "$repo_root/.github/workflows/kernel-dataplane.yml" \
         "$repo_root/.github/actions"; then
-        fail_self_test "legacy grpcurl download call site remains outside the helper"
+        fail_self_test "legacy grpcurl installer invocation remains"
     fi
 
     printf '%s\n' 'grpcurl installer self-test passed'
 )
 
+usage() {
+    echo "usage: $0 --prepare-archive ARCHIVE | --install-archive ARCHIVE INSTALL_DIR | --self-test" >&2
+    exit 2
+}
+
 case ${1:-} in
-    "")
-        install_grpcurl_with_retry \
-            "$GRPCURL_VERSION" \
-            "$GRPCURL_SHA256" \
-            "$GRPCURL_URL" \
-            /usr/local/bin
+    --prepare-archive)
+        [[ $# -eq 2 ]] || usage
+        prepare_archive "$GRPCURL_SHA256" "$GRPCURL_URL" "$2"
+        ;;
+    --install-archive)
+        [[ $# -eq 3 ]] || usage
+        install_from_archive "$GRPCURL_VERSION" "$GRPCURL_SHA256" "$2" "$3"
         ;;
     --self-test)
+        [[ $# -eq 1 ]] || usage
         self_test
         ;;
     *)
-        echo "usage: $0 [--self-test]" >&2
-        exit 2
+        usage
         ;;
 esac

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -167,6 +167,35 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: python3 scripts/classify_heavy_ci_paths.py
 
+  grpcurl_archive:
+    needs: classify_changes
+    if: needs.classify_changes.outputs.run_labs == 'true'
+    name: Prepare exact grpcurl archive
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+      - name: Restore exact grpcurl archive cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/grpcurl-cache/grpcurl_1.9.1_linux_x86_64.tar.gz
+          key: grpcurl-v1.9.1-linux-x86_64-588c9c429476d9ed66cd3b2ae32283a6da36e0cfbb7e446f5d6a1b68dc770214
+      - name: Prepare exact grpcurl archive
+        run: |
+          .github/scripts/install-grpcurl.sh \
+            --prepare-archive \
+            "$RUNNER_TEMP/grpcurl-cache/grpcurl_1.9.1_linux_x86_64.tar.gz"
+      - name: Upload verified grpcurl archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: grpcurl-v1.9.1-linux-x86_64
+          path: ${{ runner.temp }}/grpcurl-cache/grpcurl_1.9.1_linux_x86_64.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
   # Warm one fixed-scope cache per source SHA; jobs still build and load their
   # own image, falling back to an uncached build if the cache is unavailable.
   prime_dev_image:
@@ -195,7 +224,7 @@ jobs:
           cache-to: type=gha,scope=rustbgpd-dev,mode=max,ignore-error=true
 
   m1:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M1 — basic session + UPDATE (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -205,9 +234,8 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl
-        run: |
-          bash .github/scripts/install-grpcurl.sh
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -229,7 +257,7 @@ jobs:
           script: tests/interop/scripts/test-m1-frr.sh
 
   m13:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M13 — Policy Engine (FRR 10.3.1, 3-node)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -239,9 +267,8 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl
-        run: |
-          bash .github/scripts/install-grpcurl.sh
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -263,7 +290,7 @@ jobs:
           script: tests/interop/scripts/test-m13-policy-frr.sh
 
   m80:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M80 — rpol policy parity (ADR-0096, FRR 10.3.1, 4-node)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -273,11 +300,13 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         # jq drives the parity tuple comparisons (rustbgpd gRPC JSON
         # vs FRR vtysh JSON) and the policy test/stats assertions.
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -300,7 +329,7 @@ jobs:
           script: tests/interop/scripts/test-m80-rpol-policy-parity-frr.sh
 
   m15:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M15 — Route Refresh via gRPC SoftResetIn (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -310,9 +339,8 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl
-        run: |
-          bash .github/scripts/install-grpcurl.sh
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -334,7 +362,7 @@ jobs:
           script: tests/interop/scripts/test-m15-rr-frr.sh
 
   m10:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M10 — IPv6 dual-stack / MP-BGP (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -344,9 +372,8 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl
-        run: |
-          bash .github/scripts/install-grpcurl.sh
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -368,7 +395,7 @@ jobs:
           script: tests/interop/scripts/test-m10-frr-ipv6.sh
 
   m14:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M14 — Route Reflector (FRR 10.3.1, 3-node iBGP)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -378,9 +405,8 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl
-        run: |
-          bash .github/scripts/install-grpcurl.sh
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -402,7 +428,7 @@ jobs:
           script: tests/interop/scripts/test-m14-rr-frr.sh
 
   m17:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M17/M89 — Add-Path + experimental Paths-Limit (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -412,9 +438,11 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -444,7 +472,7 @@ jobs:
           script: tests/interop/scripts/test-m89-paths-limit-frr.sh
 
   m73:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M73/M87 — GoBGP BGP-LS + exact-export/BIRD
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -454,9 +482,11 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -492,7 +522,7 @@ jobs:
           script: tests/interop/scripts/test-m87-exact-export-rejection.sh
 
   m74:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M74 — VPNv4 route reflection (GoBGP 3.x)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -502,9 +532,11 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -530,7 +562,7 @@ jobs:
           script: tests/interop/scripts/test-m74-vpnv4-reflection-gobgp.sh
 
   m75:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M75 — RT-Constrain VPNv4 filtering (GoBGP 3.x)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -540,9 +572,11 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -568,7 +602,7 @@ jobs:
           script: tests/interop/scripts/test-m75-rtc-vpnv4-filter-gobgp.sh
 
   m76:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M76 — ORR divergent-best (GoBGP 4.6.0)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -578,9 +612,11 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -606,7 +642,7 @@ jobs:
           script: tests/interop/scripts/test-m76-orr-divergent-best-gobgp.sh
 
   m77:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M77 — GR/LLGR RR-family stale preservation (GoBGP 4.6.0)
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -616,9 +652,11 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -644,7 +682,7 @@ jobs:
           script: tests/interop/scripts/test-m77-gr-llgr-rr-gobgp.sh
 
   m78:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M78 — Multi-cluster ORR + inter-RR Add-Path (GoBGP 4.6.0)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -654,9 +692,11 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -682,7 +722,7 @@ jobs:
           script: tests/interop/scripts/test-m78-multicluster-orr-gobgp.sh
 
   m79:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M79 — Labeled-unicast route reflection + GR (GoBGP 4.6.0)
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -692,9 +732,11 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -720,7 +762,7 @@ jobs:
           script: tests/interop/scripts/test-m79-labeled-reflection-gobgp.sh
 
   m22:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M22 — FlowSpec (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -730,12 +772,14 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         # jq parses FRR's `show bgp ipv4 flowspec json` output for
         # the direct convergence checks and `show bgp summary json`
         # for the per-step flap-detection assertion.
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -758,7 +802,7 @@ jobs:
           script: tests/interop/scripts/test-m22-flowspec-frr.sh
 
   m24:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M24 — BMP (FRR 10.3.1, Python receiver)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -768,9 +812,8 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl
-        run: |
-          bash .github/scripts/install-grpcurl.sh
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -792,7 +835,7 @@ jobs:
           script: tests/interop/scripts/test-m24-bmp-frr.sh
 
   m81:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M81 — BMP trio + BMPv4 receipt (pmacct + gobmp + tshark)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -802,10 +845,12 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         # jq drives the pmacct-msglog and gobmp-JSON oracle assertions.
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -837,7 +882,7 @@ jobs:
           script: tests/interop/scripts/test-m81-bmp-trio-gobgp.sh
 
   m82:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     # Synthetic leg only. The SR Linux vendor leg
     # (m82-evpn-bundle-srlinux.clab.yml) stays local: the NOS image is
     # ~750 MB compressed / 3.2 GB on disk and boots a full chassis sim —
@@ -852,9 +897,11 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -880,7 +927,7 @@ jobs:
           script: tests/interop/scripts/test-m82-evpn-bundle-synthetic-gobgp.sh
 
   m83:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     # Full 3-stack leg in CI: BIRD 2 is a plain apt install on
     # bookworm-slim (deterministic build) and BIRD already runs in
     # hosted CI (M43, kernel-dataplane.yml) without flake history —
@@ -894,10 +941,12 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         # jq drives the FRR vtysh / GoBGP JSON client-view assertions.
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -937,7 +986,7 @@ jobs:
           retention-days: 14
 
   m85:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M85/M93/M95 — RR core, required families, and RFC 8212 presence transitions against BIRD 2
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -947,10 +996,12 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         # jq drives the rbgp JSON client-view assertions.
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -994,7 +1045,7 @@ jobs:
           script: tests/interop/scripts/test-m95-rfc8212-presence.sh
 
   m94:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M94 — RFC 6793 AS4 migration against OLD speakers
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1004,10 +1055,12 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         # jq drives the exact reconstructed-RIB and wire-receipt assertions.
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -1035,7 +1088,7 @@ jobs:
           script: tests/interop/scripts/test-m94-as4-migration-exabgp.sh
 
   m86:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M86 — RR core reflection + GR truth against OpenBGPD 9.1 clients
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -1045,10 +1098,12 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         # jq drives the bgpctl -j and rbgp JSON client-view assertions.
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -1078,7 +1133,7 @@ jobs:
           script: tests/interop/scripts/test-m86-rr-openbgpd.sh
 
   m25:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M25 — TCP MD5 + GTSM (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1088,9 +1143,8 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl
-        run: |
-          bash .github/scripts/install-grpcurl.sh
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1112,7 +1166,7 @@ jobs:
           script: tests/interop/scripts/test-m25-md5-gtsm-frr.sh
 
   m29:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M29 — EVPN cap negotiation (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1128,9 +1182,8 @@ jobs:
         # new version before merging.
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl
-        run: |
-          bash .github/scripts/install-grpcurl.sh
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
 
       # Buildx cache cuts the docker build step from ~6 min to ~30 s on
       # cache hits. The cargo registry / target dir gets reused via the
@@ -1157,7 +1210,7 @@ jobs:
           script: tests/interop/scripts/test-m29-evpn-rr-frr.sh
 
   m30:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M30 — EVPN Type 2 reflection (FRR 10.3.1, kernel VXLAN)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1167,12 +1220,14 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         # jq is required for M30 test 6's strict next_hop assertion
         # (scoped to the entry containing the test MAC); a substring
         # grep would let a malformed match slip past.
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -1195,7 +1250,7 @@ jobs:
           script: tests/interop/scripts/test-m30-evpn-type2-frr.sh
 
   m34:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M34 — SIGHUP policy soft-reset (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1205,11 +1260,13 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         # jq is required for the strict per-prefix counting + session
         # uptime epoch comparison in test-m34.
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -1232,7 +1289,7 @@ jobs:
           script: tests/interop/scripts/test-m34-policy-soft-reset-frr.sh
 
   m35:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M35 — RFC 8326 Graceful Shutdown (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1242,11 +1299,13 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         # jq parses NeighborState.localPref + FRR's `show ip bgp` JSON
         # for the community-presence assertion.
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -1269,7 +1328,7 @@ jobs:
           script: tests/interop/scripts/test-m35-graceful-shutdown-frr.sh
 
   m35b:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M35b — RFC 8326 GShut FlowSpec (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1279,11 +1338,13 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         # jq parses FRR's `show bgp ipv4 flowspec json` output for
         # the community-presence assertion.
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -1306,7 +1367,7 @@ jobs:
           script: tests/interop/scripts/test-m35b-graceful-shutdown-flowspec-frr.sh
 
   m35c:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M35c — RFC 8326 GShut EVPN (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1316,10 +1377,12 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         # jq pretty-prints EVPN diagnostics and parses grpcurl JSON.
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -1342,7 +1405,7 @@ jobs:
           script: tests/interop/scripts/test-m35c-graceful-shutdown-evpn-frr.sh
 
   m41:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M41 — RFC 7999 BLACKHOLE (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1352,12 +1415,14 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         # jq parses `ListReceivedRoutes` JSON for the per-prefix
         # community assertions (BLACKHOLE + implicit NO_ADVERTISE
         # on tagged /32, neither on untagged /32).
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -1380,7 +1445,7 @@ jobs:
           script: tests/interop/scripts/test-m41-blackhole-frr.sh
 
   m44:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M44 — ADR-0064 gRPC tier authorization (mTLS)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1390,9 +1455,8 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl
-        run: |
-          bash .github/scripts/install-grpcurl.sh
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1421,7 +1485,7 @@ jobs:
           script: tests/interop/scripts/test-m44-grpc-tier-authz.sh
 
   m54:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M54 — ADR-0070 gNMI / OpenConfig over mTLS
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1431,9 +1495,11 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl and gnmic
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Install gnmic
         run: |
-          bash .github/scripts/install-grpcurl.sh
           curl -sL https://github.com/openconfig/gnmic/releases/download/v0.46.0/gnmic_0.46.0_Linux_x86_64.tar.gz \
             | sudo tar -xz -C /usr/local/bin gnmic
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
@@ -1463,7 +1529,7 @@ jobs:
           script: tests/interop/scripts/test-m54-gnmi-openconfig.sh
 
   m55:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M55 — ADR-0071 BGP Roles + OTC (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1473,9 +1539,11 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl and jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -1498,7 +1566,7 @@ jobs:
           script: tests/interop/scripts/test-m55-bgp-roles-otc-frr.sh
 
   m56:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M56 — gNMI Subscribe ON_CHANGE (ADR-0070 deferral resolved)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1508,9 +1576,11 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl, gnmic, and jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Install gnmic and ensure jq
         run: |
-          bash .github/scripts/install-grpcurl.sh
           curl -sL https://github.com/openconfig/gnmic/releases/download/v0.46.0/gnmic_0.46.0_Linux_x86_64.tar.gz \
             | sudo tar -xz -C /usr/local/bin gnmic
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
@@ -1539,7 +1609,7 @@ jobs:
           script: tests/interop/scripts/test-m56-gnmi-onchange-frr.sh
 
   m45:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M45 — EVPN Type 5 injection (gRPC → FRR)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1549,9 +1619,8 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl
-        run: |
-          bash .github/scripts/install-grpcurl.sh
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -1573,7 +1642,7 @@ jobs:
           script: tests/interop/scripts/test-m45-evpn-type5-injection.sh
 
   m57:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M57 — Outbound Route Filtering (RFC 5291/5292, FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1583,11 +1652,13 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         # grpcurl injects routes via InjectionService.AddPath; jq parses FRR's
         # `show bgp ipv4 unicast json` for the received-prefix-set assertions.
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -1610,7 +1681,7 @@ jobs:
           script: tests/interop/scripts/test-m57-orf-frr.sh
 
   m63:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M63 — ADR-0078 stalled-RIB hold-timer survival (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -1620,12 +1691,14 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         # jq parses GetNeighborState / ListReceivedRoutes JSON for the
         # survival-window and never-drop assertions; the Prometheus
         # counters come over plain HTTP.
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -1648,7 +1721,7 @@ jobs:
           script: tests/interop/scripts/test-m63-stalled-rib-hold-timer.sh
 
   m64:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M64 — IPv6-only peering via disable_ipv4_unicast (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1658,12 +1731,14 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         # jq parses FRR's `show bgp neighbors json` capability output for
         # the no-IPv4-MP assertion; grpcurl injects the bidirectional
         # route-exchange prefixes and reads rustbgpd's RIB.
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -1686,7 +1761,7 @@ jobs:
           script: tests/interop/scripts/test-m64-ipv6-only.sh
 
   m26_m27_m28_m59_m91:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M26/M27/M28/M59/M91 — cheap protocol interop (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1696,9 +1771,11 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -1749,7 +1826,7 @@ jobs:
           script: tests/interop/scripts/test-m91-rfc7606-malformed.sh
 
   m92:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M92 — GoBGP 4.7 route-server differential
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -1759,9 +1836,11 @@ jobs:
       - name: Install containerlab
         uses: ./.github/actions/install-containerlab
 
-      - name: Install grpcurl + jq
+      - name: Install exact grpcurl offline
+        uses: ./.github/actions/install-grpcurl-artifact
+
+      - name: Ensure jq
         run: |
-          bash .github/scripts/install-grpcurl.sh
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -1797,3 +1876,48 @@ jobs:
           label: M92-negative
           topology: tests/interop/m92-gobgp-v47-rs-differential.clab.yml
           script: tests/interop/scripts/test-m92-gobgp-v47-rs-differential.sh
+
+  check:
+    name: check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ always() }}
+    needs: [classify_changes, grpcurl_archive, prime_dev_image, m1, m13, m80,
+      m15, m10, m14, m17, m73, m74, m75, m76, m77, m78, m79, m22, m24,
+      m81, m82, m83, m85, m94, m86, m25, m29, m30, m34, m35, m35b, m35c,
+      m41, m44, m54, m55, m56, m45, m57, m63, m64,
+      m26_m27_m28_m59_m91, m92]
+    env:
+      NEEDS_CONTEXT: ${{ toJSON(needs) }}
+      EXPECTED_JOBS: >-
+        classify_changes grpcurl_archive prime_dev_image m1 m13 m80 m15 m10
+        m14 m17 m73 m74 m75 m76 m77 m78 m79 m22 m24 m81 m82 m83 m85 m94
+        m86 m25 m29 m30 m34 m35 m35b m35c m41 m44 m54 m55 m56 m45 m57
+        m63 m64 m26_m27_m28_m59_m91 m92
+    steps:
+      - name: Aggregate required Interop result
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["NEEDS_CONTEXT"])
+          expected = os.environ["EXPECTED_JOBS"].split()
+          if set(needs) != set(expected) or len(needs) != len(expected):
+              print(f"aggregate dependency drift: expected={expected} actual={sorted(needs)}")
+              sys.exit(1)
+
+          classifier = needs["classify_changes"]
+          run_labs = classifier.get("outputs", {}).get("run_labs")
+          failed = classifier.get("result") != "success" or run_labs not in {"true", "false"}
+          expected_result = "success" if run_labs == "true" else "skipped"
+          for job in expected:
+              result = needs[job].get("result")
+              print(f"{job}={result}")
+              if job != "classify_changes" and result != expected_result:
+                  failed = True
+          if failed:
+              sys.exit(1)
+          PY

--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -55,6 +55,35 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: python3 scripts/classify_heavy_ci_paths.py
 
+  grpcurl_archive:
+    needs: classify_changes
+    if: needs.classify_changes.outputs.run_labs == 'true'
+    name: Prepare exact grpcurl archive
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+      - name: Restore exact grpcurl archive cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/grpcurl-cache/grpcurl_1.9.1_linux_x86_64.tar.gz
+          key: grpcurl-v1.9.1-linux-x86_64-588c9c429476d9ed66cd3b2ae32283a6da36e0cfbb7e446f5d6a1b68dc770214
+      - name: Prepare exact grpcurl archive
+        run: |
+          .github/scripts/install-grpcurl.sh \
+            --prepare-archive \
+            "$RUNNER_TEMP/grpcurl-cache/grpcurl_1.9.1_linux_x86_64.tar.gz"
+      - name: Upload verified grpcurl archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: grpcurl-v1.9.1-linux-x86_64
+          path: ${{ runner.temp }}/grpcurl-cache/grpcurl_1.9.1_linux_x86_64.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
   # Warm one fixed-scope cache per source SHA; jobs still build and load their
   # own image, falling back to an uncached build if the cache is unavailable.
   prime_dev_image:
@@ -83,7 +112,7 @@ jobs:
           cache-to: type=gha,scope=rustbgpd-dev,mode=max,ignore-error=true
 
   m36:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M36 — EVPN VTEP receive FDB programming (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -99,7 +128,7 @@ jobs:
           script: tests/interop/scripts/test-m36-evpn-vtep-smoke.sh
 
   m37:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M37 — EVPN local MAC origination (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -115,7 +144,7 @@ jobs:
           script: tests/interop/scripts/test-m37-evpn-local-origination.sh
 
   m37-ip:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M37+IP — EVPN local MAC/IP origination (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -131,7 +160,7 @@ jobs:
           script: tests/interop/scripts/test-m37-evpn-mac-ip-origination.sh
 
   m38:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M38 — EVPN DF election + Type 1/4 origination
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -147,7 +176,7 @@ jobs:
           script: tests/interop/scripts/test-m38-evpn-df-election.sh
 
   m39:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M39 — EVPN Type 5 symmetric Interface-less IRB (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -164,7 +193,7 @@ jobs:
           script: tests/interop/scripts/test-m39-evpn-type5-symmetric-irb.sh
 
   m39b:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M39b — EVPN auto-derived Route Targets cross-vendor (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -181,7 +210,7 @@ jobs:
           script: tests/interop/scripts/test-m39b-evpn-auto-rt-frr.sh
 
   m48:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M48 — EVPN runtime tenant teardown over kernel L3 datapath (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -198,7 +227,7 @@ jobs:
           script: tests/interop/scripts/test-m48-evpn-tenant-teardown-datapath.sh
 
   m60:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M60 — ADR-0079 EVPN adoption sweep kill-and-restart (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -214,7 +243,7 @@ jobs:
           script: tests/interop/scripts/test-m60-evpn-adoption-sweep.sh
 
   m61:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M61 — ADR-0079 EVPN L3 adoption sweep kill-and-restart (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -231,7 +260,7 @@ jobs:
           script: tests/interop/scripts/test-m61-evpn-l3-adoption-sweep.sh
 
   m62:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M62 — ADR-0079 blackhole adoption sweep kill-and-restart (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -247,7 +276,7 @@ jobs:
           script: tests/interop/scripts/test-m62-blackhole-adoption-sweep.sh
 
   m40:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M40 — ADR-0059 aliasing dataplane ECMP (FRR EVPN-MH 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -263,7 +292,7 @@ jobs:
           script: tests/interop/scripts/test-m40-evpn-aliasing-ecmp-frr.sh
 
   m42:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M42 — ADR-0061 configured-table unicast FIB runtime (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -279,7 +308,7 @@ jobs:
           script: tests/interop/scripts/test-m42-fib-runtime-frr.sh
 
   m50:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M50 — ADR-0066 unicast multipath/ECMP FIB install (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -295,7 +324,7 @@ jobs:
           script: tests/interop/scripts/test-m50-fib-ecmp-frr.sh
 
   m52:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M52 — ADR-0066 multipath-relax (FRR 10.3.1, mixed ASes)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -311,7 +340,7 @@ jobs:
           script: tests/interop/scripts/test-m52-fib-ecmp-relax-frr.sh
 
   m58:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M58 — ADR-0061 FIB-table runtime CRUD (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -327,7 +356,7 @@ jobs:
           script: tests/interop/scripts/test-m58-fib-table-crud-frr.sh
 
   m53:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M53 — ADR-0069 BGP unnumbered + scoped FIB (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -343,7 +372,7 @@ jobs:
           script: tests/interop/scripts/test-m53-bgp-unnumbered-frr.sh
 
   m51:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M51 — ADR-0067 single-hop BFD + RFC 5882 coupling (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -359,7 +388,7 @@ jobs:
           script: tests/interop/scripts/test-m51-bfd-frr.sh
 
   m43:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M43 — TCP-AO live rotation and crash recovery (BIRD 3.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -490,7 +519,7 @@ jobs:
           script: tests/interop/scripts/test-m43-tcp-ao-bird-crash-restart.sh
 
   m46:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M46 — EVPN HRW DF election (rustbgpd ×2)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -506,7 +535,7 @@ jobs:
           script: tests/interop/scripts/test-m46-evpn-df-hrw.sh
 
   m47:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M47 — EVPN runtime tenant teardown (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -522,7 +551,7 @@ jobs:
           script: tests/interop/scripts/test-m47-evpn-tenant-teardown.sh
 
   m49:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M49 — EVPN preference-DF election (rustbgpd ×2)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -538,7 +567,7 @@ jobs:
           script: tests/interop/scripts/test-m49-evpn-preference-df.sh
 
   m69:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M69 — EVPN preference-DF election (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -554,7 +583,7 @@ jobs:
           script: tests/interop/scripts/test-m69-evpn-preference-df-frr.sh
 
   m70:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M70 — ADR-0089 VLAN-aware bridge FDB attribution (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -574,7 +603,7 @@ jobs:
           script: tests/interop/scripts/test-m70-evpn-vlan-aware-bridge-frr.sh
 
   m65:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M65 — ADR-0083 single-active failover blackout measurement (GoBGP 3.x)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -596,7 +625,7 @@ jobs:
           script: tests/interop/scripts/test-m65-evpn-single-active-failover.sh
 
   m71:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M71 — RFC 9136 §4.3 ESI overlay-index Type 5 single-active receive (GoBGP 3.x)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -620,7 +649,7 @@ jobs:
           script: tests/interop/scripts/test-m71-evpn-esi-overlay-type5-receive-gobgp.sh
 
   m72:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M72 — RFC 9136 §4.3 ESI overlay-index Type 5 all-active receive (GoBGP 3.x)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -643,7 +672,7 @@ jobs:
           script: tests/interop/scripts/test-m72-evpn-esi-overlay-type5-all-active-gobgp.sh
 
   m66:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M66 — ADR-0084 ES drain service handover (rustbgpd ×3)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -662,7 +691,7 @@ jobs:
           script: tests/interop/scripts/test-m66-evpn-es-drain-handover.sh
 
   m67:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M67 — ADR-0085 link-driven ES drain failover (rustbgpd ×3)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -683,7 +712,7 @@ jobs:
           script: tests/interop/scripts/test-m67-evpn-link-drain-failover.sh
 
   m68:
-    needs: prime_dev_image
+    needs: [grpcurl_archive, prime_dev_image]
     name: M68 — ADR-0087 GW-IP overlay-index Type 5 (FRR 10.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -797,3 +826,46 @@ jobs:
       - name: LAN-76 all-active Type 5 L3 writer netns proof
         if: steps.vrf.outputs.vrf-available == 'true'
         run: bash crates/evpn-linux/tests/docker/run-netns-tests.sh l3_all_active_writer
+
+  check:
+    name: check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ always() }}
+    needs: [classify_changes, grpcurl_archive, prime_dev_image, m36, m37,
+      m37-ip, m38, m39, m39b, m48, m60, m61, m62, m40, m42, m50, m52,
+      m58, m53, m51, m43, m46, m47, m49, m69, m70, m65, m71, m72, m66,
+      m67, m68, netns]
+    env:
+      NEEDS_CONTEXT: ${{ toJSON(needs) }}
+      EXPECTED_JOBS: >-
+        classify_changes grpcurl_archive prime_dev_image m36 m37 m37-ip m38 m39
+        m39b m48 m60 m61 m62 m40 m42 m50 m52 m58 m53 m51 m43 m46 m47 m49
+        m69 m70 m65 m71 m72 m66 m67 m68 netns
+    steps:
+      - name: Aggregate required Kernel Dataplane result
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["NEEDS_CONTEXT"])
+          expected = os.environ["EXPECTED_JOBS"].split()
+          if set(needs) != set(expected) or len(needs) != len(expected):
+              print(f"aggregate dependency drift: expected={expected} actual={sorted(needs)}")
+              sys.exit(1)
+
+          classifier = needs["classify_changes"]
+          run_labs = classifier.get("outputs", {}).get("run_labs")
+          failed = classifier.get("result") != "success" or run_labs not in {"true", "false"}
+          expected_result = "success" if run_labs == "true" else "skipped"
+          for job in expected:
+              result = needs[job].get("result")
+              print(f"{job}={result}")
+              if job != "classify_changes" and result != expected_result:
+                  failed = True
+          if failed:
+              sys.exit(1)
+          PY

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import collections
 import hashlib
 import re
+import stat
 import sys
 from pathlib import Path
 
@@ -49,6 +50,11 @@ V064_SHA256 = "bd4829de08d0c50074f9ecd5c351399fae42be06d456b3880a04aa4a7cda1137"
 V064_ARCHIVE = "rustbgpd-linux-amd64.tar.gz"
 V064_ARTIFACT = "rustbgpd-v0.64.0-linux-amd64"
 V064_CACHE_KEY = f"rustbgpd-v0.64.0-linux-amd64-{V064_SHA256}"
+GRPCURL_SHA256 = "588c9c429476d9ed66cd3b2ae32283a6da36e0cfbb7e446f5d6a1b68dc770214"
+GRPCURL_ARCHIVE = "grpcurl_1.9.1_linux_x86_64.tar.gz"
+GRPCURL_ARTIFACT = "grpcurl-v1.9.1-linux-x86_64"
+GRPCURL_CACHE_KEY = f"grpcurl-v1.9.1-linux-x86_64-{GRPCURL_SHA256}"
+GRPCURL_ACTION = "uses: ./.github/actions/install-grpcurl-artifact"
 
 TRIGGER_HASHES = {
     "ci.yml": "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8",
@@ -68,15 +74,15 @@ CALL_HASHES = {
 }
 PINS = collections.Counter(
     {
-        "actions/checkout@v7": 82,
+        "actions/checkout@v7": 84,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 3,
         "Swatinem/rust-cache@v2": 5,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 2,
         "docker/setup-buildx-action@v4": 44,
         "docker/build-push-action@v7": 45,
-        "actions/cache@v6": 1,
-        "actions/upload-artifact@v7": 2,
-        "actions/download-artifact@v8": 2,
+        "actions/cache@v6": 3,
+        "actions/upload-artifact@v7": 4,
+        "actions/download-artifact@v8": 3,
         "rustsec/audit-check@v2.0.0": 1,
         "EmbarkStudios/cargo-deny-action@v2": 1,
     }
@@ -107,8 +113,31 @@ def _has_line(block: str, line: str) -> bool:
     return re.search(rf"(?m)^{re.escape(line)}$", block) is not None
 
 
+def _list_needs(block: str) -> list[str]:
+    flow = re.search(r"(?ms)^    needs: \[(.*?)\]\n", block)
+    if flow:
+        values = (value.strip() for value in flow.group(1).split(","))
+        return [value for value in values if value]
+    match = re.search(r"(?m)^    needs:\n((?:      - [\w-]+\n)+)", block)
+    if not match:
+        return []
+    return re.findall(r"(?m)^      - ([\w-]+)$", match.group(1))
+
+
+def _expected_jobs(block: str) -> list[str]:
+    match = re.search(
+        r"(?ms)^      EXPECTED_JOBS: >-\n(.*?)^    steps:\n", block
+    )
+    return match.group(1).split() if match else []
+
+
 def check(root: Path) -> list[str]:
     errors: list[str] = []
+    grpcurl_installer = root / ".github" / "scripts" / "install-grpcurl.sh"
+    if not grpcurl_installer.is_file():
+        errors.append("install-grpcurl.sh is missing")
+    elif stat.S_IMODE(grpcurl_installer.stat().st_mode) != 0o755:
+        errors.append("install-grpcurl.sh must have exact executable mode 100755")
     workflow_dir = root / ".github" / "workflows"
     texts = {name: (workflow_dir / name).read_text() for name in WORKFLOWS}
     for name, text in texts.items():
@@ -196,9 +225,14 @@ def check(root: Path) -> list[str]:
         ("kernel-dataplane.yml", KERNEL, True),
     ):
         jobs = _jobs(texts[name])
-        expected = ["classify_changes", "prime_dev_image", *roster] + (
-            ["netns"] if setup else []
-        )
+        heavy = [*roster] + (["netns"] if setup else [])
+        expected = [
+            "classify_changes",
+            "grpcurl_archive",
+            "prime_dev_image",
+            *heavy,
+            "check",
+        ]
         if list(jobs) != expected:
             errors.append(f"{name}: exact job roster/order drifted")
         classifier = jobs.get("classify_changes", "")
@@ -211,6 +245,54 @@ def check(root: Path) -> list[str]:
         for forbidden in ("continue-on-error:", "if:"):
             if re.search(rf"(?m)^ +{re.escape(forbidden)}", classifier):
                 errors.append(f"{name}: classifier permits active {forbidden}")
+        grpcurl_producer = jobs.get("grpcurl_archive", "")
+        for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
+            if not _has_line(grpcurl_producer, f"    {seam}"):
+                errors.append(
+                    f"{name}:grpcurl_archive missing job-level {seam}"
+                )
+        for seam in (
+            "name: Prepare exact grpcurl archive",
+            "runs-on: ubuntu-latest",
+            "timeout-minutes: 10",
+            CHECKOUT,
+            "ref: ${{ github.sha }}",
+            "uses: actions/cache@v6",
+            f"path: ${{{{ runner.temp }}}}/grpcurl-cache/{GRPCURL_ARCHIVE}",
+            f"key: {GRPCURL_CACHE_KEY}",
+            "--prepare-archive",
+            f'"$RUNNER_TEMP/grpcurl-cache/{GRPCURL_ARCHIVE}"',
+            "uses: actions/upload-artifact@v7",
+            f"name: {GRPCURL_ARTIFACT}",
+            "if-no-files-found: error",
+            "retention-days: 1",
+            "compression-level: 0",
+        ):
+            if seam not in grpcurl_producer:
+                errors.append(f"{name}:grpcurl_archive missing {seam}")
+        for forbidden in (
+            "restore-keys:",
+            "continue-on-error:",
+            "actions/download-artifact@",
+            "--install-archive",
+        ):
+            if forbidden in grpcurl_producer:
+                errors.append(f"{name}:grpcurl_archive permits {forbidden}")
+        if grpcurl_producer.count("uses: actions/cache@v6") != 1:
+            errors.append(f"{name}:grpcurl_archive must restore one exact cache")
+        if grpcurl_producer.count("--prepare-archive") != 1:
+            errors.append(f"{name}:grpcurl_archive must prepare one archive")
+        if grpcurl_producer.count("uses: actions/upload-artifact@v7") != 1:
+            errors.append(f"{name}:grpcurl_archive must upload one artifact")
+        exact_path = (
+            f"path: ${{{{ runner.temp }}}}/grpcurl-cache/{GRPCURL_ARCHIVE}"
+        )
+        if grpcurl_producer.count(exact_path) != 2:
+            errors.append(f"{name}:grpcurl_archive cache/artifact paths drifted")
+        if grpcurl_producer.count(f"key: {GRPCURL_CACHE_KEY}") != 1:
+            errors.append(f"{name}:grpcurl_archive cache key drifted")
+        if grpcurl_producer.count(f"name: {GRPCURL_ARTIFACT}") != 1:
+            errors.append(f"{name}:grpcurl_archive artifact name drifted")
         primer = jobs.get("prime_dev_image", "")
         for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
             if not _has_line(primer, f"    {seam}"):
@@ -236,19 +318,52 @@ def check(root: Path) -> list[str]:
             errors.append(f"{name}: primer must export cache, not load an image")
         for job_name in roster:
             job = jobs.get(job_name, "")
-            if "needs: prime_dev_image" not in job:
-                errors.append(f"{name}:{job_name}: missing primer dependency")
+            if not _has_line(
+                job, "    needs: [grpcurl_archive, prime_dev_image]"
+            ):
+                errors.append(
+                    f"{name}:{job_name}: missing exact grpcurl/primer dependencies"
+                )
             if CHECKOUT not in job:
                 errors.append(f"{name}:{job_name}: pinned checkout drifted")
             if setup:
                 if "uses: ./.github/actions/setup-dataplane-host" not in job:
                     errors.append(f"{name}:{job_name}: setup call drifted")
+                if GRPCURL_ACTION in job:
+                    errors.append(f"{name}:{job_name}: bypasses shared host setup")
             else:
+                if job.count(GRPCURL_ACTION) != 1:
+                    errors.append(
+                        f"{name}:{job_name}: must consume one grpcurl artifact"
+                    )
                 for seam in (IMPORT, "load: true", "tags: rustbgpd:dev", "target: dev"):
                     if seam not in job:
                         errors.append(f"{name}:{job_name}: consumer missing {seam}")
                 if "cache-to:" in job:
                     errors.append(f"{name}:{job_name}: consumer exports a cache")
+        aggregate = jobs.get("check", "")
+        aggregate_needs = ["classify_changes", "grpcurl_archive", "prime_dev_image", *heavy]
+        if _list_needs(aggregate) != aggregate_needs:
+            errors.append(f"{name}:check exact dependency roster drifted")
+        if _expected_jobs(aggregate) != aggregate_needs:
+            errors.append(f"{name}:check runtime expected roster drifted")
+        for seam in (
+            "name: check",
+            "runs-on: ubuntu-latest",
+            "timeout-minutes: 5",
+            "if: ${{ always() }}",
+            "NEEDS_CONTEXT: ${{ toJSON(needs) }}",
+            'classifier.get("result") != "success"',
+            'run_labs not in {"true", "false"}',
+            'expected_result = "success" if run_labs == "true" else "skipped"',
+            'result != expected_result',
+            "sys.exit(1)",
+        ):
+            if seam not in aggregate:
+                errors.append(f"{name}:check missing aggregate seam {seam}")
+        for forbidden in ("continue-on-error:", "if: success()"):
+            if forbidden in aggregate:
+                errors.append(f"{name}:check permits {forbidden}")
         calls = "\n".join(
             line.strip()
             for line in texts[name].splitlines()
@@ -261,7 +376,7 @@ def check(root: Path) -> list[str]:
             errors.append(f"{name}: existing test/setup calls drifted")
     m92 = _jobs(texts["interop.yml"]).get("m92", "")
     required = {
-        "bash .github/scripts/install-grpcurl.sh": 1,
+        GRPCURL_ACTION: 1,
         "docker build -t bird:2-bookworm -f tests/interop/Dockerfile.bird tests/interop": 1,
         "docker build -t gobgp:v4.7.0-m92 -f tests/interop/Dockerfile.gobgp-v47 tests/interop": 1,
         "uses: ./.github/actions/run-interop-test": 2,
@@ -290,10 +405,41 @@ def check(root: Path) -> list[str]:
             errors.append(f"kernel-dataplane.yml:netns missing job-level {seam}")
     if "needs: prime_dev_image" in netns:
         errors.append("kernel-dataplane.yml:netns must remain independent")
+    if "grpcurl_archive" in netns or GRPCURL_ACTION in netns:
+        errors.append("kernel-dataplane.yml:netns must remain grpcurl-independent")
 
     action = (
         root / ".github" / "actions" / "setup-dataplane-host" / "action.yml"
     ).read_text()
+    grpcurl_action = (
+        root / ".github" / "actions" / "install-grpcurl-artifact" / "action.yml"
+    ).read_text()
+    for seam in (
+        "uses: actions/download-artifact@v8",
+        f"name: {GRPCURL_ARTIFACT}",
+        "path: ${{ runner.temp }}/grpcurl-artifact",
+        "--install-archive",
+        f'"$RUNNER_TEMP/grpcurl-artifact/{GRPCURL_ARCHIVE}"',
+        "/usr/local/bin",
+    ):
+        if seam not in grpcurl_action:
+            errors.append(f"install-grpcurl-artifact missing {seam}")
+    if grpcurl_action.count("uses: actions/download-artifact@v8") != 1:
+        errors.append("install-grpcurl-artifact must download one same-run artifact")
+    if grpcurl_action.count("--install-archive") != 1:
+        errors.append("install-grpcurl-artifact must perform one offline install")
+    for forbidden in (
+        "--prepare-archive",
+        "actions/cache@",
+        "actions/upload-artifact@",
+        "restore-keys:",
+        "continue-on-error:",
+        "releases/download/",
+    ):
+        if forbidden in grpcurl_action:
+            errors.append(f"install-grpcurl-artifact permits {forbidden}")
+    if re.search(r"(?m)^\s*curl\s", grpcurl_action):
+        errors.append("install-grpcurl-artifact permits curl")
     # split(...)[-1] returns the whole file when the step name drifts, which
     # turns every seam check below into a file-wide search that passes
     # vacuously. Scope the region only once the anchor is known to be present.
@@ -305,6 +451,10 @@ def check(root: Path) -> list[str]:
     build = action.split(build_step, 1)[-1] if build_step in action else ""
     if BUILDX not in action:
         errors.append(f"setup-dataplane-host: consumer missing {BUILDX}")
+    if action.count(GRPCURL_ACTION) != 1:
+        errors.append("setup-dataplane-host must consume one grpcurl artifact")
+    if "bash .github/scripts/install-grpcurl.sh" in action:
+        errors.append("setup-dataplane-host retains legacy grpcurl install")
     for seam in (
         BUILD_PUSH,
         "context: .",
@@ -318,8 +468,20 @@ def check(root: Path) -> list[str]:
     if "cache-to:" in build:
         errors.append("setup-dataplane-host: consumer must not export cache")
 
+    if texts["interop.yml"].count(GRPCURL_ACTION) != len(INTEROP):
+        errors.append("interop.yml: grpcurl consumer inventory drifted")
+    if texts["kernel-dataplane.yml"].count(GRPCURL_ACTION) != 0:
+        errors.append("kernel-dataplane.yml: grpcurl must flow through host setup")
+    grpcurl_surfaces = "\n".join(
+        (texts["interop.yml"], texts["kernel-dataplane.yml"], action, grpcurl_action)
+    )
+    if "bash .github/scripts/install-grpcurl.sh" in grpcurl_surfaces:
+        errors.append("legacy grpcurl installer invocation remains")
+    if "fullstorydev/grpcurl/releases" in grpcurl_surfaces:
+        errors.append("grpcurl release URL escaped the producer helper")
+
     pins = collections.Counter()
-    for text in [*texts.values(), action]:
+    for text in [*texts.values(), action, grpcurl_action]:
         for value in re.findall(r"^\s*(?:- )?uses:\s*(.+)$", text, re.MULTILINE):
             if not value.strip().startswith("./"):
                 pins[value.strip()] += 1

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -5,12 +5,13 @@ import os
 import shutil
 import subprocess
 import tempfile
+import textwrap
 import unittest
 from unittest import mock
 from pathlib import Path
 
 from scripts import classify_heavy_ci_paths as heavy
-from scripts.check_ci_image_primer_contract import check
+from scripts.check_ci_image_primer_contract import INTEROP, KERNEL, _list_needs, check
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -90,12 +91,16 @@ class PrimerContractTests(unittest.TestCase):
             root = Path(temporary)
             for fixture in (
                 ".github/workflows",
+                ".github/actions/install-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
             ):
                 source = ROOT / fixture
                 target = root / fixture
                 target.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copytree(source, target)
+            installer = root / ".github" / "scripts" / "install-grpcurl.sh"
+            installer.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(ROOT / installer.relative_to(root), installer)
             shutil.copy2(ROOT / "Dockerfile", root / "Dockerfile")
             gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
             gobgp.parent.mkdir(parents=True, exist_ok=True)
@@ -114,6 +119,227 @@ class PrimerContractTests(unittest.TestCase):
 
     def test_live_contract(self):
         self.assertEqual([], check(ROOT))
+
+    def test_empty_flow_needs_is_empty(self):
+        self.assertEqual([], _list_needs("    needs: []\n"))
+        self.assertEqual(
+            ["producer", "primer"],
+            _list_needs("    needs: [producer, primer]\n"),
+        )
+
+    def test_missing_grpcurl_installer_returns_contract_error(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            for fixture in (
+                ".github/workflows",
+                ".github/actions/install-grpcurl-artifact",
+                ".github/actions/setup-dataplane-host",
+            ):
+                shutil.copytree(ROOT / fixture, root / fixture)
+            shutil.copy2(ROOT / "Dockerfile", root / "Dockerfile")
+            gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
+            gobgp.parent.mkdir(parents=True)
+            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
+            self.assertIn("install-grpcurl.sh is missing", check(root))
+
+    def test_grpcurl_installer_executable_mode_is_load_bearing(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            for fixture in (
+                ".github/workflows",
+                ".github/actions/install-grpcurl-artifact",
+                ".github/actions/setup-dataplane-host",
+            ):
+                shutil.copytree(ROOT / fixture, root / fixture)
+            shutil.copy2(ROOT / "Dockerfile", root / "Dockerfile")
+            gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
+            gobgp.parent.mkdir(parents=True)
+            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
+            installer = root / ".github" / "scripts" / "install-grpcurl.sh"
+            installer.parent.mkdir(parents=True)
+            shutil.copy2(ROOT / installer.relative_to(root), installer)
+            installer.chmod(0o644)
+            self.assertIn(
+                "install-grpcurl.sh must have exact executable mode 100755",
+                check(root),
+            )
+
+    def run_aggregate(self, workflow, run_labs, results):
+        text = (ROOT / ".github" / "workflows" / workflow).read_text()
+        block = text.rsplit("\n  check:\n", 1)[1]
+        script = block.split("          python3 - <<'PY'\n", 1)[1].split(
+            "\n          PY", 1
+        )[0]
+        script = textwrap.dedent(script)
+        roster = INTEROP if workflow == "interop.yml" else KERNEL
+        expected = ["classify_changes", "grpcurl_archive", "prime_dev_image", *roster]
+        if workflow == "kernel-dataplane.yml":
+            expected.append("netns")
+        needs = {
+            job: {
+                "result": results.get(job, "success"),
+                "outputs": {"run_labs": run_labs} if job == "classify_changes" else {},
+            }
+            for job in expected
+        }
+        return subprocess.run(
+            ["python3", "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            env={
+                **os.environ,
+                "NEEDS_CONTEXT": json.dumps(needs),
+                "EXPECTED_JOBS": " ".join(expected),
+            },
+        )
+
+    def test_heavy_workflow_aggregate_truth_table(self):
+        for workflow in ("interop.yml", "kernel-dataplane.yml"):
+            with self.subTest(workflow=workflow, state="labs run"):
+                self.assertEqual(0, self.run_aggregate(workflow, "true", {}).returncode)
+
+            roster = INTEROP if workflow == "interop.yml" else KERNEL
+            skipped = {
+                job: "skipped" for job in ["grpcurl_archive", "prime_dev_image", *roster]
+            }
+            if workflow == "kernel-dataplane.yml":
+                skipped["netns"] = "skipped"
+            with self.subTest(workflow=workflow, state="docs only"):
+                self.assertEqual(
+                    0, self.run_aggregate(workflow, "false", skipped).returncode
+                )
+
+            for result in ("failure", "cancelled", "skipped"):
+                with self.subTest(workflow=workflow, producer=result):
+                    self.assertNotEqual(
+                        0,
+                        self.run_aggregate(
+                            workflow, "true", {"grpcurl_archive": result}
+                        ).returncode,
+                    )
+            with self.subTest(workflow=workflow, state="producer red consumers skipped"):
+                failed = {job: "skipped" for job in roster}
+                failed.update({"grpcurl_archive": "failure"})
+                self.assertNotEqual(
+                    0, self.run_aggregate(workflow, "true", failed).returncode
+                )
+            for run_labs, results in (
+                ("", {}),
+                ("unknown", {}),
+                ("true", {"classify_changes": "failure"}),
+                ("false", {"grpcurl_archive": "success"}),
+            ):
+                with self.subTest(workflow=workflow, state=(run_labs, results)):
+                    self.assertNotEqual(
+                        0,
+                        self.run_aggregate(workflow, run_labs, results).returncode,
+                    )
+
+    def test_grpcurl_producers_are_load_bearing(self):
+        archive = "grpcurl_1.9.1_linux_x86_64.tar.gz"
+        checksum = "588c9c429476d9ed66cd3b2ae32283a6da36e0cfbb7e446f5d6a1b68dc770214"
+        for workflow in ("interop.yml", "kernel-dataplane.yml"):
+            relative = f".github/workflows/{workflow}"
+            cases = (
+                ("  grpcurl_archive:\n", "  removed_grpcurl_archive:\n", 0),
+                ("needs: classify_changes", "needs: []", 0),
+                (
+                    "if: needs.classify_changes.outputs.run_labs == 'true'",
+                    "if: false",
+                    0,
+                ),
+                ("timeout-minutes: 10", "timeout-minutes: 9", 0),
+                ("ref: ${{ github.sha }}", "ref: main", 0),
+                ("actions/cache@v6", "actions/cache@main", 0),
+                (f"key: grpcurl-v1.9.1-linux-x86_64-{checksum}", "key: grpcurl", 0),
+                ("--prepare-archive", "--install-archive", 0),
+                ("actions/upload-artifact@v7", "actions/upload-artifact@main", 0),
+                ("name: grpcurl-v1.9.1-linux-x86_64", "name: grpcurl-latest", 0),
+                ("if-no-files-found: error", "if-no-files-found: warn", 0),
+                ("retention-days: 1", "retention-days: 30", 0),
+                ("compression-level: 0", "compression-level: 6", 0),
+                (
+                    f"key: grpcurl-v1.9.1-linux-x86_64-{checksum}",
+                    f"key: grpcurl-v1.9.1-linux-x86_64-{checksum}\n          restore-keys: grpcurl-",
+                    0,
+                ),
+                (
+                    "uses: actions/cache@v6",
+                    "uses: actions/cache@v6\n        continue-on-error: true",
+                    0,
+                ),
+            )
+            for old, new, occurrence in cases:
+                with self.subTest(workflow=workflow, seam=old, occurrence=occurrence):
+                    self.mutate(relative, old, new, occurrence=occurrence)
+            for occurrence in (0, 1):
+                with self.subTest(workflow=workflow, path=occurrence):
+                    self.mutate(
+                        relative,
+                        f"path: ${{{{ runner.temp }}}}/grpcurl-cache/{archive}",
+                        "path: ${{ runner.temp }}/grpcurl-cache/wrong.tar.gz",
+                        occurrence=occurrence,
+                    )
+
+    def test_grpcurl_offline_consumer_is_load_bearing(self):
+        relative = ".github/actions/install-grpcurl-artifact/action.yml"
+        for old, new in (
+            ("actions/download-artifact@v8", "actions/download-artifact@main"),
+            ("name: grpcurl-v1.9.1-linux-x86_64", "name: grpcurl-latest"),
+            (
+                "path: ${{ runner.temp }}/grpcurl-artifact",
+                "path: ${{ runner.temp }}/wrong",
+            ),
+            ("--install-archive", "--prepare-archive"),
+            (
+                "set -euo pipefail",
+                "set -euo pipefail\n        curl https://example.invalid/grpcurl",
+            ),
+            (
+                "uses: actions/download-artifact@v8",
+                "uses: actions/download-artifact@v8\n    - uses: actions/cache@v6",
+            ),
+        ):
+            with self.subTest(seam=old):
+                self.mutate(relative, old, new)
+
+        self.mutate(
+            ".github/actions/setup-dataplane-host/action.yml",
+            "uses: ./.github/actions/install-grpcurl-artifact",
+            "uses: ./.github/actions/install-containerlab",
+        )
+        self.mutate(
+            ".github/workflows/interop.yml",
+            "uses: ./.github/actions/install-grpcurl-artifact",
+            "run: bash .github/scripts/install-grpcurl.sh",
+        )
+
+    def test_heavy_workflow_aggregate_source_is_load_bearing(self):
+        for workflow, lab in (
+            ("interop.yml", "m1"),
+            ("kernel-dataplane.yml", "m36"),
+        ):
+            relative = f".github/workflows/{workflow}"
+            needs_prefix = (
+                "needs: [classify_changes, grpcurl_archive, prime_dev_image, "
+            )
+            for old, new in (
+                ("if: ${{ always() }}", "if: success()"),
+                ("NEEDS_CONTEXT: ${{ toJSON(needs) }}", "NEEDS_CONTEXT: '{}'"),
+                (f"{needs_prefix}{lab},", needs_prefix),
+                (
+                    'classifier.get("result") != "success"',
+                    'classifier.get("result") == "success"',
+                ),
+                ("result != expected_result", "False"),
+                (
+                    "    if: ${{ always() }}",
+                    "    continue-on-error: true\n    if: ${{ always() }}",
+                ),
+            ):
+                with self.subTest(workflow=workflow, seam=old):
+                    self.mutate(relative, old, new)
 
     def test_classifier_workflow_wiring_is_load_bearing(self):
         for workflow in ("interop.yml", "kernel-dataplane.yml"):
@@ -142,7 +368,7 @@ class PrimerContractTests(unittest.TestCase):
                     ".github/workflows/kernel-dataplane.yml",
                     old,
                     f"# {old}",
-                    occurrence=1,
+                    occurrence=2,
                 )
 
     def test_destructive_workflow_seams(self):
@@ -184,7 +410,11 @@ class PrimerContractTests(unittest.TestCase):
                 "cancel-in-progress: false",
                 "cancel-in-progress: true",
             ),
-            (".github/workflows/interop.yml", "needs: prime_dev_image", "needs: []"),
+            (
+                ".github/workflows/interop.yml",
+                "needs: [grpcurl_archive, prime_dev_image]",
+                "needs: []",
+            ),
             (
                 ".github/workflows/interop.yml",
                 "cache-from: type=gha,scope=rustbgpd-dev",
@@ -300,7 +530,7 @@ class PrimerContractTests(unittest.TestCase):
                 interop,
                 "actions/checkout@v7",
                 "actions/checkout@main",
-                occurrence=1,
+                occurrence=3,
             )
 
         kernel = ".github/workflows/kernel-dataplane.yml"
@@ -309,10 +539,14 @@ class PrimerContractTests(unittest.TestCase):
                 kernel,
                 "actions/checkout@v7",
                 "actions/checkout@main",
-                occurrence=1,
+                occurrence=3,
             )
         with self.subTest(workflow=kernel, seam="consumer needs"):
-            self.mutate(kernel, "needs: prime_dev_image", "needs: []")
+            self.mutate(
+                kernel,
+                "needs: [grpcurl_archive, prime_dev_image]",
+                "needs: []",
+            )
 
     def test_destructive_consumer_action_seams(self):
         relative = ".github/actions/setup-dataplane-host/action.yml"
@@ -361,7 +595,7 @@ class PrimerContractTests(unittest.TestCase):
             count = (ROOT / relative).read_text().count("missing M92 seam")
             self.assertGreater(count, 0, "missing M92 seam: synthetic")
         for old in (
-            "          bash .github/scripts/install-grpcurl.sh\n",
+            "        uses: ./.github/actions/install-grpcurl-artifact\n",
             "      - name: Run M92\n        uses: ./.github/actions/run-interop-test\n",
             "      - name: Run M92 negative completeness proof\n        uses: ./.github/actions/run-interop-test\n",
             '          M92_COMPLETENESS_NEGATIVE: "1"\n',


### PR DESCRIPTION
## What changed

- prepare and verify the pinned grpcurl v1.9.1 archive once in each independent heavy-lab workflow
- restore the immutable version-and-checksum cache before any release fetch, then publish a same-run artifact
- make all 40 Interop and 29 Kernel Dataplane lab jobs install from the verified artifact without a network fallback
- add fail-closed aggregate jobs so producer failures remain clearly distinguishable from product-test failures
- expand the CI contract checker and destructive installer tests, including executable-mode enforcement

## Why

One GitHub Release outage recently produced the same grpcurl download failure in eight Interop jobs and seven Kernel Dataplane jobs. Those infrastructure failures obscured a concurrent real Interop regression. Fetching once and reusing a verified artifact preserves the existing pin and trust boundary while restoring a useful CI signal.

Warm exact-cache runs require no upstream grpcurl download. A cold-cache upstream outage fails one named producer per workflow instead of producing dozens of indistinguishable lab failures.

Linear: https://linear.app/lance0/issue/LAN-1008/cache-the-grpcurl-ci-dependency-one-upstream-download-failure-reds-15

## Validation

- direct executable installer self-test
- Bash syntax and ShellCheck
- 21 destructive CI contract tests
- live CI contract checker
- actionlint for both workflows
- composite-action and workflow YAML parsing
- exact 40 Interop / 29 Kernel consumer inventories
- repository fmt and Clippy commit hooks

Hosted cold-cache, warm-cache, and same-key cache-restoration receipts will be captured on this PR.
