### PR TITLE
fix: isolate runtime config fail-stop clock

### DIFF
--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -3,9 +3,12 @@
 //! This module supplies the fail-stop ownership kernel. Call sites arm it only
 //! after acquiring [`RuntimeConfigCoordinatorPermit`].
 
-use std::collections::HashMap;
+use arc_swap::ArcSwapOption;
+use prometheus::core::{Collector, Desc};
+use prometheus::proto::MetricFamily;
+use prometheus::{CounterVec, GaugeVec, Opts};
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
-use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
@@ -51,11 +54,57 @@ pub enum RuntimeConfigOperationKind {
     NeighborExportChainClear,
 }
 
+impl RuntimeConfigOperationKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Sighup => "sighup",
+            Self::Apply => "apply",
+            Self::GnmiSet => "gnmi_set",
+            Self::Confirm => "confirm",
+            Self::Abort => "abort",
+            Self::Rollback => "rollback",
+            Self::AutoRevert => "auto_revert",
+            Self::NeighborAdd => "neighbor_add",
+            Self::NeighborDelete => "neighbor_delete",
+            Self::DynamicNeighborAdd => "dynamic_neighbor_add",
+            Self::DynamicNeighborDelete => "dynamic_neighbor_delete",
+            Self::FibSet => "fib_set",
+            Self::FibDelete => "fib_delete",
+            Self::PeerGroupSet => "peer_group_set",
+            Self::PeerGroupDelete => "peer_group_delete",
+            Self::NeighborPeerGroupSet => "neighbor_peer_group_set",
+            Self::NeighborPeerGroupClear => "neighbor_peer_group_clear",
+            Self::PolicySet => "policy_set",
+            Self::PolicyDelete => "policy_delete",
+            Self::NeighborSetSet => "neighbor_set_set",
+            Self::NeighborSetDelete => "neighbor_set_delete",
+            Self::GlobalImportChainSet => "global_import_chain_set",
+            Self::GlobalExportChainSet => "global_export_chain_set",
+            Self::GlobalImportChainClear => "global_import_chain_clear",
+            Self::GlobalExportChainClear => "global_export_chain_clear",
+            Self::NeighborImportChainSet => "neighbor_import_chain_set",
+            Self::NeighborExportChainSet => "neighbor_export_chain_set",
+            Self::NeighborImportChainClear => "neighbor_import_chain_clear",
+            Self::NeighborExportChainClear => "neighbor_export_chain_clear",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum RuntimeConfigSettlementPhase {
     OwnedPreflight,
     Mutating,
     SettlingRollback,
+}
+
+impl RuntimeConfigSettlementPhase {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::OwnedPreflight => "owned_preflight",
+            Self::Mutating => "mutating",
+            Self::SettlingRollback => "settling_rollback",
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -74,6 +123,18 @@ pub enum RuntimeConfigFenceReason {
     AcknowledgementLost,
 }
 
+impl RuntimeConfigFenceReason {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::BudgetExpired => "budget_expired",
+            Self::ExecutorLost => "executor_lost",
+            Self::KnownDivergence => "known_divergence",
+            Self::PublicationAmbiguous => "publication_ambiguous",
+            Self::AcknowledgementLost => "acknowledgement_lost",
+        }
+    }
+}
+
 const PHASE_PREFLIGHT: u8 = 0;
 const PHASE_MUTATING: u8 = 1;
 const PHASE_SETTLING: u8 = 2;
@@ -82,13 +143,48 @@ const TERMINAL_OWNED: u8 = 0;
 const TERMINAL_SETTLED: u8 = 1 << 2;
 const TERMINAL_AMBIGUOUS: u8 = 2 << 2;
 const TERMINAL_MASK: u8 = 0b11 << 2;
-const AMBIGUITY_REASON_NONE: u8 = 0;
+const REASON_SHIFT: u8 = 4;
+const REASON_MASK: u8 = 0b111 << REASON_SHIFT;
 const AMBIGUITY_REASON_BUDGET: u8 = 1;
 const AMBIGUITY_REASON_EXECUTOR: u8 = 2;
 const FENCE_REASON_DIVERGENCE: u8 = 3;
 const FENCE_REASON_PUBLICATION: u8 = 4;
 const FENCE_REASON_ACKNOWLEDGEMENT: u8 = 5;
 const RECOVERY_NOT_READY: &str = "runtime config settlement requires supervised recovery";
