### PR TITLE
Reduce live event stream memory overhead

### DIFF
--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -242,7 +242,7 @@ impl proto::event_service_server::EventService for EventService {
                         Ok(event) => {
                             let _subscriber_guard = &route_subscriber_guard;
                             if route_filter.matches_route_event(&event) {
-                                Some(Ok(route_event_to_bgp_event(event)))
+                                Some(Ok(route_event_to_bgp_event(event.as_ref().clone())))
                             } else {
                                 None
                             }
@@ -284,7 +284,7 @@ impl proto::event_service_server::EventService for EventService {
                         Ok(event) => {
                             let _subscriber_guard = &session_subscriber_guard;
                             if session_filter.matches_session_event(&event) {
-                                Some(Ok(session_event_to_bgp_event(event)))
+                                Some(Ok(session_event_to_bgp_event(event.as_ref().clone())))
                             } else {
                                 None
                             }
@@ -326,7 +326,7 @@ impl proto::event_service_server::EventService for EventService {
                         Ok(event) => {
                             let _subscriber_guard = &policy_subscriber_guard;
                             if policy_filter.matches_policy_event(&event) {
-                                Some(Ok(policy_event_to_bgp_event(event)))
+                                Some(Ok(policy_event_to_bgp_event(event.as_ref().clone())))
                             } else {
                                 None
                             }
@@ -442,7 +442,7 @@ impl proto::event_service_server::EventService for EventService {
                         Ok(event) => {
                             let _subscriber_guard = &evpn_subscriber_guard;
                             if evpn_filter.matches_evpn_event(&event) {
-                                Some(Ok(evpn_event_to_bgp_event(event)))
+                                Some(Ok(evpn_event_to_bgp_event(event.as_ref().clone())))
                             } else {
                                 None
                             }
@@ -1015,10 +1015,10 @@ mod tests {
         let mut stream = response.into_inner();
 
         events_tx
-            .send(route_event(
+            .send(Arc::new(route_event(
                 Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24)),
                 IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            ))
+            )))
             .unwrap();
 
         let event = stream.next().await.unwrap().unwrap();
@@ -1204,11 +1204,11 @@ mod tests {
         let mut stream = response.into_inner();
 
         evpn_events_tx
-            .send(evpn_event(
+            .send(Arc::new(evpn_event(
                 RouteEventType::Added,
                 Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
                 None,
-            ))
+            )))
             .unwrap();
 
         let event = stream.next().await.unwrap().unwrap();
@@ -1825,22 +1825,22 @@ mod tests {
         let mut stream = response.into_inner();
 
         events_tx
-            .send(route_event(
+            .send(Arc::new(route_event(
                 Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24)),
                 IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            ))
+            )))
             .unwrap();
         events_tx
-            .send(route_event(
+            .send(Arc::new(route_event(
                 Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24)),
                 IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
-            ))
+            )))
             .unwrap();
         events_tx
-            .send(route_event(
+            .send(Arc::new(route_event(
                 Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24)),
                 IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            ))
+            )))
             .unwrap();
 
         let event = stream.next().await.unwrap().unwrap();
@@ -1865,16 +1865,16 @@ mod tests {
         let mut stream = response.into_inner();
 
         session_events_tx
-            .send(session_event(
+            .send(Arc::new(session_event(
                 IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
                 SessionLifecycleEventType::Established,
-            ))
+            )))
             .unwrap();
         session_events_tx
-            .send(session_event(
+            .send(Arc::new(session_event(
                 IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
                 SessionLifecycleEventType::Established,
-            ))
+            )))
             .unwrap();
 
         let event = stream.next().await.unwrap().unwrap();
@@ -1907,16 +1907,16 @@ mod tests {
         let mut stream = response.into_inner();
 
         session_events_tx
-            .send(notification_event(
+            .send(Arc::new(notification_event(
                 IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
                 SessionNotificationEventType::Sent,
-            ))
+            )))
             .unwrap();
         session_events_tx
-            .send(notification_event(
+            .send(Arc::new(notification_event(
                 IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
                 SessionNotificationEventType::Sent,
-            ))
+            )))
             .unwrap();
 
         let event = stream.next().await.unwrap().unwrap();
@@ -2118,10 +2118,10 @@ mod tests {
         assert_eq!(session_events_tx.receiver_count(), 0);
         assert!(
             session_events_tx
-                .send(session_event(
+                .send(Arc::new(session_event(
                     IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
                     SessionLifecycleEventType::Established,
-                ))
+                )))
                 .is_err()
         );
         assert!(stream.next().await.is_none());
@@ -2178,7 +2178,7 @@ mod tests {
             .unwrap();
         let mut stream = response.into_inner();
 
-        policy_events_tx.send(policy_event(None)).unwrap();
+        policy_events_tx.send(Arc::new(policy_event(None))).unwrap();
         let event = stream.next().await.unwrap().unwrap();
         assert_eq!(event.category, proto::EventCategory::Policy as i32);
         assert_eq!(event.event_type, proto::BgpEventType::PolicyChanged as i32);
@@ -2204,7 +2204,7 @@ mod tests {
             .unwrap();
         let mut stream = response.into_inner();
 
-        policy_events_tx.send(policy_event(None)).unwrap();
+        policy_events_tx.send(Arc::new(policy_event(None))).unwrap();
         let event = stream.next().await.unwrap().unwrap();
         assert_eq!(event.category, proto::EventCategory::Policy as i32);
         assert_eq!(event.event_type, proto::BgpEventType::PolicyChanged as i32);
@@ -2225,12 +2225,16 @@ mod tests {
             .unwrap();
         let mut stream = response.into_inner();
 
-        policy_events_tx.send(policy_event(None)).unwrap();
+        policy_events_tx.send(Arc::new(policy_event(None))).unwrap();
         policy_events_tx
-            .send(policy_event(Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)))))
+            .send(Arc::new(policy_event(Some(IpAddr::V4(Ipv4Addr::new(
+                10, 0, 0, 2,
+            ))))))
             .unwrap();
         policy_events_tx
-            .send(policy_event(Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))))
+            .send(Arc::new(policy_event(Some(IpAddr::V4(Ipv4Addr::new(
+                10, 0, 0, 1,
+            ))))))
             .unwrap();
 
         let event = stream.next().await.unwrap().unwrap();
@@ -2374,10 +2378,10 @@ mod tests {
 
         for i in 0..32 {
             events_tx
-                .send(route_event(
+                .send(Arc::new(route_event(
                     Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, i), 32)),
                     IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-                ))
+                )))
                 .unwrap();
         }
 
@@ -2409,10 +2413,10 @@ mod tests {
 
         for _ in 0..32 {
             session_events_tx
-                .send(session_event(
+                .send(Arc::new(session_event(
                     IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
                     SessionLifecycleEventType::Established,
-                ))
+                )))
                 .unwrap();
         }
 
@@ -2470,7 +2474,7 @@ mod tests {
         let mut stream = response.into_inner();
 
         for _ in 0..32 {
-            policy_events_tx.send(policy_event(None)).unwrap();
+            policy_events_tx.send(Arc::new(policy_event(None))).unwrap();
         }
 
         let event = stream.next().await.unwrap().unwrap();
@@ -2501,11 +2505,11 @@ mod tests {
 
         for _ in 0..32 {
             evpn_events_tx
-                .send(evpn_event(
+                .send(Arc::new(evpn_event(
                     RouteEventType::Added,
                     Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
                     None,
-                ))
+                )))
                 .unwrap();
         }
 
@@ -2586,10 +2590,10 @@ mod tests {
 
         for index in 0..20 {
             events_tx
-                .send(route_event(
+                .send(Arc::new(route_event(
                     Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, index), 32)),
                     IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
-                ))
+                )))
                 .unwrap();
         }
 

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv6Addr};
+use std::sync::Arc;
 
 use bytes::Bytes;
 use rustbgpd_fsm::SessionState;
@@ -747,12 +748,12 @@ pub enum PeerManagerCommand {
     /// Subscribe to live session lifecycle events.
     SubscribeSessionEvents {
         /// Reply channel returning a fresh broadcast receiver.
-        reply: oneshot::Sender<broadcast::Receiver<SessionEvent>>,
+        reply: oneshot::Sender<broadcast::Receiver<Arc<SessionEvent>>>,
     },
     /// Subscribe to live policy mutation events.
     SubscribePolicyEvents {
         /// Reply channel returning a fresh broadcast receiver.
-        reply: oneshot::Sender<broadcast::Receiver<PolicyEvent>>,
+        reply: oneshot::Sender<broadcast::Receiver<Arc<PolicyEvent>>>,
     },
     /// Query recent policy mutation events from the bounded in-memory history.
     QueryPolicyEventHistory {

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -1639,7 +1639,7 @@ impl proto::rib_service_server::RibService for RibService {
             Ok(event) => {
                 let _subscriber_guard = &subscriber_guard;
                 route_event_matches_watch_filter(&event, afi_safi_filter, peer_filter)
-                    .then(|| Ok(route_event_to_proto(event)))
+                    .then(|| Ok(route_event_to_proto(event.as_ref().clone())))
             }
             Err(BroadcastStreamRecvError::Lagged(missed)) => {
                 let _subscriber_guard = &subscriber_guard;
@@ -1684,7 +1684,7 @@ impl proto::rib_service_server::RibService for RibService {
             Ok(event) => {
                 let _subscriber_guard = &subscriber_guard;
                 route_event_matches_watch_filter(&event, afi_safi_filter, peer_filter)
-                    .then(|| Ok(route_event_to_bgp_event(event)))
+                    .then(|| Ok(route_event_to_bgp_event(event.as_ref().clone())))
             }
             Err(BroadcastStreamRecvError::Lagged(missed)) => {
                 let _subscriber_guard = &subscriber_guard;
@@ -3940,7 +3940,7 @@ mod tests {
 
     fn make_watch_routes_service(
         metrics: BgpMetrics,
-    ) -> (RibService, broadcast::Sender<rustbgpd_rib::RouteEvent>) {
+    ) -> (RibService, broadcast::Sender<Arc<rustbgpd_rib::RouteEvent>>) {
         let (tx, mut rx) = mpsc::channel(16);
         let (events_tx, _) = broadcast::channel(16);
         let events_tx_for_task = events_tx.clone();
@@ -4003,10 +4003,10 @@ mod tests {
 
         for index in 0..20 {
             events_tx
-                .send(route_event(
+                .send(Arc::new(route_event(
                     Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 1, 0, index), 32)),
                     IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
-                ))
+                )))
                 .unwrap();
         }
 
@@ -4050,22 +4050,22 @@ mod tests {
         let mut stream = response.into_inner();
 
         events_tx
-            .send(route_event(
+            .send(Arc::new(route_event(
                 Prefix::V6(Ipv6Prefix::new("2001:db8::".parse().unwrap(), 64)),
                 IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
-            ))
+            )))
             .unwrap();
         events_tx
-            .send(route_event(
+            .send(Arc::new(route_event(
                 Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 1, 0, 0), 24)),
                 IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1)),
-            ))
+            )))
             .unwrap();
         events_tx
-            .send(route_event(
+            .send(Arc::new(route_event(
                 Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 2, 0, 0), 24)),
                 IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
-            ))
+            )))
             .unwrap();
 
         let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
@@ -4101,7 +4101,7 @@ mod tests {
         let mut stream = response.into_inner();
 
         events_tx
-            .send(rustbgpd_rib::RouteEvent {
+            .send(Arc::new(rustbgpd_rib::RouteEvent {
                 event_id: 0,
                 event_type: RouteEventType::PolicyFiltered,
                 prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 3, 0, 0), 24)),
@@ -4111,7 +4111,7 @@ mod tests {
                 timestamp: "123".to_string(),
                 path_id: 0,
                 reason: "policy_denied".to_string(),
-            })
+            }))
             .unwrap();
 
         let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
