### PR TITLE
fix(tui): render complete advertised explanations

### DIFF
--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -82,7 +82,6 @@ pub(crate) type RibClient = RibServiceClient<
 ///
 /// Pagination tokens are opaque server state. Keep the caller's bytes intact
 /// and return the server response verbatim; navigation belongs to the view.
-#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
 pub(crate) async fn fetch_tui_best_route_page(
     client: &mut RibClient,
     page_token: String,
@@ -101,7 +100,6 @@ pub(crate) async fn fetch_tui_best_route_page(
 ///
 /// This is deliberately the unicast winner form: no RD, label, or source
 /// identity. Scoped link-local peer rendering follows the CLI path exactly.
-#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
 pub(crate) async fn fetch_tui_explain_advertised(
     client: &mut RibClient,
     peer_address: &str,
@@ -1234,11 +1232,11 @@ fn gate_verdict_label(verdict: i32) -> &'static str {
 }
 
 /// Render an ORR vantage cost for text output (`12` / `unreachable`).
-fn orr_cost_label(cost: Option<u64>) -> String {
+pub(crate) fn orr_cost_label(cost: Option<u64>) -> String {
     cost.map_or_else(|| "unreachable".to_string(), |c| c.to_string())
 }
 
-fn advertised_path_id_line(
+pub(crate) fn advertised_path_id_line(
     explain: &crate::proto::ExplainAdvertisedRouteResponse,
 ) -> Option<String> {
     if explain.source.is_some() {

--- a/crates/cli/src/tui/data.rs
+++ b/crates/cli/src/tui/data.rs
@@ -21,14 +21,12 @@ use crate::proto::{
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
 pub(super) enum RibQueryKind {
     BestPage { page_token: String },
     ExplainAdvertised { prefix: String, prefix_length: u32 },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
 pub(super) struct RibQueryIdentity {
     pub request_id: u64,
     pub view_id: u64,
@@ -37,14 +35,12 @@ pub(super) struct RibQueryIdentity {
 }
 
 #[derive(Debug)]
-#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
 pub(super) enum RibQueryResponse {
     BestPage(ListRoutesResponse),
     ExplainAdvertised(Box<ExplainAdvertisedRouteResponse>),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
 pub(super) struct RibQueryError {
     pub code: tonic::Code,
     pub message: String,
@@ -60,27 +56,23 @@ impl From<tonic::Status> for RibQueryError {
 }
 
 #[derive(Debug)]
-#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
 pub(super) struct RibQueryResult {
     pub identity: RibQueryIdentity,
     pub result: Result<RibQueryResponse, RibQueryError>,
 }
 
-#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
 enum RibQueryCommand {
     Query(RibQueryIdentity),
     Cancel,
     Close,
 }
 
-#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
 pub(super) struct RibQueryHandle {
     command_tx: mpsc::UnboundedSender<RibQueryCommand>,
     next_request_id: Arc<AtomicU64>,
     task: JoinHandle<()>,
 }
 
-#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
 impl RibQueryHandle {
     pub fn query(&self, view_id: u64, peer_address: String, query: RibQueryKind) -> Option<u64> {
         let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
@@ -116,7 +108,6 @@ impl Drop for RibQueryHandle {
 /// The lane owns one client and one RPC future. Receiving another command
 /// drops that future before any replacement starts; results use an unbounded
 /// sender so a stopped UI can never hold shutdown open.
-#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
 pub(super) fn spawn_rib_query_lane(
     connection: Connection,
 ) -> (RibQueryHandle, mpsc::UnboundedReceiver<RibQueryResult>) {
@@ -133,7 +124,6 @@ pub(super) fn spawn_rib_query_lane(
     )
 }
 
-#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
 async fn run_rib_query(
     client: &mut RibClient,
     identity: &RibQueryIdentity,
@@ -159,7 +149,6 @@ async fn run_rib_query(
     }
 }
 
-#[allow(dead_code, reason = "wired into the interactive view by LAN-995 W2")]
 async fn rib_query_loop(
     connection: Connection,
     mut command_rx: mpsc::UnboundedReceiver<RibQueryCommand>,

--- a/crates/cli/src/tui/ui.rs
+++ b/crates/cli/src/tui/ui.rs
@@ -367,7 +367,7 @@ fn draw_peer_detail(f: &mut Frame, app: &mut App, address: &str, theme: &Theme) 
     };
 
     let cfg = neighbor.config.as_ref();
-    let title = format!(" Peer Detail: {address} | Esc back | j/k scroll ");
+    let title = format!(" Peer Detail: {address} | r Best RIB | Esc back | j/k scroll ");
 
     let block = Block::default()
         .title(title)
@@ -769,17 +769,59 @@ fn explain_lines(
         Line::from(format!("Peer: {}", normalized.peer_address)),
         Line::from(format!("Prefix: {}", normalized.prefix)),
     ];
+    if !normalized.rd.is_empty() {
+        lines.push(Line::from(format!("RD: {}", normalized.rd)));
+    }
+    if let Some(source) = normalized.source.as_ref() {
+        lines.push(Line::from(format!(
+            "Source path: {} inbound path ID {}",
+            source.peer_address, source.path_id
+        )));
+    }
     if !normalized.route_peer_address.is_empty() {
         lines.push(Line::from(format!(
             "Route peer: {}",
             normalized.route_peer_address
         )));
     }
+    if !normalized.route_type.is_empty() {
+        lines.push(Line::from(format!("Route type: {}", normalized.route_type)));
+    }
     if !normalized.next_hop.is_empty() {
         lines.push(Line::from(format!("Next hop: {}", normalized.next_hop)));
     }
+    if let Some(path_id) = crate::commands::rib::advertised_path_id_line(explain) {
+        lines.push(Line::from(path_id));
+    }
     if let Some(group) = normalized.update_group_id {
         lines.push(Line::from(format!("Update group: {group}")));
+    }
+    if !normalized.orr_vantage.is_empty() {
+        lines.push(Line::from(format!(
+            "ORR vantage: {}",
+            normalized.orr_vantage
+        )));
+    }
+    if !normalized.orr_candidates.is_empty() {
+        lines.push(Line::styled(
+            "ORR candidates (per-vantage best first)",
+            Style::default()
+                .fg(theme.header_fg)
+                .add_modifier(Modifier::BOLD),
+        ));
+        lines.extend(normalized.orr_candidates.iter().map(|candidate| {
+            Line::from(format!(
+                "  {} next-hop {} cost={}{}",
+                candidate.peer_address,
+                candidate.next_hop,
+                crate::commands::rib::orr_cost_label(candidate.cost),
+                if candidate.selected {
+                    " (selected)"
+                } else {
+                    ""
+                }
+            ))
+        }));
     }
     lines.push(Line::from(format!(
         "Adj-RIB-Out sync: {}",
@@ -1257,6 +1299,7 @@ mod tests {
         rich.on_data(snapshot(vec![safety_neighbor()], Freshness::Fresh));
         rich.view = View::PeerDetail("192.0.2.2".into());
         let rendered = rendered_detail(&mut rich, 130, 50);
+        assert!(rendered.contains("r Best RIB"));
 
         for (label, expected) in [
             ("Configured Hold Time:", "90s"),
@@ -1573,6 +1616,30 @@ mod tests {
                 prefix_length: 24,
                 next_hop: "192.0.2.1".into(),
                 route_peer_address: "192.0.2.2".into(),
+                route_type: "external".into(),
+                path_id: 42,
+                rd: "65000:100".into(),
+                source: Some(crate::proto::RouteSourceIdentity {
+                    peer_address: "192.0.2.9".into(),
+                    path_id: 7,
+                }),
+                orr_vantage: "10.0.1.1".into(),
+                orr_candidates: vec![
+                    crate::proto::OrrExplainCandidate {
+                        peer_address: "192.0.2.2".into(),
+                        next_hop: "192.0.2.1".into(),
+                        cost: Some(10),
+                        selected: true,
+                        ..Default::default()
+                    },
+                    crate::proto::OrrExplainCandidate {
+                        peer_address: "192.0.2.3".into(),
+                        next_hop: "192.0.2.254".into(),
+                        cost: None,
+                        selected: false,
+                        ..Default::default()
+                    },
+                ],
                 update_group_id: Some(7),
                 already_advertised: true,
                 reasons: vec![crate::proto::ExplainReason {
@@ -1597,14 +1664,21 @@ mod tests {
                     as_path_prepend_count: Some(2),
                     ..Default::default()
                 }),
-                ..Default::default()
             },
         )));
-        let rendered = rendered_app(&mut app, 160, 24);
+        let rendered = rendered_app(&mut app, 160, 40);
         for text in [
             "Decision: Deny",
+            "RD: 65000:100",
+            "Source path: 192.0.2.9 inbound path ID 7",
             "Route peer: 192.0.2.2",
+            "Route type: external",
+            "Outbound path ID: 42",
             "Update group: 7",
+            "ORR vantage: 10.0.1.1",
+            "ORR candidates (per-vantage best first)",
+            "192.0.2.2 next-hop 192.0.2.1 cost=10 (selected)",
+            "192.0.2.3 next-hop 192.0.2.254 cost=unreachable",
             "already advertised",
             "Reasons",
             "policy_denied",


### PR DESCRIPTION
## Summary

- render all advertised-explain metadata already normalized by the CLI, including ORR vantage/candidates and route/source/path identity
- expose the existing `r Best RIB` action in the peer-detail title
- remove 13 stale LAN-995 W2 dead-code allowances from fully wired code

This is a rendering and discoverability correction. It does not change query state, RPC requests, protobuf/API behavior, authentication, polling, or the TUI's supported route-family scope.

## Verification

- TUI tests: 55/55
- advertised explain command tests: 5/5
- full `rustbgpctl` package tests
- strict CLI and workspace all-target Clippy
- v1 stable-surface and release-install checks
- exact stale-allow inventory: zero

Exact scope: 3 files, +79/-18.
