### PR TITLE
fix: make config settlement state truthful

### DIFF
--- a/crates/api/src/config_service.rs
+++ b/crates/api/src/config_service.rs
@@ -19,6 +19,7 @@ use crate::peer_types::{
     RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus,
 };
 use crate::proto;
+use crate::runtime_config_settlement::OwnedRuntimeConfigRequestContext;
 use crate::server::{
     ConfigHistoryListFn, ConfigRollbackFn, ConfigTransactionAbortFn, ConfigTransactionApplyContext,
     ConfigTransactionApplyError, ConfigTransactionApplyFn, ConfigTransactionConfirmFn,
@@ -331,7 +332,8 @@ impl proto::config_service_server::ConfigService for ConfigService {
                 "ConfigService.ConfirmConfigTransaction executor is unavailable",
             ));
         };
-        transaction_confirm(request)
+        let (context, _attachment) = OwnedRuntimeConfigRequestContext::unary();
+        transaction_confirm(request, context)
             .await
             .map(Response::new)
             .map_err(ConfigTransactionApplyError::into_status)
@@ -351,7 +353,8 @@ impl proto::config_service_server::ConfigService for ConfigService {
                 "ConfigService.AbortConfigTransaction executor is unavailable",
             ));
         };
-        transaction_abort(request)
+        let (context, _attachment) = OwnedRuntimeConfigRequestContext::unary();
+        transaction_abort(request, context)
             .await
             .map(Response::new)
             .map_err(ConfigTransactionApplyError::into_status)
@@ -412,7 +415,8 @@ impl proto::config_service_server::ConfigService for ConfigService {
                 "ConfigService.RollbackConfigTransaction executor is unavailable",
             ));
         };
-        rollback(request)
+        let (context, _attachment) = OwnedRuntimeConfigRequestContext::unary();
+        rollback(request, context)
             .await
             .map(Response::new)
             .map_err(ConfigTransactionApplyError::into_status)
