### PR TITLE
Compact update-group permit labels

### DIFF
--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -454,17 +454,11 @@ pub(in crate::manager) struct GroupRibOut {
     /// empty ([`Self::record_policy_filtered`] removes whole prefixes),
     /// so outer emptiness remains "no denials".
     policy_filtered: FxHashMap<Prefix, FxHashMap<(IpAddr, u32), Option<PolicyLabel>>>,
-    /// Terminal policy label per staged entry — join-time counter replay
-    /// residue. Entries ONLY for labelled entries: an inline (unlabelled)
-    /// entry stores nothing and its key is removed, so absent and
-    /// present-`None` are the same verdict. Every reader collapses the
-    /// two, so keep the insert conditional — an unconditional insert
-    /// costs a slot per staged route across the whole table for a value
-    /// no reader can distinguish from absence.
-    staged_labels: FxHashMap<(Prefix, u32), Option<PolicyLabel>>,
-    /// VPN sibling of `staged_labels`, keyed by RD+prefix identity, with
-    /// the same absent-means-inline invariant.
-    vpn_staged_labels: FxHashMap<VpnRouteKey, Option<PolicyLabel>>,
+    /// Terminal Permit label for every staged unicast and VPN entry.
+    /// Export-chain identity is group-uniform and immutable, and a chain
+    /// Permit is always attributed to its final named policy, so retaining
+    /// this once per group replaces two route-keyed label maps.
+    permit_policy_label: Option<PolicyLabel>,
     /// Persistent group-verdict VPN export-policy denials: denied key →
     /// (source peer, denying policy label, the denied route's extended
     /// communities). The per-peer VPN path keeps no denial *records*
@@ -563,6 +557,11 @@ impl GroupRibOut {
         per_client_best: bool,
         capacity: usize,
     ) -> Self {
+        let permit_policy_label = export_chain
+            .as_ref()
+            .and_then(|chain| chain.policies.last())
+            .and_then(|policy| policy.name.as_deref())
+            .map(Arc::from);
         Self {
             table: AdjRibOut::with_capacity(GROUP_FILTERED_PLACEHOLDER, capacity),
             nh_overrides: FxHashMap::default(),
@@ -574,8 +573,7 @@ impl GroupRibOut {
             members: HashSet::new(),
             dirty_members: HashSet::new(),
             policy_filtered: FxHashMap::default(),
-            staged_labels: FxHashMap::default(),
-            vpn_staged_labels: FxHashMap::default(),
+            permit_policy_label,
             vpn_policy_denied: FxHashMap::default(),
             otc_blocked: FxHashMap::default(),
             otc_blocked_totals: [0; 2],
@@ -769,6 +767,11 @@ impl GroupRibOut {
             self.dec_source(old_peer, &delta.prefix);
         }
         if let Some((route, nh)) = &delta.new {
+            debug_assert_eq!(
+                delta.policy_label.as_deref(),
+                self.permit_policy_label.as_deref(),
+                "staged Permit attribution must match the immutable export-chain tail"
+            );
             self.inc_source(route.peer, &delta.prefix);
             match nh {
                 Some(action) => {
@@ -786,20 +789,11 @@ impl GroupRibOut {
                     self.source_attrs.remove(&key);
                 }
             }
-            match &delta.policy_label {
-                Some(label) => {
-                    self.staged_labels.insert(key, Some(label.clone()));
-                }
-                None => {
-                    self.staged_labels.remove(&key);
-                }
-            }
             self.table.insert(route.clone());
         } else {
             self.table.withdraw(&delta.prefix, delta.path_id);
             self.nh_overrides.remove(&key);
             self.source_attrs.remove(&key);
-            self.staged_labels.remove(&key);
         }
     }
 
@@ -861,20 +855,15 @@ impl GroupRibOut {
             self.dec_source_slot(old_peer, slot);
         }
         if let Some(route) = &delta.new {
+            debug_assert_eq!(
+                delta.policy_label.as_deref(),
+                self.permit_policy_label.as_deref(),
+                "staged VPN Permit attribution must match the immutable export-chain tail"
+            );
             self.inc_source_slot(route.peer, slot);
-            match &delta.policy_label {
-                Some(label) => {
-                    self.vpn_staged_labels
-                        .insert(delta.key, Some(label.clone()));
-                }
-                None => {
-                    self.vpn_staged_labels.remove(&delta.key);
-                }
-            }
             self.table.insert_vpn(route.clone());
         } else {
             self.table.remove_vpn(&rib_key);
-            self.vpn_staged_labels.remove(&delta.key);
         }
     }
 
@@ -964,7 +953,7 @@ impl GroupRibOut {
                 route: staged,
                 nh: self.nh_overrides.get(&key),
                 source_attrs: self.source_attrs.get(&key),
-                policy_label: self.staged_labels.get(&key).and_then(Option::as_ref),
+                policy_label: self.permit_policy_label.as_ref(),
             });
         }
         if !self.per_client_best {
@@ -1494,7 +1483,7 @@ impl RibManager {
                         // documented counter deviation).
                         let key = route.nlri.key();
                         count_delta[GroupRibOut::vpn_count_slot(&key) - 2] += 1;
-                        let label = group.vpn_staged_labels.get(&key).cloned().unwrap_or(None);
+                        let label = group.permit_policy_label.clone();
                         bump_counter_row(&mut permit_rows, label.as_ref(), PolicyAction::Permit);
                         vpn_announce.push(route.clone());
                     }

--- a/crates/rib/src/manager/update_groups/policy_transition.rs
+++ b/crates/rib/src/manager/update_groups/policy_transition.rs
@@ -136,10 +136,7 @@ impl RibManager {
                 inventory.next_hop_override.push(next_hop);
             }
 
-            let label = new
-                .staged_labels
-                .get(&key)
-                .and_then(|label| label.as_deref());
+            let label = new.permit_policy_label.as_deref();
             run = Some(match run {
                 Some((peer, run_label, count)) if peer == route.peer && run_label == label => {
                     (peer, run_label, count + 1)
@@ -535,7 +532,7 @@ impl RibManager {
             // Counter fold: one permit per staged entry, labelled by its
             // retained terminal policy; per-source rows feed the
             // Decision 4 `totals − own + lane` synthesis below.
-            let label = destination.staged_labels.get(&key).cloned().unwrap_or(None);
+            let label = destination.permit_policy_label.clone();
             counters.record_permit(route.peer, label);
             // Member-scoped correction for the slot's own source — the
             // one member the shared exclusion silences at this key. Its

--- a/crates/rib/src/manager/update_groups/tests.rs
+++ b/crates/rib/src/manager/update_groups/tests.rs
@@ -624,6 +624,12 @@ fn per_client_best_group(chain: Option<PolicyChain>) -> GroupRibOut {
     )
 }
 
+fn named_permit_chain(label: &str) -> PolicyChain {
+    let mut chain = empty_policy(PolicyAction::Permit);
+    chain.policies[0].name = Some(label.to_string());
+    chain
+}
+
 fn announce_delta(p: Prefix, src: IpAddr, old: Option<IpAddr>) -> GroupDelta {
     let new = route(p, src);
     let source_attrs = capture_source_attrs(&new);
@@ -1097,13 +1103,7 @@ fn pcb_winner_label_is_captured_at_its_permit_point() {
     // denial attributes to "screen". The winner keeps "tail".
     assert_eq!(out.deltas[0].policy_label.as_deref(), Some("tail"));
     let group = m.group_ribs.get(&PCB_GID).unwrap();
-    assert_eq!(
-        group
-            .staged_labels
-            .get(&(p, 0))
-            .and_then(|label| label.as_deref()),
-        Some("tail")
-    );
+    assert_eq!(group.permit_policy_label.as_deref(), Some("tail"));
     assert_eq!(
         group
             .policy_filtered
@@ -1655,7 +1655,7 @@ fn adv_entry_derivation_matrix() {
     let p = prefix(1);
 
     // Non-own staged entry: passthrough with its table residue.
-    let mut group = per_client_best_group(None);
+    let mut group = per_client_best_group(Some(named_permit_chain("staged")));
     group.apply_delta(&GroupDelta {
         prefix: p,
         path_id: 0,
@@ -1975,7 +1975,7 @@ fn pcb_grouped_count_queries_include_lane_term() {
 #[test]
 fn pcb_join_counters_replay_lane_permit() {
     let (p1, p2) = (prefix(1), prefix(2));
-    let mut group = per_client_best_group(None);
+    let mut group = per_client_best_group(Some(named_permit_chain("win")));
     // p1: winner MEMBER (label "win"), runner-up OTHER2 in the
     // lane (label "lane"). p2: winner OTHER1 (label "win").
     group.apply_delta(&GroupDelta {
@@ -3832,11 +3832,11 @@ fn vpn_counts_and_family_synthesis_track_deltas() {
     assert_eq!(group.vpn_advertised_count_for(MEMBER), 0);
     assert_eq!(group.vpn_advertised_count_for(OTHER1), 2);
 
-    // Withdraw drops the entry and its label residue.
+    // Withdraw drops the entry; the immutable group Permit label remains.
     group.apply_vpn_delta(&vpn_withdraw_delta(1, Some(MEMBER)));
     assert_eq!(group.vpn_advertised_count_for(OTHER1), 1);
     assert_eq!(group.table.vpn_len(), 1);
-    assert!(!group.vpn_staged_labels.contains_key(&vpn_key(1)));
+    assert!(group.permit_policy_label.is_none());
 
     // An RTC-negotiated sendable set stages VPN too (v2 slice 2):
     // Φ is applied per member at emit, not by a staging gate.
@@ -3859,15 +3859,11 @@ fn vpn_counts_and_family_synthesis_track_deltas() {
     assert!(rtc_group.rtc_negotiated());
 }
 
-/// Inline (unlabelled) staged entries leave NO slot in either label
-/// residue map. Absent and present-`None` are the same verdict at
-/// every reader, so the unlabelled case — the whole table when no
-/// export policy is configured — must not pay a slot per staged
-/// route. Asserted on map occupancy: the resolved label is `None`
-/// either way, so occupancy is the only observable difference.
+/// The group Permit label is derived once from the immutable chain tail.
+/// No chain, an empty chain, and an anonymous tail are inline.
 #[test]
-fn inline_staged_entries_leave_no_label_residue() {
-    let mut group = GroupRibOut::new(
+fn group_permit_label_is_the_named_chain_tail_or_inline() {
+    let group = GroupRibOut::new(
         None,
         false,
         false,
@@ -3878,89 +3874,88 @@ fn inline_staged_entries_leave_no_label_residue() {
         false,
         0,
     );
-    let key = (prefix(1), 0);
-    let resolved = |g: &GroupRibOut| {
-        (
-            g.staged_labels
-                .get(&key)
-                .and_then(|l| l.as_deref())
-                .is_none(),
-            g.vpn_staged_labels
-                .get(&vpn_key(1))
-                .cloned()
-                .unwrap_or(None)
-                .is_none(),
-        )
-    };
+    assert!(group.permit_policy_label.is_none());
 
-    // Unlabelled announce: no slot, and the readers still see None.
-    group.apply_delta(&announce_delta(prefix(1), OTHER1, None));
-    group.apply_vpn_delta(&vpn_announce_delta(1, OTHER1, None));
-    assert!(!group.staged_labels.contains_key(&key));
-    assert!(!group.vpn_staged_labels.contains_key(&vpn_key(1)));
-    assert_eq!(resolved(&group), (true, true));
-
-    // A labelled restage DOES take a slot — the residue still
-    // carries what join-time counter replay reads.
-    let mut labelled = announce_delta(prefix(1), OTHER1, Some(OTHER1));
-    labelled.policy_label = Some(Arc::from("export-chain"));
-    group.apply_delta(&labelled);
-    let mut vpn_labelled = vpn_announce_delta(1, OTHER1, Some(OTHER1));
-    vpn_labelled.policy_label = Some(Arc::from("export-chain"));
-    group.apply_vpn_delta(&vpn_labelled);
-    assert_eq!(
-        group.staged_labels.get(&key).and_then(|l| l.as_deref()),
-        Some("export-chain")
+    let empty = GroupRibOut::new(
+        Some(PolicyChain::default()),
+        false,
+        false,
+        true,
+        None,
+        vec![],
+        vec![],
+        false,
+        0,
     );
-    assert_eq!(
-        group
-            .vpn_staged_labels
-            .get(&vpn_key(1))
-            .and_then(|label| label.as_deref()),
-        Some("export-chain")
-    );
+    assert!(empty.permit_policy_label.is_none());
 
-    // Restaging inline REMOVES the slot rather than retaining the
-    // stale label — a skipped insert would leak the old verdict
-    // into the joining member's replayed counters.
-    group.apply_delta(&announce_delta(prefix(1), OTHER1, Some(OTHER1)));
-    group.apply_vpn_delta(&vpn_announce_delta(1, OTHER1, Some(OTHER1)));
-    assert!(!group.staged_labels.contains_key(&key));
-    assert!(!group.vpn_staged_labels.contains_key(&vpn_key(1)));
-    assert_eq!(resolved(&group), (true, true));
+    let anonymous = GroupRibOut::new(
+        Some(empty_policy(PolicyAction::Permit)),
+        false,
+        false,
+        true,
+        None,
+        vec![],
+        vec![],
+        false,
+        0,
+    );
+    assert!(anonymous.permit_policy_label.is_none());
 }
 
-/// Shared staging must retain the evaluator's policy-label allocation from
-/// one delta through the group-table residue. Two routes ending in the
-/// same policy therefore share one backing label rather than allocating a
-/// `String` per staged key.
-///
-/// Red proof: rebuilding either stored label with
-/// `Arc::from(label.as_ref())` leaves the operator-visible text unchanged
-/// but makes the pointer-identity assertion fail.
+/// A named multi-policy chain retains one group-owned terminal Permit label
+/// for both unicast and VPN staged routes, independent of restaging.
 #[test]
-fn staged_policy_labels_share_the_evaluation_allocation() {
-    let mut group = empty_group();
-    let label: Arc<str> = Arc::from("shared-export-policy");
-    for n in [1, 2] {
-        let mut delta = announce_delta(prefix(n), OTHER1, None);
-        delta.policy_label = Some(Arc::clone(&label));
-        group.apply_delta(&delta);
-    }
-
-    let first = group
-        .staged_labels
-        .get(&(prefix(1), 0))
-        .and_then(Option::as_ref)
-        .expect("first route carries its terminal policy");
-    let second = group
-        .staged_labels
-        .get(&(prefix(2), 0))
-        .and_then(Option::as_ref)
-        .expect("second route carries its terminal policy");
-    assert_eq!(first.as_ref(), "shared-export-policy");
-    assert!(Arc::ptr_eq(&label, first));
-    assert!(Arc::ptr_eq(first, second));
+fn named_chain_tail_is_one_group_owned_permit_label() {
+    let mut chain = PolicyChain::new(vec![
+        Policy {
+            entries: vec![],
+            default_action: PolicyAction::Permit,
+        },
+        Policy {
+            entries: vec![],
+            default_action: PolicyAction::Permit,
+        },
+    ]);
+    chain.policies[0].name = Some("screen".into());
+    chain.policies[1].name = Some("tail".into());
+    let mut group = GroupRibOut::new(
+        Some(chain),
+        false,
+        false,
+        true,
+        None,
+        vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv4, Safi::MplsVpn)],
+        vec![],
+        false,
+        0,
+    );
+    let label = Arc::clone(group.permit_policy_label.as_ref().expect("named tail"));
+    let mut announce = announce_delta(prefix(1), OTHER1, Some(OTHER1));
+    announce.policy_label = Some(Arc::clone(&label));
+    group.apply_delta(&announce);
+    let mut vpn_announce = vpn_announce_delta(1, OTHER1, Some(OTHER1));
+    vpn_announce.policy_label = Some(Arc::clone(&label));
+    group.apply_vpn_delta(&vpn_announce);
+    assert_eq!(label.as_ref(), "tail");
+    assert!(Arc::ptr_eq(
+        &label,
+        group
+            .adv_entry(OTHER2, &prefix(1), 0)
+            .unwrap()
+            .policy_label
+            .unwrap()
+    ));
+    let mut restage = announce_delta(prefix(1), OTHER1, Some(OTHER2));
+    restage.policy_label = Some(Arc::clone(&label));
+    group.apply_delta(&restage);
+    let mut vpn_restage = vpn_announce_delta(1, OTHER1, Some(OTHER2));
+    vpn_restage.policy_label = Some(Arc::clone(&label));
+    group.apply_vpn_delta(&vpn_restage);
+    assert!(Arc::ptr_eq(
+        &label,
+        group.permit_policy_label.as_ref().unwrap()
+    ));
 }
 
 /// An RTC membership over a specific Route Target (full 96-bit

--- a/crates/rib/src/manager/update_groups/views.rs
+++ b/crates/rib/src/manager/update_groups/views.rs
@@ -307,11 +307,7 @@ impl RibManager {
                 {
                     continue;
                 }
-                let label = group
-                    .vpn_staged_labels
-                    .get(&route.nlri.key())
-                    .cloned()
-                    .unwrap_or(None);
+                let label = group.permit_policy_label.clone();
                 bump(&label, PolicyAction::Permit);
             }
             for (key, (source, label, rts)) in &group.vpn_policy_denied {

--- a/crates/rib/tests/update_group_policy_label_profile.rs
+++ b/crates/rib/tests/update_group_policy_label_profile.rs
@@ -56,14 +56,14 @@ fn labelled_staged_routes_have_zero_per_route_permit_label_collection() {
     }
     let capacity = historical.capacity();
     let with_collection = ALLOC.live.load(Ordering::Relaxed);
-    let reclaimed = with_collection - before;
+    let historical_map_bytes = with_collection - before;
 
     println!(
-        "{{\"kind\":\"update_group_policy_label_profile\",\"routes\":{ROUTES},\"per_route_collections\":0,\"historical_capacity\":{capacity},\"reclaimed_bytes\":{reclaimed}}}"
+        "{{\"kind\":\"update_group_policy_label_profile\",\"routes\":{ROUTES},\"per_route_collections\":0,\"historical_capacity\":{capacity},\"historical_map_bytes\":{historical_map_bytes}}}"
     );
     assert_eq!(historical.len(), ROUTES);
     assert!(
-        reclaimed >= FOUR_MIB,
-        "route-keyed Permit-label collection used only {reclaimed} bytes"
+        historical_map_bytes >= FOUR_MIB,
+        "route-keyed Permit-label collection allocated only {historical_map_bytes} bytes"
     );
 }

--- a/crates/rib/tests/update_group_policy_label_profile.rs
+++ b/crates/rib/tests/update_group_policy_label_profile.rs
@@ -1,0 +1,69 @@
+#![cfg(feature = "bench-internals")]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rustbgpd_wire::{Ipv4Prefix, Prefix};
+use rustc_hash::FxHashMap;
+
+struct TrackingAllocator {
+    live: AtomicUsize,
+}
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            self.live.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        self.live.fetch_sub(layout.size(), Ordering::Relaxed);
+        unsafe { System.dealloc(ptr, layout) };
+    }
+}
+
+#[global_allocator]
+static ALLOC: TrackingAllocator = TrackingAllocator {
+    live: AtomicUsize::new(0),
+};
+
+fn prefix(n: u32) -> Prefix {
+    Prefix::V4(Ipv4Prefix::new(Ipv4Addr::from(n), 32))
+}
+
+#[test]
+fn labelled_staged_routes_have_zero_per_route_permit_label_collection() {
+    const ROUTES: usize = 100_000;
+    const FOUR_MIB: usize = 4 * 1024 * 1024;
+
+    // Structural pin: production owns one group label and neither historical
+    // route-keyed Permit-label collection remains.
+    let source = include_str!("../src/manager/update_groups.rs");
+    assert!(source.contains("permit_policy_label: Option<PolicyLabel>"));
+    assert!(!source.contains("staged_labels"));
+    assert!(!source.contains("vpn_staged_labels"));
+
+    let shared_label: Arc<str> = Arc::from("terminal-export-policy");
+    let before = ALLOC.live.load(Ordering::Relaxed);
+    let mut historical: FxHashMap<(Prefix, u32), Option<Arc<str>>> = FxHashMap::default();
+    for n in 0..ROUTES as u32 {
+        historical.insert((prefix(n), 0), Some(Arc::clone(&shared_label)));
+    }
+    let capacity = historical.capacity();
+    let with_collection = ALLOC.live.load(Ordering::Relaxed);
+    let reclaimed = with_collection - before;
+
+    println!(
+        "{{\"kind\":\"update_group_policy_label_profile\",\"routes\":{ROUTES},\"per_route_collections\":0,\"historical_capacity\":{capacity},\"reclaimed_bytes\":{reclaimed}}}"
+    );
+    assert_eq!(historical.len(), ROUTES);
+    assert!(
+        reclaimed >= FOUR_MIB,
+        "route-keyed Permit-label collection used only {reclaimed} bytes"
+    );
+}


### PR DESCRIPTION
## Summary

- replace the unicast and VPN per-route Permit-label residue maps with one immutable update-group tail label
- keep denial attribution and per-client-best runner-up attribution route-keyed
- pin the chain-tail invariant at commit seams and cover unicast, VPN, join replay, and restaging behavior

## Structural proof

The bench-internals structural test constructs one synthetic historical unicast Permit-label map with 100,000 entries. Under the System allocator it allocated exactly 5,373,968 bytes at capacity 114,688; the replacement has zero per-route Permit-label collections.

This is a deterministic allocation result for that one synthetic historical map. It is not an RSS measurement, does not represent both removed maps together, and is not a whole-process memory measurement.

## Verification

- `cargo test --locked -p rustbgpd-rib named_chain_tail_is_one_group_owned_permit_label`
- `cargo test --locked -p rustbgpd-rib adv_entry_derivation_matrix`
- `cargo test --locked -p rustbgpd-rib pcb_join_counters_replay_lane_permit`
- `cargo test --locked -p rustbgpd-rib --features bench-internals --test update_group_policy_label_profile -- --nocapture`
- `cargo test --locked -p rustbgpd-rib`
- `cargo clippy --locked -p rustbgpd-rib --all-targets --features bench-internals -- -D warnings`
- `cargo fmt --all -- --check`

## Limitations

- no runtime benchmark result is claimed
- no throughput, latency, or CPU claim is made
- per-client-best lane labels and policy-denial attribution remain route-keyed
- documentation, changelog, and roadmap are unchanged because this is an internal representation optimization with no operator-visible contract change
