### PR TITLE
Add settlement lifecycle logs, ten-minute advisory alert, and scrape-derivation proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Runtime-config settlement logs now carry the operation ID, kind, phase,
+  elapsed seconds, and budget at ownership registration, every phase
+  transition, and settlement, matching the existing fencing diagnostic. The
+  shipped Prometheus alert pack adds `BgpRuntimeConfigSettlementSlow`, a
+  ten-minute early advisory ahead of the half-budget warning, and
+  docs/OPERATIONS.md gains a settlement metrics reference table. (LAN-1023)
+
 - The TUI peer detail now opens an on-demand unicast export-explain view with
   `r`: page through the global Best-RIB and explain advertise/deny gates,
   ordered policy reasons, and modifications for the selected peer. (LAN-995)

--- a/crates/api/src/runtime_config_settlement.rs
+++ b/crates/api/src/runtime_config_settlement.rs
@@ -810,8 +810,20 @@ impl OperationInner {
         fence_reason_from_state(self.state.load(Ordering::Acquire))
     }
 
+    /// Elapsed ownership time, derived on every call from the stored
+    /// `registered_at` instant. Nothing stores an elapsed value at phase
+    /// transitions, so a wedged owner still reads a growing elapsed on a
+    /// frozen phase at scrape time.
     fn elapsed(&self) -> Duration {
-        Instant::now().saturating_duration_since(self.registered_at)
+        let now = Instant::now();
+        #[cfg(test)]
+        let now = now
+            + Duration::from_nanos(
+                self.registry
+                    .scrape_clock_advance_nanos
+                    .load(Ordering::Acquire),
+            );
+        now.saturating_duration_since(self.registered_at)
     }
 }
 
@@ -830,6 +842,11 @@ struct Registry {
     terminal: std::sync::mpsc::Sender<i32>,
     #[cfg(test)]
     terminal_fired: AtomicBool,
+    /// Test-only clock advance applied to elapsed derivation, proving the
+    /// scrape reads elapsed from `registered_at` instead of a value written
+    /// at the last phase transition.
+    #[cfg(test)]
+    scrape_clock_advance_nanos: AtomicU64,
 }
 
 impl Registry {
@@ -864,6 +881,7 @@ impl Registry {
             observer_thread: OnceLock::new(),
             terminal,
             terminal_fired: AtomicBool::new(false),
+            scrape_clock_advance_nanos: AtomicU64::new(0),
         }
     }
 
@@ -1149,6 +1167,14 @@ impl RuntimeConfigSettlementWatchdog {
             previous.is_none(),
             "runtime-config settlement permits only one current operation"
         );
+        tracing::info!(
+            operation_id = operation.id,
+            kind = operation.kind.as_str(),
+            phase = operation.phase().as_str(),
+            elapsed_seconds = operation.elapsed().as_secs(),
+            budget_seconds = self.registry.budget.as_secs(),
+            "runtime config settlement ownership registered"
+        );
         self.registry.wake.notify_one();
         if let Some(observer) = self.registry.observer_thread.get() {
             observer.unpark();
@@ -1350,7 +1376,17 @@ impl OwnedRuntimeConfigOperation {
                 Ordering::AcqRel,
                 Ordering::Acquire,
             ) {
-                Ok(_) => return,
+                Ok(_) => {
+                    tracing::info!(
+                        operation_id = self.inner.id,
+                        kind = self.inner.kind.as_str(),
+                        phase = phase.as_str(),
+                        elapsed_seconds = self.inner.elapsed().as_secs(),
+                        budget_seconds = self.inner.registry.budget.as_secs(),
+                        "runtime config settlement phase advanced"
+                    );
+                    return;
+                }
                 Err(actual) => observed = actual,
             }
         }
@@ -1395,6 +1431,14 @@ impl OwnedRuntimeConfigOperation {
                 Err(actual) => observed = actual,
             }
         }
+        tracing::info!(
+            operation_id = self.inner.id,
+            kind = self.inner.kind.as_str(),
+            phase = self.inner.phase().as_str(),
+            elapsed_seconds = self.inner.elapsed().as_secs(),
+            budget_seconds = self.inner.registry.budget.as_secs(),
+            "runtime config settlement settled"
+        );
         self.inner.registry.current.store(None);
         self.inner.registry.wake_threads();
         let resources = self
