### PR TITLE
fix: classify config publication recovery outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Config publication failures now carry an exact rename-boundary result:
+  pre-rename failures preserve the prior config and may return clean only after
+  complete acknowledged compensation, while post-rename directory-sync
+  failures adopt the visible candidate and fail stop without rollback. Lost
+  commit, rollback, and finalization acknowledgements likewise fence mutation
+  admission, turn readiness red, retain ownership, and exit 70 for supervised
+  restart instead of guessing or exposing a clean failure. A real-daemon test
+  proves both restart authorities and rejects a second mutation during the
+  recovery fence. (LAN-1009)
 - Persisted runtime-config owners now fail stop with exit 70 five seconds after
   settlement ambiguity is detected, or when an owner remains unsettled for the
   fixed 30-minute budget plus that grace. Transaction/Apply, Neighbor4, FIB2,

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -225,8 +225,9 @@ impl NeighborService {
             let join = tokio::spawn(async move {
                 let _permit = coordinator.acquire().await?;
                 match body(None).await {
-                    OwnedRuntimeConfigOutcome::Clean(result) => result,
-                    OwnedRuntimeConfigOutcome::Ambiguous(error) => {
+                    OwnedRuntimeConfigOutcome::CleanNoEffect(result) => result,
+                    OwnedRuntimeConfigOutcome::PublishedDurable(()) => Ok(()),
+                    OwnedRuntimeConfigOutcome::Fenced { error, .. } => {
                         let _ = error;
                         std::future::pending().await
                     }
@@ -300,12 +301,12 @@ where
     B: FnOnce(crate::peer_types::ConfigPersistAck) -> ConfigEvent,
 {
     if daemon_gate.is_some_and(|gate| gate.is_shutting_down()) {
-        return OwnedRuntimeConfigOutcome::Clean(Err(Status::unavailable(format!(
+        return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(Status::unavailable(format!(
             "{operation_name} rejected: daemon is shutting down"
         ))));
     }
     if let Err(error) = check_config_mutation_gate(&config_mutation_gate, operation_name).await {
-        return OwnedRuntimeConfigOutcome::Clean(Err(error));
+        return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(error));
     }
     if let Some(operation) = &owned {
         operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
@@ -314,7 +315,7 @@ where
         match stage_runtime_config_event_typed(permit, build_event).await {
             Ok(staged) => Some(staged),
             Err(error) => {
-                return OwnedRuntimeConfigOutcome::Clean(Err(error.into_status()));
+                return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(error.into_status()));
             }
         }
     } else {
@@ -325,31 +326,41 @@ where
     match outcome {
         OwnedNeighborDispatch::NotAccepted(error) => {
             drop(staged);
-            OwnedRuntimeConfigOutcome::Clean(Err(error))
+            OwnedRuntimeConfigOutcome::CleanNoEffect(Err(error))
         }
-        OwnedNeighborDispatch::AcceptedReplyLost(error) => {
-            OwnedRuntimeConfigOutcome::Ambiguous(error)
-        }
+        OwnedNeighborDispatch::AcceptedReplyLost(error) => OwnedRuntimeConfigOutcome::Fenced {
+            error,
+            reason: crate::runtime_config_settlement::RuntimeConfigFenceReason::AcknowledgementLost,
+        },
         OwnedNeighborDispatch::Replied(
             OwnedNeighborMutationOutcome::RejectedNoEffect(error)
             | OwnedNeighborMutationOutcome::FullyCompensated(error),
         ) => {
             drop(staged);
-            OwnedRuntimeConfigOutcome::Clean(Err(owned_neighbor_error_status(error)))
+            OwnedRuntimeConfigOutcome::CleanNoEffect(Err(owned_neighbor_error_status(error)))
         }
         OwnedNeighborDispatch::Replied(OwnedNeighborMutationOutcome::CompensationAmbiguous(
             error,
-        )) => OwnedRuntimeConfigOutcome::Ambiguous(owned_neighbor_error_status(error)),
+        )) => OwnedRuntimeConfigOutcome::Fenced {
+            error: owned_neighbor_error_status(error),
+            reason: crate::runtime_config_settlement::RuntimeConfigFenceReason::KnownDivergence,
+        },
         OwnedNeighborDispatch::Replied(OwnedNeighborMutationOutcome::Success) => {
             let Some(staged) = staged else {
-                return OwnedRuntimeConfigOutcome::Clean(Ok(()));
+                return OwnedRuntimeConfigOutcome::PublishedDurable(());
             };
             if let Some(operation) = &owned {
                 operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
             }
             match staged.commit_typed().await {
-                Ok(()) => OwnedRuntimeConfigOutcome::Clean(Ok(())),
-                Err(error) => OwnedRuntimeConfigOutcome::Ambiguous(error.into_status()),
+                Ok(()) => OwnedRuntimeConfigOutcome::PublishedDurable(()),
+                Err(error) => {
+                    let reason = error.fence_reason();
+                    OwnedRuntimeConfigOutcome::Fenced {
+                        error: error.into_status(),
+                        reason,
+                    }
+                }
             }
         }
     }

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -381,8 +381,9 @@ impl PeerGroupService {
             let join = tokio::spawn(async move {
                 let _permit = coordinator.acquire().await?;
                 match body(None).await {
-                    OwnedRuntimeConfigOutcome::Clean(result) => result,
-                    OwnedRuntimeConfigOutcome::Ambiguous(error) => {
+                    OwnedRuntimeConfigOutcome::CleanNoEffect(result) => result,
+                    OwnedRuntimeConfigOutcome::PublishedDurable(()) => Ok(()),
+                    OwnedRuntimeConfigOutcome::Fenced { error, .. } => {
                         let _ = error;
                         std::future::pending().await
                     }
@@ -434,12 +435,12 @@ async fn owned_peer_group_mutation_body(
     persist_permit: Option<mpsc::OwnedPermit<ConfigEvent>>,
 ) -> OwnedRuntimeConfigOutcome<(), Status> {
     if daemon_gate.is_some_and(|gate| gate.is_shutting_down()) {
-        return OwnedRuntimeConfigOutcome::Clean(Err(Status::unavailable(format!(
+        return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(Status::unavailable(format!(
             "{operation_name} rejected: daemon is shutting down"
         ))));
     }
     if let Err(error) = check_config_mutation_gate(&config_mutation_gate, operation_name).await {
-        return OwnedRuntimeConfigOutcome::Clean(Err(error));
+        return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(error));
     }
 
     let (mutation, event) = match intent {
@@ -459,15 +460,15 @@ async fn owned_peer_group_mutation_body(
                 .await
                 {
                     Ok(prior) => prior,
-                    Err(error) => return OwnedRuntimeConfigOutcome::Clean(Err(error)),
+                    Err(error) => return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(error)),
                 };
                 match prior {
                     Some(prior) => definition.md5_password = prior.md5_password,
                     None if allow_passwordless_create => {}
                     None => {
-                        return OwnedRuntimeConfigOutcome::Clean(Err(Status::not_found(format!(
-                            "peer group {name} not found"
-                        ))));
+                        return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(Status::not_found(
+                            format!("peer group {name} not found"),
+                        )));
                     }
                 }
             }
@@ -515,7 +516,9 @@ async fn owned_peer_group_mutation_body(
             .await
         {
             Ok(staged) => Some(staged),
-            Err(error) => return OwnedRuntimeConfigOutcome::Clean(Err(error.into_status())),
+            Err(error) => {
+                return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(error.into_status()));
+            }
         }
     } else {
         None
@@ -530,28 +533,38 @@ async fn owned_peer_group_mutation_body(
     match dispatch {
         OwnedCatalogDispatch::NotAccepted(error) => {
             drop(staged);
-            OwnedRuntimeConfigOutcome::Clean(Err(error))
+            OwnedRuntimeConfigOutcome::CleanNoEffect(Err(error))
         }
-        OwnedCatalogDispatch::AcceptedReplyLost(error) => {
-            OwnedRuntimeConfigOutcome::Ambiguous(error)
-        }
+        OwnedCatalogDispatch::AcceptedReplyLost(error) => OwnedRuntimeConfigOutcome::Fenced {
+            error,
+            reason: crate::runtime_config_settlement::RuntimeConfigFenceReason::AcknowledgementLost,
+        },
         OwnedCatalogDispatch::Replied(
             OwnedCatalogMutationOutcome::RejectedNoEffect(error)
             | OwnedCatalogMutationOutcome::FullyCompensated(error),
         ) => {
             drop(staged);
-            OwnedRuntimeConfigOutcome::Clean(Err(catalog_mutation_error_to_status(&error)))
+            OwnedRuntimeConfigOutcome::CleanNoEffect(Err(catalog_mutation_error_to_status(&error)))
         }
         OwnedCatalogDispatch::Replied(OwnedCatalogMutationOutcome::CompensationAmbiguous(
             error,
-        )) => OwnedRuntimeConfigOutcome::Ambiguous(catalog_mutation_error_to_status(&error)),
+        )) => OwnedRuntimeConfigOutcome::Fenced {
+            error: catalog_mutation_error_to_status(&error),
+            reason: crate::runtime_config_settlement::RuntimeConfigFenceReason::KnownDivergence,
+        },
         OwnedCatalogDispatch::Replied(OwnedCatalogMutationOutcome::Success) => {
             let Some(staged) = staged else {
-                return OwnedRuntimeConfigOutcome::Clean(Ok(()));
+                return OwnedRuntimeConfigOutcome::PublishedDurable(());
             };
             match staged.commit_typed().await {
-                Ok(()) => OwnedRuntimeConfigOutcome::Clean(Ok(())),
-                Err(error) => OwnedRuntimeConfigOutcome::Ambiguous(error.into_status()),
+                Ok(()) => OwnedRuntimeConfigOutcome::PublishedDurable(()),
+                Err(error) => {
+                    let reason = error.fence_reason();
+                    OwnedRuntimeConfigOutcome::Fenced {
+                        error: error.into_status(),
+                        reason,
+                    }
+                }
             }
         }
     }
@@ -1751,7 +1764,9 @@ mod tests {
         let (config_tx, mut config_rx) = mpsc::channel(4);
         let svc = PeerGroupService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
         let (mut call, ack) = staged_delete_call(svc, &mut config_rx).await;
-        let crate::peer_types::ConfigPersistAck { staged, commit } = ack;
+        let crate::peer_types::ConfigPersistAck::Staged { staged, commit } = ack else {
+            panic!("expected staged persistence")
+        };
         staged.send(Ok(())).unwrap();
         match peer_rx.recv().await.expect("expected owned delete") {
             PeerManagerCommand::OwnedCatalogMutation { reply, .. } => {
@@ -1760,7 +1775,6 @@ mod tests {
             _ => panic!("expected owned peer-group delete"),
         }
         let reply = commit
-            .expect("owned mutation requires commit handshake")
             .await
             .expect("runtime owner must hand off commit acknowledgement");
         drop(reply);
@@ -1786,7 +1800,9 @@ mod tests {
             coordinator.clone(),
         );
         let (call, ack) = staged_delete_call(svc, &mut config_rx).await;
-        let crate::peer_types::ConfigPersistAck { staged, commit } = ack;
+        let crate::peer_types::ConfigPersistAck::Staged { staged, commit } = ack else {
+            panic!("expected staged persistence")
+        };
         staged.send(Ok(())).unwrap();
         let PeerManagerCommand::OwnedCatalogMutation { reply, .. } =
             peer_rx.recv().await.expect("expected owned delete")
@@ -1802,11 +1818,10 @@ mod tests {
             "caller cancellation must not release mutation ownership"
         );
         reply.send(OwnedCatalogMutationOutcome::Success).unwrap();
-        let commit_reply = commit
-            .expect("owned mutation requires commit handshake")
-            .await
-            .expect("detached executor must request commit");
-        commit_reply.send(Ok(())).unwrap();
+        let commit_reply = commit.await.expect("detached executor must request commit");
+        commit_reply
+            .send(crate::peer_types::ConfigPersistCommitOutcome::PublishedDurable)
+            .unwrap();
         assert!(
             tokio::time::timeout(Duration::from_secs(1), coordinator.acquire())
                 .await

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -2014,6 +2014,19 @@ impl std::fmt::Display for ConfigPersistError {
     }
 }
 
+/// Exact result of attempting to publish a config candidate.
+///
+/// The persister selects this at the atomic rename boundary. Receivers must
+/// not reconstruct it from errno, strings, or channel state.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ConfigPersistCommitOutcome {
+    /// The candidate is on disk; adopt it as the bridge snapshot.
+    PublishedDurable,
+    /// Nothing was written; keep the previous snapshot.
+    NotPublished(String),
+    PublicationAmbiguous(String),
+}
+
 /// Two-phase persistence acknowledgement carried by a [`ConfigEvent`].
 ///
 /// `FAILED_PRECONDITION` from a mutating RPC means the request did nothing.
@@ -2028,30 +2041,38 @@ impl std::fmt::Display for ConfigPersistError {
 /// `staged`. Nothing is observable on disk yet. The caller applies its runtime
 /// change and returns its commit channel through `commit`; dropping that
 /// channel discards the staged write instead.
-pub struct ConfigPersistAck {
+pub enum ConfigPersistAck {
+    /// Stage first, then wait for the runtime owner to request publication.
     /// Fires once the candidate is durably staged, or with the staging
     /// failure. A failure here means nothing was written and — because the
     /// caller has not applied yet — nothing was mutated.
-    pub staged: oneshot::Sender<Result<(), ConfigPersistError>>,
     /// Carries the caller's reply channel once its runtime change landed,
     /// which publishes the staged write. Dropping it discards the stage.
+    Staged {
+        /// Fires once the candidate is durably staged, or with the staging
+        /// failure. A failure here means nothing was written and — because the
+        /// caller has not applied yet — nothing was mutated.
+        staged: oneshot::Sender<Result<(), ConfigPersistError>>,
+        /// Carries the caller's reply channel once its runtime change landed,
+        /// which publishes the staged write. Dropping it discards the stage.
+        commit: oneshot::Receiver<oneshot::Sender<ConfigPersistCommitOutcome>>,
+    },
+    /// Publish immediately for an owner that supplies its own compensation
+    /// protocol (config transactions and FIB-table CRUD).
     ///
     /// `None` requests single-phase persistence: the bridge publishes as soon
     /// as the candidate is staged and reports the durable outcome on `staged`.
     /// Used by the paths that own an apply/rollback executor of their own
     /// (ADR-0076 config transactions, FIB-table CRUD).
-    pub commit: Option<oneshot::Receiver<oneshot::Sender<Result<(), String>>>>,
+    Immediate(oneshot::Sender<ConfigPersistCommitOutcome>),
 }
 
 impl ConfigPersistAck {
     /// Single-phase acknowledgement: stage and publish in one step, reporting
     /// the durable outcome on the supplied channel.
     #[must_use]
-    pub fn immediate(staged: oneshot::Sender<Result<(), ConfigPersistError>>) -> Self {
-        Self {
-            staged,
-            commit: None,
-        }
+    pub fn immediate(commit: oneshot::Sender<ConfigPersistCommitOutcome>) -> Self {
+        Self::Immediate(commit)
     }
 
     /// Drive the handshake to a successful persist, the way the config bridge
@@ -2060,25 +2081,36 @@ impl ConfigPersistAck {
     /// Returns whether the caller committed. `false` means it dropped the
     /// staged write, so nothing was persisted.
     pub async fn accept(self) -> bool {
-        let _ = self.staged.send(Ok(()));
-        let Some(commit) = self.commit else {
-            return true;
-        };
-        match commit.await {
-            Ok(reply) => {
-                let _ = reply.send(Ok(()));
+        match self {
+            Self::Immediate(reply) => {
+                let _ = reply.send(ConfigPersistCommitOutcome::PublishedDurable);
                 true
             }
-            Err(_) => false,
+            Self::Staged { staged, commit } => {
+                let _ = staged.send(Ok(()));
+                match commit.await {
+                    Ok(reply) => {
+                        let _ = reply.send(ConfigPersistCommitOutcome::PublishedDurable);
+                        true
+                    }
+                    Err(_) => false,
+                }
+            }
         }
     }
 
     /// Fail the handshake the way an unwritable config file does: the durable
     /// write never landed, and the caller has not mutated anything yet.
     pub fn fail_write(self, message: impl Into<String>) {
-        let _ = self
-            .staged
-            .send(Err(ConfigPersistError::Write(message.into())));
+        let message = message.into();
+        match self {
+            Self::Staged { staged, .. } => {
+                let _ = staged.send(Err(ConfigPersistError::Write(message)));
+            }
+            Self::Immediate(reply) => {
+                let _ = reply.send(ConfigPersistCommitOutcome::NotPublished(message));
+            }
+        }
     }
 }
 

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -417,8 +417,9 @@ impl PolicyService {
             tokio::spawn(async move {
                 let _permit = coordinator.acquire().await?;
                 match body(None).await {
-                    OwnedRuntimeConfigOutcome::Clean(result) => result,
-                    OwnedRuntimeConfigOutcome::Ambiguous(error) => {
+                    OwnedRuntimeConfigOutcome::CleanNoEffect(result) => result,
+                    OwnedRuntimeConfigOutcome::PublishedDurable(()) => Ok(()),
+                    OwnedRuntimeConfigOutcome::Fenced { error, .. } => {
                         let _ = error;
                         std::future::pending().await
                     }
@@ -448,12 +449,12 @@ async fn owned_policy_mutation_body(
     persist_permit: Option<mpsc::OwnedPermit<ConfigEvent>>,
 ) -> OwnedRuntimeConfigOutcome<(), Status> {
     if daemon_gate.is_some_and(|gate| gate.is_shutting_down()) {
-        return OwnedRuntimeConfigOutcome::Clean(Err(Status::unavailable(format!(
+        return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(Status::unavailable(format!(
             "{operation_name} rejected: daemon is shutting down"
         ))));
     }
     if let Err(error) = check_config_mutation_gate(&config_mutation_gate, operation_name).await {
-        return OwnedRuntimeConfigOutcome::Clean(Err(error));
+        return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(error));
     }
     if let Some(operation) = &owned {
         operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
@@ -463,7 +464,9 @@ async fn owned_policy_mutation_body(
             .await
         {
             Ok(staged) => Some(staged),
-            Err(error) => return OwnedRuntimeConfigOutcome::Clean(Err(error.into_status())),
+            Err(error) => {
+                return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(error.into_status()));
+            }
         }
     } else {
         None
@@ -477,28 +480,38 @@ async fn owned_policy_mutation_body(
     match dispatch {
         OwnedCatalogDispatch::NotAccepted(error) => {
             drop(staged);
-            OwnedRuntimeConfigOutcome::Clean(Err(error))
+            OwnedRuntimeConfigOutcome::CleanNoEffect(Err(error))
         }
-        OwnedCatalogDispatch::AcceptedReplyLost(error) => {
-            OwnedRuntimeConfigOutcome::Ambiguous(error)
-        }
+        OwnedCatalogDispatch::AcceptedReplyLost(error) => OwnedRuntimeConfigOutcome::Fenced {
+            error,
+            reason: crate::runtime_config_settlement::RuntimeConfigFenceReason::AcknowledgementLost,
+        },
         OwnedCatalogDispatch::Replied(
             OwnedCatalogMutationOutcome::RejectedNoEffect(error)
             | OwnedCatalogMutationOutcome::FullyCompensated(error),
         ) => {
             drop(staged);
-            OwnedRuntimeConfigOutcome::Clean(Err(catalog_mutation_error_to_status(&error)))
+            OwnedRuntimeConfigOutcome::CleanNoEffect(Err(catalog_mutation_error_to_status(&error)))
         }
         OwnedCatalogDispatch::Replied(OwnedCatalogMutationOutcome::CompensationAmbiguous(
             error,
-        )) => OwnedRuntimeConfigOutcome::Ambiguous(catalog_mutation_error_to_status(&error)),
+        )) => OwnedRuntimeConfigOutcome::Fenced {
+            error: catalog_mutation_error_to_status(&error),
+            reason: crate::runtime_config_settlement::RuntimeConfigFenceReason::KnownDivergence,
+        },
         OwnedCatalogDispatch::Replied(OwnedCatalogMutationOutcome::Success) => {
             let Some(staged) = staged else {
-                return OwnedRuntimeConfigOutcome::Clean(Ok(()));
+                return OwnedRuntimeConfigOutcome::PublishedDurable(());
             };
             match staged.commit_typed().await {
-                Ok(()) => OwnedRuntimeConfigOutcome::Clean(Ok(())),
-                Err(error) => OwnedRuntimeConfigOutcome::Ambiguous(error.into_status()),
+                Ok(()) => OwnedRuntimeConfigOutcome::PublishedDurable(()),
+                Err(error) => {
+                    let reason = error.fence_reason();
+                    OwnedRuntimeConfigOutcome::Fenced {
+                        error: error.into_status(),
+                        reason,
+                    }
+                }
             }
         }
     }
@@ -3747,7 +3760,9 @@ policy customer-in(peer_lp: u32) {
         let (config_tx, mut config_rx) = mpsc::channel(4);
         let svc = PolicyService::new(AccessMode::ReadWrite, peer_tx, Some(config_tx), None);
         let (mut call, ack) = staged_policy_delete(svc, &mut config_rx).await;
-        let crate::peer_types::ConfigPersistAck { staged, commit } = ack;
+        let crate::peer_types::ConfigPersistAck::Staged { staged, commit } = ack else {
+            panic!("expected staged persistence")
+        };
         staged.send(Ok(())).unwrap();
         match peer_rx.recv().await.expect("expected owned policy delete") {
             PeerManagerCommand::OwnedCatalogMutation { reply, .. } => {
@@ -3756,7 +3771,6 @@ policy customer-in(peer_lp: u32) {
             _ => panic!("expected owned policy delete"),
         }
         let reply = commit
-            .expect("owned policy mutation requires commit handshake")
             .await
             .expect("runtime owner must hand off commit acknowledgement");
         drop(reply);

--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -61,14 +61,16 @@ pub enum RuntimeConfigSettlementPhase {
 pub enum RuntimeConfigSettlementTerminal {
     Owned,
     Settled,
-    AmbiguousFenced,
+    RecoveryFenced,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RuntimeConfigFenceReason {
     BudgetExpired,
     ExecutorLost,
-    DetectedAmbiguousOutcome,
+    KnownDivergence,
+    PublicationAmbiguous,
+    AcknowledgementLost,
 }
 
 const TERMINAL_OWNED: u8 = 0;
@@ -80,8 +82,10 @@ const PHASE_SETTLING: u8 = 2;
 const AMBIGUITY_REASON_NONE: u8 = 0;
 const AMBIGUITY_REASON_BUDGET: u8 = 1;
 const AMBIGUITY_REASON_EXECUTOR: u8 = 2;
-const AMBIGUITY_REASON_DETECTED: u8 = 3;
-const AMBIGUITY_NOT_READY: &str = "runtime config settlement is ambiguous";
+const FENCE_REASON_DIVERGENCE: u8 = 3;
+const FENCE_REASON_PUBLICATION: u8 = 4;
+const FENCE_REASON_ACKNOWLEDGEMENT: u8 = 5;
+const RECOVERY_NOT_READY: &str = "runtime config settlement requires supervised recovery";
 
 #[derive(Debug)]
 struct OwnedResources {
@@ -327,16 +331,23 @@ impl RuntimeConfigSettlementWatchdog {
             );
             let outcome = body(operation.clone()).await;
             match outcome {
-                OwnedRuntimeConfigOutcome::Clean(result) => {
+                OwnedRuntimeConfigOutcome::CleanNoEffect(result) => {
                     if !operation.try_settle() {
                         std::future::pending::<()>().await;
                     }
                     drop(executor_guard);
                     result
                 }
-                OwnedRuntimeConfigOutcome::Ambiguous(error) => {
+                OwnedRuntimeConfigOutcome::PublishedDurable(value) => {
+                    if !operation.try_settle() {
+                        std::future::pending::<()>().await;
+                    }
+                    drop(executor_guard);
+                    Ok(value)
+                }
+                OwnedRuntimeConfigOutcome::Fenced { error, reason } => {
                     let _ = error;
-                    let _ = operation.fence_ambiguous_outcome();
+                    let _ = operation.fence_recovery(reason);
                     std::future::pending().await
                 }
             }
@@ -364,9 +375,15 @@ impl RuntimeConfigSettlementWatchdog {
 /// Typed result from an owned body; never inferred from transport status.
 pub enum OwnedRuntimeConfigOutcome<T, E> {
     /// Success or a proven no-effect or fully-compensated failure.
-    Clean(Result<T, E>),
+    CleanNoEffect(Result<T, E>),
+    /// The requested candidate is fully applied and durable.
+    PublishedDurable(T),
     /// An accepted effect whose final state cannot be proved.
-    Ambiguous(E),
+    /// Ownership must be retained until supervised recovery.
+    Fenced {
+        error: E,
+        reason: RuntimeConfigFenceReason,
+    },
 }
 
 /// Response attachment shared with a detached owned executor.
@@ -444,7 +461,7 @@ impl OwnedRuntimeConfigOperation {
         match self.inner.terminal.load(Ordering::Acquire) {
             TERMINAL_OWNED => RuntimeConfigSettlementTerminal::Owned,
             TERMINAL_SETTLED => RuntimeConfigSettlementTerminal::Settled,
-            _ => RuntimeConfigSettlementTerminal::AmbiguousFenced,
+            _ => RuntimeConfigSettlementTerminal::RecoveryFenced,
         }
     }
 
@@ -453,7 +470,9 @@ impl OwnedRuntimeConfigOperation {
         match self.inner.fence_reason.load(Ordering::Acquire) {
             AMBIGUITY_REASON_BUDGET => Some(RuntimeConfigFenceReason::BudgetExpired),
             AMBIGUITY_REASON_EXECUTOR => Some(RuntimeConfigFenceReason::ExecutorLost),
-            AMBIGUITY_REASON_DETECTED => Some(RuntimeConfigFenceReason::DetectedAmbiguousOutcome),
+            FENCE_REASON_DIVERGENCE => Some(RuntimeConfigFenceReason::KnownDivergence),
+            FENCE_REASON_PUBLICATION => Some(RuntimeConfigFenceReason::PublicationAmbiguous),
+            FENCE_REASON_ACKNOWLEDGEMENT => Some(RuntimeConfigFenceReason::AcknowledgementLost),
             _ => None,
         }
     }
@@ -465,13 +484,10 @@ impl OwnedRuntimeConfigOperation {
             .store(attached, Ordering::Release);
     }
 
-    /// Fence a known ambiguous result before any response can be published.
+    /// Fence a typed recovery result before any response can be published.
     #[must_use]
-    pub fn fence_ambiguous_outcome(&self) -> bool {
-        fence(
-            self.inner.as_ref(),
-            RuntimeConfigFenceReason::DetectedAmbiguousOutcome,
-        )
+    pub fn fence_recovery(&self, reason: RuntimeConfigFenceReason) -> bool {
+        fence(self.inner.as_ref(), reason)
     }
 
     #[must_use]
@@ -538,12 +554,14 @@ fn fence(operation: &OperationInner, reason: RuntimeConfigFenceReason) -> bool {
     let reason_value = match reason {
         RuntimeConfigFenceReason::BudgetExpired => AMBIGUITY_REASON_BUDGET,
         RuntimeConfigFenceReason::ExecutorLost => AMBIGUITY_REASON_EXECUTOR,
-        RuntimeConfigFenceReason::DetectedAmbiguousOutcome => AMBIGUITY_REASON_DETECTED,
+        RuntimeConfigFenceReason::KnownDivergence => FENCE_REASON_DIVERGENCE,
+        RuntimeConfigFenceReason::PublicationAmbiguous => FENCE_REASON_PUBLICATION,
+        RuntimeConfigFenceReason::AcknowledgementLost => FENCE_REASON_ACKNOWLEDGEMENT,
     };
     operation
         .fence_reason
         .store(reason_value, Ordering::Release);
-    operation.daemon_gate.mark_not_ready(AMBIGUITY_NOT_READY);
+    operation.daemon_gate.mark_not_ready(RECOVERY_NOT_READY);
     operation.daemon_gate.begin_shutdown();
     operation.coordinator.close();
     if let Some(admission) = operation
@@ -783,7 +801,7 @@ mod tests {
         drop(guard);
         assert_eq!(
             operation.terminal(),
-            RuntimeConfigSettlementTerminal::AmbiguousFenced
+            RuntimeConfigSettlementTerminal::RecoveryFenced
         );
         assert_eq!(
             operation.fence_reason(),
@@ -799,10 +817,10 @@ mod tests {
     async fn detected_ambiguity_closes_both_admission_resources() {
         let (watchdog, receiver) = test_watchdog(Duration::from_secs(5), Duration::from_millis(20));
         let (operation, guard, coordinator, admission) = operation(&watchdog, true).await;
-        assert!(operation.fence_ambiguous_outcome());
+        assert!(operation.fence_recovery(RuntimeConfigFenceReason::PublicationAmbiguous));
         assert_eq!(
             operation.fence_reason(),
-            Some(RuntimeConfigFenceReason::DetectedAmbiguousOutcome)
+            Some(RuntimeConfigFenceReason::PublicationAmbiguous)
         );
         assert!(coordinator.is_closed());
         assert!(admission.unwrap().is_closed());
@@ -847,7 +865,7 @@ mod tests {
                         move |operation| async move {
                             let _ = operation_tx.send(operation);
                             let _ = release_rx.await;
-                            OwnedRuntimeConfigOutcome::<(), tonic::Status>::Clean(Ok(()))
+                            OwnedRuntimeConfigOutcome::<(), tonic::Status>::PublishedDurable(())
                         },
                     )
                     .await
@@ -900,9 +918,10 @@ mod tests {
                         move |operation| async move {
                             let _ = operation_tx.send(operation);
                             let _ = ambiguous_rx.await;
-                            OwnedRuntimeConfigOutcome::<(), tonic::Status>::Ambiguous(
-                                tonic::Status::internal("typed ambiguous test outcome"),
-                            )
+                            OwnedRuntimeConfigOutcome::<(), tonic::Status>::Fenced {
+                                error: tonic::Status::internal("typed recovery test outcome"),
+                                reason: RuntimeConfigFenceReason::PublicationAmbiguous,
+                            }
                         },
                     )
                     .await
@@ -923,11 +942,11 @@ mod tests {
         .unwrap();
         assert_eq!(
             operation.terminal(),
-            RuntimeConfigSettlementTerminal::AmbiguousFenced
+            RuntimeConfigSettlementTerminal::RecoveryFenced
         );
         assert_eq!(
             operation.fence_reason(),
-            Some(RuntimeConfigFenceReason::DetectedAmbiguousOutcome)
+            Some(RuntimeConfigFenceReason::PublicationAmbiguous)
         );
         assert!(gate.is_shutting_down());
         assert!(queued.await.unwrap().is_err());

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -59,6 +59,8 @@ use crate::proto::policy_service_server::PolicyServiceServer;
 use crate::proto::rib_service_server::RibServiceServer;
 use crate::rib_service::RibService;
 use crate::runtime_config_settlement::RuntimeConfigSettlementWatchdog;
+
+use crate::runtime_config_settlement::RuntimeConfigFenceReason;
 use rustbgpd_rib::{RibReadinessQuery, RibUpdate};
 use rustbgpd_telemetry::BgpMetrics;
 
@@ -157,7 +159,12 @@ pub enum ConfigTransactionApplyError {
     /// Internal actor/rollback failure.
     Internal(String),
     /// The daemon cannot prove whether the candidate took effect.
-    DetectedAmbiguousOutcome(String),
+    /// The owned mutation requires supervised recovery and must not return
+    /// while the settlement watchdog retains ownership.
+    RecoveryRequired {
+        reason: RuntimeConfigFenceReason,
+        message: String,
+    },
 }
 
 impl ConfigTransactionApplyError {
@@ -168,7 +175,7 @@ impl ConfigTransactionApplyError {
             Self::Unavailable(message) => Status::unavailable(message),
             Self::DeadlineExceeded(message) => Status::deadline_exceeded(message),
             Self::Internal(message) => Status::internal(message),
-            Self::DetectedAmbiguousOutcome(message) => Status::aborted(message),
+            Self::RecoveryRequired { message, .. } => Status::aborted(message),
         }
     }
 }
@@ -181,7 +188,7 @@ impl std::fmt::Display for ConfigTransactionApplyError {
             | Self::Unavailable(message)
             | Self::DeadlineExceeded(message)
             | Self::Internal(message)
-            | Self::DetectedAmbiguousOutcome(message) => f.write_str(message),
+            | Self::RecoveryRequired { message, .. } => f.write_str(message),
         }
     }
 }
@@ -585,7 +592,9 @@ pub async fn check_config_mutation_gate(
 /// discards the write with no trace.
 #[must_use = "a staged config write must be committed or explicitly dropped"]
 pub(crate) struct StagedConfigWrite {
-    commit_tx: tokio::sync::oneshot::Sender<tokio::sync::oneshot::Sender<Result<(), String>>>,
+    commit_tx: tokio::sync::oneshot::Sender<
+        tokio::sync::oneshot::Sender<crate::peer_types::ConfigPersistCommitOutcome>,
+    >,
 }
 
 impl StagedConfigWrite {
@@ -597,8 +606,16 @@ impl StagedConfigWrite {
             .map_err(|_| RuntimeConfigCommitError::HandoffLost)?;
         ack_rx
             .await
-            .map_err(|_| RuntimeConfigCommitError::AcknowledgementLost)?
-            .map_err(RuntimeConfigCommitError::Failed)
+            .map_err(|_| RuntimeConfigCommitError::AcknowledgementLost)
+            .and_then(|outcome| match outcome {
+                crate::peer_types::ConfigPersistCommitOutcome::PublishedDurable => Ok(()),
+                crate::peer_types::ConfigPersistCommitOutcome::NotPublished(error) => {
+                    Err(RuntimeConfigCommitError::NotPublished(error))
+                }
+                crate::peer_types::ConfigPersistCommitOutcome::PublicationAmbiguous(error) => {
+                    Err(RuntimeConfigCommitError::PublicationAmbiguous(error))
+                }
+            })
     }
 }
 
@@ -627,18 +644,33 @@ impl RuntimeConfigStageError {
 pub(crate) enum RuntimeConfigCommitError {
     HandoffLost,
     AcknowledgementLost,
-    Failed(String),
+    NotPublished(String),
+    PublicationAmbiguous(String),
 }
 
 impl RuntimeConfigCommitError {
     pub(crate) fn into_status(self) -> Status {
         match self {
-            Self::HandoffLost | Self::AcknowledgementLost => Status::internal(COMMIT_LOST),
-            Self::Failed(error) => Status::internal(format!(
+            Self::HandoffLost => {
+                Status::internal("config bridge rejected the staged config commit before delivery")
+            }
+            Self::AcknowledgementLost => Status::internal(COMMIT_LOST),
+            Self::NotPublished(error) => Status::internal(format!(
                 "config persistence commit failed after the runtime change was applied \
                  (runtime and persisted config have drifted — SIGHUP or restart to \
                  reconcile): {error}"
             )),
+            Self::PublicationAmbiguous(error) => Status::internal(format!(
+                "config candidate is visible but its crash durability is unproved: {error}"
+            )),
+        }
+    }
+
+    pub(crate) fn fence_reason(&self) -> RuntimeConfigFenceReason {
+        match self {
+            Self::HandoffLost | Self::NotPublished(_) => RuntimeConfigFenceReason::KnownDivergence,
+            Self::PublicationAmbiguous(_) => RuntimeConfigFenceReason::PublicationAmbiguous,
+            Self::AcknowledgementLost => RuntimeConfigFenceReason::AcknowledgementLost,
         }
     }
 }
@@ -676,9 +708,9 @@ pub(crate) async fn stage_runtime_config_event_typed(
 ) -> Result<StagedConfigWrite, RuntimeConfigStageError> {
     let (staged_tx, staged_rx) = tokio::sync::oneshot::channel();
     let (commit_tx, commit_rx) = tokio::sync::oneshot::channel();
-    permit.send(build_event(crate::peer_types::ConfigPersistAck {
+    permit.send(build_event(crate::peer_types::ConfigPersistAck::Staged {
         staged: staged_tx,
-        commit: Some(commit_rx),
+        commit: commit_rx,
     }));
     staged_rx
         .await

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -49,17 +49,22 @@ Persisted runtime mutations use a cancellation-shielded owner. If creation of
 the initial persistence stage fails because the config directory is not
 writable, the request is rejected cleanly before runtime state changes and the
 daemon remains available. That is different from failure after durable staging
-and runtime mutation have begun: if rename or directory fsync publication
-cannot be proved, the outcome is ambiguous. A read-only bind-mounted config
-*file* in an otherwise writable directory is especially dangerous because the
-temporary stage can succeed while replacement of the mount point cannot.
+and runtime mutation have begun. A failed rename is `NotPublished`, with the
+old file still authoritative. It returns cleanly only after complete
+acknowledged compensation; an unrestorable session identity instead fences as
+`KnownDivergence`. Directory fsync failing after rename is
+`PublicationAmbiguous`: the complete candidate is visible and adopted, no
+rollback is attempted, and restart decides durability. A read-only bind-mounted
+config *file* in an otherwise writable directory can stage successfully but
+fails replacement as `NotPublished`.
 
-An ambiguous owner immediately makes `/readyz` fail, closes admission for new
-persisted mutations, and retains ownership until process death. Detected
-ambiguity or executor loss exits with status 70 after a five-second fencing
-grace. A silent owner is fenced after the fixed 30-minute owned-settlement
-budget and exits five seconds later. Do not classify 70 as success or suppress
-its restart: the new process re-establishes authority from durable state.
+A recovery-fenced owner immediately makes `/readyz` fail, closes admission for
+new persisted mutations, and retains ownership until process death. Detected
+divergence, publication ambiguity, acknowledgement loss, or executor loss exits
+with status 70 after a five-second fencing grace. A silent owner is fenced after
+the fixed 30-minute owned-settlement budget and exits five seconds later. Do not
+classify 70 as success or suppress its restart: the new process re-establishes
+authority from durable state.
 
 The shipped systemd unit uses `Restart=on-failure`, but caps recovery at five
 starts per ten minutes so a deterministic persistence fault cannot flap every

--- a/docs/adr/0127-config-transaction-settlement-watchdog.md
+++ b/docs/adr/0127-config-transaction-settlement-watchdog.md
@@ -45,6 +45,46 @@ described below and the final cross-roster recovery proofs also remain
 incomplete. Until those land, this ADR stays Proposed and the source inventory
 must distinguish shipped owners from the decision's full target roster.
 
+### Typed publication and recovery classification
+
+The ordinary config publisher now classifies failures at the rename boundary,
+not from errno or error text. `NotPublished` means rename did not succeed and
+the old target remains authoritative. `PublicationAmbiguous` means rename
+succeeded, the complete candidate is visible at the target, and only its
+directory-fsync durability is unproved. The persister and config bridge adopt
+the candidate before returning either `PublishedDurable` or
+`PublicationAmbiguous`; they retain their prior snapshot for `NotPublished`.
+Only `PublishedDurable` enters applied-config history.
+
+Post-ownership settlement has three exact terminal states: `Owned`, `Settled`,
+and `RecoveryFenced`. A clean no-effect rejection or fully acknowledged
+compensation can settle. A durable success can settle only after finalization.
+Recovery fencing records one of `BudgetExpired`, `ExecutorLost`,
+`KnownDivergence`, `PublicationAmbiguous`, or `AcknowledgementLost`; it makes
+readiness red, closes mutation admission, retains ownership, and exits 70 after
+the existing five-second grace.
+
+The authority and compensation matrix is:
+
+| Publication/finalization result | Runtime action | Terminal classification |
+| --- | --- | --- |
+| Stage failure or lost stage acknowledgement before runtime mutation | No runtime work begins | Clean no effect |
+| `NotPublished` plus complete acknowledged compensation | Restore runtime and snapshot | Clean no effect |
+| `NotPublished` after a neighbor, peer-group, or policy session mutation | Session identity cannot be restored | `KnownDivergence` |
+| `NotPublished` plus known compensation failure | Stop compensation | `KnownDivergence` |
+| `NotPublished` plus accepted compensation reply loss | Do not guess completion | `AcknowledgementLost` |
+| `PublicationAmbiguous` | Adopt candidate; do not roll back | `PublicationAmbiguous` |
+| Accepted persistence acknowledgement lost | Do not roll back | `AcknowledgementLost` |
+| `PublishedDurable` plus successful finalization | Keep candidate | Durable success |
+| `PublishedDurable` plus known finalization failure | Keep candidate | `KnownDivergence` |
+| `PublishedDurable` plus finalization reply loss | Keep candidate | `AcknowledgementLost` |
+
+A commit handoff definitely rejected before delivery is `NotPublished`.
+Once a commit or finalization command is accepted, loss of its reply is
+`AcknowledgementLost`; no path rolls back or infers authority from channel
+closure. Restart validates the old config for a pre-rename failure and the
+complete candidate for a post-rename durability ambiguity.
+
 ## Decision
 
 ### One operation, one owner, one candidate
@@ -92,12 +132,12 @@ Any owned live phase terminates through exactly one mutually exclusive branch:
   rejection, a fully acknowledged rollback, or an acknowledged SIGHUP
   known-partial result after the runtime snapshot and config bridge adopted
   the same authority; or
-- `ambiguous_fenced`: ambiguity branches from any owned phase when settlement
-  cannot be proved; no success or rollback claim is permitted and fail-stop is
-  in progress.
+- `RecoveryFenced`: recovery fencing branches from any owned phase when
+  settlement cannot be proved; no success or rollback claim is permitted and
+  fail-stop is in progress.
 
 Only `clean_settled` releases the coordinator and streamed admission normally.
-`ambiguous_fenced` retains their logical ownership until process death. At
+`RecoveryFenced` retains their logical ownership until process death. At
 fail-stop or shutdown, every operation still queued in `waiting-for-ownership`
 is rejected and no queued waiter may acquire the newly freed physical mutex.
 A new process reconstructs authority from durable state.
@@ -141,7 +181,7 @@ cannot
 extend or replace the deadline.
 
 At 30 minutes without `clean_settled`, one atomic compare-and-swap irreversibly
-wins the `owned -> ambiguous_fenced` race against settlement. It marks readiness
+wins the `Owned -> RecoveryFenced` race against settlement. It marks readiness
 unavailable, closes admission for new persisted mutations, and requests
 supervised shutdown. Settlement may disarm only if its compare-and-swap wins
 first; after expiry wins, no late reply can reverse the fence or claim success.
@@ -157,7 +197,7 @@ disconnect, dropped response receiver, or caller cancellation may prevent a
 client from learning the outcome, but never aborts the transaction task,
 releases the coordinator, releases streamed admission, or disarms the terminal
 watchdog. The daemon-owned operation continues toward `clean_settled` or
-fail-stop.
+`RecoveryFenced`.
 
 The response therefore remains at-least-once ambiguous to the caller. Existing
 transaction status is authoritative only for the confirmed-transaction
@@ -173,7 +213,7 @@ acquisition advances the hard-exit deadline to five seconds after the loss.
 The same exact compare-and-swap decides executor-loss versus a concurrent
 `clean_settled` transition: loss cannot fence a prior settlement, and
 settlement cannot revoke a loss-won fence. Unless already `clean_settled`, the
-owner guard marks `ambiguous_fenced` before its coordinator guard or stream
+owner guard marks `RecoveryFenced` before its coordinator guard or stream
 permit can drop; the OS-thread registration outlives the task. Process abort
 already meets fail-stop.
 
@@ -191,7 +231,7 @@ For an unconfirmed apply:
 - After atomic persistence publishes it, restart uses the candidate on disk as
   authority even if the response or in-process finalization was lost.
 - If publication cannot be proven at watchdog expiry, the running process says
-  only `ambiguous_fenced`. Startup validates the one atomically published
+  only `RecoveryFenced`. Startup validates the one atomically published
   config object and fails closed under the existing persistence contract.
 
 V3 authority has three explicit publication windows. Before locator
@@ -214,12 +254,12 @@ Restart with a retained locator performs the existing verified boot revert.
 The typed terminal classifier is uniform across owner families.
 `clean_settled` includes success, a proved no-side-effect rejection, a fully
 acknowledged rollback, and the acknowledged SIGHUP known-partial case above.
-`ambiguous_fenced` includes an accepted-command deadline, lost mutation or
+`RecoveryFenced` includes an accepted-command deadline, lost mutation or
 persistence acknowledgement, failed or unacknowledged rollback, uncertain
 publication, executor loss, and true SIGHUP reconcile or bridge ambiguity.
 Pre-persistence, post-persistence, rollback, and lost-ack windows obey the same
 rule: no success or clean-failure claim without proof. A family-local timeout
-may advance an ambiguous operation to `ambiguous_fenced`; it never releases
+may advance an operation to `RecoveryFenced`; it never releases
 ownership or proves settlement. The watchdog does not guess which side effect
 completed. It fences, exits, and lets established durable authority decide
 startup behavior.
@@ -271,7 +311,7 @@ recovery contract:
 1. An injected deterministic watchdog driver holds each actor and persistence
    reply used by every persisted owner family. At 29 minutes 59 seconds the
    owner, coordinator, admission, and watchdog remain live; at 30 minutes the
-   state becomes `ambiguous_fenced` exactly once. Tokio paused time cannot
+   state becomes `RecoveryFenced` exactly once. Tokio paused time cannot
    drive an OS-thread condition variable, so real OS-thread and subprocess
    tests must separately prove wake-up and terminal behavior.
 2. Caller-`JoinHandle` wait/drop tests prove the operation remains owned/running.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -518,14 +518,16 @@ For your own deployment:
 - **Settlement fail-stop**: `--stop-timeout=1920` gives an explicit stop the
   same 32-minute grace as the shipped systemd unit. A failure to create the
   initial persistence stage rejects cleanly before runtime mutation. After
-  staging and runtime mutation begin, an unprovable rename or directory fsync
-  is ambiguous; a read-only bind-mounted config *file* can have a writable
-  parent yet still fail replacement in this window. The daemon then marks
-  readiness unavailable, closes persisted-mutation admission, and exits 70
-  within five seconds of detected ambiguity. A silent owner is fenced at 30
-  minutes and exits five seconds later. This standalone command has no restart
-  policy; use bounded supervisor retries and inspect durable config authority
-  before recovery.
+  runtime mutation begins, a failed rename is `NotPublished`: only complete
+  acknowledged compensation returns cleanly; otherwise known divergence fences
+  recovery. A post-rename directory-fsync failure is `PublicationAmbiguous`:
+  the complete visible candidate is adopted without rollback, and restart
+  selects durable authority. A read-only bind-mounted config *file* can have a
+  writable parent yet still fail replacement as `NotPublished`. A fenced daemon
+  marks readiness unavailable, closes persisted-mutation admission, and exits
+  70 within five seconds; a silent owner is fenced at 30 minutes and exits five
+  seconds later. This standalone command has no restart policy; use bounded
+  supervisor retries and inspect durable config authority before recovery.
 
 - **Health**: the image declares a `HEALTHCHECK` that runs `rbgp
   --json health` against the daemon's local gRPC socket and requires a

--- a/src/config_migration.rs
+++ b/src/config_migration.rs
@@ -286,10 +286,10 @@ fn migrate(request: &Request) -> Result<Outcome, MigrationFailure> {
             )
         })
         .map_err(|error| {
-            if error
-                .to_string()
-                .contains("directory fsync after rename failed")
-            {
+            if matches!(
+                error,
+                crate::confirm_journal::AtomicPublishError::PublicationAmbiguous(_)
+            ) {
                 "migration publication durability is ambiguous; inspect CONFIG_PATH before retrying"
                     .to_string()
             } else {

--- a/src/config_persister.rs
+++ b/src/config_persister.rs
@@ -16,6 +16,7 @@ use tracing::{error, info, warn};
 #[cfg(test)]
 use crate::config::Config;
 use crate::config::{AcceptedConfigSnapshot, Neighbor};
+use rustbgpd_api::peer_types::ConfigPersistCommitOutcome;
 
 /// File under `runtime_state_dir` recording the config file's mtime as of the
 /// daemon's last read or write of it.
@@ -37,7 +38,7 @@ pub enum ConfigMutation {
     /// the result to a caller that must not proceed until the write has settled.
     ReplaceConfigAck(
         Arc<AcceptedConfigSnapshot>,
-        oneshot::Sender<Result<(), String>>,
+        oneshot::Sender<ConfigPersistCommitOutcome>,
     ),
     /// Durably stage a replacement snapshot without publishing it, then
     /// acknowledge whether the write can land. Every persistence failure an
@@ -50,7 +51,7 @@ pub enum ConfigMutation {
         oneshot::Sender<Result<(), String>>,
     ),
     /// Publish the staged snapshot: rename it into place and adopt it.
-    CommitStagedConfig(oneshot::Sender<Result<(), String>>),
+    CommitStagedConfig(oneshot::Sender<ConfigPersistCommitOutcome>),
     /// Drop the staged snapshot. The caller's runtime change did not land, so
     /// neither may the write.
     DiscardStagedConfig,
@@ -127,14 +128,18 @@ impl ConfigPersister {
                     let previous = Arc::clone(&self.current);
                     info!("replacing persister config snapshot and persisting it");
                     self.current = new_config;
-                    let result = self.persist().map_err(|e| e.to_string());
-                    if let Err(e) = &result {
+                    let result = self.persist();
+                    if let ConfigPersistCommitOutcome::NotPublished(error) = &result {
                         self.current = previous;
                         error!(
                             path = %self.config_path.display(),
-                            error = %e,
-                            "failed to persist config — persister snapshot rolled back to previous state"
+                            error = %error,
+                            "config was not published — persister snapshot rolled back to previous state"
                         );
+                    } else if let ConfigPersistCommitOutcome::PublicationAmbiguous(error) = &result
+                    {
+                        error!(path = %self.config_path.display(), error = %error,
+                            "config is visible but crash durability is unproved");
                     }
                     let _ = ack.send(result);
                     continue;
@@ -158,12 +163,20 @@ impl ConfigPersister {
             // that is still outstanding here can no longer be published.
             self.discard_staged();
             let should_persist = self.apply(mutation);
-            if should_persist && let Err(e) = self.persist() {
-                error!(
-                    path = %self.config_path.display(),
-                    error = %e,
-                    "failed to persist config — in-memory state diverges from disk"
-                );
+            if should_persist {
+                match self.persist() {
+                    ConfigPersistCommitOutcome::PublishedDurable => {}
+                    ConfigPersistCommitOutcome::NotPublished(error) => error!(
+                        path = %self.config_path.display(),
+                        error = %error,
+                        "config was not published — in-memory state diverges from disk"
+                    ),
+                    ConfigPersistCommitOutcome::PublicationAmbiguous(error) => error!(
+                        path = %self.config_path.display(),
+                        error = %error,
+                        "config is visible but crash durability is unproved"
+                    ),
+                }
             }
         }
     }
@@ -189,21 +202,36 @@ impl ConfigPersister {
     }
 
     /// Publish the staged candidate and adopt it as the persister snapshot.
-    fn commit_staged(&mut self) -> Result<(), String> {
+    fn commit_staged(&mut self) -> ConfigPersistCommitOutcome {
         let Some((staged, config)) = self.staged.take() else {
-            return Err("no staged config write to commit".to_string());
-        };
-        if let Err(error) = staged.commit() {
-            error!(
-                path = %self.config_path.display(),
-                error = %error,
-                "failed to publish the staged config write"
+            return ConfigPersistCommitOutcome::NotPublished(
+                "no staged config write to commit".to_string(),
             );
-            return Err(error.to_string());
+        };
+        match staged.commit() {
+            Ok(()) => {
+                self.current = config;
+                self.record_current_history();
+                ConfigPersistCommitOutcome::PublishedDurable
+            }
+            Err(crate::confirm_journal::AtomicPublishError::NotPublished(error)) => {
+                error!(
+                    path = %self.config_path.display(),
+                    error = %error,
+                    "staged config was not published"
+                );
+                ConfigPersistCommitOutcome::NotPublished(error.to_string())
+            }
+            Err(crate::confirm_journal::AtomicPublishError::PublicationAmbiguous(error)) => {
+                self.current = config;
+                error!(
+                    path = %self.config_path.display(),
+                    error = %error,
+                    "staged config is visible but crash durability is unproved"
+                );
+                ConfigPersistCommitOutcome::PublicationAmbiguous(error.to_string())
+            }
         }
-        self.current = config;
-        self.record_current_history();
-        Ok(())
     }
 
     fn discard_staged(&mut self) {
@@ -282,19 +310,28 @@ impl ConfigPersister {
         }
     }
 
-    fn persist(&self) -> std::io::Result<()> {
+    fn persist(&self) -> ConfigPersistCommitOutcome {
         // Durable atomic write: temp file → fsync → rename → fsync parent dir.
         // Reuses the commit-confirm journal's proven primitive so a crash in the
         // settle window can never leave a torn/zero-length config (LAN-206).
-        crate::confirm_journal::write_atomic(
-            &self.config_path,
-            self.current.normalized_toml().as_bytes(),
-        )?;
         // Every durable config write funnels through this method, so recording
         // here gives the applied-config history exactly one choke point:
         // transaction commits, gRPC CRUD mutations, and boot all land in it.
-        self.record_current_history();
-        Ok(())
+        match crate::confirm_journal::write_atomic(
+            &self.config_path,
+            self.current.normalized_toml().as_bytes(),
+        ) {
+            Ok(()) => {
+                self.record_current_history();
+                ConfigPersistCommitOutcome::PublishedDurable
+            }
+            Err(crate::confirm_journal::AtomicPublishError::NotPublished(error)) => {
+                ConfigPersistCommitOutcome::NotPublished(error.to_string())
+            }
+            Err(crate::confirm_journal::AtomicPublishError::PublicationAmbiguous(error)) => {
+                ConfigPersistCommitOutcome::PublicationAmbiguous(error.to_string())
+            }
+        }
     }
 
     /// Best-effort recording of an applied config: the rollback history entry
@@ -1004,7 +1041,10 @@ log_format = "json"
         ))
         .await
         .unwrap();
-        assert_eq!(ack_rx.await.unwrap(), Ok(()));
+        assert_eq!(
+            ack_rx.await.unwrap(),
+            ConfigPersistCommitOutcome::PublishedDurable
+        );
 
         // A following mutation must build from the accepted replacement,
         // proving the warning-only history failure did not roll it back.

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -12,12 +12,14 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex, mpsc, oneshot, watch};
 
 use rustbgpd_api::health_probe::DaemonGate;
+use rustbgpd_api::peer_types::ConfigPersistCommitOutcome;
 use rustbgpd_api::peer_types::{
     ConfigEvent, ConfigPersistAck, DynamicPeerBounceOutcome, DynamicRangeTarget, PeerKey,
     PeerLifecycleError, PeerManagerCommand, PeerManagerNeighborConfig, ResolvedPeerPolicy,
     RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus, StageConfigSnapshotError,
 };
 use rustbgpd_api::proto;
+use rustbgpd_api::runtime_config_settlement::RuntimeConfigFenceReason;
 use rustbgpd_api::runtime_config_settlement::{
     OwnedRuntimeConfigOperation, RuntimeConfigOperationKind, RuntimeConfigSettlementPhase,
     RuntimeConfigSettlementWatchdog,
@@ -36,7 +38,8 @@ use crate::config::{
     diff_neighbors,
 };
 use crate::fib_table_control::{
-    FibTableControlDeps, read_current_tables, replace_tables, runtime_unavailable_error,
+    FibTableControlDeps, FibTransactionReplaceOutcome, read_current_tables,
+    replace_tables_for_transaction, runtime_unavailable_error,
 };
 use crate::gnmi_set_bridge;
 use crate::peer_manager::InternalCommand;
@@ -133,7 +136,7 @@ struct ConfirmedApplyMode {
 trait OwnedOperationError: From<RuntimeConfigCoordinatorClosed> + Send + 'static {
     fn unavailable(message: &'static str) -> Self;
     fn task_lost(message: &'static str) -> Self;
-    fn is_ambiguous(&self) -> bool;
+    fn fence_reason(&self) -> Option<RuntimeConfigFenceReason>;
 }
 
 impl OwnedOperationError for ConfigTransactionApplyError {
@@ -145,14 +148,20 @@ impl OwnedOperationError for ConfigTransactionApplyError {
         Self::Internal(message.to_string())
     }
 
-    fn is_ambiguous(&self) -> bool {
-        matches!(self, Self::DetectedAmbiguousOutcome(_))
+    fn fence_reason(&self) -> Option<RuntimeConfigFenceReason> {
+        match self {
+            Self::RecoveryRequired { reason, .. } => Some(*reason),
+            _ => None,
+        }
     }
 }
 
 enum OwnedGnmiSetError {
     Clean(GnmiSetError),
-    Ambiguous(String),
+    Fenced {
+        message: String,
+        reason: RuntimeConfigFenceReason,
+    },
 }
 
 impl From<RuntimeConfigCoordinatorClosed> for OwnedGnmiSetError {
@@ -170,8 +179,11 @@ impl OwnedOperationError for OwnedGnmiSetError {
         Self::Clean(GnmiSetError::Internal(message.to_string()))
     }
 
-    fn is_ambiguous(&self) -> bool {
-        matches!(self, Self::Ambiguous(_))
+    fn fence_reason(&self) -> Option<RuntimeConfigFenceReason> {
+        match self {
+            Self::Fenced { reason, .. } => Some(*reason),
+            Self::Clean(_) => None,
+        }
     }
 }
 
@@ -223,11 +235,10 @@ impl ConfigTransactionController {
                 return Err(E::unavailable(shutdown_message));
             }
             let result = body(self, Some(operation.clone())).await;
-            if result
-                .as_ref()
-                .is_err_and(OwnedOperationError::is_ambiguous)
+            if let Err(error) = &result
+                && let Some(reason) = error.fence_reason()
             {
-                let _ = operation.fence_ambiguous_outcome();
+                let _ = operation.fence_recovery(reason);
                 std::future::pending::<()>().await;
             }
             if !operation.try_settle() {
@@ -459,13 +470,7 @@ impl ConfigTransactionController {
                 self.peer_mgr_internal_tx.as_ref(),
             )
             .await
-            .map_err(|failure| {
-                if failure.ambiguous {
-                    ConfigTransactionApplyError::DetectedAmbiguousOutcome(failure.error.to_string())
-                } else {
-                    failure.error
-                }
-            })
+            .map_err(ApplyFailure::into_apply_error)
         } else {
             self.apply_locked(request, None).await
         }
@@ -666,11 +671,8 @@ impl ConfigTransactionController {
             }
             operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
             let result = self.apply_locked(request, confirmed).await;
-            if matches!(
-                result,
-                Err(ConfigTransactionApplyError::DetectedAmbiguousOutcome(_))
-            ) {
-                let _ = operation.fence_ambiguous_outcome();
+            if let Err(ConfigTransactionApplyError::RecoveryRequired { reason, .. }) = &result {
+                let _ = operation.fence_recovery(*reason);
                 std::future::pending::<()>().await;
             }
             if !operation.try_settle() {
@@ -819,14 +821,14 @@ impl ConfigTransactionController {
                             self_.peer_mgr_internal_tx.as_ref(),
                         )
                         .await
-                        .map_err(|failure| {
-                            if failure.ambiguous {
-                                OwnedGnmiSetError::Ambiguous(failure.error.to_string())
-                            } else {
-                                OwnedGnmiSetError::Clean(apply_error_to_gnmi_set_error(
-                                    failure.error,
-                                ))
-                            }
+                        .map_err(|failure| match failure.fence_reason {
+                            Some(reason) => OwnedGnmiSetError::Fenced {
+                                message: failure.error.to_string(),
+                                reason,
+                            },
+                            None => OwnedGnmiSetError::Clean(apply_error_to_gnmi_set_error(
+                                failure.error,
+                            )),
                         })?
                     };
                     gnmi_set_outcome_from_apply_response(response).map_err(OwnedGnmiSetError::Clean)
@@ -836,7 +838,7 @@ impl ConfigTransactionController {
         match result {
             Ok(outcome) => Ok(outcome),
             Err(OwnedGnmiSetError::Clean(error)) => Err(error),
-            Err(OwnedGnmiSetError::Ambiguous(message)) => {
+            Err(OwnedGnmiSetError::Fenced { message, .. }) => {
                 let _ = message;
                 std::future::pending().await
             }
@@ -868,15 +870,7 @@ impl ConfigTransactionController {
                 .await?;
             apply_config_transaction_locked(&self.deps, request, self.peer_mgr_internal_tx.as_ref())
                 .await
-                .map_err(|failure| {
-                    if failure.ambiguous {
-                        ConfigTransactionApplyError::DetectedAmbiguousOutcome(
-                            failure.error.to_string(),
-                        )
-                    } else {
-                        failure.error
-                    }
-                })
+                .map_err(ApplyFailure::into_apply_error)
         }
     }
 
@@ -969,7 +963,10 @@ impl ConfigTransactionController {
                         }
                     );
                     return Err(if error.authority_retained() {
-                        ConfigTransactionApplyError::DetectedAmbiguousOutcome(message)
+                        ConfigTransactionApplyError::RecoveryRequired {
+                            reason: RuntimeConfigFenceReason::PublicationAmbiguous,
+                            message,
+                        }
                     } else {
                         ConfigTransactionApplyError::Internal(message)
                     });
@@ -994,7 +991,7 @@ impl ConfigTransactionController {
         {
             Ok(response) => response,
             Err(failure) => {
-                if failure.ambiguous {
+                if let Some(reason) = failure.fence_reason {
                     // LAN-277: the apply failed somewhere the daemon cannot
                     // prove the candidate left no trace (lost persistence
                     // acknowledgement, failed post-persist finalization, or
@@ -1011,12 +1008,13 @@ impl ConfigTransactionController {
                         error = %failure.error,
                         "confirmed config transaction failed with an ambiguous outcome; retaining the revert journal and blocking config mutations until restart"
                     );
-                    return Err(ConfigTransactionApplyError::DetectedAmbiguousOutcome(
-                        format!(
+                    return Err(ConfigTransactionApplyError::RecoveryRequired {
+                        reason,
+                        message: format!(
                             "{}; the transaction outcome is ambiguous; the commit-confirm revert journal is retained and config mutations are blocked; restart rustbgpd to boot-revert to the pre-transaction config",
                             failure.error
                         ),
-                    ));
+                    });
                 }
                 // Provably nothing committed — a stale journal would only
                 // trigger a harmless same-content boot revert, but clean it
@@ -1105,10 +1103,13 @@ impl ConfigTransactionController {
         let matched = self.matching_pending(&confirm_id).await?;
         let residue_cleanup = if let Some(files) = &matched.v3_files {
             files.remove_locator_authority().map_err(|error| {
-                ConfigTransactionApplyError::DetectedAmbiguousOutcome(format!(
-                    "confirm not recorded: durable v3 locator removal failed ({:?}); the transaction is still pending and will roll back on timeout",
-                    error.kind()
-                ))
+                ConfigTransactionApplyError::RecoveryRequired {
+                    reason: RuntimeConfigFenceReason::PublicationAmbiguous,
+                    message: format!(
+                        "confirm not recorded: durable v3 locator removal failed ({:?}); the transaction is still pending and will roll back on timeout",
+                        error.kind()
+                    ),
+                }
             })?;
             self.claim_v3(files, "confirmed transaction")
         } else {
@@ -1696,13 +1697,7 @@ impl ConfigTransactionController {
             self.peer_mgr_internal_tx.as_ref(),
         )
         .await;
-        let response = result.map_err(|failure| {
-            if failure.ambiguous {
-                ConfigTransactionApplyError::DetectedAmbiguousOutcome(failure.error.to_string())
-            } else {
-                failure.error
-            }
-        })?;
+        let response = result.map_err(ApplyFailure::into_apply_error)?;
         // A rollback whose re-apply plan did not commit leaves the
         // aborted/expired candidate running — that is a rollback failure,
         // not a success, and the caller must record AbortFailed /
@@ -1751,12 +1746,13 @@ impl ConfigTransactionController {
             Err(error) => {
                 let mut state = self.state.lock().await;
                 state.ambiguous_failure_confirm_id = Some(confirm_id.to_string());
-                Err(ConfigTransactionApplyError::DetectedAmbiguousOutcome(
-                    format!(
+                Err(ConfigTransactionApplyError::RecoveryRequired {
+                    reason: RuntimeConfigFenceReason::PublicationAmbiguous,
+                    message: format!(
                         "confirm outcome is ambiguous because durable v3 locator removal could not be proven ({:?}); config mutation admission is being fenced and the daemon will exit for supervised recovery",
                         error.kind()
                     ),
-                ))
+                })
             }
         }
     }
@@ -1777,10 +1773,13 @@ impl ConfigTransactionController {
         let matched = self.matching_pending(confirm_id).await?;
         let residue_cleanup = if let Some(files) = &matched.v3_files {
             files.remove_locator_authority().map_err(|error| {
-                ConfigTransactionApplyError::DetectedAmbiguousOutcome(format!(
-                    "rollback restored the prior config but remains nonterminal because durable v3 locator removal failed ({:?})",
-                    error.kind()
-                ))
+                ConfigTransactionApplyError::RecoveryRequired {
+                    reason: RuntimeConfigFenceReason::PublicationAmbiguous,
+                    message: format!(
+                        "rollback restored the prior config but remains nonterminal because durable v3 locator removal failed ({:?})",
+                        error.kind()
+                    ),
+                }
             })?;
             self.claim_v3(files, "confirmed rollback")
         } else {
@@ -1921,14 +1920,12 @@ impl Drop for V3Reservation {
     }
 }
 
-/// Internal apply-pipeline failure carrying whether the transaction's
-/// completion state is provably clean (LAN-277).
+/// Internal apply-pipeline failure carrying an exact recovery classification.
 ///
-/// `ambiguous == false` means the daemon can prove nothing of the candidate
+/// `fence_reason == None` means the daemon can prove nothing of the candidate
 /// survives: the config file was never replaced and every live mutation was
 /// rolled back, so the pre-transaction revert journal is redundant and may be
-/// removed. `ambiguous == true` marks the windows where that proof does not
-/// exist:
+/// removed. A reason marks a window that must retain ownership:
 ///
 /// - **(a) post-persist finalization failure** — the candidate is already
 ///   durable on disk when a later step (`commit_config_snapshot_stage`) fails;
@@ -1942,23 +1939,37 @@ impl Drop for V3Reservation {
 #[derive(Debug)]
 struct ApplyFailure {
     error: ConfigTransactionApplyError,
-    ambiguous: bool,
+    fence_reason: Option<RuntimeConfigFenceReason>,
 }
 
 impl ApplyFailure {
-    fn ambiguous(error: ConfigTransactionApplyError) -> Self {
+    fn fenced(error: ConfigTransactionApplyError, fence_reason: RuntimeConfigFenceReason) -> Self {
         Self {
             error,
-            ambiguous: true,
+            fence_reason: Some(fence_reason),
+        }
+    }
+
+    fn into_apply_error(self) -> ConfigTransactionApplyError {
+        match self.fence_reason {
+            Some(reason) => ConfigTransactionApplyError::RecoveryRequired {
+                reason,
+                message: self.error.to_string(),
+            },
+            None => self.error,
         }
     }
 }
 
 impl From<ConfigTransactionApplyError> for ApplyFailure {
     fn from(error: ConfigTransactionApplyError) -> Self {
+        let fence_reason = match &error {
+            ConfigTransactionApplyError::RecoveryRequired { reason, .. } => Some(*reason),
+            _ => None,
+        };
         Self {
             error,
-            ambiguous: false,
+            fence_reason,
         }
     }
 }
@@ -2311,10 +2322,11 @@ async fn finish_outbound_prefix_limit_transaction(
     });
     let outcome = crate::reload::finish_outbound_prefix_limits(rib_tx, txn, activate).await;
     match outcome {
-        Err(error) if activate => Err(ApplyFailure::ambiguous(
+        Err(error) if activate => Err(ApplyFailure::fenced(
             ConfigTransactionApplyError::Internal(format!(
                 "persisted configuration was committed but its outbound prefix maxima could not be activated: {error}"
             )),
+            RuntimeConfigFenceReason::KnownDivergence,
         )),
         // A discard cannot fail meaningfully: nothing was applied.
         Ok(()) | Err(_) => Ok(()),
@@ -2461,15 +2473,34 @@ async fn commit_fib_transaction(
     .unwrap_or_default();
     let staged_tables = candidate.fib_tables.clone();
     let previous = stage_preloaded_config_snapshot(peer_mgr_internal_tx, candidate).await?;
-    if let Err(error) = replace_tables(&fib_cmd_tx, staged_tables.clone()).await {
-        return Err(restore_preloaded_snapshot_after_error(
-            peer_mgr_internal_tx,
-            previous,
-            fib_error_to_apply_error(error).into(),
-        )
-        .await);
+    match replace_tables_for_transaction(&fib_cmd_tx, staged_tables.clone()).await {
+        FibTransactionReplaceOutcome::Applied => {}
+        FibTransactionReplaceOutcome::NotAccepted(error)
+        | FibTransactionReplaceOutcome::RejectedNoEffect(error) => {
+            return Err(restore_preloaded_snapshot_after_error(
+                peer_mgr_internal_tx,
+                previous,
+                fib_error_to_apply_error(error).into(),
+            )
+            .await);
+        }
+        FibTransactionReplaceOutcome::KnownDivergence(error) => {
+            return Err(ApplyFailure::fenced(
+                fib_error_to_apply_error(error),
+                RuntimeConfigFenceReason::KnownDivergence,
+            ));
+        }
+        FibTransactionReplaceOutcome::AcknowledgementLost(error) => {
+            return Err(ApplyFailure::fenced(
+                fib_error_to_apply_error(error),
+                RuntimeConfigFenceReason::AcknowledgementLost,
+            ));
+        }
     }
     if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
+        if failure.fence_reason.is_some() {
+            return Err(failure);
+        }
         return Err(rollback_fib_transaction_after_error(
             &fib_cmd_tx,
             peer_mgr_internal_tx,
@@ -2479,9 +2510,7 @@ async fn commit_fib_transaction(
         )
         .await);
     }
-    commit_config_snapshot_stage(&deps.peer_mgr_tx)
-        .await
-        .map_err(ApplyFailure::ambiguous)?;
+    commit_config_snapshot_stage(&deps.peer_mgr_tx).await?;
     Ok(committable_response(
         post_commit_runtime_snapshot_token,
         vec![FIB_SECTION.to_string()],
@@ -2531,11 +2560,13 @@ async fn restore_preloaded_config_snapshot(
                 "peer manager is unavailable during config transaction rollback".to_string(),
             )
         })?;
-    reply_rx.await.map_err(|_| {
-        ConfigTransactionApplyError::Unavailable(
-            "peer manager dropped config transaction snapshot rollback reply".to_string(),
-        )
-    })
+    reply_rx
+        .await
+        .map_err(|_| ConfigTransactionApplyError::RecoveryRequired {
+            reason: RuntimeConfigFenceReason::AcknowledgementLost,
+            message: "peer manager accepted config snapshot rollback but dropped its reply"
+                .to_string(),
+        })
 }
 
 async fn restore_preloaded_snapshot_after_error(
@@ -2543,12 +2574,18 @@ async fn restore_preloaded_snapshot_after_error(
     previous: Box<Config>,
     original: ApplyFailure,
 ) -> ApplyFailure {
+    if original.fence_reason.is_some() {
+        return original;
+    }
     match restore_preloaded_config_snapshot(peer_mgr_internal_tx, previous).await {
         Ok(()) => original,
-        Err(rollback) => ApplyFailure::ambiguous(ConfigTransactionApplyError::Internal(format!(
-            "{}; config snapshot rollback failed: {rollback}",
-            original.error
-        ))),
+        Err(rollback) => ApplyFailure::fenced(
+            ConfigTransactionApplyError::Internal(format!(
+                "{}; config snapshot rollback failed: {rollback}",
+                original.error
+            )),
+            recovery_reason(&rollback),
+        ),
     }
 }
 
@@ -2559,22 +2596,32 @@ async fn rollback_fib_transaction_after_error(
     previous: Box<Config>,
     original: ApplyFailure,
 ) -> ApplyFailure {
-    let runtime_rollback = replace_tables(fib_cmd_tx, previous_tables).await;
-    let snapshot_rollback = restore_preloaded_config_snapshot(peer_mgr_internal_tx, previous).await;
-    match (runtime_rollback, snapshot_rollback) {
-        (Ok(()), Ok(())) => original,
-        (runtime, snapshot) => {
-            ApplyFailure::ambiguous(ConfigTransactionApplyError::Internal(format!(
-                "{}; FIB transaction rollback failed; runtime: {}; snapshot: {}",
-                original.error,
-                runtime
-                    .err()
-                    .map_or_else(|| "ok".to_string(), |error| error.to_string()),
-                snapshot
-                    .err()
-                    .map_or_else(|| "ok".to_string(), |error| error.to_string()),
-            )))
+    if original.fence_reason.is_some() {
+        return original;
+    }
+    match replace_tables_for_transaction(fib_cmd_tx, previous_tables).await {
+        FibTransactionReplaceOutcome::Applied => {
+            match restore_preloaded_config_snapshot(peer_mgr_internal_tx, previous).await {
+                Ok(()) => original,
+                Err(rollback) => ApplyFailure::fenced(
+                    ConfigTransactionApplyError::Internal(format!(
+                        "{}; config snapshot rollback failed: {rollback}",
+                        original.error
+                    )),
+                    recovery_reason(&rollback),
+                ),
+            }
         }
+        FibTransactionReplaceOutcome::AcknowledgementLost(error) => ApplyFailure::fenced(
+            fib_error_to_apply_error(error),
+            RuntimeConfigFenceReason::AcknowledgementLost,
+        ),
+        FibTransactionReplaceOutcome::NotAccepted(error)
+        | FibTransactionReplaceOutcome::RejectedNoEffect(error)
+        | FibTransactionReplaceOutcome::KnownDivergence(error) => ApplyFailure::fenced(
+            fib_error_to_apply_error(error),
+            RuntimeConfigFenceReason::KnownDivergence,
+        ),
     }
 }
 
@@ -2680,13 +2727,14 @@ async fn commit_candidate_snapshot_locked(
     let permit = reserve_persist_permit(config_tx).await?;
     let previous_toml = stage_config_snapshot(peer_mgr_tx, candidate_toml.clone()).await?;
     if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
+        if failure.fence_reason.is_some() {
+            return Err(failure);
+        }
         return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_toml, failure).await);
     }
     // LAN-277 window (a): the candidate is durable on disk from here on — a
     // finalization failure must not be reported as a clean no-commit failure.
-    commit_config_snapshot_stage(peer_mgr_tx)
-        .await
-        .map_err(ApplyFailure::ambiguous)?;
+    commit_config_snapshot_stage(peer_mgr_tx).await?;
     Ok(())
 }
 
@@ -2729,13 +2777,14 @@ async fn commit_dynamic_neighbors_locked(
         return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error.into()).await);
     }
     if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
+        if failure.fence_reason.is_some() {
+            return Err(failure);
+        }
         return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_toml, failure).await);
     }
     // LAN-277 window (a): the candidate is durable on disk from here on — a
     // finalization failure must not be reported as a clean no-commit failure.
-    commit_config_snapshot_stage(peer_mgr_tx)
-        .await
-        .map_err(ApplyFailure::ambiguous)?;
+    commit_config_snapshot_stage(peer_mgr_tx).await?;
     Ok(())
 }
 
@@ -2849,14 +2898,15 @@ async fn commit_static_neighbors_locked(
     }
 
     if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
+        if failure.fence_reason.is_some() {
+            return Err(failure);
+        }
         return Err(
             rollback_static_and_snapshot(peer_mgr_tx, applied, previous_toml, failure).await,
         );
     }
     // LAN-277 window (a): candidate durable on disk from here on.
-    commit_config_snapshot_stage(peer_mgr_tx)
-        .await
-        .map_err(ApplyFailure::ambiguous)?;
+    commit_config_snapshot_stage(peer_mgr_tx).await?;
     Ok(())
 }
 
@@ -2906,14 +2956,15 @@ async fn commit_live_policy_impact_locked(
     };
 
     if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
+        if failure.fence_reason.is_some() {
+            return Err(failure);
+        }
         return Err(
             rollback_live_policy_and_snapshot(peer_mgr_tx, priors, previous_toml, failure).await,
         );
     }
     // LAN-277 window (a): candidate durable on disk from here on.
-    commit_config_snapshot_stage(peer_mgr_tx)
-        .await
-        .map_err(ApplyFailure::ambiguous)?;
+    commit_config_snapshot_stage(peer_mgr_tx).await?;
     Ok(priors.len())
 }
 
@@ -3010,6 +3061,9 @@ async fn commit_peer_session_reshape_locked(
     };
 
     if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
+        if failure.fence_reason.is_some() {
+            return Err(failure);
+        }
         return Err(rollback_peer_reshape_and_snapshot(
             peer_mgr_tx,
             priors,
@@ -3019,9 +3073,7 @@ async fn commit_peer_session_reshape_locked(
         .await);
     }
     // LAN-277 window (a): candidate durable on disk from here on.
-    commit_config_snapshot_stage(peer_mgr_tx)
-        .await
-        .map_err(ApplyFailure::ambiguous)?;
+    commit_config_snapshot_stage(peer_mgr_tx).await?;
 
     let dynamic_bounce =
         send_bounce_dynamic_range_peers(peer_mgr_tx, targets.dynamic_bounce_ranges).await;
@@ -3317,10 +3369,10 @@ async fn send_apply_resolved_policy_snapshot(
         })?;
     reply_rx
         .await
-        .map_err(|_| {
-            ConfigTransactionApplyError::Unavailable(
-                "peer manager dropped resolved-policy reply".to_string(),
-            )
+        .map_err(|_| ConfigTransactionApplyError::RecoveryRequired {
+            reason: RuntimeConfigFenceReason::AcknowledgementLost,
+            message: "peer manager accepted resolved-policy apply but dropped its reply"
+                .to_string(),
         })?
         .map_err(ConfigTransactionApplyError::Internal)
 }
@@ -3341,10 +3393,9 @@ async fn send_apply_peer_reshape_snapshot(
         })?;
     reply_rx
         .await
-        .map_err(|_| {
-            ConfigTransactionApplyError::Unavailable(
-                "peer manager dropped peer-reshape reply".to_string(),
-            )
+        .map_err(|_| ConfigTransactionApplyError::RecoveryRequired {
+            reason: RuntimeConfigFenceReason::AcknowledgementLost,
+            message: "peer manager accepted peer reshape but dropped its reply".to_string(),
         })?
         .map_err(peer_lifecycle_error_to_apply_error)
 }
@@ -3355,6 +3406,9 @@ async fn rollback_live_policy_and_snapshot(
     previous_toml: String,
     original: ApplyFailure,
 ) -> ApplyFailure {
+    if original.fence_reason.is_some() {
+        return original;
+    }
     let live_rollback = send_apply_resolved_policy_snapshot(peer_mgr_tx, priors)
         .await
         .map(|_| ());
@@ -3376,6 +3430,9 @@ async fn rollback_peer_reshape_and_snapshot(
     previous_toml: String,
     original: ApplyFailure,
 ) -> ApplyFailure {
+    if original.fence_reason.is_some() {
+        return original;
+    }
     let live_rollback = send_apply_peer_reshape_snapshot(peer_mgr_tx, priors)
         .await
         .map(|_| ());
@@ -3509,7 +3566,7 @@ async fn stage_config_snapshot(
         .await
         .map_err(|_| {
             ConfigTransactionApplyError::Unavailable(
-                "peer manager dropped config snapshot stage reply".to_string(),
+                "peer manager dropped config transaction snapshot stage reply".to_string(),
             )
         })?
         .map_err(stage_config_snapshot_error_to_apply_error)
@@ -3531,10 +3588,10 @@ async fn rollback_config_snapshot(
         })?;
     reply_rx
         .await
-        .map_err(|_| {
-            ConfigTransactionApplyError::Unavailable(
-                "peer manager dropped config snapshot rollback reply".to_string(),
-            )
+        .map_err(|_| ConfigTransactionApplyError::RecoveryRequired {
+            reason: RuntimeConfigFenceReason::AcknowledgementLost,
+            message: "peer manager accepted config snapshot rollback but dropped its reply"
+                .to_string(),
         })?
         .map_err(stage_config_snapshot_error_to_apply_error)
         .map_err(|error| {
@@ -3546,17 +3603,27 @@ async fn rollback_config_snapshot(
 
 async fn commit_config_snapshot_stage(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-) -> Result<(), ConfigTransactionApplyError> {
+) -> Result<(), ApplyFailure> {
     let (reply_tx, reply_rx) = oneshot::channel();
     peer_mgr_tx
         .send(PeerManagerCommand::CommitConfigSnapshotStage { reply: reply_tx })
         .await
         .map_err(|_| {
-            ConfigTransactionApplyError::Unavailable("peer manager is unavailable".to_string())
+            ApplyFailure::fenced(
+                ConfigTransactionApplyError::Unavailable(
+                    "peer manager rejected config snapshot finalization before delivery"
+                        .to_string(),
+                ),
+                RuntimeConfigFenceReason::KnownDivergence,
+            )
         })?;
     reply_rx.await.map_err(|_| {
-        ConfigTransactionApplyError::Unavailable(
-            "peer manager dropped config snapshot commit reply".to_string(),
+        ApplyFailure::fenced(
+            ConfigTransactionApplyError::Unavailable(
+                "peer manager accepted config snapshot finalization but dropped its reply"
+                    .to_string(),
+            ),
+            RuntimeConfigFenceReason::AcknowledgementLost,
         )
     })
 }
@@ -3566,6 +3633,9 @@ async fn rollback_snapshot_after_error(
     previous_toml: String,
     original: ApplyFailure,
 ) -> ApplyFailure {
+    if original.fence_reason.is_some() {
+        return original;
+    }
     match rollback_config_snapshot(peer_mgr_tx, previous_toml).await {
         Ok(()) => original,
         Err(rollback_error) => {
@@ -3602,19 +3672,26 @@ async fn persist_candidate_config(
         ack: Some(ConfigPersistAck::immediate(ack_tx)),
     });
     match ack_rx.await {
-        Ok(Ok(())) => Ok(()),
+        Ok(ConfigPersistCommitOutcome::PublishedDurable) => Ok(()),
         // The persister reported failure: the atomic write did not replace the
         // config file, so disk provably still holds the previous config.
-        Ok(Err(error)) => {
-            Err(ConfigTransactionApplyError::FailedPrecondition(error.to_string()).into())
+        Ok(ConfigPersistCommitOutcome::NotPublished(error)) => {
+            Err(ConfigTransactionApplyError::FailedPrecondition(error).into())
         }
+        Ok(ConfigPersistCommitOutcome::PublicationAmbiguous(error)) => Err(ApplyFailure::fenced(
+            ConfigTransactionApplyError::Internal(format!(
+                "config candidate is visible but publication durability is unproved: {error}"
+            )),
+            RuntimeConfigFenceReason::PublicationAmbiguous,
+        )),
         // LAN-277 window (b): the acknowledgement was lost. The persister may
         // or may not have written the candidate — the on-disk outcome is
         // unknowable from here.
-        Err(_) => Err(ApplyFailure::ambiguous(
+        Err(_) => Err(ApplyFailure::fenced(
             ConfigTransactionApplyError::Internal(
                 "config bridge dropped transaction persistence acknowledgement".to_string(),
             ),
+            RuntimeConfigFenceReason::AcknowledgementLost,
         )),
     }
 }
@@ -3636,10 +3713,9 @@ async fn add_static_peer(
         })?;
     reply_rx
         .await
-        .map_err(|_| {
-            ConfigTransactionApplyError::Unavailable(
-                "peer manager dropped static-neighbor add reply".to_string(),
-            )
+        .map_err(|_| ConfigTransactionApplyError::RecoveryRequired {
+            reason: RuntimeConfigFenceReason::AcknowledgementLost,
+            message: "peer manager accepted static-neighbor add but dropped its reply".to_string(),
         })?
         .map_err(peer_lifecycle_error_to_apply_error)
 }
@@ -3661,10 +3737,10 @@ async fn delete_static_peer(
         })?;
     reply_rx
         .await
-        .map_err(|_| {
-            ConfigTransactionApplyError::Unavailable(
-                "peer manager dropped static-neighbor delete reply".to_string(),
-            )
+        .map_err(|_| ConfigTransactionApplyError::RecoveryRequired {
+            reason: RuntimeConfigFenceReason::AcknowledgementLost,
+            message: "peer manager accepted static-neighbor delete but dropped its reply"
+                .to_string(),
         })?
         .map_err(peer_lifecycle_error_to_apply_error)
 }
@@ -3685,10 +3761,10 @@ async fn reconfigure_static_peer(
         })?;
     reply_rx
         .await
-        .map_err(|_| {
-            ConfigTransactionApplyError::Unavailable(
-                "peer manager dropped static-neighbor reconfigure reply".to_string(),
-            )
+        .map_err(|_| ConfigTransactionApplyError::RecoveryRequired {
+            reason: RuntimeConfigFenceReason::AcknowledgementLost,
+            message: "peer manager accepted static-neighbor reconfigure but dropped its reply"
+                .to_string(),
         })?
         .map_err(peer_lifecycle_error_to_apply_error)
 }
@@ -3743,6 +3819,9 @@ async fn rollback_static_and_snapshot(
     previous_toml: String,
     original: ApplyFailure,
 ) -> ApplyFailure {
+    if original.fence_reason.is_some() {
+        return original;
+    }
     let static_rollback = rollback_static_ops(peer_mgr_tx, applied).await;
     let snapshot_rollback = rollback_config_snapshot(peer_mgr_tx, previous_toml).await;
     match (static_rollback, snapshot_rollback) {
@@ -3770,6 +3849,10 @@ fn combine_rollback_errors(
         ?snapshot_rollback,
         "config transaction rollback failed"
     );
+    let reason = first_rollback
+        .as_ref()
+        .or(snapshot_rollback.as_ref())
+        .map_or(RuntimeConfigFenceReason::KnownDivergence, recovery_reason);
     let mut message = format!("{original}; rollback failed");
     if let Some(error) = first_rollback {
         let _ = write!(message, "; {first_label}: {error}");
@@ -3777,7 +3860,14 @@ fn combine_rollback_errors(
     if let Some(error) = snapshot_rollback {
         let _ = write!(message, "; snapshot rollback: {error}");
     }
-    ApplyFailure::ambiguous(ConfigTransactionApplyError::Internal(message))
+    ApplyFailure::fenced(ConfigTransactionApplyError::Internal(message), reason)
+}
+
+fn recovery_reason(error: &ConfigTransactionApplyError) -> RuntimeConfigFenceReason {
+    match error {
+        ConfigTransactionApplyError::RecoveryRequired { reason, .. } => *reason,
+        _ => RuntimeConfigFenceReason::KnownDivergence,
+    }
 }
 
 fn committable_response(
@@ -3826,7 +3916,7 @@ fn apply_error_to_gnmi_set_error(error: ConfigTransactionApplyError) -> GnmiSetE
             GnmiSetError::Unavailable(message)
         }
         ConfigTransactionApplyError::Internal(message) => GnmiSetError::Internal(message),
-        ConfigTransactionApplyError::DetectedAmbiguousOutcome(message) => {
+        ConfigTransactionApplyError::RecoveryRequired { message, .. } => {
             GnmiSetError::Internal(message)
         }
     }
@@ -3834,8 +3924,8 @@ fn apply_error_to_gnmi_set_error(error: ConfigTransactionApplyError) -> GnmiSetE
 
 fn apply_error_to_owned_gnmi_set_error(error: ConfigTransactionApplyError) -> OwnedGnmiSetError {
     match error {
-        ConfigTransactionApplyError::DetectedAmbiguousOutcome(message) => {
-            OwnedGnmiSetError::Ambiguous(message)
+        ConfigTransactionApplyError::RecoveryRequired { reason, message } => {
+            OwnedGnmiSetError::Fenced { message, reason }
         }
         error => OwnedGnmiSetError::Clean(apply_error_to_gnmi_set_error(error)),
     }
@@ -3923,8 +4013,11 @@ fn confirm_abort_rollback_error(
             ConfigTransactionApplyError::DeadlineExceeded(message)
         }
         ConfigTransactionApplyError::Internal(_) => ConfigTransactionApplyError::Internal(message),
-        ConfigTransactionApplyError::DetectedAmbiguousOutcome(_) => {
-            ConfigTransactionApplyError::DetectedAmbiguousOutcome(message)
+        ConfigTransactionApplyError::RecoveryRequired { reason, .. } => {
+            ConfigTransactionApplyError::RecoveryRequired {
+                reason: *reason,
+                message,
+            }
         }
     }
 }
@@ -7182,7 +7275,10 @@ families = ["ipv4_unicast"]
             .unwrap_err();
         assert!(matches!(
             error,
-            ConfigTransactionApplyError::DetectedAmbiguousOutcome(ref message)
+            ConfigTransactionApplyError::RecoveryRequired {
+                reason: RuntimeConfigFenceReason::PublicationAmbiguous,
+                ref message,
+            }
                 if message.contains("confirm outcome is ambiguous")
                     && message.contains("daemon will exit for supervised recovery")
         ));
@@ -7485,8 +7581,10 @@ families = ["ipv4_unicast"]
 
         let err = assert_ambiguous_apply_failure_wedges(&controller, &dir, &previous_toml).await;
         assert!(
-            matches!(err, ConfigTransactionApplyError::DetectedAmbiguousOutcome(ref message)
-                if message.contains("snapshot commit") && message.contains("ambiguous")),
+            matches!(err, ConfigTransactionApplyError::RecoveryRequired {
+                reason: RuntimeConfigFenceReason::AcknowledgementLost,
+                ref message,
+            } if message.contains("finalization") && message.contains("dropped its reply")),
             "{err:?}"
         );
         ack_task.abort();
@@ -7526,7 +7624,7 @@ families = ["ipv4_unicast"]
 
         let err = assert_ambiguous_apply_failure_wedges(&controller, &dir, &previous_toml).await;
         assert!(
-            matches!(err, ConfigTransactionApplyError::DetectedAmbiguousOutcome(ref message)
+            matches!(err, ConfigTransactionApplyError::RecoveryRequired { ref message, .. }
                 if message.contains("persistence acknowledgement") && message.contains("ambiguous")),
             "{err:?}"
         );
@@ -7575,7 +7673,7 @@ families = ["ipv4_unicast"]
 
         let err = assert_ambiguous_apply_failure_wedges(&controller, &dir, &previous_toml).await;
         assert!(
-            matches!(err, ConfigTransactionApplyError::DetectedAmbiguousOutcome(ref message)
+            matches!(err, ConfigTransactionApplyError::RecoveryRequired { ref message, .. }
                 if message.contains("rollback failed") && message.contains("ambiguous")),
             "{err:?}"
         );
@@ -10430,9 +10528,9 @@ families = ["ipv4_unicast"]
         )
         .await
         .unwrap_err();
-        assert!(failure.ambiguous);
-        assert_eq!(*fib_state.lock().await, vec![edge]);
-        assert_eq!(*current.lock().await, prior);
+        assert!(failure.fence_reason.is_some());
+        assert_eq!(*fib_state.lock().await, vec![core]);
+        assert_ne!(*current.lock().await, prior);
     }
 
     #[test]

--- a/src/confirm_journal.rs
+++ b/src/confirm_journal.rs
@@ -9,6 +9,33 @@ use std::io::{self, Write as _};
 use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _, PermissionsExt as _};
 use std::path::{Path, PathBuf};
 
+/// Exact publication boundary for an atomic write.
+///
+/// The variants are selected by control flow around `rename(2)`, never by
+/// errno or error text. Before rename the target is provably unchanged; after
+/// rename the candidate is visible but its crash durability is not proved.
+#[derive(Debug)]
+pub(crate) enum AtomicPublishError {
+    NotPublished(io::Error),
+    PublicationAmbiguous(io::Error),
+}
+
+impl std::fmt::Display for AtomicPublishError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotPublished(error) | Self::PublicationAmbiguous(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for AtomicPublishError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::NotPublished(error) | Self::PublicationAmbiguous(error) => Some(error),
+        }
+    }
+}
+
 /// Journal file name under `runtime_state_dir`.
 pub const JOURNAL_FILE_NAME: &str = "commit-confirm-journal.json";
 
@@ -56,8 +83,10 @@ pub fn refuse_retired_journal(path: &Path) -> Result<(), String> {
 /// Failures name the destination path: a bare io error ("No such file or
 /// directory (os error 2)") is useless to an operator who doesn't know
 /// which file the daemon was writing.
-pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
-    stage_atomic(path, bytes)?.commit()
+pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), AtomicPublishError> {
+    stage_atomic(path, bytes)
+        .map_err(AtomicPublishError::NotPublished)?
+        .commit()
 }
 
 /// A durable write that has been fully written and fsynced next to its
@@ -105,32 +134,61 @@ impl StagedWrite {
     }
 
     /// Publish the staged bytes: rename into place and fsync the directory.
-    pub(crate) fn commit(mut self) -> io::Result<()> {
-        self.file.sync_all()?;
+    pub(crate) fn commit(mut self) -> Result<(), AtomicPublishError> {
+        self.file
+            .sync_all()
+            .map_err(AtomicPublishError::NotPublished)?;
         self.publish()
     }
 
     /// Re-run a caller-owned stale-source fence immediately before publish.
-    pub(crate) fn commit_if(mut self, fence: impl FnOnce() -> io::Result<()>) -> io::Result<()> {
-        self.file.sync_all()?;
-        fence().map_err(|error| name_write_failure(&self.target, &error))?;
+    pub(crate) fn commit_if(
+        mut self,
+        fence: impl FnOnce() -> io::Result<()>,
+    ) -> Result<(), AtomicPublishError> {
+        self.file
+            .sync_all()
+            .map_err(AtomicPublishError::NotPublished)?;
+        fence()
+            .map_err(|error| name_write_failure(&self.target, &error))
+            .map_err(AtomicPublishError::NotPublished)?;
         self.publish()
     }
 
-    fn publish(&mut self) -> io::Result<()> {
+    fn publish(&mut self) -> Result<(), AtomicPublishError> {
         self.publish_with(fsync_dir)
     }
 
     fn publish_with(
         &mut self,
         sync_directory: impl FnOnce(&Path) -> io::Result<()>,
-    ) -> io::Result<()> {
-        self.verify_owned_temp()?;
+    ) -> Result<(), AtomicPublishError> {
+        self.verify_owned_temp()
+            .map_err(AtomicPublishError::NotPublished)?;
+        #[cfg(debug_assertions)]
+        if std::env::var("RUSTBGPD_TEST_CONFIG_PUBLISH_FAILURE").as_deref() == Ok("not_published") {
+            return Err(AtomicPublishError::NotPublished(io::Error::other(
+                "injected pre-rename config publication failure",
+            )));
+        }
         fs::rename(&self.tmp, &self.target)
-            .map_err(|error| name_write_failure(&self.target, &error))?;
+            .map_err(|error| name_write_failure(&self.target, &error))
+            .map_err(AtomicPublishError::NotPublished)?;
         self.tmp = PathBuf::new();
-        sync_directory(parent_dir(&self.target)?).map_err(|_| {
-            io::Error::other("directory fsync after rename failed; published state is ambiguous")
+        #[cfg(debug_assertions)]
+        if std::env::var("RUSTBGPD_TEST_CONFIG_PUBLISH_FAILURE").as_deref()
+            == Ok("publication_ambiguous")
+        {
+            return Err(AtomicPublishError::PublicationAmbiguous(io::Error::other(
+                "injected post-rename directory fsync failure",
+            )));
+        }
+        let parent = parent_dir(&self.target).map_err(AtomicPublishError::PublicationAmbiguous)?;
+        sync_directory(parent).map_err(|error| {
+            AtomicPublishError::PublicationAmbiguous(io::Error::new(
+                error.kind(),
+                format!("post-rename directory fsync failed; durability ambiguous: {error}"),
+            ))
         })
     }
 
@@ -138,8 +196,10 @@ impl StagedWrite {
     fn commit_with_dir_fsync(
         mut self,
         sync_directory: impl FnOnce(&Path) -> io::Result<()>,
-    ) -> io::Result<()> {
-        self.file.sync_all()?;
+    ) -> Result<(), AtomicPublishError> {
+        self.file
+            .sync_all()
+            .map_err(AtomicPublishError::NotPublished)?;
         self.publish_with(sync_directory)
     }
 
@@ -446,12 +506,34 @@ mod tests {
                 Err(io::Error::other("injected directory fsync failure"))
             })
             .unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("directory fsync after rename failed")
-        );
+        assert!(matches!(
+            &error,
+            AtomicPublishError::PublicationAmbiguous(_)
+        ));
+        let message = error.to_string();
+        assert!(message.contains("post-rename directory fsync failed"));
+        assert!(message.contains("injected directory fsync failure"));
         assert_eq!(fs::read(&target).unwrap(), b"candidate");
         assert_eq!(fs::read(&successor).unwrap(), b"successor");
+    }
+
+    #[test]
+    fn failures_before_rename_are_typed_not_published_and_preserve_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("config.toml");
+        fs::write(&target, b"accepted").unwrap();
+        let tmp = target.with_extension("toml.tmp");
+        let stage = stage_atomic(&target, b"candidate").unwrap();
+        let owned = dir.path().join("owned-aside");
+        fs::rename(&tmp, &owned).unwrap();
+        fs::write(&tmp, b"substitute").unwrap();
+
+        assert!(matches!(
+            stage.commit(),
+            Err(AtomicPublishError::NotPublished(_))
+        ));
+        assert_eq!(fs::read(&target).unwrap(), b"accepted");
+        assert_eq!(fs::read(&tmp).unwrap(), b"substitute");
+        assert_eq!(fs::read(&owned).unwrap(), b"candidate");
     }
 }

--- a/src/fib_table_control.rs
+++ b/src/fib_table_control.rs
@@ -29,6 +29,7 @@ use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 
 use rustbgpd_api::health_probe::DaemonGate;
+use rustbgpd_api::peer_types::ConfigPersistCommitOutcome;
 use rustbgpd_api::peer_types::{
     CatalogMutationError, ConfigEvent, ConfigPersistAck, ConfigPersistError, FibTableSnapshot,
     PeerManagerCommand,
@@ -37,6 +38,7 @@ use rustbgpd_api::proto;
 use rustbgpd_api::rib_service::{
     FibTableControlError, FibTableControlFn, FibTableControlFuture, FibTableControlRequest,
 };
+use rustbgpd_api::runtime_config_settlement::RuntimeConfigFenceReason;
 use rustbgpd_api::runtime_config_settlement::{
     OwnedRuntimeConfigOperation, OwnedRuntimeConfigOutcome, OwnedRuntimeConfigRequestContext,
     RuntimeConfigOperationKind, RuntimeConfigSettlementPhase, RuntimeConfigSettlementWatchdog,
@@ -271,8 +273,9 @@ async fn mutate(
         let join = tokio::spawn(async move {
             let _guard = coordinator.acquire().await?;
             match body(None).await {
-                OwnedRuntimeConfigOutcome::Clean(result) => result,
-                OwnedRuntimeConfigOutcome::Ambiguous(error) => {
+                OwnedRuntimeConfigOutcome::CleanNoEffect(result) => result,
+                OwnedRuntimeConfigOutcome::PublishedDurable(value) => Ok(value),
+                OwnedRuntimeConfigOutcome::Fenced { error, .. } => {
                     let _ = error;
                     std::future::pending().await
                 }
@@ -290,37 +293,27 @@ async fn mutate(
 }
 
 struct StagedFibPersistence {
-    commit: oneshot::Sender<oneshot::Sender<Result<(), String>>>,
+    commit: oneshot::Sender<oneshot::Sender<ConfigPersistCommitOutcome>>,
+}
+
+enum StagedFibCommitOutcome {
+    Settled(ConfigPersistCommitOutcome),
+    NotDelivered,
+    AcknowledgementLost,
 }
 
 impl StagedFibPersistence {
-    async fn commit(
-        self,
-        candidate: &[FibTableConfig],
-    ) -> OwnedRuntimeConfigOutcome<proto::ListFibTablesResponse, OwnedFibControlError> {
+    async fn commit(self) -> StagedFibCommitOutcome {
         let (reply, acknowledgement) = oneshot::channel();
+        // The caller is applying its runtime change. A dropped commit channel
+        // means that apply failed, or the caller is gone: either way the staged
+        // write must not land.
         if self.commit.send(reply).is_err() {
-            return OwnedRuntimeConfigOutcome::Ambiguous(
-                FibTableControlError::Internal(
-                    "config bridge dropped staged FIB commit handoff".to_string(),
-                )
-                .into(),
-            );
+            return StagedFibCommitOutcome::NotDelivered;
         }
         match acknowledgement.await {
-            Ok(Ok(())) => OwnedRuntimeConfigOutcome::Clean(Ok(response(candidate))),
-            Ok(Err(error)) => OwnedRuntimeConfigOutcome::Ambiguous(
-                FibTableControlError::Internal(format!(
-                    "staged FIB commit outcome is uncertain: {error}"
-                ))
-                .into(),
-            ),
-            Err(_) => OwnedRuntimeConfigOutcome::Ambiguous(
-                FibTableControlError::Internal(
-                    "config bridge dropped staged FIB commit acknowledgement".to_string(),
-                )
-                .into(),
-            ),
+            Ok(outcome) => StagedFibCommitOutcome::Settled(outcome),
+            Err(_) => StagedFibCommitOutcome::AcknowledgementLost,
         }
     }
 }
@@ -339,9 +332,9 @@ async fn stage_fib_persistence(
     let (commit_tx, commit_rx) = oneshot::channel();
     permit.send(ConfigEvent::FibTablesReplaced {
         tables: snapshots,
-        ack: Some(ConfigPersistAck {
+        ack: Some(ConfigPersistAck::Staged {
             staged: staged_tx,
-            commit: Some(commit_rx),
+            commit: commit_rx,
         }),
     });
     match staged_rx.await {
@@ -434,10 +427,55 @@ async fn dispatch_owned_replace(
     }
 }
 
+/// Typed reconciler settlement used by the config-transaction executor.
+pub(crate) enum FibTransactionReplaceOutcome {
+    /// The command was definitely rejected before the actor accepted it.
+    NotAccepted(FibTableControlError),
+    /// The actor proved the requested replacement is active.
+    Applied,
+    /// The actor rejected the replacement and proved it produced no effect.
+    RejectedNoEffect(FibTableControlError),
+    /// The actor reported a failed internal compensation.
+    KnownDivergence(FibTableControlError),
+    /// The actor accepted the replacement but its reply was lost.
+    AcknowledgementLost(FibTableControlError),
+}
+
+/// Replace the runtime table set without collapsing accepted-reply loss into
+/// the same error as a definitely rejected handoff.
+pub(crate) async fn replace_tables_for_transaction(
+    fib_cmd_tx: &mpsc::Sender<FibRuntimeCommand>,
+    tables: Vec<FibTableConfig>,
+) -> FibTransactionReplaceOutcome {
+    match dispatch_owned_replace(fib_cmd_tx, tables).await {
+        AcceptedDispatch::NotAccepted(error) => FibTransactionReplaceOutcome::NotAccepted(error),
+        AcceptedDispatch::AcceptedReplyLost(error) => {
+            FibTransactionReplaceOutcome::AcknowledgementLost(error)
+        }
+        AcceptedDispatch::Replied(OwnedFibReplaceOutcome::Applied) => {
+            FibTransactionReplaceOutcome::Applied
+        }
+        AcceptedDispatch::Replied(OwnedFibReplaceOutcome::RejectedNoEffect(error)) => {
+            FibTransactionReplaceOutcome::RejectedNoEffect(
+                FibTableControlError::FailedPrecondition(error),
+            )
+        }
+        AcceptedDispatch::Replied(OwnedFibReplaceOutcome::CompensationAmbiguous(error)) => {
+            FibTransactionReplaceOutcome::KnownDivergence(FibTableControlError::Internal(error))
+        }
+    }
+}
+
+enum CompensationOutcome {
+    Complete,
+    KnownFailure(FibTableControlError),
+    AcknowledgementLost(FibTableControlError),
+}
+
 async fn restore_pm_snapshot(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     snapshots: Vec<FibTableSnapshot>,
-) -> Result<(), FibTableControlError> {
+) -> CompensationOutcome {
     let (reply_tx, reply_rx) = oneshot::channel();
     match tokio::time::timeout(
         OWNED_FIB_ACTOR_TIMEOUT,
@@ -448,21 +486,48 @@ async fn restore_pm_snapshot(
     )
     .await
     {
-        Err(_) => Err(FibTableControlError::Internal(
+        Err(_) => CompensationOutcome::KnownFailure(FibTableControlError::Internal(
             "peer manager rollback queue timed out before accepting command".to_string(),
         )),
-        Ok(Err(_)) => Err(FibTableControlError::Internal(
+        Ok(Err(_)) => CompensationOutcome::KnownFailure(FibTableControlError::Internal(
             "peer manager unavailable during FIB snapshot rollback".to_string(),
         )),
         Ok(Ok(())) => match tokio::time::timeout(OWNED_FIB_ACTOR_TIMEOUT, reply_rx).await {
-            Ok(Ok(())) => Ok(()),
-            Err(_) => Err(FibTableControlError::Internal(
+            Ok(Ok(())) => CompensationOutcome::Complete,
+            Err(_) => CompensationOutcome::AcknowledgementLost(FibTableControlError::Internal(
                 "peer manager accepted FIB snapshot rollback but reply timed out".to_string(),
             )),
-            Ok(Err(_)) => Err(FibTableControlError::Internal(
+            Ok(Err(_)) => CompensationOutcome::AcknowledgementLost(FibTableControlError::Internal(
                 "peer manager accepted FIB snapshot rollback but dropped its reply".to_string(),
             )),
         },
+    }
+}
+
+fn fenced_fib(
+    error: FibTableControlError,
+    reason: RuntimeConfigFenceReason,
+) -> OwnedRuntimeConfigOutcome<proto::ListFibTablesResponse, OwnedFibControlError> {
+    OwnedRuntimeConfigOutcome::Fenced {
+        error: error.into(),
+        reason,
+    }
+}
+
+fn settle_pm_compensation(
+    outcome: CompensationOutcome,
+    original: FibTableControlError,
+) -> OwnedRuntimeConfigOutcome<proto::ListFibTablesResponse, OwnedFibControlError> {
+    match outcome {
+        CompensationOutcome::Complete => {
+            OwnedRuntimeConfigOutcome::CleanNoEffect(Err(original.into()))
+        }
+        CompensationOutcome::KnownFailure(error) => {
+            fenced_fib(error, RuntimeConfigFenceReason::KnownDivergence)
+        }
+        CompensationOutcome::AcknowledgementLost(error) => {
+            fenced_fib(error, RuntimeConfigFenceReason::AcknowledgementLost)
+        }
     }
 }
 
@@ -473,6 +538,10 @@ fn response(candidate: &[FibTableConfig]) -> proto::ListFibTablesResponse {
     }
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear typed settlement matrix keeps every authority transition visible"
+)]
 async fn owned_fib_mutation_body(
     owned: Option<OwnedRuntimeConfigOperation>,
     config_mutation_gate: Option<ConfigMutationGateFn>,
@@ -485,20 +554,19 @@ async fn owned_fib_mutation_body(
     if let Some(gate) = config_mutation_gate
         && let Err(error) = gate(operation_name).await
     {
-        return OwnedRuntimeConfigOutcome::Clean(Err(FibTableControlError::FailedPrecondition(
-            error,
-        )
-        .into()));
+        return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(
+            FibTableControlError::FailedPrecondition(error).into(),
+        ));
     }
     let previous =
         match read_current_tables(Some(&fib_cmd_tx), FibTableControlError::Internal).await {
             Ok(Some(tables)) => tables,
             Ok(None) => Vec::new(),
-            Err(error) => return OwnedRuntimeConfigOutcome::Clean(Err(error.into())),
+            Err(error) => return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(error.into())),
         };
     let candidate = match apply_mutation(previous.clone(), mutation) {
         Ok(candidate) => candidate,
-        Err(error) => return OwnedRuntimeConfigOutcome::Clean(Err(error.into())),
+        Err(error) => return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(error.into())),
     };
     let previous_snapshots = previous.iter().map(config_to_snapshot).collect::<Vec<_>>();
     let snapshots = candidate.iter().map(config_to_snapshot).collect::<Vec<_>>();
@@ -508,22 +576,21 @@ async fn owned_fib_mutation_body(
     }
     let staged = match stage_fib_persistence(persist_permit, snapshots.clone()).await {
         Ok(staged) => staged,
-        Err(error) => return OwnedRuntimeConfigOutcome::Clean(Err(error.into())),
+        Err(error) => return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(error.into())),
     };
     match stage_pm_candidate(&peer_mgr_tx, snapshots).await {
         AcceptedDispatch::NotAccepted(error) => {
             drop(staged);
-            return OwnedRuntimeConfigOutcome::Clean(Err(error.into()));
+            return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(error.into()));
         }
         AcceptedDispatch::Replied(Err(error)) => {
             drop(staged);
-            return OwnedRuntimeConfigOutcome::Clean(Err(FibTableControlError::InvalidArgument(
-                error,
-            )
-            .into()));
+            return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(
+                FibTableControlError::InvalidArgument(error).into(),
+            ));
         }
         AcceptedDispatch::AcceptedReplyLost(error) => {
-            return OwnedRuntimeConfigOutcome::Ambiguous(error.into());
+            return fenced_fib(error, RuntimeConfigFenceReason::AcknowledgementLost);
         }
         AcceptedDispatch::Replied(Ok(())) => {}
     }
@@ -531,11 +598,12 @@ async fn owned_fib_mutation_body(
     let replacement = dispatch_owned_replace(&fib_cmd_tx, candidate.clone()).await;
     match replacement {
         AcceptedDispatch::AcceptedReplyLost(error) => {
-            return OwnedRuntimeConfigOutcome::Ambiguous(error.into());
+            return fenced_fib(error, RuntimeConfigFenceReason::AcknowledgementLost);
         }
         AcceptedDispatch::Replied(OwnedFibReplaceOutcome::CompensationAmbiguous(error)) => {
-            return OwnedRuntimeConfigOutcome::Ambiguous(
-                FibTableControlError::Internal(error).into(),
+            return fenced_fib(
+                FibTableControlError::Internal(error),
+                RuntimeConfigFenceReason::KnownDivergence,
             );
         }
         AcceptedDispatch::NotAccepted(error) => {
@@ -543,22 +611,20 @@ async fn owned_fib_mutation_body(
                 operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
             }
             drop(staged);
-            return match restore_pm_snapshot(&peer_mgr_tx, previous_snapshots).await {
-                Ok(()) => OwnedRuntimeConfigOutcome::Clean(Err(error.into())),
-                Err(rollback) => OwnedRuntimeConfigOutcome::Ambiguous(rollback.into()),
-            };
+            return settle_pm_compensation(
+                restore_pm_snapshot(&peer_mgr_tx, previous_snapshots).await,
+                error,
+            );
         }
         AcceptedDispatch::Replied(OwnedFibReplaceOutcome::RejectedNoEffect(error)) => {
             if let Some(operation) = &owned {
                 operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
             }
             drop(staged);
-            return match restore_pm_snapshot(&peer_mgr_tx, previous_snapshots).await {
-                Ok(()) => OwnedRuntimeConfigOutcome::Clean(Err(
-                    FibTableControlError::FailedPrecondition(error).into(),
-                )),
-                Err(rollback) => OwnedRuntimeConfigOutcome::Ambiguous(rollback.into()),
-            };
+            return settle_pm_compensation(
+                restore_pm_snapshot(&peer_mgr_tx, previous_snapshots).await,
+                FibTableControlError::FailedPrecondition(error),
+            );
         }
         AcceptedDispatch::Replied(OwnedFibReplaceOutcome::Applied) => {}
     }
@@ -566,7 +632,80 @@ async fn owned_fib_mutation_body(
     if let Some(operation) = &owned {
         operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
     }
-    staged.commit(&candidate).await
+    match staged.commit().await {
+        StagedFibCommitOutcome::Settled(ConfigPersistCommitOutcome::PublishedDurable) => {
+            OwnedRuntimeConfigOutcome::PublishedDurable(response(&candidate))
+        }
+        StagedFibCommitOutcome::Settled(ConfigPersistCommitOutcome::PublicationAmbiguous(
+            error,
+        )) => fenced_fib(
+            FibTableControlError::Internal(format!(
+                "FIB candidate is visible but publication durability is unproved: {error}"
+            )),
+            RuntimeConfigFenceReason::PublicationAmbiguous,
+        ),
+        StagedFibCommitOutcome::AcknowledgementLost => fenced_fib(
+            FibTableControlError::Internal(
+                "config bridge dropped staged FIB commit acknowledgement".to_string(),
+            ),
+            RuntimeConfigFenceReason::AcknowledgementLost,
+        ),
+        StagedFibCommitOutcome::NotDelivered => {
+            compensate_fib_not_published(
+                &fib_cmd_tx,
+                &peer_mgr_tx,
+                previous,
+                previous_snapshots,
+                FibTableControlError::Internal(
+                    "config bridge rejected staged FIB commit before delivery".to_string(),
+                ),
+            )
+            .await
+        }
+        StagedFibCommitOutcome::Settled(ConfigPersistCommitOutcome::NotPublished(error)) => {
+            compensate_fib_not_published(
+                &fib_cmd_tx,
+                &peer_mgr_tx,
+                previous,
+                previous_snapshots,
+                FibTableControlError::FailedPrecondition(format!(
+                    "FIB candidate was not published: {error}"
+                )),
+            )
+            .await
+        }
+    }
+}
+
+async fn compensate_fib_not_published(
+    fib_cmd_tx: &mpsc::Sender<FibRuntimeCommand>,
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    previous: Vec<FibTableConfig>,
+    previous_snapshots: Vec<FibTableSnapshot>,
+    original: FibTableControlError,
+) -> OwnedRuntimeConfigOutcome<proto::ListFibTablesResponse, OwnedFibControlError> {
+    match dispatch_owned_replace(fib_cmd_tx, previous).await {
+        AcceptedDispatch::Replied(OwnedFibReplaceOutcome::Applied) => {}
+        AcceptedDispatch::AcceptedReplyLost(error) => {
+            return fenced_fib(error, RuntimeConfigFenceReason::AcknowledgementLost);
+        }
+        AcceptedDispatch::NotAccepted(error) => {
+            return fenced_fib(error, RuntimeConfigFenceReason::KnownDivergence);
+        }
+        AcceptedDispatch::Replied(
+            OwnedFibReplaceOutcome::RejectedNoEffect(error)
+            | OwnedFibReplaceOutcome::CompensationAmbiguous(error),
+        ) => {
+            return fenced_fib(
+                FibTableControlError::Internal(format!("FIB rollback failed: {error}")),
+                RuntimeConfigFenceReason::KnownDivergence,
+            );
+        }
+    }
+    settle_pm_compensation(
+        restore_pm_snapshot(peer_mgr_tx, previous_snapshots).await,
+        original,
+    )
 }
 
 /// Legacy rollback harness retained for the config-transaction regression
@@ -643,15 +782,25 @@ pub(crate) async fn commit_fib_tables_locked(
             ),
         });
     };
-    if let Err(error) = persist_result {
-        return Err(rollback_applied_tables_after_error(
-            fib_cmd_tx,
-            peer_mgr_tx,
-            previous_tables,
-            previous_snapshots,
-            FibTableControlError::FailedPrecondition(error.to_string()).into(),
-        )
-        .await);
+    match persist_result {
+        ConfigPersistCommitOutcome::PublishedDurable => {}
+        ConfigPersistCommitOutcome::NotPublished(error) => {
+            return Err(rollback_applied_tables_after_error(
+                fib_cmd_tx,
+                peer_mgr_tx,
+                previous_tables,
+                previous_snapshots,
+                FibTableControlError::FailedPrecondition(error).into(),
+            )
+            .await);
+        }
+        ConfigPersistCommitOutcome::PublicationAmbiguous(error) => {
+            return Err(FibCommitFailure {
+                error: FibTableControlError::Internal(format!(
+                    "FIB publication durability is ambiguous: {error}"
+                )),
+            });
+        }
     }
 
     Ok(proto::ListFibTablesResponse {
@@ -856,6 +1005,7 @@ async fn reserve_persist_permit(
         })
 }
 
+#[cfg(test)]
 pub(crate) async fn replace_tables(
     fib_cmd_tx: &mpsc::Sender<FibRuntimeCommand>,
     tables: Vec<FibTableConfig>,
@@ -1274,7 +1424,10 @@ mod tests {
                 if drop_ack {
                     drop(ack);
                 } else {
-                    let _ = ack.staged.send(Err(ConfigPersistError::Rejected(
+                    let ConfigPersistAck::Staged { staged, .. } = ack else {
+                        panic!("expected staged FIB acknowledgement")
+                    };
+                    let _ = staged.send(Err(ConfigPersistError::Rejected(
                         CatalogMutationError::invalid("invalid staged FIB candidate"),
                     )));
                 }
@@ -1324,6 +1477,7 @@ mod tests {
     enum CommitBehavior {
         Applied,
         Rejected,
+        PublicationAmbiguous,
         AckLost,
         HandoffLost,
     }
@@ -1333,6 +1487,8 @@ mod tests {
         Reply(OwnedFibReplaceOutcome),
         ReplyLost,
     }
+
+    type PersistOutcome = ConfigPersistCommitOutcome;
 
     async fn run_owned_body(
         fib_behavior: FibBehavior,
@@ -1352,22 +1508,29 @@ mod tests {
             else {
                 panic!("expected staged FIB event")
             };
-            let ConfigPersistAck { staged, commit } = ack;
+            let ConfigPersistAck::Staged { staged, commit } = ack else {
+                panic!("expected staged FIB persistence")
+            };
             staged.send(Ok(())).unwrap();
-            let commit = commit.unwrap();
             if matches!(commit_behavior, CommitBehavior::HandoffLost) {
                 drop(commit);
                 return;
             }
             let Ok(reply) = commit.await else { return };
             match commit_behavior {
-                CommitBehavior::Applied => reply.send(Ok(())).unwrap(),
-                CommitBehavior::Rejected => reply.send(Err("commit rejected".to_string())).unwrap(),
+                CommitBehavior::Applied => reply.send(PersistOutcome::PublishedDurable).unwrap(),
+                CommitBehavior::Rejected => reply
+                    .send(PersistOutcome::NotPublished("commit rejected".to_string()))
+                    .unwrap(),
+                CommitBehavior::PublicationAmbiguous => reply
+                    .send(PersistOutcome::PublicationAmbiguous(
+                        "directory sync failed".to_string(),
+                    ))
+                    .unwrap(),
                 CommitBehavior::AckLost => drop(reply),
                 CommitBehavior::HandoffLost => unreachable!(),
             }
         });
-
         let rollback_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let rollback_count_actor = rollback_count.clone();
         let (peer_tx, mut peer_rx) = mpsc::channel(2);
@@ -1387,8 +1550,14 @@ mod tests {
                 }
             }
         });
-
         let (fib_tx, mut fib_rx) = mpsc::channel(2);
+        let expect_runtime_rollback = matches!(
+            (&fib_behavior, commit_behavior),
+            (
+                FibBehavior::Reply(OwnedFibReplaceOutcome::Applied),
+                CommitBehavior::Rejected | CommitBehavior::HandoffLost
+            )
+        );
         tokio::spawn(async move {
             let FibRuntimeCommand::GetTables { reply } = fib_rx.recv().await.unwrap() else {
                 panic!("expected GetTables")
@@ -1403,6 +1572,14 @@ mod tests {
                     let _ = reply.send(outcome);
                 }
                 FibBehavior::ReplyLost => drop(reply),
+            }
+            if expect_runtime_rollback {
+                let FibRuntimeCommand::OwnedReplaceTables { reply, .. } =
+                    fib_rx.recv().await.unwrap()
+                else {
+                    panic!("expected owned FIB rollback")
+                };
+                let _ = reply.send(OwnedFibReplaceOutcome::Applied);
             }
         });
 
@@ -1428,23 +1605,55 @@ mod tests {
             true,
         )
         .await;
-        assert!(matches!(outcome, OwnedRuntimeConfigOutcome::Clean(Ok(_))));
+        assert!(matches!(
+            outcome,
+            OwnedRuntimeConfigOutcome::PublishedDurable(_)
+        ));
         assert_eq!(rollback, 0);
 
-        for behavior in [
-            CommitBehavior::Rejected,
-            CommitBehavior::AckLost,
-            CommitBehavior::HandoffLost,
-        ] {
+        for behavior in [CommitBehavior::Rejected, CommitBehavior::HandoffLost] {
             let (outcome, rollback) = run_owned_body(
                 FibBehavior::Reply(OwnedFibReplaceOutcome::Applied),
                 behavior,
                 true,
             )
             .await;
-            assert!(matches!(outcome, OwnedRuntimeConfigOutcome::Ambiguous(_)));
-            assert_eq!(rollback, 0, "commit uncertainty must never compensate");
+            assert!(matches!(
+                outcome,
+                OwnedRuntimeConfigOutcome::CleanNoEffect(Err(_))
+            ));
+            assert_eq!(rollback, 1);
         }
+
+        let (ack_lost, rollback) = run_owned_body(
+            FibBehavior::Reply(OwnedFibReplaceOutcome::Applied),
+            CommitBehavior::AckLost,
+            true,
+        )
+        .await;
+        assert!(matches!(
+            ack_lost,
+            OwnedRuntimeConfigOutcome::Fenced {
+                reason: RuntimeConfigFenceReason::AcknowledgementLost,
+                ..
+            }
+        ));
+        assert_eq!(rollback, 0);
+
+        let (publication_ambiguous, rollback) = run_owned_body(
+            FibBehavior::Reply(OwnedFibReplaceOutcome::Applied),
+            CommitBehavior::PublicationAmbiguous,
+            true,
+        )
+        .await;
+        assert!(matches!(
+            publication_ambiguous,
+            OwnedRuntimeConfigOutcome::Fenced {
+                reason: RuntimeConfigFenceReason::PublicationAmbiguous,
+                ..
+            }
+        ));
+        assert_eq!(rollback, 0);
     }
 
     #[tokio::test]
@@ -1457,7 +1666,10 @@ mod tests {
             true,
         )
         .await;
-        assert!(matches!(clean, OwnedRuntimeConfigOutcome::Clean(Err(_))));
+        assert!(matches!(
+            clean,
+            OwnedRuntimeConfigOutcome::CleanNoEffect(Err(_))
+        ));
         assert_eq!(rollback, 1);
 
         for behavior in [
@@ -1468,7 +1680,10 @@ mod tests {
         ] {
             let (ambiguous, rollback) =
                 run_owned_body(behavior, CommitBehavior::Applied, true).await;
-            assert!(matches!(ambiguous, OwnedRuntimeConfigOutcome::Ambiguous(_)));
+            assert!(matches!(
+                ambiguous,
+                OwnedRuntimeConfigOutcome::Fenced { .. }
+            ));
             assert_eq!(rollback, 0, "accepted ambiguity must never compensate");
         }
 
@@ -1482,7 +1697,10 @@ mod tests {
         .await;
         assert!(matches!(
             rollback_lost,
-            OwnedRuntimeConfigOutcome::Ambiguous(_)
+            OwnedRuntimeConfigOutcome::Fenced {
+                reason: RuntimeConfigFenceReason::AcknowledgementLost,
+                ..
+            }
         ));
         assert_eq!(rollback, 1);
     }
@@ -1538,7 +1756,7 @@ mod tests {
         let disk = body.find("stage_fib_persistence(").unwrap();
         let pm = body.find("stage_pm_candidate(").unwrap();
         let actor = body.find("dispatch_owned_replace(").unwrap();
-        let commit = body.find("staged.commit(&candidate)").unwrap();
+        let commit = body.find("staged.commit().await").unwrap();
         assert!(disk < pm && pm < actor && actor < commit);
     }
 

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -11,6 +11,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Instant;
 
+use rustbgpd_api::peer_types::ConfigPersistCommitOutcome;
 use rustbgpd_api::peer_types::{
     CatalogMutationError, ConfigEvent, ConfigPersistAck, ConfigPersistError, FibTableSnapshot,
     PeerManagerCommand, PeerManagerNeighborConfig,
@@ -853,18 +854,23 @@ async fn set_pm_fib_tables_snapshot(
 /// What the bridge should do with its held snapshot after an acknowledged
 /// config event.
 enum AckedPersistOutcome {
+    /// Publication settled. Authority adoption must precede the reply.
     /// The candidate is on disk; adopt it as the bridge snapshot.
-    Applied,
+    Settled {
+        outcome: ConfigPersistCommitOutcome,
+        reply: oneshot::Sender<ConfigPersistCommitOutcome>,
+    },
+    /// Staging was rejected or the runtime owner discarded its stage.
     /// Nothing was written; keep the previous snapshot.
     Rejected,
     /// The persister is gone; the bridge has nothing left to do.
     PersisterLost,
 }
 
-async fn persister_round_trip(rx: oneshot::Receiver<Result<(), String>>) -> Result<(), String> {
-    rx.await
-        .map_err(|_| "config persister dropped persistence acknowledgement".to_string())
-        .and_then(|result| result)
+async fn persister_round_trip(
+    rx: oneshot::Receiver<ConfigPersistCommitOutcome>,
+) -> Result<ConfigPersistCommitOutcome, ()> {
+    rx.await.map_err(|_| ())
 }
 
 /// Drive one acknowledged config event through the persister.
@@ -880,72 +886,82 @@ async fn persist_acknowledged(
     candidate: Arc<AcceptedConfigSnapshot>,
     ack: ConfigPersistAck,
 ) -> AckedPersistOutcome {
-    let ConfigPersistAck { staged, commit } = ack;
-    let Some(commit) = commit else {
+    let (reply, staged_commit) = match ack {
+        ConfigPersistAck::Immediate(reply) => (reply, false),
+        ConfigPersistAck::Staged { staged, commit } => {
+            let (stage_ack_tx, stage_ack_rx) = oneshot::channel();
+            if mutation_tx
+                .send(ConfigMutation::StageConfigAck(
+                    Arc::clone(&candidate),
+                    stage_ack_tx,
+                ))
+                .await
+                .is_err()
+            {
+                let _ = staged.send(Err(ConfigPersistError::Write(
+                    "config persister unavailable".to_string(),
+                )));
+                return AckedPersistOutcome::PersisterLost;
+            }
+            let stage_result = stage_ack_rx
+                .await
+                .map_err(|_| "config persister dropped staging acknowledgement".to_string())
+                .and_then(|result| result);
+            let stage_ok = stage_result.is_ok();
+            let _ = staged.send(stage_result.map_err(ConfigPersistError::Write));
+            if !stage_ok {
+                return AckedPersistOutcome::Rejected;
+            }
+
+            // The caller is applying its runtime change. A dropped commit channel
+            // means that apply failed, or the caller is gone: either way the staged
+            // write must not land.
+            // A dropped commit channel proves the runtime owner never asked
+            // the persister to publish this stage.
+            let Ok(reply) = commit.await else {
+                let _ = mutation_tx.send(ConfigMutation::DiscardStagedConfig).await;
+                return AckedPersistOutcome::Rejected;
+            };
+            (reply, true)
+        }
+    };
+
+    if !staged_commit {
         // Single-phase: the caller owns its own apply/rollback executor and
         // asked for one durable write with one acknowledgement.
         let (persist_ack_tx, persist_ack_rx) = oneshot::channel();
-        if mutation_tx
+        if let Err(error) = mutation_tx
             .send(ConfigMutation::ReplaceConfigAck(candidate, persist_ack_tx))
             .await
-            .is_err()
         {
-            let _ = staged.send(Err(ConfigPersistError::Write(
-                "config persister unavailable".to_string(),
-            )));
-            return AckedPersistOutcome::PersisterLost;
+            let ConfigMutation::ReplaceConfigAck(_, persist_ack) = error.0 else {
+                unreachable!("rejected mutation must be ReplaceConfigAck")
+            };
+            let _ = persist_ack.send(ConfigPersistCommitOutcome::NotPublished(
+                "persister rejected replacement pre-publication".to_string(),
+            ));
         }
-        let result = persister_round_trip(persist_ack_rx).await;
-        let applied = result.is_ok();
-        let _ = staged.send(result.map_err(ConfigPersistError::Write));
-        return if applied {
-            AckedPersistOutcome::Applied
-        } else {
-            AckedPersistOutcome::Rejected
+        return match persister_round_trip(persist_ack_rx).await {
+            Ok(outcome) => AckedPersistOutcome::Settled { outcome, reply },
+            Err(()) => AckedPersistOutcome::PersisterLost,
         };
-    };
-
-    let (stage_ack_tx, stage_ack_rx) = oneshot::channel();
-    if mutation_tx
-        .send(ConfigMutation::StageConfigAck(candidate, stage_ack_tx))
-        .await
-        .is_err()
-    {
-        let _ = staged.send(Err(ConfigPersistError::Write(
-            "config persister unavailable".to_string(),
-        )));
-        return AckedPersistOutcome::PersisterLost;
-    }
-    let stage_result = persister_round_trip(stage_ack_rx).await;
-    let stage_ok = stage_result.is_ok();
-    let _ = staged.send(stage_result.map_err(ConfigPersistError::Write));
-    if !stage_ok {
-        return AckedPersistOutcome::Rejected;
     }
 
-    // The caller is applying its runtime change. A dropped commit channel
-    // means that apply failed, or the caller is gone: either way the staged
-    // write must not land.
-    let Ok(commit_reply) = commit.await else {
-        let _ = mutation_tx.send(ConfigMutation::DiscardStagedConfig).await;
-        return AckedPersistOutcome::Rejected;
-    };
     let (commit_ack_tx, commit_ack_rx) = oneshot::channel();
-    if mutation_tx
+    if let Err(error) = mutation_tx
         .send(ConfigMutation::CommitStagedConfig(commit_ack_tx))
         .await
-        .is_err()
     {
-        let _ = commit_reply.send(Err("config persister unavailable".to_string()));
-        return AckedPersistOutcome::PersisterLost;
+        let ConfigMutation::CommitStagedConfig(commit_ack) = error.0 else {
+            unreachable!("rejected mutation must be CommitStagedConfig")
+        };
+        let _ = commit_ack.send(ConfigPersistCommitOutcome::NotPublished(
+            "persister rejected staged commit pre-publication".to_string(),
+        ));
     }
-    let result = persister_round_trip(commit_ack_rx).await;
-    let applied = result.is_ok();
-    let _ = commit_reply.send(result);
-    if applied {
-        AckedPersistOutcome::Applied
-    } else {
-        AckedPersistOutcome::Rejected
+    match persister_round_trip(commit_ack_rx).await {
+        Ok(outcome) => AckedPersistOutcome::Settled { outcome, reply },
+        Err(()) => AckedPersistOutcome::PersisterLost,
     }
 }
 
@@ -981,6 +997,10 @@ pub(crate) struct AcceptedBridgeReplacement {
     adopted: oneshot::Sender<()>,
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "single serialized bridge loop makes authority adoption ordering explicit"
+)]
 pub(crate) async fn run_config_bridge_accepted(
     mut event_rx: mpsc::Receiver<rustbgpd_api::peer_types::ConfigEvent>,
     mut bridge_replace_rx: mpsc::UnboundedReceiver<AcceptedBridgeReplacement>,
@@ -1055,17 +1075,38 @@ pub(crate) async fn run_config_bridge_accepted(
                             Err(error) => {
                             error!(error = %error, "rejected config event before persistence");
                             if let Some(ack) = event_ack {
-                                let _ = ack.staged.send(Err(ConfigPersistError::Rejected(error)));
+                                match ack {
+                                    ConfigPersistAck::Staged { staged, .. } => {
+                                        let _ = staged.send(Err(ConfigPersistError::Rejected(error)));
+                                    }
+                                    ConfigPersistAck::Immediate(reply) => {
+                                        let _ = reply.send(ConfigPersistCommitOutcome::NotPublished(
+                                            error.to_string(),
+                                        ));
+                                    }
+                                }
                             }
                             continue;
                             }
                         };
                         if let Some(ack) = event_ack {
                             match persist_acknowledged(&mutation_tx, Arc::clone(&candidate), ack).await {
-                                AckedPersistOutcome::Applied => {
-                                    current = candidate;
-                                    accepted_tx.send_replace(Arc::clone(&current));
+                                AckedPersistOutcome::Settled { outcome, reply } => {
+                                    // The candidate is on disk; adopt it as the bridge snapshot.
+                                    if matches!(
+                                        outcome,
+                                        ConfigPersistCommitOutcome::PublishedDurable
+                                            | ConfigPersistCommitOutcome::PublicationAmbiguous(_)
+                                    ) {
+                                        current = candidate;
+                                        accepted_tx.send_replace(Arc::clone(&current));
+                                    }
+                                    // Both bridge and persister authority are
+                                    // updated before the owner can observe the
+                                    // terminal publication result.
+                                    let _ = reply.send(outcome);
                                 }
+                                // Nothing was written; keep the previous snapshot.
                                 AckedPersistOutcome::Rejected => {}
                                 AckedPersistOutcome::PersisterLost => break,
                             }
@@ -2931,6 +2972,18 @@ mod tests {
             .into_temp_path()
             .keep()
             .unwrap()
+    }
+
+    macro_rules! assert_not_published {
+        ($outcome:expr $(,)?) => {
+            assert!(matches!(
+                $outcome,
+                AckedPersistOutcome::Settled {
+                    outcome: ConfigPersistCommitOutcome::NotPublished(_),
+                    ..
+                }
+            ))
+        };
     }
 
     #[test]
@@ -7809,15 +7862,47 @@ peer_group = "secure"
             matches!(ack_rx.try_recv(), Err(TryRecvError::Empty),),
             "bridge must not acknowledge the FIB event before the persister replies"
         );
-        let _ = persist_ack.send(Ok(()));
+        let _ = persist_ack.send(ConfigPersistCommitOutcome::PublishedDurable);
         assert!(
             timeout(Duration::from_secs(1), ack_rx)
                 .await
                 .unwrap()
                 .unwrap()
-                .is_ok(),
+                == ConfigPersistCommitOutcome::PublishedDurable,
             "FIB event ack should reflect the persister result"
         );
+
+        let (closed_tx, closed_rx) = mpsc::channel(1);
+        drop(closed_rx);
+        assert_not_published!(
+            persist_acknowledged(
+                &closed_tx,
+                Arc::clone(&received_event),
+                ConfigPersistAck::immediate(oneshot::channel().0),
+            )
+            .await,
+        );
+
+        let (staged_tx, mut staged_rx) = mpsc::channel(1);
+        let (commit, commit_rx) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            persist_acknowledged(
+                &staged_tx,
+                received_event,
+                ConfigPersistAck::Staged {
+                    staged: oneshot::channel().0,
+                    commit: commit_rx,
+                },
+            )
+            .await
+        });
+        let ConfigMutation::StageConfigAck(_, stage_reply) = staged_rx.recv().await.unwrap() else {
+            panic!("staged persistence must stage first")
+        };
+        stage_reply.send(Ok(())).unwrap();
+        drop(staged_rx);
+        commit.send(oneshot::channel().0).unwrap();
+        assert_not_published!(task.await.unwrap());
 
         drop(replace_tx);
         drop(event_tx);
@@ -7827,6 +7912,10 @@ peer_group = "secure"
             .unwrap();
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one authority-adoption sequence covers durable, not-published, and ambiguous"
+    )]
     #[tokio::test]
     async fn config_bridge_watch_publishes_only_the_successfully_persisted_arc() {
         use rustbgpd_api::peer_types::{ConfigEvent, FibTableSnapshot};
@@ -7871,8 +7960,13 @@ peer_group = "secure"
             panic!("acknowledged event must carry its accepted Arc");
         };
         assert!(Arc::ptr_eq(&accepted_rx.borrow(), &initial));
-        persist_ack.send(Ok(())).unwrap();
-        assert!(ack_rx.await.unwrap().is_ok());
+        persist_ack
+            .send(ConfigPersistCommitOutcome::PublishedDurable)
+            .unwrap();
+        assert_eq!(
+            ack_rx.await.unwrap(),
+            ConfigPersistCommitOutcome::PublishedDurable
+        );
         timeout(Duration::from_secs(1), accepted_rx.changed())
             .await
             .unwrap()
@@ -7891,11 +7985,41 @@ peer_group = "secure"
         };
         assert!(!Arc::ptr_eq(&candidate, &rejected));
         failed_persist_ack
-            .send(Err("injected".to_string()))
+            .send(ConfigPersistCommitOutcome::NotPublished(
+                "injected".to_string(),
+            ))
             .unwrap();
-        assert!(failed_ack_rx.await.unwrap().is_err());
+        assert!(matches!(
+            failed_ack_rx.await.unwrap(),
+            ConfigPersistCommitOutcome::NotPublished(_)
+        ));
         assert!(Arc::ptr_eq(&accepted_rx.borrow(), &candidate));
         assert!(!accepted_rx.has_changed().unwrap());
+
+        let (ambiguous_ack_tx, ambiguous_ack_rx) = oneshot::channel();
+        event_tx
+            .send(event("visible-candidate", ambiguous_ack_tx))
+            .await
+            .unwrap();
+        let ConfigMutation::ReplaceConfigAck(ambiguous, ambiguous_persist_ack) =
+            mutation_rx.recv().await.unwrap()
+        else {
+            panic!("ambiguous event must carry its candidate Arc");
+        };
+        ambiguous_persist_ack
+            .send(ConfigPersistCommitOutcome::PublicationAmbiguous(
+                "directory sync failed".to_string(),
+            ))
+            .unwrap();
+        assert!(matches!(
+            ambiguous_ack_rx.await.unwrap(),
+            ConfigPersistCommitOutcome::PublicationAmbiguous(_)
+        ));
+        timeout(Duration::from_secs(1), accepted_rx.changed())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(Arc::ptr_eq(&accepted_rx.borrow(), &ambiguous));
 
         drop(replace_tx);
         drop(event_tx);
@@ -7957,13 +8081,13 @@ remote_asn = 65002
             matches!(ack_rx.try_recv(), Err(TryRecvError::Empty),),
             "bridge must not acknowledge the config transaction before the persister replies"
         );
-        let _ = persist_ack.send(Ok(()));
+        let _ = persist_ack.send(ConfigPersistCommitOutcome::PublishedDurable);
         assert!(
             timeout(Duration::from_secs(1), ack_rx)
                 .await
                 .unwrap()
                 .unwrap()
-                .is_ok(),
+                == ConfigPersistCommitOutcome::PublishedDurable,
             "config transaction ack should reflect the persister result"
         );
 
@@ -8066,13 +8190,13 @@ remote_asn = 65002
             matches!(ack_rx.try_recv(), Err(TryRecvError::Empty),),
             "bridge must not acknowledge the static-neighbor event before the persister replies"
         );
-        let _ = persist_ack.send(Ok(()));
+        let _ = persist_ack.send(ConfigPersistCommitOutcome::PublishedDurable);
         assert!(
             timeout(Duration::from_secs(1), ack_rx)
                 .await
                 .unwrap()
                 .unwrap()
-                .is_ok(),
+                == ConfigPersistCommitOutcome::PublishedDurable,
             "static-neighbor event ack should reflect the persister result"
         );
 
@@ -8173,16 +8297,16 @@ remote_asn = 65002
                 .iter()
                 .any(|neighbor| neighbor.address == "10.0.0.9")
         );
-        let _ = persist_ack.send(Err("disk full".to_string()));
-        assert_eq!(
+        let _ = persist_ack.send(ConfigPersistCommitOutcome::NotPublished(
+            "disk full".to_string(),
+        ));
+        assert!(matches!(
             timeout(Duration::from_secs(1), ack_rx)
                 .await
                 .unwrap()
-                .unwrap()
-                .unwrap_err()
-                .to_string(),
-            "disk full"
-        );
+                .unwrap(),
+            ConfigPersistCommitOutcome::NotPublished(ref error) if error == "disk full"
+        ));
 
         event_tx
             .send(ConfigEvent::NeighborDeleted {
@@ -8265,13 +8389,13 @@ remote_asn = 65002
             matches!(ack_rx.try_recv(), Err(TryRecvError::Empty),),
             "bridge must not acknowledge the dynamic-neighbor event before the persister replies"
         );
-        let _ = persist_ack.send(Ok(()));
+        let _ = persist_ack.send(ConfigPersistCommitOutcome::PublishedDurable);
         assert!(
             timeout(Duration::from_secs(1), ack_rx)
                 .await
                 .unwrap()
                 .unwrap()
-                .is_ok(),
+                == ConfigPersistCommitOutcome::PublishedDurable,
             "dynamic-neighbor event ack should reflect the persister result"
         );
 
@@ -8325,16 +8449,16 @@ remote_asn = 65002
             panic!("acked event must request acknowledged persist");
         };
         assert_eq!(first_candidate.dynamic_neighbors.len(), 1);
-        let _ = persist_ack.send(Err("disk full".to_string()));
-        assert_eq!(
+        let _ = persist_ack.send(ConfigPersistCommitOutcome::NotPublished(
+            "disk full".to_string(),
+        ));
+        assert!(matches!(
             timeout(Duration::from_secs(1), ack_rx)
                 .await
                 .unwrap()
-                .unwrap()
-                .unwrap_err()
-                .to_string(),
-            "disk full"
-        );
+                .unwrap(),
+            ConfigPersistCommitOutcome::NotPublished(ref error) if error == "disk full"
+        ));
 
         event_tx
             .send(ConfigEvent::DynamicNeighborAdded {

--- a/tests/runtime_config_persistence_failstop.rs
+++ b/tests/runtime_config_persistence_failstop.rs
@@ -1,0 +1,271 @@
+//! Real-daemon proof for typed config-publication failures.
+
+use std::fs::File;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const FIRST_NEIGHBOR: &str = "192.0.2.1";
+const SECOND_NEIGHBOR: &str = "192.0.2.2";
+const FAILSTOP_GRACE_WITH_JITTER: Duration = Duration::from_secs(7);
+
+struct Daemon {
+    child: Child,
+    log_path: PathBuf,
+}
+
+impl Daemon {
+    fn spawn(config: &Path, log_path: PathBuf, fault: Option<&str>) -> Self {
+        let stderr = File::create(&log_path).expect("create daemon log");
+        let stdout = stderr.try_clone().expect("clone daemon log handle");
+        let mut command = Command::new(env!("CARGO_BIN_EXE_rustbgpd"));
+        command
+            .arg(config)
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr));
+        if let Some(fault) = fault {
+            command.env("RUSTBGPD_TEST_CONFIG_PUBLISH_FAILURE", fault);
+        }
+        let child = command.spawn().expect("spawn rustbgpd");
+        Self { child, log_path }
+    }
+
+    fn assert_running(&mut self) {
+        if let Some(status) = self.child.try_wait().expect("query daemon status") {
+            panic!("rustbgpd exited early with {status}\nlog:\n{}", self.log());
+        }
+    }
+
+    fn wait_for_exit(&mut self, timeout: Duration) -> ExitStatus {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(status) = self.child.try_wait().expect("query daemon status") {
+                return status;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "daemon did not exit\n{}",
+                self.log()
+            );
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    fn log(&self) -> String {
+        std::fs::read_to_string(&self.log_path).unwrap_or_default()
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+fn rbgp_command(grpc_addr: &str, args: &[&str]) -> Command {
+    let mut command = if let Ok(path) = std::env::var("CARGO_BIN_EXE_rbgp") {
+        Command::new(path)
+    } else {
+        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+        let mut command = Command::new(cargo);
+        command.args(["run", "--quiet", "-p", "rustbgpctl", "--bin", "rbgp", "--"]);
+        command
+    };
+    command.arg("--addr").arg(grpc_addr).args(args);
+    command
+}
+
+fn rbgp(grpc_addr: &str, args: &[&str]) -> Output {
+    rbgp_command(grpc_addr, args).output().expect("run rbgp")
+}
+
+fn wait_until_serving(grpc_addr: &str, daemon: &mut Daemon) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if rbgp(grpc_addr, &["--json", "config", "status"])
+            .status
+            .success()
+        {
+            return;
+        }
+        daemon.assert_running();
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!("daemon never served gRPC\n{}", daemon.log());
+}
+
+fn unused_loopback_addr() -> SocketAddr {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("reserve loopback port")
+        .local_addr()
+        .expect("read loopback port")
+}
+
+fn ready_status(addr: SocketAddr) -> Option<u16> {
+    let mut stream = TcpStream::connect_timeout(&addr, Duration::from_millis(100)).ok()?;
+    stream
+        .set_read_timeout(Some(Duration::from_millis(200)))
+        .ok()?;
+    stream
+        .write_all(b"GET /readyz HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .ok()?;
+    let mut response = String::new();
+    stream.read_to_string(&mut response).ok()?;
+    response
+        .lines()
+        .next()?
+        .split_whitespace()
+        .nth(1)?
+        .parse()
+        .ok()
+}
+
+fn wait_until_ready(addr: SocketAddr, daemon: &mut Daemon, expected: u16) {
+    let deadline = Instant::now() + Duration::from_secs(4);
+    while Instant::now() < deadline {
+        if ready_status(addr) == Some(expected) {
+            return;
+        }
+        daemon.assert_running();
+        thread::sleep(Duration::from_millis(20));
+    }
+    panic!(
+        "daemon never reported readiness {expected}\n{}",
+        daemon.log()
+    );
+}
+
+fn wait_output(mut child: Child, timeout: Duration) -> Output {
+    let deadline = Instant::now() + timeout;
+    while child.try_wait().expect("query rbgp status").is_none() {
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            panic!("rbgp did not finish before fail-stop deadline");
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    child.wait_with_output().expect("collect rbgp output")
+}
+
+fn config(runtime_dir: &Path, metrics: SocketAddr) -> String {
+    format!(
+        r#"
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+"rustbgpd://operator/persistence-failstop-test" = "operator"
+
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 0
+runtime_state_dir = "{}"
+
+[global.telemetry]
+log_format = "json"
+prometheus_addr = "{metrics}"
+
+[global.telemetry.grpc_uds]
+path = "{}/grpc.sock"
+principal = "rustbgpd://operator/persistence-failstop-test"
+"#,
+        runtime_dir.display(),
+        runtime_dir.display()
+    )
+}
+
+fn exercise(fault: &str, published: bool) {
+    let dir = tempfile::tempdir().expect("create test dir");
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    let runtime_dir = dir.path().join("runtime");
+    std::fs::create_dir(&runtime_dir).unwrap();
+    std::fs::set_permissions(&runtime_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+    let config_path = dir.path().join("rustbgpd.toml");
+    let metrics = unused_loopback_addr();
+    std::fs::write(&config_path, config(&runtime_dir, metrics)).unwrap();
+    let grpc_addr = format!("unix://{}", runtime_dir.join("grpc.sock").display());
+
+    let mut daemon = Daemon::spawn(
+        &config_path,
+        dir.path().join("fault-daemon.log"),
+        Some(fault),
+    );
+    wait_until_serving(&grpc_addr, &mut daemon);
+    wait_until_ready(metrics, &mut daemon, 200);
+
+    let first = rbgp_command(
+        &grpc_addr,
+        &["neighbor", FIRST_NEIGHBOR, "add", "--remote-asn", "65002"],
+    )
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()
+    .expect("start first mutation");
+    wait_until_ready(metrics, &mut daemon, 503);
+    let recovery_fenced_at = Instant::now();
+
+    let second = rbgp_command(
+        &grpc_addr,
+        &["neighbor", SECOND_NEIGHBOR, "add", "--remote-asn", "65003"],
+    )
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()
+    .expect("start rejected mutation");
+
+    let second = wait_output(second, Duration::from_secs(2));
+    assert!(
+        !second.status.success(),
+        "second mutation unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&second.stdout),
+        String::from_utf8_lossy(&second.stderr)
+    );
+    daemon.assert_running();
+
+    let status = daemon
+        .wait_for_exit(FAILSTOP_GRACE_WITH_JITTER.saturating_sub(recovery_fenced_at.elapsed()));
+    assert_eq!(status.code(), Some(70), "log:\n{}", daemon.log());
+    assert!(
+        recovery_fenced_at.elapsed() <= FAILSTOP_GRACE_WITH_JITTER,
+        "exit 70 exceeded the five-second grace plus test jitter"
+    );
+    assert!(!wait_output(first, Duration::from_secs(2)).status.success());
+
+    let bytes = std::fs::read(&config_path).expect("read persisted config");
+    assert!(!bytes.is_empty(), "published config must never be empty");
+    let parsed: toml::Value = toml::from_slice(&bytes).expect("persisted config must parse");
+    let neighbors = parsed
+        .get("neighbors")
+        .and_then(toml::Value::as_array)
+        .map_or(0, Vec::len);
+    assert_eq!(neighbors, usize::from(published));
+    let text = String::from_utf8(bytes).unwrap();
+    assert_eq!(text.contains(FIRST_NEIGHBOR), published);
+    assert!(!text.contains(SECOND_NEIGHBOR));
+    assert!(!config_path.with_extension("toml.tmp").exists());
+
+    let mut restarted = Daemon::spawn(&config_path, dir.path().join("restart-daemon.log"), None);
+    wait_until_serving(&grpc_addr, &mut restarted);
+    let first_state = rbgp(&grpc_addr, &["--json", "neighbor", FIRST_NEIGHBOR]);
+    assert_eq!(first_state.status.success(), published);
+    let second_state = rbgp(&grpc_addr, &["--json", "neighbor", SECOND_NEIGHBOR]);
+    assert!(!second_state.status.success());
+}
+
+#[test]
+fn pre_rename_failure_fences_and_restart_loads_prior_config() {
+    exercise("not_published", false);
+}
+
+#[test]
+fn post_rename_failure_fences_and_restart_loads_complete_candidate() {
+    exercise("publication_ambiguous", true);
+}


### PR DESCRIPTION
## Summary

- classify config publication failures at the exact rename boundary as not published or publication ambiguous
- carry typed durable, divergence, publication, and acknowledgement outcomes through the persister, bridge, CRUD, transaction, and FIB owners
- adopt the visible candidate after post-rename ambiguity, retain prior authority before rename, and fail stop whenever safe convergence cannot be proved
- add a debug-only real-daemon fault matrix for readiness fencing, mutation rejection, exit 70, and restart authority

## Why

The previous persistence path conservatively collapsed ordinary pre-publication write failures and post-rename durability uncertainty into one ambiguity class. That could unnecessarily terminate the daemon for a determinate no-publication failure, while other paths could still attempt rollback after publication or acknowledgement had become unknowable.

This change makes each authority boundary explicit. Clean no-effect failures may return normally; known runtime/disk divergence, publication ambiguity, and lost acknowledgements retain ownership and use the existing supervised fail-stop recovery contract.

## Validation

- full workspace tests with all features
- strict workspace Clippy across all targets and features
- focused settlement, CRUD, transaction, FIB, journal, persister, bridge, and commit-confirm suites
- real-daemon pre/post-rename fail-stop and restart proof
- v1 stable-surface and release-install contract checkers
- release build proving the debug fault seam is absent

ADR-0127 remains Proposed. SIGHUP ownership, observability, and final cross-roster recovery acceptance remain follow-up closure work for LAN-974.

Linear: LAN-1009
