### PR TITLE
Delta-scope RPKI revalidation to routes covered by the VRP incremental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- RPKI origin revalidation after an RTR incremental (serial) update is now
+  scoped to the routes whose prefix is covered by an announced or withdrawn
+  VRP, instead of rescanning every peer's full Adj-RIB-In on each changed
+  table. Validation outcomes are unchanged — only the revisited set shrinks;
+  full snapshots, cache resets, resyncs, and server loss still trigger a
+  full revalidation. The completion log now reports the mode (`delta`/
+  `full`), routes revalidated, changed routes, affected prefixes, and
+  elapsed time. In-test receipt at 100 peers × 10k routes with a 1-entry
+  delta (release build): 129.3 ms full rescan → 141.7 µs delta-scoped.
+  (LAN-1029)
+
 - **The RFC 8212 secure default is activated for epoch 2 (ADR-0119; owner
   decision recorded in ADR-0125 DR4).** `config_epoch = 2` with
   `[global].ebgp_requires_policy` omitted now resolves to effective `true`

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -306,6 +306,21 @@ impl AdjRibIn {
         self.routes.iter_mut()
     }
 
+    /// Visit mutably every unicast route whose prefix is covered by
+    /// `covering` — the prefix itself and all stored more-specifics
+    /// (network containment, same family). Uses the prefix trie for
+    /// O(covered) enumeration instead of an O(N) full scan.
+    pub fn for_each_covered_mut(&mut self, covering: &Prefix, mut f: impl FnMut(&mut Route)) {
+        let routes = &mut self.routes;
+        for (_, ids) in self.prefix_index.children(covering) {
+            for &(_, handle) in ids {
+                if let Some(route) = routes.get_mut(handle) {
+                    f(route);
+                }
+            }
+        }
+    }
+
     /// Look up a route by prefix and path ID.
     #[must_use]
     pub fn get(&self, prefix: &Prefix, path_id: u32) -> Option<&Route> {

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -308,40 +308,81 @@ impl RibManager {
     pub(super) fn handle_rpki_cache_update(
         &mut self,
         table: Arc<VrpTable>,
-        _delta: Option<Vec<rustbgpd_rpki::VrpEntry>>,
+        delta: Option<Vec<rustbgpd_rpki::VrpEntry>>,
     ) {
-        info!(
-            vrps = table.len(),
-            "RPKI cache update — re-validating routes"
-        );
+        let started = std::time::Instant::now();
+        // The delta arm assumes every stored `validation_state` reflects the
+        // previously distributed snapshot. Before the first table there is
+        // no such baseline, so the first update always rescans fully.
+        let delta = if self.vrp_table.is_some() {
+            delta
+        } else {
+            None
+        };
+        let mode = if delta.is_some() { "delta" } else { "full" };
         self.vrp_table = Some(table);
         let Some(table) = self.vrp_table.as_ref() else {
             return;
         };
+        let vrps = table.len();
         self.metrics
             .set_rpki_vrp_count("ipv4", gauge_val(table.v4_count()));
         self.metrics
             .set_rpki_vrp_count("ipv6", gauge_val(table.v6_count()));
 
         let mut affected = HashSet::new();
-        for rib in self.ribs.values_mut() {
-            for route in rib.iter_mut() {
-                let new_state = validate_route_rpki(route, table);
-                if route.validation_state != new_state {
-                    route.validation_state = new_state;
-                    affected.insert(route.prefix);
+        let mut routes_revalidated = 0_u64;
+        let mut changed_routes = 0_u64;
+        let mut revalidate = |route: &mut crate::route::Route| {
+            routes_revalidated += 1;
+            let new_state = validate_route_rpki(route, table);
+            if route.validation_state != new_state {
+                route.validation_state = new_state;
+                changed_routes += 1;
+                affected.insert(route.prefix);
+            }
+        };
+        if let Some(delta) = delta {
+            // A route's RFC 6811 outcome depends only on the VRPs covering
+            // its prefix, and coverage is by VRP prefix length (max_len only
+            // gates the Valid decision). Every entry that differs between
+            // the previous and this snapshot is in `delta`, so the union of
+            // the delta entries' covered sets is a superset of every route
+            // whose outcome can change — including Valid→NotFound/Invalid
+            // flips from withdrawals and overlap where a surviving VRP still
+            // covers. Revalidating covered routes against the FULL new table
+            // keeps outcomes identical to a full rescan; only the set of
+            // routes revisited shrinks. Overlapping delta entries may visit
+            // a route twice; revalidation is idempotent.
+            for rib in self.ribs.values_mut() {
+                for entry in &delta {
+                    let Some(covering) = super::helpers::vrp_covering_prefix(entry) else {
+                        continue;
+                    };
+                    rib.for_each_covered_mut(&covering, &mut revalidate);
+                }
+            }
+        } else {
+            for rib in self.ribs.values_mut() {
+                for route in rib.iter_mut() {
+                    revalidate(route);
                 }
             }
         }
 
         if !affected.is_empty() {
-            info!(
-                changed = affected.len(),
-                "RPKI re-validation changed routes"
-            );
             let changed = self.recompute_best(&affected);
             self.distribute_changes(&changed, &affected);
         }
+        info!(
+            vrps,
+            mode,
+            routes_revalidated,
+            changed_routes,
+            affected_prefixes = affected.len(),
+            elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "RPKI cache update re-validation complete"
+        );
     }
 
     pub(super) fn handle_aspa_cache_update(&mut self, table: Arc<rustbgpd_rpki::AspaTable>) {

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -305,7 +305,11 @@ impl RibManager {
         true
     }
 
-    pub(super) fn handle_rpki_cache_update(&mut self, table: Arc<VrpTable>) {
+    pub(super) fn handle_rpki_cache_update(
+        &mut self,
+        table: Arc<VrpTable>,
+        _delta: Option<Vec<rustbgpd_rpki::VrpEntry>>,
+    ) {
         info!(
             vrps = table.len(),
             "RPKI cache update — re-validating routes"

--- a/crates/rib/src/manager/helpers.rs
+++ b/crates/rib/src/manager/helpers.rs
@@ -257,6 +257,23 @@ pub(super) fn should_suppress_ibgp_inner(
     }
 }
 
+/// The covering prefix of a VRP entry: the routes whose RFC 6811 outcome
+/// the entry can influence are exactly those contained within it. Coverage
+/// is defined by `prefix_len` alone — `max_len` only gates the Valid
+/// decision, never coverage. Malformed lengths (beyond the family width)
+/// can cover nothing (`VrpTable::new` skips them), so they yield `None`.
+pub(super) fn vrp_covering_prefix(entry: &rustbgpd_rpki::VrpEntry) -> Option<Prefix> {
+    match entry.prefix {
+        IpAddr::V4(addr) if entry.prefix_len <= 32 => Some(Prefix::V4(
+            rustbgpd_wire::Ipv4Prefix::new(addr, entry.prefix_len),
+        )),
+        IpAddr::V6(addr) if entry.prefix_len <= 128 => Some(Prefix::V6(
+            rustbgpd_wire::Ipv6Prefix::new(addr, entry.prefix_len),
+        )),
+        _ => None,
+    }
+}
+
 /// Validate a route's origin against the VRP table (RFC 6811).
 ///
 /// Extracts the origin ASN from the route's `AS_PATH` (last AS in rightmost

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2365,7 +2365,9 @@ impl RibManager {
                     self.ensure_all_route_pages_advanced(page_versions);
                 }
             }
-            RibUpdate::RpkiCacheUpdate { table } => self.handle_rpki_cache_update(table),
+            RibUpdate::RpkiCacheUpdate { table, delta } => {
+                self.handle_rpki_cache_update(table, delta);
+            }
             RibUpdate::AspaTableUpdate { table } => self.handle_aspa_cache_update(table),
             RibUpdate::InjectFlowSpec { route, reply } => self.handle_inject_flowspec(route, reply),
             RibUpdate::WithdrawFlowSpec { key, reply } => {

--- a/crates/rib/src/manager/tests/rpki.rs
+++ b/crates/rib/src/manager/tests/rpki.rs
@@ -296,7 +296,9 @@ async fn routes_validated_on_insert_with_vrp_table() {
         max_len: 24,
         origin_asn: 65001,
     }]));
-    tx.send(RibUpdate::RpkiCacheUpdate { table }).await.unwrap();
+    tx.send(RibUpdate::RpkiCacheUpdate { table, delta: None })
+        .await
+        .unwrap();
 
     // Now send a route with matching origin
     let peer = IpAddr::V4(Ipv4Addr::new(1, 0, 0, 1));
@@ -380,7 +382,9 @@ async fn rpki_cache_update_revalidates_existing_routes() {
         max_len: 24,
         origin_asn: 65001,
     }]));
-    tx.send(RibUpdate::RpkiCacheUpdate { table }).await.unwrap();
+    tx.send(RibUpdate::RpkiCacheUpdate { table, delta: None })
+        .await
+        .unwrap();
 
     // Query again — should be Valid now
     let (reply_tx, reply_rx) = oneshot::channel();
@@ -453,7 +457,9 @@ async fn rpki_cache_update_changes_best_path() {
         max_len: 24,
         origin_asn: 65002,
     }]));
