### PR TITLE
Document independent format/version namespaces and settle two doc drifts

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1,9 +1,11 @@
 //! rustbgpd-api — gRPC API server
 //!
-//! Tonic bindings for the rustbgpd services:
-//! `GlobalService`, `NeighborService`, `PolicyService`, `PeerGroupService`,
-//! `RibService`, `EventService`, `InjectionService`, `ControlService`,
-//! `EvpnService`.
+//! Tonic bindings for the rustbgpd services: `GlobalService`,
+//! `ConfigService`, `NeighborService`, `PolicyService`, `PeerGroupService`,
+//! `RibService`, `BfdService`, `EventService`, `InjectionService`,
+//! `ControlService`, `EvpnService`, and the `OpenConfig` `gnmi.gNMI` service.
+//! The authoritative roster is the set of `add_service` registrations in
+//! [`server`].
 
 #![deny(unsafe_code)]
 #![deny(clippy::all)]

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -27,13 +27,16 @@ does not continuously poll the RIB.
 
 ```bash
 rbgp config diff config.toml
-rbgp config plan config.toml
+# The runtime snapshot token printed by plan is opaque — capture it and pass
+# it back verbatim:
+RUNTIME_SNAPSHOT_TOKEN="$(rbgp --json config plan config.toml \
+  | jq -r .runtime_snapshot_token)"
 rbgp config apply config.toml \
-  --expected-runtime-snapshot-token kv1:...
+  --expected-runtime-snapshot-token "$RUNTIME_SNAPSHOT_TOKEN"
 
 # Confirmed apply: rolls back unless confirmed before the timeout.
 rbgp config apply config.toml \
-  --expected-runtime-snapshot-token kv1:... \
+  --expected-runtime-snapshot-token "$RUNTIME_SNAPSHOT_TOKEN" \
   --confirm-id deploy-123 \
   --confirm-timeout 120
 rbgp config status

--- a/docs/API.md
+++ b/docs/API.md
@@ -649,7 +649,7 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   -d @ localhost:50051 rustbgpd.v1.ConfigService/ApplyConfigTransaction <<'JSON'
 {
   "candidate_toml": "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\nlisten_port = 179\n\n[[fib_tables]]\nname = \"edge\"\ntable_id = 1000\nmetric = 200\n",
-  "expected_runtime_snapshot_token": "kv1:...",
+  "expected_runtime_snapshot_token": "<runtime-snapshot-token-from-plan>",
   "client_request_id": "deploy-2026-06-03-001",
   "comment": "roll edge FIB table definition"
 }
@@ -663,7 +663,7 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   -d @ localhost:50051 rustbgpd.v1.ConfigService/ApplyConfigTransaction <<'JSON'
 {
   "candidate_toml": "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\nlisten_port = 179\n\n[[neighbors]]\naddress = \"192.0.2.10\"\nremote_asn = 65010\nhold_time = 45\n",
-  "expected_runtime_snapshot_token": "kv1:...",
+  "expected_runtime_snapshot_token": "<runtime-snapshot-token-from-plan>",
   "client_request_id": "deploy-2026-06-03-002",
   "comment": "adjust neighbor hold timer"
 }
@@ -677,7 +677,7 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   -d @ localhost:50051 rustbgpd.v1.ConfigService/ApplyConfigTransaction <<'JSON'
 {
   "candidate_toml": "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\nlisten_port = 179\n\n[[neighbors]]\naddress = \"192.0.2.10\"\nremote_asn = 65010\nhold_time = 45\n",
-  "expected_runtime_snapshot_token": "kv1:...",
+  "expected_runtime_snapshot_token": "<runtime-snapshot-token-from-plan>",
   "client_request_id": "deploy-2026-06-03-003",
   "comment": "safe neighbor timer deploy",
   "confirm_id": "deploy-2026-06-03-003",
@@ -759,11 +759,14 @@ CLI equivalent:
 ```bash
 rbgp config diff /tmp/new-config.toml
 rbgp --json config diff /tmp/new-config.toml
-rbgp config plan /tmp/new-config.toml
+# The runtime snapshot token printed by plan is opaque — capture it and pass
+# it back verbatim:
+RUNTIME_SNAPSHOT_TOKEN="$(rbgp --json config plan /tmp/new-config.toml \
+  | jq -r .runtime_snapshot_token)"
 rbgp config apply /tmp/new-config.toml \
-  --expected-runtime-snapshot-token kv1:...
+  --expected-runtime-snapshot-token "$RUNTIME_SNAPSHOT_TOKEN"
 rbgp config apply /tmp/new-config.toml \