@@ -1970,6 +2014,56 @@ mod tests {
             1
         );
         assert_eq!(receiver.recv_timeout(Duration::from_secs(1)).unwrap(), 70);
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn scrape_derives_elapsed_from_start_instant_while_wedged_phase_is_frozen() {
+        let (watchdog, _receiver) = test_watchdog(Duration::from_mins(30), Duration::from_secs(5));
+        let registry = prometheus::Registry::new();
+        watchdog.register_metrics(&registry);
+        let (operation, guard, _, _) = operation(&watchdog, false).await;
+        operation.advance_phase(RuntimeConfigSettlementPhase::Mutating);
+        // The operation is now wedged: nothing below writes any phase or
+        // metric. Only the scrape clock advances, and each scrape must derive
+        // elapsed from the stored start instant at that moment.
+        let scrape_elapsed_at = |advance: Duration| {
+            watchdog.registry.scrape_clock_advance_nanos.store(
+                u64::try_from(advance.as_nanos()).unwrap(),
+                Ordering::Release,
+            );
+            let text = encode_metric_families(&registry.gather());
+            assert!(
+                text.contains(
+                    "bgp_runtime_config_settlement_active{fence_reason=\"none\",\
+                     kind=\"apply\",phase=\"mutating\",response_attached=\"attached\"} 1"
+                ),
+                "wedged owner must stay active in its frozen phase: {text}"
+            );
+            assert!(!text.contains("phase=\"owned_preflight\""));
+            assert!(text.contains("bgp_runtime_config_settlement_fail_stops_total{"));
+            assert!(!text.contains("fail_stops_total{fence_reason=\"budget_expired\""));
+            text.lines()
+                .find(|line| line.starts_with("bgp_runtime_config_settlement_elapsed_seconds{"))
+                .unwrap()
+                .rsplit_once(' ')
+                .unwrap()
+                .1
+                .parse::<f64>()
+                .unwrap()
+        };
+        let fifteen = scrape_elapsed_at(Duration::from_mins(15));
+        assert!(
+            (900.0..905.0).contains(&fifteen),
+            "scrape 15 minutes into the wedge must read 15 minutes, got {fifteen}"
+        );
+        let sixteen = scrape_elapsed_at(Duration::from_mins(16));
+        assert!(
+            sixteen - fifteen >= 59.0,
+            "elapsed must keep growing on a frozen phase: {fifteen} -> {sixteen}"
+        );
+        assert_eq!(operation.phase(), RuntimeConfigSettlementPhase::Mutating);
+        assert!(operation.try_settle());
         drop(guard);
     }
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -69,24 +69,34 @@ none of those paths can postpone the 30-minute-plus-five-second deadline. Do not
 classify 70 as success or suppress its restart: the new process re-establishes
 authority from durable state.
 
-While one owner exists, `/metrics` exposes exactly one series for each of
-`bgp_runtime_config_settlement_active`, `_elapsed_seconds`, and
-`_budget_seconds`. `bgp_runtime_config_settlement_fail_stops_total` becomes 1
-when recovery fencing wins. All four use the bounded labels `kind`, `phase`
+While one owner exists, `/metrics` exposes exactly one series for each family
+below; they emit no idle tuple.
+
+| Metric | Type | Meaning |
+| --- | --- | --- |
+| `bgp_runtime_config_settlement_active` | gauge | 1 while one owner is live or recovery-fenced. |
+| `bgp_runtime_config_settlement_elapsed_seconds` | gauge | Seconds since ownership, derived at scrape time from the stored start instant — it keeps growing while a wedged owner's phase stays frozen. |
+| `bgp_runtime_config_settlement_budget_seconds` | gauge | The fixed 1800-second fail-stop budget. |
+| `bgp_runtime_config_settlement_fail_stops_total` | counter | Becomes 1 when recovery fencing wins; exit 70 follows after the grace. |
+
+All four use the bounded labels `kind`, `phase`
 (`owned_preflight`, `mutating`, or `settling_rollback`), `response_attached`
 (`attached` or `detached`), and `fence_reason` (`none`, `budget_expired`,
 `executor_lost`, `known_divergence`, `publication_ambiguous`, or
-`acknowledgement_lost`). They emit no idle tuple. Detached means the daemon owns
-the work without a live RPC response; it does not weaken the deadline.
+`acknowledgement_lost`). Detached means the daemon owns
+the work without a live RPC response; it does not weaken the deadline. The
+daemon-generated operation ID appears in logs at ownership registration, each
+phase transition, settlement, and fencing — never as a metric label.
 
 The daemon warns once at 15, 25, and 29 minutes without extending or resetting
