### PR TITLE
rib: release private unicast storage after regrouping

### DIFF
--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -67,8 +67,9 @@ impl AdjRibOut {
     /// Use `LocRib::len()` for an authoritative per-peer unicast table. A
     /// freshly installed grouped peer's private table owns only the other
     /// address families, so it starts with zero unicast capacity; the shared
-    /// group table carries the Loc-RIB-sized reservation. Moving an existing
-    /// ungrouped table into a group may retain its prior allocation.
+    /// group table carries the Loc-RIB-sized reservation. Group transfer
+    /// releases an existing private reservation; a later return to the
+    /// per-peer path grows the private table again from empty.
     #[must_use]
     pub fn with_capacity(peer: IpAddr, capacity: usize) -> Self {
         Self {
@@ -186,13 +187,26 @@ impl AdjRibOut {
     }
 
     /// Remove only the unicast routes and their secondary prefix index,
-    /// leaving every other family untouched. Used when a peer moves onto
-    /// the update-group path: its unicast advertised state becomes
-    /// group-owned while non-unicast families keep riding this per-peer
-    /// table.
+    /// leaving every other family untouched. This keeps the backing
+    /// allocations for callers that expect the unicast table to refill.
+    /// Use [`Self::release_unicast`] when ownership moves to an update group.
     pub fn clear_unicast(&mut self) {
         self.routes.clear();
         self.prefix_path_ids.clear();
+    }
+
+    /// Remove only the unicast routes and their secondary prefix index,
+    /// releasing their backing allocations while leaving every other family
+    /// untouched.
+    ///
+    /// Unlike [`Self::clear_unicast`], this is used when a peer moves onto the
+    /// update-group path and its unicast state becomes group-owned. Returning
+    /// to the private path grows the empty table again, so repeated membership
+    /// flaps deliberately trade reallocation for lower grouped steady-state
+    /// memory.
+    pub fn release_unicast(&mut self) {
+        self.routes = RouteSlab::default();
+        self.prefix_path_ids = FamilyPrefixMap::default();
     }
 
     /// Remove only the VPN routes and their secondary key index, leaving
@@ -823,6 +837,38 @@ mod tests {
         assert!(rib.path_ids_for_prefix(&prefix_b()).is_empty());
         assert!(rib.is_empty());
         assert_eq!(rib.bgpls_len(), 0);
+    }
+
+    #[test]
+    fn clear_unicast_keeps_capacity_and_other_families() {
+        let mut rib = AdjRibOut::with_capacity(IpAddr::V4(Ipv4Addr::LOCALHOST), 64);
+        rib.insert(make_route(prefix_a(), 0));
+        rib.insert_vpn(make_vpn_route(vpn_nlri([10, 0, 1, 0], 24, 100), 1));
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, bgpls_nlri(15), 1));
+        let capacity = rib.bench_route_capacity();
+
+        rib.clear_unicast();
+
+        assert!(rib.is_empty());
+        assert_eq!(rib.bench_route_capacity(), capacity);
+        assert_eq!(rib.vpn_len(), 1);
+        assert_eq!(rib.bgpls_len(), 1);
+    }
+
+    #[test]
+    fn release_unicast_drops_capacity_and_keeps_other_families() {
+        let mut rib = AdjRibOut::with_capacity(IpAddr::V4(Ipv4Addr::LOCALHOST), 64);
+        rib.insert(make_route(prefix_a(), 0));
+        rib.insert_vpn(make_vpn_route(vpn_nlri([10, 0, 1, 0], 24, 100), 1));
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, bgpls_nlri(16), 1));
+        assert!(rib.bench_route_capacity() >= 64);
+
+        rib.release_unicast();
+
+        assert!(rib.is_empty());
+        assert_eq!(rib.bench_route_capacity(), 0);
+        assert_eq!(rib.vpn_len(), 1);
+        assert_eq!(rib.bgpls_len(), 1);
     }
 
     #[test]

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -885,7 +885,7 @@ fn grouped_peer_non_unicast_first_delta_keeps_private_unicast_unallocated() {
 }
 
 #[test]
