### PR TITLE
rib: omit source-control residue for passthrough groups

### DIFF
--- a/crates/policy/src/compile.rs
+++ b/crates/policy/src/compile.rs
@@ -344,7 +344,7 @@ mod tests {
     use std::net::Ipv4Addr;
     use std::sync::Arc;
 
-    use rustbgpd_wire::{Ipv4Prefix, Prefix};
+    use rustbgpd_wire::{ExtendedCommunity, Ipv4Prefix, LargeCommunity, Prefix};
 
     use crate::engine::{
         NamedPolicy, Policy, PolicyAction, PolicyChain, PolicyStatement, RouteContext,
@@ -523,6 +523,68 @@ policy bogon-filter {
         )]);
         assert!(chain.requires_as_path_string());
         assert!(!chain.requires_rpki_validation());
+    }
+
+    #[test]
+    fn source_control_mutation_classifier_covers_literals_and_nested_variables() {
+        let classifies = |modifications| {
+            let mut named = toml_deny_policy();
+            let statement = &mut named.policy.entries[0];
+            statement.prefix = None;
+            statement.action = PolicyAction::Permit;
+            statement.modifications = modifications;
+            PolicyChain::from_named(vec![named]).modifies_source_control_communities()
+        };
+        let large = LargeCommunity::new(65_000, 1, 2);
+        for modifications in [
+            RouteModifications {
+                communities_add: vec![1],
+                ..RouteModifications::default()
+            },
+            RouteModifications {
+                communities_remove: vec![1],
+                ..RouteModifications::default()
+            },
+            RouteModifications {
+                large_communities_add: vec![large],
+                ..RouteModifications::default()
+            },
+            RouteModifications {
+                large_communities_remove: vec![large],
+                ..RouteModifications::default()
+            },
+        ] {
+            assert!(classifies(modifications));
+        }
+        assert!(!classifies(RouteModifications::default()));
+        assert!(!classifies(RouteModifications {
+            extended_communities_add: vec![ExtendedCommunity::new(1)],
+            extended_communities_remove: vec![ExtendedCommunity::new(2)],
+            ..RouteModifications::default()
+        }));
+
+        let file = RpolFile::parse(
+            "asn-set one { 1 }
+            policy p { term t {
+                for outer in route.communities {
+                    for ignored in one {
+                        remove community outer;
+                        add community outer
+                    }
+                }
+                accept
+            } }",
+        )
+        .expect("clean nested community-variable program");
+        let mut store = SetStore::new();
+        let compiled = file
+            .compile_policy("p", &[], &mut store)
+            .expect("policy exists");
+        let chain = PolicyChain::from_named(vec![NamedPolicy::from_rpol(
+            "p".to_string(),
+            Arc::new(compiled),
+        )]);
+        assert!(chain.modifies_source_control_communities());
     }
 
     /// An rpol member's placeholder `policy` never reaches evaluation:

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -11,7 +11,7 @@ use rustbgpd_wire::{
 };
 
 use crate::eval::PolicyHitCounters;
-use crate::ir::CompiledChain;
+use crate::ir::{CompiledChain, TermAction};
 use crate::sets::SetStore;
 
 /// Implicit `LOCAL_PREF` used when a route arrives without the
