### PR TITLE
Classify no-authority v3 publication failure as FailedPrecondition and tolerate the tombstone unlink race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- A confirmed apply whose v3 pending-authority publication fails before the
+  locator rename — no authority retained, candidate and runtime untouched —
+  now returns `FAILED_PRECONDITION` instead of `INTERNAL`, matching the
+  ADR-0127 clean no-effect classification for pre-mutation publication
+  failures. Publication no longer spuriously fails with `NotFound` when it
+  immediately follows a terminal confirmed transaction: losing the tombstone
+  unlink race against that transaction's detached residue cleanup is now
+  tolerated, since the residue is gone either way. (LAN-1020)
+
 - General FIB owned-state files whose payload shape contradicts their declared
   envelope version — e.g. a current-generation payload whose version field
   reads 1, or a claimed-v5 file carrying only the v1 scalar next-hop — are now

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -1012,7 +1012,13 @@ impl ConfigTransactionController {
                             message,
                         }
                     } else {
-                        ConfigTransactionApplyError::Internal(message)
+                        // ADR-0127: a publication failure before the locator
+                        // rename retains no authority and precedes every
+                        // runtime mutation — a determinate clean no-effect
+                        // refusal, same as the NotPublished persistence
+                        // mapping in persist_candidate_config, not an
+                        // internal invariant breach.
+                        ConfigTransactionApplyError::FailedPrecondition(message)
                     });
                 }
             }
@@ -6947,7 +6953,13 @@ remote_asn = 65010
             ))
             .await
             .unwrap_err();
-        assert!(matches!(error, ConfigTransactionApplyError::Internal(_)));
+        // ADR-0127: no authority retained and nothing mutated — a clean
+        // no-effect refusal, so the client sees FailedPrecondition.
+        assert!(matches!(
+            error,
+            ConfigTransactionApplyError::FailedPrecondition(ref message)
+                if message.contains("publication failed")
+        ));
         assert!(!peer_apply_seen.load(std::sync::atomic::Ordering::SeqCst));
         assert!(config_rx.try_recv().is_err());
         assert_eq!(std::fs::read_to_string(config_path).unwrap(), previous);
@@ -6955,8 +6967,9 @@ remote_asn = 65010
 
     #[tokio::test]
     async fn oversized_v3_prior_is_a_precondition_failure_before_publication_or_mutation() {
-        // Destructive proof: deleting the controller preflight changes this
-        // stable failure to INTERNAL in the publisher; moving it after
+        // Destructive proof: deleting the controller preflight replaces this
+        // stable message with the publisher's limit refusal (which lacks the
+        // "without confirmation" guidance asserted below); moving it after
         // publication or apply makes the empty-authority or mutation
         // assertions red.
         use std::os::unix::fs::PermissionsExt as _;
@@ -7220,6 +7233,12 @@ remote_asn = 65010
         // Destructive proof: bypassing the ordinary planner makes either
         // full-snapshot request committable; publishing after the verdict or
         // skipping cleanup leaves v3 authority after the rejection.
+        //
+        // LAN-1020: the second publication used to race the first apply's
+        // detached residue-cleanup thread over the tombstone names and could
+        // fail with NotFound before the fence was consulted; remove_named_safe
+        // now tolerates losing that unlink race, so publication succeeds and
+        // only the plan verdict can reject here.
         let harness = v3_external_fence_harness(RuntimeConfigTransactionStatus::Rejected);
         let mut candidate: Config = toml::from_str(&harness.current_toml).unwrap();
         candidate.neighbors[0].description = Some("must remain fenced".to_string());
@@ -7259,6 +7278,69 @@ remote_asn = 65010
         );
         assert!(!harness.locator.exists());
         assert!(!harness.journal.exists());
