### PR TITLE
Trim unused group route slab capacity

### DIFF
--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -209,6 +209,12 @@ impl AdjRibOut {
         self.prefix_path_ids = FamilyPrefixMap::default();
     }
 
+    /// Release unused unicast route-slab tail capacity without touching the
+    /// prefix index, route handles, holes, or any non-unicast family.
+    pub fn shrink_unicast_to_fit(&mut self) {
+        self.routes.shrink_to_fit();
+    }
+
     /// Remove only the VPN routes and their secondary key index, leaving
     /// every other family untouched. The VPN sibling of
     /// [`Self::clear_unicast`]: used when a peer's VPN advertised state
@@ -867,6 +873,25 @@ mod tests {
 
         assert!(rib.is_empty());
         assert_eq!(rib.bench_route_capacity(), 0);
+        assert_eq!(rib.vpn_len(), 1);
+        assert_eq!(rib.bgpls_len(), 1);
+    }
+
+    #[test]
+    fn shrink_unicast_to_fit_preserves_routes_index_and_other_families() {
+        let mut rib = AdjRibOut::with_capacity(IpAddr::V4(Ipv4Addr::LOCALHOST), 64);
+        rib.insert(make_route(prefix_a(), 0));
+        rib.insert(make_route(prefix_b(), 1));
+        rib.insert_vpn(make_vpn_route(vpn_nlri([10, 0, 1, 0], 24, 100), 1));
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, bgpls_nlri(17), 1));
+
+        rib.shrink_unicast_to_fit();
+
+        assert_eq!(rib.bench_route_capacity(), 2);
+        assert_eq!(rib.get(&prefix_a(), 0).unwrap().prefix, prefix_a());
+        assert_eq!(rib.get(&prefix_b(), 1).unwrap().prefix, prefix_b());
+        assert_eq!(rib.path_ids_for_prefix(&prefix_a()).as_slice(), [0]);
+        assert_eq!(rib.path_ids_for_prefix(&prefix_b()).as_slice(), [1]);
         assert_eq!(rib.vpn_len(), 1);
         assert_eq!(rib.bgpls_len(), 1);
     }

--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -209,8 +209,9 @@ impl AdjRibOut {
         self.prefix_path_ids = FamilyPrefixMap::default();
     }
 
-    /// Release unused unicast route-slab tail capacity without touching the
-    /// prefix index, route handles, holes, or any non-unicast family.
+    /// Release unused unicast route-slab tail capacity while preserving
+    /// logical slot indices, route handles, occupancy, the free list, the
+    /// prefix index, and every non-unicast family.
     pub fn shrink_unicast_to_fit(&mut self) {
         self.routes.shrink_to_fit();
     }
@@ -884,10 +885,13 @@ mod tests {
         rib.insert(make_route(prefix_b(), 1));
         rib.insert_vpn(make_vpn_route(vpn_nlri([10, 0, 1, 0], 24, 100), 1));
         rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, bgpls_nlri(17), 1));
+        let capacity_before = rib.bench_route_capacity();
 
         rib.shrink_unicast_to_fit();
 
-        assert_eq!(rib.bench_route_capacity(), 2);
+        let capacity_after = rib.bench_route_capacity();
+        assert!(capacity_after >= rib.len());
+        assert!(capacity_after <= capacity_before);
         assert_eq!(rib.get(&prefix_a(), 0).unwrap().prefix, prefix_a());
         assert_eq!(rib.get(&prefix_b(), 1).unwrap().prefix, prefix_b());
         assert_eq!(rib.path_ids_for_prefix(&prefix_a()).as_slice(), [0]);

--- a/crates/rib/src/manager/update_groups/membership.rs
+++ b/crates/rib/src/manager/update_groups/membership.rs
@@ -315,6 +315,9 @@ impl RibManager {
         // the O(table) walk rides the join replay's existing cost.
         let filter = self.member_rt_filter(peer);
         if let Some(group) = self.group_ribs.get_mut(&gid) {
+            if group.members.is_empty() {
+                group.table.shrink_unicast_to_fit();
+            }
             group.members.insert(peer);
             group.recompute_vpn_member_counts(peer, filter.as_ref());
         }

--- a/crates/rib/src/manager/update_groups/tests.rs
+++ b/crates/rib/src/manager/update_groups/tests.rs
@@ -5430,11 +5430,14 @@ fn ordinary_first_adoption_trims_once_and_preserves_member_view() {
             ],
         ),
     );
+    let capacity_before = m.group_ribs[&GID].table.bench_route_capacity();
 
     m.install_group_member(GID, MEMBER);
 
     let group = m.group_ribs.get(&GID).unwrap();
