### PR TITLE
Use keyed EVPN lookup and by-reference candidates in distribution recompute

### DIFF
--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -606,6 +606,12 @@ impl AdjRibIn {
         self.evpn_routes.remove(key).is_some()
     }
 
+    /// Look up an EVPN route by key.
+    #[must_use]
+    pub fn get_evpn(&self, key: &EvpnRouteKey) -> Option<&EvpnRibRoute> {
+        self.evpn_routes.get(key)
+    }
+
     /// Iterate over all EVPN routes in this Adj-RIB-In.
     pub fn iter_evpn(&self) -> impl Iterator<Item = &EvpnRibRoute> {
         self.evpn_routes.values()
@@ -3333,6 +3339,70 @@ mod tests {
             is_llgr_stale: false,
         });
         key
+    }
+
+    #[test]
+    fn get_evpn_hit_miss_and_after_withdraw() {
+        use rustbgpd_wire::{EthernetTagId, RouteDistinguisher};
+        let peer_ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer_ip);
+        let key = insert_evpn_imet(&mut rib, Ipv4Addr::new(10, 0, 0, 1), 100, vec![]);
+        let sibling = insert_evpn_imet(&mut rib, Ipv4Addr::new(10, 0, 0, 1), 200, vec![]);
+
+        let hit = rib.get_evpn(&key).expect("inserted key resolves");
+        assert_eq!(hit.key(), key);
+
+        let missing = EvpnRouteKey::Imet {
+            rd: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 100]),
+            ethernet_tag: EthernetTagId(999),
+            originator_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        };
+        assert!(rib.get_evpn(&missing).is_none());
+
+        assert!(rib.withdraw_evpn(&key));
+        assert!(rib.get_evpn(&key).is_none());
+        assert!(rib.get_evpn(&sibling).is_some(), "sibling key survives");
+    }
+
+    #[test]
+    fn get_evpn_candidates_match_key_filter_scan_across_peers() {
+        // Differential guard for the keyed candidate gathering in
+        // `recompute_and_distribute_evpn`: per-rib `get_evpn` must return
+        // exactly the routes the old `iter_evpn().filter(|r| r.key() == *key)`
+        // full scan returned, for every key on a populated multi-peer set.
+        let mut ribs = Vec::new();
+        for i in 1..=3u8 {
+            ribs.push(AdjRibIn::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, i))));
+        }
+        // Same IMET identity (originator + tag) advertised by two peers,
+        // plus a unique key per rib.
+        insert_evpn_imet(&mut ribs[0], Ipv4Addr::new(10, 0, 0, 99), 100, vec![]);
+        let shared = insert_evpn_imet(&mut ribs[1], Ipv4Addr::new(10, 0, 0, 99), 100, vec![]);
+        insert_evpn_imet(&mut ribs[0], Ipv4Addr::new(10, 0, 0, 1), 200, vec![]);
+        insert_evpn_imet(&mut ribs[2], Ipv4Addr::new(10, 0, 0, 3), 300, vec![]);
+
+        let keys: std::collections::HashSet<EvpnRouteKey> = ribs
+            .iter()
+            .flat_map(|rib| rib.iter_evpn().map(EvpnRibRoute::key))
+            .collect();
+        assert_eq!(keys.len(), 3);
+
+        for key in keys {
+            let mut scanned: Vec<*const EvpnRibRoute> = ribs
+                .iter()
+                .flat_map(|rib| rib.iter_evpn().filter(|r| r.key() == key))
+                .map(std::ptr::from_ref)
+                .collect();
+            let mut keyed: Vec<*const EvpnRibRoute> = ribs
+                .iter()
+                .filter_map(|rib| rib.get_evpn(&key))
+                .map(std::ptr::from_ref)
+                .collect();
+            scanned.sort_unstable();
+            keyed.sort_unstable();
+            assert_eq!(scanned, keyed);
+            assert_eq!(keyed.len(), if key == shared { 2 } else { 1 });
+        }
     }
 
     #[test]

