### PR TITLE
ci: share verified gobgp fixture archive

### DIFF
--- a/.github/actions/stage-gobgp-artifact/action.yml
+++ b/.github/actions/stage-gobgp-artifact/action.yml
@@ -1,0 +1,22 @@
+name: "Stage verified GoBGP archive"
+description: >-
+  Download the same-run GoBGP release archive, verify its immutable checksum
+  and exact gobgp/gobgpd versions offline, and stage it into the interop
+  image build context.
+runs:
+  using: "composite"
+  steps:
+    - name: Download verified GoBGP archive
+      uses: actions/download-artifact@v8
+      with:
+        name: gobgp-v3.37.0-linux-amd64
+        path: ${{ runner.temp }}/gobgp-artifact
+
+    - name: Stage exact GoBGP archive offline
+      shell: bash
+      run: |
+        set -euo pipefail
+        .github/scripts/install-gobgp.sh \
+          --stage-archive \
+          "$RUNNER_TEMP/gobgp-artifact/gobgp_3.37.0_linux_amd64.tar.gz" \
+          tests/interop/gobgp-archive

--- a/.github/scripts/install-gobgp.sh
+++ b/.github/scripts/install-gobgp.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly GOBGP_VERSION="3.37.0"
+readonly GOBGP_SHA256="e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522"
+readonly GOBGP_ASSET="gobgp_${GOBGP_VERSION}_linux_amd64.tar.gz"
+readonly GOBGP_URL="https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/${GOBGP_ASSET}"
+readonly GOBGP_ATTEMPTS=3
+
+verify_archive() {
+    local sha256=${1:?sha256}
+    local archive=${2:?archive}
+
+    [[ -f "$archive" ]] || return 1
+    if ! printf '%s  %s\n' "$sha256" "$archive" \
+        | sha256sum --check --status; then
+        echo "gobgp archive checksum mismatch: ${archive}" >&2
+        return 1
+    fi
+}
+
+verify_archive_contents() (
+    local sha256=${1:?sha256}
+    local archive=${2:?archive}
+    local work_dir binary reported
+
+    verify_archive "$sha256" "$archive" || return 1
+    work_dir=$(mktemp -d) || return 1
+    trap 'rm -rf -- "$work_dir"' EXIT
+    tar -xzf "$archive" -C "$work_dir" gobgp gobgpd || return 1
+    for binary in gobgp gobgpd; do
+        [[ -f "$work_dir/$binary" ]] || {
+            echo "gobgp archive did not contain ${binary}" >&2
+            return 1
+        }
+        chmod 0755 "$work_dir/$binary"
+        reported=$("$work_dir/$binary" --version 2>&1) || return 1
+        if [[ "$reported" != "${binary} version ${GOBGP_VERSION}" ]]; then
+            echo "unexpected ${binary} version: ${reported}" >&2
+            return 1
+        fi
+    done
+)
+
+stage_archive() (
+    local sha256=${1:?sha256}
+    local archive=${2:?archive}
+    local stage_dir=${3:?stage directory}
+    local staged_target
+
+    # This path is deliberately offline. Only the producer may fetch the
+    # release archive; consumers re-verify the same-run artifact before the
+    # gobgp image build context sees any bytes. The archive itself is staged
+    # (not extracted): Dockerfile.gobgp re-verifies the checksum and both
+    # binary versions inside the build.
+    verify_archive_contents "$sha256" "$archive" || return 1
+    mkdir -p "$stage_dir"
+    staged_target=$(mktemp "${stage_dir}/.${GOBGP_ASSET}.XXXXXX")
+    trap 'rm -f -- "$staged_target"' EXIT
+    install -m 0644 "$archive" "$staged_target"
+    mv -f -- "$staged_target" "${stage_dir}/${GOBGP_ASSET}"
+    printf 'staged verified gobgp %s archive\n' "$GOBGP_VERSION"
+)
+
+download_archive_once() {
+    local url=${1:?url}
+    local destination=${2:?destination}
+
+    curl -fsSL \
+        --connect-timeout 10 \
+        --max-time 120 \
+        --output "$destination" \
+        "$url"
+}
+
+prepare_archive() {
+    local sha256=${1:?sha256}
+    local url=${2:?url}
+    local archive=${3:?archive}
+    local attempt staged_archive
+
+    if verify_archive_contents "$sha256" "$archive" 2>/dev/null; then
+        echo "using verified cached gobgp archive"
+        return 0
+    fi
+    if [[ -e "$archive" ]]; then
+        echo "::warning::discarding invalid cached gobgp archive" >&2
+        rm -f -- "$archive"
+    fi
+
+    mkdir -p "$(dirname "$archive")"
+    for ((attempt = 1; attempt <= GOBGP_ATTEMPTS; attempt++)); do
+        staged_archive=$(mktemp "${archive}.download.XXXXXX")
+        if download_archive_once "$url" "$staged_archive" \
+            && verify_archive_contents "$sha256" "$staged_archive"; then
+            mv -f -- "$staged_archive" "$archive"
+            echo "downloaded and verified gobgp archive"
+            return 0
+        fi
+        rm -f -- "$staged_archive"
+        if ((attempt < GOBGP_ATTEMPTS)); then
+            echo "::warning::gobgp download/verify attempt ${attempt}/${GOBGP_ATTEMPTS} failed; retrying" >&2
+            sleep $((attempt * 5))
+        fi
+    done
+
+    echo "::error::gobgp download/verification failed after ${GOBGP_ATTEMPTS} attempts: ${url}" >&2
+    return 1
+}
+
+fail_self_test() {
+    echo "gobgp installer self-test failed: $*" >&2
+    return 1
+}
+
+self_test() (
+    local fixture_dir source_dir valid_archive valid_checksum wrong_dir wrong_archive
+    local wrong_checksum partial_archive expected_url staged_hash attempts
+
+    fixture_dir=$(mktemp -d)
+    trap 'rm -rf -- "$fixture_dir"' EXIT
+    [[ "$GOBGP_VERSION" == "3.37.0" ]] || fail_self_test "version pin drifted"
+    [[ "$GOBGP_SHA256" == "e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522" ]] \
+        || fail_self_test "checksum pin drifted"
+    [[ "$GOBGP_ASSET" == "gobgp_3.37.0_linux_amd64.tar.gz" ]] \
+        || fail_self_test "archive name drifted"
+    printf -v expected_url '%s%s' \
+        'https://github.com/osrg/gobgp/releases' \
+        '/download/v3.37.0/gobgp_3.37.0_linux_amd64.tar.gz'
+    [[ "$GOBGP_URL" == "$expected_url" ]] \
+        || fail_self_test "release URL drifted"
+    [[ "$GOBGP_ATTEMPTS" -eq 3 ]] || fail_self_test "retry bound drifted"
+
+    source_dir="$fixture_dir/source"
+    mkdir -p "$source_dir"
+    cat >"$source_dir/gobgp" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' 'gobgp version 3.37.0'
+EOF
+    cat >"$source_dir/gobgpd" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' 'gobgpd version 3.37.0'
+EOF
+    chmod +x "$source_dir/gobgp" "$source_dir/gobgpd"
+    valid_archive="$fixture_dir/valid.tar.gz"
+    tar -czf "$valid_archive" -C "$source_dir" gobgp gobgpd
+    valid_checksum=$(sha256sum "$valid_archive" | awk '{print $1}')
+
+    stage_archive "$valid_checksum" "$valid_archive" \
+        "$fixture_dir/stage" >/dev/null
+    [[ -f "$fixture_dir/stage/$GOBGP_ASSET" ]] \
+        || fail_self_test "verified archive was not staged"
+    cmp -s "$valid_archive" "$fixture_dir/stage/$GOBGP_ASSET" \
+        || fail_self_test "staged archive bytes drifted"
+    staged_hash=$(sha256sum "$fixture_dir/stage/$GOBGP_ASSET" | awk '{print $1}')
+
+    if stage_archive "$GOBGP_SHA256" "$valid_archive" \
+        "$fixture_dir/stage" 2>/dev/null; then
+        fail_self_test "wrong checksum was accepted"
+    fi
+    [[ "$(sha256sum "$fixture_dir/stage/$GOBGP_ASSET" | awk '{print $1}')" == "$staged_hash" ]] \
+        || fail_self_test "checksum failure replaced the staged target"
+    head -c 12 "$valid_archive" >"$fixture_dir/truncated.tar.gz"
+    if stage_archive "$valid_checksum" "$fixture_dir/truncated.tar.gz" \
+        "$fixture_dir/truncated" 2>/dev/null; then
+        fail_self_test "truncated archive was accepted"
+    fi
+    printf '<html>503</html>\n' >"$fixture_dir/http-body.tar.gz"
+    if stage_archive "$valid_checksum" "$fixture_dir/http-body.tar.gz" \
+        "$fixture_dir/http" 2>/dev/null; then
+        fail_self_test "HTTP response body was accepted"
+    fi
+
+    partial_archive="$fixture_dir/gobgp-only.tar.gz"
+    tar -czf "$partial_archive" -C "$source_dir" gobgp
+    if stage_archive "$(sha256sum "$partial_archive" | awk '{print $1}')" \
+        "$partial_archive" "$fixture_dir/partial" 2>/dev/null; then
+        fail_self_test "archive without gobgpd was accepted"
+    fi
+
+    wrong_dir="$fixture_dir/wrong"
+    mkdir -p "$wrong_dir"
+    cat >"$wrong_dir/gobgp" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' 'gobgp version 3.36.0'
+EOF
+    cat >"$wrong_dir/gobgpd" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' 'gobgpd version 3.36.0'
+EOF
+    chmod +x "$wrong_dir/gobgp" "$wrong_dir/gobgpd"
+    wrong_archive="$fixture_dir/wrong-version.tar.gz"
+    tar -czf "$wrong_archive" -C "$wrong_dir" gobgp gobgpd
+    wrong_checksum=$(sha256sum "$wrong_archive" | awk '{print $1}')
+    if stage_archive "$wrong_checksum" "$wrong_archive" \
+        "$fixture_dir/stage" 2>/dev/null; then
+        fail_self_test "wrong binary version was accepted"
+    fi
+    [[ "$(sha256sum "$fixture_dir/stage/$GOBGP_ASSET" | awk '{print $1}')" == "$staged_hash" ]] \
+        || fail_self_test "version failure replaced the staged target"
+
+    printf 'invalid cache\n' >"$fixture_dir/cache.tar.gz"
+    attempts=0
+    download_archive_once() {
+        ((attempts += 1))
+        if ((attempts == 1)); then
+            printf 'transient failure\n' >"$2"
+        else
+            cp "$valid_archive" "$2"
+        fi
+    }
+    sleep() { :; }
+    prepare_archive "$valid_checksum" "https://example.invalid/retry" \
+        "$fixture_dir/cache.tar.gz" >/dev/null 2>&1
+    [[ "$attempts" -eq 2 ]] || fail_self_test "bounded retry count drifted"
+    cmp -s "$valid_archive" "$fixture_dir/cache.tar.gz" \
+        || fail_self_test "invalid cache was not atomically replaced"
+
+    download_archive_once() { fail_self_test "warm cache reached upstream"; }
+    prepare_archive "$valid_checksum" "https://example.invalid/unreachable" \
+        "$fixture_dir/cache.tar.gz" \
+        | grep -Fxq "using verified cached gobgp archive" \
+        || fail_self_test "warm cache attempted an upstream fetch"
+
+    attempts=0
+    download_archive_once() {
+        ((attempts += 1))
+        printf '<html>503</html>\n' >"$2"
+    }
+    if prepare_archive "$valid_checksum" "https://example.invalid/unavailable" \
+        "$fixture_dir/cold-cache.tar.gz" >/dev/null 2>&1; then
+        fail_self_test "cold-cache upstream failure was accepted"
+    fi
+    [[ "$attempts" -eq "$GOBGP_ATTEMPTS" ]] \
+        || fail_self_test "cold-cache retry bound was not enforced"
+    [[ ! -e "$fixture_dir/cold-cache.tar.gz" ]] \
+        || fail_self_test "failed cold-cache fetch left an artifact"
+
+    # shellcheck disable=SC2317
+    curl() { fail_self_test "offline stage invoked curl"; }
+    stage_archive "$valid_checksum" "$valid_archive" \
+        "$fixture_dir/offline-stage" >/dev/null \
+        || fail_self_test "offline archive stage failed"
+
+    echo "gobgp installer self-test passed"
+)
+
+usage() {
+    echo "usage: $0 --prepare-archive ARCHIVE | --stage-archive ARCHIVE STAGE_DIR | --self-test" >&2
+    return 2
+}
+
+case "${1:-}" in
+    --prepare-archive)
+        [[ $# -eq 2 ]] || usage
+        prepare_archive "$GOBGP_SHA256" "$GOBGP_URL" "$2"
+        ;;
+    --stage-archive)
+        [[ $# -eq 3 ]] || usage
+        stage_archive "$GOBGP_SHA256" "$2" "$3"
+        ;;
+    --self-test)
+        [[ $# -eq 1 ]] || usage
+        self_test
+        ;;
+    *) usage ;;
+esac

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -225,6 +225,35 @@ jobs:
           retention-days: 1
           compression-level: 0
 
+  gobgp_archive:
+    needs: classify_changes
+    if: needs.classify_changes.outputs.run_labs == 'true'
+    name: Prepare exact gobgp archive
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+      - name: Restore exact gobgp archive cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/gobgp-cache/gobgp_3.37.0_linux_amd64.tar.gz
+          key: gobgp-v3.37.0-linux-amd64-e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522
+      - name: Prepare exact gobgp archive
+        run: |
+          .github/scripts/install-gobgp.sh \
+            --prepare-archive \
+            "$RUNNER_TEMP/gobgp-cache/gobgp_3.37.0_linux_amd64.tar.gz"
+      - name: Upload verified gobgp archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: gobgp-v3.37.0-linux-amd64
+          path: ${{ runner.temp }}/gobgp-cache/gobgp_3.37.0_linux_amd64.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
   # Warm one fixed-scope cache per source SHA; jobs still build and load their
   # own image, falling back to an uncached build if the cache is unavailable.
   prime_dev_image:
@@ -551,7 +580,7 @@ jobs:
           script: tests/interop/scripts/test-m87-exact-export-rejection.sh
 
   m74:
-    needs: [grpcurl_archive, prime_dev_image]
+    needs: [grpcurl_archive, gobgp_archive, prime_dev_image]
     name: M74 — VPNv4 route reflection (GoBGP 3.x)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -580,6 +609,9 @@ jobs:
           target: dev
           cache-from: type=gha,scope=rustbgpd-dev
 
+      - name: Stage verified GoBGP archive
+        uses: ./.github/actions/stage-gobgp-artifact
+
       - name: Build gobgp:interop
         run: docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
 
@@ -591,7 +623,7 @@ jobs:
           script: tests/interop/scripts/test-m74-vpnv4-reflection-gobgp.sh
 
   m75:
-    needs: [grpcurl_archive, prime_dev_image]
+    needs: [grpcurl_archive, gobgp_archive, prime_dev_image]
     name: M75 — RT-Constrain VPNv4 filtering (GoBGP 3.x)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -619,6 +651,9 @@ jobs:
           tags: rustbgpd:dev
           target: dev
           cache-from: type=gha,scope=rustbgpd-dev
+
+      - name: Stage verified GoBGP archive
+        uses: ./.github/actions/stage-gobgp-artifact
 
       - name: Build gobgp:interop
         run: docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
@@ -864,7 +899,7 @@ jobs:
           script: tests/interop/scripts/test-m24-bmp-frr.sh
 
   m81:
-    needs: [grpcurl_archive, prime_dev_image]
+    needs: [grpcurl_archive, gobgp_archive, prime_dev_image]
     name: M81 — BMP trio + BMPv4 receipt (pmacct + gobmp + tshark)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -894,6 +929,9 @@ jobs:
           target: dev
           cache-from: type=gha,scope=rustbgpd-dev
 
+      - name: Stage verified GoBGP archive
+        uses: ./.github/actions/stage-gobgp-artifact
+
       - name: Build gobgp:interop
         run: docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
 
@@ -911,7 +949,7 @@ jobs:
           script: tests/interop/scripts/test-m81-bmp-trio-gobgp.sh
 
   m82:
-    needs: [grpcurl_archive, prime_dev_image]
+    needs: [grpcurl_archive, gobgp_archive, prime_dev_image]
     # Synthetic leg only. The SR Linux vendor leg
     # (m82-evpn-bundle-srlinux.clab.yml) stays local: the NOS image is
     # ~750 MB compressed / 3.2 GB on disk and boots a full chassis sim —
@@ -945,6 +983,9 @@ jobs:
           target: dev
           cache-from: type=gha,scope=rustbgpd-dev
 
+      - name: Stage verified GoBGP archive
+        uses: ./.github/actions/stage-gobgp-artifact
+
       - name: Build gobgp:interop
         run: docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
 
@@ -956,7 +997,7 @@ jobs:
           script: tests/interop/scripts/test-m82-evpn-bundle-synthetic-gobgp.sh
 
   m83:
-    needs: [grpcurl_archive, prime_dev_image]
+    needs: [grpcurl_archive, gobgp_archive, prime_dev_image]
     # Full 3-stack leg in CI: BIRD 2 is a plain apt install on
     # bookworm-slim (deterministic build) and BIRD already runs in
     # hosted CI (M43, kernel-dataplane.yml) without flake history —
@@ -994,6 +1035,9 @@ jobs:
         # bird2 + tshark: the member stack that carries the byte-level
         # RFC 7947 transparency / OTC / EoR wire assertions.
         run: docker build -t bird:2-bookworm -f tests/interop/Dockerfile.bird tests/interop
+
+      - name: Stage verified GoBGP archive
+        uses: ./.github/actions/stage-gobgp-artifact
 
       - name: Build gobgp:interop
         run: docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
@@ -1913,15 +1957,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: ${{ always() }}
-    needs: [classify_changes, grpcurl_archive, gnmic_archive, prime_dev_image, m1, m13, m80,
-      m15, m10, m14, m17, m73, m74, m75, m76, m77, m78, m79, m22, m24,
+    needs: [classify_changes, grpcurl_archive, gnmic_archive, gobgp_archive, prime_dev_image, m1,
+      m13, m80, m15, m10, m14, m17, m73, m74, m75, m76, m77, m78, m79, m22, m24,
       m81, m82, m83, m85, m94, m86, m25, m29, m30, m34, m35, m35b, m35c,
       m41, m44, m54, m55, m56, m45, m57, m63, m64,
       m26_m27_m28_m59_m91, m92]
     env:
       NEEDS_CONTEXT: ${{ toJSON(needs) }}
       EXPECTED_JOBS: >-
-        classify_changes grpcurl_archive gnmic_archive prime_dev_image m1 m13 m80 m15 m10
+        classify_changes grpcurl_archive gnmic_archive gobgp_archive prime_dev_image
+        m1 m13 m80 m15 m10
         m14 m17 m73 m74 m75 m76 m77 m78 m79 m22 m24 m81 m82 m83 m85 m94
         m86 m25 m29 m30 m34 m35 m35b m35c m41 m44 m54 m55 m56 m45 m57
         m63 m64 m26_m27_m28_m59_m91 m92

--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -84,6 +84,35 @@ jobs:
           retention-days: 1
           compression-level: 0
 
+  gobgp_archive:
+    needs: classify_changes
+    if: needs.classify_changes.outputs.run_labs == 'true'
+    name: Prepare exact gobgp archive
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+      - name: Restore exact gobgp archive cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/gobgp-cache/gobgp_3.37.0_linux_amd64.tar.gz
+          key: gobgp-v3.37.0-linux-amd64-e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522
+      - name: Prepare exact gobgp archive
+        run: |
+          .github/scripts/install-gobgp.sh \
+            --prepare-archive \
+            "$RUNNER_TEMP/gobgp-cache/gobgp_3.37.0_linux_amd64.tar.gz"
+      - name: Upload verified gobgp archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: gobgp-v3.37.0-linux-amd64
+          path: ${{ runner.temp }}/gobgp-cache/gobgp_3.37.0_linux_amd64.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
   # Warm one fixed-scope cache per source SHA; jobs still build and load their
   # own image, falling back to an uncached build if the cache is unavailable.
   prime_dev_image:
@@ -603,7 +632,7 @@ jobs:
           script: tests/interop/scripts/test-m70-evpn-vlan-aware-bridge-frr.sh
 
   m65:
-    needs: [grpcurl_archive, prime_dev_image]
+    needs: [grpcurl_archive, gobgp_archive, prime_dev_image]
     name: M65 — ADR-0083 single-active failover blackout measurement (GoBGP 3.x)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -615,6 +644,8 @@ jobs:
       # §8.2 mass-withdraw wire shape — EAD-per-ES withdrawn with the MAC
       # routes retained — which neither rustbgpd nor FRR can originate; see
       # the topology header).
+      - name: Stage verified GoBGP archive
+        uses: ./.github/actions/stage-gobgp-artifact
       - name: Build gobgp:interop image
         run: docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
       - name: Run M65 (deploy + test + destroy with retry)
@@ -625,7 +656,7 @@ jobs:
           script: tests/interop/scripts/test-m65-evpn-single-active-failover.sh
 
   m71:
-    needs: [grpcurl_archive, prime_dev_image]
+    needs: [grpcurl_archive, gobgp_archive, prime_dev_image]
     name: M71 — RFC 9136 §4.3 ESI overlay-index Type 5 single-active receive (GoBGP 3.x)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -638,6 +669,8 @@ jobs:
       # the EAD-per-ES Single-Active vs All-Active ESI Label flag injected and
       # withdrawn separately from the Type 5 — FRR's EVPN multi-homing is
       # all-active only and cannot originate a single-active EAD-per-ES.
+      - name: Stage verified GoBGP archive
+        uses: ./.github/actions/stage-gobgp-artifact
       - name: Build gobgp:interop image
         run: docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
       - name: Run M71 (deploy + test + destroy with retry)
@@ -649,7 +682,7 @@ jobs:
           script: tests/interop/scripts/test-m71-evpn-esi-overlay-type5-receive-gobgp.sh
 
   m72:
-    needs: [grpcurl_archive, prime_dev_image]
+    needs: [grpcurl_archive, gobgp_archive, prime_dev_image]
     name: M72 — RFC 9136 §4.3 ESI overlay-index Type 5 all-active receive (GoBGP 3.x)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -661,6 +694,8 @@ jobs:
       # sources. This extends M71's exact ESI-overlay Type 5/EAD
       # command shape to the all-active success path: route-level ECMP
       # over l3vxlan100 plus a Router-MAC FDB-NHG row.
+      - name: Stage verified GoBGP archive
+        uses: ./.github/actions/stage-gobgp-artifact
       - name: Build gobgp:interop image
         run: docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
       - name: Run M72 (deploy + test + destroy with retry)
@@ -832,14 +867,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: ${{ always() }}
-    needs: [classify_changes, grpcurl_archive, prime_dev_image, m36, m37,
+    needs: [classify_changes, grpcurl_archive, gobgp_archive, prime_dev_image, m36, m37,
       m37-ip, m38, m39, m39b, m48, m60, m61, m62, m40, m42, m50, m52,
       m58, m53, m51, m43, m46, m47, m49, m69, m70, m65, m71, m72, m66,
       m67, m68, netns]
     env:
       NEEDS_CONTEXT: ${{ toJSON(needs) }}
       EXPECTED_JOBS: >-
-        classify_changes grpcurl_archive prime_dev_image m36 m37 m37-ip m38 m39
+        classify_changes grpcurl_archive gobgp_archive prime_dev_image m36 m37 m37-ip m38 m39
         m39b m48 m60 m61 m62 m40 m42 m50 m52 m58 m53 m51 m43 m46 m47 m49
         m69 m70 m65 m71 m72 m66 m67 m68 netns
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ clab-*/
 # Soak harness output (one directory per run; machine-specific timeseries)
 tests/soak/runs/
 
+# CI-staged GoBGP fixture archive (never vendor release binaries into git)
+tests/interop/gobgp-archive/*
+!tests/interop/gobgp-archive/.gitkeep
+
 
 # M44 mTLS PKI fixture — regenerated per CI run by gen-m44-certs.sh so
 # certificate validity windows never expire in the repo.

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -60,6 +60,13 @@ GNMIC_ARCHIVE = "gnmic_0.46.0_Linux_x86_64.tar.gz"
 GNMIC_ARTIFACT = "gnmic-v0.46.0-linux-x86_64"
 GNMIC_CACHE_KEY = f"gnmic-v0.46.0-linux-x86_64-{GNMIC_SHA256}"
 GNMIC_ACTION = "uses: ./.github/actions/install-gnmic-artifact"
+GOBGP_ARCHIVE = f"gobgp_{GOBGP_VERSION}_linux_amd64.tar.gz"
+GOBGP_ARTIFACT = f"gobgp-v{GOBGP_VERSION}-linux-amd64"
+GOBGP_CACHE_KEY = f"{GOBGP_ARTIFACT}-{GOBGP_CHECKSUMS['amd64']}"
+GOBGP_ACTION = "uses: ./.github/actions/stage-gobgp-artifact"
+GOBGP_BUILD = (
+    "docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop"
+)
 
 TRIGGER_HASHES = {
     "ci.yml": "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8",
@@ -79,15 +86,15 @@ CALL_HASHES = {
 }
 PINS = collections.Counter(
     {
-        "actions/checkout@v7": 85,
+        "actions/checkout@v7": 87,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 3,
         "Swatinem/rust-cache@v2": 5,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 2,
         "docker/setup-buildx-action@v4": 44,
         "docker/build-push-action@v7": 45,
-        "actions/cache@v6": 4,
-        "actions/upload-artifact@v7": 5,
-        "actions/download-artifact@v8": 4,
+        "actions/cache@v6": 6,
+        "actions/upload-artifact@v7": 7,
+        "actions/download-artifact@v8": 5,
         "rustsec/audit-check@v2.0.0": 1,
         "EmbarkStudios/cargo-deny-action@v2": 1,
     }
@@ -170,6 +177,34 @@ def check(root: Path) -> list[str]:
         errors.append("install-gnmic.sh release URL inventory drifted")
     if re.search(r"curl[^\n]*\|\s*(?:sudo\s+)?tar", gnmic_installer_text):
         errors.append("install-gnmic.sh streams network bytes into tar")
+    gobgp_installer = root / ".github" / "scripts" / "install-gobgp.sh"
+    if not gobgp_installer.is_file():
+        errors.append("install-gobgp.sh is missing")
+    elif stat.S_IMODE(gobgp_installer.stat().st_mode) != 0o755:
+        errors.append("install-gobgp.sh must have exact executable mode 100755")
+    gobgp_installer_text = (
+        gobgp_installer.read_text() if gobgp_installer.is_file() else ""
+    )
+    for seam in (
+        f'readonly GOBGP_VERSION="{GOBGP_VERSION}"',
+        f'readonly GOBGP_SHA256="{GOBGP_CHECKSUMS["amd64"]}"',
+        'readonly GOBGP_ASSET="gobgp_${GOBGP_VERSION}_linux_amd64.tar.gz"',
+        "https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/${GOBGP_ASSET}",
+        "readonly GOBGP_ATTEMPTS=3",
+        "curl -fsSL",
+        "--connect-timeout 10",
+        "--max-time 120",
+        "--prepare-archive",
+        "--stage-archive",
+        "--self-test",
+        "unexpected ${binary} version",
+    ):
+        if seam not in gobgp_installer_text:
+            errors.append(f"install-gobgp.sh missing {seam}")
+    if gobgp_installer_text.count("osrg/gobgp/releases/download/") != 1:
+        errors.append("install-gobgp.sh release URL inventory drifted")
+    if re.search(r"curl[^\n]*\|\s*(?:sudo\s+)?tar", gobgp_installer_text):
+        errors.append("install-gobgp.sh streams network bytes into tar")
     workflow_dir = root / ".github" / "workflows"
     texts = {name: (workflow_dir / name).read_text() for name in WORKFLOWS}
     for name, text in texts.items():
@@ -258,7 +293,14 @@ def check(root: Path) -> list[str]:
     ):
         jobs = _jobs(texts[name])
         heavy = [*roster] + (["netns"] if setup else [])
-        artifact_jobs = ["grpcurl_archive"] + ([] if setup else ["gnmic_archive"])
+        artifact_jobs = (
+            ["grpcurl_archive"]
+            + ([] if setup else ["gnmic_archive"])
+            + ["gobgp_archive"]
+        )
+        gobgp_consumers = (
+            {"m65", "m71", "m72"} if setup else {"m74", "m75", "m81", "m82", "m83"}
+        )
         expected = [
             "classify_changes",
             *artifact_jobs,
@@ -367,6 +409,48 @@ def check(root: Path) -> list[str]:
             )
             if gnmic_producer.count(exact_gnmic_path) != 2:
                 errors.append(f"{name}:gnmic_archive cache/artifact paths drifted")
+        gobgp_producer = jobs.get("gobgp_archive", "")
+        for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
+            if not _has_line(gobgp_producer, f"    {seam}"):
+                errors.append(f"{name}:gobgp_archive missing job-level {seam}")
+        for seam in (
+            "name: Prepare exact gobgp archive",
+            "runs-on: ubuntu-latest",
+            "timeout-minutes: 10",
+            CHECKOUT,
+            "ref: ${{ github.sha }}",
+            "uses: actions/cache@v6",
+            f"path: ${{{{ runner.temp }}}}/gobgp-cache/{GOBGP_ARCHIVE}",
+            f"key: {GOBGP_CACHE_KEY}",
+            "--prepare-archive",
+            f'"$RUNNER_TEMP/gobgp-cache/{GOBGP_ARCHIVE}"',
+            "uses: actions/upload-artifact@v7",
+            f"name: {GOBGP_ARTIFACT}",
+            "if-no-files-found: error",
+            "retention-days: 1",
+            "compression-level: 0",
+        ):
+            if seam not in gobgp_producer:
+                errors.append(f"{name}:gobgp_archive missing {seam}")
+        for forbidden in (
+            "restore-keys:",
+            "continue-on-error:",
+            "actions/download-artifact@",
+            "--stage-archive",
+        ):
+            if forbidden in gobgp_producer:
+                errors.append(f"{name}:gobgp_archive permits {forbidden}")
+        if gobgp_producer.count("uses: actions/cache@v6") != 1:
+            errors.append(f"{name}:gobgp_archive must restore one exact cache")
+        if gobgp_producer.count("--prepare-archive") != 1:
+            errors.append(f"{name}:gobgp_archive must prepare one archive")
+        if gobgp_producer.count("uses: actions/upload-artifact@v7") != 1:
+            errors.append(f"{name}:gobgp_archive must upload one artifact")
+        exact_gobgp_path = (
+            f"path: ${{{{ runner.temp }}}}/gobgp-cache/{GOBGP_ARCHIVE}"
+        )
+        if gobgp_producer.count(exact_gobgp_path) != 2:
+            errors.append(f"{name}:gobgp_archive cache/artifact paths drifted")
         primer = jobs.get("prime_dev_image", "")
         for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
             if not _has_line(primer, f"    {seam}"):
@@ -392,14 +476,32 @@ def check(root: Path) -> list[str]:
             errors.append(f"{name}: primer must export cache, not load an image")
         for job_name in roster:
             job = jobs.get(job_name, "")
-            expected_needs = (
-                "    needs: [grpcurl_archive, gnmic_archive, prime_dev_image]"
-                if not setup and job_name in ("m54", "m56")
-                else "    needs: [grpcurl_archive, prime_dev_image]"
-            )
+            if not setup and job_name in ("m54", "m56"):
+                expected_needs = (
+                    "    needs: [grpcurl_archive, gnmic_archive, prime_dev_image]"
+                )
+            elif job_name in gobgp_consumers:
+                expected_needs = (
+                    "    needs: [grpcurl_archive, gobgp_archive, prime_dev_image]"
+                )
+            else:
+                expected_needs = "    needs: [grpcurl_archive, prime_dev_image]"
             if not _has_line(job, expected_needs):
                 errors.append(
                     f"{name}:{job_name}: missing exact artifact/primer dependencies"
+                )
+            expected_gobgp = 1 if job_name in gobgp_consumers else 0
+            if job.count(GOBGP_ACTION) != expected_gobgp:
+                errors.append(f"{name}:{job_name}: gobgp stage consumer drifted")
+            if job.count(GOBGP_BUILD) != expected_gobgp:
+                errors.append(
+                    f"{name}:{job_name}: gobgp:interop build inventory drifted"
+                )
+            if expected_gobgp and not (
+                0 <= job.find(GOBGP_ACTION) < job.find(GOBGP_BUILD)
+            ):
+                errors.append(
+                    f"{name}:{job_name}: gobgp build precedes the staged artifact"
                 )
             if CHECKOUT not in job:
                 errors.append(f"{name}:{job_name}: pinned checkout drifted")
@@ -502,6 +604,9 @@ def check(root: Path) -> list[str]:
     gnmic_action = (
         root / ".github" / "actions" / "install-gnmic-artifact" / "action.yml"
     ).read_text()
+    gobgp_action = (
+        root / ".github" / "actions" / "stage-gobgp-artifact" / "action.yml"
+    ).read_text()
     for seam in (
         "uses: actions/download-artifact@v8",
         f"name: {GRPCURL_ARTIFACT}",
@@ -553,6 +658,31 @@ def check(root: Path) -> list[str]:
     ):
         if forbidden in gnmic_action:
             errors.append(f"install-gnmic-artifact permits {forbidden}")
+    for seam in (
+        "uses: actions/download-artifact@v8",
+        f"name: {GOBGP_ARTIFACT}",
+        "path: ${{ runner.temp }}/gobgp-artifact",
+        "--stage-archive",
+        f'"$RUNNER_TEMP/gobgp-artifact/{GOBGP_ARCHIVE}"',
+        "tests/interop/gobgp-archive",
+    ):
+        if seam not in gobgp_action:
+            errors.append(f"stage-gobgp-artifact missing {seam}")
+    if gobgp_action.count("uses: actions/download-artifact@v8") != 1:
+        errors.append("stage-gobgp-artifact must download one same-run artifact")
+    if gobgp_action.count("--stage-archive") != 1:
+        errors.append("stage-gobgp-artifact must perform one offline stage")
+    for forbidden in (
+        "--prepare-archive",
+        "actions/cache@",
+        "actions/upload-artifact@",
+        "restore-keys:",
+        "continue-on-error:",
+        "releases/download/",
+        "curl ",
+    ):
+        if forbidden in gobgp_action:
+            errors.append(f"stage-gobgp-artifact permits {forbidden}")
     # split(...)[-1] returns the whole file when the step name drifts, which
     # turns every seam check below into a file-wide search that passes
     # vacuously. Scope the region only once the anchor is known to be present.
@@ -601,9 +731,18 @@ def check(root: Path) -> list[str]:
         errors.append("gnmic release URL escaped the producer helper")
     if re.search(r"curl\s.*gnmic|curl\s.*\|\s*(?:sudo\s+)?tar", gnmic_surfaces):
         errors.append("interop.yml retains a streaming gnmic download")
+    if texts["interop.yml"].count(GOBGP_ACTION) != 5:
+        errors.append("interop.yml: gobgp stage consumer inventory drifted")
+    if texts["kernel-dataplane.yml"].count(GOBGP_ACTION) != 3:
+        errors.append("kernel-dataplane.yml: gobgp stage consumer inventory drifted")
+    gobgp_surfaces = "\n".join(
+        (texts["interop.yml"], texts["kernel-dataplane.yml"], gobgp_action)
+    )
+    if "osrg/gobgp/releases" in gobgp_surfaces:
+        errors.append("gobgp release URL escaped the installer/Dockerfile")
 
     pins = collections.Counter()
-    for text in [*texts.values(), action, grpcurl_action, gnmic_action]:
+    for text in [*texts.values(), action, grpcurl_action, gnmic_action, gobgp_action]:
         for value in re.findall(r"^\s*(?:- )?uses:\s*(.+)$", text, re.MULTILINE):
             if not value.strip().startswith("./"):
                 pins[value.strip()] += 1
@@ -629,11 +768,14 @@ def check(root: Path) -> list[str]:
         "FROM debian:bookworm-slim AS gobgp-release",
         "ARG TARGETARCH",
         f"ENV GOBGP_VERSION={GOBGP_VERSION}",
+        "COPY gobgp-archive/ /tmp/gobgp-archive/",
         'archive="gobgp_${GOBGP_VERSION}_linux_${TARGETARCH}.tar.gz"',
         '*) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;;',
+        'if [ ! -f "/tmp/gobgp-archive/${archive}" ]; then',
         "https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/${archive}",
-        'echo "${checksum}  /tmp/${archive}" | sha256sum --check --strict',
-        'tar --extract --gzip --file "/tmp/${archive}" --directory /usr/local/bin gobgp gobgpd',
+        'if [ "${attempt}" -ge 3 ]; then',
+        'echo "${checksum}  /tmp/gobgp-archive/${archive}" | sha256sum --check --strict',
+        'tar --extract --gzip --file "/tmp/gobgp-archive/${archive}" --directory /usr/local/bin gobgp gobgpd',
         'test "$(gobgp --version)" = "gobgp version ${GOBGP_VERSION}"',
         'test "$(gobgpd --version)" = "gobgpd version ${GOBGP_VERSION}"',
     ):

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -94,6 +94,7 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
+                ".github/actions/stage-gobgp-artifact",
             ):
                 source = ROOT / fixture
                 target = root / fixture
@@ -104,6 +105,8 @@ class PrimerContractTests(unittest.TestCase):
             shutil.copy2(ROOT / installer.relative_to(root), installer)
             gnmic_installer = root / ".github" / "scripts" / "install-gnmic.sh"
             shutil.copy2(ROOT / gnmic_installer.relative_to(root), gnmic_installer)
+            gobgp_installer = root / ".github" / "scripts" / "install-gobgp.sh"
+            shutil.copy2(ROOT / gobgp_installer.relative_to(root), gobgp_installer)
             shutil.copy2(ROOT / "Dockerfile", root / "Dockerfile")
             gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
             gobgp.parent.mkdir(parents=True, exist_ok=True)
@@ -138,6 +141,7 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
+                ".github/actions/stage-gobgp-artifact",
             ):
                 shutil.copytree(ROOT / fixture, root / fixture)
             shutil.copy2(ROOT / "Dockerfile", root / "Dockerfile")
@@ -147,6 +151,8 @@ class PrimerContractTests(unittest.TestCase):
             gnmic_installer = root / ".github" / "scripts" / "install-gnmic.sh"
             gnmic_installer.parent.mkdir(parents=True)
             shutil.copy2(ROOT / gnmic_installer.relative_to(root), gnmic_installer)
+            gobgp_installer = root / ".github" / "scripts" / "install-gobgp.sh"
+            shutil.copy2(ROOT / gobgp_installer.relative_to(root), gobgp_installer)
             self.assertIn("install-grpcurl.sh is missing", check(root))
 
     def test_grpcurl_installer_executable_mode_is_load_bearing(self):
@@ -157,6 +163,7 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
+                ".github/actions/stage-gobgp-artifact",
             ):
                 shutil.copytree(ROOT / fixture, root / fixture)
             shutil.copy2(ROOT / "Dockerfile", root / "Dockerfile")
@@ -168,6 +175,8 @@ class PrimerContractTests(unittest.TestCase):
             shutil.copy2(ROOT / installer.relative_to(root), installer)
             gnmic_installer = root / ".github" / "scripts" / "install-gnmic.sh"
             shutil.copy2(ROOT / gnmic_installer.relative_to(root), gnmic_installer)
+            gobgp_installer = root / ".github" / "scripts" / "install-gobgp.sh"
+            shutil.copy2(ROOT / gobgp_installer.relative_to(root), gobgp_installer)
             installer.chmod(0o644)
             self.assertIn(
                 "install-grpcurl.sh must have exact executable mode 100755",
@@ -185,6 +194,7 @@ class PrimerContractTests(unittest.TestCase):
         artifacts = ["grpcurl_archive"]
         if workflow == "interop.yml":
             artifacts.append("gnmic_archive")
+        artifacts.append("gobgp_archive")
         expected = ["classify_changes", *artifacts, "prime_dev_image", *roster]
         if workflow == "kernel-dataplane.yml":
             expected.append("netns")
@@ -216,6 +226,7 @@ class PrimerContractTests(unittest.TestCase):
             artifacts = ["grpcurl_archive"]
             if workflow == "interop.yml":
                 artifacts.append("gnmic_archive")
+            artifacts.append("gobgp_archive")
             skipped = {
                 job: "skipped" for job in [*artifacts, "prime_dev_image", *roster]
             }
@@ -254,6 +265,18 @@ class PrimerContractTests(unittest.TestCase):
                             },
                         ).returncode,
                     )
+            gobgp_consumers = (
+                ("m74", "m75", "m81", "m82", "m83")
+                if workflow == "interop.yml"
+                else ("m65", "m71", "m72")
+            )
+            with self.subTest(workflow=workflow, state="gobgp producer red"):
+                gobgp_red = {job: "skipped" for job in gobgp_consumers}
+                gobgp_red["gobgp_archive"] = "failure"
+                self.assertNotEqual(
+                    0,
+                    self.run_aggregate(workflow, "true", gobgp_red).returncode,
+                )
             for run_labs, results in (
                 ("", {}),
                 ("unknown", {}),
@@ -411,6 +434,94 @@ class PrimerContractTests(unittest.TestCase):
             with self.subTest(seam=old):
                 self.mutate(installer, old, new)
 
+    def test_gobgp_producer_and_stage_consumers_are_load_bearing(self):
+        checksum = "e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522"
+        for workflow in ("interop.yml", "kernel-dataplane.yml"):
+            relative = f".github/workflows/{workflow}"
+            producer_occurrence = 2 if workflow == "interop.yml" else 1
+            for old, new in (
+                ("  gobgp_archive:\n", "  removed_gobgp_archive:\n"),
+                (f"key: gobgp-v3.37.0-linux-amd64-{checksum}", "key: gobgp-latest"),
+                ("name: gobgp-v3.37.0-linux-amd64", "name: gobgp-latest"),
+                (
+                    "needs: [grpcurl_archive, gobgp_archive, prime_dev_image]",
+                    "needs: [grpcurl_archive, prime_dev_image]",
+                ),
+                (
+                    "uses: ./.github/actions/stage-gobgp-artifact",
+                    "run: curl https://example.invalid/gobgp -o /tmp/gobgp.tar.gz",
+                ),
+            ):
+                with self.subTest(workflow=workflow, seam=old):
+                    self.mutate(relative, old, new)
+            for seam, replacement in (
+                ("actions/cache@v6", "actions/cache@main"),
+                ("--prepare-archive", "--stage-archive"),
+                ("actions/upload-artifact@v7", "actions/upload-artifact@main"),
+            ):
+                with self.subTest(workflow=workflow, seam=f"gobgp producer {seam}"):
+                    self.mutate(
+                        relative, seam, replacement, occurrence=producer_occurrence
+                    )
+            exact_path = (
+                "path: ${{ runner.temp }}/gobgp-cache/"
+                "gobgp_3.37.0_linux_amd64.tar.gz"
+            )
+            for occurrence in (0, 1):
+                with self.subTest(
+                    workflow=workflow, seam="gobgp exact path", occurrence=occurrence
+                ):
+                    self.mutate(
+                        relative,
+                        exact_path,
+                        "path: ${{ runner.temp }}/gobgp-cache/wrong.tar.gz",
+                        occurrence=occurrence,
+                    )
+
+        stage_then_build = (
+            "      - name: Stage verified GoBGP archive\n"
+            "        uses: ./.github/actions/stage-gobgp-artifact\n"
+            "\n"
+            "      - name: Build gobgp:interop\n"
+            "        run: docker build -t gobgp:interop"
+            " -f tests/interop/Dockerfile.gobgp tests/interop\n"
+        )
+        build_then_stage = (
+            "      - name: Build gobgp:interop\n"
+            "        run: docker build -t gobgp:interop"
+            " -f tests/interop/Dockerfile.gobgp tests/interop\n"
+            "\n"
+            "      - name: Stage verified GoBGP archive\n"
+            "        uses: ./.github/actions/stage-gobgp-artifact\n"
+        )
+        with self.subTest(seam="stage precedes build"):
+            self.mutate(
+                ".github/workflows/interop.yml", stage_then_build, build_then_stage
+            )
+
+        action = ".github/actions/stage-gobgp-artifact/action.yml"
+        for old, new in (
+            ("actions/download-artifact@v8", "actions/download-artifact@main"),
+            ("name: gobgp-v3.37.0-linux-amd64", "name: gobgp-latest"),
+            ("--stage-archive", "--prepare-archive"),
+            (
+                "set -euo pipefail",
+                "set -euo pipefail\n        curl https://example.invalid/gobgp",
+            ),
+        ):
+            with self.subTest(seam=old):
+                self.mutate(action, old, new)
+
+        installer = ".github/scripts/install-gobgp.sh"
+        for old, new in (
+            ('readonly GOBGP_VERSION="3.37.0"', 'readonly GOBGP_VERSION="latest"'),
+            (checksum, "0" * 64),
+            ("curl -fsSL", "curl -sL"),
+            ("--connect-timeout 10", "--connect-timeout 0"),
+        ):
+            with self.subTest(seam=old):
+                self.mutate(installer, old, new)
+
     def test_gnmic_installer_executable_mode_is_load_bearing(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -419,6 +530,7 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
+                ".github/actions/stage-gobgp-artifact",
             ):
                 shutil.copytree(ROOT / fixture, root / fixture)
             shutil.copy2(ROOT / "Dockerfile", root / "Dockerfile")
@@ -427,11 +539,36 @@ class PrimerContractTests(unittest.TestCase):
             shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
             scripts = root / ".github" / "scripts"
             scripts.mkdir(parents=True)
-            for name in ("install-grpcurl.sh", "install-gnmic.sh"):
+            for name in ("install-grpcurl.sh", "install-gnmic.sh", "install-gobgp.sh"):
                 shutil.copy2(ROOT / ".github" / "scripts" / name, scripts / name)
             (scripts / "install-gnmic.sh").chmod(0o644)
             self.assertIn(
                 "install-gnmic.sh must have exact executable mode 100755",
+                check(root),
+            )
+
+    def test_gobgp_installer_executable_mode_is_load_bearing(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            for fixture in (
+                ".github/workflows",
+                ".github/actions/install-gnmic-artifact",
+                ".github/actions/install-grpcurl-artifact",
+                ".github/actions/setup-dataplane-host",
+                ".github/actions/stage-gobgp-artifact",
+            ):
+                shutil.copytree(ROOT / fixture, root / fixture)
+            shutil.copy2(ROOT / "Dockerfile", root / "Dockerfile")
+            gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
+            gobgp.parent.mkdir(parents=True)
+            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
+            scripts = root / ".github" / "scripts"
+            scripts.mkdir(parents=True)
+            for name in ("install-grpcurl.sh", "install-gnmic.sh", "install-gobgp.sh"):
+                shutil.copy2(ROOT / ".github" / "scripts" / name, scripts / name)
+            (scripts / "install-gobgp.sh").chmod(0o644)
+            self.assertIn(
+                "install-gobgp.sh must have exact executable mode 100755",
                 check(root),
             )
 
@@ -444,7 +581,7 @@ class PrimerContractTests(unittest.TestCase):
             needs_prefix = (
                 "needs: [classify_changes, grpcurl_archive, "
                 + ("gnmic_archive, " if workflow == "interop.yml" else "")
-                + "prime_dev_image, "
+                + "gobgp_archive, prime_dev_image, "
             )
             for old, new in (
                 ("if: ${{ always() }}", "if: success()"),
@@ -760,16 +897,28 @@ class PrimerContractTests(unittest.TestCase):
                 "*) exit 1 ;;",
             ),
             (
+                "COPY gobgp-archive/ /tmp/gobgp-archive/",
+                "RUN mkdir -p /tmp/gobgp-archive",
+            ),
+            (
+                'if [ ! -f "/tmp/gobgp-archive/${archive}" ]; then',
+                "if true; then",
+            ),
+            (
                 'https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/${archive}',
                 "https://example.invalid/${archive}",
             ),
             (
-                'echo "${checksum}  /tmp/${archive}" | sha256sum --check --strict',
+                'if [ "${attempt}" -ge 3 ]; then',
+                'if [ "${attempt}" -ge 9999 ]; then',
+            ),
+            (
+                'echo "${checksum}  /tmp/gobgp-archive/${archive}" | sha256sum --check --strict',
                 "true # skipped checksum verification",
             ),
             (
-                'tar --extract --gzip --file "/tmp/${archive}" --directory /usr/local/bin gobgp gobgpd',
-                'tar --extract --gzip --file "/tmp/${archive}" --directory /usr/local/bin',
+                'tar --extract --gzip --file "/tmp/gobgp-archive/${archive}" --directory /usr/local/bin gobgp gobgpd',
+                'tar --extract --gzip --file "/tmp/gobgp-archive/${archive}" --directory /usr/local/bin',
             ),
             (
                 'test "$(gobgp --version)" = "gobgp version ${GOBGP_VERSION}"',

--- a/tests/interop/Dockerfile.gobgp
+++ b/tests/interop/Dockerfile.gobgp
@@ -8,6 +8,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
+# CI stages the same-run, checksum- and version-verified release archive here
+# (.github/actions/stage-gobgp-artifact) so hosted builds never contact the
+# upstream release; the committed directory is empty, which keeps cold
+# local/multi-arch builds on the bounded in-build fetch below.
+COPY gobgp-archive/ /tmp/gobgp-archive/
+
 RUN set -eux; \
     case "${TARGETARCH}" in \
         amd64) checksum="e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522" ;; \
@@ -15,11 +21,23 @@ RUN set -eux; \
         *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
     archive="gobgp_${GOBGP_VERSION}_linux_${TARGETARCH}.tar.gz"; \
-    curl --fail --location --silent --show-error \
-        "https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/${archive}" \
-        --output "/tmp/${archive}"; \
-    echo "${checksum}  /tmp/${archive}" | sha256sum --check --strict; \
-    tar --extract --gzip --file "/tmp/${archive}" --directory /usr/local/bin gobgp gobgpd; \
+    if [ ! -f "/tmp/gobgp-archive/${archive}" ]; then \
+        attempt=1; \
+        while ! curl --fail --location --silent --show-error \
+            --connect-timeout 10 --max-time 120 \
+            "https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/${archive}" \
+            --output "/tmp/gobgp-archive/${archive}"; do \
+            rm -f "/tmp/gobgp-archive/${archive}"; \
+            if [ "${attempt}" -ge 3 ]; then \
+                echo "GoBGP ${GOBGP_VERSION} download failed after ${attempt} attempts" >&2; \
+                exit 1; \
+            fi; \
+            sleep $((attempt * 5)); \
+            attempt=$((attempt + 1)); \
+        done; \
+    fi; \
+    echo "${checksum}  /tmp/gobgp-archive/${archive}" | sha256sum --check --strict; \
+    tar --extract --gzip --file "/tmp/gobgp-archive/${archive}" --directory /usr/local/bin gobgp gobgpd; \
     test "$(gobgp --version)" = "gobgp version ${GOBGP_VERSION}"; \
     test "$(gobgpd --version)" = "gobgpd version ${GOBGP_VERSION}"
 


### PR DESCRIPTION
Third instance of the shared-verified-artifact pattern (#1630 grpcurl, #1631 gnmic), applied to the pinned GoBGP v3.37.0 interop fixture. Both hosted reproductions (M82 curl exit 56, M81 HTTP 503) failed inside the `tests/interop/Dockerfile.gobgp` BuildKit step, before any scenario ran.

Linear: [LAN-1007](https://linear.app/lance0/issue/LAN-1007/make-the-pinned-gobgp-v3-interop-fixture-independent-of-a-live-release)

## What changed

- `.github/scripts/install-gobgp.sh` — same producer/consumer split as the grpcurl/gnmic installers: `--prepare-archive` (cache reuse, bounded 3-attempt fetch, atomic replace) and `--self-test`. Verification is checksum **plus** extraction and exact `gobgp --version` / `gobgpd --version` checks on every path, including cache reuse.
- **Adaptation for a Docker-image fixture**: this fixture is an image built from `tests/interop/Dockerfile.gobgp`, not a host binary, so the consumer mode is `--stage-archive` instead of `--install-archive` — it re-verifies the same-run artifact offline and stages the archive into `tests/interop/gobgp-archive/` (committed empty, tarballs gitignored), where the Dockerfile now `COPY`s it. The Dockerfile re-verifies the pinned checksum and both binary versions inside the build, exactly as before.
- One `gobgp_archive` producer job per heavy workflow (Interop and Kernel Dataplane; artifacts are per-run), `actions/cache` keyed `gobgp-v3.37.0-linux-amd64-<sha256>`, artifact shared to all eight v3 consumers: M74/M75/M81/M82/M83 and M65/M71/M72. Consumer jobs gain `needs: gobgp_archive` and a `stage-gobgp-artifact` step before the image build.
- The Dockerfile keeps a bounded (3-attempt) in-build fetch **only** when no archive is staged, preserving the documented one-command local build and arm64 multi-arch support. Hosted CI can never take that path silently: the stage step fails the job first if the artifact is absent or invalid.
- `check_ci_image_primer_contract.py` extends to the new producer/consumer/installer seams, including: every job that builds `gobgp:interop` must stage the verified artifact first (bypass or reordering fails the contract), the release URL may exist only in the installer and the Dockerfile fallback, and the producer must be download-free on warm cache.

Not changed: GoBGP stays pinned at v3.37.0 with both existing architecture checksums (availability hardening, not an upgrade); the 4.6.0/4.7.0 fixtures (`Dockerfile.gobgp-bgpls`, `Dockerfile.gobgp-v47`) are separate images outside LAN-1007 scope; all existing scenario inputs are untouched.

## Checksum provenance

Fresh downloads of the v3.37.0 release assets from `github.com/osrg/gobgp/releases` were hashed during this change:

- amd64 `e20b2a155fe14450b9fe37e5c1a1d1bfe101eb479645f5bbea860a8fde30e522`
- arm64 `0aaa2da6e4dcaaf57e3d0e64eae14946292b0a5894d80ef3b7ebde3bf52beb29`

Both match the pins introduced by LAN-857 verbatim; `--prepare-archive` was additionally run against the live release and passed checksum plus real binary version verification end to end.

## Receipts (all exit-code gates)

- `shellcheck .github/scripts/install-gobgp.sh` — 0
- `bash .github/scripts/install-gobgp.sh --self-test` — 0 (valid stage, wrong checksum, truncated, HTTP-body, missing `gobgpd` member, wrong version, warm cache with no network, corrupt-cache atomic replacement, transient-retry recovery, bounded persistent failure, offline stage never invokes curl)
- grpcurl and gnmic installer self-tests — 0 (unchanged behavior)
- `python3 scripts/check_ci_image_primer_contract.py` — 0; `python3 -m unittest scripts.test_check_ci_image_primer_contract` — 27 tests, 0 failures (new mutation coverage for the producer, stage action, installer pins, Dockerfile seams, and stage-before-build ordering)
- CI scale-split contract check and tests — 0
- YAML parse of both touched workflows and the new composite action — 0 (actionlint not installed on this host)
- Load-bearing docker proofs: staged archive + dead release URL builds successfully (offline); corrupt staged archive fails at `sha256sum --check --strict` before extraction; empty stage directory builds via the bounded fallback fetch (local/multi-arch parity)