@@ -4147,10 +4147,10 @@ mod tests {
 
         for index in 0..20 {
             events_tx
-                .send(route_event(
+                .send(Arc::new(route_event(
                     Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 3, 0, index), 32)),
                     IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
-                ))
+                )))
                 .unwrap();
         }
 

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -2576,10 +2576,10 @@ mod tests {
             .insert("authorization", "Bearer new".parse().unwrap());
         client.get_global(new).await.unwrap();
         session_events
-            .send(session_event(
+            .send(Arc::new(session_event(
                 "192.0.2.9".parse().unwrap(),
                 SessionLifecycleEventType::Established,
-            ))
+            )))
             .unwrap();
         let event = tokio::time::timeout(Duration::from_secs(1), stream.message())
             .await

--- a/crates/api/src/test_support.rs
+++ b/crates/api/src/test_support.rs
@@ -161,7 +161,7 @@ pub(crate) fn evpn_event(
     }
 }
 
-pub(crate) fn spawn_fake_rib() -> (mpsc::Sender<RibUpdate>, broadcast::Sender<RouteEvent>) {
+pub(crate) fn spawn_fake_rib() -> (mpsc::Sender<RibUpdate>, broadcast::Sender<Arc<RouteEvent>>) {
     let (rib_tx, mut rib_rx) = mpsc::channel(16);
     let (events_tx, _) = broadcast::channel(16);
     let (evpn_events_tx, _) = broadcast::channel(16);
@@ -240,8 +240,10 @@ pub(crate) fn spawn_fake_rib_with_evpn_history(
     rib_tx
 }
 
-pub(crate) fn spawn_fake_evpn_rib() -> (mpsc::Sender<RibUpdate>, broadcast::Sender<EvpnRouteEvent>)
-{
+pub(crate) fn spawn_fake_evpn_rib() -> (
+    mpsc::Sender<RibUpdate>,
+    broadcast::Sender<Arc<EvpnRouteEvent>>,
+) {
     let (rib_tx, mut rib_rx) = mpsc::channel(16);
     let (route_events_tx, _) = broadcast::channel(16);
     let (evpn_events_tx, _) = broadcast::channel(16);
@@ -267,8 +269,8 @@ pub(crate) fn spawn_fake_evpn_rib() -> (mpsc::Sender<RibUpdate>, broadcast::Send
 
 pub(crate) fn spawn_fake_peer_manager() -> (
     mpsc::Sender<PeerManagerCommand>,
-    broadcast::Sender<SessionEvent>,
-    broadcast::Sender<PolicyEvent>,
+    broadcast::Sender<Arc<SessionEvent>>,
+    broadcast::Sender<Arc<PolicyEvent>>,
 ) {
     let (peer_tx, mut peer_rx) = mpsc::channel(16);
     let (session_events_tx, _) = broadcast::channel(16);

--- a/crates/rib/src/event.rs
+++ b/crates/rib/src/event.rs
@@ -48,9 +48,10 @@ pub struct RouteEvent {
 /// daemon's local-MAC originator — need the full new best to build a
 /// `RemoteMacView` without a follow-up RIB query. Carrying the full
 /// [`EvpnRibRoute`] on the event side keeps the consumer's hot path
-/// allocation-free: path attributes are already `Arc`-shared, so the
-/// per-subscriber broadcast clone copies a `~120` B struct plus a
-/// pointer increment.
+/// allocation-free: the 400 B event is allocated once, then the
+/// history and live broadcast share that allocation through `Arc`.
+/// Each subscriber clone copies one `Arc`; nested path attributes
+/// remain shared, and the hot path still avoids a follow-up query.
 ///
 /// Both `best` and `previous_best` are carried so consumers can derive
 /// per-VNI context (the RFC 8365 §5 raw-24-bit VNI lives in

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -465,7 +465,7 @@ pub struct RibManager {
     vrp_table: Option<Arc<VrpTable>>,
     /// Current ASPA table for path verification. `None` = no ASPA data.
     aspa_table: Option<Arc<rustbgpd_rpki::AspaTable>>,
-    route_events_tx: broadcast::Sender<RouteEvent>,
+    route_events_tx: broadcast::Sender<Arc<RouteEvent>>,
     /// Currently surfaced unicast export-policy denials. This keeps
     /// route-level policy-filtered events transition-based instead of
     /// re-emitting on every dirty or forced outbound resync.
@@ -474,7 +474,7 @@ pub struct RibManager {
     export_policy_stats: HashMap<IpAddr, NeighborPolicyStats>,
     /// Bounded recent route-event history for after-the-fact operator
     /// timeline queries. Live streaming still uses `route_events_tx`.
-    route_event_history: VecDeque<RouteEvent>,
+    route_event_history: VecDeque<Arc<RouteEvent>>,
     /// Monotonic process-local id assigned before route events are recorded in
     /// history and broadcast to live subscribers.
     next_route_event_id: u64,
@@ -489,11 +489,11 @@ pub struct RibManager {
     /// (unicast-only) and EVPN consumers (the daemon's local-MAC
     /// originator) need an `EvpnRouteKey`-shaped event with the full
     /// new best path attached. ADR-0055 §5 — Gate 7c.
-    evpn_events_tx: broadcast::Sender<crate::event::EvpnRouteEvent>,
+    evpn_events_tx: broadcast::Sender<Arc<crate::event::EvpnRouteEvent>>,
     /// Bounded recent EVPN best-path event history for after-the-fact
     /// operator timeline queries. Live streaming still uses
     /// `evpn_events_tx`.
-    evpn_route_event_history: VecDeque<crate::event::EvpnRouteEvent>,
+    evpn_route_event_history: VecDeque<Arc<crate::event::EvpnRouteEvent>>,
     /// Sink for the durable event outbox (ADR-0072). Fires AFTER the
     /// process-local ring + broadcast at every publish site. Defaults
     /// to [`crate::event_sink::NoopRibEventSink`] so callers that
@@ -1165,11 +1165,11 @@ impl RibManager {
             route_events_tx,
             policy_filtered_routes: HashMap::new(),
             export_policy_stats: HashMap::new(),
-            route_event_history: VecDeque::with_capacity(ROUTE_EVENT_HISTORY_CAPACITY),
+            route_event_history: VecDeque::new(),
             next_route_event_id: 1,
             route_event_id_exhausted: false,
             evpn_events_tx,
-            evpn_route_event_history: VecDeque::with_capacity(EVPN_ROUTE_EVENT_HISTORY_CAPACITY),
+            evpn_route_event_history: VecDeque::new(),
             event_sink: std::sync::Arc::new(crate::event_sink::NoopRibEventSink),
             bmp_tx: None,
             metrics,
@@ -2615,7 +2615,8 @@ impl RibManager {
         if self.route_event_history.len() == ROUTE_EVENT_HISTORY_CAPACITY {
             self.route_event_history.pop_front();
         }
-        self.route_event_history.push_back(event.clone());
+        let event = Arc::new(event);
+        self.route_event_history.push_back(Arc::clone(&event));
         self.metrics.set_route_event_history_depth(
             i64::try_from(self.route_event_history.len()).unwrap_or(i64::MAX),
         );
@@ -2629,7 +2630,7 @@ impl RibManager {
         // not load-bearing for correctness; pick the order that
         // avoids the second clone (sink first, then move into
         // broadcast).
-        self.event_sink.publish_route_event(&event);
+        self.event_sink.publish_route_event(event.as_ref());
         let _ = self.route_events_tx.send(event);
     }
 
@@ -2686,10 +2687,11 @@ impl RibManager {
         if self.evpn_route_event_history.len() == EVPN_ROUTE_EVENT_HISTORY_CAPACITY {
             self.evpn_route_event_history.pop_front();
         }
-        self.evpn_route_event_history.push_back(event.clone());
+        let event = Arc::new(event);
+        self.evpn_route_event_history.push_back(Arc::clone(&event));
         // ADR-0072: durable outbox sink fires alongside the legacy
         // broadcast. See `publish_route_event` for the ordering note.
-        self.event_sink.publish_evpn_event(&event);
+        self.event_sink.publish_evpn_event(event.as_ref());
         let _ = self.evpn_events_tx.send(event);
     }
 

--- a/crates/rib/src/manager/queries.rs
+++ b/crates/rib/src/manager/queries.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
 
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_wire::{Afi, Prefix, Safi};
@@ -1568,7 +1569,7 @@ impl RibManager {
     }
     pub(super) fn handle_subscribe_route_events(
         &mut self,
-        reply: tokio::sync::oneshot::Sender<broadcast::Receiver<RouteEvent>>,
+        reply: tokio::sync::oneshot::Sender<broadcast::Receiver<Arc<RouteEvent>>>,
     ) {
         let rx = self.route_events_tx.subscribe();
         let _ = reply.send(rx);
@@ -1610,14 +1611,14 @@ impl RibManager {
                 None => true,
             })
             .take(limit)
-            .cloned()
+            .map(|event| event.as_ref().clone())
             .collect();
         events.reverse();
         let _ = reply.send(events);
     }
     pub(super) fn handle_subscribe_evpn_route_events(
         &mut self,
-        reply: tokio::sync::oneshot::Sender<broadcast::Receiver<crate::event::EvpnRouteEvent>>,
+        reply: tokio::sync::oneshot::Sender<broadcast::Receiver<Arc<crate::event::EvpnRouteEvent>>>,
     ) {
         let rx = self.evpn_events_tx.subscribe();
         let _ = reply.send(rx);
@@ -1651,7 +1652,7 @@ impl RibManager {
                 None => true,
             })
             .take(limit)
-            .cloned()
+            .map(|event| event.as_ref().clone())
             .collect();
         events.reverse();
         let _ = reply.send(events);

--- a/crates/rib/src/manager/tests/events_metrics.rs
+++ b/crates/rib/src/manager/tests/events_metrics.rs
@@ -1,8 +1,57 @@
 use super::*;
 
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn event_storage_layout_and_lazy_history_capacity_are_pinned() {
+    use std::mem::size_of;
+
+    assert_eq!(size_of::<crate::event::RouteEvent>(), 136);
+    assert_eq!(size_of::<crate::event::EvpnRouteEvent>(), 400);
+    assert_eq!(size_of::<Arc<crate::event::RouteEvent>>(), 8);
+    assert_eq!(size_of::<Arc<crate::event::EvpnRouteEvent>>(), 8);
+
+    let (_tx, rx) = mpsc::channel(1);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    assert_eq!(manager.route_event_history.capacity(), 0);
+    assert_eq!(manager.evpn_route_event_history.capacity(), 0);
+}
+
+#[tokio::test]
+async fn route_history_and_live_broadcast_share_arc_but_queries_are_owned() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let mut live = manager.route_events_tx.subscribe();
+    manager.publish_route_event(crate::event::RouteEvent {
+        event_id: 0,
+        event_type: RouteEventType::Added,
+        prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24)),
+        peer: None,
+        previous_peer: None,
+        target_peer: None,
+        timestamp: "1".to_string(),
+        path_id: 0,
+        reason: "original".to_string(),
+    });
+
+    let broadcast = live.try_recv().unwrap();
+    assert!(Arc::ptr_eq(
+        manager.route_event_history.back().unwrap(),
+        &broadcast
+    ));
+
+    let (reply, result) = oneshot::channel();
+    manager.handle_query_route_event_history(None, None, None, 0, reply);
+    let mut owned = result.await.unwrap();
+    owned[0].reason = "caller mutation".to_string();
+    assert_eq!(
+        manager.route_event_history.back().unwrap().reason,
+        "original"
+    );
+}
+
 async fn subscribe_events(
     tx: &mpsc::Sender<RibUpdate>,
-) -> tokio::sync::broadcast::Receiver<crate::event::RouteEvent> {
+) -> tokio::sync::broadcast::Receiver<Arc<crate::event::RouteEvent>> {
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(RibUpdate::SubscribeRouteEvents { reply: reply_tx })
         .await

--- a/crates/rib/src/manager/tests/evpn.rs
+++ b/crates/rib/src/manager/tests/evpn.rs
@@ -2031,12 +2031,49 @@ fn make_evpn_macip(
 
 async fn subscribe_evpn_events(
     tx: &mpsc::Sender<RibUpdate>,
-) -> tokio::sync::broadcast::Receiver<crate::event::EvpnRouteEvent> {
+) -> tokio::sync::broadcast::Receiver<Arc<crate::event::EvpnRouteEvent>> {
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(RibUpdate::SubscribeEvpnRouteEvents { reply: reply_tx })
         .await
         .unwrap();
     reply_rx.await.unwrap()
+}
+
+#[test]
+fn evpn_history_and_live_broadcast_share_arc() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let mut live = manager.evpn_events_tx.subscribe();
+    let route = make_evpn_macip(
+        Ipv4Addr::new(10, 0, 0, 1),
+        [0x02, 0, 0, 0, 0, 1],
+        None,
+        false,
+    );
+    manager.publish_evpn_route_event(crate::event::EvpnRouteEvent {
+        event_type: RouteEventType::Added,
+        key: route.key(),
+        peer: Some(route.peer),
+        previous_peer: None,
+        best: Some(route),
+        previous_best: None,
+        timestamp: "1".to_string(),
+    });
+
+    let broadcast = live.try_recv().unwrap();
+    assert!(Arc::ptr_eq(
+        manager.evpn_route_event_history.back().unwrap(),
+        &broadcast
+    ));
+
+    let (reply, result) = oneshot::channel();
+    manager.handle_query_evpn_route_event_history(None, None, None, &BTreeSet::new(), 0, reply);
+    let mut owned = result.blocking_recv().unwrap();
+    owned[0].timestamp = "caller mutation".to_string();
+    assert_eq!(
+        manager.evpn_route_event_history.back().unwrap().timestamp,
+        "1"
+    );
 }
 
 async fn query_evpn_event_history(
@@ -2291,10 +2328,14 @@ async fn evpn_route_event_best_changed_on_higher_mobility() {
     assert_eq!(event.event_type, crate::event::RouteEventType::BestChanged);
     assert_eq!(event.peer, Some(IpAddr::V4(new_peer)));
     assert_eq!(event.previous_peer, Some(IpAddr::V4(original_peer)));
-    let best = event.best.expect("BestChanged must carry a best path");
+    let best = event
+        .best
+        .as_ref()
+        .expect("BestChanged must carry a best path");
     assert_eq!(best.peer, IpAddr::V4(new_peer));
     let prior = event
         .previous_best
+        .as_ref()
         .expect("BestChanged must carry the prior best path");
     assert_eq!(prior.peer, IpAddr::V4(original_peer));
 
@@ -2357,6 +2398,7 @@ async fn evpn_route_event_withdrawn_on_last_removed() {
     assert!(event.best.is_none(), "Withdrawn must not carry a best");
     let prior = event
         .previous_best
+        .as_ref()
         .expect("Withdrawn must carry the prior best so consumers recover VNI");
     assert_eq!(prior.peer, peer);
 

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -1824,7 +1824,7 @@ pub enum RibUpdate {
     /// Subscribe to route change events via broadcast channel.
     SubscribeRouteEvents {
         /// Response channel carrying the broadcast receiver.
-        reply: oneshot::Sender<broadcast::Receiver<RouteEvent>>,
+        reply: oneshot::Sender<broadcast::Receiver<Arc<RouteEvent>>>,
     },
     /// Query recent route change events from the bounded in-memory history.
     QueryRouteEventHistory {
@@ -1850,7 +1850,7 @@ pub enum RibUpdate {
     /// build a `RemoteMacView`.
     SubscribeEvpnRouteEvents {
         /// Response channel carrying the broadcast receiver.
-        reply: oneshot::Sender<broadcast::Receiver<EvpnRouteEvent>>,
+        reply: oneshot::Sender<broadcast::Receiver<Arc<EvpnRouteEvent>>>,
     },
     /// Query recent EVPN best-path change events from the bounded in-memory history.
     QueryEvpnRouteEventHistory {

--- a/src/blackhole.rs
+++ b/src/blackhole.rs
@@ -20,6 +20,7 @@ use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::net::IpAddr;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::Duration;
 
 use rustbgpd_rib::{RibUpdate, Route, RouteOrigin};
@@ -424,7 +425,7 @@ fn kernel_route_drift_wakes(
 
 async fn subscribe_route_events(
     rib_tx: &mpsc::Sender<RibUpdate>,
-) -> Option<broadcast::Receiver<rustbgpd_rib::RouteEvent>> {
+) -> Option<broadcast::Receiver<Arc<rustbgpd_rib::RouteEvent>>> {
     let (reply, rx) = oneshot::channel();
     if rib_tx
         .send(RibUpdate::SubscribeRouteEvents { reply })
@@ -443,7 +444,7 @@ async fn subscribe_route_events(
 }
 
 async fn recv_route_event(
-    rx: &mut Option<broadcast::Receiver<rustbgpd_rib::RouteEvent>>,
+    rx: &mut Option<broadcast::Receiver<Arc<rustbgpd_rib::RouteEvent>>>,
 ) -> Option<()> {
     let Some(rx) = rx.as_mut() else {
         std::future::pending::<()>().await;
@@ -1298,7 +1299,7 @@ mod tests {
     ) -> (
         mpsc::Sender<RibUpdate>,
         Arc<AtomicUsize>,
-        broadcast::Sender<RouteEvent>,
+        broadcast::Sender<Arc<RouteEvent>>,
     ) {
         let (tx, mut rx) = mpsc::channel(8);
         let query_count = Arc::new(AtomicUsize::new(0));
@@ -1662,7 +1663,7 @@ mod tests {
         );
 
         for _ in 0..5 {
-            events_tx.send(route_event(prefix)).unwrap();
+            events_tx.send(Arc::new(route_event(prefix))).unwrap();
         }
         tokio::task::yield_now().await;
         assert_eq!(
@@ -1719,7 +1720,7 @@ mod tests {
         assert_eq!(query_count.load(Ordering::SeqCst), 1);
 
         tokio::time::sleep(ROUTE_EVENT_DEBOUNCE + Duration::from_millis(50)).await;
-        events_tx.send(route_event(prefix)).unwrap();
+        events_tx.send(Arc::new(route_event(prefix))).unwrap();
         tokio::time::sleep(ROUTE_EVENT_DEBOUNCE / 2).await;
         tokio::task::yield_now().await;
 

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -1132,7 +1132,7 @@ async fn supervisor_loop(
 /// convergence at the old cadence.
 async fn subscribe_evpn_route_events(
     rib_tx: &mpsc::Sender<RibUpdate>,
-) -> Option<broadcast::Receiver<rustbgpd_rib::EvpnRouteEvent>> {
+) -> Option<broadcast::Receiver<Arc<rustbgpd_rib::EvpnRouteEvent>>> {
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
     if rib_tx
         .send(RibUpdate::SubscribeEvpnRouteEvents { reply: reply_tx })
@@ -1153,7 +1153,7 @@ async fn subscribe_evpn_route_events(
 /// (poll-only mode), letting the surrounding `select!` service the
 /// other arms.
 async fn recv_evpn_route_event(
-    rx: &mut Option<broadcast::Receiver<rustbgpd_rib::EvpnRouteEvent>>,
+    rx: &mut Option<broadcast::Receiver<Arc<rustbgpd_rib::EvpnRouteEvent>>>,
 ) -> Option<()> {
     let Some(rx) = rx.as_mut() else {
         std::future::pending::<()>().await;
@@ -3913,7 +3913,7 @@ mod tests {
     ) -> (
         mpsc::Sender<RibUpdate>,
         Arc<AtomicUsize>,
-        broadcast::Sender<rustbgpd_rib::EvpnRouteEvent>,
+        broadcast::Sender<Arc<rustbgpd_rib::EvpnRouteEvent>>,
     ) {
         let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(16);
         let query_count = Arc::new(AtomicUsize::new(0));
@@ -4018,7 +4018,7 @@ mod tests {
         assert!(initial.remote_macs.get(vni(100), mac(1)).is_some());
         assert!(initial.remote_macs.get(vni(100), mac(2)).is_none());
 
-        events_tx.send(evpn_route_event(2)).unwrap();
+        events_tx.send(Arc::new(evpn_route_event(2))).unwrap();
 
         // Debounce is 200 ms; 2 s of headroom is generous and still
         // far below the 60 s poll, so a pass proves the event path
@@ -4086,7 +4086,7 @@ mod tests {
         // the supervisor dirty (re-arm semantics — no query per event,
         // nothing queued)…
         for _ in 0..25 {
-            events_tx.send(evpn_route_event(2)).unwrap();
+            events_tx.send(Arc::new(evpn_route_event(2))).unwrap();
         }
         tokio::task::yield_now().await;
         assert_eq!(

--- a/src/evpn_originator/rib_polling.rs
+++ b/src/evpn_originator/rib_polling.rs
@@ -1,6 +1,6 @@
 use super::{
-    BTreeMap, BTreeSet, BgpMetrics, EthernetSegmentIdentifier, EvpnInstanceId, EvpnInstanceTable,
-    EvpnRibRoute, EvpnRoute, EvpnRouteEvent, EvpnRouteKey, IpAddr, MacAddress,
+    Arc, BTreeMap, BTreeSet, BgpMetrics, EthernetSegmentIdentifier, EvpnInstanceId,
+    EvpnInstanceTable, EvpnRibRoute, EvpnRoute, EvpnRouteEvent, EvpnRouteKey, IpAddr, MacAddress,
     OriginatedLocalMacCounts, OriginatorState, PathAttribute, ProjectedEvpnRoute, RemoteMacIpView,
     RemoteMacIpViewMap, RemoteMacView, RemoteMacViewMap, RibQueryError, RibUpdate, broadcast, mpsc,
     oneshot, project_evpn_routes, warn,
@@ -17,7 +17,7 @@ type StickyMacWinnerKey = (EvpnInstanceId, MacAddress, IpAddr, Option<u32>);
 /// the originator's 5 s poll backstop covers both cases.
 pub(super) async fn subscribe_evpn_events(
     rib_tx: &mpsc::Sender<RibUpdate>,
-) -> Option<broadcast::Receiver<EvpnRouteEvent>> {
+) -> Option<broadcast::Receiver<Arc<EvpnRouteEvent>>> {
     let (reply_tx, reply_rx) = oneshot::channel();
     rib_tx
         .send(RibUpdate::SubscribeEvpnRouteEvents { reply: reply_tx })
@@ -30,8 +30,8 @@ pub(super) async fn subscribe_evpn_events(
 /// (poll-only mode). Parking on `pending` lets the surrounding
 /// `tokio::select!` continue to service the other arms.
 pub(super) async fn recv_evpn_event(
-    rx: &mut Option<broadcast::Receiver<EvpnRouteEvent>>,
-) -> Result<EvpnRouteEvent, broadcast::error::RecvError> {
+    rx: &mut Option<broadcast::Receiver<Arc<EvpnRouteEvent>>>,
+) -> Result<Arc<EvpnRouteEvent>, broadcast::error::RecvError> {
     match rx {
         Some(r) => r.recv().await,
         None => std::future::pending().await,
@@ -54,7 +54,7 @@ pub(super) fn evpn_event_requires_repoll(event: &EvpnRouteEvent) -> bool {
 }
 
 pub(super) fn drain_ready_evpn_events(
-    rx: &mut broadcast::Receiver<EvpnRouteEvent>,
+    rx: &mut broadcast::Receiver<Arc<EvpnRouteEvent>>,
 ) -> ReadyEvpnEventDrain {
     let mut drain = ReadyEvpnEventDrain::default();
     loop {
@@ -281,8 +281,8 @@ pub(super) async fn handle_evpn_event(
     reason = "RIB poll reconciliation needs the snapshot, generation, and actor outputs"
 )]
 pub(super) async fn handle_evpn_event_coalesced(
-    event: EvpnRouteEvent,
-    rx: &mut Option<broadcast::Receiver<EvpnRouteEvent>>,
+    event: Arc<EvpnRouteEvent>,
+    rx: &mut Option<broadcast::Receiver<Arc<EvpnRouteEvent>>>,
     instances: &EvpnInstanceTable,
     state: &mut OriginatorState,
     rib_tx: &mpsc::Sender<RibUpdate>,

--- a/src/evpn_originator/tests.rs
+++ b/src/evpn_originator/tests.rs
@@ -2320,7 +2320,7 @@ async fn handle_evpn_event_coalesces_ready_type2_events_into_one_repoll() {
     let (event_tx, event_rx) = broadcast::channel(16);
     let mut event_rx = Some(event_rx);
     event_tx
-        .send(evpn_event_macip(
+        .send(Arc::new(evpn_event_macip(
             100,
             0xAA,
             "10.0.0.2",
@@ -2328,10 +2328,10 @@ async fn handle_evpn_event_coalesces_ready_type2_events_into_one_repoll() {
             false,
             rustbgpd_rib::RouteEventType::Added,
             None,
-        ))
+        )))
         .unwrap();
     event_tx
-        .send(evpn_event_macip(
+        .send(Arc::new(evpn_event_macip(
             100,
             0xBB,
             "10.0.0.3",
@@ -2339,10 +2339,10 @@ async fn handle_evpn_event_coalesces_ready_type2_events_into_one_repoll() {
             false,
             rustbgpd_rib::RouteEventType::Added,
             None,
-        ))
+        )))
         .unwrap();
 
-    let trigger = evpn_event_macip(
+    let trigger = Arc::new(evpn_event_macip(
         100,
         0xCC,
         "10.0.0.4",
@@ -2350,7 +2350,7 @@ async fn handle_evpn_event_coalesces_ready_type2_events_into_one_repoll() {
         false,
         rustbgpd_rib::RouteEventType::Added,
         None,
-    );
+    ));
     handle_evpn_event_coalesced(
         trigger,
         &mut event_rx,

--- a/src/evpn_segment.rs
+++ b/src/evpn_segment.rs
@@ -655,7 +655,7 @@ async fn apply_runtime_segment_snapshot(
 
 async fn subscribe_evpn_events(
     rib_tx: &mpsc::Sender<RibUpdate>,
-) -> Option<broadcast::Receiver<EvpnRouteEvent>> {
+) -> Option<broadcast::Receiver<Arc<EvpnRouteEvent>>> {
     let (reply_tx, reply_rx) = oneshot::channel();
     rib_tx
         .send(RibUpdate::SubscribeEvpnRouteEvents { reply: reply_tx })
@@ -665,8 +665,8 @@ async fn subscribe_evpn_events(
 }
 
 async fn recv_evpn_event(
-    rx: &mut Option<broadcast::Receiver<EvpnRouteEvent>>,
-) -> Result<EvpnRouteEvent, broadcast::error::RecvError> {
+    rx: &mut Option<broadcast::Receiver<Arc<EvpnRouteEvent>>>,
+) -> Result<Arc<EvpnRouteEvent>, broadcast::error::RecvError> {
     match rx {
         Some(r) => r.recv().await,
         None => std::future::pending().await,
@@ -3599,7 +3599,7 @@ mod tests {
         injects: Arc<tokio::sync::Mutex<Vec<EvpnRouteKey>>>,
         withdraws: Arc<tokio::sync::Mutex<Vec<EvpnRouteKey>>>,
         routes: Arc<tokio::sync::Mutex<Vec<EvpnRibRoute>>>,
-        events_tx: broadcast::Sender<EvpnRouteEvent>,
+        events_tx: broadcast::Sender<Arc<EvpnRouteEvent>>,
     ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             while let Some(update) = rib_rx.recv().await {
@@ -3724,7 +3724,7 @@ mod tests {
         let remote_type4 = type_4_es_route(id, "10.0.0.2", attrs_with_es_import_rt(id));
         routes.lock().await.push(remote_type4.clone());
         events_tx
-            .send(EvpnRouteEvent {
+            .send(Arc::new(EvpnRouteEvent {
                 event_type: rustbgpd_rib::RouteEventType::Added,
                 key: EvpnRouteKey::Es {
                     rd: rd(65000, 100),
@@ -3736,7 +3736,7 @@ mod tests {
                 peer: Some(ipa("10.0.0.2")),
                 previous_peer: None,
                 timestamp: rustbgpd_rib::event::unix_timestamp_now(),
-            })
+            }))
             .expect("segment actor subscribed");
 
         wait_for_dataplane_state(&bias_rx, &bum_rx, "post-flip snapshots", |bias, bum| {

--- a/src/fib_runtime.rs
+++ b/src/fib_runtime.rs
@@ -11,6 +11,7 @@ use std::future::Future;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::Duration;
 
 use rustbgpd_rib::{FibInstallCandidate, RibUpdate, RouteOrigin};
@@ -539,7 +540,7 @@ fn kernel_route_drift_wakes(
 
 async fn subscribe_route_events(
     rib_tx: &mpsc::Sender<RibUpdate>,
-) -> Option<broadcast::Receiver<rustbgpd_rib::RouteEvent>> {
+) -> Option<broadcast::Receiver<Arc<rustbgpd_rib::RouteEvent>>> {
     let (reply, rx) = oneshot::channel();
     if rib_tx
         .send(RibUpdate::SubscribeRouteEvents { reply })
@@ -558,7 +559,7 @@ async fn subscribe_route_events(
 }
 
 async fn recv_route_event(
-    rx: &mut Option<broadcast::Receiver<rustbgpd_rib::RouteEvent>>,
+    rx: &mut Option<broadcast::Receiver<Arc<rustbgpd_rib::RouteEvent>>>,
 ) -> Option<()> {
     let Some(rx) = rx.as_mut() else {
         std::future::pending::<()>().await;
@@ -2486,7 +2487,7 @@ mod tests {
     ) -> (
         mpsc::Sender<RibUpdate>,
         Arc<AtomicUsize>,
-        broadcast::Sender<RouteEvent>,
+        broadcast::Sender<Arc<RouteEvent>>,
     ) {
         let (tx, mut rx) = mpsc::channel(8);
         let query_count = Arc::new(AtomicUsize::new(0));
@@ -3559,7 +3560,7 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
         let initial = query_count.load(Ordering::SeqCst);
-        events_tx.send(route_event(v4(24))).unwrap();
+        events_tx.send(Arc::new(route_event(v4(24)))).unwrap();
         tokio::time::sleep(ROUTE_EVENT_DEBOUNCE + Duration::from_millis(50)).await;
         tokio::task::yield_now().await;
 
@@ -3812,7 +3813,7 @@ mod tests {
         assert_eq!(query_count.load(Ordering::SeqCst), 1);
 
         tokio::time::sleep(ROUTE_EVENT_DEBOUNCE + Duration::from_millis(50)).await;
-        events_tx.send(route_event(v4(24))).unwrap();
+        events_tx.send(Arc::new(route_event(v4(24)))).unwrap();
         tokio::time::sleep(ROUTE_EVENT_DEBOUNCE / 2).await;
         tokio::task::yield_now().await;
 

--- a/src/peer_manager/events.rs
+++ b/src/peer_manager/events.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 use std::net::IpAddr;
+use std::sync::Arc;
 
 use rustbgpd_api::peer_types::{
     ConfigEvent, POLICY_EVENT_HISTORY_CAPACITY, PeerKey, PolicyEvent,
@@ -68,7 +69,7 @@ impl PeerManager {
             );
             rustbgpd_api::event_history_sinks::try_send_envelope(handle, &self.metrics, envelope);
         }
-        let _ = self.session_events_tx.send(event);
+        let _ = self.session_events_tx.send(Arc::new(event));
     }
 
     pub(super) fn publish_lifecycle_event(&mut self, event: SessionLifecycleEvent) {
@@ -79,14 +80,15 @@ impl PeerManager {
         if self.policy_event_history.len() >= POLICY_EVENT_HISTORY_CAPACITY {
             self.policy_event_history.pop_front();
         }
-        self.policy_event_history.push_back(event.clone());
+        let event = Arc::new(event);
+        self.policy_event_history.push_back(Arc::clone(&event));
         // ADR-0072 durable outbox enqueue; legacy ring + broadcast
         // above remain authoritative for `ListPolicyEvents` /
         // `WatchEvents`.
         if let Some(handle) = &self.event_history {
             let peer = event.peer;
             let proto_event =
-                rustbgpd_api::event_converters::policy_event_to_bgp_event(event.clone());
+                rustbgpd_api::event_converters::policy_event_to_bgp_event(event.as_ref().clone());
             let envelope = rustbgpd_api::event_history_sinks::envelope_from_bgp_event(
                 &proto_event,
                 Category::Policy,
@@ -373,7 +375,7 @@ impl PeerManager {
                 None => true,
             })
             .take(limit)
-            .cloned()
+            .map(|event| event.as_ref().clone())
             .collect();
         events.reverse();
         let _ = reply.send(events);

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -1,15 +1,15 @@
 use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use futures::stream::{self, StreamExt};
 use rustbgpd_api::peer_types::{
     ConfigEvent, DynamicNeighborInfo, OwnedCatalogMutation, OwnedNeighborMutation,
-    OwnedNeighborMutationError, OwnedNeighborMutationOutcome, POLICY_EVENT_HISTORY_CAPACITY,
-    PeerKey, PeerManagerCommand, PeerManagerNeighborConfig, PeerManagerReadinessQuery,
-    PolicyDatasetStatusRow, PolicyEvent, SESSION_EVENT_HISTORY_CAPACITY, SessionEvent,
-    SessionLifecycleEvent, StageConfigSnapshotError,
+    OwnedNeighborMutationError, OwnedNeighborMutationOutcome, PeerKey, PeerManagerCommand,
+    PeerManagerNeighborConfig, PeerManagerReadinessQuery, PolicyDatasetStatusRow, PolicyEvent,
+    SessionEvent, SessionLifecycleEvent, StageConfigSnapshotError,
 };
 use rustbgpd_bmp::BmpEvent;
 use rustbgpd_fsm::PeerConfig;
@@ -337,10 +337,10 @@ pub struct PeerManager {
     session_lifecycle_rx: mpsc::Receiver<SessionLifecycleNotification>,
     session_notification_event_tx: mpsc::Sender<TransportNotificationEvent>,
     session_notification_event_rx: mpsc::Receiver<TransportNotificationEvent>,
-    session_events_tx: broadcast::Sender<SessionEvent>,
+    session_events_tx: broadcast::Sender<Arc<SessionEvent>>,
     session_event_history: VecDeque<SessionLifecycleEvent>,
-    policy_events_tx: broadcast::Sender<PolicyEvent>,
-    policy_event_history: VecDeque<PolicyEvent>,
+    policy_events_tx: broadcast::Sender<Arc<PolicyEvent>>,
+    policy_event_history: VecDeque<Arc<PolicyEvent>>,
     current_config: Config,
     /// True between `StageConfigSnapshot` and the transaction controller's
     /// persist/rollback completion signal. Dynamic inbound accepts are refused
@@ -689,9 +689,9 @@ impl PeerManager {
             session_notification_event_tx,
             session_notification_event_rx,
             session_events_tx,
-            session_event_history: VecDeque::with_capacity(SESSION_EVENT_HISTORY_CAPACITY),
+            session_event_history: VecDeque::new(),
             policy_events_tx,
-            policy_event_history: VecDeque::with_capacity(POLICY_EVENT_HISTORY_CAPACITY),
+            policy_event_history: VecDeque::new(),
             config_snapshot_staged: false,
             dynamic_ranges: Self::parse_dynamic_ranges(&current_config),
             dynamic_peer_count: 0,

--- a/src/peer_manager/tests/events.rs
+++ b/src/peer_manager/tests/events.rs
@@ -1,5 +1,46 @@
 use super::*;
 
+use rustbgpd_api::peer_types::{POLICY_EVENT_HISTORY_CAPACITY, SESSION_EVENT_HISTORY_CAPACITY};
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn event_storage_layout_savings_and_lazy_history_capacity_are_pinned() {
+    use std::mem::size_of;
+
+    assert_eq!(size_of::<SessionEvent>(), 168);
+    assert_eq!(size_of::<SessionLifecycleEvent>(), 120);
+    assert_eq!(size_of::<PolicyEvent>(), 160);
+    assert_eq!(size_of::<Arc<SessionEvent>>(), 8);
+    assert_eq!(size_of::<Arc<PolicyEvent>>(), 8);
+
+    let manager = test_peer_manager();
+    assert_eq!(manager.session_event_history.capacity(), 0);
+    assert_eq!(manager.policy_event_history.capacity(), 0);
+
+    let eager_history_bytes = (136 + 400 + 120 + 160) * 4096;
+    assert_eq!(eager_history_bytes, 3_342_336);
+    let broadcast_payload_savings = (136 + 400 + 168 + 160 - 4 * 8) * 4096;
+    assert_eq!(broadcast_payload_savings, 3_407_872);
+}
+
+#[tokio::test]
+async fn session_history_queries_return_owned_events() {
+    let mut manager = test_peer_manager();
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    manager.publish_peer_lifecycle_event(
+        &key(peer),
+        SessionLifecycleEventType::PeerEnabled,
+        "original".to_string(),
+    );
+
+    let mut queried = query_session_event_history(&manager, None, BTreeSet::new(), 0).await;
+    queried[0].reason = "caller mutation".to_string();
+    assert_eq!(
+        manager.session_event_history.back().unwrap().reason,
+        "original"
+    );
+}
+
 fn test_policy_event(target: &str, peer: Option<IpAddr>) -> PolicyEvent {
     PolicyEvent {
         operation: "set",
@@ -159,7 +200,7 @@ async fn lifecycle_notification_matches_scoped_static_peer_by_session_id() {
         .await
         .expect("session event timeout")
         .expect("session event channel closed");
-    let SessionEvent::Lifecycle(event) = event else {
+    let SessionEvent::Lifecycle(event) = event.as_ref() else {
         panic!("expected lifecycle event");
     };
     assert_eq!(event.peer, peer);
@@ -248,6 +289,7 @@ async fn notification_event_reason_includes_bounded_failure_cause() {
     let mut mgr = test_peer_manager();
     let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
     let mut events = mgr.session_events_tx.subscribe();
+    assert!(mgr.session_event_history.is_empty());
     mgr.publish_notification_event(rustbgpd_transport::SessionNotificationEvent {
         session_id: 1,
         peer_addr: addr,
@@ -260,10 +302,14 @@ async fn notification_event_reason_includes_bounded_failure_cause() {
         failure_cause: Some(rustbgpd_transport::handle::SessionFailureCause::OutboundSaturation),
     });
 
-    let rustbgpd_api::peer_types::SessionEvent::Notification(event) = events.try_recv().unwrap()
-    else {
+    let event = events.try_recv().unwrap();
+    let rustbgpd_api::peer_types::SessionEvent::Notification(event) = event.as_ref() else {
         panic!("expected notification event");
     };
+    assert!(
+        mgr.session_event_history.is_empty(),
+        "notifications must remain excluded from lifecycle history"
+    );
     assert_eq!(
         event.reason,
         "BGP NOTIFICATION sent for peer 10.0.0.2: 6/8 (Out of Resources); transport failure: outbound writer queue saturated"
@@ -307,8 +353,8 @@ async fn notification_event_uses_scoped_peer_label_for_interface_scoped_peer() {
         failure_cause: None,
     });
 
-    let rustbgpd_api::peer_types::SessionEvent::Notification(event) = events.try_recv().unwrap()
-    else {
+    let event = events.try_recv().unwrap();
+    let rustbgpd_api::peer_types::SessionEvent::Notification(event) = event.as_ref() else {
         panic!("expected notification event");
     };
     assert!(

--- a/src/peer_manager/tests/max_prefix.rs
+++ b/src/peer_manager/tests/max_prefix.rs
@@ -359,7 +359,7 @@ async fn due_max_prefix_restarts_share_one_readiness_serving_deadline() {
     );
 
     let enabled: Vec<IpAddr> = std::iter::from_fn(|| events.try_recv().ok())
-        .filter_map(|event| match event {
+        .filter_map(|event| match event.as_ref() {
             SessionEvent::Lifecycle(event)
                 if event.event_type == SessionLifecycleEventType::PeerEnabled =>
             {

--- a/src/peer_manager/tests/mod.rs
+++ b/src/peer_manager/tests/mod.rs
@@ -105,7 +105,7 @@ fn make_config(addr: IpAddr, asn: u32) -> PeerManagerNeighborConfig {
 
 async fn subscribe_session_events(
     tx: &mpsc::Sender<PeerManagerCommand>,
-) -> broadcast::Receiver<SessionEvent> {
+) -> broadcast::Receiver<Arc<SessionEvent>> {
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(PeerManagerCommand::SubscribeSessionEvents { reply: reply_tx })
         .await
@@ -125,7 +125,7 @@ async fn skip_destination_prestage(rib_rx: &mut mpsc::Receiver<RibUpdate>) {
 }
 
 async fn wait_for_session_event(
-    rx: &mut broadcast::Receiver<SessionEvent>,
+    rx: &mut broadcast::Receiver<Arc<SessionEvent>>,
     event_type: SessionLifecycleEventType,
 ) -> SessionLifecycleEvent {
     for _ in 0..20 {
@@ -133,10 +133,10 @@ async fn wait_for_session_event(
             .await
             .expect("session event timeout")
             .expect("session event channel closed");
-        if let SessionEvent::Lifecycle(event) = event
+        if let SessionEvent::Lifecycle(event) = event.as_ref()
             && event.event_type == event_type
         {
-            return event;
+            return event.clone();
         }
     }
     panic!("session event {event_type:?} did not arrive");

--- a/src/peer_manager/tests/policy.rs
+++ b/src/peer_manager/tests/policy.rs
@@ -2,7 +2,7 @@ use super::*;
 
 async fn subscribe_policy_events(
     tx: &mpsc::Sender<PeerManagerCommand>,
-) -> broadcast::Receiver<PolicyEvent> {
+) -> broadcast::Receiver<Arc<PolicyEvent>> {
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(PeerManagerCommand::SubscribePolicyEvents { reply: reply_tx })
         .await
@@ -42,6 +42,37 @@ fn assert_validation_import_refresh_metric(
     assert!(
         (actual - expected).abs() < f64::EPSILON,
         "metric dependency={dependency} outcome={outcome}: got {actual}, expected {expected}"
+    );
+}
+
+#[tokio::test]
+async fn policy_history_and_live_broadcast_share_arc_but_queries_are_owned() {
+    let mut manager = test_peer_manager();
+    let mut live = manager.policy_events_tx.subscribe();
+    manager.publish_policy_event(PolicyEvent {
+        operation: "set",
+        target_type: "policy",
+        target: "shared".to_string(),
+        peer: None,
+        peer_label: None,
+        affected_peer_count: 0,
+        timestamp: "1".to_string(),
+        reason: "original".to_string(),
+    });
+
+    let broadcast = live.try_recv().unwrap();
+    assert!(Arc::ptr_eq(
+        manager.policy_event_history.back().unwrap(),
+        &broadcast
+    ));
+
+    let (reply, result) = oneshot::channel();
+    manager.handle_query_policy_event_history(None, 0, reply);
+    let mut owned = result.await.unwrap();
+    owned[0].reason = "caller mutation".to_string();
+    assert_eq!(
+        manager.policy_event_history.back().unwrap().reason,
+        "original"
     );
 }
 


### PR DESCRIPTION
## Summary

- change the four live event broadcasts to carry `Arc` payloads
- make route, EVPN, session, and policy histories allocate lazily
- share the exact route, EVPN, and policy allocation between history and live subscribers
- preserve owned query/RPC responses, 4096-entry capacities, lag behavior, durable-sink ordering, and lifecycle-only session history

## Why

The event system eagerly reserved large broadcast slots and four full history buffers even when histories were empty. Route, EVPN, and policy publication also retained separate outer event values for history and live delivery.

The 64-bit layout tests pin a 3,407,872-byte broadcast payload reduction and remove 3,342,336 bytes of eager history element reservation. These are structural allocation reductions, not an observed RSS claim; a separate current-tip process measurement will follow before user-facing memory numbers are published.

## Validation

- `cargo check --workspace --all-targets --all-features`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- focused layout, pointer-sharing, query-isolation, session-history, eviction/order/filter, lag, and consumer tests
- controlled Criterion base/candidate comparison across all nine `event_history_producer` cases: no regression above 5%; largest slowdown was SQLite route publication at 3.45%

`cargo test --workspace --all-targets --all-features` completed the real test suites and event-history benchmark, then reached the unchanged harnessless `vpn_query_allocation` benchmark, whose executable requires positional CLI arguments. Its source and Cargo target definition are byte-identical to the base commit.

## Documentation

No changelog or roadmap update yet. This PR proves structural allocation removal; it deliberately does not claim an observed whole-process RSS or cgroup reduction.
