### PR TITLE
ci: share verified BIRD 3.3.1 source archive

### DIFF
--- a/.github/actions/stage-bird3-artifact/action.yml
+++ b/.github/actions/stage-bird3-artifact/action.yml
@@ -1,0 +1,22 @@
+name: "Stage verified BIRD 3 source archive"
+description: >-
+  Download the same-run BIRD 3 source archive, verify its immutable checksum
+  and source version offline, and stage it into the interop image build
+  context.
+runs:
+  using: "composite"
+  steps:
+    - name: Download verified BIRD 3 archive
+      uses: actions/download-artifact@v8
+      with:
+        name: bird3-v3.3.1-source
+        path: ${{ runner.temp }}/bird3-artifact
+
+    - name: Stage exact BIRD 3 archive offline
+      shell: bash
+      run: |
+        set -euo pipefail
+        .github/scripts/install-bird3.sh \
+          --stage-archive \
+          "$RUNNER_TEMP/bird3-artifact/bird-3.3.1.tar.gz" \
+          tests/interop/bird3-archive

--- a/.github/scripts/install-bird3.sh
+++ b/.github/scripts/install-bird3.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly BIRD3_VERSION="3.3.1"
+readonly BIRD3_SHA256="d5a8d651d6184c18252954932bb249dfee1fd213b3665cdd86226ac45edc0190"
+readonly BIRD3_ASSET="bird-${BIRD3_VERSION}.tar.gz"
+readonly BIRD3_URL="https://bird.nic.cz/download/${BIRD3_ASSET}"
+readonly BIRD3_ATTEMPTS=3
+
+verify_archive() {
+    local sha256=${1:?sha256}
+    local archive=${2:?archive}
+
+    [[ -f "$archive" ]] || return 1
+    if ! printf '%s  %s\n' "$sha256" "$archive" \
+        | sha256sum --check --status; then
+        echo "bird3 archive checksum mismatch: ${archive}" >&2
+        return 1
+    fi
+}
+
+verify_archive_contents() {
+    local sha256=${1:?sha256}
+    local archive=${2:?archive}
+    local reported
+
+    verify_archive "$sha256" "$archive" || return 1
+    # Source tarball: the analogue of a binary --version check is the
+    # version-named top directory plus the upstream VERSION file. grep runs
+    # without -q so it drains the listing (pipefail would otherwise surface
+    # tar's SIGPIPE on an early -q exit as a spurious failure).
+    if ! tar -tzf "$archive" | grep -x "bird-${BIRD3_VERSION}/configure" >/dev/null; then
+        echo "bird3 archive did not contain bird-${BIRD3_VERSION}/configure" >&2
+        return 1
+    fi
+    reported=$(tar -xzOf "$archive" "bird-${BIRD3_VERSION}/VERSION") || return 1
+    if [[ "$reported" != "$BIRD3_VERSION" ]]; then
+        echo "unexpected bird3 source version: ${reported}" >&2
+        return 1
+    fi
+}
+
+stage_archive() (
+    local sha256=${1:?sha256}
+    local archive=${2:?archive}
+    local stage_dir=${3:?stage directory}
+    local staged_target
+
+    # This path is deliberately offline. Only the producer may fetch the
+    # release archive; consumers re-verify the same-run artifact before the
+    # bird3 image build context sees any bytes. The archive itself is staged
+    # (not extracted): Dockerfile.bird3 re-verifies the checksum inside the
+    # build before extraction.
+    verify_archive_contents "$sha256" "$archive" || return 1
+    mkdir -p "$stage_dir"
+    staged_target=$(mktemp "${stage_dir}/.${BIRD3_ASSET}.XXXXXX")
+    trap 'rm -f -- "$staged_target"' EXIT
+    install -m 0644 "$archive" "$staged_target"
+    mv -f -- "$staged_target" "${stage_dir}/${BIRD3_ASSET}"
+    printf 'staged verified bird %s source archive\n' "$BIRD3_VERSION"
+)
+
+download_archive_once() {
+    local url=${1:?url}
+    local destination=${2:?destination}
+
+    curl -fsSL \
+        --connect-timeout 10 \
+        --max-time 120 \
+        --output "$destination" \
+        "$url"
+}
+
+prepare_archive() {
+    local sha256=${1:?sha256}
+    local url=${2:?url}
+    local archive=${3:?archive}
+    local attempt staged_archive
+
+    if verify_archive_contents "$sha256" "$archive" 2>/dev/null; then
+        echo "using verified cached bird3 archive"
+        return 0
+    fi
+    if [[ -e "$archive" ]]; then
+        echo "::warning::discarding invalid cached bird3 archive" >&2
+        rm -f -- "$archive"
+    fi
+
+    mkdir -p "$(dirname "$archive")"
+    for ((attempt = 1; attempt <= BIRD3_ATTEMPTS; attempt++)); do
+        staged_archive=$(mktemp "${archive}.download.XXXXXX")
+        if download_archive_once "$url" "$staged_archive" \
+            && verify_archive_contents "$sha256" "$staged_archive"; then
+            mv -f -- "$staged_archive" "$archive"
+            echo "downloaded and verified bird3 archive"
+            return 0
+        fi
+        rm -f -- "$staged_archive"
+        if ((attempt < BIRD3_ATTEMPTS)); then
+            echo "::warning::bird3 download/verify attempt ${attempt}/${BIRD3_ATTEMPTS} failed; retrying" >&2
+            sleep $((attempt * 5))
+        fi
+    done
+
+    echo "::error::bird3 download/verification failed after ${BIRD3_ATTEMPTS} attempts: ${url}" >&2
+    return 1
+}
+
+fail_self_test() {
+    echo "bird3 installer self-test failed: $*" >&2
+    return 1
+}
+
+self_test() (
+    local fixture_dir source_dir valid_archive valid_checksum wrong_dir wrong_archive
+    local wrong_checksum partial_archive expected_url staged_hash attempts
+
+    fixture_dir=$(mktemp -d)
+    trap 'rm -rf -- "$fixture_dir"' EXIT
+    [[ "$BIRD3_VERSION" == "3.3.1" ]] || fail_self_test "version pin drifted"
+    [[ "$BIRD3_SHA256" == "d5a8d651d6184c18252954932bb249dfee1fd213b3665cdd86226ac45edc0190" ]] \
+        || fail_self_test "checksum pin drifted"
+    [[ "$BIRD3_ASSET" == "bird-3.3.1.tar.gz" ]] \
+        || fail_self_test "archive name drifted"
+    printf -v expected_url '%s%s' \
+        'https://bird.nic.cz' \
+        '/download/bird-3.3.1.tar.gz'
+    [[ "$BIRD3_URL" == "$expected_url" ]] \
+        || fail_self_test "release URL drifted"
+    [[ "$BIRD3_ATTEMPTS" -eq 3 ]] || fail_self_test "retry bound drifted"
+
+    source_dir="$fixture_dir/source/bird-3.3.1"
+    mkdir -p "$source_dir"
+    printf '#!/bin/sh\n' >"$source_dir/configure"
+    printf '3.3.1\n' >"$source_dir/VERSION"
+    valid_archive="$fixture_dir/valid.tar.gz"
+    tar -czf "$valid_archive" -C "$fixture_dir/source" bird-3.3.1
+    valid_checksum=$(sha256sum "$valid_archive" | awk '{print $1}')
+
+    stage_archive "$valid_checksum" "$valid_archive" \
+        "$fixture_dir/stage" >/dev/null
+    [[ -f "$fixture_dir/stage/$BIRD3_ASSET" ]] \
+        || fail_self_test "verified archive was not staged"
+    cmp -s "$valid_archive" "$fixture_dir/stage/$BIRD3_ASSET" \
+        || fail_self_test "staged archive bytes drifted"
+    staged_hash=$(sha256sum "$fixture_dir/stage/$BIRD3_ASSET" | awk '{print $1}')
+
+    if stage_archive "$BIRD3_SHA256" "$valid_archive" \
+        "$fixture_dir/stage" 2>/dev/null; then
+        fail_self_test "wrong checksum was accepted"
+    fi
+    [[ "$(sha256sum "$fixture_dir/stage/$BIRD3_ASSET" | awk '{print $1}')" == "$staged_hash" ]] \
+        || fail_self_test "checksum failure replaced the staged target"
+    head -c 12 "$valid_archive" >"$fixture_dir/truncated.tar.gz"
+    if stage_archive "$valid_checksum" "$fixture_dir/truncated.tar.gz" \
+        "$fixture_dir/truncated" 2>/dev/null; then
+        fail_self_test "truncated archive was accepted"
+    fi
+    printf '<html>503</html>\n' >"$fixture_dir/http-body.tar.gz"
+    if stage_archive "$valid_checksum" "$fixture_dir/http-body.tar.gz" \
+        "$fixture_dir/http" 2>/dev/null; then
+        fail_self_test "HTTP response body was accepted"
+    fi
+
+    partial_archive="$fixture_dir/no-configure.tar.gz"
+    rm -f -- "$source_dir/configure"
+    tar -czf "$partial_archive" -C "$fixture_dir/source" bird-3.3.1
+    printf '#!/bin/sh\n' >"$source_dir/configure"
+    if stage_archive "$(sha256sum "$partial_archive" | awk '{print $1}')" \
+        "$partial_archive" "$fixture_dir/partial" 2>/dev/null; then
+        fail_self_test "archive without configure was accepted"
+    fi
+
+    wrong_dir="$fixture_dir/wrong/bird-3.3.1"
+    mkdir -p "$wrong_dir"
+    printf '#!/bin/sh\n' >"$wrong_dir/configure"
+    printf '3.3.0\n' >"$wrong_dir/VERSION"
+    wrong_archive="$fixture_dir/wrong-version.tar.gz"
+    tar -czf "$wrong_archive" -C "$fixture_dir/wrong" bird-3.3.1
+    wrong_checksum=$(sha256sum "$wrong_archive" | awk '{print $1}')
+    if stage_archive "$wrong_checksum" "$wrong_archive" \
+        "$fixture_dir/stage" 2>/dev/null; then
+        fail_self_test "wrong source version was accepted"
+    fi
+    [[ "$(sha256sum "$fixture_dir/stage/$BIRD3_ASSET" | awk '{print $1}')" == "$staged_hash" ]] \
+        || fail_self_test "version failure replaced the staged target"
+
+    printf 'invalid cache\n' >"$fixture_dir/cache.tar.gz"
+    attempts=0
+    download_archive_once() {
+        ((attempts += 1))
+        if ((attempts == 1)); then
+            printf 'transient failure\n' >"$2"
+        else
+            cp "$valid_archive" "$2"
+        fi
+    }
+    sleep() { :; }
+    prepare_archive "$valid_checksum" "https://example.invalid/retry" \
+        "$fixture_dir/cache.tar.gz" >/dev/null 2>&1
+    [[ "$attempts" -eq 2 ]] || fail_self_test "bounded retry count drifted"
+    cmp -s "$valid_archive" "$fixture_dir/cache.tar.gz" \
+        || fail_self_test "invalid cache was not atomically replaced"
+
+    download_archive_once() { fail_self_test "warm cache reached upstream"; }
+    prepare_archive "$valid_checksum" "https://example.invalid/unreachable" \
+        "$fixture_dir/cache.tar.gz" \
+        | grep -Fxq "using verified cached bird3 archive" \
+        || fail_self_test "warm cache attempted an upstream fetch"
+
+    attempts=0
+    download_archive_once() {
+        ((attempts += 1))
+        printf '<html>503</html>\n' >"$2"
+    }
+    if prepare_archive "$valid_checksum" "https://example.invalid/unavailable" \
+        "$fixture_dir/cold-cache.tar.gz" >/dev/null 2>&1; then
+        fail_self_test "cold-cache upstream failure was accepted"
+    fi
+    [[ "$attempts" -eq "$BIRD3_ATTEMPTS" ]] \
+        || fail_self_test "cold-cache retry bound was not enforced"
+    [[ ! -e "$fixture_dir/cold-cache.tar.gz" ]] \
+        || fail_self_test "failed cold-cache fetch left an artifact"
+
+    # shellcheck disable=SC2317
+    curl() { fail_self_test "offline stage invoked curl"; }
+    stage_archive "$valid_checksum" "$valid_archive" \
+        "$fixture_dir/offline-stage" >/dev/null \
+        || fail_self_test "offline archive stage failed"
+
+    echo "bird3 installer self-test passed"
+)
+
+usage() {
+    echo "usage: $0 --prepare-archive ARCHIVE | --stage-archive ARCHIVE STAGE_DIR | --self-test" >&2
+    return 2
+}
+
+case "${1:-}" in
+    --prepare-archive)
+        [[ $# -eq 2 ]] || usage
+        prepare_archive "$BIRD3_SHA256" "$BIRD3_URL" "$2"
+        ;;
+    --stage-archive)
+        [[ $# -eq 3 ]] || usage
+        stage_archive "$BIRD3_SHA256" "$2" "$3"
+        ;;
+    --self-test)
+        [[ $# -eq 1 ]] || usage
+        self_test
+        ;;
+    *) usage ;;
+esac

--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -113,6 +113,35 @@ jobs:
           retention-days: 1
           compression-level: 0
 
+  bird3_archive:
+    needs: classify_changes
+    if: needs.classify_changes.outputs.run_labs == 'true'
+    name: Prepare exact bird3 archive
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+      - name: Restore exact bird3 archive cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/bird3-cache/bird-3.3.1.tar.gz
+          key: bird3-v3.3.1-source-d5a8d651d6184c18252954932bb249dfee1fd213b3665cdd86226ac45edc0190
+      - name: Prepare exact bird3 archive
+        run: |
+          .github/scripts/install-bird3.sh \
+            --prepare-archive \
+            "$RUNNER_TEMP/bird3-cache/bird-3.3.1.tar.gz"
+      - name: Upload verified bird3 archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: bird3-v3.3.1-source
+          path: ${{ runner.temp }}/bird3-cache/bird-3.3.1.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
   # Warm one fixed-scope cache per source SHA; jobs still build and load their
   # own image, falling back to an uncached build if the cache is unavailable.
   prime_dev_image:
@@ -417,7 +446,7 @@ jobs:
           script: tests/interop/scripts/test-m51-bfd-frr.sh
 
   m43:
-    needs: [grpcurl_archive, prime_dev_image]
+    needs: [grpcurl_archive, bird3_archive, prime_dev_image]
     name: M43 — TCP-AO live rotation and crash recovery (BIRD 3.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -513,13 +542,19 @@ jobs:
           cargo test -p rustbgpd-transport --lib "$receipt" -- \
             --ignored --exact --nocapture
 
-      # Buildx GHA layer cache (LAN-252): the bird.nic.cz tarball fetch and
-      # the full BIRD source build live in layers keyed on the Dockerfile
-      # content (which pins BIRD_VERSION and the configure flags), so warm
-      # runs skip both the flaky download and the compile; a version bump
-      # edits the Dockerfile and naturally invalidates. Buildx itself is set
+      # The staged verified archive (LAN-1024) composes with the buildx GHA
+      # layer cache (LAN-252): on a cache hit the full BIRD source build is
+      # replayed from layers keyed on the Dockerfile content and the staged
+      # archive bytes, so neither the fetch nor the stage matters; on a cache
+      # miss the staged archive keeps the build offline, confining the
+      # upstream fetch to a bounded fallback for cold local builds. A version
+      # bump edits the Dockerfile and naturally invalidates. Buildx is set
       # up by setup-dataplane-host above. The dedicated scope keeps this
       # image's cache separate from rustbgpd:dev's.
+      - name: Stage verified BIRD 3 archive
+        if: steps.tcp_ao.outputs.supported == 'true'
+        uses: ./.github/actions/stage-bird3-artifact
+
       - name: Build BIRD 3.3.1 TCP-AO image
         if: steps.tcp_ao.outputs.supported == 'true'
         uses: docker/build-push-action@v7
@@ -835,14 +870,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: ${{ always() }}
-    needs: [classify_changes, grpcurl_archive, gobgp_archive, prime_dev_image, m36, m37,
-      m37-ip, m38, m39, m39b, m48, m60, m61, m62, m40, m42, m50, m52,
+    needs: [classify_changes, grpcurl_archive, gobgp_archive, bird3_archive, prime_dev_image, m36,
+      m37, m37-ip, m38, m39, m39b, m48, m60, m61, m62, m40, m42, m50, m52,
       m58, m53, m51, m43, m47, m69, m70, m65, m71, m72, m66,
       m67, m68, netns]
     env:
       NEEDS_CONTEXT: ${{ toJSON(needs) }}
       EXPECTED_JOBS: >-
-        classify_changes grpcurl_archive gobgp_archive prime_dev_image m36 m37 m37-ip m38 m39
+        classify_changes grpcurl_archive gobgp_archive bird3_archive prime_dev_image
+        m36 m37 m37-ip m38 m39
         m39b m48 m60 m61 m62 m40 m42 m50 m52 m58 m53 m51 m43 m47
         m69 m70 m65 m71 m72 m66 m67 m68 netns
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,10 @@ tests/soak/runs/
 tests/interop/gobgp-archive/*
 !tests/interop/gobgp-archive/.gitkeep
 
+# CI-staged BIRD 3 source archive (never vendor upstream tarballs into git)
+tests/interop/bird3-archive/*
+!tests/interop/bird3-archive/.gitkeep
+
 
 # M44 mTLS PKI fixture — regenerated per CI run by gen-m44-certs.sh so
 # certificate validity windows never expire in the repo.

--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -67,6 +67,17 @@ GOBGP_ACTION = "uses: ./.github/actions/stage-gobgp-artifact"
 GOBGP_BUILD = (
     "docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop"
 )
+BIRD3_VERSION = "3.3.1"
+BIRD3_SHA256 = "d5a8d651d6184c18252954932bb249dfee1fd213b3665cdd86226ac45edc0190"
+BIRD3_ARCHIVE = f"bird-{BIRD3_VERSION}.tar.gz"
+BIRD3_ARTIFACT = f"bird3-v{BIRD3_VERSION}-source"
+BIRD3_CACHE_KEY = f"{BIRD3_ARTIFACT}-{BIRD3_SHA256}"
+BIRD3_ACTION = "uses: ./.github/actions/stage-bird3-artifact"
+BIRD3_BUILD = "file: tests/interop/Dockerfile.bird3"
+BIRD3_CACHE_SEAMS = (
+    "cache-from: type=gha,scope=bird3-tcpao",
+    "cache-to: type=gha,mode=max,scope=bird3-tcpao,ignore-error=true",
+)
 
 TRIGGER_HASHES = {
     "ci.yml": "65951f4c4d1d6c4d3aae2c33705d14cdc144b3efd8bcc01653049e6d7f2fb5f8",
@@ -86,15 +97,15 @@ CALL_HASHES = {
 }
 PINS = collections.Counter(
     {
-        "actions/checkout@v7": 85,
+        "actions/checkout@v7": 86,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable": 3,
         "Swatinem/rust-cache@v2": 5,
         "dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 1.95": 2,
         "docker/setup-buildx-action@v4": 44,
         "docker/build-push-action@v7": 45,
-        "actions/cache@v6": 6,
-        "actions/upload-artifact@v7": 7,
-        "actions/download-artifact@v8": 5,
+        "actions/cache@v6": 7,
+        "actions/upload-artifact@v7": 8,
+        "actions/download-artifact@v8": 6,
         "rustsec/audit-check@v2.0.0": 1,
         "EmbarkStudios/cargo-deny-action@v2": 1,
     }
@@ -205,6 +216,34 @@ def check(root: Path) -> list[str]:
         errors.append("install-gobgp.sh release URL inventory drifted")
     if re.search(r"curl[^\n]*\|\s*(?:sudo\s+)?tar", gobgp_installer_text):
         errors.append("install-gobgp.sh streams network bytes into tar")
+    bird3_installer = root / ".github" / "scripts" / "install-bird3.sh"
+    if not bird3_installer.is_file():
+        errors.append("install-bird3.sh is missing")
+    elif stat.S_IMODE(bird3_installer.stat().st_mode) != 0o755:
+        errors.append("install-bird3.sh must have exact executable mode 100755")
+    bird3_installer_text = (
+        bird3_installer.read_text() if bird3_installer.is_file() else ""
+    )
+    for seam in (
+        f'readonly BIRD3_VERSION="{BIRD3_VERSION}"',
+        f'readonly BIRD3_SHA256="{BIRD3_SHA256}"',
+        'readonly BIRD3_ASSET="bird-${BIRD3_VERSION}.tar.gz"',
+        "https://bird.nic.cz/download/${BIRD3_ASSET}",
+        "readonly BIRD3_ATTEMPTS=3",
+        "curl -fsSL",
+        "--connect-timeout 10",
+        "--max-time 120",
+        "--prepare-archive",
+        "--stage-archive",
+        "--self-test",
+        "unexpected bird3 source version",
+    ):
+        if seam not in bird3_installer_text:
+            errors.append(f"install-bird3.sh missing {seam}")
+    if bird3_installer_text.count("bird.nic.cz/download/") != 1:
+        errors.append("install-bird3.sh download URL inventory drifted")
+    if re.search(r"curl[^\n]*\|\s*(?:sudo\s+)?tar", bird3_installer_text):
+        errors.append("install-bird3.sh streams network bytes into tar")
     workflow_dir = root / ".github" / "workflows"
     texts = {name: (workflow_dir / name).read_text() for name in WORKFLOWS}
     for name, text in texts.items():
@@ -297,6 +336,7 @@ def check(root: Path) -> list[str]:
             ["grpcurl_archive"]
             + ([] if setup else ["gnmic_archive"])
             + ["gobgp_archive"]
+            + (["bird3_archive"] if setup else [])
         )
         gobgp_consumers = (
             {"m65", "m71", "m72"} if setup else {"m74", "m75", "m81", "m82", "m83"}
@@ -451,6 +491,49 @@ def check(root: Path) -> list[str]:
         )
         if gobgp_producer.count(exact_gobgp_path) != 2:
             errors.append(f"{name}:gobgp_archive cache/artifact paths drifted")
+        if setup:
+            bird3_producer = jobs.get("bird3_archive", "")
+            for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
+                if not _has_line(bird3_producer, f"    {seam}"):
+                    errors.append(f"{name}:bird3_archive missing job-level {seam}")
+            for seam in (
+                "name: Prepare exact bird3 archive",
+                "runs-on: ubuntu-latest",
+                "timeout-minutes: 10",
+                CHECKOUT,
+                "ref: ${{ github.sha }}",
+                "uses: actions/cache@v6",
+                f"path: ${{{{ runner.temp }}}}/bird3-cache/{BIRD3_ARCHIVE}",
+                f"key: {BIRD3_CACHE_KEY}",
+                "--prepare-archive",
+                f'"$RUNNER_TEMP/bird3-cache/{BIRD3_ARCHIVE}"',
+                "uses: actions/upload-artifact@v7",
+                f"name: {BIRD3_ARTIFACT}",
+                "if-no-files-found: error",
+                "retention-days: 1",
+                "compression-level: 0",
+            ):
+                if seam not in bird3_producer:
+                    errors.append(f"{name}:bird3_archive missing {seam}")
+            for forbidden in (
+                "restore-keys:",
+                "continue-on-error:",
+                "actions/download-artifact@",
+                "--stage-archive",
+            ):
+                if forbidden in bird3_producer:
+                    errors.append(f"{name}:bird3_archive permits {forbidden}")
+            if bird3_producer.count("uses: actions/cache@v6") != 1:
+                errors.append(f"{name}:bird3_archive must restore one exact cache")
+            if bird3_producer.count("--prepare-archive") != 1:
+                errors.append(f"{name}:bird3_archive must prepare one archive")
+            if bird3_producer.count("uses: actions/upload-artifact@v7") != 1:
+                errors.append(f"{name}:bird3_archive must upload one artifact")
+            exact_bird3_path = (
+                f"path: ${{{{ runner.temp }}}}/bird3-cache/{BIRD3_ARCHIVE}"
+            )
+            if bird3_producer.count(exact_bird3_path) != 2:
+                errors.append(f"{name}:bird3_archive cache/artifact paths drifted")
         primer = jobs.get("prime_dev_image", "")
         for seam in (CLASSIFIER_NEEDS, CLASSIFIER_IF):
             if not _has_line(primer, f"    {seam}"):
@@ -480,6 +563,10 @@ def check(root: Path) -> list[str]:
                 expected_needs = (
                     "    needs: [grpcurl_archive, gnmic_archive, prime_dev_image]"
                 )
+            elif setup and job_name == "m43":
+                expected_needs = (
+                    "    needs: [grpcurl_archive, bird3_archive, prime_dev_image]"
+                )
             elif job_name in gobgp_consumers:
                 expected_needs = (
                     "    needs: [grpcurl_archive, gobgp_archive, prime_dev_image]"
@@ -503,6 +590,25 @@ def check(root: Path) -> list[str]:
                 errors.append(
                     f"{name}:{job_name}: gobgp build precedes the staged artifact"
                 )
+            expected_bird3 = 1 if setup and job_name == "m43" else 0
+            if job.count(BIRD3_ACTION) != expected_bird3:
+                errors.append(f"{name}:{job_name}: bird3 stage consumer drifted")
+            if job.count(BIRD3_BUILD) != expected_bird3:
+                errors.append(
+                    f"{name}:{job_name}: bird3 image build inventory drifted"
+                )
+            if expected_bird3 and not (
+                0 <= job.find(BIRD3_ACTION) < job.find(BIRD3_BUILD)
+            ):
+                errors.append(
+                    f"{name}:{job_name}: bird3 build precedes the staged artifact"
+                )
+            if expected_bird3:
+                for seam in BIRD3_CACHE_SEAMS:
+                    if seam not in job:
+                        errors.append(
+                            f"{name}:{job_name}: bird3 buildx layer cache missing {seam}"
+                        )
             if CHECKOUT not in job:
                 errors.append(f"{name}:{job_name}: pinned checkout drifted")
             if setup:
@@ -607,6 +713,9 @@ def check(root: Path) -> list[str]:
     gobgp_action = (
         root / ".github" / "actions" / "stage-gobgp-artifact" / "action.yml"
     ).read_text()
+    bird3_action = (
+        root / ".github" / "actions" / "stage-bird3-artifact" / "action.yml"
+    ).read_text()
     for seam in (
         "uses: actions/download-artifact@v8",
         f"name: {GRPCURL_ARTIFACT}",
@@ -683,6 +792,31 @@ def check(root: Path) -> list[str]:
     ):
         if forbidden in gobgp_action:
             errors.append(f"stage-gobgp-artifact permits {forbidden}")
+    for seam in (
+        "uses: actions/download-artifact@v8",
+        f"name: {BIRD3_ARTIFACT}",
+        "path: ${{ runner.temp }}/bird3-artifact",
+        "--stage-archive",
+        f'"$RUNNER_TEMP/bird3-artifact/{BIRD3_ARCHIVE}"',
+        "tests/interop/bird3-archive",
+    ):
+        if seam not in bird3_action:
+            errors.append(f"stage-bird3-artifact missing {seam}")
+    if bird3_action.count("uses: actions/download-artifact@v8") != 1:
+        errors.append("stage-bird3-artifact must download one same-run artifact")
+    if bird3_action.count("--stage-archive") != 1:
+        errors.append("stage-bird3-artifact must perform one offline stage")
+    for forbidden in (
+        "--prepare-archive",
+        "actions/cache@",
+        "actions/upload-artifact@",
+        "restore-keys:",
+        "continue-on-error:",
+        "bird.nic.cz",
+        "curl ",
+    ):
+        if forbidden in bird3_action:
+            errors.append(f"stage-bird3-artifact permits {forbidden}")
     # split(...)[-1] returns the whole file when the step name drifts, which
     # turns every seam check below into a file-wide search that passes
     # vacuously. Scope the region only once the anchor is known to be present.
@@ -740,9 +874,25 @@ def check(root: Path) -> list[str]:
     )
     if "osrg/gobgp/releases" in gobgp_surfaces:
         errors.append("gobgp release URL escaped the installer/Dockerfile")
+    if texts["interop.yml"].count(BIRD3_ACTION) != 0:
+        errors.append("interop.yml: bird3 stage must remain kernel-only")
+    if texts["kernel-dataplane.yml"].count(BIRD3_ACTION) != 1:
+        errors.append("kernel-dataplane.yml: bird3 stage consumer inventory drifted")
+    bird3_surfaces = "\n".join(
+        (texts["interop.yml"], texts["kernel-dataplane.yml"], bird3_action)
+    )
+    if "bird.nic.cz" in bird3_surfaces:
+        errors.append("bird.nic.cz URL escaped the installer/Dockerfile")
 
     pins = collections.Counter()
-    for text in [*texts.values(), action, grpcurl_action, gnmic_action, gobgp_action]:
+    for text in [
+        *texts.values(),
+        action,
+        grpcurl_action,
+        gnmic_action,
+        gobgp_action,
+        bird3_action,
+    ]:
         for value in re.findall(r"^\s*(?:- )?uses:\s*(.+)$", text, re.MULTILINE):
             if not value.strip().startswith("./"):
                 pins[value.strip()] += 1
@@ -792,6 +942,32 @@ def check(root: Path) -> list[str]:
         errors.append("Dockerfile.gobgp: floating GoBGP release is forbidden")
     if "go install github.com/osrg/gobgp" in gobgp or "FROM golang:" in gobgp:
         errors.append("Dockerfile.gobgp: source build replaced pinned release archives")
+
+    bird3 = (root / "tests" / "interop" / "Dockerfile.bird3").read_text()
+    for seam in (
+        f"ARG BIRD_VERSION={BIRD3_VERSION}",
+        "COPY bird3-archive/ /tmp/bird3-archive/",
+        f'checksum="{BIRD3_SHA256}"',
+        'archive="bird-${BIRD_VERSION}.tar.gz"',
+        'if [ ! -f "/tmp/bird3-archive/${archive}" ]; then',
+        "https://bird.nic.cz/download/bird-${BIRD_VERSION}.tar.gz",
+        'if [ "${attempt}" -ge 3 ]; then',
+        'echo "${checksum}  /tmp/bird3-archive/${archive}" | sha256sum --check --strict',
+        'tar -xzf "/tmp/bird3-archive/${archive}" --strip-components=1',
+        "bird --version",
+    ):
+        if seam not in bird3:
+            errors.append(f"Dockerfile.bird3: pinned source seam missing: {seam}")
+    if bird3.count("bird.nic.cz") != 1:
+        errors.append("Dockerfile.bird3: download URL inventory drifted")
+    if not (
+        0
+        <= bird3.find("sha256sum --check --strict")
+        < bird3.find('tar -xzf "/tmp/bird3-archive/${archive}"')
+    ):
+        errors.append("Dockerfile.bird3: extraction precedes checksum verification")
+    if re.search(r"BIRD_VERSION=latest|/download/latest", bird3):
+        errors.append("Dockerfile.bird3: floating BIRD release is forbidden")
     return errors
 
 

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -94,6 +94,7 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
+                ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",
             ):
                 source = ROOT / fixture
@@ -107,10 +108,14 @@ class PrimerContractTests(unittest.TestCase):
             shutil.copy2(ROOT / gnmic_installer.relative_to(root), gnmic_installer)
             gobgp_installer = root / ".github" / "scripts" / "install-gobgp.sh"
             shutil.copy2(ROOT / gobgp_installer.relative_to(root), gobgp_installer)
+            bird3_installer = root / ".github" / "scripts" / "install-bird3.sh"
+            shutil.copy2(ROOT / bird3_installer.relative_to(root), bird3_installer)
             shutil.copy2(ROOT / "Dockerfile", root / "Dockerfile")
             gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
             gobgp.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
+            bird3 = root / "tests" / "interop" / "Dockerfile.bird3"
+            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.bird3", bird3)
             path = root / relative
             text = path.read_text()
             start = 0
@@ -141,6 +146,7 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
+                ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",
             ):
                 shutil.copytree(ROOT / fixture, root / fixture)
@@ -148,11 +154,15 @@ class PrimerContractTests(unittest.TestCase):
             gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
             gobgp.parent.mkdir(parents=True)
             shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
+            bird3 = root / "tests" / "interop" / "Dockerfile.bird3"
+            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.bird3", bird3)
             gnmic_installer = root / ".github" / "scripts" / "install-gnmic.sh"
             gnmic_installer.parent.mkdir(parents=True)
             shutil.copy2(ROOT / gnmic_installer.relative_to(root), gnmic_installer)
             gobgp_installer = root / ".github" / "scripts" / "install-gobgp.sh"
             shutil.copy2(ROOT / gobgp_installer.relative_to(root), gobgp_installer)
+            bird3_installer = root / ".github" / "scripts" / "install-bird3.sh"
+            shutil.copy2(ROOT / bird3_installer.relative_to(root), bird3_installer)
             self.assertIn("install-grpcurl.sh is missing", check(root))
 
     def test_grpcurl_installer_executable_mode_is_load_bearing(self):
@@ -163,6 +173,7 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
+                ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",
             ):
                 shutil.copytree(ROOT / fixture, root / fixture)
@@ -170,6 +181,8 @@ class PrimerContractTests(unittest.TestCase):
             gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
             gobgp.parent.mkdir(parents=True)
             shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
+            bird3 = root / "tests" / "interop" / "Dockerfile.bird3"
+            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.bird3", bird3)
             installer = root / ".github" / "scripts" / "install-grpcurl.sh"
             installer.parent.mkdir(parents=True)
             shutil.copy2(ROOT / installer.relative_to(root), installer)
@@ -177,6 +190,8 @@ class PrimerContractTests(unittest.TestCase):
             shutil.copy2(ROOT / gnmic_installer.relative_to(root), gnmic_installer)
             gobgp_installer = root / ".github" / "scripts" / "install-gobgp.sh"
             shutil.copy2(ROOT / gobgp_installer.relative_to(root), gobgp_installer)
+            bird3_installer = root / ".github" / "scripts" / "install-bird3.sh"
+            shutil.copy2(ROOT / bird3_installer.relative_to(root), bird3_installer)
             installer.chmod(0o644)
             self.assertIn(
                 "install-grpcurl.sh must have exact executable mode 100755",
@@ -195,6 +210,8 @@ class PrimerContractTests(unittest.TestCase):
         if workflow == "interop.yml":
             artifacts.append("gnmic_archive")
         artifacts.append("gobgp_archive")
+        if workflow == "kernel-dataplane.yml":
+            artifacts.append("bird3_archive")
         expected = ["classify_changes", *artifacts, "prime_dev_image", *roster]
         if workflow == "kernel-dataplane.yml":
             expected.append("netns")
@@ -227,6 +244,8 @@ class PrimerContractTests(unittest.TestCase):
             if workflow == "interop.yml":
                 artifacts.append("gnmic_archive")
             artifacts.append("gobgp_archive")
+            if workflow == "kernel-dataplane.yml":
+                artifacts.append("bird3_archive")
             skipped = {
                 job: "skipped" for job in [*artifacts, "prime_dev_image", *roster]
             }
@@ -277,6 +296,16 @@ class PrimerContractTests(unittest.TestCase):
                     0,
                     self.run_aggregate(workflow, "true", gobgp_red).returncode,
                 )
+            if workflow == "kernel-dataplane.yml":
+                with self.subTest(workflow=workflow, state="bird3 producer red"):
+                    self.assertNotEqual(
+                        0,
+                        self.run_aggregate(
+                            workflow,
+                            "true",
+                            {"bird3_archive": "failure", "m43": "skipped"},
+                        ).returncode,
+                    )
             for run_labs, results in (
                 ("", {}),
                 ("unknown", {}),
@@ -522,6 +551,95 @@ class PrimerContractTests(unittest.TestCase):
             with self.subTest(seam=old):
                 self.mutate(installer, old, new)
 
+    def test_bird3_producer_and_stage_consumer_are_load_bearing(self):
+        checksum = "d5a8d651d6184c18252954932bb249dfee1fd213b3665cdd86226ac45edc0190"
+        relative = ".github/workflows/kernel-dataplane.yml"
+        for old, new in (
+            ("  bird3_archive:\n", "  removed_bird3_archive:\n"),
+            (f"key: bird3-v3.3.1-source-{checksum}", "key: bird3-latest"),
+            ("name: bird3-v3.3.1-source", "name: bird3-latest"),
+            (
+                "needs: [grpcurl_archive, bird3_archive, prime_dev_image]",
+                "needs: [grpcurl_archive, prime_dev_image]",
+            ),
+            (
+                "uses: ./.github/actions/stage-bird3-artifact",
+                "run: curl https://example.invalid/bird3 -o /tmp/bird.tar.gz",
+            ),
+            ("cache-from: type=gha,scope=bird3-tcpao", "cache-from: type=gha"),
+            (
+                "cache-to: type=gha,mode=max,scope=bird3-tcpao,ignore-error=true",
+                "cache-to: type=gha",
+            ),
+        ):
+            with self.subTest(seam=old):
+                self.mutate(relative, old, new)
+        for seam, replacement in (
+            ("actions/cache@v6", "actions/cache@main"),
+            ("--prepare-archive", "--stage-archive"),
+            ("actions/upload-artifact@v7", "actions/upload-artifact@main"),
+        ):
+            with self.subTest(seam=f"bird3 producer {seam}"):
+                self.mutate(relative, seam, replacement, occurrence=2)
+        exact_path = (
+            "path: ${{ runner.temp }}/bird3-cache/bird-3.3.1.tar.gz"
+        )
+        for occurrence in (0, 1):
+            with self.subTest(seam="bird3 exact path", occurrence=occurrence):
+                self.mutate(
+                    relative,
+                    exact_path,
+                    "path: ${{ runner.temp }}/bird3-cache/wrong.tar.gz",
+                    occurrence=occurrence,
+                )
+
+        stage_step = (
+            "      - name: Stage verified BIRD 3 archive\n"
+            "        if: steps.tcp_ao.outputs.supported == 'true'\n"
+            "        uses: ./.github/actions/stage-bird3-artifact\n"
+        )
+        build_step = (
+            "      - name: Build BIRD 3.3.1 TCP-AO image\n"
+            "        if: steps.tcp_ao.outputs.supported == 'true'\n"
+            "        uses: docker/build-push-action@v7\n"
+            "        with:\n"
+            "          context: tests/interop\n"
+            "          file: tests/interop/Dockerfile.bird3\n"
+            "          load: true\n"
+            "          tags: bird:3.3.1-tcpao\n"
+            "          cache-from: type=gha,scope=bird3-tcpao\n"
+            "          cache-to: type=gha,mode=max,scope=bird3-tcpao,ignore-error=true\n"
+        )
+        with self.subTest(seam="stage precedes build"):
+            self.mutate(
+                relative,
+                f"{stage_step}\n{build_step}",
+                f"{build_step}\n{stage_step}",
+            )
+
+        action = ".github/actions/stage-bird3-artifact/action.yml"
+        for old, new in (
+            ("actions/download-artifact@v8", "actions/download-artifact@main"),
+            ("name: bird3-v3.3.1-source", "name: bird3-latest"),
+            ("--stage-archive", "--prepare-archive"),
+            (
+                "set -euo pipefail",
+                "set -euo pipefail\n        curl https://example.invalid/bird3",
+            ),
+        ):
+            with self.subTest(seam=old):
+                self.mutate(action, old, new)
+
+        installer = ".github/scripts/install-bird3.sh"
+        for old, new in (
+            ('readonly BIRD3_VERSION="3.3.1"', 'readonly BIRD3_VERSION="latest"'),
+            (checksum, "0" * 64),
+            ("curl -fsSL", "curl -sL"),
+            ("--connect-timeout 10", "--connect-timeout 0"),
+        ):
+            with self.subTest(seam=old):
+                self.mutate(installer, old, new)
+
     def test_gnmic_installer_executable_mode_is_load_bearing(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -530,6 +648,7 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
+                ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",
             ):
                 shutil.copytree(ROOT / fixture, root / fixture)
@@ -537,9 +656,16 @@ class PrimerContractTests(unittest.TestCase):
             gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
             gobgp.parent.mkdir(parents=True)
             shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
+            bird3 = root / "tests" / "interop" / "Dockerfile.bird3"
+            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.bird3", bird3)
             scripts = root / ".github" / "scripts"
             scripts.mkdir(parents=True)
-            for name in ("install-grpcurl.sh", "install-gnmic.sh", "install-gobgp.sh"):
+            for name in (
+                "install-grpcurl.sh",
+                "install-gnmic.sh",
+                "install-gobgp.sh",
+                "install-bird3.sh",
+            ):
                 shutil.copy2(ROOT / ".github" / "scripts" / name, scripts / name)
             (scripts / "install-gnmic.sh").chmod(0o644)
             self.assertIn(
@@ -555,6 +681,7 @@ class PrimerContractTests(unittest.TestCase):
                 ".github/actions/install-gnmic-artifact",
                 ".github/actions/install-grpcurl-artifact",
                 ".github/actions/setup-dataplane-host",
+                ".github/actions/stage-bird3-artifact",
                 ".github/actions/stage-gobgp-artifact",
             ):
                 shutil.copytree(ROOT / fixture, root / fixture)
@@ -562,13 +689,53 @@ class PrimerContractTests(unittest.TestCase):
             gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
             gobgp.parent.mkdir(parents=True)
             shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
+            bird3 = root / "tests" / "interop" / "Dockerfile.bird3"
+            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.bird3", bird3)
             scripts = root / ".github" / "scripts"
             scripts.mkdir(parents=True)
-            for name in ("install-grpcurl.sh", "install-gnmic.sh", "install-gobgp.sh"):
+            for name in (
+                "install-grpcurl.sh",
+                "install-gnmic.sh",
+                "install-gobgp.sh",
+                "install-bird3.sh",
+            ):
                 shutil.copy2(ROOT / ".github" / "scripts" / name, scripts / name)
             (scripts / "install-gobgp.sh").chmod(0o644)
             self.assertIn(
                 "install-gobgp.sh must have exact executable mode 100755",
+                check(root),
+            )
+
+    def test_bird3_installer_executable_mode_is_load_bearing(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            for fixture in (
+                ".github/workflows",
+                ".github/actions/install-gnmic-artifact",
+                ".github/actions/install-grpcurl-artifact",
+                ".github/actions/setup-dataplane-host",
+                ".github/actions/stage-bird3-artifact",
+                ".github/actions/stage-gobgp-artifact",
+            ):
+                shutil.copytree(ROOT / fixture, root / fixture)
+            shutil.copy2(ROOT / "Dockerfile", root / "Dockerfile")
+            gobgp = root / "tests" / "interop" / "Dockerfile.gobgp"
+            gobgp.parent.mkdir(parents=True)
+            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.gobgp", gobgp)
+            bird3 = root / "tests" / "interop" / "Dockerfile.bird3"
+            shutil.copy2(ROOT / "tests" / "interop" / "Dockerfile.bird3", bird3)
+            scripts = root / ".github" / "scripts"
+            scripts.mkdir(parents=True)
+            for name in (
+                "install-grpcurl.sh",
+                "install-gnmic.sh",
+                "install-gobgp.sh",
+                "install-bird3.sh",
+            ):
+                shutil.copy2(ROOT / ".github" / "scripts" / name, scripts / name)
+            (scripts / "install-bird3.sh").chmod(0o644)
+            self.assertIn(
+                "install-bird3.sh must have exact executable mode 100755",
                 check(root),
             )
 
@@ -581,7 +748,9 @@ class PrimerContractTests(unittest.TestCase):
             needs_prefix = (
                 "needs: [classify_changes, grpcurl_archive, "
                 + ("gnmic_archive, " if workflow == "interop.yml" else "")
-                + "gobgp_archive, prime_dev_image, "
+                + "gobgp_archive, "
+                + ("bird3_archive, " if workflow == "kernel-dataplane.yml" else "")
+                + "prime_dev_image, "
             )
             for old, new in (
                 ("if: ${{ always() }}", "if: success()"),
@@ -936,6 +1105,51 @@ class PrimerContractTests(unittest.TestCase):
                 "\nFROM debian:bookworm-slim\n",
                 "\nFROM debian:trixie-slim\n",
             ),
+        )
+        for old, new in cases:
+            with self.subTest(seam=old):
+                self.mutate(relative, old, new)
+
+    def test_bird3_source_archive_contract_is_load_bearing(self):
+        relative = "tests/interop/Dockerfile.bird3"
+        checksum = "d5a8d651d6184c18252954932bb249dfee1fd213b3665cdd86226ac45edc0190"
+        cases = (
+            ("ARG BIRD_VERSION=3.3.1", "ARG BIRD_VERSION=latest"),
+            (
+                f'checksum="{checksum}"',
+                f'checksum="{checksum[::-1]}"',
+            ),
+            (
+                "COPY bird3-archive/ /tmp/bird3-archive/",
+                "RUN mkdir -p /tmp/bird3-archive",
+            ),
+            (
+                'if [ ! -f "/tmp/bird3-archive/${archive}" ]; then',
+                "if true; then",
+            ),
+            (
+                "https://bird.nic.cz/download/bird-${BIRD_VERSION}.tar.gz",
+                "https://example.invalid/bird-${BIRD_VERSION}.tar.gz",
+            ),
+            (
+                'if [ "${attempt}" -ge 3 ]; then',
+                'if [ "${attempt}" -ge 9999 ]; then',
+            ),
+            (
+                'echo "${checksum}  /tmp/bird3-archive/${archive}" | sha256sum --check --strict',
+                "true # skipped checksum verification",
+            ),
+            (
+                'tar -xzf "/tmp/bird3-archive/${archive}" --strip-components=1',
+                'tar -xzf "/tmp/bird3-archive/${archive}"',
+            ),
+            (
+                '    echo "${checksum}  /tmp/bird3-archive/${archive}" | sha256sum --check --strict; \\\n'
+                '    tar -xzf "/tmp/bird3-archive/${archive}" --strip-components=1; \\\n',
+                '    tar -xzf "/tmp/bird3-archive/${archive}" --strip-components=1; \\\n'
+                '    echo "${checksum}  /tmp/bird3-archive/${archive}" | sha256sum --check --strict; \\\n',
+            ),
+            ("bird --version", "true # removed bird assertion"),
         )
         for old, new in cases:
             with self.subTest(seam=old):

--- a/tests/interop/Dockerfile.bird3
+++ b/tests/interop/Dockerfile.bird3
@@ -17,14 +17,38 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
+# CI stages the same-run, checksum- and version-verified source archive here
+# (.github/actions/stage-bird3-artifact) so hosted builds never contact the
+# upstream download site; the committed directory is empty, which keeps cold
+# local builds on the bounded in-build fetch below.
+COPY bird3-archive/ /tmp/bird3-archive/
+
 WORKDIR /tmp/bird
 
-RUN curl -fsSL "https://bird.nic.cz/download/bird-${BIRD_VERSION}.tar.gz" -o bird.tar.gz \
-    && tar -xzf bird.tar.gz --strip-components=1 \
-    && ./configure --prefix=/usr --sysconfdir=/etc/bird --localstatedir=/run/bird \
-    && make -j"$(nproc)" \
-    && make install \
-    && mkdir -p /etc/bird /run/bird \
-    && bird --version
+RUN set -eux; \
+    checksum="d5a8d651d6184c18252954932bb249dfee1fd213b3665cdd86226ac45edc0190"; \
+    archive="bird-${BIRD_VERSION}.tar.gz"; \
+    if [ ! -f "/tmp/bird3-archive/${archive}" ]; then \
+        attempt=1; \
+        while ! curl --fail --location --silent --show-error \
+            --connect-timeout 10 --max-time 120 \
+            "https://bird.nic.cz/download/bird-${BIRD_VERSION}.tar.gz" \
+            --output "/tmp/bird3-archive/${archive}"; do \
+            rm -f "/tmp/bird3-archive/${archive}"; \
+            if [ "${attempt}" -ge 3 ]; then \
+                echo "BIRD ${BIRD_VERSION} download failed after ${attempt} attempts" >&2; \
+                exit 1; \
+            fi; \
+            sleep $((attempt * 5)); \
+            attempt=$((attempt + 1)); \
+        done; \
+    fi; \
+    echo "${checksum}  /tmp/bird3-archive/${archive}" | sha256sum --check --strict; \
+    tar -xzf "/tmp/bird3-archive/${archive}" --strip-components=1; \
+    ./configure --prefix=/usr --sysconfdir=/etc/bird --localstatedir=/run/bird; \
+    make -j"$(nproc)"; \
+    make install; \
+    mkdir -p /etc/bird /run/bird; \
+    bird --version
 
 CMD ["sleep", "infinity"]


### PR DESCRIPTION
Fourth instance of the shared-verified-artifact pattern (#1630 grpcurl, #1631 gnmic, #1653 GoBGP), applied to the BIRD 3.3.1 source fetch in `tests/interop/Dockerfile.bird3`. Kernel Dataplane run `31805561020` failed in M43 before the scenario ran: the image build fetches the source tarball live from bird.nic.cz and upstream returned an HTTP error (curl exit 22). The LAN-252 buildx layer cache fronts that fetch only on a cache hit — the failure occurred on a miss — so the staged verified archive now sits beneath it: on a cache hit neither the fetch nor the stage matters; on a miss the staged archive keeps the build offline.

Scope note: the exposure is exactly one site. Interop's BIRD 2 image (`Dockerfile.bird`) builds from Debian packages, not bird.nic.cz, and is untouched.

Linear: [LAN-1024](https://linear.app/lance0/issue/LAN-1024/m43-builds-bird-331-from-a-live-birdniccz-fetch-fourth-instance-of-the)

## What changed

- `.github/scripts/install-bird3.sh` — same producer/consumer split as the gobgp installer: `--prepare-archive` (cache reuse, bounded 3-attempt fetch, atomic replace), `--stage-archive` (offline re-verification, staged into `tests/interop/bird3-archive/`, committed empty with tarballs gitignored), and `--self-test`. **Adaptation for a source tarball**: content verification is the version-named `bird-3.3.1/configure` member plus the upstream `VERSION` file reading `3.3.1` — the source-tree analogue of the gobgp binary `--version` checks — on every path including cache reuse.
- One `bird3_archive` producer job in Kernel Dataplane (the only workflow that builds this image), `actions/cache` keyed `bird3-v3.3.1-source-<sha256>`, same-run artifact consumed by m43 via `needs: bird3_archive` and a `stage-bird3-artifact` step before the image build.
- `Dockerfile.bird3` COPYs the staged archive, verifies the hard-pinned checksum with `sha256sum --check --strict` before extraction, and keeps a bounded (3-attempt) in-build fetch **only** when no archive is staged, preserving the documented one-command cold local build. Hosted CI can never take that path silently: the stage step fails the job first if the artifact is absent or invalid.
- The LAN-252 buildx GHA layer cache (`scope=bird3-tcpao`) is preserved unchanged and now pinned by the contract checker; the staged archive composes beneath it.
- `check_ci_image_primer_contract.py` extends to the new producer/consumer/installer seams: the m43 job must stage the verified artifact before building `bird:3.3.1-tcpao` (bypass or reordering fails the contract), the download URL may exist only in the installer and the Dockerfile fallback, checksum verification must precede extraction, the stage must remain kernel-only, and the producer must be download-free on warm cache.

## Consumer inventory

`Dockerfile.bird3` is built by exactly one job: Kernel Dataplane `m43` (both the live-rotation and crash-restart M43 scenarios run inside it). Interop has no consumer.

## Checksum provenance

`bird-3.3.1.tar.gz` pinned at SHA-256:

```
d5a8d651d6184c18252954932bb249dfee1fd213b3665cdd86226ac45edc0190
```

Two independent downloads of `https://bird.nic.cz/download/bird-3.3.1.tar.gz` during this change hashed byte-identically (2,861,610 bytes). The archive extracts to a single `bird-3.3.1/` tree (614 members) whose upstream `VERSION` file reads `3.3.1`; `--prepare-archive` was additionally run against the live site and passed checksum plus content verification end to end.

## Receipts (all exit-code gates)

- `shellcheck .github/scripts/install-bird3.sh` — 0
- `bash .github/scripts/install-bird3.sh --self-test` — 0 (valid stage, wrong checksum, truncated, HTTP-body, missing `configure` member, wrong source version, warm cache with no network, corrupt-cache atomic replacement, transient-retry recovery, bounded persistent failure, offline stage never invokes curl)
- `python3 scripts/check_ci_image_primer_contract.py` — 0; `python3 -m unittest scripts.test_check_ci_image_primer_contract` — 30 tests, 0 failures (new mutation coverage for the producer, stage action, installer pins, Dockerfile seams, stage-before-build ordering, and buildx layer-cache preservation)
- CI scale-split contract check and tests — 0
- YAML parse of the touched workflow and the new composite action — 0
- Load-bearing docker proofs: staged archive + dead download URL builds successfully with zero curl executions (offline); corrupt staged archive fails at `sha256sum --check --strict` before extraction (no tar, no configure); empty stage directory builds via the bounded fallback fetch (cold local parity)
- `git diff --check` — 0
