### PR TITLE
perf(config): bound runtime TOML serialization

### DIFF
--- a/src/config/canonical.rs
+++ b/src/config/canonical.rs
@@ -14,6 +14,12 @@ const STATEMENT_CHUNK_LEN: usize = 256;
 const SENTINEL_ONE: &str = "rustbgpd_bounded_writer_sentinel_one";
 const SENTINEL_TWO: &str = "rustbgpd_bounded_writer_sentinel_two";
 
+#[derive(Clone, Copy)]
+enum DocumentShape {
+    Raw,
+    CanonicalPersisted,
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(super) struct BoundedRenderStats {
     pub(super) neighbor_import_lanes: usize,
@@ -447,16 +453,31 @@ pub(super) fn render(config: &Config) -> Result<String, toml::ser::Error> {
 pub(super) fn render_document_bounded(
     config: &mut Config,
 ) -> Result<(String, BoundedRenderStats), toml::ser::Error> {
-    render_document_bounded_with_hook(config, |_| Ok(()))
+    render_document_bounded_with_hook(config, DocumentShape::CanonicalPersisted, |_| Ok(()))
+}
+
+/// Render the legacy raw `Config` shape without materializing its statement
+/// vectors in one serializer graph. Unlike the persisted shape, this preserves
+/// absent RFC 8212 fields and carries no maintenance header.
+pub(super) fn render_raw_bounded(
+    config: &mut Config,
+) -> Result<(String, BoundedRenderStats), toml::ser::Error> {
+    render_document_bounded_with_hook(config, DocumentShape::Raw, |_| Ok(()))
 }
 
 fn render_document_bounded_with_hook(
     config: &mut Config,
+    shape: DocumentShape,
     mut hook: impl FnMut(&'static str) -> Result<(), toml::ser::Error>,
 ) -> Result<(String, BoundedRenderStats), toml::ser::Error> {
     let extraction = StatementExtraction::new(config);
     hook("after-extraction")?;
-    let skeleton = toml::to_string_pretty(&CanonicalConfig::from(&*extraction.config))?;
+    let skeleton = match shape {
+        DocumentShape::Raw => toml::to_string_pretty(&*extraction.config)?,
+        DocumentShape::CanonicalPersisted => {
+            toml::to_string_pretty(&CanonicalConfig::from(&*extraction.config))?
+        }
+    };
     let mut templates = extraction
         .lanes
         .iter()
@@ -483,14 +504,16 @@ fn render_document_bounded_with_hook(
         }
     }
 
-    let mut document = String::with_capacity(
-        super::PERSISTED_CONFIG_HEADER.len()
-            + 1
-            + skeleton.len()
-            + stats.statements.saturating_mul(64),
-    );
-    document.push_str(super::PERSISTED_CONFIG_HEADER);
-    document.push('\n');
+    let header_len = match shape {
+        DocumentShape::Raw => 0,
+        DocumentShape::CanonicalPersisted => super::PERSISTED_CONFIG_HEADER.len() + 1,
+    };
+    let mut document =
+        String::with_capacity(header_len + skeleton.len() + stats.statements.saturating_mul(64));
+    if matches!(shape, DocumentShape::CanonicalPersisted) {
+        document.push_str(super::PERSISTED_CONFIG_HEADER);
+        document.push('\n');
+    }
     let mut cursor = 0;
     for (lane_index, template) in templates {
         document.push_str(&skeleton[cursor..template.range.start]);
@@ -516,7 +539,15 @@ pub(super) fn render_document_bounded_with_test_hook(
     config: &mut Config,
     hook: impl FnMut(&'static str) -> Result<(), toml::ser::Error>,
 ) -> Result<(String, BoundedRenderStats), toml::ser::Error> {
-    render_document_bounded_with_hook(config, hook)
+    render_document_bounded_with_hook(config, DocumentShape::CanonicalPersisted, hook)
+}
+
+#[cfg(test)]
+pub(super) fn render_raw_bounded_with_test_hook(
+    config: &mut Config,
+    hook: impl FnMut(&'static str) -> Result<(), toml::ser::Error>,
+) -> Result<(String, BoundedRenderStats), toml::ser::Error> {
+    render_document_bounded_with_hook(config, DocumentShape::Raw, hook)
 }
 
 /// Test-only decomposition of [`render`] at the TOML ownership boundaries.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2361,6 +2361,7 @@ impl RuntimeSnapshotKey {
     }
 
     /// Keyed token additionally bound to a canonical live-runtime context.
+    #[cfg(test)]
     pub fn token_with_context(&self, config: &Config, context: &[u8]) -> Result<String, String> {
         // The shared borrowed projection uses explicit sorted serializers for
         // every HashMap-valued config field, making this token independent of
@@ -2368,6 +2369,17 @@ impl RuntimeSnapshotKey {
         let normalized = canonical::render(config)
             .map_err(|error| format!("failed to serialize runtime config snapshot: {error}"))?;
         Ok(self.token_for_canonical_body(&normalized, context))
+    }
+
+    /// Keyed token rendered through the bounded canonical document path.
+    pub fn token_with_context_bounded(
+        &self,
+        config: &mut Config,
+        context: &[u8],
+    ) -> Result<String, String> {
+        let normalized = persisted_config_document_bounded(config)
+            .map_err(|error| format!("failed to serialize runtime config snapshot: {error}"))?;
+        self.token_with_normalized_document(&normalized, context)
     }
 
     /// Token a persisted candidate without serializing it a second time.
@@ -2466,6 +2478,11 @@ pub(crate) fn persisted_config_document_bounded(
     config: &mut Config,
 ) -> Result<String, toml::ser::Error> {
     canonical::render_document_bounded(config).map(|(document, _)| document)
+}
+
+/// Render the legacy raw `Config` TOML shape with bounded statement chunks.
+pub(crate) fn raw_config_document_bounded(config: &mut Config) -> Result<String, toml::ser::Error> {
+    canonical::render_raw_bounded(config).map(|(document, _)| document)
 }
 
 impl Config {

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -1459,14 +1459,14 @@ fn verify_bounded_writer_receipt(source: &str) {
 
 #[cfg(target_os = "linux")]
 #[test]
-#[ignore = "release-only six-child 3.2M-statement bounded-writer A/B"]
-fn bounded_writer_release_probe() {
+#[ignore = "release-only six-child 3.2M-statement raw bounded-writer A/B"]
+fn raw_bounded_writer_release_probe() {
     use sha2::{Digest as _, Sha256};
     use std::{fmt::Write as _, process::Command, time::Instant};
 
-    const ARM: &str = "RUSTBGPD_BOUNDED_WRITER_ARM";
-    const ATTEMPT: &str = "RUSTBGPD_BOUNDED_WRITER_ATTEMPT";
-    const RECEIPT: &str = "RUSTBGPD_BOUNDED_WRITER_RECEIPT";
+    const ARM: &str = "RUSTBGPD_RAW_BOUNDED_WRITER_ARM";
+    const ATTEMPT: &str = "RUSTBGPD_RAW_BOUNDED_WRITER_ATTEMPT";
+    const RECEIPT: &str = "RUSTBGPD_RAW_BOUNDED_WRITER_RECEIPT";
     assert!(
         !std::hint::black_box(cfg!(debug_assertions)),
         "run with --release"
@@ -1481,10 +1481,10 @@ fn bounded_writer_release_probe() {
         let started = Instant::now();
         let (document, stats) = match arm.as_str() {
             "legacy" => (
-                persisted_config_document(&config).unwrap(),
+                toml::to_string_pretty(&config).unwrap(),
                 super::canonical::BoundedRenderStats::default(),
             ),
-            "bounded" => super::canonical::render_document_bounded(&mut config).unwrap(),
+            "bounded" => super::canonical::render_raw_bounded(&mut config).unwrap(),
             other => panic!("unknown bounded-writer arm {other}"),
         };
         let elapsed = started.elapsed().as_nanos();
@@ -1526,7 +1526,7 @@ fn bounded_writer_release_probe() {
         assert!(
             Command::new(&executable)
                 .args([
-                    "config::tests::bounded_writer_release_probe",
+                    "config::tests::raw_bounded_writer_release_probe",
                     "--ignored",
                     "--exact",
                     "--nocapture"
@@ -1541,8 +1541,8 @@ fn bounded_writer_release_probe() {
         output.push_str(&fs::read_to_string(receipt.path()).unwrap());
     }
     verify_bounded_writer_receipt(&output);
-    let output_path = std::env::var("RUSTBGPD_BOUNDED_WRITER_OUTPUT")
-        .expect("RUSTBGPD_BOUNDED_WRITER_OUTPUT is required");
+    let output_path = std::env::var("RUSTBGPD_RAW_BOUNDED_WRITER_OUTPUT")
+        .expect("RUSTBGPD_RAW_BOUNDED_WRITER_OUTPUT is required");
     retain_persistence_phase_receipt(Path::new(&output_path), &output);
 }
 

--- a/src/config/tests/persistence.rs
+++ b/src/config/tests/persistence.rs
@@ -47,6 +47,169 @@ fn persisted_config_sorts_every_hash_map_and_round_trips_to_a_fixpoint() {
     assert_eq!(statements[1].action, "deny");
 }
 
+fn raw_bounded_fixture(
+    reverse: bool,
+    statement_count: usize,
+    epoch: Option<ConfigEpoch>,
+    policy: Option<bool>,
+) -> Config {
+    let mut config = persistence_order_fixture(reverse, 1);
+    let statement = config.policy.definitions["zeta"].statements[0].clone();
+    config
+        .policy
+        .definitions
+        .get_mut("zeta")
+        .unwrap()
+        .statements
+        .clear();
+    config.config_epoch = epoch;
+    config.global.ebgp_requires_policy = policy;
+    config.neighbors[0].import_policy = vec![statement.clone(); statement_count];
+    config.neighbors[0].export_policy = vec![statement.clone(); statement_count];
+    config.peer_groups.insert(
+        "dotted.key \"雪\"".to_string(),
+        PeerGroupConfig {
+            import_policy: vec![statement.clone(); statement_count],
+            export_policy: vec![statement.clone(); statement_count],
+            ..PeerGroupConfig::default()
+        },
+    );
+    config.policy.definitions.insert(
+        "quoted.\"policy\".雪".to_string(),
+        NamedPolicyConfig {
+            default_action: "deny".to_string(),
+            statements: vec![statement; statement_count],
+        },
+    );
+    config
+}
+
+#[test]
+fn bounded_raw_matches_legacy_for_every_lane_boundary_key_and_posture() {
+    use sha2::{Digest as _, Sha256};
+
+    for (epoch, policy) in [
+        (None, None),
+        (Some(ConfigEpoch::V2), None),
+        (None, Some(false)),
+        (Some(ConfigEpoch::V2), Some(true)),
+    ] {
+        for count in [0, 1, 255, 256, 257] {
+            let mut config = raw_bounded_fixture(true, count, epoch, policy);
+            let original = config.clone();
+            let legacy = toml::to_string_pretty(&config).unwrap();
+            let (bounded, stats) = super::canonical::render_raw_bounded(&mut config).unwrap();
+            assert_eq!(config, original);
+            assert_eq!(
+                bounded, legacy,
+                "count={count} epoch={epoch:?} policy={policy:?}"
+            );
+            assert_eq!(Sha256::digest(&bounded), Sha256::digest(&legacy));
+            assert!(!bounded.contains(PERSISTED_CONFIG_HEADER));
+            assert_eq!(stats.statements, count * 5);
+            assert_eq!(
+                stats.max_chunk_statements,
+                if count == 0 { 0 } else { count.min(256) }
+            );
+            let lanes = usize::from(count != 0);
+            assert_eq!(stats.neighbor_import_lanes, lanes);
+            assert_eq!(stats.neighbor_export_lanes, lanes);
+            assert_eq!(stats.peer_group_import_lanes, lanes);
+            assert_eq!(stats.peer_group_export_lanes, lanes);
+            assert_eq!(stats.named_policy_lanes, lanes);
+            for field in [
+                "match_community",
+                "set_community_add",
+                "set_community_remove",
+            ] {
+                assert!(!bounded.contains(field), "{field} count={count}");
+            }
+        }
+    }
+}
+
+fn raw_lane_storage(config: &Config) -> [(usize, usize, Vec<PolicyStatementConfig>); 5] {
+    let group = &config.peer_groups["dotted.key \"雪\""];
+    let policy = &config.policy.definitions["quoted.\"policy\".雪"];
+    let snapshot =
+        |lane: &Vec<PolicyStatementConfig>| (lane.as_ptr() as usize, lane.capacity(), lane.clone());
+    [
+        snapshot(&config.neighbors[0].import_policy),
+        snapshot(&config.neighbors[0].export_policy),
+        snapshot(&group.import_policy),
+        snapshot(&group.export_policy),
+        snapshot(&policy.statements),
+    ]
+}
+
+#[test]
+fn bounded_raw_error_restores_every_lane_allocation_order_and_content() {
+    let mut config = raw_bounded_fixture(false, 257, None, None);
+    let before = raw_lane_storage(&config);
+    let error = super::canonical::render_raw_bounded_with_test_hook(&mut config, |phase| {
+        if phase == "before-statement-chunk" {
+            Err(<toml::ser::Error as serde::ser::Error>::custom(
+                "injected raw bounded-writer failure",
+            ))
+        } else {
+            Ok(())
+        }
+    })
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("injected raw bounded-writer failure")
+    );
+    assert_eq!(raw_lane_storage(&config), before);
+}
+
+#[test]
+fn bounded_tokens_equal_legacy_across_lanes_order_posture_context_and_secrets() {
+    let key = RuntimeSnapshotKey::random();
+    let context = [9_u8; 8];
+    for (epoch, policy) in [
+        (None, None),
+        (Some(ConfigEpoch::V2), None),
+        (None, Some(false)),
+        (Some(ConfigEpoch::V2), Some(true)),
+    ] {
+        let mut left = raw_bounded_fixture(false, 257, epoch, policy);
+        let mut right = raw_bounded_fixture(true, 257, epoch, policy);
+        for config in [&mut left, &mut right] {
+            let original = config.clone();
+            for token_context in [&[][..], &context[..]] {
+                let legacy = key.token_with_context(config, token_context).unwrap();
+                let bounded = key
+                    .token_with_context_bounded(config, token_context)
+                    .unwrap();
+                assert_eq!(bounded, legacy);
+                assert!(bounded.starts_with(if token_context.is_empty() {
+                    "kv1:"
+                } else {
+                    "kv2:"
+                }));
+            }
+            assert_eq!(*config, original);
+        }
+        assert_eq!(
+            key.token_with_context_bounded(&mut left, &context).unwrap(),
+            key.token_with_context_bounded(&mut right, &context)
+                .unwrap()
+        );
+    }
+
+    let mut old = raw_bounded_fixture(false, 1, None, None);
+    old.neighbors[0].md5_password = Some("old-secret".to_string());
+    let mut rotated = old.clone();
+    rotated.neighbors[0].md5_password = Some("new-secret".to_string());
+    assert_ne!(
+        key.token_with_context_bounded(&mut old, &context).unwrap(),
+        key.token_with_context_bounded(&mut rotated, &context)
+            .unwrap()
+    );
+}
+
 #[test]
 fn bounded_persistence_matches_oracle_for_every_statement_lane_and_boundary() {
     use sha2::{Digest as _, Sha256};
@@ -178,6 +341,30 @@ fn production_persisted_document_roster_uses_only_the_bounded_writer() {
         );
         assert!(!source.contains("persisted_config_document("), "{name}");
     }
+}
+
+#[test]
+fn production_raw_and_token_roster_uses_only_bounded_rendering() {
+    let peer_manager = include_str!("../../peer_manager/mod.rs");
+    assert_eq!(
+        peer_manager.matches("raw_config_document_bounded").count(),
+        2
+    );
+    assert!(!peer_manager.contains("toml::to_string_pretty(&self.current_config)"));
+
+    let reconciliation = include_str!("../../peer_manager/reconcile.rs");
+    assert_eq!(
+        reconciliation.matches("token_with_context_bounded").count(),
+        2
+    );
+    assert!(!reconciliation.contains(".token_with_context("));
+
+    let controller = include_str!("../../config_transaction_control.rs")
+        .split("#[cfg(test)]\nmod tests {")
+        .next()
+        .unwrap();
+    assert_eq!(controller.matches("raw_config_document_bounded").count(), 1);
+    assert!(!controller.contains("toml::to_string_pretty(&candidate)"));
 }
 
 /// Every canonical sink materializes the effective epoch and policy through

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -808,14 +808,15 @@ impl ConfigTransactionController {
                     let current = self_.accepted_runtime_snapshot().await.map_err(|error| {
                         OwnedGnmiSetError::Clean(GnmiSetError::Unavailable(error))
                     })?;
-                    let candidate =
+                    let mut candidate =
                         gnmi_set_bridge::apply_transaction_to_config(current, &transaction)
                             .map_err(OwnedGnmiSetError::Clean)?;
-                    let candidate_toml = toml::to_string_pretty(&candidate).map_err(|error| {
-                        GnmiSetError::Internal(format!(
-                            "failed to serialize gNMI Set candidate config: {error}"
-                        ))
-                    })?;
+                    let candidate_toml = crate::config::raw_config_document_bounded(&mut candidate)
+                        .map_err(|error| {
+                            GnmiSetError::Internal(format!(
+                                "failed to serialize gNMI Set candidate config: {error}"
+                            ))
+                        })?;
                     let (confirm_id, confirm_timeout_seconds) = match transaction.commit_action {
                         Some(GnmiSetCommitAction::Commit {
                             confirm_id,

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -1200,7 +1200,10 @@ impl PeerManager {
                             .map_err(StageConfigSnapshotError::InvalidCandidate)
                             .and_then(|candidate| {
                                 let previous =
-                                    toml::to_string_pretty(&self.current_config).map_err(
+                                    crate::config::raw_config_document_bounded(
+                                        &mut self.current_config,
+                                    )
+                                    .map_err(
                                         |error| {
                                             StageConfigSnapshotError::SerializePreviousSnapshot(
                                                 error.to_string(),
@@ -1252,7 +1255,9 @@ impl PeerManager {
                             }
                         }
                         PeerManagerCommand::RuntimeConfigSnapshot { reply } => {
-                            let result = toml::to_string_pretty(&self.current_config)
+                            let result = crate::config::raw_config_document_bounded(
+                                &mut self.current_config,
+                            )
                                 .map_err(|error| {
                                     format!(
                                         "failed to serialize runtime config snapshot: {error}"

--- a/src/peer_manager/reconcile.rs
+++ b/src/peer_manager/reconcile.rs
@@ -146,7 +146,7 @@ impl PeerManager {
     }
 
     pub(super) async fn plan_config_transaction(
-        &self,
+        &mut self,
         candidate_toml: &str,
         expected_runtime_snapshot_token: Option<&str>,
     ) -> Result<RuntimeConfigTransactionPlan, RuntimeConfigTransactionPlanError> {
@@ -170,7 +170,7 @@ impl PeerManager {
     }
 
     pub(super) async fn plan_preloaded_config_transaction(
-        &self,
+        &mut self,
         candidate: &mut Config,
         expected_runtime_snapshot_token: Option<&str>,
     ) -> Result<RuntimeConfigTransactionPlan, RuntimeConfigTransactionPlanError> {
@@ -201,7 +201,7 @@ impl PeerManager {
     }
 
     async fn config_transaction_plan_context(
-        &self,
+        &mut self,
         expected_runtime_snapshot_token: Option<&str>,
     ) -> Result<
         (rustbgpd_rib::UpdateGroupSnapshot, [u8; 8], String),
@@ -218,7 +218,7 @@ impl PeerManager {
         let live_snapshot_identity = self.snapshot_key.digest_context(&live_snapshot);
         let runtime_snapshot_token = self
             .snapshot_key
-            .token_with_context(&self.current_config, &live_snapshot_identity)
+            .token_with_context_bounded(&mut self.current_config, &live_snapshot_identity)
             .map_err(RuntimeConfigTransactionPlanError::Internal)?;
         if let Some(expected) = expected_runtime_snapshot_token.filter(|token| !token.is_empty())
             && expected != runtime_snapshot_token
@@ -236,7 +236,7 @@ impl PeerManager {
     }
 
     fn finish_config_transaction_plan(
-        &self,
+        &mut self,
         candidate: &mut Config,
         materialization: Option<&crate::config::ConfigDiff>,
         live_snapshot: rustbgpd_rib::UpdateGroupSnapshot,
@@ -299,7 +299,7 @@ impl PeerManager {
         } else {
             let token = self
                 .snapshot_key
-                .token_with_context(candidate, &live_snapshot_identity)
+                .token_with_context_bounded(candidate, &live_snapshot_identity)
                 .map_err(RuntimeConfigTransactionPlanError::Internal)?;
             (token, None)
         };

--- a/src/peer_manager/tests/config_transaction.rs
+++ b/src/peer_manager/tests/config_transaction.rs
@@ -18,7 +18,7 @@ log_format = "json"
     let (_tx, rx) = mpsc::channel(4);
     let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
     let (rib_tx, mut rib_rx) = mpsc::channel(4);
-    let mgr = PeerManager::new_with_config(
+    let mut mgr = PeerManager::new_with_config(
         rx,
         internal_rx,
         65001,
@@ -122,7 +122,7 @@ remote_asn = 65002
     let (_tx, rx) = mpsc::channel(4);
     let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
     let (rib_tx, mut rib_rx) = mpsc::channel(4);
-    let mgr = PeerManager::new_with_config(
+    let mut mgr = PeerManager::new_with_config(
         rx,
         internal_rx,
         65001,
@@ -215,7 +215,7 @@ import_policy_chain = ["edge-in"]
     let (_tx, rx) = mpsc::channel(4);
     let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
     let (rib_tx, mut rib_rx) = mpsc::channel(4);
-    let mgr = PeerManager::new_with_config(
+    let mut mgr = PeerManager::new_with_config(
         rx,
         internal_rx,
         65001,
@@ -950,7 +950,7 @@ log_format = "json"
     let (_tx, rx) = mpsc::channel(4);
     let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
     let (rib_tx, mut rib_rx) = mpsc::channel(4);
-    let mgr = PeerManager::new_with_config(
+    let mut mgr = PeerManager::new_with_config(
         rx,
         internal_rx,
         65001,


### PR DESCRIPTION
## Summary

- Reuse the bounded TOML splice engine for the legacy raw `Config` document shape as well as canonical persisted documents.
- Route stage/runtime snapshots and gNMI candidate serialization through that bounded raw renderer, and route both reconciliation-token paths through bounded canonical rendering.
- Preserve raw bytes, omitted defaults, persisted-header behavior, token identity, statement ordering, and exact rollback/restoration semantics.

## Performance receipt

- Linear: LAN-1043.
- Accepted T072 artifact: retained in the local campaign archive, identified by the durable TSV SHA-256 below.
- Durable TSV SHA-256: `44fb81ea8a97968a30f610dce4f9f12b54c19d1d3cf95ce5b0d3f4459b5f4ed7`.
- The sole accepted six-process AB/BA/AB campaign rendered the same 342,421,716-byte, 3.2M-statement document in every row. Bounded/legacy HWM ratios were 0.235541, 0.235307, and 0.236317; paired elapsed-time ratios were 0.661100, 0.676318, and 0.667040; the bounded/legacy median elapsed-time ratio was 0.666604. Maximum bounded chunk size was 256 statements.
- These numbers are a controlled single-host release-build formatter-fixture result. They do not claim daemon steady-state RSS, whole-daemon reload latency, compiled/external rpol allocation behavior, or production workload end-to-end performance.

## Testing

- [x] Focused byte/SHA, allocation restoration, token parity, static roster, stage/restore/runtime/SIGHUP, gNMI, and reconciliation filters passed separately
- [x] `cargo test --locked --test config_persistence_lifecycle` (10/10)
- [x] `cargo test --locked --test runtime_config_settlement_matrix` (2/2)
- [x] `cargo test --locked --package rustbgpd --bin rustbgpd` (1,988 passed, 3 ignored)
- [x] `cargo clippy --locked --package rustbgpd --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Large-fixture rerun intentionally omitted; T072 is the sole accepted measurement receipt under the promotion contract

## Docs / release notes

- [x] CHANGELOG.md intentionally unchanged
- [x] ROADMAP.md intentionally unchanged
- [x] User/operator docs intentionally unchanged

This is an internal allocation-bound change. It does not change configuration syntax, defaults, APIs, metrics, wire behavior, operator-visible output bytes, or supported feature limits.

