### PR TITLE
Fix SIGHUP runtime settlement ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,10 +123,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Persisted runtime-config owners now fail stop with exit 70 five seconds after
   settlement ambiguity is detected, or when an owner remains unsettled for the
   fixed 30-minute budget plus that grace. Transaction/Apply, Neighbor4, FIB2,
-  PeerGroup4, and Policy12 are wired; SIGHUP, observability, and final recovery
-  proofs remain before LAN-974 is complete. The shipped systemd unit keeps exit
-  70 restartable, caps recovery at five starts per ten minutes, and gives
-  explicit stops 32 minutes to settle.
+  PeerGroup4, Policy12, and SIGHUP are wired; observability and final
+  cross-roster recovery proofs remain before LAN-974 is complete. A SIGHUP now
+  retains one cancellation-shielded owner through peer reconciliation,
+  snapshot/persister adoption, tracing, and dial-out finalization; lost
+  acknowledgement fences instead of inferring success. Shutdown closes and
+  drains mutation admission, then awaits an owned reload before checkpointing
+  or actor teardown. The shipped systemd unit keeps exit 70 restartable, caps
+  recovery at five starts per ten minutes, and gives explicit stops 32 minutes
+  to settle. (LAN-1004)
 - Config transaction apply now bounds its pre-ownership wait for the shared runtime config coordinator at ten minutes. (LAN-974)
 - Ambiguous `rustbgpd` invocations now fail with exit 2 instead of silently
   overwriting a config path or option value, consuming a flag as a value, or

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -226,7 +226,8 @@ impl NeighborService {
                 let _permit = coordinator.acquire().await?;
                 match body(None).await {
                     OwnedRuntimeConfigOutcome::CleanNoEffect(result) => result,
-                    OwnedRuntimeConfigOutcome::PublishedDurable(()) => Ok(()),
+                    OwnedRuntimeConfigOutcome::PublishedDurable(())
+                    | OwnedRuntimeConfigOutcome::AcknowledgedAuthority(()) => Ok(()),
                     OwnedRuntimeConfigOutcome::Fenced { error, .. } => {
                         let _ = error;
                         std::future::pending().await

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -382,7 +382,8 @@ impl PeerGroupService {
                 let _permit = coordinator.acquire().await?;
                 match body(None).await {
                     OwnedRuntimeConfigOutcome::CleanNoEffect(result) => result,
-                    OwnedRuntimeConfigOutcome::PublishedDurable(()) => Ok(()),
+                    OwnedRuntimeConfigOutcome::PublishedDurable(())
+                    | OwnedRuntimeConfigOutcome::AcknowledgedAuthority(()) => Ok(()),
                     OwnedRuntimeConfigOutcome::Fenced { error, .. } => {
                         let _ = error;
                         std::future::pending().await

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -82,19 +82,29 @@ pub struct ReconcileFailure {
     pub error: String,
 }
 
-/// Result of a peer reconciliation run.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ReconcileResult {
-    /// List of individual failures (empty means success).
-    pub failures: Vec<ReconcileFailure>,
+/// One peer-table effect acknowledged by the manager during reconciliation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PeerReconcileEffect {
+    Added(PeerKey),
+    Removed(PeerKey),
+    Replaced(PeerKey),
+    RemovedForFailedReplacement(PeerKey),
 }
 
-impl ReconcileResult {
-    /// Returns `true` if all reconciliation operations succeeded.
-    #[must_use]
-    pub fn is_success(&self) -> bool {
-        self.failures.is_empty()
-    }
+/// Whether the receipt is sufficient to reconstruct the live peer table.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PeerReconcileAuthority {
+    #[default]
+    Known,
+    Diverged,
+}
+
+/// Typed reconciliation receipt used by cancellation-safe SIGHUP settlement.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PeerReconcileOutcome {
+    pub effects: Vec<PeerReconcileEffect>,
+    pub failures: Vec<ReconcileFailure>,
+    pub authority: PeerReconcileAuthority,
 }
 
 /// Session lifecycle event type published by `PeerManager`.
@@ -1088,7 +1098,7 @@ pub enum PeerManagerCommand {
         /// Neighbors whose config changed (remove + re-add).
         changed: Vec<PeerManagerNeighborConfig>,
         /// Reply channel with reconciliation results.
-        reply: oneshot::Sender<ReconcileResult>,
+        reply: oneshot::Sender<PeerReconcileOutcome>,
     },
     /// LAN-341: apply a config change whose every edited field is
     /// reload-matrix `live` (hot-applied) to an existing static peer in
@@ -1104,7 +1114,7 @@ pub enum PeerManagerCommand {
         /// fields may differ from the live peer's).
         config: PeerManagerNeighborConfig,
         /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), PeerLifecycleError>>,
+        reply: oneshot::Sender<OwnedHotUpdatePeerOutcome>,
     },
     /// ADR-0073: refresh the peer manager's `[policy.explain]` snapshot
     /// (`enabled` / `cache_size`) ahead of any reload step that
@@ -1128,25 +1138,6 @@ pub enum PeerManagerCommand {
         reject_retention_capacity: usize,
         /// Reply channel acknowledging the snapshot update.
         reply: oneshot::Sender<()>,
-    },
-    /// ADR-0096: replace the compiled `.rpol` policy registry
-    /// (SIGHUP reload of `[policy] rpol_files` or of a referenced
-    /// file's content) and re-resolve every live peer's chains
-    /// through it. Route Refresh fires for peers whose import chain
-    /// materially changed, via the same rollback-capable resolved-policy
-    /// snapshot path as `[policy.definitions]` edits.
-    SyncRpolPolicies {
-        /// New `[policy] rpol_files` list (paths already absolute).
-        rpol_files: Vec<String>,
-        /// New compiled registry.
-        rpol: rustbgpd_policy::rpol::RpolPolicySet,
-        /// Dataset bindings the new registry's `dataset` declarations
-        /// resolve through (LAN-305) — handles reused from the running
-        /// config where declarations are unchanged, so a
-        /// content-equal reload still diffs chains as no-ops.
-        dataset_bindings: rustbgpd_policy::datasets::DatasetBindings,
-        /// Reply channel for success/failure.
-        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// LAN-305: one or more external dataset snapshots swapped content
     /// during a reload. Refresh exactly the peers whose chains
@@ -1477,6 +1468,16 @@ pub enum OwnedNeighborMutationOutcome {
 
 /// One of the catalog mutations protected by settlement ownership.
 pub enum OwnedCatalogMutation {
+    /// ADR-0096: replace the compiled `.rpol` registry and re-resolve every
+    /// live peer through the rollback-capable policy snapshot path.
+    SyncRpolPolicies {
+        /// New `[policy] rpol_files` list (paths already absolute).
+        rpol_files: Vec<String>,
+        /// New compiled registry.
+        rpol: rustbgpd_policy::rpol::RpolPolicySet,
+        /// Live handles used to resolve the registry's dataset declarations.
+        dataset_bindings: rustbgpd_policy::datasets::DatasetBindings,
+    },
     SetPeerGroup {
         name: String,
         definition: Box<PeerGroupDefinition>,
@@ -1540,6 +1541,14 @@ pub enum OwnedCatalogMutationOutcome {
     FullyCompensated(CatalogMutationError),
     /// A forward or compensation effect left final runtime state unknown.
     CompensationAmbiguous(CatalogMutationError),
+}
+
+/// Actor-owned settlement proof for a SIGHUP hot peer update.
+#[derive(Debug)]
+pub enum OwnedHotUpdatePeerOutcome {
+    Success,
+    RejectedNoEffect(PeerLifecycleError),
+    KnownDivergence(PeerLifecycleError),
 }
 
 /// Read-only peer-manager queries admitted between bounded policy-transaction

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -418,7 +418,8 @@ impl PolicyService {
                 let _permit = coordinator.acquire().await?;
                 match body(None).await {
                     OwnedRuntimeConfigOutcome::CleanNoEffect(result) => result,
-                    OwnedRuntimeConfigOutcome::PublishedDurable(()) => Ok(()),
+                    OwnedRuntimeConfigOutcome::PublishedDurable(())
+                    | OwnedRuntimeConfigOutcome::AcknowledgedAuthority(()) => Ok(()),
                     OwnedRuntimeConfigOutcome::Fenced { error, .. } => {
                         let _ = error;
                         std::future::pending().await

--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -20,6 +20,7 @@ pub const AMBIGUOUS_CONFIG_EXIT_STATUS: i32 = 70;
 /// Closed roster of runtime-config operations wired into settlement ownership.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RuntimeConfigOperationKind {
+    Sighup,
     Apply,
     GnmiSet,
     Confirm,
@@ -338,7 +339,8 @@ impl RuntimeConfigSettlementWatchdog {
                     drop(executor_guard);
                     result
                 }
-                OwnedRuntimeConfigOutcome::PublishedDurable(value) => {
+                OwnedRuntimeConfigOutcome::PublishedDurable(value)
+                | OwnedRuntimeConfigOutcome::AcknowledgedAuthority(value) => {
                     if !operation.try_settle() {
                         std::future::pending::<()>().await;
                     }
@@ -378,6 +380,9 @@ pub enum OwnedRuntimeConfigOutcome<T, E> {
     CleanNoEffect(Result<T, E>),
     /// The requested candidate is fully applied and durable.
     PublishedDurable(T),
+    /// A non-publication operation whose authority was acknowledged by every
+    /// runtime consumer.
+    AcknowledgedAuthority(T),
     /// An accepted effect whose final state cannot be proved.
     /// Ownership must be retained until supervised recovery.
     Fenced {
@@ -858,14 +863,14 @@ mod tests {
             async move {
                 watchdog
                     .execute_owned(
-                        RuntimeConfigOperationKind::FibSet,
+                        RuntimeConfigOperationKind::Sighup,
                         coordinator,
                         gate,
                         context.response_attached(),
                         move |operation| async move {
                             let _ = operation_tx.send(operation);
                             let _ = release_rx.await;
-                            OwnedRuntimeConfigOutcome::<(), tonic::Status>::PublishedDurable(())
+                            OwnedRuntimeConfigOutcome::<(), tonic::Status>::AcknowledgedAuthority(())
                         },
                     )
                     .await

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use futures::StreamExt as FuturesStreamExt;
 use futures::{Future, Stream};
 use tokio::net::{TcpListener, UnixListener};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc, oneshot, watch};
+use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore, mpsc, oneshot, watch};
 use tokio::task::JoinSet;
 use tokio_rustls::TlsAcceptor;
 use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
@@ -68,8 +68,14 @@ const MAX_CONCURRENT_GRPC_TLS_HANDSHAKES: usize = 64;
 const GRPC_TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Closeable, one-permit serializer for persisted runtime-config mutations.
+#[derive(Debug)]
+struct RuntimeConfigCoordinatorInner {
+    semaphore: Arc<Semaphore>,
+    drained: Notify,
+}
+
 #[derive(Clone, Debug)]
-pub struct RuntimeConfigCoordinator(Arc<Semaphore>);
+pub struct RuntimeConfigCoordinator(Arc<RuntimeConfigCoordinatorInner>);
 
 impl RuntimeConfigCoordinator {
     /// Create an open coordinator.
@@ -79,7 +85,10 @@ impl RuntimeConfigCoordinator {
         reason = "Default is intentionally absent so coordinator creation stays explicit"
     )]
     pub fn new() -> Self {
-        Self(Arc::new(Semaphore::new(1)))
+        Self(Arc::new(RuntimeConfigCoordinatorInner {
+            semaphore: Arc::new(Semaphore::new(1)),
+            drained: Notify::new(),
+        }))
     }
 
     /// Wait for exclusive ownership.
@@ -91,22 +100,37 @@ impl RuntimeConfigCoordinator {
         &self,
     ) -> Result<RuntimeConfigCoordinatorPermit, RuntimeConfigCoordinatorClosed> {
         self.0
+            .semaphore
             .clone()
             .acquire_owned()
             .await
-            .map(RuntimeConfigCoordinatorPermit)
+            .map(|permit| RuntimeConfigCoordinatorPermit {
+                permit: Some(permit),
+                coordinator: self.clone(),
+            })
             .map_err(|_| RuntimeConfigCoordinatorClosed)
     }
 
     /// Permanently reject queued and future acquisitions.
     pub fn close(&self) {
-        self.0.close();
+        self.0.semaphore.close();
     }
 
     /// Whether the coordinator has been permanently closed.
     #[must_use]
     pub fn is_closed(&self) -> bool {
-        self.0.is_closed()
+        self.0.semaphore.is_closed()
+    }
+
+    /// Wait until the physical owner has released the permit.
+    pub async fn wait_until_drained(&self) {
+        loop {
+            let notified = self.0.drained.notified();
+            if self.0.semaphore.available_permits() == 1 {
+                return;
+            }
+            notified.await;
+        }
     }
 }
 
@@ -131,7 +155,17 @@ impl From<RuntimeConfigCoordinatorClosed> for Status {
 /// Opaque exclusive runtime-config ownership, released on drop.
 #[must_use = "dropping the runtime-config permit immediately releases ownership"]
 #[derive(Debug)]
-pub struct RuntimeConfigCoordinatorPermit(#[allow(dead_code)] OwnedSemaphorePermit);
+pub struct RuntimeConfigCoordinatorPermit {
+    permit: Option<OwnedSemaphorePermit>,
+    coordinator: RuntimeConfigCoordinator,
+}
+
+impl Drop for RuntimeConfigCoordinatorPermit {
+    fn drop(&mut self) {
+        drop(self.permit.take());
+        self.coordinator.0.drained.notify_waiters();
+    }
+}
 
 fn bounded_handshakes<S, F, T, E>(incoming: S) -> impl Stream<Item = Result<T, E>>
 where
@@ -2222,6 +2256,23 @@ mod tests {
         // Closure does not revoke the already-issued opaque owner, and
         // releasing that owner cannot reopen the coordinator.
         drop(owner);
+        assert!(coordinator.acquire().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn runtime_config_coordinator_close_drains_physical_owner() {
+        let coordinator = RuntimeConfigCoordinator::new();
+        let owner = coordinator.acquire().await.expect("initial owner");
+        coordinator.close();
+        let drain = tokio::spawn({
+            let coordinator = coordinator.clone();
+            async move { coordinator.wait_until_drained().await }
+        });
+        tokio::task::yield_now().await;
+        assert!(!drain.is_finished());
+        drop(owner);
+        drain.await.expect("drain waiter");
+        coordinator.wait_until_drained().await;
         assert!(coordinator.acquire().await.is_err());
     }
 

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -291,7 +291,47 @@ pub struct TcpAoListenerHandle {
     status_rx: watch::Receiver<TcpAoRotationStatus>,
 }
 
+/// Typed delivery boundary for SIGHUP listener mutations.
+#[derive(Debug)]
+pub enum ReloadDispatch<T, E> {
+    /// The actor definitely did not accept the command.
+    NotAccepted(E),
+    /// The actor returned an authoritative reply.
+    Replied(T),
+    /// The actor accepted the command but its reply was lost or late.
+    AcknowledgementLost,
+}
+
 impl TcpAoListenerHandle {
+    async fn dispatch<T>(
+        &self,
+        build: impl FnOnce(oneshot::Sender<std::io::Result<T>>) -> TcpAoListenerCommand,
+        operation: &'static str,
+    ) -> ReloadDispatch<std::io::Result<T>, std::io::Error> {
+        let deadline = tokio::time::Instant::now() + TCP_AO_ROTATION_CONTROL_TIMEOUT;
+        let permit = match tokio::time::timeout_at(deadline, self.tx.reserve()).await {
+            Ok(Ok(permit)) => permit,
+            Ok(Err(_)) => {
+                return ReloadDispatch::NotAccepted(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    format!("{operation} listener task exited before accepting command"),
+                ));
+            }
+            Err(_) => {
+                return ReloadDispatch::NotAccepted(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("{operation} timed out before listener accepted command"),
+                ));
+            }
+        };
+        let (reply, response) = oneshot::channel();
+        permit.send(build(reply));
+        match tokio::time::timeout_at(deadline, response).await {
+            Ok(Ok(result)) => ReloadDispatch::Replied(result),
+            Ok(Err(_)) | Err(_) => ReloadDispatch::AcknowledgementLost,
+        }
+    }
+
     /// Validate the complete desired listener inventory against kernel state
     /// without issuing a target-socket `setsockopt`.
     ///
@@ -302,32 +342,12 @@ impl TcpAoListenerHandle {
     pub async fn preflight_add_only(
         &self,
         desired: TcpAoListenerGeneration,
-    ) -> std::io::Result<()> {
-        tokio::time::timeout(TCP_AO_ROTATION_CONTROL_TIMEOUT, async {
-            let (reply, response) = oneshot::channel();
-            self.tx
-                .send(TcpAoListenerCommand::PreflightAddOnly { desired, reply })
-                .await
-                .map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        "TCP-AO listener rotation task exited",
-                    )
-                })?;
-            response.await.map_err(|_| {
-                std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "TCP-AO listener preflight reply dropped",
-                )
-            })?
-        })
+    ) -> ReloadDispatch<std::io::Result<()>, std::io::Error> {
+        self.dispatch(
+            |reply| TcpAoListenerCommand::PreflightAddOnly { desired, reply },
+            "TCP-AO listener preflight",
+        )
         .await
-        .map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                "TCP-AO listener preflight timed out",
-            )
-        })?
     }
 
     /// Apply one immutable successor generation. Current/RNext are untouched;
@@ -341,32 +361,12 @@ impl TcpAoListenerHandle {
     pub async fn apply_add_only(
         &self,
         desired: TcpAoListenerGeneration,
-    ) -> std::io::Result<TcpAoRotationStatus> {
-        tokio::time::timeout(TCP_AO_ROTATION_CONTROL_TIMEOUT, async {
-            let (reply, response) = oneshot::channel();
-            self.tx
-                .send(TcpAoListenerCommand::ApplyAddOnly { desired, reply })
-                .await
-                .map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        "TCP-AO listener rotation task exited",
-                    )
-                })?;
-            response.await.map_err(|_| {
-                std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "TCP-AO listener rotation reply dropped",
-                )
-            })?
-        })
+    ) -> ReloadDispatch<std::io::Result<TcpAoRotationStatus>, std::io::Error> {
+        self.dispatch(
+            |reply| TcpAoListenerCommand::ApplyAddOnly { desired, reply },
+            "TCP-AO listener rotation",
+        )
         .await
-        .map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                "TCP-AO listener rotation control timed out",
-            )
-        })?
     }
 
     /// Validate an already-installed successor-selection generation without
@@ -379,32 +379,12 @@ impl TcpAoListenerHandle {
     pub async fn preflight_selection(
         &self,
         desired: TcpAoListenerGeneration,
-    ) -> std::io::Result<()> {
-        tokio::time::timeout(TCP_AO_ROTATION_CONTROL_TIMEOUT, async {
-            let (reply, response) = oneshot::channel();
-            self.tx
-                .send(TcpAoListenerCommand::PreflightSelection { desired, reply })
-                .await
-                .map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        "TCP-AO listener rotation task exited",
-                    )
-                })?;
-            response.await.map_err(|_| {
-                std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "TCP-AO listener selection preflight reply dropped",
-                )
-            })?
-        })
+    ) -> ReloadDispatch<std::io::Result<()>, std::io::Error> {
+        self.dispatch(
+            |reply| TcpAoListenerCommand::PreflightSelection { desired, reply },
+            "TCP-AO listener selection preflight",
+        )
         .await
-        .map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                "TCP-AO listener selection preflight timed out",
-            )
-        })?
     }
 
     /// Stage successor preference metadata for future accepted children.
@@ -416,32 +396,12 @@ impl TcpAoListenerHandle {
     pub async fn begin_selection(
         &self,
         desired: TcpAoListenerGeneration,
-    ) -> std::io::Result<TcpAoRotationStatus> {
-        tokio::time::timeout(TCP_AO_ROTATION_CONTROL_TIMEOUT, async {
-            let (reply, response) = oneshot::channel();
-            self.tx
-                .send(TcpAoListenerCommand::BeginSelection { desired, reply })
-                .await
-                .map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        "TCP-AO listener rotation task exited",
-                    )
-                })?;
-            response.await.map_err(|_| {
-                std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "TCP-AO listener selection reply dropped",
-                )
-            })?
-        })
+    ) -> ReloadDispatch<std::io::Result<TcpAoRotationStatus>, std::io::Error> {
+        self.dispatch(
+            |reply| TcpAoListenerCommand::BeginSelection { desired, reply },
+            "TCP-AO listener selection",
+        )
         .await
-        .map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                "TCP-AO listener selection control timed out",
-            )
-        })?
     }
 
     /// Commit final declaration metadata after every affected session has
@@ -454,32 +414,12 @@ impl TcpAoListenerHandle {
     pub async fn finalize_selection(
         &self,
         generation: TcpAoRotationGeneration,
-    ) -> std::io::Result<TcpAoRotationStatus> {
-        tokio::time::timeout(TCP_AO_ROTATION_CONTROL_TIMEOUT, async {
-            let (reply, response) = oneshot::channel();
-            self.tx
-                .send(TcpAoListenerCommand::FinalizeSelection { generation, reply })
-                .await
-                .map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        "TCP-AO listener rotation task exited",
-                    )
-                })?;
-            response.await.map_err(|_| {
-                std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "TCP-AO listener metadata commit reply dropped",
-                )
-            })?
-        })
+    ) -> ReloadDispatch<std::io::Result<TcpAoRotationStatus>, std::io::Error> {
+        self.dispatch(
+            |reply| TcpAoListenerCommand::FinalizeSelection { generation, reply },
+            "TCP-AO listener metadata commit",
+        )
         .await
-        .map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                "TCP-AO listener metadata commit timed out",
-            )
-        })?
     }
 
     /// Validate a strict current-to-survivor listener generation without
@@ -490,32 +430,15 @@ impl TcpAoListenerHandle {
     /// Returns an error when owner identity changes, a survivor is reordered
     /// or redefined, a non-deprecated/selected key would be removed, or the
     /// exact kernel inventory cannot be proved before the control deadline.
-    pub async fn preflight_delete(&self, desired: TcpAoListenerGeneration) -> std::io::Result<()> {
-        tokio::time::timeout(TCP_AO_ROTATION_CONTROL_TIMEOUT, async {
-            let (reply, response) = oneshot::channel();
-            self.tx
-                .send(TcpAoListenerCommand::PreflightDelete { desired, reply })
-                .await
-                .map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        "TCP-AO listener rotation task exited",
-                    )
-                })?;
-            response.await.map_err(|_| {
-                std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "TCP-AO listener deletion preflight reply dropped",
-                )
-            })?
-        })
+    pub async fn preflight_delete(
+        &self,
+        desired: TcpAoListenerGeneration,
+    ) -> ReloadDispatch<std::io::Result<()>, std::io::Error> {
+        self.dispatch(
+            |reply| TcpAoListenerCommand::PreflightDelete { desired, reply },
+            "TCP-AO listener deletion preflight",
+        )
         .await
-        .map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                "TCP-AO listener deletion preflight timed out",
-            )
-        })?
     }
 
     /// Remove one immutable set of deprecated, unselected listener MKTs and
@@ -528,32 +451,12 @@ impl TcpAoListenerHandle {
     pub async fn apply_delete(
         &self,
         desired: TcpAoListenerGeneration,
-    ) -> std::io::Result<TcpAoRotationStatus> {
-        tokio::time::timeout(TCP_AO_ROTATION_CONTROL_TIMEOUT, async {
-            let (reply, response) = oneshot::channel();
-            self.tx
-                .send(TcpAoListenerCommand::ApplyDelete { desired, reply })
-                .await
-                .map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        "TCP-AO listener rotation task exited",
-                    )
-                })?;
-            response.await.map_err(|_| {
-                std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "TCP-AO listener deletion reply dropped",
-                )
-            })?
-        })
+    ) -> ReloadDispatch<std::io::Result<TcpAoRotationStatus>, std::io::Error> {
+        self.dispatch(
+            |reply| TcpAoListenerCommand::ApplyDelete { desired, reply },
+            "TCP-AO listener deletion",
+        )
         .await
-        .map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                "TCP-AO listener deletion control timed out",
-            )
-        })?
     }
 
     /// Publish a one-shot observation miss without polling in the actor.
@@ -566,36 +469,16 @@ impl TcpAoListenerHandle {
         &self,
         generation: TcpAoRotationGeneration,
         detail: String,
-    ) -> std::io::Result<()> {
-        tokio::time::timeout(TCP_AO_ROTATION_CONTROL_TIMEOUT, async {
-            let (reply, response) = oneshot::channel();
-            self.tx
-                .send(TcpAoListenerCommand::MarkAwaitingPeer {
-                    generation,
-                    detail,
-                    reply,
-                })
-                .await
-                .map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        "TCP-AO listener rotation task exited",
-                    )
-                })?;
-            response.await.map_err(|_| {
-                std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "TCP-AO listener awaiting-peer reply dropped",
-                )
-            })?
-        })
+    ) -> ReloadDispatch<std::io::Result<()>, std::io::Error> {
+        self.dispatch(
+            |reply| TcpAoListenerCommand::MarkAwaitingPeer {
+                generation,
+                detail,
+                reply,
+            },
+            "TCP-AO listener awaiting-peer marker",
+        )
         .await
-        .map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                "TCP-AO listener awaiting-peer marker timed out",
-            )
-        })?
     }
 
     /// Latest secret-free desired/applied listener status.
@@ -618,36 +501,16 @@ impl TcpAoListenerHandle {
         &self,
         md5_keys: Vec<Md5ListenerKey>,
         ttl_security: Vec<TtlSecurityListenerPolicy>,
-    ) -> std::io::Result<()> {
-        tokio::time::timeout(TCP_AO_ROTATION_CONTROL_TIMEOUT, async {
-            let (reply, response) = oneshot::channel();
-            self.tx
-                .send(TcpAoListenerCommand::ReplaceInboundAuth {
-                    md5_keys,
-                    ttl_security,
-                    reply,
-                })
-                .await
-                .map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        "BGP listener control task exited",
-                    )
-                })?;
-            response.await.map_err(|_| {
-                std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "BGP listener inbound-auth reply dropped",
-                )
-            })?
-        })
+    ) -> ReloadDispatch<std::io::Result<()>, std::io::Error> {
+        self.dispatch(
+            |reply| TcpAoListenerCommand::ReplaceInboundAuth {
+                md5_keys,
+                ttl_security,
+                reply,
+            },
+            "BGP listener inbound-auth replacement",
+        )
         .await
-        .map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                "BGP listener inbound-auth replacement timed out",
-            )
-        })?
     }
 
     /// Mark a later global phase (currently established-session apply) failed
@@ -662,36 +525,16 @@ impl TcpAoListenerHandle {
         &self,
         generation: TcpAoRotationGeneration,
         error: String,
-    ) -> std::io::Result<()> {
-        tokio::time::timeout(TCP_AO_ROTATION_CONTROL_TIMEOUT, async {
-            let (reply, response) = oneshot::channel();
-            self.tx
-                .send(TcpAoListenerCommand::MarkDependentFailure {
-                    generation,
-                    error,
-                    reply,
-                })
-                .await
-                .map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        "TCP-AO listener rotation task exited",
-                    )
-                })?;
-            response.await.map_err(|_| {
-                std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "TCP-AO listener dependent-failure reply dropped",
-                )
-            })?
-        })
+    ) -> ReloadDispatch<std::io::Result<()>, std::io::Error> {
+        self.dispatch(
+            |reply| TcpAoListenerCommand::MarkDependentFailure {
+                generation,
+                error,
+                reply,
+            },
+            "TCP-AO listener dependent-failure marker",
+        )
         .await
-        .map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                "TCP-AO listener dependent-failure marker timed out",
-            )
-        })?
     }
 
     /// Publish a listener generation as applied only after every established
@@ -705,46 +548,12 @@ impl TcpAoListenerHandle {
     pub async fn acknowledge_global_commit(
         &self,
         generation: TcpAoRotationGeneration,
-    ) -> std::io::Result<TcpAoRotationStatus> {
-        let result = tokio::time::timeout(TCP_AO_ROTATION_CONTROL_TIMEOUT, async {
-            let (reply, response) = oneshot::channel();
-            self.tx
-                .send(TcpAoListenerCommand::AcknowledgeGlobalCommit { generation, reply })
-                .await
-                .map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        "TCP-AO listener rotation task exited",
-                    )
-                })?;
-            response.await.map_err(|_| {
-                std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "TCP-AO listener commit reply dropped",
-                )
-            })?
-        })
+    ) -> ReloadDispatch<std::io::Result<TcpAoRotationStatus>, std::io::Error> {
+        self.dispatch(
+            |reply| TcpAoListenerCommand::AcknowledgeGlobalCommit { generation, reply },
+            "TCP-AO listener commit acknowledgement",
+        )
         .await
-        .map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                "TCP-AO listener commit acknowledgement timed out",
-            )
-        });
-        match result {
-            Ok(Ok(status)) => Ok(status),
-            Ok(Err(error)) | Err(error) => {
-                let status = self.status();
-                if status.phase == TcpAoRotationPhase::Idle
-                    && status.desired == generation
-                    && status.applied == generation
-                {
-                    Ok(status)
-                } else {
-                    Err(error)
-                }
-            }
-        }
     }
 }
 