-the deadline. `BgpRuntimeConfigSettlementHalfBudget` fires at 50%; at that point
-identify the labeled owner and inspect the owning actor rather than retrying the
-mutation. Fencing produces one redacted diagnostic containing only operation
-identity/classification, phase, elapsed/budget seconds, attachment, terminal,
-optional fence reason, and exit status. It never includes config contents,
-tokens, confirm IDs, comments, credentials, paths, digests, candidates, or raw
-error text.
+the deadline. `BgpRuntimeConfigSettlementSlow` fires after ten minutes of owned
+settlement and `BgpRuntimeConfigSettlementHalfBudget` at 50% of the budget; at
+either point identify the labeled owner and inspect the owning actor rather
+than retrying the mutation. Fencing produces one redacted diagnostic containing
+only operation identity/classification, phase, elapsed/budget seconds,
+attachment, terminal, optional fence reason, and exit status. It never includes
+config contents, tokens, confirm IDs, comments, credentials, paths, digests,
+candidates, or raw error text.
 
 The shipped systemd unit uses `Restart=on-failure`, but caps recovery at five
 starts per ten minutes so a deterministic persistence fault cannot flap every

--- a/examples/prometheus/rustbgpd-alerts.yml
+++ b/examples/prometheus/rustbgpd-alerts.yml
@@ -36,6 +36,31 @@ groups:
             {{ $labels.instance }} for 2 minutes. The daemon is down,
             unreachable, or `prometheus_addr` is no longer configured.
 
+      - alert: BgpRuntimeConfigSettlementSlow
+        # Early advisory: ten minutes of owned settlement is far past any
+        # measured normal apply but leaves twenty minutes of the fixed
+        # 30-minute fail-stop budget for an operator to inspect the owner.
+        # Elapsed is derived at scrape time from the stored start instant,
+        # so a wedged owner keeps this firing on a frozen phase.
+        # Recovery-fenced owners are already committed to exit 70 and are
+        # deliberately excluded.
+        expr: >-
+          bgp_runtime_config_settlement_active{fence_reason="none"} == 1
+          and
+          bgp_runtime_config_settlement_elapsed_seconds{fence_reason="none"} >= 600
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Runtime-config settlement still running after ten minutes"
+          description: >-
+            The {{ $labels.kind }} runtime-config operation on
+            {{ $labels.instance }} has held ownership in {{ $labels.phase }}
+            with its response {{ $labels.response_attached }} for at least
+            ten minutes. Inspect the owning actor now; the daemon exits
+            independently when the fixed 30-minute budget plus five-second
+            grace expires.
+
       - alert: BgpRuntimeConfigSettlementHalfBudget
         # The owner has consumed half of the fixed 30-minute settlement
         # budget. Recovery-fenced owners are already committed to exit 70 and

--- a/examples/prometheus/rustbgpd-alerts_test.yml
+++ b/examples/prometheus/rustbgpd-alerts_test.yml
@@ -41,6 +41,54 @@ tests:
                 edge1:9179 for 2 minutes. The daemon is down,
                 unreachable, or `prometheus_addr` is no longer configured.
 