@@ -441,10 +445,43 @@ mod tests {
     use super::*;
     use prost::Message as _;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use tokio::time::Duration;
 
     use crate::audit::GrpcAuditHandle;
     use proto::config_service_server::ConfigService as _;
+
+    #[derive(Clone)]
+    struct DetachedHookProbe {
+        started: mpsc::UnboundedSender<Arc<AtomicBool>>,
+        release: Arc<tokio::sync::Semaphore>,
+        continued: mpsc::UnboundedSender<()>,
+    }
+
+    impl DetachedHookProbe {
+        fn hook<T: Default + Send + 'static>(
+            &self,
+            context: &OwnedRuntimeConfigRequestContext,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<T, ConfigTransactionApplyError>> + Send>,
+        > {
+            let attached = context.response_attached();
+            let started = self.started.clone();
+            let release = Arc::clone(&self.release);
+            let continued = self.continued.clone();
+            Box::pin(async move {
+                tokio::spawn(async move {
+                    assert!(attached.load(Ordering::Acquire));
+                    started.send(Arc::clone(&attached)).unwrap();
+                    release.acquire().await.unwrap().forget();
+                    continued.send(()).unwrap();
+                    Ok(T::default())
+                })
+                .await
+                .unwrap()
+            })
+        }
+    }
 
     #[derive(Clone, PartialEq, prost::Message)]
     struct LegacyConfigHistoryEntry {
@@ -962,8 +999,13 @@ mod tests {
         let (tx, _rx) = mpsc::channel(1);
         let svc = ConfigService::new(tx).with_transaction_hooks(
             None,
-            Some(Arc::new(|request| {
+            Some(Arc::new(|request, context| {
                 Box::pin(async move {
+                    assert!(
+                        context
+                            .response_attached()
+                            .load(std::sync::atomic::Ordering::Acquire)
+                    );
                     assert_eq!(request.confirm_id, "deploy-42");
                     Ok(proto::ConfirmConfigTransactionResponse {
                         confirmation: Some(proto::ConfigTransactionConfirmation {
@@ -979,8 +1021,13 @@ mod tests {
                     })
                 })
             })),
-            Some(Arc::new(|request| {
+            Some(Arc::new(|request, context| {
                 Box::pin(async move {
+                    assert!(
+                        context
+                            .response_attached()
+                            .load(std::sync::atomic::Ordering::Acquire)
+                    );
                     assert_eq!(request.confirm_id, "deploy-42");
                     Ok(proto::AbortConfigTransactionResponse {
                         confirmation: Some(proto::ConfigTransactionConfirmation {
@@ -1052,6 +1099,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unary_control_cancellation_detaches_but_does_not_cancel_daemon_hooks() {
+        let (started, mut started_rx) = mpsc::unbounded_channel();
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+        let (continued, mut continued_rx) = mpsc::unbounded_channel();
+        let probe = DetachedHookProbe {
+            started,
+            release: Arc::clone(&release),
+            continued,
+        };
+        let (tx, _rx) = mpsc::channel(1);
+        let svc = Arc::new(ConfigService::new(tx).with_transaction_hooks(
+            None,
+            Some(Arc::new({
+                let probe = probe.clone();
+                move |_, context| probe.hook::<proto::ConfirmConfigTransactionResponse>(&context)
+            })),
+            Some(Arc::new({
+                let probe = probe.clone();
+                move |_, context| probe.hook::<proto::AbortConfigTransactionResponse>(&context)
+            })),
+            None,
+            None,
+            Some(Arc::new(move |_, context| {
+                probe.hook::<proto::ConfigTransactionApplyResponse>(&context)
+            })),
+        ));
+
+        macro_rules! assert_detached {
+            ($method:ident, $request:expr) => {{
+                let svc = Arc::clone(&svc);
+                let rpc =
+                    tokio::spawn(
+                        async move { svc.$method(Request::new($request)).await.map(|_| ()) },
+                    );
+                let attached = started_rx.recv().await.unwrap();
+                assert!(attached.load(Ordering::Acquire));
+                rpc.abort();
+                assert!(rpc.await.unwrap_err().is_cancelled());
+                assert!(!attached.load(Ordering::Acquire));
+                release.add_permits(1);
+                continued_rx.recv().await.unwrap();
+            }};
+        }
+        let confirm = proto::ConfirmConfigTransactionRequest::default();
+        let abort = proto::AbortConfigTransactionRequest::default();
+        let rollback = proto::RollbackConfigTransactionRequest::default();
+        assert_detached!(confirm_config_transaction, confirm);
+        assert_detached!(abort_config_transaction, abort);
+        assert_detached!(rollback_config_transaction, rollback);
+    }
+
+    #[tokio::test]
     async fn confirmed_transaction_control_hooks_fail_closed_without_executor() {
         let (tx, _rx) = mpsc::channel(1);
         let svc = ConfigService::new(tx);
@@ -1106,8 +1205,13 @@ mod tests {
                 })
             })),
             Some(Arc::new(
-                |request: proto::RollbackConfigTransactionRequest| {
+                |request: proto::RollbackConfigTransactionRequest, context| {
                     Box::pin(async move {
+                        assert!(
+                            context
+                                .response_attached()
+                                .load(std::sync::atomic::Ordering::Acquire)
+                        );
                         assert_eq!(request.index, 2);
                         assert_eq!(request.confirm_id, "rollback-1");
                         Ok(proto::ConfigTransactionApplyResponse {

--- a/crates/api/src/gnmi_service.rs
+++ b/crates/api/src/gnmi_service.rs
@@ -21,6 +21,7 @@ use crate::gnmi;
 use crate::gnmi_ext;
 use crate::peer_types::{PeerInfo, PeerManagerCommand};
 use crate::proto;
+use crate::runtime_config_settlement::OwnedRuntimeConfigRequestContext;
 use crate::server::{
     AccessMode, GnmiSetCommitAction, GnmiSetFn, GnmiSetOperation, GnmiSetTransaction,
     read_only_rejection,
@@ -2466,7 +2467,8 @@ impl gnmi::g_nmi_server::GNmi for GnmiService {
         // therefore only ever sent when every operation was applied — partial
         // apply is unrepresentable by construction, not misreported.
         let mut response = set_response_from_operations(&transaction.operations);
-        let outcome = set_handler(transaction)
+        let (context, _attachment) = OwnedRuntimeConfigRequestContext::unary();
+        let outcome = set_handler(transaction, context)
             .await
             .map_err(crate::server::GnmiSetError::into_status)?;
         response.timestamp = now_nanos();
@@ -2553,6 +2555,7 @@ mod tests {
     use super::*;
     use crate::test_support::peer_info;
     use gnmi::g_nmi_server::GNmi as _;
+    use std::sync::atomic::Ordering;
     use std::sync::{Arc, Mutex};
 
     fn test_service(peers: Vec<PeerInfo>) -> GnmiService {
@@ -2762,7 +2765,12 @@ mod tests {
     async fn set_with_hook_normalizes_operations_and_builds_response() {
         let captured = Arc::new(Mutex::new(Vec::new()));
         let hook_captured = Arc::clone(&captured);
-        let hook: crate::server::GnmiSetFn = Arc::new(move |transaction| {
+        let hook: crate::server::GnmiSetFn = Arc::new(move |transaction, context| {
+            assert!(
+                context
+                    .response_attached()
+                    .load(std::sync::atomic::Ordering::Acquire)
+            );
             hook_captured.lock().unwrap().push(transaction);
             Box::pin(async { Ok(crate::server::GnmiSetOutcome::default()) })
         });
@@ -2837,8 +2845,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn set_cancellation_detaches_but_does_not_cancel_daemon_hook() {
+        let (started, mut started_rx) = tokio::sync::mpsc::unbounded_channel();
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+        let daemon_release = Arc::clone(&release);
+        let (continued, mut continued_rx) = tokio::sync::mpsc::unbounded_channel();
+        let hook: crate::server::GnmiSetFn = Arc::new(move |_, context| {
+            let attached = context.response_attached();
+            let started = started.clone();
+            let daemon_release = Arc::clone(&daemon_release);
+            let continued = continued.clone();
+            Box::pin(async move {
+                tokio::spawn(async move {
+                    assert!(attached.load(Ordering::Acquire));
+                    started.send(Arc::clone(&attached)).unwrap();
+                    daemon_release.acquire().await.unwrap().forget();
+                    assert!(!attached.load(Ordering::Acquire));
+                    continued.send(()).unwrap();
+                    Ok(crate::server::GnmiSetOutcome::default())
+                })
+                .await
+                .unwrap()
+            })
+        });
+        let service = test_service(Vec::new()).with_set_handler(Some(hook));
+        let rpc = tokio::spawn(async move {
+            service
+                .set(Request::new(gnmi::SetRequest {
+                    prefix: Some(mounted_path(&[])),
+                    delete: vec![relative_path(&["neighbors"])],
+                    replace: Vec::new(),
+                    update: Vec::new(),
+                    extension: Vec::new(),
+                    union_replace: Vec::new(),
+                }))
+                .await
+        });
+        let attached = started_rx.recv().await.unwrap();
+        assert!(attached.load(Ordering::Acquire));
+        rpc.abort();
+        assert!(rpc.await.unwrap_err().is_cancelled());
+        assert!(!attached.load(Ordering::Acquire));
+        release.add_permits(1);
+        continued_rx.recv().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn set_rejects_union_replace_before_hook() {
-        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_, _| {
             panic!("union_replace must reject before invoking the hook");
         });
         let err = test_service(Vec::new())
@@ -2859,7 +2913,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_rejects_empty_request_before_hook() {
-        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_, _| {
             panic!("empty Set request must reject before invoking the hook");
         });
         let err = test_service(Vec::new())
@@ -2882,7 +2936,7 @@ mod tests {
     async fn set_with_commit_request_forwards_confirmed_apply_action() {
         let captured = Arc::new(Mutex::new(Vec::new()));
         let hook_captured = Arc::clone(&captured);
-        let hook: crate::server::GnmiSetFn = Arc::new(move |transaction| {
+        let hook: crate::server::GnmiSetFn = Arc::new(move |transaction, _context| {
             hook_captured.lock().unwrap().push(transaction);
             Box::pin(async { Ok(crate::server::GnmiSetOutcome::default()) })
         });
@@ -2924,7 +2978,7 @@ mod tests {
     async fn set_with_commit_confirm_forwards_empty_transaction_action() {
         let captured = Arc::new(Mutex::new(Vec::new()));
         let hook_captured = Arc::clone(&captured);
-        let hook: crate::server::GnmiSetFn = Arc::new(move |transaction| {
+        let hook: crate::server::GnmiSetFn = Arc::new(move |transaction, _context| {
             hook_captured.lock().unwrap().push(transaction);
             Box::pin(async { Ok(crate::server::GnmiSetOutcome::default()) })
         });
@@ -2960,7 +3014,7 @@ mod tests {
     async fn set_with_commit_cancel_forwards_empty_transaction_action() {
         let captured = Arc::new(Mutex::new(Vec::new()));
         let hook_captured = Arc::clone(&captured);
-        let hook: crate::server::GnmiSetFn = Arc::new(move |transaction| {
+        let hook: crate::server::GnmiSetFn = Arc::new(move |transaction, _context| {
             hook_captured.lock().unwrap().push(transaction);
             Box::pin(async { Ok(crate::server::GnmiSetOutcome::default()) })
         });
@@ -2992,7 +3046,7 @@ mod tests {
     async fn set_with_commit_rollback_reset_forwards_empty_transaction_action() {
         let captured = Arc::new(Mutex::new(Vec::new()));
         let hook_captured = Arc::clone(&captured);
-        let hook: crate::server::GnmiSetFn = Arc::new(move |transaction| {
+        let hook: crate::server::GnmiSetFn = Arc::new(move |transaction, _context| {
             hook_captured.lock().unwrap().push(transaction);
             Box::pin(async { Ok(crate::server::GnmiSetOutcome::default()) })
         });
@@ -3030,7 +3084,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_rejects_unknown_extensions_before_hook() {
-        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_, _| {
             panic!("extensions must reject before invoking the hook");
         });
         let err = test_service(Vec::new())
@@ -3051,7 +3105,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_rejects_commit_action_shape_errors_before_hook() {
-        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_, _| {
             panic!("commit action shape errors must reject before invoking the hook");
         });
         let err = test_service(Vec::new())
@@ -3090,7 +3144,7 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
         assert!(err.message().contains("must not include Set operations"));
 
-        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_, _| {
             panic!("rollback-duration shape errors must reject before invoking the hook");
         });
         let err = test_service(Vec::new())
@@ -3120,7 +3174,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_rejects_commit_rollback_reset_missing_duration_before_hook() {
-        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_, _| {
             panic!("rollback-duration validation errors must reject before invoking the hook");
         });
         let err = test_service(Vec::new())
@@ -3147,7 +3201,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_rejects_empty_typed_value_before_hook() {
-        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_, _| {
             panic!("empty typed value must reject before invoking the hook");
         });
         let err = test_service(Vec::new())
@@ -3168,7 +3222,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_rejects_non_openconfig_origin_before_hook() {
-        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_, _| {
             panic!("bad origin must reject before invoking the hook");
         });
         let mut path = relative_path(&["bgp"]);
@@ -3194,7 +3248,7 @@ mod tests {
     /// `gnmi.gNMI/Set`.
     #[tokio::test]
     async fn set_on_read_only_listener_is_rejected_before_hook() {
-        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_, _| {
             panic!("read-only listeners must reject Set before invoking the hook");
         });
         let mut service = test_service(Vec::new()).with_set_handler(Some(hook));
@@ -3215,7 +3269,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_hook_error_maps_to_grpc_status() {
-        let hook: crate::server::GnmiSetFn = Arc::new(|_| {
+        let hook: crate::server::GnmiSetFn = Arc::new(|_, _| {
             Box::pin(async {
                 Err(crate::server::GnmiSetError::FailedPrecondition(
                     "confirmed transaction pending".to_string(),

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -526,11 +526,6 @@ async fn owned_peer_group_mutation_body(
     };
 
     let dispatch = dispatch_owned_catalog_mutation(peer_mgr_tx, actor_timeout, mutation).await;
-    if matches!(dispatch, OwnedCatalogDispatch::Replied(_))
-        && let Some(operation) = &owned
-    {
-        operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
-    }
     match dispatch {
         OwnedCatalogDispatch::NotAccepted(error) => {
             drop(staged);
@@ -557,6 +552,9 @@ async fn owned_peer_group_mutation_body(
             let Some(staged) = staged else {
                 return OwnedRuntimeConfigOutcome::PublishedDurable(());
             };
+            if let Some(operation) = &owned {
+                operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
+            }
             match staged.commit_typed().await {
                 Ok(()) => OwnedRuntimeConfigOutcome::PublishedDurable(()),
                 Err(error) => {

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -473,11 +473,6 @@ async fn owned_policy_mutation_body(
         None
     };
     let dispatch = dispatch_owned_catalog_mutation(peer_mgr_tx, actor_timeout, mutation).await;
-    if matches!(dispatch, OwnedCatalogDispatch::Replied(_))
-        && let Some(operation) = &owned
-    {
-        operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
-    }
     match dispatch {
         OwnedCatalogDispatch::NotAccepted(error) => {
             drop(staged);
@@ -504,6 +499,9 @@ async fn owned_policy_mutation_body(
             let Some(staged) = staged else {
                 return OwnedRuntimeConfigOutcome::PublishedDurable(());
             };
+            if let Some(operation) = &owned {
+                operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
+            }
             match staged.commit_typed().await {
                 Ok(()) => OwnedRuntimeConfigOutcome::PublishedDurable(()),
                 Err(error) => {

--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -74,12 +74,14 @@ pub enum RuntimeConfigFenceReason {
     AcknowledgementLost,
 }
 
-const TERMINAL_OWNED: u8 = 0;
-const TERMINAL_SETTLED: u8 = 1;
-const TERMINAL_AMBIGUOUS: u8 = 2;
 const PHASE_PREFLIGHT: u8 = 0;
 const PHASE_MUTATING: u8 = 1;
 const PHASE_SETTLING: u8 = 2;
+const PHASE_MASK: u8 = 0b11;
+const TERMINAL_OWNED: u8 = 0;
+const TERMINAL_SETTLED: u8 = 1 << 2;
+const TERMINAL_AMBIGUOUS: u8 = 2 << 2;
+const TERMINAL_MASK: u8 = 0b11 << 2;
 const AMBIGUITY_REASON_NONE: u8 = 0;
 const AMBIGUITY_REASON_BUDGET: u8 = 1;
 const AMBIGUITY_REASON_EXECUTOR: u8 = 2;
@@ -99,8 +101,7 @@ struct OperationInner {
     id: u64,
     kind: RuntimeConfigOperationKind,
     deadline: Instant,
-    phase: AtomicU8,
-    terminal: AtomicU8,
+    state: AtomicU8,
     fence_reason: AtomicU8,
     response_attached: Arc<AtomicBool>,
     coordinator: RuntimeConfigCoordinator,
@@ -264,8 +265,7 @@ impl RuntimeConfigSettlementWatchdog {
             id,
             kind,
             deadline,
-            phase: AtomicU8::new(PHASE_PREFLIGHT),
-            terminal: AtomicU8::new(TERMINAL_OWNED),
+            state: AtomicU8::new(TERMINAL_OWNED | PHASE_PREFLIGHT),
             fence_reason: AtomicU8::new(AMBIGUITY_REASON_NONE),
             response_attached,
             coordinator,
@@ -409,6 +409,14 @@ impl OwnedRuntimeConfigRequestContext {
         )
     }
 
+    /// Create a daemon-owned request with no response transport attached.
+    #[must_use]
+    pub fn detached() -> Self {
+        Self {
+            response_attached: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
     /// Transfer the shared attachment sentinel to the detached executor.
     #[must_use]
     pub fn response_attached(&self) -> Arc<AtomicBool> {
@@ -444,26 +452,42 @@ impl OwnedRuntimeConfigOperation {
 
     #[must_use]
     pub fn phase(&self) -> RuntimeConfigSettlementPhase {
-        match self.inner.phase.load(Ordering::Acquire) {
+        match self.inner.state.load(Ordering::Acquire) & PHASE_MASK {
             PHASE_PREFLIGHT => RuntimeConfigSettlementPhase::OwnedPreflight,
             PHASE_MUTATING => RuntimeConfigSettlementPhase::Mutating,
             _ => RuntimeConfigSettlementPhase::SettlingRollback,
         }
     }
 
-    /// Advance the phase monotonically. Regressions are ignored.
+    /// Advance the phase monotonically while ownership is live.
+    /// Settlement and recovery fencing atomically freeze the last phase.
     pub fn advance_phase(&self, phase: RuntimeConfigSettlementPhase) {
         let desired = match phase {
             RuntimeConfigSettlementPhase::OwnedPreflight => PHASE_PREFLIGHT,
             RuntimeConfigSettlementPhase::Mutating => PHASE_MUTATING,
             RuntimeConfigSettlementPhase::SettlingRollback => PHASE_SETTLING,
         };
-        self.inner.phase.fetch_max(desired, Ordering::AcqRel);
+        let mut observed = self.inner.state.load(Ordering::Acquire);
+        loop {
+            if observed & TERMINAL_MASK != TERMINAL_OWNED || observed & PHASE_MASK >= desired {
+                return;
+            }
+            let next = (observed & !PHASE_MASK) | desired;
+            match self.inner.state.compare_exchange_weak(
+                observed,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return,
+                Err(actual) => observed = actual,
+            }
+        }
     }
 
     #[must_use]
     pub fn terminal(&self) -> RuntimeConfigSettlementTerminal {
-        match self.inner.terminal.load(Ordering::Acquire) {
+        match self.inner.state.load(Ordering::Acquire) & TERMINAL_MASK {
             TERMINAL_OWNED => RuntimeConfigSettlementTerminal::Owned,
             TERMINAL_SETTLED => RuntimeConfigSettlementTerminal::Settled,
             _ => RuntimeConfigSettlementTerminal::RecoveryFenced,
@@ -482,13 +506,6 @@ impl OwnedRuntimeConfigOperation {
         }
     }
 
-    /// Mark whether a transport is still waiting; this never changes ownership.
-    pub fn set_response_attached(&self, attached: bool) {
-        self.inner
-            .response_attached
-            .store(attached, Ordering::Release);
-    }
-
     /// Fence a typed recovery result before any response can be published.
     #[must_use]
     pub fn fence_recovery(&self, reason: RuntimeConfigFenceReason) -> bool {
@@ -502,18 +519,21 @@ impl OwnedRuntimeConfigOperation {
 
     /// Prove settlement and release physical ownership. Returns false after fencing.
     pub fn try_settle(&self) -> bool {
-        if self
-            .inner
-            .terminal
-            .compare_exchange(
-                TERMINAL_OWNED,
-                TERMINAL_SETTLED,
+        let mut observed = self.inner.state.load(Ordering::Acquire);
+        loop {
+            if observed & TERMINAL_MASK != TERMINAL_OWNED {
+                return false;
+            }
+            let settled = (observed & PHASE_MASK) | TERMINAL_SETTLED;
+            match self.inner.state.compare_exchange_weak(
+                observed,
+                settled,
                 Ordering::AcqRel,
                 Ordering::Acquire,
-            )
-            .is_err()
-        {
-            return false;
+            ) {
+                Ok(_) => break,
+                Err(actual) => observed = actual,
+            }
         }
         self.inner.registry.unregister(self.inner.id);
         let resources = self
@@ -544,17 +564,21 @@ impl Drop for RuntimeConfigExecutorGuard {
 }
 
 fn fence(operation: &OperationInner, reason: RuntimeConfigFenceReason) -> bool {
-    if operation
-        .terminal
-        .compare_exchange(
-            TERMINAL_OWNED,
-            TERMINAL_AMBIGUOUS,
+    let mut observed = operation.state.load(Ordering::Acquire);
+    loop {
+        if observed & TERMINAL_MASK != TERMINAL_OWNED {
+            return false;
+        }
+        let fenced = (observed & PHASE_MASK) | TERMINAL_AMBIGUOUS;
+        match operation.state.compare_exchange_weak(
+            observed,
+            fenced,
             Ordering::AcqRel,
             Ordering::Acquire,
-        )
-        .is_err()
-    {
-        return false;
+        ) {
+            Ok(_) => break,
+            Err(actual) => observed = actual,
+        }
     }
     let reason_value = match reason {
         RuntimeConfigFenceReason::BudgetExpired => AMBIGUITY_REASON_BUDGET,
@@ -600,7 +624,7 @@ fn watchdog_loop(registry: &Arc<Registry>) {
                 .registrations
                 .values()
                 .filter(|entry| {
-                    entry.operation.terminal.load(Ordering::Acquire) == TERMINAL_OWNED
+                    entry.operation.state.load(Ordering::Acquire) & TERMINAL_MASK == TERMINAL_OWNED
                         && entry.operation.deadline <= now
                 })
                 .map(|entry| Arc::clone(&entry.operation))
@@ -609,7 +633,8 @@ fn watchdog_loop(registry: &Arc<Registry>) {
                 .registrations
                 .values()
                 .find(|entry| {
-                    entry.operation.terminal.load(Ordering::Acquire) == TERMINAL_AMBIGUOUS
+                    entry.operation.state.load(Ordering::Acquire) & TERMINAL_MASK
+                        == TERMINAL_AMBIGUOUS
                         && entry.terminal_at <= now
                 })
                 .map(|entry| Arc::clone(&entry.operation));
@@ -617,7 +642,9 @@ fn watchdog_loop(registry: &Arc<Registry>) {
                 .registrations
                 .values()
                 .map(|entry| {
-                    if entry.operation.terminal.load(Ordering::Acquire) == TERMINAL_OWNED {
+                    if entry.operation.state.load(Ordering::Acquire) & TERMINAL_MASK
+                        == TERMINAL_OWNED
+                    {
                         entry.operation.deadline
                     } else {
                         entry.terminal_at
@@ -781,6 +808,53 @@ mod tests {
         );
         assert_eq!(operation.deadline(), deadline);
         assert!(operation.try_settle());
+        operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
+        assert_eq!(
+            operation.phase(),
+            RuntimeConfigSettlementPhase::SettlingRollback
+        );
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn terminal_transition_freezes_phase_against_concurrent_advance() {
+        let (watchdog, _receiver) = test_watchdog(Duration::from_secs(1), Duration::from_secs(1));
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        let barrier = Arc::new(std::sync::Barrier::new(3));
+        let advance = {
+            let operation = operation.clone();
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
+            })
+        };
+        let settle = {
+            let operation = operation.clone();
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                operation.try_settle()
+            })
+        };
+        barrier.wait();
+        advance.join().unwrap();
+        assert!(settle.join().unwrap());
+        let frozen = operation.phase();
+        operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
+        assert_eq!(operation.phase(), frozen);
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn recovery_fence_freezes_last_owned_phase() {
+        let (watchdog, receiver) = test_watchdog(Duration::from_secs(5), Duration::from_millis(20));
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
+        assert!(operation.fence_recovery(RuntimeConfigFenceReason::KnownDivergence));
+        operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
+        assert_eq!(operation.phase(), RuntimeConfigSettlementPhase::Mutating);
+        assert_eq!(receiver.recv_timeout(Duration::from_secs(5)).unwrap(), 70);
         drop(guard);
     }
 
@@ -797,6 +871,19 @@ mod tests {
         drop(guard);
         assert!(coordinator_waiter.await.unwrap().is_ok());
         assert!(admission_waiter.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn clean_settlement_freezes_preflight_phase() {
+        let (watchdog, _receiver) = test_watchdog(Duration::from_secs(1), Duration::from_secs(1));
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        assert!(operation.try_settle());
+        operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
+        assert_eq!(
+            operation.phase(),
+            RuntimeConfigSettlementPhase::OwnedPreflight
+        );
+        drop(guard);
     }
 
     #[tokio::test]
@@ -968,8 +1055,18 @@ mod tests {
     async fn std_thread_deadline_ignores_paused_tokio_clock_and_detach() {
         let (watchdog, receiver) =
             test_watchdog(Duration::from_millis(40), Duration::from_millis(20));
-        let (operation, guard, coordinator, _) = operation(&watchdog, false).await;
-        operation.set_response_attached(false);
+        let coordinator = RuntimeConfigCoordinator::new();
+        let permit = coordinator.acquire().await.unwrap();
+        let context = OwnedRuntimeConfigRequestContext::detached();
+        let (operation, guard) = watchdog.register_owned(
+            RuntimeConfigOperationKind::Sighup,
+            coordinator.clone(),
+            permit,
+            DaemonGate::new(),
+            None,
+            None,
+            context.response_attached(),
+        );
         assert!(!operation.response_attached());
         assert_eq!(receiver.recv_timeout(Duration::from_secs(5)).unwrap(), 70);
         assert!(coordinator.is_closed());

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -58,9 +58,10 @@ use crate::proto::peer_group_service_server::PeerGroupServiceServer;
 use crate::proto::policy_service_server::PolicyServiceServer;
 use crate::proto::rib_service_server::RibServiceServer;
 use crate::rib_service::RibService;
-use crate::runtime_config_settlement::RuntimeConfigSettlementWatchdog;
-
-use crate::runtime_config_settlement::RuntimeConfigFenceReason;
+use crate::runtime_config_settlement::{
+    OwnedRuntimeConfigRequestContext, OwnedRuntimeConfigResponseAttachment,
+    RuntimeConfigFenceReason, RuntimeConfigSettlementWatchdog,
+};
 use rustbgpd_rib::{RibReadinessQuery, RibUpdate};
 use rustbgpd_telemetry::BgpMetrics;
 
@@ -402,7 +403,12 @@ pub type GnmiSetFuture =
 ///
 /// The binary crate owns this because `OpenConfig` Set must translate into
 /// complete candidate TOML and then use the ADR-0076 transaction controller.
-pub type GnmiSetFn = Arc<dyn Fn(GnmiSetTransaction) -> GnmiSetFuture + Send + Sync + 'static>;
+pub type GnmiSetFn = Arc<
+    dyn Fn(GnmiSetTransaction, OwnedRuntimeConfigRequestContext) -> GnmiSetFuture
+        + Send
+        + Sync
+        + 'static,
+>;
 
 /// Future returned by the daemon-owned config transaction apply hook.
 pub type ConfigTransactionApplyFuture = Pin<
@@ -432,20 +438,20 @@ pub type ConfigTransactionApplyFn = Arc<
 
 /// Transport state transferred to the daemon-owned Apply executor.
 pub struct ConfigTransactionApplyContext {
-    response_attached: Arc<std::sync::atomic::AtomicBool>,
+    request: OwnedRuntimeConfigRequestContext,
     stream: Option<StreamApplyOwnership>,
 }
 
 impl ConfigTransactionApplyContext {
     #[must_use]
-    pub fn unary() -> (Self, ConfigTransactionResponseAttachment) {
-        let attached = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    pub fn unary() -> (Self, OwnedRuntimeConfigResponseAttachment) {
+        let (request, attachment) = OwnedRuntimeConfigRequestContext::unary();
         (
             Self {
-                response_attached: Arc::clone(&attached),
+                request,
                 stream: None,
             },
-            ConfigTransactionResponseAttachment(attached),
+            attachment,
         )
     }
 
@@ -453,15 +459,15 @@ impl ConfigTransactionApplyContext {
     pub(crate) fn streamed(
         permit: OwnedSemaphorePermit,
         admission: Arc<Semaphore>,
-    ) -> (Self, ConfigTransactionResponseAttachment) {
+    ) -> (Self, OwnedRuntimeConfigResponseAttachment) {
         let (mut context, attachment) = Self::unary();
         context.stream = Some(StreamApplyOwnership { permit, admission });
         (context, attachment)
     }
 
     #[must_use]
-    pub fn response_attached(&self) -> Arc<std::sync::atomic::AtomicBool> {
-        Arc::clone(&self.response_attached)
+    pub fn request_context(&self) -> &OwnedRuntimeConfigRequestContext {
+        &self.request
     }
 
     #[must_use]
@@ -475,15 +481,6 @@ impl ConfigTransactionApplyContext {
 struct StreamApplyOwnership {
     permit: OwnedSemaphorePermit,
     admission: Arc<Semaphore>,
-}
-
-/// Response-lifetime sentinel; dropping it records transport cancellation.
-pub struct ConfigTransactionResponseAttachment(Arc<std::sync::atomic::AtomicBool>);
-
-impl Drop for ConfigTransactionResponseAttachment {
-    fn drop(&mut self) {
-        self.0.store(false, std::sync::atomic::Ordering::Release);
-    }
 }
 
 /// Future returned by the daemon-owned config transaction confirm hook.
@@ -500,7 +497,10 @@ pub type ConfigTransactionConfirmFuture = Pin<
 
 /// Daemon-owned hook for `ConfigService.ConfirmConfigTransaction`.
 pub type ConfigTransactionConfirmFn = Arc<
-    dyn Fn(crate::proto::ConfirmConfigTransactionRequest) -> ConfigTransactionConfirmFuture
+    dyn Fn(
+            crate::proto::ConfirmConfigTransactionRequest,
+            OwnedRuntimeConfigRequestContext,
+        ) -> ConfigTransactionConfirmFuture
         + Send
         + Sync
         + 'static,
@@ -520,7 +520,10 @@ pub type ConfigTransactionAbortFuture = Pin<
 
 /// Daemon-owned hook for `ConfigService.AbortConfigTransaction`.
 pub type ConfigTransactionAbortFn = Arc<
-    dyn Fn(crate::proto::AbortConfigTransactionRequest) -> ConfigTransactionAbortFuture
+    dyn Fn(
+            crate::proto::AbortConfigTransactionRequest,
+            OwnedRuntimeConfigRequestContext,
+        ) -> ConfigTransactionAbortFuture
         + Send
         + Sync
         + 'static,
@@ -587,7 +590,10 @@ pub type ConfigRollbackFuture = Pin<
 /// entry and routes it through the same transaction executor as
 /// `ApplyConfigTransaction`.
 pub type ConfigRollbackFn = Arc<
-    dyn Fn(crate::proto::RollbackConfigTransactionRequest) -> ConfigRollbackFuture
+    dyn Fn(
+            crate::proto::RollbackConfigTransactionRequest,
+            OwnedRuntimeConfigRequestContext,
+        ) -> ConfigRollbackFuture
         + Send
         + Sync
         + 'static,

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -303,11 +303,15 @@ pub enum ReloadDispatch<T, E> {
 }
 
 impl TcpAoListenerHandle {
-    async fn dispatch<T>(
+    async fn dispatch<T, F>(
         &self,
         build: impl FnOnce(oneshot::Sender<std::io::Result<T>>) -> TcpAoListenerCommand,
         operation: &'static str,
-    ) -> ReloadDispatch<std::io::Result<T>, std::io::Error> {
+        before_dispatch: F,
+    ) -> ReloadDispatch<std::io::Result<T>, std::io::Error>
+    where
+        F: FnOnce(),
+    {
         let deadline = tokio::time::Instant::now() + TCP_AO_ROTATION_CONTROL_TIMEOUT;
         let permit = match tokio::time::timeout_at(deadline, self.tx.reserve()).await {
             Ok(Ok(permit)) => permit,
@@ -325,7 +329,9 @@ impl TcpAoListenerHandle {
             }
         };
         let (reply, response) = oneshot::channel();
-        permit.send(build(reply));
+        let command = build(reply);
+        before_dispatch();
+        permit.send(command);
         match tokio::time::timeout_at(deadline, response).await {
             Ok(Ok(result)) => ReloadDispatch::Replied(result),
             Ok(Err(_)) | Err(_) => ReloadDispatch::AcknowledgementLost,
@@ -346,6 +352,7 @@ impl TcpAoListenerHandle {
         self.dispatch(
             |reply| TcpAoListenerCommand::PreflightAddOnly { desired, reply },
             "TCP-AO listener preflight",
+            || {},
         )
         .await
     }
@@ -358,13 +365,18 @@ impl TcpAoListenerHandle {
     /// Returns an error when the listener task is unavailable or times out,
     /// the candidate is not a strict add-only successor, an MKT cannot be
     /// installed, or the complete kernel inventory cannot be verified.
-    pub async fn apply_add_only(
+    pub async fn apply_add_only<F>(
         &self,
         desired: TcpAoListenerGeneration,
-    ) -> ReloadDispatch<std::io::Result<TcpAoRotationStatus>, std::io::Error> {
+        before_dispatch: F,
+    ) -> ReloadDispatch<std::io::Result<TcpAoRotationStatus>, std::io::Error>
+    where
+        F: FnOnce(),
+    {
         self.dispatch(
             |reply| TcpAoListenerCommand::ApplyAddOnly { desired, reply },
             "TCP-AO listener rotation",
+            before_dispatch,
         )
         .await
     }
@@ -383,6 +395,7 @@ impl TcpAoListenerHandle {
         self.dispatch(
             |reply| TcpAoListenerCommand::PreflightSelection { desired, reply },
             "TCP-AO listener selection preflight",
+            || {},
         )
         .await
     }
@@ -393,13 +406,18 @@ impl TcpAoListenerHandle {
     ///
     /// Returns an error when the candidate is invalid or listener control
     /// delivery, acknowledgement, or completion times out.
-    pub async fn begin_selection(
+    pub async fn begin_selection<F>(
         &self,
         desired: TcpAoListenerGeneration,
-    ) -> ReloadDispatch<std::io::Result<TcpAoRotationStatus>, std::io::Error> {
+        before_dispatch: F,
+    ) -> ReloadDispatch<std::io::Result<TcpAoRotationStatus>, std::io::Error>
+    where
+        F: FnOnce(),
+    {
         self.dispatch(
             |reply| TcpAoListenerCommand::BeginSelection { desired, reply },
             "TCP-AO listener selection",
+            before_dispatch,
         )
         .await
     }
@@ -411,13 +429,18 @@ impl TcpAoListenerHandle {
     ///
     /// Returns an error when the generation cannot commit or listener control
     /// delivery, acknowledgement, or completion times out.
-    pub async fn finalize_selection(
+    pub async fn finalize_selection<F>(
         &self,
         generation: TcpAoRotationGeneration,
-    ) -> ReloadDispatch<std::io::Result<TcpAoRotationStatus>, std::io::Error> {
+        before_dispatch: F,
+    ) -> ReloadDispatch<std::io::Result<TcpAoRotationStatus>, std::io::Error>
+    where
+        F: FnOnce(),
+    {
         self.dispatch(
             |reply| TcpAoListenerCommand::FinalizeSelection { generation, reply },
             "TCP-AO listener metadata commit",
+            before_dispatch,
         )
         .await
     }
@@ -437,6 +460,7 @@ impl TcpAoListenerHandle {
         self.dispatch(
             |reply| TcpAoListenerCommand::PreflightDelete { desired, reply },
             "TCP-AO listener deletion preflight",
+            || {},
         )
         .await
     }
@@ -448,13 +472,18 @@ impl TcpAoListenerHandle {
     ///
     /// Returns an error when control fails or exact pre/post-delete kernel
     /// inventory cannot be proved.
-    pub async fn apply_delete(
+    pub async fn apply_delete<F>(
         &self,
         desired: TcpAoListenerGeneration,
-    ) -> ReloadDispatch<std::io::Result<TcpAoRotationStatus>, std::io::Error> {
+        before_dispatch: F,
+    ) -> ReloadDispatch<std::io::Result<TcpAoRotationStatus>, std::io::Error>
+    where
+        F: FnOnce(),
+    {
         self.dispatch(
             |reply| TcpAoListenerCommand::ApplyDelete { desired, reply },
             "TCP-AO listener deletion",
+            before_dispatch,
         )
         .await
     }
@@ -465,11 +494,15 @@ impl TcpAoListenerHandle {
     ///
     /// Returns an error when the generation is invalid or listener control
     /// delivery, acknowledgement, or completion times out.
-    pub async fn mark_awaiting_peer(
+    pub async fn mark_awaiting_peer<F>(
         &self,
         generation: TcpAoRotationGeneration,
         detail: String,
-    ) -> ReloadDispatch<std::io::Result<()>, std::io::Error> {
+        before_dispatch: F,
+    ) -> ReloadDispatch<std::io::Result<()>, std::io::Error>
+    where
+        F: FnOnce(),
+    {
         self.dispatch(
             |reply| TcpAoListenerCommand::MarkAwaitingPeer {
                 generation,
@@ -477,6 +510,7 @@ impl TcpAoListenerHandle {
                 reply,
             },
             "TCP-AO listener awaiting-peer marker",
+            before_dispatch,
         )
         .await
     }
@@ -497,11 +531,15 @@ impl TcpAoListenerHandle {
     /// Returns an error when the listener task is unavailable, the control
     /// deadline expires, or a kernel key install/remove fails (a partial
     /// application is safe to retry with the identical inventory).
-    pub async fn replace_inbound_auth(
+    pub async fn replace_inbound_auth<F>(
         &self,
         md5_keys: Vec<Md5ListenerKey>,
         ttl_security: Vec<TtlSecurityListenerPolicy>,
-    ) -> ReloadDispatch<std::io::Result<()>, std::io::Error> {
+        before_dispatch: F,
+    ) -> ReloadDispatch<std::io::Result<()>, std::io::Error>
+    where
+        F: FnOnce(),
+    {
         self.dispatch(
             |reply| TcpAoListenerCommand::ReplaceInboundAuth {
                 md5_keys,
@@ -509,6 +547,7 @@ impl TcpAoListenerHandle {
                 reply,
             },
             "BGP listener inbound-auth replacement",
+            before_dispatch,
         )
         .await
     }
@@ -521,11 +560,15 @@ impl TcpAoListenerHandle {
     ///
     /// Returns an error when the listener task is unavailable, the control
     /// deadline expires, or the generation is stale/already committed.
-    pub async fn mark_dependent_failure(
+    pub async fn mark_dependent_failure<F>(
         &self,
         generation: TcpAoRotationGeneration,
         error: String,
-    ) -> ReloadDispatch<std::io::Result<()>, std::io::Error> {
+        before_dispatch: F,
+    ) -> ReloadDispatch<std::io::Result<()>, std::io::Error>
+    where
+        F: FnOnce(),
+    {
         self.dispatch(
             |reply| TcpAoListenerCommand::MarkDependentFailure {
                 generation,
@@ -533,6 +576,7 @@ impl TcpAoListenerHandle {
                 reply,
             },
             "TCP-AO listener dependent-failure marker",
+            before_dispatch,
         )
         .await
     }
@@ -545,13 +589,18 @@ impl TcpAoListenerHandle {
     /// Returns an error when the listener task is unavailable, the control
     /// deadline expires, or the installed inventory does not exactly match
     /// the generation being committed.
-    pub async fn acknowledge_global_commit(
+    pub async fn acknowledge_global_commit<F>(
         &self,
         generation: TcpAoRotationGeneration,
-    ) -> ReloadDispatch<std::io::Result<TcpAoRotationStatus>, std::io::Error> {
+        before_dispatch: F,
+    ) -> ReloadDispatch<std::io::Result<TcpAoRotationStatus>, std::io::Error>
+    where
+        F: FnOnce(),
+    {
         self.dispatch(
             |reply| TcpAoListenerCommand::AcknowledgeGlobalCommit { generation, reply },
             "TCP-AO listener commit acknowledgement",
+            before_dispatch,
         )
         .await
     }
@@ -2692,26 +2741,41 @@ mod tests {
 
     #[tokio::test]
     async fn reload_dispatch_distinguishes_rejection_from_lost_acknowledgement() {
+        let phase_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let (tx, rx) = mpsc::channel(1);
         let (_status_tx, status_rx) = watch::channel(TcpAoRotationStatus::default());
         let rejected = TcpAoListenerHandle { tx, status_rx };
         drop(rx);
+        let rejected_phase = phase_calls.clone();
         assert!(matches!(
-            rejected.replace_inbound_auth(Vec::new(), Vec::new()).await,
+            rejected
+                .replace_inbound_auth(Vec::new(), Vec::new(), move || {
+                    rejected_phase.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                })
+                .await,
             ReloadDispatch::NotAccepted(_)
         ));
+        assert_eq!(phase_calls.load(std::sync::atomic::Ordering::SeqCst), 0);
 
         let (tx, mut rx) = mpsc::channel(1);
         let (_status_tx, status_rx) = watch::channel(TcpAoRotationStatus::default());
         let accepted = TcpAoListenerHandle { tx, status_rx };
+        let handler_phase = phase_calls.clone();
         let actor = tokio::spawn(async move {
             let command = rx.recv().await.expect("accepted listener command");
+            assert_eq!(handler_phase.load(std::sync::atomic::Ordering::SeqCst), 1);
             drop(command);
         });
+        let accepted_phase = phase_calls.clone();
         assert!(matches!(
-            accepted.replace_inbound_auth(Vec::new(), Vec::new()).await,
+            accepted
+                .replace_inbound_auth(Vec::new(), Vec::new(), move || {
+                    accepted_phase.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                })
+                .await,
             ReloadDispatch::AcknowledgementLost
         ));
+        assert_eq!(phase_calls.load(std::sync::atomic::Ordering::SeqCst), 1);
         actor.await.unwrap();
     }
 
@@ -2733,8 +2797,11 @@ mod tests {
         .unwrap();
 
         let started = tokio::time::Instant::now();
-        let pending =
-            tokio::spawn(async move { handle.replace_inbound_auth(Vec::new(), Vec::new()).await });
+        let pending = tokio::spawn(async move {
+            handle
+                .replace_inbound_auth(Vec::new(), Vec::new(), || {})
+                .await
+        });
         tokio::task::yield_now().await;
         tokio::time::advance(
             TCP_AO_ROTATION_CONTROL_TIMEOUT
@@ -3586,7 +3653,7 @@ mod tests {
         let task = tokio::spawn(listener.run());
 
         let outcome = handle
-            .mark_dependent_failure(generation, "session apply failed".to_string())
+            .mark_dependent_failure(generation, "session apply failed".to_string(), || {})
             .await;
         assert!(matches!(outcome, ReloadDispatch::Replied(Ok(()))));
         assert_eq!(handle.status().phase, TcpAoRotationPhase::AddOnlyFailed);
@@ -3596,7 +3663,8 @@ mod tests {
             Some("session apply failed")
         );
 
-        let ReloadDispatch::Replied(Ok(status)) = handle.apply_add_only(desired).await else {
+        let ReloadDispatch::Replied(Ok(status)) = handle.apply_add_only(desired, || {}).await
+        else {
             panic!("same-generation retry must return an authoritative success");
         };
         assert_eq!(status.phase, TcpAoRotationPhase::AddOnly);
@@ -3747,7 +3815,7 @@ mod tests {
             drop(reply);
         });
 
-        let status = handle.acknowledge_global_commit(generation).await;
+        let status = handle.acknowledge_global_commit(generation, || {}).await;
         assert!(matches!(status, ReloadDispatch::AcknowledgementLost));
         let status = handle.status();
         assert_eq!(status.phase, TcpAoRotationPhase::Idle);

--- a/crates/transport/tests/listener.rs
+++ b/crates/transport/tests/listener.rs
@@ -4,6 +4,56 @@ use rustbgpd_transport::BgpListener;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 
+#[tokio::test]
+async fn mutation_phase_waits_for_listener_command_admission() {
+    let (accept_tx, _accept_rx) = mpsc::channel(1);
+    let listener = BgpListener::bind("127.0.0.1:0".parse().unwrap(), accept_tx)
+        .await
+        .unwrap();
+    let control = listener.tcp_ao_rotation_handle();
+    let admitted = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let mut queued = Vec::new();
+    for _ in 0..4 {
+        let handle = control.clone();
+        let phase = admitted.clone();
+        queued.push(tokio::spawn(async move {
+            handle
+                .replace_inbound_auth(Vec::new(), Vec::new(), move || {
+                    phase.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                })
+                .await
+        }));
+    }
+    while admitted.load(std::sync::atomic::Ordering::SeqCst) != 4 {
+        tokio::task::yield_now().await;
+    }
+
+    let blocked_phase = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let phase = blocked_phase.clone();
+    let blocked = tokio::spawn(async move {
+        control
+            .replace_inbound_auth(Vec::new(), Vec::new(), move || {
+                phase.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            })
+            .await
+    });
+    tokio::task::yield_now().await;
+    assert_eq!(blocked_phase.load(std::sync::atomic::Ordering::SeqCst), 0);
+
+    drop(listener);
+    assert!(matches!(
+        blocked.await.unwrap(),
+        rustbgpd_transport::listener::ReloadDispatch::NotAccepted(_)
+    ));
+    assert_eq!(blocked_phase.load(std::sync::atomic::Ordering::SeqCst), 0);
+    for task in queued {
+        assert!(matches!(
+            task.await.unwrap(),
+            rustbgpd_transport::listener::ReloadDispatch::AcknowledgementLost
+        ));
+    }
+}
+
 #[cfg(target_os = "linux")]
 mod inbound_auth {
     use std::io::Write;
@@ -353,6 +403,8 @@ mod inbound_auth {
         let accepted = expect_accept(&mut accept_rx).await;
         expect_data_flows(signed_old, accepted).await;
 
+        let phase_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let phase = phase_calls.clone();
         let outcome = control
             .replace_inbound_auth(
                 vec![Md5ListenerKey {
@@ -361,9 +413,13 @@ mod inbound_auth {
                     password: "new-secret".into(),
                 }],
                 Vec::new(),
+                move || {
+                    phase.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                },
             )
             .await;
         assert!(matches!(outcome, ReloadDispatch::Replied(Ok(()))));
+        assert_eq!(phase_calls.load(std::sync::atomic::Ordering::SeqCst), 1);
 
         let stale = spawn_connect(addr, None, Some("old-secret".to_string()), None).await;
         assert!(
@@ -376,7 +432,9 @@ mod inbound_auth {
         let accepted = expect_accept(&mut accept_rx).await;
         expect_data_flows(signed_new, accepted).await;
 
-        let outcome = control.replace_inbound_auth(Vec::new(), Vec::new()).await;
+        let outcome = control
+            .replace_inbound_auth(Vec::new(), Vec::new(), || {})
+            .await;
         assert!(matches!(outcome, ReloadDispatch::Replied(Ok(()))));
         let plaintext = spawn_connect(addr, None, None, None)
             .await
@@ -412,6 +470,7 @@ mod inbound_auth {
                     prefix_len: 32,
                     enforce: true,
                 }],
+                || {},
             )
             .await;
         assert!(matches!(outcome, ReloadDispatch::Replied(Ok(()))));
@@ -538,6 +597,7 @@ mod inbound_auth {
                     },
                 ],
                 Vec::new(),
+                || {},
             )
             .await;
         assert!(matches!(outcome, ReloadDispatch::Replied(Ok(()))));

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -21,8 +21,8 @@ use rustbgpd_api::peer_types::{
 use rustbgpd_api::proto;
 use rustbgpd_api::runtime_config_settlement::RuntimeConfigFenceReason;
 use rustbgpd_api::runtime_config_settlement::{
-    OwnedRuntimeConfigOperation, RuntimeConfigOperationKind, RuntimeConfigSettlementPhase,
-    RuntimeConfigSettlementWatchdog,
+    OwnedRuntimeConfigOperation, OwnedRuntimeConfigRequestContext, RuntimeConfigOperationKind,
+    RuntimeConfigSettlementPhase, RuntimeConfigSettlementWatchdog,
 };
 use rustbgpd_api::server::{
     ConfigHistoryListFn, ConfigMutationGateFn, ConfigRollbackFn, ConfigTransactionAbortFn,
@@ -193,11 +193,32 @@ impl From<GnmiSetError> for OwnedGnmiSetError {
     }
 }
 
+#[derive(Clone, Default)]
+struct RuntimeConfigMutationProgress(Option<OwnedRuntimeConfigOperation>);
+
+impl RuntimeConfigMutationProgress {
+    fn owned(operation: &OwnedRuntimeConfigOperation) -> Self {
+        Self(Some(operation.clone()))
+    }
+
+    fn begin_mutation(&self) {
+        if let Some(operation) = &self.0 {
+            operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
+        }
+    }
+
+    fn begin_settling(&self) {
+        if let Some(operation) = &self.0 {
+            operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
+        }
+    }
+}
+
 impl ConfigTransactionController {
     async fn execute_owned_operation<T, E, F, Fut>(
         self,
         kind: RuntimeConfigOperationKind,
-        response_attached: bool,
+        context: OwnedRuntimeConfigRequestContext,
         shutdown_message: &'static str,
         task_lost_message: &'static str,
         body: F,
@@ -221,7 +242,7 @@ impl ConfigTransactionController {
                 daemon_gate,
                 None,
                 None,
-                Arc::new(AtomicBool::new(response_attached)),
+                context.response_attached(),
             );
             if self
                 .settlement
@@ -443,12 +464,13 @@ impl ConfigTransactionController {
             rustbgpd_api::peer_types::RuntimeConfigTransactionPlan,
             Arc<AcceptedConfigSnapshot>,
         )>,
+        progress: &RuntimeConfigMutationProgress,
     ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
         let confirmed = parse_confirmed_apply_mode(&request)?;
         if let Some(confirmed) = confirmed {
             self.begin_confirmed_apply(&confirmed.confirm_id).await?;
             let result = self
-                .apply_confirmed_locked(request, confirmed.clone(), preloaded)
+                .apply_confirmed_locked(request, confirmed.clone(), preloaded, progress)
                 .await;
             if !matches!(
                 result,
@@ -468,11 +490,12 @@ impl ConfigTransactionController {
                 request,
                 Some(preloaded),
                 self.peer_mgr_internal_tx.as_ref(),
+                progress,
             )
             .await
             .map_err(ApplyFailure::into_apply_error)
         } else {
-            self.apply_locked(request, None).await
+            self.apply_locked(request, None, progress).await
         }
     }
 
@@ -518,27 +541,31 @@ impl ConfigTransactionController {
     #[must_use]
     pub fn gnmi_set_fn(&self) -> GnmiSetFn {
         let controller = self.clone();
-        Arc::new(move |transaction| {
+        Arc::new(move |transaction, context| {
             let controller = controller.clone();
-            Box::pin(async move { controller.apply_gnmi_set(transaction).await })
+            Box::pin(async move {
+                controller
+                    .apply_gnmi_set_with_context(transaction, context)
+                    .await
+            })
         })
     }
 
     #[must_use]
     pub fn confirm_fn(&self) -> ConfigTransactionConfirmFn {
         let controller = self.clone();
-        Arc::new(move |request| {
+        Arc::new(move |request, context| {
             let controller = controller.clone();
-            Box::pin(async move { controller.confirm(request).await })
+            Box::pin(async move { controller.confirm_with_context(request, context).await })
         })
     }
 
     #[must_use]
     pub fn abort_fn(&self) -> ConfigTransactionAbortFn {
         let controller = self.clone();
-        Arc::new(move |request| {
+        Arc::new(move |request, context| {
             let controller = controller.clone();
-            Box::pin(async move { controller.abort(request).await })
+            Box::pin(async move { controller.abort_with_context(request, context).await })
         })
     }
 
@@ -563,9 +590,9 @@ impl ConfigTransactionController {
     #[must_use]
     pub fn rollback_fn(&self) -> ConfigRollbackFn {
         let controller = self.clone();
-        Arc::new(move |request| {
+        Arc::new(move |request, context| {
             let controller = controller.clone();
-            Box::pin(async move { controller.rollback(request).await })
+            Box::pin(async move { controller.rollback_with_context(request, context).await })
         })
     }
 
@@ -636,11 +663,17 @@ impl ConfigTransactionController {
                 )
             })??;
             let Some((watchdog, daemon_gate)) = self.settlement.clone() else {
-                let result = self.apply_locked(request, confirmed).await;
+                let result = self
+                    .apply_locked(
+                        request,
+                        confirmed,
+                        &RuntimeConfigMutationProgress::default(),
+                    )
+                    .await;
                 drop(context);
                 return result;
             };
-            let response_attached = context.response_attached();
+            let response_attached = context.request_context().response_attached();
             let stream = context.take_stream_ownership();
             let (stream_permit, stream_admission) = stream
                 .map_or((None, None), |(permit, admission)| {
@@ -669,8 +702,8 @@ impl ConfigTransactionController {
                     "config transaction rejected: daemon is shutting down".to_string(),
                 ));
             }
-            operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
-            let result = self.apply_locked(request, confirmed).await;
+            let progress = RuntimeConfigMutationProgress::owned(&operation);
+            let result = self.apply_locked(request, confirmed, &progress).await;
             if let Err(ConfigTransactionApplyError::RecoveryRequired { reason, .. }) = &result {
                 let _ = operation.fence_recovery(*reason);
                 std::future::pending::<()>().await;
@@ -691,31 +724,39 @@ impl ConfigTransactionController {
         }
     }
 
-    #[expect(
-        clippy::too_many_lines,
-        reason = "gNMI Set keeps its closed commit-action dispatch inside one owned settlement executor"
-    )]
+    #[cfg(test)]
     async fn apply_gnmi_set(
         self,
         transaction: rustbgpd_api::server::GnmiSetTransaction,
     ) -> Result<GnmiSetOutcome, GnmiSetError> {
+        let (context, _attachment) = OwnedRuntimeConfigRequestContext::unary();
+        self.apply_gnmi_set_with_context(transaction, context).await
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "gNMI Set keeps its closed commit-action dispatch inside one owned settlement executor"
+    )]
+    async fn apply_gnmi_set_with_context(
+        self,
+        transaction: rustbgpd_api::server::GnmiSetTransaction,
+        context: OwnedRuntimeConfigRequestContext,
+    ) -> Result<GnmiSetOutcome, GnmiSetError> {
         let result = self
             .execute_owned_operation(
                 RuntimeConfigOperationKind::GnmiSet,
-                true,
+                context,
                 "gNMI Set rejected: daemon is shutting down",
                 "gNMI Set transaction task did not complete",
                 move |controller, operation| async move {
                     let self_ = controller;
+                    let progress = RuntimeConfigMutationProgress(operation);
                     match transaction.commit_action.clone() {
                         Some(GnmiSetCommitAction::Confirm { confirm_id }) => {
                             let confirm_id = validate_confirm_id(&confirm_id)
                                 .map_err(apply_error_to_owned_gnmi_set_error)?;
-                            if let Some(operation) = &operation {
-                                operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
-                            }
                             self_
-                                .confirm_locked(confirm_id)
+                                .confirm_locked(confirm_id, &progress)
                                 .await
                                 .map_err(apply_error_to_owned_gnmi_set_error)?;
                             return Ok(GnmiSetOutcome::default());
@@ -723,12 +764,8 @@ impl ConfigTransactionController {
                         Some(GnmiSetCommitAction::Cancel { confirm_id }) => {
                             let confirm_id = validate_confirm_id(&confirm_id)
                                 .map_err(apply_error_to_owned_gnmi_set_error)?;
-                            if let Some(operation) = &operation {
-                                operation
-                                    .advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
-                            }
                             self_
-                                .abort_locked(confirm_id)
+                                .abort_locked(confirm_id, &progress)
                                 .await
                                 .map_err(apply_error_to_owned_gnmi_set_error)?;
                             return Ok(GnmiSetOutcome::default());
@@ -742,11 +779,12 @@ impl ConfigTransactionController {
                             let confirm_timeout_seconds =
                                 validate_confirm_timeout_seconds(confirm_timeout_seconds)
                                     .map_err(apply_error_to_owned_gnmi_set_error)?;
-                            if let Some(operation) = &operation {
-                                operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
-                            }
                             self_
-                                .reset_rollback_duration_locked(confirm_id, confirm_timeout_seconds)
+                                .reset_rollback_duration_locked(
+                                    confirm_id,
+                                    confirm_timeout_seconds,
+                                    &progress,
+                                )
                                 .await
                                 .map_err(apply_error_to_owned_gnmi_set_error)?;
                             return Ok(GnmiSetOutcome::default());
@@ -802,12 +840,9 @@ impl ConfigTransactionController {
                     };
                     let confirmed = parse_confirmed_apply_mode(&request)
                         .map_err(apply_error_to_owned_gnmi_set_error)?;
-                    if let Some(operation) = &operation {
-                        operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
-                    }
                     let response = if confirmed.is_some() {
                         self_
-                            .apply_locked(request, confirmed)
+                            .apply_locked(request, confirmed, &progress)
                             .await
                             .map_err(apply_error_to_owned_gnmi_set_error)?
                     } else {
@@ -819,6 +854,7 @@ impl ConfigTransactionController {
                             &self_.deps,
                             request,
                             self_.peer_mgr_internal_tx.as_ref(),
+                            &progress,
                         )
                         .await
                         .map_err(|failure| match failure.fence_reason {
@@ -849,11 +885,12 @@ impl ConfigTransactionController {
         &self,
         request: proto::ApplyConfigTransactionRequest,
         confirmed: Option<ConfirmedApplyMode>,
+        progress: &RuntimeConfigMutationProgress,
     ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
         if let Some(confirmed) = confirmed {
             self.begin_confirmed_apply(&confirmed.confirm_id).await?;
             let result = self
-                .apply_confirmed_locked(request, confirmed.clone(), None)
+                .apply_confirmed_locked(request, confirmed.clone(), None, progress)
                 .await;
             if !matches!(
                 result,
@@ -868,9 +905,14 @@ impl ConfigTransactionController {
         } else {
             self.reject_if_pending("ConfigService.ApplyConfigTransaction")
                 .await?;
-            apply_config_transaction_locked(&self.deps, request, self.peer_mgr_internal_tx.as_ref())
-                .await
-                .map_err(ApplyFailure::into_apply_error)
+            apply_config_transaction_locked(
+                &self.deps,
+                request,
+                self.peer_mgr_internal_tx.as_ref(),
+                progress,
+            )
+            .await
+            .map_err(ApplyFailure::into_apply_error)
         }
     }
 
@@ -886,6 +928,7 @@ impl ConfigTransactionController {
             rustbgpd_api::peer_types::RuntimeConfigTransactionPlan,
             Arc<AcceptedConfigSnapshot>,
         )>,
+        progress: &RuntimeConfigMutationProgress,
     ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
         let prior_snapshot = self
             .accepted_prior_snapshot()
@@ -941,6 +984,7 @@ impl ConfigTransactionController {
                         "refusing confirmed apply: v3 pending storage is unavailable".to_string(),
                     )
                 })?;
+            progress.begin_settling();
             match launch.publish(
                 pending_dir,
                 &confirmed.confirm_id,
@@ -986,6 +1030,7 @@ impl ConfigTransactionController {
             request,
             preloaded,
             self.peer_mgr_internal_tx.as_ref(),
+            progress,
         )
         .await
         {
@@ -1019,6 +1064,7 @@ impl ConfigTransactionController {
                 // Provably nothing committed — a stale journal would only
                 // trigger a harmless same-content boot revert, but clean it
                 // up anyway.
+                progress.begin_settling();
                 self.cleanup_uncommitted_authority(
                     &confirmed.confirm_id,
                     v3_files.as_deref(),
@@ -1029,6 +1075,7 @@ impl ConfigTransactionController {
             }
         };
         if response.status != proto::ConfigTransactionPlanStatus::Committable as i32 {
+            progress.begin_settling();
             self.cleanup_uncommitted_authority(
                 &confirmed.confirm_id,
                 v3_files.as_deref(),
@@ -1062,6 +1109,7 @@ impl ConfigTransactionController {
             &pending,
             "Confirmed config transaction is pending confirmation.",
         );
+        progress.begin_settling();
         self.install_pending_confirmed_transaction(pending).await;
         self.spawn_confirm_timeout(confirmed.confirm_id).await;
         response.confirmation = Some(confirmation);
@@ -1071,21 +1119,29 @@ impl ConfigTransactionController {
         Ok(response)
     }
 
+    #[cfg(test)]
     async fn confirm(
         self,
         request: proto::ConfirmConfigTransactionRequest,
     ) -> Result<proto::ConfirmConfigTransactionResponse, ConfigTransactionApplyError> {
+        let (context, _attachment) = OwnedRuntimeConfigRequestContext::unary();
+        self.confirm_with_context(request, context).await
+    }
+
+    async fn confirm_with_context(
+        self,
+        request: proto::ConfirmConfigTransactionRequest,
+        context: OwnedRuntimeConfigRequestContext,
+    ) -> Result<proto::ConfirmConfigTransactionResponse, ConfigTransactionApplyError> {
         let confirm_id = validate_confirm_id(&request.confirm_id)?;
         self.execute_owned_operation(
             RuntimeConfigOperationKind::Confirm,
-            true,
+            context,
             "config transaction confirm rejected: daemon is shutting down",
             "config transaction confirm task did not complete",
             move |controller, operation| async move {
-                if let Some(operation) = operation {
-                    operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
-                }
-                controller.confirm_locked(confirm_id).await
+                let progress = RuntimeConfigMutationProgress(operation);
+                controller.confirm_locked(confirm_id, &progress).await
             },
         )
         .await
@@ -1094,6 +1150,7 @@ impl ConfigTransactionController {
     async fn confirm_locked(
         &self,
         confirm_id: String,
+        progress: &RuntimeConfigMutationProgress,
     ) -> Result<proto::ConfirmConfigTransactionResponse, ConfigTransactionApplyError> {
         // Validate the handle against the pending transaction before touching
         // the journal, then delete the journal BEFORE clearing the pending
@@ -1101,6 +1158,7 @@ impl ConfigTransactionController {
         // timer stay armed — a leftover journal would boot-revert a config
         // the operator explicitly confirmed.
         let matched = self.matching_pending(&confirm_id).await?;
+        progress.begin_settling();
         let residue_cleanup = if let Some(files) = &matched.v3_files {
             files.remove_locator_authority().map_err(|error| {
                 ConfigTransactionApplyError::RecoveryRequired {
@@ -1136,21 +1194,29 @@ impl ConfigTransactionController {
         })
     }
 
+    #[cfg(test)]
     async fn abort(
         self,
         request: proto::AbortConfigTransactionRequest,
     ) -> Result<proto::AbortConfigTransactionResponse, ConfigTransactionApplyError> {
+        let (context, _attachment) = OwnedRuntimeConfigRequestContext::unary();
+        self.abort_with_context(request, context).await
+    }
+
+    async fn abort_with_context(
+        self,
+        request: proto::AbortConfigTransactionRequest,
+        context: OwnedRuntimeConfigRequestContext,
+    ) -> Result<proto::AbortConfigTransactionResponse, ConfigTransactionApplyError> {
         let confirm_id = validate_confirm_id(&request.confirm_id)?;
         self.execute_owned_operation(
             RuntimeConfigOperationKind::Abort,
-            true,
+            context,
             "config transaction abort rejected: daemon is shutting down",
             "config transaction abort task did not complete",
             move |controller, operation| async move {
-                if let Some(operation) = operation {
-                    operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
-                }
-                controller.abort_locked(confirm_id).await
+                let progress = RuntimeConfigMutationProgress(operation);
+                controller.abort_locked(confirm_id, &progress).await
             },
         )
         .await
@@ -1159,9 +1225,11 @@ impl ConfigTransactionController {
     async fn abort_locked(
         &self,
         confirm_id: String,
+        progress: &RuntimeConfigMutationProgress,
     ) -> Result<proto::AbortConfigTransactionResponse, ConfigTransactionApplyError> {
         let pending = self.matching_pending(&confirm_id).await?;
-        match self.rollback_pending_locked(&pending).await {
+        progress.begin_settling();
+        match self.rollback_pending_locked(&pending, progress).await {
             Ok(response) => {
                 self.remove_pending_after_rollback(
                         &confirm_id,
@@ -1205,6 +1273,7 @@ impl ConfigTransactionController {
         &self,
         confirm_id: String,
         timeout_seconds: u32,
+        progress: &RuntimeConfigMutationProgress,
     ) -> Result<(), ConfigTransactionApplyError> {
         // The revert journal is NOT rewritten here: its deadline field is
         // informational only — boot revert fires on any unconfirmed journal
@@ -1228,6 +1297,7 @@ impl ConfigTransactionController {
                     pending.confirm_id
                 )));
             }
+            progress.begin_settling();
             pending.timeout_seconds = timeout_seconds;
             pending.deadline = deadline;
             pending.deadline_unix_seconds = deadline_unix_seconds;
@@ -1368,9 +1438,19 @@ impl ConfigTransactionController {
     /// the plan/impact classification, commit, receipts, and (when a confirm
     /// handle is given) the whole confirmed-commit lifecycle. There is
     /// deliberately no second apply route here.
+    #[cfg(test)]
     async fn rollback(
         self,
         request: proto::RollbackConfigTransactionRequest,
+    ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
+        let (context, _attachment) = OwnedRuntimeConfigRequestContext::unary();
+        self.rollback_with_context(request, context).await
+    }
+
+    async fn rollback_with_context(
+        self,
+        request: proto::RollbackConfigTransactionRequest,
+        context: OwnedRuntimeConfigRequestContext,
     ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
         self.history_dir()?;
         if request.index == 0 {
@@ -1385,11 +1465,12 @@ impl ConfigTransactionController {
         }
         self.execute_owned_operation(
             RuntimeConfigOperationKind::Rollback,
-            true,
+            context,
             "config rollback rejected: daemon is shutting down",
             "config rollback task did not complete",
             move |controller, operation| async move {
             let self_ = controller;
+            let progress = RuntimeConfigMutationProgress(operation);
             // Resolve the entry under the coordinator lock so a concurrent
             // commit cannot shift indexes between resolution and apply.
             let dir = self_.history_dir()?;
@@ -1436,11 +1517,8 @@ impl ConfigTransactionController {
                 confirm_id: request.confirm_id,
                 confirm_timeout_seconds: request.confirm_timeout_seconds,
             };
-            if let Some(operation) = operation {
-                operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
-            }
             let mut response = self_
-                .apply_prepared_rollback(apply_request, preloaded)
+                .apply_prepared_rollback(apply_request, preloaded, &progress)
                 .await?;
             // Name the restored entry only when something actually committed;
             // a noop ("already running that config") or rejected plan keeps
@@ -1564,20 +1642,22 @@ impl ConfigTransactionController {
     async fn auto_revert(self, confirm_id: String) -> Result<(), ConfigTransactionApplyError> {
         self.execute_owned_operation(
             RuntimeConfigOperationKind::AutoRevert,
-            false,
+            OwnedRuntimeConfigRequestContext::detached(),
             "config transaction auto-revert rejected: daemon is shutting down",
             "config transaction auto-revert task did not complete",
             move |controller, operation| async move {
-                if let Some(operation) = operation {
-                    operation.advance_phase(RuntimeConfigSettlementPhase::SettlingRollback);
-                }
+                let progress = RuntimeConfigMutationProgress(operation);
                 let Some(pending) = controller.pending_for_timeout(&confirm_id).await else {
                     return Ok(());
                 };
                 if tokio::time::Instant::now() < pending.deadline {
                     return Ok(());
                 }
-                match controller.rollback_pending_locked(&pending).await {
+                progress.begin_settling();
+                match controller
+                    .rollback_pending_locked(&pending, &progress)
+                    .await
+                {
                     Ok(response) => {
                         controller.remove_pending_after_rollback(
                         &confirm_id,
@@ -1672,6 +1752,7 @@ impl ConfigTransactionController {
     async fn rollback_pending_locked(
         &self,
         pending: &PendingConfirmedTransaction,
+        progress: &RuntimeConfigMutationProgress,
     ) -> Result<proto::ConfigTransactionApplyResponse, ConfigTransactionApplyError> {
         let request = proto::ApplyConfigTransactionRequest {
             candidate_toml: pending.prior_snapshot.normalized_toml().to_string(),
@@ -1695,6 +1776,7 @@ impl ConfigTransactionController {
             request,
             Some((plan, Arc::clone(prior))),
             self.peer_mgr_internal_tx.as_ref(),
+            progress,
         )
         .await;
         let response = result.map_err(ApplyFailure::into_apply_error)?;
@@ -2082,9 +2164,14 @@ async fn apply_config_transaction(
 
     let join = tokio::spawn(async move {
         let _guard = deps.lock.acquire().await?;
-        apply_config_transaction_locked(&deps, request, None)
-            .await
-            .map_err(|failure| failure.error)
+        apply_config_transaction_locked(
+            &deps,
+            request,
+            None,
+            &RuntimeConfigMutationProgress::default(),
+        )
+        .await
+        .map_err(|failure| failure.error)
     });
 
     join.await.map_err(|_| {
@@ -2103,9 +2190,14 @@ async fn apply_config_transaction_with_internal(
     validate_apply_request(&request)?;
     let join = tokio::spawn(async move {
         let _guard = deps.lock.acquire().await?;
-        apply_config_transaction_locked(&deps, request, Some(&peer_mgr_internal_tx))
-            .await
-            .map_err(|failure| failure.error)
+        apply_config_transaction_locked(
+            &deps,
+            request,
+            Some(&peer_mgr_internal_tx),
+            &RuntimeConfigMutationProgress::default(),
+        )
+        .await
+        .map_err(|failure| failure.error)
     });
     join.await.map_err(|_| {
         ConfigTransactionApplyError::Internal(
@@ -2118,8 +2210,16 @@ async fn apply_config_transaction_locked(
     deps: &FibTableControlDeps,
     request: proto::ApplyConfigTransactionRequest,
     peer_mgr_internal_tx: Option<&mpsc::UnboundedSender<InternalCommand>>,
+    progress: &RuntimeConfigMutationProgress,
 ) -> Result<proto::ConfigTransactionApplyResponse, ApplyFailure> {
-    apply_config_transaction_locked_with_preloaded(deps, request, None, peer_mgr_internal_tx).await
+    apply_config_transaction_locked_with_preloaded(
+        deps,
+        request,
+        None,
+        peer_mgr_internal_tx,
+        progress,
+    )
+    .await
 }
 
 async fn apply_config_transaction_locked_with_preloaded(
@@ -2130,6 +2230,7 @@ async fn apply_config_transaction_locked_with_preloaded(
         Arc<AcceptedConfigSnapshot>,
     )>,
     peer_mgr_internal_tx: Option<&mpsc::UnboundedSender<InternalCommand>>,
+    progress: &RuntimeConfigMutationProgress,
 ) -> Result<proto::ConfigTransactionApplyResponse, ApplyFailure> {
     let plan = match &preloaded {
         Some((plan, _)) => plan.clone(),
@@ -2216,6 +2317,7 @@ async fn apply_config_transaction_locked_with_preloaded(
         plan.supported_sections,
         post_commit_runtime_snapshot_token,
         update_group_impact,
+        progress,
     )
     .await?;
     if family == ApplyFamily::LivePolicyImpact {
@@ -2244,6 +2346,7 @@ async fn commit_apply_family(
     supported_sections: Vec<String>,
     post_commit_runtime_snapshot_token: String,
     update_group_impact: proto::UpdateGroupImpactPlan,
+    progress: &RuntimeConfigMutationProgress,
 ) -> Result<proto::ConfigTransactionApplyResponse, ApplyFailure> {
     // ADR-0113 deliberately INVERTS ADR-0076's apply-live-before-persist
     // order for outbound prefix maxima. Applying a raise or removal first
@@ -2267,6 +2370,7 @@ async fn commit_apply_family(
         supported_sections,
         post_commit_runtime_snapshot_token,
         update_group_impact,
+        progress,
     ))
     .await;
     finish_outbound_prefix_limit_transaction(deps, prepared, &committed).await?;
@@ -2335,6 +2439,7 @@ async fn finish_outbound_prefix_limit_transaction(
 
 #[expect(
     clippy::too_many_arguments,
+    clippy::too_many_lines,
     reason = "family dispatch mirrors commit_apply_family's parameters verbatim"
 )]
 async fn commit_apply_family_inner(
@@ -2347,6 +2452,7 @@ async fn commit_apply_family_inner(
     supported_sections: Vec<String>,
     post_commit_runtime_snapshot_token: String,
     update_group_impact: proto::UpdateGroupImpactPlan,
+    progress: &RuntimeConfigMutationProgress,
 ) -> Result<proto::ConfigTransactionApplyResponse, ApplyFailure> {
     match family {
         ApplyFamily::FibTables => {
@@ -2358,6 +2464,7 @@ async fn commit_apply_family_inner(
                 candidate,
                 post_commit_runtime_snapshot_token,
                 update_group_impact,
+                progress,
             )
             .await
         }
@@ -2367,6 +2474,7 @@ async fn commit_apply_family_inner(
                 config_tx,
                 candidate_toml,
                 &candidate,
+                progress,
             )
             .await?;
             Ok(committable_response(
@@ -2380,7 +2488,13 @@ async fn commit_apply_family_inner(
             ))
         }
         ApplyFamily::CatalogSnapshot => {
-            commit_candidate_snapshot_locked(&deps.peer_mgr_tx, config_tx, candidate_toml).await?;
+            commit_candidate_snapshot_locked(
+                &deps.peer_mgr_tx,
+                config_tx,
+                candidate_toml,
+                progress,
+            )
+            .await?;
             Ok(committable_response(
                 post_commit_runtime_snapshot_token,
                 supported_sections,
@@ -2399,6 +2513,7 @@ async fn commit_apply_family_inner(
                 config_tx,
                 candidate_toml,
                 &candidate,
+                progress,
             )
             .await?;
             Ok(committable_response(
@@ -2416,6 +2531,7 @@ async fn commit_apply_family_inner(
                 config_tx,
                 candidate_toml,
                 &candidate,
+                progress,
             )
             .await?;
             Ok(committable_response(
@@ -2432,6 +2548,7 @@ async fn commit_apply_family_inner(
                 candidate_toml,
                 &candidate,
                 &supported_sections,
+                progress,
             )
             .await?;
             Ok(committable_response(
@@ -2444,6 +2561,10 @@ async fn commit_apply_family_inner(
     }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "FIB commit carries the typed settlement progress with its existing closed transaction inputs"
+)]
 async fn commit_fib_transaction(
     deps: &FibTableControlDeps,
     peer_mgr_internal_tx: Option<&mpsc::UnboundedSender<InternalCommand>>,
@@ -2452,6 +2573,7 @@ async fn commit_fib_transaction(
     candidate: Config,
     post_commit_runtime_snapshot_token: String,
     update_group_impact: proto::UpdateGroupImpactPlan,
+    progress: &RuntimeConfigMutationProgress,
 ) -> Result<proto::ConfigTransactionApplyResponse, ApplyFailure> {
     let fib_cmd_tx = deps.fib_cmd_tx.clone().ok_or_else(|| {
         fib_error_to_apply_error(runtime_unavailable_error(!deps.startup_tables.is_empty()))
@@ -2472,11 +2594,13 @@ async fn commit_fib_transaction(
     .map_err(fib_error_to_apply_error)?
     .unwrap_or_default();
     let staged_tables = candidate.fib_tables.clone();
+    progress.begin_mutation();
     let previous = stage_preloaded_config_snapshot(peer_mgr_internal_tx, candidate).await?;
     match replace_tables_for_transaction(&fib_cmd_tx, staged_tables.clone()).await {
         FibTransactionReplaceOutcome::Applied => {}
         FibTransactionReplaceOutcome::NotAccepted(error)
         | FibTransactionReplaceOutcome::RejectedNoEffect(error) => {
+            progress.begin_settling();
             return Err(restore_preloaded_snapshot_after_error(
                 peer_mgr_internal_tx,
                 previous,
@@ -2497,6 +2621,7 @@ async fn commit_fib_transaction(
             ));
         }
     }
+    progress.begin_settling();
     if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
         if failure.fence_reason.is_some() {
             return Err(failure);
@@ -2723,9 +2848,12 @@ async fn commit_candidate_snapshot_locked(
     peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
     config_tx: &mpsc::Sender<ConfigEvent>,
     candidate_toml: String,
+    progress: &RuntimeConfigMutationProgress,
 ) -> Result<(), ApplyFailure> {
     let permit = reserve_persist_permit(config_tx).await?;
+    progress.begin_mutation();
     let previous_toml = stage_config_snapshot(peer_mgr_tx, candidate_toml.clone()).await?;
+    progress.begin_settling();
     if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
         if failure.fence_reason.is_some() {
             return Err(failure);
@@ -2750,8 +2878,10 @@ async fn commit_dynamic_neighbors_locked(
     config_tx: &mpsc::Sender<ConfigEvent>,
     candidate_toml: String,
     candidate: &Config,
+    progress: &RuntimeConfigMutationProgress,
 ) -> Result<(), ApplyFailure> {
     let permit = reserve_persist_permit(config_tx).await?;
+    progress.begin_mutation();
     let previous_toml = stage_config_snapshot(peer_mgr_tx, candidate_toml.clone()).await?;
     let previous = match Config::load_toml_with_diagnostics(
         &previous_toml,
@@ -2760,6 +2890,7 @@ async fn commit_dynamic_neighbors_locked(
         Ok(previous) => previous,
         Err(error) => {
             let error = ConfigTransactionApplyError::Internal(error);
+            progress.begin_settling();
             return Err(
                 rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error.into()).await,
             );
@@ -2774,8 +2905,10 @@ async fn commit_dynamic_neighbors_locked(
              reload — apply this change through the config file and SIGHUP"
                 .to_string(),
         ));
+        progress.begin_settling();
         return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error.into()).await);
     }
+    progress.begin_settling();
     if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
         if failure.fence_reason.is_some() {
             return Err(failure);
@@ -2798,8 +2931,10 @@ async fn commit_static_neighbors_locked(
     candidate_toml: String,
     candidate: &Config,
     committed_sections: &[String],
+    progress: &RuntimeConfigMutationProgress,
 ) -> Result<(), ApplyFailure> {
     let permit = reserve_persist_permit(config_tx).await?;
+    progress.begin_mutation();
     let previous_toml = stage_config_snapshot(peer_mgr_tx, candidate_toml.clone()).await?;
     let previous = match Config::load_toml_with_diagnostics(
         &previous_toml,
@@ -2808,6 +2943,7 @@ async fn commit_static_neighbors_locked(
         Ok(previous) => previous,
         Err(error) => {
             let error = ConfigTransactionApplyError::Internal(error);
+            progress.begin_settling();
             return Err(
                 rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error.into()).await,
             );
@@ -2820,6 +2956,7 @@ async fn commit_static_neighbors_locked(
         let error = ConfigTransactionApplyError::Internal(
             "static-neighbor transaction executor received a non-static-neighbor diff".to_string(),
         );
+        progress.begin_settling();
         return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error.into()).await);
     }
 
@@ -2827,6 +2964,7 @@ async fn commit_static_neighbors_locked(
     let added = match resolve_static_neighbors(candidate, &neighbor_diff.added) {
         Ok(added) => added,
         Err(error) => {
+            progress.begin_settling();
             return Err(
                 rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error.into()).await,
             );
@@ -2835,6 +2973,7 @@ async fn commit_static_neighbors_locked(
     let changed = match resolve_static_neighbors(candidate, &neighbor_diff.changed) {
         Ok(changed) => changed,
         Err(error) => {
+            progress.begin_settling();
             return Err(rollback_static_and_snapshot(
                 peer_mgr_tx,
                 applied,
@@ -2846,6 +2985,7 @@ async fn commit_static_neighbors_locked(
     };
     for config in added {
         if let Some(error) = runtime_added_neighbor_inbound_auth_error(&config) {
+            progress.begin_settling();
             return Err(rollback_static_and_snapshot(
                 peer_mgr_tx,
                 applied,
@@ -2855,6 +2995,7 @@ async fn commit_static_neighbors_locked(
             .await);
         }
         if let Err(error) = add_static_peer(peer_mgr_tx, config.clone()).await {
+            progress.begin_settling();
             return Err(rollback_static_and_snapshot(
                 peer_mgr_tx,
                 applied,
@@ -2872,6 +3013,7 @@ async fn commit_static_neighbors_locked(
         match reconfigure_static_peer(peer_mgr_tx, config).await {
             Ok(previous) => applied.push(AppliedStaticOp::Modified(Box::new(previous))),
             Err(error) => {
+                progress.begin_settling();
                 return Err(rollback_static_and_snapshot(
                     peer_mgr_tx,
                     applied,
@@ -2886,6 +3028,7 @@ async fn commit_static_neighbors_locked(
         match delete_static_peer(peer_mgr_tx, peer.clone()).await {
             Ok(removed) => applied.push(AppliedStaticOp::Deleted(Box::new(removed))),
             Err(error) => {
+                progress.begin_settling();
                 return Err(rollback_static_and_snapshot(
                     peer_mgr_tx,
                     applied,
@@ -2897,6 +3040,7 @@ async fn commit_static_neighbors_locked(
         }
     }
 
+    progress.begin_settling();
     if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
         if failure.fence_reason.is_some() {
             return Err(failure);
@@ -2919,8 +3063,10 @@ async fn commit_live_policy_impact_locked(
     config_tx: &mpsc::Sender<ConfigEvent>,
     candidate_toml: String,
     candidate: &Config,
+    progress: &RuntimeConfigMutationProgress,
 ) -> Result<usize, ApplyFailure> {
     let permit = reserve_persist_permit(config_tx).await?;
+    progress.begin_mutation();
     let previous_toml = stage_config_snapshot(peer_mgr_tx, candidate_toml.clone()).await?;
     let previous = match Config::load_toml_with_diagnostics(
         &previous_toml,
@@ -2929,6 +3075,7 @@ async fn commit_live_policy_impact_locked(
         Ok(previous) => previous,
         Err(error) => {
             let error = ConfigTransactionApplyError::Internal(error);
+            progress.begin_settling();
             return Err(
                 rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error.into()).await,
             );
@@ -2938,6 +3085,7 @@ async fn commit_live_policy_impact_locked(
     let targets = match resolve_live_policy_targets(&previous, candidate) {
         Ok(targets) => targets,
         Err(error) => {
+            progress.begin_settling();
             return Err(
                 rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error.into()).await,
             );
@@ -2949,12 +3097,14 @@ async fn commit_live_policy_impact_locked(
         Err(error) => {
             // The peer-manager command self-heals its live mutations on a
             // mid-fanout failure, so only the staged snapshot needs rollback.
+            progress.begin_settling();
             return Err(
                 rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error.into()).await,
             );
         }
     };
 
+    progress.begin_settling();
     if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
         if failure.fence_reason.is_some() {
             return Err(failure);
@@ -3018,8 +3168,10 @@ async fn commit_peer_session_reshape_locked(
     config_tx: &mpsc::Sender<ConfigEvent>,
     candidate_toml: String,
     candidate: &Config,
+    progress: &RuntimeConfigMutationProgress,
 ) -> Result<PeerSessionReshapeCommit, ApplyFailure> {
     let permit = reserve_persist_permit(config_tx).await?;
+    progress.begin_mutation();
     let previous_toml = stage_config_snapshot(peer_mgr_tx, candidate_toml.clone()).await?;
     let previous = match Config::load_toml_with_diagnostics(
         &previous_toml,
@@ -3028,6 +3180,7 @@ async fn commit_peer_session_reshape_locked(
         Ok(previous) => previous,
         Err(error) => {
             let error = ConfigTransactionApplyError::Internal(error);
+            progress.begin_settling();
             return Err(
                 rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error.into()).await,
             );
@@ -3037,6 +3190,7 @@ async fn commit_peer_session_reshape_locked(
     let targets = match resolve_peer_session_reshape_targets(&previous, candidate) {
         Ok(targets) => targets,
         Err(error) => {
+            progress.begin_settling();
             return Err(
                 rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error.into()).await,
             );
@@ -3045,6 +3199,7 @@ async fn commit_peer_session_reshape_locked(
     if let Some(error) =
         dynamic_bounce_listener_auth_error(&previous, candidate, &targets.dynamic_bounce_ranges)
     {
+        progress.begin_settling();
         return Err(rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error.into()).await);
     }
     let reconfigured = targets.static_targets.len();
@@ -3054,12 +3209,14 @@ async fn commit_peer_session_reshape_locked(
         Err(error) => {
             // The peer-manager command self-heals its live mutations on a
             // mid-fanout failure, so only the staged snapshot needs rollback.
+            progress.begin_settling();
             return Err(
                 rollback_snapshot_after_error(peer_mgr_tx, previous_toml, error.into()).await,
             );
         }
     };
 
+    progress.begin_settling();
     if let Err(failure) = persist_candidate_config(permit, candidate_toml).await {
         if failure.fence_reason.is_some() {
             return Err(failure);
@@ -4138,12 +4295,302 @@ remote_asn = 65002
             .split_once("};")
             .unwrap()
             .0;
-        let apply = fallback
-            .find("let result = self.apply_locked(request, confirmed).await;")
-            .unwrap();
+        let apply = fallback.find(".apply_locked(").unwrap();
         let detach = fallback.find("drop(context);").unwrap();
         let response = fallback.find("return result;").unwrap();
         assert!(apply < detach && detach < response);
+    }
+
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the source proof inventories every transaction family mutation and recovery boundary"
+    )]
+    fn owned_transaction_phase_boundaries_are_closed() {
+        fn body<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+            source
+                .split_once(start)
+                .unwrap()
+                .1
+                .split_once(end)
+                .unwrap()
+                .0
+        }
+
+        let source = include_str!("config_transaction_control.rs");
+        let apply = body(
+            source,
+            "async fn apply_config_transaction_locked_with_preloaded",
+            "async fn commit_apply_family(",
+        );
+        assert!(
+            apply.find("let plan = match").unwrap() < apply.find("commit_apply_family(").unwrap()
+        );
+        assert!(!apply.contains("progress.begin_mutation()"));
+
+        let dispatch = body(
+            source,
+            "async fn commit_apply_family(",
+            "fn confirmed_apply_loosens_outbound_limits",
+        );
+        assert!(
+            dispatch
+                .find("prepare_outbound_prefix_limit_transaction")
+                .unwrap()
+                < dispatch.find("commit_apply_family_inner(").unwrap()
+        );
+        assert!(!dispatch.contains("progress.begin_mutation()"));
+
+        let reload = include_str!("reload.rs");
+        for (start, end) in [
+            (
+                "async fn dispatch_rib_mutation_step",
+                "/// Preflight `config`'s outbound prefix maxima",
+            ),
+            ("async fn dispatch_actor_mutation_step", "fn step_result"),
+        ] {
+            let mutation_dispatch = body(reload, start, end);
+            let reserve = mutation_dispatch.find(".reserve().await").unwrap();
+            let mutation = mutation_dispatch.find("progress.begin_mutation()").unwrap();
+            let send = mutation_dispatch
+                .find("permit.send(build(reply_tx))")
+                .unwrap();
+            assert!(reserve < mutation && mutation < send, "{start}");
+        }
+        for (send, phase) in [
+            (
+                "permit.send(PeerManagerCommand::ReconcilePeers",
+                "progress.begin_mutation()",
+            ),
+            (
+                "permit.send(FibRuntimeCommand::OwnedReplaceTables",
+                "progress.begin_mutation()",
+            ),
+        ] {
+            let send = reload.find(send).unwrap();
+            let mutation = reload[..send].rfind(phase).unwrap();
+            let reserve = reload[..mutation].rfind(".reserve().await").unwrap();
+            assert!(reserve < mutation && mutation < send);
+        }
+
+        let rotation = include_str!("peer_manager/rotation.rs");
+        for (start, end) in [
+            (
+                "async fn preflight_tcp_ao_add_only(",
+                "async fn apply_tcp_ao_add_only(",
+            ),
+            (
+                "async fn preflight_tcp_ao_delete(",
+                "async fn apply_tcp_ao_delete(",
+            ),
+            (
+                "async fn preflight_tcp_ao_selection(",
+                "async fn apply_tcp_ao_selection(",
+            ),
+        ] {
+            let preflight = body(rotation, start, end);
+            assert!(preflight.contains("&self,"), "{start}");
+            for mutation in [
+                "retain_desired_inventory",
+                "mark_tcp_ao_rotation_failed",
+                "self.tcp_ao_rotation =",
+                ".get_mut(",
+            ] {
+                assert!(!preflight.contains(mutation), "{start}: {mutation}");
+            }
+        }
+        for (start, end, first_session_mutation, phase) in [
+            (
+                "async fn apply_tcp_ao_add_only(",
+                "async fn preflight_tcp_ao_delete(",
+                "apply_to_session(",
+                "TcpAoRotationPhase::AddOnly",
+            ),
+            (
+                "async fn apply_tcp_ao_delete(",
+                "async fn preflight_tcp_ao_selection(",
+                "apply_delete_session(",
+                "TcpAoRotationPhase::Deleting",
+            ),
+            (
+                "async fn apply_tcp_ao_selection(",
+                "#[cfg(test)]\nmod tests",
+                "apply_selection_session(",
+                "TcpAoRotationPhase::Selecting",
+            ),
+        ] {
+            let apply = body(rotation, start, end);
+            assert!(
+                apply.find(phase).unwrap() < apply.find(first_session_mutation).unwrap(),
+                "{start}"
+            );
+        }
+
+        let listener = include_str!("../crates/transport/src/listener.rs");
+        let listener_dispatch = body(
+            listener,
+            "async fn dispatch<T, F>(",
+            "/// Validate the complete desired listener inventory",
+        );
+        let reserve = listener_dispatch.find("self.tx.reserve()").unwrap();
+        let phase = listener_dispatch.find("before_dispatch();").unwrap();
+        let send = listener_dispatch.find("permit.send(command)").unwrap();
+        assert!(reserve < phase && phase < send);
+
+        let evpn = include_str!("evpn_runtime_converger.rs");
+        let changed_apply = body(
+            evpn,
+            "pub(crate) async fn apply_config_if_changed",
+            "fn reload_state(",
+        );
+        assert!(
+            changed_apply
+                .find("if !changed(&config, &baseline)")
+                .unwrap()
+                < changed_apply
+                    .find("apply_candidate_config_locked(&config, false, begin_mutation)")
+                    .unwrap()
+        );
+        let candidate_apply = body(
+            evpn,
+            "async fn apply_evpn_runtime_candidate_locked",
+            "/// Apply the #268-decomposed primitive steps",
+        );
+        let commit_path = candidate_apply.split_once("if plan.is_noop() {").unwrap().1;
+        assert!(
+            commit_path.find("validate_supported_plan_shape").unwrap()
+                < commit_path.find("begin_mutation();").unwrap()
+        );
+        assert!(
+            commit_path.rfind("begin_mutation();").unwrap()
+                < commit_path.find("converger.converge(").unwrap()
+        );
+
+        for (start, end, first_mutation) in [
+            (
+                "async fn commit_fib_transaction(",
+                "fn apply_family(",
+                "stage_preloaded_config_snapshot(",
+            ),
+            (
+                "async fn commit_candidate_snapshot_locked(",
+                "async fn commit_dynamic_neighbors_locked(",
+                "stage_config_snapshot(",
+            ),
+            (
+                "async fn commit_dynamic_neighbors_locked(",
+                "async fn commit_static_neighbors_locked(",
+                "stage_config_snapshot(",
+            ),
+            (
+                "async fn commit_static_neighbors_locked(",
+                "async fn commit_live_policy_impact_locked(",
+                "stage_config_snapshot(",
+            ),
+            (
+                "async fn commit_live_policy_impact_locked(",
+                "struct PeerSessionReshapeCommit",
+                "stage_config_snapshot(",
+            ),
+            (
+                "async fn commit_peer_session_reshape_locked(",
+                "async fn send_bounce_dynamic_range_peers(",
+                "stage_config_snapshot(",
+            ),
+        ] {
+            let owned = body(source, start, end);
+            let reserve = owned.find("reserve_persist_permit(").unwrap();
+            let mutation = owned.find("progress.begin_mutation()").unwrap();
+            let first_mutation = owned.find(first_mutation).unwrap();
+            let settling = owned.find("progress.begin_settling()").unwrap();
+            let publication = owned.find("persist_candidate_config(").unwrap();
+            assert!(reserve < mutation && mutation < first_mutation, "{start}");
+            assert!(mutation < settling && settling < publication, "{start}");
+        }
+
+        for (start, end, rollback, expected) in [
+            (
+                "async fn commit_fib_transaction(",
+                "fn apply_family(",
+                "restore_preloaded_snapshot_after_error(",
+                1,
+            ),
+            (
+                "async fn commit_dynamic_neighbors_locked(",
+                "async fn commit_static_neighbors_locked(",
+                "rollback_snapshot_after_error(",
+                2,
+            ),
+            (
+                "async fn commit_static_neighbors_locked(",
+                "async fn commit_live_policy_impact_locked(",
+                "rollback_snapshot_after_error(",
+                3,
+            ),
+            (
+                "async fn commit_static_neighbors_locked(",
+                "async fn commit_live_policy_impact_locked(",
+                "rollback_static_and_snapshot(",
+                5,
+            ),
+            (
+                "async fn commit_live_policy_impact_locked(",
+                "struct PeerSessionReshapeCommit",
+                "rollback_snapshot_after_error(",
+                3,
+            ),
+            (
+                "async fn commit_peer_session_reshape_locked(",
+                "async fn send_bounce_dynamic_range_peers(",
+                "rollback_snapshot_after_error(",
+                4,
+            ),
+        ] {
+            let owned = body(source, start, end);
+            let pre_persist = owned.split_once("persist_candidate_config(").unwrap().0;
+            assert_eq!(pre_persist.matches(rollback).count(), expected, "{start}");
+            for prefix in pre_persist.split(rollback).take(expected) {
+                let after_phase = prefix.rsplit_once("progress.begin_settling();").unwrap().1;
+                let structural = after_phase
+                    .chars()
+                    .filter(|character| !character.is_whitespace())
+                    .collect::<String>();
+                assert_eq!(structural, "returnErr(", "{start}: {rollback}");
+            }
+        }
+
+        let confirmed = body(
+            source,
+            "async fn apply_confirmed_locked(",
+            "async fn confirm(",
+        );
+        assert!(
+            confirmed.find("progress.begin_settling()").unwrap()
+                < confirmed.find("match launch.publish(").unwrap()
+        );
+        let confirm = body(source, "async fn confirm_locked(", "async fn abort(");
+        assert!(
+            confirm.find("matching_pending(").unwrap()
+                < confirm.find("progress.begin_settling()").unwrap()
+        );
+        let abort = body(
+            source,
+            "async fn abort_locked(",
+            "async fn reset_rollback_duration_locked(",
+        );
+        assert!(
+            abort.find("matching_pending(").unwrap()
+                < abort.find("progress.begin_settling()").unwrap()
+        );
+        let auto = body(
+            source,
+            "async fn auto_revert(",
+            "async fn matching_pending(",
+        );
+        assert!(
+            auto.find("pending_for_timeout(").unwrap()
+                < auto.find("progress.begin_settling()").unwrap()
+        );
     }
 
     #[test]
@@ -4171,6 +4618,8 @@ remote_asn = 65002
             .unwrap()
             .0;
         let main = production(include_str!("main.rs"));
+        let config_service = production(include_str!("../crates/api/src/config_service.rs"));
+        let gnmi_service = production(include_str!("../crates/api/src/gnmi_service.rs"));
         let owners = [server, neighbor, peer_group, policy, fib, transaction, main];
 
         #[rustfmt::skip]
@@ -4211,6 +4660,48 @@ remote_asn = 65002
                 "settlement registration inventory for {kind}"
             );
         }
+        assert!(!settlement.contains("set_response_attached"));
+        assert!(!server.contains("ConfigTransactionResponseAttachment"));
+        assert!(!transaction.contains("response_attached: bool"));
+        assert_eq!(
+            main.matches("OwnedRuntimeConfigRequestContext::detached()")
+                .count(),
+            1,
+            "SIGHUP must register as detached"
+        );
+        assert_eq!(
+            transaction
+                .matches("OwnedRuntimeConfigRequestContext::detached()")
+                .count(),
+            1,
+            "AutoRevert must register as detached"
+        );
+        assert_eq!(
+            config_service
+                .matches("OwnedRuntimeConfigRequestContext::unary()")
+                .count(),
+            3,
+            "Confirm, Abort, and Rollback must carry unary attachment contexts"
+        );
+        assert_eq!(
+            gnmi_service
+                .matches("OwnedRuntimeConfigRequestContext::unary()")
+                .count(),
+            1,
+            "gNMI Set must carry one unary attachment context"
+        );
+        let credential_reload = main.find("match credentials.reload()").unwrap();
+        let credential_success = main[credential_reload..].find("Ok(generation) =>").unwrap();
+        let credential_mutating = main[credential_reload..]
+            .find("operation.advance_phase(RuntimeConfigSettlementPhase::Mutating)")
+            .unwrap();
+        let credential_effect = main[credential_reload..]
+            .find("accepted_effect = true")
+            .unwrap();
+        assert!(
+            credential_success < credential_mutating && credential_mutating < credential_effect,
+            "SIGHUP credential reload enters Mutating only after atomic publication"
+        );
         for kind in [
             "NeighborAdd",
             "NeighborDelete",
@@ -10465,6 +10956,7 @@ families = ["ipv4_unicast"]
             fib_config(&core),
             "next".to_string(),
             proto::UpdateGroupImpactPlan::default(),
+            &RuntimeConfigMutationProgress::default(),
         )
         .await
         .unwrap_err();
@@ -10517,6 +11009,7 @@ families = ["ipv4_unicast"]
             fib_config(&core),
             "next".to_string(),
             proto::UpdateGroupImpactPlan::default(),
+            &RuntimeConfigMutationProgress::default(),
         )
         .await
         .unwrap_err();

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -304,7 +304,7 @@ impl EvpnRuntimeReloadApply {
         let join = tokio::spawn(async move {
             let _apply_guard = this.apply_lock.lock().await;
             let response = this
-                .apply_candidate_config_locked(&config, validate_only)
+                .apply_candidate_config_locked(&config, validate_only, || {})
                 .await?;
             if !validate_only
                 && matches!(
@@ -321,13 +321,15 @@ impl EvpnRuntimeReloadApply {
             .map_err(|error| apply_task_join_error("apply", &error))?
     }
 
-    pub(crate) async fn apply_config_if_changed<F>(
+    pub(crate) async fn apply_config_if_changed<F, M>(
         &self,
         config: &Config,
         changed: F,
+        begin_mutation: M,
     ) -> EvpnRuntimeReloadAttempt
     where
         F: FnOnce(&Config, &Config) -> bool + Send + 'static,
+        M: FnOnce() + Send + 'static,
     {
         let this = self.clone();
         let config = config.clone();
@@ -352,7 +354,9 @@ impl EvpnRuntimeReloadApply {
                     };
                 }
             };
-            let result = this.apply_candidate_config_locked(&config, false).await;
+            let result = this
+                .apply_candidate_config_locked(&config, false, begin_mutation)
+                .await;
             let terminal = match this.reload_state() {
                 Ok(after) => classify_reload_terminal(before, after, result),
                 Err(error) => EvpnRuntimeReloadTerminal::PublicationAmbiguous(error),
@@ -390,11 +394,15 @@ impl EvpnRuntimeReloadApply {
         })
     }
 
-    async fn apply_candidate_config_locked(
+    async fn apply_candidate_config_locked<M>(
         &self,
         config: &Config,
         validate_only: bool,
-    ) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError> {
+        begin_mutation: M,
+    ) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError>
+    where
+        M: FnOnce(),
+    {
         let candidate = evpn_runtime_candidate_from_config(config)?;
         apply_evpn_runtime_candidate_locked(
             candidate,
@@ -402,6 +410,7 @@ impl EvpnRuntimeReloadApply {
             &self.coordinator,
             self.converger.as_ref(),
             &self.metrics,
+            begin_mutation,
         )
         .await
     }
@@ -2511,6 +2520,7 @@ pub(crate) async fn apply_evpn_runtime_request_with_metrics(
         coordinator,
         converger,
         metrics,
+        || {},
     )
     .await
 }
@@ -2519,13 +2529,17 @@ pub(crate) async fn apply_evpn_runtime_request_with_metrics(
     clippy::too_many_lines,
     reason = "the plan/validate-only/converge/decompose/commit sequence reads clearest as one flow"
 )]
-async fn apply_evpn_runtime_candidate_locked(
+async fn apply_evpn_runtime_candidate_locked<M>(
     candidate: rustbgpd_evpn::EvpnRuntimeCandidate,
     validate_only: bool,
     coordinator: &Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>,
     converger: &dyn DaemonEvpnRuntimeConverger,
     metrics: &BgpMetrics,
-) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError> {
+    begin_mutation: M,
+) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError>
+where
+    M: FnOnce(),
+{
     let (current, plan, snapshot) = {
         let coordinator = coordinator.lock().map_err(|_| {
             GrpcEvpnRuntimeApplyError::Internal(
@@ -2657,6 +2671,75 @@ async fn apply_evpn_runtime_candidate_locked(
         });
     }
 
+    // Reject unsupported shapes and unavailable actor routes while this is
+    // still a pure plan. Once the phase callback fires, the next awaited work
+    // is a mutation-capable converge (direct or decomposed).
+    match validate_supported_plan_shape(&current, &candidate, &plan) {
+        Ok(()) => {
+            if let Err(error) = converger.validate_availability(&current, &candidate, &plan) {
+                return Err(GrpcEvpnRuntimeApplyError::FailedPrecondition(format!(
+                    "EVPN runtime mutation failed: {}; generation {} remains committed",
+                    error.message(),
+                    snapshot.generation.as_u64()
+                )));
+            }
+        }
+        Err(shape_error) => {
+            match crate::evpn_plan_decomposer::decompose_evpn_runtime_candidate(
+                &current, &candidate, &plan,
+            ) {
+                Ok(steps) => {
+                    let total = steps.len();
+                    let mut model = current.clone();
+                    for (index, step) in steps.iter().enumerate() {
+                        let step_plan = model.plan_candidate(&step.candidate);
+                        if !step_plan.is_noop()
+                            && let Err(error) =
+                                converger.validate_availability(&model, &step.candidate, &step_plan)
+                        {
+                            return Err(GrpcEvpnRuntimeApplyError::FailedPrecondition(format!(
+                                "EVPN runtime mutation failed: decomposed step {}/{total} ({}) \
+                                 would fail: {}; generation {} remains committed",
+                                index + 1,
+                                step.description,
+                                error.message(),
+                                snapshot.generation.as_u64()
+                            )));
+                        }
+                        model = rustbgpd_evpn::EvpnRuntimeModel::startup(
+                            step.candidate.instances().clone(),
+                            step.candidate.ip_vrfs().clone(),
+                            step.candidate.ethernet_segments().to_vec(),
+                        );
+                    }
+                    begin_mutation();
+                    return apply_decomposed_evpn_runtime_steps(
+                        steps,
+                        &plan,
+                        coordinator,
+                        converger,
+                        metrics,
+                    )
+                    .await;
+                }
+                Err(crate::evpn_plan_decomposer::EvpnDecomposeError::AlreadyPrimitive) => {
+                    return Err(GrpcEvpnRuntimeApplyError::FailedPrecondition(format!(
+                        "EVPN runtime mutation failed: {}; generation {} remains committed",
+                        shape_error.message(),
+                        snapshot.generation.as_u64()
+                    )));
+                }
+                Err(crate::evpn_plan_decomposer::EvpnDecomposeError::Unsupported(reason)) => {
+                    return Err(GrpcEvpnRuntimeApplyError::FailedPrecondition(format!(
+                        "EVPN runtime mutation failed: {reason}; generation {} remains committed",
+                        snapshot.generation.as_u64()
+                    )));
+                }
+            }
+        }
+    }
+
+    begin_mutation();
     if let Err(error) = converger.converge(&current, &candidate, &plan).await {
         // #268: a candidate the dispatch rejects as an unsupported *mixed*
         // composition may still converge as an ordered sequence of
@@ -3001,7 +3084,11 @@ mod tests {
             baseline,
         );
         let attempt = reload_apply
-            .apply_config_if_changed(&candidate, |_, _| panic!("join-error proof"))
+            .apply_config_if_changed(
+                &candidate,
+                |_, _| panic!("join-error proof"),
+                || panic!("join-error must fail before mutation"),
+            )
             .await;
         assert!(matches!(
             attempt.terminal,
@@ -5191,13 +5278,26 @@ local_vtep_ip = "10.0.0.1"
             baseline,
         );
 
+        let mutation_started = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let apply = reload_apply.clone();
-        let mut caller =
-            Box::pin(async move { apply.apply_config_if_changed(&candidate, |_, _| true).await });
+        let phase = mutation_started.clone();
+        let mut caller = Box::pin(async move {
+            apply
+                .apply_config_if_changed(
+                    &candidate,
+                    |_, _| true,
+                    move || phase.store(true, std::sync::atomic::Ordering::SeqCst),
+                )
+                .await
+        });
         tokio::select! {
             _ = &mut caller => panic!("reload apply must still be blocked in converge"),
             () = entered.notified() => {}
         }
+        assert!(
+            mutation_started.load(std::sync::atomic::Ordering::SeqCst),
+            "blocked converge must observe the mutation phase"
+        );
         // Simulate an outer reload waiter going away.
         drop(caller);
         release.add_permits(1);
@@ -5254,7 +5354,9 @@ local_vtep_ip = "10.0.0.1"
 
         // Bind: SIGHUP-shaped apply commits (Noop) and republishes.
         let attempt = reload_apply
-            .apply_config_if_changed(&bound, evpn_runtime_changed_for_test)
+            .apply_config_if_changed(&bound, evpn_runtime_changed_for_test, || {
+                panic!("planner no-op must remain preflight")
+            })
             .await;
         assert!(matches!(
             attempt.terminal,
@@ -5273,7 +5375,9 @@ local_vtep_ip = "10.0.0.1"
         let unbound =
             load_runtime_test_config(l2vni_one_es_runtime_candidate_toml(), "test candidate");
         let attempt = reload_apply
-            .apply_config_if_changed(&unbound, evpn_runtime_changed_for_test)
+            .apply_config_if_changed(&unbound, evpn_runtime_changed_for_test, || {
+                panic!("planner no-op must remain preflight")
+            })
             .await;
         assert!(matches!(
             attempt.terminal,
@@ -10973,6 +11077,52 @@ local_vtep_ip = "10.0.0.1"
             guard.model().mutation_state(),
             rustbgpd_evpn::EvpnRuntimeMutationState::Idle,
             "an unsupported candidate must not pin/degrade the runtime"
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_undecomposable_candidate_stays_preflight() {
+        let baseline = load_runtime_test_config(ip_vrf_runtime_candidate_toml(), "test baseline");
+        let mut candidate_toml = ip_vrf_redefined_l3vni_runtime_candidate_toml().to_string();
+        candidate_toml.push_str(
+            r#"
+[[evpn_instances]]
+vni = 300
+rd = "65000:300"
+route_targets = ["65000:300"]
+local_vtep_ip = "10.0.0.1"
+"#,
+        );
+        let candidate = load_runtime_test_config(&candidate_toml, "test candidate");
+        let coordinator = Arc::new(Mutex::new(rustbgpd_evpn::EvpnRuntimeCoordinator::new(
+            baseline.resolve_evpn_instances().unwrap(),
+            baseline.resolve_evpn_ip_vrfs().unwrap(),
+            baseline.resolve_ethernet_segments().unwrap(),
+        )));
+        let reload_apply = EvpnRuntimeReloadApply::new(
+            coordinator,
+            Arc::new(tokio::sync::Mutex::new(())),
+            Arc::new(ShapeCheckingConverger::new()),
+            baseline,
+        );
+        let mutation_started = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let phase = mutation_started.clone();
+
+        let attempt = reload_apply
+            .apply_config_if_changed(
+                &candidate,
+                |_, _| true,
+                move || phase.store(true, std::sync::atomic::Ordering::SeqCst),
+            )
+            .await;
+
+        assert!(matches!(
+            attempt.terminal,
+            EvpnRuntimeReloadTerminal::RejectedNoEffect(_)
+        ));
+        assert!(
+            !mutation_started.load(std::sync::atomic::Ordering::SeqCst),
+            "rejected candidate must remain preflight"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,8 @@ use rustbgpd_api::peer_types::{
     PeerManagerReadinessQuery, WarmCheckpointCapture, WarmCheckpointSession,
 };
 use rustbgpd_api::runtime_config_settlement::{
-    OwnedRuntimeConfigOutcome, RuntimeConfigOperationKind, RuntimeConfigSettlementWatchdog,
+    OwnedRuntimeConfigOutcome, OwnedRuntimeConfigRequestContext, RuntimeConfigOperationKind,
+    RuntimeConfigSettlementPhase, RuntimeConfigSettlementWatchdog,
 };
 use rustbgpd_api::server::{
     AccessMode as GrpcServerAccessMode, ConfigMutationGateFn, ListenerConfig as GrpcListenerConfig,
@@ -5066,7 +5067,7 @@ async fn run<T>(
                         RuntimeConfigOperationKind::Sighup,
                         runtime_config_lock,
                         daemon_gate,
-                        Arc::new(AtomicBool::new(true)),
+                        OwnedRuntimeConfigRequestContext::detached().response_attached(),
                         move |operation| async move {
                     if let Err(error) = config_transaction_controller.reject_if_pending("SIGHUP reload").await {
                         return OwnedRuntimeConfigOutcome::CleanNoEffect(Err(
@@ -5118,9 +5119,12 @@ async fn run<T>(
                             ));
                         }
                     };
+                    let mut accepted_effect = false;
                     if let Some(credentials) = grpc_credentials {
                         match credentials.reload() {
                             Ok(generation) => {
+                                operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
+                                accepted_effect = true;
                                 reload_metrics.record_grpc_credential_reload("success");
                                 info!(generation, "gRPC credential generation reloaded");
                             }
@@ -5131,7 +5135,11 @@ async fn run<T>(
                         }
                     }
                     let outcome = reload_config_with_tcp_ao(
-                        SighupReloadPlan { baseline_runtime: snapshot, desired },
+                        SighupReloadPlan {
+                            baseline_runtime: snapshot,
+                            desired,
+                            accepted_effect,
+                        },
                         live_tcp.as_ref(),
                         live_uds.as_ref(),
                         &pm_tx,

--- a/src/peer_manager/rotation.rs
+++ b/src/peer_manager/rotation.rs
@@ -802,7 +802,7 @@ impl PeerManager {
     }
 
     pub(super) async fn preflight_tcp_ao_rotation(
-        &mut self,
+        &self,
         generation: TcpAoRotationGeneration,
         operation: TcpAoRotationOperation,
         listener_keys: &[TcpAoListenerKey],
@@ -864,63 +864,15 @@ impl PeerManager {
     }
 
     async fn preflight_tcp_ao_add_only(
-        &mut self,
+        &self,
         generation: TcpAoRotationGeneration,
         listener_keys: &[TcpAoListenerKey],
         static_keyrings: &[(PeerKey, TcpAoKeyring)],
     ) -> Result<(), String> {
-        let desired_inventory = canonical_desired_inventory(
-            generation,
-            TcpAoRotationOperation::AddOnly,
-            listener_keys,
-            static_keyrings,
-        );
-        if let Err(error) =
-            retain_desired_inventory(&mut self.tcp_ao_desired_inventory, desired_inventory)
-        {
-            self.mark_tcp_ao_rotation_failed(generation, TcpAoRotationOperation::AddOnly, &error);
-            return Err(error);
-        }
-        self.tcp_ao_rotation = TcpAoRotationStatus {
-            desired: generation,
-            applied: self.tcp_ao_generation,
-            phase: TcpAoRotationPhase::AddOnly,
-            last_error: None,
-        };
-        let plan = match self.build_tcp_ao_add_only_plan(generation, listener_keys, static_keyrings)
-        {
-            Ok(plan) => plan,
-            Err(error) => {
-                self.mark_tcp_ao_rotation_failed(
-                    generation,
-                    TcpAoRotationOperation::AddOnly,
-                    &error,
-                );
-                return Err(error);
-            }
-        };
-        for (peer, _, _) in &plan {
-            let applied = self.peers[peer].tcp_ao_rotation.applied;
-            self.peers
-                .get_mut(peer)
-                .expect("peer came from current map")
-                .tcp_ao_rotation = TcpAoRotationStatus {
-                desired: generation,
-                applied,
-                phase: TcpAoRotationPhase::AddOnly,
-                last_error: None,
-            };
-        }
+        let plan = self.build_tcp_ao_add_only_plan(generation, listener_keys, static_keyrings)?;
         for (_, desired, sessions) in plan {
             for commands in sessions {
-                if let Err(error) = preflight_session(commands, desired.clone()).await {
-                    self.mark_tcp_ao_rotation_failed(
-                        generation,
-                        TcpAoRotationOperation::AddOnly,
-                        &error,
-                    );
-                    return Err(error);
-                }
+                preflight_session(commands, desired.clone()).await?;
             }
         }
         Ok(())
@@ -990,6 +942,13 @@ impl PeerManager {
                 );
                 return Err(error);
             }
+        };
+
+        self.tcp_ao_rotation = TcpAoRotationStatus {
+            desired: generation,
+            applied: self.tcp_ao_generation,
+            phase: TcpAoRotationPhase::AddOnly,
+            last_error: None,
         };
 
         for (peer, _, _) in &plan {
@@ -1100,59 +1059,20 @@ impl PeerManager {
     }
 
     async fn preflight_tcp_ao_delete(
-        &mut self,
+        &self,
         generation: TcpAoRotationGeneration,
         current_listener_keys: &[TcpAoListenerKey],
         desired_listener_keys: &[TcpAoListenerKey],
         current_static_keyrings: &[(PeerKey, TcpAoKeyring)],
         desired_static_keyrings: &[(PeerKey, TcpAoKeyring)],
     ) -> Result<(), String> {
-        let inventory = canonical_desired_inventory(
-            generation,
-            TcpAoRotationOperation::Delete,
-            desired_listener_keys,
-            desired_static_keyrings,
-        );
-        if let Err(error) = retain_desired_inventory(&mut self.tcp_ao_desired_inventory, inventory)
-        {
-            self.mark_tcp_ao_rotation_failed(generation, TcpAoRotationOperation::Delete, &error);
-            return Err(error);
-        }
-        let plan = match self.build_tcp_ao_deletion_plan(
+        let plan = self.build_tcp_ao_deletion_plan(
             generation,
             current_listener_keys,
             desired_listener_keys,
             current_static_keyrings,
             desired_static_keyrings,
-        ) {
-            Ok(plan) => plan,
-            Err(error) => {
-                self.mark_tcp_ao_rotation_failed(
-                    generation,
-                    TcpAoRotationOperation::Delete,
-                    &error,
-                );
-                return Err(error);
-            }
-        };
-        self.tcp_ao_rotation = TcpAoRotationStatus {
-            desired: generation,
-            applied: self.tcp_ao_generation,
-            phase: TcpAoRotationPhase::Deleting,
-            last_error: None,
-        };
-        for entry in &plan {
-            let applied = self.peers[&entry.peer].tcp_ao_rotation.applied;
-            self.peers
-                .get_mut(&entry.peer)
-                .expect("peer came from current map")
-                .tcp_ao_rotation = TcpAoRotationStatus {
-                desired: generation,
-                applied,
-                phase: TcpAoRotationPhase::Deleting,
-                last_error: None,
-            };
-        }
+        )?;
         let mut preflights = Vec::new();
         for entry in &plan {
             for commands in &entry.sessions {
@@ -1165,13 +1085,9 @@ impl PeerManager {
         }
         for (peer, result) in join_all(preflights).await {
             if let Err(error) = result {
-                let error = format!("TCP-AO deletion preflight failed for {peer:?}: {error}");
-                self.mark_tcp_ao_rotation_failed(
-                    generation,
-                    TcpAoRotationOperation::Delete,
-                    &error,
-                );
-                return Err(error);
+                return Err(format!(
+                    "TCP-AO deletion preflight failed for {peer:?}: {error}"
+                ));
             }
         }
         Ok(())
@@ -1216,6 +1132,12 @@ impl PeerManager {
                 );
                 return Err(error);
             }
+        };
+        self.tcp_ao_rotation = TcpAoRotationStatus {
+            desired: generation,
+            applied: self.tcp_ao_generation,
+            phase: TcpAoRotationPhase::Deleting,
+            last_error: None,
         };
         for entry in &plan {
             let applied = self.peers[&entry.peer].tcp_ao_rotation.applied;
@@ -1312,52 +1234,12 @@ impl PeerManager {
     }
 
     async fn preflight_tcp_ao_selection(
-        &mut self,
+        &self,
         generation: TcpAoRotationGeneration,
         listener_keys: &[TcpAoListenerKey],
         static_keyrings: &[(PeerKey, TcpAoKeyring)],
     ) -> Result<(), String> {
-        let inventory = canonical_desired_inventory(
-            generation,
-            TcpAoRotationOperation::Selection,
-            listener_keys,
-            static_keyrings,
-        );
-        if let Err(error) = retain_desired_inventory(&mut self.tcp_ao_desired_inventory, inventory)
-        {
-            self.mark_tcp_ao_rotation_failed(generation, TcpAoRotationOperation::Selection, &error);
-            return Err(error);
-        }
-        let plan =
-            match self.build_tcp_ao_selection_plan(generation, listener_keys, static_keyrings) {
-                Ok(plan) => plan,
-                Err(error) => {
-                    self.mark_tcp_ao_rotation_failed(
-                        generation,
-                        TcpAoRotationOperation::Selection,
-                        &error,
-                    );
-                    return Err(error);
-                }
-            };
-        self.tcp_ao_rotation = TcpAoRotationStatus {
-            desired: generation,
-            applied: self.tcp_ao_generation,
-            phase: TcpAoRotationPhase::Selecting,
-            last_error: None,
-        };
-        for entry in &plan {
-            let applied = self.peers[&entry.peer].tcp_ao_rotation.applied;
-            self.peers
-                .get_mut(&entry.peer)
-                .expect("peer came from current map")
-                .tcp_ao_rotation = TcpAoRotationStatus {
-                desired: generation,
-                applied,
-                phase: TcpAoRotationPhase::Selecting,
-                last_error: None,
-            };
-        }
+        let plan = self.build_tcp_ao_selection_plan(generation, listener_keys, static_keyrings)?;
         let mut preflights = Vec::new();
         for entry in plan.iter().filter(|entry| entry.selection_changed) {
             for commands in &entry.sessions {
@@ -1371,13 +1253,9 @@ impl PeerManager {
         }
         for (peer, result) in join_all(preflights).await {
             if let Err(error) = result {
-                let error = format!("TCP-AO selection preflight failed for {peer:?}: {error}");
-                self.mark_tcp_ao_rotation_failed(
-                    generation,
-                    TcpAoRotationOperation::Selection,
-                    &error,
-                );
-                return Err(error);
+                return Err(format!(
+                    "TCP-AO selection preflight failed for {peer:?}: {error}"
+                ));
             }
         }
         Ok(())
@@ -1443,6 +1321,13 @@ impl PeerManager {
                     return Err(error);
                 }
             };
+
+        self.tcp_ao_rotation = TcpAoRotationStatus {
+            desired: generation,
+            applied: self.tcp_ao_generation,
+            phase: TcpAoRotationPhase::Selecting,
+            last_error: None,
+        };
 
         for entry in &plan {
             let applied = self.peers[&entry.peer].tcp_ao_rotation.applied;
@@ -2043,6 +1928,130 @@ mod tests {
         );
         manager.register_session(session_id, &peer);
         peer
+    }
+
+    fn preflight_only_peer_handle(result: Result<(), PeerCommandError>) -> PeerHandle {
+        let (commands, mut rx) = mpsc::channel(4);
+        let task = tokio::spawn(async move {
+            while let Some(command) = rx.recv().await {
+                match command {
+                    PeerCommand::PreflightTcpAoAddOnly { reply, .. }
+                    | PeerCommand::PreflightTcpAoSelection { reply, .. }
+                    | PeerCommand::PreflightTcpAoDelete { reply, .. } => {
+                        let _ = reply.send(result.clone());
+                    }
+                    PeerCommand::Shutdown
+                    | PeerCommand::Stop { .. }
+                    | PeerCommand::CollisionDump => break,
+                    _ => {}
+                }
+            }
+            Ok(())
+        });
+        PeerHandle::from_parts(commands, task)
+    }
+
+    async fn assert_preflight_state_unchanged(
+        operation: TcpAoRotationOperation,
+        result: Result<(), PeerCommandError>,
+    ) {
+        let generation = TcpAoRotationGeneration::STARTUP.next().unwrap();
+        let (_manager_tx, manager_rx) = mpsc::channel(4);
+        let (rib_tx, _rib_rx) = mpsc::channel(4);
+        let mut manager = PeerManager::new(
+            manager_rx,
+            65_001,
+            Ipv4Addr::new(10, 0, 0, 1),
+            None,
+            None,
+            BgpMetrics::new(),
+            rib_tx,
+            None,
+        );
+        let mut current = TcpAoKeyring(vec![key(1, 11), key(2, 12)]);
+        let desired = match operation {
+            TcpAoRotationOperation::AddOnly => {
+                let mut desired = current.clone();
+                desired.0.push(key(3, 13));
+                desired
+            }
+            TcpAoRotationOperation::Selection => {
+                let mut desired = current.clone();
+                desired.0[0].deprecated = true;
+                desired.0[1].preferred = true;
+                desired
+            }
+            TcpAoRotationOperation::Delete => {
+                current.0[0].deprecated = true;
+                current.0[1].preferred = true;
+                TcpAoKeyring(vec![current.0[1].clone()])
+            }
+        };
+        let peer = install_rotation_peer(
+            &mut manager,
+            "192.0.2.1".parse().unwrap(),
+            1,
+            preflight_only_peer_handle(result.clone()),
+            current.clone(),
+        );
+        let before = (
+            manager.tcp_ao_generation,
+            manager.tcp_ao_desired_inventory.clone(),
+            manager.tcp_ao_rotation.clone(),
+            manager.peers[&peer].tcp_ao_rotation.clone(),
+            manager.peers[&peer].transport_config.tcp_ao.clone(),
+        );
+
+        let attempt = manager
+            .preflight_tcp_ao_rotation(
+                generation,
+                operation,
+                &[],
+                &[],
+                &[(peer.clone(), desired)],
+                &[(peer.clone(), current)],
+            )
+            .await;
+        assert_eq!(attempt.is_ok(), result.is_ok());
+        assert_eq!(
+            (
+                manager.tcp_ao_generation,
+                manager.tcp_ao_desired_inventory.clone(),
+                manager.tcp_ao_rotation.clone(),
+                manager.peers[&peer].tcp_ao_rotation.clone(),
+                manager.peers[&peer].transport_config.tcp_ao.clone(),
+            ),
+            before,
+            "{operation:?} preflight changed peer-manager authority"
+        );
+    }
+
+    #[tokio::test]
+    async fn tcp_ao_preflight_success_is_read_only_for_every_operation() {
+        for operation in [
+            TcpAoRotationOperation::AddOnly,
+            TcpAoRotationOperation::Selection,
+            TcpAoRotationOperation::Delete,
+        ] {
+            assert_preflight_state_unchanged(operation, Ok(())).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn tcp_ao_preflight_rejection_is_read_only_for_every_operation() {
+        for operation in [
+            TcpAoRotationOperation::AddOnly,
+            TcpAoRotationOperation::Selection,
+            TcpAoRotationOperation::Delete,
+        ] {
+            assert_preflight_state_unchanged(
+                operation,
+                Err(PeerCommandError::CommandFailed(
+                    "injected read-only preflight rejection".to_string(),
+                )),
+            )
+            .await;
+        }
     }
 
     #[tokio::test]

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -73,6 +73,24 @@ async fn dispatch_rib_step<T, E>(
     }
 }
 
+async fn dispatch_rib_mutation_step<T, E>(
+    rib_tx: &mpsc::Sender<rustbgpd_rib::RibUpdate>,
+    progress: &SighupMutationProgress<'_>,
+    build: impl FnOnce(oneshot::Sender<Result<T, E>>) -> rustbgpd_rib::RibUpdate,
+) -> ReloadDispatch<Result<T, E>, String> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let permit = match rib_tx.reserve().await {
+        Ok(permit) => permit,
+        Err(error) => return ReloadDispatch::NotAccepted(error.to_string()),
+    };
+    progress.begin_mutation();
+    permit.send(build(reply_tx));
+    match reply_rx.await {
+        Ok(result) => ReloadDispatch::Replied(result),
+        Err(_) => ReloadDispatch::AcknowledgementLost,
+    }
+}
+
 /// Preflight `config`'s outbound prefix maxima across every live peer and
 /// hold them as an inactive prepared transaction (ADR-0113).
 ///
@@ -277,6 +295,7 @@ impl std::fmt::Display for ReloadStepError {
 pub(crate) struct SighupReloadPlan {
     pub(crate) baseline_runtime: Config,
     pub(crate) desired: Arc<AcceptedConfigSnapshot>,
+    pub(crate) accepted_effect: bool,
 }
 
 #[derive(Clone)]
@@ -348,17 +367,20 @@ struct SighupMutationProgress<'a> {
 }
 
 impl<'a> SighupMutationProgress<'a> {
-    fn new(operation: Option<&'a OwnedRuntimeConfigOperation>) -> Self {
+    fn new(operation: Option<&'a OwnedRuntimeConfigOperation>, accepted_effect: bool) -> Self {
         Self {
             operation,
-            accepted_effect: false,
+            accepted_effect,
+        }
+    }
+
+    fn begin_mutation(&self) {
+        if let Some(operation) = self.operation {
+            operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
         }
     }
 
     fn mark_accepted_effect(&mut self) {
-        if let Some(operation) = self.operation {
-            operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
-        }
         self.accepted_effect = true;
     }
 }
@@ -898,9 +920,10 @@ async fn mark_tcp_ao_failed(
     generation: TcpAoRotationGeneration,
     operation: TcpAoRotationOperation,
     error: String,
+    progress: &SighupMutationProgress<'_>,
 ) {
     let result = step_result(
-        dispatch_peer_step(peer_mgr_tx, |reply| {
+        dispatch_actor_mutation_step(peer_mgr_tx, progress, |reply| {
             PeerManagerCommand::MarkTcpAoRotationFailed {
                 generation,
                 operation,
@@ -989,6 +1012,24 @@ async fn dispatch_peer_step<E>(
     dispatch_actor_step(peer_mgr_tx, build).await
 }
 
+async fn dispatch_actor_mutation_step<T>(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+    progress: &SighupMutationProgress<'_>,
+    build: impl FnOnce(oneshot::Sender<T>) -> PeerManagerCommand,
+) -> ReloadDispatch<T, String> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let permit = match peer_mgr_tx.reserve().await {
+        Ok(permit) => permit,
+        Err(error) => return ReloadDispatch::NotAccepted(error.to_string()),
+    };
+    progress.begin_mutation();
+    permit.send(build(reply_tx));
+    match reply_rx.await {
+        Ok(result) => ReloadDispatch::Replied(result),
+        Err(_) => ReloadDispatch::AcknowledgementLost,
+    }
+}
+
 fn step_result<E: std::fmt::Display>(
     dispatch: ReloadDispatch<Result<(), E>, String>,
 ) -> Result<(), ReloadStepError> {
@@ -1005,8 +1046,8 @@ async fn peer_step<E: std::fmt::Display>(
     progress: &mut SighupMutationProgress<'_>,
     build: impl FnOnce(oneshot::Sender<Result<(), E>>) -> PeerManagerCommand,
 ) -> Result<(), ReloadStepError> {
-    let dispatch = dispatch_peer_step(peer_mgr_tx, build).await;
-    if !matches!(dispatch, ReloadDispatch::NotAccepted(_)) {
+    let dispatch = dispatch_actor_mutation_step(peer_mgr_tx, progress, build).await;
+    if matches!(dispatch, ReloadDispatch::Replied(Ok(()))) {
         progress.mark_accepted_effect();
     }
     step_result(dispatch)
@@ -1025,7 +1066,7 @@ async fn catalog_step(
     progress: &mut SighupMutationProgress<'_>,
     mutation: OwnedCatalogMutation,
 ) -> Result<(), OwnedStepFailure> {
-    match dispatch_actor_step(peer_mgr_tx, |reply| {
+    match dispatch_actor_mutation_step(peer_mgr_tx, progress, |reply| {
         PeerManagerCommand::OwnedCatalogMutation { mutation, reply }
     })
     .await
@@ -1044,19 +1085,15 @@ async fn catalog_step(
             error.to_string(),
         ))),
         ReloadDispatch::Replied(OwnedCatalogMutationOutcome::CompensationAmbiguous(error)) => {
-            progress.mark_accepted_effect();
             Err(OwnedStepFailure::Fenced {
                 error: ReloadStepError::Rejected(error.to_string()),
                 reason: RuntimeConfigFenceReason::KnownDivergence,
             })
         }
-        ReloadDispatch::AcknowledgementLost => {
-            progress.mark_accepted_effect();
-            Err(OwnedStepFailure::Fenced {
-                error: ReloadStepError::AcknowledgementLost,
-                reason: RuntimeConfigFenceReason::AcknowledgementLost,
-            })
-        }
+        ReloadDispatch::AcknowledgementLost => Err(OwnedStepFailure::Fenced {
+            error: ReloadStepError::AcknowledgementLost,
+            reason: RuntimeConfigFenceReason::AcknowledgementLost,
+        }),
     }
 }
 
@@ -1088,9 +1125,8 @@ async fn hot_peer_step(
     progress: &mut SighupMutationProgress<'_>,
     config: PeerManagerNeighborConfig,
 ) -> Result<(), OwnedStepFailure> {
-    match dispatch_actor_step(peer_mgr_tx, |reply| PeerManagerCommand::HotUpdatePeer {
-        config,
-        reply,
+    match dispatch_actor_mutation_step(peer_mgr_tx, progress, |reply| {
+        PeerManagerCommand::HotUpdatePeer { config, reply }
     })
     .await
     {
@@ -1105,19 +1141,15 @@ async fn hot_peer_step(
             OwnedStepFailure::Partial(ReloadStepError::Rejected(error.to_string())),
         ),
         ReloadDispatch::Replied(OwnedHotUpdatePeerOutcome::KnownDivergence(error)) => {
-            progress.mark_accepted_effect();
             Err(OwnedStepFailure::Fenced {
                 error: ReloadStepError::Rejected(error.to_string()),
                 reason: RuntimeConfigFenceReason::KnownDivergence,
             })
         }
-        ReloadDispatch::AcknowledgementLost => {
-            progress.mark_accepted_effect();
-            Err(OwnedStepFailure::Fenced {
-                error: ReloadStepError::AcknowledgementLost,
-                reason: RuntimeConfigFenceReason::AcknowledgementLost,
-            })
-        }
+        ReloadDispatch::AcknowledgementLost => Err(OwnedStepFailure::Fenced {
+            error: ReloadStepError::AcknowledgementLost,
+            reason: RuntimeConfigFenceReason::AcknowledgementLost,
+        }),
     }
 }
 
@@ -1136,7 +1168,7 @@ fn listener_mutation_step<T>(
     dispatch: ReloadDispatch<std::io::Result<T>, std::io::Error>,
     progress: &mut SighupMutationProgress<'_>,
 ) -> Result<T, ReloadStepError> {
-    if !matches!(dispatch, ReloadDispatch::NotAccepted(_)) {
+    if matches!(dispatch, ReloadDispatch::Replied(Ok(_))) {
         progress.mark_accepted_effect();
     }
     listener_step(dispatch)
@@ -1830,6 +1862,7 @@ pub(crate) async fn reload_config(
         SighupReloadPlan {
             baseline_runtime: current.clone(),
             desired,
+            accepted_effect: false,
         },
         live_grpc_tcp,
         live_grpc_uds,
@@ -1861,7 +1894,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
 ) -> SighupReloadOutcome {
     let current = &plan.baseline_runtime;
     let desired_snapshot = plan.desired;
-    let mut progress = SighupMutationProgress::new(operation);
+    let mut progress = SighupMutationProgress::new(operation, plan.accepted_effect);
     // LAN-305: parse dataset contents against the running binding schema, but
     // stage changed data and refresh errors on detached candidate handles.
     // Shared live handles are committed only after the complete no-side-effect
@@ -2047,6 +2080,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 plan.generation,
                 plan.operation,
                 error.to_string(),
+                &progress,
             )
             .await;
             error!(error = %error, "TCP-AO generation rejected during complete listener kernel preflight");
@@ -2057,9 +2091,21 @@ pub(crate) async fn reload_config_with_tcp_ao(
             return preflight_dispatch_failure("tcp_ao.peer_preflight", error);
         }
         let listener_apply = match plan.operation {
-            TcpAoRotationOperation::AddOnly => listener.apply_add_only(desired_listener).await,
-            TcpAoRotationOperation::Selection => listener.begin_selection(desired_listener).await,
-            TcpAoRotationOperation::Delete => listener.apply_delete(desired_listener).await,
+            TcpAoRotationOperation::AddOnly => {
+                listener
+                    .apply_add_only(desired_listener, || progress.begin_mutation())
+                    .await
+            }
+            TcpAoRotationOperation::Selection => {
+                listener
+                    .begin_selection(desired_listener, || progress.begin_mutation())
+                    .await
+            }
+            TcpAoRotationOperation::Delete => {
+                listener
+                    .apply_delete(desired_listener, || progress.begin_mutation())
+                    .await
+            }
         };
         if let Err(error) = listener_mutation_step(listener_apply, &mut progress) {
             mark_tcp_ao_failed(
@@ -2067,6 +2113,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 plan.generation,
                 plan.operation,
                 error.to_string(),
+                &progress,
             )
             .await;
             error!(error = %error, "TCP-AO generation failed on listener; retry the identical generation unless the error reports failed exact prior-inventory restoration, in which case restart rustbgpd");
@@ -2082,7 +2129,9 @@ pub(crate) async fn reload_config_with_tcp_ao(
                 && matches!(&error, ReloadStepError::Rejected(message) if message.starts_with(crate::peer_manager::TCP_AO_AWAITING_PEER_PREFIX))
             {
                 let marker = listener
-                    .mark_awaiting_peer(plan.generation, error.to_string())
+                    .mark_awaiting_peer(plan.generation, error.to_string(), || {
+                        progress.begin_mutation();
+                    })
                     .await;
                 if matches!(&marker, ReloadDispatch::Replied(Ok(()))) {
                     info!(error = %error, generation = plan.generation.as_u64(), "TCP-AO successor selected; peer-use observation remains pending until a later identical SIGHUP");
@@ -2105,7 +2154,9 @@ pub(crate) async fn reload_config_with_tcp_ao(
             }
             if let Err(marker_error) = listener_step(
                 listener
-                    .mark_dependent_failure(plan.generation, error.to_string())
+                    .mark_dependent_failure(plan.generation, error.to_string(), || {
+                        progress.begin_mutation();
+                    })
                     .await,
             ) {
                 warn!(error = %marker_error, "TCP-AO listener dependent-failure marker was not acknowledged; staged generation remains globally uncommitted");
@@ -2119,13 +2170,18 @@ pub(crate) async fn reload_config_with_tcp_ao(
             return fenced_reload_failure("tcp_ao.peer_apply", error, reason);
         }
         if plan.operation == TcpAoRotationOperation::Selection
-            && let Err(error) = listener_step(listener.finalize_selection(plan.generation).await)
+            && let Err(error) = listener_step(
+                listener
+                    .finalize_selection(plan.generation, || progress.begin_mutation())
+                    .await,
+            )
         {
             mark_tcp_ao_failed(
                 peer_mgr_tx,
                 plan.generation,
                 plan.operation,
                 error.to_string(),
+                &progress,
             )
             .await;
             error!(error = %error, "TCP-AO session cohort observed successor use, but listener metadata commit failed; retrying the identical generation is required");
@@ -2136,13 +2192,17 @@ pub(crate) async fn reload_config_with_tcp_ao(
             };
             return fenced_reload_failure("tcp_ao.listener_finalize", error, reason);
         }
-        if let Err(error) = listener_step(listener.acknowledge_global_commit(plan.generation).await)
-        {
+        if let Err(error) = listener_step(
+            listener
+                .acknowledge_global_commit(plan.generation, || progress.begin_mutation())
+                .await,
+        ) {
             mark_tcp_ao_failed(
                 peer_mgr_tx,
                 plan.generation,
                 plan.operation,
                 error.to_string(),
+                &progress,
             )
             .await;
             error!(error = %error, "TCP-AO generation reached sessions but listener global commit acknowledgement failed; retrying the same immutable generation is required");
@@ -2185,7 +2245,9 @@ pub(crate) async fn reload_config_with_tcp_ao(
         if current_inventory != desired_inventory {
             let (md5_keys, ttl_security) = desired_inventory;
             if let Err(error) = listener_mutation_step(
-                listener.replace_inbound_auth(md5_keys, ttl_security).await,
+                listener
+                    .replace_inbound_auth(md5_keys, ttl_security, || progress.begin_mutation())
+                    .await,
                 &mut progress,
             ) {
                 error!(
@@ -2210,8 +2272,13 @@ pub(crate) async fn reload_config_with_tcp_ao(
     new_config.policy.dataset_events = desired_config.policy.dataset_events.clone();
 
     if let Some(apply) = evpn_runtime_apply {
+        let evpn_operation = operation.cloned();
         let attempt = apply
-            .apply_config_if_changed(&new_config, evpn_runtime_changed)
+            .apply_config_if_changed(&new_config, evpn_runtime_changed, move || {
+                if let Some(operation) = evpn_operation.as_ref() {
+                    operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
+                }
+            })
             .await;
         match attempt.terminal {
             EvpnRuntimeReloadTerminal::Applied(result) => {
@@ -2487,7 +2554,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
             );
         }
 
-        let activation = dispatch_rib_step(rib_tx, |reply| {
+        let activation = dispatch_rib_mutation_step(rib_tx, &progress, |reply| {
             rustbgpd_rib::RibUpdate::ApplyOutboundPrefixLimits {
                 txn,
                 activate: true,
@@ -2557,15 +2624,16 @@ pub(crate) async fn reload_config_with_tcp_ao(
         // command channel and awaited, so it is applied before every
         // subsequent step. A send failure means the peer manager is gone and
         // returns the authority accumulated before this step.
-        let outcome =
-            dispatch_actor_step(peer_mgr_tx, |reply| PeerManagerCommand::SyncExplainConfig {
+        let outcome = dispatch_actor_mutation_step(peer_mgr_tx, &progress, |reply| {
+            PeerManagerCommand::SyncExplainConfig {
                 enabled: new_config.policy.explain.enabled,
                 cache_size: new_config.policy.explain.cache_size,
                 reject_retention_enabled: new_config.policy.reject_retention.enabled,
                 reject_retention_capacity: new_config.policy.reject_retention.capacity,
                 reply,
-            })
-            .await;
+            }
+        })
+        .await;
         match outcome {
             ReloadDispatch::Replied(()) => {
                 progress.mark_accepted_effect();
@@ -2665,6 +2733,9 @@ pub(crate) async fn reload_config_with_tcp_ao(
     // fallible peer-manager registry/snapshot step has succeeded. Commit the
     // staged contents/errors now, then publish honest snapshot bookkeeping and
     // dependency-scoped refreshes. Its acknowledgement is part of the owner.
+    if dataset_commit_pending {
+        progress.begin_mutation();
+    }
     dataset_commit.commit();
     if dataset_commit_pending {
         progress.mark_accepted_effect();
@@ -2676,7 +2747,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
     working_config.policy.dataset_bindings = new_config.policy.dataset_bindings.clone();
     let dataset_events = &new_config.policy.dataset_events;
     if !dataset_events.swapped.is_empty() || !dataset_events.failed.is_empty() {
-        let outcome = dispatch_actor_step(peer_mgr_tx, |reply| {
+        let outcome = dispatch_actor_mutation_step(peer_mgr_tx, &progress, |reply| {
             PeerManagerCommand::RefreshDatasetDependents {
                 swapped: dataset_events.swapped.clone(),
                 failed: dataset_events.failed.clone(),
@@ -3212,6 +3283,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                     );
                 }
             };
+            progress.begin_mutation();
             permit.send(PeerManagerCommand::ReconcilePeers {
                 added: resolve(&diff.added),
                 removed: diff.removed.clone(),
@@ -3407,6 +3479,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
                         );
                     }
                 };
+                progress.begin_mutation();
                 permit.send(FibRuntimeCommand::OwnedReplaceTables {
                     tables: new_config.fib_tables.clone(),
                     reply: reply_tx,
@@ -4656,11 +4729,10 @@ originator_ip = "10.0.0.1"
     )]
     async fn reload_fences_decomposed_evpn_failure_before_later_command() {
         // #268: an ES delete + its (surviving) member L2VNI redefine + a new
-        // L2VNI add in ONE SIGHUP. The converge of the mixed whole rejects it
-        // (scripted `Unsupported`, as the real dispatch would), and the
-        // decomposer commits the delete, then the redefine fails after
-        // effects and pins the coordinator. The reload must fence without
-        // dispatching the later honor-graceful-shutdown mutation.
+        // L2VNI add in ONE SIGHUP. Pure shape planning decomposes the mixed
+        // whole before mutation begins; the delete commits, then the redefine
+        // fails after effects and pins the coordinator. The reload must fence
+        // without dispatching the later honor-graceful-shutdown mutation.
         let path = unique_temp_path("reload-evpn-decomposed-mixed");
         std::fs::write(
             &path,
@@ -4692,11 +4764,6 @@ originator_ip = "10.0.0.1"
         let (apply, coordinator) = evpn_reload_apply_sequence(
             &initial,
             vec![
-                Err(
-                    crate::evpn_runtime_converger::DaemonEvpnRuntimeConvergeError::Unsupported(
-                        "mixed shape rejected by the dispatch".to_string(),
-                    ),
-                ),
                 Ok(()),
                 Err(
                     crate::evpn_runtime_converger::DaemonEvpnRuntimeConvergeError::Failed(
@@ -5488,6 +5555,7 @@ hold_time = 90
             SighupReloadPlan {
                 baseline_runtime: current,
                 desired: AcceptedConfigSnapshot::from_config_for_test(desired),
+                accepted_effect: false,
             },
             None,
             None,
@@ -6140,7 +6208,7 @@ hold_time = 90
                     CatalogMutationError::internal("injected ambiguous compensation"),
                 ));
             });
-            let mut progress = SighupMutationProgress::new(None);
+            let mut progress = SighupMutationProgress::new(None, false);
             assert!(matches!(
                 catalog_step(&tx, &mut progress, mutation).await,
                 Err(OwnedStepFailure::Fenced {
@@ -6168,7 +6236,7 @@ hold_time = 90
                 };
                 drop(reply);
             });
-            let mut progress = SighupMutationProgress::new(None);
+            let mut progress = SighupMutationProgress::new(None, false);
             assert!(matches!(
                 catalog_step(&tx, &mut progress, mutation).await,
                 Err(OwnedStepFailure::Fenced {
@@ -6176,6 +6244,40 @@ hold_time = 90
                     ..
                 })
             ));
+        }
+    }
+
+    #[tokio::test]
+    async fn rejected_and_compensated_catalog_outcomes_do_not_claim_authority() {
+        for outcome in [
+            OwnedCatalogMutationOutcome::RejectedNoEffect(CatalogMutationError::internal(
+                "injected rejection",
+            )),
+            OwnedCatalogMutationOutcome::FullyCompensated(CatalogMutationError::internal(
+                "injected compensation",
+            )),
+        ] {
+            let (tx, mut rx) = mpsc::channel(1);
+            tokio::spawn(async move {
+                let Some(PeerManagerCommand::OwnedCatalogMutation { reply, .. }) = rx.recv().await
+                else {
+                    panic!("expected owned catalog mutation");
+                };
+                let _ = reply.send(outcome);
+            });
+            let mut progress = SighupMutationProgress::new(None, false);
+            assert!(matches!(
+                catalog_step(
+                    &tx,
+                    &mut progress,
+                    OwnedCatalogMutation::DeletePolicy {
+                        name: "rejected".to_string(),
+                    },
+                )
+                .await,
+                Err(OwnedStepFailure::Partial(_))
+            ));
+            assert!(!progress.accepted_effect);
         }
     }
 
@@ -6188,7 +6290,7 @@ hold_time = 90
             };
             drop(reply);
         });
-        let mut progress = SighupMutationProgress::new(None);
+        let mut progress = SighupMutationProgress::new(None, false);
         let config = load_config_from_toml("hot-reply-loss", baseline_toml());
         let resolved = config.resolved_neighbors().unwrap().remove(0);
         assert!(matches!(
@@ -6891,7 +6993,7 @@ tcp_ao = [
         let mut desired = Config::load_toml_with_diagnostics(&desired_toml, "desired").unwrap();
         desired.file_path = Some(PathBuf::from("/operator/candidate.toml"));
         let desired_snapshot = AcceptedConfigSnapshot::from_config_for_test(desired.clone());
-        let mut progress = SighupMutationProgress::new(None);
+        let mut progress = SighupMutationProgress::new(None, false);
         progress.mark_accepted_effect();
         let detail = format!(
             "{} peer 10.0.0.2 has not observed successor traffic",
@@ -6941,7 +7043,7 @@ tcp_ao = [
     fn tcp_ao_awaiting_peer_marker_uncertainty_still_recovery_fences() {
         let current = Config::load_toml_with_diagnostics(baseline_toml(), "current").unwrap();
         let desired = AcceptedConfigSnapshot::from_config_for_test(current.clone());
-        let mut progress = SighupMutationProgress::new(None);
+        let mut progress = SighupMutationProgress::new(None, false);
         progress.mark_accepted_effect();
         let awaiting = || {
             ReloadStepError::Rejected(format!(


### PR DESCRIPTION
## Summary

- atomically freeze the last truthful phase when a runtime-config owner settles or recovery-fences
- carry generic response-attachment contexts through Apply, gNMI, transaction controls, AutoRevert, and SIGHUP
- place mutation and settling/rollback transitions at the actual first effect and compensation boundaries
- keep rejected PeerGroup/Policy outcomes out of settling and preserve the TCP-AO awaiting-peer retry authority

## Why

The watchdog safety contract was already active, but several observability fields could lie: phase updates could race terminal settlement, detached owners could appear response-attached, caller cancellation was not represented consistently, and some rollback paths remained in Mutating. This makes the internal settlement state match the real owner lifecycle without adding public API, configuration, or metric surface.

## Validation

- cargo test --locked --workspace --all-features
- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
- focused settlement, ConfigService, gNMI, PeerGroup, Policy, controller, and reload suites
- blocked-hook cancellation proofs for gNMI Set and Confirm/Abort/Rollback
- watchdog exit and persistence/SIGHUP real-process tests
- independent exact-head phase/attachment audit
- repository commit and pre-push hooks