+    }
+
+    #[tokio::test]
+    async fn v3_publication_failure_without_authority_is_failed_precondition() {
+        // LAN-1020 / ADR-0127: a pre-rename publication failure retains no v3
+        // authority and precedes every runtime mutation — a determinate clean
+        // no-effect refusal that must surface as FailedPrecondition (matching
+        // the NotPublished persistence mapping), never Internal, and must not
+        // fence later applies.
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let harness = v3_external_fence_harness(RuntimeConfigTransactionStatus::Rejected);
+        let pending_dir = harness.journal.parent().unwrap().to_path_buf();
+        let read_only = std::fs::Permissions::from_mode(0o500);
+        std::fs::set_permissions(&pending_dir, read_only).unwrap();
+
+        let Err(error) = harness
+            .controller
+            .clone()
+            .apply(confirmed_dynamic_request(
+                harness.current_toml.clone(),
+                "native-unpublishable",
+                60,
+            ))
+            .await
+        else {
+            panic!("unpublishable v3 pending storage must refuse the confirmed apply");
+        };
+        assert!(
+            matches!(
+                &error,
+                ConfigTransactionApplyError::FailedPrecondition(message)
+                    if message.contains("publication failed")
+            ),
+            "expected FailedPrecondition, got: {error:?}"
+        );
+        assert!(!harness.locator.exists());
+        assert!(!harness.journal.exists());
+
+        // No fence: the next confirmed apply is admitted and refused the
+        // same clean way on the gNMI surface.
+        let Err(error) = harness
+            .controller
+            .clone()
+            .apply_gnmi_set(gnmi_set_add_neighbor_confirmed(
+                "10.0.0.3",
+                65003,
+                "gnmi-unpublishable",
+                60,
+            ))
+            .await
+        else {
+            panic!("unpublishable v3 pending storage must refuse the confirmed gNMI set");
+        };
+        assert!(
+            matches!(
+                &error,
+                GnmiSetError::FailedPrecondition(message)
+                    if message.contains("publication failed")
+            ),
+            "expected FailedPrecondition, got: {error:?}"
+        );
+        std::fs::set_permissions(&pending_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
     }
 
     #[tokio::test]

--- a/src/confirm_journal/v3.rs
+++ b/src/confirm_journal/v3.rs
@@ -1210,7 +1210,14 @@ fn remove_named_safe(directory: &File, name: &OsStr) -> io::Result<()> {
     {
         return Err(invalid("unsafe exact pending residue"));
     }
-    unlinkat(directory, Path::new(name), UnlinkatFlags::NoRemoveDir).map_err(errno)
+    // LAN-1020: the detached terminal-residue cleanup thread removes the same
+    // tombstone names and can win the unlink between the fstatat above and
+    // this unlinkat. The postcondition — name absent — holds either way, so a
+    // lost race must not fail the next publication.
+    match unlinkat(directory, Path::new(name), UnlinkatFlags::NoRemoveDir) {
+        Ok(()) | Err(nix::errno::Errno::ENOENT) => Ok(()),
+        Err(error) => Err(errno(error)),
+    }
 }
 
 fn validate_file_metadata(metadata: &std::fs::Metadata, cap: usize) -> io::Result<()> {


### PR DESCRIPTION
Closes the remaining instance-1 question on LAN-1020: under battery load,
`v3_activation_preserves_native_and_gnmi_full_snapshot_fence` received
`Internal("refusing confirmed apply: v3 pending authority publication failed (NotFound); the candidate and runtime remain untouched")`
instead of `FailedPrecondition`. Both halves of that failure were real
defects, not test artifacts.

## Race root cause (the NotFound)

A confirmed apply's terminal cleanup removes the locator synchronously, then
renames the metadata/raw residue to tombstone names and hands their removal to
a detached `rustbgpd-v3-cleanup` OS thread (`hand_off_v3`). The next
publication's `cleanup_locator_absent_residue_pinned` removes those same
tombstone names via `remove_named_safe`, which did `fstatat` + `unlinkat`.
When the cleaner thread's unlink landed between those two calls, the lost race
surfaced as `unlinkat` ENOENT and refused the entire publication — the only
`NotFound` leak on the publish path, matching the captured diagnosis. Under
load the cleaner thread's scheduling lags, so the tombstones are still present
when the second apply publishes and the window becomes reachable.

`remove_named_safe` now tolerates ENOENT from the unlinkat: the postcondition
— name absent — holds whichever side wins, and the identity/safety checks are
unchanged. This also fixes the production-visible form: a confirmed apply
immediately following a terminal confirmed transaction could spuriously fail.
With the race gone, publication in the fence scenario succeeds
deterministically and only the plan verdict can reject, which is the order the
test pins.

## Classification (ADR-0127 taxonomy)

The non-retained branch of the v3 publication failure mapping returned
`Internal`. That predates the LAN-1009/#1632 taxonomy work, which reclassified
only the authority-retained branch (`DetectedAmbiguousOutcome` →
`RecoveryRequired`/`PublicationAmbiguous`) and left the clean branch
untouched; no why-comment defends `Internal` there. A pre-locator-rename
failure retains no authority and precedes every runtime mutation — ADR-0127's
"stage failure before runtime mutation → clean no effect" row, and
docs/settlement-watchdog.md already lists "any failure before the first
mutation" among the clean rejections. The shipped precedents for the same
boundary both use `FAILED_PRECONDITION`:

- `persist_candidate_config`: `NotPublished` → `FailedPrecondition` ("disk
  provably still holds the previous config")
- `RuntimeConfigStageError::Write` → `failed_precondition`

The mapping now returns `FailedPrecondition` for the no-authority case, with
the reasoning at the mapping site. The `authority_retained` branch keeps its
`RecoveryRequired`/`PublicationAmbiguous` fence. No fence reason changes, so
the settlement-watchdog fence-reason table is unaffected (verified).

## Tests

- New `v3_publication_failure_without_authority_is_failed_precondition` pins
  the classification on both the native and gNMI surfaces via a read-only
  pending directory, including that the refusal leaves no fence behind.
- `v3_publication_failure_never_enters_peer_or_persister_apply` previously
  codified the old `Internal` variant; its ordering purpose is unchanged and
  its variant assertion now pins `FailedPrecondition`.
- The fence test carries a comment naming the resolved race.

## Gates

- `cargo test --bin rustbgpd config_transaction_control`: 94 passed, exit 0
- `v3_activation_preserves_native_and_gnmi_full_snapshot_fence` 10/10 exit 0,
  run concurrently with a full scoped clippy compile (load average ~10.9
  during the loop, above the original flake's load 4-8)
- `cargo test --bin rustbgpd confirm_journal`: 21 passed, exit 0
- `cargo test -p rustbgpd-api runtime_config_settlement`: 29 passed, exit 0;
  `--test runtime_config_settlement_exit`: 1 passed, exit 0
- `cargo clippy -p rustbgpd --all-targets -- -D warnings`: exit 0
- `cargo fmt --check`: exit 0
