### PR TITLE
ci(bench): require two consecutive nightly confirmations to fail

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -17,6 +17,17 @@ name: Criterion Bench Nightly
 # Straddle-zero (min..max or CI), high-stddev, or delta-only rows remain
 # advisory/inconclusive. bgperf2 stays release-time `/bench` only — it is too
 # stateful (Docker, one-at-a-time, shared container names) for unattended runs.
+#
+# TWO-CONSECUTIVE-NIGHTS RULE — on scheduled runs a confident-regression row
+# fails the workflow only when the same row was also confident on the previous
+# nightly. With 53 rows per run on a virtualized VPS, one all-positive row
+# clears the per-row bar by chance roughly nightly (2026-08-12..14 each fired
+# a single different row and the next night contradicted it: rib_pipeline/1000
+# +5.81% then -7.43%; loc_rib_recompute/8 -7.97% then +4.65%), while every
+# real regression this tripwire has caught repeated identically the following
+# night (2026-08-02/03: adj_rib_in_insert/500000 +49.3%/+49.8%,
+# best_path_cmp/equal +3.55%/+4.55%). First-night rows stay advisory in the
+# run summary. workflow_dispatch runs keep single-run verdicts.
 
 on:
   schedule:
@@ -143,14 +154,49 @@ jobs:
             echo "::notice::host lock held by an active soak — skipping nightly bench (advisory, non-gating)"
             exit 0
           fi
-          exit "$rc"
           # require_performance is intentionally NOT set — the VPS CPU is
           # virtualized and exposes no cpufreq governor (see bench.yml).
+          if [ "$GITHUB_EVENT_NAME" != "schedule" ]; then
+            exit "$rc"
+          fi
+          # Two-consecutive-nights rule (see the header comment): rc=1 with a
+          # confident-regression verdict fails the run only when a fired row
+          # also fired on the previous nightly. Streak state lives next to the
+          # host lock on this single pinned runner; a run without confident
+          # rows resets it. Harness errors (no summary, or rc other than 0/1)
+          # propagate untouched.
+          summary="$(find target/bench-compare -name summary.md -print 2>/dev/null | sort | tail -n 1 || true)"
+          if { [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; } || [ -z "$summary" ]; then
+            exit "$rc"
+          fi
+          current="$(grep -m1 '^Confident regression rows:' "$summary" | grep -o '`[^`]*`' | tr -d '`' | sort -u || true)"
+          if [ "$rc" -eq 1 ] && [ -z "$current" ]; then
+            exit "$rc"
+          fi
+          state_file="${HOME}/.local/state/rustbgpd-bench-nightly-confident-rows-${PACKAGE}-${BENCH}.txt"
+          previous=""
+          if [ -f "$state_file" ]; then
+            previous="$(cat "$state_file")"
+          fi
+          mkdir -p "$(dirname "$state_file")"
+          printf '%s' "$current" > "$state_file"
+          if [ "$rc" -eq 0 ]; then
+            exit 0
+          fi
+          confirmed="$(comm -12 <(printf '%s' "$current") <(printf '%s' "$previous") || true)"
+          if [ -n "$confirmed" ]; then
+            echo "::error::confident regression on two consecutive nightly runs: $(echo "$confirmed" | paste -sd' ' -)"
+            exit 1
+          fi
+          echo "unconfirmed=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::confident-regression row(s) not confident on the previous nightly — advisory; the run fails if the same row repeats tomorrow: $(echo "$current" | paste -sd' ' -)"
+          exit 0
 
       - name: Publish summary
         if: always()
         env:
           SOAK_SKIP: ${{ steps.compare.outputs.soak_skip }}
+          UNCONFIRMED: ${{ steps.compare.outputs.unconfirmed }}
         run: |
           set -euo pipefail
           if [ "${SOAK_SKIP:-}" = "true" ]; then
@@ -171,10 +217,20 @@ jobs:
             echo "for confident regressions: enough attempts, \`min..max\` and the"
             echo "last-run 95% CI both entirely above zero, bounded stddev, and"
             echo "\`mean delta\` above the configured threshold. Straddle-zero (range"
-            echo "or CI) and high-stddev rows remain advisory."
+            echo "or CI) and high-stddev rows remain advisory. A scheduled run"
+            echo "fails only when the same row is confident on two consecutive"
+            echo "nightlies."
             echo "See docs/BENCHMARKS.md."
             echo
           } >> "$GITHUB_STEP_SUMMARY"