-    assert_eq!(group.table.bench_route_capacity(), 2);
+    let capacity_after = group.table.bench_route_capacity();
+    assert!(capacity_after >= group.table.len());
+    assert!(capacity_after <= capacity_before);
     let view = group.member_view_snapshot(MEMBER, None, &HashSet::new());
     assert_eq!(view.len(), 2);
     assert_eq!(view[&(p1, 0)].prefix, p1);
@@ -5473,11 +5476,14 @@ fn clean_prestaged_first_adoption_trims_complete_table_without_wire_drift() {
             ],
         ),
     );
+    let capacity_before = m.group_ribs[&GID].table.bench_route_capacity();
 
     m.install_group_member(GID, MEMBER);
 
     let group = &m.group_ribs[&GID];
-    assert_eq!(group.table.bench_route_capacity(), 2);
+    let capacity_after = group.table.bench_route_capacity();
+    assert!(capacity_after >= group.table.len());
+    assert!(capacity_after <= capacity_before);
     let view = group.member_view_snapshot(MEMBER, None, &HashSet::new());
     assert_eq!(view.len(), 2);
     assert_eq!(view[&(p1, 0)].peer, OTHER1);

--- a/crates/rib/src/manager/update_groups/tests.rs
+++ b/crates/rib/src/manager/update_groups/tests.rs
@@ -5395,6 +5395,95 @@ fn group_with(deltas: &[GroupDelta]) -> GroupRibOut {
     group
 }
 
+fn reserved_group(capacity: usize, deltas: &[GroupDelta]) -> GroupRibOut {
+    let mut group = GroupRibOut::new(
+        None,
+        false,
+        false,
+        true,
+        None,
+        vec![(Afi::Ipv4, Safi::Unicast)],
+        vec![],
+        false,
+        capacity,
+    );
+    for delta in deltas {
+        group.apply_delta(delta);
+    }
+    group
+}
+
+#[test]
+fn ordinary_first_adoption_trims_once_and_preserves_member_view() {
+    const GID: usize = 301;
+    let p1 = prefix(1);
+    let p2 = prefix(2);
+    let p3 = prefix(3);
+    let mut m = staging_manager();
+    m.group_ribs.insert(
+        GID,
+        reserved_group(
+            64,
+            &[
+                announce_delta(p1, OTHER1, None),
+                announce_delta(p2, OTHER1, None),
+            ],
+        ),
+    );
+
+    m.install_group_member(GID, MEMBER);
+
+    let group = m.group_ribs.get(&GID).unwrap();
+    assert_eq!(group.table.bench_route_capacity(), 2);
+    let view = group.member_view_snapshot(MEMBER, None, &HashSet::new());
+    assert_eq!(view.len(), 2);
+    assert_eq!(view[&(p1, 0)].prefix, p1);
+    assert_eq!(view[&(p2, 0)].prefix, p2);
+
+    m.group_ribs
+        .get_mut(&GID)
+        .unwrap()
+        .apply_delta(&announce_delta(p3, OTHER1, None));
+    let grown = m.group_ribs[&GID].table.bench_route_capacity();
+    assert!(grown > 3);
+    m.install_group_member(GID, OTHER2);
+    let group = &m.group_ribs[&GID];
+    assert_eq!(group.table.bench_route_capacity(), grown);
+    assert_eq!(
+        group
+            .member_view_snapshot(OTHER2, None, &HashSet::new())
+            .len(),
+        3
+    );
+}
+
+#[test]
+fn clean_prestaged_first_adoption_trims_complete_table_without_wire_drift() {
+    const GID: usize = 302;
+    let p1 = prefix(4);
+    let p2 = prefix(5);
+    let mut m = staging_manager();
+    m.group_ribs.insert(
+        GID,
+        reserved_group(
+            128,
+            &[
+                announce_delta(p1, OTHER1, None),
+                announce_delta(p2, OTHER2, None),
+            ],
+        ),
+    );
+
+    m.install_group_member(GID, MEMBER);
+
+    let group = &m.group_ribs[&GID];
+    assert_eq!(group.table.bench_route_capacity(), 2);
+    let view = group.member_view_snapshot(MEMBER, None, &HashSet::new());
+    assert_eq!(view.len(), 2);
+    assert_eq!(view[&(p1, 0)].peer, OTHER1);
+    assert_eq!(view[&(p2, 0)].peer, OTHER2);
+}
+
 const CLEAN_SOURCE: usize = 1;
 const CLEAN_DESTINATION: usize = 2;
 