@@ -1589,6 +1589,36 @@ impl PolicyChain {
     #[must_use]
     pub fn requires_peer_context(&self) -> bool {
         self.compiled().requires_peer_context()
+    }
+
+    /// Whether this chain can change the standard or large communities
+    /// consumed by RFC 7947 route-server control.
+    ///
+    /// The classification walks compiled IR so TOML and `.rpol` chains share
+    /// one conservative answer, including actions nested in bounded loops.
+    /// Extended-community-only changes are deliberately excluded: RFC 7947
+    /// source control does not read that attribute partition.
+    #[must_use]
+    pub fn modifies_source_control_communities(&self) -> bool {
+        let modifies = |term: &crate::ir::Term| match &term.action {
+            TermAction::Permit(mods) | TermAction::Continue(mods) => {
+                !mods.communities_add.is_empty()
+                    || !mods.communities_remove.is_empty()
+                    || !mods.large_communities_add.is_empty()
+                    || !mods.large_communities_remove.is_empty()
+            }
+            TermAction::CommunityVar { .. } => true,
+            TermAction::Deny
+            | TermAction::Bind { .. }
+            | TermAction::ForEach(_)
+            | TermAction::Break
+            | TermAction::ContinueLoop => false,
+        };
+        self.compiled()
+            .policies
+            .iter()
+            .flat_map(|policy| &policy.terms)
+            .any(|term| term.any_term(&modifies))
     }
 
     /// Evaluate a route against this chain of policies. Hit counters

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -1246,7 +1246,7 @@ impl RibManager {
                     continue;
                 };
                 let (source_communities, source_large_communities) =
-                    super::update_groups::source_control_input(entry.source_attrs);
+                    group.source_control_for_route(entry.route, entry.source_attrs);
                 if super::distribution::rs_control::rs_control_suppressed(
                     source_communities,
                     source_large_communities,

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -1045,7 +1045,7 @@ impl RibManager {
                         continue;
                     };
                     let (source_communities, source_large_communities) =
-                        super::update_groups::source_control_input(entry.source_attrs);
+                        group.source_control_for_route(entry.route, entry.source_attrs);
                     if super::distribution::rs_control::rs_control_suppressed(
                         source_communities,
                         source_large_communities,

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -416,14 +416,18 @@ pub(in crate::manager) struct GroupRibOut {
     /// Next-hop-override flags for staged entries (`Some` values only)
     /// so joins/replays don't re-run policy to recover them.
     nh_overrides: FxHashMap<(Prefix, u32), NextHopAction>,
-    /// Captured pre-policy SOURCE attributes per staged entry (entries
-    /// only for sources carrying communities; the `Arc` is shared with
-    /// the Adj-RIB-In/Loc-RIB copy). RFC 7947 decisions at the table
-    /// replay seams — resync, join, refresh, regroup baseline — read
-    /// these, never the staged (post-policy) route: policy may have
-    /// stripped a control community (deciding post-policy leaks a
-    /// source-prohibited route) or added one (spurious steering).
+    /// Captured pre-policy SOURCE attributes per staged entry for a policy
+    /// that can modify source-control communities (entries only for sources
+    /// carrying communities; the `Arc` is shared with the Adj-RIB-In/Loc-RIB
+    /// copy). RFC 7947 replay decisions for such groups read these, never the
+    /// staged route: policy may have stripped a control community (deciding
+    /// post-policy leaks a source-prohibited route) or added one (spurious
+    /// steering). Proven passthrough groups leave this map empty.
     source_attrs: FxHashMap<(Prefix, u32), Arc<Vec<PathAttribute>>>,
+    /// Group-uniform proof that export policy preserves the standard and
+    /// large communities used by RFC 7947 control. Such groups derive the
+    /// control input from their staged route and keep `source_attrs` empty.
+    source_control_passthrough: bool,
     /// Staged-entry count per source peer — O(1) per-member advertised
     /// count synthesis (`len − own`), one slot per staged family
     /// (v4-unicast, v6-unicast, vpnv4, vpnv6) for the BMP stat-17
@@ -557,6 +561,9 @@ impl GroupRibOut {
         per_client_best: bool,
         capacity: usize,
     ) -> Self {
+        let source_control_passthrough = export_chain
+            .as_ref()
+            .is_none_or(|chain| !chain.modifies_source_control_communities());
         let permit_policy_label = export_chain
             .as_ref()
             .and_then(|chain| chain.policies.last())
@@ -566,6 +573,7 @@ impl GroupRibOut {
             table: AdjRibOut::with_capacity(GROUP_FILTERED_PLACEHOLDER, capacity),
             nh_overrides: FxHashMap::default(),
             source_attrs: FxHashMap::default(),
+            source_control_passthrough,
             source_counts: FxHashMap::default(),
             family_totals: [0; 4],
             tombstones: HashSet::new(),
@@ -781,19 +789,23 @@ impl GroupRibOut {
                     self.nh_overrides.remove(&key);
                 }
             }
-            match &delta.source_attrs {
-                Some(attrs) => {
-                    self.source_attrs.insert(key, Arc::clone(attrs));
-                }
-                None => {
-                    self.source_attrs.remove(&key);
+            if !self.source_control_passthrough {
+                match &delta.source_attrs {
+                    Some(attrs) => {
+                        self.source_attrs.insert(key, Arc::clone(attrs));
+                    }
+                    None => {
+                        self.source_attrs.remove(&key);
+                    }
                 }
             }
             self.table.insert(route.clone());
         } else {
             self.table.withdraw(&delta.prefix, delta.path_id);
             self.nh_overrides.remove(&key);
-            self.source_attrs.remove(&key);
+            if !self.source_control_passthrough {
+                self.source_attrs.remove(&key);
+            }
         }
     }
 
@@ -872,15 +884,35 @@ impl GroupRibOut {
         self.nh_overrides.get(&key).cloned()
     }
 
-    /// RFC 7947 control-decision input for a staged table entry: the
-    /// SOURCE route's communities as captured at staging (empty when
-    /// the source carried none). Table replay seams must decide
-    /// suppression/prepend on this, never on the post-policy entry.
+    /// RFC 7947 control-decision input for a staged table entry: either the
+    /// source snapshot required by a modifying policy or the staged route for
+    /// a policy proven to preserve source-control communities.
     pub(in crate::manager) fn source_control(
         &self,
         key: (Prefix, u32),
     ) -> (&[u32], &[LargeCommunity]) {
+        if self.source_control_passthrough {
+            return self.table.get(&key.0, key.1).map_or((&[], &[]), |route| {
+                (route.communities(), route.large_communities())
+            });
+        }
         source_control_input(self.source_attrs.get(&key))
+    }
+
+    /// RFC 7947 input for a resolved staged or exception-lane entry.
+    /// Passthrough groups read the post-policy route because the immutable
+    /// compiled-policy classification proves its source control partitions
+    /// unchanged; modifying groups retain the historical source snapshot.
+    pub(in crate::manager) fn source_control_for_route<'a>(
+        &self,
+        route: &'a Route,
+        source_attrs: Option<&'a Arc<Vec<PathAttribute>>>,
+    ) -> (&'a [u32], &'a [LargeCommunity]) {
+        if self.source_control_passthrough {
+            (route.communities(), route.large_communities())
+        } else {
+            source_control_input(source_attrs)
+        }
     }
 
     /// Tag-only transition check for a pass that staged NO delta for
@@ -894,6 +926,9 @@ impl GroupRibOut {
         prefix: Prefix,
         source_attrs: Option<&Arc<Vec<PathAttribute>>>,
     ) -> Option<RsTagTransition> {
+        if self.source_control_passthrough {
+            return None;
+        }
         let staged = self.table.get(&prefix, 0)?;
         let key = (prefix, 0);
         let prior = self.source_attrs.get(&key);
@@ -912,6 +947,10 @@ impl GroupRibOut {
     /// Commit a pass's tag-only transitions into the source-attribute
     /// residue (the delta-borne updates ride [`Self::apply_delta`]).
     fn commit_rs_transitions(&mut self, transitions: &[RsTagTransition]) {
+        if self.source_control_passthrough {
+            debug_assert!(transitions.is_empty());
+            return;
+        }
         for transition in transitions {
             let key = (transition.prefix, transition.path_id);
             match &transition.source_attrs {
@@ -952,7 +991,11 @@ impl GroupRibOut {
             return Some(AdvEntry {
                 route: staged,
                 nh: self.nh_overrides.get(&key),
-                source_attrs: self.source_attrs.get(&key),
+                source_attrs: if self.source_control_passthrough {
+                    None
+                } else {
+                    self.source_attrs.get(&key)
+                },
                 policy_label: self.permit_policy_label.as_ref(),
             });
         }
@@ -1166,7 +1209,8 @@ impl GroupRibOut {
                     return None;
                 }
                 let entry = self.adv_entry(member, &staged.prefix, staged.path_id)?;
-                let (communities, large_communities) = source_control_input(entry.source_attrs);
+                let (communities, large_communities) =
+                    self.source_control_for_route(entry.route, entry.source_attrs);
                 // LAN-474: a key whose SOURCE communities suppress it
                 // toward the member was never on its wire — the
                 // snapshot records true wire state, not the shared

--- a/crates/rib/src/manager/update_groups/payload.rs
+++ b/crates/rib/src/manager/update_groups/payload.rs
@@ -84,9 +84,10 @@ pub(in crate::manager) struct AdvEntry<'a> {
     pub(in crate::manager) route: &'a Route,
     /// Next-hop-override residue for the slot.
     pub(in crate::manager) nh: Option<&'a NextHopAction>,
-    /// Modifying-policy groups carry captured pre-policy RFC 7947 control
-    /// attributes. Proven passthrough groups leave this `None` and derive
-    /// equivalent input from [`Self::route`].
+    /// Modifying-policy groups and [`RunnerUp`] lane entries may carry captured
+    /// pre-policy RFC 7947 control attributes. Passthrough mode ignores this
+    /// field and derives equivalent input from [`Self::route`]; its dense
+    /// staged entries leave the field `None`.
     pub(in crate::manager) source_attrs: Option<&'a Arc<Vec<PathAttribute>>>,
     /// Terminal policy label of the permitting evaluation (`None` =
     /// inline verdict) — join-time counter replay residue.

--- a/crates/rib/src/manager/update_groups/payload.rs
+++ b/crates/rib/src/manager/update_groups/payload.rs
@@ -84,8 +84,9 @@ pub(in crate::manager) struct AdvEntry<'a> {
     pub(in crate::manager) route: &'a Route,
     /// Next-hop-override residue for the slot.
     pub(in crate::manager) nh: Option<&'a NextHopAction>,
-    /// Captured pre-policy SOURCE attributes (RFC 7947 rs-control
-    /// decisions read these, never the post-policy route).
+    /// Modifying-policy groups carry captured pre-policy RFC 7947 control
+    /// attributes. Proven passthrough groups leave this `None` and derive
+    /// equivalent input from [`Self::route`].
     pub(in crate::manager) source_attrs: Option<&'a Arc<Vec<PathAttribute>>>,
     /// Terminal policy label of the permitting evaluation (`None` =
     /// inline verdict) — join-time counter replay residue.
@@ -367,7 +368,8 @@ impl GroupStageOutput {
     ///   substitution is rs-suppressed toward it, a per-member verdict
     ///   this method cannot see — so the key is recorded
     ///   unconditionally: the resync's `member_retains` guard (routed
-    ///   through [`GroupRibOut::adv_entry`]) drops it exactly when the
+    ///   through [`GroupRibOut::adv_entry`] and
+    ///   [`GroupRibOut::source_control_for_route`]) drops it exactly when the
     ///   lane still substitutes, and the resync substitution announces
     ///   `adv(m)` in its place;
     /// - the ADR-0126 lane-retire arm — a retire toward its

--- a/crates/rib/src/manager/update_groups/tests.rs
+++ b/crates/rib/src/manager/update_groups/tests.rs
@@ -1659,7 +1659,7 @@ fn adv_entry_derivation_matrix() {
     group.apply_delta(&GroupDelta {
         prefix: p,
         path_id: 0,
-        new: Some((route(p, OTHER1), Some(NextHopAction::Self_))),
+        new: Some((route_with_comm(p, OTHER1, 7), Some(NextHopAction::Self_))),
         old_source: None,
         policy_label: Some(Arc::from("staged")),
         source_attrs: Some(Arc::new(vec![PathAttribute::Communities(vec![7])])),
@@ -1670,7 +1670,12 @@ fn adv_entry_derivation_matrix() {
         .expect("non-own staged entry");
     assert_eq!((adv.route.peer, adv.route.path_id), (OTHER1, 0));
     assert!(matches!(adv.nh, Some(NextHopAction::Self_)));
-    assert_eq!(source_control_input(adv.source_attrs).0, &[7]);
+    assert_eq!(
+        group
+            .source_control_for_route(adv.route, adv.source_attrs)
+            .0,
+        &[7]
+    );
     assert_eq!(adv.policy_label.map(|label| &**label), Some("staged"));
 
     // Own-sourced + lane: the runner-up substitutes with ITS
@@ -1679,12 +1684,22 @@ fn adv_entry_derivation_matrix() {
     group.apply_delta(&announce_delta(p, MEMBER, None));
     group.apply_lane(
         p,
-        Some(lane_entry(route(p, OTHER2), MEMBER, "lane", Some(9))),
+        Some(lane_entry(
+            route_with_comm(p, OTHER2, 9),
+            MEMBER,
+            "lane",
+            Some(9),
+        )),
     );
     let adv = group.adv_entry(MEMBER, &p, 0).expect("lane substitutes");
     assert_eq!((adv.route.peer, adv.route.path_id), (OTHER2, 0));
     assert!(matches!(adv.nh, Some(NextHopAction::Self_)));
-    assert_eq!(source_control_input(adv.source_attrs).0, &[9]);
+    assert_eq!(
+        group
+            .source_control_for_route(adv.route, adv.source_attrs)
+            .0,
+        &[9]
+    );
     assert_eq!(adv.policy_label.map(|label| &**label), Some("lane"));
     // Any other member still sees the staged winner (with the
     // winner's residue: none was staged for it).
@@ -3011,7 +3026,7 @@ fn pcb_resync_substitution_applies_rs_control() {
 
     // Suppressing tag: skip + withdraw, and the extras filter
     // agrees (a suppressed substitution does not retain).
-    let mut group = per_client_best_group(None);
+    let mut group = per_client_best_group(Some(strip_communities_chain(vec![deny_comm])));
     group.apply_delta(&announce_delta(k, MEMBER, None));
     group.apply_lane(
         k,
@@ -3254,14 +3269,15 @@ fn replay_group(lane_comm: Option<u32>) -> GroupRibOut {
     group.apply_delta(&announce_delta(prefix(1), OTHER1, None));
     group.apply_delta(&announce_delta(prefix(2), MEMBER, None));
     group.apply_delta(&announce_delta(prefix(3), MEMBER, None));
+    let mut lane_route = route(prefix(2), OTHER2);
+    if let Some(community) = lane_comm {
+        let mut attrs = (*lane_route.attributes).clone();
+        attrs.push(PathAttribute::Communities(vec![community]));
+        lane_route.attributes = Arc::new(attrs);
+    }
     group.apply_lane(
         prefix(2),
-        Some(lane_entry(
-            route(prefix(2), OTHER2),
-            MEMBER,
-            "lane",
-            lane_comm,
-        )),
+        Some(lane_entry(lane_route, MEMBER, "lane", lane_comm)),
     );
     group
 }
@@ -4184,6 +4200,81 @@ fn join_view_and_count_synthesis_track_deltas() {
     group.apply_delta(&withdraw_delta(k1, Some(MEMBER)));
     assert_eq!(group.advertised_count_for(OTHER1), 1);
     assert_eq!(group.table.len(), 1);
+}
+
+#[test]
+fn source_control_passthrough_keeps_dense_residue_empty() {
+    const CONTROL: u32 = 65_001 << 16 | 7;
+    let p = prefix(1);
+    let source = cand_with_comm(p, OTHER1, 300, CONTROL);
+    let mut group = empty_group();
+    assert!(group.source_control_passthrough);
+    group.apply_delta(&GroupDelta {
+        prefix: p,
+        path_id: 0,
+        new: Some((source.clone(), None)),
+        old_source: None,
+        policy_label: None,
+        source_attrs: capture_source_attrs(&source),
+        lane: None,
+    });
+
+    assert_eq!(
+        (group.source_attrs.len(), group.source_attrs.capacity()),
+        (0, 0)
+    );
+    assert_eq!(group.source_control((p, 0)).0, &[CONTROL]);
+    let entry = group
+        .adv_entry(MEMBER, &p, 0)
+        .expect("non-source member retains staged route");
+    assert_eq!(
+        group
+            .source_control_for_route(entry.route, entry.source_attrs)
+            .0,
+        &[CONTROL]
+    );
+    assert!(group.rs_tag_transition(p, None).is_none());
+
+    group.apply_delta(&withdraw_delta(p, Some(OTHER1)));
+    assert_eq!(
+        (group.source_attrs.len(), group.source_attrs.capacity()),
+        (0, 0)
+    );
+}
+
+#[test]
+fn source_control_modifying_mode_preserves_historical_residue_and_transition() {
+    const CONTROL: u32 = 65_001 << 16 | 7;
+    let p = prefix(1);
+    let source = cand_with_comm(p, OTHER1, 300, CONTROL);
+    let staged = cand(p, OTHER1, 300);
+    let mut group = plain_group_with_chain(Some(strip_communities_chain(vec![CONTROL])));
+    assert!(!group.source_control_passthrough);
+    group.apply_delta(&GroupDelta {
+        prefix: p,
+        path_id: 0,
+        new: Some((staged, None)),
+        old_source: None,
+        policy_label: None,
+        source_attrs: capture_source_attrs(&source),
+        lane: None,
+    });
+
+    assert_eq!(group.source_attrs.len(), 1);
+    assert_eq!(group.source_control((p, 0)).0, &[CONTROL]);
+    let transition = group
+        .rs_tag_transition(p, None)
+        .expect("source tag removal is invisible post-policy");
+    assert_eq!(
+        source_control_input(transition.prior_source_attrs.as_ref()).0,
+        &[CONTROL]
+    );
+    assert!(transition.source_attrs.is_none());
+    group.commit_rs_transitions(&[transition]);
+    assert!(group.source_attrs.is_empty());
+
+    group.apply_delta(&withdraw_delta(p, Some(OTHER1)));
+    assert!(group.source_attrs.is_empty());
 }
 
 // --- ADR-0126 staging trigger: per-client-best groups stage from

--- a/crates/rib/src/manager/update_groups/views.rs
+++ b/crates/rib/src/manager/update_groups/views.rs
@@ -2,8 +2,7 @@ use super::{
     Afi, ExactExportKey, FxHashMap, GroupEvalAccumulator, GroupRibOut, HashSet, IpAddr,
     NextHopAction, PolicyAction, PolicyLabel, Prefix, RibManager, Route, RouteQueryKey,
     RtcMembership, Safi, VpnAddressFamily, VpnRibRoute, VpnRibRouteKey, VpnRouteKey,
-    bump_counter_row, route_query_key, routes_equal, rt_passes, source_control_input,
-    vpn_routes_equal,
+    bump_counter_row, route_query_key, routes_equal, rt_passes, vpn_routes_equal,
 };
 
 impl RibManager {
@@ -67,7 +66,7 @@ impl RibManager {
                 continue;
             };
             let (source_communities, source_large_communities) =
-                source_control_input(entry.source_attrs);
+                group.source_control_for_route(entry.route, entry.source_attrs);
             if rs_control_suppressed(source_communities, source_large_communities, rs_control) {
                 // Not on this member's wire going forward. Withdraw when
                 // it may be there now: always on a plain dirty resync
@@ -104,7 +103,8 @@ impl RibManager {
         // does not).
         let member_retains = |key: &(Prefix, u32)| {
             group.adv_entry(member, &key.0, key.1).is_some_and(|entry| {
-                let (communities, large_communities) = source_control_input(entry.source_attrs);
+                let (communities, large_communities) =
+                    group.source_control_for_route(entry.route, entry.source_attrs);
                 !rs_control_suppressed(communities, large_communities, rs_control)
             })
         };

--- a/crates/rib/tests/update_group_source_control_profile.rs
+++ b/crates/rib/tests/update_group_source_control_profile.rs
@@ -1,0 +1,71 @@
+#![cfg(feature = "bench-internals")]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rustbgpd_wire::{Ipv4Prefix, PathAttribute, Prefix};
+use rustc_hash::FxHashMap;
+
+struct TrackingAllocator {
+    live: AtomicUsize,
+}
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            self.live.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        self.live.fetch_sub(layout.size(), Ordering::Relaxed);
+        unsafe { System.dealloc(ptr, layout) };
+    }
+}
+
+#[global_allocator]
+static ALLOC: TrackingAllocator = TrackingAllocator {
+    live: AtomicUsize::new(0),
+};
+
+fn prefix(n: u32) -> Prefix {
+    Prefix::V4(Ipv4Prefix::new(Ipv4Addr::from(n), 32))
+}
+
+#[test]
+fn passthrough_group_avoids_historical_source_control_collection() {
+    const ROUTES: usize = 100_000;
+    const MIN_HISTORICAL_BYTES: usize = 3 * 1024 * 1024;
+
+    let source = include_str!("../src/manager/update_groups.rs");
+    assert!(source.contains("source_control_passthrough: bool"));
+    assert!(source.contains("if !self.source_control_passthrough"));
+    assert!(source.contains("source_control_for_route"));
+
+    let safe: FxHashMap<(Prefix, u32), Arc<Vec<PathAttribute>>> = FxHashMap::default();
+    assert_eq!((safe.len(), safe.capacity()), (0, 0));
+
+    let shared_attrs = Arc::new(vec![PathAttribute::Communities(vec![1])]);
+    let before = ALLOC.live.load(Ordering::Relaxed);
+    let mut historical: FxHashMap<(Prefix, u32), Arc<Vec<PathAttribute>>> = FxHashMap::default();
+    for n in 0..ROUTES as u32 {
+        historical.insert((prefix(n), 0), Arc::clone(&shared_attrs));
+    }
+    let historical_map_bytes = ALLOC.live.load(Ordering::Relaxed) - before;
+
+    println!(
+        "{{\"kind\":\"update_group_source_control_profile\",\"routes\":{ROUTES},\"safe_len\":{},\"safe_capacity\":{},\"historical_capacity\":{},\"historical_map_bytes\":{historical_map_bytes}}}",
+        safe.len(),
+        safe.capacity(),
+        historical.capacity()
+    );
+    assert_eq!(historical.len(), ROUTES);
+    assert!(
+        historical_map_bytes >= MIN_HISTORICAL_BYTES,
+        "historical source-control map allocated only {historical_map_bytes} bytes"
+    );
+}


### PR DESCRIPTION
## Summary

- Classify compiled export-policy chains by whether they can mutate the standard or large communities consumed by RFC 7947 route-server control.
- For groups proven to preserve those attributes, keep the dense route-keyed source-attribute sidecar empty and derive control input from the staged route.
- Preserve the existing pre-policy snapshot path for modifying chains, including tag-only transitions, per-client-best lanes, resync, join, and refresh behavior.

## Structural proof

The feature-gated 100,000-route x86_64 System-allocation fixture reports:

- passthrough group sidecar: `len=0`, `capacity=0`
- historical route-keyed map: `4,325,392` requested-live bytes

This is a conditional component-level structural result for safe groups. It is not an RSS, allocator-independent, whole-daemon, RunnerUp, or transient-staging claim.

## Performance

The stock `distribute_fanout` comparator ran all eight rows for three alternating base/candidate pairs on CPU 8. No row met the configured 3% regression gate; fresh current-main mean deltas ranged from `-1.74%` to `+0.94%`.

This PR makes no CPU or latency improvement claim.

## Verification

- classifier matrix plus focused passthrough, modifying, transition, lane, resync, join, and refresh tests
- `cargo test --locked -p rustbgpd-policy`
- `cargo test --locked -p rustbgpd-rib`
- strict all-target/all-feature Clippy for policy and RIB
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked -p rustbgpd-rib --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bench/compare-criterion.sh` with `--attempts 3 --fail-on-regression`

## Limitations

- Chains with standard/large community mutations retain the historical map and behavior.
- Extended-community-only mutations qualify because RFC 7947 source control does not read that attribute partition.
- The classifier is an internal Rust surface in a `publish = false` workspace crate, not a daemon or operator API.

Docs: not needed because configuration, API, metrics, logs, wire behavior, defaults, and operator workflows are unchanged.