+          if [ "${UNCONFIRMED:-}" = "true" ]; then
+            {
+              echo "**Advisory:** confident-regression row(s) fired on this run but"
+              echo "were not confident on the previous nightly. The run stays green;"
+              echo "it fails if the same row repeats on the next nightly."
+              echo
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
           summary="$(find target/bench-compare -name summary.md -print 2>/dev/null | sort | tail -n 1 || true)"
           if [ -n "$summary" ]; then
             cat "$summary" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -373,7 +373,12 @@ whose `min..max` straddles zero remain advisory/noise, high-stddev rows remain
 inconclusive, all-positive rows whose last-run 95% CI straddles zero stay
 advisory (`ci-straddles-zero`), and a confirmed row at or above the threshold
 whose last-run 95% CI is entirely above zero makes the workflow fail for human
-review.
+review. On scheduled nightly runs one further filter applies: a confident row
+fails the workflow only when the same row was also confident on the previous
+nightly. With ~53 rows per run on the VPS a single all-positive row clears the
+per-row bar by chance roughly nightly and is contradicted the next night,
+while real regressions repeat identically; first-night rows are surfaced as
+advisory in the run summary instead of failing the run.
 
 **Worked example** — the first multi-attempt comparison on the VPS
 runner (`rib_ops`, `v0.30.0` → `main`, 3 attempts; the span includes


### PR DESCRIPTION
## Diagnosis

Criterion Bench Nightly has failed every scheduled run since 2026-08-12 (31568772740, 31672753541, 31775140314; last green 31462662662 on 08-11).

All three runs resolved the baseline correctly (`Nightly baseline: v0.64.0`) and completed the full ~2h A/B. The `no release tag found` string in `--log-failed` output is only the step's echoed script source inside the `##[group]Run` block, not an emitted error. Each run failed in the compare step on a `--fail-on-regression` verdict — a different single row each night, contradicted by the next night against the same v0.64.0 baseline:

| Row | 08-11 | 08-12 | 08-13 | 08-14 |
|---|---|---|---|---|
| `rib_pipeline/1000` | +0.03% | **+5.81% regression** | -7.43% | +0.22% |
| `adj_rib_in_insert/10000` | +2.55% | +4.00% | **+6.81% regression** | -4.36% |
| `loc_rib_recompute/8` | -0.97% | +0.39% | -7.97% improvement | **+4.65% regression** |

No commit in the 08-11..08-12 window touched the workflow, `bench/`, build configuration, or the measured code paths (`crates/rib` changes: a rustdoc backtick in `bench_support.rs` and a 7-line `policy_transition.rs` change outside the bench paths).

## Root cause

With 53 rows per run on the virtualized VPS, a single all-positive row clears the per-row confidence bar (mean >= 3%, stddev < 10%, min..max above zero, last-attempt propagated CI above zero) by chance roughly nightly. The last-attempt CI only reflects within-attempt sampling, so one systematically noisy quarter hour satisfies it while the between-attempt spread disagrees. By contrast, every real regression the tripwire has caught repeated identically on the following night (08-02/03 vs v0.62.0: `adj_rib_in_insert/500000` +49.3%/+49.8%, `best_path_cmp/equal` +3.55%/+4.55%).

## Fix

On scheduled runs, a confident-regression row fails the workflow only when the same row was also confident on the previous nightly. First-night rows stay green with a `::notice` and a step-summary advisory banner. Streak state lives next to the existing host lock (`~/.local/state/`) on the single pinned runner and resets on any run without confident rows. Harness errors (rc other than 0/1, or no summary) propagate untouched; the soak-lock rc=75 skip is unchanged; `workflow_dispatch` runs keep single-run verdicts. The generic `bench/compare-criterion.sh` verdict rule is untouched, so `bench.yml` manual A/Bs are unaffected.

Applied to the 08-02..08-14 history: the three single-night false fires stay green (none repeated), and all four real 08-02/03 rows still fail (both `adj_rib_in_insert/500000` and `best_path_cmp/equal` were confident on consecutive nights).

## Verification

- Behavioral test of the extracted `run` block against a stubbed harness: 10/10 scenarios pass (first-night advisory, repeat fails, different-row advisory, green resets streak, rc=2 propagates with state untouched, dispatch keeps single-run verdicts, multi-row overlap confirms, soak skip).
- `python3 yaml.safe_load` on the workflow: OK.
- `shellcheck` on the extracted step script: clean.
- No action pins changed.