-  --expected-runtime-snapshot-token kv1:... \
+  --expected-runtime-snapshot-token "$RUNTIME_SNAPSHOT_TOKEN" \
   --client-request-id deploy-2026-06-03-003 \
   --confirm-id deploy-2026-06-03-003 \
   --confirm-timeout 120

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -197,12 +197,15 @@ rbgp config plan /tmp/new-config.toml
 rbgp --json config plan /tmp/new-config.toml
 
 # Apply can plan the same candidate automatically, or consume the exact token
-# printed by `config plan` when a separate review/approval step is required:
+# printed by `config plan` when a separate review/approval step is required.
+# The runtime snapshot token is opaque — capture it and pass it back verbatim:
+RUNTIME_SNAPSHOT_TOKEN="$(rbgp --json config plan /tmp/new-config.toml \
+  | jq -r .runtime_snapshot_token)"
 rbgp config apply /tmp/new-config.toml \
-  --expected-runtime-snapshot-token kv1:...
+  --expected-runtime-snapshot-token "$RUNTIME_SNAPSHOT_TOKEN"
 rbgp config apply /tmp/new-config.toml \
   --plan-token 550e8400-e29b-41d4-a716-446655440000 \
-  --expected-runtime-snapshot-token kv1:...
+  --expected-runtime-snapshot-token "$RUNTIME_SNAPSHOT_TOKEN"
 ```
 
 `rbgp config effective` downloads this byte-exact full document with a finite
@@ -231,7 +234,7 @@ same handle is confirmed:
 ```bash
 rbgp config apply /tmp/new-config.toml \
   --plan-token 550e8400-e29b-41d4-a716-446655440000 \
-  --expected-runtime-snapshot-token kv1:... \
+  --expected-runtime-snapshot-token "$RUNTIME_SNAPSHOT_TOKEN" \
   --confirm-id deploy-20260605-1 \
   --confirm-timeout 120
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ Start here if you have never run the daemon.
 | [API.md](API.md) | gRPC API reference with examples for every RPC |
 | [grpc-method-inventory.md](grpc-method-inventory.md) | Authorization tier of every gRPC method (machine-readable twin: [grpc-method-inventory.json](grpc-method-inventory.json)) |
 | [rpol-language.md](rpol-language.md) | The `.rpol` typed policy language, ADR-0096 |
+| [format-version-namespaces.md](format-version-namespaces.md) | Map of the independent format/version namespaces (commit-confirm journal, config history, snapshot tokens, stream frames, support bundle, FIB owned state, GR marker) |
 | [OPERATIONS.md](OPERATIONS.md) | Production reference: reload semantics, metrics catalog, failure modes, authorization audit (contains runbook-style debugging sections) |
 | [GNMI.md](GNMI.md) | The supported gNMI / OpenConfig operational-state subset |
 | [EMBEDDING.md](EMBEDDING.md) | The crate map for using rustbgpd's layers as Rust libraries |

--- a/docs/adr/0127-config-transaction-settlement-watchdog.md
+++ b/docs/adr/0127-config-transaction-settlement-watchdog.md
@@ -3,6 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-08-11
 **Accepted:** 2026-08-13
+**Amended:** 2026-08-14 (Consequences: receipt-backed fail-stop session cost)
 
 ## Context
 
@@ -408,7 +409,20 @@ and Interop runs also completed successfully.
   The shipped unit and deployment documentation satisfy this requirement.
 - The bound is deliberately fail-stop, so BGP sessions can be interrupted after
   a severe control-plane ambiguity. Supervision and graceful-restart behavior
-  mitigate but do not erase that operational cost.
+  mitigate but do not erase that operational cost. *Amendment (2026-08-14):*
+  the GR mitigation is exactly as strong as the negotiated per-peer capability
+  shape, and the M85 receipt ([docs/INTEROP.md](../INTEROP.md)) measured both
+  shapes against BIRD 2: a peer with a real two-sided GR capability
+  (`graceful restart on`, address families listed in the capability) has its
+  routes held stale-preserved through a restart — zero withdraws toward
+  survivors until re-establish plus the EoR sweep — while BIRD's default
+  `graceful restart aware` still sends the GR capability but with restart
+  time 0 and no address families, producing immediate withdraws with nothing
+  preserved. Independently, the [ROADMAP](../../ROADMAP.md) GR row records
+  that optional bounded shutdown checkpoint publication shipped "without boot
+  restore/adoption": the restarted daemon reconverges its full RIB from peers
+  rather than restoring a checkpoint, so even a fully mitigated fail-stop
+  pays complete reconvergence.
 - Healthy applies retain cancellation shielding and one-candidate admission.
   They pay one operation record, one watchdog registration, phase updates, and
   bounded telemetry; the data-plane executor path gains no per-command timer.