@@ -2881,6 +2690,74 @@ mod tests {
     use std::cell::RefCell;
     use std::net::Ipv4Addr;
 
+    #[tokio::test]
+    async fn reload_dispatch_distinguishes_rejection_from_lost_acknowledgement() {
+        let (tx, rx) = mpsc::channel(1);
+        let (_status_tx, status_rx) = watch::channel(TcpAoRotationStatus::default());
+        let rejected = TcpAoListenerHandle { tx, status_rx };
+        drop(rx);
+        assert!(matches!(
+            rejected.replace_inbound_auth(Vec::new(), Vec::new()).await,
+            ReloadDispatch::NotAccepted(_)
+        ));
+
+        let (tx, mut rx) = mpsc::channel(1);
+        let (_status_tx, status_rx) = watch::channel(TcpAoRotationStatus::default());
+        let accepted = TcpAoListenerHandle { tx, status_rx };
+        let actor = tokio::spawn(async move {
+            let command = rx.recv().await.expect("accepted listener command");
+            drop(command);
+        });
+        assert!(matches!(
+            accepted.replace_inbound_auth(Vec::new(), Vec::new()).await,
+            ReloadDispatch::AcknowledgementLost
+        ));
+        actor.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reload_dispatch_uses_one_deadline_across_admission_and_reply() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let (_status_tx, status_rx) = watch::channel(TcpAoRotationStatus::default());
+        let handle = TcpAoListenerHandle {
+            tx: tx.clone(),
+            status_rx,
+        };
+        let (blocking_reply, _blocking_response) = oneshot::channel();
+        tx.send(TcpAoListenerCommand::ReplaceInboundAuth {
+            md5_keys: Vec::new(),
+            ttl_security: Vec::new(),
+            reply: blocking_reply,
+        })
+        .await
+        .unwrap();
+
+        let started = tokio::time::Instant::now();
+        let pending =
+            tokio::spawn(async move { handle.replace_inbound_auth(Vec::new(), Vec::new()).await });
+        tokio::task::yield_now().await;
+        tokio::time::advance(
+            TCP_AO_ROTATION_CONTROL_TIMEOUT
+                .checked_sub(std::time::Duration::from_millis(100))
+                .expect("timeout exceeds the test margin"),
+        )
+        .await;
+        assert!(!pending.is_finished());
+
+        drop(rx.recv().await.expect("blocking command"));
+        tokio::task::yield_now().await;
+        let accepted = rx.recv().await.expect("admitted reload command");
+        tokio::time::advance(std::time::Duration::from_millis(100)).await;
+        tokio::task::yield_now().await;
+
+        assert!(matches!(
+            pending.await.unwrap(),
+            ReloadDispatch::AcknowledgementLost
+        ));
+        assert_eq!(started.elapsed(), TCP_AO_ROTATION_CONTROL_TIMEOUT);
+        drop(accepted);
+    }
+
     #[test]
     fn accept_errors_classify_by_errno() {
         for errno in [libc::EMFILE, libc::ENFILE, libc::ENOMEM, libc::ENOBUFS] {
@@ -3708,10 +3585,10 @@ mod tests {
         let handle = listener.tcp_ao_rotation_handle();
         let task = tokio::spawn(listener.run());
 
-        handle
+        let outcome = handle
             .mark_dependent_failure(generation, "session apply failed".to_string())
-            .await
-            .unwrap();
+            .await;
+        assert!(matches!(outcome, ReloadDispatch::Replied(Ok(()))));
         assert_eq!(handle.status().phase, TcpAoRotationPhase::AddOnlyFailed);
         assert_eq!(handle.status().applied, TcpAoRotationGeneration::STARTUP);
         assert_eq!(
@@ -3719,7 +3596,9 @@ mod tests {
             Some("session apply failed")
         );
 
-        let status = handle.apply_add_only(desired).await.unwrap();
+        let ReloadDispatch::Replied(Ok(status)) = handle.apply_add_only(desired).await else {
+            panic!("same-generation retry must return an authoritative success");
+        };
         assert_eq!(status.phase, TcpAoRotationPhase::AddOnly);
         assert_eq!(status.desired, generation);
         assert_eq!(status.applied, TcpAoRotationGeneration::STARTUP);
@@ -3840,7 +3719,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn lost_commit_ack_reply_uses_published_committed_status() {
+    async fn lost_commit_ack_remains_lost_when_status_looks_committed() {
         let generation = TcpAoRotationGeneration::new(2).unwrap();
         let (tx, mut rx) = mpsc::channel(1);
         let (status_tx, status_rx) = watch::channel(TcpAoRotationStatus {
@@ -3868,7 +3747,9 @@ mod tests {
             drop(reply);
         });
 
-        let status = handle.acknowledge_global_commit(generation).await.unwrap();
+        let status = handle.acknowledge_global_commit(generation).await;
+        assert!(matches!(status, ReloadDispatch::AcknowledgementLost));
+        let status = handle.status();
         assert_eq!(status.phase, TcpAoRotationPhase::Idle);
         assert_eq!(status.applied, generation);
         task.await.unwrap();

--- a/crates/transport/tests/listener.rs
+++ b/crates/transport/tests/listener.rs
@@ -10,6 +10,7 @@ mod inbound_auth {
     use std::net::{IpAddr, SocketAddr};
     use std::time::Duration;
 
+    use rustbgpd_transport::listener::ReloadDispatch;
     use rustbgpd_transport::{
         AcceptedConnection, BgpListener, ListenerSocketOptions, Md5ListenerKey,
         TcpAoListenerOwnerKind, TtlSecurityListenerPolicy, set_gtsm, set_tcp_md5sig,
@@ -352,7 +353,7 @@ mod inbound_auth {
         let accepted = expect_accept(&mut accept_rx).await;
         expect_data_flows(signed_old, accepted).await;
 
-        control
+        let outcome = control
             .replace_inbound_auth(
                 vec![Md5ListenerKey {
                     peer,
@@ -361,8 +362,8 @@ mod inbound_auth {
                 }],
                 Vec::new(),
             )
-            .await
-            .expect("replace listener MD5 inventory");
+            .await;
+        assert!(matches!(outcome, ReloadDispatch::Replied(Ok(()))));
 
         let stale = spawn_connect(addr, None, Some("old-secret".to_string()), None).await;
         assert!(
@@ -375,10 +376,8 @@ mod inbound_auth {
         let accepted = expect_accept(&mut accept_rx).await;
         expect_data_flows(signed_new, accepted).await;
 
-        control
-            .replace_inbound_auth(Vec::new(), Vec::new())
-            .await
-            .expect("remove listener MD5 inventory");
+        let outcome = control.replace_inbound_auth(Vec::new(), Vec::new()).await;
+        assert!(matches!(outcome, ReloadDispatch::Replied(Ok(()))));
         let plaintext = spawn_connect(addr, None, None, None)
             .await
             .expect("plaintext inbound after key removal");
@@ -404,7 +403,7 @@ mod inbound_auth {
         let control = listener.tcp_ao_rotation_handle();
         tokio::spawn(listener.run());
 
-        control
+        let outcome = control
             .replace_inbound_auth(
                 Vec::new(),
                 vec![TtlSecurityListenerPolicy {
@@ -414,8 +413,8 @@ mod inbound_auth {
                     enforce: true,
                 }],
             )
-            .await
-            .expect("add GTSM policy to live listener");
+            .await;
+        assert!(matches!(outcome, ReloadDispatch::Replied(Ok(()))));
 
         let client = spawn_gtsm_connect(addr, None)
             .await
@@ -524,7 +523,7 @@ mod inbound_auth {
         };
         let (v4_addr, v6_addr, mut accept_rx, control) = bind_dual_listener(options).await;
 
-        control
+        let outcome = control
             .replace_inbound_auth(
                 vec![
                     Md5ListenerKey {
@@ -540,8 +539,8 @@ mod inbound_auth {
                 ],
                 Vec::new(),
             )
-            .await
-            .expect("replace dual-family listener MD5 inventory");
+            .await;
+        assert!(matches!(outcome, ReloadDispatch::Replied(Ok(()))));
 
         let stale = spawn_connect(v6_addr, None, Some("v6-old".to_string()), None).await;
         assert!(

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -475,12 +475,20 @@ What happens (in dependency order):
    `AdjRibIn` get re-evaluated against the new policy. Operators no
    longer need to run `softreset` manually after a chain swap.
 
-Reload halts at the first step failure and returns a partial-state
-snapshot, so the daemon's in-memory config tracks what actually
-landed at the peer manager. Operator fixes the failing TOML and
-reloads again to converge against the half-applied state. Per-step
-errors are logged with structured `bucket` / `target` / `error`
-fields.
+Reload halts at the first step failure. A typed authoritative receipt records
+the exact successful peer effects, and the peer-manager snapshot, config
+bridge/persister, tracing projection, and gNMI dial-out targets all adopt that
+same complete or known-partial runtime state before the owner settles. The
+operator can then fix the failing TOML and reload again to converge. A command
+that was definitely not accepted before any prior effect is a clean rejection;
+an accepted reply loss or non-authoritative reconcile instead recovery-fences
+the daemon, makes `/readyz` fail, rejects another persisted mutation, and exits
+70 after the five-second grace. Per-step errors are logged with structured
+`bucket` / `target` / `error` fields.
+
+Coordinated shutdown closes new SIGHUP and runtime-mutation admission first.
+It does not abort an already-owned reload: the daemon waits for its typed
+settlement before taking the warm checkpoint or tearing down required actors.
 
 **Restart-required surfaces** (logged at reload, surfaced under
 "Restart-required" in `--diff`): `[global]` ASN/router-id/families,

--- a/docs/adr/0127-config-transaction-settlement-watchdog.md
+++ b/docs/adr/0127-config-transaction-settlement-watchdog.md
@@ -30,20 +30,24 @@ before ownership and does not close the underlying settlement-liveness issue.
 
 This ADR defines the post-ownership contract. Transaction-watchdog substrate
 exists in current source, but Proposed status does not claim the complete owner
-roster, SIGHUP settlement/shutdown rules, or required recovery proof has
-shipped.
+roster, observability, or required cross-roster recovery proof has shipped.
 
 ### Implementation status (2026-08-12)
 
 The shared watchdog, readiness/admission fence, Linux exit-70 terminal action,
 and typed settlement wiring have shipped for transaction/Apply owners,
-Neighbor4, FIB2, PeerGroup4, and Policy12. That is a partial roster, not
-acceptance of this ADR or closure of the underlying issue.
+Neighbor4, FIB2, PeerGroup4, Policy12, and SIGHUP. SIGHUP now has one owner from
+post-acquire validation through peer-manager, config-bridge/persister, tracing,
+and dial-out acknowledgement. Its accepted authority may be complete or an
+explicit known-partial runtime projection; lost acknowledgement or a
+non-authoritative reconcile fences instead of guessing.
 
-SIGHUP ownership remains incomplete. The bounded metrics/log observability
-described below and the final cross-roster recovery proofs also remain
-incomplete. Until those land, this ADR stays Proposed and the source inventory
-must distinguish shipped owners from the decision's full target roster.
+Shutdown closes coordinator admission, physically drains queued owners, and
+awaits an already-owned SIGHUP before checkpointing or actor teardown. Real
+daemon faults prove reconcile and bridge/persister acknowledgement loss make
+readiness red, reject a second mutation, and exit 70. The bounded metrics/log
+observability described below and final cross-roster recovery proofs remain
+incomplete, so this ADR stays Proposed.
 
 ### Typed publication and recovery classification
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1927,7 +1927,7 @@ pub struct ConfigDiff {
     /// `[[fib_tables]]` blocks added/removed/modified between old and new.
     /// Reload-applied in the common case: the ADR-0061 general-FIB actor
     /// accepts a runtime table-set swap on SIGHUP
-    /// (`FibRuntimeCommand::ReplaceTables`), so edits hot-apply when the
+    /// (`FibRuntimeCommand::OwnedReplaceTables`), so edits hot-apply when the
     /// reconciler is running. The one exception the static diff *can* know is
     /// the startup-from-empty case — see [`Self::fib_tables_requires_restart`].
     pub fib_tables_changed: bool,

--- a/src/config/tests/dataplane.rs
+++ b/src/config/tests/dataplane.rs
@@ -425,7 +425,7 @@ bfd = {{ profile = "nope" }}
 fn fib_tables_diff_marks_reload_applied() {
     // N→M edit: a table already exists at startup (so the reconciler is live),
     // and the new config tweaks it. These hot-apply via SIGHUP / gRPC
-    // (`FibRuntimeCommand::ReplaceTables`), so the static diff classifies them
+    // (`FibRuntimeCommand::OwnedReplaceTables`), so the static diff classifies them
     // reload-applied, not restart-required.
     let with_table = |metric: u32| {
         format!(

--- a/src/config_persister.rs
+++ b/src/config_persister.rs
@@ -55,14 +55,13 @@ pub enum ConfigMutation {
     /// Drop the staged snapshot. The caller's runtime change did not land, so
     /// neither may the write.
     DiscardStagedConfig,
-    /// Refresh the persister's base snapshot without writing to disk.
-    ///
-    /// SIGHUP reload uses this for operator-authored TOML that
-    /// contains restart-required fields. Runtime keeps a pinned live
-    /// snapshot, but future gRPC mutations must still apply on top of
-    /// the operator's desired file rather than writing the pinned
-    /// runtime snapshot back to disk.
-    RefreshSnapshotNoPersist(Arc<AcceptedConfigSnapshot>),
+    /// Adopt an operator-authored SIGHUP snapshot without rewriting its file.
+    /// The acknowledgement is sent only after the persister and history view
+    /// both observe the replacement.
+    AdoptReloadSnapshot {
+        snapshot: Arc<AcceptedConfigSnapshot>,
+        adopted: oneshot::Sender<()>,
+    },
 }
 
 /// Listens for config mutations and persists them atomically.
@@ -154,6 +153,14 @@ impl ConfigPersister {
                 }
                 ConfigMutation::DiscardStagedConfig => {
                     self.discard_staged();
+                    continue;
+                }
+                ConfigMutation::AdoptReloadSnapshot { snapshot, adopted } => {
+                    self.discard_staged();
+                    info!("adopting SIGHUP config snapshot without rewriting the operator file");
+                    self.current = snapshot;
+                    self.record_current_history();
+                    let _ = adopted.send(());
                     continue;
                 }
                 _ => {}
@@ -250,7 +257,8 @@ impl ConfigPersister {
             // single-phase applier.
             ConfigMutation::StageConfigAck(..)
             | ConfigMutation::CommitStagedConfig(_)
-            | ConfigMutation::DiscardStagedConfig => false,
+            | ConfigMutation::DiscardStagedConfig
+            | ConfigMutation::AdoptReloadSnapshot { .. } => false,
             ConfigMutation::AddNeighbor(neighbor) => {
                 if self
                     .current
@@ -296,16 +304,6 @@ impl ConfigPersister {
                 info!("replacing persister config snapshot and persisting it");
                 self.current = new_config;
                 true
-            }
-            ConfigMutation::RefreshSnapshotNoPersist(new_config) => {
-                info!("refreshing persister config snapshot without writing to disk");
-                self.current = new_config;
-                // The operator already persisted and successfully reloaded
-                // this desired config. Record the validated snapshot without
-                // writing it back: otherwise history index 0 still names the
-                // pre-SIGHUP config and `rollback 1` cannot restore it.
-                self.record_current_history();
-                false
             }
         }
     }
@@ -692,40 +690,8 @@ remote_asn = 65002
         );
     }
 
-    /// Load-bearing SIGHUP-history proof: refreshing the validated desired
-    /// snapshot without a daemon write must still make that snapshot the
-    /// newest rollback entry. Removing the history record from
-    /// `RefreshSnapshotNoPersist` leaves this list at one entry.
-    #[test]
-    fn refresh_snapshot_no_persist_records_validated_config_history() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("config.toml");
-        let state_dir = dir.path().to_path_buf();
-        let history = crate::config_history::history_dir(&state_dir);
-        let config = minimal_config();
-        std::fs::write(&path, toml::to_string_pretty(&config).unwrap()).unwrap();
-
-        let (_tx, rx) = mpsc::channel(1);
-        let mut persister = ConfigPersister::new(rx, path, config, Some(state_dir));
-        persister.record_current_history();
-
-        let mut refreshed = minimal_config();
-        refreshed.neighbors.push(test_neighbor("10.0.0.2", 65002));
-        let refreshed_snapshot = persister.current.derive_config(refreshed.clone()).unwrap();
-        assert!(!persister.apply(ConfigMutation::RefreshSnapshotNoPersist(refreshed_snapshot)));
-
-        let entries = crate::config_history::v2::scan_mixed(&history).unwrap();
-        assert_eq!(entries.len(), 2);
-        let crate::config_history::v2::StoredPayload::V2(newest) =
-            crate::config_history::v2::read_mixed(&history, &entries[0]).unwrap();
-        assert_eq!(
-            newest.normalized_toml,
-            persisted_config_document(&refreshed).unwrap()
-        );
-    }
-
     #[tokio::test]
-    async fn refresh_snapshot_no_persist_updates_base_without_writing() {
+    async fn adopt_reload_snapshot_acks_before_following_write() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
         let config = minimal_config();
@@ -738,11 +704,16 @@ remote_asn = 65002
         let persister = ConfigPersister::new(rx, path.clone(), config, None);
         let handle = tokio::spawn(persister.run());
 
-        tx.send(ConfigMutation::RefreshSnapshotNoPersist(
-            AcceptedConfigSnapshot::from_config_for_test(refreshed),
-        ))
+        let (adopted, adopted_rx) = oneshot::channel();
+        tx.send(ConfigMutation::AdoptReloadSnapshot {
+            snapshot: AcceptedConfigSnapshot::from_config_for_test(refreshed),
+            adopted,
+        })
         .await
         .unwrap();
+        adopted_rx
+            .await
+            .expect("persister adoption acknowledgement");
         tx.send(ConfigMutation::AddNeighbor(Box::new(test_neighbor(
             "10.0.0.3", 65003,
         ))))

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -4178,8 +4178,9 @@ remote_asn = 65002
             (main, "RuntimeConfigCoordinator::new()", 1),
             (main, "\n                lock: runtime_config_lock.clone(),", 2),
             (main, "runtime_config_lock: runtime_config_lock.clone(),", 1),
-            (main, "let Ok(_runtime_config_guard) = runtime_config_lock.acquire().await else {", 1),
-            (main, "tokio::time::timeout_at(runtime_config_deadline, runtime_config_lock.acquire())", 1),
+            (main, "runtime_config_lock.acquire()", 0),
+            (main, "RuntimeConfigOperationKind::Sighup,", 1),
+            (main, "tokio::time::timeout_at(runtime_config_deadline, runtime_config_lock.acquire())", 0),
             (main, "RuntimeConfigSettlementWatchdog::new()", 1),
             (main, ".with_runtime_config_settlement(", 1),
             (main, "move || settlement_wait.wait_until_idle()", 1),
@@ -4422,13 +4423,11 @@ remote_asn = 65002
         let watched_idle = main
             .find("move || settlement_wait.wait_until_idle()")
             .unwrap();
-        let bounded_fence = main
-            .find("tokio::time::timeout_at(runtime_config_deadline, runtime_config_lock.acquire())")
+        let drained = main
+            .find("runtime_config_lock.wait_until_drained().await;")
             .unwrap();
         let closed = main.find("runtime_config_lock.close();").unwrap();
-        assert!(
-            shutdown_gate < watched_idle && watched_idle < bounded_fence && bounded_fence < closed
-        );
+        assert!(shutdown_gate < closed && closed < watched_idle && watched_idle < drained);
         assert!(
             owners[1..6]
                 .iter()
@@ -5167,13 +5166,6 @@ peer_group = "edge"
             match cmd {
                 FibRuntimeCommand::GetTables { reply } => {
                     let _ = reply.send(state.lock().await.clone());
-                }
-                FibRuntimeCommand::ReplaceTables { tables, reply } => {
-                    let result = replace_result.clone().unwrap_or(Ok(()));
-                    if result.is_ok() {
-                        *state.lock().await = tables;
-                    }
-                    let _ = reply.send(result);
                 }
                 FibRuntimeCommand::OwnedReplaceTables { tables, reply } => {
                     let result = replace_result.clone().unwrap_or(Ok(()));
@@ -10446,7 +10438,7 @@ families = ["ipv4_unicast"]
             reply.send(vec![edge]).unwrap();
             assert!(
                 fib_rx.recv().await.is_none(),
-                "stage rejection must precede ReplaceTables"
+                "stage rejection must precede typed FIB replacement"
             );
         });
         let (internal_tx, mut internal_rx) = mpsc::unbounded_channel();

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -143,7 +143,24 @@ pub(crate) struct EvpnRuntimeReloadApplyResult {
 
 pub(crate) struct EvpnRuntimeReloadAttempt {
     pub(crate) baseline: Config,
-    pub(crate) result: Result<Option<EvpnRuntimeReloadApplyResult>, GrpcEvpnRuntimeApplyError>,
+    pub(crate) terminal: EvpnRuntimeReloadTerminal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EvpnRuntimeReloadTerminal {
+    Unchanged,
+    Applied(EvpnRuntimeReloadApplyResult),
+    RejectedNoEffect(GrpcEvpnRuntimeApplyError),
+    KnownPartial(GrpcEvpnRuntimeApplyError),
+    KnownDivergence(GrpcEvpnRuntimeApplyError),
+    PublicationAmbiguous(GrpcEvpnRuntimeApplyError),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct EvpnRuntimeReloadState {
+    generation: rustbgpd_evpn::EvpnRuntimeGeneration,
+    lifecycle: rustbgpd_evpn::EvpnRuntimeLifecycle,
+    mutation_state: rustbgpd_evpn::EvpnRuntimeMutationState,
 }
 
 #[derive(Clone)]
@@ -314,41 +331,63 @@ impl EvpnRuntimeReloadApply {
     {
         let this = self.clone();
         let config = config.clone();
-        // Same ADR-0080 shield as `apply_candidate_config`: shutdown aborts
-        // an in-flight reload task, and that abort must not cancel a
-        // converge mid-flight.
+        // Same ADR-0080 shield as `apply_candidate_config`: losing an outer
+        // reload waiter must not cancel a converge mid-flight.
         let join = tokio::spawn(async move {
             let _apply_guard = this.apply_lock.lock().await;
             let baseline = this.committed_config_locked();
             if !changed(&config, &baseline) {
                 return EvpnRuntimeReloadAttempt {
                     baseline,
-                    result: Ok(None),
+                    terminal: EvpnRuntimeReloadTerminal::Unchanged,
                 };
             }
 
-            let result = match this.apply_candidate_config_locked(&config, false).await {
-                Ok(response) => response_to_reload_outcome(response.outcome).map(|outcome| {
-                    Some(EvpnRuntimeReloadApplyResult {
-                        outcome,
-                        message: response.message,
-                    })
-                }),
-                Err(error) => Err(error),
+            let before = match this.reload_state() {
+                Ok(state) => state,
+                Err(error) => {
+                    return EvpnRuntimeReloadAttempt {
+                        baseline,
+                        terminal: EvpnRuntimeReloadTerminal::PublicationAmbiguous(error),
+                    };
+                }
             };
-            if matches!(result, Ok(Some(_))) {
+            let result = this.apply_candidate_config_locked(&config, false).await;
+            let terminal = match this.reload_state() {
+                Ok(after) => classify_reload_terminal(before, after, result),
+                Err(error) => EvpnRuntimeReloadTerminal::PublicationAmbiguous(error),
+            };
+            if matches!(terminal, EvpnRuntimeReloadTerminal::Applied(_)) {
                 this.set_committed_config(&config);
             }
 
-            EvpnRuntimeReloadAttempt { baseline, result }
+            EvpnRuntimeReloadAttempt { baseline, terminal }
         });
         match join.await {
             Ok(attempt) => attempt,
             Err(error) => EvpnRuntimeReloadAttempt {
                 baseline: self.committed_config_locked(),
-                result: Err(apply_task_join_error("reload apply", &error)),
+                terminal: EvpnRuntimeReloadTerminal::PublicationAmbiguous(apply_task_join_error(
+                    "reload apply",
+                    &error,
+                )),
             },
         }
+    }
+
+    fn reload_state(&self) -> Result<EvpnRuntimeReloadState, GrpcEvpnRuntimeApplyError> {
+        let coordinator = self.coordinator.lock().map_err(|_| {
+            GrpcEvpnRuntimeApplyError::Internal(
+                "EVPN runtime coordinator lock poisoned while classifying reload settlement"
+                    .to_string(),
+            )
+        })?;
+        let model = coordinator.model();
+        Ok(EvpnRuntimeReloadState {
+            generation: model.generation(),
+            lifecycle: model.lifecycle(),
+            mutation_state: model.mutation_state(),
+        })
     }
 
     async fn apply_candidate_config_locked(
@@ -365,6 +404,60 @@ impl EvpnRuntimeReloadApply {
             &self.metrics,
         )
         .await
+    }
+}
+
+fn classify_reload_terminal(
+    before: EvpnRuntimeReloadState,
+    after: EvpnRuntimeReloadState,
+    result: Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError>,
+) -> EvpnRuntimeReloadTerminal {
+    match result {
+        Ok(_)
+            if after.mutation_state == rustbgpd_evpn::EvpnRuntimeMutationState::Failed
+                || after.lifecycle == rustbgpd_evpn::EvpnRuntimeLifecycle::Degraded
+                || (before.mutation_state != rustbgpd_evpn::EvpnRuntimeMutationState::Idle
+                    && after.mutation_state != rustbgpd_evpn::EvpnRuntimeMutationState::Idle) =>
+        {
+            EvpnRuntimeReloadTerminal::KnownDivergence(GrpcEvpnRuntimeApplyError::Internal(
+                "EVPN runtime returned success while coordinator authority remained degraded"
+                    .to_string(),
+            ))
+        }
+        Ok(response) => match response_to_reload_outcome(response.outcome) {
+            Ok(outcome) => EvpnRuntimeReloadTerminal::Applied(EvpnRuntimeReloadApplyResult {
+                outcome,
+                message: response.message,
+            }),
+            Err(error) => EvpnRuntimeReloadTerminal::PublicationAmbiguous(error),
+        },
+        Err(error) if after.generation != before.generation => {
+            EvpnRuntimeReloadTerminal::KnownPartial(error)
+        }
+        Err(error)
+            if after.mutation_state == rustbgpd_evpn::EvpnRuntimeMutationState::Failed
+                || after.lifecycle == rustbgpd_evpn::EvpnRuntimeLifecycle::Degraded
+                || (before.mutation_state != rustbgpd_evpn::EvpnRuntimeMutationState::Idle
+                    && after.mutation_state != rustbgpd_evpn::EvpnRuntimeMutationState::Idle) =>
+        {
+            EvpnRuntimeReloadTerminal::KnownDivergence(error)
+        }
+        Err(error)
+            if after.generation == before.generation
+                && after.mutation_state == rustbgpd_evpn::EvpnRuntimeMutationState::Idle
+                && matches!(
+                    error,
+                    GrpcEvpnRuntimeApplyError::InvalidArgument(_)
+                        | GrpcEvpnRuntimeApplyError::FailedPrecondition(_)
+                ) =>
+        {
+            EvpnRuntimeReloadTerminal::RejectedNoEffect(error)
+        }
+        Err(
+            error @ (GrpcEvpnRuntimeApplyError::Internal(_)
+            | GrpcEvpnRuntimeApplyError::Unavailable(_)),
+        ) => EvpnRuntimeReloadTerminal::PublicationAmbiguous(error),
+        Err(error) => EvpnRuntimeReloadTerminal::KnownDivergence(error),
     }
 }
 
@@ -2800,6 +2893,122 @@ mod tests {
         }
     }
 
+    fn reload_test_state(
+        generation: rustbgpd_evpn::EvpnRuntimeGeneration,
+        lifecycle: rustbgpd_evpn::EvpnRuntimeLifecycle,
+        mutation_state: rustbgpd_evpn::EvpnRuntimeMutationState,
+    ) -> EvpnRuntimeReloadState {
+        EvpnRuntimeReloadState {
+            generation,
+            lifecycle,
+            mutation_state,
+        }
+    }
+
+    #[test]
+    fn reload_classifier_reports_determinate_idle_rejection() {
+        let state = reload_test_state(
+            rustbgpd_evpn::EvpnRuntimeGeneration::STARTUP,
+            rustbgpd_evpn::EvpnRuntimeLifecycle::Active,
+            rustbgpd_evpn::EvpnRuntimeMutationState::Idle,
+        );
+        let terminal = classify_reload_terminal(
+            state,
+            state,
+            Err(GrpcEvpnRuntimeApplyError::FailedPrecondition(
+                "unsupported candidate".to_string(),
+            )),
+        );
+        assert!(matches!(
+            terminal,
+            EvpnRuntimeReloadTerminal::RejectedNoEffect(_)
+        ));
+    }
+
+    #[test]
+    fn reload_classifier_reports_advanced_generation_as_known_partial() {
+        let before = reload_test_state(
+            rustbgpd_evpn::EvpnRuntimeGeneration::STARTUP,
+            rustbgpd_evpn::EvpnRuntimeLifecycle::Active,
+            rustbgpd_evpn::EvpnRuntimeMutationState::Idle,
+        );
+        let after = reload_test_state(
+            rustbgpd_evpn::EvpnRuntimeGeneration::STARTUP.next(),
+            rustbgpd_evpn::EvpnRuntimeLifecycle::Active,
+            rustbgpd_evpn::EvpnRuntimeMutationState::Idle,
+        );
+        let terminal = classify_reload_terminal(
+            before,
+            after,
+            Err(GrpcEvpnRuntimeApplyError::FailedPrecondition(
+                "decomposed step failed".to_string(),
+            )),
+        );
+        assert!(matches!(
+            terminal,
+            EvpnRuntimeReloadTerminal::KnownPartial(_)
+        ));
+    }
+
+    #[test]
+    fn reload_classifier_reports_failed_or_degraded_state_as_divergence() {
+        let before = reload_test_state(
+            rustbgpd_evpn::EvpnRuntimeGeneration::STARTUP,
+            rustbgpd_evpn::EvpnRuntimeLifecycle::Active,
+            rustbgpd_evpn::EvpnRuntimeMutationState::Idle,
+        );
+        let after = reload_test_state(
+            before.generation,
+            rustbgpd_evpn::EvpnRuntimeLifecycle::Degraded,
+            rustbgpd_evpn::EvpnRuntimeMutationState::Failed,
+        );
+        let terminal = classify_reload_terminal(
+            before,
+            after,
+            Err(GrpcEvpnRuntimeApplyError::FailedPrecondition(
+                "converger failed after effects".to_string(),
+            )),
+        );
+        assert!(matches!(
+            terminal,
+            EvpnRuntimeReloadTerminal::KnownDivergence(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn reload_classifier_reports_transport_and_join_uncertainty_as_ambiguous() {
+        let state = reload_test_state(
+            rustbgpd_evpn::EvpnRuntimeGeneration::STARTUP,
+            rustbgpd_evpn::EvpnRuntimeLifecycle::Active,
+            rustbgpd_evpn::EvpnRuntimeMutationState::Idle,
+        );
+        for error in [
+            GrpcEvpnRuntimeApplyError::Internal("internal".to_string()),
+            GrpcEvpnRuntimeApplyError::Unavailable("unavailable".to_string()),
+        ] {
+            assert!(matches!(
+                classify_reload_terminal(state, state, Err(error)),
+                EvpnRuntimeReloadTerminal::PublicationAmbiguous(_)
+            ));
+        }
+
+        let baseline = load_runtime_test_config(minimal_runtime_candidate_toml(), "test baseline");
+        let candidate = load_runtime_test_config(l2vni_runtime_candidate_toml(), "test candidate");
+        let reload_apply = EvpnRuntimeReloadApply::new(
+            empty_evpn_runtime_coordinator(),
+            Arc::new(tokio::sync::Mutex::new(())),
+            Arc::new(TestRuntimeConverger::ok()),
+            baseline,
+        );
+        let attempt = reload_apply
+            .apply_config_if_changed(&candidate, |_, _| panic!("join-error proof"))
+            .await;
+        assert!(matches!(
+            attempt.terminal,
+            EvpnRuntimeReloadTerminal::PublicationAmbiguous(GrpcEvpnRuntimeApplyError::Internal(_))
+        ));
+    }
+
     /// Signals entry into `converge` and then blocks until the test grants
     /// a permit — lets a test drop the caller's future mid-converge.
     struct GatedRuntimeConverger {
@@ -4962,8 +5171,8 @@ local_vtep_ip = "10.0.0.1"
         }
     }
 
-    /// ADR-0080, SIGHUP flavor: shutdown aborts an in-flight reload task;
-    /// the abort must not cancel an EVPN converge already past planning.
+    /// ADR-0080, SIGHUP flavor: losing the outer reload waiter must not
+    /// cancel an EVPN converge already past planning.
     #[tokio::test]
     async fn reload_apply_dropped_mid_converge_still_commits_and_advances_baseline() {
         let baseline = load_runtime_test_config(minimal_runtime_candidate_toml(), "test baseline");
@@ -4989,7 +5198,7 @@ local_vtep_ip = "10.0.0.1"
             _ = &mut caller => panic!("reload apply must still be blocked in converge"),
             () = entered.notified() => {}
         }
-        // Simulate the shutdown-time `JoinHandle::abort` of the reload task.
+        // Simulate an outer reload waiter going away.
         drop(caller);
         release.add_permits(1);
 
@@ -5002,7 +5211,7 @@ local_vtep_ip = "10.0.0.1"
             }
             assert!(
                 StdInstant::now() < deadline,
-                "aborted reload cancelled the apply: generation/baseline never advanced"
+                "dropped reload waiter cancelled the apply: generation/baseline never advanced"
             );
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
@@ -5048,11 +5257,11 @@ local_vtep_ip = "10.0.0.1"
             .apply_config_if_changed(&bound, evpn_runtime_changed_for_test)
             .await;
         assert!(matches!(
-            attempt.result,
-            Ok(Some(EvpnRuntimeReloadApplyResult {
+            attempt.terminal,
+            EvpnRuntimeReloadTerminal::Applied(EvpnRuntimeReloadApplyResult {
                 outcome: EvpnRuntimeReloadOutcome::Noop,
                 ..
-            }))
+            })
         ));
         assert!(bindings_rx.has_changed().unwrap(), "binding add published");
         let published = bindings_rx.borrow_and_update().clone();
@@ -5066,7 +5275,10 @@ local_vtep_ip = "10.0.0.1"
         let attempt = reload_apply
             .apply_config_if_changed(&unbound, evpn_runtime_changed_for_test)
             .await;
-        assert!(matches!(attempt.result, Ok(Some(_))));
+        assert!(matches!(
+            attempt.terminal,
+            EvpnRuntimeReloadTerminal::Applied(_)
+        ));
         assert!(
             bindings_rx.has_changed().unwrap(),
             "binding removal published"

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -66,30 +66,7 @@ impl FibRuntimeConfig {
 /// Runtime control messages for the FIB reconciler actor. Sent by the SIGHUP
 /// reload path and the gRPC FIB-table CRUD handlers to mutate the live
 /// `[[fib_tables]]` set without a restart.
-#[expect(
-    clippy::enum_variant_names,
-    reason = "the closed actor protocol names each operation's FIB-table scope explicitly"
-)]
 pub enum FibRuntimeCommand {
-    /// Replace the desired table set and run an immediate reconcile.
-    ///
-    /// The reply distinguishes "the actor applied the new set" from "it
-    /// couldn't act on it":
-    /// - `Ok(())` — the new set is in effect and the immediate reconcile
-    ///   reached the apply phase. Per-route kernel failures within the plan
-    ///   stay best-effort + observable via statuses/metrics; they do not fail
-    ///   the ack. The caller may advance its config snapshot / persist.
-    /// - `Err(_)` — the caller must NOT advance its snapshot. Two shapes:
-    ///   (a) the reconcile bailed before the apply phase (RIB-candidate or
-    ///   peer-group query failed, or the kernel dump failed); or (b) it reached
-    ///   the apply phase but a removed table's withdraw failed, leaving an owned
-    ///   route outside the new set — the desired set is reverted to keep that
-    ///   route owned (and retried on the next reconcile). Either way the live
-    ///   table set is unchanged from the caller's perspective.
-    ReplaceTables {
-        tables: Vec<FibTableConfig>,
-        reply: oneshot::Sender<Result<(), String>>,
-    },
     /// Replace the desired table set for an owned FIB CRUD mutation.
     ///
     /// Unlike the legacy reply, this preserves whether rejection happened
@@ -102,7 +79,7 @@ pub enum FibRuntimeCommand {
     },
     /// Return the actor's current desired table set — its live source of truth.
     /// The gRPC CRUD control path reads this, applies the upsert/delete,
-    /// validates the candidate, then issues a `ReplaceTables`, all while
+    /// validates the candidate, then issues an `OwnedReplaceTables`, all while
     /// holding the FIB-config coordinator lock so the read-modify-write is
     /// atomic against concurrent CRUD and SIGHUP reloads.
     GetTables {
@@ -121,31 +98,6 @@ pub enum OwnedFibReplaceOutcome {
     /// Reconcile reached its apply phase, then restored the desired set after
     /// detecting an orphan. Kernel and owned-route compensation is not proved.
     CompensationAmbiguous(String),
-}
-
-enum FibRuntimeReplaceReply {
-    Legacy(oneshot::Sender<Result<(), String>>),
-    Owned(oneshot::Sender<OwnedFibReplaceOutcome>),
-}
-
-impl FibRuntimeReplaceReply {
-    fn send(self, outcome: OwnedFibReplaceOutcome) {
-        match (self, outcome) {
-            (Self::Legacy(reply), OwnedFibReplaceOutcome::Applied) => {
-                let _ = reply.send(Ok(()));
-            }
-            (
-                Self::Legacy(reply),
-                OwnedFibReplaceOutcome::RejectedNoEffect(reason)
-                | OwnedFibReplaceOutcome::CompensationAmbiguous(reason),
-            ) => {
-                let _ = reply.send(Err(reason));
-            }
-            (Self::Owned(reply), outcome) => {
-                let _ = reply.send(outcome);
-            }
-        }
-    }
 }
 
 /// Operator-visible state for one projected FIB row.
@@ -382,17 +334,7 @@ async fn run_loop<F>(
             // sustained route-event stream while a caller awaits the ack.
             maybe_cmd = cmd_rx.recv(), if cmd_open => {
                 match maybe_cmd {
-                    Some(command @ (FibRuntimeCommand::ReplaceTables { .. }
-                        | FibRuntimeCommand::OwnedReplaceTables { .. })) => {
-                        let (tables, reply) = match command {
-                            FibRuntimeCommand::ReplaceTables { tables, reply } => {
-                                (tables, FibRuntimeReplaceReply::Legacy(reply))
-                            }
-                            FibRuntimeCommand::OwnedReplaceTables { tables, reply } => {
-                                (tables, FibRuntimeReplaceReply::Owned(reply))
-                            }
-                            FibRuntimeCommand::GetTables { .. } => unreachable!(),
-                        };
+                    Some(FibRuntimeCommand::OwnedReplaceTables { tables, reply }) => {
                         // Tentatively swap to the new desired set and reconcile.
                         let previous = std::mem::replace(&mut config.tables, tables);
                         let reached_apply = reconcile_once_with_events(
@@ -433,7 +375,7 @@ async fn run_loop<F>(
                             // signature — otherwise a later restart sees a config
                             // mismatch and quarantines valid owned state.
                             persist_owned_state(&config, &owned);
-                            reply.send(OwnedFibReplaceOutcome::Applied);
+                            let _ = reply.send(OwnedFibReplaceOutcome::Applied);
                         } else {
                             // Revert. A pre-plan bail (`!reached_apply`) never
                             // touched `owned` and never persisted, so the on-disk
@@ -457,7 +399,7 @@ async fn run_loop<F>(
                                  query or kernel dump failed); table set unchanged"
                                     .to_string()
                             };
-                            reply.send(if reached_apply {
+                            let _ = reply.send(if reached_apply {
                                 OwnedFibReplaceOutcome::CompensationAmbiguous(reason)
                             } else {
                                 OwnedFibReplaceOutcome::RejectedNoEffect(reason)
@@ -725,7 +667,7 @@ async fn query_peer_groups(
 /// Returns `true` when the reconcile reached the apply phase (a plan was
 /// computed against a successful RIB query + kernel dump), `false` when it
 /// bailed before that — shutdown, RIB-candidate query failure, peer-group
-/// query failure, or kernel dump failure. The `ReplaceTables` command path
+/// query failure, or kernel dump failure. The `OwnedReplaceTables` command path
 /// uses this to decide whether the new desired table set was actually
 /// applied: per-route apply failures inside the plan are best-effort and do
 /// NOT flip this to `false` (they stay observable via statuses/metrics), but a
@@ -2865,7 +2807,7 @@ mod tests {
         }
     }
 
-    // The next three tests model the runtime `ReplaceTables` path (SIGHUP /
+    // The next three tests model the typed runtime table-replacement path (SIGHUP /
     // gRPC hot-swap): the actor swaps its desired table set and reconciles
     // against persistent owned + kernel state. Two successive
     // `reconcile_config_for_test` calls sharing `fib` + `owned` reproduce
@@ -2943,7 +2885,7 @@ mod tests {
     async fn failed_withdraw_on_table_removal_keeps_route_owned_outside_set() {
         // Regression for the orphan bug: removing a table whose kernel Remove
         // fails leaves the route owned but outside the (now-empty) configured
-        // set. The ReplaceTables command guard detects exactly this — an owned
+        // set. The typed command guard detects exactly this — an owned
         // route not covered by the new table set — and reverts rather than
         // persisting a signature that would quarantine the still-present kernel
         // row on the next restart.
@@ -3488,7 +3430,7 @@ mod tests {
 
     #[tokio::test]
     async fn replace_tables_pre_apply_bail_does_not_rewrite_owned_state() {
-        // A ReplaceTables whose reconcile bails before the apply phase (kernel
+        // A table replacement whose reconcile bails before the apply phase (kernel
         // dump failure here) leaves `owned` untouched, so the cancel path must
         // not rewrite the owned-state file: persisting would stamp a signature
         // the reconcile never acted on.

--- a/src/fib_table_control.rs
+++ b/src/fib_table_control.rs
@@ -10,7 +10,7 @@
 //! Safety properties (see ADR-0061):
 //! - **Atomic read-modify-write.** A single coordinator `Mutex`, shared with
 //!   the SIGHUP reload path, is held across read (`GetTables`) → validate →
-//!   apply (`ReplaceTables`) → persist. Concurrent CRUD calls and SIGHUP FIB
+//!   apply (typed `OwnedReplaceTables`) → persist. Concurrent CRUD calls and SIGHUP FIB
 //!   reloads can't interleave and clobber each other.
 //! - **Validate before dispatch.** The candidate set is validated against the
 //!   live config (peer-group references, reserved/duplicate ids, families, ECMP
@@ -28,6 +28,8 @@ use std::time::Duration;
 
 use tokio::sync::{mpsc, oneshot};
 
+use crate::config::FibTableConfig;
+use crate::fib_runtime::{FibRuntimeCommand, OwnedFibReplaceOutcome};
 use rustbgpd_api::health_probe::DaemonGate;
 use rustbgpd_api::peer_types::ConfigPersistCommitOutcome;
 use rustbgpd_api::peer_types::{
@@ -46,13 +48,6 @@ use rustbgpd_api::runtime_config_settlement::{
 use rustbgpd_api::server::{
     ConfigMutationGateFn, RuntimeConfigCoordinator, RuntimeConfigCoordinatorClosed,
 };
-#[cfg(test)]
-use std::fmt::Write as _;
-#[cfg(test)]
-use tracing::error;
-
-use crate::config::FibTableConfig;
-use crate::fib_runtime::{FibRuntimeCommand, OwnedFibReplaceOutcome};
 
 /// How long to wait for a config-persistence permit before refusing the
 /// mutation (mirrors the dynamic-neighbor CRUD reserve deadline).
@@ -112,22 +107,6 @@ impl From<RuntimeConfigCoordinatorClosed> for OwnedFibControlError {
 impl From<FibTableControlError> for OwnedFibControlError {
     fn from(error: FibTableControlError) -> Self {
         Self(error)
-    }
-}
-
-#[cfg(test)]
-#[allow(
-    dead_code,
-    reason = "test-only legacy rollback harness is retained for focused transaction regression construction"
-)]
-pub(crate) struct FibCommitFailure {
-    pub(crate) error: FibTableControlError,
-}
-
-#[cfg(test)]
-impl From<FibTableControlError> for FibCommitFailure {
-    fn from(error: FibTableControlError) -> Self {
-        Self { error }
     }
 }
 
@@ -274,7 +253,8 @@ async fn mutate(
             let _guard = coordinator.acquire().await?;
             match body(None).await {
                 OwnedRuntimeConfigOutcome::CleanNoEffect(result) => result,
-                OwnedRuntimeConfigOutcome::PublishedDurable(value) => Ok(value),
+                OwnedRuntimeConfigOutcome::PublishedDurable(value)
+                | OwnedRuntimeConfigOutcome::AcknowledgedAuthority(value) => Ok(value),
                 OwnedRuntimeConfigOutcome::Fenced { error, .. } => {
                     let _ = error;
                     std::future::pending().await
@@ -708,107 +688,6 @@ async fn compensate_fib_not_published(
     )
 }
 
-/// Legacy rollback harness retained for the config-transaction regression
-/// tests. Production targeted CRUD uses the typed owned path above; production
-/// config transactions preserve their separate legacy `ReplaceTables` flow.
-#[cfg(test)]
-#[allow(
-    dead_code,
-    reason = "test-only legacy rollback harness is retained for focused transaction regression construction"
-)]
-pub(crate) async fn commit_fib_tables_locked(
-    fib_cmd_tx: &mpsc::Sender<FibRuntimeCommand>,
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    config_tx: &mpsc::Sender<ConfigEvent>,
-    candidate: Vec<FibTableConfig>,
-) -> Result<proto::ListFibTablesResponse, FibCommitFailure> {
-    let previous_tables = read_current_tables(Some(fib_cmd_tx), FibTableControlError::Internal)
-        .await?
-        .unwrap_or_default();
-    let previous_snapshots: Vec<FibTableSnapshot> =
-        previous_tables.iter().map(config_to_snapshot).collect();
-    let snapshots: Vec<FibTableSnapshot> = candidate.iter().map(config_to_snapshot).collect();
-
-    // Validate AND stage the candidate into the peer manager's live config in
-    // one atomic command. This closes the TOCTOU against peer-group deletion:
-    // once staged, the candidate's `allowed_peer_groups` are visible to
-    // `peer_group_references`, so a concurrent delete is rejected (and if a
-    // delete raced ahead, the candidate fails validation here). The peer manager
-    // processes commands one at a time, so the check and commit cannot
-    // interleave with another config mutation.
-    stage_candidate(peer_mgr_tx, snapshots.clone()).await?;
-
-    // From here the candidate is staged in the live config, so every early exit
-    // must roll it back to `previous` to keep the snapshot from drifting ahead
-    // of the runtime/disk state.
-    let permit = match reserve_persist_permit(config_tx).await {
-        Ok(permit) => permit,
-        Err(error) => {
-            return Err(rollback_snapshot_after_error(
-                peer_mgr_tx,
-                previous_snapshots,
-                error.into(),
-            )
-            .await);
-        }
-    };
-
-    // Apply to the reconciler and wait for its acknowledgement.
-    if let Err(error) = replace_tables(fib_cmd_tx, candidate.clone()).await {
-        return Err(
-            rollback_snapshot_after_error(peer_mgr_tx, previous_snapshots, error.into()).await,
-        );
-    }
-
-    // Persist exactly the accepted set, only after the ack. The live config
-    // snapshot already holds the candidate (staged above). Await the bridge and
-    // persister acknowledgement before releasing the coordinator lock, otherwise
-    // an immediate SIGHUP can reload stale disk and overwrite the accepted
-    // runtime snapshot.
-    let (persist_ack_tx, persist_ack_rx) = oneshot::channel();
-    // Single-phase on purpose: FIB-table CRUD owns a rollback that restores
-    // the exact prior table set and already reports an ambiguous outcome when
-    // it cannot.
-    permit.send(ConfigEvent::FibTablesReplaced {
-        tables: snapshots,
-        ack: Some(ConfigPersistAck::immediate(persist_ack_tx)),
-    });
-    // LAN-277 window (b): a lost acknowledgement means the on-disk outcome of
-    // the persistence attempt is unknowable from here.
-    let Ok(persist_result) = persist_ack_rx.await else {
-        return Err(FibCommitFailure {
-            error: FibTableControlError::Internal(
-                "config bridge dropped FIB-table persistence acknowledgement".to_string(),
-            ),
-        });
-    };
-    match persist_result {
-        ConfigPersistCommitOutcome::PublishedDurable => {}
-        ConfigPersistCommitOutcome::NotPublished(error) => {
-            return Err(rollback_applied_tables_after_error(
-                fib_cmd_tx,
-                peer_mgr_tx,
-                previous_tables,
-                previous_snapshots,
-                FibTableControlError::FailedPrecondition(error).into(),
-            )
-            .await);
-        }
-        ConfigPersistCommitOutcome::PublicationAmbiguous(error) => {
-            return Err(FibCommitFailure {
-                error: FibTableControlError::Internal(format!(
-                    "FIB publication durability is ambiguous: {error}"
-                )),
-            });
-        }
-    }
-
-    Ok(proto::ListFibTablesResponse {
-        tables: candidate.iter().map(config_to_proto).collect(),
-        runtime_available: true,
-    })
-}
-
 /// Read the reconciler's current table set. `Ok(None)` means no reconciler is
 /// running (used by `List` to report `runtime_available = false`).
 pub(crate) async fn read_current_tables(
@@ -854,142 +733,6 @@ fn apply_mutation(
     }
 }
 
-/// Atomically validate the candidate against the live config and, on success,
-/// stage it into the peer manager's `current_config.fib_tables`. Returns
-/// `InvalidArgument` if it doesn't validate (nothing is staged in that case).
-#[cfg(test)]
-#[allow(
-    dead_code,
-    reason = "reachable only through the test-only legacy rollback harness"
-)]
-async fn stage_candidate(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    tables: Vec<FibTableSnapshot>,
-) -> Result<(), FibTableControlError> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(PeerManagerCommand::StageFibTables {
-            tables,
-            reply: reply_tx,
-        })
-        .await
-        .map_err(|_| {
-            FibTableControlError::Internal("peer manager command channel closed".to_string())
-        })?;
-    reply_rx
-        .await
-        .map_err(|_| {
-            FibTableControlError::Internal(
-                "peer manager dropped the StageFibTables reply".to_string(),
-            )
-        })?
-        .map_err(FibTableControlError::InvalidArgument)
-}
-
-/// Restore the peer manager's staged `current_config.fib_tables` to `previous`
-/// after a post-stage failure (reserve or reconciler apply), so the live
-/// config snapshot can't drift ahead of the runtime/disk state.
-#[cfg(test)]
-#[allow(
-    dead_code,
-    reason = "reachable only through the test-only legacy rollback harness"
-)]
-async fn rollback_snapshot(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    previous: Vec<FibTableSnapshot>,
-) -> Result<(), FibTableControlError> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(PeerManagerCommand::SetFibTablesSnapshot {
-            tables: previous,
-            reply: reply_tx,
-        })
-        .await
-        .map_err(|_| {
-            FibTableControlError::Internal(
-                "peer manager command channel closed during FIB-table snapshot rollback"
-                    .to_string(),
-            )
-        })?;
-    reply_rx.await.map_err(|_| {
-        FibTableControlError::Internal(
-            "peer manager dropped the SetFibTablesSnapshot rollback reply".to_string(),
-        )
-    })
-}
-
-#[cfg(test)]
-#[allow(
-    dead_code,
-    reason = "reachable only through the test-only legacy rollback harness"
-)]
-async fn rollback_snapshot_after_error(
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    previous_snapshots: Vec<FibTableSnapshot>,
-    original: FibCommitFailure,
-) -> FibCommitFailure {
-    match rollback_snapshot(peer_mgr_tx, previous_snapshots).await {
-        Ok(()) => original,
-        Err(snapshot_rollback) => {
-            combine_fib_rollback_errors(&original.error, None, Some(snapshot_rollback))
-        }
-    }
-}
-
-#[cfg(test)]
-#[allow(
-    dead_code,
-    reason = "reachable only through the test-only legacy rollback harness"
-)]
-async fn rollback_applied_tables_after_error(
-    fib_cmd_tx: &mpsc::Sender<FibRuntimeCommand>,
-    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    previous_tables: Vec<FibTableConfig>,
-    previous_snapshots: Vec<FibTableSnapshot>,
-    original: FibCommitFailure,
-) -> FibCommitFailure {
-    if let Err(runtime_rollback) = replace_tables(fib_cmd_tx, previous_tables).await {
-        return combine_fib_rollback_errors(&original.error, Some(runtime_rollback), None);
-    }
-    match rollback_snapshot(peer_mgr_tx, previous_snapshots).await {
-        Ok(()) => original,
-        Err(snapshot_rollback) => {
-            combine_fib_rollback_errors(&original.error, None, Some(snapshot_rollback))
-        }
-    }
-}
-
-/// LAN-277 window (c): only reached when a rollback component failed, so the
-/// runtime/staged state is left part-candidate — always an ambiguous
-/// completion.
-#[cfg(test)]
-#[allow(
-    dead_code,
-    reason = "reachable only through the test-only legacy rollback harness"
-)]
-fn combine_fib_rollback_errors(
-    original: &FibTableControlError,
-    runtime_rollback: Option<FibTableControlError>,
-    snapshot_rollback: Option<FibTableControlError>,
-) -> FibCommitFailure {
-    error!(
-        %original,
-        ?runtime_rollback,
-        ?snapshot_rollback,
-        "FIB-table rollback failed"
-    );
-    let mut message = format!("{original}; rollback failed");
-    if let Some(error) = runtime_rollback {
-        let _ = write!(message, "; runtime rollback: {error}");
-    }
-    if let Some(error) = snapshot_rollback {
-        let _ = write!(message, "; snapshot rollback: {error}");
-    }
-    FibCommitFailure {
-        error: FibTableControlError::Internal(message),
-    }
-}
-
 async fn reserve_persist_permit(
     config_tx: &mpsc::Sender<ConfigEvent>,
 ) -> Result<mpsc::OwnedPermit<ConfigEvent>, FibTableControlError> {
@@ -1003,33 +746,6 @@ async fn reserve_persist_permit(
         .map_err(|_| {
             FibTableControlError::Unavailable("config persistence unavailable".to_string())
         })
-}
-
-#[cfg(test)]
-pub(crate) async fn replace_tables(
-    fib_cmd_tx: &mpsc::Sender<FibRuntimeCommand>,
-    tables: Vec<FibTableConfig>,
-) -> Result<(), FibTableControlError> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    fib_cmd_tx
-        .send(FibRuntimeCommand::ReplaceTables {
-            tables,
-            reply: reply_tx,
-        })
-        .await
-        .map_err(|_| {
-            FibTableControlError::Internal("FIB reconciler command channel closed".to_string())
-        })?;
-    reply_rx
-        .await
-        .map_err(|_| {
-            FibTableControlError::Internal(
-                "FIB reconciler dropped the ReplaceTables reply".to_string(),
-            )
-        })?
-        // The reconciler reverted (RIB/dump bail or a removed-table withdraw
-        // that would orphan a kernel row) — surface it without persisting.
-        .map_err(FibTableControlError::FailedPrecondition)
 }
 
 pub(crate) fn runtime_unavailable_error(startup_had_tables: bool) -> FibTableControlError {
@@ -1327,10 +1043,6 @@ mod tests {
                 match cmd {
                     FibRuntimeCommand::GetTables { reply } => {
                         let _ = reply.send(fib_state_for_task.lock().await.clone());
-                    }
-                    FibRuntimeCommand::ReplaceTables { tables, reply } => {
-                        *fib_state_for_task.lock().await = tables;
-                        let _ = reply.send(Ok(()));
                     }
                     FibRuntimeCommand::OwnedReplaceTables { tables, reply } => {
                         *fib_state_for_task.lock().await = tables;
@@ -1743,7 +1455,7 @@ mod tests {
             .split_once("async fn owned_fib_mutation_body")
             .unwrap()
             .1
-            .split_once("/// Legacy rollback harness")
+            .split_once("async fn compensate_fib_not_published")
             .unwrap()
             .0;
         for forbidden in [".code()", ".message()", "to_string().contains"] {
@@ -1752,7 +1464,6 @@ mod tests {
                 "typed settlement bypass: {forbidden}"
             );
         }
-        assert!(!body.contains("FibRuntimeCommand::ReplaceTables"));
         let disk = body.find("stage_fib_persistence(").unwrap();
         let pm = body.find("stage_pm_candidate(").unwrap();
         let actor = body.find("dispatch_owned_replace(").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,8 @@ use crate::config::{
 use crate::config_persister::{ConfigMutation, ConfigPersister};
 use crate::peer_manager::PeerManager;
 use crate::reload::{
-    apply_reload_outcome, reload_config_with_tcp_ao, run_config_bridge_accepted,
+    ReloadStepError, SighupAuthority, SighupReloadError, SighupReloadOutcome, SighupReloadPlan,
+    finalize_sighup_authority, reload_config_with_tcp_ao, run_config_bridge_accepted,
     runtime_config_snapshot_accepted,
 };
 use rustbgpd_api::health_probe::DaemonGate;
@@ -95,7 +96,9 @@ use rustbgpd_api::peer_types::{
     ImportValidationDependency, PeerManagerCommand, PeerManagerNeighborConfig,
     PeerManagerReadinessQuery, WarmCheckpointCapture, WarmCheckpointSession,
 };
-use rustbgpd_api::runtime_config_settlement::RuntimeConfigSettlementWatchdog;
+use rustbgpd_api::runtime_config_settlement::{
+    OwnedRuntimeConfigOutcome, RuntimeConfigOperationKind, RuntimeConfigSettlementWatchdog,
+};
 use rustbgpd_api::server::{
     AccessMode as GrpcServerAccessMode, ConfigMutationGateFn, ListenerConfig as GrpcListenerConfig,
     ListenerEndpoint, RuntimeConfigCoordinator, ServeConfig,
@@ -4966,19 +4969,21 @@ async fn run<T>(
     // surface) and reconciles targets again after every successful SIGHUP
     // reload in the outcome arm below. A collector being down never affects
     // the daemon: each target retries independently with capped backoff.
-    let mut gnmi_dialout_manager = rustbgpd_api::gnmi_dialout::DialoutManager::new(
-        rustbgpd_api::gnmi_dialout::GnmiService::new(
-            config.global.asn,
-            config.global.router_id.clone(),
-            // Dial-out only renders Subscribe snapshots; it never serves Set.
-            rustbgpd_api::server::AccessMode::ReadOnly,
-            peer_mgr_tx.clone(),
-        )
-        .with_event_history(event_history_handle.clone()),
-        metrics.clone(),
-    );
+    let gnmi_dialout_manager = Arc::new(tokio::sync::Mutex::new(
+        rustbgpd_api::gnmi_dialout::DialoutManager::new(
+            rustbgpd_api::gnmi_dialout::GnmiService::new(
+                config.global.asn,
+                config.global.router_id.clone(),
+                // Dial-out only renders Subscribe snapshots; it never serves Set.
+                rustbgpd_api::server::AccessMode::ReadOnly,
+                peer_mgr_tx.clone(),
+            )
+            .with_event_history(event_history_handle.clone()),
+            metrics.clone(),
+        ),
+    ));
     match config::gnmi_dialout_targets(&config) {
-        Ok(targets) => gnmi_dialout_manager.apply(&targets),
+        Ok(targets) => gnmi_dialout_manager.lock().await.apply(&targets),
         // Unreachable in practice: Config::load validated the section.
         Err(reason) => error!(error = %reason, "invalid [gnmi_dialout] section; dial-out disabled"),
     }
@@ -5000,7 +5005,7 @@ async fn run<T>(
     // running is logged and dropped — the operator-facing back-pressure
     // surface.
     let mut reload_in_flight: Option<
-        tokio::task::JoinHandle<Option<Result<Config, &'static str>>>,
+        tokio::task::JoinHandle<Result<SighupAuthority, SighupReloadError>>,
     > = None;
     let mut grpc_server_failed = false;
     loop {
@@ -5053,52 +5058,43 @@ async fn run<T>(
                 let limits_rib_tx = rib_tx.clone();
                 let accepted_rx = accepted_rx.clone();
                 let live_bindings = config.policy.dataset_bindings.clone();
+                let runtime_config_settlement = runtime_config_settlement.clone();
+                let daemon_gate = daemon_gate.clone();
+                let dialout_manager = Arc::clone(&gnmi_dialout_manager);
                 reload_in_flight = Some(tokio::spawn(async move {
-                    let Ok(_runtime_config_guard) = runtime_config_lock.acquire().await else {
-                        error!("SIGHUP reload rejected: runtime config coordinator is closed");
-                        return None;
-                    };
-                    if let Err(error) = config_transaction_controller
-                        .reject_if_pending("SIGHUP reload")
-                        .await
-                    {
-                        warn!(
-                            error = %error,
-                            "SIGHUP reload ignored while confirmed config transaction is applying or pending"
-                        );
-                        return None;
-                    }
-                    if let Some(credentials) = grpc_credentials {
-                        match credentials.reload() {
-                            Ok(generation) => {
-                                reload_metrics.record_grpc_credential_reload("success");
-                                info!(generation, "gRPC credential generation reloaded");
-                            }
-                            Err(error) => {
-                                reload_metrics.record_grpc_credential_reload("failure");
-                                error!(error = %error, "gRPC credential reload rejected; last-known-good generation remains active");
-                            }
-                        }
+                    runtime_config_settlement.execute_owned(
+                        RuntimeConfigOperationKind::Sighup,
+                        runtime_config_lock,
+                        daemon_gate,
+                        Arc::new(AtomicBool::new(true)),
+                        move |operation| async move {
+                    if let Err(error) = config_transaction_controller.reject_if_pending("SIGHUP reload").await {
+                        return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(
+                            SighupReloadError::preflight("transaction.preflight", error.to_string()),
+                        ));
                     }
                     let Some(accepted_rx) = accepted_rx else {
-                        error!("SIGHUP reload has no accepted-config authority");
-                        return None;
+                        return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(
+                            SighupReloadError::preflight("authority.preflight", "accepted-config authority unavailable"),
+                        ));
                     };
                     let prior_accepted = accepted_rx.borrow().clone();
-                    let snapshot = match runtime_config_snapshot_accepted(
-                        &pm_tx,
-                        &prior_accepted,
-                        &live_bindings,
-                    )
-                    .await
-                    {
-                        Ok(snapshot) => snapshot,
-                        Err(error) => {
-                            error!(
-                                error = %error,
-                                "failed to read live runtime config snapshot for SIGHUP reload"
-                            );
-                            return None;
+                    let snapshot = match runtime_config_snapshot_accepted(&pm_tx, &prior_accepted, &live_bindings).await {
+                        rustbgpd_transport::listener::ReloadDispatch::NotAccepted(error) => {
+                            return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(
+                                SighupReloadError::step("runtime_snapshot.preflight", ReloadStepError::NotAccepted(error)),
+                            ));
+                        }
+                        rustbgpd_transport::listener::ReloadDispatch::Replied(Ok(snapshot)) => snapshot,
+                        rustbgpd_transport::listener::ReloadDispatch::Replied(Err(error)) => {
+                            return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(
+                                SighupReloadError::step("runtime_snapshot.preflight", ReloadStepError::Rejected(error)),
+                            ));
+                        }
+                        rustbgpd_transport::listener::ReloadDispatch::AcknowledgementLost => {
+                            return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(
+                                SighupReloadError::step("runtime_snapshot.preflight", ReloadStepError::AcknowledgementLost),
+                            ));
                         }
                     };
                     // ADR-0113: preflight every live peer's outbound prefix
@@ -5117,32 +5113,56 @@ async fn run<T>(
                     ) {
                         Ok(snapshot) => Arc::new(snapshot),
                         Err(diagnostic) => {
-                            error!("{diagnostic}");
-                            return None;
+                            return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(
+                                SighupReloadError::preflight("parse.preflight", diagnostic.clone()),
+                            ));
                         }
                     };
-                    if let Err(error) = reload::apply_outbound_prefix_limits_if_changed(
-                        &limits_rib_tx,
-                        &snapshot,
-                        desired.config_ref(),
-                    )
-                    .await
-                    {
-                        error!(error = %error, "SIGHUP reload rejected");
-                        return None;
+                    if let Some(credentials) = grpc_credentials {
+                        match credentials.reload() {
+                            Ok(generation) => {
+                                reload_metrics.record_grpc_credential_reload("success");
+                                info!(generation, "gRPC credential generation reloaded");
+                            }
+                            Err(error) => {
+                                reload_metrics.record_grpc_credential_reload("failure");
+                                error!(error = %error, "gRPC credential reload rejected; last-known-good generation remains active");
+                            }
+                        }
                     }
-                    let reloaded = reload_config_with_tcp_ao(
-                        desired,
-                        &snapshot,
+                    let outcome = reload_config_with_tcp_ao(
+                        SighupReloadPlan { baseline_runtime: snapshot, desired },
                         live_tcp.as_ref(),
                         live_uds.as_ref(),
                         &pm_tx,
+                        Some(&limits_rib_tx),
                         fib_cmd.as_ref(),
                         Some(&evpn_runtime_reload_apply),
                         tcp_ao_listener.as_ref(),
+                        Some(&operation),
                     )
-                    .await?;
-                    Some(apply_reload_outcome(reloaded, &pm_internal, bridge_replace.as_ref()).await)
+                    .await;
+                    match outcome {
+                        SighupReloadOutcome::CleanNoEffect(error) => OwnedRuntimeConfigOutcome::CleanNoEffect(Err(error)),
+                        SighupReloadOutcome::RecoveryFenced { error, reason } => OwnedRuntimeConfigOutcome::Fenced { error, reason },
+                        SighupReloadOutcome::Acknowledged(authority) => {
+                            let Some(bridge_replace) = bridge_replace.as_ref() else {
+                                return OwnedRuntimeConfigOutcome::Fenced {
+                                    error: SighupReloadError::preflight("config_bridge", "bridge authority unavailable after runtime effects"),
+                                    reason: rustbgpd_api::runtime_config_settlement::RuntimeConfigFenceReason::KnownDivergence,
+                                };
+                            };
+                            finalize_sighup_authority(
+                                &operation,
+                                authority,
+                                &pm_internal,
+                                bridge_replace,
+                                &dialout_manager,
+                            ).await
+                        }
+                    }
+                        },
+                    ).await
                 }));
             }
             // Only polled when a reload is in flight. Standard tokio
@@ -5159,80 +5179,46 @@ async fn run<T>(
             } => {
                 reload_in_flight = None;
                 match outcome {
-                    Ok(Some(Ok(advanced))) => {
-                        config = advanced;
-                        // [gnmi_dialout] is reload-applied: reconcile the
-                        // dial-out targets against the advanced config —
-                        // removed targets stop (gauge series reaped), added
-                        // start, changed redial, unchanged keep their live
-                        // collector connections.
-                        match config::gnmi_dialout_targets(&config) {
-                            Ok(targets) => gnmi_dialout_manager.apply(&targets),
-                            // Unreachable in practice: the reload path
-                            // re-validated the config before advancing.
-                            Err(reason) => error!(
-                                error = %reason,
-                                "invalid [gnmi_dialout] after reload; dial-out targets unchanged"
+                    Ok(Ok(authority)) => {
+                        match &authority.completion {
+                            reload::SighupCompletion::Complete => {}
+                            reload::SighupCompletion::KnownPartial { failures } => warn!(
+                                failures = failures.len(),
+                                "SIGHUP settled with an authoritative partial runtime receipt"
                             ),
                         }
+                        config = authority.runtime;
                     }
-                    Ok(Some(Err(stage))) => error!(
-                        stage,
-                        "post-reload sync failed mid-flight; in-memory config not advanced — next SIGHUP will retry"
-                    ),
-                    Ok(None) => {
-                        // reload_config returned None (failure) or short-circuited.
-                    }
+                    Ok(Err(error)) => error!(error = %error, "SIGHUP reload rejected without runtime effect"),
                     Err(e) => error!(error = %e, "reload task panicked"),
                 }
             }
         }
     }
 
-    // If a reload is still in flight at shutdown, abort it before
-    // tearing down the peer manager. Letting it run would race the
-    // peer manager's Shutdown command and potentially queue commands
-    // against an already-draining manager. An EVPN runtime apply the
-    // reload already started keeps running on its ADR-0080 detached
-    // task; the apply-lock fence below serializes with it.
+    // Coordinated shutdown closes admission first, then drains both logical
+    // watchdog registrations and the acquire-to-registration physical gap.
+    daemon_gate.begin_shutdown();
+    runtime_config_lock.close();
+    info!("initiating coordinated shutdown");
+    let settlement_wait = runtime_config_settlement.clone();
+    tokio::task::spawn_blocking(move || settlement_wait.wait_until_idle())
+        .await
+        .expect("runtime-config settlement wait task must not panic");
+    runtime_config_lock.wait_until_drained().await;
     if let Some(handle) = reload_in_flight.take() {
-        handle.abort();
-        let _ = handle.await;
+        match handle.await {
+            Ok(Ok(authority)) => config = authority.runtime,
+            Ok(Err(error)) => warn!(error = %error, "SIGHUP rejected during shutdown drain"),
+            Err(error) => error!(error = %error, "SIGHUP task failed during shutdown drain"),
+        }
     }
 
     // Drop the profiler now while all data structures are still alive,
     // so the heap snapshot captures the live working set.
     drop(profiler);
 
-    // Coordinated shutdown:
-    // 0. Flip the availability gate FIRST: readiness goes red, persisted
-    //    config mutations are rejected, and new inbound BGP sessions are
-    //    dropped — nothing new is admitted into the teardown below.
-    // 1. Tell PeerManager to shut down (sends NOTIFICATIONs to all peers)
-    daemon_gate.begin_shutdown();
-    info!("initiating coordinated shutdown");
-    let settlement_wait = runtime_config_settlement.clone();
-    tokio::task::spawn_blocking(move || settlement_wait.wait_until_idle())
-        .await
-        .expect("runtime-config settlement wait task must not panic");
     let runtime_config_deadline = tokio::time::Instant::now() + WARM_CHECKPOINT_DEADLINE;
-    let mut runtime_config_fence_failure = None;
-    let runtime_config_fence =
-        match tokio::time::timeout_at(runtime_config_deadline, runtime_config_lock.acquire()).await
-        {
-            Ok(Ok(permit)) => Some(permit),
-            Ok(Err(_)) => {
-                runtime_config_fence_failure =
-                    Some("authoritative runtime-config coordinator is closed".to_string());
-                None
-            }
-            Err(_) => {
-                runtime_config_fence_failure =
-                    Some("timed out acquiring the authoritative runtime-config fence".to_string());
-                None
-            }
-        };
-    runtime_config_lock.close();
     let mut restart_time_secs = max_gr_restart_time_secs(&config);
     let mut checkpoint_generation = None;
     let mut checkpoint_failure = None;
@@ -5241,8 +5227,7 @@ async fn run<T>(
     if warm_checkpoint_on_shutdown {
         if let Some(directory) = warm_bundle_directory.clone() {
             let deadline = runtime_config_deadline;
-            checkpoint_failure = runtime_config_fence_failure.take();
-            if checkpoint_failure.is_none() && runtime_config_fence.is_some() {
+            if checkpoint_failure.is_none() {
                 match tokio::time::timeout_at(deadline, evpn_runtime_apply_lock.lock()).await {
                     Ok(guard) => evpn_apply_fence = Some(guard),
                     Err(_) => {
@@ -5250,9 +5235,6 @@ async fn run<T>(
                             Some("timed out waiting for the EVPN runtime-apply fence".to_string());
                     }
                 }
-            } else if checkpoint_failure.is_none() {
-                checkpoint_failure =
-                    Some("authoritative runtime-config coordinator is closed".to_string());
             }
             if checkpoint_failure.is_none() {
                 match tokio::time::timeout_at(deadline, query_warm_checkpoint_capture(&peer_mgr_tx))

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -967,6 +967,7 @@ impl PeerManager {
     /// socket-scoped fields are copied from `config` into the stored
     /// transport config by the next rebuild path, which resolves from the
     /// config snapshot anyway).
+    #[cfg(test)]
     pub(super) async fn hot_update_peer(
         &mut self,
         config: PeerManagerNeighborConfig,
@@ -983,6 +984,29 @@ impl PeerManager {
             )));
         }
         self.hot_update_peer_in_place(config).await
+    }
+
+    pub(super) async fn hot_update_peer_owned(
+        &mut self,
+        config: PeerManagerNeighborConfig,
+    ) -> rustbgpd_api::peer_types::OwnedHotUpdatePeerOutcome {
+        use rustbgpd_api::peer_types::OwnedHotUpdatePeerOutcome;
+
+        let peer = PeerKey::new(config.address, config.interface.clone());
+        let Some(managed) = self.peers.get(&peer) else {
+            return OwnedHotUpdatePeerOutcome::RejectedNoEffect(PeerLifecycleError::NotFound(peer));
+        };
+        if managed.is_dynamic {
+            return OwnedHotUpdatePeerOutcome::RejectedNoEffect(PeerLifecycleError::Invalid(
+                format!(
+                    "hot update target {peer} is a dynamic peer; reload reconciles static neighbors only"
+                ),
+            ));
+        }
+        match self.hot_update_peer_in_place(config).await {
+            Ok(()) => OwnedHotUpdatePeerOutcome::Success,
+            Err(error) => OwnedHotUpdatePeerOutcome::KnownDivergence(error),
+        }
     }
 
     /// The applier half of [`Self::hot_update_peer`], without the

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -1032,6 +1032,13 @@ impl PeerManager {
                                         self.apply_peer_group_change_owned(event, affected).await
                                     }
                                 }
+                                OwnedCatalogMutation::SyncRpolPolicies {
+                                    rpol_files,
+                                    rpol,
+                                    dataset_bindings,
+                                } => self
+                                    .sync_rpol_policies_owned(rpol_files, rpol, dataset_bindings)
+                                    .await,
                                 OwnedCatalogMutation::DeletePeerGroup { name } => {
                                     self.apply_peer_group_change_owned(
                                         ConfigEvent::DeletePeerGroup { name, ack: None },
@@ -1356,8 +1363,7 @@ impl PeerManager {
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::HotUpdatePeer { config, reply } => {
-                            let result = self.hot_update_peer(config).await;
-                            let _ = reply.send(result);
+                            let _ = reply.send(self.hot_update_peer_owned(config).await);
                         }
                         PeerManagerCommand::SyncExplainConfig {
                             enabled,
@@ -1377,13 +1383,6 @@ impl PeerManager {
                             self.current_config.policy.reject_retention.capacity =
                                 reject_retention_capacity;
                             let _ = reply.send(());
-                        }
-                        PeerManagerCommand::SyncRpolPolicies { rpol_files, rpol, dataset_bindings, reply } => {
-                            // LAN-888: receipt stamp — the gap back to the
-                            // reload flow's dispatch log is FIFO queue wait.
-                            info!("rpol policy sync command received");
-                            let result = self.sync_rpol_policies(rpol_files, rpol, dataset_bindings).await;
-                            let _ = reply.send(result);
                         }
                         PeerManagerCommand::RefreshDatasetDependents { swapped, failed, reply } => {
                             let result = self.refresh_dataset_dependents(&swapped, &failed).await;

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -2547,7 +2547,7 @@ impl PeerManager {
         //
         // Failure for an Established peer bubbles up to
         // `apply_policy_change`'s caller — for SIGHUP reloads, that
-        // halts the reload via `halt_partial` so the failure is
+        // returns acknowledged partial SIGHUP authority so the failure is
         // surfaced rather than logged-and-forgotten. Before bubbling
         // up, set `pending_refresh` so the next operator action
         // retries the refresh — otherwise a single transient send
@@ -2773,6 +2773,7 @@ impl PeerManager {
     /// resolve-first, rollback-capable fan-out as catalog policy edits. Peers
     /// whose import chain materially changed get a Route Refresh inside
     /// `apply_resolved_policy_snapshot`.
+    #[cfg(test)]
     pub(super) async fn sync_rpol_policies(
         &mut self,
         rpol_files: Vec<String>,
@@ -2799,6 +2800,42 @@ impl PeerManager {
             "rpol policy registry replaced; live peer chains re-resolved"
         );
         Ok(())
+    }
+
+    pub(super) async fn sync_rpol_policies_owned(
+        &mut self,
+        rpol_files: Vec<String>,
+        rpol: rustbgpd_policy::rpol::RpolPolicySet,
+        dataset_bindings: rustbgpd_policy::datasets::DatasetBindings,
+    ) -> OwnedCatalogMutationOutcome {
+        let mut next_config = self.current_config.clone();
+        next_config.policy.rpol_files = rpol_files;
+        next_config.policy.rpol = rpol;
+        next_config.policy.dataset_bindings = dataset_bindings;
+        match self
+            .refresh_policies_for_config_classified(next_config, None, true)
+            .await
+        {
+            Ok(_) => OwnedCatalogMutationOutcome::Success,
+            Err(PolicySnapshotFailure {
+                kind: PolicySnapshotFailureKind::RejectedNoEffect,
+                message,
+            }) => OwnedCatalogMutationOutcome::RejectedNoEffect(CatalogMutationError::internal(
+                message,
+            )),
+            Err(PolicySnapshotFailure {
+                kind: PolicySnapshotFailureKind::FullyCompensated,
+                message,
+            }) => OwnedCatalogMutationOutcome::FullyCompensated(CatalogMutationError::internal(
+                message,
+            )),
+            Err(PolicySnapshotFailure {
+                kind: PolicySnapshotFailureKind::CompensationAmbiguous,
+                message,
+            }) => OwnedCatalogMutationOutcome::CompensationAmbiguous(
+                CatalogMutationError::internal(message),
+            ),
+        }
     }
 
     /// Shared catalog-change fan-out: resolve every affected peer's

--- a/src/peer_manager/reconcile.rs
+++ b/src/peer_manager/reconcile.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
 use rustbgpd_api::peer_types::{
-    FibTableSnapshot, PeerKey, PeerManagerNeighborConfig, ReconcileFailure, ReconcileFailureKind,
-    ReconcileResult, RuntimeConfigDiff, RuntimeConfigDiffError, RuntimeConfigTransactionPlan,
+    FibTableSnapshot, PeerKey, PeerManagerNeighborConfig, PeerReconcileAuthority,
+    PeerReconcileEffect, PeerReconcileOutcome, ReconcileFailure, ReconcileFailureKind,
+    RuntimeConfigDiff, RuntimeConfigDiffError, RuntimeConfigTransactionPlan,
     RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus,
 };
 use tracing::{info, warn};
@@ -18,8 +19,10 @@ impl PeerManager {
         added: Vec<PeerManagerNeighborConfig>,
         removed: Vec<PeerKey>,
         changed: Vec<PeerManagerNeighborConfig>,
-    ) -> ReconcileResult {
-        let mut result = ReconcileResult::default();
+    ) -> PeerReconcileOutcome {
+        let mut effects = Vec::new();
+        let mut failures = Vec::new();
+        let mut authority = PeerReconcileAuthority::Known;
         let added_count = added.len();
         let removed_count = removed.len();
         let changed_count = changed.len();
@@ -41,11 +44,13 @@ impl PeerManager {
         for addr in &removed {
             if let Err(e) = self.delete_peer(addr.clone(), false).await {
                 warn!(peer = %addr, error = %e, "reconcile: failed to remove peer");
-                result.failures.push(ReconcileFailure {
+                failures.push(ReconcileFailure {
                     kind: ReconcileFailureKind::Remove,
                     peer: addr.clone(),
                     error: e.to_string(),
                 });
+            } else {
+                effects.push(PeerReconcileEffect::Removed(addr.clone()));
             }
         }
         // Changed peers: delete then re-add
@@ -56,9 +61,9 @@ impl PeerManager {
                 .await
             {
                 warn!(peer = %addr, error = %e, "reconcile: failed to remove changed peer");
-                result.failures.push(ReconcileFailure {
+                failures.push(ReconcileFailure {
                     kind: ReconcileFailureKind::ChangeRemove,
-                    peer: addr,
+                    peer: addr.clone(),
                     error: e.to_string(),
                 });
                 continue;
@@ -71,11 +76,14 @@ impl PeerManager {
                 .await
             {
                 warn!(peer = %addr, error = %e, "reconcile: failed to re-add changed peer");
-                result.failures.push(ReconcileFailure {
+                failures.push(ReconcileFailure {
                     kind: ReconcileFailureKind::ChangeAdd,
-                    peer: addr,
+                    peer: addr.clone(),
                     error: e.to_string(),
                 });
+                effects.push(PeerReconcileEffect::RemovedForFailedReplacement(addr));
+            } else {
+                effects.push(PeerReconcileEffect::Replaced(addr));
             }
         }
         // Replay preserved RFC 8326 toggles onto the freshly added peers. This
@@ -95,6 +103,7 @@ impl PeerManager {
                     error = %e,
                     "reconcile: failed to replay graceful-shutdown toggle on changed peer"
                 );
+                authority = PeerReconcileAuthority::Diverged;
             }
         }
         // Add new peers
@@ -102,21 +111,27 @@ impl PeerManager {
             let addr = PeerKey::new(cfg.address, cfg.interface.clone());
             if let Err(e) = self.add_peer(cfg, false).await {
                 warn!(peer = %addr, error = %e, "reconcile: failed to add new peer");
-                result.failures.push(ReconcileFailure {
+                failures.push(ReconcileFailure {
                     kind: ReconcileFailureKind::Add,
                     peer: addr,
                     error: e.to_string(),
                 });
+            } else {
+                effects.push(PeerReconcileEffect::Added(addr));
             }
         }
         info!(
             added = added_count,
             removed = removed_count,
             changed = changed_count,
-            failures = result.failures.len(),
+            failures = failures.len(),
             "peer reconciliation complete"
         );
-        result
+        PeerReconcileOutcome {
+            effects,
+            failures,
+            authority,
+        }
     }
 
     pub(super) fn diff_runtime_config(

--- a/src/peer_manager/tests/config_mutation.rs
+++ b/src/peer_manager/tests/config_mutation.rs
@@ -487,6 +487,30 @@ async fn rejected_hot_update_preserves_old_restart_countdown() {
 }
 
 #[tokio::test]
+async fn owned_hot_update_classifies_precheck_and_post_effect_failure() {
+    use rustbgpd_api::peer_types::{OwnedHotUpdatePeerOutcome, PeerLifecycleError};
+
+    let mut mgr = test_peer_manager();
+    let missing = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 88));
+    assert!(matches!(
+        mgr.hot_update_peer_owned(make_config(missing, 65002)).await,
+        OwnedHotUpdatePeerOutcome::RejectedNoEffect(PeerLifecycleError::NotFound(_))
+    ));
+
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 89));
+    let (rib_tx, rib_rx) = mpsc::channel(1);
+    mgr.rib_tx = rib_tx;
+    mgr.add_peer(make_config(addr, 65002), false).await.unwrap();
+    drop(rib_rx);
+    let mut update = make_config(addr, 65002);
+    update.local_ipv6_nexthop = Some("2001:db8::89".parse().unwrap());
+    assert!(matches!(
+        mgr.hot_update_peer_owned(update).await,
+        OwnedHotUpdatePeerOutcome::KnownDivergence(_)
+    ));
+}
+
+#[tokio::test]
 async fn hot_update_peer_refreshes_outbound_for_export_affecting_knobs() {
     let (_tx, rx) = mpsc::channel(16);
     let (rib_tx, mut rib_rx) = mpsc::channel(64);
@@ -657,6 +681,16 @@ async fn reconcile_changed_peer_still_rebuilds_session_task() {
         .reconcile_peers(Vec::new(), Vec::new(), vec![changed])
         .await;
     assert!(result.failures.is_empty(), "{:?}", result.failures);
+    assert_eq!(
+        result.authority,
+        rustbgpd_api::peer_types::PeerReconcileAuthority::Known
+    );
+    assert_eq!(
+        result.effects,
+        vec![rustbgpd_api::peer_types::PeerReconcileEffect::Replaced(
+            key(addr)
+        )]
+    );
 
     let managed = mgr.peers.get(&key(addr)).expect("rebuilt peer");
     assert_ne!(managed.session_id, session_id_before);
@@ -1192,6 +1226,16 @@ async fn reconcile_changed_peer_preserves_disabled_state() {
         .await;
 
     assert!(result.failures.is_empty(), "{:?}", result.failures);
+    assert_eq!(
+        result.authority,
+        rustbgpd_api::peer_types::PeerReconcileAuthority::Known
+    );
+    assert_eq!(
+        result.effects,
+        vec![rustbgpd_api::peer_types::PeerReconcileEffect::Replaced(
+            key(addr)
+        )]
+    );
     let managed = mgr.peers.get(&key(addr)).expect("reconciled peer");
     assert_eq!(managed.description, "reloaded description");
     assert_eq!(managed.hold_time, Some(45));

--- a/src/peer_manager/tests/max_prefix.rs
+++ b/src/peer_manager/tests/max_prefix.rs
@@ -841,6 +841,16 @@ async fn reconcile_preserves_max_prefix_emitted_during_old_actor_shutdown() {
         .await;
 
     assert!(result.failures.is_empty(), "{:?}", result.failures);
+    assert_eq!(
+        result.authority,
+        rustbgpd_api::peer_types::PeerReconcileAuthority::Known
+    );
+    assert_eq!(
+        result.effects,
+        vec![rustbgpd_api::peer_types::PeerReconcileEffect::Replaced(
+            key(addr)
+        )]
+    );
     assert_eq!(counters.shutdown.load(Ordering::SeqCst), 1);
     let managed = mgr.peers.get(&key(addr)).expect("replacement peer");
     assert_ne!(managed.session_id, 1);

--- a/src/peer_manager/tests/policy.rs
+++ b/src/peer_manager/tests/policy.rs
@@ -356,16 +356,20 @@ async fn sync_rpol_policies_rejection_keeps_old_registry_for_live_and_new_sessio
     // Candidate registry renames the policy, so the static peer's
     // `import_policy_chain = ["edge-in"]` no longer resolves: the sync
     // is rejected mid-apply with zero peers touched.
-    mgr.sync_rpol_policies(
-        vec!["policies/core.rpol".to_string()],
-        registry(
-            "edge-in-renamed",
-            "policy edge-in-renamed { term all { set local-pref 250; accept } }",
-        ),
-        rustbgpd_policy::datasets::DatasetBindings::default(),
-    )
-    .await
-    .expect_err("chain resolution failure must reject the sync");
+    let outcome = mgr
+        .sync_rpol_policies_owned(
+            vec!["policies/core.rpol".to_string()],
+            registry(
+                "edge-in-renamed",
+                "policy edge-in-renamed { term all { set local-pref 250; accept } }",
+            ),
+            rustbgpd_policy::datasets::DatasetBindings::default(),
+        )
+        .await;
+    assert!(matches!(
+        outcome,
+        rustbgpd_api::peer_types::OwnedCatalogMutationOutcome::RejectedNoEffect(_)
+    ));
 
     // Existing session: the live chain still evaluates the OLD decision.
     let managed = mgr.peers.values().next().expect("peer present");
@@ -1035,6 +1039,41 @@ async fn owned_policy_change_fences_when_failing_peer_cannot_restore() {
             .contains_key("edge-import"),
         "a failed catalog mutation must not advance current_config"
     );
+}
+
+#[tokio::test]
+async fn owned_rpol_sync_reports_ambiguous_failed_session() {
+    use rustbgpd_policy::rpol::{RpolFile, RpolPolicyEntry, RpolPolicySet};
+
+    let mut mgr = live_policy_test_manager();
+    let peer: IpAddr = "10.0.0.9".parse().unwrap();
+    insert_test_managed_peer(&mut mgr, peer, closed_peer_handle(), false);
+    let mut neighbor = config_neighbor(peer, 65002);
+    neighbor.import_policy_chain = vec!["edge-in".to_string()];
+    mgr.current_config.neighbors = vec![neighbor];
+
+    let file =
+        Arc::new(RpolFile::parse("policy edge-in { term all { accept } }").expect("clean rpol"));
+    let mut rpol = RpolPolicySet::default();
+    rpol.policies.insert(
+        "edge-in".to_string(),
+        RpolPolicyEntry {
+            file,
+            params: 0,
+            path: "policies/core.rpol".to_string(),
+        },
+    );
+    let outcome = mgr
+        .sync_rpol_policies_owned(
+            vec!["policies/core.rpol".to_string()],
+            rpol,
+            rustbgpd_policy::datasets::DatasetBindings::default(),
+        )
+        .await;
+    assert!(matches!(
+        outcome,
+        rustbgpd_api::peer_types::OwnedCatalogMutationOutcome::CompensationAmbiguous(_)
+    ));
 }
 
 #[tokio::test]

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -5,21 +5,26 @@
 //! and ordered peer-manager reconciliation.
 
 use std::collections::BTreeMap;
-use std::fmt::Display;
 use std::net::IpAddr;
-use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Instant;
 
 use rustbgpd_api::peer_types::ConfigPersistCommitOutcome;
 use rustbgpd_api::peer_types::{
     CatalogMutationError, ConfigEvent, ConfigPersistAck, ConfigPersistError, FibTableSnapshot,
-    PeerManagerCommand, PeerManagerNeighborConfig,
+    OwnedCatalogMutation, OwnedCatalogMutationOutcome, OwnedHotUpdatePeerOutcome,
+    PeerManagerCommand, PeerManagerNeighborConfig, PeerReconcileAuthority, PeerReconcileEffect,
 };
 use rustbgpd_policy::PolicyChain;
 use tokio::sync::{mpsc, oneshot, watch};
 use tracing::{error, info, warn};
 
+use rustbgpd_api::gnmi_dialout::DialoutTarget;
+use rustbgpd_api::runtime_config_settlement::{
+    OwnedRuntimeConfigOperation, OwnedRuntimeConfigOutcome, RuntimeConfigFenceReason,
+    RuntimeConfigSettlementPhase,
+};
+use rustbgpd_transport::listener::ReloadDispatch;
 use rustbgpd_transport::{
     TcpAoKeyring, TcpAoListenerGeneration, TcpAoListenerHandle, TcpAoListenerKey,
     TcpAoListenerOwnerKind, TcpAoRotationGeneration, TcpAoRotationOperation, TcpAoRotationPhase,
@@ -28,10 +33,20 @@ use rustbgpd_transport::{
 
 use crate::config::{self, AcceptedConfigSnapshot, Config};
 use crate::config_persister::ConfigMutation;
-use crate::evpn_runtime_converger::EvpnRuntimeReloadApply;
-use crate::fib_runtime::FibRuntimeCommand;
+use crate::evpn_runtime_converger::{EvpnRuntimeReloadApply, EvpnRuntimeReloadTerminal};
+use crate::fib_runtime::{FibRuntimeCommand, OwnedFibReplaceOutcome};
 use crate::peer_manager::InternalCommand;
 use crate::policy_admin::{self, apply_config_event, catalog_config_error};
+
+#[cfg(debug_assertions)]
+fn sighup_ack_fault(point: &str) -> bool {
+    std::env::var("RUSTBGPD_TEST_SIGHUP_ACK_LOSS").is_ok_and(|value| value == point)
+}
+
+#[cfg(not(debug_assertions))]
+fn sighup_ack_fault(_point: &str) -> bool {
+    false
+}
 
 /// Monotonic identity for one outbound prefix-limit transaction. Activation
 /// is idempotent by it, so a retry cannot apply two recovery transitions.
@@ -40,6 +55,22 @@ pub(crate) fn next_outbound_prefix_limit_txn() -> u64 {
 
     static NEXT: AtomicU64 = AtomicU64::new(1);
     NEXT.fetch_add(1, Ordering::Relaxed)
+}
+
+async fn dispatch_rib_step<T, E>(
+    rib_tx: &mpsc::Sender<rustbgpd_rib::RibUpdate>,
+    build: impl FnOnce(oneshot::Sender<Result<T, E>>) -> rustbgpd_rib::RibUpdate,
+) -> ReloadDispatch<Result<T, E>, String> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let permit = match rib_tx.reserve().await {
+        Ok(permit) => permit,
+        Err(error) => return ReloadDispatch::NotAccepted(error.to_string()),
+    };
+    permit.send(build(reply_tx));
+    match reply_rx.await {
+        Ok(result) => ReloadDispatch::Replied(result),
+        Err(_) => ReloadDispatch::AcknowledgementLost,
+    }
 }
 
 /// Preflight `config`'s outbound prefix maxima across every live peer and
@@ -53,18 +84,17 @@ pub(crate) async fn prepare_outbound_prefix_limits(
     txn: u64,
     config: &Config,
 ) -> Result<(), String> {
-    let (reply, rx) = oneshot::channel();
-    rib_tx
-        .send(rustbgpd_rib::RibUpdate::PrepareOutboundPrefixLimits {
+    match dispatch_rib_step(rib_tx, |reply| {
+        rustbgpd_rib::RibUpdate::PrepareOutboundPrefixLimits {
             txn,
             config: config.outbound_prefix_limits(),
             reply,
-        })
-        .await
-        .map_err(|_| "RIB manager unavailable".to_string())?;
-    match rx.await {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(violations)) => Err(format!(
+        }
+    })
+    .await
+    {
+        ReloadDispatch::Replied(Ok(())) => Ok(()),
+        ReloadDispatch::Replied(Err(violations)) => Err(format!(
             "outbound prefix limit rejected: {}",
             violations
                 .iter()
@@ -72,7 +102,10 @@ pub(crate) async fn prepare_outbound_prefix_limits(
                 .collect::<Vec<_>>()
                 .join("; ")
         )),
-        Err(_) => Err("RIB manager dropped the outbound prefix-limit preflight".to_string()),
+        ReloadDispatch::NotAccepted(_) => Err("RIB manager unavailable".to_string()),
+        ReloadDispatch::AcknowledgementLost => {
+            Err("RIB manager dropped the outbound prefix-limit preflight".to_string())
+        }
     }
 }
 
@@ -82,17 +115,21 @@ pub(crate) async fn finish_outbound_prefix_limits(
     txn: u64,
     activate: bool,
 ) -> Result<(), String> {
-    let (reply, rx) = oneshot::channel();
-    rib_tx
-        .send(rustbgpd_rib::RibUpdate::ApplyOutboundPrefixLimits {
+    match dispatch_rib_step(rib_tx, |reply| {
+        rustbgpd_rib::RibUpdate::ApplyOutboundPrefixLimits {
             txn,
             activate,
             reply,
-        })
-        .await
-        .map_err(|_| "RIB manager unavailable".to_string())?;
-    rx.await
-        .map_err(|_| "RIB manager dropped the outbound prefix-limit activation".to_string())?
+        }
+    })
+    .await
+    {
+        ReloadDispatch::NotAccepted(_) => Err("RIB manager unavailable".to_string()),
+        ReloadDispatch::Replied(result) => result,
+        ReloadDispatch::AcknowledgementLost => {
+            Err("RIB manager dropped the outbound prefix-limit activation".to_string())
+        }
+    }
 }
 
 /// Preflight and activate `config`'s outbound prefix maxima as one
@@ -128,6 +165,7 @@ pub(crate) async fn apply_outbound_prefix_limits(
 /// preflight is a no-op by construction; activation would re-install the
 /// identical set. The common rpol-content-only reload therefore never
 /// touches the RIB here.
+#[cfg(test)]
 pub(crate) async fn apply_outbound_prefix_limits_if_changed(
     rib_tx: &mpsc::Sender<rustbgpd_rib::RibUpdate>,
     live: &Config,
@@ -201,8 +239,8 @@ pub(crate) fn build_peer_mgr_config(
 
 /// One reconcile-step failure during a SIGHUP reload, surfaced in
 /// the structured failure log when the new config is rejected.
-#[derive(Debug)]
-struct ReloadStepFailure {
+#[derive(Clone, Debug)]
+pub(crate) struct ReloadStepFailure {
     /// Which delta bucket the command came from
     /// (e.g., `"policy.set"`, `"peer_group.delete"`).
     bucket: &'static str,
@@ -210,7 +248,203 @@ struct ReloadStepFailure {
     /// or neighbor address). Empty for global-chain operations.
     target: String,
     /// Human-readable failure reason.
-    error: String,
+    error: ReloadStepError,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum ReloadStepError {
+    NotAccepted(String),
+    Rejected(String),
+    AcknowledgementLost,
+}
+
+impl From<String> for ReloadStepError {
+    fn from(error: String) -> Self {
+        Self::Rejected(error)
+    }
+}
+
+impl std::fmt::Display for ReloadStepError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotAccepted(error) | Self::Rejected(error) => formatter.write_str(error),
+            Self::AcknowledgementLost => formatter.write_str("acknowledgement lost"),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SighupReloadPlan {
+    pub(crate) baseline_runtime: Config,
+    pub(crate) desired: Arc<AcceptedConfigSnapshot>,
+}
+
+#[derive(Clone)]
+pub(crate) struct SighupAuthority {
+    pub(crate) runtime: Config,
+    pub(crate) desired: Arc<AcceptedConfigSnapshot>,
+    pub(crate) dialout_targets: Vec<DialoutTarget>,
+    pub(crate) completion: SighupCompletion,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum SighupCompletion {
+    Complete,
+    KnownPartial { failures: Vec<ReloadStepFailure> },
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum SighupReloadError {
+    CoordinatorClosed,
+    Failed(ReloadStepFailure),
+}
+
+impl From<rustbgpd_api::server::RuntimeConfigCoordinatorClosed> for SighupReloadError {
+    fn from(_: rustbgpd_api::server::RuntimeConfigCoordinatorClosed) -> Self {
+        Self::CoordinatorClosed
+    }
+}
+
+impl std::fmt::Display for SighupReloadError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CoordinatorClosed => formatter.write_str("runtime config coordinator is closed"),
+            Self::Failed(failure) => write!(
+                formatter,
+                "{} {}: {}",
+                failure.bucket, failure.target, failure.error
+            ),
+        }
+    }
+}
+
+impl SighupReloadError {
+    pub(crate) fn preflight(bucket: &'static str, error: impl Into<String>) -> Self {
+        sighup_error(
+            bucket,
+            String::new(),
+            ReloadStepError::Rejected(error.into()),
+        )
+    }
+
+    pub(crate) fn step(bucket: &'static str, error: ReloadStepError) -> Self {
+        sighup_error(bucket, String::new(), error)
+    }
+}
+
+#[expect(clippy::large_enum_variant, reason = "T288 keeps authority unboxed")]
+pub(crate) enum SighupReloadOutcome {
+    CleanNoEffect(SighupReloadError),
+    Acknowledged(SighupAuthority),
+    RecoveryFenced {
+        error: SighupReloadError,
+        reason: RuntimeConfigFenceReason,
+    },
+}
+
+struct SighupMutationProgress<'a> {
+    operation: Option<&'a OwnedRuntimeConfigOperation>,
+    accepted_effect: bool,
+}
+
+impl<'a> SighupMutationProgress<'a> {
+    fn new(operation: Option<&'a OwnedRuntimeConfigOperation>) -> Self {
+        Self {
+            operation,
+            accepted_effect: false,
+        }
+    }
+
+    fn mark_accepted_effect(&mut self) {
+        if let Some(operation) = self.operation {
+            operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
+        }
+        self.accepted_effect = true;
+    }
+}
+
+#[cfg(test)]
+impl SighupReloadOutcome {
+    fn as_ref(&self) -> Option<&SighupAuthority> {
+        match self {
+            Self::Acknowledged(authority) => Some(authority),
+            Self::CleanNoEffect(_) | Self::RecoveryFenced { .. } => None,
+        }
+    }
+    fn expect(self, message: &str) -> SighupAuthority {
+        match self {
+            Self::Acknowledged(authority) => authority,
+            Self::CleanNoEffect(error) | Self::RecoveryFenced { error, .. } => {
+                panic!("{message}: {error}")
+            }
+        }
+    }
+
+    fn is_some(&self) -> bool {
+        matches!(self, Self::Acknowledged(_))
+    }
+
+    fn is_none(&self) -> bool {
+        matches!(self, Self::CleanNoEffect(_))
+    }
+}
+
+#[cfg(test)]
+impl std::ops::Deref for SighupAuthority {
+    type Target = Config;
+
+    fn deref(&self) -> &Self::Target {
+        &self.runtime
+    }
+}
+
+fn sighup_error(
+    bucket: &'static str,
+    target: impl Into<String>,
+    error: ReloadStepError,
+) -> SighupReloadError {
+    SighupReloadError::Failed(ReloadStepFailure {
+        bucket,
+        target: target.into(),
+        error,
+    })
+}
+
+fn clean_reload_failure(bucket: &'static str, error: impl Into<String>) -> SighupReloadOutcome {
+    SighupReloadOutcome::CleanNoEffect(sighup_error(
+        bucket,
+        String::new(),
+        ReloadStepError::Rejected(error.into()),
+    ))
+}
+
+fn fenced_reload_failure(
+    bucket: &'static str,
+    error: ReloadStepError,
+    reason: RuntimeConfigFenceReason,
+) -> SighupReloadOutcome {
+    SighupReloadOutcome::RecoveryFenced {
+        error: sighup_error(bucket, String::new(), error),
+        reason,
+    }
+}
+
+fn preflight_dispatch_failure(bucket: &'static str, error: ReloadStepError) -> SighupReloadOutcome {
+    SighupReloadOutcome::CleanNoEffect(sighup_error(bucket, String::new(), error))
+}
+
+fn acknowledged_reload(
+    runtime: Config,
+    desired: Arc<AcceptedConfigSnapshot>,
+    dialout_targets: Vec<DialoutTarget>,
+    completion: SighupCompletion,
+) -> SighupReloadOutcome {
+    SighupReloadOutcome::Acknowledged(SighupAuthority {
+        runtime,
+        desired,
+        dialout_targets,
+        completion,
+    })
 }
 
 struct TcpAoRotationPlan {
@@ -583,26 +817,29 @@ fn prepare_tcp_ao_rotation_plan(
 async fn send_tcp_ao_preflight(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     plan: &TcpAoRotationPlan,
-) -> Result<(), String> {
-    send_pm_step(peer_mgr_tx, |reply| {
-        PeerManagerCommand::PreflightTcpAoRotation {
-            generation: plan.generation,
-            operation: plan.operation,
-            listener_keys: plan.listener_keys.clone(),
-            current_listener_keys: plan.current_listener_keys.clone(),
-            static_keyrings: plan.static_keyrings.clone(),
-            current_static_keyrings: plan.current_static_keyrings.clone(),
-            reply,
-        }
-    })
-    .await
+) -> Result<(), ReloadStepError> {
+    step_result(
+        dispatch_peer_step(peer_mgr_tx, |reply| {
+            PeerManagerCommand::PreflightTcpAoRotation {
+                generation: plan.generation,
+                operation: plan.operation,
+                listener_keys: plan.listener_keys.clone(),
+                current_listener_keys: plan.current_listener_keys.clone(),
+                static_keyrings: plan.static_keyrings.clone(),
+                current_static_keyrings: plan.current_static_keyrings.clone(),
+                reply,
+            }
+        })
+        .await,
+    )
 }
 
 async fn send_tcp_ao_apply(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     plan: &TcpAoRotationPlan,
-) -> Result<(), String> {
-    send_pm_step(peer_mgr_tx, |reply| {
+    progress: &mut SighupMutationProgress<'_>,
+) -> Result<(), ReloadStepError> {
+    peer_step(peer_mgr_tx, progress, |reply| {
         PeerManagerCommand::ApplyTcpAoRotation {
             generation: plan.generation,
             operation: plan.operation,
@@ -622,15 +859,17 @@ async fn mark_tcp_ao_failed(
     operation: TcpAoRotationOperation,
     error: String,
 ) {
-    let result = send_pm_step(peer_mgr_tx, |reply| {
-        PeerManagerCommand::MarkTcpAoRotationFailed {
-            generation,
-            operation,
-            error,
-            reply,
-        }
-    })
-    .await;
+    let result = step_result(
+        dispatch_peer_step(peer_mgr_tx, |reply| {
+            PeerManagerCommand::MarkTcpAoRotationFailed {
+                generation,
+                operation,
+                error,
+                reply,
+            }
+        })
+        .await,
+    );
     if let Err(mark_error) = result {
         warn!(%mark_error, "failed to publish TCP-AO rotation failure to peer status");
     }
@@ -656,26 +895,6 @@ fn copy_tcp_ao_runtime_fields(target: &mut Config, source: &Config) {
     }
 }
 
-#[derive(Clone)]
-pub(crate) struct ReloadedConfig {
-    runtime: Config,
-    desired: Arc<AcceptedConfigSnapshot>,
-}
-
-impl ReloadedConfig {
-    fn new(runtime: Config, desired: Arc<AcceptedConfigSnapshot>) -> Self {
-        Self { runtime, desired }
-    }
-}
-
-impl Deref for ReloadedConfig {
-    type Target = Config;
-
-    fn deref(&self) -> &Self::Target {
-        &self.runtime
-    }
-}
-
 fn evpn_runtime_changed(new_config: &Config, current: &Config) -> bool {
     new_config.evpn_instances != current.evpn_instances
         || new_config.evpn_ip_vrfs != current.evpn_ip_vrfs
@@ -690,38 +909,197 @@ fn copy_evpn_runtime_fields(target: &mut Config, source: &Config) {
         .clone_from(&source.ethernet_segments);
 }
 
-async fn send_pm_result_step<E: Display>(
+fn copy_outbound_prefix_limit_fields(target: &mut Config, source: &Config) {
+    for neighbor in &mut target.neighbors {
+        if let Some(desired) = source.neighbors.iter().find(|desired| {
+            desired.address == neighbor.address && desired.interface == neighbor.interface
+        }) {
+            neighbor.max_prefixes_out_ipv4 = desired.max_prefixes_out_ipv4;
+            neighbor.max_prefixes_out_ipv6 = desired.max_prefixes_out_ipv6;
+        }
+    }
+    for (name, group) in &mut target.peer_groups {
+        if let Some(desired) = source.peer_groups.get(name) {
+            group.max_prefixes_out_ipv4 = desired.max_prefixes_out_ipv4;
+            group.max_prefixes_out_ipv6 = desired.max_prefixes_out_ipv6;
+        }
+    }
+}
+
+async fn dispatch_actor_step<T>(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    build: impl FnOnce(oneshot::Sender<T>) -> PeerManagerCommand,
+) -> ReloadDispatch<T, String> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let permit = match peer_mgr_tx.reserve().await {
+        Ok(permit) => permit,
+        Err(error) => return ReloadDispatch::NotAccepted(error.to_string()),
+    };
+    permit.send(build(reply_tx));
+    match reply_rx.await {
+        Ok(result) => ReloadDispatch::Replied(result),
+        Err(_) => ReloadDispatch::AcknowledgementLost,
+    }
+}
+
+async fn dispatch_peer_step<E>(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     build: impl FnOnce(oneshot::Sender<Result<(), E>>) -> PeerManagerCommand,
-) -> Result<(), String> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    if let Err(e) = peer_mgr_tx.send(build(reply_tx)).await {
-        return Err(format!("send to peer manager failed: {e}"));
-    }
-    match reply_rx.await {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(error)) => Err(error.to_string()),
-        Err(e) => Err(format!("peer manager dropped reply: {e}")),
+) -> ReloadDispatch<Result<(), E>, String> {
+    dispatch_actor_step(peer_mgr_tx, build).await
+}
+
+fn step_result<E: std::fmt::Display>(
+    dispatch: ReloadDispatch<Result<(), E>, String>,
+) -> Result<(), ReloadStepError> {
+    match dispatch {
+        ReloadDispatch::NotAccepted(error) => Err(ReloadStepError::NotAccepted(error)),
+        ReloadDispatch::Replied(Ok(())) => Ok(()),
+        ReloadDispatch::Replied(Err(error)) => Err(ReloadStepError::Rejected(error.to_string())),
+        ReloadDispatch::AcknowledgementLost => Err(ReloadStepError::AcknowledgementLost),
     }
 }
 
-/// Send a single `PeerManagerCommand` and await its `Result<(), String>`
-/// reply. Maps both channel-send and dropped-reply errors to a single
-/// `String` so callers can record one structured failure per step.
-async fn send_pm_step(
+async fn peer_step<E: std::fmt::Display>(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    build: impl FnOnce(oneshot::Sender<Result<(), String>>) -> PeerManagerCommand,
-) -> Result<(), String> {
-    send_pm_result_step(peer_mgr_tx, build).await
+    progress: &mut SighupMutationProgress<'_>,
+    build: impl FnOnce(oneshot::Sender<Result<(), E>>) -> PeerManagerCommand,
+) -> Result<(), ReloadStepError> {
+    let dispatch = dispatch_peer_step(peer_mgr_tx, build).await;
+    if !matches!(dispatch, ReloadDispatch::NotAccepted(_)) {
+        progress.mark_accepted_effect();
+    }
+    step_result(dispatch)
 }
 
-/// Send a catalog mutation command and convert its typed error to reload's
-/// existing string-shaped step failure.
-async fn send_catalog_pm_step(
+enum OwnedStepFailure {
+    Partial(ReloadStepError),
+    Fenced {
+        error: ReloadStepError,
+        reason: RuntimeConfigFenceReason,
+    },
+}
+
+async fn catalog_step(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
-    build: impl FnOnce(oneshot::Sender<Result<(), CatalogMutationError>>) -> PeerManagerCommand,
-) -> Result<(), String> {
-    send_pm_result_step(peer_mgr_tx, build).await
+    progress: &mut SighupMutationProgress<'_>,
+    mutation: OwnedCatalogMutation,
+) -> Result<(), OwnedStepFailure> {
+    match dispatch_actor_step(peer_mgr_tx, |reply| {
+        PeerManagerCommand::OwnedCatalogMutation { mutation, reply }
+    })
+    .await
+    {
+        ReloadDispatch::NotAccepted(error) => Err(OwnedStepFailure::Partial(
+            ReloadStepError::NotAccepted(error),
+        )),
+        ReloadDispatch::Replied(OwnedCatalogMutationOutcome::Success) => {
+            progress.mark_accepted_effect();
+            Ok(())
+        }
+        ReloadDispatch::Replied(
+            OwnedCatalogMutationOutcome::RejectedNoEffect(error)
+            | OwnedCatalogMutationOutcome::FullyCompensated(error),
+        ) => Err(OwnedStepFailure::Partial(ReloadStepError::Rejected(
+            error.to_string(),
+        ))),
+        ReloadDispatch::Replied(OwnedCatalogMutationOutcome::CompensationAmbiguous(error)) => {
+            progress.mark_accepted_effect();
+            Err(OwnedStepFailure::Fenced {
+                error: ReloadStepError::Rejected(error.to_string()),
+                reason: RuntimeConfigFenceReason::KnownDivergence,
+            })
+        }
+        ReloadDispatch::AcknowledgementLost => {
+            progress.mark_accepted_effect();
+            Err(OwnedStepFailure::Fenced {
+                error: ReloadStepError::AcknowledgementLost,
+                reason: RuntimeConfigFenceReason::AcknowledgementLost,
+            })
+        }
+    }
+}
+
+fn owned_step_failure(
+    progress: &SighupMutationProgress<'_>,
+    working_config: Config,
+    desired: &Arc<AcceptedConfigSnapshot>,
+    bucket: &'static str,
+    target: String,
+    failure: OwnedStepFailure,
+) -> SighupReloadOutcome {
+    match failure {
+        OwnedStepFailure::Partial(error) => acknowledge_partial(
+            progress,
+            working_config,
+            desired,
+            ReloadStepFailure {
+                bucket,
+                target,
+                error,
+            },
+        ),
+        OwnedStepFailure::Fenced { error, reason } => fenced_reload_failure(bucket, error, reason),
+    }
+}
+
+async fn hot_peer_step(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    progress: &mut SighupMutationProgress<'_>,
+    config: PeerManagerNeighborConfig,
+) -> Result<(), OwnedStepFailure> {
+    match dispatch_actor_step(peer_mgr_tx, |reply| PeerManagerCommand::HotUpdatePeer {
+        config,
+        reply,
+    })
+    .await
+    {
+        ReloadDispatch::NotAccepted(error) => Err(OwnedStepFailure::Partial(
+            ReloadStepError::NotAccepted(error),
+        )),
+        ReloadDispatch::Replied(OwnedHotUpdatePeerOutcome::Success) => {
+            progress.mark_accepted_effect();
+            Ok(())
+        }
+        ReloadDispatch::Replied(OwnedHotUpdatePeerOutcome::RejectedNoEffect(error)) => Err(
+            OwnedStepFailure::Partial(ReloadStepError::Rejected(error.to_string())),
+        ),
+        ReloadDispatch::Replied(OwnedHotUpdatePeerOutcome::KnownDivergence(error)) => {
+            progress.mark_accepted_effect();
+            Err(OwnedStepFailure::Fenced {
+                error: ReloadStepError::Rejected(error.to_string()),
+                reason: RuntimeConfigFenceReason::KnownDivergence,
+            })
+        }
+        ReloadDispatch::AcknowledgementLost => {
+            progress.mark_accepted_effect();
+            Err(OwnedStepFailure::Fenced {
+                error: ReloadStepError::AcknowledgementLost,
+                reason: RuntimeConfigFenceReason::AcknowledgementLost,
+            })
+        }
+    }
+}
+
+fn listener_step<T>(
+    dispatch: ReloadDispatch<std::io::Result<T>, std::io::Error>,
+) -> Result<T, ReloadStepError> {
+    match dispatch {
+        ReloadDispatch::NotAccepted(error) => Err(ReloadStepError::NotAccepted(error.to_string())),
+        ReloadDispatch::Replied(Ok(value)) => Ok(value),
+        ReloadDispatch::Replied(Err(error)) => Err(ReloadStepError::Rejected(error.to_string())),
+        ReloadDispatch::AcknowledgementLost => Err(ReloadStepError::AcknowledgementLost),
+    }
+}
+
+fn listener_mutation_step<T>(
+    dispatch: ReloadDispatch<std::io::Result<T>, std::io::Error>,
+    progress: &mut SighupMutationProgress<'_>,
+) -> Result<T, ReloadStepError> {
+    if !matches!(dispatch, ReloadDispatch::NotAccepted(_)) {
+        progress.mark_accepted_effect();
+    }
+    listener_step(dispatch)
 }
 
 /// Read the peer manager's current runtime config snapshot.
@@ -753,21 +1131,23 @@ pub(crate) async fn runtime_config_snapshot_accepted(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     accepted: &AcceptedConfigSnapshot,
     live_bindings: &rustbgpd_policy::datasets::DatasetBindings,
-) -> Result<Config, String> {
+) -> ReloadDispatch<Result<Config, String>, String> {
     let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(PeerManagerCommand::RuntimeConfigSnapshot { reply: reply_tx })
-        .await
-        .map_err(|e| format!("send to peer manager failed: {e}"))?;
-    let snapshot = reply_rx
-        .await
-        .map_err(|e| format!("peer manager dropped runtime snapshot reply: {e}"))??;
-    accepted.runtime_config_without_sources(
-        &snapshot.toml,
-        &snapshot.rpol_files,
-        snapshot.rpol,
-        live_bindings,
-    )
+    let permit = match peer_mgr_tx.reserve().await {
+        Ok(permit) => permit,
+        Err(error) => return ReloadDispatch::NotAccepted(error.to_string()),
+    };
+    permit.send(PeerManagerCommand::RuntimeConfigSnapshot { reply: reply_tx });
+    match reply_rx.await {
+        Ok(Ok(snapshot)) => ReloadDispatch::Replied(accepted.runtime_config_without_sources(
+            &snapshot.toml,
+            &snapshot.rpol_files,
+            snapshot.rpol,
+            live_bindings,
+        )),
+        Ok(Err(error)) => ReloadDispatch::Replied(Err(error)),
+        Err(_) => ReloadDispatch::AcknowledgementLost,
+    }
 }
 
 /// Reconstruct the transaction-editing document without external-source reads
@@ -837,18 +1217,14 @@ fn take_config_event_ack(event: &mut ConfigEvent) -> Option<ConfigPersistAck> {
 async fn set_pm_fib_tables_snapshot(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     tables: &[config::FibTableConfig],
-) -> Result<(), String> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    peer_mgr_tx
-        .send(PeerManagerCommand::SetFibTablesSnapshot {
+) -> ReloadDispatch<(), String> {
+    dispatch_actor_step(peer_mgr_tx, |reply| {
+        PeerManagerCommand::SetFibTablesSnapshot {
             tables: fib_table_snapshots(tables),
-            reply: reply_tx,
-        })
-        .await
-        .map_err(|e| format!("send to peer manager failed: {e}"))?;
-    reply_rx
-        .await
-        .map_err(|e| format!("peer manager dropped reply: {e}"))
+            reply,
+        }
+    })
+    .await
 }
 
 /// What the bridge should do with its held snapshot after an acknowledged
@@ -994,7 +1370,7 @@ async fn persist_acknowledged(
 /// left to do here.
 pub(crate) struct AcceptedBridgeReplacement {
     snapshot: Arc<AcceptedConfigSnapshot>,
-    adopted: oneshot::Sender<()>,
+    adopted: oneshot::Sender<ReloadDispatch<(), String>>,
 }
 
 #[expect(
@@ -1021,18 +1397,29 @@ pub(crate) async fn run_config_bridge_accepted(
                 match replace {
                     Some(replacement) => {
                         let new_snapshot = replacement.snapshot;
-                        if mutation_tx
-                            .send(ConfigMutation::RefreshSnapshotNoPersist(Arc::clone(
-                                &new_snapshot,
-                            )))
-                            .await
-                            .is_err()
-                        {
+                        let permit = match mutation_tx.reserve().await {
+                            Ok(permit) => permit,
+                            Err(error) => {
+                                let _ = replacement.adopted.send(ReloadDispatch::NotAccepted(error.to_string()));
+                                break;
+                            }
+                        };
+                        let (persister_adopted, persister_adopted_rx) = oneshot::channel();
+                        permit.send(ConfigMutation::AdoptReloadSnapshot {
+                            snapshot: Arc::clone(&new_snapshot),
+                            adopted: persister_adopted,
+                        });
+                        if persister_adopted_rx.await.is_err() {
+                            let _ = replacement.adopted.send(ReloadDispatch::AcknowledgementLost);
                             break;
                         }
                         current = new_snapshot;
                         accepted_tx.send_replace(Arc::clone(&current));
-                        let _ = replacement.adopted.send(());
+                        if sighup_ack_fault("bridge") {
+                            drop(replacement.adopted);
+                            continue;
+                        }
+                        let _ = replacement.adopted.send(ReloadDispatch::Replied(()));
                     }
                     None => bridge_replace_rx_open = false,
                 }
@@ -1159,10 +1546,7 @@ pub(crate) async fn run_config_bridge(
     run_config_bridge_accepted(event_rx, accepted_replace_rx, mutation_tx, accepted_tx).await;
 }
 
-/// Forward a freshly reloaded config to the peer manager and the
-/// config bridge, in that order. Returns the runtime `Config` on success
-/// so the caller can advance its in-memory snapshot in one step
-/// (`config = apply_reload_outcome(...).await?;`).
+/// Acknowledge a freshly reloaded authority across every runtime consumer.
 ///
 /// Order matters. `peer_mgr_internal_tx` is unbounded and can only fail
 /// on receiver-drop (peer manager task is dead — fatal anyway). The
@@ -1188,11 +1572,22 @@ pub(crate) async fn run_config_bridge(
 ///
 /// This remains async because it waits for both the peer-manager snapshot
 /// assignment and the bridge's accepted-snapshot adoption acknowledgements.
-pub(crate) async fn apply_reload_outcome(
-    reloaded: ReloadedConfig,
+pub(crate) async fn finalize_sighup_authority(
+    operation: &OwnedRuntimeConfigOperation,
+    authority: SighupAuthority,
     peer_mgr_internal_tx: &mpsc::UnboundedSender<InternalCommand>,
-    bridge_replace_tx: Option<&mpsc::UnboundedSender<AcceptedBridgeReplacement>>,
-) -> Result<Config, &'static str> {
+    bridge_replace_tx: &mpsc::UnboundedSender<AcceptedBridgeReplacement>,
+    dialout_manager: &Arc<tokio::sync::Mutex<rustbgpd_api::gnmi_dialout::DialoutManager>>,
+) -> OwnedRuntimeConfigOutcome<SighupAuthority, SighupReloadError> {
+    operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
+    let fenced = |bucket, reason, fence_reason| OwnedRuntimeConfigOutcome::Fenced {
+        error: SighupReloadError::Failed(ReloadStepFailure {
+            bucket,
+            target: String::new(),
+            error: reason,
+        }),
+        reason: fence_reason,
+    };
     // Acknowledge the snapshot so the caller (holding the FIB coordinator lock)
     // doesn't release the lock until the peer manager has actually assigned
     // `current_config`. Otherwise a following gRPC FIB-table CRUD could enqueue
@@ -1201,27 +1596,53 @@ pub(crate) async fn apply_reload_outcome(
     let (ack_tx, ack_rx) = oneshot::channel();
     if peer_mgr_internal_tx
         .send(InternalCommand::ReplaceConfigSnapshot {
-            config: Box::new(reloaded.runtime.clone()),
+            config: Box::new(authority.runtime.clone()),
             ack: Some(ack_tx),
         })
         .is_err()
     {
-        return Err("peer_mgr_snapshot");
+        return fenced(
+            "peer_mgr_snapshot",
+            ReloadStepError::NotAccepted("peer manager snapshot command was not accepted".into()),
+            RuntimeConfigFenceReason::KnownDivergence,
+        );
     }
     if ack_rx.await.is_err() {
-        return Err("peer_mgr_snapshot");
+        return fenced(
+            "peer_mgr_snapshot",
+            ReloadStepError::AcknowledgementLost,
+            RuntimeConfigFenceReason::AcknowledgementLost,
+        );
     }
-    if let Some(tx) = bridge_replace_tx {
-        let (adopted, adopted_rx) = oneshot::channel();
-        if tx
-            .send(AcceptedBridgeReplacement {
-                snapshot: Arc::clone(&reloaded.desired),
-                adopted,
-            })
-            .is_err()
-            || adopted_rx.await.is_err()
-        {
-            return Err("config_bridge");
+    let (adopted, adopted_rx) = oneshot::channel();
+    if bridge_replace_tx
+        .send(AcceptedBridgeReplacement {
+            snapshot: Arc::clone(&authority.desired),
+            adopted,
+        })
+        .is_err()
+    {
+        return fenced(
+            "config_bridge",
+            ReloadStepError::NotAccepted("config bridge adoption was not accepted".into()),
+            RuntimeConfigFenceReason::KnownDivergence,
+        );
+    }
+    match adopted_rx.await {
+        Ok(ReloadDispatch::Replied(())) => {}
+        Ok(ReloadDispatch::NotAccepted(error)) => {
+            return fenced(
+                "config_persister",
+                ReloadStepError::NotAccepted(error),
+                RuntimeConfigFenceReason::KnownDivergence,
+            );
+        }
+        Ok(ReloadDispatch::AcknowledgementLost) | Err(_) => {
+            return fenced(
+                "config_bridge",
+                ReloadStepError::AcknowledgementLost,
+                RuntimeConfigFenceReason::AcknowledgementLost,
+            );
         }
     }
 
@@ -1234,15 +1655,23 @@ pub(crate) async fn apply_reload_outcome(
     // full filter (RUST_LOG base + all per-peer directives), so the global
     // base level always survives. Reapplying identical directives is a
     // no-op; a malformed directive leaves the live filter untouched. A
-    // failure here is non-fatal — the config is already committed — so warn
-    // rather than unwind the reload.
+    // failure here leaves the adopted config and tracing projection divergent,
+    // so the owner fences rather than claiming acknowledged authority.
     if let Err(error) =
-        rustbgpd_telemetry::reload_per_peer_directives(&reloaded.desired.per_peer_log_directives())
+        rustbgpd_telemetry::reload_per_peer_directives(&authority.desired.per_peer_log_directives())
     {
-        warn!(error = %error, "failed to re-apply per-peer log_level filter on config reload");
+        return fenced(
+            "peer_tracing",
+            ReloadStepError::Rejected(error.to_string()),
+            RuntimeConfigFenceReason::KnownDivergence,
+        );
     }
 
-    Ok(reloaded.runtime)
+    dialout_manager
+        .lock()
+        .await
+        .apply(&authority.dialout_targets);
+    OwnedRuntimeConfigOutcome::AcknowledgedAuthority(authority)
 }
 
 /// Reload configuration from disk and reconcile runtime state.
@@ -1344,7 +1773,7 @@ pub(crate) async fn reload_config(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     fib_cmd_tx: Option<&mpsc::Sender<FibRuntimeCommand>>,
     evpn_runtime_apply: Option<&EvpnRuntimeReloadApply>,
-) -> Option<ReloadedConfig> {
+) -> SighupReloadOutcome {
     let config_path = std::path::Path::new(config_path);
     let source = std::fs::read_to_string(config_path).unwrap();
     write_tier_test_config(config_path, &source);
@@ -1355,16 +1784,20 @@ pub(crate) async fn reload_config(
             &prior,
             &current.policy.dataset_bindings,
         )
-        .ok()?,
+        .expect("test reload config must parse"),
     );
     reload_config_with_tcp_ao(
-        desired,
-        current,
+        SighupReloadPlan {
+            baseline_runtime: current.clone(),
+            desired,
+        },
         live_grpc_tcp,
         live_grpc_uds,
         peer_mgr_tx,
+        None,
         fib_cmd_tx,
         evpn_runtime_apply,
+        None,
         None,
     )
     .await
@@ -1376,15 +1809,19 @@ pub(crate) async fn reload_config(
     reason = "reload threads live subsystem handles, ordered reconciliation, and failure aggregation through one transaction coordinator"
 )]
 pub(crate) async fn reload_config_with_tcp_ao(
-    desired_snapshot: Arc<AcceptedConfigSnapshot>,
-    current: &Config,
+    plan: SighupReloadPlan,
     live_grpc_tcp: Option<&config::GrpcTcpListenerConfig>,
     live_grpc_uds: Option<&config::GrpcUdsListenerConfig>,
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    rib_tx: Option<&mpsc::Sender<rustbgpd_rib::RibUpdate>>,
     fib_cmd_tx: Option<&mpsc::Sender<FibRuntimeCommand>>,
     evpn_runtime_apply: Option<&EvpnRuntimeReloadApply>,
     tcp_ao_listener: Option<&TcpAoListenerHandle>,
-) -> Option<ReloadedConfig> {
+    operation: Option<&OwnedRuntimeConfigOperation>,
+) -> SighupReloadOutcome {
+    let current = &plan.baseline_runtime;
+    let desired_snapshot = plan.desired;
+    let mut progress = SighupMutationProgress::new(operation);
     // LAN-305: parse dataset contents against the running binding schema, but
     // stage changed data and refresh errors on detached candidate handles.
     // Shared live handles are committed only after the complete no-side-effect
@@ -1465,7 +1902,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             Ok(plan) => plan,
             Err(error) => {
                 error!(%error, "failed to compile TCP-AO rotation generation");
-                return None;
+                return clean_reload_failure("tcp_ao.plan", error);
             }
         }
     } else {
@@ -1486,7 +1923,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
         });
         if retained {
             error!(%reason, "TCP-AO reload changed a retained immutable generation; halting before unrelated reload work");
-            return None;
+            return clean_reload_failure("tcp_ao.plan", reason.clone());
         }
         error!(%reason, "TCP-AO reload is outside the ordered live-rotation phases; retaining restart-pinned runtime inventory");
     }
@@ -1537,8 +1974,13 @@ pub(crate) async fn reload_config_with_tcp_ao(
             error = %error,
             "reload pinning produced an invalid runtime configuration; refusing reload before any runtime actor mutation. Restart rustbgpd to change TCP-AO authentication boundaries"
         );
-        return None;
+        return clean_reload_failure("reload.validate", error.to_string());
     }
+
+    let dialout_targets = match config::gnmi_dialout_targets(&new_config) {
+        Ok(targets) => targets,
+        Err(error) => return clean_reload_failure("gnmi_dialout.plan", error),
+    };
 
     // TCP-AO rotation is the first fallible external apply. The
     // complete pinned candidate is valid now; preflight every managed session,
@@ -1559,7 +2001,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 listener.preflight_delete(desired_listener.clone()).await
             }
         };
-        if let Err(error) = listener_preflight {
+        if let Err(error) = listener_step(listener_preflight) {
             mark_tcp_ao_failed(
                 peer_mgr_tx,
                 plan.generation,
@@ -1568,18 +2010,18 @@ pub(crate) async fn reload_config_with_tcp_ao(
             )
             .await;
             error!(error = %error, "TCP-AO generation rejected during complete listener kernel preflight");
-            return None;
+            return preflight_dispatch_failure("tcp_ao.listener_preflight", error);
         }
         if let Err(error) = send_tcp_ao_preflight(peer_mgr_tx, plan).await {
             error!(error = %error, "TCP-AO generation rejected during global session preflight");
-            return None;
+            return preflight_dispatch_failure("tcp_ao.peer_preflight", error);
         }
         let listener_apply = match plan.operation {
             TcpAoRotationOperation::AddOnly => listener.apply_add_only(desired_listener).await,
             TcpAoRotationOperation::Selection => listener.begin_selection(desired_listener).await,
             TcpAoRotationOperation::Delete => listener.apply_delete(desired_listener).await,
         };
-        if let Err(error) = listener_apply {
+        if let Err(error) = listener_mutation_step(listener_apply, &mut progress) {
             mark_tcp_ao_failed(
                 peer_mgr_tx,
                 plan.generation,
@@ -1588,32 +2030,48 @@ pub(crate) async fn reload_config_with_tcp_ao(
             )
             .await;
             error!(error = %error, "TCP-AO generation failed on listener; retry the identical generation unless the error reports failed exact prior-inventory restoration, in which case restart rustbgpd");
-            return None;
+            let reason = if matches!(error, ReloadStepError::AcknowledgementLost) {
+                RuntimeConfigFenceReason::AcknowledgementLost
+            } else {
+                RuntimeConfigFenceReason::KnownDivergence
+            };
+            return fenced_reload_failure("tcp_ao.listener_apply", error, reason);
         }
-        if let Err(error) = send_tcp_ao_apply(peer_mgr_tx, plan).await {
+        if let Err(error) = send_tcp_ao_apply(peer_mgr_tx, plan, &mut progress).await {
             if plan.operation == TcpAoRotationOperation::Selection
-                && error.starts_with(crate::peer_manager::TCP_AO_AWAITING_PEER_PREFIX)
+                && matches!(&error, ReloadStepError::Rejected(message) if message.starts_with(crate::peer_manager::TCP_AO_AWAITING_PEER_PREFIX))
             {
-                if let Err(marker_error) = listener
-                    .mark_awaiting_peer(plan.generation, error.clone())
-                    .await
-                {
+                if let Err(marker_error) = listener_step(
+                    listener
+                        .mark_awaiting_peer(plan.generation, error.to_string())
+                        .await,
+                ) {
                     warn!(error = %marker_error, "TCP-AO listener awaiting-peer marker was not acknowledged");
                 }
                 info!(error = %error, generation = plan.generation.as_u64(), "TCP-AO successor selected; peer-use observation remains pending until a later identical SIGHUP");
-                return None;
+                return fenced_reload_failure(
+                    "tcp_ao.awaiting_peer",
+                    error,
+                    RuntimeConfigFenceReason::KnownDivergence,
+                );
             }
-            if let Err(marker_error) = listener
-                .mark_dependent_failure(plan.generation, error.clone())
-                .await
-            {
+            if let Err(marker_error) = listener_step(
+                listener
+                    .mark_dependent_failure(plan.generation, error.to_string())
+                    .await,
+            ) {
                 warn!(error = %marker_error, "TCP-AO listener dependent-failure marker was not acknowledged; staged generation remains globally uncommitted");
             }
             error!(error = %error, "TCP-AO generation failed on an established session; listener accepts remain generation-fenced until retry");
-            return None;
+            let reason = if matches!(error, ReloadStepError::AcknowledgementLost) {
+                RuntimeConfigFenceReason::AcknowledgementLost
+            } else {
+                RuntimeConfigFenceReason::KnownDivergence
+            };
+            return fenced_reload_failure("tcp_ao.peer_apply", error, reason);
         }
         if plan.operation == TcpAoRotationOperation::Selection
-            && let Err(error) = listener.finalize_selection(plan.generation).await
+            && let Err(error) = listener_step(listener.finalize_selection(plan.generation).await)
         {
             mark_tcp_ao_failed(
                 peer_mgr_tx,
@@ -1623,9 +2081,15 @@ pub(crate) async fn reload_config_with_tcp_ao(
             )
             .await;
             error!(error = %error, "TCP-AO session cohort observed successor use, but listener metadata commit failed; retrying the identical generation is required");
-            return None;
+            let reason = if matches!(error, ReloadStepError::AcknowledgementLost) {
+                RuntimeConfigFenceReason::AcknowledgementLost
+            } else {
+                RuntimeConfigFenceReason::KnownDivergence
+            };
+            return fenced_reload_failure("tcp_ao.listener_finalize", error, reason);
         }
-        if let Err(error) = listener.acknowledge_global_commit(plan.generation).await {
+        if let Err(error) = listener_step(listener.acknowledge_global_commit(plan.generation).await)
+        {
             mark_tcp_ao_failed(
                 peer_mgr_tx,
                 plan.generation,
@@ -1634,7 +2098,12 @@ pub(crate) async fn reload_config_with_tcp_ao(
             )
             .await;
             error!(error = %error, "TCP-AO generation reached sessions but listener global commit acknowledgement failed; retrying the same immutable generation is required");
-            return None;
+            let reason = if matches!(error, ReloadStepError::AcknowledgementLost) {
+                RuntimeConfigFenceReason::AcknowledgementLost
+            } else {
+                RuntimeConfigFenceReason::KnownDivergence
+            };
+            return fenced_reload_failure("tcp_ao.listener_commit", error, reason);
         }
         tcp_ao_rotation_applied = true;
         info!(
@@ -1655,25 +2124,33 @@ pub(crate) async fn reload_config_with_tcp_ao(
             Ok(inventory) => inventory,
             Err(error) => {
                 error!(%error, "failed to compute the live listener inbound-auth inventory");
-                return None;
+                return clean_reload_failure("listener_auth.plan", error);
             }
         };
         let desired_inventory = match listener_inbound_auth_inventory(&new_config) {
             Ok(inventory) => inventory,
             Err(error) => {
                 error!(%error, "failed to compute the desired listener inbound-auth inventory");
-                return None;
+                return clean_reload_failure("listener_auth.plan", error);
             }
         };
         if current_inventory != desired_inventory {
             let (md5_keys, ttl_security) = desired_inventory;
-            if let Err(error) = listener.replace_inbound_auth(md5_keys, ttl_security).await {
+            if let Err(error) = listener_mutation_step(
+                listener.replace_inbound_auth(md5_keys, ttl_security).await,
+                &mut progress,
+            ) {
                 error!(
                     error = %error,
                     "listener inbound MD5/GTSM inventory replacement failed; \
                      refusing reload (retrying the identical reload converges)"
                 );
-                return None;
+                let reason = if matches!(error, ReloadStepError::AcknowledgementLost) {
+                    RuntimeConfigFenceReason::AcknowledgementLost
+                } else {
+                    RuntimeConfigFenceReason::KnownDivergence
+                };
+                return fenced_reload_failure("listener_auth.apply", error, reason);
             }
             info!("listener inbound MD5/GTSM inventory replaced");
         }
@@ -1688,16 +2165,17 @@ pub(crate) async fn reload_config_with_tcp_ao(
         let attempt = apply
             .apply_config_if_changed(&new_config, evpn_runtime_changed)
             .await;
-        match attempt.result {
-            Ok(Some(result)) => {
+        match attempt.terminal {
+            EvpnRuntimeReloadTerminal::Applied(result) => {
+                progress.mark_accepted_effect();
                 info!(
                     outcome = ?result.outcome,
                     message = %result.message,
                     "reload: EVPN runtime model hot-applied through ADR-0063 coordinator"
                 );
             }
-            Ok(None) => {}
-            Err(error) => {
+            EvpnRuntimeReloadTerminal::Unchanged => {}
+            EvpnRuntimeReloadTerminal::RejectedNoEffect(error) => {
                 error!(
                     error = ?error,
                     "reload: EVPN runtime model differs but the ADR-0063 coordinator \
@@ -1706,6 +2184,31 @@ pub(crate) async fn reload_config_with_tcp_ao(
                      restart-required EVPN identity changes."
                 );
                 copy_evpn_runtime_fields(&mut new_config, &attempt.baseline);
+            }
+            EvpnRuntimeReloadTerminal::KnownPartial(error)
+            | EvpnRuntimeReloadTerminal::KnownDivergence(error) => {
+                error!(
+                    error = ?error,
+                    "reload: EVPN runtime apply changed or degraded coordinator authority; \
+                     fencing before later reload mutations"
+                );
+                return fenced_reload_failure(
+                    "evpn_runtime.apply",
+                    ReloadStepError::Rejected(format!("{error:?}")),
+                    RuntimeConfigFenceReason::KnownDivergence,
+                );
+            }
+            EvpnRuntimeReloadTerminal::PublicationAmbiguous(error) => {
+                error!(
+                    error = ?error,
+                    "reload: EVPN runtime apply publication is ambiguous; \
+                     fencing before later reload mutations"
+                );
+                return fenced_reload_failure(
+                    "evpn_runtime.apply",
+                    ReloadStepError::Rejected(format!("{error:?}")),
+                    RuntimeConfigFenceReason::PublicationAmbiguous,
+                );
             }
         }
     } else if evpn_runtime_changed(&new_config, current) {
@@ -1859,7 +2362,12 @@ pub(crate) async fn reload_config_with_tcp_ao(
         } else {
             info!("config reloaded — no neighbor / policy / peer-group changes detected");
         }
-        return Some(ReloadedConfig::new(new_config, desired_snapshot));
+        return acknowledged_reload(
+            new_config,
+            desired_snapshot,
+            dialout_targets,
+            SighupCompletion::Complete,
+        );
     }
 
     if explain_changed {
@@ -1870,19 +2378,10 @@ pub(crate) async fn reload_config_with_tcp_ao(
         );
     }
 
-    // working_config is the honest snapshot of runtime state. We
-    // start from `current` and apply each ConfigEvent locally as the
-    // matching peer-manager command succeeds. On any failure we
-    // halt and return Some(working_config) — the caller's in-memory
-    // config then matches what's actually live on the peer manager,
-    // instead of pretending the prior config is in effect when half
-    // of it has already been mutated. Returning the partial state is
-    // honest at the cost of leaving the operator with a half-applied
-    // reload; they re-edit the failing TOML and reload again to
-    // converge. Captured under "SIGHUP reconcile is not transactional"
-    // in KNOWN_ISSUES — this fix moves the snapshot from "lying about
-    // prior state" to "matching live state", which is the practical
-    // step short of true rollback.
+    // `working_config` is the authoritative runtime projection. Each
+    // acknowledged actor effect advances it. A known failure returns that
+    // explicit known-partial authority for composite finalization; a lost
+    // acknowledgement or non-authoritative reconcile fences instead.
     let mut working_config = current.clone();
     if tcp_ao_rotation_applied {
         copy_tcp_ao_runtime_fields(&mut working_config, &new_config);
@@ -1899,8 +2398,78 @@ pub(crate) async fn reload_config_with_tcp_ao(
         .clone_from(&desired_config.file_path);
     // EVPN runtime edits are applied before the staged peer-manager/FIB
     // sequence. Carry their accepted-or-pinned state into partial snapshots
-    // returned by halt_partial paths.
+    // returned by authoritative partial receipts.
     copy_evpn_runtime_fields(&mut working_config, &new_config);
+
+    if let Some(rib_tx) = rib_tx
+        && current.outbound_prefix_limits() != new_config.outbound_prefix_limits()
+    {
+        let txn = next_outbound_prefix_limit_txn();
+        let preparation = dispatch_rib_step(rib_tx, |reply| {
+            rustbgpd_rib::RibUpdate::PrepareOutboundPrefixLimits {
+                txn,
+                config: new_config.outbound_prefix_limits(),
+                reply,
+            }
+        })
+        .await;
+        let preparation = match preparation {
+            ReloadDispatch::NotAccepted(error) => Err(ReloadStepError::NotAccepted(error)),
+            ReloadDispatch::Replied(Ok(())) => Ok(()),
+            ReloadDispatch::Replied(Err(violations)) => Err(ReloadStepError::Rejected(format!(
+                "outbound prefix limit rejected: {}",
+                violations
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            ))),
+            ReloadDispatch::AcknowledgementLost => Err(ReloadStepError::AcknowledgementLost),
+        };
+        if let Err(error) = preparation {
+            return acknowledge_partial(
+                &progress,
+                working_config,
+                &desired_snapshot,
+                ReloadStepFailure {
+                    bucket: "prefix_limit.prepare",
+                    target: String::new(),
+                    error,
+                },
+            );
+        }
+
+        let activation = dispatch_rib_step(rib_tx, |reply| {
+            rustbgpd_rib::RibUpdate::ApplyOutboundPrefixLimits {
+                txn,
+                activate: true,
+                reply,
+            }
+        })
+        .await;
+        let activation = match activation {
+            ReloadDispatch::NotAccepted(error) => Err(ReloadStepError::NotAccepted(error)),
+            ReloadDispatch::Replied(Ok(())) => {
+                progress.mark_accepted_effect();
+                Ok(())
+            }
+            ReloadDispatch::Replied(Err(error)) => Err(ReloadStepError::Rejected(error)),
+            ReloadDispatch::AcknowledgementLost => Err(ReloadStepError::AcknowledgementLost),
+        };
+        if let Err(error) = activation {
+            return acknowledge_partial(
+                &progress,
+                working_config,
+                &desired_snapshot,
+                ReloadStepFailure {
+                    bucket: "prefix_limit.activate",
+                    target: String::new(),
+                    error,
+                },
+            );
+        }
+        copy_outbound_prefix_limit_fields(&mut working_config, &new_config);
+    }
 
     // `[[dynamic_neighbors]]` edits are applied by the peer manager's
     // accept-matcher rebuild when the returned snapshot is swapped in
@@ -1930,41 +2499,55 @@ pub(crate) async fn reload_config_with_tcp_ao(
     // explicitly. Safe: no ConfigEvent mutates `policy.explain`, and the
     // explain-only reload already returns `new_config` directly above.
     if explain_changed {
-        working_config.policy.explain = new_config.policy.explain.clone();
-        working_config.policy.reject_retention = new_config.policy.reject_retention.clone();
-
         // Push the new explain snapshot to the peer manager *before* any
         // reconcile step below constructs a session. `build_transport_config`
         // reads `[policy.explain]` from the peer manager's `current_config`,
-        // which is otherwise replaced only after this whole reload completes
-        // (`apply_reload_outcome`). Without this, a peer re-added by a
+        // which is otherwise replaced only after this whole reload completes.
+        // Without this, a peer re-added by a
         // neighbor reconcile or peer-group change in *this same* reload would
         // be built with the stale explain settings. Sent on the same FIFO
         // command channel and awaited, so it is applied before every
-        // subsequent step. A send failure means the peer manager is gone —
-        // halt with the honest partial snapshot like any other step.
-        let (ack_tx, ack_rx) = oneshot::channel();
-        if peer_mgr_tx
-            .send(PeerManagerCommand::SyncExplainConfig {
+        // subsequent step. A send failure means the peer manager is gone and
+        // returns the authority accumulated before this step.
+        let outcome =
+            dispatch_actor_step(peer_mgr_tx, |reply| PeerManagerCommand::SyncExplainConfig {
                 enabled: new_config.policy.explain.enabled,
                 cache_size: new_config.policy.explain.cache_size,
                 reject_retention_enabled: new_config.policy.reject_retention.enabled,
                 reject_retention_capacity: new_config.policy.reject_retention.capacity,
-                reply: ack_tx,
+                reply,
             })
-            .await
-            .is_err()
-            || ack_rx.await.is_err()
-        {
-            return halt_partial(
-                working_config,
-                &desired_snapshot,
-                ReloadStepFailure {
-                    bucket: "policy.explain.sync",
-                    target: "[policy.explain]".to_string(),
-                    error: "peer manager unavailable while syncing explain snapshot".to_string(),
-                },
-            );
+            .await;
+        match outcome {
+            ReloadDispatch::Replied(()) => {
+                progress.mark_accepted_effect();
+                working_config.policy.explain = new_config.policy.explain.clone();
+                working_config.policy.reject_retention = new_config.policy.reject_retention.clone();
+            }
+            ReloadDispatch::NotAccepted(error) => {
+                return acknowledge_partial(
+                    &progress,
+                    working_config,
+                    &desired_snapshot,
+                    ReloadStepFailure {
+                        bucket: "policy.explain.sync",
+                        target: "[policy.explain]".to_string(),
+                        error: ReloadStepError::NotAccepted(error),
+                    },
+                );
+            }
+            ReloadDispatch::AcknowledgementLost => {
+                return acknowledge_partial(
+                    &progress,
+                    working_config,
+                    &desired_snapshot,
+                    ReloadStepFailure {
+                        bucket: "policy.explain.sync",
+                        target: "[policy.explain]".to_string(),
+                        error: ReloadStepError::AcknowledgementLost,
+                    },
+                );
+            }
         }
     }
 
@@ -1980,7 +2563,6 @@ pub(crate) async fn reload_config_with_tcp_ao(
         // LAN-888: stamp the registry-clone cost and the dispatch moment.
         // The gap between this line and the peer manager's receipt log is
         // pure command-channel queue wait — the only piece of the
-        // SIGHUP→snapshot window no other span can see.
         let clone_started = Instant::now();
         let rpol_files = new_config.policy.rpol_files.clone();
         let rpol = new_config.policy.rpol.clone();
@@ -1989,25 +2571,16 @@ pub(crate) async fn reload_config_with_tcp_ao(
             clone_ms = u64::try_from(clone_started.elapsed().as_millis()).unwrap_or(u64::MAX),
             "rpol policy sync dispatched"
         );
-        let (ack_tx, ack_rx) = oneshot::channel();
-        let send_failed = peer_mgr_tx
-            .send(PeerManagerCommand::SyncRpolPolicies {
+        let result = catalog_step(
+            peer_mgr_tx,
+            &mut progress,
+            OwnedCatalogMutation::SyncRpolPolicies {
                 rpol_files,
                 rpol,
                 dataset_bindings,
-                reply: ack_tx,
-            })
-            .await
-            .is_err();
-        let result = if send_failed {
-            Err("peer manager unavailable while syncing rpol policies".to_string())
-        } else {
-            match ack_rx.await {
-                Ok(Ok(())) => Ok(()),
-                Ok(Err(error)) => Err(error.to_string()),
-                Err(_) => Err("peer manager dropped rpol sync reply".to_string()),
-            }
-        };
+            },
+        )
+        .await;
         match result {
             // LAN-284: adopt the candidate registry into the runtime
             // snapshot ONLY after the peer manager committed it. The
@@ -2015,7 +2588,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             // its `current_config` and every live chain on the old
             // registry), so absorbing the candidate before the ack
             // would ship the REJECTED registry to the runtime snapshot
-            // via halt_partial → ReplaceConfigSnapshot — new sessions
+            // via the authoritative partial receipt — new sessions
             // would then resolve against a registry no live session
             // runs. On failure the candidate survives only as on-disk
             // `.rpol` intent; the next successful reload adopts it.
@@ -2027,15 +2600,14 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 working_config.policy.rpol = new_config.policy.rpol.clone();
                 info!("reload: rpol policy registry synced");
             }
-            Err(error) => {
-                return halt_partial(
+            Err(failure) => {
+                return owned_step_failure(
+                    &progress,
                     working_config,
                     &desired_snapshot,
-                    ReloadStepFailure {
-                        bucket: "policy.rpol.sync",
-                        target: "[policy] rpol_files".to_string(),
-                        error,
-                    },
+                    "policy.rpol.sync",
+                    "[policy] rpol_files".to_string(),
+                    failure,
                 );
             }
         }
@@ -2044,10 +2616,11 @@ pub(crate) async fn reload_config_with_tcp_ao(
     // LAN-305: this is the first point after preflight where every earlier
     // fallible peer-manager registry/snapshot step has succeeded. Commit the
     // staged contents/errors now, then publish honest snapshot bookkeeping and
-    // dependency-scoped refreshes. A refresh failure is warned, not halted:
-    // an accepted swap is durable, and stale evaluations converge on the next
-    // churn or refresh.
+    // dependency-scoped refreshes. Its acknowledgement is part of the owner.
     dataset_commit.commit();
+    if dataset_commit_pending {
+        progress.mark_accepted_effect();
+    }
     working_config
         .policy
         .datasets
@@ -2055,28 +2628,53 @@ pub(crate) async fn reload_config_with_tcp_ao(
     working_config.policy.dataset_bindings = new_config.policy.dataset_bindings.clone();
     let dataset_events = &new_config.policy.dataset_events;
     if !dataset_events.swapped.is_empty() || !dataset_events.failed.is_empty() {
-        let (ack_tx, ack_rx) = oneshot::channel();
-        let send_failed = peer_mgr_tx
-            .send(PeerManagerCommand::RefreshDatasetDependents {
+        let outcome = dispatch_actor_step(peer_mgr_tx, |reply| {
+            PeerManagerCommand::RefreshDatasetDependents {
                 swapped: dataset_events.swapped.clone(),
                 failed: dataset_events.failed.clone(),
-                reply: ack_tx,
-            })
-            .await
-            .is_err();
-        let outcome = if send_failed {
-            Err("peer manager unavailable".to_string())
-        } else {
-            match ack_rx.await {
-                Ok(result) => result,
-                Err(_) => Err("peer manager dropped dataset refresh reply".to_string()),
+                reply,
             }
-        };
-        if let Err(error) = outcome {
-            warn!(
-                error = %error,
-                "dataset-swap dependency-scoped refresh incomplete; affected peers converge on next churn or manual refresh"
-            );
+        })
+        .await;
+        match outcome {
+            ReloadDispatch::Replied(Ok(())) => progress.mark_accepted_effect(),
+            ReloadDispatch::NotAccepted(error) => {
+                return acknowledge_partial(
+                    &progress,
+                    working_config,
+                    &desired_snapshot,
+                    ReloadStepFailure {
+                        bucket: "policy.dataset.refresh",
+                        target: "[policy.datasets]".to_string(),
+                        error: ReloadStepError::NotAccepted(error),
+                    },
+                );
+            }
+            ReloadDispatch::Replied(Err(error)) => {
+                return acknowledge_partial(
+                    &progress,
+                    working_config,
+                    &desired_snapshot,
+                    ReloadStepFailure {
+                        bucket: "policy.dataset.refresh",
+                        target: "[policy.datasets]".to_string(),
+                        error: ReloadStepError::Rejected(error),
+                    },
+                );
+            }
+            ReloadDispatch::AcknowledgementLost => {
+                progress.mark_accepted_effect();
+                return acknowledge_partial(
+                    &progress,
+                    working_config,
+                    &desired_snapshot,
+                    ReloadStepFailure {
+                        bucket: "policy.dataset.refresh",
+                        target: "[policy.datasets]".to_string(),
+                        error: ReloadStepError::AcknowledgementLost,
+                    },
+                );
+            }
         }
     }
 
@@ -2096,7 +2694,8 @@ pub(crate) async fn reload_config_with_tcp_ao(
         // diff and the config snapshot disagree — treat as halt.
         let Some(definition) = policy_admin::named_neighbor_set_from_config(&new_config, name)
         else {
-            return halt_partial(
+            return acknowledge_partial(
+                &progress,
                 working_config,
                 &desired_snapshot,
                 ReloadStepFailure {
@@ -2104,7 +2703,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                     target: name.clone(),
                     error: format!(
                         "internal: neighbor_set {name:?} present in diff but not resolvable from new config"
-                    ),
+                    ).into(),
                 },
             );
         };
@@ -2113,17 +2712,20 @@ pub(crate) async fn reload_config_with_tcp_ao(
             definition: definition.clone(),
             ack: None,
         };
-        let cmd_name = name.clone();
-        match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::SetNeighborSet {
-            name: cmd_name,
-            definition,
-            reply,
-        })
+        match catalog_step(
+            peer_mgr_tx,
+            &mut progress,
+            OwnedCatalogMutation::SetNeighborSet {
+                name: name.clone(),
+                definition,
+            },
+        )
         .await
         {
             Ok(()) => {
                 if let Err(error) = apply_config_event(&mut working_config, &event) {
-                    return halt_partial(
+                    return acknowledge_partial(
+                        &progress,
                         working_config,
                         &desired_snapshot,
                         ReloadStepFailure {
@@ -2131,21 +2733,20 @@ pub(crate) async fn reload_config_with_tcp_ao(
                             target: name.clone(),
                             error: format!(
                                 "applied at peer manager but local snapshot rejected the event: {error}"
-                            ),
+                            ).into(),
                         },
                     );
                 }
                 info!(name = %name, %bucket, "reload: neighbor_set applied");
             }
-            Err(error) => {
-                return halt_partial(
+            Err(failure) => {
+                return owned_step_failure(
+                    &progress,
                     working_config,
                     &desired_snapshot,
-                    ReloadStepFailure {
-                        bucket,
-                        target: name.clone(),
-                        error,
-                    },
+                    bucket,
+                    name.clone(),
+                    failure,
                 );
             }
         }
@@ -2163,7 +2764,8 @@ pub(crate) async fn reload_config_with_tcp_ao(
             "policy.change"
         };
         let Some(definition) = policy_admin::named_policy_from_config(&new_config, name) else {
-            return halt_partial(
+            return acknowledge_partial(
+                &progress,
                 working_config,
                 &desired_snapshot,
                 ReloadStepFailure {
@@ -2171,7 +2773,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                     target: name.clone(),
                     error: format!(
                         "internal: policy {name:?} present in diff but not resolvable from new config"
-                    ),
+                    ).into(),
                 },
             );
         };
@@ -2180,17 +2782,20 @@ pub(crate) async fn reload_config_with_tcp_ao(
             definition: definition.clone(),
             ack: None,
         };
-        let cmd_name = name.clone();
-        match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::SetPolicy {
-            name: cmd_name,
-            definition,
-            reply,
-        })
+        match catalog_step(
+            peer_mgr_tx,
+            &mut progress,
+            OwnedCatalogMutation::SetPolicy {
+                name: name.clone(),
+                definition: Box::new(definition),
+            },
+        )
         .await
         {
             Ok(()) => {
                 if let Err(error) = apply_config_event(&mut working_config, &event) {
-                    return halt_partial(
+                    return acknowledge_partial(
+                        &progress,
                         working_config,
                         &desired_snapshot,
                         ReloadStepFailure {
@@ -2198,21 +2803,20 @@ pub(crate) async fn reload_config_with_tcp_ao(
                             target: name.clone(),
                             error: format!(
                                 "applied at peer manager but local snapshot rejected the event: {error}"
-                            ),
+                            ).into(),
                         },
                     );
                 }
                 info!(name = %name, %bucket, "reload: policy applied");
             }
-            Err(error) => {
-                return halt_partial(
+            Err(failure) => {
+                return owned_step_failure(
+                    &progress,
                     working_config,
                     &desired_snapshot,
-                    ReloadStepFailure {
-                        bucket,
-                        target: name.clone(),
-                        error,
-                    },
+                    bucket,
+                    name.clone(),
+                    failure,
                 );
             }
         }
@@ -2230,7 +2834,8 @@ pub(crate) async fn reload_config_with_tcp_ao(
             "peer_group.change"
         };
         let Some(definition) = policy_admin::named_peer_group_from_config(&new_config, name) else {
-            return halt_partial(
+            return acknowledge_partial(
+                &progress,
                 working_config,
                 &desired_snapshot,
                 ReloadStepFailure {
@@ -2238,7 +2843,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                     target: name.clone(),
                     error: format!(
                         "internal: peer_group {name:?} present in diff but not resolvable from new config"
-                    ),
+                    ).into(),
                 },
             );
         };
@@ -2247,17 +2852,20 @@ pub(crate) async fn reload_config_with_tcp_ao(
             definition: definition.clone(),
             ack: None,
         };
-        let cmd_name = name.clone();
-        match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::SetPeerGroup {
-            name: cmd_name,
-            definition,
-            reply,
-        })
+        match catalog_step(
+            peer_mgr_tx,
+            &mut progress,
+            OwnedCatalogMutation::SetPeerGroup {
+                name: name.clone(),
+                definition: Box::new(definition),
+            },
+        )
         .await
         {
             Ok(()) => {
                 if let Err(error) = apply_config_event(&mut working_config, &event) {
-                    return halt_partial(
+                    return acknowledge_partial(
+                        &progress,
                         working_config,
                         &desired_snapshot,
                         ReloadStepFailure {
@@ -2265,21 +2873,20 @@ pub(crate) async fn reload_config_with_tcp_ao(
                             target: name.clone(),
                             error: format!(
                                 "applied at peer manager but local snapshot rejected the event: {error}"
-                            ),
+                            ).into(),
                         },
                     );
                 }
                 info!(name = %name, %bucket, "reload: peer_group applied");
             }
-            Err(error) => {
-                return halt_partial(
+            Err(failure) => {
+                return owned_step_failure(
+                    &progress,
                     working_config,
                     &desired_snapshot,
-                    ReloadStepFailure {
-                        bucket,
-                        target: name.clone(),
-                        error,
-                    },
+                    bucket,
+                    name.clone(),
+                    failure,
                 );
             }
         }
@@ -2298,23 +2905,27 @@ pub(crate) async fn reload_config_with_tcp_ao(
             }
         };
         let res = if chain.is_empty() {
-            send_catalog_pm_step(peer_mgr_tx, |reply| {
-                PeerManagerCommand::ClearGlobalImportChain { reply }
-            })
+            catalog_step(
+                peer_mgr_tx,
+                &mut progress,
+                OwnedCatalogMutation::ClearGlobalImportChain,
+            )
             .await
         } else {
-            send_catalog_pm_step(peer_mgr_tx, |reply| {
-                PeerManagerCommand::SetGlobalImportChain {
+            catalog_step(
+                peer_mgr_tx,
+                &mut progress,
+                OwnedCatalogMutation::SetGlobalImportChain {
                     policy_names: chain,
-                    reply,
-                }
-            })
+                },
+            )
             .await
         };
         match res {
             Ok(()) => {
                 if let Err(error) = apply_config_event(&mut working_config, &event) {
-                    return halt_partial(
+                    return acknowledge_partial(
+                        &progress,
                         working_config,
                         &desired_snapshot,
                         ReloadStepFailure {
@@ -2322,21 +2933,20 @@ pub(crate) async fn reload_config_with_tcp_ao(
                             target: String::new(),
                             error: format!(
                                 "applied at peer manager but local snapshot rejected the event: {error}"
-                            ),
+                            ).into(),
                         },
                     );
                 }
                 info!("reload: global import_chain applied");
             }
-            Err(error) => {
-                return halt_partial(
+            Err(failure) => {
+                return owned_step_failure(
+                    &progress,
                     working_config,
                     &desired_snapshot,
-                    ReloadStepFailure {
-                        bucket: "global_chain.import",
-                        target: String::new(),
-                        error,
-                    },
+                    "global_chain.import",
+                    String::new(),
+                    failure,
                 );
             }
         }
@@ -2352,23 +2962,27 @@ pub(crate) async fn reload_config_with_tcp_ao(
             }
         };
         let res = if chain.is_empty() {
-            send_catalog_pm_step(peer_mgr_tx, |reply| {
-                PeerManagerCommand::ClearGlobalExportChain { reply }
-            })
+            catalog_step(
+                peer_mgr_tx,
+                &mut progress,
+                OwnedCatalogMutation::ClearGlobalExportChain,
+            )
             .await
         } else {
-            send_catalog_pm_step(peer_mgr_tx, |reply| {
-                PeerManagerCommand::SetGlobalExportChain {
+            catalog_step(
+                peer_mgr_tx,
+                &mut progress,
+                OwnedCatalogMutation::SetGlobalExportChain {
                     policy_names: chain,
-                    reply,
-                }
-            })
+                },
+            )
             .await
         };
         match res {
             Ok(()) => {
                 if let Err(error) = apply_config_event(&mut working_config, &event) {
-                    return halt_partial(
+                    return acknowledge_partial(
+                        &progress,
                         working_config,
                         &desired_snapshot,
                         ReloadStepFailure {
@@ -2376,21 +2990,20 @@ pub(crate) async fn reload_config_with_tcp_ao(
                             target: String::new(),
                             error: format!(
                                 "applied at peer manager but local snapshot rejected the event: {error}"
-                            ),
+                            ).into(),
                         },
                     );
                 }
                 info!("reload: global export_chain applied");
             }
-            Err(error) => {
-                return halt_partial(
+            Err(failure) => {
+                return owned_step_failure(
+                    &progress,
                     working_config,
                     &desired_snapshot,
-                    ReloadStepFailure {
-                        bucket: "global_chain.export",
-                        target: String::new(),
-                        error,
-                    },
+                    "global_chain.export",
+                    String::new(),
+                    failure,
                 );
             }
         }
@@ -2454,13 +3067,14 @@ pub(crate) async fn reload_config_with_tcp_ao(
         let peer_configs = match new_config.resolved_neighbors() {
             Ok(p) => p,
             Err(e) => {
-                return halt_partial(
+                return acknowledge_partial(
+                    &progress,
                     working_config,
                     &desired_snapshot,
                     ReloadStepFailure {
                         bucket: "neighbors.resolve",
                         target: "new_config.resolved_neighbors".to_string(),
-                        error: e.to_string(),
+                        error: ReloadStepError::Rejected(e.to_string()),
                     },
                 );
             }
@@ -2511,19 +3125,14 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 );
                 continue;
             };
-            if let Err(error) = send_pm_result_step(peer_mgr_tx, |reply| {
-                PeerManagerCommand::HotUpdatePeer { config: cfg, reply }
-            })
-            .await
-            {
-                return halt_partial(
+            if let Err(failure) = hot_peer_step(peer_mgr_tx, &mut progress, cfg).await {
+                return owned_step_failure(
+                    &progress,
                     working_config,
                     &desired_snapshot,
-                    ReloadStepFailure {
-                        bucket: "neighbors.hot_update",
-                        target: n.address.clone(),
-                        error,
-                    },
+                    "neighbors.hot_update",
+                    n.address.clone(),
+                    failure,
                 );
             }
             if let Some(entry) = working_config
@@ -2540,49 +3149,78 @@ pub(crate) async fn reload_config_with_tcp_ao(
             !diff.added.is_empty() || !diff.removed.is_empty() || !rebuild_changed.is_empty();
         if needs_rebuild_pass {
             let (reply_tx, reply_rx) = oneshot::channel();
-            if let Err(e) = peer_mgr_tx
-                .send(PeerManagerCommand::ReconcilePeers {
-                    added: resolve(&diff.added),
-                    removed: diff.removed.clone(),
-                    changed: resolve(&rebuild_changed),
-                    reply: reply_tx,
-                })
-                .await
-            {
-                return halt_partial(
-                    working_config,
-                    &desired_snapshot,
-                    ReloadStepFailure {
-                        bucket: "neighbors.reconcile",
-                        target: String::new(),
-                        error: format!("send: {e}"),
-                    },
+            let permit = match peer_mgr_tx.reserve().await {
+                Ok(permit) => permit,
+                Err(error) => {
+                    return acknowledge_partial(
+                        &progress,
+                        working_config,
+                        &desired_snapshot,
+                        ReloadStepFailure {
+                            bucket: "neighbors.reconcile",
+                            target: String::new(),
+                            error: ReloadStepError::NotAccepted(error.to_string()),
+                        },
+                    );
+                }
+            };
+            permit.send(PeerManagerCommand::ReconcilePeers {
+                added: resolve(&diff.added),
+                removed: diff.removed.clone(),
+                changed: resolve(&rebuild_changed),
+                reply: reply_tx,
+            });
+            if sighup_ack_fault("reconcile") {
+                drop(reply_rx);
+                return fenced_reload_failure(
+                    "neighbors.reconcile",
+                    ReloadStepError::AcknowledgementLost,
+                    RuntimeConfigFenceReason::AcknowledgementLost,
                 );
             }
             match reply_rx.await {
-                Ok(reconcile) if reconcile.is_success() => {
-                    working_config.neighbors = new_config.neighbors.clone();
-                }
                 Ok(reconcile) => {
-                    // Reconcile is the one step where partial failure
-                    // leaves the live state genuinely ambiguous: it
-                    // sequences delete-then-readd for changed peers,
-                    // independent removes, and adds — any subset can
-                    // succeed before the failure point, the manager
-                    // doesn't update its own `current_config` during the
-                    // run, and `delete_peer` / `add_peer` of the wrong
-                    // ordering can leave orphaned `PeerHandle`s. Returning
-                    // a guessed snapshot here would let the next reload
-                    // diff against state that doesn't match live, which is
-                    // worse than just bailing.
-                    //
-                    // Preserve the last-known neighbor config in the honest
-                    // partial snapshot while retaining every earlier step
-                    // that definitely landed (including dataset generations,
-                    // policy, and EVPN state). The live peer table remains
-                    // explicitly ambiguous either way; discarding the partial
-                    // snapshot would additionally make all known-successful
-                    // state look unapplied and corrupt the next reload's diff.
+                    if reconcile.authority == PeerReconcileAuthority::Diverged {
+                        return fenced_reload_failure(
+                            "neighbors.reconcile",
+                            ReloadStepError::Rejected(
+                                "peer reconcile returned non-authoritative state".into(),
+                            ),
+                            RuntimeConfigFenceReason::KnownDivergence,
+                        );
+                    }
+                    for effect in &reconcile.effects {
+                        progress.mark_accepted_effect();
+                        let key = match effect {
+                            PeerReconcileEffect::Added(key)
+                            | PeerReconcileEffect::Removed(key)
+                            | PeerReconcileEffect::Replaced(key)
+                            | PeerReconcileEffect::RemovedForFailedReplacement(key) => key,
+                        };
+                        working_config.neighbors.retain(|neighbor| {
+                            rustbgpd_api::peer_types::PeerKey::new(
+                                neighbor
+                                    .address
+                                    .parse()
+                                    .expect("validated neighbor address"),
+                                neighbor.interface.clone(),
+                            ) != *key
+                        });
+                        if matches!(
+                            effect,
+                            PeerReconcileEffect::Added(_) | PeerReconcileEffect::Replaced(_)
+                        ) && let Some(neighbor) = new_config.neighbors.iter().find(|neighbor| {
+                            rustbgpd_api::peer_types::PeerKey::new(
+                                neighbor
+                                    .address
+                                    .parse()
+                                    .expect("validated neighbor address"),
+                                neighbor.interface.clone(),
+                            ) == *key
+                        }) {
+                            working_config.neighbors.push(neighbor.clone());
+                        }
+                    }
                     for failure in &reconcile.failures {
                         warn!(
                             bucket = "neighbors.reconcile",
@@ -2592,26 +3230,25 @@ pub(crate) async fn reload_config_with_tcp_ao(
                             "config reload step failed"
                         );
                     }
-                    error!(
-                        failures = reconcile.failures.len(),
-                        "config reload halted at neighbor reconcile — live peer-manager state \
-                     may differ from the in-memory config snapshot. Inspect live state via \
-                     `rbgp neighbor list` and re-edit the failing TOML before \
-                     reloading again. Earlier reload steps (policy / peer-group / chain \
-                     edits) DID land at the manager and remain in effect."
-                    );
-                    return Some(ReloadedConfig::new(working_config, desired_snapshot));
+                    if let Some(failure) = reconcile.failures.first() {
+                        return acknowledge_partial(
+                            &progress,
+                            working_config,
+                            &desired_snapshot,
+                            ReloadStepFailure {
+                                bucket: "neighbors.reconcile",
+                                target: failure.peer.to_string(),
+                                error: ReloadStepError::Rejected(failure.error.clone()),
+                            },
+                        );
+                    }
                 }
-                Err(e) => {
-                    error!(
-                        error = %e,
-                        "config reload halted: peer manager dropped reconcile reply — live \
-                         state may differ from the in-memory config snapshot. Inspect via \
-                         `rbgp neighbor list` before reloading again. Earlier reload \
-                         steps (policy / peer-group / chain edits) DID land at the manager \
-                         and remain in effect."
+                Err(_) => {
+                    return fenced_reload_failure(
+                        "neighbors.reconcile",
+                        ReloadStepError::AcknowledgementLost,
+                        RuntimeConfigFenceReason::AcknowledgementLost,
                     );
-                    return Some(ReloadedConfig::new(working_config, desired_snapshot));
                 }
             }
         }
@@ -2623,7 +3260,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
     //    same live snapshot the rest of this reload has just shaped.
     if honor_graceful_shutdown_changed {
         let enabled = new_config.global.honor_graceful_shutdown;
-        match send_pm_step(peer_mgr_tx, |reply| {
+        match peer_step(peer_mgr_tx, &mut progress, |reply| {
             PeerManagerCommand::SetHonorGracefulShutdown { enabled, reply }
         })
         .await
@@ -2633,6 +3270,13 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 info!(
                     enabled,
                     "reload: [global] honor_graceful_shutdown hot-applied"
+                );
+            }
+            Err(error @ ReloadStepError::AcknowledgementLost) => {
+                return fenced_reload_failure(
+                    "honor_graceful_shutdown.apply",
+                    error,
+                    RuntimeConfigFenceReason::AcknowledgementLost,
                 );
             }
             Err(error) => {
@@ -2653,7 +3297,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 // `pending_export_apply`).
                 warn!(
                     enabled,
-                    error,
+                    error = %error,
                     "reload: [global] honor_graceful_shutdown partial-apply — snapshot \
                      advanced anyway; bail-and-carry will retry failed peers on next \
                      policy edit"
@@ -2664,9 +3308,8 @@ pub(crate) async fn reload_config_with_tcp_ao(
     }
     if honor_blackhole_changed {
         let enabled = new_config.global.honor_blackhole;
-        match send_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::SetHonorBlackhole {
-            enabled,
-            reply,
+        match peer_step(peer_mgr_tx, &mut progress, |reply| {
+            PeerManagerCommand::SetHonorBlackhole { enabled, reply }
         })
         .await
         {
@@ -2674,10 +3317,17 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 working_config.global.honor_blackhole = enabled;
                 info!(enabled, "reload: [global] honor_blackhole hot-applied");
             }
+            Err(error @ ReloadStepError::AcknowledgementLost) => {
+                return fenced_reload_failure(
+                    "honor_blackhole.apply",
+                    error,
+                    RuntimeConfigFenceReason::AcknowledgementLost,
+                );
+            }
             Err(error) => {
                 warn!(
                     enabled,
-                    error,
+                    error = %error,
                     "reload: [global] honor_blackhole partial-apply — snapshot \
                      advanced anyway; bail-and-carry will retry failed peers on next \
                      policy edit"
@@ -2694,56 +3344,88 @@ pub(crate) async fn reload_config_with_tcp_ao(
         match fib_cmd_tx {
             Some(tx) => {
                 let (reply_tx, reply_rx) = oneshot::channel();
-                match tx
-                    .send(FibRuntimeCommand::ReplaceTables {
-                        tables: new_config.fib_tables.clone(),
-                        reply: reply_tx,
-                    })
-                    .await
-                {
-                    Ok(()) => match reply_rx.await {
-                        Ok(Ok(())) => {
-                            if let Err(error) =
-                                set_pm_fib_tables_snapshot(peer_mgr_tx, &new_config.fib_tables)
-                                    .await
-                            {
-                                working_config.fib_tables.clone_from(&new_config.fib_tables);
-                                return halt_partial(
+                let permit = match tx.reserve().await {
+                    Ok(permit) => permit,
+                    Err(error) => {
+                        return acknowledge_partial(
+                            &progress,
+                            working_config,
+                            &desired_snapshot,
+                            ReloadStepFailure {
+                                bucket: "fib_tables.apply",
+                                target: "[[fib_tables]]".to_string(),
+                                error: ReloadStepError::NotAccepted(error.to_string()),
+                            },
+                        );
+                    }
+                };
+                permit.send(FibRuntimeCommand::OwnedReplaceTables {
+                    tables: new_config.fib_tables.clone(),
+                    reply: reply_tx,
+                });
+                match reply_rx.await {
+                    Ok(OwnedFibReplaceOutcome::Applied) => {
+                        progress.mark_accepted_effect();
+                        working_config.fib_tables.clone_from(&new_config.fib_tables);
+                        match set_pm_fib_tables_snapshot(peer_mgr_tx, &new_config.fib_tables).await
+                        {
+                            ReloadDispatch::Replied(()) => {
+                                progress.mark_accepted_effect();
+                                info!(
+                                    tables = new_config.fib_tables.len(),
+                                    "reload: [[fib_tables]] hot-applied"
+                                );
+                            }
+                            ReloadDispatch::NotAccepted(error) => {
+                                return acknowledge_partial(
+                                    &progress,
                                     working_config,
                                     &desired_snapshot,
                                     ReloadStepFailure {
                                         bucket: "fib_tables.snapshot",
                                         target: "[[fib_tables]]".to_string(),
-                                        error,
+                                        error: ReloadStepError::NotAccepted(error),
                                     },
                                 );
                             }
-                            working_config.fib_tables.clone_from(&new_config.fib_tables);
-                            info!(
-                                tables = new_config.fib_tables.len(),
-                                "reload: [[fib_tables]] hot-applied"
-                            );
+                            ReloadDispatch::AcknowledgementLost => {
+                                return acknowledge_partial(
+                                    &progress,
+                                    working_config,
+                                    &desired_snapshot,
+                                    ReloadStepFailure {
+                                        bucket: "fib_tables.snapshot",
+                                        target: "[[fib_tables]]".to_string(),
+                                        error: ReloadStepError::AcknowledgementLost,
+                                    },
+                                );
+                            }
                         }
-                        Ok(Err(reason)) => {
-                            error!(
-                                %reason,
-                                "reload: FIB runtime could not apply the [[fib_tables]] update \
-                                 (reverted); runtime unchanged"
-                            );
-                        }
-                        Err(error) => {
-                            error!(
-                                %error,
-                                "reload: FIB runtime did not acknowledge the [[fib_tables]] \
-                                 update; reverting (runtime unchanged)"
-                            );
-                        }
-                    },
-                    Err(error) => {
-                        error!(
-                            %error,
-                            "reload: FIB runtime command channel closed; [[fib_tables]] not \
-                             applied, reverting (runtime unchanged)"
+                    }
+                    Ok(OwnedFibReplaceOutcome::RejectedNoEffect(error)) => {
+                        return acknowledge_partial(
+                            &progress,
+                            working_config,
+                            &desired_snapshot,
+                            ReloadStepFailure {
+                                bucket: "fib_tables.apply",
+                                target: "[[fib_tables]]".to_string(),
+                                error: ReloadStepError::Rejected(error),
+                            },
+                        );
+                    }
+                    Ok(OwnedFibReplaceOutcome::CompensationAmbiguous(error)) => {
+                        return fenced_reload_failure(
+                            "fib_tables.apply",
+                            ReloadStepError::Rejected(error),
+                            RuntimeConfigFenceReason::KnownDivergence,
+                        );
+                    }
+                    Err(_) => {
+                        return fenced_reload_failure(
+                            "fib_tables.apply",
+                            ReloadStepError::AcknowledgementLost,
+                            RuntimeConfigFenceReason::AcknowledgementLost,
                         );
                     }
                 }
@@ -2775,16 +3457,17 @@ pub(crate) async fn reload_config_with_tcp_ao(
             name: name.clone(),
             ack: None,
         };
-        let cmd_name = name.clone();
-        match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::DeletePeerGroup {
-            name: cmd_name,
-            reply,
-        })
+        match catalog_step(
+            peer_mgr_tx,
+            &mut progress,
+            OwnedCatalogMutation::DeletePeerGroup { name: name.clone() },
+        )
         .await
         {
             Ok(()) => {
                 if let Err(error) = apply_config_event(&mut working_config, &event) {
-                    return halt_partial(
+                    return acknowledge_partial(
+                        &progress,
                         working_config,
                         &desired_snapshot,
                         ReloadStepFailure {
@@ -2792,21 +3475,20 @@ pub(crate) async fn reload_config_with_tcp_ao(
                             target: name.clone(),
                             error: format!(
                                 "applied at peer manager but local snapshot rejected the event: {error}"
-                            ),
+                            ).into(),
                         },
                     );
                 }
                 info!(name = %name, "reload: peer_group removed");
             }
-            Err(error) => {
-                return halt_partial(
+            Err(failure) => {
+                return owned_step_failure(
+                    &progress,
                     working_config,
                     &desired_snapshot,
-                    ReloadStepFailure {
-                        bucket: "peer_group.delete",
-                        target: name.clone(),
-                        error,
-                    },
+                    "peer_group.delete",
+                    name.clone(),
+                    failure,
                 );
             }
         }
@@ -2816,16 +3498,17 @@ pub(crate) async fn reload_config_with_tcp_ao(
             name: name.clone(),
             ack: None,
         };
-        let cmd_name = name.clone();
-        match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::DeletePolicy {
-            name: cmd_name,
-            reply,
-        })
+        match catalog_step(
+            peer_mgr_tx,
+            &mut progress,
+            OwnedCatalogMutation::DeletePolicy { name: name.clone() },
+        )
         .await
         {
             Ok(()) => {
                 if let Err(error) = apply_config_event(&mut working_config, &event) {
-                    return halt_partial(
+                    return acknowledge_partial(
+                        &progress,
                         working_config,
                         &desired_snapshot,
                         ReloadStepFailure {
@@ -2833,21 +3516,20 @@ pub(crate) async fn reload_config_with_tcp_ao(
                             target: name.clone(),
                             error: format!(
                                 "applied at peer manager but local snapshot rejected the event: {error}"
-                            ),
+                            ).into(),
                         },
                     );
                 }
                 info!(name = %name, "reload: policy removed");
             }
-            Err(error) => {
-                return halt_partial(
+            Err(failure) => {
+                return owned_step_failure(
+                    &progress,
                     working_config,
                     &desired_snapshot,
-                    ReloadStepFailure {
-                        bucket: "policy.delete",
-                        target: name.clone(),
-                        error,
-                    },
+                    "policy.delete",
+                    name.clone(),
+                    failure,
                 );
             }
         }
@@ -2857,16 +3539,17 @@ pub(crate) async fn reload_config_with_tcp_ao(
             name: name.clone(),
             ack: None,
         };
-        let cmd_name = name.clone();
-        match send_catalog_pm_step(peer_mgr_tx, |reply| PeerManagerCommand::DeleteNeighborSet {
-            name: cmd_name,
-            reply,
-        })
+        match catalog_step(
+            peer_mgr_tx,
+            &mut progress,
+            OwnedCatalogMutation::DeleteNeighborSet { name: name.clone() },
+        )
         .await
         {
             Ok(()) => {
                 if let Err(error) = apply_config_event(&mut working_config, &event) {
-                    return halt_partial(
+                    return acknowledge_partial(
+                        &progress,
                         working_config,
                         &desired_snapshot,
                         ReloadStepFailure {
@@ -2874,21 +3557,20 @@ pub(crate) async fn reload_config_with_tcp_ao(
                             target: name.clone(),
                             error: format!(
                                 "applied at peer manager but local snapshot rejected the event: {error}"
-                            ),
+                            ).into(),
                         },
                     );
                 }
                 info!(name = %name, "reload: neighbor_set removed");
             }
-            Err(error) => {
-                return halt_partial(
+            Err(failure) => {
+                return owned_step_failure(
+                    &progress,
                     working_config,
                     &desired_snapshot,
-                    ReloadStepFailure {
-                        bucket: "neighbor_set.delete",
-                        target: name.clone(),
-                        error,
-                    },
+                    "neighbor_set.delete",
+                    name.clone(),
+                    failure,
                 );
             }
         }
@@ -2905,48 +3587,59 @@ pub(crate) async fn reload_config_with_tcp_ao(
     // reaches dynamic peers (which live only in the manager's
     // runtime table, not in `[[neighbors]]`). A soft-reset failure
     // there bubbles up through the SetPolicy / etc command result
-    // handled above, halting this reload via `halt_partial` so the
+    // handled above, returning an authoritative partial receipt so the
     // failure is surfaced rather than logged-and-forgotten.
 
     info!("config reload complete");
-    Some(ReloadedConfig::new(working_config, desired_snapshot))
+    acknowledged_reload(
+        working_config,
+        desired_snapshot,
+        dialout_targets,
+        SighupCompletion::Complete,
+    )
 }
 
-/// Halt a SIGHUP reload at the first failed step. Logs the failure
-/// at error level and returns the partially-applied config snapshot
-/// so the caller's in-memory config tracks live runtime state
-/// instead of lying that the prior config is still in effect. The
-/// daemon converges by the operator fixing the failing TOML and
-/// reloading again — at that point the diff runs against the
-/// half-applied state and only the remaining steps fire.
+/// Record the first known SIGHUP step failure and return its explicit
+/// known-partial authority. Composite finalization must acknowledge the same
+/// peer-manager snapshot, bridge/persister snapshot, tracing projection, and
+/// dial-out targets before the owner can settle.
 ///
-/// Returned wrapped in `Option<ReloadedConfig>` so the call sites can use
-/// `return halt_partial(...)` directly inside `reload_config`,
-/// matching its `Option<ReloadedConfig>` return shape.
-#[expect(
-    clippy::needless_pass_by_value,
-    clippy::unnecessary_wraps,
-    reason = "owned ReloadStepFailure simplifies call sites that build the value inline; Option<ReloadedConfig> return matches reload_config's signature so call sites can `return halt_partial(...)` directly"
-)]
-fn halt_partial(
+fn acknowledge_partial(
+    progress: &SighupMutationProgress<'_>,
     working_config: Config,
     desired_config: &Arc<AcceptedConfigSnapshot>,
     failure: ReloadStepFailure,
-) -> Option<ReloadedConfig> {
+) -> SighupReloadOutcome {
     error!(
         bucket = failure.bucket,
         target = %failure.target,
         error = %failure.error,
-        "config reload halted at this step — runtime state matches the in-memory snapshot returned by reload (partial). Re-edit TOML and reload again to converge."
+        "config reload stopped at this step; settling the acknowledged partial runtime authority before another reload may begin"
     );
-    Some(ReloadedConfig::new(
+    if matches!(failure.error, ReloadStepError::AcknowledgementLost) {
+        return SighupReloadOutcome::RecoveryFenced {
+            error: SighupReloadError::Failed(failure),
+            reason: RuntimeConfigFenceReason::AcknowledgementLost,
+        };
+    }
+    if !progress.accepted_effect {
+        return SighupReloadOutcome::CleanNoEffect(SighupReloadError::Failed(failure));
+    }
+    let dialout_targets = config::gnmi_dialout_targets(&working_config).unwrap_or_default();
+    acknowledged_reload(
         working_config,
         Arc::clone(desired_config),
-    ))
+        dialout_targets,
+        SighupCompletion::KnownPartial {
+            failures: vec![failure],
+        },
+    )
 }
 
 #[cfg(test)]
 mod tests {
+    #![expect(clippy::large_futures, reason = "T288 keeps authority unboxed")]
+
     use std::fmt::Write as _;
     use std::path::PathBuf;
 
@@ -2997,7 +3690,7 @@ mod tests {
             (concat!("load_tier", "_test_config("), 29),
             (concat!("load_tier", "_test_toml("), 9),
             (concat!("tier_authorized_uds", "_test_config("), 2),
-            (concat!("assert_tier_authorized", "_test_config("), 17),
+            (concat!("assert_tier_authorized", "_test_config("), 15),
         ];
 
         assert!(!source.contains(legacy_toml));
@@ -3384,7 +4077,7 @@ hold_time = 90
 
     /// Regression: `[[dynamic_neighbors]]` edits must be carried into the
     /// runtime snapshot returned by `reload_config`. The accept-matcher is
-    /// rebuilt from that snapshot when `apply_reload_outcome` swaps it into
+    /// rebuilt from that snapshot when finalization swaps it into
     /// the peer manager (#338) — previously the main reload path never
     /// copied the new range set into `working_config`, so the swap
     /// re-parsed the OLD ranges, the SIGHUP edit silently never took
@@ -3913,12 +4606,13 @@ originator_ip = "10.0.0.1"
         clippy::too_many_lines,
         reason = "reload hot-apply test keeps initial/candidate EVPN TOML fixtures inline"
     )]
-    async fn reload_decomposes_mixed_evpn_runtime_edit_across_generations() {
+    async fn reload_fences_decomposed_evpn_failure_before_later_command() {
         // #268: an ES delete + its (surviving) member L2VNI redefine + a new
         // L2VNI add in ONE SIGHUP. The converge of the mixed whole rejects it
         // (scripted `Unsupported`, as the real dispatch would), and the
-        // decomposer then applies deletes → redefine → add as three
-        // primitive steps — three committed generations for one SIGHUP.
+        // decomposer commits the delete, then the redefine fails after
+        // effects and pins the coordinator. The reload must fence without
+        // dispatching the later honor-graceful-shutdown mutation.
         let path = unique_temp_path("reload-evpn-decomposed-mixed");
         std::fs::write(
             &path,
@@ -3956,8 +4650,13 @@ originator_ip = "10.0.0.1"
                     ),
                 ),
                 Ok(()),
-                Ok(()),
-                Ok(()),
+                Err(
+                    crate::evpn_runtime_converger::DaemonEvpnRuntimeConvergeError::Failed(
+                        rustbgpd_evpn::EvpnRuntimeConvergeError::new(
+                            "decomposed redefine failed after effects",
+                        ),
+                    ),
+                ),
             ],
         );
 
@@ -3968,6 +4667,7 @@ originator_ip = "10.0.0.1"
 asn = 65001
 router_id = "10.0.0.1"
 listen_port = 179
+honor_graceful_shutdown = true
 
 [global.telemetry]
 log_format = "json"
@@ -3987,8 +4687,8 @@ local_vtep_ip = "10.0.0.1"
         )
         .unwrap();
 
-        let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(8);
-        let returned = reload_config(
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(8);
+        let outcome = reload_config(
             path.to_str().unwrap(),
             &initial,
             live_grpc_tcp.as_ref(),
@@ -3997,20 +4697,24 @@ local_vtep_ip = "10.0.0.1"
             None,
             Some(&apply),
         )
-        .await
-        .expect("reload should hot-apply the decomposed mixed EVPN edit");
+        .await;
 
-        assert_eq!(
-            returned.evpn_instances.len(),
-            2,
-            "the reload snapshot must advance to the mixed candidate"
-        );
-        assert!(returned.ethernet_segments.is_empty());
+        assert!(matches!(
+            outcome,
+            SighupReloadOutcome::RecoveryFenced {
+                reason: RuntimeConfigFenceReason::KnownDivergence,
+                ..
+            }
+        ));
+        assert!(matches!(
+            peer_mgr_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
         let guard = coordinator.lock().unwrap();
         assert_eq!(
             guard.model().generation().as_u64(),
-            4,
-            "one SIGHUP must commit three generations (deletes, redefine, add)"
+            2,
+            "the committed delete remains authoritative after the later step fails"
         );
         assert!(guard.model().ethernet_segments().is_empty());
         assert_eq!(
@@ -4021,14 +4725,14 @@ local_vtep_ip = "10.0.0.1"
                 .unwrap()
                 .rd
                 .to_string(),
-            "65000:101"
+            "65000:100"
         );
         assert!(
             guard
                 .model()
                 .instances()
                 .get(rustbgpd_evpn::EvpnInstanceId::new(200).unwrap())
-                .is_some()
+                .is_none()
         );
         std::fs::remove_file(&path).ok();
     }
@@ -4274,7 +4978,7 @@ local_vtep_ip = "10.0.0.1"
     }
 
     #[tokio::test]
-    async fn reload_rejected_evpn_candidate_pins_to_committed_runtime_baseline() {
+    async fn reload_failed_evpn_candidate_fences_at_committed_runtime_baseline() {
         let path = unique_temp_path("reload-evpn-reject-committed-baseline");
         std::fs::write(&path, EVPN_VNI_100_TOML).unwrap();
         let initial = load_tier_test_config(&path);
@@ -4302,7 +5006,7 @@ local_vtep_ip = "10.0.0.1"
 
         std::fs::write(&path, EVPN_VNI_100_200_300_TOML).unwrap();
         let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(8);
-        let returned = reload_config(
+        let outcome = reload_config(
             path.to_str().unwrap(),
             &initial,
             live_grpc_tcp.as_ref(),
@@ -4311,15 +5015,18 @@ local_vtep_ip = "10.0.0.1"
             None,
             Some(&apply),
         )
-        .await
-        .expect("reload should pin when the committed-baseline candidate fails to converge");
+        .await;
+
+        assert!(matches!(
+            outcome,
+            SighupReloadOutcome::RecoveryFenced {
+                reason: RuntimeConfigFenceReason::KnownDivergence,
+                ..
+            }
+        ));
 
         let committed = rustbgpd_evpn::EvpnInstanceId::new(200).unwrap();
         let rejected = rustbgpd_evpn::EvpnInstanceId::new(300).unwrap();
-        assert_eq!(
-            returned.evpn_instances, runtime_config.evpn_instances,
-            "rejected EVPN reload must pin to the coordinator's committed config, not stale startup tables"
-        );
         assert!(
             coordinator
                 .lock()
@@ -4713,6 +5420,61 @@ hold_time = 90
         std::fs::remove_file(&path).ok();
     }
 
+    async fn assert_honor_reply_loss_fences(graceful: bool, bucket: &'static str) {
+        let current = load_config_from_toml("honor-reply-loss", baseline_toml());
+        let mut desired = current.clone();
+        if graceful {
+            desired.global.honor_graceful_shutdown = true;
+        } else {
+            desired.global.honor_blackhole = true;
+        }
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(1);
+        let actor = tokio::spawn(async move {
+            match (graceful, peer_mgr_rx.recv().await.expect("honor command")) {
+                (true, PeerManagerCommand::SetHonorGracefulShutdown { reply, .. })
+                | (false, PeerManagerCommand::SetHonorBlackhole { reply, .. }) => drop(reply),
+                _ => panic!("unexpected honor command"),
+            }
+        });
+        let outcome = reload_config_with_tcp_ao(
+            SighupReloadPlan {
+                baseline_runtime: current,
+                desired: AcceptedConfigSnapshot::from_config_for_test(desired),
+            },
+            None,
+            None,
+            &peer_mgr_tx,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        actor.await.unwrap();
+        assert!(matches!(
+            outcome,
+            SighupReloadOutcome::RecoveryFenced {
+                error: SighupReloadError::Failed(ReloadStepFailure {
+                    bucket: actual,
+                    error: ReloadStepError::AcknowledgementLost,
+                    ..
+                }),
+                reason: RuntimeConfigFenceReason::AcknowledgementLost,
+            } if actual == bucket
+        ));
+    }
+
+    #[tokio::test]
+    async fn honor_graceful_shutdown_reply_loss_recovery_fences() {
+        assert_honor_reply_loss_fences(true, "honor_graceful_shutdown.apply").await;
+    }
+
+    #[tokio::test]
+    async fn honor_blackhole_reply_loss_recovery_fences() {
+        assert_honor_reply_loss_fences(false, "honor_blackhole.apply").await;
+    }
+
     const FIB_ONE_TABLE_TOML: &str = r#"
 [global]
 asn = 65001
@@ -4773,15 +5535,12 @@ metric = 200
         let (fib_tx, mut fib_rx) = mpsc::channel(8);
         let actor = tokio::spawn(async move {
             match fib_rx.recv().await {
-                Some(FibRuntimeCommand::ReplaceTables { tables, reply }) => {
-                    let _ = reply.send(Ok(()));
+                Some(FibRuntimeCommand::OwnedReplaceTables { tables, reply }) => {
+                    let _ = reply.send(OwnedFibReplaceOutcome::Applied);
                     tables.len()
                 }
                 Some(FibRuntimeCommand::GetTables { .. }) => panic!("unexpected GetTables"),
-                Some(FibRuntimeCommand::OwnedReplaceTables { .. }) => {
-                    panic!("unexpected OwnedReplaceTables")
-                }
-                None => panic!("expected ReplaceTables"),
+                None => panic!("expected OwnedReplaceTables"),
             }
         });
 
@@ -4864,8 +5623,8 @@ metric = 200
                     PeerManagerCommand::SetFibTablesSnapshot { reply, .. } => {
                         let _ = reply.send(());
                     }
-                    PeerManagerCommand::DeletePeerGroup { reply, .. } => {
-                        let _ = reply.send(Ok(()));
+                    PeerManagerCommand::OwnedCatalogMutation { reply, .. } => {
+                        let _ = reply.send(OwnedCatalogMutationOutcome::Success);
                     }
                     _ => panic!("unexpected peer manager command"),
                 }
@@ -4875,11 +5634,11 @@ metric = 200
         let (fib_tx, mut fib_rx) = mpsc::channel(8);
         let actor = tokio::spawn(async move {
             match fib_rx.recv().await {
-                Some(FibRuntimeCommand::ReplaceTables { tables, reply }) => {
+                Some(FibRuntimeCommand::OwnedReplaceTables { tables, reply }) => {
                     assert!(tables[0].allowed_peer_groups.is_empty());
-                    let _ = reply.send(Ok(()));
+                    let _ = reply.send(OwnedFibReplaceOutcome::Applied);
                 }
-                _ => panic!("expected ReplaceTables"),
+                _ => panic!("expected OwnedReplaceTables"),
             }
         });
 
@@ -4928,7 +5687,7 @@ metric = 200
         let (fib_tx, fib_rx) = mpsc::channel::<FibRuntimeCommand>(8);
         drop(fib_rx); // actor gone — the send fails, so the snapshot must not advance
 
-        let returned = reload_config(
+        let outcome = reload_config(
             path.to_str().unwrap(),
             &initial,
             tcp.as_ref(),
@@ -4937,14 +5696,8 @@ metric = 200
             Some(&fib_tx),
             None,
         )
-        .await
-        .expect("reload returns a config even when the FIB actor is unreachable");
-
-        assert_eq!(
-            returned.fib_tables.len(),
-            1,
-            "no ack ⇒ snapshot must stay on the live table set"
-        );
+        .await;
+        assert!(matches!(outcome, SighupReloadOutcome::CleanNoEffect(_)));
         std::fs::remove_file(&path).ok();
     }
 
@@ -5038,12 +5791,14 @@ log_format = "json"
         let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(8);
         let (fib_tx, mut fib_rx) = mpsc::channel(8);
         let actor = tokio::spawn(async move {
-            if let Some(FibRuntimeCommand::ReplaceTables { reply, .. }) = fib_rx.recv().await {
-                let _ = reply.send(Err("simulated reconcile failure".to_string()));
+            if let Some(FibRuntimeCommand::OwnedReplaceTables { reply, .. }) = fib_rx.recv().await {
+                let _ = reply.send(OwnedFibReplaceOutcome::RejectedNoEffect(
+                    "simulated reconcile failure".to_string(),
+                ));
             }
         });
 
-        let returned = reload_config(
+        let outcome = reload_config(
             path.to_str().unwrap(),
             &initial,
             tcp.as_ref(),
@@ -5052,14 +5807,8 @@ log_format = "json"
             Some(&fib_tx),
             None,
         )
-        .await
-        .expect("reload returns a config even when the actor reports failure");
-
-        assert_eq!(
-            returned.fib_tables.len(),
-            1,
-            "an Err ack must not advance the snapshot"
-        );
+        .await;
+        assert!(matches!(outcome, SighupReloadOutcome::CleanNoEffect(_)));
         let _ = actor.await;
         std::fs::remove_file(&path).ok();
     }
@@ -5230,6 +5979,38 @@ hold_time = 90
     /// to the full command struct.
     fn cmd_tag(cmd: &PeerManagerCommand) -> String {
         match cmd {
+            PeerManagerCommand::OwnedCatalogMutation { mutation, .. } => match mutation {
+                OwnedCatalogMutation::SetPolicy { name, .. } => format!("SetPolicy({name})"),
+                OwnedCatalogMutation::DeletePolicy { name } => format!("DeletePolicy({name})"),
+                OwnedCatalogMutation::SetNeighborSet { name, .. } => {
+                    format!("SetNeighborSet({name})")
+                }
+                OwnedCatalogMutation::DeleteNeighborSet { name } => {
+                    format!("DeleteNeighborSet({name})")
+                }
+                OwnedCatalogMutation::SetPeerGroup { name, .. } => {
+                    format!("SetPeerGroup({name})")
+                }
+                OwnedCatalogMutation::DeletePeerGroup { name } => {
+                    format!("DeletePeerGroup({name})")
+                }
+                OwnedCatalogMutation::SetGlobalImportChain { policy_names } => {
+                    format!("SetGlobalImportChain({})", policy_names.join(","))
+                }
+                OwnedCatalogMutation::SetGlobalExportChain { policy_names } => {
+                    format!("SetGlobalExportChain({})", policy_names.join(","))
+                }
+                OwnedCatalogMutation::ClearGlobalImportChain => {
+                    "ClearGlobalImportChain".to_string()
+                }
+                OwnedCatalogMutation::ClearGlobalExportChain => {
+                    "ClearGlobalExportChain".to_string()
+                }
+                OwnedCatalogMutation::SyncRpolPolicies { rpol, .. } => {
+                    format!("SyncRpolPolicies({})", rpol.policies.len())
+                }
+                _ => "OwnedCatalogMutation".to_string(),
+            },
             PeerManagerCommand::SetPolicy { name, .. } => format!("SetPolicy({name})"),
             PeerManagerCommand::DeletePolicy { name, .. } => format!("DeletePolicy({name})"),
             PeerManagerCommand::SetNeighborSet { name, .. } => format!("SetNeighborSet({name})"),
@@ -5273,9 +6054,6 @@ hold_time = 90
             } => {
                 format!("SyncExplainConfig(enabled={enabled},cache_size={cache_size})")
             }
-            PeerManagerCommand::SyncRpolPolicies { rpol, .. } => {
-                format!("SyncRpolPolicies({})", rpol.policies.len())
-            }
             PeerManagerCommand::SetFibTablesSnapshot { tables, .. } => {
                 format!("SetFibTablesSnapshot({})", tables.len())
             }
@@ -5289,6 +6067,149 @@ hold_time = 90
         }
     }
 
+    #[tokio::test]
+    async fn owned_catalog_ambiguity_and_accepted_reply_loss_fence() {
+        let mutations = [
+            OwnedCatalogMutation::DeletePolicy {
+                name: "policy".to_string(),
+            },
+            OwnedCatalogMutation::DeleteNeighborSet {
+                name: "set".to_string(),
+            },
+            OwnedCatalogMutation::DeletePeerGroup {
+                name: "group".to_string(),
+            },
+            OwnedCatalogMutation::ClearGlobalImportChain,
+        ];
+        for mutation in mutations {
+            let (tx, mut rx) = mpsc::channel(1);
+            tokio::spawn(async move {
+                let Some(PeerManagerCommand::OwnedCatalogMutation { reply, .. }) = rx.recv().await
+                else {
+                    panic!("expected owned catalog mutation");
+                };
+                let _ = reply.send(OwnedCatalogMutationOutcome::CompensationAmbiguous(
+                    CatalogMutationError::internal("injected ambiguous compensation"),
+                ));
+            });
+            let mut progress = SighupMutationProgress::new(None);
+            assert!(matches!(
+                catalog_step(&tx, &mut progress, mutation).await,
+                Err(OwnedStepFailure::Fenced {
+                    reason: RuntimeConfigFenceReason::KnownDivergence,
+                    ..
+                })
+            ));
+        }
+
+        for mutation in [
+            OwnedCatalogMutation::DeletePolicy {
+                name: "reply-loss".to_string(),
+            },
+            OwnedCatalogMutation::SyncRpolPolicies {
+                rpol_files: Vec::new(),
+                rpol: rustbgpd_policy::rpol::RpolPolicySet::default(),
+                dataset_bindings: rustbgpd_policy::datasets::DatasetBindings::default(),
+            },
+        ] {
+            let (tx, mut rx) = mpsc::channel(1);
+            tokio::spawn(async move {
+                let Some(PeerManagerCommand::OwnedCatalogMutation { reply, .. }) = rx.recv().await
+                else {
+                    panic!("expected owned catalog mutation");
+                };
+                drop(reply);
+            });
+            let mut progress = SighupMutationProgress::new(None);
+            assert!(matches!(
+                catalog_step(&tx, &mut progress, mutation).await,
+                Err(OwnedStepFailure::Fenced {
+                    reason: RuntimeConfigFenceReason::AcknowledgementLost,
+                    ..
+                })
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn owned_hot_update_reply_loss_fences() {
+        let (tx, mut rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            let Some(PeerManagerCommand::HotUpdatePeer { reply, .. }) = rx.recv().await else {
+                panic!("expected hot update");
+            };
+            drop(reply);
+        });
+        let mut progress = SighupMutationProgress::new(None);
+        let config = load_config_from_toml("hot-reply-loss", baseline_toml());
+        let resolved = config.resolved_neighbors().unwrap().remove(0);
+        assert!(matches!(
+            hot_peer_step(
+                &tx,
+                &mut progress,
+                build_peer_mgr_config(
+                    &resolved.transport_config,
+                    None,
+                    &resolved.label,
+                    resolved.import_policy.as_ref(),
+                    resolved.export_policy.as_ref(),
+                    None,
+                ),
+            )
+            .await,
+            Err(OwnedStepFailure::Fenced {
+                reason: RuntimeConfigFenceReason::AcknowledgementLost,
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn preflight_ack_loss_is_clean_and_runtime_snapshot_retries() {
+        for bucket in ["tcp_ao.listener_preflight", "tcp_ao.peer_preflight"] {
+            assert!(matches!(
+                preflight_dispatch_failure(bucket, ReloadStepError::AcknowledgementLost),
+                SighupReloadOutcome::CleanNoEffect(_)
+            ));
+        }
+        assert!(matches!(
+            fenced_reload_failure(
+                "tcp_ao.peer_apply",
+                ReloadStepError::AcknowledgementLost,
+                RuntimeConfigFenceReason::AcknowledgementLost,
+            ),
+            SighupReloadOutcome::RecoveryFenced {
+                reason: RuntimeConfigFenceReason::AcknowledgementLost,
+                ..
+            }
+        ));
+
+        let config = load_config_from_toml("snapshot-retry", baseline_toml());
+        let accepted = AcceptedConfigSnapshot::from_config_for_test(config.clone());
+        let bindings = config.policy.dataset_bindings.clone();
+        let (tx, mut rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            if let Some(PeerManagerCommand::RuntimeConfigSnapshot { reply }) = rx.recv().await {
+                drop(reply);
+            }
+            if let Some(PeerManagerCommand::RuntimeConfigSnapshot { reply }) = rx.recv().await {
+                let _ = reply.send(Ok(rustbgpd_api::peer_types::RuntimeConfigSnapshotReply {
+                    toml: toml::to_string(&config).unwrap(),
+                    rpol_files: Vec::new(),
+                    rpol: rustbgpd_policy::rpol::RpolPolicySet::default(),
+                }));
+            }
+        });
+        assert!(matches!(
+            runtime_config_snapshot_accepted(&tx, &accepted, &bindings).await,
+            ReloadDispatch::AcknowledgementLost
+        ));
+        assert!(matches!(
+            runtime_config_snapshot_accepted(&tx, &accepted, &bindings).await,
+            ReloadDispatch::Replied(Ok(_))
+        ));
+    }
+
     /// Drive sequential reloads against the given initial+next TOML and return
     /// the outcomes plus commands the mock peer manager observed, in order.
     /// Replies `Ok(())` to every command that carries a reply channel.
@@ -5296,7 +6217,7 @@ hold_time = 90
         initial_toml: &str,
         new_toml: &str,
         reloads: usize,
-    ) -> (Vec<Option<ReloadedConfig>>, Vec<String>) {
+    ) -> (Vec<SighupReloadOutcome>, Vec<String>) {
         let path = unique_temp_path("reload-driver");
         write_tier_test_config(&path, initial_toml);
         let mut current = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
@@ -5308,13 +6229,16 @@ hold_time = 90
 
         let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel::<PeerManagerCommand>(64);
         let mock = tokio::spawn(async move {
-            use rustbgpd_api::peer_types::ReconcileResult;
+            use rustbgpd_api::peer_types::PeerReconcileOutcome;
             let mut tags = Vec::new();
             while let Some(cmd) = peer_mgr_rx.recv().await {
                 tags.push(cmd_tag(&cmd));
                 // Respond Ok(()) to every command that has a reply
                 // channel so reload_config doesn't hang.
                 match cmd {
+                    PeerManagerCommand::OwnedCatalogMutation { reply, .. } => {
+                        let _ = reply.send(OwnedCatalogMutationOutcome::Success);
+                    }
                     PeerManagerCommand::SetPolicy { reply, .. }
                     | PeerManagerCommand::DeletePolicy { reply, .. }
                     | PeerManagerCommand::SetNeighborSet { reply, .. }
@@ -5324,15 +6248,40 @@ hold_time = 90
                     | PeerManagerCommand::SetGlobalImportChain { reply, .. }
                     | PeerManagerCommand::SetGlobalExportChain { reply, .. }
                     | PeerManagerCommand::ClearGlobalImportChain { reply }
-                    | PeerManagerCommand::ClearGlobalExportChain { reply }
-                    | PeerManagerCommand::SyncRpolPolicies { reply, .. } => {
+                    | PeerManagerCommand::ClearGlobalExportChain { reply } => {
                         let _ = reply.send(Ok(()));
                     }
                     PeerManagerCommand::SoftResetIn { reply, .. } => {
                         let _ = reply.send(Ok(()));
                     }
-                    PeerManagerCommand::ReconcilePeers { reply, .. } => {
-                        let _ = reply.send(ReconcileResult::default());
+                    PeerManagerCommand::ReconcilePeers {
+                        added,
+                        removed,
+                        changed,
+                        reply,
+                    } => {
+                        let effects = removed
+                            .into_iter()
+                            .map(PeerReconcileEffect::Removed)
+                            .chain(added.into_iter().map(|peer| {
+                                PeerReconcileEffect::Added(rustbgpd_api::peer_types::PeerKey::new(
+                                    peer.address,
+                                    peer.interface,
+                                ))
+                            }))
+                            .chain(changed.into_iter().map(|peer| {
+                                PeerReconcileEffect::Replaced(
+                                    rustbgpd_api::peer_types::PeerKey::new(
+                                        peer.address,
+                                        peer.interface,
+                                    ),
+                                )
+                            }))
+                            .collect();
+                        let _ = reply.send(PeerReconcileOutcome {
+                            effects,
+                            ..PeerReconcileOutcome::default()
+                        });
                     }
                     PeerManagerCommand::SetFibTablesSnapshot { reply, .. }
                     | PeerManagerCommand::SyncExplainConfig { reply, .. } => {
@@ -5376,7 +6325,7 @@ hold_time = 90
     async fn drive_reload(
         initial_toml: &str,
         new_toml: &str,
-    ) -> (Option<ReloadedConfig>, Vec<String>) {
+    ) -> (SighupReloadOutcome, Vec<String>) {
         let (mut outcomes, tags) = drive_reloads(initial_toml, new_toml, 1).await;
         (outcomes.pop().unwrap(), tags)
     }
@@ -5445,8 +6394,8 @@ hold_time = 90
             let mut tags = Vec::new();
             while let Some(cmd) = peer_mgr_rx.recv().await {
                 tags.push(cmd_tag(&cmd));
-                if let PeerManagerCommand::SyncRpolPolicies { reply, .. } = cmd {
-                    let _ = reply.send(Ok(()));
+                if let PeerManagerCommand::OwnedCatalogMutation { reply, .. } = cmd {
+                    let _ = reply.send(OwnedCatalogMutationOutcome::Success);
                 }
             }
             tags
@@ -5548,8 +6497,8 @@ hold_time = 90
                     let mut tags = Vec::new();
                     while let Some(cmd) = peer_mgr_rx.recv().await {
                         tags.push(cmd_tag(&cmd));
-                        if let PeerManagerCommand::SyncRpolPolicies { reply, .. } = cmd {
-                            let _ = reply.send(Ok(()));
+                        if let PeerManagerCommand::OwnedCatalogMutation { reply, .. } = cmd {
+                            let _ = reply.send(OwnedCatalogMutationOutcome::Success);
                         }
                     }
                     tags
@@ -5689,10 +6638,10 @@ hold_time = 90
         let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel::<PeerManagerCommand>(64);
         let mock = tokio::spawn(async move {
             while let Some(cmd) = peer_mgr_rx.recv().await {
-                if let PeerManagerCommand::SyncRpolPolicies { reply, .. } = cmd {
-                    let _ = reply.send(Err(CatalogMutationError::internal(
-                        "mid-apply chain resolution failed",
-                    )));
+                if let PeerManagerCommand::OwnedCatalogMutation { reply, .. } = cmd {
+                    let _ = reply.send(OwnedCatalogMutationOutcome::RejectedNoEffect(
+                        CatalogMutationError::internal("mid-apply chain resolution failed"),
+                    ));
                 }
             }
         });
@@ -5705,14 +6654,21 @@ hold_time = 90
             None,
             None,
         )
-        .await
-        .expect("halted reload still returns the honest partial snapshot");
+        .await;
         drop(peer_mgr_tx);
         mock.await.unwrap();
+        assert!(matches!(
+            rejected,
+            SighupReloadOutcome::CleanNoEffect(SighupReloadError::Failed(ReloadStepFailure {
+                bucket: "policy.rpol.sync",
+                error: ReloadStepError::Rejected(_),
+                ..
+            }))
+        ));
 
-        // The runtime snapshot — what a session created after the failed
-        // reload resolves against — still evaluates the OLD decision.
-        let chain = rejected
+        // A session created after the rejected no-effect reload still resolves
+        // the OLD decision.
+        let chain = initial
             .import_chain()
             .expect("chain resolves")
             .expect("chain configured");
@@ -5721,14 +6677,14 @@ hold_time = 90
         // Reload 2 (operator retries; peer manager now accepts): the
         // diff re-detects the on-disk candidate against the reverted
         // runtime snapshot and adopts it for everyone.
-        let current: Config = (*rejected).clone();
+        let current = initial.clone();
         let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel::<PeerManagerCommand>(64);
         let mock = tokio::spawn(async move {
             let mut synced = 0_u32;
             while let Some(cmd) = peer_mgr_rx.recv().await {
-                if let PeerManagerCommand::SyncRpolPolicies { reply, .. } = cmd {
+                if let PeerManagerCommand::OwnedCatalogMutation { reply, .. } = cmd {
                     synced += 1;
-                    let _ = reply.send(Ok(()));
+                    let _ = reply.send(OwnedCatalogMutationOutcome::Success);
                 }
             }
             synced
@@ -6956,7 +7912,7 @@ import_policy_chain = ["origin-guard"]
         let (peer_mgr_tx, peer_mgr_rx) = mpsc::channel(1);
         drop(peer_mgr_rx);
 
-        let returned = reload_config(
+        let outcome = reload_config(
             config_path.to_str().unwrap(),
             &initial,
             initial.global.telemetry.grpc_tcp.as_ref(),
@@ -6965,22 +7921,22 @@ import_policy_chain = ["origin-guard"]
             None,
             None,
         )
-        .await
-        .expect("explain-sync failure returns the honest partial snapshot");
-        assert_tier_authorized_test_config(&returned);
-        assert_tier_authorized_test_config(&returned.desired);
+        .await;
+        assert!(matches!(outcome, SighupReloadOutcome::CleanNoEffect(_)));
 
         assert_eq!(live.pin().generation, 1);
         assert_eq!(live.pin().data.records(), 1);
         assert!(std::sync::Arc::ptr_eq(
             &live,
-            returned.policy.dataset_bindings.get("customers").unwrap()
+            initial.policy.dataset_bindings.get("customers").unwrap()
         ));
     }
 
     #[tokio::test]
     async fn reload_neighbor_reconcile_failure_retains_committed_dataset_snapshot() {
-        use rustbgpd_api::peer_types::{ReconcileFailure, ReconcileFailureKind, ReconcileResult};
+        use rustbgpd_api::peer_types::{
+            PeerReconcileAuthority, PeerReconcileOutcome, ReconcileFailure, ReconcileFailureKind,
+        };
 
         let initial_toml = r#"
 [global]
@@ -7023,7 +7979,8 @@ remote_asn = 65099
                         let _ = reply.send(Ok(()));
                     }
                     PeerManagerCommand::ReconcilePeers { reply, .. } => {
-                        let _ = reply.send(ReconcileResult {
+                        let _ = reply.send(PeerReconcileOutcome {
+                            effects: Vec::new(),
                             failures: vec![ReconcileFailure {
                                 kind: ReconcileFailureKind::Add,
                                 peer: rustbgpd_api::peer_types::PeerKey::new(
@@ -7032,6 +7989,7 @@ remote_asn = 65099
                                 ),
                                 error: "injected add failure".to_string(),
                             }],
+                            authority: PeerReconcileAuthority::Known,
                         });
                     }
                     other => panic!("unexpected command: {}", cmd_tag(&other)),
@@ -7464,7 +8422,9 @@ peer_group = "secure"
     /// new policy but not the new neighbors.
     #[tokio::test]
     async fn reload_halts_on_failure_with_honest_partial_snapshot() {
-        use rustbgpd_api::peer_types::{ReconcileFailure, ReconcileFailureKind, ReconcileResult};
+        use rustbgpd_api::peer_types::{
+            PeerReconcileAuthority, PeerReconcileOutcome, ReconcileFailure, ReconcileFailureKind,
+        };
 
         let initial_toml = baseline_toml().to_string();
         let new_toml = format!(
@@ -7491,6 +8451,9 @@ peer_group = "secure"
             while let Some(cmd) = peer_mgr_rx.recv().await {
                 tags.push(cmd_tag(&cmd));
                 match cmd {
+                    PeerManagerCommand::OwnedCatalogMutation { reply, .. } => {
+                        let _ = reply.send(OwnedCatalogMutationOutcome::Success);
+                    }
                     PeerManagerCommand::SetPolicy { reply, .. }
                     | PeerManagerCommand::DeletePolicy { reply, .. }
                     | PeerManagerCommand::SetNeighborSet { reply, .. }
@@ -7504,7 +8467,8 @@ peer_group = "secure"
                         let _ = reply.send(Ok(()));
                     }
                     PeerManagerCommand::ReconcilePeers { reply, .. } => {
-                        let result = ReconcileResult {
+                        let result = PeerReconcileOutcome {
+                            effects: Vec::new(),
                             failures: vec![ReconcileFailure {
                                 kind: ReconcileFailureKind::Add,
                                 peer: rustbgpd_api::peer_types::PeerKey::new(
@@ -7513,6 +8477,7 @@ peer_group = "secure"
                                 ),
                                 error: "simulated reconcile failure".to_string(),
                             }],
+                            authority: PeerReconcileAuthority::Known,
                         };
                         let _ = reply.send(result);
                     }
@@ -7553,143 +8518,6 @@ peer_group = "secure"
             tags.contains(&"SetPolicy(block-private)".to_string()),
             "earlier reload steps must still have fired before the reconcile failure — saw {tags:?}"
         );
-    }
-
-    /// `apply_reload_outcome` must send to the peer manager FIRST, so
-    /// the authoritative runtime view always advances even if the
-    /// optional bridge channel later fails. Drives the helper directly
-    /// with a closed bridge channel to assert the failure stage name
-    /// matches and the peer manager already received the snapshot
-    /// before the bridge send was attempted.
-    #[tokio::test]
-    async fn apply_reload_outcome_bridge_failure_after_peer_mgr_snapshot() {
-        let (peer_mgr_internal_tx, mut peer_mgr_internal_rx) =
-            mpsc::unbounded_channel::<InternalCommand>();
-        let (bridge_tx, bridge_rx) = mpsc::unbounded_channel::<AcceptedBridgeReplacement>();
-        // Drop the bridge rx so the helper's send fails immediately
-        // with a closed-channel error.
-        drop(bridge_rx);
-
-        let path = unique_temp_path("apply-reload-outcome");
-        std::fs::write(&path, baseline_toml()).unwrap();
-        let cfg = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
-        std::fs::remove_file(&path).ok();
-
-        // Stand in for the peer manager: receive the snapshot and ack it so
-        // apply_reload_outcome proceeds to the (failing) bridge send.
-        let expected_asn = cfg.global.asn;
-        let pm = tokio::spawn(async move {
-            match peer_mgr_internal_rx.recv().await {
-                Some(InternalCommand::ReplaceConfigSnapshot { config, ack }) => {
-                    if let Some(ack) = ack {
-                        let _ = ack.send(());
-                    }
-                    config.global.asn
-                }
-                Some(InternalCommand::PlanAcceptedSnapshot { .. }) => {
-                    panic!("reload test expected only ReplaceConfigSnapshot")
-                }
-                Some(
-                    InternalCommand::StageTransactionConfig { .. }
-                    | InternalCommand::RestoreTransactionConfig { .. },
-                ) => panic!("reload test expected no config transaction snapshot command"),
-                None => panic!("peer manager must receive the snapshot"),
-            }
-        });
-
-        let result = apply_reload_outcome(
-            ReloadedConfig::new(
-                cfg.clone(),
-                AcceptedConfigSnapshot::from_config_for_test(cfg.clone()),
-            ),
-            &peer_mgr_internal_tx,
-            Some(&bridge_tx),
-        )
-        .await;
-
-        assert_eq!(
-            result.err(),
-            Some("config_bridge"),
-            "bridge failure must surface as the named stage so the caller's log line is actionable"
-        );
-        assert_eq!(
-            pm.await.unwrap(),
-            expected_asn,
-            "peer manager must receive the snapshot before the bridge send is attempted"
-        );
-    }
-
-    #[tokio::test]
-    async fn apply_reload_outcome_waits_for_bridge_adoption() {
-        let cfg = Config::load_toml_with_diagnostics(baseline_toml(), "adoption test").unwrap();
-        let desired = AcceptedConfigSnapshot::from_config_for_test(cfg.clone());
-        let (peer_tx, mut peer_rx) = mpsc::unbounded_channel::<InternalCommand>();
-        let (bridge_tx, mut bridge_rx) = mpsc::unbounded_channel::<AcceptedBridgeReplacement>();
-        let apply_peer_tx = peer_tx.clone();
-        let apply_bridge_tx = bridge_tx.clone();
-        let apply_desired = Arc::clone(&desired);
-        let apply = tokio::spawn(async move {
-            apply_reload_outcome(
-                ReloadedConfig::new(cfg, apply_desired),
-                &apply_peer_tx,
-                Some(&apply_bridge_tx),
-            )
-            .await
-        });
-
-        let Some(InternalCommand::ReplaceConfigSnapshot { ack: Some(ack), .. }) =
-            peer_rx.recv().await
-        else {
-            panic!("reload outcome must request peer-manager adoption");
-        };
-        ack.send(()).unwrap();
-        let replacement = bridge_rx.recv().await.unwrap();
-        assert!(Arc::ptr_eq(&replacement.snapshot, &desired));
-        tokio::task::yield_now().await;
-        assert!(
-            !apply.is_finished(),
-            "reload must retain its coordinator barrier until bridge adoption"
-        );
-        replacement.adopted.send(()).unwrap();
-        assert!(apply.await.unwrap().is_ok());
-    }
-
-    /// Bridge-disabled mode (no persister, so no bridge) must succeed: the
-    /// helper takes `Option<&Sender>`, and a `None` bridge is the shape an
-    /// embedder or a unit test wires when nothing persists gRPC mutations.
-    /// The daemon itself always has a bridge.
-    #[tokio::test]
-    async fn apply_reload_outcome_succeeds_without_bridge() {
-        let (peer_mgr_internal_tx, mut peer_mgr_internal_rx) =
-            mpsc::unbounded_channel::<InternalCommand>();
-
-        let path = unique_temp_path("apply-reload-outcome-nobridge");
-        std::fs::write(&path, baseline_toml()).unwrap();
-        let cfg = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
-        std::fs::remove_file(&path).ok();
-
-        // Stand in for the peer manager: receive the snapshot and ack it.
-        let pm = tokio::spawn(async move {
-            match peer_mgr_internal_rx.recv().await {
-                Some(InternalCommand::ReplaceConfigSnapshot { ack: Some(ack), .. }) => {
-                    ack.send(()).is_ok()
-                }
-                _ => false,
-            }
-        });
-
-        let advanced = apply_reload_outcome(
-            ReloadedConfig::new(
-                cfg.clone(),
-                AcceptedConfigSnapshot::from_config_for_test(cfg.clone()),
-            ),
-            &peer_mgr_internal_tx,
-            None,
-        )
-        .await
-        .expect("no-bridge mode must succeed");
-        assert_eq!(advanced.global.asn, cfg.global.asn);
-        assert!(pm.await.unwrap(), "peer manager must receive the snapshot");
     }
 
     /// Regression test for the bridge stale-snapshot bug. The bridge
@@ -7751,7 +8579,20 @@ peer_group = "secure"
                 adopted,
             })
             .unwrap();
-        adopted_rx.await.unwrap();
+        let replace_msg = mutation_rx.recv().await.expect("replacement forwarded");
+        let ConfigMutation::AdoptReloadSnapshot {
+            snapshot: received_replace,
+            adopted: persister_ack,
+        } = replace_msg
+        else {
+            panic!("bridge must forward replacement as AdoptReloadSnapshot");
+        };
+        assert!(received_replace.peer_groups.contains_key("upstream"));
+        persister_ack.send(()).unwrap();
+        assert!(matches!(
+            adopted_rx.await.unwrap(),
+            ReloadDispatch::Replied(())
+        ));
         // Then a gRPC mutation that adds a policy definition. If the
         // bridge missed the swap, this would compute against `stale`
         // and the resulting ReplaceConfig wouldn't carry the new
@@ -7767,19 +8608,6 @@ peer_group = "secure"
             })
             .await
             .unwrap();
-
-        // First persister message is the replacement itself, but as a
-        // no-persist refresh. The on-disk TOML is already the
-        // operator's desired snapshot; rewriting it here would clobber
-        // restart-required edits that runtime intentionally pinned.
-        let replace_msg = mutation_rx.recv().await.expect("replacement forwarded");
-        let ConfigMutation::RefreshSnapshotNoPersist(received_replace) = replace_msg else {
-            panic!("bridge must forward replacement as RefreshSnapshotNoPersist");
-        };
-        assert!(
-            received_replace.peer_groups.contains_key("upstream"),
-            "replacement message must carry the new peer_groups.upstream"
-        );
 
         // Second persister message is the post-event snapshot — must
         // contain BOTH the replacement-supplied peer_groups.upstream
@@ -8536,20 +9364,18 @@ remote_asn = 65002
         .await
         .expect("reload should return pinned runtime plus desired config");
 
-        let (peer_mgr_internal_tx, mut peer_mgr_internal_rx) =
-            mpsc::unbounded_channel::<InternalCommand>();
-        let pm = tokio::spawn(async move {
-            match peer_mgr_internal_rx.recv().await {
-                Some(InternalCommand::ReplaceConfigSnapshot { ack: Some(ack), .. }) => {
-                    ack.send(()).is_ok()
-                }
-                _ => false,
-            }
-        });
-        let runtime = apply_reload_outcome(reloaded, &peer_mgr_internal_tx, Some(&replace_tx))
-            .await
-            .expect("post-reload sync should succeed");
-        assert!(pm.await.unwrap(), "peer manager snapshot must be refreshed");
+        let runtime = reloaded.runtime.clone();
+        let (adopted, adopted_rx) = oneshot::channel();
+        replace_tx
+            .send(AcceptedBridgeReplacement {
+                snapshot: Arc::clone(&reloaded.desired),
+                adopted,
+            })
+            .unwrap();
+        assert!(matches!(
+            adopted_rx.await.unwrap(),
+            ReloadDispatch::Replied(())
+        ));
 
         event_tx
             .send(ConfigEvent::SetPolicy {

--- a/tests/runtime_config_persistence_failstop.rs
+++ b/tests/runtime_config_persistence_failstop.rs
@@ -9,6 +9,9 @@ use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use nix::sys::signal::{Signal, kill};
+use nix::unistd::Pid;
+
 const FIRST_NEIGHBOR: &str = "192.0.2.1";
 const SECOND_NEIGHBOR: &str = "192.0.2.2";
 const FAILSTOP_GRACE_WITH_JITTER: Duration = Duration::from_secs(7);
@@ -20,6 +23,14 @@ struct Daemon {
 
 impl Daemon {
     fn spawn(config: &Path, log_path: PathBuf, fault: Option<&str>) -> Self {
+        Self::spawn_with_fault(
+            config,
+            log_path,
+            fault.map(|value| ("RUSTBGPD_TEST_CONFIG_PUBLISH_FAILURE", value)),
+        )
+    }
+
+    fn spawn_with_fault(config: &Path, log_path: PathBuf, fault: Option<(&str, &str)>) -> Self {
         let stderr = File::create(&log_path).expect("create daemon log");
         let stdout = stderr.try_clone().expect("clone daemon log handle");
         let mut command = Command::new(env!("CARGO_BIN_EXE_rustbgpd"));
@@ -27,8 +38,8 @@ impl Daemon {
             .arg(config)
             .stdout(Stdio::from(stdout))
             .stderr(Stdio::from(stderr));
-        if let Some(fault) = fault {
-            command.env("RUSTBGPD_TEST_CONFIG_PUBLISH_FAILURE", fault);
+        if let Some((name, value)) = fault {
+            command.env(name, value);
         }
         let child = command.spawn().expect("spawn rustbgpd");
         Self { child, log_path }
@@ -57,6 +68,11 @@ impl Daemon {
 
     fn log(&self) -> String {
         std::fs::read_to_string(&self.log_path).unwrap_or_default()
+    }
+
+    fn sighup(&self) {
+        let pid = i32::try_from(self.child.id()).expect("daemon PID fits i32");
+        kill(Pid::from_raw(pid), Signal::SIGHUP).expect("send SIGHUP");
     }
 }
 
@@ -268,4 +284,50 @@ fn pre_rename_failure_fences_and_restart_loads_prior_config() {
 #[test]
 fn post_rename_failure_fences_and_restart_loads_complete_candidate() {
     exercise("publication_ambiguous", true);
+}
+
+fn exercise_sighup_ack_loss(fault: &str) {
+    let dir = tempfile::tempdir().expect("create test dir");
+    let runtime_dir = dir.path().join("runtime");
+    std::fs::create_dir(&runtime_dir).unwrap();
+    let config_path = dir.path().join("rustbgpd.toml");
+    let metrics = unused_loopback_addr();
+    let initial = config(&runtime_dir, metrics);
+    std::fs::write(&config_path, &initial).unwrap();
+    let grpc_addr = format!("unix://{}", runtime_dir.join("grpc.sock").display());
+    let mut daemon = Daemon::spawn_with_fault(
+        &config_path,
+        dir.path().join("sighup-fault-daemon.log"),
+        Some(("RUSTBGPD_TEST_SIGHUP_ACK_LOSS", fault)),
+    );
+    wait_until_serving(&grpc_addr, &mut daemon);
+    wait_until_ready(metrics, &mut daemon, 200);
+
+    std::fs::write(
+        &config_path,
+        format!("{initial}\n[[neighbors]]\naddress = \"{FIRST_NEIGHBOR}\"\nremote_asn = 65002\n"),
+    )
+    .unwrap();
+    daemon.sighup();
+    wait_until_ready(metrics, &mut daemon, 503);
+    let fenced_at = Instant::now();
+    let rejected = rbgp(
+        &grpc_addr,
+        &["neighbor", SECOND_NEIGHBOR, "add", "--remote-asn", "65003"],
+    );
+    assert!(!rejected.status.success());
+    daemon.assert_running();
+    let status =
+        daemon.wait_for_exit(FAILSTOP_GRACE_WITH_JITTER.saturating_sub(fenced_at.elapsed()));
+    assert_eq!(status.code(), Some(70), "log:\n{}", daemon.log());
+}
+
+#[test]
+fn sighup_reconcile_ack_loss_fences_and_exits_once() {
+    exercise_sighup_ack_loss("reconcile");
+}
+
+#[test]
+fn sighup_bridge_persister_ack_loss_fences_and_exits_once() {
+    exercise_sighup_ack_loss("bridge");
 }


### PR DESCRIPTION
## Summary

- make SIGHUP a watched runtime-config settlement owner from coordinator admission through final authority adoption
- preserve typed no-effect, durable, partial, divergent, publication-ambiguous, and acknowledgement-lost outcomes across peer, policy, FIB, EVPN, persister, and transport work
- close mutation admission during shutdown, wait for logical settlement and physical coordinator drain, and remove legacy SIGHUP/FIB compatibility paths
- classify read-only snapshot and TCP-AO preflight failures as clean no-effect while fail-stopping accepted mutation uncertainty

Linear: LAN-1004

## Verification

- `cargo test --locked --workspace --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- reload 90/90; peer-manager policy 23/23; config mutation 30/30; EVPN converger 119/119
- serial real-process settlement fail-stop suite 4/4
- v1 stable-surface and release-install contract checkers