-    tx.send(RibUpdate::RpkiCacheUpdate { table }).await.unwrap();
+    tx.send(RibUpdate::RpkiCacheUpdate { table, delta: None })
+        .await
+        .unwrap();
 
     // After RPKI: peer2 should be best (Valid > NotFound)
     // But peer1's route has origin 65001, not covered → still NotFound.
@@ -519,7 +525,9 @@ async fn rpki_cache_update_invalid_demotes_best_path() {
         max_len: 24,
         origin_asn: 65002,
     }]));
-    tx.send(RibUpdate::RpkiCacheUpdate { table }).await.unwrap();
+    tx.send(RibUpdate::RpkiCacheUpdate { table, delta: None })
+        .await
+        .unwrap();
 
     // peer1 is now Invalid (VRP covers prefix but wrong origin), peer2 is Valid
     let (reply_tx, reply_rx) = oneshot::channel();
@@ -774,7 +782,9 @@ async fn rpki_cache_update_no_change_no_redistribution() {
         max_len: 24,
         origin_asn: 65099,
     }]));
-    tx.send(RibUpdate::RpkiCacheUpdate { table }).await.unwrap();
+    tx.send(RibUpdate::RpkiCacheUpdate { table, delta: None })
+        .await
+        .unwrap();
 
     // Verify route stays NotFound — no VRP covers 10.0.0.0/24
     let (reply_tx, reply_rx) = oneshot::channel();

--- a/crates/rib/src/manager/tests/rpki.rs
+++ b/crates/rib/src/manager/tests/rpki.rs
@@ -802,3 +802,467 @@ async fn rpki_cache_update_no_change_no_redistribution() {
 }
 
 // ---- Add-Path multi-path send tests ----