--- a/docs/cookbook/rr-pair-day2.md
+++ b/docs/cookbook/rr-pair-day2.md
@@ -91,9 +91,12 @@ use a config transaction with a confirm timer instead of SIGHUP:
 
 ```bash
 rbgp config plan /etc/rustbgpd/candidate.toml
-# plan prints the runtime snapshot token; apply requires it:
+# plan prints the runtime snapshot token; it is opaque — capture it and pass
+# it back verbatim on apply:
+RUNTIME_SNAPSHOT_TOKEN="$(rbgp --json config plan /etc/rustbgpd/candidate.toml \
+  | jq -r .runtime_snapshot_token)"
 rbgp config apply /etc/rustbgpd/candidate.toml \
-  --expected-runtime-snapshot-token kv1:... \
+  --expected-runtime-snapshot-token "$RUNTIME_SNAPSHOT_TOKEN" \
   --confirm-id rr1-edit-$(date -u +%Y%m%d-%H%M) \
   --confirm-timeout 120
 

--- a/docs/format-version-namespaces.md
+++ b/docs/format-version-namespaces.md
@@ -1,0 +1,41 @@
+# Format and version namespaces
+
+rustbgpd does not have one global "v1/v2/v3" format lineage. Each durable or
+machine-readable surface below owns an independent version namespace with its
+own compatibility rules. None of these numbers is comparable with the product
+SemVer version, the protobuf package `rustbgpd.v1`, the frozen v1
+stable-surface inventory ([v1-stable-surface.json](v1-stable-surface.json)),
+or one another.
+
+| Surface | Current marker | What the number means | Compatibility owner |
+|---------|----------------|-----------------------|---------------------|
+| Commit-confirm authority | v3 (`VERSION = 3`, [`src/confirm_journal/v3.rs`](../src/confirm_journal/v3.rs)) | Current durable pending-authority format. A retired journal (locator-free or v2) refuses boot with the artifact untouched instead of being decoded. | [ADR-0076 amendment](adr/0076-config-transaction-model.md), [ADR-0122](adr/0122-compatibility-debt-inventory.md) rows D1/D3 |
+| Config history | v2 (`VERSION = 2`, [`src/config_history/v2.rs`](../src/config_history/v2.rs)) | Current JSON history codec. Retired TOML history is ignored and retained. | [ADR-0122](adr/0122-compatibility-debt-inventory.md) row D1 |
+| Runtime snapshot token | `kv1:` / `kv2:` prefix ([`src/config/mod.rs`](../src/config/mod.rs)) | Keyed, process-local change-detector tokens minted by one algorithm. The prefix discriminates whether live runtime context is bound into the preimage — `kv1:` config only, `kv2:` config plus the live update-group snapshot identity — not successive format generations. Production planning always binds context, so live tokens carry `kv2:`; callers compare tokens opaquely and re-plan after a daemon restart. | [ADR-0076](adr/0076-config-transaction-model.md) |
+| Streamed config frame | `FRAME_VERSION = 1` ([`crates/api/src/config_service/stream.rs`](../crates/api/src/config_service/stream.rs)) | Exact version of the streamed Plan/Apply ingress frames. Independent of unary API versioning and outside the initial v1 frozen inventory (ADR-0125 DR6). | [ADR-0125](adr/0125-v1-stability-contract.md) |
+| Support bundle | manifest `format: 2` (`support-bundle-manifest/2`) | Frozen machine-readable doctor bundle layout with additive-fields-only evolution. Not a config-transaction format. | [v1-stable-surface.json](v1-stable-surface.json) |
+| General FIB owned state | v5 current, loads v1–v5 ([`src/fib_runtime.rs`](../src/fib_runtime.rs)) | Crash-restart ownership receipt: v1 single next-hop scalar, v2 equal-cost set, v3 per-next-hop weights, v4/v5 link-local ifindexes (landed together; no standalone v4 shipped). One serde model plus an on-load upgrader, not parallel readers. | [ADR-0066](adr/0066-unicast-multipath-ecmp-fib.md), [ADR-0068](adr/0068-weighted-multipath.md), [ADR-0069](adr/0069-bgp-unnumbered.md), [ADR-0079](adr/0079-kernel-state-crash-restart-reconciliation.md) |
+| GR restart marker | v3 current, accepts v1–v3 (`gr-restart.toml`, [`src/main.rs`](../src/main.rs)) | Planned-restart marker: v1 carries the wall-clock expiry only, v2 binds the warm-checkpoint generation, v3 adds the restart clock domain (boot id, time namespace, boottime offsets and boottime expiry). The writer emits v3 and degrades to v2/v1 when clock sampling fails; the validator accepts each version only with its exact field set. | [ADR-0040](adr/0040-gr-restarting-speaker.md), [ADR-0104](adr/0104-shutdown-warm-checkpoint-publication.md) |
+
+## Why the compatibility behaviors differ
+
+The namespaces deliberately do not share one policy:
+
+- **Refuse retired authority** (commit-confirm journal): when interpreting an
+  old format could corrupt recovery, boot refuses with the artifact untouched
+  rather than guessing.
+- **Load and upgrade** (FIB owned state): when refusal would orphan live
+  kernel state — misclassifying rustbgpd's own programmed routes as foreign —
+  old receipts are upgraded on load, and only versions newer than the build
+  understands are quarantined.
+- **Opaque equality values** (runtime snapshot tokens): tokens are keyed and
+  process-local; the only supported operation is passing one back verbatim
+  for equality comparison. Never parse a token or depend on its prefix, and
+  re-plan after a daemon restart.
+- **Additive frozen formats** (support bundle, streamed frame): frozen public
+  machine formats evolve additively under the stable-surface inventory.
+
+Changing a reader floor, a token algorithm, the frozen bundle format, or the
+streamed frame version is a separately reviewed behavior change owned by the
+ADR or machine inventory linked above. This page records the map; it creates
+no new compatibility policy.


### PR DESCRIPTION
Docs-only batch, three items, every claim re-verified against HEAD.

## Format/version namespace map ([LAN-1000](https://linear.app/lance0/issue/LAN-1000/document-independent-format-and-version-namespaces))

New `docs/format-version-namespaces.md` (indexed from `docs/README.md`): the repository has no global v1/v2/v3 lineage, only independent per-surface namespaces. The map covers commit-confirm authority v3, config history v2, `kv1:`/`kv2:` runtime snapshot tokens, streamed config `FRAME_VERSION = 1`, support-bundle manifest format 2, FIB owned-state v1–v5, and the GR restart marker v1–v3 — each linked to its source and owning ADR or machine inventory, with the four distinct compatibility behaviors (refuse retired authority, load-and-upgrade, opaque equality tokens, additive frozen formats) spelled out.

Two points where the page follows source rather than the ticket text:

- `kv1:`/`kv2:` are one algorithm whose prefix discriminates whether live runtime context is bound into the preimage (`token_for_canonical_body` branches on `context.is_empty()`), not successive generations. Production planning always binds the update-group snapshot identity (the empty-context `token()` wrapper is `#[cfg(test)]`), so live tokens carry `kv2:`.
- The GR restart marker namespace is v1–v3 at HEAD: v1 wall-clock expiry, v2 checkpoint-generation binding, v3 the restart clock domain; the writer emits v3 and degrades when clock sampling fails.

