### PR TITLE
Compact peer command channel payloads

### DIFF
--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -315,6 +315,28 @@ pub enum SessionLifecycleNotification {
     },
 }
 
+/// Runtime knobs applied to an established peer without restarting its session.
+#[derive(Debug)]
+pub struct PeerRuntimeConfigUpdate {
+    /// Maximum prefixes accepted before Cease/1 (None = unlimited). Lowering
+    /// this aggregate limit retains its historical next-UPDATE enforcement.
+    pub max_prefixes: Option<u32>,
+    /// Independent IPv4-unicast prefix limit (ADR-0108). Lowering below the
+    /// current count enforces immediately on apply.
+    pub max_prefixes_ipv4: Option<u32>,
+    /// Independent IPv6-unicast prefix limit (ADR-0108). Lowering below the
+    /// current count enforces immediately on apply.
+    pub max_prefixes_ipv6: Option<u32>,
+    /// Stale-route retention after peer restart (seconds).
+    pub gr_stale_routes_time: u64,
+    /// Upper bound on the peer-advertised GR Restart Time.
+    pub gr_peer_restart_time_max: u16,
+    /// Explicit IPv6 next-hop for eBGP (None = derive from socket).
+    pub local_ipv6_nexthop: Option<std::net::Ipv6Addr>,
+    /// Private AS removal mode for outbound `AS_PATH`.
+    pub remove_private_as: crate::config::RemovePrivateAs,
+}
+
 /// Commands sent to a running peer session.
 #[derive(Debug)]
 pub enum PeerCommand {
@@ -352,14 +374,14 @@ pub enum PeerCommand {
     /// Replace the import policy chain for future inbound UPDATE processing.
     UpdateImportPolicy {
         /// New effective import policy chain (`None` = permit-all).
-        policy: Option<PolicyChain>,
+        policy: Option<Box<PolicyChain>>,
         /// Reply channel for success/failure.
         reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
     /// Replace the export policy chain used on future `PeerUp` registration.
     UpdateExportPolicy {
         /// New effective export policy chain (`None` = permit-all).
-        policy: Option<PolicyChain>,
+        policy: Option<Box<PolicyChain>>,
         /// Reply channel for success/failure.
         reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
@@ -371,22 +393,8 @@ pub enum PeerCommand {
     /// `gr_peer_restart_time_max`), so
     /// the swap takes effect on the next evaluation.
     UpdateRuntimeConfig {
-        /// Maximum prefixes accepted before Cease/1 (None = unlimited).
-        max_prefixes: Option<u32>,
-        /// Independent IPv4-unicast prefix limit (ADR-0108). Lowering
-        /// below the current count enforces immediately on apply.
-        max_prefixes_ipv4: Option<u32>,
-        /// Independent IPv6-unicast prefix limit (ADR-0108). Lowering
-        /// below the current count enforces immediately on apply.
-        max_prefixes_ipv6: Option<u32>,
-        /// Stale-route retention after peer restart (seconds).
-        gr_stale_routes_time: u64,
-        /// Upper bound on the peer-advertised GR Restart Time.
-        gr_peer_restart_time_max: u16,
-        /// Explicit IPv6 next-hop for eBGP (None = derive from socket).
-        local_ipv6_nexthop: Option<std::net::Ipv6Addr>,
-        /// Private AS removal mode for outbound `AS_PATH`.
-        remove_private_as: crate::config::RemovePrivateAs,
+        /// Runtime configuration carried out of the inline command envelope.
+        config: Box<PeerRuntimeConfigUpdate>,
         /// Reply channel for success/failure.
         reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
@@ -394,47 +402,47 @@ pub enum PeerCommand {
     /// currently owned connected socket, then advance future active-open
     /// configuration. Current/RNext and existing MKTs are untouched.
     ApplyTcpAoAddOnly {
-        desired: crate::TcpAoSessionGeneration,
+        desired: Box<crate::TcpAoSessionGeneration>,
         reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
     /// Validate a desired add-only generation against this session's current
     /// immutable owner inventory without mutating its socket or configuration.
     PreflightTcpAoAddOnly {
-        desired: crate::TcpAoSessionGeneration,
+        desired: Box<crate::TcpAoSessionGeneration>,
         reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
     /// Validate exact unchanged inventory and explicit owner selection before
     /// any local `RNext` mutation.
     PreflightTcpAoSelection {
-        desired: crate::config::TcpAoSessionSelection,
+        desired: Box<crate::config::TcpAoSessionSelection>,
         reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
     /// Select the already-installed successor as local `RNext` once.
     ApplyTcpAoSelection {
-        desired: crate::config::TcpAoSessionSelection,
+        desired: Box<crate::config::TcpAoSessionSelection>,
         reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
     /// Observe peer-driven successor use once without polling.
     ObserveTcpAoSelection {
-        desired: crate::config::TcpAoSessionSelection,
+        desired: Box<crate::config::TcpAoSessionSelection>,
         reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
     /// Commit declaration-only preferred/deprecated metadata after the whole
     /// cohort has passed observation.
     CommitTcpAoSelection {
-        desired: crate::config::TcpAoSessionSelection,
+        desired: Box<crate::config::TcpAoSessionSelection>,
         reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
     /// Validate an exact current-to-survivor deletion without mutating the
     /// currently owned connected socket.
     PreflightTcpAoDelete {
-        desired: crate::TcpAoSessionDeletion,
+        desired: Box<crate::TcpAoSessionDeletion>,
         reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
     /// Delete deprecated, unselected MKTs from the currently owned connected
     /// socket and advance future active-open configuration.
     ApplyTcpAoDelete {
-        desired: crate::TcpAoSessionDeletion,
+        desired: Box<crate::TcpAoSessionDeletion>,
         reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
     /// Discard this session's connected stream after any sibling may have
@@ -1616,7 +1624,7 @@ impl PeerHandle {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.commands
             .send(PeerCommand::UpdateImportPolicy {
-                policy,
+                policy: policy.map(Box::new),
                 reply: reply_tx,
             })
             .await
@@ -1680,7 +1688,7 @@ impl PeerHandle {
         let (reply_tx, reply_rx) = oneshot::channel();
         commands
             .send(PeerCommand::UpdateImportPolicy {
-                policy,
+                policy: policy.map(Box::new),
                 reply: reply_tx,
             })
             .await
@@ -1773,7 +1781,7 @@ impl PeerHandle {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.commands
             .send(PeerCommand::UpdateExportPolicy {
-                policy,
+                policy: policy.map(Box::new),
                 reply: reply_tx,
             })
             .await
@@ -1841,7 +1849,7 @@ impl PeerHandle {
         let (reply_tx, reply_rx) = oneshot::channel();
         commands
             .send(PeerCommand::UpdateExportPolicy {
-                policy,
+                policy: policy.map(Box::new),
                 reply: reply_tx,
             })
             .await
@@ -1879,13 +1887,15 @@ impl PeerHandle {
             let (reply_tx, reply_rx) = oneshot::channel();
             commands
                 .send(PeerCommand::UpdateRuntimeConfig {
-                    max_prefixes,
-                    max_prefixes_ipv4,
-                    max_prefixes_ipv6,
-                    gr_stale_routes_time,
-                    gr_peer_restart_time_max,
-                    local_ipv6_nexthop,
-                    remove_private_as,
+                    config: Box::new(PeerRuntimeConfigUpdate {
+                        max_prefixes,
+                        max_prefixes_ipv4,
+                        max_prefixes_ipv6,
+                        gr_stale_routes_time,
+                        gr_peer_restart_time_max,
+                        local_ipv6_nexthop,
+                        remove_private_as,
+                    }),
                     reply: reply_tx,
                 })
                 .await
@@ -1919,7 +1929,7 @@ impl PeerHandle {
             let (reply_tx, reply_rx) = oneshot::channel();
             commands
                 .send(PeerCommand::ApplyTcpAoAddOnly {
-                    desired,
+                    desired: Box::new(desired),
                     reply: reply_tx,
                 })
                 .await

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -42,6 +42,7 @@ pub use error::TransportError;
 pub use event_sink::{
     NoopTransportEventSink, OtcDirection, OtcRouteBlockedEvent, TransportEventSink,
 };
+pub use handle::PeerRuntimeConfigUpdate;
 pub use handle::{
     ImportPolicyTermHits, NegotiatedGracefulRestartState, NegotiatedSessionState, PeerCommand,
     PeerCommandError, PeerHandle, PeerSessionState, PeerShutdownError, SessionIdentity,

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -1324,6 +1324,7 @@ impl PeerSession {
                 ControlFlow::Continue(())
             }
             PeerCommand::UpdateImportPolicy { policy, reply } => {
+                let policy = policy.map(|policy| *policy);
                 self.install_import_policy(policy);
                 // ADR-0073: advancing the session-local generation makes
                 // every decision recorded under the prior chain read as
@@ -1411,20 +1412,21 @@ impl PeerSession {
                 ControlFlow::Continue(())
             }
             PeerCommand::UpdateExportPolicy { policy, reply } => {
+                let policy = policy.map(|policy| *policy);
                 self.export_policy = policy;
                 let _ = reply.send(Ok(()));
                 ControlFlow::Continue(())
             }
-            PeerCommand::UpdateRuntimeConfig {
-                max_prefixes,
-                max_prefixes_ipv4,
-                max_prefixes_ipv6,
-                gr_stale_routes_time,
-                gr_peer_restart_time_max,
-                local_ipv6_nexthop,
-                remove_private_as,
-                reply,
-            } => {
+            PeerCommand::UpdateRuntimeConfig { config, reply } => {
+                let crate::handle::PeerRuntimeConfigUpdate {
+                    max_prefixes,
+                    max_prefixes_ipv4,
+                    max_prefixes_ipv6,
+                    gr_stale_routes_time,
+                    gr_peer_restart_time_max,
+                    local_ipv6_nexthop,
+                    remove_private_as,
+                } = *config;
                 // LAN-341 hot-apply: these knobs are read from
                 // `self.config` on every evaluation (see the command's
                 // doc) — no FSM event, no TCP impact. A lowered
@@ -1457,7 +1459,7 @@ impl PeerSession {
             }
             PeerCommand::ApplyTcpAoAddOnly { desired, reply } => {
                 let generation = desired.generation.as_u64();
-                let result = self.apply_tcp_ao_add_only(desired);
+                let result = self.apply_tcp_ao_add_only(*desired);
                 if result.is_ok() {
                     info!(peer = %self.peer_label, generation, "applied TCP-AO add-only generation");
                 }
@@ -1465,18 +1467,18 @@ impl PeerSession {
                 ControlFlow::Continue(())
             }
             PeerCommand::PreflightTcpAoAddOnly { desired, reply } => {
-                let result = self.preflight_tcp_ao_add_only(&desired);
+                let result = self.preflight_tcp_ao_add_only(desired.as_ref());
                 let _ = reply.send(result);
                 ControlFlow::Continue(())
             }
             PeerCommand::PreflightTcpAoSelection { desired, reply } => {
-                let result = self.preflight_tcp_ao_selection(&desired);
+                let result = self.preflight_tcp_ao_selection(desired.as_ref());
                 let _ = reply.send(result);
                 ControlFlow::Continue(())
             }
             PeerCommand::ApplyTcpAoSelection { desired, reply } => {
                 let generation = desired.generation.as_u64();
-                let result = self.apply_tcp_ao_selection(desired);
+                let result = self.apply_tcp_ao_selection(*desired);
                 if result.is_ok() {
                     info!(peer = %self.peer_label, generation, "selected TCP-AO successor RNext");
                 }
@@ -1484,13 +1486,13 @@ impl PeerSession {
                 ControlFlow::Continue(())
             }
             PeerCommand::ObserveTcpAoSelection { desired, reply } => {
-                let result = self.observe_tcp_ao_selection(&desired);
+                let result = self.observe_tcp_ao_selection(desired.as_ref());
                 let _ = reply.send(result);
                 ControlFlow::Continue(())
             }
             PeerCommand::CommitTcpAoSelection { desired, reply } => {
                 let generation = desired.generation.as_u64();
-                let result = self.commit_tcp_ao_selection(&desired);
+                let result = self.commit_tcp_ao_selection(desired.as_ref());
                 if result.is_ok() {
                     info!(peer = %self.peer_label, generation, "committed TCP-AO selection metadata");
                 }
@@ -1498,13 +1500,13 @@ impl PeerSession {
                 ControlFlow::Continue(())
             }
             PeerCommand::PreflightTcpAoDelete { desired, reply } => {
-                let result = self.preflight_tcp_ao_delete(&desired);
+                let result = self.preflight_tcp_ao_delete(desired.as_ref());
                 let _ = reply.send(result);
                 ControlFlow::Continue(())
             }
             PeerCommand::ApplyTcpAoDelete { desired, reply } => {
                 let generation = desired.generation.as_u64();
-                let result = self.apply_tcp_ao_delete(&desired);
+                let result = self.apply_tcp_ao_delete(desired.as_ref());
                 if result.is_ok() {
                     info!(peer = %self.peer_label, generation, "applied TCP-AO deletion generation");
                 }

--- a/crates/transport/src/session/tests/denied_replacements.rs
+++ b/crates/transport/src/session/tests/denied_replacements.rs
@@ -45,7 +45,7 @@ async fn denied_classic_replacement_withdraws_exact_route_and_remains_explainabl
     let (reply_tx, reply_rx) = oneshot::channel();
     let flow = session
         .handle_command(PeerCommand::UpdateImportPolicy {
-            policy: Some(deny_chain),
+            policy: Some(Box::new(deny_chain)),
             reply: reply_tx,
         })
         .await;
@@ -586,7 +586,7 @@ async fn denied_replacement_is_removed_before_eorr_and_cannot_survive_gr() {
     assert_eq!(
         session
             .handle_command(PeerCommand::UpdateImportPolicy {
-                policy: Some(deny_policy),
+                policy: Some(Box::new(deny_policy)),
                 reply: reply_tx,
             })
             .await,

--- a/crates/transport/src/session/tests/exact_export.rs
+++ b/crates/transport/src/session/tests/exact_export.rs
@@ -348,13 +348,15 @@ async fn export_profile_generation_changes_once_per_wire_runtime_mutation() {
         assert_eq!(
             session
                 .handle_command(PeerCommand::UpdateRuntimeConfig {
-                    max_prefixes: Some(123),
-                    max_prefixes_ipv4: None,
-                    max_prefixes_ipv6: None,
-                    gr_stale_routes_time: 999,
-                    gr_peer_restart_time_max: 333,
-                    local_ipv6_nexthop,
-                    remove_private_as,
+                    config: Box::new(crate::handle::PeerRuntimeConfigUpdate {
+                        max_prefixes: Some(123),
+                        max_prefixes_ipv4: None,
+                        max_prefixes_ipv6: None,
+                        gr_stale_routes_time: 999,
+                        gr_peer_restart_time_max: 333,
+                        local_ipv6_nexthop,
+                        remove_private_as,
+                    }),
                     reply,
                 })
                 .await,

--- a/crates/transport/src/session/tests/import_policy.rs
+++ b/crates/transport/src/session/tests/import_policy.rs
@@ -611,7 +611,7 @@ async fn query_import_policy_term_hits_snapshots_without_counting() {
         let (reply_tx, reply_rx) = oneshot::channel();
         let _ = session
             .handle_command(PeerCommand::UpdateImportPolicy {
-                policy: Some(chain),
+                policy: Some(Box::new(chain)),
                 reply: reply_tx,
             })
             .await;
@@ -894,7 +894,7 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
     let (reply_tx, reply_rx) = oneshot::channel();
     let _ = session
         .handle_command(PeerCommand::UpdateImportPolicy {
-            policy: Some(chain),
+            policy: Some(Box::new(chain)),
             reply: reply_tx,
         })
         .await;

--- a/crates/transport/src/session/tests/max_prefix.rs
+++ b/crates/transport/src/session/tests/max_prefix.rs
@@ -230,13 +230,15 @@ async fn max_prefix_capacity_metrics_follow_updates_and_runtime_limits() {
     assert_eq!(
         session
             .handle_command(PeerCommand::UpdateRuntimeConfig {
-                max_prefixes: None,
-                max_prefixes_ipv4: None,
-                max_prefixes_ipv6: None,
-                gr_stale_routes_time: session.config.gr_stale_routes_time,
-                gr_peer_restart_time_max: session.config.gr_peer_restart_time_max,
-                local_ipv6_nexthop: session.config.local_ipv6_nexthop,
-                remove_private_as: session.config.remove_private_as,
+                config: Box::new(crate::handle::PeerRuntimeConfigUpdate {
+                    max_prefixes: None,
+                    max_prefixes_ipv4: None,
+                    max_prefixes_ipv6: None,
+                    gr_stale_routes_time: session.config.gr_stale_routes_time,
+                    gr_peer_restart_time_max: session.config.gr_peer_restart_time_max,
+                    local_ipv6_nexthop: session.config.local_ipv6_nexthop,
+                    remove_private_as: session.config.remove_private_as,
+                }),
                 reply,
             })
             .await,
@@ -824,13 +826,15 @@ async fn runtime_lowering_per_family_limit_enforces_immediately() {
     assert_eq!(
         session
             .handle_command(PeerCommand::UpdateRuntimeConfig {
-                max_prefixes: None,
-                max_prefixes_ipv4: Some(1),
-                max_prefixes_ipv6: None,
-                gr_stale_routes_time: 360,
-                gr_peer_restart_time_max: 4095,
-                local_ipv6_nexthop: None,
-                remove_private_as: RemovePrivateAs::Disabled,
+                config: Box::new(crate::handle::PeerRuntimeConfigUpdate {
+                    max_prefixes: None,
+                    max_prefixes_ipv4: Some(1),
+                    max_prefixes_ipv6: None,
+                    gr_stale_routes_time: 360,
+                    gr_peer_restart_time_max: 4095,
+                    local_ipv6_nexthop: None,
+                    remove_private_as: RemovePrivateAs::Disabled,
+                }),
                 reply,
             })
             .await,
@@ -872,13 +876,15 @@ async fn runtime_lowering_aggregate_limit_keeps_next_update_semantics() {
     assert_eq!(
         session
             .handle_command(PeerCommand::UpdateRuntimeConfig {
-                max_prefixes: Some(1),
-                max_prefixes_ipv4: None,
-                max_prefixes_ipv6: None,
-                gr_stale_routes_time: 360,
-                gr_peer_restart_time_max: 4095,
-                local_ipv6_nexthop: None,
-                remove_private_as: RemovePrivateAs::Disabled,
+                config: Box::new(crate::handle::PeerRuntimeConfigUpdate {
+                    max_prefixes: Some(1),
+                    max_prefixes_ipv4: None,
+                    max_prefixes_ipv6: None,
+                    gr_stale_routes_time: 360,
+                    gr_peer_restart_time_max: 4095,
+                    local_ipv6_nexthop: None,
+                    remove_private_as: RemovePrivateAs::Disabled,
+                }),
                 reply,
             })
             .await,

--- a/src/peer_manager/rotation.rs
+++ b/src/peer_manager/rotation.rs
@@ -290,7 +290,10 @@ async fn apply_to_session(
     let (reply, response) = oneshot::channel();
     tokio::time::timeout(
         PEER_LIFECYCLE_COMMAND_TIMEOUT,
-        commands.send(PeerCommand::ApplyTcpAoAddOnly { desired, reply }),
+        commands.send(PeerCommand::ApplyTcpAoAddOnly {
+            desired: Box::new(desired),
+            reply,
+        }),
     )
     .await
     .map_err(|_| SessionApplyFailure::before_mutation("TCP-AO session command delivery timed out"))?
@@ -398,7 +401,10 @@ async fn preflight_session(
     let (reply, response) = oneshot::channel();
     tokio::time::timeout(
         PEER_LIFECYCLE_COMMAND_TIMEOUT,
-        commands.send(PeerCommand::PreflightTcpAoAddOnly { desired, reply }),
+        commands.send(PeerCommand::PreflightTcpAoAddOnly {
+            desired: Box::new(desired),
+            reply,
+        }),
     )
     .await
     .map_err(|_| "TCP-AO session preflight delivery timed out".to_string())?
@@ -417,7 +423,10 @@ async fn preflight_selection_session(
     let (reply, response) = oneshot::channel();
     tokio::time::timeout(
         PEER_LIFECYCLE_COMMAND_TIMEOUT,
-        commands.send(PeerCommand::PreflightTcpAoSelection { desired, reply }),
+        commands.send(PeerCommand::PreflightTcpAoSelection {
+            desired: Box::new(desired),
+            reply,
+        }),
     )
     .await
     .map_err(|_| "TCP-AO selection preflight delivery timed out".to_string())?
@@ -436,7 +445,10 @@ async fn apply_selection_session(
     let (reply, response) = oneshot::channel();
     tokio::time::timeout(
         PEER_LIFECYCLE_COMMAND_TIMEOUT,
-        commands.send(PeerCommand::ApplyTcpAoSelection { desired, reply }),
+        commands.send(PeerCommand::ApplyTcpAoSelection {
+            desired: Box::new(desired),
+            reply,
+        }),
     )
     .await
     .map_err(|_| SessionApplyFailure::before_mutation("TCP-AO selection delivery timed out"))?
@@ -472,7 +484,10 @@ async fn observe_selection_session(
     let (reply, response) = oneshot::channel();
     tokio::time::timeout(
         PEER_LIFECYCLE_COMMAND_TIMEOUT,
-        commands.send(PeerCommand::ObserveTcpAoSelection { desired, reply }),
+        commands.send(PeerCommand::ObserveTcpAoSelection {
+            desired: Box::new(desired),
+            reply,
+        }),
     )
     .await
     .map_err(|_| "TCP-AO selection observation delivery timed out".to_string())?
@@ -497,7 +512,10 @@ async fn commit_selection_session(
     let (reply, response) = oneshot::channel();
     tokio::time::timeout(
         PEER_LIFECYCLE_COMMAND_TIMEOUT,
-        commands.send(PeerCommand::CommitTcpAoSelection { desired, reply }),
+        commands.send(PeerCommand::CommitTcpAoSelection {
+            desired: Box::new(desired),
+            reply,
+        }),
     )
     .await
     .map_err(|_| "TCP-AO selection metadata commit delivery timed out".to_string())?
@@ -516,7 +534,10 @@ async fn preflight_delete_session(
     let (reply, response) = oneshot::channel();
     tokio::time::timeout(
         PEER_LIFECYCLE_COMMAND_TIMEOUT,
-        commands.send(PeerCommand::PreflightTcpAoDelete { desired, reply }),
+        commands.send(PeerCommand::PreflightTcpAoDelete {
+            desired: Box::new(desired),
+            reply,
+        }),
     )
     .await
     .map_err(|_| "TCP-AO deletion preflight delivery timed out".to_string())?
@@ -535,7 +556,10 @@ async fn apply_delete_session(
     let (reply, response) = oneshot::channel();
     tokio::time::timeout(
         PEER_LIFECYCLE_COMMAND_TIMEOUT,
-        commands.send(PeerCommand::ApplyTcpAoDelete { desired, reply }),
+        commands.send(PeerCommand::ApplyTcpAoDelete {
+            desired: Box::new(desired),
+            reply,
+        }),
     )
     .await
     .map_err(|_| SessionApplyFailure::before_mutation("TCP-AO deletion delivery timed out"))?

--- a/src/peer_manager/tests/cohort_handoff.rs
+++ b/src/peer_manager/tests/cohort_handoff.rs
@@ -49,7 +49,7 @@ fn import_tolerant_cohort_test_session_with_states(
             match command {
                 PeerCommand::UpdateImportPolicy { policy, reply } => {
                     counters.import_installs.fetch_add(1, Ordering::SeqCst);
-                    *counters.live_import.lock().unwrap() = policy;
+                    *counters.live_import.lock().unwrap() = policy.map(|policy| *policy);
                     let _ = reply.send(Ok(()));
                 }
                 PeerCommand::UpdateExportPolicy { reply, .. } => {

--- a/src/peer_manager/tests/export_cohorts.rs
+++ b/src/peer_manager/tests/export_cohorts.rs
@@ -21,7 +21,7 @@ fn import_ack_loss_policy_handle(
                         reply.send(policy_test_peer_state(peer_addr, SessionState::Established));
                 }
                 PeerCommand::UpdateImportPolicy { policy, reply } => {
-                    *live_import.lock().unwrap() = policy;
+                    *live_import.lock().unwrap() = policy.map(|policy| *policy);
                     import_installs.fetch_add(1, Ordering::SeqCst);
                     if first_import.swap(false, Ordering::SeqCst) {
                         drop(reply);

--- a/src/peer_manager/tests/inbound_admission.rs
+++ b/src/peer_manager/tests/inbound_admission.rs
@@ -397,7 +397,10 @@ async fn fresh_dynamic_tcp_ao_inbound_seeds_selected_owner_keyring_for_manager_a
     };
     let (reply, response) = oneshot::channel();
     commands
-        .send(rustbgpd_transport::PeerCommand::PreflightTcpAoSelection { desired, reply })
+        .send(rustbgpd_transport::PeerCommand::PreflightTcpAoSelection {
+            desired: Box::new(desired),
+            reply,
+        })
         .await
         .unwrap();
     let error = tokio::time::timeout(Duration::from_secs(1), response)

--- a/src/peer_manager/tests/mod.rs
+++ b/src/peer_manager/tests/mod.rs
@@ -432,12 +432,8 @@ fn recording_runtime_config_handle() -> (PeerHandle, mpsc::UnboundedReceiver<u16
     let task = tokio::spawn(async move {
         while let Some(command) = command_rx.recv().await {
             match command {
-                PeerCommand::UpdateRuntimeConfig {
-                    gr_peer_restart_time_max,
-                    reply,
-                    ..
-                } => {
-                    let _ = seen_tx.send(gr_peer_restart_time_max);
+                PeerCommand::UpdateRuntimeConfig { config, reply } => {
+                    let _ = seen_tx.send(config.gr_peer_restart_time_max);
                     let _ = reply.send(Ok(()));
                 }
                 PeerCommand::Shutdown => break,


### PR DESCRIPTION
## Summary

- reduce `PeerCommand` from 120 bytes to 40 bytes by boxing only rare policy, runtime, and TCP-AO payloads
- reduce the always-present command channel allocation from 4,384 to 1,824 bytes per peer, saving 2,560 bytes per session
- preserve command names, replies, FIFO ordering, channel capacity, cancellation, and timeout behavior

The heavy commands now perform one payload allocation. Common lifecycle, query, refresh, collision, and explain commands remain allocation-free. This intentionally changes the Rust source field types of several `PeerCommand` variants; `rustbgpd-transport` is not published, and the new runtime payload type is re-exported coherently.

## Validation

- `cargo check --locked --workspace --all-targets --all-features`
- strict workspace Clippy with all targets and features
- warning-denied workspace documentation build
- transport tests: 508 passed, 3 kernel-only ignored
- peer-manager tests: 326 passed
- allocation/layout proof: command 120 -> 40 bytes; channel 4,384 -> 1,824 bytes; common commands allocate zero; all 11 heavy forms allocate exactly once
- paired release benchmark, 10 AB/BA pairs per case: every 95% CI upper bound was below the strict +2% regression ceiling