+const WARNING_HALF_BUDGET: Duration = Duration::from_mins(15);
+const WARNING_FIVE_MINUTES_REMAINING: Duration = Duration::from_mins(25);
+const WARNING_ONE_MINUTE_REMAINING: Duration = Duration::from_mins(29);
+const WARNING_HALF_BIT: u8 = 1;
+const WARNING_FIVE_MINUTES_BIT: u8 = 1 << 1;
+const WARNING_ONE_MINUTE_BIT: u8 = 1 << 2;
+const METRIC_LABELS: [&str; 4] = ["kind", "phase", "response_attached", "fence_reason"];
+
+fn phase_from_state(state: u8) -> RuntimeConfigSettlementPhase {
+    match state & PHASE_MASK {
+        PHASE_PREFLIGHT => RuntimeConfigSettlementPhase::OwnedPreflight,
+        PHASE_MUTATING => RuntimeConfigSettlementPhase::Mutating,
+        _ => RuntimeConfigSettlementPhase::SettlingRollback,
+    }
+}
+
+fn terminal_from_state(state: u8) -> RuntimeConfigSettlementTerminal {
+    match state & TERMINAL_MASK {
+        TERMINAL_OWNED => RuntimeConfigSettlementTerminal::Owned,
+        TERMINAL_SETTLED => RuntimeConfigSettlementTerminal::Settled,
+        _ => RuntimeConfigSettlementTerminal::RecoveryFenced,
+    }
+}
+
+fn fence_reason_from_state(state: u8) -> Option<RuntimeConfigFenceReason> {
+    match (state & REASON_MASK) >> REASON_SHIFT {
+        AMBIGUITY_REASON_BUDGET => Some(RuntimeConfigFenceReason::BudgetExpired),
+        AMBIGUITY_REASON_EXECUTOR => Some(RuntimeConfigFenceReason::ExecutorLost),
+        FENCE_REASON_DIVERGENCE => Some(RuntimeConfigFenceReason::KnownDivergence),
+        FENCE_REASON_PUBLICATION => Some(RuntimeConfigFenceReason::PublicationAmbiguous),
+        FENCE_REASON_ACKNOWLEDGEMENT => Some(RuntimeConfigFenceReason::AcknowledgementLost),
+        _ => None,
+    }
+}
 
 #[derive(Debug)]
 struct OwnedResources {
@@ -100,10 +196,15 @@ struct OwnedResources {
 struct OperationInner {
     id: u64,
     kind: RuntimeConfigOperationKind,
+    registered_at: Instant,
     deadline: Instant,
     state: AtomicU8,
-    fence_reason: AtomicU8,
     response_attached: Arc<AtomicBool>,
+    fatal_at_nanos: AtomicU64,
+    warning_bits: AtomicU8,
+    propagation_claimed: AtomicBool,
+    #[cfg(test)]
+    propagation_completed: AtomicBool,
     coordinator: RuntimeConfigCoordinator,
     daemon_gate: DaemonGate,
     resources: Mutex<Option<OwnedResources>>,
@@ -116,58 +217,245 @@ impl std::fmt::Debug for OperationInner {
             .debug_struct("OperationInner")
             .field("id", &self.id)
             .field("kind", &self.kind)
+            .field("registered_at", &self.registered_at)
             .field("deadline", &self.deadline)
             .finish_non_exhaustive()
     }
 }
 
-#[derive(Debug)]
-struct Registration {
-    operation: Arc<OperationInner>,
-    terminal_at: Instant,
-}
+impl OperationInner {
+    fn phase(&self) -> RuntimeConfigSettlementPhase {
+        phase_from_state(self.state.load(Ordering::Acquire))
+    }
 
-struct RegistryState {
-    registrations: HashMap<u64, Registration>,
-    stopping: bool,
+    fn terminal(&self) -> RuntimeConfigSettlementTerminal {
+        terminal_from_state(self.state.load(Ordering::Acquire))
+    }
+
+    fn fence_reason(&self) -> Option<RuntimeConfigFenceReason> {
+        fence_reason_from_state(self.state.load(Ordering::Acquire))
+    }
+
+    fn elapsed(&self) -> Duration {
+        Instant::now().saturating_duration_since(self.registered_at)
+    }
 }
 
 struct Registry {
-    state: Mutex<RegistryState>,
+    current: ArcSwapOption<OperationInner>,
+    idle_lock: Mutex<()>,
     wake: Condvar,
     next_id: AtomicU64,
     budget: Duration,
     grace: Duration,
-    thread_id: Mutex<Option<thread::ThreadId>>,
+    epoch: Instant,
+    stopping: AtomicBool,
+    fatal_thread: OnceLock<thread::Thread>,
+    observer_thread: OnceLock<thread::Thread>,
     #[cfg(test)]
     terminal: std::sync::mpsc::Sender<i32>,
     #[cfg(test)]
-    pre_wait_hook: Mutex<Option<PreWaitHook>>,
-}
-
-#[cfg(test)]
-struct PreWaitHook {
-    reached: std::sync::mpsc::Sender<()>,
-    resume: std::sync::mpsc::Receiver<()>,
+    terminal_fired: AtomicBool,
 }
 
 impl Registry {
-    fn lock(&self) -> MutexGuard<'_, RegistryState> {
-        self.state
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-    }
-
-    fn unregister(&self, id: u64) {
-        self.lock().registrations.remove(&id);
-        self.wake.notify_all();
-    }
-
-    fn advance_terminal(&self, id: u64, when: Instant) {
-        if let Some(registration) = self.lock().registrations.get_mut(&id) {
-            registration.terminal_at = when;
+    #[cfg(not(test))]
+    fn new(budget: Duration, grace: Duration) -> Self {
+        Self {
+            current: ArcSwapOption::empty(),
+            idle_lock: Mutex::new(()),
+            wake: Condvar::new(),
+            next_id: AtomicU64::new(1),
+            budget,
+            grace,
+            epoch: Instant::now(),
+            stopping: AtomicBool::new(false),
+            fatal_thread: OnceLock::new(),
+            observer_thread: OnceLock::new(),
         }
-        self.wake.notify_one();
+    }
+
+    #[cfg(test)]
+    fn new(budget: Duration, grace: Duration, terminal: std::sync::mpsc::Sender<i32>) -> Self {
+        Self {
+            current: ArcSwapOption::empty(),
+            idle_lock: Mutex::new(()),
+            wake: Condvar::new(),
+            next_id: AtomicU64::new(1),
+            budget,
+            grace,
+            epoch: Instant::now(),
+            stopping: AtomicBool::new(false),
+            fatal_thread: OnceLock::new(),
+            observer_thread: OnceLock::new(),
+            terminal,
+            terminal_fired: AtomicBool::new(false),
+        }
+    }
+
+    fn instant_nanos(&self, instant: Instant) -> u64 {
+        u64::try_from(instant.saturating_duration_since(self.epoch).as_nanos())
+            .unwrap_or(u64::MAX)
+            .max(1)
+    }
+
+    fn nanos_instant(&self, nanos: u64) -> Instant {
+        self.epoch + Duration::from_nanos(nanos)
+    }
+
+    fn wake_threads(&self) {
+        self.wake.notify_all();
+        if let Some(observer) = self.observer_thread.get() {
+            observer.unpark();
+        }
+        if let Some(fatal) = self.fatal_thread.get() {
+            fatal.unpark();
+        }
+    }
+}
+
+struct RuntimeConfigSettlementCollector {
+    registry: Arc<Registry>,
+    scrape_lock: Mutex<()>,
+    active: GaugeVec,
+    elapsed: GaugeVec,
+    budget: GaugeVec,
+    fail_stops: CounterVec,
+    descs: Vec<Desc>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SettlementMetricSnapshot {
+    phase: RuntimeConfigSettlementPhase,
+    terminal: RuntimeConfigSettlementTerminal,
+    fence_reason: Option<RuntimeConfigFenceReason>,
+    response_attached: bool,
+}
+
+impl SettlementMetricSnapshot {
+    fn capture(operation: &OperationInner) -> Self {
+        let state = operation.state.load(Ordering::Acquire);
+        let response_attached = operation.response_attached.load(Ordering::Acquire);
+        Self::decode(state, response_attached)
+    }
+
+    fn decode(state: u8, response_attached: bool) -> Self {
+        Self {
+            phase: phase_from_state(state),
+            terminal: terminal_from_state(state),
+            fence_reason: fence_reason_from_state(state),
+            response_attached,
+        }
+    }
+
+    fn labels(self, kind: RuntimeConfigOperationKind) -> [&'static str; 4] {
+        [
+            kind.as_str(),
+            self.phase.as_str(),
+            if self.response_attached {
+                "attached"
+            } else {
+                "detached"
+            },
+            self.fence_reason
+                .map_or("none", RuntimeConfigFenceReason::as_str),
+        ]
+    }
+}
+
+impl RuntimeConfigSettlementCollector {
+    fn new(registry: Arc<Registry>) -> Self {
+        let active = GaugeVec::new(
+            Opts::new(
+                "bgp_runtime_config_settlement_active",
+                "Whether one runtime-config settlement owner is active or recovery-fenced.",
+            ),
+            &METRIC_LABELS,
+        )
+        .expect("valid runtime-config settlement active metric");
+        let elapsed = GaugeVec::new(
+            Opts::new(
+                "bgp_runtime_config_settlement_elapsed_seconds",
+                "Elapsed wall-clock seconds for the current runtime-config settlement owner.",
+            ),
+            &METRIC_LABELS,
+        )
+        .expect("valid runtime-config settlement elapsed metric");
+        let budget = GaugeVec::new(
+            Opts::new(
+                "bgp_runtime_config_settlement_budget_seconds",
+                "Fixed wall-clock budget for the current runtime-config settlement owner.",
+            ),
+            &METRIC_LABELS,
+        )
+        .expect("valid runtime-config settlement budget metric");
+        let fail_stops = CounterVec::new(
+            Opts::new(
+                "bgp_runtime_config_settlement_fail_stops_total",
+                "Runtime-config settlement owners that won recovery fencing and armed exit 70.",
+            ),
+            &METRIC_LABELS,
+        )
+        .expect("valid runtime-config settlement fail-stop metric");
+        let descs = active
+            .desc()
+            .into_iter()
+            .chain(elapsed.desc())
+            .chain(budget.desc())
+            .chain(fail_stops.desc())
+            .cloned()
+            .collect();
+        Self {
+            registry,
+            scrape_lock: Mutex::new(()),
+            active,
+            elapsed,
+            budget,
+            fail_stops,
+            descs,
+        }
+    }
+}
+
+impl Collector for RuntimeConfigSettlementCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        self.descs.iter().collect()
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        let _scrape = self
+            .scrape_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.active.reset();
+        self.elapsed.reset();
+        self.budget.reset();
+        self.fail_stops.reset();
+        let Some(operation) = self.registry.current.load_full() else {
+            return Vec::new();
+        };
+        let snapshot = SettlementMetricSnapshot::capture(&operation);
+        let labels = snapshot.labels(operation.kind);
+        self.active.with_label_values(&labels).set(1.0);
+        self.elapsed
+            .with_label_values(&labels)
+            .set(operation.elapsed().as_secs_f64());
+        self.budget
+            .with_label_values(&labels)
+            .set(self.registry.budget.as_secs_f64());
+        // The sole recovery-fenced owner cannot settle, and its fatal clock
+        // exits this process. The process-lifetime counter therefore moves
+        // only from 0 to 1; a fence-reason label change is a distinct series.
+        let fail_stops_total =
+            u32::from(snapshot.terminal == RuntimeConfigSettlementTerminal::RecoveryFenced);
+        self.fail_stops
+            .with_label_values(&labels)
+            .inc_by(f64::from(fail_stops_total));
+        let mut families = self.active.collect();
+        families.extend(self.elapsed.collect());
+        families.extend(self.budget.collect());
+        families.extend(self.fail_stops.collect());
+        families
     }
 }
 
@@ -175,7 +463,7 @@ impl Registry {
 pub struct RuntimeConfigSettlementWatchdog {
     registry: Arc<Registry>,
     #[cfg(test)]
-    thread: Arc<Mutex<Option<thread::JoinHandle<()>>>>,
+    threads: Arc<Mutex<Vec<thread::JoinHandle<()>>>>,
 }
 
 impl std::fmt::Debug for RuntimeConfigSettlementWatchdog {
@@ -200,55 +488,43 @@ impl RuntimeConfigSettlementWatchdog {
 
     #[cfg(not(test))]
     fn start(budget: Duration, grace: Duration) -> Self {
-        let registry = Arc::new(Registry {
-            state: Mutex::new(RegistryState {
-                registrations: HashMap::new(),
-                stopping: false,
-            }),
-            wake: Condvar::new(),
-            next_id: AtomicU64::new(1),
-            budget,
-            grace,
-            thread_id: Mutex::new(None),
-        });
-        let thread_registry = Arc::clone(&registry);
-        thread::Builder::new()
-            .name("config-settlement-watchdog".into())
-            .spawn(move || watchdog_loop(&thread_registry))
-            .expect("config settlement watchdog OS thread must start");
+        let registry = Arc::new(Registry::new(budget, grace));
+        start_threads(&registry);
         Self { registry }
     }
 
     #[cfg(test)]
     fn start(budget: Duration, grace: Duration, terminal: std::sync::mpsc::Sender<i32>) -> Self {
-        let registry = Arc::new(Registry {
-            state: Mutex::new(RegistryState {
-                registrations: HashMap::new(),
-                stopping: false,
-            }),
-            wake: Condvar::new(),
-            next_id: AtomicU64::new(1),
-            budget,
-            grace,
-            thread_id: Mutex::new(None),
-            terminal,
-            pre_wait_hook: Mutex::new(None),
-        });
-        let thread_registry = Arc::clone(&registry);
-        let thread = thread::Builder::new()
-            .name("config-settlement-watchdog".into())
-            .spawn(move || watchdog_loop(&thread_registry))
-            .expect("config settlement watchdog OS thread must start");
+        let registry = Arc::new(Registry::new(budget, grace, terminal));
+        let threads = start_threads(&registry);
         Self {
             registry,
-            thread: Arc::new(Mutex::new(Some(thread))),
+            threads: Arc::new(Mutex::new(threads)),
         }
+    }
+
+    /// Register scrape-time settlement metrics in the daemon's private registry.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the registry already contains one of the closed metric names.
+    pub fn register_metrics(&self, registry: &prometheus::Registry) {
+        registry
+            .register(Box::new(RuntimeConfigSettlementCollector::new(Arc::clone(
+                &self.registry,
+            ))))
+            .expect("runtime-config settlement metric definitions must be unique");
     }
 
     #[expect(
         clippy::too_many_arguments,
         reason = "the closed ownership registration lists every retained fail-stop resource explicitly"
     )]
+    /// Register the sole retained runtime-config owner.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a second owner bypasses the coordinator invariant.
     pub fn register_owned(
         &self,
         kind: RuntimeConfigOperationKind,
@@ -259,15 +535,23 @@ impl RuntimeConfigSettlementWatchdog {
         stream_admission: Option<Arc<Semaphore>>,
         response_attached: Arc<AtomicBool>,
     ) -> (OwnedRuntimeConfigOperation, RuntimeConfigExecutorGuard) {
-        let deadline = Instant::now() + self.registry.budget;
+        let registered_at = Instant::now();
+        let deadline = registered_at + self.registry.budget;
         let id = self.registry.next_id.fetch_add(1, Ordering::Relaxed);
         let operation = Arc::new(OperationInner {
             id,
             kind,
+            registered_at,
             deadline,
             state: AtomicU8::new(TERMINAL_OWNED | PHASE_PREFLIGHT),
-            fence_reason: AtomicU8::new(AMBIGUITY_REASON_NONE),
             response_attached,
+            fatal_at_nanos: AtomicU64::new(
+                self.registry.instant_nanos(deadline + self.registry.grace),
+            ),
+            warning_bits: AtomicU8::new(0),
+            propagation_claimed: AtomicBool::new(false),
+            #[cfg(test)]
+            propagation_completed: AtomicBool::new(false),
             coordinator,
             daemon_gate,
             resources: Mutex::new(Some(OwnedResources {
@@ -277,14 +561,21 @@ impl RuntimeConfigSettlementWatchdog {
             })),
             registry: Arc::clone(&self.registry),
         });
-        self.registry.lock().registrations.insert(
-            id,
-            Registration {
-                operation: Arc::clone(&operation),
-                terminal_at: deadline + self.registry.grace,
-            },
+        let previous = self
+            .registry
+            .current
+            .compare_and_swap(&None::<Arc<OperationInner>>, Some(Arc::clone(&operation)));
+        assert!(
+            previous.is_none(),
+            "runtime-config settlement permits only one current operation"
         );
         self.registry.wake.notify_one();
+        if let Some(observer) = self.registry.observer_thread.get() {
+            observer.unpark();
+        }
+        if let Some(fatal) = self.registry.fatal_thread.get() {
+            fatal.unpark();
+        }
         (
             OwnedRuntimeConfigOperation {
                 inner: Arc::clone(&operation),
@@ -363,12 +654,16 @@ impl RuntimeConfigSettlementWatchdog {
     /// Block the calling OS thread until every clean registration settles.
     /// Ambiguous ownership deliberately never unregisters; its fail-stop wins.
     pub fn wait_until_idle(&self) {
-        let mut state = self.registry.lock();
-        while !state.registrations.is_empty() {
-            state = self
+        let mut idle = self
+            .registry
+            .idle_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while self.registry.current.load().is_some() {
+            idle = self
                 .registry
                 .wake
-                .wait(state)
+                .wait(idle)
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
         }
     }
@@ -452,11 +747,7 @@ impl OwnedRuntimeConfigOperation {
 
     #[must_use]
     pub fn phase(&self) -> RuntimeConfigSettlementPhase {
-        match self.inner.state.load(Ordering::Acquire) & PHASE_MASK {
-            PHASE_PREFLIGHT => RuntimeConfigSettlementPhase::OwnedPreflight,
-            PHASE_MUTATING => RuntimeConfigSettlementPhase::Mutating,
-            _ => RuntimeConfigSettlementPhase::SettlingRollback,
-        }
+        self.inner.phase()
     }
 
     /// Advance the phase monotonically while ownership is live.
@@ -487,23 +778,12 @@ impl OwnedRuntimeConfigOperation {
 
     #[must_use]
     pub fn terminal(&self) -> RuntimeConfigSettlementTerminal {
-        match self.inner.state.load(Ordering::Acquire) & TERMINAL_MASK {
-            TERMINAL_OWNED => RuntimeConfigSettlementTerminal::Owned,
-            TERMINAL_SETTLED => RuntimeConfigSettlementTerminal::Settled,
-            _ => RuntimeConfigSettlementTerminal::RecoveryFenced,
-        }
+        self.inner.terminal()
     }
 
     #[must_use]
     pub fn fence_reason(&self) -> Option<RuntimeConfigFenceReason> {
-        match self.inner.fence_reason.load(Ordering::Acquire) {
-            AMBIGUITY_REASON_BUDGET => Some(RuntimeConfigFenceReason::BudgetExpired),
-            AMBIGUITY_REASON_EXECUTOR => Some(RuntimeConfigFenceReason::ExecutorLost),
-            FENCE_REASON_DIVERGENCE => Some(RuntimeConfigFenceReason::KnownDivergence),
-            FENCE_REASON_PUBLICATION => Some(RuntimeConfigFenceReason::PublicationAmbiguous),
-            FENCE_REASON_ACKNOWLEDGEMENT => Some(RuntimeConfigFenceReason::AcknowledgementLost),
-            _ => None,
-        }
+        self.inner.fence_reason()
     }
 
     /// Fence a typed recovery result before any response can be published.
@@ -535,7 +815,8 @@ impl OwnedRuntimeConfigOperation {
                 Err(actual) => observed = actual,
             }
         }
-        self.inner.registry.unregister(self.inner.id);
+        self.inner.registry.current.store(None);
+        self.inner.registry.wake_threads();
         let resources = self
             .inner
             .resources
@@ -564,12 +845,23 @@ impl Drop for RuntimeConfigExecutorGuard {
 }
 
 fn fence(operation: &OperationInner, reason: RuntimeConfigFenceReason) -> bool {
+    transition_to_fenced(operation, reason)
+}
+
+fn transition_to_fenced(operation: &OperationInner, reason: RuntimeConfigFenceReason) -> bool {
+    let reason_value = match reason {
+        RuntimeConfigFenceReason::BudgetExpired => AMBIGUITY_REASON_BUDGET,
+        RuntimeConfigFenceReason::ExecutorLost => AMBIGUITY_REASON_EXECUTOR,
+        RuntimeConfigFenceReason::KnownDivergence => FENCE_REASON_DIVERGENCE,
+        RuntimeConfigFenceReason::PublicationAmbiguous => FENCE_REASON_PUBLICATION,
+        RuntimeConfigFenceReason::AcknowledgementLost => FENCE_REASON_ACKNOWLEDGEMENT,
+    };
     let mut observed = operation.state.load(Ordering::Acquire);
     loop {
         if observed & TERMINAL_MASK != TERMINAL_OWNED {
             return false;
         }
-        let fenced = (observed & PHASE_MASK) | TERMINAL_AMBIGUOUS;
+        let fenced = (observed & PHASE_MASK) | TERMINAL_AMBIGUOUS | (reason_value << REASON_SHIFT);
         match operation.state.compare_exchange_weak(
             observed,
             fenced,
@@ -580,16 +872,31 @@ fn fence(operation: &OperationInner, reason: RuntimeConfigFenceReason) -> bool {
             Err(actual) => observed = actual,
         }
     }
-    let reason_value = match reason {
-        RuntimeConfigFenceReason::BudgetExpired => AMBIGUITY_REASON_BUDGET,
-        RuntimeConfigFenceReason::ExecutorLost => AMBIGUITY_REASON_EXECUTOR,
-        RuntimeConfigFenceReason::KnownDivergence => FENCE_REASON_DIVERGENCE,
-        RuntimeConfigFenceReason::PublicationAmbiguous => FENCE_REASON_PUBLICATION,
-        RuntimeConfigFenceReason::AcknowledgementLost => FENCE_REASON_ACKNOWLEDGEMENT,
-    };
-    operation
-        .fence_reason
-        .store(reason_value, Ordering::Release);
+    shorten_fatal_deadline(operation, Instant::now() + operation.registry.grace);
+    operation.registry.wake_threads();
+    true
+}
+
+fn shorten_fatal_deadline(operation: &OperationInner, deadline: Instant) {
+    let candidate = operation.registry.instant_nanos(deadline);
+    let mut observed = operation.fatal_at_nanos.load(Ordering::Acquire);
+    while candidate < observed {
+        match operation.fatal_at_nanos.compare_exchange_weak(
+            observed,
+            candidate,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => return,
+            Err(actual) => observed = actual,
+        }
+    }
+}
+
+fn propagate_fence(operation: &OperationInner) {
+    if operation.propagation_claimed.swap(true, Ordering::AcqRel) {
+        return;
+    }
     operation.daemon_gate.mark_not_ready(RECOVERY_NOT_READY);
     operation.daemon_gate.begin_shutdown();
     operation.coordinator.close();
@@ -602,110 +909,148 @@ fn fence(operation: &OperationInner, reason: RuntimeConfigFenceReason) -> bool {
     {
         admission.close();
     }
+    tracing::error!(
+        operation_id = operation.id,
+        kind = operation.kind.as_str(),
+        phase = operation.phase().as_str(),
+        elapsed_seconds = operation.elapsed().as_secs(),
+        budget_seconds = operation.registry.budget.as_secs(),
+        response_attached = if operation.response_attached.load(Ordering::Acquire) {
+            "attached"
+        } else {
+            "detached"
+        },
+        terminal = "recovery_fenced",
+        fence_reason = operation
+            .fence_reason()
+            .map_or("none", RuntimeConfigFenceReason::as_str),
+        exit_status = AMBIGUOUS_CONFIG_EXIT_STATUS,
+        "runtime config settlement fail-stop armed"
+    );
+    #[cfg(test)]
     operation
-        .registry
-        .advance_terminal(operation.id, Instant::now() + operation.registry.grace);
-    true
+        .propagation_completed
+        .store(true, Ordering::Release);
 }
 
-fn watchdog_loop(registry: &Arc<Registry>) {
-    *registry
-        .thread_id
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(thread::current().id());
-    'watchdog: loop {
-        let mut state = registry.lock();
-        loop {
-            if state.stopping {
-                break 'watchdog;
+fn start_threads(registry: &Arc<Registry>) -> Vec<thread::JoinHandle<()>> {
+    let observer_registry = Arc::clone(registry);
+    let observer = thread::Builder::new()
+        .name("config-settlement-observer".into())
+        .spawn(move || observer_loop(&observer_registry))
+        .expect("config settlement observer OS thread must start");
+    let fatal_registry = Arc::clone(registry);
+    let fatal = thread::Builder::new()
+        .name("config-settlement-fatal-clock".into())
+        .spawn(move || fatal_clock_loop(&fatal_registry))
+        .expect("config settlement fatal-clock OS thread must start");
+    vec![observer, fatal]
+}
+
+fn observer_loop(registry: &Arc<Registry>) {
+    let _ = registry.observer_thread.set(thread::current());
+    while !registry.stopping.load(Ordering::Acquire) {
+        if let Some(operation) = registry.current.load_full() {
+            if operation.terminal() == RuntimeConfigSettlementTerminal::RecoveryFenced {
+                propagate_fence(&operation);
+            } else if operation.terminal() == RuntimeConfigSettlementTerminal::Owned {
+                emit_due_warnings(&operation, Instant::now());
             }
-            let now = Instant::now();
-            let expired = state
-                .registrations
-                .values()
-                .filter(|entry| {
-                    entry.operation.state.load(Ordering::Acquire) & TERMINAL_MASK == TERMINAL_OWNED
-                        && entry.operation.deadline <= now
-                })
-                .map(|entry| Arc::clone(&entry.operation))
-                .collect::<Vec<_>>();
-            let terminal = state
-                .registrations
-                .values()
-                .find(|entry| {
-                    entry.operation.state.load(Ordering::Acquire) & TERMINAL_MASK
-                        == TERMINAL_AMBIGUOUS
-                        && entry.terminal_at <= now
-                })
-                .map(|entry| Arc::clone(&entry.operation));
-            let wait = state
-                .registrations
-                .values()
-                .map(|entry| {
-                    if entry.operation.state.load(Ordering::Acquire) & TERMINAL_MASK
-                        == TERMINAL_OWNED
-                    {
-                        entry.operation.deadline
-                    } else {
-                        entry.terminal_at
-                    }
-                })
-                .min()
-                .map_or(registry.budget, |next| next.saturating_duration_since(now));
-            if !expired.is_empty() || terminal.is_some() {
-                drop(state);
-                for operation in expired {
-                    fence(&operation, RuntimeConfigFenceReason::BudgetExpired);
-                }
-                if let Some(operation) = terminal {
-                    run_terminal_action(registry, &operation);
-                }
-                continue 'watchdog;
-            }
-            #[cfg(test)]
-            if let Some(hook) = registry
-                .pre_wait_hook
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .take()
-            {
-                let _ = hook.reached.send(());
-                let _ = hook.resume.recv();
-            }
-            (state, _) = registry
-                .wake
-                .wait_timeout(state, wait)
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+        thread::park_timeout(Duration::from_secs(1));
+    }
+}
+
+fn emit_due_warnings(operation: &OperationInner, now: Instant) {
+    let elapsed = now.saturating_duration_since(operation.registered_at);
+    for (threshold, bit, remaining) in [
+        (WARNING_HALF_BUDGET, WARNING_HALF_BIT, "15_minutes"),
+        (
+            WARNING_FIVE_MINUTES_REMAINING,
+            WARNING_FIVE_MINUTES_BIT,
+            "5_minutes",
+        ),
+        (
+            WARNING_ONE_MINUTE_REMAINING,
+            WARNING_ONE_MINUTE_BIT,
+            "1_minute",
+        ),
+    ] {
+        if elapsed >= threshold && operation.warning_bits.fetch_or(bit, Ordering::AcqRel) & bit == 0
+        {
+            tracing::warn!(
+                operation_id = operation.id,
+                kind = operation.kind.as_str(),
+                phase = operation.phase().as_str(),
+                elapsed_seconds = elapsed.as_secs(),
+                budget_seconds = operation.registry.budget.as_secs(),
+                response_attached = if operation.response_attached.load(Ordering::Acquire) {
+                    "attached"
+                } else {
+                    "detached"
+                },
+                terminal = "owned",
+                fence_reason = "none",
+                remaining,
+                "runtime config settlement budget warning"
+            );
         }
     }
-    *registry
-        .thread_id
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
-    registry.wake.notify_all();
+}
+
+fn fatal_clock_loop(registry: &Arc<Registry>) {
+    let _ = registry.fatal_thread.set(thread::current());
+    while !registry.stopping.load(Ordering::Acquire) {
+        let Some(operation) = registry.current.load_full() else {
+            thread::park();
+            continue;
+        };
+        let now = Instant::now();
+        match operation.terminal() {
+            RuntimeConfigSettlementTerminal::Owned => {
+                if now >= operation.deadline {
+                    let _ =
+                        transition_to_fenced(&operation, RuntimeConfigFenceReason::BudgetExpired);
+                    continue;
+                }
+                thread::park_timeout(operation.deadline.saturating_duration_since(now));
+            }
+            RuntimeConfigSettlementTerminal::RecoveryFenced => {
+                let fatal_at =
+                    registry.nanos_instant(operation.fatal_at_nanos.load(Ordering::Acquire));
+                if now >= fatal_at {
+                    run_terminal_action(registry);
+                }
+                thread::park_timeout(fatal_at.saturating_duration_since(now));
+            }
+            RuntimeConfigSettlementTerminal::Settled => thread::yield_now(),
+        }
+    }
 }
 
 #[cfg(not(test))]
 #[allow(unsafe_code)]
-fn run_terminal_action(_registry: &Registry, _operation: &OperationInner) -> ! {
-    // SAFETY: `_exit` is the fail-stop contract and must skip cleanup.
+fn terminate_process() -> ! {
     unsafe { libc::_exit(AMBIGUOUS_CONFIG_EXIT_STATUS) }
 }
 
+#[cfg(not(test))]
+fn run_terminal_action(_registry: &Registry) -> ! {
+    terminate_process()
+}
+
 #[cfg(test)]
-fn run_terminal_action(registry: &Registry, operation: &OperationInner) {
-    let _ = registry.terminal.send(AMBIGUOUS_CONFIG_EXIT_STATUS);
-    registry.unregister(operation.id);
-    operation
-        .resources
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .take();
+fn run_terminal_action(registry: &Registry) {
+    if !registry.terminal_fired.swap(true, Ordering::AcqRel) {
+        let _ = registry.terminal.send(AMBIGUOUS_CONFIG_EXIT_STATUS);
+    }
+    thread::park();
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use prometheus::Encoder as _;
 
     struct TestWatchdog(RuntimeConfigSettlementWatchdog);
 
@@ -719,29 +1064,14 @@ mod tests {
 
     impl Drop for TestWatchdog {
         fn drop(&mut self) {
-            let deadline = Instant::now() + Duration::from_secs(5);
-            let mut state = self.registry.lock();
-            while !state.registrations.is_empty() {
-                let remaining = deadline.saturating_duration_since(Instant::now());
-                assert!(
-                    !remaining.is_zero(),
-                    "watchdog cleanup refused owned registrations"
-                );
-                (state, _) = self
-                    .registry
-                    .wake
-                    .wait_timeout(state, remaining)
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-            }
-            state.stopping = true;
-            self.registry.wake.notify_all();
-            drop(state);
-            if let Some(thread) = self.0.thread.lock().unwrap().take() {
+            self.registry.stopping.store(true, Ordering::Release);
+            self.registry.current.store(None);
+            self.registry.wake_threads();
+            for thread in self.0.threads.lock().unwrap().drain(..) {
                 thread
                     .join()
                     .expect("watchdog test thread must stop cleanly");
             }
-            assert!(self.registry.thread_id.lock().unwrap().is_none());
         }
     }
 
@@ -786,6 +1116,35 @@ mod tests {
         (operation, guard, coordinator, admission)
     }
 
+    fn metrics(watchdog: &RuntimeConfigSettlementWatchdog) -> String {
+        let registry = prometheus::Registry::new();
+        watchdog.register_metrics(&registry);
+        encode_metric_families(&registry.gather())
+    }
+
+    fn encode_metric_families(families: &[MetricFamily]) -> String {
+        let mut output = Vec::new();
+        prometheus::TextEncoder::new()
+            .encode(families, &mut output)
+            .unwrap();
+        String::from_utf8(output).unwrap()
+    }
+
+    fn wait_for_propagation(operation: &OwnedRuntimeConfigOperation) {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while !operation
+            .inner
+            .propagation_completed
+            .load(Ordering::Acquire)
+        {
+            assert!(
+                Instant::now() < deadline,
+                "fence propagation did not complete"
+            );
+            thread::yield_now();
+        }
+    }
+
     #[test]
     fn constants_and_closed_states_are_exact() {
         assert_eq!(OWNED_SETTLEMENT_BUDGET, Duration::from_mins(30));
@@ -793,6 +1152,340 @@ mod tests {
         assert_eq!(AMBIGUOUS_CONFIG_EXIT_STATUS, 70);
         assert_eq!(RuntimeConfigSettlementTerminal::Owned as u8, 0);
         assert_eq!(RuntimeConfigFenceReason::BudgetExpired as u8, 0);
+        assert_eq!(WARNING_HALF_BUDGET, Duration::from_mins(15));
+        assert_eq!(WARNING_FIVE_MINUTES_REMAINING, Duration::from_mins(25));
+        assert_eq!(WARNING_ONE_MINUTE_REMAINING, Duration::from_mins(29));
+        assert_eq!(
+            [
+                RuntimeConfigSettlementPhase::OwnedPreflight.as_str(),
+                RuntimeConfigSettlementPhase::Mutating.as_str(),
+                RuntimeConfigSettlementPhase::SettlingRollback.as_str(),
+            ],
+            ["owned_preflight", "mutating", "settling_rollback"]
+        );
+        assert_eq!(
+            [
+                RuntimeConfigFenceReason::BudgetExpired.as_str(),
+                RuntimeConfigFenceReason::ExecutorLost.as_str(),
+                RuntimeConfigFenceReason::KnownDivergence.as_str(),
+                RuntimeConfigFenceReason::PublicationAmbiguous.as_str(),
+                RuntimeConfigFenceReason::AcknowledgementLost.as_str(),
+            ],
+            [
+                "budget_expired",
+                "executor_lost",
+                "known_divergence",
+                "publication_ambiguous",
+                "acknowledgement_lost",
+            ]
+        );
+        assert_eq!(
+            [
+                RuntimeConfigOperationKind::Sighup,
+                RuntimeConfigOperationKind::Apply,
+                RuntimeConfigOperationKind::GnmiSet,
+                RuntimeConfigOperationKind::Confirm,
+                RuntimeConfigOperationKind::Abort,
+                RuntimeConfigOperationKind::Rollback,
+                RuntimeConfigOperationKind::AutoRevert,
+                RuntimeConfigOperationKind::NeighborAdd,
+                RuntimeConfigOperationKind::NeighborDelete,
+                RuntimeConfigOperationKind::DynamicNeighborAdd,
+                RuntimeConfigOperationKind::DynamicNeighborDelete,
+                RuntimeConfigOperationKind::FibSet,
+                RuntimeConfigOperationKind::FibDelete,
+                RuntimeConfigOperationKind::PeerGroupSet,
+                RuntimeConfigOperationKind::PeerGroupDelete,
+                RuntimeConfigOperationKind::NeighborPeerGroupSet,
+                RuntimeConfigOperationKind::NeighborPeerGroupClear,
+                RuntimeConfigOperationKind::PolicySet,
+                RuntimeConfigOperationKind::PolicyDelete,
+                RuntimeConfigOperationKind::NeighborSetSet,
+                RuntimeConfigOperationKind::NeighborSetDelete,
+                RuntimeConfigOperationKind::GlobalImportChainSet,
+                RuntimeConfigOperationKind::GlobalExportChainSet,
+                RuntimeConfigOperationKind::GlobalImportChainClear,
+                RuntimeConfigOperationKind::GlobalExportChainClear,
+                RuntimeConfigOperationKind::NeighborImportChainSet,
+                RuntimeConfigOperationKind::NeighborExportChainSet,
+                RuntimeConfigOperationKind::NeighborImportChainClear,
+                RuntimeConfigOperationKind::NeighborExportChainClear,
+            ]
+            .map(RuntimeConfigOperationKind::as_str),
+            [
+                "sighup",
+                "apply",
+                "gnmi_set",
+                "confirm",
+                "abort",
+                "rollback",
+                "auto_revert",
+                "neighbor_add",
+                "neighbor_delete",
+                "dynamic_neighbor_add",
+                "dynamic_neighbor_delete",
+                "fib_set",
+                "fib_delete",
+                "peer_group_set",
+                "peer_group_delete",
+                "neighbor_peer_group_set",
+                "neighbor_peer_group_clear",
+                "policy_set",
+                "policy_delete",
+                "neighbor_set_set",
+                "neighbor_set_delete",
+                "global_import_chain_set",
+                "global_export_chain_set",
+                "global_import_chain_clear",
+                "global_export_chain_clear",
+                "neighbor_import_chain_set",
+                "neighbor_export_chain_set",
+                "neighbor_import_chain_clear",
+                "neighbor_export_chain_clear",
+            ]
+        );
+    }
+
+    #[test]
+    fn metric_snapshot_decodes_one_packed_state_coherently() {
+        for (phase_bits, expected_phase) in [
+            (
+                PHASE_PREFLIGHT,
+                RuntimeConfigSettlementPhase::OwnedPreflight,
+            ),
+            (PHASE_MUTATING, RuntimeConfigSettlementPhase::Mutating),
+            (
+                PHASE_SETTLING,
+                RuntimeConfigSettlementPhase::SettlingRollback,
+            ),
+        ] {
+            let owned = SettlementMetricSnapshot::decode(TERMINAL_OWNED | phase_bits, true);
+            assert_eq!(owned.phase, expected_phase);
+            assert_eq!(owned.terminal, RuntimeConfigSettlementTerminal::Owned);
+            assert_eq!(owned.fence_reason, None);
+            assert!(owned.response_attached);
+
+            let settled = SettlementMetricSnapshot::decode(TERMINAL_SETTLED | phase_bits, false);
+            assert_eq!(settled.phase, expected_phase);
+            assert_eq!(settled.terminal, RuntimeConfigSettlementTerminal::Settled);
+            assert_eq!(settled.fence_reason, None);
+            assert!(!settled.response_attached);
+
+            for (reason_bits, expected_reason) in [
+                (
+                    AMBIGUITY_REASON_BUDGET,
+                    RuntimeConfigFenceReason::BudgetExpired,
+                ),
+                (
+                    AMBIGUITY_REASON_EXECUTOR,
+                    RuntimeConfigFenceReason::ExecutorLost,
+                ),
+                (
+                    FENCE_REASON_DIVERGENCE,
+                    RuntimeConfigFenceReason::KnownDivergence,
+                ),
+                (
+                    FENCE_REASON_PUBLICATION,
+                    RuntimeConfigFenceReason::PublicationAmbiguous,
+                ),
+                (
+                    FENCE_REASON_ACKNOWLEDGEMENT,
+                    RuntimeConfigFenceReason::AcknowledgementLost,
+                ),
+            ] {
+                let fenced = SettlementMetricSnapshot::decode(
+                    TERMINAL_AMBIGUOUS | phase_bits | (reason_bits << REASON_SHIFT),
+                    false,
+                );
+                assert_eq!(fenced.phase, expected_phase);
+                assert_eq!(
+                    fenced.terminal,
+                    RuntimeConfigSettlementTerminal::RecoveryFenced
+                );
+                assert_eq!(fenced.fence_reason, Some(expected_reason));
+                assert!(!fenced.response_attached);
+            }
+        }
+    }
+
+    #[test]
+    fn collector_source_captures_state_and_attachment_exactly_once() {
+        let source = include_str!("runtime_config_settlement.rs");
+        let capture = source
+            .split_once("fn capture(operation: &OperationInner) -> Self {")
+            .unwrap()
+            .1
+            .split_once("fn decode(state: u8, response_attached: bool) -> Self {")
+            .unwrap()
+            .0;
+        assert_eq!(capture.matches("operation.state.load(").count(), 1);
+        assert_eq!(
+            capture.matches("operation.response_attached.load(").count(),
+            1
+        );
+
+        let collect = source
+            .split_once("impl Collector for RuntimeConfigSettlementCollector {")
+            .unwrap()
+            .1
+            .split_once("#[derive(Clone)]\npub struct RuntimeConfigSettlementWatchdog")
+            .unwrap()
+            .0;
+        assert_eq!(
+            collect
+                .matches("SettlementMetricSnapshot::capture(&operation)")
+                .count(),
+            1
+        );
+        for forbidden in [
+            "operation.state.load(",
+            "operation.response_attached.load(",
+            "operation.phase()",
+            "operation.terminal()",
+            "operation.fence_reason()",
+            "GaugeVec::new(",
+            "CounterVec::new(",
+        ] {
+            assert!(!collect.contains(forbidden), "collector used {forbidden}");
+        }
+    }
+
+    #[tokio::test]
+    async fn metrics_are_dynamic_single_tuple_and_idle_is_empty() {
+        let (watchdog, receiver) = test_watchdog(Duration::from_secs(5), Duration::from_millis(20));
+        let registry = prometheus::Registry::new();
+        watchdog.register_metrics(&registry);
+        assert!(encode_metric_families(&registry.gather()).is_empty());
+        let (first_operation, guard, _, _) = operation(&watchdog, false).await;
+        let attached = encode_metric_families(&registry.gather());
+        assert!(attached.contains("kind=\"apply\""));
+        assert!(attached.contains("phase=\"owned_preflight\""));
+        assert!(attached.contains("response_attached=\"attached\""));
+        assert!(attached.contains("fence_reason=\"none\""));
+        first_operation
+            .inner
+            .response_attached
+            .store(false, Ordering::Release);
+        first_operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
+        let detached = encode_metric_families(&registry.gather());
+        assert!(detached.contains("phase=\"mutating\""));
+        assert!(detached.contains("response_attached=\"detached\""));
+        assert!(!detached.contains("phase=\"owned_preflight\""));
+        assert!(!detached.contains("response_attached=\"attached\""));
+        assert!(first_operation.try_settle());
+        assert!(encode_metric_families(&registry.gather()).is_empty());
+        drop(guard);
+
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        assert!(operation.fence_recovery(RuntimeConfigFenceReason::KnownDivergence));
+        wait_for_propagation(&operation);
+        let fenced = metrics(&watchdog);
+        assert!(fenced.contains("fence_reason=\"known_divergence\""));
+        assert!(fenced.contains("bgp_runtime_config_settlement_fail_stops_total"));
+        assert_eq!(
+            fenced
+                .lines()
+                .filter(|line| line.starts_with("bgp_runtime_config_settlement_active{"))
+                .count(),
+            1
+        );
+        assert_eq!(receiver.recv_timeout(Duration::from_secs(1)).unwrap(), 70);
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn concurrent_scrapes_each_return_one_coherent_tuple() {
+        let (watchdog, _receiver) = test_watchdog(Duration::from_secs(5), Duration::from_secs(1));
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
+        operation
+            .inner
+            .response_attached
+            .store(false, Ordering::Release);
+        let collector = Arc::new(RuntimeConfigSettlementCollector::new(Arc::clone(
+            &watchdog.registry,
+        )));
+        let barrier = Arc::new(std::sync::Barrier::new(9));
+        let scrapes = (0..8)
+            .map(|_| {
+                let collector = Arc::clone(&collector);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    encode_metric_families(&collector.collect())
+                })
+            })
+            .collect::<Vec<_>>();
+        barrier.wait();
+        for scrape in scrapes {
+            let text = scrape.join().unwrap();
+            for name in [
+                "bgp_runtime_config_settlement_active{",
+                "bgp_runtime_config_settlement_elapsed_seconds{",
+                "bgp_runtime_config_settlement_budget_seconds{",
+                "bgp_runtime_config_settlement_fail_stops_total{",
+            ] {
+                assert_eq!(
+                    text.lines().filter(|line| line.starts_with(name)).count(),
+                    1
+                );
+            }
+            assert_eq!(text.matches("kind=\"apply\"").count(), 4);
+            assert_eq!(text.matches("phase=\"mutating\"").count(), 4);
+            assert_eq!(text.matches("response_attached=\"detached\"").count(), 4);
+            assert_eq!(text.matches("fence_reason=\"none\"").count(), 4);
+        }
+        assert!(operation.try_settle());
+        drop(guard);
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "permits only one current operation")]
+    async fn second_current_registration_is_an_invariant_failure() {
+        let (watchdog, _receiver) = test_watchdog(Duration::from_secs(5), Duration::from_secs(1));
+        let (_operation, _guard, _, _) = operation(&watchdog, false).await;
+        let coordinator = RuntimeConfigCoordinator::new();
+        let permit = coordinator.acquire().await.unwrap();
+        let _ = watchdog.register_owned(
+            RuntimeConfigOperationKind::Confirm,
+            coordinator.clone(),
+            permit,
+            DaemonGate::new(),
+            None,
+            None,
+            Arc::new(AtomicBool::new(false)),
+        );
+    }
+
+    #[tokio::test]
+    async fn warning_boundaries_fire_once_without_changing_deadline() {
+        let (watchdog, _receiver) = test_watchdog(Duration::from_mins(30), Duration::from_secs(5));
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        let deadline = operation.deadline();
+        let start = operation.inner.registered_at;
+        emit_due_warnings(
+            &operation.inner,
+            (start + WARNING_HALF_BUDGET)
+                .checked_sub(Duration::from_nanos(1))
+                .unwrap(),
+        );
+        assert_eq!(operation.inner.warning_bits.load(Ordering::Acquire), 0);
+        emit_due_warnings(&operation.inner, start + WARNING_HALF_BUDGET);
+        emit_due_warnings(
+            &operation.inner,
+            start + WARNING_HALF_BUDGET + Duration::from_nanos(1),
+        );
+        assert_eq!(
+            operation.inner.warning_bits.load(Ordering::Acquire),
+            WARNING_HALF_BIT
+        );
+        emit_due_warnings(&operation.inner, start + WARNING_FIVE_MINUTES_REMAINING);
+        emit_due_warnings(&operation.inner, start + WARNING_ONE_MINUTE_REMAINING);
+        emit_due_warnings(&operation.inner, start + WARNING_ONE_MINUTE_REMAINING);
+        assert_eq!(operation.inner.warning_bits.load(Ordering::Acquire), 0b111);
+        assert_eq!(operation.deadline(), deadline);
+        assert!(operation.try_settle());
+        drop(guard);
     }
 
     #[tokio::test]
@@ -891,6 +1584,7 @@ mod tests {
         let (watchdog, receiver) = test_watchdog(Duration::from_secs(5), Duration::from_millis(20));
         let (operation, guard, coordinator, admission) = operation(&watchdog, true).await;
         drop(guard);
+        wait_for_propagation(&operation);
         assert_eq!(
             operation.terminal(),
             RuntimeConfigSettlementTerminal::RecoveryFenced
@@ -910,6 +1604,7 @@ mod tests {
         let (watchdog, receiver) = test_watchdog(Duration::from_secs(5), Duration::from_millis(20));
         let (operation, guard, coordinator, admission) = operation(&watchdog, true).await;
         assert!(operation.fence_recovery(RuntimeConfigFenceReason::PublicationAmbiguous));
+        wait_for_propagation(&operation);
         assert_eq!(
             operation.fence_reason(),
             Some(RuntimeConfigFenceReason::PublicationAmbiguous)
@@ -917,8 +1612,83 @@ mod tests {
         assert!(coordinator.is_closed());
         assert!(admission.unwrap().is_closed());
         assert!(!operation.try_settle());
+        let fatal_at = operation.inner.fatal_at_nanos.load(Ordering::Acquire);
+        assert!(!operation.fence_recovery(RuntimeConfigFenceReason::ExecutorLost));
+        assert_eq!(
+            operation.inner.fatal_at_nanos.load(Ordering::Acquire),
+            fatal_at,
+            "a repeated fence must neither reset nor extend grace"
+        );
+        assert!(metrics(&watchdog).contains(
+            "bgp_runtime_config_settlement_fail_stops_total{fence_reason=\"publication_ambiguous\",kind=\"apply\",phase=\"owned_preflight\",response_attached=\"attached\"} 1"
+        ));
         assert_eq!(receiver.recv_timeout(Duration::from_secs(5)).unwrap(), 70);
         drop(guard);
+    }
+
+    #[tokio::test]
+    async fn blocked_propagation_and_locks_cannot_delay_fatal_clock() {
+        let (watchdog, receiver) = test_watchdog(Duration::from_secs(5), Duration::from_millis(20));
+        let (operation, guard, _, _) = operation(&watchdog, true).await;
+        let idle_lock = watchdog.registry.idle_lock.lock().unwrap();
+        let resource_lock = operation.inner.resources.lock().unwrap();
+        assert!(operation.fence_recovery(RuntimeConfigFenceReason::KnownDivergence));
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while !operation.inner.propagation_claimed.load(Ordering::Acquire) {
+            assert!(
+                Instant::now() < deadline,
+                "observer did not claim propagation"
+            );
+            thread::yield_now();
+        }
+        assert!(metrics(&watchdog).contains(
+            "bgp_runtime_config_settlement_fail_stops_total{fence_reason=\"known_divergence\",kind=\"apply\",phase=\"owned_preflight\",response_attached=\"attached\"} 1"
+        ));
+        assert!(
+            !operation
+                .inner
+                .propagation_completed
+                .load(Ordering::Acquire)
+        );
+        assert_eq!(receiver.recv_timeout(Duration::from_secs(1)).unwrap(), 70);
+        drop(resource_lock);
+        drop(idle_lock);
+        wait_for_propagation(&operation);
+        drop(guard);
+    }
+
+    #[test]
+    fn production_terminal_wrapper_is_an_exact_exit_only_boundary() {
+        let source = include_str!("runtime_config_settlement.rs");
+        let body = source
+            .split_once("fn terminate_process() -> ! {")
+            .unwrap()
+            .1
+            .split_once("\n}")
+            .unwrap()
+            .0;
+        assert_eq!(
+            body.trim(),
+            "unsafe { libc::_exit(AMBIGUOUS_CONFIG_EXIT_STATUS) }"
+        );
+        for forbidden in [
+            "lock", "alloc", "clone", "drop", "tracing", "metric", "write", "wait", "park",
+            "sleep", "spawn", "dispatch", "panic", "unwrap",
+        ] {
+            assert!(
+                !body.contains(forbidden),
+                "terminal wrapper contains {forbidden}"
+            );
+        }
+        assert!(source.contains("current: ArcSwapOption<OperationInner>"));
+        let final_decision = source
+            .split_once("if now >= fatal_at {")
+            .unwrap()
+            .1
+            .split_once("\n                }")
+            .unwrap()
+            .0;
+        assert_eq!(final_decision.trim(), "run_terminal_action(registry);");
     }
 
     #[tokio::test]
@@ -1040,6 +1810,7 @@ mod tests {
             operation.fence_reason(),
             Some(RuntimeConfigFenceReason::PublicationAmbiguous)
         );
+        wait_for_propagation(&operation);
         assert!(gate.is_shutting_down());
         assert!(queued.await.unwrap().is_err());
         assert!(coordinator.acquire().await.is_err());
@@ -1082,8 +1853,8 @@ mod tests {
         let (watchdog, _receiver) = test_watchdog(Duration::from_secs(5), Duration::from_secs(1));
         let start_deadline = Instant::now() + Duration::from_secs(5);
         let thread_id = loop {
-            if let Some(thread_id) = *watchdog.registry.thread_id.lock().unwrap() {
-                break thread_id;
+            if let Some(thread) = watchdog.registry.fatal_thread.get() {
+                break thread.id();
             }
             assert!(
                 Instant::now() < start_deadline,
@@ -1096,10 +1867,10 @@ mod tests {
             assert!(operation.try_settle());
             drop(guard);
         }
-        assert!(watchdog.registry.lock().registrations.is_empty());
+        assert!(watchdog.registry.current.load().is_none());
         assert_eq!(
-            *watchdog.registry.thread_id.lock().unwrap(),
-            Some(thread_id)
+            watchdog.registry.fatal_thread.get().map(thread::Thread::id),
+            Some(thread_id),
         );
     }
 
@@ -1161,34 +1932,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn executor_loss_at_pre_wait_boundary_terminates_by_grace() {
+    async fn executor_loss_shortens_prearmed_fatal_deadline() {
         let old_deadline = Duration::from_secs(4);
         let grace = Duration::from_millis(20);
         let (watchdog, receiver) = test_watchdog(old_deadline, grace);
         let (operation, guard, _, _) = operation(&watchdog, false).await;
-        let (reached_sender, reached_receiver) = std::sync::mpsc::channel();
-        let (resume_sender, resume_receiver) = std::sync::mpsc::channel();
-        *watchdog.registry.pre_wait_hook.lock().unwrap() = Some(PreWaitHook {
-            reached: reached_sender,
-            resume: resume_receiver,
-        });
-        watchdog.registry.wake.notify_one();
-        reached_receiver
-            .recv_timeout(Duration::from_secs(5))
-            .unwrap();
-        let (dropping_sender, dropping_receiver) = std::sync::mpsc::channel();
-        let losing_executor = thread::spawn(move || {
-            dropping_sender.send(()).unwrap();
-            drop(guard);
-        });
-        dropping_receiver
-            .recv_timeout(Duration::from_secs(1))
-            .unwrap();
+        let prearmed = operation.inner.fatal_at_nanos.load(Ordering::Acquire);
         let started = Instant::now();
-        resume_sender.send(()).unwrap();
+        drop(guard);
+        let shortened = operation.inner.fatal_at_nanos.load(Ordering::Acquire);
+        assert!(shortened < prearmed);
         assert_eq!(receiver.recv_timeout(Duration::from_secs(1)).unwrap(), 70);
         assert!(started.elapsed() < old_deadline);
-        losing_executor.join().unwrap();
         assert_eq!(
             operation.fence_reason(),
             Some(RuntimeConfigFenceReason::ExecutorLost)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -62,9 +62,31 @@ A recovery-fenced owner immediately makes `/readyz` fail, closes admission for
 new persisted mutations, and retains ownership until process death. Detected
 divergence, publication ambiguity, acknowledgement loss, or executor loss exits
 with status 70 after a five-second fencing grace. A silent owner is fenced after
-the fixed 30-minute owned-settlement budget and exits five seconds later. Do not
+the fixed 30-minute owned-settlement budget and exits five seconds later. The
+fatal clock is a prestarted OS thread independent of the mutation executor,
+readiness propagation, metric collection, logging, and retained-resource locks;
+none of those paths can postpone the 30-minute-plus-five-second deadline. Do not
 classify 70 as success or suppress its restart: the new process re-establishes
 authority from durable state.
+
+While one owner exists, `/metrics` exposes exactly one series for each of
+`bgp_runtime_config_settlement_active`, `_elapsed_seconds`, and
+`_budget_seconds`. `bgp_runtime_config_settlement_fail_stops_total` becomes 1
+when recovery fencing wins. All four use the bounded labels `kind`, `phase`
+(`owned_preflight`, `mutating`, or `settling_rollback`), `response_attached`
+(`attached` or `detached`), and `fence_reason` (`none`, `budget_expired`,
+`executor_lost`, `known_divergence`, `publication_ambiguous`, or
+`acknowledgement_lost`). They emit no idle tuple. Detached means the daemon owns
+the work without a live RPC response; it does not weaken the deadline.
+
+The daemon warns once at 15, 25, and 29 minutes without extending or resetting
+the deadline. `BgpRuntimeConfigSettlementHalfBudget` fires at 50%; at that point
+identify the labeled owner and inspect the owning actor rather than retrying the
+mutation. Fencing produces one redacted diagnostic containing only operation
+identity/classification, phase, elapsed/budget seconds, attachment, terminal,
+optional fence reason, and exit status. It never includes config contents,
+tokens, confirm IDs, comments, credentials, paths, digests, candidates, or raw
+error text.
 
 The shipped systemd unit uses `Restart=on-failure`, but caps recovery at five
 starts per ten minutes so a deterministic persistence fault cannot flap every

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -36,6 +36,28 @@ groups:
             {{ $labels.instance }} for 2 minutes. The daemon is down,
             unreachable, or `prometheus_addr` is no longer configured.
 
+      - alert: BgpRuntimeConfigSettlementHalfBudget
+        # The owner has consumed half of the fixed 30-minute settlement
+        # budget. Recovery-fenced owners are already committed to exit 70 and
+        # are deliberately excluded from this early operator warning.
+        expr: >-
+          bgp_runtime_config_settlement_active{fence_reason="none"} == 1
+          and
+          (bgp_runtime_config_settlement_elapsed_seconds{fence_reason="none"}
+          / bgp_runtime_config_settlement_budget_seconds{fence_reason="none"}) >= 0.5
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Runtime-config settlement consumed half its budget"
+          description: >-
+            The {{ $labels.kind }} runtime-config operation on
+            {{ $labels.instance }} remains in {{ $labels.phase }} with its
+            response {{ $labels.response_attached }} after consuming at least
+            half of the fail-stop budget. Inspect the owning actor now; the
+            daemon exits independently when the 30-minute budget plus
+            five-second grace expires.
+
       - alert: BgpSessionNotEstablished
         # Exact configured identity join: catches enabled peers that have never
         # Established as well as peers that established previously and went

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -41,6 +41,57 @@ tests:
                 edge1:9179 for 2 minutes. The daemon is down,
                 unreachable, or `prometheus_addr` is no longer configured.
 
+  # ── BgpRuntimeConfigSettlementHalfBudget ──────────────────────
+  - interval: 1s
+    input_series:
+      - series: 'bgp_runtime_config_settlement_active{instance="edge1:9179",kind="apply",phase="mutating",response_attached="attached",fence_reason="none"}'
+        values: "1x902"
+      - series: 'bgp_runtime_config_settlement_elapsed_seconds{instance="edge1:9179",kind="apply",phase="mutating",response_attached="attached",fence_reason="none"}'
+        values: "0+1x902"
+      - series: 'bgp_runtime_config_settlement_budget_seconds{instance="edge1:9179",kind="apply",phase="mutating",response_attached="attached",fence_reason="none"}'
+        values: "1800x902"
+      # Inactive, fenced, and still-under-half owners must not fire.
+      - series: 'bgp_runtime_config_settlement_active{instance="edge2:9179",kind="confirm",phase="owned_preflight",response_attached="detached",fence_reason="none"}'
+        values: "0x902"
+      - series: 'bgp_runtime_config_settlement_elapsed_seconds{instance="edge2:9179",kind="confirm",phase="owned_preflight",response_attached="detached",fence_reason="none"}'
+        values: "900x902"
+      - series: 'bgp_runtime_config_settlement_budget_seconds{instance="edge2:9179",kind="confirm",phase="owned_preflight",response_attached="detached",fence_reason="none"}'
+        values: "1800x902"
+      - series: 'bgp_runtime_config_settlement_active{instance="edge3:9179",kind="sighup",phase="settling_rollback",response_attached="detached",fence_reason="acknowledgement_lost"}'
+        values: "1x902"
+      - series: 'bgp_runtime_config_settlement_elapsed_seconds{instance="edge3:9179",kind="sighup",phase="settling_rollback",response_attached="detached",fence_reason="acknowledgement_lost"}'
+        values: "901x902"
+      - series: 'bgp_runtime_config_settlement_budget_seconds{instance="edge3:9179",kind="sighup",phase="settling_rollback",response_attached="detached",fence_reason="acknowledgement_lost"}'
+        values: "1800x902"
+      - series: 'bgp_runtime_config_settlement_active{instance="edge4:9179",kind="rollback",phase="settling_rollback",response_attached="attached",fence_reason="none"}'
+        values: "1x902"
+      - series: 'bgp_runtime_config_settlement_elapsed_seconds{instance="edge4:9179",kind="rollback",phase="settling_rollback",response_attached="attached",fence_reason="none"}'
+        values: "899x902"
+      - series: 'bgp_runtime_config_settlement_budget_seconds{instance="edge4:9179",kind="rollback",phase="settling_rollback",response_attached="attached",fence_reason="none"}'
+        values: "1800x902"
+    alert_rule_test:
+      - eval_time: 14m59s
+        alertname: BgpRuntimeConfigSettlementHalfBudget
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: BgpRuntimeConfigSettlementHalfBudget
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: edge1:9179
+              kind: apply
+              phase: mutating
+              response_attached: attached
+              fence_reason: none
+            exp_annotations:
+              summary: "Runtime-config settlement consumed half its budget"
+              description: >-
+                The apply runtime-config operation on edge1:9179 remains in
+                mutating with its response attached after consuming at least
+                half of the fail-stop budget. Inspect the owning actor now;
+                the daemon exits independently when the 30-minute budget plus
+                five-second grace expires.
+
   # ── Session rules ─────────────────────────────────────────────
   # Every series carries the bare neighbor address in `peer`, matching
   # the daemon's real export, so the session/RIB join needs no rewrite.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4477,6 +4477,7 @@ async fn run<T>(
     // runtime-config owner and the readiness/admission surfaces.
     let daemon_gate = DaemonGate::new();
     let runtime_config_settlement = RuntimeConfigSettlementWatchdog::new();
+    runtime_config_settlement.register_metrics(metrics.registry());
     let config_transaction_controller =
         config_transaction_control::ConfigTransactionController::new_accepted(
             fib_table_control::FibTableControlDeps {

--- a/tests/runtime_config_persistence_failstop.rs
+++ b/tests/runtime_config_persistence_failstop.rs
@@ -124,23 +124,84 @@ fn unused_loopback_addr() -> SocketAddr {
         .expect("read loopback port")
 }
 
-fn ready_status(addr: SocketAddr) -> Option<u16> {
+fn http_get(addr: SocketAddr, path: &str) -> Option<String> {
     let mut stream = TcpStream::connect_timeout(&addr, Duration::from_millis(100)).ok()?;
     stream
         .set_read_timeout(Some(Duration::from_millis(200)))
         .ok()?;
     stream
-        .write_all(b"GET /readyz HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .write_all(
+            format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+                .as_bytes(),
+        )
         .ok()?;
     let mut response = String::new();
     stream.read_to_string(&mut response).ok()?;
-    response
+    Some(response)
+}
+
+fn ready_status(addr: SocketAddr) -> Option<u16> {
+    http_get(addr, "/readyz")?
         .lines()
         .next()?
         .split_whitespace()
         .nth(1)?
         .parse()
         .ok()
+}
+
+fn settlement_metrics(addr: SocketAddr) -> String {
+    http_get(addr, "/metrics")
+        .and_then(|response| {
+            response
+                .split_once("\r\n\r\n")
+                .map(|(_, body)| body.to_string())
+        })
+        .expect("scrape settlement metrics")
+}
+
+fn assert_settlement_metrics(text: &str, kind: &str, phase: &str, attachment: &str, reason: &str) {
+    for (name, value) in [
+        ("bgp_runtime_config_settlement_active", "1"),
+        ("bgp_runtime_config_settlement_elapsed_seconds", ""),
+        ("bgp_runtime_config_settlement_budget_seconds", "1800"),
+        ("bgp_runtime_config_settlement_fail_stops_total", "1"),
+    ] {
+        let lines = text
+            .lines()
+            .filter(|line| line.starts_with(&format!("{name}{{")))
+            .collect::<Vec<_>>();
+        assert_eq!(lines.len(), 1, "expected one {name} tuple:\n{text}");
+        let line = lines[0];
+        for label in [
+            format!("kind=\"{kind}\""),
+            format!("phase=\"{phase}\""),
+            format!("response_attached=\"{attachment}\""),
+            format!("fence_reason=\"{reason}\""),
+        ] {
+            assert!(line.contains(&label), "missing {label} in {line}");
+        }
+        assert!(
+            value.is_empty() || line.ends_with(value),
+            "unexpected value in {line}"
+        );
+    }
+}
+
+fn assert_one_redacted_diagnostic(daemon: &Daemon) {
+    let matching = daemon
+        .log()
+        .lines()
+        .filter(|line| line.contains("runtime config settlement fail-stop armed"))
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    assert_eq!(matching.len(), 1, "log:\n{}", daemon.log());
+    for forbidden in ["injected", "rustbgpd.toml", "grpc.sock", FIRST_NEIGHBOR] {
+        assert!(
+            !matching[0].contains(forbidden),
+            "diagnostic leaked {forbidden}"
+        );
+    }
 }
 
 fn wait_until_ready(addr: SocketAddr, daemon: &mut Daemon, expected: u16) {
@@ -227,6 +288,17 @@ fn exercise(fault: &str, published: bool) {
     .expect("start first mutation");
     wait_until_ready(metrics, &mut daemon, 503);
     let recovery_fenced_at = Instant::now();
+    assert_settlement_metrics(
+        &settlement_metrics(metrics),
+        "neighbor_add",
+        "settling_rollback",
+        "attached",
+        if fault == "not_published" {
+            "known_divergence"
+        } else {
+            "publication_ambiguous"
+        },
+    );
 
     let second = rbgp_command(
         &grpc_addr,
@@ -249,6 +321,7 @@ fn exercise(fault: &str, published: bool) {
     let status = daemon
         .wait_for_exit(FAILSTOP_GRACE_WITH_JITTER.saturating_sub(recovery_fenced_at.elapsed()));
     assert_eq!(status.code(), Some(70), "log:\n{}", daemon.log());
+    assert_one_redacted_diagnostic(&daemon);
     assert!(
         recovery_fenced_at.elapsed() <= FAILSTOP_GRACE_WITH_JITTER,
         "exit 70 exceeded the five-second grace plus test jitter"
@@ -311,6 +384,17 @@ fn exercise_sighup_ack_loss(fault: &str) {
     daemon.sighup();
     wait_until_ready(metrics, &mut daemon, 503);
     let fenced_at = Instant::now();
+    assert_settlement_metrics(
+        &settlement_metrics(metrics),
+        "sighup",
+        if fault == "reconcile" {
+            "mutating"
+        } else {
+            "settling_rollback"
+        },
+        "detached",
+        "acknowledgement_lost",
+    );
     let rejected = rbgp(
         &grpc_addr,
         &["neighbor", SECOND_NEIGHBOR, "add", "--remote-asn", "65003"],
@@ -320,6 +404,7 @@ fn exercise_sighup_ack_loss(fault: &str) {
     let status =
         daemon.wait_for_exit(FAILSTOP_GRACE_WITH_JITTER.saturating_sub(fenced_at.elapsed()));
     assert_eq!(status.code(), Some(70), "log:\n{}", daemon.log());
+    assert_one_redacted_diagnostic(&daemon);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- pre-arm a process-wide fatal clock that reaches exit 70 independently of tracing, metrics, readiness propagation, and retained-resource locks
- expose one coherent, closed-label settlement metric snapshot plus fixed 15/25/29-minute warnings
- ship a half-budget Prometheus alert, redacted operator diagnostics, and real-daemon grace-window proofs

## Why

Settlement ownership is now truthful, but the old watchdog clock still shared potentially blocking propagation work. A stalled diagnostic or resource lock could delay the terminal edge. This isolates the hard deadline while making long-running and fenced owners observable without unbounded labels or sensitive payloads.

## Validation

- focused settlement module: 23 tests
- production settlement-exit subprocess
- real-daemon persistence/SIGHUP fail-stop suite: 4 tests
- promtool check rules and test rules
- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
- cargo test --locked --workspace --all-features
- release API check and source inventory for the exact `_exit(70)` boundary
- independent exact-head terminal-clock and metric-atomicity audit