--- a/crates/rib/src/slab.rs
+++ b/crates/rib/src/slab.rs
@@ -106,8 +106,8 @@ impl<T> RouteSlab<T> {
         self.free.clear();
     }
 
-    /// Release only unused tail capacity without moving slots or changing
-    /// handles, occupancy, or the free list.
+    /// Release only unused tail capacity while preserving logical slot
+    /// indices, handles, occupancy, and the free list.
     pub(crate) fn shrink_to_fit(&mut self) {
         if self.slots.capacity() == self.slots.len() {
             return;
@@ -170,10 +170,13 @@ mod tests {
         slab.remove(handles[2]);
         slab.remove(handles[5]);
         let free = slab.free.clone();
+        let capacity_before = slab.capacity();
 
         slab.shrink_to_fit();
 
-        assert_eq!(slab.capacity(), slab.slot_count());
+        let capacity_after = slab.capacity();
+        assert!(capacity_after >= slab.slot_count());
+        assert!(capacity_after <= capacity_before);
         assert_eq!(slab.len(), 6);
         assert_eq!(slab.free, free);
         for (index, handle) in handles.into_iter().enumerate() {

--- a/crates/rib/src/slab.rs
+++ b/crates/rib/src/slab.rs
@@ -106,6 +106,15 @@ impl<T> RouteSlab<T> {
         self.free.clear();
     }
 
+    /// Release only unused tail capacity without moving slots or changing
+    /// handles, occupancy, or the free list.
+    pub(crate) fn shrink_to_fit(&mut self) {
+        if self.slots.capacity() == self.slots.len() {
+            return;
+        }
+        self.slots.shrink_to_fit();
+    }
+
     pub(crate) fn iter(&self) -> impl Iterator<Item = &T> {
         self.slots.iter().filter_map(Option::as_ref)
     }
@@ -152,6 +161,27 @@ mod tests {
             1000,
             "withdraw/re-insert churn must reuse freed slots, not grow"
         );
+    }
+
+    #[test]
+    fn shrink_to_fit_preserves_handles_occupancy_and_free_slots() {
+        let mut slab = RouteSlab::with_capacity(64);
+        let handles: Vec<_> = (0..8).map(|value| slab.insert(value)).collect();
+        slab.remove(handles[2]);
+        slab.remove(handles[5]);
+        let free = slab.free.clone();
+
+        slab.shrink_to_fit();
+
+        assert_eq!(slab.capacity(), slab.slot_count());
+        assert_eq!(slab.len(), 6);
+        assert_eq!(slab.free, free);
+        for (index, handle) in handles.into_iter().enumerate() {
+            assert_eq!(
+                slab.get(handle),
+                (![2, 5].contains(&index)).then_some(&index)
+            );
+        }
     }
 
     #[test]

--- a/crates/rib/tests/memory_profile.rs
+++ b/crates/rib/tests/memory_profile.rs
@@ -718,6 +718,38 @@ fn adj_rib_out_release_unicast_reclaims_100k_structural_capacity() {
     );
 }
 
+#[cfg(feature = "bench-internals")]
+#[test]
+fn adj_rib_out_first_adoption_tail_trim_reclaims_expected_slot_bytes() {
+    const RESERVED: usize = 100_000;
+    const STAGED: usize = 68_928;
+    const EXPECTED_SLOT_DELTA_BYTES: usize = 3_977_216;
+    const MIN_RECLAIMED_BYTES: usize = 3_500_000;
+
+    let prefixes = generate_prefixes(STAGED);
+    let attrs = typical_attributes(1);
+    let mut rib = AdjRibOut::with_capacity(IpAddr::V4(Ipv4Addr::new(10, 0, 11, 1)), RESERVED);
+    for prefix in prefixes {
+        rib.insert(make_route(prefix, 1, &attrs));
+    }
+    let capacity_before = rib.bench_route_capacity();
+    let bytes_before = capacity_before * std::mem::size_of::<Option<Route>>();
+
+    rib.shrink_unicast_to_fit();
+
+    let capacity_after = rib.bench_route_capacity();
+    let bytes_after = capacity_after * std::mem::size_of::<Option<Route>>();
+    let slot_delta_bytes = bytes_before - bytes_after;
+    println!(
+        "reserved={RESERVED} staged={STAGED} capacity_before={capacity_before} capacity_after={capacity_after} bytes_before={bytes_before} bytes_after={bytes_after} slot_delta_bytes={slot_delta_bytes}"
+    );
+    assert_eq!(rib.len(), STAGED);
+    assert_eq!(capacity_before, RESERVED);
+    assert_eq!(capacity_after, STAGED);
+    assert_eq!(slot_delta_bytes, EXPECTED_SLOT_DELTA_BYTES);
+    assert!(slot_delta_bytes >= MIN_RECLAIMED_BYTES);
+}
+
 #[test]
 #[ignore = "manual high-N memory regression harness; use bench/compare-rib-memory.sh"]
 fn memory_profile_high_n() {

--- a/crates/rib/tests/memory_profile.rs
+++ b/crates/rib/tests/memory_profile.rs
@@ -723,7 +723,7 @@ fn adj_rib_out_release_unicast_reclaims_100k_structural_capacity() {
 fn adj_rib_out_first_adoption_tail_trim_reclaims_expected_slot_bytes() {
     const RESERVED: usize = 100_000;
     const STAGED: usize = 68_928;
-    const MIN_RECLAIMED_BYTES: usize = 3_500_000;
+    const MIN_RECLAIMED_BYTES: usize = 7 * 1024 * 1024 / 2;
 
     let prefixes = generate_prefixes(STAGED);
     let attrs = typical_attributes(1);
@@ -738,7 +738,7 @@ fn adj_rib_out_first_adoption_tail_trim_reclaims_expected_slot_bytes() {
 
     let capacity_after = rib.bench_route_capacity();
     let bytes_after = capacity_after * std::mem::size_of::<Option<Route>>();
-    let slot_delta_bytes = bytes_before - bytes_after;
+    let slot_delta_bytes = bytes_before.saturating_sub(bytes_after);
     println!(
         "reserved={RESERVED} staged={STAGED} capacity_before={capacity_before} capacity_after={capacity_after} bytes_before={bytes_before} bytes_after={bytes_after} slot_delta_bytes={slot_delta_bytes}"
     );

--- a/crates/rib/tests/memory_profile.rs
+++ b/crates/rib/tests/memory_profile.rs
@@ -723,7 +723,6 @@ fn adj_rib_out_release_unicast_reclaims_100k_structural_capacity() {
 fn adj_rib_out_first_adoption_tail_trim_reclaims_expected_slot_bytes() {
     const RESERVED: usize = 100_000;
     const STAGED: usize = 68_928;
-    const EXPECTED_SLOT_DELTA_BYTES: usize = 3_977_216;
     const MIN_RECLAIMED_BYTES: usize = 3_500_000;
 
     let prefixes = generate_prefixes(STAGED);
@@ -744,9 +743,9 @@ fn adj_rib_out_first_adoption_tail_trim_reclaims_expected_slot_bytes() {
         "reserved={RESERVED} staged={STAGED} capacity_before={capacity_before} capacity_after={capacity_after} bytes_before={bytes_before} bytes_after={bytes_after} slot_delta_bytes={slot_delta_bytes}"
     );
     assert_eq!(rib.len(), STAGED);
-    assert_eq!(capacity_before, RESERVED);
-    assert_eq!(capacity_after, STAGED);
-    assert_eq!(slot_delta_bytes, EXPECTED_SLOT_DELTA_BYTES);
+    assert!(capacity_before >= RESERVED);
+    assert!(capacity_after >= STAGED);
+    assert!(capacity_after <= capacity_before);
     assert!(slot_delta_bytes >= MIN_RECLAIMED_BYTES);
 }
 


### PR DESCRIPTION
## Summary

- trim unused unicast route-slab tail capacity immediately before a group's first member is adopted
- preserve logical route handles, occupied slots, free-list holes, indexes, and non-unicast families
- cover ordinary and clean-prestaged first adoption while leaving later joins unchanged

## Structural proof

The synthetic structural fixture requests capacity for 100,000 slots and stages 68,928 routes. On the verified x86_64 run, the observed capacity moved from 100,000 to 68,928, reclaiming 3,977,216 bytes based on `size_of::<Option<Route>>()`.

The portable regression gate does not require those exact capacities: it requires the pre-trim capacity to be at least the requested reservation, the post-trim capacity to remain at least the staged route count and not exceed the pre-trim capacity, and the observed reclaimed slot bytes to be at least 3.5 MiB.

## Verification

- five LAN-1035 focused filters, run separately
- LAN-1033 `update_group_policy_label_profile` preservation test
- `cargo test --locked -p rustbgpd-rib` (1,155 passed, 2 ignored)
- `cargo clippy --locked -p rustbgpd-rib --all-targets --features bench-internals -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Limitations

This is a first-adoption tail-only optimization. It does not compact holes, trim after adoption, or make RSS, allocator, whole-process, timing, or wire-performance claims. Documentation, changelog, and roadmap are unchanged because the external behavior and wire contract are unchanged.