+
+// ---- Delta-scoped revalidation (LAN-1029) ----
+//
+// Correctness fence: the delta arm must produce validation outcomes
+// identical to a full rescan — only which routes get revisited changes.
+// Several tests poison an uncovered route's stored state as a sentinel:
+// the delta arm must NOT touch it (a full rescan would repair it), which
+// proves both the scoping and which arm actually ran.
+
+fn delta_vrp(addr: Ipv4Addr, prefix_len: u8, max_len: u8, asn: u32) -> rustbgpd_rpki::VrpEntry {
+    rustbgpd_rpki::VrpEntry {
+        prefix: IpAddr::V4(addr),
+        prefix_len,
+        max_len,
+        origin_asn: asn,
+    }
+}
+
+fn delta_table(entries: &[rustbgpd_rpki::VrpEntry]) -> Arc<rustbgpd_rpki::VrpTable> {
+    Arc::new(rustbgpd_rpki::VrpTable::new(entries.to_vec()))
+}
+
+fn delta_manager() -> RibManager {
+    let (_tx, rx) = mpsc::channel(1);
+    RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new())
+}
+
+fn insert_routes(manager: &mut RibManager, peer: Ipv4Addr, routes: Vec<Route>) {
+    let peer = IpAddr::V4(peer);
+    let mut rib = crate::adj_rib_in::AdjRibIn::new(peer);
+    for route in routes {
+        rib.insert(route);
+    }
+    manager.ribs.insert(peer, rib);
+}
+
+fn set_state(manager: &mut RibManager, peer: IpAddr, prefix: Prefix, state: RpkiValidation) {
+    manager
+        .ribs
+        .get_mut(&peer)
+        .unwrap()
+        .iter_mut()
+        .find(|r| r.prefix == prefix)
+        .unwrap()
+        .validation_state = state;
+}
+
+fn state_of(manager: &RibManager, peer: IpAddr, prefix: Prefix) -> RpkiValidation {
+    manager
+        .ribs
+        .get(&peer)
+        .unwrap()
+        .iter()
+        .find(|r| r.prefix == prefix)
+        .unwrap()
+        .validation_state
+}
+
+fn rpki_states(manager: &RibManager) -> Vec<(IpAddr, Prefix, u32, RpkiValidation)> {
+    let mut out: Vec<(IpAddr, Prefix, u32, RpkiValidation)> = manager
+        .ribs
+        .iter()
+        .flat_map(|(peer, rib)| {
+            rib.iter()
+                .map(move |r| (*peer, r.prefix, r.path_id, r.validation_state))
+        })
+        .collect();
+    out.sort_unstable_by_key(|&(peer, prefix, path_id, _)| (peer, prefix, path_id));
+    out
+}
+
+#[test]
+fn rpki_delta_revalidates_only_covered_routes() {
+    let mut manager = delta_manager();
+    let peer = Ipv4Addr::new(1, 0, 0, 1);
+    let covered = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
+    let more_specific = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 1, 0), 25));
+    let outside = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 168, 0, 0), 24));
+    insert_routes(
+        &mut manager,
+        peer,
+        vec![
+            make_route_with_as_path(
+                Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24),
+                peer,
+                vec![65001],
+            ),
+            make_route_with_as_path(
+                Ipv4Prefix::new(Ipv4Addr::new(10, 0, 1, 0), 25),
+                peer,
+                vec![65002],
+            ),
+            make_route_with_as_path(
+                Ipv4Prefix::new(Ipv4Addr::new(192, 168, 0, 0), 24),
+                peer,
+                vec![65003],
+            ),
+        ],
+    );
+    let peer = IpAddr::V4(peer);
+
+    // Baseline snapshot (first table always full-rescans): everything NotFound.
+    manager.handle_rpki_cache_update(delta_table(&[]), None);
+    assert_eq!(state_of(&manager, peer, covered), RpkiValidation::NotFound);
+
+    // Sentinel: poison the uncovered route's stored state.
+    set_state(&mut manager, peer, outside, RpkiValidation::Valid);
+
+    // Announce 10.0.0.0/16 max_len 25 AS65001 as an incremental delta.
+    let announced = delta_vrp(Ipv4Addr::new(10, 0, 0, 0), 16, 25, 65001);
+    manager.handle_rpki_cache_update(
+        delta_table(std::slice::from_ref(&announced)),
+        Some(vec![announced]),
+    );
+
+    // The covered set includes more-specifics of the announced VRP.
+    assert_eq!(state_of(&manager, peer, covered), RpkiValidation::Valid);
+    // Covered, within max_len, wrong origin → Invalid.
+    assert_eq!(
+        state_of(&manager, peer, more_specific),
+        RpkiValidation::Invalid
+    );
+    // Uncovered sentinel untouched — the delta path did not scan it.
+    assert_eq!(state_of(&manager, peer, outside), RpkiValidation::Valid);
+}
+
+#[test]
+fn rpki_delta_withdrawal_flips_states_and_respects_overlap() {
+    let mut manager = delta_manager();
+    let peer1 = Ipv4Addr::new(1, 0, 0, 1);
+    let peer2 = Ipv4Addr::new(1, 0, 0, 2);
+    let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
+    insert_routes(
+        &mut manager,
+        peer1,
+        vec![make_route_with_as_path(
+            Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24),
+            peer1,
+            vec![65001],
+        )],
+    );
+    insert_routes(
+        &mut manager,
+        peer2,
+        vec![make_route_with_as_path(
+            Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24),
+            peer2,
+            vec![65002],
+        )],
+    );
+    let (peer1, peer2) = (IpAddr::V4(peer1), IpAddr::V4(peer2));
+
+    let general = delta_vrp(Ipv4Addr::new(10, 0, 0, 0), 16, 24, 65001);
+    let specific = delta_vrp(Ipv4Addr::new(10, 0, 0, 0), 24, 24, 65002);
+    manager.handle_rpki_cache_update(delta_table(&[general.clone(), specific.clone()]), None);
+    assert_eq!(state_of(&manager, peer1, prefix), RpkiValidation::Valid);
+    assert_eq!(state_of(&manager, peer2, prefix), RpkiValidation::Valid);
+
+    // Withdraw the general VRP: the specific one still covers, so peer1's
+    // route flips Valid→Invalid (covered, wrong origin) — NOT NotFound —
+    // and peer2's route is revisited but stays Valid.
+    manager.handle_rpki_cache_update(
+        delta_table(std::slice::from_ref(&specific)),
+        Some(vec![general]),
+    );
+    assert_eq!(state_of(&manager, peer1, prefix), RpkiValidation::Invalid);
+    assert_eq!(state_of(&manager, peer2, prefix), RpkiValidation::Valid);
+
+    // Withdraw the last covering VRP: both flip to NotFound.
+    manager.handle_rpki_cache_update(delta_table(&[]), Some(vec![specific]));
+    assert_eq!(state_of(&manager, peer1, prefix), RpkiValidation::NotFound);
+    assert_eq!(state_of(&manager, peer2, prefix), RpkiValidation::NotFound);
+}
+
+#[test]
+fn rpki_delta_max_len_gates_valid_but_not_coverage() {
+    let mut manager = delta_manager();
+    let peer = Ipv4Addr::new(1, 0, 0, 1);
+    let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
+    insert_routes(
+        &mut manager,
+        peer,
+        vec![make_route_with_as_path(
+            Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24),
+            peer,
+            vec![65001],
+        )],
+    );
+    let peer = IpAddr::V4(peer);
+    manager.handle_rpki_cache_update(delta_table(&[]), None);
+
+    // The announced VRP authorizes only up to /16, but coverage is by
+    // prefix-length containment: the /24 must be revisited and flip
+    // NotFound→Invalid even though it can never be Valid under this VRP.
+    let tight = delta_vrp(Ipv4Addr::new(10, 0, 0, 0), 16, 16, 65001);
+    manager.handle_rpki_cache_update(
+        delta_table(std::slice::from_ref(&tight)),
+        Some(vec![tight.clone()]),
+    );
+    assert_eq!(state_of(&manager, peer, prefix), RpkiValidation::Invalid);
+
+    // A second VRP for the same network with max_len 24 makes it Valid...
+    let loose = delta_vrp(Ipv4Addr::new(10, 0, 0, 0), 16, 24, 65001);
+    manager.handle_rpki_cache_update(
+        delta_table(&[tight.clone(), loose.clone()]),
+        Some(vec![loose.clone()]),
+    );
+    assert_eq!(state_of(&manager, peer, prefix), RpkiValidation::Valid);
+
+    // ...and withdrawing it flips back to Invalid under the surviving
+    // tighter VRP.
+    manager.handle_rpki_cache_update(delta_table(std::slice::from_ref(&tight)), Some(vec![loose]));
+    assert_eq!(state_of(&manager, peer, prefix), RpkiValidation::Invalid);
+}
+
+#[test]
+fn rpki_first_table_with_delta_forces_full_rescan() {
+    let mut manager = delta_manager();
+    let peer = Ipv4Addr::new(1, 0, 0, 1);
+    let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
+    insert_routes(
+        &mut manager,
+        peer,
+        vec![make_route_with_as_path(
+            Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24),
+            peer,
+            vec![65001],
+        )],
+    );
+    let peer = IpAddr::V4(peer);
+    // Poison before any table exists.
+    set_state(&mut manager, peer, prefix, RpkiValidation::Valid);
+
+    // The first-ever update arrives claiming a delta that does not cover
+    // the route. With no baseline to delta from, the manager must ignore
+    // the delta, full-rescan, and repair the poisoned state.
+    let unrelated = delta_vrp(Ipv4Addr::new(192, 168, 0, 0), 24, 24, 65099);
+    manager.handle_rpki_cache_update(
+        delta_table(std::slice::from_ref(&unrelated)),
+        Some(vec![unrelated]),
+    );
+    assert_eq!(state_of(&manager, peer, prefix), RpkiValidation::NotFound);
+}
+
+#[test]
+fn rpki_delta_covers_ipv6_routes() {
+    fn v6_route(addr: &str, len: u8, peer: Ipv4Addr, asns: Vec<u32>) -> Route {
+        let mut route =
+            make_route_with_as_path(Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0), peer, asns);
+        route.prefix = Prefix::V6(rustbgpd_wire::Ipv6Prefix::new(addr.parse().unwrap(), len));
+        route
+    }
+
+    let mut manager = delta_manager();
+    let peer = Ipv4Addr::new(1, 0, 0, 1);
+    let covered = Prefix::V6(rustbgpd_wire::Ipv6Prefix::new(
+        "2001:db8:1::".parse().unwrap(),
+        48,
+    ));
+    let outside = Prefix::V6(rustbgpd_wire::Ipv6Prefix::new(
+        "2001:db9::".parse().unwrap(),
+        32,
+    ));
+    insert_routes(
+        &mut manager,
+        peer,
+        vec![
+            v6_route("2001:db8:1::", 48, peer, vec![65001]),
+            v6_route("2001:db9::", 32, peer, vec![65001]),
+        ],
+    );
+    let peer = IpAddr::V4(peer);
+    manager.handle_rpki_cache_update(delta_table(&[]), None);
+    set_state(&mut manager, peer, outside, RpkiValidation::Invalid);
+
+    let announced = rustbgpd_rpki::VrpEntry {
+        prefix: IpAddr::V6("2001:db8::".parse().unwrap()),
+        prefix_len: 32,
+        max_len: 48,
+        origin_asn: 65001,
+    };
+    manager.handle_rpki_cache_update(
+        delta_table(std::slice::from_ref(&announced)),
+        Some(vec![announced]),
+    );
+    assert_eq!(state_of(&manager, peer, covered), RpkiValidation::Valid);
+    // Same family, different network: the sentinel proves it was skipped.
+    assert_eq!(state_of(&manager, peer, outside), RpkiValidation::Invalid);
+}
+
+/// Differential fence: a random announce/withdraw sequence applied through
+/// the delta arm and through full rescans must land every route of every
+/// peer in identical validation states at every step.
+#[test]
+fn rpki_delta_matches_full_rescan_on_random_sequences() {
+    fn rng_next(state: &mut u64) -> u64 {
+        *state ^= *state << 13;
+        *state ^= *state >> 7;
+        *state ^= *state << 17;
+        *state
+    }
+
+    // VRP candidate universe with deliberate overlap: a /8 umbrella, /16s
+    // and /24s at competing origins and max lengths.
+    let mut candidates = vec![delta_vrp(Ipv4Addr::new(10, 0, 0, 0), 8, 24, 65001)];
+    for x in 0..4u8 {
+        for &(asn, max_len) in &[(65001u32, 16u8), (65001, 24), (65002, 20)] {
+            candidates.push(delta_vrp(Ipv4Addr::new(10, x, 0, 0), 16, max_len, asn));
+        }
+        for y in 0..2u8 {
+            for &(asn, max_len) in &[(65001u32, 24u8), (65002, 32), (65003, 25)] {
+                candidates.push(delta_vrp(Ipv4Addr::new(10, x, y, 0), 24, max_len, asn));
+            }
+        }
+    }
+
+    // Identical route sets in both managers: 4 peers × mixed lengths and
+    // origins across the candidate networks, plus one never-covered route
+    // per peer.
+    let build = || {
+        let mut manager = delta_manager();
+        for p in 1..=4u8 {
+            let peer = Ipv4Addr::new(1, 0, 0, p);
+            let mut routes = Vec::new();
+            for x in 0..4u8 {
+                for &(y, len) in &[(0u8, 16u8), (0, 20), (0, 24), (0, 25), (1, 24), (1, 32)] {
+                    let origin = 65001 + u32::from((x + y + p) % 4);
+                    routes.push(make_route_with_as_path(
+                        Ipv4Prefix::new(Ipv4Addr::new(10, x, y, 0), len),
+                        peer,
+                        vec![64900, origin],
+                    ));
+                }
+            }
+            routes.push(make_route_with_as_path(
+                Ipv4Prefix::new(Ipv4Addr::new(172, 16, p, 0), 24),
+                peer,
+                vec![65001],
+            ));
+            insert_routes(&mut manager, peer, routes);
+        }
+        manager
+    };
+    let mut with_delta = build();
+    let mut with_full = build();
+
+    let mut rng = 0x1029_5EED_u64;
+    let mut current: Vec<rustbgpd_rpki::VrpEntry> = Vec::new();
+    let mut prev_table = delta_table(&[]);
+    for step in 0..40 {
+        // 1-3 withdrawals then 1-3 announcements of random candidates,
+        // mirroring the VRP manager's withdraw-before-announce order and
+        // its delta = withdrawn + announced construction.
+        let mut delta = Vec::new();
+        for _ in 0..=(rng_next(&mut rng) % 3) {
+            let pick = usize::try_from(rng_next(&mut rng)).unwrap_or(usize::MAX);
+            let entry = candidates[pick % candidates.len()].clone();
+            current.retain(|c| c != &entry);
+            delta.push(entry);
+        }
+        for _ in 0..=(rng_next(&mut rng) % 3) {
+            let pick = usize::try_from(rng_next(&mut rng)).unwrap_or(usize::MAX);
+            let entry = candidates[pick % candidates.len()].clone();
+            if !current.contains(&entry) {
+                current.push(entry.clone());
+            }
+            delta.push(entry);
+        }
+        let table = delta_table(&current);
+        // Mirror the VRP manager's deep-equality suppression: an update
+        // that leaves the merged table unchanged is never distributed, so
+        // its delta is dropped for both arms.
+        if *table == *prev_table {
+            continue;
+        }
+        prev_table = Arc::clone(&table);
+        with_delta.handle_rpki_cache_update(Arc::clone(&table), Some(delta));
+        with_full.handle_rpki_cache_update(table, None);
+        assert_eq!(
+            rpki_states(&with_delta),
+            rpki_states(&with_full),
+            "delta and full rescan diverged at step {step}"
+        );
+    }
+}
+
+/// Timing receipt at the LAN-1029 synthetic shape: 100 peers × 10k routes,
+/// 1-entry delta. Two managers with identical state take the same T1→T2
+/// transition, one through each arm, so the timed sections do identical
+/// recompute work and differ only in revalidation scan scope. Outcomes are
+/// asserted identical; timings print to stderr (run with --nocapture).
+#[test]
+fn rpki_delta_timing_receipt() {
+    let build = || {
+        let mut manager = delta_manager();
+        for p in 0..100u8 {
+            let peer = Ipv4Addr::new(1, 0, p, 1);
+            let mut routes = Vec::with_capacity(10_000);
+            for a in 0..40u8 {
+                for b in 0..250u8 {
+                    // 10.0.0.0/24 carries origin 65002 so the delta below
+                    // flips exactly that route on every peer.
+                    let origin = if a == 0 && b == 0 { 65002 } else { 65001 };
+                    routes.push(make_route_with_as_path(
+                        Ipv4Prefix::new(Ipv4Addr::new(10, a, b, 0), 24),
+                        peer,
+                        vec![64900, origin],
+                    ));
+                }
+            }
+            insert_routes(&mut manager, peer, routes);
+        }
+        manager
+    };
+
+    // T1: one VRP per route prefix authorizing AS65001.
+    let mut t1_entries = Vec::with_capacity(10_000);
+    for a in 0..40u8 {
+        for b in 0..250u8 {
+            t1_entries.push(delta_vrp(Ipv4Addr::new(10, a, b, 0), 24, 24, 65001));
+        }
+    }
+    let t1 = delta_table(&t1_entries);
+    // T2 = T1 + one VRP authorizing AS65002 on 10.0.0.0/24.
+    let extra = delta_vrp(Ipv4Addr::new(10, 0, 0, 0), 24, 24, 65002);
+    let mut t2_entries = t1_entries.clone();
+    t2_entries.push(extra.clone());
+    let t2 = delta_table(&t2_entries);
+
+    let mut with_full = build();
+    let mut with_delta = build();
+    with_full.handle_rpki_cache_update(Arc::clone(&t1), None);
+    with_delta.handle_rpki_cache_update(Arc::clone(&t1), None);
+
+    let target = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
+    let probe_peer = IpAddr::V4(Ipv4Addr::new(1, 0, 0, 1));
+    assert_eq!(
+        state_of(&with_full, probe_peer, target),
+        RpkiValidation::Invalid
+    );
+    assert_eq!(
+        state_of(&with_delta, probe_peer, target),
+        RpkiValidation::Invalid
+    );
+
+    let started = std::time::Instant::now();
+    with_full.handle_rpki_cache_update(Arc::clone(&t2), None);
+    let full_elapsed = started.elapsed();
+    let started = std::time::Instant::now();
+    with_delta.handle_rpki_cache_update(t2, Some(vec![extra]));
+    let delta_elapsed = started.elapsed();
+
+    // Identical outcomes on every peer: the 10.0.0.0/24 route flipped
+    // Invalid→Valid through both arms.
+    assert_eq!(rpki_states(&with_full), rpki_states(&with_delta));
+    for p in 0..100u8 {
+        let peer = IpAddr::V4(Ipv4Addr::new(1, 0, p, 1));
+        assert_eq!(state_of(&with_delta, peer, target), RpkiValidation::Valid);
+    }
+    eprintln!(
+        "rpki revalidation receipt (100 peers x 10k routes, 1-entry delta): \
+         full={full_elapsed:?} delta={delta_elapsed:?}"
+    );
+}