+  # ── BgpRuntimeConfigSettlementSlow ────────────────────────────
+  # Label names and values mirror the daemon's closed metric surface in
+  # crates/api/src/runtime_config_settlement.rs: labels kind/phase/
+  # response_attached/fence_reason with closed-enum values only.
+  - interval: 1s
+    input_series:
+      # edge1: one live apply owner wedged in `mutating`. Elapsed is derived
+      # at scrape time, so it keeps growing while the phase stays frozen.
+      - series: 'bgp_runtime_config_settlement_active{instance="edge1:9179",kind="apply",phase="mutating",response_attached="attached",fence_reason="none"}'
+        values: "1x602"
+      - series: 'bgp_runtime_config_settlement_elapsed_seconds{instance="edge1:9179",kind="apply",phase="mutating",response_attached="attached",fence_reason="none"}'
+        values: "0+1x602"
+      - series: 'bgp_runtime_config_settlement_budget_seconds{instance="edge1:9179",kind="apply",phase="mutating",response_attached="attached",fence_reason="none"}'
+        values: "1800x602"
+      # An inactive owner with a stale high elapsed must not fire.
+      - series: 'bgp_runtime_config_settlement_active{instance="edge2:9179",kind="confirm",phase="owned_preflight",response_attached="detached",fence_reason="none"}'
+        values: "0x602"
+      - series: 'bgp_runtime_config_settlement_elapsed_seconds{instance="edge2:9179",kind="confirm",phase="owned_preflight",response_attached="detached",fence_reason="none"}'
+        values: "700x602"
+      # A recovery-fenced owner past ten minutes is excluded: it is already
+      # committed to exit 70.
+      - series: 'bgp_runtime_config_settlement_active{instance="edge3:9179",kind="sighup",phase="settling_rollback",response_attached="detached",fence_reason="acknowledgement_lost"}'
+        values: "1x602"
+      - series: 'bgp_runtime_config_settlement_elapsed_seconds{instance="edge3:9179",kind="sighup",phase="settling_rollback",response_attached="detached",fence_reason="acknowledgement_lost"}'
+        values: "700x602"
+    alert_rule_test:
+      - eval_time: 9m59s
+        alertname: BgpRuntimeConfigSettlementSlow
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: BgpRuntimeConfigSettlementSlow
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: edge1:9179
+              kind: apply
+              phase: mutating
+              response_attached: attached
+              fence_reason: none
+            exp_annotations:
+              summary: "Runtime-config settlement still running after ten minutes"
+              description: >-
+                The apply runtime-config operation on edge1:9179 has held
+                ownership in mutating with its response attached for at least
+                ten minutes. Inspect the owning actor now; the daemon exits
+                independently when the fixed 30-minute budget plus five-second
+                grace expires.
+
   # ── BgpRuntimeConfigSettlementHalfBudget ──────────────────────
   - interval: 1s
     input_series:


### PR DESCRIPTION
Implements the remaining runtime-config settlement observability per ADR-0127's fencing/observability section (LAN-1023).

## Logs

Ownership registration, every phase transition, and settlement now emit one `info` event carrying `operation_id`, `kind`, `phase`, `elapsed_seconds`, and `budget_seconds` — the same field shape as the existing fencing diagnostic and budget warnings. The operation ID appears only in logs, never as a metric label; all logged values are closed-enum strings or integers.

## Scrape-derivation proof

Elapsed remains derived at read time from the stored `registered_at` instant; nothing writes an elapsed value at phase transitions. A new test (`scrape_derives_elapsed_from_start_instant_while_wedged_phase_is_frozen`) registers an owner, advances it to `mutating`, and then wedges it: only a test-only scrape-clock advance moves. Scraping the real Prometheus registry 15 minutes into the wedge reads an elapsed of 15 minutes on the frozen `mutating` phase, and a later scrape reads a further-grown elapsed with the phase still frozen. The metric surface also empties on settlement (existing `metrics_are_dynamic_single_tuple_and_idle_is_empty`), so both growth and reclaim paths refresh.

## Ten-minute advisory

`BgpRuntimeConfigSettlementSlow` fires when an unfenced owner's scrape-derived elapsed reaches 600 seconds, twenty minutes before the fixed fail-stop budget expires. Recovery-fenced owners are excluded; they are already committed to exit 70. The promtool test's input series use exactly the label set the daemon emits (`kind`, `phase`, `response_attached`, `fence_reason`, values from the closed enums in `crates/api/src/runtime_config_settlement.rs`), and cover firing at 10m, not firing at 9m59s, an inactive stale series, and a fenced owner.

## Docs

docs/OPERATIONS.md settlement section gains the metrics reference table (metric, type, meaning plus the closed label roster) and the two-alert escalation sentence. CHANGELOG [Unreleased] entry added.

## Gates

- `cargo test -p rustbgpd-api runtime_config_settlement`: 29 passed, 0 failed (includes the new wedge proof test)
- `cargo test -p rustbgpd-telemetry`: 93 passed, 0 failed
- Observability assets battery: Grafana checker unittest (14 tests) + dashboard check + `promtool check rules` (27 rules) + `promtool test rules` all SUCCESS with pinned promtool 3.4.1
- `cargo clippy -p rustbgpd-api --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean

Workspace battery intentionally not run here; it runs at merge.