### PR TITLE
docs(adr): replace live line-number anchors with symbol and section anchors

### DIFF
--- a/docs/adr/0051-per-peer-outbound-writer-task.md
+++ b/docs/adr/0051-per-peer-outbound-writer-task.md
@@ -259,7 +259,8 @@ still holds for any future broken peer (real or synthetic).
 
 ## What this does NOT fix
 
-- The dirty-resync HashSet rebuild cost in `distribution.rs:1362-1373`.
+- The dirty-resync HashSet rebuild cost in `distribute_changes` in
+  `crates/rib/src/manager/distribution/mod.rs`.
   Disconnecting a saturated peer drops its `dirty_peers` membership, so
   the symptom abates, but a healthy peer at the edge of capacity could
   still drive distribution-side allocation pressure. Address separately

--- a/docs/adr/0058-evpn-gate-9-irb-l3vni.md
+++ b/docs/adr/0058-evpn-gate-9-irb-l3vni.md
@@ -190,7 +190,7 @@ value that doesn't match what's actually being used to decapsulate.
 ### 5. Type 5 wire shape — single label, Interface-less
 
 The Type 5 codec already round-trips (`EvpnIpPrefixRoute` in
-`crates/wire/src/evpn.rs:453`) and carries one MPLS label slot.
+`crates/wire/src/evpn.rs`) and carries one MPLS label slot.
 RFC 9136 §4.4.2 mandates the Interface-less model uses that single
 label as the L3VNI and `gateway = 0.0.0.0 / ::`.
 

--- a/docs/adr/0059-evpn-aliasing-fdb-nexthop-groups.md
+++ b/docs/adr/0059-evpn-aliasing-fdb-nexthop-groups.md
@@ -168,7 +168,7 @@ message; only the attribute payload differs).
 
 ### 4. Portable intent shape: add `alias_group_key` to `RemoteMacEntry`
 
-The current `RemoteMacEntry` (`crates/evpn/src/mac.rs:67`) carries:
+The current `RemoteMacEntry` (`crates/evpn/src/mac.rs`) carries:
 
 ```rust
 pub remote_vtep_ip: IpAddr,

--- a/docs/adr/0072-durable-event-history.md
+++ b/docs/adr/0072-durable-event-history.md
@@ -46,7 +46,8 @@ history" work:
 - **ADR-0071 (Roles + OTC)** deferred the `OtcRouteBlocked` event
   payload because a backfillable event needs stable cursors that the
   current 4096-entry process-local ring cannot provide
-  (`docs/adr/0071-bgp-roles-otc.md:241-245`).
+  (the deferred `OtcRouteBlocked` event note under "Observability" in
+  `docs/adr/0071-bgp-roles-otc.md`).
 - **ADR-0070 (gNMI / OpenConfig telemetry)** deferred
   `Subscribe ON_CHANGE` for the same reason: gNMI ON_CHANGE
   subscribers need restart-survivable change history with
@@ -646,7 +647,7 @@ Prometheus counters and gauges added by this work:
 
 The existing
 `bgp_event_stream_lagged_total{service, source}` counter
-(`crates/telemetry/src/metrics.rs:46`) keeps its current semantics
+(`crates/telemetry/src/metrics.rs`) keeps its current semantics
 — broadcast subscribers falling behind. EHM owning the broadcast
 doesn't change that contract.
 

--- a/docs/adr/0094-evpn-vxlan-nondf-filtering-l2miss.md
+++ b/docs/adr/0094-evpn-vxlan-nondf-filtering-l2miss.md
@@ -34,7 +34,7 @@ was dead, and deferred A2 as ASIC/SAI-only.
 
 ### What ADR-0065 did not test (and explicitly flagged as the open avenue)
 
-ADR-0065's own *Decision outcome* (lines 156–164) named the remaining softswitch
+ADR-0065's own "Decision outcome" section named the remaining softswitch
 avenue — classify/mark on the **underlay before decap**, or operate on the
 decapsulated inner frame — but blocked it on two unknowns: **(1) mark survival
 through decap** and **(2) per-MAC state to separate unknown-unicast from


### PR DESCRIPTION
A reference that locates its target by line number breaks silently the next time the target file is edited — the same anchor-on-editable-text pattern behind the `test_classifiers.py` CI red and the LAN-950 packaged-config hollow-out. This converts the six remaining live reference anchors across five ADRs to the durable forms the surrounding documents already use (a named symbol, a metric name, or a section heading), each verified to exist at HEAD. LAN-958.

| ADR | Before | After |
|---|---|---|
| 0051 | `distribution.rs:1362-1373` (file no longer exists after the `distribution/` split) | `distribute_changes` in `crates/rib/src/manager/distribution/mod.rs` |
| 0058 | `crates/wire/src/evpn.rs:453` | `crates/wire/src/evpn.rs` (the already-named `EvpnIpPrefixRoute`; now at line 479) |
| 0059 | `crates/evpn/src/mac.rs:67` | `crates/evpn/src/mac.rs` (the already-named `RemoteMacEntry`; now at line 71) |
| 0072 | `docs/adr/0071-bgp-roles-otc.md:241-245` (range had drifted off the deferral text) | the deferred `OtcRouteBlocked` event note under "Observability" in ADR-0071 |
| 0072 | `crates/telemetry/src/metrics.rs:46` (registration now at line 751) | `crates/telemetry/src/metrics.rs` (the `bgp_event_stream_lagged_total` metric name) |
| 0094 | ADR-0065 "lines 156–164" (referenced text now extends past 164) | the ADR-0065 "Decision outcome" section heading |

Left as-is, per the ticket's scope note (decision-time rationale, not live references):

- ADR-0051 diagnosis narrative and validation citations (dated 2026-04-27)
- ADR-0071 "Repo seams (grounded)" implementation plan (all slices shipped; historical record)
- ADR-0072 design-body line ranges (decision-time design grounding)
- ADR-0081 bug walkthrough citations
- ADR-0100 proposal-time grounded-audit citations
- ADR-0059 docs.rs links (version-pinned URLs, already durable)
- ADR-0073 "around line 1855" (file already settled by #1575; the durable symbol is adjacent)

Gates: `check_public_tracker_ids.py` pass (591 public documents), `check-v1-stable-surface.py` pass, reference-existence check over all five touched files pass (0 failures across 6 anchor targets), `git diff --check` clean.
