### PR TITLE
Assert installer executable mode from the git index, not the on-disk mode

### DIFF
--- a/scripts/check_ci_image_primer_contract.py
+++ b/scripts/check_ci_image_primer_contract.py
@@ -7,6 +7,7 @@ import collections
 import hashlib
 import re
 import stat
+import subprocess
 import sys
 from pathlib import Path
 
@@ -116,6 +117,34 @@ def _hash(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()
 
 
+def _installer_executable(root: Path, installer: Path) -> bool:
+    """True when the installer is executable where the repo records it.
+
+    The repo property is the git index mode (100755); on-disk group-write
+    from umask 002 checkouts is a checkout artifact, not contract drift.
+    Outside a git checkout (unittest fixtures) fall back to the on-disk
+    executable bits so a genuinely non-executable installer still fails.
+    """
+    proc = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(root),
+            "ls-files",
+            "-s",
+            "--",
+            installer.relative_to(root).as_posix(),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    fields = proc.stdout.split()
+    if proc.returncode == 0 and fields:
+        return fields[0] == "100755"
+    mode = stat.S_IMODE(installer.stat().st_mode)
+    return mode & 0o111 == 0o111
+
+
 def _top_block(text: str, key: str) -> str:
     match = re.search(rf"(?ms)^{re.escape(key)}:\n.*?(?=^[A-Za-z][\w-]*:|\Z)", text)
     return match.group(0).rstrip() if match else ""
@@ -159,13 +188,13 @@ def check(root: Path) -> list[str]:
     grpcurl_installer = root / ".github" / "scripts" / "install-grpcurl.sh"
     if not grpcurl_installer.is_file():
         errors.append("install-grpcurl.sh is missing")
-    elif stat.S_IMODE(grpcurl_installer.stat().st_mode) != 0o755:
-        errors.append("install-grpcurl.sh must have exact executable mode 100755")
+    elif not _installer_executable(root, grpcurl_installer):
+        errors.append("install-grpcurl.sh must be executable (git index mode 100755)")
     gnmic_installer = root / ".github" / "scripts" / "install-gnmic.sh"
     if not gnmic_installer.is_file():
         errors.append("install-gnmic.sh is missing")
-    elif stat.S_IMODE(gnmic_installer.stat().st_mode) != 0o755:
-        errors.append("install-gnmic.sh must have exact executable mode 100755")
+    elif not _installer_executable(root, gnmic_installer):
+        errors.append("install-gnmic.sh must be executable (git index mode 100755)")
     gnmic_installer_text = (
         gnmic_installer.read_text() if gnmic_installer.is_file() else ""
     )
@@ -191,8 +220,8 @@ def check(root: Path) -> list[str]:
     gobgp_installer = root / ".github" / "scripts" / "install-gobgp.sh"
     if not gobgp_installer.is_file():
         errors.append("install-gobgp.sh is missing")
-    elif stat.S_IMODE(gobgp_installer.stat().st_mode) != 0o755:
-        errors.append("install-gobgp.sh must have exact executable mode 100755")
+    elif not _installer_executable(root, gobgp_installer):
+        errors.append("install-gobgp.sh must be executable (git index mode 100755)")
     gobgp_installer_text = (
         gobgp_installer.read_text() if gobgp_installer.is_file() else ""
     )
@@ -219,8 +248,8 @@ def check(root: Path) -> list[str]:
     bird3_installer = root / ".github" / "scripts" / "install-bird3.sh"
     if not bird3_installer.is_file():
         errors.append("install-bird3.sh is missing")
-    elif stat.S_IMODE(bird3_installer.stat().st_mode) != 0o755:
-        errors.append("install-bird3.sh must have exact executable mode 100755")
+    elif not _installer_executable(root, bird3_installer):
+        errors.append("install-bird3.sh must be executable (git index mode 100755)")
     bird3_installer_text = (
         bird3_installer.read_text() if bird3_installer.is_file() else ""
     )

--- a/scripts/test_check_ci_image_primer_contract.py
+++ b/scripts/test_check_ci_image_primer_contract.py
@@ -128,6 +128,65 @@ class PrimerContractTests(unittest.TestCase):
             path.write_text(text[:index] + new + text[index + len(old) :])
             self.assertTrue(check(root), f"mutation stayed green: {relative}: {old}")
 
+    def stage_indexed_fixture(self, root):
+        for fixture in (
+            ".github/workflows",
+            ".github/actions/install-gnmic-artifact",
+            ".github/actions/install-grpcurl-artifact",
+            ".github/actions/setup-dataplane-host",
+            ".github/actions/stage-bird3-artifact",
+            ".github/actions/stage-gobgp-artifact",
+        ):
+            shutil.copytree(ROOT / fixture, root / fixture)
+        shutil.copy2(ROOT / "Dockerfile", root / "Dockerfile")
+        interop = root / "tests" / "interop"
+        interop.mkdir(parents=True)
+        shutil.copy2(
+            ROOT / "tests" / "interop" / "Dockerfile.gobgp", interop / "Dockerfile.gobgp"
+        )
+        shutil.copy2(
+            ROOT / "tests" / "interop" / "Dockerfile.bird3", interop / "Dockerfile.bird3"
+        )
+        scripts = root / ".github" / "scripts"
+        scripts.mkdir(parents=True)
+        for name in (
+            "install-grpcurl.sh",
+            "install-gnmic.sh",
+            "install-gobgp.sh",
+            "install-bird3.sh",
+        ):
+            shutil.copy2(ROOT / ".github" / "scripts" / name, scripts / name)
+        subprocess.run(["git", "-C", str(root), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+
+    def test_group_writable_checkout_passes_with_executable_index(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.stage_indexed_fixture(root)
+            for name in (
+                "install-grpcurl.sh",
+                "install-gnmic.sh",
+                "install-gobgp.sh",
+                "install-bird3.sh",
+            ):
+                (root / ".github" / "scripts" / name).chmod(0o775)
+            self.assertEqual([], check(root))
+
+    def test_non_executable_index_mode_fails_despite_executable_disk(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.stage_indexed_fixture(root)
+            installer = ".github/scripts/install-grpcurl.sh"
+            subprocess.run(
+                ["git", "-C", str(root), "update-index", "--chmod=-x", installer],
+                check=True,
+            )
+            self.assertTrue(os.access(root / installer, os.X_OK))
+            self.assertIn(
+                "install-grpcurl.sh must be executable (git index mode 100755)",
+                check(root),
+            )
+
     def test_live_contract(self):
         self.assertEqual([], check(ROOT))
 
@@ -194,7 +253,7 @@ class PrimerContractTests(unittest.TestCase):
             shutil.copy2(ROOT / bird3_installer.relative_to(root), bird3_installer)
             installer.chmod(0o644)
             self.assertIn(
-                "install-grpcurl.sh must have exact executable mode 100755",
+                "install-grpcurl.sh must be executable (git index mode 100755)",
                 check(root),
             )
 
@@ -669,7 +728,7 @@ class PrimerContractTests(unittest.TestCase):
                 shutil.copy2(ROOT / ".github" / "scripts" / name, scripts / name)
             (scripts / "install-gnmic.sh").chmod(0o644)
             self.assertIn(
-                "install-gnmic.sh must have exact executable mode 100755",
+                "install-gnmic.sh must be executable (git index mode 100755)",
                 check(root),
             )
 
@@ -702,7 +761,7 @@ class PrimerContractTests(unittest.TestCase):
                 shutil.copy2(ROOT / ".github" / "scripts" / name, scripts / name)
             (scripts / "install-gobgp.sh").chmod(0o644)
             self.assertIn(
-                "install-gobgp.sh must have exact executable mode 100755",
+                "install-gobgp.sh must be executable (git index mode 100755)",
                 check(root),
             )
 
@@ -735,7 +794,7 @@ class PrimerContractTests(unittest.TestCase):
                 shutil.copy2(ROOT / ".github" / "scripts" / name, scripts / name)
             (scripts / "install-bird3.sh").chmod(0o644)
             self.assertIn(
-                "install-bird3.sh must have exact executable mode 100755",
+                "install-bird3.sh must be executable (git index mode 100755)",
                 check(root),
             )
 


### PR DESCRIPTION
## Problem

`scripts/check_ci_image_primer_contract.py` asserted exact on-disk mode 0755 for the four `.github/scripts/install-*.sh` installers. Fresh worktree checkouts under umask 002 materialize tracked files as 0775, so the checker went red locally with zero repo change (four separate diagnosis cycles on 2026-08-14). Git records only the executable bit; group-write on disk is a checkout artifact, not a repo property. CI (umask 022) checks out 0755, so the assertion never fired there.

## Fix (LAN-1027, option 1)

Replace the on-disk `stat` comparison at all four sites (grpcurl, gnmic, gobgp, bird3) with an assertion on the git index mode via `git ls-files -s` == `100755` — the actual repo property, immune to umask. Outside a git checkout (the unittest temp fixtures), the helper falls back to the on-disk executable bits, so a genuinely non-executable installer still fails everywhere.

## Verification

- Checker on a umask-002 checkout (0775 on disk, 100755 in index): green — previously the four-error false red.
- `git update-index --chmod=-x` on `install-grpcurl.sh` (disk still 0775 executable): red with `install-grpcurl.sh must be executable (git index mode 100755)`; restored with `--chmod=+x`.
- Both cases codified as new unittests (`test_group_writable_checkout_passes_with_executable_index`, `test_non_executable_index_mode_fails_despite_executable_disk`) against a git-initialized fixture; the four existing chmod-644 fallback tests keep covering the non-repo path.
- Full suite: 32 tests, OK. `check_ci_scale_split_contract.py` green (no interaction). `git diff --check` clean.
- CI behavior unchanged: checkout is a git repo with index 100755, umask 022.