### PR TITLE
Run the interop daemon-liveness probe without a local pipe

### DIFF
--- a/tests/interop/scripts/test-lib.sh
+++ b/tests/interop/scripts/test-lib.sh
@@ -139,6 +139,15 @@ grpc_health() {
         "$GRPC_ADDR" rustbgpd.v1.ControlService/GetHealth 2>/dev/null
 }
 
+# Liveness probe: true iff a /proc/*/comm entry in the lab container
+# matches rustbgpd. grep runs inside the container on purpose: piping
+# docker exec output into a host-side `grep -q` lets grep exit at the
+# first match and SIGPIPE the still-writing docker side (exit 141),
+# which `set -o pipefail` reports as a false "daemon exited" (LAN-1039).
+rustbgpd_running() {
+    docker exec "$RUSTBGPD" sh -c 'grep -q rustbgpd /proc/*/comm 2>/dev/null'
+}
+
 # Standardized rustbgpd start, used by every interop script. Pass a
 # custom command string to run a non-default daemon invocation
 # (e.g. M21/M24 launch the binary directly against `/tmp/config.toml`
@@ -155,7 +164,7 @@ start_rustbgpd() {
     # environments room to land the fork.
     local found=0
     for i in $(seq 1 10); do
-        if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
+        if rustbgpd_running; then
             log "rustbgpd is running (after ${i}s)"
             found=1
             break
@@ -537,7 +546,9 @@ wait_vtep_established() {
     local timeout=$((attempts * 2))
     log "Waiting for $label session to reach Established..."
     for i in $(seq 1 "$attempts"); do
-        if vtep_ctl neighbor "$peer" 2>/dev/null | grep -qi "establ"; then
+        # grep reads to EOF (no -q): -q's early exit can SIGPIPE the
+        # vtep_ctl writer, a false failure under pipefail (LAN-1039).
+        if vtep_ctl neighbor "$peer" 2>/dev/null | grep -i "establ" >/dev/null; then
             ok "$label session established (attempt $i)"
             return 0
         fi

--- a/tests/interop/scripts/test-m44-grpc-tier-authz.sh
+++ b/tests/interop/scripts/test-m44-grpc-tier-authz.sh
@@ -126,7 +126,7 @@ start_rustbgpd_mtls() {
     docker exec -d "$RUSTBGPD" sh -c "/usr/local/bin/start-rustbgpd.sh"
     local up=0
     for i in $(seq 1 10); do
-        if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
+        if rustbgpd_running; then
             log "rustbgpd process up (after ${i}s)"
             up=1
             break
@@ -161,8 +161,7 @@ start_rustbgpd_mtls() {
 assert_daemon_healthy_after_settlement_window() {
     log "Waiting beyond the 5s runtime-config settlement window..."
     sleep 6
-    if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' \
-        | grep -q rustbgpd; then
+    if rustbgpd_running; then
         ok "rustbgpd remains live after the settlement window"
     else
         fail "rustbgpd exited after the authorized no-effect mutation"

--- a/tests/interop/scripts/test-m54-gnmi-openconfig.sh
+++ b/tests/interop/scripts/test-m54-gnmi-openconfig.sh
@@ -198,7 +198,7 @@ start_rustbgpd_gnmi() {
 
     local up=0
     for i in $(seq 1 10); do
-        if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
+        if rustbgpd_running; then
             log "rustbgpd process up (after ${i}s)"
             up=1
             break

--- a/tests/interop/scripts/test-m56-gnmi-onchange-frr.sh
+++ b/tests/interop/scripts/test-m56-gnmi-onchange-frr.sh
@@ -58,7 +58,7 @@ start_rustbgpd_gnmi() {
 
     local up=0
     for i in $(seq 1 10); do
-        if docker exec "$RUSTBGPD" sh -c 'cat /proc/*/comm 2>/dev/null' | grep -q rustbgpd; then
+        if rustbgpd_running; then
             log "rustbgpd process up (after ${i}s)"
             up=1
             break

--- a/tests/interop/scripts/test-m83-routeserver-multistack.sh
+++ b/tests/interop/scripts/test-m83-routeserver-multistack.sh
@@ -707,9 +707,12 @@ stop_capture() {
         return 1
     fi
 
+    # grep reads to EOF (no -q): -q's early exit can SIGPIPE the docker
+    # exec writer, and under pipefail a still-running tshark would then
+    # read as a false "terminated" verdict (LAN-1039).
     for _ in $(seq 1 10); do
         if ! docker exec "$BIRD" sh -c 'cat /proc/[0-9]*/comm 2>/dev/null' \
-            | grep -qx tshark; then
+            | grep -x tshark >/dev/null; then
             if docker exec "$BIRD" test -s /tmp/m83.pcap \
                 && docker exec "$BIRD" tshark -r /tmp/m83.pcap -c 1 >/dev/null 2>&1; then
                 log "tshark capture $signaled terminated; pcap is nonempty and readable"

--- a/tests/interop/scripts/test-m92-gobgp-v47-rs-differential.sh
+++ b/tests/interop/scripts/test-m92-gobgp-v47-rs-differential.sh
@@ -62,17 +62,20 @@ kill_round_daemons() {
             ' sh "$comm" "$signal" >/dev/null 2>&1 || true
         done
     done
+    # grep reads to EOF (no -q): -q's early exit can SIGPIPE the docker
+    # exec writer, and under pipefail a surviving daemon would then read
+    # as a false "stopped" verdict (LAN-1039).
     for _ in $(seq 1 10); do
         if ! docker exec "$RUSTBGPD" sh -c 'cat /proc/[0-9]*/comm 2>/dev/null' \
-            | grep -Eq '^(rustbgpd|gobgpd|bird|tshark)$' \
+            | grep -E '^(rustbgpd|gobgpd|bird|tshark)$' >/dev/null \
             && ! docker exec "$GOBGP_RS" sh -c 'cat /proc/[0-9]*/comm 2>/dev/null' \
-            | grep -Eq '^(rustbgpd|gobgpd|bird|tshark)$' \
+            | grep -E '^(rustbgpd|gobgpd|bird|tshark)$' >/dev/null \
             && ! docker exec "$SOURCE1" sh -c 'cat /proc/[0-9]*/comm 2>/dev/null' \
-            | grep -Eq '^(rustbgpd|gobgpd|bird|tshark)$' \
+            | grep -E '^(rustbgpd|gobgpd|bird|tshark)$' >/dev/null \
             && ! docker exec "$SOURCE2" sh -c 'cat /proc/[0-9]*/comm 2>/dev/null' \
-            | grep -Eq '^(rustbgpd|gobgpd|bird|tshark)$' \
+            | grep -E '^(rustbgpd|gobgpd|bird|tshark)$' >/dev/null \
             && ! docker exec "$TARGET" sh -c 'cat /proc/[0-9]*/comm 2>/dev/null' \
-            | grep -Eq '^(rustbgpd|gobgpd|bird|tshark)$'; then
+            | grep -E '^(rustbgpd|gobgpd|bird|tshark)$' >/dev/null; then
             docker exec "$RUSTBGPD" rm -f /var/lib/rustbgpd/gr-restart.toml
             return
         fi
@@ -220,9 +223,12 @@ stop_capture() {
             pid=${file#/proc/}; pid=${pid%/comm}; kill -INT "$pid"
         done
     '
+    # grep reads to EOF (no -q): -q's early exit can SIGPIPE the docker
+    # exec writer, and under pipefail a still-running tshark would then
+    # read as a false "terminated" verdict (LAN-1039).
     for _ in $(seq 1 10); do
         if ! docker exec "$TARGET" sh -c 'cat /proc/[0-9]*/comm 2>/dev/null' \
-            | grep -qx tshark; then
+            | grep -x tshark >/dev/null; then
             docker exec "$TARGET" test -s /tmp/m92.pcap
             docker exec "$TARGET" tshark -r /tmp/m92.pcap -c 1 >/dev/null
             return


### PR DESCRIPTION
## Mechanism

The interop scripts run under `set -o pipefail`, and the daemon-liveness probe piped `docker exec … cat /proc/*/comm` into a host-side `grep -q`, which exits at the first match and closes the pipe; the still-writing docker exec side then dies with SIGPIPE (exit 141). pipefail reports the pipeline red even though the match succeeded, so a healthy daemon reads as "daemon exited".

Observed on the main `9af18a0a` Interop run 31859836117, M44 job: "rustbgpd exited after the authorized no-effect mutation" immediately followed by a passing gRPC health probe. This is a harness defect, not a daemon regression.

## Fix shape

The five duplicated probes consolidate into one `rustbgpd_running()` helper in `test-lib.sh` that runs grep **inside the container** (`docker exec "$RUSTBGPD" sh -c 'grep -q rustbgpd /proc/*/comm 2>/dev/null'`) — no local pipe exists, so no SIGPIPE/pipefail interaction. GNU grep 3.8 is present in `rustbgpd:dev` (verified with `command -v grep`). Sweep-found probes that target non-rustbgpd containers (gobgp/BIRD/tshark images, grep availability unverified) instead keep the local pipe but make the consumer read to EOF (`grep PAT >/dev/null` instead of `-q`), with a comment at each site naming the constraint. Semantics are preserved exactly at every site: exit 0 iff a match exists, so a genuinely dead process still fails the probe. No `|| true`, no masking.

## Sites fixed

- `test-lib.sh` `start_rustbgpd` probe (was :158), `test-m44-grpc-tier-authz.sh` :129 and :164, `test-m54-gnmi-openconfig.sh` :201, `test-m56-gnmi-onchange-frr.sh` :61 — consolidated to `rustbgpd_running()` (all four scripts already source `test-lib.sh`)
- `test-m92-gobgp-v47-rs-differential.sh` `stop_prior_daemons` (five negated comm probes) and `stop_capture` tshark probe — read-to-EOF; a SIGPIPE red there inverts through `!` into a false "process stopped" verdict
- `test-m83-routeserver-multistack.sh` tshark liveness probe (was :712) — read-to-EOF, same inversion
- `test-lib.sh` `wait_vtep_established` (was :540) — read-to-EOF

## Seam sweep disposition

Sweep: every pipeline in `tests/interop/scripts` feeding an early-exiting consumer (`grep -q`, `grep -m1`, `head -1`, …). pipefail is active in every test script (directly or via sourcing `test-lib.sh`) except `test-m38-evpn-df-election.sh`.

| Hit(s) | Disposition |
|---|---|
| `test-lib.sh` start probe, m44 ×2, m54, m56 | fixed — `rustbgpd_running()`, grep in-container |
| m92 `stop_prior_daemons` ×5, m92 `stop_capture`, m83 tshark probe | fixed — consumer reads to EOF |
| `test-lib.sh` `wait_vtep_established` | fixed — consumer reads to EOF |
| m34:135, m80:475, m83:616, m83:759, m95:188 (`/proc` comm pipelines) | not affected — pipeline runs inside `docker exec sh -c '…'`; the container shell does not set pipefail |
| `… \| grep -o … \| head -1 \| cut … \|\| true` capture idiom (~25 sites, e.g. `test-lib.sh:212`) and `… \| head -N >&2 \|\| true` diagnostics | not affected — pipeline status discarded by `\|\| true` |
| `test-lib.sh` `ac_port_state` and similar `$(pipeline)` used as a test-command operand | not affected — command-substitution exit status is discarded; only the captured text is compared |
| `start-frr-vtep-mh.sh:143`; `test-m38-evpn-df-election.sh` | not affected — no pipefail in those scripts |
| `echo "$captured_var" \| grep -q …` (~200 sites) | not in class — the writer is the shell emitting an already-captured variable, not a long writer; exposure requires the variable to exceed pipe capacity mid-write |
| Wrapper-function streams into `-q` consumers (`frr_vtysh … \| grep -q`, `rb_fdb \| grep -qi`, `gobgp … \| grep -qi establ`, tshark field dumps `\| grep -q .`, ~100 sites across ~35 scripts) | same mechanism, latent — deferred to a follow-up; each conversion needs its own lab run to verify, and most sit in retry loops where a SIGPIPE red costs one retry rather than a verdict. This PR fixes the observed liveness-probe class and every single-shot/negated probe, where the false verdict is immediate |

## Red proof (scripted, under `set -o pipefail`)

- `{ echo rustbgpd; head -c 1000000 /dev/zero | tr '\0' x; } | grep -q rustbgpd` → exit **141** (mechanism proven)
- read-to-EOF shape: present-pattern → exit 0; absent-pattern → exit 1
- in-container shape (`rustbgpd:dev`): process named rustbgpd present → exit 0; absent → exit 1

## M44 receipt

Fresh `rustbgpd:dev` build from this branch, fresh containerlab deploy, single attempt, no sudo: `test-m44-grpc-tier-authz.sh` → **11 passed, 0 failed**, exit 0, 6.6 s wall after deploy — including "rustbgpd remains live after the settlement window", the exact site of the observed false failure, now via `rustbgpd_running()`. `bash -n` clean on all six touched scripts; shellcheck reports only pre-existing info-level findings on untouched lines.

Linear: LAN-1039
