### PR TITLE
Silence the shared-path cargo warning from the vpn_query bench targets

### DIFF
--- a/bench/tests/test-vpn-query-campaign.sh
+++ b/bench/tests/test-vpn-query-campaign.sh
@@ -9,7 +9,7 @@ verifier=$root/bench/verify-vpn-query-campaign.py
 bash -n "$runner"
 python3 -m unittest -v "$root/bench/tests/test_verify_vpn_query_campaign.py"
 python3 "$verifier" --help >/dev/null
-[[ $(grep -Fc '.checked_mul(' "$root/crates/api/benches/vpn_query.rs") -eq 2 && $(grep -Fc '.checked_add(' "$root/crates/api/benches/vpn_query.rs") -eq 1 ]]
+[[ $(grep -Fc '.checked_mul(' "$root/crates/api/benches/vpn_query/mod.rs") -eq 2 && $(grep -Fc '.checked_add(' "$root/crates/api/benches/vpn_query/mod.rs") -eq 1 ]]
 [[ $(grep -Fc 'taskset -c "$declared_cpu" "$output/bin/vpn_query_$target"' "$runner") -eq 1 ]]
 [[ $(grep -Fc 'taskset -c "$declared_cpu" "$output/bin/vpn_query_timing"' "$runner") -eq 1 ]]
 [[ $(grep -Fc 'taskset -c "$declared_cpu" "$output/bin/vpn_query_allocation"' "$runner") -eq 1 ]]

--- a/bench/tests/test-vpn-query-receipt.sh
+++ b/bench/tests/test-vpn-query-receipt.sh
@@ -7,7 +7,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
 
 timing_receipt="$tmp_dir/timing.json"
 allocation_receipt="$tmp_dir/allocation.json"
-bench_source="$repo_root/crates/api/benches/vpn_query.rs"
+bench_source="$repo_root/crates/api/benches/vpn_query/mod.rs"
 declared_cpu=$(awk '/^Cpus_allowed_list:/{split($2, a, /[-,]/); print a[1]}' /proc/self/status)
 
 check_allocator_seam() {

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -69,10 +69,8 @@ required-features = ["bench-internals"]
 name = "vpn_query_timing"
 harness = false
 required-features = ["bench-internals"]
-path = "benches/vpn_query.rs"
 
 [[bench]]
 name = "vpn_query_allocation"
 harness = false
 required-features = ["bench-internals", "vpn-query-allocation"]
-path = "benches/vpn_query.rs"

--- a/crates/api/benches/vpn_query/mod.rs
+++ b/crates/api/benches/vpn_query/mod.rs
@@ -558,7 +558,7 @@ fn receipt_json(value: &QueryReceipt) -> serde_json::Value {
     })
 }
 
-fn main() {
+pub(crate) fn main() {
     let args: Vec<_> = std::env::args().filter(|arg| arg != "--bench").collect();
     let (routes, case, output, timeout, declared_cpu) = match args.as_slice() {
         [_, mode, case, output, cpu] if mode == "smoke" && (case == "U" || case == "F") => (

--- a/crates/api/benches/vpn_query_allocation.rs
+++ b/crates/api/benches/vpn_query_allocation.rs
@@ -1,0 +1,12 @@
+//! Allocation entry for the shared VPN query bench body in `vpn_query/mod.rs`.
+//!
+//! The two `vpn_query_*` targets compile that body from distinct entry files
+//! so they do not share a target `path` (cargo warns on that). The binary
+//! names are pinned by the event-history host-fence scripts — do not rename
+//! or collapse the targets.
+
+mod vpn_query;
+
+fn main() {
+    vpn_query::main();
+}

--- a/crates/api/benches/vpn_query_timing.rs
+++ b/crates/api/benches/vpn_query_timing.rs
@@ -1,0 +1,12 @@
+//! Timing entry for the shared VPN query bench body in `vpn_query/mod.rs`.
+//!
+//! The two `vpn_query_*` targets compile that body from distinct entry files
+//! so they do not share a target `path` (cargo warns on that). The binary
+//! names are pinned by the event-history host-fence scripts — do not rename
+//! or collapse the targets.
+
+mod vpn_query;
+
+fn main() {
+    vpn_query::main();
+}


### PR DESCRIPTION
Closes LAN-987.

Cargo warned on every build/clippy run that `crates/api/benches/vpn_query.rs` is present in multiple build targets, because `vpn_query_timing` and `vpn_query_allocation` both declared it as their `path`. The dual target is intentional — the two targets compile different code from the same source via the `vpn-query-allocation` feature gate — so the fix is ticket option 1: split the entry points, not the targets.

## Changes

- Move the shared bench body to `crates/api/benches/vpn_query/mod.rs` (outside cargo's `benches/*.rs` / `benches/*/main.rs` auto-discovery patterns).
- Add thin entry files `benches/vpn_query_timing.rs` and `benches/vpn_query_allocation.rs`, each `mod`-including the body and delegating `main`. Entry file names match the target names, so the explicit `path` declarations are dropped (same convention as `event_history_producer`).
- The produced binary names are unchanged. The event-history host-fence scripts pin them as PID match targets (`docs/perf/event-history-host-fence.sh:79`, `docs/perf/test-event-history-host-fence.sh:31-32`) and are untouched.
- Point the two bench test scripts that inspect the bench source (`bench/tests/test-vpn-query-receipt.sh`, `bench/tests/test-vpn-query-campaign.sh`) at the moved body; their content assertions are unchanged.

No CHANGELOG entry: no user-visible change.

## Verification

- `cargo clippy -p rustbgpd-api --all-targets -- -D warnings` — exit 0, zero warnings; the `multiple build targets` warning is gone from the build output.
- `cargo bench -p rustbgpd-api --no-run --bench vpn_query_timing --features bench-internals` and `--bench vpn_query_allocation --features bench-internals,vpn-query-allocation` — both compile (both sides of the `#[cfg(feature = "vpn-query-allocation")]` gate), producing `vpn_query_timing-*` / `vpn_query_allocation-*` binaries.
- `bash -n` on both host-fence scripts passes and their pinned name patterns still match the built binaries.
- `bash bench/tests/test-vpn-query-receipt.sh` — exit 0 (allocator-seam checks against the moved body, both smoke benches, receipt verification, censor path).
- `bash bench/tests/test-vpn-query-campaign.sh` — exit 0.
- `cargo test -p rustbgpd-api` — 653 passed, 0 failed.
- `cargo fmt --check -p rustbgpd-api`, `git diff --check` — clean.