--- a/crates/rib/src/prefix_map.rs
+++ b/crates/rib/src/prefix_map.rs
@@ -139,6 +139,32 @@ impl<V> FamilyPrefixMap<V> {
     }
 }
 
+impl<V> FamilyPrefixMap<V> {
+    /// Iterate `covering` and every stored more-specific prefix contained
+    /// within it (network containment), with their values. The other address
+    /// family contributes nothing.
+    pub(crate) fn children(&self, covering: &Prefix) -> impl Iterator<Item = (Prefix, &V)> {
+        let (v4, v6) = match covering {
+            Prefix::V4(p) => (Some(self.v4.children(&v4_net(*p))), None),
+            Prefix::V6(p) => (None, Some(self.v6.children(&v6_net(*p)))),
+        };
+        v4.into_iter()
+            .flatten()
+            .map(|(prefix, value)| {
+                (
+                    Prefix::V4(Ipv4Prefix::new(prefix.addr(), prefix.prefix_len())),
+                    value,
+                )
+            })
+            .chain(v6.into_iter().flatten().map(|(prefix, value)| {
+                (
+                    Prefix::V6(Ipv6Prefix::new(prefix.addr(), prefix.prefix_len())),
+                    value,
+                )
+            }))
+    }
+}
+
 impl<V: Default> FamilyPrefixMap<V> {
     /// Return a mutable reference to the value for `prefix`, inserting `V::default()`
     /// if absent — mirrors `HashMap::entry(_).or_default()`.

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -2210,6 +2210,11 @@ pub enum RibUpdate {
     RpkiCacheUpdate {
         /// The new VRP table snapshot.
         table: Arc<VrpTable>,
+        /// VRP entries announced or withdrawn since the previously
+        /// distributed snapshot (see [`rustbgpd_rpki::RpkiTableUpdate`]).
+        /// `Some` scopes revalidation to routes covered by these entries;
+        /// `None` forces a full revalidation of every Adj-RIB-In.
+        delta: Option<Vec<rustbgpd_rpki::VrpEntry>>,
     },
     /// ASPA cache update — new ASPA table for path verification.
     AspaTableUpdate {

--- a/crates/rpki/src/aspa_verify.rs
+++ b/crates/rpki/src/aspa_verify.rs
@@ -4,8 +4,14 @@
 //! direction selected from the locally configured BGP Role when available.
 
 use rustbgpd_wire::{AsPath, AsPathSegment, AspaValidation, AspaValidationContext, BgpRole};
+use smallvec::SmallVec;
 
 use crate::aspa::{AspaTable, ProviderAuth};
+
+/// Compressed `AS_PATH` hop list. Inline capacity 8 keeps the global-table
+/// common case (compressed paths of ~3-6 ASNs) allocation-free; this runs
+/// once per route per ASPA revalidation pass.
+type CompressedPath = SmallVec<[u32; 8]>;
 
 /// Proven customer/provider pair that made an ASPA path invalid.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -45,8 +51,8 @@ impl AspaVerificationResult {
 ///
 /// Returns `None` if any `AS_SET` segment is encountered (`AS_SET` makes the
 /// path unverifiable).
-fn compress_as_path(path: &AsPath) -> Option<Vec<u32>> {
-    let mut result = Vec::new();
+fn compress_as_path(path: &AsPath) -> Option<CompressedPath> {
+    let mut result = CompressedPath::new();
     for segment in &path.segments {
         match segment {
             AsPathSegment::AsSet(_) => return None,
@@ -240,7 +246,7 @@ fn verify_downstream_detailed(
         return AspaVerificationResult::state(AspaValidation::Valid);
     }
 
-    let origin_to_neighbor: Vec<u32> = compressed.iter().rev().copied().collect();
+    let origin_to_neighbor: CompressedPath = compressed.iter().rev().copied().collect();
     let n = origin_to_neighbor.len();
     let (max_up, invalid_hop) = ramp_up_bound(&origin_to_neighbor, table, BoundMode::Max);
     let (min_up, _) = ramp_up_bound(&origin_to_neighbor, table, BoundMode::Min);

--- a/crates/rpki/src/vrp_manager.rs
+++ b/crates/rpki/src/vrp_manager.rs
@@ -21,6 +21,17 @@ use crate::vrp::{VrpEntry, VrpTable};
 pub struct RpkiTableUpdate {
     /// The new merged VRP table snapshot.
     pub table: Arc<VrpTable>,
+    /// The VRP entries announced or withdrawn since the previously
+    /// distributed snapshot, when this update came from an RTR incremental
+    /// (serial) sync. The merged table is a union of per-server sets, so any
+    /// entry that differs between consecutive distributed snapshots is
+    /// guaranteed to appear in this list — a route's validation outcome can
+    /// only change if its prefix is covered by one of these entries, which
+    /// lets the RIB manager revalidate just the covered routes.
+    ///
+    /// `None` means no delta is known (full cache snapshot, cache reset,
+    /// resync, server loss) and consumers must revalidate everything.
+    pub delta: Option<Vec<VrpEntry>>,
 }
 
 /// Message sent from VRP manager to RIB manager when the ASPA table changes.
@@ -88,7 +99,7 @@ impl VrpManager {
     }
 
     async fn handle_update(&mut self, update: VrpUpdate) {
-        match update {
+        let vrp_delta = match update {
             VrpUpdate::FullTable {
                 server,
                 entries,
@@ -111,6 +122,9 @@ impl VrpManager {
                         .map(|r| (r.customer_asn, r.provider_asns))
                         .collect(),
                 );
+                // A full snapshot replaces the server's whole set — there is
+                // no bounded changed-entry list, so downstream must rescan.
+                None
             }
             VrpUpdate::IncrementalUpdate {
                 server,
@@ -138,6 +152,11 @@ impl VrpManager {
                 for w in &withdrawn {
                     table.remove(w);
                 }
+                // Every merged-table entry that can differ from the previous
+                // snapshot is in one of these two lists (only this server's
+                // set is mutated, and only by exactly these entries).
+                let mut delta = withdrawn.clone();
+                delta.extend(announced.iter().cloned());
                 table.extend(announced);
 
                 // ASPA incremental (8210bis semantics): a withdraw (which
@@ -151,15 +170,20 @@ impl VrpManager {
                 for a in aspa_announced {
                     aspa_table.insert(a.customer_asn, a.provider_asns);
                 }
+                Some(delta)
             }
             VrpUpdate::ServerDown { server } => {
                 info!(%server, "cache server down — removing entries");
                 self.server_tables.remove(&server);
                 self.server_aspa_tables.remove(&server);
+                // ponytail: the removed set IS the exact delta, but server
+                // loss is rare and multi-cache overlap makes it usually a
+                // no-op distribution; wire it through if it ever shows up.
+                None
             }
-        }
+        };
 
-        self.rebuild_and_distribute_vrp().await;
+        self.rebuild_and_distribute_vrp(vrp_delta).await;
         self.rebuild_and_distribute_aspa().await;
     }
 
@@ -169,7 +193,7 @@ impl VrpManager {
     // O(total log total) on a single manager task off the hot path.
     // ponytail: revisit with per-family incremental table maintenance only if
     // caches ever stream high-rate deltas.
-    async fn rebuild_and_distribute_vrp(&mut self) {
+    async fn rebuild_and_distribute_vrp(&mut self, delta: Option<Vec<VrpEntry>>) {
         let merged: Vec<VrpEntry> = self
             .server_tables
             .values()
@@ -178,6 +202,9 @@ impl VrpManager {
 
         let new_table = Arc::new(VrpTable::new(merged));
 
+        // Dropping a suppressed update's delta is sound: suppression proves
+        // the merged table did not change, so the last *distributed* snapshot
+        // still equals the table any later delta is computed against.
         if *new_table == *self.current_table {
             debug!("VRP table unchanged — skipping distribution");
             return;
@@ -190,7 +217,13 @@ impl VrpManager {
             "VRP table updated"
         );
         self.current_table = Arc::clone(&new_table);
-        let _ = self.rib_tx.send(RpkiTableUpdate { table: new_table }).await;
+        let _ = self
+            .rib_tx
+            .send(RpkiTableUpdate {
+                table: new_table,
+                delta,
+            })
+            .await;
     }
 
     async fn rebuild_and_distribute_aspa(&mut self) {
@@ -271,6 +304,10 @@ mod tests {
 
         let update = rib_rx.try_recv().unwrap();
         assert_eq!(update.table.len(), 2);
+        assert!(
+            update.delta.is_none(),
+            "full snapshot must not carry a delta"
+        );
     }
 
     #[tokio::test]
@@ -324,7 +361,7 @@ mod tests {
         mgr.handle_update(VrpUpdate::IncrementalUpdate {
             server: server1(),
             announced: vec![e3.clone()],
-            withdrawn: vec![e1],
+            withdrawn: vec![e1.clone()],
             aspa_announced: vec![],
             aspa_withdrawn: vec![],
         })
@@ -332,6 +369,10 @@ mod tests {
 
         let update = rib_rx.try_recv().unwrap();
         assert_eq!(update.table.len(), 2); // e2 + e3
+        // Incremental sync carries exactly the withdrawn + announced entries.
+        let delta = update.delta.expect("incremental sync must carry a delta");
+        assert_eq!(delta.len(), 2);
+        assert!(delta.contains(&e1) && delta.contains(&e3));
     }
 
     #[tokio::test]
@@ -361,6 +402,7 @@ mod tests {
 
         let update = rib_rx.try_recv().unwrap();
         assert_eq!(update.table.len(), 1);
+        assert!(update.delta.is_none(), "server loss must not carry a delta");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3597,6 +3597,7 @@ async fn run<T>(
                 let _ = rpki_rib_tx
                     .send(RibUpdate::RpkiCacheUpdate {
                         table: update.table,
+                        delta: update.delta,
                     })
                     .await;
                 trigger_import_validation_refresh(


### PR DESCRIPTION
Delta-scope RPKI revalidation (LAN-1029, first tranche: VRP only).

## Problem

Every changed merged VRP table triggered a full O(peers × routes) rescan of all Adj-RIB-Ins on the RIB manager task, even though `VrpUpdate::IncrementalUpdate` already carries the announced/withdrawn VRP lists — `rebuild_and_distribute_vrp` discarded them. RTR serial-notify deltas arrive every few minutes in steady state, so this is recurring cost at exactly the IXP profile.

## Mechanism

- `RpkiTableUpdate` / `RibUpdate::RpkiCacheUpdate` gain an optional `delta: Vec<VrpEntry>`. Only the incremental-sync arm produces it; full snapshots, cache resets, resyncs (`ResyncAndRetain` voids the epoch, so the next sync is a Reset Query → `FullTable`), and server loss keep `delta = None`, and the first table after startup forces a full rescan regardless (no baseline). The full-rescan arm is unchanged and remains the fallback.
- With a delta, `handle_rpki_cache_update` revalidates only routes whose prefix is covered by an announced or withdrawn VRP, enumerated in O(covered) per peer via the existing Adj-RIB-In prefix trie (`FamilyPrefixMap::children` → `AdjRibIn::for_each_covered_mut`).
- Soundness: a route's RFC 6811 outcome depends only on its covering VRPs, coverage is containment by VRP prefix length (`max_len` only gates the Valid decision), and every entry that differs between consecutive distributed snapshots appears in the delta (the merged table is a union of per-server sets mutated only by exactly those entries; the deep-equality suppression drops a delta only when the table provably did not change). Covered routes revalidate against the full new table, so outcomes are identical to a full rescan — only the visited set shrinks.
- ASPA stays full-scan (explicitly deferred; needs an ASN→routes index).
- Sub-item: `compress_as_path` now returns a `SmallVec<[u32; 8]>` instead of allocating a `Vec<u32>` per route per ASPA pass (in-crate precedent: `vrp.rs`).
- The completion log now reports `mode` (delta/full), `routes_revalidated`, `changed_routes`, `affected_prefixes`, and `elapsed_ms`.

## Correctness fence

Validation outcomes are identical by construction; only which routes get revisited changes. Targeted tests (each with a poisoned-sentinel proof that uncovered routes are not revisited, which also proves which arm ran):

- announced VRP whose covered set includes more-specifics
- withdrawal flipping Valid → NotFound
- overlapping VRPs where a withdrawn one leaves another covering (Valid → Invalid, not NotFound)
- max-length semantics: a VRP with `max_len` equal to its own length still covers (and Invalid-flips) more-specific routes; announce/withdraw of a looser `max_len` VRP flips Valid ↔ Invalid under the surviving tighter one
- IPv6 coverage with a same-family uncovered sentinel
- first-table guard: a delta arriving before any baseline is ignored in favor of a full rescan

Differential test (`rpki_delta_matches_full_rescan_on_random_sequences`): a deterministic random announce/withdraw sequence — 40 steps over an overlapping 37-candidate VRP universe (a /8 umbrella, /16s and /24s at competing origins and max lengths), 4 peers × 25 routes at mixed lengths — driven through the delta arm and through full rescans in twin managers, asserting identical per-route validation states across all peers at every step, including the VRP manager's deep-equality suppression behavior.

## Timing receipt

In-test shape from the ticket: 100 peers × 10k routes, 1-entry delta. Twin managers with identical state take the same T1→T2 table transition (10k-entry table), one through each arm, so the timed sections do identical recompute work and differ only in revalidation scan scope (`rpki_delta_timing_receipt`, prints with `--nocapture`):

| build | full rescan | delta-scoped |
|---|---|---|
| release | 129.3 ms | 141.7 µs |
| debug | 781.6 ms | 361.7 µs |

Claim scope: this is the in-test synthetic shape only; an RR-harness receipt can follow separately.

## Gates

- `cargo test -p rustbgpd-rib` — 1147 passed, 0 failed (exit 0)
- `cargo test -p rustbgpd-rpki` — 158 passed, 0 failed (exit 0)
- `cargo clippy -p rustbgpd-rib -p rustbgpd-rpki --all-targets -- -D warnings` — exit 0
- `cargo fmt --check` — exit 0
- `cargo doc -p rustbgpd-rib -p rustbgpd-rpki --no-deps` — exit 0

Out of scope per ticket: `vrp_manager`'s full rebuild (recorded deliberate ceiling), ASPA delta-indexing.

LAN-1029
