### PR TITLE
transport: release read buffer storage on disconnect

### DIFF
--- a/crates/transport/src/framing.rs
+++ b/crates/transport/src/framing.rs
@@ -85,6 +85,16 @@ impl ReadBuffer {
     pub fn clear(&mut self) {
         self.buf.clear();
     }
+
+    /// Drop buffered data and release any grown backing allocation.
+    ///
+    /// This is a cold transport-lifecycle operation: callers must first drop
+    /// the TCP read half so no active read can race the replacement. The
+    /// negotiated framing limit is deliberately preserved; the FSM owns its
+    /// per-session reset independently.
+    pub(crate) fn reset_storage(&mut self) {
+        self.buf = BytesMut::with_capacity(MAX_MESSAGE_LEN.into());
+    }
 }
 
 impl Default for ReadBuffer {
@@ -216,5 +226,28 @@ mod tests {
         rb.buf.put_slice(&[0xFF; 100]);
         rb.clear();
         assert!(rb.buf.is_empty());
+    }
+
+    #[test]
+    fn cold_reset_releases_extended_capacity_and_preserves_limit() {
+        let mut rb = ReadBuffer::new();
+        rb.set_max_message_len(EXTENDED_MAX_MESSAGE_LEN);
+        rb.buf.resize(usize::from(EXTENDED_MAX_MESSAGE_LEN), 0xab);
+        let grown_capacity = rb.buf.capacity();
+        assert!(
+            grown_capacity >= usize::from(EXTENDED_MAX_MESSAGE_LEN),
+            "extended framing must grow to at least the wire ceiling"
+        );
+
+        rb.reset_storage();
+
+        assert!(rb.buf.is_empty());
+        assert_eq!(rb.buf.capacity(), usize::from(MAX_MESSAGE_LEN));
+        assert_eq!(rb.max_message_len, EXTENDED_MAX_MESSAGE_LEN);
+        assert!(
+            grown_capacity - rb.buf.capacity()
+                >= usize::from(EXTENDED_MAX_MESSAGE_LEN - MAX_MESSAGE_LEN),
+            "cold reset must release at least the logical extended-message delta"
+        );
     }
 }

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -462,8 +462,8 @@ impl PeerSession {
         self.handle_tcp_disconnect();
     }
 
-    /// Drop the TCP read half + writer channels and clear the read
-    /// buffer. Dropping the writer's `Sender` halves causes the writer
+    /// Drop the TCP read half + writer channels and reset the read
+    /// buffer storage. Dropping the writer's `Sender` halves causes the writer
     /// task's biased `select!` to fall through to its `else` arm and
     /// exit cleanly; the `JoinHandle` then resolves and the session's
     /// own select observes it via the writer-exit arm.
