### PR TITLE
Correct RFC 8955 section citation in the 0.12.1 release note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12622,7 +12622,8 @@ stable track (Tokio's policy) — gated in PR-CI so it doesn't drift.
 ### Fixed
 
 - **FlowSpec MP_REACH next-hop validation no longer tears the
-  session.** Per RFC 8955 §6.1 the `NEXT_HOP` value for FlowSpec
+  session.** Per RFC 8955 §4 (the original release note
+  incorrectly cited §6.1) the `NEXT_HOP` value for FlowSpec
   (SAFI 133) advertisements is "irrelevant" and recommended to be
   0. Wire decoder fills `MpReachNlri.next_hop` with `0.0.0.0`
   when the on-wire NH-Len is 0 (the FlowSpec convention). The


### PR DESCRIPTION
The 0.12.1 "Fixed" entry cites RFC 8955 §6.1 for the FlowSpec next-hop convention. That section does not exist: RFC 8955 §6 (Validation Procedure) has no subsections. The rule the entry describes is in §4, in the introductory material before §4.1:

> When advertising Flow Specifications, the Length of the Next-Hop Network Address MUST be set to 0. The Network Address of the Next-Hop field MUST be ignored.

The citation is amended in place with an explicit note — "Per RFC 8955 §4 (the original release note incorrectly cited §6.1) …" — rather than silently rewritten, because shipped release notes are historical records.

The same wrong citation was previously corrected at every live documentation site (wire README and source doc-comments); this was the last remaining instance. Closes the actionable item of LAN-959; the other three residuals recorded there are deliberately unchanged.

Docs-only change: single-hunk diff in CHANGELOG.md.