-fn grouped_peer_ungroup_seeds_private_advertised_routes() {
+fn grouped_peer_slow_round_trip_releases_private_unicast_without_wire_delta() {
     let (_tx, rx) = mpsc::channel(1);
     let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
     let peer = IpAddr::V4(Ipv4Addr::new(10, 63, 1, 4));
@@ -908,11 +908,34 @@ fn grouped_peer_ungroup_seeds_private_advertised_routes() {
         .get(&peer)
         .expect("private fallback state");
     assert_eq!(private.len(), 1);
+    assert!(private.bench_route_capacity() > 0);
     assert!(private.get(&Prefix::V4(prefix), 0).is_some());
     assert!(matches!(
         outbound.try_recv(),
         Err(mpsc::error::TryRecvError::Empty)
     ));
+
+    for slow in [false, true, false] {
+        manager.handle_update(RibUpdate::PeerSlowState {
+            peer,
+            session_id: 0,
+            slow,
+        });
+        while manager.process_next_route_chunk() {}
+
+        let private = manager.adj_ribs_out.get(&peer).expect("private state");
+        if slow {
+            assert!(manager.grouped_member_of(peer).is_none());
+            assert_eq!(private.len(), 1);
+            assert!(private.bench_route_capacity() > 0);
+            assert!(private.get(&Prefix::V4(prefix), 0).is_some());
+        } else {
+            assert!(manager.grouped_member_of(peer).is_some());
+            assert_eq!(private.len(), 0);
+            assert_eq!(private.bench_route_capacity(), 0);
+        }
+        assert!(outbound.try_recv().is_err());
+    }
 }
 
 fn drive_exact_precommit_step(

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -934,7 +934,10 @@ fn grouped_peer_slow_round_trip_releases_private_unicast_without_wire_delta() {
             assert_eq!(private.len(), 0);
             assert_eq!(private.bench_route_capacity(), 0);
         }
-        assert!(outbound.try_recv().is_err());
+        assert!(matches!(
+            outbound.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
     }
 }
 

--- a/crates/rib/src/manager/update_groups/membership.rs
+++ b/crates/rib/src/manager/update_groups/membership.rs
@@ -121,7 +121,7 @@ impl RibManager {
                 // ownership into the bounded member set first.
                 self.carry_outbound_admitted_across_regroup(peer, true);
                 if let Some(rib_out) = self.adj_ribs_out.get_mut(&peer) {
-                    rib_out.clear_unicast();
+                    rib_out.release_unicast();
                     if vpn_groupable {
                         rib_out.clear_vpn();
                     }

--- a/crates/rib/tests/memory_profile.rs
+++ b/crates/rib/tests/memory_profile.rs
@@ -665,6 +665,59 @@ fn memory_profile_schema_quick() {
     assert_eq!(rr.stats.adj_out_routes, 512 * 2);
 }
 
+#[cfg(feature = "bench-internals")]
+#[test]
+fn adj_rib_out_release_unicast_reclaims_100k_structural_capacity() {
+    const PREFIX_COUNT: usize = 100_000;
+    const MIN_RECLAIMED_BYTES: usize = 1024 * 1024;
+
+    let prefixes = generate_prefixes(PREFIX_COUNT);
+    let attrs = typical_attributes(1);
+    let mut rib = AdjRibOut::new(IpAddr::V4(Ipv4Addr::new(10, 0, 11, 1)));
+    for prefix in &prefixes {
+        rib.insert(make_route(*prefix, 1, &attrs));
+    }
+
+    let route_capacity_before = rib.bench_route_capacity();
+    let prefix_len_before = rib.bench_prefix_index_len();
+    let route_bytes_before = route_capacity_before * std::mem::size_of::<Option<Route>>();
+    let prefix_bytes_before = rib.bench_prefix_index_mem_size();
+    let structural_bytes_before = route_bytes_before + prefix_bytes_before;
+    assert_eq!(rib.len(), PREFIX_COUNT);
+    assert_eq!(prefix_len_before, PREFIX_COUNT);
+    let fresh = AdjRibOut::new(IpAddr::V4(Ipv4Addr::new(10, 0, 12, 1)));
+    let fresh_route_capacity = fresh.bench_route_capacity();
+    let fresh_route_bytes = fresh_route_capacity * std::mem::size_of::<Option<Route>>();
+    let fresh_prefix_len = fresh.bench_prefix_index_len();
+    let fresh_prefix_bytes = fresh.bench_prefix_index_mem_size();
+
+    rib.release_unicast();
+
+    let route_capacity_after = rib.bench_route_capacity();
+    let prefix_len_after = rib.bench_prefix_index_len();
+    let route_bytes_after = route_capacity_after * std::mem::size_of::<Option<Route>>();
+    let prefix_bytes_after = rib.bench_prefix_index_mem_size();
+    let structural_bytes_after = route_bytes_after + prefix_bytes_after;
+    let route_reclaimed = route_bytes_before.saturating_sub(route_bytes_after);
+    let prefix_reclaimed = prefix_bytes_before.saturating_sub(prefix_bytes_after);
+    let reclaimed = route_reclaimed + prefix_reclaimed;
+    println!(
+        "route_capacity_before={} route_bytes_before={route_bytes_before} prefix_len_before={} prefix_bytes_before={prefix_bytes_before} route_capacity_after={} route_bytes_after={route_bytes_after} prefix_len_after={} prefix_bytes_after={prefix_bytes_after} fresh_route_bytes={fresh_route_bytes} fresh_prefix_bytes={fresh_prefix_bytes} route_reclaimed={route_reclaimed} prefix_reclaimed={prefix_reclaimed} total_before={structural_bytes_before} total_after={structural_bytes_after} total_reclaimed={reclaimed}",
+        route_capacity_before, prefix_len_before, route_capacity_after, prefix_len_after,
+    );
+    assert!(rib.is_empty());
+    assert_eq!(route_capacity_after, fresh_route_capacity);
+    assert_eq!(route_bytes_after, fresh_route_bytes);
+    assert_eq!(prefix_bytes_after, fresh_prefix_bytes);
+    assert_eq!(prefix_len_after, fresh_prefix_len);
+    assert!(route_bytes_before > route_bytes_after);
+    assert!(prefix_bytes_before > prefix_bytes_after);
+    assert!(
+        reclaimed >= MIN_RECLAIMED_BYTES,
+        "released {reclaimed} structural bytes, expected at least {MIN_RECLAIMED_BYTES}"
+    );
+}
+
 #[test]
 #[ignore = "manual high-N memory regression harness; use bench/compare-rib-memory.sh"]
 fn memory_profile_high_n() {


### PR DESCRIPTION
## Summary

- release the private unicast `RouteSlab` and `FamilyPrefixMap` after an existing peer transfers ownership back to an update group
- preserve the allocation-retaining `clear_unicast` path for callers that expect to refill the table
- keep VPN and all other address-family state intact
- cover two slow-peer isolate/rejoin cycles and independently pin route-slab and prefix-index reclamation

## Structural proof

In the deterministic 100,000-prefix x86-64 fixture, the private unicast view changes from:

- route slots: 16,777,216 bytes to 0
- prefix index: 3,277,808 bytes to 912
- total structure: 20,055,024 bytes to 912

That reclaims 20,054,112 structural bytes after the regroup baseline and admitted-prefix state have been carried forward. The released table matches a fresh empty table.

## Verification

- focused `clear_unicast` allocation-retention test
- focused `release_unicast` family-preservation test
- two-cycle slow-peer private/group lifecycle test with no outbound wire delta
- exact 100,000-prefix structural-capacity test
- `cargo test --locked -p rustbgpd-rib` — 1,151 unit tests plus the memory schema passed
- exact memory schema test
- strict `cargo clippy --locked -p rustbgpd-rib --all-targets --features bench-internals -- -D warnings`
- repository pre-commit and pre-push formatting, workspace Clippy/check, and rustdoc hooks

## Limitations

This is a cold ownership-lifecycle change and the claim is limited to deterministic structural capacity. Repeated private/group flapping refills the private view from empty, trading reallocation and deallocation work for lower grouped steady-state memory. Cleanup latency was not benchmarked.

This does not claim an RSS, jemalloc, DHAT, convergence, throughput, whole-daemon, fleet-wide, or historical-regression result.

Linear: LAN-1032
