### PR TITLE
Fence the documented RIB struct sizes and record the tracker-ID scan scope

### DIFF
--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -1442,6 +1442,30 @@ mod tests {
     use super::*;
     use crate::route::{BgpLsFamily, RouteOrigin};
 
+    /// The BENCHMARKS.md type-size table quotes `size_of` for `AdjRibIn`
+    /// and `LocRib`, and — unlike the other rows — nothing regenerates
+    /// them: both structs grow through nested per-family types with no
+    /// edit in their own files, and the documented figures went stale
+    /// silently (LAN-957). Fence the two rows the harness JSON cannot
+    /// see, the same include-the-doc pattern as the gRPC method
+    /// inventory fence in `crates/api/src/authz.rs`.
+    #[test]
+    fn benchmarks_doc_type_size_rows_match_compiler() {
+        let doc = include_str!("../../../docs/BENCHMARKS.md");
+        for (name, size) in [
+            ("AdjRibIn", size_of::<crate::adj_rib_in::AdjRibIn>()),
+            ("LocRib", size_of::<LocRib>()),
+        ] {
+            let row = format!("| `{name}` | {size} bytes |");
+            assert!(
+                doc.contains(&row),
+                "docs/BENCHMARKS.md type-size table is missing the row {row:?}: \
+                 the struct changed size or the doc was edited; update the \
+                 table (and its growth prose) to match the compiler"
+            );
+        }
+    }
+
     fn make_route(peer_oct: u8, prefix: Ipv4Prefix, local_pref: u32) -> Route {
         crate::test_support::make_route_with_lp(
             prefix,

--- a/scripts/check_public_tracker_ids.py
+++ b/scripts/check_public_tracker_ids.py
@@ -37,6 +37,15 @@ ROOT = Path(__file__).resolve().parents[1]
 # changelog's released sections are historical records that must not be
 # rewritten, and the roadmap tracks unshipped work whose only public name is
 # often the tracker item itself.
+#
+# The rest of the tree — `bench/`, `examples/`, `scripts/`, crate sources —
+# is deliberately out of scope too (settled with LAN-957, the same
+# narrow-the-rule-to-what-matters call as the host-path-identifier
+# decision): those files are read by people working inside the repository,
+# where a tracker ID is the conventional cross-reference, and a stale one
+# in a harness README costs that reader very little. Known mentions outside
+# the fence (e.g. bench/scale/rrharness/README.md) are accepted, not
+# missed. Do not widen the scan without a new recorded decision.
 SCANNED_PREFIXES = ("docs/",)
 SCANNED_FILES = frozenset(
     {


### PR DESCRIPTION
Closes the two remaining LAN-957 blind spots; the inventory percentage column was already fenced by #1580.

## LocRib / AdjRibIn size rows in docs/BENCHMARKS.md

The type-size table quotes `size_of` for `AdjRibIn` (1336) and `LocRib` (1040), and the doc itself notes those two rows are not in the allocator-tracked harness JSON — nothing regenerated them. Both structs grow through nested per-family types with no edit in their own files, which is how the LocRib figure drifted from 1008 to 1040 with no fence going red.

New test `benchmarks_doc_type_size_rows_match_compiler` in `crates/rib/src/loc_rib.rs` formats each table row from the compiler's `size_of` and asserts it appears in the doc (the same include-the-doc pattern as the gRPC method inventory fence in `crates/api/src/authz.rs`). Either direction of drift — struct growth or a doc edit — now fails `cargo test -p rustbgpd-rib`.

Destructive proof: editing the LocRib row to `1048 bytes` fails the test with the stale row named; restoring the doc returns it to green.

## Tracker-ID scan scope

`scripts/check_public_tracker_ids.py` scopes to `docs/` plus the top-level landing files. Per the ticket's decision framing, the scope stays as-is: the rest of the tree (`bench/`, `examples/`, `scripts/`, crate sources) is read by people working inside the repository, where a tracker ID is the conventional cross-reference — the same narrow-the-rule call as the host-path-identifier decision. The change records that decision in the scanning comment, names the known accepted mention (`bench/scale/rrharness/README.md`), and states that the scan must not widen without a new recorded decision. Comment-only; checker behavior is unchanged (582 documents scanned, green, and an injected in-scope ID still fails with exit 1).

## Gates

- `cargo test -p rustbgpd-rib --lib benchmarks_doc_type_size_rows_match_compiler`: pass
- Destructive proofs: stale doc row fails the new test (exit 101); injected in-scope `LAN-9999` fails the checker (exit 1); both restored
- `python3 scripts/test_check_public_tracker_ids.py` and a green checker run: pass
- `python3 scripts/check-v1-stable-surface.py`: pass
- `cargo fmt` / `cargo clippy -p rustbgpd-rib --tests`: pass
- `git diff --check`: clean