--- a/crates/rib/src/manager/distribution/bgpls.rs
+++ b/crates/rib/src/manager/distribution/bgpls.rs
@@ -207,16 +207,10 @@ impl RibManager {
     ///
     /// BGP-LS remains opaque: the selected route is reflected as received with
     /// ordinary BGP attribute handling, and no LSDB/TLV semantics are parsed.
-    #[expect(
-        clippy::too_many_lines,
-        reason = "typed BGP-LS recompute stages every outbound distribution mode"
-    )]
     pub(in crate::manager) fn recompute_and_distribute_bgpls(
         &mut self,
         affected: &HashSet<crate::route::BgpLsRouteKey>,
     ) {
-        use crate::route::BgpLsRibRoute;
-
         self.record_deferred_bgpls(affected);
         let affected: HashSet<_> = affected
             .iter()
@@ -229,12 +223,8 @@ impl RibManager {
 
         let mut changed_keys: HashSet<crate::route::BgpLsRouteKey> = HashSet::new();
         for key in &affected {
-            let candidates: Vec<BgpLsRibRoute> = self
-                .ribs
-                .values()
-                .filter_map(|rib| rib.get_bgpls(key).cloned())
-                .collect();
-            if self.loc_rib.recompute_bgpls(key.clone(), candidates.iter()) {
+            let candidates = self.ribs.values().filter_map(|rib| rib.get_bgpls(key));
+            if self.loc_rib.recompute_bgpls(key.clone(), candidates) {
                 changed_keys.insert(key.clone());
             }
         }

--- a/crates/rib/src/manager/distribution/evpn.rs
+++ b/crates/rib/src/manager/distribution/evpn.rs
@@ -417,7 +417,7 @@ impl RibManager {
             let candidates: Vec<&EvpnRibRoute> = self
                 .ribs
                 .values()
-                .flat_map(|rib| rib.iter_evpn().filter(|r| r.key() == *key))
+                .filter_map(|rib| rib.get_evpn(key))
                 .collect();
             // Capture old state BEFORE recompute_evpn so the event-type
             // derivation below distinguishes Added / Withdrawn /

--- a/crates/rib/src/manager/distribution/labeled.rs
+++ b/crates/rib/src/manager/distribution/labeled.rs
@@ -693,12 +693,12 @@ impl RibManager {
 
         let mut changed_keys: HashSet<Prefix> = HashSet::new();
         for key in &affected_nlri {
-            let candidates: Vec<LabeledRibRoute> = self
+            let candidates: Vec<&LabeledRibRoute> = self
                 .ribs
                 .values()
-                .flat_map(|rib| rib.iter_labeled_for_prefix(key).cloned())
+                .flat_map(|rib| rib.iter_labeled_for_prefix(key))
                 .collect();
-            if self.loc_rib.recompute_labeled(*key, candidates.iter()) {
+            if self.loc_rib.recompute_labeled(*key, candidates.into_iter()) {
                 changed_keys.insert(*key);
             }
         }

--- a/crates/rib/src/manager/distribution/rtc.rs
+++ b/crates/rib/src/manager/distribution/rtc.rs
@@ -231,8 +231,6 @@ impl RibManager {
         &mut self,
         affected: &HashSet<crate::route::RtcRibRouteKey>,
     ) {
-        use crate::route::RtcRibRoute;
-
         self.record_deferred_rtc(affected);
         if self.selection_deferred(crate::route::RtcRibRouteKey::afi_safi()) {
             return;
@@ -240,12 +238,8 @@ impl RibManager {
 
         let mut changed_keys: HashSet<crate::route::RtcRibRouteKey> = HashSet::new();
         for key in affected {
-            let candidates: Vec<RtcRibRoute> = self
-                .ribs
-                .values()
-                .filter_map(|rib| rib.get_rtc(key).cloned())
-                .collect();
-            if self.loc_rib.recompute_rtc(key.clone(), candidates.iter()) {
+            let candidates = self.ribs.values().filter_map(|rib| rib.get_rtc(key));
+            if self.loc_rib.recompute_rtc(key.clone(), candidates) {
                 changed_keys.insert(key.clone());
             }
         }

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -759,12 +759,12 @@ impl RibManager {
                 .bmp_tx
                 .as_ref()
                 .and_then(|_| self.loc_rib.get_vpn(key).map(|route| route.nlri.clone()));
-            let candidates: Vec<VpnRibRoute> = self
+            let candidates: Vec<&VpnRibRoute> = self
                 .ribs
                 .values()
-                .flat_map(|rib| rib.iter_vpn_for_nlri(key).cloned())
+                .flat_map(|rib| rib.iter_vpn_for_nlri(key))
                 .collect();
-            if self.loc_rib.recompute_vpn(*key, candidates.iter()) {
+            if self.loc_rib.recompute_vpn(*key, candidates.into_iter()) {
                 changed_keys.insert(*key);
                 if self.bmp_tx.is_some() {
                     let (pdu, path_status) = match self.loc_rib.get_vpn(key) {

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2532,10 +2532,7 @@ impl RibManager {
                 rib.iter_flowspec()
                     .any(|route| route.selection_key() == *key)
             }),
-            ExactExportKey::Evpn(key) => self
-                .ribs
-                .values()
-                .any(|rib| rib.iter_evpn().any(|route| route.key() == *key)),
+            ExactExportKey::Evpn(key) => self.ribs.values().any(|rib| rib.get_evpn(key).is_some()),
             ExactExportKey::BgpLs(key) => self.ribs.values().any(|rib| {
                 rib.iter_bgpls().any(|route| {
                     ExactExportKey::BgpLs(route.key()).nlri_identity()


### PR DESCRIPTION
Two mechanical changes in RibManager distribution candidate gathering (LAN-1028).

## Keyed EVPN lookup

`recompute_and_distribute_evpn` collected candidates via `iter_evpn().filter(|r| r.key() == *key)` — a full scan of every peer's EVPN table per affected key, making EVPN initial sync quadratic on the RIB manager task. `AdjRibIn` already stores `evpn_routes: HashMap<EvpnRouteKey, EvpnRibRoute>` keyed by `route.key()`: the sole insert path (`insert_evpn`) derives the map key from the route, and no mutation path (`values_mut`/`get_mut` sites touch only `is_stale`/`is_llgr_stale`/`attributes`) can alter the key-bearing NLRI. A `get_evpn(key)` accessor mirroring `get_bgpls` is therefore semantics-identical, and the recompute plus the `exact_export_nlri_is_live` EVPN arm now use it: O(peers) hash lookups per affected key.

EVPN was the sole outlier among the families — unicast has the `prefix_peers` reverse index, bgpls uses `get_bgpls`, vpn/labeled use keyed `iter_*_for_*`.

## By-reference candidates

The bgpls/rtc/vpn/labeled recomputes collected candidates into owned Vecs via `.cloned()` (deep-cloning NLRI heap fields: label stacks, opaque bytes) and then only iterated them by reference — every `recompute_*` signature takes `Iterator<Item = &T>`.

- `vpn.rs`/`labeled.rs`: `Vec<&T>` per EVPN's existing pattern, keeping the diff to the `.cloned()` lines (these files are on LAN-866's list).
- `bgpls.rs`/`rtc.rs`: the per-rib keyed lookups yield at most one route each, so the iterator passes straight through with no intermediate Vec. This drops `recompute_and_distribute_bgpls` below the clippy `too_many_lines` threshold, so its now-unfulfilled `#[expect]` is removed with it.

## Tests

- `get_evpn_hit_miss_and_after_withdraw`: hit resolves to the route with the matching key, a never-inserted key misses, a withdrawn key misses while a sibling key survives.
- `get_evpn_candidates_match_key_filter_scan_across_peers`: differential guard — on a populated multi-peer set (one key shared by two peers, unique keys elsewhere), per-rib `get_evpn` returns pointer-identical routes to the old `iter_evpn().filter(|r| r.key() == *key)` scan for every key, including candidate multiplicity.

`cargo test -p rustbgpd-rib -- --list` before/after diff is exactly the two new tests. Full `cargo test -p rustbgpd-rib`: 1143 passed, 0 failed. Scoped clippy `--all-targets -- -D warnings` and `cargo fmt --check` clean. No CHANGELOG entry: internal, no observable change.
