### PR TITLE
Update the pinned interop grpcurl consumer count for M84

### DIFF
--- a/.github/scripts/install-grpcurl.sh
+++ b/.github/scripts/install-grpcurl.sh
@@ -278,10 +278,12 @@ EOF
             "$fixture_dir/offline-install"
     ) || fail_self_test "offline artifact install failed"
 
+    # Pinned to the current consumer roster; bump when a job that uses the
+    # offline artifact path is added or removed (41st consumer: m84).
     interop_calls=$(grep -cF 'uses: ./.github/actions/install-grpcurl-artifact' \
         "$repo_root/.github/workflows/interop.yml")
-    [[ "$interop_calls" -eq 40 ]] \
-        || fail_self_test "Interop must have 40 offline grpcurl consumers"
+    [[ "$interop_calls" -eq 41 ]] \
+        || fail_self_test "Interop must have 41 offline grpcurl consumers"
     setup_calls=$(grep -cF 'uses: ./.github/actions/install-grpcurl-artifact' \
         "$repo_root/.github/actions/setup-dataplane-host/action.yml")
     [[ "$setup_calls" -eq 1 ]] \


### PR DESCRIPTION
The core job's "Check pinned grpcurl installer contract" step is red on main since #1667: the installer self-test pins the number of interop jobs consuming the verified same-run grpcurl artifact at 40, and #1667 added the M84 multi-cache RTR/ASPA epoch conformance job as the 41st.

The pin exists to catch a new consumer bypassing the offline staging path (fetching the release archive directly instead of re-verifying the same-run artifact). M84 is a proper offline consumer: it declares `needs: [grpcurl_archive, ...]` and installs via `uses: ./.github/actions/install-grpcurl-artifact`, matching the other 40 jobs. The correct fix is therefore a count bump, not a workflow change.

- Bump the interop consumer pin from 40 to 41 with a comment noting the count moves with the consumer roster.
- The sibling pins are untouched: setup-dataplane-host still has exactly one consumer, the two heavy workflows still have exactly two producers, and the consumer action still has one offline install.

Verified locally: `bash -n`, `shellcheck`, and `--self-test` all exit 0 ("grpcurl installer self-test passed"), and the CI image-primer and scale-split contract checkers still pass.