### PR TITLE
ci: share verified gnmic artifact

### DIFF
--- a/.github/actions/install-gnmic-artifact/action.yml
+++ b/.github/actions/install-gnmic-artifact/action.yml
@@ -1,0 +1,21 @@
+name: "Install verified gnmic artifact"
+description: >-
+  Download the same-run gnmic archive, verify its immutable checksum and
+  version offline, and install it on the hosted runner.
+runs:
+  using: "composite"
+  steps:
+    - name: Download verified gnmic archive
+      uses: actions/download-artifact@v8
+      with:
+        name: gnmic-v0.46.0-linux-x86_64
+        path: ${{ runner.temp }}/gnmic-artifact
+
+    - name: Install exact gnmic offline
+      shell: bash
+      run: |
+        set -euo pipefail
+        .github/scripts/install-gnmic.sh \
+          --install-archive \
+          "$RUNNER_TEMP/gnmic-artifact/gnmic_0.46.0_Linux_x86_64.tar.gz" \
+          /usr/local/bin

--- a/.github/scripts/install-gnmic.sh
+++ b/.github/scripts/install-gnmic.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly GNMIC_VERSION="0.46.0"
+readonly GNMIC_SHA256="a3ded2f355a615df73900f31b9791f41e796e9c5c63b171e1ce041e8139ee00e"
+readonly GNMIC_ASSET="gnmic_${GNMIC_VERSION}_Linux_x86_64.tar.gz"
+readonly GNMIC_URL="https://github.com/openconfig/gnmic/releases/download/v${GNMIC_VERSION}/${GNMIC_ASSET}"
+readonly GNMIC_ATTEMPTS=3
+
+verify_archive() {
+    local sha256=${1:?sha256}
+    local archive=${2:?archive}
+
+    [[ -f "$archive" ]] || return 1
+    if ! printf '%s  %s\n' "$sha256" "$archive" \
+        | sha256sum --check --status; then
+        echo "gnmic archive checksum mismatch: ${archive}" >&2
+        return 1
+    fi
+}
+
+verify_version() {
+    local binary=${1:?binary}
+    local version=${2:?version}
+    local reported
+
+    reported=$("$binary" version 2>&1) || return 1
+    if [[ "${reported%%$'\n'*}" != "version : ${version}" ]]; then
+        echo "unexpected gnmic version: ${reported%%$'\n'*}" >&2
+        return 1
+    fi
+}
+
+install_from_archive() (
+    local version=${1:?version}
+    local sha256=${2:?sha256}
+    local archive=${3:?archive}
+    local install_dir=${4:?install directory}
+    local work_dir staged_target
+
+    # This path is deliberately offline. Only the producer may fetch the
+    # release archive; consumers re-verify the same-run artifact before tar.
+    verify_archive "$sha256" "$archive" || return 1
+    work_dir=$(mktemp -d) || return 1
+    trap 'rm -rf -- "$work_dir"' EXIT
+    tar -xzf "$archive" -C "$work_dir" gnmic || return 1
+    [[ -f "$work_dir/gnmic" ]] || {
+        echo "gnmic archive did not contain gnmic" >&2
+        return 1
+    }
+    chmod 0755 "$work_dir/gnmic"
+    verify_version "$work_dir/gnmic" "$version" || return 1
+
+    if [[ -d "$install_dir" && -w "$install_dir" ]] \
+        || { [[ ! -e "$install_dir" ]] && [[ -w "$(dirname "$install_dir")" ]]; }; then
+        mkdir -p "$install_dir"
+        staged_target=$(mktemp "${install_dir}/.gnmic.XXXXXX")
+        trap 'rm -rf -- "$work_dir"; rm -f -- "$staged_target"' EXIT
+        install -m 0755 "$work_dir/gnmic" "$staged_target"
+        mv -f -- "$staged_target" "$install_dir/gnmic"
+    else
+        staged_target="${install_dir}/.gnmic.$$.${RANDOM}"
+        sudo mkdir -p "$install_dir"
+        sudo install -m 0755 "$work_dir/gnmic" "$staged_target"
+        trap 'rm -rf -- "$work_dir"; sudo rm -f -- "$staged_target"' EXIT
+        sudo mv -f -- "$staged_target" "$install_dir/gnmic"
+    fi
+    verify_version "$install_dir/gnmic" "$version"
+    printf 'gnmic version %s\n' "$version"
+)
+
+download_archive_once() {
+    local url=${1:?url}
+    local destination=${2:?destination}
+
+    curl -fsSL \
+        --connect-timeout 10 \
+        --max-time 120 \
+        --output "$destination" \
+        "$url"
+}
+
+prepare_archive() {
+    local sha256=${1:?sha256}
+    local url=${2:?url}
+    local archive=${3:?archive}
+    local attempt staged_archive
+
+    if verify_archive "$sha256" "$archive" 2>/dev/null; then
+        echo "using verified cached gnmic archive"
+        return 0
+    fi
+    if [[ -e "$archive" ]]; then
+        echo "::warning::discarding invalid cached gnmic archive" >&2
+        rm -f -- "$archive"
+    fi
+
+    mkdir -p "$(dirname "$archive")"
+    for ((attempt = 1; attempt <= GNMIC_ATTEMPTS; attempt++)); do
+        staged_archive=$(mktemp "${archive}.download.XXXXXX")
+        if download_archive_once "$url" "$staged_archive" \
+            && verify_archive "$sha256" "$staged_archive"; then
+            mv -f -- "$staged_archive" "$archive"
+            echo "downloaded and verified gnmic archive"
+            return 0
+        fi
+        rm -f -- "$staged_archive"
+        if ((attempt < GNMIC_ATTEMPTS)); then
+            echo "::warning::gnmic download/verify attempt ${attempt}/${GNMIC_ATTEMPTS} failed; retrying" >&2
+            sleep $((attempt * 5))
+        fi
+    done
+
+    echo "::error::gnmic download/verification failed after ${GNMIC_ATTEMPTS} attempts: ${url}" >&2
+    return 1
+}
+
+fail_self_test() {
+    echo "gnmic installer self-test failed: $*" >&2
+    return 1
+}
+
+self_test() (
+    local fixture_dir source_dir valid_archive valid_checksum wrong_dir wrong_archive
+    local wrong_checksum expected_url installed_hash attempts
+
+    fixture_dir=$(mktemp -d)
+    trap 'rm -rf -- "$fixture_dir"' EXIT
+    [[ "$GNMIC_VERSION" == "0.46.0" ]] || fail_self_test "version pin drifted"
+    [[ "$GNMIC_SHA256" == "a3ded2f355a615df73900f31b9791f41e796e9c5c63b171e1ce041e8139ee00e" ]] \
+        || fail_self_test "checksum pin drifted"
+    [[ "$GNMIC_ASSET" == "gnmic_0.46.0_Linux_x86_64.tar.gz" ]] \
+        || fail_self_test "archive name drifted"
+    printf -v expected_url '%s%s' \
+        'https://github.com/openconfig/gnmic/releases' \
+        '/download/v0.46.0/gnmic_0.46.0_Linux_x86_64.tar.gz'
+    [[ "$GNMIC_URL" == "$expected_url" ]] \
+        || fail_self_test "release URL drifted"
+    [[ "$GNMIC_ATTEMPTS" -eq 3 ]] || fail_self_test "retry bound drifted"
+
+    source_dir="$fixture_dir/source"
+    mkdir -p "$source_dir"
+    cat >"$source_dir/gnmic" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' 'version : 0.46.0'
+EOF
+    chmod +x "$source_dir/gnmic"
+    valid_archive="$fixture_dir/valid.tar.gz"
+    tar -czf "$valid_archive" -C "$source_dir" gnmic
+    valid_checksum=$(sha256sum "$valid_archive" | awk '{print $1}')
+
+    install_from_archive "$GNMIC_VERSION" "$valid_checksum" "$valid_archive" \
+        "$fixture_dir/install" >/dev/null
+    [[ -x "$fixture_dir/install/gnmic" ]] \
+        || fail_self_test "verified archive was not installed"
+    installed_hash=$(sha256sum "$fixture_dir/install/gnmic" | awk '{print $1}')
+
+    if install_from_archive "$GNMIC_VERSION" "$GNMIC_SHA256" \
+        "$valid_archive" "$fixture_dir/install" 2>/dev/null; then
+        fail_self_test "wrong checksum was accepted"
+    fi
+    [[ "$(sha256sum "$fixture_dir/install/gnmic" | awk '{print $1}')" == "$installed_hash" ]] \
+        || fail_self_test "checksum failure replaced the installed target"
+    head -c 12 "$valid_archive" >"$fixture_dir/truncated.tar.gz"
+    if install_from_archive "$GNMIC_VERSION" "$valid_checksum" \
+        "$fixture_dir/truncated.tar.gz" "$fixture_dir/truncated" 2>/dev/null; then
+        fail_self_test "truncated archive was accepted"
+    fi
+    printf '<html>503</html>\n' >"$fixture_dir/http-body.tar.gz"
+    if install_from_archive "$GNMIC_VERSION" "$valid_checksum" \
+        "$fixture_dir/http-body.tar.gz" "$fixture_dir/http" 2>/dev/null; then
+        fail_self_test "HTTP response body was accepted"
+    fi
+
+    wrong_dir="$fixture_dir/wrong"
+    mkdir -p "$wrong_dir"
+    cat >"$wrong_dir/gnmic" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' 'version : 0.45.0'
+EOF
+    chmod +x "$wrong_dir/gnmic"
+    wrong_archive="$fixture_dir/wrong-version.tar.gz"
+    tar -czf "$wrong_archive" -C "$wrong_dir" gnmic
+    wrong_checksum=$(sha256sum "$wrong_archive" | awk '{print $1}')
+    if install_from_archive "$GNMIC_VERSION" "$wrong_checksum" "$wrong_archive" \
+        "$fixture_dir/install" 2>/dev/null; then
+        fail_self_test "wrong binary version was accepted"
+    fi
+    [[ "$(sha256sum "$fixture_dir/install/gnmic" | awk '{print $1}')" == "$installed_hash" ]] \
+        || fail_self_test "version failure replaced the installed target"
+
+    printf 'invalid cache\n' >"$fixture_dir/cache.tar.gz"
+    attempts=0
+    download_archive_once() {
+        ((attempts += 1))
+        if ((attempts == 1)); then
+            printf 'transient failure\n' >"$2"
+        else
+            cp "$valid_archive" "$2"
+        fi
+    }
+    sleep() { :; }
+    prepare_archive "$valid_checksum" "https://example.invalid/retry" \
+        "$fixture_dir/cache.tar.gz" >/dev/null 2>&1
+    [[ "$attempts" -eq 2 ]] || fail_self_test "bounded retry count drifted"
+    cmp -s "$valid_archive" "$fixture_dir/cache.tar.gz" \
+        || fail_self_test "invalid cache was not atomically replaced"
+
+    download_archive_once() { fail_self_test "warm cache reached upstream"; }
+    prepare_archive "$valid_checksum" "https://example.invalid/unreachable" \
+        "$fixture_dir/cache.tar.gz" \
+        | grep -Fxq "using verified cached gnmic archive" \
+        || fail_self_test "warm cache attempted an upstream fetch"
+
+    attempts=0
+    download_archive_once() {
+        ((attempts += 1))
+        printf '<html>503</html>\n' >"$2"
+    }
+    if prepare_archive "$valid_checksum" "https://example.invalid/unavailable" \
+        "$fixture_dir/cold-cache.tar.gz" >/dev/null 2>&1; then
+        fail_self_test "cold-cache upstream failure was accepted"
+    fi
+    [[ "$attempts" -eq "$GNMIC_ATTEMPTS" ]] \
+        || fail_self_test "cold-cache retry bound was not enforced"
+    [[ ! -e "$fixture_dir/cold-cache.tar.gz" ]] \
+        || fail_self_test "failed cold-cache fetch left an artifact"
+
+    echo "gnmic installer self-test passed"
+)
+
+usage() {
+    echo "usage: $0 --prepare-archive ARCHIVE | --install-archive ARCHIVE INSTALL_DIR | --self-test" >&2
+    return 2
+}
+
+case "${1:-}" in
+    --prepare-archive)
+        [[ $# -eq 2 ]] || usage
+        prepare_archive "$GNMIC_SHA256" "$GNMIC_URL" "$2"
+        ;;
+    --install-archive)
+        [[ $# -eq 3 ]] || usage
+        install_from_archive "$GNMIC_VERSION" "$GNMIC_SHA256" "$2" "$3"
+        ;;
+    --self-test)
+        [[ $# -eq 1 ]] || usage
+        self_test
+        ;;
+    *) usage ;;
+esac

--- a/.github/scripts/install-grpcurl.sh
+++ b/.github/scripts/install-grpcurl.sh
@@ -286,7 +286,7 @@ EOF
         "$repo_root/.github/actions/setup-dataplane-host/action.yml")
     [[ "$setup_calls" -eq 1 ]] \
         || fail_self_test "setup-dataplane-host must have one grpcurl consumer"
-    prepare_calls=$(grep -R -F -- '--prepare-archive' \
+    prepare_calls=$(grep -R -F -- '.github/scripts/install-grpcurl.sh' \
         "$repo_root/.github/workflows/interop.yml" \
         "$repo_root/.github/workflows/kernel-dataplane.yml" | wc -l)
     [[ "$prepare_calls" -eq 2 ]] \

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -196,6 +196,35 @@ jobs:
           retention-days: 1
           compression-level: 0
 
+  gnmic_archive:
+    needs: classify_changes
+    if: needs.classify_changes.outputs.run_labs == 'true'
+    name: Prepare exact gnmic archive
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+      - name: Restore exact gnmic archive cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/gnmic-cache/gnmic_0.46.0_Linux_x86_64.tar.gz
+          key: gnmic-v0.46.0-linux-x86_64-a3ded2f355a615df73900f31b9791f41e796e9c5c63b171e1ce041e8139ee00e
+      - name: Prepare exact gnmic archive
+        run: |
+          .github/scripts/install-gnmic.sh \
+            --prepare-archive \
+            "$RUNNER_TEMP/gnmic-cache/gnmic_0.46.0_Linux_x86_64.tar.gz"
+      - name: Upload verified gnmic archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: gnmic-v0.46.0-linux-x86_64
+          path: ${{ runner.temp }}/gnmic-cache/gnmic_0.46.0_Linux_x86_64.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
   # Warm one fixed-scope cache per source SHA; jobs still build and load their
   # own image, falling back to an uncached build if the cache is unavailable.
   prime_dev_image:
@@ -1485,7 +1514,7 @@ jobs:
           script: tests/interop/scripts/test-m44-grpc-tier-authz.sh
 
   m54:
-    needs: [grpcurl_archive, prime_dev_image]
+    needs: [grpcurl_archive, gnmic_archive, prime_dev_image]
     name: M54 — ADR-0070 gNMI / OpenConfig over mTLS
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1498,10 +1527,11 @@ jobs:
       - name: Install exact grpcurl offline
         uses: ./.github/actions/install-grpcurl-artifact
 
-      - name: Install gnmic
+      - name: Install exact gnmic offline
+        uses: ./.github/actions/install-gnmic-artifact
+
+      - name: Ensure jq
         run: |
-          curl -sL https://github.com/openconfig/gnmic/releases/download/v0.46.0/gnmic_0.46.0_Linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin gnmic
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -1566,7 +1596,7 @@ jobs:
           script: tests/interop/scripts/test-m55-bgp-roles-otc-frr.sh
 
   m56:
-    needs: [grpcurl_archive, prime_dev_image]
+    needs: [grpcurl_archive, gnmic_archive, prime_dev_image]
     name: M56 — gNMI Subscribe ON_CHANGE (ADR-0070 deferral resolved)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1579,10 +1609,11 @@ jobs:
       - name: Install exact grpcurl offline
         uses: ./.github/actions/install-grpcurl-artifact
 
-      - name: Install gnmic and ensure jq
+      - name: Install exact gnmic offline
+        uses: ./.github/actions/install-gnmic-artifact
+
+      - name: Ensure jq
         run: |
-          curl -sL https://github.com/openconfig/gnmic/releases/download/v0.46.0/gnmic_0.46.0_Linux_x86_64.tar.gz \
-            | sudo tar -xz -C /usr/local/bin gnmic
           command -v jq >/dev/null || { sudo apt-get update -y && sudo apt-get install -y jq; }
 
       - name: Set up Docker Buildx
@@ -1882,7 +1913,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: ${{ always() }}
-    needs: [classify_changes, grpcurl_archive, prime_dev_image, m1, m13, m80,
+    needs: [classify_changes, grpcurl_archive, gnmic_archive, prime_dev_image, m1, m13, m80,
       m15, m10, m14, m17, m73, m74, m75, m76, m77, m78, m79, m22, m24,
       m81, m82, m83, m85, m94, m86, m25, m29, m30, m34, m35, m35b, m35c,
       m41, m44, m54, m55, m56, m45, m57, m63, m64,
@@ -1890,7 +1921,7 @@ jobs:
     env:
       NEEDS_CONTEXT: ${{ toJSON(needs) }}
       EXPECTED_JOBS: >-
-        classify_changes grpcurl_archive prime_dev_image m1 m13 m80 m15 m10
+        classify_changes grpcurl_archive gnmic_archive prime_dev_image m1 m13 m80 m15 m10
         m14 m17 m73 m74 m75 m76 m77 m78 m79 m22 m24 m81 m82 m83 m85 m94
         m86 m25 m29 m30 m34 m35 m35b m35c m41 m44 m54 m55 m56 m45 m57
         m63 m64 m26_m27_m28_m59_m91 m92

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -55,6 +55,11 @@ GRPCURL_ARCHIVE = "grpcurl_1.9.1_linux_x86_64.tar.gz"
 GRPCURL_ARTIFACT = "grpcurl-v1.9.1-linux-x86_64"
 GRPCURL_CACHE_KEY = f"grpcurl-v1.9.1-linux-x86_64-{GRPCURL_SHA256}"
 GRPCURL_ACTION = "uses: ./.github/actions/install-grpcurl-artifact"
+GNMIC_SHA256 = "a3ded2f355a615df73900f31b9791f41e796e9c5c63b171e1ce041e8139ee00e"
+GNMIC_ARCHIVE = "gnmic_0.46.0_Linux_x86_64.tar.gz"
+GNMIC_ARTIFACT = "gnmic-v0.46.0-linux-x86_64"
+GNMIC_CACHE_KEY = f"gnmic-v0.46.0-linux-x86_64-{GNMIC_SHA256}"
+GNMIC_ACTION = "uses: ./.github/actions/install-gnmic-artifact"
 
 TRIGGER_HASHES = {
     "ci.yml": "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8",
@@ -74,15 +79,15 @@ CALL_HASHES = {
 }
 PINS = collections.Counter(
     {
-        "actions/checkout@v7": 84,
+        "actions/checkout@v7": 85,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 3,
         "Swatinem/rust-cache@v2": 5,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 2,
         "docker/setup-buildx-action@v4": 44,
         "docker/build-push-action@v7": 45,
-        "actions/cache@v6": 3,
-        "actions/upload-artifact@v7": 4,
-        "actions/download-artifact@v8": 3,
+        "actions/cache@v6": 4,
+        "actions/upload-artifact@v7": 5,
+        "actions/download-artifact@v8": 4,
         "rustsec/audit-check@v2.0.0": 1,
         "EmbarkStudios/cargo-deny-action@v2": 1,
     }
@@ -138,6 +143,33 @@ def check(root: Path) -> list[str]:
         errors.append("install-grpcurl.sh is missing")
     elif stat.S_IMODE(grpcurl_installer.stat().st_mode) != 0o755:
         errors.append("install-grpcurl.sh must have exact executable mode 100755")
+    gnmic_installer = root / ".github" / "scripts" / "install-gnmic.sh"
+    if not gnmic_installer.is_file():
+        errors.append("install-gnmic.sh is missing")
+    elif stat.S_IMODE(gnmic_installer.stat().st_mode) != 0o755:
+        errors.append("install-gnmic.sh must have exact executable mode 100755")
+    gnmic_installer_text = (
+        gnmic_installer.read_text() if gnmic_installer.is_file() else ""
+    )
+    for seam in (
+        'readonly GNMIC_VERSION="0.46.0"',
+        f'readonly GNMIC_SHA256="{GNMIC_SHA256}"',
+        'readonly GNMIC_ASSET="gnmic_${GNMIC_VERSION}_Linux_x86_64.tar.gz"',
+        "https://github.com/openconfig/gnmic/releases/download/v${GNMIC_VERSION}/${GNMIC_ASSET}",
+        "readonly GNMIC_ATTEMPTS=3",
+        "curl -fsSL",
+        "--connect-timeout 10",
+        "--max-time 120",
+        "--prepare-archive",
+        "--install-archive",
+        "--self-test",
+    ):
+        if seam not in gnmic_installer_text:
+            errors.append(f"install-gnmic.sh missing {seam}")
+    if gnmic_installer_text.count("openconfig/gnmic/releases/download/") != 1:
+        errors.append("install-gnmic.sh release URL inventory drifted")
+    if re.search(r"curl[^\n]*\|\s*(?:sudo\s+)?tar", gnmic_installer_text):
+        errors.append("install-gnmic.sh streams network bytes into tar")
     workflow_dir = root / ".github" / "workflows"
     texts = {name: (workflow_dir / name).read_text() for name in WORKFLOWS}
     for name, text in texts.items():
@@ -226,9 +258,10 @@ def check(root: Path) -> list[str]:
     ):
         jobs = _jobs(texts[name])
         heavy = [*roster] + (["netns"] if setup else [])
+        artifact_jobs = ["grpcurl_archive"] + ([] if setup else ["gnmic_archive"])
         expected = [
             "classify_changes",
-            "grpcurl_archive",
+            *artifact_jobs,
             "prime_dev_image",
             *heavy,
             "check",
@@ -293,6 +326,47 @@ def check(root: Path) -> list[str]:
             errors.append(f"{name}:grpcurl_archive cache key drifted")
         if grpcurl_producer.count(f"name: {GRPCURL_ARTIFACT}") != 1:
             errors.append(f"{name}:grpcurl_archive artifact name drifted")
+        if not setup:
+            gnmic_producer = jobs.get("gnmic_archive", "")
+            for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
+                if not _has_line(gnmic_producer, f"    {seam}"):
+                    errors.append(f"{name}:gnmic_archive missing job-level {seam}")
+            for seam in (
+                "name: Prepare exact gnmic archive",
+                "runs-on: ubuntu-latest",
+                "timeout-minutes: 10",
+                CHECKOUT,
+                "ref: ${{ github.sha }}",
+                "uses: actions/cache@v6",
+                f"path: ${{{{ runner.temp }}}}/gnmic-cache/{GNMIC_ARCHIVE}",
+                f"key: {GNMIC_CACHE_KEY}",
+                "--prepare-archive",
+                f'"$RUNNER_TEMP/gnmic-cache/{GNMIC_ARCHIVE}"',
+                "uses: actions/upload-artifact@v7",
+                f"name: {GNMIC_ARTIFACT}",
+                "if-no-files-found: error",
+                "retention-days: 1",
+                "compression-level: 0",
+            ):
+                if seam not in gnmic_producer:
+                    errors.append(f"{name}:gnmic_archive missing {seam}")
+            for forbidden in (
+                "restore-keys:",
+                "continue-on-error:",
+                "actions/download-artifact@",
+                "--install-archive",
+            ):
+                if forbidden in gnmic_producer:
+                    errors.append(f"{name}:gnmic_archive permits {forbidden}")
+            if gnmic_producer.count("uses: actions/cache@v6") != 1:
+                errors.append(f"{name}:gnmic_archive must restore one exact cache")
+            if gnmic_producer.count("uses: actions/upload-artifact@v7") != 1:
+                errors.append(f"{name}:gnmic_archive must upload one artifact")
+            exact_gnmic_path = (
+                f"path: ${{{{ runner.temp }}}}/gnmic-cache/{GNMIC_ARCHIVE}"
+            )
+            if gnmic_producer.count(exact_gnmic_path) != 2:
+                errors.append(f"{name}:gnmic_archive cache/artifact paths drifted")
         primer = jobs.get("prime_dev_image", "")
         for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
             if not _has_line(primer, f"    {seam}"):
@@ -318,11 +392,14 @@ def check(root: Path) -> list[str]:
             errors.append(f"{name}: primer must export cache, not load an image")
         for job_name in roster:
             job = jobs.get(job_name, "")
-            if not _has_line(
-                job, "    needs: [grpcurl_archive, prime_dev_image]"
-            ):
+            expected_needs = (
+                "    needs: [grpcurl_archive, gnmic_archive, prime_dev_image]"
+                if not setup and job_name in ("m54", "m56")
+                else "    needs: [grpcurl_archive, prime_dev_image]"
+            )
+            if not _has_line(job, expected_needs):
                 errors.append(
-                    f"{name}:{job_name}: missing exact grpcurl/primer dependencies"
+                    f"{name}:{job_name}: missing exact artifact/primer dependencies"
                 )
             if CHECKOUT not in job:
                 errors.append(f"{name}:{job_name}: pinned checkout drifted")
@@ -341,8 +418,16 @@ def check(root: Path) -> list[str]:
                         errors.append(f"{name}:{job_name}: consumer missing {seam}")
                 if "cache-to:" in job:
                     errors.append(f"{name}:{job_name}: consumer exports a cache")
+                expected_gnmic = 1 if job_name in ("m54", "m56") else 0
+                if job.count(GNMIC_ACTION) != expected_gnmic:
+                    errors.append(f"{name}:{job_name}: gnmic consumer drifted")
         aggregate = jobs.get("check", "")
-        aggregate_needs = ["classify_changes", "grpcurl_archive", "prime_dev_image", *heavy]
+        aggregate_needs = [
+            "classify_changes",
+            *artifact_jobs,
+            "prime_dev_image",
+            *heavy,
+        ]
         if _list_needs(aggregate) != aggregate_needs:
             errors.append(f"{name}:check exact dependency roster drifted")
         if _expected_jobs(aggregate) != aggregate_needs:
@@ -414,6 +499,9 @@ def check(root: Path) -> list[str]:
     grpcurl_action = (
         root / ".github" / "actions" / "install-grpcurl-artifact" / "action.yml"
     ).read_text()
+    gnmic_action = (
+        root / ".github" / "actions" / "install-gnmic-artifact" / "action.yml"
+    ).read_text()
     for seam in (
         "uses: actions/download-artifact@v8",
         f"name: {GRPCURL_ARTIFACT}",
@@ -440,6 +528,31 @@ def check(root: Path) -> list[str]:
             errors.append(f"install-grpcurl-artifact permits {forbidden}")
     if re.search(r"(?m)^\s*curl\s", grpcurl_action):
         errors.append("install-grpcurl-artifact permits curl")
+    for seam in (
+        "uses: actions/download-artifact@v8",
+        f"name: {GNMIC_ARTIFACT}",
+        "path: ${{ runner.temp }}/gnmic-artifact",
+        "--install-archive",
+        f'"$RUNNER_TEMP/gnmic-artifact/{GNMIC_ARCHIVE}"',
+        "/usr/local/bin",
+    ):
+        if seam not in gnmic_action:
+            errors.append(f"install-gnmic-artifact missing {seam}")
+    if gnmic_action.count("uses: actions/download-artifact@v8") != 1:
+        errors.append("install-gnmic-artifact must download one same-run artifact")
+    if gnmic_action.count("--install-archive") != 1:
+        errors.append("install-gnmic-artifact must perform one offline install")
+    for forbidden in (
+        "--prepare-archive",
+        "actions/cache@",
+        "actions/upload-artifact@",
+        "restore-keys:",
+        "continue-on-error:",
+        "releases/download/",
+        "curl ",
+    ):
+        if forbidden in gnmic_action:
+            errors.append(f"install-gnmic-artifact permits {forbidden}")
     # split(...)[-1] returns the whole file when the step name drifts, which
     # turns every seam check below into a file-wide search that passes
     # vacuously. Scope the region only once the anchor is known to be present.
@@ -472,6 +585,10 @@ def check(root: Path) -> list[str]:
         errors.append("interop.yml: grpcurl consumer inventory drifted")
     if texts["kernel-dataplane.yml"].count(GRPCURL_ACTION) != 0:
         errors.append("kernel-dataplane.yml: grpcurl must flow through host setup")
+    if texts["interop.yml"].count(GNMIC_ACTION) != 2:
+        errors.append("interop.yml: gnmic consumer inventory drifted")
+    if texts["kernel-dataplane.yml"].count(GNMIC_ACTION) != 0:
+        errors.append("kernel-dataplane.yml: gnmic must remain interop-only")
     grpcurl_surfaces = "\n".join(
         (texts["interop.yml"], texts["kernel-dataplane.yml"], action, grpcurl_action)
     )
@@ -479,9 +596,14 @@ def check(root: Path) -> list[str]:
         errors.append("legacy grpcurl installer invocation remains")
     if "fullstorydev/grpcurl/releases" in grpcurl_surfaces:
         errors.append("grpcurl release URL escaped the producer helper")
+    gnmic_surfaces = "\n".join((texts["interop.yml"], gnmic_action))
+    if "openconfig/gnmic/releases" in gnmic_surfaces:
+        errors.append("gnmic release URL escaped the producer helper")
+    if re.search(r"curl\s.*gnmic|curl\s.*\|\s*(?:sudo\s+)?tar", gnmic_surfaces):
+        errors.append("interop.yml retains a streaming gnmic download")
 
     pins = collections.Counter()
-    for text in [*texts.values(), action, grpcurl_action]:
+    for text in [*texts.values(), action, grpcurl_action, gnmic_action]:
         for value in re.findall(r"^\s*(?:- )?uses:\s*(.+)$", text, re.MULTILINE):
             if not value.strip().startswith("./"):
                 pins[value.strip()] += 1

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -91,6 +91,7 @@ class PrimerContractTests(unittest.TestCase):
             root = Path(temporary)
             for fixture in (
                 ".github/workflows",
+                ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
             ):
@@ -101,6 +102,8 @@ class PrimerContractTests(unittest.TestCase):
             installer = root / ".github" / "scripts" / "install-grpcurl.sh"
             installer.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(ROOT / installer.relative_to(root), installer)
+            gnmic_installer = root / ".github" / "scripts" / "install-gnmic.sh"
+            shutil.copy2(ROOT / gnmic_installer.relative_to(root), gnmic_installer)
             shutil.copy2(ROOT / "Dockerfile", root / "Dockerfile")
             gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
             gobgp.parent.mkdir(parents=True, exist_ok=True)
@@ -132,6 +135,7 @@ class PrimerContractTests(unittest.TestCase):
             root = Path(temporary)
             for fixture in (
                 ".github/workflows",
+                ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
             ):
@@ -140,6 +144,9 @@ class PrimerContractTests(unittest.TestCase):
             gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
             gobgp.parent.mkdir(parents=True)
             shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
+            gnmic_installer = root / ".github" / "scripts" / "install-gnmic.sh"
+            gnmic_installer.parent.mkdir(parents=True)
+            shutil.copy2(ROOT / gnmic_installer.relative_to(root), gnmic_installer)
             self.assertIn("install-grpcurl.sh is missing", check(root))
 
     def test_grpcurl_installer_executable_mode_is_load_bearing(self):
@@ -147,6 +154,7 @@ class PrimerContractTests(unittest.TestCase):
             root = Path(temporary)
             for fixture in (
                 ".github/workflows",
+                ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
             ):
@@ -158,6 +166,8 @@ class PrimerContractTests(unittest.TestCase):
             installer = root / ".github" / "scripts" / "install-grpcurl.sh"
             installer.parent.mkdir(parents=True)
             shutil.copy2(ROOT / installer.relative_to(root), installer)
+            gnmic_installer = root / ".github" / "scripts" / "install-gnmic.sh"
+            shutil.copy2(ROOT / gnmic_installer.relative_to(root), gnmic_installer)
             installer.chmod(0o644)
             self.assertIn(
                 "install-grpcurl.sh must have exact executable mode 100755",
@@ -172,7 +182,10 @@ class PrimerContractTests(unittest.TestCase):
         )[0]
         script = textwrap.dedent(script)
         roster = INTEROP if workflow == "interop.yml" else KERNEL
-        expected = ["classify_changes", "grpcurl_archive", "prime_dev_image", *roster]
+        artifacts = ["grpcurl_archive"]
+        if workflow == "interop.yml":
+            artifacts.append("gnmic_archive")
+        expected = ["classify_changes", *artifacts, "prime_dev_image", *roster]
         if workflow == "kernel-dataplane.yml":
             expected.append("netns")
         needs = {
@@ -200,8 +213,11 @@ class PrimerContractTests(unittest.TestCase):
                 self.assertEqual(0, self.run_aggregate(workflow, "true", {}).returncode)
 
             roster = INTEROP if workflow == "interop.yml" else KERNEL
+            artifacts = ["grpcurl_archive"]
+            if workflow == "interop.yml":
+                artifacts.append("gnmic_archive")
             skipped = {
-                job: "skipped" for job in ["grpcurl_archive", "prime_dev_image", *roster]
+                job: "skipped" for job in [*artifacts, "prime_dev_image", *roster]
             }
             if workflow == "kernel-dataplane.yml":
                 skipped["netns"] = "skipped"
@@ -224,6 +240,20 @@ class PrimerContractTests(unittest.TestCase):
                 self.assertNotEqual(
                     0, self.run_aggregate(workflow, "true", failed).returncode
                 )
+            if workflow == "interop.yml":
+                with self.subTest(workflow=workflow, state="gnmic producer red"):
+                    self.assertNotEqual(
+                        0,
+                        self.run_aggregate(
+                            workflow,
+                            "true",
+                            {
+                                "gnmic_archive": "failure",
+                                "m54": "skipped",
+                                "m56": "skipped",
+                            },
+                        ).returncode,
+                    )
             for run_labs, results in (
                 ("", {}),
                 ("unknown", {}),
@@ -315,6 +345,96 @@ class PrimerContractTests(unittest.TestCase):
             "run: bash .github/scripts/install-grpcurl.sh",
         )
 
+    def test_gnmic_producer_and_offline_consumers_are_load_bearing(self):
+        workflow = ".github/workflows/interop.yml"
+        for old, new in (
+            ("  gnmic_archive:\n", "  removed_gnmic_archive:\n"),
+            (
+                "key: gnmic-v0.46.0-linux-x86_64-a3ded2f355a615df73900f31b9791f41e796e9c5c63b171e1ce041e8139ee00e",
+                "key: gnmic-latest",
+            ),
+            ("name: gnmic-v0.46.0-linux-x86_64", "name: gnmic-latest"),
+            (
+                "needs: [grpcurl_archive, gnmic_archive, prime_dev_image]",
+                "needs: [grpcurl_archive, prime_dev_image]",
+            ),
+            (
+                "uses: ./.github/actions/install-gnmic-artifact",
+                "run: curl https://example.invalid/gnmic | sudo tar -xz",
+            ),
+        ):
+            with self.subTest(seam=old):
+                self.mutate(workflow, old, new)
+        for seam, replacement in (
+            ("actions/cache@v6", "actions/cache@main"),
+            ("--prepare-archive", "--install-archive"),
+            ("actions/upload-artifact@v7", "actions/upload-artifact@main"),
+        ):
+            with self.subTest(seam=f"gnmic producer {seam}"):
+                self.mutate(workflow, seam, replacement, occurrence=1)
+        exact_path = (
+            "path: ${{ runner.temp }}/gnmic-cache/"
+            "gnmic_0.46.0_Linux_x86_64.tar.gz"
+        )
+        for occurrence in (0, 1):
+            with self.subTest(seam="gnmic exact path", occurrence=occurrence):
+                self.mutate(
+                    workflow,
+                    exact_path,
+                    "path: ${{ runner.temp }}/gnmic-cache/wrong.tar.gz",
+                    occurrence=occurrence,
+                )
+
+        action = ".github/actions/install-gnmic-artifact/action.yml"
+        for old, new in (
+            ("actions/download-artifact@v8", "actions/download-artifact@main"),
+            ("name: gnmic-v0.46.0-linux-x86_64", "name: gnmic-latest"),
+            ("--install-archive", "--prepare-archive"),
+            (
+                "set -euo pipefail",
+                "set -euo pipefail\n        curl https://example.invalid/gnmic",
+            ),
+        ):
+            with self.subTest(seam=old):
+                self.mutate(action, old, new)
+
+        installer = ".github/scripts/install-gnmic.sh"
+        for old, new in (
+            ('readonly GNMIC_VERSION="0.46.0"', 'readonly GNMIC_VERSION="latest"'),
+            (
+                "a3ded2f355a615df73900f31b9791f41e796e9c5c63b171e1ce041e8139ee00e",
+                "0" * 64,
+            ),
+            ("curl -fsSL", "curl -sL"),
+            ("--connect-timeout 10", "--connect-timeout 0"),
+        ):
+            with self.subTest(seam=old):
+                self.mutate(installer, old, new)
+
+    def test_gnmic_installer_executable_mode_is_load_bearing(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            for fixture in (
+                ".github/workflows",
+                ".github/actions/install-gnmic-artifact",
+                ".github/actions/install-grpcurl-artifact",
+                ".github/actions/setup-dataplane-host",
+            ):
+                shutil.copytree(ROOT / fixture, root / fixture)
+            shutil.copy2(ROOT / "Dockerfile", root / "Dockerfile")
+            gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
+            gobgp.parent.mkdir(parents=True)
+            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
+            scripts = root / ".github" / "scripts"
+            scripts.mkdir(parents=True)
+            for name in ("install-grpcurl.sh", "install-gnmic.sh"):
+                shutil.copy2(ROOT / ".github" / "scripts" / name, scripts / name)
+            (scripts / "install-gnmic.sh").chmod(0o644)
+            self.assertIn(
+                "install-gnmic.sh must have exact executable mode 100755",
+                check(root),
+            )
+
     def test_heavy_workflow_aggregate_source_is_load_bearing(self):
         for workflow, lab in (
             ("interop.yml", "m1"),
@@ -322,7 +442,9 @@ class PrimerContractTests(unittest.TestCase):
         ):
             relative = f".github/workflows/{workflow}"
             needs_prefix = (
-                "needs: [classify_changes, grpcurl_archive, prime_dev_image, "
+                "needs: [classify_changes, grpcurl_archive, "
+                + ("gnmic_archive, " if workflow == "interop.yml" else "")
+                + "prime_dev_image, "
             )
             for old, new in (
                 ("if: ${{ always() }}", "if: success()"),


### PR DESCRIPTION
## Summary

- fetch and checksum the pinned gNMIc v0.46.0 archive once per Interop run
- publish the verified archive as a same-run artifact and install it offline in M54 and M56
- add fail-closed installer and CI contract tests for retries, cache replacement, target preservation, workflow topology, and aggregate behavior

## Why

M54 and M56 independently streamed the same upstream release archive directly into `tar`. A transient upstream failure could make both jobs fail before their test logic ran, and the download path did not verify the pinned artifact checksum. Sharing one verified artifact separates dependency acquisition failure from product failures and removes duplicate network exposure.

This preserves the existing v0.46.0 behavior pin; upgrading gNMIc is intentionally separate.

## Validation

- installer self-test, `bash -n`, and ShellCheck
- 25 destructive CI contract tests and the live image-primer contract checker
- exact workflow Actionlint and YAML parsing
- official v0.46.0 archive checksum and offline version validation
- stable-surface, diff, formatting, Clippy, and rustdoc hooks

Hosted acceptance will verify the cold producer path, both offline consumers, aggregate result, and a subsequent warm-cache restore.

Linear: LAN-1010