All 11 stale literal `kv1:...` example tokens (`docs/API.md` ×5, `docs/OPERATIONS.md` ×3, `crates/cli/README.md` ×2, `docs/cookbook/rr-pair-day2.md` ×1) are replaced with opaque capture-and-pass placeholders (`"$RUNTIME_SNAPSHOT_TOKEN"` captured from `--json config plan | jq -r .runtime_snapshot_token`, verified against `plan_to_json`; JSON examples use `<runtime-snapshot-token-from-plan>`), so examples no longer teach an implementation prefix as a caller contract. No token prefix, reader floor, or runtime behavior changes.

## api crate service roster ([LAN-999](https://linear.app/lance0/issue/LAN-999/doc-drift-api-crate-librs-comment-lists-9-services-code-implements-11))

`crates/api/src/lib.rs` listed 9 services; the `add_service` registration site in `crates/api/src/server.rs` registers 11 native services plus the OpenConfig `gnmi.gNMI` service (`ConfigService` and `BfdService` were missing, as the ticket said). The comment now lists all twelve and names the `server.rs` registrations as the authoritative roster so it cannot silently re-stale.

## ADR-0127 fail-stop cost amendment

The Consequences bullet said only that BGP sessions "can be interrupted". The dated amendment adds the receipt-backed specifics: per the M85 row in `docs/INTEROP.md`, a peer with a real two-sided GR capability (`graceful restart on`, address families listed) has routes held stale-preserved through a restart with zero withdraws toward survivors until re-establish plus the EoR sweep, while BIRD's default `graceful restart aware` still sends the GR capability but with restart time 0 and no address families, producing immediate withdraws; and per the ROADMAP GR row, shutdown checkpoint publication shipped "without boot restore/adoption", so even a fully mitigated fail-stop pays complete RIB reconvergence.

## Gates

- `python3 scripts/check_public_tracker_ids.py` — exit 0 (no tracker IDs in any docs/ file)
- `python3 -m unittest scripts/test_check_public_tracker_ids.py` — exit 0
- `python3 scripts/check-v1-stable-surface.py` — exit 0
- `cargo doc -p rustbgpd-api --no-deps` — exit 0 (intra-doc `[server]` link resolves)
- relative-link existence check over the new/edited pages — all targets resolve
- `git diff --check` — clean; pre-commit fmt + clippy passed

Note: the lib.rs rustdoc edit means this PR touches one `.rs` file, so main CI runs rather than being skipped by paths-ignore.
