### PR TITLE
Shrink never-publishable FIB/BFD WatchEvents rings to 1-slot placeholders

### DIFF
--- a/crates/api/src/event_service.rs
+++ b/crates/api/src/event_service.rs
@@ -1773,6 +1773,71 @@ mod tests {
         assert!(result.is_err(), "BFD event leaked into the default stream");
     }
 
+    /// LAN-1014: on a daemon whose FIB/BFD subsystem never spawns (fixed at
+    /// startup — reload and CRUD both answer restart-required), the daemon
+    /// wires 1-slot placeholder rings into `ServeConfig` instead of the full
+    /// 4096/1024-slot rings. A subscriber arriving before (or without) the
+    /// subsystem must still get an open, functional stream: pending while
+    /// silent, delivering if a publisher ever sends.
+    #[tokio::test]
+    async fn bfd_watch_on_one_slot_placeholder_ring_stays_open_and_delivers() {
+        let (rib_tx, _) = spawn_fake_rib();
+        let (peer_tx, _, _) = spawn_fake_peer_manager();
+        let (bfd_tx, _) = broadcast::channel(1);
+        let (fib_route_tx, _) = broadcast::channel(1);
+        let service = EventService::with_dataplane_snapshots_broadcaster_and_metrics(
+            rib_tx,
+            peer_tx,
+            Arc::new(Vec::new),
+            Arc::new(Vec::new),
+            dataplane_event_broadcaster(),
+            Some(fib_route_tx),
+            Some(bfd_tx.clone()),
+            BgpMetrics::new(),
+        );
+        let response = service
+            .watch_events(Request::new(proto::WatchEventsRequest {
+                categories: vec![proto::EventCategory::Bfd as i32],
+                event_types: vec![],
+                neighbor_address: String::new(),
+                afi_safi: proto::AddressFamily::Unspecified as i32,
+                prefix: String::new(),
+                prefix_length: 0,
+            }))
+            .await
+            .unwrap();
+        let mut stream = response.into_inner();
+
+        // No publisher: the stream stays open (pending), it does not end.
+        let idle = tokio::time::timeout(std::time::Duration::from_millis(300), stream.next()).await;
+        assert!(
+            idle.is_err(),
+            "BFD stream on a placeholder ring must stay pending, got {idle:?}"
+        );
+
+        // A publisher on the 1-slot ring still reaches the subscriber.
+        bfd_tx
+            .send(bfd_bgp_event(proto::BgpEventType::BfdSessionUp, "10.0.0.1"))
+            .unwrap();
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+            .await
+            .expect("event on placeholder ring must be delivered")
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.category, proto::EventCategory::Bfd as i32);
+    }
+
+    /// LAN-1014 structural pin: tokio broadcast allocates its slot array at
+    /// construction, and each slot embeds an `Option<BgpEvent>` payload
+    /// (prost oneof sized by its largest variant). Shrinking the never-used
+    /// FIB (4096-slot) and BFD (1024-slot) proto rings to 1-slot placeholders
+    /// removes 4095 + 1023 = 5118 slots of eager payload capacity per daemon:
+    /// 5118 × 944 B = 4,831,392 B of slot payload, before per-slot metadata.
+    #[test]
+    fn watch_events_ring_slot_payload_size_pin() {
+        assert_eq!(std::mem::size_of::<Option<proto::BgpEvent>>(), 944);
+    }
+
     #[test]
     fn dataplane_summaries_count_blackhole_and_fib_states() {
         let summaries = dataplane_summaries(

--- a/src/main.rs
+++ b/src/main.rs
@@ -4264,10 +4264,22 @@ async fn run<T>(
     // route-server / route-reflector deployments control-plane-only.
     let (fib_status_tx, fib_status_rx) =
         tokio::sync::watch::channel(Vec::<fib_runtime::FibRuntimeStatus>::new());
+    // LAN-1014: tokio broadcast allocates its full slot array at
+    // construction. The reconciler's existence is fixed at startup — with no
+    // `[[fib_tables]]` it never spawns, and both SIGHUP reload and FIB-table
+    // CRUD answer restart-required — so on a control-plane-only daemon these
+    // rings can never carry an event. Shrink them to 1-slot placeholders in
+    // that case; the senders stay alive either way so WatchEvents dataplane
+    // subscribers keep an open (silent) stream.
+    let fib_ring_capacity = if config.fib_tables.is_empty() {
+        1
+    } else {
+        4096
+    };
     let (fib_event_tx, fib_event_rx) =
-        tokio::sync::broadcast::channel::<fib_runtime::FibRuntimeEvent>(4096);
+        tokio::sync::broadcast::channel::<fib_runtime::FibRuntimeEvent>(fib_ring_capacity);
     let (fib_bgp_event_tx, _) =
-        tokio::sync::broadcast::channel::<rustbgpd_api::proto::BgpEvent>(4096);
+        tokio::sync::broadcast::channel::<rustbgpd_api::proto::BgpEvent>(fib_ring_capacity);
     let _fib_event_bridge_handle = spawn_fib_dataplane_event_bridge(
         fib_event_rx,
         fib_bgp_event_tx.clone(),
@@ -4309,10 +4321,17 @@ async fn run<T>(
     // stream stays open even when no sessions are configured. The actor event
     // channel (`bfd_event_tx`) is dropped if the actor doesn't start (no
     // sessions), which simply ends the bridge task.
+    //
+    // LAN-1014: like the FIB rings above, the BFD actor's existence is fixed
+    // at startup (BFD config is restart-required; reload pins BFD edits to
+    // the startup snapshot and there is no BFD CRUD), so without configured
+    // sessions these rings can never carry an event — shrink them to 1-slot
+    // placeholders while keeping the long-lived sink open.
+    let bfd_ring_capacity = if bfd_initial.enabled() { 1024 } else { 1 };
     let (bfd_event_tx, bfd_event_rx) =
-        tokio::sync::broadcast::channel::<bfd_runtime::BfdRuntimeEvent>(1024);
+        tokio::sync::broadcast::channel::<bfd_runtime::BfdRuntimeEvent>(bfd_ring_capacity);
     let (bfd_bgp_event_tx, _) =
-        tokio::sync::broadcast::channel::<rustbgpd_api::proto::BgpEvent>(1024);
+        tokio::sync::broadcast::channel::<rustbgpd_api::proto::BgpEvent>(bfd_ring_capacity);
     let _bfd_event_bridge = spawn_bfd_event_bridge(
         bfd_event_rx,
         bfd_bgp_event_tx.clone(),


### PR DESCRIPTION
Startup unconditionally built four Tokio broadcast rings for FIB and BFD event fan-out: `FibRuntimeEvent` (4096), a FIB proto `BgpEvent` ring (4096), `BfdRuntimeEvent` (1024), and a BFD proto `BgpEvent` ring (1024). Tokio broadcast allocates the whole slot array at construction, so pure RS/RR deployments paid full capacity for rings that can never carry an event.

## Design choice: config-gated 1-slot placeholders, not lazy-init

Both subsystems' existence is fixed at startup, so no publisher can ever appear later:

- **FIB**: with an empty `[[fib_tables]]`, `fib_runtime::spawn` returns `None`, FIB-table CRUD fails with `FailedPrecondition` ("restart rustbgpd to start it", `fib_table_control.rs`), and the SIGHUP reload path logs restart-required when tables are added from an empty set (`reload.rs`).
- **BFD**: BFD config is restart-required — `pin_bfd_startup_only_runtime` pins reload edits to the startup snapshot (codified by `reload_pins_bfd_edits_to_startup_snapshot`), and the gRPC surface has no BFD CRUD (inspection only).

That rules out the alternatives:

- **Constructing rings only when the subsystem runs** (passing `None` into `ServeConfig`) would end the merged WatchEvents stream immediately for a BFD-only subscriber, breaking the documented contract that the BFD stream stays open when no sessions are configured.
- **Lazy-init on first subscriber** would allocate a full-capacity ring for a subscriber that can never receive an event — strictly worse than a placeholder — and there is no "subsystem starts later" side to initialize from.

So the rings are sized at construction: full capacity when the subsystem runs, 1 slot (the broadcast minimum) when it cannot. The senders stay alive either way; every subscription path, the lag contract, and the open-stream behavior are byte-identical.

## Structural saving (layout facts, not an RSS claim)

`size_of::<Option<proto::BgpEvent>>()` = 944 bytes (pinned by a new layout test). On a daemon running neither subsystem, the two proto rings shrink from 4096 + 1024 slots to 1 + 1: 5118 fewer eagerly allocated payload slots, 5118 x 944 B = 4,831,392 B of slot payload capacity, before per-slot metadata (sequencing atomics and lock). The `FibRuntimeEvent`/`BfdRuntimeEvent` actor rings shrink identically; on the not-spawned path those were already freed shortly after startup (sender dropped, bridge task exits), so their saving is transient startup allocation only.

## Tests

- `bfd_watch_on_one_slot_placeholder_ring_stays_open_and_delivers`: a WatchEvents BFD subscriber on a 1-slot ring gets a stream that stays pending while silent and still delivers when a publisher sends.
- `watch_events_ring_slot_payload_size_pin`: pins the 944-byte slot payload size.
- Existing lag/capacity contract tests are untouched — they construct their own small rings and never reference the daemon's 4096/1024 values.

No observable behavior change; no CHANGELOG entry.

Gates: `cargo test -p rustbgpd-api` (654 lib tests + doc tests, 0 failed), `cargo clippy -p rustbgpd -p rustbgpd-api --all-targets -- -D warnings`, `cargo fmt --check` — all exit 0.

Closes LAN-1014.