@@ -481,7 +481,7 @@ impl PeerSession {
         self.writer_priority_tx = None;
         self.writer_keepalive_tx = None;
         self.writer_teardown_tx = None;
-        self.read_buf.clear();
+        self.read_buf.reset_storage();
         self.tcp_ao_info = None;
         self.tcp_ao_stream_was_accepted = false;
         self.tcp_ao_selected_owner = None;
@@ -503,7 +503,7 @@ impl PeerSession {
         self.writer_priority_tx = None;
         self.writer_keepalive_tx = None;
         self.writer_teardown_tx = None;
-        self.read_buf.clear();
+        self.read_buf.reset_storage();
         self.tcp_ao_info = None;
         self.tcp_ao_stream_was_accepted = false;
         self.tcp_ao_selected_owner = None;

--- a/crates/transport/src/session/tests/run_loop.rs
+++ b/crates/transport/src/session/tests/run_loop.rs
@@ -732,6 +732,44 @@ async fn send_hold_expiry_tears_down_without_notification() {
     );
 }
 
+fn assert_read_reset(
+    session: &mut PeerSession,
+    teardown: fn(&mut PeerSession),
+    initial_capacity: usize,
+) {
+    teardown(session);
+    assert!(session.read_half.is_none());
+    assert!(session.read_buf.buf.is_empty());
+    assert_eq!(session.read_buf.buf.capacity(), initial_capacity);
+}
+
+async fn assert_reconnected_extended_update_decodes(
+    session: &mut PeerSession,
+    encoded: &[u8],
+    initial_capacity: usize,
+) {
+    let (reconnected, mut reconnected_peer) = connected_stream_pair().await;
+    session.test_install_stream(reconnected);
+    reconnected_peer.write_all(encoded).await.unwrap();
+    while !session.read_buf.has_complete_frame() {
+        let bytes_read = tokio::time::timeout(
+            Duration::from_secs(5),
+            read_tcp(&mut session.read_half, &mut session.read_buf.buf),
+        )
+        .await
+        .expect("reconnected session must read the extended UPDATE promptly")
+        .unwrap();
+        assert!(
+            bytes_read > 0,
+            "reconnected peer closed before the UPDATE was complete"
+        );
+    }
+    assert!(session.read_buf.buf.capacity() > initial_capacity);
+    let (decoded, raw) = session.read_buf.try_decode().unwrap().unwrap();
+    assert!(matches!(decoded, Message::Update(_)));
+    assert_eq!(raw.as_ref(), encoded);
+}
+
 /// RFC 8654 §2 directionality, inbound: OUR advertised Extended Message
 /// capability governs what we accept. The peer here did NOT advertise the
 /// capability (see `establish_test_session`'s OPEN), yet a >4096-byte
@@ -833,6 +871,23 @@ async fn inbound_extended_message_accepted_from_peer_without_capability() {
             break;
         }
     }
+
+    // The same PeerSession actor survives reconnects. A cold close must drop
+    // the grown backing allocation after taking the read half, while retaining
+    // the current logical framing limit until SessionDown resets it.
+    assert_read_reset(&mut session, PeerSession::close_tcp, initial_capacity);
+    drop(server);
+
+    // Reinstall a stream on the same actor and feed the same extended UPDATE.
+    // No limit setter is called here: successful decode proves the cold storage
+    // reset did not overwrite the independently-owned negotiated limit.
+    assert_reconnected_extended_update_decodes(&mut session, encoded.as_ref(), initial_capacity)
+        .await;
+
+    // The socket-error teardown site has the same cold-storage contract as
+    // close_tcp and likewise runs only after clearing read_half.
+    let disconnect = PeerSession::handle_tcp_disconnect;
+    assert_read_reset(&mut session, disconnect, initial_capacity);
 }
 
 /// RFC 8654 §2 directionality, outbound: the PEER's advertised Extended


### PR DESCRIPTION
## Summary

- Replace grown transport `ReadBuffer` storage with the standard baseline after the TCP read half is dropped on both disconnect paths.
- Preserve the negotiated maximum message length so the FSM remains responsible for negotiation lifecycle resets.
- Add structural and reconnect-oriented coverage for both teardown sites.

## Verification

- `cargo test --locked -p rustbgpd-transport inbound_extended_message_accepted_from_peer_without_capability`
- `cargo clippy --locked -p rustbgpd-transport --all-targets --all-features -- -D warnings`
- `cargo test --locked -p rustbgpd-transport`
- `cargo fmt --all -- --check`
- `git diff --check`

## Capacity proof

The framing test grows the read buffer to the 65,535-byte extended-message ceiling, then verifies that a cold reset installs the standard 4,096-byte baseline while preserving the logical message limit. When the buffer has grown to at least that ceiling, this conditionally releases at least 61,439 bytes of session-owned capacity from the active `ReadBuffer` handle.

## Limitations

- This does not claim immediate RSS reduction or physical deallocation because outstanding `Bytes` aliases may retain the prior allocation.
- The direct stream-reinstall test is not a full FSM reconnect test.
- There is no negotiation or wire-behavior change.
- Documentation, changelog, and roadmap updates are intentionally a no-op for this internal lifecycle correction.
